### PR TITLE
UCS: Add API for a per-process aggregate-sum statistics report

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -54,6 +54,7 @@ extern const ucp_request_send_proto_t ucp_am_reply_proto;
 static ucs_stats_class_t ucp_ep_stats_class = {
     .name           = "ucp_ep",
     .num_counters   = UCP_EP_STAT_LAST,
+    .class_id       = UCS_STATS_CLASS_ID_INVALID,
     .counter_names  = {
         [UCP_EP_STAT_TAG_TX_EAGER]      = "tx_eager",
         [UCP_EP_STAT_TAG_TX_EAGER_SYNC] = "tx_eager_sync",

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -48,6 +48,7 @@ typedef enum ucp_worker_event_fd_op {
 static ucs_stats_class_t ucp_worker_tm_offload_stats_class = {
     .name           = "tag_offload",
     .num_counters   = UCP_WORKER_STAT_TAG_OFFLOAD_LAST,
+    .class_id       = UCS_STATS_CLASS_ID_INVALID,
     .counter_names  = {
         [UCP_WORKER_STAT_TAG_OFFLOAD_POSTED]           = "posted",
         [UCP_WORKER_STAT_TAG_OFFLOAD_MATCHED]          = "matched",
@@ -68,6 +69,7 @@ static ucs_stats_class_t ucp_worker_tm_offload_stats_class = {
 static ucs_stats_class_t ucp_worker_stats_class = {
     .name           = "ucp_worker",
     .num_counters   = UCP_WORKER_STAT_LAST,
+    .class_id       = UCS_STATS_CLASS_ID_INVALID,
     .counter_names  = {
         [UCP_WORKER_STAT_TAG_RX_EAGER_MSG]         = "rx_eager_msg",
         [UCP_WORKER_STAT_TAG_RX_EAGER_SYNC_MSG]    = "rx_sync_msg",

--- a/src/ucs/datastruct/frag_list.c
+++ b/src/ucs/datastruct/frag_list.c
@@ -1,6 +1,7 @@
 
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -14,8 +15,9 @@
 #ifdef ENABLE_STATS
 
 static ucs_stats_class_t ucs_frag_list_stats_class = {
-    .name = "frag_list",
-    .num_counters = UCS_FRAG_LIST_STAT_LAST,
+    .name          = "frag_list",
+    .num_counters  = UCS_FRAG_LIST_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
             [UCS_FRAG_LIST_STAT_GAPS]              = "gaps",
             [UCS_FRAG_LIST_STAT_GAP_LEN]           = "gap_len",

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -52,8 +53,9 @@ static ucs_memtrack_context_t ucs_memtrack_context = {
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t ucs_memtrack_stats_class = {
-    .name = "memtrack",
-    .num_counters = UCS_MEMTRACK_STAT_LAST,
+    .name          = "memtrack",
+    .num_counters  = UCS_MEMTRACK_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCS_MEMTRACK_STAT_ALLOCATION_COUNT] = "alloc_cnt",
         [UCS_MEMTRACK_STAT_ALLOCATION_SIZE]  = "alloc_size"

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -81,8 +82,9 @@ typedef struct {
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t ucs_rcache_stats_class = {
-    .name = "rcache",
-    .num_counters = UCS_RCACHE_STAT_LAST,
+    .name          = "rcache",
+    .num_counters  = UCS_RCACHE_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCS_RCACHE_GETS]               = "gets",
         [UCS_RCACHE_HITS_FAST]          = "hits_fast",

--- a/src/ucs/stats/libstats.h
+++ b/src/ucs/stats/libstats.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -54,6 +55,7 @@ typedef enum ucs_stats_children_sel {
 struct ucs_stats_class {
     const char           *name;
     unsigned             num_counters;
+    unsigned             class_id;
     const char*          counter_names[];
 };
 

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -14,16 +15,67 @@
 
 #include <ucs/sys/compiler_def.h>
 #include <ucs/sys/stubs.h>
+#include <ucs/stats/stats_fwd.h>
+
+#include "stats_fwd.h"
 
 BEGIN_C_DECLS
 
 /** @file stats.h */
 
+/* Unassigned class id */
+#define UCS_STATS_CLASS_ID_INVALID (-1)
+
+typedef struct {
+    /* Counter class name */
+    const char *class_name;
+
+    /* Counter name */
+    const char *counter_name;
+
+} ucs_stats_aggrgt_counter_name_t;
+
+
 void ucs_stats_init();
 void ucs_stats_cleanup();
 void ucs_stats_dump();
 int ucs_stats_is_active();
-#include "stats_fwd.h"
+
+/**
+ * A UCX statistics API function to return the aggregate-sum of all counters
+ * from all workers/interfaces for a compact statistics trace.
+ * Used for Score-P UCX plugin to collect a compact trace of the counters.
+ *
+ * @param [out] counters     The aggregate-sum of all counters of each class/type.
+ * @param [in]  max_counters The number of elements in aggregate_sum_counters.
+ *
+ * Complexity: O(n) / recursive.
+ *
+ * @return: The actual number of aggregate_sum counters in the output
+ *          buffer.
+ *
+ * Remarks: The function calls a recursive function.
+ */
+size_t ucs_stats_aggregate(ucs_stats_counter_t *counters, size_t max_counters);
+
+
+/**
+ * A UCX statistics API to get the names of counters on the last call to
+ * ucs_stats_aggregate(). 
+ *
+ * Note, that ucs_stats_aggregate() must be called before calling this 
+ * function.
+ *
+ * @param [out] names_p The aggregate-sum counters names database
+ * @param [out] size_p  number of counters in database
+ *
+ * Complexity: O(1)
+ *
+ */
+void ucs_stats_aggregate_get_counter_names(
+        const ucs_stats_aggrgt_counter_name_t **names_p, size_t *size_p);
+
+
 #ifdef ENABLE_STATS
 
 #include "libstats.h"

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -1,7 +1,8 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
-*
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+*
 * See file LICENSE for terms.
 */
 
@@ -24,8 +25,9 @@
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ep_stats_class = {
-    .name = "uct_ep",
-    .num_counters = UCT_EP_STAT_LAST,
+    .name          = "uct_ep",
+    .num_counters  = UCT_EP_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_EP_STAT_AM]          = "am",
         [UCT_EP_STAT_PUT]         = "put",
@@ -46,8 +48,9 @@ static ucs_stats_class_t uct_ep_stats_class = {
 };
 
 static ucs_stats_class_t uct_iface_stats_class = {
-    .name = "uct_iface",
-    .num_counters = UCT_IFACE_STAT_LAST,
+    .name          = "uct_iface",
+    .num_counters  = UCT_IFACE_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_IFACE_STAT_RX_AM]       = "rx_am",
         [UCT_IFACE_STAT_RX_AM_BYTES] = "rx_am_bytes",

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -73,8 +73,9 @@ KHASH_IMPL(uct_ib_async_event, uct_ib_async_event_t, uct_ib_async_event_val_t, 1
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ib_device_stats_class = {
-    .name           = "",
-    .num_counters   = UCT_IB_DEVICE_STAT_LAST,
+    .name          = "",
+    .num_counters  = UCT_IB_DEVICE_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_IB_DEVICE_STAT_ASYNC_EVENT] = "async_event"
     }

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -196,8 +196,9 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ib_md_stats_class = {
-    .name           = "",
-    .num_counters   = UCT_IB_MD_STAT_LAST,
+    .name          = "",
+    .num_counters  = UCT_IB_MD_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_IB_MD_STAT_MEM_ALLOC]   = "mem_alloc",
         [UCT_IB_MD_STAT_MEM_REG]     = "mem_reg"

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -239,8 +240,9 @@ UCT_RC_MLX5_DEFINE_ATOMIC_LE_HANDLER(64)
 #if IBV_HW_TM
 #  ifdef ENABLE_STATS
 static ucs_stats_class_t uct_rc_mlx5_tag_stats_class = {
-    .name = "tag",
-    .num_counters = UCT_RC_MLX5_STAT_TAG_LAST,
+    .name          = "tag",
+    .num_counters  = UCT_RC_MLX5_STAT_TAG_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_RC_MLX5_STAT_TAG_RX_EXP]            = "rx_exp",
         [UCT_RC_MLX5_STAT_TAG_RX_EAGER_UNEXP]    = "rx_unexp_eager",

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -56,8 +57,9 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops;
 
 #ifdef ENABLE_STATS
 ucs_stats_class_t uct_rc_mlx5_iface_stats_class = {
-    .name = "mlx5",
-    .num_counters = UCT_RC_MLX5_IFACE_STAT_LAST,
+    .name          = "mlx5",
+    .num_counters  = UCT_RC_MLX5_IFACE_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
      [UCT_RC_MLX5_IFACE_STAT_RX_INL_32] = "rx_inl_32",
      [UCT_RC_MLX5_IFACE_STAT_RX_INL_64] = "rx_inl_64"

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 * Copyright (c) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -20,8 +21,9 @@
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_rc_fc_stats_class = {
-    .name = "rc_fc",
-    .num_counters = UCT_RC_FC_STAT_LAST,
+    .name          = "rc_fc",
+    .num_counters  = UCT_RC_FC_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_RC_FC_STAT_NO_CRED]            = "no_cred",
         [UCT_RC_FC_STAT_TX_GRANT]           = "tx_grant",
@@ -37,8 +39,9 @@ static ucs_stats_class_t uct_rc_fc_stats_class = {
 };
 
 static ucs_stats_class_t uct_rc_txqp_stats_class = {
-    .name = "rc_txqp",
-    .num_counters = UCT_RC_TXQP_STAT_LAST,
+    .name          = "rc_txqp",
+    .num_counters  = UCT_RC_TXQP_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_RC_TXQP_STAT_QP_FULL]          = "qp_full",
         [UCT_RC_TXQP_STAT_SIGNAL]           = "signal"

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -124,8 +125,9 @@ ucs_config_field_t uct_rc_iface_config_table[] = {
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_rc_iface_stats_class = {
-    .name = "rc_iface",
-    .num_counters = UCT_RC_IFACE_STAT_LAST,
+    .name          = "rc_iface",
+    .num_counters  = UCT_RC_IFACE_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_RC_IFACE_STAT_RX_COMPLETION] = "rx_completion",
         [UCT_RC_IFACE_STAT_TX_COMPLETION] = "tx_completion",

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2021.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -22,8 +23,9 @@
 
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ud_iface_stats_class = {
-    .name = "ud_iface",
-    .num_counters = UCT_UD_IFACE_STAT_LAST,
+    .name          = "ud_iface",
+    .num_counters  = UCT_UD_IFACE_STAT_LAST,
+    .class_id      = UCS_STATS_CLASS_ID_INVALID,
     .counter_names = {
         [UCT_UD_IFACE_STAT_RX_DROP] = "rx_drop"
     }

--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -29,6 +30,7 @@ public:
         m_data_stats_class->counter_names[1] = "counter1";
         m_data_stats_class->counter_names[2] = "counter2";
         m_data_stats_class->counter_names[3] = "counter3";
+        m_data_stats_class->class_id         = UCS_STATS_CLASS_ID_INVALID;
 
         cat_node = NULL;
         data_nodes[0] = data_nodes[1] = data_nodes[2] = NULL;


### PR DESCRIPTION
- The problems:
  (1) The UDP server interface for counters collection is very
      inefficient.
  (2) The number of UCX counters grows significantly by the number of
      MPI processes due to an increased number of endpoints.
      This yields a challenge for trace counters collection tools such
      as Score-P.

- The proposed solution:
  (1) Use a per-process API rather than a gathering of all counters
      in the root process by the UDP server.
  (2) Use an aggregate-sum API of all counters of the same class
      and type.
      ==> This mechanism yields a constant number of counters.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
