### PR TITLE
APPS/IO_DEMO: Fix typo in log message

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1442,7 +1442,7 @@ public:
 
         LOG << "disconnecting connection " << server_info.conn << " with "
             << get_num_uncompleted(server_info) << " uncompleted operations due"
-            "to \"" << reason << "\"";
+            " to \"" << reason << "\"";
 
         // Destroying the connection will complete its outstanding operations
         server_info.conn->disconnect(new DisconnectCallback(*this,


### PR DESCRIPTION
## What

Fix typo in log message.

## Why ?

Fixes the following message:
```
[1620370171.610665] [DEMO] disconnecting connection 0x22d4010 with 16 uncompleted operations dueto "timeout for replies"
```

## How ?

Added whitespace before `to`