### PR TITLE
UCP/WIREUP: Fix leak of UCP request for sending WIREUP/REQ

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -116,7 +116,7 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self)
             ucs_trace("ep %p: not sending wireup message - remote already connected",
                       ep);
             status = UCS_OK;
-            goto out;
+            goto out_free_req;
         }
     } else if (req->send.wireup.type == UCP_WIREUP_MSG_PRE_REQUEST) {
         ucs_assert (!(ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED));


### PR DESCRIPTION
## What

Fix leak of UCP request for sending WIREUP/REQ.

## Why ?

Fixes #6746
This PR fixes the leak of UCP request allocated from a heap directly. This UCP request was needed to send WIRUEP/REQ message to a peer, but it happens that a peer is already connected, i.e. REMOTE_CONNECTED flag is set on a EP.

## How ?

Use `out_free_req` instead of `out` in order to free allocated request and buffer for sending WIREUP/REQ message.