### PR TITLE
GTEST/UCP: Use requests_wait where it is possible

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -56,8 +56,6 @@ protected:
     void send_recv(ucp_ep_h send_ep, ucp_worker_h recv_worker, ucp_ep_h recv_ep,
                    size_t vecsize, int repeat);
 
-    void waitall(std::vector<void*> reqs);
-
     void disconnect(ucp_ep_h ep);
 
     void disconnect(ucp_test::entity &e);
@@ -271,7 +269,7 @@ void test_ucp_wireup::send_b(ucp_ep_h ep, size_t length, int repeat,
 {
     std::vector<void*> reqs;
     send_nb(ep, length, repeat, reqs, send_data);
-    waitall(reqs);
+    requests_wait(reqs);
 }
 
 void test_ucp_wireup::recv_b(ucp_worker_h worker, ucp_ep_h ep, size_t length,
@@ -345,7 +343,7 @@ void test_ucp_wireup::send_recv(ucp_ep_h send_ep, ucp_worker_h recv_worker,
 
     send_nb(send_ep, length, repeat, send_reqs, send_data);
     recv_b (recv_worker, recv_ep, length, repeat, send_data);
-    waitall(send_reqs);
+    requests_wait(send_reqs);
     m_rkeys.clear();
 }
 
@@ -359,14 +357,6 @@ void test_ucp_wireup::disconnect(ucp_ep_h ep) {
 
 void test_ucp_wireup::disconnect(ucp_test::entity &e) {
     disconnect(e.revoke_ep());
-}
-
-void test_ucp_wireup::waitall(std::vector<void*> reqs)
-{
-    while (!reqs.empty()) {
-        request_wait(reqs.back());
-        reqs.pop_back();
-    }
 }
 
 bool test_ucp_wireup::ep_iface_has_caps(const entity& e, const std::string& tl,
@@ -692,7 +682,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, disconnect_nb_onesided) {
     sender().close_ep_req_free(req);
 
     recv_b(receiver().worker(), receiver().ep(), 1000, 1000);
-    waitall(sreqs);
+    requests_wait(sreqs);
 }
 
 UCS_TEST_P(test_ucp_wireup_1sided, multi_ep_1sided) {
@@ -813,7 +803,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_wireup_2sided, async_connect,
     reqs.push_back(ucp_tag_recv_nb(receiver().worker(), NULL, 0, DT_U64, 1,
                                    (ucp_tag_t)-1, tag_recv_completion));
     EXPECT_FALSE(UCS_PTR_IS_ERR(reqs.back()));
-    waitall(reqs);
+    requests_wait(reqs);
 }
 
 UCS_TEST_P(test_ucp_wireup_2sided, connect_disconnect) {
@@ -850,7 +840,7 @@ UCS_TEST_P(test_ucp_wireup_2sided, close_nbx_callback) {
         EXPECT_FALSE(UCS_PTR_IS_ERR(reqs.back()));
     }
 
-    waitall(reqs);
+    requests_wait(reqs);
 }
 
 UCS_TEST_P(test_ucp_wireup_2sided, multi_ep_2sided) {

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -251,17 +251,18 @@ ucs_status_t ucp_test::request_wait(void *req, int worker_index)
     return request_process(req, worker_index, true);
 }
 
-ucs_status_t ucp_test::requests_wait(const std::vector<void*> &reqs,
+ucs_status_t ucp_test::requests_wait(std::vector<void*> &reqs,
                                      int worker_index)
 {
     ucs_status_t ret_status = UCS_OK;
 
-    for (std::vector<void*>::const_iterator it = reqs.begin(); it != reqs.end();
-         ++it) {
-        ucs_status_t status = request_process(*it, worker_index, true);
-        if (status != UCS_OK) {
+    while (!reqs.empty()) {
+        ucs_status_t status = request_wait(reqs.back(), worker_index);
+        if (ret_status == UCS_OK) {
+            // Save the first failure
             ret_status = status;
         }
+        reqs.pop_back();
     }
 
     return ret_status;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -235,7 +235,7 @@ protected:
     void flush_workers();
     void disconnect(entity& entity);
     ucs_status_t request_wait(void *req, int worker_index = 0);
-    ucs_status_t requests_wait(const std::vector<void*> &reqs, int worker_index = 0);
+    ucs_status_t requests_wait(std::vector<void*> &reqs, int worker_index = 0);
     void request_release(void *req);
     int max_connections();
     void set_tl_timeouts(ucs::ptr_vector<ucs::scoped_setenv> &env);


### PR DESCRIPTION
## What

Use `requests_wait()` where it is possible

## Why ?

To reduce code/functionality duplication

## How ?

1. Reimplement `requests_wait()` to use `test_ucp_wireup::waitall()` implementation - it is simpler and retrieves elements from `std::vector`.
2. Use `requests_wait()` instead of `waitall`.