### PR TITLE
UCT/BASE/SM: Add iface internal operation to refresh VFS

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -231,9 +231,14 @@ typedef ucs_status_t (*uct_iface_estimate_perf_func_t)(
         uct_iface_h iface, uct_perf_attr_t *perf_attr);
 
 
+/* Refresh the VFS representation of the interface */
+typedef void (*uct_iface_vfs_refresh_func_t)(uct_iface_h iface);
+
+
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
     uct_iface_estimate_perf_func_t iface_estimate_perf;
+    uct_iface_vfs_refresh_func_t   iface_vfs_refresh;
 } uct_iface_internal_ops_t;
 
 
@@ -720,6 +725,9 @@ void uct_base_iface_progress_enable_cb(uct_base_iface_t *iface,
                                        ucs_callback_t cb, unsigned flags);
 
 void uct_base_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
+
+ucs_status_t
+uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
 
 ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);

--- a/src/uct/base/uct_iface_vfs.c
+++ b/src/uct/base/uct_iface_vfs.c
@@ -160,14 +160,15 @@ uct_iface_vfs_init_cap_limits(uct_iface_h iface, uint64_t iface_cap_flags)
 
 void uct_iface_vfs_refresh(void *obj)
 {
-    uct_iface_h iface = obj;
+    uct_base_iface_t *iface = obj;
     uct_iface_attr_t iface_attr;
 
-    if (uct_iface_query(iface, &iface_attr) != UCS_OK) {
+    if (uct_iface_query(&iface->super, &iface_attr) == UCS_OK) {
+        uct_iface_vfs_init_caps(&iface->super, iface_attr.cap.flags);
+        uct_iface_vfs_init_cap_limits(&iface->super, iface_attr.cap.flags);
+    } else {
         ucs_debug("failed to query iface attributes");
-        return;
     }
 
-    uct_iface_vfs_init_caps(iface, iface_attr.cap.flags);
-    uct_iface_vfs_init_cap_limits(iface, iface_attr.cap.flags);
+    iface->internal_ops->iface_vfs_refresh(&iface->super);
 }

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1131,17 +1131,20 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
 }
 
 static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
-    {
-        .super            = {},
-        .create_cq        = uct_ib_mlx5_create_cq,
-        .arm_cq           = uct_rc_mlx5_iface_common_arm_cq,
-        .event_cq         = uct_rc_mlx5_iface_common_event_cq,
-        .handle_failure   = uct_dc_mlx5_iface_handle_failure,
+    .super = {
+        .super = {
+            .iface_estimate_perf = uct_base_iface_estimate_perf,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        },
+        .create_cq      = uct_ib_mlx5_create_cq,
+        .arm_cq         = uct_rc_mlx5_iface_common_arm_cq,
+        .event_cq       = uct_rc_mlx5_iface_common_event_cq,
+        .handle_failure = uct_dc_mlx5_iface_handle_failure,
     },
-    .init_rx                  = uct_dc_mlx5_init_rx,
-    .cleanup_rx               = uct_dc_mlx5_cleanup_rx,
-    .fc_ctrl                  = uct_dc_mlx5_ep_fc_ctrl,
-    .fc_handler               = uct_dc_mlx5_iface_fc_handler,
+    .init_rx    = uct_dc_mlx5_init_rx,
+    .cleanup_rx = uct_dc_mlx5_cleanup_rx,
+    .fc_ctrl    = uct_dc_mlx5_ep_fc_ctrl,
+    .fc_handler = uct_dc_mlx5_iface_fc_handler,
 };
 
 static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -830,19 +830,22 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_mlx5_iface_t, uct_iface_t, uct_md_h,
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_mlx5_iface_t, uct_iface_t);
 
 static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
-    {
-        .super            = {},
-        .create_cq        = uct_ib_mlx5_create_cq,
-        .arm_cq           = uct_rc_mlx5_iface_common_arm_cq,
-        .event_cq         = uct_rc_mlx5_iface_common_event_cq,
-        .handle_failure   = uct_rc_mlx5_iface_handle_failure,
+    .super = {
+        .super = {
+            .iface_estimate_perf = uct_base_iface_estimate_perf,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        },
+        .create_cq      = uct_ib_mlx5_create_cq,
+        .arm_cq         = uct_rc_mlx5_iface_common_arm_cq,
+        .event_cq       = uct_rc_mlx5_iface_common_event_cq,
+        .handle_failure = uct_rc_mlx5_iface_handle_failure,
     },
-    .init_rx                  = uct_rc_mlx5_iface_init_rx,
-    .cleanup_rx               = uct_rc_mlx5_iface_cleanup_rx,
-    .fc_ctrl                  = uct_rc_mlx5_ep_fc_ctrl,
-    .fc_handler               = uct_rc_iface_fc_handler,
-    .cleanup_qp               = uct_rc_mlx5_ep_cleanup_qp,
-    .ep_post_check            = uct_rc_mlx5_ep_post_check
+    .init_rx       = uct_rc_mlx5_iface_init_rx,
+    .cleanup_rx    = uct_rc_mlx5_iface_cleanup_rx,
+    .fc_ctrl       = uct_rc_mlx5_ep_fc_ctrl,
+    .fc_handler    = uct_rc_iface_fc_handler,
+    .cleanup_qp    = uct_rc_mlx5_ep_cleanup_qp,
+    .ep_post_check = uct_rc_mlx5_ep_post_check,
 };
 
 static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -476,19 +476,22 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
     };
 
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
-    {
-        .super            = {},
-        .create_cq        = uct_ib_verbs_create_cq,
-        .arm_cq           = uct_ib_iface_arm_cq,
-        .event_cq         = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
-        .handle_failure   = uct_rc_verbs_handle_failure,
+    .super = {
+        .super = {
+            .iface_estimate_perf = uct_base_iface_estimate_perf,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        },
+        .create_cq      = uct_ib_verbs_create_cq,
+        .arm_cq         = uct_ib_iface_arm_cq,
+        .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
+        .handle_failure = uct_rc_verbs_handle_failure,
     },
-    .init_rx                  = uct_rc_iface_verbs_init_rx,
-    .cleanup_rx               = uct_rc_iface_verbs_cleanup_rx,
-    .fc_ctrl                  = uct_rc_verbs_ep_fc_ctrl,
-    .fc_handler               = uct_rc_iface_fc_handler,
-    .cleanup_qp               = uct_rc_verbs_ep_cleanup_qp,
-    .ep_post_check            = uct_rc_verbs_ep_post_check
+    .init_rx       = uct_rc_iface_verbs_init_rx,
+    .cleanup_rx    = uct_rc_iface_verbs_cleanup_rx,
+    .fc_ctrl       = uct_rc_verbs_ep_fc_ctrl,
+    .fc_handler    = uct_rc_iface_fc_handler,
+    .cleanup_qp    = uct_rc_verbs_ep_cleanup_qp,
+    .ep_post_check = uct_rc_verbs_ep_post_check,
 };
 
 static ucs_status_t

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -751,22 +751,25 @@ static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg
 }
 
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
-    {
-            .super            = {},
-            .create_cq        = uct_ib_mlx5_create_cq,
-            .arm_cq           = uct_ud_mlx5_iface_arm_cq,
-            .event_cq         = uct_ud_mlx5_iface_event_cq,
-            .handle_failure   = uct_ud_mlx5_iface_handle_failure,
+    .super = {
+        .super = {
+            .iface_estimate_perf = uct_base_iface_estimate_perf,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        },
+        .create_cq      = uct_ib_mlx5_create_cq,
+        .arm_cq         = uct_ud_mlx5_iface_arm_cq,
+        .event_cq       = uct_ud_mlx5_iface_event_cq,
+        .handle_failure = uct_ud_mlx5_iface_handle_failure,
     },
-    .async_progress           = uct_ud_mlx5_iface_async_progress,
-    .send_ctl                 = uct_ud_mlx5_ep_send_ctl,
-    .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
-    .create_qp                = uct_ud_mlx5_iface_create_qp,
-    .destroy_qp               = uct_ud_mlx5_iface_destroy_qp,
-    .unpack_peer_address      = uct_ud_mlx5_iface_unpack_peer_address,
-    .ep_get_peer_address      = uct_ud_mlx5_ep_get_peer_address,
-    .get_peer_address_length  = uct_ud_mlx5_get_peer_address_length,
-    .peer_address_str         = uct_ud_mlx5_iface_peer_address_str
+    .async_progress          = uct_ud_mlx5_iface_async_progress,
+    .send_ctl                = uct_ud_mlx5_ep_send_ctl,
+    .ep_free                 = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
+    .create_qp               = uct_ud_mlx5_iface_create_qp,
+    .destroy_qp              = uct_ud_mlx5_iface_destroy_qp,
+    .unpack_peer_address     = uct_ud_mlx5_iface_unpack_peer_address,
+    .ep_get_peer_address     = uct_ud_mlx5_ep_get_peer_address,
+    .get_peer_address_length = uct_ud_mlx5_get_peer_address_length,
+    .peer_address_str        = uct_ud_mlx5_iface_peer_address_str,
 };
 
 static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -554,22 +554,25 @@ static void uct_ud_verbs_iface_destroy_qp(uct_ud_iface_t *ud_iface)
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t)(uct_iface_t*);
 
 static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
-    {
-        .super            = {},
-        .create_cq        = uct_ib_verbs_create_cq,
-        .arm_cq           = uct_ib_iface_arm_cq,
-        .event_cq         = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
-        .handle_failure   = (uct_ib_iface_handle_failure_func_t)ucs_empty_function_do_assert,
+    .super = {
+        .super = {
+            .iface_estimate_perf = uct_base_iface_estimate_perf,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        },
+        .create_cq      = uct_ib_verbs_create_cq,
+        .arm_cq         = uct_ib_iface_arm_cq,
+        .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
+        .handle_failure = (uct_ib_iface_handle_failure_func_t)ucs_empty_function_do_assert,
     },
-    .async_progress           = uct_ud_verbs_iface_async_progress,
-    .send_ctl                 = uct_ud_verbs_ep_send_ctl,
-    .ep_free                  = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_ep_t),
-    .create_qp                = uct_ib_iface_create_qp,
-    .destroy_qp               = uct_ud_verbs_iface_destroy_qp,
-    .unpack_peer_address      = uct_ud_verbs_iface_unpack_peer_address,
-    .ep_get_peer_address      = uct_ud_verbs_ep_get_peer_address,
-    .get_peer_address_length  = uct_ud_verbs_get_peer_address_length,
-    .peer_address_str         = uct_ud_verbs_iface_peer_address_str
+    .async_progress          = uct_ud_verbs_iface_async_progress,
+    .send_ctl                = uct_ud_verbs_ep_send_ctl,
+    .ep_free                 = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_ep_t),
+    .create_qp               = uct_ib_iface_create_qp,
+    .destroy_qp              = uct_ud_verbs_iface_destroy_qp,
+    .unpack_peer_address     = uct_ud_verbs_iface_unpack_peer_address,
+    .ep_get_peer_address     = uct_ud_verbs_ep_get_peer_address,
+    .get_peer_address_length = uct_ud_verbs_get_peer_address_length,
+    .peer_address_str        = uct_ud_verbs_iface_peer_address_str,
 };
 
 static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -77,7 +77,8 @@ size_t uct_sm_iface_get_device_addr_len()
                    sizeof(uct_iface_local_addr_ns_t);
 }
 
-UCS_CLASS_INIT_FUNC(uct_sm_iface_t, uct_iface_ops_t *ops, uct_md_h md,
+UCS_CLASS_INIT_FUNC(uct_sm_iface_t, uct_iface_ops_t *ops,
+                    uct_iface_internal_ops_t *internal_ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_params_t *params,
                     const uct_iface_config_t *tl_config)
 {
@@ -92,8 +93,7 @@ UCS_CLASS_INIT_FUNC(uct_sm_iface_t, uct_iface_ops_t *ops, uct_md_h md,
     }
 
     UCS_CLASS_CALL_SUPER_INIT(
-            uct_base_iface_t, ops, &uct_base_iface_internal_ops, md, worker,
-            params,
+            uct_base_iface_t, ops, internal_ops, md, worker, params,
             tl_config UCS_STATS_ARG(
                     (params->field_mask & UCT_IFACE_PARAM_FIELD_STATS_ROOT) ?
                             params->stats_root :

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -48,7 +48,8 @@ size_t uct_sm_iface_get_device_addr_len();
 
 ucs_status_t uct_sm_ep_fence(uct_ep_t *tl_ep, unsigned flags);
 
-UCS_CLASS_DECLARE(uct_sm_iface_t, uct_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const uct_iface_params_t*, const uct_iface_config_t*);
+UCS_CLASS_DECLARE(uct_sm_iface_t, uct_iface_ops_t*, uct_iface_internal_ops_t*,
+                  uct_md_h, uct_worker_h, const uct_iface_params_t*,
+                  const uct_iface_config_t*);
 
 #endif

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -614,8 +614,9 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
     ucs_status_t status;
     unsigned i;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_mm_iface_ops, md,
-                              worker, params, tl_config);
+    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &uct_mm_iface_ops,
+                              &uct_base_iface_internal_ops, md, worker, params,
+                              tl_config);
 
     if (ucs_derived_of(worker, uct_priv_worker_t)->thread_mode == UCS_THREAD_MODE_MULTI) {
         ucs_error("Shared memory transport does not support multi-threaded worker");

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -83,7 +83,8 @@ void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_att
     iface_attr->latency                 = ucs_linear_func_make(80e-9, 0); /* 80 ns */
 }
 
-UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_scopy_iface_ops_t *ops, uct_md_h md,
+UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_iface_ops_t *ops,
+                    uct_scopy_iface_ops_t *scopy_ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_params_t *params,
                     const uct_iface_config_t *tl_config)
 {
@@ -92,9 +93,10 @@ UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_scopy_iface_ops_t *ops, uct_md_h md,
     size_t elem_size;
     ucs_status_t status;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, &ops->super, md, worker, params, tl_config);
+    UCS_CLASS_CALL_SUPER_INIT(uct_sm_iface_t, ops, &scopy_ops->super, md,
+                              worker, params, tl_config);
 
-    self->tx              = ops->ep_tx;
+    self->tx              = scopy_ops->ep_tx;
     self->config.max_iov  = ucs_min(config->max_iov, ucs_iov_get_max());
     self->config.seg_size = config->seg_size;
     self->config.tx_quota = config->tx_quota;

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -54,15 +54,16 @@ typedef struct uct_scopy_iface {
 
 
 typedef struct uct_scopy_iface_ops {
-    uct_iface_ops_t               super;
-    uct_scopy_ep_tx_func_t        ep_tx;
+    uct_iface_internal_ops_t super;
+    uct_scopy_ep_tx_func_t   ep_tx;
 } uct_scopy_iface_ops_t;
 
 
 void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr);
 
-UCS_CLASS_DECLARE(uct_scopy_iface_t, uct_scopy_iface_ops_t*, uct_md_h, uct_worker_h,
-                  const uct_iface_params_t*, const uct_iface_config_t*);
+UCS_CLASS_DECLARE(uct_scopy_iface_t, uct_iface_ops_t*, uct_scopy_iface_ops_t*,
+                  uct_md_h, uct_worker_h, const uct_iface_params_t*,
+                  const uct_iface_config_t*);
 
 unsigned uct_scopy_iface_progress(uct_iface_h tl_iface);
 

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -88,39 +88,45 @@ uct_cma_iface_is_reachable(const uct_iface_h tl_iface,
 
 static UCS_CLASS_DECLARE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 
+static uct_iface_ops_t uct_cma_iface_tl_ops = {
+    .ep_put_zcopy             = uct_scopy_ep_put_zcopy,
+    .ep_get_zcopy             = uct_scopy_ep_get_zcopy,
+    .ep_pending_add           = ucs_empty_function_return_busy,
+    .ep_pending_purge         = ucs_empty_function,
+    .ep_flush                 = uct_scopy_ep_flush,
+    .ep_fence                 = uct_sm_ep_fence,
+    .ep_check                 = uct_cma_ep_check,
+    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cma_ep_t),
+    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_ep_t),
+    .iface_flush              = uct_scopy_iface_flush,
+    .iface_fence              = uct_sm_iface_fence,
+    .iface_progress_enable    = ucs_empty_function,
+    .iface_progress_disable   = ucs_empty_function,
+    .iface_progress           = uct_scopy_iface_progress,
+    .iface_event_fd_get       = ucs_empty_function_return_unsupported,
+    .iface_event_arm          = uct_scopy_iface_event_arm,
+    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
+    .iface_query              = uct_cma_iface_query,
+    .iface_get_address        = uct_cma_iface_get_address,
+    .iface_get_device_address = uct_sm_iface_get_device_address,
+    .iface_is_reachable       = uct_cma_iface_is_reachable,
+};
+
 static uct_scopy_iface_ops_t uct_cma_iface_ops = {
     .super = {
-        .ep_put_zcopy             = uct_scopy_ep_put_zcopy,
-        .ep_get_zcopy             = uct_scopy_ep_get_zcopy,
-        .ep_pending_add           = ucs_empty_function_return_busy,
-        .ep_pending_purge         = ucs_empty_function,
-        .ep_flush                 = uct_scopy_ep_flush,
-        .ep_fence                 = uct_sm_ep_fence,
-        .ep_check                 = uct_cma_ep_check,
-        .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cma_ep_t),
-        .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_ep_t),
-        .iface_flush              = uct_scopy_iface_flush,
-        .iface_fence              = uct_sm_iface_fence,
-        .iface_progress_enable    = ucs_empty_function,
-        .iface_progress_disable   = ucs_empty_function,
-        .iface_progress           = uct_scopy_iface_progress,
-        .iface_event_fd_get       = ucs_empty_function_return_unsupported,
-        .iface_event_arm          = uct_scopy_iface_event_arm,
-        .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
-        .iface_query              = uct_cma_iface_query,
-        .iface_get_address        = uct_cma_iface_get_address,
-        .iface_get_device_address = uct_sm_iface_get_device_address,
-        .iface_is_reachable       = uct_cma_iface_is_reachable
+        .iface_estimate_perf = uct_base_iface_estimate_perf,
+        .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     },
-    .ep_tx                        = uct_cma_ep_tx
+    .ep_tx = uct_cma_ep_tx,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    UCS_CLASS_CALL_SUPER_INIT(uct_scopy_iface_t, &uct_cma_iface_ops, md,
-                              worker, params, tl_config);
+    UCS_CLASS_CALL_SUPER_INIT(uct_scopy_iface_t, &uct_cma_iface_tl_ops,
+                              &uct_cma_iface_ops, md, worker, params,
+                              tl_config);
 
     return UCS_OK;
 }

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -41,38 +41,44 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
 
 static UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
+static uct_iface_ops_t uct_knem_iface_tl_ops = {
+    .ep_put_zcopy             = uct_scopy_ep_put_zcopy,
+    .ep_get_zcopy             = uct_scopy_ep_get_zcopy,
+    .ep_pending_add           = ucs_empty_function_return_busy,
+    .ep_pending_purge         = ucs_empty_function,
+    .ep_flush                 = uct_scopy_ep_flush,
+    .ep_fence                 = uct_sm_ep_fence,
+    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_knem_ep_t),
+    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_ep_t),
+    .iface_flush              = uct_scopy_iface_flush,
+    .iface_fence              = uct_sm_iface_fence,
+    .iface_progress_enable    = ucs_empty_function,
+    .iface_progress_disable   = ucs_empty_function,
+    .iface_progress           = uct_scopy_iface_progress,
+    .iface_event_fd_get       = ucs_empty_function_return_unsupported,
+    .iface_event_arm          = uct_scopy_iface_event_arm,
+    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
+    .iface_query              = uct_knem_iface_query,
+    .iface_get_device_address = uct_sm_iface_get_device_address,
+    .iface_get_address        = ucs_empty_function_return_success,
+    .iface_is_reachable       = uct_sm_iface_is_reachable,
+};
+
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {
     .super = {
-        .ep_put_zcopy             = uct_scopy_ep_put_zcopy,
-        .ep_get_zcopy             = uct_scopy_ep_get_zcopy,
-        .ep_pending_add           = ucs_empty_function_return_busy,
-        .ep_pending_purge         = ucs_empty_function,
-        .ep_flush                 = uct_scopy_ep_flush,
-        .ep_fence                 = uct_sm_ep_fence,
-        .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_knem_ep_t),
-        .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_ep_t),
-        .iface_flush              = uct_scopy_iface_flush,
-        .iface_fence              = uct_sm_iface_fence,
-        .iface_progress_enable    = ucs_empty_function,
-        .iface_progress_disable   = ucs_empty_function,
-        .iface_progress           = uct_scopy_iface_progress,
-        .iface_event_fd_get       = ucs_empty_function_return_unsupported,
-        .iface_event_arm          = uct_scopy_iface_event_arm,
-        .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
-        .iface_query              = uct_knem_iface_query,
-        .iface_get_device_address = uct_sm_iface_get_device_address,
-        .iface_get_address        = ucs_empty_function_return_success,
-        .iface_is_reachable       = uct_sm_iface_is_reachable
+        .iface_estimate_perf = uct_base_iface_estimate_perf,
+        .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     },
-    .ep_tx                        = uct_knem_ep_tx
+    .ep_tx = uct_knem_ep_tx,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_knem_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
-    UCS_CLASS_CALL_SUPER_INIT(uct_scopy_iface_t, &uct_knem_iface_ops, md,
-                              worker, params, tl_config);
+    UCS_CLASS_CALL_SUPER_INIT(uct_scopy_iface_t, &uct_knem_iface_tl_ops,
+                              &uct_knem_iface_ops, md, worker, params,
+                              tl_config);
     self->knem_md = (uct_knem_md_t *)md;
 
     return UCS_OK;


### PR DESCRIPTION
## Why
- Allow transport interfaces to extend VFS-refresh function and add their own information
- scopy transports should also use internal ops to define "ep_tx" method