### PR TITLE
GITHUB: Updating issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,6 +18,7 @@ A clear and concise description of what the bug is.
 ### Setup and versions
 - OS version (e.g Linux distro) + CPU architecture (x86_64/aarch64/ppc64le/...)
    - `cat /etc/issue` or `cat /etc/redhat-release` + `uname -a`
+   - For Nvidia Bluefield SmartNIC include `cat /etc/mlnx-release` (the string identifies software and firmware setup)
 - For RDMA/IB/RoCE related issues:
     - Driver version:
         - `rpm -q rdma-core` or `rpm -q libibverbs`


### PR DESCRIPTION
## What
Adding information how to identify Bluefield DOCA setups

## Why ?
It is not obvious how to identify DOCA setup

## How ?
It is based on info from DOCA devs

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>

