### PR TITLE
UCS: stats performance enhancements (contig. allocation)

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -41,6 +41,7 @@ nobase_dist_libucs_la_HEADERS = \
 	datastruct/mpool.h \
 	datastruct/mpool_set.h \
 	datastruct/pgtable.h \
+	datastruct/ptr_array_fwd.h \
 	datastruct/queue_types.h \
 	datastruct/strided_alloc.h \
 	datastruct/string_buffer.h \

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -326,7 +326,8 @@ unsigned ucs_ptr_array_locked_insert(ucs_ptr_array_locked_t *locked_ptr_array,
  * Allocate a number of contiguous slots in the locked array.
  *
  * @param [in] locked_ptr_array  Pointer to a locked ptr array.
- * @param [in] element_count     Number of slots to allocate
+ * @param [in] element_count     Number of slots to allocate.
+ * @param [in] init_value     Value to set in every allocated slot.
  *
  * @return The index of the requested amount of slots (initialized to zero).
  *
@@ -337,7 +338,8 @@ unsigned ucs_ptr_array_locked_insert(ucs_ptr_array_locked_t *locked_ptr_array,
  */
 unsigned
 ucs_ptr_array_locked_bulk_alloc(ucs_ptr_array_locked_t *locked_ptr_array,
-                                unsigned element_count);
+                                unsigned element_count,
+                                void *init_value);
 
 
 /**
@@ -363,6 +365,20 @@ void ucs_ptr_array_locked_set(ucs_ptr_array_locked_t *locked_ptr_array,
  */
 void ucs_ptr_array_locked_remove(ucs_ptr_array_locked_t *locked_ptr_array,
                                  unsigned element_index);
+
+
+/**
+ * Release a number of contiguous locked array slots.
+ *
+ * @param [in] ptr_array      Pointer to a locked ptr array.
+ * @param [in] element_index  Index to remove from.
+ * @param [in] element_count  Number of slots to release.
+ *
+ * Complexity: O(n)
+ */
+void ucs_ptr_array_locked_bulk_remove(ucs_ptr_array_locked_t *locked_ptr_array,
+                                      unsigned element_index,
+                                      unsigned element_count);
 
 
 /**

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -9,99 +9,18 @@
 #define PTR_ARRAY_H_
 
 #include <ucs/sys/math.h>
-#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/spinlock.h>
-#include <ucs/debug/assert.h>
-
-/*
- * Array element layout:
- *
- *         64                 32               1   0
- *          +-----------------+----------------+---+
- * free:    |     free_ahead  |  next index    | 1 |
- *          +-----------------+----------------+---+
- * used:    |           user pointer           | 0 |
- *          +-----------------+----------------+---+
- *
- *
- * free_ahead is the number of consecutive free elements ahead.
- *
- * The remove / insert algorithm works as follows:
- * On remove of an index: If start[index+1] is free ==>
- * start[index].free_elements_ahead = start[index+1].free_elements_ahead+1
- * Then, the removed index is pushed to the HEAD of the freelist.
- * NOTE, that if start[index+1] is free ==> It's already in the freelist !!!
- *
- * On insert, we fetch the first entry of the freelist and we rely on the
- * fact that the remove/insert mechanism effectively implements a LIFO
- * freelist, i.e. the last item pushed into the freelist will be fetched
- * first ==> There is no chance that index+1 will be fetched before index,
- * since index+1 was already in the list before index was put into the list.
- *
- * Therefore, we can rely on the free_size_ahead field to tell how many free
- * elements are from any index in the freelist.
- *
- * To clarify, "free_ahead" is a best-effort optimization, so when it is not
- * updated on removal - the for-each code runs slower, but still correctly.
- * This decision was made in order to preserve the O(1) performance of
- * ucs_ptr_array_remove() - at the expense of ptr_array_for_each() performance.
- * If we wanted to favor ptr_array_for_each() we had to update "free_ahead"
- * values in all the empty cells before the changed one, a noticeable overhead.
- * Instead, the for-each checks if the cell is empty even if it's indicated as
- * such by "free_ahead". As for insert() - a new cell can be either inserted
- * right after an occupied cell (no need to update "free_ahead") or instead of
- * a removed cell (so that "free_ahead" already points to it). The resulting
- * effect is that "free_ahead" may have "false positives" but never "false
- * negatives". Set() is different, because it "messes" with this logic - and
- * can create that "false negative". This is why it requires such a complicated
- * update of the "free_ahead" (unless the set overwrites an occupied cell).
- *
- */
-typedef uint64_t ucs_ptr_array_elem_t;
-
-
-/**
- * A sparse array of pointers.
- */
-typedef struct ucs_ptr_array {
-    ucs_ptr_array_elem_t     *start;   /* Pointer to the allocated array */
-    unsigned                 freelist; /* Index of first free slot (see above) */
-    unsigned                 size;     /* Number of allocated array slots */
-    unsigned                 count;    /* Actual number of occupied slots */
-    const char               *name;    /* Name of this pointer array */
-} ucs_ptr_array_t;
-
+#include <ucs/datastruct/ptr_array_fwd.h>
 
 /* Flags added to lower bits of the value */
-#define UCS_PTR_ARRAY_FLAG_FREE    ((unsigned long)0x01)  /* Slot is free */
-
+#define UCS_PTR_ARRAY_FLAG_FREE        ((unsigned long)0x01)  /* Slot is free */
 #define UCS_PTR_ARRAY_FREE_AHEAD_SHIFT 32
 #define UCS_PTR_ARRAY_FREE_AHEAD_MASK  (((ucs_ptr_array_elem_t)-1) & ~UCS_MASK(UCS_PTR_ARRAY_FREE_AHEAD_SHIFT))
-#define UCS_PTR_ARRAY_NEXT_SHIFT       1
 #define UCS_PTR_ARRAY_NEXT_MASK        (UCS_MASK(UCS_PTR_ARRAY_FREE_AHEAD_SHIFT) & ~UCS_MASK(UCS_PTR_ARRAY_NEXT_SHIFT))
 #define UCS_PTR_ARRAY_SENTINEL         (UCS_PTR_ARRAY_NEXT_MASK >> UCS_PTR_ARRAY_NEXT_SHIFT)
 
 #define __ucs_ptr_array_is_free(_elem) \
     ((uintptr_t)(_elem) & UCS_PTR_ARRAY_FLAG_FREE)
-
-
-/**
- * Initialize the array.
- *
- * @param [in] ptr_array          Pointer to a ptr array.
- * @param [in] name               The name of the ptr array.
- */
-void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, const char *name);
-
-
-/**
- * Cleanup the array.
- *
- * @param ptr_array  Pointer to a ptr array.
- * @param leak_check Whether to check for leaks (elements which were not
- *                   freed from this ptr array).
- */
-void ucs_ptr_array_cleanup(ucs_ptr_array_t *ptr_array, int leak_check);
 
 
 /**
@@ -120,23 +39,6 @@ unsigned ucs_ptr_array_insert(ucs_ptr_array_t *ptr_array, void *value);
 
 
 /**
- * Allocate a number of contiguous array slots.
- *
- * @param [in] ptr_array      Pointer to a ptr array.
- * @param [in] element_count  Number of slots to allocate
- *
- * @return The index of the requested amount of slots (initialized to zero).
- *
- * Complexity: O(n*n) - not recommended for data-path
- *
- * @note The array will grow if needed.
- * @note Use @ref ucs_ptr_array_remove to "deallocate" the slots.
- */
-unsigned
-ucs_ptr_array_bulk_alloc(ucs_ptr_array_t *ptr_array, unsigned element_count);
-
-
-/**
  * Set a pointer in the array, overwriting the contents of the slot.
  *
  * @param [in] ptr_array      Pointer to a ptr array.
@@ -150,17 +52,6 @@ void ucs_ptr_array_set(ucs_ptr_array_t *ptr_array, unsigned element_index,
 
 
 /**
- * Remove a pointer from the array.
- *
- * @param [in] ptr_array      Pointer to a ptr array.
- * @param [in] element_index  Index to remove from.
- *
- * Complexity: O(1)
- */
-void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned element_index);
-
-
-/**
  * Replace pointer in the array, assuming the slot is occupied.
  *
  * @param [in] ptr_array      Pointer to a ptr array.
@@ -171,6 +62,17 @@ void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned element_index);
  */
 void *ucs_ptr_array_replace(ucs_ptr_array_t *ptr_array, unsigned element_index,
                             void *new_val);
+
+
+/**
+ * Remove a pointer from the array.
+ *
+ * @param [in] ptr_array      Pointer to a ptr array.
+ * @param [in] element_index  Index to remove from.
+ *
+ * Complexity: O(1)
+ */
+void ucs_ptr_array_remove(ucs_ptr_array_t *ptr_array, unsigned element_index);
 
 
 /**

--- a/src/ucs/datastruct/ptr_array_fwd.h
+++ b/src/ucs/datastruct/ptr_array_fwd.h
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_PTR_ARRAY_FWD_H_
+#define UCS_PTR_ARRAY_FWD_H_
+
+#include <stdint.h>
+
+#include <ucs/sys/compiler_def.h>
+
+BEGIN_C_DECLS
+
+/** @file ptr_array_fwd.h */
+
+#define UCS_PTR_ARRAY_NEXT_SHIFT (1)
+
+/*
+ * Array element layout:
+ *
+ *         64                 32               1   0
+ *          +-----------------+----------------+---+
+ * free:    |     free_ahead  |  next index    | 1 |
+ *          +-----------------+----------------+---+
+ * used:    |           user pointer           | 0 |
+ *          +-----------------+----------------+---+
+ *
+ *
+ * free_ahead is the number of consecutive free elements ahead.
+ *
+ * The remove / insert algorithm works as follows:
+ * On remove of an index: If start[index+1] is free ==>
+ * start[index].free_elements_ahead = start[index+1].free_elements_ahead+1
+ * Then, the removed index is pushed to the HEAD of the freelist.
+ * NOTE, that if start[index+1] is free ==> It's already in the freelist !!!
+ *
+ * On insert, we fetch the first entry of the freelist and we rely on the
+ * fact that the remove/insert mechanism effectively implements a LIFO
+ * freelist, i.e. the last item pushed into the freelist will be fetched
+ * first ==> There is no chance that index+1 will be fetched before index,
+ * since index+1 was already in the list before index was put into the list.
+ *
+ * Therefore, we can rely on the free_size_ahead field to tell how many free
+ * elements are from any index in the freelist.
+ *
+ * To clarify, "free_ahead" is a best-effort optimization, so when it is not
+ * updated on removal - the for-each code runs slower, but still correctly.
+ * This decision was made in order to preserve the O(1) performance of
+ * ucs_ptr_array_remove() - at the expense of ptr_array_for_each() performance.
+ * If we wanted to favor ptr_array_for_each() we had to update "free_ahead"
+ * values in all the empty cells before the changed one, a noticeable overhead.
+ * Instead, the for-each checks if the cell is empty even if it's indicated as
+ * such by "free_ahead". As for insert() - a new cell can be either inserted
+ * right after an occupied cell (no need to update "free_ahead") or instead of
+ * a removed cell (so that "free_ahead" already points to it). The resulting
+ * effect is that "free_ahead" may have "false positives" but never "false
+ * negatives". Set() is different, because it "messes" with this logic - and
+ * can create that "false negative". This is why it requires such a complicated
+ * update of the "free_ahead" (unless the set overwrites an occupied cell).
+ *
+ */
+typedef uint64_t ucs_ptr_array_elem_t;
+
+
+/**
+ * A sparse array of pointers.
+ */
+typedef struct ucs_ptr_array {
+    ucs_ptr_array_elem_t *start;   /* Pointer to the allocated array */
+    unsigned             freelist; /* Index of first free slot (see above) */
+    unsigned             size;     /* Number of allocated array slots */
+    unsigned             count;    /* Actual number of occupied slots */
+    const char           *name;    /* Name of this pointer array */
+} ucs_ptr_array_t;
+
+
+/**
+ * Shift an input value so it will fit in a ptr array slot.
+ *
+ * @param [in] new_val        Value to be put into a slot (at some point).
+ *
+ * @return The same value, as it would be stored in the ptr array.
+ */
+static UCS_F_ALWAYS_INLINE uintptr_t ucs_ptr_array_shift(uintptr_t new_val)
+{
+    return new_val << UCS_PTR_ARRAY_NEXT_SHIFT;
+}
+
+
+/**
+ * Shift back the value retrieved from a ptr array (@ref ucs_ptr_array_shift).
+ *
+ * @param [in] old_val        Value which has been stored in the ptr array slot.
+ *
+ * @return The original value stored in the ptr array slot (before shifting).
+ */
+static UCS_F_ALWAYS_INLINE uintptr_t ucs_ptr_array_unshift(uintptr_t old_val)
+{
+    return old_val >> UCS_PTR_ARRAY_NEXT_SHIFT;
+}
+
+
+/**
+ * Pointer to the element location by its index in the ptr array.
+ *
+ * @param [in]  ptr_array     Pointer to a ptr array.
+ * @param [in]  index         Index to return the point to.
+ *
+ * @return A pointer to the element inside the ptr array.
+ */
+static UCS_F_ALWAYS_INLINE ucs_ptr_array_elem_t*
+ucs_ptr_array_at(ucs_ptr_array_t *ptr_array, uint64_t index)
+{
+    return &ptr_array->start[index];
+}
+
+
+/**
+ * Initialize the array.
+ *
+ * @param [in] ptr_array          Pointer to a ptr array.
+ * @param [in] name               The name of the ptr array.
+ */
+void ucs_ptr_array_init(ucs_ptr_array_t *ptr_array, const char *name);
+
+
+/**
+ * Cleanup the array.
+ *
+ * @param ptr_array  Pointer to a ptr array.
+ * @param leak_check Whether to check for leaks (elements which were not
+ *                   freed from this ptr array).
+ */
+void ucs_ptr_array_cleanup(ucs_ptr_array_t *ptr_array, int leak_check);
+
+
+/**
+ * Allocate a number of contiguous slots in the array.
+ *
+ * @param [in] locked_ptr_array  Pointer to a ptr array.
+ * @param [in] element_count     Number of slots to allocate.
+ * @param [in] init_value     Value to set in every allocated slot.
+ *
+ * @return The index of the requested amount of slots (initialized to zero).
+ *
+ * Complexity: O(n*n) - not recommended for data-path
+ *
+ * @note The array will grow if needed.
+ * @note Use @ref ucs_ptr_array_bulk_remove to "deallocate" the slots.
+ */
+unsigned
+ucs_ptr_array_bulk_alloc(ucs_ptr_array_t *locked_ptr_array,
+                         unsigned element_count,
+                         void *init_value);
+
+
+/**
+ * Release a number of contiguous array slots.
+ *
+ * @param [in] ptr_array      Pointer to a ptr array.
+ * @param [in] element_index  Index to remove from.
+ * @param [in] element_count  Number of slots to release.
+ *
+ * Complexity: O(n)
+ */
+void ucs_ptr_array_bulk_remove(ucs_ptr_array_t *locked_ptr_array,
+                               unsigned element_index,
+                               unsigned element_count);
+
+
+END_C_DECLS
+
+#endif /* UCS_PTR_ARRAY_FWD_H_ */

--- a/src/ucs/stats/client_server.c
+++ b/src/ucs/stats/client_server.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -618,6 +619,7 @@ int ucs_stats_server_get_port(ucs_stats_server_h server)
 ucs_list_link_t *ucs_stats_server_get_stats(ucs_stats_server_h server)
 {
     struct sglib_hashed_stats_entity_t_iterator it;
+    ucs_ptr_array_t counters;
     stats_entity_t *entity;
     ucs_stats_node_t *node;
     ucs_status_t status;
@@ -632,7 +634,7 @@ ucs_list_link_t *ucs_stats_server_get_stats(ucs_stats_server_h server)
         /* Parse the statistics data */
         pthread_mutex_lock(&entity->lock);
         stream = fmemopen(entity->completed_buffer, entity->buffer_size, "rb");
-        status = ucs_stats_deserialize(stream, &node);
+        status = ucs_stats_deserialize(stream, &counters, &node);
         fclose(stream);
         pthread_mutex_unlock(&entity->lock);
 
@@ -641,6 +643,8 @@ ucs_list_link_t *ucs_stats_server_get_stats(ucs_stats_server_h server)
         }
     }
     pthread_mutex_unlock(&server->entities_lock);
+
+    ucs_ptr_array_cleanup(&counters, 0);
 
     return &server->curr_stats;
 }

--- a/src/ucs/stats/libstats.c
+++ b/src/ucs/stats/libstats.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2013.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -63,7 +64,6 @@ ucs_status_t ucs_stats_node_initv(ucs_stats_node_t *node, ucs_stats_class_t *cls
     ucs_vsnprintf_safe(node->name, UCS_STAT_NAME_MAX, name, ap);
     ucs_list_head_init(&node->children[UCS_STATS_INACTIVE_CHILDREN]);
     ucs_list_head_init(&node->children[UCS_STATS_ACTIVE_CHILDREN]);
-    memset(node->counters, 0, cls->num_counters * sizeof(ucs_stats_counter_t));
 
     return UCS_OK;
 }

--- a/src/ucs/stats/stats_fwd.h
+++ b/src/ucs/stats/stats_fwd.h
@@ -15,10 +15,11 @@ BEGIN_C_DECLS
 
 /** @file stats_fwd.h */
 
-typedef uint64_t                          ucs_stats_counter_t;        /* Stats counter*/
-typedef struct ucs_stats_class            ucs_stats_class_t;          /* Stats class */
-typedef struct ucs_stats_node             ucs_stats_node_t;           /* Stats node */
-typedef struct ucs_stats_filter_node      ucs_stats_filter_node_t;    /* Stats filter node */
+typedef uint64_t                             ucs_stats_counter_t;
+typedef struct ucs_stats_class               ucs_stats_class_t;
+typedef struct ucs_stats_node                ucs_stats_node_t;
+typedef struct ucs_stats_filter_node         ucs_stats_filter_node_t;
+typedef struct ucs_stats_aggrgt_counter_name ucs_stats_aggrgt_counter_name_t;
 
 typedef enum {
     UCS_STATS_FULL,        /* Full statistics report */

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -547,7 +547,7 @@ UCS_TEST_F(test_datatype, ptr_array_basic) {
 
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 7);
 
-    index = ucs_ptr_array_bulk_alloc(&pa, 200);
+    index = ucs_ptr_array_bulk_alloc(&pa, 200, NULL);
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 207);
 
     EXPECT_EQ(301u, pa.size);
@@ -605,47 +605,38 @@ UCS_TEST_F(test_datatype, ptr_array_basic) {
     ucs_ptr_array_cleanup(&pa, 1);
 }
 
-UCS_TEST_F(test_datatype, ptr_array_bulk_alloc) {
+UCS_TEST_F(test_datatype, ptr_array_bulk) {
     ucs_ptr_array_t pa;
-    unsigned idx, alloc1, alloc2;
+    unsigned alloc1, alloc2;
 
     ucs_ptr_array_init(&pa, "ptr_array alloc test");
 
-    alloc1 = ucs_ptr_array_bulk_alloc(&pa, 10);
+    alloc1 = ucs_ptr_array_bulk_alloc(&pa, 10, NULL);
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 10);
 
     EXPECT_GE(pa.size, 10u);
     EXPECT_EQ(alloc1, 0u);
 
-    alloc2 = ucs_ptr_array_bulk_alloc(&pa, 100);
+    alloc2 = ucs_ptr_array_bulk_alloc(&pa, 100, NULL);
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 110);
 
     EXPECT_GE(pa.size, 110u);
     EXPECT_EQ(alloc2, alloc1 + 10u);
 
-    for (idx = 0; idx < alloc2; idx++) {
-        ucs_ptr_array_remove(&pa, idx);
-    }
+    ucs_ptr_array_bulk_remove(&pa, 0, alloc2);
 
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 100);
-    EXPECT_EQ(alloc1, ucs_ptr_array_bulk_alloc(&pa, 10));
+    EXPECT_EQ(alloc1, ucs_ptr_array_bulk_alloc(&pa, 10, NULL));
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 110);
 
-    for (idx = alloc1 + 10; idx > alloc1; idx--) {
-        ucs_ptr_array_remove(&pa, idx - 1);
-    }
+    ucs_ptr_array_bulk_remove(&pa, alloc1, 10);
 
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 100);
-    EXPECT_EQ(alloc1, ucs_ptr_array_bulk_alloc(&pa, 10));
+    EXPECT_EQ(alloc1, ucs_ptr_array_bulk_alloc(&pa, 10, NULL));
     EXPECT_EQ(ucs_ptr_array_get_elem_count(&pa), 110);
 
-    for (idx = alloc1; idx < alloc1 + 10; idx++) {
-        ucs_ptr_array_remove(&pa, idx);
-    }
-
-    for (idx = alloc2; idx < alloc2 + 100; idx++) {
-        ucs_ptr_array_remove(&pa, idx);
-    }
+    ucs_ptr_array_bulk_remove(&pa, alloc1, 10);
+    ucs_ptr_array_bulk_remove(&pa, alloc2, 100);
 
     EXPECT_EQ(ucs_ptr_array_is_empty(&pa), 1);
 
@@ -833,7 +824,7 @@ UCS_TEST_F(test_datatype, ptr_array_locked_basic) {
 
     ucs_ptr_array_locked_set(&pa, 100, &g);
 
-    index = ucs_ptr_array_locked_bulk_alloc(&pa, 200);
+    index = ucs_ptr_array_locked_bulk_alloc(&pa, 200, NULL);
     EXPECT_EQ(301u, pa.super.size);
     EXPECT_EQ(101u, index);
 

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -8,7 +8,7 @@
 #include <common/test.h>
 
 extern "C" {
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/datastruct/array.inl>
 #include <ucs/datastruct/list.h>
 #include <ucs/datastruct/hlist.h>


### PR DESCRIPTION
Signed-off-by: Alex Margolin <alex.margolin@huawei.com>

## What
Make both the _stats_ nodes and the counters are **more or less** contiguous in (virtual) memory.

## Why ?
An effort to reduce the average latency of accessing stats, and also to put all the counters in a single buffer so it could be RDMA-ed instead of UDP-ed.

## How ?
Both filter and regular stats nodes are allocated from a memory pool (the first chunk should cover common UCX initialization), and the counters are allocated in a flexible array (so there's one buffer containing all of them).
