### PR TITLE
TOOLS/PERF: correct mpi options range in perftest

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -953,8 +953,8 @@ static ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized
                 return status;
             }
             break;
-        case 'P':
 #ifdef HAVE_MPI
+        case 'P':
             ctx->mpi = atoi(optarg) && mpi_initialized;
             break;
 #endif


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
"-P" optoin is for mpi in ucx_perftest. 

## Why ?
It's wrong for "-P" go through directly to the same code with "-h" option when macro "HAVE_MPI" is not defined.
