### PR TITLE
IODEMO: extend server statistics

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -816,56 +816,66 @@ public:
         MemoryPool<IoWriteResponseCallback>& _pool;
     };
 
-    typedef struct {
-        long    read_count;
-        long    write_count;
-        long    active_conns;
-    } state_t;
-
-    class ConnectionState {
+    class ConnectionStat {
     public:
-        ConnectionState() {
+        ConnectionStat() {
             reset();
         }
 
         void reset() {
-            _read_req_bytes  = 0;
-            _read_req_count  = 0;
-            _write_req_bytes = 0;
-            _write_req_count = 0;
+            for (int i = 0; i < IO_OP_MAX; ++i) {
+                _bytes_counters[i] = 0;
+                _op_counters[i]    = 0;
+            }
         }
 
-        long get_total_count() const {
-            return _read_req_count + _write_req_count;
+        void operator+=(const ConnectionStat &other) {
+            for (int i = 0; i < IO_OP_MAX; ++i) {
+                _bytes_counters[i] += other._bytes_counters[i];
+                _op_counters[i]    += other._op_counters[i];
+            }
         }
 
-        long get_total_bytes() const {
-            return _read_req_bytes + _write_req_bytes;
+        template<io_op_t op_type> long&
+        completions() {
+            UCS_STATIC_ASSERT(op_type < IO_OP_MAX);
+            return _op_counters[op_type];
         }
 
-        void read_started(size_t bytes) {
-            _read_req_bytes += bytes;
-            ++_read_req_count;
-        }
-
-        void write_started(size_t bytes) {
-            _write_req_bytes += bytes;
-            ++_write_req_count;
+        template<io_op_t op_type> long&
+        bytes() {
+            UCS_STATIC_ASSERT(op_type < IO_OP_MAX);
+            return _bytes_counters[op_type];
         }
 
     private:
-        long _read_req_bytes;
-        long _read_req_count;
-        long _write_req_bytes;
-        long _write_req_count;
+        long _bytes_counters[IO_OP_MAX];
+        long _op_counters[IO_OP_MAX];
+    };
+
+    typedef std::map<UcxConnection*, ConnectionStat> conn_stat_map_t;
+
+    class DisconnectCallback : public UcxDisconnectCallback {
+    public:
+        DisconnectCallback(conn_stat_map_t &stat_map,
+                           conn_stat_map_t::key_type map_key) :
+            _stat_map(stat_map), _map_key(map_key) {
+        }
+
+        virtual void operator()(ucs_status_t status) {
+            conn_stat_map_t::iterator it = _stat_map.find(_map_key);
+            assert(it != _stat_map.end());
+            _stat_map.erase(it);
+            delete this;
+        }
+
+    private:
+        conn_stat_map_t           &_stat_map;
+        conn_stat_map_t::key_type _map_key;
     };
 
     DemoServer(const options_t& test_opts) :
         P2pDemoCommon(test_opts), _callback_pool(0, "callbacks") {
-        _curr_state.read_count   = 0;
-        _curr_state.write_count  = 0;
-        _curr_state.active_conns = 0;
-        save_prev_state();
     }
 
     void run() {
@@ -911,8 +921,8 @@ public:
 
                 double curr_time = get_time();
                 if (curr_time >= (prev_time + opts().print_interval)) {
+                    report_state(curr_time - prev_time);
                     prev_time = curr_time;
-                    report_state();
                 }
             } catch (const std::exception &e) {
                 std::cerr << e.what();
@@ -925,16 +935,14 @@ public:
         VERBOSE_LOG << "sending IO read data";
         assert(opts().max_data_size >= msg->data_size);
 
-        BufferIov *iov           = _data_buffers_pool.get();
-        SendCompleteCallback *cb = _send_callback_pool.get();
+        BufferIov *iov            = _data_buffers_pool.get();
+        SendCompleteCallback *cb  = _send_callback_pool.get();
+        ConnectionStat &conn_stat = _conn_stat_map.find(conn)->second;
 
         iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
-        cb->init(iov, &_curr_state.read_count);
+        cb->init(iov, &conn_stat.completions<IO_READ>());
 
-        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
-        assert(it != _conn_stat_map.end());
-        it->second.read_started(msg->data_size);
-
+        conn_stat.bytes<IO_READ>() += msg->data_size;
         send_data(conn, *iov, msg->sn, cb);
 
         // send response as data
@@ -951,16 +959,13 @@ public:
 
         BufferIov *iov = _data_buffers_pool.get();
         iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
-
-        SendCompleteCallback *cb = _send_callback_pool.get();
-        cb->init(iov, &_curr_state.read_count, m);
-
         assert(iov->size() == 1);
 
-        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
-        assert(it != _conn_stat_map.end());
-        it->second.read_started(msg->data_size);
+        ConnectionStat &conn_stat = _conn_stat_map.find(conn)->second;
+        SendCompleteCallback *cb  = _send_callback_pool.get();
+        cb->init(iov, &conn_stat.completions<IO_READ>(), m);
 
+        conn_stat.bytes<IO_READ>() += msg->data_size;
         // Send IO_READ_COMP as AM header and first iov element as payload
         // (note that multi-iov send is not supported for IODEMO with AM yet)
         conn->send_am(m->buffer(), opts().iomsg_size, (*iov)[0].buffer(),
@@ -973,13 +978,12 @@ public:
 
         BufferIov *iov             = _data_buffers_pool.get();
         IoWriteResponseCallback *w = _callback_pool.get();
+        ConnectionStat &conn_stat  = _conn_stat_map.find(conn)->second;
 
         iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
-        w->init(this, conn, msg->sn, iov, &_curr_state.write_count);
+        w->init(this, conn, msg->sn, iov, &conn_stat.completions<IO_WRITE>());
 
-        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
-        assert(it != _conn_stat_map.end());
-        it->second.write_started(msg->data_size);
+        conn_stat.bytes<IO_WRITE>() += msg->data_size;
         recv_data(conn, *iov, msg->sn, w);
     }
 
@@ -990,35 +994,29 @@ public:
 
         BufferIov *iov             = _data_buffers_pool.get();
         IoWriteResponseCallback *w = _callback_pool.get();
+        ConnectionStat &conn_stat  = _conn_stat_map.find(conn)->second;
 
         iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
-        w->init(this, conn, msg->sn, iov, &_curr_state.write_count);
-
+        w->init(this, conn, msg->sn, iov, &conn_stat.completions<IO_WRITE>());
         assert(iov->size() == 1);
 
-        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
-        assert(it != _conn_stat_map.end());
-        it->second.write_started(msg->data_size);
+        conn_stat.bytes<IO_WRITE>() += msg->data_size;
         conn->recv_am_data((*iov)[0].buffer(), (*iov)[0].size(), data_desc, w);
     }
 
     virtual void dispatch_connection_accepted(UcxConnection* conn) {
-        bool res = _conn_stat_map.insert(
-                std::make_pair(conn->id(), ConnectionState())).second;
-        assert(res);
-        ++_curr_state.active_conns;
+        if (!_conn_stat_map.insert(std::make_pair(conn,
+                                                  ConnectionStat())).second) {
+            LOG << "connection duplicate in statistics map";
+            abort();
+        }
     }
 
     virtual void dispatch_connection_error(UcxConnection *conn) {
         LOG << "disconnecting connection with status "
             << ucs_status_string(conn->ucx_status());
 
-        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
-        assert(it != _conn_stat_map.end());
-        _conn_stat_map.erase(it);
-
-        --_curr_state.active_conns;
-        conn->disconnect(new UcxDisconnectCallback());
+        conn->disconnect(new DisconnectCallback(_conn_stat_map, conn));
     }
 
     virtual void dispatch_io_message(UcxConnection* conn, const void *buffer,
@@ -1067,57 +1065,61 @@ public:
     }
 
 private:
-    void save_prev_state() {
-        _prev_state = _curr_state;
+    template<io_op_t op_type> static void
+    update_min_max(const conn_stat_map_t::iterator& i,
+                   conn_stat_map_t::iterator& min,
+                   conn_stat_map_t::iterator& max)
+    {
+        long i_bytes = i->second.bytes<op_type>();
+
+        if (i_bytes <= min->second.bytes<op_type>()) {
+            min = i;
+        } else if (i_bytes >= max->second.bytes<op_type>()) {
+            max = i;
+        }
     }
 
-    void report_state() {
-        conn_stat_map_t::iterator it_min = _conn_stat_map.begin(),
-                                  it_max = _conn_stat_map.begin();
-        for (conn_stat_map_t::iterator it = _conn_stat_map.begin();
-             it != _conn_stat_map.end(); ++it) {
-            long i_val = it->second.get_total_count();
-            if (i_val <= it_min->second.get_total_count()) {
-                it_min = it;
-            } else if (i_val >= it_max->second.get_total_count()) {
-                it_max = it;
-            } else {
-                it->second.reset();
-            }
+    void report_state(double time_interval) {
+        ConnectionStat total_stat;
+        conn_stat_map_t::iterator it_read_min  = _conn_stat_map.begin(),
+                                  it_read_max  = _conn_stat_map.begin(),
+                                  it_write_min = _conn_stat_map.begin(),
+                                  it_write_max = _conn_stat_map.begin();
+        conn_stat_map_t::iterator it;
+        for (it = _conn_stat_map.begin(); it != _conn_stat_map.end(); ++it) {
+            total_stat += it->second;
+            update_min_max<IO_READ>(it, it_read_min, it_read_max);
+            update_min_max<IO_WRITE>(it, it_write_min, it_write_max);
         }
 
         UcxLog log(LOG_PREFIX);
-        log << "read:" << _curr_state.read_count - _prev_state.read_count
-            << " ops, "
-            << "write:" << _curr_state.write_count - _prev_state.write_count
-            << " ops, "
-            << "connections:" << _curr_state.active_conns << "/"
-           << UcxConnection::get_num_instances();
-
-        if (_curr_state.active_conns > 0) {
-            log << ", min:" << it_min->second.get_total_count() << "/"
-                << it_min->second.get_total_bytes() / double(UCS_MBYTE)
-                << "MB(" << get_connection(it_min->first).get_peer_name()
-                << ")"
-                << ", max:" << it_max->second.get_total_count() << "/"
-                << it_max->second.get_total_bytes() / double(UCS_MBYTE)
-                << "MB(" << get_connection(it_max->first).get_peer_name()
-                << ")";
-            it_min->second.reset();
-            it_max->second.reset();
+        if (!_conn_stat_map.empty()) {
+            log << "read " << total_stat.bytes<IO_READ>() /
+                              (time_interval * UCS_MBYTE) << " MBs "
+                << "min:" << it_read_min->second.completions<IO_READ>()
+                << "(" << it_read_min->first->get_peer_name() << ") "
+                << "max:" << it_read_max->second.completions<IO_READ>()
+                << " total:" << total_stat.completions<IO_READ>() << " | "
+                << "write " << total_stat.bytes<IO_WRITE>() /
+                               (time_interval * UCS_MBYTE) << " MBs "
+                << "min:" << it_write_min->second.completions<IO_WRITE>()
+                << "(" << it_write_min->first->get_peer_name() << ") "
+                << "max:" << it_write_max->second.completions<IO_WRITE>()
+                << " total:" << total_stat.completions<IO_WRITE>() << " | ";
         }
 
-        log << ", buffers:" << _data_buffers_pool.allocated();
-        save_prev_state();
+        log << "active: " << _conn_stat_map.size() << "/"
+            << UcxConnection::get_num_instances()
+            << ", buffers:" << _data_buffers_pool.allocated();
+
+        for (it = _conn_stat_map.begin(); it != _conn_stat_map.end(); ++it) {
+            it->second.reset();
+        }
     }
 
 private:
-    typedef std::map<uint64_t, ConnectionState> conn_stat_map_t;
-
     MemoryPool<IoWriteResponseCallback> _callback_pool;
     conn_stat_map_t                     _conn_stat_map;
-    state_t                             _prev_state;
-    state_t                             _curr_state;
 };
 
 
@@ -1891,14 +1893,14 @@ private:
             }
 
             if (!first_print) {
-                log << ", "; // print comma for non-first operation
+                log << " | "; // print separator for non-first operation
             }
             first_print = false;
 
             // Report bandwidth
             double throughput_mbs = op_info[op_id].total_bytes /
                                     elapsed / (1024.0 * 1024.0);
-            log << io_op_names[op_id] << " " << throughput_mbs << " MB/s";
+            log << io_op_names[op_id] << " " << throughput_mbs << " MBs";
             op_info[op_id].total_bytes = 0;
 
             // Collect min/max among all connections
@@ -1924,20 +1926,20 @@ private:
             }
 
             // Report delta of min/max/total operations for every connection
-            log << " min:" << delta_min << " (" << opts().servers[min_index]
-               << ") max:" << delta_max << " total:"
-                << op_info[op_id].num_iters << " ops";
+            log << " min:" << delta_min << "(" << opts().servers[min_index]
+                << ") max:" << delta_max << " total:"
+                << op_info[op_id].num_iters;
             op_info[op_id].num_iters = 0;
         }
 
-        log << ", connections:" << _active_servers.size() << "/"
+        log << " | active:" << _active_servers.size() << "/"
             << UcxConnection::get_num_instances();
 
         if (opts().window_size == 1) {
-            log << ", latency:" << latency_usec << " usec";
+            log << " latency:" << latency_usec << "usec";
         }
 
-        log << ", buffers:" << _data_buffers_pool.allocated();
+        log << " buffers:" << _data_buffers_pool.allocated();
     }
 
     inline void check_time_limit(double current_time) {

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -957,6 +957,10 @@ public:
 
         assert(iov->size() == 1);
 
+        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
+        assert(it != _conn_stat_map.end());
+        it->second.read_started(msg->data_size);
+
         // Send IO_READ_COMP as AM header and first iov element as payload
         // (note that multi-iov send is not supported for IODEMO with AM yet)
         conn->send_am(m->buffer(), opts().iomsg_size, (*iov)[0].buffer(),
@@ -992,6 +996,9 @@ public:
 
         assert(iov->size() == 1);
 
+        conn_stat_map_t::iterator it = _conn_stat_map.find(conn->id());
+        assert(it != _conn_stat_map.end());
+        it->second.write_started(msg->data_size);
         conn->recv_am_data((*iov)[0].buffer(), (*iov)[0].size(), data_desc, w);
     }
 
@@ -1105,7 +1112,7 @@ private:
     }
 
 private:
-    typedef std::map<uint32_t, ConnectionState> conn_stat_map_t;
+    typedef std::map<uint64_t, ConnectionState> conn_stat_map_t;
 
     MemoryPool<IoWriteResponseCallback> _callback_pool;
     conn_stat_map_t                     _conn_stat_map;

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -532,12 +532,6 @@ double UcxContext::get_time() {
     return tv.tv_sec + (tv.tv_usec * 1e-6);
 }
 
-UcxConnection& UcxContext::get_connection(uint64_t id) const {
-    conn_map_t::const_iterator it = _conns.find(id);
-    assert(it != _conns.end());
-    return *it->second;
-}
-
 void UcxContext::destroy_listener()
 {
     if (_listener) {

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -532,6 +532,12 @@ double UcxContext::get_time() {
     return tv.tv_sec + (tv.tv_usec * 1e-6);
 }
 
+UcxConnection& UcxContext::get_connection(uint64_t id) const {
+    conn_map_t::const_iterator it = _conns.find(id);
+    assert(it != _conns.end());
+    return *it->second;
+}
+
 void UcxContext::destroy_listener()
 {
     if (_listener) {
@@ -870,8 +876,8 @@ void UcxConnection::set_log_prefix(const struct sockaddr* saddr,
                                    socklen_t addrlen)
 {
     std::stringstream ss;
-    ss << "[UCX-connection #" << _conn_id << " " <<
-          UcxContext::sockaddr_str(saddr, addrlen) << "]";
+    _remote_address = UcxContext::sockaddr_str(saddr, addrlen);
+    ss << "[UCX-connection #" << _conn_id << " " << _remote_address << "]";
     memset(_log_prefix, 0, MAX_LOG_PREFIX_SIZE);
     int length = ss.str().length();
     if (length >= MAX_LOG_PREFIX_SIZE) {

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -112,8 +112,6 @@ public:
 
     static double get_time();
 
-    UcxConnection &get_connection(uint64_t id) const;
-
 protected:
 
     // Called when new IO message is received

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -10,6 +10,7 @@
 #include <ucp/api/ucp.h>
 #include <ucs/algorithm/crc.h>
 #include <ucs/datastruct/list.h>
+#include <ucs/sys/math.h>
 #include <ucs/sys/sock.h>
 #include <deque>
 #include <exception>
@@ -110,6 +111,8 @@ public:
     void destroy_connections();
 
     static double get_time();
+
+    UcxConnection &get_connection(uint64_t id) const;
 
 protected:
 
@@ -270,6 +273,10 @@ public:
         return _establish_cb == NULL;
     }
 
+    const std::string& get_peer_name() const {
+        return _remote_address;
+    }
+
     bool is_disconnecting() const {
         return _disconnect_cb != NULL;
     }
@@ -336,6 +343,7 @@ private:
     uint64_t        _remote_conn_id;
     char            _log_prefix[MAX_LOG_PREFIX_SIZE];
     ucp_ep_h        _ep;
+    std::string     _remote_address;
     void            *_close_request;
     ucs_list_link_t _all_requests;
     ucs_status_t    _ucx_status;


### PR DESCRIPTION
## What
extend io_demo server statistics
```
[1620725353.456991] [DEMO] read:77376 ops, write:77402 ops, active connections:1, min:154777/604.598MB(2.1.3.26:60322), max:154777/604.598MB(2.1.3.26:60322), buffers:698
[1620725354.457181] [DEMO] read:77559 ops, write:77554 ops, active connections:1, min:155113/605.91MB(2.1.3.26:60322), max:155113/605.91MB(2.1.3.26:60322), buffers:698
[1620725355.457230] [DEMO] read:77272 ops, write:77265 ops, active connections:1, min:154537/603.66MB(2.1.3.26:60322), max:154537/603.66MB(2.1.3.26:60322), buffers:698
```

## Why ?
to analyze fairness

## How ?
cherry-pick from https://github.com/yosefe/ucx/pull/140