### PR TITLE
UCT/RC/IFACE: remove EPs lock

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -157,10 +157,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
     UCS_STATIC_ASSERT(UCT_RC_EP_FC_MASK < UINT8_MAX);
 
     ucs_arbiter_group_init(&self->arb_group);
-
-    ucs_spin_lock(&iface->eps_lock);
     ucs_list_add_head(&iface->ep_list, &self->list);
-    ucs_spin_unlock(&iface->eps_lock);
 
     ucs_debug("created rc ep %p", self);
     return UCS_OK;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -271,7 +271,6 @@ struct uct_rc_iface {
 
     UCS_STATS_NODE_DECLARE(stats)
 
-    ucs_spinlock_t           eps_lock; /* common lock for eps and ep_list */
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
     ucs_list_link_t          ep_list;
     ucs_list_link_t          ep_gc_list;


### PR DESCRIPTION
## What
remove EPs lock

## Why ?
 UCP does not call `uct_ep_create` from async thread any more due to improvements in UCT CM API and related UCP wireup impl
