### PR TITLE
UCT/TCP/RDMACM: early client closure

### DIFF
--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -34,11 +34,19 @@ UCS_CLASS_DECLARE(uct_listener_t, uct_cm_h);
     })
 
 
+#define uct_cm_peer_error(_cm, _fmt, ...) \
+    { \
+        ucs_log((_cm)->config.failure_level, _fmt, ## __VA_ARGS__); \
+    }
+
+
 #define uct_cm_ep_peer_error(_cep, _fmt, ...) \
     { \
-        uct_cm_t *_cm_base = ucs_container_of((_cep)->super.super.iface, uct_cm_t, iface); \
-        ucs_log((_cm_base)->config.failure_level, _fmt, ## __VA_ARGS__); \
+        uct_cm_t *_cm_base = ucs_container_of((_cep)->super.super.iface, \
+                                              uct_cm_t, iface); \
+        uct_cm_peer_error(_cm_base, _fmt, ## __VA_ARGS__); \
     }
+
 
 /**
  * "Base" structure which defines CM configuration options.

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -76,7 +76,7 @@ ucs_status_t uct_rdmacm_cm_destroy_id(struct rdma_cm_id *id);
 
 ucs_status_t uct_rdmacm_cm_ack_event(struct rdma_cm_event *event);
 
-ucs_status_t uct_rdmacm_cm_reject(struct rdma_cm_id *id);
+ucs_status_t uct_rdmacm_cm_reject(uct_rdmacm_cm_t *cm, struct rdma_cm_id *id);
 
 ucs_status_t uct_rdmacm_cm_get_cq(uct_rdmacm_cm_t *cm, struct ibv_context *verbs,
                                   struct ibv_cq **cq);

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -366,7 +366,7 @@ static ucs_status_t uct_rdamcm_cm_ep_server_init(uct_rdmacm_cm_ep_t *cep,
 
     return uct_rdmacm_cm_ack_event(event);
 err_reject:
-    uct_rdmacm_cm_reject(cep->id);
+    uct_rdmacm_cm_reject(cm, cep->id);
 err:
     uct_rdmacm_cm_destroy_id(cep->id);
     cep->id = NULL;
@@ -431,7 +431,7 @@ uct_rdmacm_cm_ep_send_priv_data(uct_rdmacm_cm_ep_t *cep, const void *priv_data,
         if (rdma_accept(cep->id, &conn_param)) {
             uct_cm_ep_peer_error(&cep->super,
                                  "rdma_accept(on id=%p) failed: %m", cep->id);
-            status = UCS_ERR_IO_ERROR;
+            status = UCS_ERR_CONNECTION_RESET;
             goto err;
         }
     }

--- a/src/uct/ib/rdmacm/rdmacm_listener.c
+++ b/src/uct/ib/rdmacm/rdmacm_listener.c
@@ -113,15 +113,16 @@ err:
 ucs_status_t uct_rdmacm_listener_reject(uct_listener_h listener,
                                         uct_conn_request_h conn_request)
 {
-    uct_rdmacm_listener_t *rdmacm_listener = ucs_derived_of(listener, uct_rdmacm_listener_t);
+    uct_rdmacm_listener_t *rdmacm_listener = ucs_derived_of(listener,
+                                                            uct_rdmacm_listener_t);
+    uct_rdmacm_cm_t *rdmacm_cm             = ucs_derived_of(listener->cm,
+                                                            uct_rdmacm_cm_t);
     struct rdma_cm_event *event            = (struct rdma_cm_event*)conn_request;
 
     ucs_assert_always(rdmacm_listener->id == event->listen_id);
 
-    uct_rdmacm_cm_reject(event->id);
-
+    uct_rdmacm_cm_reject(rdmacm_cm, event->id);
     uct_rdmacm_cm_destroy_id(event->id);
-
     return uct_rdmacm_cm_ack_event(event);
 }
 

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -934,12 +934,14 @@ static ssize_t uct_tcp_sockcm_ep_pack_cb(uct_tcp_sockcm_ep_t *tcp_ep,
     return priv_data_ret;
 }
 
+/**
+ * The caller has to block async.
+ */
 static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
                                                     const uct_ep_params_t *params,
                                                     uct_ep_h *ep_p)
 {
     uct_tcp_sockcm_t *tcp_sockcm = uct_tcp_sockcm_ep_get_cm(tcp_ep);
-    ucs_async_context_t *async   = tcp_sockcm->super.iface.worker->async;
     void *data_buf               = NULL;
     uct_tcp_sockcm_t *params_tcp_sockcm;
     const void *priv_data;
@@ -960,11 +962,9 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
         goto err;
     }
 
-    UCS_ASYNC_BLOCK(async);
-
     if (tcp_ep->state & UCT_TCP_SOCKCM_EP_FAILED) {
         status = UCS_ERR_CONNECTION_RESET;
-        goto err_unblock;
+        goto err;
     }
 
     /* check if the server opened this ep, to the client, on a CM that is
@@ -975,7 +975,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
         if (status != UCS_OK) {
             ucs_error("failed to remove fd %d from the async handlers: %s",
                       tcp_ep->fd, ucs_status_string(status));
-            goto err_unblock;
+            goto err;
         }
     }
 
@@ -985,7 +985,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
     status = uct_cm_ep_set_common_data(&tcp_ep->super, params);
     if (status != UCS_OK) {
         ucs_error("failed to set common data for a uct_cm_base_ep_t endpoint");
-        goto err_unblock;
+        goto err;
     }
 
     status = UCT_CM_SET_CB(params, UCT_EP_PARAM_FIELD_SOCKADDR_NOTIFY_CB_SERVER,
@@ -993,12 +993,11 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
                            uct_cm_ep_server_conn_notify_callback_t,
                            ucs_empty_function);
     if (status != UCS_OK) {
-        goto err_unblock;
+        goto err;
     }
 
     /* the server's endpoint was already created by the listener, return it */
     *ep_p             = &tcp_ep->super.super.super;
-    tcp_ep->state    |= UCT_TCP_SOCKCM_EP_SERVER_CREATED;
     params_tcp_sockcm = ucs_derived_of(params->cm, uct_tcp_sockcm_t);
 
     if (&tcp_sockcm->super != params->cm) {
@@ -1011,7 +1010,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
         if (status != UCS_OK) {
             ucs_error("failed to set event handler (fd %d): %s",
                       tcp_ep->fd, ucs_status_string(status));
-            goto err_unblock;
+            goto err;
         }
 
         /* set the server's ep to use the iface from the cm in params */
@@ -1021,7 +1020,7 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
         if (status != UCS_OK) {
             ucs_error("failed to reset the stats on ep %p: %s",
                       tcp_ep, ucs_status_string(status));
-            goto err_unblock;
+            goto err;
         }
 
         ucs_trace("moved tcp_sockcm ep %p from cm %p to cm %p", tcp_ep,
@@ -1045,14 +1044,14 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
         data_buf = ucs_malloc(tcp_sockcm->priv_data_len, "tcp_priv_data");
         if (data_buf == NULL) {
             status = UCS_ERR_NO_MEMORY;
-            goto err_unblock;
+            goto err;
         }
 
         priv_data        = data_buf;
         priv_data_length = uct_tcp_sockcm_ep_pack_cb(tcp_ep, data_buf);
         if (priv_data_length < 0) {
             status = (ucs_status_t)priv_data_length;
-            goto err_unblock;
+            goto err;
         }
     } else {
         priv_data        = NULL;
@@ -1061,9 +1060,10 @@ static ucs_status_t uct_tcp_sockcm_ep_server_create(uct_tcp_sockcm_ep_t *tcp_ep,
 
     status = uct_tcp_sockcm_ep_pack_priv_data(tcp_ep, priv_data,
                                               priv_data_length);
+    if (status == UCS_OK) {
+        tcp_ep->state |= UCT_TCP_SOCKCM_EP_SERVER_CREATED;
+    }
 
-err_unblock:
-    UCS_ASYNC_UNBLOCK(async);
 err:
     ucs_free(data_buf);
     return status;
@@ -1108,6 +1108,7 @@ out:
 ucs_status_t uct_tcp_sockcm_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p)
 {
     uct_tcp_sockcm_ep_t *tcp_ep;
+    ucs_async_context_t *async;
     ucs_status_t status;
 
     if (params->field_mask & UCT_EP_PARAM_FIELD_SOCKADDR) {
@@ -1115,12 +1116,15 @@ ucs_status_t uct_tcp_sockcm_ep_create(const uct_ep_params_t *params, uct_ep_h *e
         return UCS_CLASS_NEW(uct_tcp_sockcm_ep_t, ep_p, params);
     } else if (params->field_mask & UCT_EP_PARAM_FIELD_CONN_REQUEST) {
         tcp_ep = (uct_tcp_sockcm_ep_t*)params->conn_request;
+        async  = uct_tcp_sockcm_ep_get_cm(tcp_ep)->super.iface.worker->async;
 
+        UCS_ASYNC_BLOCK(async);
         status = uct_tcp_sockcm_ep_server_create(tcp_ep, params, ep_p);
         if (status != UCS_OK) {
             UCS_CLASS_DELETE(uct_tcp_sockcm_ep_t, tcp_ep);
         }
 
+        UCS_ASYNC_UNBLOCK(async);
         return status;
     } else {
         ucs_error("either UCT_EP_PARAM_FIELD_SOCKADDR or UCT_EP_PARAM_FIELD_CONN_REQUEST "


### PR DESCRIPTION
## What
improve server side error handling in case if client EP is destroyed before server does accept/reject 

cherry-picked form https://github.com/openucx/ucx/pull/6688 + rdmacm_cm fixes