### PR TITLE
UCP/CORE: Fix doing KA multiple times for the same EP in a single round

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -334,6 +334,8 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
         ucs_list_add_tail(&worker->internal_eps, &ucp_ep_ext_gen(ep)->ep_list);
     } else {
         ucs_list_add_tail(&worker->all_eps, &ucp_ep_ext_gen(ep)->ep_list);
+        ucs_assert(ep->worker->num_all_eps < UINT_MAX);
+        ++ep->worker->num_all_eps;
     }
 
     *ep_p = ep;
@@ -348,6 +350,8 @@ err:
 void ucp_ep_delete(ucp_ep_h ep)
 {
     if (!(ep->flags & UCP_EP_FLAG_INTERNAL)) {
+        ucs_assert(ep->worker->num_all_eps > 0);
+        --ep->worker->num_all_eps;
         ucp_worker_keepalive_remove_ep(ep);
     }
 
@@ -2704,7 +2708,6 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
 
 void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map)
 {
-    ucp_lane_map_t check_lanes;
     ucp_lane_index_t lane;
     ucs_status_t status;
     ucp_rsc_index_t rsc_index;
@@ -2715,9 +2718,9 @@ void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map)
     }
 
     /* Take updated ep_check_map, in case ep configuration has changed */
-    check_lanes = *lane_map & ucp_ep_config(ep)->key.ep_check_map;
+    *lane_map &= ucp_ep_config(ep)->key.ep_check_map;
 
-    ucs_for_each_bit(lane, check_lanes) {
+    ucs_for_each_bit(lane, *lane_map) {
         ucs_assert(lane < UCP_MAX_LANES);
         rsc_index = ucp_ep_get_rsc_index(ep, lane);
         ucs_assert((rsc_index != UCP_NULL_RESOURCE) ||

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -259,7 +259,10 @@ typedef struct ucp_worker {
     void                             *user_data;          /* User-defined data */
     ucs_strided_alloc_t              ep_alloc;            /* Endpoint allocator */
     ucs_list_link_t                  stream_ready_eps;    /* List of EPs with received stream data */
-    ucs_list_link_t                  all_eps;             /* List of all endpoints */
+    unsigned                         num_all_eps;         /* Number of all endpoints (except internal
+                                                           * endpoints) */
+    ucs_list_link_t                  all_eps;             /* List of all endpoints (except internal
+                                                           * endpoints) */
     ucs_list_link_t                  internal_eps;        /* List of internal endpoints */
     ucs_conn_match_ctx_t             conn_match_ctx;      /* Endpoint-to-endpoint matching context */
     ucp_worker_iface_t               **ifaces;            /* Array of pointers to interfaces,


### PR DESCRIPTION
## What

Fix doing KA multiple times for the same EP in a single round.

## Why ?

before (difference 0.002-0.003 seconds between KA messages until KA message is not done for all 128 EPs):
```
[1620746626.363275] [jazz17:141234:0]          ucp_ep.c:2654 UCX  DIAG  ep 0x7f114bcdd0f0: sending KA: src-7 dst-139: 88
...
[1620746626.365858] [jazz17:141234:0]          ucp_ep.c:2654 UCX  DIAG  ep 0x7f114bcdd0f0: sending KA: src-7 dst-139: 88
...
```
after (every 60 seconds - as expected):
```
[1620844406.049948] [jazz03:161405:0]          ucp_ep.c:2654 UCX  DIAG  ep 0x7f65cac7e438: sending KA: src-21 dst-165: 88
...
[1620844466.052248] [jazz03:161405:0]          ucp_ep.c:2654 UCX  DIAG  ep 0x7f65cac7e438: sending KA: src-21 dst-165: 88
...
```

## How ?

Save first EP iterator that was set when the round completed and use it to not do cyclic KA in the same round.