### PR TITLE
UCP/CORE: Don't release ID for receive operations

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -746,7 +746,7 @@ static ucs_status_t ucp_am_send_start_rndv(ucp_request_t *sreq)
                   sreq->send.length);
     UCS_PROFILE_REQUEST_EVENT(sreq, "start_rndv", sreq->send.length);
 
-    ucp_request_id_alloc(sreq);
+    ucp_send_request_id_alloc(sreq);
 
     /* Note: no need to call ucp_ep_resolve_remote_id() here, because it
      * was done in ucp_am_send_nbx

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2744,7 +2744,11 @@ static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
     ucp_trace_req(req, "purged with status %s (%d) on ep %p",
                   ucs_status_string(status), status, ucp_ep);
 
-    ucp_request_id_release(req);
+    /* Only send operations could have request ID allocated */
+    if (!(req->flags &
+          (UCP_REQUEST_FLAG_RECV_AM | UCP_REQUEST_FLAG_RECV_TAG))) {
+        ucp_send_request_id_release(req);
+    }
 
     if (req->flags & (UCP_REQUEST_FLAG_SEND_AM | UCP_REQUEST_FLAG_SEND_TAG)) {
         ucs_assert(!(req->flags & UCP_REQUEST_FLAG_SUPER_VALID));

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -417,7 +417,7 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
     /* Set REMOTE_COMPLETED flag to make sure that TAG/Sync operations will be
      * fully completed here */
     req->flags |= UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED;
-    ucp_request_id_release(req);
+    ucp_send_request_id_release(req);
 
     if (req->send.uct.func == ucp_proto_progress_am_single) {
         ucs_assert(req->send.state.uct_comp.count == 0);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -24,7 +24,7 @@ static size_t ucp_proto_get_am_bcopy_pack(void *dest, void *arg)
     getreqh->address    = req->send.rma.remote_addr;
     getreqh->length     = req->send.state.dt_iter.length;
     getreqh->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
-    getreqh->req.req_id = ucp_request_get_id(req);
+    getreqh->req.req_id = ucp_send_request_get_id(req);
     getreqh->mem_type   = req->send.rma.rkey->mem_type;
 
     return sizeof(*getreqh);
@@ -56,7 +56,7 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
         req->send.buffer = req->send.state.dt_iter.type.contig.buffer;
         req->send.length = req->send.state.dt_iter.length;
         req->flags      |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
-        ucp_request_id_alloc(req);
+        ucp_send_request_id_alloc(req);
     }
 
     ucp_worker_flush_ops_count_inc(worker);

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -98,7 +98,7 @@ ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
         /* bcopy is the fast path */
         if (ucs_likely(req->send.state.uct_comp.count == 0)) {
             if (req_id != UCS_PTR_MAP_KEY_INVALID) {
-                ucp_request_id_release(req);
+                ucp_send_request_id_release(req);
             }
             ucp_request_send_buffer_dereg(req);
             ucp_request_complete_send(req, UCS_OK);

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -513,8 +513,8 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
     ucs_status_t status;
     ucp_request_t *req;
 
-    UCP_REQUEST_GET_BY_ID(&req, worker, rtr->sreq_id, 1, return UCS_OK,
-                          "RTR %p", rtr);
+    UCP_SEND_REQUEST_GET_BY_ID(&req, worker, rtr->sreq_id, 1, return UCS_OK,
+                               "RTR %p", rtr);
 
     if (rtr->address == 0) {
         ucs_fatal("RTR without remote address is currently unsupported");

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -53,7 +53,7 @@ ucp_proto_rndv_rts_request_init(ucp_request_t *req)
         return status;
     }
 
-    ucp_request_id_alloc(req);
+    ucp_send_request_id_alloc(req);
     req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
 
     return UCS_OK;
@@ -66,8 +66,8 @@ ucp_proto_rndv_ats_handler(void *arg, void *data, size_t length, unsigned flags)
     const ucp_reply_hdr_t *ats = data;
     ucp_request_t *req;
 
-    UCP_REQUEST_GET_BY_ID(&req, worker, ats->req_id, 1, return UCS_OK, "ATS %p",
-                          ats);
+    UCP_SEND_REQUEST_GET_BY_ID(&req, worker, ats->req_id, 1, return UCS_OK,
+                               "ATS %p", ats);
     ucp_proto_request_zcopy_complete(req, ats->status);
     return UCS_OK;
 }
@@ -78,7 +78,7 @@ static UCS_F_ALWAYS_INLINE size_t ucp_proto_rndv_rts_pack(
     void *rkey_buffer = UCS_PTR_BYTE_OFFSET(rts, hdr_len);
     size_t rkey_size;
 
-    rts->sreq.req_id = ucp_request_get_id(req);
+    rts->sreq.req_id = ucp_send_request_get_id(req);
     rts->sreq.ep_id  = ucp_send_request_get_ep_remote_id(req);
     rts->size        = req->send.state.dt_iter.length;
 

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -180,7 +180,7 @@ static size_t ucp_eager_sync_bcopy_pack_first(void *dest, void *arg)
 
     ucp_proto_eager_set_first_hdr(req, &hdr->super);
     hdr->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
-    hdr->req.req_id = ucp_request_get_id(req);
+    hdr->req.req_id = ucp_send_request_get_id(req);
 
     return sizeof(*hdr) + ucp_proto_multi_data_pack(pack_ctx, hdr + 1);
 }
@@ -213,8 +213,8 @@ void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
 {
     ucp_request_t *req;
 
-    UCP_REQUEST_GET_BY_ID(&req, worker, rep_hdr->req_id, 1, return,
-                          "EAGER_S ACK %p", rep_hdr);
+    UCP_SEND_REQUEST_GET_BY_ID(&req, worker, rep_hdr->req_id, 1, return,
+                               "EAGER_S ACK %p", rep_hdr);
 
     req->flags |= UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED;
     if (req->flags & UCP_REQUEST_FLAG_SYNC_LOCAL_COMPLETED) {
@@ -226,7 +226,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
 {
     ucp_proto_msg_multi_request_init(req);
-    ucp_request_id_alloc(req);
+    ucp_send_request_id_alloc(req);
 }
 
 static ucs_status_t

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -260,7 +260,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
         if ((sreq->send.tag_offload.ssend_tag == rep_hdr->sender_tag) &&
             !(sreq->send.ep->flags & UCP_EP_FLAG_FAILED) &&
             (ucp_ep_local_id(sreq->send.ep) == rep_hdr->ep_id)) {
-            ucp_request_id_release(sreq);
+            ucp_send_request_id_release(sreq);
             ucp_tag_eager_sync_completion(
                     sreq, UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED, UCS_OK);
             ucs_queue_del_iter(queue, iter);
@@ -284,8 +284,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_ack_handler,
     if (worker->context->config.ext.proto_enable) {
         ucp_proto_eager_sync_ack_handler(worker, rep_hdr);
     } else {
-        UCP_REQUEST_GET_BY_ID(&req, worker, rep_hdr->req_id, 1, return UCS_OK,
-                              "EAGER_S ACK %p", rep_hdr);
+        UCP_SEND_REQUEST_GET_BY_ID(&req, worker, rep_hdr->req_id, 1,
+                                   return UCS_OK, "EAGER_S ACK %p", rep_hdr);
         ucp_tag_eager_sync_completion(req,
                                       UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED,
                                       UCS_OK);

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -52,7 +52,7 @@ static size_t ucp_tag_pack_eager_sync_only_dt(void *dest, void *arg)
 
     hdr->super.super.tag = req->send.msg_proto.tag;
     hdr->req.ep_id       = ucp_send_request_get_ep_remote_id(req);
-    hdr->req.req_id      = ucp_request_get_id(req);
+    hdr->req.req_id      = ucp_send_request_get_id(req);
 
     return ucp_tag_pack_eager_common(req, hdr + 1, req->send.length,
                                      sizeof(*hdr), 1);
@@ -92,7 +92,7 @@ static size_t ucp_tag_pack_eager_sync_first_dt(void *dest, void *arg)
     hdr->super.total_len       = req->send.length;
     hdr->req.ep_id             = ucp_send_request_get_ep_remote_id(req);
     hdr->super.msg_id          = req->send.msg_proto.message_id;
-    hdr->req.req_id            = ucp_request_get_id(req);
+    hdr->req.req_id            = ucp_send_request_get_id(req);
 
     return ucp_tag_pack_eager_common(req, hdr + 1, length, sizeof(*hdr), 1);
 }
@@ -254,7 +254,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_single(uct_pending_req_t *self)
 
     hdr.super.super.tag = req->send.msg_proto.tag;
     hdr.req.ep_id       = ucp_send_request_get_ep_remote_id(req);
-    hdr.req.req_id      = ucp_request_get_id(req);
+    hdr.req.req_id      = ucp_send_request_get_id(req);
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_EAGER_SYNC_ONLY, &hdr,
                                   sizeof(hdr), NULL, 0ul,
@@ -280,7 +280,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
     first_hdr.super.super.super.tag = req->send.msg_proto.tag;
     first_hdr.super.total_len       = req->send.length;
     first_hdr.req.ep_id             = ucp_send_request_get_ep_remote_id(req);
-    first_hdr.req.req_id            = ucp_request_get_id(req);
+    first_hdr.req.req_id            = ucp_send_request_get_id(req);
     first_hdr.super.msg_id          = req->send.msg_proto.message_id;
 
     return ucp_do_am_zcopy_multi(self, UCP_AM_ID_EAGER_SYNC_FIRST,

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -569,7 +569,7 @@ static void ucp_tag_offload_rndv_zcopy_completion(uct_completion_t *self)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
 
-    ucp_request_id_release(req);
+    ucp_send_request_id_release(req);
     ucp_proto_am_zcopy_req_complete(req, self->status);
 }
 
@@ -587,7 +587,7 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
         .ep_id    = ucp_send_request_get_ep_remote_id(req),
-        .req_id   = ucp_request_get_id(req),
+        .req_id   = ucp_send_request_get_id(req),
         .md_index = ucp_ep_md_index(ep, req->send.lane)
     };
 

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -101,7 +101,7 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
         return status;
     }
 
-    ucp_request_id_alloc(sreq);
+    ucp_send_request_id_alloc(sreq);
 
     if (ucp_ep_config_key_has_tag_lane(&ucp_ep_config(ep)->key)) {
         status = ucp_tag_offload_start_rndv(sreq);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -89,7 +89,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     if (ucs_likely(status == UCS_OK)) {
         /* Eager send initialized successfully */
         if (req->flags & UCP_REQUEST_FLAG_SYNC) {
-            ucp_request_id_alloc(req);
+            ucp_send_request_id_alloc(req);
             UCP_EP_STAT_TAG_OP(req->send.ep, EAGER_SYNC);
         } else {
             UCP_EP_STAT_TAG_OP(req->send.ep, EAGER);

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1505,9 +1505,8 @@ protected:
             req->flags        |= UCP_REQUEST_FLAG_COMPLETED;
 
             ucp_request_t *req_from_id;
-            ucs_status_t status = ucp_request_get_by_id(sender().worker(),
-                                                        req->id,&req_from_id,
-                                                        1);
+            ucs_status_t status = ucp_send_request_get_by_id(
+                    sender().worker(), req->id,&req_from_id, 1);
             if (status == UCS_OK) {
                 EXPECT_EQ(req, req_from_id);
             }


### PR DESCRIPTION
## What

Don't release ID for receive operations.

## Why ?

To fix the crash after "Retry count exceeded":
```
[1620863140.234291] [jazz05:77128:0]     ib_mlx5_log.c:147  UCX  DIAG  Transport retry count exceeded on mlx5_3:1/RoCE (synd 0x15 vend 0x81 hw_synd 0/0)
[1620863140.234291] [jazz05:77128:0]     ib_mlx5_log.c:147  UCX  DIAG  RC QP 0x327a1 wqe[921]: SEND s-- [inl len 18] [va 0x7fb5feb1c564 len 8238 lkey 0x5fb7c9]
[jazz05:77128:0:77128] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucp/core/ucp_request.inl: [ ucp_request_id_release() ]
      ...
      883     ucp_ep_h ep = req->send.ep;
      884     ucs_status_t UCS_V_UNUSED status;
      885
==>   886     status = ucs_ptr_map_del(&ep->worker->ptr_map, req->id);
      887     if (status == UCS_OK) {
      888         ucs_hlist_del(&ucp_ep_ext_gen(ep)->proto_reqs, &req->send.list);
      889     }

==== backtrace (tid:  77128) ====
 0 0x000000000004215b ucp_request_id_release()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucp/core/ucp_request.inl:886
 1 0x000000000004215b ucp_ep_req_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c:2747
 2 0x0000000000043db4 ucp_ep_req_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c:2796
 3 0x0000000000043f3b ucp_ep_reqs_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c:2809
 4 0x00000000000546a9 ucp_worker_iface_err_handle_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucp/core/ucp_worker.c:443
 5 0x0000000000055474 ucs_callbackq_slow_proxy()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.c:402
 6 0x000000000005138f ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
 7 0x000000000005de37 uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
 8 0x0000000000403ddc UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:211
 9 0x0000000000410240 DemoServer::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:871
10 0x000000000040db7d do_server()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2250
11 0x000000000040e03b main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210513_003809_71416_11691_jazz05.swx.labs.mlnx/installs/qPA2/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2305
12 0x00000000000223d5 __libc_start_main()  ???:0
13 0x0000000000402ee9 _start()  ???:0
=================================
```

## How ?

Check if `RECV_AM`/`RECV_TAG` flags are set in the request and don't invoke `ucp_request_id_release()` to avoid dereferencing the request's send part.