### PR TITLE
UCT/CUDA_COPY: Add local memory handle for mem_type lookup

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 #include <uct/cuda/base/cuda_md.h>
+#include <ucs/memory/memory_type.h>
 
 
 extern uct_component_t uct_cuda_copy_component;
@@ -26,4 +27,12 @@ typedef struct uct_cuda_copy_md_config {
     uct_md_config_t super;
 } uct_cuda_copy_md_config_t;
 
+/**
+ * @brief cuda_copy packed and remote key for put/get
+ */
+typedef struct uct_cuda_copy_key {
+    void              *address;        /* Address needed for unregistering */
+    uint8_t           host_registered; /* Is cuHostRegister called on address */
+    ucs_memory_type_t mem_type;        /* Memory type */
+} uct_cuda_copy_key_t;
 #endif


### PR DESCRIPTION
## What/Why

- add NEED_MEMH for local memory handle creation which embeds mem_type of local buffer
- looking up mem_type of local buffer allows picking right stream based on mem_type

TODO:
@bureddy @yosefe 
- Do we need NEED_RKEY? (adding this leads to assertion failure in rndv_progress_put_zcopy with lanes_count < 0)
- We need to change pipeline protocol to pass valid rkey (currently NULL) as part of put/get_frag_mem_type
