### PR TITLE
UCT/DC: Fix number of CQEs for DCI pools

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -958,11 +958,12 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                     int preferred_cpu, size_t inl)
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
+    unsigned cq_size     = uct_ib_cq_size(iface, init_attr, dir);
     struct ibv_cq *cq;
 #if HAVE_DECL_IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN
     struct ibv_cq_init_attr_ex cq_attr = {};
 
-    cq_attr.cqe         = init_attr->cq_len[dir];
+    cq_attr.cqe         = cq_size;
     cq_attr.channel     = iface->comp_channel;
     cq_attr.comp_vector = preferred_cpu;
     if (init_attr->flags & UCT_IB_CQ_IGNORE_OVERRUN) {
@@ -975,12 +976,12 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
 #endif
     {
         iface->config.max_inl_cqe[dir] = 0;
-        cq = ibv_create_cq(dev->ibv_context, init_attr->cq_len[dir], NULL,
-                           iface->comp_channel, preferred_cpu);
+        cq = ibv_create_cq(dev->ibv_context, cq_size, NULL, iface->comp_channel,
+                           preferred_cpu);
     }
 
     if (!cq) {
-        ucs_error("ibv_create_cq(cqe=%d) failed: %m", init_attr->cq_len[dir]);
+        ucs_error("ibv_create_cq(cqe=%d) failed: %m", cq_size);
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -172,7 +172,12 @@ struct uct_ib_iface_config {
 
 enum {
     UCT_IB_CQ_IGNORE_OVERRUN         = UCS_BIT(0),
-    UCT_IB_TM_SUPPORTED              = UCS_BIT(1)
+    UCT_IB_TM_SUPPORTED              = UCS_BIT(1),
+
+    /* Indicates that TX cq len in uct_ib_iface_init_attr_t is specified per
+     * each IB path. Therefore IB interface constructor would need to multiply
+     * TX CQ len by the number of IB paths (when it is properly initialized). */
+    UCT_IB_TX_OPS_PER_PATH           = UCS_BIT(2)
 };
 
 
@@ -604,6 +609,19 @@ static UCS_F_ALWAYS_INLINE void
 uct_ib_fence_info_init(uct_ib_fence_info_t* fence)
 {
     fence->fence_beat = 0;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_ib_cq_size(uct_ib_iface_t *iface, const uct_ib_iface_init_attr_t *init_attr,
+               uct_ib_dir_t dir)
+{
+    if (dir == UCT_IB_DIR_RX) {
+        return init_attr->cq_len[UCT_IB_DIR_RX];
+    } else if (init_attr->flags & UCT_IB_TX_OPS_PER_PATH) {
+        return init_attr->cq_len[UCT_IB_DIR_TX] * iface->num_paths;
+    } else {
+        return init_attr->cq_len[UCT_IB_DIR_TX];
+    }
 }
 
 #endif

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -73,12 +73,12 @@ ucs_status_t uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                    int preferred_cpu, size_t inl)
 {
 #if HAVE_DECL_MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE
-    uct_ib_device_t *dev = uct_ib_iface_device(iface);
-    struct ibv_cq *cq;
+    uct_ib_device_t *dev               = uct_ib_iface_device(iface);
     struct ibv_cq_init_attr_ex cq_attr = {};
     struct mlx5dv_cq_init_attr dv_attr = {};
+    struct ibv_cq *cq;
 
-    cq_attr.cqe         = init_attr->cq_len[dir];
+    cq_attr.cqe         = uct_ib_cq_size(iface, init_attr, dir);
     cq_attr.channel     = iface->comp_channel;
     cq_attr.comp_vector = preferred_cpu;
     if (init_attr->flags & UCT_IB_CQ_IGNORE_OVERRUN) {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -282,7 +282,7 @@ struct uct_rc_iface {
 UCS_CLASS_DECLARE(uct_rc_iface_t, uct_rc_iface_ops_t*, uct_iface_ops_t*,
                   uct_md_h, uct_worker_h, const uct_iface_params_t*,
                   const uct_rc_iface_common_config_t*,
-                  uct_ib_iface_init_attr_t*);
+                  const uct_ib_iface_init_attr_t*);
 
 
 struct uct_rc_iface_send_op {


### PR DESCRIPTION
## What
Provide correct number of DC CQEs to CQ creation (and tx ops) routines, taking into account number of DCI pools.

Fixes #6579 
