### PR TITLE
UCP/RNDV: Remove fatal error in AM zcopy completion in case of error

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1604,8 +1604,6 @@ static void ucp_rndv_am_zcopy_completion(uct_completion_t *self)
 
     if (sreq->send.state.dt.offset == sreq->send.length) {
         ucp_rndv_am_zcopy_send_req_complete(sreq, status);
-    } else if (status != UCS_OK) {
-        ucs_fatal("error handling is unsupported with rendezvous protocol");
     }
 }
 


### PR DESCRIPTION
## What

Remove fatal error in AM zcopy completion in case of error.

## Why ?

To fix:
```
[jazz14:75380:0:75380]        rndv.c:1608 Fatal: error handling is unsupported with rendezvous protocol

/labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c: [ ucp_rndv_am_zcopy_completion() ]
      ...
     1605     if (sreq->send.state.dt.offset == sreq->send.length) {
     1606         ucp_rndv_am_zcopy_send_req_complete(sreq, status);
     1607     } else if (status != UCS_OK) {
==>  1608         ucs_fatal("error handling is unsupported with rendezvous protocol");
     1609     }
     1610 }
     1611

==== backtrace (tid:  75380) ====
 0 0x00000000000b7de9 ucp_rndv_am_zcopy_completion()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:1608
 1 0x000000000003446f uct_invoke_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:791
 2 0x00000000001281a4 uct_dc_mlx5_ep_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1387
 3 0x000000000014caf4 uct_dc_mlx5_dci_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1148
 4 0x000000000014cc7c uct_dc_mlx5_iface_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1161
 5 0x000000000002a410 uct_ib_mlx5_check_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.c:361
 6 0x000000000013f81a uct_ib_mlx5_poll_cq()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.inl:81
 7 0x000000000013f81a uct_dc_mlx5_poll_tx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:224
 8 0x000000000013f81a uct_dc_mlx5_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:266
 9 0x000000000013f81a uct_dc_mlx5_iface_progress_ll()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:276
10 0x0000000000051494 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
11 0x000000000005e40e uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
12 0x0000000000403d7c UcxContext::progress()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:211
13 0x00000000004101e0 DemoServer::run()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:871
14 0x000000000040db1d do_server()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2250
15 0x000000000040dfdb main()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2305
16 0x00000000000223d5 __libc_start_main()  ???:0
17 0x0000000000402e89 _start()  ???:0
=================================
```
No need to do `ucs_fatal()`, the failure should be handled in the same way as we do for AM Zcopy, RNDV GET/PUT Zcopy operations.
Operations will be completed from fast-forwarding of purged pending operations.

## How ?

Remove `ucs_fatal()` in case of `status != UCS_OK`.