### PR TITLE
UCP/CORE: Always set completion callback for correct send state ff

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -420,7 +420,6 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
     ucp_request_id_release(req);
 
     if (req->send.uct.func == ucp_proto_progress_am_single) {
-        ucs_assert(req->send.state.uct_comp.count == 0);
         req->send.proto.comp_cb(req);
     } else if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);


### PR DESCRIPTION
## What

Always set completion callback for correct send state ff.

## Why ?

Fixing:
```
[jazz14:24302:0:24302]  ucp_worker.c:2346 Assertion `req->send.discard_uct_ep.cb_id == UCS_CALLBACKQ_ID_NULL' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_worker.c: [ ucp_worker_discard_uct_ep_progress_register() ]
      ...
     2343 {
     2344     ucp_worker_h worker = req->send.ep->worker;
     2345
==>  2346     ucs_assert_always(req->send.discard_uct_ep.cb_id == UCS_CALLBACKQ_ID_NULL);
     2347     uct_worker_progress_register_safe(worker->uct, func, req,
     2348                                       UCS_CALLBACKQ_FLAG_ONESHOT,
     2349                                       &req->send.discard_uct_ep.cb_id);

==== backtrace (tid:  24302) ====
 0 0x000000000005d3ee ucp_worker_discard_uct_ep_progress_register()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_worker.c:2346
 1 0x000000000005d4b1 ucp_worker_discard_uct_ep_flush_comp()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_worker.c:2362
 2 0x000000000004df32 ucp_request_send_state_ff()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.c:438
 3 0x0000000000039b5c ucp_ep_err_pending_purge()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:921
 4 0x0000000000127991 uct_dc_mlx5_ep_arbiter_purge_cb()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1306
 5 0x000000000005303a ucs_arbiter_group_purge()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/arbiter.c:135
 6 0x0000000000127d86 uct_dc_mlx5_ep_pending_purge()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1338
 7 0x0000000000061c93 uct_ep_pending_purge()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:3015
 8 0x000000000003b18d ucp_ep_discard_lanes()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:1167
 9 0x000000000003b504 ucp_ep_close_nbx()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:1206
10 0x000000000003aff3 ucp_ep_close_nb()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:1145
11 0x0000000000406d87 UcxConnection::ep_close()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:1034
12 0x0000000000405aee UcxConnection::disconnect()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:679
13 0x0000000000412d06 DemoClient::disconnect_server()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:1449
14 0x0000000000412479 DemoClient::disconnect_uncompleted_servers()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:1337
15 0x0000000000412e8e DemoClient::wait_for_responses()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:1479
16 0x0000000000414032 DemoClient::run()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:1708
17 0x000000000040dc17 do_client()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2264
18 0x000000000040dfee main()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2307
19 0x00000000000223d5 __libc_start_main()  ???:0
20 0x0000000000402e89 _start()  ???:0
=================================
```
Always set completion function to make sure this value is initialized when doing send fast-forwarding in `ucp_request_send_state_ff()`

## How ?

1. Remove incorrect check for completion counter in `ucp_request_send_state_ff()` for `(req->send.uct.func == ucp_proto_progress_am_single)` case.
2. Set completion callback for all protocols in `ucp_request_send_state_reset()`.