### PR TITLE
UCP/CORE: Print memory type EPs info

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -606,9 +606,12 @@ size_t ucp_ep_config_get_zcopy_auto_thresh(size_t iovcnt,
                                            const ucp_context_h context,
                                            double bandwidth);
 
-ucs_status_t ucp_worker_create_mem_type_endpoints(ucp_worker_h worker);
+ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker);
 
-void ucp_worker_destroy_mem_type_endpoints(ucp_worker_h worker);
+void ucp_worker_mem_type_eps_destroy(ucp_worker_h worker);
+
+void ucp_worker_mem_type_eps_print_info(ucp_worker_h worker,
+                                              FILE *stream);
 
 ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2251,7 +2251,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
 
     /* Create loopback endpoints to copy across memory types */
-    status = ucp_worker_create_mem_type_endpoints(worker);
+    status = ucp_worker_mem_type_eps_create(worker);
     if (status != UCS_OK) {
         goto err_close_cms;
     }
@@ -2292,7 +2292,7 @@ err_tag_match_cleanup:
 err_destroy_mpools:
     ucp_worker_destroy_mpools(worker);
 err_destroy_memtype_eps:
-    ucp_worker_destroy_mem_type_endpoints(worker);
+    ucp_worker_mem_type_eps_create(worker);
 err_close_cms:
     ucp_worker_close_cms(worker);
 err_close_ifaces:
@@ -2873,6 +2873,8 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream)
         ucs_string_buffer_dump(&strb, "# ", stream);
         ucs_string_buffer_cleanup(&strb);
     }
+
+    ucp_worker_mem_type_eps_print_info(worker, stream);
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 }


### PR DESCRIPTION
## What

Print UCP memory type EPs information when printing UCP worker information

## Why ?

The PR fixes 2nd item of https://github.com/openucx/ucx/pull/6271#issuecomment-773386235
```
$ ./install/bin/ucx_info -w -u t
#
# UCP worker 'swx-rdmz-ucx-gpu-01:10139'
#
#                 address: 602 bytes
#
#
# UCP endpoint for NVIDIA GPU memory ("cuda" memory type)
#
#                 lane[0]:  6:cuda_copy/cuda.0 md[4]        -> md[4]/cuda_cpy/sysdev[255] rma_bw#0
#
#                tag_send: 0..<egr/short>..0..<egr/bcopy>..(inf)
#            tag_send_nbr: 0..<egr/short>..0..<egr/bcopy>..(inf)
#           tag_send_sync: 0..<egr/short>..0..<egr/bcopy>..(inf)
#
#                  rma_bw: mds rndv_rkey_size 9
#
#
# UCP endpoint for NVIDIA GPU managed/unified memory ("cuda-managed" memory type)
#
#                 lane[0]:  6:cuda_copy/cuda.0 md[4]        -> md[4]/cuda_cpy/sysdev[255] rma_bw#0
#
#                tag_send: 0..<egr/short>..0..<egr/bcopy>..(inf)
#            tag_send_nbr: 0..<egr/short>..0..<egr/bcopy>..(inf)
#           tag_send_sync: 0..<egr/short>..0..<egr/bcopy>..(inf)
#
#                  rma_bw: mds rndv_rkey_size 9
#
# memory: 96.64MB, file descriptors: 26
# create time: 164.720 ms
#
```

## How ?

1. Go through all memory types and use `ucp_ep_print_info()` function to print endpoint information.
2. Update `ucp_ep_print_info()` function to check whether some endpoint is "memtype" one or not:
if it is "memtype" endpoint, print memory type description and name and don't print peer name