### PR TITLE
API/EXPERIMENTAL/MD: added flags-based mem_dereg

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -689,9 +689,10 @@ enum {
     UCT_MD_FLAG_RKEY_PTR   = UCS_BIT(6),  /**< MD supports direct access to
                                                remote memory via a pointer that
                                                is returned by @ref uct_rkey_ptr */
-    UCT_MD_FLAG_SOCKADDR   = UCS_BIT(7)   /**< MD support for client-server
+    UCT_MD_FLAG_SOCKADDR   = UCS_BIT(7),  /**< MD support for client-server
                                                connection establishment via
                                                sockaddr */
+    UCT_MD_FLAG_INVALIDATE = UCS_BIT(8)   /**< MD supports memory invalidation */
 };
 
 /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -122,6 +122,78 @@ typedef struct {
 
 
 /**
+ * @ingroup UCT_MD
+ * @brief MD memory de-registration operation flags.
+ */
+typedef enum {
+    UCT_MD_MEM_DEREG_FIELD_MEMH     = UCS_BIT(0), /**< memh field */
+    UCT_MD_MEM_DEREG_FIELD_FLAGS    = UCS_BIT(1), /**< flags field */
+    UCT_MD_MEM_DEREG_FIELD_CALLBACK = UCS_BIT(2), /**< cb field */
+    UCT_MD_MEM_DEREG_FIELD_ARG      = UCS_BIT(3)  /**< arg field */
+} uct_md_mem_dereg_field_mask_t;
+
+
+typedef enum {
+    /**
+     * Invalidate memory region. If this flag is set then memory region is
+     * invalidated after de-registration and callback (see @ref
+     * uct_md_mem_dereg_params_t) is is called when the memory is fully
+     * invalidated and would not be accessed anymore by zero-copy or remote
+     * memory access operations.
+     */
+    UCT_MD_MEM_DEREG_FLAG_INVALIDATE = UCS_BIT(0) 
+} uct_md_mem_dereg_flags_t;
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Completion callback for memory region invalidation.
+ *
+ * This callback routine is invoked when when it is no longer accessible by
+ * remote peer.
+ *
+ * @param [in]  arg User data passed to "arg" value, see
+ *                  @ref uct_md_mem_dereg_params_t
+ */
+typedef void (*uct_md_mem_invalidate_cb_t)(void *arg);
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Operation parameters passed to @ref uct_md_mem_dereg_v2.
+ */
+typedef struct uct_md_mem_dereg_params {
+    /**
+     * Mask of valid fields in this structure and operation flags, using
+     * bits from @ref uct_md_mem_dereg_field_mask_t. Fields not specified
+     * in this mask will be ignored. Provides ABI compatibility with respect
+     * to adding new fields.
+     */
+    uint64_t                     field_mask;
+
+    /**
+     * Operation specific flags, using bits from @ref uct_md_mem_dereg_flags_t.
+     */
+    unsigned                     flags;
+
+    /**
+     * Memory handle to deregister.
+     */
+    uct_mem_h                    memh;
+
+    /**
+     * Callback function that is invoked when region is invalidated.
+     */
+    uct_md_mem_invalidate_cb_t   cb;
+
+    /**
+     * User-defined argument for the callback function.
+     */
+    void                         *arg;
+} uct_md_mem_dereg_params_t;
+
+
+/**
  * @ingroup UCT_RESOURCE
  * @brief Get interface performance attributes, by memory types and operation.
  *        A pointer to uct_perf_attr_t struct must be passed, with the memory
@@ -133,6 +205,19 @@ typedef struct {
  */
 ucs_status_t
 uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Undo the operation of @ref uct_md_mem_reg() and invalidate memory
+ *        region.
+ *
+ * @param [in]  md          Memory domain which was used to register the memory.
+ * @param [in]  params      Operation parameters, see @ref 
+ *                          uct_md_mem_dereg_params_t.
+ */
+ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
+                                 const uct_md_mem_dereg_params_t *params);
 
 END_C_DECLS
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -474,7 +474,12 @@ ucs_status_t uct_md_mem_reg(uct_md_h md, void *address, size_t length,
 
 ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh)
 {
-    return md->ops->mem_dereg(md, memh);
+    uct_md_mem_dereg_params_t params = {
+        .field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH,
+        .memh       = memh
+    };
+
+    return md->ops->mem_dereg(md, &params);
 }
 
 ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -111,11 +111,15 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_dereg,
-                 (md, memh), uct_md_h md, uct_mem_h memh)
+                 (md, params),
+                 uct_md_h md, const uct_md_mem_dereg_params_t *params)
 {
-    void *address = (void *)memh;
+    void *address;
     ucs_status_t status;
 
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    address = (void *)params->memh;
     if (address == (void*)0xdeadbeef) {
         return UCS_OK;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -271,9 +271,13 @@ static ucs_status_t uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t leng
     return UCS_OK;
 }
 
-static ucs_status_t uct_cuda_ipc_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t
+uct_cuda_ipc_mem_dereg(uct_md_h md,
+                       const uct_md_mem_dereg_params_t *params)
 {
-    ucs_free(memh);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    ucs_free(params->memh);
     return UCS_OK;
 }
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -210,12 +210,17 @@ static ucs_status_t uct_gdr_copy_mem_reg(uct_md_h uct_md, void *address, size_t 
     return UCS_OK;
 }
 
-static ucs_status_t uct_gdr_copy_mem_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t
+uct_gdr_copy_mem_dereg(uct_md_h uct_md,
+                       const uct_md_mem_dereg_params_t *params)
 {
-    uct_gdr_copy_mem_t *mem_hndl = memh;
+    uct_gdr_copy_mem_t *mem_hndl;
     ucs_status_t status;
 
-    status = uct_gdr_copy_mem_dereg_internal(uct_md, mem_hndl);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    mem_hndl = params->memh;
+    status   = uct_gdr_copy_mem_dereg_internal(uct_md, mem_hndl);
     if (status != UCS_OK) {
         ucs_warn("failed to deregister memory handle");
     }
@@ -296,11 +301,17 @@ uct_gdr_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
     return UCS_OK;
 }
 
-static ucs_status_t uct_gdr_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t
+uct_gdr_copy_mem_rcache_dereg(uct_md_h uct_md,
+                              const uct_md_mem_dereg_params_t *params)
+
 {
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
-    uct_gdr_copy_rcache_region_t *region = uct_gdr_copy_rache_region_from_memh(memh);
+    uct_gdr_copy_rcache_region_t *region;
 
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    region = uct_gdr_copy_rache_region_from_memh(params->memh);
     ucs_rcache_region_put(md->rcache, &region->super);
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -852,13 +852,17 @@ static ucs_status_t uct_ib_mem_reg(uct_md_h uct_md, void *address, size_t length
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_mem_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t uct_ib_mem_dereg(uct_md_h uct_md,
+                                     const uct_md_mem_dereg_params_t *params)
 {
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
-    uct_ib_mem_t *ib_memh = memh;
+    uct_ib_mem_t *ib_memh;
     ucs_status_t status;
 
-    status = uct_ib_memh_dereg(md, ib_memh);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    ib_memh = params->memh;
+    status  = uct_ib_memh_dereg(md, ib_memh);
     uct_ib_memh_free(ib_memh);
     return status;
 }
@@ -1026,11 +1030,16 @@ static ucs_status_t uct_ib_mem_rcache_reg(uct_md_h uct_md, void *address,
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t
+uct_ib_mem_rcache_dereg(uct_md_h uct_md,
+                        const uct_md_mem_dereg_params_t *params)
 {
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
-    uct_ib_rcache_region_t *region = uct_ib_rcache_region_from_memh(memh);
+    uct_ib_rcache_region_t *region;
 
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    region = uct_ib_rcache_region_from_memh(params->memh);
     ucs_rcache_region_put(md->rcache, &region->super);
     return UCS_OK;
 }
@@ -1131,15 +1140,24 @@ static ucs_status_t uct_ib_mem_global_odp_reg(uct_md_h uct_md, void *address,
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_mem_global_odp_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t
+uct_ib_mem_global_odp_dereg(uct_md_h uct_md,
+                            const uct_md_mem_dereg_params_t *params)
 {
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    uct_ib_mem_t *ib_memh;
+    ucs_status_t status;
 
-    if (memh == md->global_odp) {
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    if (params->memh == md->global_odp) {
         return UCS_OK;
     }
 
-    return uct_ib_mem_dereg(uct_md, memh);
+    ib_memh = params->memh;
+    status  = uct_ib_memh_dereg(md, ib_memh);
+    uct_ib_memh_free(ib_memh);
+    return status;
 }
 
 static uct_md_ops_t UCS_V_UNUSED uct_ib_md_global_odp_ops = {

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -147,10 +147,18 @@ static ucs_status_t uct_rocm_copy_mem_reg(uct_md_h md, void *address, size_t len
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_copy_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t
+uct_rocm_copy_mem_dereg(uct_md_h md,
+                        const uct_md_mem_dereg_params_t *params)
 {
-    uct_rocm_copy_mem_t *mem_hndl = (uct_rocm_copy_mem_t *)memh;
-    void *address = mem_hndl->vaddr;
+    uct_rocm_copy_mem_t *mem_hndl;
+    void *address;
+    hsa_status_t status;
+
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    mem_hndl = (uct_rocm_copy_mem_t *)params->memh;
+    address  = mem_hndl->vaddr;
     hsa_status_t status;
 
     if (address == NULL) {
@@ -214,11 +222,16 @@ uct_rocm_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_copy_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t
+uct_rocm_copy_mem_rcache_dereg(uct_md_h uct_md,
+                               const uct_md_mem_dereg_params_t *params)
 {
     uct_rocm_copy_md_t *md = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
-    uct_rocm_copy_rcache_region_t *region = uct_rocm_copy_rache_region_from_memh(memh);
+    uct_rocm_copy_rcache_region_t *region;
 
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    region = uct_rocm_copy_rache_region_from_memh(params->memh);
     ucs_rcache_region_put(md->rcache, &region->super);
     return UCS_OK;
 }

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -97,10 +97,15 @@ static ucs_status_t uct_rocm_gdr_mem_reg(uct_md_h md, void *address, size_t leng
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_gdr_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t
+uct_rocm_gdr_mem_dereg(uct_md_h md,
+                       const uct_md_mem_dereg_params_t *params)
 {
-    uct_rocm_gdr_mem_t *mem_hndl = memh;
+    uct_rocm_gdr_mem_t *mem_hndl;
 
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    mem_hndl = params->memh;
     ucs_free(mem_hndl);
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -101,11 +101,16 @@ static ucs_status_t uct_rocm_ipc_mem_reg(uct_md_h md, void *address, size_t leng
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_ipc_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t
+uct_rocm_ipc_mem_dereg(uct_md_h md,
+                       const uct_md_mem_dereg_params_t *params)
 {
-    uct_rocm_ipc_key_t *key = (uct_rocm_ipc_key_t *)memh;
+    uct_rocm_ipc_mem_t *mem_hndl;
 
-    ucs_free(key);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    mem_hndl = params->memh;
+    ucs_free(mem_hndl);
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -423,9 +423,15 @@ static ucs_status_t uct_xmpem_mem_reg(uct_md_h md, void *address, size_t length,
     return UCS_OK;
 }
 
-static ucs_status_t uct_xmpem_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t
+uct_xmpem_mem_dereg(uct_md_h md,
+                    const uct_md_mem_dereg_params_t *params)
 {
-    uct_mm_seg_t *seg = memh;
+    uct_mm_seg_t *seg;
+
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    seg = params->memh;
     ucs_free(seg);
     return UCS_OK;
 }

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -138,6 +138,16 @@ static ucs_status_t uct_cma_mem_reg(uct_md_h md, void *address, size_t length,
     return UCS_OK;
 }
 
+static ucs_status_t uct_cma_mem_dereg(uct_md_h uct_md,
+                                      const uct_md_mem_dereg_params_t *params)
+{
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    ucs_assert(params->memh == (void*)0xdeadbeef);
+
+    return UCS_OK;
+}
+
 static ucs_status_t
 uct_cma_md_open(uct_component_t *component, const char *md_name,
                 const uct_md_config_t *md_config, uct_md_h *md_p)
@@ -149,7 +159,7 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
         .mem_free               = (uct_md_mem_free_func_t)ucs_empty_function_return_success,
         .mkey_pack              = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
         .mem_reg                = uct_cma_mem_reg,
-        .mem_dereg              = (uct_md_mem_dereg_func_t)ucs_empty_function_return_success,
+        .mem_dereg              = uct_cma_mem_dereg,
         .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
         .detect_memory_type     = ucs_empty_function_return_unsupported,
     };

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -18,6 +18,9 @@
 #include <ucm/api/ucm.h>
 
 
+#define UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(_params) \
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(_params, 0)
+
 static ucs_config_field_t uct_knem_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_knem_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -179,11 +182,15 @@ static ucs_status_t uct_knem_mem_dereg_internal(uct_md_h md, uct_knem_key_t *key
     return UCS_OK;
 }
 
-static ucs_status_t uct_knem_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t uct_knem_mem_dereg(uct_md_h md,
+                                       const uct_md_mem_dereg_params_t *params)
 {
-    uct_knem_key_t *key = (uct_knem_key_t *)memh;
+    uct_knem_key_t *key;
     ucs_status_t status;
 
+    UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(params);
+
+    key    = (uct_knem_key_t *)params->memh;
     status = uct_knem_mem_dereg_internal(md, key);
     if (status == UCS_OK) {
         ucs_free(key);
@@ -266,10 +273,16 @@ static ucs_status_t uct_knem_mem_rcache_reg(uct_md_h uct_md, void *address,
     return UCS_OK;
 }
 
-static ucs_status_t uct_knem_mem_rcache_dereg(uct_md_h uct_md, uct_mem_h memh)
+static ucs_status_t
+uct_knem_mem_rcache_dereg(uct_md_h uct_md,
+                          const uct_md_mem_dereg_params_t *params)
 {
-    uct_knem_md_t *md                = ucs_derived_of(uct_md, uct_knem_md_t);
-    uct_knem_rcache_region_t *region = uct_knem_rcache_region_from_memh(memh);
+    uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
+    uct_knem_rcache_region_t *region;
+ 
+    UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(params);
+ 
+    region = uct_knem_rcache_region_from_memh(params->memh);
 
     ucs_rcache_region_put(md->rcache, &region->super);
     return UCS_OK;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -405,6 +405,16 @@ static ucs_status_t uct_self_mem_reg(uct_md_h md, void *address, size_t length,
     return UCS_OK;
 }
 
+static ucs_status_t uct_self_mem_dereg(uct_md_h uct_md,
+                                       const uct_md_mem_dereg_params_t *params)
+{
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    ucs_assert(params->memh == (void*)0xdeadbeef);
+
+    return UCS_OK;
+}
+
 static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_name,
                                      const uct_md_config_t *config, uct_md_h *md_p)
 {
@@ -415,7 +425,7 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .query              = uct_self_md_query,
         .mkey_pack          = ucs_empty_function_return_success,
         .mem_reg            = uct_self_mem_reg,
-        .mem_dereg          = ucs_empty_function_return_success,
+        .mem_dereg          = uct_self_mem_dereg,
         .detect_memory_type = ucs_empty_function_return_unsupported
     };
 

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -37,6 +37,16 @@ static ucs_status_t uct_tcp_md_mem_reg(uct_md_h md, void *address, size_t length
     return UCS_OK;
 }
 
+static ucs_status_t uct_tcp_mem_dereg(uct_md_h uct_md,
+                                      const uct_md_mem_dereg_params_t *params)
+{
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
+    ucs_assert(params->memh == (void*)0xdeadbeef);
+
+    return UCS_OK;
+}
+
 static ucs_status_t
 uct_tcp_md_open(uct_component_t *component, const char *md_name,
                 const uct_md_config_t *md_config, uct_md_h *md_p)
@@ -46,7 +56,7 @@ uct_tcp_md_open(uct_component_t *component, const char *md_name,
         .query              = uct_tcp_md_query,
         .mkey_pack          = ucs_empty_function_return_success,
         .mem_reg            = uct_tcp_md_mem_reg,
-        .mem_dereg          = ucs_empty_function_return_success,
+        .mem_dereg          = uct_tcp_mem_dereg,
         .detect_memory_type = ucs_empty_function_return_unsupported
     };
     static uct_md_t md = {

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -93,15 +93,19 @@ mem_err:
     return status;
 }
 
-static ucs_status_t uct_ugni_mem_dereg(uct_md_h md, uct_mem_h memh)
+static ucs_status_t uct_ugni_mem_dereg(uct_md_h md,
+                                       const uct_md_mem_dereg_params_t *params)
 {
     uct_ugni_md_t *ugni_md = ucs_derived_of(md, uct_ugni_md_t);
-    gni_mem_handle_t *mem_hndl = (gni_mem_handle_t *) memh;
+    gni_mem_handle_t *mem_hndl;
     gni_return_t ugni_rc;
     ucs_status_t status = UCS_OK;
 
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+
     uct_ugni_cdm_lock(&ugni_md->cdm);
-    ugni_rc = GNI_MemDeregister(ugni_md->cdm.nic_handle, mem_hndl);
+    mem_hndl = (gni_mem_handle_t *)params->memh;
+    ugni_rc  = GNI_MemDeregister(ugni_md->cdm.nic_handle, mem_hndl);
     uct_ugni_cdm_unlock(&ugni_md->cdm);
     if (GNI_RC_SUCCESS != ugni_rc) {
         ucs_error("GNI_MemDeregister failed, Error status: %s %d",


### PR DESCRIPTION
- added experimental API uct_md_mem_dereg_flags function to support flags in
  memory de-registration

Why:
- needed to fix issue in error handling when connect-to-iface transport is used

How:
- in case if error happened delay user request completion till memory region is unregistered to provide RDMA operation failure or data consistency

Details:
The goal of this PR is to solve data corruption issue with rendezvous protocol during error flow: one side unexpectedly closes the connection (for example because keepalive detects temporary network error), while the other side can still do RDMA_READ invalid data from it.
The method to solve the problem is to destroy the related registration cache region after all other users of it (maybe other connections) finished using it and its refcount reached 0. This way, any subsequent RDMA_READ will get remote access error and not read wrong data. Send request completion on the closing side will be delayed until then, to prevent early buffer release.
Note: Such issue may happen only on non-p2p transports like DC or CMA where closing ep on one side does not invalidate the ep on other side.