### PR TITLE
APPS/IODEMO: Fix unknown conn_id happened when only one peer is fully connected

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -454,6 +454,7 @@ void UcxContext::add_connection(UcxConnection *conn)
 {
     assert(_conns.find(conn->id()) == _conns.end());
     _conns[conn->id()] = conn;
+    UCX_LOG << "added " << conn->get_log_prefix() << " to connection map";
 }
 
 void UcxContext::remove_connection(UcxConnection *conn)
@@ -461,6 +462,8 @@ void UcxContext::remove_connection(UcxConnection *conn)
     conn_map_t::iterator i = _conns.find(conn->id());
     if (i != _conns.end()) {
         _conns.erase(i);
+        UCX_LOG << "removed " << conn->get_log_prefix()
+                << " from connection map";
     }
 }
 
@@ -949,6 +952,8 @@ void UcxConnection::connect_common(ucp_ep_params_t &ep_params,
     } else {
         connect_tag(callback);
     }
+
+    _context.add_connection(this);
 }
 
 void UcxConnection::established(ucs_status_t status)
@@ -960,9 +965,6 @@ void UcxConnection::established(ucs_status_t status)
 
     _ucx_status = status;
     _context.remove_connection_inprogress(this);
-    if (status == UCS_OK) {
-        _context.add_connection(this);
-    }
 
     (*_establish_cb)(status);
     _establish_cb = NULL;

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -266,6 +266,10 @@ public:
         return _ucx_status;
     }
 
+    const char* get_log_prefix() const {
+        return _log_prefix;
+    }
+
     bool is_established() const {
         return _establish_cb == NULL;
     }


### PR DESCRIPTION
## What

Fix unknown conn_id happened when only one peer is fully connected.

## Why ?

It happens that peers are connected to do UCP TAG operations beetween each other, but only the client received a connection ID from a peer through UCP Stream. So the client started sending IO messages (11 reads and 5 writes), but the server isn't received a connection ID from a peer and isn't ready to receive the data - it just discards the 16 received messages.
client:
```
[1621265591.444772] [UCX-connection #4 0.0.0.0:0] created new connection 0x2081f10 total: 4
[1621265591.444781] [UCX-connection #4 2.1.3.20:20002] Connecting to 2.1.3.20:20002
[1621265591.444800] [UCX-connection #4 2.1.3.20:20002] created endpoint 0x7f7e48565168, connection id 4
...<after 5 minutes>...
[1621265896.249686] [DEMO] timeout waiting for 16 replies
[1621265896.249728] [DEMO] disconnecting connection 0x2081f10 with 16 uncompleted operations (read: 0/11; write: 0/5) due to "timeout for replies"
[1621265896.249737] [UCX-connection #4 2.1.3.20:20002] destroying, ep is 0x7f7e48565168
```
server:
```
[1621265592.240362] [UCX-connection #17 0.0.0.0:0] created new connection 0x12d5720 total: 17
[1621265592.240759] [UCX-connection #17 2.1.3.20:36280] created endpoint 0x7ff92ed70780, connection id 17
...
[1621265592.296225] [UCX] could not find connection with id 17
[1621265592.296234] [UCX] could not find connection with id 17
[1621265592.296238] [UCX] could not find connection with id 17
[1621265592.296242] [UCX] could not find connection with id 17
[1621265592.296246] [UCX] could not find connection with id 17
[1621265592.296263] [UCX] could not find connection with id 17
[1621265592.296267] [UCX] could not find connection with id 17
[1621265592.296271] [UCX] could not find connection with id 17
[1621265592.296275] [UCX] could not find connection with id 17
[1621265592.296278] [UCX] could not find connection with id 17
[1621265592.296284] [UCX] could not find connection with id 17
[1621265592.296288] [UCX] could not find connection with id 17
[1621265592.296292] [UCX] could not find connection with id 17
[1621265592.296297] [UCX] could not find connection with id 17
[1621265592.296300] [UCX] could not find connection with id 17
[1621265592.296305] [UCX] could not find connection with id 17
[1621265592.296310] [UCX-connection #17 2.1.3.20:36280] Remote id is 4
...
[1621265896.253262] [UCX-connection #17 2.1.3.20:36280] detected error: Connection reset by remote peer
[1621265896.253293] [DEMO] disconnecting connection with status Connection reset by remote peer
[1621265896.253297] [UCX-connection #17 2.1.3.20:36280] destroying, ep is 0x7ff92ed70780
[1621265896.253301] [UCX-connection #17 2.1.3.20:36280] closing ep 0x7ff92ed70780 mode force
```

## How ?

Add connection ID to `_conns` map when accepted a connection a peer or connected to a peer, i.e. in `UcxConnection::connect_common()`. It is done a bit earlier than `UcxConnection::established()` which is called after receiving a connection ID from a peer in case of UCP TAG API mode.