### PR TITLE
UCP/CONTEXT: add ERROR_HANDLER_DELAY configuration

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -329,6 +329,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "endpoint.",
    ucs_offsetof(ucp_config_t, ctx.proto_indirect_id), UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
+  {"ERROR_HANDLER_DELAY", "0us",
+   "Artificial delay between detecting an error and processing it (0 - disabled).\n"
+   "Used for testing purposes",
+   ucs_offsetof(ucp_config_t, ctx.err_handler_delay),
+   UCS_CONFIG_TYPE_TIME_UNITS},
+
    {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t,

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -114,6 +114,8 @@ typedef struct ucp_context_config {
     unsigned                               keepalive_num_eps;
     /** Enable indirect IDs to object pointers in wire protocols */
     ucs_on_off_auto_value_t                proto_indirect_id;
+    /** Error handler delay */
+    ucs_time_t                             err_handler_delay;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1206,15 +1206,7 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
     ucp_ep_update_flags(ep, UCP_EP_FLAG_CLOSED, 0);
 
     if (ucp_request_param_flags(param) & UCP_EP_CLOSE_FLAG_FORCE) {
-        /* FIXME: there is a potential issue with flush completion after an EP
-         * was forcibly closed from a user's error handling callback after
-         * disconnect event was received, but some EP flush operation still
-         * is in-progress, so, the destroyed EP will be touched upon flush
-         * completion on some transport */
-        if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
-            ucp_ep_discard_lanes(ep, UCS_ERR_CANCELED);
-        }
-
+        ucp_ep_discard_lanes(ep, UCS_ERR_CANCELED);
         ucp_ep_disconnected(ep, 1);
     } else {
         request = ucp_ep_flush_internal(ep, 0, param, NULL,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3006,7 +3006,7 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
                                       &worker->keepalive.cb_id);
 }
 
-/* EP is removed from worker */
+/* EP is removed from worker, advance iterator if it points to the EP */
 void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 {
     ucp_worker_h worker = ep->worker;
@@ -3017,8 +3017,6 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
         ucs_assert(worker->keepalive.iter == &worker->all_eps);
         return;
     }
-
-    ucs_assert(!ucs_list_is_empty(&worker->all_eps));
 
     if (ucs_list_is_only(&worker->all_eps, &ucp_ep_ext_gen(ep)->ep_list)) {
         /* this is the last EP in worker */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -431,7 +431,22 @@ static unsigned ucp_worker_iface_err_handle_progress(void *arg)
     ucp_ep_h ucp_ep                             = err_handle_arg->ucp_ep;
     ucs_status_t status                         = err_handle_arg->status;
     ucp_worker_h worker                         = ucp_ep->worker;
+    ucs_time_t curr_time                        = ucs_get_time();
     ucp_request_t *close_req;
+    uct_worker_cb_id_t prog_id;
+
+    if (curr_time < err_handle_arg->timeout) {
+        ucs_debug("ep %p: delay error handler by %.2f usec, flags: 0x%x, status %s",
+                  ucp_ep, ucs_time_to_usec(err_handle_arg->timeout - curr_time),
+                  ucp_ep->flags, ucs_status_string(status));
+
+        prog_id = UCS_CALLBACKQ_ID_NULL;
+        uct_worker_progress_register_safe(worker->uct,
+                                          ucp_worker_iface_err_handle_progress,
+                                          err_handle_arg,
+                                          UCS_CALLBACKQ_FLAG_ONESHOT, &prog_id);
+        return 0;
+    }
 
     UCS_ASYNC_BLOCK(&worker->async);
 
@@ -533,8 +548,10 @@ ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
         goto out;
     }
 
-    err_handle_arg->ucp_ep      = ucp_ep;
-    err_handle_arg->status      = status;
+    err_handle_arg->ucp_ep  = ucp_ep;
+    err_handle_arg->status  = status;
+    err_handle_arg->timeout = ucs_get_time() +
+            worker->context->config.ext.err_handler_delay;
 
     /* invoke the rest of the error handling flow from the main thread */
     uct_worker_progress_register_safe(worker->uct,

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -315,6 +315,7 @@ typedef struct ucp_worker {
  */
 typedef struct ucp_worker_err_handle_arg {
     ucp_ep_h         ucp_ep;
+    ucs_time_t       timeout;
     ucs_status_t     status;
 } ucp_worker_err_handle_arg_t;
 

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -533,17 +533,10 @@ ucp_stream_am_handler(void *am_arg, void *am_data, size_t am_length,
 
     ucs_assert(am_length >= sizeof(ucp_stream_am_hdr_t));
 
+    /* Drop the date if the endpoint is invalid */
     UCP_WORKER_GET_VALID_EP_BY_ID(&ep, worker, data->hdr.ep_id, return UCS_OK,
                                   "stream data");
     ep_ext = ucp_ep_ext_proto(ep);
-
-    if (ucs_unlikely(ep->flags & (UCP_EP_FLAG_CLOSED |
-                                  UCP_EP_FLAG_FAILED))) {
-        ucs_trace_data("ep %p: stream is invalid", ep);
-        /* drop the data */
-        return UCS_OK;
-    }
-
     status = ucp_stream_am_data_process(worker, ep_ext, data,
                                         am_length - sizeof(data->hdr),
                                         am_flags);

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1056,8 +1056,9 @@ static int uct_tcp_ep_is_conn_closed_by_peer(ucs_status_t io_status)
 ucs_status_t uct_tcp_ep_handle_io_err(uct_tcp_ep_t *ep, const char *op_str,
                                       ucs_status_t io_status)
 {
-    uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
-                                            uct_tcp_iface_t);
+    uct_tcp_iface_t *iface    = ucs_derived_of(ep->super.super.iface,
+                                               uct_tcp_iface_t);
+    ucs_log_level_t log_level = UCS_LOG_LEVEL_DIAG;
     ucs_status_t status;
     char str_local_addr[UCS_SOCKADDR_STRING_LEN];
     char str_remote_addr[UCS_SOCKADDR_STRING_LEN];
@@ -1070,6 +1071,7 @@ ucs_status_t uct_tcp_ep_handle_io_err(uct_tcp_ep_t *ep, const char *op_str,
 
     if (!uct_tcp_ep_is_conn_closed_by_peer(io_status)) {
         /* IO operation failed with the unrecoverable error */
+        log_level = UCS_LOG_LEVEL_ERROR;
         goto err;
     }
 
@@ -1129,9 +1131,9 @@ ucs_status_t uct_tcp_ep_handle_io_err(uct_tcp_ep_t *ep, const char *op_str,
     }
 
 err:
-    ucs_error("tcp_ep %p (state=%s): %s(%d) failed: %s",
-              ep, uct_tcp_ep_cm_state[ep->conn_state].name,
-              op_str, ep->fd, ucs_status_string(io_status));
+    ucs_log(log_level, "tcp_ep %p (state=%s): %s(%d) failed: %s",
+            ep, uct_tcp_ep_cm_state[ep->conn_state].name,
+            op_str, ep->fd, ucs_status_string(io_status));
     return io_status;
 }
 


### PR DESCRIPTION
## What
 - add ERROR_HANDLER_DELAY configuration
 - add test_ucp_sockaddr.close_ep_force_before_err_cb
 - related fixes in UCP and UCT
 - updated version of  of https://github.com/openucx/ucx/pull/5931

## Why
to handle a case then err handling callback is scheduled on slow path progress but EP was closed by ucp_ep_close_nbx(force) earlier