### PR TITLE
UCT/BASE: Fixed crash on UCT iface vfs refresh.

### DIFF
--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -411,7 +411,8 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 }
 
 uct_iface_internal_ops_t uct_base_iface_internal_ops = {
-    .iface_estimate_perf = uct_base_iface_estimate_perf
+    .iface_estimate_perf = uct_base_iface_estimate_perf,
+    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
 };
 
 UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -329,7 +329,8 @@ static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
-    .iface_estimate_perf = uct_cuda_copy_estimate_perf
+    .iface_estimate_perf = uct_cuda_copy_estimate_perf,
+    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -147,7 +147,8 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
-    .iface_estimate_perf = uct_gdr_copy_estimate_perf
+    .iface_estimate_perf = uct_gdr_copy_estimate_perf,
+    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,


### PR DESCRIPTION
## What
Fixed crash while refreshing UCT iface VFS sub-tree. 

## Why ?
The issue was detected on `ucp_hello_world` application. `iface_vfs_refresh` was not initialized for TCP  UCT iface. This caused a crash in `uct_iface_vfs_refresh` function
```C
        ucs_debug("failed to query iface attributes");
    }

    iface->internal_ops->iface_vfs_refresh(&iface->super);
}
```
