### PR TITLE
UCS/PROFILE: add support for external profiler context

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -1167,7 +1167,7 @@ static void ucs_debug_signal_handler(int signo)
 {
     ucs_log_flush();
     ucs_global_opts.log_component.log_level = UCS_LOG_LEVEL_TRACE_DATA;
-    ucs_profile_dump();
+    ucs_profile_dump(ucs_profile_default_ctx);
 }
 
 static void ucs_debug_set_signal_alt_stack()

--- a/src/ucs/profile/profile_defs.h
+++ b/src/ucs/profile/profile_defs.h
@@ -116,26 +116,42 @@ typedef struct ucs_profile_record {
     uint32_t                 location;      /**< Location identifier */
 } UCS_S_PACKED ucs_profile_record_t;
 
+typedef struct ucs_profile_context ucs_profile_context_t;
+
 
 extern const char *ucs_profile_mode_names[];
+extern ucs_profile_context_t *ucs_profile_default_ctx;
 
 
 /**
  * Initialize profiling system.
+ *
+ * @param [in]  profile_mode  Profiling mode.
+ * @param [in]  file_name     Profiling file.
+ * @param [in]  max_file_size Limit for profiling log size.
+ * @param [out] ctx_p         Profile context.
+ *
+ * @return Status code.
  */
-void ucs_profile_global_init();
+ucs_status_t ucs_profile_init(unsigned profile_mode, const char *file_name,
+                              size_t max_file_size, ucs_profile_context_t **ctx_p);
 
 
 /**
  * Save and cleanup profiling.
+ *
+ * @param [in] ctx       Profile context.
  */
-void ucs_profile_global_cleanup();
+void ucs_profile_cleanup(ucs_profile_context_t *ctx);
 
 
 /**
  * Save and reset profiling.
+ *
+ * @param [in] ctx       Profile context.
  */
-void ucs_profile_dump();
+void ucs_profile_dump(ucs_profile_context_t *ctx);
+
 
 END_C_DECLS
 

--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -19,40 +19,43 @@ BEGIN_C_DECLS
 /** @file profile_on.h */
 
 /* Helper macro */
-#define _UCS_PROFILE_RECORD(_type, _name, _param64, _param32, _loc_id_p) \
+#define _UCS_PROFILE_CTX_RECORD(_ctx, _type, _name, _param64, _param32, _loc_id_p) \
     { \
         if (*(_loc_id_p) != 0) { \
-            ucs_profile_record((_type), (_name), (_param64), (_param32),  \
-                               __FILE__, __LINE__, __FUNCTION__, (_loc_id_p)); \
+            ucs_profile_record((_ctx), (_type), (_name), (_param64), \
+                               (_param32), __FILE__, __LINE__, __FUNCTION__, \
+                               (_loc_id_p)); \
         } \
     }
 
 
 /* Helper macro */
-#define __UCS_PROFILE_CODE(_name, _loop_var) \
+#define __UCS_PROFILE_CTX_CODE(_ctx, _name, _loop_var) \
     int _loop_var ; \
-    for (({ UCS_PROFILE_SCOPE_BEGIN(); _loop_var = 1;}); \
+    for (({ UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); _loop_var = 1;}); \
          _loop_var; \
-         ({ UCS_PROFILE_SCOPE_END(_name); _loop_var = 0;}))
+         ({ UCS_PROFILE_CTX_SCOPE_END((_ctx), (_name)); _loop_var = 0;}))
 
 
 /* Helper macro */
-#define _UCS_PROFILE_CODE(_name, _var_suffix) \
-    __UCS_PROFILE_CODE(_name, UCS_PP_TOKENPASTE(loop, _var_suffix))
+#define _UCS_PROFILE_CTX_CODE(_ctx, _name, _var_suffix) \
+    __UCS_PROFILE_CTX_CODE(_ctx, _name, UCS_PP_TOKENPASTE(loop, _var_suffix))
 
 
 /**
  * Record a profiling event.
  *
+ * @param _ctx      Profiling context.
  * @param _type     Event type.
  * @param _name     Event name.
  * @param _param32  Custom 32-bit parameter.
  * @param _param64  Custom 64-bit parameter.
  */
-#define UCS_PROFILE(_type, _name, _param32, _param64) \
+#define UCS_PROFILE_CTX_RECORD(_ctx, _type, _name, _param32, _param64) \
     { \
         static int loc_id = -1; \
-        _UCS_PROFILE_RECORD((_type), (_name), (_param32), (_param64), &loc_id); \
+        _UCS_PROFILE_CTX_RECORD((_ctx), (_type), (_name), (_param32), \
+                                (_param64), &loc_id); \
     }
 
 
@@ -62,15 +65,18 @@ BEGIN_C_DECLS
  * @param _name   Event name.
  */
 #define UCS_PROFILE_SAMPLE(_name) \
-    UCS_PROFILE(UCS_PROFILE_TYPE_SAMPLE, (_name), 0, 0)
+    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_SAMPLE, \
+                           (_name), 0, 0)
 
 
 /**
  * Record a scope-begin profiling event.
+ *
+ * @param _ctx  Profiling context.
  */
-#define UCS_PROFILE_SCOPE_BEGIN() \
+#define UCS_PROFILE_CTX_SCOPE_BEGIN(_ctx) \
     { \
-        UCS_PROFILE(UCS_PROFILE_TYPE_SCOPE_BEGIN, "", 0, 0); \
+        UCS_PROFILE_CTX_RECORD((_ctx), UCS_PROFILE_TYPE_SCOPE_BEGIN, "", 0, 0); \
         ucs_compiler_fence(); \
     }
 
@@ -78,12 +84,13 @@ BEGIN_C_DECLS
 /**
  * Record a scope-end profiling event.
  *
- * @param _name   Scope name.
+ * @param _ctx  Profiling context.
+ * @param _name Scope name.
  */
-#define UCS_PROFILE_SCOPE_END(_name) \
+#define UCS_PROFILE_CTX_SCOPE_END(_ctx, _name) \
     { \
         ucs_compiler_fence(); \
-        UCS_PROFILE(UCS_PROFILE_TYPE_SCOPE_END, _name, 0, 0); \
+        UCS_PROFILE_CTX_RECORD((_ctx), UCS_PROFILE_TYPE_SCOPE_END, _name, 0, 0); \
     }
 
 
@@ -98,11 +105,37 @@ BEGIN_C_DECLS
  * @param _name   Scope name.
  */
 #define UCS_PROFILE_CODE(_name) \
-    _UCS_PROFILE_CODE(_name, UCS_PP_UNIQUE_ID)
+    _UCS_PROFILE_CTX_CODE(ucs_profile_default_ctx, _name, UCS_PP_UNIQUE_ID)
 
 
 /**
  * Create a profiled function.
+ *
+ * Usage:
+ *  _UCS_PROFILE_CTX_FUNC(ctx, <retval>, <name>, (a, b), int a, char b)
+ *
+ * @param _ctx        Profiling context.
+ * @param _ret_type   Function return type.
+ * @param _name       Function name.
+ * @param _arglist    List of argument *names* only.
+ * @param ...         Argument declarations (with types).
+ */
+#define _UCS_PROFILE_CTX_FUNC(_ctx, _ret_type, _name, _arglist, ...) \
+    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__); \
+    \
+    _ret_type _name(__VA_ARGS__) \
+    { \
+        _ret_type _ret; \
+        UCS_PROFILE_CTX_SCOPE_BEGIN(_ctx); \
+        _ret = _name##_inner _arglist; \
+        UCS_PROFILE_CTX_SCOPE_END(_ctx, #_name); \
+        return _ret; \
+    } \
+    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__)
+
+
+/**
+ * Create a profiled function. Uses default profile context.
  *
  * Usage:
  *  UCS_PROFILE_FUNC(<retval>, <name>, (a, b), int a, char b)
@@ -113,21 +146,34 @@ BEGIN_C_DECLS
  * @param ...         Argument declarations (with types).
  */
 #define UCS_PROFILE_FUNC(_ret_type, _name, _arglist, ...) \
-    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__); \
-    \
-    _ret_type _name(__VA_ARGS__) \
-    { \
-        _ret_type _ret; \
-        UCS_PROFILE_SCOPE_BEGIN(); \
-        _ret = _name##_inner _arglist; \
-        UCS_PROFILE_SCOPE_END(#_name); \
-        return _ret; \
-    } \
-    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__)
+    _UCS_PROFILE_CTX_FUNC(ucs_profile_default_ctx, _ret_type, _name, _arglist, ## __VA_ARGS__)
 
 
 /**
  * Create a profiled function whose return type is void.
+ *
+ * Usage:
+ *  _UCS_PROFILE_CTX_FUNC_VOID(ctx, <name>, (a, b), int a, char b)
+ *
+ * @param _ctx        Profiling context.
+ * @param _name       Function name.
+ * @param _arglist    List of argument *names* only.
+ * @param ...         Argument declarations (with types).
+ */
+#define _UCS_PROFILE_CTX_FUNC_VOID(_ctx, _name, _arglist, ...) \
+    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__); \
+    \
+    void _name(__VA_ARGS__) { \
+        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
+        _name##_inner _arglist; \
+        UCS_PROFILE_CTX_SCOPE_END((_ctx), #_name); \
+    } \
+    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__)
+
+
+/**
+ * Create a profiled function whose return type is void. Uses default profile
+ * context.
  *
  * Usage:
  *  UCS_PROFILE_FUNC_VOID(<name>, (a, b), int a, char b)
@@ -137,19 +183,33 @@ BEGIN_C_DECLS
  * @param ...         Argument declarations (with types).
  */
 #define UCS_PROFILE_FUNC_VOID(_name, _arglist, ...) \
-    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__); \
-    \
-    void _name(__VA_ARGS__) { \
-        UCS_PROFILE_SCOPE_BEGIN(); \
-        _name##_inner _arglist; \
-        UCS_PROFILE_SCOPE_END(#_name); \
-    } \
-    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__)
+    _UCS_PROFILE_CTX_FUNC_VOID(ucs_profile_default_ctx, _name, _arglist, ## __VA_ARGS__)
 
 
 /*
  * Profile a function call, and specify explicit name string for the profile.
- * Useful when calling a function by a pointer.
+ * Useful when calling a function by a pointer. Uses default profile context.
+ *
+ * Usage:
+ *  _UCS_PROFILE_CTX_NAMED_CALL(ctx, "name", function, arg1, arg2)
+ *
+ * @param _name   Name string for the profile.
+ * @param _func   Function name.
+ * @param ...     Function call arguments.
+ */
+#define _UCS_PROFILE_CTX_NAMED_CALL(_ctx, _name, _func, ...) \
+    ({ \
+        typeof(_func(__VA_ARGS__)) retval; \
+        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
+        retval = _func(__VA_ARGS__); \
+        UCS_PROFILE_CTX_SCOPE_END((_ctx), _name); \
+        retval; \
+    })
+
+
+/*
+ * Profile a function call, and specify explicit name string for the profile.
+ * Useful when calling a function by a pointer. Uses default profile context.
  *
  * Usage:
  *  UCS_PROFILE_NAMED_CALL("name", function, arg1, arg2)
@@ -159,13 +219,7 @@ BEGIN_C_DECLS
  * @param ...     Function call arguments.
  */
 #define UCS_PROFILE_NAMED_CALL(_name, _func, ...) \
-    ({ \
-        typeof(_func(__VA_ARGS__)) retval; \
-        UCS_PROFILE_SCOPE_BEGIN(); \
-        retval = _func(__VA_ARGS__); \
-        UCS_PROFILE_SCOPE_END(_name); \
-        retval; \
-    })
+    _UCS_PROFILE_CTX_NAMED_CALL(ucs_profile_default_ctx, _name, _func,  ## __VA_ARGS__)
 
 
 /*
@@ -186,6 +240,27 @@ BEGIN_C_DECLS
  * name string for the profile. Useful when calling a function by a pointer.
  *
  * Usage:
+ *  _UCS_PROFILE_CTX_NAMED_CALL_VOID(ctx, "name", function, arg1, arg2)
+ *
+ * @param _ctx    Profiling context.
+ * @param _name   Name string for the profile.
+ * @param _func   Function name.
+ * @param ...     Function call arguments.
+ */
+#define _UCS_PROFILE_CTX_NAMED_CALL_VOID(_ctx, _name, _func, ...) \
+    { \
+        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
+        _func(__VA_ARGS__); \
+        UCS_PROFILE_CTX_SCOPE_END((_ctx), _name); \
+    }
+
+
+/*
+ * Profile a function call which does not return a value, and specify explicit
+ * name string for the profile. Useful when calling a function by a pointer.
+ * Uses default profile context.
+ *
+ * Usage:
  *  UCS_PROFILE_NAMED_CALL_VOID("name", function, arg1, arg2)
  *
  * @param _name   Name string for the profile.
@@ -193,11 +268,7 @@ BEGIN_C_DECLS
  * @param ...     Function call arguments.
  */
 #define UCS_PROFILE_NAMED_CALL_VOID(_name, _func, ...) \
-    { \
-        UCS_PROFILE_SCOPE_BEGIN(); \
-        _func(__VA_ARGS__); \
-        UCS_PROFILE_SCOPE_END(_name); \
-    }
+    _UCS_PROFILE_CTX_NAMED_CALL_VOID(ucs_profile_default_ctx, _name, _func, ## __VA_ARGS__)
 
 
 /*
@@ -221,7 +292,8 @@ BEGIN_C_DECLS
  * @param _param32  Custom 32-bit parameter.
  */
 #define UCS_PROFILE_REQUEST_NEW(_req, _name, _param32) \
-    UCS_PROFILE(UCS_PROFILE_TYPE_REQUEST_NEW, (_name), (_param32), (uintptr_t)(_req));
+    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_NEW, \
+                           (_name), (_param32), (uintptr_t)(_req));
 
 
 /*
@@ -232,7 +304,8 @@ BEGIN_C_DECLS
  * @param _param32  Custom 32-bit parameter.
  */
 #define UCS_PROFILE_REQUEST_EVENT(_req, _name, _param32) \
-    UCS_PROFILE(UCS_PROFILE_TYPE_REQUEST_EVENT, (_name), (_param32), (uintptr_t)(_req));
+    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_EVENT, \
+                           (_name), (_param32), (uintptr_t)(_req));
 
 
 /*
@@ -255,13 +328,14 @@ BEGIN_C_DECLS
  * @param _req      Request pointer.
  */
 #define UCS_PROFILE_REQUEST_FREE(_req) \
-    UCS_PROFILE(UCS_PROFILE_TYPE_REQUEST_FREE, "", 0, (uintptr_t)(_req));
+    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_FREE, \
+                           "", 0, (uintptr_t)(_req));
 
 
 /*
  * Store a new record with the given data.
  * SHOULD NOT be used directly - use UCS_PROFILE macros instead.
- *
+ * @param [in]     ctx         Global profile context.
  * @param [in]     type        Location type.
  * @param [in]     name        Location name.
  * @param [in]     param32     custom 32-bit parameter.
@@ -271,16 +345,19 @@ BEGIN_C_DECLS
  * @param [in]     function    Calling function name.
  * @param [in,out] loc_id_p    Variable used to maintain the location ID.
  */
-void ucs_profile_record(ucs_profile_type_t type, const char *name,
-                        uint32_t param32, uint64_t param64, const char *file,
-                        int line, const char *function, volatile int *loc_id_p);
+void ucs_profile_record(ucs_profile_context_t *ctx, ucs_profile_type_t type,
+                        const char *name, uint32_t param32, uint64_t param64,
+                        const char *file, int line, const char *function,
+                        volatile int *loc_id_p);
 
 
 /**
  * Reset the internal array of profiling locations.
  * Used for testing purposes only.
+ *
+ * @param [in] ctx Global profile context.
  */
-void ucs_profile_reset_locations();
+void ucs_profile_reset_locations(ucs_profile_context_t *ctx);
 
 
 END_C_DECLS

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -87,6 +87,8 @@ static void ucs_modules_load()
 
 static void UCS_F_CTOR ucs_init()
 {
+    ucs_status_t status;
+
     ucs_check_cpu_flags();
     ucs_log_early_init(); /* Must be called before all others */
     ucs_global_opts_init();
@@ -97,7 +99,14 @@ static void UCS_F_CTOR ucs_init()
 #endif
     ucs_memtrack_init();
     ucs_debug_init();
-    ucs_profile_global_init();
+    status = ucs_profile_init(ucs_global_opts.profile_mode,
+                              ucs_global_opts.profile_file,
+                              ucs_global_opts.profile_log_size,
+                              &ucs_profile_default_ctx);
+    if (status != UCS_OK) {
+        ucs_fatal("failed to init ucs profile - aborting");
+    }
+
     ucs_async_global_init();
     ucs_topo_init();
     ucs_rand_seed_init();
@@ -111,7 +120,7 @@ static void UCS_F_DTOR ucs_cleanup(void)
 {
     ucs_topo_cleanup();
     ucs_async_global_cleanup();
-    ucs_profile_global_cleanup();
+    ucs_profile_cleanup(ucs_profile_default_ctx);
     ucs_debug_cleanup(0);
     ucs_memtrack_cleanup();
 #ifdef ENABLE_STATS

--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -19,28 +19,32 @@ extern "C" {
 class scoped_profile {
 public:
     scoped_profile(ucs::test_base& test, const std::string &file_name,
-                   const char *mode) : m_test(test), m_file_name(file_name)
-{
-        ucs_profile_global_cleanup();
-        ucs_profile_reset_locations();
+                   const char *mode) : m_test(test), m_file_name(file_name) {
+        ucs_profile_cleanup(ucs_profile_default_ctx);
         m_test.push_config();
         m_test.modify_config("PROFILE_MODE", mode);
         m_test.modify_config("PROFILE_FILE", m_file_name.c_str());
-        ucs_profile_global_init();
+        ucs_profile_init(ucs_global_opts.profile_mode,
+                         ucs_global_opts.profile_file,
+                         ucs_global_opts.profile_log_size,
+                         &ucs_profile_default_ctx);
     }
 
     std::string read() {
-        ucs_profile_dump();
+        ucs_profile_dump(ucs_profile_default_ctx);
         std::ifstream f(m_file_name.c_str());
         return std::string(std::istreambuf_iterator<char>(f),
                            std::istreambuf_iterator<char>());
     }
 
     ~scoped_profile() {
-        ucs_profile_global_cleanup();
+        ucs_profile_cleanup(ucs_profile_default_ctx);
         unlink(m_file_name.c_str());
         m_test.pop_config();
-        ucs_profile_global_init();
+        ucs_profile_init(ucs_global_opts.profile_mode,
+                         ucs_global_opts.profile_file,
+                         ucs_global_opts.profile_log_size,
+                         &ucs_profile_default_ctx);
     }
 private:
     ucs::test_base&   m_test;


### PR DESCRIPTION
## What
Extend ucs profiler API in order to support profiling external code.

## Why ?
These changes are needed to reuse ucs profiler in ucc.

## How ?
- Move ucs global opts out from profiler, pass them as profiler init arguments and store on context.
- Add global profiler context as a parameter to API functions so that ucx and ucc will have different contexts and can be profiled independently.
- API macros will be duplicated in ucc e.g. UCC_PROFILE_FUNC
