### PR TITLE
UCS/VFS: Added return status to add file/directory methods.

### DIFF
--- a/src/ucs/vfs/base/vfs_obj.h
+++ b/src/ucs/vfs/base/vfs_obj.h
@@ -152,9 +152,15 @@ typedef void (*ucs_vfs_list_dir_cb_t)(const char *name, void *arg);
  * @param [in] obj        Pointer to the object to be represented in VFS.
  * @param [in] rel_path   Format string which specifies relative path
  *                        @a obj directory.
+ *
+ * @return UCS_ERR_ALREADY_EXISTS if directory with specified name already
+ *                                exists.
+ *         UCS_ERR_INVALID_PARAM  if node for @a parent_obj does not exist.
+ *         UCS_ERR_NO_MEMORY      if cannot create a new node for @a obj.
+ *         UCS_OK                 otherwise.
  */
-void ucs_vfs_obj_add_dir(void *parent_obj, void *obj, const char *rel_path, ...)
-        UCS_F_PRINTF(3, 4);
+ucs_status_t ucs_vfs_obj_add_dir(void *parent_obj, void *obj,
+                                 const char *rel_path, ...) UCS_F_PRINTF(3, 4);
 
 
 /**
@@ -169,10 +175,16 @@ void ucs_vfs_obj_add_dir(void *parent_obj, void *obj, const char *rel_path, ...)
  * @param [in] arg_u64  Optional numeric argument that is passed to the callback
  *                      method.
  * @param [in] rel_path Format string which specifies relative path to the file.
+ *
+ * @return UCS_ERR_ALREADY_EXISTS if file with specified name already exists.
+ *         UCS_ERR_INVALID_PARAM  if node for @a obj does not exist.
+ *         UCS_ERR_NO_MEMORY      if cannot create a new node for @a obj.
+ *         UCS_OK                 otherwise.
  */
-void ucs_vfs_obj_add_ro_file(void *obj, ucs_vfs_file_show_cb_t text_cb,
-                             void *arg_ptr, uint64_t arg_u64,
-                             const char *rel_path, ...) UCS_F_PRINTF(5, 6);
+ucs_status_t ucs_vfs_obj_add_ro_file(void *obj, ucs_vfs_file_show_cb_t text_cb,
+                                     void *arg_ptr, uint64_t arg_u64,
+                                     const char *rel_path, ...)
+        UCS_F_PRINTF(5, 6);
 
 
 /**

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -257,3 +257,22 @@ UCS_MT_TEST_F(test_vfs_obj, set_dirty_and_refresh, 4) {
     barrier();
     ucs_vfs_obj_remove(&obj);
 }
+
+UCS_TEST_F(test_vfs_obj, check_ret) {
+    char obj1, obj2;
+
+    EXPECT_UCS_OK(ucs_vfs_obj_add_dir(NULL, &obj1, "obj"));
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS, ucs_vfs_obj_add_dir(NULL, &obj1, "obj"));
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, ucs_vfs_obj_add_dir(&obj2, &obj1, "obj"));
+
+    EXPECT_UCS_OK(ucs_vfs_obj_add_ro_file(&obj1, test_vfs_obj::file_show_cb,
+                                          NULL, 0, "info"));
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS,
+              ucs_vfs_obj_add_ro_file(&obj1, test_vfs_obj::file_show_cb, NULL,
+                                      0, "info"));
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              ucs_vfs_obj_add_ro_file(&obj2, test_vfs_obj::file_show_cb, NULL,
+                                      0, "info"));
+
+    ucs_vfs_obj_remove(&obj1);
+}


### PR DESCRIPTION
## What
Added return status to `ucs_vfs_obj_add_dir` and `ucs_vfs_obj_add_ro_file`.
The methods return:
- `UCS_ERR_ALREADY_EXISTS` if directory or file with specified name already exists.
- `UCS_ERR_INVALID_PARAM`  if node for parent object does not exist.
- `UCS_ERR_NO_MEMORY` if cannot create a new node.
- `UCS_OK` if everything is ok.


## Why ?
To be able to handle duplicate names while creating new directories or files. E.g.:
```C
while (ucs_vfs_obj_add_dir(NULL, rcache, "ucs/rcache/%s_%zu", rcache->name, i) ==
       UCS_ERR_ALREADY_EXISTS) {
    ++i;
}
```
