### PR TITLE
UCP/CORE: UCP ep name to VFS node.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2880,7 +2880,14 @@ void ucp_ep_vfs_init(ucp_ep_h ep)
 {
     ucp_err_handling_mode_t err_mode;
 
+#if ENABLE_DEBUG_DATA
+    ucs_vfs_obj_add_dir(ep->worker, ep, "ep/%s", ep->name);
+    ucs_vfs_obj_add_ro_file(ep, ucs_vfs_show_memory_address, NULL, 0,
+                            "memory_address");
+#else
     ucs_vfs_obj_add_dir(ep->worker, ep, "ep/%p", ep);
+#endif
+
     ucs_vfs_obj_add_ro_file(ep, ucp_ep_vfs_show_peer_name, NULL, 0,
                             "peer_name");
 


### PR DESCRIPTION
## What
Added name to VFS node representing UCP endpoint.
The name is available only if debug data is enabled.

![image](https://user-images.githubusercontent.com/74596089/118839046-da4a2c80-b8ce-11eb-8f7f-7b6af9fc575a.png)

