### PR TITLE
UCP/WORKER: fix error handling

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2623,6 +2623,26 @@ int ucp_ep_is_cm_local_connected(ucp_ep_h ep)
            (ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
 }
 
+int ucp_ep_is_local_connected(ucp_ep_h ep)
+{
+    int is_local_connected = !!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
+    ucp_wireup_ep_t *wireup_ep;
+    ucp_lane_index_t i;
+
+    if (ucp_ep_has_cm_lane(ep)) {
+        /* For CM case need to check all wireup lanes because transport lanes
+         * can be not connected yet. */
+        for (i = 0; is_local_connected && (i < ucp_ep_num_lanes(ep)); ++i) {
+            wireup_ep          = ucp_wireup_ep(ep->uct_eps[i]);
+            is_local_connected = (wireup_ep == NULL) ||
+                                 (wireup_ep->flags &
+                                  UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED);
+        }
+    }
+
+    return is_local_connected;
+}
+
 void ucp_ep_get_tl_bitmap(ucp_ep_h ep, ucp_tl_bitmap_t *tl_bitmap)
 {
     ucp_lane_index_t lane;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -621,6 +621,8 @@ uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep);
 
 int ucp_ep_is_cm_local_connected(ucp_ep_h ep);
 
+int ucp_ep_is_local_connected(ucp_ep_h ep);
+
 unsigned ucp_ep_local_disconnect_progress(void *arg);
 
 size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config_t *config);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -599,7 +599,7 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
     wireup_ep = ucp_wireup_ep(ucp_ep->uct_eps[lane]);
     if ((wireup_ep == NULL) ||
         !ucp_wireup_aux_ep_is_owner(wireup_ep, uct_ep) ||
-        !(ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
+        !ucp_ep_is_local_connected(ucp_ep)) {
         /* Failure on NON-AUX EP or failure on AUX EP before it sent its address
          * means failure on the UCP EP */
         return ucp_worker_set_ep_failed(worker, ucp_ep, uct_ep, lane, status);


### PR DESCRIPTION
## What
test all wireup lanes to define if the EP local connected in case of
presence CM lane

## Why ?

```
#0  0x00007eff9d429207 in raise () from /lib64/libc.so.6
#1  0x00007eff9d42a8f8 in abort () from /lib64/libc.so.6
#2  0x00007eff9f2b31d0 in ucs_fatal_error_message (file=0x7eff9f031186 "wireup/wireup_ep.c", line=610,
    function=0x7eff9f031d10 <__FUNCTION__.15913> "ucp_wireup_ep_mark_ready",
    message_buf=0x7ffe512a8460 "Assertion `wireup_ep->flags & UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED' failed")
    at debug/assert.c:38
#3  0x00007eff9f2b334b in ucs_fatal_error_format (file=0x7eff9f031186 "wireup/wireup_ep.c", line=610,
    function=0x7eff9f031d10 <__FUNCTION__.15913> "ucp_wireup_ep_mark_ready",
    format=0x7eff9f030e85 "Assertion `%s' failed") at debug/assert.c:53
#4  0x00007eff9efde108 in ucp_wireup_ep_mark_ready (uct_ep=0x25ee7e0) at wireup/wireup_ep.c:610
#5  0x00007eff9efde1ad in ucp_wireup_ep_remote_connected (uct_ep=0x25ee7e0) at wireup/wireup_ep.c:622
#6  0x00007eff9efe13e0 in ucp_wireup_remote_connected (ep=0x7eff942fe318) at wireup/wireup.c:421
#7  0x00007eff9eef911c in ucp_worker_iface_handle_uct_ep_failure (ucp_ep=0x7eff942fe318, lane=0 '\000',
    uct_ep=0x2889ed0, status=UCS_ERR_ENDPOINT_TIMEOUT) at core/ucp_worker.c:622
#8  0x00007eff9eef9401 in ucp_worker_iface_error_handler (arg=0x1866010, uct_ep=0x2889ed0,
    status=UCS_ERR_ENDPOINT_TIMEOUT) at core/ucp_worker.c:672
#9  0x00007eff9ec61e30 in uct_iface_handle_ep_err (iface=0x1b61040, ep=0x2889ed0,
    status=UCS_ERR_ENDPOINT_TIMEOUT) at base/uct_iface.c:318
#10 0x00007eff9c4bce6e in uct_rc_mlx5_iface_handle_failure (ib_iface=0x1b61040, arg=0x7eff94e2cf40,
    ep_status=UCS_ERR_ENDPOINT_TIMEOUT) at rc/accel/rc_mlx5_iface.c:262
#11 0x00007eff9c42d524 in uct_ib_mlx5_check_completion (iface=0x1b61040, cq=0x1b69778, cqe=0x7eff94e2cf40)
    at mlx5/ib_mlx5.c:361
#12 0x00007eff9c4aa490 in uct_ib_mlx5_poll_cq (cq=0x1b69778, iface=0x1b61040)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210519_081851_19906_13027_jazz01.swx.labs.mlnx/installs/hMfR/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.inl:81
#13 uct_rc_mlx5_iface_poll_tx (iface=0x1b61040) at rc/accel/rc_mlx5_iface.c:141
#14 uct_rc_mlx5_iface_progress (flags=2, arg=0x1b61040) at rc/accel/rc_mlx5_iface.c:178
#15 uct_rc_mlx5_iface_progress_cyclic (arg=0x1b61040) at rc/accel/rc_mlx5_iface.c:183
#16 0x00007eff9eef548b in ucs_callbackq_dispatch (cbq=0x17c1aa0)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210519_081851_19906_13027_jazz01.swx.labs.mlnx/installs/hMfR/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
#17 0x00007eff9ef02654 in uct_worker_progress (worker=0x17c1aa0)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210519_081851_19906_13027_jazz01.swx.labs.mlnx/installs/hMfR/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
#18 ucp_worker_progress (worker=0x1866010) at core/ucp_worker.c:2607
#19 0x0000000000403ddc in UcxContext::progress (this=0x7ffe512aa400) at ucx_wrapper.cc:211
#20 0x00000000004130a1 in DemoClient::wait_for_responses (this=0x7ffe512aa400, max_outstanding=1023)
    at io_demo.cc:1470
#21 0x0000000000414120 in DemoClient::run (this=0x7ffe512aa400) at io_demo.cc:1674
#22 0x000000000040ddc3 in do_client (test_opts=...) at io_demo.cc:2272
#23 0x000000000040e19a in main (argc=286, argv=0x7ffe512aab68) at io_demo.cc:2315
...
#6  0x00007eff9efe13e0 in ucp_wireup_remote_connected (ep=0x7eff942fe318) at wireup/wireup.c:421
421                 ucp_wireup_ep_remote_connected(ep->uct_eps[lane]);
(gdb) p lane
$1 = 1 '\001'
...
#7  0x00007eff9eef911c in ucp_worker_iface_handle_uct_ep_failure (ucp_ep=0x7eff942fe318, lane=0 '\000',
    uct_ep=0x2889ed0, status=UCS_ERR_ENDPOINT_TIMEOUT) at core/ucp_worker.c:622
```
the failure occurred on lane 0 (CM) but transport lane (1) is not locally connected yet, so need to handle error as expected in https://github.com/openucx/ucx/blob/07a31e8e7a0a7656521781441aabacadf831b438/src/ucp/core/ucp_worker.c#L603