### PR TITLE
UCP/CORE: Remove worker KA if no EPs for KA

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -546,9 +546,6 @@ void ucp_ep_delete(ucp_ep_h ep);
 
 void ucp_ep_release_id(ucp_ep_h ep);
 
-ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
-                                       ucp_wireup_ep_t **wireup_ep);
-
 ucs_status_t
 ucp_ep_create_to_worker_addr(ucp_worker_h worker,
                              const ucp_tl_bitmap_t *local_tl_bitmap,

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -303,7 +303,11 @@ typedef struct ucp_worker {
         ucs_time_t                   last_round;          /* Last round timestamp */
         ucs_list_link_t              *iter;               /* Last EP processed keepalive */
         ucp_lane_map_t               lane_map;            /* Lane map used to retry after no-resources */
+#if UCS_ENABLE_ASSERT
+        ucp_lane_map_t               init_lane_map;       /* Initial lane map taken from EP configuration */
+#endif
         unsigned                     ep_count;            /* Number of EPs processed in current time slot */
+        unsigned                     num_eps;             /* Total number of EPs processed in keepalive */
         unsigned                     iter_count;          /* Number of progress iterations to skip,
                                                            * used to minimize call of ucs_get_time */
         size_t                       round_count;         /* Number of rounds done */

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -328,6 +328,11 @@ ucp_wireup_cm_ep_cleanup(ucp_ep_t *ucp_ep, ucs_queue_head_t *queue)
         uct_ep_destroy(ucp_ep->uct_eps[lane_idx]);
         ucp_ep->uct_eps[lane_idx] = NULL;
     }
+
+    /* If the endpoint uses some configuration, need to remove from keepalive
+     * to make sure that won't do keepalive for the endpoint with empty
+     * 'ep_check_map' from the new configuration */
+    ucp_worker_keepalive_remove_ep(ucp_ep);
 }
 
 static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep,
@@ -415,6 +420,7 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
     }
 
     ep->am_lane = key.am_lane;
+    ucp_worker_keepalive_add_ep(ep);
 
     status = ucp_cm_ep_init_lanes(ep, &tl_bitmap, &dev_index);
     if (status != UCS_OK) {


### PR DESCRIPTION
## What

1. Remove KA progress function when no EPs with `ep_check_map != 0` to do KA anymore.
2. Remove/add EP from/to KA when reconfigure.

## Why ?

Fixes #6813 
It was broken in #6742, because it deletes adding EP to keepalive inside `ucp_cm_client_connect_progress()`. So, it can't detect an error before WIREUP_MSG phase.

1. To avoid calling KA progress function when it is not needed.
2. To make sure new configuration will be added only if `ep_check_map != 0`.

## How ?

1. When the number of KA EPs getting empty, do `uct_worker_progress_unregister_safe()`.
2. If the previous EP configuration index was `UCP_WORKER_CFG_INDEX_NULL`, remove EP from KA and when new configuration was applied - add EP to KA.