### PR TITLE
UCP/CORE: Block worker async before doing KA for EPs

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2745,6 +2745,8 @@ void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map)
     ucs_status_t status;
     ucp_rsc_index_t rsc_index;
 
+    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(ep->worker);
+
     if (ep->flags & UCP_EP_FLAG_FAILED) {
         *lane_map = 0;
         return;


### PR DESCRIPTION
## What

Block worker async before doing KA for EPs.

## Why ?

To prevent touching lanes which haven't initialized in `ucp_wireup_init_lanes()` yet.
- async thread
```
#0  ucp_wireup_init_lanes (ep=0x7fffe1f3a000, ep_init_flags=16, local_tl_bitmap=0x7ffff77f49b0 <ucp_tl_bitmap_max>, remote_address=0x7fffef19c520, addr_indices=0x7f
ffef19c420) at wireup/wireup.c:1352
#1  0x00007ffff77d2e37 in ucp_wireup_init_lanes_by_request (worker=0x6b7010, ep=0x7fffe1f3a000, ep_init_flags=16, remote_address=0x7fffef19c520, addr_indices=0x7fff
ef19c420) at wireup/wireup.c:434
#2  0x00007ffff77d356e in ucp_wireup_process_request (worker=0x6b7010, ep=0x7fffe1f3a000, msg=0x7fffeb659fb0, remote_address=0x7fffef19c520) at wireup/wireup.c:561
#3  0x00007ffff77d4456 in ucp_wireup_msg_handler (arg=0x6b7010, data=0x7fffeb659fb0, length=135, flags=1) at wireup/wireup.c:791
#4  0x00007ffff4a1a255 in uct_iface_invoke_am (iface=0x859640, id=1 '\001', data=0x7fffeb659fb0, length=135, flags=1) at /labhome/dmitrygla/work_auto/ucx/src/uct/ba
se/uct_iface.h:766
#5  0x00007ffff4a209e3 in uct_ib_iface_invoke_am_desc (ib_desc=0x7fffeb659f54, length=135, data=0x7fffeb659fb0, am_id=1 '\001', iface=0x859640)
    at /labhome/dmitrygla/work_auto/ucx/src/uct/ib/base/ib_iface.h:360
#6  uct_ud_ep_process_rx (iface=0x859640, neth=0x7fffeb659fa8, byte_len=143, skb=0x7fffeb659f54, is_async=1) at ud/base/ud_ep.c:926
#7  0x00007ffff4a428de in uct_ud_mlx5_iface_poll_rx (is_async=1, iface=0x859640) at ud/accel/ud_mlx5.c:510
#8  uct_ud_mlx5_iface_async_progress (ud_iface=0x859640) at ud/accel/ud_mlx5.c:578
#9  0x00007ffff4a15a3a in uct_ud_iface_async_progress (iface=0x859640) at ud/base/ud_iface.c:229
#10 0x00007ffff4a15a96 in uct_ud_iface_async_handler (fd=44, events=1 '\001', arg=0x859640) at ud/base/ud_iface.c:240
#11 0x00007ffff7a8607e in ucs_async_handler_invoke (handler=0x7de9d0, events=1 '\001') at async/async.c:249
#12 0x00007ffff7a8617b in ucs_async_handler_dispatch (handler=0x7de9d0, events=1 '\001') at async/async.c:271
#13 0x00007ffff7a863b8 in ucs_async_dispatch_handlers (handler_ids=0x7fffef19ccd0, count=1, events=1 '\001') at async/async.c:303
#14 0x00007ffff7a8a372 in ucs_async_thread_ev_handler (callback_data=0x2c, events=1 '\001', arg=0x7fffef19ce60) at async/thread.c:87
#15 0x00007ffff7ab0d8a in ucs_event_set_wait (event_set=0x6140f0, num_events=0x7fffef19ce7c, timeout_ms=-1, event_set_handler=0x7ffff7a8a270 <ucs_async_thread_ev_ha
ndler>, arg=0x7fffef19ce60)
    at sys/event_set.c:215
#16 0x00007ffff7a8a4ad in ucs_async_thread_func (arg=0x6140a0) at async/thread.c:130
#17 0x00007ffff6af7dd5 in start_thread () from /lib64/libpthread.so.0
#18 0x00007ffff61feead in clone () from /lib64/libc.so.6
```
- main thread (where it happens that `ep->uct_eps[1] == NULL`)
```
#0  ucp_ep_do_keepalive (ep=0x7fffe1f3a000, lane_map=0x6d6e98 "\003") at core/ucp_ep.c:2748
#1  0x00007ffff76f64a5 in ucp_worker_do_keepalive_progress (worker=0x6b7010) at core/ucp_worker.c:2999
#2  0x00007ffff76f691d in ucp_worker_keepalive_progress (arg=0x6b7010) at core/ucp_worker.c:3033
#3  0x00007ffff7a94414 in ucs_callbackq_slow_proxy (arg=0x617c90) at datastruct/callbackq.c:402
#4  0x00007ffff76e6563 in ucs_callbackq_dispatch (cbq=0x617c90) at /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
#5  0x00007ffff76f3a0b in uct_worker_progress (worker=0x617c90) at /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
#6  ucp_worker_progress (worker=0x6b7010) at core/ucp_worker.c:2628
#7  0x000000000040297d in run_ucx_server (ucp_worker=0x6b7010) at ucp_hello_world.c:380
#8  0x0000000000402e58 in run_test (client_target_name=0x0, ucp_worker=0x6b7010) at ucp_hello_world.c:504
#9  0x0000000000403332 in main (argc=6, argv=0x7fffffffe008) at ucp_hello_world.c:598
(gdb)
#0  ucp_ep_do_keepalive (ep=0x7fffe1f3a000, lane_map=0x6d6e98 "\003") at core/ucp_ep.c:2748
#1  0x00007ffff76f64a5 in ucp_worker_do_keepalive_progress (worker=0x6b7010) at core/ucp_worker.c:2999
#2  0x00007ffff76f691d in ucp_worker_keepalive_progress (arg=0x6b7010) at core/ucp_worker.c:3033
#3  0x00007ffff7a94414 in ucs_callbackq_slow_proxy (arg=0x617c90) at datastruct/callbackq.c:402
#4  0x00007ffff76e6563 in ucs_callbackq_dispatch (cbq=0x617c90) at /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
#5  0x00007ffff76f3a0b in uct_worker_progress (worker=0x617c90) at /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
#6  ucp_worker_progress (worker=0x6b7010) at core/ucp_worker.c:2628
#7  0x000000000040297d in run_ucx_server (ucp_worker=0x6b7010) at ucp_hello_world.c:380
#8  0x0000000000402e58 in run_test (client_target_name=0x0, ucp_worker=0x6b7010) at ucp_hello_world.c:504
#9  0x0000000000403332 in main (argc=6, argv=0x7fffffffe008) at ucp_hello_world.c:598
```

## How ?

Add async block-unblock after checking time in `ucp_worker_do_keepalive_progress()`