### PR TITLE
AZP/RELEASE: simplify release packages.

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -17,46 +17,29 @@ jobs:
       matrix:
         centos7_cuda10_1:
           build_container: centos7_cuda10_1
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda10.1.tar.bz2
+          artifact_name: $(POSTFIX)-centos-cuda10.1.tar.bz2
         centos7_cuda10_2:
           build_container: centos7_cuda10_2
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda10.2.tar.bz2
+          artifact_name: $(POSTFIX)-centos-cuda10.2.tar.bz2
         centos7_cuda11_0:
           build_container: centos7_cuda11_0
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda11.0.tar.bz2
+          artifact_name: $(POSTFIX)-centos-cuda11.0.tar.bz2
         centos7_cuda11_2:
           build_container: centos7_cuda11_2
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda11.2.tar.bz2
-        centos8_cuda11_0:
-          build_container: centos8_cuda11_0
-          artifact_name: $(POSTFIX)-centos8-mofed5.x-cuda11.0.tar.bz2
-        centos8_cuda11_2:
-          build_container: centos8_cuda11_2
-          artifact_name: $(POSTFIX)-centos8-mofed5.x-cuda11.2.tar.bz2
+          artifact_name: $(POSTFIX)-centos-cuda11.2.tar.bz2
         ubuntu16_cuda10_1:
           build_container: ubuntu16_cuda10_1
-          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5.x-cuda10.1.deb
+          artifact_name: $(POSTFIX)-ubuntu-cuda10.1.deb
         ubuntu16_cuda10_2:
           build_container: ubuntu16_cuda10_2
-          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5.x-cuda10.2.deb
-        ubuntu18_cuda10_1:
-          build_container: ubuntu18_cuda10_1
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda10.1.deb
-        ubuntu18_cuda10_2:
-          build_container: ubuntu18_cuda10_2
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda10.2.deb
-        ubuntu18_cuda11_0:
-          build_container: ubuntu18_cuda11_0
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda11.0.deb
-        ubuntu18_cuda11_2:
-          build_container: ubuntu18_cuda11_2
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda11.2.deb
-        ubuntu20_cuda11_0:
-          build_container: ubuntu20_cuda11_0
-          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5.x-cuda11.0.deb
-        ubuntu20_cuda11_2:
-          build_container: ubuntu20_cuda11_2
-          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5.x-cuda11.2.deb
+          artifact_name: $(POSTFIX)-ubuntu-cuda10.2.deb
+        ubuntu16_cuda11_0:
+          build_container: ubuntu16_cuda11_0
+          artifact_name: $(POSTFIX)-ubuntu-cuda11.0.deb
+        ubuntu16_cuda11_2:
+          build_container: ubuntu16_cuda11_2
+          artifact_name: $(POSTFIX)-ubuntu-cuda11.2.deb
+
 
     container: $[ variables['build_container'] ]
 

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -27,6 +27,10 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.1:1
     - container: ubuntu16_cuda10_2
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.2:1
+    - container: ubuntu16_cuda11_0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda11.0:1
+    - container: ubuntu16_cuda11_2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda11.2:1
     - container: ubuntu18_cuda10_1
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.1:1
     - container: ubuntu18_cuda10_2


### PR DESCRIPTION
## What
Build release packages on the lowest supported OS, and remove OS component from a build matrix.

## Why?
It's enough to build on the lowest libc library, thus simplify release packages. Only vary by cuda version.