### PR TITLE
UCP/UCS: Fixing broken doxygen references

### DIFF
--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -3,6 +3,7 @@
 * Copyright (C) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
 * Copyright (C) IBM 2015. ALL RIGHTS RESERVED.
 * Copyright (C) Los Alamos National Security, LLC. 2018. ALL RIGHTS RESERVED.
+* Copyright (C) Arm, Ltd. 2021. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -507,7 +508,7 @@ typedef void (*ucp_tag_recv_callback_t)(void *request, ucs_status_t status,
  *                        @ref UCS_ERR_MESSAGE_TRUNCATED error code is returned.
  *                        Otherwise, an @ref ucs_status_t "error status" is
  *                        returned.
- * @param [in]  info      @ref ucp_tag_recv_info_t "Completion information"
+ * @param [in]  tag_info  @ref ucp_tag_recv_info_t "Completion information"
  *                        The @a info descriptor is Valid only if the status is
  *                        UCS_OK.
  * @param [in]  user_data User data passed to "user_data" value,

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
+* Copyright (C) Arm, Ltd. 2021. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -123,9 +124,9 @@
 /**
  * Get a pointer to a struct containing a member.
  *
- * @param __ptr   Pointer to the member.
- * @param type    Container type.
- * @param member  Element member inside the container.
+ * @param _ptr     Pointer to the member.
+ * @param _type    Container type.
+ * @param _member  Element member inside the container.
 
  * @return Address of the container structure.
  */


### PR DESCRIPTION
## What
This part of documentation improvement efforts.
## Why
This references break clean doxygen generation.
## How
Manual debug