### PR TITLE
UCT/MD: added md_dereg_v2 implementation

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -482,6 +482,12 @@ ucs_status_t uct_md_mem_dereg(uct_md_h md, uct_mem_h memh)
     return md->ops->mem_dereg(md, &params);
 }
 
+ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
+                                 const uct_md_mem_dereg_params_t *params)
+{
+    return md->ops->mem_dereg(md, params);
+}
+
 ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,
                               uct_md_mem_attr_t *mem_attr)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -33,10 +33,17 @@
     if (!UCT_MD_MEM_DEREG_FIELD_VALUE(_params, memh, FIELD_MEMH, NULL)) { \
         return UCS_ERR_INVALID_PARAM; \
     } \
-    if (ENABLE_PARAMS_CHECK && !(_invalidate_supported) && \
-        (UCT_MD_MEM_DEREG_FIELD_VALUE(_params, flags, FIELD_FLAGS, 0) & \
-                UCT_MD_MEM_DEREG_FLAG_INVALIDATE)) { \
-        return UCS_ERR_UNSUPPORTED; \
+    if (ENABLE_PARAMS_CHECK) { \
+        if (UCT_MD_MEM_DEREG_FIELD_VALUE(_params, flags, FIELD_FLAGS, 0) & \
+            UCT_MD_MEM_DEREG_FLAG_INVALIDATE) { \
+            if (!(_invalidate_supported)) { \
+                return UCS_ERR_UNSUPPORTED; \
+            } \
+            if (!UCT_MD_MEM_DEREG_FIELD_VALUE(params, cb, FIELD_CALLBACK, \
+                                              NULL)) { \
+                return UCS_ERR_INVALID_PARAM; \
+            } \
+        } \
     }
 
 

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -54,6 +54,10 @@ protected:
         return m_md_attr;
     }
 
+    static void dereg_cb(void *arg);
+
+    size_t                        m_comp_count;
+
 private:
     ucs::handle<uct_md_config_t*> m_md_config;
     ucs::handle<uct_md_h>         m_md;


### PR DESCRIPTION
- added uct_md_mem_dereg_v2 implementation
- added support of memory invalidation into IB memory
  domain
- improved UCT_MD_MEM_DEREG_CHECK_PARAMS macro
- added gtest for new API
