### PR TITLE
GTEST: fix race condition on client user data in test_uct_sockaddr

### DIFF
--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1212,8 +1212,6 @@ uct_test::entity::connect_to_sockaddr(unsigned index,
     uct_ep_h ep;
     ucs_status_t status;
 
-    ucs::scoped_async_lock lock(async());
-
     reserve_ep(index);
     ASSERT_FALSE(m_eps[index]) << "Already connected";
 


### PR DESCRIPTION
## What
add lock on async to prevent race of accessing user data

## Why ?
bugfix

## How ?
lock async thread until user data is added to `m_ep_client_data`