### PR TITLE
UCT/IB/DC: Resend FC_HARD_REQ when FC window is 0

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -96,6 +96,11 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      "there are other endpoints waiting for it.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, quota), UCS_CONFIG_TYPE_UINT},
 
+    {"FC_HARD_REQ_TIMEOUT", "5s",
+     "Timeout for re-sending FC_HARD_REQ when FC window is empty.",
+     ucs_offsetof(uct_dc_mlx5_iface_config_t, fc_hard_req_timeout),
+     UCS_CONFIG_TYPE_TIME_UNITS},
+
     {NULL}
 };
 
@@ -1089,7 +1094,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
 
         it = kh_get(uct_dc_mlx5_fc_hash, &iface->tx.fc_hash, sender->ep);
         if ((it == kh_end(&iface->tx.fc_hash)) ||
-            (kh_value(&iface->tx.fc_hash, it) != sender->payload.seq)) {
+            (kh_value(&iface->tx.fc_hash, it).seq != sender->payload.seq)) {
             /* Just ignore, ep was removed. We either not expecting grant on
              * this EP or this is not the same grant sequence number we are
              * expecting. */
@@ -1102,7 +1107,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
         /* Peer granted resources, so update wnd */
         ep->fc.fc_wnd = rc_iface->config.fc_wnd_size;
 
-        /* Remove entry for flush to complete  */
+        /* Remove entry for flush to complete */
         kh_del(uct_dc_mlx5_fc_hash, &iface->tx.fc_hash, it);
 
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_PURE_GRANT, 1);
@@ -1285,6 +1290,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     self->tx.ndci                          = config->ndci;
     self->tx.policy                        = (uct_dc_tx_policy_t)config->tx_policy;
     self->tx.fc_seq                        = 0;
+    self->tx.fc_hard_req_timeout           = config->fc_hard_req_timeout;
     self->keepalive_dci                    = -1;
     self->tx.num_dci_pools                 = 1;
     self->super.super.config.tx_moderation = 0; /* disable tx moderation for dcs */

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -135,6 +135,7 @@ typedef struct uct_dc_mlx5_iface_config {
     int                                 dct_full_handshake;
     unsigned                            quota;
     unsigned                            rand_seed;
+    ucs_time_t                          fc_hard_req_timeout;
     uct_ud_mlx5_iface_common_config_t   mlx5_ud;
 } uct_dc_mlx5_iface_config_t;
 
@@ -186,7 +187,13 @@ typedef struct uct_dc_fc_request {
 } uct_dc_fc_request_t;
 
 
-KHASH_MAP_INIT_INT64(uct_dc_mlx5_fc_hash, uint64_t);
+typedef struct uct_dc_mlx5_ep_fc_entry {
+    uint64_t   seq; /* Sequence number in FC_HARD_REQ's sender data */
+    ucs_time_t send_time; /* Last time FC_HARD_REQ was sent */
+} uct_dc_mlx5_ep_fc_entry_t;
+
+
+KHASH_MAP_INIT_INT64(uct_dc_mlx5_fc_hash, uct_dc_mlx5_ep_fc_entry_t);
 
 
 typedef struct {
@@ -223,6 +230,9 @@ struct uct_dc_mlx5_iface {
 
         /* Sequence number of expected FC grants */
         uint64_t                  fc_seq;
+
+        /* Timeout for sending FC_HARD_REQ when FC window is empty */
+        ucs_time_t                fc_hard_req_timeout;
 
         /* Seed used for random dci allocation */
         unsigned                  rand_seed;

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -592,12 +592,11 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
                          (_iface)->super.super.config.fc_hard_thresh)) { \
             ucs_status_t _status = uct_dc_mlx5_ep_check_fc(_iface, _ep); \
             if (ucs_unlikely(_status != UCS_OK)) { \
-                if (((_ep)->dci != UCT_DC_MLX5_EP_NO_DCI) && \
-                    !uct_dc_mlx5_iface_is_dci_rand(_iface)) { \
-                    ucs_assertv_always(uct_dc_mlx5_iface_dci_has_outstanding(_iface, \
-                                                                             (_ep)->dci), \
-                                       "iface (%p) ep (%p) dci leak detected: dci=%d", \
-                                       _iface, _ep, (_ep)->dci); \
+                if ((_ep)->fc.fc_wnd <= 0) { \
+                    UCS_STATS_UPDATE_COUNTER((_ep)->fc.stats, \
+                                             UCT_RC_FC_STAT_NO_CRED, 1); \
+                    UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, \
+                                             UCT_EP_STAT_NO_RES, 1); \
                 } \
                 return _status; \
             } \


### PR DESCRIPTION
## What

Resend FC_HARD_REQ when FC window is 0.

## Why ?

Timeout waiting for replies was reproduced in IO-demo application under high load and doing port up/down for some port.
Doing port up/down affects DC Flow Control (FC) EP which detects error on DCI which was assigned to send data to a peer on failed nodes and on normal ones. So, FC_PURE_GRANT could be missed during recovering from error. And sender's EP is waiting for FC_PURE_GRANT endlessly. 

## How ?

The fix is to do resend of FC_HARD_REQ packet every `fc_hard_req_timeout` (default=5) seconds from sender's side when window reaches `0` to receive FC_PURE_GRANT and unblock TX.