### PR TITLE
API/UCP/ERR-HANDLING: added memory invalidation on error

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2812,6 +2812,19 @@ int ucp_ep_do_keepalive(ucp_ep_h ep)
     return 0;
 }
 
+static void ucp_ep_req_purge_send(ucp_request_t *req, ucs_status_t status)
+{
+    if ((status != UCS_OK) &&
+        (ucp_ep_config(req->send.ep)->key.err_mode !=
+         UCP_ERR_HANDLING_MODE_NONE) &&
+        (req->flags & UCP_REQUEST_FLAG_RKEY_INUSE)) {
+        ucp_request_dt_invalidate(req, status);
+        return;
+    }
+
+    ucp_request_complete_and_dereg_send(req, status);
+}
+
 static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
                              ucs_status_t status, int recursive)
 {
@@ -2827,7 +2840,7 @@ static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
     if (req->flags & (UCP_REQUEST_FLAG_SEND_AM | UCP_REQUEST_FLAG_SEND_TAG)) {
         ucs_assert(!(req->flags & UCP_REQUEST_FLAG_SUPER_VALID));
         ucs_assert(req->send.ep == ucp_ep);
-        ucp_request_complete_and_dereg_send(req, status);
+        ucp_ep_req_purge_send(req, status);
     } else if (req->flags & UCP_REQUEST_FLAG_RECV_AM) {
         ucs_assert(!(req->flags & UCP_REQUEST_FLAG_SUPER_VALID));
         ucs_assert(recursive); /* Mustn't be directly contained in an EP list

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -50,10 +50,11 @@ enum {
     UCP_REQUEST_FLAG_RNDV_FRAG             = UCS_BIT(15),
     UCP_REQUEST_FLAG_RECV_AM               = UCS_BIT(16),
     UCP_REQUEST_FLAG_RECV_TAG              = UCS_BIT(17),
+    UCP_REQUEST_FLAG_RKEY_INUSE            = UCS_BIT(18),
 #if UCS_ENABLE_ASSERT
-    UCP_REQUEST_FLAG_STREAM_RECV           = UCS_BIT(18),
-    UCP_REQUEST_DEBUG_FLAG_EXTERNAL        = UCS_BIT(19),
-    UCP_REQUEST_FLAG_SUPER_VALID           = UCS_BIT(20)
+    UCP_REQUEST_FLAG_STREAM_RECV           = UCS_BIT(19),
+    UCP_REQUEST_DEBUG_FLAG_EXTERNAL        = UCS_BIT(20),
+    UCP_REQUEST_FLAG_SUPER_VALID           = UCS_BIT(21)
 #else
     UCP_REQUEST_FLAG_STREAM_RECV           = 0,
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL        = 0,
@@ -439,6 +440,8 @@ ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
 
 void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
                               ucp_dt_state_t *state, ucp_request_t *req_dbg);
+
+void ucp_request_dt_invalidate(ucp_request_t *req, ucs_status_t status);
 
 ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
                                     size_t zcopy_thresh, size_t zcopy_max,

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -221,6 +221,8 @@ ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq)
         if (status != UCS_OK) {
             return status;
         }
+
+        sreq->flags |= UCP_REQUEST_FLAG_RKEY_INUSE;
     }
 
     return UCS_OK;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -126,10 +126,9 @@ typedef struct {
  * @brief MD memory de-registration operation flags.
  */
 typedef enum {
-    UCT_MD_MEM_DEREG_FIELD_MEMH     = UCS_BIT(0), /**< memh field */
-    UCT_MD_MEM_DEREG_FIELD_FLAGS    = UCS_BIT(1), /**< flags field */
-    UCT_MD_MEM_DEREG_FIELD_CALLBACK = UCS_BIT(2), /**< cb field */
-    UCT_MD_MEM_DEREG_FIELD_ARG      = UCS_BIT(3)  /**< arg field */
+    UCT_MD_MEM_DEREG_FIELD_MEMH       = UCS_BIT(0), /**< memh field */
+    UCT_MD_MEM_DEREG_FIELD_FLAGS      = UCS_BIT(1), /**< flags field */
+    UCT_MD_MEM_DEREG_FIELD_COMPLETION = UCS_BIT(2)  /**< comp field */
 } uct_md_mem_dereg_field_mask_t;
 
 
@@ -182,14 +181,10 @@ typedef struct uct_md_mem_dereg_params {
     uct_mem_h                    memh;
 
     /**
-     * Callback function that is invoked when region is invalidated.
+     * Pointer to UCT completion object that is invoked when region is
+     * invalidated.
      */
-    uct_md_mem_invalidate_cb_t   cb;
-
-    /**
-     * User-defined argument for the callback function.
-     */
-    void                         *arg;
+    uct_completion_t             *comp;
 } uct_md_mem_dereg_params_t;
 
 

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -39,7 +39,7 @@
             if (!(_invalidate_supported)) { \
                 return UCS_ERR_UNSUPPORTED; \
             } \
-            if (!UCT_MD_MEM_DEREG_FIELD_VALUE(params, cb, FIELD_CALLBACK, \
+            if (!UCT_MD_MEM_DEREG_FIELD_VALUE(params, comp, FIELD_COMPLETION, \
                                               NULL)) { \
                 return UCS_ERR_INVALID_PARAM; \
             } \

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -209,6 +209,22 @@ void ucp_test::disconnect(entity& e) {
     }
 }
 
+ucp_tag_message_h ucp_test::message_wait(entity& e, ucp_tag_t tag,
+                                         ucp_tag_t tag_mask,
+                                         ucp_tag_recv_info_t *info, int remove,
+                                         int worker_index)
+{
+    ucs_time_t deadline = ucs::get_deadline();
+    ucp_tag_message_h message;
+    do {
+        progress(worker_index);
+        message = ucp_tag_probe_nb(e.worker(worker_index), tag, tag_mask,
+                                   remove, info);
+    } while ((message == NULL) && (ucs_get_time() < deadline));
+
+    return message;
+}
+
 ucs_status_t ucp_test::request_process(void *req, int worker_index, bool wait)
 {
     if (req == NULL) {
@@ -1058,4 +1074,9 @@ ucp_mem_h ucp_test::mapped_buffer::memh() const
 void test_ucp_context::get_test_variants(std::vector<ucp_test_variant> &variants)
 {
     add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP);
+}
+
+void ucp_test::disable_keepalive()
+{
+    modify_config("KEEPALIVE_INTERVAL", "inf");
 }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -211,6 +211,8 @@ public:
     void stats_activate();
     void stats_restore();
 
+    void disable_keepalive();
+
 private:
     static void set_ucp_config(ucp_config_t *config, const std::string& tls);
     static bool check_tls(const std::string& tls);
@@ -236,6 +238,9 @@ protected:
     void disconnect(entity& entity);
     ucs_status_t request_wait(void *req, int worker_index = 0);
     ucs_status_t requests_wait(std::vector<void*> &reqs, int worker_index = 0);
+    ucp_tag_message_h message_wait(entity& e, ucp_tag_t tag, ucp_tag_t tag_mask,
+                                   ucp_tag_recv_info_t *info, int remove = 1,
+                                   int worker_index = 0);
     void request_release(void *req);
     int max_connections();
     void set_tl_timeouts(ucs::ptr_vector<ucs::scoped_setenv> &env);

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -54,7 +54,16 @@ protected:
         return m_md_attr;
     }
 
-    static void dereg_cb(void *arg);
+    typedef struct {
+        test_md          *self;
+        uct_completion_t comp;
+    } test_md_comp_t;
+
+    test_md_comp_t &comp() {
+        return m_comp;
+    }
+
+    static void dereg_cb(uct_completion_t *comp);
 
     size_t                        m_comp_count;
 
@@ -62,6 +71,7 @@ private:
     ucs::handle<uct_md_config_t*> m_md_config;
     ucs::handle<uct_md_h>         m_md;
     uct_md_attr_t                 m_md_attr;
+    test_md_comp_t                m_comp;
 };
 
 


### PR DESCRIPTION
## Why
Invalidate remote key of UCP rendezvous requests when force-closeing an endpoint, to prevent the remote peer from accessing the memory. 

## How
- Start invalidation process during ep requests purge and complete when mem region is not used any more
- After this point the memory will not be accessed remotely so it's OK to release the region
- Enable only for RDNV RTS requests and for one-sided transports such as DC