### PR TITLE
IODEMO: add UcxLog life time

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -2060,8 +2060,8 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
     test_opts->use_am                = false;
     test_opts->memory_type           = UCS_MEMORY_TYPE_HOST;
 
-    while ((c = getopt(argc, argv, "p:c:r:d:b:i:w:a:k:o:t:n:l:s:y:vqAHP:m:")) !=
-           -1) {
+    while ((c = getopt(argc, argv,
+                       "p:c:r:d:b:i:w:a:k:o:t:n:l:s:y:vqAHP:m:L:")) != -1) {
         switch (c) {
         case 'p':
             test_opts->port_num = atoi(optarg);
@@ -2179,6 +2179,9 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
         case 'H':
             UcxLog::use_human_time = true;
             break;
+        case 'L':
+            UcxLog::timeout_sec = atof(optarg);
+            break;
         case 'P':
             test_opts->print_interval = atof(optarg);
             break;
@@ -2228,6 +2231,7 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
             std::cout << "  -q                          Enable data integrity and transaction check" << std::endl;
             std::cout << "  -A                          Use UCP Active Messages API (use TAG API otherwise)" << std::endl;
             std::cout << "  -H                          Use human-readable timestamps" << std::endl;
+            std::cout << "  -L <logger life-time>       Set life time of logger object, if log message print takes longer, warning will be printed" << std::endl;
             std::cout << "  -P <interval>               Set report printing interval"  << std::endl;
             std::cout << "" << std::endl;
             std::cout << "  -m <memory_type>            Memory type to use. Possible values: host"

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -54,7 +54,9 @@ public:
  */
 class UcxLog {
 public:
-    static bool use_human_time;
+    static bool         use_human_time;
+    static double       timeout_sec;
+    static const double timeout_inf;
 
     UcxLog(const char* prefix, bool enable = true);
     ~UcxLog();
@@ -68,6 +70,10 @@ public:
     }
 
 private:
+    void check_timeout() const;
+
+private:
+    struct timeval           _tv;
     std::stringstream        *_ss;
 };
 
@@ -115,6 +121,8 @@ public:
                                           size_t addrlen);
 
     void destroy_connections();
+
+    static double get_time(const struct timeval &tv);
 
     static double get_time();
 


### PR DESCRIPTION
## What
add UcxLog life time, new command line parameter parameter `-L`, example:

```
$ io_demo 2.1.3.2:1337 -d 512:524288 -P 2 -o read,write -i 0 -w 16 -t 10 -L 4e-05
...
[1622031973.935931] [UCX-connection #1 0.0.0.0:0] created new connection 0x14eff20 total: 1
[1622031973.935947] [UCX-connection #1 2.1.3.2:1337] Connecting to 2.1.3.2:1337
[1622031973.936152] [UCX-connection #1 2.1.3.2:1337] created endpoint 0x7f4db2826000, connection id 1
[1622031973.942050] [UCX] added [UCX-connection #1 2.1.3.2:1337] to connection map
[1622031973.996871] [UCX-connection #1 2.1.3.2:1337] Remote id is 17
WARNING: too long living (4.60148e-05 from 4e-05 sec) UcxLog object: [1622031973.996871] [UCX-connection #1 2.1.3.2:1337] Remote id is 17
[1622031973.996992] [DEMO] Connected to server [0] 2.1.3.2:1337 after 1 attempts
[1622031975.936157] [DEMO] read 10172.8 MB/s min:81179 (2.1.3.2:1337) max:81179 total:81179 ops, write 10184.7 MB/s min:81182 (2.1.3.2:1337) max:81182 total:81182 ops, active:1, buffers:20
WARNING: too long living (4.60148e-05 from 4e-05 sec) UcxLog object: [1622031975.936157] [DEMO] read 10172.8 MB/s min:81179 (2.1.3.2:1337) max:81179 total:81179 ops, write 10184.7 MB/s min:81182 (2.1.3.2:1337) max:81182 total:81182 ops, active:1, buffers:20
[1622031977.936151] [DEMO] read 10540.6 MB/s min:84217 (2.1.3.2:1337) max:84217 total:84217 ops, write 10523.2 MB/s min:84213 (2.1.3.2:1337) max:84213 total:84213 ops, active:1, buffers:21
[1622031979.936264] [DEMO] read 10551.7 MB/s min:84394 (2.1.3.2:1337) max:84394 total:84394 ops, write 10564.4 MB/s min:84406 (2.1.3.2:1337) max:84406 total:84406 ops, active:1, buffers:22
[1622031981.936360] [DEMO] read 10567.2 MB/s min:84646 (2.1.3.2:1337) max:84646 total:84646 ops, write 10635.7 MB/s min:84654 (2.1.3.2:1337) max:84654 total:84654 ops, active:1, buffers:22
[1622031983.936434] [DEMO] read 10613.2 MB/s min:84911 (2.1.3.2:1337) max:84911 total:84911 ops, write 10624.9 MB/s min:84889 (2.1.3.2:1337) max:84889 total:84889 ops, active:1, buffers:22
WARNING: too long living (4.00543e-05 from 4e-05 sec) UcxLog object: [1622031983.936434] [DEMO] read 10613.2 MB/s min:84911 (2.1.3.2:1337) max:84911 total:84911 ops, write 10624.9 MB/s min:84889 (2.1.3.2:1337) max:84889 total:84889 ops, active:1, buffers:22
```

## Why ?
To detect slow file system issues at scale

