### PR TITLE
UCT/IB/DC: Remove extra lookup EP from DCI

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1144,7 +1144,6 @@ static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
         return;
     }
 
-    ep = uct_dc_mlx5_ep_from_dci(iface, dci_index);
     uct_dc_mlx5_ep_handle_failure(ep, cqe, status);
 }
 


### PR DESCRIPTION
## What

Remove extra lookup EP from DCI.

## Why ?

Lookup EP is already done in `src/uct/ib/dc/dc_mlx5.c:1136`.

## How ?

Remove invoking `ep = uct_dc_mlx5_ep_from_dci(iface, dci_index);`