### PR TITLE
UCT/IB/DC: Resend FC_PURE_GRANT in case of CQE failure

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -273,8 +273,6 @@ void uct_dc_mlx5_iface_set_quota(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_iface_c
 
 ucs_status_t uct_dc_mlx5_iface_init_fc_ep(uct_dc_mlx5_iface_t *iface);
 
-void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface);
-
 ucs_status_t uct_dc_mlx5_iface_fc_grant(uct_pending_req_t *self);
 
 ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -184,7 +184,11 @@ ucs_status_t uct_dc_mlx5_ep_fence(uct_ep_h tl_ep, unsigned flags);
 ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 
 ucs_status_t uct_dc_mlx5_ep_fc_pure_grant_send(uct_dc_mlx5_ep_t *ep,
-                                               uct_dc_fc_request_t *fc_req);
+                                               uct_rc_iface_send_op_t *send_op);
+
+void
+uct_dc_mlx5_ep_fc_pure_grant_send_completion(uct_rc_iface_send_op_t *send_op,
+                                             const void *resp);
 
 ucs_arbiter_cb_result_t
 uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -450,6 +450,9 @@ void uct_rc_txqp_purge_outstanding(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
+        op->status = status;
+        op->flags |= UCT_RC_IFACE_SEND_OP_STATUS;
+
         if (op->handler != (uct_rc_send_handler_t)ucs_mpool_put) {
             /* Allow clean flush cancel op from destroy flow */
             if (warn &&


### PR DESCRIPTION
## What

Resend `FC_PURE_GRANT` in case of CQE failure.

## Why ?

To re-send `FC_PURE_GRANT` packets which are failed to be sent due to error detected to another peer.

## How ?

1. Add `FC_PURE_GRANT` operation to TX outstanding.
2. Resend `FC_PURE_GRANT` in case of CQE status is `FLUSH_ERR` - this is done when purging TX QP outstanding operations during error handling.