### PR TITLE
UCS/LOG: Add log filter by source file name.

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -20,7 +20,7 @@
 
 
 ucs_global_opts_t ucs_global_opts = {
-    .log_component         = {UCS_LOG_LEVEL_WARN, "UCX"},
+    .log_component         = {UCS_LOG_LEVEL_WARN, "UCX", "*"},
     .log_print_enable      = 0,
     .log_file              = "",
     .log_file_size         = SIZE_MAX,
@@ -71,8 +71,15 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "UCS logging level. Messages with a level higher or equal to the selected "
   "will be printed.\n"
   "Possible values are: fatal, error, warn, info, debug, trace, data, func, poll.",
-  ucs_offsetof(ucs_global_opts_t, log_component),
+  ucs_offsetof(ucs_global_opts_t, log_component.log_level),
   UCS_CONFIG_TYPE_LOG_COMP},
+
+ {"LOG_FILE_FILTER", "*",
+  "Set a filter for log message according to source file path. See glob (7) for\n"
+  "pattern syntax.\n"
+  "NOTE: The source file path must fully match the given pattern.",
+  ucs_offsetof(ucs_global_opts_t, log_component.file_filter),
+               UCS_CONFIG_TYPE_STRING},
 
  {"LOG_FILE", "",
   "If not empty, UCS will print log messages to the specified file instead of stdout.\n"

--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -139,12 +139,14 @@ typedef struct ucs_sock_addr {
     socklen_t                addrlen;   /**< Address length */
 } ucs_sock_addr_t;
 
+
 /**
  * Logging component.
  */
 typedef struct ucs_log_component_config {
     ucs_log_level_t log_level;
     char            name[16];
+    const char      *file_filter; /* glob pattern of source files */
 } ucs_log_component_config_t;
 
 #endif /* TYPES_H_ */

--- a/test/gtest/ucs/test_log.cc
+++ b/test/gtest/ucs/test_log.cc
@@ -166,15 +166,17 @@ protected:
 
 class log_test_info : public log_test {
 protected:
-    log_test_info() : m_spacer("  "), m_log_str("hello world")
+    log_test_info() :
+        m_spacer("  "), m_log_str("hello world"), m_exp_found(true)
     {
     }
 
     virtual void check_log_file()
     {
         std::string log_str = "UCX  INFO" + m_spacer + m_log_str;
-        if (!do_grep(log_str)) {
-            ADD_FAILURE() << read_logfile();
+        if (m_exp_found != do_grep(log_str)) {
+            ADD_FAILURE() << read_logfile() << " Expected to "
+                          << (m_exp_found ? "" : "not ") << "find " << log_str;
         }
     }
 
@@ -185,6 +187,7 @@ protected:
 
     std::string m_spacer;
     std::string m_log_str;
+    bool m_exp_found;
 };
 
 UCS_TEST_F(log_test_info, hello) {
@@ -196,6 +199,15 @@ UCS_TEST_F(log_test_info, hello_indent) {
     log_info();
     ucs_log_indent(-1);
     m_spacer += "  ";
+}
+
+UCS_TEST_F(log_test_info, filter_on, "LOG_FILE_FILTER=*test_lo*.cc") {
+    log_info();
+}
+
+UCS_TEST_F(log_test_info, filter_off, "LOG_FILE_FILTER=file.c") {
+    log_info();
+    m_exp_found = false;
 }
 
 class log_test_print : public log_test {


### PR DESCRIPTION
# Why
Allow filtering log messages by file name to get a more precise log output.
Reminder: the default log level for release build is now "debug".

# How
- Add glob-syntax config for log filter
- Use hash table to cache result of glob pattern matching

@Sergei-Lebedev  @dmitrygx 