### PR TITLE
UCP/CORE: Use TIME_UNITS for KA interval configuration

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -315,8 +315,9 @@ static ucs_config_field_t ucp_config_table[] = {
 
   /* TODO: set for keepalive more reasonable values */
   {"KEEPALIVE_INTERVAL", "60s",
-   "Time interval between keepalive rounds (0 - disabled).",
-   ucs_offsetof(ucp_config_t, ctx.keepalive_interval), UCS_CONFIG_TYPE_TIME},
+   "Time interval between keepalive rounds.",
+   ucs_offsetof(ucp_config_t, ctx.keepalive_interval),
+   UCS_CONFIG_TYPE_TIME_UNITS},
 
   {"KEEPALIVE_NUM_EPS", "128",
    "Maximal number of endpoints to check on every keepalive round\n"
@@ -1472,7 +1473,6 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
         goto err_free_alloc_methods;
     }
 
-    context->config.keepalive_interval = ucs_time_from_sec(context->config.ext.keepalive_interval);
     return UCS_OK;
 
 err_free_alloc_methods:

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -107,8 +107,8 @@ typedef struct ucp_context_config {
     size_t                                 listener_backlog;
     /** Enable new protocol selection logic */
     int                                    proto_enable;
-    /** Time period between keepalive rounds (0 - disabled) */
-    double                                 keepalive_interval;
+    /** Time period between keepalive rounds */
+    ucs_time_t                             keepalive_interval;
     /** Maximal number of endpoints to check on every keepalive round
      * (0 - disabled, inf - check all endpoints on every round) */
     unsigned                               keepalive_num_eps;
@@ -252,9 +252,6 @@ typedef struct ucp_context {
 
         /* Config environment prefix used to create the context */
         char                      *env_prefix;
-
-        /* Time period between keepalive rounds */
-        ucs_time_t                keepalive_interval;
 
         /* MD to compare for transport selection scores */
         char                      *selection_cmp;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1305,7 +1305,8 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
 
     if (ucp_worker_keepalive_is_enabled(worker)) {
         iface_params->field_mask        |= UCT_IFACE_PARAM_FIELD_KEEPALIVE_INTERVAL;
-        iface_params->keepalive_interval = context->config.keepalive_interval;
+        iface_params->keepalive_interval =
+                context->config.ext.keepalive_interval;
     }
 
     /* Open UCT interface */
@@ -2927,7 +2928,7 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
 
     now = ucs_get_time();
     if (ucs_likely((now - worker->keepalive.last_round) <
-                   worker->context->config.keepalive_interval)) {
+                   worker->context->config.ext.keepalive_interval)) {
         goto out;
     }
 

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -75,7 +75,7 @@ ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
 static UCS_F_ALWAYS_INLINE int
 ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
 {
-    return worker->context->config.keepalive_interval != 0;
+    return worker->context->config.ext.keepalive_interval != UCS_TIME_INFINITY;
 }
 
 /**


### PR DESCRIPTION
## What

Use TIME_UNITS for KA interval configuration.

## Why ?

To align with other parameters and set `inf` - if user want to disable doing KA.
And it aligns with `uct_iface_params_t`'s `keepalive_interval` parameter

## How ?

1. Replace `UCS_CONFIG_TYPE_TIME` by `UCS_CONFIG_TYPE_TIME_UNITS`.
2. Change type of interval from `double` to `ucs_time_t`
3. When checking whether KA is enabled or not, compare interval value with `UCS_TIME_INFINITY`.