### PR TITLE
DOCS: Locking-in explicit version requirements

### DIFF
--- a/docs/.readthedoc.requirements.txt
+++ b/docs/.readthedoc.requirements.txt
@@ -1,1 +1,3 @@
-breathe
+breathe==4.30.0
+sphinx==4.0.2
+sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
It appears that by default openucx.readthedocs.org cached some very old version
requirements for our project. Locking-in special version requirements to a
specific version that we know works well. This shell solve rendering issues on
our documentation website.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>