### PR TITLE
UCP/RNDV/GTEST: Add support for fragmented RNDV AM and setting RNDV_AM scheme

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -175,6 +175,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "Communication scheme in RNDV protocol.\n"
    " get_zcopy - use get_zcopy scheme in RNDV protocol.\n"
    " put_zcopy - use put_zcopy scheme in RNDV protocol.\n"
+   " put_zcopy - use Active Messages scheme in RNDV protocol.\n"
    " auto      - runtime automatically chooses optimal scheme to use.\n",
    ucs_offsetof(ucp_config_t, ctx.rndv_mode), UCS_CONFIG_TYPE_ENUM(ucp_rndv_modes)},
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -740,7 +740,7 @@ ucp_request_complete_am_recv(ucp_request_t *req, ucs_status_t status)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_request_process_recv_data(ucp_request_t *req, const void *data,
                               size_t length, size_t offset, int is_zcopy,
-                              int is_am)
+                              int is_am, int should_complete)
 {
     ucs_status_t status;
     int last;
@@ -763,14 +763,17 @@ ucp_request_process_recv_data(ucp_request_t *req, const void *data,
     }
 
     status = req->status;
-    if (is_zcopy) {
-        ucp_request_recv_buffer_dereg(req);
-    }
 
-    if (is_am) {
-        ucp_request_complete_am_recv(req, status);
-    } else {
-        ucp_request_complete_tag_recv(req, status);
+    if (should_complete) {
+       if (is_zcopy) {
+           ucp_request_recv_buffer_dereg(req);
+       }
+     
+       if (is_am) {
+            ucp_request_complete_am_recv(req, status);
+        } else {
+            ucp_request_complete_tag_recv(req, status);
+        }
     }
 
     ucs_assert(status != UCS_INPROGRESS);

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -326,7 +326,8 @@ ucp_tag_request_process_recv_data(ucp_request_t *req, const void *data,
         return ucp_request_recv_offload_data(req, data, length, recv_flags);
     }
 
-    return ucp_request_process_recv_data(req, data, length, offset, dereg, 0);
+    return ucp_request_process_recv_data(req, data, length, offset, dereg, 0,
+                                         1);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1243,6 +1243,7 @@ static uint64_t ucp_wireup_get_rma_bw_iface_flags(ucp_rndv_mode_t rndv_mode)
         return UCT_IFACE_FLAG_GET_ZCOPY;
     case UCP_RNDV_MODE_PUT_ZCOPY:
         return UCT_IFACE_FLAG_PUT_ZCOPY;
+    case UCP_RNDV_MODE_AM:
     default:
         return 0;
     }

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1253,7 +1253,7 @@ public:
 
     void init()
     {
-        modify_config("RNDV_THRESH", "128");
+        modify_config("RNDV_THRESH", "0");
 
         test_ucp_am_nbx::init();
         m_rx_memtype = static_cast<ucs_memory_type_t>(get_variant_value(1));
@@ -1261,6 +1261,12 @@ public:
 };
 
 UCS_TEST_P(test_ucp_am_nbx_rndv_memtype, rndv)
+{
+    ucs_memory_type_t mt = static_cast<ucs_memory_type_t>(get_variant_value(0));
+    test_am_send_recv(64 * UCS_KBYTE, 8, 0, mt);
+}
+
+UCS_TEST_P(test_ucp_am_nbx_rndv_memtype, rndv_am, "RNDV_SCHEME=am")
 {
     ucs_memory_type_t mt = static_cast<ucs_memory_type_t>(get_variant_value(0));
     test_am_send_recv(64 * UCS_KBYTE, 8, 0, mt);


### PR DESCRIPTION
## What

1. UCP/RNDV: Add support for fragmented RNDV AM.
2. UCP/RNDV/GTEST: Add AM RNDV scheme + test it with memtype

## Why ?

1. Fixes #6836.
2. To reproduce problem reported in #6836.

## How ?

1. Handle RNDV data message on a receiver when request has RNDV_FRAG flag set.
2. Handle `UCX_RNDV_SCHEME=am` to transfer data by using RNDV AM scheme. Extend `test_ucp_am_nbx_rndv_memtype` test suite with `rndv_am` which sets `UCX_RNDV_SCHEME=am`