### PR TITLE
UCT/IB/DC: Refactoring of FC send operations

### DIFF
--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -178,19 +178,36 @@ struct uct_rc_iface_config {
 };
 
 
+typedef ucs_status_t
+(*uct_rc_iface_init_rx_func_t)(uct_rc_iface_t *iface,
+                               const uct_rc_iface_common_config_t *config);
+
+typedef void (*uct_rc_iface_cleanup_rx_func_t)(uct_rc_iface_t *iface);
+
+typedef ucs_status_t (*uct_rc_iface_fc_ctrl_func_t)(uct_ep_t *ep, unsigned op,
+                                                    uct_rc_pending_req_t *req);
+
+typedef ucs_status_t (*uct_rc_iface_fc_handler_func_t)(uct_rc_iface_t *iface,
+                                                       unsigned qp_num,
+                                                       uct_rc_hdr_t *hdr,
+                                                       unsigned length,
+                                                       uint32_t imm_data,
+                                                       uint16_t lid,
+                                                       unsigned flags);
+
+typedef unsigned (*uct_rc_iface_cleanup_qp_func_t)(void *arg);
+
+typedef void (*uct_rc_iface_ep_post_check_func_t)(uct_ep_h tl_ep);
+
+
 typedef struct uct_rc_iface_ops {
-    uct_ib_iface_ops_t   super;
-    ucs_status_t         (*init_rx)(uct_rc_iface_t *iface,
-                                    const uct_rc_iface_common_config_t *config);
-    void                 (*cleanup_rx)(uct_rc_iface_t *iface);
-    ucs_status_t         (*fc_ctrl)(uct_ep_t *ep, unsigned op,
-                                    uct_rc_pending_req_t *req);
-    ucs_status_t         (*fc_handler)(uct_rc_iface_t *iface, unsigned qp_num,
-                                       uct_rc_hdr_t *hdr, unsigned length,
-                                       uint32_t imm_data, uint16_t lid,
-                                       unsigned flags);
-    unsigned             (*cleanup_qp)(void *arg);
-    void                 (*ep_post_check)(uct_ep_h tl_ep);
+    uct_ib_iface_ops_t                super;
+    uct_rc_iface_init_rx_func_t       init_rx;
+    uct_rc_iface_cleanup_rx_func_t    cleanup_rx;
+    uct_rc_iface_fc_ctrl_func_t       fc_ctrl;
+    uct_rc_iface_fc_handler_func_t    fc_handler;
+    uct_rc_iface_cleanup_qp_func_t    cleanup_qp;
+    uct_rc_iface_ep_post_check_func_t ep_post_check;
 } uct_rc_iface_ops_t;
 
 


### PR DESCRIPTION
## What

Refactoring of FC send operations.

## Why ?

Fixes #6904
1. Fixes comments from #6850.
2. Get rid of calling DCI put operations in case of failure.
3. Remove `uct_dc_mlx5_ep_fc_ctrl()` function and do sending of `FC_HARD_REQ`/`FC_PURE_GRANT` directly.

## How ?

1. Add comment in DCI put, re-organize code in `uct_dc_mlx5_ep_fc_hard_req_send()` to make it more readable.
2. Don't do DCI put in case of failure or not expired timeout - just delete added EP from hash in case of failure from sending FC_HARD_REQ (it is better, since it handles not only `UCS_ERR_NO_RESOURCE` failures).
3. Introduce `uct_dc_mlx5_ep_fc_pure_grant_send()`/`uct_dc_mlx5_ep_fc_hard_req_send()` functions and use them directly instead of `uct_dc_mlx5_ep_fc_ctrl()` which is passed to RC iface ops.