### PR TITLE
UCT/IB/DC: Fix DCI get operation for DCI random policy

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -393,6 +393,9 @@ static UCS_F_ALWAYS_INLINE int
 uct_dc_mlx5_iface_dci_has_tx_resources(uct_dc_mlx5_iface_t *iface,
                                        uint8_t dci_index)
 {
+    ucs_assertv(dci_index < UCT_DC_MLX5_IFACE_MAX_DCIS,
+                "dci_index (%u) must be less than %u",
+                dci_index, UCT_DC_MLX5_IFACE_MAX_DCIS);
     return uct_rc_txqp_available(&iface->tx.dcis[dci_index].txqp) > 0;
 }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -478,17 +478,17 @@ uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 
     ucs_assert(!iface->super.super.config.tx_moderation);
 
-    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
-        if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci)) {
-            return UCS_OK;
-        } else {
-            UCS_STATS_UPDATE_COUNTER(iface->tx.dcis[ep->dci].txqp.stats,
-                                     UCT_RC_TXQP_STAT_QP_FULL, 1);
-            goto out_no_res;
-        }
-    }
-
     if (ep->dci != UCT_DC_MLX5_EP_NO_DCI) {
+        if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+            if (uct_dc_mlx5_iface_dci_has_tx_resources(iface, ep->dci)) {
+                return UCS_OK;
+            } else {
+                UCS_STATS_UPDATE_COUNTER(iface->tx.dcis[ep->dci].txqp.stats,
+                                         UCT_RC_TXQP_STAT_QP_FULL, 1);
+                goto out_no_res;
+            }
+        }
+
         /* dci is already assigned - keep using it */
         if ((iface->tx.policy == UCT_DC_TX_POLICY_DCS_QUOTA) &&
             (ep->flags & UCT_DC_MLX5_EP_FLAG_TX_WAIT)) {


### PR DESCRIPTION
## What

Fix DCI get operation for DCI random policy.

## Why ?

Don't use EP's DCI as a index for IFACE's tx DCIs array when we don't really know that EP's DCI is not `NO_DCI`.

## How ?

Move checking for random policy and outstanding operations under:
```
if (ep->dci != UCT_DC_MLX5_EP_NO_DCI)
``` 