### PR TITLE
UCP/RNDV: Fallback to PUT pipeline only if PUT protocol is supported

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1723,9 +1723,8 @@ ucp_ep_config_rndv_zcopy_set(ucp_context_t *context, uint64_t cap_flag,
     }
 }
 
-static void
-ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
-                                ucp_ep_rndv_zcopy_config_t *rndv_zcopy)
+void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
+                                     ucp_ep_rndv_zcopy_config_t *rndv_zcopy)
 {
     if (lanes_count == 0) {
         /* if there are no RNDV RMA BW lanes that support Zcopy operation, reset

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -633,8 +633,14 @@ unsigned ucp_ep_local_disconnect_progress(void *arg);
 
 size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config_t *config);
 
+void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
+                                     ucp_ep_rndv_zcopy_config_t *rndv_zcopy);
+
 void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
                               ucs_string_buffer_t *lane_info_strb);
+
+void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
+                                     ucp_ep_rndv_zcopy_config_t *rndv_zcopy);
 
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 


### PR DESCRIPTION
## What

Fallback to PUT pipeline only if PUT protocol is supported. 

## Why ?

Fixes #6836.

## How ?

When is going to fallback to PUT pipeline protocol, check PUT Zcopy support assuming symmetric configuration of sender and receiver, i.e. check that the length of the message is:
- greater than minimum PUT Zcopy
- maximum PUT Zcopy isn't `0`