### PR TITLE
UCP/WIREUP: Fixes in wireup replay request

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -63,6 +63,7 @@ noinst_HEADERS = \
 	tag/tag_match.h \
 	tag/tag_match.inl \
 	tag/offload.h \
+	tag/tag_send.h \
 	wireup/address.h \
 	wireup/ep_match.h \
 	wireup/wireup_ep.h \

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
  * Copyright (C) Mellanox Technologies Ltd. 2020. ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -95,6 +96,8 @@ size_t ucp_am_max_header_size(ucp_worker_h worker);
 
 ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
                                      unsigned tl_flags);
+
+void ucp_am_replay_request(ucp_request_t *req);
 
 UCS_ARRAY_DECLARE_TYPE(ucp_am_cbs, unsigned, ucp_am_entry_t)
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
 * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -2407,4 +2408,10 @@ void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map)
                      ep, ucs_status_string(status));
         }
     }
+}
+
+int ucp_ep_is_connected(ucp_ep_h ep)
+{
+    return (ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED) &&
+           (ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED);
 }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
  * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -612,5 +613,7 @@ void ucp_ep_discard_lanes(ucp_ep_h ucp_ep, ucs_status_t status);
  *                          has no resources.
  */
 void ucp_ep_do_keepalive(ucp_ep_h ep, ucp_lane_map_t *lane_map);
+
+int ucp_ep_is_connected(ucp_ep_h ep);
 
 #endif

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -2,6 +2,7 @@
  * Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
  * Copyright (c) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
  * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -56,12 +57,14 @@ enum {
 #if UCS_ENABLE_ASSERT
     UCP_REQUEST_FLAG_STREAM_RECV          = UCS_BIT(18),
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = UCS_BIT(19),
-    UCP_REQUEST_FLAG_IN_PTR_MAP           = UCS_BIT(20)
+    UCP_REQUEST_FLAG_IN_PTR_MAP           = UCS_BIT(20),
 #else
     UCP_REQUEST_FLAG_STREAM_RECV          = 0,
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL       = 0,
-    UCP_REQUEST_FLAG_IN_PTR_MAP           = 0
+    UCP_REQUEST_FLAG_IN_PTR_MAP           = 0,
 #endif
+    UCP_REQUEST_FLAG_SEND_STREAM          = UCS_BIT(21),
+    UCP_REQUEST_FLAG_REPLAY               = UCS_BIT(22),
 };
 
 
@@ -127,6 +130,8 @@ struct ucp_request {
             ucp_ep_h                ep;
             void                    *buffer;    /* Send buffer */
             ucp_datatype_t          datatype;   /* Send type */
+            size_t                  dt_count;
+            uint32_t                replay_flags;
             size_t                  length;     /* Total length, in bytes */
             ucp_send_nbx_callback_t cb;         /* Completion callback */
 

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2020.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -144,6 +145,10 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
     }
 
     ucp_request_send(req, 0);
+    if (ucs_unlikely(req->flags & UCP_REQUEST_FLAG_REPLAY)) {
+        return req + 1;
+    }
+
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         goto out_put_request;
     }

--- a/src/ucp/stream/stream.h
+++ b/src/ucp/stream/stream.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -66,5 +67,7 @@ ucp_stream_worker_dequeue_ep_head(ucp_worker_h worker)
     ucp_stream_ep_dequeue(ep_ext);
     return ep_ext;
 }
+
+void ucp_stream_replay_request(ucp_request_t *req);
 
 #endif /* UCP_STREAM_H_ */

--- a/src/ucp/tag/tag_send.h
+++ b/src/ucp/tag/tag_send.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_TAG_SEND_H_
+#define UCP_TAG_SEND_H_
+
+#include <ucp/core/ucp_request.h>
+
+
+void ucp_tag_replay_request(ucp_request_t *req);
+
+#endif


### PR DESCRIPTION
## What
Reselecting a protocol when replaying pending requests.

## Why ?
After user gets the EP through `ucp_ep_create()` and sends messages, UCP may reselect lanes of the EP and replay all pending requests. If the thresholds or capabilities of the EP are different before and after EP reconfiguration , problems like #6872  may appear.
| Time |	Client|	Server |
| --- | --- | --- |
| 1 | ucp_ep_create(sockaddr) | |
| 2	| ucp_tag_recv_nbx() | ucp_ep_create(conn_request) -> This EP only contains a uct_tcp_ep and a CM ep.|
| 3	| | ucp_tag_send_nbx(ucp_dt_iov_t) -> According to the threshold of uct_tcp_ep, it selects zcopy protocol. For uct_tcp_ep ,  it's no need to register memory. Because the uct_tcp_ep is not connected, this request is added to pending queue. |
| 4	| ucp_worker_progress()	| ucp_worker_progress() -> After UCP EP reconfiguration, the selected lane is uct_rc_ep. When replaying the request, it find the reuqest did not register memory, so the assertion failed. |

There may be other problems when the protocol selected based on the old threshold is used to replay the request.