### PR TITLE
UCT/IB/DC: Introduce debug for DCI alloc/release + fix for DCI leaks

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -176,14 +176,28 @@ enum {
     }
 
 /**
+ * Skip if this is a zero-length operation and do user-defined action prior
+ * returning UCS_OK.
+ */
+#define UCT_SKIP_ZERO_LENGTH_ACTION(_length, _action, ...) \
+    if (0 == (_length)) { \
+        ucs_trace_data("Zero length request: skip it"); \
+        UCS_PP_FOREACH(_UCT_RELEASE_DESC, _, __VA_ARGS__) \
+        _action; \
+        return UCS_OK; \
+    }
+
+
+/**
  * Skip if this is a zero-length operation.
  */
 #define UCT_SKIP_ZERO_LENGTH(_length, ...) \
-    if (0 == (_length)) { \
-        ucs_trace_data("Zero length request: skip it"); \
-        UCS_PP_FOREACH(_UCT_RELEASE_DESC, _, __VA_ARGS__)  \
-        return UCS_OK; \
-    }
+        UCT_SKIP_ZERO_LENGTH_ACTION(_length, (void)_length, ## __VA_ARGS__)
+
+
+/**
+ * Auxiliary macro for releasing desc.
+ */
 #define _UCT_RELEASE_DESC(_, _desc) \
     ucs_mpool_put(_desc);
 

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -1629,7 +1629,8 @@ static ucs_status_t UCS_F_ALWAYS_INLINE uct_rc_mlx5_common_dm_make_data(
     desc = ucs_mpool_get_inline(&iface->dm.dm->mp);
     if (ucs_unlikely(desc == NULL)) {
         /* in case if no resources available - fallback to bcopy */
-        UCT_RC_IFACE_GET_TX_DESC(&iface->super, &iface->super.tx.mp, desc);
+        UCT_RC_IFACE_GET_TX_DESC(&iface->super, &iface->super.tx.mp, desc,
+                                 return UCS_ERR_NO_RESOURCE);
         desc->super.handler = (uct_rc_send_handler_t)ucs_mpool_put;
         buffer = desc + 1;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -289,10 +289,10 @@ KHASH_INIT(uct_rc_mlx5_mp_hash_gid, uct_rc_mlx5_mp_hash_key_t,
 
 #if IBV_HW_TM
 #  define UCT_RC_MLX5_IFACE_GET_TM_BCOPY_DESC(_iface, _mp, _desc, _tag, _app_ctx, \
-                                              _pack_cb, _arg, _length) \
+                                              _pack_cb, _arg, _length, _failure) \
        { \
            void *hdr; \
-           UCT_RC_IFACE_GET_TX_DESC(_iface, _mp, _desc) \
+           UCT_RC_IFACE_GET_TX_DESC(_iface, _mp, _desc, _failure) \
            (_desc)->super.handler = (uct_rc_send_handler_t)ucs_mpool_put; \
            hdr = (_desc) + 1; \
            uct_rc_mlx5_fill_tmh(hdr, _tag, _app_ctx, IBV_TMH_EAGER); \
@@ -487,19 +487,21 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_rc_iface_ops_t*,
        uct_rc_mlx5_tag_imm_data_pack(&(_ib_imm), &(_app_ctx), _imm_data); \
    }
 
-#define UCT_RC_MLX5_GET_TX_TM_DESC(_iface, _mp, _desc, _tag, _app_ctx, _hdr) \
+#define UCT_RC_MLX5_GET_TX_TM_DESC(_iface, _mp, _desc, _tag, _app_ctx, _hdr, \
+                                   _failure) \
    { \
-       UCT_RC_IFACE_GET_TX_DESC(_iface, _mp, _desc) \
+       UCT_RC_IFACE_GET_TX_DESC(_iface, _mp, _desc, _failure) \
        _hdr = _desc + 1; \
        uct_rc_mlx5_fill_tmh(_hdr, _tag, _app_ctx, IBV_EXP_TMH_EAGER); \
        _hdr += sizeof(struct ibv_tmh); \
    }
 
 #define UCT_RC_MLX5_GET_TM_BCOPY_DESC(_iface, _mp, _desc, _tag, _app_ctx, \
-                                      _pack_cb, _arg, _length) \
+                                      _pack_cb, _arg, _length, _failure) \
    { \
        void *hdr; \
-       UCT_RC_MLX5_GET_TX_TM_DESC(_iface, _mp, _desc, _tag, _app_ctx, hdr) \
+       UCT_RC_MLX5_GET_TX_TM_DESC(_iface, _mp, _desc, _tag, _app_ctx, hdr, \
+                                  _failure) \
        (_desc)->super.handler = (uct_rc_send_handler_t)ucs_mpool_put; \
        _length = _pack_cb(hdr, _arg); \
    }

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -136,8 +136,10 @@ uct_rc_verbs_ep_atomic(uct_rc_verbs_ep_t *ep, int opcode, void *result,
 
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_ATOMIC_FETCH_DESC(&iface->super, &iface->short_desc_mp,
-                                          desc, iface->super.config.atomic64_handler,
-                                          result, comp);
+                                          desc,
+                                          iface->super.config.atomic64_handler,
+                                          result, comp,
+                                          return UCS_ERR_NO_RESOURCE);
     uct_rc_verbs_ep_atomic_post(ep, opcode, compare_add, swap, remote_addr,
                                 rkey, desc, IBV_SEND_SIGNALED |
                                 uct_rc_ep_fm(&iface->super, &ep->fi, IBV_SEND_FENCE));
@@ -174,7 +176,10 @@ ssize_t uct_rc_verbs_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
 
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_PUT_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
-                                       pack_cb, arg, length);
+                                       pack_cb, arg, length,
+                                       return UCS_ERR_NO_RESOURCE);
+    UCT_SKIP_ZERO_LENGTH(length, desc);
+
     uct_rc_verbs_ep_fence_put(iface, ep, &rkey, &remote_addr);
     UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.opcode, IBV_WR_RDMA_WRITE, sge,
                               length, remote_addr, rkey);
@@ -219,7 +224,9 @@ ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
     UCT_CHECK_LENGTH(length, 0, iface->super.super.config.seg_size, "get_bcopy");
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
     UCT_RC_IFACE_GET_TX_GET_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
-                                       unpack_cb, comp, arg, length);
+                                       unpack_cb, comp, arg, length,
+                                       return UCS_ERR_NO_RESOURCE);
+    UCT_SKIP_ZERO_LENGTH(length, desc);
 
     UCT_RC_VERBS_FILL_RDMA_WR(wr, wr.opcode, IBV_WR_RDMA_READ, sge, length, remote_addr,
                               uct_ib_md_direct_rkey(rkey));
@@ -310,7 +317,8 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
     UCT_RC_IFACE_GET_TX_AM_BCOPY_DESC(&iface->super, &iface->super.tx.mp, desc,
                                       id, uct_rc_am_hdr_fill, uct_rc_hdr_t,
-                                      pack_cb, arg, &length);
+                                      pack_cb, arg, &length,
+                                      return UCS_ERR_NO_RESOURCE);
     UCT_RC_VERBS_FILL_AM_BCOPY_WR(wr, sge, length + sizeof(uct_rc_hdr_t),
                                   wr.opcode);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, length);
@@ -343,7 +351,8 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
 
     UCT_RC_IFACE_GET_TX_AM_ZCOPY_DESC(&iface->super, &iface->short_desc_mp,
                                       desc, id, header, header_length, comp,
-                                      &send_flags);
+                                      &send_flags, return UCS_ERR_NO_RESOURCE);
+
     sge[0].length = sizeof(uct_rc_hdr_t) + header_length;
     sge_cnt = uct_ib_verbs_sge_fill_iov(sge + 1, iov, iovcnt);
     UCT_RC_VERBS_FILL_AM_ZCOPY_WR_IOV(wr, sge, (sge_cnt + 1), wr.opcode);
@@ -370,7 +379,8 @@ ucs_status_t uct_rc_verbs_ep_atomic64_post(uct_ep_h tl_ep, unsigned opcode, uint
 
     /* TODO don't allocate descriptor - have dummy buffer */
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
-    UCT_RC_IFACE_GET_TX_ATOMIC_DESC(&iface->super, &iface->short_desc_mp, desc);
+    UCT_RC_IFACE_GET_TX_ATOMIC_DESC(&iface->super, &iface->short_desc_mp, desc,
+                                    return UCS_ERR_NO_RESOURCE);
 
     uct_rc_verbs_ep_atomic_post(ep,
                                 IBV_WR_ATOMIC_FETCH_AND_ADD, value, 0,


### PR DESCRIPTION
## What

1. Introduce debug for DCI alloc/release.
2. Fix DCI leaks.
3. Fix checking DCI leaks.

## Why ?

1. Introduces debugging for DCI alloc/release for easy debugging.
2. To release DCI after:
- detecting problems with allocating TX desc;
- skipping TX operation if length is 0.
3. To not fail a condition in assertion when DCI was allocated from waiting DCI, but no outstanding operations yet.

## How ?

1. Introduce special macros, `uct_dc_mlx5_ep_check_dci_leak()` function and use it.
2. Extend `*_GET_TX_*_BCOPY_DESC* and `_GET_TX_ATOMIC_*_DESC` macro by doing some actions on failure and use it for DC to put DCI; Add new `UCT_SKIP_ZERO_LENGTH_ACTION` macro to check and do action, it is used by DC only.
3. Save flag indicating whether DCI was allocated from waiting DCI or not to check it when checking for outstanding operations in DCI leak (allow no outstanding operations if DCI allocated from DCI waiting queue).