### PR TITLE
UCT/IB: Device memory allocation

### DIFF
--- a/src/tools/perf/configure.m4
+++ b/src/tools/perf/configure.m4
@@ -8,6 +8,7 @@ ucx_perftest_modules=""
 m4_include([src/tools/perf/lib/configure.m4])
 m4_include([src/tools/perf/cuda/configure.m4])
 m4_include([src/tools/perf/rocm/configure.m4])
+m4_include([src/tools/perf/dm/configure.m4])
 AC_DEFINE_UNQUOTED([ucx_perftest_MODULES], ["${ucx_perftest_modules}"],
                    [Perftest loadable modules])
 

--- a/src/tools/perf/dm/Makefile.am
+++ b/src/tools/perf/dm/Makefile.am
@@ -1,0 +1,17 @@
+#
+# Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+if HAVE_IB_DM
+
+module_LTLIBRARIES               = libucx_perftest_dm.la
+libucx_perftest_dm_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libucx_perftest_dm_la_CFLAGS   = $(BASE_CFLAGS)
+libucx_perftest_dm_la_LDFLAGS  = $(BASE_LDLAGS) -version-info $(SOVERSION)
+libucx_perftest_dm_la_SOURCES  = dm_alloc.c
+
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/tools/perf/dm/configure.m4
+++ b/src/tools/perf/dm/configure.m4
@@ -1,0 +1,9 @@
+#
+# Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+AS_IF([test "x$has_ib_dm" = "xyes"], [ucx_perftest_modules="${ucx_perftest_modules}:dm"])
+
+AC_CONFIG_FILES([src/tools/perf/dm/Makefile])

--- a/src/tools/perf/dm/dm_alloc.c
+++ b/src/tools/perf/dm/dm_alloc.c
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <tools/perf/lib/libperf_int.h>
+
+#include <ucs/sys/compiler.h>
+
+
+static ucs_status_t ucx_perf_dm_init(ucx_perf_context_t *perf)
+{
+    return UCS_OK; // TODO: find the UCT MD of the device we want for DM
+}
+
+static ucs_status_t ucp_perf_dm_alloc(const ucx_perf_context_t *perf, size_t length,
+                                        void **address_p, ucp_mem_h *memh_p,
+                                        int non_blk_flag)
+{
+    return uct_ib_mem_dm_alloc();
+}
+
+static void ucp_perf_dm_free(const ucx_perf_context_t *perf,
+                               void *address, ucp_mem_h memh)
+{
+    uct_ib_mem_dm_free();
+}
+
+static inline ucs_status_t
+uct_perf_dm_alloc_reg_mem(const ucx_perf_context_t *perf,
+                            size_t length,
+                            ucs_memory_type_t mem_type,
+                            unsigned flags,
+                            uct_allocated_memory_t *alloc_mem)
+{
+    ucs_status_t status;
+
+    status = ucx_perf_dm_alloc(length, mem_type, &alloc_mem->address);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_md_mem_reg(perf->uct.md, alloc_mem->address,
+                            length, flags, &alloc_mem->memh);
+    if (status != UCS_OK) {
+        uct_md_mem_free(alloc_mem->address);
+        ucs_error("failed to register memory");
+        return status;
+    }
+
+    alloc_mem->mem_type = mem_type;
+    alloc_mem->md       = perf->uct.md;
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_perf_dm_alloc(const ucx_perf_context_t *perf,
+                                        size_t length, unsigned flags,
+                                        uct_allocated_memory_t *alloc_mem)
+{
+    return uct_perf_dm_alloc_reg_mem(perf, length, UCS_MEMORY_TYPE_RDMA_DM,
+                                       flags, alloc_mem);
+}
+
+static void uct_perf_dm_free(const ucx_perf_context_t *perf,
+                               uct_allocated_memory_t *alloc_mem)
+{
+    ucs_status_t status;
+
+    ucs_assert(alloc_mem->md == perf->uct.md);
+
+    status = uct_md_mem_dereg(perf->uct.md, alloc_mem->memh);
+    if (status != UCS_OK) {
+        ucs_error("failed to deregister memory");
+    }
+
+    uct_md_mem_free(alloc_mem->address);
+}
+
+static void ucx_perf_dm_memcpy(void *dst, ucs_memory_type_t dst_mem_type,
+                               const void *src, ucs_memory_type_t src_mem_type,
+                               size_t count)
+{
+    struct ibv_dm *dm;
+    int ret;
+
+    if (dst_mem_type == UCS_MEMORY_TYPE_RDMA_DM) {
+        if (src_mem_type != UCS_MEMORY_TYPE_HOST) {
+            goto memcpy_unsupported_error;
+        }
+
+        ret = ibv_memcpy_to_dm(dm, uint64_t dm_offset, const void *host_addr, size_t length);
+    } else if (dst_mem_type == UCS_MEMORY_TYPE_HOST) {
+        if (src_mem_type != UCS_MEMORY_TYPE_RDMA_DM) {
+            goto memcpy_unsupported_error;
+        }
+
+        ret = ibv_memcpy_from_dm(dm, uint64_t dm_offset, const void *host_addr, size_t length);
+    } else {
+        goto memcpy_unsupported_error;
+    }
+
+    if (ret) {
+        ucs_error("failed to copy RDMA device memory");
+    }
+    return;
+
+memcpy_unsupported_error:
+    ucs_error("failed to copy memory: can only copy from or to the device");
+}
+
+static void* ucx_perf_dm_memset(void *dst, int value, size_t count)
+{
+    void *tmp = ucs_malloc(count, "perf_dm_memset");
+    if (tmp == NULL) {
+        ucs_error("failed to allocate memory for memset");
+        return NULL;
+    }
+
+    (void)memset(tmp, value, count);
+    ucx_perf_dm_memcpy(dst, UCS_MEMORY_TYPE_RDMA_DM, tmp, UCS_MEMORY_TYPE_HOST,
+                       count);
+
+    ucs_free(tmp);
+    return dst;
+}
+
+UCS_STATIC_INIT {
+    static ucx_perf_allocator_t dm_allocator = {
+        .mem_type  = UCS_MEMORY_TYPE_RDMA_DM,
+        .init      = ucx_perf_dm_init,
+        .ucp_alloc = ucp_perf_dm_alloc,
+        .ucp_free  = ucp_perf_dm_free,
+        .uct_alloc = uct_perf_dm_alloc,
+        .uct_free  = uct_perf_dm_free,
+        .memcpy    = ucx_perf_dm_memcpy,
+        .memset    = ucx_perf_dm_memset
+    };
+
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_RDMA_DM] = &dm_allocator;
+}
+UCS_STATIC_CLEANUP {
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_RDMA_DM] = NULL;
+
+}

--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -249,6 +249,19 @@ ucs_status_t ucs_mpool_chunk_malloc(ucs_mpool_t *mp, size_t *size_p, void **chun
     return (*chunk_p == NULL) ? UCS_ERR_NO_MEMORY : UCS_OK;
 }
 
+ucs_status_t ucs_mpool_chunk_malloc_zero(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
+{
+    ucs_status_t status;
+
+    status = ucs_mpool_chunk_malloc(mp, size_p, chunk_p);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    memset(*chunk_p, 0, *size_p);
+    return UCS_OK;
+}
+
 void ucs_mpool_chunk_free(ucs_mpool_t *mp, void *chunk)
 {
     ucs_free(chunk);

--- a/src/ucs/datastruct/mpool.h
+++ b/src/ucs/datastruct/mpool.h
@@ -230,6 +230,7 @@ void *ucs_mpool_get_grow(ucs_mpool_t *mp);
  * heap-based chunk allocator.
  */
 ucs_status_t ucs_mpool_chunk_malloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p);
+ucs_status_t ucs_mpool_chunk_malloc_zero(ucs_mpool_t *mp, size_t *size_p, void **chunk_p);
 void ucs_mpool_chunk_free(ucs_mpool_t *mp, void *chunk);
 
 

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -41,6 +41,7 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
+    UCS_MEMORY_TYPE_RDMA_DM,       /**< RDMA device memory */
     UCS_MEMORY_TYPE_LAST,
     UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -80,6 +80,7 @@ typedef struct uct_md_config         uct_md_config_t;
 typedef struct uct_cm_config         uct_cm_config_t;
 typedef struct uct_ep                *uct_ep_h;
 typedef void *                       uct_mem_h;
+typedef struct uct_atomic            *uct_atomic_h;
 typedef uintptr_t                    uct_rkey_t;
 typedef struct uct_md                *uct_md_h;          /**< @brief Memory domain handler */
 typedef struct uct_md_ops            uct_md_ops_t;

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -24,6 +24,11 @@
 #define uct_md_log_mem_reg_error(_flags, _fmt, ...) \
     ucs_log(uct_md_reg_log_lvl(_flags), _fmt, ## __VA_ARGS__)
 
+typedef struct uct_atomic {
+    ucs_memory_type_t type;
+    uct_mem_h memh;
+    void     *var;
+} uct_atomic_t;
 
 #define UCT_MD_MEM_DEREG_FIELD_VALUE(_params, _name, _flag, _default) \
     UCS_PARAM_VALUE(UCT_MD_MEM_DEREG, _params, _name, _flag, _default)
@@ -115,6 +120,15 @@ typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
                                                          size_t length,
                                                          ucs_memory_type_t *mem_type_p);
 
+typedef ucs_status_t (*uct_md_atomic_alloc_func_t)(uct_md_h md,
+                                                   void **address_p,
+                                                   ucs_memory_type_t mem_type,
+                                                   unsigned flags,
+                                                   const char *alloc_name,
+                                                   uct_atomic_h *atomic_p);
+
+typedef ucs_status_t (*uct_md_atomic_free_func_t)(uct_md_h md,
+                                                  uct_atomic_h atomic);
 
 /**
  * Memory domain operations
@@ -207,6 +221,36 @@ ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
  * @param [in]     memh        Memory handle, as returned from @ref uct_md_mem_alloc.
  */
 ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh);
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Create an atomic variable for remote operations.
+ *
+ * Allocate an register memory to be used for a 64-bit atomic variable.
+ *
+ * @param [in]     md          Memory domain to allocate memory on.
+ * @param [in,out] address_p   The address
+ * @param [in]     mem_type    Memory type of the allocation
+ * @param [in]     flags       Reserved
+ * @param [in]     name        Name of the allocated region, used to track memory
+ *                             usage for debugging and profiling.
+ * @param [out]    memh_p      Filled with handle for allocated region.
+ */
+ucs_status_t uct_md_atomic_create(uct_md_h md, void **address_p,
+                                  ucs_memory_type_t mem_type, unsigned flags,
+                                  const char *alloc_name,
+                                  uct_atomic_h *atomich_p);
+
+/**
+ * @ingroup UCT_MD
+ * @brief Release resources allocated by @ref uct_md_atomic_alloc.
+ *
+ * @param [in]     md          Memory domain memory was allocated on.
+ * @param [in]     atomich     Atomic handle, as returned from
+ *                             @ref uct_md_atomic_alloc.
+ */
+ucs_status_t uct_md_atomic_destroy(uct_md_h md, uct_atomic_h atomich);
 
 
 /**

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -402,12 +402,15 @@ AS_IF([test "x$with_ib" = "xyes"],
        # Device Memory support
        AS_IF([test "x$with_dm" != xno], [
            AC_CHECK_DECLS([ibv_exp_alloc_dm],
-               [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support])
-                AC_DEFINE([HAVE_IBV_EXP_DM], 1, [Device Memory support (EXP)])],
+               [AC_DEFINE([HAVE_IBV_EXP_DM], 1, [Device Memory support (EXP)])
+                has_ib_dm=yes],
                [], [[#include <infiniband/verbs_exp.h>]])
            AC_CHECK_DECLS([ibv_alloc_dm],
-               [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support])],
+               [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support (Verbs)])
+                has_ib_dm=yes],
                [], [[#include <infiniband/verbs.h>]])])
+       AS_IF([test "x$has_ib_dm" = xyes],
+             [AC_DEFINE([HAVE_DM], 1, [Device Memory support])])
 
        AC_CHECK_DECLS([ibv_cmd_modify_qp],
                       [], [], [[#include <infiniband/driver.h>]])
@@ -443,6 +446,7 @@ AM_CONDITIONAL([HAVE_DC_EXP],  [test -n "$have_dc_exp"])
 AM_CONDITIONAL([HAVE_TL_UD],   [test "x$with_ud" != xno])
 AM_CONDITIONAL([HAVE_MLX5_HW], [test "x$with_mlx5_hw" != xno])
 AM_CONDITIONAL([HAVE_MLX5_DV], [test "x$with_mlx5_dv" = xyes])
+AM_CONDITIONAL([HAVE_IB_DM],   [test -n "$has_ib_dm"])
 AM_CONDITIONAL([HAVE_DEVX],    [test -n "$have_devx"])
 AM_CONDITIONAL([HAVE_EXP],     [test "x$verbs_exp" != xno])
 AM_CONDITIONAL([HAVE_MLX5_HW_UD], [test "x$with_mlx5_hw" != xno -a "x$has_get_av" != xno])

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -166,7 +166,7 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     size_t max_put_inline      = UCT_IB_MLX5_PUT_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE);
     ucs_status_t status;
 
-#if HAVE_IBV_DM
+#if HAVE_DM
     if (iface->super.dm.dm != NULL) {
         max_am_inline  = ucs_max(iface->super.dm.dm->seg_len,
                                  UCT_IB_MLX5_AM_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE));

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -285,7 +285,7 @@ static ucs_status_t UCS_F_ALWAYS_INLINE uct_dc_mlx5_ep_am_short_iov_inline(
 ucs_status_t uct_dc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                                      const void *buffer, unsigned length)
 {
-#if HAVE_IBV_DM
+#if HAVE_DM
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     ucs_status_t status;
@@ -297,7 +297,7 @@ ucs_status_t uct_dc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                    !iface->super.dm.dm)) {
 #endif
         return uct_dc_mlx5_ep_am_short_inline(tl_ep, id, hdr, buffer, length);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_AM_ID(id);
@@ -328,7 +328,7 @@ ucs_status_t uct_dc_mlx5_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
                                          const uct_iov_t *iov, size_t iovcnt)
 {
     size_t iov_length = uct_iov_total_length(iov, iovcnt);
-#if HAVE_IBV_DM
+#if HAVE_DM
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface,
                                                 uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
@@ -341,7 +341,7 @@ ucs_status_t uct_dc_mlx5_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
 #endif
         return uct_dc_mlx5_ep_am_short_iov_inline(tl_ep, id, iov, iovcnt,
                                                   iov_length);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_AM_ID(id);
@@ -443,7 +443,7 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
                                       unsigned length, uint64_t remote_addr,
                                       uct_rkey_t rkey)
 {
-#if HAVE_IBV_DM
+#if HAVE_DM
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     ucs_status_t status;
@@ -453,7 +453,7 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
                    !iface->super.dm.dm)) {
 #endif
         return uct_dc_mlx5_ep_put_short_inline(tl_ep, payload, length, remote_addr, rkey);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_LENGTH(length, 0, iface->super.dm.seg_len, "put_short");
@@ -695,7 +695,7 @@ uct_dc_mlx5_ep_tag_eager_short_inline(uct_ep_h tl_ep, uct_tag_t tag,
 ucs_status_t uct_dc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                                             const void *data, size_t length)
 {
-#if HAVE_IBV_DM
+#if HAVE_DM
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uct_rc_mlx5_dm_copy_data_t cache;
@@ -707,7 +707,7 @@ ucs_status_t uct_dc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                    !iface->super.dm.dm)) {
 #endif
         return uct_dc_mlx5_ep_tag_eager_short_inline(tl_ep, tag, data, length);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_LENGTH(length + sizeof(struct ibv_tmh), 0,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -13,6 +13,7 @@
 
 #include <ucs/arch/bitops.h>
 #include <ucs/profile/profile.h>
+#include <uct/ib/base/ib_md.h>
 
 typedef struct {
     struct mlx5dv_devx_obj     *dvmr;
@@ -1052,3 +1053,27 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
 
 UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);
 
+ucs_status_t
+uct_ib_mlx5dv_md_dm_create(uct_ib_md_t *md, size_t length, uct_ib_mlx5_dm_t *dm)
+{
+    struct mlx5dv_dm dvdm = {};
+    uct_ib_mlx5dv_t obj = {};
+    ucs_status_t status;
+
+    status = uct_ib_md_dm_create(md, length, &dm->super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    UCT_IB_MLX5_DV_DM(obj).in  = dm->super.dm;
+    UCT_IB_MLX5_DV_DM(obj).out = &dvdm;
+    uct_ib_mlx5dv_init_obj(&obj, MLX5DV_OBJ_DM);
+    dm->start_va = dvdm.buf;
+
+    return UCS_OK;
+}
+
+void uct_ib_mlx5dv_md_dm_destroy(uct_ib_mlx5_dm_t *dm)
+{
+    uct_ib_md_dm_destroy(&dm->super);
+}

--- a/src/uct/ib/mlx5/exp/ib_exp_md.c
+++ b/src/uct/ib/mlx5/exp/ib_exp_md.c
@@ -12,6 +12,7 @@
 
 #include <ucs/arch/bitops.h>
 #include <ucs/profile/profile.h>
+#include <uct/ib/base/ib_md.h>
 
 
 typedef struct {
@@ -751,3 +752,22 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
 
 UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);
 
+ucs_status_t
+uct_ib_mlx5dv_md_dm_create(uct_ib_md_t *md, size_t length, uct_ib_mlx5_dm_t *dm)
+{
+    ucs_status_t status;
+
+    status = uct_ib_md_dm_create(md, length, &dm->super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    dm->start_va = dm->super.mr.ib->addr;
+
+    return UCS_OK;
+}
+
+void uct_ib_mlx5dv_md_dm_destroy(uct_ib_mlx5_dm_t *dm)
+{
+    uct_ib_md_dm_destroy(&dm->super);
+}

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -31,7 +31,7 @@ static const char *uct_ib_mlx5_mmio_modes[] = {
 };
 
 ucs_config_field_t uct_ib_mlx5_iface_config_table[] = {
-#if HAVE_IBV_DM
+#if HAVE_DM
     {"DM_SIZE", "2k",
      "Device Memory segment size (0 - disabled)",
      ucs_offsetof(uct_ib_mlx5_iface_config_t, dm.seg_len), UCS_CONFIG_TYPE_MEMUNITS},

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -237,7 +237,7 @@ typedef enum {
 
 
 typedef struct uct_ib_mlx5_iface_config {
-#if HAVE_IBV_DM
+#if HAVE_DM
     struct {
         size_t               seg_len;
         unsigned             count;

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -1540,7 +1540,7 @@ done:
     return count;
 }
 
-#if HAVE_IBV_DM
+#if HAVE_DM
 /* DM memory should be written by 8 bytes to eliminate
  * processor cache issues. To make this used uct_rc_mlx5_dm_copy_data_t
  * datatype where first hdr_len bytes are filled by message header
@@ -1646,7 +1646,7 @@ static ucs_status_t UCS_F_ALWAYS_INLINE uct_rc_mlx5_common_dm_make_data(
          * hint to valgrind to make it defined */
         VALGRIND_MAKE_MEM_DEFINED(desc, sizeof(*desc));
         ucs_assert(desc->super.buffer != NULL);
-        buffer = (void*)UCS_PTR_BYTE_DIFF(iface->dm.dm->start_va,
+        buffer = (void*)UCS_PTR_BYTE_DIFF(iface->dm.dm->dm.start_va,
                                           desc->super.buffer);
 
         uct_rc_mlx5_iface_common_copy_to_dm(cache, hdr_len, iov, iovcnt,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -335,13 +335,11 @@ typedef struct uct_rc_mlx5_ctx_priv {
     uint32_t                    tag_handle;
 } uct_rc_mlx5_ctx_priv_t;
 
-#if HAVE_IBV_DM
+#if HAVE_DM
 typedef struct uct_mlx5_dm_data {
     uct_worker_tl_data_t super;
     ucs_mpool_t          mp;
-    struct ibv_mr        *mr;
-    struct ibv_dm        *dm;
-    void                 *start_va;
+    uct_ib_mlx5_dm_t     dm;
     size_t               seg_len;
     unsigned             seg_count;
     unsigned             seg_attached;
@@ -409,7 +407,7 @@ typedef struct uct_rc_mlx5_iface_common {
         uct_rc_mlx5_release_desc_t     am_desc;
         UCS_STATS_NODE_DECLARE(stats)
     } tm;
-#if HAVE_IBV_DM
+#if HAVE_DM
     struct {
         uct_mlx5_dm_data_t             *dm;
         size_t                         seg_len; /* cached value to avoid double-pointer access */

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -129,7 +129,7 @@ ucs_status_t
 uct_rc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *buffer, unsigned length,
                          uint64_t remote_addr, uct_rkey_t rkey)
 {
-#if HAVE_IBV_DM
+#if HAVE_DM
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     uct_rc_iface_t *rc_iface = &iface->super;
     ucs_status_t status;
@@ -137,7 +137,7 @@ uct_rc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *buffer, unsigned length,
     if (ucs_likely((length <= UCT_IB_MLX5_PUT_MAX_SHORT(0)) || !iface->dm.dm)) {
 #endif
         return uct_rc_mlx5_ep_put_short_inline(tl_ep, buffer, length, remote_addr, rkey);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_LENGTH(length, 0, iface->dm.seg_len, "put_short");
@@ -265,7 +265,7 @@ ucs_status_t
 uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                         const void *payload, unsigned length)
 {
-#if HAVE_IBV_DM
+#if HAVE_DM
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     uct_rc_iface_t *rc_iface = &iface->super;
     ucs_status_t status;
@@ -275,7 +275,7 @@ uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                    !iface->dm.dm)) {
 #endif
         return uct_rc_mlx5_ep_am_short_inline(tl_ep, id, hdr, payload, length);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_LENGTH(length + sizeof(uct_rc_mlx5_am_short_hdr_t), 0,
@@ -304,7 +304,7 @@ ucs_status_t uct_rc_mlx5_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
                                          const uct_iov_t *iov, size_t iovcnt)
 {
     size_t iov_length = uct_iov_total_length(iov, iovcnt);
-#if HAVE_IBV_DM
+#if HAVE_DM
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     ucs_status_t status;
 
@@ -314,7 +314,7 @@ ucs_status_t uct_rc_mlx5_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
 #endif
         return uct_rc_mlx5_ep_am_short_iov_inline(tl_ep, id, iov, iovcnt,
                                                   iov_length);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_AM_ID(id);
@@ -779,7 +779,7 @@ uct_rc_mlx5_ep_tag_eager_short_inline(uct_ep_h tl_ep, uct_tag_t tag,
 ucs_status_t uct_rc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                                             const void *data, size_t length)
 {
-#if HAVE_IBV_DM
+#if HAVE_DM
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
     uct_rc_mlx5_dm_copy_data_t cache;
     ucs_status_t status;
@@ -788,7 +788,7 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_short(uct_ep_h tl_ep, uct_tag_t tag,
                    !iface->dm.dm)) {
 #endif
         return uct_rc_mlx5_ep_tag_eager_short_inline(tl_ep, tag, data, length);
-#if HAVE_IBV_DM
+#if HAVE_DM
     }
 
     UCT_CHECK_LENGTH(length + sizeof(struct ibv_tmh), 0,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -203,7 +203,7 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     size_t max_put_inline      = UCT_IB_MLX5_PUT_MAX_SHORT(0);
     ucs_status_t status;
 
-#if HAVE_IBV_DM
+#if HAVE_DM
     if (iface->dm.dm != NULL) {
         max_am_inline  = ucs_max(iface->dm.dm->seg_len, UCT_IB_MLX5_AM_MAX_SHORT(0));
         max_put_inline = ucs_max(iface->dm.dm->seg_len, UCT_IB_MLX5_PUT_MAX_SHORT(0));


### PR DESCRIPTION
Signed-off-by: Alex Margolin <alex.margolin@huawei.com>

## What
Utilize RDMA Device memory (part of IB Verbs API) for atomics, and in general make it easier to use in UCX.

## Why ?
Want to have the ability to allocate buffers, especially (64-bit) atomic variables, on (NIC) device memory. Should be faster than host-memory-based in some cases.

## How ?
re-used the code from rc_mlx5 and made it part of uct_md_ib.

## Missing
(g)tests will be added once we agree on the general layout of the patch, and copyrights too I suppose :)
