### PR TITLE
UCP/CORE: Ensure that KA isn't done several times for the same EP during the round

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -433,7 +433,7 @@ typedef struct {
     ucp_err_handler_cb_t     err_cb; /* Error handler */
     ucp_ep_close_proto_req_t close_req; /* Close protocol request */
 #if UCS_ENABLE_ASSERT
-    size_t                   ka_count; /* Number of KA rounds done */
+    ucs_time_t               ka_last_round; /* Time of last KA round done */
 #endif
 } ucp_ep_ext_control_t;
 
@@ -671,10 +671,11 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
  * @brief Do keepalive operation.
  *
  * @param [in] ep    UCP Endpoint object to operate keepalive.
+ * @param [in] now   Current time when keepalive started.
  *
  * @return Indication whether keepalive was fully done for UCP Endpoint or not.
  */
-int ucp_ep_do_keepalive(ucp_ep_h ep);
+int ucp_ep_do_keepalive(ucp_ep_h ep, ucs_time_t now);
 
 /**
  * @brief Purge flush and protocol requests scheduled on a given UCP endpoint.

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -302,6 +302,8 @@ typedef struct ucp_worker {
         uct_worker_cb_id_t           cb_id;               /* Keepalive callback id */
         ucs_time_t                   last_round;          /* Last round timestamp */
         ucs_list_link_t              *iter;               /* Last EP processed keepalive */
+        ucs_list_link_t              *iter_begin;         /* First EP processed keepalive in the
+                                                           * current round */
         ucp_lane_map_t               lane_map;            /* Lane map used to retry after no-resources */
         unsigned                     ep_count;            /* Number of EPs processed in current time slot */
         unsigned                     iter_count;          /* Number of progress iterations to skip,


### PR DESCRIPTION
## What

Ensure that KA isn't done several times for the same EP during the round.

## Why ?

1. To not do KA for the same EP several times in a keepalive interval.
2. To simplify check for KA that verifies if we ensure doing KA for the same EP once per round.

## How ?

1. Use global `iter_begin` to stop doing KA for EPs when either `iter` == `iter_begin` or EP count reaches `KEEAPLIVE_NUM_EPS` value.
2. Remove `ka_count` from EP and introduce `ucs_time_t ka_last_round` field and check and set it every time when KA done for a EP.