### PR TITLE
UCT/IB/RC: Use a configurable ack frequency for requests in DevX

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -141,6 +141,8 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(qpc, qpc, rnr_retry, iface->super.super.config.rnr_retry);
     UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.ack_timeout, iface->super.super.config.timeout);
     UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.log_rtm, iface->super.super.config.exp_backoff);
+    UCT_IB_MLX5DV_SET(qpc, qpc, log_ack_req_freq,
+                      iface->super.config.log_ack_req_freq);
 
     return uct_ib_mlx5_devx_modify_qp(qp, in_2rts, sizeof(in_2rts),
                                       out_2rts, sizeof(out_2rts));

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -73,6 +73,12 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    "                  treats it as a linked list. Doesn`t require DEVX.",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, srq_topo),
    UCS_CONFIG_TYPE_STRING_ARRAY},
+   
+  {"LOG_ACK_REQ_FREQ", "8",
+   "Log of the ack frequency for requests, when using DevX. Valid values are: 0-"
+    UCS_PP_MAKE_STRING(UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ) ".",
+   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, log_ack_req_freq),
+   UCS_CONFIG_TYPE_UINT},
 
   {NULL}
 };

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -425,6 +425,7 @@ typedef struct uct_rc_mlx5_iface_common {
     struct {
         uint8_t                        atomic_fence_flag;
         uct_rc_mlx5_srq_topo_t         srq_topo;
+        uint8_t                        log_ack_req_freq;
     } config;
     UCS_STATS_NODE_DECLARE(stats)
 } uct_rc_mlx5_iface_common_t;
@@ -443,6 +444,7 @@ typedef struct uct_rc_mlx5_iface_common_config {
         size_t                           mp_num_strides;
     } tm;
     unsigned                             exp_backoff;
+    uint8_t                              log_ack_req_freq;
     UCS_CONFIG_STRING_ARRAY_FIELD(types) srq_topo;
 } uct_rc_mlx5_iface_common_config_t;
 
@@ -503,6 +505,11 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_rc_iface_ops_t*,
        (_desc)->super.handler = (uct_rc_send_handler_t)ucs_mpool_put; \
        _length = _pack_cb(hdr, _arg); \
    }
+
+
+/* Max value for log_ack_req_freq field in QPC */
+#define UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ 8
+
 
 #if IBV_HW_TM
 void uct_rc_mlx5_handle_unexp_rndv(uct_rc_mlx5_iface_common_t *iface,

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -432,6 +432,8 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                       iface->super.config.timeout);
     UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.log_rtm,
                       iface->super.config.exp_backoff);
+    UCT_IB_MLX5DV_SET(qpc, qpc, log_ack_req_freq,
+                      iface->config.log_ack_req_freq);
 
     status = uct_ib_mlx5_devx_modify_qp(qp, in_2rts, sizeof(in_2rts),
                                         out_2rts, sizeof(out_2rts));

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -693,6 +693,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_rc_iface_ops_t *ops,
     self->super.config.fence_mode  = (uct_rc_fence_mode_t)rc_config->fence_mode;
     self->super.rx.srq.quota       = self->rx.srq.mask + 1;
     self->super.config.exp_backoff = mlx5_config->exp_backoff;
+    self->config.log_ack_req_freq  = mlx5_config->log_ack_req_freq;
 
     if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
@@ -806,6 +807,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
 
     self->super.super.config.tx_moderation = ucs_min(config->super.tx_cq_moderation,
                                                      self->super.tx.bb_max / 4);
+    self->super.config.log_ack_req_freq    = ucs_min(config->super.log_ack_req_freq,
+                                                     UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ);
 
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -175,6 +175,8 @@ struct uct_rc_iface_config {
     unsigned                       tx_cq_moderation; /* How many TX messages are
                                                         batched to one CQE */
     unsigned                       tx_cq_len;
+    unsigned                       log_ack_req_freq; /* Log of requests ack
+                                                        frequency on DevX */
 };
 
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -265,13 +265,13 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
                               &uct_rc_verbs_iface_tl_ops, tl_md, worker, params,
                               &config->super.super, &init_attr);
 
-    self->config.tx_max_wr           = ucs_min(config->tx_max_wr,
-                                               self->super.config.tx_qp_len);
-    self->super.config.tx_moderation = ucs_min(config->super.tx_cq_moderation,
-                                               self->config.tx_max_wr / 4);
-    self->super.config.fence_mode    = (uct_rc_fence_mode_t)config->super.super.fence_mode;
-    self->super.progress             = uct_rc_verbs_iface_progress;
-    self->super.super.config.sl      = uct_ib_iface_config_select_sl(ib_config);
+    self->config.tx_max_wr               = ucs_min(config->tx_max_wr,
+                                                   self->super.config.tx_qp_len);
+    self->super.config.tx_moderation     = ucs_min(config->super.tx_cq_moderation,
+                                                   self->config.tx_max_wr / 4);
+    self->super.config.fence_mode        = (uct_rc_fence_mode_t)config->super.super.fence_mode;
+    self->super.progress                 = uct_rc_verbs_iface_progress;
+    self->super.super.config.sl          = uct_ib_iface_config_select_sl(ib_config);
 
     if ((config->super.super.fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         (config->super.super.fence_mode == UCT_RC_FENCE_MODE_AUTO)) {


### PR DESCRIPTION
## What
Set `log_ack_req_freq` to a default of 8 (or overridden by configuration) when invoking RTR2RTS in DevX.

## Why ?
Current value of 0 means an ack for every packet, which is undesirable.