### PR TITLE
UCT/IB/MLX5: Build mlx5 in a separate module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_TUNING], [false])
      AM_CONDITIONAL([HAVE_MEMTRACK], [false])
      AM_CONDITIONAL([HAVE_IB], [false])
+     AM_CONDITIONAL([HAVE_MLX5], [false])
      AM_CONDITIONAL([HAVE_MLX5_HW], [false])
      AM_CONDITIONAL([HAVE_MLX5_HW_UD], [false])
      AM_CONDITIONAL([HAVE_MLX5_DV], [false])

--- a/src/uct/ib/Makefile.am
+++ b/src/uct/ib/Makefile.am
@@ -5,15 +5,15 @@
 
 if HAVE_IB
 
-SUBDIRS = . rdmacm
+SUBDIRS = . rdmacm mlx5
 
 module_LTLIBRARIES    = libuct_ib.la
 libuct_ib_la_CPPFLAGS = $(BASE_CPPFLAGS) $(IBVERBS_CPPFLAGS)
 libuct_ib_la_CFLAGS   = $(BASE_CFLAGS)
+libuct_ib_la_LDFLAGS  = $(IBVERBS_LDFLAGS) -version-info $(SOVERSION)
 libuct_ib_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
-                        $(top_builddir)/src/uct/libuct.la
-libuct_ib_la_LDFLAGS  = $(IBVERBS_LDFLAGS) $(NUMA_LIBS) -version-info $(SOVERSION)
-libmlx5_ver           = $(shell (rpm -qf $(IBVERBS_DIR)/include/infiniband/mlx5_hw.h &>/dev/null && rpm -qf /usr/include/infiniband/mlx5_hw.h) | grep -v 'not owned' | head -1)
+                        $(top_builddir)/src/uct/libuct.la \
+						$(IBVERBS_LIBS) $(NUMA_LIBS)
 
 noinst_HEADERS = \
 	base/ib_device.h \
@@ -27,42 +27,6 @@ libuct_ib_la_SOURCES = \
 	base/ib_iface.c \
 	base/ib_log.c \
 	base/ib_md.c
-
-# TODO separate module for mlx5
-if HAVE_MLX5_HW
-libuct_ib_la_CPPFLAGS += -DUCT_IB_LIBMLX5_VER=\"$(libmlx5_ver)\"
-
-noinst_HEADERS += \
-	mlx5/ib_mlx5_log.h \
-	mlx5/ib_mlx5.h \
-	mlx5/ib_mlx5.inl \
-	mlx5/dv/ib_mlx5_dv.h \
-	mlx5/dv/ib_mlx5_ifc.h \
-	mlx5/exp/ib_mlx5_hw.h
-
-libuct_ib_la_SOURCES += \
-	mlx5/ib_mlx5_log.c \
-	mlx5/ib_mlx5.c
-
-if HAVE_EXP
-noinst_HEADERS += \
-	mlx5/exp/ib_exp.h
-
-libuct_ib_la_SOURCES += \
-	mlx5/exp/ib_mlx5_hw.c \
-	mlx5/exp/ib_exp.c \
-	mlx5/exp/ib_exp_md.c
-endif # HAVE_EXP
-
-if HAVE_MLX5_DV
-libuct_ib_la_LDFLAGS +=  $(LIB_MLX5)
-libuct_ib_la_SOURCES += \
-	mlx5/dv/ib_mlx5_dv.c \
-	mlx5/dv/ib_mlx5dv_md.c
-endif # HAVE_MLX5_DV
-
-endif # HAVE_MLX5_HW
-
 
 if HAVE_TL_RC
 noinst_HEADERS += \
@@ -78,43 +42,7 @@ libuct_ib_la_SOURCES += \
 	rc/verbs/rc_verbs_ep.c \
 	rc/verbs/rc_verbs_iface.c
 
-if HAVE_MLX5_HW
-noinst_HEADERS += \
-	rc/accel/rc_mlx5.h \
-	rc/accel/rc_mlx5.inl \
-	rc/accel/rc_mlx5_common.h
-
-libuct_ib_la_SOURCES += \
-	rc/accel/rc_mlx5_ep.c \
-	rc/accel/rc_mlx5_iface.c \
-	rc/accel/rc_mlx5_common.c
-endif # HAVE_MLX5_HW
-
-if HAVE_DEVX
-libuct_ib_la_SOURCES += \
-	rc/accel/rc_mlx5_devx.c
-endif # HAVE_DEVX
-
 endif # HAVE_TL_RC
-
-
-if HAVE_TL_DC
-noinst_HEADERS += \
-	dc/dc_mlx5_ep.h \
-	dc/dc_mlx5.inl \
-	dc/dc_mlx5.h
-
-libuct_ib_la_SOURCES += \
-	dc/dc_mlx5_ep.c \
-	dc/dc_mlx5.c
-
-if HAVE_DEVX
-libuct_ib_la_SOURCES += \
-	dc/dc_mlx5_devx.c
-endif # HAVE_DEVX
-
-endif # HAVE_TL_DC
-
 
 if HAVE_TL_UD
 noinst_HEADERS += \
@@ -131,17 +59,6 @@ libuct_ib_la_SOURCES += \
 	ud/base/ud_ep.c \
 	ud/base/ud_log.c \
 	ud/verbs/ud_verbs.c
-
-
-if HAVE_MLX5_HW_UD
-noinst_HEADERS += \
-	ud/accel/ud_mlx5_common.h \
-	ud/accel/ud_mlx5.h
-
-libuct_ib_la_SOURCES += \
-	ud/accel/ud_mlx5_common.c \
-	ud/accel/ud_mlx5.c
-endif # HAVE_MLX5_HW_UD
 
 endif # HAVE_TL_UD
 

--- a/src/uct/ib/mlx5/Makefile.am
+++ b/src/uct/ib/mlx5/Makefile.am
@@ -1,0 +1,110 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+if HAVE_MLX5
+
+module_LTLIBRARIES         = libuct_ib_mlx5.la
+libuct_ib_mlx5_la_CPPFLAGS = $(BASE_CPPFLAGS) $(IBVERBS_CPPFLAGS) $(MLX5_CPPFLAGS)
+libuct_ib_mlx5_la_CFLAGS   = $(BASE_CFLAGS)
+libuct_ib_mlx5_la_LDFLAGS  = $(IBVERBS_LDFLAGS) $(MLX5_LDFLAGS) -version-info $(SOVERSION)
+libuct_ib_mlx5_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
+                             $(top_builddir)/src/uct/ib/libuct_ib.la \
+                             $(IBVERBS_LIBS)
+
+libmlx5_ver = $(shell (rpm -qf $(IBVERBS_DIR)/include/infiniband/mlx5_hw.h &>/dev/null && rpm -qf /usr/include/infiniband/mlx5_hw.h) | grep -v 'not owned' | head -1)
+
+noinst_HEADERS =
+libuct_ib_mlx5_la_SOURCES =
+
+if HAVE_MLX5_HW
+libuct_ib_mlx5_la_CPPFLAGS += -DUCT_IB_LIBMLX5_VER=\"$(libmlx5_ver)\"
+
+noinst_HEADERS += \
+	ib_mlx5_log.h \
+	ib_mlx5.h \
+	ib_mlx5.inl \
+	dv/ib_mlx5_dv.h \
+	dv/ib_mlx5_ifc.h \
+	exp/ib_mlx5_hw.h
+
+libuct_ib_mlx5_la_SOURCES += \
+	ib_mlx5_log.c \
+	ib_mlx5.c
+
+if HAVE_EXP
+noinst_HEADERS += \
+	exp/ib_exp.h
+
+libuct_ib_mlx5_la_SOURCES += \
+	exp/ib_mlx5_hw.c \
+	exp/ib_exp.c \
+	exp/ib_exp_md.c
+endif # HAVE_EXP
+
+if HAVE_MLX5_DV
+libuct_ib_mlx5_la_LIBADD += $(MLX5_LIBS)
+libuct_ib_mlx5_la_SOURCES += \
+	dv/ib_mlx5_dv.c \
+	dv/ib_mlx5dv_md.c
+endif # HAVE_MLX5_DV
+
+endif # HAVE_MLX5_HW
+
+
+if HAVE_TL_RC
+if HAVE_MLX5_HW
+noinst_HEADERS += \
+	../rc/accel/rc_mlx5.h \
+	../rc/accel/rc_mlx5.inl \
+	../rc/accel/rc_mlx5_common.h
+
+libuct_ib_mlx5_la_SOURCES += \
+	../rc/accel/rc_mlx5_ep.c \
+	../rc/accel/rc_mlx5_iface.c \
+	../rc/accel/rc_mlx5_common.c
+endif # HAVE_MLX5_HW
+
+if HAVE_DEVX
+libuct_ib_mlx5_la_SOURCES += \
+	../rc/accel/rc_mlx5_devx.c
+endif # HAVE_DEVX
+
+endif # HAVE_TL_RC
+
+
+if HAVE_TL_DC
+noinst_HEADERS += \
+	../dc/dc_mlx5_ep.h \
+	../dc/dc_mlx5.inl \
+	../dc/dc_mlx5.h
+
+libuct_ib_mlx5_la_SOURCES += \
+	../dc/dc_mlx5_ep.c \
+	../dc/dc_mlx5.c
+
+if HAVE_DEVX
+libuct_ib_mlx5_la_SOURCES += \
+	../dc/dc_mlx5_devx.c
+endif # HAVE_DEVX
+
+endif # HAVE_TL_DC
+
+
+if HAVE_TL_UD
+if HAVE_MLX5_HW_UD
+noinst_HEADERS += \
+	../ud/accel/ud_mlx5_common.h \
+	../ud/accel/ud_mlx5.h
+
+libuct_ib_mlx5_la_SOURCES += \
+	../ud/accel/ud_mlx5_common.c \
+	../ud/accel/ud_mlx5.c
+endif # HAVE_MLX5_HW_UD
+
+endif # HAVE_TL_UD
+
+include $(top_srcdir)/config/module.am
+
+endif # HAVE_MLX5

--- a/src/uct/ib/mlx5/configure.m4
+++ b/src/uct/ib/mlx5/configure.m4
@@ -1,0 +1,196 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# See file LICENSE for terms.
+#
+
+AC_ARG_WITH([mlx5],
+           [AS_HELP_STRING([--with-mlx5=(DIR)], [Compile with mlx5 support.])],
+           [], [with_mlx5=/usr])
+#
+# DC Support
+#
+AC_ARG_WITH([dc],
+            [AC_HELP_STRING([--with-dc], [Compile with IB Dynamic Connection support])],
+            [],
+            [with_dc=yes])
+
+
+#
+# mlx5 DV support
+#
+AC_ARG_WITH([mlx5-dv],
+            [AC_HELP_STRING([--with-mlx5-dv], [Compile with mlx5 Direct Verbs
+                support. Direct Verbs (DV) support provides additional
+                acceleration capabilities that are not available in a
+                regular mode.])])
+
+
+#
+# DEVX Support
+#
+AC_ARG_WITH([devx], [], [], [with_devx=check])
+
+
+AS_IF([test "x$with_ib" = "xno"], [with_mlx5=no])
+
+AS_IF([test "x$with_mlx5" = "xyes"], [with_mlx5=/usr])
+AS_IF([test -d "$with_mlx5"],
+      [str="with mlx5 support from $with_mlx5"],
+      [with_mlx5=no; str="without mlx5 support"])
+
+AS_IF([test "x$with_mlx5" != "xno"],
+      [
+       AS_IF([test -d "$with_mlx5/lib64"],[libsuff="64"],[libsuff=""])
+       AS_IF([test "x$with_mlx5" = "x/usr"],
+          [],
+          [mlx5_incl_dir="-I$with_mlx5/include"
+           mlx5_libs_dir="-L$with_mlx5/lib$libsuff"])
+
+       save_LIBS="$LIBS"
+       save_LDFLAGS="$LDFLAGS"
+       save_CFLAGS="$CFLAGS"
+       save_CPPFLAGS="$CPPFLAGS"
+
+       AC_SUBST(MLX5_LDFLAGS,  ["$mlx5_libs_dir"])
+       AC_SUBST(MLX5_CFLAGS,   ["$mlx5_incl_dir"])
+       AC_SUBST(MLX5_CPPFLAGS, ["$mlx5_incl_dir"])
+
+       LDFLAGS="$MLX5_LDFLAGS $LDFLAGS"
+       CFLAGS="$MLX5_CFLAGS $CFLAGS"
+       CPPFLAGS="$MLX5_CPPFLAGS $CPPFLAGS"
+
+       AS_IF([test "x$with_mlx5_dv" != xno], [
+               AC_MSG_NOTICE([Checking for legacy bare-metal support])
+               AC_CHECK_HEADERS([infiniband/mlx5_hw.h],
+                               [with_mlx5_hw=yes
+                                mlx5_include=mlx5_hw.h
+                       AC_CHECK_DECLS([
+                           ibv_mlx5_exp_get_qp_info,
+                           ibv_mlx5_exp_get_cq_info,
+                           ibv_mlx5_exp_get_srq_info,
+                           ibv_mlx5_exp_update_cq_ci,
+                           MLX5_WQE_CTRL_SOLICITED],
+                                  [], [], [[#include <infiniband/mlx5_hw.h>]])
+                       AC_CHECK_MEMBERS([struct mlx5_srq.cmd_qp],
+                                  [], [with_ib_hw_tm=no],
+                                      [[#include <infiniband/mlx5_hw.h>]])
+                       AC_CHECK_MEMBERS([struct mlx5_ah.ibv_ah],
+                                  [has_get_av=yes], [],
+                                      [[#include <infiniband/mlx5_hw.h>]])
+                       AC_CHECK_MEMBERS([struct ibv_mlx5_qp_info.bf.need_lock],
+                               [],
+                               [AC_MSG_WARN([Cannot use mlx5 QP because it assumes dedicated BF])
+                                AC_MSG_WARN([Please upgrade MellanoxOFED to 3.0 or above])
+                                with_mlx5_hw=no],
+                               [[#include <infiniband/mlx5_hw.h>]])
+                       AC_CHECK_DECLS([
+                           IBV_EXP_QP_INIT_ATTR_RES_DOMAIN,
+                           IBV_EXP_RES_DOMAIN_THREAD_MODEL,
+                           ibv_exp_create_res_domain,
+                           ibv_exp_destroy_res_domain],
+                                [AC_DEFINE([HAVE_IBV_EXP_RES_DOMAIN], 1, [IB resource domain])
+                                 has_res_domain=yes], [], [[#include <infiniband/verbs_exp.h>]])
+                               ], [with_mlx5_hw=no])
+
+              AC_MSG_NOTICE([Checking for DV bare-metal support])
+
+              AC_CHECK_LIB([mlx5-rdmav2], [mlx5dv_query_device],
+                                    [AC_SUBST(MLX5_LIBS, [-lmlx5-rdmav2])],[
+              AC_CHECK_LIB([mlx5], [mlx5dv_query_device],
+                                    [AC_SUBST(MLX5_LIBS, [-lmlx5])],
+                                    [with_mlx5_dv=no], [-libverbs])], [-libverbs])
+
+              AS_IF([test "x$with_mlx5_dv" != xno], [
+                       AC_CHECK_HEADERS([infiniband/mlx5dv.h],
+                               [with_mlx5_hw=yes
+                                with_mlx5_dv=yes
+                                mlx5_include=mlx5dv.h], [], [ ])])
+
+              AS_IF([test "x$with_mlx5_dv" = "xyes" -a "x$have_cq_io" = "xyes" ], [
+                       AC_CHECK_DECLS([
+                           mlx5dv_init_obj,
+                           mlx5dv_create_qp,
+                           mlx5dv_is_supported,
+                           mlx5dv_devx_subscribe_devx_event,
+                           MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE,
+                           MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE,
+                           MLX5DV_UAR_ALLOC_TYPE_BF,
+                           MLX5DV_UAR_ALLOC_TYPE_NC],
+                                  [], [], [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_MEMBERS([struct mlx5dv_cq.cq_uar],
+                                  [], [], [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_DECLS([MLX5DV_OBJ_AH], [has_get_av=yes],
+                                      [], [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_DECLS([MLX5DV_DCTYPE_DCT],
+                                  [have_dc_dv=yes], [], [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_DECLS([ibv_alloc_td],
+                                  [has_res_domain=yes], [], [[#include <infiniband/verbs.h>]])])
+
+              AC_CHECK_DECLS([ibv_alloc_td],
+                      [has_res_domain=yes], [], [[#include <infiniband/verbs.h>]])])
+
+       AS_IF([test "x$with_devx" != xno], [
+            AC_CHECK_DECL(MLX5DV_CONTEXT_FLAGS_DEVX, [
+                 AC_DEFINE([HAVE_DEVX], [1], [DEVX support])
+                 have_devx=yes
+            ], [
+                 AS_IF([test "x$with_devx" != xcheck],
+                       [AC_MSG_ERROR([devx requested but not found])])
+            ], [[#include <infiniband/mlx5dv.h>]])])
+
+       AS_IF([test "x$has_res_domain" = "xyes" -a "x$have_cq_io" = "xyes" ], [], [
+               with_mlx5_hw=no])
+
+       AS_IF([test "x$with_mlx5_hw" = "xyes"],
+             [AC_MSG_NOTICE([Compiling with mlx5 bare-metal support])
+              AC_DEFINE([HAVE_MLX5_HW], 1, [mlx5 bare-metal support])
+              AS_IF([test "x$has_get_av" = "xyes"],
+                 [AC_DEFINE([HAVE_MLX5_HW_UD], 1, [mlx5 UD bare-metal support])])])
+
+       AC_CHECK_MEMBERS([struct mlx5_wqe_av.base,
+                         struct mlx5_grh_av.rmac],
+                        [], [], [[#include <infiniband/$mlx5_include>]])
+
+       AC_CHECK_MEMBERS([struct mlx5_cqe64.ib_stride_index],
+                        [], [], [[#include <infiniband/$mlx5_include>]])
+
+       AC_CHECK_DECLS([IBV_EXP_QPT_DC_INI],
+                [have_dc_exp=yes], [], [[#include <infiniband/verbs.h>]])
+
+       AS_IF([test "x$with_dc" != xno -a \( "x$have_dc_exp" = xyes -o "x$have_dc_dv" = xyes \) -a "x$with_mlx5_hw" = "xyes"], [
+           AC_DEFINE([HAVE_TL_DC], 1, [DC transport support])
+           AS_IF([test -n "$have_dc_dv"],
+                 [AC_DEFINE([HAVE_DC_DV], 1, [DC DV support])], [
+           AS_IF([test -n "$have_dc_exp"],
+                 [AC_DEFINE([HAVE_DC_EXP], 1, [DC EXP support])])])],
+           [with_dc=no])
+
+
+       LIBS="$save_LIBS"
+       LDFLAGS="$save_LDFLAGS"
+       CFLAGS="$save_CFLAGS"
+       CPPFLAGS="$save_CPPFLAGS"
+
+       uct_ib_modules="${uct_ib_modules}:mlx5"
+    ],
+    [
+        with_mlx5=no
+        with_mlx5_hw=no
+        with_mlx5_dv=no
+        with_dc=no
+    ])
+
+#
+# For automake
+#
+AM_CONDITIONAL([HAVE_MLX5],    [test "x$with_mlx5" != xno])
+AM_CONDITIONAL([HAVE_TL_DC],   [test "x$with_dc" != xno])
+AM_CONDITIONAL([HAVE_DC_DV],   [test -n "$have_dc_dv"])
+AM_CONDITIONAL([HAVE_DC_EXP],  [test -n "$have_dc_exp"])
+AM_CONDITIONAL([HAVE_MLX5_HW], [test "x$with_mlx5_hw" != xno])
+AM_CONDITIONAL([HAVE_MLX5_DV], [test "x$with_mlx5_dv" = xyes])
+AM_CONDITIONAL([HAVE_DEVX],    [test -n "$have_devx"])
+AM_CONDITIONAL([HAVE_MLX5_HW_UD], [test "x$with_mlx5_hw" != xno -a "x$has_get_av" != xno])
+
+AC_CONFIG_FILES([src/uct/ib/mlx5/Makefile])

--- a/src/uct/ib/rdmacm/Makefile.am
+++ b/src/uct/ib/rdmacm/Makefile.am
@@ -26,6 +26,17 @@ libuct_rdmacm_la_SOURCES = \
 	rdmacm_listener.c \
 	rdmacm_cm_ep.c
 
+if HAVE_MLX5
+libuct_rdmacm_la_CPPFLAGS += $(MLX5_CPPFLAGS)
+libuct_rdmacm_la_CFLAGS   += $(MLX5_CFLAGS)
+libuct_rdmacm_la_LDFLAGS  += $(MLX5_LDFLAGS)
+libuct_rdmacm_la_LIBADD   += $(top_builddir)/src/uct/ib/mlx5/libuct_ib_mlx5.la
+endif
+
+if HAVE_MLX5_DV
+libuct_rdmacm_la_LIBADD += $(MLX5_LIBS)
+endif
+
 include $(top_srcdir)/config/module.am
 
 endif # HAVE_RDMACM

--- a/src/uct/ib/rdmacm/configure.m4
+++ b/src/uct/ib/rdmacm/configure.m4
@@ -12,6 +12,8 @@ AC_ARG_WITH([rdmacm],
            [AS_HELP_STRING([--with-rdmacm=(DIR)], [Enable the use of RDMACM (default is guess).])],
            [], [with_rdmacm=guess])
 
+AS_IF([test "x$with_mlx5" = "xno"], [with_rdmacm=no])
+
 AS_IF([test "x$with_rdmacm" != xno],
       [AS_IF([test "x$with_rdmacm" = xguess -o "x$with_rdmacm" = xyes -o "x$with_rdmacm" = x],
              [ucx_check_rdmacm_dir=/usr],

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -194,9 +194,23 @@ gtest_SOURCES += \
 	uct/ib/test_ib_event.cc
 gtest_CPPFLAGS += \
 	$(IBVERBS_CPPFLAGS)
+gtest_LDFLAGS += \
+	$(IBVERBS_LDFLAGS)
 gtest_LDADD += \
-	$(IBVERBS_LDFLAGS) \
+	$(IBVERBS_LIBS) \
 	$(top_builddir)/src/uct/ib/libuct_ib.la
+if HAVE_MLX5
+gtest_CPPFLAGS += \
+	$(MLX5_CPPFLAGS)
+gtest_LDFLAGS += \
+	$(MLX5_LDFLAGS)
+gtest_LDADD += \
+	$(top_builddir)/src/uct/ib/mlx5/libuct_ib_mlx5.la
+endif
+if HAVE_MLX5_DV
+gtest_LDADD += \
+	$(MLX5_LIBS)
+endif
 if HAVE_DEVX
 gtest_SOURCES += \
 	uct/ib/test_devx.cc

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -760,7 +760,7 @@ UCS_TEST_SKIP_COND_P(test_tag, sw_rndv_unexpected,
 UCT_TAG_INSTANTIATE_TEST_CASE(test_tag)
 
 
-#if defined (ENABLE_STATS) && IBV_HW_TM
+#if defined (ENABLE_STATS) && IBV_HW_TM && HAVE_MLX5
 extern "C" {
 #include <uct/api/uct.h>
 #include <uct/ib/rc/accel/rc_mlx5_common.h>
@@ -928,7 +928,7 @@ UCT_TAG_INSTANTIATE_TEST_CASE(test_tag_stats)
 #endif
 
 
-#if IBV_HW_TM
+#if IBV_HW_TM && HAVE_MLX5
 
 extern "C" {
 #include <uct/ib/rc/accel/rc_mlx5_common.h>


### PR DESCRIPTION
## What
Creates a separate IB module for mlx5.

## Why ?
All code for each specific provider should be compiled into its own separate library. This will allow us to avoid linking libuct_ib.so with multiple provider libraries (e.g., both mlx5 and efa). 