### PR TITLE
UCT/CUDA_COPY: add memtype cache instance

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_iface.h>
 #include <uct/cuda/base/cuda_iface.h>
+#include <ucs/memory/memtype_cache.h>
 #include <pthread.h>
 
 
@@ -30,12 +31,14 @@ typedef enum uct_cuda_copy_stream {
 typedef struct uct_cuda_copy_iface {
     uct_base_iface_t            super;
     uct_cuda_copy_iface_addr_t  id;
+    ucs_memtype_cache_t         *memtype_cache;
     ucs_mpool_t                 cuda_event_desc;
     ucs_queue_head_t            outstanding_event_q[UCT_CUDA_COPY_STREAM_LAST];
     cudaStream_t                stream[UCT_CUDA_COPY_STREAM_LAST];
     struct {
         unsigned                max_poll;
         unsigned                max_cuda_events;
+        int                     enable_memtype_cache;
     } config;
     struct {
         void                    *event_arg;
@@ -48,6 +51,7 @@ typedef struct uct_cuda_copy_iface_config {
     uct_iface_config_t      super;
     unsigned                max_poll;
     unsigned                max_cuda_events;
+    int                     enable_memtype_cache;
 } uct_cuda_copy_iface_config_t;
 
 
@@ -57,4 +61,8 @@ typedef struct uct_cuda_copy_event_desc {
     ucs_queue_elem_t  queue;
 } uct_cuda_copy_event_desc_t;
 
+
+void uct_cuda_copy_memory_detect(uct_cuda_copy_iface_t *iface,
+                                 const void *address, size_t length,
+                                 ucs_memory_info_t *mem_info);
 #endif


### PR DESCRIPTION
## What
Use memtype_cache in UCT cuda_copy to cutdown pointer query cost needed to pick the correct stream for each transfer.

@yosefe @bureddy Chose this approach as caching memory type in local memory handle proved problematic to use for end-to-end rendezvous pipeline in https://github.com/openucx/ucx/pull/6801. I'll request that we optimize the problem of finding the right place for the cache later as this solution isn't perfect (drawback being there are two instances {one here and one in UCP} of the memory type cache which is a memory overhead and not a correctness issue).

Also, I tried to move ucp_memory_detect* API and functionality out of ucp/core and into ucs/memory for both UCP and UCT/CUDA_COPY to use but unfortunately UCP needs to additionally check if there are `mem_type_detect_mds` and then iterate through them to correctly detect. For this reason, the code from ucp/core is largely replicated in uct/cuda_copy memory detection functionality. 