### PR TITLE
CONFIG/SPEC: Bump version to 1.12.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@
 AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)
-define([ucx_ver_minor], 11)
+define([ucx_ver_minor], 12)
 define([ucx_ver_patch], 0)
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
 

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -306,6 +306,8 @@ library internals, protocol objects, transports status, and more.
 %endif
 
 %changelog
+* Wed Jun 9 2021 Yossi Itigin <yosefe@mellanox.com> 1.12.0-1
+- Bump version to 1.12.0
 * Tue Apr 27 2021 Leonid Genkin <lgenkin@nvidia.com> 1.11.0-1
 - Remove obsolete ib/cm code
 * Wed Dec 16 2020 Yossi Itigin <yosefe@mellanox.com> 1.11.0-1


### PR DESCRIPTION
# Why
The first commit after creating a new branch https://github.com/openucx/ucx/tree/v1.11.x should be version bump