### PR TITLE
UCS/VFS: Symbolic links support in VFS.

### DIFF
--- a/src/ucs/vfs/base/vfs_obj.h
+++ b/src/ucs/vfs/base/vfs_obj.h
@@ -158,7 +158,7 @@ typedef void (*ucs_vfs_list_dir_cb_t)(const char *name, void *arg);
  * @return UCS_ERR_ALREADY_EXISTS if directory with specified name already
  *                                exists for given @a obj.
  *         UCS_ERR_INVALID_PARAM  if node for @a parent_obj does not exist.
- *         UCS_ERR_NO_MEMORY      if cannot create a new node for @a obj.
+ *         UCS_ERR_NO_MEMORY      if cannot create a new node for directory.
  *         UCS_OK                 otherwise.
  */
 ucs_status_t ucs_vfs_obj_add_dir(void *parent_obj, void *obj,
@@ -180,13 +180,35 @@ ucs_status_t ucs_vfs_obj_add_dir(void *parent_obj, void *obj,
  *
  * @return UCS_ERR_ALREADY_EXISTS if file with specified name already exists.
  *         UCS_ERR_INVALID_PARAM  if node for @a obj does not exist.
- *         UCS_ERR_NO_MEMORY      if cannot create a new node for @a obj.
+ *         UCS_ERR_NO_MEMORY      if cannot create a new node for read-only
+ *                                file.
  *         UCS_OK                 otherwise.
  */
 ucs_status_t ucs_vfs_obj_add_ro_file(void *obj, ucs_vfs_file_show_cb_t text_cb,
                                      void *arg_ptr, uint64_t arg_u64,
                                      const char *rel_path, ...)
         UCS_F_PRINTF(5, 6);
+
+
+/**
+ * Add symbolic link to directory representing @a target_obj. If @a obj is NULL,
+ * the mount directory will be used as the base for @a rel_path.
+ *
+ * @param [in] obj        Pointer to the object. @a rel_path is relative to
+ *                        @a obj directory.
+ * @param [in] target_obj Pointer to object to be linked.
+ * @param [in] rel_path   Format string which specifies relative path to the
+ *                        symbolic link.
+ *
+ * @return UCS_ERR_ALREADY_EXISTS if file with specified name already exists.
+ *         UCS_ERR_INVALID_PARAM  if node for @a obj or for @a target_obj does
+ *                                not exist.
+ *         UCS_ERR_NO_MEMORY      if cannot create a new node for symbolic link.
+ *         UCS_OK                 otherwise.
+ */
+ucs_status_t
+ucs_vfs_obj_add_sym_link(void *obj, void *target_obj, const char *rel_path, ...)
+        UCS_F_PRINTF(3, 4);
 
 
 /**
@@ -258,6 +280,21 @@ ucs_vfs_path_read_file(const char *path, ucs_string_buffer_t *strb);
  */
 ucs_status_t ucs_vfs_path_list_dir(const char *path,
                                    ucs_vfs_list_dir_cb_t dir_cb, void *arg);
+
+
+/**
+ * Fill the string buffer @a strb with the target of a symbolic link.
+ *
+ * @param [in]    path     String which specifies path to the symbolic link node
+ *                         in VFS.
+ * @param [inout] strb     String buffer to be filled with relative path to the
+ *                         target.
+ *
+ * @return UCS_OK          VFS node corresponding to specified path exists and
+ *                         the node is a symbolic link.
+ *         UCS_ERR_NO_ELEM Otherwise.
+ */
+ucs_status_t ucs_vfs_path_get_link(const char *path, ucs_string_buffer_t *strb);
 
 END_C_DECLS
 

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -94,11 +94,9 @@ static int ucs_vfs_fuse_getattr(const char *path, struct stat *stbuf,
 static int ucs_vfs_fuse_open(const char *path, struct fuse_file_info *fi)
 {
     ucs_string_buffer_t strb;
-    ucs_status_t status;
 
     ucs_string_buffer_init(&strb);
-    status = ucs_vfs_path_read_file(path, &strb);
-    if (status != UCS_OK) {
+    if (ucs_vfs_path_read_file(path, &strb) != UCS_OK) {
         return -ENOENT;
     }
 
@@ -126,6 +124,18 @@ static int ucs_vfs_fuse_read(const char *path, char *buf, size_t size,
     memcpy(buf, data + offset, nread);
 
     return nread;
+}
+
+static int ucs_vfs_fuse_readlink(const char *path, char *buf, size_t size)
+{
+    ucs_string_buffer_t strb;
+
+    ucs_string_buffer_init_fixed(&strb, buf, size);
+    if (ucs_vfs_path_get_link(path, &strb) != UCS_OK) {
+        return -ENOENT;
+    }
+
+    return 0;
 }
 
 static int ucs_vfs_fuse_readdir(const char *path, void *buf,
@@ -158,11 +168,12 @@ static int ucs_vfs_fuse_release(const char *path, struct fuse_file_info *fi)
 }
 
 struct fuse_operations ucs_vfs_fuse_operations = {
-    .getattr = ucs_vfs_fuse_getattr,
-    .open    = ucs_vfs_fuse_open,
-    .read    = ucs_vfs_fuse_read,
-    .readdir = ucs_vfs_fuse_readdir,
-    .release = ucs_vfs_fuse_release,
+    .getattr  = ucs_vfs_fuse_getattr,
+    .open     = ucs_vfs_fuse_open,
+    .read     = ucs_vfs_fuse_read,
+    .readlink = ucs_vfs_fuse_readlink,
+    .readdir  = ucs_vfs_fuse_readdir,
+    .release  = ucs_vfs_fuse_release,
 };
 
 static void ucs_vfs_fuse_main()

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -280,3 +280,26 @@ UCS_TEST_F(test_vfs_obj, check_ret) {
     ucs_vfs_obj_remove(&obj1);
     ucs_vfs_obj_remove(&obj2);
 }
+
+UCS_MT_TEST_F(test_vfs_obj, add_sym_link, 4)
+{
+    static const char path_to_target[] = "target";
+
+    static char target;
+    ucs_vfs_obj_add_dir(NULL, &target, "target");
+    ucs_vfs_obj_add_sym_link(NULL, &target, "link");
+
+    ucs_vfs_path_info_t path_info;
+    EXPECT_UCS_OK(ucs_vfs_path_get_info("/link", &path_info));
+    EXPECT_EQ(strlen(path_to_target), path_info.size);
+    EXPECT_TRUE(path_info.mode & S_IFLNK);
+
+    ucs_string_buffer_t strb;
+    ucs_string_buffer_init(&strb);
+    EXPECT_UCS_OK(ucs_vfs_path_get_link("/link", &strb));
+    EXPECT_STREQ(path_to_target, ucs_string_buffer_cstr(&strb));
+    ucs_string_buffer_cleanup(&strb);
+
+    barrier();
+    ucs_vfs_obj_remove(&target);
+}


### PR DESCRIPTION
## What
Added method to add symbolic link to VFS tree.
Added method to get relative to the target of a symbolic link.
Implemented FUSE callback to read symbolic link.
Added gtest for the new method.

## Why ?
To support links between nodes in VFS. E.g. link between UCP lane and UCT ep.