### PR TITLE
APPS/IO-DEMO: Improve logging for connection-related actions

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -875,7 +875,8 @@ void UcxConnection::set_log_prefix(const struct sockaddr* saddr,
 {
     std::stringstream ss;
     _remote_address = UcxContext::sockaddr_str(saddr, addrlen);
-    ss << "[UCX-connection #" << _conn_id << " " << _remote_address << "]";
+    ss << "[UCX-connection " << this << ": #" << _conn_id << " "
+       << _remote_address << "]";
     memset(_log_prefix, 0, MAX_LOG_PREFIX_SIZE);
     int length = ss.str().length();
     if (length >= MAX_LOG_PREFIX_SIZE) {


### PR DESCRIPTION
## What
 
Improve logging for connection-related actions.

## Why ?

To print connection info when disconnecting to improve debugging.
```
[1623350558.799549] [DEMO] timeout waiting for 45 replies on the following connections (0 connections to disconnect):
1. [0x246f640: [UCX-connection #13 2.1.3.23:20000]] has 14 uncompleted operations (read: 0/6; write: 2/10)
2. [0x25a9190: [UCX-connection #38 2.1.3.23:20008]] has 15 uncompleted operations (read: 1/11; write: 0/5)
3. [0x2570770: [UCX-connection #29 2.1.3.23:20007]] has 16 uncompleted operations (read: 0/7; write: 0/9)
```
```
[1623350274.213618] [DEMO] disconnecting [0x25815d0: [UCX-connection #31 2.1.3.23:20002]] connection with 0 uncompleted operations (read: 0/0; write: 0/0) due to "Operation timed out"
```

## How ?

1. Get log prefix of the connection and its pointer to print the information about the connection when disconnecting.
2. Get the list of servers with uncompleted operations and also print the number of connection to disconnect in this case.