### PR TITLE
UCP/CORE: Re-initialize KA begin iterator correctly

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3066,8 +3066,10 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 
         ucp_worker_keepalive_next_ep(worker);
         ucs_assert(worker->keepalive.iter != &ucp_ep_ext_gen(ep)->ep_list);
+    }
 
-        worker->keepalive.iter_begin = worker->keepalive.iter;
+    if (worker->keepalive.iter_begin == &ucp_ep_ext_gen(ep)->ep_list) {
+        worker->keepalive.iter_begin = worker->keepalive.iter_begin->next;
     }
 }
 


### PR DESCRIPTION
## What

Re-initialize KA begin iterator correctly.

## Why ?

To fix possible doing KA for the same EP twice.

## How ?

Check if removed EP from KA is the same as EP set in `iter_begin`. If it is true, move `iter_begin` to the next one.