### PR TITLE
UCT/IB/RC/DC: Set FAILED flag for TXWQ when error is detected

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1189,6 +1189,10 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_dc_mlx5_iface_t);
     struct mlx5_cqe64 *cqe     = arg;
     uint8_t dci_index          = uct_dc_mlx5_iface_dci_find(iface, cqe);
+    UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
+
+    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
+    uct_ib_mlx5_txwq_update_flags(txwq, UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
 
     if (uct_dc_mlx5_iface_is_dci_keepalive(iface, dci_index)) {
         uct_dc_mlx5_dci_keepalive_handle_failure(iface, cqe, dci_index, status);
@@ -1536,6 +1540,8 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
                   iface, dci_index, txwq->super.qp_num,
                   ucs_status_string(status));
     }
+
+    uct_ib_mlx5_txwq_update_flags(txwq, 0, UCT_IB_MLX5_TXWQ_FLAG_FAILED);
 }
 
 void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -477,6 +477,7 @@ void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
     txwq->prev_sw_pi = UINT16_MAX;
 #if UCS_ENABLE_ASSERT
     txwq->hw_ci      = 0xFFFF;
+    txwq->flags      = 0;
 #endif
     uct_ib_fence_info_init(&txwq->fi);
     memset(txwq->qstart, 0, UCS_PTR_BYTE_DIFF(txwq->qstart, txwq->qend));

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -197,6 +197,12 @@ enum {
     UCT_IB_MLX5_SRQ_TOPO_CYCLIC_MP_RQ = 0x3
 };
 
+
+enum {
+    UCT_IB_MLX5_TXWQ_FLAG_FAILED = UCS_BIT(0)
+};
+
+
 #if HAVE_DEVX
 typedef struct uct_ib_mlx5_devx_umem {
     struct mlx5dv_devx_umem  *mem;
@@ -384,6 +390,7 @@ typedef struct uct_ib_mlx5_txwq {
     uint16_t                    sig_pi;     /* PI for last signaled WQE */
 #if UCS_ENABLE_ASSERT
     uint16_t                    hw_ci;
+    uint8_t                     flags; /* Debug flags */
 #endif
     uct_ib_fence_info_t         fi;
 } uct_ib_mlx5_txwq_t;

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -147,6 +147,16 @@ uct_ib_mlx5_txwq_validate(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb)
 }
 
 
+static UCS_F_ALWAYS_INLINE void
+uct_ib_mlx5_txwq_update_flags(uct_ib_mlx5_txwq_t *txwq, uint32_t flags_add,
+                              uint32_t flags_remove)
+{
+#if UCS_ENABLE_ASSERT
+    txwq->flags = (txwq->flags | flags_add) & ~flags_remove;
+#endif
+}
+
+
 /**
  * Copy data to inline segment, taking into account QP wrap-around.
  *

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -450,6 +450,12 @@ uct_rc_mlx5_common_post_send(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     struct mlx5_wqe_ctrl_seg *ctrl;
     uint16_t res_count;
 
+    if (opcode != MLX5_OPCODE_NOP) {
+        /* If FAILED, allow only NOP sends to be posted (used by endpoint
+         * flush operations) */
+        ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
+    }
+
     ctrl = txwq->curr;
 
     if (opcode == MLX5_OPCODE_SEND_IMM) {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -246,6 +246,8 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     ucs_status_t       status;
 
     ucs_assert(ep != NULL);
+
+    uct_ib_mlx5_txwq_update_flags(&ep->tx.wq, UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status, pi, 0);
 
     /* Do not invoke pending requests on a failed endpoint */

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -93,6 +93,7 @@ ucs_status_t test_uct_peer_failure::err_cb(void *arg, uct_ep_h ep,
     test_uct_peer_failure *self = reinterpret_cast<test_uct_peer_failure*>(arg);
 
     self->m_err_count++;
+    self->m_failed_eps.insert(std::make_pair(ep, status));
 
     switch (status) {
     case UCS_ERR_ENDPOINT_TIMEOUT:
@@ -140,10 +141,20 @@ void test_uct_peer_failure::set_am_handlers()
 ucs_status_t test_uct_peer_failure::send_am(int index)
 {
     ucs_status_t status;
-    while ((status = uct_ep_am_short(m_sender->ep(index), 0, 0, NULL, 0)) ==
-           UCS_ERR_NO_RESOURCE) {
+
+    do {
         progress();
-    };
+
+        /* If the endpoint has failed, return error and avoid calling send */
+        std::map<uct_ep_h, ucs_status_t>::iterator it =
+                m_failed_eps.find(m_sender->ep(index));
+        if (it != m_failed_eps.end()) {
+            return it->second;
+        }
+
+        status = uct_ep_am_short(m_sender->ep(index), 0, 0, NULL, 0);
+    } while (status == UCS_ERR_NO_RESOURCE);
+
     return status;
 }
 
@@ -335,30 +346,6 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send,
 }
 
 
-UCS_TEST_SKIP_COND_P(test_uct_peer_failure, two_pairs_send_after,
-                     !check_caps(m_required_caps))
-{
-    set_am_handlers();
-
-    {
-        scoped_log_handler slh(wrap_errors_logger);
-        kill_receiver();
-        for (int i = 0; (i < 100) && (m_err_count == 0); ++i) {
-            send_am(0);
-        }
-        flush();
-    }
-
-    wait_for_value(&m_err_count, size_t(1), true);
-    m_am_count = 0;
-    send_am(1);
-    ucs_debug("flushing");
-    flush_ep(1);
-    ucs_debug("flushed");
-    wait_for_flag(&m_am_count);
-    EXPECT_EQ(m_am_count, 1ul);
-}
-
 UCT_INSTANTIATE_TEST_CASE(test_uct_peer_failure)
 
 class test_uct_peer_failure_multiple : public test_uct_peer_failure
@@ -441,17 +428,16 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure_multiple, test,
 
     {
         scoped_log_handler slh(wrap_errors_logger);
-        for (size_t idx = 0; idx < m_nreceivers - 1; ++idx) {
+        for (size_t idx = 0; idx < (m_nreceivers - 1); ++idx) {
             for (size_t i = 0; i < m_tx_window; ++i) {
-                send_am(idx);
+                EXPECT_UCS_OK(send_am(idx));
             }
             kill_receiver();
         }
         flush(timeout);
 
-        /* if EPs are not failed yet, these ops should trigger that */
-        for (size_t idx = 0; (idx < m_nreceivers - 1) &&
-                             (m_err_count == 0); ++idx) {
+        for (size_t idx = 0; idx < (m_nreceivers - 1); ++idx) {
+            /* If EP were not failed yet, these ops should trigger that */
             for (size_t i = 0; i < m_tx_window; ++i) {
                 if (UCS_STATUS_IS_ERR(send_am(idx))) {
                     break;
@@ -463,7 +449,7 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure_multiple, test,
     }
 
     m_am_count = 0;
-    send_am(m_nreceivers - 1);
+    EXPECT_UCS_OK(send_am(m_nreceivers - 1));
     ucs_debug("flushing");
     flush_ep(m_nreceivers - 1);
     ucs_debug("flushed");

--- a/test/gtest/uct/test_peer_failure.h
+++ b/test/gtest/uct/test_peer_failure.h
@@ -66,13 +66,14 @@ public:
     void fill_resources(bool expect_error, ucs_time_t loop_end_limit);
 
 protected:
-    entity               *m_sender;
-    std::vector<entity *> m_receivers;
-    size_t                m_nreceivers;
-    size_t                m_tx_window;
-    size_t                m_err_count;
-    size_t                m_am_count;
-    static size_t         m_req_purge_count;
-    static const uint64_t m_required_caps;
+    entity                           *m_sender;
+    std::vector<entity *>            m_receivers;
+    std::map<uct_ep_h, ucs_status_t> m_failed_eps;
+    size_t                           m_nreceivers;
+    size_t                           m_tx_window;
+    size_t                           m_err_count;
+    size_t                           m_am_count;
+    static size_t                    m_req_purge_count;
+    static const uint64_t            m_required_caps;
 };
 


### PR DESCRIPTION
## What

Set flag `FAILED` for DCI when error is detected and verify that send/rma/amo/ep_check are not done when `FAILED` flag set on a DCI.

## Why ?

No operations should be scheduled on a failed DCI, because the operations will be failed immediately.

## How ?

1. Set `UCT_DC_MLX5_DCI_FLAG_FAILED` flag when failure is detected on some DCI.
2. Remove `UCT_DC_MLX5_DCI_FLAG_FAILED` flag in `uct_dc_mlx5_iface_reset_dci()`.
3. Check that `UCT_DC_MLX5_DCI_FLAG_FAILED` isn't set when doing am/rma/amo/ep_check operations.
4. Introduce `uct_dc_mlx5_iface_inline_post()` to minimize code duplication for inline operations.