### PR TITLE
UCP/EP: fix discarding from pending on failed lane

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -600,6 +600,9 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
         req->send.proto.comp_cb(req);
     } else if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
+    } else if (req->send.state.uct_comp.func ==
+               ucp_worker_discard_uct_ep_flush_comp) {
+        ucp_worker_discard_uct_ep_progress(req);
     } else if (req->send.state.uct_comp.func != NULL) {
         /* Fast-forward the sending state to complete the operation when last
          * network completion callback is called

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -365,6 +365,12 @@ char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
                                 ucp_worker_cfg_index_t config_idx, char *info,
                                 size_t max);
 
+void ucp_worker_vfs_refresh(void *obj);
+
+void ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self);
+
+unsigned ucp_worker_discard_uct_ep_progress(void *arg);
+
 static UCS_F_ALWAYS_INLINE void
 ucp_worker_flush_ops_count_inc(ucp_worker_h worker)
 {
@@ -381,7 +387,5 @@ ucp_worker_flush_ops_count_dec(ucp_worker_h worker)
     ucs_assert(worker->flush_ops_count > 0);
     --worker->flush_ops_count;
 }
-
-void ucp_worker_vfs_refresh(void *obj);
 
 #endif

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -43,7 +43,6 @@ protected:
     static ucs_status_t
     am_callback(void *arg, const void *header, size_t header_length, void *data,
                 size_t length, const ucp_am_recv_param_t *param);
-    void set_timeouts();
     static void err_cb(void *arg, ucp_ep_h ep, ucs_status_t status);
     ucp_ep_h stable_sender();
     ucp_ep_h failing_sender();
@@ -75,7 +74,6 @@ protected:
     std::string                         m_sbuf, m_rbuf;
     mem_handle_t                        m_stable_memh, m_failing_memh;
     ucs::handle<ucp_rkey_h>             m_stable_rkey, m_failing_rkey;
-    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_peer_failure)
@@ -85,7 +83,7 @@ test_ucp_peer_failure::test_ucp_peer_failure() :
     m_am_rx_count(0), m_err_count(0), m_err_status(UCS_OK)
 {
     ucs::fill_random(m_sbuf);
-    set_timeouts();
+    set_tl_small_timeouts();
 }
 
 void test_ucp_peer_failure::get_test_variants(
@@ -137,10 +135,6 @@ test_ucp_peer_failure::am_callback(void *arg, const void *header,
     test_ucp_peer_failure *self = reinterpret_cast<test_ucp_peer_failure*>(arg);
     ++self->m_am_rx_count;
     return UCS_OK;
-}
-
-void test_ucp_peer_failure::set_timeouts() {
-    set_tl_timeouts(m_env);
 }
 
 void test_ucp_peer_failure::err_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -297,12 +297,12 @@ int ucp_test::max_connections() {
     }
 }
 
-void ucp_test::set_tl_timeouts(ucs::ptr_vector<ucs::scoped_setenv> &env)
+void ucp_test::set_tl_small_timeouts()
 {
     /* Set small TL timeouts to reduce testing time */
-    env.push_back(new ucs::scoped_setenv("UCX_RC_TIMEOUT",     "10ms"));
-    env.push_back(new ucs::scoped_setenv("UCX_RC_RNR_TIMEOUT", "10ms"));
-    env.push_back(new ucs::scoped_setenv("UCX_RC_RETRY_COUNT", "2"));
+    m_env.push_back(new ucs::scoped_setenv("UCX_RC_TIMEOUT",     "10ms"));
+    m_env.push_back(new ucs::scoped_setenv("UCX_RC_RNR_TIMEOUT", "10ms"));
+    m_env.push_back(new ucs::scoped_setenv("UCX_RC_RETRY_COUNT", "2"));
 }
 
 void ucp_test::set_ucp_config(ucp_config_t *config, const std::string& tls)

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -243,7 +243,7 @@ protected:
                                    int worker_index = 0);
     void request_release(void *req);
     int max_connections();
-    void set_tl_timeouts(ucs::ptr_vector<ucs::scoped_setenv> &env);
+    void set_tl_small_timeouts();
 
     // Add test variant without values, with given context params
     static ucp_test_variant&
@@ -339,6 +339,8 @@ protected:
         ucp_mem_h     m_memh;
         void*         m_rkey_buffer;
     };
+
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
 };
 
 


### PR DESCRIPTION
## What
fix discarding from pending on failed lane

## Why ?
bugfix

## How ?
 - increase completion counter only when flush cancel operation has been posted
 - purge pending for discarding lane since discard op can be on pending