### PR TITLE
UCT/IB/DC: Remove unused DCI flags field

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -377,10 +377,6 @@ init_qp:
         dci->ep = NULL;
     }
 
-#if UCS_ENABLE_ASSERT
-    dci->flags = 0;
-#endif
-
     if (dci->txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_VERBS) {
         status = uct_ib_mlx5_txwq_init(iface->super.super.super.super.worker,
                                        iface->super.tx.mmio_mode, &dci->txwq,

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -161,9 +161,6 @@ typedef struct uct_dc_dci {
     };
     uint8_t                       pool_index; /* DCI pool index. */
     uint8_t                       path_index; /* Path index */
-#if UCS_ENABLE_ASSERT
-    uint8_t                       flags; /* debug state, @ref uct_dc_dci_state_t */
-#endif
 } uct_dc_dci_t;
 
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -366,9 +366,6 @@ uct_dc_mlx5_iface_dci_release(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 
     pool->stack_top--;
     pool->stack[pool->stack_top] = dci_index;
-#if UCS_ENABLE_ASSERT
-    iface->tx.dcis[dci_index].flags = 0;
-#endif
 }
 
 /* Release endpoint's DCI below, if the endpoint does not have outstanding
@@ -444,7 +441,6 @@ static inline void uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_d
     ucs_assert(ep->dci >= (iface->tx.ndci * pool_index));
     ucs_assert(ep->dci < (iface->tx.ndci * (pool_index + 1)));
     ucs_assert(uct_dc_mlx5_ep_from_dci(iface, ep->dci) == NULL);
-    ucs_assert(iface->tx.dcis[ep->dci].flags == 0);
     iface->tx.dcis[ep->dci].ep = ep;
     pool->stack_top++;
 }


### PR DESCRIPTION
## What

Remove unused DCI flags field.

## Why ?

It is not used anymore in DC code.

## How ?

1. Remove the `flags` field in `uct_dc_dci_t` structure.
2. Remove all usages/occurrences of `uct_dc_dci_t::flags` field.