### PR TITLE
TOOLS/PERF: Generalize median calculation to support any percentile

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -3,7 +3,7 @@
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
-* Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
+* Copyright (C) ARM Ltd. 2020-2021.  ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -117,7 +117,7 @@ typedef struct ucx_perf_result {
     double                  elapsed_time;
     ucx_perf_counter_t      bytes;
     struct {
-        double              typical;
+        double              percentile;
         double              moment_average; /* Average since last report */
         double              total_average;  /* Average of the whole test */
     }
@@ -195,6 +195,8 @@ typedef struct ucx_perf_params {
     ucx_perf_counter_t     max_iter;        /* Iterations limit, 0 - unlimited */
     double                 max_time;        /* Time limit (seconds), 0 - unlimited */
     double                 report_interval; /* Interval at which to call the report callback */
+    double                 percentile_rank; /* The percentile rank of the percentile reported
+                                               in latency tests */
 
     void                   *rte_group;      /* Opaque RTE group handle */
     ucx_perf_rte_t         *rte;            /* RTE functions used to exchange data */


### PR DESCRIPTION
## What

This PR generalizes the calculation and display of the median latency to support any user-defined percentile.

A `-R <rank>` option is added to `ucx_perftest` so that the user can provide a percentile rank (0% ~ 100%), and the corresponding percentile will be displayed in the output.

## Why ?

So the user can get different types of statistics: 0.01% = best latency, 50.0% = median latency, 99.9% = tail latency.

This PR also fixes an issue in median latency calculation: if the number of iterations is less than half of `TIMING_QUEUE_SIZE`, the `timing_queue` array will only be less than half full, so the median latency will always be zero.

## How ?

Add a new `-R` option, adjust the quick select function, adjust the stats display code.

One question: is there any reason why the length of the `timing_queue` array, `TIMING_QUEUE_SIZE`, is only 2048? This is too short for getting high-quality percentiles for small messages which usually runs for millions of iterations.