### PR TITLE
COVERITY: suppressed false positives - v1.10

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -204,6 +204,7 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, uint64_t tl_bitmap,
     req->send.buffer = address;
 
     ucp_request_send(req, 0);
+    /* coverity[leaked_storage] */
     return UCS_OK;
 }
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -438,6 +438,7 @@ int ucs_config_sscanf_time(const char *buf, void *dest, const void *arg)
         return 0;
     }
 
+    /* cppcheck-suppress[uninitvar] */
     *(double*)dest = value / per_sec;
     return 1;
 }

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -845,6 +845,7 @@ static void ucs_rcache_before_fork(void)
              * - Other use cases shouldn't be affected
              */
             pthread_rwlock_wrlock(&rcache->pgt_lock);
+            /* coverity[double_lock] */
             ucs_rcache_invalidate_range(rcache, 0, UCS_PGT_ADDR_MAX, 0);
             pthread_rwlock_unlock(&rcache->pgt_lock);
         }

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -433,6 +433,7 @@ void uct_ib_mlx5_av_dump(char *buf, size_t max,
     p    = buf;
     endp = buf + max - 1;
 
+    /* cppcheck-suppress[uninitvar] */
     snprintf(p, endp - p, " [rqpn 0x%x",
              ntohl(base_av->dqp_dct & ~UCT_IB_MLX5_EXTENDED_UD_AV));
     p += strlen(p);
@@ -442,6 +443,7 @@ void uct_ib_mlx5_av_dump(char *buf, size_t max,
         p += strlen(p);
     }
 
+    /* cppcheck-suppress[uninitvar] */
     if (base_av->dqp_dct & UCT_IB_MLX5_EXTENDED_UD_AV) {
         if (is_eth || (grh_av->grh_gid_fl & UCT_IB_MLX5_AV_GRH_PRESENT)) {
             if (is_eth) {


### PR DESCRIPTION
- there is set of coverity false positives
- suppressed

back port from https://github.com/openucx/ucx/pull/6945

(cherry picked from commit a1f0aa9ec6902a5ce38d8f023a3e626d89b80aaa)
