### PR TITLE
BUILD/RPM: Fix with-fuse arg for rpm build

### DIFF
--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -105,7 +105,7 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_args+=" $(with_arg rocm)"
 	with_args+=" $(with_arg ugni)"
 	with_args+=" $(with_arg xpmem)"
-	with_args+=" $(with_arg vfs)"
+	with_args+=" $(with_arg fuse)"
 	with_args+=" $(with_arg java)"
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx


### PR DESCRIPTION
# Why
Fix issue that binary RPM created with rpmbuild.sh tool did not include VFS/Fuse support