### PR TITLE
TOOLS/PERF: Fix run_stream_uni

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -590,6 +590,11 @@ public:
         rkey        = m_perf.ucp.rkey;
         sn          = 0;
 
+        if (CMD == UCX_PERF_CMD_PUT) {
+            *(uint8_t*)send_buffer = 0;
+            *(uint8_t*)recv_buffer = 0;
+        }
+
         ucp_perf_init_common_params(&length, &send_length, &send_datatype,
                                     &send_buffer, &recv_length, &recv_datatype,
                                     &recv_buffer);


### PR DESCRIPTION
Set sn to 0 before run UCX_PERF_CMD_PUT.

## What/Why

When test `ucp_put`, `run_stream_uni` use `sn = 1` to indicate the completion of the last iteration. In multiple rounds of testing, sn must be set to 0 before the start of test. Without this fix, `ucx_perftest -t ucp_put_bw` will get wrong results with ud transport.

```
# before fix
➜  ucx git:(master) ✗ UCX_NET_DEVICES=mlx4_0:1 UCX_TLS=ud ./install-debug/bin/ucx_perftest t04 -t ucp_put_bw -s 409600
[1623772525.376478] [tstore04:5596 :0]        perftest.c:1581 UCX  WARN  CPU affinity is not set (bound to 24 cpus). Performance may be impacted.
+--------------+--------------+-----------------------------+---------------------+-----------------------+
|              |              |      overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | typical | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
[thread 0]               133     0.000  7538.510  7538.510       51.82      51.82         133         133
[thread 0]               268     0.000  7490.474  7514.313       52.15      51.98         134         133
[thread 0]               403     0.000  7421.667  7483.278       52.63      52.20         135         134

# after fix
➜  ucx git:(master) ✗ UCX_NET_DEVICES=mlx4_0:1 UCX_TLS=ud ./install-debug/bin/ucx_perftest t04 -t ucp_put_bw -s 409600
[1623773120.727365] [tstore04:28530:0]        perftest.c:1581 UCX  WARN  CPU affinity is not set (bound to 24 cpus). Performance may be impacted.
+--------------+--------------+-----------------------------+---------------------+-----------------------+
|              |              |      overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | typical | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+---------+---------+---------+----------+----------+-----------+-----------+
[thread 0]             11777    90.122    84.911    84.911     4600.40    4600.40       11777       11777
[thread 0]             23798    91.145    83.192    84.043     4695.46    4647.93       12020       11899
```