### PR TITLE
UCP/RNDV/CORE: Complete super request and release ID if sending RTR fails

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2817,8 +2817,8 @@ static void ucp_ep_req_purge_send(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_and_dereg_send(req, status);
 }
 
-static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
-                             ucs_status_t status, int recursive)
+void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
+                      ucs_status_t status, int recursive)
 {
     ucp_trace_req(req, "purged with status %s (%d) on ep %p",
                   ucs_status_string(status), status, ucp_ep);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -677,6 +677,21 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
  */
 int ucp_ep_do_keepalive(ucp_ep_h ep, ucs_time_t now);
 
+
+/**
+ * @brief Purge the protocol request scheduled on a given UCP endpoint.
+ *
+ * @param [in]     ucp_ep           Endpoint object on which the request should
+ *                                  be purged.
+ * @param [in]     req              The request to purge.
+ * @param [in]     status           Completion status.
+ * @param [in]     recursive        Indicates if the function was called from
+ *                                  the @ref ucp_ep_req_purge recursively.
+ */
+void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
+                      ucs_status_t status, int recursive);
+
+
 /**
  * @brief Purge flush and protocol requests scheduled on a given UCP endpoint.
  *

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -87,8 +87,8 @@ void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,
                       const ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                       const void *rkey_buf);
 
-ucs_status_t ucp_rndv_rts_handle_status_from_pending(ucp_request_t *sreq,
-                                                     ucs_status_t status);
+ucs_status_t ucp_rndv_send_handle_status_from_pending(ucp_request_t *sreq,
+                                                      ucs_status_t status);
 
 static UCS_F_ALWAYS_INLINE int
 ucp_rndv_rts_is_am(const ucp_rndv_rts_hdr_t *rts_hdr)

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -563,7 +563,7 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     status = uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane],
                                      req->send.msg_proto.tag, rndv_rts_hdr,
                                      packed_len, 0);
-    return ucp_rndv_rts_handle_status_from_pending(req, status);
+    return ucp_rndv_send_handle_status_from_pending(req, status);
 }
 
 static void ucp_tag_offload_rndv_zcopy_completion(uct_completion_t *self)
@@ -609,7 +609,7 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
                                     &req->send.state.uct_comp);
     if (ucs_unlikely(UCS_PTR_IS_ERR(rndv_op))) {
         status = UCS_PTR_STATUS(rndv_op);
-        return ucp_rndv_rts_handle_status_from_pending(req, status);
+        return ucp_rndv_send_handle_status_from_pending(req, status);
     }
 
     ucp_request_send_state_advance(req, &dt_state,


### PR DESCRIPTION
## What

Complete super request and release ID if sending RTR fails.

## Why ?

To complete user's request and fix request ID leak,

## How ?

1. Rename `ucp_rndv_rts_handle_status_from_pending()` to `ucp_rndv_send_handle_status_from_pending()`.
2. Update `ucp_rndv_send_handle_status_from_pending()` to handle RTR send request by releasing RTR request and super RECV request.
3. Use `ucp_rndv_send_handle_status_from_pending()` for handling status of sending RTS/RTR packets.