### PR TITLE
UCP/CORE: Purge super request for send request during fast-forward

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -627,7 +627,7 @@ static void ucp_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_send(req, status);
 }
 
-void ucp_am_zcopy_completion(uct_completion_t *self)
+static void ucp_am_zcopy_completion(uct_completion_t *self)
 {
     ucp_request_t *req  = ucs_container_of(self, ucp_request_t,
                                            send.state.uct_comp);
@@ -703,7 +703,7 @@ static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
                                  ucp_am_zcopy_req_complete, 1);
 }
 
-size_t ucp_am_rndv_rts_pack(void *dest, void *arg)
+static size_t ucp_am_rndv_rts_pack(void *dest, void *arg)
 {
     ucp_request_t *sreq         = arg;
     ucp_rndv_rts_hdr_t *rts_hdr = dest;

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -90,6 +90,8 @@ void ucp_am_ep_cleanup(ucp_ep_h ep);
 
 size_t ucp_am_max_header_size(ucp_worker_h worker);
 
+ucs_status_t ucp_proto_progress_am_rndv_rts(uct_pending_req_t *self);
+
 ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
                                      unsigned tl_flags);
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2817,11 +2817,17 @@ static void ucp_ep_req_purge_send(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_and_dereg_send(req, status);
 }
 
-static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
-                             ucs_status_t status, int recursive)
+void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
+                      ucs_status_t status, int recursive)
 {
     ucp_trace_req(req, "purged with status %s (%d) on ep %p",
                   ucs_status_string(status), status, ucp_ep);
+
+    /* RNDV GET/PUT Zcopy operations shouldn't be handled here, because they
+     * don't allocate local request ID, so they are not added on a list of
+     * tracked operations */
+    ucs_assert((req->send.uct.func != ucp_rndv_progress_rma_get_zcopy) &&
+               (req->send.uct.func != ucp_rndv_progress_rma_put_zcopy));
 
     /* Only send operations could have request ID allocated */
     if (!(req->flags &
@@ -2837,11 +2843,13 @@ static void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
         ucs_assert(!(req->flags & UCP_REQUEST_FLAG_SUPER_VALID));
         ucs_assert(recursive); /* Mustn't be directly contained in an EP list
                                 * of tracking requests */
+        ucp_request_recv_buffer_dereg(req);
         ucp_request_complete_am_recv(req, status);
     } else if (req->flags & UCP_REQUEST_FLAG_RECV_TAG) {
         ucs_assert(!(req->flags & UCP_REQUEST_FLAG_SUPER_VALID));
         ucs_assert(recursive); /* Mustn't be directly contained in an EP list
                                 * of tracking requests */
+        ucp_request_recv_buffer_dereg(req);
         ucp_request_complete_tag_recv(req, status);
     } else if (req->flags & UCP_REQUEST_FLAG_RNDV_FRAG) {
         ucs_assert(req->flags & UCP_REQUEST_FLAG_SUPER_VALID);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -677,6 +677,21 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
  */
 int ucp_ep_do_keepalive(ucp_ep_h ep, ucs_time_t now);
 
+
+/**
+ * @brief Purge the protocol request scheduled on a given UCP endpoint.
+ *
+ * @param [in]     ucp_ep           Endpoint object on which the request should
+ *                                  be purged.
+ * @param [in]     req              The request to purge.
+ * @param [in]     status           Completion status.
+ * @param [in]     recursive        Indicates if the function was called from
+ *                                  the @ref ucp_ep_req_purge recursively.
+ */
+void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
+                      ucs_status_t status, int recursive);
+
+
 /**
  * @brief Purge flush and protocol requests scheduled on a given UCP endpoint.
  *

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -14,6 +14,7 @@
 #include "ucp_request.inl"
 
 #include <ucp/proto/proto_am.h>
+#include <ucp/tag/tag_rndv.h>
 
 #include <ucs/datastruct/mpool.inl>
 #include <ucs/debug/debug_int.h>
@@ -613,6 +614,12 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
              */
             req->send.state.uct_comp.func(&req->send.state.uct_comp);
         }
+    } else if ((req->send.uct.func == ucp_proto_progress_rndv_rtr) ||
+               (req->send.uct.func == ucp_proto_progress_am_rndv_rts) ||
+               (req->send.uct.func == ucp_proto_progress_tag_rndv_rts)) {
+        /* Canceling control message which asks for remote side to reply is
+         * equivalent to reply not being received */
+        ucp_ep_req_purge(req->send.ep, req, status, 1);
     } else {
         ucp_request_complete_send(req, status);
     }

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -81,6 +81,8 @@ ucs_status_t ucp_rndv_progress_rma_put_zcopy(uct_pending_req_t *self);
 size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                          ucp_rndv_rts_opcode_t opcode);
 
+ucs_status_t ucp_proto_progress_rndv_rtr(uct_pending_req_t *self);
+
 ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq);
 
 void ucp_rndv_receive(ucp_worker_h worker, ucp_request_t *rreq,

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -77,7 +77,7 @@ size_t ucp_tag_rndv_rts_pack(void *dest, void *arg)
     return ucp_rndv_rts_pack(sreq, rts_hdr, UCP_RNDV_RTS_TAG_OK);
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_rndv_rts, (self),
+UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_tag_rndv_rts, (self),
                  uct_pending_req_t *self)
 {
     ucp_request_t *sreq = ucs_container_of(self, ucp_request_t, send.uct);
@@ -107,7 +107,7 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
         status = ucp_tag_offload_start_rndv(sreq);
     } else {
         ucs_assert(sreq->send.lane == ucp_ep_get_am_lane(ep));
-        sreq->send.uct.func = ucp_proto_progress_rndv_rts;
+        sreq->send.uct.func = ucp_proto_progress_tag_rndv_rts;
         status              = ucp_rndv_reg_send_buffer(sreq);
     }
 

--- a/src/ucp/tag/tag_rndv.h
+++ b/src/ucp/tag/tag_rndv.h
@@ -30,6 +30,8 @@ ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
 
 size_t ucp_tag_rndv_rts_pack(void *dest, void *arg);
 
+ucs_status_t ucp_proto_progress_tag_rndv_rts(uct_pending_req_t *self);
+
 
 static UCS_F_ALWAYS_INLINE ucp_rndv_rts_hdr_t *
 ucp_tag_rndv_rts_from_rdesc(ucp_recv_desc_t *rdesc)


### PR DESCRIPTION
## What

Purge super request for send request during fast-forward.

## Why ?

When doing send state fast-forward for normal send request, this send request can be RTR send request which has super request (i.e. receive request - exposed to a user). So, the receive request should be completed as well if the derived request fails, otherwise - it will be a leak.
Fixes `"No traffic"` and `"timeout waiting for <number> replies"` and `"Have read min:0"`/`"write min:0"`.

## How ?

1. Expose `ucp_ep_req_purge()` for using in `ucp_request_send_state_ff()`.
2. Use `ucp_ep_req_purge()` to complete super request when doing fast-forward for the send request and `super_req` is not `NULL`.