### PR TITLE
UCT/DC/MLX5: Fix deadlock between DCI resources and RDMA_READ credits

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -299,6 +299,24 @@ uct_dc_mlx5_iface_dci_can_alloc(uct_dc_mlx5_iface_t *iface, uint8_t pool_index)
 }
 
 static UCS_F_ALWAYS_INLINE void
+uct_dc_mlx5_iface_check_tx(uct_dc_mlx5_iface_t *iface)
+{
+#if UCS_ENABLE_ASSERT
+    uint8_t pool_index;
+
+    for (pool_index = 0; pool_index < iface->tx.num_dci_pools; ++pool_index) {
+        if (uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index)) {
+            ucs_assertv(ucs_arbiter_is_empty(
+                                uct_dc_mlx5_iface_dci_waitq(iface, pool_index)),
+                        "dc_iface %p pool %d: can allocate dci, but pending is "
+                        "not empty",
+                        iface, pool_index);
+        }
+    }
+#endif
+}
+
+static UCS_F_ALWAYS_INLINE void
 uct_dc_mlx5_iface_progress_pending(uct_dc_mlx5_iface_t *iface,
                                    uint8_t pool_index)
 {
@@ -326,6 +344,7 @@ uct_dc_mlx5_iface_progress_pending(uct_dc_mlx5_iface_t *iface,
 
     } while (ucs_unlikely(!ucs_arbiter_is_empty(dci_waitq) &&
                           uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index)));
+    uct_dc_mlx5_iface_check_tx(iface);
 }
 
 static inline int uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
@@ -523,10 +542,7 @@ uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
         return UCS_OK;
     }
 
-    /* Do not alloc dci if no TX desc resources,
-     * otherwise this dci may never be released. */
-    if (uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index) &&
-        uct_dc_mlx5_iface_has_tx_resources(iface)) {
+    if (uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index)) {
         uct_dc_mlx5_iface_dci_alloc(iface, ep);
         return UCS_OK;
     }
@@ -562,15 +578,14 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
 
 #define UCT_DC_CHECK_RES_PTR(_iface, _ep) \
     { \
-        UCT_RC_CHECK_NUM_RDMA_READ_RET(&(_iface)->super.super, \
-                                       UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
         { \
-            ucs_status_t status = \
-                uct_dc_mlx5_iface_dci_get(_iface, _ep); \
+            ucs_status_t status = uct_dc_mlx5_iface_dci_get(_iface, _ep); \
             if (ucs_unlikely(status != UCS_OK)) { \
                 return UCS_STATUS_PTR(status); \
             } \
         } \
+        UCT_RC_CHECK_NUM_RDMA_READ_RET(&(_iface)->super.super, \
+                                       UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE)) \
     }
 
 
@@ -582,9 +597,9 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
  */
 #define UCT_DC_MLX5_CHECK_RES(_iface, _ep) \
     { \
+        UCT_DC_MLX5_CHECK_DCI_RES(_iface, _ep) \
         UCT_RC_CHECK_NUM_RDMA_READ_RET(&(_iface)->super.super, \
                                        UCS_ERR_NO_RESOURCE) \
-        UCT_DC_MLX5_CHECK_DCI_RES(_iface, _ep) \
     }
 
 
@@ -594,6 +609,7 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
  * available TX resources. */
 #define UCT_DC_CHECK_RES_AND_FC(_iface, _ep) \
     { \
+        UCT_DC_MLX5_CHECK_RES(_iface, _ep) \
         if (ucs_unlikely((_ep)->fc.fc_wnd <= \
                          (_iface)->super.super.config.fc_hard_thresh)) { \
             ucs_status_t _status = uct_dc_mlx5_ep_check_fc(_iface, _ep); \
@@ -607,7 +623,6 @@ static inline struct mlx5_grh_av *uct_dc_mlx5_ep_get_grh(uct_dc_mlx5_ep_t *ep)
                 return _status; \
             } \
         } \
-        UCT_DC_MLX5_CHECK_RES(_iface, _ep) \
         if (!uct_dc_mlx5_iface_is_dci_rand(_iface)) { \
             uct_rc_iface_check_pending(&(_iface)->super.super, \
                                        &(_ep)->arb_group); \


### PR DESCRIPTION
## Why
Fix a hang in the following test, which is caused by adding a pending request to DCI-wait arbiter while it's actually waiting for RDMA_READ credits and not for a DCI.
```
mpirun -np 8 -x UCX_TLS=dc_x,self,sm -x UCX_IB_NUM_PATHS=4 -x UCX_MAX_EAGER_LANES=4 -x UCX_MAX_RNDV_LANES=4 --map-by node -x UCX_RC_MAX_GET_ZCOPY=8192 -x UCX_RC_TX_NUM_GET_BYTES=128K osu_alltoall
...
# OSU MPI All-to-All Personalized Exchange Latency Test v5.6.2
# Size       Avg Latency(us)
1                       2.57
2                       2.50
4                       2.44
8                       2.45
16                      2.44
32                      2.55
64                      2.80
128                     3.14
256                     4.37
512                     4.86
1024                    6.19
2048                    8.19
4096                   14.49
8192                   28.20
16384                  58.23
32768                 116.97
65536                 224.96
131072                432.23
<hang>
```
Internal issue ref: https://redmine.mellanox.com/issues/2691179

## How
- Check and allocate a DCI before checking TX resources
- Add assertion than if we can allocate a DCI, its arbiter is empty


## Branches
 This fix should be ported to v1.11.x branch and not relevant for v1.10 which does not have multiple DCI pools.