### PR TITLE
UCP/WIREUP: Fix comment

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1330,8 +1330,9 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     bw_info.criteria.title          = "high-bw remote memory access";
     bw_info.max_lanes               = context->config.ext.max_rndv_lanes;
     bw_info.criteria.local_md_flags = md_reg_flag;
-    /* in case if error handling is requested we require memory invalidation
-     * support to provide correct data integrity in in case of error */
+
+    /* If error handling is requested we require memory invalidation
+     * support to provide correct data integrity in case of error */
     if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
         bw_info.criteria.local_md_flags |= UCT_MD_FLAG_INVALIDATE;
     }


### PR DESCRIPTION
## What

Fix comment in CUP/WIREUP selection code.

## Why ?

1. To not repeat `"in case"`.
2. To remove extra `"in"`.

## How ?

1. Remove `"in case"` at the begging of the comment and start the comment from the capital letter,
2. Remove `"in"`