### PR TITLE
UCP/WIRUEP/GTEST/UCT: Fix not selecting RNDV/RMA/AMO lanes during CM init phase

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -120,9 +120,10 @@ enum {
                                                            CM phase */
     UCP_EP_INIT_FLAG_INTERNAL          = UCS_BIT(6),  /**< Endpoint for internal usage
                                                            (e.g. memtype, reply on keepalive) */
-    UCP_EP_INIT_CONNECT_TO_IFACE_ONLY  = UCS_BIT(7)   /**< Select transports which
+    UCP_EP_INIT_CONNECT_TO_IFACE_ONLY  = UCS_BIT(7),  /**< Select transports which
                                                            support CONNECT_TO_IFACE
                                                            mode only */
+    UCP_EP_INIT_CREATE_AM_LANE_ONLY    = UCS_BIT(8)   /**< Endpoint requires an AM lane only */
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -859,7 +859,7 @@ ucp_wireup_add_rma_lanes(const ucp_wireup_select_params_t *select_params,
 
     if ((!(ucp_ep_get_context_features(select_params->ep) & UCP_FEATURE_RMA) &&
          !(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE)) ||
-        (ep_init_flags & UCP_EP_INIT_CM_PHASE)) {
+        (ep_init_flags & UCP_EP_INIT_CREATE_AM_LANE_ONLY)) {
         return UCS_OK;
     }
 
@@ -910,7 +910,8 @@ ucp_wireup_add_amo_lanes(const ucp_wireup_select_params_t *select_params,
 
     if (!ucs_test_flags(context->config.features, UCP_FEATURE_AMO32,
                         UCP_FEATURE_AMO64) ||
-        (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE | UCP_EP_INIT_CM_PHASE))) {
+        (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE |
+                          UCP_EP_INIT_CREATE_AM_LANE_ONLY))) {
         return UCS_OK;
     }
 
@@ -1187,7 +1188,8 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
     /* Check if we need active message BW lanes */
     if (!(ucp_ep_get_context_features(ep) &
           (UCP_FEATURE_TAG | UCP_FEATURE_AM)) ||
-        (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE | UCP_EP_INIT_CM_PHASE)) ||
+        (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE |
+                          UCP_EP_INIT_CREATE_AM_LANE_ONLY)) ||
         (context->config.ext.max_eager_lanes < 2)) {
         return UCS_OK;
     }
@@ -1271,7 +1273,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_tl_bitmap_t tl_bitmap;
     uint8_t i;
 
-    if (ep_init_flags & UCP_EP_INIT_CM_PHASE) {
+    if (ep_init_flags & UCP_EP_INIT_CREATE_AM_LANE_ONLY) {
         return UCS_OK;
     }
 
@@ -1400,7 +1402,8 @@ ucp_wireup_add_tag_lane(const ucp_wireup_select_params_t *select_params,
     ucs_status_t status;
 
     if (!(ucp_ep_get_context_features(ep) & UCP_FEATURE_TAG) ||
-        (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE | UCP_EP_INIT_CM_PHASE)) ||
+        (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE |
+                          UCP_EP_INIT_CREATE_AM_LANE_ONLY)) ||
         /* TODO: remove check below when UCP_ERR_HANDLING_MODE_PEER supports
          *       RNDV-protocol or HW TM supports fragmented protocols
          */
@@ -1797,8 +1800,11 @@ out:
     ucp_wireup_construct_lanes(&select_params, &select_ctx, addr_indices, key);
 
     /* Only two lanes must be created during CM phase (CM lane and TL lane) of
-     * connection setup between two peers */
-    ucs_assert(!(ep_init_flags & UCP_EP_INIT_CM_PHASE) || key->num_lanes == 2);
+     * connection setup between two peers, if an AM lane only requested */
+    ucs_assert(!ucs_test_all_flags(ep_init_flags,
+                                   UCP_EP_INIT_CREATE_AM_LANE_ONLY |
+                                   UCP_EP_INIT_CM_PHASE) ||
+               (key->num_lanes == 2));
 
     return UCS_OK;
 }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -588,8 +588,8 @@ std::string exit_status_info(int exit_status)
     return ss.str().substr(2, std::string::npos);
 }
 
-sock_addr_storage::sock_addr_storage(bool is_rdmacm_netdev) :
-        m_size(0), m_is_valid(false), m_is_rdmacm_netdev(is_rdmacm_netdev)
+sock_addr_storage::sock_addr_storage() :
+        m_size(0), m_is_valid(false), m_is_rdmacm_netdev(false)
 {
     memset(&m_storage, 0, sizeof(m_storage));
 }

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -325,7 +325,7 @@ std::string sockaddr_to_str(const S *saddr) {
  */
 class sock_addr_storage {
 public:
-    sock_addr_storage(bool is_rdmacm_netdev = false);
+    sock_addr_storage();
 
     sock_addr_storage(const ucs_sock_addr_t &ucs_sock_addr,
                       bool is_rdmacm_netdev = false);

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -190,11 +190,12 @@ public:
                     continue;
                 }
 
-                saddrs.push_back(ucs::sock_addr_storage(
-                        ucs::is_rdmacm_netdev(ifa->ifa_name)));
+                saddrs.push_back(ucs::sock_addr_storage());
                 status = ucs_sockaddr_sizeof(ifa->ifa_addr, &size);
                 ASSERT_UCS_OK(status);
-                saddrs.back().set_sock_addr(*ifa->ifa_addr, size);
+                saddrs.back().set_sock_addr(*ifa->ifa_addr, size,
+                                            ucs::is_rdmacm_netdev(
+                                                    ifa->ifa_name));
                 saddrs.back().set_port(0); /* listen on any port then update */
             }
         }
@@ -1220,6 +1221,41 @@ UCS_TEST_P(test_ucp_sockaddr_cm_private_data,
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_sockaddr_cm_private_data, all, "all")
 
+
+class test_ucp_sockaddr_check_lanes : public test_ucp_sockaddr {
+protected:
+    void check_rndv_lanes(ucp_ep_h ep)
+    {
+        for (ucp_lane_index_t lane_idx = 0;
+             lane_idx < ucp_ep_num_lanes(ep); ++lane_idx) {
+            if ((lane_idx != ucp_ep_get_cm_lane(ep)) &&
+                (ucp_ep_get_iface_attr(ep, lane_idx)->cap.flags &
+                         (UCT_IFACE_FLAG_GET_ZCOPY |
+                          UCT_IFACE_FLAG_PUT_ZCOPY)) &&
+                /* RNDV lanes should be selected if transport supports GET/PUT
+                 * Zcopy and memory invalidation */
+                (ucp_ep_md_attr(ep, lane_idx)->cap.flags &
+                         UCT_MD_FLAG_INVALIDATE)) {
+                EXPECT_NE(UCP_NULL_LANE, ucp_ep_config(ep)->key.rma_bw_lanes[0])
+                        << "RNDV lanes should be selected";
+                break;
+            }
+        }
+    }
+};
+
+
+UCS_TEST_P(test_ucp_sockaddr_check_lanes, check_rndv_lanes)
+{
+    listen_and_communicate(false, SEND_DIRECTION_BIDI);
+
+    check_rndv_lanes(sender().ep());
+    check_rndv_lanes(receiver().ep());
+
+    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+}
+
+UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_check_lanes)
 
 class test_ucp_sockaddr_destroy_ep_on_err : public test_ucp_sockaddr {
 public:


### PR DESCRIPTION
## What

1. Fix not selecting RNDV/RMA/AMO lanes during CM init phase.
2. Add gtest to check RNDV lanes selection.
3. Add support for `UCT_MD_FLAG_INVALIDATE` flags in TCP.

## Why ?

1. To use RNDV GET/PUT Zcopy schemes for EP created when `UCX_CM_USE_ALL_DEVICES=n` is set.
2. To reproduce the problem.
3. To pass gtest for TCP.

## How ?

1. Added support `UCP_EP_INIT_CREATE_AM_LANE_ONLY` EP init flags; use this flag when creating CM client initial config to fit CM data length limit.
2. If PUT/GET Zcopy capabilities are supported by EP, check that RNDV lanes are created.
3. To pass the new gtest for TCP.