### PR TITLE
UCT/IB/RC: Don't invoke AM handler for PURE_GRANT messages

### DIFF
--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -350,7 +350,10 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
     ucs_assert(iface->config.fc_enabled);
 
     if ((ep == NULL) || (ep->flags & UCT_RC_EP_FLAG_FLUSH_CANCEL)) {
-        /* We get fc for ep which is being removed or canceled so should ignore it */
+        /* We get fc for ep which is being removed or cancelled, so should ignore it */
+        if (fc_hdr == UCT_RC_EP_FC_PURE_GRANT) {
+            return UCS_OK;
+        }
         goto out;
     }
 


### PR DESCRIPTION
## What
Skip invoking AM handler when getting PURE_GRANT message on an endpoint which is being removed or cancelled.

## Why ?
Invoking the AM handler results in reaching the stub AM handler (id = 0, length = 0).