### PR TITLE
UCP/WIREUP/GTEST: Handle WIRUEP_MSG sending failure

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1213,16 +1213,15 @@ out:
 static unsigned ucp_cm_server_conn_notify_progress(void *arg)
 {
     ucp_ep_h ucp_ep = arg;
-    ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&ucp_ep->worker->async);
     if (!ucp_ep->worker->context->config.ext.cm_use_all_devices) {
         ucp_wireup_remote_connected(ucp_ep);
     } else {
-        status = ucp_wireup_send_pre_request(ucp_ep);
-        ucs_assert_always(status == UCS_OK);
+        ucp_wireup_send_pre_request(ucp_ep);
     }
     UCS_ASYNC_UNBLOCK(&ucp_ep->worker->async);
+
     return 1;
 }
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -110,7 +110,7 @@ static ssize_t ucp_wireup_ep_bcopy_send_func(uct_ep_h uct_ep)
     return UCS_ERR_NO_RESOURCE;
 }
 
-static uct_ep_h ucp_wireup_ep_get_msg_ep(ucp_wireup_ep_t *wireup_ep)
+uct_ep_h ucp_wireup_ep_get_msg_ep(ucp_wireup_ep_t *wireup_ep)
 {
     uct_ep_h wireup_msg_ep;
 

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -114,6 +114,8 @@ int ucp_wireup_ep_is_owner(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
 void ucp_wireup_ep_disown(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
+uct_ep_h ucp_wireup_ep_get_msg_ep(ucp_wireup_ep_t *wireup_ep);
+
 ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self);
 
 ucp_wireup_ep_t *ucp_wireup_ep(uct_ep_h uct_ep);


### PR DESCRIPTION
## What

Handle WIRUEP_MSG sending failure.

## Why ?

Fixes:
```
[jazz11:58472:0:58472]   wireup_cm.c:1223 Assertion `status == UCS_OK' failed

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/src/ucp/wireup/wireup_cm.c: [ ucp_cm_server_conn_notify_progress() ]
      ...
     1220         ucp_wireup_remote_connected(ucp_ep);
     1221     } else {
     1222         status = ucp_wireup_send_pre_request(ucp_ep);
==>  1223         ucs_assert_always(status == UCS_OK);
     1224     }
     1225     UCS_ASYNC_UNBLOCK(&ucp_ep->worker->async);
     1226     return 1;

==== backtrace (tid:  58472) ====
 0 0x000000000014f568 ucp_cm_server_conn_notify_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/src/ucp/wireup/wireup_cm.c:1223
 1 0x0000000000055946 ucs_callbackq_slow_proxy()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.c:402
 2 0x0000000000054441 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
 3 0x00000000000615ca uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
 4 0x0000000000403d3c UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:203
 5 0x000000000041039c DemoServer::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:871
 6 0x000000000040dccb do_server()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2252
 7 0x000000000040e189 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210615_112011_166943_41021_jazz11.swx.labs.mlnx/installs/7RUC/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2307
 8 0x00000000000223d5 __libc_start_main()  ???:0
 9 0x0000000000402ee9 _start()  ???:0
=================================
```
gtest:
```
[jazz23:81349:0:81349]   wireup_cm.c:1223 Assertion `status == UCS_OK' failed

/labhome/dmitrygla/work_auto/ucx/src/ucp/wireup/wireup_cm.c: [ ucp_cm_server_conn_notify_progress() ]
      ...
     1220         ucp_wireup_remote_connected(ucp_ep);
     1221     } else {
     1222         status = ucp_wireup_send_pre_request(ucp_ep);
==>  1223         ucs_assert_always(status == UCS_OK);
     1224     }
     1225     UCS_ASYNC_UNBLOCK(&ucp_ep->worker->async);
     1226

==== backtrace (tid:  81349) ====
 0 0x000000000014ece6 ucp_cm_server_conn_notify_progress()  /labhome/dmitrygla/work_auto/ucx/src/ucp/wireup/wireup_cm.c:1223
 1 0x0000000000055916 ucs_callbackq_slow_proxy()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.c:402
 2 0x00000000000544d1 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
 3 0x000000000006165a uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
 4 0x0000000000901612 ucp_test_base::entity::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:904
 5 0x00000000008fcb2a ucp_test::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:155
 6 0x00000000008c7d12 test_ucp_sockaddr::connect_and_fail_wireup()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:636
 7 0x00000000008b6bbf test_ucp_sockaddr_connect_and_fail_wireup_on_server_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:1100
 8 0x00000000005a9f32 ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:365
 9 0x00000000005aa0f5 ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:391
10 0x000000000072e48a ucp_test::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:195
11 0x0000000000587624 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
12 0x0000000000582802 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
13 0x0000000000569b11 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3635
14 0x000000000056a2ec testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3812
15 0x000000000056a97c testing::TestCase::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3930
16 0x00000000005711d4 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5808
17 0x0000000000588a02 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3562
18 0x0000000000583664 testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:3598
19 0x000000000056fe10 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest-all.cc:5422
20 0x0000000000591e11 RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/gtest.h:20059
21 0x0000000000591cfa main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:109
22 0x00000000000223d5 __libc_start_main()  ???:0
23 0x0000000000564429 _start()  ???:0
=================================
```

## How ?

1. Reproduced in gtest.
2. Removed incorrect assertion.
3. Set EP as failed if WIREUP_MSG failed by some reason (memory allocation failure, address packing failure and etc), because there is no other way to provide the error to a user.