### PR TITLE
UCP/CORE/WIREUP/GTEST: Don't ask INVALIDATE for p2p lanes

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -272,16 +272,13 @@ static UCS_F_ALWAYS_INLINE ucp_lane_index_t ucp_ep_get_cm_lane(ucp_ep_h ep)
     return ucp_ep_config(ep)->key.cm_lane;
 }
 
-static inline int
+static UCS_F_ALWAYS_INLINE int
 ucp_ep_config_connect_p2p(ucp_worker_h worker,
                           const ucp_ep_config_key_t *ep_config_key,
                           ucp_rsc_index_t rsc_index)
 {
-    /* The EP with CM lane has to be connected to remote EP, so prefer native
-     * UCT p2p capability. */
-    return ucp_ep_config_key_has_cm_lane(ep_config_key) ?
-           ucp_worker_is_tl_p2p(worker, rsc_index) :
-           !ucp_worker_is_tl_2iface(worker, rsc_index);
+    return ucp_wireup_connect_p2p(worker, rsc_index,
+                                  ucp_ep_config_key_has_cm_lane(ep_config_key));
 }
 
 static UCS_F_ALWAYS_INLINE int ucp_ep_use_indirect_id(ucp_ep_h ep)

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -302,15 +302,14 @@ static ucp_md_map_t ucp_request_get_invalidation_map(ucp_request_t *req)
     ucp_lane_index_t lane;
     ucp_lane_index_t i;
     ucp_md_map_t inv_map;
-    uint64_t cap_flags;
 
     for (i = 0, inv_map = 0;
          (key->rma_bw_lanes[i] != UCP_NULL_LANE) && (i < UCP_MAX_LANES); i++) {
-        lane      = key->rma_bw_lanes[i];
-        cap_flags = ucp_ep_get_iface_attr(ep, lane)->cap.flags;
+        lane = key->rma_bw_lanes[i];
 
-        if (cap_flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
-            ucs_assert(cap_flags & UCT_IFACE_FLAG_GET_ZCOPY);
+        if (!ucp_ep_is_lane_p2p(ep, lane)) {
+            ucs_assert(ucp_ep_get_iface_attr(ep, lane)->cap.flags &
+                       UCT_IFACE_FLAG_GET_ZCOPY);
             ucs_assert(ucp_ep_md_attr(ep, lane)->cap.flags &
                        UCT_MD_FLAG_INVALIDATE);
             inv_map |= UCS_BIT(ucp_ep_md_index(ep, lane));

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -274,6 +274,16 @@ ucp_wireup_get_ep_tl_bitmap(ucp_ep_h ep, ucp_lane_map_t lane_map)
     return tl_bitmap;
 }
 
+int ucp_wireup_connect_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
+                           int has_cm_lane)
+{
+    /* The EP with CM lane has to be connected to remote EP, so prefer native
+     * UCT p2p capability. */
+    return has_cm_lane ?
+           ucp_worker_is_tl_p2p(worker, rsc_index) :
+           !ucp_worker_is_tl_2iface(worker, rsc_index);
+}
+
 /*
  * Select remote ep address for every remote address entry (because there
  * could be multiple ep addresses per entry). This selection is used to create

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -143,6 +143,9 @@ void ucp_wireup_remote_connected(ucp_ep_h ep);
 unsigned ucp_ep_init_flags(const ucp_worker_h worker,
                            const ucp_ep_params_t *params);
 
+int ucp_wireup_connect_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
+                           int has_cm_lane);
+
 ucs_status_t
 ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_unpacked_address_t *remote_address,


### PR DESCRIPTION
## What

Don't ask INVALIDATE for p2p lanes. 

## Why ?

They don't need to support INVALIDATE capability on their MD.
This returns back usage RNDV for TCP with CM + Error-Handling.

## How ?

1. Check p2p connection mode instead of just `CONNECT_TO_IFACE` (transport could support both `CONNECT_TO_EP` and `CONNECT_TO_IFACE`).
2. Don't request support of `INVALIDATE` flag during selection if p2p connection is going to be used.
3. Fix gtests to pass now.