### PR TITLE
UCP/CORE: Set lanes failed when error is detected

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -336,12 +336,6 @@ static ucs_config_field_t ucp_config_table[] = {
    "endpoint.",
    ucs_offsetof(ucp_config_t, ctx.proto_indirect_id), UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
-  {"ERROR_HANDLER_DELAY", "0us",
-   "Artificial delay between detecting an error and processing it (0 - disabled).\n"
-   "Used for testing purposes",
-   ucs_offsetof(ucp_config_t, ctx.err_handler_delay),
-   UCS_CONFIG_TYPE_TIME_UNITS},
-
    {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t,

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -117,8 +117,6 @@ typedef struct ucp_context_config {
     ucs_on_off_auto_value_t                proto_indirect_id;
     /** Bitmap of memory types whose allocations are registered fully */
     unsigned                               reg_whole_alloc_bitmap;
-    /** Error handler delay */
-    ucs_time_t                             err_handler_delay;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -633,6 +633,9 @@ unsigned ucp_ep_local_disconnect_progress(void *arg);
 
 size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config_t *config);
 
+void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                              ucs_string_buffer_t *lane_info_strb);
+
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 
 int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -313,16 +313,6 @@ typedef struct ucp_worker {
 } ucp_worker_t;
 
 
-/**
- * UCP worker argument for the error handling callback
- */
-typedef struct ucp_worker_err_handle_arg {
-    ucp_ep_h         ucp_ep;
-    ucs_time_t       timeout;
-    ucs_status_t     status;
-} ucp_worker_err_handle_arg_t;
-
-
 ucs_status_t
 ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_ep_config_key_t *key,
                          int print_cfg, ucp_worker_cfg_index_t *cfg_index_p);
@@ -349,9 +339,6 @@ void ucp_worker_iface_unprogress_ep(ucp_worker_iface_t *wiface);
 void ucp_worker_signal_internal(ucp_worker_h worker);
 
 void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags);
-
-int ucp_worker_err_handle_remove_filter(const ucs_callbackq_elem_t *elem,
-                                        void *arg);
 
 ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
                                       uct_ep_h uct_ep, ucp_lane_index_t lane,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1339,7 +1339,6 @@ ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
     return UCS_OK;
 
 err:
-    ucp_worker_set_ep_failed(worker, ep, ep->uct_eps[lane], lane, status);
     /* coverity[leaked_storage] (uct_ep) */
     return status;
 }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -738,31 +738,6 @@ protected:
 
 unsigned test_ucp_sockaddr::m_err_count = 0;
 
-UCS_TEST_P(test_ucp_sockaddr, close_ep_force_before_err_cb,
-           "ERROR_HANDLER_DELAY=1s") {
-    const size_t num_sends = 3000; // should be big enough to fill up TX-queue
-    std::vector<char> buffer(20);
-
-    listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    for (size_t i = 0; i < num_sends; ++i) {
-        ucs_status_ptr_t req = ucp_stream_send_nb(sender().ep(), &buffer[0],
-                                                  buffer.size(),
-                                                  ucp_dt_make_contig(1),
-                                                  scomplete_cb, 0);
-        if (UCS_PTR_IS_PTR(req)) {
-            ucp_request_free(req);
-        }
-    }
-
-    ucs_time_t deadline = ucs::get_deadline(10);
-
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
-    short_progress_loop();
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FORCE);
-
-    EXPECT_LT(ucs_get_time(), deadline);
-}
-
 UCS_TEST_P(test_ucp_sockaddr, listen) {
     listen_and_communicate(false, 0);
 }
@@ -2238,7 +2213,6 @@ public:
     virtual void init() {
         m_err_count = 0;
         modify_config("CM_USE_ALL_DEVICES", cm_use_all_devices() ? "y" : "n");
-        modify_config("ERROR_HANDLER_DELAY", "inf");
         /* receiver should try to read wrong data, instead of detecting error
            in keepalive process and closing the connection */
         disable_keepalive();


### PR DESCRIPTION
## What

Set lanes failed when error is detected.

## Why ?

To fix doing AM/GET/PUT/AMO operations after the UCT EP failed.
```
[1623875636.709979] [UCX-connection #5 1.1.28.1:33236] completing request 0x137fc10 with status "Endpoint timeout" (-80) during disconnect
[1623875636.709985] [UCX-connection #5 1.1.28.1:33236] released
[swx-ucx03:52327:0:52327]   rc_mlx5.inl:456  Assertion `!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED)' failed

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl: [ uct_rc_mlx5_common_post_send() ]
      ...
      453     if (opcode != MLX5_OPCODE_NOP) {
      454         /* If FAILED, allow only NOP sends to be posted (used by endpoint
      455          * flush operations) */
==>   456         ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
      457     }
      458 
      459     ctrl = txwq->curr;

==== backtrace (tid:  52327) ====
 0 0x000000000005a2a7 uct_rc_mlx5_common_post_send()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl:456
 1 0x000000000005a2a7 uct_rc_mlx5_txqp_dptr_post_iov()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl:897
 2 0x000000000005a2a7 uct_rc_mlx5_ep_zcopy_post()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_ep.c:54
 3 0x000000000005a2a7 uct_rc_mlx5_ep_get_zcopy()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_ep.c:252
 4 0x00000000000af1c0 uct_ep_get_zcopy()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/api/uct.h:2784
 5 0x00000000000af888 ucp_rndv_progress_rma_get_zcopy_inner()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/ucp/rndv/rndv.c:560
 6 0x00000000000af888 ucp_rndv_progress_rma_get_zcopy()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/ucp/rndv/rndv.c:549
 7 0x000000000003507d uct_rc_iface_invoke_pending_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_iface.h:552
 8 0x000000000003507d uct_rc_ep_process_pending()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_ep.c:365
 9 0x0000000000053cd4 ucs_arbiter_dispatch_nonempty()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.c:321
10 0x000000000009db1b ucs_arbiter_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.h:386
11 0x00000000000bbaba uct_rc_mlx5_iface_update_tx_res()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:129
12 0x000000000002b691 uct_ib_mlx5_check_completion()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.c:361
13 0x00000000000a90ce uct_ib_mlx5_poll_cq()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.inl:81
14 0x00000000000a90ce uct_rc_mlx5_iface_poll_tx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:141
15 0x00000000000a90ce uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:178
16 0x00000000000a90ce uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:183
17 0x0000000000054441 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
18 0x00000000000615ca uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
19 0x0000000000403d4c UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:203
20 0x00000000004103ac DemoServer::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:871
21 0x000000000040dcdb do_server()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2252
22 0x000000000040e199 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210616_214156_71374_41349_swx-ucx01.swx.labs.mlnx/installs/4qZZ/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2307
23 0x00000000000223d5 __libc_start_main()  ???:0
24 0x0000000000402ef9 _start()  ???:0
=================================
timeout: the monitored command dumped core
```

## How ?

Set lanes as failed, do discarding, purging all requests when the error callback was invoked from UCT level - to avoid doing UCT operations for already failed UCT EP.