### PR TITLE
UCP/CORE/PROTO: Handle in-place failure from AM/RMA operations

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -608,12 +608,10 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
         req->send.state.dt.offset = req->send.length;
         uct_completion_update_status(&req->send.state.uct_comp, status);
 
-        if (req->send.state.uct_comp.count == 0) {
-            /* If nothing is in-flight, call completion callback to ensure
-             * cleanup of zero-copy resources
-             */
-            req->send.state.uct_comp.func(&req->send.state.uct_comp);
-        }
+        /* If nothing is in-flight, call completion callback to ensure cleanup
+         * of zero-copy resources
+         */
+        ucp_send_request_invoke_uct_completion(req);
     } else if ((req->send.uct.func == ucp_proto_progress_rndv_rtr) ||
                (req->send.uct.func == ucp_proto_progress_am_rndv_rts) ||
                (req->send.uct.func == ucp_proto_progress_tag_rndv_rts)) {
@@ -621,6 +619,7 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
          * equivalent to reply not being received */
         ucp_ep_req_purge(req->send.ep, req, status, 1);
     } else {
+        ucp_request_send_buffer_dereg(req);
         ucp_request_complete_send(req, status);
     }
 }

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -294,10 +294,7 @@ void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status)
     ucs_assert(req->send.state.uct_comp.count >= num_comps);
     req->send.state.uct_comp.count -= num_comps;
     uct_completion_update_status(&req->send.state.uct_comp, status);
-
-    if (req->send.state.uct_comp.count == 0) {
-        req->send.state.uct_comp.func(&req->send.state.uct_comp);
-    }
+    ucp_send_request_invoke_uct_completion(req);
 }
 
 void ucp_ep_flush_remote_completed(ucp_request_t *req)

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -66,8 +66,6 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
                                   req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
-        ucp_request_send_state_advance(req, NULL, UCP_REQUEST_SEND_PROTO_RMA,
-                                       status);
     }
 
     return ucp_rma_request_advance(req, packed_len, status,
@@ -111,11 +109,6 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
                                   req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
-    }
-
-    if (status == UCS_INPROGRESS) {
-        ucp_request_send_state_advance(req, 0, UCP_REQUEST_SEND_PROTO_RMA,
-                                       UCS_INPROGRESS);
     }
 
     return ucp_rma_request_advance(req, frag_length, status,


### PR DESCRIPTION
## What

Handle in-place failure from AM/RMA operations.

## Why ?

To not complete the same operation twice - it leads to undefined behavior.

## How ?

- Removed ucp_request_send_state_advance_comp() as no longer needed.
- Operations now responsible to correctly handle failure - i.e. to call ucp_request_send_state_ff() - this is mvoed to the operations level, because some operations need to advance send state, but other don't need to do it (e.g. RMA basic and SW).
- Added memory deregistration in ucp_request_send_state_ff() to be used for RMA operations as well - it is safe, since it is no-op if no registrations were done.