### PR TITLE
UCP/CORE: Complete KA round if iter == iter_begin when removing EP from KA

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2794,10 +2794,13 @@ int ucp_ep_do_keepalive(ucp_ep_h ep, ucs_time_t now)
 #if UCS_ENABLE_ASSERT
     ucs_assertv((now - ucp_ep_ext_control(ep)->ka_last_round) >=
                         worker->context->config.ext.keepalive_interval,
-                "ep %p: now=%" PRIu64 " ka_last_round=%" PRIu64
-                " ka_interval=%" PRIu64,
-                ep, now, ucp_ep_ext_control(ep)->ka_last_round,
-                worker->context->config.ext.keepalive_interval);
+                "ep %p: now=<%lf sec> ka_last_round=<%lf sec>"
+                "(diff=<%lf sec>) ka_interval=<%lf sec>",
+                ep, ucs_time_to_sec(now),
+                ucs_time_to_sec(ucp_ep_ext_control(ep)->ka_last_round),
+                ucs_time_to_sec(now - ucp_ep_ext_control(ep)->ka_last_round),
+                ucs_time_to_sec(
+                        worker->context->config.ext.keepalive_interval));
     ucp_ep_ext_control(ep)->ka_last_round = now;
 #endif
 


### PR DESCRIPTION
## What

Complete KA round if iter == iter_begin when removing EP from KAю

## Why ?

To fix the following assertion detected when running IO-demo:
```
[jazz15:169944:0:169944]      ucp_ep.c:2803 Assertion `(now - ucp_ep_ext_control(ep)->ka_last_round) >= worker->context->config.ext.keepalive_interval' failed: ep 0x7fb3009b16b0: now=<975076.878278 sec> ka_last_r
ound=<975076.268333 sec> (diff=<0.609944 sec>) ka_interval=<60.000000 sec>
```

## How ?

Before the PR, we completed KA round when moved `iter` now points to `iter_begin`. This PR moves this to the common place, which handles not only moving of `iter`, but also moving of `iter_begin`.