### PR TITLE
EXAMPLES: install examples in --prefix path.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -37,7 +37,7 @@ installcheck-local:
 
 if HAVE_EXAMPLES
 
-noinst_PROGRAMS = \
+bin_PROGRAMS = \
 	ucp_hello_world \
 	uct_hello_world \
 	ucp_client_server


### PR DESCRIPTION
## What
Install examples to target directory. Revert `noinst_data` made in #6629

## Why ?
If it was configured `--with-examples` examples should be in the install path. Blocks for binary compatibility test #6859, since after `make install` no `ucp_client_server` in `$PREFIX/bin/`