### PR TITLE
APPS/IO-DEMO: Go over active servers when reporting performance

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1906,8 +1906,8 @@ private:
             // Collect min/max among all connections
             long delta_min = std::numeric_limits<long>::max(), delta_max = 0;
             size_t min_index = 0;
-            for (size_t server_index = 0; server_index < _server_info.size();
-                 ++server_index) {
+            for (size_t i = 0; i < _active_servers.size(); ++i) {
+                size_t server_index        = _active_servers[i];
                 server_info_t& server_info = _server_info[server_index];
                 long delta_completed       = server_info.num_completed[op_id] -
                                              server_info.prev_completed[op_id];


### PR DESCRIPTION
## What

Go over active servers when reporting performance.

## Why ?

To avoid reporting "min:0" for connections which are closed, e.g.:
```
[1624472736.755994] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] detected error: Endpoint timeout
[1624472736.756066] [UCX] removed [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] from connection map
[1624472736.756085] [DEMO] disconnecting [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] connection with 4 uncompleted operations (read: 199/203; write: 216/216) due to "Endpoint timeout"
[1624472736.756089] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] destroying, ep is 0x7f92c9a2b390
[1624472736.756093] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] closing ep 0x7f92c9a2b390 mode force
[1624472736.756105] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] canceling ucp_tag_recv_nb request 0x1ee7cd0 #1
[1624472736.756113] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] canceling ucp_tag_recv_nb request 0x1eeb150 #2
[1624472736.756123] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] canceling ucp_tag_recv_nb request 0x1ebec50 #3
[1624472736.756134] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] canceling ucp_tag_recv_nb request 0x1e1da10 #4
[1624472736.756156] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] completing ucp_tag_recv_nb request 0x1ee7cd0 with status "Request canceled" (-16) during disconnect
[1624472736.759034] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] completing ucp_tag_recv_nb request 0x1eeb150 with status "Request canceled" (-16) during disconnect
[1624472736.759073] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] completing ucp_tag_recv_nb request 0x1ebec50 with status "Request canceled" (-16) during disconnect
[1624472736.759097] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] completing ucp_tag_recv_nb request 0x1e1da10 with status "Request canceled" (-16) during disconnect
[1624472736.759104] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] disconnection completed
[1624472736.759125] [UCX-connection 0x1c4fe60: #7 2.1.3.17:20004] released
[1624472736.759130] [DEMO] read 54.5204 MBs min:0(2.1.3.17:20004) max:30 total:1394 | write 51.4546 MBs min:0(2.1.3.17:20004) max:32 total:1396 | active:61/61 buffers:992
```

## How ?

Go over `_active_servers` only in `report_performance()`.