### PR TITLE
UCS/VFS: Changed log level of inotify_init failure to diag.

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1501,3 +1501,19 @@ ucs_status_t ucs_sys_get_file_time(const char *name, ucs_sys_file_time_t type,
         return UCS_ERR_INVALID_PARAM;
     }
 }
+
+ucs_status_t ucs_sys_check_fd_limit_per_process()
+{
+    int fd;
+
+    fd = open("/dev/null", O_RDONLY);
+    if ((fd == -1) && (errno == EMFILE)) {
+        return UCS_ERR_EXCEEDS_LIMIT;
+    }
+
+    if (fd != -1) {
+        close(fd);
+    }
+
+    return UCS_OK;
+}

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -617,6 +617,15 @@ ucs_status_t ucs_sys_enum_threads(ucs_sys_enum_threads_cb_t cb, void *ctx);
 ucs_status_t ucs_sys_get_file_time(const char *name, ucs_sys_file_time_t type,
                                    ucs_time_t *time);
 
+
+/**
+ * Check the per-process limit on the number of open file descriptors.
+ *
+ * @return UCS_OK if the limit has not been reached. UCS_ERR_EXCEEDS_LIMIT,
+ *         otherwise.
+ */
+ucs_status_t ucs_sys_check_fd_limit_per_process();
+
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
## What
Changed log level of inotify_init() failure from 'error' to 'diag'.
Added workaround to diagnostic message.

## Why ?
Use case.
User doesn't launch ucx_vfs daemon.
User runs several processes that use UCX library.
Each process initializes inotify to be ready to connect with daemon when it starts.
However, the number of inotify instances are limited by fs.inotify.max_user_instances.
Thus, only first fs.inotify.max_user_instance processes will be monitored by ucx_vfs, when user start the daemon.


