### PR TITLE
DC/MLX5: fix in flush resource check

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -235,6 +235,8 @@ struct uct_dc_mlx5_iface {
         unsigned                  rand_seed;
 
         ucs_arbiter_callback_t    pend_cb;
+
+        uct_worker_cb_id_t        dci_release_prog_id;
     } tx;
 
     struct {


### PR DESCRIPTION
- there was issue in ep_flush resource check:
  incorrect sequence of evaluation which caused
  extra arbiter processing
- added progress pending into purge_pending routine
