### PR TITLE
RPM/SPEC: Do not generate ucx.conf default config after installation - v1.11.x

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -138,9 +138,7 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.a
 
 %post
 /sbin/ldconfig
-rm -f %{_sysconfdir}/ucx/ucx.conf
 mkdir -p %{_sysconfdir}/ucx
-ucx_info -fC > %{_sysconfdir}/ucx/ucx.conf
 
 %postun -p /sbin/ldconfig
 


### PR DESCRIPTION
## What
Remove execution of `ucx_info -fC` upon RPM installation. 

## Why ?
Transactions on several sub-packages can lead to an inconsistent state and invalid execution of `ucx_info`, with memory corruption. 
The default config can be manually generated later by the user.