### PR TITLE
AZP/TEST: Increase test job timeout to 6 hours

### DIFF
--- a/buildlib/tests.yml
+++ b/buildlib/tests.yml
@@ -10,7 +10,7 @@ jobs:
       name: MLNX
       demands: ${{ parameters.demands }}
     displayName: ${{ parameters.name }} on worker
-    timeoutInMinutes: 300
+    timeoutInMinutes: 360
     strategy:
       matrix:
         ${{ each wid in parameters.worker_ids }}:


### PR DESCRIPTION
## What
Increase the timeout of test job in the pipeline to 6 hours.

## Why ?
Tests number is increasing and they take more time. We want to avoid the pipeline failing on timeout.