### PR TITLE
VFS: fixed uninitialized variable access

### DIFF
--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -330,6 +330,7 @@ static void ucs_vfs_fuse_thread_reset_affinity()
         return;
     }
 
+    CPU_ZERO(&cpuset);
     for (i = 0; i < num_cpus; ++i) {
         CPU_SET(i, &cpuset);
     }


### PR DESCRIPTION
- there was uninitialized variable access in affinity set
