### PR TITLE
UCP/CONTEXT: Don't fail if no CM components are found

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -288,17 +288,25 @@ stages:
               downloadPath: $(System.DefaultWorkingDirectory)
           - bash: chmod u+rwx $(System.DefaultWorkingDirectory)/ucx_bin_$(Build.BuildId) -R
           - bash: |
-              set -x
-              ./bin/ucx_info -e -u t 2>&1 | tee info.txt
-              grep -i error info.txt
-              retVal=$?
-              if [ $retVal -eq 0 ]; then
-                  exit 1;
-              fi
-              exit 0;
+              set -xEe
+              check_ucx_info() {
+                 ./bin/ucx_info -e -u t $@ |& tee ucx_info.txt
+                 ## the word "lane" should be found
+                 egrep 'lane' ucx_info.txt
+                 ## no failures
+                 ! egrep -i 'error|fail|warn|assert|fatal' ucx_info.txt
+              }
+              # version check
+              ./bin/ucx_info -v
+              # test default
+              check_ucx_info
+              # test without CM components
+              UCX_SOCKADDR_TLS_PRIORITY="" check_ucx_info
+              # test intra-node
+              check_ucx_info -P intra
             displayName: Test ucx_info
             workingDirectory: $(System.DefaultWorkingDirectory)/ucx_bin_$(Build.BuildId)/install
-            env: 
+            env:
               LD_LIBRARY_PATH: $(System.DefaultWorkingDirectory)/ucx_bin_$(Build.BuildId)/install/lib:$LD_LIBRARY_PATH
           - bash: |
               set -Eex
@@ -310,7 +318,7 @@ stages:
               grep "Final:" perf.txt
             displayName: Test ucx_perftest
             workingDirectory: $(System.DefaultWorkingDirectory)/ucx_bin_$(Build.BuildId)/install
-            env: 
+            env:
               LD_LIBRARY_PATH: $(System.DefaultWorkingDirectory)/ucx_bin_$(Build.BuildId)/install/lib:$LD_LIBRARY_PATH
 
   - stage: Coverity

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -59,7 +59,7 @@ static void usage() {
     printf("                    'inter' : different node\n");
     /* TODO: add IPv6 support */
     printf("  -A <ipv4>       Local IPv4 device address to use for creating\n"
-           "                  endpoint in client/server mode");
+           "                  endpoint in client/server mode\n");
     printf("  -h              Show this help message\n");
     printf("\n");
 }

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -113,7 +113,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
         ucs_debug("%s general_obj_types_caps: reserved qpn is not support", dev_name);
         goto dummy_qp_ctx_init;
     }
-    
+
     UCT_IB_MLX5DV_SET(query_hca_cap_in, in, op_mod,
                       (UCT_IB_MLX5_CAP_2_GENERAL << 1) |
                       UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR);
@@ -161,7 +161,7 @@ uct_rdmacm_cm_device_context_cleanup(uct_rdmacm_cm_device_context_t *ctx)
     int ret;
 
     if (ctx->use_reserved_qpn) {
-        /* There can be some blks are not fully used, then they won't be 
+        /* There can be some blks are not fully used, then they won't be
            destroyed in RDMACM CM EP, so need to be destroyed here. */
         ucs_list_for_each_safe(blk, tmp, &ctx->blk_list, entry) {
             uct_rdmacm_cm_reserved_qpn_blk_destroy(blk);
@@ -877,12 +877,9 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
 
     self->ev_ch = rdma_create_event_channel();
     if (self->ev_ch == NULL) {
-        if (errno == ENODEV) {
-            status  = UCS_ERR_NO_DEVICE;
-            log_lvl = UCS_LOG_LEVEL_DIAG;
-        } else if (errno == ENOENT) {
+        if ((errno == ENODEV) || (errno == ENOENT)) {
             status  = UCS_ERR_IO_ERROR;
-            log_lvl = UCS_LOG_LEVEL_WARN;
+            log_lvl = UCS_LOG_LEVEL_DIAG;
         } else {
             status  = UCS_ERR_IO_ERROR;
             log_lvl = UCS_LOG_LEVEL_ERROR;


### PR DESCRIPTION
## What
- Don't fail to create UCP context if no CM components are present
- Add ucx_info-based tests to AZP

## Why
We may want to use UCX without client/server connection establishment, so no need to always require CM components.
For example, inside a docker, we don't always have TCP.
