### PR TITLE
UCP/CORE/UCS/GTEST: Don't invoke set_ep_failed from async thread

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -583,6 +583,12 @@ void ucp_ep_disconnected(ucp_ep_h ep, int force);
 
 void ucp_ep_destroy_internal(ucp_ep_h ep);
 
+void ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                       ucs_status_t status);
+
+void ucp_ep_set_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                                ucs_status_t status);
+
 void ucp_ep_cleanup_lanes(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -427,95 +427,14 @@ void ucp_worker_signal_internal(ucp_worker_h worker)
     }
 }
 
-/*
- * Caller must acquire lock
- */
-ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
-                                      uct_ep_h uct_ep, ucp_lane_index_t lane,
-                                      ucs_status_t status)
-{
-    UCS_STRING_BUFFER_ONSTACK(lane_info_strb, 64);
-    ucs_status_t ret_status = UCS_OK;
-    ucs_log_level_t log_level;
-    ucp_request_t *close_req;
-
-    ucs_assert((lane != UCP_NULL_LANE) || (uct_ep == NULL));
-
-    ucs_debug("ep %p: set_ep_failed status %s on lane[%d]=%p", ucp_ep,
-              ucs_status_string(status), lane, uct_ep);
-
-    /* In case if this is a local failure we need to notify remote side */
-    if (ucp_ep_is_cm_local_connected(ucp_ep)) {
-        ucp_ep_cm_disconnect_cm_lane(ucp_ep);
-    }
-
-    /* set endpoint to failed to prevent wireup_ep switch */
-    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
-        goto out_ok;
-    }
-
-    /* The EP can be closed from last completion callback */
-    ucp_ep_discard_lanes(ucp_ep, status);
-    ucp_ep_reqs_purge(ucp_ep, status);
-    ucp_stream_ep_cleanup(ucp_ep);
-
-    if (ucp_ep->flags & UCP_EP_FLAG_USED) {
-        if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
-            ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
-            /* Promote close operation to CANCEL in case of transport error,
-             * since the disconnect event may never arrive. */
-            close_req                        = ucp_ep_ext_control(ucp_ep)->
-                close_req.req;
-            close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
-            ucp_ep_local_disconnect_progress(close_req);
-        } else if (ucp_ep_ext_control(ucp_ep)->err_cb == NULL) {
-            /* Do not print error if connection reset by remote peer since it
-             * can be part of user level close protocol */
-            log_level = (status == UCS_ERR_CONNECTION_RESET) ?
-                        UCS_LOG_LEVEL_DIAG : UCS_LOG_LEVEL_ERROR;
-
-            ucp_ep_get_lane_info_str(ucp_ep, lane, &lane_info_strb);
-            ucs_log(log_level, "ep %p: error '%s' on %s will not be handled"
-                    " since no error callback is installed",
-                    ucp_ep, ucs_status_string(status),
-                    ucs_string_buffer_cstr(&lane_info_strb));
-            ret_status = status;
-            goto out;
-        } else {
-            ucp_ep_invoke_err_cb(ucp_ep, status);
-        }
-    } else if (ucp_ep->flags & (UCP_EP_FLAG_INTERNAL | UCP_EP_FLAG_CLOSED)) {
-        /* No additional actions are required, this is already closed EP or
-         * an internal one for sending WIREUP/EP_REMOVED messsage to a peer.
-         * So, close operation was already scheduled, this EP will be deleted
-         * after all lanes will be discarded successfully */
-        ucs_debug("ep %p: detected peer failure on internal endpoint", ucp_ep);
-    } else {
-        ucs_debug("ep %p: destroy endpoint which is not exposed to a user due"
-                  " to peer failure", ucp_ep);
-        ucp_ep_disconnected(ucp_ep, 1);
-    }
-
-out_ok:
-    ret_status = UCS_OK;
-
-out:
-    /* If the worker supports the UCP_FEATURE_WAKEUP feature, signal the user so
-     * that he can wake-up on this event */
-    ucp_worker_signal_internal(worker);
-
-    return ret_status;
-}
-
-static ucs_status_t
+static void
 ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
                                        uct_ep_h uct_ep, ucs_status_t status)
 {
-    ucp_worker_h worker = ucp_ep->worker;
     ucp_wireup_ep_t *wireup_ep;
 
     if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
-        return UCS_OK;
+        return;
     }
 
     wireup_ep = ucp_wireup_ep(ucp_ep->uct_eps[lane]);
@@ -524,13 +443,14 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         !ucp_ep_is_local_connected(ucp_ep)) {
         /* Failure on NON-AUX EP or failure on AUX EP before it sent its address
          * means failure on the UCP EP */
-        return ucp_worker_set_ep_failed(worker, ucp_ep, uct_ep, lane, status);
+        ucp_ep_set_failed(ucp_ep, lane, status);
+        return;
     }
 
     if (wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY) {
         /* @ref ucp_wireup_ep_progress was scheduled, wireup ep and its
          * pending requests have to be handled there */
-        return UCS_OK;
+        return;
     }
 
     /**
@@ -542,7 +462,6 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
     ucp_wireup_ep_discard_aux_ep(wireup_ep, UCT_FLUSH_FLAG_CANCEL,
                                  ucp_destroyed_ep_pending_purge, ucp_ep);
     ucp_wireup_remote_connected(ucp_ep);
-    return UCS_OK;
 }
 
 static ucp_ep_h ucp_worker_find_lane(ucs_list_link_t *ep_list, uct_ep_h uct_ep,
@@ -570,7 +489,6 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
 {
     ucp_worker_h worker = (ucp_worker_h)arg;
     ucp_lane_index_t lane;
-    ucs_status_t ret_status;
     ucp_ep_h ucp_ep;
 
     UCS_ASYNC_BLOCK(&worker->async);
@@ -588,28 +506,28 @@ ucp_worker_iface_error_handler(void *arg, uct_ep_h uct_ep, ucs_status_t status)
          * operations are completed before destroying the failed endpoint. */
         uct_ep_pending_purge(uct_ep, ucp_ep_err_pending_purge,
                              UCS_STATUS_PTR(UCS_ERR_CANCELED));
-        ret_status = UCS_OK;
+        status = UCS_OK;
         goto out;
     }
 
     ucp_ep = ucp_worker_find_lane(&worker->all_eps, uct_ep, &lane);
     if (ucp_ep == NULL) {
         ucp_ep = ucp_worker_find_lane(&worker->internal_eps, uct_ep, &lane);
+        if (ucp_ep == NULL) {
+            ucs_error("worker %p: uct_ep %p isn't associated with any UCP"
+                      " endpoint and was not scheduled to be discarded",
+                      worker, uct_ep);
+            status = UCS_ERR_NO_ELEM;
+            goto out;
+        }
     }
 
-    if (ucp_ep != NULL) {
-        ret_status = ucp_worker_iface_handle_uct_ep_failure(ucp_ep, lane,
-                                                            uct_ep, status);
-    } else {
-        ucs_error("worker %p: uct_ep %p isn't associated with any ucp endpoint"
-                  " and was not scheduled to be discarded",
-                  worker, uct_ep);
-        ret_status = UCS_ERR_NO_ELEM;
-    }
+    ucp_worker_iface_handle_uct_ep_failure(ucp_ep, lane, uct_ep, status);
+    status = UCS_OK;
 
 out:
     UCS_ASYNC_UNBLOCK(&worker->async);
-    return ret_status;
+    return status;
 }
 
 void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags)

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -340,10 +340,6 @@ void ucp_worker_signal_internal(ucp_worker_h worker);
 
 void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags);
 
-ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
-                                      uct_ep_h uct_ep, ucp_lane_index_t lane,
-                                      ucs_status_t status);
-
 void ucp_worker_keepalive_add_ep(ucp_ep_h );
 
 /* EP should be removed from worker all_eps prior to call this function */

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -253,7 +253,7 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, const ucp_tl_bitmap_t *tl_bitmap,
     return UCS_OK;
 
 err:
-    ucp_worker_set_ep_failed(ep->worker, ep, NULL, UCP_NULL_LANE, status);
+    ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, status);
     return status;
 }
 
@@ -450,7 +450,7 @@ ucp_wireup_init_lanes_by_request(ucp_worker_h worker, ucp_ep_h ep,
         return UCS_OK;
     }
 
-    ucp_worker_set_ep_failed(worker, ep, NULL, UCP_NULL_LANE, status);
+    ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, status);
     return status;
 }
 
@@ -805,8 +805,7 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
         ucp_wireup_send_ep_removed(worker, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_EP_REMOVED) {
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
-        ucp_worker_set_ep_failed(worker, ep, NULL, UCP_NULL_LANE,
-                                 UCS_ERR_CONNECTION_RESET);
+        ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, UCS_ERR_CONNECTION_RESET);
     } else {
         ucs_bug("invalid wireup message");
     }

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -72,6 +72,8 @@ static int ucs_async_poll_tryblock(ucs_async_context_t *async)
 static ucs_async_ops_t ucs_async_poll_ops = {
     .init               = ucs_empty_function,
     .cleanup            = ucs_empty_function,
+    .is_from_async      =
+            (ucs_async_is_from_async_t)ucs_empty_function_return_zero,
     .block              = ucs_empty_function,
     .unblock            = ucs_empty_function,
     .context_init       = ucs_async_poll_init,
@@ -410,6 +412,11 @@ void ucs_async_context_destroy(ucs_async_context_t *async)
 {
     ucs_async_context_cleanup(async);
     ucs_free(async);
+}
+
+int ucs_async_is_from_async(const ucs_async_context_t *async)
+{
+    return ucs_async_method_call(async->mode, is_from_async);
 }
 
 static ucs_status_t

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -74,6 +74,17 @@ void ucs_async_context_cleanup(ucs_async_context_t *async);
 
 
 /**
+ * Returns whether a function called from an async thread or not.
+ *
+ * @param async Event context to check `is_called_from_async` status for.
+ *
+ * @return 0 - isn't called from an async thread, otherwise - from an async
+ *         thread.
+ */
+int ucs_async_is_from_async(const ucs_async_context_t *async);
+
+
+/**
  * Check if an async callback was missed because the main thread has blocked
  * the async context. This works as edge-triggered.
  * Should be called with the lock held.

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -53,6 +53,8 @@ typedef void (*ucs_async_init_t)();
 
 typedef void (*ucs_async_cleanup_t)();
 
+typedef int (*ucs_async_is_from_async_t)();
+
 typedef void (*ucs_async_block_t)();
 
 typedef void (*ucs_async_unblock_t)();
@@ -90,6 +92,7 @@ typedef ucs_status_t (*ucs_async_remove_timer_t)(ucs_async_context_t *async,
 typedef struct ucs_async_ops {
     ucs_async_init_t              init;
     ucs_async_cleanup_t           cleanup;
+    ucs_async_is_from_async_t     is_from_async;
 
     ucs_async_block_t             block;
     ucs_async_unblock_t           unblock;

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -619,6 +619,8 @@ static void ucs_async_signal_global_cleanup()
 ucs_async_ops_t ucs_async_signal_ops = {
     .init               = ucs_async_signal_global_init,
     .cleanup            = ucs_async_signal_global_cleanup,
+    .is_from_async      =
+            (ucs_async_is_from_async_t)ucs_empty_function_return_zero,
     .block              = ucs_async_signal_block_all,
     .unblock            = ucs_async_signal_unblock_all,
     .context_init       = ucs_async_signal_init,

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -231,6 +231,11 @@ out_unlock:
     return status;
 }
 
+static int ucs_async_thread_is_from_async()
+{
+    return pthread_self() == ucs_async_thread_global_context.thread->thread_id;
+}
+
 static void ucs_async_thread_stop()
 {
     ucs_async_thread_t *thread = NULL;
@@ -434,6 +439,7 @@ static void ucs_async_signal_global_cleanup()
 ucs_async_ops_t ucs_async_thread_spinlock_ops = {
     .init               = ucs_empty_function,
     .cleanup            = ucs_async_signal_global_cleanup,
+    .is_from_async      = ucs_async_thread_is_from_async,
     .block              = ucs_empty_function,
     .unblock            = ucs_empty_function,
     .context_init       = ucs_async_thread_spinlock_init,
@@ -450,6 +456,7 @@ ucs_async_ops_t ucs_async_thread_spinlock_ops = {
 ucs_async_ops_t ucs_async_thread_mutex_ops = {
     .init               = ucs_empty_function,
     .cleanup            = ucs_async_signal_global_cleanup,
+    .is_from_async      = ucs_async_thread_is_from_async,
     .block              = ucs_empty_function,
     .unblock            = ucs_empty_function,
     .context_init       = ucs_async_thread_mutex_init,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1031,8 +1031,7 @@ protected:
             /* Emulate failure of the endpoint by invoking error handling
              * procedure */
             UCS_ASYNC_BLOCK(&e.worker()->async);
-            ucp_worker_set_ep_failed(e.worker(), e.ep(), NULL, UCP_NULL_LANE,
-                                     UCS_ERR_ENDPOINT_TIMEOUT);
+            ucp_ep_set_failed(e.ep(), UCP_NULL_LANE, UCS_ERR_ENDPOINT_TIMEOUT);
             UCS_ASYNC_UNBLOCK(&e.worker()->async);
         }
 


### PR DESCRIPTION
## What

Don't invoke set_ep_failed from async thread.

## Why ?

`ucp_worker_set_ep_failed()` mustn't be called from async thread to avoid undefined behavior. e.g.:
```
[1624837542.225089] [jazz29:91333:async]       wireup_cm.c:143  UCX  DIAG  client ep 0x7f39bccda000 failed to connect to 2.1.3.29:20000 using rdmacm,tcp cms
[jazz29:91333:0:91333] ucp_request.inl:947  Assertion `req->flags & UCP_REQUEST_FLAG_SUPER_VALID' failed: req=0x2469980 req->super_req=(nil)
[jazz29:91333:async:91397] ucp_request.inl:947  Assertion `req->flags & UCP_REQUEST_FLAG_SUPER_VALID' failed: req=0x2469980 req->super_req=(nil)
[1624837542.225940] [jazz29:91333:async]           debug.c:1377 UCX  WARN  ucs_debug_disable_signal: signal 8 was not set in ucs

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucp/core/ucp_request.inl: [ ucp_request_get_super() ]
      ...
      943 static UCS_F_ALWAYS_INLINE ucp_request_t*
      944 ucp_request_get_super(ucp_request_t *req)
      945 {
==>   946     ucs_assertv(req->flags & UCP_REQUEST_FLAG_SUPER_VALID,
      947                 "req=%p req->super_req=%p", req, req->super_req);
      948     return req->super_req;
      949 }

==== backtrace (tid:  91397) ====
 0 0x00000000000432e3 ucp_request_get_super()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucp/core/ucp_request.inl:946
 1 0x00000000000432e3 ucp_ep_req_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c:2908
 2 0x0000000000043499 ucp_ep_reqs_purge()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.c:2921
 3 0x0000000000055d71 ucp_worker_set_ep_failed()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucp/core/ucp_worker.c:459
 4 0x0000000000146616 ucp_cm_client_connect_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucp/wireup/wireup_cm.c:754
 5 0x000000000001873a uct_cm_ep_client_connect_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/uct/base/uct_cm.c:122
 6 0x000000000003b327 uct_tcp_sockcm_ep_client_connect_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/uct/tcp/tcp_sockcm_ep.c:57
 7 0x000000000003bd12 uct_tcp_sockcm_ep_invoke_error_cb()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/uct/tcp/tcp_sockcm_ep.c:210
 8 0x000000000003c099 uct_tcp_sockcm_ep_handle_event_status()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/uct/tcp/tcp_sockcm_ep.c:260
 9 0x00000000000396bf uct_tcp_sa_data_handler()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/uct/tcp/tcp_sockcm.c:106
10 0x000000000004762e ucs_async_handler_invoke()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucs/async/async.c:249
11 0x000000000004772b ucs_async_handler_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucs/async/async.c:271
12 0x0000000000047968 ucs_async_dispatch_handlers()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucs/async/async.c:303
13 0x000000000004b944 ucs_async_thread_ev_handler()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucs/async/thread.c:87
14 0x0000000000073adf ucs_event_set_wait()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucs/sys/event_set.c:215
15 0x000000000004ba7f ucs_async_thread_func()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210628_015958_133135_44637_jazz28.swx.labs.mlnx/installs/xPFX/tests/io_demo/ucx.git/src/ucs/async/thread.c:130
16 0x0000000000007dd5 start_thread()  pthread_create.c:0
17 0x00000000000fdead __clone()  ???:0
=================================
```

## How ?

1. Added `int ucs_async_is_from_async(ucs_async_conext_t *async)` whihc indicates whether it is called from async thread or not.
2. Invoked `ucs_async_is_from_async()` inside `ucp_worker_set_ep_failed()`.
3. Introduced functions:
- `ucp_worker_set_ep_failed_schedule()` to schedule `ucp_worker_set_ep_failed()` on worker progress.
- `ucp_worker_set_ep_failed_progress()` is the function to add on worker progress.
- `ucp_worker_set_ep_failed_remove_filter()` to remove the function from worker progress when it is not needed anymore.
4. Introduced `ucp_worker_set_ep_failed_arg_t` structure to save ucp_ep/lane/status parameters.