### PR TITLE
API/UCP/UCT/IODEMO: Add functions to query the ucp and uct endpoints

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4501,7 +4501,9 @@ ucs_status_ptr_t ucp_worker_flush_nbx(ucp_worker_h worker,
  * present. It is used to enable backward compatibility support.
  */
 enum ucp_ep_attr_field {
-    UCP_EP_ATTR_FIELD_NAME = UCS_BIT(0) /**< UCP endpoint name */
+    UCP_EP_ATTR_FIELD_NAME            = UCS_BIT(0), /**< UCP endpoint name */
+    UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(1), /**< Sockaddr used by the endpoint */
+    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2)  /**< Sockaddr the endpoint is connected to */
 };
 
 
@@ -4526,12 +4528,28 @@ typedef struct ucp_ep_attr {
      * this name.
      */
     char     name[UCP_ENTITY_NAME_MAX];
+
+    /**
+     * Local socket address for this endpoint. Valid only for endpoints created 
+     * by connecting to a socket address.
+     * If this field is specified for an endpoint not connected to a socket address,
+     * UCS_ERR_NOT_CONNECTED will be returned.
+     */
+    struct sockaddr_storage local_sockaddr;
+
+    /**
+     * Remote socket address this endpoint is connected to. Valid only for endpoints
+     * created by connecting to a socket address.
+     * If this field is specified for an endpoint not connected to a socket address,
+     * UCS_ERR_NOT_CONNECTED will be returned.
+     */
+    struct sockaddr_storage remote_sockaddr;
 } ucp_ep_attr_t;
 
 
 /**
  * @ingroup UCP_ENDPOINT
- * @brief Get attributes specific to a particular endpoint.
+ * @brief Get attributes of a given endpoint.
  *
  * This routine fetches information about the endpoint.
  *

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3099,6 +3099,51 @@ void ucp_ep_vfs_init(ucp_ep_h ep)
                             UCS_VFS_TYPE_STRING, "error_mode");
 }
 
+static ucs_status_t ucp_ep_query_sockaddr(ucp_ep_h ep, ucp_ep_attr_t *attr)
+{
+    uct_ep_h uct_cm_ep = ucp_ep_get_cm_uct_ep(ep);
+    uct_ep_attr_t uct_cm_ep_attr;
+    ucs_status_t status;
+
+    if ((uct_cm_ep == NULL) || ucp_is_uct_ep_failed(uct_cm_ep)) {
+        ucs_debug("ep %p: no cm", ep);
+        return UCS_ERR_NOT_CONNECTED;
+    }
+
+    memset(&uct_cm_ep_attr, 0, sizeof(uct_ep_attr_t));
+
+    if (attr->field_mask & UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR) {
+        uct_cm_ep_attr.field_mask |= UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR;
+    }
+
+    if (attr->field_mask & UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR) {
+        uct_cm_ep_attr.field_mask |= UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR;
+    }
+
+    status = uct_ep_query(uct_cm_ep, &uct_cm_ep_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (uct_cm_ep_attr.field_mask & UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR) {
+        status = ucs_sockaddr_copy((struct sockaddr*)&attr->local_sockaddr,
+                                   (struct sockaddr*)&uct_cm_ep_attr.local_address);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+    
+    if (uct_cm_ep_attr.field_mask & UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR) {
+        status = ucs_sockaddr_copy((struct sockaddr*)&attr->remote_sockaddr,
+                                   (struct sockaddr*)&uct_cm_ep_attr.remote_address);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr)
 {
     if (attr->field_mask & UCP_EP_ATTR_FIELD_NAME) {
@@ -3109,5 +3154,11 @@ ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr)
 #endif
     }
 
+    if (attr->field_mask &
+        (UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR | UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR)) {
+        return ucp_ep_query_sockaddr(ep, attr);
+    }
+
     return UCS_OK;
 }
+

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -15,6 +15,7 @@
 #include <ucp/wireup/ep_match.h>
 #include <ucp/api/ucp.h>
 #include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/datastruct/queue.h>
 #include <ucs/datastruct/ptr_map.inl>
 #include <ucs/datastruct/strided_alloc.h>

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -181,17 +181,30 @@ ucs_status_t ucs_socket_getopt(int fd, int level, int optname,
     return UCS_OK;
 }
 
+ucs_status_t ucs_socket_getname(int fd, struct sockaddr_storage *sock_addr,
+                                socklen_t *addr_len)
+{
+    int ret;
+
+    *addr_len = sizeof(struct sockaddr_storage);
+    ret       = getsockname(fd, (struct sockaddr*)sock_addr,
+                            addr_len);
+    if (ret < 0) {
+        ucs_error("getsockname(fd=%d) failed: %m", fd);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    return UCS_OK;
+}
+
 const char *ucs_socket_getname_str(int fd, char *str, size_t max_size)
 {
     struct sockaddr_storage sock_addr = {0}; /* Suppress Clang false-positive */
     socklen_t addr_size;
-    int ret;
+    ucs_status_t status;
 
-    addr_size = sizeof(sock_addr);
-    ret       = getsockname(fd, (struct sockaddr*)&sock_addr,
-                            &addr_size);
-    if (ret < 0) {
-        ucs_debug("getsockname(fd=%d) failed: %m", fd);
+    status = ucs_socket_getname(fd, &sock_addr, &addr_size);
+    if (status != UCS_OK) {
         ucs_strncpy_safe(str, "-", max_size);
         return str;
     }

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -429,6 +429,19 @@ int ucs_sockaddr_is_known_af(const struct sockaddr *sa);
 
 
 /**
+ * Extract the IP address from a given socket fd.
+ *
+ * @param [in]   fd          Socket fd.
+ * @param [out]  sock_addr   IP address.
+ * @param [out]  addr_len    Length of the IP address.
+ *
+ * @return UCS_OK if sock_addr has a valid IP address.
+ */
+ucs_status_t ucs_socket_getname(int fd, struct sockaddr_storage *sock_addr,
+                                socklen_t *addr_len);
+
+
+/**
  * Extract the IP address from a given socket fd and return it as a string.
  *
  * @param [in]   fd          Socket fd.

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -86,6 +86,7 @@ typedef struct uct_md_ops            uct_md_ops_t;
 typedef void                         *uct_rkey_ctx_h;
 typedef struct uct_iface_attr        uct_iface_attr_t;
 typedef struct uct_iface_params      uct_iface_params_t;
+typedef struct uct_ep_attr           uct_ep_attr_t;
 typedef struct uct_md_attr           uct_md_attr_t;
 typedef struct uct_completion        uct_completion_t;
 typedef struct uct_pending_req       uct_pending_req_t;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -136,6 +136,21 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief UCT endpoint attributes field mask.
+ *
+ * The enumeration allows specifying which fields in @ref uct_ep_attr_t are
+ * present, for backward compatibility support.
+ */
+enum uct_ep_attr_field {
+    /** Enables @ref uct_ep_attr::local_address */
+    UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(0),
+    /** Enables @ref uct_ep_attr::remote_address */
+    UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(1)
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief field mask of @ref uct_iface_is_reachable_v2
  */
 typedef enum {
@@ -156,6 +171,30 @@ typedef enum {
      */
     UCT_MD_MEM_DEREG_FLAG_INVALIDATE = UCS_BIT(0)
 } uct_md_mem_dereg_flags_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Endpoint attributes, capabilities and limitations.
+ */
+struct uct_ep_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_ep_attr_field. Fields not specified by this mask
+     * will be ignored.
+     */
+    uint64_t                field_mask;
+
+    /**
+     * Local sockaddr used by the endpoint.
+     */
+    struct sockaddr_storage local_address;
+
+    /**
+     * Remote sockaddr the endpoint is connected to.
+     */
+    struct sockaddr_storage remote_address;
+};
 
 
 /**
@@ -284,6 +323,20 @@ uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
  */
 ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
                                  const uct_md_mem_dereg_params_t *params);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Get ep's attributes.
+ *
+ * This routine fetches information about the endpoint.
+ *
+ * @param [in]  ep         Endpoint to query.
+ * @param [out] ep_attr    Filled with endpoint attributes.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_ep_query(uct_ep_h ep, uct_ep_attr_t *ep_attr);
 
 
 /**

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -282,12 +282,14 @@ static ucs_stats_class_t uct_cm_stats_class = {
 #endif
 
 UCS_CLASS_INIT_FUNC(uct_cm_t, uct_cm_ops_t* ops, uct_iface_ops_t* iface_ops,
+                    uct_iface_internal_ops_t* internal_ops,
                     uct_worker_h worker, uct_component_h component,
                     const uct_cm_config_t* config)
 {
     self->ops                     = ops;
     self->component               = component;
     self->iface.super.ops         = *iface_ops;
+    self->iface.internal_ops      = internal_ops;
     self->iface.worker            = ucs_derived_of(worker, uct_priv_worker_t);
 
     self->iface.md                = NULL;
@@ -318,6 +320,7 @@ UCS_CLASS_CLEANUP_FUNC(uct_cm_t)
 
 UCS_CLASS_DEFINE(uct_cm_t, void);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_cm_t, void, uct_cm_ops_t*, uct_iface_ops_t*,
+                          uct_iface_internal_ops_t*,
                           uct_worker_h, uct_component_h, const uct_cm_config_t*);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_cm_t, void);
 

--- a/src/uct/base/uct_cm.h
+++ b/src/uct/base/uct_cm.h
@@ -128,8 +128,8 @@ UCS_CLASS_DECLARE_DELETE_FUNC(uct_cm_base_ep_t, uct_base_ep_t);
 
 extern ucs_config_field_t uct_cm_config_table[];
 
-UCS_CLASS_DECLARE(uct_cm_t, uct_cm_ops_t*, uct_iface_ops_t*, uct_worker_h,
-                  uct_component_h, const uct_cm_config_t*);
+UCS_CLASS_DECLARE(uct_cm_t, uct_cm_ops_t*, uct_iface_ops_t*, uct_iface_internal_ops_t*,
+                  uct_worker_h, uct_component_h, const uct_cm_config_t*);
 
 ucs_status_t uct_listener_backlog_adjust(const uct_listener_params_t *params,
                                          int max_value, int *backlog);

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -442,6 +442,7 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 uct_iface_internal_ops_t uct_base_iface_internal_ops = {
     .iface_estimate_perf = uct_base_iface_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
 };
 
 UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
@@ -590,6 +591,13 @@ ucs_status_t uct_ep_connect_to_ep(uct_ep_h ep, const uct_device_addr_t *dev_addr
 ucs_status_t uct_cm_client_ep_conn_notify(uct_ep_h ep)
 {
     return ep->iface->ops.cm_ep_conn_notify(ep);
+}
+
+ucs_status_t uct_ep_query(uct_ep_h ep, uct_ep_attr_t *ep_attr)
+{
+    const uct_base_iface_t *iface = ucs_derived_of(ep->iface, uct_base_iface_t);
+
+    return iface->internal_ops->ep_query(ep, ep_attr);
 }
 
 void uct_ep_set_iface(uct_ep_h ep, uct_iface_t *iface)

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -235,10 +235,15 @@ typedef ucs_status_t (*uct_iface_estimate_perf_func_t)(
 typedef void (*uct_iface_vfs_refresh_func_t)(uct_iface_h iface);
 
 
+/* Query the attributes of the ep */
+typedef ucs_status_t (*uct_ep_query_func_t)(uct_ep_h ep, uct_ep_attr_t *ep_attr);
+
+
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
     uct_iface_estimate_perf_func_t iface_estimate_perf;
     uct_iface_vfs_refresh_func_t   iface_vfs_refresh;
+    uct_ep_query_func_t            ep_query;
 } uct_iface_internal_ops_t;
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -336,6 +336,7 @@ static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .iface_estimate_perf = uct_cuda_copy_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -149,6 +149,7 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
     .iface_estimate_perf = uct_gdr_copy_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -825,6 +825,12 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_is_reachable       = (uct_iface_is_reachable_func_t)ucs_empty_function_return_zero
 };
 
+static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
+    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function,
+    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query            = uct_rdmacm_ep_query,
+};
+
 static ucs_status_t
 uct_rdmacm_cm_ipstr_to_sockaddr(const char *ip_str, struct sockaddr **saddr_p,
                                 const char *debug_name)
@@ -870,8 +876,8 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
     ucs_log_level_t log_lvl;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_cm_t, &uct_rdmacm_cm_ops,
-                              &uct_rdmacm_cm_iface_ops, worker, component,
-                              config);
+                              &uct_rdmacm_cm_iface_ops, &uct_rdmacm_cm_iface_internal_ops,
+                              worker, component, config);
 
     kh_init_inplace(uct_rdmacm_cm_device_contexts, &self->ctxs);
 

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -111,6 +111,33 @@ void uct_rdmacm_cm_ep_set_failed(uct_rdmacm_cm_ep_t *cep,
     UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_ep_get_async(cep));
 }
 
+ucs_status_t uct_rdmacm_ep_query(uct_ep_h ep, uct_ep_attr_t *ep_attr)
+{
+    uct_rdmacm_cm_ep_t *rdmacm_ep = ucs_derived_of(ep, uct_rdmacm_cm_ep_t);
+    struct sockaddr *local_saddr, *remote_saddr;
+    ucs_status_t status;
+
+    if (ep_attr->field_mask & UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR) {
+        local_saddr = rdma_get_local_addr(rdmacm_ep->id);
+        status = ucs_sockaddr_copy((struct sockaddr*)&ep_attr->local_address,
+                                   local_saddr);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    if (ep_attr->field_mask & UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR) {
+        remote_saddr = rdma_get_peer_addr(rdmacm_ep->id);
+        status = ucs_sockaddr_copy((struct sockaddr*)&ep_attr->remote_address,
+                                   remote_saddr);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t uct_rdmacm_cm_ep_conn_notify(uct_ep_h ep)
 {
     uct_rdmacm_cm_ep_t *cep                 = ucs_derived_of(ep, uct_rdmacm_cm_ep_t);

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.h
@@ -77,6 +77,8 @@ ucs_status_t uct_rdmacm_cm_ep_pack_cb(uct_rdmacm_cm_ep_t *cep,
                                       void *private_data,
                                       size_t *priv_data_length);
 
+ucs_status_t uct_rdmacm_ep_query(uct_ep_h ep, uct_ep_attr_t *ep_attr);
+
 ucs_status_t uct_rdmacm_cm_ep_resolve_cb(uct_rdmacm_cm_ep_t *cep);
 
 void uct_rdmacm_cm_ep_error_cb(uct_rdmacm_cm_ep_t *cep,

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -324,6 +324,8 @@ private:
 
     void set_log_prefix(const struct sockaddr* saddr, socklen_t addrlen);
 
+    void print_addresses();
+
     void connect_common(ucp_ep_params_t &ep_params, UcxCallback *callback);
 
     void connect_tag(UcxCallback *callback);

--- a/test/gtest/uct/ib/test_sockaddr.cc
+++ b/test/gtest/uct/ib/test_sockaddr.cc
@@ -9,6 +9,7 @@
 
 extern "C" {
 #include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 #include <ucs/arch/atomic.h>
@@ -214,6 +215,36 @@ protected:
         connect();
         wait_for_bits(&m_state, TEST_STATE_CONNECT_REQUESTED);
         EXPECT_TRUE(m_state & TEST_STATE_CONNECT_REQUESTED);
+    }
+
+    void ep_query(unsigned index = 0) {
+        uct_ep_attr_t attr;
+        ucs_status_t status;
+
+        attr.field_mask = UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR |
+                          UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR;
+        status = uct_ep_query(m_server->ep(index), &attr);
+        ASSERT_UCS_OK(status);
+
+        EXPECT_EQ(m_connect_addr, attr.local_address);
+
+        /* The ports are expected to be different. Ignore them. */
+        ucs_sockaddr_set_port((struct sockaddr*)&attr.remote_address,
+                              m_connect_addr.get_port());
+        EXPECT_EQ(m_connect_addr, attr.remote_address);
+
+        memset(&attr, 0, sizeof(attr));
+        attr.field_mask = UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR |
+                          UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR;
+        status = uct_ep_query(m_client->ep(index), &attr);
+        ASSERT_UCS_OK(status);
+
+        /* The ports are expected to be different. Ignore them. */
+        ucs_sockaddr_set_port((struct sockaddr*)&attr.local_address,
+                              m_connect_addr.get_port());
+        EXPECT_EQ(m_connect_addr, attr.local_address);
+
+        EXPECT_EQ(m_connect_addr, attr.remote_address);
     }
 
     size_t priv_data_do_pack(size_t pack_limit, void *priv_data) {
@@ -737,6 +768,20 @@ UCS_TEST_P(test_uct_sockaddr, listener_query)
     ASSERT_UCS_OK(status);
 
     EXPECT_EQ(m_listen_addr.get_port(), port);
+}
+
+UCS_TEST_P(test_uct_sockaddr, ep_query)
+{
+    listen_and_connect();
+
+    wait_for_bits(&m_state, TEST_STATE_SERVER_CONNECTED |
+                            TEST_STATE_CLIENT_CONNECTED);
+    EXPECT_TRUE(ucs_test_all_flags(m_state, (TEST_STATE_SERVER_CONNECTED |
+                                             TEST_STATE_CLIENT_CONNECTED)));
+
+    ep_query();
+
+    cm_disconnect(m_client);
 }
 
 UCS_TEST_P(test_uct_sockaddr, cm_open_listen_close)


### PR DESCRIPTION
## What
Add functions to query the ucp and uct endpoints

## Why ?
Sometimes users need API to get remote and local IP/port per endpoint

## How ?
Get the remote and local IP/port through RDMA_CM
