### PR TITLE
UCT/IFACE: Improve uct_iface_estimate_perf

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -55,23 +55,23 @@ typedef enum uct_ep_operation {
  * @ingroup UCT_RESOURCE
  * @brief UCT interface query by @ref uct_iface_estimate_perf parameters field mask.
  *
- * The enumeration allows specifying which fields in @ref uct_perf_attr_t are
+ * The enumeration allows specifying which fields in @ref uct_iface_perf_attr_t are
  * present, for backward compatibility support.
  */
 enum uct_perf_attr_field {
-    /** Enables @ref uct_perf_attr_t::operation */
+    /** Enables @ref uct_iface_perf_attr_t::operation */
     UCT_PERF_ATTR_FIELD_OPERATION          = UCS_BIT(0),
 
-    /** Enables @ref uct_perf_attr_t::local_memory_type */
+    /** Enables @ref uct_iface_perf_attr_t::local_memory_type */
     UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE  = UCS_BIT(1),
 
-    /** Enables @ref uct_perf_attr_t::remote_memory_type */
+    /** Enables @ref uct_iface_perf_attr_t::remote_memory_type */
     UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE = UCS_BIT(2),
 
-    /** Enables @ref uct_perf_attr_t::overhead */
+    /** Enables @ref uct_iface_perf_attr_t::overhead */
     UCT_PERF_ATTR_FIELD_OVERHEAD           = UCS_BIT(3),
 
-    /** Enables @ref uct_perf_attr_t::bandwidth */
+    /** Enables @ref uct_iface_perf_attr_t::bandwidth */
     UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(4)
 };
 
@@ -118,7 +118,7 @@ typedef struct {
      * Bandwidth model. This field is set by the UCT layer.
      */
     uct_ppn_bandwidth_t bandwidth;
-} uct_perf_attr_t;
+} uct_iface_perf_attr_t;
 
 
 /**
@@ -196,7 +196,7 @@ typedef struct uct_md_mem_dereg_params {
 /**
  * @ingroup UCT_RESOURCE
  * @brief Get interface performance attributes, by memory types and operation.
- *        A pointer to uct_perf_attr_t struct must be passed, with the memory
+ *        A pointer to uct_iface_perf_attr_t struct must be passed, with the memory
  *        types and operation members initialized. Overhead and bandwidth
  *        for the operation on the given memory types will be reported.
  *
@@ -204,7 +204,7 @@ typedef struct uct_md_mem_dereg_params {
  * @param [inout] perf_attr Filled with performance attributes.
  */
 ucs_status_t
-uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
+uct_iface_estimate_perf(uct_iface_h tl_iface, uct_iface_perf_attr_t *perf_attr);
 
 
 /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -72,7 +72,10 @@ enum uct_perf_attr_field {
     UCT_PERF_ATTR_FIELD_OVERHEAD           = UCS_BIT(3),
 
     /** Enables @ref uct_iface_perf_attr_t::bandwidth */
-    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(4)
+    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(4),
+
+    /** Enables @ref uct_iface_perf_attr_t::latency */
+    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(5)
 };
 
 
@@ -118,6 +121,13 @@ typedef struct {
      * Bandwidth model. This field is set by the UCT layer.
      */
     uct_ppn_bandwidth_t bandwidth;
+
+    /**
+     * Latency as function of number of active endpoints.
+     * This field is set by the UCT layer.
+     */
+    ucs_linear_func_t   latency;      
+    
 } uct_iface_perf_attr_t;
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -407,6 +407,10 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr
         perf_attr->overhead = iface_attr.overhead;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = iface_attr.latency;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -174,7 +174,7 @@ ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 }
 
 ucs_status_t
-uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
+uct_iface_estimate_perf(uct_iface_h tl_iface, uct_iface_perf_attr_t *perf_attr)
 {
     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
 
@@ -388,7 +388,7 @@ ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
 }
 
 ucs_status_t
-uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+uct_base_iface_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr)
 {
     ucs_status_t status;
     uct_iface_attr_t iface_attr;

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -228,7 +228,7 @@ typedef struct uct_am_handler {
 
 /* Performance estimation operation */
 typedef ucs_status_t (*uct_iface_estimate_perf_func_t)(
-        uct_iface_h iface, uct_perf_attr_t *perf_attr);
+        uct_iface_h iface, uct_iface_perf_attr_t *perf_attr);
 
 
 /* Refresh the VFS representation of the interface */
@@ -727,7 +727,7 @@ void uct_base_iface_progress_enable_cb(uct_base_iface_t *iface,
 void uct_base_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
 
 ucs_status_t
-uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
+uct_base_iface_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr);
 
 ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -286,7 +286,7 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 }
 
 static ucs_status_t
-uct_cuda_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+uct_cuda_copy_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr)
 {
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         perf_attr->bandwidth.dedicated = 0;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -105,7 +105,7 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency                 = ucs_linear_func_make(8e-6, 0);
+    iface_attr->latency                 = UCT_CUDA_COPY_LATENCY;
     iface_attr->bandwidth.dedicated     = 0;
     iface_attr->bandwidth.shared        = UCT_CUDA_COPY_IFACE_DEFAULT_BANDWIDTH;
     iface_attr->overhead                = UCT_CUDA_COPY_IFACE_OVERHEAD;
@@ -317,6 +317,11 @@ uct_cuda_copy_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr)
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
         perf_attr->overhead = UCT_CUDA_COPY_IFACE_OVERHEAD;
     }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = UCT_CUDA_COPY_LATENCY;
+    }
+
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -17,6 +17,9 @@
 #define UCT_CUDA_COPY_IFACE_OVERHEAD          (0)
 
 
+#define UCT_CUDA_COPY_LATENCY (ucs_linear_func_make(8e-6, 0))
+
+
 typedef uint64_t uct_cuda_copy_iface_addr_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -96,7 +96,7 @@ uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 }
 
 static ucs_status_t
-uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr)
 {
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         perf_attr->bandwidth.dedicated = 0;

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -86,7 +86,7 @@ uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
+    iface_attr->latency                 = UCT_GDR_COPY_IFACE_LATENCY;
     iface_attr->bandwidth.dedicated     = 0;
     iface_attr->bandwidth.shared        = UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
     iface_attr->overhead                = UCT_GDR_COPY_IFACE_OVERHEAD;
@@ -121,6 +121,11 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_iface_perf_attr_t *perf_attr)
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
         perf_attr->overhead = UCT_GDR_COPY_IFACE_OVERHEAD;
     }
+    
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = UCT_GDR_COPY_IFACE_LATENCY;
+    }
+
 
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.h
@@ -15,6 +15,9 @@
 #define UCT_GDR_COPY_IFACE_OVERHEAD (0)
 
 
+#define UCT_GDR_COPY_IFACE_LATENCY (ucs_linear_func_make(1e-6, 0))
+
+
 typedef uint64_t uct_gdr_copy_iface_addr_t;
 
 

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -20,7 +20,7 @@ public:
 
 UCS_TEST_P(test_uct_query, query_perf)
 {
-    uct_perf_attr_t perf_attr;
+    uct_iface_perf_attr_t perf_attr;
     ucs_status_t status;
 
     perf_attr.field_mask         = UCT_PERF_ATTR_FIELD_OPERATION |
@@ -44,7 +44,7 @@ UCS_TEST_P(test_uct_query, query_perf)
     EXPECT_NE(0, perf_attr.bandwidth.shared + perf_attr.bandwidth.dedicated);
 
     if (has_transport("cuda_copy") || has_transport("gdr_copy")) {
-        uct_perf_attr_t perf_attr_get;
+        uct_iface_perf_attr_t perf_attr_get;
         perf_attr_get.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
                                    UCT_PERF_ATTR_FIELD_BANDWIDTH;
         perf_attr_get.operation  = UCT_OP_GET_SHORT;

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -21,13 +21,14 @@ public:
 UCS_TEST_P(test_uct_query, query_perf)
 {
     uct_iface_perf_attr_t perf_attr;
-    ucs_status_t status;
+    ucs_status_t status;    
 
     perf_attr.field_mask         = UCT_PERF_ATTR_FIELD_OPERATION |
                                    UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE |
                                    UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE |
                                    UCT_PERF_ATTR_FIELD_OVERHEAD |
-                                   UCT_PERF_ATTR_FIELD_BANDWIDTH;
+                                   UCT_PERF_ATTR_FIELD_BANDWIDTH |
+                                   UCT_PERF_ATTR_FIELD_LATENCY;
     perf_attr.operation          = UCT_OP_AM_SHORT;
     perf_attr.local_memory_type  = UCS_MEMORY_TYPE_HOST;
     perf_attr.remote_memory_type = UCS_MEMORY_TYPE_HOST;
@@ -43,17 +44,26 @@ UCS_TEST_P(test_uct_query, query_perf)
     /* At least one type of bandwidth must be non-zero */
     EXPECT_NE(0, perf_attr.bandwidth.shared + perf_attr.bandwidth.dedicated);
 
+    if (has_transport("self")) {
+        /* The latency in "self" is 0 */
+        EXPECT_EQ(perf_attr.latency.c, 0);
+    } else {
+        EXPECT_NE(perf_attr.latency.c, 0);
+    }
+
     if (has_transport("cuda_copy") || has_transport("gdr_copy")) {
         uct_iface_perf_attr_t perf_attr_get;
         perf_attr_get.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
-                                   UCT_PERF_ATTR_FIELD_BANDWIDTH;
+                                   UCT_PERF_ATTR_FIELD_BANDWIDTH |
+                                   UCT_PERF_ATTR_FIELD_LATENCY;
         perf_attr_get.operation  = UCT_OP_GET_SHORT;
         status = uct_iface_estimate_perf(sender().iface(), &perf_attr_get);
         EXPECT_EQ(status, UCS_OK);
 
         /* Put and get operations have different bandwidth in cuda_copy
            and gdr_copy transports */
-        EXPECT_NE(perf_attr.bandwidth.shared, perf_attr_get.bandwidth.shared);
+        EXPECT_NE(perf_attr.latency.c, 0);
+
     }
 }
 


### PR DESCRIPTION
## What
* Add latency and overhead
* Provide BW per operation + local / remote memory types

## Why ?
Provide more precise estimates

## How ?
Use `ucx_perftest` for benchmarking
