### PR TITLE
UCS/MEMTRACK: added public API for memtrack:

### DIFF
--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -7,7 +7,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/type/spinlock.h>
 

--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,6 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_GTEST], [false])
      AM_CONDITIONAL([HAVE_STATS], [false])
      AM_CONDITIONAL([HAVE_TUNING], [false])
-     AM_CONDITIONAL([HAVE_MEMTRACK], [false])
      AM_CONDITIONAL([HAVE_IB], [false])
      AM_CONDITIONAL([HAVE_MLX5_HW], [false])
      AM_CONDITIONAL([HAVE_MLX5_HW_UD], [false])

--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -18,7 +18,6 @@ $basedir/../configure \
 	--enable-profiling \
 	--enable-frame-pointer \
 	--enable-stats \
-	--enable-memtrack \
 	--enable-fault-injection \
 	--enable-debug-data \
 	--enable-mt \

--- a/contrib/configure-prof
+++ b/contrib/configure-prof
@@ -20,5 +20,4 @@ $basedir/../configure \
 	--enable-profiling \
 	--enable-frame-pointer \
 	--enable-stats \
-	--enable-memtrack \
 	"$@"

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -29,7 +29,7 @@
 #include <ucp/rma/rma.h>
 
 #include <ucs/datastruct/queue.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/debug_int.h>
 #include <ucs/sys/string.h>

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -13,7 +13,7 @@
 #include "ucp_worker.h"
 
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>

--- a/src/ucp/dt/dt_generic.c
+++ b/src/ucp/dt/dt_generic.c
@@ -11,7 +11,7 @@
 #include "dt_generic.h"
 
 #include <ucs/sys/math.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 
 
 ucs_status_t ucp_dt_create_generic(const ucp_generic_dt_ops_t *ops, void *context,

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -45,6 +45,7 @@ nobase_dist_libucs_la_HEADERS = \
 	datastruct/string_set.h \
 	debug/log_def.h \
 	debug/debug.h \
+	debug/memtrack.h \
 	memory/rcache.h \
 	memory/memory_type.h \
 	memory/memtype_cache.h \
@@ -99,7 +100,7 @@ noinst_HEADERS = \
 	debug/assert.h \
 	debug/debug_int.h \
 	debug/log.h \
-	debug/memtrack.h \
+	debug/memtrack_int.h \
 	memory/numa.h \
 	memory/rcache_int.h \
 	profile/profile.h \

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -219,7 +219,6 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   ucs_offsetof(ucs_global_opts_t, vfs_thread_affinity),
   UCS_CONFIG_TYPE_BOOL},
 
-#ifdef ENABLE_MEMTRACK
  {"MEMTRACK_DEST", "",
   "Destination to output memory tracking report to. If the value is empty,\n"
   "results are not reported. Possible values are:\n"
@@ -232,7 +231,6 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "Memory limit allocated by memtrack. In case if limit is reached then\n"
   "memtrack report is generated and process is terminated.\n",
   ucs_offsetof(ucs_global_opts_t, memtrack_limit), UCS_CONFIG_TYPE_MEMUNITS},
-#endif
 
   {"PROFILE_MODE", "",
    "Profile collection modes. If none is specified, profiling is disabled.\n"

--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -120,24 +120,6 @@ AM_CONDITIONAL([HAVE_TUNING],[test "x$HAVE_TUNING" = "xyes"])
 
 
 #
-# Enable memory tracking
-#
-AC_ARG_ENABLE([memtrack],
-	AS_HELP_STRING([--enable-memtrack], 
-	               [Enable memory tracking, useful for profiling, default: NO]),
-	[],
-	[enable_memtrack=no])
-	
-AS_IF([test "x$enable_memtrack" = xyes],
-	  [AS_MESSAGE([enabling memory tracking])
-	   AC_DEFINE([ENABLE_MEMTRACK], [1], [Enable memory tracking])
-	   HAVE_MEMTRACK=yes],
-	  [:]
-  )
-AM_CONDITIONAL([HAVE_MEMTRACK],[test "x$HAVE_MEMTRACK" = "xyes"])
-
-
-#
 # Disable logging levels below INFO
 #
 AC_ARG_ENABLE([logging],

--- a/src/ucs/datastruct/array.c
+++ b/src/ucs/datastruct/array.c
@@ -12,7 +12,7 @@
 
 #include <ucs/sys/math.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 
 
 /* Increase the array buffer length by this factor, whenever it needs to grow */

--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -12,7 +12,7 @@
 
 #include <ucs/debug/log.h>
 #include <ucs/debug/assert.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/algorithm/crc.h>
 
 

--- a/src/ucs/datastruct/mpmc.c
+++ b/src/ucs/datastruct/mpmc.c
@@ -14,7 +14,7 @@
 #include <ucs/arch/atomic.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/debug/assert.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 
 
 ucs_status_t ucs_mpmc_queue_init(ucs_mpmc_queue_t *mpmc, uint32_t length)

--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -13,7 +13,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 #include <string.h>
 

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -9,7 +9,7 @@
 #define PTR_ARRAY_H_
 
 #include <ucs/sys/math.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/debug/assert.h>
 
@@ -68,9 +68,7 @@ typedef struct ucs_ptr_array {
     unsigned                 freelist; /* Index of first free slot (see above) */
     unsigned                 size;     /* Number of allocated array slots */
     unsigned                 count;    /* Actual number of occupied slots */
-#ifdef ENABLE_MEMTRACK
-    char                     name[64]; /* Name of this pointer array */
-#endif
+    const char               *name;    /* Name of this pointer array */
 } ucs_ptr_array_t;
 
 

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -12,7 +12,7 @@
 
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>
 #include <string.h>

--- a/src/ucs/datastruct/string_set.c
+++ b/src/ucs/datastruct/string_set.c
@@ -12,7 +12,7 @@
 
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 
 
 #define UCS_STRING_SET_ALLOC_NAME          "string_set"

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -382,8 +382,7 @@ ucs_status_t ucs_debug_backtrace_create(backtrace_h *bckt, int strip)
     ucs_status_t status;
 
     *bckt  = NULL;
-    status = ucs_mmap_alloc(&size, (void**)bckt, 0
-                            UCS_MEMTRACK_NAME("debug backtrace object"));
+    status = ucs_mmap_alloc(&size, (void**)bckt, 0, "debug backtrace object");
     if (status != UCS_OK) {
         return status;
     }
@@ -589,8 +588,7 @@ ucs_status_t ucs_debug_backtrace_create(backtrace_h *bckt, int strip)
     ucs_status_t status;
 
     *bckt  = NULL;
-    status = ucs_mmap_alloc(&size, (void**)bckt, 0
-                            UCS_MEMTRACK_NAME("debug backtrace object"));
+    status = ucs_mmap_alloc(&size, (void**)bckt, 0, "debug backtrace object");
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucs/debug/memtrack.h
+++ b/src/ucs/debug/memtrack.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+* Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
@@ -7,79 +7,13 @@
 #ifndef UCS_MEMTRACK_H_
 #define UCS_MEMTRACK_H_
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <ucs/sys/compiler_def.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <stddef.h>
 
 
 BEGIN_C_DECLS
 
 /** @file memtrack.h */
-
-enum {
-    UCS_MEMTRACK_STAT_ALLOCATION_COUNT,
-    UCS_MEMTRACK_STAT_ALLOCATION_SIZE,
-    UCS_MEMTRACK_STAT_LAST
-};
-
-
-/**
- * Allocation site entry
- */
-typedef struct ucs_memtrack_entry {
-    size_t                  size;       /* currently allocated total size */
-    size_t                  peak_size;  /* peak allocated total size */
-    unsigned                count;      /* number of currently allocated blocks */
-    unsigned                peak_count; /* peak number of allocated blocks */
-    char                    name[0];    /* allocation name */
-} ucs_memtrack_entry_t;
-
-
-
-#ifdef ENABLE_MEMTRACK
-
-#define UCS_MEMTRACK_ARG        , const char* alloc_name
-#define UCS_MEMTRACK_VAL        , alloc_name
-#define UCS_MEMTRACK_VAL_ALWAYS alloc_name
-#define UCS_MEMTRACK_NAME(_n)   , _n
-
-
-/**
- * Start tracking memory (or increment reference count).
- */
-void ucs_memtrack_init();
-
-
-/**
- * Stop tracking memory (or decrement reference count).
- */
-void ucs_memtrack_cleanup();
-
-
-/*
- * Check if memtrack is enabled at the moment.
- */
-int ucs_memtrack_is_enabled();
-
-
-/**
- * Print a summary of memory tracked so far.
- *
- * @param output         Stream to direct output to.
- */
-void ucs_memtrack_dump(FILE* output);
-
-
-/**
- * Calculates the total of buffers currently tracked.
- *
- * @param total          Entry (pre-allocated) to place results in.
- */
-void ucs_memtrack_total(ucs_memtrack_entry_t* total);
 
 
 /**
@@ -94,59 +28,6 @@ void ucs_memtrack_allocated(void *ptr, size_t size, const char *name);
  */
 void ucs_memtrack_releasing(void *ptr);
 
-
-/*
- * Memory allocation replacements. Their interface is the same as the originals,
- * except the additional parameter which specifies the allocation name.
- */
-void *ucs_malloc(size_t size, const char *name);
-void *ucs_calloc(size_t nmemb, size_t size, const char *name);
-void *ucs_realloc(void *ptr, size_t size, const char *name);
-int ucs_posix_memalign(void **ptr, size_t boundary, size_t size,
-                       const char *name);
-void ucs_free(void *ptr);
-void *ucs_mmap(void *addr, size_t length, int prot, int flags, int fd,
-               off_t offset, const char *name);
-int ucs_munmap(void *addr, size_t length);
-char *ucs_strdup(const char *src, const char *name);
-char *ucs_strndup(const char *src, size_t n, const char *name);
-
-#else
-
-#define UCS_MEMTRACK_ARG
-#define UCS_MEMTRACK_VAL
-#define UCS_MEMTRACK_VAL_ALWAYS                    ""
-#define UCS_MEMTRACK_NAME(_n)
-
-#define ucs_memtrack_init()                        UCS_EMPTY_STATEMENT
-#define ucs_memtrack_cleanup()                     UCS_EMPTY_STATEMENT
-#define ucs_memtrack_is_enabled()                  0
-#define ucs_memtrack_dump(_output)                 UCS_EMPTY_STATEMENT
-#define ucs_memtrack_total(_total)                 ucs_memtrack_total_init(_total)
-
-#define ucs_memtrack_allocated(_ptr, _sz, ...)     UCS_EMPTY_STATEMENT
-#define ucs_memtrack_releasing(_ptr)               UCS_EMPTY_STATEMENT
-
-#define ucs_malloc(_s, ...)                        malloc(_s)
-#define ucs_calloc(_n, _s, ...)                    calloc(_n, _s)
-#define ucs_realloc(_p, _s, ...)                   realloc(_p, _s)
-#if HAVE_POSIX_MEMALIGN
-#define ucs_posix_memalign(_pp, _b, _s, ...)       posix_memalign(_pp, _b, _s)
-#endif
-#define ucs_free(_p)                               free(_p)
-#define ucs_mmap(_a, _l, _p, _fl, _fd, _o, ...)    mmap(_a, _l, _p, _fl, _fd, _o)
-#define ucs_munmap(_a, _l)                         munmap(_a, _l)
-#define ucs_strdup(_src, ...)                      strdup(_src)
-#define ucs_strndup(_src, _n, ...)                 strndup(_src, _n)
-
-#endif /* ENABLE_MEMTRACK */
-
 END_C_DECLS
 
-/*
- * The functions below have no native implementation, they apply to both cases.
- */
-int ucs_posix_memalign_realloc(void **ptr, size_t boundary, size_t size,
-                               const char *name);
-
-#endif
+#endif /* UCS_MEMTRACK_H_ */

--- a/src/ucs/debug/memtrack_int.h
+++ b/src/ucs/debug/memtrack_int.h
@@ -1,0 +1,101 @@
+/**
+* Copyright (C) Mellanox Technologies Ltd. 2001-2019.  ALL RIGHTS RESERVED.
+* Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_MEMTRACK_INT_H_
+#define UCS_MEMTRACK_INT_H_
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <ucs/sys/compiler_def.h>
+#include <ucs/debug/memtrack.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+
+BEGIN_C_DECLS
+
+/** @file memtrack_int.h */
+
+enum {
+    UCS_MEMTRACK_STAT_ALLOCATION_COUNT,
+    UCS_MEMTRACK_STAT_ALLOCATION_SIZE,
+    UCS_MEMTRACK_STAT_LAST
+};
+
+
+/**
+ * Allocation site entry
+ */
+typedef struct ucs_memtrack_entry {
+    size_t                  size;       /* currently allocated total size */
+    size_t                  peak_size;  /* peak allocated total size */
+    unsigned                count;      /* number of currently allocated blocks */
+    unsigned                peak_count; /* peak number of allocated blocks */
+    char                    name[0];    /* allocation name */
+} ucs_memtrack_entry_t;
+
+
+/**
+ * Start tracking memory (or increment reference count).
+ */
+void ucs_memtrack_init();
+
+
+/**
+ * Stop tracking memory (or decrement reference count).
+ */
+void ucs_memtrack_cleanup();
+
+
+/*
+ * Check if memtrack is enabled at the moment.
+ */
+int ucs_memtrack_is_enabled();
+
+
+/**
+ * Print a summary of memory tracked so far.
+ *
+ * @param output         Stream to direct output to.
+ */
+void ucs_memtrack_dump(FILE* output);
+
+
+/**
+ * Calculates the total of buffers currently tracked.
+ *
+ * @param total          Entry (pre-allocated) to place results in.
+ */
+void ucs_memtrack_total(ucs_memtrack_entry_t* total);
+
+
+/*
+ * Memory allocation replacements. Their interface is the same as the originals,
+ * except the additional parameter which specifies the allocation name.
+ */
+void *ucs_malloc(size_t size, const char *name);
+void *ucs_calloc(size_t nmemb, size_t size, const char *name);
+void *ucs_realloc(void *ptr, size_t size, const char *name);
+int ucs_posix_memalign(void **ptr, size_t boundary, size_t size,
+                       const char *name);
+void ucs_free(void *ptr);
+void *ucs_mmap(void *addr, size_t length, int prot, int flags, int fd,
+               off_t offset, const char *name);
+int ucs_munmap(void *addr, size_t length);
+char *ucs_strdup(const char *src, const char *name);
+char *ucs_strndup(const char *src, size_t n, const char *name);
+
+/*
+ * The functions below have no native implementation, they apply to both cases.
+ */
+int ucs_posix_memalign_realloc(void **ptr, size_t boundary, size_t size,
+                               const char *name);
+
+END_C_DECLS
+
+#endif /* UCS_MEMTRACK_INT_H_ */

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -15,7 +15,7 @@
 #include <ucs/datastruct/queue.h>
 #include <ucs/debug/log.h>
 #include <ucs/profile/profile.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/stats/stats.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>

--- a/src/ucs/memory/numa.h
+++ b/src/ucs/memory/numa.h
@@ -11,7 +11,7 @@
 #  include "config.h"
 #endif
 
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 
 #if HAVE_NUMA
 #include <numaif.h>

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -14,7 +14,7 @@
 #include <ucs/datastruct/queue.h>
 #include <ucs/debug/log.h>
 #include <ucs/profile/profile.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/stats/stats.h>
 #include <ucs/sys/math.h>
 #include <ucs/sys/sys.h>

--- a/src/ucs/sys/event_set.c
+++ b/src/ucs/sys/event_set.c
@@ -10,7 +10,7 @@
 
 #include "event_set.h"
 
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/assert.h>
 #include <ucs/sys/math.h>

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -14,7 +14,7 @@
 #include <ucs/config/parser.h>
 #include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/stats/stats.h>
 #include <ucs/async/async.h>

--- a/src/ucs/sys/module.c
+++ b/src/ucs/sys/module.c
@@ -15,7 +15,7 @@
 #include "module.h"
 
 #include <ucs/sys/preprocessor.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/string.h>

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -924,7 +924,7 @@ ucs_status_t ucs_sysv_alloc(size_t *size, size_t max_size, void **address_p,
         }
     }
 
-    ucs_memtrack_allocated(ptr, alloc_size UCS_MEMTRACK_VAL);
+    ucs_memtrack_allocated(ptr, alloc_size, alloc_name);
     *address_p = ptr;
     *size      = alloc_size;
     return UCS_OK;
@@ -945,7 +945,7 @@ ucs_status_t ucs_sysv_free(void *address)
 }
 
 ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
-                            int flags UCS_MEMTRACK_ARG)
+                            int flags, const char *alloc_name)
 {
     size_t alloc_length;
     void *addr;
@@ -953,7 +953,7 @@ ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
     alloc_length = ucs_align_up_pow2(*size, ucs_get_page_size());
 
     addr = ucs_mmap(*address_p, alloc_length, PROT_READ | PROT_WRITE,
-                    MAP_PRIVATE | MAP_ANON | flags, -1, 0 UCS_MEMTRACK_VAL);
+                    MAP_PRIVATE | MAP_ANON | flags, -1, 0, alloc_name);
     if (addr == MAP_FAILED) {
         return UCS_ERR_NO_MEMORY;
     }

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -17,7 +17,7 @@
 #include <ucs/type/status.h>
 #include <ucs/type/cpu_set.h>
 #include <ucs/time/time_def.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/config/types.h>
 #include <ucs/config/parser.h>
 
@@ -356,7 +356,7 @@ ucs_status_t ucs_sysv_free(void *address);
  * @param flags     Flags to pass to the mmap() system call
  */
 ucs_status_t ucs_mmap_alloc(size_t *size, void **address_p,
-                            int flags UCS_MEMTRACK_ARG);
+                            int flags, const char *alloc_name);
 
 /**
  * Release memory allocated via mmap API.

--- a/src/ucs/time/timer_wheel.c
+++ b/src/ucs/time/timer_wheel.c
@@ -12,7 +12,7 @@
 
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 
 

--- a/src/ucs/time/timerq.c
+++ b/src/ucs/time/timerq.c
@@ -11,7 +11,7 @@
 #include "timerq.h"
 
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 #include <stdlib.h>
 

--- a/src/ucs/type/class.c
+++ b/src/ucs/type/class.c
@@ -11,7 +11,7 @@
 #include "class.h"
 
 #include <ucs/debug/assert.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 
 

--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -14,7 +14,7 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log_def.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/string.h>
 #include <stdarg.h>

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -8,7 +8,7 @@
 #include "config.h"
 #endif
 
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/vfs/sock/vfs_sock.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/sys/compiler.h>

--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -11,7 +11,7 @@
 #include "uct_component.h"
 
 #include <ucs/debug/assert.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/module.h>
 #include <ucs/sys/string.h>
 #include <limits.h>

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -15,7 +15,7 @@
 
 #include <uct/api/uct.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/memory/rcache.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/module.h>

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -202,8 +202,8 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
                 break;
             }
 
-            ret = ucs_posix_memalign(&address, huge_page_size, alloc_length
-                                     UCS_MEMTRACK_VAL);
+            ret = ucs_posix_memalign(&address, huge_page_size, alloc_length,
+                                     alloc_name);
             if (ret != 0) {
                 ucs_trace("failed to allocate %zu bytes using THP: %m", alloc_length);
             } else {
@@ -233,7 +233,7 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
 
             address = uct_mem_alloc_params_get_address(params);
             ret = ucs_posix_memalign(&address, UCS_SYS_CACHE_LINE_SIZE,
-                                     length UCS_MEMTRACK_VAL);
+                                     length, alloc_name);
             if (ret == 0) {
                 goto allocated_without_md;
             }
@@ -251,8 +251,7 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
             alloc_length = length;
             address      = uct_mem_alloc_params_get_address(params);
             status = ucs_mmap_alloc(&alloc_length, &address,
-                                    uct_mem_get_mmap_flags(flags)
-                                    UCS_MEMTRACK_VAL);
+                                    uct_mem_get_mmap_flags(flags), alloc_name);
             if (status== UCS_OK) {
                 goto allocated_without_md;
             }

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -13,7 +13,7 @@
 #include <uct/base/uct_log.h>
 #include <uct/base/uct_iov.inl>
 #include <ucs/profile/profile.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 #include <ucs/type/class.h>
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -13,7 +13,7 @@
 #include <limits.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <ucs/profile/profile.h>
 #include <uct/cuda/base/cuda_iface.h>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -11,7 +11,7 @@
 #include "cuda_ipc_cache.h"
 #include "cuda_ipc_iface.h"
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -14,7 +14,7 @@
 
 #include <uct/base/uct_log.h>
 #include <uct/base/uct_iov.inl>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 #include <ucs/type/class.h>
 #include <ucs/profile/profile.h>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -15,7 +15,7 @@
 #include <limits.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <ucs/profile/profile.h>
 #include <sys/types.h>

--- a/src/uct/cuda/gdr_copy/gdr_copy_ep.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_ep.c
@@ -13,7 +13,7 @@
 #include "gdr_copy_iface.h"
 
 #include <uct/base/uct_log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 #include <ucs/profile/profile.h>
 #include <ucs/type/class.h>

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -15,7 +15,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <ucs/profile/profile.h>
 #include <ucm/api/ucm.h>

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -13,7 +13,7 @@
 #include "ib_md.h"
 
 #include <ucs/arch/bitops.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/compiler.h>

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -13,7 +13,7 @@
 #include "rc_iface.h"
 
 #include <uct/ib/base/ib_verbs.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/type/class.h>

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -12,7 +12,7 @@
 #include "rc_ep.h"
 
 #include <ucs/arch/cpu.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/type/class.h>
 #include <ucs/vfs/base/vfs_obj.h>

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -16,7 +16,7 @@
 #include <uct/base/uct_md.h>
 #include <uct/base/uct_log.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <string.h>
 #include <arpa/inet.h> /* For htonl */

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -15,7 +15,7 @@
 
 #include <uct/api/uct_def.h>
 #include <uct/ib/base/ib_verbs.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/time/time.h>
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -13,7 +13,7 @@
 #include "ud_inl.h"
 
 #include <ucs/arch/cpu.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/type/class.h>
 #include <ucs/datastruct/queue.h>

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -13,7 +13,7 @@
 #include <uct/base/uct_md.h>
 #include <uct/base/uct_log.h>
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <string.h>
 #include <arpa/inet.h> /* For htonl */

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -15,7 +15,7 @@
 #include <uct/rocm/base/rocm_base.h>
 #include <uct/base/uct_log.h>
 #include <uct/base/uct_iov.inl>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <ucs/arch/cpu.h>
 

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -16,7 +16,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucm/api/ucm.h>
 #include <ucs/type/class.h>
 

--- a/src/uct/rocm/gdr/rocm_gdr_ep.c
+++ b/src/uct/rocm/gdr/rocm_gdr_ep.c
@@ -11,7 +11,7 @@
 #include "rocm_gdr_iface.h"
 
 #include <uct/base/uct_log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 
 #include <gdrapi.h>

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -15,7 +15,7 @@
 #include <limits.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 
 #include <hsa_ext_amd.h>

--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -12,7 +12,7 @@
 #include "rocm_ipc_cache.h"
 
 #include <ucs/debug/log.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -13,7 +13,7 @@
 #include <uct/base/uct_iface.h>
 #include <uct/sm/base/sm_iface.h>
 #include <ucs/arch/cpu.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/datastruct/arbiter.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -10,7 +10,7 @@
 
 #include <uct/base/uct_md.h>
 #include <ucs/config/types.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/status.h>
 
 

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -11,7 +11,7 @@
 
 #include <uct/sm/mm/base/mm_md.h>
 #include <uct/sm/mm/base/mm_iface.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/string.h>
 #include <sys/mman.h>
@@ -300,7 +300,7 @@ uct_posix_mmap(void **address_p, size_t *length_p, int flags, int fd,
 #endif
 
     result = ucs_mmap(*address_p, aligned_length, UCT_POSIX_MMAP_PROT,
-                      MAP_SHARED | flags, fd, 0 UCS_MEMTRACK_VAL);
+                      MAP_SHARED | flags, fd, 0, alloc_name);
     if (result == MAP_FAILED) {
         ucs_log(err_level,
                 "shared memory mmap(addr=%p, length=%zu, flags=%s%s, fd=%d) failed: %m",

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -10,7 +10,7 @@
 
 #include <uct/sm/mm/base/mm_md.h>
 #include <uct/sm/mm/base/mm_iface.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -14,7 +14,7 @@
 #include <uct/sm/mm/base/mm_md.h>
 #include <uct/sm/mm/base/mm_iface.h>
 #include <ucs/datastruct/khash.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/init_once.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/memory/rcache.h>

--- a/src/uct/sm/scopy/cma/cma_md.h
+++ b/src/uct/sm/scopy/cma/cma_md.h
@@ -9,7 +9,7 @@
 #define UCT_CMA_MD_H_
 
 #include <ucs/config/types.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/status.h>
 #include <uct/base/uct_md.h>
 

--- a/src/uct/sm/scopy/knem/knem_md.h
+++ b/src/uct/sm/scopy/knem/knem_md.h
@@ -9,7 +9,7 @@
 #define UCT_KNEM_MD_H_
 
 #include <ucs/config/types.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/type/status.h>
 #include <ucs/memory/rcache.h>
 #include <uct/base/uct_md.h>

--- a/test/apps/test_memtrack_limit.c
+++ b/test/apps/test_memtrack_limit.c
@@ -9,7 +9,7 @@
 #endif
 
 #include <ucp/api/ucp.h>
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/math.h>
 
 int main(int argc, char **argv)

--- a/test/gtest/ucs/test_memtrack.cc
+++ b/test/gtest/ucs/test_memtrack.cc
@@ -7,7 +7,7 @@
 #include <common/test.h>
 
 extern "C" {
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/sys.h>
 }
 
@@ -18,8 +18,6 @@ extern "C" {
 #include <fcntl.h>
 #include <limits>
 
-
-#ifdef ENABLE_MEMTRACK
 
 class test_memtrack : public ucs::test {
 protected:
@@ -230,5 +228,3 @@ UCS_TEST_F(test_memtrack, custom) {
 
     test_total(1, ALLOC_SIZE);
 }
-
-#endif

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -6,7 +6,7 @@
 
 #include <common/test.h>
 extern "C" {
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/datastruct/string_buffer.h>
 #include <ucs/datastruct/string_set.h>
 #include <ucs/sys/string.h>

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -6,7 +6,7 @@
 
 #include <common/test.h>
 extern "C" {
-#include <ucs/debug/memtrack.h>
+#include <ucs/debug/memtrack_int.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/vfs/sock/vfs_sock.h>
 }

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -48,8 +48,7 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer,
 
     buffer     = NULL;
     alloc_size = size;
-    status     = ucs_mmap_alloc(&alloc_size, &buffer, 0
-                                UCS_MEMTRACK_NAME("test_umr"));
+    status     = ucs_mmap_alloc(&alloc_size, &buffer, 0, "test_umr");
     ASSERT_UCS_OK(status);
 
     uct_mem_h memh;

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -125,8 +125,7 @@ public:
     static void* get_unused_address(size_t length)
     {
         void *address = NULL;
-        ucs_status_t status = ucs_mmap_alloc(&length, &address, 0
-                                             UCS_MEMTRACK_NAME("test_dummy"));
+        ucs_status_t status = ucs_mmap_alloc(&length, &address, 0, "test_dummy");
         ASSERT_UCS_OK(status, << "length = " << length);
         status = ucs_mmap_free(address, length);
         ASSERT_UCS_OK(status);


### PR DESCRIPTION
- routines ucs_memtrack_allocated and ucs_memtrack_releasing moved
  to public header
- added internal memtrack header
- memtrack configure option is removed, memtrack
  now is always built-in
