### PR TITLE
TOOLS/PERF: Improve help and error message

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -1614,6 +1614,38 @@ static ucs_status_t clone_params(perftest_params_t *dest,
     return UCS_OK;
 }
 
+static ucs_status_t check_params(const perftest_params_t *params)
+{
+    switch (params->super.api) {
+    case UCX_PERF_API_UCT:
+        if (!strcmp(params->super.uct.dev_name, TL_RESOURCE_NAME_NONE)) {
+            ucs_error("A device must be specified with -d flag for UCT test");
+            return UCS_ERR_INVALID_PARAM;
+        }
+        if (!strcmp(params->super.uct.tl_name, TL_RESOURCE_NAME_NONE)) {
+            ucs_error(
+                    "A transport must be specified with -x flag for UCT test");
+            return UCS_ERR_INVALID_PARAM;
+        }
+        return UCS_OK;
+    case UCX_PERF_API_UCP:
+        if (strcmp(params->super.uct.dev_name, TL_RESOURCE_NAME_NONE)) {
+            ucs_warn("-d '%s' ignored for UCP test; see NOTES section in help "
+                     "message",
+                     params->super.uct.dev_name);
+        }
+        if (strcmp(params->super.uct.tl_name, TL_RESOURCE_NAME_NONE)) {
+            ucs_warn("-x '%s' ignored for UCP test; see NOTES section in help "
+                     "message",
+                     params->super.uct.tl_name);
+        }
+        return UCS_OK;
+    default:
+        ucs_error("Invalid test case");
+        return UCS_ERR_INVALID_PARAM;
+    }
+}
+
 static ucs_status_t run_test_recurs(struct perftest_context *ctx,
                                     const perftest_params_t *parent_params,
                                     unsigned depth)
@@ -1626,34 +1658,13 @@ static ucs_status_t run_test_recurs(struct perftest_context *ctx,
 
     ucs_trace_func("depth=%u, num_files=%u", depth, ctx->num_batch_files);
 
-    switch (parent_params->super.api) {
-    case UCX_PERF_API_UCT:
-        if (!strcmp(parent_params->super.uct.dev_name, TL_RESOURCE_NAME_NONE)) {
-            ucs_error("A device must be specified with -d flag for UCT test");
-            return UCS_ERR_INVALID_PARAM;
-        }
-        if (!strcmp(parent_params->super.uct.tl_name, TL_RESOURCE_NAME_NONE)) {
-            ucs_error("A transport must be specified with -x flag for UCT test");
-            return UCS_ERR_INVALID_PARAM;
-        }
-        break;
-    case UCX_PERF_API_UCP:
-        if (strcmp(parent_params->super.uct.dev_name, TL_RESOURCE_NAME_NONE)) {
-            ucs_warn("-d '%s' ignored for UCP test; see NOTES section in help message",
-                     parent_params->super.uct.dev_name);
-        }
-        if (strcmp(parent_params->super.uct.tl_name, TL_RESOURCE_NAME_NONE)) {
-            ucs_warn("-x '%s' ignored for UCP test; see NOTES section in help message",
-                     parent_params->super.uct.tl_name);
-        }
-        break;
-    default:
-        ucs_error("Invalid test case");
-        return UCS_ERR_INVALID_PARAM;
-    }
-
     if (depth >= ctx->num_batch_files) {
         print_test_name(ctx);
+        status = check_params(parent_params);
+        if (status != UCS_OK) {
+            return status;
+        }
+
         return ucx_perf_run(&parent_params->super, &result);
     }
 


### PR DESCRIPTION
# Why
Improve ucx_perftest usability

# How
- Print if transport or device are missing for UCT test
- Remove "iov" data layout from UCT tests help message
