### PR TITLE
UCP/CORE: Reduce KA interval to detect failures earlier

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -319,8 +319,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_config_t, ctx.proto_enable), UCS_CONFIG_TYPE_BOOL},
 
-  /* TODO: set for keepalive more reasonable values */
-  {"KEEPALIVE_INTERVAL", "60s",
+  {"KEEPALIVE_INTERVAL", "20s",
    "Time interval between keepalive rounds.",
    ucs_offsetof(ucp_config_t, ctx.keepalive_interval),
    UCS_CONFIG_TYPE_TIME_UNITS},


### PR DESCRIPTION
## What

Reduce KA interval to detect failures earlier.

## Why ?

To detect peer failures earlier and no impact on normal flow.

## How ?

1. "60s" -> "20s".
2. Remove the comment.