### PR TITLE
UCP/WORKER: fix pending discard lane on failure

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -642,3 +642,13 @@ ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
 
     return UCS_ERR_MESSAGE_TRUNCATED;
 }
+
+void ucp_request_purge_enqueue_cb(uct_pending_req_t *self, void *arg)
+{
+    ucp_request_t *req      = ucs_container_of(self, ucp_request_t, send.uct);
+    ucs_queue_head_t *queue = arg;
+
+    ucs_trace_req("ep %p: extracted request %p from pending queue",
+                  req->send.ep, req);
+    ucs_queue_push(queue, (ucs_queue_elem_t*)&req->send.uct.priv);
+}

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -456,4 +456,6 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status);
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);
 
+void ucp_request_purge_enqueue_cb(uct_pending_req_t *self, void *arg);
+
 #endif

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -153,6 +153,4 @@ ucp_wireup_connect_local(ucp_ep_h ep,
 
 uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane);
 
-void ucp_wireup_pending_purge_cb(uct_pending_req_t *self, void *arg);
-
 #endif

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -316,7 +316,7 @@ ucp_wireup_cm_ep_cleanup(ucp_ep_t *ucp_ep, ucs_queue_head_t *queue)
         /* Transfer the pending queues content from the previosly configured
          * UCP EP to a temporary queue for futher replaying */
         uct_ep_pending_purge(ucp_ep->uct_eps[lane_idx],
-                             ucp_wireup_pending_purge_cb, &queue);
+                             ucp_request_purge_enqueue_cb, &queue);
 
         if (ucp_ep_config(ucp_ep)->p2p_lanes & UCS_BIT(lane_idx)) {
             uct_ep = ucp_wireup_extract_lane(ucp_ep, lane_idx);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -484,7 +484,7 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_wireup_ep_t)
          * but it will make sure that no completions will be received if some
          * error was detected */
         ucp_wireup_ep_discard_aux_ep(self, UCT_FLUSH_FLAG_CANCEL,
-                                     ucp_wireup_pending_purge_cb,
+                                     ucp_request_purge_enqueue_cb,
                                      &tmp_pending_queue);
         self->aux_ep = NULL;
         ucp_wireup_replay_pending_requests(ucp_ep, &tmp_pending_queue);


### PR DESCRIPTION
## What
fix pending discard lane on failure

## Why ?
bug fix

## How ?
fast forward pending queue requests via temporary queue since uct_arbiter_t does not support recursive calls
