### PR TITLE
UCS/VFS: RW files support in VFS. 

### DIFF
--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -25,6 +25,7 @@
 typedef enum {
     UCS_VFS_NODE_TYPE_DIR,
     UCS_VFS_NODE_TYPE_RO_FILE,
+    UCS_VFS_NODE_TYPE_RW_FILE,
     UCS_VFS_NODE_TYPE_SUBDIR,
     UCS_VFS_NODE_TYPE_SYM_LINK,
     UCS_VFS_NODE_TYPE_LAST
@@ -52,23 +53,25 @@ struct ucs_vfs_node {
     /* List item to represent the node in parent's list of children. */
     ucs_list_link_t     list;
     union {
-        /* Callback method to show content of the file. */
-        ucs_vfs_file_show_cb_t text_cb;
+        /* Callback method to read content of the file. */
+        ucs_vfs_file_read_cb_t read_cb;
         /* Callback method to update content of the directory. */
         ucs_vfs_refresh_cb_t   refresh_cb;
         /* Pointer to the target node of symbolic link. */
         ucs_vfs_node_t         *target;
     };
+    /* Callback method to write data to the file. */
+    ucs_vfs_file_write_cb_t write_cb;
     /* Pointer to an optional argument passed to the text_cb. */
-    void                *arg_ptr;
+    void                    *arg_ptr;
     /* Type of value passed to ucs_vfs_show_primitive referenced by arg_ptr. */
-    uint64_t            arg_u64;
+    uint64_t                arg_u64;
     /* List of symbolic links targeting to the node. */
-    ucs_list_link_t     links;
+    ucs_list_link_t         links;
     /* List item to represent the node in target node's list of links. */
-    ucs_list_link_t     link_list;
+    ucs_list_link_t         link_list;
     /* Path to the node in VFS. */
-    char                path[0];
+    char                    path[0];
 };
 
 KHASH_MAP_INIT_STR(vfs_path, ucs_vfs_node_t*);
@@ -136,7 +139,8 @@ static void ucs_vfs_node_init(ucs_vfs_node_t *node, ucs_vfs_node_type_t type,
     node->flags      = 0;
     node->obj        = obj;
     node->parent     = parent_node;
-    node->text_cb    = NULL;
+    node->read_cb    = NULL;
+    node->write_cb   = NULL;
     node->refresh_cb = NULL;
     node->arg_ptr    = NULL;
     node->arg_u64    = 0;
@@ -374,22 +378,59 @@ static void ucs_vfs_refresh_dir(ucs_vfs_node_t *node)
 }
 
 /* must be called with lock held */
-static void
-ucs_vfs_read_ro_file(ucs_vfs_node_t *node, ucs_string_buffer_t *strb)
+static ucs_vfs_node_t *ucs_vfs_get_parent_dir(ucs_vfs_node_t *node)
 {
     ucs_vfs_node_t *parent_node = node->parent;
-
-    ucs_assert(ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RO_FILE) == 1);
 
     while (ucs_vfs_check_node(parent_node, UCS_VFS_NODE_TYPE_SUBDIR)) {
         parent_node = parent_node->parent;
     }
 
+    return parent_node;
+}
+
+/* must be called with lock held */
+int ucs_vfs_check_node_file(ucs_vfs_node_t *node)
+{
+    return ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RO_FILE) ||
+           ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RW_FILE);
+}
+
+/* must be called with lock held */
+static void ucs_vfs_read_file(ucs_vfs_node_t *node, ucs_string_buffer_t *strb)
+{
+    ucs_vfs_node_t *parent_node;
+
+    ucs_assert(ucs_vfs_check_node_file(node));
+
+    parent_node = ucs_vfs_get_parent_dir(node);
+
     ucs_spin_unlock(&ucs_vfs_obj_context.lock);
 
-    node->text_cb(parent_node->obj, strb, node->arg_ptr, node->arg_u64);
+    node->read_cb(parent_node->obj, strb, node->arg_ptr, node->arg_u64);
 
     ucs_spin_lock(&ucs_vfs_obj_context.lock);
+}
+
+/* must be called with lock held */
+static ucs_status_t
+ucs_vfs_write_file(ucs_vfs_node_t *node, const char *buffer, size_t size)
+{
+    ucs_vfs_node_t *parent_node;
+    ucs_status_t status;
+
+    ucs_assert(ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RW_FILE));
+
+    parent_node = ucs_vfs_get_parent_dir(node);
+
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    status = node->write_cb(parent_node->obj, buffer, size, node->arg_ptr,
+                            node->arg_u64);
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    return status;
 }
 
 /* must be called with lock held */
@@ -440,7 +481,7 @@ ucs_vfs_obj_add_dir(void *parent_obj, void *obj, const char *rel_path, ...)
     return status;
 }
 
-ucs_status_t ucs_vfs_obj_add_ro_file(void *obj, ucs_vfs_file_show_cb_t text_cb,
+ucs_status_t ucs_vfs_obj_add_ro_file(void *obj, ucs_vfs_file_read_cb_t read_cb,
                                      void *arg_ptr, uint64_t arg_u64,
                                      const char *rel_path, ...)
 {
@@ -456,9 +497,37 @@ ucs_status_t ucs_vfs_obj_add_ro_file(void *obj, ucs_vfs_file_show_cb_t text_cb,
     va_end(ap);
 
     if (status == UCS_OK) {
-        node->text_cb = text_cb;
+        node->read_cb = read_cb;
         node->arg_ptr = arg_ptr;
         node->arg_u64 = arg_u64;
+    }
+
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    return status;
+}
+
+ucs_status_t ucs_vfs_obj_add_rw_file(void *obj, ucs_vfs_file_read_cb_t read_cb,
+                                     ucs_vfs_file_write_cb_t write_cb,
+                                     void *arg_ptr, uint64_t arg_u64,
+                                     const char *rel_path, ...)
+{
+    ucs_vfs_node_t *node;
+    va_list ap;
+    ucs_status_t status;
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    va_start(ap, rel_path);
+    status = ucs_vfs_node_add(obj, UCS_VFS_NODE_TYPE_RW_FILE, NULL, rel_path,
+                              ap, &node);
+    va_end(ap);
+
+    if (status == UCS_OK) {
+        node->read_cb  = read_cb;
+        node->write_cb = write_cb;
+        node->arg_ptr  = arg_ptr;
+        node->arg_u64  = arg_u64;
     }
 
     ucs_spin_unlock(&ucs_vfs_obj_context.lock);
@@ -545,11 +614,16 @@ ucs_status_t ucs_vfs_path_get_info(const char *path, ucs_vfs_path_info_t *info)
 
     switch (node->type) {
     case UCS_VFS_NODE_TYPE_RO_FILE:
+    case UCS_VFS_NODE_TYPE_RW_FILE:
         ucs_string_buffer_init(&strb);
-        ucs_vfs_read_ro_file(node, &strb);
-        info->mode = S_IFREG | S_IRUSR;
+        ucs_vfs_read_file(node, &strb);
         info->size = ucs_string_buffer_length(&strb);
         ucs_string_buffer_cleanup(&strb);
+
+        info->mode = S_IFREG | S_IRUSR;
+        if (node->type == UCS_VFS_NODE_TYPE_RW_FILE) {
+            info->mode |= S_IWUSR;
+        }
         status = UCS_OK;
         break;
     case UCS_VFS_NODE_TYPE_DIR:
@@ -588,17 +662,39 @@ ucs_status_t ucs_vfs_path_read_file(const char *path, ucs_string_buffer_t *strb)
     ucs_spin_lock(&ucs_vfs_obj_context.lock);
 
     node = ucs_vfs_node_find_by_path(path);
-    if (!ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RO_FILE)) {
+    if (!ucs_vfs_check_node_file(node)) {
         status = UCS_ERR_NO_ELEM;
         goto out_unlock;
     }
 
     ucs_vfs_node_increase_refcount(node);
 
-    ucs_vfs_read_ro_file(node, strb);
+    ucs_vfs_read_file(node, strb);
     status = UCS_OK;
 
     ucs_vfs_node_decrease_refcount(node);
+
+out_unlock:
+    ucs_spin_unlock(&ucs_vfs_obj_context.lock);
+
+    return status;
+}
+
+ucs_status_t
+ucs_vfs_path_write_file(const char *path, const char *buffer, size_t size)
+{
+    ucs_vfs_node_t *node;
+    ucs_status_t status;
+
+    ucs_spin_lock(&ucs_vfs_obj_context.lock);
+
+    node = ucs_vfs_node_find_by_path(path);
+    if (!ucs_vfs_check_node(node, UCS_VFS_NODE_TYPE_RW_FILE)) {
+        status = UCS_ERR_NO_ELEM;
+        goto out_unlock;
+    }
+
+    status = ucs_vfs_write_file(node, buffer, size);
 
 out_unlock:
     ucs_spin_unlock(&ucs_vfs_obj_context.lock);

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -7,6 +7,7 @@
 #include <common/test.h>
 extern "C" {
 #include <ucs/debug/memtrack_int.h>
+#include <ucs/vfs/base/vfs_cb.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/vfs/sock/vfs_sock.h>
 }
@@ -142,6 +143,15 @@ public:
         ucs_vfs_obj_add_ro_file(&obj, test_vfs_obj::file_show_cb, NULL, 0,
                                 "info");
         return &obj;
+    }
+
+    static ucs_status_t file_write_cb(void *obj, const char *buffer,
+                                      size_t size, void *arg_ptr,
+                                      uint64_t arg_u64)
+    {
+        int *arg = (int*)arg_ptr;
+        *arg     = atoi(buffer);
+        return UCS_OK;
     }
 };
 
@@ -302,4 +312,58 @@ UCS_MT_TEST_F(test_vfs_obj, add_sym_link, 4)
 
     barrier();
     ucs_vfs_obj_remove(&target);
+}
+
+UCS_TEST_F(test_vfs_obj, add_rw_check_ret) {
+    int obj = 0, no_obj;
+
+    EXPECT_UCS_OK(ucs_vfs_obj_add_dir(NULL, &obj, "obj"));
+
+    EXPECT_UCS_OK(ucs_vfs_obj_add_rw_file(&obj, ucs_vfs_show_primitive,
+                                          test_vfs_obj::file_write_cb, &obj,
+                                          UCS_VFS_TYPE_INT, "info"));
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS,
+              ucs_vfs_obj_add_rw_file(&obj, ucs_vfs_show_primitive,
+                                      test_vfs_obj::file_write_cb, &obj,
+                                      UCS_VFS_TYPE_INT, "info"));
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              ucs_vfs_obj_add_rw_file(&no_obj, ucs_vfs_show_primitive,
+                                      test_vfs_obj::file_write_cb, &obj,
+                                      UCS_VFS_TYPE_INT, "info"));
+
+    ucs_vfs_obj_remove(&obj);
+}
+
+UCS_MT_TEST_F(test_vfs_obj, rw_file, 4)
+{
+    static int obj = 0;
+    ucs_vfs_obj_add_dir(NULL, &obj, "obj");
+    ucs_vfs_obj_add_rw_file(&obj, ucs_vfs_show_primitive,
+                            test_vfs_obj::file_write_cb, &obj, UCS_VFS_TYPE_INT,
+                            "info");
+
+    ucs_vfs_path_info_t path_info;
+    EXPECT_UCS_OK(ucs_vfs_path_get_info("/obj/info", &path_info));
+    EXPECT_EQ(2, path_info.size);
+    EXPECT_TRUE(path_info.mode & S_IWUSR);
+
+    barrier();
+
+    const char new_value[] = "777\n";
+    EXPECT_UCS_OK(
+            ucs_vfs_path_write_file("/obj/info", new_value, sizeof(new_value)));
+    EXPECT_EQ(UCS_ERR_NO_ELEM,
+              ucs_vfs_path_write_file("/obj", new_value, sizeof(new_value)));
+
+    barrier();
+
+    ucs_string_buffer_t strb;
+    ucs_string_buffer_init(&strb);
+    EXPECT_UCS_OK(ucs_vfs_path_read_file("/obj/info", &strb));
+    EXPECT_STREQ(new_value, ucs_string_buffer_cstr(&strb));
+    ucs_string_buffer_cleanup(&strb);
+
+    barrier();
+
+    ucs_vfs_obj_remove(&obj);
 }


### PR DESCRIPTION
## What
Added method to add a read-write file to VFS.
Added method to write to the read-write file.
Implemented write fs operation.
Added gtests for the feature.

## Why ?
RW files in VFS allows to configure the library via VFS files, e.g. change log level.
