### PR TITLE
UCT_V2/API: add system device attrbutes for perf estimate query

### DIFF
--- a/src/ucs/sys/topo.c
+++ b/src/ucs/sys/topo.c
@@ -107,6 +107,17 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
     return UCS_OK;
 }
 
+ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
+                                        ucs_sys_bus_id_t *bus_id)
+{
+    if (sys_dev < ucs_topo_ctx.sys_dev_to_bus_lookup.count) {
+        *bus_id = ucs_topo_ctx.sys_dev_to_bus_lookup.bus_arr[sys_dev];
+        return UCS_OK;
+    } else {
+        return UCS_ERR_NO_ELEM;
+    }
+}
+
 static void
 ucs_topo_get_bus_path(const ucs_sys_bus_id_t *bus_id, char *path, size_t max)
 {

--- a/src/ucs/sys/topo.h
+++ b/src/ucs/sys/topo.h
@@ -66,6 +66,18 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 
 
 /**
+ * Find pci bus id of the given system device.
+ *
+ * @param [in]  sys_dev system device index.
+ * @param [out] bus_id  pointer to bus id to be populated.
+ *
+ * @return UCS_OK or error in case system device or its bus id cannot be found.
+ */
+ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
+                                        ucs_sys_bus_id_t *bus_id);
+
+
+/**
  * Find the distance between two system devices (in terms of latency,
  * bandwidth, hops, etc).
  *

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -11,6 +11,7 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/memory/memory_type.h>
 #include <uct/api/uct.h>
+#include <ucs/sys/topo.h>
 
 #include <stdint.h>
 
@@ -68,11 +69,17 @@ enum uct_perf_attr_field {
     /** Enables @ref uct_perf_attr_t::remote_memory_type */
     UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE = UCS_BIT(2),
 
+    /** Enables @ref uct_perf_attr_t::local_sys_device */
+    UCT_PERF_ATTR_FIELD_LOCAL_SYS_DEVICE   = UCS_BIT(3),
+
+    /** Enables @ref uct_perf_attr_t::remote_sys_device */
+    UCT_PERF_ATTR_FIELD_REMOTE_SYS_DEIVCE  = UCS_BIT(4),
+
     /** Enables @ref uct_perf_attr_t::overhead */
-    UCT_PERF_ATTR_FIELD_OVERHEAD           = UCS_BIT(3),
+    UCT_PERF_ATTR_FIELD_OVERHEAD           = UCS_BIT(5),
 
     /** Enables @ref uct_perf_attr_t::bandwidth */
-    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(4)
+    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(6)
 };
 
 
@@ -108,6 +115,20 @@ typedef struct {
      * This field must be initialized by the caller.
      */
     ucs_memory_type_t   remote_memory_type;
+
+    /**
+     * System device where the local memory type resides.
+     * Can be UCS_SYS_DEVICE_ID_UNKNOWN.
+     * This field must be initialized by the caller.
+     */
+    ucs_sys_device_t    local_sys_device;
+
+    /**
+     * System device where the remote memory type resides.
+     * Can be UCS_SYS_DEVICE_ID_UNKNOWN and be the same as local system device.
+     * This field must be initialized by the caller.
+     */
+    ucs_sys_device_t    remote_sys_device;
 
     /**
      * Message overhead time, in seconds. This field is set by the UCT layer.

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -17,6 +17,8 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     ucs_sys_device_t dev1;
     ucs_sys_device_t dev2;
     ucs_sys_bus_id_t dummy_bus_id;
+    ucs_sys_bus_id_t bus_id1;
+    ucs_sys_bus_id_t bus_id2;
 
     dummy_bus_id.domain   = 0xffff;
     dummy_bus_id.bus      = 0xff;
@@ -27,12 +29,28 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     ASSERT_UCS_OK(status);
     EXPECT_LT(dev1, UCS_SYS_DEVICE_ID_MAX);
 
+    status = ucs_topo_get_device_bus_id(dev1, &bus_id1);
+    ASSERT_UCS_OK(status);
+
+    EXPECT_EQ(bus_id1.domain, dummy_bus_id.domain);
+    EXPECT_EQ(bus_id1.bus, dummy_bus_id.bus);
+    EXPECT_EQ(bus_id1.slot, dummy_bus_id.slot);
+    EXPECT_EQ(bus_id1.function, dummy_bus_id.function);
+
     dummy_bus_id.function = 2;
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev2);
     ASSERT_UCS_OK(status);
     EXPECT_EQ((unsigned)dev1 + 1, dev2);
     EXPECT_LT(dev2, UCS_SYS_DEVICE_ID_MAX);
+
+    status = ucs_topo_get_device_bus_id(dev2, &bus_id2);
+    ASSERT_UCS_OK(status);
+
+    EXPECT_EQ(bus_id2.domain, dummy_bus_id.domain);
+    EXPECT_EQ(bus_id2.bus, dummy_bus_id.bus);
+    EXPECT_EQ(bus_id2.slot, dummy_bus_id.slot);
+    EXPECT_EQ(bus_id2.function, dummy_bus_id.function);
 
     EXPECT_GE(ucs_topo_num_devices(), 2);
 }

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -6,6 +6,7 @@
 
 extern "C" {
 #include <uct/api/uct.h>
+#include <ucs/sys/topo.h>
 #include <uct/api/v2/uct_v2.h>
 }
 
@@ -26,11 +27,15 @@ UCS_TEST_P(test_uct_query, query_perf)
     perf_attr.field_mask         = UCT_PERF_ATTR_FIELD_OPERATION |
                                    UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE |
                                    UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE |
+                                   UCT_PERF_ATTR_FIELD_LOCAL_SYS_DEVICE |
+                                   UCT_PERF_ATTR_FIELD_REMOTE_SYS_DEIVCE |
                                    UCT_PERF_ATTR_FIELD_OVERHEAD |
                                    UCT_PERF_ATTR_FIELD_BANDWIDTH;
     perf_attr.operation          = UCT_OP_AM_SHORT;
     perf_attr.local_memory_type  = UCS_MEMORY_TYPE_HOST;
     perf_attr.remote_memory_type = UCS_MEMORY_TYPE_HOST;
+    perf_attr.local_sys_device   = UCS_SYS_DEVICE_ID_UNKNOWN;
+    perf_attr.remote_sys_device  = UCS_SYS_DEVICE_ID_UNKNOWN;
     status                       = uct_iface_estimate_perf(sender().iface(),
                                                            &perf_attr);
     EXPECT_EQ(status, UCS_OK);


### PR DESCRIPTION
## What/Why?
Add system device ids for remote and local memory types as performance is determined by location and memory type.