### PR TITLE
DC/MLX5/OPTIMIZATION: use bitmap to release detached dci's

### DIFF
--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -38,11 +38,22 @@ typedef uint64_t ucs_bitmap_word_t;
 /**
  * Get the number of words in a given bitmap
  *
- * @param _bitmap Words number in this bitmap
+ * @param _bitmap Bitmap variable to get words number
  *
  * @return Number of words
  */
 #define _UCS_BITMAP_NUM_WORDS(_bitmap) ucs_static_array_size((_bitmap).bits)
+
+
+/**
+ * Get the number of bits in a given bitmap
+ *
+ * @param _bitmap Bitmap variable to get bits number
+ *
+ * @return Number of bits
+ */
+#define UCS_BITMAP_NUM_BITS(_bitmap) \
+    (_UCS_BITMAP_NUM_WORDS(_bitmap) * UCS_BITMAP_BITS_IN_WORD)
 
 
 /**

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1339,6 +1339,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
                          uct_dc_mlx5_iface_dci_do_rand_pending_tx :
                          uct_dc_mlx5_iface_dci_do_dcs_pending_tx;
 
+    UCS_BITMAP_CLEAR(&self->tx.dci_release_bitmap);
+
     if (ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_DEVX_DCI |
                                       UCT_IB_MLX5_MD_FLAG_CQE_V1)) {
         self->flags           |= UCT_DC_MLX5_IFACE_FLAG_UIDX;

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -14,6 +14,7 @@
 #include <uct/ib/ud/base/ud_iface_common.h>
 #include <uct/ib/ud/accel/ud_mlx5_common.h>
 #include <ucs/debug/assert.h>
+#include <ucs/datastruct/bitmap.h>
 
 
 /*
@@ -237,6 +238,8 @@ struct uct_dc_mlx5_iface {
         ucs_arbiter_callback_t    pend_cb;
 
         uct_worker_cb_id_t        dci_release_prog_id;
+
+        ucs_bitmap_t(128)         dci_release_bitmap;
     } tx;
 
     struct {


### PR DESCRIPTION
- use ucs_bitmap to store set of dci's to release instead of check every DCI
