### PR TITLE
AZP/RELEASE: Fix github release pipeline conditions

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -1,6 +1,5 @@
 jobs:
   - job: distro_release
-    condition: eq(stageDependencies.Check_Commit.Check.outputs['Commit.Launch'], 'Yes')
     displayName: distro
     variables:
       ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
@@ -101,8 +100,8 @@ jobs:
           AZ_ARTIFACT_NAME: $(artifact_name)
 
       - task: GithubRelease@0
-        condition: eq(variables['Build.Reason'], 'ResourceTrigger')
-        displayName: Upload artifacts to draft release
+        condition: eq(variables['Build.Reason'], 'IndividualCI')
+        displayName: Upload artifacts
         inputs:
           githubConnection: release
           repositoryName: openucx/ucx

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -132,17 +132,26 @@ try_load_cuda_env() {
 }
 
 
-check_commit_message() {
-    git_id=$1
-    title_mask=$2
-    build_reason=$3
-    echo "Get commit message target $git_id"
-    title=`git log -1 --format="%s" $git_id`
+check_release_build() {
+    build_reason=$1
+    build_sourceversion=$2
 
-    if [[ ( "$build_reason" == "IndividualCI" ) || ( "$title" == "$title_mask"* && "$build_reason" == "PullRequest" ) ]]
+
+    if [ "${build_reason}" == "IndividualCI" ] || \
+       [ "${build_reason}" == "ResourceTrigger" ]
     then
-        echo "##vso[task.setvariable variable=Launch;isOutput=true]Yes"
-    else
-        echo "##vso[task.setvariable variable=Launch;isOutput=true]No"
+        launch=True
+    elif [ "${build_reason}" == "PullRequest" ]
+    then
+        launch=False
+        # In case of pull request, HEAD^ is the branch commit we merge with
+        range="$(git rev-parse HEAD^)..${build_sourceversion}"
+        for sha1 in `git log $range --format="%h"`
+        do
+            title=`git log -1 --format="%s" $sha1`
+            [[ "$title" == "$title_mask"* ]] && launch=True
+        done
     fi
+
+    echo "##vso[task.setvariable variable=Launch;isOutput=true]${launch}"
 }

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -41,27 +41,28 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5.0-cuda11.2:2
 
 stages:
-  - stage: Check_Commit
+  - stage: Prepare
     jobs:
-      - job: Check
+      - job: CheckRelease
         steps:
           - checkout: self
+            fetchDepth: 100
             clean: true
 
           - bash: |
               source ./buildlib/az-helpers.sh
               set -x
-              pr_commit=$(system.pullRequest.sourceCommitId)
-              commit_id=${pr_commit:-$(Build.SourceVersion)}
-              set -eE
-              check_commit_message ${commit_id} "AZP/RELEASE: " $(Build.Reason)
-            name: Commit
+              check_release_build $(Build.Reason) $(Build.SourceVersion)
+            name: Result
+            displayName: Check build condition
+
   # Create an empty draft to avoid race condition in distro releases
   - stage: GitHubDraft
-    dependsOn: Check_Commit
+    condition: eq(dependencies.Prepare.outputs['CheckRelease.Result.Launch'], 'True')
+    dependsOn: Prepare
     jobs:
       - job: DraftRelease
-        condition: eq(stageDependencies.Check_Commit.Check.outputs['Commit.Launch'], 'Yes')
+        displayName: Create draft release
         container: centos7_cuda11_2
         pool:
           name: MLNX
@@ -100,15 +101,10 @@ stages:
               ./ucx-*.tar.gz
               ./rpm-dist/ucx-*.src.rpm
 
-  - stage: Release
-    dependsOn: Check_Commit
-    variables:
-      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-        TARGET: publish-release
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        TARGET: package
+  - stage: Build
+    displayName: Build binary packages
+    dependsOn: Prepare
+    condition: eq(dependencies.Prepare.outputs['CheckRelease.Result.Launch'], 'True')
     jobs:
       - template: az-distro-release.yml
       - template: jucx/jucx-publish.yml
-        parameters:
-          target: $(TARGET)

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -25,6 +25,4 @@ stages:
     dependsOn: Check_Commit
     jobs:
       - template: jucx/jucx-publish.yml
-        parameters:
-          target: publish-snapshot
 

--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -1,32 +1,42 @@
 parameters:
-  target: publish-snapshot
   temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/tmp-settings.xml
   gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg
 
 jobs:
   - job: jucx_release
-    condition: eq(stageDependencies.Check_Commit.Check.outputs['Commit.Launch'], 'Yes')
-    # we need to use lowest version for compatible
-    container: centos7_cuda10_1
+
     pool:
       name: MLNX
       demands:
-      - ucx_docker -equals yes
+        - harbor_registry -equals yes
+
+    # we need to use lowest version for compatible
+    container: centos7_cuda10_1
+
+    variables:
+      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+        target: publish-release
+      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        target: package
+      ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
+        target: publish-snapshot
 
     steps:
       - checkout: self
         clean: true
         fetchDepth: 100
+        path: "we/need/to/go/deeper"
+        # ^workaround agent issue with container in root path
 
       - bash: |
-          set -eE
+          set -eEx
           gcc --version
           ./autogen.sh
           ./contrib/configure-release --with-java
         displayName: Configure
 
       - bash: |
-          set -eE
+          set -eEx
           make -s -j`nproc`
         displayName: Build ucx
 
@@ -63,7 +73,7 @@ jobs:
           # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
           # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
           MAVEN_VERSION=${TAG:1}
-          make -C bindings/java/src/main/native/ ${{ parameters.target }} \
+          make -C bindings/java/src/main/native/ ${{ variables.target }} \
               ARGS="--settings ${{ parameters.temp_cfg }}" JUCX_VERSION=${MAVEN_VERSION}
         displayName: Publish JUCX jar to maven central
         env:


### PR DESCRIPTION
## What
Fix condition checking for release pipeline

## Why
- Fix that artifacts are not uploaded for tag trigger
- Fix jucx publish

## How
Build.Reason| Trigger reason | Build packages |  Upload release artifacts| JUcx mode
-- | -- | -- | -- | ---
PullRequest | PR with `"AZP/RELEASE"*` commit title | Yes | No | Build only
PullRequest | PR without `"AZP/RELEASE"*` commit title | No | No | Skip
ResourceTrigger | Merge to master/release branch | Yes | No | Snapshot
IndividualCI | New tag matching `v*` pattern | Yes | Yes | Release

- Move conditions to upper layer script (az-pipelines-release.yml)
- Use variables instead of parameters for jucx-publish.yml
- Change container path in jucx pipeline to workaround docker run error