### PR TITLE
UCP/RNDV: Don't send ATP on PUT failure

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -330,15 +330,17 @@ static void ucp_rndv_complete_rma_put_zcopy(ucp_request_t *sreq, int is_frag_put
     } else {
         ucp_rkey_destroy(sreq->send.rndv.rkey);
 
-        atp_req = ucp_request_get(sreq->send.ep->worker);
-        if (ucs_unlikely(atp_req == NULL)) {
-            ucs_fatal("failed to allocate request for sending ATP");
-        }
+        if (status == UCS_OK) {
+            atp_req = ucp_request_get(sreq->send.ep->worker);
+            if (ucs_unlikely(atp_req == NULL)) {
+                ucs_fatal("failed to allocate request for sending ATP");
+            }
 
-        atp_req->send.ep = sreq->send.ep;
-        atp_req->flags   = 0;
-        ucp_rndv_req_send_ack(atp_req, sreq, sreq->send.rndv.remote_req_id,
-                              status, UCP_AM_ID_RNDV_ATP, "send_atp");
+            atp_req->send.ep = sreq->send.ep;
+            atp_req->flags   = 0;
+            ucp_rndv_req_send_ack(atp_req, sreq, sreq->send.rndv.remote_req_id,
+                                  status, UCP_AM_ID_RNDV_ATP, "send_atp");
+        }
     }
 
     ucp_request_send_buffer_dereg(sreq);


### PR DESCRIPTION
## What

Don't send ATP on PUT Zcopy failure.

## Why ?

Fixes:
```
[jazz28:20338:0:20338]   rc_mlx5.inl:456  Assertion `!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED)' failed

/labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl: [ uct_rc_mlx5_common_post_send() ]
      ...
      453     if (opcode != MLX5_OPCODE_NOP) {
      454         /* If FAILED, allow only NOP sends to be posted (used by endpoint
      455          * flush operations) */
==>   456         ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
      457     }
      458
      459     ctrl = txwq->curr;

==== backtrace (tid:  20338) ====
 0 0x00000000000e4521 uct_rc_mlx5_common_post_send()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:456
 1 0x00000000000e4521 uct_rc_mlx5_txqp_inline_post()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:616
 2 0x00000000000e4521 uct_dc_mlx5_ep_am_short_inline()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:248
 3 0x00000000000e4521 uct_dc_mlx5_ep_am_short()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:299
 4 0x0000000000065990 uct_ep_am_short()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2795
 5 0x0000000000065bfb ucp_proto_progress_am_single()  /labhome/dmitrygla/work_auto/ucx/src/ucp/proto/proto_am.c:81
 6 0x00000000000a92fc ucp_request_try_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:301
 7 0x00000000000a92fc ucp_request_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:326
 8 0x00000000000a92fc ucp_rndv_req_send_ack()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:289
 9 0x00000000000aa3e0 ucp_rndv_complete_rma_put_zcopy()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:340
10 0x00000000000adb2a ucp_rndv_put_completion_inner()  /labhome/dmitrygla/work_auto/ucx/src/ucp/rndv/rndv.c:588
11 0x0000000000035fd8 uct_invoke_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:791
12 0x000000000012c0d8 uct_dc_mlx5_ep_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:1485
13 0x0000000000151334 uct_dc_mlx5_dci_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1183
14 0x0000000000151552 uct_dc_mlx5_iface_handle_failure()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1200
15 0x000000000002ba4f uct_ib_mlx5_check_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.c:361
16 0x0000000000143c55 uct_ib_mlx5_poll_cq()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/mlx5/ib_mlx5.inl:81
17 0x0000000000143c55 uct_dc_mlx5_poll_tx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:229
18 0x0000000000143c55 uct_dc_mlx5_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:271
19 0x0000000000143c55 uct_dc_mlx5_iface_progress_ll()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:281
20 0x00000000000532f5 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
21 0x000000000005f85a uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
22 0x0000000000403cdc UcxContext::progress()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:204
23 0x0000000000410702 DemoServer::run()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:929
24 0x000000000040dcff do_server()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2384
25 0x000000000040e29c main()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2449
26 0x00000000000223d5 __libc_start_main()  ???:0
27 0x0000000000402e89 _start()  ???:0
=================================
```

## How ?

Send ATP only if PUT Zcopy completed with `UCS_OK` status, the same as we do in GET Zcopy.