### PR TITLE
UCS/CONFIG: Search for configuration in multiple paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ AC_DEFINE_UNQUOTED([UCX_CONFIGURE_FLAGS], ["$config_flags"], [UCX configure flag
 #
 # Define path of ucx.conf configuration file
 #
-AC_SUBST([ucx_conf_dir], [${sysconfdir}/ucx])
+AC_SUBST([ucx_config_dir], [${sysconfdir}/ucx])
 
 #
 # Provide the functionality of AS_VAR_APPEND if Autoconf does not have it.
@@ -402,7 +402,7 @@ AC_MSG_NOTICE([Building documents only])
 [
 AC_MSG_NOTICE([UCX build configuration:])
 AC_MSG_NOTICE([        Build prefix:   ${prefix}])
-AC_MSG_NOTICE([   Configuration dir:   ${ucx_conf_dir}])
+AC_MSG_NOTICE([   Configuration dir:   ${ucx_config_dir}])
 AC_MSG_NOTICE([  Preprocessor flags:   ${BASE_CPPFLAGS}])
 AC_MSG_NOTICE([          C compiler:   ${CC} ${BASE_CFLAGS}])
 AC_MSG_NOTICE([        C++ compiler:   ${CXX} ${BASE_CXXFLAGS}])

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -12,7 +12,7 @@ lib_LTLIBRARIES     = libucs.la
 bin_PROGRAMS        =
 
 libucs_la_CPPFLAGS = $(BASE_CPPFLAGS) -DUCX_MODULE_DIR=\"$(moduledir)\" \
-                     -DUCX_CONF_DIR=\"$(ucx_conf_dir)\"
+                     -DUCX_CONFIG_DIR=\"$(ucx_config_dir)\"
 libucs_la_CFLAGS   = $(BASE_CFLAGS)
 libucs_la_LDFLAGS  = -ldl $(NUMA_LIBS) -version-info $(SOVERSION)
 libucs_ladir       = $(includedir)/ucs
@@ -106,6 +106,7 @@ noinst_HEADERS = \
 	stats/stats.h \
 	sys/checker.h \
 	sys/compiler.h \
+	sys/lib.h \
 	sys/module.h \
 	sys/sys.h \
 	sys/iovec.h \
@@ -168,6 +169,7 @@ libucs_la_SOURCES = \
 	sys/string.c \
 	sys/sys.c \
 	sys/iovec.c \
+	sys/lib.c \
 	sys/sock.c \
 	sys/topo.c \
 	sys/stubs.c \

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -18,7 +18,7 @@
 
 #define UCS_DEFAULT_ENV_PREFIX "UCX_"
 #define UCS_CONFIG_ARRAY_MAX   128
-#define UCX_CONF_FILE          UCX_CONF_DIR "/ucx.conf"
+#define UCX_CONFIG_FILE_NAME   "ucx.conf"
 
 BEGIN_C_DECLS
 
@@ -377,10 +377,19 @@ ucs_config_parser_set_default_values(void *opts, ucs_config_field_t *fields);
 /**
  * Parse INI configuration file with UCX options.
  * 
- * @param path     Path file at this path.
- * @param override Whether to override, if another file was previously parsed
+ * @param dir_path  Parse file at this location.
+ * @param file_name Parse this file.
+ * @param override  Whether to override, if another file was previously parsed
  */
-ucs_status_t ucs_config_parse_config_file(const char *path, int override);
+void ucs_config_parse_config_file(const char *dir_path, const char *file_name,
+                                  int override);
+
+
+/**
+ * Parse configuration files. This function searches for config in several
+ * locations and parses them in order of precedence.
+ */
+void ucs_config_parse_config_files();
 
 
 /**

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -1277,45 +1277,6 @@ static int ucs_debug_backtrace_is_excluded(void *address, const char *symbol)
            (strstr(symbol, "_L_unlock_") == symbol);
 }
 
-static ucs_status_t ucs_debug_get_lib_info(Dl_info *dl_info)
-{
-    int ret;
-
-    (void)dlerror();
-    ret = dladdr(ucs_debug_get_lib_info, dl_info);
-    if (ret == 0) {
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    return UCS_OK;
-}
-
-const char *ucs_debug_get_lib_path()
-{
-    ucs_status_t status;
-    Dl_info dl_info;
-
-    status = ucs_debug_get_lib_info(&dl_info);
-    if (status != UCS_OK) {
-        return "<failed to resolve libucs path>";
-    }
-
-    return dl_info.dli_fname;
-}
-
-unsigned long ucs_debug_get_lib_base_addr()
-{
-    ucs_status_t status;
-    Dl_info dl_info;
-
-    status = ucs_debug_get_lib_info(&dl_info);
-    if (status != UCS_OK) {
-        return 0;
-    }
-
-    return (uintptr_t)dl_info.dli_fbase;
-}
-
 void ucs_debug_init()
 {
     ucs_recursive_spinlock_init(&ucs_kh_lock, 0);

--- a/src/ucs/debug/debug_int.h
+++ b/src/ucs/debug/debug_int.h
@@ -65,18 +65,6 @@ ucs_status_t ucs_debug_lookup_address(void *address, ucs_debug_address_info_t *i
 
 
 /**
- * @return Full path to current library.
- */
-const char *ucs_debug_get_lib_path();
-
-
-/**
- * @return UCS library loading address.
- */
-unsigned long ucs_debug_get_lib_base_addr();
-
-
-/**
  * Create a backtrace from the calling location.
  *
  * @param bckt          Backtrace object.

--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -13,6 +13,7 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
+#include <ucs/sys/lib.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 #include <ucs/time/time.h>
@@ -246,7 +247,7 @@ static void ucs_profile_write(ucs_profile_context_t *ctx)
     ucs_read_file(header.cmdline, sizeof(header.cmdline), 1, "/proc/self/cmdline");
     strncpy(header.hostname, ucs_get_host_name(), sizeof(header.hostname) - 1);
     header.version       = UCS_PROFILE_FILE_VERSION;
-    strncpy(header.ucs_path, ucs_debug_get_lib_path(), sizeof(header.ucs_path) - 1);
+    strncpy(header.ucs_path, ucs_sys_get_lib_path(), sizeof(header.ucs_path) - 1);
     header.pid           = getpid();
     header.mode          = ctx->profile_mode;
     header.num_locations = ctx->num_locations;

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -18,6 +18,7 @@
 #include <ucs/profile/profile.h>
 #include <ucs/stats/stats.h>
 #include <ucs/async/async.h>
+#include <ucs/sys/lib.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/topo.h>
 #include <ucs/sys/math.h>
@@ -110,8 +111,8 @@ static void UCS_F_CTOR ucs_init()
     ucs_async_global_init();
     ucs_topo_init();
     ucs_rand_seed_init();
-    ucs_debug("%s loaded at 0x%lx", ucs_debug_get_lib_path(),
-              ucs_debug_get_lib_base_addr());
+    ucs_debug("%s loaded at 0x%lx", ucs_sys_get_lib_path(),
+              ucs_sys_get_lib_base_addr());
     ucs_debug("cmd line: %s", ucs_get_process_cmdline());
     ucs_modules_load();
 }

--- a/src/ucs/sys/lib.c
+++ b/src/ucs/sys/lib.c
@@ -1,0 +1,51 @@
+/**
+* Copyright © 2021 NVIDIA CORPORATION & AFFILIATES. 
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "lib.h"
+
+
+ucs_status_t ucs_sys_get_lib_info(Dl_info *dl_info)
+{
+    int ret;
+
+    (void)dlerror();
+    ret = dladdr(ucs_sys_get_lib_info, dl_info);
+    if (ret == 0) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    return UCS_OK;
+}
+
+const char *ucs_sys_get_lib_path()
+{
+    ucs_status_t status;
+    Dl_info dl_info;
+
+    status = ucs_sys_get_lib_info(&dl_info);
+    if (status != UCS_OK) {
+        return "<failed to resolve libucs path>";
+    }
+
+    return dl_info.dli_fname;
+}
+
+unsigned long ucs_sys_get_lib_base_addr()
+{
+    ucs_status_t status;
+    Dl_info dl_info;
+
+    status = ucs_sys_get_lib_info(&dl_info);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return (uintptr_t)dl_info.dli_fbase;
+}

--- a/src/ucs/sys/lib.h
+++ b/src/ucs/sys/lib.h
@@ -1,0 +1,42 @@
+/**
+* Copyright © 2021 NVIDIA CORPORATION & AFFILIATES. 
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef LIB_H
+#define LIB_H
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <ucs/sys/compiler_def.h>
+#include <ucs/type/status.h>
+
+#include <stdint.h>
+#include <dlfcn.h>
+
+
+BEGIN_C_DECLS
+
+/**
+ * @return Full info on current library.
+ */
+ucs_status_t ucs_sys_get_lib_info(Dl_info *dl_info);
+
+
+/**
+ * @return Full path to current library.
+ */
+const char *ucs_sys_get_lib_path();
+
+
+/**
+ * @return UCS library loading address.
+ */
+unsigned long ucs_sys_get_lib_base_addr();
+
+END_C_DECLS
+
+#endif /* LIB_H */

--- a/test/gtest/ucs/ucx_test.conf
+++ b/test/gtest/ucs/ucx_test.conf
@@ -1,0 +1,2 @@
+UCX_PRICE=200
+UCX_BRAND=Mazda


### PR DESCRIPTION
## What
Search in several directories for the `ucx.conf`. Each file is parsed and its contents override the previous ones. Any file which is not found or cannot be parsed is silently ignored. The paths are scanned in the following order:

1. %sysconfdir/ucx.conf
2. <libucs.so>/../etc/ucx.conf
3. ~/.ucx.conf
4. $UCX_CONFIG_DIR
5. $PWD/ucx.conf


## Why ?
Provide more flexibility for the user, by combining system-wide, user personal and local project configuration.
