### PR TITLE
UCP/CORE: Move to the previous EP if removed EP points to the last EP

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -302,7 +302,7 @@ typedef struct ucp_worker {
         uct_worker_cb_id_t           cb_id;               /* Keepalive callback id */
         ucs_time_t                   last_round;          /* Last round timestamp */
         ucs_list_link_t              *iter;               /* Last EP processed keepalive */
-        ucs_list_link_t              *iter_begin;         /* First EP processed keepalive in the
+        ucs_list_link_t              *iter_end;           /* Last EP processed keepalive in the
                                                            * current round */
         ucp_lane_map_t               lane_map;            /* Lane map used to retry after no-resources */
         unsigned                     ep_count;            /* Number of EPs processed in current time slot */


### PR DESCRIPTION
## What

Move to the previous EP if removed EP points to the last EP.

## Why ?

To avoid doing keepalive twice for `iter_begin` element during the same round.

Before:
![image](https://user-images.githubusercontent.com/11650339/124646173-fd3f9880-de9c-11eb-9a5c-9cbb805530b9.png)

After:
![image](https://user-images.githubusercontent.com/11650339/124646203-04ff3d00-de9d-11eb-83c5-d3d7e0cb7a99.png)


## How ?

1. Rename `iter_begin` to `iter_end`, because this name better reflects the purpose of the iterator.
2. When removing `iter` which points to `iter_end`, update `iter_end` to point to the predecessor of the `iter_end`. If `iter == iter_end`, KA round will be completed.