### PR TITLE
UCT/IB/DC: Don't send FC_PURE_GRANT if DCI hasn't been reset yet after failure

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1567,14 +1567,16 @@ void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,
         return;
     }
 
-    if (ep_status == UCS_ERR_CANCELED) {
-        return;
-    }
-
     if (ep == iface->tx.fc_ep) {
+        iface->flags |= UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED;
+
         /* Do not report errors on flow control endpoint */
         ucs_debug("got error on DC flow-control endpoint, iface %p: %s", iface,
                   ucs_status_string(ep_status));
+        return;
+    }
+
+    if (ep_status == UCS_ERR_CANCELED) {
         return;
     }
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -74,7 +74,10 @@ typedef enum {
     UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE_FULL_HANDSHAKE = UCS_BIT(1),
 
     /** uidx is set to dci idx */
-    UCT_DC_MLX5_IFACE_FLAG_UIDX                     = UCS_BIT(2)
+    UCT_DC_MLX5_IFACE_FLAG_UIDX                     = UCS_BIT(2),
+
+    /** Flow control endpoint is using a DCI in error state */
+    UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED             = UCS_BIT(3)
 } uct_dc_mlx5_iface_flags_t;
 
 


### PR DESCRIPTION
## What

Don't send FC_PURE_GRANT if DCI hasn't been reset yet after failure.

## Why ?

To fix the following failure:
```
[jazz26:110223:0:110223]   rc_mlx5.inl:456  Assertion `!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED)' failed

/labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl: [ uct_rc_mlx5_common_post_send() ]
      ...
      453     if (opcode != MLX5_OPCODE_NOP) {
      454         /* If FAILED, allow only NOP sends to be posted (used by endpoint
      455          * flush operations) */
==>   456         ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
      457     }
      458
      459     ctrl = txwq->curr;

==== backtrace (tid: 110223) ====
 0 0x00000000001265da uct_rc_mlx5_common_post_send()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:456
 1 0x00000000001265da uct_rc_mlx5_txqp_inline_post()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:616
 2 0x00000000001265da uct_dc_mlx5_ep_fc_pure_grant_send()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5_ep.c:944
 3 0x0000000000151852 uct_dc_mlx5_iface_fc_grant()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1073
 4 0x0000000000151a3d uct_dc_mlx5_iface_fc_handler()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:1115
 5 0x000000000013d3d9 uct_rc_mlx5_iface_common_am_handler()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:417
 6 0x000000000013d3d9 uct_rc_mlx5_iface_common_poll_rx()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:1449
 7 0x000000000013d3d9 uct_dc_mlx5_iface_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:267
 8 0x000000000013d3d9 uct_dc_mlx5_iface_progress_ll()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/dc/dc_mlx5.c:282
 9 0x00000000000555e3 ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
10 0x0000000000061cf3 uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2592
11 0x00000000004048d6 UcxContext::progress_worker_event()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:383
12 0x0000000000404002 UcxContext::progress()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/ucx_wrapper.cc:222
13 0x0000000000410e88 DemoServer::run()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:936
14 0x000000000040e466 do_server()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2474
15 0x000000000040ea03 main()  /labhome/dmitrygla/work_auto/ucx/test/apps/iodemo/io_demo.cc:2539
16 0x00000000000223d5 __libc_start_main()  ???:0
17 0x00000000004030d9 _start()  ???:0
=================================
```

## How ?

Save sending of FC_PURE_GRANT operation to the pending queue for further processing when DCI will be reset, i.e. the same actions as we do in FC_PURE_GRANT send completion when it fails with the `CANCELED` status:
https://github.com/openucx/ucx/blob/847078e8bd3eb2bea2b25f9886501a78b1b49724/src/uct/ib/dc/dc_mlx5_ep.c#L989
All scheduled FC_PURE_GRANT operations will be sent when DCI will be reset.