### PR TITLE
UCP/CORE/WIREUP/GTEST: Remove trying next CM callback upon destroying EP

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -62,7 +62,7 @@ int ucp_ep_init_flags_has_cm(unsigned ep_init_flags)
  * The main thread progress part of attempting connecting the client to the server
  * through the next available cm.
  */
-static unsigned ucp_cm_client_try_next_cm_progress(void *arg)
+unsigned ucp_cm_client_try_next_cm_progress(void *arg)
 {
     ucp_ep_h ucp_ep       = arg;
     ucp_worker_h worker   = ucp_ep->worker;
@@ -72,6 +72,8 @@ static unsigned ucp_cm_client_try_next_cm_progress(void *arg)
     ucp_rsc_index_t cm_idx;
 
     UCS_ASYNC_BLOCK(&worker->async);
+
+    ucs_assert(!(ucp_ep->flags & UCP_EP_FLAG_FAILED));
 
     cm_idx = ucp_ep_ext_control(ucp_ep)->cm_idx;
     ucs_assert(cm_idx != UCP_NULL_RESOURCE);
@@ -1348,7 +1350,8 @@ ucp_cm_connect_progress_remove_filter(const ucs_callbackq_elem_t *elem,
             return 1;
         }
     } else if (((elem->cb == ucp_cm_server_conn_notify_progress) ||
-                (elem->cb == ucp_cm_client_uct_connect_progress)) &&
+                (elem->cb == ucp_cm_client_uct_connect_progress) ||
+                (elem->cb == ucp_cm_client_try_next_cm_progress)) &&
                (elem->arg == arg)) {
         return 1;
     }

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -23,6 +23,8 @@ unsigned ucp_cm_ep_init_flags(const ucp_ep_params_t *params);
 
 int ucp_ep_init_flags_has_cm(unsigned ep_init_flags);
 
+unsigned ucp_cm_client_try_next_cm_progress(void *arg);
+
 void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep, ucp_ep_h ucp_ep);
 
 ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -14,6 +14,7 @@
 #include <sys/poll.h>
 
 extern "C" {
+#include <uct/base/uct_worker.h>
 #include <ucp/core/ucp_listener.h>
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
@@ -967,78 +968,8 @@ protected:
                     ((lane1 != UCP_NULL_LANE) && (lane2 != UCP_NULL_LANE) &&
                      ucp_ep_config_lane_is_peer_match(key1, lane1, key2, lane2)));
     }
-
-    bool check_ep_flags(entity &e, uint32_t wait_ep_flags)
-    {
-        bool result;
-
-        UCS_ASYNC_BLOCK(&e.worker()->async);
-        result = ucs_test_all_flags(e.ep()->flags, wait_ep_flags);
-        UCS_ASYNC_UNBLOCK(&e.worker()->async);
-
-        return result;
-    }
-
-    typedef enum {
-        FAIL_WIREUP_MSG_SEND,
-        FAIL_WIREUP_MSG_ADDR_PACK,
-        FAIL_WIREUP_SET_EP_FAILED
-    } fail_wireup_t;
-
-    void connect_and_fail_wireup(entity &e, uint32_t wait_ep_flags,
-                                 fail_wireup_t fail_wireup_type)
-    {
-        start_listener(cb_type());
-
-        scoped_log_handler slh(wrap_errors_logger);
-        client_ep_connect();
-        if (!wait_for_server_ep(false)) {
-            UCS_TEST_SKIP_R("cannot connect to server");
-        }
-
-        if (fail_wireup_type == FAIL_WIREUP_MSG_SEND) {
-            /* Emulate failure of WIREUP MSG sending by setting the AM Bcopy
-             * function which always return EP_TIMEOUT error */
-            UCS_ASYNC_BLOCK(&e.worker()->async);
-            for (ucp_lane_index_t lane_idx = 0;
-                 lane_idx < ucp_ep_num_lanes(e.ep()); ++lane_idx) {
-                uct_ep_h uct_ep = e.ep()->uct_eps[lane_idx];
-                uct_ep->iface->ops.ep_am_bcopy =
-                        reinterpret_cast<uct_ep_am_bcopy_func_t>(
-                                ucs_empty_function_return_bc_ep_timeout);
-            }
-            UCS_ASYNC_UNBLOCK(&e.worker()->async);
-        }
-
-        while (!check_ep_flags(e, wait_ep_flags)) {
-            progress();
-        }
-
-        if (fail_wireup_type == FAIL_WIREUP_MSG_ADDR_PACK) {
-            /* Emulate failure of preparation of WIREUP MSG sending by setting
-             * the device address getter to the function that always returns
-             * error */
-            UCS_ASYNC_BLOCK(&e.worker()->async);
-            for (ucp_lane_index_t lane_idx = 0;
-                 lane_idx < ucp_ep_num_lanes(e.ep()); ++lane_idx) {
-                uct_ep_h uct_ep = e.ep()->uct_eps[lane_idx];
-                uct_ep->iface->ops.iface_get_device_address =
-                        reinterpret_cast<uct_iface_get_device_address_func_t>(
-                                ucs_empty_function_return_ep_timeout);
-            }
-            UCS_ASYNC_UNBLOCK(&e.worker()->async);
-        } else if (fail_wireup_type == FAIL_WIREUP_SET_EP_FAILED) {
-            /* Emulate failure of the endpoint by invoking error handling
-             * procedure */
-            UCS_ASYNC_BLOCK(&e.worker()->async);
-            ucp_ep_set_failed(e.ep(), UCP_NULL_LANE, UCS_ERR_ENDPOINT_TIMEOUT);
-            UCS_ASYNC_UNBLOCK(&e.worker()->async);
-        }
-
-        wait_for_flag(&m_err_count);
-        concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
-    }    
 };
+
 
 UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup, compare_cm_and_wireup_configs,
                      !cm_use_all_devices()) {
@@ -1121,53 +1052,199 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup, compare_cm_and_wireup_configs,
     }
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup,
+UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_wireup)
+
+
+class test_ucp_sockaddr_wireup_fail : public test_ucp_sockaddr_wireup {
+protected:
+    typedef enum {
+        FAIL_WIREUP_MSG_SEND,
+        FAIL_WIREUP_MSG_ADDR_PACK,
+        FAIL_WIREUP_SET_EP_FAILED
+    } fail_wireup_t;
+
+    virtual bool wait(entity &e, uint32_t wait_ep_flags)
+    {
+        UCS_ASYNC_BLOCK(&e.worker()->async);
+        bool result = ucs_test_all_flags(e.ep()->flags, wait_ep_flags);
+        UCS_ASYNC_UNBLOCK(&e.worker()->async);
+
+        return result;
+    }
+
+    void connect_and_fail_wireup(entity &e, fail_wireup_t fail_wireup_type,
+                                 uint32_t wait_ep_flags,
+                                 bool wait_cm_failure = false)
+    {
+        start_listener(cb_type());
+
+        scoped_log_handler slh(wrap_errors_logger);
+        client_ep_connect();
+        if (!wait_cm_failure && !wait_for_server_ep(false)) {
+            UCS_TEST_SKIP_R("cannot connect to server");
+        }
+
+        if (fail_wireup_type == FAIL_WIREUP_MSG_SEND) {
+            /* Emulate failure of WIREUP MSG sending by setting the AM Bcopy
+             * function which always return EP_TIMEOUT error */
+            UCS_ASYNC_BLOCK(&e.worker()->async);
+            for (ucp_lane_index_t lane_idx = 0;
+                 lane_idx < ucp_ep_num_lanes(e.ep()); ++lane_idx) {
+                uct_ep_h uct_ep = e.ep()->uct_eps[lane_idx];
+                uct_ep->iface->ops.ep_am_bcopy =
+                        reinterpret_cast<uct_ep_am_bcopy_func_t>(
+                                ucs_empty_function_return_bc_ep_timeout);
+            }
+            UCS_ASYNC_UNBLOCK(&e.worker()->async);
+        }
+
+        while (!wait(e, wait_ep_flags) && (sender().get_err_num() == 0)) {
+            progress();
+        }
+
+        if (fail_wireup_type == FAIL_WIREUP_MSG_ADDR_PACK) {
+            /* Emulate failure of preparation of WIREUP MSG sending by setting
+             * the device address getter to the function that always returns
+             * error */
+            UCS_ASYNC_BLOCK(&e.worker()->async);
+            for (ucp_lane_index_t lane_idx = 0;
+                 lane_idx < ucp_ep_num_lanes(e.ep()); ++lane_idx) {
+                uct_ep_h uct_ep = e.ep()->uct_eps[lane_idx];
+                uct_ep->iface->ops.iface_get_device_address =
+                        reinterpret_cast<uct_iface_get_device_address_func_t>(
+                                ucs_empty_function_return_ep_timeout);
+            }
+            UCS_ASYNC_UNBLOCK(&e.worker()->async);
+        } else if (fail_wireup_type == FAIL_WIREUP_SET_EP_FAILED) {
+            /* Emulate failure of the endpoint by invoking error handling
+             * procedure */
+            UCS_ASYNC_BLOCK(&e.worker()->async);
+            ucp_ep_set_failed(e.ep(), UCP_NULL_LANE, UCS_ERR_ENDPOINT_TIMEOUT);
+            UCS_ASYNC_UNBLOCK(&e.worker()->async);
+        }
+
+        wait_for_flag(&m_err_count);
+
+        if (wait_cm_failure) {
+            one_sided_disconnect(e, UCP_EP_CLOSE_MODE_FORCE);
+        } else {
+            concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
+        }
+    }
+};
+
+
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup_fail,
                      connect_and_fail_wireup_msg_send_on_client,
                      !cm_use_all_devices())
 {
-    connect_and_fail_wireup(sender(), UCP_EP_FLAG_CONNECT_REQ_QUEUED,
-                            FAIL_WIREUP_MSG_SEND);
+    connect_and_fail_wireup(sender(), FAIL_WIREUP_MSG_SEND,
+                            UCP_EP_FLAG_CONNECT_REQ_QUEUED);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup,
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup_fail,
                      connect_and_fail_wireup_msg_send_on_server,
                      !cm_use_all_devices())
 {
-    connect_and_fail_wireup(receiver(), UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED,
-                            FAIL_WIREUP_MSG_SEND);
+    connect_and_fail_wireup(receiver(), FAIL_WIREUP_MSG_SEND,
+                            UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup,
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup_fail,
                      connect_and_fail_wireup_msg_pack_addr_on_client,
                      !cm_use_all_devices())
 {
-    connect_and_fail_wireup(sender(), UCP_EP_FLAG_CLIENT_CONNECT_CB,
-                            FAIL_WIREUP_MSG_ADDR_PACK);
+    connect_and_fail_wireup(sender(), FAIL_WIREUP_MSG_ADDR_PACK,
+                            UCP_EP_FLAG_CLIENT_CONNECT_CB);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup,
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup_fail,
                      connect_and_fail_wireup_msg_pack_addr_on_server,
                      !cm_use_all_devices())
 {
-    connect_and_fail_wireup(receiver(), UCP_EP_FLAG_SERVER_NOTIFY_CB,
-                            FAIL_WIREUP_MSG_ADDR_PACK);
+    connect_and_fail_wireup(receiver(), FAIL_WIREUP_MSG_ADDR_PACK,
+                            UCP_EP_FLAG_SERVER_NOTIFY_CB);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_wireup,
+UCS_TEST_P(test_ucp_sockaddr_wireup_fail,
            connect_and_fail_wireup_set_ep_failed_on_client)
 {
-    connect_and_fail_wireup(sender(), UCP_EP_FLAG_CLIENT_CONNECT_CB,
-                            FAIL_WIREUP_SET_EP_FAILED);
+    connect_and_fail_wireup(sender(), FAIL_WIREUP_SET_EP_FAILED,
+                            UCP_EP_FLAG_CLIENT_CONNECT_CB);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_wireup,
+UCS_TEST_P(test_ucp_sockaddr_wireup_fail,
            connect_and_fail_wireup_set_ep_failed_on_server)
 {
-    connect_and_fail_wireup(receiver(), UCP_EP_FLAG_SERVER_NOTIFY_CB,
-                            FAIL_WIREUP_SET_EP_FAILED);
+    connect_and_fail_wireup(receiver(), FAIL_WIREUP_SET_EP_FAILED,
+                            UCP_EP_FLAG_SERVER_NOTIFY_CB);
 }
 
-UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_wireup)
+UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_wireup_fail)
+
+
+class test_ucp_sockaddr_wireup_fail_try_next_cm :
+        public test_ucp_sockaddr_wireup_fail  {
+private:
+    typedef struct {
+        entity &e;
+        bool   found;
+    } find_try_next_cm_arg_t;
+
+    static int find_try_next_cm_cb(const ucs_callbackq_elem_t *elem, void *arg)
+    {
+        find_try_next_cm_arg_t *find_try_next_cm_arg =
+                reinterpret_cast<find_try_next_cm_arg_t*>(arg);
+
+        if ((elem->cb == ucp_cm_client_try_next_cm_progress) &&
+            (elem->arg == find_try_next_cm_arg->e.ep())) {
+            find_try_next_cm_arg->found = true;
+        }
+
+        return 0;
+    }
+
+    virtual bool wait(entity &e, uint32_t wait_ep_flags)
+    {
+        if (test_ucp_sockaddr_wireup_fail::wait(e, wait_ep_flags)) {
+            UCS_TEST_SKIP_R("trying the next CM calback wasn't scheduled");
+        }
+
+        /* Waiting for ucp_cm_client_try_next_cm_progress() callback being
+         * scheduled on a progress. When it is found, the test emulates failure
+         * to check that the callback is removed from the callback queue on
+         * the worker */
+        find_try_next_cm_arg_t find_try_next_cm_arg = { e, false };
+
+        UCS_ASYNC_BLOCK(&e.worker()->async);
+        uct_priv_worker_t *worker = ucs_derived_of(e.worker()->uct,
+                                                   uct_priv_worker_t);
+        ucs_callbackq_remove_if(&worker->super.progress_q,
+                                find_try_next_cm_cb, &find_try_next_cm_arg);
+        UCS_ASYNC_UNBLOCK(&e.worker()->async);
+
+        return find_try_next_cm_arg.found;
+    }
+};
+
+
+UCS_TEST_P(test_ucp_sockaddr_wireup_fail_try_next_cm,
+           connect_and_fail_wireup_next_cm_tcp2rdmacm_set_ep_failed_on_client,
+           "SOCKADDR_TLS_PRIORITY=tcp,rdmacm")
+{
+    connect_and_fail_wireup(sender(), FAIL_WIREUP_SET_EP_FAILED,
+                            UCP_EP_FLAG_CLIENT_CONNECT_CB, true);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_wireup_fail_try_next_cm,
+           connect_and_fail_wireup_next_cm_rdmacm2tcp_set_ep_failed_on_client,
+           "SOCKADDR_TLS_PRIORITY=rdmacm,tcp")
+{
+    connect_and_fail_wireup(sender(), FAIL_WIREUP_SET_EP_FAILED,
+                            UCP_EP_FLAG_CLIENT_CONNECT_CB, true);
+}
+
+UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_wireup_fail_try_next_cm)
 
 
 class test_ucp_sockaddr_different_tl_rsc : public test_ucp_sockaddr


### PR DESCRIPTION
## What

Remove trying next CM callback upon destroying EP.

## Why ?

Trying next CM callback should be removed upon destroying EP to avoid calling it when UCP EP is already destroyed.

## How ?

1. Added `UCP_EP_FLAG_TRY_NEXT_CM` flag to check whether trying next CM callback scheduled or not - needed for DEBUG-only purposes and for GTESTs.
2. Introduced two GTESTs which fail wireup procedure when client is scheduling trying next CM callback.
3. Introduced filter function to remove trying next CM callback from cbq.
4. Use the new filter to remove trying next CM callback from cbq upon destroying UCP EP.
5. Destroy next UCT EP by using discarding functionality to allow calling it from async functions, e.g. UCT CM callback (resolve_cb, connect_cb).
6. Move destroying next UCT EP of CM lane to the place where scheduling trying next CM callback in order to make sure no lanes at all when doing `ucp_ep_close_nbx()` which disccards lanes in case of FORCE. So, discard shouldn't be added to progress and callbacks should be removed.