### PR TITLE
UCP/RNDV: Don't initialize variable by 0 if it is not read then

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1342,12 +1342,11 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_receive, (worker, rreq, rndv_rts_hdr, rkey_buf),
         goto err;
     }
 
-    rndv_req->flags        = 0;
-    rndv_req->send.ep      = ep;
-    rndv_req->send.mdesc   = NULL;
-    is_get_zcopy_failed    = 0;
-    is_get_zcopy_supported = 0;
-    src_mem_type           = UCS_MEMORY_TYPE_HOST;
+    rndv_req->flags      = 0;
+    rndv_req->send.ep    = ep;
+    rndv_req->send.mdesc = NULL;
+    is_get_zcopy_failed  = 0;
+    src_mem_type         = UCS_MEMORY_TYPE_HOST;
 
     ucp_trace_req(rreq,
                   "rndv matched remote {address 0x%"PRIx64" size %zu sreq_id "


### PR DESCRIPTION
## What

Don't initialize variable by 0 if it is not read then.

## Why ?

To fix the following warning:
```
/__w/1/s/src/ucp/rndv/rndv.c:1349:5: warning: Value stored to 'is_get_zcopy_supported' is never read [deadcode.DeadStores] <--[clang]
    is_get_zcopy_supported = 0;
    ^                        ~
1 warning generated.
```
The initial value stored in `is_get_zcopy_supported` is not used then, it is just overwritten.

## How ?

Don't initialize `is_get_zcopy_supported` by `0`.