### PR TITLE
UCT/DC: Fix compilation with rdma-core 20

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -317,8 +317,8 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
 
 #else
 
-static UCS_F_MAYBE_UNUSED ucs_status_t
-uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
+static UCS_F_MAYBE_UNUSED ucs_status_t uct_dc_mlx5_iface_devx_create_dct(
+        uct_dc_mlx5_iface_t *iface, int full_handshake)
 {
     return UCS_ERR_UNSUPPORTED;
 }


### PR DESCRIPTION
# Why
Fix build with rdma-core 20 which does not have devx

# How
Add full_handshake parameter to dummy function