### PR TITLE
UCT/RC: Fix handling error CQE after rc_ep is destroyed 

### DIFF
--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -109,8 +109,7 @@ static inline int ucs_async_check_miss(ucs_async_context_t *async)
 static inline int ucs_async_is_blocked(const ucs_async_context_t *async)
 {
     if (async->mode == UCS_ASYNC_MODE_THREAD_SPINLOCK) {
-        return ucs_recursive_spin_is_owner(&async->thread.spinlock,
-                                           pthread_self());
+        return ucs_recursive_spinlock_is_held(&async->thread.spinlock);
     } else if (async->mode == UCS_ASYNC_MODE_THREAD_MUTEX) {
         return ucs_recursive_mutex_is_blocked(&async->thread.mutex);
     } else if (async->mode == UCS_ASYNC_MODE_SIGNAL) {

--- a/src/ucs/type/spinlock.c
+++ b/src/ucs/type/spinlock.c
@@ -32,3 +32,18 @@ void ucs_recursive_spinlock_destroy(ucs_recursive_spinlock_t *lock)
 
     ucs_spinlock_destroy(&lock->super);
 }
+
+int ucs_spinlock_is_held(ucs_spinlock_t *lock)
+{
+    if (!ucs_spin_try_lock(lock)) {
+        return 1; /* If can't lock, it is already locked */
+    }
+
+    ucs_spin_unlock(lock);
+    return 0;
+}
+
+int ucs_recursive_spinlock_is_held(const ucs_recursive_spinlock_t *lock)
+{
+    return ucs_recursive_spin_is_owner(lock, pthread_self());
+}

--- a/src/ucs/type/spinlock.h
+++ b/src/ucs/type/spinlock.h
@@ -138,6 +138,10 @@ static inline void ucs_recursive_spin_unlock(ucs_recursive_spinlock_t *lock)
     }
 }
 
+int ucs_spinlock_is_held(ucs_spinlock_t *lock);
+
+int ucs_recursive_spinlock_is_held(const ucs_recursive_spinlock_t *lock);
+
 END_C_DECLS
 
 #endif

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -197,6 +197,16 @@ static void uct_ib_device_get_locality(const char *dev_name,
 }
 
 static void
+uct_ib_device_async_event_schedule_callback(uct_ib_device_t *dev,
+                                            uct_ib_async_event_wait_t *wait_ctx)
+{
+    ucs_assert(ucs_spinlock_is_held(&dev->async_event_lock));
+    ucs_assert(wait_ctx->cb_id == UCS_CALLBACKQ_ID_NULL);
+    wait_ctx->cb_id = ucs_callbackq_add_safe(wait_ctx->cbq, wait_ctx->cb,
+                                             wait_ctx, 0);
+}
+
+static void
 uct_ib_device_async_event_dispatch(uct_ib_device_t *dev,
                                    const uct_ib_async_event_t *event)
 {
@@ -207,13 +217,9 @@ uct_ib_device_async_event_dispatch(uct_ib_device_t *dev,
     iter = kh_get(uct_ib_async_event, &dev->async_events_hash, *event);
     if (iter != kh_end(&dev->async_events_hash)) {
         entry = &kh_value(&dev->async_events_hash, iter);
-        entry->flag = 1;
+        entry->fired = 1;
         if (entry->wait_ctx != NULL) {
-            /* someone is waiting */
-            ucs_assert(entry->wait_ctx->cb_id == UCS_CALLBACKQ_ID_NULL);
-            entry->wait_ctx->cb_id = ucs_callbackq_add_safe(
-                    entry->wait_ctx->cbq, entry->wait_ctx->cb,
-                    entry->wait_ctx, 0);
+            uct_ib_device_async_event_schedule_callback(dev, entry->wait_ctx);
         }
     }
     ucs_spin_unlock(&dev->async_event_lock);
@@ -243,12 +249,18 @@ uct_ib_device_async_event_register(uct_ib_device_t *dev,
     ucs_assert(ret != UCS_KH_PUT_KEY_PRESENT);
     entry           = &kh_value(&dev->async_events_hash, iter);
     entry->wait_ctx = NULL;
-    entry->flag     = 0;
+    entry->fired    = 0;
     status          = UCS_OK;
 
 out:
     ucs_spin_unlock(&dev->async_event_lock);
     return status;
+}
+
+static int uct_ib_device_async_event_inprogress(uct_ib_async_event_val_t *entry)
+{
+    return (entry->wait_ctx != NULL) &&
+           (entry->wait_ctx->cb_id != UCS_CALLBACKQ_ID_NULL);
 }
 
 ucs_status_t
@@ -270,20 +282,19 @@ uct_ib_device_async_event_wait(uct_ib_device_t *dev,
     ucs_assert(iter != kh_end(&dev->async_events_hash));
     entry = &kh_value(&dev->async_events_hash, iter);
 
-    if (entry->flag) {
-        /* event already arrived */
-        status          = UCS_OK;
-        entry->wait_ctx = NULL;
-    } else if (entry->wait_ctx != NULL) {
-        /* someone is already waiting for this event */
-        status          = UCS_ERR_BUSY;
-    } else {
-        /* start waiting for this event */
-        wait_ctx->cb_id = UCS_CALLBACKQ_ID_NULL;
-        status          = UCS_INPROGRESS;
-        entry->wait_ctx = wait_ctx;
+    if (uct_ib_device_async_event_inprogress(entry)) {
+        status = UCS_ERR_BUSY;
+        goto out_unlock;
     }
 
+    status          = UCS_OK;
+    wait_ctx->cb_id = UCS_CALLBACKQ_ID_NULL;
+    entry->wait_ctx = wait_ctx;
+    if (entry->fired) {
+        uct_ib_device_async_event_schedule_callback(dev, wait_ctx);
+    }
+
+out_unlock:
     ucs_spin_unlock(&dev->async_event_lock);
     return status;
 }
@@ -303,8 +314,7 @@ void uct_ib_device_async_event_unregister(uct_ib_device_t *dev,
     iter = kh_get(uct_ib_async_event, &dev->async_events_hash, event);
     ucs_assert(iter != kh_end(&dev->async_events_hash));
     entry = &kh_value(&dev->async_events_hash, iter);
-    if ((entry->wait_ctx != NULL) &&
-        (entry->wait_ctx->cb_id != UCS_CALLBACKQ_ID_NULL)) {
+    if (uct_ib_device_async_event_inprogress(entry)) {
         /* cancel scheduled callback */
         ucs_callbackq_remove_safe(entry->wait_ctx->cbq, entry->wait_ctx->cb_id);
     }

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -191,7 +191,7 @@ typedef struct uct_ib_async_event_wait {
  * IB async event state.
  */
 typedef struct {
-    unsigned                  flag;             /* Event happened */
+    unsigned                  fired;            /* Event happened */
     uct_ib_async_event_wait_t *wait_ctx;        /* Waiting context */
 } uct_ib_async_event_val_t;
 
@@ -415,6 +415,12 @@ uct_ib_device_async_event_register(uct_ib_device_t *dev,
                                    enum ibv_event_type event_type,
                                    uint32_t resource_id);
 
+/* Invoke the callback defined by 'wait_ctx' from callback queue when the event
+ * fires. If it has already been fired, the callback is scheduled immediately to
+ * the callback queue.
+ *
+ * @return UCS_OK, or UCS_ERR_BUSY if someone already waiting for this event.
+ */
 ucs_status_t
 uct_ib_device_async_event_wait(uct_ib_device_t *dev,
                                enum ibv_event_type event_type,

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -481,6 +481,10 @@ void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
 #endif
     uct_ib_fence_info_init(&txwq->fi);
     memset(txwq->qstart, 0, UCS_PTR_BYTE_DIFF(txwq->qstart, txwq->qend));
+
+    /* Make uct_ib_mlx5_txwq_num_posted_wqes() work if no wqe has completed by
+       setting number-of-segments (ds) field of the last wqe to 1 */
+    uct_ib_mlx5_set_ctrl_qpn_ds(uct_ib_mlx5_txwq_get_wqe(txwq, 0xffff), 0, 1);
 }
 
 void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
@@ -598,6 +602,36 @@ ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
 
     uct_ib_mlx5_txwq_reset(txwq);
     return UCS_OK;
+}
+
+void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi)
+{
+    uint16_t num_bb = UCS_PTR_BYTE_DIFF(txwq->qstart, txwq->qend) /
+                      MLX5_SEND_WQE_BB;
+    return UCS_PTR_BYTE_OFFSET(txwq->qstart, (pi % num_bb) * MLX5_SEND_WQE_BB);
+}
+
+uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
+                                          uint16_t outstanding)
+{
+    struct mlx5_wqe_ctrl_seg *ctrl;
+    uint16_t pi, count;
+    size_t wqe_size;
+
+    /* Start iteration with the most recently completed WQE, so count from -1.
+       uct_ib_mlx5_txwq_reset() sets qpn_ds in the last WQE in case no WQE has
+       completed */
+    pi    = txwq->prev_sw_pi - outstanding;
+    count = -1;
+    ucs_assert(pi == txwq->hw_ci);
+    do {
+        ctrl     = uct_ib_mlx5_txwq_get_wqe(txwq, pi);
+        wqe_size = (ctrl->qpn_ds >> 24) * UCT_IB_MLX5_WQE_SEG_SIZE;
+        pi      += (wqe_size + MLX5_SEND_WQE_BB - 1) / MLX5_SEND_WQE_BB;
+        ++count;
+    } while (pi != txwq->sw_pi);
+
+    return count;
 }
 
 void uct_ib_mlx5_qp_mmio_cleanup(uct_ib_mlx5_qp_t *qp,

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -551,6 +551,13 @@ ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
                                    uct_ib_mlx5_mmio_mode_t cfg_mmio_mode,
                                    uct_ib_mlx5_txwq_t *txwq, struct ibv_qp *verbs_qp);
 
+/* Get pointer to a WQE by producer index */
+void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi);
+
+/* Count how many WQEs are currently posted */
+uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
+                                          uint16_t outstanding);
+
 void uct_ib_mlx5_qp_mmio_cleanup(uct_ib_mlx5_qp_t *qp,
                                  uct_ib_mlx5_mmio_reg_t *reg);
 

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -37,6 +37,18 @@ typedef struct uct_rc_mlx5_ep {
     uct_rc_mlx5_mp_context_t mp;
 } uct_rc_mlx5_ep_t;
 
+
+/**
+ * RC MLX5 EP cleanup context
+ */
+typedef struct {
+    uct_rc_iface_qp_cleanup_ctx_t super; /* Base class */
+    uct_ib_mlx5_qp_t              qp; /* Main QP */
+    uct_ib_mlx5_qp_t              tm_qp; /* TM Rendezvous QP */
+    uct_ib_mlx5_mmio_reg_t        *reg; /* Doorbell register */
+} uct_rc_mlx5_iface_qp_cleanup_ctx_t;
+
+
 typedef struct uct_rc_mlx5_ep_address {
     uct_ib_uint24_t  qp_num;
     /* For RNDV TM enabling 2 QPs should be created, one is for sending WRs and
@@ -45,6 +57,7 @@ typedef struct uct_rc_mlx5_ep_address {
     uct_ib_uint24_t  tm_qp_num;
     uint8_t          atomic_mr_id;
 } UCS_S_PACKED uct_rc_mlx5_ep_address_t;
+
 
 UCS_CLASS_DECLARE(uct_rc_mlx5_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rc_mlx5_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -22,17 +22,6 @@
 #include "rc_mlx5.inl"
 
 
-/**
- * RC MLX5 EP cleanup context
- */
-typedef struct {
-    uct_rc_ep_cleanup_ctx_t    super;           /* Base class */
-    uct_ib_mlx5_qp_t           tm_qp;           /* TM Rendezvous QP */
-    uct_ib_mlx5_qp_t           qp;              /* Main QP */
-    uct_ib_mlx5_mmio_reg_t     *reg;            /* Doorbell register */
-} uct_rc_mlx5_ep_cleanup_ctx_t;
-
-
 /*
  * Helper function for zero-copy post.
  * Adds user completion to the callback queue.
@@ -548,8 +537,7 @@ ucs_status_t uct_rc_mlx5_ep_fence(uct_ep_h tl_ep, unsigned flags)
 void uct_rc_mlx5_ep_post_check(uct_ep_h tl_ep)
 {
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
-    /* use this variable as dummy buffer to suppress compiler warning */ 
-    uint64_t dummy = 0;
+    uint64_t dummy = 0; /* Dummy buffer to suppress compiler warning */
 
     uct_rc_mlx5_txqp_inline_post(iface, IBV_QPT_RC,
                                  &ep->super.txqp, &ep->tx.wq,
@@ -984,53 +972,20 @@ err:
     return status;
 }
 
-unsigned uct_rc_mlx5_ep_cleanup_qp(void *arg)
-{
-    uct_rc_mlx5_ep_cleanup_ctx_t *ep_cleanup_ctx
-                                      = arg;
-    uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ep_cleanup_ctx->super.iface,
-                                                       uct_rc_mlx5_iface_common_t);
-    uct_ib_mlx5_md_t *md              = ucs_derived_of(iface->super.super.super.md,
-                                                       uct_ib_mlx5_md_t);
-#if !HAVE_DECL_MLX5DV_INIT_OBJ
-    int count;
-
-    count = uct_rc_mlx5_iface_commom_clean(&iface->cq[UCT_IB_DIR_RX],
-                                           &iface->rx.srq,
-                                           ep_cleanup_ctx->qp.qp_num);
-    iface->super.rx.srq.available += count;
-    uct_rc_mlx5_iface_common_update_cqs_ci(iface, &iface->super.super);
-#endif
-
-#if IBV_HW_TM
-    if (UCT_RC_MLX5_TM_ENABLED(iface)) {
-        /* using uct_ib_mlx5_iface_put_res_domain and not
-         * uct_ib_mlx5_qp_mmio_cleanup: in case of devx, we don't have uar,
-         * and uct_ib_mlx5_qp_mmio_cleanup would try to release uar */
-        uct_ib_mlx5_iface_put_res_domain(&ep_cleanup_ctx->tm_qp);
-        uct_ib_mlx5_destroy_qp(md, &ep_cleanup_ctx->tm_qp);
-    }
-#endif
-
-    uct_ib_mlx5_qp_mmio_cleanup(&ep_cleanup_ctx->qp, ep_cleanup_ctx->reg);
-    uct_ib_mlx5_destroy_qp(md, &ep_cleanup_ctx->qp);
-    uct_rc_ep_cleanup_qp_done(&ep_cleanup_ctx->super, ep_cleanup_ctx->qp.qp_num);
-    return 1;
-}
-
 UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(self->super.super.super.iface,
                                                        uct_rc_mlx5_iface_common_t);
     uct_ib_mlx5_md_t *md              = ucs_derived_of(iface->super.super.super.md,
                                                        uct_ib_mlx5_md_t);
-    uct_rc_mlx5_ep_cleanup_ctx_t *ep_cleanup_ctx;
+    uct_rc_mlx5_iface_qp_cleanup_ctx_t *cleanup_ctx;
+    uint16_t outstanding, wqe_count;
 
-    ep_cleanup_ctx = ucs_malloc(sizeof(*ep_cleanup_ctx), "ep_cleanup_ctx");
-    ucs_assert_always(ep_cleanup_ctx != NULL);
-    ep_cleanup_ctx->tm_qp = self->tm_qp;
-    ep_cleanup_ctx->qp    = self->tx.wq.super;
-    ep_cleanup_ctx->reg   = self->tx.wq.reg;
+    cleanup_ctx = ucs_malloc(sizeof(*cleanup_ctx), "mlx5_qp_cleanup_ctx");
+    ucs_assert_always(cleanup_ctx != NULL);
+    cleanup_ctx->qp    = self->tx.wq.super;
+    cleanup_ctx->tm_qp = self->tm_qp;
+    cleanup_ctx->reg   = self->tx.wq.reg;
 
     uct_rc_txqp_purge_outstanding(&iface->super, &self->super.txqp,
                                   UCS_ERR_CANCELED, self->tx.wq.sw_pi, 1);
@@ -1042,8 +997,14 @@ UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)
 
     ucs_assert(self->mp.free == 1);
     (void)uct_ib_mlx5_modify_qp_state(md, &self->tx.wq.super, IBV_QPS_ERR);
-    uct_rc_ep_cleanup_qp(&iface->super, &self->super, &ep_cleanup_ctx->super,
-                         self->tx.wq.super.qp_num);
+
+    /* Keep only one unreleased CQ credit per WQE, so we will not have CQ
+       overflow. These CQ credits will be released by error CQE handler. */
+    outstanding = self->tx.wq.bb_max - self->super.txqp.available;
+    wqe_count   = uct_ib_mlx5_txwq_num_posted_wqes(&self->tx.wq, outstanding);
+    ucs_assert(outstanding >= wqe_count);
+    uct_rc_ep_cleanup_qp(&self->super, &cleanup_ctx->super,
+                         self->tx.wq.super.qp_num, outstanding - wqe_count);
 }
 
 UCS_CLASS_DEFINE(uct_rc_mlx5_ep_t, uct_rc_ep_t);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -223,14 +223,6 @@ struct uct_rc_ep {
 };
 
 
-/* EP QP TX cleanup context */
-typedef struct {
-    uct_ib_async_event_wait_t super;      /* LAST_WQE event callback */
-    ucs_list_link_t           list;       /* entry in interface ep_gc_list */
-    uct_rc_iface_t            *iface;     /* interface */
-} uct_rc_ep_cleanup_ctx_t;
-
-
 UCS_CLASS_DECLARE(uct_rc_ep_t, uct_rc_iface_t*, uint32_t, const uct_ep_params_t*);
 
 
@@ -266,11 +258,6 @@ ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
 void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void*arg);
 
-ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
-                                                  ucs_arbiter_group_t *group,
-                                                  ucs_arbiter_elem_t *elem,
-                                                  void *arg);
-
 ucs_status_t uct_rc_fc_init(uct_rc_fc_t *fc, int16_t winsize
                             UCS_STATS_ARG(ucs_stats_node_t* stats_parent));
 void uct_rc_fc_cleanup(uct_rc_fc_t *fc);
@@ -286,11 +273,9 @@ ucs_status_t uct_rc_ep_flush(uct_rc_ep_t *ep, int16_t max_available,
 ucs_status_t
 uct_rc_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 
-void uct_rc_ep_cleanup_qp(uct_rc_iface_t *iface, uct_rc_ep_t *ep,
-                          uct_rc_ep_cleanup_ctx_t *cleanup_ctx, uint32_t qp_num);
-
-void uct_rc_ep_cleanup_qp_done(uct_rc_ep_cleanup_ctx_t *cleanup_ctx,
-                               uint32_t qp_num);
+void uct_rc_ep_cleanup_qp(uct_rc_ep_t *ep,
+                          uct_rc_iface_qp_cleanup_ctx_t *cleanup_ctx,
+                          uint32_t qp_num, uint16_t cq_credits);
 
 void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 0)(uct_rc_iface_send_op_t *op,
                                                    const void *resp);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -579,7 +579,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     memset(self->eps, 0, sizeof(self->eps));
     ucs_arbiter_init(&self->tx.arbiter);
     ucs_list_head_init(&self->ep_list);
-    ucs_list_head_init(&self->ep_gc_list);
+    ucs_list_head_init(&self->qp_gc_list);
 
     /* Check FC parameters correctness */
     if ((config->fc.hard_thresh <= 0) || (config->fc.hard_thresh >= 1)) {
@@ -679,16 +679,38 @@ err:
     return status;
 }
 
-void uct_rc_iface_cleanup_eps(uct_rc_iface_t *iface)
+unsigned uct_rc_iface_qp_cleanup_progress(void *arg)
 {
-    uct_rc_iface_ops_t *ops = ucs_derived_of(iface->super.ops, uct_rc_iface_ops_t);
-    uct_rc_ep_cleanup_ctx_t *cleanup_ctx, *tmp;
+    uct_rc_iface_qp_cleanup_ctx_t *cleanup_ctx = arg;
+    uct_rc_iface_t *iface                      = cleanup_ctx->iface;
+    uct_rc_iface_ops_t *ops;
 
-    ucs_list_for_each_safe(cleanup_ctx, tmp, &iface->ep_gc_list, list) {
-        ops->cleanup_qp(&cleanup_ctx->super);
+    uct_ib_device_async_event_unregister(uct_ib_iface_device(&iface->super),
+                                         IBV_EVENT_QP_LAST_WQE_REACHED,
+                                         cleanup_ctx->qp_num);
+
+    ops = ucs_derived_of(iface->super.ops, uct_rc_iface_ops_t);
+    ops->cleanup_qp(cleanup_ctx);
+
+    if (cleanup_ctx->cq_credits > 0) {
+        uct_rc_iface_add_cq_credits_dispatch(iface, cleanup_ctx->cq_credits);
     }
 
-    ucs_assert(ucs_list_is_empty(&iface->ep_gc_list));
+    ucs_list_del(&cleanup_ctx->list);
+    ucs_free(cleanup_ctx);
+    return 1;
+}
+
+void uct_rc_iface_cleanup_qps(uct_rc_iface_t *iface)
+{
+    uct_rc_iface_qp_cleanup_ctx_t *cleanup_ctx, *tmp;
+
+    ucs_list_for_each_safe(cleanup_ctx, tmp, &iface->qp_gc_list, list) {
+        cleanup_ctx->cq_credits = 0; /* prevent arbiter dispatch */
+        uct_rc_iface_qp_cleanup_progress(cleanup_ctx);
+    }
+
+    ucs_assert(ucs_list_is_empty(&iface->qp_gc_list));
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rc_iface_t)

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -181,6 +181,16 @@ struct uct_rc_iface_config {
 };
 
 
+/* QP TX cleanup context */
+typedef struct {
+    uct_ib_async_event_wait_t super;      /* LAST_WQE event callback */
+    uct_rc_iface_t            *iface;     /* interface */
+    ucs_list_link_t           list;       /* entry in interface ep_gc_list */
+    uint32_t                  qp_num;     /* QP number to clean up */
+    uint16_t                  cq_credits; /* how many CQ credits to release */
+} uct_rc_iface_qp_cleanup_ctx_t;
+
+
 typedef ucs_status_t
 (*uct_rc_iface_init_rx_func_t)(uct_rc_iface_t *iface,
                                const uct_rc_iface_common_config_t *config);
@@ -198,7 +208,9 @@ typedef ucs_status_t (*uct_rc_iface_fc_handler_func_t)(uct_rc_iface_t *iface,
                                                        uint16_t lid,
                                                        unsigned flags);
 
-typedef unsigned (*uct_rc_iface_cleanup_qp_func_t)(void *arg);
+typedef void (*uct_rc_iface_qp_cleanup_func_t)(
+        uct_rc_iface_qp_cleanup_ctx_t *cleanup_ctx);
+
 
 typedef void (*uct_rc_iface_ep_post_check_func_t)(uct_ep_h tl_ep);
 
@@ -209,7 +221,7 @@ typedef struct uct_rc_iface_ops {
     uct_rc_iface_cleanup_rx_func_t    cleanup_rx;
     uct_rc_iface_fc_ctrl_func_t       fc_ctrl;
     uct_rc_iface_fc_handler_func_t    fc_handler;
-    uct_rc_iface_cleanup_qp_func_t    cleanup_qp;
+    uct_rc_iface_qp_cleanup_func_t    cleanup_qp;
     uct_rc_iface_ep_post_check_func_t ep_post_check;
 } uct_rc_iface_ops_t;
 
@@ -293,7 +305,7 @@ struct uct_rc_iface {
 
     uct_rc_ep_t              **eps[UCT_RC_QP_TABLE_SIZE];
     ucs_list_link_t          ep_list;
-    ucs_list_link_t          ep_gc_list;
+    ucs_list_link_t          qp_gc_list;
 
     /* Progress function (either regular or TM aware) */
     ucs_callback_t           progress;
@@ -368,7 +380,10 @@ void uct_rc_iface_send_desc_init(uct_iface_h tl_iface, void *obj, uct_mem_h memh
 
 void uct_rc_ep_am_zcopy_handler(uct_rc_iface_send_op_t *op, const void *resp);
 
-void uct_rc_iface_cleanup_eps(uct_rc_iface_t *iface);
+void uct_rc_iface_cleanup_qps(uct_rc_iface_t *iface);
+
+unsigned uct_rc_iface_qp_cleanup_progress(void *arg);
+
 
 /**
  * Creates an RC or DCI QP
@@ -409,6 +424,10 @@ ucs_status_t uct_rc_iface_fence(uct_iface_h tl_iface, unsigned flags);
 
 void uct_rc_iface_vfs_populate(uct_rc_iface_t *iface);
 
+ucs_arbiter_cb_result_t
+uct_rc_ep_process_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+                          ucs_arbiter_elem_t *elem, void *arg);
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_rc_fc_ctrl(uct_ep_t *ep, unsigned op, uct_rc_pending_req_t *req)
 {
@@ -447,6 +466,17 @@ uct_rc_iface_update_reads(uct_rc_iface_t *iface)
 
     iface->tx.reads_available += iface->tx.reads_completed;
     iface->tx.reads_completed  = 0;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_add_cq_credits_dispatch(uct_rc_iface_t *iface, uint16_t cq_credits)
+{
+    iface->tx.cq_available += cq_credits;
+    ucs_assertv(iface->tx.cq_available <= iface->config.tx_cq_len,
+                "cq_available=%d tx_cq_len=%d cq_credits=%d",
+                iface->tx.cq_available, iface->config.tx_cq_len, cq_credits);
+    ucs_arbiter_dispatch(&iface->tx.arbiter, 1, uct_rc_ep_process_pending,
+                         NULL);
 }
 
 static UCS_F_ALWAYS_INLINE uct_rc_iface_send_op_t*

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -58,6 +58,13 @@ typedef struct uct_rc_verbs_ep {
 } uct_rc_verbs_ep_t;
 
 
+/* Context for cleaning QP */
+typedef struct {
+    uct_rc_iface_qp_cleanup_ctx_t super;
+    struct ibv_qp                 *qp;
+} uct_rc_verbs_iface_qp_cleanup_ctx_t;
+
+
 /**
  * RC verbs interface configuration.
  */
@@ -161,7 +168,5 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 ucs_status_t uct_rc_verbs_ep_connect_to_ep(uct_ep_h tl_ep,
                                            const uct_device_addr_t *dev_addr,
                                            const uct_ep_addr_t *ep_addr);
-
-unsigned uct_rc_verbs_ep_cleanup_qp(void *arg);
 
 #endif

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -618,45 +618,24 @@ err:
     return status;
 }
 
-typedef struct {
-    uct_rc_ep_cleanup_ctx_t    super;
-    struct ibv_qp              *qp;
-} uct_rc_verbs_ep_cleanup_ctx_t;
-
-unsigned uct_rc_verbs_ep_cleanup_qp(void *arg)
-{
-    uct_rc_verbs_ep_cleanup_ctx_t *ep_cleanup_ctx = arg;
-    uint32_t qp_num = ep_cleanup_ctx->qp->qp_num;
-
-    uct_ib_destroy_qp(ep_cleanup_ctx->qp);
-    uct_rc_ep_cleanup_qp_done(&ep_cleanup_ctx->super, qp_num);
-    return 1;
-}
-
 UCS_CLASS_CLEANUP_FUNC(uct_rc_verbs_ep_t)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(self->super.super.super.iface,
                                                  uct_rc_verbs_iface_t);
-    uct_rc_verbs_ep_cleanup_ctx_t *ep_cleanup_ctx;
-
-    ep_cleanup_ctx = ucs_malloc(sizeof(*ep_cleanup_ctx), "ep_cleanup_ctx");
-    ucs_assert_always(ep_cleanup_ctx != NULL);
-    ep_cleanup_ctx->qp = self->qp;
+    uct_rc_verbs_iface_qp_cleanup_ctx_t *cleanup_ctx;
 
     uct_rc_txqp_purge_outstanding(&iface->super, &self->super.txqp,
                                   UCS_ERR_CANCELED, self->txcnt.pi, 1);
-    /* NOTE: usually, ci == pi here, but if user calls
-     *       flush(UCT_FLUSH_FLAG_CANCEL) then ep_destroy without next progress,
-     *       TX-completion handler is not able to return CQ credits because
-     *       the EP will not be found (base class destructor deletes itself from
-     *       iface->eps). So, lets return credits here since handle_failure
-     *       ignores not found EP. */
-    ucs_assert(self->txcnt.pi >= self->txcnt.ci);
-    iface->super.tx.cq_available += self->txcnt.pi - self->txcnt.ci;
-    ucs_assert(iface->super.tx.cq_available < iface->super.config.tx_ops_count);
     uct_ib_modify_qp(self->qp, IBV_QPS_ERR);
-    uct_rc_ep_cleanup_qp(&iface->super, &self->super, &ep_cleanup_ctx->super,
-                         self->qp->qp_num);
+
+    /* We can release all CQ credits after ibv_qp_destroy(), since it would
+     * clean any leftover CQEs from the CQ (and prevent CQ overflow) */
+    cleanup_ctx = ucs_malloc(sizeof(*cleanup_ctx), "verbs_qp_cleanup_ctx");
+    ucs_assert_always(cleanup_ctx != NULL);
+    cleanup_ctx->qp = self->qp;
+    ucs_assert(UCS_CIRCULAR_COMPARE16(self->txcnt.pi, >=, self->txcnt.ci));
+    uct_rc_ep_cleanup_qp(&self->super, &cleanup_ctx->super, self->qp->qp_num,
+                         self->txcnt.pi - self->txcnt.ci);
 }
 
 UCS_CLASS_DEFINE(uct_rc_verbs_ep_t, uct_rc_ep_t);


### PR DESCRIPTION
## Why
- Handle rc_mlx5 error CQEs which arrive after endpoint id destroyed
- Fix potential reorder in rc_verbs when releasing CQ resources without arbiter dispatch (during ep destroy)

## How
- Refactor RC cleanup so it will always happen from the progress queue
- Release CQ resources from RC cleanup context and dispatch arbiter
- mlx5: keep one CQ credit for each posted WQE to be released when the CQE eventually arrives. This is needed to avoid CQ overrun if CQ credits are released too soon (for verbs, ibv_destroy_qp would remove CQE entries)

## Details
Since we count CQ credits by building blocks[1], if we have a completion without an associated endpoint, we cannot know how many CQ credits to return. On the other hand, can't release all credits during EP destroy since completions did not arrive and it may cause CQ overrun.

[1] If we change the code to consume 1 CQ credit for each WQE, would need to maintain an array for post-send and poll_cq, which stores how many unsignaled WQEs are before each signaled one.