### PR TITLE
TEST: Improvements for gtest with valgrind

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -304,3 +304,18 @@
    Memcheck:Cond
    fun:xpmem_get
 }
+{
+   libc_resolv_leak
+   Memcheck:Leak
+   ...
+   fun:__resolv_conf_allocate
+   fun:__resolv_conf_load
+   ...
+   fun:__resolv_context_get
+}
+{
+   libnl_trans
+   Memcheck:Leak
+   ...
+   fun:__trans_list_add
+}

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -204,7 +204,9 @@ test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsi
         params.max_iter    = test.iters;
     } else {
         params.warmup_iter = 0;
-        params.max_iter    = ucs_min(20u, test.iters / ucs::test_time_multiplier());
+        params.max_iter    = ucs_min(20u, test.iters /
+                                                  ucs::test_time_multiplier() /
+                                                  ucs::test_time_multiplier());
     }
     params.max_time        = 0.0;
     params.report_interval = 1.0;

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -740,7 +740,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
 
     /* small sizes should warm-up tag cache */
     for (unsigned i = 0; i < ucs_static_array_size(sizes); ++i) {
-        const size_t size = sizes[i] / ucs::test_time_multiplier();
+        const size_t size = sizes[i] / ucs::test_time_multiplier() /
+                            ucs::test_time_multiplier();
         request *my_send_req, *my_recv_req;
 
         std::vector<char> sendbuf(size, 0);

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -245,7 +245,7 @@ UCS_TEST_F(test_mpool, leak_check) {
     ucs_mpool_cleanup(&mp, 1);
 }
 
-UCS_TEST_F(test_mpool, alloc_4g) {
+UCS_TEST_SKIP_COND_F(test_mpool, alloc_4g, RUNNING_ON_VALGRIND) {
     const unsigned elems_per_chunk = 128;
     const size_t elem_size         = 32 * UCS_MBYTE;
     ucs_mpool_ops_t mpool_ops = {ucs_mpool_chunk_malloc, ucs_mpool_chunk_free,


### PR DESCRIPTION
# Why
- Reduce testing time with valgrind to prevent kill by timeout
- Add some suppressions to fix [valgrind failures](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=20810&view=logs&jobId=df68dda4-06c2-536e-ce97-89c9eb16a9f6&j=df68dda4-06c2-536e-ce97-89c9eb16a9f6&t=8fc70d47-5a35-50c6-bed4-97d5d142cf9e)