### PR TITLE
UCP/CORE: Add assertion that request hasn't been completed yet

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -65,7 +65,11 @@
     { \
         /* NOTE: external request can't have RELEASE flag and we */ \
         /* will never put it into mpool */ \
-        uint32_t _flags = ((_req)->flags |= UCP_REQUEST_FLAG_COMPLETED); \
+        uint32_t _flags; \
+        \
+        ucs_assert(!((_req)->flags & UCP_REQUEST_FLAG_COMPLETED)); \
+        \
+        _flags         = ((_req)->flags |= UCP_REQUEST_FLAG_COMPLETED); \
         (_req)->status = (_status); \
         \
         ucp_request_id_check(_req, ==, UCS_PTR_MAP_KEY_INVALID); \


### PR DESCRIPTION
## What

Add assertion that request hasn't been completed yet.

## Why ?

To debug the possible issue when completing receive operations more than once.

## How ?

Before setting `UCP_REQUEST_FLAG_COMPLETED` check that it is not set for the request.