### PR TITLE
UCP/CORE/WIREUP: Destroy UCT EP before destroying UCP EP in discarding

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2222,7 +2222,6 @@ static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
     req->send.discard_uct_ep.cb_id = UCS_CALLBACKQ_ID_NULL;
 
     UCS_ASYNC_BLOCK(&worker->async);
-    ucp_worker_discard_uct_ep_complete(req);
     iter = kh_get(ucp_worker_discard_uct_ep_hash, &worker->discard_uct_ep_hash,
                   uct_ep);
     if (iter == kh_end(&worker->discard_uct_ep_hash)) {
@@ -2230,11 +2229,12 @@ static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
                   uct_ep, worker);
     }
 
+    uct_ep_destroy(uct_ep);
+    ucp_worker_discard_uct_ep_complete(req);
+
     ucs_assert(kh_value(&worker->discard_uct_ep_hash, iter) == req);
     kh_del(ucp_worker_discard_uct_ep_hash, &worker->discard_uct_ep_hash, iter);
     UCS_ASYNC_UNBLOCK(&worker->async);
-
-    uct_ep_destroy(uct_ep);
 
     return 1;
 }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -485,7 +485,6 @@ ucp_cm_client_resolve_cb(void *user_data, const uct_cm_ep_resolve_args_t *args)
     ucp_wireup_ep_t *cm_wireup_ep;
     char addr_str[UCS_SOCKADDR_STRING_LEN];
 
-    UCS_ASYNC_BLOCK(&worker->async);
     ucs_assert_always(args->field_mask & UCT_CM_EP_RESOLVE_ARGS_FIELD_DEV_NAME);
 
     UCP_EP_CM_CALLBACK_ENTER(ep, ucp_ep_get_cm_uct_ep(ep),
@@ -529,7 +528,6 @@ ucp_cm_client_resolve_cb(void *user_data, const uct_cm_ep_resolve_args_t *args)
     ucp_worker_signal_internal(worker);
 
 out:
-    UCS_ASYNC_UNBLOCK(&worker->async);
     return status;
 }
 
@@ -743,9 +741,7 @@ err_free_sa_data:
 err_free_arg:
     ucs_free(progress_arg);
 err_out:
-    UCS_ASYNC_BLOCK(&worker->async);
     ucp_ep_set_failed_schedule(ucp_ep, ucp_ep_get_cm_lane(ucp_ep), status);
-    UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
 static void ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)


### PR DESCRIPTION
## What

Destroy UCT EP before destroying UCP EP in discarding.

## Why ?

to fix the following data race:
```
Thread 2 (Thread 0x7fd346f1d780 (LWP 174140)):
#0  0x00007fd345b2b4b2 in pthread_spin_lock () from /lib64/libpthread.so.0
#1  0x00007fd3427ddf44 in ucs_spin_lock (lock=0x142d028)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/ucs/type/spinlock.h:83
#2  0x00007fd3427ddf91 in ucs_recursive_spin_lock (lock=0x142d028)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/ucs/type/spinlock.h:95
#3  0x00007fd3427e1b3e in uct_rdmacm_cm_ep_t_cleanup (self=0x15e3700) at rdmacm_cm_ep.c:704
#4  0x00007fd3467f5de0 in ucs_class_call_cleanup_chain (cls=0x7fd3429e6820 <uct_rdmacm_cm_ep_t_class>, obj=0x15e3700, limit=-1) at type/class.c:56
#5  0x00007fd3427e1e5b in uct_rdmacm_cm_ep_t_delete (self=0x15e3700) at rdmacm_cm_ep.c:717
#6  0x00007fd346180ccb in uct_ep_destroy (ep=0x15e3700) at base/uct_iface.c:550
#7  0x00007fd346422c1a in ucp_worker_discard_uct_ep_destroy_progress (arg=0x30c33000) at core/ucp_worker.c:2237
#8  0x00007fd3467cbb90 in ucs_callbackq_slow_proxy (arg=0x13b5a40) at datastruct/callbackq.c:402
#9  0x00007fd346417643 in ucs_callbackq_dispatch (cbq=0x13b5a40)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
#10 0x00007fd346423d53 in uct_worker_progress (worker=0x13b5a40)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
#11 ucp_worker_progress (worker=0x142d020) at core/ucp_worker.c:2489
#12 0x00000000004049e6 in UcxContext::progress_worker_event (this=0x7fff69c098b0) at ucx_wrapper.cc:386
#13 0x0000000000404112 in UcxContext::progress (this=0x7fff69c098b0) at ucx_wrapper.cc:225
#14 0x00000000004144e6 in DemoClient::wait_for_responses (this=0x7fff69c098b0, max_outstanding=0) at io_demo.cc:1625
#15 0x0000000000415695 in DemoClient::run (this=0x7fff69c098b0) at io_demo.cc:1868
#16 0x000000000040e7de in do_client (test_opts=...) at io_demo.cc:2420
#17 0x000000000040ebd2 in main (argc=57, argv=0x7fff69c0a038) at io_demo.cc:2463

Thread 1 (Thread 0x7fd341da3700 (LWP 174340)):
#0  0x00007fd344947207 in raise () from /lib64/libc.so.6
#1  0x00007fd3449488f8 in abort () from /lib64/libc.so.6
#2  0x00007fd3467d6965 in ucs_fatal_error_message (
    file=0x7fd3465576d8 "/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.inl", line=165,
    function=0x7fd3465591b0 <__FUNCTION__.14656> "ucp_ep_update_flags", message_buf=0x7fd341da2130 "Assertion `ucs_async_is_blocked(&(ep->worker)->async)' failed") at debug/assert.c:38
#3  0x00007fd3467d6ae0 in ucs_fatal_error_format (
    file=0x7fd3465576d8 "/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.inl", line=165,
    function=0x7fd3465591b0 <__FUNCTION__.14656> "ucp_ep_update_flags", format=0x7fd3465574a5 "Assertion `%s' failed") at debug/assert.c:53
#4  0x00007fd34650d8c1 in ucp_ep_update_flags (flags_remove=0, flags_add=8388608, ep=0x7fd3406e20a0)
    at /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210711_081125_22405_47588_jazz11.swx.labs.mlnx/installs/TfJU/tests/io_demo/ucx.git/src/ucp/core/ucp_ep.inl:165
#5  ucp_cm_client_connect_cb (uct_cm_ep=0x15e3700, arg=0x7fd3406e20a0, connect_args=0x7fd341da27b0) at wireup/wireup_cm.c:674
#6  0x00007fd34618373a in uct_cm_ep_client_connect_cb (cep=0x15e3700, remote_data=0x7fd341da2830, status=UCS_OK) at base/uct_cm.c:122
#7  0x00007fd3427de2ce in uct_rdmacm_cm_ep_client_connect_cb (cep=0x15e3700, remote_data=0x7fd341da2830, status=UCS_OK) at rdmacm_cm_ep.c:68
#8  0x00007fd3427dbf8b in uct_rdmacm_cm_handle_event_connect_response (event=0x7fd3300008c0) at rdmacm_cm.c:569
#9  0x00007fd3427dc609 in uct_rdmacm_cm_process_event (cm=0x13f6010, event=0x7fd3300008c0) at rdmacm_cm.c:717
#10 0x00007fd3427dc96f in uct_rdmacm_cm_event_handler (fd=25, events=1 '\001', arg=0x13f6010) at rdmacm_cm.c:776
#11 0x00007fd3467bd73e in ucs_async_handler_invoke (handler=0x1493df0, events=1 '\001') at async/async.c:251
#12 0x00007fd3467bd83b in ucs_async_handler_dispatch (handler=0x1493df0, events=1 '\001') at async/async.c:273
#13 0x00007fd3467bda78 in ucs_async_dispatch_handlers (handler_ids=0x7fd341da2cd0, count=1, events=1 '\001') at async/async.c:305
#14 0x00007fd3467c1acf in ucs_async_thread_ev_handler (callback_data=0x19, events=1 '\001', arg=0x7fd341da2e60) at async/thread.c:87
#15 0x00007fd3467eaab6 in ucs_event_set_wait (event_set=0x13beb10, num_events=0x7fd341da2e7c, timeout_ms=-1, event_set_handler=0x7fd3467c19cd <ucs_async_thread_ev_handler>, arg=0x7fd341da2e60)
    at sys/event_set.c:215
#16 0x00007fd3467c1c0a in ucs_async_thread_func (arg=0x13be880) at async/thread.c:130
#17 0x00007fd345b26dd5 in start_thread () from /lib64/libpthread.so.0
```

`Thread 2` is destroying CM UCT EP from discarding callback while `Thread 1` handles `RDMA_CM_EVENT_CONNECT_RESPONSE` event by calling `uct_cm_ep_client_connect_cb()` from RDMACM. `uct_cm_ep_client_connect_cb()` touches UCP EP which has already been destroyed in `ucp_worker_discard_uct_ep_destroy_progress()` before calling `uct_ep_destroy()` for CM UCT EP.

## How ?

1. Call `uct_ep_destroy()` before completing discarding request and destroying UCP EP.
2. Remove unnecessary async block/unblock in CM callbacks. CM UCT EP locks them before calling a callback.