### PR TITLE
AZP: fix JUCX publish.

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -111,3 +111,8 @@ stages:
     jobs:
       - template: az-distro-release.yml
       - template: jucx/jucx-publish.yml
+        parameters:
+          ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+            target: publish-release
+          ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+            target: package

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -25,4 +25,5 @@ stages:
     dependsOn: Check_Commit
     jobs:
       - template: jucx/jucx-publish.yml
-
+        parameters:
+          target: publish-snapshot

--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -1,6 +1,7 @@
 parameters:
   temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/tmp-settings.xml
   gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg
+  target: package
 
 jobs:
   - job: jucx_release
@@ -12,14 +13,6 @@ jobs:
 
     # we need to use lowest version for compatible
     container: centos7_cuda10_1
-
-    variables:
-      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-        target: publish-release
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        target: package
-      ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
-        target: publish-snapshot
 
     steps:
       - checkout: self


### PR DESCRIPTION
## What
Reverts jucx changes on #7081 

## Why ?
https://search.maven.org/artifact/org.openucx/jucx - it publishes to maven central except of snapshot on master merge. 
Master merge triggers by `Individual CI`: 
![image](https://user-images.githubusercontent.com/1121987/125310130-fc928080-e33a-11eb-863d-92734714ff49.png)

Need to publish release only when tag is created, otherwise publish to snapshot.

Thanks, @abellina for mentioning it.