### PR TITLE
APPS/IO-DEMO: Fix reporting throughput

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1957,7 +1957,8 @@ private:
             first_print = false;
 
             // Report bandwidth
-            double throughput_mbs = total_bytes[op_id] / UCS_MBYTE / elapsed;
+            double throughput_mbs = (total_bytes[op_id] / elapsed) /
+                                    UCS_MBYTE;
             log << io_op_names[op_id] << " " << throughput_mbs << " MBs";
             total_bytes[op_id] = 0;
 


### PR DESCRIPTION
## What

Fix reporting throughput.

## Why ?

To fix:
```
==============================
Client Errors:
==============================
Log: /hpc/mtr_scrap/evgenylek/nb/ucx/1626161159-379977119/iodemo_jazz17_client_03.log
Error iodemo analyzer: Have 'read' zero speed:
Line [1626161929.197692] [DEMO] read 0 MBs min:0(2.1.3.15:20022) max:1 total:4 | write 0.0498737 MBs min:0(2.1.3.15:20022) max:1 total:6 | active:94/96 b
uffers:1024
```

## How ?

Need to cast to double to report correct performance data instead of 0 MBs.