### PR TITLE
UCT/TCP: Increase keepalive interval from 1 to 2 seconds and use system default for keepalive retries count

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -65,7 +65,7 @@
 #define UCT_TCP_EP_DEFAULT_KEEPALIVE_IDLE    10
 
 /* The seconds between individual keepalive probes */
-#define UCT_TCP_EP_DEFAULT_KEEPALIVE_INTVL   1
+#define UCT_TCP_EP_DEFAULT_KEEPALIVE_INTVL   2
 
 
 /**
@@ -402,7 +402,7 @@ typedef struct uct_tcp_iface {
             ucs_time_t            idle;              /* The time the connection needs to remain
                                                       * idle before TCP starts sending keepalive
                                                       * probes (TCP_KEEPIDLE socket option) */
-            unsigned              cnt;               /* The maximum number of keepalive probes TCP
+            unsigned long         cnt;               /* The maximum number of keepalive probes TCP
                                                       * should send before dropping the connection
                                                       * (TCP_KEEPCNT socket option). */
             ucs_time_t            intvl;             /* The time between individual keepalive
@@ -440,7 +440,7 @@ typedef struct uct_tcp_iface_config {
     ucs_range_spec_t               port_range;
     struct {
         ucs_time_t                 idle;
-        unsigned                   cnt;
+        unsigned long              cnt;
         ucs_time_t                 intvl;
     } keepalive;
 } uct_tcp_iface_config_t;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -89,18 +89,19 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
 #ifdef UCT_TCP_EP_KEEPALIVE
   {"KEEPIDLE", UCS_PP_MAKE_STRING(UCT_TCP_EP_DEFAULT_KEEPALIVE_IDLE) "s",
    "The time the connection needs to remain idle before TCP starts sending "
-   "keepalive probes.",
+   "keepalive probes. Specifying \"inf\" disables keepalive.",
    ucs_offsetof(uct_tcp_iface_config_t, keepalive.idle),
                 UCS_CONFIG_TYPE_TIME_UNITS},
 
-  {"KEEPCNT", "3",
+  {"KEEPCNT", "auto",
    "The maximum number of keepalive probes TCP should send before "
-   "dropping the connection.",
+   "dropping the connection. Specifying \"inf\" disables keepalive.",
    ucs_offsetof(uct_tcp_iface_config_t, keepalive.cnt),
-                UCS_CONFIG_TYPE_UINT},
+                UCS_CONFIG_TYPE_ULUNITS},
 
   {"KEEPINTVL", UCS_PP_MAKE_STRING(UCT_TCP_EP_DEFAULT_KEEPALIVE_INTVL) "s",
-   "The time between individual keepalive probes.",
+   "The time between individual keepalive probes. Specifying \"inf\" disables"
+   " keepalive.",
    ucs_offsetof(uct_tcp_iface_config_t, keepalive.intvl),
                 UCS_CONFIG_TYPE_TIME_UNITS},
 #endif /* UCT_TCP_EP_KEEPALIVE */
@@ -872,7 +873,7 @@ int uct_tcp_keepalive_is_enabled(uct_tcp_iface_t *iface)
 {
 #ifdef UCT_TCP_EP_KEEPALIVE
     return (iface->config.keepalive.idle != UCS_TIME_INFINITY) &&
-           (iface->config.keepalive.cnt != 0) &&
+           (iface->config.keepalive.cnt != UCS_ULUNITS_INF) &&
            (iface->config.keepalive.intvl != UCS_TIME_INFINITY);
 #else /* UCT_TCP_EP_KEEPALIVE */
     return 0;


### PR DESCRIPTION
## What

Increase keepalive interval from 1 to 2 seconds and use system default for keepalive retries count.

## Why ?

Fixes #6705.
Fixes #6471.
When the large amount of connections are started simultaneously, it leads to network congestions and some TCP EPs are failed, because they don't receive ACK on previously sent KEEPALIVE packet. Increasing timeout helps to resolve the issue. `1s` timeout between retries is too small one.

## How ?

1. Change value of `UCT_TCP_EP_DEFAULT_KEEPALIVE_INTVL` from `1` to `2`.
2. Update KEEPCNT configuration parameter to be ULUNITS and set `"auto"` as a default value. Handle it when setting socket options for KA.