### PR TITLE
BUILD: Help cmake find UCX on system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ test/apps/iodemo/io_demo
 test/apps/test_cuda_hook_dynamic
 test/apps/test_memtrack_limit
 test/apps/profiling/ucx_profiling
+cmake/*.cmake

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,8 @@ SUBDIRS += \
 	bindings/go \
 	bindings/java \
 	test/apps \
-	examples
+	examples \
+	cmake
 
 if HAVE_GTEST
 SUBDIRS += test/gtest

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -319,6 +319,36 @@ check_config_h() {
 }
 
 #
+# Test if cmake can correctly find and link ucx
+#
+build_cmake_examples() {
+	echo "==== Build CMake sample ===="
+
+	if which cmake
+	then
+		${WORKSPACE}/contrib/configure-release --prefix=$ucx_inst
+		$MAKEP
+		$MAKEP install
+
+		mkdir -p /tmp/cmake-ucx
+		pushd /tmp/cmake-ucx
+		cmake ${WORKSPACE}/examples/cmake -DCMAKE_PREFIX_PATH=$ucx_inst
+		cmake --build .
+
+		if ./test_ucp && ./test_uct
+		then
+			echo "Check successful "
+		else
+			azure_log_error "CMake test failed."
+			exit 1
+		fi
+		popd
+	else
+		azure_log_warning "cmake executable not found, skipping cmake test"
+	fi
+}
+
+#
 # Do a given task and update progress indicator
 #
 do_task() {
@@ -347,6 +377,7 @@ do_task "${prog}" build_disable_numa
 do_task "${prog}" build_cuda
 do_task "${prog}" build_no_verbs
 do_task "${prog}" build_release_pkg
+do_task "${prog}" build_cmake_examples
 
 if [ "${long_test}" = "yes" ]
 then

--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -1,0 +1,13 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+cmakedir = $(libdir)/cmake/ucx
+cmake_DATA = \
+    ucx-targets.cmake \
+    ucx-config.cmake \
+    ucx-config-version.cmake
+
+EXTRA_DIST = $(cmake_DATA)

--- a/cmake/ucx-config-version.cmake.in
+++ b/cmake/ucx-config-version.cmake.in
@@ -1,0 +1,33 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+# This is a basic version file for the Config-mode of find_package().
+#
+# This file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version.
+
+set(PACKAGE_VERSION @VERSION@)
+
+if (PACKAGE_FIND_VERSION_RANGE)
+  # Package version must be in the requested version range
+  if ((PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+      OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND PACKAGE_VERSION VERSION_GREATER_EQUAL PACKAGE_FIND_VERSION_MAX))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
+else()
+  if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()

--- a/cmake/ucx-config.cmake.in
+++ b/cmake/ucx-config.cmake.in
@@ -1,0 +1,10 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+include("${CMAKE_CURRENT_LIST_DIR}/ucx-targets.cmake")
+
+set(UCX_LIBRARIES "@libdir@")
+set(UCX_INCLUDE_DIRS "@includedir@")

--- a/cmake/ucx-targets.cmake.in
+++ b/cmake/ucx-targets.cmake.in
@@ -1,0 +1,29 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+set(prefix "@prefix@")
+set(exec_prefix "@exec_prefix@")
+
+add_library(ucx::ucs SHARED IMPORTED)
+
+set_target_properties(ucx::ucs PROPERTIES
+  IMPORTED_LOCATION "@libdir@/libucs.so"
+  INTERFACE_INCLUDE_DIRECTORIES "@includedir@"
+)
+
+add_library(ucx::ucp SHARED IMPORTED)
+
+set_target_properties(ucx::ucp PROPERTIES
+  IMPORTED_LOCATION "@libdir@/libucp.so"
+  INTERFACE_INCLUDE_DIRECTORIES "@includedir@"
+)
+
+add_library(ucx::uct SHARED IMPORTED)
+
+set_target_properties(ucx::uct PROPERTIES
+  IMPORTED_LOCATION "@libdir@/libuct.so"
+  INTERFACE_INCLUDE_DIRECTORIES "@includedir@"
+)

--- a/configure.ac
+++ b/configure.ac
@@ -381,6 +381,10 @@ AC_CONFIG_FILES([
                  bindings/java/pom.xml
                  bindings/java/src/main/native/Makefile
                  examples/Makefile
+                 cmake/Makefile
+                 cmake/ucx-config-version.cmake
+                 cmake/ucx-config.cmake
+                 cmake/ucx-targets.cmake
                  ])
 
 AC_CONFIG_FILES([test/mpi/run_mpi.sh], [chmod a+x test/mpi/run_mpi.sh])

--- a/examples/cmake/CMakeLists.txt
+++ b/examples/cmake/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+cmake_minimum_required(VERSION 2.8)
+
+project(test_ucx)
+
+find_package(UCX REQUIRED COMPONENTS ucp uct ucs)
+
+add_executable(test_ucp test_ucp.c)
+target_link_libraries(test_ucp ucx::ucp)
+
+add_executable(test_uct test_uct.c)
+target_link_libraries(test_uct ucx::uct ucx::ucs)

--- a/examples/cmake/test_ucp.c
+++ b/examples/cmake/test_ucp.c
@@ -1,0 +1,24 @@
+/**
+* Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include <ucp/api/ucp.h>
+#include <assert.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    ucp_params_t ucp_params = {};
+    ucp_context_h ucp_context;
+    ucs_status_t status;
+
+    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ucp_params.features   = UCP_FEATURE_AM;
+    status = ucp_init(&ucp_params, NULL, &ucp_context);
+    assert(status == UCS_OK);
+
+    ucp_cleanup(ucp_context);
+    return 0;
+}

--- a/examples/cmake/test_uct.c
+++ b/examples/cmake/test_uct.c
@@ -1,0 +1,27 @@
+/**
+* Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#include <uct/api/uct.h>
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+    ucs_async_context_t *async;
+    uct_worker_h worker;
+
+    /* Initialize context */
+    ucs_status_t status = ucs_async_context_create(UCS_ASYNC_MODE_THREAD_SPINLOCK, &async);
+    assert(UCS_OK == status);
+
+    /* Create a worker object */
+    status = uct_worker_create(async, UCS_THREAD_MODE_SINGLE, &worker);
+    assert(UCS_OK == status);
+
+    /* Cleanup */
+    uct_worker_destroy(worker);
+    ucs_async_context_destroy(async);
+    return 0;
+}

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -134,6 +134,7 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.a
 %{_includedir}/uc*
 %{_libdir}/lib*.so
 %{_libdir}/pkgconfig/ucx.pc
+%{_libdir}/cmake/ucx/*.cmake
 %{_datadir}/ucx/examples
 
 %post


### PR DESCRIPTION
This PR makes the installation script writes cmake config files to ${prefix}/lib/cmake/ucx so that cmake projects can easily find UCX installed on the system. PyTorch uses cmake, so this will be helpful for PyTorch to integrate the ucx/ucc backend to upstream.

This PR is tested by: https://github.com/zasdfgbnm/cmake-ucx-ucc, please let me know if you want cmake testes to be included in this repository as well.

Related: https://github.com/openucx/ucc/pull/255