### PR TITLE
UCP/CORE/PROTO: Remove unused flags in pending_add wrapper

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -914,7 +914,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
      * If it is completed immediately, release the request and return the status.
      * Otherwise, return the request.
      */
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucp_request_imm_cmpl_param(param, req, send);
     }

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -250,7 +250,7 @@ ucs_mpool_ops_t ucp_rndv_get_mpool_ops = {
     .obj_cleanup   = NULL
 };
 
-int ucp_request_pending_add(ucp_request_t *req, unsigned pending_flags)
+int ucp_request_pending_add(ucp_request_t *req)
 {
     ucs_status_t status;
     uct_ep_h uct_ep;
@@ -259,7 +259,7 @@ int ucp_request_pending_add(ucp_request_t *req, unsigned pending_flags)
                 ucs_debug_get_symbol_name(req->send.uct.func));
 
     uct_ep = req->send.ep->uct_eps[req->send.lane];
-    status = uct_ep_pending_add(uct_ep, &req->send.uct, pending_flags);
+    status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
     if (status == UCS_OK) {
         ucs_trace_data("ep %p: added pending uct request %p to lane[%d]=%p",
                        req->send.ep, req, req->send.lane, uct_ep);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -429,7 +429,7 @@ extern ucs_mpool_ops_t ucp_rndv_get_mpool_ops;
 extern const ucp_request_param_t ucp_request_null_param;
 
 
-int ucp_request_pending_add(ucp_request_t *req, unsigned pending_flags);
+int ucp_request_pending_add(ucp_request_t *req);
 
 ucs_status_t ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                                     void *buffer, size_t length, ucp_datatype_t datatype,

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -291,8 +291,7 @@ static UCS_F_ALWAYS_INLINE void ucp_request_mem_free(ucp_request_t *req)
  * @return Whether completed.
  *         *req_status if filled with the completion status if completed.
  */
-static int UCS_F_ALWAYS_INLINE
-ucp_request_try_send(ucp_request_t *req, unsigned pending_flags)
+static int UCS_F_ALWAYS_INLINE ucp_request_try_send(ucp_request_t *req)
 {
     ucs_status_t status;
 
@@ -307,7 +306,7 @@ ucp_request_try_send(ucp_request_t *req, unsigned pending_flags)
         return 0;
     } else if (status == UCS_ERR_NO_RESOURCE) {
         /* No send resources, try to add to pending queue */
-        return ucp_request_pending_add(req, pending_flags);
+        return ucp_request_pending_add(req);
     }
 
     ucs_fatal("unexpected error: %s", ucs_status_string(status));
@@ -317,13 +316,11 @@ ucp_request_try_send(ucp_request_t *req, unsigned pending_flags)
  * Start sending a request.
  *
  * @param [in]  req             Request to start.
- * @param [in]  pending_flags   flags to be passed to UCT if request will be
- *                              added to pending queue.
  * */
 static UCS_F_ALWAYS_INLINE void
-ucp_request_send(ucp_request_t *req, unsigned pending_flags)
+ucp_request_send(ucp_request_t *req)
 {
-    while (!ucp_request_try_send(req, pending_flags));
+    while (!ucp_request_try_send(req));
 }
 
 static UCS_F_ALWAYS_INLINE

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -101,7 +101,7 @@ ucs_status_t ucp_do_am_bcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
             if ((packed_len == UCS_ERR_NO_RESOURCE) &&
                 (req->send.lane != req->send.pending_lane)) {
                 /* switch to new pending lane */
-                pending_add_res = ucp_request_pending_add(req, 0);
+                pending_add_res = ucp_request_pending_add(req);
                 if (!pending_add_res) {
                     /* failed to switch req to pending queue, try again */
                     continue;
@@ -449,7 +449,7 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
         if (status == UCS_ERR_NO_RESOURCE) {
             if (req->send.lane != req->send.pending_lane) {
                 /* switch to new pending lane */
-                pending_add_res = ucp_request_pending_add(req, 0);
+                pending_add_res = ucp_request_pending_add(req);
                 if (!pending_add_res) {
                     /* failed to switch req to pending queue, try again */
                     continue;

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -168,7 +168,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
         goto out_put_request;
     }
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         goto out_put_request;
     }

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -261,7 +261,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
         req->send.atomic_reply.remote_req_id = atomicreqh->req.req_id;
         req->send.length                     = atomicreqh->length;
         req->send.uct.func                   = ucp_progress_atomic_reply;
-        ucp_request_send(req, 0);
+        ucp_request_send(req);
     }
 
     return UCS_OK;

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -20,7 +20,7 @@ ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 {
     ucs_status_t status;
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     status = req->status;
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
@@ -39,7 +39,7 @@ ucp_rma_send_request_cb(ucp_request_t *req, ucp_send_callback_t cb)
 static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
 ucp_rma_send_request(ucp_request_t *req, const ucp_request_param_t *param)
 {
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucp_request_imm_cmpl_param(param, req, send);

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -139,7 +139,7 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
     req->flags         = 0;
     req->send.ep       = ep;
     req->send.uct.func = ucp_progress_rma_cmpl;
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_put_handler, (arg, data, length, am_flags),
@@ -250,7 +250,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
         req->send.mem_type = UCS_MEMORY_TYPE_HOST;
     }
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     return UCS_OK;
 }
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -404,7 +404,7 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
                   req->send.rndv.remote_req_id,
                   req->send.proto_config->proto->name);
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     return UCS_OK;
 
 err_destroy_rkey:

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -286,7 +286,7 @@ void ucp_rndv_req_send_ack(ucp_request_t *ack_req, ucp_request_t *req,
     ucp_request_send_state_reset(ack_req, NULL,
                                  UCP_REQUEST_SEND_PROTO_BCOPY_AM);
 
-    ucp_request_send(ack_req, 0);
+    ucp_request_send(ack_req);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -389,7 +389,7 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_request_set_super(rndv_req, rreq);
     ucp_send_request_id_alloc(rndv_req);
 
-    ucp_request_send(rndv_req, 0);
+    ucp_request_send(rndv_req);
 }
 
 static ucp_lane_index_t ucp_rndv_zcopy_get_lane(ucp_request_t *rndv_req,
@@ -525,7 +525,7 @@ ucp_rndv_progress_rma_zcopy_common(ucp_request_t *req, ucp_lane_index_t lane,
         } else if (status == UCS_ERR_NO_RESOURCE) {
             if (lane != req->send.pending_lane) {
                 /* switch to new pending lane */
-                pending_add_res = ucp_request_pending_add(req, 0);
+                pending_add_res = ucp_request_pending_add(req);
                 if (!pending_add_res) {
                     /* failed to switch req to pending queue, try again */
                     continue;
@@ -788,7 +788,7 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
     }
 
     UCP_WORKER_STAT_RNDV(ep->worker, GET_ZCOPY, 1);
-    ucp_request_send(rndv_req, 0);
+    ucp_request_send(rndv_req);
 
     return UCS_OK;
 
@@ -909,7 +909,7 @@ ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *freq,
     ucp_rndv_req_init_zcopy_lane_map(freq, freq->send.mem_type,
                                      UCP_REQUEST_SEND_PROTO_RNDV_PUT);
 
-    ucp_request_send(freq, 0);
+    ucp_request_send(freq);
 }
 
 static void
@@ -988,7 +988,7 @@ ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
     UCP_WORKER_STAT_RNDV(freq->send.ep->worker, GET_ZCOPY, 1);
 
     freq->status = UCS_INPROGRESS;
-    ucp_request_send(freq, 0);
+    ucp_request_send(freq);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_rndv_recv_frag_get_completion, (self),
@@ -1689,7 +1689,7 @@ UCS_PROFILE_FUNC_VOID(ucp_rndv_put_pipeline_frag_get_completion, (self),
     freq->send.lane                      = fsreq->send.lane;
     freq->send.state.dt.dt.contig.md_map = 0;
 
-    ucp_request_send(freq, 0);
+    ucp_request_send(freq);
 }
 
 static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
@@ -1789,7 +1789,7 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
             freq->send.mdesc        = NULL;
             freq->send.pending_lane = UCP_NULL_LANE;
 
-            ucp_request_send(freq, 0);
+            ucp_request_send(freq);
         } else {
             ucp_rndv_send_frag_get_mem_type(
                     fsreq, length,
@@ -1970,7 +1970,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
 out_send:
     /* if it is not a PUT pipeline protocol, delete the send request ID */
     ucp_send_request_id_release(sreq);
-    ucp_request_send(sreq, 0);
+    ucp_request_send(sreq);
     return UCS_OK;
 }
 

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -59,7 +59,7 @@ static void ucp_proto_rndv_get_completion(uct_completion_t *uct_comp)
                                           send.state.uct_comp);
 
     ucp_trace_req(req, "%s completed", req->send.proto_config->proto->name);
-    ucp_request_send(req, 0); /* reschedule to send ATS */
+    ucp_request_send(req); /* reschedule to send ATS */
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_zcopy_send_func(

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -77,7 +77,7 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
      * If it is completed immediately, release the request and return the status.
      * Otherwise, return the request.
      */
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucp_request_imm_cmpl_param(param, req, send);
     }

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -334,5 +334,5 @@ void ucp_tag_eager_sync_send_ack(ucp_worker_h worker, void *hdr, uint16_t recv_f
 
     ucs_trace_req("send_sync_ack req %p ep %p", req, req->send.ep);
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
 }

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -747,7 +747,7 @@ void ucp_tag_offload_sync_send_ack(ucp_worker_h worker, ucs_ptr_map_key_t ep_id,
     ucs_trace_req("tag_offload send_sync_ack ep_id 0x%lx tag %"PRIx64, ep_id,
                   stag);
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
 }
 
 const ucp_request_send_proto_t ucp_tag_offload_sync_proto = {

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -113,7 +113,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
      * release the request and return the status.
      * Otherwise, return the request.
      */
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         ucp_request_imm_cmpl_param(param, req, send);
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -248,7 +248,7 @@ ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, const ucp_tl_bitmap_t *tl_bitmap,
         goto err;
     }
 
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
     /* coverity[leaked_storage] */
     return UCS_OK;
 
@@ -835,7 +835,7 @@ ucp_wireup_replay_pending_request(uct_pending_req_t *self, void *arg)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
     ucs_assert(req->send.ep == (ucp_ep_h)arg);
-    ucp_request_send(req, 0);
+    ucp_request_send(req);
 }
 
 void ucp_wireup_replay_pending_requests(ucp_ep_h ucp_ep,


### PR DESCRIPTION
## What

Remove unused flags in pending_add wrapper/

## Why ?

All functions pass `0` as `pending_flags` argument to `ucp_request_pending_add()`.

## How ?

1. Remove `pending_flags` argument for `ucp_request_pending_add()`, `ucp_request_send()`, `ucp_request_try_send()`.
2. Remove passing the second argument to these functions in all places where they are called.