### PR TITLE
UCT/SOCKCM: suppress EHOSTUNREACH

### DIFF
--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -73,8 +73,9 @@ static ucs_status_t uct_tcp_sockcm_event_err_to_ucs_err_log(int fd,
         *log_level = UCS_LOG_LEVEL_DEBUG;
         return UCS_ERR_CONNECTION_RESET;
     case ENETUNREACH:
+    case EHOSTUNREACH:
     case ETIMEDOUT:
-        *log_level = UCS_LOG_LEVEL_DEBUG;
+        *log_level = UCS_LOG_LEVEL_DIAG;
         return UCS_ERR_UNREACHABLE;
     default:
         goto err;


### PR DESCRIPTION
## What
suppress EHOSTUNREACH error message

## Why ?
this error can be handled by user via return code

## How ?
decrease log level