### PR TITLE
UCT/IFACE: verbose AM CB return assert

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -764,8 +764,12 @@ uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
 
     handler = &iface->am[id];
     status = handler->cb(handler->arg, data, length, flags);
-    ucs_assert((status == UCS_OK) ||
-               ((status == UCS_INPROGRESS) && (flags & UCT_CB_PARAM_FLAG_DESC)));
+    ucs_assertv((status == UCS_OK) ||
+                ((status == UCS_INPROGRESS) && (flags &
+                                                UCT_CB_PARAM_FLAG_DESC)),
+                "%s(arg=%p data=%p length=%u flags=0x%x) returned %s",
+                ucs_debug_get_symbol_name((void*)handler->cb), handler->arg,
+                data, length, flags, ucs_status_string(status));
     return status;
 }
 


### PR DESCRIPTION
## What
verbose AM CB return assert

## Why ?
to simplify debugging
cherry-picked from https://github.com/yosefe/ucx/pull/162
