### PR TITLE
GTEST/UCM/ROCM: Fix hipMallocManaged hook gtest

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -71,6 +71,20 @@ bool mem_buffer::is_gpu_supported()
     return is_cuda_supported() || is_rocm_supported();
 }
 
+bool mem_buffer::is_rocm_managed_supported()
+{
+#if HAVE_ROCM
+    int device_id, has_managed_mem;
+    return ((hipGetDevice(&device_id) == hipSuccess) &&
+            (hipDeviceGetAttribute(&has_managed_mem,
+                                   hipDeviceAttributeManagedMemory,
+                                   device_id) == hipSuccess) &&
+            has_managed_mem);
+#else
+    return false;
+#endif
+}
+
 const std::vector<ucs_memory_type_t>&  mem_buffer::supported_mem_types()
 {
     static std::vector<ucs_memory_type_t> vec;
@@ -83,6 +97,8 @@ const std::vector<ucs_memory_type_t>&  mem_buffer::supported_mem_types()
         }
         if (is_rocm_supported()) {
             vec.push_back(UCS_MEMORY_TYPE_ROCM);
+        }
+        if (is_rocm_managed_supported()) {
             vec.push_back(UCS_MEMORY_TYPE_ROCM_MANAGED);
         }
     }

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -70,6 +70,9 @@ public:
     /* set device context if compiled with GPU support */
     static void set_device_context();
 
+    /* returns whether ROCM device supports managed memory */
+    static bool is_rocm_managed_supported();
+
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     virtual ~mem_buffer();
 

--- a/test/gtest/ucm/rocm_hooks.cc
+++ b/test/gtest/ucm/rocm_hooks.cc
@@ -124,13 +124,15 @@ UCS_TEST_F(rocm_hooks, test_hipMallocManaged) {
     hipError_t ret;
     void * dptr;
 
-    ret = hipMallocManaged(&dptr, 64);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events((void *)dptr, 64);
+    if (mem_buffer::is_rocm_managed_supported()) {
+        ret = hipMallocManaged(&dptr, 64);
+        ASSERT_EQ(ret, hipSuccess);
+        check_mem_alloc_events((void *)dptr, 64);
 
-    ret = hipFree(dptr);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_free_events((void *)dptr, 0, UCS_MEMORY_TYPE_ROCM_MANAGED);
+        ret = hipFree(dptr);
+        ASSERT_EQ(ret, hipSuccess);
+        check_mem_free_events((void *)dptr, 0, UCS_MEMORY_TYPE_ROCM_MANAGED);
+    }
 }
 
 UCS_TEST_F(rocm_hooks, test_hipMallocPitch) {
@@ -190,4 +192,3 @@ UCS_TEST_F(rocm_hooks, test_hip_Malloc_Free) {
     ret = hipFree(NULL);
     ASSERT_EQ(ret, hipSuccess);
 }
-


### PR DESCRIPTION
## What
Fixes a gtest that tests hipMallocManaged

## Why ?
The unit test fails on machines on devices which are not capable of performing hipMallocManaged

## How ?
Add a check to see if the current device can perform hipMallocManaged, and only perform the test if this is true.