### PR TITLE
UCS/SYS: Set names for threads

### DIFF
--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -105,7 +105,7 @@ static void *ucs_async_thread_func(void *arg)
     cb_arg.thread    = thread;
     cb_arg.is_missed = &is_missed;
 
-    ucs_log_set_thread_name("async");
+    ucs_log_set_thread_name("a");
 
     while (!thread->stop) {
         num_events = ucs_min(UCS_ASYNC_EPOLL_MAX_EVENTS,
@@ -156,7 +156,6 @@ static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
     ucs_async_thread_t *thread;
     ucs_status_t status;
     int wakeup_rfd;
-    int ret;
 
     ucs_trace_func("");
 
@@ -203,10 +202,9 @@ static ucs_status_t ucs_async_thread_start(ucs_async_thread_t **thread_p)
         goto err_free_event_set;
     }
 
-    ret = pthread_create(&thread->thread_id, NULL, ucs_async_thread_func, thread);
-    if (ret != 0) {
-        ucs_error("pthread_create() returned %d: %m", ret);
-        status = UCS_ERR_IO_ERROR;
+    status = ucs_pthread_create(&thread->thread_id, ucs_async_thread_func,
+                                thread, "async");
+    if (status != UCS_OK) {
         goto err_free_event_set;
     }
 

--- a/src/ucs/debug/assert.c
+++ b/src/ucs/debug/assert.c
@@ -41,13 +41,13 @@ void ucs_fatal_error_message(const char *file, unsigned line,
 void ucs_fatal_error_format(const char *file, unsigned line,
                             const char *function, const char *format, ...)
 {
-    size_t buffer_size = ucs_log_get_buffer_size();
+    const size_t buffer_size = ucs_log_get_buffer_size();
     char *buffer;
     va_list ap;
 
-    buffer = ucs_alloca(buffer_size + 1);
+    buffer = ucs_alloca(buffer_size);
     va_start(ap, format);
-    vsnprintf(buffer, buffer_size, format, ap);
+    ucs_vsnprintf_safe(buffer, buffer_size, format, ap);
     va_end(ap);
 
     ucs_fatal_error_message(file, line, function, buffer);

--- a/src/ucs/stats/libstats.c
+++ b/src/ucs/stats/libstats.c
@@ -10,6 +10,7 @@
 
 #include "libstats.h"
 
+#include <ucs/sys/string.h>
 #include <ucs/debug/log.h>
 #include <errno.h>
 #include <string.h>
@@ -59,7 +60,7 @@ ucs_status_t ucs_stats_node_initv(ucs_stats_node_t *node, ucs_stats_class_t *cls
 
     /* Set up node */
     node->cls = cls;
-    vsnprintf(node->name, UCS_STAT_NAME_MAX, name, ap);
+    ucs_vsnprintf_safe(node->name, UCS_STAT_NAME_MAX, name, ap);
     ucs_list_head_init(&node->children[UCS_STATS_INACTIVE_CHILDREN]);
     ucs_list_head_init(&node->children[UCS_STATS_ACTIVE_CHILDREN]);
     memset(node->counters, 0, cls->num_counters * sizeof(ucs_stats_counter_t));

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -649,7 +649,7 @@ static void* ucs_stats_thread_func(void *arg)
     unsigned flags;
     long nsec;
 
-    ucs_log_set_thread_name("stats");
+    ucs_log_set_thread_name("s");
 
     if (ucs_stats_context.interval > 0) {
         nsec = (long)(ucs_stats_context.interval * UCS_NSEC_PER_SEC + 0.5);
@@ -785,7 +785,8 @@ static void ucs_stats_set_trigger()
         }
 
         ucs_stats_context.flags |= UCS_STATS_FLAG_ON_TIMER;
-        pthread_create(&ucs_stats_context.thread, NULL, ucs_stats_thread_func, NULL);
+        ucs_pthread_create(&ucs_stats_context.thread, ucs_stats_thread_func,
+                           NULL, "stats");
    } else if (!strncmp(ucs_global_opts.stats_trigger, "signal:", 7)) {
         p = ucs_global_opts.stats_trigger + 7;
         if (!ucs_config_sscanf_signo(p, &ucs_stats_context.signo, NULL)) {

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -219,17 +219,22 @@ char *ucs_dirname(char *path, int num_layers)
     return path;
 }
 
-void ucs_snprintf_safe(char *buf, size_t size, const char *fmt, ...)
+void ucs_vsnprintf_safe(char *buf, size_t size, const char *fmt, va_list ap)
 {
-    va_list ap;
-
     if (size == 0) {
         return;
     }
 
-    va_start(ap, fmt);
     vsnprintf(buf, size, fmt, ap);
     buf[size - 1] = '\0';
+}
+
+void ucs_snprintf_safe(char *buf, size_t size, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    ucs_vsnprintf_safe(buf, size, fmt, ap);
     va_end(ap);
 }
 

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -146,6 +146,18 @@ size_t ucs_string_quantity_prefix_value(char prefix);
 
 
 /**
+ * Format a vararg string to a buffer of given size, and guarantee that the last
+ * char in the buffer is '\0'.
+ *
+ * @param buf  Buffer to format the string to.
+ * @param size Buffer size.
+ * @param fmt  Format string.
+ * @param ap   Variable argument list for the format string.
+ */
+void ucs_vsnprintf_safe(char *buf, size_t size, const char *fmt, va_list ap);
+
+
+/**
  * Format a string to a buffer of given size, and guarantee that the last char
  * in the buffer is '\0'.
  *

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -399,7 +399,7 @@ static ssize_t ucs_read_file_vararg(char *buffer, size_t max, int silent,
     ssize_t read_bytes;
     int fd;
 
-    vsnprintf(filename, MAXPATHLEN, filename_fmt, ap);
+    ucs_vsnprintf_safe(filename, MAXPATHLEN, filename_fmt, ap);
 
     fd = open(filename, O_RDONLY);
     if (fd < 0) {

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1517,3 +1517,27 @@ ucs_status_t ucs_sys_check_fd_limit_per_process()
 
     return UCS_OK;
 }
+
+ucs_status_t ucs_pthread_create(pthread_t *thread_id_p,
+                                void *(*start_routine)(void*), void *arg,
+                                const char *fmt, ...)
+{
+    char thread_name[NAME_MAX];
+    pthread_t thread_id;
+    va_list ap;
+    int ret;
+
+    ret = pthread_create(&thread_id, NULL, start_routine, arg);
+    if (ret != 0) {
+        ucs_error("pthread_create() failed: %m");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    va_start(ap, fmt);
+    ucs_vsnprintf_safe(thread_name, sizeof(thread_name), fmt, ap);
+    va_end(ap);
+
+    pthread_setname_np(thread_id, thread_name);
+    *thread_id_p = thread_id;
+    return UCS_OK;
+}

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -579,7 +579,7 @@ uint64_t ucs_iface_get_system_id();
  *
  * @return UCS_OK if directory is found and successfully iterated thought all
  *         entries, error code in all other cases, see NOTES.
- * 
+ *
  * @note ucs_sys_readdir function reads directory pointed by @a path argument
  *       and calls @a cb function for every entry in directory, including
  *       '.' and '..'. In case if @a cb function returns value different from
@@ -596,7 +596,7 @@ ucs_status_t ucs_sys_readdir(const char *path, ucs_sys_readdir_cb_t cb, void *ct
  *
  * @return UCS_OK if directory is found and successfully iterated thought all
  *         entries, error code in all other cases, see NOTES.
- * 
+ *
  * @note ucs_sys_enum_threads function enumerates current process threads
  *       and calls @a cb function for every thread. In case if @a cb function
  *       returns value different from UCS_OK then function breaks
@@ -625,6 +625,21 @@ ucs_status_t ucs_sys_get_file_time(const char *name, ucs_sys_file_time_t type,
  *         otherwise.
  */
 ucs_status_t ucs_sys_check_fd_limit_per_process();
+
+
+/*
+ * Create a named thread.
+ *
+ * @param [out] thread_id_p     If successful, set to the new thread id.
+ * @param [in]  start_routine   Thread function.
+ * @param [in]  arg             Custom argument for start_routine.
+ * @param [in]  fmt             Thread name format string.
+ *
+ * @return UCS_OK if successful, or error status if failed.
+ */
+ucs_status_t ucs_pthread_create(pthread_t *thread_id_p,
+                                void *(*start_routine)(void*), void *arg,
+                                const char *fmt, ...) UCS_F_PRINTF(4, 5);
 
 END_C_DECLS
 

--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -254,7 +254,7 @@ static ucs_status_t ucs_vfs_node_add(void *parent_obj, ucs_vfs_node_type_t type,
     }
 
     /* generate the relative path */
-    vsnprintf(rel_path_buf, sizeof(rel_path_buf), rel_path, ap);
+    ucs_vsnprintf_safe(rel_path_buf, sizeof(rel_path_buf), rel_path, ap);
 
     /* Build parent nodes along the rel_path, without associated object */
     next_token = rel_path_buf;

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -378,6 +378,8 @@ static void *ucs_vfs_fuse_thread_func(void *arg)
     int connfd;
     int ret;
 
+    ucs_log_set_thread_name("f");
+
     if (!ucs_global_opts.vfs_thread_affinity) {
         ucs_vfs_fuse_thread_reset_affinity();
     }
@@ -496,8 +498,8 @@ static void ucs_fuse_thread_stop()
 UCS_STATIC_INIT
 {
     if (ucs_global_opts.vfs_enable) {
-        pthread_create(&ucs_vfs_fuse_context.thread_id, NULL,
-                       ucs_vfs_fuse_thread_func, NULL);
+        ucs_pthread_create(&ucs_vfs_fuse_context.thread_id,
+                           ucs_vfs_fuse_thread_func, NULL, "fuse");
     }
 }
 


### PR DESCRIPTION
## Why
To allow quick identification of the various service threads in gdb