### PR TITLE
UCS/RCACHE: Print region pointer when destroying in-use region

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -373,7 +373,7 @@ static void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
 
     ucs_rcache_region_trace(rcache, region, "destroy");
 
-    ucs_assertv(region->refcount == 0, "region 0x%lx..0x%lx of %s",
+    ucs_assertv(region->refcount == 0, "region %p 0x%lx..0x%lx of %s", region,
                 region->super.start, region->super.end, rcache->name);
     ucs_assert(!(region->flags & UCS_RCACHE_REGION_FLAG_PGTABLE));
 


### PR DESCRIPTION
# Why
Add debug information for removing in-use region