### PR TITLE
UCP/API: Add ucp_worker_address_query routine

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -448,6 +448,19 @@ enum ucp_worker_attr_field {
 
 /**
  * @ingroup UCP_WORKER
+ * @brief UCP worker address attributes field mask.
+ *
+ * The enumeration allows specifying which fields in
+ * @ref ucp_worker_address_attr_t are present. It is used to enable backward
+ * compatibility support.
+ */
+enum ucp_worker_address_attr_field {
+    UCP_WORKER_ADDRESS_ATTR_FIELD_UID = UCS_BIT(0) /**< Unique id of the worker */
+};
+
+
+/**
+ * @ingroup UCP_WORKER
  * @brief UCP listener attributes field mask.
  *
  * The enumeration allows specifying which fields in @ref ucp_listener_attr_t are
@@ -1276,6 +1289,28 @@ typedef struct ucp_worker_params {
 
 
 /**
+ * @ingroup UCP_WORKER
+ * @brief UCP worker address attributes.
+ *
+ * The structure defines the attributes of the particular worker address.
+ */
+typedef struct ucp_worker_address_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref ucp_worker_address_attr_field.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t              field_mask;
+
+    /**
+     * Unique id of the worker this address belongs to.
+     */
+    uint64_t              worker_uid;
+} ucp_worker_address_attr_t;
+
+
+/**
  * @ingroup UCP_ENDPOINT
  * @brief UCP endpoint performance evaluation request attributes.
  *
@@ -2089,6 +2124,22 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
  * errors when worker != address
  */
 void ucp_worker_release_address(ucp_worker_h worker, ucp_address_t *address);
+
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief Get attributes of the particular worker address.
+ *
+ * This routine fetches information about the worker address. The address can be
+ * either of local or remote worker.
+ *
+ * @param [in]  address    Worker address to query.
+ * @param [out] attr       Filled with attributes of the worker address.
+ *
+ * @return Error code as defined by @ref ucs_status_t.
+ */
+ucs_status_t ucp_worker_address_query(ucp_address_t *address,
+                                      ucp_worker_address_attr_t *attr);
 
 
 /**

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -361,6 +361,11 @@ typedef struct ucp_tl_iface_atomic_flags {
     UCS_PARAM_VALUE(UCP_PARAM_FIELD, _params, _name, _flag, _default)
 
 
+#define UCP_ATTR_VALUE(_obj, _attrs, _name, _flag, _default) \
+    UCS_PARAM_VALUE(UCS_PP_TOKENPASTE3(UCP_, _obj, _ATTR_FIELD), _attrs, \
+                    _name, _flag, _default)
+
+
 #define ucp_assert_memtype(_context, _buffer, _length, _mem_type) \
     ucs_assert(ucp_memory_type_detect(_context, _buffer, _length) == (_mem_type))
 

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -620,6 +620,11 @@ ucp_address_unpack_iface_length(ucp_worker_h worker, const void *flags_ptr,
     return UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
 }
 
+uint64_t ucp_address_get_uuid(const void *address)
+{
+    return *(uint64_t*)UCS_PTR_TYPE_OFFSET(address, uint8_t);
+}
+
 static ucs_status_t
 ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
                     unsigned pack_flags, const ucp_lane_index_t *lanes2remote,
@@ -990,10 +995,11 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     }
 
     if (unpack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
-        unpacked_address->uuid = *(uint64_t*)ptr;
-        ptr = UCS_PTR_TYPE_OFFSET(ptr, unpacked_address->uuid);
+        unpacked_address->uuid = ucp_address_get_uuid(buffer);
+        ptr                    = UCS_PTR_TYPE_OFFSET(ptr,
+                                                     unpacked_address->uuid);
     } else {
-        unpacked_address->uuid = 0;
+        unpacked_address->uuid = 0ul;
     }
 
     if ((address_header & UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO) &&

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -188,4 +188,14 @@ ucs_status_t ucp_address_unpack(ucp_worker_h worker, const void *buffer,
                                 ucp_unpacked_address_t *unpacked_address);
 
 
+/**
+ * Unpack worker unique id from the given address.
+ *
+ * @param [in] address Worker address.
+ *
+ * @return Worker unique id.
+  */
+uint64_t ucp_address_get_uuid(const void *address);
+
+
 #endif


### PR DESCRIPTION
## What
Add query routine for ucp worker address. The only available parameter for now is worker unique ID   

## Why ?
The process may need to know the identificator of its peer. With this routine it is possible to get unique id of the remote process.
Can be useful for various profiling tools.  
