### PR TITLE
UCT/API/V2: Add names for UCT endpoint operations

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -28,26 +28,28 @@ BEGIN_C_DECLS
 */
 
 /**
+ * @ingroup UCT_RESOURCE
  * @brief All existing UCT operations
  *
  * This enumeration defines all available UCT operations.
  */
 typedef enum uct_ep_operation {
-    UCT_OP_AM_SHORT,     /**< Short active message */
-    UCT_OP_AM_BCOPY,     /**< Buffered active message */
-    UCT_OP_AM_ZCOPY,     /**< Zero-copy active message */
-    UCT_OP_PUT_SHORT,    /**< Short put */
-    UCT_OP_PUT_BCOPY,    /**< Buffered put */
-    UCT_OP_PUT_ZCOPY,    /**< Zero-copy put */
-    UCT_OP_GET_SHORT,    /**< Short get */
-    UCT_OP_GET_BCOPY,    /**< Buffered get */
-    UCT_OP_GET_ZCOPY,    /**< Zero-copy get */
-    UCT_OP_EAGER_SHORT,  /**< Tag matching short eager */
-    UCT_OP_EAGER_BCOPY,  /**< Tag matching bcopy eager */
-    UCT_OP_EAGER_ZCOPY,  /**< Tag matching zcopy eager */
-    UCT_OP_RNDV_ZCOPY,   /**< Tag matching rendezvous eager */
-    UCT_OP_ATOMIC_POST,  /**< Atomic post */
-    UCT_OP_ATOMIC_FETCH  /**< Atomic fetch */
+    UCT_EP_OP_AM_SHORT,     /**< Short active message */
+    UCT_EP_OP_AM_BCOPY,     /**< Buffered active message */
+    UCT_EP_OP_AM_ZCOPY,     /**< Zero-copy active message */
+    UCT_EP_OP_PUT_SHORT,    /**< Short put */
+    UCT_EP_OP_PUT_BCOPY,    /**< Buffered put */
+    UCT_EP_OP_PUT_ZCOPY,    /**< Zero-copy put */
+    UCT_EP_OP_GET_SHORT,    /**< Short get */
+    UCT_EP_OP_GET_BCOPY,    /**< Buffered get */
+    UCT_EP_OP_GET_ZCOPY,    /**< Zero-copy get */
+    UCT_EP_OP_EAGER_SHORT,  /**< Tag matching short eager */
+    UCT_EP_OP_EAGER_BCOPY,  /**< Tag matching bcopy eager */
+    UCT_EP_OP_EAGER_ZCOPY,  /**< Tag matching zcopy eager */
+    UCT_EP_OP_RNDV_ZCOPY,   /**< Tag matching rendezvous eager */
+    UCT_EP_OP_ATOMIC_POST,  /**< Atomic post */
+    UCT_EP_OP_ATOMIC_FETCH, /**< Atomic fetch */
+    UCT_EP_OP_LAST
 } uct_ep_operation_t;
 
 
@@ -191,6 +193,13 @@ typedef struct uct_md_mem_dereg_params {
      */
     uct_completion_t             *comp;
 } uct_md_mem_dereg_params_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Names for UCT endpoint operations.
+ */
+extern const char *uct_ep_operation_names[];
 
 
 /**

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -23,6 +23,25 @@
 #include <ucs/vfs/base/vfs_obj.h>
 
 
+const char *uct_ep_operation_names[] = {
+    [UCT_EP_OP_AM_SHORT]     = "am_short",
+    [UCT_EP_OP_AM_BCOPY]     = "am_bcopy",
+    [UCT_EP_OP_AM_ZCOPY]     = "am_zcopy",
+    [UCT_EP_OP_PUT_SHORT]    = "put_short",
+    [UCT_EP_OP_PUT_BCOPY]    = "put_bcopy",
+    [UCT_EP_OP_PUT_ZCOPY]    = "put_zcopy",
+    [UCT_EP_OP_GET_SHORT]    = "get_short",
+    [UCT_EP_OP_GET_BCOPY]    = "get_bcopy",
+    [UCT_EP_OP_GET_ZCOPY]    = "get_zcopy",
+    [UCT_EP_OP_EAGER_SHORT]  = "eager_short",
+    [UCT_EP_OP_EAGER_BCOPY]  = "eager_bcopy",
+    [UCT_EP_OP_EAGER_ZCOPY]  = "eager_zcopy",
+    [UCT_EP_OP_RNDV_ZCOPY]   = "rndv_zcopy",
+    [UCT_EP_OP_ATOMIC_POST]  = "atomic_post",
+    [UCT_EP_OP_ATOMIC_FETCH] = "atomic_fetch",
+    [UCT_EP_OP_LAST]         = NULL
+};
+
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ep_stats_class = {
     .name          = "uct_ep",

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -300,16 +300,16 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
             perf_attr->bandwidth.shared = iface->config.bandwidth;
         } else {
             switch (perf_attr->operation) {
-            case UCT_OP_GET_SHORT:
+            case UCT_EP_OP_GET_SHORT:
                 perf_attr->bandwidth.shared = 9320.0 * UCS_MBYTE;
                 break;
-            case UCT_OP_GET_ZCOPY:
+            case UCT_EP_OP_GET_ZCOPY:
                 perf_attr->bandwidth.shared = 11660.0 * UCS_MBYTE;
                 break;
-            case UCT_OP_PUT_SHORT:
+            case UCT_EP_OP_PUT_SHORT:
                 perf_attr->bandwidth.shared = 8110.0 * UCS_MBYTE;
                 break;
-            case UCT_OP_PUT_ZCOPY:
+            case UCT_EP_OP_PUT_ZCOPY:
                 perf_attr->bandwidth.shared = 9980.0 * UCS_MBYTE;
                 break;
             default:

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -102,11 +102,11 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->bandwidth.dedicated = 0;
         if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OPERATION) {
             switch (perf_attr->operation) {
-            case UCT_OP_GET_SHORT:
-            case UCT_OP_GET_ZCOPY:
+            case UCT_EP_OP_GET_SHORT:
+            case UCT_EP_OP_GET_ZCOPY:
                 perf_attr->bandwidth.shared = 440.0 * UCS_MBYTE;
                 break;
-            case UCT_OP_PUT_SHORT:
+            case UCT_EP_OP_PUT_SHORT:
                 perf_attr->bandwidth.shared = 10200.0 * UCS_MBYTE;
                 break;
             default:

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -28,7 +28,7 @@ UCS_TEST_P(test_uct_query, query_perf)
                                    UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE |
                                    UCT_PERF_ATTR_FIELD_OVERHEAD |
                                    UCT_PERF_ATTR_FIELD_BANDWIDTH;
-    perf_attr.operation          = UCT_OP_AM_SHORT;
+    perf_attr.operation          = UCT_EP_OP_AM_SHORT;
     perf_attr.local_memory_type  = UCS_MEMORY_TYPE_HOST;
     perf_attr.remote_memory_type = UCS_MEMORY_TYPE_HOST;
     status                       = uct_iface_estimate_perf(sender().iface(),
@@ -36,7 +36,7 @@ UCS_TEST_P(test_uct_query, query_perf)
     EXPECT_EQ(status, UCS_OK);
 
     perf_attr.remote_memory_type = UCS_MEMORY_TYPE_CUDA;
-    perf_attr.operation          = UCT_OP_PUT_SHORT;
+    perf_attr.operation          = UCT_EP_OP_PUT_SHORT;
     status                       = uct_iface_estimate_perf(sender().iface(),
                                                            &perf_attr);
 
@@ -49,7 +49,7 @@ UCS_TEST_P(test_uct_query, query_perf)
         uct_perf_attr_t perf_attr_get;
         perf_attr_get.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
                                    UCT_PERF_ATTR_FIELD_BANDWIDTH;
-        perf_attr_get.operation  = UCT_OP_GET_SHORT;
+        perf_attr_get.operation  = UCT_EP_OP_GET_SHORT;
         status = uct_iface_estimate_perf(sender().iface(), &perf_attr_get);
         EXPECT_EQ(status, UCS_OK);
 


### PR DESCRIPTION
# Why
- Rename UCT_OP_xx to UCT_EP_OP_xx because the enum is named `uct_ep_operation_t`
- Add informative names for UCT endpoint operations
- Add UCT_EP_OP_LAST to be the invalid operation ID