### PR TITLE
UCP/PROTO/RNDV: Add protocol stages

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -58,7 +58,7 @@ enum {
 #else
     UCP_REQUEST_FLAG_STREAM_RECV           = 0,
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL        = 0,
-    UCP_REQUEST_FLAG_SUPER_VALID           = 0    
+    UCP_REQUEST_FLAG_SUPER_VALID           = 0
 #endif
 };
 
@@ -293,6 +293,7 @@ struct ucp_request {
 
             union {
                 ucp_lane_index_t  am_bw_index;     /* AM BW lane index */
+                ucp_lane_index_t  multi_lane_idx;  /* Index of the lane with multi-send */
                 ucp_lane_map_t    lanes_map_avail; /* Used lanes map */
             };
             uint8_t               mem_type;        /* Memory type, values are
@@ -300,7 +301,7 @@ struct ucp_request {
             ucp_lane_index_t      pending_lane;    /* Lane on which request was moved
                                                     * to pending state */
             ucp_lane_index_t      lane;            /* Lane on which this request is being sent */
-            ucp_lane_index_t      multi_lane_idx;  /* Index of the lane with multi-send */
+            uint8_t               proto_stage;     /* Protocol current stage */
             uct_pending_req_t     uct;             /* UCT pending request */
             ucp_mem_desc_t        *mdesc;
         } send;
@@ -455,5 +456,7 @@ ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset);
 
 void ucp_request_purge_enqueue_cb(uct_pending_req_t *self, void *arg);
+
+ucs_status_t ucp_request_progress_wrapper(uct_pending_req_t *self);
 
 #endif

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -46,6 +46,16 @@ typedef unsigned ucp_proto_id_t;
 typedef uint64_t ucp_proto_id_mask_t;
 
 
+/* Protocol stage ID */
+enum {
+    /* Initial stage. All protocols start from this stage. */
+    UCP_PROTO_STAGE_START = 0,
+
+    /* Stage ID must be lower than this value */
+    UCP_PROTO_STAGE_LAST  = 8
+};
+
+
 /**
  * Protocol flags for internal usage, to allow searching for specific protocols
  */
@@ -179,7 +189,7 @@ struct ucp_proto {
     /* Initial UCT progress function, can be changed during the protocol
      * request lifetime to implement different stages
      */
-    uct_pending_callback_t          progress;
+    uct_pending_callback_t          progress[UCP_PROTO_STAGE_LAST];
 };
 
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -562,6 +562,21 @@ void ucp_proto_request_zcopy_completion(uct_completion_t *self)
     ucp_request_complete_send(req, req->send.state.uct_comp.status);
 }
 
+void ucp_proto_trace_selected(ucp_request_t *req, size_t msg_length)
+{
+    UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
+    UCS_STRING_BUFFER_ONSTACK(proto_config_strb, UCP_PROTO_CONFIG_STR_MAX);
+    const ucp_proto_config_t *proto_config = req->send.proto_config;
+
+    ucp_proto_select_param_str(&proto_config->select_param, &sel_param_strb);
+    proto_config->proto->config_str(msg_length, msg_length, proto_config->priv,
+                                    &proto_config_strb);
+    ucp_trace_req(req, "%s length %zu using %s{%s}",
+                  ucs_string_buffer_cstr(&sel_param_strb), msg_length,
+                  proto_config->proto->name,
+                  ucs_string_buffer_cstr(&proto_config_strb));
+}
+
 void ucp_proto_request_select_error(ucp_request_t *req,
                                     ucp_proto_select_t *proto_select,
                                     ucp_worker_cfg_index_t rkey_cfg_index,

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -157,6 +157,9 @@ void ucp_proto_common_calc_perf(const ucp_proto_common_init_params_t *params,
 void ucp_proto_request_zcopy_completion(uct_completion_t *self);
 
 
+void ucp_proto_trace_selected(ucp_request_t *req, size_t msg_length);
+
+
 void ucp_proto_request_select_error(ucp_request_t *req,
                                     ucp_proto_select_t *proto_select,
                                     ucp_worker_cfg_index_t rkey_cfg_index,

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -104,6 +104,6 @@ static ucp_proto_t ucp_reconfig_proto = {
     .flags      = UCP_PROTO_FLAG_INVALID,
     .init       = ucp_proto_reconfig_init,
     .config_str = (ucp_proto_config_str_func_t)ucs_empty_function,
-    .progress   = ucp_proto_reconfig_progress
+    .progress   = {ucp_proto_reconfig_progress}
 };
 UCP_PROTO_REGISTER(&ucp_reconfig_proto);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -99,6 +99,6 @@ static ucp_proto_t ucp_get_am_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_get_am_bcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_get_am_bcopy_progress
+    .progress   = {ucp_proto_get_am_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_get_am_bcopy_proto);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -100,7 +100,7 @@ static ucp_proto_t ucp_get_offload_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_get_offload_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_get_offload_bcopy_progress
+    .progress   = {ucp_proto_get_offload_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_get_offload_bcopy_proto);
 
@@ -167,6 +167,6 @@ static ucp_proto_t ucp_get_offload_zcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_get_offload_zcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_get_offload_zcopy_progress
+    .progress   = {ucp_proto_get_offload_zcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_get_offload_zcopy_proto);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -101,7 +101,7 @@ static ucp_proto_t ucp_put_am_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_put_am_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_put_am_bcopy_progress
+    .progress   = {ucp_proto_put_am_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_put_am_bcopy_proto);
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -73,7 +73,7 @@ static ucp_proto_t ucp_put_offload_short_proto = {
     .flags      = UCP_PROTO_FLAG_PUT_SHORT,
     .init       = ucp_proto_put_offload_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_put_offload_short_progress
+    .progress   = {ucp_proto_put_offload_short_progress}
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_short_proto);
 
@@ -158,7 +158,7 @@ static ucp_proto_t ucp_put_offload_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_put_offload_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_put_offload_bcopy_progress
+    .progress   = {ucp_proto_put_offload_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_bcopy_proto);
 
@@ -224,6 +224,6 @@ static ucp_proto_t ucp_put_offload_zcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_put_offload_zcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_put_offload_zcopy_progress
+    .progress   = {ucp_proto_put_offload_zcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_zcopy_proto);

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -113,6 +113,6 @@ static ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_rdnv_am_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_rndv_am_bcopy_progress,
+    .progress   = {ucp_proto_rndv_am_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_rndv_am_bcopy_proto);

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -140,6 +140,6 @@ static ucp_proto_t ucp_rndv_rtr_proto = {
     .flags      = 0,
     .init       = ucp_proto_rndv_rtr_init,
     .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = ucp_proto_rndv_rtr_progress
+    .progress   = {ucp_proto_rndv_rtr_progress}
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rtr_proto);

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -160,7 +160,7 @@ static ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_bcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_eager_bcopy_multi_progress
+    .progress   = {ucp_proto_eager_bcopy_multi_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_multi_proto);
 
@@ -246,7 +246,7 @@ static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_sync_bcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_eager_sync_bcopy_multi_progress
+    .progress   = {ucp_proto_eager_sync_bcopy_multi_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_multi_proto);
 
@@ -315,6 +315,6 @@ static ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_zcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = ucp_proto_eager_zcopy_multi_progress
+    .progress   = {ucp_proto_eager_zcopy_multi_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_multi_proto);

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -77,7 +77,7 @@ static ucp_proto_t ucp_eager_short_proto = {
     .flags      = UCP_PROTO_FLAG_AM_SHORT,
     .init       = ucp_proto_eager_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_eager_short_progress
+    .progress   = {ucp_eager_short_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
@@ -138,7 +138,7 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_bcopy_single_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_eager_bcopy_single_progress,
+    .progress   = {ucp_eager_bcopy_single_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
@@ -198,6 +198,6 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_zcopy_single_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_eager_zcopy_single_progress,
+    .progress   = {ucp_proto_eager_zcopy_single_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -74,7 +74,7 @@ static ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .flags      = UCP_PROTO_FLAG_TAG_SHORT,
     .init       = ucp_proto_eager_tag_offload_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_eager_tag_offload_short_progress
+    .progress   = {ucp_proto_eager_tag_offload_short_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_tag_offload_short_proto);
 
@@ -159,7 +159,7 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_tag_offload_bcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_eager_tag_offload_bcopy_progress
+    .progress   = {ucp_proto_eager_tag_offload_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
@@ -193,7 +193,7 @@ static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_sync_tag_offload_bcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_eager_sync_tag_offload_bcopy_progress
+    .progress   = {ucp_proto_eager_sync_tag_offload_bcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_single_proto);
 
@@ -258,7 +258,7 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_tag_offload_zcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_eager_tag_offload_zcopy_progress,
+    .progress   = {ucp_proto_eager_tag_offload_zcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);
 
@@ -295,6 +295,6 @@ static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_sync_tag_offload_zcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = ucp_proto_eager_sync_tag_offload_zcopy_progress
+    .progress   = {ucp_proto_eager_sync_tag_offload_zcopy_progress}
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_zcopy_single_proto);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -153,6 +153,6 @@ static ucp_proto_t ucp_tag_rndv_proto = {
     .flags      = 0,
     .init       = ucp_proto_rndv_rts_init,
     .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = ucp_tag_rndv_rts_progress
+    .progress   = {ucp_tag_rndv_rts_progress}
 };
 UCP_PROTO_REGISTER(&ucp_tag_rndv_proto);


### PR DESCRIPTION
## Why
- Optimize protocols progress function by using different function pointers instead of branches
- More structured definition of protocols with multiple stages. For example: rdnv-get has {get_zcopy, ats} and rndv-put would have {put_zcopy, flush/fence, atp}. Pipeline protocol will have an additional stage of rdnv fragment copy.