### PR TITLE
UCT/DC: Don't schedule failed flow control ep

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1115,8 +1115,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_
 
         status = uct_dc_mlx5_iface_fc_grant(&dc_req->super.super);
         if (status == UCS_ERR_NO_RESOURCE){
-            uct_dc_mlx5_ep_pending_common(iface, ep, &dc_req->super.super,
-                                          0, 1);
+            uct_dc_mlx5_ep_do_pending_fc(ep, dc_req);
         } else {
             ucs_assertv_always(status == UCS_OK,
                                "Failed to send FC grant msg: %s",

--- a/src/uct/ib/dc/dc_mlx5.inl
+++ b/src/uct/ib/dc/dc_mlx5.inl
@@ -39,3 +39,44 @@ uct_dc_mlx5_get_arbiter_params(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
         *group_p = &ep->arb_group;
     }
 }
+
+static UCS_F_ALWAYS_INLINE void
+uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
+                              uct_pending_req_t *r, unsigned flags,
+                              int push_to_head, int schedule)
+{
+    int no_dci = (ep->dci == UCT_DC_MLX5_EP_NO_DCI);
+    ucs_arbiter_group_t *group;
+
+    UCS_STATIC_ASSERT(sizeof(uct_dc_mlx5_pending_req_priv) <=
+                      UCT_PENDING_REQ_PRIV_LEN);
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+        uct_dc_mlx5_pending_req_priv(r)->ep = ep;
+        group = uct_dc_mlx5_ep_rand_arb_group(iface, ep);
+    } else {
+        group = &ep->arb_group;
+    }
+
+    if (push_to_head) {
+        uct_pending_req_arb_group_push_head(group, r);
+    } else {
+        uct_pending_req_arb_group_push(group, r);
+    }
+
+    UCT_TL_EP_STAT_PEND(&ep->super);
+    if (!schedule) {
+        return;
+    }
+
+    if (no_dci) {
+        /* no dci:
+         *  Do not grab dci here. Instead put the group on dci allocation arbiter.
+         *  This way we can assure fairness between all eps waiting for
+         *  dci allocation. Relevant for dcs and dcs_quota policies.
+         */
+        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
+    } else {
+        uct_dc_mlx5_iface_dci_sched_tx(iface, ep);
+    }
+}

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -213,9 +213,8 @@ ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
                                         unsigned flags);
 void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, void *arg);
 
-void uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface,
-                                   uct_dc_mlx5_ep_t *ep, uct_pending_req_t *r,
-                                   unsigned flags, int push_to_head);
+void uct_dc_mlx5_ep_do_pending_fc(uct_dc_mlx5_ep_t *fc_ep,
+                                  uct_dc_fc_request_t *fc_req);
 
 ucs_status_t
 uct_dc_mlx5_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);


### PR DESCRIPTION
## Why

Potential fix for this error. The queued operation is `uct_dc_mlx5_iface_fc_grant` which returns UCS_ERR_NO_RESOURCES because its DCI has failed.
```
[1626626933.466407] [jazz20:154486:0]     ib_mlx5_log.c:170  UCX  DIAG  Transport retry count exceeded on mlx5_3:1/RoCE (synd 0x15 vend 0x81 hw_synd 0/0)
[1626626933.466407] [jazz20:154486:0]     ib_mlx5_log.c:170  UCX  DIAG  DCI QP 0x1d11e wqe[0]: SEND s-e [rqpn 0x1f3ee rmac ec:0d:9a:c0:46:3d sgix 3 dgid ::ffff:2.1.3.21 tc 106] [inl len 11]
[jazz20:154486:0:154486]  dc_mlx5_ep.c:1297 Assertion `!uct_dc_mlx5_iface_dci_ep_can_send(ep)' failed: pending callback returned error, but send resources are available

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5_ep.c: [ uct_dc_mlx5_iface_dci_do_common_pending_tx() ]
      ...
     1292      * arbiter group for which flush(CANCEL) was done */
     1293     ucs_assert(!(ep->flags & UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL));
     1294
==>  1295     ucs_assertv(!uct_dc_mlx5_iface_dci_ep_can_send(ep),
     1296                 "pending callback returned error, but send resources are"
     1297                 " available");
     1298     return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;

==== backtrace (tid: 154486) ====
 0 0x000000000012d202 uct_dc_mlx5_iface_dci_do_common_pending_tx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5_ep.c:1295
 1 0x000000000012dc0d uct_dc_mlx5_iface_dci_do_dcs_pending_tx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5_ep.c:1361
 2 0x000000000005405e ucs_arbiter_dispatch_nonempty()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.c:321
 3 0x00000000000ca05b ucs_arbiter_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/ucs/datastruct/arbiter.h:386
 4 0x000000000012fa59 uct_dc_mlx5_iface_progress_pending()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5_ep.h:343
 5 0x000000000012fa59 uct_dc_mlx5_ep_handle_failure()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5_ep.c:1583
 6 0x0000000000153fdf uct_dc_mlx5_dci_handle_failure()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5.c:1186
 7 0x0000000000154205 uct_dc_mlx5_iface_handle_failure()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5.c:1203
 8 0x000000000002bd04 uct_ib_mlx5_check_completion()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.c:362
 9 0x0000000000146979 uct_ib_mlx5_poll_cq()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/mlx5/ib_mlx5.inl:81
10 0x0000000000146979 uct_dc_mlx5_poll_tx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5.c:230
11 0x0000000000146979 uct_dc_mlx5_iface_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5.c:273
12 0x0000000000146979 uct_dc_mlx5_iface_progress_ll()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/ib/dc/dc_mlx5.c:283
13 0x0000000000055ba7 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
14 0x00000000000622ee uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/src/uct/api/uct.h:2592
15 0x00000000004049e6 UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:386
16 0x0000000000404112 UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:225
17 0x00000000004146b8 DemoClient::wait_for_responses()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1669
18 0x00000000004158b1 DemoClient::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:1912
19 0x000000000040e7de do_client()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2513
20 0x000000000040ebd2 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210717_111502_22719_49387_jazz03.swx.labs.mlnx/installs/2M7r/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2556
21 0x00000000000223d5 __libc_start_main()  ???:0
22 0x00000000004031e9 _start()  ???:0
=================================
```