### PR TITLE
UCT/CUDA: Disable whole alloc reg if T4 GPUs detected

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -99,25 +99,13 @@ UCM_DEFINE_REPLACE_DLSYM_PTR_FUNC(cudaMallocPitch, cudaError_t, -1, void**,
 static void ucm_cuda_dispatch_mem_alloc(CUdeviceptr ptr, size_t length,
                                         ucs_memory_type_t mem_type)
 {
-    unsigned sync_atr_value = 1;
-    const char *cu_err_str;
     ucm_event_t event;
-    CUresult ret;
-
-    if ((ptr != 0) && (mem_type == UCS_MEMORY_TYPE_CUDA)) {
-        /* Synchronous operation for GPU direct */
-        ret = cuPointerSetAttribute(&sync_atr_value,
-                                    CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, ptr);
-        if (ret != CUDA_SUCCESS) {
-            cuGetErrorString(ret, &cu_err_str);
-            ucm_warn("cuPointerSetAttribute(%p) failed: %s", (void*)ptr,
-                     cu_err_str);
-        }
-    }
 
     event.mem_type.address  = (void*)ptr;
     event.mem_type.size     = length;
-    event.mem_type.mem_type = mem_type;
+    event.mem_type.mem_type = UCS_MEMORY_TYPE_LAST; /* indicate unknown type
+                                                       and let cuda_md detect
+                                                       attributes */
     ucm_event_dispatch(UCM_EVENT_MEM_TYPE_ALLOC, &event);
 }
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -129,7 +129,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "MD whose distance is queried when evaluating transport selection score",
    ucs_offsetof(ucp_config_t, selection_cmp), UCS_CONFIG_TYPE_STRING},
 
-  {"MEMTYPE_REG_WHOLE_ALLOC_TYPES", "",
+  {"MEMTYPE_REG_WHOLE_ALLOC_TYPES", "cuda",
    "Memory types which have whole allocations registered.\n"
    "Allowed memory types: cuda, rocm, rocm-managed",
    ucs_offsetof(ucp_config_t, ctx.reg_whole_alloc_bitmap),

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -116,6 +116,7 @@ uct_cuda_base_query_devices(
         unsigned *num_tl_devices_p);
 
 ucs_status_t
-uct_cuda_base_get_sys_dev(CUdevice cuda_device, ucs_sys_device_t *sys_dev_p);
+uct_cuda_base_get_sys_dev(CUdevice cuda_device,
+                          ucs_sys_device_t *sys_dev_p);
 
 #endif

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -12,11 +12,17 @@
 #include "cuda_iface.h"
 
 #include <ucs/sys/module.h>
+#include <ucs/type/spinlock.h>
 #include <ucs/profile/profile.h>
 #include <ucs/debug/log.h>
+#include <uct/cuda/cuda_copy/cuda_copy_md.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
 
+#define UCT_CUDA_DEV_NAME_MAX_LEN 64
+#define UCT_CUDA_MAX_DEVICES      32
+
+ucs_spinlock_t uct_cuda_base_lock;
 
 ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
                                        ucs_sys_device_t *sys_dev_p)
@@ -55,6 +61,80 @@ ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
     return ucs_topo_find_device_by_bus_id(&bus_id, sys_dev_p);
 }
 
+static size_t
+uct_cuda_base_get_total_device_mem(CUdevice cuda_device)
+{
+    static size_t total_bytes[UCT_CUDA_MAX_DEVICES];
+    char dev_name[UCT_CUDA_DEV_NAME_MAX_LEN];
+    CUresult cu_err;
+    const char *cu_err_str;
+
+    ucs_assert(cuda_device < UCT_CUDA_MAX_DEVICES);
+
+    ucs_spin_lock(&uct_cuda_base_lock);
+
+    if (!total_bytes[cuda_device]) {
+        cu_err = cuDeviceTotalMem(&total_bytes[cuda_device], cuda_device);
+        if (cu_err != CUDA_SUCCESS) {
+            cuGetErrorString(cu_err, &cu_err_str);
+            ucs_error("cuDeviceTotalMem error: %s", cu_err_str);
+            goto err;
+        }
+
+        cu_err = cuDeviceGetName(dev_name, sizeof(dev_name), cuda_device);
+        if (cu_err != CUDA_SUCCESS) {
+            cuGetErrorString(cu_err, &cu_err_str);
+            ucs_error("cuDeviceGetName error: %s", cu_err_str);
+            goto err;
+        }
+
+        if (!strncmp(dev_name, "T4", 2)) {
+            total_bytes[cuda_device] = 1; /* should ensure that whole alloc
+                                             registration is not used for t4 */
+        }
+    }
+
+    ucs_spin_unlock(&uct_cuda_base_lock);
+    return total_bytes[cuda_device];
+
+err:
+    ucs_spin_unlock(&uct_cuda_base_lock);
+    return 1; /* return 1 byte to avoid division by zero */
+}
+
+static ucs_status_t
+uct_cuda_base_get_base_addr_alloc_length(uct_cuda_copy_md_t *md,
+                                         CUdevice cuda_device,
+                                         const void *address,
+                                         size_t length,
+                                         void **base_address,
+                                         size_t *alloc_length)
+{
+    size_t total_bytes = uct_cuda_base_get_total_device_mem(cuda_device);
+    CUresult cu_err;
+    const char *cu_err_str;
+    CUdeviceptr base_addr;
+    size_t alloc_len;
+    double ratio;
+
+    cu_err = cuMemGetAddressRange(&base_addr, &alloc_len, (CUdeviceptr)address);
+    if (cu_err != CUDA_SUCCESS) {
+        cuGetErrorString(cu_err, &cu_err_str);
+        ucs_error("cuMemGetAddressRange(%p) error: %s", address, cu_err_str);
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    ratio = ((double)alloc_len / total_bytes);
+
+    if ((md->config.alloc_whole_reg == UCS_CONFIG_ON) ||
+        ((md->config.alloc_whole_reg == UCS_CONFIG_AUTO) &&
+         (ratio < md->config.max_reg_ratio))) {
+        *base_address = (void*)base_addr;
+        *alloc_length = alloc_len;
+    }
+
+    return UCS_OK;
+}
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_type,
                  (md, address, length, mem_type_p),
@@ -76,8 +156,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_detect_memory_type,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
-                 (md, address, length, mem_attr),
-                 uct_md_h md, const void *address, size_t length,
+                 (tl_md, address, length, mem_attr),
+                 uct_md_h tl_md, const void *address, size_t length,
                  uct_md_mem_attr_t *mem_attr)
 {
 #define UCT_CUDA_MEM_QUERY_NUM_ATTRS 3
@@ -87,7 +167,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
     CUdevice cuda_device       = -1;
     void *base_address         = (void*)address;
     size_t alloc_length        = length;
-    ucs_sys_device_t sys_dev   =  UCS_SYS_DEVICE_ID_UNKNOWN;
+    ucs_sys_device_t sys_dev   = UCS_SYS_DEVICE_ID_UNKNOWN;
+    uct_cuda_copy_md_t *md     = ucs_derived_of(tl_md, uct_cuda_copy_md_t);
     CUpointer_attribute attr_type[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
     void *attr_data[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
     ucs_memory_type_t mem_type;
@@ -145,13 +226,14 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_base_mem_query,
 
         if (mem_attr->field_mask & (UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH |
                                     UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS)) {
-            cu_err = cuMemGetAddressRange((CUdeviceptr*)&base_address,
-                                          &alloc_length, (CUdeviceptr)address);
-            if (cu_err != CUDA_SUCCESS) {
-                cuGetErrorString(cu_err, &cu_err_str);
-                ucs_error("ccuMemGetAddressRange(%p) error: %s", address,
-                          cu_err_str);
-                return UCS_ERR_INVALID_ADDR;
+
+            status =
+                uct_cuda_base_get_base_addr_alloc_length(md, cuda_device,
+                                                         address, length,
+                                                         &base_address,
+                                                         &alloc_length);
+            if (status != UCS_OK) {
+                return status;
             }
         }
     }
@@ -190,6 +272,14 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
 
     return uct_md_query_single_md_resource(component, resources_p,
                                            num_resources_p);
+}
+
+UCS_STATIC_INIT {
+    ucs_spinlock_init(&uct_cuda_base_lock, 0);
+}
+
+UCS_STATIC_CLEANUP {
+    ucs_spinlock_destroy(&uct_cuda_base_lock);
 }
 
 UCS_MODULE_INIT() {

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -16,14 +16,22 @@ extern uct_component_t uct_cuda_copy_component;
  * @brief cuda_copy MD descriptor
  */
 typedef struct uct_cuda_copy_md {
-    struct uct_md super;   /**< Domain info */
+    struct uct_md               super;           /* Domain info */
+    struct {
+        ucs_on_off_auto_value_t alloc_whole_reg; /* force return of allocation
+                                                    range even for small bar
+                                                    GPUs*/
+        double                  max_reg_ratio;
+    } config;
 } uct_cuda_copy_md_t;
 
 /**
  * gdr copy domain configuration.
  */
 typedef struct uct_cuda_copy_md_config {
-    uct_md_config_t super;
+    uct_md_config_t             super;
+    ucs_on_off_auto_value_t     alloc_whole_reg;
+    double                      max_reg_ratio;
 } uct_cuda_copy_md_config_t;
 
 #endif

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -83,7 +83,8 @@ protected:
                                 int expect_mem_type = UCS_MEMORY_TYPE_CUDA)  {
         ASSERT_EQ(ptr, alloc_event.mem_type.address);
         ASSERT_EQ(size, alloc_event.mem_type.size);
-        ASSERT_EQ(expect_mem_type, alloc_event.mem_type.mem_type);
+        EXPECT_TRUE((alloc_event.mem_type.mem_type == expect_mem_type) ||
+                    (alloc_event.mem_type.mem_type == UCS_MEMORY_TYPE_UNKNOWN));
     }
 
     void check_mem_free_events(void *ptr, size_t size,
@@ -142,11 +143,11 @@ UCS_TEST_F(cuda_hooks, test_cuMemAllocManaged) {
 
     ret = cuMemAllocManaged(&dptr, 64, CU_MEM_ATTACH_GLOBAL);
     ASSERT_EQ(ret, CUDA_SUCCESS);
-    check_mem_alloc_events((void *)dptr, 64, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    check_mem_alloc_events((void*)dptr, 64, UCS_MEMORY_TYPE_CUDA_MANAGED);
 
     ret = cuMemFree(dptr);
     ASSERT_EQ(ret, CUDA_SUCCESS);
-    check_mem_free_events((void *)dptr, 0);
+    check_mem_free_events((void*)dptr, 0);
 }
 
 UCS_TEST_F(cuda_hooks, test_cuMemAllocPitch) {

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -1224,7 +1224,8 @@ protected:
 
             if ((event_type == UCM_EVENT_MEM_TYPE_ALLOC) &&
                 (m_events[i].second.mem_type.address == address) &&
-                (m_events[i].second.mem_type.mem_type == mem_type()) &&
+                ((m_events[i].second.mem_type.mem_type == mem_type()) ||
+                 (m_events[i].second.mem_type.mem_type == UCS_MEMORY_TYPE_UNKNOWN)) &&
                 (m_events[i].second.mem_type.size == size)) {
                 return true;
             }

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -57,7 +57,8 @@ protected:
                                (ucs_memory_type_t)mem_info.type);
         } else {
             EXPECT_UCS_OK(status);
-            EXPECT_EQ(expected_type, mem_info.type)
+            EXPECT_TRUE((UCS_MEMORY_TYPE_UNKNOWN == mem_info.type) ||
+                        (expected_type == mem_info.type))
                     << "ptr=" << ptr << " size=" << size;
         }
     }


### PR DESCRIPTION
## Why/How ?
 - T4 GPUs have smaller bar1 space so registering whole allocations increases changes of IB reg failures
 - So we detect device name and disable whole registration

