### PR TITLE
UCT/IB/RC/VERBS: Align WC error status with MLX5 error handling

### DIFF
--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -124,14 +124,18 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
             wc->wr_id, wc->vendor_err, peer_info);
 }
 
-ucs_status_t uct_rc_verbs_wc_to_ucs_status(enum ibv_wc_status status)
+static ucs_status_t uct_rc_verbs_wc_to_ucs_status(enum ibv_wc_status status)
 {
     switch (status)
     {
     case IBV_WC_SUCCESS:
         return UCS_OK;
+    case IBV_WC_REM_ACCESS_ERR:
+    case IBV_WC_REM_OP_ERR:
+        return UCS_ERR_CONNECTION_RESET;
     case IBV_WC_RETRY_EXC_ERR:
     case IBV_WC_RNR_RETRY_EXC_ERR:
+    case IBV_WC_REM_ABORT_ERR:
         return UCS_ERR_ENDPOINT_TIMEOUT;
     case IBV_WC_WR_FLUSH_ERR:
         return UCS_ERR_CANCELED;

--- a/src/uct/ib/rc/verbs/rc_verbs_impl.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_impl.h
@@ -12,7 +12,6 @@
 #include <uct/ib/rc/base/rc_iface.h>
 #include <uct/ib/rc/base/rc_ep.h>
 
-ucs_status_t uct_rc_verbs_wc_to_ucs_status(enum ibv_wc_status status);
 
 static inline void
 uct_rc_verbs_txqp_posted(uct_rc_txqp_t *txqp, uct_rc_verbs_txcnt_t *txcnt,


### PR DESCRIPTION
## What

Align WC error status with MLX5 error handling.

## Why ?

If this is some recoverable error (e.g. due to connection reset or remote access error in case of peer down), need to report error with DIAG log level instead of ERROR.

## How ?

1. Mapping MLX5 CQE syndrome to WC status was taken from `mlx5_handle_error_cqe()` - https://github.com/gpudirect/libmlx5/blob/9d34626161340d3c922654ea2654a25c73766386/src/cq.c#L368
2. Make `uct_rc_verbs_wc_to_ucs_status()` static, since it is used only in a single place.