### PR TITLE
TEST/INIT_MT: improved diagnostic

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -928,7 +928,7 @@ test_init_mt() {
 	$MAKEP
 	for ((i=0;i<50;++i))
 	do
-		$AFFINITY timeout 1m ./test/apps/test_init_mt
+		$AFFINITY timeout 5m ./test/apps/test_init_mt
 	done
 }
 

--- a/test/apps/test_init_mt.c
+++ b/test/apps/test_init_mt.c
@@ -14,10 +14,19 @@
 #include <omp.h>
 #endif
 
+#include <time.h>
+#include <sys/time.h>
+
 
 int main(int argc, char **argv)
 {
     int count = 0;
+    struct timeval start;
+    struct timeval finish;
+
+    gettimeofday(&start, NULL);
+    printf("starting test [%ld.%06ld] .. ", start.tv_sec, start.tv_usec);
+    fflush(stdout);
 
 #pragma omp parallel
     {
@@ -50,6 +59,9 @@ int main(int argc, char **argv)
 
 #pragma omp barrier
 
-    printf("finished %d threads\n", count);
+    gettimeofday(&finish, NULL);
+    printf("[%ld.%06ld] finished %d threads\n",
+           finish.tv_sec, finish.tv_usec, count);
+    fflush(stdout);
     return 0;
 }


### PR DESCRIPTION
- there is at test on multithread init test
- in some cases when filesystem works slow test failed
  due to timeout
- this fix excludes FS affect
