### PR TITLE
APPS/IO-DEMO: memcpy removal for AM eager data receiving

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -512,10 +512,11 @@ protected:
             _data_size(0lu), _memory_type(UCS_MEMORY_TYPE_UNKNOWN), _pool(pool)
         {
             _iov.reserve(size);
+            _extra_buf = NULL;
         }
 
         size_t size() const {
-            return _iov.size();
+            return _iov.size() + !!_extra_buf;
         }
 
         size_t data_size() const {
@@ -544,6 +545,14 @@ protected:
             }
         }
 
+        void init(size_t data_size, void *ext_buf)
+        {
+            assert(ext_buf != NULL);
+
+            _data_size = data_size;
+            _extra_buf = ext_buf;
+        }
+
         inline Buffer &operator[](size_t i) const
         {
             return *_iov[i];
@@ -555,11 +564,12 @@ protected:
                 _iov.pop_back();
             }
 
+            _extra_buf = NULL;
             _pool.put(this);
         }
 
         inline size_t validate(unsigned seed) const {
-            assert(!_iov.empty());
+            assert(!_iov.empty() || _extra_buf);
 
             for (size_t iov_err_pos = 0, i = 0; i < _iov.size(); ++i) {
                 size_t buf_err_pos = IoDemoRandom::validate(seed,
@@ -570,6 +580,15 @@ protected:
                 if (buf_err_pos < _iov[i]->size()) {
                     return iov_err_pos;
                 }
+            }
+
+            if (_extra_buf) {
+                size_t buf_err_pos = IoDemoRandom::validate(seed,
+                                                            _extra_buf,
+                                                            _data_size,
+                                                            _memory_type);
+                if (buf_err_pos < _data_size)
+                    return buf_err_pos;
             }
 
             return _npos;
@@ -599,6 +618,7 @@ protected:
         ucs_memory_type_t      _memory_type;
         std::vector<Buffer*>   _iov;
         MemoryPool<BufferIov>& _pool;
+        void                   *_extra_buf;
     };
 
     /* Asynchronous IO message */
@@ -1091,12 +1111,20 @@ public:
         IoWriteResponseCallback *w = _callback_pool.get();
         ConnectionStat &conn_stat  = _conn_stat_map.find(conn)->second;
 
-        iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
+        if (!ucx_am_is_rndv(data_desc)) {
+            iov->init(msg->data_size, ucx_am_get_data(data_desc));
+        } else {
+            iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
+        }
         w->init(this, conn, msg->sn, iov, &conn_stat.completions<IO_WRITE>());
         assert(iov->size() == 1);
 
         conn_stat.bytes<IO_WRITE>() += msg->data_size;
-        conn->recv_am_data((*iov)[0].buffer(), (*iov)[0].size(), data_desc, w);
+        if (!ucx_am_is_rndv(data_desc)) {
+            conn->recv_am_data(NULL, 0, data_desc, w);
+        } else {
+            conn->recv_am_data((*iov)[0].buffer(), (*iov)[0].size(), data_desc, w);
+        }
     }
 
     virtual void dispatch_connection_accepted(UcxConnection* conn) {
@@ -1655,14 +1683,22 @@ public:
                                         msg->data_size);
         } else if (msg->op == IO_READ_COMP) {
             BufferIov *iov = _data_buffers_pool.get();
-            iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
 
+            if (!ucx_am_is_rndv(data_desc)) {
+                iov->init(msg->data_size, ucx_am_get_data(data_desc));
+            } else {
+                iov->init(msg->data_size, _data_chunks_pool, msg->sn, opts().validate);
+            }
             IoReadResponseCallback *r = _read_callback_pool.get();
             r->init(this, server_index, msg->sn, opts().validate, iov, 0);
 
             assert(iov->size() == 1);
 
-            conn->recv_am_data((*iov)[0].buffer(), msg->data_size, data_desc, r);
+            if (!ucx_am_is_rndv(data_desc)) {
+                conn->recv_am_data(NULL, 0, data_desc, r);
+            } else {
+                conn->recv_am_data((*iov)[0].buffer(), msg->data_size, data_desc, r);
+            }
         }
     }
 

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -28,7 +28,16 @@
 /* Forward declarations */
 class UcxConnection;
 struct ucx_request;
-struct UcxAmDesc;
+
+// Holds details of arrived AM message
+struct UcxAmDesc {
+    UcxAmDesc(void *data, const ucp_am_recv_param_t *param) :
+        _data(data), _param(param) {
+    }
+
+    void                         *_data;
+    const ucp_am_recv_param_t    *_param;
+};
 
 /*
  * UCX callback for send/receive completion
@@ -145,6 +154,16 @@ protected:
     void wait_disconnected_connections();
 
     void destroy_listener();
+
+    static inline void *ucx_am_get_data(const UcxAmDesc &desc)
+    {
+        return desc._data;
+    }
+
+    static inline bool ucx_am_is_rndv(const UcxAmDesc &desc)
+    {
+        return desc._param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV;
+    }
 
 private:
     typedef enum {


### PR DESCRIPTION
## What
Using network buffer directly within am receive callback not only avoids extra buffer allocation but also improves throughput.

## Why ?
Using network buffer directly within am receive callback not only avoids extra buffer allocation but also improves throughput.

## How ?
Added a new memory type support for class Buffer. That way keeps the logic clear and not impact current code structure much.
