### PR TITLE
UCT/TCP: Implement flush of all outstanding operations

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -848,6 +848,16 @@ static void uct_perf_test_cleanup_endpoints(ucx_perf_context_t *perf)
     free(perf->uct.peers);
 }
 
+static void ucp_perf_worker_progress(void *arg)
+{
+    ucx_perf_context_t *perf = arg;
+    int i;
+
+    for (i = 0; i < perf->params.thread_count; ++i) {
+        ucp_worker_progress(perf->ucp.tctx[i].perf.ucp.worker);
+    }
+}
+
 static ucs_status_t ucp_perf_test_fill_params(ucx_perf_params_t *params,
                                               ucp_params_t *ucp_params)
 {
@@ -909,8 +919,10 @@ static ucs_status_t ucp_perf_test_fill_params(ucx_perf_params_t *params,
 static void ucp_perf_test_destroy_eps(ucx_perf_context_t* perf)
 {
     unsigned i, thread_count = perf->params.thread_count;
-    ucs_status_ptr_t    *req;
-    ucs_status_t        status;
+    unsigned num_in_prog     = 0;
+    ucs_status_ptr_t **reqs  = ucs_alloca(thread_count * sizeof(*reqs));
+    ucs_status_ptr_t *req;
+    ucs_status_t status;
 
     for (i = 0; i < thread_count; ++i) {
         if (perf->ucp.tctx[i].perf.ucp.rkey != NULL) {
@@ -922,16 +934,22 @@ static void ucp_perf_test_destroy_eps(ucx_perf_context_t* perf)
                                   UCP_EP_CLOSE_MODE_FLUSH);
 
             if (UCS_PTR_IS_PTR(req)) {
-                do {
-                    ucp_worker_progress(perf->ucp.tctx[i].perf.ucp.worker);
-                    status = ucp_request_check_status(req);
-                } while (status == UCS_INPROGRESS);
-
-                ucp_request_release(req);
+                reqs[num_in_prog++] = req;
             } else if (UCS_PTR_STATUS(req) != UCS_OK) {
                 ucs_warn("failed to close ep %p on thread %d: %s\n",
                          perf->ucp.tctx[i].perf.ucp.ep, i,
                          ucs_status_string(UCS_PTR_STATUS(req)));
+            }
+        }
+    }
+
+    while (num_in_prog != 0) {
+        ucp_perf_worker_progress(perf);
+        for (i = 0; i < num_in_prog; ++i) {
+            status = ucp_request_check_status(reqs[i]);
+            if (status != UCS_INPROGRESS) {
+                ucp_request_release(reqs[i]);
+                reqs[i] = reqs[--num_in_prog];
             }
         }
     }
@@ -1323,7 +1341,7 @@ void uct_perf_barrier(ucx_perf_context_t *perf)
              (void*)perf->uct.worker);
 }
 
-void ucp_perf_barrier(ucx_perf_context_t *perf)
+void ucp_perf_thread_barrier(ucx_perf_context_t *perf)
 {
     rte_call(perf, barrier, (void(*)(void*))ucp_worker_progress,
 #if _OPENMP
@@ -1331,6 +1349,11 @@ void ucp_perf_barrier(ucx_perf_context_t *perf)
 #else
              (void*)perf->ucp.tctx[0].perf.ucp.worker);
 #endif
+}
+
+void ucp_perf_barrier(ucx_perf_context_t *perf)
+{
+    rte_call(perf, barrier, ucp_perf_worker_progress, perf);
 }
 
 static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf)
@@ -1566,7 +1589,7 @@ ucx_perf_funcs_t ucx_perf_funcs[] = {
     [UCX_PERF_API_UCT] = {uct_perf_setup, uct_perf_cleanup,
                           uct_perf_test_dispatch, uct_perf_barrier},
     [UCX_PERF_API_UCP] = {ucp_perf_setup, ucp_perf_cleanup,
-                          ucp_perf_test_dispatch, ucp_perf_barrier}
+                          ucp_perf_test_dispatch, ucp_perf_thread_barrier}
 };
 
 ucs_status_t ucx_perf_run(const ucx_perf_params_t *params,

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -149,6 +149,7 @@ ucs_status_t uct_perf_test_dispatch(ucx_perf_context_t *perf);
 ucs_status_t ucp_perf_test_dispatch(ucx_perf_context_t *perf);
 void ucx_perf_calc_result(ucx_perf_context_t *perf, ucx_perf_result_t *result);
 void uct_perf_barrier(ucx_perf_context_t *perf);
+void ucp_perf_thread_barrier(ucx_perf_context_t *perf);
 void ucp_perf_barrier(ucx_perf_context_t *perf);
 
 ucs_status_t ucp_perf_test_alloc_mem(ucx_perf_context_t *perf);

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -109,7 +109,9 @@ enum {
      * method. */
     UCT_TCP_EP_FLAG_CONNECT_TO_EP      = UCS_BIT(8),
     /* EP is on EP PTR map. */
-    UCT_TCP_EP_FLAG_ON_PTR_MAP         = UCS_BIT(9)
+    UCT_TCP_EP_FLAG_ON_PTR_MAP         = UCS_BIT(9),
+    /* EP has some operations done without flush */
+    UCT_TCP_EP_FLAG_NEED_FLUSH         = UCS_BIT(10)
 };
 
 
@@ -217,7 +219,7 @@ typedef enum uct_tcp_ep_am_id {
     UCT_TCP_EP_PUT_REQ_AM_ID   = UCT_AM_ID_MAX + 1,
     /* AM ID reserved for TCP internal PUT ACK message */
     UCT_TCP_EP_PUT_ACK_AM_ID   = UCT_AM_ID_MAX + 2,
-    /* AM ID reserved for TCP internal PUT ACK message */
+    /* AM ID reserved for TCP internal keepalive message */
     UCT_TCP_EP_KEEPALIVE_AM_ID = UCT_AM_ID_MAX + 3
 } uct_tcp_ep_am_id_t;
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -516,8 +516,9 @@ bool ucp_test::check_tls(const std::string& tls)
 ucp_test_base::entity::entity(const ucp_test_param& test_param,
                               ucp_config_t* ucp_config,
                               const ucp_worker_params_t& worker_params,
-                              const ucp_test_base *test_owner)
-    : m_err_cntr(0), m_rejected_cntr(0), m_accept_err_cntr(0)
+                              const ucp_test_base *test_owner) :
+        m_err_cntr(0), m_rejected_cntr(0), m_accept_err_cntr(0),
+        m_test(test_owner)
 {
     const int thread_type                   = test_param.variant.thread_type;
     ucp_params_t local_ctx_params           = test_param.variant.ctx_params;
@@ -987,7 +988,10 @@ void ucp_test_base::entity::ep_destructor(ucp_ep_h ep, entity *e)
     ucs_status_t        status;
     ucp_tag_recv_info_t info;
     do {
-        e->progress();
+        const ucp_test *test = dynamic_cast<const ucp_test*>(e->m_test);
+        ASSERT_TRUE(test != NULL);
+
+        test->progress();
         status = ucp_request_test(req, &info);
     } while (status == UCS_INPROGRESS);
     EXPECT_EQ(UCS_OK, status);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -165,6 +165,7 @@ public:
         size_t                          m_rejected_cntr;
         size_t                          m_accept_err_cntr;
         ucs::handle<ucp_ep_params_t*>   m_server_ep_params;
+        const ucp_test_base             *m_test;
 
     private:
         static void empty_send_completion(void *r, ucs_status_t status);


### PR DESCRIPTION
## What

 Implement flush of all outstanding operations.

## Why ?

To fix `uct_ep_flush()` which don't wait for all operations being completed. As a result if fixes the following case:
```
/* client */
for (i= 0; i < 1000; ++i) { 
    req = ucp_ep_tag_send_nb(ep)
    reqs.push_back(req);
}
wait_for_reqs(reqs);

req = ucp_ep_close_nb(ep, FLUSH);
wait_for_req(req);

exit(0);
```
```
/* server */
for (i = 0; i < 1000; ++i) {
    req = ucp_worker_tag_recv_nb(worker);
    reqs.push_back(req);
}
wait_for_reqs(reqs);

/* 998-999 completed successfully, but 1-2 completed with error  */
```

## How ?

1. Do PUT operation if `last_acked_sn != tx.sn` in EP
2. Fix EP flush conditions when checking resources. Return `UCS_OK` if connection has already been closed.
3. Fix tests.