### PR TITLE
UCS/UCP/UCT: Introduce maximum conn_sn after which conn_match isn't done

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2116,7 +2116,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     /* Initialize connection matching structure */
     ucs_conn_match_init(&worker->conn_match_ctx, sizeof(uint64_t),
-                        &ucp_ep_match_ops);
+                        UCP_EP_MATCH_CONN_SN_MAX, &ucp_ep_match_ops);
 
     /* Open all resources as interfaces on this worker */
     status = ucp_worker_add_resource_ifaces(worker);

--- a/src/ucp/wireup/ep_match.h
+++ b/src/ucp/wireup/ep_match.h
@@ -39,9 +39,9 @@ ucp_ep_match_conn_sn_t ucp_ep_match_get_sn(ucp_worker_h worker,
                                            uint64_t dest_uuid);
 
 
-void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
-                         ucp_ep_match_conn_sn_t conn_sn,
-                         ucs_conn_match_queue_type_t conn_queue_type);
+int ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
+                        ucp_ep_match_conn_sn_t conn_sn,
+                        ucs_conn_match_queue_type_t conn_queue_type);
 
 
 ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -534,8 +534,10 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
 
             /* add internal endpoint to hash */
             ep->conn_sn = msg->conn_sn;
-            ucp_ep_match_insert(worker, ep, remote_uuid, ep->conn_sn,
-                                UCS_CONN_MATCH_QUEUE_UNEXP);
+            if (!ucp_ep_match_insert(worker, ep, remote_uuid, ep->conn_sn,
+                                     UCS_CONN_MATCH_QUEUE_UNEXP)) {
+                ucp_ep_flush_state_reset(ep);
+            }
         } else {
             ucp_ep_flush_state_reset(ep);
         }

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -52,6 +52,7 @@ ucs_global_opts_t ucs_global_opts = {
     .rcache_check_pfn      = 0,
     .module_dir            = UCX_MODULE_DIR, /* defined in Makefile.am */
     .module_log_level      = UCS_LOG_LEVEL_TRACE,
+    .initial_conn_sn       = 0,
     .arch                  = UCS_ARCH_GLOBAL_OPTS_INITALIZER
 };
 
@@ -261,6 +262,10 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   {"MODULE_LOG_LEVEL", "trace",
    "Logging level for module loader\n",
    ucs_offsetof(ucs_global_opts_t, module_log_level), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
+
+   {"INITIAL_CONN_SN", "0",
+    "Initial value for the connection sequence number",
+    ucs_offsetof(ucs_global_opts_t, initial_conn_sn), UCS_CONFIG_TYPE_ULUNITS},
 
   {"", "", NULL,
    ucs_offsetof(ucs_global_opts_t, arch),

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -135,6 +135,9 @@ typedef struct {
 
     /* Enable affinity for virtual monitoring filesystem service thread */
     int                        vfs_thread_affinity;
+
+    /* Initial value for the connection sequence number */
+    unsigned long              initial_conn_sn;
 } ucs_global_opts_t;
 
 

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -17,6 +17,12 @@ BEGIN_C_DECLS
 
 
 /**
+ * Maximal value for connection sequence number 
+ */
+#define UCS_CONN_MATCH_SN_MAX ((ucs_conn_sn_t)-1)
+
+
+/**
  * Connection sequence number
  */
 typedef uint64_t ucs_conn_sn_t;
@@ -125,6 +131,8 @@ KHASH_TYPE(ucs_conn_match, ucs_conn_match_peer_t*, char)
  */
 struct ucs_conn_match_ctx {
     khash_t(ucs_conn_match)      hash;           /* Hash of matched connections */
+    ucs_conn_sn_t                max_conn_sn;    /* Maximum value for the connection sequence
+                                                  * number */
     size_t                       address_length; /* Length of the addresses used for the
                                                     connection between peers */
     ucs_conn_match_ops_t         ops;            /* User's connection matching operations */
@@ -137,11 +145,12 @@ struct ucs_conn_match_ctx {
  * @param [in] conn_match_ctx    Pointer to the connection matching context.
  * @param [in] address_length    Length of the addresses used for the connection
  *                               between peers.
+ * @param [in] max_conn_sn       Maximum value for the connection sequence number.
  * @param [in] ops               Pointer to the user-defined connection matching
  *                               operations.
  */
 void ucs_conn_match_init(ucs_conn_match_ctx_t *conn_match_ctx,
-                         size_t address_length,
+                         size_t address_length, size_t max_conn_sn,
                          const ucs_conn_match_ops_t *ops);
 
 
@@ -177,11 +186,14 @@ ucs_conn_sn_t ucs_conn_match_get_next_sn(ucs_conn_match_ctx_t *conn_match_ctx,
  * @param [in] elem              Pointer to the connection matching structure.
  * @param [in] conn_queue_type   Connection queue which should be used to insert
  *                               the connection matching element to.
+ *
+ * @return Flag that indicates whether connection element was added
+ *         successfully or not to the connection matching context.
  */
-void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
-                           const void *address, ucs_conn_sn_t conn_sn,
-                           ucs_conn_match_elem_t *elem,
-                           ucs_conn_match_queue_type_t conn_queue_type);
+int ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
+                          const void *address, ucs_conn_sn_t conn_sn,
+                          ucs_conn_match_elem_t *elem,
+                          ucs_conn_match_queue_type_t conn_queue_type);
 
 
 /**

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -21,6 +21,9 @@
 #include <sys/poll.h>
 
 
+#define UCT_UD_IFACE_CEP_CONN_SN_MAX ((uct_ud_ep_conn_sn_t)-1)
+
+
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ud_iface_stats_class = {
     .name          = "ud_iface",
@@ -68,11 +71,11 @@ uct_ud_iface_cep_get_conn_sn(uct_ud_iface_t *iface,
                              int path_index)
 {
     void *peer_address = ucs_alloca(iface->conn_match_ctx.address_length);
-    return (uct_ud_ep_conn_sn_t)
-           ucs_conn_match_get_next_sn(&iface->conn_match_ctx,
+
+    return ucs_conn_match_get_next_sn(&iface->conn_match_ctx,
                                       uct_ud_iface_cep_get_peer_address(
-                                          iface, ib_addr, if_addr, path_index,
-                                          peer_address));
+                                            iface, ib_addr, if_addr,
+                                            path_index, peer_address));;
 }
 
 void uct_ud_iface_cep_insert_ep(uct_ud_iface_t *iface,
@@ -90,9 +93,10 @@ void uct_ud_iface_cep_insert_ep(uct_ud_iface_t *iface,
                                       peer_address);
 
     ucs_assert(!(ep->flags & UCT_UD_EP_FLAG_ON_CEP));
-    ucs_conn_match_insert(&iface->conn_match_ctx, peer_address,
-                          conn_sn, &ep->conn_match, queue_type);
-    ep->flags |= UCT_UD_EP_FLAG_ON_CEP;
+    if (ucs_conn_match_insert(&iface->conn_match_ctx, peer_address,
+                              conn_sn, &ep->conn_match, queue_type)) {
+        ep->flags |= UCT_UD_EP_FLAG_ON_CEP;
+    }
 }
 
 uct_ud_ep_t *uct_ud_iface_cep_get_ep(uct_ud_iface_t *iface,
@@ -313,7 +317,7 @@ ucs_status_t uct_ud_iface_complete_init(uct_ud_iface_t *iface)
                         uct_iface_invoke_ops_func(&iface->super,
                                                   uct_ud_iface_ops_t,
                                                   get_peer_address_length),
-                        &conn_match_ops);
+                        UCT_UD_IFACE_CEP_CONN_SN_MAX, &conn_match_ops);
 
     status = ucs_twheel_init(&iface->tx.timer, iface->tx.tick / 4,
                              uct_ud_iface_get_time(iface));

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -659,7 +659,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     ucs_list_head_init(&self->ep_list);
     ucs_conn_match_init(&self->conn_match_ctx,
                         ucs_field_sizeof(uct_tcp_ep_t, peer_addr),
-                        &uct_tcp_cm_conn_match_ops);
+                        UCS_CONN_MATCH_SN_MAX, &uct_tcp_cm_conn_match_ops);
     status = ucs_ptr_map_init(&self->ep_ptr_map);
     ucs_assert_always(status == UCS_OK);
 

--- a/test/gtest/ucs/test_conn_match.cc
+++ b/test/gtest/ucs/test_conn_match.cc
@@ -36,7 +36,7 @@ private:
         conn_match_ops.purge_cb    = purge_cb;
 
         ucs_conn_match_init(&m_conn_match_ctx, address_length,
-                            &conn_match_ops);
+                            UCS_CONN_MATCH_SN_MAX, &conn_match_ops);
         m_address_length = address_length;
     }
 
@@ -104,8 +104,10 @@ protected:
 
     void insert(const void *dest_address, ucs_conn_sn_t conn_sn,
                 ucs_conn_match_queue_type_t queue_type, conn_elem_t &elem) {
-        ucs_conn_match_insert(&m_conn_match_ctx, dest_address, conn_sn,
-                              &elem.elem, queue_type);
+        int ret = ucs_conn_match_insert(&m_conn_match_ctx, dest_address,
+                                        conn_sn, &elem.elem, queue_type);
+        ASSERT_TRUE(ret);
+
         elem.queue_type = queue_type;
         elem.conn_sn    = conn_sn;
         m_added_elems++;


### PR DESCRIPTION
## What

Introduce maximum conn_sn after which conn_match isn't done.

## Why ?

If total number of connection established to some peer reaches maximum supported value, don't use connection matching.

## How ?

1. Accept `max_conn_sn` value in `ucs_conn_match_init()` which is used to check whether maximum conn_sn value is reached or not.
2. Update all functions to not insert/get/retrieve connections with `conn_sn`  equal to `max_conn_sn`.
3. Introduce `UCX_INITIAL_CONN_SN` configuration parameter to accept value which indicates starting value of conn_sn allocation (it is `0` by default). The parameter is used for testing purposes and can be used to disable connection matching for TCP. UD and UCP.