### PR TITLE
UCP/CORE: Set lanes failed when error is detected, Don't invoke set_ep_failed from async thread - v1.11.x

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -336,12 +336,6 @@ static ucs_config_field_t ucp_config_table[] = {
    "endpoint.",
    ucs_offsetof(ucp_config_t, ctx.proto_indirect_id), UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
-  {"ERROR_HANDLER_DELAY", "0us",
-   "Artificial delay between detecting an error and processing it (0 - disabled).\n"
-   "Used for testing purposes",
-   ucs_offsetof(ucp_config_t, ctx.err_handler_delay),
-   UCS_CONFIG_TYPE_TIME_UNITS},
-
    {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t,

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -117,8 +117,6 @@ typedef struct ucp_context_config {
     ucs_on_off_auto_value_t                proto_indirect_id;
     /** Bitmap of memory types whose allocations are registered fully */
     unsigned                               reg_whole_alloc_bitmap;
-    /** Error handler delay */
-    ucs_time_t                             err_handler_delay;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -46,6 +46,17 @@ typedef struct {
     size_t bw;
 } ucp_ep_thresh_params_t;
 
+
+/**
+ * Argument for the setting UCP endpoint as failed
+ */
+typedef struct ucp_ep_set_failed_arg {
+    ucp_ep_h         ucp_ep; /* UCP endpoint which is failed */
+    ucp_lane_index_t lane; /* UCP endpoint lane which is failed  */
+    ucs_status_t     status; /* Failure status */
+} ucp_ep_set_failed_arg_t;
+
+
 extern const ucp_request_send_proto_t ucp_stream_am_proto;
 extern const ucp_request_send_proto_t ucp_am_proto;
 extern const ucp_request_send_proto_t ucp_am_reply_proto;
@@ -249,26 +260,45 @@ ucp_ep_local_disconnect_progress_remove_filter(const ucs_callbackq_elem_t *elem,
     return 1;
 }
 
-static UCS_F_NOINLINE void ucp_ep_remove_progress_callbacks(ucp_ep_h ep)
+static unsigned ucp_ep_set_failed_progress(void *arg)
 {
-    ucp_worker_h worker = ep->worker;
+    ucp_ep_set_failed_arg_t *set_ep_failed_arg = arg;
+    ucp_ep_h ucp_ep                            = set_ep_failed_arg->ucp_ep;
+    ucp_worker_h worker                        = ucp_ep->worker;
 
-    /* Remove pending slow-path functions after all UCT EP lanes are destroyed,
-     * because cleanup lanes purges all outstanding operation and purged
-     * operations could add callbacks on the progress */
-    ucs_assert(ep->refcount == 0);
+    UCS_ASYNC_BLOCK(&worker->async);
+    ucp_ep_set_failed(ucp_ep, set_ep_failed_arg->lane,
+                      set_ep_failed_arg->status);
+    UCS_ASYNC_UNBLOCK(&worker->async);
 
-    ucs_callbackq_remove_if(&ep->worker->uct->progress_q,
-                            ucp_wireup_msg_ack_cb_pred, ep);
+    ucs_free(set_ep_failed_arg);
+    return 1;
+}
 
-    ucs_callbackq_remove_if(&worker->uct->progress_q,
-                            ucp_worker_err_handle_remove_filter, ep);
+static int ucp_ep_set_failed_remove_filter(const ucs_callbackq_elem_t *elem,
+                                           void *arg)
+{
+    ucp_ep_set_failed_arg_t *set_ep_failed_arg = elem->arg;
 
-    ucs_callbackq_remove_if(&worker->uct->progress_q,
-                            ucp_listener_accept_cb_remove_filter, ep);
+    if ((elem->cb == ucp_ep_set_failed_progress) &&
+        (set_ep_failed_arg->ucp_ep == arg)) {
+        ucs_free(set_ep_failed_arg);
+        return 1;
+    }
 
-    ucs_callbackq_remove_if(&worker->uct->progress_q,
-                            ucp_ep_local_disconnect_progress_remove_filter, ep);
+    return 0;
+}
+
+static int ucp_ep_remove_filter(const ucs_callbackq_elem_t *elem, void *arg)
+{
+    if (ucp_wireup_msg_ack_cb_pred(elem, arg) ||
+        ucp_listener_accept_cb_remove_filter(elem, arg) ||
+        ucp_ep_local_disconnect_progress_remove_filter(elem, arg) ||
+        ucp_ep_set_failed_remove_filter(elem, arg)) {
+        return 1;
+    }
+
+    return 0;
 }
 
 static void ucp_ep_destroy_base(ucp_ep_h ep)
@@ -279,7 +309,8 @@ static void ucp_ep_destroy_base(ucp_ep_h ep)
     ucs_assert(ucs_hlist_is_empty(&ucp_ep_ext_gen(ep)->proto_reqs));
 
     ucs_vfs_obj_remove(ep);
-    ucp_ep_remove_progress_callbacks(ep);
+    ucs_callbackq_remove_if(&ep->worker->uct->progress_q, ucp_ep_remove_filter,
+                            ep);
     UCS_STATS_NODE_FREE(ep->stats);
     ucs_free(ucp_ep_ext_control(ep));
     ucs_strided_alloc_put(&ep->worker->ep_alloc, ep);
@@ -1013,6 +1044,100 @@ static void ucp_ep_set_lanes_failed(ucp_ep_h ep, uct_ep_h *uct_eps)
     }
 }
 
+void ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                       ucs_status_t status)
+{
+    UCS_STRING_BUFFER_ONSTACK(lane_info_strb, 64);
+    ucp_ep_ext_control_t *ep_ext_control = ucp_ep_ext_control(ucp_ep);
+    ucs_log_level_t log_level;
+    ucp_request_t *close_req;
+
+    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(ucp_ep->worker);
+    ucs_assert(!ucs_async_is_from_async(&ucp_ep->worker->async));
+
+    ucs_debug("ep %p: set_ep_failed status %s on lane[%d]=%p", ucp_ep,
+              ucs_status_string(status), lane,
+              (lane != UCP_NULL_LANE) ? ucp_ep->uct_eps[lane] : NULL);
+
+    /* In case if this is a local failure we need to notify remote side */
+    if (ucp_ep_is_cm_local_connected(ucp_ep)) {
+        ucp_ep_cm_disconnect_cm_lane(ucp_ep);
+    }
+
+    /* set endpoint to failed to prevent wireup_ep switch */
+    if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
+        return;
+    }
+
+    /* The EP can be closed from last completion callback */
+    ucp_ep_discard_lanes(ucp_ep, status);
+    ucp_ep_reqs_purge(ucp_ep, status);
+    ucp_stream_ep_cleanup(ucp_ep);
+
+    if (ucp_ep->flags & UCP_EP_FLAG_USED) {
+        if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
+            ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
+            /* Promote close operation to CANCEL in case of transport error,
+             * since the disconnect event may never arrive. */
+            close_req                        = ep_ext_control->close_req.req;
+            close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
+            ucp_ep_local_disconnect_progress(close_req);
+        } else if (ep_ext_control->err_cb == NULL) {
+            /* Do not print error if connection reset by remote peer since it
+             * can be part of user level close protocol */
+            log_level = (status == UCS_ERR_CONNECTION_RESET) ?
+                        UCS_LOG_LEVEL_DIAG : UCS_LOG_LEVEL_ERROR;
+
+            ucp_ep_get_lane_info_str(ucp_ep, lane, &lane_info_strb);
+            ucs_log(log_level, "ep %p: error '%s' on %s will not be handled"
+                    " since no error callback is installed",
+                    ucp_ep, ucs_status_string(status),
+                    ucs_string_buffer_cstr(&lane_info_strb));
+        } else {
+            ucp_ep_invoke_err_cb(ucp_ep, status);
+        }
+    } else if (ucp_ep->flags & (UCP_EP_FLAG_INTERNAL | UCP_EP_FLAG_CLOSED)) {
+        /* No additional actions are required, this is already closed EP or
+         * an internal one for sending WIREUP/EP_REMOVED messsage to a peer.
+         * So, close operation was already scheduled, this EP will be deleted
+         * after all lanes will be discarded successfully */
+        ucs_debug("ep %p: detected peer failure on internal endpoint", ucp_ep);
+    } else {
+        ucs_debug("ep %p: destroy endpoint which is not exposed to a user due"
+                  " to peer failure", ucp_ep);
+        ucp_ep_disconnected(ucp_ep, 1);
+    }
+}
+
+void ucp_ep_set_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                                ucs_status_t status)
+{
+    ucp_worker_h worker        = ucp_ep->worker;
+    uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
+    ucp_ep_set_failed_arg_t *set_ep_failed_arg;
+
+    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(worker);
+
+    set_ep_failed_arg = ucs_malloc(sizeof(*set_ep_failed_arg),
+                                   "set_ep_failed_arg");
+    if (set_ep_failed_arg == NULL) {
+        ucs_error("failed to allocate set_ep_failed argument");
+        return;
+    }
+
+    set_ep_failed_arg->ucp_ep = ucp_ep;
+    set_ep_failed_arg->lane   = lane;
+    set_ep_failed_arg->status = status;
+
+    uct_worker_progress_register_safe(worker->uct, ucp_ep_set_failed_progress,
+                                      set_ep_failed_arg,
+                                      UCS_CALLBACKQ_FLAG_ONESHOT, &prog_id);
+
+    /* If the worker supports the UCP_FEATURE_WAKEUP feature, signal the user so
+     * that he can wake-up on this event */
+    ucp_worker_signal_internal(worker);
+}
+
 void ucp_ep_cleanup_lanes(ucp_ep_h ep)
 {
     uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
@@ -1159,14 +1284,15 @@ ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
 
 void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t status)
 {
+    unsigned ep_flush_flags = (ucp_ep_config(ep)->key.err_mode ==
+                                       UCP_ERR_HANDLING_MODE_NONE) ?
+                              UCT_FLUSH_FLAG_LOCAL: UCT_FLUSH_FLAG_CANCEL;
     uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
     ucp_lane_index_t lane;
     uct_ep_h uct_ep;
 
     ucs_debug("ep %p: discarding lanes", ep);
 
-    /* flush CANCEL mustn't be called for EPs without error handling support */
-    ucs_assert(ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER);
     ucp_ep_set_lanes_failed(ep, uct_eps);
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
@@ -1176,7 +1302,7 @@ void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t status)
         }
 
         ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
-        ucp_worker_discard_uct_ep(ep, uct_ep, UCT_FLUSH_FLAG_CANCEL,
+        ucp_worker_discard_uct_ep(ep, uct_ep, ep_flush_flags,
                                   ucp_ep_err_pending_purge,
                                   UCS_STATUS_PTR(status),
                                   (ucp_send_nbx_callback_t)ucs_empty_function,
@@ -2668,14 +2794,34 @@ void ucp_ep_get_tl_bitmap(ucp_ep_h ep, ucp_tl_bitmap_t *tl_bitmap)
     }
 }
 
+void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                              ucs_string_buffer_t *lane_info_strb)
+{
+    ucp_rsc_index_t rsc_index;
+    uct_tl_resource_desc_t *tl_rsc;
+
+    if (lane == UCP_NULL_LANE) {
+        ucs_string_buffer_appendf(lane_info_strb, "NULL lane");
+    } else if (lane == ucp_ep_get_cm_lane(ucp_ep)) {
+        ucs_string_buffer_appendf(lane_info_strb, "CM lane");
+    } else {
+        rsc_index = ucp_ep_get_rsc_index(ucp_ep, lane);
+        tl_rsc    = &ucp_ep->worker->context->tl_rscs[rsc_index].tl_rsc;
+
+        ucs_string_buffer_appendf(lane_info_strb,
+                                  UCT_TL_RESOURCE_DESC_FMT,
+                                  UCT_TL_RESOURCE_DESC_ARG(tl_rsc));
+    }
+}
+
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status)
 {
-    /* Do not invoke error handler if it's not enabled */
-    if ((ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) ||
-        /* error callback is not set */
-        (ucp_ep_ext_control(ep)->err_cb == NULL) ||
-        /* the EP has been closed by user, or error callback already called */
-        (ep->flags & (UCP_EP_FLAG_CLOSED | UCP_EP_FLAG_ERR_HANDLER_INVOKED))) {
+    ucs_assert(ucp_ep_ext_control(ep)->err_cb != NULL);
+    ucs_assert(ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_NONE);
+
+    /* Do not invoke error handler if the EP has been closed by user, or error
+     * callback already called */
+    if ((ep->flags & (UCP_EP_FLAG_CLOSED | UCP_EP_FLAG_ERR_HANDLER_INVOKED))) {
         return;
     }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -582,6 +582,12 @@ void ucp_ep_disconnected(ucp_ep_h ep, int force);
 
 void ucp_ep_destroy_internal(ucp_ep_h ep);
 
+void ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                       ucs_status_t status);
+
+void ucp_ep_set_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                                ucs_status_t status);
+
 void ucp_ep_cleanup_lanes(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
@@ -631,6 +637,9 @@ int ucp_ep_is_local_connected(ucp_ep_h ep);
 unsigned ucp_ep_local_disconnect_progress(void *arg);
 
 size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_ep_config_t *config);
+
+void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                              ucs_string_buffer_t *lane_info_strb);
 
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -311,16 +311,6 @@ typedef struct ucp_worker {
 } ucp_worker_t;
 
 
-/**
- * UCP worker argument for the error handling callback
- */
-typedef struct ucp_worker_err_handle_arg {
-    ucp_ep_h         ucp_ep;
-    ucs_time_t       timeout;
-    ucs_status_t     status;
-} ucp_worker_err_handle_arg_t;
-
-
 ucs_status_t
 ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_ep_config_key_t *key,
                          int print_cfg, ucp_worker_cfg_index_t *cfg_index_p);
@@ -347,13 +337,6 @@ void ucp_worker_iface_unprogress_ep(ucp_worker_iface_t *wiface);
 void ucp_worker_signal_internal(ucp_worker_h worker);
 
 void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags);
-
-int ucp_worker_err_handle_remove_filter(const ucs_callbackq_elem_t *elem,
-                                        void *arg);
-
-ucs_status_t ucp_worker_set_ep_failed(ucp_worker_h worker, ucp_ep_h ucp_ep,
-                                      uct_ep_h uct_ep, ucp_lane_index_t lane,
-                                      ucs_status_t status);
 
 void ucp_worker_keepalive_add_ep(ucp_ep_h );
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -438,7 +438,7 @@ ucp_wireup_init_lanes_by_request(ucp_worker_h worker, ucp_ep_h ep,
         return UCS_OK;
     }
 
-    ucp_worker_set_ep_failed(worker, ep, NULL, UCP_NULL_LANE, status);
+    ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, status);
     return status;
 }
 
@@ -796,8 +796,7 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
         ucp_wireup_send_ep_removed(worker, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_EP_REMOVED) {
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
-        ucp_worker_set_ep_failed(worker, ep, NULL, UCP_NULL_LANE,
-                                 UCS_ERR_CONNECTION_RESET);
+        ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, UCS_ERR_CONNECTION_RESET);
     } else {
         ucs_bug("invalid wireup message");
     }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -90,8 +90,7 @@ static unsigned ucp_cm_client_try_next_cm_progress(void *arg)
         ucs_error("failed to create a uct sockaddr endpoint on %s cm %p",
                   ucp_context_cm_name(context, cm_idx), worker->cms[cm_idx].cm);
 
-        ucp_worker_set_ep_failed(worker, ucp_ep, &cm_wireup_ep->super.super,
-                                 ucp_ep_get_cm_lane(ucp_ep), status);
+        ucp_ep_set_failed(ucp_ep, ucp_ep_get_cm_lane(ucp_ep), status);
     }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
@@ -455,9 +454,7 @@ try_fallback:
     }
 
 err:
-    ucp_worker_set_ep_failed(worker, ep,
-                             &ucp_ep_get_cm_wireup_ep(ep)->super.super,
-                             ucp_ep_get_cm_lane(ep), status);
+    ucp_ep_set_failed(ep, ucp_ep_get_cm_lane(ep), status);
 out:
     ucs_free(ucp_addr);
     UCS_ASYNC_UNBLOCK(&worker->async);
@@ -499,10 +496,7 @@ ucp_cm_client_resolve_cb(void *user_data, const uct_cm_ep_resolve_args_t *args)
                  args->dev_name);
         status = UCS_ERR_UNREACHABLE;
         if (!ucp_cm_client_try_fallback_cms(ep)) {
-            ucp_worker_set_ep_failed(worker, ep,
-                                     &cm_wireup_ep->super.super,
-                                     ucp_ep_get_cm_lane(ep), status);
-
+            ucp_ep_set_failed_schedule(ep, ucp_ep_get_cm_lane(ep), status);
         }
         goto out;
     }
@@ -617,8 +611,7 @@ out_free_addr:
     ucs_free(addr.address_list);
 out:
     if (status != UCS_OK) {
-        ucp_worker_set_ep_failed(worker, ucp_ep, &wireup_ep->super.super,
-                                 ucp_ep_get_cm_lane(ucp_ep), status);
+        ucp_ep_set_failed(ucp_ep, ucp_ep_get_cm_lane(ucp_ep), status);
     }
 
     ucs_log_indent(-1);
@@ -735,8 +728,7 @@ err_free_arg:
     ucs_free(progress_arg);
 err_out:
     UCS_ASYNC_BLOCK(&worker->async);
-    ucp_worker_set_ep_failed(worker, ucp_ep, uct_cm_ep,
-                             ucp_ep_get_cm_lane(ucp_ep), status);
+    ucp_ep_set_failed_schedule(ucp_ep, ucp_ep_get_cm_lane(ucp_ep), status);
     UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
@@ -775,9 +767,7 @@ static void ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
     }
 
 set_ep_failed:
-    ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep,
-                             ucp_ep_get_cm_uct_ep(ucp_ep),
-                             ucp_ep_get_cm_lane(ucp_ep), status);
+    ucp_ep_set_failed(ucp_ep, ucp_ep_get_cm_lane(ucp_ep), status);
 }
 
 static unsigned ucp_ep_cm_disconnect_progress(void *arg)
@@ -1235,7 +1225,6 @@ static void ucp_cm_server_conn_notify_cb(
 {
     ucp_ep_h ucp_ep            = arg;
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
-    ucp_lane_index_t cm_lane;
     ucs_status_t status;
 
     ucs_assert_always(notify_args->field_mask &
@@ -1257,9 +1246,7 @@ static void ucp_cm_server_conn_notify_cb(
     } else {
         /* if reject is arrived on server side, then UCT does something wrong */
         ucs_assert(status != UCS_ERR_REJECTED);
-        cm_lane = ucp_ep_get_cm_lane(ucp_ep);
-        ucp_worker_set_ep_failed(ucp_ep->worker, ucp_ep,
-                                 ucp_ep->uct_eps[cm_lane], cm_lane, status);
+        ucp_ep_set_failed_schedule(ucp_ep, ucp_ep_get_cm_lane(ucp_ep), status);
     }
 }
 
@@ -1326,7 +1313,6 @@ ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
     return UCS_OK;
 
 err:
-    ucp_worker_set_ep_failed(worker, ep, ep->uct_eps[lane], lane, status);
     /* coverity[leaked_storage] (uct_ep) */
     return status;
 }

--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -412,6 +412,11 @@ void ucs_async_context_destroy(ucs_async_context_t *async)
     ucs_free(async);
 }
 
+int ucs_async_is_from_async(const ucs_async_context_t *async)
+{
+    return ucs_async_method_call(async->mode, is_from_async);
+}
+
 static ucs_status_t
 ucs_async_alloc_handler(int min_id, int max_id, ucs_async_mode_t mode,
                         ucs_event_set_types_t events, ucs_async_event_cb_t cb,

--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -74,6 +74,17 @@ void ucs_async_context_cleanup(ucs_async_context_t *async);
 
 
 /**
+ * Returns whether a function called from an async thread or not.
+ *
+ * @param async Event context to check `is_called_from_async` status for.
+ *
+ * @return 0 - isn't called from an async thread, otherwise - from an async
+ *         thread.
+ */
+int ucs_async_is_from_async(const ucs_async_context_t *async);
+
+
+/**
  * Check if an async callback was missed because the main thread has blocked
  * the async context. This works as edge-triggered.
  * Should be called with the lock held.

--- a/src/ucs/async/async_int.h
+++ b/src/ucs/async/async_int.h
@@ -53,6 +53,8 @@ typedef void (*ucs_async_init_t)();
 
 typedef void (*ucs_async_cleanup_t)();
 
+typedef int (*ucs_async_is_from_async_t)();
+
 typedef void (*ucs_async_block_t)();
 
 typedef void (*ucs_async_unblock_t)();
@@ -90,6 +92,7 @@ typedef ucs_status_t (*ucs_async_remove_timer_t)(ucs_async_context_t *async,
 typedef struct ucs_async_ops {
     ucs_async_init_t              init;
     ucs_async_cleanup_t           cleanup;
+    ucs_async_is_from_async_t     is_from_async;
 
     ucs_async_block_t             block;
     ucs_async_unblock_t           unblock;

--- a/src/ucs/async/signal.c
+++ b/src/ucs/async/signal.c
@@ -619,6 +619,8 @@ static void ucs_async_signal_global_cleanup()
 ucs_async_ops_t ucs_async_signal_ops = {
     .init               = ucs_async_signal_global_init,
     .cleanup            = ucs_async_signal_global_cleanup,
+    .is_from_async      =
+            (ucs_async_is_from_async_t)ucs_empty_function_return_zero,
     .block              = ucs_async_signal_block_all,
     .unblock            = ucs_async_signal_unblock_all,
     .context_init       = ucs_async_signal_init,

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -231,6 +231,11 @@ out_unlock:
     return status;
 }
 
+static int ucs_async_thread_is_from_async()
+{
+    return pthread_self() == ucs_async_thread_global_context.thread->thread_id;
+}
+
 static void ucs_async_thread_stop()
 {
     ucs_async_thread_t *thread = NULL;
@@ -434,6 +439,7 @@ static void ucs_async_signal_global_cleanup()
 ucs_async_ops_t ucs_async_thread_spinlock_ops = {
     .init               = ucs_empty_function,
     .cleanup            = ucs_async_signal_global_cleanup,
+    .is_from_async      = ucs_async_thread_is_from_async,
     .block              = ucs_empty_function,
     .unblock            = ucs_empty_function,
     .context_init       = ucs_async_thread_spinlock_init,
@@ -450,6 +456,7 @@ ucs_async_ops_t ucs_async_thread_spinlock_ops = {
 ucs_async_ops_t ucs_async_thread_mutex_ops = {
     .init               = ucs_empty_function,
     .cleanup            = ucs_async_signal_global_cleanup,
+    .is_from_async      = ucs_async_thread_is_from_async,
     .block              = ucs_empty_function,
     .unblock            = ucs_empty_function,
     .context_init       = ucs_async_thread_mutex_init,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -691,31 +691,6 @@ protected:
 
 unsigned test_ucp_sockaddr::m_err_count = 0;
 
-UCS_TEST_P(test_ucp_sockaddr, close_ep_force_before_err_cb,
-           "ERROR_HANDLER_DELAY=1s") {
-    const size_t num_sends = 3000; // should be big enough to fill up TX-queue
-    std::vector<char> buffer(20);
-
-    listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    for (size_t i = 0; i < num_sends; ++i) {
-        ucs_status_ptr_t req = ucp_stream_send_nb(sender().ep(), &buffer[0],
-                                                  buffer.size(),
-                                                  ucp_dt_make_contig(1),
-                                                  scomplete_cb, 0);
-        if (UCS_PTR_IS_PTR(req)) {
-            ucp_request_free(req);
-        }
-    }
-
-    ucs_time_t deadline = ucs::get_deadline(10);
-
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
-    short_progress_loop();
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FORCE);
-
-    EXPECT_LT(ucs_get_time(), deadline);
-}
-
 UCS_TEST_P(test_ucp_sockaddr, listen) {
     listen_and_communicate(false, 0);
 }


### PR DESCRIPTION
## What

 Set lanes failed when error is detected, Don't invoke set_ep_failed from async thread.

## Why ?

Backporting fixes from the master branch:
- #6974
- #7015

## How ?

The PRs were ported manually, since the have merge conflicts which are quite hard to resolve.