### PR TITLE
UCS/ARCH/BITOPS: Add ucs_ffs32

### DIFF
--- a/src/ucs/arch/aarch64/bitops.h
+++ b/src/ucs/arch/aarch64/bitops.h
@@ -27,6 +27,11 @@ static UCS_F_ALWAYS_INLINE unsigned __ucs_ilog2_u64(uint64_t n)
     return 63 - bit;
 }
 
+static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
+{
+    return __ucs_ilog2_u32(n & -n);
+}
+
 static UCS_F_ALWAYS_INLINE unsigned ucs_ffs64(uint64_t n)
 {
     return __ucs_ilog2_u64(n & -n);

--- a/src/ucs/arch/ppc64/bitops.h
+++ b/src/ucs/arch/ppc64/bitops.h
@@ -25,6 +25,11 @@ static UCS_F_ALWAYS_INLINE unsigned __ucs_ilog2_u64(uint64_t n)
     return 63 - bit;
 }
 
+static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
+{
+    return __ucs_ilog2_u32(n & -n);
+}
+
 static UCS_F_ALWAYS_INLINE unsigned ucs_ffs64(uint64_t n)
 {
     return __ucs_ilog2_u64(n & -n);

--- a/src/ucs/arch/x86_64/bitops.h
+++ b/src/ucs/arch/x86_64/bitops.h
@@ -11,6 +11,15 @@
 #include <stdint.h>
 
 
+static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
+{
+    uint32_t result;
+    asm("bsfl %1,%0"
+        : "=r" (result)
+        : "r" (n));
+    return result;
+}
+
 static UCS_F_ALWAYS_INLINE unsigned ucs_ffs64(uint64_t n)
 {
     uint64_t result;

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -11,6 +11,13 @@ extern "C" {
 class test_bitops : public ucs::test {
 };
 
+UCS_TEST_F(test_bitops, ffs32) {
+    EXPECT_EQ(0u, ucs_ffs32(0xfffff));
+    EXPECT_EQ(16u, ucs_ffs32(0xf0000));
+    EXPECT_EQ(1u, ucs_ffs32(0x4002));
+    EXPECT_EQ(21u, ucs_ffs32(1ull << 21));
+}
+
 UCS_TEST_F(test_bitops, ffs64) {
     EXPECT_EQ(0u, ucs_ffs64(0xfffff));
     EXPECT_EQ(16u, ucs_ffs64(0xf0000));


### PR DESCRIPTION
## Why
rdnv/put/zcopy protocol would have to go over lane bitmaps which are small