### PR TITLE
TEST/GTEST: Set name for the watchdog thread

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -143,6 +143,7 @@ WATCHDOG_DEFINE_GETTER(kill_signal, int)
 int watchdog_start()
 {
     pthread_mutexattr_t mutex_attr;
+    ucs_status_t status;
     int ret;
 
     ret = pthread_mutexattr_init(&mutex_attr);
@@ -178,8 +179,9 @@ int watchdog_start()
     watchdog.watched_thread = pthread_self();
     pthread_mutex_unlock(&watchdog.mutex);
 
-    ret = pthread_create(&watchdog.thread, NULL, watchdog_func, NULL);
-    if (ret != 0) {
+    status = ucs_pthread_create(&watchdog.thread, watchdog_func, NULL,
+                                "watchdog");
+    if (status != UCS_OK) {
         goto err_destroy_barrier;
     }
 


### PR DESCRIPTION
## Why
Ignore watchdog thread when debugging with gdb