### PR TITLE
UCP/DATATPE: Arbitrary offset for ucp_datatype_iter_unpack()

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -98,6 +98,7 @@ libucp_la_SOURCES = \
 	core/ucp_rkey.c \
 	core/ucp_version.c \
 	core/ucp_worker.c \
+	dt/datatype_iter.c \
 	dt/dt_contig.c \
 	dt/dt_iov.c \
 	dt/dt_generic.c \

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "datatype_iter.inl"
+
+
+void ucp_datatype_iter_str(const ucp_datatype_iter_t *dt_iter,
+                           ucs_string_buffer_t *strb)
+{
+    size_t iov_index, offset;
+    const ucp_dt_iov_t *iov;
+    const char *sysdev_name;
+    char buffer[32];
+
+    if (dt_iter->mem_info.type != UCS_MEMORY_TYPE_HOST) {
+        ucs_string_buffer_appendf(
+                strb, "%s ", ucs_memory_type_names[dt_iter->mem_info.type]);
+    }
+
+    if (dt_iter->mem_info.sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+        sysdev_name = ucs_topo_sys_device_bdf_name(dt_iter->mem_info.sys_dev,
+                                                   buffer, sizeof(buffer));
+        ucs_string_buffer_appendf(strb, "%s ", sysdev_name);
+    }
+
+    ucs_string_buffer_appendf(strb, "%zu/%zu %s", dt_iter->offset,
+                              dt_iter->length,
+                              ucp_datatype_class_names[dt_iter->dt_class]);
+
+    switch (dt_iter->dt_class) {
+    case UCP_DATATYPE_CONTIG:
+        ucs_string_buffer_appendf(strb, " buffer:%p",
+                                  dt_iter->type.contig.buffer);
+        break;
+    case UCP_DATATYPE_IOV:
+        iov_index = 0;
+        offset    = 0;
+        while (offset < dt_iter->length) {
+            iov = &dt_iter->type.iov.iov[iov_index];
+            ucs_string_buffer_appendf(strb, " [%zu]", iov_index);
+            if (iov_index == dt_iter->type.iov.iov_index) {
+                ucs_string_buffer_appendf(strb, " *{%p,%zu/%zu}", iov->buffer,
+                                          dt_iter->type.iov.iov_offset,
+                                          iov->length);
+            } else {
+                ucs_string_buffer_appendf(strb, " {%p, %zu}", iov->buffer,
+                                          iov->length);
+            }
+            offset += iov->length;
+            ++iov_index;
+        }
+        break;
+    case UCP_DATATYPE_GENERIC:
+        ucs_string_buffer_appendf(strb, " dt_gen:%p state:%p",
+                                  dt_iter->type.generic.dt_gen,
+                                  dt_iter->type.generic.state);
+
+        break;
+    default:
+        break;
+    }
+}

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -12,6 +12,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucs/memory/memtype_cache.h>
+#include <ucs/datastruct/string_buffer.h>
 
 
 /*
@@ -35,6 +36,9 @@ typedef struct {
         } generic;
         struct {
             const ucp_dt_iov_t    *iov;       /* IOV list */
+#if UCS_ENABLE_ASSERT
+            size_t                iov_count;  /* Number of IOV items */
+#endif
             size_t                iov_index;  /* Index of current IOV item */
             size_t                iov_offset; /* Offset in the current IOV item */
             /* TODO support memory registration with IOV */
@@ -48,5 +52,8 @@ typedef struct {
     } type;
 } ucp_datatype_iter_t;
 
+
+void ucp_datatype_iter_str(const ucp_datatype_iter_t *dt_iter,
+                           ucs_string_buffer_t *strb);
 
 #endif

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -390,6 +390,10 @@ static inline int rand() {
     return ::rand();
 }
 
+static inline int rand_range(int max) {
+    return rand() % max;
+}
+
 static inline void srand(unsigned seed) {
     /* coverity[dont_call] */
     return ::srand(seed);

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -5,6 +5,7 @@
  */
 
 #include <common/test.h>
+#include <algorithm>
 
 #include "ucp_datatype.h"
 
@@ -65,48 +66,90 @@ protected:
         m_ucph.reset();
     }
 
-    void do_test(size_t size, bool is_pack) {
-        std::string dt_buffer(size, 0), packed_buffer(size, 0);
-        ucs::fill_random(dt_buffer);
+    void init_dt_iter(size_t size)
+    {
+        m_dt_buffer.resize(size, 0);
+        ucs::fill_random(m_dt_buffer);
+
+        m_packed_buffer.resize(size, 0);
+        ucs::fill_random(m_packed_buffer);
 
         size_t iovcnt = 1;
         if (GetParam() == UCP_DATATYPE_IOV) {
             iovcnt = std::min(static_cast<size_t>((ucs::rand() % 20) + 1),
-                              dt_buffer.size());
+                              m_dt_buffer.size());
         }
 
-        ucp::data_type_desc_t dt_desc(GetParam(), &dt_buffer[0],
-                                      dt_buffer.size(), iovcnt);
+        m_dt_desc.make(GetParam(), &m_dt_buffer[0], m_dt_buffer.size(), iovcnt);
 
-        ucp_datatype_iter_t dt_iter = {};
         uint8_t sg_count;
-        ucp_datatype_iter_init(m_ucph.get(), dt_desc.buf(), dt_desc.count(),
-                               dt_desc.dt(), dt_buffer.size(), &dt_iter, &sg_count);
-        EXPECT_EQ(iovcnt, sg_count);
+        ucp_datatype_iter_init(m_ucph.get(), m_dt_desc.buf(), m_dt_desc.count(),
+                               m_dt_desc.dt(), m_dt_buffer.size(), &m_dt_iter,
+                               &sg_count);
+        if (!UCP_DT_IS_GENERIC(GetParam())) {
+            EXPECT_EQ(iovcnt, sg_count);
+        }
 
-        size_t offset = 0;
-        ucs::fill_random(packed_buffer);
+        UCS_STRING_BUFFER_ONSTACK(strb, 64);
+        ucp_datatype_iter_str(&m_dt_iter, &strb);
+        UCS_TEST_MESSAGE << ucs_string_buffer_cstr(&strb);
+    }
 
-        while (!ucp_datatype_iter_is_end(&dt_iter)) {
-            void *packed_ptr = UCS_PTR_BYTE_OFFSET(&packed_buffer[0], offset);
-            size_t seg_size  = (ucs::rand() % (size / 2));
-            ucp_datatype_iter_t next_iter;
+    void finalize_dt_iter()
+    {
+        EXPECT_EQ(m_dt_buffer, m_packed_buffer);
+        ucp_datatype_iter_cleanup(&m_dt_iter, UINT_MAX);
+    }
+
+    size_t random_seg_size() const
+    {
+        return ucs::rand() % (m_dt_buffer.size() / 2);
+    }
+
+    void test_pack(size_t size)
+    {
+        init_dt_iter(size);
+
+        ucp_datatype_iter_t next_iter;
+        do {
+            EXPECT_FALSE(ucp_datatype_iter_is_end(&m_dt_iter));
+            size_t seg_size  = random_seg_size();
+            void *packed_ptr = UCS_PTR_BYTE_OFFSET(&m_packed_buffer[0],
+                                                   m_dt_iter.offset);
             /* TODO create non-NULL worker when using memtype */
-            if (is_pack) {
-                ucp_datatype_iter_next_pack(&dt_iter, NULL, seg_size,
-                                            &next_iter, packed_ptr);
-            } else {
-                size_t unpack_size = std::min(seg_size, size - offset);
-                ucp_datatype_iter_next_unpack(&dt_iter, NULL, unpack_size,
-                                              &next_iter, packed_ptr);
-            }
-            ucp_datatype_iter_copy_from_next(&dt_iter, &next_iter, UINT_MAX);
+            ucp_datatype_iter_next_pack(&m_dt_iter, NULL, seg_size, &next_iter,
+                                        packed_ptr);
+            ucp_datatype_iter_copy_from_next(&m_dt_iter, &next_iter, UINT_MAX);
+        } while (!ucp_datatype_iter_is_end(&m_dt_iter));
+
+        finalize_dt_iter();
+    }
+
+    void test_unpack(size_t size)
+    {
+        init_dt_iter(size);
+
+        typedef std::vector< std::pair<size_t, size_t> > segment_vector_t;
+        segment_vector_t segments;
+        size_t offset = 0;
+        while (offset < m_dt_buffer.size()) {
+            size_t seg_size = ucs_min(random_seg_size(),
+                                      m_dt_buffer.size() - offset);
+            segments.push_back(std::make_pair(offset, seg_size));
             offset += seg_size;
         }
+        std::random_shuffle(segments.begin(), segments.end(), ucs::rand_range);
 
-        EXPECT_EQ(dt_buffer, packed_buffer);
+        for (segment_vector_t::iterator it = segments.begin();
+             it != segments.end(); ++it) {
+            size_t offset    = it->first;
+            void *packed_ptr = UCS_PTR_BYTE_OFFSET(&m_packed_buffer[0], offset);
+            /* TODO create non-NULL worker when using memtype */
+            ucp_datatype_iter_unpack(&m_dt_iter, NULL, it->second, offset,
+                                     packed_ptr);
+        }
 
-        ucp_datatype_iter_cleanup(&dt_iter, UINT_MAX);
+        finalize_dt_iter();
     }
 
 public:
@@ -128,27 +171,30 @@ public:
     }
 
 private:
-    static ucp_dt_generic_t* dt_gen;
-
+    static ucp_dt_generic_t   *dt_gen;
     ucs::handle<ucp_context_h> m_ucph;
+    std::string                m_dt_buffer;
+    std::string                m_packed_buffer;
+    ucp::data_type_desc_t      m_dt_desc;
+    ucp_datatype_iter_t        m_dt_iter;
 };
 
 ucp_dt_generic_t* test_ucp_dt_iter::dt_gen = 0;
 
 UCS_TEST_P(test_ucp_dt_iter, pack_100b) {
-    do_test(100, true);
+    test_pack(100);
 }
 
 UCS_TEST_P(test_ucp_dt_iter, pack_1MB) {
-    do_test(UCS_MBYTE + (ucs::rand() % UCS_KBYTE), true);
+    test_pack(UCS_MBYTE + (ucs::rand() % UCS_KBYTE));
 }
 
 UCS_TEST_P(test_ucp_dt_iter, unpack_100b) {
-    do_test(100, false);
+    test_unpack(100);
 }
 
 UCS_TEST_P(test_ucp_dt_iter, unpack_1MB) {
-    do_test(UCS_MBYTE + (ucs::rand() % UCS_KBYTE), false);
+    test_unpack(UCS_MBYTE + (ucs::rand() % UCS_KBYTE));
 }
 
 INSTANTIATE_TEST_CASE_P(contig, test_ucp_dt_iter,
@@ -157,7 +203,7 @@ INSTANTIATE_TEST_CASE_P(contig, test_ucp_dt_iter,
                                         ucp_dt_make_contig(39)));
 
 INSTANTIATE_TEST_CASE_P(iov, test_ucp_dt_iter,
-                        testing::Values((ucp_datatype_t)ucp_dt_make_iov()));
+                        testing::Values(ucp_dt_make_iov()));
 
 INSTANTIATE_TEST_CASE_P(generic, test_ucp_dt_iter,
                         testing::ValuesIn(test_ucp_dt_iter::enum_dt_generic_params()));

--- a/test/gtest/ucp/ucp_datatype.cc
+++ b/test/gtest/ucp/ucp_datatype.cc
@@ -170,7 +170,8 @@ dt_pack_copy(void *state, size_t offset, void *dest, size_t max_length)
     dt_gen_state *dt_state = (dt_gen_state*)state;
     size_t length;
 
-    ucs_assert(offset <= dt_state->count);
+    ucs_assertv(offset <= dt_state->count, "offset=%zu count=%zu", offset,
+                dt_state->count);
     length = std::min(max_length, dt_state->count - offset);
     memcpy(dest, UCS_PTR_BYTE_OFFSET(dt_state->buffer, offset), length);
 
@@ -182,7 +183,9 @@ dt_unpack_copy(void *state, size_t offset, const void *src, size_t length)
 {
     dt_gen_state *dt_state = (dt_gen_state*)state;
 
-    ucs_assert(offset + length <= dt_state->count);
+    ucs_assertv(offset + length <= dt_state->count,
+                "offset=%zu length=%zu count=%zu", offset, length,
+                dt_state->count);
     memcpy(UCS_PTR_BYTE_OFFSET(dt_state->buffer, offset), src, length);
 
     return UCS_OK;

--- a/test/gtest/ucp/ucp_datatype.h
+++ b/test/gtest/ucp/ucp_datatype.h
@@ -46,6 +46,9 @@ public:
     };
 
     data_type_desc_t &make(ucp_datatype_t datatype, const void *buf,
+                           size_t length, size_t iov_count);
+
+    data_type_desc_t &make(ucp_datatype_t datatype, const void *buf,
                            size_t length) {
         return make(datatype, buf, length, m_iov_cnt_limit);
     };
@@ -83,9 +86,6 @@ public:
     };
 
 private:
-    data_type_desc_t &make(ucp_datatype_t datatype, const void *buf,
-                           size_t length, size_t iov_count);
-
     uintptr_t       m_origin;
     size_t          m_length;
 


### PR DESCRIPTION
## Why
In order to use datatype_iter to unpack RDNV_DATA, it should be able to handle any offset

## How
- Add datatype seek
- Extend tests to test unpack with random segment size and order