### PR TITLE
UCP/REQUEST: Fix proto request tracing

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -671,11 +671,12 @@ ucs_status_t ucp_request_progress_wrapper(uct_pending_req_t *self)
 
     ucs_log_indent(1);
     status = progress_cb(self);
-    if (status == UCS_OK) {
-        ucp_trace_req(req, "progress protocol %s returned OK", proto->name);
-    } else {
+    if (UCS_STATUS_IS_ERR(status)) {
         ucp_trace_req(req, "progress protocol %s returned: %s lane %d",
                       proto->name, ucs_status_string(status), req->send.lane);
+    } else {
+        ucp_trace_req(req, "progress protocol %s returned: %s", proto->name,
+                      ucs_status_string(status));
     }
     ucs_log_indent(-1);
     return status;

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -141,11 +141,11 @@ ucp_proto_request_set_proto(ucp_worker_h worker, ucp_ep_h ep,
     /* Set pointer to request's protocol configuration */
     ucs_assert(thresh_elem->proto_config.ep_cfg_index == ep->cfg_index);
     ucs_assert(thresh_elem->proto_config.rkey_cfg_index == rkey_cfg_index);
+    req->send.proto_config = &thresh_elem->proto_config;
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_REQ)) {
         ucp_proto_trace_selected(req, msg_length);
     }
 
-    req->send.proto_config = &thresh_elem->proto_config;
     ucp_proto_request_set_stage(req, UCP_PROTO_STAGE_START);
     return UCS_OK;
 }


### PR DESCRIPTION
## Why
- Fix tracing req before req->send.proto_config is set
- When progress func returns INPROGRESS, req->send.lane may be uninitialized
