### PR TITLE
CONTRIB: Fix typo in test_jenkins.sh

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -543,7 +543,7 @@ run_uct_hello() {
 				run_hello uct -d ${ucx_dev} -t "rc_verbs" ${send_func} -m ${mem_type}
 			done
 		done
-		for ucx_dev in $(get_active_ip_iface)
+		for ucx_dev in $(get_active_ip_ifaces)
 		do
 			echo "==== Running UCT hello world server on tcp/${ucx_dev} with sending ${send_func} ===="
 			run_hello uct -d ${ucx_dev} -t "tcp" ${send_func}


### PR DESCRIPTION
## What
Call `get_active_ip_ifaces` instead of `get_active_ip_iface`.

## Why ?
Fix a typo - `get_active_ip_iface` does not exist.
