### PR TITLE
TEST/PERF: Increase thresholds for test_ucp_wait_mem

### DIFF
--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -396,7 +396,7 @@ UCS_TEST_P(test_ucp_wait_mem, envelope) {
                               0, 1, { 8 }, 1, 1000lu,
                               ucs_offsetof(ucx_perf_result_t,
                                            latency.total_average),
-                              1e6, perf_min * 0.7, perf_avg * 2, 0 };
+                              1e6, perf_min * 0.3, perf_avg * 3, 0 };
     run_test(test2, 0, true, "", "");
 }
 


### PR DESCRIPTION
## Why

Fix the following failures:
```
[2021-07-27T06:07:26.947Z] [ RUN      ] shm/test_ucp_wait_mem.envelope/33 <shm/am_mr>
[2021-07-27T06:07:27.203Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:27.460Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:27.717Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:27.973Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:28.230Z] [     INFO ]      put latency reference : 0.322 usec (performance not checked)
[2021-07-27T06:07:28.487Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:28.743Z] [     INFO ]      put latency reference : 0.322 usec (performance not checked)
[2021-07-27T06:07:29.308Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:29.565Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:29.823Z] [     INFO ]      put latency reference : 0.319 usec (performance not checked)
[2021-07-27T06:07:30.081Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.124 usec
[2021-07-27T06:07:32.668Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.124 usec (attempt 1)
[2021-07-27T06:07:34.561Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.124 usec (attempt 2)
[2021-07-27T06:07:37.100Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.124 usec (attempt 3)
[2021-07-27T06:07:39.621Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.126 usec (attempt 4)
[2021-07-27T06:07:41.544Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.129 usec (attempt 5)
[2021-07-27T06:07:44.081Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.126 usec (attempt 6)
[2021-07-27T06:07:45.974Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.126 usec (attempt 7)
[2021-07-27T06:07:48.537Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.127 usec (attempt 8)
[2021-07-27T06:07:50.438Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.126 usec (attempt 9)
[2021-07-27T06:07:52.960Z] [     INFO ]  put latency with ucp_worker_wait_mem() : 0.126 usec (attempt 10)
[2021-07-27T06:07:54.855Z] /scrap/jenkins/workspace/ucx/contrib/../test/gtest/common/test_perf.cc:308: Failure
[2021-07-27T06:07:54.855Z] Failed
[2021-07-27T06:07:54.855Z] Invalid put latency with ucp_worker_wait_mem() performance, expected: 0.223..0.639
[2021-07-27T06:07:54.855Z] [  FAILED  ] shm/test_ucp_wait_mem.envelope/33, where GetParam() = shm/am_mr (27656 ms)
```
[Internal link](http://hpc-master.lab.mtl.com:8080/blue/rest/organizations/jenkins/pipelines/ucx/runs/13145/nodes/36/steps/165/log/?start=0)