### PR TITLE
UCS/DATASTRUCT: Thread safe put to ptr_map.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -356,7 +356,7 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
         ucp_ep_update_flags(ep, UCP_EP_FLAG_INDIRECT_ID, 0);
     }
 
-    status = ucs_ptr_map_put(&worker->ep_map, ep,
+    status = UCS_PTR_MAP_PUT(ep, &worker->ep_map, ep,
                              !!(ep->flags & UCP_EP_FLAG_INDIRECT_ID),
                              &ucp_ep_ext_control(ep)->local_ep_id);
     if ((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS)) {
@@ -405,7 +405,7 @@ void ucp_ep_release_id(ucp_ep_h ep)
 
     /* Don't use ucp_ep_local_id() function here to avoid assertion failure,
      * because local_ep_id can be set to @ref UCS_PTR_MAP_KEY_INVALID */
-    status = ucs_ptr_map_del(&ep->worker->ep_map,
+    status = UCS_PTR_MAP_DEL(ep, &ep->worker->ep_map,
                              ucp_ep_ext_control(ep)->local_ep_id);
     if ((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS)) {
         ucs_warn("ep %p local id 0x%" PRIxPTR ": ucs_ptr_map_del failed: %s",

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -17,7 +17,7 @@
 #include <uct/api/uct.h>
 #include <uct/api/v2/uct_v2.h>
 #include <ucs/datastruct/queue.h>
-#include <ucs/datastruct/ptr_map.inl>
+#include <ucs/datastruct/ptr_map.h>
 #include <ucs/datastruct/strided_alloc.h>
 #include <ucs/debug/assert.h>
 #include <ucs/stats/stats.h>

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -11,8 +11,6 @@
 #include "ucp_worker.h"
 #include "ucp_ep.inl"
 
-
-#include <ucp/core/ucp_worker.h>
 #include <ucp/dt/dt.h>
 #include <ucs/profile/profile.h>
 #include <ucs/datastruct/mpool.inl>
@@ -20,6 +18,9 @@
 #include <ucs/debug/debug_int.h>
 #include <ucp/dt/dt.inl>
 #include <inttypes.h>
+
+
+UCS_PTR_MAP_IMPL(request, 0);
 
 
 #define UCP_REQUEST_FLAGS_FMT \
@@ -864,7 +865,7 @@ ucp_ep_ptr_id_alloc(ucp_ep_h ep, void *ptr, ucs_ptr_map_key_t *ptr_id_p)
 {
     ucs_status_t status;
 
-    status = ucs_ptr_map_put(&ep->worker->request_map, ptr,
+    status = UCS_PTR_MAP_PUT(request, &ep->worker->request_map, ptr,
                              ucp_ep_use_indirect_id(ep), ptr_id_p);
     ucp_ep_ptr_map_check_status(ep, ptr, "allocate", status);
 
@@ -903,7 +904,7 @@ static UCS_F_ALWAYS_INLINE void ucp_send_request_id_release(ucp_request_t *req)
                  (UCP_REQUEST_FLAG_RECV_AM | UCP_REQUEST_FLAG_RECV_TAG)));
     ep = req->send.ep;
 
-    status = ucs_ptr_map_del(&ep->worker->request_map, req->id);
+    status = UCS_PTR_MAP_DEL(request, &ep->worker->request_map, req->id);
     if (status == UCS_OK) {
         ucs_hlist_del(&ucp_ep_ext_gen(ep)->proto_reqs, &req->send.list);
     }
@@ -921,7 +922,7 @@ ucp_send_request_get_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
 
     ucs_assert(id != UCS_PTR_MAP_KEY_INVALID);
 
-    status = ucs_ptr_map_get(&worker->request_map, id, extract, &ptr);
+    status = UCS_PTR_MAP_GET(request, &worker->request_map, id, extract, &ptr);
     if (ucs_unlikely((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS))) {
         return status;
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2070,12 +2070,12 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     ucs_snprintf_zero(worker->address_name, name_length, "%s:%d",
                       ucs_get_host_name(), getpid());
 
-    status = ucs_ptr_map_init(&worker->ep_map);
+    status = UCS_PTR_MAP_INIT(ep, &worker->ep_map);
     if (status != UCS_OK) {
         goto err_free;
     }
 
-    status = ucs_ptr_map_init(&worker->request_map);
+    status = UCS_PTR_MAP_INIT(request, &worker->request_map);
     if (status != UCS_OK) {
         goto err_destroy_ep_map;
     }
@@ -2195,9 +2195,9 @@ err_free_tm_offload_stats:
 err_free_stats:
     UCS_STATS_NODE_FREE(worker->stats);
 err_destroy_request_map:
-    ucs_ptr_map_destroy(&worker->request_map);
+    UCS_PTR_MAP_DESTROY(request, &worker->request_map);
 err_destroy_ep_map:
-    ucs_ptr_map_destroy(&worker->ep_map);
+    UCS_PTR_MAP_DESTROY(ep, &worker->ep_map);
 err_free:
     ucs_strided_alloc_cleanup(&worker->ep_alloc);
     kh_destroy_inplace(ucp_worker_discard_uct_ep_hash,
@@ -2426,8 +2426,8 @@ void ucp_worker_destroy(ucp_worker_h worker)
     ucs_async_context_cleanup(&worker->async);
     UCS_STATS_NODE_FREE(worker->tm_offload_stats);
     UCS_STATS_NODE_FREE(worker->stats);
-    ucs_ptr_map_destroy(&worker->request_map);
-    ucs_ptr_map_destroy(&worker->ep_map);
+    UCS_PTR_MAP_DESTROY(request, &worker->request_map);
+    UCS_PTR_MAP_DESTROY(ep, &worker->ep_map);
     ucs_strided_alloc_cleanup(&worker->ep_alloc);
     kh_destroy_inplace(ucp_worker_discard_uct_ep_hash,
                        &worker->discard_uct_ep_hash);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -229,6 +229,10 @@ struct ucp_worker_cm {
 };
 
 
+UCS_PTR_MAP_TYPE(ep, 1);
+UCS_PTR_MAP_TYPE(request, 0);
+
+
 /**
  * UCP worker (thread context).
  */
@@ -290,9 +294,10 @@ typedef struct ucp_worker {
 
     ucp_worker_rkey_config_hash_t    rkey_config_hash;    /* RKEY config key -> index */
     ucp_worker_discard_uct_ep_hash_t discard_uct_ep_hash; /* Hash of discarded UCT EPs */
-    ucs_ptr_map_t                    ep_map; /* UCP ep key to ptr mapping */
-    ucs_ptr_map_t                    request_map; /* UCP requests key to ptr
-                                                     mapping */
+    UCS_PTR_MAP_T(ep)                ep_map;              /* UCP ep key to ptr
+                                                             mapping */
+    UCS_PTR_MAP_T(request)           request_map;         /* UCP requests key to
+                                                             ptr mapping */
 
     unsigned                         ep_config_count;     /* Current number of ep configurations */
     ucp_ep_config_t                  ep_config[UCP_WORKER_MAX_EP_CONFIG];

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -15,6 +15,9 @@
 #include <ucs/datastruct/ptr_map.inl>
 
 
+UCS_PTR_MAP_IMPL(ep, 1);
+
+
 KHASH_IMPL(ucp_worker_rkey_config, ucp_rkey_config_key_t,
            ucp_worker_cfg_index_t, 1, ucp_rkey_config_hash_func,
            ucp_rkey_config_is_equal);
@@ -61,7 +64,7 @@ ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
     void *ptr;
 
     ucs_assert(id != UCS_PTR_MAP_KEY_INVALID);
-    status = ucs_ptr_map_get(&worker->ep_map, id, 0, &ptr);
+    status = UCS_PTR_MAP_GET(ep, &worker->ep_map, id, 0, &ptr);
     if (ucs_unlikely((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS))) {
         return status;
     }

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -151,6 +151,7 @@ libucs_la_SOURCES = \
 	datastruct/mpool.c \
 	datastruct/pgtable.c \
 	datastruct/ptr_array.c \
+	datastruct/ptr_map.c \
 	datastruct/strided_alloc.c \
 	datastruct/string_buffer.c \
 	datastruct/string_set.c \

--- a/src/ucs/datastruct/ptr_map.c
+++ b/src/ucs/datastruct/ptr_map.c
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2021 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ptr_map.inl"
+
+
+static void ucs_ptr_hash_destroy(ucs_ptr_hash_t *ptr_hash)
+{
+    size_t size = kh_size(ptr_hash);
+    if (size != 0) {
+        ucs_warn("ptr hash %p contains %zd elements on destroy", ptr_hash,
+                 size);
+    }
+    kh_destroy_inplace(ucs_ptr_map_impl, ptr_hash);
+}
+
+static ucs_status_t ucs_ptr_safe_hash_init(ucs_ptr_safe_hash_t *safe_hash)
+{
+    kh_init_inplace(ucs_ptr_map_impl, &safe_hash->hash);
+    return ucs_spinlock_init(&safe_hash->lock, 0);
+}
+
+static void ucs_ptr_safe_hash_destroy(ucs_ptr_safe_hash_t *safe_hash)
+{
+    ucs_ptr_hash_destroy(&safe_hash->hash);
+    ucs_spinlock_destroy(&safe_hash->lock);
+}
+
+ucs_status_t ucs_ptr_safe_hash_get(ucs_ptr_map_t *map, ucs_ptr_map_key_t key,
+                                   int extract, void **ptr_p,
+                                   ucs_ptr_safe_hash_t *safe_hash)
+{
+    ucs_status_t status;
+
+    ucs_spin_lock(&safe_hash->lock);
+    status = ucs_ptr_hash_get(&safe_hash->hash, key, 1, ptr_p);
+    ucs_spin_unlock(&safe_hash->lock);
+
+    if ((status == UCS_OK) && !extract) {
+        ucs_ptr_hash_put(&map->hash, key, *ptr_p);
+    }
+
+    return status;
+}
+
+ucs_status_t ucs_ptr_safe_hash_put(ucs_ptr_map_t *map, void *ptr,
+                                   ucs_ptr_map_key_t *key,
+                                   ucs_ptr_safe_hash_t *safe_hash)
+{
+    ucs_status_t status;
+
+    ucs_spin_lock(&safe_hash->lock);
+    *key   = ucs_ptr_map_create_key(map);
+    status = ucs_ptr_hash_put(&safe_hash->hash, *key, ptr);
+    ucs_spin_unlock(&safe_hash->lock);
+
+    return status;
+}
+
+ucs_status_t ucs_ptr_map_init(ucs_ptr_map_t *map, int is_put_thread_safe,
+                              ucs_ptr_safe_hash_t *safe_hash)
+{
+    ucs_status_t status = UCS_OK;
+
+    UCS_STATIC_ASSERT(!ucs_ptr_map_key_indirect(UCS_PTR_MAP_KEY_INVALID));
+    map->next_id = 0;
+    kh_init_inplace(ucs_ptr_map_impl, &map->hash);
+
+    if (is_put_thread_safe) {
+        status = ucs_ptr_safe_hash_init(safe_hash);
+    }
+
+    return status;
+}
+
+void ucs_ptr_map_destroy(ucs_ptr_map_t *map, int is_put_thread_safe,
+                         ucs_ptr_safe_hash_t *safe_hash)
+{
+    ucs_ptr_hash_destroy(&map->hash);
+
+    if (is_put_thread_safe) {
+        ucs_ptr_safe_hash_destroy(safe_hash);
+    }
+}

--- a/src/ucs/datastruct/ptr_map.h
+++ b/src/ucs/datastruct/ptr_map.h
@@ -10,6 +10,7 @@
 #include "khash.h"
 
 #include <ucs/sys/compiler.h>
+#include <ucs/type/spinlock.h>
 #include <ucs/type/status.h>
 
 #include <stdint.h>
@@ -39,14 +40,60 @@ KHASH_TYPE(ucs_ptr_map_impl, ucs_ptr_map_key_t, void*);
 typedef khash_t(ucs_ptr_map_impl) ucs_ptr_hash_t;
 
 
+typedef struct ucs_ptr_map {
+    uint64_t       next_id; /**< Generator of unique keys per map. */
+    ucs_ptr_hash_t hash; /**< Hash table to store indirect key to pointer
+                              associations. */
+} ucs_ptr_map_t;
+
+
+typedef struct ucs_ptr_safe_hash {
+    ucs_ptr_hash_t hash; /**< Hash table to store indirect key to pointer
+                              associations. */
+    ucs_spinlock_t lock; /**< Spin lock to synchronize access to hash table. */
+} ucs_ptr_safe_hash_t;
+
+
 /**
  * Associative container key -> object pointer.
+ *
+ * @param [in]  _is_put_thread_safe  Defines whether UCS_PTR_MAP_PUT is thread
+ *                                   safe or not. If the operation is safe, then
+ *                                   it is safe to use the operation
+ *                                   concurrently with itself, UCS_PTR_MAP_GET
+ *                                   or UCS_PTR_MAP_DEL operations. 0 or 1 are
+ *                                   only acceptable values for the parameter.
+ *
+ * @note Using UCS_PTR_MAP_GET and UCS_PTR_MAP_DEL with themselves and among
+ *       themselves is not thread safe regardless of @a _is_put_thread_safe.
  */
-typedef struct ucs_ptr_map {
-    uint64_t        next_id; /**< Generator of unique keys per map. */
-    ucs_ptr_hash_t  hash;    /**< Hash table to store indirect key to pointer
-                                  associations. */
-} ucs_ptr_map_t;
+#define UCS_PTR_MAP_TYPE(_name, _is_put_thread_safe) \
+    typedef struct { \
+        ucs_ptr_map_t       ptr_map; \
+        ucs_ptr_safe_hash_t safe[_is_put_thread_safe]; \
+    } UCS_PTR_MAP_T(_name);
+
+
+#define UCS_PTR_MAP_T(_name) UCS_PP_TOKENPASTE3(ucs_ptr_map_, _name, _t)
+
+
+/* Internal helper function */
+ucs_status_t ucs_ptr_map_init(ucs_ptr_map_t *map, int is_put_thread_safe,
+                              ucs_ptr_safe_hash_t *safe_hash);
+
+
+void ucs_ptr_map_destroy(ucs_ptr_map_t *map, int is_put_thread_safe,
+                         ucs_ptr_safe_hash_t *safe_hash);
+
+
+ucs_status_t
+ucs_ptr_safe_hash_put(ucs_ptr_map_t *map, void *ptr, ucs_ptr_map_key_t *key,
+                      ucs_ptr_safe_hash_t *safe_hash);
+
+
+ucs_status_t
+ucs_ptr_safe_hash_get(ucs_ptr_map_t *map, ucs_ptr_map_key_t key, int extract,
+                      void **ptr_p, ucs_ptr_safe_hash_t *safe_hash);
 
 END_C_DECLS
 

--- a/src/ucs/datastruct/ptr_map.inl
+++ b/src/ucs/datastruct/ptr_map.inl
@@ -33,36 +33,158 @@ BEGIN_C_DECLS
 KHASH_IMPL(ucs_ptr_map_impl, ucs_ptr_map_key_t, void*, 1,
            kh_int64_hash_func, kh_int64_hash_equal);
 
+static UCS_F_ALWAYS_INLINE ucs_ptr_map_key_t
+ucs_ptr_map_create_key(ucs_ptr_map_t *map)
+{
+    return (map->next_id += UCS_PTR_MAP_KEY_MIN_ALIGN) |
+            UCS_PTR_MAP_KEY_INDIRECT_FLAG;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_hash_put(ucs_ptr_hash_t *hash, ucs_ptr_map_key_t key, void *ptr)
+{
+    khiter_t iter;
+    int ret;
+
+    iter = kh_put(ucs_ptr_map_impl, hash, key, &ret);
+    if (ucs_unlikely(ret == UCS_KH_PUT_FAILED)) {
+        return UCS_ERR_NO_MEMORY;
+    } else if (ucs_unlikely(ret == UCS_KH_PUT_KEY_PRESENT)) {
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
+    kh_value(hash, iter) = ptr;
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_hash_get(ucs_ptr_hash_t *hash, ucs_ptr_map_key_t key, int extract,
+                 void **ptr_p)
+{
+    khiter_t iter;
+
+    iter = kh_get(ucs_ptr_map_impl, hash, key);
+    if (ucs_unlikely(iter == kh_end(hash))) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    *ptr_p = kh_value(hash, iter);
+    if (extract) {
+        kh_del(ucs_ptr_map_impl, hash, iter);
+    }
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_map_put(ucs_ptr_map_t *map, void *ptr, int indirect,
+                ucs_ptr_map_key_t *key, int is_put_thread_safe,
+                ucs_ptr_safe_hash_t *safe_hash)
+{
+    if (ucs_likely(!indirect)) {
+        *key = (uintptr_t)ptr;
+        ucs_assert(!(*key & UCS_PTR_MAP_KEY_MIN_ALIGN));
+        ucs_assert(*key != 0);
+        return UCS_ERR_NO_PROGRESS;
+    }
+
+    if (is_put_thread_safe) {
+        return ucs_ptr_safe_hash_put(map, ptr, key, safe_hash);
+    }
+
+    *key = ucs_ptr_map_create_key(map);
+    return ucs_ptr_hash_put(&map->hash, *key, ptr);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_map_get(ucs_ptr_map_t *map, ucs_ptr_map_key_t key, int extract,
+                void **ptr_p, int is_put_thread_safe,
+                ucs_ptr_safe_hash_t *safe_hash)
+{
+    ucs_status_t status;
+
+    if (ucs_likely(!ucs_ptr_map_key_indirect(key))) {
+        *ptr_p = (void*)key;
+        return UCS_ERR_NO_PROGRESS;
+    }
+
+    status = ucs_ptr_hash_get(&map->hash, key, extract, ptr_p);
+    if (ucs_likely(status != UCS_ERR_NO_ELEM)) {
+        return status;
+    }
+
+    if (is_put_thread_safe) {
+        status = ucs_ptr_safe_hash_get(map, key, extract, ptr_p, safe_hash);
+    }
+
+    return status;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucs_ptr_map_del(ucs_ptr_map_t *map, ucs_ptr_map_key_t key,
+                int is_put_thread_safe, ucs_ptr_safe_hash_t *safe_hash)
+{
+    void UCS_V_UNUSED *dummy;
+    return ucs_ptr_map_get(map, key, 1, &dummy, is_put_thread_safe, safe_hash);
+}
+
+#define UCS_PTR_MAP_IMPL(_name, _is_put_thread_safe) \
+static UCS_F_ALWAYS_INLINE ucs_status_t \
+ucs_ptr_map_init_##_name(UCS_PTR_MAP_T(_name) *map) \
+{ \
+    UCS_STATIC_ASSERT(((_is_put_thread_safe) == 0) || \
+                      ((_is_put_thread_safe) == 1)); \
+    return ucs_ptr_map_init(&map->ptr_map, _is_put_thread_safe, map->safe); \
+} \
+\
+static UCS_F_ALWAYS_INLINE void \
+ucs_ptr_map_destroy_##_name(UCS_PTR_MAP_T(_name) *map) \
+{ \
+    ucs_ptr_map_destroy(&map->ptr_map, _is_put_thread_safe, map->safe); \
+} \
+\
+static UCS_F_ALWAYS_INLINE ucs_status_t \
+ucs_ptr_map_put_##_name(UCS_PTR_MAP_T(_name) *map, void *ptr, int indirect, \
+                       ucs_ptr_map_key_t *key) \
+{ \
+    return ucs_ptr_map_put(&map->ptr_map, ptr, indirect, key, \
+                           _is_put_thread_safe, map->safe); \
+} \
+\
+static UCS_F_ALWAYS_INLINE ucs_status_t \
+ucs_ptr_map_get_##_name(UCS_PTR_MAP_T(_name) *map, ucs_ptr_map_key_t key, \
+                       int extract, void **ptr_p) \
+{ \
+    return ucs_ptr_map_get(&map->ptr_map, key, extract, ptr_p, \
+                           _is_put_thread_safe, map->safe); \
+} \
+\
+static UCS_F_ALWAYS_INLINE ucs_status_t \
+ucs_ptr_map_del_##_name(UCS_PTR_MAP_T(_name) *map, ucs_ptr_map_key_t key) \
+{ \
+    return ucs_ptr_map_del(&map->ptr_map, key, _is_put_thread_safe, \
+                           map->safe); \
+}
+
+
+#define UCS_PTR_MAP_DEFINE(_name, _is_put_thread_safe) \
+    UCS_PTR_MAP_TYPE(_name, _is_put_thread_safe) \
+    UCS_PTR_MAP_IMPL(_name, _is_put_thread_safe)
+
 /**
  * Initialize a pointer map.
  *
- * @param [in]  map     Map to initialize.
+ * @param [in]  map  Map to initialize.
  * @return      UCS_OK on success otherwise error code as defined by
  *              @ref ucs_status_t.
  */
-static inline ucs_status_t ucs_ptr_map_init(ucs_ptr_map_t *map)
-{
-    UCS_STATIC_ASSERT(!ucs_ptr_map_key_indirect(UCS_PTR_MAP_KEY_INVALID));
-    map->next_id = 0;
-    kh_init_inplace(ucs_ptr_map_impl, &map->hash);
-    return UCS_OK;
-}
+#define UCS_PTR_MAP_INIT(_name, _map) ucs_ptr_map_init_##_name(_map)
 
 /**
  * Destroy a pointer map.
  *
- * @param [in]  map     Map to destroy.
+ * @param [in]  map  Map to destroy.
  */
-static inline void ucs_ptr_map_destroy(ucs_ptr_map_t *map)
-{
-    size_t size = kh_size(&map->hash);
-
-    if (size != 0) {
-        ucs_warn("ptr map %p contains %zd elements on destroy", map, size);
-    }
-
-    kh_destroy_inplace(ucs_ptr_map_impl, &map->hash);
-}
+#define UCS_PTR_MAP_DESTROY(_name, _map) ucs_ptr_map_destroy_##_name(_map)
 
 /**
  * Put a pointer into the map.
@@ -73,41 +195,16 @@ static inline void ucs_ptr_map_destroy(ucs_ptr_map_t *map)
  *                        internal hash table, associated with a unique indirect
  *                        key which is returned from this function. Otherwise,
  *                        the returned value is the integer representation of
- *                        the pointer @ptr.
+ *                        the pointer @a ptr.
  * @param [out] key       Key to object pointer @ptr if operation completed
  *                        successfully otherwise value is undefined.
  * @return UCS_OK on success, UCS_ERR_NO_PROGRESS if this key is direct and
- *         therefore no action was performed, otherwise error code as defined by
- *         @ref ucs_status_t.
- * @note @ptr must be aligned on @ref UCS_PTR_MAP_KEY_MIN_ALIGN.
+ *         therefore no action was performed, otherwise error code as defined
+ *         by @ref ucs_status_t.
+ * @note @a ptr must be aligned on @ref UCS_PTR_MAP_KEY_MIN_ALIGN.
  */
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucs_ptr_map_put(ucs_ptr_map_t *map, void *ptr, int indirect,
-                ucs_ptr_map_key_t *key)
-{
-    khiter_t iter;
-    int ret;
-
-    if (ucs_likely(!indirect)) {
-        *key = (uintptr_t)ptr;
-        ucs_assert(!(*key & UCS_PTR_MAP_KEY_MIN_ALIGN));
-        ucs_assert(*key != 0);
-        return UCS_ERR_NO_PROGRESS;
-    }
-
-    *key = (map->next_id += UCS_PTR_MAP_KEY_MIN_ALIGN) |
-           UCS_PTR_MAP_KEY_INDIRECT_FLAG;
-
-    iter = kh_put(ucs_ptr_map_impl, &map->hash, *key, &ret);
-    if (ucs_unlikely(ret == UCS_KH_PUT_FAILED)) {
-        return UCS_ERR_NO_MEMORY;
-    } else if (ucs_unlikely(ret == UCS_KH_PUT_KEY_PRESENT)) {
-        return UCS_ERR_ALREADY_EXISTS;
-    }
-
-    kh_value(&map->hash, iter) = ptr;
-    return UCS_OK;
-}
+#define UCS_PTR_MAP_PUT(_name, _map, _ptr, _indirect, _key) \
+    ucs_ptr_map_put_##_name(_map, _ptr, _indirect, _key)
 
 /**
  * Get a pointer value from the map by its key.
@@ -120,46 +217,22 @@ ucs_ptr_map_put(ucs_ptr_map_t *map, void *ptr, int indirect,
  * @return UCS_OK if found, UCS_ERR_NO_PROGRESS if this key is direct and
  *         therefore no action was performed, UCS_ERR_NO_ELEM if not found.
  */
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucs_ptr_map_get(ucs_ptr_map_t *map, ucs_ptr_map_key_t key, int extract,
-                void **ptr_p)
-{
-    khiter_t iter;
-
-    if (ucs_likely(!ucs_ptr_map_key_indirect(key))) {
-        *ptr_p = (void*)key;
-        return UCS_ERR_NO_PROGRESS;
-    }
-
-    iter = kh_get(ucs_ptr_map_impl, &map->hash, key);
-    if (ucs_unlikely(iter == kh_end(&map->hash))) {
-        return UCS_ERR_NO_ELEM;
-    }
-
-    *ptr_p = kh_value(&map->hash, iter);
-    if (extract) {
-        kh_del(ucs_ptr_map_impl, &map->hash, iter);
-    }
-    return UCS_OK;
-}
+#define UCS_PTR_MAP_GET(_name, _map, _key, _extract, _ptr_p) \
+    ucs_ptr_map_get_##_name(_map, _key, _extract, _ptr_p)
 
 /**
  * Remove object pointer from the map by key.
  *
- * @param [in]  map     Container.
- * @param [in]  key     Key to object pointer.
+ * @param [in]  map Container.
+ * @param [in]  key Key to object pointer.
  *
  * @return - UCS_OK on success
  *         - UCS_ERR_NO_PROGRESS if this key is direct and therefore no action
  *           was performed
- *         - UCS_ERR_NO_ELEM if the key is not found in the internal hash table.
+ *         - UCS_ERR_NO_ELEM if the key is not found in the internal hash
+ *           table.
  */
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucs_ptr_map_del(ucs_ptr_map_t *map, ucs_ptr_map_key_t key)
-{
-    void UCS_V_UNUSED *dummy;
-    return ucs_ptr_map_get(map, key, 1, &dummy);
-}
+#define UCS_PTR_MAP_DEL(_name, _map, _key) ucs_ptr_map_del_##_name(_map, _key)
 
 END_C_DECLS
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -353,6 +353,9 @@ struct uct_tcp_ep {
 };
 
 
+UCS_PTR_MAP_DEFINE(tcp_ep, 0);
+
+
 /**
  * TCP interface
  */
@@ -361,8 +364,9 @@ typedef struct uct_tcp_iface {
     int                           listen_fd;         /* Server socket */
     ucs_conn_match_ctx_t          conn_match_ctx;    /* Connection matching context that contains EPs
                                                       * created with CONNECT_TO_IFACE method */
-    ucs_ptr_map_t                 ep_ptr_map;        /* EP PTR map that contains EPs created
-                                                      * with CONNECT_TO_EP method */
+    UCS_PTR_MAP_T(tcp_ep)         ep_ptr_map;        /* EP PTR map that contains
+                                                      * EPs created with
+                                                      * CONNECT_TO_EP method */
     ucs_list_link_t               ep_list;           /* List of endpoints */
     char                          if_name[IFNAMSIZ]; /* Network interface name */
     ucs_sys_event_set_t           *event_set;        /* Event set identifier */

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -185,7 +185,7 @@ static void uct_tcp_ep_ptr_map_add(uct_tcp_ep_t *ep)
 
     uct_tcp_ep_ptr_map_verify(ep, 0);
 
-    status = ucs_ptr_map_put(&iface->ep_ptr_map, ep, 1,
+    status = UCS_PTR_MAP_PUT(tcp_ep, &iface->ep_ptr_map, ep, 1,
                              &ep->cm_id.ptr_map_key);
     ucs_assert_always(status == UCS_OK);
 
@@ -204,7 +204,7 @@ static void uct_tcp_ep_ptr_map_del(uct_tcp_ep_t *ep)
                                             uct_tcp_iface_t);
     ucs_status_t status;
 
-    status = ucs_ptr_map_del(&iface->ep_ptr_map, ep->cm_id.ptr_map_key);
+    status = UCS_PTR_MAP_DEL(tcp_ep, &iface->ep_ptr_map, ep->cm_id.ptr_map_key);
     ucs_assert_always(status == UCS_OK);
     uct_tcp_ep_ptr_map_removed(ep);
 }
@@ -216,7 +216,7 @@ uct_tcp_ep_ptr_map_get(uct_tcp_iface_t *iface, ucs_ptr_map_key_t ptr_map_key)
     uct_tcp_ep_t *ep;
     void *ptr;
 
-    status = ucs_ptr_map_get(&iface->ep_ptr_map, ptr_map_key, 0, &ptr);
+    status = UCS_PTR_MAP_GET(tcp_ep, &iface->ep_ptr_map, ptr_map_key, 0, &ptr);
     if (ucs_likely(status == UCS_OK)) {
         ep = ptr;
         uct_tcp_ep_ptr_map_verify(ep, 1);
@@ -233,7 +233,7 @@ uct_tcp_ep_t *uct_tcp_ep_ptr_map_retrieve(uct_tcp_iface_t *iface,
     uct_tcp_ep_t *ep;
     void *ptr;
 
-    status = ucs_ptr_map_get(&iface->ep_ptr_map, ptr_map_key, 1, &ptr);
+    status = UCS_PTR_MAP_GET(tcp_ep, &iface->ep_ptr_map, ptr_map_key, 1, &ptr);
     if (ucs_likely(status == UCS_OK)) {
         ep = ptr;
         uct_tcp_ep_ptr_map_removed(ep);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -660,7 +660,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     ucs_conn_match_init(&self->conn_match_ctx,
                         ucs_field_sizeof(uct_tcp_ep_t, peer_addr),
                         &uct_tcp_cm_conn_match_ops);
-    status = ucs_ptr_map_init(&self->ep_ptr_map);
+    status = UCS_PTR_MAP_INIT(tcp_ep, &self->ep_ptr_map);
     ucs_assert_always(status == UCS_OK);
 
     if (self->config.tx_seg_size > self->config.rx_seg_size) {
@@ -781,7 +781,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_iface_t)
 
     uct_tcp_iface_ep_list_cleanup(self);
     ucs_conn_match_cleanup(&self->conn_match_ctx);
-    ucs_ptr_map_destroy(&self->ep_ptr_map);
+    UCS_PTR_MAP_DESTROY(tcp_ep, &self->ep_ptr_map);
 
     ucs_mpool_cleanup(&self->rx_mpool, 1);
     ucs_mpool_cleanup(&self->tx_mpool, 1);


### PR DESCRIPTION
## What
Converted ptr_map implementation to macros.
Implemented thread safe put operation. Other operations are not thread safe.
Added gtest.

## Why ?
The changes are required to fix retrieving endpoint from worker using endpoint's id.