### PR TITLE
UCT: Include string.h because memcpy is used

### DIFF
--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <errno.h>
+#include <string.h>
 
 #include <ucs/type/status.h>
 #include <ucs/debug/log.h>


### PR DESCRIPTION
This fixes the following error:
```
#39 81.07 In file included from base/ib_log.h:10:0,
#39 81.07                  from base/ib_log.c:11:
#39 81.07 base/ib_verbs.h: In function 'uct_ib_query_qp_peer_info':
#39 81.07 base/ib_verbs.h:346:5: error: implicit declaration of function 'memcpy' [-Werror=implicit-function-declaration]
#39 81.07      memcpy(ah_attr, &qp_attr.ah_attr, sizeof(*ah_attr));
#39 81.07      ^~~~~~
#39 81.07 base/ib_verbs.h:346:5: error: incompatible implicit declaration of built-in function 'memcpy' [-Werror]
#39 81.07 base/ib_verbs.h:346:5: note: include '<string.h>' or provide a declaration of 'memcpy'
#39 81.07 cc1: all warnings being treated as errors
#39 81.08 make[4]: *** [base/libuct_ib_la-ib_log.lo] Error 1
#39 81.08 make[4]: *** Waiting for unfinished jobs....
#39 81.08 Makefile:1006: recipe for target 'base/libuct_ib_la-ib_log.lo' failed
```
This issue makes UCX fails to build on PyTorch's CI:
- https://app.circleci.com/pipelines/github/pytorch/pytorch/356640/workflows/0c9ad636-a7e0-4916-a5d8-30afb08fbf6a/jobs/15035393
- https://github.com/pytorch/pytorch/pull/62270