### PR TITLE
UCS/UCP/UCT: Introduce maximum conn_sn after which conn_match isn't done

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -874,9 +874,9 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
         !(flags & UCP_EP_PARAMS_FLAGS_NO_LOOPBACK)) {
         ucp_ep_update_remote_id(ep, ucp_ep_local_id(ep));
         ucp_ep_flush_state_reset(ep);
-    } else {
-        ucp_ep_match_insert(worker, ep, remote_address.uuid, conn_sn,
-                            UCS_CONN_MATCH_QUEUE_EXP);
+    } else if (!ucp_ep_match_insert(worker, ep, remote_address.uuid, conn_sn,
+                                    UCS_CONN_MATCH_QUEUE_EXP)) {
+        ucp_ep_flush_state_reset(ep);
     }
 
     /* if needed, send initial wireup message */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2124,7 +2124,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     /* Initialize connection matching structure */
     ucs_conn_match_init(&worker->conn_match_ctx, sizeof(uint64_t),
-                        &ucp_ep_match_ops);
+                        UCP_EP_MATCH_CONN_SN_MAX, &ucp_ep_match_ops);
 
     /* Open all resources as interfaces on this worker */
     status = ucp_worker_add_resource_ifaces(worker);

--- a/src/ucp/wireup/ep_match.h
+++ b/src/ucp/wireup/ep_match.h
@@ -39,9 +39,9 @@ ucp_ep_match_conn_sn_t ucp_ep_match_get_sn(ucp_worker_h worker,
                                            uint64_t dest_uuid);
 
 
-void ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
-                         ucp_ep_match_conn_sn_t conn_sn,
-                         ucs_conn_match_queue_type_t conn_queue_type);
+int ucp_ep_match_insert(ucp_worker_h worker, ucp_ep_h ep, uint64_t dest_uuid,
+                        ucp_ep_match_conn_sn_t conn_sn,
+                        ucs_conn_match_queue_type_t conn_queue_type);
 
 
 ucp_ep_h ucp_ep_match_retrieve(ucp_worker_h worker, uint64_t dest_uuid,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -534,8 +534,10 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
 
             /* add internal endpoint to hash */
             ep->conn_sn = msg->conn_sn;
-            ucp_ep_match_insert(worker, ep, remote_uuid, ep->conn_sn,
-                                UCS_CONN_MATCH_QUEUE_UNEXP);
+            if (!ucp_ep_match_insert(worker, ep, remote_uuid, ep->conn_sn,
+                                     UCS_CONN_MATCH_QUEUE_UNEXP)) {
+                ucp_ep_flush_state_reset(ep);
+            }
         } else {
             ucp_ep_flush_state_reset(ep);
         }

--- a/src/ucs/datastruct/conn_match.c
+++ b/src/ucs/datastruct/conn_match.c
@@ -14,6 +14,7 @@
 #include <ucs/debug/assert.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/algorithm/crc.h>
+#include <ucs/sys/string.h>
 
 
 /**
@@ -61,11 +62,12 @@ const static char *ucs_conn_match_queue_title[] = {
 
 
 void ucs_conn_match_init(ucs_conn_match_ctx_t *conn_match_ctx,
-                         size_t address_length,
+                         size_t address_length, ucs_conn_sn_t max_conn_sn,
                          const ucs_conn_match_ops_t *ops)
 {
     kh_init_inplace(ucs_conn_match, &conn_match_ctx->hash);
     conn_match_ctx->address_length = address_length;
+    conn_match_ctx->max_conn_sn    = max_conn_sn;
     conn_match_ctx->ops            = *ops;
 }
 
@@ -145,7 +147,6 @@ ucs_conn_match_get_conn(ucs_conn_match_ctx_t *conn_match_ctx,
     }
 
     /* initialize match list on first use */
-    peer->next_conn_sn = 0;
     ucs_hlist_head_init(&peer->conn_q[UCS_CONN_MATCH_QUEUE_EXP]);
     ucs_hlist_head_init(&peer->conn_q[UCS_CONN_MATCH_QUEUE_UNEXP]);
 
@@ -157,18 +158,34 @@ ucs_conn_sn_t ucs_conn_match_get_next_sn(ucs_conn_match_ctx_t *conn_match_ctx,
 {
     ucs_conn_match_peer_t *peer = ucs_conn_match_get_conn(conn_match_ctx,
                                                           address);
-    return peer->next_conn_sn++;
+    ucs_conn_sn_t conn_sn       =
+            (peer->next_conn_sn != conn_match_ctx->max_conn_sn) ?
+            peer->next_conn_sn++ : peer->next_conn_sn;
+
+    if (conn_sn == conn_match_ctx->max_conn_sn) {
+        ucs_debug("connection ID reached the maximal possible value: %" PRIu64,
+                  conn_match_ctx->max_conn_sn);
+        /* If the connection sequence number reaches the maximal possible value
+         * for the current connection, return MAX to indicate that the
+         * connection shouldn't participate in the connection matching */
+    }
+
+    return conn_sn;
 }
 
-void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
-                           const void *address, ucs_conn_sn_t conn_sn,
-                           ucs_conn_match_elem_t *conn_match,
-                           ucs_conn_match_queue_type_t conn_queue_type)
+int ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
+                          const void *address, ucs_conn_sn_t conn_sn,
+                          ucs_conn_match_elem_t *conn_match,
+                          ucs_conn_match_queue_type_t conn_queue_type)
 {
     ucs_conn_match_peer_t *peer = ucs_conn_match_get_conn(conn_match_ctx,
                                                           address);
     ucs_hlist_head_t *head      = &peer->conn_q[conn_queue_type];
     char UCS_V_UNUSED address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
+
+    if (conn_sn == conn_match_ctx->max_conn_sn) {
+        return 0;
+    }
 
     ucs_hlist_add_tail(head, &conn_match->list);
     ucs_trace("match_ctx %p: conn_match %p added as %s address %s "
@@ -178,6 +195,8 @@ void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
                                               address, address_str,
                                               UCS_CONN_MATCH_ADDRESS_STR_MAX),
               conn_sn);
+
+    return 1;
 }
 
 ucs_conn_match_elem_t *
@@ -192,6 +211,10 @@ ucs_conn_match_get_elem(ucs_conn_match_ctx_t *conn_match_ctx,
     ucs_conn_match_elem_t *elem;
     unsigned i, start_q, end_q;
     khiter_t iter;
+
+    if (conn_sn == conn_match_ctx->max_conn_sn) {
+        return NULL;
+    }
 
     peer = ucs_conn_match_peer_alloc(conn_match_ctx, address);
     iter = kh_get(ucs_conn_match, &conn_match_ctx->hash, peer);
@@ -252,11 +275,14 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
                                 ucs_conn_match_elem_t *elem,
                                 ucs_conn_match_queue_type_t conn_queue_type)
 {
-    const void *address = conn_match_ctx->ops.get_address(elem);
+    const void *address   = conn_match_ctx->ops.get_address(elem);
+    ucs_conn_sn_t conn_sn = conn_match_ctx->ops.get_conn_sn(elem);
     char UCS_V_UNUSED address_str[UCS_CONN_MATCH_ADDRESS_STR_MAX];
     ucs_conn_match_peer_t *peer;
     ucs_hlist_head_t *head;
     khiter_t iter;
+
+    ucs_assert(conn_sn != conn_match_ctx->max_conn_sn);
 
     peer = ucs_conn_match_peer_alloc(conn_match_ctx, address);
     iter = kh_get(ucs_conn_match, &conn_match_ctx->hash, peer);
@@ -266,8 +292,7 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
                   elem, conn_match_ctx->ops.address_str(conn_match_ctx,
                                                   address, address_str,
                                                   UCS_CONN_MATCH_ADDRESS_STR_MAX),
-                  conn_match_ctx->ops.get_conn_sn(elem),
-                  ucs_conn_match_queue_title[conn_queue_type]);
+                  conn_sn, ucs_conn_match_queue_title[conn_queue_type]);
     }
 
     ucs_free(peer);
@@ -282,5 +307,5 @@ void ucs_conn_match_remove_elem(ucs_conn_match_ctx_t *conn_match_ctx,
               elem, conn_match_ctx->ops.address_str(conn_match_ctx,
                                                     address, address_str,
                                                     UCS_CONN_MATCH_ADDRESS_STR_MAX),
-              conn_match_ctx->ops.get_conn_sn(elem));
+              conn_sn);
 }

--- a/src/ucs/datastruct/conn_match.h
+++ b/src/ucs/datastruct/conn_match.h
@@ -17,6 +17,12 @@ BEGIN_C_DECLS
 
 
 /**
+ * Maximal value for connection sequence number 
+ */
+#define UCS_CONN_MATCH_SN_MAX ((ucs_conn_sn_t)-1)
+
+
+/**
  * Connection sequence number
  */
 typedef uint64_t ucs_conn_sn_t;
@@ -125,6 +131,8 @@ KHASH_TYPE(ucs_conn_match, ucs_conn_match_peer_t*, char)
  */
 struct ucs_conn_match_ctx {
     khash_t(ucs_conn_match)      hash;           /* Hash of matched connections */
+    ucs_conn_sn_t                max_conn_sn;    /* Maximum value for the connection sequence
+                                                  * number */
     size_t                       address_length; /* Length of the addresses used for the
                                                     connection between peers */
     ucs_conn_match_ops_t         ops;            /* User's connection matching operations */
@@ -137,11 +145,12 @@ struct ucs_conn_match_ctx {
  * @param [in] conn_match_ctx    Pointer to the connection matching context.
  * @param [in] address_length    Length of the addresses used for the connection
  *                               between peers.
+ * @param [in] max_conn_sn       Maximum value for the connection sequence number.
  * @param [in] ops               Pointer to the user-defined connection matching
  *                               operations.
  */
 void ucs_conn_match_init(ucs_conn_match_ctx_t *conn_match_ctx,
-                         size_t address_length,
+                         size_t address_length, ucs_conn_sn_t max_conn_sn,
                          const ucs_conn_match_ops_t *ops);
 
 
@@ -177,11 +186,14 @@ ucs_conn_sn_t ucs_conn_match_get_next_sn(ucs_conn_match_ctx_t *conn_match_ctx,
  * @param [in] elem              Pointer to the connection matching structure.
  * @param [in] conn_queue_type   Connection queue which should be used to insert
  *                               the connection matching element to.
+ *
+ * @return Flag that indicates whether connection element was added
+ *         successfully or not to the connection matching context.
  */
-void ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
-                           const void *address, ucs_conn_sn_t conn_sn,
-                           ucs_conn_match_elem_t *elem,
-                           ucs_conn_match_queue_type_t conn_queue_type);
+int ucs_conn_match_insert(ucs_conn_match_ctx_t *conn_match_ctx,
+                          const void *address, ucs_conn_sn_t conn_sn,
+                          ucs_conn_match_elem_t *elem,
+                          ucs_conn_match_queue_type_t conn_queue_type);
 
 
 /**

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -349,6 +349,7 @@ uct_tcp_ep_t *uct_tcp_cm_get_ep(uct_tcp_iface_t *iface,
 void uct_tcp_cm_insert_ep(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep)
 {
     uint8_t ctx_caps = ep->flags & UCT_TCP_EP_CTX_CAPS;
+    int ret;
 
     ucs_assert(ep->cm_id.conn_sn < UCT_TCP_CM_CONN_SN_MAX);
     ucs_assert((ctx_caps & UCT_TCP_EP_FLAG_CTX_TYPE_TX) ||
@@ -356,11 +357,12 @@ void uct_tcp_cm_insert_ep(uct_tcp_iface_t *iface, uct_tcp_ep_t *ep)
     ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_ON_MATCH_CTX));
     ucs_assert(!(ep->flags & UCT_TCP_EP_FLAG_CONNECT_TO_EP));
 
-    ucs_conn_match_insert(&iface->conn_match_ctx, &ep->peer_addr,
-                          ep->cm_id.conn_sn, &ep->elem,
-                          (ctx_caps & UCT_TCP_EP_FLAG_CTX_TYPE_TX) ?
-                          UCS_CONN_MATCH_QUEUE_EXP :
-                          UCS_CONN_MATCH_QUEUE_UNEXP);
+    ret = ucs_conn_match_insert(&iface->conn_match_ctx, &ep->peer_addr,
+                                ep->cm_id.conn_sn, &ep->elem,
+                                (ctx_caps & UCT_TCP_EP_FLAG_CTX_TYPE_TX) ?
+                                UCS_CONN_MATCH_QUEUE_EXP :
+                                UCS_CONN_MATCH_QUEUE_UNEXP);
+    ucs_assert_always(ret == 1);
 
     ep->flags |= UCT_TCP_EP_FLAG_ON_MATCH_CTX;
 }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -659,7 +659,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     ucs_list_head_init(&self->ep_list);
     ucs_conn_match_init(&self->conn_match_ctx,
                         ucs_field_sizeof(uct_tcp_ep_t, peer_addr),
-                        &uct_tcp_cm_conn_match_ops);
+                        UCT_TCP_CM_CONN_SN_MAX,  &uct_tcp_cm_conn_match_ops);
     status = UCS_PTR_MAP_INIT(tcp_ep, &self->ep_ptr_map);
     ucs_assert_always(status == UCS_OK);
 

--- a/test/gtest/ucs/test_conn_match.cc
+++ b/test/gtest/ucs/test_conn_match.cc
@@ -36,7 +36,7 @@ private:
         conn_match_ops.purge_cb    = purge_cb;
 
         ucs_conn_match_init(&m_conn_match_ctx, address_length,
-                            &conn_match_ops);
+                            UCS_CONN_MATCH_SN_MAX, &conn_match_ops);
         m_address_length = address_length;
     }
 


### PR DESCRIPTION
## What
 
Introduce maximum connection sequence number after which connection matching is disabled.

## Why ?

Some applications may want to support creating large number of connections even without connection matching, e.g. it makes sense, if they create more than 65534 connections to the same peer from one UCP context.

## How ?

1. Introduce maximum connection sequence number after which connection matching is not done.
2. Provided supported maximum connection sequence number in UCP, TCP and UD.
3. If maximum connection sequence number is reached on UD or TCP - abort.
4. Handle connection matching in UCP according to updated connection API to support working without connection matching.