### PR TITLE
UCT/IB: mind device capabilities when creating QPs and MRs

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -636,4 +636,15 @@ uct_ib_iface_roce_dscp(uct_ib_iface_t *iface)
     return iface->config.traffic_class >> 2;
 }
 
+static UCS_F_ALWAYS_INLINE void
+uct_ib_iface_check_cap_limit(uct_ib_iface_t *iface, uint32_t limit,
+                             const char* cap_name, uint32_t *cap_p)
+{
+    if (*cap_p > limit) {
+        ucs_debug("iface %p: reduced %s from %d to %d based on caps", iface,
+                  cap_name, *cap_p, limit);
+        *cap_p = limit;
+    }
+}
+
 #endif

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -389,8 +389,8 @@ unsigned uct_rc_iface_qp_cleanup_progress(void *arg);
  * Creates an RC or DCI QP
  */
 ucs_status_t uct_rc_iface_qp_create(uct_rc_iface_t *iface, struct ibv_qp **qp_p,
-                                    uct_ib_qp_attr_t *attr, unsigned max_send_wr,
-                                    struct ibv_srq *srq);
+                                    uct_ib_qp_attr_t *attr,
+                                    unsigned *max_send_wr, struct ibv_srq *srq);
 
 void uct_rc_iface_fill_attr(uct_rc_iface_t *iface,
                             uct_ib_qp_attr_t *qp_init_attr,

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -585,7 +585,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_verbs_ep_t, const uct_ep_params_t *params)
     ucs_status_t status;
 
     status = uct_rc_iface_qp_create(&iface->super, &self->qp, &attr,
-                                    iface->super.config.tx_qp_len, iface->srq);
+                                    &iface->super.config.tx_qp_len, iface->srq);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -349,7 +349,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     /* Create a dummy QP in order to find out max_inline */
     uct_ib_exp_qp_fill_attr(&self->super.super, &attr);
     status = uct_rc_iface_qp_create(&self->super, &qp, &attr,
-                                    self->super.config.tx_qp_len,
+                                    &self->super.config.tx_qp_len,
                                     self->srq);
     if (status != UCS_OK) {
         goto err_common_cleanup;

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -708,14 +708,14 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
 
     status = uct_ib_mlx5_iface_create_qp(ib_iface, qp, &attr);
     if (status != UCS_OK) {
-        goto err_destroy_qp;
+        goto err;
     }
 
     status = uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
                                    iface->tx.mmio_mode, &iface->tx.wq,
                                    qp->verbs.qp);
     if (status != UCS_OK) {
-        return status;
+        goto err_destroy_qp;
     }
 
     *qp_p = qp->verbs.qp;
@@ -723,6 +723,7 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
 
 err_destroy_qp:
     uct_ib_mlx5_destroy_qp(ib_md, qp);
+err:
     return status;
 }
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -106,7 +106,8 @@ typedef struct uct_ud_iface_ops {
                                           const uct_ud_iov_t *iov, uint16_t iovcnt,
                                           int flags, int max_log_sge);
     void                      (*ep_free)(uct_ep_h ep);
-    ucs_status_t              (*create_qp)(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr,
+    ucs_status_t              (*create_qp)(uct_ib_iface_t *iface,
+                                           uct_ib_qp_attr_t *attr,
                                            struct ibv_qp **qp_p);
     void                      (*destroy_qp)(uct_ud_iface_t *ud_iface);
     ucs_status_t              (*unpack_peer_address)(uct_ud_iface_t *iface,

--- a/test/gtest/uct/ib/test_ib_event.cc
+++ b/test/gtest/uct/ib/test_ib_event.cc
@@ -391,7 +391,7 @@ private:
             ucs_status_t status;
 
             status = uct_rc_iface_qp_create(&m_iface->super, &m_ibqp, &attr,
-                                            m_iface->super.config.tx_qp_len,
+                                            &m_iface->super.config.tx_qp_len,
                                             m_iface->srq);
             ASSERT_UCS_OK(status);
 


### PR DESCRIPTION
Signed-off-by: Alex Margolin <alex.margolin@huawei.com>

## What
Check some configured values against the IB device capabilities (as opposed to just hoping it'll be supported).

## Why ?
I stumbled upon an device which supports less S/G entries than the default configuration and UCX failed while ibv_pingpong works fine.

## How ?
Store device capabilities (UCX queries them anyway) and check before creating RC and UD QPs.
