### PR TITLE
UCP/PROTO/RNDV: Add new protocol for rndv over put_zcopy

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -125,6 +125,7 @@ libucp_la_SOURCES = \
 	rndv/proto_rndv.c \
 	rndv/rndv_am.c \
 	rndv/rndv_get.c \
+	rndv/rndv_put.c \
 	rndv/rndv_rtr.c \
 	rndv/rndv.c \
 	tag/eager_multi.c \

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -336,6 +336,14 @@ static ucs_config_field_t ucp_config_table[] = {
    "endpoint.",
    ucs_offsetof(ucp_config_t, ctx.proto_indirect_id), UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
+  {"RNDV_PUT_FORCE_FLUSH", "n",
+   "When using rendezvous put protocol, force using a flush operation to ensure\n"
+   "remote data delivery before sending ATP message.\n"
+   "If flush mode is not forced, and the underlying transport supports both active\n"
+   "messages and put operations, the protocol will do {put,fence,ATP} on the same\n"
+   "lane without waiting for remote completion.",
+   ucs_offsetof(ucp_config_t, ctx.rndv_put_force_flush), UCS_CONFIG_TYPE_BOOL},
+
    {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t,

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -117,6 +117,8 @@ typedef struct ucp_context_config {
     ucs_on_off_auto_value_t                proto_indirect_id;
     /** Bitmap of memory types whose allocations are registered fully */
     unsigned                               reg_whole_alloc_bitmap;
+    /** Always use flush operation in rendezvous put */
+    int                                    rndv_put_force_flush;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -70,6 +70,12 @@ static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t
     return ucp_ep_config(ep)->key.lanes[lane].rsc_index;
 }
 
+static inline const uct_tl_resource_desc_t *
+ucp_ep_get_tl_rsc(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    return &ep->worker->context->tl_rscs[ucp_ep_get_rsc_index(ep, lane)].tl_rsc;
+}
+
 static inline uint8_t ucp_ep_get_path_index(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     return ucp_ep_config(ep)->key.lanes[lane].path_index;

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -209,21 +209,36 @@ struct ucp_request {
                 } proxy;
 
                 struct {
-                    uint64_t          remote_address;  /* address of the sender/receiver's data
-                                                          buffer for the GET/PUT operation */
-                    /* Remote request ID received from a peer */
+                    /* Remote request ID to acknowledge */
                     ucs_ptr_map_key_t remote_req_id;
-                    ucp_rkey_h        rkey;            /* key for remote send/receive buffer for
-                                                          the GET/PUT operation */
+
+                    /* Remote buffer address for get/put operation */
+                    uint64_t          remote_address;
+
+                    /* Key for remote buffer get/put operation */
+                    ucp_rkey_h        rkey;
+
                     union {
+                        /* Used by version 1 rendezvous protocols */
                         struct {
-                            ucp_lane_map_t lanes_map_all; /* actual lanes map */
-                            uint8_t        lanes_count; /* actual lanes count */
+                            /* Actual lanes map */
+                            ucp_lane_map_t lanes_map_all;
+
+                            /* Actual lanes count */
+                            uint8_t        lanes_count;
+
+                            /* Remote key index map */
                             uint8_t        rkey_index[UCP_MAX_LANES];
                         };
+
+                        /* Used by rndv/put */
                         struct {
-                            ucs_ptr_map_key_t rreq_id; /* id of receive request */
-                        } rtr;
+                            /* which lanes need to flush (0 in fence mode) */
+                            ucp_lane_map_t flush_map;
+
+                            /* which lanes need to send atp */
+                            ucp_lane_map_t atp_map;
+                        } put;
                     };
                 } rndv;
 

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -25,15 +25,21 @@ static size_t ucp_proto_pack(void *dest, void *arg)
     ucp_request_t *req = arg;
     ucp_reply_hdr_t *rep_hdr;
     ucp_offload_ssend_hdr_t *off_rep_hdr;
+    ucp_rndv_atp_hdr_t *atp_hdr;
 
     switch (req->send.proto.am_id) {
     case UCP_AM_ID_EAGER_SYNC_ACK:
     case UCP_AM_ID_RNDV_ATS:
-    case UCP_AM_ID_RNDV_ATP:
         rep_hdr = dest;
         rep_hdr->req_id = req->send.proto.remote_req_id;
         rep_hdr->status = req->send.proto.status;
         return sizeof(*rep_hdr);
+    case UCP_AM_ID_RNDV_ATP:
+        atp_hdr               = dest;
+        atp_hdr->super.req_id = req->send.proto.remote_req_id;
+        atp_hdr->super.status = req->send.proto.status;
+        atp_hdr->count        = 1;
+        return sizeof(*atp_hdr);
     case UCP_AM_ID_OFFLOAD_SYNC_ACK:
         off_rep_hdr = dest;
         off_rep_hdr->sender_tag = req->send.proto.sender_tag;

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -84,6 +84,19 @@ typedef ucs_status_t (*ucp_proto_send_multi_cb_t)(
                 ucp_datatype_iter_t *next_iter);
 
 
+/**
+ * Send callback for lane-map multi-send protocol
+ *
+ * @param [in] req   Request to send.
+ * @param [in] lane  Endpoint lane index to send on.
+ *
+ * @return Send operation status, using same semantics as returned from UCT send
+ *         functions.
+ */
+typedef ucs_status_t (*ucp_proto_multi_lane_send_func_t)(ucp_request_t *req,
+                                                         ucp_lane_index_t lane);
+
+
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                                   ucp_proto_multi_priv_t *mpriv,
                                   size_t *priv_size_p);

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -73,19 +73,18 @@ ucp_proto_multi_data_pack(ucp_proto_multi_pack_ctx_t *pack_ctx, void *dest)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_multi_no_resource(ucp_request_t *req,
-                            const ucp_proto_multi_lane_priv_t *lpriv)
+ucp_proto_multi_no_resource(ucp_request_t *req, ucp_lane_index_t lane)
 {
     ucs_status_t status;
     uct_ep_h uct_ep;
 
-    if (lpriv->super.lane == req->send.lane) {
+    if (lane == req->send.lane) {
         /* if we failed to send on same lane, return error */
         return UCS_ERR_NO_RESOURCE;
     }
 
     /* failed to send on another lane - add to its pending queue */
-    uct_ep = req->send.ep->uct_eps[lpriv->super.lane];
+    uct_ep = req->send.ep->uct_eps[lane];
     status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
     if (status == UCS_ERR_BUSY) {
         /* try sending again */
@@ -93,11 +92,23 @@ ucp_proto_multi_no_resource(ucp_request_t *req,
     }
 
     ucs_assert(status == UCS_OK);
-    req->send.lane = lpriv->super.lane;
+    req->send.lane = lane;
 
     /* Remove the request from current pending queue because it was added to
      * other lane's pending queue.
      */
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_handle_send_error(
+        ucp_request_t *req, ucp_lane_index_t lane, ucs_status_t status)
+{
+    if (ucs_likely(status == UCS_ERR_NO_RESOURCE)) {
+        return ucp_proto_multi_no_resource(req, lane);
+    }
+
+    /* failed to send - call common error handler */
+    ucp_proto_request_abort(req, status);
     return UCS_OK;
 }
 
@@ -128,12 +139,9 @@ ucp_proto_multi_progress(ucp_request_t *req,
     } else if (status == UCS_INPROGRESS) {
         /* operation started and completion will be called later */
         ++req->send.state.uct_comp.count;
-    } else if (status == UCS_ERR_NO_RESOURCE) {
-        return ucp_proto_multi_no_resource(req, lpriv);
     } else {
-        /* failed to send - call common error handler */
-        ucp_proto_request_abort(req, status);
-        return UCS_OK;
+        return ucp_proto_multi_handle_send_error(req, lpriv->super.lane,
+                                                 status);
     }
 
     /* advance position in send buffer */
@@ -199,6 +207,33 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_zcopy_progress(
 
     return ucp_proto_multi_progress(req, mpriv, send_func, complete_func,
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_multi_lane_map_progress(ucp_request_t *req, ucp_lane_map_t *lane_map,
+                                   ucp_proto_multi_lane_send_func_t send_func)
+{
+    ucp_lane_index_t lane = ucs_ffs32(*lane_map);
+    ucs_status_t status;
+
+    ucs_assert(*lane_map != 0);
+
+    status = send_func(req, lane);
+    if (ucs_likely(status == UCS_OK)) {
+        /* fast path is OK */
+    } else if (status == UCS_INPROGRESS) {
+        ++req->send.state.uct_comp.count;
+    } else {
+        return ucp_proto_multi_handle_send_error(req, lane, status);
+    }
+
+    *lane_map &= ~UCS_BIT(lane);
+    if (*lane_map != 0) {
+        return UCS_INPROGRESS; /* Not finished all lanes yet */
+    }
+
+    ucp_request_invoke_uct_completion_success(req);
+    return UCS_OK;
 }
 
 #endif

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -36,7 +36,8 @@ ucp_proto_rndv_ctrl_reg_md_map(const ucp_proto_rndv_ctrl_init_params_t *params)
         /* Check the lane supports get_zcopy */
         iface_attr = ucp_proto_common_get_iface_attr(&params->super.super,
                                                      lane);
-        if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_GET_ZCOPY)) {
+        if (!(iface_attr->cap.flags &
+              (UCT_IFACE_FLAG_GET_ZCOPY | UCT_IFACE_FLAG_PUT_ZCOPY))) {
             continue;
         }
 

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -129,6 +129,10 @@ ucs_status_t
 ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags);
 
 
+ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,
+                                           unsigned flags);
+
+
 ucs_status_t ucp_proto_rndv_handle_data(void *arg, void *data, size_t length,
                                         unsigned flags);
 

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -107,6 +107,17 @@ ucp_proto_rndv_ack_progress(ucp_request_t *req, ucp_am_id_t am_id,
                                               complete_func);
 }
 
+static size_t UCS_F_ALWAYS_INLINE
+ucp_proto_rndv_send_pack_atp(ucp_request_t *req, void *dest, uint16_t count)
+{
+    ucp_rndv_atp_hdr_t *atp = dest;
+
+    atp->super.req_id = req->send.rndv.remote_req_id;
+    atp->super.status = UCS_OK;
+    atp->count        = count;
+    return sizeof(*atp);
+}
+
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_rndv_rkey_destroy(ucp_request_t *req)
 {

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1826,6 +1826,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
     ucp_reply_hdr_t *rep_hdr = data;
     ucp_request_t *rtr_sreq, *req;
 
+    if (worker->context->config.ext.proto_enable) {
+        return ucp_proto_rndv_rtr_handle_atp(arg, data, length, flags);
+    }
+
     UCP_SEND_REQUEST_GET_BY_ID(&rtr_sreq, worker, rep_hdr->req_id, 1,
                                return UCS_OK, "RNDV ATP %p", rep_hdr);
 

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -75,6 +75,18 @@ typedef struct {
 } UCS_S_PACKED ucp_rndv_data_hdr_t;
 
 
+/*
+ * RNDV_ATP
+ */
+typedef struct {
+    ucp_reply_hdr_t super;
+
+    /* The receive is considered complete when this number of ATP packets
+       has arrived */
+    uint16_t        count;
+} UCS_S_PACKED ucp_rndv_atp_hdr_t;
+
+
 ucs_status_t ucp_rndv_send_rts(ucp_request_t *sreq, uct_pack_callback_t pack_cb,
                                size_t rts_body_size);
 

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -1,0 +1,305 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "proto_rndv.inl"
+
+#include <ucp/core/ucp_request.inl>
+#include <ucp/proto/proto_am.inl>
+#include <ucp/proto/proto_multi.inl>
+#include <ucp/proto/proto_single.inl>
+
+
+enum {
+    UCP_PROTO_RNDV_PUT_STAGE_SEND = UCP_PROTO_STAGE_START,
+
+    /* Flush all lanes to ensure remote delivery */
+    UCP_PROTO_RNDV_PUT_STAGE_FLUSH,
+
+    /* Send ATP without fence (could be done after a flush) */
+    UCP_PROTO_RNDV_PUT_STAGE_ATP,
+
+    /* Send ATP with fence (could be done if using send lanes for ATP) */
+    UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP,
+};
+
+typedef struct ucp_proto_rndv_put_priv {
+    uct_completion_callback_t  put_comp_cb;
+    uct_completion_callback_t  atp_comp_cb;
+    uint8_t                    stage_after_put;
+    ucp_lane_map_t             flush_map;
+    ucp_lane_map_t             atp_map;
+    ucp_lane_index_t           atp_num_lanes;
+    ucp_proto_rndv_bulk_priv_t bulk;
+} ucp_proto_rndv_put_priv_t;
+
+
+static void
+ucp_proto_rndv_put_common_completion_send_atp(uct_completion_t *uct_comp)
+{
+    ucp_request_t *req = ucs_container_of(uct_comp, ucp_request_t,
+                                          send.state.uct_comp);
+    const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
+
+    ucp_trace_req(req, "rndv_put_common_completion_send_atp");
+    ucp_proto_completion_init(&req->send.state.uct_comp, rpriv->atp_comp_cb);
+    ucp_proto_request_set_stage(req, UCP_PROTO_RNDV_PUT_STAGE_ATP);
+    ucp_request_send(req);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_rndv_put_common_flush_send(ucp_request_t *req, ucp_lane_index_t lane)
+{
+    ucp_ep_h ep = req->send.ep;
+
+    ucp_trace_req(req, "flush lane[%d] " UCT_TL_RESOURCE_DESC_FMT, lane,
+                  UCT_TL_RESOURCE_DESC_ARG(ucp_ep_get_tl_rsc(ep, lane)));
+    return uct_ep_flush(ep->uct_eps[lane], 0, &req->send.state.uct_comp);
+}
+
+static ucs_status_t
+ucp_proto_rndv_put_common_flush_progress(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_lane_map_progress(
+            req, &req->send.rndv.put.flush_map,
+            ucp_proto_rndv_put_common_flush_send);
+}
+
+static size_t ucp_proto_rndv_put_common_pack_atp(void *dest, void *arg)
+{
+    ucp_request_t *req                     = arg;
+    const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
+
+    return ucp_proto_rndv_send_pack_atp(req, dest, rpriv->atp_num_lanes);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_rndv_put_common_atp_send(ucp_request_t *req, ucp_lane_index_t lane)
+{
+    const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
+
+    ucp_trace_req(req, "send ATP lane %d count %d", lane, rpriv->atp_num_lanes);
+    return ucp_proto_am_bcopy_single_send(req, UCP_AM_ID_RNDV_ATP, lane,
+                                          ucp_proto_rndv_put_common_pack_atp,
+                                          req, sizeof(ucp_rndv_atp_hdr_t));
+}
+
+static ucs_status_t
+ucp_proto_rndv_put_common_atp_progress(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_lane_map_progress(req, &req->send.rndv.put.atp_map,
+                                             ucp_proto_rndv_put_common_atp_send);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_rndv_put_common_fenced_atp_send(ucp_request_t *req,
+                                          ucp_lane_index_t lane)
+{
+    ucs_status_t status;
+
+    status = uct_ep_fence(req->send.ep->uct_eps[lane], 0);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    return ucp_proto_rndv_put_common_atp_send(req, lane);
+}
+
+static ucs_status_t
+ucp_proto_rndv_put_common_fenced_atp_progress(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    return ucp_proto_multi_lane_map_progress(
+            req, &req->send.rndv.put.atp_map,
+            ucp_proto_rndv_put_common_fenced_atp_send);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_rndv_put_common_data_sent(ucp_request_t *req)
+{
+    const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
+
+    ucp_trace_req(req, "rndv_put_common_data_sent");
+    ucp_proto_request_set_stage(req, rpriv->stage_after_put);
+    return UCS_INPROGRESS;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_rndv_put_common_request_init(ucp_request_t *req)
+{
+    const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
+
+    req->send.rndv.put.atp_map   = rpriv->atp_map;
+    req->send.rndv.put.flush_map = rpriv->flush_map;
+    ucp_proto_rndv_bulk_request_init(req, &rpriv->bulk);
+}
+
+static void ucp_proto_rndv_put_zcopy_completion(uct_completion_t *uct_comp)
+{
+    ucp_request_t *req = ucs_container_of(uct_comp, ucp_request_t,
+                                          send.state.uct_comp);
+
+    ucp_trace_req(req, "put_zcopy_completion");
+    ucp_proto_rndv_rkey_destroy(req);
+    ucp_proto_request_zcopy_complete(req, req->send.state.uct_comp.status);
+}
+
+static ucs_status_t
+ucp_proto_rndv_put_zcopy_init(const ucp_proto_init_params_t *init_params)
+{
+    const size_t atp_size                = sizeof(ucp_rndv_atp_hdr_t);
+    ucp_context_t *context               = init_params->worker->context;
+    ucp_proto_rndv_put_priv_t *rpriv     = init_params->priv;
+    uint64_t rndv_modes                  = UCS_BIT(UCP_RNDV_MODE_PUT_ZCOPY);
+    ucp_proto_multi_init_params_t params = {
+        .super.super         = *init_params,
+        .super.overhead      = 0,
+        .super.latency       = 0,
+        .super.cfg_thresh    = ucp_proto_rndv_cfg_thresh(context, rndv_modes),
+        .super.cfg_priority  = 0,
+        .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t,
+                                            cap.put.min_zcopy),
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t,
+                                            cap.put.max_zcopy),
+        .super.hdr_size      = 0,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS,
+        .max_lanes           = context->config.ext.max_rndv_lanes,
+        .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_ZCOPY,
+        .first.lane_type     = UCP_LANE_TYPE_RMA_BW,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_PUT_ZCOPY,
+        .middle.lane_type    = UCP_LANE_TYPE_RMA_BW,
+    };
+    const uct_iface_attr_t *iface_attr;
+    ucp_lane_index_t lane_idx, lane;
+    size_t bulk_priv_size;
+    ucs_status_t status;
+    int use_fence;
+
+    if ((init_params->select_param->op_id != UCP_OP_ID_RNDV_SEND) ||
+        (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = ucp_proto_rndv_bulk_init(&params, &rpriv->bulk, &bulk_priv_size);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *init_params->priv_size = ucs_offsetof(ucp_proto_rndv_put_priv_t, bulk) +
+                              bulk_priv_size;
+
+    /* Check if all potential lanes support sending ATP */
+    use_fence = !context->config.ext.rndv_put_force_flush;
+    lane_idx  = 0;
+    while (use_fence && (lane_idx < rpriv->bulk.mpriv.num_lanes)) {
+        lane       = rpriv->bulk.mpriv.lanes[lane_idx++].super.lane;
+        iface_attr = ucp_proto_common_get_iface_attr(init_params, lane);
+        use_fence  = use_fence &&
+                     (((iface_attr->cap.flags & UCT_IFACE_FLAG_AM_SHORT) &&
+                       (iface_attr->cap.am.max_short >= atp_size)) ||
+                      ((iface_attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) &&
+                       (iface_attr->cap.am.max_bcopy >= atp_size)));
+    }
+
+    /* All lanes can send ATP - invalidate am_lane, to use mpriv->lanes.
+     * Otherwise, would need to flush all lanes and send ATP on
+     * rpriv->super.lane when the flush is completed
+     */
+    if (use_fence) {
+        /* Send fence followed by ATP on all lanes */
+        rpriv->bulk.super.lane = UCP_NULL_LANE;
+        rpriv->put_comp_cb     = ucp_proto_rndv_put_zcopy_completion;
+        rpriv->atp_comp_cb     = NULL;
+        rpriv->stage_after_put = UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP;
+        rpriv->flush_map       = 0;
+        rpriv->atp_map         = rpriv->bulk.mpriv.lane_map;
+    } else {
+        /* Flush all lanes and send single ATP on control message lane */
+        rpriv->put_comp_cb     = ucp_proto_rndv_put_common_completion_send_atp;
+        rpriv->atp_comp_cb     = ucp_proto_rndv_put_zcopy_completion;
+        rpriv->atp_map         = UCS_BIT(rpriv->bulk.super.lane);
+        rpriv->stage_after_put = UCP_PROTO_RNDV_PUT_STAGE_FLUSH;
+        rpriv->flush_map       = rpriv->bulk.mpriv.lane_map;
+        ucs_assert(rpriv->flush_map != 0);
+    }
+
+    ucs_assert(rpriv->atp_map != 0);
+    rpriv->atp_num_lanes = ucs_popcount(rpriv->atp_map);
+
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_put_zcopy_send_func(
+        ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
+        ucp_datatype_iter_t *next_iter)
+{
+    ucp_rkey_h rkey    = req->send.rndv.rkey;
+    uct_rkey_t tl_rkey = rkey->tl_rkey[lpriv->super.rkey_index].rkey.rkey;
+    size_t max_payload;
+    uct_iov_t iov;
+
+    max_payload = ucp_proto_multi_max_payload(req, lpriv, 0);
+    ucp_datatype_iter_next_iov(&req->send.state.dt_iter,
+                               lpriv->super.memh_index, max_payload, next_iter,
+                               &iov);
+    return uct_ep_put_zcopy(req->send.ep->uct_eps[lpriv->super.lane], &iov, 1,
+                            req->send.rndv.remote_address +
+                                    req->send.state.dt_iter.offset,
+                            tl_rkey, &req->send.state.uct_comp);
+}
+
+static ucs_status_t
+ucp_proto_rndv_put_zcopy_send_progress(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+    const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
+
+    return ucp_proto_multi_zcopy_progress(
+            req, &rpriv->bulk.mpriv, ucp_proto_rndv_put_common_request_init,
+            UCT_MD_MEM_ACCESS_LOCAL_READ, ucp_proto_rndv_put_zcopy_send_func,
+            ucp_proto_rndv_put_common_data_sent, rpriv->put_comp_cb);
+}
+
+static void ucp_proto_rndv_put_config_str(size_t min_length, size_t max_length,
+                                          const void *priv,
+                                          ucs_string_buffer_t *strb)
+{
+    const ucp_proto_rndv_put_priv_t *rpriv = priv;
+
+    ucp_proto_rndv_bulk_config_str(min_length, max_length, &rpriv->bulk, strb);
+    if (rpriv->flush_map != 0) {
+        ucs_string_buffer_appendf(strb, " flush:");
+        ucs_string_buffer_append_flags(strb, rpriv->flush_map, NULL);
+    }
+    if (rpriv->atp_map != 0) {
+        ucs_string_buffer_appendf(strb, " atp:");
+        ucs_string_buffer_append_flags(strb, rpriv->atp_map, NULL);
+    }
+}
+
+static ucp_proto_t ucp_rndv_put_zcopy_proto = {
+    .name        = "rndv/put/zcopy",
+    .flags       = 0,
+    .init        = ucp_proto_rndv_put_zcopy_init,
+    .config_str  = ucp_proto_rndv_put_config_str,
+    .progress    = {
+        [UCP_PROTO_RNDV_PUT_STAGE_SEND]       = ucp_proto_rndv_put_zcopy_send_progress,
+        [UCP_PROTO_RNDV_PUT_STAGE_FLUSH]      = ucp_proto_rndv_put_common_flush_progress,
+        [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
+        [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
+    },
+};
+UCP_PROTO_REGISTER(&ucp_rndv_put_zcopy_proto);

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -554,8 +554,6 @@ typedef struct {
  * @param _priv   Variable which will hold a pointer to request private data.
  * @param _queue  The pending queue.
  * @param _cond   Condition which should be true in order to keep dispatching.
- *
- * TODO support a callback returning UCS_INPROGRESS.
  */
 #define uct_pending_queue_dispatch(_priv, _queue, _cond) \
     while (!ucs_queue_is_empty(_queue)) { \
@@ -563,10 +561,8 @@ typedef struct {
         uct_pending_req_t *_req; \
         ucs_status_t _status; \
         \
-        _base_priv = \
-            ucs_queue_head_elem_non_empty((_queue), \
-                                          uct_pending_req_priv_queue_t, \
-                                          queue_elem); \
+        _base_priv = ucs_queue_head_elem_non_empty( \
+                (_queue), uct_pending_req_priv_queue_t, queue_elem); \
         \
         UCS_STATIC_ASSERT(sizeof(*(_priv)) <= UCT_PENDING_REQ_PRIV_LEN); \
         _priv = (typeof(_priv))(_base_priv); \
@@ -578,8 +574,15 @@ typedef struct {
         _req = ucs_container_of(_priv, uct_pending_req_t, priv); \
         ucs_queue_pull_non_empty(_queue); \
         _status = _req->func(_req); \
-        if ((_status == UCS_ERR_NO_RESOURCE) || (_status == UCS_INPROGRESS)) { \
-            ucs_queue_push_head(_queue, &_base_priv->queue_elem); \
+        if ((_status) == UCS_OK) { \
+            /* pending element should be removed from queue */ \
+            continue; \
+        } \
+        \
+        /* pending element did not complete; return it to the queue */ \
+        ucs_queue_push_head(_queue, &_base_priv->queue_elem); \
+        if (UCS_STATUS_IS_ERR(_status)) { \
+            break; \
         } \
     }
 


### PR DESCRIPTION
## Why
- Allow put_zcopy mode with new protocols, useful for TCP transport for example
- Infrastructure for 3-staged pipeline which also uses put-based protocol
- Fixes vs. current put protocol: 
   - better latency by sending ATP immediately after put
   - fix correctness by using either fence or flush to ensure data is written remotely

## How
put/zcopy protocol can work in 2 modes:
- fence: put_zcopy,fence(all lanes),atp(all lanes)
- flush: put_zcopy,flush(all lanes). on flush completion: atp(one lane)
The mode is selected according to transport capabilities (supports am_bcopy and put_zcopy on same lane) and according to configuration. "fence" mode is preferred because it has better latency.