### PR TITLE
UCP/RNDV: Option to fallback from GDR to pipeline rndv after threshold

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -284,6 +284,10 @@ static ucs_config_field_t ucp_config_table[] = {
    "RNDV fragment size \n",
    ucs_offsetof(ucp_config_t, ctx.rndv_frag_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"RNDV_PIPELINE_THRESH", "inf",
+   "RNDV size threshold to enable pipeline for mem type\n",
+   ucs_offsetof(ucp_config_t, ctx.rndv_pipeline_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"RNDV_PIPELINE_SEND_THRESH", "inf",
    "RNDV size threshold to enable sender side pipeline for mem type\n",
    ucs_offsetof(ucp_config_t, ctx.rndv_pipeline_send_thresh), UCS_CONFIG_TYPE_MEMUNITS},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -67,6 +67,8 @@ typedef struct ucp_context_config {
     size_t                                 rndv_frag_size;
     /** RNDV pipeline send threshold */
     size_t                                 rndv_pipeline_send_thresh;
+    /** RNDV pipeline threshold */
+    size_t                                 rndv_pipeline_thresh;
     /** Threshold for using tag matching offload capabilities. Smaller buffers
      *  will not be posted to the transport. */
     size_t                                 tm_thresh;


### PR DESCRIPTION
## Why ?
Option to avoid GPUDirectRDMA on large messages.

## How ?
For mem type, Ignore mem type GDR lane while initializing the lanes for zcopy if length of the zcopy is greater than threshold, 
