### PR TITLE
DC/DEBUG: added dci alloc assert, allow missorder

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -77,7 +77,10 @@ typedef enum {
     UCT_DC_MLX5_IFACE_FLAG_UIDX                     = UCS_BIT(2),
 
     /** Flow control endpoint is using a DCI in error state */
-    UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED             = UCS_BIT(3)
+    UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED             = UCS_BIT(3),
+
+    /** Ignore DCI allocation reorder */
+    UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER      = UCS_BIT(4)
 } uct_dc_mlx5_iface_flags_t;
 
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -554,10 +554,11 @@ uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
     }
 
     if (uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index)) {
-        /* TODO: disabled due to shot on some tests where resources are updated
-         * manually: dc_mlx5/test_dc_flow_control.pending_grant for instance. */
-        /* TODO: look how to eliminate assert on such tests */
-        /* ucs_assert(ucs_arbiter_is_empty(waitq)); */
+        if (!(iface->flags & UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER)) {
+            waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
+            ucs_assert(ucs_arbiter_is_empty(waitq));
+        }
+
         uct_dc_mlx5_iface_dci_alloc(iface, ep);
         return UCS_OK;
     }

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -500,6 +500,13 @@ public:
         }
         iface->tx.dci_pool[0].stack_top = 0;
     }
+
+    virtual void ignore_dci_waitq_reorder(uct_test::entity *e)
+    {
+        uct_dc_mlx5_iface_t *iface = test_dc::dc_iface(e);
+
+        iface->flags |= UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER;
+    }
 };
 
 UCS_TEST_P(test_dc_flow_control, general_enabled)
@@ -517,6 +524,10 @@ UCS_TEST_P(test_dc_flow_control, general_disabled)
 
 UCS_TEST_P(test_dc_flow_control, pending_grant)
 {
+    /* test uses manipulation with available TX resources which may break
+       DCI allocation ordering. allow out-of-order DCI waitq */
+    ignore_dci_waitq_reorder(m_e2);
+
     test_pending_grant(5);
     flush();
 }
@@ -582,6 +593,10 @@ UCS_TEST_P(test_dc_flow_control, flush_destroy)
     int wnd = 5;
     ucs_status_t status;
 
+    /* test uses manipulation with available TX resources which may break
+       DCI allocation ordering. allow out-of-order DCI waitq */
+    ignore_dci_waitq_reorder(m_e2);
+
     disable_entity(m_e2);
 
     set_fc_attributes(m_e1, true, wnd,
@@ -618,6 +633,10 @@ UCS_TEST_P(test_dc_flow_control, flush_destroy)
  * is scheduled for dci allocation. */
 UCS_TEST_P(test_dc_flow_control, dci_leak)
 {
+    /* test uses manipulation with available TX resources which may break
+       DCI allocation ordering. allow out-of-order DCI waitq */
+    ignore_dci_waitq_reorder(m_e2);
+
     disable_entity(m_e2);
     int wnd = 5;
     set_fc_attributes(m_e1, true, wnd,


### PR DESCRIPTION
- allow missordered dci allocation in some tests
- some tests update resources manually to make some corner cases in UCX, due to this dci allocation ordering may be broken. suppress assertion in such cases