### PR TITLE
IODEMO: Kill with -9, Stop via SIGINT

### DIFF
--- a/test/apps/iodemo/run_io_demo.sh
+++ b/test/apps/iodemo/run_io_demo.sh
@@ -694,7 +694,14 @@ make_scripts()
 			    for pid in \$(list_pids_with_role \${tag})
 			    do
 			        echo "Stopping process \${pid}"
-			        kill -9 \${pid}
+			        kill -INT \${pid}
+			    done
+			    ;;
+			kill)
+			    for pid in \$(list_pids_with_role \${tag})
+			    do
+			        echo "Killing process \${pid}"
+			        kill -KILL \${pid}
 			    done
 			    ;;
 			status)


### PR DESCRIPTION
https://github.com/Mellanox/hpc-mtt-conf/issues/638

kill via -9
stop via SIGINT 