### PR TITLE
LIBPERF: Add loopback transport support for UCP tests

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -86,7 +86,8 @@ enum ucx_perf_test_flags {
     UCX_PERF_TEST_FLAG_STREAM_RECV_DATA = UCS_BIT(8), /* For stream tests, use recv data API */
     UCX_PERF_TEST_FLAG_FLUSH_EP         = UCS_BIT(9), /* Issue flush on endpoint instead of worker */
     UCX_PERF_TEST_FLAG_WAKEUP           = UCS_BIT(10), /* Create context with wakeup feature enabled */
-    UCX_PERF_TEST_FLAG_ERR_HANDLING     = UCS_BIT(11) /* Create UCP eps with error handling support */
+    UCX_PERF_TEST_FLAG_ERR_HANDLING     = UCS_BIT(11), /* Create UCP eps with error handling support */
+    UCX_PERF_TEST_FLAG_LOOPBACK         = UCS_BIT(12)  /* Use loopback connection */
 };
 
 

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -142,6 +142,7 @@ typedef struct {
 
 extern ucx_perf_funcs_t ucx_perf_funcs[];
 
+unsigned rte_peer_index(unsigned group_size, unsigned group_index);
 void ucx_perf_test_start_clock(ucx_perf_context_t *perf);
 void uct_perf_ep_flush_b(ucx_perf_context_t *perf, int peer_index);
 void uct_perf_iface_flush_b(ucx_perf_context_t *perf);

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -20,7 +20,7 @@
 #define MAX_BATCH_FILES         32
 #define MAX_CPUS                1024
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:l"
 #define TEST_ID_UNDEFINED       -1
 
 enum {
@@ -33,8 +33,11 @@ enum {
 };
 
 typedef struct sock_rte_group {
+    int                          sendfd;
+    int                          recvfd;
     int                          is_server;
-    int                          connfd;
+    int                          size;
+    int                          peer;
 } sock_rte_group_t;
 
 typedef struct test_type {

--- a/src/tools/perf/perftest_run.c
+++ b/src/tools/perf/perftest_run.c
@@ -120,13 +120,13 @@ static void print_header(struct perftest_context *ctx)
             return;
         }
 
-        printf("+------------------------------------------------------------------------------------------+\n");
-        printf("| API:          %-60s               |\n", test_api_str);
-        printf("| Test:         %-60s               |\n", test->desc);
-        printf("| Data layout:  %-60s               |\n", test_data_str);
-        printf("| Send memory:  %-60s               |\n", ucs_memory_type_names[ctx->params.super.send_mem_type]);
-        printf("| Recv memory:  %-60s               |\n", ucs_memory_type_names[ctx->params.super.recv_mem_type]);
-        printf("| Message size: %-60zu               |\n", ucx_perf_get_message_size(&ctx->params.super));
+        printf("+----------------------------------------------------------------------------------------------------------+\n");
+        printf("| API:          %-60s                               |\n", test_api_str);
+        printf("| Test:         %-60s                               |\n", test->desc);
+        printf("| Data layout:  %-60s                               |\n", test_data_str);
+        printf("| Send memory:  %-60s                               |\n", ucs_memory_type_names[ctx->params.super.send_mem_type]);
+        printf("| Recv memory:  %-60s                               |\n", ucs_memory_type_names[ctx->params.super.recv_mem_type]);
+        printf("| Message size: %-60zu                               |\n", ucx_perf_get_message_size(&ctx->params.super));
         if ((test->api == UCX_PERF_API_UCP) &&
             (test->command == UCX_PERF_CMD_AM)) {
             printf("| AM header size: %-60zu             |\n",
@@ -151,7 +151,7 @@ static void print_header(struct perftest_context *ctx)
             printf("|    Stage     | # iterations | %4.1f%%ile | average | overall |  average |  overall |  average  |  overall  |\n", ctx->params.super.percentile_rank);
             printf("+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+\n");
         } else if (ctx->flags & TEST_FLAG_PRINT_TEST) {
-            printf("+------------------------------------------------------------------------------------------+\n");
+            printf("+----------------------------------------------------------------------------------------------------------+\n");
         }
     }
 }

--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -56,9 +56,12 @@ private:
     class rte {
     public:
         /* RTE functions */
-        rte(unsigned index, rte_comm& send, rte_comm& recv);
+        rte(unsigned index, unsigned group_size, unsigned peer,
+            rte_comm& send, rte_comm& recv);
 
         unsigned index() const;
+
+        unsigned gsize() const;
 
         static unsigned group_size(void *rte_group);
 
@@ -82,6 +85,8 @@ private:
 
     private:
         const unsigned m_index;
+        const unsigned m_gsize;
+        const unsigned m_peer;
         rte_comm       &m_send;
         rte_comm       &m_recv;
     };
@@ -98,12 +103,23 @@ private:
 
     static void set_affinity(int cpu);
 
-    static void* thread_func(void *arg);
+    static void* test_func(void *arg);
+
+    void test_params_init(const test_spec &test,
+                          ucx_perf_params_t &params,
+                          unsigned flags,
+                          const std::string &tl_name,
+                          const std::string &dev_name);
 
     test_result run_multi_threaded(const test_spec &test, unsigned flags,
                                    const std::string &tl_name,
                                    const std::string &dev_name,
                                    const std::vector<int> &cpus);
+
+    test_result run_single_threaded(const test_spec &test, unsigned flags,
+                                    const std::string &tl_name,
+                                    const std::string &dev_name,
+                                    const std::vector<int> &cpus);
 };
 
 #endif

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -357,6 +357,17 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_perf)
 
+class test_ucp_loopback : public test_ucp_perf {};
+
+UCS_TEST_P(test_ucp_loopback, envelope)
+{
+    test_spec test = tests[get_variant_value(VARIANT_TEST_TYPE)];
+
+    run_test(test, UCX_PERF_TEST_FLAG_LOOPBACK, true, "", "");
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_loopback)
+
 
 class test_ucp_wait_mem : public test_ucp_perf {
 public:


### PR DESCRIPTION
Signed-off-by: Vasily Philipov <vasilyf@nvidia.com>

## Why ?
Add loopback transport support for UCP tests
