### PR TITLE
UCP/TAG/AM: Print xpmem lane when it is used

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1587,7 +1587,7 @@ char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
     p += strlen(p);
 
     for (lane = 0; lane < key->num_lanes; ++lane) {
-        if ((key->am_lane == lane) ||
+        if ((key->am_lane == lane) || (key->rkey_ptr_lane == lane) ||
             (ucp_ep_config_get_multi_lane_prio(key->am_bw_lanes, lane) >= 0)  ||
             (ucp_ep_config_get_multi_lane_prio(key->rma_bw_lanes, lane) >= 0)) {
             if (context->config.features & UCP_FEATURE_TAG) {


### PR DESCRIPTION
## What
Print xpmem lane when it is used

## Why ?
Better debugging experience:
Now it is shown (when selected ) with info log level
`[1628016549.696474] [swx-dgx03:75816:0]      ucp_worker.c:1810 UCX  INFO    ep_cfg[0]: tag(posix/memory xpmem/memory cma/memory);`

