### PR TITLE
UCT/TCP: Implement flush of all outstanding operations [v1.11.x]

### DIFF
--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -158,6 +158,7 @@ void ucx_perf_calc_result(ucx_perf_context_t *perf, ucx_perf_result_t *result);
 
 void uct_perf_barrier(ucx_perf_context_t *perf);
 
+void ucp_perf_thread_barrier(ucx_perf_context_t *perf);
 
 void ucp_perf_barrier(ucx_perf_context_t *perf);
 

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -109,7 +109,9 @@ enum {
      * method. */
     UCT_TCP_EP_FLAG_CONNECT_TO_EP      = UCS_BIT(8),
     /* EP is on EP PTR map. */
-    UCT_TCP_EP_FLAG_ON_PTR_MAP         = UCS_BIT(9)
+    UCT_TCP_EP_FLAG_ON_PTR_MAP         = UCS_BIT(9),
+    /* EP has some operations done without flush */
+    UCT_TCP_EP_FLAG_NEED_FLUSH         = UCS_BIT(10)
 };
 
 
@@ -217,7 +219,7 @@ typedef enum uct_tcp_ep_am_id {
     UCT_TCP_EP_PUT_REQ_AM_ID   = UCT_AM_ID_MAX + 1,
     /* AM ID reserved for TCP internal PUT ACK message */
     UCT_TCP_EP_PUT_ACK_AM_ID   = UCT_AM_ID_MAX + 2,
-    /* AM ID reserved for TCP internal PUT ACK message */
+    /* AM ID reserved for TCP internal keepalive message */
     UCT_TCP_EP_KEEPALIVE_AM_ID = UCT_AM_ID_MAX + 3
 } uct_tcp_ep_am_id_t;
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -500,8 +500,9 @@ bool ucp_test::check_tls(const std::string& tls)
 ucp_test_base::entity::entity(const ucp_test_param& test_param,
                               ucp_config_t* ucp_config,
                               const ucp_worker_params_t& worker_params,
-                              const ucp_test_base *test_owner)
-    : m_err_cntr(0), m_rejected_cntr(0), m_accept_err_cntr(0)
+                              const ucp_test_base *test_owner) :
+        m_err_cntr(0), m_rejected_cntr(0), m_accept_err_cntr(0),
+        m_test(test_owner)
 {
     const int thread_type                   = test_param.variant.thread_type;
     ucp_params_t local_ctx_params           = test_param.variant.ctx_params;
@@ -971,7 +972,10 @@ void ucp_test_base::entity::ep_destructor(ucp_ep_h ep, entity *e)
     ucs_status_t        status;
     ucp_tag_recv_info_t info;
     do {
-        e->progress();
+        const ucp_test *test = dynamic_cast<const ucp_test*>(e->m_test);
+        ASSERT_TRUE(test != NULL);
+
+        test->progress();
         status = ucp_request_test(req, &info);
     } while (status == UCS_INPROGRESS);
     EXPECT_EQ(UCS_OK, status);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -165,6 +165,7 @@ public:
         size_t                          m_rejected_cntr;
         size_t                          m_accept_err_cntr;
         ucs::handle<ucp_ep_params_t*>   m_server_ep_params;
+        const ucp_test_base             *m_test;
 
     private:
         static void empty_send_completion(void *r, ucs_status_t status);


### PR DESCRIPTION
backport of #7140 PR to v1.11.x branch to be included in 1.11.1 release version

## What

 Implement flush of all outstanding operations.

## Why ?

To fix `uct_ep_flush()` which don't wait for all operations being completed. As a result if fixes the following case:
```
/* client */
for (i= 0; i < 1000; ++i) { 
    req = ucp_ep_tag_send_nb(ep)
    reqs.push_back(req);
}
wait_for_reqs(reqs);

req = ucp_ep_close_nb(ep, FLUSH);
wait_for_req(req);

exit(0);
```
```
/* server */
for (i = 0; i < 1000; ++i) {
    req = ucp_worker_tag_recv_nb(worker);
    reqs.push_back(req);
}
wait_for_reqs(reqs);

/* 998-999 completed successfully, but 1-2 completed with error  */
```

## How ?

1. Do PUT operation if `last_acked_sn != tx.sn` in EP
2. Fix EP flush conditions when checking resources. Return `UCS_OK` if connection has already been closed.
3. Fix tests.