### PR TITLE
AZP/RELEASE: Release matrix

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -16,48 +16,21 @@ jobs:
 
     strategy:
       matrix:
-        centos7_cuda10_1:
-          build_container: centos7_cuda10_1
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda10.1.tar.bz2
-        centos7_cuda10_2:
-          build_container: centos7_cuda10_2
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda10.2.tar.bz2
-        centos7_cuda11_0:
-          build_container: centos7_cuda11_0
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda11.0.tar.bz2
-        centos7_cuda11_2:
-          build_container: centos7_cuda11_2
-          artifact_name: $(POSTFIX)-centos7-mofed5.x-cuda11.2.tar.bz2
-        centos8_cuda11_0:
-          build_container: centos8_cuda11_0
-          artifact_name: $(POSTFIX)-centos8-mofed5.x-cuda11.0.tar.bz2
-        centos8_cuda11_2:
-          build_container: centos8_cuda11_2
-          artifact_name: $(POSTFIX)-centos8-mofed5.x-cuda11.2.tar.bz2
-        ubuntu16_cuda10_1:
-          build_container: ubuntu16_cuda10_1
-          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5.x-cuda10.1.deb
-        ubuntu16_cuda10_2:
-          build_container: ubuntu16_cuda10_2
-          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5.x-cuda10.2.deb
-        ubuntu18_cuda10_1:
-          build_container: ubuntu18_cuda10_1
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda10.1.deb
-        ubuntu18_cuda10_2:
-          build_container: ubuntu18_cuda10_2
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda10.2.deb
-        ubuntu18_cuda11_0:
-          build_container: ubuntu18_cuda11_0
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda11.0.deb
-        ubuntu18_cuda11_2:
-          build_container: ubuntu18_cuda11_2
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5.x-cuda11.2.deb
-        ubuntu20_cuda11_0:
-          build_container: ubuntu20_cuda11_0
-          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5.x-cuda11.0.deb
-        ubuntu20_cuda11_2:
-          build_container: ubuntu20_cuda11_2
-          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5.x-cuda11.2.deb
+        centos7_cuda11:
+          build_container: centos7_cuda11
+          artifact_name: $(POSTFIX)-centos7-mofed5-cuda11.tar.bz2
+        centos8_cuda11:
+          build_container: centos8_cuda11
+          artifact_name: $(POSTFIX)-centos8-mofed5-cuda11.tar.bz2
+        ubuntu16_cuda11:
+          build_container: ubuntu16_cuda11
+          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5-cuda11.deb
+        ubuntu18_cuda11:
+          build_container: ubuntu18_cuda11
+          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5-cuda11.deb
+        ubuntu20_cuda11:
+          build_container: ubuntu20_cuda11
+          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5-cuda11.deb
 
     container: $[ variables['build_container'] ]
 

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -11,34 +11,16 @@ pr:
 
 resources:
   containers:
-    - container: centos7_cuda10_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.1:1
-    - container: centos7_cuda10_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda10.2:1
-    - container: centos7_cuda11_0
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda11.0:2
-    - container: centos7_cuda11_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.0-cuda11.2:2
-    - container: centos8_cuda11_0
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5.0-cuda11.0:2
-    - container: centos8_cuda11_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5.1-cuda11.2:2
-    - container: ubuntu16_cuda10_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.1:1
-    - container: ubuntu16_cuda10_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5.0-cuda10.2:1
-    - container: ubuntu18_cuda10_1
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.1:1
-    - container: ubuntu18_cuda10_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda10.2:1
-    - container: ubuntu18_cuda11_0
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.0:2
-    - container: ubuntu18_cuda11_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5.0-cuda11.2:2
-    - container: ubuntu20_cuda11_0
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5.0-cuda11.0:2
-    - container: ubuntu20_cuda11_2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5.0-cuda11.2:2
+    - container: centos7_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5-cuda11:1
+    - container: centos8_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:1
+    - container: ubuntu16_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5-cuda11:1
+    - container: ubuntu18_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:1
+    - container: ubuntu20_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:1
 
 stages:
   - stage: Prepare
@@ -64,7 +46,7 @@ stages:
     jobs:
       - job: DraftRelease
         displayName: Create draft release
-        container: centos7_cuda11_2
+        container: centos7_cuda11
         pool:
           name: MLNX
           demands:

--- a/buildlib/dockers/centos-release.Dockerfile
+++ b/buildlib/dockers/centos-release.Dockerfile
@@ -5,7 +5,6 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-centos${OS_VERSION}
 RUN yum install -y \
     autoconf \
     automake \
-    doxygen \
     file \
     gcc-c++ \
     git \
@@ -22,6 +21,9 @@ RUN yum install -y \
     wget \
     libusbx \
     fuse-libs \
+    python36 \
+    lsof \
+    ethtool \
     && yum clean all
 
 # MOFED
@@ -40,6 +42,8 @@ RUN wget --no-verbose http://content.mellanox.com/ofed/${MOFED_SITE_PLACE}/${MOF
         --without-hcoll \
         --without-openmpi \
         --without-sharp \
+        --skip-distro-check \
+        --distro ${MOFED_OS} \
     && rm -rf ${MOFED_DIR} && rm -rf *.tgz
 
 ENV CPATH /usr/local/cuda/include:${CPATH}

--- a/buildlib/dockers/centos8-release.Dockerfile
+++ b/buildlib/dockers/centos8-release.Dockerfile
@@ -22,6 +22,7 @@ RUN yum install -y \
     libusbx \
     fuse-libs \
     python36 \
+    lsof \
     && yum clean all
 
 # MOFED
@@ -40,6 +41,8 @@ RUN wget --no-verbose http://content.mellanox.com/ofed/${MOFED_SITE_PLACE}/${MOF
         --without-hcoll \
         --without-openmpi \
         --without-sharp \
+        --skip-distro-check \
+        --distro ${MOFED_OS} \
     && rm -rf ${MOFED_DIR} && rm -rf *.tgz
 
 ENV CPATH /usr/local/cuda/include:${CPATH}

--- a/buildlib/dockers/docker-compose.yml
+++ b/buildlib/dockers/docker-compose.yml
@@ -1,67 +1,55 @@
 version: "3"
 
 services:
-  centos7-mofed5.1-cuda11.1:
-    image: centos7-mofed5.1-cuda11.1
+  centos7-mofed5-cuda11:
+    image: centos7-mofed5-cuda11
     build:
       context: .
       network: host
       dockerfile: centos-release.Dockerfile
       args:
-        MOFED_VERSION: 5.1-2.5.8.0
+        MOFED_VERSION: 5.0-1.0.0.0
         MOFED_OS: rhel7.6
-        CUDA_VERSION: 11.1
+        CUDA_VERSION: 11.2.0
         OS_VERSION: 7
-  centos8-mofed5.1-cuda11.1:
-    image: centos8-mofed5.1-cuda11.1
+  centos8-mofed5-cuda11:
+    image: centos8-mofed5-cuda11
     build:
       context: .
       network: host
-      dockerfile: centos8-release.Dockerfile
+      dockerfile: centos-release.Dockerfile
       args:
-        MOFED_VERSION: 5.1-2.5.8.0
-        MOFED_OS: rhel8.3
-        CUDA_VERSION: 11.1
+        MOFED_VERSION: 5.0-1.0.0.0
+        MOFED_OS: rhel8.2
+        CUDA_VERSION: 11.2.0
         OS_VERSION: 8
-  ubuntu18.04-mofed5.1-cuda11.1:
-    image: ubuntu18.04-mofed5.1-cuda11.1
+  ubuntu16.04-mofed5-cuda11:
+    image: ubuntu16.04-mofed5-cuda11
     build:
       context: .
       network: host
       dockerfile: ubuntu-release.Dockerfile
       args:
-        MOFED_VERSION: 5.1-2.5.8.0
+        MOFED_VERSION: 5.0-1.0.0.0
+        UBUNTU_VERSION: 16.04
+        CUDA_VERSION: 11.2.0
+  ubuntu18.04-mofed5-cuda11:
+    image: ubuntu18.04-mofed5-cuda11
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.0-1.0.0.0
         UBUNTU_VERSION: 18.04
-        CUDA_VERSION: 11.1
-  ubuntu20.04-mofed5.1-cuda11.1:
-    image: ubuntu20.04-mofed5.1-cuda11.1
+        CUDA_VERSION: 11.2.0
+  ubuntu20.04-mofed5-cuda11:
+    image: ubuntu20.04-mofed5-cuda11
     build:
       context: .
       network: host
       dockerfile: ubuntu-release.Dockerfile
       args:
-        MOFED_VERSION: 5.1-2.5.8.0
+        MOFED_VERSION: 5.0-1.0.0.0
         UBUNTU_VERSION: 20.04
-        CUDA_VERSION: 11.1
-  ubuntu20.10-mofed5.1-cuda11.1:
-    image: ubuntu20.10-mofed5.1-cuda11.1
-    build:
-      context: .
-      network: host
-      dockerfile: ubuntu-release.Dockerfile
-      args:
-        MOFED_VERSION: 5.1-2.5.8.0
-        UBUNTU_VERSION: 20.10
-        CUDA_VERSION: 11.1
-        MOFED_OS: ubuntu20.04
-  fedora31-mofed5.1-cuda11.1:
-    image: fedora31-mofed5.1-cuda11.1
-    build:
-      context: .
-      network: host
-      dockerfile: fedora-release.Dockerfile
-      args:
-        MOFED_VERSION: 5.1-2.5.8.0
-        OS_VERSION: 31
-        CUDA_VERSION: 11.1
-        MOFED_OS: fc31
+        CUDA_VERSION: 11.2.0

--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -12,7 +12,7 @@ jobs:
         - harbor_registry -equals yes
 
     # we need to use lowest version for compatible
-    container: centos7_cuda10_1
+    container: centos7_cuda11
 
     steps:
       - checkout: self


### PR DESCRIPTION
The UCX community releases:

We are dropping support for CUDA 10.x.

WRT to the OS’s, the released builds will remain as they are now (rpm/deps) – for example - https://github.com/openucx/ucx/releases
(other than dropping cuda10 support and the renaming in bullet #4)

The naming will change to reflect backwards compatibility for MLNX_OFED 5.x and CUDA 11.x.
For example - ucx-v1.11.0-ubuntu18.04-mofed5-cuda11.deb