### PR TITLE
CONTRIB: Introduce QP check script

### DIFF
--- a/contrib/check_qps.sh
+++ b/contrib/check_qps.sh
@@ -1,0 +1,103 @@
+#!/bin/sh -eE
+#
+# Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+#
+# This script detects potentially stuck Queue Pairs which have ci != pi.
+#
+
+VFS_UCX_PATH="/tmp/ucx"
+HW_CI_FILE="hw_ci"
+PREV_SW_PI_FILE="prev_sw_pi"
+QP_NUM_FILE="qp_num"
+
+# Interval between traversing QPs (in seconds)
+QP_CHECK_INTERVAL=10
+# "yes" - print all QPs, "no" - print only stuck QPs
+PRINT_ALL_QPS=0
+
+# Show script usage help message
+usage()
+{
+    echo " Usage:"
+    echo "  "$0" [ options ]"
+    echo " Options:"
+    echo "  -a           Print all QPs"
+    echo "  -p <path>    Path to UCX CFS mount point (/tmp/ucx)"
+    echo "  -i <seconds> Interval to check QP state"
+    exit 1
+}
+
+while getopts ":ap:i:" o; do
+    case "${o}" in
+    a)
+        PRINT_ALL_QPS=1
+        ;;
+    i)
+        QP_CHECK_INTERVAL=${OPTARG}
+        ;;
+    p)
+        VFS_UCX_PATH=${OPTARG}
+        ;;
+    *)
+        usage
+        ;;
+    esac
+done
+shift $((OPTIND-1))
+
+declare -A qp_nums
+declare -A initial_hw_cis
+
+traverse() {
+    DC_TXWQ_GLOB_PATH="${VFS_UCX_PATH}/*/uct/worker/*/iface/*/dci_pool/*/*"
+    for file in ${DC_TXWQ_GLOB_PATH}/${QP_NUM_FILE}
+    do
+        filename=$(basename ${file})
+        dir=$(dirname ${file})
+        if [ -f ${dir}/${HW_CI_FILE} ] && \
+            [ -f ${dir}/${PREV_SW_PI_FILE} ] ; then
+            qp_num=$(<${file})
+
+            if [ ! ${qp_nums[${qp_num}]} ] ; then
+                qp_nums[${qp_num}]=${dir}
+                initial_hw_cis[${qp_num}]=$(<${dir}/${HW_CI_FILE})
+            fi
+        fi
+    done
+}
+
+print_qp_num_info() {
+    for qp_num in "${!qp_nums[@]}"
+    do
+        dir=${qp_nums[${qp_num}]}
+        if [ ! -d ${dir} ] ; then
+            continue
+        fi
+
+        hw_ci=$(<${dir}/${HW_CI_FILE})
+        prev_sw_pi=$(<${dir}/${PREV_SW_PI_FILE})
+        initial_hw_ci=${initial_hw_cis[${qp_num}]}
+
+        # QP is considered as stuck if (hw_ci != sw_pi) AND hw_ci hasn't been changed
+        if [ ${hw_ci} -eq ${prev_sw_pi} ] || [ ${initial_hw_ci} -ne ${hw_ci} ] ; then
+            result_str="ok"
+            if [ ${PRINT_ALL_QPS} -eq 0 ] ; then
+                continue
+            fi
+        else
+            result_str="stuck (path=$dir)"
+        fi
+
+        echo "qp=0x${qp_num}: pi=${prev_sw_pi} ci=${hw_ci} initial_ci=${initial_hw_ci} - ${result_str}"
+    done
+}
+
+traverse
+sleep ${QP_CHECK_INTERVAL}
+traverse
+
+print_qp_num_info


### PR DESCRIPTION
## What

Introduce QP check script which finds QPs that are stuck.

## Why ?

To find QPs which are stuck, i.e. `ci != pi` and `ci` wasn't increased from the first run.
e.g.:
```
$ PRINT_ALL_QPS=yes QP_CHECK_INTERVAL=1 ~/work_auto/ucx/contrib/check_qps.sh
...
qp=0xaae7: pi=65535 ci=65535 initial_ci=65535 - ok
qp=0x19527: pi=36687 ci=36677 initial_ci=48895 - ok
qp=0xaa48: pi=65535 ci=65535 initial_ci=65535 - ok
qp=0x1955b: pi=56554 ci=56522 initial_ci=56522 - stuck (path=/tmp/ucx/62136/uct/worker/0x766d40/iface/0x78af00/dci_pool/0/7)
qp=0x194ff: pi=62989 ci=62989 initial_ci=62959 - ok
qp=0x195c8: pi=23262 ci=23262 initial_ci=23262 - ok
...
```

## How ?

1. Goes over `/tmp/ucx` VFS directory and trying to find TXWQ directory which contains `qp_num`, `hw_ci`, `prev_sw_pi` files (only DC is supported now, since RC/UD doesn't report this info at the moment). All QPs are stored in associate array.
2. Sleep for soemn time.
3. Does the 2nd traversing over all QPs.
4. Prints QPs info and results ("ok"/"stuck"). "stuck" is printed if `ci != pi` and `ci` of the first traversing is equal to `ci` of the second traversing.