### PR TITLE
UCP/RKEY: optimizes memory consumption of ucp_rkey_t

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -33,6 +33,16 @@ static struct {
     uint8_t      mem_type;
 } UCS_S_PACKED ucp_mem_dummy_buffer = {0, UCS_MEMORY_TYPE_HOST};
 
+const ucp_amo_proto_t *ucp_amo_proto_list[] = {
+    [UCP_RKEY_BASIC_PROTO] = &ucp_amo_basic_proto,
+    [UCP_RKEY_SW_PROTO]    = &ucp_amo_sw_proto
+};
+
+const ucp_rma_proto_t *ucp_rma_proto_list[] = {
+    [UCP_RKEY_BASIC_PROTO] = &ucp_rma_basic_proto,
+    [UCP_RKEY_SW_PROTO]    = &ucp_rma_sw_proto
+};
+
 
 size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map,
                             ucs_sys_device_t sys_dev, uint64_t sys_dev_map)
@@ -338,6 +348,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
     ucp_rkey_h rkey;
     uint8_t flags;
 
+    UCS_STATIC_ASSERT(ucs_offsetof(ucp_rkey_t, mem_type) ==
+                      ucs_offsetof(ucp_rkey_t, cache.mem_type));
+    UCS_STATIC_ASSERT(ucs_same_type(ucs_field_type(ucp_rkey_t, mem_type),
+                                    ucs_field_type(ucp_rkey_t, cache.mem_type)));
+
     ucs_trace("ep %p: unpacking rkey buffer %p length %zu", ep, buffer, length);
     ucs_log_indent(1);
 
@@ -599,20 +614,27 @@ void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
     ucs_status_t status;
     uct_rkey_t uct_rkey;
 
+    UCS_STATIC_ASSERT(ucs_offsetof(ucp_rkey_t, flags) ==
+                      ucs_offsetof(ucp_rkey_t, cache.flags));
+    UCS_STATIC_ASSERT(ucs_same_type(ucs_field_type(ucp_rkey_t, flags),
+                                    ucs_field_type(ucp_rkey_t, cache.flags)));
+
     rkey->cache.rma_lane = ucp_rkey_find_rma_lane(context, config,
                                                   UCS_MEMORY_TYPE_HOST,
                                                   config->key.rma_lanes, rkey,
                                                   0, &uct_rkey);
     if (rkey->cache.rma_lane == UCP_NULL_LANE) {
-        rkey->cache.rma_proto     = &ucp_rma_sw_proto;
-        rkey->cache.rma_rkey      = UCT_INVALID_RKEY;
-        rkey->cache.max_put_short = 0;
-        rma_sw                    = !!(context->config.features & UCP_FEATURE_RMA);
+        rkey->cache.rma_proto_index = UCP_RKEY_SW_PROTO;
+        rkey->cache.rma_rkey        = UCT_INVALID_RKEY;
+        rkey->cache.max_put_short   = 0;
+        rma_sw                      = !!(context->config.features & UCP_FEATURE_RMA);
     } else {
-        rkey->cache.rma_proto     = &ucp_rma_basic_proto;
-        rkey->cache.rma_rkey      = uct_rkey;
-        rkey->cache.rma_proto     = &ucp_rma_basic_proto;
-        rkey->cache.max_put_short = config->rma[rkey->cache.rma_lane].max_put_short;
+        rkey->cache.rma_proto_index = UCP_RKEY_BASIC_PROTO;
+        rkey->cache.rma_rkey        = uct_rkey;
+        UCS_STATIC_ASSERT(ucs_same_type(ucs_field_type(ucp_rkey_t,
+                                        cache.max_put_short), int8_t));
+        rkey->cache.max_put_short   =
+            ucs_min(config->rma[rkey->cache.rma_lane].max_put_short, INT8_MAX);
     }
 
     rkey->cache.amo_lane = ucp_rkey_find_rma_lane(context, config,
@@ -620,13 +642,13 @@ void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
                                                   config->key.amo_lanes, rkey,
                                                   0, &uct_rkey);
     if (rkey->cache.amo_lane == UCP_NULL_LANE) {
-        rkey->cache.amo_proto     = &ucp_amo_sw_proto;
-        rkey->cache.amo_rkey      = UCT_INVALID_RKEY;
-        amo_sw                    = !!(context->config.features &
-                                       (UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64));
+        rkey->cache.amo_proto_index = UCP_RKEY_SW_PROTO;
+        rkey->cache.amo_rkey        = UCT_INVALID_RKEY;
+        amo_sw                      = !!(context->config.features &
+                                         (UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64));
     } else {
-        rkey->cache.amo_proto     = &ucp_amo_basic_proto;
-        rkey->cache.amo_rkey      = uct_rkey;
+        rkey->cache.amo_proto_index = UCP_RKEY_BASIC_PROTO;
+        rkey->cache.amo_rkey        = uct_rkey;
     }
 
     /* If we use sw rma/amo need to resolve destination endpoint in order to
@@ -655,8 +677,10 @@ void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep)
     ucs_trace("rkey %p ep %p @ cfg[%d] %s: lane[%d] rkey 0x%"PRIxPTR
               " %s: lane[%d] rkey 0x%"PRIxPTR,
               rkey, ep, ep->cfg_index,
-              rkey->cache.rma_proto->name, rkey->cache.rma_lane, rkey->cache.rma_rkey,
-              rkey->cache.amo_proto->name, rkey->cache.amo_lane, rkey->cache.amo_rkey);
+              UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index)->name,
+              rkey->cache.rma_lane, rkey->cache.rma_rkey,
+              UCP_RKEY_AMO_PROTO(rkey->cache.amo_proto_index)->name,
+              rkey->cache.amo_lane, rkey->cache.amo_rkey);
 }
 
 void ucp_rkey_config_dump_brief(const ucp_rkey_config_key_t *rkey_config_key,

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -15,8 +15,41 @@
 
 /* Remote keys with that many remote MDs or less would be allocated from a
  * memory pool.
+ *
+ * The element size of rkey mpool has aligned by the cache line (64B), so the
+ * UCP_RKEY_MPOOL_MAX_MD is adjusted to 2 to minimize gaps between mpool items,
+ * in turn, reduce the memory consumption.
+ *
+ * See the byte-scheme of the rkey mpool element:
+ * +------+------------+------------+------------+------------+------------+------
+ * |elem  |            |            |            |            |            |
+ * |header| ucp_rkey_t | uct rkey 0 | uct rkey 1 | uct rkey 2 | uct rkey 3 | ...
+ * +------+------------+------------+------------+------------+------------+-----
+ * | 8B   |    32B     |    32B     |    32B     |    32B     |    32B     | ...
+ * +----------------------------+-------------------------+----------------------+
+ * |        64B Cache line      |     64B Cache line      |    64B Cache line    |
+ * +----------------------------+-------------------------+---+------------------+
+ * |                 UCP_RKEY_MPOOL_MAX_MD=3                  |     40B gap      |
+ * +---------------------------------------------+--------+---+------------------+
+ * |           UCP_RKEY_MPOOL_MAX_MD=2           | 16B gap|
+ * +---------------------------------------------+--------+
+ *
+ * Thus UCP_RKEY_MPOOL_MAX_MD=2 is the optimal value to keeping short rkeys in
+ * the rkey mpool.
  */
-#define UCP_RKEY_MPOOL_MAX_MD     3
+#define UCP_RKEY_MPOOL_MAX_MD     2
+
+
+/**
+ * Rkey proto index
+ */
+enum {
+    UCP_RKEY_BASIC_PROTO,
+    UCP_RKEY_SW_PROTO
+};
+
+
+typedef uint8_t ucp_rkey_proto_index_t;
 
 
 /**
@@ -84,26 +117,38 @@ typedef struct {
  * The array itself contains only the MDs specified in md_map, without gaps.
  */
 typedef struct ucp_rkey {
-    /* cached values for the most recent endpoint configuration */
-    struct {
-        ucp_worker_cfg_index_t    ep_cfg_index; /* EP configuration relevant for the cache */
-        ucp_lane_index_t          rma_lane;     /* Lane to use for RMAs */
-        ucp_lane_index_t          amo_lane;     /* Lane to use for AMOs */
-        ssize_t                   max_put_short;/* Cached value of max_put_short */
-        uct_rkey_t                rma_rkey;     /* Key to use for RMAs */
-        uct_rkey_t                amo_rkey;     /* Key to use for AMOs */
-        ucp_amo_proto_t           *amo_proto;   /* Protocol for AMOs */
-        ucp_rma_proto_t           *rma_proto;   /* Protocol for RMAs */
-    } cache;
-    ucp_md_map_t                  md_map;       /* Which *remote* MDs have valid memory handles */
-    ucs_memory_type_t             mem_type;     /* Memory type of remote key memory */
-    uint8_t                       flags;        /* Rkey flags */
-    ucp_worker_cfg_index_t        cfg_index;    /* Rkey configuration index */
+    union {
+        /* Cached values for the most recent endpoint configuration */
+        struct {
+            uint8_t                   flags;           /* Rkey flags */
+            uint8_t                   mem_type;        /* Memory type of remote key memory */
+            int8_t                    max_put_short;   /* Cached value of max_put_short */
+            ucp_worker_cfg_index_t    ep_cfg_index;    /* EP configuration relevant for the cache */
+            ucp_lane_index_t          rma_lane;        /* Lane to use for RMAs */
+            ucp_lane_index_t          amo_lane;        /* Lane to use for AMOs */
+            ucp_rkey_proto_index_t    amo_proto_index; /* Protocol for AMOs */
+            ucp_rkey_proto_index_t    rma_proto_index; /* Protocol for RMAs */
+            uct_rkey_t                rma_rkey;        /* Key to use for RMAs */
+            uct_rkey_t                amo_rkey;        /* Key to use for AMOs */
+        } cache;
+        struct {
+            uint8_t                   flags;           /* Rkey flags */
+            uint8_t                   mem_type;        /* Memory type of remote key memory */
+            ucp_worker_cfg_index_t    cfg_index;       /* Rkey configuration index */
+        };
+    };
 #if ENABLE_PARAMS_CHECK
-    ucp_ep_h                      ep;
+    ucp_ep_h                          ep;
 #endif
-    ucp_tl_rkey_t                 tl_rkey[0];   /* UCT rkey for every remote MD */
+    ucp_md_map_t                      md_map;          /* Which *remote* MDs have valid memory handles */
+    ucp_tl_rkey_t                     tl_rkey[0];      /* UCT rkey for every remote MD */
 } ucp_rkey_t;
+
+
+#define UCP_RKEY_AMO_PROTO(_amo_proto_index) ucp_amo_proto_list[_amo_proto_index]
+
+
+#define UCP_RKEY_RMA_PROTO(_rma_proto_index) ucp_rma_proto_list[_rma_proto_index]
 
 
 #define UCP_RKEY_RESOLVE_NOCHECK(_rkey, _ep, _op_type) \

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -228,11 +228,13 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_atomic_op_nbx,
         if (param->op_attr_mask & UCP_OP_ATTR_FIELD_REPLY_BUFFER) {
             ucp_amo_init_fetch(req, ep, param->reply_buffer,
                                ucp_uct_atomic_op_table[opcode], op_size,
-                               remote_addr, rkey, value, rkey->cache.amo_proto);
+                               remote_addr, rkey, value,
+                               UCP_RKEY_AMO_PROTO(rkey->cache.amo_proto_index));
             status_p = ucp_rma_send_request(req, param);
         } else {
             ucp_amo_init_post(req, ep, ucp_uct_atomic_op_table[opcode], op_size,
-                              remote_addr, rkey, value, rkey->cache.amo_proto);
+                              remote_addr, rkey, value,
+                              UCP_RKEY_AMO_PROTO(rkey->cache.amo_proto_index));
             status_p = ucp_rma_send_request(req, param);
         }
     }

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -82,6 +82,10 @@ extern ucp_amo_proto_t ucp_amo_basic_proto;
 extern ucp_amo_proto_t ucp_amo_sw_proto;
 
 
+extern const ucp_rma_proto_t *ucp_rma_proto_list[];
+extern const ucp_amo_proto_t *ucp_amo_proto_list[];
+
+
 ucs_status_t ucp_rma_request_advance(ucp_request_t *req, ssize_t frag_length,
                                      ucs_status_t status,
                                      ucs_ptr_map_key_t req_id);

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -296,7 +296,7 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
 
         rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
         ret = ucp_rma_nonblocking(ep, buffer, count, remote_addr, rkey,
-                                  rkey->cache.rma_proto->progress_put,
+                                  UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index)->progress_put,
                                   rma_config->put_zcopy_thresh, param);
     }
 
@@ -379,7 +379,7 @@ ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
 
         rma_config = &ucp_ep_config(ep)->rma[rkey->cache.rma_lane];
         ret        = ucp_rma_nonblocking(ep, buffer, count, remote_addr, rkey,
-                                         rkey->cache.rma_proto->progress_get,
+                                         UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index)->progress_get,
                                          rma_config->get_zcopy_thresh, param);
     }
 

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -192,4 +192,10 @@
 #define UCS_STATIC_CLEANUP \
     static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
 
+/*
+ * Check if the two types are the same
+ */
+#define ucs_same_type(_type1, _type2) \
+    __builtin_types_compatible_p(_type1, _type2)
+
 #endif /* UCS_COMPILER_DEF_H */

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,6 +50,11 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
+#if ENABLE_PARAMS_CHECK
+    EXPECTED_SIZE(ucp_rkey_t, 32 + sizeof(ucp_ep_h));
+#else
+    EXPECTED_SIZE(ucp_rkey_t, 32);
+#endif
     /* TODO reduce request size to 240 or less after removing old protocols state */
     EXPECTED_SIZE(ucp_request_t, 272);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -223,10 +223,13 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
 
         if (expect_rma_offload) {
             if (is_dummy) {
-                EXPECT_EQ(&ucp_rma_sw_proto, rkey->cache.rma_proto);
+                EXPECT_EQ(&ucp_rma_sw_proto,
+                          UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index));
             } else {
-                ucs_assert(&ucp_rma_basic_proto == rkey->cache.rma_proto);
-                EXPECT_EQ(&ucp_rma_basic_proto, rkey->cache.rma_proto);
+                ucs_assert(&ucp_rma_basic_proto ==
+                           UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index));
+                EXPECT_EQ(&ucp_rma_basic_proto,
+                          UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index));
             }
         }
     }


### PR DESCRIPTION
## What
Reduces `ucp_rkey_t` from 64 to 40 bytes.

## Why ?
Allows reducing mem consumption by approximately 30%.

## How ?
- reordering of structure fields
- using protocols indexes instead of pointers {amo|rma}_proto

UPD: removed `max_put_short` that reduces rkey to 32 bytes.