### PR TITLE
GTEST/UCP/WIREUP: Don't overwrite EP params from base test suite

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1471,14 +1471,15 @@ public:
     }
 
     ucp_ep_params_t get_ep_params() {
-        ucp_ep_params_t params;
-        memset(&params, 0, sizeof(params));
-        params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+        ucp_ep_params_t params = test_ucp_wireup::get_ep_params();
+
+        params.field_mask     |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                  UCP_EP_PARAM_FIELD_ERR_HANDLER;
         params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
         params.err_handler.cb  = reinterpret_cast<ucp_err_handler_cb_t>
                                  (ucs_empty_function);
         params.err_handler.arg = reinterpret_cast<void*>(this);
+
         return params;
     }
 


### PR DESCRIPTION
## What

The PR fixes setting EP params in UCP wireup keepalive test suite.

## Why ?

No need to overwrite EP params from base test suite.

## How ?

1. Remove `memset(&params, 0, sizeof(params));` at the beginning of the function.
2. Assign `field_mask` field of `ucp_ep_params_t` by ORing values.