### PR TITLE
UCP/PROTO: Calculate protocol pipelined performance

### DIFF
--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -19,7 +19,7 @@
 
 
 /* Maximal number of protocol performance ranges */
-#define UCP_PROTO_MAX_PERF_RANGES   32
+#define UCP_PROTO_MAX_PERF_RANGES 24
 
 
 /* Maximal size of protocol private data */
@@ -84,30 +84,43 @@ typedef struct {
 } UCS_S_PACKED ucp_proto_select_param_t;
 
 
-/**
- * Protocol and its private configuration
+/*
+ * Some protocols can be pipelined, so the time they consume when multiple
+ * such operations are issued is less than their cumulative time. Therefore we
+ * define two metrics: "single" operation time and "multi" operation time.
+ *
+ * -------time---------->
+ *
+ *        +-------------------------+
+ * op1:   |   "single" time         |
+ *        +---------------+---------+---------------+
+ *                op2:    | overlap | "multi" time  |
+ *                        +---------+-----+---------+---------------+
+ *                                op3:    | overlap | "multi" time  |
+ *                                        +---------+---------------+
  */
-typedef struct {
-    const ucp_proto_t        *proto;       /* Protocol definition */
-    const void               *priv;        /* Protocol private configuration space */
-    ucp_worker_cfg_index_t   ep_cfg_index; /* Endpoint configuration index this
-                                              protocol was selected on */
-    ucp_worker_cfg_index_t   rkey_cfg_index; /* Remote key configuration index
-                                                this protocol was elected on
-                                                (can be UCP_WORKER_CFG_INDEX_NULL) */
-    ucp_proto_select_param_t select_param; /* Copy of protocol selection parameters,
-                                              used to re-select protocol for existing
-                                              in-progress request */
-} ucp_proto_config_t;
+typedef enum {
+    /* Time to complete this operation assuming it's the only one. */
+    UCP_PROTO_PERF_TYPE_SINGLE,
+
+    /* Time to complete this operation after all previous ones complete. */
+    UCP_PROTO_PERF_TYPE_MULTI,
+
+    UCP_PROTO_PERF_TYPE_LAST
+} ucp_proto_perf_type_t;
 
 
 /*
- * Performance estimation for a range of message sizes
+ * Performance estimation for a range of message sizes.
  */
 typedef struct {
-    size_t                  max_length; /* Maximal message size */
-    ucs_linear_func_t       perf;       /* Estimated time in seconds, as a
-                                           function of message size in bytes */
+    /* Maximal payload size for this range */
+    size_t            max_length;
+
+    /* Estimated time in seconds, as a function of message size in bytes, to
+     * complete the operation. See @ref ucp_proto_perf_type_t for details
+     */
+    ucs_linear_func_t perf[UCP_PROTO_PERF_TYPE_LAST];
 } ucp_proto_perf_range_t;
 
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -501,14 +501,9 @@ ucp_proto_common_buffer_copy_time(ucp_worker_h worker, const char *title,
     return UCS_OK;
 }
 
-/*
- * Calculate the performance pipelining an operation with performance 'perf1'
- * with an operation with performance 'perf2' by using fragments with size
- * 'frag_size' bytes.
-*/
-static ucs_linear_func_t ucp_proto_common_ppln_perf(ucs_linear_func_t perf1,
-                                                    ucs_linear_func_t perf2,
-                                                    double frag_size)
+ucs_linear_func_t ucp_proto_common_ppln_perf(ucs_linear_func_t perf1,
+                                             ucs_linear_func_t perf2,
+                                             double frag_size)
 {
     double adjusted_frag_size = ucs_max(frag_size, 1.0);
     double max_m              = ucs_max(perf1.m, perf2.m);
@@ -552,7 +547,6 @@ ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
     ucs_linear_func_t send_ovrh, xfer, recv_ovrh;
     ucp_proto_perf_range_t *range0, *range1;
     ucs_memory_type_t recv_mem_type;
-    ucs_linear_func_t perf_multi;
     uint32_t op_attr_mask;
     ucs_status_t status;
     size_t frag_size;
@@ -646,9 +640,13 @@ ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
     frag_size = ucs_min(params->max_length, perf->max_frag - params->hdr_size);
 
     /* First range represents sending the first fragment */
-    range0             = &caps->ranges[0];
-    range0->max_length = frag_size;
-    range0->perf       = ucs_linear_func_add3(send_ovrh, xfer, recv_ovrh);
+    range0                                   = &caps->ranges[0];
+    range0->max_length                       = frag_size;
+    range0->perf[UCP_PROTO_PERF_TYPE_SINGLE] = ucs_linear_func_add3(send_ovrh,
+                                                                    xfer,
+                                                                    recv_ovrh);
+    range0->perf[UCP_PROTO_PERF_TYPE_MULTI]  =
+            ucp_proto_common_ppln3_perf(send_ovrh, xfer, recv_ovrh, frag_size);
 
     /* Second range represents sending rest of the fragments, if applicable */
     if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG) {
@@ -661,16 +659,21 @@ ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
         range1             = &caps->ranges[1];
         range1->max_length = params->max_length;
 
-        perf_multi = ucp_proto_common_ppln3_perf(send_ovrh, xfer, recv_ovrh,
-                                                 frag_size);
-
         /* Overhead of sending one fragment before starting the pipeline */
-        frag_ovrh = ucs_linear_func_apply(range0->perf, frag_size) -
-                    ucs_linear_func_apply(perf_multi, frag_size);
+        frag_ovrh =
+                ucs_linear_func_apply(range0->perf[UCP_PROTO_PERF_TYPE_SINGLE],
+                                      frag_size) -
+                ucs_linear_func_apply(range0->perf[UCP_PROTO_PERF_TYPE_MULTI],
+                                      frag_size);
 
         /* Apply the pipelining effect when sending multiple fragments */
-        range1->perf = ucs_linear_func_add(perf_multi,
-                                           ucs_linear_func_make(frag_ovrh, 0));
+        range1->perf[UCP_PROTO_PERF_TYPE_SINGLE] =
+                ucs_linear_func_add(range0->perf[UCP_PROTO_PERF_TYPE_MULTI],
+                                    ucs_linear_func_make(frag_ovrh, 0));
+
+        /* Multiple send performance is the same */
+        range1->perf[UCP_PROTO_PERF_TYPE_MULTI] =
+                range0->perf[UCP_PROTO_PERF_TYPE_MULTI];
     }
 
     return UCS_OK;

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -164,6 +164,16 @@ ucp_lane_index_t
 ucp_proto_common_find_am_bcopy_hdr_lane(const ucp_proto_init_params_t *params);
 
 
+/*
+ * Calculate the performance pipelining an operation with performance 'perf1'
+ * with an operation with performance 'perf2' by using fragments with size
+ * 'frag_size' bytes.
+*/
+ucs_linear_func_t ucp_proto_common_ppln_perf(ucs_linear_func_t perf1,
+                                             ucs_linear_func_t perf2,
+                                             double frag_size);
+
+
 ucs_status_t
 ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
                            const ucp_proto_common_tl_perf_t *perf,

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -84,6 +84,8 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
 static ucs_status_t
 ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
 {
+    ucp_proto_perf_type_t perf_type;
+
     /* Default reconfiguration protocol is a fallback for any case protocol
      * selection is unsuccessful. The protocol keeps queuing requests until they
      * can be executed.
@@ -94,8 +96,10 @@ ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
     init_params->caps->min_length           = 0;
     init_params->caps->num_ranges           = 1;
     init_params->caps->ranges[0].max_length = SIZE_MAX;
-    init_params->caps->ranges[0].perf       = ucs_linear_func_make(INFINITY, 0);
-
+    for (perf_type = 0; perf_type < UCP_PROTO_PERF_TYPE_LAST; ++perf_type) {
+        init_params->caps->ranges[0].perf[perf_type] =
+                ucs_linear_func_make(INFINITY, 0);
+    }
     return UCS_OK;
 }
 

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -24,6 +24,37 @@
 #define UCP_PROTO_SELECT_PARAM_STR_MAX 128
 
 
+typedef struct {
+    ucp_proto_perf_range_t super;
+    size_t                 cfg_thresh; /* Configured protocol threshold */
+} ucp_proto_select_range_t;
+
+
+/**
+ * Protocol and its private configuration
+ */
+typedef struct {
+    /* Protocol definition */
+    const ucp_proto_t        *proto;
+
+    /* Protocol private configuration space */
+    const void               *priv;
+
+    /* Endpoint configuration index this protocol was selected on */
+    ucp_worker_cfg_index_t   ep_cfg_index;
+
+    /* Remote key configuration index this protocol was selected on (can be
+     * UCP_WORKER_CFG_INDEX_NULL)
+     */
+    ucp_worker_cfg_index_t   rkey_cfg_index;
+
+    /* Copy of protocol selection parameters, used to re-select protocol for
+     * existing in-progress request
+     */
+    ucp_proto_select_param_t select_param;
+} ucp_proto_config_t;
+
+
 /**
  * Entry which defines which protocol should be used for a message size range.
  */
@@ -37,12 +68,14 @@ typedef struct {
  * Protocol selection per a particular buffer type and operation
  */
 typedef struct {
-    const ucp_proto_threshold_elem_t *thresholds; /* Array of which protocol to use
-                                                     for different message sizes */
-    const ucp_proto_perf_range_t     *perf_ranges;/* Estimated performance for
-                                                     the selected protocols */
-    void                             *priv_buf;   /* Private configuration area
-                                                     for the selected protocols */
+    /* Array of which protocol to use for different message sizes */
+    const ucp_proto_threshold_elem_t *thresholds;
+
+    /* Estimated performance for the selected protocols */
+    const ucp_proto_select_range_t   *perf_ranges;
+
+    /* Private configuration area for the selected protocols */
+    void                             *priv_buf;
 } ucp_proto_select_elem_t;
 
 
@@ -122,5 +155,11 @@ ucp_proto_select_short_init(ucp_worker_h worker, ucp_proto_select_t *proto_selec
                             ucp_operation_id_t op_id, uint32_t op_attr_mask,
                             unsigned proto_flags,
                             ucp_proto_select_short_t *proto_short);
+
+
+void ucp_proto_select_get_valid_range(
+        const ucp_proto_threshold_elem_t *thresholds, size_t *min_length_p,
+        size_t *max_length_p);
+
 
 #endif

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -95,11 +95,8 @@ ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params);
 
 
 ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
-                                     ucp_proto_rndv_ack_priv_t *apriv);
-
-
-ucs_linear_func_t
-ucp_proto_rndv_ack_time(const ucp_proto_init_params_t *init_params);
+                                     ucp_proto_rndv_ack_priv_t *apriv,
+                                     ucs_linear_func_t *ack_perf);
 
 
 void ucp_proto_rndv_ack_config_str(size_t min_length, size_t max_length,

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -147,7 +147,8 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *params)
         return UCS_ERR_UNSUPPORTED;
     }
 
-    status = ucp_proto_rndv_ack_init(params, params->priv);
+    status = ucp_proto_rndv_ack_init(params, params->priv,
+                                     params->caps->ranges[0].perf);
     if (status != UCS_OK) {
         return status;
     }
@@ -159,7 +160,7 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *params)
     params->caps->min_length           = 0;
     params->caps->num_ranges           = 1;
     params->caps->ranges[0].max_length = 0;
-    params->caps->ranges[0].perf       = ucp_proto_rndv_ack_time(params);
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## Why
Add performance calculation infra for rndv pipeline protocol. Each protocol should estimate its own "pipelined" performance, so we can estimate the overall performance of sending sub-protocols such as rndv-put-frag or rndv-get-frag in a pipelined fashion.