### PR TITLE
APPS/IO-DEMO: Cancel connection establishment if disconnecting

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -110,8 +111,6 @@ public:
     static const std::string sockaddr_str(const struct sockaddr* saddr,
                                           size_t addrlen);
 
-    void destroy_connections();
-
     static double get_time();
 
     static void *malloc(size_t size, const char *name);
@@ -138,6 +137,12 @@ protected:
     // Called when new server connection is accepted
     virtual void dispatch_connection_accepted(UcxConnection* conn);
 
+    void destroy_connections();
+
+    void wait_disconnected_connections();
+
+    void destroy_listener();
+
 private:
     typedef enum {
         WAIT_STATUS_OK,
@@ -149,6 +154,10 @@ private:
         ucp_conn_request_h conn_request;
         struct timeval     arrival_time;
     } conn_req_t;
+
+    typedef std::map<uint64_t, UcxConnection*> conn_map_t;
+
+    typedef std::vector<std::pair<double, UcxConnection*> > timeout_conn_t;
 
     friend class UcxConnection;
 
@@ -201,20 +210,24 @@ private:
 
     void remove_connection(UcxConnection *conn);
 
+    timeout_conn_t::iterator find_connection_inprogress(UcxConnection *conn);
+
     void remove_connection_inprogress(UcxConnection *conn);
 
     void move_connection_to_disconnecting(UcxConnection *conn);
 
-    void handle_connection_error(UcxConnection *conn);
+    bool is_in_disconnecting_list(UcxConnection *conn)
+    {
+        return std::find(_disconnecting_conns.begin(),
+                         _disconnecting_conns.end(), conn) !=
+                _disconnecting_conns.end();
+    }
 
-    void destroy_listener();
+    void handle_connection_error(UcxConnection *conn);
 
     void destroy_worker();
 
     void set_am_handler(ucp_am_recv_callback_t cb, void *arg);
-
-    typedef std::map<uint64_t, UcxConnection*>              conn_map_t;
-    typedef std::vector<std::pair<double, UcxConnection*> > timeout_conn_t;
 
     ucp_context_h               _context;
     ucp_worker_h                _worker;


### PR DESCRIPTION
## What

1. Cancel connection establishment if disconnecting.
2. Destroy all connections in UCxContext dtor to remove them from lists.

## Why ?

1. To fix the following assertion:
```
[1628505026.738032] [DEMO] disconnecting [UCX-connection 0x254b1c0: #147 1.1.28.5:20011] read 0/0 write 0/0 due to "End of the Client run"
io_demo: ucx_wrapper.cc:784: void UcxConnection::disconnect(UcxCallback*): Assertion `_establish_cb == __null' failed.
```
2. To fix the following assertion:
```
[1628619045.774204] [UCX] removed [UCX-connection 0x20f7610: #208 1.1.28.3:20011] from connection map
io_demo: ucx_wrapper.cc:786: void UcxConnection::disconnect(UcxCallback*): Assertion `_disconnect_cb == __null' failed.
```

## How ?

1. If connection isn't established yet, call `established(UCS_ERR_CANCLED)` to free memory stored in `_establish_cb`.
2. Remove unneeded destroying of all connections in `DemoClient::run()`, since they can be correctly destroyed in `UcxContext::~UcxContext`.