### PR TITLE
UCT/IB/RC: Print EP info using VFS instrumentation

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -130,6 +130,8 @@ ucs_status_t uct_rc_mlx5_ep_fence(uct_ep_h tl_ep, unsigned flags);
 
 void uct_rc_mlx5_ep_post_check(uct_ep_h tl_ep);
 
+void uct_rc_mlx5_ep_vfs_populate(uct_rc_ep_t *rc_ep);
+
 ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 
 ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -15,6 +15,8 @@
 
 #include <uct/ib/mlx5/ib_mlx5_log.h>
 #include <uct/ib/mlx5/exp/ib_exp.h>
+#include <ucs/vfs/base/vfs_cb.h>
+#include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/sys/compiler.h>
 #include <arpa/inet.h> /* For htonl */
@@ -546,6 +548,17 @@ void uct_rc_mlx5_ep_post_check(uct_ep_h tl_ep)
                                  0, 0,
                                  NULL, NULL, 0, 0,
                                  INT_MAX);
+}
+
+void uct_rc_mlx5_ep_vfs_populate(uct_rc_ep_t *rc_ep)
+{
+    uct_rc_iface_t *rc_iface = ucs_derived_of(rc_ep->super.super.iface,
+                                              uct_rc_iface_t);
+    uct_rc_mlx5_ep_t *ep     = ucs_derived_of(rc_ep, uct_rc_mlx5_ep_t);
+
+    ucs_vfs_obj_add_dir(rc_iface, ep, "ep/%p", ep);
+    uct_ib_mlx5_txwq_vfs_populate(&ep->tx.wq, ep);
+    uct_rc_txqp_vfs_populate(&ep->super.txqp, ep);
 }
 
 ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -866,19 +866,20 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
     .super = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
-            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh
         },
         .create_cq      = uct_ib_mlx5_create_cq,
         .arm_cq         = uct_rc_mlx5_iface_common_arm_cq,
         .event_cq       = uct_rc_mlx5_iface_common_event_cq,
         .handle_failure = uct_rc_mlx5_iface_handle_failure,
     },
-    .init_rx       = uct_rc_mlx5_iface_init_rx,
-    .cleanup_rx    = uct_rc_mlx5_iface_cleanup_rx,
-    .fc_ctrl       = uct_rc_mlx5_ep_fc_ctrl,
-    .fc_handler    = uct_rc_iface_fc_handler,
-    .cleanup_qp    = uct_rc_mlx5_iface_qp_cleanup,
-    .ep_post_check = uct_rc_mlx5_ep_post_check,
+    .init_rx         = uct_rc_mlx5_iface_init_rx,
+    .cleanup_rx      = uct_rc_mlx5_iface_cleanup_rx,
+    .fc_ctrl         = uct_rc_mlx5_ep_fc_ctrl,
+    .fc_handler      = uct_rc_iface_fc_handler,
+    .cleanup_qp      = uct_rc_mlx5_iface_qp_cleanup,
+    .ep_post_check   = uct_rc_mlx5_ep_post_check,
+    .ep_vfs_populate = uct_rc_mlx5_ep_vfs_populate
 };
 
 static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -948,3 +948,19 @@ void uct_rc_iface_vfs_populate(uct_rc_iface_t *iface)
                             &iface->tx.reads_completed, UCS_VFS_TYPE_SSIZET,
                             "reads_completed");
 }
+
+void uct_rc_iface_vfs_refresh(uct_iface_h iface)
+{
+    uct_rc_iface_t *rc_iface         = ucs_derived_of(iface, uct_rc_iface_t);
+    uct_rc_iface_ops_t *rc_iface_ops = ucs_derived_of(rc_iface->super.ops,
+                                                      uct_rc_iface_ops_t);
+    uct_rc_ep_t *ep;
+
+    /* Add iface resources */
+    uct_rc_iface_vfs_populate(rc_iface);
+
+    /* Add objects for EPs */
+    ucs_list_for_each(ep, &rc_iface->ep_list, list) {
+        rc_iface_ops->ep_vfs_populate(ep);
+    }
+}

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -215,14 +215,18 @@ typedef void (*uct_rc_iface_qp_cleanup_func_t)(
 typedef void (*uct_rc_iface_ep_post_check_func_t)(uct_ep_h tl_ep);
 
 
+typedef void (*uct_rc_iface_ep_vfs_populate_func_t)(uct_rc_ep_t *rc_ep);
+
+
 typedef struct uct_rc_iface_ops {
-    uct_ib_iface_ops_t                super;
-    uct_rc_iface_init_rx_func_t       init_rx;
-    uct_rc_iface_cleanup_rx_func_t    cleanup_rx;
-    uct_rc_iface_fc_ctrl_func_t       fc_ctrl;
-    uct_rc_iface_fc_handler_func_t    fc_handler;
-    uct_rc_iface_qp_cleanup_func_t    cleanup_qp;
-    uct_rc_iface_ep_post_check_func_t ep_post_check;
+    uct_ib_iface_ops_t                  super;
+    uct_rc_iface_init_rx_func_t         init_rx;
+    uct_rc_iface_cleanup_rx_func_t      cleanup_rx;
+    uct_rc_iface_fc_ctrl_func_t         fc_ctrl;
+    uct_rc_iface_fc_handler_func_t      fc_handler;
+    uct_rc_iface_qp_cleanup_func_t      cleanup_qp;
+    uct_rc_iface_ep_post_check_func_t   ep_post_check;
+    uct_rc_iface_ep_vfs_populate_func_t ep_vfs_populate;
 } uct_rc_iface_ops_t;
 
 
@@ -423,6 +427,8 @@ ucs_status_t uct_rc_iface_init_rx(uct_rc_iface_t *iface,
 ucs_status_t uct_rc_iface_fence(uct_iface_h tl_iface, unsigned flags);
 
 void uct_rc_iface_vfs_populate(uct_rc_iface_t *iface);
+
+void uct_rc_iface_vfs_refresh(uct_iface_h iface);
 
 ucs_arbiter_cb_result_t
 uct_rc_ep_process_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -160,6 +160,8 @@ ucs_status_t uct_rc_verbs_ep_fence(uct_ep_h tl_ep, unsigned flags);
 
 void uct_rc_verbs_ep_post_check(uct_ep_h tl_ep);
 
+void uct_rc_verbs_ep_vfs_populate(uct_rc_ep_t *rc_ep);
+
 ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,
                                      uct_rc_pending_req_t *req);
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -12,6 +12,8 @@
 #include "rc_verbs.h"
 #include "rc_verbs_impl.h"
 
+#include <ucs/vfs/base/vfs_cb.h>
+#include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/arch/bitops.h>
 #include <uct/ib/base/ib_log.h>
 
@@ -476,6 +478,18 @@ void uct_rc_verbs_ep_post_check(uct_ep_h tl_ep)
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
 
     uct_rc_verbs_ep_post_flush(ep, 0);
+}
+
+void uct_rc_verbs_ep_vfs_populate(uct_rc_ep_t *rc_ep)
+{
+    uct_rc_iface_t *rc_iface = ucs_derived_of(rc_ep->super.super.iface,
+                                              uct_rc_iface_t);
+    uct_rc_verbs_ep_t *ep    = ucs_derived_of(rc_ep, uct_rc_verbs_ep_t);
+
+    ucs_vfs_obj_add_dir(rc_iface, ep, "ep/%p", ep);
+    ucs_vfs_obj_add_ro_file(ep, ucs_vfs_show_primitive, &ep->qp->qp_num,
+                            UCS_VFS_TYPE_U32_HEX, "qp_num");
+    uct_rc_txqp_vfs_populate(&ep->super.txqp, ep);
 }
 
 ucs_status_t uct_rc_verbs_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -498,19 +498,20 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .super = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
-            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .arm_cq         = uct_ib_iface_arm_cq,
         .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
         .handle_failure = uct_rc_verbs_handle_failure,
     },
-    .init_rx       = uct_rc_iface_verbs_init_rx,
-    .cleanup_rx    = uct_rc_iface_verbs_cleanup_rx,
-    .fc_ctrl       = uct_rc_verbs_ep_fc_ctrl,
-    .fc_handler    = uct_rc_iface_fc_handler,
-    .cleanup_qp    = uct_rc_verbs_iface_qp_cleanup,
-    .ep_post_check = uct_rc_verbs_ep_post_check,
+    .init_rx         = uct_rc_iface_verbs_init_rx,
+    .cleanup_rx      = uct_rc_iface_verbs_cleanup_rx,
+    .fc_ctrl         = uct_rc_verbs_ep_fc_ctrl,
+    .fc_handler      = uct_rc_iface_fc_handler,
+    .cleanup_qp      = uct_rc_verbs_iface_qp_cleanup,
+    .ep_post_check   = uct_rc_verbs_ep_post_check,
+    .ep_vfs_populate = uct_rc_verbs_ep_vfs_populate
 };
 
 static ucs_status_t


### PR DESCRIPTION
## What

Print EP info using VFS instrumentation.

## Why ?

It is needed for better debugging and will be used by #7205.
e.g.:
```
tree /tmp/ucx/*/uct/worker/*/iface/*/ep/*/
...
/tmp/ucx/64267/uct/worker/0x109d7e0/iface/0x114e080/ep/0x11f8d20/
├── available
├── bb_max
├── hw_ci
├── prev_sw_pi
├── qend
├── qp_num
├── qstart
├── sig_pi
├── sw_pi
└── unsignaled
/tmp/ucx/64267/uct/worker/0x109d7e0/iface/0x114e080/ep/0x123a2d0/
├── available
├── bb_max
├── hw_ci
├── prev_sw_pi
├── qend
├── qp_num
├── qstart
├── sig_pi
├── sw_pi
└── unsignaled
...
```

## How ?

Introduced `uct_rc_mlx5_iface_vfs_refresh()` and `uct_rc_verbs_iface_vfs_refresh()` to go over all EPs on a specific IFACE and print TXQP and TXWQ (mlx5) or QP number only (verbs) information.