### PR TITLE
UCP/UCS: Print UCP version and reduce log level for bond init error

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1492,17 +1492,18 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
     ucp_config_t *dfl_config = NULL;
     ucp_context_t *context;
     ucs_status_t status;
-    ucs_debug_address_info_t addr_info;
 
     ucp_get_version(&major_version, &minor_version, &release_number);
 
     if ((api_major_version != major_version) ||
-        ((api_major_version == major_version) && (api_minor_version > minor_version))) {
-        status = ucs_debug_lookup_address(ucp_init_version, &addr_info);
-        ucs_warn("UCP version is incompatible, required: %d.%d, actual: %d.%d (release %d %s)",
-                  api_major_version, api_minor_version,
-                  major_version, minor_version, release_number,
-                  status == UCS_OK ? addr_info.file.path : "");
+        ((api_major_version == major_version) &&
+         (api_minor_version > minor_version))) {
+        ucs_warn("UCP version is incompatible, required: %d.%d, actual: %d.%d"
+                 " (release %d)", api_major_version, api_minor_version,
+                  major_version, minor_version, release_number);
+    } else {
+        ucs_info("UCP version is %d.%d (release %d)",
+                 major_version, minor_version, release_number);
     }
 
     if (config == NULL) {

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -125,7 +125,7 @@ unsigned ucs_netif_bond_ad_num_ports(const char *bond_name)
                                   UCS_NETIF_BOND_AD_NUM_PORTS_FMT, bond_name);
     if ((status != UCS_OK) || (ad_num_ports <= 0) ||
         (ad_num_ports > UINT_MAX)) {
-        ucs_diag("failed to read from " UCS_NETIF_BOND_AD_NUM_PORTS_FMT ": %m, "
+        ucs_trace("failed to read from " UCS_NETIF_BOND_AD_NUM_PORTS_FMT ": %m, "
                  "assuming 802.3ad bonding is disabled", bond_name);
         return 1;
     }


### PR DESCRIPTION
## What
- Print UCP version with log level info.
- Reduce log level for `failed to read ... assuming 802.3ad bonding is disabled` to avoid logs flooding.

## Why
Better debug experience