### PR TITLE
TCP/TEST: Fix simultaneous ep close with ucp_hello_world

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -504,19 +504,26 @@ run_ucp_hello() {
 
 	export UCX_KEEPALIVE_INTERVAL=1s
 	export UCX_KEEPALIVE_NUM_EPS=10
+	export UCX_LOG_LEVEL=info
 
-	for test_mode in -w -f -b -erecv -esend -ekeepalive
+	for tls in all tcp,cuda
 	do
-		for mem_type in $mem_types_list
+		export UCX_TLS=${tls}
+		for test_mode in -w -f -b -erecv -esend -ekeepalive
 		do
-			echo "==== Running UCP hello world with mode ${test_mode} and \"${mem_type}\" memory type ===="
-			run_hello ucp ${test_mode} -m ${mem_type}
+			for mem_type in $mem_types_list
+			do
+				echo "==== Running UCP hello world with mode ${test_mode} and \"${mem_type}\" memory type ===="
+				run_hello ucp ${test_mode} -m ${mem_type}
+			done
 		done
 	done
 	rm -f ./ucp_hello_world
 
 	unset UCX_KEEPALIVE_INTERVAL
 	unset UCX_KEEPALIVE_NUM_EPS
+	unset UCX_LOG_LEVEL
+	unset UCX_TLS
 }
 
 #

--- a/examples/ucp_hello_world.c
+++ b/examples/ucp_hello_world.c
@@ -85,6 +85,7 @@ static const ucp_tag_t tag      = 0x1337a880u;
 static const ucp_tag_t tag_mask = UINT64_MAX;
 static const char *addr_msg_str = "UCX address message";
 static const char *data_msg_str = "UCX data message";
+static int print_config         = 0;
 static ucp_address_t *local_addr;
 static ucp_address_t *peer_addr;
 
@@ -292,7 +293,7 @@ static int run_ucx_client(ucp_worker_h ucp_worker)
             CHKERR_JUMP(status != UCS_OK, "test_poll_wait\n", err_ep);
         }
     }
-    
+
     if (err_handling_opt.failure_mode == FAILURE_MODE_KEEPALIVE) {
         fprintf(stderr, "Emulating unexpected failure after receive completion "
                         "on client side, server should detect error by "
@@ -505,6 +506,11 @@ static int run_test(const char *client_target_name, ucp_worker_h ucp_worker)
     }
 }
 
+static void progress_worker(void *arg)
+{
+    ucp_worker_progress((ucp_worker_h)arg);
+}
+
 int main(int argc, char **argv)
 {
     /* UCP temporary vars */
@@ -546,7 +552,9 @@ int main(int argc, char **argv)
 
     status = ucp_init(&ucp_params, config, &ucp_context);
 
-    ucp_config_print(config, stdout, NULL, UCS_CONFIG_PRINT_CONFIG);
+    if (print_config) {
+        ucp_config_print(config, stdout, NULL, UCS_CONFIG_PRINT_CONFIG);
+    }
 
     ucp_config_release(config);
     CHKERR_JUMP(status != UCS_OK, "ucp_init\n", err);
@@ -597,9 +605,9 @@ int main(int argc, char **argv)
 
     ret = run_test(client_target_name, ucp_worker);
 
-    if (!ret && (err_handling_opt.failure_mode != FAILURE_MODE_NONE)) {
+    if (!ret && (err_handling_opt.failure_mode == FAILURE_MODE_NONE)) {
         /* Make sure remote is disconnected before destroying local worker */
-        ret = barrier(oob_sock);
+        ret = barrier(oob_sock, progress_worker, ucp_worker);
     }
     close(oob_sock);
 
@@ -641,6 +649,7 @@ static void print_usage()
                                 "before receive completed\n");
     fprintf(stderr, "            keepalive - keepalive failure on client side "
                                 "after communication completed\n");
+    fprintf(stderr, "  -c      Print UCP configuration\n");
     print_common_help();
     fprintf(stderr, "\n");
 }
@@ -652,7 +661,7 @@ ucs_status_t parse_cmd(int argc, char * const argv[], char **server_name)
     err_handling_opt.ucp_err_mode = UCP_ERR_HANDLING_MODE_NONE;
     err_handling_opt.failure_mode = FAILURE_MODE_NONE;
 
-    while ((c = getopt(argc, argv, "wfbe:n:p:s:m:h")) != -1) {
+    while ((c = getopt(argc, argv, "wfbe:n:p:s:m:ch")) != -1) {
         switch (c) {
         case 'w':
             ucp_test_mode = TEST_MODE_WAIT;
@@ -698,6 +707,9 @@ ucs_status_t parse_cmd(int argc, char * const argv[], char **server_name)
             if (test_mem_type == UCS_MEMORY_TYPE_LAST) {
                 return UCS_ERR_UNSUPPORTED;
             }
+            break;
+        case 'c':
+            print_config = 1;
             break;
         case 'h':
         default:

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1077,13 +1077,14 @@ void ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
     ucp_stream_ep_cleanup(ucp_ep);
 
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
-        if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
-            ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
-            /* Promote close operation to CANCEL in case of transport error,
+        if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
+            if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
+                /* Promote close operation to CANCEL in case of transport error,
              * since the disconnect event may never arrive. */
-            close_req                        = ep_ext_control->close_req.req;
-            close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
-            ucp_ep_local_disconnect_progress(close_req);
+                close_req = ep_ext_control->close_req.req;
+                close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
+                ucp_ep_local_disconnect_progress(close_req);
+            }
         } else if (ep_ext_control->err_cb == NULL) {
             /* Do not print error if connection reset by remote peer since it
              * can be part of user level close protocol */
@@ -1388,7 +1389,8 @@ void ucp_ep_destroy(ucp_ep_h ep)
             ucp_worker_progress(worker);
             status = ucp_request_check_status(request);
         } while (status == UCS_INPROGRESS);
-
+        ucs_debug("ep_close request %p completed with status %s", request,
+                  ucs_status_string(status));
         ucp_request_release(request);
     }
 
@@ -3132,7 +3134,7 @@ static ucs_status_t ucp_ep_query_sockaddr(ucp_ep_h ep, ucp_ep_attr_t *attr)
             return status;
         }
     }
-    
+
     if (uct_cm_ep_attr.field_mask & UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR) {
         status = ucs_sockaddr_copy((struct sockaddr*)&attr->remote_sockaddr,
                                    (struct sockaddr*)&uct_cm_ep_attr.remote_address);


### PR DESCRIPTION
## Why
As a result of #7140, ucp_hello_world fails in docker when it uses TCP transport, like this:
```
2021-08-10T19:42:56.9329573Z + taskset -c 0 ./examples/ucp_hello_world -f -m host -p 16001
2021-08-10T19:42:56.9651931Z INFO: UCP_HELLO_WORLD mode = 2 server = (null) port = 16001, pid = 20460
2021-08-10T19:43:11.9295628Z + '[' 0 -eq 1 ']'
2021-08-10T19:43:11.9304753Z + client_pid=20476
2021-08-10T19:43:11.9305794Z + wait 20476
2021-08-10T19:43:11.9307301Z + taskset -c 1 ./examples/ucp_hello_world -f -m host -n 0231793f6e3f -p 16001
...
2021-08-10T19:43:12.0205215Z [0231793f6e3f:20476:0:20476]      ucp_ep.c:2822 Assertion `ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_NONE' failed
2021-08-10T19:43:12.0206896Z ==== backtrace (tid:  20476) ====
2021-08-10T19:43:12.0208701Z  0  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_handle_error+0xfc) [0x7f0a5481f44c]
2021-08-10T19:43:12.0210714Z  1  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_fatal_error_message+0x58) [0x7f0a5481c228]
2021-08-10T19:43:12.0212782Z  2  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_fatal_error_format+0xd1) [0x7f0a5481c3b1]
2021-08-10T19:43:12.0214903Z  3  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(ucp_ep_invoke_err_cb+0x1cb) [0x7f0a5450b36b]
2021-08-10T19:43:12.0216926Z  4  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(ucp_ep_set_failed+0x1f2) [0x7f0a54510102]
2021-08-10T19:43:12.0218867Z  5  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(+0x4ec2a) [0x7f0a54525c2a]
2021-08-10T19:43:12.0221995Z  6  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(uct_tcp_ep_set_failed+0x61) [0x7f0a542b3cc1]
2021-08-10T19:43:12.0224157Z  7  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(+0x256bf) [0x7f0a542b66bf]
2021-08-10T19:43:12.0225985Z  8  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(+0x29e84) [0x7f0a542bae84]
2021-08-10T19:43:12.0227836Z  9  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_event_set_wait+0xf1) [0x7f0a5482ccf1]
2021-08-10T19:43:12.0229713Z 10  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(uct_tcp_iface_progress+0x74) [0x7f0a542bad94]
2021-08-10T19:43:12.0231969Z 11  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(ucp_worker_progress+0x6a) [0x7f0a54523bca]
2021-08-10T19:43:12.0233840Z 12  /__w/1/s/build-test/examples/.libs/lt-ucp_hello_world() [0x401ed2]
2021-08-10T19:43:12.0235177Z 13  /lib64/libc.so.6(__libc_start_main+0xf5) [0x7f0a53190555]
2021-08-10T19:43:12.0236900Z 14  /__w/1/s/build-test/examples/.libs/lt-ucp_hello_world() [0x402746]
2021-08-10T19:43:12.0238169Z =================================
2021-08-10T19:43:12.0239342Z [0231793f6e3f:20476:0:20476] Process frozen..
```
(https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/22781/logs/389)

## How
- UCP: Don't try to invoke error callback if endpoint closed but not flushed yet. If user started to close endpoint, callbacks should not be called on this endpoint anymore. This change avoids the assert fail above.
- TCP: Flush outstanding put operations in case of error. Without this change, endpoint close (flush stage) does not finish.
- Test: run ucp_hello_world with TCP