### PR TITLE
UCS/LOG: Don't call fsync for stdout/stderr

### DIFF
--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -105,7 +105,10 @@ void ucs_log_flush()
 {
     if (ucs_log_file != NULL) {
         fflush(ucs_log_file);
-        fsync(fileno(ucs_log_file));
+
+        if (ucs_log_file_close) { /* non-stdout/stderr */
+            fsync(fileno(ucs_log_file));
+        }
     }
 }
 


### PR DESCRIPTION
## What

Don't call fsync for stdout/stderr.

## Why ?

To avoid errors shown from `strace`
```
$ strace ucx_info -eptw -u tra
...
rt_sigaction(SIGSEGV, {SIG_DFL, [], SA_RESTORER, 0x7fdc7fb315d0}, {0x7fdc804d492b, [], SA_RESTORER|SA_STACK|SA_SIGIN│  PID TTY          TIME CMD
FO, 0x7fdc7fb315d0}, 8) = 0                                                                                         │47146 pts/1    00:00:00 pdsh
rt_sigaction(SIGILL, {SIG_DFL, [], SA_RESTORER, 0x7fdc7fb315d0}, {0x7fdc804d492b, [], SA_RESTORER|SA_STACK|SA_SIGINF│  PID TTY          TIME CMD
O, 0x7fdc7fb315d0}, 8) = 0                                                                                          │47146 pts/1    00:00:00 pdsh
rt_sigaction(SIGBUS, {SIG_DFL, [], SA_RESTORER, 0x7fdc7fb315d0}, {0x7fdc804d492b, [], SA_RESTORER|SA_STACK|SA_SIGINF│  PID TTY          TIME CMD
O, 0x7fdc7fb315d0}, 8) = 0                                                                                          │47146 pts/1    00:00:00 pdsh
fsync(1)                                = -1 EINVAL (Invalid argument)                                              │  PID TTY          TIME CMD
exit_group(0)                           = ?                                                                         │47146 pts/1    00:00:00 pdsh
...
+++ exited with 0 +++
```

## How ?

Check `ucs_log_file_close` global variable which is set to `0` if it is stdout/stderr. If the value is `1`, then invoke `fsync()`