### PR TITLE
UCP/RNDV: Option to limit GPUDirectRDMA size in rndv

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -170,6 +170,11 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.reg_whole_alloc_bitmap),
    UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
 
+  {"RNDV_MEMTYPE_DIRECT_SIZE", "inf",
+   "Maximum size for mem type direct in rendezvous protocol\n",
+   ucs_offsetof(ucp_config_t, ctx.rndv_memtype_direct_size),
+   UCS_CONFIG_TYPE_MEMUNITS},
+
   {"WARN_INVALID_CONFIG", "y",
    "Issue a warning in case of invalid device and/or transport configuration.",
    ucs_offsetof(ucp_config_t, warn_invalid_config), UCS_CONFIG_TYPE_BOOL},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -121,6 +121,8 @@ typedef struct ucp_context_config {
     unsigned                               reg_whole_alloc_bitmap;
     /** Always use flush operation in rendezvous put */
     int                                    rndv_put_force_flush;
+    /** Maximum size of mem type direct rndv*/
+    size_t                                 rndv_memtype_direct_size;
     /** UCP sockaddr private data format version */
     ucp_object_version_t                   sa_client_min_hdr_version;
     /** Remote keys with that many remote MDs or less would be allocated from a


### PR DESCRIPTION
## What
Option to avoid GPUDirectRDMA on large messages rndv

## How ?
or mem type, Ignore mem type GDR lane while initializing the lanes for zcopy if the length of the zcopy is greater than the threshold,
