### PR TITLE
UCP/PROTO: Enable test_tag_xfer on new protocol and fix related issues

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -61,6 +61,7 @@ noinst_HEADERS = \
 	rndv/proto_rndv.inl \
 	rndv/rndv.h \
 	tag/eager.h \
+	tag/proto_eager.inl \
 	tag/tag_rndv.h \
 	tag/tag_match.h \
 	tag/tag_match.inl \

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -46,7 +46,7 @@ ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
     ucp_ep_h ep = req->send.ep;
     ucs_status_t status;
 
-    ucp_trace_req(req, "ucp_proto_zcopy_request_init for %s",
+    ucp_trace_req(req, "ucp_proto_request_zcopy_init for %s",
                   req->send.proto_config->proto->name);
 
     ucp_proto_completion_init(&req->send.state.uct_comp, comp_func);
@@ -153,7 +153,8 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
     req->send.ep = ep;
 
     ucp_datatype_iter_init(worker->context, (void*)buffer, count, datatype,
-                           contig_length, &req->send.state.dt_iter, &sg_count);
+                           contig_length, 1, &req->send.state.dt_iter,
+                           &sg_count);
 
     ucp_proto_select_param_init(&sel_param, op_id, param->op_attr_mask,
                                 req->send.state.dt_iter.dt_class,

--- a/src/ucp/proto/proto_single.inl
+++ b/src/ucp/proto/proto_single.inl
@@ -44,22 +44,27 @@ ucp_proto_am_bcopy_single_send(ucp_request_t *req, ucp_am_id_t am_id,
     }
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_single_status_handle(ucp_request_t *req,
-                               ucp_proto_complete_cb_t complete_func,
-                               ucp_lane_index_t lane, ucs_status_t status)
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_single_status_handle(
+        ucp_request_t *req, int is_zcopy, ucp_proto_complete_cb_t complete_func,
+        ucp_lane_index_t lane, ucs_status_t status)
 {
     if (ucs_likely(status == UCS_OK)) {
-        if (complete_func != NULL) {
-            complete_func(req);
-        }
+        /* fast path is OK */
+    } else if (is_zcopy && (status == UCS_INPROGRESS)) {
+        ++req->send.state.uct_comp.count;
     } else if (status == UCS_ERR_NO_RESOURCE) {
         /* keep on pending queue */
         req->send.lane = lane;
         return UCS_ERR_NO_RESOURCE;
-    } else if (status != UCS_INPROGRESS) {
+    } else {
         ucp_proto_request_abort(req, status);
+        return UCS_OK;
     }
+
+    if (complete_func != NULL) {
+        return complete_func(req);
+    }
+
     return UCS_OK;
 }
 
@@ -74,13 +79,14 @@ ucp_proto_am_bcopy_single_progress(ucp_request_t *req, ucp_am_id_t am_id,
 
     status = ucp_proto_am_bcopy_single_send(req, am_id, lane, pack_func,
                                             pack_arg, max_packed_size);
-    return ucp_proto_single_status_handle(req, complete_func, lane, status);
+    return ucp_proto_single_status_handle(req, 0, complete_func, lane, status);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_zcopy_single_progress(ucp_request_t *req, unsigned uct_mem_flags,
                                 ucp_proto_send_single_cb_t send_func,
-                                const char *name)
+                                ucp_proto_complete_cb_t complete_func,
+                                uct_completion_callback_t uct_comp_cb)
 {
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
     ucp_datatype_iter_t next_iter;
@@ -92,9 +98,9 @@ ucp_proto_zcopy_single_progress(ucp_request_t *req, unsigned uct_mem_flags,
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
         md_map = (spriv->reg_md == UCP_NULL_RESOURCE) ? 0 : UCS_BIT(spriv->reg_md);
-        status = ucp_proto_request_zcopy_init(
-                req, md_map, ucp_proto_request_zcopy_completion, uct_mem_flags,
-                UCS_BIT(UCP_DATATYPE_CONTIG));
+        status = ucp_proto_request_zcopy_init(req, md_map, uct_comp_cb,
+                                              uct_mem_flags,
+                                              UCS_BIT(UCP_DATATYPE_CONTIG));
         if (status != UCS_OK) {
             ucp_proto_request_abort(req, status);
             return UCS_OK; /* remove from pending after request is completed */
@@ -107,12 +113,10 @@ ucp_proto_zcopy_single_progress(ucp_request_t *req, unsigned uct_mem_flags,
                                spriv->super.memh_index,
                                UCS_BIT(UCP_DATATYPE_CONTIG), &next_iter, &iov,
                                1);
-    status = send_func(req, spriv, &iov);
-    UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(req, name, iov.length, status);
 
-    return ucp_proto_single_status_handle(
-            req, ucp_proto_request_zcopy_complete_success, spriv->super.lane,
-            status);
+    status = send_func(req, spriv, &iov);
+    return ucp_proto_single_status_handle(req, 1, complete_func,
+                                          spriv->super.lane, status);
 }
 
 #endif

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -73,7 +73,9 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_am_bcopy_send_func(
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_rndv_am_bcopy_complete(ucp_request_t *req)
 {
-    ucp_proto_rndv_rkey_destroy(req);
+    if (req->send.rndv.rkey != NULL) {
+        ucp_proto_rndv_rkey_destroy(req);
+    }
     ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
                                 &req->send.state.dt_iter,
                                 UCS_BIT(UCP_DATATYPE_CONTIG));

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -8,7 +8,7 @@
 #  include "config.h"
 #endif
 
-#include "eager.h"
+#include "proto_eager.inl"
 
 #include <ucp/core/ucp_request.inl>
 #include <ucp/proto/proto_multi.inl>
@@ -199,18 +199,6 @@ ucp_proto_eager_sync_bcopy_multi_send_func(
             req, lpriv, next_iter, UCP_AM_ID_EAGER_SYNC_FIRST,
             ucp_eager_sync_bcopy_pack_first,
             sizeof(ucp_eager_sync_first_hdr_t));
-}
-
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_eager_sync_bcopy_send_completed(ucp_request_t *req)
-{
-    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UINT_MAX);
-
-    req->flags |= UCP_REQUEST_FLAG_SYNC_LOCAL_COMPLETED;
-    if (req->flags & UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED) {
-        ucp_request_complete_send(req, UCS_OK);
-    }
-    return UCS_OK;
 }
 
 void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -201,9 +201,10 @@ ucp_proto_eager_zcopy_single_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
-    return ucp_proto_zcopy_single_progress(req, UCT_MD_MEM_ACCESS_LOCAL_READ,
-                                           ucp_proto_eager_zcopy_send_func,
-                                           "am_zcopy_only");
+    return ucp_proto_zcopy_single_progress(
+            req, UCT_MD_MEM_ACCESS_LOCAL_READ, ucp_proto_eager_zcopy_send_func,
+            ucp_request_invoke_uct_completion_success,
+            ucp_proto_request_zcopy_completion);
 }
 
 static ucp_proto_t ucp_eager_zcopy_single_proto = {

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -690,14 +690,13 @@ const ucp_request_send_proto_t ucp_tag_offload_proto = {
 /* Eager sync */
 static ucs_status_t ucp_tag_offload_eager_sync_bcopy(uct_pending_req_t *self)
 {
-    ucp_request_t *req   = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_worker_t *worker = req->send.ep->worker;
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t status;
 
     status = ucp_do_tag_offload_bcopy(self,
                                       ucp_send_request_get_ep_remote_id(req));
     if (status == UCS_OK) {
-        ucp_tag_offload_sync_posted(worker, req);
+        ucp_tag_offload_sync_posted(req);
     }
 
     return ucp_am_bcopy_handle_status_from_pending(self, 0, 1, status);
@@ -705,15 +704,14 @@ static ucs_status_t ucp_tag_offload_eager_sync_bcopy(uct_pending_req_t *self)
 
 static ucs_status_t ucp_tag_offload_eager_sync_zcopy(uct_pending_req_t *self)
 {
-    ucp_request_t *req   = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_worker_t *worker = req->send.ep->worker;
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t status;
 
     status = ucp_do_tag_offload_zcopy(self,
                                       ucp_send_request_get_ep_remote_id(req),
                                       ucp_tag_eager_sync_zcopy_req_complete);
     if (status == UCS_OK) {
-        ucp_tag_offload_sync_posted(worker, req);
+        ucp_tag_offload_sync_posted(req);
     }
     return status;
 }

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -160,9 +160,10 @@ ucp_tag_offload_unexp(ucp_worker_iface_t *wiface, ucp_tag_t tag, size_t length)
     }
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_tag_offload_sync_posted(ucp_worker_t *worker, ucp_request_t *req)
+static UCS_F_ALWAYS_INLINE void ucp_tag_offload_sync_posted(ucp_request_t *req)
 {
+    ucp_worker_t *worker = req->send.ep->worker;
+
     req->send.tag_offload.ssend_tag = req->send.msg_proto.tag;
     ucs_queue_push(&worker->tm.offload.sync_reqs, &req->send.tag_offload.queue);
 }

--- a/src/ucp/tag/proto_eager.inl
+++ b/src/ucp/tag/proto_eager.inl
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Mellanox Technologies Ltd. 2021.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef PROTO_EAGER_INL_
+#define PROTO_EAGER_INL_
+
+#include "eager.h"
+
+#include <ucp/proto/proto_common.inl>
+
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_eager_sync_send_completed_common(ucp_request_t *req)
+{
+    req->flags |= UCP_REQUEST_FLAG_SYNC_LOCAL_COMPLETED;
+    if (req->flags & UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED) {
+        ucp_request_complete_send(req, UCS_OK);
+    }
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_eager_sync_bcopy_send_completed(ucp_request_t *req)
+{
+    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UCP_DT_MASK_ALL);
+    ucp_proto_eager_sync_send_completed_common(req);
+    return UCS_OK;
+}
+
+#endif

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -150,9 +150,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     /* process first fragment */
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
     msg_id = eagerf_hdr->msg_id;
-    status = ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
-    ucs_assert((status == UCS_OK) || (status == UCS_INPROGRESS) ||
-               (status == UCS_ERR_MESSAGE_TRUNCATED));
+    ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
 
     /* process additional fragments */
     ucp_tag_frag_list_process_queue(&worker->tm, req, msg_id

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -262,7 +262,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
             ucp_request_send_check_status(status, ret, goto out);
         }
     } else {
-        datatype = ucp_dt_make_contig(1);
+        datatype      = ucp_dt_make_contig(1);
+        contig_length = count;
     }
 
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -66,7 +66,7 @@ protected:
         m_ucph.reset();
     }
 
-    void init_dt_iter(size_t size)
+    void init_dt_iter(size_t size, bool is_pack)
     {
         m_dt_buffer.resize(size, 0);
         ucs::fill_random(m_dt_buffer);
@@ -84,8 +84,8 @@ protected:
 
         uint8_t sg_count;
         ucp_datatype_iter_init(m_ucph.get(), m_dt_desc.buf(), m_dt_desc.count(),
-                               m_dt_desc.dt(), m_dt_buffer.size(), &m_dt_iter,
-                               &sg_count);
+                               m_dt_desc.dt(), m_dt_buffer.size(), is_pack,
+                               &m_dt_iter, &sg_count);
         if (!UCP_DT_IS_GENERIC(GetParam())) {
             EXPECT_EQ(iovcnt, sg_count);
         }
@@ -108,7 +108,7 @@ protected:
 
     void test_pack(size_t size)
     {
-        init_dt_iter(size);
+        init_dt_iter(size, true);
 
         ucp_datatype_iter_t next_iter;
         do {
@@ -127,7 +127,7 @@ protected:
 
     void test_unpack(size_t size)
     {
-        init_dt_iter(size);
+        init_dt_iter(size, false);
 
         typedef std::vector< std::pair<size_t, size_t> > segment_vector_t;
         segment_vector_t segments;

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -554,6 +554,7 @@ public:
     void init() {
         ASSERT_LE(rndv_scheme(), (int)RNDV_SCHEME_GET_ZCOPY);
         UCS_STATIC_ASSERT(!(ENABLE_PROTO & UCS_MASK(RNDV_SCHEME_LAST)));
+        modify_config("RNDV_THRESH", "0");
         modify_config("RNDV_SCHEME", rndv_schemes[rndv_scheme()]);
         modify_config("RNDV_PUT_FORCE_FLUSH", force_flush() ? "y" : "n");
         test_ucp_tag_match::init();
@@ -593,7 +594,7 @@ const std::string test_ucp_tag_match_rndv::rndv_schemes[] = { "auto",
                                                               "put_zcopy",
                                                               "get_zcopy" };
 
-UCS_TEST_P(test_ucp_tag_match_rndv, length0, "RNDV_THRESH=0")
+UCS_TEST_P(test_ucp_tag_match_rndv, length0)
 {
     request *my_send_req = send_nb((void*)0xdeadbeef, 0, DATATYPE, 1);
     ASSERT_TRUE(!UCS_PTR_IS_ERR(my_send_req));
@@ -605,7 +606,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, length0, "RNDV_THRESH=0")
     wait_and_validate(my_send_req);
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, sync_send_unexp, "RNDV_THRESH=1048576") {
+UCS_TEST_P(test_ucp_tag_match_rndv, sync_send_unexp)
+{
     static const size_t size = 1148576;
     request             *my_send_req;
     ucp_tag_recv_info_t info;
@@ -640,7 +642,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, sync_send_unexp, "RNDV_THRESH=1048576") {
     request_free(my_send_req);
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, req_exp, "RNDV_THRESH=1048576") {
+UCS_TEST_P(test_ucp_tag_match_rndv, req_exp)
+{
     static const size_t size = 1148576;
     request *my_send_req, *my_recv_req;
 
@@ -674,7 +677,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, req_exp, "RNDV_THRESH=1048576") {
     request_free(my_recv_req);
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, rts_unexp, "RNDV_THRESH=1048576") {
+UCS_TEST_P(test_ucp_tag_match_rndv, rts_unexp)
+{
     static const size_t size = 1148576;
     request             *my_send_req;
     ucp_tag_recv_info_t info;
@@ -706,7 +710,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, rts_unexp, "RNDV_THRESH=1048576") {
     EXPECT_EQ(sendbuf, recvbuf);
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, truncated, "RNDV_THRESH=1048576") {
+UCS_TEST_P(test_ucp_tag_match_rndv, truncated)
+{
     static const size_t size = 1148576;
     request *my_send_req;
     ucp_tag_recv_info_t info;
@@ -734,7 +739,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, truncated, "RNDV_THRESH=1048576") {
     wait_and_validate(my_send_req);
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, post_larger_recv, "RNDV_THRESH=0") {
+UCS_TEST_P(test_ucp_tag_match_rndv, post_larger_recv)
+{
     /* small send size should probably be lower than minimum GET Zcopy
      * size supported by IB TLs */
     static const size_t small_send_size = 16;
@@ -845,7 +851,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
     }
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post, "RNDV_THRESH=0") {
+UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post)
+{
     const size_t sizes[] = { 8 * UCS_KBYTE, 128 * UCS_KBYTE, 512 * UCS_KBYTE,
                              8 * UCS_MBYTE, 128 * UCS_MBYTE, 512 * UCS_MBYTE };
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -26,8 +26,8 @@ public:
         VARIANT_ERR_HANDLING,
         VARIANT_RNDV_PUT_ZCOPY,
         VARIANT_RNDV_GET_ZCOPY,
-        VARIANT_RNDV_AUTO,
         VARIANT_SEND_NBR,
+        VARIANT_PROTO
     };
 
     test_ucp_tag_xfer() {
@@ -49,13 +49,19 @@ public:
             modify_config("RNDV_SCHEME", "put_zcopy");
         } else if (get_variant_value() == VARIANT_RNDV_GET_ZCOPY) {
             modify_config("RNDV_SCHEME", "get_zcopy");
-        } else if (get_variant_value() == VARIANT_RNDV_AUTO) {
-            modify_config("RNDV_SCHEME", "auto");
+        } else if (get_variant_value() == VARIANT_PROTO) {
+            modify_config("PROTO_ENABLE", "y");
         }
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
 
         test_ucp_tag::init();
+    }
+
+    virtual void cleanup()
+    {
+        EXPECT_EQ(ucp::dt_gen_start_count, ucp::dt_gen_finish_count);
+        test_ucp_tag::cleanup();
     }
 
     bool skip_on_ib_dc() {
@@ -77,9 +83,9 @@ public:
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_RNDV_GET_ZCOPY, "rndv_get_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
-                               VARIANT_RNDV_AUTO, "rndv_auto");
-        add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_SEND_NBR, "send_nbr");
+        add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO,
+                               "proto");
     }
 
     virtual ucp_ep_params_t get_ep_params() {


### PR DESCRIPTION
## Why
- Enable rndv on non-contig data
- Enable more tests for new protocols and fix related issues