### PR TITLE
APPS/IO-DEMO: Don't do IO operations on failed connection

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -1109,6 +1109,8 @@ bool UcxConnection::send_common(const void *buffer, size_t length, ucp_tag_t tag
         return false;
     }
 
+    assert(_ucx_status == UCS_OK);
+
     ucs_status_ptr_t ptr_status = ucp_tag_send_nb(_ep, buffer, length,
                                                   ucp_dt_make_contig(1), tag,
                                                   common_request_callback);


### PR DESCRIPTION
## What

Don't do IO operations on failed connection.

## Why ?

Doing IO operations on failed connections don't have any effect, it reports errors and can lead to "Have min:0 ..." since it is trying to send data on failed connection and don't reconnect on it and don't report performance.

## How ?

1. Move removing from `active_servers` list to `disconnect_server()` function instead of `DisconnectCallback`.
2. Add assertions to check that no IO operations done on failed connections.
3. Add `progress()` to the `DemoClient::run()` loop in order to progress failed connections - it is needed to progress disconnection and make them connected then (no performance degradations seen, the following operations and message sizes are checked: 4k read/write, 32k read/write, 64k read/write).