### PR TITLE
UCT/TCP: Add IPv6 address support

### DIFF
--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -49,6 +49,7 @@
 static long test_string_length = 16;
 static long iov_cnt            = 1;
 static uint16_t server_port    = DEFAULT_PORT;
+static sa_family_t ai_family   = AF_INET;
 static int num_iterations      = DEFAULT_NUM_ITERATIONS;
 
 
@@ -196,38 +197,53 @@ static void err_cb(void *arg, ucp_ep_h ep, ucs_status_t status)
 /**
  * Set an address for the server to listen on - INADDR_ANY on a well known port.
  */
-void set_listen_addr(const char *address_str, struct sockaddr_in *listen_addr)
+void set_sock_addr(const char *address_str, struct sockaddr_storage *saddr)
 {
-    /* The server will listen on INADDR_ANY */
-    memset(listen_addr, 0, sizeof(struct sockaddr_in));
-    listen_addr->sin_family      = AF_INET;
-    listen_addr->sin_addr.s_addr = (address_str) ? inet_addr(address_str) : INADDR_ANY;
-    listen_addr->sin_port        = htons(server_port);
-}
+    struct sockaddr_in *sa_in;
+    struct sockaddr_in6 *sa_in6;
 
-/**
- * Set an address to connect to. A given IP address on a well known port.
- */
-void set_connect_addr(const char *address_str, struct sockaddr_in *connect_addr)
-{
-    memset(connect_addr, 0, sizeof(struct sockaddr_in));
-    connect_addr->sin_family      = AF_INET;
-    connect_addr->sin_addr.s_addr = inet_addr(address_str);
-    connect_addr->sin_port        = htons(server_port);
+    /* The server will listen on INADDR_ANY */
+    memset(saddr, 0, sizeof(*saddr));
+
+    switch (ai_family) {
+    case AF_INET:
+        sa_in = (struct sockaddr_in*)saddr;
+        if (address_str != NULL) {
+            inet_pton(AF_INET, address_str, &sa_in->sin_addr);
+        } else {
+            sa_in->sin_addr.s_addr = INADDR_ANY;
+        }
+        sa_in->sin_family = AF_INET;
+        sa_in->sin_port   = htons(server_port);
+        break;
+    case AF_INET6:
+        sa_in6 = (struct sockaddr_in6*)saddr;
+        if (address_str != NULL) {
+            inet_pton(AF_INET6, address_str, &sa_in6->sin6_addr);
+        } else {
+            sa_in6->sin6_addr = in6addr_any;
+        }
+        sa_in6->sin6_family = AF_INET6;
+        sa_in6->sin6_port   = htons(server_port);
+        break;
+    default:
+        fprintf(stderr, "Invalid address family");
+        break;
+    }
 }
 
 /**
  * Initialize the client side. Create an endpoint from the client side to be
  * connected to the remote server (to the given IP).
  */
-static ucs_status_t start_client(ucp_worker_h ucp_worker, const char *ip,
-                                 ucp_ep_h *client_ep)
+static ucs_status_t start_client(ucp_worker_h ucp_worker,
+                                 const char *address_str, ucp_ep_h *client_ep)
 {
     ucp_ep_params_t ep_params;
-    struct sockaddr_in connect_addr;
+    struct sockaddr_storage connect_addr;
     ucs_status_t status;
 
-    set_connect_addr(ip, &connect_addr);
+    set_sock_addr(address_str, &connect_addr);
 
     /*
      * Endpoint field mask bits:
@@ -256,7 +272,8 @@ static ucs_status_t start_client(ucp_worker_h ucp_worker, const char *ip,
 
     status = ucp_ep_create(ucp_worker, &ep_params, client_ep);
     if (status != UCS_OK) {
-        fprintf(stderr, "failed to connect to %s (%s)\n", ip, ucs_status_string(status));
+        fprintf(stderr, "failed to connect to %s (%s)\n", address_str,
+                ucs_status_string(status));
     }
 
     return status;
@@ -624,7 +641,7 @@ static int parse_cmd(int argc, char *const argv[], char **server_addr,
     int c = 0;
     int port;
 
-    while ((c = getopt(argc, argv, "a:l:p:c:i:s:v:m:h")) != -1) {
+    while ((c = getopt(argc, argv, "a:l:p:c:6i:s:v:m:h")) != -1) {
         switch (c) {
         case 'a':
             *server_addr = optarg;
@@ -652,6 +669,9 @@ static int parse_cmd(int argc, char *const argv[], char **server_addr,
                 return -1;
             }
             server_port = port;
+            break;
+        case '6':
+            ai_family = AF_INET6;
             break;
         case 'i':
             num_iterations = atoi(optarg);
@@ -843,18 +863,18 @@ static ucs_status_t server_create_ep(ucp_worker_h data_worker,
 /**
  * Initialize the server side. The server starts listening on the set address.
  */
-static ucs_status_t start_server(ucp_worker_h ucp_worker,
-                                 ucx_server_ctx_t *context,
-                                 ucp_listener_h *listener_p, const char *ip)
+static ucs_status_t
+start_server(ucp_worker_h ucp_worker, ucx_server_ctx_t *context,
+             ucp_listener_h *listener_p, const char *address_str)
 {
-    struct sockaddr_in listen_addr;
+    struct sockaddr_storage listen_addr;
     ucp_listener_params_t params;
     ucp_listener_attr_t attr;
     ucs_status_t status;
     char ip_str[IP_STRING_LEN];
     char port_str[PORT_STRING_LEN];
 
-    set_listen_addr(ip, &listen_addr);
+    set_sock_addr(address_str, &listen_addr);
 
     params.field_mask         = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
                                 UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;

--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -99,13 +99,22 @@ static void listener_accept_callback(ucp_ep_h ep, void *arg)
     *(ucp_ep_h*)arg = ep;
 }
 
-static void
-set_saddr(const char *addr_str, uint16_t port, struct sockaddr_in *saddr)
+static void set_saddr(const char *addr_str, uint16_t port, sa_family_t af,
+                      struct sockaddr_storage *saddr)
 {
     memset(saddr, 0, sizeof(*saddr));
-    saddr->sin_family      = AF_INET;
-    saddr->sin_addr.s_addr = inet_addr(addr_str);
-    saddr->sin_port        = htons(port);
+
+    if (addr_str != NULL) {
+        /* coverity[check_return] */
+        ucs_sock_ipstr_to_sockaddr(addr_str, saddr);
+        ucs_assert(saddr->ss_family == af);
+    } else {
+        saddr->ss_family = af;
+        /* coverity[check_return] */
+        ucs_sockaddr_set_inaddr_any((struct sockaddr*)saddr, af);
+    }
+
+    ucs_sockaddr_set_port((struct sockaddr*)saddr, port);
 }
 
 static ucs_status_t
@@ -144,17 +153,18 @@ ep_close(ucp_worker_h worker, ucp_worker_h peer_worker, ucp_ep_h ep,
     wait_completion(worker, peer_worker, status_ptr);
 }
 
-static ucs_status_t
-create_listener(ucp_worker_h worker, ucp_listener_h *listener_p,
-                uint16_t *listen_port_p, void *accept_cb_arg)
+static ucs_status_t create_listener(ucp_worker_h worker,
+                                    ucp_listener_h *listener_p,
+                                    uint16_t *listen_port_p,
+                                    sa_family_t ai_family, void *accept_cb_arg)
 {
     ucp_listener_h listener;
-    struct sockaddr_in listen_saddr;
+    struct sockaddr_storage listen_saddr;
     ucp_listener_params_t listen_params;
     ucp_listener_attr_t listen_attr;
     ucs_status_t status;
 
-    set_saddr("0.0.0.0", 0, &listen_saddr);
+    set_saddr(NULL, 0, ai_family, &listen_saddr);
 
     listen_params.field_mask         = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
                                        UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER;
@@ -196,7 +206,7 @@ out_destroy_listener:
 static ucs_status_t
 print_ucp_ep_info(ucp_worker_h worker, ucp_worker_h peer_worker,
                   const ucp_ep_params_t *base_ep_params, const char *ip_addr,
-                  process_placement_t proc_placement)
+                  sa_family_t af, process_placement_t proc_placement)
 {
     ucp_listener_h listener        = NULL;
     ucp_ep_h server_ep             = NULL;
@@ -204,21 +214,22 @@ print_ucp_ep_info(ucp_worker_h worker, ucp_worker_h peer_worker,
     ucp_worker_attr_t worker_attrs = {};
     ucs_status_t status;
     ucs_status_ptr_t status_ptr;
-    struct sockaddr_in connect_saddr;
+    struct sockaddr_storage connect_saddr;
     uint16_t listen_port;
     ucp_ep_h ep;
     char ep_name[64];
     ucp_request_param_t request_param;
 
     if (ip_addr != NULL) {
-        status = create_listener(peer_worker, &listener, &listen_port, &server_ep);
+        status = create_listener(peer_worker, &listener, &listen_port, af,
+                                 &server_ep);
         if (status != UCS_OK) {
             return status;
         }
 
         ucs_strncpy_zero(ep_name, "client", sizeof(ep_name));
 
-        set_saddr(ip_addr, listen_port, &connect_saddr);
+        set_saddr(ip_addr, listen_port, af, &connect_saddr);
 
         ep_params.field_mask      |= UCP_EP_PARAM_FIELD_FLAGS |
                                      UCP_EP_PARAM_FIELD_SOCK_ADDR;
@@ -289,7 +300,7 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
                size_t estimated_num_eps, size_t estimated_num_ppn,
                unsigned dev_type_bitmap, process_placement_t proc_placement,
-               const char *mem_size, const char *ip_addr)
+               const char *mem_size, const char *ip_addr, sa_family_t af)
 {
     ucp_worker_h peer_worker = NULL;
     ucp_config_t *config;
@@ -372,7 +383,7 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
         }
 
         status = print_ucp_ep_info(worker, peer_worker, base_ep_params, ip_addr,
-                                   proc_placement);
+                                   af, proc_placement);
         if (peer_worker != worker) {
             ucp_worker_destroy(peer_worker);
         }

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -57,9 +57,9 @@ static void usage() {
     printf("                    'self'  : same process (default)\n");
     printf("                    'intra' : same node\n");
     printf("                    'inter' : different node\n");
-    /* TODO: add IPv6 support */
-    printf("  -A <ipv4>       Local IPv4 device address to use for creating\n"
+    printf("  -A <ip>         Local IP device address to use for creating\n"
            "                  endpoint in client/server mode\n");
+    printf("  -6              IPv6 address specified with option -A\n");
     printf("  -T              Print system topology\n");
     printf("  -M              Print memory copy bandwidth\n");
     printf("  -h              Show this help message\n");
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
                                            UCP_FEATURE_AMO64 | UCP_FEATURE_RMA |
                                            UCP_FEATURE_TAG | UCP_FEATURE_AM;
     char *ip_addr = NULL;
+    sa_family_t ip_addr_family;
     ucs_config_print_flags_t print_flags;
     ucp_ep_params_t ucp_ep_params;
     unsigned dev_type_bitmap;
@@ -94,8 +95,9 @@ int main(int argc, char **argv)
     dev_type_bitmap          = UINT_MAX;
     proc_placement           = PROCESS_PLACEMENT_SELF;
     ucp_ep_params.field_mask = 0;
+    ip_addr_family           = AF_INET;
 
-    while ((c = getopt(argc, argv, "fahvcydbswpeCt:n:u:D:P:m:N:A:TM")) != -1) {
+    while ((c = getopt(argc, argv, "fahvc6ydbswpeCt:n:u:D:P:m:N:A:TM")) != -1) {
         switch (c) {
         case 'f':
             print_flags |= UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HEADER | UCS_CONFIG_PRINT_DOC;
@@ -204,6 +206,9 @@ int main(int argc, char **argv)
         case 'A':
             ip_addr = optarg;
             break;
+        case '6':
+            ip_addr_family = AF_INET6;
+            break;
         case 'T':
             print_opts |= PRINT_SYS_TOPO;
             break;
@@ -264,7 +269,7 @@ int main(int argc, char **argv)
         return print_ucp_info(print_opts, print_flags, ucp_features,
                               &ucp_ep_params, ucp_num_eps, ucp_num_ppn,
                               dev_type_bitmap, proc_placement, mem_size,
-                              ip_addr);
+                              ip_addr, ip_addr_family);
     }
 
     return 0;

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -52,6 +52,6 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
                size_t estimated_num_eps, size_t estimated_num_ppn,
                unsigned dev_type_bitmap, process_placement_t proc_placement,
-               const char *mem_size, const char *ip_addr);
+               const char *mem_size, const char *ip_addr, sa_family_t af);
 
 #endif

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -60,6 +60,7 @@ struct perftest_context {
     perftest_params_t            params;
     const char                   *server_addr;
     int                          port;
+    sa_family_t                  af;
     int                          mpi;
     unsigned                     num_cpus;
     unsigned                     cpus[MAX_CPUS];

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -85,6 +85,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -R <rank>      percentile rank of the percentile data in latency tests (%.1f)\n",
                                 ctx->params.super.percentile_rank);
     printf("     -p <port>      TCP port to use for data exchange (%d)\n", ctx->port);
+    printf("     -6             Use IPv6 address for in data exchange\n");
 #ifdef HAVE_MPI
     printf("     -P <0|1>       disable/enable MPI mode (%d)\n", ctx->mpi);
 #endif
@@ -540,14 +541,18 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
     ctx->server_addr     = NULL;
     ctx->num_batch_files = 0;
     ctx->port            = 13337;
+    ctx->af              = AF_INET;
     ctx->flags           = 0;
     ctx->mpi             = mpi_initialized;
 
     optind = 1;
-    while ((c = getopt(argc, argv, "p:b:NfvIc:P:h" TEST_PARAMS_ARGS)) != -1) {
+    while ((c = getopt(argc, argv, "p:b:6NfvIc:P:h" TEST_PARAMS_ARGS)) != -1) {
         switch (c) {
         case 'p':
             ctx->port = atoi(optarg);
+            break;
+        case '6':
+            ctx->af = AF_INET6;
             break;
         case 'b':
             if (ctx->num_batch_files < MAX_BATCH_FILES) {

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -25,6 +25,8 @@ BEGIN_C_DECLS
 #define UCS_IPV4_ADDR_LEN            sizeof(struct in_addr)
 #define UCS_IPV6_ADDR_LEN            sizeof(struct in6_addr)
 
+#define UCS_IPV4_SOCKADDR_LEN        sizeof(struct sockaddr_in)
+#define UCS_IPV6_SOCKADDR_LEN        sizeof(struct sockaddr_in6)
 /* A string to hold the IP address and port from a sockaddr */
 #define UCS_SOCKADDR_STRING_LEN      60
 
@@ -72,10 +74,26 @@ ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,
  * Check if the given interface is in an active state.
  *
  * @param [in]  if_name      Interface name to check.
+ * @param [in]  af           Address family.
  *
  * @return 1 if true, otherwise 0
  */
-int ucs_netif_is_active(const char *if_name);
+int ucs_netif_is_active(const char *if_name, sa_family_t af);
+
+
+/**
+ * Get address and netmask for a given interface.
+ *
+ * @param [in]  if_name      Interface name to check.
+ * @param [in]  af           Address family.
+ * @param [out] addr         Interface address.
+ * @param [out] netmask      Interface address.
+ *
+ * @return UCS_OK on success or an error code on failure.
+ */
+ucs_status_t ucs_netif_get_addr(const char *if_name, sa_family_t af,
+                                struct sockaddr *saddr,
+                                struct sockaddr *netmask);
 
 
 /**
@@ -513,6 +531,17 @@ int ucs_sockaddr_is_inaddr_loopback(const struct sockaddr *addr);
 
 
 /**
+ * set INADDR_ANY (IPV4) or in6addr_any (IPV6) to addr.
+ *
+ * @param [out]  addr       Pointer to sockaddr structure.
+ * @param [in]   af         Address family.
+ *
+ * @return UCS_OK on success or UCS_ERR_INVALID_PARAM on failure.
+ */
+ucs_status_t ucs_sockaddr_set_inaddr_any(struct sockaddr *addr, sa_family_t af);
+
+
+/**
  * Copy the src_addr sockaddr to dst_addr sockaddr. The length to copy is
  * the size of the src_addr sockaddr.
  *
@@ -535,24 +564,6 @@ ucs_status_t ucs_sockaddr_copy(struct sockaddr *dst_addr,
  */
 ucs_status_t
 ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen);
-
-/**
- * Copy the IP address associated with the given network interface.
- *
- * @param [in]   if_name     Interface name.
- * @param [out]  addr        The IP address of the given interface.
- */
-ucs_status_t
-ucs_sockaddr_get_ifaddr(const char *if_name, struct sockaddr_in *addr);
-
-/**
- * Copy the IP subnet mask associated with the given network interface.
- *
- * @param [in]   if_name     Interface name.
- * @param [out]  addr        The IP address of the given interface.
- */
-ucs_status_t
-ucs_sockaddr_get_ifmask(const char *if_name, struct sockaddr_in *mask);
 
 
 /**

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1194,7 +1194,7 @@ uct_ib_iface_init_roce_mask_info(uct_ib_iface_t *iface, size_t md_config_index)
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     uint8_t port_num     = iface->config.port_num;
 
-    struct sockaddr_in mask;
+    struct sockaddr_storage mask;
     char ndev_name[IFNAMSIZ];
     ucs_status_t status;
     size_t addr_size;
@@ -1209,7 +1209,8 @@ uct_ib_iface_init_roce_mask_info(uct_ib_iface_t *iface, size_t md_config_index)
         goto mask_info_failed;
     }
 
-    status = ucs_sockaddr_get_ifmask(ndev_name, &mask);
+    status = ucs_netif_get_addr(ndev_name, AF_UNSPEC, NULL,
+                                (struct sockaddr*)&mask);
     if (status != UCS_OK) {
         goto mask_info_failed;
     }

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -122,27 +122,11 @@ static inline void uct_tcp_ep_ctx_reset(uct_tcp_ep_ctx_t *ctx)
     uct_tcp_ep_ctx_rewind(ctx);
 }
 
-static void uct_tcp_ep_addr_cleanup(struct sockaddr_in *sock_addr)
-{
-    memset(sock_addr, 0, sizeof(*sock_addr));
-}
-
-static void uct_tcp_ep_addr_init(struct sockaddr_in *sock_addr,
-                                 const struct sockaddr_in *peer_addr)
-{
-    /* TODO: handle IPv4 and IPv6 */
-    if (peer_addr == NULL) {
-        uct_tcp_ep_addr_cleanup(sock_addr);
-    } else {
-        *sock_addr = *peer_addr;
-    }
-}
-
 int uct_tcp_ep_is_self(const uct_tcp_ep_t *ep)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
-    return uct_tcp_iface_is_self_addr(iface, &ep->peer_addr);
+    return uct_tcp_iface_is_self_addr(iface, (struct sockaddr*)&ep->peer_addr);
 }
 
 static void uct_tcp_ep_cleanup(uct_tcp_ep_t *ep)
@@ -237,12 +221,10 @@ uct_tcp_ep_t *uct_tcp_ep_ptr_map_retrieve(uct_tcp_iface_t *iface,
     return NULL;
 }
 
-static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
-                           int fd, const struct sockaddr_in *dest_addr)
+static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface, int fd,
+                           const struct sockaddr *dest_addr)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super)
-
-    uct_tcp_ep_addr_init(&self->peer_addr, dest_addr);
 
     uct_tcp_ep_ctx_init(&self->tx);
     uct_tcp_ep_ctx_init(&self->rx);
@@ -258,6 +240,10 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_ep_t, uct_tcp_iface_t *iface,
     ucs_list_head_init(&self->list);
     ucs_queue_head_init(&self->pending_q);
     ucs_queue_head_init(&self->put_comp_q);
+
+    if (dest_addr != NULL) {
+        memcpy(&self->peer_addr[0], dest_addr, iface->config.sockaddr_len);
+    }
 
     if (self->fd != -1) /* EP is created during accepting a connection */ {
         self->conn_retries++;
@@ -418,16 +404,41 @@ static UCS_CLASS_CLEANUP_FUNC(uct_tcp_ep_t)
 
     uct_tcp_ep_cleanup(self);
     uct_tcp_cm_change_conn_state(self, UCT_TCP_EP_CONN_STATE_CLOSED);
-    uct_tcp_ep_addr_cleanup(&self->peer_addr);
 
     ucs_debug("tcp_ep %p: destroyed on iface %p", self, iface);
 }
 
 UCS_CLASS_DEFINE(uct_tcp_ep_t, uct_base_ep_t);
 
-UCS_CLASS_DEFINE_NAMED_NEW_FUNC(uct_tcp_ep_init, uct_tcp_ep_t, uct_tcp_ep_t,
-                                uct_tcp_iface_t*, int,
-                                const struct sockaddr_in*)
+ucs_status_t uct_tcp_ep_init(uct_tcp_iface_t *iface, int fd,
+                             const struct sockaddr *dest_addr,
+                             uct_tcp_ep_t **ep_p)
+{
+    ucs_status_t status;
+    uct_tcp_ep_t *ep;
+
+    ep = ucs_malloc(sizeof(uct_tcp_ep_t) + iface->config.sockaddr_len,
+                    "tcp_ep");
+    if (ep == NULL) {
+        ucs_error("failed to allocate tcp ep");
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    status = UCS_CLASS_INIT(uct_tcp_ep_t, ep, iface, fd, dest_addr);
+    if (status != UCS_OK) {
+        goto err_free;
+    }
+
+    *ep_p = ep;
+    return UCS_OK;
+
+err_free:
+    ucs_free(ep);
+err:
+    return status;
+}
+
 UCS_CLASS_DEFINE_NAMED_DELETE_FUNC(uct_tcp_ep_destroy_internal,
                                    uct_tcp_ep_t, uct_ep_t)
 
@@ -579,9 +590,10 @@ static ucs_status_t uct_tcp_ep_create_socket_and_connect(uct_tcp_ep_t *ep)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_tcp_iface_t);
+    struct sockaddr *saddr = (struct sockaddr*)ep->peer_addr;
     ucs_status_t status;
 
-    status = ucs_socket_create(AF_INET, SOCK_STREAM, &ep->fd);
+    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, &ep->fd);
     if (status != UCS_OK) {
         goto err;
     }
@@ -683,8 +695,8 @@ static ucs_status_t uct_tcp_ep_connect(uct_tcp_ep_t *ep)
         goto out;
     }
 
-    peer_ep = uct_tcp_cm_get_ep(iface, &ep->peer_addr, ep->cm_id.conn_sn,
-                                UCT_TCP_EP_FLAG_CTX_TYPE_RX);
+    peer_ep = uct_tcp_cm_get_ep(iface, (struct sockaddr*)&ep->peer_addr,
+                                ep->cm_id.conn_sn, UCT_TCP_EP_FLAG_CTX_TYPE_RX);
     if (peer_ep == NULL) {
         status = uct_tcp_ep_create_socket_and_connect(ep);
         if (status != UCS_OK) {
@@ -730,26 +742,26 @@ ucs_status_t uct_tcp_ep_set_dest_addr(const uct_device_addr_t *dev_addr,
                                       const uct_iface_addr_t *iface_addr,
                                       struct sockaddr *dest_addr)
 {
-    uct_tcp_device_addr_t *tcp_dev_addr  = (uct_tcp_device_addr_t*)dev_addr;
-    uct_tcp_iface_addr_t *tcp_iface_addr = (uct_tcp_iface_addr_t*)iface_addr;
-    const struct in_addr loopback_addr   = {
+    uct_tcp_device_addr_t *tcp_dev_addr   = (uct_tcp_device_addr_t*)dev_addr;
+    uct_tcp_iface_addr_t *tcp_iface_addr  = (uct_tcp_iface_addr_t*)iface_addr;
+    const struct in_addr in4addr_loopback = {
         .s_addr = htonl(INADDR_LOOPBACK)
     };
     const void *in_addr;
     ucs_status_t status;
 
-    memset(dest_addr, 0, sizeof(*dest_addr));
+    memset(dest_addr, 0, ((tcp_dev_addr->sa_family == AF_INET) ?
+                          UCS_IPV4_SOCKADDR_LEN : UCS_IPV6_SOCKADDR_LEN));
+    dest_addr->sa_family = tcp_dev_addr->sa_family;
 
     if (tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) {
-        in_addr = &loopback_addr;
+        in_addr = (dest_addr->sa_family == AF_INET) ? (void*)&in4addr_loopback :
+                                                      (void*)&in6addr_loopback;
     } else {
         in_addr = tcp_dev_addr + 1;
     }
 
-    /* TODO: handle AF_INET6 */
-    dest_addr->sa_family = tcp_dev_addr->sa_family;
-    ucs_assert(dest_addr->sa_family == AF_INET);
-
+    /* coverity[overrun-buffer-val] */
     status = ucs_sockaddr_set_inet_addr(dest_addr, in_addr);
     if (status != UCS_OK) {
         return status;
@@ -766,11 +778,11 @@ uint64_t uct_tcp_ep_get_cm_id(const uct_tcp_ep_t *ep)
 
 ucs_status_t uct_tcp_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p)
 {
-    uct_tcp_iface_t *iface           = ucs_derived_of(params->iface,
-                                                      uct_tcp_iface_t);
-    uct_tcp_ep_t *ep                 = NULL;
-    struct sockaddr_in *ep_dest_addr = NULL;
-    struct sockaddr_in dest_addr;
+    uct_tcp_iface_t *iface                = ucs_derived_of(params->iface,
+                                                           uct_tcp_iface_t);
+    uct_tcp_ep_t *ep                      = NULL;
+    struct sockaddr_storage *ep_dest_addr = NULL;
+    struct sockaddr_storage dest_addr;
     ucs_status_t status;
 
     if (ucs_test_all_flags(params->field_mask,
@@ -785,7 +797,7 @@ ucs_status_t uct_tcp_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p)
         ep_dest_addr = &dest_addr;
     }
 
-    status = uct_tcp_ep_init(iface, -1, ep_dest_addr, &ep);
+    status = uct_tcp_ep_init(iface, -1, (struct sockaddr*)ep_dest_addr, &ep);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -124,7 +124,7 @@ static ucs_status_t uct_tcp_iface_get_device_address(uct_iface_h tl_iface,
     ucs_status_t status;
 
     dev_addr->flags     = 0;
-    dev_addr->sa_family = iface->config.ifaddr.sin_family;
+    dev_addr->sa_family = saddr->sa_family;
 
     if (ucs_sockaddr_is_inaddr_loopback(saddr)) {
         dev_addr->flags |= UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK;
@@ -167,8 +167,17 @@ uct_tcp_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr)
     uct_tcp_iface_t *iface           = ucs_derived_of(tl_iface,
                                                       uct_tcp_iface_t);
     uct_tcp_iface_addr_t *iface_addr = (uct_tcp_iface_addr_t*)addr;
+    ucs_status_t status;
+    uint16_t port;
 
-    iface_addr->port = iface->config.ifaddr.sin_port;
+    status = ucs_sockaddr_get_port((struct sockaddr*)&iface->config.ifaddr,
+                                   &port);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    iface_addr->port = htons(port);
+
     return UCS_OK;
 }
 
@@ -180,6 +189,10 @@ static int uct_tcp_iface_is_reachable(const uct_iface_h tl_iface,
                                                          uct_tcp_iface_t);
     uct_tcp_device_addr_t *tcp_dev_addr = (uct_tcp_device_addr_t*)dev_addr;
     uct_iface_local_addr_ns_t *local_addr_ns;
+
+    if (iface->config.ifaddr.ss_family != tcp_dev_addr->sa_family) {
+        return 0;
+    }
 
     /* Loopback can connect only to loopback */
     if (!!(tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) !=
@@ -348,7 +361,7 @@ uct_tcp_iface_connect_handler(int listen_fd, ucs_event_set_types_t events,
                               void *arg)
 {
     uct_tcp_iface_t *iface = arg;
-    struct sockaddr_in peer_addr;
+    struct sockaddr_storage peer_addr;
     socklen_t addrlen;
     ucs_status_t status;
     int fd;
@@ -367,7 +380,9 @@ uct_tcp_iface_connect_handler(int listen_fd, ucs_event_set_types_t events,
         }
         ucs_assert(fd != -1);
 
-        status = uct_tcp_cm_handle_incoming_conn(iface, &peer_addr, fd);
+        status = uct_tcp_cm_handle_incoming_conn(iface,
+                                                 (struct sockaddr*)&peer_addr,
+                                                 fd);
         if (status != UCS_OK) {
             ucs_close_fd(&fd);
             return;
@@ -434,10 +449,11 @@ static uct_iface_ops_t uct_tcp_iface_ops = {
 
 static ucs_status_t uct_tcp_iface_server_init(uct_tcp_iface_t *iface)
 {
-    struct sockaddr_in bind_addr = iface->config.ifaddr;
-    unsigned port_range_start    = iface->port_range.first;
-    unsigned port_range_end      = iface->port_range.last;
+    struct sockaddr_storage bind_addr = iface->config.ifaddr;
+    unsigned port_range_start         = iface->port_range.first;
+    unsigned port_range_end           = iface->port_range.last;
     ucs_status_t status;
+    size_t addr_len;
     int port, retry;
 
     /* retry is 1 for a range of ports or when port value is zero.
@@ -454,14 +470,19 @@ static ucs_status_t uct_tcp_iface_server_init(uct_tcp_iface_t *iface)
             port = 0;   /* let the operating system choose the port */
         }
 
-        status = ucs_sockaddr_set_port((struct sockaddr *)&bind_addr, port);
+        status = ucs_sockaddr_set_port((struct sockaddr*)&bind_addr, port);
         if (status != UCS_OK) {
             break;
         }
 
-        status = ucs_socket_server_init((struct sockaddr *)&bind_addr,
-                                        sizeof(bind_addr), ucs_socket_max_conn(),
-                                        retry, 0, &iface->listen_fd);
+        status = ucs_sockaddr_sizeof((struct sockaddr*)&bind_addr, &addr_len);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = ucs_socket_server_init((struct sockaddr*)&bind_addr, addr_len,
+                                        ucs_socket_max_conn(), retry, 0,
+                                        &iface->listen_fd);
     } while (retry && (status == UCS_ERR_BUSY));
 
     return status;
@@ -469,10 +490,11 @@ static ucs_status_t uct_tcp_iface_server_init(uct_tcp_iface_t *iface)
 
 static ucs_status_t uct_tcp_iface_listener_init(uct_tcp_iface_t *iface)
 {
-    struct sockaddr_in bind_addr = iface->config.ifaddr;
-    socklen_t socklen            = sizeof(bind_addr);
+    struct sockaddr_storage bind_addr = iface->config.ifaddr;
+    socklen_t socklen                 = sizeof(bind_addr);
     char ip_port_str[UCS_SOCKADDR_STRING_LEN];
     ucs_status_t status;
+    uint16_t port;
     int ret;
 
     status = uct_tcp_iface_server_init(iface);
@@ -481,14 +503,23 @@ static ucs_status_t uct_tcp_iface_listener_init(uct_tcp_iface_t *iface)
     }
 
     /* Get the port which was selected for the socket */
-    ret = getsockname(iface->listen_fd, (struct sockaddr *)&bind_addr, &socklen);
+    ret = getsockname(iface->listen_fd, (struct sockaddr*)&bind_addr, &socklen);
     if (ret < 0) {
         ucs_error("getsockname(fd=%d) failed: %m", iface->listen_fd);
         status = UCS_ERR_IO_ERROR;
         goto err_close_sock;
     }
 
-    iface->config.ifaddr.sin_port = bind_addr.sin_port;
+    status = ucs_sockaddr_get_port((struct sockaddr*)&bind_addr, &port);
+    if (status != UCS_OK) {
+        goto err_close_sock;
+    }
+
+    status = ucs_sockaddr_set_port((struct sockaddr*)&iface->config.ifaddr,
+                                   port);
+    if (status != UCS_OK) {
+        goto err_close_sock;
+    }
 
     /* Register event handler for incoming connections */
     status = ucs_async_set_event_handler(iface->super.worker->async->mode,
@@ -573,7 +604,9 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
 {
     uct_tcp_iface_config_t *config = ucs_derived_of(tl_config,
                                                     uct_tcp_iface_config_t);
+    uct_tcp_md_t *tcp_md           = ucs_derived_of(md, uct_tcp_md_t);
     ucs_status_t status;
+    int i;
 
     UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
                     "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
@@ -666,13 +699,6 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         goto err;
     }
 
-    ucs_list_head_init(&self->ep_list);
-    ucs_conn_match_init(&self->conn_match_ctx,
-                        ucs_field_sizeof(uct_tcp_ep_t, peer_addr),
-                        UCT_TCP_CM_CONN_SN_MAX,  &uct_tcp_cm_conn_match_ops);
-    status = UCS_PTR_MAP_INIT(tcp_ep, &self->ep_ptr_map);
-    ucs_assert_always(status == UCS_OK);
-
     if (self->config.tx_seg_size > self->config.rx_seg_size) {
         ucs_error("RX segment size (%zu) must be >= TX segment size (%zu)",
                   self->config.rx_seg_size, self->config.tx_seg_size);
@@ -699,15 +725,31 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         goto err_cleanup_tx_mpool;
     }
 
-    status = ucs_sockaddr_get_ifaddr(self->if_name, &self->config.ifaddr);
+    for (i = 0; i < tcp_md->config.af_prio_count; i++) {
+        status = ucs_netif_get_addr(self->if_name,
+                                    tcp_md->config.af_prio_list[i],
+                                    (struct sockaddr*)&self->config.ifaddr,
+                                    (struct sockaddr*)&self->config.netmask);
+        if (status == UCS_OK) {
+            break;
+        }
+    }
+
     if (status != UCS_OK) {
         goto err_cleanup_rx_mpool;
     }
 
-    status = ucs_sockaddr_get_ifmask(self->if_name, &self->config.netmask);
+    status = ucs_sockaddr_sizeof((struct sockaddr*)&self->config.ifaddr,
+                                 &self->config.sockaddr_len);
     if (status != UCS_OK) {
-        goto err_cleanup_rx_mpool;
+        return status;
     }
+
+    ucs_list_head_init(&self->ep_list);
+    ucs_conn_match_init(&self->conn_match_ctx, self->config.sockaddr_len,
+                        UCT_TCP_CM_CONN_SN_MAX, &uct_tcp_cm_conn_match_ops);
+    status = UCS_PTR_MAP_INIT(tcp_ep, &self->ep_ptr_map);
+    ucs_assert_always(status == UCS_OK);
 
     status = ucs_event_set_create(&self->event_set);
     if (status != UCS_OK) {
@@ -762,12 +804,12 @@ void uct_tcp_iface_remove_ep(uct_tcp_ep_t *ep)
 }
 
 int uct_tcp_iface_is_self_addr(uct_tcp_iface_t *iface,
-                               const struct sockaddr_in *peer_addr)
+                               const struct sockaddr *peer_addr)
 {
     ucs_status_t status;
     int cmp;
 
-    cmp = ucs_sockaddr_cmp((const struct sockaddr*)peer_addr,
+    cmp = ucs_sockaddr_cmp(peer_addr,
                            (const struct sockaddr*)&iface->config.ifaddr,
                            &status);
     ucs_assert(status == UCS_OK);
@@ -809,10 +851,12 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
                                    uct_tl_device_resource_t **devices_p,
                                    unsigned *num_devices_p)
 {
+    uct_tcp_md_t *tcp_md = ucs_derived_of(md, uct_tcp_md_t);
     uct_tl_device_resource_t *devices, *tmp;
     static const char *netdev_dir = "/sys/class/net";
     struct dirent *entry;
     unsigned num_devices;
+    int is_active, i;
     ucs_status_t status;
     DIR *dir;
 
@@ -848,7 +892,16 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
             continue;
         }
 
-        if (!ucs_netif_is_active(entry->d_name)) {
+        is_active = 0;
+        for (i = 0; i < tcp_md->config.af_prio_count; i++) {
+            if (ucs_netif_is_active(entry->d_name,
+                                    tcp_md->config.af_prio_list[i])) {
+                is_active = 1;
+                break;
+            }
+        }
+
+        if (!is_active) {
             continue;
         }
 

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -12,6 +12,17 @@
 #include <uct/base/uct_md.h>
 
 
+static ucs_config_field_t uct_tcp_md_config_table[] = {
+    {"", "", NULL,
+     ucs_offsetof(uct_tcp_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
+
+    {"AF_PRIO", "inet,inet6",
+     "Priority of address families used for socket connections",
+     ucs_offsetof(uct_tcp_md_config_t, af_prio), UCS_CONFIG_TYPE_STRING_ARRAY},
+
+    {NULL}
+};
+
 static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
@@ -47,25 +58,61 @@ static ucs_status_t uct_tcp_mem_dereg(uct_md_h uct_md,
     return UCS_OK;
 }
 
+static void uct_tcp_md_close(uct_md_h md)
+{
+    uct_tcp_md_t *tcp_md = ucs_derived_of(md, uct_tcp_md_t);
+    ucs_free(tcp_md);
+}
+
+static uct_md_ops_t uct_tcp_md_ops = {
+    .close              = uct_tcp_md_close,
+    .query              = uct_tcp_md_query,
+    .mkey_pack          = ucs_empty_function_return_success,
+    .mem_reg            = uct_tcp_md_mem_reg,
+    .mem_dereg          = uct_tcp_mem_dereg,
+    .detect_memory_type = ucs_empty_function_return_unsupported
+};
+
 static ucs_status_t
 uct_tcp_md_open(uct_component_t *component, const char *md_name,
-                const uct_md_config_t *md_config, uct_md_h *md_p)
+                const uct_md_config_t *uct_md_config, uct_md_h *md_p)
 {
-    static uct_md_ops_t md_ops = {
-        .close              = ucs_empty_function,
-        .query              = uct_tcp_md_query,
-        .mkey_pack          = ucs_empty_function_return_success,
-        .mem_reg            = uct_tcp_md_mem_reg,
-        .mem_dereg          = uct_tcp_mem_dereg,
-        .detect_memory_type = ucs_empty_function_return_unsupported
-    };
-    static uct_md_t md = {
-        .ops          = &md_ops,
-        .component    = &uct_tcp_component
-    };
+    const uct_tcp_md_config_t *md_config = ucs_derived_of(uct_md_config,
+                                                          uct_tcp_md_config_t);
+    uct_tcp_md_t *tcp_md;
+    ucs_status_t status;
+    int i;
 
-    *md_p = &md;
+    tcp_md = ucs_malloc(sizeof(uct_tcp_md_t), "uct_tcp_md_t");
+    if (NULL == tcp_md) {
+        ucs_error("failed to allocate memory for uct_tcp_md_t");
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    tcp_md->super.ops            = &uct_tcp_md_ops;
+    tcp_md->super.component      = &uct_tcp_component;
+    tcp_md->config.af_prio_count = ucs_min(md_config->af_prio.count, 2);
+
+    for (i = 0; i < tcp_md->config.af_prio_count; i++) {
+        if (!strcasecmp(md_config->af_prio.af[i], "inet")) {
+            tcp_md->config.af_prio_list[i] = AF_INET;
+        } else if (!strcasecmp(md_config->af_prio.af[i], "inet6")) {
+            tcp_md->config.af_prio_list[i] = AF_INET6;
+        } else {
+            ucs_error("invalid address family: %s", md_config->af_prio.af[i]);
+            status = UCS_ERR_INVALID_PARAM;
+            goto err_free;
+        }
+    }
+
+    *md_p = &tcp_md->super;
     return UCS_OK;
+
+err_free:
+    ucs_free(tcp_md);
+err:
+    return status;
 }
 
 static ucs_status_t uct_tcp_md_rkey_unpack(uct_component_t *component,
@@ -89,7 +136,12 @@ uct_component_t uct_tcp_component = {
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
     .name               = UCT_TCP_NAME,
-    .md_config          = UCT_MD_DEFAULT_CONFIG_INITIALIZER,
+    .md_config          = {
+        .name           = "TCP memory domain",
+        .prefix         = "TCP_",
+        .table          = uct_tcp_md_config_table,
+        .size           = sizeof(uct_tcp_md_config_t)
+    },
     .cm_config          = {
         .name           = "TCP-SOCKCM connection manager",
         .prefix         = "TCP_CM_",

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -62,7 +62,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);
     EXPECTED_SIZE(uct_self_ep_t, 8);
-    EXPECTED_SIZE(uct_tcp_ep_t, 160);
+    EXPECTED_SIZE(uct_tcp_ep_t, 144);
 #  if HAVE_TL_RC
     EXPECTED_SIZE(uct_rc_ep_t, 64);
     EXPECTED_SIZE(uct_rc_verbs_ep_t, 80);

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -179,14 +179,17 @@ private:
         status = uct_iface_get_address(to.iface(), iface_addr);
         ASSERT_UCS_OK(status);
 
-        struct sockaddr dest_addr;
-        uct_tcp_ep_set_dest_addr(dev_addr, iface_addr, &dest_addr);
+        struct sockaddr_storage dest_addr;
+        uct_tcp_ep_set_dest_addr(dev_addr, iface_addr,
+                                 (struct sockaddr*)&dest_addr);
 
         int fd;
-        status = ucs_socket_create(AF_INET, SOCK_STREAM, &fd);
+        EXPECT_TRUE((dest_addr.ss_family == AF_INET) ||
+                    (dest_addr.ss_family == AF_INET6));
+        status = ucs_socket_create(dest_addr.ss_family, SOCK_STREAM, &fd);
         ASSERT_UCS_OK(status);
 
-        status = ucs_socket_connect(fd, &dest_addr);
+        status = ucs_socket_connect(fd, (struct sockaddr*)&dest_addr);
         ASSERT_UCS_OK(status);
 
         status = ucs_sys_fcntl_modfl(fd, O_NONBLOCK, 0);


### PR DESCRIPTION
## What
 Add IPv6 address support

## How ?
-  Use generic IPv4/IPv6 portable data structures and socket APIs
-  Port TOOLS and EXAMPLES to support IPv6 addresses for data exchange
