### PR TITLE
UCP/API: Add request flag to influence latency vs. bandwidth protocol

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -698,10 +698,14 @@ typedef enum {
                                                         synchronization with the
                                                         remote peer before releasing
                                                         the local send buffer */
-    UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL = UCS_BIT(18)  /**< force immediate complete
+    UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL = UCS_BIT(18), /**< force immediate complete
                                                         operation, fail if the
                                                         operation cannot be
                                                         completed immediately */
+    UCP_OP_ATTR_FLAG_MULTI_SEND     = UCS_BIT(19)  /**< optimize for bandwidth of
+                                                        multiple in-flight operations,
+                                                        rather than for the latency
+                                                        of a single operation */
 } ucp_op_attr_t;
 
 
@@ -4581,7 +4585,7 @@ typedef struct ucp_ep_attr {
     char     name[UCP_ENTITY_NAME_MAX];
 
     /**
-     * Local socket address for this endpoint. Valid only for endpoints created 
+     * Local socket address for this endpoint. Valid only for endpoints created
      * by connecting to a socket address.
      * If this field is specified for an endpoint not connected to a socket address,
      * UCS_ERR_NOT_CONNECTED will be returned.

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -540,8 +540,8 @@ static ucs_status_t ucp_proto_select_elem_init_thresh(
     ucp_proto_select_range_t *perf_ranges, *tmp_range_elem;
     ucp_proto_threshold_tmp_elem_t *tmp_thresh_elem;
     ucp_proto_threshold_elem_t *thresholds;
-    size_t msg_length, max_length;
     ucp_proto_config_t *proto_config;
+    size_t msg_length, max_length;
     ucp_proto_id_t proto_id;
     ucs_status_t status;
     size_t priv_offset;
@@ -638,8 +638,12 @@ err:
 static ucp_proto_perf_type_t
 ucp_proto_select_param_perf_type(const ucp_proto_select_param_t *select_param)
 {
-    /* TODO select according to operation flags */
-    return UCP_PROTO_PERF_TYPE_SINGLE;
+    if (ucp_proto_select_op_attr_from_flags(select_param->op_flags) &
+        UCP_OP_ATTR_FLAG_MULTI_SEND) {
+        return UCP_PROTO_PERF_TYPE_MULTI;
+    } else {
+        return UCP_PROTO_PERF_TYPE_SINGLE;
+    }
 }
 
 static ucs_status_t
@@ -1055,6 +1059,11 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
         ucs_string_buffer_appendf(strb, ", fast-completion");
     }
 
+    if (op_attr_mask & UCP_OP_ATTR_FLAG_MULTI_SEND) {
+        ucs_string_buffer_appendf(strb, "multi,");
+    }
+
+    ucs_string_buffer_rtrim(strb, ",");
     ucs_string_buffer_appendf(strb, ")");
 }
 

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -17,7 +17,9 @@
  * selection decision.
  */
 #define UCP_PROTO_SELECT_OP_ATTR_BASE   UCP_OP_ATTR_FLAG_NO_IMM_CMPL
-#define UCP_PROTO_SELECT_OP_ATTR_MASK   UCP_OP_ATTR_FLAG_FAST_CMPL
+#define UCP_PROTO_SELECT_OP_ATTR_MASK   (UCP_OP_ATTR_FLAG_FAST_CMPL | \
+                                         UCP_OP_ATTR_FLAG_MULTI_SEND)
+#define UCP_PROTO_SELECT_OP_FLAGS_BASE  UCS_BIT(5)
 
 
 /** Maximal length of ucp_proto_select_param_str() */

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -45,8 +45,9 @@ ucp_proto_thresholds_search(const ucp_proto_threshold_elem_t *thresholds,
 static UCS_F_ALWAYS_INLINE uint8_t
 ucp_proto_select_op_attr_to_flags(uint32_t op_attr_mask)
 {
-    UCS_STATIC_ASSERT(UCP_PROTO_SELECT_OP_ATTR_MASK /
-                      UCP_PROTO_SELECT_OP_ATTR_BASE <= UINT8_MAX);
+    UCS_STATIC_ASSERT(
+            (UCP_PROTO_SELECT_OP_ATTR_MASK / UCP_PROTO_SELECT_OP_ATTR_BASE) <
+            UCP_PROTO_SELECT_OP_FLAGS_BASE);
     return op_attr_mask / UCP_PROTO_SELECT_OP_ATTR_BASE;
 }
 


### PR DESCRIPTION
## Why
- On API layer, add hints for protocol selection
- Internally, this flag will be used for RNDV pipeline protocols - to prefer staging protocols even though they have higher latency