### PR TITLE
UCP/MPOOL: Detailed mpool leak check

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -92,28 +92,32 @@ ucs_mpool_ops_t ucp_am_mpool_ops = {
     .chunk_alloc   = ucs_mpool_hugetlb_malloc,
     .chunk_release = ucs_mpool_hugetlb_free,
     .obj_init      = ucs_empty_function,
-    .obj_cleanup   = ucs_empty_function
+    .obj_cleanup   = ucs_empty_function,
+    .obj_str       = NULL
 };
 
 ucs_mpool_ops_t ucp_reg_mpool_ops = {
     .chunk_alloc   = ucp_reg_mpool_malloc,
     .chunk_release = ucp_reg_mpool_free,
     .obj_init      = ucp_mpool_obj_init,
-    .obj_cleanup   = ucs_empty_function
+    .obj_cleanup   = ucs_empty_function,
+    .obj_str       = NULL
 };
 
 ucs_mpool_ops_t ucp_frag_mpool_ops = {
     .chunk_alloc   = ucp_frag_mpool_malloc,
     .chunk_release = ucp_frag_mpool_free,
     .obj_init      = ucp_mpool_obj_init,
-    .obj_cleanup   = ucs_empty_function
+    .obj_cleanup   = ucs_empty_function,
+    .obj_str       = NULL
 };
 
 static ucs_mpool_ops_t ucp_rkey_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 #define ucp_worker_discard_uct_ep_hash_key(_uct_ep) \

--- a/src/ucs/datastruct/mpool.h
+++ b/src/ucs/datastruct/mpool.h
@@ -10,6 +10,8 @@
 #include <stddef.h>
 #include <ucs/type/status.h>
 #include <ucs/sys/compiler_def.h>
+#include <ucs/datastruct/string_buffer.h>
+
 
 BEGIN_C_DECLS
 
@@ -127,6 +129,16 @@ struct ucs_mpool_ops {
      * @param obj          Object to initialize.
      */
     void         (*obj_cleanup)(ucs_mpool_t *mp, void *obj);
+
+    /**
+     * Return a string representing the object, used for debug.
+     * May be NULL.
+     *
+     * @param mp           Memory pool structure.
+     * @param obj          Object to show.
+     * @param strb         String buffer to fill with object information.
+     */
+    void         (*obj_str)(ucs_mpool_t *mp, void *obj, ucs_string_buffer_t *strb);
 };
 
 

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -42,6 +42,11 @@ void ucs_string_buffer_cleanup(ucs_string_buffer_t *strb)
     ucs_array_cleanup_dynamic(&strb->str);
 }
 
+void ucs_string_buffer_reset(ucs_string_buffer_t *strb)
+{
+    ucs_array_length(&strb->str) = 0;
+}
+
 size_t ucs_string_buffer_length(ucs_string_buffer_t *strb)
 {
     return ucs_array_length(&strb->str);

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -121,6 +121,14 @@ void ucs_string_buffer_cleanup(ucs_string_buffer_t *strb);
 
 
 /**
+ * Reset a string buffer to initial empty state.
+ *
+ * @param [out] strb   String buffer reset.
+ */
+void ucs_string_buffer_reset(ucs_string_buffer_t *strb);
+
+
+/**
  * Get the number of characters in a string buffer
  *
  * @param [out] strb   Return the length of this string buffer.

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -223,7 +223,8 @@ static ucs_mpool_ops_t ucs_rcache_mp_ops = {
     .chunk_alloc   = ucs_rcache_mp_chunk_alloc,
     .chunk_release = ucs_rcache_mp_chunk_release,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static unsigned ucs_rcache_region_page_count(ucs_rcache_region_t *region)

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -473,7 +473,8 @@ static ucs_mpool_ops_t uct_iface_mpool_ops = {
     .chunk_alloc   = uct_iface_mp_chunk_alloc,
     .chunk_release = uct_iface_mp_chunk_release,
     .obj_init      = uct_iface_mp_obj_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 ucs_status_t uct_iface_mpool_init(uct_base_iface_t *iface, ucs_mpool_t *mp,

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -331,6 +331,7 @@ static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = uct_cuda_copy_event_desc_init,
     .obj_cleanup   = uct_cuda_copy_event_desc_cleanup,
+    .obj_str       = NULL
 };
 
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -406,6 +406,7 @@ static ucs_mpool_ops_t uct_cuda_ipc_event_desc_mpool_ops = {
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = uct_cuda_ipc_event_desc_init,
     .obj_cleanup   = uct_cuda_ipc_event_desc_cleanup,
+    .obj_str       = NULL
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -473,7 +473,8 @@ static ucs_mpool_ops_t uct_ib_mlx5_dbrec_ops = {
     .chunk_alloc   = uct_ib_mlx5_add_page,
     .chunk_release = uct_ib_mlx5_free_page,
     .obj_init      = uct_ib_mlx5_init_dbrec,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static ucs_status_t

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -74,7 +74,7 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    "                  treats it as a linked list. Doesn`t require DEVX.",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, srq_topo),
    UCS_CONFIG_TYPE_STRING_ARRAY},
-   
+
   {"LOG_ACK_REQ_FREQ", "8",
    "Log of the ack frequency for requests, when using DevX. Valid values are: 0-"
     UCS_PP_MAKE_STRING(UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ) ".",
@@ -696,7 +696,8 @@ static ucs_mpool_ops_t uct_dm_iface_mpool_ops = {
     .chunk_alloc   = uct_rc_mlx5_iface_common_dm_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = uct_rc_mlx5_iface_common_dm_mp_obj_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -145,14 +145,16 @@ static ucs_mpool_ops_t uct_rc_pending_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static ucs_mpool_ops_t uct_rc_send_op_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -216,6 +216,7 @@ static ucs_mpool_ops_t uct_rocm_ipc_signal_desc_mpool_ops = {
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = uct_rocm_ipc_signal_desc_init,
     .obj_cleanup   = uct_rocm_ipc_signal_desc_cleanup,
+    .obj_str       = NULL
 };
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -50,7 +50,8 @@ static ucs_mpool_ops_t uct_scopy_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr)

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -167,7 +167,8 @@ static ucs_mpool_ops_t uct_self_iface_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static UCS_CLASS_INIT_FUNC(uct_self_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -30,7 +30,7 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
   {"TX_SEG_SIZE", "8kb",
    "Size of send copy-out buffer",
    ucs_offsetof(uct_tcp_iface_config_t, tx_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
-  
+
   {"RX_SEG_SIZE", "64kb",
    "Size of receive copy-out buffer",
    ucs_offsetof(uct_tcp_iface_config_t, rx_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
@@ -553,6 +553,7 @@ out:
 static ucs_mpool_ops_t uct_tcp_mpool_ops = {
     ucs_mpool_chunk_malloc,
     ucs_mpool_chunk_free,
+    NULL,
     NULL,
     NULL
 };

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -51,7 +51,8 @@ static ucs_mpool_ops_t uct_ugni_flush_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 void uct_ugni_cleanup_base_iface(uct_ugni_iface_t *iface)

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -242,7 +242,8 @@ static ucs_mpool_ops_t uct_ugni_rdma_desc_mpool_ops = {
     .chunk_alloc   = ucs_mpool_hugetlb_malloc,
     .chunk_release = ucs_mpool_hugetlb_free,
     .obj_init      = uct_ugni_base_desc_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static uct_iface_ops_t *uct_ugni_rdma_choose_ops_by_device(uct_ugni_device_t *dev)

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -255,14 +255,16 @@ static ucs_mpool_ops_t uct_ugni_smsg_desc_mpool_ops = {
     .chunk_alloc   = ucs_mpool_hugetlb_malloc,
     .chunk_release = ucs_mpool_hugetlb_free,
     .obj_init      = uct_ugni_base_desc_init,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static ucs_mpool_ops_t uct_ugni_smsg_mbox_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_mmap,
     .chunk_release = ucs_mpool_chunk_munmap,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -379,7 +379,8 @@ static ucs_mpool_ops_t uct_ugni_udt_desc_mpool_ops = {
     .chunk_alloc   = ucs_mpool_hugetlb_malloc,
     .chunk_release = ucs_mpool_hugetlb_free,
     .obj_init      = NULL,
-    .obj_cleanup   = NULL
+    .obj_cleanup   = NULL,
+    .obj_str       = NULL
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worker,
@@ -448,7 +449,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
                                          UCS_EVENT_SET_EVREAD,
                                          uct_ugni_proccess_datagram_pipe,
                                          self, self->super.super.worker->async);
-                                 
+
     if (UCS_OK != status) {
         goto clean_cancel_desc;
     }

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -24,6 +24,11 @@ protected:
         free(chunk);
     }
 
+    static void obj_str(ucs_mpool_t *mp, void *obj, ucs_string_buffer_t *strb)
+    {
+        ucs_string_buffer_appendf(strb, "test-obj-%p", obj);
+    }
+
     static ucs_log_func_rc_t
     mpool_log_handler(const char *file, unsigned line, const char *function,
                       ucs_log_level_t level,
@@ -44,6 +49,12 @@ protected:
         return UCS_LOG_FUNC_RC_CONTINUE;
     }
 
+    static bool is_leak_str(const std::string &str)
+    {
+        return (str.find("not returned to mpool test") != std::string::npos) &&
+               (str.find("{test-obj-") != std::string::npos);
+    }
+
     static ucs_log_func_rc_t
     mpool_log_leak_handler(const char *file, unsigned line,
                            const char *function, ucs_log_level_t level,
@@ -51,10 +62,10 @@ protected:
                            const char *message, va_list ap)
     {
         if (level == UCS_LOG_LEVEL_WARN) {
-            std::string err_str = format_message(message, ap);
-
-            if (err_str.find("was not returned to mpool test") !=
-                std::string::npos) {
+            std::string msg = format_message(message, ap);
+            if (is_leak_str(msg)) {
+                UCS_TEST_MESSAGE << "< " << msg << " >";
+                ++leak_count;
                 return UCS_LOG_FUNC_RC_STOP;
             }
         }
@@ -65,7 +76,10 @@ protected:
     static const size_t header_size = 30;
     static const size_t data_size = 152;
     static const size_t align = 128;
+    static size_t leak_count;
 };
+
+size_t test_mpool::leak_count;
 
 UCS_TEST_F(test_mpool, no_allocs) {
     ucs_mpool_t mp;
@@ -74,6 +88,7 @@ UCS_TEST_F(test_mpool, no_allocs) {
     ucs_mpool_ops_t ops = {
        ucs_mpool_chunk_malloc,
        ucs_mpool_chunk_free,
+       NULL,
        NULL,
        NULL
     };
@@ -102,6 +117,7 @@ UCS_TEST_F(test_mpool, basic) {
     ucs_mpool_ops_t ops = {
        ucs_mpool_chunk_malloc,
        ucs_mpool_chunk_free,
+       NULL,
        NULL,
        NULL
     };
@@ -151,6 +167,7 @@ UCS_TEST_F(test_mpool, custom_alloc) {
        test_alloc,
        test_free,
        NULL,
+       NULL,
        NULL
     };
 
@@ -173,6 +190,7 @@ UCS_TEST_F(test_mpool, grow) {
     ucs_mpool_ops_t ops = {
        ucs_mpool_chunk_malloc,
        ucs_mpool_chunk_free,
+       NULL,
        NULL,
        NULL
     };
@@ -199,6 +217,7 @@ UCS_TEST_F(test_mpool, infinite) {
     ucs_mpool_ops_t ops = {
        ucs_mpool_chunk_malloc,
        ucs_mpool_chunk_free,
+       NULL,
        NULL,
        NULL
     };
@@ -230,26 +249,32 @@ UCS_TEST_F(test_mpool, leak_check) {
         ucs_mpool_chunk_malloc,
         ucs_mpool_chunk_free,
         NULL,
-        NULL
+        NULL,
+        obj_str
     };
 
     status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
                             6, 18, &ops, "test");
     ASSERT_UCS_OK(status);
 
-    void *obj = ucs_mpool_get(&mp);
-    EXPECT_TRUE(obj != NULL);
-    // Do not release allocated object
+    for (int i = 0; i < 5; ++i) {
+        void *obj = ucs_mpool_get(&mp);
+        EXPECT_TRUE(obj != NULL);
+    }
+    // Do not release allocated objects
 
+    leak_count = 0;
     scoped_log_handler log_handler(mpool_log_leak_handler);
     ucs_mpool_cleanup(&mp, 1);
+
+    EXPECT_EQ(5u, leak_count);
 }
 
 UCS_TEST_SKIP_COND_F(test_mpool, alloc_4g, RUNNING_ON_VALGRIND) {
     const unsigned elems_per_chunk = 128;
     const size_t elem_size         = 32 * UCS_MBYTE;
     ucs_mpool_ops_t mpool_ops = {ucs_mpool_chunk_malloc, ucs_mpool_chunk_free,
-                                 NULL, NULL};
+                                 NULL, NULL, NULL};
     ucs_mpool_t mp;
 
     ucs_status_t status = ucs_mpool_init(&mp, 0, header_size + elem_size,

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -124,6 +124,12 @@ UCS_TEST_F(test_string_buffer, appendf) {
     EXPECT_EQ("We, Created, The-Monster",
               std::string(ucs_string_buffer_cstr(&strb)));
 
+    ucs_string_buffer_reset(&strb);
+    EXPECT_EQ("", std::string(ucs_string_buffer_cstr(&strb)));
+
+    ucs_string_buffer_appendf(&strb, "%s", "Clean slate");
+    EXPECT_EQ("Clean slate", std::string(ucs_string_buffer_cstr(&strb)));
+
     ucs_string_buffer_cleanup(&strb);
 }
 


### PR DESCRIPTION
## Why
When memory pool object leaks, it's useful to know more details to understand why the object wasn't released