### PR TITLE
UCS/MEMTYPE_CACHE: add global memtype cache instance

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -541,7 +541,7 @@ ucp_proto_is_inline(ucp_ep_h ep, const ucp_memtype_thresh_t *max_eager_short,
 {
     return (ucs_likely(length <= max_eager_short->memtype_off) ||
             (length <= max_eager_short->memtype_on &&
-             ucp_memory_type_cache_is_empty(ep->worker->context)));
+             ucs_memtype_cache_is_empty()));
 }
 
 static UCS_F_ALWAYS_INLINE ucp_request_t*

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -131,7 +131,7 @@ ucp_proto_select_is_short(ucp_ep_h ep,
 {
     return ucs_likely(length <= proto_short->max_length_unknown_mem) ||
            ((length <= proto_short->max_length_host_mem) &&
-            ucp_memory_type_cache_is_empty(ep->worker->context));
+            ucs_memtype_cache_is_empty());
 }
 
 #endif

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -152,7 +152,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_stream_send_nbx,
         goto out;
     }
 
-    if (ucp_memory_type_cache_is_empty(ep->worker->context)) {
+    if (ucs_memtype_cache_is_empty()) {
         attr_mask = param->op_attr_mask &
                     (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
         if (ucs_likely(attr_mask == 0)) {

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -37,6 +37,7 @@ ucs_global_opts_t ucs_global_opts = {
     .debug_signo           = SIGHUP,
     .log_level_trigger     = UCS_LOG_LEVEL_FATAL,
     .warn_unused_env_vars  = 1,
+    .enable_memtype_cache  = 1,
     .async_max_events      = 64,
     .async_signo           = SIGALRM,
     .stats_dest            = "",
@@ -164,6 +165,10 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "Issue warning about UCX_ environment variables which were not used by the\n"
   "configuration parser.",
   ucs_offsetof(ucs_global_opts_t, warn_unused_env_vars), UCS_CONFIG_TYPE_BOOL},
+
+  {"MEMTYPE_CACHE", "y",
+   "Enable memory type (cuda/rocm) cache \n",
+   ucs_offsetof(ucs_global_opts_t, enable_memtype_cache), UCS_CONFIG_TYPE_BOOL},
 
  {"ASYNC_MAX_EVENTS", "1024", /* TODO remove this; resize mpmc */
   "Maximal number of events which can be handled from one context",

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -79,6 +79,9 @@ typedef struct {
     /* Max. events per context, will be removed in the future */
     unsigned                   async_max_events;
 
+    /** Memtype cache */
+    int                        enable_memtype_cache;
+
     /* Destination for statistics: udp:host:port / file:path / stdout
      */
     char                       *stats_dest;

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -23,6 +23,10 @@ typedef struct ucs_memtype_cache         ucs_memtype_cache_t;
 typedef struct ucs_memtype_cache_region  ucs_memtype_cache_region_t;
 
 
+/* The single global instance of memory type cache */
+extern ucs_memtype_cache_t *ucs_memtype_cache_global_instance;
+
+
 /* Memory information record */
 typedef struct ucs_memory_info {
     ucs_memory_type_t type;          /**< Memory type, use uint8 for compact size */
@@ -47,27 +51,8 @@ struct ucs_memtype_cache {
 
 
 /**
- * Create a memtype cache.
- *
- * @param [out] memtype_cache_p Filled with a pointer to the memtype cache.
- *
- * @return Error code.
- */
-ucs_status_t ucs_memtype_cache_create(ucs_memtype_cache_t **memtype_cache_p);
-
-
-/**
- * Destroy a memtype cache.
- *
- * @param [in]  memtype_cache       Memtype cache to destroy.
- */
-void ucs_memtype_cache_destroy(ucs_memtype_cache_t *memtype_cache);
-
-
-/**
  * Find if address range is in memtype cache.
  *
- * @param [in]  memtype_cache   Memtype cache to search.
  * @param [in]  address         Address to lookup.
  * @param [in]  size            Length of the memory.
  * @param [out] mem_info        Set to the memory info of the address range.
@@ -77,8 +62,7 @@ void ucs_memtype_cache_destroy(ucs_memtype_cache_t *memtype_cache);
  *
  * @return Error code.
  */
-ucs_status_t ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache,
-                                      const void *address, size_t size,
+ucs_status_t ucs_memtype_cache_lookup(const void *address, size_t size,
                                       ucs_memory_info_t *mem_info);
 
 
@@ -87,26 +71,22 @@ ucs_status_t ucs_memtype_cache_lookup(ucs_memtype_cache_t *memtype_cache,
  * Can be used after @ucs_memtype_cache_lookup returns UCM_MEM_TYPE_LAST, to
  * set the memory type after it was detected.
  *
- * @param [in]  memtype_cache   Memtype cache to update.
  * @param [in]  address         Start address to update.
  * @param [in]  size            Size of the memory to update.
  * @param [in]  mem_info        Set the memory info of the address range to this
  *                              value.
  */
-void ucs_memtype_cache_update(ucs_memtype_cache_t *memtype_cache,
-                              const void *address, size_t size,
+void ucs_memtype_cache_update(const void *address, size_t size,
                               const ucs_memory_info_t *mem_info);
 
 
 /**
  * Remove the address range from a memtype cache.
  *
- * @param [in]  memtype_cache   Memtype cache to remove.
  * @param [in]  address         Start address to remove.
  * @param [in]  size            Size of the memory to remove.
  */
-void ucs_memtype_cache_remove(ucs_memtype_cache_t *memtype_cache,
-                              const void *address, size_t size);
+void ucs_memtype_cache_remove(const void *address, size_t size);
 
 
 /**
@@ -115,6 +95,18 @@ void ucs_memtype_cache_remove(ucs_memtype_cache_t *memtype_cache,
  * @param [out] mem_info        Pointer to memory info structure.
  */
 void ucs_memory_info_set_host(ucs_memory_info_t *mem_info);
+
+
+/**
+ * Find if global memtype_cache is empty.
+ *
+ * @return 1 if empty 0 if otherwise.
+ */
+static UCS_F_ALWAYS_INLINE int ucs_memtype_cache_is_empty()
+{
+    return (ucs_memtype_cache_global_instance != NULL) &&
+           (ucs_memtype_cache_global_instance->pgtable.num_regions == 0);
+}
 
 END_C_DECLS
 

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -16,6 +16,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
+#include <ucs/memory/memtype_cache.h>
 #include <ucs/stats/stats.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/lib.h>

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -17,19 +17,14 @@ extern "C" {
 
 class test_memtype_cache : public ucs::test_with_param<ucs_memory_type_t> {
 protected:
-    test_memtype_cache() : m_memtype_cache(NULL) {
+    test_memtype_cache() {
     }
 
     virtual void init() {
         ucs::test_with_param<ucs_memory_type_t>::init();
-        ucs_status_t status = ucs_memtype_cache_create(&m_memtype_cache);
-        ASSERT_UCS_OK(status);
     }
 
     virtual void cleanup() {
-        if (m_memtype_cache != NULL) {
-            ucs_memtype_cache_destroy(m_memtype_cache);
-        }
 
         ucs::test_with_param<ucs_memory_type_t>::cleanup();
     }
@@ -43,8 +38,7 @@ protected:
         }
 
         ucs_memory_info_t mem_info;
-        ucs_status_t status = ucs_memtype_cache_lookup(m_memtype_cache, ptr,
-                                                       size, &mem_info);
+        ucs_status_t status = ucs_memtype_cache_lookup(ptr, size, &mem_info);
 
         if (!expect_found || (expected_type == UCS_MEMORY_TYPE_HOST)) {
             /* memory type should be not found or unknown */
@@ -290,7 +284,7 @@ protected:
         ucs_memory_info_t mem_info;
         mem_info.type    = mem_type;
         mem_info.sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-        ucs_memtype_cache_update(m_memtype_cache, ptr, size, &mem_info);
+        ucs_memtype_cache_update(ptr, size, &mem_info);
     }
 
     void memtype_cache_update(const mem_buffer &b) {
@@ -298,11 +292,8 @@ protected:
     }
 
     void memtype_cache_remove(const void *ptr, size_t size) {
-        ucs_memtype_cache_remove(m_memtype_cache, ptr, size);
+        ucs_memtype_cache_remove(ptr, size);
     }
-
-private:
-    ucs_memtype_cache_t *m_memtype_cache;
 };
 
 UCS_TEST_P(test_memtype_cache, basic) {


### PR DESCRIPTION
## Why ?
A single instance of memtype cache that can be accessed within UCP as well as UCTs. This allows UCTs themselves to avoid repeated lookups of memory attributes.

Review topic:
Disabling memtype cache in UCP land doesn't disable the same for UCTs with this PR -- i.e global instance continues to be used by UCTs. All intercepted regions in CUDA are marked unknown to begin with and they go through CUDA API to actually mark regions as CUDA or not. This means that entries in memtype cache are always valid (whether libcudart gets statically or dynamically linked). Are there issues in this logic? If not, should we change things in ucm/rocm as well?

cc @yosefe @bureddy 