### PR TITLE
UCP/API: extend ucp_ep_query for debug info string

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4554,7 +4554,9 @@ ucs_status_ptr_t ucp_worker_flush_nbx(ucp_worker_h worker,
 enum ucp_ep_attr_field {
     UCP_EP_ATTR_FIELD_NAME            = UCS_BIT(0), /**< UCP endpoint name */
     UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(1), /**< Sockaddr used by the endpoint */
-    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2)  /**< Sockaddr the endpoint is connected to */
+    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2), /**< Sockaddr the endpoint is connected to */
+    UCP_EP_ATTR_FIELD_DEBUG_STR       = UCS_BIT(3), /**< Available debug info in string format */
+    UCP_EP_ATTR_FIELD_DEBUG_STR_MAX   = UCS_BIT(4)  /**< Debug string buffer size */
 };
 
 
@@ -4595,6 +4597,18 @@ typedef struct ucp_ep_attr {
      * UCS_ERR_NOT_CONNECTED will be returned.
      */
     struct sockaddr_storage remote_sockaddr;
+
+     /**
+      * Available debug info in string format which fits into
+      * @ref ucp_ep_attr_t::debug_str_max.
+      */
+    char                    *debug_str;
+
+    /**
+     * Size of debug string buffer @ref ucp_ep_attr_t::debug_str including
+     * null-terminator.
+     */
+    size_t                  debug_str_max;
 } ucp_ep_attr_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4601,6 +4601,10 @@ typedef struct ucp_ep_attr {
      /**
       * Available debug info in string format which fits into
       * @ref ucp_ep_attr_t::debug_string_size.
+      * @note Available debug info and its format depends on compile time flags
+      *       and configuration, available hardware in run time and more, also
+      *       it can be changed in future releases for optimization or debugging
+      *       purposes.
       */
     char                    *debug_string;
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4552,11 +4552,11 @@ ucs_status_ptr_t ucp_worker_flush_nbx(ucp_worker_h worker,
  * present. It is used to enable backward compatibility support.
  */
 enum ucp_ep_attr_field {
-    UCP_EP_ATTR_FIELD_NAME            = UCS_BIT(0), /**< UCP endpoint name */
-    UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(1), /**< Sockaddr used by the endpoint */
-    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2), /**< Sockaddr the endpoint is connected to */
-    UCP_EP_ATTR_FIELD_DEBUG_STR       = UCS_BIT(3), /**< Available debug info in string format */
-    UCP_EP_ATTR_FIELD_DEBUG_STR_MAX   = UCS_BIT(4)  /**< Debug string buffer size */
+    UCP_EP_ATTR_FIELD_NAME              = UCS_BIT(0), /**< UCP endpoint name */
+    UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR    = UCS_BIT(1), /**< Sockaddr used by the endpoint */
+    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR   = UCS_BIT(2), /**< Sockaddr the endpoint is connected to */
+    UCP_EP_ATTR_FIELD_DEBUG_STRING      = UCS_BIT(3), /**< Available debug info in string format */
+    UCP_EP_ATTR_FIELD_DEBUG_STRING_SIZE = UCS_BIT(4)  /**< Debug string buffer size */
 };
 
 
@@ -4600,15 +4600,15 @@ typedef struct ucp_ep_attr {
 
      /**
       * Available debug info in string format which fits into
-      * @ref ucp_ep_attr_t::debug_str_max.
+      * @ref ucp_ep_attr_t::debug_string_size.
       */
-    char                    *debug_str;
+    char                    *debug_string;
 
     /**
-     * Size of debug string buffer @ref ucp_ep_attr_t::debug_str including
+     * Size of debug string buffer @ref ucp_ep_attr_t::debug_string including
      * null-terminator.
      */
-    size_t                  debug_str_max;
+    size_t                  debug_string_size;
 } ucp_ep_attr_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3151,11 +3151,10 @@ static ucs_status_t ucp_ep_query_sockaddr(ucp_ep_h ep, ucp_ep_attr_t *attr)
 
 static ucs_status_t ucp_ep_query_debug_str(ucp_ep_h ep, ucp_ep_attr_t *attr)
 {
-    if (attr->debug_str_max == 0ul) {
-        return UCS_ERR_INVALID_PARAM;
+    if (attr->debug_string_size > 0ul) {
+        attr->debug_string[0] = '\0';
     }
 
-    attr->debug_str[0] = '\0';
     return UCS_OK;
 }
 
@@ -3174,13 +3173,18 @@ ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr)
     if (attr->field_mask &
         (UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR | UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR)) {
         status = ucp_ep_query_sockaddr(ep, attr);
-        UCS_IF_STATUS_IS_NOT_OK(status, return status);
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
-    if (ucs_test_all_flags(attr->field_mask, UCP_EP_ATTR_FIELD_DEBUG_STR |
-                                             UCP_EP_ATTR_FIELD_DEBUG_STR_MAX)) {
+    if (ucs_test_all_flags(attr->field_mask,
+                           UCP_EP_ATTR_FIELD_DEBUG_STRING |
+                           UCP_EP_ATTR_FIELD_DEBUG_STRING_SIZE)) {
         status = ucp_ep_query_debug_str(ep, attr);
-        UCS_IF_STATUS_IS_NOT_OK(status, return status);
+        if (status != UCS_OK) {
+            return status;
+        }
     }
 
     return UCS_OK;

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -113,6 +113,12 @@ typedef void *ucs_status_ptr_t;
 #define UCS_STATUS_IS_ERR(_status) ((_status) < 0)
 
 
+#define UCS_IF_STATUS_IS_NOT_OK(_status, _action) \
+    if ((_status) != UCS_OK) { \
+        _action; \
+    }
+
+
 /**
  * @param  status UCS status code.
  *

--- a/src/ucs/type/status.h
+++ b/src/ucs/type/status.h
@@ -113,12 +113,6 @@ typedef void *ucs_status_ptr_t;
 #define UCS_STATUS_IS_ERR(_status) ((_status) < 0)
 
 
-#define UCS_IF_STATUS_IS_NOT_OK(_status, _action) \
-    if ((_status) != UCS_OK) { \
-        _action; \
-    }
-
-
 /**
  * @param  status UCS status code.
  *

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -560,12 +560,12 @@ public:
 
         std::vector<char> debug_info(UCS_KBYTE);
         memset(&attr, 0, sizeof(attr));
-        attr.field_mask    = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  |
-                             UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR |
-                             UCP_EP_ATTR_FIELD_DEBUG_STR       |
-                             UCP_EP_ATTR_FIELD_DEBUG_STR_MAX;
-        attr.debug_str     = &debug_info[0];
-        attr.debug_str_max = debug_info.size();
+        attr.field_mask        = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  |
+                                 UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR |
+                                 UCP_EP_ATTR_FIELD_DEBUG_STRING    |
+                                 UCP_EP_ATTR_FIELD_DEBUG_STRING_SIZE;
+        attr.debug_string      = &debug_info[0];
+        attr.debug_string_size = debug_info.size();
         status = ucp_ep_query(sender().ep(), &attr);
         ASSERT_UCS_OK(status);
 
@@ -576,8 +576,8 @@ public:
                               m_test_addr.get_port());
         EXPECT_EQ(m_test_addr, attr.local_sockaddr);
 
-        std::string debug_str(attr.debug_str);
-        EXPECT_LT(debug_str.length(), attr.debug_str_max);
+        std::string debug_str(attr.debug_string);
+        EXPECT_LT(debug_str.length(), attr.debug_string_size);
         UCS_TEST_MESSAGE << "EP debug string: \"" << debug_str << "\"";
     }
 


### PR DESCRIPTION
## What
Add debug info string to ucp_ep_query() API

## Why
Show the internal state of the connection, including underlying transport state, for example:
- When the application created new connection
- When the application detected a problem with a connects, such as no progress / "stuck" requests
