### PR TITLE
UCP/RMA: Return UCS_OK when status != UCS_ERR_NO_RESOURCE

### DIFF
--- a/src/ucp/rma/amo_basic.c
+++ b/src/ucp/rma/amo_basic.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -24,6 +25,7 @@ ucs_status_t ucp_amo_check_send_status(ucp_request_t *req, ucs_status_t status)
     /* Complete for UCS_OK and unexpected errors */
     if (status != UCS_ERR_NO_RESOURCE) {
         ucp_request_complete_send(req, status);
+        return UCS_OK;
     }
     return status;
 }

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -77,6 +78,7 @@ ucp_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
              * - with error if a fetch/post operation
              * - either with error or with success if a post operation */
             ucp_request_complete_send(req, status);
+            return UCS_OK;
         }
     }
 

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -83,6 +84,7 @@ static ucs_status_t ucp_rma_sw_progress_get(uct_pending_req_t *self)
         if (ucs_unlikely(status != UCS_ERR_NO_RESOURCE)) {
             /* completed with error */
             ucp_request_complete_send(req, status);
+            return UCS_OK;
         }
     }
 


### PR DESCRIPTION
## What
The error code returned by `req->send.uct.func()` is not `UCS_OK`, `UCS_INPROGRESS` and `UCS_ERR_NO_RESOURCE`, that cause process aborts.
https://github.com/openucx/ucx/blob/797596d8582b85434129b5795405999983f5e5de/src/ucp/core/ucp_request.inl#L318

In my case, TCP Iface is used to simulate RMA, and it returns `UCS_ERR_CONNECTION_RESET`.

## Why ?
The following code assumes that only three error codes will be returned, and other error codes will cause fatal.
https://github.com/openucx/ucx/blob/797596d8582b85434129b5795405999983f5e5de/src/ucp/core/ucp_request.inl#L312-L331

## How ?
`UCS_OK` should be returned when the request fails not because there are no resources.
