### PR TITLE
RPM/POST: Don't create $sysconfdir/ucx at post-install step

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -139,7 +139,6 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.a
 
 %post
 /sbin/ldconfig
-mkdir -p %{_sysconfdir}/ucx
 
 %postun -p /sbin/ldconfig
 


### PR DESCRIPTION
## Why
Fix UCX RPM install issue during kickstart if 'coreutils' not installed yet
Internal issue [link](https://redmine.mellanox.com/issues/2780194)