### PR TITLE
UCP/CORE: Do not fill user_hdr in AM handler when length is 0

### DIFF
--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -462,6 +462,7 @@ ucs_status_t ucp_am_data_cb(void *arg, const void *header, size_t header_length,
 
     if ((header != NULL) || (header_length != 0)) {
         fprintf(stderr, "received unexpected header, length %ld", header_length);
+        abort();
     }
 
     am_data_desc.complete = 1;

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1199,7 +1199,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
     void *data               = am_hdr + 1;
     size_t data_length       = total_length -
                                (sizeof(*am_hdr) + am_hdr->header_length);
-    void *user_hdr           = UCS_PTR_BYTE_OFFSET(data, data_length);
+    void *user_hdr           = (user_hdr_size > 0) ? UCS_PTR_BYTE_OFFSET(data, data_length) :
+                               NULL;
     ucs_status_t desc_status = UCS_OK;
     ucs_status_t status;
 


### PR DESCRIPTION
## What
Set `user_hdr` to `NULL` if `user_hdr_size` is 0. Verify it in `ucp_client_server`.

## Why ?
Current behavior is a bug.
