### PR TITLE
UCP/STREAM: Pass endpoint failure status to stream receive completion

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1074,7 +1074,7 @@ void ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
     /* The EP can be closed from last completion callback */
     ucp_ep_discard_lanes(ucp_ep, status);
     ucp_ep_reqs_purge(ucp_ep, status);
-    ucp_stream_ep_cleanup(ucp_ep);
+    ucp_stream_ep_cleanup(ucp_ep, status);
 
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
         if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
@@ -1174,7 +1174,7 @@ void ucp_ep_disconnected(ucp_ep_h ep, int force)
 
     ucp_ep_cm_slow_cbq_cleanup(ep);
 
-    ucp_stream_ep_cleanup(ep);
+    ucp_stream_ep_cleanup(ep, UCS_ERR_CANCELED);
     ucp_am_ep_cleanup(ep);
     ucp_ep_reqs_purge(ep, UCS_ERR_CANCELED);
 

--- a/src/ucp/stream/stream.h
+++ b/src/ucp/stream/stream.h
@@ -27,7 +27,7 @@ typedef struct {
 
 void ucp_stream_ep_init(ucp_ep_h ep);
 
-void ucp_stream_ep_cleanup(ucp_ep_h ep);
+void ucp_stream_ep_cleanup(ucp_ep_h ep, ucs_status_t status);
 
 void ucp_stream_ep_activate(ucp_ep_h ep);
 

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -480,7 +480,7 @@ void ucp_stream_ep_init(ucp_ep_h ep)
     }
 }
 
-void ucp_stream_ep_cleanup(ucp_ep_h ep)
+void ucp_stream_ep_cleanup(ucp_ep_h ep, ucs_status_t status)
 {
     ucp_ep_ext_proto_t* ep_ext;
     ucp_request_t *req;
@@ -508,7 +508,7 @@ void ucp_stream_ep_cleanup(ucp_ep_h ep)
     while (!ucs_queue_is_empty(&ep_ext->stream.match_q)) {
         req = ucs_queue_head_elem_non_empty(&ep_ext->stream.match_q,
                                             ucp_request_t, recv.queue);
-        ucp_request_complete_stream_recv(req, ep_ext, UCS_ERR_CANCELED);
+        ucp_request_complete_stream_recv(req, ep_ext, status);
     }
 }
 


### PR DESCRIPTION
## Why
So that stream receive callback will have the endpoint failure status