### PR TITLE
APPS/IO-DEMO: Improve assertion of send/completed bytes in server_info

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -61,7 +61,8 @@ EmptyCallback* EmptyCallback::get() {
 
 bool UcxLog::use_human_time = false;
 
-UcxLog::UcxLog(const char* prefix, bool enable)
+UcxLog::UcxLog(const char* prefix, bool enable, std::ostream *os, bool abort) :
+        _os(os), _abort(abort)
 {
     if (!enable) {
         _ss = NULL;
@@ -86,9 +87,12 @@ UcxLog::UcxLog(const char* prefix, bool enable)
 UcxLog::~UcxLog()
 {
     if (_ss != NULL) {
-        (*_ss) << std::endl;
-        std::cout << (*_ss).str();
+        (*_os) << (*_ss).str() << std::endl;
         delete _ss;
+
+        if (_abort) {
+            abort();
+        }
     }
 }
 

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -59,7 +59,8 @@ class UcxLog {
 public:
     static bool use_human_time;
 
-    UcxLog(const char* prefix, bool enable = true);
+    UcxLog(const char* prefix, bool enable = true,
+           std::ostream *os = &std::cout, bool abort = false);
     ~UcxLog();
 
     template<typename T>
@@ -72,6 +73,8 @@ public:
 
 private:
     std::stringstream        *_ss;
+    std::ostream             *_os;
+    bool                     _abort;
 };
 
 


### PR DESCRIPTION
## What

Improve assertion of send/completed bytes in server_info.

## Why ?

To improve debugging of issues related to `bytes_sent`/`bytes_completed`.

## How ?

1. Update `commit_operation()` to check that `bytes_completed < bytes_sent` if no zero-length operations are allowed and otherwise - `bytes_completed <= bytes_sent`.
2. Update `handle_operation_completion()` to check that `bytes_completed == bytes_sent` if no uncompleted operations and otherwise - if no zero-length operations are allowed, then `bytes_completed < bytes_sent`, else - `bytes_completed <= bytes_sent`.