### PR TITLE
UCT/SM: Adjust SCOPY cost to reflect expense over MM

### DIFF
--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -61,7 +61,13 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
                                       sizeof(ucs_cma_iface_ext_device_addr_t);
     iface_attr->bandwidth.dedicated = iface->super.super.config.bandwidth;
     iface_attr->bandwidth.shared    = 0;
-    iface_attr->overhead            = 0.4e-6; /* 0.4 us */
+
+    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM) {
+        iface_attr->overhead        = 6e-6;
+    } else {
+        iface_attr->overhead        = 2e-6;
+    }
+
     iface_attr->cap.flags          |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
                                       UCT_IFACE_FLAG_EP_CHECK;
 

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -34,7 +34,12 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     iface_attr->iface_addr_len      = 0;
     iface_attr->bandwidth.shared    = iface->super.super.config.bandwidth;
     iface_attr->bandwidth.dedicated = 0;
-    iface_attr->overhead            = 0.25e-6; /* 0.25 us */
+
+    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM) {
+        iface_attr->overhead        = 6e-6;
+    } else {
+        iface_attr->overhead        = 2e-6;
+    }
 
     return UCS_OK;
 }


### PR DESCRIPTION
## What
Adjust knem and cma overhead estimated cost

## Why ?
This way new protocol selection logic will select MM protocols for small messages providing better performance 

## How ?
Calculation done basing on osu_bw measurements on Fujitsu ARM and x86 setups
