### PR TITLE
UCT: Fix test_ib runs without devices bug

### DIFF
--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -734,7 +734,9 @@ UCS_TEST_F(test_uct_ib_sl_utils, query_ooo_sl_mask) {
     ucs_status_t status;
 
     ib_device_list = ibv_get_device_list(&num_devices);
-    ASSERT_TRUE(ib_device_list != NULL);
+    if (ib_device_list == NULL) {
+        num_devices = 0;
+    }
 
     for (int i = 0; i < num_devices; ++i) {
         const char *dev_name = ibv_get_device_name(ib_device_list[i]);
@@ -782,11 +784,14 @@ UCS_TEST_F(test_uct_ib_sl_utils, query_ooo_sl_mask) {
         }
 
         uct_ib_md_close(md);
+
 out_md_config_release:
         uct_config_release(md_config);
     }
 
-    ibv_free_device_list(ib_device_list);
+    if (ib_device_list != NULL) {
+        ibv_free_device_list(ib_device_list);
+    }
 }
 #endif
 


### PR DESCRIPTION
UCT: Fix test_ib runs without devices bug

- Fixes a bug in test_ib that causes the test to fail and stop running
  when the ib_device_list is empty.
