### PR TITLE
AZP: use per build directory for artifacts.

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -231,6 +231,8 @@ stages:
        # Perform test builds on relevant distributions.
       - job: Distros
         displayName: Build for
+        workspace:
+          clean: all
         pool:
           name: MLNX
           demands:
@@ -278,6 +280,7 @@ stages:
               CONTAINER: ubuntu2004
         steps:
           - checkout: none
+            clean: true
           - task: DownloadBuildArtifacts@0
             displayName: 'Download Build Artifacts'
             inputs:


### PR DESCRIPTION
## What
Use per build directory for downloading artifacts and build ucx-1.11

## Why ?
Fixes 
```
+ git clone --depth 1 -b v1.11.x https://github.com/openucx/ucx.git /scrap/azure/agent-07/AZP_WORKSPACE/1/s/ucx-1.11 
fatal: destination path '/scrap/azure/agent-07/AZP_WORKSPACE/1/s/ucx-1.11' already exists and is not an empty directory. 
```
