### PR TITLE
TEST/GTEST: Don't open too many files

### DIFF
--- a/test/gtest/ucp/test_ucp_rma_mt.cc
+++ b/test/gtest/ucp/test_ucp_rma_mt.cc
@@ -38,9 +38,10 @@ public:
 };
 
 UCS_TEST_P(test_ucp_rma_mt, put_get) {
+    const unsigned num_threads = mt_num_threads();
     ucs_status_t st;
-    uint64_t orig_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
-    uint64_t target_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
+    uint64_t orig_data[num_threads] GTEST_ATTRIBUTE_UNUSED_;
+    uint64_t target_data[num_threads] GTEST_ATTRIBUTE_UNUSED_;
 
     ucp_mem_map_params_t params;
     ucp_mem_h memh;
@@ -50,7 +51,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
                         UCP_MEM_MAP_PARAM_FIELD_LENGTH |
                         UCP_MEM_MAP_PARAM_FIELD_FLAGS;
     params.address    = memheap;
-    params.length     = sizeof(uint64_t) * MT_TEST_NUM_THREADS;
+    params.length     = sizeof(uint64_t) * num_threads;
     params.flags      = get_variant_value();
 
     st = ucp_mem_map(receiver().ucph(), &params, &memh);
@@ -63,12 +64,12 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
     ASSERT_UCS_OK(st);
 
     std::vector<ucp_rkey_h> rkey;
-    rkey.resize(MT_TEST_NUM_THREADS);
+    rkey.resize(num_threads);
 
     /* test parallel rkey unpack */
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         int worker_index = 0;
         if (get_variant_thread_type() == MULTI_THREAD_CONTEXT) {
             worker_index = i;
@@ -83,14 +84,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test blocking PUT */
 
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         orig_data[i] = 0xdeadbeefdeadbeef + 10 * i;
         target_data[i] = 0;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         int worker_index = 0;
 
         if (get_variant_thread_type() == MULTI_THREAD_CONTEXT) {
@@ -110,14 +111,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test nonblocking PUT */
 
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         orig_data[i] = 0xdeadbeefdeadbeef + 10 * i;
         target_data[i] = 0;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         ucs_status_t status;
         int worker_index = 0;
 
@@ -136,14 +137,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test blocking GET */
 
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         orig_data[i] = 0;
         target_data[i] = 0xdeadbeefdeadbeef + 10 * i;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         int worker_index = 0;
 
         if (get_variant_thread_type() == MULTI_THREAD_CONTEXT) {
@@ -163,14 +164,14 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
     /* test nonblocking GET */
 
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         orig_data[i] = 0;
         target_data[i] = 0xdeadbeefdeadbeef + 10 * i;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         ucs_status_t status;
         int worker_index = 0;
 
@@ -190,7 +191,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         ucp_rkey_destroy(rkey[i]);
     }
 #endif

--- a/test/gtest/ucp/test_ucp_tag_mt.cc
+++ b/test/gtest/ucp/test_ucp_tag_mt.cc
@@ -38,18 +38,19 @@ public:
 };
 
 UCS_TEST_P(test_ucp_tag_mt, send_recv) {
-    uint64_t            send_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
-    uint64_t            recv_data[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
-    ucp_tag_recv_info_t info[MT_TEST_NUM_THREADS] GTEST_ATTRIBUTE_UNUSED_;
+    const unsigned num_threads = mt_num_threads();
+    uint64_t send_data[num_threads] GTEST_ATTRIBUTE_UNUSED_;
+    uint64_t recv_data[num_threads] GTEST_ATTRIBUTE_UNUSED_;
+    ucp_tag_recv_info_t info[num_threads] GTEST_ATTRIBUTE_UNUSED_;
 
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         send_data[i] = 0xdeadbeefdeadbeef + 10 * i;
         recv_data[i] = 0;
     }
 
 #if _OPENMP && ENABLE_MT
 #pragma omp parallel for
-    for (int i = 0; i < MT_TEST_NUM_THREADS; i++) {
+    for (int i = 0; i < num_threads; i++) {
         ucs_status_t status;
         int worker_index = 0;
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -24,12 +24,6 @@
 #include "omp.h"
 #endif
 
-#if _OPENMP && ENABLE_MT
-#define MT_TEST_NUM_THREADS omp_get_max_threads()
-#else
-#define MT_TEST_NUM_THREADS 4
-#endif
-
 
 namespace ucp {
 extern const uint32_t MAGIC;
@@ -300,6 +294,10 @@ protected:
 
     // Return context parameters of the current test variant
     const ucp_params_t& get_variant_ctx_params() const;
+
+    // Return maximal UCP threads in current environment, assuming each thread
+    // can create 2 workers
+    static unsigned mt_num_threads();
 
     static void err_handler_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {
         entity *e = reinterpret_cast<entity*>(arg);


### PR DESCRIPTION
## Why
Fix failures in gtest when running on 28-core machine with 2 RDMA NICs:

<details>
<summary>

`make -C build-devel/test/gtest test GTEST_FILTER=rc_mlx5/test_uct_peer_failure_multiple.test*:shm_ib/test_ucp_rma_mt.put_get*:shm_ib/test_ucp_tag_mt.send_recv*`

</summary>
<p>

```
[     INFO ] ugni is not available
[     INFO ] ugni,cuda_copy,rocm_copy is not available
[     INFO ] Using random seed of 20954
Note: Google Test filter = rc_mlx5/test_uct_peer_failure_multiple.test*:shm_ib/test_ucp_rma_mt.put_get*:shm_ib/test_ucp_tag_mt.send_recv*
Note: Randomizing tests' orders with a seed of 95248 .
[==========] Running 10 tests from 3 test cases.
[----------] Global test environment set-up.
[----------] 4 tests from shm_ib/test_ucp_tag_mt
[ RUN      ] shm_ib/test_ucp_tag_mt.send_recv/0 <shm,ib/req_int,mt_context>
[1629999582.816013] [jazz25:192298:0]        ib_iface.c:844  UCX  ERROR there is no valid pkey to use on mlx5_0:1
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/ucp/ucp_test.cc:563: Failure
Error: No such element
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/common/test.cc:353: Failure
Failed
Got 1 errors and 0 warnings during the test
[     INFO ] < /hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../src/uct/ib/base/ib_iface.c:844 there is no valid pkey to use on mlx5_0:1 >
[  FAILED  ] shm_ib/test_ucp_tag_mt.send_recv/0, where GetParam() = shm,ib/req_int,mt_context (6345 ms)
[ RUN      ] shm_ib/test_ucp_tag_mt.send_recv/3 <shm,ib/req_ext,mt_worker>
[       OK ] shm_ib/test_ucp_tag_mt.send_recv/3 (601 ms)
[ RUN      ] shm_ib/test_ucp_tag_mt.send_recv/2 <shm,ib/req_int,mt_worker>
[       OK ] shm_ib/test_ucp_tag_mt.send_recv/2 (592 ms)
[ RUN      ] shm_ib/test_ucp_tag_mt.send_recv/1 <shm,ib/req_ext,mt_context>
[1629999590.378681] [jazz25:192298:0]        ib_iface.c:844  UCX  ERROR there is no valid pkey to use on mlx5_0:1
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/ucp/ucp_test.cc:563: Failure
Error: No such element
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/common/test.cc:353: Failure
Failed
Got 1 errors and 0 warnings during the test
[     INFO ] < /hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../src/uct/ib/base/ib_iface.c:844 there is no valid pkey to use on mlx5_0:1 >
[  FAILED  ] shm_ib/test_ucp_tag_mt.send_recv/1, where GetParam() = shm,ib/req_ext,mt_context (6338 ms)
[----------] 4 tests from shm_ib/test_ucp_tag_mt (13876 ms total)

[----------] 2 tests from shm_ib/test_ucp_rma_mt
[ RUN      ] shm_ib/test_ucp_rma_mt.put_get/0 <shm,ib>
[1629999596.606578] [jazz25:192298:0]        ib_iface.c:844  UCX  ERROR there is no valid pkey to use on mlx5_0:1
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/ucp/ucp_test.cc:563: Failure
Error: No such element
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/common/test.cc:353: Failure
Failed
Got 1 errors and 0 warnings during the test
[     INFO ] < /hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../src/uct/ib/base/ib_iface.c:844 there is no valid pkey to use on mlx5_0:1 >
[  FAILED  ] shm_ib/test_ucp_rma_mt.put_get/0, where GetParam() = shm,ib (6174 ms)
[ RUN      ] shm_ib/test_ucp_rma_mt.put_get/1 <shm,ib>
[       OK ] shm_ib/test_ucp_rma_mt.put_get/1 (523 ms)
[----------] 2 tests from shm_ib/test_ucp_rma_mt (6697 ms total)

[----------] 4 tests from rc_mlx5/test_uct_peer_failure_multiple
[ RUN      ] rc_mlx5/test_uct_peer_failure_multiple.test/0 <rc_mlx5/mlx5_0:1>
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/uct/uct_test.cc:850: Failure
Error: Input/output error
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/0, where GetParam() = rc_mlx5/mlx5_0:1 (7876 ms)
[ RUN      ] rc_mlx5/test_uct_peer_failure_multiple.test/2 <rc_mlx5/mlx5_3:1>
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/uct/uct_test.cc:850: Failure
Error: Input/output error
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/2, where GetParam() = rc_mlx5/mlx5_3:1 (10968 ms)
[ RUN      ] rc_mlx5/test_uct_peer_failure_multiple.test/1 <rc_mlx5/mlx5_2:1>
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/uct/uct_test.cc:850: Failure
Error: Input/output error
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/1, where GetParam() = rc_mlx5/mlx5_2:1 (11097 ms)
[ RUN      ] rc_mlx5/test_uct_peer_failure_multiple.test/3 <rc_mlx5/mlx5_4:1>
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/uct/uct_test.cc:850: Failure
Error: Input/output error
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/3, where GetParam() = rc_mlx5/mlx5_4:1 (8365 ms)
[----------] 4 tests from rc_mlx5/test_uct_peer_failure_multiple (38306 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 3 test cases ran. (58879 ms total)
[  PASSED  ] 3 tests.
[  FAILED  ] 7 tests, listed below:
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/0, where GetParam() = rc_mlx5/mlx5_0:1
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/2, where GetParam() = rc_mlx5/mlx5_3:1
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/1, where GetParam() = rc_mlx5/mlx5_2:1
[  FAILED  ] rc_mlx5/test_uct_peer_failure_multiple.test/3, where GetParam() = rc_mlx5/mlx5_4:1
[  FAILED  ] shm_ib/test_ucp_rma_mt.put_get/0, where GetParam() = shm,ib
[  FAILED  ] shm_ib/test_ucp_tag_mt.send_recv/0, where GetParam() = shm,ib/req_int,mt_context
[  FAILED  ] shm_ib/test_ucp_tag_mt.send_recv/1, where GetParam() = shm,ib/req_ext,mt_context
```

</p>
</details>