### PR TITLE
AZP: Fix jucx publish. [v.1.11]

### DIFF
--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -66,7 +66,7 @@ jobs:
           # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
           # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
           MAVEN_VERSION=${TAG:1}
-          make -C bindings/java/src/main/native/ ${{ variables.target }} \
+          make -C bindings/java/src/main/native/ ${{ parameters.target }} \
               ARGS="--settings ${{ parameters.temp_cfg }}" JUCX_VERSION=${MAVEN_VERSION}
         displayName: Publish JUCX jar to maven central
         env:


### PR DESCRIPTION
## What
Fixes pipeline to publish JUCX

## Why ?
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=23637&view=logs&j=3b8f64b7-a2e1-51c0-437a-a2837672d5dc&t=8e177047-27c9-5572-82a4-c49c81f6b0fa - it doesn't call target of `publish-release` so no jar published.


For 1.11 fix - will port to master. Would need to do 1.11-rc4 to make sure it's working