### PR TITLE
APPS/IO-DEMO: Use C-string constant instead of std::string

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1386,7 +1386,7 @@ public:
     }
 
     void check_counters(const server_info_t& server_info, io_op_t op,
-                        const std::string &type_str)
+                        const char *type_str)
     {
         ASSERTV(server_info.num_completed[op] < server_info.num_sent[op])
                 << type_str << ": op=" << io_op_names[op] << " num_completed="


### PR DESCRIPTION
## What

Use C-string constant instead of std::string.

## Why ?

To not pay for memory allocation/release on a heap, since `check_counters()` method is called on data path.
`std::string_view` couldn't be used, since C++17 is not used by UCX.

## How ?

Replce `const std::string&` by `const char*`.