### PR TITLE
UCP/KEEPALIVE: Fix assertion that keepalive done too soon on same ep

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2953,6 +2953,9 @@ int ucp_ep_do_keepalive(ucp_ep_h ep, ucs_time_t now)
         return 0;
     }
 
+    ucs_trace("worker %p: keepalive done on ep %p, now: <%lf sec>", worker, ep,
+              ucs_time_to_sec(now));
+
 #if UCS_ENABLE_ASSERT
     ucs_assertv((now - ucp_ep_ext_control(ep)->ka_last_round) >=
                         worker->context->config.ext.keepalive_interval,


### PR DESCRIPTION
## Why

Fix this:
```
Assertion `(now - ucp_ep_ext_control(ep)->ka_last_round) >= worker->context->config.ext.keepalive_interval'
```

As a result of https://github.com/openucx/ucx/pull/7301, we can restart an active keepalive round which leads to this assertion.
This PR will make sure that if we are during a keepalive round and iter reached end - the round will be finished, and we are not during a round - no action will be taken.