### PR TITLE
UCP/CORE: Do not fill user_hdr in ucp_am_handle_unfinished when length is 0

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1369,7 +1369,8 @@ ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *first_rdesc,
     am_id           = hdr->am_id;
     user_hdr_length = hdr->header_length;
     total_size      = first_ftr->total_size;
-    user_hdr        = UCS_PTR_BYTE_OFFSET(payload, total_size);
+    user_hdr        = (user_hdr_length > 0) ? UCS_PTR_BYTE_OFFSET(payload, total_size) :
+                      NULL;
 
     /* Need to reinit descriptor, because we have two headers between rdesc and
      * the data. In ucp_am_data_release() and ucp_am_recv_data_nbx() functions,

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -383,6 +383,11 @@ protected:
     void check_header(const void *header, size_t header_length)
     {
         std::string check_pattern((char*)header, header_length);
+        
+        if (header_length == 0) {
+            ASSERT_TRUE(header == NULL);
+        }
+        
         EXPECT_EQ(check_pattern, m_hdr);
     }
 
@@ -634,6 +639,11 @@ UCS_TEST_P(test_ucp_am_nbx, max_am_header)
 UCS_TEST_P(test_ucp_am_nbx, zero_send)
 {
     test_am_send_recv(0, max_am_hdr());
+}
+
+UCS_TEST_P(test_ucp_am_nbx, zero_header)
+{
+    test_am_send_recv(0, 0);
 }
 
 UCS_TEST_P(test_ucp_am_nbx, rx_persistent_data)


### PR DESCRIPTION
…h is 0

## What
Fix incorrect behavior