### PR TITLE
APPS/IO_DEMO: Don't validate msg if connection failed

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1121,6 +1121,8 @@ public:
                     << msg->sn << " data size " << msg->data_size
                     << " conn " << conn;
 
+        assert(conn->ucx_status() == UCS_OK);
+
         if (opts().validate) {
             assert(length == opts().iomsg_size);
             validate(msg, length);
@@ -1143,6 +1145,8 @@ public:
         VERBOSE_LOG << "got io (AM) message " << io_op_names[msg->op] << " sn "
                     << msg->sn << " data size " << msg->data_size
                     << " conn " << conn;
+
+        assert(conn->ucx_status() == UCS_OK);
 
         if (opts().validate) {
             assert(length == opts().iomsg_size);
@@ -1612,18 +1616,16 @@ public:
                     << msg->sn << " data size " << msg->data_size
                     << " conn " << conn;
 
+        assert(conn->ucx_status() == UCS_OK);
+
         if (msg->op >= IO_COMP_MIN) {
             assert(msg->op == IO_WRITE_COMP);
 
             size_t server_index = get_active_server_index(conn);
-            if (server_index < _server_info.size()) {
-                handle_operation_completion(server_index, IO_WRITE,
-                                            msg->data_size);
-            } else {
-                /* do not increment _num_completed here since we decremented
-                 * _num_sent on connection termination */
-                LOG << "got WRITE completion on failed connection";
-            }
+            assert(server_index < _server_info.size());
+
+            handle_operation_completion(server_index, IO_WRITE,
+                                        msg->data_size);
         }
     }
 
@@ -1636,7 +1638,11 @@ public:
                     << msg->sn << " data size " << msg->data_size
                     << " conn " << conn;
 
+        assert(conn->ucx_status() == UCS_OK);
         assert(msg->op >= IO_COMP_MIN);
+
+        size_t server_index = get_active_server_index(conn);
+        assert(server_index < _server_info.size());
 
         if (opts().validate) {
             assert(length == opts().iomsg_size);
@@ -1644,7 +1650,6 @@ public:
         }
 
         // Client can receive IO_WRITE_COMP or IO_READ_COMP only
-        size_t server_index = get_active_server_index(conn);
         if (msg->op == IO_WRITE_COMP) {
             assert(msg->op == IO_WRITE_COMP);
             handle_operation_completion(server_index, IO_WRITE,

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -456,8 +456,10 @@ void UcxContext::progress_io_message()
             return;
         }
 
-        dispatch_io_message(conn, &_iomsg_buffer[0],
-                            _iomsg_recv_request->recv_length);
+        if (conn->ucx_status() == UCS_OK) {
+            dispatch_io_message(conn, &_iomsg_buffer[0],
+                                _iomsg_recv_request->recv_length);
+        }
     }
     request_release(_iomsg_recv_request);
     recv_io_message();
@@ -695,9 +697,10 @@ ucs_status_t UcxContext::am_recv_callback(void *arg, const void *header,
 
     UcxConnection *conn = iter->second;
 
-    UcxAmDesc data_desc(data, param);
-
-    self->dispatch_am_message(conn, header, header_length, data_desc);
+    if (conn->ucx_status() == UCS_OK) {
+        UcxAmDesc data_desc(data, param);
+        self->dispatch_am_message(conn, header, header_length, data_desc);
+    }
 
     return UCS_OK;
 }


### PR DESCRIPTION
## What

Don't validate msg if connection failed.

## Why ?

The message may be incomplete.

## How ?

1. Move calling `validate()` method under `UcxConnection::ucx_status() == UCS_OK` check.
2. Replace checking `server_index < _server_info.size()` by assertion, where `server_index` is the result of `get_active_server_index(conn)`.