### PR TITLE
UCP/CORE: Allow calling user's error callback when error mode is NONE

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2830,7 +2830,6 @@ void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status)
 {
     ucs_assert(ucp_ep_ext_control(ep)->err_cb != NULL);
-    ucs_assert(ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_NONE);
 
     /* Do not invoke error handler if the EP has been closed by user, or error
      * callback already called */


### PR DESCRIPTION
## What

Allow calling user's error callback when error mode is NONE.

## Why ?

To not catch the following assertion:
```
[ddf9089ce11d:20961:0:20961]      ucp_ep.c:2833 Assertion `ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_NONE' failed
==== backtrace (tid:  20961) ====
 0  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_handle_error+0x13c) [0x7f8c7a4f4adc]
 1  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_fatal_error_message+0x58) [0x7f8c7a4f1878]
 2  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_fatal_error_format+0xd1) [0x7f8c7a4f1a01]
 3  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(ucp_ep_invoke_err_cb+0x1cb) [0x7f8c7a1db6eb]
 4  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(ucp_ep_set_failed+0x1f2) [0x7f8c7a1e05c2]
 5  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(+0x4f3da) [0x7f8c7a1f63da]
 6  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(uct_tcp_ep_set_failed+0x61) [0x7f8c79f84081]
 7  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(+0x25a8f) [0x7f8c79f86a8f]
 8  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(+0x2a284) [0x7f8c79f8b284]
 9  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_event_set_wait+0xf1) [0x7f8c7a502401]
10  /__w/1/s/build-test/src/uct/.libs/libuct.so.0(uct_tcp_iface_progress+0x74) [0x7f8c79f8b194]
11  /__w/1/s/build-test/src/ucp/.libs/libucp.so.0(ucp_worker_progress+0x6a) [0x7f8c7a1f422a]
12  /__w/1/s/build-test/examples/.libs/lt-ucp_hello_world() [0x402108]
13  /lib64/libc.so.6(__libc_start_main+0xf5) [0x7f8c78e60555]
14  /__w/1/s/build-test/examples/.libs/lt-ucp_hello_world() [0x402800]
=================================
```

## How ?

Update `ucp_ep_set_failed()`/`ucp_ep_invoke_err_cb()` to not fail the assertion when no peer failure error mode is set by the user, but error callback was specified.