### PR TITLE
UCP/DATATYPE: Reduce memory reg/dereg overhead for new protocols

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -111,7 +111,7 @@ static UCS_F_ALWAYS_INLINE uct_mem_h
 ucp_memh_map2uct(const uct_mem_h *uct, ucp_md_map_t md_map, ucp_md_index_t md_idx)
 {
     if (!(md_map & UCS_BIT(md_idx))) {
-        return NULL;
+        return UCT_MEM_HANDLE_NULL;
     }
 
     return uct[ucs_bitmap2idx(md_map, md_idx)];

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -16,6 +16,134 @@
          _length += ucp_datatype_iter_iov_at(_dt_iter, _iov_index++)->length)
 
 
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_mem_dereg_some(ucp_context_h context,
+                                 ucp_md_map_t keep_md_map,
+                                 const ucp_dt_reg_t *dt_reg,
+                                 uct_mem_h *prev_memh)
+{
+    ucp_md_index_t md_index, memh_index, memh_index_old;
+    ucs_status_t status;
+    uct_mem_h uct_memh;
+
+    memh_index_old = 0;
+    memh_index     = 0;
+    ucs_for_each_bit(md_index, dt_reg->md_map) {
+        uct_memh = dt_reg->memh[memh_index++];
+        if (keep_md_map & UCS_BIT(md_index)) {
+            prev_memh[memh_index_old++] = uct_memh;
+        } else if (ucs_likely(uct_memh != UCT_MEM_HANDLE_NULL)) {
+            /* memh not needed and registered - deregister it */
+            ucs_trace("de-registering memh=%p from md[%d]=%s", uct_memh,
+                      md_index, context->tl_mds[md_index].rsc.md_name);
+            status = uct_md_mem_dereg(context->tl_mds[md_index].md, uct_memh);
+            if (ucs_unlikely(status != UCS_OK)) {
+                ucs_warn("failed to dereg from md[%d]=%s: %s", md_index,
+                         context->tl_mds[md_index].rsc.md_name,
+                         ucs_status_string(status));
+            }
+        }
+    }
+}
+
+static void UCS_F_NOINLINE ucp_datatype_iter_mem_dereg_some_noninline(
+        ucp_context_h context, ucp_md_map_t keep_md_map,
+        const ucp_dt_reg_t *dt_reg, uct_mem_h *prev_memh)
+{
+    ucp_datatype_iter_mem_dereg_some(context, keep_md_map, dt_reg, prev_memh);
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, ucp_datatype_iter_mem_reg_internal,
+                 (context, address, length, uct_flags, mem_type, md_map,
+                  dt_reg),
+                 ucp_context_h context, void *address, size_t length,
+                 unsigned uct_flags, ucs_memory_type_t mem_type,
+                 ucp_md_map_t md_map, ucp_dt_reg_t *dt_reg)
+{
+    uct_mem_h tmp_reg[UCP_MAX_OP_MDS] = {UCT_MEM_HANDLE_NULL}; /* cppcheck */
+    ucp_md_index_t md_index, memh_index, memh_index_old;
+    ucs_memory_info_t mem_info;
+    ucs_log_level_t log_level;
+    ucs_status_t status;
+    void *reg_address;
+    size_t reg_length;
+
+    if (ucs_unlikely(dt_reg->md_map != 0)) {
+        ucp_datatype_iter_mem_dereg_some_noninline(context, md_map, dt_reg,
+                                                   tmp_reg);
+    }
+
+    if (ucs_unlikely(length == 0)) {
+        for (memh_index = 0; UCS_BIT(memh_index) <= md_map; ++memh_index) {
+            dt_reg->memh[memh_index] = UCT_MEM_HANDLE_NULL;
+        }
+        goto out;
+    }
+
+    ucs_assert(address != NULL);
+    if (ucs_unlikely(context->config.ext.reg_whole_alloc_bitmap &
+                     UCS_BIT(mem_type))) {
+        ucp_memory_detect_internal(context, address, length, &mem_info);
+        reg_address = mem_info.base_address;
+        reg_length  = mem_info.alloc_length;
+    } else {
+        reg_address = address;
+        reg_length  = length;
+    }
+
+    memh_index_old = 0;
+    memh_index     = 0;
+    ucs_for_each_bit(md_index, md_map) {
+        if (UCS_BIT(md_index) & dt_reg->md_map) {
+            /* memh already registered */
+            ucs_assert(memh_index_old < UCP_MAX_OP_MDS);
+            dt_reg->memh[memh_index++] = tmp_reg[memh_index_old++];
+            continue;
+        }
+
+        /* MD supports registration, register new memh on it */
+        status = uct_md_mem_reg(context->tl_mds[md_index].md, reg_address,
+                                reg_length, uct_flags,
+                                &dt_reg->memh[memh_index]);
+        if (ucs_unlikely(status != UCS_OK)) {
+            log_level = (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ?
+                                UCS_LOG_LEVEL_DIAG :
+                                UCS_LOG_LEVEL_ERROR;
+            ucs_log(log_level,
+                    "failed to register %s %p length %zu on md[%d]=%s: %s",
+                    ucs_memory_type_names[mem_type], reg_address, reg_length,
+                    md_index, context->tl_mds[md_index].rsc.md_name,
+                    ucs_status_string(status));
+            dt_reg->md_map |= md_map & UCS_MASK(md_index);
+            ucp_datatype_iter_mem_dereg_internal(context, dt_reg);
+            return status;
+        }
+
+        ucs_trace("registered address %p length %zu on md[%d]=%s memh[%d]=%p",
+                  reg_address, reg_length, md_index,
+                  context->tl_mds[md_index].rsc.md_name, memh_index,
+                  dt_reg->memh[memh_index]);
+        ++memh_index;
+    }
+
+    ucs_assert(memh_index == ucs_popcount(md_map));
+
+out:
+    /* We expect the registration to happen on all desired memory domains,
+     * since subsequent access to the iterator will use 'memh_index' which
+     * assumes the md_map is as expected.
+     */
+    dt_reg->md_map = md_map;
+    return UCS_OK;
+}
+
+UCS_PROFILE_FUNC_VOID(ucp_datatype_iter_mem_dereg_internal, (context, dt_reg),
+                      ucp_context_h context, ucp_dt_reg_t *dt_reg)
+{
+    ucp_datatype_iter_mem_dereg_some(context, 0, dt_reg, NULL);
+    dt_reg->md_map = 0;
+}
+
 static UCS_F_ALWAYS_INLINE const ucp_dt_iov_t *
 ucp_datatype_iter_iov_at(const ucp_datatype_iter_t *dt_iter, size_t index)
 {
@@ -52,10 +180,10 @@ ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
 
     for (iov_index = 0; iov_index < iov_count; ++iov_index) {
         iov    = ucp_datatype_iter_iov_at(dt_iter, iov_index);
-        status = ucp_datatype_iter_mem_reg_internal(context, dt_iter, md_map,
-                                                    iov->buffer, iov->length,
-                                                    uct_flags,
-                                                    &dt_reg[iov_index]);
+        status = ucp_datatype_iter_mem_reg_internal(context, iov->buffer,
+                                                    iov->length, uct_flags,
+                                                    dt_iter->mem_info.type,
+                                                    md_map, &dt_reg[iov_index]);
         if (status != UCS_OK) {
             ucp_datatype_iter_iov_mem_dereg(context, dt_iter);
             return status;
@@ -71,13 +199,9 @@ void ucp_datatype_iter_iov_mem_dereg(ucp_context_h context,
 {
     ucp_dt_reg_t *dt_reg = dt_iter->type.iov.reg;
     size_t iov_index, length;
-    const ucp_dt_iov_t *iov;
 
     ucp_datatype_iter_iov_for_each(iov_index, length, dt_iter) {
-        iov = ucp_datatype_iter_iov_at(dt_iter, iov_index);
-        ucp_mem_rereg_mds(context, 0, iov->buffer, iov->length, 0, NULL,
-                          dt_iter->mem_info.type, NULL, dt_reg[iov_index].memh,
-                          &dt_reg[iov_index].md_map);
+        ucp_datatype_iter_mem_dereg_internal(context, &dt_reg[iov_index]);
     }
 
     ucs_free(dt_reg);

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -60,6 +60,17 @@ typedef struct {
 } ucp_datatype_iter_t;
 
 
+ucs_status_t
+ucp_datatype_iter_mem_reg_internal(ucp_context_h context, void *address,
+                                   size_t length, unsigned uct_flags,
+                                   ucs_memory_type_t mem_type,
+                                   ucp_md_map_t md_map, ucp_dt_reg_t *dt_reg);
+
+
+void ucp_datatype_iter_mem_dereg_internal(ucp_context_h context,
+                                          ucp_dt_reg_t *dt_reg);
+
+
 ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
                                            ucp_datatype_iter_t *dt_iter,
                                            ucp_md_map_t md_map,

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -417,32 +417,6 @@ ucp_datatype_iter_is_end(const ucp_datatype_iter_t *dt_iter)
     return dt_iter->offset == dt_iter->length;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_datatype_iter_mem_reg_internal(ucp_context_h context,
-                                   ucp_datatype_iter_t *dt_iter,
-                                   ucp_md_map_t md_map, void *buffer,
-                                   size_t length, unsigned uct_flags,
-                                   ucp_dt_reg_t *dt_reg)
-{
-    ucs_status_t status;
-
-    status = ucp_mem_rereg_mds(context, md_map, buffer, length, uct_flags, NULL,
-                               (ucs_memory_type_t)dt_iter->mem_info.type, NULL,
-                               dt_reg->memh, &dt_reg->md_map);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    /* We expect the registration to happen on all desired memory domains,
-     * since subsequent access to the iterator will use 'memh_index' which
-     * assumes the md_map is as expected.
-     */
-    ucs_assertv((length == 0) || (dt_reg->md_map == md_map),
-                "reg.md_map=0x%" PRIx64 " md_map=0x%" PRIx64, dt_reg->md_map,
-                md_map);
-    return UCS_OK;
-}
-
 /*
  * Register memory and update iterator state
  */
@@ -456,10 +430,10 @@ ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
             return UCS_OK;
         }
 
-        return ucp_datatype_iter_mem_reg_internal(context, dt_iter, md_map,
-                                                  dt_iter->type.contig.buffer,
-                                                  dt_iter->length, uct_flags,
-                                                  &dt_iter->type.contig.reg);
+        return ucp_datatype_iter_mem_reg_internal(
+                context, dt_iter->type.contig.buffer, dt_iter->length,
+                uct_flags, (ucs_memory_type_t)dt_iter->mem_info.type, md_map,
+                &dt_iter->type.contig.reg);
     } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
         return ucp_datatype_iter_iov_mem_reg(context, dt_iter, md_map, uct_flags);
     } else {
@@ -477,10 +451,8 @@ ucp_datatype_iter_mem_dereg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
                             unsigned dt_mask)
 {
     if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_CONTIG, dt_mask)) {
-        ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL,
-                          (ucs_memory_type_t)dt_iter->mem_info.type, NULL,
-                          dt_iter->type.contig.reg.memh,
-                          &dt_iter->type.contig.reg.md_map);
+        ucp_datatype_iter_mem_dereg_internal(context,
+                                             &dt_iter->type.contig.reg);
     } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
         ucp_datatype_iter_iov_mem_dereg(context, dt_iter);
     }

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -84,7 +84,8 @@ static UCS_F_ALWAYS_INLINE size_t ucp_proto_rndv_rts_pack(
     rts->sreq.ep_id  = ucp_send_request_get_ep_remote_id(req);
     rts->size        = req->send.state.dt_iter.length;
 
-    if (req->send.state.dt_iter.type.contig.reg.md_map == 0) {
+    if ((rts->size == 0) ||
+        (req->send.state.dt_iter.type.contig.reg.md_map == 0)) {
         rts->address = 0;
         rkey_size    = 0;
     } else {

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -4,12 +4,14 @@
  * See file LICENSE for terms.
  */
 
-#include <common/test.h>
-
 #include "ucp_test.h"
+
+#include <common/test.h>
+#include <common/mem_buffer.h>
 
 extern "C" {
 #include <ucp/core/ucp_rkey.h>
+#include <ucp/dt/datatype_iter.inl>
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_select.h>
 #include <ucp/proto/proto_select.inl>
@@ -23,16 +25,83 @@ public:
     }
 
 protected:
+    void do_mem_reg(ucp_datatype_iter_t *dt_iter, ucp_md_map_t md_map);
+
+    ucp_md_map_t get_md_map(ucs_memory_type_t mem_type);
+
+    void test_dt_iter_mem_reg(ucs_memory_type_t mem_type, size_t size,
+                              ucp_md_map_t md_map);
+
     virtual void init() {
         modify_config("PROTO_ENABLE", "y");
         ucp_test::init();
         sender().connect(&receiver(), get_ep_params());
     }
 
+    ucp_context_h context() {
+        return sender().ucph();
+    }
+
     ucp_worker_h worker() {
         return sender().worker();
     }
 };
+
+ucp_md_map_t test_ucp_proto::get_md_map(ucs_memory_type_t mem_type)
+{
+    ucp_md_map_t md_map = 0;
+
+    for (ucp_md_index_t md_index = 0; md_index < context()->num_mds;
+         ++md_index) {
+        const uct_md_attr_t *md_attr = &context()->tl_mds[md_index].attr;
+        if ((md_attr->cap.flags & UCT_MD_FLAG_REG) &&
+            (md_attr->cap.reg_mem_types & UCS_BIT(mem_type))) {
+            md_map |= UCS_BIT(md_index);
+        }
+    }
+    return md_map;
+}
+
+void test_ucp_proto::do_mem_reg(ucp_datatype_iter_t *dt_iter,
+                                ucp_md_map_t md_map)
+{
+    ucp_datatype_iter_mem_reg(context(), dt_iter, md_map, UCT_MD_MEM_ACCESS_ALL,
+                              UCP_DT_MASK_ALL);
+    ucp_datatype_iter_mem_dereg(context(), dt_iter, UCP_DT_MASK_ALL);
+}
+
+void test_ucp_proto::test_dt_iter_mem_reg(ucs_memory_type_t mem_type,
+                                          size_t size, ucp_md_map_t md_map)
+{
+    const double test_time_sec = 1.0;
+    mem_buffer buffer(size, mem_type);
+
+    ucp_datatype_iter_t dt_iter;
+    uint8_t sg_count;
+    ucp_datatype_iter_init(context(), buffer.ptr(), size, UCP_DATATYPE_CONTIG,
+                           size, 1, &dt_iter, &sg_count);
+
+    ucs_time_t start_time = ucs_get_time();
+    ucs_time_t deadline   = start_time + ucs_time_from_sec(test_time_sec);
+    ucs_time_t end_time   = start_time;
+    unsigned count        = 0;
+    do {
+        do_mem_reg(&dt_iter, md_map);
+        ++count;
+        if ((count % 8) == 0) {
+            end_time = ucs_get_time();
+        }
+    } while (end_time < deadline);
+
+    char memunits_str[32];
+    UCS_TEST_MESSAGE << ucs_memory_type_names[mem_type] << " "
+                     << ucs_memunits_to_str(size, memunits_str,
+                                            sizeof(memunits_str))
+                     << " md_map 0x" << std::hex << md_map << std::dec
+                     << " registration time: "
+                     << (ucs_time_to_nsec(end_time - start_time) / count)
+                     << " nsec";
+}
 
 UCS_TEST_P(test_ucp_proto, dump_protocols) {
     ucp_proto_select_param_t select_param;
@@ -116,4 +185,23 @@ UCS_TEST_P(test_ucp_proto, worker_print_info_rkey)
     ucp_worker_print_info(worker(), stdout);
 }
 
+UCS_TEST_P(test_ucp_proto, dt_iter_mem_reg)
+{
+    static const size_t buffer_size = 8192;
+
+    for (size_t i = 0; i < mem_buffer::supported_mem_types().size(); ++i) {
+        const ucs_memory_type_t mem_type = mem_buffer::supported_mem_types()[i];
+        ucp_md_map_t md_map              = get_md_map(mem_type);
+        if (md_map == 0) {
+            UCS_TEST_MESSAGE << "No memory domains can register "
+                             << ucs_memory_type_names[mem_type] << " memory";
+            continue;
+        }
+
+        test_dt_iter_mem_reg(mem_type, buffer_size, md_map);
+    }
+}
+
 UCP_INSTANTIATE_TEST_CASE(test_ucp_proto)
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_proto, shm_ipc,
+                                        "shm,cuda_ipc,rocm_ipc")


### PR DESCRIPTION
## Why
With new protocols no need to check all the things we check in the rereg_mds() function. We can assume registration is needed and supported, and that no prior registration was done.