### PR TITLE
GTEST/UCS: Don't use base type name

### DIFF
--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -17,12 +17,12 @@ extern "C" {
 #include <sys/poll.h>
 
 
-class base {
+class base_async {
 public:
-    base(ucs_async_mode_t mode) : m_mode(mode), m_count(0), m_handler_set(0) {
+    base_async(ucs_async_mode_t mode) : m_mode(mode), m_count(0), m_handler_set(0) {
     }
 
-    virtual ~base() {
+    virtual ~base_async() {
     }
 
     int count() const {
@@ -42,14 +42,14 @@ public:
     }
 
 private:
-    base(const base& other);
+    base_async(const base_async& other);
 
 protected:
     virtual void ack_event() = 0;
     virtual int event_id() = 0;
 
     static void cb(int id, ucs_event_set_types_t events, void *arg) {
-        base *self = reinterpret_cast<base*>(arg);
+        base_async *self = reinterpret_cast<base_async*>(arg);
         self->handler();
     }
 
@@ -67,9 +67,9 @@ protected:
     uint32_t               m_handler_set;
 };
 
-class base_event : public base {
+class base_event : public base_async {
 public:
-    base_event(ucs_async_mode_t mode) : base(mode) {
+    base_event(ucs_async_mode_t mode) : base_async(mode) {
         ucs_status_t status = ucs_async_pipe_create(&m_event_pipe);
         ASSERT_UCS_OK(status);
     }
@@ -84,7 +84,7 @@ public:
                                         UCS_EVENT_SET_EVREAD,
                                         cb, this, async);
         ASSERT_UCS_OK(status);
-        base::set_handler();
+        base_async::set_handler();
     }
 
     virtual int event_id() {
@@ -112,10 +112,10 @@ private:
     ucs_async_pipe_t m_event_pipe;
 };
 
-class base_timer : public base {
+class base_timer : public base_async {
 public:
     base_timer(ucs_async_mode_t mode) :
-        base(mode), m_timer_id(-1)
+        base_async(mode), m_timer_id(-1)
     {
     }
 
@@ -127,7 +127,7 @@ public:
         ucs_status_t status = ucs_async_add_timer(mode(), interval, cb,
                                                   this, async, &m_timer_id);
         ASSERT_UCS_OK(status);
-        base::set_handler();
+        base_async::set_handler();
     }
 
     virtual int event_id() {
@@ -708,7 +708,7 @@ public:
 
 protected:
     virtual void handler() {
-         base::handler();
+         base_async::handler();
          unset_handler(false);
     }
 };
@@ -732,8 +732,8 @@ public:
 
 protected:
     virtual void handler() {
-         base::handler();
-         unset_handler(m_sync);
+        base_async::handler();
+        unset_handler(m_sync);
     }
 
 private:
@@ -789,15 +789,16 @@ protected:
     }
 
     virtual void handler() {
-         base::handler();
-         if (!m_event_set) {
-             ucs_status_t status =
-                 ucs_async_set_event_handler(mode(), m_pipefd[0],
-                                             UCS_EVENT_SET_EVREAD,
-                                             dummy_cb, this, &m_async);
-             ASSERT_UCS_OK(status);
-             m_event_set = true;
-         }
+        base_async::handler();
+        if (!m_event_set) {
+            ucs_status_t status =
+                    ucs_async_set_event_handler(mode(), m_pipefd[0],
+                                                UCS_EVENT_SET_EVREAD,
+                                                dummy_cb, this,
+                                                &m_async);
+            ASSERT_UCS_OK(status);
+            m_event_set = true;
+        }
     }
 
     int m_pipefd[2];

--- a/test/gtest/ucs/test_class.cc
+++ b/test/gtest/ucs/test_class.cc
@@ -13,18 +13,18 @@ class test_class : public ucs::test {
 };
 
 
-typedef struct base {
+typedef struct {
     int            field1;
 } base_t;
 UCS_CLASS_DECLARE(base_t, int);
 
-typedef struct derived {
+typedef struct {
     base_t         super;
     int            field2;
 } derived_t;
 UCS_CLASS_DECLARE(derived_t, int, int);
 
-typedef struct derived2 {
+typedef struct {
     base_t         super;
     int            field2;
 } derived2_t;


### PR DESCRIPTION
## What

Don't use "base" for type names.

## Why ?

Fixes #7329 

## How ?

1. Rename "base" class to "base_async" in ucs/test_class.cc.
2. Remove "base"/"derived"/"derived2", since they can use only typedef version of it - "base_t"/"derived_t"/"dervied2_t"