### PR TITLE
UCT/SCOPY: Move overhead of iface_attr from CMA/KNEM to common code

### DIFF
--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -82,6 +82,9 @@ void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_att
                                           UCT_IFACE_FLAG_EVENT_RECV      |
                                           UCT_IFACE_FLAG_EVENT_ASYNC_CB;
     iface_attr->latency                 = ucs_linear_func_make(80e-9, 0); /* 80 ns */
+    iface_attr->overhead                = (ucs_arch_get_cpu_vendor() ==
+                                           UCS_CPU_VENDOR_FUJITSU_ARM) ?
+                                          6e-6 : 2e-6;
 }
 
 UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_iface_ops_t *ops,
@@ -171,13 +174,4 @@ ucs_status_t uct_scopy_iface_flush(uct_iface_h tl_iface, unsigned flags,
 
     UCT_TL_IFACE_STAT_FLUSH(&iface->super.super);
     return UCS_OK;
-}
-
-double uct_scopy_iface_overhead()
-{
-    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM) {
-        return 6e-6;
-    }
-
-    return 2e-6;
 }

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -72,6 +72,4 @@ ucs_status_t uct_scopy_iface_event_arm(uct_iface_h tl_iface, unsigned events);
 ucs_status_t uct_scopy_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                    uct_completion_t *comp);
 
-double uct_scopy_iface_overhead();
-
 #endif

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -56,13 +56,12 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
 
     uct_scopy_iface_query(&iface->super, iface_attr);
 
-    iface_attr->iface_addr_len      = ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_PID) ?
-                                      sizeof(ucs_cma_iface_base_device_addr_t) :
-                                      sizeof(ucs_cma_iface_ext_device_addr_t);
+    iface_attr->iface_addr_len      =
+            ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_PID) ?
+            sizeof(ucs_cma_iface_base_device_addr_t) :
+            sizeof(ucs_cma_iface_ext_device_addr_t);
     iface_attr->bandwidth.dedicated = iface->super.super.config.bandwidth;
     iface_attr->bandwidth.shared    = 0;
-    iface_attr->overhead            = uct_scopy_iface_overhead();
-
     iface_attr->cap.flags          |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
                                       UCT_IFACE_FLAG_EP_CHECK;
 

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -34,7 +34,6 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     iface_attr->iface_addr_len      = 0;
     iface_attr->bandwidth.shared    = iface->super.super.config.bandwidth;
     iface_attr->bandwidth.dedicated = 0;
-    iface_attr->overhead            = uct_scopy_iface_overhead();
 
     return UCS_OK;
 }


### PR DESCRIPTION
## What

Move overhead of iface_attr from CMA/KNEM to common code

## Why ?

To reduce code duplication, because overhead of CMA and KNEM are identical.

## How ?

1. Remove setting of overhead attribute in CMA and KNEM iface_query implementation.
2. Add setting of overhead attribute in SCOPY iface_query implementation which is called from CMA and KNEM.