### PR TITLE
UCP/API: Revert "UCP/CORE: Do not fill user_hdr in AM handler when length is 0"

### DIFF
--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -460,7 +460,7 @@ ucs_status_t ucp_am_data_cb(void *arg, const void *header, size_t header_length,
         return UCS_OK;
     }
 
-    if ((header != NULL) || (header_length != 0)) {
+    if (header_length != 0) {
         fprintf(stderr, "received unexpected header, length %ld", header_length);
     }
 

--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -462,7 +462,6 @@ ucs_status_t ucp_am_data_cb(void *arg, const void *header, size_t header_length,
 
     if ((header != NULL) || (header_length != 0)) {
         fprintf(stderr, "received unexpected header, length %ld", header_length);
-        abort();
     }
 
     am_data_desc.complete = 1;

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -625,9 +625,9 @@ typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
  *
  * @param [in]  arg           User-defined argument.
  * @param [in]  header        User defined active message header. Can be NULL.
- * @param [in]  header_length Active message header length in bytes. If this
- *                            value is 0, the @a header pointer is undefined
- *                            and should not be accessed.
+ *                            If @a header_length is 0, this value is undefined
+ *                            and must not be accessed.
+ * @param [in]  header_length Active message header length in bytes. 
  * @param [in]  data          Points to the received data if @a
  *                            UCP_AM_RECV_ATTR_FLAG_RNDV flag is not set in
  *                            @ref ucp_am_recv_param_t.recv_attr. Otherwise

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1199,8 +1199,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
     void *data               = am_hdr + 1;
     size_t data_length       = total_length -
                                (sizeof(*am_hdr) + am_hdr->header_length);
-    void *user_hdr           = (user_hdr_size > 0) ? UCS_PTR_BYTE_OFFSET(data, data_length) :
-                               NULL;
+    void *user_hdr           = UCS_PTR_BYTE_OFFSET(data, data_length);
     ucs_status_t desc_status = UCS_OK;
     ucs_status_t status;
 


### PR DESCRIPTION
## What
Revert to filling `user_hdr`, even if the header length is 0.

## Why ?
Avoid extra branch.