### PR TITLE
GTEST/UCP: Use std::string::size_type instead of size_t

### DIFF
--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -963,9 +963,9 @@ void test_ucp_stream_many2one::check_recv_data(size_t n_iter, ucp_datatype_t dt)
             test = std::string(test_gen.data());
         }
 
-        size_t            next = 0;
+        std::string::size_type next = 0;
         for (size_t j = 0; j < n_iter; ++j) {
-            size_t match = str.find(test, next);
+            std::string::size_type match = str.find(test, next);
             EXPECT_NE(std::string::npos, match) << "failed on sender " << i
                                                 << " iteration " << j;
             if (match == std::string::npos) {


### PR DESCRIPTION
## What

Use `std::string::size_type` instead of `size_t`.

## Why ?

To align with other places in our C++ code:
https://github.com/openucx/ucx/blob/3e4ed2735ef4b34b3e52fb51a09f9188bf5720ca/test/gtest/common/test.cc#L61
Also, it is useful if some `std::string` implementation uses other type than `size_t` for `std::string::npos` constant.

## How ?

Replace size_t by `std::string::size_type`.