### PR TITLE
UCP/AMO: Mem type atomic arguments

### DIFF
--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -14,15 +14,15 @@
 
 #include <ucs/arch/atomic.h>
 #include <ucs/profile/profile.h>
+#include <ucp/dt/datatype_iter.inl>
 #include <ucp/proto/proto_single.h>
 
 
-static size_t ucp_amo_sw_pack(void *dest, void *arg, uint8_t fetch)
+static size_t ucp_amo_sw_pack(void *dest, ucp_request_t *req, int fetch,
+                              size_t size)
 {
-    ucp_request_t *req            = arg;
     ucp_atomic_req_hdr_t *atomich = dest;
     ucp_ep_t *ep                  = req->send.ep;
-    size_t size                   = req->send.length;
     size_t length;
 
     atomich->address    = req->send.amo.remote_addr;
@@ -46,12 +46,16 @@ static size_t ucp_amo_sw_pack(void *dest, void *arg, uint8_t fetch)
 
 static size_t ucp_amo_sw_post_pack_cb(void *dest, void *arg)
 {
-    return ucp_amo_sw_pack(dest, arg, 0);
+    ucp_request_t *req = arg;
+
+    return ucp_amo_sw_pack(dest, req, 0, req->send.length);
 }
 
 static size_t ucp_amo_sw_fetch_pack_cb(void *dest, void *arg)
 {
-    return ucp_amo_sw_pack(dest, arg, 1);
+    ucp_request_t *req = arg;
+
+    return ucp_amo_sw_pack(dest, req, 1, req->send.length);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -329,6 +333,20 @@ UCP_DEFINE_AM(UCP_FEATURE_AMO, UCP_AM_ID_ATOMIC_REP, ucp_atomic_rep_handler,
 
 UCP_DEFINE_AM_PROXY(UCP_AM_ID_ATOMIC_REQ);
 
+static size_t ucp_proto_amo_sw_post_pack_cb(void *dest, void *arg)
+{
+    ucp_request_t *req = arg;
+
+    return ucp_amo_sw_pack(dest, req, 0, req->send.state.dt_iter.length);
+}
+
+static size_t ucp_proto_amo_sw_fetch_pack_cb(void *dest, void *arg)
+{
+    ucp_request_t *req = arg;
+
+    return ucp_amo_sw_pack(dest, req, 1, req->send.state.dt_iter.length);
+}
+
 static ucs_status_t
 ucp_proto_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
                           int fetch)
@@ -336,6 +354,7 @@ ucp_proto_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
     ucp_request_t *req                   = ucs_container_of(self, ucp_request_t,
                                                             send.uct);
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
+    ucp_datatype_iter_t next_iter;
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
@@ -343,6 +362,10 @@ ucp_proto_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
         if (status != UCS_OK) {
             return status;
         }
+
+        ucp_datatype_iter_next_pack(&req->send.state.dt_iter,
+                                    req->send.ep->worker, SIZE_MAX,
+                                    &next_iter, &req->send.amo.value);
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
@@ -376,7 +399,7 @@ ucp_proto_amo_sw_init(const ucp_proto_init_params_t *init_params, unsigned flags
 
 static ucs_status_t ucp_proto_amo_sw_progress_post(uct_pending_req_t *self)
 {
-    return ucp_proto_amo_sw_progress(self, ucp_amo_sw_post_pack_cb, 0);
+    return ucp_proto_amo_sw_progress(self, ucp_proto_amo_sw_post_pack_cb, 0);
 }
 
 static ucs_status_t
@@ -398,7 +421,7 @@ UCP_PROTO_REGISTER(&ucp_get_amo_post_proto);
 
 static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
 {
-    return ucp_proto_amo_sw_progress(self, ucp_amo_sw_fetch_pack_cb, 1);
+    return ucp_proto_amo_sw_progress(self, ucp_proto_amo_sw_fetch_pack_cb, 1);
 }
 
 static ucs_status_t

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -59,6 +59,11 @@ public:
     static void copy_from(void *dst, const void *src, size_t length,
                           ucs_memory_type_t src_mem_type);
 
+    /* copy between memtype buffers */
+    static void copy_between(void *dst, const void *src, size_t length,
+                             ucs_memory_type_t dst_mem_type,
+                             ucs_memory_type_t src_mem_type);
+
     /* compare memtype buffer with host memory, return true if equal */
     static bool compare(const void *expected, const void *buffer,
                         size_t length, ucs_memory_type_t mem_type);
@@ -97,8 +102,6 @@ public:
     void memset(int c);
 
 private:
-    static void abort_wrong_mem_type(ucs_memory_type_t mem_type);
-
     static bool is_cuda_supported();
 
     static bool is_rocm_supported();
@@ -125,6 +128,9 @@ private:
     static void pattern_check_failed(uint64_t expected, uint64_t actual,
                                      size_t length, uint64_t mask,
                                      size_t offset, const void *orig_ptr);
+    static bool check_mem_types(ucs_memory_type_t dst_mem_type,
+                                ucs_memory_type_t src_mem_type,
+                                const uint64_t mem_types);
 
     const ucs_memory_type_t m_mem_type;
     void * const            m_ptr;

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -9,6 +9,7 @@
 
 extern "C" {
 #include <ucp/core/ucp_types.h> /* for atomic mode */
+#include <ucp/core/ucp_mm.h>
 }
 
 template <typename T>
@@ -36,50 +37,80 @@ public:
         get_test_variants(variants, ENABLE_PROTO, "/proto");
     }
 
+    struct send_func_data {
+        ucp_atomic_op_t   op;
+        ucs_memory_type_t send_mem_type;
+        ucs_memory_type_t recv_mem_type;
+    };
+
     void post(size_t size, void *target_ptr, ucp_rkey_h rkey,
               void *expected_data, void *arg)
     {
-        ucp_atomic_op_t op = *(ucp_atomic_op_t*)arg;
-        T value            = (T)ucs::rand() * (T)ucs::rand();
-        T prev             = *(T*)target_ptr;
-        *(T*)expected_data = atomic_op_result(op, value, prev, 0);
+        const send_func_data* data = (send_func_data*)arg;
+        T value                    = (T)ucs::rand() * (T)ucs::rand();
+        T prev;
+        T result;
+
+        mem_buffer::copy_to(expected_data, &value, sizeof(T),
+                            data->send_mem_type);
+        mem_buffer::copy_from(&prev, target_ptr, sizeof(T),
+                              data->recv_mem_type);
+        result = atomic_op_result(data->op, value, prev, 0);
 
         ucp_request_param_t param;
         param.op_attr_mask = 0;
-        ucs_status_t status = do_atomic(op, size, target_ptr, rkey, value, param);
+        ucs_status_t status = do_atomic(data->op, size, target_ptr, rkey,
+                                        expected_data, param);
         ASSERT_UCS_OK(status);
+        mem_buffer::copy_to(expected_data, &result, sizeof(T),
+                            data->send_mem_type);
     }
 
     void misaligned_post(size_t size, void *target_ptr, ucp_rkey_h rkey,
                          void *expected_data, void *arg)
     {
-        *(T*)expected_data = *(T*)target_ptr; /* remote should not change */
+        const send_func_data* data = (send_func_data*)arg;
+        T value = 0;
+
+        /* remote should not change */
+        mem_buffer::copy_between(expected_data, target_ptr, sizeof(T),
+                                 data->send_mem_type, data->recv_mem_type);
 
         ucp_request_param_t param;
         param.op_attr_mask  = 0;
         ucs_status_t status = do_atomic(*(ucp_atomic_op_t*)arg, size,
                                         UCS_PTR_BYTE_OFFSET(target_ptr, 1),
-                                        rkey, 0, param);
+                                        rkey, &value, param);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
     }
 
     void fetch(size_t size, void *target_ptr, ucp_rkey_h rkey,
                void *expected_data, void *arg)
     {
-        ucp_atomic_op_t op = *(ucp_atomic_op_t*)arg;
-        T value            = (T)ucs::rand() * (T)ucs::rand();
-        T prev             = *(T*)target_ptr;
-        T reply_data       = ((op == UCP_ATOMIC_OP_CSWAP) && (ucs::rand() % 2)) ?
-                             prev : /* cswap success */
-                             ((T)ucs::rand() * (T)ucs::rand());
-        *(T*)expected_data = atomic_op_result(op, value, prev, reply_data);
+        const send_func_data* data = (send_func_data*)arg;
+        T value                    = (T)ucs::rand() * (T)ucs::rand();
+        T prev;
+        T reply_data;
+        T result;
+
+        mem_buffer::copy_to(expected_data, &value, sizeof(T),
+                            data->send_mem_type);
+        mem_buffer::copy_from(&prev, target_ptr, sizeof(T),
+                              data->recv_mem_type);
+        reply_data = ((data->op == UCP_ATOMIC_OP_CSWAP) && (ucs::rand() % 2)) ?
+                     prev : /* cswap success */
+                     ((T)ucs::rand() * (T)ucs::rand());
+        result = atomic_op_result(data->op, value, prev, reply_data);
 
         ucp_request_param_t param;
         param.op_attr_mask = UCP_OP_ATTR_FIELD_REPLY_BUFFER;
         param.reply_buffer = &reply_data;
 
-        ucs_status_t status = do_atomic(op, size, target_ptr, rkey, value, param);
+        ucs_status_t status = do_atomic(data->op, size, target_ptr, rkey,
+                                        expected_data, param);
         ASSERT_UCS_OK(status);
+        mem_buffer::copy_to(expected_data, &result, sizeof(T),
+                            data->send_mem_type);
 
         EXPECT_EQ(prev, reply_data); /* expect the previous value */
     }
@@ -115,8 +146,8 @@ protected:
 
     void test(send_func_t send_func, uint64_t op_mask,
               unsigned num_iters = default_num_iters()) {
-        test_all_opcodes(send_func, num_iters, op_mask, true);
-        test_all_opcodes(send_func, num_iters, op_mask, false);
+        test_mem_types(send_func, num_iters, op_mask, true);
+        test_mem_types(send_func, num_iters, op_mask, false);
     }
 
 private:
@@ -159,30 +190,79 @@ private:
     }
 
     ucs_status_t do_atomic(ucp_atomic_op_t op, size_t size, void *target_ptr,
-                           ucp_rkey_h rkey, T value, ucp_request_param_t &param) {
+                           ucp_rkey_h rkey, void* value, ucp_request_param_t &param) {
 
         param.op_attr_mask |= UCP_OP_ATTR_FIELD_DATATYPE;
         param.datatype      = ucp_dt_make_contig(sizeof(T));
 
         EXPECT_EQ(sizeof(T), size);
         ucs_status_ptr_t status_ptr = ucp_atomic_op_nbx(sender().ep(), op,
-                                                        &value, 1,
+                                                        value, 1,
                                                         (uintptr_t)target_ptr,
                                                         rkey, &param);
         return request_wait(status_ptr);
     }
 
+    void test_mem_types(send_func_t send_func, unsigned num_iters,
+                        uint64_t op_mask, int is_ep_flush) {
+        int atomic_mode = get_variant_value() & ATOMIC_MODE;
+        std::vector<std::vector<ucs_memory_type_t> > pairs =
+                ucs::supported_mem_type_pairs();
+
+        for (size_t i = 0; i < pairs.size(); ++i) {
+            ucs_memory_type_t send_mem_type = pairs[i][0], recv_mem_type = pairs[i][1];
+            if (!UCP_MEM_IS_HOST(send_mem_type) || !UCP_MEM_IS_HOST(recv_mem_type)) {
+                /* Memory type atomics are fully supported only with new protocols */
+                if (!(get_variant_value() & ENABLE_PROTO)) {
+                    continue;
+                }
+
+                static const std::string tls[] = { "ud_v", "ud_x", "rc_v", "tcp" };
+                /* Target memory type atomics emulation not supported yet */
+                if (((atomic_mode == UCP_ATOMIC_MODE_CPU) ||
+                     has_any_transport(tls, ucs_static_array_size(tls))) &&
+                    !UCP_MEM_IS_HOST(recv_mem_type)) {
+                    continue;
+                }
+
+                /* GPU-direct to managed not supported */
+                if ((atomic_mode != UCP_ATOMIC_MODE_CPU) &&
+                    UCP_MEM_IS_CUDA_MANAGED(recv_mem_type)) {
+                    continue;
+                }
+
+                /* GPU-direct required for destination CUDA */
+                if (UCP_MEM_IS_CUDA(recv_mem_type) &&
+                    !check_reg_mem_types(sender(), recv_mem_type)) {
+                    continue;
+                }
+            }
+
+            test_all_opcodes(send_func, num_iters, op_mask, is_ep_flush,
+                             send_mem_type, recv_mem_type);
+        }
+    }
+
     void test_all_opcodes(send_func_t send_func, unsigned num_iters,
-                          uint64_t op_mask, int is_ep_flush) {
+                          uint64_t op_mask, int is_ep_flush,
+                          ucs_memory_type_t send_mem_type,
+                          ucs_memory_type_t recv_mem_type) {
         ucs::detail::message_stream ms("INFO");
+
+        ms << ucs_memory_type_names[send_mem_type] << "->" <<
+              ucs_memory_type_names[recv_mem_type] << " ";
 
         unsigned op_value;
         ucs_for_each_bit(op_value, op_mask) {
-            ucp_atomic_op_t op = static_cast<ucp_atomic_op_t>(op_value);
-            ms << opcode_name(op) << " ";
+            send_func_data data;
+            data.op            = static_cast<ucp_atomic_op_t>(op_value);
+            data.send_mem_type = send_mem_type;
+            data.recv_mem_type = recv_mem_type;
+
+            ms << opcode_name(data.op) << " ";
             test_xfer(send_func, sizeof(T), num_iters, sizeof(T),
-                      UCS_MEMORY_TYPE_HOST, UCS_MEMORY_TYPE_HOST, 0,
-                      is_ep_flush, &op);
+                      send_mem_type, recv_mem_type, 0,
+                      is_ep_flush, &data);
         }
     }
 };
@@ -198,7 +278,7 @@ UCS_TEST_P(test_ucp_atomic32, fetch) {
     test(static_cast<send_func_t>(&test_ucp_atomic32::fetch), FETCH_ATOMIC_OPS);
 }
 
-UCP_INSTANTIATE_TEST_CASE(test_ucp_atomic32)
+UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_atomic32)
 
 class test_ucp_atomic64 : public test_ucp_atomic<uint64_t> {
 };
@@ -232,4 +312,4 @@ UCS_TEST_P(test_ucp_atomic64, misaligned_post) {
 }
 #endif
 
-UCP_INSTANTIATE_TEST_CASE(test_ucp_atomic64)
+UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_atomic64)

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -114,6 +114,11 @@ bool ucp_test::has_any_transport(const std::vector<std::string>& tl_names) const
            all_tl_names.end();
 }
 
+bool ucp_test::has_any_transport(const std::string *tls, size_t tl_size) const {
+    const std::vector<std::string> tl_names(tls, tls + tl_size);
+    return has_any_transport(tl_names);
+}
+
 bool ucp_test::is_self() const {
     return "self" == GetParam().transports.front();
 }
@@ -1094,4 +1099,15 @@ void test_ucp_context::get_test_variants(std::vector<ucp_test_variant> &variants
 void ucp_test::disable_keepalive()
 {
     modify_config("KEEPALIVE_INTERVAL", "inf");
+}
+
+bool ucp_test::check_reg_mem_types(const entity& e, ucs_memory_type_t mem_type) {
+    for (ucp_lane_index_t lane = 0; lane < ucp_ep_num_lanes(e.ep()); lane++) {
+        const uct_md_attr_t* attr = ucp_ep_md_attr(e.ep(), lane);
+        if (attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -221,6 +221,7 @@ protected:
     virtual void cleanup();
     virtual bool has_transport(const std::string& tl_name) const;
     bool has_any_transport(const std::vector<std::string>& tl_names) const;
+    bool has_any_transport(const std::string *tls, size_t tl_size) const;
     entity* create_entity(bool add_in_front = false);
     entity* create_entity(bool add_in_front, const ucp_test_param& test_param);
     unsigned progress(int worker_index = 0) const;
@@ -237,6 +238,8 @@ protected:
     void request_release(void *req);
     int max_connections();
     void set_tl_small_timeouts();
+
+    static bool check_reg_mem_types(const entity& e, ucs_memory_type_t mem_type);
 
     // Add test variant without values, with given context params
     static ucp_test_variant&


### PR DESCRIPTION
## What
Add support for atomic arguments allocated in GPU memory.

## How ?
Copy arguments to host memory using dt_pack API.
