### PR TITLE
UCS/MALLOC/FREE: use UCS allocators

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -90,7 +90,7 @@ static int __find_string_in_list(const char *str, const char **list)
 
 int ucs_config_sscanf_string(const char *buf, void *dest, const void *arg)
 {
-    *((char**)dest) = strdup(buf);
+    *((char**)dest) = ucs_strdup(buf, "config_sscanf_string");
     return 1;
 }
 
@@ -103,7 +103,7 @@ int ucs_config_sprintf_string(char *buf, size_t max,
 
 ucs_status_t ucs_config_clone_string(const void *src, void *dest, const void *arg)
 {
-    char *new_str = strdup(*(char**)src);
+    char *new_str = ucs_strdup(*(char**)src, "config_clone_string");
     if (new_str == NULL) {
         return UCS_ERR_NO_MEMORY;
     }
@@ -114,7 +114,7 @@ ucs_status_t ucs_config_clone_string(const void *src, void *dest, const void *ar
 
 void ucs_config_release_string(void *ptr, const void *arg)
 {
-    free(*(char**)ptr);
+    ucs_free(*(char**)ptr);
 }
 
 int ucs_config_sscanf_int(const char *buf, void *dest, const void *arg)
@@ -366,7 +366,7 @@ ucs_status_t ucs_config_clone_log_comp(const void *src, void *dst, const void *a
 
 int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg)
 {
-    char *str = strdup(buf);
+    char *str = ucs_strdup(buf, "config_sscanf_bitmap_str");
     char *p, *saveptr;
     int ret, i;
 
@@ -387,7 +387,7 @@ int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg)
         p = strtok_r(NULL, ",", &saveptr);
     }
 
-    free(str);
+    ucs_free(str);
     return ret;
 }
 
@@ -693,7 +693,7 @@ int ucs_config_sscanf_range_spec(const char *buf, void *dest, const void *arg)
     char *p, *str;
     int ret = 1;
 
-    str = strdup(buf);
+    str = ucs_strdup(buf, "config_range_spec_str");
     if (str == NULL) {
         return 0;
     }
@@ -722,7 +722,7 @@ int ucs_config_sscanf_range_spec(const char *buf, void *dest, const void *arg)
     range_spec->last = last;
 
 out:
-    free (str);
+    ucs_free(str);
     return ret;
 }
 
@@ -760,7 +760,7 @@ int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg)
     int ret;
     unsigned i;
 
-    str_dup = strdup(buf);
+    str_dup = ucs_strdup(buf, "config_scanf_array");
     if (str_dup == NULL) {
         return 0;
     }
@@ -774,7 +774,7 @@ int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg)
                                  array->parser.arg);
         if (!ret) {
             ucs_free(temp_field);
-            free(str_dup);
+            ucs_free(str_dup);
             return 0;
         }
 
@@ -787,7 +787,7 @@ int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg)
 
     field->data = temp_field;
     field->count = i;
-    free(str_dup);
+    ucs_free(str_dup);
     return 1;
 }
 
@@ -957,7 +957,7 @@ int ucs_config_sscanf_table(const char *buf, void *dest, const void *arg)
     char *name, *value, *saveptr2;
     ucs_status_t status;
 
-    tokens = strdup(buf);
+    tokens = ucs_strdup(buf, "config_sscanf_table");
     if (tokens == NULL) {
         return 0;
     }
@@ -969,7 +969,7 @@ int ucs_config_sscanf_table(const char *buf, void *dest, const void *arg)
         name  = strtok_r(token, "=", &saveptr2);
         value = strtok_r(NULL,  "=", &saveptr2);
         if (name == NULL || value == NULL) {
-            free(tokens);
+            ucs_free(tokens);
             ucs_error("Could not parse list of values in '%s' (token: '%s')", buf, token);
             return 0;
         }
@@ -983,14 +983,14 @@ int ucs_config_sscanf_table(const char *buf, void *dest, const void *arg)
                 ucs_debug("Failed to set %s to '%s': %s", name, value,
                           ucs_status_string(status));
             }
-            free(tokens);
+            ucs_free(tokens);
             return 0;
         }
 
         token = strtok_r(NULL, ";", &saveptr1);
     }
 
-    free(tokens);
+    ucs_free(tokens);
     return 1;
 }
 
@@ -1040,7 +1040,7 @@ static void ucs_config_print_doc_line_by_line(const ucs_config_field_t *field,
     char *doc, *line, *p;
     int num;
 
-    line = doc = strdup(field->doc);
+    line = doc = ucs_strdup(field->doc, "config_doc");
     p = strchr(line, '\n');
     num = 0;
     while (p != NULL) {
@@ -1051,7 +1051,7 @@ static void ucs_config_print_doc_line_by_line(const ucs_config_field_t *field,
         ++num;
     }
     cb(num, line, arg);
-    free(doc);
+    ucs_free(doc);
 }
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -217,7 +217,7 @@ ucs_status_t uct_rocm_ipc_create_cache(uct_rocm_ipc_cache_t **cache,
         goto err_destroy_rwlock;
     }
 
-    cache_desc->name = strdup(name);
+    cache_desc->name = ucs_strdup(name, "rocm_ipc_cache_name");
     if (cache_desc->name == NULL) {
         status = UCS_ERR_NO_MEMORY;
         goto err_destroy_rwlock;
@@ -229,7 +229,7 @@ ucs_status_t uct_rocm_ipc_create_cache(uct_rocm_ipc_cache_t **cache,
 err_destroy_rwlock:
     pthread_rwlock_destroy(&cache_desc->lock);
 err:
-    free(cache_desc);
+    ucs_free(cache_desc);
     return status;
 }
 
@@ -238,6 +238,6 @@ void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache)
     uct_rocm_ipc_cache_purge(cache);
     ucs_pgtable_cleanup(&cache->pgtable);
     pthread_rwlock_destroy(&cache->lock);
-    free(cache->name);
+    ucs_free(cache->name);
     ucs_free(cache);
 }

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -363,7 +363,7 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
     knem_md->knem_fd = open("/dev/knem", O_RDWR);
     if (knem_md->knem_fd < 0) {
         ucs_error("Could not open the KNEM device file at /dev/knem: %m.");
-        free(knem_md);
+        ucs_free(knem_md);
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -89,7 +89,7 @@ static ucs_status_t uct_ugni_mem_reg(uct_md_h md, void *address, size_t length,
     return UCS_OK;
 
 mem_err:
-    free(mem_hndl);
+    ucs_free(mem_hndl);
     return status;
 }
 


### PR DESCRIPTION
- use UCS allocators for parser and client/server stats
- fixed potential ucs/malloc/free calls in error handlers
