### PR TITLE
UCT/IB/BASE: Handle SM_CHANGE/CLIENT_REREGISTER async events as diagnostics

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -438,6 +438,8 @@ void uct_ib_handle_async_event(uct_ib_device_t *dev, uct_ib_async_event_t *event
         break;
     case IBV_EVENT_PORT_ACTIVE:
     case IBV_EVENT_PORT_ERR:
+    case IBV_EVENT_SM_CHANGE:
+    case IBV_EVENT_CLIENT_REREGISTER:
         snprintf(event_info, sizeof(event_info), "%s on port %d",
                  ibv_event_type_str(event->event_type), event->port_num);
         level = UCS_LOG_LEVEL_DIAG;
@@ -447,8 +449,6 @@ void uct_ib_handle_async_event(uct_ib_device_t *dev, uct_ib_async_event_t *event
 #endif
     case IBV_EVENT_LID_CHANGE:
     case IBV_EVENT_PKEY_CHANGE:
-    case IBV_EVENT_SM_CHANGE:
-    case IBV_EVENT_CLIENT_REREGISTER:
         snprintf(event_info, sizeof(event_info), "%s on port %d",
                  ibv_event_type_str(event->event_type), event->port_num);
         level = UCS_LOG_LEVEL_WARN;


### PR DESCRIPTION
## What

Handle SM_CHANGE/CLIENT_REREGISTER async events as diagnostics.

## Why ?

[1630842634.549719] [node01:33913:1]      ib_device.c:482  UCX  WARN  IB Async event on mlx5_0: client reregistration on port 1
[1630842635.421273] [node01:33913:1]      ib_device.c:482  UCX  WARN  IB Async event on mlx5_0: client reregistration on port 1

## How ?

Move `IBV_EVENT_SM_CHANGE`/`IBV_EVENT_CLIENT_REREGISTER` to the case where we print diagnostic instead of warning.