### PR TITLE
UCP/WIREUP: Handle address count > 64

### DIFF
--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -78,6 +78,14 @@ enum {
 
 
 /**
+ * UCP TL address bitmap
+ *
+ * Bitmap type for representing which TL addresses are in use.
+ */
+typedef ucs_bitmap_t(UCP_MAX_RESOURCES) ucp_tl_addr_bitmap_t;
+
+
+/**
  * Remote interface attributes.
  */
 struct ucp_address_iface_attr {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -297,7 +297,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     int has_cm                            =
             ucp_ep_init_flags_has_cm(select_params->ep_init_flags);
     uint64_t local_md_flags;
-    uint64_t addr_index_map, rsc_addr_index_map;
+    ucp_tl_addr_bitmap_t addr_index_map, rsc_addr_index_map;
     const ucp_wireup_lane_desc_t *lane_desc;
     unsigned addr_index;
     uct_tl_resource_desc_t *resource;
@@ -320,7 +320,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     show_error   = (select_params->show_error && show_error);
 
     /* Check which remote addresses satisfy the criteria */
-    addr_index_map = 0;
+    UCS_BITMAP_CLEAR(&addr_index_map);
     ucp_unpacked_address_for_each(ae, address) {
         addr_index = ucp_unpacked_address_index(address, ae);
         if (!(remote_dev_bitmap & UCS_BIT(ae->dev_index))) {
@@ -372,10 +372,10 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
         UCP_WIREUP_CHECK_AMO_FLAGS(ae, criteria, context, addr_index, fop, 32);
         UCP_WIREUP_CHECK_AMO_FLAGS(ae, criteria, context, addr_index, fop, 64);
 
-        addr_index_map |= UCS_BIT(addr_index);
+        UCS_BITMAP_SET(addr_index_map, addr_index);
     }
 
-    if (!addr_index_map) {
+    if (UCS_BITMAP_IS_ZERO_INPLACE(&addr_index_map)) {
          snprintf(p, endp - p, "%s  ", ucs_status_string(UCS_ERR_UNSUPPORTED));
          p += strlen(p);
          goto out;
@@ -466,18 +466,18 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
              * be the same when connecting to worker address and when connecting
              * to a remote ep by wireup protocol.
              */
-            rsc_addr_index_map = 0;
+            UCS_BITMAP_CLEAR(&rsc_addr_index_map);
             for (lane = 0; lane < select_ctx->num_lanes; ++lane) {
                 lane_desc = &select_ctx->lane_descs[lane];
                 if (lane_desc->rsc_index == rsc_index) {
-                    rsc_addr_index_map |= UCS_BIT(lane_desc->addr_index);
+                    UCS_BITMAP_SET(rsc_addr_index_map, lane_desc->addr_index);
                 }
             }
-            rsc_addr_index_map &= addr_index_map;
+            UCS_BITMAP_AND_INPLACE(&rsc_addr_index_map, addr_index_map);
         }
 
         is_reachable = 0;
-        ucs_for_each_bit(addr_index, rsc_addr_index_map) {
+        UCS_BITMAP_FOR_EACH_BIT(rsc_addr_index_map, addr_index) {
             ae = &address->address_list[addr_index];
             if (!ucp_wireup_is_reachable(ep, select_params->ep_init_flags,
                                          rsc_index, ae)) {


### PR DESCRIPTION
## What

Handle address count > 64.

## Why ?

To fix using UCX out of the box on large nodes, e.g NVIDIA DGX A100, where the number of resources is bigger than 64. And as result, the number of address entries is bigger than 64.
```
...
#      resource 64 :  md 13 dev 23 flags -- ud_mlx5/mlx5_9:1
#      resource 65 :  md 14 dev 24 flags -- rc_verbs/mlx5_10:1
#      resource 66 :  md 14 dev 24 flags -- rc_mlx5/mlx5_10:1
#      resource 67 :  md 14 dev 24 flags -- dc_mlx5/mlx5_10:1
#      resource 68 :  md 14 dev 24 flags -- ud_verbs/mlx5_10:1
#      resource 69 :  md 14 dev 24 flags -- ud_mlx5/mlx5_10:1
#      resource 70 :  md 15 dev 0  flags -- cma/memory
#      resource 71 :  md 16 dev 0  flags -- knem/memory
#
# memory: 5.51MB, file descriptors: 28
# create time: 78.895 ms
#
[1630939198.390763] [node01:683504:0]          wireup.c:1061 UCX  ERROR   old: am_lane 0 wireup_msg_lane 3 cm_lane <none> reachable_mds 0x1ffff ep_check_map 0x0
[1630939198.390802] [node01:683504:0]          wireup.c:1082 UCX  ERROR   old: lane[0]:  2:self/memory0.0 md[2]          -> md[2]/self/sysdev[255] am am_bw#0
[1630939198.390808] [node01:683504:0]          wireup.c:1082 UCX  ERROR   old: lane[1]:  0:posix/memory.0 md[0]          -> md[0]/posix/sysdev[255] rkey_ptr
[1630939198.390813] [node01:683504:0]          wireup.c:1082 UCX  ERROR   old: lane[2]: 16:rc_mlx5/mlx5_0:1.0 md[4]      -> md[4]/ib/sysdev[255] rma_bw#0
[1630939198.390818] [node01:683504:0]          wireup.c:1082 UCX  ERROR   old: lane[3]: 21:rc_mlx5/mlx5_1:1.0 md[5]      -> md[5]/ib/sysdev[255] rma_bw#1 wireup
[1630939198.390824] [node01:683504:0]          wireup.c:1061 UCX  ERROR   new: am_lane 0 wireup_msg_lane 2 cm_lane <none> reachable_mds 0x1ffff ep_check_map 0x0
[1630939198.390828] [node01:683504:0]          wireup.c:1082 UCX  ERROR   new: lane[0]:  2:self/memory0.0 md[2]          -> md[2]/self/sysdev[255] am am_bw#0
[1630939198.390832] [node01:683504:0]          wireup.c:1082 UCX  ERROR   new: lane[1]: 16:rc_mlx5/mlx5_0:1.0 md[4]      -> md[4]/ib/sysdev[255] rma_bw#0
[1630939198.390835] [node01:683504:0]          wireup.c:1082 UCX  ERROR   new: lane[2]: 21:rc_mlx5/mlx5_1:1.0 md[5]      -> md[5]/ib/sysdev[255] rma_bw#1 wireup
[node01:683504:0:683504]      wireup.c:1368 Fatal: endpoint reconfiguration not supported yet
```

## How ?

1. Introduce new type `ucp_tl_addr_bitmap_t` which is the same as `ucp_tl_bitmap_t`, but have more meaningful name.
2. Replace using `uint64_t` by `ucp_tl_addr_bitmap_t` to store address indices.