### PR TITLE
UCT/IB/UD/BASE: Align negative-ack packet flag name with other flags

### DIFF
--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -55,7 +55,7 @@ enum {
     UCT_UD_PACKET_FLAG_AM      = UCS_BIT(24),
     UCT_UD_PACKET_FLAG_ACK_REQ = UCS_BIT(25),
     UCT_UD_PACKET_FLAG_ECN     = UCS_BIT(26),
-    UCT_UD_PACKET_FLAG_NAK     = UCS_BIT(27),
+    UCT_UD_PACKET_FLAG_NACK    = UCS_BIT(27),
     UCT_UD_PACKET_FLAG_PUT     = UCS_BIT(28),
     UCT_UD_PACKET_FLAG_CTL     = UCS_BIT(29),
 
@@ -73,7 +73,7 @@ network header layout
 
 A - ack request
 E - explicit congestion notification (ecn)
-N - negative acknoledgement
+N - negative acknowledgement
 P - put emulation (will be disabled in the future)
 C - control packet extended header
 
@@ -104,7 +104,7 @@ Control packet header
         struct { // am false
             uint8_t ack_req:1;
             uint8_t ecn:1;
-            uint8_t nak:1;
+            uint8_t nack:1;
             uint8_t put:1;
             uint8_t ctl:1;
             uint8_t reserved:2;

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -881,7 +881,7 @@ void uct_ud_ep_process_rx(uct_ud_iface_t *iface, uct_ud_neth_t *neth, unsigned b
     }
 
     if (ucs_unlikely(!is_am)) {
-        if (neth->packet_type & UCT_UD_PACKET_FLAG_NAK) {
+        if (neth->packet_type & UCT_UD_PACKET_FLAG_NACK) {
             uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_TX_NACKED);
             goto out;
         }
@@ -1321,7 +1321,7 @@ static void uct_ud_ep_send_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
     }
 
     if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_NACK)) {
-        skb->neth->packet_type |= UCT_UD_PACKET_FLAG_NAK;
+        skb->neth->packet_type |= UCT_UD_PACKET_FLAG_NACK;
     }
 
     if (ctl_flags & UCT_UD_IFACE_SEND_CTL_FLAG_INLINE) {

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -205,7 +205,7 @@ enum {
     UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(9),  /* CREQ message is NOT sent, because
                                                        connection establishment process
                                                        is driven by remote side. */
-    UCT_UD_EP_FLAG_TX_NACKED         = UCS_BIT(10), /* Last psn was acked with NAK */
+    UCT_UD_EP_FLAG_TX_NACKED         = UCS_BIT(10), /* Last psn was acked with NACK */
 
     /* Endpoint is currently executing the pending queue */
 #if UCS_ENABLE_ASSERT

--- a/src/uct/ib/ud/base/ud_log.c
+++ b/src/uct/ib/ud/base/ud_log.c
@@ -38,8 +38,8 @@ void uct_ud_dump_packet(uct_base_iface_t *iface, uct_am_trace_type_t type,
         p += strlen(p);
         uct_iface_dump_am(iface, type, am_id, neth + 1,
                           length - sizeof(*neth), p, endp - p);
-    } else if (neth->packet_type & UCT_UD_PACKET_FLAG_NAK) {
-        snprintf(p, endp - p, " NAK");
+    } else if (neth->packet_type & UCT_UD_PACKET_FLAG_NACK) {
+        snprintf(p, endp - p, " NACK");
     } else if (neth->packet_type & UCT_UD_PACKET_FLAG_PUT) {
         puth = (uct_ud_put_hdr_t *)(neth + 1);
         snprintf(p, endp - p, " PUT: 0x%0lx len %zu", puth->rva,


### PR DESCRIPTION
## What

Align negative-ack packet flag name with other flags.

## Why ?

It is easier to find code related to negative-ack and also it aligns with other flags (e.g. `UCT_UD_EP_FLAG_TX_NACKED`)


## How ?

1. Replace `UCT_UD_PACKET_FLAG_NAK` by `UCT_UD_PACKET_FLAG_NACK`.
2. Fix all occurrences.
3. Fix comments where negative-ack is mentioned.