### PR TITLE
UCT/IB/UD/BASE: Fix receiving duplicated CREQ or CREQ after CREP

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -684,6 +684,21 @@ static uct_ud_ep_t *uct_ud_ep_create_passive(uct_ud_iface_t *iface, uct_ud_ctl_h
     return ep;
 }
 
+static void uct_ud_ep_rx_ctl_drop_packet(uct_ud_ep_t *ep, uct_ud_neth_t *neth,
+                                         uint16_t exp_flags,
+                                         const char *packet_type_str)
+{
+    ucs_trace_data("ep %p: drop %s with psn %u, head_sn %u",
+                   ep, packet_type_str, neth->psn, ep->rx.ooo_pkts.head_sn);\
+    ucs_assertv_always(ep->flags & exp_flags, /* At lease one must be set */
+                       "conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u"
+                       " neth_psn=%u ep_flags=0x%x exp_ep_flags=0x%x"
+                       " ctl_ops=0x%x rx_creq_count=%d",
+                       ep->conn_sn, ep->ep_id, ep->dest_ep_id,
+                       ep->rx.ooo_pkts.head_sn, neth->psn, ep->flags,
+                       exp_flags, ep->tx.pending.ops, ep->rx_creq_count);
+}
+
 static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
 {
     uct_ud_ctl_hdr_t *ctl = (uct_ud_ctl_hdr_t *)(neth + 1);
@@ -701,24 +716,22 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
         ep->rx.ooo_pkts.head_sn = neth->psn;
         uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
         uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREP);
-    } else {
-        if (ep->dest_ep_id == UCT_UD_EP_NULL_ID) {
-            /* simultaneuous CREQ */
-            uct_ud_ep_set_dest_ep_id(ep, uct_ib_unpack_uint24(ctl->conn_req.ep_addr.ep_id));
-            ep->rx.ooo_pkts.head_sn = neth->psn;
-            uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
-            ucs_debug("simultaneuous CREQ ep=%p"
-                      "(iface=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u)",
-                      ep, iface, ep->conn_sn, ep->ep_id,
-                      ep->dest_ep_id, ep->rx.ooo_pkts.head_sn);
-            if (UCT_UD_PSN_COMPARE(ep->tx.psn, >, UCT_UD_INITIAL_PSN)) {
-                /* our own creq was sent, treat incoming creq as ack and remove our own
-                 * from tx window
-                 */
-                uct_ud_ep_process_ack(iface, ep, UCT_UD_INITIAL_PSN, 0);
-            }
-            uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREP);
+    } else if (ep->dest_ep_id == UCT_UD_EP_NULL_ID) {
+        /* simultaneuous CREQ */
+        uct_ud_ep_set_dest_ep_id(ep, uct_ib_unpack_uint24(ctl->conn_req.ep_addr.ep_id));
+        ep->rx.ooo_pkts.head_sn = neth->psn;
+        uct_ud_peer_copy(&ep->peer, ucs_unaligned_ptr(&ctl->peer));
+        ucs_debug("simultaneuous CREQ ep=%p"
+                  "(iface=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u)",
+                  ep, iface, ep->conn_sn, ep->ep_id,
+                  ep->dest_ep_id, ep->rx.ooo_pkts.head_sn);
+        if (UCT_UD_PSN_COMPARE(ep->tx.psn, >, UCT_UD_INITIAL_PSN)) {
+            /* our own creq was sent, treat incoming creq as ack and remove our
+             * own from tx window
+             */
+            uct_ud_ep_process_ack(iface, ep, UCT_UD_INITIAL_PSN, 0);
         }
+        uct_ud_ep_ctl_op_add(iface, ep, UCT_UD_EP_OP_CREP);
     }
 
     ++ep->rx_creq_count;
@@ -737,14 +750,25 @@ static void uct_ud_ep_rx_creq(uct_ud_iface_t *iface, uct_ud_neth_t *neth)
                        uct_ib_unpack_uint24(ctl->conn_req.ep_addr.ep_id),
                        ep->dest_ep_id);
 
-    /* creq must always have same psn */
+    /* Discard duplicate CREQ or CREQ after CREP */
+    if (UCT_UD_PSN_COMPARE(neth->psn, <, ep->rx.ooo_pkts.head_sn)) {
+        uct_ud_ep_rx_ctl_drop_packet(ep, neth,
+                                     UCT_UD_EP_FLAG_CREQ_RCVD |
+                                     UCT_UD_EP_FLAG_CREP_RCVD,
+                                     "CREQ");
+        return;
+    }
+
+    /* CREQ must have same psn */
     ucs_assertv_always(ep->rx.ooo_pkts.head_sn == neth->psn,
-                       "iface=%p ep=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
-                       "neth_psn=%u ep_flags=0x%x ctl_ops=0x%x rx_creq_count=%d",
+                       "iface=%p ep=%p conn_sn=%d ep_id=%d, dest_ep_id=%d"
+                       " rx_psn=%u neth_psn=%u ep_flags=0x%x ctl_ops=0x%x"
+                       " rx_creq_count=%d",
                        iface, ep, ep->conn_sn, ep->ep_id, ep->dest_ep_id,
                        ep->rx.ooo_pkts.head_sn, neth->psn, ep->flags,
                        ep->tx.pending.ops, ep->rx_creq_count);
-    /* scedule connection reply op */
+
+    /* Schedule connection reply op */
     UCT_UD_EP_HOOK_CALL_RX(ep, neth, sizeof(*neth) + sizeof(*ctl));
     if (uct_ud_ep_ctl_op_check(ep, UCT_UD_EP_OP_CREQ)) {
         uct_ud_ep_set_state(ep, UCT_UD_EP_FLAG_CREQ_NOTSENT);
@@ -771,6 +795,8 @@ static void uct_ud_ep_rx_ctl(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 
     /* Discard duplicate CREP */
     if (UCT_UD_PSN_COMPARE(neth->psn, <, ep->rx.ooo_pkts.head_sn)) {
+        uct_ud_ep_rx_ctl_drop_packet(ep, neth, UCT_UD_EP_FLAG_CREP_RCVD,
+                                     "CREP");
         return;
     }
 


### PR DESCRIPTION
## What

Fix receiving duplicated CREQ packet or CREQ packet after CREP packet was already received.

## Why ?

Fixes the following assertion (`head_sn == 2`, `neth->psn == 1`):
```
[node1:17303:0:17303]       ud_ep.c:746  Assertion `ep->rx.ooo_pkts.head_sn == neth->psn' failed: iface=0x404c7090 ep=0x40559bc0 conn_sn=0 ep_id=0, dest_ep_id=0 rx_psn=2 neth_psn=1 ep_flags=0xd8 ctl
_ops=0x0 rx_creq_count=1

/hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/uct/ib/ud/base/ud_ep.c: [ uct_ud_ep_rx_creq() ]
      ...
      738                        ep->dest_ep_id);
      739
      740     /* creq must always have same psn */
==>   741     ucs_assertv_always(ep->rx.ooo_pkts.head_sn == neth->psn,
      742                        "iface=%p ep=%p conn_sn=%d ep_id=%d, dest_ep_id=%d rx_psn=%u "
      743                        "neth_psn=%u ep_flags=0x%x ctl_ops=0x%x rx_creq_count=%d",
      744                        iface, ep, ep->conn_sn, ep->ep_id, ep->dest_ep_id,

==== backtrace (tid:  17303) ====
 0 0x000000000014909c uct_ud_ep_rx_creq()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/uct/ib/ud/base/ud_ep.c:741
 1 0x0000000000149a50 uct_ud_ep_process_rx()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/uct/ib/ud/base/ud_ep.c:855
 2 0x0000000000168294 uct_ud_mlx5_iface_poll_rx()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/uct/ib/ud/accel/ud_mlx5.c:510
 3 0x0000000000168294 uct_ud_mlx5_iface_progress()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/uct/ib/ud/accel/ud_mlx5.c:561
 4 0x000000000005714c ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/ucs/datastruct/callbackq.h:211
 5 0x0000000000063d2c uct_worker_progress()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/uct/api/uct.h:2592
 6 0x00000000000a553c ucp_rma_wait()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/ucp/rma/rma.inl:71
 7 0x00000000000a91a4 ucp_flush_wait()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/ucp/rma/flush.c:603
 8 0x00000000000a935c ucp_worker_flush_inner()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/ucp/rma/flush.c:614
 9 0x00000000000a935c ucp_worker_flush()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/ucp/rma/flush.c:606
10 0x000000000040c138 ucp_perf_test_setup_endpoints()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/libperf.c:1211
11 0x000000000040cffc ucp_perf_setup()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/libperf.c:1563
12 0x000000000040d408 ucx_perf_run()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/libperf.c:1650
13 0x0000000000405bd8 run_test_recurs()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest_run.c:253
14 0x0000000000405e70 run_test()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest_run.c:312
15 0x0000000000404e14 main()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest.c:877
16 0x00000000000215d4 __libc_start_main()  :0
17 0x00000000004036ec _start()  :0
=================================
```

## How ?

1. Replace `else` and inner `if` by `else if` to simplify code in `uct_ud_ep_rx_creq()` function.
2. Add checking of `neth->psn < head_sn` on the endpoint when handling CREQ packet and do nothing in case duplicated CREQ (or CREQ was received after CERP). This is the same behavior as UD already has for handling CREP packet.
3. Add assertion that CREQ_RCVD flag set and `rx_creq_count > 1` on the endpoint if `neth->psn < head_sn` condition is true when handling CREQ packet.
4. Add assertion that CREP_RCVD flag set on the endpoint if `neth->psn < head_sn` condition is true when handling CREP packet.