### PR TITLE
IB/SEND-OPS/STR: added obj-str implementation

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1071,6 +1071,7 @@ ucs_status_t uct_dc_mlx5_iface_fc_grant(uct_pending_req_t *self)
 
     uct_rc_ep_init_send_op(send_op, 0, NULL,
                            uct_dc_mlx5_ep_fc_pure_grant_send_completion);
+    uct_rc_iface_send_op_set_name(send_op, "dc_mlx5_iface_fc_grant");
 
     send_op->buffer = fc_req;
     status          = uct_dc_mlx5_ep_fc_pure_grant_send(ep, send_op);

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1598,6 +1598,7 @@ uct_dc_mlx5_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
     }
 
     uct_rc_ep_init_send_op(op, 0, NULL, uct_dc_mlx5_ep_check_send_completion);
+    uct_rc_iface_send_op_set_name(op, "dc_mlx5_ep_check");
     op->ep = tl_ep;
     UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, iface->keepalive_dci, txqp, txwq);
     uct_rc_mlx5_txqp_inline_post(&iface->super, UCT_IB_QPT_DCI,

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -377,8 +377,8 @@ uct_rc_txqp_add_send_comp(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
 
 static inline void
 uct_rc_ep_init_send_op(uct_rc_iface_send_op_t *op, unsigned flags,
-                            uct_completion_t *comp,
-                            uct_rc_send_handler_t handler)
+                       uct_completion_t *comp,
+                       uct_rc_send_handler_t handler)
 {
     op->flags     = flags;
     op->user_comp = comp;
@@ -400,6 +400,7 @@ uct_rc_txqp_add_flush_comp(uct_rc_iface_t *iface, uct_base_ep_t *ep,
         }
 
         uct_rc_ep_init_send_op(op, 0, comp, uct_rc_ep_flush_op_completion_handler);
+        uct_rc_iface_send_op_set_name(op, "rc_txqp_add_flush_comp");
         op->iface = iface;
         uct_rc_txqp_add_send_op_sn(txqp, op, sn);
     }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -149,12 +149,17 @@ static ucs_mpool_ops_t uct_rc_pending_mpool_ops = {
     .obj_str       = NULL
 };
 
+
+static void ucp_send_op_mpool_obj_str(ucs_mpool_t *mp, void *obj,
+                                      ucs_string_buffer_t *strb);
+
+
 static ucs_mpool_ops_t uct_rc_send_op_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
     .obj_init      = NULL,
     .obj_cleanup   = NULL,
-    .obj_str       = NULL
+    .obj_str       = ucp_send_op_mpool_obj_str
 };
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
@@ -966,3 +971,28 @@ void uct_rc_iface_vfs_refresh(uct_iface_h iface)
         rc_iface_ops->ep_vfs_populate(ep);
     }
 }
+
+static void ucp_send_op_mpool_obj_str(ucs_mpool_t *mp, void *obj,
+                                      ucs_string_buffer_t *strb)
+{
+    uct_rc_iface_send_op_t *op    = obj;
+    const char *handler_func_name = ucs_debug_get_symbol_name(op->handler);
+    const char *comp_func_name;
+
+    ucs_string_buffer_appendf(strb, "flags:0x%x handler:%s()", op->flags,
+                              handler_func_name);
+
+    if (op->flags & UCT_RC_IFACE_SEND_OP_STATUS) {
+        ucs_string_buffer_appendf(strb, " status:%d", op->status);
+    }
+
+    if (op->user_comp != NULL) {
+        comp_func_name = ucs_debug_get_symbol_name(op->user_comp->func);
+        ucs_string_buffer_appendf(strb, " comp:%s()", comp_func_name);
+    }
+
+#if ENABLE_DEBUG_DATA
+    ucs_string_buffer_appendf(strb, " name:%s", op->name);
+#endif
+}
+

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -342,6 +342,10 @@ struct uct_rc_iface_send_op {
 #ifndef NVALGRIND
     struct iovec                  *iov;        /* get_zcopy with valgrind */
 #endif
+
+#if ENABLE_DEBUG_DATA
+    const char                    *name;       /* object ID, debug only */
+#endif
 };
 
 
@@ -600,6 +604,14 @@ static UCS_F_ALWAYS_INLINE int
 uct_rc_iface_poll_tx(uct_rc_iface_t *iface, unsigned count)
 {
     return (count == 0) || iface->config.tx_poll_always;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_send_op_set_name(uct_rc_iface_send_op_t *op, const char *name)
+{
+#if ENABLE_DEBUG_DATA
+    op->name = name;
+#endif
 }
 
 #endif


### PR DESCRIPTION
- added obj_str implementation for send-ops mpool to simplify
  resource leaks investigation
