### PR TITLE
APPS/IO-DEMO/UCP: Add assertion for connection status

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1064,6 +1064,7 @@ void ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
     ucp_request_t *close_req;
 
     UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(ucp_ep->worker);
+    ucs_assert(UCS_STATUS_IS_ERR(status));
     ucs_assert(!ucs_async_is_from_async(&ucp_ep->worker->async));
 
     ucs_debug("ep %p: set_ep_failed status %s on lane[%d]=%p", ucp_ep,

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -971,6 +971,9 @@ void UcxConnection::stream_recv_callback(void *request, ucs_status_t status,
     ucx_request *r      = reinterpret_cast<ucx_request*>(request);
     UcxConnection *conn = r->conn;
 
+    assert(!r->completed);
+    r->status = status;
+
     if (!conn->is_established()) {
         assert(conn->_establish_cb == r->callback);
 


### PR DESCRIPTION
## What

1. Add assertion for connection status.
2. Set `status` for `ucx_request` objects when handling UCP Stream receive operations.

## Why ?

1. 
2. Ensure that stream receive operation status reflects correct
before:
```
[1630617673.417183] [UCX-connection 0xdc1d90: #101 2.1.3.4:20009] completing conn_id receive request 0xfc64d8 with status "Success" (0) during disconnect
```
after:
```
[1631102046.926942] [UCX-connection 0x1fe2630: #163 2.1.3.11:20017] completing conn_id receive request 0x2407998 with status "Endpoint is not connected" (-24) during disconnect
```


## How ?

1. Add assertions:
- `status` must be error in `ucp_ep_set_failed()`.
- `status` must be `UCS_OK` when handling receive operations.
2. Set `status` for `ucx_request` objects in `UcxConnection::stream_recv_callback()` callback.