### PR TITLE
GTEST/UCT: Don't use ptr_vector's method for std::vector, use ptr_vector where possible

### DIFF
--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -47,11 +47,13 @@ void* test_md::alloc_thread(void *arg)
 
     while (!*stop_flag) {
         int count = ucs::rand() % 100;
-        std::vector<void*> buffers;
+        ucs::ptr_vector<void> buffers;
         for (int i = 0; i < count; ++i) {
+            // allocate via malloc(), because ptr_vector<void>::release()
+            // method specialization uses free() to release a memory obtained
+            // for an element
             buffers.push_back(malloc(ucs::rand() % (256 * UCS_KBYTE)));
         }
-        std::for_each(buffers.begin(), buffers.end(), free);
     }
     return NULL;
 }

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -566,9 +566,8 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_hold_uct_desc,
                             msg_size, true);
     }
 
-    for (ucs::ptr_vector<void>::const_iterator iter = m_uct_descs.begin();
-         iter != m_uct_descs.end(); ++iter)
-    {
+    for (std::vector<void*>::const_iterator iter = m_uct_descs.begin();
+         iter != m_uct_descs.end(); ++iter) {
         uct_iface_release_desc(*iter);
     }
 }


### PR DESCRIPTION
## What

1. Don't use `ucs::ptr_vector`'s methods for manipulating with `std::vector`.
2. Use ptr_vector where possible.

## Why ?

1. Using `ucs::ptr_vector`'s methods for `std::vector` is possible, but make code unclear.
2. Use `ucs::ptr_vector` instead of `std::vector` to not take care of objects allocated and added to the vector.

## How ?

1. Replace `ucs::ptr_vector<void>::const_iterator` by `std::vector<void>::const_iterator`.
2. Remove `std::for_each` which calls `free()` for all objects, and use declare buffers as `ucs::ptr_vector` instead of `std::vector`.