### PR TITLE
UCT: Remove component name from rkey

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -330,28 +330,12 @@ ucs_status_t uct_config_modify(void *config, const char *name, const char *value
 
 ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
 {
-    void *rbuf = uct_md_fill_md_name(md, rkey_buffer);
-    return md->ops->mkey_pack(md, memh, rbuf);
+    return md->ops->mkey_pack(md, memh, rkey_buffer);
 }
 
 ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,
                              uct_rkey_bundle_t *rkey_ob)
 {
-    char component_name[UCT_COMPONENT_NAME_MAX + 1];
-
-    if (ENABLE_DEBUG_DATA) {
-        if (ENABLE_PARAMS_CHECK &&
-            strncmp(rkey_buffer, component->name, UCT_COMPONENT_NAME_MAX)) {
-            ucs_snprintf_zero(component_name, sizeof(component_name), "%s",
-                              (const char*)rkey_buffer);
-            ucs_error("invalid component for rkey unpack; "
-                      "expected: %s, actual: %s", component_name, component->name);
-            return UCS_ERR_INVALID_PARAM;
-        }
-
-        rkey_buffer = UCS_PTR_BYTE_OFFSET(rkey_buffer, UCT_COMPONENT_NAME_MAX);
-    }
-
     return component->rkey_unpack(component, rkey_buffer, &rkey_ob->rkey,
                                   &rkey_ob->handle);
 }
@@ -380,11 +364,6 @@ ucs_status_t uct_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 
     /* Component name + data */
     memcpy(md_attr->component_name, md->component->name, UCT_COMPONENT_NAME_MAX);
-
-#if ENABLE_DEBUG_DATA
-    /* MD name is packed into rkey in DEBUG mode only */
-    md_attr->rkey_packed_size += UCT_COMPONENT_NAME_MAX;
-#endif
 
     return UCS_OK;
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -153,17 +153,6 @@ struct uct_md {
     }
 
 
-static UCS_F_ALWAYS_INLINE void*
-uct_md_fill_md_name(uct_md_h md, void *buffer)
-{
-#if ENABLE_DEBUG_DATA
-    memcpy(buffer, md->component->name, UCT_COMPONENT_NAME_MAX);
-    return (char*)buffer + UCT_COMPONENT_NAME_MAX;
-#else
-    return buffer;
-#endif
-}
-
 /*
  * Base implementation of query_md_resources(), which returns a single md
  * resource whose name is identical to component name.

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -613,15 +613,13 @@ void uct_rc_mlx5_handle_unexp_rndv(uct_rc_mlx5_iface_common_t *iface,
                                    unsigned byte_len, int poll_flags)
 {
     uct_rc_mlx5_tmh_priv_data_t *priv = (uct_rc_mlx5_tmh_priv_data_t*)tmh->reserved;
-    uct_ib_md_t *ib_md                = uct_ib_iface_md(&iface->super.super);
     struct ibv_rvh *rvh;
     unsigned tm_hdrs_len;
     unsigned rndv_usr_hdr_len;
     size_t rndv_data_len;
     void *rndv_usr_hdr;
-    void *rb;
     ucs_status_t status;
-    char packed_rkey[UCT_COMPONENT_NAME_MAX + UCT_IB_MD_PACKED_RKEY_SIZE];
+    char packed_rkey[UCT_IB_MD_PACKED_RKEY_SIZE];
 
     rvh = (struct ibv_rvh*)(tmh + 1);
 
@@ -645,8 +643,7 @@ void uct_rc_mlx5_handle_unexp_rndv(uct_rc_mlx5_iface_common_t *iface,
     memcpy((char*)rndv_usr_hdr - priv->length, &priv->data, priv->length);
 
     /* Create "packed" rkey to pass it in the callback */
-    rb = uct_md_fill_md_name(&ib_md->super, packed_rkey);
-    uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_RKEY, rb);
+    uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_RKEY, packed_rkey);
 
     /* Do not pass flags to cb, because rkey is allocated on stack */
     status = iface->tm.rndv_unexp.cb(iface->tm.rndv_unexp.arg, 0, tag,

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -392,7 +392,7 @@ static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
     attr->cap.access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->cap.max_alloc        = 0;
     attr->cap.max_reg          = ULONG_MAX;
-    attr->rkey_packed_size     = 0; /* uct_md_query adds UCT_COMPONENT_NAME_MAX to this */
+    attr->rkey_packed_size     = 0;
     attr->reg_cost             = ucs_linear_func_make(0, 0);
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;


### PR DESCRIPTION
## What
Remove component name from UCT rkey (which is present in debug mode only)

## Why ?
align with release version format and facilitate potential extensions