### PR TITLE
UCS/ARCH/AARCH64: Suppress warning about set but never used variable

### DIFF
--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -145,7 +145,8 @@ static inline void ucs_cpu_init()
 
 static inline void ucs_arch_wait_mem(void *address)
 {
-    unsigned long tmp;
+    /* Suppress potential warning that variable was set but never used */
+    unsigned long UCS_V_UNUSED tmp;
     asm volatile ("ldaxrb %w0, [%1] \n"
                   "wfe           \n"
                   : "=&r"(tmp)


### PR DESCRIPTION
## What

Suppress the warning about set but never used variable

## Why ?

Fixes #7371

## How ?

Use `UCS_V_UNUSED` attribute for `tmp` variable declaration in`ucs_arch_wait_mem()` function.