### PR TITLE
TOOLS/PERF: Don't check the received message if recv failed

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -226,9 +226,10 @@ static void sock_rte_barrier(void *rte_group, void (*progress)(void *arg),
     safe_send(group->connfd, &snc, sizeof(unsigned), progress, arg);
 
     snc = 0;
-    safe_recv(group->connfd, &snc, sizeof(unsigned), progress, arg);
-
-    ucs_assert(snc == magic);
+    
+    if (safe_recv(group->connfd, &snc, sizeof(unsigned), progress, arg) == 0) {
+        ucs_assert(snc == magic);
+    }
   }
 #pragma omp barrier
 }


### PR DESCRIPTION
## What

Don't check the received message if receive failed during barrier.

## Why ?

Fixes the following assertion failed:
```
+--------------+--------------+------------------------------+---------------------+-----------------------+
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
[1631303657.809706] [bf2-smc-02-01:10881:0]        perftest.c:129  UCX  ERROR recv() failed: Connection reset by peer
[bf2-smc-02-01:10881:0:10881]    perftest.c:231  Assertion `snc == magic' failed

/hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest.c: [ sock_rte_barrier() ]
      ...
      228     snc = 0;
      229     safe_recv(group->connfd, &snc, sizeof(unsigned), progress, arg);
      230
==>   231     ucs_assert(snc == magic);
      232   }
      233 #pragma omp barrier
      234 }

==== backtrace (tid:  10881) ====
 0 0x0000000000403fd4 sock_rte_barrier()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest.c:231
 1 0x000000000040c798 ucp_perf_barrier()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/libperf.c:1356
 2 0x00000000004bc190 ucp_perf_test_runner<(ucx_perf_cmd_t)8, (ucx_perf_test_type_t)2, 0u>::run_stream_uni()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/ucp_tests.cc:654
 3 0x00000000004aabac ucp_perf_test_runner<(ucx_perf_cmd_t)8, (ucx_perf_test_type_t)2, 0u>::run()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/ucp_tests.cc:700
 4 0x00000000004a8528 ucp_perf_test_dispatch()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/ucp_tests.cc:834
 5 0x000000000040d4cc ucx_perf_run()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/lib/libperf.c:1665
 6 0x0000000000405bd8 run_test_recurs()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest_run.c:253
 7 0x0000000000405e70 run_test()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest_run.c:312
 8 0x0000000000404e14 main()  /hpc/mtr_scrap/users/dmitrygla_bf2/ucx/src/tools/perf/perftest.c:877
 9 0x00000000000215d4 __libc_start_main()  :0
10 0x00000000004036ec _start()  :0
=================================
```

## How ?

Check assertion `ucs_assert(snc == magic);` only if `safe_recv()` returns `0` which means success,