### PR TITLE
GTEST/UCS: Reduce rcache pfn test runtime under valgrind

### DIFF
--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -1025,8 +1025,10 @@ protected:
 };
 
 UCS_TEST_F(test_rcache_pfn, enum_pfn) {
-    const int MAX_PAGE_NUM = 1024 * 100; /* 400Mb max buffer */
-    size_t page_size       = ucs_get_page_size();
+    const size_t page_size = ucs_get_page_size();
+    const int MAX_PAGE_NUM = RUNNING_ON_VALGRIND ? 16 :
+                             /* 400Mb max buffer */
+                             (400 * UCS_MBYTE / page_size);
     void *region;
     unsigned i;
     size_t len;
@@ -1045,7 +1047,7 @@ UCS_TEST_F(test_rcache_pfn, enum_pfn) {
     /* initialize stream here to avoid incorrect debug output */
     ucs::detail::message_stream ms("PAGES");
 
-    for (i = 1; i < MAX_PAGE_NUM; i *= 2) {
+    for (i = 1; i <= MAX_PAGE_NUM; i *= 2) {
         len = page_size * i;
         ms << i << " ";
         region = mmap(NULL, len, PROT_READ | PROT_WRITE,


### PR DESCRIPTION
## What

Reduce testing time by decreasing number of pages checked in rcache pfn test when running under valgrind.

## Why ?

To reduce testing time.
before:
```
[ RUN      ] test_rcache_pfn.enum_pfn <> <>
[    PAGES ] 1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536
[       OK ] test_rcache_pfn.enum_pfn (181494 ms)
[----------] 1 test from test_rcache_pfn (181508 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (181625 ms total)
[  PASSED  ] 1 test.

```
after:
```
[ RUN      ] test_rcache_pfn.enum_pfn <> <>
[    PAGES ] 1 2 4 8 16
[       OK ] test_rcache_pfn.enum_pfn (107 ms)
[----------] 1 test from test_rcache_pfn (119 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (224 ms total)
[  PASSED  ] 1 test.
```

e.g. on CI gpu nodes, it is longest test that we have:
```
2021-09-10T18:51:20.7250928Z TOP-20 longest tests:
2021-09-10T18:51:20.7298181Z  1. test_rcache_pfn.enum_pfn                                                                                                  - 52967 ms
2021-09-10T18:51:20.7313988Z  2. rc_mlx5/test_uct_perf.envelope/1                                                                                          - 24881 ms
2021-09-10T18:51:20.7323667Z  3. dc_mlx5/test_uct_perf.envelope/1                                                                                          - 23437 ms
2021-09-10T18:51:20.7333384Z  4. ud_mlx5/test_uct_perf.envelope/1                                                                                          - 23395 ms
2021-09-10T18:51:20.7342723Z  5. shm_ib/test_ucp_rma.get_blocking/2                                                                                        - 17482 ms
...
```

## How ?

1. Change `MAX_PAGE_NUM` calculation to make it more clear: `400 * UCS_MBYTE / page_size` instead of `100 * 1024`.
2. Set ` 16` as `MAX_PAGE_NUM` when running the test under valgrind.