### PR TITLE
UCS/CONFIG: Allow-list for loadable modules

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -914,6 +914,14 @@ test_ucp_dlopen() {
 	else
 		echo "==== Not running UCP library loading test ===="
 	fi
+
+	# Test module allow-list
+	UCX_MODULES=^ib,rdmacm ./src/tools/info/ucx_info -d |& tee ucx_info_noib.log
+	if grep -in "component:\s*ib$" ucx_info_noib.log
+	then
+		echo "IB module was loaded even though it was disabled"
+		exit 1
+	fi
 }
 
 test_init_mt() {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1393,7 +1393,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
         context->proto_bitmap = UCS_MASK(ucp_protocols_count);
     } else {
         for (proto_id = 0; proto_id < ucp_protocols_count; ++proto_id) {
-            match = ucs_config_names_search(config->protos.array,
+            match = ucs_config_names_search(&config->protos.array,
                                             ucp_proto_id_field(proto_id, name));
             if (((config->protos.mode == UCS_CONFIG_ALLOW_LIST_ALLOW) &&
                  (match >= 0)) ||

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -53,6 +53,7 @@ ucs_global_opts_t ucs_global_opts = {
     .rcache_check_pfn      = 0,
     .module_dir            = UCX_MODULE_DIR, /* defined in Makefile.am */
     .module_log_level      = UCS_LOG_LEVEL_TRACE,
+    .modules               = { {NULL, 0}, UCS_CONFIG_ALLOW_LIST_ALLOW_ALL },
     .arch                  = UCS_ARCH_GLOBAL_OPTS_INITALIZER
 };
 
@@ -262,6 +263,13 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   {"MODULE_LOG_LEVEL", "trace",
    "Logging level for module loader\n",
    ucs_offsetof(ucs_global_opts_t, module_log_level), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
+
+  {"MODULES", "all",
+   "Comma-separated list of glob patterns specifying which module load.\n"
+   "The order is not meaningful. For example:\n"
+   " *     - load all modules\n"
+   " ^cu*  - do not load modules that begin with 'cu'\n",
+   ucs_offsetof(ucs_global_opts_t, modules), UCS_CONFIG_TYPE_ALLOW_LIST},
 
   {"", "", NULL,
    ucs_offsetof(ucs_global_opts_t, arch),

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -130,6 +130,9 @@ typedef struct {
     /* log level for module loader code */
     ucs_log_level_t            module_log_level;
 
+    /* which modules to load */
+    ucs_config_allow_list_t    modules;
+
     /* arch-specific global options */
     ucs_arch_global_opts_t     arch;
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -910,7 +910,7 @@ int ucs_config_sprintf_allow_list(char *buf, size_t max, const void *src,
         snprintf(buf, max, UCS_CONFIG_PARSER_ALL);
         return 1;
     }
-    
+
     if (allow_list->mode == UCS_CONFIG_ALLOW_LIST_NEGATE) {
         buf[offset++] = ucs_config_parser_negate;
         max--;
@@ -1974,14 +1974,14 @@ size_t ucs_config_memunits_get(size_t config_size, size_t auto_size,
     }
 }
 
-int ucs_config_names_search(ucs_config_names_array_t config_names,
+int ucs_config_names_search(const ucs_config_names_array_t *config_names,
                             const char *str)
 {
     unsigned i;
 
-    for (i = 0; i < config_names.count; ++i) {
-        if (!fnmatch(config_names.names[i], str, 0)) {
-           return i;
+    for (i = 0; i < config_names->count; ++i) {
+        if (!fnmatch(config_names->names[i], str, 0)) {
+            return i;
         }
     }
 

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -502,7 +502,7 @@ size_t ucs_config_memunits_get(size_t config_size, size_t auto_size,
  * @param config_names     lookup array of counters patterns.
  * @param str              string to search.
  */
-int ucs_config_names_search(ucs_config_names_array_t config_names,
+int ucs_config_names_search(const ucs_config_names_array_t *config_names,
                             const char *str);
 
 END_C_DECLS

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -370,7 +370,7 @@ static void ucs_stats_add_to_filter(ucs_stats_node_t *node,
     node->filter_node = filter_node;
 
     for (i = 0; (i < node->cls->num_counters) && (i < 64); ++i) {
-        filter_index = ucs_config_names_search(ucs_global_opts.stats_filter,
+        filter_index = ucs_config_names_search(&ucs_global_opts.stats_filter,
                                                node->cls->counter_names[i]);
         if (filter_index >= 0) {
             filter_node->counters_bitmask |= UCS_BIT(i);

--- a/src/ucs/sys/module.c
+++ b/src/ucs/sys/module.c
@@ -197,6 +197,22 @@ static void ucs_module_init(const char *module_path, void *dl)
     }
 }
 
+
+static int ucs_module_is_enabled(const char *module_name)
+{
+    ucs_config_allow_list_mode_t mode = ucs_global_opts.modules.mode;
+    int found;
+
+    if (mode == UCS_CONFIG_ALLOW_LIST_ALLOW_ALL) {
+        return 1;
+    }
+
+    found = ucs_config_names_search(&ucs_global_opts.modules.array,
+                                    module_name) >= 0;
+    return ((mode == UCS_CONFIG_ALLOW_LIST_ALLOW) && found) ||
+           ((mode == UCS_CONFIG_ALLOW_LIST_NEGATE) && !found);
+}
+
 static void ucs_module_load_one(const char *framework, const char *module_name,
                                 unsigned flags)
 {
@@ -205,6 +221,12 @@ static void ucs_module_load_one(const char *framework, const char *module_name,
     unsigned i;
     void *dl;
     int mode;
+
+    if (!ucs_module_is_enabled(module_name)) {
+        ucs_module_trace("module '%s' is disabled by configuration",
+                         module_name);
+        return;
+    }
 
     mode = RTLD_LAZY;
     if (flags & UCS_MODULE_LOAD_FLAG_NODELETE) {
@@ -215,6 +237,8 @@ static void ucs_module_load_one(const char *framework, const char *module_name,
     } else {
         mode |= RTLD_LOCAL;
     }
+
+    ucs_module_trace("loading module '%s' with mode 0x%x", module_name, mode);
 
     for (i = 0; i < ucs_module_loader_state.srchpath_cnt; ++i) {
         snprintf(module_path, sizeof(module_path) - 1, "%s/lib%s_%s%s",


### PR DESCRIPTION
## Why
Allow disabling some of the loadable modules by a configuration parameter, to prevent undesired initialzation.
For example, `UCX_MODULES=^cuda` would disable loading cuda modules.