### PR TITLE
GTEST/UCP: Decrease maximum test size and use step=111 under valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -605,7 +605,8 @@ UCS_TEST_P(test_ucp_stream, send_recv_data_recv_iov) {
 
 UCS_TEST_P(test_ucp_stream, send_zero_ending_iov_recv_data) {
     const size_t min_size         = UCS_KBYTE;
-    const size_t max_size         = min_size * 64;
+    const size_t max_size         = min_size * 64 / ucs::test_time_multiplier();
+    const size_t step_size        = RUNNING_ON_VALGRIND ? 111 : 1;
     const size_t iov_num          = 8; /* must be divisible by 4 without a
                                         * remainder, caught on mlx5 based TLs
                                         * where max_iov = 3 for zcopy multi
@@ -621,7 +622,7 @@ UCS_TEST_P(test_ucp_stream, send_zero_ending_iov_recv_data) {
     param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE;
     param.datatype     = DATATYPE_IOV;
 
-    for (size_t size = min_size; size < max_size; ++size) {
+    for (size_t size = min_size; size < max_size; size += step_size) {
         size_t slen = 0;
         for (size_t j = 0; j < iov_num; ++j) {
             if ((j % 2) == 0) {


### PR DESCRIPTION
## What

Reduce testing time by decreasing maximum test size and use step=111 instead of step=1 when running under valgrind.

## Why ?

To reduce testing time.
before:
```
[ RUN      ] tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0 <tcp>
==168595== WARNING: valgrind ignores shmget(shmflg) SHM_HUGETLB
[       OK ] tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0 (97415 ms)
[----------] 1 test from tcp/test_ucp_stream (97428 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (97534 ms total)
[  PASSED  ] 1 test.
```
after:
```
[ RUN      ] tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0 <tcp>
==172248== WARNING: valgrind ignores shmget(shmflg) SHM_HUGETLB
[       OK ] tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0 (2515 ms)
[----------] 1 test from tcp/test_ucp_stream (2528 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2633 ms total)
[  PASSED  ] 1 test.
```

e.g. on CI "new" nodes, it is the longest tests that we have:
```
2021-09-10T18:46:19.4506196Z TOP-20 longest tests:
2021-09-10T18:46:19.4508433Z  1. tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                      - 96770 ms
2021-09-10T18:46:19.4511003Z  2. ud/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                       - 93583 ms
2021-09-10T18:46:19.4513632Z  3. udx/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                      - 81979 ms
2021-09-10T18:46:19.4521822Z  4. rc/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                       - 60894 ms
2021-09-10T18:46:19.4524804Z  5. dcx/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                      - 54209 ms
2021-09-10T18:46:19.4527313Z  6. self/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                     - 53927 ms
2021-09-10T18:46:19.4535259Z  7. rcx/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                      - 52701 ms
2021-09-10T18:46:19.4538274Z  8. shm_ib/test_ucp_stream.send_zero_ending_iov_recv_data/0                                                                   - 52657 ms
...
```

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
