### PR TITLE
GTEST/UCT: Remove IB CM related stuff

### DIFF
--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -717,16 +717,13 @@ UCS_TEST_P(uct_p2p_am_tx_bufs, am_tx_max_bufs) {
     status = uct_iface_set_am_handler(receiver().iface(), AM_ID, am_handler,
                                       this, UCT_CB_FLAG_ASYNC);
     ASSERT_UCS_OK(status);
-    /* skip on cm, ud */
+    /* skip on ud/rc */
     if (!m_inited) {
         UCS_TEST_SKIP_R("Test does not apply to the current transport");
-    }
-    if (has_transport("cm")) {
-        UCS_TEST_SKIP_R("Test does not work with IB CM transport");
-    }
-    if (has_rc()) {
+    } else if (has_rc()) {
         UCS_TEST_SKIP_R("Test does not work with IB RC transports");
     }
+
     do {
         status = am_bcopy(sender_ep(), sendbuf_bcopy, recvbuf);
     } while (status == UCS_OK);

--- a/test/gtest/uct/test_pending.cc
+++ b/test/gtest/uct/test_pending.cc
@@ -487,8 +487,7 @@ UCS_TEST_SKIP_COND_P(test_uct_pending, pending_async,
  */
 UCS_TEST_SKIP_COND_P(test_uct_pending, pending_ucs_ok_dc_arbiter_bug,
                      !check_caps(UCT_IFACE_FLAG_AM_SHORT |
-                                 UCT_IFACE_FLAG_PENDING) ||
-                     has_transport("cm"))
+                                 UCT_IFACE_FLAG_PENDING))
 {
     int N, max_listen_conn;
 

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -175,8 +175,7 @@ const test_perf::test_spec test_uct_perf::tests[] =
 
 
 UCS_TEST_P(test_uct_perf, envelope) {
-    if (has_transport("cm") ||
-        has_transport("ugni_udt")) {
+    if (has_transport("ugni_udt")) {
         UCS_TEST_SKIP;
     }
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -443,8 +443,7 @@ protected:
     rc_verbs,           \
     dc_mlx5,            \
     ud_verbs,           \
-    ud_mlx5,            \
-    cm
+    ud_mlx5
 
 
 #define UCT_TEST_CMS rdmacm, tcp


### PR DESCRIPTION
## What

Remove IB CM related stuff.

## Why ?

IB CM is deprecated.

## How ?

1. Remove `has_transport("cm")` checks.
2. Remove "cm" from UCT transports enabled for testing.