### PR TITLE
GTEST/UCS: Reduce testing time of conn_match under valgrind

### DIFF
--- a/test/gtest/ucs/test_conn_match.cc
+++ b/test/gtest/ucs/test_conn_match.cc
@@ -175,11 +175,14 @@ ucs_conn_match_ctx_t test_conn_match::m_conn_match_ctx = {};
 
 
 UCS_TEST_F(test_conn_match, random_insert_retrieve) {
-    const size_t        max_addresses      = 128;
-    const ucs_conn_sn_t max_conns          = 128;
-    const size_t        max_address_length = 2048 / ucs::test_time_multiplier();
-    const size_t        min_address_length = ucs::to_string(max_addresses).size();
-    const size_t        max_iters          = 4;
+    const size_t max_conn_iters     =
+            ucs_max(1, ucs_min(5, 128 / ucs::test_time_multiplier()));;       
+    const size_t max_addresses      = max_conn_iters;
+    const ucs_conn_sn_t max_conns   = max_conn_iters;
+    const size_t min_address_length = ucs::to_string(max_addresses).size();
+    const size_t max_address_length =
+            ucs_max(min_address_length, 2048 / ucs::test_time_multiplier());
+    const size_t max_iters          = 4;
 
     for (size_t it = 0; it < max_iters; it++) {
         size_t address_length = ucs::rand() %


### PR DESCRIPTION
## What

Reduce testing time of conn_match under valgrind.

## Why ?

Check only 5 connections and up to 5 addresses instead of 128 when the test running under valgrind.
It reduces testing time.
before:
```
[ RUN      ] tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0 <tcp>
==168595== WARNING: valgrind ignores shmget(shmflg) SHM_HUGETLB
[       OK ] tcp/test_ucp_stream.send_zero_ending_iov_recv_data/0 (97415 ms)
[----------] 1 test from tcp/test_ucp_stream (97428 ms total)
```
after:
```
[ RUN      ] test_conn_match.random_insert_retrieve <> <>
[     INFO ] address length: 56
[     INFO ] address length: 23
[     INFO ] address length: 9
[     INFO ] address length: 93
[       OK ] test_conn_match.random_insert_retrieve (419 ms)
[----------] 1 test from test_conn_match (432 ms total)
```
The test is one of the longest one:
```
2021-09-11T17:53:34.4722461Z TOP-20 longest tests:
2021-09-11T17:53:34.4771887Z  1. test_conn_match.random_insert_retrieve                                                                                    - 48950 ms
2021-09-11T17:53:34.4789193Z  2. rc_verbs/test_uct_perf.envelope/1                                                                                         - 42352 ms
2021-09-11T17:53:34.4799141Z  3. ud_verbs/test_uct_perf.envelope/1                                                                                         - 40097 ms
```

## How ?

1. Get a minimum between `5` and `128 / test_time_multiplier()` for `max_addresses` and `max_conns`. And also make sure that the value is >= `1`.
2. Make sure that `max_address_length` is >= `min_address_length`