### PR TITLE
APPS/IO-DEMO: Remove the checks for status=OK from Write/Read response callbacks

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -876,12 +876,12 @@ public:
             }
 
             if (_status == UCS_OK) {
-                ASSERTV(_conn->ucx_status() == UCS_OK) << "conn_status="
-                        << _conn->ucx_status();
-
-                _server->send_io_write_response(_conn, *_iov, _sn);
                 if (_server->opts().validate) {
                     validate(*_iov, _sn);
+                }
+                
+                if (_conn->ucx_status() == UCS_OK) {
+                    _server->send_io_write_response(_conn, *_iov, _sn);
                 }
             }
 
@@ -1336,24 +1336,16 @@ public:
             _client->handle_operation_completion(_server_index, IO_READ,
                                                  _iov->data_size());
 
-            if (_status == UCS_OK) {
-                const server_info_t& server_info =
-                        _client->_server_info[_server_index];
-
-                ASSERTV(server_info.conn->ucx_status() == UCS_OK)
-                        << "conn_status=" << server_info.conn->ucx_status();
-
-                if (_validate) {
-                    validate(*_iov, _sn);
-                    if (_meta_comp_counter != 0) {
-                        // With tag API, we also wait for READ_COMP arrival, so need
-                        // to validate it. With AM API, READ_COMP arrives as AM
-                        // header together with data descriptor, we validate it in
-                        // place to avoid unneeded memory copy to this
-                        // IoReadResponseCallback _buffer.
-                        iomsg_t *msg = reinterpret_cast<iomsg_t*>(_buffer);
-                        validate(msg, _sn, _buffer_size);
-                    }
+            if ((_status == UCS_OK) && _validate) {
+                validate(*_iov, _sn);
+                if (_meta_comp_counter != 0) {
+                    // With tag API, we also wait for READ_COMP arrival, so
+                    // need to validate it. With AM API, READ_COMP arrives as
+                    // AM header together with data descriptor, we validate it
+                    // in place to avoid unneeded memory copy to this
+                    // IoReadResponseCallback _buffer.
+                    iomsg_t *msg = reinterpret_cast<iomsg_t*>(_buffer);
+                    validate(msg, _sn, _buffer_size);
                 }
             }
 


### PR DESCRIPTION
## What

Remove the checks for status=OK from Write/Read response callbacks.

## Why ?

Fixes:
```
Log: /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20210912_081742_57991_66409_jazz23.swx.labs.mlnx/iodemo_logs/1631424149-447875792/iodemo_jazz23_server_12.log
Error iodemo analyzer: [1631424864.852342] [DEMO] Assertion "_conn->ucx_status() == UCS_OK" failed conn_status=-25
```
introduced by #7362.

## How ?

Update `IoReadResponseCallback`/`IoWriteResponseCallback` to not have assertion for `conn.ucx_status() == UCS_OK`.