### PR TITLE
GTEST/UCP: Reduce buffer length and step multiplier under valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -253,15 +253,16 @@ void test_ucp_stream::do_send_recv_data_test(ucp_datatype_t datatype)
 template <typename T, unsigned recv_flags>
 void test_ucp_stream::do_send_recv_test(ucp_datatype_t datatype)
 {
-    const size_t      dt_elem_size = UCP_DT_IS_CONTIG(datatype) ?
-                                     ucp_contig_dt_elem_size(datatype) : 1;
-    size_t            ssize        = 0; /* total send size */
-    std::vector<char> sbuf(16 * UCS_MBYTE, 's');
+    const size_t      dt_elem_size    = UCP_DT_IS_CONTIG(datatype) ?
+                                        ucp_contig_dt_elem_size(datatype) : 1;
+    size_t            ssize           = 0; /* total send size */
+    size_t            iter_multiplier = RUNNING_ON_VALGRIND ? 10 : 2;
+    std::vector<char> sbuf(16 * UCS_MBYTE / ucs::test_time_multiplier(), 's');
     ucs_status_ptr_t  sstatus;
     std::vector<char> check_pattern;
 
     /* send all msg sizes in bytes*/
-    for (size_t i = 3; i < sbuf.size(); i *= 2) {
+    for (size_t i = 3; i < sbuf.size(); i *= iter_multiplier) {
         ucp_datatype_t dt;
         if (UCP_DT_IS_GENERIC(datatype)) {
             dt = datatype;


### PR DESCRIPTION
## What

Reduce buffer length and step multiplier when running under valgrind.

## Why ?

before:
```
[ RUN      ] udx/test_ucp_stream.send_recv_iov/0 <ud_x>
[       OK ] udx/test_ucp_stream.send_recv_iov/0 (13095 ms)
[----------] 1 test from udx/test_ucp_stream (13105 ms total)
```
after:
```
[ RUN      ] udx/test_ucp_stream.send_recv_iov/0 <ud_x>
[       OK ] udx/test_ucp_stream.send_recv_iov/0 (1592 ms)
[----------] 1 test from udx/test_ucp_stream (1603 ms total)
```
i.e. now the test takes 1.6s instead of 13.1s.
These are one of the longest tests under valgrind:
```
2021-09-12T21:37:45.4632585Z 12. shm_ib/test_ucp_stream.send_recv_iov/0                                                                                    - 15444 ms
2021-09-12T21:37:45.4641504Z 13. posix/test_uct_perf.envelope/0                                                                                            - 15423 ms
2021-09-12T21:37:45.4650081Z 14. shm_ib/test_ucp_stream.send_recv_8/0                                                                                      - 15008 ms
2021-09-12T21:37:45.4658285Z 15. rc/test_ucp_wireup_1sided.multi_wireup/7                                                                                  - 14959 ms
2021-09-12T21:37:45.4666968Z 16. udx/test_ucp_stream.send_recv_iov/0                                                                                       - 14718 ms
2021-09-12T21:37:45.4675641Z 17. udx/test_ucp_stream.send_recv_8/0                                                                                         - 14466 ms
2021-09-12T21:37:45.4684610Z 18. rc/test_ucp_stream.send_recv_8/0                                                                                          - 14314 ms
2021-09-12T21:37:45.4693275Z 19. rc/test_ucp_stream.send_recv_iov/0                                                                                        - 14212 ms
```

## How ?

 1. Apply test multiplier for sender buffer size to reduce it from `16 MB` to `16 MB / 20` when running under valgrind.
 2. Use iteration multiplier `ucs::test_time_mutiplier()` instead of `2` when running under valgrind.