### PR TITLE
APPS/IO-DEMO: Throw a range_error exception if validation fails

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -793,7 +793,22 @@ protected:
         abort();
     }
 
-    class DataCorruptionError : public std::exception {
+    class ValidateError : public std::exception {
+    public:
+        ValidateError() throw() {
+        }
+
+        ValidateError(const ValidateError& other) throw() {
+        }
+
+        ~ValidateError() throw() {
+        }
+
+    protected:
+        std::stringstream _ss;
+    };
+
+    class DataCorruptionError : public ValidateError {
     public:
         DataCorruptionError(const char *type, size_t err_pos) throw() {
             _ss << "ERROR: iov " << type << " corruption at " << err_pos
@@ -810,11 +825,10 @@ protected:
             return _ss.str().c_str();
         }
 
-    private:
-        std::stringstream _ss;
+    
     };
 
-    class SnMismatchError : public std::exception {
+    class SnMismatchError : public ValidateError {
     public:
         SnMismatchError(size_t sn, size_t exp_sn) throw() {
             _ss << "ERROR: io msg sn mismatch " << sn << " != " << exp_sn;
@@ -829,9 +843,6 @@ protected:
         virtual const char *what() const throw() {
             return _ss.str().c_str();
         }
-
-    private:
-        std::stringstream _ss;
     };
 
     static void validate(const BufferIov& iov, unsigned seed) {

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -804,15 +804,21 @@ protected:
         ~ValidateError() throw() {
         }
 
+        virtual const char *what() const throw() {
+            return _str.c_str();
+        }
+
     protected:
-        std::stringstream _ss;
+        std::string _str;
     };
 
     class DataCorruptionError : public ValidateError {
     public:
         DataCorruptionError(const char *type, size_t err_pos) throw() {
-            _ss << "ERROR: iov " << type << " corruption at " << err_pos
-                << " position";
+            std::stringstream ss;
+            ss << "ERROR: iov " << type << " corruption at " << err_pos
+               << " position";
+            _str = ss.str();
         }
 
         DataCorruptionError(const DataCorruptionError& other) throw() {
@@ -820,28 +826,20 @@ protected:
 
         ~DataCorruptionError() throw() {
         }
-
-        virtual const char *what() const throw() {
-            return _ss.str().c_str();
-        }
-
-    
     };
 
     class SnMismatchError : public ValidateError {
     public:
         SnMismatchError(size_t sn, size_t exp_sn) throw() {
-            _ss << "ERROR: io msg sn mismatch " << sn << " != " << exp_sn;
+            std::stringstream ss;
+            ss << "ERROR: io msg sn mismatch " << sn << " != " << exp_sn;
+            _str = ss.str();
         }
 
         SnMismatchError(const SnMismatchError& other) throw() {
         }
 
         ~SnMismatchError() throw() {
-        }
-
-        virtual const char *what() const throw() {
-            return _ss.str().c_str();
         }
     };
 

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -820,12 +820,6 @@ protected:
                << " position";
             _str = ss.str();
         }
-
-        DataCorruptionError(const DataCorruptionError& other) throw() {
-        }
-
-        ~DataCorruptionError() throw() {
-        }
     };
 
     class SnMismatchError : public ValidateError {
@@ -834,12 +828,6 @@ protected:
             std::stringstream ss;
             ss << "ERROR: io msg sn mismatch " << sn << " != " << exp_sn;
             _str = ss.str();
-        }
-
-        SnMismatchError(const SnMismatchError& other) throw() {
-        }
-
-        ~SnMismatchError() throw() {
         }
     };
 


### PR DESCRIPTION
## What

Throw a range_error exception if validation fails.

## Why ?

Throwing an exception was chosen over returning `npos()` like `std::find()` does, because:
- it aligns validating iov and messages.
- exceptions could be used in https://github.com/openucx/ucx/blob/2a5d4264274b9cc21a91450a3257d6f18fa3592e/test/apps/iodemo/io_demo.cc#L811 

## How ?

1. Throw `std::range_error` exception from `validate()` functions.
2. Catch exceptions in all functions that validate messages and iovs and print an error, connection and connection's status.