### PR TITLE
UCP/WIREUP/GTEST: Always calculate BW locally to avoid EP reconfigura…

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1389,18 +1389,17 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 
     ucp_context_uct_atomic_iface_flags(context, &atomic);
 
-    iface_cap_flags                      = UCT_IFACE_FLAG_ATOMIC_DEVICE;
+    iface_cap_flags = UCT_IFACE_FLAG_ATOMIC_DEVICE;
 
-    dummy_iface_attr.bandwidth.dedicated = 1e12;
-    dummy_iface_attr.bandwidth.shared    = 0;
-    dummy_iface_attr.cap_flags           = UINT64_MAX;
-    dummy_iface_attr.overhead            = 0;
-    dummy_iface_attr.priority            = 0;
-    dummy_iface_attr.lat_ovh             = 0;
+    dummy_iface_attr.bandwidth = 1e12;
+    dummy_iface_attr.cap_flags = UINT64_MAX;
+    dummy_iface_attr.overhead  = 0;
+    dummy_iface_attr.priority  = 0;
+    dummy_iface_attr.lat_ovh   = 0;
 
-    best_score                           = -1;
-    best_rsc                             = NULL;
-    best_priority                        = 0;
+    best_score    = -1;
+    best_rsc      = NULL;
+    best_priority = 0;
 
     /* Select best interface for atomics device */
     for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -397,13 +397,6 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
     ucp_address_packed_iface_attr_t  *packed;
     ucp_address_unified_iface_attr_t *unified;
 
-    /* check if at least one of bandwidth values is 0 */
-    if ((iface_attr->bandwidth.dedicated * iface_attr->bandwidth.shared) != 0) {
-        ucs_error("Incorrect bandwidth value: one of bandwidth dedicated/shared must be zero");
-        return -1;
-    }
-
-
     if (ucp_worker_is_unified_mode(worker)) {
         /* In unified mode all workers have the same transports and tl bitmap.
          * Just send rsc index, so the remote peer could fetch iface attributes
@@ -420,7 +413,8 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
     packed                 = ptr;
     packed->prio_cap_flags = (uint8_t)iface_attr->priority;
     packed->overhead       = iface_attr->overhead;
-    packed->bandwidth      = iface_attr->bandwidth.dedicated - iface_attr->bandwidth.shared;
+    packed->bandwidth      = ucp_tl_iface_bandwidth(worker->context,
+                                                    &iface_attr->bandwidth);
     packed->lat_ovh        = iface_attr->latency.c;
 
     ucs_assert((ucs_popcount(UCP_ADDRESS_IFACE_FLAGS) +
@@ -492,8 +486,11 @@ ucp_address_unpack_iface_attr(ucp_worker_t *worker,
         iface_attr->event_flags   = wiface->attr.cap.event_flags;
         iface_attr->priority      = wiface->attr.priority;
         iface_attr->overhead      = wiface->attr.overhead;
-        iface_attr->bandwidth     = wiface->attr.bandwidth;
+        iface_attr->bandwidth     =
+                ucp_tl_iface_bandwidth(worker->context,
+                                       &wiface->attr.bandwidth);
         iface_attr->dst_rsc_index = rsc_idx;
+
         if (signbit(unified->lat_ovh)) {
             iface_attr->atomic.atomic32.op_flags  = wiface->attr.cap.atomic32.op_flags;
             iface_attr->atomic.atomic32.fop_flags = wiface->attr.cap.atomic32.fop_flags;
@@ -505,12 +502,11 @@ ucp_address_unpack_iface_attr(ucp_worker_t *worker,
         return UCS_OK;
     }
 
-    packed                          = ptr;
-    iface_attr->priority            = packed->prio_cap_flags & UCS_MASK(8);
-    iface_attr->overhead            = packed->overhead;
-    iface_attr->bandwidth.dedicated = ucs_max(0.0, packed->bandwidth);
-    iface_attr->bandwidth.shared    = ucs_max(0.0, -packed->bandwidth);
-    iface_attr->lat_ovh             = packed->lat_ovh;
+    packed                = ptr;
+    iface_attr->priority  = packed->prio_cap_flags & UCS_MASK(8);
+    iface_attr->overhead  = packed->overhead;
+    iface_attr->bandwidth = packed->bandwidth;
+    iface_attr->lat_ovh   = packed->lat_ovh;
 
     /* Unpack iface flags */
     iface_attr->cap_flags =
@@ -1120,7 +1116,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
             if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
                 ucs_trace("unpack addr[%d] : sysdev %d paths %d eps %u"
                           " md_flags 0x%" PRIx64 " tl_iface_flags 0x%" PRIx64
-                          " tl_event_flags 0x%" PRIx64 " bw %.2f+%.2f/nMBs"
+                          " tl_event_flags 0x%" PRIx64 " bw %.2f/nMBs"
                           " ovh %.0fns lat_ovh %.0fns dev_priority %d"
                           " a32 0x%" PRIx64 "/0x%" PRIx64 " a64 0x%" PRIx64
                           "/0x%" PRIx64,
@@ -1128,8 +1124,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                           address->dev_num_paths, address->num_ep_addrs,
                           address->md_flags, address->iface_attr.cap_flags,
                           address->iface_attr.event_flags,
-                          address->iface_attr.bandwidth.dedicated / UCS_MBYTE,
-                          address->iface_attr.bandwidth.shared / UCS_MBYTE,
+                          address->iface_attr.bandwidth / UCS_MBYTE,
                           address->iface_attr.overhead * 1e9,
                           address->iface_attr.lat_ovh * 1e9,
                           address->iface_attr.priority,

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -84,7 +84,7 @@ struct ucp_address_iface_attr {
     uint64_t                    cap_flags;    /* Interface capability flags */
     uint64_t                    event_flags;  /* Interface event capability flags */
     double                      overhead;     /* Interface performance - overhead */
-    uct_ppn_bandwidth_t         bandwidth;    /* Interface performance - bandwidth */
+    double                      bandwidth;    /* Interface performance - bandwidth */
     int                         priority;     /* Priority of device */
     double                      lat_ovh;      /* Latency overhead */
     ucp_rsc_index_t             dst_rsc_index;/* Destination resource index */

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -769,7 +769,7 @@ static double ucp_wireup_rma_score_func(ucp_context_h context,
     return 1e-3 / (ucp_wireup_tl_iface_latency(context, iface_attr, remote_iface_attr) +
                    iface_attr->overhead +
                    (4096.0 / ucs_min(ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth),
-                                     ucp_tl_iface_bandwidth(context, &remote_iface_attr->bandwidth))));
+                                     remote_iface_attr->bandwidth)));
 }
 
 static void ucp_wireup_fill_peer_err_criteria(ucp_wireup_criteria_t *criteria,
@@ -958,7 +958,7 @@ static double ucp_wireup_rma_bw_score_func(ucp_context_h context,
      * how long it would take to transfer it with a certain transport. */
     return 1 / ((UCP_WIREUP_RMA_BW_TEST_MSG_SIZE /
                 ucs_min(ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth),
-                        ucp_tl_iface_bandwidth(context, &remote_iface_attr->bandwidth))) +
+                        remote_iface_attr->bandwidth)) +
                 ucp_wireup_tl_iface_latency(context, iface_attr, remote_iface_attr) +
                 iface_attr->overhead +
                 ucs_linear_func_apply(md_attr->reg_cost,
@@ -1080,7 +1080,7 @@ static double ucp_wireup_am_bw_score_func(ucp_context_h context,
     /* best single MTU bandwidth */
     double size = iface_attr->cap.am.max_bcopy;
     double t    = (size / ucs_min(ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth),
-                                  ucp_tl_iface_bandwidth(context, &remote_iface_attr->bandwidth))) +
+                                  remote_iface_attr->bandwidth)) +
                   iface_attr->overhead + remote_iface_attr->overhead +
                   ucp_wireup_tl_iface_latency(context, iface_attr, remote_iface_attr);
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1349,10 +1349,68 @@ UCS_TEST_P(test_ucp_wireup_fallback_amo, different_amo_types) {
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_fallback_amo,
                               shm_rc, "shm,rc_x,rc_v")
 
+
 /* NOTE: this fixture is NOT inherited from test_ucp_wireup, because we want to
  * create our own entities.
  */
 class test_ucp_wireup_asymmetric : public ucp_test {
+protected:
+    void tag_sendrecv(size_t size) {
+        std::string send_data(size, 's');
+        std::string recv_data(size, 'x');
+
+        ucs_status_ptr_t sreq = ucp_tag_send_nb(
+                        sender().ep(0), &send_data[0], size,
+                        ucp_dt_make_contig(1), 1,
+                        (ucp_send_callback_t)ucs_empty_function);
+        ucs_status_ptr_t rreq = ucp_tag_recv_nb(
+                        receiver().worker(), &recv_data[0], size,
+                        ucp_dt_make_contig(1), 1, 1,
+                        (ucp_tag_recv_callback_t)ucs_empty_function);
+        request_wait(sreq);
+        request_wait(rreq);
+
+        EXPECT_EQ(send_data, recv_data);
+    }
+
+public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant(variants, UCP_FEATURE_TAG);
+    }
+};
+
+
+/*
+ * Force asymmetric configuration by different PPN settings
+ */
+UCS_TEST_SKIP_COND_P(test_ucp_wireup_asymmetric, different_ppn_connect,
+                     is_self())
+{
+    {
+        modify_config("NUM_PPN", ucs::to_string(1).c_str());
+        create_entity();
+    }
+
+    {
+        modify_config("NUM_PPN", ucs::to_string(128).c_str());
+        create_entity();
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    receiver().connect(&sender(), get_ep_params());
+
+    ucp_ep_print_info(sender().ep(), stdout);
+    ucp_ep_print_info(receiver().ep(), stdout);
+
+    tag_sendrecv(1);
+    tag_sendrecv(100000);
+    tag_sendrecv(1000000);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_ucp_wireup_asymmetric)
+
+
+class test_ucp_wireup_asymmetric_ib : public test_ucp_wireup_asymmetric {
 protected:
     virtual void init() {
         static const char *ibdev_sysfs_dir = "/sys/class/infiniband";
@@ -1378,24 +1436,6 @@ protected:
         closedir(dir);
     }
 
-    void tag_sendrecv(size_t size) {
-        std::string send_data(size, 's');
-        std::string recv_data(size, 'x');
-
-        ucs_status_ptr_t sreq = ucp_tag_send_nb(
-                        sender().ep(0), &send_data[0], size,
-                        ucp_dt_make_contig(1), 1,
-                        (ucp_send_callback_t)ucs_empty_function);
-        ucs_status_ptr_t rreq = ucp_tag_recv_nb(
-                        receiver().worker(), &recv_data[0], size,
-                        ucp_dt_make_contig(1), 1, 1,
-                        (ucp_tag_recv_callback_t)ucs_empty_function);
-        request_wait(sreq);
-        request_wait(rreq);
-
-        EXPECT_EQ(send_data, recv_data);
-    }
-
     /* Generate a pci_bw configuration string for IB devices, which assigns
      * the speed ai+b for device i.
      */
@@ -1412,18 +1452,14 @@ protected:
     }
 
     std::vector<std::string> m_ib_devices;
-
-public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
-        add_variant(variants, UCP_FEATURE_TAG);
-    }
 };
 
 /*
  * Force asymmetric configuration by different PCI_BW settings
  */
-UCS_TEST_SKIP_COND_P(test_ucp_wireup_asymmetric, connect, is_self()) {
-
+UCS_TEST_SKIP_COND_P(test_ucp_wireup_asymmetric_ib, different_pci_bw_connect,
+                     is_self())
+{
     /* Enable cross-dev connection */
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv path_mtu_env("UCX_RC_PATH_MTU", "1024");
@@ -1455,9 +1491,9 @@ UCS_TEST_SKIP_COND_P(test_ucp_wireup_asymmetric, connect, is_self()) {
     tag_sendrecv(1000000);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric, rcv, "rc_v")
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric, rcx, "rc_x")
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric, ib, "ib")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric_ib, rcv, "rc_v")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric_ib, rcx, "rc_x")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_asymmetric_ib, ib, "ib")
 
 class test_ucp_wireup_keepalive : public test_ucp_wireup {
 public:


### PR DESCRIPTION
## What

Backporting #7335 PR to v1.11.x

## Why ?

The fix will be released along with v1.11.2.

## How ?

Cherry-pick commit from #7335 PR.