### PR TITLE
AZP: remove --privileged for docker

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -5,10 +5,9 @@ resources:
       options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
     - container: fedora
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:1
-      options: --privileged
     - container: fedora34
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora34:2
-      options: --privileged -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
+      options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
     - container: coverity_rh7
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/coverity:mofed-5.1-2.3.8.0
       options: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools


### PR DESCRIPTION
## Why
Fix test failures when RoCE devices are visible inside the container, but cannot be used because no `--net=host`