### PR TITLE
UCP/FLUSH: Handle removed lanes during wireup process

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -47,39 +47,28 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
 
     /* If the number of lanes changed since flush operation was submitted, adjust
      * the number of expected completions */
-    if (ucs_unlikely(req->send.flush.num_lanes != num_lanes)) {
-        ucp_trace_req(req, "ep %p: number of lanes changed from %d to %d",
-                      ep, req->send.flush.num_lanes, num_lanes);
-        diff                      = num_lanes - req->send.flush.num_lanes;
-        req->send.flush.num_lanes = num_lanes;
-        if (diff >= 0) {
-            ucp_trace_req(req,
-                          "ep %p: adjusting expected flush completion count by %d",
-                          ep, diff);
+    diff = num_lanes - req->send.flush.num_lanes;
+    if (ucs_unlikely(diff != 0)) {
+        if (diff > 0) {
+            ucs_debug("ep %p: flush req %p lanes changed from %d to %d, "
+                      "adding %d to completion count",
+                      ep, req, req->send.flush.num_lanes, num_lanes, diff);
             req->send.state.uct_comp.count += diff;
         } else {
-            /* If we have less lanes, it means we are in error flow:
-             * - if count == 0, we have completed the flush on all lanes
-             * - otherwise, flush progress was re-scheduled from flush progress
-             *   pending right after ucp_worker_iface_err_handle_progress(),
-             *   so remove destroyed/failed lanes from started_lanes and count
-             *   them completed.
-             */
-            ucs_assert(ep->flags & UCP_EP_FLAG_FAILED);
-            if (req->send.state.uct_comp.count > 0) {
-                destroyed_lanes = req->send.flush.started_lanes & ~all_lanes;
-
-                ucs_debug("req %p: lanes 0x%x were destroyed so reducing comp "
-                          "count by %d", req, destroyed_lanes,
-                          ucs_popcount(destroyed_lanes));
-                req->send.flush.started_lanes  &= ~destroyed_lanes;
-                req->send.state.uct_comp.count -= ucs_popcount(destroyed_lanes);
-            }
-
-            ucs_assertv(req->send.state.uct_comp.count == 0,
-                        "uct_comp.count=%d num_lanes=%d",
-                        req->send.state.uct_comp.count, num_lanes);
+            /* Some lanes that we wanted to flush were destroyed. If we already
+               started to flush them, they would be completed by discard flow,
+               so reduce completion count only by the lanes we have not started
+               to flush yet. */
+            destroyed_lanes = UCS_MASK(req->send.flush.num_lanes) & ~all_lanes &
+                              ~req->send.flush.started_lanes;
+            ucs_debug("ep %p: flush req %p lanes changed from %d to %d, "
+                      "destroyed_lanes 0x%x, reducing completion count by %d",
+                      ep, req, req->send.flush.num_lanes, num_lanes,
+                      destroyed_lanes, ucs_popcount(destroyed_lanes));
+            ucs_assert(!(req->send.flush.started_lanes & destroyed_lanes));
+            req->send.state.uct_comp.count -= ucs_popcount(destroyed_lanes);
         }
+        req->send.flush.num_lanes = num_lanes;
     }
 
     ucs_trace("ep %p flags 0x%x: progress flush req %p, started_lanes 0x%x "


### PR DESCRIPTION
## Why
Fix recent CI failures on "roce" machines: 
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=25646&view=logs&s=8bfbeaae-4c8e-5f12-f154-edd305817000&j=fe065d53-24bf-55d6-97e1-9993908ec8ed
```
[ RUN      ] all/test_ucp_sockaddr_destroy_ep_on_err.onesided_client_sforce/2 <all/tag,not_all_devs>
[     INFO ] Testing 2.1.6.4:0
[     INFO ] server listening on 2.1.6.4:54226
[swx-rain04:87501:0:87501]       flush.c:68   Assertion `ep->flags & UCP_EP_FLAG_FAILED' failed

/scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/rma/flush.c: [ ucp_ep_flush_progress() ]
      ...
       65              *   so remove destroyed/failed lanes from started_lanes and count
       66              *   them completed.
       67              */
==>    68             ucs_assert(ep->flags & UCP_EP_FLAG_FAILED);
       69             if (req->send.state.uct_comp.count > 0) {
       70                 destroyed_lanes = req->send.flush.started_lanes & ~all_lanes;
       71 

==== backtrace (tid:  87501) ====
 0 0x000000000007455f ucp_ep_flush_progress()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/rma/flush.c:68
 1 0x0000000000074640 ucp_ep_flush_progress_pending()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/rma/flush.c:226
 2 0x0000000000074640 ucp_flush_check_completion()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/rma/flush.c:185
 3 0x0000000000074640 ucp_ep_flush_progress_pending()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/rma/flush.c:227
 4 0x00000000000d54ed ucp_request_try_send()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_request.inl:318
 5 0x00000000000d54ed ucp_request_send()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_request.inl:341
 6 0x00000000000d54ed ucp_wireup_replay_pending_request()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/wireup/wireup.c:864
 7 0x00000000000d54ed ucp_wireup_replay_pending_requests()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/wireup/wireup.c:874
 8 0x00000000000d0397 ucp_wireup_ep_progress()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucp/wireup/wireup_ep.c:99
 9 0x000000000005574b ucs_callbackq_slow_proxy()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/callbackq.c:402
```