### PR TITLE
UCP/PROTO: Add request debugging and profiling

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1102,6 +1102,10 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
         req->recv.am.desc  = desc;
         rts                = data_desc;
 
+#if ENABLE_DEBUG_DATA
+        req->recv.proto_rndv_config = NULL;
+#endif
+
         ucp_request_set_callback_param(param, recv_am, req, recv.am);
 
         ucs_assert(rts->opcode == UCP_RNDV_RTS_AM);

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -14,6 +14,7 @@
 #include "ucp_request.inl"
 
 #include <ucp/proto/proto_am.h>
+#include <ucp/proto/proto_select.h>
 #include <ucp/tag/tag_rndv.h>
 
 #include <ucs/datastruct/mpool.inl>
@@ -49,6 +50,13 @@ ucp_request_str(ucp_request_t *req, ucs_string_buffer_t *strb, int recurse)
 
     ucs_string_buffer_appendf(strb, "flags:0x%x ", req->flags);
 
+    if (req->flags & UCP_REQUEST_FLAG_PROTO_SEND) {
+        ucp_proto_select_config_str(req->send.ep->worker,
+                                    req->send.proto_config,
+                                    req->send.state.dt_iter.length, strb);
+        return;
+    }
+
     if (req->flags & (UCP_REQUEST_FLAG_SEND_AM | UCP_REQUEST_FLAG_SEND_TAG)) {
         ucs_string_buffer_appendf(strb, "send length %zu ", req->send.length);
 
@@ -75,9 +83,19 @@ ucp_request_str(ucp_request_t *req, ucs_string_buffer_t *strb, int recurse)
         }
     } else if (req->flags &
                (UCP_REQUEST_FLAG_RECV_AM | UCP_REQUEST_FLAG_RECV_TAG)) {
+#if ENABLE_DEBUG_DATA
+        if (req->recv.proto_rndv_config != NULL) {
+            /* Print the send protocol of the rendezvous request */
+            ucp_proto_select_config_str(req->recv.worker,
+                                        req->recv.proto_rndv_config,
+                                        req->recv.length, strb);
+            return;
+        }
+#endif
         ucs_string_buffer_appendf(strb, "recv length %zu ", req->recv.length);
     } else {
-        ucs_string_buffer_appendf(strb, "no debug info ");
+        ucs_string_buffer_appendf(strb, "<no debug info>");
+        return;
     }
 
     ucs_string_buffer_appendf(

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -36,7 +36,8 @@
 enum {
     UCP_REQUEST_FLAG_COMPLETED             = UCS_BIT(0),
     UCP_REQUEST_FLAG_RELEASED              = UCS_BIT(1),
-    /* UCS_BIT(2) and UCS_BIT(3) are vacant flags */
+    UCP_REQUEST_FLAG_PROTO_SEND            = UCS_BIT(2),
+    /* UCS_BIT(3) is a vacant flag */
     UCP_REQUEST_FLAG_SYNC_LOCAL_COMPLETED  = UCS_BIT(4),
     UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED = UCS_BIT(5),
     UCP_REQUEST_FLAG_CALLBACK              = UCS_BIT(6),
@@ -355,6 +356,12 @@ struct ucp_request {
 
             /* Remote request ID received from a peer */
             ucs_ptr_map_key_t     remote_req_id;
+
+#if ENABLE_DEBUG_DATA
+            /* For rendezvous receive with new protocols: selected protocol for
+               fetching remote data */
+            const ucp_proto_config_t *proto_rndv_config;
+#endif
 
             union {
                 struct {

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -176,25 +176,25 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
     ucs_status_t status;
     uint8_t sg_count;
 
-    req->flags   = 0;
+    req->flags   = UCP_REQUEST_FLAG_PROTO_SEND;
     req->send.ep = ep;
 
-    ucp_datatype_iter_init(worker->context, (void*)buffer, count, datatype,
-                           contig_length, 1, &req->send.state.dt_iter,
-                           &sg_count);
+    UCS_PROFILE_CALL_VOID(ucp_datatype_iter_init, worker->context,
+                          (void*)buffer, count, datatype, contig_length, 1,
+                          &req->send.state.dt_iter, &sg_count);
 
     ucp_proto_select_param_init(&sel_param, op_id, param->op_attr_mask,
                                 req->send.state.dt_iter.dt_class,
                                 &req->send.state.dt_iter.mem_info, sg_count);
 
-    status = ucp_proto_request_lookup_proto(worker, ep, req, proto_select,
-                                            rkey_cfg_index, &sel_param,
-                                            req->send.state.dt_iter.length);
+    status = UCS_PROFILE_CALL(ucp_proto_request_lookup_proto, worker, ep, req,
+                              proto_select, rkey_cfg_index, &sel_param,
+                              req->send.state.dt_iter.length);
     if (status != UCS_OK) {
         goto out_put_request;
     }
 
-    ucp_request_send(req);
+    UCS_PROFILE_CALL_VOID(ucp_request_send, req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
         goto out_put_request;
     }

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -179,4 +179,10 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
                      ucp_worker_cfg_index_t rkey_cfg_index,
                      ucp_worker_cfg_index_t *new_rkey_cfg_index);
 
+
+/* Print protocol configuration info to a string buffer */
+void ucp_proto_select_config_str(ucp_worker_h worker,
+                                 const ucp_proto_config_t *proto_config,
+                                 size_t msg_length, ucs_string_buffer_t *strb);
+
 #endif

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -37,6 +37,10 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     ucp_trace_req(req, "%s buffer %p dt 0x%lx count %zu tag %"PRIx64"/%"PRIx64,
                   debug_name, buffer, datatype, count, tag, tag_mask);
 
+#if ENABLE_DEBUG_DATA
+    req->recv.proto_rndv_config = NULL;
+#endif
+
     /* First, check the fast path case - single fragment
      * in this case avoid initializing most of request fields
      * */


### PR DESCRIPTION
## Why
- Implement UCP request info string for new protocols
- Add profiling for potentially time-consuming steps during a request lifetime