### PR TITLE
UCP/RMA/RNDV: Handle rkey_index==UCP_NULL_RESOURCE

### DIFF
--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -37,4 +37,15 @@ ucp_rkey_config(ucp_worker_h worker, ucp_rkey_h rkey)
     return &worker->rkey_config[rkey->cfg_index];
 }
 
+static UCS_F_ALWAYS_INLINE uct_rkey_t
+ucp_rkey_get_tl_rkey(ucp_rkey_h rkey, ucp_md_index_t rkey_index)
+{
+    if (rkey_index == UCP_NULL_RESOURCE) {
+        return UCT_INVALID_RKEY;
+    }
+
+    ucs_assert(rkey_index < ucs_popcount(rkey->md_map));
+    return rkey->tl_rkey[rkey_index].rkey.rkey;
+}
+
 #endif

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -27,8 +27,8 @@ ucp_proto_get_offload_bcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
                                       ucp_datatype_iter_t *next_iter)
 {
-    uct_rkey_t tl_rkey = ucp_rma_request_get_tl_rkey(req,
-                                                     lpriv->super.rkey_index);
+    uct_rkey_t tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
+                                              lpriv->super.rkey_index);
     size_t max_length, length;
     void *dest;
 
@@ -116,8 +116,8 @@ ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
                                       ucp_datatype_iter_t *next_iter)
 {
-    uct_rkey_t tl_rkey = ucp_rma_request_get_tl_rkey(req,
-                                                     lpriv->super.rkey_index);
+    uct_rkey_t tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
+                                              lpriv->super.rkey_index);
     uct_iov_t iov;
 
     ucp_datatype_iter_next_iov(&req->send.state.dt_iter,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -26,7 +26,7 @@ static ucs_status_t ucp_proto_put_offload_short_progress(uct_pending_req_t *self
     ucs_status_t status;
     uct_rkey_t tl_rkey;
 
-    tl_rkey = ucp_rma_request_get_tl_rkey(req, spriv->super.rkey_index);
+    tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey, spriv->super.rkey_index);
     status  = uct_ep_put_short(ep->uct_eps[spriv->super.lane],
                                req->send.state.dt_iter.type.contig.buffer,
                                req->send.state.dt_iter.length,
@@ -104,7 +104,8 @@ ucp_proto_put_offload_bcopy_send_func(ucp_request_t *req,
     ssize_t packed_size;
     uct_rkey_t tl_rkey;
 
-    tl_rkey     = ucp_rma_request_get_tl_rkey(req, lpriv->super.rkey_index);
+    tl_rkey     = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
+                                       lpriv->super.rkey_index);
     packed_size = uct_ep_put_bcopy(ep->uct_eps[lpriv->super.lane],
                                    ucp_proto_put_offload_bcopy_pack, &pack_ctx,
                                    req->send.rma.remote_addr +
@@ -179,7 +180,8 @@ ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
                                       ucp_datatype_iter_t *next_iter)
 {
-    uct_rkey_t tl_rkey = ucp_rma_request_get_tl_rkey(req, lpriv->super.rkey_index);
+    uct_rkey_t tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
+                                              lpriv->super.rkey_index);
     uct_iov_t iov;
 
     ucp_datatype_iter_next_iov(&req->send.state.dt_iter,

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -126,11 +126,4 @@ ucp_rma_sw_do_am_bcopy(ucp_request_t *req, uint8_t id, ucp_lane_index_t lane,
     return (ucs_status_t)packed_len;
 }
 
-static UCS_F_ALWAYS_INLINE uct_rkey_t
-ucp_rma_request_get_tl_rkey(ucp_request_t *req, ucp_md_index_t rkey_index)
-{
-    ucs_assert(rkey_index != UCP_NULL_RESOURCE);
-    return req->send.rma.rkey->tl_rkey[rkey_index].rkey.rkey;
-}
-
 #endif

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -227,7 +227,7 @@ ucp_put_send_short(ucp_ep_h ep, const void *buffer, size_t length,
         return UCS_ERR_NO_RESOURCE;
     }
 
-    tl_rkey = rkey->tl_rkey[rkey_config->put_short.rkey_index].rkey.rkey;
+    tl_rkey = ucp_rkey_get_tl_rkey(rkey, rkey_config->put_short.rkey_index);
     return UCS_PROFILE_CALL(uct_ep_put_short,
                             ep->uct_eps[rkey_config->put_short.lane],
                             buffer, length, remote_addr, tl_rkey);

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -412,8 +412,7 @@ static ucp_lane_index_t ucp_rndv_zcopy_get_lane(ucp_request_t *rndv_req,
     ucs_assert(lane_idx < UCP_MAX_LANES);
     rkey       = rndv_req->send.rndv.rkey;
     rkey_index = rndv_req->send.rndv.rkey_index[lane_idx];
-    *uct_rkey  = (rkey_index != UCP_NULL_RESOURCE) ?
-                 rkey->tl_rkey[rkey_index].rkey.rkey : UCT_INVALID_RKEY;
+    *uct_rkey  = ucp_rkey_get_tl_rkey(rkey, rkey_index);
     ep_config  = ucp_ep_config(rndv_req->send.ep);
     return (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ?
            ep_config->rndv.get_zcopy.lanes[lane_idx] :

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -72,8 +72,8 @@ ucp_proto_rndv_get_common_send(ucp_request_t *req,
                                const ucp_proto_multi_lane_priv_t *lpriv,
                                const uct_iov_t *iov, uct_completion_t *comp)
 {
-    ucp_rkey_h rkey         = req->send.rndv.rkey;
-    uct_rkey_t tl_rkey      = rkey->tl_rkey[lpriv->super.rkey_index].rkey.rkey;
+    uct_rkey_t tl_rkey      = ucp_rkey_get_tl_rkey(req->send.rndv.rkey,
+                                                   lpriv->super.rkey_index);
     uint64_t remote_address = req->send.rndv.remote_address +
                               req->send.state.dt_iter.offset;
 

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -53,8 +53,8 @@ ucp_proto_rndv_put_common_send(ucp_request_t *req,
                                const ucp_proto_multi_lane_priv_t *lpriv,
                                const uct_iov_t *iov, uct_completion_t *comp)
 {
-    ucp_rkey_h rkey         = req->send.rndv.rkey;
-    uct_rkey_t tl_rkey      = rkey->tl_rkey[lpriv->super.rkey_index].rkey.rkey;
+    uct_rkey_t tl_rkey      = ucp_rkey_get_tl_rkey(req->send.rndv.rkey,
+                                                   lpriv->super.rkey_index);
     uint64_t remote_address = req->send.rndv.remote_address +
                               req->send.state.dt_iter.offset;
 


### PR DESCRIPTION
## Why
Fix failures with new protocols when a transport does not require a remote key (NEED_RKEY for me is not set), so it's initialized with rkey_index==NULL_RESOURCE. When used without any checks, it generates memory access error (to invalid array index).