### PR TITLE
UCP/CONTEXT: Remove wrong DIAG message during context create

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -668,7 +668,8 @@ static void ucp_add_tl_resource_if_enabled(ucp_context_h context, ucp_tl_md_t *m
 
     if (ucp_is_resource_enabled(resource, config, &rsc_flags, dev_cfg_masks,
                                 tl_cfg_mask)) {
-        if (resource->sys_device >= UCP_MAX_SYS_DEVICES) {
+        if ((resource->sys_device != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+            (resource->sys_device >= UCP_MAX_SYS_DEVICES)) {
             ucs_diag(UCT_TL_RESOURCE_DESC_FMT
                      " system device is %d, which exceeds the maximal "
                      "supported (%d), system locality may be ignored",


### PR DESCRIPTION
## Why
No need to print a ucs_diag() warning if `resource->sys_device` is `UCS_SYS_DEVICE_ID_UNKNOWN`

## How
Before this PR, if `resource->sys_device` was `UCS_SYS_DEVICE_ID_UNKNOWN`, it triggered a ucs_diag() message, since `UCS_SYS_DEVICE_ID_UNKNOWN` >= ` UCP_MAX_SYS_DEVICES`, But it's not really a problem we should warn about.
