### PR TITLE
UCP/AM: Fix request datatype state during CM switch

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -301,13 +301,16 @@ ucs_status_t ucp_do_am_zcopy_single(uct_pending_req_t *self, uint8_t am_id,
     ucp_ep_t *ep         = req->send.ep;
     size_t max_iov       = ucp_ep_config(ep)->am.max_iov;
     uct_iov_t *iov       = ucs_alloca(max_iov * sizeof(uct_iov_t));
-    ucp_dt_state_t state = req->send.state.dt;
     size_t iovcnt        = 0;
+    ucp_dt_state_t state;
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
     ucp_send_request_add_reg_lane(req, req->send.lane);
 
+    /* Cache datatype state only after registering the lane, since registering
+       the lane can change the state */
+    state  = req->send.state.dt;
     status = ucp_am_zcopy_common(req, hdr, hdr_size, user_hdr_desc,
                                  user_hdr_size, 0ul, iov, iovcnt, max_iov,
                                  req->send.length, am_id, &state, 0);


### PR DESCRIPTION
## Why
Fix failure like [this (internal link)](http://hpc-master.lab.mtl.com:8080/blue/organizations/jenkins/ucx/detail/ucx/14255/pipeline/135) on r-vmb-ppc-jenkins (MellanoxLab test)
```
[2021-09-21T21:49:03.447Z] [ RUN      ] all/test_ucp_sockaddr_cm_switch.rereg_memory_on_cm_switch/0
[2021-09-21T21:49:03.703Z] [     INFO ] Testing 65.65.65.12:0
2021-09-21T21:49:03.703Z] [     INFO ] server listening on 65.65.65.12:33430
[2021-09-21T21:49:03.960Z] /scrap/jenkins/workspace/ucx-9/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:271: Failure
[2021-09-21T21:49:03.960Z] Error: Input/output error
[2021-09-21T21:49:03.960Z] [r-vmb-ppc-jenkins:14408:p-0:14408]  ucp_worker.c:2534 Assertion `worker->inprogress++ == 0' failed
[2021-09-21T21:49:05.327Z] 
[2021-09-21T21:49:05.327Z] /scrap/jenkins/workspace/ucx-9/contrib/../src/ucp/core/ucp_worker.c: [ ucp_worker_progress() ]
[2021-09-21T21:49:05.327Z]       ...
[2021-09-21T21:49:05.327Z]      2531     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
[2021-09-21T21:49:05.327Z]      2532 
[2021-09-21T21:49:05.327Z]      2533     /* check that ucp_worker_progress is not called from within ucp_worker_progress */
[2021-09-21T21:49:05.327Z] ==>  2534     ucs_assert(worker->inprogress++ == 0);
[2021-09-21T21:49:05.327Z]      2535     count = uct_worker_progress(worker->uct);
[2021-09-21T21:49:05.327Z]      2536     ucs_async_check_miss(&worker->async);
[2021-09-21T21:49:05.327Z]      2537 
[2021-09-21T21:49:05.327Z] 
```

Issue started after merging #7403