### PR TITLE
AZP: use -xeE for JUCX and Go tests.

### DIFF
--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -22,19 +22,12 @@ jobs:
         clean: true
         displayName: Checkout
       - bash: |
-          set -x
+          set -xeE
           source buildlib/az-helpers.sh
           az_init_modules
-          res=0
           az_module_load dev/mvn
-          res=$(($res+$?))
           az_module_load dev/jdk-${JAVA_VERSION}
-          res=$(($res+$?))
-          if [ $res -ne 0 ]; then
-            exit 0;
-          fi
           try_load_cuda_env
-          set -eE
           ./autogen.sh
           ./contrib/configure-devel --prefix=$(Build.Repository.LocalPath)/install \
             --with-java --enable-gtest=no --with-cuda=$have_cuda
@@ -42,19 +35,13 @@ jobs:
           make install
         displayName: Build UCX
       - bash: |
-          set -x
+          set -xeE
           source buildlib/az-helpers.sh
           az_init_modules
           try_load_cuda_env
-          res=0
           az_module_load dev/mvn
-          res=$(($res+$?))
           az_module_load dev/jdk-${JAVA_VERSION}
-          res=$(($res+$?))
-          if [ $res -ne 0 ]; then
-            exit 0;
-          fi
-          set -eE
+
           ifaces=`get_rdma_interfaces`
           if [ -z "$ifaces" ]; then
               azure_log_warning "No active RDMA interfaces on machine"

--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -32,16 +32,10 @@ jobs:
 
         exit 1
     - bash: |
-        set -x
+        set -xeE
         source buildlib/az-helpers.sh
-        az_init_modules
         az_module_load dev/go-latest
-        res=$?
-        if [ $res -ne 0 ]; then
-          exit 0;
-        fi
         try_load_cuda_env
-        set -eE
         ./autogen.sh
         mkdir build
         cd build
@@ -51,16 +45,10 @@ jobs:
         make install
       displayName: Build UCX
     - bash: |
-        set -x
+        set -xeE
         source buildlib/az-helpers.sh
         az_init_modules
         try_load_cuda_env
-        res=0
         az_module_load dev/go-latest
-        res=$?
-        if [ $res -ne 0 ]; then
-          exit 0;
-        fi
-        set -Eex
         make -C build/bindings/go test
       displayName: Run go tests


### PR DESCRIPTION
## What
use -xeE for JUCX and Go tests.

## Why ?
As mentioned in comment in #7412 