### PR TITLE
UCP: Define new worker address format

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -81,10 +81,10 @@ static size_t ucp_rndv_frag_default_num_elems[] = {
     [UCS_MEMORY_TYPE_LAST]         = 0
 };
 
-static const char *ucp_sa_client_hdr_versions[] = {
-    [UCP_SA_DATA_VERSION_V1]   = "v1",
-    [UCP_SA_DATA_VERSION_V2]   = "v2",
-    [UCP_SA_DATA_VERSION_LAST] = NULL
+const char *ucp_object_versions[] = {
+    [UCP_OBJECT_VERSION_V1]   = "v1",
+    [UCP_OBJECT_VERSION_V2]   = "v2",
+    [UCP_OBJECT_VERSION_LAST] = NULL
 };
 
 static UCS_CONFIG_DEFINE_ARRAY(memunit_sizes, sizeof(size_t),
@@ -387,7 +387,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "Defines the minimal header version the client will use for establishing\n"
    "client/server connection",
    ucs_offsetof(ucp_config_t, ctx.sa_client_min_hdr_version),
-   UCS_CONFIG_TYPE_ENUM(ucp_sa_client_hdr_versions)},
+   UCS_CONFIG_TYPE_ENUM(ucp_object_versions)},
 
   {"RKEY_MPOOL_MAX_MD", "2",
    "Maximum number of UCP rkey MDs which can be unpacked into memory pool\n"
@@ -401,6 +401,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "These pools are used for UCP AM and unexpected TAG messages. When assigning\n"
    "pool sizes, note that the data may be stored with some header.",
    ucs_offsetof(ucp_config_t, mpool_sizes), UCS_CONFIG_TYPE_ARRAY(memunit_sizes)},
+
+  {"ADDRESS_VERSION", "v1",
+   "Defines UCP worker address format obtained with ucp_worker_get_address() or\n"
+   "ucp_worker_query() routines.",
+   ucs_offsetof(ucp_config_t, ctx.worker_addr_version),
+   UCS_CONFIG_TYPE_ENUM(ucp_object_versions)},
 
    {NULL}
 };

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -122,10 +122,12 @@ typedef struct ucp_context_config {
     /** Always use flush operation in rendezvous put */
     int                                    rndv_put_force_flush;
     /** UCP sockaddr private data format version */
-    int                                    sa_client_min_hdr_version;
+    ucp_object_version_t                   sa_client_min_hdr_version;
     /** Remote keys with that many remote MDs or less would be allocated from a
       * memory pool.*/
     int                                    rkey_mpool_max_md;
+    /** Worker address format version */
+    ucp_object_version_t                   worker_addr_version;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -142,6 +142,8 @@ typedef struct ucp_ep_config_key_lane {
     uint8_t              path_index; /* Device path index */
     ucp_lane_type_mask_t lane_types; /* Which types of operations this lane
                                         was selected for */
+    size_t               seg_size; /* Maximal fragment size which can be
+                                      received by the peer */
 } ucp_ep_config_key_lane_t;
 
 
@@ -491,13 +493,6 @@ enum {
 };
 
 
-enum {
-    UCP_SA_DATA_VERSION_V1, /* represented by ucp_wireup_sockaddr_data_v1_t */
-    UCP_SA_DATA_VERSION_V2, /* represented by ucp_wireup_sockaddr_data_base_t */
-    UCP_SA_DATA_VERSION_LAST
-};
-
-
 /* Sockaddr data flags that are packed to the header field in
  * ucp_wireup_sockaddr_data_base_t structure.
  */
@@ -525,7 +520,7 @@ typedef struct ucp_wireup_sockaddr_data_base {
      *        flags
      *
      * It is safe to keep version in 3 MSB, because it will always be zeros
-     * (i.e. UCP_SA_DATA_VERSION_V1) in sa_data v1 (err_mode value is small).
+     * (i.e. UCP_OBJECT_VERSION_V1) in sa_data v1 (err_mode value is small).
      */
     uint8_t                   header;
     /* packed worker address (or sa_data v1) follows */

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -91,12 +91,6 @@ void ucp_rkey_packed_copy(ucp_context_h context, ucp_md_map_t md_map,
     }
 }
 
-/* Pack bandwidth as bytes/second, range: 512 MB/s to 4 TB/s */
-UCS_FP8_DECLARE_TYPE(RKEY_BANDWIDTH, 512 * UCS_MBYTE, 4 * UCS_TBYTE)
-
-/* Pack latency as nanoseconds, range: 16 nsec to 131 usec */
-UCS_FP8_DECLARE_TYPE(RKEY_LATENCY, UCS_BIT(4), UCS_BIT(17))
-
 static void ucp_rkey_pack_distance(ucs_sys_device_t sys_dev,
                                    const ucs_sys_dev_distance_t *distance,
                                    ucp_rkey_packed_distance_t *packed_distance)
@@ -104,9 +98,8 @@ static void ucp_rkey_pack_distance(ucs_sys_device_t sys_dev,
     double latency_nsec = distance->latency * UCS_NSEC_PER_SEC;
 
     packed_distance->sys_dev   = sys_dev;
-    packed_distance->latency   = UCS_FP8_PACK(RKEY_LATENCY, latency_nsec);
-    packed_distance->bandwidth = UCS_FP8_PACK(RKEY_BANDWIDTH,
-                                              distance->bandwidth);
+    packed_distance->latency   = UCS_FP8_PACK(LATENCY, latency_nsec);
+    packed_distance->bandwidth = UCS_FP8_PACK(BANDWIDTH, distance->bandwidth);
 }
 
 static void
@@ -114,13 +107,11 @@ ucp_rkey_unpack_distance(const ucp_rkey_packed_distance_t *packed_distance,
                          ucs_sys_device_t *sys_dev_p,
                          ucs_sys_dev_distance_t *distance)
 {
-    double latency_nsec = UCS_FP8_UNPACK(RKEY_LATENCY,
-                                         packed_distance->latency);
+    double latency_nsec = UCS_FP8_UNPACK(LATENCY, packed_distance->latency);
 
     *sys_dev_p          = packed_distance->sys_dev;
     distance->latency   = latency_nsec / UCS_NSEC_PER_SEC;
-    distance->bandwidth = UCS_FP8_UNPACK(RKEY_BANDWIDTH,
-                                         packed_distance->bandwidth);
+    distance->bandwidth = UCS_FP8_UNPACK(BANDWIDTH, packed_distance->bandwidth);
 }
 
 UCS_PROFILE_FUNC(ssize_t, ucp_rkey_pack_uct,

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -8,9 +8,11 @@
 #define UCP_TYPES_H_
 
 #include <ucp/api/ucp.h>
+#include <ucs/type/float8.h>
 #include <uct/api/uct.h>
 #include <ucs/datastruct/bitmap.h>
 #include <ucs/sys/preprocessor.h>
+#include <ucs/sys/math.h>
 #include <stdint.h>
 
 
@@ -111,6 +113,18 @@ extern const ucp_tl_bitmap_t ucp_tl_bitmap_min;
                    UCP_MAX_RESOURCES)
 
 
+/* Pack bandwidth as bytes/second, range: 512 MB/s to 4 TB/s */
+UCS_FP8_DECLARE_TYPE(BANDWIDTH, 512 * UCS_MBYTE, 4 * UCS_TBYTE)
+
+
+/* Pack latency as nanoseconds, range: 16 nsec to 131 usec */
+UCS_FP8_DECLARE_TYPE(LATENCY, UCS_BIT(4), UCS_BIT(17))
+
+
+/* Pack overhead as nanoseconds, range: 1 nsec to 4 usec */
+UCS_FP8_DECLARE_TYPE(OVERHEAD, UCS_BIT(0), UCS_BIT(12))
+
+
 /**
  * Operation for which protocol is selected
  */
@@ -202,6 +216,16 @@ typedef enum {
     UCP_RNDV_MODE_RKEY_PTR, /* Use rkey_ptr in RNDV protocol */
     UCP_RNDV_MODE_LAST
 } ucp_rndv_mode_t;
+
+
+/* Versions enumeration used for various UCP objects (e.g. ucp worker address,
+ * sockaddr data structure, etc).
+ */
+typedef enum {
+    UCP_OBJECT_VERSION_V1,
+    UCP_OBJECT_VERSION_V2,
+    UCP_OBJECT_VERSION_LAST
+} ucp_object_version_t;
 
 
 /**

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1434,11 +1434,12 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 
     iface_cap_flags = UCT_IFACE_FLAG_ATOMIC_DEVICE;
 
-    dummy_iface_attr.bandwidth = 1e12;
-    dummy_iface_attr.cap_flags = UINT64_MAX;
-    dummy_iface_attr.overhead  = 0;
-    dummy_iface_attr.priority  = 0;
-    dummy_iface_attr.lat_ovh   = 0;
+    dummy_iface_attr.bandwidth    = 1e12;
+    dummy_iface_attr.flags        = UINT64_MAX;
+    dummy_iface_attr.overhead     = 0;
+    dummy_iface_attr.priority     = 0;
+    dummy_iface_attr.lat_ovh      = 0;
+    dummy_iface_attr.addr_version = UCP_OBJECT_VERSION_V1;
 
     best_score    = -1;
     best_rsc      = NULL;
@@ -2566,7 +2567,8 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
         UCS_BITMAP_SET_ALL(tl_bitmap);
     }
 
-    return ucp_address_pack(worker, NULL, &tl_bitmap, flags, NULL,
+    return ucp_address_pack(worker, NULL, &tl_bitmap, flags,
+                            context->config.ext.worker_addr_version, NULL,
                             address_length_p, (void**)address_p);
 }
 

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -16,6 +16,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/debug/log.h>
 #include <ucs/type/serialize.h>
+#include <ucs/type/float8.h>
 #include <inttypes.h>
 
 
@@ -47,6 +48,57 @@
  *   * For any mode, ep address is followed by a lane index.
  */
 
+/* Address version 2 format:
+*
+ *            addr_version
+ *                ^
+ * proto_version  |    flags    worker_uuid     worker_name
+ *         ^      |       ^          ^               ^
+ *      +------+------+---------+---------------+---------+
+ *      |  4   |  4   |   8     |     64        | string  +---------+
+ *      +------+------+---------+---------------+---------+         |
+ *                                                                  |
+ *                                     for each device              |
+ *   +--------------------------------------------------------------+
+ *   |
+ *   |           md_idx(*1)         dev_addr_len(*2)
+ *   |           extension             extension
+ *   |    md_idx      ^    dev_addr_len   ^       npath   sys_dev  dev_addr
+ *   |        ^       |          ^        |        ^        ^        ^
+ *   |  +---+-----+---------+---+-----+--------+--------+--------+-------------+
+ *   +->| 1 |  7  |   8     | 3 |  5  |   8    |   8    |   8    |dev_addr_len +-+
+ *      +---+-----+---------+---+-----+--------+--------+--------+-------------+ |
+ *        v                   v                                                  |
+ *     md_flags             dev_flags                                            |
+ *                                                                for each iface
+|
+ *   +---------------------------------------------------------------------------+
+ *   |         iface_attr(*3)        if_addr_len(*4)
+ *   |iface_id       ^    if_addr_len   extension    if_addr
+ *   |    ^          |          ^           ^           ^
+ *   |  +---------+--------+--+-------+----------+-----------+
+ *   +->|   8     |attr_len|2 |  6    |    8     |if_addr_len+-+
+ *      +---------+--------+--+-------+----------+-----------+ |
+ *                          v                                  |
+ *                         if_flags                            |
+ *                                                 for each ep |
+ *   +---------------------------------------------------------+
+ *   |  ep_addr_len    ep_addr   lane_idx
+ *   |     ^             ^          ^
+ *   |  +---------+-----------+-+-------+
+ *   +->|    8    |ep_addr_len|1|   7   |
+ *      +---------+-----------+-+-------+
+ *                             v
+ *                           ep_flags
+ *
+ *    (*1) - present and contains actual md id, if md_idx == 127
+ *    (*2) - present and contains actual device address length,
+ *           if dev_addr_len == 31
+ *    (*3) - iface attrs format defined by ucp_address_v2_packed_iface_attr_t
+ *    (*4) - present and contains actual iface address length,
+ *           if if_addr_len == 63
+ */
+
 
 typedef struct {
     size_t           dev_addr_len;
@@ -73,6 +125,18 @@ typedef struct {
 } UCS_S_PACKED ucp_address_packed_iface_attr_t;
 
 
+typedef struct {
+    ucs_fp8_t        overhead;
+    ucs_fp8_t        bandwidth;
+    ucs_fp8_t        latency;
+    uint8_t          prio;
+    /* Maximal segment size than can be received by this iface */
+    uint16_t         seg_size;
+    /* Includes caps, event and atomic flags */
+    uint16_t         flags;
+} UCS_S_PACKED ucp_address_v2_packed_iface_attr_t;
+
+
 /* In unified mode we pack resource index instead of iface attrs to the address,
  * so the peer can get all attrs from the local device with the same resource
  * index.
@@ -91,8 +155,8 @@ typedef struct {
 } UCS_S_PACKED ucp_address_unified_iface_attr_t;
 
 
-#define UCP_ADDRESS_FLAG_ATOMIC32     UCS_BIT(30) /* 32bit atomic operations */
-#define UCP_ADDRESS_FLAG_ATOMIC64     UCS_BIT(31) /* 64bit atomic operations */
+#define UCP_ADDRESS_V1_FLAG_ATOMIC32  UCS_BIT(30) /* 32bit atomic operations */
+#define UCP_ADDRESS_V1_FLAG_ATOMIC64  UCS_BIT(31) /* 64bit atomic operations */
 
 #define UCP_ADDRESS_FLAG_LAST         0x80u  /* Last address in the list */
 #define UCP_ADDRESS_FLAG_HAS_EP_ADDR  0x40u  /* For iface address:
@@ -107,6 +171,9 @@ typedef struct {
                                                 Indicates that system device is
                                                 packed after device address or
                                                 number of paths (if present) */
+
+/* Multiplicator of ucp_address_v2_packed_iface_attr_t->seg_size value */
+#define UCP_ADDRESS_IFACE_SEG_SIZE_FACTOR 64
 
 /* Mask for iface and endpoint address length */
 #define UCP_ADDRESS_IFACE_LEN_MASK   (UCS_MASK(8) ^ \
@@ -128,34 +195,31 @@ typedef struct {
                                          UCP_ADDRESS_FLAG_MD_REG))
 
 #define UCP_ADDRESS_HEADER_VERSION_MASK     UCS_MASK(4) /* Version - 4 bits */
+#define UCP_ADDRESS_HEADER_FLAGS_SHIFT_V1   4
 
 #define UCP_ADDRESS_DEFAULT_WORKER_UUID     0
 #define UCP_ADDRESS_DEFAULT_CLIENT_ID       0
 
-/* Enumeration of UCP address versions.
- * Every release which changes the address binary format must bump this number.
- */
 enum {
-    UCP_ADDRESS_VERSION_V1      = 0,
-    UCP_ADDRESS_VERSION_LAST,
-    UCP_ADDRESS_VERSION_CURRENT = UCP_ADDRESS_VERSION_LAST - 1
+    UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO  = UCS_BIT(0),  /* Address has debug info */
+    UCP_ADDRESS_HEADER_FLAG_WORKER_UUID = UCS_BIT(1),  /* Worker unique id */
+    UCP_ADDRESS_HEADER_FLAG_CLIENT_ID   = UCS_BIT(2),  /* Worker client id */
+    UCP_ADDRESS_HEADER_FLAG_AM_ONLY     = UCS_BIT(3)   /* Only AM lane info */
 };
 
-enum {
-    UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO  = UCS_BIT(4),  /* Address has debug info */
-    UCP_ADDRESS_HEADER_FLAG_WORKER_UUID = UCS_BIT(5),  /* Worker unique id */
-    UCP_ADDRESS_HEADER_FLAG_CLIENT_ID   = UCS_BIT(6),  /* Worker client id */
-    UCP_ADDRESS_HEADER_FLAG_AM_ONLY     = UCS_BIT(7)   /* Only AM lane info */
-};
-
-static size_t ucp_address_iface_attr_size(ucp_worker_t *worker,
-                                          uint64_t flags)
+static size_t ucp_address_iface_attr_size(ucp_worker_t *worker, uint64_t flags,
+                                          ucp_object_version_t addr_version)
 {
-    return ucp_worker_is_unified_mode(worker) ?
-           sizeof(ucp_address_unified_iface_attr_t) :
-           (sizeof(ucp_address_packed_iface_attr_t) +
-            ((flags & UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX) ?
-             sizeof(uint8_t) : 0));
+    size_t rsc_id_size = (flags & UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX) ?
+                         sizeof(uint8_t) : 0ul;
+
+    if (ucp_worker_is_unified_mode(worker)) {
+        return sizeof(ucp_address_unified_iface_attr_t);
+    } else if (addr_version == UCP_OBJECT_VERSION_V1) {
+        return sizeof(ucp_address_packed_iface_attr_t) + rsc_id_size;
+    } else {
+        return sizeof(ucp_address_v2_packed_iface_attr_t) + rsc_id_size;
+    }
 }
 
 static uint64_t ucp_worker_iface_can_connect(uct_iface_attr_t *attrs)
@@ -213,9 +277,39 @@ out:
     return dev;
 }
 
+static size_t ucp_address_packed_value_size(size_t value, size_t max_value,
+                                            ucp_object_version_t addr_version)
+{
+    if (addr_version == UCP_OBJECT_VERSION_V1) {
+        /* Address version 1 does not support value extension */
+        ucs_assertv_always(value <= max_value, "value %zu, max_value %zu",
+                           value, max_value);
+        return sizeof(uint8_t);
+    } else if (value < max_value) {
+        /* The value fits into a partial byte, up to max_value */
+        return sizeof(uint8_t);
+    } else {
+        /* The value needs to be extended to a full byte */
+        ucs_assertv_always(value <= UINT8_MAX, "value %zu", value);
+        return sizeof(uint8_t) * 2;
+    }
+}
+
+static size_t ucp_address_packed_length_size(ucp_worker_h worker, size_t length,
+                                             size_t max_length,
+                                             ucp_object_version_t addr_version)
+{
+    if (ucp_worker_is_unified_mode(worker)) {
+        return 0;
+    }
+
+    return ucp_address_packed_value_size(length, max_length, addr_version);
+}
+
 static ucs_status_t
 ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep,
                            const ucp_tl_bitmap_t *tl_bitmap, uint64_t flags,
+                           ucp_object_version_t addr_version,
                            ucp_address_packed_device_t **devices_p,
                            ucp_rsc_index_t *num_devices_p)
 {
@@ -261,8 +355,14 @@ ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep,
         if (flags & UCP_ADDRESS_PACK_FLAG_IFACE_ADDR) {
             /* iface address (its length will be packed in non-unified mode only) */
             dev->tl_addrs_size += iface_attr->iface_addr_len;
-            dev->tl_addrs_size += !ucp_worker_is_unified_mode(worker); /* if addr length */
-            dev->tl_addrs_size += ucp_address_iface_attr_size(worker, flags);
+            /* iface address length (+flags) can take 2 bytes with address
+             * version 2 in non-unified mode
+             */
+            dev->tl_addrs_size += ucp_address_packed_length_size(
+                                      worker, iface_attr->iface_addr_len,
+                                      UCP_ADDRESS_IFACE_LEN_MASK, addr_version);
+            dev->tl_addrs_size += ucp_address_iface_attr_size(worker, flags,
+                                                              addr_version);
         } else {
             dev->tl_addrs_size += 1; /* 0-value for valid unpacking */
         }
@@ -296,16 +396,22 @@ ucp_address_gather_devices(ucp_worker_h worker, ucp_ep_h ep,
     return UCS_OK;
 }
 
-static size_t ucp_address_packed_size(ucp_worker_h worker,
-                                      const ucp_address_packed_device_t *devices,
-                                      ucp_rsc_index_t num_devices,
-                                      uint64_t pack_flags)
+static size_t
+ucp_address_packed_size(ucp_worker_h worker,
+                        const ucp_address_packed_device_t *devices,
+                        ucp_rsc_index_t num_devices, uint64_t pack_flags,
+                        ucp_object_version_t addr_version)
 {
     size_t size = 0;
     const ucp_address_packed_device_t *dev;
+    ucp_md_index_t md_index;
 
     /* header: version and flags */
-    size += 1;
+    if (addr_version == UCP_OBJECT_VERSION_V1) {
+        size += sizeof(uint8_t);
+    } else {
+        size += sizeof(uint16_t);
+    }
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
         size += sizeof(uint64_t);
@@ -321,13 +427,23 @@ static size_t ucp_address_packed_size(ucp_worker_h worker,
     }
 
     if (num_devices == 0) {
-        size += 1;                      /* NULL md_index */
+        size += 1; /* NULL md_index */
     } else {
         for (dev = devices; dev < (devices + num_devices); ++dev) {
-            size += 1;                  /* device md_index */
-            size += 1;                  /* device address length */
+            /* device md_index */
+            md_index = worker->context->tl_rscs[dev->rsc_index].md_index;
+            /* md index (+flags) can take 2 bytes with address version 2 */
+            size    += ucp_address_packed_value_size(md_index,
+                                                     UCP_ADDRESS_FLAG_MD_MASK,
+                                                     addr_version);
             if (pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
+                /* device address length */
+                size += ucp_address_packed_value_size(
+                            dev->dev_addr_len, UCP_ADDRESS_DEVICE_LEN_MASK,
+                            addr_version);
                 size += dev->dev_addr_len;  /* device address */
+            } else {
+                size += 1; /* 0 device address length */
             }
             if (dev->num_paths > 1) {
                 size += 1; /* number of paths */
@@ -354,6 +470,79 @@ static void ucp_address_memcheck(ucp_context_h context, void *ptr, size_t size,
                   UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[rsc_index].tl_rsc),
                   UCS_PTR_BYTE_DIFF(ptr, undef_ptr));
     }
+}
+
+static void *ucp_address_pack_byte_extended(void *ptr, size_t value,
+                                            size_t max_value,
+                                            ucp_object_version_t addr_version)
+{
+    if ((addr_version != UCP_OBJECT_VERSION_V1) && (value >= max_value)) {
+        /* Set maximal possible value, indicating that the actual value is in
+         * the next byte. */
+        *ucs_serialize_next(&ptr, uint8_t) = max_value;
+        max_value                          = UINT8_MAX;
+    }
+
+    ucs_assertv_always(value <= max_value, "value=%zu, max_value %zu", value,
+                       max_value);
+
+    *ucs_serialize_next(&ptr, uint8_t) = value;
+
+    return ptr;
+}
+
+static void *
+ucp_address_unpack_byte_extended(const void *ptr, size_t value_mask,
+                                 ucp_object_version_t addr_version,
+                                 uint8_t *value_p)
+{
+    uint8_t value = *ucs_serialize_next(&ptr, const uint8_t) & value_mask;
+
+    if ((addr_version != UCP_OBJECT_VERSION_V1) && (value == value_mask)) {
+        value = *ucs_serialize_next(&ptr, const uint8_t);
+    }
+
+    *value_p = value;
+    return (void*)ptr;
+}
+
+static void *
+ucp_address_pack_md_info(void *ptr, int is_empty_dev, uint64_t md_flags,
+                         ucp_md_index_t md_index,
+                         ucp_object_version_t addr_version)
+{
+    void *flags_ptr = ptr;
+
+    ptr = ucp_address_pack_byte_extended(ptr, md_index,
+                                         UCP_ADDRESS_FLAG_MD_MASK,
+                                         addr_version);
+
+    if (is_empty_dev) {
+        *(uint8_t*)flags_ptr |= UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
+    }
+
+    if (md_flags & UCT_MD_FLAG_ALLOC) {
+        *(uint8_t*)flags_ptr |= UCP_ADDRESS_FLAG_MD_ALLOC;
+    }
+
+    if (md_flags & UCT_MD_FLAG_REG) {
+        *(uint8_t*)flags_ptr |= UCP_ADDRESS_FLAG_MD_REG;
+    }
+
+    return ptr;
+}
+
+static void *ucp_address_unpack_md_info(const void *ptr,
+                                        ucp_object_version_t addr_version,
+                                        ucp_md_index_t *md_index,
+                                        int *empty_dev)
+{
+    uint8_t md_byte = *(uint8_t*)ptr;
+
+    *empty_dev = md_byte & UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
+
+    return ucp_address_unpack_byte_extended(ptr, UCP_ADDRESS_FLAG_MD_MASK,
+                                            addr_version, md_index);
 }
 
 static uint32_t ucp_address_pack_flags(uint64_t input_flags,
@@ -400,54 +589,130 @@ static uint64_t ucp_address_unpack_flags(uint32_t input_flags,
     return result_flags;
 }
 
-static uint64_t ucp_address_flags_from_iface_flags(uint64_t iface_flags)
+static uint64_t ucp_address_flags_from_iface_flags(uint64_t iface_cap_flags,
+                                                   uint64_t iface_event_flags)
 {
-    uint64_t iface_cap_flags = 0;
+    uint64_t iface_flags = 0;
 
-    if (iface_flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_CONNECT_TO_IFACE;
+    if (iface_cap_flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_CONNECT_TO_IFACE;
     }
 
-    if (iface_flags & UCT_IFACE_FLAG_CB_ASYNC) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_CB_ASYNC;
+    if (iface_cap_flags & UCT_IFACE_FLAG_CB_ASYNC) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_CB_ASYNC;
     }
 
-    if (ucs_test_all_flags(iface_flags,
+    if (ucs_test_all_flags(iface_cap_flags,
                            UCT_IFACE_FLAG_CB_SYNC | UCT_IFACE_FLAG_AM_BCOPY)) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_AM_SYNC;
+        iface_flags |= UCP_ADDR_IFACE_FLAG_AM_SYNC;
     }
 
-    if (iface_flags & (UCT_IFACE_FLAG_PUT_SHORT | UCT_IFACE_FLAG_PUT_BCOPY |
-                       UCT_IFACE_FLAG_PUT_ZCOPY)) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_PUT;
+    if (iface_cap_flags & (UCT_IFACE_FLAG_PUT_SHORT | UCT_IFACE_FLAG_PUT_BCOPY |
+                           UCT_IFACE_FLAG_PUT_ZCOPY)) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_PUT;
     }
 
-    if (iface_flags & (UCT_IFACE_FLAG_GET_SHORT | UCT_IFACE_FLAG_GET_BCOPY |
-                       UCT_IFACE_FLAG_GET_ZCOPY)) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_GET;
+    if (iface_cap_flags & (UCT_IFACE_FLAG_GET_SHORT | UCT_IFACE_FLAG_GET_BCOPY |
+                           UCT_IFACE_FLAG_GET_ZCOPY)) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_GET;
     }
 
-    if (iface_flags & (UCT_IFACE_FLAG_TAG_EAGER_SHORT |
-                       UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
-                       UCT_IFACE_FLAG_TAG_EAGER_ZCOPY)) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_TAG_EAGER;
+    if (iface_cap_flags & (UCT_IFACE_FLAG_TAG_EAGER_SHORT |
+                           UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
+                           UCT_IFACE_FLAG_TAG_EAGER_ZCOPY)) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_TAG_EAGER;
     }
 
-    if (iface_flags & UCT_IFACE_FLAG_TAG_RNDV_ZCOPY) {
-        iface_cap_flags |= UCP_ADDR_IFACE_FLAG_TAG_RNDV;
+    if (iface_cap_flags & UCT_IFACE_FLAG_TAG_RNDV_ZCOPY) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_TAG_RNDV;
     }
 
-    return iface_cap_flags;
+    if (iface_event_flags & UCT_IFACE_FLAG_EVENT_RECV) {
+        iface_flags |= UCP_ADDR_IFACE_FLAG_EVENT_RECV;
+    }
+
+    return iface_flags;
+}
+
+static unsigned
+ucp_address_pack_iface_attr_v1(ucp_worker_h worker, void *ptr,
+                               const uct_iface_attr_t *iface_attr,
+                               unsigned atomic_flags)
+{
+    ucp_address_packed_iface_attr_t *packed = ptr;
+
+    packed->overhead       = iface_attr->overhead;
+    packed->bandwidth      = ucp_tl_iface_bandwidth(worker->context,
+                                                    &iface_attr->bandwidth);
+    packed->lat_ovh        = iface_attr->latency.c;
+    /* Pack prio, capability and atomic flags */
+    packed->prio_cap_flags = (uint8_t)iface_attr->priority |
+                             ucp_address_pack_flags(iface_attr->cap.flags,
+                                                    UCP_ADDRESS_IFACE_FLAGS, 8);
+    /* Keep only the bits defined by UCP_ADDRESS_IFACE_EVENT_FLAGS to shrink
+     * address. */
+    packed->prio_cap_flags |= ucp_address_pack_flags(
+            iface_attr->cap.event_flags, UCP_ADDRESS_IFACE_EVENT_FLAGS,
+            8 + ucs_popcount(UCP_ADDRESS_IFACE_FLAGS));
+
+    if (atomic_flags & UCP_ADDR_IFACE_FLAG_ATOMIC32) {
+        packed->prio_cap_flags |= UCP_ADDRESS_V1_FLAG_ATOMIC32;
+    }
+
+    if (atomic_flags & UCP_ADDR_IFACE_FLAG_ATOMIC64) {
+        packed->prio_cap_flags |= UCP_ADDRESS_V1_FLAG_ATOMIC64;
+    }
+
+    ucs_assert_always((ucs_popcount(UCP_ADDRESS_IFACE_FLAGS) +
+                ucs_popcount(UCP_ADDRESS_IFACE_EVENT_FLAGS)) <= 22);
+
+    return sizeof(*packed);
+}
+
+static unsigned
+ucp_address_pack_iface_attr_v2(ucp_worker_h worker, void *ptr,
+                               const uct_iface_attr_t *iface_attr,
+                               unsigned atomic_flags)
+{
+    unsigned seg_size                          = 0;
+    ucp_address_v2_packed_iface_attr_t *packed = ptr;
+    uint64_t addr_iface_flags;
+
+    packed->overhead  = UCS_FP8_PACK(OVERHEAD, iface_attr->overhead);
+    packed->bandwidth = UCS_FP8_PACK(BANDWIDTH,
+                                     ucp_tl_iface_bandwidth(worker->context,
+                                     &iface_attr->bandwidth));
+    packed->latency   = UCS_FP8_PACK(LATENCY,
+                                     ucp_tl_iface_latency(worker->context,
+                                                          &iface_attr->latency));
+    packed->prio      = ucs_min(UINT8_MAX, iface_attr->priority);
+    addr_iface_flags  = ucp_address_flags_from_iface_flags(
+                            iface_attr->cap.flags, iface_attr->cap.event_flags);
+    packed->flags     = (uint16_t)(addr_iface_flags | atomic_flags);
+
+    /* To be replaced by iface_attr.cap.am.max_recv when it is added to the
+     * UCT API */
+    if (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) {
+        seg_size = iface_attr->cap.am.max_bcopy;
+    } else if (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_ZCOPY) {
+        seg_size = iface_attr->cap.am.max_zcopy;
+    } else if (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_SHORT) {
+        seg_size = iface_attr->cap.am.max_short;
+    }
+    packed->seg_size = seg_size / UCP_ADDRESS_IFACE_SEG_SIZE_FACTOR;
+
+    return sizeof(*packed);
 }
 
 static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
                                        ucp_rsc_index_t rsc_index,
                                        const uct_iface_attr_t *iface_attr,
                                        unsigned pack_flags,
+                                       ucp_object_version_t addr_version,
                                        int enable_atomics)
 {
-    int packed_len;
-    ucp_address_packed_iface_attr_t  *packed;
+    unsigned atomic_flags = 0;
+    unsigned packed_len;
     ucp_address_unified_iface_attr_t *unified;
 
     if (ucp_worker_is_unified_mode(worker)) {
@@ -463,44 +728,31 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
         return sizeof(*unified);
     }
 
-    packed                 = ptr;
-    packed->prio_cap_flags = (uint8_t)iface_attr->priority;
-    packed->overhead       = iface_attr->overhead;
-    packed->bandwidth      = ucp_tl_iface_bandwidth(worker->context,
-                                                    &iface_attr->bandwidth);
-    packed->lat_ovh        = iface_attr->latency.c;
-
-    ucs_assert((ucs_popcount(UCP_ADDRESS_IFACE_FLAGS) +
-                ucs_popcount(UCP_ADDRESS_IFACE_EVENT_FLAGS)) <= 22);
-
-    /* Keep only the bits defined by UCP_ADDRESS_IFACE_FLAGS
-     * to shrink address. */
-    packed->prio_cap_flags |=
-        ucp_address_pack_flags(iface_attr->cap.flags,
-                               UCP_ADDRESS_IFACE_FLAGS, 8);
-
-    /* Keep only the bits defined by UCP_ADDRESS_IFACE_EVENT_FLAGS
-     * to shrink address. */
-    packed->prio_cap_flags |=
-        ucp_address_pack_flags(iface_attr->cap.event_flags,
-                               UCP_ADDRESS_IFACE_EVENT_FLAGS,
-                               8 + ucs_popcount(UCP_ADDRESS_IFACE_FLAGS));
-
     if (enable_atomics) {
-        if (ucs_test_all_flags(iface_attr->cap.atomic32.op_flags, UCP_ATOMIC_OP_MASK) &&
-            ucs_test_all_flags(iface_attr->cap.atomic32.fop_flags, UCP_ATOMIC_FOP_MASK)) {
-            packed->prio_cap_flags |= UCP_ADDRESS_FLAG_ATOMIC32;
+        if (ucs_test_all_flags(iface_attr->cap.atomic32.op_flags,
+                               UCP_ATOMIC_OP_MASK) &&
+            ucs_test_all_flags(iface_attr->cap.atomic32.fop_flags,
+                               UCP_ATOMIC_FOP_MASK)) {
+            atomic_flags |= UCP_ADDR_IFACE_FLAG_ATOMIC32;
         }
-        if (ucs_test_all_flags(iface_attr->cap.atomic64.op_flags, UCP_ATOMIC_OP_MASK) &&
-            ucs_test_all_flags(iface_attr->cap.atomic64.fop_flags, UCP_ATOMIC_FOP_MASK)) {
-            packed->prio_cap_flags |= UCP_ADDRESS_FLAG_ATOMIC64;
+        if (ucs_test_all_flags(iface_attr->cap.atomic64.op_flags,
+                               UCP_ATOMIC_OP_MASK) &&
+            ucs_test_all_flags(iface_attr->cap.atomic64.fop_flags,
+                               UCP_ATOMIC_FOP_MASK)) {
+            atomic_flags |= UCP_ADDR_IFACE_FLAG_ATOMIC64;
         }
     }
 
-    packed_len = sizeof(*packed);
+    if (addr_version == UCP_OBJECT_VERSION_V1) {
+        packed_len = ucp_address_pack_iface_attr_v1(worker, ptr, iface_attr,
+                                                    atomic_flags);
+    } else {
+        packed_len = ucp_address_pack_iface_attr_v2(worker, ptr, iface_attr,
+                                                    atomic_flags);
+    }
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX) {
-        ptr             = packed + 1;
+        ptr             = UCS_PTR_BYTE_OFFSET(ptr, packed_len);
         *(uint8_t*)ptr  = rsc_index;
         packed_len     += sizeof(uint8_t);
     }
@@ -508,60 +760,38 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
     return packed_len;
 }
 
-static ucs_status_t
-ucp_address_unpack_iface_attr(ucp_worker_t *worker,
-                              ucp_address_iface_attr_t *iface_attr,
-                              const void *ptr, unsigned unpack_flags,
-                              size_t *size_p)
+static unsigned
+ucp_address_unpack_iface_attr_v1(ucp_worker_t *worker,
+                                 ucp_address_iface_attr_t *iface_attr,
+                                 const void *ptr)
 {
-    const ucp_address_packed_iface_attr_t *packed;
-    const ucp_address_unified_iface_attr_t *unified;
-    ucp_worker_iface_t *wiface;
-    ucp_rsc_index_t rsc_idx;
+    const ucp_address_packed_iface_attr_t *packed = ptr;
     uct_ppn_bandwidth_t bandwidth;
-    uint64_t iface_flags;
+    uint64_t iface_flags, event_flags;
 
-    if (ucp_worker_is_unified_mode(worker)) {
-        /* Address contains resources index and iface latency overhead
-         * (not all iface attrs). */
-        unified             = ptr;
-        rsc_idx             = unified->rsc_index & UCP_ADDRESS_IFACE_LEN_MASK;
-        iface_attr->lat_ovh = fabs(unified->lat_ovh);
-        if (!UCS_BITMAP_GET(worker->context->tl_bitmap, rsc_idx)) {
-            if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
-                ucs_error("failed to unpack address, resource[%d] is not valid",
-                          rsc_idx);
-            }
-            return UCS_ERR_INVALID_ADDR;
-        }
+    iface_attr->overhead    = packed->overhead;
+    iface_attr->lat_ovh     = packed->lat_ovh;
+    iface_attr->priority    = packed->prio_cap_flags & UCS_MASK(8);
+    /* UCP address v1 does not carry segment size, MAX will not affect ep
+     * threshold calculations (which are trimmed by this value). */
+    iface_attr->seg_size    = UINT_MAX;
+    iface_flags             = ucp_address_unpack_flags(packed->prio_cap_flags,
+                                                       UCP_ADDRESS_IFACE_FLAGS,
+                                                       8);
+    event_flags             = ucp_address_unpack_flags(
+                                  packed->prio_cap_flags,
+                                  UCP_ADDRESS_IFACE_EVENT_FLAGS,
+                                  8 + ucs_popcount(UCP_ADDRESS_IFACE_FLAGS));
+    iface_attr->flags       = ucp_address_flags_from_iface_flags(iface_flags,
+                                                                 event_flags);
 
-        /* Just take the rest of iface attrs from the local resource. */
-        wiface                    = ucp_worker_iface(worker, rsc_idx);
-        iface_attr->cap_flags     = ucp_address_flags_from_iface_flags(
-                                        wiface->attr.cap.flags);
-        iface_attr->event_flags   = wiface->attr.cap.event_flags;
-        iface_attr->priority      = wiface->attr.priority;
-        iface_attr->overhead      = wiface->attr.overhead;
-        iface_attr->bandwidth     =
-                ucp_tl_iface_bandwidth(worker->context,
-                                       &wiface->attr.bandwidth);
-        iface_attr->dst_rsc_index = rsc_idx;
-
-        if (signbit(unified->lat_ovh)) {
-            iface_attr->atomic.atomic32.op_flags  = wiface->attr.cap.atomic32.op_flags;
-            iface_attr->atomic.atomic32.fop_flags = wiface->attr.cap.atomic32.fop_flags;
-            iface_attr->atomic.atomic64.op_flags  = wiface->attr.cap.atomic64.op_flags;
-            iface_attr->atomic.atomic64.fop_flags = wiface->attr.cap.atomic64.fop_flags;
-        }
-
-        *size_p = sizeof(*unified);
-        return UCS_OK;
+    if (packed->prio_cap_flags & UCP_ADDRESS_V1_FLAG_ATOMIC32) {
+        iface_attr->flags  |= UCP_ADDR_IFACE_FLAG_ATOMIC32;
     }
 
-    packed               = ptr;
-    iface_attr->priority = packed->prio_cap_flags & UCS_MASK(8);
-    iface_attr->overhead = packed->overhead;
-    iface_attr->lat_ovh  = packed->lat_ovh;
+    if (packed->prio_cap_flags & UCP_ADDRESS_V1_FLAG_ATOMIC64) {
+        iface_attr->flags  |= UCP_ADDR_IFACE_FLAG_ATOMIC64;
+    }
 
     if (packed->bandwidth < 0.0) {
         /* The received value of the bandwidth is "dedicated - shared" which
@@ -579,37 +809,109 @@ ucp_address_unpack_iface_attr(ucp_worker_t *worker,
         iface_attr->bandwidth = packed->bandwidth;
     }
 
+    return sizeof(*packed);
+}
+
+static unsigned
+ucp_address_unpack_iface_attr_v2(ucp_worker_t *worker,
+                                 ucp_address_iface_attr_t *iface_attr,
+                                 const void *ptr)
+{
+    const ucp_address_v2_packed_iface_attr_t *packed = ptr;
+
+    iface_attr->priority    = packed->prio;
+    iface_attr->seg_size    = packed->seg_size *
+                              UCP_ADDRESS_IFACE_SEG_SIZE_FACTOR;
+    iface_attr->overhead    = UCS_FP8_UNPACK(OVERHEAD, packed->overhead) /
+                                             UCS_NSEC_PER_SEC;
+    iface_attr->lat_ovh     = UCS_FP8_UNPACK(LATENCY, packed->latency) /
+                                             UCS_NSEC_PER_SEC;
+    iface_attr->bandwidth   = UCS_FP8_UNPACK(BANDWIDTH, packed->bandwidth);
+    iface_attr->flags       = packed->flags;
+
+    return sizeof(*packed);
+}
+
+static ucs_status_t
+ucp_address_unpack_iface_attr(ucp_worker_t *worker,
+                              ucp_address_iface_attr_t *iface_attr,
+                              const void *ptr, unsigned unpack_flags,
+                              ucp_object_version_t addr_version, size_t *size_p)
+{
+    const ucp_address_unified_iface_attr_t *unified;
+    ucp_worker_iface_t *wiface;
+    ucp_rsc_index_t rsc_idx;
+    int iface_attr_len;
+
+    if (ucp_worker_is_unified_mode(worker)) {
+        /* Address contains resources index and iface latency overhead
+         * (not all iface attrs). */
+        unified             = ptr;
+        rsc_idx             = unified->rsc_index & UCP_ADDRESS_IFACE_LEN_MASK;
+        iface_attr->lat_ovh = fabs(unified->lat_ovh);
+        if (!UCS_BITMAP_GET(worker->context->tl_bitmap, rsc_idx)) {
+            if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
+                ucs_error("failed to unpack address, resource[%d] is not valid",
+                          rsc_idx);
+            }
+            return UCS_ERR_INVALID_ADDR;
+        }
+
+        /* Just take the rest of iface attrs from the local resource. */
+        wiface                    = ucp_worker_iface(worker, rsc_idx);
+        iface_attr->flags         = ucp_address_flags_from_iface_flags(
+                                        wiface->attr.cap.flags,
+                                        wiface->attr.cap.event_flags);
+        iface_attr->priority      = wiface->attr.priority;
+        iface_attr->overhead      = wiface->attr.overhead;
+        iface_attr->bandwidth     =
+                ucp_tl_iface_bandwidth(worker->context,
+                                       &wiface->attr.bandwidth);
+        iface_attr->dst_rsc_index = rsc_idx;
+        iface_attr->seg_size      = wiface->attr.cap.am.max_bcopy;
+        iface_attr->addr_version  = UCP_OBJECT_VERSION_V1;
+
+        if (signbit(unified->lat_ovh)) {
+            iface_attr->atomic.atomic32.op_flags  = wiface->attr.cap.atomic32.op_flags;
+            iface_attr->atomic.atomic32.fop_flags = wiface->attr.cap.atomic32.fop_flags;
+            iface_attr->atomic.atomic64.op_flags  = wiface->attr.cap.atomic64.op_flags;
+            iface_attr->atomic.atomic64.fop_flags = wiface->attr.cap.atomic64.fop_flags;
+        }
+
+        *size_p = sizeof(*unified);
+        return UCS_OK;
+    }
+
+    if (addr_version == UCP_OBJECT_VERSION_V1) {
+        iface_attr_len = ucp_address_unpack_iface_attr_v1(worker, iface_attr,
+                                                          ptr);
+    } else {
+        iface_attr_len = ucp_address_unpack_iface_attr_v2(worker, iface_attr,
+                                                          ptr);
+    }
+
+    iface_attr->addr_version = addr_version;
+
     if (iface_attr->bandwidth <= 0) {
         return UCS_ERR_INVALID_ADDR;
     }
 
-    /* Unpack iface flags */
-    iface_flags = ucp_address_unpack_flags(packed->prio_cap_flags,
-                                           UCP_ADDRESS_IFACE_FLAGS, 8);
-    iface_attr->cap_flags = ucp_address_flags_from_iface_flags(iface_flags);
-
-    /* Unpack iface event flags */
-    iface_attr->event_flags =
-        ucp_address_unpack_flags(packed->prio_cap_flags,
-                                 UCP_ADDRESS_IFACE_EVENT_FLAGS,
-                                 8 + ucs_popcount(UCP_ADDRESS_IFACE_FLAGS));
-
     /* Unpack iface 32-bit atomic operations */
-    if (packed->prio_cap_flags & UCP_ADDRESS_FLAG_ATOMIC32) {
+    if (iface_attr->flags & UCP_ADDR_IFACE_FLAG_ATOMIC32) {
         iface_attr->atomic.atomic32.op_flags  |= UCP_ATOMIC_OP_MASK;
         iface_attr->atomic.atomic32.fop_flags |= UCP_ATOMIC_FOP_MASK;
     }
 
     /* Unpack iface 64-bit atomic operations */
-    if (packed->prio_cap_flags & UCP_ADDRESS_FLAG_ATOMIC64) {
+    if (iface_attr->flags & UCP_ADDR_IFACE_FLAG_ATOMIC64) {
         iface_attr->atomic.atomic64.op_flags  |= UCP_ATOMIC_OP_MASK;
         iface_attr->atomic.atomic64.fop_flags |= UCP_ATOMIC_FOP_MASK;
     }
 
-    *size_p = sizeof(*packed);
+    *size_p = iface_attr_len;
 
     if (unpack_flags & UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX) {
-        ptr                       = packed + 1;
+        ptr                       = UCS_PTR_BYTE_OFFSET(ptr, iface_attr_len);
         iface_attr->dst_rsc_index = *(uint8_t*)ptr;
         *size_p                  += sizeof(uint8_t);
     } else {
@@ -635,24 +937,30 @@ ucp_address_iface_flags_ptr(ucp_worker_h worker, void *attr_ptr, int attr_len)
     return UCS_PTR_BYTE_OFFSET(attr_ptr, attr_len);
 }
 
-static void *ucp_address_pack_iface_length(ucp_worker_h worker, void *ptr,
-                                           size_t addr_length)
+static void *ucp_address_pack_tl_length(ucp_worker_h worker, void *ptr,
+                                        unsigned max_length, size_t addr_length,
+                                        ucp_object_version_t addr_version,
+                                        int is_extendable)
 {
     if (ucp_worker_is_unified_mode(worker)) {
         return ptr;
     }
 
-    ucs_assertv(addr_length <= UCP_ADDRESS_IFACE_LEN_MASK, "addr_length=%zu",
-                addr_length);
-    *(uint8_t*)ptr = addr_length;
+    if (is_extendable) {
+        return ucp_address_pack_byte_extended(ptr, addr_length, max_length,
+                                              addr_version);
+    }
 
-    return UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+    *ucs_serialize_next(&ptr, uint8_t) = addr_length;
+
+    return ptr;
 }
 
 static const void *
-ucp_address_unpack_iface_length(ucp_worker_h worker, const void *flags_ptr,
-                                const void *ptr, size_t *addr_length,
-                                int is_ep_addr, int *is_last_iface)
+ucp_address_unpack_tl_length(ucp_worker_h worker, const void *flags_ptr,
+                             const void *ptr, ucp_object_version_t addr_version,
+                             uint8_t *addr_length, int is_ep_addr,
+                             int *is_last_iface)
 {
     ucp_rsc_index_t rsc_index;
     uct_iface_attr_t *attr;
@@ -682,39 +990,78 @@ ucp_address_unpack_iface_length(ucp_worker_h worker, const void *flags_ptr,
         return ptr;
     }
 
-    if (!is_ep_addr) {
-        *is_last_iface = *(uint8_t*)ptr & UCP_ADDRESS_FLAG_LAST;
+    if (is_ep_addr) {
+        *addr_length = *ucs_serialize_next(&ptr, uint8_t);
+        return ptr;
     }
 
-    *addr_length = *(uint8_t*)ptr & UCP_ADDRESS_IFACE_LEN_MASK;
+    *is_last_iface = *(uint8_t*)ptr & UCP_ADDRESS_FLAG_LAST;
 
-    return UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+    return ucp_address_unpack_byte_extended(ptr, UCP_ADDRESS_IFACE_LEN_MASK,
+                                            addr_version, addr_length);
+}
+
+static void ucp_address_pack_header_flags(uint8_t *address_header,
+                                          ucp_object_version_t addr_version,
+                                          uint8_t flags)
+{
+    if (addr_version == UCP_OBJECT_VERSION_V1) {
+        *address_header |= (flags << UCP_ADDRESS_HEADER_FLAGS_SHIFT_V1);
+    } else {
+        address_header += 1;
+        *address_header = flags;
+    }
+}
+
+static void *ucp_address_unpack_header(const void *ptr,
+                                       ucp_object_version_t *addr_version,
+                                       uint8_t *addr_flags)
+{
+    const uint8_t *addr_header = ptr;
+
+    *addr_version = *addr_header & UCP_ADDRESS_HEADER_VERSION_MASK;
+
+    if (*addr_version == UCP_OBJECT_VERSION_V1) {
+        *addr_flags = *addr_header >> UCP_ADDRESS_HEADER_FLAGS_SHIFT_V1;
+        return UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+    }
+
+    ucs_assertv_always(*addr_version == UCP_OBJECT_VERSION_V2,
+                       "addr version %u", *addr_version);
+
+    *addr_flags = *(addr_header + 1);
+
+    return UCS_PTR_TYPE_OFFSET(ptr, uint16_t);
 }
 
 uint64_t ucp_address_get_uuid(const void *address)
 {
-    const uint8_t address_header = *(const uint8_t *)address;
-    if (address_header & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID) {
-        return *(uint64_t*)UCS_PTR_TYPE_OFFSET(address, uint8_t);
-    } else {
-        return UCP_ADDRESS_DEFAULT_WORKER_UUID;
-    }
+    uint64_t *uuid;
+    ucp_object_version_t address_version;
+    uint8_t flags;
+
+    uuid = ucp_address_unpack_header(address, &address_version, &flags);
+
+    return (flags & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID) ?
+           *uuid : UCP_ADDRESS_DEFAULT_WORKER_UUID;
 }
 
 uint64_t ucp_address_get_client_id(const void *address)
 {
-    const uint8_t address_header = *(const uint8_t *)address;
     const void *offset;
+    ucp_object_version_t address_version;
+    uint8_t flags;
 
-    if (address_header & UCP_ADDRESS_HEADER_FLAG_CLIENT_ID) {
-        offset = UCS_PTR_TYPE_OFFSET(address, uint8_t);
-        if (address_header & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID) {
-            offset = UCS_PTR_TYPE_OFFSET(offset, uint64_t);
-        }
-        return *ucs_serialize_next(&offset, uint64_t);
-    } else {
+    offset = ucp_address_unpack_header(address, &address_version, &flags);
+    if (!(flags & UCP_ADDRESS_HEADER_FLAG_CLIENT_ID)) {
         return UCP_ADDRESS_DEFAULT_CLIENT_ID;
     }
+
+    if (flags & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID) {
+        offset = UCS_PTR_TYPE_OFFSET(offset, uint64_t);
+    }
+
+    return *ucs_serialize_next(&offset, uint64_t);
 }
 
 uint8_t ucp_address_is_am_only(const void *address)
@@ -726,7 +1073,8 @@ uint8_t ucp_address_is_am_only(const void *address)
 
 static ucs_status_t
 ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
-                    unsigned pack_flags, const ucp_lane_index_t *lanes2remote,
+                    unsigned pack_flags, ucp_object_version_t addr_version,
+                    const ucp_lane_index_t *lanes2remote,
                     const ucp_address_packed_device_t *devices,
                     ucp_rsc_index_t num_devices)
 {
@@ -751,39 +1099,45 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
     int attr_len;
     void *ptr;
     int enable_amo;
+    uint8_t addr_flags;
 
     ptr               = buffer;
     addr_index        = 0;
+    addr_flags        = 0;
     address_header_p  = ptr;
-    *address_header_p = UCP_ADDRESS_VERSION_CURRENT;
-    ptr               = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+    *address_header_p = addr_version;
+    ptr               = (addr_version == UCP_OBJECT_VERSION_V1) ?
+                        UCS_PTR_TYPE_OFFSET(ptr, uint8_t) :
+                        UCS_PTR_TYPE_OFFSET(ptr, uint16_t);
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_AM_ONLY) {
-        *address_header_p |= UCP_ADDRESS_HEADER_FLAG_AM_ONLY;
+        addr_flags |= UCP_ADDRESS_HEADER_FLAG_AM_ONLY;
     }
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
-        *(uint64_t*)ptr    = worker->uuid;
-        ptr                = UCS_PTR_TYPE_OFFSET(ptr, uint64_t);
-        *address_header_p |= UCP_ADDRESS_HEADER_FLAG_WORKER_UUID;
+        *(uint64_t*)ptr = worker->uuid;
+        ptr             = UCS_PTR_TYPE_OFFSET(ptr, uint64_t);
+        addr_flags     |= UCP_ADDRESS_HEADER_FLAG_WORKER_UUID;
     }
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_CLIENT_ID) {
-        *(uint64_t*)ptr    = worker->client_id;
-        ptr                = UCS_PTR_TYPE_OFFSET(ptr, uint64_t);
-        *address_header_p |= UCP_ADDRESS_HEADER_FLAG_CLIENT_ID;
+        *(uint64_t*)ptr = worker->client_id;
+        ptr             = UCS_PTR_TYPE_OFFSET(ptr, uint64_t);
+        addr_flags     |= UCP_ADDRESS_HEADER_FLAG_CLIENT_ID;
     }
 
     if (worker->context->config.ext.address_debug_info) {
         /* Add debug information to the packed address, and set the corresponding
          * flag in address header.
          */
-        *address_header_p |= UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO;
+        addr_flags |= UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO;
 
         if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME) {
             ptr            = ucp_address_pack_worker_address_name(worker, ptr);
         }
     }
+
+    ucp_address_pack_header_flags(address_header_p, addr_version, addr_flags);
 
     if (num_devices == 0) {
         *((uint8_t*)ptr) = UCP_NULL_RESOURCE;
@@ -796,36 +1150,21 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
         UCS_BITMAP_AND_INPLACE(&dev_tl_bitmap, dev->tl_bitmap);
 
         /* MD index */
-        md_index       = context->tl_rscs[dev->rsc_index].md_index;
-        md_flags       = context->tl_mds[md_index].attr.cap.flags & md_flags_pack_mask;
-        ucs_assertv_always(md_index <= UCP_ADDRESS_FLAG_MD_MASK,
-                           "md_index=%d", md_index);
+        md_index      = context->tl_rscs[dev->rsc_index].md_index;
+        md_flags      = context->tl_mds[md_index].attr.cap.flags &
+                            md_flags_pack_mask;
+        ptr           = ucp_address_pack_md_info(
+                            ptr, UCS_BITMAP_IS_ZERO_INPLACE(&dev_tl_bitmap),
+                            md_flags, md_index, addr_version);
+        flags_ptr     = ptr;
+        ucs_assert_always((pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) ||
+                          (dev->dev_addr_len == 0));
+        ptr = ucp_address_pack_byte_extended(ptr, dev->dev_addr_len,
+                                             UCP_ADDRESS_DEVICE_LEN_MASK,
+                                             addr_version);
 
-        *(uint8_t*)ptr = md_index;
-
-        if (UCS_BITMAP_IS_ZERO_INPLACE(&dev_tl_bitmap)) {
-            *(uint8_t*)ptr |= UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
-        }
-
-        if (md_flags & UCT_MD_FLAG_ALLOC) {
-            *(uint8_t*)ptr |= UCP_ADDRESS_FLAG_MD_ALLOC;
-        }
-
-        if (md_flags & UCT_MD_FLAG_REG) {
-            *(uint8_t*)ptr |= UCP_ADDRESS_FLAG_MD_REG;
-        }
-
-        ptr = UCS_PTR_TYPE_OFFSET(ptr, md_index);
-
-        /* Device address length */
-        *(uint8_t*)ptr = (dev == (devices + num_devices - 1)) ?
-                         UCP_ADDRESS_FLAG_LAST : 0;
-        if (pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) {
-            ucs_assert(dev->dev_addr_len <= UCP_ADDRESS_DEVICE_LEN_MASK);
-            *(uint8_t*)ptr |= dev->dev_addr_len;
-        }
-        flags_ptr = ptr;
-        ptr       = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+        *(uint8_t*)flags_ptr |= (dev == (devices + num_devices - 1)) ?
+                                UCP_ADDRESS_FLAG_LAST : 0;
 
         /* Device number of paths flag and value */
         ucs_assert(dev->num_paths >= 1);
@@ -874,7 +1213,7 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
             enable_amo = UCS_BITMAP_GET(worker->atomic_tls, rsc_index);
             attr_len   = ucp_address_pack_iface_attr(worker, ptr, rsc_index,
                                                      iface_attr, pack_flags,
-                                                     enable_amo);
+                                                     addr_version, enable_amo);
             if (attr_len < 0) {
                 return UCS_ERR_INVALID_ADDR;
             }
@@ -891,7 +1230,9 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
             ptr       = UCS_PTR_BYTE_OFFSET(ptr, attr_len);
 
             /* Pack iface address */
-            ptr = ucp_address_pack_iface_length(worker, ptr, iface_addr_len);
+            ptr = ucp_address_pack_tl_length(worker, ptr,
+                                             UCP_ADDRESS_IFACE_LEN_MASK,
+                                             iface_addr_len, addr_version, 1);
             if (pack_flags & UCP_ADDRESS_PACK_FLAG_IFACE_ADDR) {
                 status = uct_iface_get_address(wiface->iface,
                                                (uct_iface_addr_t*)ptr);
@@ -919,9 +1260,10 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
                         continue;
                     }
 
-                    /* pack ep address length and save pointer to flags */
-                    ptr = ucp_address_pack_iface_length(worker, ptr,
-                                                        ep_addr_len);
+                    /* pack ep address length */
+                    ptr = ucp_address_pack_tl_length(worker, ptr, UINT8_MAX,
+                                                     ep_addr_len, addr_version,
+                                                     0);
 
                     /* pack ep address */
                     status = uct_ep_get_address(ep->uct_eps[lane], ptr);
@@ -1012,6 +1354,7 @@ out:
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
                               const ucp_tl_bitmap_t *tl_bitmap,
                               unsigned pack_flags,
+                              ucp_object_version_t addr_version,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p)
 {
@@ -1027,13 +1370,14 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
 
     /* Collect all devices we want to pack */
     status = ucp_address_gather_devices(worker, ep, tl_bitmap, pack_flags,
-                                        &devices, &num_devices);
+                                        addr_version, &devices, &num_devices);
     if (status != UCS_OK) {
         goto out;
     }
 
     /* Calculate packed size */
-    size = ucp_address_packed_size(worker, devices, num_devices, pack_flags);
+    size = ucp_address_packed_size(worker, devices, num_devices, pack_flags,
+                                   addr_version);
 
     /* Allocate address */
     buffer = ucs_malloc(size, "ucp_address");
@@ -1046,7 +1390,8 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
 
     /* Pack the address */
     status = ucp_address_do_pack(worker, ep, buffer, size, pack_flags,
-                                 lanes2remote, devices, num_devices);
+                                 addr_version, lanes2remote, devices,
+                                 num_devices);
     if (status != UCS_OK) {
         ucs_free(buffer);
         goto out_free_devices;
@@ -1069,7 +1414,8 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                                 ucp_unpacked_address_t *unpacked_address)
 {
     ucp_address_entry_t *address_list, *address;
-    uint8_t address_header;
+    uint8_t addr_flags;
+    ucp_object_version_t addr_version;
     ucp_address_entry_ep_addr_t *ep_addr;
     int last_dev, last_tl, last_ep_addr;
     const uct_device_addr_t *dev_addr;
@@ -1079,11 +1425,9 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     unsigned dev_num_paths;
     ucs_status_t status;
     int empty_dev;
-    size_t dev_addr_len;
-    size_t iface_addr_len;
-    size_t ep_addr_len;
+    uint8_t dev_addr_len, iface_addr_len, ep_addr_len;
     size_t attr_len;
-    uint8_t md_byte;
+    uint8_t flags;
     const void *ptr;
     const void *flags_ptr;
 
@@ -1091,20 +1435,18 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     unpacked_address->address_count = 0;
     unpacked_address->address_list  = NULL;
 
-    ptr                             = buffer;
-    address_header                  = *(const uint8_t *)ptr;
-    ptr                             = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
+    ptr = ucp_address_unpack_header(buffer, &addr_version, &addr_flags);
 
     if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
-        ucs_trace("unpacking address version %u",
-                  (uint8_t)(address_header & UCP_ADDRESS_HEADER_VERSION_MASK));
+        ucs_trace("unpack address version %u flags 0x%x",
+                  addr_version, addr_flags);
     }
 
     if (unpack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
-        ucs_assert(address_header & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID);
+        ucs_assert(addr_flags & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID);
     }
 
-    if (address_header & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID) {
+    if (addr_flags & UCP_ADDRESS_HEADER_FLAG_WORKER_UUID) {
         unpacked_address->uuid = ucp_address_get_uuid(buffer);
         ptr                    = UCS_PTR_TYPE_OFFSET(ptr,
                                                      unpacked_address->uuid);
@@ -1112,11 +1454,11 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
         unpacked_address->uuid = 0ul;
     }
 
-    if (address_header & UCP_ADDRESS_HEADER_FLAG_CLIENT_ID) {
+    if (addr_flags & UCP_ADDRESS_HEADER_FLAG_CLIENT_ID) {
         ptr = UCS_PTR_TYPE_OFFSET(ptr, uint64_t);
     }
 
-    if ((address_header & UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO) &&
+    if ((addr_flags & UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO) &&
         (unpack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_NAME)) {
         ptr = ucp_address_unpack_worker_address_name(ptr,
                                                      unpacked_address->name);
@@ -1143,24 +1485,23 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     dev_index = 0;
 
     do {
-        /* md_index */
-        md_byte      = (*(uint8_t*)ptr);
-        md_index     = md_byte & UCP_ADDRESS_FLAG_MD_MASK;
-        empty_dev    = md_byte & UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
-        ptr          = UCS_PTR_TYPE_OFFSET(ptr, md_byte);
+        /* md_index and empty flag */
+        ptr      = ucp_address_unpack_md_info(ptr, addr_version, &md_index,
+                                              &empty_dev);
 
         /* device address length */
-        flags_ptr    = ptr;
-        ptr          = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
-        dev_addr_len = (*(uint8_t*)flags_ptr) & UCP_ADDRESS_DEVICE_LEN_MASK;
-        last_dev     = (*(uint8_t*)flags_ptr) & UCP_ADDRESS_FLAG_LAST;
-        if ((*(uint8_t*)flags_ptr) & UCP_ADDRESS_FLAG_NUM_PATHS) {
+        flags    = (*(uint8_t*)ptr) & ~UCP_ADDRESS_DEVICE_LEN_MASK;
+        last_dev = flags & UCP_ADDRESS_FLAG_LAST;
+        ptr = ucp_address_unpack_byte_extended(ptr, UCP_ADDRESS_DEVICE_LEN_MASK,
+                                               addr_version, &dev_addr_len);
+
+        if (flags & UCP_ADDRESS_FLAG_NUM_PATHS) {
             dev_num_paths = *(uint8_t*)ptr;
             ptr           = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
         } else {
             dev_num_paths = 1;
         }
-        if ((*(uint8_t*)flags_ptr) & UCP_ADDRESS_FLAG_SYS_DEVICE) {
+        if (flags & UCP_ADDRESS_FLAG_SYS_DEVICE) {
             sys_dev = *(uint8_t*)ptr;
             ptr     = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
         } else {
@@ -1191,20 +1532,24 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
             address->dev_num_paths = dev_num_paths;
 
             status = ucp_address_unpack_iface_attr(worker, &address->iface_attr,
-                                                   ptr, unpack_flags, &attr_len);
+                                                   ptr, unpack_flags,
+                                                   addr_version, &attr_len);
             if (status != UCS_OK) {
                 goto err_free;
             }
 
-            flags_ptr = ucp_address_iface_flags_ptr(worker, (void*)ptr, attr_len);
+            flags_ptr = ucp_address_iface_flags_ptr(worker, (void*)ptr,
+                                                    attr_len);
             ptr       = UCS_PTR_BYTE_OFFSET(ptr, attr_len);
-            ptr       = ucp_address_unpack_iface_length(worker, flags_ptr, ptr,
-                                                        &iface_addr_len, 0, &last_tl);
+            ptr       = ucp_address_unpack_tl_length(worker, flags_ptr, ptr,
+                                                     addr_version,
+                                                     &iface_addr_len, 0,
+                                                     &last_tl);
             address->iface_addr   = (iface_addr_len > 0) ? ptr : NULL;
             address->num_ep_addrs = 0;
             ptr                   = UCS_PTR_BYTE_OFFSET(ptr, iface_addr_len);
-
-            last_ep_addr = !(*(uint8_t*)flags_ptr & UCP_ADDRESS_FLAG_HAS_EP_ADDR);
+            last_ep_addr          = !(*(uint8_t*)flags_ptr &
+                                      UCP_ADDRESS_FLAG_HAS_EP_ADDR);
             while (!last_ep_addr) {
                 if (address->num_ep_addrs >= UCP_MAX_LANES) {
                     if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
@@ -1214,8 +1559,9 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                     goto err_free;
                 }
 
-                ptr = ucp_address_unpack_iface_length(worker, flags_ptr, ptr,
-                                                      &ep_addr_len, 1, NULL);
+                ptr = ucp_address_unpack_tl_length(worker, flags_ptr, ptr,
+                                                   addr_version, &ep_addr_len,
+                                                   1, NULL);
 
                 ep_addr       = &address->ep_addrs[address->num_ep_addrs++];
                 ep_addr->addr = ptr;
@@ -1225,10 +1571,10 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
                 last_ep_addr  = *(uint8_t*)ptr & UCP_ADDRESS_FLAG_LAST;
 
                 if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
-                    ucs_trace("unpack addr[%d].ep_addr[%d] : len %zu lane %d",
+                    ucs_trace("unpack addr[%d].ep_addr[%d] : len %d lane %d",
                               (int)(address - address_list),
-                              (int)(ep_addr - address->ep_addrs),
-                              ep_addr_len, ep_addr->lane);
+                              (int)(ep_addr - address->ep_addrs), ep_addr_len,
+                              ep_addr->lane);
                 }
 
                 ptr           = UCS_PTR_TYPE_OFFSET(ptr, uint8_t);
@@ -1236,15 +1582,13 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
 
             if (!(unpack_flags & UCP_ADDRESS_PACK_FLAG_NO_TRACE)) {
                 ucs_trace("unpack addr[%d] : sysdev %d paths %d eps %u"
-                          " tl_iface_flags 0x%" PRIx64
-                          " tl_event_flags 0x%" PRIx64 " bw %.2f/nMBs"
+                          " tl_iface_flags 0x%" PRIx64 " bw %.2f/nMBs"
                           " ovh %.0fns lat_ovh %.0fns dev_priority %d"
                           " a32 0x%" PRIx64 "/0x%" PRIx64 " a64 0x%" PRIx64
                           "/0x%" PRIx64,
                           (int)(address - address_list), address->sys_dev,
                           address->dev_num_paths, address->num_ep_addrs,
-                          address->iface_attr.cap_flags,
-                          address->iface_attr.event_flags,
+                          address->iface_attr.flags,
                           address->iface_attr.bandwidth / UCS_MBYTE,
                           address->iface_attr.overhead * 1e9,
                           address->iface_attr.lat_ovh * 1e9,

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -39,7 +39,10 @@ enum {
     UCP_ADDR_IFACE_FLAG_PUT              = UCS_BIT(3),
     UCP_ADDR_IFACE_FLAG_GET              = UCS_BIT(4),
     UCP_ADDR_IFACE_FLAG_TAG_EAGER        = UCS_BIT(5),
-    UCP_ADDR_IFACE_FLAG_TAG_RNDV         = UCS_BIT(6)
+    UCP_ADDR_IFACE_FLAG_TAG_RNDV         = UCS_BIT(6),
+    UCP_ADDR_IFACE_FLAG_EVENT_RECV       = UCS_BIT(7),
+    UCP_ADDR_IFACE_FLAG_ATOMIC32         = UCS_BIT(8),
+    UCP_ADDR_IFACE_FLAG_ATOMIC64         = UCS_BIT(9)
 };
 
 
@@ -106,20 +109,27 @@ typedef ucs_bitmap_t(UCP_MAX_RESOURCES) ucp_tl_addr_bitmap_t;
  * Remote interface attributes.
  */
 struct ucp_address_iface_attr {
-    uint64_t                    cap_flags;    /* Interface capability flags */
-    uint64_t                    event_flags;  /* Interface event capability flags */
+    uint64_t                    flags;        /* Interface capability and event
+                                                 flags */
     double                      overhead;     /* Interface performance - overhead */
     double                      bandwidth;    /* Interface performance - bandwidth */
     int                         priority;     /* Priority of device */
-    double                      lat_ovh;      /* Latency overhead */
+    double                      lat_ovh;      /* Address v1: latency overhead
+                                               * address v2: latency */
     ucp_rsc_index_t             dst_rsc_index;/* Destination resource index */
     ucp_tl_iface_atomic_flags_t atomic;       /* Atomic operations */
+    size_t                      seg_size;     /* Maximal fragment size which can
+                                                 be received on the particular
+                                                 interface */
+    ucp_object_version_t        addr_version; /* Peer address version */
 };
+
 
 typedef struct ucp_address_entry_ep_addr {
     ucp_lane_index_t            lane;         /* Lane index (local or remote) */
     const uct_ep_addr_t         *addr;        /* Pointer to ep address */
 } ucp_address_entry_ep_addr_t;
+
 
 /**
  * Address entry.
@@ -176,6 +186,7 @@ struct ucp_unpacked_address {
  *                            (ep or iface) should be packed.
  * @param [in]  pack_flags    UCP_ADDRESS_PACK_FLAG_xx flags to specify address
  *                            format.
+ * @param [in]  addr_version  Address format version to pack.
  * @param [in]  lanes2remote  If NULL, the lane index in each packed ep address
  *                            will be the local lane index. Otherwise, specifies
  *                            which lane index should be packed in the ep address
@@ -187,6 +198,7 @@ struct ucp_unpacked_address {
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
                               const ucp_tl_bitmap_t *tl_bitmap,
                               unsigned pack_flags,
+                              ucp_object_version_t addr_version,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p);
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -187,8 +187,9 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
                        ucp_wireup_msg_t *msg_hdr, void **address_p,
                        size_t *address_length_p)
 {
-    unsigned pack_flags = ucp_worker_default_address_pack_flags(ep->worker) |
-                          UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX;
+    ucp_context_h context = ep->worker->context;
+    unsigned pack_flags   = ucp_worker_default_address_pack_flags(ep->worker) |
+                            UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX;
     ucs_status_t status;
 
     msg_hdr->type      = type;
@@ -205,6 +206,7 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
 
     /* pack all addresses */
     status = ucp_address_pack(ep->worker, ep, tl_bitmap, pack_flags,
+                              context->config.ext.worker_addr_version,
                               lanes2remote, address_length_p, address_p);
     if (status != UCS_OK) {
         ucs_error("failed to pack address: %s", ucs_status_string(status));

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -34,7 +34,7 @@ ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
                                            ucp_rsc_index_t cm_idx,
                                            const char *dev_name,
                                            unsigned ep_init_flags,
-                                           uint8_t sa_data_version);
+                                           ucp_object_version_t sa_data_version);
 
 ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
                                             const ucp_ep_params_t *params);
@@ -61,6 +61,6 @@ ucp_request_t* ucp_ep_cm_close_request_get(ucp_ep_h ep,
 
 void ucp_ep_cm_slow_cbq_cleanup(ucp_ep_h ep);
 
-size_t ucp_cm_sa_data_length(uint8_t sa_data_version);
+size_t ucp_cm_sa_data_length(ucp_object_version_t sa_data_version);
 
 #endif /* WIREUP_CM_H_ */

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -99,7 +99,7 @@ UCS_TEST_F(test_type, serialize) {
 }
 
 /* Represents latency (in ns) */
-UCS_FP8_DECLARE_TYPE(LATENCY, UCS_BIT(7), UCS_BIT(20))
+UCS_FP8_DECLARE_TYPE(TEST_LATENCY, UCS_BIT(7), UCS_BIT(20))
 
 UCS_TEST_F(test_type, pack_float) {
     const std::size_t values_size    = 10;
@@ -110,28 +110,32 @@ UCS_TEST_F(test_type, pack_float) {
     float unpacked;
 
     /* 0 -> 0 */
-    unpacked = UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, 0));
+    unpacked = UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, 0));
     EXPECT_EQ(unpacked, 0);
 
     /* NaN -> NaN */
-    unpacked = UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, NAN));
+    unpacked = UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, NAN));
     EXPECT_TRUE(isnan(unpacked));
 
     /* Below min -> min */
-    EXPECT_EQ(UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, UCS_BIT(7))),
-              UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, 15)));
+    EXPECT_EQ(UCS_FP8_UNPACK(TEST_LATENCY,
+                             UCS_FP8_PACK(TEST_LATENCY, UCS_BIT(7))),
+              UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, 15)));
 
     /* Precision test throughout the whole range */
     for (std::vector<double>::const_iterator it = values.begin();
          it < values.end(); it++) {
-        unpacked = UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, *it));
+        unpacked = UCS_FP8_UNPACK(TEST_LATENCY,
+                                  UCS_FP8_PACK(TEST_LATENCY, *it));
         ucs_assert((UCS_FP8_PRECISION < unpacked / *it) &&
                    (unpacked / *it <= 1));
     }
 
     /* Above max -> max */
-    EXPECT_EQ(UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, UCS_BIT(20))),
-              UCS_FP8_UNPACK(LATENCY, UCS_FP8_PACK(LATENCY, 200000000)));
+    EXPECT_EQ(UCS_FP8_UNPACK(TEST_LATENCY,
+                             UCS_FP8_PACK(TEST_LATENCY, UCS_BIT(20))),
+              UCS_FP8_UNPACK(TEST_LATENCY,
+                             UCS_FP8_PACK(TEST_LATENCY, 200000000)));
 }
 
 class test_init_once: public test_type {


### PR DESCRIPTION
## What
Define new version of UCP worker address format

## Why ?
- Make it shorter
- Make it more flexible (allowing bigger address lengths, md ids, etc)

## How ?
- use `ucs_fp8` instead of `floats`
- use extensions for address length or md id if they are too big
