### PR TITLE
UCP/WIREUP: del dev_idx from sockaddr data

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -762,7 +762,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
 
     for (i = 0; i < remote_addr.address_count; ++i) {
         remote_addr.address_list[i].dev_addr  = conn_request->remote_dev_addr;
-        remote_addr.address_list[i].dev_index = conn_request->sa_data.dev_index;
+        remote_addr.address_list[i].dev_index = 0; /* CM addr contains only 1 device */
     }
 
     status = ucp_ep_cm_server_create_connected(worker, ep_init_flags,

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -494,10 +494,6 @@ struct ucp_wireup_sockaddr_data {
     uint8_t                   addr_mode;     /**< The attached address format
                                                   defined by
                                                   UCP_WIREUP_SA_DATA_xx */
-    uint8_t                   dev_index;     /**< Device address index used to
-                                                  build remote address in
-                                                  UCP_WIREUP_SA_DATA_CM_ADDR
-                                                  mode */
     /* packed worker address follows */
 } UCS_S_PACKED;
 


### PR DESCRIPTION
## What
del dev_idx from sockaddr data

## Why ?
cleanup & optimization of wireup protocol
