### PR TITLE
AZP: remove unused label

### DIFF
--- a/buildlib/pr/static_checks.yml
+++ b/buildlib/pr/static_checks.yml
@@ -4,7 +4,7 @@ jobs:
     pool:
       name: MLNX
       demands:
-      - ucx_docker_fast -equals yes
+      - ucx_docker -equals yes
     container: fedora
     steps:
       - checkout: self


### PR DESCRIPTION
## Why ?
remove ucx_docker_fast label because this label duplicate with ucx_docker 

## How ?
remove ucx_docker_fast