### PR TITLE
TEST/PERF: Do not set CPU affinity for loopback tests

### DIFF
--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -118,8 +118,7 @@ private:
 
     test_result run_single_threaded(const test_spec &test, unsigned flags,
                                     const std::string &tl_name,
-                                    const std::string &dev_name,
-                                    const std::vector<int> &cpus);
+                                    const std::string &dev_name);
 };
 
 #endif


### PR DESCRIPTION
## Why
Potentially reduce testing time by not binding to a single core after loopback perftest

## How
Do not call test_func in single-threaded/loopback mode since it sets CPU affinity; call ucx_perf_run() directly