### PR TITLE
TEST/PERF: Do not print 'Final' when output set to CSV

### DIFF
--- a/src/tools/perf/perftest_run.c
+++ b/src/tools/perf/perftest_run.c
@@ -44,7 +44,8 @@ void print_progress(char **test_names, unsigned num_names,
 #if _OPENMP
     if (!final) {
         printf("[thread %d]", omp_get_thread_num());
-    } else if (flags & TEST_FLAG_PRINT_RESULTS) {
+    } else if ((flags & TEST_FLAG_PRINT_RESULTS) &&
+              !(flags & TEST_FLAG_PRINT_CSV)) {
         printf("Final:    ");
     }
 #endif


### PR DESCRIPTION
## What
Fix a bug where perftest prints "Final" when the output is set to CSV

## Why ?
The word "Final" should not be printed when printing in CSV mode.

## How ?

