### PR TITLE
UCP/TAG: fix recv of single packet sent by multi protocol

### DIFF
--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -109,10 +109,13 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
             req->recv.tag.info.length =
             req->recv.remaining       = eagerf_hdr->total_len;
 
-            ucp_tag_request_process_recv_data(req, payload, recv_len, 0, 0,
-                                              flags);
-            ucp_tag_frag_list_process_queue(&worker->tm, req, eagerf_hdr->msg_id
-                                            UCS_STATS_ARG(UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP));
+            status = ucp_tag_request_process_recv_data(req, payload, recv_len,
+                                                       0, 0, flags);
+            if (status == UCS_INPROGRESS) {
+                ucp_tag_frag_list_process_queue(&worker->tm, req,
+                                                eagerf_hdr->msg_id
+                                                UCS_STATS_ARG(UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP));
+            }
         }
 
         status = UCS_OK;

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -154,11 +154,13 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     /* process first fragment */
     UCP_WORKER_STAT_EAGER_CHUNK(worker, UNEXP);
     msg_id = eagerf_hdr->msg_id;
-    ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
+    status = ucp_tag_recv_request_process_rdesc(req, rdesc, 0);
+    if (status == UCS_INPROGRESS) {
+        /* process additional fragments */
+        ucp_tag_frag_list_process_queue(&worker->tm, req, msg_id
+                                        UCS_STATS_ARG(UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP));
+    }
 
-    /* process additional fragments */
-    ucp_tag_frag_list_process_queue(&worker->tm, req, msg_id
-                                    UCS_STATS_ARG(UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP));
     return req + 1;
 }
 


### PR DESCRIPTION
## What
fix recv of single packet sent by multi protocol

## Why ?
after EP reconfiguration after wireup, max_bcopy might be increased, so the whole message will be sent as a first packet of multi packet protocol which was handled wrongly on receiver side
