### PR TITLE
BINDINGS/GO: Fix memory leak for C allocated mem.

### DIFF
--- a/bindings/go/src/ucx/context_params.go
+++ b/bindings/go/src/ucx/context_params.go
@@ -7,6 +7,10 @@ package ucx
 
 // #include <ucp/api/ucp.h>
 import "C"
+import (
+	"runtime"
+	"unsafe"
+)
 
 // Tuning parameters for UCP library.
 // The structure defines the parameters that are used for
@@ -55,7 +59,9 @@ func (p *UcpParams) SetEstimatedNumPPN(estimatedNumPPN uint64) *UcpParams {
 
 // Tracing and analysis tools can identify the context using this name.
 func (p *UcpParams) SetName(name string) *UcpParams {
+	freeParamsName(p)
 	p.params.name = C.CString(name)
+	runtime.SetFinalizer(p, func(f *UcpParams) { FreeNativeMemory(unsafe.Pointer(f.params.name)) })
 	p.params.field_mask |= C.UCP_PARAM_FIELD_NAME
 	return p
 }

--- a/bindings/go/src/ucx/endpoint_params.go
+++ b/bindings/go/src/ucx/endpoint_params.go
@@ -65,7 +65,9 @@ func (p *UcpEpParams) SetErrorHandler(errHandler UcpEpErrHandler) *UcpEpParams {
 
 // Tracing and analysis tools can identify the endpoint using this name.
 func (p *UcpEpParams) SetName(name string) *UcpEpParams {
+	freeParamsName(p)
 	p.params.name = C.CString(name)
+	runtime.SetFinalizer(p, func(f *UcpEpParams) { FreeNativeMemory(unsafe.Pointer(f.params.name)) })
 	p.params.field_mask |= C.UCP_EP_PARAM_FIELD_NAME
 	return p
 }
@@ -78,6 +80,8 @@ func (p *UcpEpParams) SetSocketAddress(a *net.TCPAddr) (*UcpEpParams, error) {
 	if error != nil {
 		return nil, error
 	}
+
+	freeParamsAddress(p)
 
 	p.params.sockaddr = *sockAddr
 	runtime.SetFinalizer(p, func(f *UcpEpParams) { FreeNativeMemory(unsafe.Pointer(f.params.sockaddr.addr)) })

--- a/bindings/go/src/ucx/listener_params.go
+++ b/bindings/go/src/ucx/listener_params.go
@@ -39,6 +39,7 @@ func (p *UcpListenerParams) SetSocketAddress(a *net.TCPAddr) (*UcpListenerParams
 		return nil, error
 	}
 
+	freeParamsAddress(p)
 	p.params.field_mask |= C.UCP_LISTENER_PARAM_FIELD_SOCK_ADDR
 	p.params.sockaddr = *sockAddr
 	runtime.SetFinalizer(p, func(f *UcpListenerParams) { FreeNativeMemory(unsafe.Pointer(f.params.sockaddr.addr)) })

--- a/bindings/go/src/ucx/request.go
+++ b/bindings/go/src/ucx/request.go
@@ -38,11 +38,11 @@ func NewRequest(request C.ucs_status_ptr_t, callbackId uint64, immidiateInfo int
 	} else {
 		requestStatus := UcsStatus(int64(uintptr(request)))
 		if callback, found := deregister(callbackId); found {
-			switch callback.(type) {
+			switch callback := callback.(type) {
 			case UcpSendCallback:
-				callback.(UcpSendCallback)(ucpRequest, requestStatus)
+				callback(ucpRequest, requestStatus)
 			case UcpTagRecvCallback:
-				callback.(UcpTagRecvCallback)(ucpRequest, requestStatus, immidiateInfo.(*UcpTagRecvInfo))
+				callback(ucpRequest, requestStatus, immidiateInfo.(*UcpTagRecvInfo))
 			}
 			if requestStatus != C.UCS_OK {
 				return ucpRequest, NewUcxError(C.ucs_status_t(requestStatus))

--- a/bindings/go/src/ucx/worker_params.go
+++ b/bindings/go/src/ucx/worker_params.go
@@ -13,7 +13,11 @@ package ucx
 // 	 UCS_CPU_SET(cpuId, cpu_mask);
 // }
 import "C"
-import "math/big"
+import (
+	"math/big"
+	"runtime"
+	"unsafe"
+)
 
 // Tuning parameters for the UCP worker.
 type UcpWorkerParams struct {
@@ -124,7 +128,9 @@ func (p *UcpWorkerParams) SetEventFD(fd uintptr) *UcpWorkerParams {
 
 // Tracing and analysis tools can identify the worker using this name.
 func (p *UcpWorkerParams) SetName(name string) *UcpWorkerParams {
+	freeParamsName(p)
 	p.params.name = C.CString(name)
+	runtime.SetFinalizer(p, func(f *UcpWorkerParams) { FreeNativeMemory(unsafe.Pointer(f.params.name)) })
 	p.params.field_mask |= C.UCP_WORKER_PARAM_FIELD_NAME
 	return p
 }

--- a/bindings/go/tests/context_test.go
+++ b/bindings/go/tests/context_test.go
@@ -20,5 +20,7 @@ func TestUcpContext(t *testing.T) {
 		t.Fatalf("Failed to create a context %v", err)
 	}
 
+	ucpParams.SetName("Go test2")
+
 	context.Close()
 }


### PR DESCRIPTION
## What
Prevent memory leak in C allocated memory. Checks if the memory is set - free it, and sets finalizer for all C allocated objects

Tested by adding loggers to finalizers and if statements. 

## Why ?
Fixes #7422 