### PR TITLE
GTEST/COMMON: Fix missing bracket on ROCM memset

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -300,7 +300,7 @@ void mem_buffer::memset(void *buffer, size_t length, int c,
 #endif
 #if HAVE_ROCM
     case UCS_MEMORY_TYPE_ROCM:
-        ROCM_CALL(hipMemset(buffer, c, length);
+        ROCM_CALL(hipMemset(buffer, c, length));
         ROCM_CALL(hipDeviceSynchronize());
         break;
 #endif


### PR DESCRIPTION
## What
Fixing a missing bracket in mem_buffer::memset for ROCM-enabled code path

## Why ?
Code won't compile properly without it

## How ?
Added a single bracket
