### PR TITLE
UCP/PROTO: Fix short not being enabled with new protoocols

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -152,7 +152,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "Issue a warning in case of invalid device and/or transport configuration.",
    ucs_offsetof(ucp_config_t, warn_invalid_config), UCS_CONFIG_TYPE_BOOL},
 
-  {"BCOPY_THRESH", "0",
+  {"BCOPY_THRESH", "auto",
    "Threshold for switching from short to bcopy protocol",
    ucs_offsetof(ucp_config_t, ctx.bcopy_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2044,7 +2044,11 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     config->tag.eager.zcopy_auto_thresh = 0;
     config->am.zcopy_auto_thresh        = 0;
     config->p2p_lanes                   = 0;
-    config->bcopy_thresh                = context->config.ext.bcopy_thresh;
+    if (context->config.ext.bcopy_thresh == UCS_MEMUNITS_AUTO) {
+        config->bcopy_thresh = 0;
+    } else {
+        config->bcopy_thresh = context->config.ext.bcopy_thresh;
+    }
     config->tag.lane                    = UCP_NULL_LANE;
     config->tag.proto                   = &ucp_tag_eager_proto;
     config->tag.sync_proto              = &ucp_tag_eager_sync_proto;


### PR DESCRIPTION
## Why
Fast-path short protocol was not used because short threshold was not set correctly so performance is not as good

## How
1. Fix signed/unsigned compare
2. Set the default of UCX_BCOPY_THRESH to "auto", to not force bcopy protocol from length 0