### PR TITLE
UCP/PROTO: Fix handling of NO_IMM_CMPL flag

### DIFF
--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -191,28 +191,18 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
                               proto_select, rkey_cfg_index, &sel_param,
                               req->send.state.dt_iter.length);
     if (status != UCS_OK) {
-        goto out_put_request;
+        ucp_request_put_param(param, req);
+        return UCS_STATUS_PTR(status);
     }
 
     UCS_PROFILE_CALL_VOID(ucp_request_send, req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
-        goto out_put_request;
+        ucp_request_imm_cmpl_param(param, req, send);
     }
 
-    /* set callback flag to allow calling it. we didn't set it before to prevent
-     * it from being called if the send is completed immediately.
-     */
     ucp_request_set_send_callback_param(param, req, send);
-
     ucs_trace_req("returning send request %p", req);
     return req + 1;
-
-out_put_request:
-    ucs_trace_req("releasing send request %p, returning status %s", req,
-                  ucs_status_string(status));
-    status = req->status;
-    ucp_request_put_param(param, req);
-    return UCS_STATUS_PTR(status);
 }
 
 static UCS_F_ALWAYS_INLINE size_t


### PR DESCRIPTION
## Why
NO_IMM_CPML flag was ignored with new protocols

## How
Use same macro as in old protocols - ucp_request_imm_cmpl_param