### PR TITLE
UCT/API/V2: Add latency estimation to uct_iface_estimate_perf()

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -81,7 +81,10 @@ enum uct_perf_attr_field {
     UCT_PERF_ATTR_FIELD_OVERHEAD           = UCS_BIT(5),
 
     /** Enables @ref uct_perf_attr_t::bandwidth */
-    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(6)
+    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(6),
+
+    /** Enables @ref uct_perf_attr_t::latency */
+    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(7)
 };
 
 
@@ -141,6 +144,12 @@ typedef struct {
      * Bandwidth model. This field is set by the UCT layer.
      */
     uct_ppn_bandwidth_t bandwidth;
+
+    /**
+     * Latency as a function of number of endpoints.
+     * This field is set by the UCT layer.
+     */
+    ucs_linear_func_t   latency;
 } uct_perf_attr_t;
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -425,8 +425,8 @@ ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
 ucs_status_t
 uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 {
-    ucs_status_t status;
     uct_iface_attr_t iface_attr;
+    ucs_status_t status;
 
     status = uct_iface_query(iface, &iface_attr);
     if (status != UCS_OK) {
@@ -434,12 +434,17 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
     }
 
     /* By default, the performance is assumed to be the same for all operations */
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
+        perf_attr->overhead = iface_attr.overhead;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         perf_attr->bandwidth = iface_attr.bandwidth;
     }
 
-    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
-        perf_attr->overhead = iface_attr.overhead;
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = iface_attr.latency;
     }
 
     return UCS_OK;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -18,6 +18,10 @@
 #include <ucs/arch/cpu.h>
 
 
+#define UCT_CUDA_COPY_IFACE_OVERHEAD 0
+#define UCT_CUDA_COPY_IFACE_LATENCY  ucs_linear_func_make(8e-6, 0)
+
+
 static ucs_config_field_t uct_cuda_copy_iface_config_table[] = {
 
     {"", "", NULL,
@@ -109,7 +113,7 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency                 = ucs_linear_func_make(8e-6, 0);
+    iface_attr->latency                 = UCT_CUDA_COPY_IFACE_LATENCY;
     iface_attr->bandwidth.dedicated     = 0;
     iface_attr->bandwidth.shared        = iface->config.bandwidth;
     iface_attr->overhead                = UCT_CUDA_COPY_IFACE_OVERHEAD;
@@ -321,6 +325,10 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
         perf_attr->overhead = UCT_CUDA_COPY_IFACE_OVERHEAD;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = UCT_CUDA_COPY_IFACE_LATENCY;
     }
 
     return UCS_OK;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -11,9 +11,6 @@
 #include <pthread.h>
 
 
-#define UCT_CUDA_COPY_IFACE_OVERHEAD          (0)
-
-
 typedef uint64_t uct_cuda_copy_iface_addr_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -16,6 +16,11 @@
 #include <ucs/sys/string.h>
 
 
+#define UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH (6911.0 * UCS_MBYTE)
+#define UCT_GDR_COPY_IFACE_OVERHEAD          0
+#define UCT_GDR_COPY_IFACE_LATENCY           ucs_linear_func_make(1e-6, 0)
+
+
 static ucs_config_field_t uct_gdr_copy_iface_config_table[] = {
 
     {"", "", NULL,
@@ -86,7 +91,7 @@ uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
+    iface_attr->latency                 = UCT_GDR_COPY_IFACE_LATENCY;
     iface_attr->bandwidth.dedicated     = 0;
     iface_attr->bandwidth.shared        = UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
     iface_attr->overhead                = UCT_GDR_COPY_IFACE_OVERHEAD;
@@ -120,6 +125,10 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OVERHEAD) {
         perf_attr->overhead = UCT_GDR_COPY_IFACE_OVERHEAD;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = UCT_GDR_COPY_IFACE_LATENCY;
     }
 
     return UCS_OK;

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.h
@@ -9,12 +9,6 @@
 #include <uct/base/uct_iface.h>
 
 
-#define UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH (6911.0 * UCS_MBYTE)
-
-
-#define UCT_GDR_COPY_IFACE_OVERHEAD (0)
-
-
 typedef uint64_t uct_gdr_copy_iface_addr_t;
 
 


### PR DESCRIPTION
## Why
Allow exposing different latency per specific UCT operation for a more accurate performance estimation with new protocols