### PR TITLE
AZP/IO_DEMO: Increase uptime in network corrupter

### DIFF
--- a/buildlib/pr/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/pr/io_demo/az-stage-io-demo.yaml
@@ -60,7 +60,7 @@ steps:
             -t 60 \
             ${{ parameters.iodemo_args }}
   displayName: Launch with run_io_demo.sh ( ${{ parameters.name }} )
-  timeoutInMinutes: 10
+  timeoutInMinutes: 15
 
 - bash: |
     python /hpc/noarch/git_projects/hpc-mtt-conf/scripts/iodemo_analyzer.py --allow_list CI,$(System.PullRequest.TargetBranch) -d $(workspace)/${{ parameters.name }} --duration ${{ parameters.duration }} -t 3
@@ -80,7 +80,7 @@ steps:
     cat corrupter.log
   displayName: Kill corrupter
   condition: always()
-  timeoutInMinutes: 10
+  timeoutInMinutes: 2
 
 - bash: |
     set -eEx

--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -13,31 +13,31 @@ parameters:
     default: 5
   - name: uptime
     type: number
-    default: 40
+    default: 180
   - name: tests
     type: object
     default:
       "tag match on CX4":
         args: ""
-        duration: 480
+        duration: 600
         interface: $(roce_iface_cx4)
         tls: "rc_x"
         test_name: tag_cx4_rc
       "active messages on CX4":
         args: "-A"
-        duration: 480
+        duration: 600
         interface: $(roce_iface_cx4)
         tls: "rc_x"
         test_name: am_cx4_rc
       "tag match on CX6/RC":
         args: ""
-        duration: 480
+        duration: 600
         interface: $(roce_iface_cx6)
         tls: "rc_x"
         test_name: tag_cx6_rc
       "active messages on CX6/RC":
         args: "-A"
-        duration: 480
+        duration: 600
         interface: $(roce_iface_cx6)
         tls: "rc_x"
         test_name: am_cx6_rc


### PR DESCRIPTION
## Why ?
40 seconds are not enough to recover from port failure, need to wait more time before bringing the port done again.
Should solve failures in io_demo/CX6 CI