### PR TITLE
GTEST/UCP: Reduce testing time of multi_wireup test under valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -552,7 +552,7 @@ UCS_TEST_P(test_ucp_wireup_1sided, one_sided_wireup_rndv, "RNDV_THRESH=1") {
 UCS_TEST_P(test_ucp_wireup_1sided, multi_wireup) {
     skip_loopback();
 
-    const size_t count = 10;
+    const size_t count = ucs_max(2, 10 / ucs::test_time_multiplier());
     while (entities().size() < count) {
         create_entity();
     }


### PR DESCRIPTION
## What

Reduce testing time of multi_wireup test under valgrind.

## Why ?

e.g. the following testing results on jazz nodes:
before:
```
[ RUN      ] shm_ib/test_ucp_wireup_1sided.multi_wireup/3 <shm,ib/rma,unified,no_ep_match>
[       OK ] shm_ib/test_ucp_wireup_1sided.multi_wireup/3 (16521 ms)
```
after:
```
[ RUN      ] shm_ib/test_ucp_wireup_1sided.multi_wireup/3 <shm,ib/rma,unified,no_ep_match>
[       OK ] shm_ib/test_ucp_wireup_1sided.multi_wireup/3 (4180 ms)
```

## How ?

Decrease the number of iterations from 10 to minimum value between `2` and `10 / ucs::test_time_multiplier()` when running under valgrind.