### PR TITLE
GTEST/UCS: Reduce number of min threads count in async_event_mt test under valgrind

### DIFF
--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -821,11 +821,12 @@ typedef test_async_mt<local_timer> test_async_timer_mt;
  */
 UCS_TEST_SKIP_COND_P(test_async_event_mt, multithread,
                      !(HAVE_DECL_F_SETOWN_EX)) {
-    const int exp_min_count = (int)(COUNT * 0.5);
-    int min_count = 0;
+    const int count         = ucs_max(4, COUNT / ucs::test_time_multiplier());
+    const int exp_min_count = (int)(count * 0.5);
+    int min_count           = 0;
     for (int retry = 0; retry < NUM_RETRIES; ++retry) {
         spawn();
-        for (int j = 0; j < COUNT; ++j) {
+        for (int j = 0; j < count; ++j) {
             for (unsigned i = 0; i < NUM_THREADS; ++i) {
                 event(i)->push_event();
                 suspend();


### PR DESCRIPTION
## What

Reduce the number of min threads count in async_event_mt test under valgrind.

## Why ?

It reduces CI testing time for `*/test_async_event_mt.multithread/0` test.
e.g. the following results could be obtained on jazz nodes:
before:
```
[ RUN      ] thread_spinlock/test_async_event_mt.multithread/0 <thread_spinlock>
[       OK ] thread_spinlock/test_async_event_mt.multithread/0 (28192 ms)
```
after:
```
[ RUN      ] thread_spinlock/test_async_event_mt.multithread/0 <thread_spinlock>
[       OK ] thread_spinlock/test_async_event_mt.multithread/0 (5194 ms)
```

## How ?

Use `ucs_max(4, COUNT / ucs::test_time_multiplier())` instead of `COUNT` to reduce testing time.