### PR TITLE
GTEST/UCP: Reduce testing time of some stream tests under valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -341,8 +341,11 @@ void test_ucp_stream::do_send_exp_recv_test(ucp_datatype_t datatype)
 {
     const size_t dt_elem_size = UCP_DT_IS_CONTIG(datatype) ?
                                 ucp_contig_dt_elem_size(datatype) : 1;
-    const size_t msg_size = dt_elem_size * UCS_MBYTE;
-    const size_t n_msgs   = 10;
+    const size_t msg_size     = dt_elem_size *
+                                /* message size must be a multiple of
+                                 * dt_elem_size */
+                                (UCS_MBYTE / ucs::test_time_multiplier());
+    const size_t n_msgs       = ucs_max(2, 10 / ucs::test_time_multiplier());
 
     std::vector<std::vector<T> > rbufs(n_msgs,
                                        std::vector<T>(msg_size / dt_elem_size, 'r'));


### PR DESCRIPTION
## What

Reduce testing time of some stream tests under valgrind.

## Why ?

e.g. it gives the following testing time improvement on jazz nodes:
before:
```
[ RUN      ] shm_ib/test_ucp_stream.send_exp_recv_32/0 <shm,ib>
==47910== Warning: noted but unhandled ioctl 0x7801 with no size/direction hints.
==47910==    This could cause spurious value errors to appear.
==47910==    See README_MISSING_SYSCALL_OR_IOCTL for guidance on writing a proper wrapper.
[       OK ] shm_ib/test_ucp_stream.send_exp_recv_32/0 (9570 ms)
```
after:
```
[ RUN      ] shm_ib/test_ucp_stream.send_exp_recv_32/0 <shm,ib>
==44644== Warning: noted but unhandled ioctl 0x7801 with no size/direction hints.
==44644==    This could cause spurious value errors to appear.
==44644==    See README_MISSING_SYSCALL_OR_IOCTL for guidance on writing a proper wrapper.
[       OK ] shm_ib/test_ucp_stream.send_exp_recv_32/0 (3994 ms)
```

## How ?

1. Use maximum between `2` and `10 / ucs::test_time_multiplier()` when running under valgrind.
2. 