### PR TITLE
AZP: Run DC io_demo without port up/down

### DIFF
--- a/buildlib/pr/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/pr/io_demo/az-stage-io-demo.yaml
@@ -9,13 +9,15 @@ parameters:
   default: 60
 - name: roce_iface
   default: $(roce_iface)
+- name: initial_delay
+  default: 20
 
 steps:
 - bash: |
     set -eEx
     source $(workspace)/buildlib/az-helpers.sh
     $(workspace)/buildlib/az-network-corrupter.sh \
-      initial_delay=$(initial_delay) \
+      initial_delay=${{ parameters.initial_delay }} \
       cycles=$(cycles) \
       downtime=$(downtime) \
       uptime=$(uptime) \

--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -44,12 +44,14 @@ parameters:
       "tag match on CX6/DC":
         args: ""
         duration: 600
+        initial_delay: 1000
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: tag_cx6_dc
       "active messages on CX6/DC":
         args: "-A"
         duration: 600
+        initial_delay: 1000
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: am_cx6_dc
@@ -111,17 +113,17 @@ jobs:
             test_time: ${{ test.Value.duration }}
             test_intefrafe: ${{ test.Value.interface }}
             test_ucx_tls: ${{ test.Value.tls }}
+            initial_delay: ${{ coalesce(test.Value.initial_delay, parameters.initial_delay) }}
       maxParallel: 1
 
     variables:
       workspace: drop_$(Build.BuildId)
       io_demo_exe: drop_$(Build.BuildId)/install/bin/io_demo
-      initial_delay: ${{ parameters.initial_delay }}
       cycles: ${{ parameters.cycles }}
       downtime: ${{ parameters.downtime }}
       uptime: ${{ parameters.uptime }}
 
-    displayName: "Test: "
+    displayName: "Test "
     steps:
       - checkout: none
         clean: true
@@ -138,3 +140,4 @@ jobs:
           duration: $(test_time)
           roce_iface: $(test_intefrafe)
           iodemo_tls: $(test_ucx_tls)
+          initial_delay: $(initial_delay)


### PR DESCRIPTION
## Why
Due to issue https://redmine.mellanox.com/issues/2789448 the port is not restored after an interference cycle, which leads to "No traffic" failures