### PR TITLE
UCT/IB/UCP: Fix decrementing completion counter twice in case of failure

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -350,6 +350,8 @@ uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
  * @param [in]  md          Memory domain that was used to register the memory.
  * @param [in]  params      Operation parameters, see @ref
  *                          uct_md_mem_dereg_params_t.
+ *
+ * @return Error code or UCS_INPROGRESS if the operation in progress.
  */
 ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
                                  const uct_md_mem_dereg_params_t *params);

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -834,12 +834,8 @@ static ucs_status_t uct_ib_mem_dereg(uct_md_h uct_md,
 
     ib_memh = params->memh;
     status  = uct_ib_memh_dereg(md, ib_memh);
+    ucs_assert(status != UCS_INPROGRESS);
     uct_ib_memh_free(ib_memh);
-    if (UCT_MD_MEM_DEREG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0) &
-        UCT_MD_MEM_DEREG_FLAG_INVALIDATE) {
-        ucs_assert(params->comp != NULL); /* suppress coverity false-positive */
-        uct_invoke_completion(params->comp, UCS_OK);
-    }
 
     return status;
 }


### PR DESCRIPTION
## What

Fix decrementing completion counter twice in case of failure.

## Why ?

To not decrement a completion counter twice in case of `uct_ib_memh_dereg()` fails. The completion counter is decremented in `ucp_request_dt_invalidate()` when handling `status != UCS_OK` from `uct_md_mem_dereg_v2()` and inside `uct_ib_mem_dereg()` by calling `uct_invoke_completion()`.

## How ?

1. Align `uct_md_mem_dereg_v2()` with other functions which work with UCT completion to return UCS_INPROGRESS if operation is in progress and not invoke `uct_inoke_completion()` in case of `UCS_OK`.
2. Handle return `status` from `uct_md_mem_dereg_v2()` in `ucp_request_dt_invalidate()`.