### PR TITLE
UCS/SYS: Fix error logging for ENOSPC from shmget(2).

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -718,7 +718,7 @@ static void ucs_sysv_shmget_error_check_ENOSPC(size_t alloc_size,
     endp = p + max;
 
     ret = shmctl(0, SHM_INFO, (struct shmid_ds *)&shm_info);
-    if (ret >= 0) {
+    if (ret < 0) {
         return;
     }
 


### PR DESCRIPTION
`ucs_sysv_shmget_error_check_ENOSPC` confuses success and failure from a call to `shmctl(2)` and so either doesn't generate the explanatory message (if `shmctl(2)` succeeds) or uses bogus values from the uninitialised structure (if `shmctl(2)` fails). This fixes that.