### PR TITLE
UCT/BASE: Fix pointers to iface internal operations

### DIFF
--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -453,7 +453,7 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 uct_iface_internal_ops_t uct_base_iface_internal_ops = {
     .iface_estimate_perf = uct_base_iface_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
 };
 
 UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
@@ -499,6 +499,10 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops,
     UCT_CB_FLAGS_CHECK((params->field_mask &
                         UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS) ?
                        params->err_handler_flags : 0);
+
+    ucs_assert(internal_ops->iface_estimate_perf != NULL);
+    ucs_assert(internal_ops->iface_vfs_refresh != NULL);
+    ucs_assert(internal_ops->ep_query != NULL);
 
     self->md                = md;
     self->internal_ops      = internal_ops;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -345,7 +345,7 @@ static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .iface_estimate_perf = uct_cuda_copy_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -417,8 +417,8 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
     ucs_status_t status;
 
     config = ucs_derived_of(tl_config, uct_cuda_ipc_iface_config_t);
-    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_ipc_iface_ops, NULL,
-                              md, worker, params,
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_cuda_ipc_iface_ops,
+                              &uct_base_iface_internal_ops, md, worker, params,
                               tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG("cuda_ipc"));
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -158,7 +158,7 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
     .iface_estimate_perf = uct_gdr_copy_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1211,6 +1211,7 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
             .iface_vfs_refresh   = uct_dc_mlx5_iface_vfs_refresh,
+            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_mlx5_create_cq,
         .arm_cq         = uct_rc_mlx5_iface_common_arm_cq,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -873,7 +873,8 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
     .super = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
-            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh
+            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh,
+            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_mlx5_create_cq,
         .arm_cq         = uct_rc_mlx5_iface_common_arm_cq,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -498,7 +498,8 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .super = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
-            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh
+            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh,
+            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .arm_cq         = uct_ib_iface_arm_cq,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -826,7 +826,7 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
-    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function,
+    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_unsupported,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query            = uct_rdmacm_ep_query,
 };

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -758,6 +758,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
             .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_mlx5_create_cq,
         .arm_cq         = uct_ud_mlx5_iface_arm_cq,

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -560,6 +560,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
         .super = {
             .iface_estimate_perf = uct_base_iface_estimate_perf,
             .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .arm_cq         = uct_ib_iface_arm_cq,

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -131,8 +131,9 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_rocm_copy_iface_internal_ops = {
-    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_success,
+    .iface_estimate_perf = uct_base_iface_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -116,6 +116,7 @@ static uct_scopy_iface_ops_t uct_cma_iface_ops = {
     .super = {
         .iface_estimate_perf = uct_base_iface_estimate_perf,
         .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
     },
     .ep_tx = uct_cma_ep_tx,
 };

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -67,6 +67,7 @@ static uct_scopy_iface_ops_t uct_knem_iface_ops = {
     .super = {
         .iface_estimate_perf = uct_base_iface_estimate_perf,
         .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported
     },
     .ep_tx = uct_knem_ep_tx,
 };

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -188,7 +188,7 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {
-    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function,
+    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_unsupported,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query            = uct_tcp_sockcm_ep_query,
 };


### PR DESCRIPTION
## Why

Fix errors like [this](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=27929&view=logs&j=73bd2a9e-6688-5c22-d122-7b1a0b6cbb81&t=cd3d3953-51ff-5d5c-c5ca-2864f3c1d670)

```
Final:                    10      1.330     1.884     1.884        8.10       8.10      530925      530925
+ucp_contig_cuda_mng_stream_data_bw/2048-+---------+---------+----------+----------+-----------+-----------+
Final:                    10      3.040     3.386     3.386      576.90     576.90      295374      295374
+ucp_contig_cuda_host_tag_bw/4096--------+---------+---------+----------+----------+-----------+-----------+
[swx-rdmz-ucx-gpu-02:27307:0:27307] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))

/scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/uct/base/uct_iface.c: [ uct_iface_estimate_perf() ]
      ...
      207     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
      208 
      209     return iface->internal_ops->iface_estimate_perf(tl_iface, perf_attr);
==>   210 }
      211 
      212 ucs_status_t uct_iface_get_device_address(uct_iface_h iface, uct_device_addr_t *addr)
      213 {

==== backtrace (tid:  27307) ====
 0 0x00000000000154ec uct_iface_estimate_perf()  /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/uct/base/uct_iface.c:210
 1 0x0000000000057087 ucp_proto_common_get_lane_perf()  /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/ucp/proto/proto_common.c:171
 2 0x00000000000595d8 ucp_proto_multi_init()  /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/ucp/proto/proto_multi.c:62
 3 0x00000000000828a7 ucp_proto_rndv_bulk_init()  /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/ucp/rndv/proto_rndv.c:350
 4 0x00000000000876fa ucp_proto_rndv_get_common_init()  /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/ucp/rndv/rndv_get.c:61
 5 0x000000000005ba32 ucp_proto_select_init_protocols()  /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../src/ucp/proto/proto_select.c:477

```