### PR TITLE
UCT/CUDA_IPC: MD_FLAG_INVALIDATE stub implementation

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -30,8 +30,9 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
 
 static ucs_status_t uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 {
-    md_attr->cap.flags            = UCT_MD_FLAG_REG |
-                                    UCT_MD_FLAG_NEED_RKEY;
+    md_attr->cap.flags            = UCT_MD_FLAG_REG       |
+                                    UCT_MD_FLAG_NEED_RKEY |
+                                    UCT_MD_FLAG_INVALIDATE;
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->cap.alloc_mem_types  = 0;
     md_attr->cap.access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -653,6 +653,10 @@ UCS_TEST_SKIP_COND_P(test_md, invalidate, !check_caps(UCT_MD_FLAG_INVALIDATE))
     ucs_status_t status;
     uct_md_mem_dereg_params_t params;
 
+    if (GetParam().md_name == "cuda_ipc") {
+        UCS_TEST_SKIP_R("test not needed with cuda-ipc");
+    }
+
     params.field_mask  = UCT_MD_MEM_DEREG_FIELD_FLAGS |
                          UCT_MD_MEM_DEREG_FIELD_MEMH |
                          UCT_MD_MEM_DEREG_FIELD_COMPLETION;


### PR DESCRIPTION
## What
Support MD_FLAG_INVALIDATE using rcache to track memory regions