### PR TITLE
AZP/IODEMO: Enable corrupter, add restore port in begin test

### DIFF
--- a/buildlib/pr/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/pr/io_demo/az-stage-io-demo.yaml
@@ -15,6 +15,13 @@ parameters:
 steps:
 - bash: |
     set -eEx
+    $(workspace)/buildlib/az-network-corrupter.sh reset=yes
+  displayName: Restore port state
+  condition: always()
+  timeoutInMinutes: 2
+
+- bash: |
+    set -eEx
     source $(workspace)/buildlib/az-helpers.sh
     $(workspace)/buildlib/az-network-corrupter.sh \
       initial_delay=${{ parameters.initial_delay }} \

--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -44,14 +44,12 @@ parameters:
       "tag match on CX6/DC":
         args: ""
         duration: 600
-        initial_delay: 1000
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: tag_cx6_dc
       "active messages on CX6/DC":
         args: "-A"
         duration: 600
-        initial_delay: 1000
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: am_cx6_dc


### PR DESCRIPTION
## What
* Enable corrupter
* add restore port in begin test

## Why ?
QP fix in fw
