### PR TITLE
UCT/IB/UD: Notify user if UD EP timeout expired

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -318,6 +318,10 @@ static void uct_ud_ep_timer(ucs_wtimer_t *self)
         ucs_callbackq_add_safe(&iface->super.super.worker->super.progress_q,
                                uct_ud_ep_deferred_timeout_handler, ep,
                                UCS_CALLBACKQ_FLAG_ONESHOT);
+        if (iface->async.event_cb != NULL) {
+            /* notify user */
+            iface->async.event_cb(iface->async.event_arg, 0);
+        }
         return;
     }
 


### PR DESCRIPTION
## What

Notify user if UD EP timeout expired.

## Why ?

If the application waits for events on wakeup_fd taken from UCP, UD async thread must notify UCP about EP timeout expiration by calling `event_cb`.

## How ?

Add `iface->async.event_cb(iface->async.event_arg, 0);` after adding `uct_ud_ep_deferred_timeout_handler` callback to callback queue.