### PR TITLE
COVERITY: Set of fixes and suppressions to support Coverity 2019.12

### DIFF
--- a/buildlib/tools/coverity.sh
+++ b/buildlib/tools/coverity.sh
@@ -4,7 +4,7 @@ realdir=$(realpath $(dirname $0))
 source ${realdir}/common.sh
 source ${realdir}/../az-helpers.sh
 
-COV_MODULE="tools/cov"
+COV_MODULE="tools/cov-2019.12"
 
 #
 # Run Coverity and report errors
@@ -60,6 +60,9 @@ run_coverity() {
 	rm -rf $cov_build
 	mkdir -p $cov_build
 	cov-build --dir $cov_build $MAKEP all
+	if [ "${ucx_build_type}" == "devel" ]; then
+		cov-manage-emit --dir $cov_build --tu-pattern "file('.*/test/gtest/common/googletest/*')" delete
+	fi
 	cov-analyze --jobs $parallel_jobs $COV_OPT --security --concurrency --dir $cov_build
 	nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')
 	rc=$(($rc+$nerrors))

--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -136,25 +136,33 @@ int fill_buffer(ucp_dt_iov_t *iov)
     return 0;
 }
 
+static void common_cb(void *user_data, const char *type_str)
+{
+    test_req_t *ctx;
+
+    if (user_data == NULL) {
+        fprintf(stderr, "user_data passed to %s mustn't be NULL\n", type_str);
+        return;
+    }
+
+    ctx           = user_data;
+    ctx->complete = 1;
+}
+
 static void tag_recv_cb(void *request, ucs_status_t status,
                         const ucp_tag_recv_info_t *info, void *user_data)
 {
-    test_req_t *ctx = user_data;
-
-    ctx->complete = 1;
+    common_cb(user_data, "tag_recv_cb");
 }
 
 /**
  * The callback on the receiving side, which is invoked upon receiving the
  * stream message.
  */
-static void
-stream_recv_cb(void *request, ucs_status_t status, size_t length,
-               void *user_data)
+static void stream_recv_cb(void *request, ucs_status_t status, size_t length,
+                           void *user_data)
 {
-    test_req_t *ctx = user_data;
-
-    ctx->complete = 1;
+    common_cb(user_data, "stream_recv_cb");
 }
 
 /**
@@ -164,9 +172,7 @@ stream_recv_cb(void *request, ucs_status_t status, size_t length,
 static void am_recv_cb(void *request, ucs_status_t status, size_t length,
                        void *user_data)
 {
-    test_req_t *ctx = user_data;
-
-    ctx->complete = 1;
+    common_cb(user_data, "am_recv_cb");
 }
 
 /**
@@ -175,9 +181,7 @@ static void am_recv_cb(void *request, ucs_status_t status, size_t length,
  */
 static void send_cb(void *request, ucs_status_t status, void *user_data)
 {
-    test_req_t *ctx = user_data;
-
-    ctx->complete = 1;
+    common_cb(user_data, "send_cb");
 }
 
 /**

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -145,6 +145,12 @@ static ucs_status_t parse_mem_type(const char *opt_arg,
                                    ucs_memory_type_t *mem_type)
 {
     ucs_memory_type_t it;
+
+    if (opt_arg == NULL) {
+        ucs_error("memory type string is NULL");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     for (it = UCS_MEMORY_TYPE_HOST; it < UCS_MEMORY_TYPE_LAST; it++) {
         if(!strcmp(opt_arg, ucs_memory_type_names[it]) &&
            (ucx_perf_mem_type_allocators[it] != NULL)) {
@@ -152,7 +158,8 @@ static ucs_status_t parse_mem_type(const char *opt_arg,
             return UCS_OK;
         }
     }
-    ucs_error("Unsupported memory type: \"%s\"", opt_arg);
+
+    ucs_error("unsupported memory type: \"%s\"", opt_arg);
     return UCS_ERR_INVALID_PARAM;
 }
 
@@ -160,11 +167,13 @@ static ucs_status_t parse_mem_type_params(const char *opt_arg,
                                           ucs_memory_type_t *send_mem_type,
                                           ucs_memory_type_t *recv_mem_type)
 {
-    const char *delim = ",";
-    char *token       = strtok((char*)opt_arg, delim);
+    const char *delim   = ",";
+    char *token         = strtok((char*)opt_arg, delim);
+    ucs_status_t status;
 
-    if (UCS_OK != parse_mem_type(token, send_mem_type)) {
-        return UCS_ERR_INVALID_PARAM;
+    status = parse_mem_type(token, send_mem_type);
+    if (status != UCS_OK) {
+        return status;
     }
 
     token = strtok(NULL, delim);

--- a/src/tools/vfs/vfs_server.c
+++ b/src/tools/vfs/vfs_server.c
@@ -243,6 +243,7 @@ static void vfs_server_recv(int idx)
         vfs_server_context.stop = 1;
         break;
     case UCS_VFS_SOCK_ACTION_MOUNT:
+        /* coverity[path_manipulation_sink] */
         vfs_server_mount(idx, vfs_msg_in.pid);
         break;
     case UCS_VFS_SOCK_ACTION_NOP:

--- a/src/ucm/util/log.h
+++ b/src/ucm/util/log.h
@@ -34,13 +34,22 @@
 
 #define ucm_assert_always(_expression) \
     do { \
-        if (!(_expression)) { \
+        if (!ucs_likely(_expression)) { \
             ucm_fatal("Assertion `%s' failed", #_expression); \
         } \
     } while (0)
 
 
-#if ENABLE_ASSERT
+#define ucm_assertv_always(_expression, _fmt, ...) \
+    do { \
+        if (!ucs_likely(_expression)) { \
+            ucm_fatal("Assertion `%s' failed: " _fmt, \
+                      #_expression, ## __VA_ARGS__); \
+        } \
+    } while (0)
+
+
+#if defined (ENABLE_ASSERT) || defined(__COVERITY__) || defined(__clang_analyzer__)
 #  define ucm_assert(...)    ucm_assert_always(__VA_ARGS__)
 #else
 #  define ucm_assert(...)    {}

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -160,7 +160,8 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
 
     maps_fd = open(UCM_PROC_SELF_MAPS, O_RDONLY);
     if (maps_fd < 0) {
-        ucm_fatal("cannot open %s for reading: %m", UCM_PROC_SELF_MAPS);
+        ucm_warn("cannot open %s for reading: %m", UCM_PROC_SELF_MAPS);
+        return;
     }
 
     /* read /proc/self/maps fully into the buffer */

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -916,6 +916,9 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
      */
     ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
+        /* Coverity wrongly resolves completion callback function to
+         * 'ucp_cm_client_connect_progress'*/
+        /* coverity[offset_free] */
         ucp_request_imm_cmpl_param(param, req, send);
     }
 
@@ -1138,6 +1141,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
         ret         = req + 1;
         req->status = status;
         req->flags  = UCP_REQUEST_FLAG_COMPLETED;
+        /* Coverity wrongly resolves completion callback function to
+         * 'ucp_cm_client_connect_progress'*/
+        /* coverity[offset_free] */
         ucp_request_cb_param(param, req, recv_am, recv_length);
     } else {
         if (param->op_attr_mask & UCP_OP_ATTR_FIELD_RECV_INFO) {

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -225,6 +225,10 @@ ucp_request_complete_send(ucp_request_t *req, ucs_status_t status)
                   req, req + 1, UCP_REQUEST_FLAGS_ARG(req->flags),
                   ucs_status_string(status));
     UCS_PROFILE_REQUEST_EVENT(req, "complete_send", status);
+    /* Coverity wrongly resolves completion callback function to
+     * 'ucp_cm_client_connect_progress'/'ucp_cm_server_conn_request_progress'
+     */
+    /* coverity[offset_free] */
     ucp_request_complete(req, send.cb, status, req->user_data);
 }
 
@@ -761,6 +765,9 @@ ucp_request_complete_am_recv(ucp_request_t *req, ucs_status_t status)
         ucp_recv_desc_release(req->recv.am.desc);
     }
 
+    /* Coverity wrongly resolves completion callback function to
+     * 'ucp_cm_server_conn_request_progress' */
+    /* coverity[offset_free] */
     ucp_request_complete(req, recv.am.cb, status, req->recv.length,
                          req->user_data);
 }
@@ -990,6 +997,7 @@ ucp_request_user_data_get_super(void *request, void *user_data)
     ucp_request_t UCS_V_UNUSED *req = (ucp_request_t*)request - 1;
     ucp_request_t *super_req        = (ucp_request_t*)user_data;
 
+    ucs_assert(super_req != NULL);
     ucs_assert(ucp_request_get_super(req) == super_req);
     return super_req;
 }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2132,7 +2132,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     status = UCS_STATS_NODE_ALLOC(&worker->tm_offload_stats,
                                   &ucp_worker_tm_offload_stats_class,
-                                  worker->stats);
+                                  worker->stats, "");
     if (status != UCS_OK) {
         goto err_free_stats;
     }
@@ -2260,6 +2260,9 @@ static void ucp_worker_discard_uct_ep_complete(ucp_request_t *req)
 
     UCP_EP_ASSERT_COUNTER_DEC(&ucp_ep->discard_refcount);
     ucp_worker_flush_ops_count_dec(ucp_ep->worker);
+    /* Coverity wrongly resolves completion callback function to
+     * 'ucp_cm_server_conn_request_progress' */
+    /* coverity[offset_free] */
     ucp_request_complete(req, send.cb, UCS_OK, req->user_data);
     ucp_ep_remove_ref(ucp_ep);
 }

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -465,6 +465,9 @@ static void ucp_worker_flush_complete_one(ucp_request_t *req, ucs_status_t statu
             ucp_worker_flush_req_set_next_ep(req, 1, &worker->all_eps);
         }
 
+        /* Coverity wrongly resolves completion callback function to
+         * 'ucp_cm_server_conn_request_progress' */
+        /* coverity[offset_free] */
         ucp_request_complete(req, flush_worker.cb, status, req->user_data);
     }
 }

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -62,6 +62,7 @@ static ucs_status_t ucp_proto_get_offload_bcopy_progress(uct_pending_req_t *self
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_progress(req, req->send.proto_config->priv,
                                     ucp_proto_get_offload_bcopy_send_func,
                                     ucp_request_invoke_uct_completion_success,
@@ -135,6 +136,7 @@ static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_zcopy_progress(
             req, req->send.proto_config->priv, NULL,
             UCT_MD_MEM_ACCESS_LOCAL_WRITE, UCP_DT_MASK_CONTIG_IOV,

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -50,6 +50,7 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req                  = ucs_container_of(self, ucp_request_t,
                                                            send.uct);
+    /* coverity[tainted_data_downcast] */
     const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
     ucs_status_t status;
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -128,6 +128,7 @@ static ucs_status_t ucp_proto_put_offload_bcopy_progress(uct_pending_req_t *self
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_progress(req, req->send.proto_config->priv,
                                     ucp_proto_put_offload_bcopy_send_func,
                                     ucp_proto_request_bcopy_complete_success,
@@ -201,6 +202,7 @@ ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_zcopy_progress(
             req, req->send.proto_config->priv, NULL,
             UCT_MD_MEM_ACCESS_LOCAL_READ, UCP_DT_MASK_CONTIG_IOV,

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -42,6 +42,9 @@ ucp_rma_send_request(ucp_request_t *req, const ucp_request_param_t *param)
     ucp_request_send(req);
 
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
+        /* Coverity wrongly resolves completion callback function to
+         * 'ucp_cm_client_connect_progress' */
+        /* coverity[offset_free] */
         ucp_request_imm_cmpl_param(param, req, send);
     }
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -571,7 +571,9 @@ static void ucp_proto_rndv_send_complete_one(void *request, ucs_status_t status,
                                              void *user_data)
 {
     ucp_request_t *freq = (ucp_request_t*)request - 1;
-    ucp_request_t *req  = ucp_request_user_data_get_super(request, user_data);
+    ucp_request_t *req;
+
+    req = ucp_request_user_data_get_super(request, user_data);
 
     if (!ucp_proto_rndv_frag_complete(req, freq, "rdnv_send")) {
         return;

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -87,6 +87,7 @@ static ucs_status_t ucp_proto_rndv_am_bcopy_progress(uct_pending_req_t *uct_req)
 {
     ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_bcopy_progress(req, req->send.proto_config->priv,
                                           NULL,
                                           ucp_proto_rndv_am_bcopy_send_func,

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -65,6 +65,7 @@ ucp_proto_rndv_get_common_init(const ucp_proto_init_params_t *init_params,
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_rndv_get_common_request_init(ucp_request_t *req)
 {
+    /* coverity[tainted_data_downcast] */
     ucp_proto_rndv_bulk_request_init(req, req->send.proto_config->priv);
 }
 
@@ -109,6 +110,7 @@ ucp_proto_rndv_get_zcopy_send_func(ucp_request_t *req,
                                    const ucp_proto_multi_lane_priv_t *lpriv,
                                    ucp_datatype_iter_t *next_iter)
 {
+    /* coverity[tainted_data_downcast] */
     const ucp_proto_rndv_bulk_priv_t *rpriv = req->send.proto_config->priv;
     size_t max_payload;
     uct_iov_t iov;
@@ -125,7 +127,10 @@ ucp_proto_rndv_get_zcopy_send_func(ucp_request_t *req,
 static ucs_status_t
 ucp_proto_rndv_get_zcopy_fetch_progress(uct_pending_req_t *uct_req)
 {
-    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+    ucp_request_t *req                      = ucs_container_of(uct_req,
+                                                               ucp_request_t,
+                                                               send.uct);                      
+    /* coverity[tainted_data_downcast] */
     const ucp_proto_rndv_bulk_priv_t *rpriv = req->send.proto_config->priv;
 
     return ucp_proto_multi_zcopy_progress(
@@ -152,6 +157,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_mtype_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter)
 {
+    /* coverity[tainted_data_downcast] */
     const ucp_proto_rndv_bulk_priv_t *rpriv = req->send.proto_config->priv;
     uct_iov_t iov;
 
@@ -206,6 +212,7 @@ ucp_proto_rndv_get_mtype_fetch_progress(uct_pending_req_t *uct_req)
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
+    /* coverity[tainted_data_downcast] */
     rpriv = req->send.proto_config->priv;
     return ucp_proto_multi_progress(req, &rpriv->mpriv,
                                     ucp_proto_rndv_get_mtype_send_func,

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -79,6 +79,9 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
      */
     ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
+        /* Coverity wrongly resolves completion callback function to
+         * 'ucp_cm_client_connect_progress' */
+        /* coverity[offset_free] */
         ucp_request_imm_cmpl_param(param, req, send);
     }
 

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -155,6 +155,7 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
 {
     ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_bcopy_progress(
             req, req->send.proto_config->priv, ucp_proto_msg_multi_request_init,
             ucp_proto_eager_bcopy_multi_send_func,
@@ -228,6 +229,7 @@ ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
 {
     ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_bcopy_progress(
             req, req->send.proto_config->priv,
             ucp_proto_eager_sync_bcopy_request_init,
@@ -307,6 +309,7 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
 
+    /* coverity[tainted_data_downcast] */
     return ucp_proto_multi_zcopy_progress(
             req, req->send.proto_config->priv, ucp_proto_msg_multi_request_init,
             UCT_MD_MEM_ACCESS_LOCAL_READ, UCP_DT_MASK_CONTIG_IOV,

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -115,6 +115,9 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
      */
     ucp_request_send(req);
     if (req->flags & UCP_REQUEST_FLAG_COMPLETED) {
+        /* Coverity wrongly resolves completion callback function to
+         * 'ucp_cm_client_connect_progress' */
+        /* coverity[offset_free] */
         ucp_request_imm_cmpl_param(param, req, send);
     }
 

--- a/src/ucs/datastruct/frag_list.c
+++ b/src/ucs/datastruct/frag_list.c
@@ -46,8 +46,9 @@ ucs_status_t ucs_frag_list_init(ucs_frag_list_sn_t initial_sn, ucs_frag_list_t *
 #ifdef ENABLE_STATS
     frag_list->prev_sn = initial_sn;
 #endif
-    status = UCS_STATS_NODE_ALLOC(&frag_list->stats, &ucs_frag_list_stats_class,
-                                 stats_parent);
+    status = UCS_STATS_NODE_ALLOC(&frag_list->stats,
+                                  &ucs_frag_list_stats_class,
+                                  stats_parent, "-%p", frag_list);
     return status;
 }
 

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -395,7 +395,7 @@ void ucs_memtrack_init()
 
     status = UCS_STATS_NODE_ALLOC(&ucs_memtrack_context.stats,
                                   &ucs_memtrack_stats_class,
-                                  ucs_stats_get_root());
+                                  ucs_stats_get_root(), "");
     if (status != UCS_OK) {
         return;
     }

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -432,6 +432,7 @@ static inline void ucs_rcache_region_put_internal(ucs_rcache_t *rcache,
 
     if (flags & UCS_RCACHE_REGION_PUT_FLAG_ADD_TO_GC) {
         /* Put the region on garbage collection list */
+        ucs_assert(!(flags & UCS_RCACHE_REGION_PUT_FLAG_TAKE_PGLOCK));
         ucs_spin_lock(&rcache->lock);
         ucs_rcache_region_trace(rcache, region, "put on GC list, flags 0x%x",
                                 flags);
@@ -594,10 +595,12 @@ static void ucs_rcache_unmapped_callback(ucm_event_type_t event_type,
      * no rcache operations are performed to clean it.
      */
     if (!pthread_rwlock_trywrlock(&rcache->pgt_lock)) {
+        /* coverity[double_lock] */
         ucs_rcache_invalidate_range(rcache, start, end,
                                     UCS_RCACHE_REGION_PUT_FLAG_ADD_TO_GC);
         UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_UNMAPS, 1);
         ucs_rcache_check_inv_queue(rcache, UCS_RCACHE_REGION_PUT_FLAG_ADD_TO_GC);
+        /* coverity[double_unlock] */
         pthread_rwlock_unlock(&rcache->pgt_lock);
         return;
     }
@@ -647,6 +650,7 @@ static void ucs_rcache_purge(ucs_rcache_t *rcache)
 static void ucs_rcache_clean(ucs_rcache_t *rcache)
 {
     pthread_rwlock_wrlock(&rcache->pgt_lock);
+    /* coverity[double_lock]*/
     ucs_rcache_check_inv_queue(rcache, 0);
     ucs_rcache_check_gc_list(rcache);
     pthread_rwlock_unlock(&rcache->pgt_lock);
@@ -852,6 +856,7 @@ retry:
     merged = 0;
 
     /* Check overlap with existing regions */
+    /* coverity[double_lock] */
     status = UCS_PROFILE_CALL(ucs_rcache_check_overlap, rcache, &start, &end,
                               &prot, &merged, &region);
     if (status == UCS_ERR_ALREADY_EXISTS) {
@@ -954,6 +959,7 @@ retry:
 out_set_region:
     *region_p = region;
 out_unlock:
+    /* coverity[double_unlock]*/
     pthread_rwlock_unlock(&rcache->pgt_lock);
     return status;
 }
@@ -1035,7 +1041,9 @@ void ucs_rcache_region_invalidate(ucs_rcache_t *rcache,
                                 "failed to allocate completion object");
     }
 
+    /* coverity[double_lock] */
     ucs_rcache_region_invalidate_internal(rcache, region, 0);
+    /* coverity[double_unlock] */
     pthread_rwlock_unlock(&rcache->pgt_lock);
     UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_PUTS, 1);
 }
@@ -1217,25 +1225,25 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
         goto err;
     }
 
-    status = UCS_STATS_NODE_ALLOC(&self->stats, &ucs_rcache_stats_class,
-                                  stats_parent);
-    if (status != UCS_OK) {
-        goto err;
-    }
-
-    self->params = *params;
-
     self->name = ucs_strdup(name, "ucs rcache name");
     if (self->name == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto err_destroy_stats;
+        goto err;
     }
+
+    status = UCS_STATS_NODE_ALLOC(&self->stats, &ucs_rcache_stats_class,
+                                  stats_parent, "-%s", self->name);
+    if (status != UCS_OK) {
+        goto err_free_name;
+    }
+
+    self->params = *params;
 
     ret = pthread_rwlock_init(&self->pgt_lock, NULL);
     if (ret) {
         ucs_error("pthread_rwlock_init() failed: %m");
         status = UCS_ERR_INVALID_PARAM;
-        goto err_free_name;
+        goto err_destroy_stats;
     }
 
     status = ucs_spinlock_init(&self->lock, 0);
@@ -1296,10 +1304,10 @@ err_destroy_inv_q_lock:
     ucs_spinlock_destroy(&self->lock);
 err_destroy_rwlock:
     pthread_rwlock_destroy(&self->pgt_lock);
-err_free_name:
-    ucs_free(self->name);
 err_destroy_stats:
     UCS_STATS_NODE_FREE(self->stats);
+err_free_name:
+    ucs_free(self->name);
 err:
     return status;
 }

--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -100,7 +100,7 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
     ucs_stats_node_t* _node;
 
 #define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) \
-    ucs_stats_node_alloc(_p_node, _class, _parent, ## __VA_ARGS__ , "")
+    ucs_stats_node_alloc(_p_node, _class, _parent, ## __VA_ARGS__)
 
 #define UCS_STATS_NODE_FREE(_node) \
     ucs_stats_node_free(_node)
@@ -151,7 +151,8 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 #define UCS_STATS_ARG(_arg)
 #define UCS_STATS_RVAL(_rval) NULL
 #define UCS_STATS_NODE_DECLARE(_node)
-#define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) ucs_empty_function_return_success()
+#define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) \
+        ucs_empty_function_return_success()
 #define UCS_STATS_NODE_FREE(_node)
 #define UCS_STATS_UPDATE_COUNTER(_node, _index, _delta)
 #define UCS_STATS_SET_COUNTER(_node, _index, _value)

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -559,6 +559,7 @@ void ucs_sys_iterate_vm(void *address, size_t size, ucs_sys_vma_cb_t cb,
             }
         }
 
+        /* coverity[tainted_data] */
         cb(&info, ctx);
     }
 

--- a/src/ucs/type/init_once.h
+++ b/src/ucs/type/init_once.h
@@ -27,7 +27,11 @@ typedef struct ucs_init_once {
 
 /* Wrapper to unlock a mutex that always returns 0 to avoid endless loop
  * and make static analyzers happy - they report "double unlock" warning */
-unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock);
+static inline unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock)
+{
+    pthread_mutex_unlock(lock);
+    return 0;
+}
 
 
 /*
@@ -51,7 +55,7 @@ unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock);
  */
 #define UCS_INIT_ONCE(_once) \
     for (pthread_mutex_lock(&(_once)->lock); \
-         !(_once)->initialized || pthread_mutex_unlock(&(_once)->lock); \
+         !(_once)->initialized || ucs_init_once_mutex_unlock(&(_once)->lock); \
          (_once)->initialized = 1)
 
 
@@ -71,7 +75,7 @@ unsigned ucs_init_once_mutex_unlock(pthread_mutex_t *lock);
  */
 #define UCS_CLEANUP_ONCE(_once) \
     for (pthread_mutex_lock(&(_once)->lock); \
-         (_once)->initialized || pthread_mutex_unlock(&(_once)->lock); \
+         (_once)->initialized || ucs_init_once_mutex_unlock(&(_once)->lock); \
          (_once)->initialized = 0)
 
 #endif

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -671,8 +671,8 @@ UCS_CLASS_INIT_FUNC(uct_base_ep_t, uct_base_iface_t *iface)
 {
     UCS_CLASS_CALL_SUPER_INIT(uct_ep_t, &iface->super);
 
-    return UCS_STATS_NODE_ALLOC(&self->stats, &uct_ep_stats_class, iface->stats,
-                                "-%p", self);
+    return UCS_STATS_NODE_ALLOC(&self->stats, &uct_ep_stats_class,
+                                iface->stats, "-%p", self);
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_base_ep_t)
@@ -723,8 +723,8 @@ ucs_status_t uct_base_ep_stats_reset(uct_base_ep_t *ep, uct_base_iface_t *iface)
 
     UCS_STATS_NODE_FREE(ep->stats);
 
-    status = UCS_STATS_NODE_ALLOC(&ep->stats, &uct_ep_stats_class, iface->stats,
-                                  "-%p", ep);
+    status = UCS_STATS_NODE_ALLOC(&ep->stats, &uct_ep_stats_class,
+                                  iface->stats, "-%p", ep);
 #ifdef ENABLE_STATS
     if (status != UCS_OK) {
         /* set the stats to NULL so that the UCS_STATS_NODE_FREE call on the

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -286,7 +286,8 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
         if (status == UCS_OK) {
             ucs_snprintf_safe(device_name, sizeof(device_name), "GPU%d",
                               cuda_device);
-            ucs_topo_sys_device_set_name(sys_dev, device_name);
+            status = ucs_topo_sys_device_set_name(sys_dev, device_name);
+            ucs_assert_always(status == UCS_OK);
         }
     }
 

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -632,8 +632,8 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
 
     dev->async_events = async_events;
 
-    uct_ib_device_get_locality(ibv_get_device_name(ibv_device), &dev->local_cpus,
-                               &dev->numa_node);
+    uct_ib_device_get_locality(ibv_get_device_name(ibv_device),
+                               &dev->local_cpus, &dev->numa_node);
 
     status = UCS_STATS_NODE_ALLOC(&dev->stats, &uct_ib_device_stats_class,
                                   stats_parent, "device");
@@ -1132,8 +1132,8 @@ static ucs_sys_device_t uct_ib_device_get_sys_dev(uct_ib_device_t *dev)
         return UCS_SYS_DEVICE_ID_UNKNOWN;
     }
 
-    /* coverity[check_return] */
-    ucs_topo_sys_device_set_name(sys_dev, uct_ib_device_name(dev));
+    status = ucs_topo_sys_device_set_name(sys_dev, uct_ib_device_name(dev));
+    ucs_assert_always(status == UCS_OK);
 
     ucs_debug("%s bus id %hu:%hhu:%hhu.%hhu sys_dev %d",
               uct_ib_device_name(dev), bus_id.domain, bus_id.bus, bus_id.slot,

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -189,6 +189,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
     attr->super.cap.max_recv_wr = max_rx;
 
     if (tx != NULL) {
+        ucs_assert(qp->devx.wq_buf != NULL);
         tx->reg    = &uar->super;
         tx->qstart = qp->devx.wq_buf;
         tx->qend   = UCS_PTR_BYTE_OFFSET(qp->devx.wq_buf, len_tx);
@@ -197,6 +198,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
         ucs_assert(*tx->dbrec == 0);
         uct_ib_mlx5_txwq_reset(tx);
     } else {
+        ucs_assert(qp->devx.wq_buf == NULL);
         uct_worker_tl_data_put(uar, uct_ib_mlx5_devx_uar_cleanup);
     }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -460,8 +460,9 @@ ucs_status_t uct_rc_mlx5_iface_common_tag_init(uct_rc_mlx5_iface_common_t *iface
     iface->tm.head = &iface->tm.list[0];
     iface->tm.tail = &iface->tm.list[i];
 
-    status = UCS_STATS_NODE_ALLOC(&iface->tm.stats, &uct_rc_mlx5_tag_stats_class,
-                                  iface->stats);
+    status = UCS_STATS_NODE_ALLOC(&iface->tm.stats,
+                                  &uct_rc_mlx5_tag_stats_class,
+                                  iface->stats, "");
     if (status != UCS_OK) {
         ucs_error("Failed to allocate tag stats: %s", ucs_status_string(status));
         goto err_cmd_wq_free;

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -711,7 +711,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     }
 
     status = UCS_STATS_NODE_ALLOC(&self->stats, &uct_rc_mlx5_iface_stats_class,
-                                  self->super.stats);
+                                  self->super.stats, "");
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -87,7 +87,7 @@ ucs_status_t uct_rc_fc_init(uct_rc_fc_t *fc, int16_t winsize
     fc->fc_wnd = winsize;
 
     status = UCS_STATS_NODE_ALLOC(&fc->stats, &uct_rc_fc_stats_class,
-                                  stats_parent);
+                                  stats_parent, "");
     if (status != UCS_OK) {
        return status;
     }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -638,7 +638,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
                                         uct_rc_ep_atomic_handler_64_be0;
 
     status = UCS_STATS_NODE_ALLOC(&self->stats, &uct_rc_iface_stats_class,
-                                  self->super.super.stats);
+                                  self->super.super.stats, "-%p", self);
     if (status != UCS_OK) {
         goto err_cleanup_tx_ops;
     }

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -587,7 +587,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
     ucs_queue_head_init(&self->rx.pending_q);
 
     status = UCS_STATS_NODE_ALLOC(&self->stats, &uct_ud_iface_stats_class,
-                                  self->super.super.stats);
+                                  self->super.super.stats, "-%p", self);
     if (status != UCS_OK) {
         goto err_tx_mpool;
     }

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -74,31 +74,59 @@
     } while (0)
 
 
+/**
+ * Checks whether a condition check with ucs_status_t is true or not.
+ *
+ * @param _condition Condition that should be checked.
+ * @param _expr      Expression which returns UCS status which needs to be
+ *                   checked.
+ */
+#define _ASSERT_UCS_STATUS(_condition, _expr, ...) \
+    do { \
+        ucs_status_t __status = (_expr); \
+        if (!(_condition)) { \
+            UCS_TEST_ABORT("Error: " \
+                    << ucs_status_string(__status)  __VA_ARGS__); \
+        } \
+    } while (0)
+
+
+/**
+ * Check equality of the status returned from the expression and the expected
+ * status.
+ *
+ * @param _exp_status Expected UCS status.
+ * @param _expr       Expression which returns UCS status which needs to be
+ *                    checked.
+ */
+#define ASSERT_UCS_STATUS_EQ(_exp_status, _expr, ...) \
+    _ASSERT_UCS_STATUS(((__status) == (_exp_status)), _expr, ## __VA_ARGS__)
+
+
+/**
+ * Check equality of the status returned from the expression to the one of the
+ * expected statuses.
+ *
+ * @param _exp_status1 First expected UCS status.
+ * @param _exp_status2 Second expected UCS status.
+ * @param _expr        Expression which returns UCS status which needs to be
+ *                     checked.
+ */
+#define ASSERT_UCS_STATUS_EQ2(_exp_status1, _exp_status2, _expr, ...) \
+    _ASSERT_UCS_STATUS((((__status) == (_exp_status1)) || \
+                       ((__status) == (_exp_status2))), _expr, ## __VA_ARGS__)
+
+
 #define ASSERT_UCS_OK(_expr, ...) \
-    do { \
-        ucs_status_t _status = (_expr); \
-        if ((_status) != UCS_OK) { \
-            UCS_TEST_ABORT("Error: " << ucs_status_string(_status)  __VA_ARGS__); \
-        } \
-    } while (0)
+    ASSERT_UCS_STATUS_EQ(UCS_OK, _expr, ## __VA_ARGS__)
 
 
-#define ASSERT_UCS_OK_OR_INPROGRESS(_expr) \
-    do { \
-        ucs_status_t _status = (_expr); \
-        if (((_status) != UCS_OK) && ((_status) != UCS_INPROGRESS)) { \
-            UCS_TEST_ABORT("Error: " << ucs_status_string(_status)); \
-        } \
-    } while (0)
+#define ASSERT_UCS_OK_OR_INPROGRESS(_expr, ...) \
+    ASSERT_UCS_STATUS_EQ2(UCS_OK, UCS_INPROGRESS, _expr, ## __VA_ARGS__)
 
 
-#define ASSERT_UCS_OK_OR_BUSY(_expr) \
-    do { \
-        ucs_status_t _status = (_expr); \
-        if (((_status) != UCS_OK) && ((_status) != UCS_ERR_BUSY)) { \
-            UCS_TEST_ABORT("Error: " << ucs_status_string(_status)); \
-        } \
-    } while (0)
+#define ASSERT_UCS_OK_OR_BUSY(_expr, ...) \
+    ASSERT_UCS_STATUS_EQ2(UCS_OK, UCS_ERR_BUSY, _expr, ## __VA_ARGS__)
 
 
 #define ASSERT_UCS_PTR_OK(_expr) \

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -37,7 +37,7 @@ public:
     void unset_handler(bool sync = true) {
         if (ucs_atomic_cswap32(&m_handler_set, 1, 0)) {
             ucs_status_t status = ucs_async_remove_handler(event_id(), sync);
-            ASSERT_UCS_OK(status);
+            ucs_assert_always(status == UCS_OK);
         }
     }
 
@@ -779,7 +779,7 @@ public:
         local_event::unset_handler(sync);
         if (m_event_set) {
             ucs_status_t status = ucs_async_remove_handler(m_pipefd[0], sync);
-            ASSERT_UCS_OK(status);
+            ucs_assert_always(status == UCS_OK);
             m_event_set = false;
         }
     }

--- a/test/gtest/ucs/test_callbackq.cc
+++ b/test/gtest/ucs/test_callbackq.cc
@@ -126,7 +126,7 @@ protected:
     static int remove_if_pred(const ucs_callbackq_elem_t *elem, void *arg)
     {
         callback_ctx *ctx = reinterpret_cast<callback_ctx*>(elem->arg);
-        int key = *reinterpret_cast<int*>(arg);
+        int key           = *reinterpret_cast<int*>(arg);
 
         /* remove callbacks with the given key */
         return (elem->cb == callback_proxy) && (ctx->key == key);

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -289,6 +289,10 @@ protected:
 
         car_opts(const car_opts& orig) : m_max(orig.m_max)
         {
+            /* reset 'm_opts' to suppress Coverity warning that fields are not
+             * initialized in the constructor */ 
+            memset(&m_opts, 0, sizeof(m_opts));
+
             m_value = new char[m_max];
             strncpy(m_value, orig.m_value, m_max);
 

--- a/test/gtest/ucs/test_event_set.cc
+++ b/test/gtest/ucs/test_event_set.cc
@@ -173,13 +173,13 @@ static void event_set_func1(void *callback_data, ucs_event_set_types_t events,
 
     EXPECT_EQ(UCS_EVENT_SET_EVREAD, events);
 
-    n = read(fd, buf, MAX_BUF_LEN);
+    n = read(fd, buf, MAX_BUF_LEN - 1);
     if (n == -1) {
         ADD_FAILURE();
         return;
     }
-    EXPECT_EQ(0, strcmp(UCS_EVENT_SET_TEST_STRING, buf));
-    EXPECT_EQ(0, strcmp(UCS_EVENT_SET_EXTRA_STRING, extra_str));
+    EXPECT_EQ(0, strncmp(UCS_EVENT_SET_TEST_STRING, buf, n));
+    EXPECT_EQ(0, strncmp(UCS_EVENT_SET_EXTRA_STRING, extra_str,n ));
     EXPECT_EQ(UCS_EVENT_SET_EXTRA_NUM, *extra_num);
 }
 

--- a/test/gtest/ucs/test_stats.cc
+++ b/test/gtest/ucs/test_stats.cc
@@ -67,7 +67,7 @@ public:
 
         ucs_status_t status = UCS_STATS_NODE_ALLOC(cat_node,
                                                    &category_stats_class,
-                                                   ucs_stats_get_root());
+                                                   ucs_stats_get_root(), "");
         ASSERT_UCS_OK(status);
         for (unsigned i = 0; i < NUM_DATA_NODES; ++i) {
             status = UCS_STATS_NODE_ALLOC(&data_nodes[i], m_data_stats_class,
@@ -295,8 +295,8 @@ UCS_TEST_F(stats_on_demand_test, null_root) {
     static ucs_stats_class_t category_stats_class = {
         "category", 0
     };
-    ucs_status_t status = UCS_STATS_NODE_ALLOC(&cat_node, &category_stats_class,
-                                               NULL);
+    ucs_status_t status                           =
+            UCS_STATS_NODE_ALLOC(&cat_node, &category_stats_class, NULL, "");
 
     EXPECT_GE(status, UCS_ERR_INVALID_PARAM);
 }

--- a/test/gtest/ucs/test_stats_filter.cc
+++ b/test/gtest/ucs/test_stats_filter.cc
@@ -67,12 +67,14 @@ public:
             "category", 0
         };
 
-        ucs_status_t status = UCS_STATS_NODE_ALLOC(&cat_node, &category_stats_class,
-                                                   ucs_stats_get_root());
+        ucs_status_t status = UCS_STATS_NODE_ALLOC(&cat_node,
+                                                   &category_stats_class,
+                                                   ucs_stats_get_root(), "");
         ASSERT_UCS_OK(status);
         for (unsigned i = 0; i < NUM_DATA_NODES; ++i) {
-            status = UCS_STATS_NODE_ALLOC(&data_nodes[i], m_data_stats_class,
-                                         cat_node, "-%d", i);
+            status = UCS_STATS_NODE_ALLOC(&data_nodes[i],
+                                          m_data_stats_class, cat_node,
+                                          "-%d", i);
             ASSERT_UCS_OK(status);
 
             UCS_STATS_UPDATE_COUNTER(data_nodes[i], 0, 10);

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -695,7 +695,8 @@ UCS_TEST_SKIP_COND_P(test_md, invalidate, !check_caps(UCT_MD_FLAG_INVALIDATE))
 }
 
 UCS_TEST_SKIP_COND_P(test_md, dereg_bad_arg,
-                     !check_reg_mem_type(UCS_MEMORY_TYPE_HOST))
+                     !check_reg_mem_type(UCS_MEMORY_TYPE_HOST) ||
+                     !ENABLE_PARAMS_CHECK)
 {
     static const size_t size = 1 * UCS_MBYTE;
     uct_mem_h memh;
@@ -720,24 +721,24 @@ UCS_TEST_SKIP_COND_P(test_md, dereg_bad_arg,
                             UCT_MD_MEM_DEREG_FIELD_FLAGS |
                             UCT_MD_MEM_DEREG_FIELD_MEMH;
         status            = uct_md_mem_dereg_v2(md(), &params);
-        EXPECT_EQ(UCS_ERR_UNSUPPORTED, status);
+        ASSERT_UCS_STATUS_EQ(UCS_ERR_UNSUPPORTED, status);
 
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
         status            = uct_md_mem_dereg_v2(md(), &params);
     } else {
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_COMPLETION;
         status            = uct_md_mem_dereg_v2(md(), &params);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        ASSERT_UCS_STATUS_EQ(UCS_ERR_INVALID_PARAM, status);
 
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_COMPLETION |
                             UCT_MD_MEM_DEREG_FIELD_FLAGS;
         status            = uct_md_mem_dereg_v2(md(), &params);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        ASSERT_UCS_STATUS_EQ(UCS_ERR_INVALID_PARAM, status);
 
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH |
                             UCT_MD_MEM_DEREG_FIELD_FLAGS;
         status            = uct_md_mem_dereg_v2(md(), &params);
-        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+        ASSERT_UCS_STATUS_EQ(UCS_ERR_INVALID_PARAM, status);
 
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH |
                             UCT_MD_MEM_DEREG_FIELD_COMPLETION |

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -1073,6 +1073,11 @@ void test_tag_mp_xrq::send_rndv_zcopy(mapped_buffer *buf)
                                                      iovcnt, 0, &m_uct_comp);
     ASSERT_FALSE(UCS_PTR_IS_ERR(rndv_op));
 
+    // Check the returned status_ptr to suppress Coverity warning about
+    // passing the negative value to TAG RNDV cancel which expect that the
+    // value is always >= 0
+    ucs_assert_always(reinterpret_cast<int64_t>(rndv_op) >= 0);
+
     // There will be no real RNDV performed, cancel the op to avoid mpool
     // warning on exit
     ASSERT_UCS_OK(uct_ep_tag_rndv_cancel(sender().ep(0),rndv_op));

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -982,7 +982,7 @@ void uct_test::entity::mem_type_dereg(uct_allocated_memory_t *mem) const {
     if ((mem->memh != UCT_MEM_HANDLE_NULL) &&
         (md_attr().cap.reg_mem_types & UCS_BIT(mem->mem_type))) {
         ucs_status_t status = uct_md_mem_dereg(m_md, mem->memh);
-        ASSERT_UCS_OK(status);
+        ucs_assert_always(status == UCS_OK);
         mem->memh = UCT_MEM_HANDLE_NULL;
         mem->md   = NULL;
     }
@@ -1016,8 +1016,9 @@ void uct_test::entity::rkey_unpack(const uct_allocated_memory_t *mem,
 void uct_test::entity::rkey_release(const uct_rkey_bundle *rkey_bundle) const
 {
     if (rkey_bundle->rkey != UCT_INVALID_RKEY) {
-        ucs_status_t status = uct_rkey_release(m_resource.component, rkey_bundle);
-        ASSERT_UCS_OK(status);
+        ucs_status_t status = uct_rkey_release(m_resource.component,
+                                               rkey_bundle);
+        ucs_assert_always(status == UCS_OK);
     }
 }
 


### PR DESCRIPTION
## What

Set of fixes and suppressions.

## Why ?

To support Coverity 2019.12.

## How ?

1. Fix the problems found by Coverity.
2. Suppress warnings by adding `/* coverity[...] */` comments if they are false-positive.
3. Suppress warnings by using `ucs_assert*()`/`ucm_assert*()` functions or adding additional `if` where it is needed.