### PR TITLE
UCP/EP: always enable RNDV protocols

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -920,16 +920,35 @@ err_destroy_ep:
     goto out_free_address;
 }
 
+static void ucp_ep_params_check_err_handling(ucp_ep_h ep,
+                                             const ucp_ep_params_t *params)
+{
+    ucp_err_handling_mode_t err_mode =
+            UCP_PARAM_VALUE(EP, params, err_mode, ERR_HANDLING_MODE,
+                            UCP_ERR_HANDLING_MODE_NONE);
+
+    if (err_mode == UCP_ERR_HANDLING_MODE_NONE) {
+        return;
+    }
+
+    if (ucp_worker_keepalive_is_enabled(ep->worker) &&
+        ucp_ep_use_indirect_id(ep)) {
+        return;
+    }
+
+    ucs_diag("ep %p: creating endpoint with error handling but without "
+             "keepalive and indirect id", ep);
+}
+
 ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
                            ucp_ep_h *ep_p)
 {
+    ucp_ep_h ep    = NULL;
+    unsigned flags = UCP_PARAM_VALUE(EP, params, flags, FLAGS, 0);
     ucs_status_t status;
-    unsigned flags;
-    ucp_ep_h ep = NULL;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
-    flags = UCP_PARAM_VALUE(EP, params, flags, FLAGS, 0);
     if (flags & UCP_EP_PARAMS_FLAGS_CLIENT_SERVER) {
         status = ucp_ep_create_to_sock_addr(worker, params, &ep);
     } else if (params->field_mask & UCP_EP_PARAM_FIELD_CONN_REQUEST) {
@@ -951,6 +970,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
         }
 #endif
 
+        ucp_ep_params_check_err_handling(ep, params);
         ucp_ep_update_flags(ep, UCP_EP_FLAG_USED, 0);
         *ep_p = ep;
     }
@@ -1731,12 +1751,6 @@ static void ucp_ep_config_set_am_rndv_thresh(
     ucs_assert(config->key.am_lane != UCP_NULL_LANE);
     ucs_assert(config->key.lanes[config->key.am_lane].rsc_index != UCP_NULL_RESOURCE);
 
-    if (!ucp_ep_config_test_rndv_support(config)) {
-        /* Disable RNDV */
-        ucs_trace("AM rendezvous protocol is not supported");
-        return;
-    }
-
     if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the AM rndv threshold on its own.*/
         rndv_thresh = ucp_ep_config_calc_rndv_thresh(worker, config,
@@ -1780,10 +1794,7 @@ ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker, ucp_ep_config_t *config,
 
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
 
-    if (!ucp_ep_config_test_rndv_support(config)) {
-        /* Disable RNDV */
-        goto out_not_supported;
-    } else if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
+    if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the RMA (get_zcopy) rndv threshold on its own.*/
         rndv_thresh       = ucp_ep_config_calc_rndv_thresh(worker, config,
                                                            config->key.am_bw_lanes,
@@ -2869,12 +2880,6 @@ void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status)
               ucs_status_string(status));
     ucp_ep_update_flags(ep, UCP_EP_FLAG_ERR_HANDLER_INVOKED, 0);
     ucp_ep_ext_control(ep)->err_cb(ucp_ep_ext_gen(ep)->user_data, ep, status);
-}
-
-int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config)
-{
-    return (config->key.err_mode == UCP_ERR_HANDLING_MODE_NONE) ||
-           (config->key.cm_lane  != UCP_NULL_LANE);
 }
 
 /* if we have ep2iface transport we need to send an active-message based

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -651,8 +651,6 @@ void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
 
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status);
 
-int ucp_ep_config_test_rndv_support(const ucp_ep_config_t *config);
-
 ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self);
 
 void ucp_ep_flush_completion(uct_completion_t *self);

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -96,7 +96,8 @@ ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
 static UCS_F_ALWAYS_INLINE int
 ucp_worker_keepalive_is_enabled(ucp_worker_h worker)
 {
-    return worker->context->config.ext.keepalive_interval != UCS_TIME_INFINITY;
+    return (worker->context->config.ext.keepalive_num_eps != 0) &&
+           (worker->context->config.ext.keepalive_interval != UCS_TIME_INFINITY);
 }
 
 /**

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -301,10 +301,10 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
 {
     ucp_worker_h worker  = ep->worker;
     size_t contig_length = 0;
+    uintptr_t datatype   = ucp_request_param_datatype(param);
     ucs_status_t status;
     ucp_request_t *req;
     ucs_status_ptr_t ret;
-    uintptr_t datatype;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
                                     return UCS_STATUS_PTR(
@@ -315,12 +315,6 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_sync_nbx,
 
     ucs_trace_req("send_sync_nbx buffer %p count %zu tag %"PRIx64" to %s",
                   buffer, count, tag, ucp_ep_peer_name(ep));
-
-    datatype = ucp_request_param_datatype(param);
-    if (!ucp_ep_config_test_rndv_support(ucp_ep_config(ep))) {
-        ret = UCS_STATUS_PTR(UCS_ERR_UNSUPPORTED);
-        goto out;
-    }
 
     status = ucp_ep_resolve_remote_id(ep, ucp_ep_config(ep)->tag.lane);
     if (status != UCS_OK) {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -431,16 +431,6 @@ UCS_TEST_P(test_ucp_peer_failure, basic) {
             false /* must_fail */);
 }
 
-UCS_TEST_P(test_ucp_peer_failure, rndv_disable) {
-    const size_t size_max = std::numeric_limits<size_t>::max();
-
-    sender().connect(&receiver(), get_ep_params(), STABLE_EP_INDEX);
-    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.am_thresh.remote);
-    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.rma_thresh.remote);
-    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.am_thresh.local);
-    EXPECT_EQ(size_max, ucp_ep_config(sender().ep())->tag.rndv.rma_thresh.local);
-}
-
 UCS_TEST_P(test_ucp_peer_failure, zcopy, "ZCOPY_THRESH=1023",
            /* to catch failure with TCP during progressing multi AM Zcopy,
             * since `must_fail=true` */


### PR DESCRIPTION
## What
always enable RNDV protocols and print diag message if KA is disabled but err handling mode peer is requested

## Why ?
we don't have this limitation since KA protocol is implemented and enabled by default if err handling mode peer is requested
