### PR TITLE
UCP/CORE: Add timerfd to signal wakeup_fd if keepalive timeout expired

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -318,6 +318,8 @@ typedef struct ucp_worker {
     ucp_rkey_config_t                rkey_config[UCP_WORKER_MAX_RKEY_CONFIG];
 
     struct {
+        int                          timerfd;             /* Timer needed to signal to user's fd when
+                                                           * the next keepalive round must be done */
         uct_worker_cb_id_t           cb_id;               /* Keepalive callback id */
         ucs_time_t                   last_round;          /* Last round timestamp */
         ucs_list_link_t              *iter;               /* Last EP processed keepalive */

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -31,9 +31,15 @@ typedef uint32_t             ucs_short_time_t;
 #define UCS_TIME_INFINITY  ULLONG_MAX
 #define UCS_TIME_AUTO      (UCS_TIME_INFINITY - 1)
 
-#define UCS_MSEC_PER_SEC   1000ull       /* Milli */
-#define UCS_USEC_PER_SEC   1000000ul     /* Micro */
-#define UCS_NSEC_PER_SEC   1000000000ul  /* Nano */
+
+/* Milli per sec */
+#define UCS_MSEC_PER_SEC   1000ull
+/* Micro per sec */
+#define UCS_USEC_PER_SEC   1000000ul
+/* Nano per sec */
+#define UCS_NSEC_PER_SEC   1000000000ul
+/* Nano per micro */
+#define UCS_NSEC_PER_USEC  (UCS_NSEC_PER_SEC / UCS_USEC_PER_SEC)
 
 
 double ucs_get_cpu_clocks_per_sec();

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -29,7 +29,8 @@ protected:
     enum {
         TEST_AM  = UCS_BIT(0),
         TEST_RMA = UCS_BIT(1),
-        FAIL_IMM = UCS_BIT(2)
+        FAIL_IMM = UCS_BIT(2),
+        WAKEUP   = UCS_BIT(3)
     };
 
     enum {
@@ -494,6 +495,8 @@ public:
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         add_variant_with_value(variants, UCP_FEATURE_AM, TEST_AM, "am");
+        add_variant_with_value(variants, UCP_FEATURE_AM | UCP_FEATURE_WAKEUP,
+                               TEST_AM | WAKEUP, "am_wakeup");
     }
 };
 
@@ -523,9 +526,16 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
 
     /* flush all outstanding ops to allow keepalive to run */
     flush_worker(sender());
+    if (get_variant_value() & WAKEUP) {
+        wait_for_wakeup({ sender().worker(), failing_receiver().worker() },
+                        100, true);
+    }
 
     /* kill EPs & ifaces */
     failing_receiver().close_all_eps(*this, 0, UCP_EP_CLOSE_MODE_FORCE);
+    if (get_variant_value() & WAKEUP) {
+        wait_for_wakeup({ sender().worker() });
+    }
     wait_for_flag(&m_err_count);
 
     /* dump warnings */

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -238,6 +238,8 @@ protected:
                                    ucp_tag_recv_info_t *info, int remove = 1,
                                    int worker_index = 0);
     void request_release(void *req);
+    void wait_for_wakeup(const std::vector<ucp_worker_h> &workers,
+                         int poll_timeout = -1, bool drain = false);
     int max_connections();
     void set_tl_small_timeouts();
 


### PR DESCRIPTION
## What

Add timerfd to signal wakeup_fd if keepalive timeout expired.

## Why ?

An application hangs If a user uses `WAKEUP` feature without all-time polling using `ucp_worker_porgress()`, but the peer fails.

## How ?

1. Add `timerfd` for KA functionality. It is added to epoll_fd exposed to user as wakeup fd,
2. Set `timerfd` time to KA interval when KA is initialized or KA is completed.