### PR TITLE
UCP/CORE: Purge all requests after discarding lanes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1067,12 +1067,29 @@ static void ucp_ep_set_lanes_failed(ucp_ep_h ep, uct_ep_h *uct_eps)
     }
 }
 
+static void ucp_ep_discard_lanes_callback(void *request, ucs_status_t status,
+                                          void *user_data)
+{
+    ucp_ep_discard_lanes_arg_t *arg = (ucp_ep_discard_lanes_arg_t*)user_data;
+
+    ucs_assert(arg != NULL);
+    ucs_assert(arg->counter > 0);
+
+    if (--arg->counter > 0) {
+        return;
+    }
+
+    ucp_ep_reqs_purge(arg->ucp_ep, arg->status);
+    ucs_free(arg);
+}
+
 ucs_status_t
 ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
 {
     UCS_STRING_BUFFER_ONSTACK(lane_info_strb, 64);
     ucp_ep_ext_control_t *ep_ext_control = ucp_ep_ext_control(ucp_ep);
     ucp_err_handling_mode_t err_mode;
+    ucp_ep_discard_lanes_arg_t *discard_arg;
     ucs_log_level_t log_level;
     ucp_request_t *close_req;
 
@@ -1094,17 +1111,31 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
         return UCS_OK;
     }
 
+    discard_arg = ucs_malloc(sizeof(*discard_arg), "discard_lanes_arg");
+    if (discard_arg == NULL) {
+        ucs_error("ep %p: failed to allocate memory for discarding lanes"
+                  " argument", ucp_ep);
+        return UCS_ERR_NO_MEMORY;
+    }
+
     /* The EP can be closed from last completion callback */
-    ucp_ep_discard_lanes(ucp_ep, status);
-    ucp_ep_reqs_purge(ucp_ep, status);
+    discard_arg->ucp_ep   = ucp_ep;
+    discard_arg->status   = status;
+    discard_arg->counter  = 1;
+    discard_arg->counter += ucp_ep_discard_lanes(ucp_ep, status,
+                                                 ucp_ep_discard_lanes_callback,
+                                                 discard_arg);
+    ucp_ep_discard_lanes_callback(NULL, UCS_OK, discard_arg);
+
     ucp_stream_ep_cleanup(ucp_ep, status);
 
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
         if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
             if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
                 /* Promote close operation to CANCEL in case of transport error,
-             * since the disconnect event may never arrive. */
-                close_req = ep_ext_control->close_req.req;
+                 * since the disconnect event may never arrive. */
+                close_req                        =
+                        ep_ext_control->close_req.req;
                 close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
                 ucp_ep_local_disconnect_progress(close_req);
             }
@@ -1316,12 +1347,17 @@ ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
     return ucp_ep_close_nbx(ep, &param);
 }
 
-void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t status)
+unsigned ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t discard_status,
+                              ucp_send_nbx_callback_t discard_cb,
+                              ucp_ep_discard_lanes_arg_t *discard_arg)
 {
-    unsigned ep_flush_flags = (ucp_ep_config(ep)->key.err_mode ==
+    unsigned ep_flush_flags         = (ucp_ep_config(ep)->key.err_mode ==
                                        UCP_ERR_HANDLING_MODE_NONE) ?
-                              UCT_FLUSH_FLAG_LOCAL: UCT_FLUSH_FLAG_CANCEL;
+                                      UCT_FLUSH_FLAG_LOCAL:
+                                      UCT_FLUSH_FLAG_CANCEL;
     uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
+    unsigned num_discard_lanes      = 0;
+    ucs_status_t status;
     ucp_lane_index_t lane;
     uct_ep_h uct_ep;
 
@@ -1336,12 +1372,17 @@ void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t status)
         }
 
         ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
-        ucp_worker_discard_uct_ep(ep, uct_ep, ep_flush_flags,
-                                  ucp_ep_err_pending_purge,
-                                  UCS_STATUS_PTR(status),
-                                  (ucp_send_nbx_callback_t)ucs_empty_function,
-                                  NULL);
+
+        status = ucp_worker_discard_uct_ep(ep, uct_ep, ep_flush_flags,
+                                           ucp_ep_err_pending_purge,
+                                           UCS_STATUS_PTR(discard_status),
+                                           discard_cb, discard_arg);
+        if (status == UCS_INPROGRESS) {
+            ++num_discard_lanes;
+        }
     }
+
+    return num_discard_lanes;
 }
 
 ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
@@ -1369,7 +1410,9 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
     ucp_ep_update_flags(ep, UCP_EP_FLAG_CLOSED, 0);
 
     if (ucp_request_param_flags(param) & UCP_EP_CLOSE_FLAG_FORCE) {
-        ucp_ep_discard_lanes(ep, UCS_ERR_CANCELED);
+        ucp_ep_discard_lanes(ep, UCS_ERR_CANCELED,
+                             (ucp_send_nbx_callback_t)ucs_empty_function,
+                             NULL);
         ucp_ep_disconnected(ep, 1);
     } else {
         request = ucp_ep_flush_internal(ep, 0, param, NULL,

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -516,6 +516,19 @@ typedef struct ucp_conn_request {
 } ucp_conn_request_t;
 
 
+/**
+ * Argument for discarding UCP endpoint's lanes
+ */
+typedef struct ucp_ep_discard_lanes_arg {
+    unsigned     counter; /* How many discarding operations on UCT lanes are
+                           * in-progress if purging of the UCP endpoint is
+                           * required */
+    ucs_status_t status; /* Completion status of operations after discarding is
+                          * done */
+    ucp_ep_h     ucp_ep; /* UCP endpoint which should be discarded */
+} ucp_ep_discard_lanes_arg_t;
+
+
 int ucp_is_uct_ep_failed(uct_ep_h uct_ep);
 
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);
@@ -663,7 +676,9 @@ void
 ucp_ep_purge_lanes(ucp_ep_h ep, uct_pending_purge_callback_t purge_cb,
                    void *purge_arg);
 
-void ucp_ep_discard_lanes(ucp_ep_h ucp_ep, ucs_status_t status);
+unsigned ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t discard_status,
+                              ucp_send_nbx_callback_t discard_cb,
+                              ucp_ep_discard_lanes_arg_t *discard_arg);
 
 void ucp_ep_register_disconnect_progress(ucp_request_t *req);
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -69,6 +69,7 @@ UCS_PTR_MAP_IMPL(request, 0);
         uint32_t _flags; \
         \
         ucs_assert(!((_req)->flags & UCP_REQUEST_FLAG_COMPLETED)); \
+        ucs_assert((_status) != UCS_INPROGRESS); \
         \
         _flags         = ((_req)->flags |= UCP_REQUEST_FLAG_COMPLETED); \
         (_req)->status = (_status); \

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3038,10 +3038,11 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
     }
 }
 
-static void ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
-                                         unsigned ep_flush_flags,
-                                         ucp_send_nbx_callback_t discarded_cb,
-                                         void *discarded_cb_arg)
+static ucs_status_t
+ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                             unsigned ep_flush_flags,
+                             ucp_send_nbx_callback_t discarded_cb,
+                             void *discarded_cb_arg)
 {
     ucp_worker_h worker = ucp_ep->worker;
     ucp_request_t *req;
@@ -3051,14 +3052,14 @@ static void ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     if (ucp_is_uct_ep_failed(uct_ep)) {
         /* No need to discard failed TL EP, because it may lead to adding the
          * same UCT EP to the hash of discarded UCT EPs */
-        return;
+        return UCS_OK;
     }
 
     req = ucp_request_get(worker);
     if (ucs_unlikely(req == NULL)) {
         ucs_error("unable to allocate request for discarding UCT EP %p "
                   "on UCP worker %p", uct_ep, worker);
-        return;
+        return UCS_ERR_NO_MEMORY;
     }
 
     ucp_ep_add_ref(ucp_ep);
@@ -3088,6 +3089,8 @@ static void ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     ucp_request_set_user_callback(req, send.cb, discarded_cb, discarded_cb_arg);
 
     ucp_worker_discard_uct_ep_progress(req);
+
+    return UCS_INPROGRESS;
 }
 
 static uct_ep_h ucp_worker_discard_wireup_ep(
@@ -3122,12 +3125,12 @@ int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep)
            kh_end(&worker->discard_uct_ep_hash);
 }
 
-void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
-                               unsigned ep_flush_flags,
-                               uct_pending_purge_callback_t purge_cb,
-                               void *purge_arg,
-                               ucp_send_nbx_callback_t discarded_cb,
-                               void *discarded_cb_arg)
+ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                                       unsigned ep_flush_flags,
+                                       uct_pending_purge_callback_t purge_cb,
+                                       void *purge_arg,
+                                       ucp_send_nbx_callback_t discarded_cb,
+                                       void *discarded_cb_arg)
 {
     UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(ucp_ep->worker);
     ucs_assert(uct_ep != NULL);
@@ -3141,12 +3144,12 @@ void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                               purge_arg, discarded_cb,
                                               discarded_cb_arg);
         if (uct_ep == NULL) {
-            return;
+            return UCS_OK;
         }
     }
 
-    ucp_worker_discard_tl_uct_ep(ucp_ep, uct_ep, ep_flush_flags, discarded_cb,
-                                 discarded_cb_arg);
+    return ucp_worker_discard_tl_uct_ep(ucp_ep, uct_ep, ep_flush_flags,
+                                        discarded_cb, discarded_cb_arg);
 }
 
 void ucp_worker_vfs_refresh(void *obj)

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -368,12 +368,12 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep);
 int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep);
 
 /* must be called with async lock held */
-void ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
-                               unsigned ep_flush_flags,
-                               uct_pending_purge_callback_t purge_cb,
-                               void *purge_arg,
-                               ucp_send_nbx_callback_t discarded_cb,
-                               void *discarded_cb_arg);
+ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                                       unsigned ep_flush_flags,
+                                       uct_pending_purge_callback_t purge_cb,
+                                       void *purge_arg,
+                                       ucp_send_nbx_callback_t discarded_cb,
+                                       void *discarded_cb_arg);
 
 char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
                                 ucp_context_h context,

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -248,6 +248,7 @@ void ucp_ep_flush_completion(uct_completion_t *self)
     ucp_trace_req(req, "flush completion status=%d", status);
 
     ucs_assert(!(req->flags & UCP_REQUEST_FLAG_COMPLETED));
+    ucs_assert(status != UCS_INPROGRESS);
 
     req->status = status;
 

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -131,4 +131,11 @@ void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep)
                                UCS_CONN_MATCH_QUEUE_EXP);
 
     ucp_ep_update_flags(ep, 0, UCP_EP_FLAG_ON_MATCH_CTX);
+    if (!(ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID)) {
+        /* Reset the endpoint's flush state to make it valid in case of
+         * discarding the endpoint during error handling. The flush state
+         * will be used to complete remote RMA requests during purging
+         * requests */
+        ucp_ep_flush_state_reset(ep);
+    }
 }


### PR DESCRIPTION
## What

Purge all requests after discarding lanes.

## Why ?

To release memory regions after UCT lanes are not valid anymore to avoid reading invalid memory by a peer.

## How ?

1. Add `ucp_ep_discard_lanes_callback()` callback and `ucp_ep_discard_lanes_arg_t` argument passed to `ucp_worker_discard_uct_ep()` inside `ucp_ep_discard_lanes()`.
2. The callback will be called every time the UCT lane is discarded. When number of remaining lanes is `0`, `ucp_ep_reqs_purge()` will be done and memory obtained for `ucp_ep_discard_lanes_arg_t` argument will be released.