### PR TITLE
UCS/PROFILE: fixed potential crash on cleanup

### DIFF
--- a/src/ucs/profile/profile.c
+++ b/src/ucs/profile/profile.c
@@ -551,7 +551,7 @@ static void ucs_profile_check_active_threads(ucs_profile_context_t *ctx)
     }
 }
 
-void ucs_profile_reset_locations(ucs_profile_context_t *ctx)
+void ucs_profile_reset_locations_id(ucs_profile_context_t *ctx)
 {
     ucs_profile_global_location_t *loc;
 
@@ -560,6 +560,13 @@ void ucs_profile_reset_locations(ucs_profile_context_t *ctx)
     ucs_profile_ctx_for_each_location(ctx, loc) {
         *loc->loc_id_p = -1;
     }
+
+    pthread_mutex_unlock(&ctx->mutex);
+}
+
+static void ucs_profile_reset_locations(ucs_profile_context_t *ctx)
+{
+    pthread_mutex_lock(&ctx->mutex);
 
     ctx->num_locations = 0;
     ctx->max_locations = 0;
@@ -622,6 +629,7 @@ ucs_status_t ucs_profile_init(unsigned profile_mode, const char *file_name,
     ctx->profile_mode     = profile_mode;
     ctx->file_name        = file_name;
     ctx->max_file_size    = max_file_size;
+    /* coverity[missing_lock] */
     ctx->num_locations    = 0;
     ctx->locations        = NULL;
     ctx->max_locations    = 0;

--- a/src/ucs/profile/profile.h
+++ b/src/ucs/profile/profile.h
@@ -17,4 +17,6 @@
 #  include "profile_off.h"
 #endif
 
+void ucs_profile_reset_locations_id(ucs_profile_context_t *ctx);
+
 #endif

--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -351,15 +351,6 @@ void ucs_profile_record(ucs_profile_context_t *ctx, ucs_profile_type_t type,
                         volatile int *loc_id_p);
 
 
-/**
- * Reset the internal array of profiling locations.
- * Used for testing purposes only.
- *
- * @param [in] ctx Global profile context.
- */
-void ucs_profile_reset_locations(ucs_profile_context_t *ctx);
-
-
 END_C_DECLS
 
 #endif

--- a/test/gtest/ucs/test_profile.cc
+++ b/test/gtest/ucs/test_profile.cc
@@ -20,6 +20,7 @@ class scoped_profile {
 public:
     scoped_profile(ucs::test_base& test, const std::string &file_name,
                    const char *mode) : m_test(test), m_file_name(file_name) {
+        ucs_profile_reset_locations_id(ucs_profile_default_ctx);
         ucs_profile_cleanup(ucs_profile_default_ctx);
         m_test.push_config();
         m_test.modify_config("PROFILE_MODE", mode);
@@ -38,6 +39,7 @@ public:
     }
 
     ~scoped_profile() {
+        ucs_profile_reset_locations_id(ucs_profile_default_ctx);
         ucs_profile_cleanup(ucs_profile_default_ctx);
         unlink(m_file_name.c_str());
         m_test.pop_config();


### PR DESCRIPTION
- on some systems data secection may be unmapped prior to
  destructor called and cleanup routine executed. check
  that loc_id_p page is still available
