### PR TITLE
UCP/RDESC: fixed initialization

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -708,7 +708,6 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
             return UCS_ERR_NO_MEMORY;
         }
 
-        ucp_recv_desc_set_name(rdesc, name);
         padding = ucs_padding((uintptr_t)(rdesc + 1), worker->am.alignment);
         rdesc   = (ucp_recv_desc_t*)UCS_PTR_BYTE_OFFSET(rdesc, padding);
         rdesc->release_desc_offset = padding;
@@ -720,6 +719,7 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
         memcpy(UCS_PTR_BYTE_OFFSET(rdesc + 1, data_offset), data, length);
     }
 
+    ucp_recv_desc_set_name(rdesc, name);
     rdesc->length         = length + data_offset;
     rdesc->payload_offset = hdr_len;
     *rdesc_p              = rdesc;


### PR DESCRIPTION
- fixed initialization of rdesc: in some cases name value is not
  initialized which may cause access error on diagnostic
