### PR TITLE
UCP/RKEY: added the adjusting of `UCP_RKEY_MPOOL_MAX_MD` through param

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -381,6 +381,12 @@ static ucs_config_field_t ucp_config_table[] = {
    "lane without waiting for remote completion.",
    ucs_offsetof(ucp_config_t, ctx.rndv_put_force_flush), UCS_CONFIG_TYPE_BOOL},
 
+  {"RKEY_MPOOL_MAX_MD", "2",
+   "Maximum number of UCP rkey MDs which can be unpacked into memory pool\n"
+   "element. UCP rkeys containing larger number of MDs will be unpacked to\n"
+   "dynamically allocated memory.",
+   ucs_offsetof(ucp_config_t, ctx.rkey_mpool_max_md), UCS_CONFIG_TYPE_INT},
+
    {NULL}
 };
 UCS_CONFIG_REGISTER_TABLE(ucp_config_table, "UCP context", NULL, ucp_config_t,

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -121,6 +121,9 @@ typedef struct ucp_context_config {
     unsigned                               reg_whole_alloc_bitmap;
     /** Always use flush operation in rendezvous put */
     int                                    rndv_put_force_flush;
+    /** Remote keys with that many remote MDs or less would be allocated from a
+      * memory pool.*/
+    int                                    rkey_mpool_max_md;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -348,7 +348,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
     ucs_status_t status;
     ucp_rkey_h rkey;
     uint8_t flags;
-    unsigned md_count;
+    int md_count;
 
     UCS_STATIC_ASSERT(ucs_offsetof(ucp_rkey_t, mem_type) ==
                       ucs_offsetof(ucp_rkey_t, cache.mem_type));
@@ -367,7 +367,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
      * allocations are done from a memory pool.
      * We keep all of them to handle a future transport switch.
      */
-    if (md_count <= UCP_RKEY_MPOOL_MAX_MD) {
+    if (md_count <= worker->context->config.ext.rkey_mpool_max_md) {
         rkey  = ucs_mpool_get_inline(&worker->rkey_mp);
         flags = UCP_RKEY_DESC_FLAG_POOL;
     } else {

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -13,33 +13,6 @@
 #include <ucp/proto/proto_select.h>
 
 
-/* Remote keys with that many remote MDs or less would be allocated from a
- * memory pool.
- *
- * The element size of rkey mpool has aligned by the cache line (64B), so the
- * UCP_RKEY_MPOOL_MAX_MD is adjusted to 2 to minimize gaps between mpool items,
- * in turn, reduce the memory consumption.
- *
- * See the byte-scheme of the rkey mpool element:
- * +------+------------+------------+------------+------------+------------+------
- * |elem  |            |            |            |            |            |
- * |header| ucp_rkey_t | uct rkey 0 | uct rkey 1 | uct rkey 2 | uct rkey 3 | ...
- * +------+------------+------------+------------+------------+------------+-----
- * | 8B   |    32B     |    32B     |    32B     |    32B     |    32B     | ...
- * +----------------------------+-------------------------+----------------------+
- * |        64B Cache line      |     64B Cache line      |    64B Cache line    |
- * +----------------------------+-------------------------+---+------------------+
- * |                 UCP_RKEY_MPOOL_MAX_MD=3                  |     40B gap      |
- * +---------------------------------------------+--------+---+------------------+
- * |           UCP_RKEY_MPOOL_MAX_MD=2           | 16B gap|
- * +---------------------------------------------+--------+
- *
- * Thus UCP_RKEY_MPOOL_MAX_MD=2 is the optimal value to keeping short rkeys in
- * the rkey mpool.
- */
-#define UCP_RKEY_MPOOL_MAX_MD     2
-
-
 /**
  * Rkey proto index
  */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1688,14 +1688,44 @@ static ucs_status_t ucp_worker_init_mpools(ucp_worker_h worker)
         goto err;
     }
 
-    /* Create memory pool for small rkeys */
-    status = ucs_mpool_init(&worker->rkey_mp, 0,
-                            sizeof(ucp_rkey_t) +
-                            sizeof(ucp_tl_rkey_t) * UCP_RKEY_MPOOL_MAX_MD,
-                            0, UCS_SYS_CACHE_LINE_SIZE, 128, UINT_MAX,
-                            &ucp_rkey_mpool_ops, "ucp_rkeys");
-    if (status != UCS_OK) {
-        goto err_req_mp_cleanup;
+    if (worker->context->config.ext.rkey_mpool_max_md >= 0) {
+        /* Create memory pool for small rkeys.
+         *
+         * `worker->context->config.ext.rkey_mpool_max_md`specifies the maximum
+         * number of remote keys with that many remote MDs or less would be
+         * allocated from a memory pool.
+         *
+         * The element size of rkey mpool has aligned by the cache line (64B),
+         * so the `worker->context->config.ext.rkey_mpool_max_md` is adjusted to
+         * 2 to minimize gaps between mpool items, in turn, reduce the memory
+         * consumption.
+         *
+         * See the byte-scheme of the rkey mpool element:
+         * +------+------------+------------+------------+------------+------------+------
+         * |elem  |            |            |            |            |            |
+         * |header| ucp_rkey_t | uct rkey 0 | uct rkey 1 | uct rkey 2 | uct rkey 3 | ...
+         * +------+------------+------------+------------+------------+------------+-----
+         * | 8B   |    32B     |    32B     |    32B     |    32B     |    32B     | ...
+         * +----------------------------+-------------------------+----------------------+
+         * |        64B Cache line      |     64B Cache line      |    64B Cache line    |
+         * +----------------------------+-------------------------+---+------------------+
+         * |                 rkey_mpool_max_md=3                      |     40B gap      |
+         * +---------------------------------------------+--------+---+------------------+
+         * |           rkey_mpool_max_md=2               | 16B gap|
+         * +---------------------------------------------+--------+
+         *
+         * Thus rkey_mpool_max_md=2 is the optimal value to keeping short
+         * rkeys in the rkey mpool.
+         */
+        status = ucs_mpool_init(&worker->rkey_mp, 0,
+                                sizeof(ucp_rkey_t) +
+                                sizeof(ucp_tl_rkey_t) *
+                                worker->context->config.ext.rkey_mpool_max_md,
+                                0, UCS_SYS_CACHE_LINE_SIZE, 128, UINT_MAX,
+                                &ucp_rkey_mpool_ops, "ucp_rkeys");
+        if (status != UCS_OK) {
+            goto err_req_mp_cleanup;
+        }
     }
 
     /* Create memory pool for incoming UCT messages without a UCT descriptor */
@@ -1722,7 +1752,9 @@ static ucs_status_t ucp_worker_init_mpools(ucp_worker_h worker)
 err_am_mp_cleanup:
     ucs_mpool_cleanup(&worker->am_mp, 0);
 err_rkey_mp_cleanup:
-    ucs_mpool_cleanup(&worker->rkey_mp, 0);
+    if (worker->context->config.ext.rkey_mpool_max_md >= 0) {
+        ucs_mpool_cleanup(&worker->rkey_mp, 0);
+    }
 err_req_mp_cleanup:
     ucs_mpool_cleanup(&worker->req_mp, 0);
 err:
@@ -1744,7 +1776,9 @@ static void ucp_worker_destroy_mpools(ucp_worker_h worker)
     kh_destroy_inplace(ucp_worker_mpool_hash, &worker->mpool_hash);
     ucs_mpool_cleanup(&worker->reg_mp, 1);
     ucs_mpool_cleanup(&worker->am_mp, 1);
-    ucs_mpool_cleanup(&worker->rkey_mp, 1);
+    if (worker->context->config.ext.rkey_mpool_max_md >= 0) {
+        ucs_mpool_cleanup(&worker->rkey_mp, 1);
+    }
     ucs_mpool_cleanup(&worker->req_mp,
                       !(worker->flags & UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK));
 }


### PR DESCRIPTION
## What
Adds an adjust to the value of `UCP_RKEY_MPOOL_MAX_MD` via the env parameter. It also allows disabling the use of mpool and force malloc for rkeys, which adds reduce the mem consumption.
