### PR TITLE
GTEST: Fix dontfork test

### DIFF
--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -142,7 +142,9 @@ class test_p2p_rma_madvise : private ucs::clear_dontcopy_regions,
 };
 
 UCS_TEST_SKIP_COND_P(test_p2p_rma_madvise, madvise,
-                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY))
+                     !check_caps(UCT_IFACE_FLAG_GET_ZCOPY),
+                     /* Allocate with mmap to avoid pinning other heap memory */
+                     "IB_ALLOC?=mmap")
 {
     mapped_buffer sendbuf(4096, 0, sender());
     mapped_buffer recvbuf(4096, 0, receiver());


### PR DESCRIPTION
## Why
Fix recent CI failures, for example:
```
2021-10-15T00:22:58.7169281Z [ RUN      ] dc_mlx5/test_p2p_rma_madvise.madvise/1 <dc_mlx5/mlx5_0:1/loopback>
2021-10-15T00:22:59.2110559Z /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/test_p2p_rma.cc:157: Failure
2021-10-15T00:22:59.2113498Z Expected equality of these values:
2021-10-15T00:22:59.2114632Z   42
2021-10-15T00:22:59.2115729Z   ((((*(int *) &(exit_status))) & 0xff00) >> 8)
2021-10-15T00:22:59.2116883Z     Which is: 1
2021-10-15T00:22:59.2117970Z exited with status 1
2021-10-15T00:22:59.2830845Z [  FAILED  ] dc_mlx5/test_p2p_rma_madvise.madvise/1, where GetParam() = dc_mlx5/mlx5_0:1/loopback (560 ms)
```
https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/28555/logs/405