### PR TITLE
UCP: Use mpool set for UCT AM descriptors

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -161,6 +161,8 @@ struct ucp_config {
     ucp_context_config_t                   ctx;
     /** Save ucx configurations not listed in ucp_config_table **/
     ucs_list_link_t                        cached_key_list;
+    /** Array of worker memory pool sizes */
+    UCS_CONFIG_ARRAY_FIELD(size_t, memunits) mpool_sizes;
 };
 
 
@@ -282,6 +284,10 @@ typedef struct ucp_context {
 
         /* MD to compare for transport selection scores */
         char                      *selection_cmp;
+        struct {
+           unsigned               count;
+           size_t                 *sizes;
+        } am_mpools;
     } config;
 
     /* Configuration of multi-threading support */

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -14,6 +14,7 @@
 #include <ucp/dt/dt.h>
 #include <ucs/profile/profile.h>
 #include <ucs/datastruct/mpool.inl>
+#include <ucs/datastruct/mpool_set.inl>
 #include <ucs/datastruct/ptr_map.inl>
 #include <ucs/debug/debug_int.h>
 #include <ucp/dt/dt.inl>
@@ -708,7 +709,8 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
         rdesc->release_desc_offset = UCP_WORKER_HEADROOM_PRIV_SIZE - priv_length;
         status                     = UCS_INPROGRESS;
     } else {
-        rdesc = (ucp_recv_desc_t*)ucs_mpool_get_inline(&worker->am_mp);
+        rdesc = (ucp_recv_desc_t*)ucs_mpool_set_get_inline(&worker->am_mps,
+                                                           length);
         if (rdesc == NULL) {
             ucs_error("ucp recv descriptor is not allocated");
             return UCS_ERR_NO_MEMORY;
@@ -743,7 +745,7 @@ ucp_recv_desc_release(ucp_recv_desc_t *rdesc)
         /* uct desc is slowpath */
         uct_iface_release_desc(desc);
     } else {
-        ucs_mpool_put_inline(desc);
+        ucs_mpool_set_put_inline(desc);
     }
 }
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -16,6 +16,7 @@
 #include <ucp/core/ucp_am.h>
 #include <ucp/tag/tag_match.h>
 #include <ucs/datastruct/mpool.h>
+#include <ucs/datastruct/mpool_set.h>
 #include <ucs/datastruct/queue_types.h>
 #include <ucs/datastruct/strided_alloc.h>
 #include <ucs/datastruct/conn_match.h>
@@ -27,6 +28,10 @@
  * use for its own needs. This size does not include ucp_recv_desc_t length,
  * because it is common for all cases and protocols (TAG, STREAM). */
 #define UCP_WORKER_HEADROOM_PRIV_SIZE 32
+
+
+#define UCP_WORKER_HEADROOM_SIZE \
+    (sizeof(ucp_recv_desc_t) + UCP_WORKER_HEADROOM_PRIV_SIZE)
 
 
 #define UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(_worker) \
@@ -92,7 +97,11 @@ enum {
 
     /** Worker event fd is external */
     UCP_WORKER_FLAG_EXTERNAL_EVENT_FD =
-            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 3)
+            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 3),
+
+    /** Indicates that AM mpool was initialized on this worker */
+    UCP_WORKER_FLAG_AM_MPOOL_INITIALIZED =
+            UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 4)
 };
 
 
@@ -287,7 +296,7 @@ typedef struct ucp_worker {
     unsigned                         num_active_ifaces;   /* Number of activated ifaces  */
     ucp_tl_bitmap_t                  scalable_tl_bitmap;  /* Map of scalable tl resources */
     ucp_worker_cm_t                  *cms;                /* Array of CMs, one for each component */
-    ucs_mpool_t                      am_mp;               /* Memory pool for AM receives */
+    ucs_mpool_set_t                  am_mps;              /* Memory pool set for AM receives */
     ucs_mpool_t                      reg_mp;              /* Registered memory pool */
     ucp_worker_mpool_hash_t          mpool_hash;          /* Hash table of memory pools */
     ucs_queue_head_t                 rkey_ptr_reqs;       /* Queue of submitted RKEY PTR requests that

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -443,7 +443,8 @@ ucp_stream_am_data_process(ucp_worker_t *worker, ucp_ep_ext_proto_t *ep_ext,
 
     /* Now, enqueue the rest of data */
     if (ucs_likely(!(am_flags & UCT_CB_PARAM_FLAG_DESC))) {
-        rdesc = (ucp_recv_desc_t*)ucs_mpool_get_inline(&worker->am_mp);
+        rdesc = (ucp_recv_desc_t*)ucs_mpool_set_get_inline(&worker->am_mps,
+                                                           length);
         ucs_assertv_always(rdesc != NULL,
                            "ucp recv descriptor is not allocated");
         rdesc->length              = rdesc_tmp.length;

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -19,6 +19,7 @@
 extern "C" {
 #include <ucp/core/ucp_am.h>
 #include <ucp/core/ucp_ep.inl>
+#include <ucs/datastruct/mpool.inl>
 }
 
 #define NUM_MESSAGES 17
@@ -688,6 +689,64 @@ UCS_TEST_P(test_ucp_am_nbx, max_short_thresh_zcopy, "ZCOPY_THRESH=0")
             ep_cfg->am_u.max_reply_eager_short.memtype_on + 1);
 
     EXPECT_LE(max_reply_short, ep_cfg->am.zcopy_thresh[0]);
+}
+
+UCS_TEST_P(test_ucp_am_nbx, rx_am_mpools,
+           "RX_MPOOL_SIZES=2,8,64,128", "RNDV_THRESH=inf")
+{
+    void *rx_data = NULL;
+
+    set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_data_hold_cb, &rx_data,
+                        UCP_AM_FLAG_PERSISTENT_DATA);
+
+    static const std::string ib_tls[] = { "dc_x", "rc_v", "rc_x", "ud_v",
+                                          "ud_x", "ib" };
+
+    // UCP takes desc from mpool only for data arrived as inlined from UCT.
+    // Typically, with IB, data is inlined up to 32 bytes, so use smaller range
+    // of values for IB transports.
+    bool has_ib = has_any_transport(
+            std::vector<std::string>(ib_tls,
+                                     ib_tls + ucs_static_array_size(ib_tls)));
+    ssize_t length = ucs::rand() % (has_ib ? 32 : 256);
+    std::vector<char> sbuf(length, 'd');
+
+    ucp_request_param_t param;
+    param.op_attr_mask = 0ul;
+
+    ucs_status_ptr_t sptr = ucp_am_send_nbx(sender().ep(), TEST_AM_NBX_ID, NULL,
+                                            0ul, sbuf.data(), sbuf.size(),
+                                            &param);
+    wait_for_flag(&rx_data);
+    EXPECT_TRUE(rx_data != NULL);
+    EXPECT_EQ(UCS_OK, request_wait(sptr));
+
+    ucp_recv_desc_t *rdesc = (ucp_recv_desc_t*)rx_data - 1;
+    if (rdesc->flags & UCP_RECV_DESC_FLAG_UCT_DESC) {
+        ucp_am_data_release(receiver().worker(), rx_data);
+        UCS_TEST_SKIP_R("non-inline data arrived");
+    } else {
+        UCS_TEST_MESSAGE << "length " << length;
+    }
+
+    ucp_worker_h worker = receiver().worker();
+
+    for (int i = 0; i < ucs_popcount(worker->am_mps.bitmap); ++i) {
+        ucs_mpool_t *mpool =
+            &reinterpret_cast<ucs_mpool_t*>(worker->am_mps.data)[i];
+        ssize_t elem_size  = mpool->data->elem_size - (sizeof(ucs_mpool_elem_t) +
+                             UCP_WORKER_HEADROOM_SIZE + worker->am.alignment);
+        ASSERT_TRUE(elem_size >= 0);
+
+        if (elem_size >= (length + 1)) {
+            EXPECT_EQ(ucs_mpool_obj_owner(rdesc), mpool);
+            break;
+        }
+
+        EXPECT_NE(ucs_mpool_obj_owner(rdesc), mpool);
+    }
+
+    ucp_am_data_release(receiver().worker(), rx_data);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx)


### PR DESCRIPTION
## What
Use set of memory pools with different sizes for UCT AM descriptors in UCP.

## Why ?
Currently, single memory pool is used for any inlined data coming from UCT. Even if 1 byte message arrives, it consumes ~8KB element, which leads to huge memory consumption (or even 64K with tcp).
Initializing several memory pools of different sizes will help to preserve reasonable memory consumption

fixes #7151


