### PR TITLE
UCP/CORE: Use request from argument in macro

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -132,7 +132,7 @@ UCS_PTR_MAP_IMPL(request, 0);
 
 #define ucp_request_cb_param(_param, _req, _cb, ...) \
     if ((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) { \
-        (_param)->cb._cb(req + 1, (_req)->status, ##__VA_ARGS__, \
+        (_param)->cb._cb((_req) + 1, (_req)->status, ##__VA_ARGS__, \
                          (_param)->user_data); \
     }
 


### PR DESCRIPTION
## What

Use request from argument in macro.

## Why ?

To avoid potential compiler errors if no `req` defined in the context of `ucp_request_cb_param()` macro caller.

## How ?

`req` -> `(_req)`