### PR TITLE
TOOLS/INFO: Dump device type for UCT components

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -145,6 +145,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
 
     printf("#      Transport: %s\n", resource->tl_name);
     printf("#         Device: %s\n", resource->dev_name);
+    printf("#           Type: %s\n", uct_device_type_names[resource->dev_type]);
     printf("#  System device: %s",
            ucs_topo_sys_device_get_name(resource->sys_device));
     if (resource->sys_device != UCS_SYS_DEVICE_ID_UNKNOWN) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -38,13 +38,6 @@ static const char *ucp_atomic_modes[] = {
     [UCP_ATOMIC_MODE_LAST]   = NULL,
 };
 
-static const char * ucp_device_type_names[] = {
-    [UCT_DEVICE_TYPE_NET]  = "network",
-    [UCT_DEVICE_TYPE_SHM]  = "intra-node",
-    [UCT_DEVICE_TYPE_ACC]  = "accelerator",
-    [UCT_DEVICE_TYPE_SELF] = "loopback",
-};
-
 static const char *ucp_rndv_modes[] = {
     [UCP_RNDV_MODE_AUTO]         = "auto",
     [UCP_RNDV_MODE_GET_ZCOPY]    = "get_zcopy",
@@ -985,7 +978,7 @@ static void ucp_resource_config_str(const ucp_config_t *config, char *buf,
     devs_p = p;
     for (dev_type_idx = 0; dev_type_idx < UCT_DEVICE_TYPE_LAST; ++dev_type_idx) {
         ucp_resource_config_array_str(&config->devices[dev_type_idx],
-                                      ucp_device_type_names[dev_type_idx], p,
+                                      uct_device_type_names[dev_type_idx], p,
                                       endp - p);
         p += strlen(p);
     }
@@ -1277,7 +1270,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
         for (dev_type = UCT_DEVICE_TYPE_NET; dev_type < UCT_DEVICE_TYPE_LAST; ++dev_type) {
             ucp_report_unavailable(&config->devices[dev_type],
                                    dev_cfg_masks[dev_type],
-                                   ucp_device_type_names[dev_type], " device",
+                                   uct_device_type_names[dev_type], " device",
                                    &avail_devices[dev_type]);
         }
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1617,6 +1617,7 @@ enum {
 
 
 extern const char *uct_alloc_method_names[];
+extern const char *uct_device_type_names[];
 
 
 /**

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -60,6 +60,13 @@ ucs_config_field_t uct_md_config_rcache_table[] = {
 };
 
 
+const char *uct_device_type_names[] = {
+    [UCT_DEVICE_TYPE_NET]  = "network",
+    [UCT_DEVICE_TYPE_SHM]  = "intra-node",
+    [UCT_DEVICE_TYPE_ACC]  = "accelerator",
+    [UCT_DEVICE_TYPE_SELF] = "loopback",
+};
+
 ucs_status_t uct_md_open(uct_component_h component, const char *md_name,
                          const uct_md_config_t *config, uct_md_h *md_p)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -58,6 +58,7 @@ typedef struct uct_md_rcache_config {
 
 
 extern ucs_config_field_t uct_md_config_rcache_table[];
+extern const char *uct_device_type_names[];
 
 /**
  * "Base" structure which defines MD configuration options.


### PR DESCRIPTION
Signed-off-by: Honggang Li <honli@redhat.com>

## What

With this simple patch, `ucx_info` will dump device type for UCT components.

```
ucx (master *)]$ /tmp/ucx/bin/ucx_info -d | grep Type -B 2
#      Transport: posix
#         Device: memory
#           Type: intra-node
--
#      Transport: sysv
#         Device: memory
#           Type: intra-node
--
#      Transport: self
#         Device: memory0
#           Type: loopback
--
#      Transport: tcp
#         Device: eno1
#           Type: network
--
#      Transport: tcp
#         Device: lo
#           Type: network
--
#      Transport: cma
#         Device: memory
#           Type: intra-node
```

## Why ?
https://github.com/openucx/ucx/discussions/7549


