### PR TITLE
UCT/CUDA-IPC: disable get_zcopy on gpus with no active nvlinks

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -41,7 +41,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          LDFLAGS="$LDFLAGS $CUDA_LDFLAGS"
 
          # Check cuda header files
-         AC_CHECK_HEADERS([cuda.h cuda_runtime.h],
+         AC_CHECK_HEADERS([cuda.h cuda_runtime.h nvml.h],
                           [cuda_happy="yes"], [cuda_happy="no"])
 
          # Check cuda libraries
@@ -51,6 +51,9 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],
                              [CUDA_LIBS="$CUDA_LIBS -lcudart"], [cuda_happy="no"])])
+         AS_IF([test "x$cuda_happy" = "xyes"],
+               [AC_CHECK_LIB([nvidia-ml], [nvmlInit],
+                             [CUDA_LIBS="$CUDA_LIBS -lnvidia-ml"], [cuda_happy="no"])])
 
          LDFLAGS="$save_LDFLAGS"
 

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -11,6 +11,7 @@
 #include <ucs/profile/profile.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
+#include <nvml.h>
 
 
 #define UCT_CUDA_DEV_NAME       "cuda"
@@ -53,6 +54,26 @@
 
 #define UCT_CUDA_FUNC_LOG_ERR(_func) \
     UCT_CUDA_FUNC(_func, UCS_LOG_LEVEL_ERROR)
+
+
+#define UCT_NVML_FUNC(_func, _log_level)                        \
+    ({                                                          \
+        ucs_status_t _status = UCS_OK;                          \
+        do {                                                    \
+            nvmlReturn_t _err = (_func);                        \
+            if (NVML_SUCCESS != _err) {                         \
+                ucs_log((_log_level), "%s failed: %s",          \
+                        UCS_PP_MAKE_STRING(_func),              \
+                        nvmlErrorString(_err));                 \
+                _status = UCS_ERR_IO_ERROR;                     \
+            }                                                   \
+        } while (0);                                            \
+        _status;                                                \
+    })
+
+
+#define UCT_NVML_FUNC_LOG_ERR(_func) \
+    UCT_NVML_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
 #define UCT_CUDADRV_FUNC(_func, _log_level)                     \

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -26,6 +26,7 @@
 
 ucs_spinlock_t uct_cuda_base_lock;
 
+
 ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
                                        ucs_sys_device_t *sys_dev_p)
 {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -18,6 +18,7 @@
 #include <ucs/debug/assert.h>
 #include <sys/eventfd.h>
 #include <pthread.h>
+#include <nvml.h>
 
 static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
 
@@ -37,6 +38,11 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
      "Enable remote endpoint IPC memhandle mapping cache",
      ucs_offsetof(uct_cuda_ipc_iface_config_t, enable_cache),
      UCS_CONFIG_TYPE_BOOL},
+
+    {"ENABLE_GET_ZCOPY", "auto",
+     "Enable get operations except for platforms known to have slower performance",
+     ucs_offsetof(uct_cuda_ipc_iface_config_t, enable_get_zcopy),
+     UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
     {"MAX_EVENTS", "inf",
      "Max number of cuda events. -1 is infinite",
@@ -116,6 +122,75 @@ static double uct_cuda_ipc_iface_get_bw()
     }
 }
 
+/* calls nvmlInit_v2 and nvmlShutdown which are expensive but
+ * get_device_nvlinks should be outside critical path */
+static int uct_cuda_ipc_get_device_nvlinks(int ordinal)
+{
+    static int num_nvlinks = -1;
+    unsigned link;
+    nvmlDevice_t device;
+    nvmlFieldValue_t value;
+    nvmlPciInfo_t pci;
+    ucs_status_t status;
+
+    if (num_nvlinks != -1) {
+        return num_nvlinks;
+    }
+
+    status = UCT_NVML_FUNC_LOG_ERR(nvmlInit_v2());
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = UCT_NVML_FUNC_LOG_ERR(nvmlDeviceGetHandleByIndex(ordinal, &device));
+    if (status != UCS_OK) {
+        goto err_sd;
+    }
+
+    value.fieldId = NVML_FI_DEV_NVLINK_LINK_COUNT;
+
+    UCT_NVML_FUNC_LOG_ERR(nvmlDeviceGetFieldValues(device, 1, &value));
+
+    num_nvlinks = ((value.nvmlReturn == NVML_SUCCESS) &&
+                   (value.valueType == NVML_VALUE_TYPE_UNSIGNED_INT)) ?
+                  value.value.uiVal : 0;
+
+    /* not enough to check number of nvlinks; need to check if links are active
+     * by seeing if remote info can be obtained */
+    for (link = 0; link < num_nvlinks; ++link) {
+        status = UCT_NVML_FUNC(nvmlDeviceGetNvLinkRemotePciInfo(device, link,
+                                                                &pci),
+                               UCS_LOG_LEVEL_DEBUG);
+        if (status != UCS_OK) {
+            ucs_debug("could not find remote end info for link %u", link);
+            goto err_sd;
+        }
+    }
+
+    UCT_NVML_FUNC_LOG_ERR(nvmlShutdown());
+    return num_nvlinks;
+
+err_sd:
+    UCT_NVML_FUNC_LOG_ERR(nvmlShutdown());
+err:
+    return 0;
+}
+
+static size_t uct_cuda_ipc_iface_get_max_get_zcopy(uct_cuda_ipc_iface_t *iface)
+{
+    int num_nvlinks;
+
+    /* assume there is at least >= 1 GPUs on the system; assume uniformity */
+    num_nvlinks = uct_cuda_ipc_get_device_nvlinks(0);
+
+    if (!num_nvlinks && (iface->config.enable_get_zcopy != UCS_CONFIG_ON)) {
+        ucs_debug("cuda-ipc get zcopy disabled as no nvlinks detected");
+        return 0;
+    }
+
+    return ULONG_MAX;
+}
+
 static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
                                              uct_iface_attr_t *iface_attr)
 {
@@ -147,7 +222,7 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
 
     iface_attr->cap.get.max_bcopy       = 0;
     iface_attr->cap.get.min_zcopy       = 0;
-    iface_attr->cap.get.max_zcopy       = ULONG_MAX;
+    iface_attr->cap.get.max_zcopy       = uct_cuda_ipc_iface_get_max_get_zcopy(iface);
     iface_attr->cap.get.opt_zcopy_align = 1;
     iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
     iface_attr->cap.get.max_iov         = 1;
@@ -431,6 +506,7 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
     self->config.max_poll            = config->max_poll;
     self->config.max_streams         = config->max_streams;
     self->config.enable_cache        = config->enable_cache;
+    self->config.enable_get_zcopy    = config->enable_get_zcopy;
     self->config.max_cuda_ipc_events = config->max_cuda_ipc_events;
 
     status = ucs_mpool_init(&self->event_desc,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -30,10 +30,11 @@ typedef struct uct_cuda_ipc_iface {
     unsigned long    stream_refcount[UCT_CUDA_IPC_MAX_PEERS];
                                               /* per stream outstanding ops */
     struct {
-        unsigned     max_poll;                /* query attempts w.o success */
-        unsigned     max_streams;             /* # concurrent streams for || progress*/
-        unsigned     max_cuda_ipc_events;     /* max mpool entries */
-        int          enable_cache;            /* enable/disable ipc handle cache */
+        unsigned                max_poll;            /* query attempts w.o success */
+        unsigned                max_streams;         /* # concurrent streams for || progress*/
+        unsigned                max_cuda_ipc_events; /* max mpool entries */
+        int                     enable_cache;        /* enable/disable ipc handle cache */
+        ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platorms */
     } config;
 } uct_cuda_ipc_iface_t;
 
@@ -43,6 +44,7 @@ typedef struct uct_cuda_ipc_iface_config {
     unsigned                max_poll;
     unsigned                max_streams;
     int                     enable_cache;
+    ucs_on_off_auto_value_t enable_get_zcopy;
     unsigned                max_cuda_ipc_events;
 } uct_cuda_ipc_iface_config_t;
 


### PR DESCRIPTION
## What

Limit cuda-ipc get zcopy to [0, 0] range on platforms where concurrent reads are slow compared to concurrent puts (observed through osu_alltoall and osu_bibw reports)