### PR TITLE
EXAMPLES/UCT: Fix uct_hello_world to run over intra-node components

### DIFF
--- a/examples/uct_hello_world.c
+++ b/examples/uct_hello_world.c
@@ -367,7 +367,9 @@ static ucs_status_t dev_tl_lookup(const cmd_args_t *cmd_args,
             for (tl_index = 0; tl_index < num_tl_resources; ++tl_index) {
                 if (!strcmp(cmd_args->dev_name, tl_resources[tl_index].dev_name) &&
                     !strcmp(cmd_args->tl_name, tl_resources[tl_index].tl_name)) {
-                    if (!(iface_p->md_attr.cap.reg_mem_types & UCS_BIT(test_mem_type))) {
+                    if ((cmd_args->func_am_type == FUNC_AM_ZCOPY) &&
+                        !(iface_p->md_attr.cap.reg_mem_types &
+                          UCS_BIT(test_mem_type))) {
                         fprintf(stderr, "Unsupported memory type %s by "
                                 UCT_TL_RESOURCE_DESC_FMT" on %s MD\n",
                                 ucs_memory_type_names[test_mem_type],
@@ -618,10 +620,6 @@ int main(int argc, char **argv)
     CHKERR_JUMP(NULL == own_iface, "allocate memory for if addr",
                 out_free_dev_addrs);
 
-    /* Get device address */
-    status = uct_iface_get_device_address(if_info.iface, own_dev);
-    CHKERR_JUMP(UCS_OK != status, "get device address", out_free_if_addrs);
-
     if (cmd_args.server_name) {
         oob_sock = client_connect(cmd_args.server_name, cmd_args.server_port);
     } else {
@@ -630,16 +628,19 @@ int main(int argc, char **argv)
     CHKERR_ACTION(oob_sock < 0, "OOB connect",
                   status = UCS_ERR_IO_ERROR; goto out_close_oob_sock);
 
-    res = sendrecv(oob_sock, own_dev, if_info.iface_attr.device_addr_len,
-                   (void **)&peer_dev);
-    CHKERR_ACTION(0 != res, "device exchange",
-                  status = UCS_ERR_NO_MESSAGE; goto out_close_oob_sock);
+    /* Get device address */
+    if (if_info.iface_attr.device_addr_len > 0) {
+        status = uct_iface_get_device_address(if_info.iface, own_dev);
+        CHKERR_JUMP(UCS_OK != status, "get device address", out_free_if_addrs);
 
-    status = (ucs_status_t)uct_iface_is_reachable(if_info.iface, peer_dev, NULL);
-    CHKERR_JUMP(0 == status, "reach the peer", out_close_oob_sock);
+        res = sendrecv(oob_sock, own_dev, if_info.iface_attr.device_addr_len,
+                       (void**)&peer_dev);
+        CHKERR_ACTION(0 != res, "device exchange", status = UCS_ERR_NO_MESSAGE;
+                      goto out_close_oob_sock);
+    }
 
     /* Get interface address */
-    if (if_info.iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+    if (if_info.iface_attr.iface_addr_len > 0) {
         status = uct_iface_get_address(if_info.iface, own_iface);
         CHKERR_JUMP(UCS_OK != status, "get interface address",
                     out_close_oob_sock);
@@ -648,6 +649,10 @@ int main(int argc, char **argv)
                                         (void **)&peer_iface);
         CHKERR_JUMP(0 != status, "ifaces exchange", out_close_oob_sock);
     }
+
+    status = (ucs_status_t)uct_iface_is_reachable(if_info.iface, peer_dev,
+                                                  peer_iface);
+    CHKERR_JUMP(0 == status, "reach the peer", out_close_oob_sock);
 
     ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
     ep_params.iface      = if_info.iface;


### PR DESCRIPTION
## What
Fix `uct_hello_world` to support `intra-node` components.  For example:

```
ucx (master +)]$ ./examples/uct_hello_world -d memory -t sysv
INFO: UCT_HELLO_WORLD AM function = uct_ep_am_short server = (null) port = 13337
Using sysv/memory
Waiting for connection...


----- UCT TEST SUCCESS ----

[callback] uct_ep_am_short sent ABCDEFGHIJKLMNO (16 bytes)

---------------------------


----- UCT TEST SUCCESS ----

[main] uct_ep_am_short sent ABCDEFGHIJKLMNO (16 bytes)

---------------------------
```

```
ucx (master +)]$ ./examples/uct_hello_world -d memory -t sysv -n localhost
INFO: UCT_HELLO_WORLD AM function = uct_ep_am_short server = localhost port = 13337
Using sysv/memory
```

## Why ?
https://github.com/openucx/ucx/discussions/7551

## How ?
1) Only ZCOPY test needs the UCT MD to support registration.

2) Exchange the iface address before test reachable.

Signed-off-by: Honggang Li <honli@redhat.com>
