### PR TITLE
UCP/CORE/INFO: Allow passing UCS variables through ucp_config_modify()

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -951,6 +951,14 @@ test_ucp_dlopen() {
 		echo "IB module was loaded even though it was disabled"
 		exit 1
 	fi
+
+	# Test module allow-list passed through ucp_config_modify()
+	./test/apps/test_ucp_config -c "UCX_MODULES=^ib,rdmacm" |& tee ucx_config_noib.log
+	if grep -in "component:\s*ib$" ucx_config_noib.log
+	then
+		echo "IB module was loaded even though it was disabled"
+		exit 1
+	fi
 }
 
 test_init_mt() {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -545,6 +545,11 @@ ucs_status_t ucp_config_modify(ucp_config_t *config, const char *name,
         return status;
     }
 
+    status = ucs_global_opts_set_value_modifiable(name, value);
+    if (status != UCS_ERR_NO_ELEM) {
+        return status;
+    }
+
     return ucp_config_cached_key_add(&config->cached_key_list, name, value);
 }
 
@@ -590,8 +595,8 @@ void ucp_apply_uct_config_list(ucp_context_h context, void *config)
     ucs_list_for_each(key_val, &context->cached_key_list, list) {
         status = uct_config_modify(config, key_val->key, key_val->value);
         if (status == UCS_OK) {
-            ucs_debug("apply uct configuration %s=%s",
-                      key_val->key, key_val->value);
+            ucs_debug("apply UCT configuration %s=%s", key_val->key,
+                      key_val->value);
             key_val->used = 1;
         }
     }

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -148,6 +148,8 @@ extern ucs_global_opts_t ucs_global_opts;
 
 void ucs_global_opts_init();
 ucs_status_t ucs_global_opts_set_value(const char *name, const char *value);
+ucs_status_t ucs_global_opts_set_value_modifiable(const char *name,
+                                                  const char *value);
 ucs_status_t ucs_global_opts_get_value(const char *name, char *value,
                                        size_t max);
 ucs_status_t ucs_global_opts_clone(void *dst);

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1557,7 +1557,7 @@ ucs_status_t ucs_config_parser_clone_opts(const void *src, void *dst,
                                     (char*)dst + field->offset,
                                     field->parser.arg);
         if (status != UCS_OK) {
-            ucs_error("Failed to clone the filed '%s': %s", field->name,
+            ucs_error("Failed to clone the field '%s': %s", field->name,
                       ucs_status_string(status));
             return status;
         }

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -18,6 +18,7 @@ endif
 
 noinst_PROGRAMS = \
 	test_ucp_dlopen \
+	test_ucp_config \
 	test_ucs_dlopen \
 	test_link_map \
 	test_dlopen_cfg_print \
@@ -37,6 +38,11 @@ test_ucp_dlopen_CPPFLAGS = $(BASE_CPPFLAGS) \
                            -DLIB_PATH=$(abs_top_builddir)/src/ucp/$(objdir)/libucp.so
 test_ucp_dlopen_CFLAGS   = $(BASE_CFLAGS)
 test_ucp_dlopen_LDADD    = -ldl
+
+test_ucp_config_SOURCES  = test_ucp_config.c
+test_ucp_config_CPPFLAGS = $(BASE_CPPFLAGS)
+test_ucp_config_CFLAGS   = $(BASE_CFLAGS)
+test_ucp_config_LDADD    = $(top_builddir)/src/ucp/libucp.la
 
 test_memtrack_limit_SOURCES  = test_memtrack_limit.c
 test_memtrack_limit_CPPFLAGS = $(BASE_CPPFLAGS)

--- a/test/apps/test_ucp_config.c
+++ b/test/apps/test_ucp_config.c
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2021 NVIDIA CORPORATION & AFFILIATES.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <getopt.h>
+#include <string.h>
+
+#include <ucp/api/ucp.h>
+#include <ucs/config/parser.h>
+#include <ucs/config/global_opts.h>
+
+
+static void apply_config_param(char *str, ucp_config_t *config)
+{
+    const char *config_param_key = strtok(str, "=");
+    const char *config_param_val = strtok(NULL, "");
+    ucs_status_t status;
+
+    if ((config_param_key == NULL) || (config_param_val == NULL)) {
+        fprintf(stderr, "incorrect configuration parameter: %s\n", str);
+        return;
+    }
+
+    status = ucp_config_modify(config, config_param_key, config_param_val);
+    if (status != UCS_OK) {
+        fprintf(stderr, "ucp_config_modify(%s) failed: %s\n", str,
+                ucs_status_string(status));
+    }
+}
+
+int main(int argc, char **argv)
+{
+    ucp_config_t *config;
+    ucp_params_t params;
+    ucp_context_h context;
+    ucp_worker_params_t worker_params;
+    ucp_worker_h worker;
+    ucs_status_t status;
+    int c, ret;
+
+    status = ucp_config_read(NULL, NULL, &config);
+    if (status != UCS_OK) {
+        fprintf(stderr, "ucp_config_read() failed: %s\n",
+                ucs_status_string(status));
+        ret = -1;
+        goto out;
+    }
+
+    while ((c = getopt(argc, argv, "c:h")) != -1) {
+        switch (c) {
+        case 'c':
+            apply_config_param(optarg, config);
+            break;
+        case 'h':
+        default:
+            printf("usage: %s\n", argv[0]);
+            printf("\n");
+            printf("supported options are:\n");
+            printf("  -c <config>=<value>\n");
+            printf("  -h print help\n");
+            break;
+        }
+    }
+
+    params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    params.features   = UCP_FEATURE_AM;
+
+    status = ucp_init(&params, config, &context);
+    if (status != UCS_OK) {
+        fprintf(stderr, "ucp_init() failed: %s\n", ucs_status_string(status));
+        ret = -1;
+        goto out_release_config;
+    }
+
+    worker_params.field_mask = 0;
+
+    status = ucp_worker_create(context, &worker_params, &worker);
+    if (status != UCS_OK) {
+        fprintf(stderr, "ucp_worker_create() failed: %s\n",
+                ucs_status_string(status));
+        ret = -1;
+        goto out_cleanup_context;
+    }
+
+    ucp_context_print_info(context, stdout);
+    ucs_config_parser_print_all_opts(stdout, UCS_DEFAULT_ENV_PREFIX,
+                                     UCS_CONFIG_PRINT_CONFIG,
+                                     &ucs_config_global_list);
+    ucp_worker_destroy(worker);
+    ret = 0;
+
+out_cleanup_context:
+    ucp_cleanup(context);
+out_release_config:
+    ucp_config_release(config);
+out:
+    return ret;
+}

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -106,10 +106,12 @@ void test_base::set_config(const std::string& config_str)
     modify_config(name, value, mode);
 }
 
-void test_base::modify_config(const std::string& name, const std::string& value,
+void test_base::modify_config(const std::string& name,
+                              const std::string& value,
                               modify_config_mode_t mode)
 {
-    ucs_status_t status = ucs_global_opts_set_value(name.c_str(), value.c_str());
+    ucs_status_t status = ucs_global_opts_set_value(name.c_str(),
+                                                    value.c_str());
     if (status == UCS_ERR_NO_ELEM) {
         switch (mode) {
         case FAIL_IF_NOT_EXIST:


### PR DESCRIPTION
## What

 Allow passing UCS variables through `ucp_config_modify()` API function.

## Why ?

Some application can use `ucp_config_modify()` to set UCS parameters, e.g. `UCX_MODULES=^cuda` to disabel CUDA modules.

## How ?

1. Add `ucp_apply_ucs_config_list()` which goes over all variables and tries to set them through `ucs_global_opts_set_value()` function.
2. Update `ucx_info` utility to handle the`"-L"` parameter which could be used to specify glob patter as `UCX_MODULES` variable accepts.
3. Add test for filtering B transport by specifying "^ib,rdmacm" through `"-L"` parameter of `ucx_info` utility.