### PR TITLE
UCP/CORE: Fix memory leak when EP_REMOVED/EP_CHECK WIREUP_MSGs are scheduled on EP

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -637,6 +637,18 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
 
     if (req->send.uct.func == ucp_proto_progress_am_single) {
         req->send.proto.comp_cb(req);
+    } else if (req->send.uct.func == ucp_wireup_msg_progress) {
+        /* Sending EP_REMOVED/EP_CHECK WIREUP_MSGs could be scheduled on UCT
+         * endpoint which is not a WIREUP_EP. Other WIREUP MSGs should not be
+         * returned from 'uct_ep_pending_purge()', since they are released by
+         * WIREUP endpoint's purge function
+         */
+        ucs_assertv((req->send.wireup.type == UCP_WIREUP_MSG_EP_REMOVED) ||
+                    (req->send.wireup.type == UCP_WIREUP_MSG_EP_CHECK),
+                    "req %p ep %p: got %s message", req, req->send.ep,
+                    ucp_wireup_msg_str(req->send.wireup.type));
+        ucs_free(req->send.buffer);
+        ucp_request_mem_free(req);
     } else if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
     } else if (req->send.state.uct_comp.func ==

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3177,9 +3177,7 @@ ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
 }
 
 static uct_ep_h ucp_worker_discard_wireup_ep(
-        ucp_ep_h ucp_ep, ucp_wireup_ep_t *wireup_ep, unsigned ep_flush_flags,
-        uct_pending_purge_callback_t purge_cb, void *purge_arg,
-        ucp_send_nbx_callback_t discarded_cb, void *discarded_cb_arg)
+        ucp_ep_h ucp_ep, ucp_wireup_ep_t *wireup_ep, unsigned ep_flush_flags)
 {
     uct_ep_h uct_ep;
     int is_owner;
@@ -3223,9 +3221,7 @@ ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
 
     if (ucp_wireup_ep_test(uct_ep)) {
         uct_ep = ucp_worker_discard_wireup_ep(ucp_ep, ucp_wireup_ep(uct_ep),
-                                              ep_flush_flags, purge_cb,
-                                              purge_arg, discarded_cb,
-                                              discarded_cb_arg);
+                                              ep_flush_flags);
         if (uct_ep == NULL) {
             return UCS_OK;
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -54,7 +54,7 @@ size_t ucp_wireup_msg_pack(void *dest, void *arg)
                         UCS_IOV_COPY_TO_BUF);
 }
 
-static const char* ucp_wireup_msg_str(uint8_t msg_type)
+const char* ucp_wireup_msg_str(uint8_t msg_type)
 {
     switch (msg_type) {
     case UCP_WIREUP_MSG_PRE_REQUEST:

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -108,6 +108,8 @@ double ucp_wireup_amo_score_func(ucp_context_h context,
 
 size_t ucp_wireup_msg_pack(void *dest, void *arg);
 
+const char* ucp_wireup_msg_str(uint8_t msg_type);
+
 ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self);
 
 ucs_status_t


### PR DESCRIPTION
## What

Fix memory leak when `EP_REMOVED`/`EP_CHECK` WIREUP_MSGs are scheduled on UCT EP which is not a WIREUP_EP and error detected on EP.

## Why ?

Found in CI PR testing:
```
==13674== 
==13674== HEAP SUMMARY:
==13674==     in use at exit: 463,062 bytes in 229 blocks
==13674==   total heap usage: 35,318,311 allocs, 25,131,388 frees, 127,066,098,269 bytes allocated
==13674== 
==13674== 280 bytes in 1 blocks are possibly lost in loss record 114 of 136
==13674==    at 0x5622C2B: ucm_malloc_allocated (malloc_hook.c:198)
==13674==    by 0x5623E91: ucm_malloc_impl (malloc_hook.c:234)
==13674==    by 0x5623E91: ucm_malloc (malloc_hook.c:301)
==13674==    by 0x50A14B7: ucs_malloc (memtrack.c:290)
==13674==    by 0x591A9EE: ucp_request_mem_alloc (ucp_request.inl:298)
==13674==    by 0x591A9EE: ucp_wireup_msg_send (wireup.c:234)
==13674==    by 0x591EDF1: ucp_wireup_send_ep_removed (wireup.c:749)
==13674==    by 0x591FA83: ucp_wireup_msg_handler (wireup.c:833)
==13674==    by 0x5BF348D: uct_iface_invoke_am (uct_iface.h:774)
==13674==    by 0x5BF348D: uct_ib_iface_invoke_am_desc (ib_iface.h:365)
==13674==    by 0x5BF348D: uct_ud_ep_process_rx (ud_ep.c:990)
==13674==    by 0x5BFE705: uct_ud_mlx5_iface_poll_rx (ud_mlx5.c:507)
==13674==    by 0x5BFE705: uct_ud_mlx5_iface_async_progress (ud_mlx5.c:580)
==13674==    by 0x5BEC2A2: uct_ud_iface_async_progress (ud_iface.c:254)
==13674==    by 0x5BEC2A2: uct_ud_iface_async_handler (ud_iface.c:265)
==13674==    by 0x5081539: ucs_async_handler_invoke (async.c:251)
==13674==    by 0x5081539: ucs_async_handler_dispatch (async.c:273)
==13674==    by 0x5081539: ucs_async_dispatch_handlers (async.c:305)
==13674==    by 0x5084EFB: ucs_async_thread_ev_handler (thread.c:87)
==13674==    by 0x50AAAA0: ucs_event_set_wait (event_set.c:215)
==13674==    by 0x5085752: ucs_async_thread_func (thread.c:130)
==13674==    by 0x64A6DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==13674==    by 0x781FEAC: clone (in /usr/lib64/libc-2.17.so)
```
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=29133&view=logs&j=2a24149b-54e0-5984-9c93-20e052df9aa1&t=6985259c-90af-5b9c-3e23-537f385bafac
https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/29133/logs/359

## How ?

1. Update `ucp_worker_discard_wireup_ep()` to not require `purge`/`discrded` callback and arguments, since they are not used by the function.
2. Update `ucp_request_send_state_ff()` to handle UCP requests which has `ucp_wireup_msg_progress()` UCT progress function: release memory allocated for the request and the buffer while holding the async lock.