### PR TITLE
UCS/MPOOL: optimize mpool usage

### DIFF
--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -16,6 +16,7 @@
 #include <ucs/sys/math.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/sys.h>
+#include <ucs/arch/cpu.h>
 
 
 static size_t ucs_mpool_elem_total_size(ucs_mpool_data_t *data)
@@ -56,37 +57,54 @@ static void ucs_mpool_chunk_leak_check(ucs_mpool_t *mp, ucs_mpool_chunk_t *chunk
     }
 }
 
-ucs_status_t ucs_mpool_init(ucs_mpool_t *mp, size_t priv_size,
-                            size_t elem_size, size_t align_offset, size_t alignment,
-                            unsigned elems_per_chunk, unsigned max_elems,
-                            ucs_mpool_ops_t *ops, const char *name)
+void ucs_mpool_params_reset(ucs_mpool_params_t *params)
+{
+    params->priv_size       = 0;
+    params->elem_size       = 0;
+    params->align_offset    = 0;
+    params->alignment       = UCS_SYS_CACHE_LINE_SIZE;
+    params->elems_per_chunk = 128;
+    params->max_chunk_size  = 128 * UCS_MBYTE;
+    params->max_elems       = UINT_MAX;
+    params->grow_factor     = 1.0;
+    params->ops             = NULL;
+    params->name            = "";
+}
+
+ucs_status_t ucs_mpool_init(const ucs_mpool_params_t *params, ucs_mpool_t *mp)
 {
     /* Check input values */
-    if ((elem_size == 0) || (align_offset > elem_size) ||
-        (alignment == 0) || !ucs_is_pow2(alignment) ||
-        (elems_per_chunk == 0) || (max_elems < elems_per_chunk) ||
-        !ops || !ops->chunk_alloc || !ops->chunk_release)
+    if ((params->elem_size == 0) ||
+        (params->align_offset > params->elem_size) ||
+        (params->alignment == 0) || !ucs_is_pow2(params->alignment) ||
+        (params->elems_per_chunk == 0) ||
+        (params->max_elems < params->elems_per_chunk) ||
+        (params->ops == NULL) ||
+        (!params->ops->chunk_alloc || !params->ops->chunk_release) ||
+        (params->grow_factor < 1))
     {
         ucs_error("Invalid memory pool parameter(s)");
         return UCS_ERR_INVALID_PARAM;
     }
 
-    mp->data = ucs_malloc(sizeof(*mp->data) + priv_size, "mpool_data");
+    mp->data = ucs_malloc(sizeof(*mp->data) + params->priv_size, "mpool_data");
     if (mp->data == NULL) {
         ucs_error("Failed to allocate memory pool slow-path area");
         return UCS_ERR_NO_MEMORY;
     }
 
     mp->freelist              = NULL;
-    mp->data->elem_size       = sizeof(ucs_mpool_elem_t) + elem_size;
-    mp->data->alignment       = alignment;
-    mp->data->align_offset    = sizeof(ucs_mpool_elem_t) + align_offset;
-    mp->data->elems_per_chunk = elems_per_chunk;
-    mp->data->quota           = max_elems;
+    mp->data->elem_size       = sizeof(ucs_mpool_elem_t) + params->elem_size;
+    mp->data->grow_factor     = params->grow_factor;
+    mp->data->max_chunk_size  = params->max_chunk_size;
+    mp->data->alignment       = params->alignment;
+    mp->data->align_offset    = sizeof(ucs_mpool_elem_t) + params->align_offset;
+    mp->data->elems_per_chunk = params->elems_per_chunk;
+    mp->data->quota           = params->max_elems;
     mp->data->tail            = NULL;
     mp->data->chunks          = NULL;
-    mp->data->ops             = ops;
-    mp->data->name            = ucs_strdup(name, "mpool_data_name");
+    mp->data->ops             = params->ops;
+    mp->data->name            = ucs_strdup(params->name, "mpool_data_name");
 
     if (mp->data->name == NULL) {
         ucs_error("Failed to allocate memory pool data name");
@@ -96,7 +114,7 @@ ucs_status_t ucs_mpool_init(ucs_mpool_t *mp, size_t priv_size,
     VALGRIND_CREATE_MEMPOOL(mp, 0, 0);
 
     ucs_debug("mpool %s: align %zu, maxelems %u, elemsize %zu",
-              ucs_mpool_name(mp), mp->data->alignment, max_elems,
+              ucs_mpool_name(mp), mp->data->alignment, params->max_elems,
               mp->data->elem_size);
     return UCS_OK;
 
@@ -192,6 +210,12 @@ static void *ucs_mpool_chunk_elems(ucs_mpool_t *mp, ucs_mpool_chunk_t *chunk)
     return UCS_PTR_BYTE_OFFSET(chunk + 1, chunk_padding);
 }
 
+static size_t ucs_mpool_chunk_size(ucs_mpool_t *mp, unsigned num_elems)
+{
+    return sizeof(ucs_mpool_chunk_t) + mp->data->alignment +
+           (num_elems * ucs_mpool_elem_total_size(mp->data));
+}
+
 unsigned ucs_mpool_num_elems_per_chunk(ucs_mpool_t *mp,
                                        ucs_mpool_chunk_t *chunk,
                                        size_t chunk_size)
@@ -213,14 +237,16 @@ void ucs_mpool_grow(ucs_mpool_t *mp, unsigned num_elems)
     ucs_mpool_elem_t *elem;
     ucs_status_t status;
     unsigned i;
+    unsigned allocated_num_elems;
     void *ptr;
 
     if (data->quota == 0) {
         return;
     }
 
-    chunk_size = sizeof(ucs_mpool_chunk_t) + data->alignment +
-                 (num_elems * ucs_mpool_elem_total_size(data));
+    allocated_num_elems = ucs_min(data->quota, num_elems);
+    chunk_size          = ucs_mpool_chunk_size(mp, allocated_num_elems);
+    chunk_size          = ucs_min(chunk_size, data->max_chunk_size);
     status = data->ops->chunk_alloc(mp, &chunk_size, &ptr);
     if (status != UCS_OK) {
         ucs_error("Failed to allocate memory pool (name=%s) chunk: %s",
@@ -265,11 +291,18 @@ void ucs_mpool_grow(ucs_mpool_t *mp, unsigned num_elems)
 void *ucs_mpool_get_grow(ucs_mpool_t *mp)
 {
     ucs_mpool_data_t *data = mp->data;
+    unsigned num_elems;
 
     ucs_mpool_grow(mp, data->elems_per_chunk);
     if (mp->freelist == NULL) {
         return NULL;
     }
+
+    /* Calculate num of elems for next growing */
+    ucs_assert(data->chunks != NULL);
+    num_elems             = ucs_min(data->elems_per_chunk,
+                                    data->chunks->num_elems);
+    data->elems_per_chunk = (num_elems * data->grow_factor) + 0.5;
 
     return ucs_mpool_get(mp);
 }

--- a/src/ucs/datastruct/mpool_set.c
+++ b/src/ucs/datastruct/mpool_set.c
@@ -42,6 +42,7 @@ ucs_mpool_set_init(ucs_mpool_set_t *mp_set, size_t *sizes, unsigned sizes_count,
     size_t size;
     ucs_mpool_t *mpools;
     ucs_status_t status;
+    ucs_mpool_params_t mp_params;
 
     if (sizes_count == 0) {
         ucs_error("creation of empty mpool_set is not allowed");
@@ -93,9 +94,17 @@ ucs_mpool_set_init(ucs_mpool_set_t *mp_set, size_t *sizes, unsigned sizes_count,
     ucs_for_each_bit(size_log2, mp_set->bitmap) {
         map_idx = max_idx - size_log2;
         size    = (map_idx == 0) ? max_mp_entry_size : UCS_BIT(size_log2);
-        status  = ucs_mpool_init(&mpools[mps_idx], priv_size,
-                                 size + priv_elem_size, align_offset, alignment,
-                                 elems_per_chunk, max_elems, ops, name);
+
+        ucs_mpool_params_reset(&mp_params);
+        mp_params.priv_size       = priv_size;
+        mp_params.elem_size       = size + priv_elem_size;
+        mp_params.align_offset    = align_offset;
+        mp_params.alignment       = alignment;
+        mp_params.elems_per_chunk = elems_per_chunk;
+        mp_params.max_elems       = max_elems;
+        mp_params.ops             = ops;
+        mp_params.name            = name;
+        status  = ucs_mpool_init(&mp_params, &mpools[mps_idx]);
         if (status != UCS_OK) {
             goto err;
         }

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -1149,6 +1149,7 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     ucs_status_t status;
     size_t mp_obj_size, mp_align;
     int ret;
+    ucs_mpool_params_t mp_params;
 
     if (params->region_struct_size < sizeof(ucs_rcache_region_t)) {
         status = UCS_ERR_INVALID_PARAM;
@@ -1203,8 +1204,14 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     mp_obj_size = ucs_max(mp_obj_size, sizeof(ucs_rcache_comp_entry_t));
 
     mp_align    = ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN);
-    status      = ucs_mpool_init(&self->mp, 0, mp_obj_size, 0, mp_align, 1024,
-                                 UINT_MAX, &ucs_rcache_mp_ops, "rcache_mp");
+
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = mp_obj_size;
+    mp_params.alignment       = mp_align;
+    mp_params.elems_per_chunk = 1024;
+    mp_params.ops             = &ucs_rcache_mp_ops;
+    mp_params.name            = "rcache_mp";
+    status = ucs_mpool_init(&mp_params, &self->mp);
     if (status != UCS_OK) {
         goto err_cleanup_pgtable;
     }

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -869,6 +869,15 @@ int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
     return addr_ns->sys_ns == my_addr.sys_ns;
 }
 
+void uct_iface_mpool_config_copy(ucs_mpool_params_t *mp_params,
+                                 const uct_iface_mpool_config_t *cfg)
+{
+      mp_params->max_elems       = cfg->max_bufs;
+      mp_params->elems_per_chunk = cfg->bufs_grow;
+      mp_params->max_chunk_size  = cfg->max_chunk_size;
+      mp_params->grow_factor     = cfg->grow_factor;
+}
+
 void uct_tl_register(uct_component_t *component, uct_tl_t *tl)
 {
     ucs_list_add_tail(&ucs_config_global_list, &tl->config.list);

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -499,23 +499,40 @@ struct uct_iface_config {
  */
 typedef struct uct_iface_mpool_config {
     unsigned          max_bufs;  /* Upper limit to number of buffers */
-    unsigned          bufs_grow; /* How many buffers (approx.) are allocated every time */
+    unsigned          bufs_grow; /* How many buffers (approx.) are allocated 1st time */
+    size_t            max_chunk_size; /* Maximal chunk size */
+    double            grow_factor; /* Increase each new allocated chunk by this factor */
 } uct_iface_mpool_config_t;
 
 
 /**
  * Define configuration fields for memory pool parameters.
  */
-#define UCT_IFACE_MPOOL_CONFIG_FIELDS(_prefix, _dfl_max, _dfl_grow, _mp_name, _offset, _desc) \
+#define UCT_IFACE_MPOOL_CONFIG_FIELDS(_prefix, _dfl_max, _dfl_grow, \
+                                      _dfl_max_chunk_size, _dfl_grow_factor, \
+                                      _mp_name, _offset, _desc) \
     {_prefix "MAX_BUFS", UCS_PP_QUOTE(_dfl_max), \
      "Maximal number of " _mp_name " buffers for the interface. -1 is infinite." \
      _desc, \
      (_offset) + ucs_offsetof(uct_iface_mpool_config_t, max_bufs), UCS_CONFIG_TYPE_INT}, \
     \
     {_prefix "BUFS_GROW", UCS_PP_QUOTE(_dfl_grow), \
-     "How much buffers are added every time the " _mp_name " memory pool grows.\n" \
+     "The initial number of buffers in " _mp_name " memory pool.\n" \
      "0 means the value is chosen by the transport.", \
-     (_offset) + ucs_offsetof(uct_iface_mpool_config_t, bufs_grow), UCS_CONFIG_TYPE_UINT}
+     (_offset) + ucs_offsetof(uct_iface_mpool_config_t, bufs_grow), UCS_CONFIG_TYPE_UINT}, \
+    \
+    {_prefix "MAX_CHUNK_SIZE", UCS_PP_QUOTE(_dfl_max_chunk_size), \
+     "Maximal chunk size for " _mp_name " memory pool.\n", \
+     (_offset) + ucs_offsetof(uct_iface_mpool_config_t, max_chunk_size), UCS_CONFIG_TYPE_MEMUNITS}, \
+    \
+    {_prefix "GROW_FACTOR", UCS_PP_QUOTE(_dfl_grow_factor), \
+     "Growth factor for new chunks in " _mp_name ". Each time a new chunk is allocated,\n" \
+     "its size is the multiple of the previous chunk size by this number.",\
+     (_offset) + ucs_offsetof(uct_iface_mpool_config_t, grow_factor), UCS_CONFIG_TYPE_DOUBLE}
+
+
+void uct_iface_mpool_config_copy(ucs_mpool_params_t *mp_params,
+                                 const uct_iface_mpool_config_t *cfg);
 
 
 /**

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -515,14 +515,21 @@ ucs_status_t uct_iface_mpool_init(uct_base_iface_t *iface, ucs_mpool_t *mp,
                                   uct_iface_mpool_init_obj_cb_t init_obj_cb,
                                   const char *name)
 {
-    unsigned elems_per_chunk;
     ucs_status_t status;
+    ucs_mpool_params_t mp_params;
 
-    elems_per_chunk = (config->bufs_grow != 0) ? config->bufs_grow : grow;
-    status = ucs_mpool_init(mp, sizeof(uct_iface_mp_priv_t),
-                            elem_size, align_offset, alignment,
-                            elems_per_chunk, config->max_bufs,
-                            &uct_iface_mpool_ops, name);
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, config);
+    mp_params.elems_per_chunk = (config->bufs_grow != 0) ?
+                                config->bufs_grow : grow;
+    mp_params.priv_size       = sizeof(uct_iface_mp_priv_t);
+    mp_params.elem_size       = elem_size;
+    mp_params.align_offset    = align_offset;
+    mp_params.alignment       = alignment;
+    mp_params.ops             = &uct_iface_mpool_ops;
+    mp_params.name            = name;
+    /* Create memory pool of bounce buffers */
+    status = ucs_mpool_init(&mp_params, mp);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -98,7 +98,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "Number of SG entries to reserve in the send WQE.",
    ucs_offsetof(uct_ib_iface_config_t, tx.min_sge), UCS_CONFIG_TYPE_UINT},
 
-  UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 1024, "send",
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 1024, 128m, 1.0, "send",
                                 ucs_offsetof(uct_ib_iface_config_t, tx.mp),
       "\nAttention: Setting this param with value != -1 is a dangerous thing\n"
       "in RC/DC and could cause deadlock or performance degradation."),
@@ -121,7 +121,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "size than requested with the same hardware resources, it will be used instead.",
    ucs_offsetof(uct_ib_iface_config_t, inl[UCT_IB_DIR_RX]), UCS_CONFIG_TYPE_MEMUNITS},
 
-  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 0, "receive",
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 0, 128m, 1.0, "receive",
                                 ucs_offsetof(uct_ib_iface_config_t, rx.mp), ""),
 
   {"ADDR_TYPE", "auto",

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -214,6 +214,7 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
                            const uct_iface_config_t *tl_config)
 {
     ucs_status_t status;
+    ucs_mpool_params_t mp_params;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_ipc_iface_ops, 
                               &uct_base_iface_internal_ops,
@@ -221,15 +222,13 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
                               tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_IPC_TL_NAME));
 
-    status = ucs_mpool_init(&self->signal_pool,
-                            0,
-                            sizeof(uct_rocm_ipc_signal_desc_t),
-                            0,
-                            UCS_SYS_CACHE_LINE_SIZE,
-                            128,
-                            1024,
-                            &uct_rocm_ipc_signal_desc_mpool_ops,
-                            "ROCM_IPC signal objects");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = sizeof(uct_rocm_ipc_signal_desc_t);
+    mp_params.elems_per_chunk = 128;
+    mp_params.max_elems       = 1024;
+    mp_params.ops             = &uct_rocm_ipc_signal_desc_mpool_ops;
+    mp_params.name            = "ROCM_IPC signal objects";
+    status = ucs_mpool_init(&mp_params, &self->signal_pool);
     if (status != UCS_OK) {
         ucs_error("rocm/ipc signal mpool creation failed");
         return status;

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -44,7 +44,7 @@ ucs_config_field_t uct_mm_iface_config_table[] = {
      "This value refers to the percentage of the FIFO size. (must be >= 0 and < 1).",
      ucs_offsetof(uct_mm_iface_config_t, release_fifo_factor), UCS_CONFIG_TYPE_DOUBLE},
 
-    UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 512, "receive",
+    UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 512, 128m, 1.0, "receive",
                                   ucs_offsetof(uct_mm_iface_config_t, mp), ""),
 
     {"FIFO_HUGETLB", "no",

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -36,7 +36,8 @@ static ucs_config_field_t uct_sysv_md_config_table[] = {
 };
 
 static ucs_config_field_t uct_sysv_iface_config_table[] = {
-  {"MM_", "", NULL, 0, UCS_CONFIG_TYPE_TABLE(uct_mm_iface_config_table)},
+  {"MM_", "RX_GROW_FACTOR=2.0", NULL, ucs_offsetof(uct_mm_iface_config_t, super),
+   UCS_CONFIG_TYPE_TABLE(uct_mm_iface_config_table)},
 
   {NULL}
 };

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -75,10 +75,10 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
 
   UCT_TCP_SYN_CNT(ucs_offsetof(uct_tcp_iface_config_t, syn_cnt)),
 
-  UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 8, "send",
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("TX_", -1, 8, 128m, 1.0, "send",
                                 ucs_offsetof(uct_tcp_iface_config_t, tx_mpool), ""),
 
-  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 8, "receive",
+  UCT_IFACE_MPOOL_CONFIG_FIELDS("RX_", -1, 8, 128m, 1.0, "receive",
                                 ucs_offsetof(uct_tcp_iface_config_t, rx_mpool), ""),
 
   {"PORT_RANGE", "0",
@@ -607,6 +607,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     uct_tcp_md_t *tcp_md           = ucs_derived_of(md, uct_tcp_md_t);
     ucs_status_t status;
     int i;
+    ucs_mpool_params_t mp_params;
 
     UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_OPEN_MODE,
                     "UCT_IFACE_PARAM_FIELD_OPEN_MODE is not defined");
@@ -705,22 +706,26 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    status = ucs_mpool_init(&self->tx_mpool, 0, self->config.tx_seg_size,
-                            0, UCS_SYS_CACHE_LINE_SIZE,
-                            (config->tx_mpool.bufs_grow == 0) ?
-                            32 : config->tx_mpool.bufs_grow,
-                            config->tx_mpool.max_bufs,
-                            &uct_tcp_mpool_ops, "uct_tcp_iface_tx_buf_mp");
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->tx_mpool);
+    mp_params.elems_per_chunk = (config->tx_mpool.bufs_grow == 0) ?
+                                32 : config->tx_mpool.bufs_grow;
+    mp_params.elem_size       = self->config.tx_seg_size;
+    mp_params.ops             = &uct_tcp_mpool_ops;
+    mp_params.name            = "uct_tcp_iface_tx_buf_mp";
+    status = ucs_mpool_init(&mp_params, &self->tx_mpool);
     if (status != UCS_OK) {
         goto err;
     }
 
-    status = ucs_mpool_init(&self->rx_mpool, 0, self->config.rx_seg_size * 2,
-                            0, UCS_SYS_CACHE_LINE_SIZE,
-                            (config->rx_mpool.bufs_grow == 0) ?
-                            32 : config->rx_mpool.bufs_grow,
-                            config->rx_mpool.max_bufs,
-                            &uct_tcp_mpool_ops, "uct_tcp_iface_rx_buf_mp");
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->rx_mpool);
+    mp_params.elems_per_chunk = (config->rx_mpool.bufs_grow == 0) ?
+                                32 : config->rx_mpool.bufs_grow;
+    mp_params.elem_size       = self->config.rx_seg_size * 2;
+    mp_params.ops             = &uct_tcp_mpool_ops;
+    mp_params.name            = "uct_tcp_iface_rx_buf_mp";
+    status = ucs_mpool_init(&mp_params, &self->rx_mpool);
     if (status != UCS_OK) {
         goto err_cleanup_tx_mpool;
     }

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -71,6 +71,7 @@ UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
 {
     uct_ugni_device_t *dev;
     ucs_status_t status;
+    ucs_mpool_params_t mp_params;
     uct_ugni_iface_config_t *config = ucs_derived_of(tl_config, uct_ugni_iface_config_t);
     unsigned grow =  (config->mpool.bufs_grow == 0) ? 128 : config->mpool.bufs_grow;
 
@@ -97,15 +98,14 @@ UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
     self->outstanding = 0;
     sglib_hashed_uct_ugni_ep_t_init(self->eps);
     ucs_arbiter_init(&self->arbiter);
-    status = ucs_mpool_init(&self->flush_pool,
-                            0,
-                            sizeof(uct_ugni_flush_group_t),
-                            0,                            /* alignment offset */
-                            UCS_SYS_CACHE_LINE_SIZE,      /* alignment */
-                            grow,                         /* grow */
-                            config->mpool.max_bufs,       /* max buffers */
-                            &uct_ugni_flush_mpool_ops,
-                            "UGNI-DESC-ONLY");
+
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->mpool);
+    mp_params.elem_size       = sizeof(uct_ugni_flush_group_t);
+    mp_params.elems_per_chunk = grow;
+    mp_params.ops             = &uct_ugni_flush_mpool_ops;
+    mp_params.name            = "UGNI-DESC-ONLY";
+    status = ucs_mpool_init(&mp_params, &self->flush_pool);
     if (UCS_OK != status) {
         ucs_error("Could not init iface");
         goto clean_cq;

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -19,7 +19,7 @@ static ucs_config_field_t uct_ugni_rdma_iface_config_table[] = {
     { "", "ALLOC=huge,mmap,heap", NULL,
     ucs_offsetof(uct_ugni_rdma_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
-    UCT_IFACE_MPOOL_CONFIG_FIELDS("RDMA", -1, 0, "rdma",
+    UCT_IFACE_MPOOL_CONFIG_FIELDS("RDMA", -1, 0, 128m, 1.0, "rdma",
                                   ucs_offsetof(uct_ugni_rdma_iface_config_t, mpool),
                                   "\nAttention: Setting this param with value != -1 is a dangerous thing\n"
                                   "and could cause deadlock or performance degradation."),
@@ -268,6 +268,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
     ucs_status_t status;
     uct_ugni_device_t *dev = uct_ugni_device_by_name(params->mode.device.dev_name);
     uct_iface_ops_t *ops;
+    ucs_mpool_params_t mp_params;
 
     ops = uct_ugni_rdma_choose_ops_by_device(dev);
     if (NULL == ops) {
@@ -280,43 +281,38 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
     self->config.fma_seg_size  = UCT_UGNI_MAX_FMA;
     self->config.rdma_max_size = UCT_UGNI_MAX_RDMA;
 
-    status = ucs_mpool_init(&self->free_desc,
-                            0,
-                            sizeof(uct_ugni_base_desc_t),
-                            0,                            /* alignment offset */
-                            UCS_SYS_CACHE_LINE_SIZE,      /* alignment */
-                            128,                          /* grow */
-                            config->mpool.max_bufs,       /* max buffers */
-                            &uct_ugni_rdma_desc_mpool_ops,
-                            "UGNI-DESC-ONLY");
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->mpool);
+    mp_params.elem_size       = sizeof(uct_ugni_base_desc_t);
+    mp_params.elems_per_chunk = 128;
+    mp_params.ops             = &uct_ugni_rdma_desc_mpool_ops;
+    mp_params.name            = "UGNI-DESC-ONLY";
+    status = ucs_mpool_init(&mp_params, &self->free_desc);
     if (UCS_OK != status) {
         ucs_error("Mpool creation failed");
         goto exit;
     }
 
-    status = ucs_mpool_init(&self->free_desc_get,
-                            0,
-                            sizeof(uct_ugni_rdma_fetch_desc_t),
-                            0,                            /* alignment offset */
-                            UCS_SYS_CACHE_LINE_SIZE,      /* alignment */
-                            128 ,                         /* grow */
-                            config->mpool.max_bufs,       /* max buffers */
-                            &uct_ugni_rdma_desc_mpool_ops,
-                            "UGNI-GET-DESC-ONLY");
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->mpool);
+    mp_params.elem_size       = sizeof(uct_ugni_rdma_fetch_desc_t);
+    mp_params.elems_per_chunk = 128;
+    mp_params.ops             = &uct_ugni_rdma_desc_mpool_ops;
+    mp_params.name            = "UGNI-GET-DESC-ONLY";
+    status = ucs_mpool_init(&mp_params, &self->free_desc_get);
     if (UCS_OK != status) {
         ucs_error("Mpool creation failed");
         goto clean_desc;
     }
 
-    status = ucs_mpool_init(&self->free_desc_buffer,
-                            0,
-                            sizeof(uct_ugni_base_desc_t) + self->config.fma_seg_size,
-                            sizeof(uct_ugni_base_desc_t), /* alignment offset */
-                            UCS_SYS_CACHE_LINE_SIZE,      /* alignment */
-                            128 ,                         /* grow */
-                            config->mpool.max_bufs,       /* max buffers */
-                            &uct_ugni_rdma_desc_mpool_ops,
-                            "UGNI-DESC-BUFFER");
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->mpool);
+    mp_params.elem_size       = sizeof(uct_ugni_base_desc_t) + self->config.fma_seg_size;
+    mp_params.align_offset    = sizeof(uct_ugni_base_desc_t);
+    mp_params.elems_per_chunk = 128;
+    mp_params.ops             = &uct_ugni_rdma_desc_mpool_ops;
+    mp_params.name            = "UGNI-DESC-BUFFER";
+    status = ucs_mpool_init(&mp_params, &self->free_desc_buffer);
     if (UCS_OK != status) {
         ucs_error("Mpool creation failed");
         goto clean_desc_get;

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -22,7 +22,7 @@ static ucs_config_field_t uct_ugni_udt_iface_config_table[] = {
     ucs_offsetof(uct_ugni_iface_config_t, super),
     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
-    UCT_IFACE_MPOOL_CONFIG_FIELDS("UDT", -1, 0, "udt",
+    UCT_IFACE_MPOOL_CONFIG_FIELDS("UDT", -1, 0, 128m, 1.0, "udt",
                                   ucs_offsetof(uct_ugni_iface_config_t, mpool),
                                   "\nAttention: Setting this param with value != -1 is a dangerous thing\n"
                                   "and could cause deadlock or performance degradation."),
@@ -392,6 +392,7 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
     uct_ugni_udt_desc_t *desc;
     gni_return_t ugni_rc;
     int rc;
+    ucs_mpool_params_t mp_params;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params,
                               &uct_ugni_udt_iface_ops,
@@ -408,15 +409,14 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
         goto exit;
     }
 
-    status = ucs_mpool_init(&self->free_desc,
-                            0,
-                            uct_ugni_udt_get_diff(self) + self->config.udt_seg_size * 2,
-                            uct_ugni_udt_get_diff(self),
-                            UCS_SYS_CACHE_LINE_SIZE,      /* alignment */
-                            128,                          /* grow */
-                            config->mpool.max_bufs,       /* max buffers */
-                            &uct_ugni_udt_desc_mpool_ops,
-                            "UGNI-UDT-DESC");
+    ucs_mpool_params_reset(&mp_params);
+    uct_iface_mpool_config_copy(&mp_params, &config->mpool);
+    mp_params.elem_size       = uct_ugni_udt_get_diff(self) + self->config.udt_seg_size * 2;
+    mp_params.align_offset    = uct_ugni_udt_get_diff(self);
+    mp_params.elems_per_chunk = 128;
+    mp_params.ops             = &uct_ugni_udt_desc_mpool_ops;
+    mp_params.name            = "UGNI-UDT-DESC";
+    status = ucs_mpool_init(&mp_params, &self->free_desc);
 
     if (UCS_OK != status) {
         ucs_error("Mpool creation failed");

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -766,7 +766,8 @@ void test_ucp_stream_many2one::do_send_worker_poll_test(ucp_datatype_t dt)
 
 void test_ucp_stream_many2one::do_send_recv_test(ucp_datatype_t dt)
 {
-    const size_t                                       niter = 2018;
+    /* Limit rx buffer memory consumption */
+    const size_t                                       niter = 1000;
     std::vector<size_t>                                roffsets(m_nsenders, 0);
     std::vector<ucp::data_type_desc_t>                 dt_rdescs(m_nsenders);
     std::vector<std::pair<size_t, request_wrapper_t> > rreqs;

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -84,6 +84,7 @@ size_t test_mpool::leak_count;
 UCS_TEST_F(test_mpool, no_allocs) {
     ucs_mpool_t mp;
     ucs_status_t status;
+    ucs_mpool_params_t mp_params;
 
     ucs_mpool_ops_t ops = {
        ucs_mpool_chunk_malloc,
@@ -93,8 +94,15 @@ UCS_TEST_F(test_mpool, no_allocs) {
        NULL
     };
 
-    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                            6, 18, &ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 6;
+    mp_params.max_elems       = 18;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    status = ucs_mpool_init(&mp_params, &mp);
     ASSERT_UCS_OK(status);
     ucs_mpool_cleanup(&mp, 1);
 }
@@ -104,9 +112,17 @@ UCS_TEST_F(test_mpool, wrong_ops) {
     ucs_status_t status;
     ucs_mpool_ops_t ops = { 0 };
     scoped_log_handler log_handler(mpool_log_handler);
+    ucs_mpool_params_t mp_params;
 
-    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                            6, 18, &ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 6;
+    mp_params.max_elems       = 18;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    status = ucs_mpool_init(&mp_params, &mp);
     EXPECT_TRUE(status == UCS_ERR_INVALID_PARAM);
 }
 
@@ -121,7 +137,16 @@ UCS_TEST_F(test_mpool, basic) {
        NULL,
        NULL
     };
+    ucs_mpool_params_t mp_params;
 
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 6;
+    mp_params.max_elems       = 18;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
     push_config();
 
     for (int mpool_fifo = 0; mpool_fifo <= 1; ++mpool_fifo) {
@@ -132,8 +157,7 @@ UCS_TEST_F(test_mpool, basic) {
             continue;
         }
 #endif
-        status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                                6, 18, &ops, "test");
+        status = ucs_mpool_init(&mp_params, &mp);
         ASSERT_UCS_OK(status);
 
         for (unsigned loop = 0; loop < 10; ++loop) {
@@ -170,9 +194,17 @@ UCS_TEST_F(test_mpool, custom_alloc) {
        NULL,
        NULL
     };
+    ucs_mpool_params_t mp_params;
 
-    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                            5, 18, &ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 5;
+    mp_params.max_elems       = 18;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    status = ucs_mpool_init(&mp_params, &mp);
     ASSERT_UCS_OK(status);
 
     void *obj = ucs_mpool_get(&mp);
@@ -194,9 +226,17 @@ UCS_TEST_F(test_mpool, grow) {
        NULL,
        NULL
     };
+    ucs_mpool_params_t mp_params;
 
-    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                            1000, 2000, &ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 1000;
+    mp_params.max_elems       = 2000;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    status = ucs_mpool_init(&mp_params, &mp);
     ASSERT_UCS_OK(status);
 
     ucs_mpool_grow(&mp, 1);
@@ -221,9 +261,16 @@ UCS_TEST_F(test_mpool, infinite) {
        NULL,
        NULL
     };
+    ucs_mpool_params_t mp_params;
 
-    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                            10000, UINT_MAX, &ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 10000;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    status = ucs_mpool_init(&mp_params, &mp);
     ASSERT_UCS_OK(status);
 
     std::queue<void*> q;
@@ -252,9 +299,17 @@ UCS_TEST_F(test_mpool, leak_check) {
         NULL,
         obj_str
     };
+    ucs_mpool_params_t mp_params;
 
-    status = ucs_mpool_init(&mp, 0, header_size + data_size, header_size, align,
-                            6, 18, &ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 6;
+    mp_params.max_elems       = 18;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    status = ucs_mpool_init(&mp_params, &mp);
     ASSERT_UCS_OK(status);
 
     for (int i = 0; i < 5; ++i) {
@@ -270,6 +325,66 @@ UCS_TEST_F(test_mpool, leak_check) {
     EXPECT_EQ(5u, leak_count);
 }
 
+class test_mpool_grow : public test_mpool {
+public:
+    void run_grow_test(double grow_factor,
+                       std::vector<unsigned> &num_elems_per_chunk)
+    {
+        ucs_mpool_ops_t ops = {ucs_mpool_chunk_malloc,
+                               ucs_mpool_chunk_free,
+                               NULL, NULL, NULL};
+        unsigned chunk_num  = num_elems_per_chunk.size();
+        ucs_mpool_chunk_t *chunk;
+        ucs_mpool_params_t mp_params;
+        ucs_mpool_t mp;
+        unsigned i;
+
+        ucs_mpool_params_reset(&mp_params);
+        mp_params.elem_size       = header_size + elem_size;
+        mp_params.align_offset    = header_size;
+        mp_params.alignment       = align;
+        mp_params.elems_per_chunk = num_elems_first_chunk;
+        mp_params.max_elems       = total_num_elems;
+        mp_params.max_chunk_size  = max_chunk_size;
+        mp_params.grow_factor     = grow_factor;
+        mp_params.ops             = &ops;
+        mp_params.name            = "tests";
+        ASSERT_UCS_OK(ucs_mpool_init(&mp_params, &mp));
+        for (i = 0; i < total_num_elems; ++i) {
+            EXPECT_NE(ucs_mpool_get(&mp), nullptr);
+        }
+
+        chunk = mp.data->chunks;
+        EXPECT_NE(chunk, nullptr);
+
+        for (; (chunk != NULL) && (chunk_num > 0);
+             chunk_num--, chunk = chunk->next) {
+            EXPECT_EQ(chunk->num_elems,
+                      num_elems_per_chunk[chunk_num - 1]);
+        }
+
+        EXPECT_EQ(chunk_num, 0);
+        EXPECT_EQ(chunk, nullptr);
+        ucs_mpool_cleanup(&mp, 0);
+    }
+
+private:
+    static const size_t elem_size = 1 * UCS_MBYTE;
+    static const unsigned num_elems_first_chunk = 8;
+    static const unsigned total_num_elems = 25;
+    static const unsigned max_chunk_size = 32 * UCS_MBYTE;
+};
+
+UCS_TEST_F(test_mpool_grow, grow_factor1) {
+    std::vector<unsigned> num_elems_per_chunk = {8, 8, 8, 1};
+    run_grow_test(1.0, num_elems_per_chunk);
+}
+
+UCS_TEST_F(test_mpool_grow, grow_factor2) {
+    std::vector<unsigned> num_elems_per_chunk = {8, 16, 1};
+    run_grow_test(2.0, num_elems_per_chunk);
+}
+
 UCS_TEST_SKIP_COND_F(test_mpool, alloc_4g, RUNNING_ON_VALGRIND) {
     const size_t elem_size         = 32 * UCS_MBYTE;
     const unsigned elems_per_chunk = ucs::limit_buffer_size(4 * UCS_GBYTE) /
@@ -277,10 +392,18 @@ UCS_TEST_SKIP_COND_F(test_mpool, alloc_4g, RUNNING_ON_VALGRIND) {
     ucs_mpool_ops_t mpool_ops = {ucs_mpool_chunk_malloc, ucs_mpool_chunk_free,
                                  NULL, NULL, NULL};
     ucs_mpool_t mp;
+    ucs_mpool_params_t mp_params;
 
-    ucs_status_t status = ucs_mpool_init(&mp, 0, header_size + elem_size,
-                                         header_size, align, elems_per_chunk,
-                                         elems_per_chunk, &mpool_ops, "test");
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + elem_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.max_chunk_size  = 4 * UCS_GBYTE;
+    mp_params.elems_per_chunk = elems_per_chunk;
+    mp_params.max_elems       = elems_per_chunk;
+    mp_params.ops             = &mpool_ops;
+    mp_params.name            = "tests";
+    ucs_status_t status = ucs_mpool_init(&mp_params, &mp);
     ASSERT_UCS_OK(status);
 
     // Allocate objects per one chunk size


### PR DESCRIPTION
## What
The change is to optimize mpool usage i.e. enable growing chunks including:
1).add grow_factor and max_chunk_size in ucs_mpool_data
2).set grow_factor to 1.0, max_chunk_size to 128m in ucs_mpool_params_reset(), hence most mpool use the two values as default
3).add gtest to check elem number in chunks

## Why ?
Mpool uses fixed size chunks, if to allocate big memory, there may be many small chunks. For underlying alloc functions using shmget(), so many chunks may exceed the system limit i.e. /proc/sys/kernel/shmmni (default value is 4096 on linux) and cause failure.

## How ?
This implementation would enlarge chunk size when grow mpool by grow_factor which is put in by users calling ucs_mpool_init(), this parameter can be one meaning using fixed chunk size.
