### PR TITLE
GTEST/COMMON: Throw abort exception from modify_config to change state

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -106,21 +106,6 @@ void test_base::set_config(const std::string& config_str)
     modify_config(name, value, mode);
 }
 
-void test_base::get_config(const std::string& name, std::string& value, size_t max)
-{
-    ucs_status_t status;
-
-    value.resize(max, '\0');
-    status = ucs_global_opts_get_value(name.c_str(),
-                                       const_cast<char*>(value.c_str()),
-                                       max);
-    if (status != UCS_OK) {
-        GTEST_FAIL() << "Invalid UCS configuration for " << name
-                     << ": " << ucs_status_string(status)
-                     << "(" << status << ")";
-    }
-}
-
 void test_base::modify_config(const std::string& name, const std::string& value,
                               modify_config_mode_t mode)
 {
@@ -128,9 +113,9 @@ void test_base::modify_config(const std::string& name, const std::string& value,
     if (status == UCS_ERR_NO_ELEM) {
         switch (mode) {
         case FAIL_IF_NOT_EXIST:
-            GTEST_FAIL() << "Invalid UCS configuration for " << name << " : "
-                         << value << ", error message: "
-                         << ucs_status_string(status) << "(" << status << ")";
+            UCS_TEST_ABORT("Invalid UCS configuration for " << name << " : "
+                    << value << ", error message: "
+                    << ucs_status_string(status) << "(" << status << ")");
         case SETENV_IF_NOT_EXIST:
             m_env_stack.push_back(new scoped_setenv(("UCX_" + name).c_str(),
                                                     value.c_str()));
@@ -317,7 +302,7 @@ void test_base::SetUpProxy() {
         check_skip_test();
         init();
         m_initialized = true;
-        m_state = RUNNING;
+        m_state       = RUNNING;
     } catch (test_skip_exception& e) {
         skipped(e);
     } catch (test_abort_exception&) {

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -46,8 +46,6 @@ public:
     void set_num_threads(unsigned num_threads);
     unsigned num_threads() const;
 
-    void get_config(const std::string& name, std::string& value,
-                            size_t max);
     virtual void set_config(const std::string& config_str = "");
     virtual void modify_config(const std::string& name, const std::string& value,
                                modify_config_mode_t mode = FAIL_IF_NOT_EXIST);


### PR DESCRIPTION
## What

 Throw abort exception from `modify_config()` to change state.

## Why ?

![image](https://user-images.githubusercontent.com/11650339/138553571-ed7be41a-f172-4921-9d1a-56f5cd1e3e36.png)

## How ?

1. Remove `test_base::get_config()`.
2. Update `test_base::modify_config()` to throw an exception instead of invoking `GTEST_FAIL()`.