### PR TITLE
AZP/IO-DEMO: Don't pass CI allow-list type to IO-demo analyzer

### DIFF
--- a/buildlib/pr/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/pr/io_demo/az-stage-io-demo.yaml
@@ -72,7 +72,7 @@ steps:
   timeoutInMinutes: 15
 
 - bash: |
-    python /hpc/noarch/git_projects/hpc-mtt-conf/scripts/iodemo_analyzer.py --allow_list CI,$(System.PullRequest.TargetBranch) -d $(workspace)/${{ parameters.name }} --duration ${{ parameters.duration }} -t 3
+    python /hpc/noarch/git_projects/hpc-mtt-conf/scripts/iodemo_analyzer.py --allow_list $(System.PullRequest.TargetBranch) -d $(workspace)/${{ parameters.name }} --duration ${{ parameters.duration }} -t 3
   displayName: Analyze for ${{ parameters.name }}
   timeoutInMinutes: 1
 


### PR DESCRIPTION
## What

Don't pass CI allow-list type to IO-demo analyzer.

## Why ?

IODEMO CI jobs are running as follows:
```
python /hpc/noarch/git_projects/hpc-mtt-conf/scripts/iodemo_analyzer.py --allow_list CI,master -d drop_29252/am_cx6_dc --duration 600 -t 3
```
So, "timeout waiting for replies" errors are allowed to be caught during CI testing, but they should be reported as error and fail jobs.

## How ?

Remove passing "CI" from `--allow_list` argument.