### PR TITLE
UCT/IB/DEVX: correct using QUEYR_LAG Input Structure

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -551,7 +551,7 @@ static ucs_status_t
 uct_ib_mlx5_devx_query_lag(uct_ib_mlx5_md_t *md, uint8_t *state)
 {
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_lag_out)] = {};
-    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_lag_out)]  = {};
+    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_lag_in)]  = {};
     void *lag;
     int ret;
 


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
It should use [uct_ib_mlx5_query_lag_in_bits ](https://github.com/openucx/ucx/blob/v1.11.2/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h#L537) to fill opcode to query lag state under DEVX cmd.