### PR TITLE
APPS/IO-DEMO: Set connection status to NOT_CONNECTED during disconnection

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -831,7 +831,11 @@ void UcxConnection::disconnect(UcxCallback *callback)
     if (!is_established()) {
         assert(_ucx_status == UCS_INPROGRESS);
         established(UCS_ERR_CANCELED);
+    } else if (_ucx_status == UCS_OK) {
+        _ucx_status = UCS_ERR_NOT_CONNECTED;
     }
+
+    assert(UCS_STATUS_IS_ERR(_ucx_status));
 
     _context.move_connection_to_disconnecting(this);
 


### PR DESCRIPTION
## What

Set connection status to NOT_CONNECTED during disconnection.

## Why ?

To improve logging if validation fails and a connection was already scheduled to be released.

## How ?

1. If a connection was already established and status is not `UCX_OK`, set status to `UCX_ERR_NOT_CONNECTED` during `UcxConnection::disconnect()`.
2. Add assertion to check that status is neither `UCX_INPROGRESS` nor `UCX_OK` at the middle of `UcxConnection::disconnect()`.