### PR TITLE
UCT/SM/SCOPY: Enable common error handling and knem invalidate

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -130,14 +130,20 @@ void ucs_string_buffer_append_flags(ucs_string_buffer_t *strb, uint64_t mask,
     ucs_string_buffer_rtrim(strb, ",|");
 }
 
-void ucs_string_buffer_append_iovec(ucs_string_buffer_t *strb,
-                                    const struct iovec *iov, size_t iovcnt)
+void ucs_string_buffer_append_iov(ucs_string_buffer_t *strb,
+                                  const void *iov, size_t iov_type_size,
+                                  size_t iovcnt,
+                                  ucs_iov_get_length_t get_length_f,
+                                  ucs_iov_get_buffer_t get_buffer_f)
 {
     size_t iov_index;
+    void *iov_elem;
 
     for (iov_index = 0; iov_index < iovcnt; ++iov_index) {
-        ucs_string_buffer_appendf(strb, "%p,%zu|", iov[iov_index].iov_base,
-                                  iov[iov_index].iov_len);
+        iov_elem = UCS_PTR_BYTE_OFFSET(iov, iov_type_size * iov_index);
+        ucs_string_buffer_appendf(strb, "%p,%zu|",
+                                  get_buffer_f(iov_elem),
+                                  get_length_f(iov_elem));
     }
     ucs_string_buffer_rtrim(strb, "|");
 }

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -130,11 +130,10 @@ void ucs_string_buffer_append_flags(ucs_string_buffer_t *strb, uint64_t mask,
     ucs_string_buffer_rtrim(strb, ",|");
 }
 
-void ucs_string_buffer_append_iov(ucs_string_buffer_t *strb,
-                                  const void *iov, size_t iov_type_size,
-                                  size_t iovcnt,
-                                  ucs_iov_get_length_t get_length_f,
-                                  ucs_iov_get_buffer_t get_buffer_f)
+void ucs_string_buffer_append_iov(
+        ucs_string_buffer_t *strb, const void *iov, size_t iov_type_size,
+        size_t iovcnt, ucs_string_buffer_iov_get_length_func_t get_length_f,
+        ucs_string_buffer_iov_get_buffer_func_t get_buffer_f)
 {
     size_t iov_index;
     void *iov_elem;

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -8,6 +8,7 @@
 #define UCS_STRING_BUFFER_H_
 
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/iovec.h>
 #include <ucs/type/status.h>
 #include <ucs/datastruct/array.h>
 #include <sys/uio.h>
@@ -180,12 +181,18 @@ void ucs_string_buffer_append_flags(ucs_string_buffer_t *strb, uint64_t mask,
 /**
  * Append an IO vector representation to the string buffer.
  *
- * @param [inout] strb        String buffer to append to.
- * @param [in]    iov         Pointer to an IO vector.
- * @param [in]    iovcnt      Number of entries in the IO vector.
+ * @param [inout] strb          String buffer to append to.
+ * @param [in]    iov           Pointer to an IO vector.
+ * @param [in]    iov_type_size Size of type of IO vector.
+ * @param [in]    iovcnt        Number of entries in the IO vector.
+ * @param [in]    get_length_f  Function to get length of IO vector element.
+ * @param [in]    get_buffer_f  Function to get buffer of IO vector element.
  */
-void ucs_string_buffer_append_iovec(ucs_string_buffer_t *strb,
-                                    const struct iovec *iov, size_t iovcnt);
+void ucs_string_buffer_append_iov(ucs_string_buffer_t *strb,
+                                  const void *iov, size_t iov_type_size,
+                                  size_t iovcnt,
+                                  ucs_iov_get_length_t get_length_f,
+                                  ucs_iov_get_buffer_t get_buffer_f);
 
 
 /**

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -95,6 +95,18 @@ typedef struct ucs_string_buffer {
 
 
 /**
+ * Type of function to get length of IO vector element.
+ */
+typedef size_t (*ucs_string_buffer_iov_get_length_func_t)(const void *iov);
+
+
+/**
+ * Type of function to get buffer of IO vector element.
+ */
+typedef void* (*ucs_string_buffer_iov_get_buffer_func_t)(const void *iov);
+
+
+/**
  * Initialize a string buffer
  *
  * @param [out] strb   String buffer to initialize.
@@ -188,11 +200,10 @@ void ucs_string_buffer_append_flags(ucs_string_buffer_t *strb, uint64_t mask,
  * @param [in]    get_length_f  Function to get length of IO vector element.
  * @param [in]    get_buffer_f  Function to get buffer of IO vector element.
  */
-void ucs_string_buffer_append_iov(ucs_string_buffer_t *strb,
-                                  const void *iov, size_t iov_type_size,
-                                  size_t iovcnt,
-                                  ucs_iov_get_length_t get_length_f,
-                                  ucs_iov_get_buffer_t get_buffer_f);
+void ucs_string_buffer_append_iov(
+        ucs_string_buffer_t *strb, const void *iov, size_t iov_type_size,
+        size_t iovcnt, ucs_string_buffer_iov_get_length_func_t get_length_f,
+        ucs_string_buffer_iov_get_buffer_func_t get_buffer_f);
 
 
 /**

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -8,7 +8,6 @@
 #define UCS_STRING_BUFFER_H_
 
 #include <ucs/sys/compiler_def.h>
-#include <ucs/sys/iovec.h>
 #include <ucs/type/status.h>
 #include <ucs/datastruct/array.h>
 #include <sys/uio.h>

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -30,6 +30,10 @@ typedef struct ucs_iov_iter {
 } ucs_iov_iter_t;
 
 
+typedef size_t (*ucs_iov_get_length_t)(const void *iov);
+typedef void* (*ucs_iov_get_buffer_t)(const void *iov);
+
+
 /**
  * Copy a data from iovec [buffer] to buffer [iovec].
  *

--- a/src/ucs/sys/iovec.h
+++ b/src/ucs/sys/iovec.h
@@ -30,10 +30,6 @@ typedef struct ucs_iov_iter {
 } ucs_iov_iter_t;
 
 
-typedef size_t (*ucs_iov_get_length_t)(const void *iov);
-typedef void* (*ucs_iov_get_buffer_t)(const void *iov);
-
-
 /**
  * Copy a data from iovec [buffer] to buffer [iovec].
  *

--- a/src/ucs/sys/iovec.inl
+++ b/src/ucs/sys/iovec.inl
@@ -188,6 +188,19 @@ size_t ucs_iovec_get_length(const struct iovec *iov)
 }
 
 /**
+ * Returns the particular IOVEC data buffer.
+ *
+ * @param [in]     iov             Pointer to the IOVEC element.
+ *
+ * @return The IOVEC data buffer.
+ */
+static UCS_F_ALWAYS_INLINE
+void* ucs_iovec_get_buffer(const struct iovec *iov)
+{
+    return iov->iov_base;
+}
+
+/**
  * Calculates the total length of the IOVEC array buffers.
  *
  * @param [in]     iov            Pointer to the array of IOVEC elements.

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -110,9 +110,8 @@ uct_scopy_ep_tx_init(uct_ep_h tl_ep, const uct_iov_t *iov,
 }
 
 void
-uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const ucs_string_buffer_t *arg_strb,
-                      const char *op_name,
-                      const ucs_string_buffer_t *op_ret_strb,
+uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const char *arg_str,
+                      const char *op_name, const char *op_ret_str,
                       int op_errno, size_t iov_type_size,
                       const void *local_iov, size_t local_iov_cnt,
                       const void *remote_iov,
@@ -140,10 +139,9 @@ uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const ucs_string_buffer_t *arg_strb,
                                  get_buffer_f);
 
     ucs_log(log_lvl, "ep %p: %s(%s, {%s}-->{%s}) returned %s: %s", ep,
-            op_name, ucs_string_buffer_cstr(arg_strb),
-            ucs_string_buffer_cstr(&local_iov_str),
-            ucs_string_buffer_cstr(&remote_iov_str),
-            ucs_string_buffer_cstr(op_ret_strb), strerror(op_errno));
+            op_name, arg_str, ucs_string_buffer_cstr(&local_iov_str),
+            ucs_string_buffer_cstr(&remote_iov_str), op_ret_str,
+            strerror(op_errno));
 }
 
 ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -109,6 +109,36 @@ uct_scopy_ep_tx_init(uct_ep_h tl_ep, const uct_iov_t *iov,
     return UCS_INPROGRESS;
 }
 
+void uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, int id, const char *op_name,
+                           ssize_t op_ret, int op_errno,
+                           const struct iovec *local_iov, size_t local_iov_cnt,
+                           const struct iovec *remote_iov)
+{
+    uct_base_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                             uct_base_iface_t);
+    UCS_STRING_BUFFER_ONSTACK(local_iov_str, 256);
+    UCS_STRING_BUFFER_ONSTACK(remote_iov_str, 256);
+    ucs_log_level_t log_lvl;
+    ucs_status_t status;
+
+    status  = uct_iface_handle_ep_err(&iface->super, &ep->super.super,
+                                      UCS_ERR_CONNECTION_RESET);
+    log_lvl = uct_base_iface_failure_log_level(iface, status,
+                                               UCS_ERR_CONNECTION_RESET);
+
+    if ((local_iov != NULL) && (remote_iov != NULL)) {
+        /* Dump IO vector */
+        ucs_string_buffer_append_iovec(&local_iov_str, local_iov,
+                                       local_iov_cnt);
+        ucs_string_buffer_append_iovec(&remote_iov_str, remote_iov, 1);
+    }
+
+    ucs_log(log_lvl, "ep %p: %s(id=%d, {%s}-->{%s}) returned %zd: %s", ep,
+            op_name, id, ucs_string_buffer_cstr(&local_iov_str),
+            ucs_string_buffer_cstr(&remote_iov_str), op_ret,
+            strerror(op_errno));
+}
+
 ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                     size_t iov_cnt, uint64_t remote_addr,
                                     uct_rkey_t rkey, uct_completion_t *comp)

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -109,15 +109,15 @@ uct_scopy_ep_tx_init(uct_ep_h tl_ep, const uct_iov_t *iov,
     return UCS_INPROGRESS;
 }
 
-void uct_scopy_ep_tx_error(uct_scopy_ep_t *ep,
-                           const ucs_string_buffer_t *arg_strb,
-                           const char *op_name,
-                           const ucs_string_buffer_t *op_ret_strb,
-                           int op_errno, size_t iov_type_size,
-                           const void *local_iov, size_t local_iov_cnt,
-                           const void *remote_iov,
-                           ucs_iov_get_length_t get_length_f,
-                           ucs_iov_get_buffer_t get_buffer_f)
+void
+uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const ucs_string_buffer_t *arg_strb,
+                      const char *op_name,
+                      const ucs_string_buffer_t *op_ret_strb,
+                      int op_errno, size_t iov_type_size,
+                      const void *local_iov, size_t local_iov_cnt,
+                      const void *remote_iov,
+                      ucs_string_buffer_iov_get_length_func_t get_length_f,
+                      ucs_string_buffer_iov_get_buffer_func_t get_buffer_f)
 {
     uct_base_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                              uct_base_iface_t);

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -66,9 +66,8 @@ typedef struct uct_scopy_ep {
 UCS_CLASS_DECLARE(uct_scopy_ep_t, const uct_ep_params_t *);
 
 void
-uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const ucs_string_buffer_t *arg_strb,
-                      const char *op_name,
-                      const ucs_string_buffer_t *op_ret_strb,
+uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const char *arg_str,
+                      const char *op_name, const char *op_ret_str,
                       int op_errno, size_t iov_type_size,
                       const void *local_iov, size_t local_iov_cnt,
                       const void *remote_iov,

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -65,15 +65,15 @@ typedef struct uct_scopy_ep {
 
 UCS_CLASS_DECLARE(uct_scopy_ep_t, const uct_ep_params_t *);
 
-void uct_scopy_ep_tx_error(uct_scopy_ep_t *ep,
-                           const ucs_string_buffer_t *arg_strb,
-                           const char *op_name,
-                           const ucs_string_buffer_t *op_ret_strb,
-                           int op_errno, size_t iov_type_size,
-                           const void *local_iov, size_t local_iov_cnt,
-                           const void *remote_iov,
-                           ucs_iov_get_length_t get_length_f,
-                           ucs_iov_get_buffer_t get_buffer_f);
+void
+uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, const ucs_string_buffer_t *arg_strb,
+                      const char *op_name,
+                      const ucs_string_buffer_t *op_ret_strb,
+                      int op_errno, size_t iov_type_size,
+                      const void *local_iov, size_t local_iov_cnt,
+                      const void *remote_iov,
+                      ucs_string_buffer_iov_get_length_func_t get_length_f,
+                      ucs_string_buffer_iov_get_buffer_func_t get_buffer_f);
 
 ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                     size_t iov_cnt, uint64_t remote_addr,

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -65,6 +65,11 @@ typedef struct uct_scopy_ep {
 
 UCS_CLASS_DECLARE(uct_scopy_ep_t, const uct_ep_params_t *);
 
+void uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, int id, const char *op_name,
+                           ssize_t op_ret, int op_errno,
+                           const struct iovec *local_iov, size_t local_iov_cnt,
+                           const struct iovec *remote_iov);
+
 ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                     size_t iov_cnt, uint64_t remote_addr,
                                     uct_rkey_t rkey, uct_completion_t *comp);

--- a/src/uct/sm/scopy/base/scopy_ep.h
+++ b/src/uct/sm/scopy/base/scopy_ep.h
@@ -65,10 +65,15 @@ typedef struct uct_scopy_ep {
 
 UCS_CLASS_DECLARE(uct_scopy_ep_t, const uct_ep_params_t *);
 
-void uct_scopy_ep_tx_error(uct_scopy_ep_t *ep, int id, const char *op_name,
-                           ssize_t op_ret, int op_errno,
-                           const struct iovec *local_iov, size_t local_iov_cnt,
-                           const struct iovec *remote_iov);
+void uct_scopy_ep_tx_error(uct_scopy_ep_t *ep,
+                           const ucs_string_buffer_t *arg_strb,
+                           const char *op_name,
+                           const ucs_string_buffer_t *op_ret_strb,
+                           int op_errno, size_t iov_type_size,
+                           const void *local_iov, size_t local_iov_cnt,
+                           const void *remote_iov,
+                           ucs_iov_get_length_t get_length_f,
+                           ucs_iov_get_buffer_t get_buffer_f);
 
 ucs_status_t uct_scopy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                     size_t iov_cnt, uint64_t remote_addr,

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -77,7 +77,8 @@ void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_att
     iface_attr->cap.flags               = UCT_IFACE_FLAG_GET_ZCOPY |
                                           UCT_IFACE_FLAG_PUT_ZCOPY |
                                           UCT_IFACE_FLAG_PENDING   |
-                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE;
+                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                          UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
     iface_attr->cap.event_flags         = UCT_IFACE_FLAG_EVENT_SEND_COMP |
                                           UCT_IFACE_FLAG_EVENT_RECV      |
                                           UCT_IFACE_FLAG_EVENT_ASYNC_CB;

--- a/src/uct/sm/scopy/cma/cma_ep.c
+++ b/src/uct/sm/scopy/cma/cma_ep.c
@@ -69,12 +69,12 @@ void uct_cma_ep_tx_error(uct_cma_ep_t *ep, uct_scopy_tx_op_t tx_op,
                               ep->remote_pid);
     ucs_string_buffer_appendf(&ret_strb, "ret=%zd", ret);
 
-    uct_scopy_ep_tx_error(&ep->super, &remote_pid_strb,
-                          uct_cma_ep_fn[tx_op].name, &ret_strb, op_errno,
-                          sizeof(struct iovec), (const void*)local_iov,
-                          local_iov_cnt, (const void*)remote_iov,
-                          (ucs_iov_get_length_t)ucs_iovec_get_length,
-                          (ucs_iov_get_buffer_t)ucs_iovec_get_buffer);
+    uct_scopy_ep_tx_error(
+            &ep->super, &remote_pid_strb, uct_cma_ep_fn[tx_op].name, &ret_strb,
+            op_errno, sizeof(struct iovec), (const void*)local_iov,
+            local_iov_cnt, (const void*)remote_iov,
+            (ucs_string_buffer_iov_get_length_func_t)ucs_iovec_get_length,
+            (ucs_string_buffer_iov_get_buffer_func_t)ucs_iovec_get_buffer);
 }
 
 ucs_status_t uct_cma_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,

--- a/src/uct/sm/scopy/cma/cma_ep.c
+++ b/src/uct/sm/scopy/cma/cma_ep.c
@@ -59,8 +59,9 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_ep_t, uct_ep_t, const uct_ep_params_t *);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_ep_t, uct_ep_t);
 
 void uct_cma_ep_tx_error(uct_cma_ep_t *ep, uct_scopy_tx_op_t tx_op,
-                         ssize_t ret, int op_errno, struct iovec *local_iov,
-                         size_t local_iov_cnt, struct iovec *remote_iov)
+                         ssize_t ret, int op_errno,
+                         const struct iovec *local_iov, size_t local_iov_cnt,
+                         const struct iovec *remote_iov)
 {
     UCS_STRING_BUFFER_ONSTACK(remote_pid_strb, 32);
     UCS_STRING_BUFFER_ONSTACK(ret_strb, 32);
@@ -70,9 +71,10 @@ void uct_cma_ep_tx_error(uct_cma_ep_t *ep, uct_scopy_tx_op_t tx_op,
     ucs_string_buffer_appendf(&ret_strb, "ret=%zd", ret);
 
     uct_scopy_ep_tx_error(
-            &ep->super, &remote_pid_strb, uct_cma_ep_fn[tx_op].name, &ret_strb,
-            op_errno, sizeof(struct iovec), (const void*)local_iov,
-            local_iov_cnt, (const void*)remote_iov,
+            &ep->super, ucs_string_buffer_cstr(&remote_pid_strb),
+            uct_cma_ep_fn[tx_op].name, ucs_string_buffer_cstr(&ret_strb),
+            op_errno, sizeof(struct iovec), local_iov, local_iov_cnt,
+            remote_iov,
             (ucs_string_buffer_iov_get_length_func_t)ucs_iovec_get_length,
             (ucs_string_buffer_iov_get_buffer_func_t)ucs_iovec_get_buffer);
 }

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -62,8 +62,7 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
             sizeof(ucs_cma_iface_ext_device_addr_t);
     iface_attr->bandwidth.dedicated = iface->super.super.config.bandwidth;
     iface_attr->bandwidth.shared    = 0;
-    iface_attr->cap.flags          |= UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
-                                      UCT_IFACE_FLAG_EP_CHECK;
+    iface_attr->cap.flags          |= UCT_IFACE_FLAG_EP_CHECK;
 
     return UCS_OK;
 }

--- a/src/uct/sm/scopy/knem/knem_ep.c
+++ b/src/uct/sm/scopy/knem/knem_ep.c
@@ -80,13 +80,12 @@ static void uct_knem_ep_tx_error(uct_ep_h tl_ep, int knem_fd,
     remote_iov.base = (uintptr_t)remote_addr;
     remote_iov.len  = remote_lenth;
 
-    uct_scopy_ep_tx_error(&knem_ep->super, &knem_fd_strb,
-                          uct_knem_ep_tx_op_str[tx_op], &ret_strb, errno,
-                          sizeof(struct knem_cmd_param_iovec),
-                          (const void*)local_iov, local_iov_cnt,
-                          (const void*)&remote_iov,
-                          (ucs_iov_get_length_t)uct_knem_iovec_get_length,
-                          (ucs_iov_get_buffer_t)uct_knem_iovec_get_buffer);
+    uct_scopy_ep_tx_error(
+            &knem_ep->super, &knem_fd_strb, uct_knem_ep_tx_op_str[tx_op],
+            &ret_strb, errno, sizeof(struct knem_cmd_param_iovec),
+            (const void*)local_iov, local_iov_cnt, (const void*)&remote_iov,
+            (ucs_string_buffer_iov_get_length_func_t)uct_knem_iovec_get_length,
+            (ucs_string_buffer_iov_get_buffer_func_t)uct_knem_iovec_get_buffer);
 }
 
 ucs_status_t uct_knem_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,

--- a/src/uct/sm/scopy/knem/knem_ep.c
+++ b/src/uct/sm/scopy/knem/knem_ep.c
@@ -51,19 +51,56 @@ void uct_knem_iovec_set_buffer(struct knem_cmd_param_iovec *iov, void *buffer)
     iov->base = (uintptr_t)buffer;
 }
 
+static size_t uct_knem_iovec_get_length(struct knem_cmd_param_iovec *iov)
+{
+    return iov->len;
+}
+
+static void* uct_knem_iovec_get_buffer(struct knem_cmd_param_iovec *iov)
+{
+    return (void*)(uintptr_t)iov->base;
+}
+
+static void uct_knem_ep_tx_error(uct_ep_h tl_ep, int knem_fd,
+                                 uct_scopy_tx_op_t tx_op, int ret,
+                                 int icopy_status, int op_errno,
+                                 struct knem_cmd_param_iovec *local_iov,
+                                 size_t local_iov_cnt, uint64_t remote_addr,
+                                 size_t remote_lenth)
+{
+    uct_knem_ep_t *knem_ep = ucs_derived_of(tl_ep, uct_knem_ep_t);
+    UCS_STRING_BUFFER_ONSTACK(knem_fd_strb, 32);
+    UCS_STRING_BUFFER_ONSTACK(ret_strb, 64);
+    struct knem_cmd_param_iovec remote_iov;
+
+    ucs_string_buffer_appendf(&knem_fd_strb, "fd=%d", knem_fd);
+    ucs_string_buffer_appendf(&ret_strb, "ret=%d icopy_status=%d", ret,
+                              icopy_status);
+
+    remote_iov.base = (uintptr_t)remote_addr;
+    remote_iov.len  = remote_lenth;
+
+    uct_scopy_ep_tx_error(&knem_ep->super, &knem_fd_strb,
+                          uct_knem_ep_tx_op_str[tx_op], &ret_strb, errno,
+                          sizeof(struct knem_cmd_param_iovec),
+                          (const void*)local_iov, local_iov_cnt,
+                          (const void*)&remote_iov,
+                          (ucs_iov_get_length_t)uct_knem_iovec_get_length,
+                          (ucs_iov_get_buffer_t)uct_knem_iovec_get_buffer);
+}
+
 ucs_status_t uct_knem_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt,
                             ucs_iov_iter_t *iov_iter, size_t *length_p,
                             uint64_t remote_addr, uct_rkey_t rkey,
                             uct_scopy_tx_op_t tx_op)
 {
-    uct_knem_ep_t *knem_ep;
     uct_knem_iface_t *knem_iface = ucs_derived_of(tl_ep->iface,
                                                   uct_knem_iface_t);
     int knem_fd                  = knem_iface->knem_md->knem_fd;
     uct_knem_key_t *key          = (uct_knem_key_t*)rkey;
     size_t local_iov_cnt         = UCT_SM_MAX_IOV;
     struct knem_cmd_param_iovec local_iov[UCT_SM_MAX_IOV];
-    size_t UCS_V_UNUSED total_iov_length;
+    size_t total_iov_length;
     struct knem_cmd_inline_copy icopy;
     int i, ret;
 
@@ -93,10 +130,9 @@ ucs_status_t uct_knem_ep_tx(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iov_cnt
     ret = ioctl(knem_fd, KNEM_CMD_INLINE_COPY, &icopy);
     if (ucs_unlikely((ret < 0) ||
                      (icopy.current_status != KNEM_STATUS_SUCCESS))) {
-        knem_ep = ucs_derived_of(tl_ep, uct_knem_ep_t);
-        uct_scopy_ep_tx_error(&knem_ep->super, knem_fd,
-                              uct_knem_ep_tx_op_str[tx_op], ret, errno, NULL,
-                              0, NULL);
+        uct_knem_ep_tx_error(tl_ep, knem_fd, tx_op, ret, icopy.current_status,
+                             errno, local_iov, local_iov_cnt, remote_addr,
+                             total_iov_length);
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -17,6 +17,7 @@
 #include <ucs/sys/sys.h>
 #include <ucm/api/ucm.h>
 #include <ucs/vfs/base/vfs_obj.h>
+#include <uct/base/uct_iface.h>
 
 
 #define UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(_params) \
@@ -42,7 +43,8 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
 
     md_attr->rkey_packed_size     = sizeof(uct_knem_key_t);
     md_attr->cap.flags            = UCT_MD_FLAG_REG |
-                                    UCT_MD_FLAG_NEED_RKEY;
+                                    UCT_MD_FLAG_NEED_RKEY |
+                                    UCT_MD_FLAG_INVALIDATE;
     md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cap.alloc_mem_types  = 0;
     md_attr->cap.access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -113,7 +115,7 @@ static ucs_status_t uct_knem_mem_reg_internal(uct_md_h md, void *address, size_t
     struct knem_cmd_create_region create;
     struct knem_cmd_param_iovec knem_iov[1];
     uct_knem_md_t *knem_md = (uct_knem_md_t *)md;
-    int knem_fd = knem_md->knem_fd;
+    int knem_fd            = knem_md->knem_fd;
 
     ucs_assert_always(knem_fd > -1);
 
@@ -178,6 +180,7 @@ static ucs_status_t uct_knem_mem_dereg_internal(uct_md_h md, uct_knem_key_t *key
     rc = ioctl(knem_fd, KNEM_CMD_DESTROY_REGION, &key->cookie);
     if (rc < 0) {
         ucs_error("KNEM destroy region failed, err = %m");
+        return UCS_ERR_IO_ERROR;
     }
 
     return UCS_OK;
@@ -189,12 +192,19 @@ static ucs_status_t uct_knem_mem_dereg(uct_md_h md,
     uct_knem_key_t *key;
     ucs_status_t status;
 
-    UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(params);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 1);
 
     key    = (uct_knem_key_t *)params->memh;
     status = uct_knem_mem_dereg_internal(md, key);
     if (status == UCS_OK) {
         ucs_free(key);
+    }
+
+    if (UCT_MD_MEM_DEREG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0) &
+        UCT_MD_MEM_DEREG_FLAG_INVALIDATE) {
+        /* suppress coverity false-positive */
+        ucs_assert(params->comp != NULL);
+        uct_invoke_completion(params->comp, UCS_OK);
     }
 
     return status;
@@ -274,6 +284,13 @@ static ucs_status_t uct_knem_mem_rcache_reg(uct_md_h uct_md, void *address,
     return UCS_OK;
 }
 
+static void uct_knem_mem_region_invalidate_cb(void *arg)
+{
+    uct_completion_t *comp = arg;
+
+    uct_invoke_completion(comp, UCS_OK);
+}
+
 static ucs_status_t
 uct_knem_mem_rcache_dereg(uct_md_h uct_md,
                           const uct_md_mem_dereg_params_t *params)
@@ -281,9 +298,15 @@ uct_knem_mem_rcache_dereg(uct_md_h uct_md,
     uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
     uct_knem_rcache_region_t *region;
  
-    UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(params);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 1);
  
     region = uct_knem_rcache_region_from_memh(params->memh);
+    if (UCT_MD_MEM_DEREG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0) &
+        UCT_MD_MEM_DEREG_FLAG_INVALIDATE) {
+        ucs_rcache_region_invalidate(md->rcache, &region->super,
+                                     uct_knem_mem_region_invalidate_cb,
+                                     params->comp);
+    }
 
     ucs_rcache_region_put(md->rcache, &region->super);
     return UCS_OK;

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2338,6 +2338,7 @@ UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_64k,
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rc, "rc_v") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rcx, "rc_x") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ib, "ib") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib, "shm,ib") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, tcp, "tcp") \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, all, "all")
 

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -10,6 +10,8 @@ extern "C" {
 #include <ucs/datastruct/string_buffer.h>
 #include <ucs/datastruct/string_set.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/iovec.h>
+#include <ucs/sys/iovec.inl>
 }
 
 class test_string : public ucs::test {
@@ -257,7 +259,10 @@ UCS_TEST_F(test_string_buffer, append_iovec) {
                                         {(void*)0x1234, 100},
                                         {(void*)0x4567, 200}};
     UCS_STRING_BUFFER_ONSTACK(strb, 128);
-    ucs_string_buffer_append_iovec(&strb, iov, ucs_static_array_size(iov));
+    ucs_string_buffer_append_iov(&strb, iov, sizeof(*iov),
+                                 ucs_static_array_size(iov),
+                                 (ucs_iov_get_length_t)ucs_iovec_get_length,
+                                 (ucs_iov_get_buffer_t)ucs_iovec_get_buffer);
     EXPECT_EQ(std::string("(nil),0|0x1234,100|0x4567,200"),
               ucs_string_buffer_cstr(&strb));
 }

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -259,10 +259,10 @@ UCS_TEST_F(test_string_buffer, append_iovec) {
                                         {(void*)0x1234, 100},
                                         {(void*)0x4567, 200}};
     UCS_STRING_BUFFER_ONSTACK(strb, 128);
-    ucs_string_buffer_append_iov(&strb, iov, sizeof(*iov),
-                                 ucs_static_array_size(iov),
-                                 (ucs_iov_get_length_t)ucs_iovec_get_length,
-                                 (ucs_iov_get_buffer_t)ucs_iovec_get_buffer);
+    ucs_string_buffer_append_iov(
+            &strb, iov, sizeof(*iov), ucs_static_array_size(iov),
+            (ucs_string_buffer_iov_get_length_func_t)ucs_iovec_get_length,
+            (ucs_string_buffer_iov_get_buffer_func_t)ucs_iovec_get_buffer);
     EXPECT_EQ(std::string("(nil),0|0x1234,100|0x4567,200"),
               ucs_string_buffer_cstr(&strb));
 }


### PR DESCRIPTION
## What

1. Enable common EP_CHECK and error handling for SCOPY transports KNEM and CMA.
2. Enable INVALIDATE capability for KNEM.

## Why ?

1. To support EP checking and error handling on KNEM.
2. To support memory handle invalidation.

As the main benefit, it allows using KNEM for error handling scenarios with better performance.

## How ?

1. Move CMA error handling and EP checking to SCOPY common code; reuse SCOPY error handling and EP checking code for KNEM.
2. Use the same as IB to enable memory invalidation for normal and RCACHE cases.