### PR TITLE
UCT/TCP/SOCK: Add loopback support toggle

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -100,22 +100,39 @@ out:
     return status;
 }
 
-int ucs_netif_is_active(const char *if_name)
+static ucs_status_t ucs_netif_get(const char *if_name,
+                                  struct ifreq *ifr)
 {
     ucs_status_t status;
-    struct ifreq ifr;
 
-    status = ucs_netif_ioctl(if_name, SIOCGIFADDR, &ifr);
+    status = ucs_netif_ioctl(if_name, SIOCGIFADDR, ifr);
     if (status != UCS_OK) {
-        return 0;
+        return -1;
     }
 
-    status = ucs_netif_ioctl(if_name, SIOCGIFFLAGS, &ifr);
-    if (status != UCS_OK) {
+    return ucs_netif_ioctl(if_name, SIOCGIFFLAGS, ifr);
+}
+
+int ucs_netif_is_active(const char *if_name)
+{
+    struct ifreq ifr;
+
+    if (ucs_netif_get(if_name, &ifr) != UCS_OK) {
         return 0;
     }
 
     return ucs_netif_flags_is_active(ifr.ifr_flags);
+}
+
+int ucs_netif_is_loopback(const char *if_name)
+{
+    struct ifreq ifr;
+
+    if (ucs_netif_get(if_name, &ifr) != UCS_OK) {
+        return 0;
+    }
+
+    return ifr.ifr_flags & IFF_LOOPBACK;
 }
 
 unsigned ucs_netif_bond_ad_num_ports(const char *bond_name)

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -79,6 +79,16 @@ int ucs_netif_is_active(const char *if_name);
 
 
 /**
+ * Check if the given interface is in loopback.
+ *
+ * @param [in]  if_name      Interface name to check.
+ *
+ * @return 1 if true, otherwise 0
+ */
+int ucs_netif_is_loopback(const char *if_name);
+
+
+/**
  * Get number of active 802.3ad ports for a bond device. If the device is not
  * a bond device, or 802.3ad is not enabled, return 1.
  *

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -357,6 +357,26 @@ UCS_PTR_MAP_DEFINE(tcp_ep, 0);
 
 
 /**
+ * TCP memory domain configuration
+ */
+typedef struct uct_tcp_md_config {
+    uct_md_config_t super;
+    int             lo_enable; /* Enable loopback interface support */
+} uct_tcp_md_config_t;
+
+
+/**
+ * TCP memory domain
+ */
+typedef struct uct_tcp_md {
+    struct uct_md super;
+    struct {
+        int       lo_enable;
+    } config;
+} uct_tcp_md_t;
+
+
+/**
  * TCP interface
  */
 typedef struct uct_tcp_iface {


### PR DESCRIPTION
## What

Add loopback support toggle in TCP MD.

## Why ?

To have a possibility for enabling/disabling LOOPBACK interface support in TCP transport.

## How ?

1. Introduce TCP MD object and its configuration.
2. Add TCP MD configuration for "LOOPBACK_ENABLE" parameter.
2. When querying devices supported by TCP, check whether the device is loopback or not (if it is loopback and loopback support is disabled - don't add such device).