### PR TITLE
UCT/TCP: Don't allow connecting loopback with other devices

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -176,8 +176,17 @@ static int uct_tcp_iface_is_reachable(const uct_iface_h tl_iface,
                                       const uct_device_addr_t *dev_addr,
                                       const uct_iface_addr_t *iface_addr)
 {
+    uct_tcp_iface_t *iface              = ucs_derived_of(tl_iface,
+                                                         uct_tcp_iface_t);
     uct_tcp_device_addr_t *tcp_dev_addr = (uct_tcp_device_addr_t*)dev_addr;
     uct_iface_local_addr_ns_t *local_addr_ns;
+
+    /* Loopback can connect only to loopback */
+    if (!!(tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) !=
+        ucs_sockaddr_is_inaddr_loopback(
+                (const struct sockaddr*)&iface->config.ifaddr)) {
+        return 0;
+    }
 
     if (tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) {
         local_addr_ns = (uct_iface_local_addr_ns_t*)(tcp_dev_addr + 1);


### PR DESCRIPTION
## What

Don't allow connecting loopback with other devices.

## Why ?

1. If `ethtool` isn't configured on a system, TCP is unable to identify BW/latency characteristics. 
2. Let's assume both nodes has the following IP configuration:
```
lo: 127.0.0.1
eth0: 192.168.22.1
```
3. Firstly, TCP client tries to check `lo -> lo` connectivity, it fails reachability check since `boot_id` values are different (it is a part of additional NS information which is packed with `lo`).
4. Then, TCP client tries to check `lo -> eth0` connectivity, it succeeded reachability check since `eth0` address doesn't contain additional NS information.
5. Trying to establish `lo -> eth0` fails, since they are really unreachable.

Fixes #7599

## How ?

1. Always pack NS information for loopback and ordinary addresses.
2. AIf at least one of the interfaces of connection is loopback, check NS information for reachability. 