### PR TITLE
UCT/TCP: Don't allow connecting loopback with other devices [v1.11.x]

### DIFF
--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -176,8 +176,17 @@ static int uct_tcp_iface_is_reachable(const uct_iface_h tl_iface,
                                       const uct_device_addr_t *dev_addr,
                                       const uct_iface_addr_t *iface_addr)
 {
+    uct_tcp_iface_t *iface              = ucs_derived_of(tl_iface,
+                                                         uct_tcp_iface_t);
     uct_tcp_device_addr_t *tcp_dev_addr = (uct_tcp_device_addr_t*)dev_addr;
     uct_iface_local_addr_ns_t *local_addr_ns;
+
+    /* Loopback can connect only to loopback */
+    if (!!(tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) !=
+        ucs_sockaddr_is_inaddr_loopback(
+                (const struct sockaddr*)&iface->config.ifaddr)) {
+        return 0;
+    }
 
     if (tcp_dev_addr->flags & UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK) {
         local_addr_ns = (uct_iface_local_addr_ns_t*)(tcp_dev_addr + 1);


### PR DESCRIPTION
ported #7600 to v1.11.x branch