### PR TITLE
refine msg format to warn the unused cached configurations.

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1999,15 +1999,15 @@ static void ucp_warn_unused_uct_config(ucp_context_h context)
 
     ucs_list_for_each(key_val, &context->cached_key_list, list) {
         if (!key_val->used) {
-            ucs_string_buffer_appendf(&unused_cached_uct_cfg, "%s,",
-                                      key_val->key);
+            ucs_string_buffer_appendf(&unused_cached_uct_cfg, "%s=%s,",
+                                      key_val->key, key_val->value);
             ++num_unused_cached_kv;
         }
     }
 
     if (num_unused_cached_kv > 0) {
         ucs_string_buffer_rtrim(&unused_cached_uct_cfg , ",");
-        ucs_warn("unused cached uct configuration%s: %s",
+        ucs_warn("Invalid configuration%s: %s",
                  (num_unused_cached_kv > 1) ? "s" : "",
                  ucs_string_buffer_cstr(&unused_cached_uct_cfg));
     }


### PR DESCRIPTION
## What
1. refine the message to warn the unused cached confiurations
2. use "key=value" to show the unused cached configurations instead of "key"
