### PR TITLE
UCS/BUILD: Support custom path for binutils dependency

### DIFF
--- a/contrib/configure-prof
+++ b/contrib/configure-prof
@@ -16,7 +16,6 @@ $basedir/../configure \
 	--disable-debug \
 	--disable-assertions \
 	--disable-params-check \
-	--enable-backtrace-detail \
 	--enable-profiling \
 	--enable-frame-pointer \
 	--enable-stats \

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -11,12 +11,13 @@ AUTOMAKE_OPTIONS    = nostdinc # avoid collision with built-in debug.h
 lib_LTLIBRARIES     = libucs.la
 bin_PROGRAMS        =
 
-libucs_la_CPPFLAGS = $(BASE_CPPFLAGS) -DUCX_MODULE_DIR=\"$(moduledir)\" \
+libucs_la_CPPFLAGS = $(BASE_CPPFLAGS) $(BFD_CPPFLAGS) \
+                     -DUCX_MODULE_DIR=\"$(moduledir)\" \
                      -DUCX_CONFIG_DIR=\"$(ucx_config_dir)\"
-libucs_la_CFLAGS   = $(BASE_CFLAGS)
-libucs_la_LDFLAGS  = -ldl $(NUMA_LIBS) -version-info $(SOVERSION)
+libucs_la_CFLAGS   = $(BASE_CFLAGS) $(BFD_CFLAGS)
+libucs_la_LDFLAGS  = -ldl $(NUMA_LIBS) $(BFD_LDFLAGS) -version-info $(SOVERSION)
 libucs_ladir       = $(includedir)/ucs
-libucs_la_LIBADD   = $(LIBM) $(top_builddir)/src/ucm/libucm.la
+libucs_la_LIBADD   = $(LIBM) $(top_builddir)/src/ucm/libucm.la $(BFD_LIBS)
 
 nobase_dist_libucs_la_HEADERS = \
 	arch/aarch64/bitops.h \

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -19,6 +19,7 @@ AM_CPPFLAGS           = \
     -DTEST_LIB_DIR="$(abs_builddir)/.libs"
 AM_CFLAGS             = $(BASE_CFLAGS)
 test_memhooks_SOURCES = test_memhooks.c
+test_memhooks_LDFLAGS = -ldl
 
 
 # A library we use for testing that memory hooks work in libraries loaded


### PR DESCRIPTION
## Why
Allow building UCX with a custom-installed binutils