### PR TITLE
UCP/WORKER: Fix removing element pointing to KA::iter and KA::iter_end

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3165,8 +3165,6 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 
         worker->keepalive.iter_end = worker->keepalive.iter_end->prev;
         ucs_assert(worker->keepalive.iter_end != &ucp_ep_ext_gen(ep)->ep_list);
-    } else {
-        ucp_worker_keeplive_check_in_progress(worker);
     }
 }
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3115,8 +3115,7 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 
     if ((worker->keepalive.iter == &ucp_ep_ext_gen(ep)->ep_list) &&
         (worker->keepalive.iter_end == &ucp_ep_ext_gen(ep)->ep_list)) {
-        /* We are removing the current and last endpoint in the keepalive round
-         */
+        /* Remove the current and last endpoint in the keepalive round */
         ucs_debug("worker %p: removed the keepalive current/stop endpoint %p",
                   worker, ep);
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3081,7 +3081,7 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
 void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 {
     ucp_worker_h worker = ep->worker;
-    ucs_time_t now;
+    ucs_time_t UCS_V_UNUSED now;
 
     ucs_assert(!(ep->flags & UCP_EP_FLAG_INTERNAL));
 


### PR DESCRIPTION
## What

Fix removing element pointing to KA::iter and KA::iter_end

## Why ?

If the iterator and the stop element point to the removed endpoint, the iterator and the stop element should be moved to the previous element and KA round should be completed only if KA is in progress.

## How ?

1. Improve "KA remove EP"-related comments.
2. Reorganize "KA remove EP" code as follows:
```
if ((iter == ep) && (iter_end == ep)) {
    iter = ep->prev;
    iter_end = ep->prev;

    if (lane_map !=0) {
        complete();
    }
} if (iter == ep) {
    lane_map = 0;
    get_next_ep();
} if (iter_end == ep) {
    iter_end = ep->prev;
}
```