### PR TITLE
IODEMO: Fixing linking issue

### DIFF
--- a/test/apps/iodemo/Makefile.am
+++ b/test/apps/iodemo/Makefile.am
@@ -28,6 +28,7 @@ io_demo_CPPFLAGS = $(BASE_CPPFLAGS) $(io_demo_CUDA_CPPFLAGS)
 
 io_demo_LDADD    = \
 	$(top_builddir)/src/ucs/libucs.la \
+	$(top_builddir)/src/uct/libuct.la \
 	$(top_builddir)/src/ucp/libucp.la \
 	$(io_demo_CUDA_LIBS)
 


### PR DESCRIPTION
## What
UCX compilation may fail if installation destination already has older 
revision of the library

## Why
Libtool by default inserts `-rpath <prefix>` to the linking command.
This also means that if `<prefix>` already has UCX libraries installed
from previous build it will use those for linking *instead* of ucx
libraries in the build tree. The problem arises when UCT introduces API
changes. In this case libtool/linker fails to resolve new symbols since
rpath overwrites search path and inserts old revision of the library.
Unfortunately there is no way to remove rpath from the libtool default
flags. Instead we can add path to libuct to make sure that the linker
picks up updated revision of the library from the build tree. Since the
io-demo is always linked to uct through ucp it actually a reasonable
approach to make sure that in tree library used durting compilation.

## How

Explicitly reference UCT as dependency from the build tree.
Anyways the binary is linked to uct and we just make sure that 
correct revision is used.