### PR TITLE
APPS/IODEMO: use write syscall in signal handler instead

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -771,9 +771,10 @@ protected:
     static void signal_terminate_handler(int signo)
     {
         char msg[64];
+        ssize_t ret __attribute__((unused));
 
         snprintf(msg, sizeof(msg), "Run-time signal handling: %d\n", signo);
-        write(STDOUT_FILENO, msg, strlen(msg) + 1);
+        ret = write(STDOUT_FILENO, msg, strlen(msg) + 1);
 
         _status = TERMINATE_SIGNALED;
     }

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -770,7 +770,10 @@ protected:
 
     static void signal_terminate_handler(int signo)
     {
-        LOG << "Run-time signal handling: " << signo;
+        char msg[64];
+
+        snprintf(msg, sizeof(msg), "Run-time signal handling: %d\n", signo);
+        write(STDOUT_FILENO, msg, strlen(msg) + 1);
 
         _status = TERMINATE_SIGNALED;
     }


### PR DESCRIPTION
## What
use write syscall in signal handler instead to print log

## Why ?
LOG requires malloc to print log, if the signal was recevied when malloc/free was being performed, a deadlock would occur.

## How ?
replace LOG of write syscall to print log
