### PR TITLE
JUCX: Always query for listener address.

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpListener.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpListener.java
@@ -27,7 +27,6 @@ public class UcpListener extends UcxNativeStruct implements Closeable {
             throw new UcxException("Connection handler must be set");
         }
         this.connectionHandler = params.connectionHandler;
-        this.address = params.getSockAddr();
         setNativeId(createUcpListener(params, worker.getNativeId()));
     }
 
@@ -35,6 +34,9 @@ public class UcpListener extends UcxNativeStruct implements Closeable {
      * Returns a socket address of this listener.
      */
     public InetSocketAddress getAddress() {
+        if (address == null) {
+            address = queryAddressNative(getNativeId());
+        }
         return address;
     }
 
@@ -45,6 +47,8 @@ public class UcpListener extends UcxNativeStruct implements Closeable {
     }
 
     private native long createUcpListener(UcpListenerParams params, long workerId);
+
+    private static native InetSocketAddress queryAddressNative(long listenerId);
 
     private static native void destroyUcpListenerNative(long listenerId);
 }

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -58,6 +58,11 @@ typedef uintptr_t native_ptr;
 bool j2cInetSockAddr(JNIEnv *env, jobject sock_addr, sockaddr_storage& ss, socklen_t& sa_len);
 
 /**
+ * @brief Utility to convert c sockaddr to java InetSocketAddress
+ */
+jobject c2jInetSockAddr(JNIEnv *env, const sockaddr_storage* ss);
+
+/**
  * @brief Get the jni env object. To be able to call java methods from ucx async callbacks.
  */
 JNIEnv* get_jni_env();

--- a/bindings/java/src/main/native/listener.cc
+++ b/bindings/java/src/main/native/listener.cc
@@ -54,6 +54,22 @@ Java_org_openucx_jucx_ucp_UcpListener_createUcpListener(JNIEnv *env, jobject lis
     return (native_ptr)listener;
 }
 
+JNIEXPORT jobject JNICALL
+Java_org_openucx_jucx_ucp_UcpListener_queryAddressNative(JNIEnv *env,
+                                                         jclass cls,
+                                                         jlong listener_ptr)
+{
+    ucp_listener_attr_t listener_attr;
+    listener_attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR;
+
+    ucs_status_t status = ucp_listener_query((ucp_listener_h)listener_ptr, &listener_attr);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
+
+    return c2jInetSockAddr(env, &listener_attr.sockaddr);
+}
+
 JNIEXPORT void JNICALL
 Java_org_openucx_jucx_ucp_UcpListener_destroyUcpListenerNative(JNIEnv *env,
                                                                jclass cls,

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
 import static org.junit.Assert.*;
 
 public class UcpListenerTest  extends UcxTest {
-    static final int port = Integer.parseInt(
-        System.getenv().getOrDefault("JUCX_TEST_PORT", "55321"));
 
     static Stream<NetworkInterface> getInterfaces() {
         try {
@@ -51,19 +49,10 @@ public class UcpListenerTest  extends UcxTest {
             .collect(Collectors.toList());
         Collections.reverse(addresses);
         for (InetAddress address : addresses) {
-            for (int i = 0; i < 10; i++) {
-                try {
-                    result = worker.newListener(
-                        params.setSockAddr(new InetSocketAddress(address, port + i)));
-                    break;
-                } catch (UcxException ex) {
-                    if (ex.getStatus() != UcsConstants.STATUS.UCS_ERR_BUSY) {
-                        break;
-                    }
-                }
-            }
+            result = worker.newListener(params.setSockAddr(new InetSocketAddress(address, 0)));
         }
         assertNotNull("Could not find socket address to start UcpListener", result);
+        assertNotEquals(0, result.getAddress().getPort());
         System.out.println("Bound UcpListner on: " + result.getAddress());
         return result;
     }


### PR DESCRIPTION
## What
Query for listener address.

## Why ?
Since ucp_listener supports bindings on port 0 (would find free port), we can't cache InterSocketAddress any more, but need to query listener for its sockaddr. Needed for SparkUCX protocol.

cc @abellina