### PR TITLE
UCM/UCS/CONFIG: Fix compile errors for ppc64

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -96,10 +96,33 @@ AC_CHECK_DECLS([ethtool_cmd_speed, SPEED_UNKNOWN], [], [],
 
 
 #
-# PowerPC query for TB frequency
+# PowerPC "sys/platform/ppc.h" header
 #
-AC_CHECK_DECLS([__ppc_get_timebase_freq], [], [], [#include <sys/platform/ppc.h>])
 AC_CHECK_HEADERS([sys/platform/ppc.h])
+
+
+#
+# PowerPC query for getting TB frequency
+#
+AC_CHECK_DECL([__ppc_get_timebase_freq],
+              [AC_CHECK_FUNCS([__ppc_get_timebase_freq])], [],
+              [#include <sys/platform/ppc.h>])
+
+
+#
+# PowerPC query for getting TB.
+# Note: AC_CHECK_FUNCS doesn't work for checking __ppc_get_timebase()
+#
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
+                #include <sys/platform/ppc.h>
+                int main(int argc, char** argv) {
+                    __ppc_get_timebase();
+                    return 0;
+                } ]])],
+                [AC_MSG_RESULT([no])
+                 AC_DEFINE([HAVE___PPC_GET_TIMEBASE], [1],
+                           [__ppc_get_timebase is defined in ppc.h])],
+                [AC_MSG_RESULT([no])])
 
 
 #

--- a/src/ucm/bistro/bistro_ppc64.c
+++ b/src/ucm/bistro/bistro_ppc64.c
@@ -154,8 +154,8 @@ ucs_status_t ucm_bistro_patch_toc(void *func_ptr, void *hook,
     }
 
 #if defined(_CALL_ELF) && (_CALL_ELF == 2)
-    func += 8;
-    hook += 8;
+    func = UCS_PTR_BYTE_OFFSET(func, 8);
+    hook = UCS_PTR_BYTE_OFFSET(hook, 8);
 #endif
 
     ucm_bistro_fill_patch(&patch, R11, (uintptr_t)hook);

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -41,12 +41,12 @@ BEGIN_C_DECLS
 
 static inline uint64_t ucs_arch_read_hres_clock()
 {
-#ifndef HAVE_SYS_PLATFORM_PPC_H
+#ifdef HAVE___PPC_GET_TIMEBASE
+    return __ppc_get_timebase();
+#else
     uint64_t tb;
     asm volatile ("mfspr %0, 268" : "=r" (tb));
     return tb;
-#else
-    return __ppc_get_timebase();
 #endif
 }
 

--- a/src/ucs/arch/ppc64/timebase.c
+++ b/src/ucs/arch/ppc64/timebase.c
@@ -19,7 +19,7 @@
 
 double ucs_arch_get_clocks_per_sec()
 {
-#if HAVE_DECL___PPC_GET_TIMEBASE_FREQ
+#ifdef HAVE___PPC_GET_TIMEBASE_FREQ
     return __ppc_get_timebase_freq();
 #else
     return ucs_get_cpuinfo_clock_freq("timebase", 1.0);


### PR DESCRIPTION
## What

Fix compile errors for ppc64.

## Why ?

Fixes #7618.

## How ?

1. Use `UCX_PTR_BYTE_OFFSET` macro for pointer arithmetic.
2. Check `__ppc_get_timebase()` function existence.