### PR TITLE
UCP/CORE: Get rid of iter_end pointer to simplify and fix KA removal …

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1960,7 +1960,6 @@ static void ucp_worker_keepalive_reset(ucp_worker_h worker)
     worker->keepalive.ep_count    = 0;
     worker->keepalive.iter_count  = 0;
     worker->keepalive.iter        = &worker->all_eps;
-    worker->keepalive.iter_end    = worker->keepalive.iter;
     worker->keepalive.round_count = 0;
 }
 
@@ -2969,7 +2968,6 @@ ucp_worker_keepalive_complete(ucp_worker_h worker, ucs_time_t now)
               worker, worker->keepalive.round_count, worker->keepalive.ep_count,
               ucs_time_to_sec(now));
 
-    worker->keepalive.iter_end   = worker->keepalive.iter;
     worker->keepalive.ep_count   = 0;
     worker->keepalive.last_round = now;
     worker->keepalive.round_count++;
@@ -3031,7 +3029,7 @@ ucp_worker_do_keepalive_progress(ucp_worker_h worker)
         progress_count++;
         worker->keepalive.ep_count++;
     } while ((worker->keepalive.ep_count < max_ep_count) &&
-             (worker->keepalive.iter != worker->keepalive.iter_end));
+             (worker->keepalive.iter != &worker->all_eps));
 
     ucp_worker_keepalive_complete(worker, now);
 
@@ -3081,7 +3079,6 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
 void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 {
     ucp_worker_h worker = ep->worker;
-    int round_inprogress;
 
     ucs_assert(!(ep->flags & UCP_EP_FLAG_INTERNAL));
 
@@ -3090,8 +3087,6 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
         return;
     }
 
-    round_inprogress = worker->keepalive.iter != worker->keepalive.iter_end;
-
     if (worker->keepalive.iter == &ucp_ep_ext_gen(ep)->ep_list) {
         /* Set lane_map=0 to make sure the endpoint won't be selected again */
         ucs_debug("worker %p: removed keepalive current ep %p, moving to next",
@@ -3099,28 +3094,12 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
         worker->keepalive.lane_map = 0;
         ucp_worker_keepalive_next_ep(worker);
         ucs_assert(worker->keepalive.iter != &ucp_ep_ext_gen(ep)->ep_list);
-    }
 
-    if (worker->keepalive.iter_end == &ucp_ep_ext_gen(ep)->ep_list) {
-        ucs_debug("worker %p: removed keepalive end ep %p, moving end to prev",
-                  worker, ep);
-        worker->keepalive.iter_end = worker->keepalive.iter_end->prev;
-        ucs_assert(worker->keepalive.iter_end != &ucp_ep_ext_gen(ep)->ep_list);
-    }
-
-    if (round_inprogress &&
-        (worker->keepalive.iter == worker->keepalive.iter_end)) {
-        /* If the keepalive iterator points to the stop element after moving the
-         * keepalive iterator or the stop element as a result of removing the
-         * endpoint, need to finish the current round to avoid doing keepalive
-         * for the same endpoint twice in the round
-         * NOTE: We should not do anything if there is no keepalive round in
-         * progress, since we would just be postponing the next keepalive round.
-         */
-        ucs_debug("worker %p: removing ep %p finished current keepalive round",
-                  worker, ep);
-        worker->keepalive.lane_map = 0;
-        ucp_worker_keepalive_complete(worker, ucs_get_time());
+        if (worker->keepalive.iter == &worker->all_eps) {
+            ucs_debug("worker %p: all_eps was reached after %p was removed -"
+                      "complete keepalive", worker, ep);
+            ucp_worker_keepalive_complete(worker, ucs_get_time());
+        }
     }
 }
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -323,8 +323,6 @@ typedef struct ucp_worker {
         uct_worker_cb_id_t           cb_id;               /* Keepalive callback id */
         ucs_time_t                   last_round;          /* Last round timestamp */
         ucs_list_link_t              *iter;               /* Last EP processed keepalive */
-        ucs_list_link_t              *iter_end;           /* Last EP processed keepalive in the
-                                                           * current round */
         ucp_lane_map_t               lane_map;            /* Lane map used to retry after no-resources */
         unsigned                     ep_count;            /* Number of EPs processed in current time slot */
         unsigned                     iter_count;          /* Number of progress iterations to skip,


### PR DESCRIPTION
## What

Get rid of iter_end pointer to simplify and fix KA removal of EP

## Why ?

Fixes removing element pointing to KA::iter and KA::iter_end and other cases which leads doing KA several times on the same during the same KA round.

## How ?

1. Remove `iter_end` and all places where it is used.
2. Stop doing KA if reaches `all_eps` or `ep_count == max_ep_count`