### PR TITLE
UCP/EP: support selecting local address for each connection

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -249,7 +249,8 @@ enum ucp_ep_params_field {
     UCP_EP_PARAM_FIELD_FLAGS             = UCS_BIT(5), /**< Endpoint flags */
     /**< Connection request field */
     UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6),
-    UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7) /**< Endpoint name */
+    UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7), /**< Endpoint name */
+    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8)  /**< Local socket Address */
 };
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -733,6 +733,15 @@ typedef struct ucp_ep_params {
     ucs_sock_addr_t         sockaddr;
 
     /**
+     * The sockaddr to bind locally. Specifies the associated network device
+     * to bind locally to establish new connections.
+     * To retrieve the endpoint's local_sockaddr, use @ref ucp_ep_query.
+     * This setting is optional. To enable it, the corresponding - @ref
+     * UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR bit in the field mask must be set.
+     */
+    ucs_sock_addr_t         local_sockaddr;
+
+    /**
      * Connection request from client; this field should be set along with its
      * corresponding bit in the field_mask - @ref
      * UCP_EP_PARAM_FIELD_CONN_REQUEST and must be obtained from @ref

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -566,6 +566,12 @@ err:
     return status;
 }
 
+int ucp_wireup_ep_has_next_ep(ucp_wireup_ep_t *wireup_ep)
+{
+    ucs_assert(wireup_ep != NULL);
+    return wireup_ep->super.uct_ep != NULL;
+}
+
 void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep)
 {
     ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(uct_ep);

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -45,6 +45,9 @@ struct ucp_wireup_ep {
     struct sockaddr_storage   cm_remote_sockaddr;  /**< sockaddr of the remote peer -
                                                         used only on the client side
                                                         in a client-server flow */
+    struct sockaddr_storage   cm_local_sockaddr;   /**< local sockaddr
+                                                        used only on the client side
+                                                        in a client-server flow */
     ucp_rsc_index_t           aux_rsc_index; /**< Index of auxiliary transport */
     volatile uint32_t         pending_count; /**< Number of pending wireup operations */
     volatile uint32_t         flags;         /**< Connection state flags */
@@ -104,6 +107,8 @@ void ucp_wireup_ep_discard_aux_ep(ucp_wireup_ep_t *wireup_ep,
                                   unsigned ep_flush_flags,
                                   uct_pending_purge_callback_t purge_cb,
                                   void *purge_arg);
+
+int ucp_wireup_ep_has_next_ep(ucp_wireup_ep_t *wireup_ep);
 
 void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep);
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -850,7 +850,10 @@ enum uct_ep_params_field {
     UCT_EP_PARAM_FIELD_PRIV_DATA                  = UCS_BIT(14),
 
     /** Enables @ref uct_ep_params::private_data_length */
-    UCT_EP_PARAM_FIELD_PRIV_DATA_LENGTH           = UCS_BIT(15)
+    UCT_EP_PARAM_FIELD_PRIV_DATA_LENGTH           = UCS_BIT(15),
+
+    /** Enables @ref uct_ep_params::local_sockaddr */
+    UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR             = UCS_BIT(16)
 };
 
 
@@ -1170,6 +1173,14 @@ struct uct_ep_params {
      * @ref UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR capability.
      */
     const ucs_sock_addr_t             *sockaddr;
+
+    /**
+     * The sockaddr to bind locally. If set, @ref uct_ep_create
+     * will create an endpoint binding with this local sockaddr.
+     * @note The interface in this routine requires the
+     * @ref UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR capability.
+     */
+    const ucs_sock_addr_t             *local_sockaddr;
 
     /**
      * @ref uct_cb_flags to indicate @ref uct_ep_params_t::sockaddr_pack_cb,

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -780,21 +780,28 @@ UcxConnection::~UcxConnection()
     --_num_instances;
 }
 
-void UcxConnection::connect(const struct sockaddr *saddr, socklen_t addrlen,
+void UcxConnection::connect(const struct sockaddr *src_saddr,
+                            const struct sockaddr *dst_saddr,
+                            socklen_t addrlen,
                             UcxCallback *callback)
 {
-    set_log_prefix(saddr, addrlen);
+    set_log_prefix(dst_saddr, addrlen);
 
     ucp_ep_params_t ep_params;
     ep_params.field_mask       = UCP_EP_PARAM_FIELD_FLAGS |
                                  UCP_EP_PARAM_FIELD_SOCK_ADDR;
     ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-    ep_params.sockaddr.addr    = saddr;
+    ep_params.sockaddr.addr    = dst_saddr;
     ep_params.sockaddr.addrlen = addrlen;
+    if (src_saddr != NULL) {
+        ep_params.field_mask            |= UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR;
+        ep_params.local_sockaddr.addr    = src_saddr;
+        ep_params.local_sockaddr.addrlen = addrlen;
+    }
 
     char sockaddr_str[UCS_SOCKADDR_STRING_LEN];
     UCX_CONN_LOG << "Connecting to "
-                 << ucs_sockaddr_str(saddr, sockaddr_str,
+                 << ucs_sockaddr_str(dst_saddr, sockaddr_str,
                                      UCS_SOCKADDR_STRING_LEN);
     connect_common(ep_params, callback);
 }

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -274,7 +274,9 @@ public:
 
     ~UcxConnection();
 
-    void connect(const struct sockaddr *saddr, socklen_t addrlen,
+    void connect(const struct sockaddr *src_saddr,
+                 const struct sockaddr *dst_saddr,
+                 socklen_t addrlen,
                  UcxCallback *callback);
 
     void accept(ucp_conn_request_h conn_req, UcxCallback *callback);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1203,12 +1203,14 @@ void uct_test::entity::destroy_eps() {
 void
 uct_test::entity::connect_to_sockaddr(unsigned index,
                                       const ucs::sock_addr_storage &remote_addr,
+                                      const ucs::sock_addr_storage *local_addr,
                                       uct_cm_ep_resolve_callback_t resolve_cb,
                                       uct_cm_ep_client_connect_callback_t connect_cb,
                                       uct_ep_disconnect_cb_t disconnect_cb,
                                       void *user_data)
 {
     ucs_sock_addr_t ucs_remote_addr = remote_addr.to_ucs_sock_addr();
+    ucs_sock_addr_t ucs_local_addr;
     uct_ep_params_t params;
     uct_ep_h ep;
     ucs_status_t status;
@@ -1224,6 +1226,12 @@ uct_test::entity::connect_to_sockaddr(unsigned index,
                         UCT_EP_PARAM_FIELD_CM_RESOLVE_CB              |
                         UCT_EP_PARAM_FIELD_SOCKADDR_CONNECT_CB_CLIENT |
                         UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB;
+
+    if (local_addr != NULL) {
+        ucs_local_addr          = local_addr->to_ucs_sock_addr();
+        params.field_mask      |= UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR;
+        params.local_sockaddr   = &ucs_local_addr;
+    }
 
     params.user_data            = user_data;
     params.cm                   = m_cm;

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -190,6 +190,7 @@ protected:
                            unsigned other_index);
         void connect_to_sockaddr(unsigned index,
                                  const ucs::sock_addr_storage &remote_addr,
+                                 const ucs::sock_addr_storage *local_addr,
                                  uct_cm_ep_resolve_callback_t resolve_cb,
                                  uct_cm_ep_client_connect_callback_t connect_cb,
                                  uct_ep_disconnect_cb_t disconnect_cb,


### PR DESCRIPTION
What
support selecting local address for each connection

Why ?
if users have multiple HCAs on client side, they can select the NIC they want to use (round robin fashion for example)

How ?
specify local address in ucp_ep_params when call ucp_ep_create() for each connection