### PR TITLE
TOOLS/INFO: Use conn_req instead accept_cb and provide EP error cb

### DIFF
--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -66,6 +66,11 @@ static void usage() {
     printf("\n");
 }
 
+static void ep_error_callback(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    /* Empty error callback */
+}
+
 int main(int argc, char **argv)
 {
     const uint64_t required_ucp_features = UCP_FEATURE_AMO32 |
@@ -167,8 +172,11 @@ int main(int argc, char **argv)
                     ucp_features |= UCP_FEATURE_WAKEUP;
                     break;
                 case 'e':
-                    ucp_ep_params.field_mask |= UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
-                    ucp_ep_params.err_mode    = UCP_ERR_HANDLING_MODE_PEER;
+                    ucp_ep_params.field_mask |=
+                            UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                            UCP_EP_PARAM_FIELD_ERR_HANDLER;
+                    ucp_ep_params.err_mode       = UCP_ERR_HANDLING_MODE_PEER;
+                    ucp_ep_params.err_handler.cb = ep_error_callback;
                     break;
                 default:
                     usage();


### PR DESCRIPTION
## What

Use conn_req instead accept_cb and provide EP error cb.

## Why ?

To fix the following error seen when launching `ucx_info` utility with error handling support and CM connection establishment method:
```
[1636141932.187527] [ice01:38606:0]          ucp_ep.c:1224 UCX  ERROR ep 0x7fffe806f098: error 'Connection reset by remote peer' on CM lane will not be handle
d since no error callback is installed
```

## How ?

1. Replace `accept_handler` by `conn_handler` to create UCP endpoint with our own EP parameters when accepting a connection from a peer.
2. Provide EP error callback along with "PEER" error mode when creating UCP EPs.