### PR TITLE
UCP/DATATYPE: Fix length==0 initialization of dt_reg array

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -1023,6 +1023,9 @@ ucp_request_param_rndv_thresh(ucp_request_t *req,
 static UCS_F_ALWAYS_INLINE void
 ucp_invoke_uct_completion(uct_completion_t *comp, ucs_status_t status)
 {
+    ucs_assertv(comp->count > 0, "comp=%p count=%d func=%p status %s", comp,
+                comp->count, comp->func, ucs_status_string(status));
+
     uct_completion_update_status(comp, status);
     if (--comp->count == 0) {
         comp->func(comp);

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -29,6 +29,7 @@ ucp_datatype_iter_mem_dereg_some(ucp_context_h context,
     memh_index_old = 0;
     memh_index     = 0;
     ucs_for_each_bit(md_index, dt_reg->md_map) {
+        ucs_assertv(memh_index < UCP_MAX_OP_MDS, "memh_index=%d", memh_index);
         uct_memh = dt_reg->memh[memh_index++];
         if (keep_md_map & UCS_BIT(md_index)) {
             prev_memh[memh_index_old++] = uct_memh;
@@ -74,8 +75,11 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_datatype_iter_mem_reg_internal,
     }
 
     if (ucs_unlikely(length == 0)) {
-        for (memh_index = 0; UCS_BIT(memh_index) <= md_map; ++memh_index) {
-            dt_reg->memh[memh_index] = UCT_MEM_HANDLE_NULL;
+        memh_index = 0;
+        ucs_for_each_bit(md_index, md_map) {
+            ucs_assertv(memh_index < UCP_MAX_OP_MDS, "memh_index=%d",
+                        memh_index);
+            dt_reg->memh[memh_index++] = UCT_MEM_HANDLE_NULL;
         }
         goto out;
     }
@@ -94,9 +98,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_datatype_iter_mem_reg_internal,
     memh_index_old = 0;
     memh_index     = 0;
     ucs_for_each_bit(md_index, md_map) {
+        ucs_assertv(memh_index < UCP_MAX_OP_MDS, "memh_index=%d", memh_index);
+
         if (UCS_BIT(md_index) & dt_reg->md_map) {
             /* memh already registered */
-            ucs_assert(memh_index_old < UCP_MAX_OP_MDS);
+            ucs_assertv(memh_index_old < UCP_MAX_OP_MDS, "memh_index_old=%d",
+                        memh_index_old);
             dt_reg->memh[memh_index++] = tmp_reg[memh_index_old++];
             continue;
         }

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -55,7 +55,8 @@ ucp_md_map_t test_ucp_proto::get_md_map(ucs_memory_type_t mem_type)
          ++md_index) {
         const uct_md_attr_t *md_attr = &context()->tl_mds[md_index].attr;
         if ((md_attr->cap.flags & UCT_MD_FLAG_REG) &&
-            (md_attr->cap.reg_mem_types & UCS_BIT(mem_type))) {
+            (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) &&
+            (ucs_popcount(md_map) < UCP_MAX_OP_MDS)) {
             md_map |= UCS_BIT(md_index);
         }
     }


### PR DESCRIPTION
## Why
Fix a [segmentation fault](https://redmine.mellanox.com/issues/2845386) (internal link):
```
(gdb) bt
#0  0x00007ffff5740efd in pause () from /lib64/libpthread.so.0
...
#6  <signal handler called>
#7  0x0000000000000000 in ?? ()
#8  0x00007fffd272ac60 in ucp_invoke_uct_completion (status=UCS_OK, comp=0x11bd020)
    at ucx/contrib/../src/ucp/core/ucp_request.inl:1028
#9  ucp_request_invoke_uct_completion_success (req=0x11bcf80)
    at ucx/contrib/../src/ucp/core/ucp_request.inl:1035
#10 ucp_proto_single_status_handle (status=<optimized out>, lane=<optimized out>,
    complete_func=<optimized out>, is_zcopy=1, req=0x11bcf80)
    at ucx/contrib/../src/ucp/proto/proto_single.inl:65
#11 ucp_proto_zcopy_single_progress (uct_comp_cb=<optimized out>, complete_func=<optimized out>,
    send_func=<optimized out>, uct_mem_flags=256, req=0x11bcf80)
    at ucx/contrib/../src/ucp/proto/proto_single.inl:118
#12 ucp_proto_eager_zcopy_single_progress (self=0x11bd068)
    at ucx/contrib/../src/ucp/tag/eager_single.c:207
#13 0x00007fffd273558c in ucp_request_try_send (req=0x11bcf80)
    at ucx/contrib/../src/ucp/core/ucp_request.inl:333
#14 ucp_request_send (req=0x11bcf80)
    at ucx/contrib/../src/ucp/core/ucp_request.inl:356
#15 ucp_proto_request_send_op (param=0x1219620, contig_length=<optimized out>, datatype=<optimized out>,
    count=<optimized out>, buffer=0x11bd068, op_id=UCP_OP_ID_TAG_SEND, req=<optimized out>,
    rkey_cfg_index=255 '\377', proto_select=0xbd3cb0, ep=0x7ffff7e0c1c8)
    at ucx/contrib/../src/ucp/proto/proto_common.inl:220
#16 ucp_tag_send_nbx_inner (param=0x1219620, tag=<optimized out>, count=<optimized out>, buffer=0x11bd068,
    ep=0x7ffff7e0c1c8) at ucx/contrib/../src/ucp/tag/tag_send.c:286
#17 ucp_tag_send_nbx (ep=ep@entry=0x7ffff7e0c1c8, buffer=buffer@entry=0x52038e0000, count=<optimized out>,
    tag=tag@entry=1099511627776, param=0x1219620)
    at ucx/contrib/../src/ucp/tag/tag_send.c:229
```