### PR TITLE
UCP/PROTO/RNDV: Fix fragmentation to avoid a too small get_zcopy size

### DIFF
--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -72,6 +72,9 @@ typedef enum {
 
     /* Requires rkey_ptr capable MD */
     UCP_PROTO_COMMON_INIT_FLAG_RKEY_PTR      = UCS_BIT(6),
+
+    /* Supports non-zero minimal fragment size */
+    UCP_PROTO_COMMON_INIT_FLAG_MIN_FRAG      = UCS_BIT(7),
 } ucp_proto_common_init_flags_t;
 
 
@@ -215,11 +218,6 @@ ucp_proto_common_get_iface_attr(const ucp_proto_init_params_t *params,
                                 ucp_lane_index_t lane);
 
 
-size_t
-ucp_proto_common_get_max_frag(const ucp_proto_common_init_params_t *params,
-                              const uct_iface_attr_t *iface_attr);
-
-
 size_t ucp_proto_common_get_iface_attr_field(const uct_iface_attr_t *iface_attr,
                                              ptrdiff_t field_offset,
                                              size_t dfl_value);
@@ -293,6 +291,14 @@ void ucp_proto_request_select_error(ucp_request_t *req,
                                     ucp_worker_cfg_index_t rkey_cfg_index,
                                     const ucp_proto_select_param_t *sel_param,
                                     size_t msg_length);
+
+
+void ucp_proto_common_zcopy_adjust_min_frag_always(ucp_request_t *req,
+                                                   size_t min_frag_diff,
+                                                   uct_iov_t *iov,
+                                                   size_t iovcnt,
+                                                   size_t *offset_p);
+
 
 void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status);
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -118,6 +118,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     mpriv->reg_md_map   = reg_md_map | params->initial_reg_md_map;
     mpriv->lane_map     = lane_map;
     mpriv->num_lanes    = 0;
+    mpriv->min_frag     = 0;
     mpriv->max_frag_sum = 0;
     perf.max_frag       = SIZE_MAX;
     perf.min_length     = 0;
@@ -188,6 +189,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         perf.min_length = ucs_max(perf.min_length, min_length);
 
         weight_sum          += lpriv->weight;
+        mpriv->min_frag      = ucs_max(mpriv->min_frag, lane_perf->min_length);
         mpriv->max_frag_sum += lpriv->max_frag;
         lpriv->weight_sum    = weight_sum;
         lpriv->max_frag_sum  = mpriv->max_frag_sum;

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -56,6 +56,7 @@ typedef struct {
  */
 typedef struct {
     ucp_md_map_t                reg_md_map;   /* Memory domains to register on */
+    size_t                      min_frag;     /* Largest minimal fragment size */
     size_t                      max_frag_sum; /* 'max_frag' sum of all lanes */
     ucp_lane_map_t              lane_map;     /* Map of used lanes */
     ucp_lane_index_t            num_lanes;    /* Number of lanes to use */

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -818,11 +818,12 @@ UCS_TEST_P(test_ucp_tag_match_rndv, req_exp_auto_thresh, "RNDV_THRESH=auto") {
 }
 
 UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
-    const size_t sizes[] = { 1000, 2000, 8000, 2500ul * UCS_MBYTE };
+    const std::vector<size_t> sizes = {1000, 2000, 8000, 2500ul * UCS_MBYTE,
+                                       UCS_GBYTE + 32};
 
     /* small sizes should warm-up tag cache */
-    for (unsigned i = 0; i < ucs_static_array_size(sizes); ++i) {
-        const size_t size = sizes[i] / ucs::test_time_multiplier() /
+    for (auto c_size : sizes) {
+        const size_t size = c_size / ucs::test_time_multiplier() /
                             ucs::test_time_multiplier();
         request *my_send_req, *my_recv_req;
 

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -183,15 +183,18 @@ size_t test_ucp_tag_mem_type::do_xfer(const void *sendbuf, void *recvbuf,
 
 UCS_TEST_P(test_ucp_tag_mem_type, realloc_buffers)
 {
-    const size_t max_iter = RUNNING_ON_VALGRIND ? 3 : 7;
+    std::vector<size_t> sizes =
+            {0, 1, 16, 128, 1048512, 1011439, UCS_MBYTE + 4, 4194324};
+    const size_t max_iter     = RUNNING_ON_VALGRIND ? 3 : 7;
+    const size_t multiplier   = RUNNING_ON_VALGRIND ? 2 : 1;
+    for (unsigned i = 0; i < max_iter; ++i) {
+        sizes.push_back((i * multiplier));
+    }
 
     ucs::detail::message_stream ms("INFO");
-    for (unsigned i = 1; i <= max_iter; ++i) {
-        const size_t multiplier = RUNNING_ON_VALGRIND ? 2 : 1;
-        const size_t length     = test_length(i * multiplier);
+    for (auto length : sizes) {
         mem_buffer recv_mem_buf(length, m_recv_mem_type);
         mem_buffer send_mem_buf(length, m_send_mem_type);
-
         do_basic_xfer(send_mem_buf, recv_mem_buf, length, ms);
     }
 }
@@ -204,7 +207,7 @@ UCS_TEST_P(test_ucp_tag_mem_type, reuse_buffers_mrail, "IB_NUM_PATHS?=2")
     mem_buffer send_mem_buf(max_length, m_send_mem_type);
 
     // Test few specific sizes that expose corner cases, plush a few random ones
-    std::vector<size_t> sizes = {0, 1, 16, 128, UCS_MBYTE + 4, 4194324};
+    std::vector<size_t> sizes = {0, 1, 16, 128, 1048512, UCS_MBYTE + 4, 4194324};
     const size_t max_iter     = RUNNING_ON_VALGRIND ? 1 : 4;
     for (unsigned i = 0; i < max_iter; ++i) {
         sizes.push_back(test_length(7));


### PR DESCRIPTION
## Why
Fix the failure https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/30370/logs/453

## How
- Protocol specified whether it can handle non-0 min_frag value
- rndv/get/zcopy and get/offload/zcopy will check if they send a too small size, and extend the sent data forward or backward to compensate. It can cause fetching overlapping data, but correctness is still maintained. In the worst case, we may send an extra 64b per rendezvous fragment, which is not a significant performance impact.