### PR TITLE
APPS/IO-DEMO: Fix performance printing if wait_for_responses takes ~= 'print_interval' seconds

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -2190,13 +2190,13 @@ public:
             if (is_control_iter(total_iter) &&
                 ((total_iter - total_prev_iter) >= _server_index_lookup.size())) {
                 // Print performance every <print_interval> seconds
-                double curr_time = get_time();
-                if (curr_time >= (prev_time + opts().print_interval)) {
+                if (get_time() >= (prev_time + opts().print_interval)) {
                     wait_for_responses(0);
                     if (_status != OK) {
                         break;
                     }
 
+                    double curr_time = get_time();
                     report_performance(total_iter - total_prev_iter,
                                        curr_time - prev_time);
 


### PR DESCRIPTION
## What

Fix performance printing if `wait_for_responses()` takes ~= `print_interval` seconds.

## Why ?

Fix inaccurate perf measurement including `wait_for_responces()` to the whole result:
Before:
```
[1636396139.269192] [DEMO] total min:90 max:90 total:90 | read 3203.26 MBs min:40(2.1.3.1:1337) max:40 total:40 | write 4004.07 MBs min:50(2.1.3.1:1337) max:50 total:50 | active:1/1 buffers:64
[1636396139.701740] [DEMO] total min:10 max:10 total:10 | read 158.012 MBs min:5(2.1.3.1:1337) max:5 total:5 | write 158.012 MBs min:5(2.1.3.1:1337) max:5 total:5 | active:1/1 buffers:64
[1636396143.053006] [DEMO] total min:80 max:80 total:80 | read 3237.73 MBs min:37(2.1.3.1:1337) max:37 total:37 | write 3762.77 MBs min:43(2.1.3.1:1337) max:43 total:43 | active:1/1 buffers:64
[1636396143.460260] [DEMO] total min:10 max:10 total:10 | read 245.575 MBs min:7(2.1.3.1:1337) max:7 total:7 | write 105.246 MBs min:3(2.1.3.1:1337) max:3 total:3 | active:1/1 buffers:64
[1636396146.856638] [DEMO] total min:80 max:80 total:80 | read 3791.05 MBs min:44(2.1.3.1:1337) max:44 total:44 | write 3101.77 MBs min:36(2.1.3.1:1337) max:36 total:36 | active:1/1 buffers:64
[1636396147.299551] [DEMO] total min:10 max:10 total:10 | read 140.18 MBs min:4(2.1.3.1:1337) max:4 total:4 | write 210.27 MBs min:6(2.1.3.1:1337) max:6 total:6 | active:1/1 buffers:64
```
After:
```
[1636367890.527848] [DEMO] total min:90 max:90 total:90 | read 953.821 MBs min:40(2.1.3.5:1337) max:40 total:40 | write 1192.28 MBs min:50(2.1.3.5:1337) max:50 total:50 | active:1/1 buffers:64
[1636367894.451265] [DEMO] total min:90 max:90 total:90 | read 1014.36 MBs min:42(2.1.3.5:1337) max:42 total:42 | write 1159.27 MBs min:48(2.1.3.5:1337) max:48 total:48 | active:1/1 buffers:64
[1636367898.152847] [DEMO] total min:90 max:90 total:90 | read 1305.53 MBs min:51(2.1.3.5:1337) max:51 total:51 | write 998.344 MBs min:39(2.1.3.5:1337) max:39 total:39 | active:1/1 buffers:64
[1636367901.788067] [DEMO] total min:90 max:90 total:90 | read 1146.91 MBs min:44(2.1.3.5:1337) max:44 total:44 | write 1199.04 MBs min:46(2.1.3.5:1337) max:46 total:46 | active:1/1 buffers:64
[1636367905.553759] [DEMO] total min:90 max:90 total:90 | read 1409.13 MBs min:56(2.1.3.5:1337) max:56 total:56 | write 855.541 MBs min:34(2.1.3.5:1337) max:34 total:34 | active:1/1 buffers:64
[1636368006.313812] [DEMO] total min:10 max:10 total:10 | read 124.695 MBs min:4(2.1.3.5:1337) max:4 total:4 | write 187.042 MBs min:6(2.1.3.5:1337) max:6 total:6 | active:1/1 buffers:64
```

## How ?

1. Get current time when checkings if it is necessary to wait for responses before performance printing.
2. Get current time again when does performance printing.