### PR TITLE
UCP/CORE/GTEST: Don't destroy UCP EP which owns send request when invalidation is in-progress

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -428,8 +428,7 @@ ucp_worker_flush_req_set_next_ep(ucp_request_t *req, int is_current_ep_valid,
     if (next_ep_iter != &worker->all_eps) {
         /* Increment UCP EP reference counter to avoid destroying UCP EP while
          * it is being scheduled to be flushed */
-        ucp_ep_add_ref(next_ep);
-        UCP_EP_ASSERT_COUNTER_INC(&next_ep->flush_iter_refcount);
+        ucp_ep_refcount_add(next_ep, flush);
     }
 
     if (!is_current_ep_valid) {
@@ -439,9 +438,7 @@ ucp_worker_flush_req_set_next_ep(ucp_request_t *req, int is_current_ep_valid,
     ucs_assert(&current_ep_ext->ep_list != &worker->all_eps);
 
     current_ep = ucp_ep_from_ext_gen(current_ep_ext);
-    UCP_EP_ASSERT_COUNTER_DEC(&current_ep->flush_iter_refcount);
-
-    return ucp_ep_remove_ref(current_ep) ? NULL : current_ep;
+    return ucp_ep_refcount_remove(current_ep, flush) ? NULL : current_ep;
 }
 
 static void ucp_worker_flush_complete_one(ucp_request_t *req, ucs_status_t status,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -12,6 +12,7 @@
 #include <ucs/sys/sys.h>
 #include <ifaddrs.h>
 #include <atomic>
+#include <memory>
 
 extern "C" {
 #include <uct/base/uct_worker.h>
@@ -273,9 +274,10 @@ public:
 
     static void scomplete_cb(void *req, ucs_status_t status)
     {
-        if ((status == UCS_OK)              ||
+        if ((status == UCS_OK) ||
             (status == UCS_ERR_UNREACHABLE) ||
-            (status == UCS_ERR_REJECTED)    ||
+            (status == UCS_ERR_REJECTED) ||
+            (status == UCS_ERR_CANCELED) ||
             (status == UCS_ERR_CONNECTION_RESET)) {
             return;
         }
@@ -286,6 +288,12 @@ public:
     {
         ASSERT_EQ(NULL, user_data);
         scomplete_cb(req, status);
+    }
+
+    static void scomplete_always_ok_cbx(void *req, ucs_status_t status, void *user_data)
+    {
+        ASSERT_EQ(NULL, user_data);
+        EXPECT_UCS_OK(status);
     }
 
     static void scomplete_reset_data_cbx(void *req, ucs_status_t status,
@@ -303,7 +311,8 @@ public:
     static void rtag_complete_cb(void *req, ucs_status_t status,
                                  ucp_tag_recv_info_t *info)
     {
-        EXPECT_TRUE((status == UCS_OK) || (status == UCS_ERR_CANCELED));
+        EXPECT_TRUE((status == UCS_OK) || (status == UCS_ERR_CANCELED) ||
+                    (status == UCS_ERR_CONNECTION_RESET));
     }
 
     static void rtag_complete_cbx(void *req, ucs_status_t status,
@@ -312,6 +321,14 @@ public:
     {
         ASSERT_EQ(NULL, user_data);
         rtag_complete_cb(req, status, const_cast<ucp_tag_recv_info_t*>(info));
+    }
+
+    static void rtag_complete_always_ok_cbx(void *req, ucs_status_t status,
+                                            const ucp_tag_recv_info_t *info,
+                                            void *user_data)
+    {
+        ASSERT_EQ(NULL, user_data);
+        EXPECT_UCS_OK(status);
     }
 
     static void rtag_complete_check_data_cbx(void *req, ucs_status_t status,
@@ -373,7 +390,7 @@ public:
 
     void* send(entity& from, const void *contig_buffer, size_t length,
                send_recv_type_t send_type, ucp_send_nbx_callback_t cb,
-               void *user_data  )
+               void *user_data, size_t ep_index = 0)
     {
         ucp_request_param_t params;
 
@@ -382,12 +399,11 @@ public:
         params.cb.send      = cb;
         params.user_data    = user_data;
 
+        ucp_ep_h ep = from.ep(0, ep_index);
         if (send_type == SEND_RECV_TAG) {
-            return ucp_tag_send_nbx(from.ep(), contig_buffer, length, 1,
-                                    &params);
+            return ucp_tag_send_nbx(ep, contig_buffer, length, 1, &params);
         } else if (send_type == SEND_RECV_STREAM) {
-            return ucp_stream_send_nbx(from.ep(), contig_buffer, length,
-                                       &params);
+            return ucp_stream_send_nbx(ep, contig_buffer, length, &params);
         }
 
         UCS_TEST_ABORT("unsupported communication type " << send_type);
@@ -449,13 +465,15 @@ public:
     }
 
     void send_recv(entity& from, entity& to, send_recv_type_t send_recv_type,
-                   bool wakeup, ucp_test_base::entity::listen_cb_type_t cb_type)
+                   bool wakeup,
+                   ucp_test_base::entity::listen_cb_type_t cb_type,
+                   size_t ep_index = 0)
     {
         const uint64_t send_data = ucs_generate_uuid(0);
         ucs_status_t send_status;
 
         void *send_req = send(from, &send_data, sizeof(send_data),
-                              send_recv_type, scomplete_cbx, NULL);
+                              send_recv_type, scomplete_cbx, NULL, ep_index);
 
         uint64_t recv_data = 0;
         void *recv_req;
@@ -525,7 +543,8 @@ public:
         return get_ep_params();
     }
 
-    void client_ep_connect_basic(const ucp_ep_params_t &base_ep_params)
+    void client_ep_connect_basic(const ucp_ep_params_t &base_ep_params,
+                                 size_t ep_index = 0)
     {
         ucp_ep_params_t ep_params = base_ep_params;
 
@@ -537,12 +556,12 @@ public:
         ep_params.sockaddr.addrlen = m_test_addr.get_addr_size();
         ep_params.user_data        = &sender();
 
-        sender().connect(&receiver(), ep_params);
+        sender().connect(&receiver(), ep_params, ep_index);
     }
 
-    void client_ep_connect()
+    void client_ep_connect(size_t ep_index = 0)
     {
-        client_ep_connect_basic(get_ep_params());
+        client_ep_connect_basic(get_ep_params(), ep_index);
     }
 
     void connect_and_send_recv(bool wakeup, uint64_t flags)
@@ -2723,7 +2742,7 @@ UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err)
 
 class test_ucp_sockaddr_protocols_err_sender
       : public test_ucp_sockaddr_protocols {
-public:
+protected:
     virtual void init() {
         m_err_count = 0;
         modify_config("CM_USE_ALL_DEVICES", cm_use_all_devices() ? "y" : "n");
@@ -2737,90 +2756,112 @@ public:
         client_ep_connect();
     }
 
-protected:
-    static void tag_recv_cb(void *request, ucs_status_t status,
-                            ucp_tag_recv_info_t *info) {
-    }
-
     test_ucp_sockaddr_protocols_err_sender() {
         set_tl_small_timeouts();
         m_env.push_back(new ucs::scoped_setenv("UCX_IB_REG_METHODS",
                                                "rcache,odp,direct"));
     }
 
-    ucs::ptr_vector<ucs::scoped_setenv> m_env;
-};
-
-/* This test is quite tricky: it checks for incorrect behavior on RNDV send
- * on DC transport: in case if sender EP was killed right after sent RTS
- * then receiver may get incorrect/corrupted data */
-UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender, tag_rndv_killed_sender,
-           "RNDV_THRESH=10k", "RNDV_SCHEME=get_zcopy")
-{
-    static size_t size = 64 * UCS_KBYTE;
-    static const std::string dc_tls[] = { "dc", "dc_x" };
-    bool has_dc = has_any_transport(
-        std::vector<std::string>(dc_tls,
-                                 dc_tls + ucs_static_array_size(dc_tls)));
-
-    if (!has_dc)
+    void entity_disconnect(entity &e)
     {
-        UCS_TEST_SKIP_R("Unsupported");
-    }
-
-    /* Warmup */
-    test_tag_send_recv(size, false);
-    request_wait(sender().flush_worker_nb());
-    request_wait(receiver().flush_worker_nb());
-
-    std::string send_buf(size, 'x');
-    std::string recv_buf(size, 'y');
-    std::string recv_copy(size, 'y');
-    std::string str_z(size, 'z');
-
-    void *rreq = NULL, *sreq = NULL;
-    ucp_tag_message_h message;
-    ucp_tag_recv_info_t info;
-    ucs_status_t status;
-
-    /* Ignore all errors - it is expected */
-    scoped_log_handler slh(wrap_errors_logger);
-    sreq = ucp_tag_send_nbx(sender().ep(), &send_buf[0], size, 0,
-                            &ucp_request_null_param);
-    ASSERT_TRUE(UCS_PTR_IS_PTR(sreq));
-    ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
-
-    /* Allow receiver to get RTS notification, but do not receive message
-     * body */
-    message = message_wait(receiver(), 0, 0, &info);
-    ASSERT_NE((void*)NULL, message);
-    ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
-
-    /* Close sender EP to force send operation to complete with CANCEL status */
-    ucp_worker_h sender_worker = sender().worker();
-    void *close_req = sender().disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
-    if (UCS_PTR_IS_PTR(close_req)) {
-        while (ucp_request_check_status(close_req) == UCS_INPROGRESS) {
-            ucp_worker_progress(sender_worker);
+        void *close_req = e.disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+        if (UCS_PTR_IS_PTR(close_req)) {
+            ucs_status_t status = request_progress(close_req, { &e });
+            ASSERT_EQ(UCS_ERR_CANCELED, status);
         }
     }
 
-    status = request_wait(sreq);
-    ASSERT_EQ(UCS_ERR_CANCELED, status);
+    /* This test is quite tricky: it checks for incorrect behavior on RNDV send
+     * on CONNECT_TO_IFACE transports with memory invalidation support: in case
+     * if sender EP was killed right after sent RTS then receiver may get
+     * incorrect/corrupted data */
+    void do_tag_rndv_killed_sender_test(size_t num_senders)
+    {
+        static constexpr size_t size = 64 * UCS_KBYTE;
+        std::vector<ucp_tag_message_h> messages;
+        std::vector<void*> reqs;
+        ucs_status_t status;
 
-    /* Receive buffer should not be updated */
-    ASSERT_EQ(recv_buf, recv_copy);
-    /* Update send buffer by new data - emulation of free(buffer) */
-    memset(&send_buf[0], 'z', size);
+        /* If the sumber of senders greater than 1, send the same buffer on
+         * multiple connections to delay the completion of md_invalidate on
+         * the closed connection */
+        mem_buffer send_buf(size, UCS_MEMORY_TYPE_HOST);
+        send_buf.pattern_fill(1, size);
+        for (size_t sender_idx = 0; sender_idx < num_senders; ++sender_idx) {
+            ucp_send_nbx_callback_t send_cb;
 
-    /* Complete receive operation */
-    rreq = ucp_tag_msg_recv_nb(receiver().worker(), &recv_buf[0], size,
-                               ucp_dt_make_contig(1), message, tag_recv_cb);
-    ASSERT_TRUE(UCS_PTR_IS_PTR(rreq));
-    status = request_wait(rreq);
+            if (sender_idx > 0) {
+                send_cb = scomplete_always_ok_cbx;
+                client_ep_connect(sender_idx);
+            } else {
+                send_cb = scomplete_cbx;
+            }
 
-    /* Receive request should fail or data should be valid */
-    EXPECT_TRUE((status != UCS_OK) || (recv_buf == send_buf));
+            /* Warmup */
+            send_recv(sender(), receiver(), send_recv_type(), false, cb_type(),
+                      sender_idx);
+
+            void *sreq = send(sender(), send_buf.ptr(), size, SEND_RECV_TAG,
+                              send_cb, NULL, sender_idx);
+            ASSERT_TRUE(UCS_PTR_IS_PTR(sreq));
+            ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
+            reqs.push_back(sreq);
+
+            /* Allow receiver to get RTS notification, but do not receive message
+             * body */
+            ucp_tag_recv_info_t info;
+            ucp_tag_message_h message = message_wait(receiver(), 0, 0, &info);
+            ASSERT_NE((void*)NULL, message);
+            ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
+
+            messages.emplace_back(message);
+        }
+
+        /* Ignore all errors - it is expected */
+        scoped_log_handler slh(wrap_errors_logger);
+
+        /* Close the first sender's EP to force send operation to be completed
+         * with CANCEL status */
+        entity_disconnect(sender());
+
+        mem_buffer extra_recv_buf(size, UCS_MEMORY_TYPE_HOST);
+        extra_recv_buf.pattern_fill(2, size);
+        for (size_t i = 1; i < messages.size(); ++i) {
+            void *rreq = recv(receiver(), extra_recv_buf.ptr(), size,
+                              messages[i], rtag_complete_always_ok_cbx, NULL);
+            reqs.push_back(rreq);
+        }
+
+        status = requests_wait(reqs);
+        ASSERT_EQ(UCS_ERR_CANCELED, status);
+
+        /* Update send buffer by new data - emulation of free(buffer) */
+        send_buf.pattern_fill(3, size);
+
+        /* Complete receive operation */
+        mem_buffer recv_buf(size, UCS_MEMORY_TYPE_HOST);
+        recv_buf.pattern_fill(2, size);
+        void *rreq = recv(receiver(), recv_buf.ptr(), size, messages[0],
+                          rtag_complete_check_data_cbx, recv_buf.ptr());
+        request_wait(rreq);
+    }
+
+private:
+    ucs::ptr_vector<ucs::scoped_setenv> m_env;
+};
+
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender, tag_rndv_killed_sender,
+           "RNDV_THRESH=0", "RNDV_SCHEME=get_zcopy")
+{
+    do_tag_rndv_killed_sender_test(1);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
+           tag_rndv_killed_sender_4_extra_senders, "RNDV_THRESH=0",
+           "RNDV_SCHEME=get_zcopy")
+{
+    do_tag_rndv_killed_sender_test(5);
 }
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err_sender)


### PR DESCRIPTION
## What

Don't destroy UCP EP which owns send request when invalidation is in-progress.

## Why ?

To fix touching UCP EP which could be already destroyed, but memory invalidation is still in-progress.
It fails when assertions from the PR are added with:
- the previous test case `test_ucp_sockaddr_protocols_err_sender::tag_rndv_killed_sender`:
```
[ RUN      ] dcudx/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender/0 <dc_x,ud,cuda_copy,rocm_copy/mt>
[New Thread 0x7fffee581700 (LWP 102949)]
[     INFO ] server listening on 2.1.3.1:57341
[jazz01:102844:0:102844] ucp_request.inl:226  Assertion `(req->send.ep == ((void *)0)) || (req->send.ep->refcount > 0)' failed: ep 0x7fffd82c6000

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl: [ ucp_request_complete_send() ]
      ...
      222 static UCS_F_ALWAYS_INLINE void
      223 ucp_request_complete_send(ucp_request_t *req, ucs_status_t status)
      224 {
==>   225     ucs_assertv((req->send.ep == NULL) || (req->send.ep->refcount > 0),
      226                 "ep %p", req->send.ep);
      227     ucs_trace_req("completing send request %p (%p) " UCP_REQUEST_FLAGS_FMT
      228                   " %s",

==== backtrace (tid: 102844) ====
 0 0x0000000000055334 ucp_request_complete_send()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.inl:225
 1 0x0000000000055334 ucp_request_dt_invalidate_progress()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.c:322
 2 0x0000000000056c76 ucs_callbackq_slow_proxy()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.c:402
 3 0x000000000005c11d ucs_callbackq_dispatch()  /labhome/dmitrygla/work_auto/ucx/src/ucs/datastruct/callbackq.h:211
 4 0x0000000000068e76 uct_worker_progress()  /labhome/dmitrygla/work_auto/ucx/src/uct/api/uct.h:2589
 5 0x0000000000a6112e ucp_test_base::entity::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:970
 6 0x0000000000a5c024 ucp_test::progress()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:168
 7 0x0000000000a5c4bd ucp_test::request_process()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:257
 8 0x0000000000a5c5f1 ucp_test::request_wait()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.cc:280
 9 0x0000000000a14f0d test_ucp_sockaddr_protocols_err_sender::do_tag_rndv_killed_sender_test()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:2614
10 0x00000000009ebbcb test_ucp_sockaddr_protocols_err_sender_tag_rndv_killed_sender_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:2639
11 0x0000000000590dde ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:356
12 0x0000000000590fa1 ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:382
13 0x00000000007a2956 ucp_test::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:192
14 0x0000000000deb3ea testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2433
15 0x0000000000de7274 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2469
16 0x0000000000dd2243 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2509
17 0x0000000000dd2aab testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2687
18 0x0000000000dd3164 testing::TestSuite::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2819
19 0x0000000000dde362 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:5350
20 0x0000000000dec0ed testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2433
21 0x0000000000de8118 testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2469
22 0x0000000000ddce2e testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:4940
23 0x0000000000574d2f RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.h:2473
24 0x00000000005749d0 main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:118
25 0x00000000000223d5 __libc_start_main()  ???:0
26 0x0000000000574059 _start()  ???:0
=================================
```
- the new test case `test_ucp_sockaddr_protocols_err_sender::tag_rndv_killed_sender_reg_mem`:
```
[ RUN      ] dcudx/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_reg_mem/0 <dc_x,ud,cuda_copy,rocm_copy/mt>
[New Thread 0x7fffee581700 (LWP 90425)]
[     INFO ] server listening on 2.1.3.1:37369
[jazz01:90320:0:90320] ucp_request.c:335  Assertion `req->send.ep->refcount > 0' failed: ep 0x7fffd82c5000

/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.c: [ ucp_request_mem_invalidate_completion() ]
      ...
      332                                                   send.state.uct_comp);
      333     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
      334
==>   335     ucs_assertv(req->send.ep->refcount > 0, "ep %p", req->send.ep);
      336     uct_worker_progress_register_safe(req->send.ep->worker->uct,
      337                                       ucp_request_dt_invalidate_progress,
      338                                       req, UCS_CALLBACKQ_FLAG_ONESHOT,

==== backtrace (tid:  90320) ====
 0 0x0000000000055898 ucp_request_mem_invalidate_completion()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_request.c:335
 1 0x00000000000270a8 uct_invoke_completion()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_iface.h:803
 2 0x000000000006f17e ucs_mem_region_destroy_internal()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:412
 3 0x000000000006f424 ucs_rcache_region_put_internal()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:450
 4 0x0000000000071608 ucs_rcache_region_put()  /labhome/dmitrygla/work_auto/ucx/src/ucs/memory/rcache.c:1017
 5 0x000000000002719d uct_ib_mem_rcache_dereg()  /labhome/dmitrygla/work_auto/ucx/src/uct/ib/base/ib_md.c:1034
 6 0x0000000000012c49 uct_md_mem_dereg()  /labhome/dmitrygla/work_auto/ucx/src/uct/base/uct_md.c:462
 7 0x000000000004e340 ucp_mem_rereg_mds()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_mm.c:79
 8 0x000000000004f454 ucp_mem_unmap_common()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_mm.c:364
 9 0x000000000004fb74 ucp_mem_unmap()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_mm.c:490
10 0x0000000000a167f8 test_ucp_sockaddr_protocols_err_sender::do_tag_rndv_killed_sender_test()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:2617
11 0x00000000009ebd15 test_ucp_sockaddr_protocols_err_sender_tag_rndv_killed_sender_reg_mem_Test::test_body()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:2652
12 0x0000000000590ece ucs::test_base::run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:356
13 0x0000000000591091 ucs::test_base::TestBodyProxy()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/test.cc:382
14 0x00000000007a2a46 ucp_test::TestBody()  /labhome/dmitrygla/work_auto/ucx/test/gtest/ucp/ucp_test.h:192
15 0x0000000000decd9c testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2433
16 0x0000000000de8c26 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2469
17 0x0000000000dd3bf5 testing::Test::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2509
18 0x0000000000dd445d testing::TestInfo::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2687
19 0x0000000000dd4b16 testing::TestSuite::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2819
20 0x0000000000ddfd14 testing::internal::UnitTestImpl::RunAllTests()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:5350
21 0x0000000000deda9f testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2433
22 0x0000000000de9aca testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:2469
23 0x0000000000dde7e0 testing::UnitTest::Run()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.cc:4940
24 0x0000000000574e1f RUN_ALL_TESTS()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/googletest/gtest.h:2473
25 0x0000000000574ac0 main()  /labhome/dmitrygla/work_auto/ucx/test/gtest/common/main.cc:118
26 0x00000000000223d5 __libc_start_main()  ???:0
27 0x0000000000574149 _start()  ???:0
=================================
```

## How ?

1. Introduce a new test which has pending memory invalidation, since the buffer is registered for another operation,
2. Add assertions to check that UCP endpoint is valid when completing send operations. Allow UCP endpoint to be invalid only if UCP endpoint is `NULL` - i.e. if it disconnection procedure.
3. Increment UCP endpoint's reference counter if a memory invalidation is scheduled.
4. Decrement UCP endpoint's reference counter if a memory invalidation is completed.