### PR TITLE
GTEST/UCP: Remove unneeded code and use move/ref where needed

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -283,7 +283,7 @@ void analyze_test_results()
                 test_name += ".";
                 test_name += test->name();
 
-                test_results.push_back(std::make_pair(test_name,
+                test_results.push_back(std::make_pair(std::move(test_name),
                                                       result->elapsed_time()));
 
                 max_name_size = std::max(test_name.size(), max_name_size);

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -283,10 +283,11 @@ void analyze_test_results()
                 test_name += ".";
                 test_name += test->name();
 
-                test_results.push_back(std::make_pair(std::move(test_name),
-                                                      result->elapsed_time()));
+                test_results.emplace_back(std::move(test_name),
+                                          result->elapsed_time());
 
-                max_name_size = std::max(test_name.size(), max_name_size);
+                max_name_size = std::max(test_results.back().first.size(),
+                                         max_name_size);
 
                 skipped_it = skipped_tests.find(test);
                 if (skipped_it != skipped_tests.end()) {
@@ -789,7 +790,7 @@ const std::vector<std::vector<ucs_memory_type_t> >& supported_mem_type_pairs()
     static std::vector<std::vector<ucs_memory_type_t> > result;
 
     if (result.empty()) {
-        result = ucs::make_pairs(mem_buffer::supported_mem_types());
+        result = std::move(ucs::make_pairs(mem_buffer::supported_mem_types()));
     }
 
     return result;

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -699,15 +699,11 @@ UCS_TEST_P(test_ucp_am_nbx, rx_am_mpools,
     set_am_data_handler(receiver(), TEST_AM_NBX_ID, am_data_hold_cb, &rx_data,
                         UCP_AM_FLAG_PERSISTENT_DATA);
 
-    static const std::string ib_tls[] = { "dc_x", "rc_v", "rc_x", "ud_v",
-                                          "ud_x", "ib" };
-
     // UCP takes desc from mpool only for data arrived as inlined from UCT.
     // Typically, with IB, data is inlined up to 32 bytes, so use smaller range
     // of values for IB transports.
-    bool has_ib = has_any_transport(
-            std::vector<std::string>(ib_tls,
-                                     ib_tls + ucs_static_array_size(ib_tls)));
+    bool has_ib = has_any_transport({ "dc_x", "rc_v", "rc_x", "ud_v", "ud_x",
+                                      "ib" });
     ssize_t length = ucs::rand() % (has_ib ? 32 : 256);
     std::vector<char> sbuf(length, 'd');
 

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -218,10 +218,9 @@ private:
                     continue;
                 }
 
-                static const std::string tls[] = { "ud_v", "ud_x", "rc_v", "tcp" };
                 /* Target memory type atomics emulation not supported yet */
                 if (((atomic_mode == UCP_ATOMIC_MODE_CPU) ||
-                     has_any_transport(tls, ucs_static_array_size(tls))) &&
+                     has_any_transport({ "ud_v", "ud_x", "rc_v", "tcp" })) &&
                     !UCP_MEM_IS_HOST(recv_mem_type)) {
                     continue;
                 }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -203,11 +203,7 @@ public:
             UCS_TEST_SKIP_R("No interface for testing");
         }
 
-        static const std::string dc_tls[] = { "dc", "dc_x", "ib" };
-
-        bool has_dc = has_any_transport(
-            std::vector<std::string>(dc_tls,
-                                     dc_tls + ucs_static_array_size(dc_tls)));
+        bool has_dc = has_any_transport({ "dc", "dc_x", "ib" });
 
         /* FIXME: select random interface, except for DC transport, which do not
                   yet support having different gid_index for different UCT

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -425,10 +425,8 @@ public:
         test_ucp_tag_offload::init();
 
         // TODO: add more tls which support tag offloading
-        std::vector<std::string> tls;
-        tls.push_back("dc_x");
-        tls.push_back("rc_x");
-        ucp_test_param params = GetParam();
+        std::vector<std::string> tls = { "dc_x", "rc_x" };
+        ucp_test_param params        = GetParam();
 
         // Create new entity and add to to the end of vector
         // (thus it will be receiver without any connections)

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1364,14 +1364,10 @@ UCS_TEST_P(test_ucp_wireup_amo, relese_key_after_flush) {
 UCP_INSTANTIATE_TEST_CASE(test_ucp_wireup_amo)
 
 UCS_TEST_P(test_ucp_wireup_fallback_amo, different_amo_types) {
-    std::vector<std::string> tls;
-
     /* the 1st peer support RC only (device atomics) */
-    tls.push_back("rc");
     /* the 2nd peer support RC and SHM (device and CPU atomics) */
-    tls.push_back("rc,shm");
-
-    size_t min_max_num_eps = test_wireup_fallback_amo(tls, 1, 1);
+    std::vector<std::string> tls = { "rc", "rc,shm" };
+    size_t min_max_num_eps       = test_wireup_fallback_amo(tls, 1, 1);
     test_wireup_fallback_amo(tls, min_max_num_eps + 1, 0);
 }
 

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -293,9 +293,7 @@ out:
         ep_test_info_map_t::iterator it = m_ep_test_info_map.find(ep);
 
         if (it == m_ep_test_info_map.end()) {
-            ep_test_info_t test_info;
-
-            m_ep_test_info_map.insert(std::make_pair(ep, test_info));
+            m_ep_test_info_map.insert(std::make_pair(ep, ep_test_info_t()));
             it = m_ep_test_info_map.find(ep);
         }
 

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -293,7 +293,7 @@ out:
         ep_test_info_map_t::iterator it = m_ep_test_info_map.find(ep);
 
         if (it == m_ep_test_info_map.end()) {
-            m_ep_test_info_map.insert(std::make_pair(ep, ep_test_info_t()));
+            m_ep_test_info_map.emplace(ep, ep_test_info_t());
             it = m_ep_test_info_map.find(ep);
         }
 

--- a/test/gtest/ucp/ucp_datatype.cc
+++ b/test/gtest/ucp/ucp_datatype.cc
@@ -237,23 +237,4 @@ ucp_generic_dt_ops test_dt_copy_ops = {
     dt_common_finish
 };
 
-std::string datatype_name(ucp_datatype_t dt)
-{
-    return ucp_datatype_class_names[ucp_datatype_class(dt)];
-}
-
-std::vector<std::vector<ucp_datatype_t> >
-datatype_pairs(const ucp_generic_dt_ops_t *ops, size_t contig_elem_size)
-{
-    ucp_datatype_t dt;
-    ASSERT_UCS_OK(ucp_dt_create_generic(ops, NULL, &dt));
-
-    ucp_datatype_t dt_arr[] = { ucp_dt_make_contig(contig_elem_size),
-                                ucp_dt_make_iov(),
-                                dt };
-    std::vector<ucp_datatype_t> dts(dt_arr, dt_arr + 3);
-
-    return ucs::make_pairs(dts);
-}
-
 } // ucp

--- a/test/gtest/ucp/ucp_datatype.h
+++ b/test/gtest/ucp/ucp_datatype.h
@@ -105,10 +105,6 @@ struct dt_gen_state {
     void                *buffer;
 };
 
-std::vector<std::vector<ucp_datatype_t> >
-datatype_pairs(const ucp_generic_dt_ops_t *ops, size_t contig_elem_size = 1);
-
-std::string datatype_name(ucp_datatype_t dt);
 
 extern int dt_gen_start_count;
 extern int dt_gen_finish_count;

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -122,11 +122,6 @@ bool ucp_test::has_any_transport(const std::vector<std::string>& tl_names) const
            all_tl_names.end();
 }
 
-bool ucp_test::has_any_transport(const std::string *tls, size_t tl_size) const {
-    const std::vector<std::string> tl_names(tls, tls + tl_size);
-    return has_any_transport(tl_names);
-}
-
 bool ucp_test::is_self() const {
     return "self" == GetParam().transports.front();
 }

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -88,8 +88,6 @@ protected:
         std::vector<std::vector<uint16_t> > > ib_pkey_pairs_t;
 
     ib_pkey_pairs_t supported_pkey_pairs(bool full_membership_only = true) {
-        static std::vector<std::vector<uint16_t> > supported_pkey_pairs;
-        static std::vector<std::vector<uint16_t> > supported_pkey_idx_pairs;
         static ib_pkey_pairs_t result;
 
         if (result.first.empty()) {
@@ -106,11 +104,9 @@ protected:
                 supported_pkeys_idx.push_back(table_idx);
             }
 
-            supported_pkey_pairs = ucs::make_pairs(supported_pkeys);
-            supported_pkey_idx_pairs = ucs::make_pairs(supported_pkeys_idx);
-
-            result = std::make_pair(supported_pkey_pairs,
-                                    supported_pkey_idx_pairs);
+            // rely on RVO for the created pairs and the result
+            result = std::make_pair(ucs::make_pairs(supported_pkeys),
+                                    ucs::make_pairs(supported_pkeys_idx));
         }
 
         return result;

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -104,9 +104,9 @@ protected:
                 supported_pkeys_idx.push_back(table_idx);
             }
 
-            // rely on RVO for the created pairs and the result
-            result = std::make_pair(ucs::make_pairs(supported_pkeys),
-                                    ucs::make_pairs(supported_pkeys_idx));
+            result = std::move(
+                    std::make_pair(ucs::make_pairs(supported_pkeys),
+                                   ucs::make_pairs(supported_pkeys_idx)));
         }
 
         return result;


### PR DESCRIPTION
## What

1. Remove unneeded code.
2. Use `std::move` for temporary `std::string`.
3. Use `std::move()` when passing temporary std::vector to `std::make_pair()`

## Why ?

1. `datatype_name()` and `datatype_pairs()` are unused.
2. To not copy one `std::string` to another one when construction `std::pair`.
3. To not copy `std::vector()`

## How ?

1. Just remove declarations and implementations of `datatype_name()` and `datatype_pairs()`.
2. Replace passing `std::string` by passing r-value using `std::move()` of `std::string`.
3. Remove static declaration of pairs and pass them `ucs::make_pairs()` result directly (RVO will be applied), but set `result` using `std::move()`, because they won't be elided by compiler (i.e. RVO won't be applied), since declaration is above.