### PR TITLE
UCT/GTEST: Disable MP_SRQ by default

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -42,7 +42,7 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.seg_size),
    UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_MP_SRQ_ENABLE", "try",
+  {"TM_MP_SRQ_ENABLE", "no",
    "Enable multi-packet SRQ support. Relevant for hardware tag-matching only.",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.mp_enable),
    UCS_CONFIG_TYPE_TERNARY},

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -374,6 +374,9 @@ UCS_TEST_P(test_ucp_tag_offload, eager_multi_probe,
 {
     activate_offload(sender());
 
+    // TODO: Update length to bigger value so that multi-fragment eager is used
+    //       when multi-eager offload probe issue is fixed (like below).
+    // size_t length = ucp_ep_config(sender().ep())->tag.rndv.am_thresh.remote - 1;
     size_t length = ucp_ep_config(sender().ep())->tag.rndv.am_thresh.remote - 1;
     ucp_tag_t tag = 0x11;
     std::vector<uint8_t> sendbuf(length);


### PR DESCRIPTION
## What
Disable MP XRQ by default

## Why ?
This in turn disables multi-eager tag offload protocols which currently have some issues
