### PR TITLE
UCP/CORE: Add states to discarding of UCT EP

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -652,7 +652,11 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
     } else if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
     } else if (req->send.state.uct_comp.func ==
-               ucp_worker_discard_uct_ep_flush_comp) {
+                       ucp_worker_discard_uct_ep_flush_comp) {
+        ucs_assert(req->send.discard_uct_ep.flags &
+                UCP_REQUEST_DISCARD_UCT_EP_ON_PENDING);
+        req->send.discard_uct_ep.flags &=
+                ~UCP_REQUEST_DISCARD_UCT_EP_ON_PENDING;
         ucp_worker_discard_uct_ep_progress(req);
     } else if (req->send.state.uct_comp.func != NULL) {
         /* Fast-forward the sending state to complete the operation when last

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -77,6 +77,17 @@ enum {
 
 
 /**
+ * Discarding UCT EP flags assign on a request
+ */
+enum {
+    UCP_REQUEST_DISCARD_UCT_EP_ON_PENDING          = UCS_BIT(0),
+    UCP_REQUEST_DISCARD_UCT_EP_ON_PROGRESS         = UCS_BIT(1),
+    UCP_REQUEST_DISCARD_UCT_EP_ON_FLUSH            = UCS_BIT(2),
+    UCP_REQUEST_DISCARD_UCT_EP_ON_DESTROY_PROGRESS = UCS_BIT(3)
+};
+
+
+/**
  * Receive descriptor flags.
  */
 enum {
@@ -315,6 +326,8 @@ struct ucp_request {
                     /* Progress ID, if it's UCS_CALLBACKQ_ID_NULL, no operations
                      * are in-progress */
                     uct_worker_cb_id_t cb_id;
+                    /* Flags */
+                    uint8_t            flags;
                 } discard_uct_ep;
 
                 struct {


### PR DESCRIPTION
## What

Add states to the discarding of UCT EP.

## Why ?

It helps to debug the current state of the discarding of UCT EP, which couldn't be determined w/o states.

## How ?

1. Introduce 4 states: ON_PENDING, ON_PROGRESS, ON_FLUSH, ON_DESTROY_PROGRESS.
2. Add 8-bit `flags` field to `ucp_request_t::send::discard_uct_ep`.
3. Set/unset them in the correct places.
4. Assert if setting some state, but another state is still set.