### PR TITLE
UCP/CORE: Ensure request purging is done after destroying of UCT EPs

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -553,19 +553,6 @@ typedef struct ucp_conn_request {
 } ucp_conn_request_t;
 
 
-/**
- * Argument for discarding UCP endpoint's lanes
- */
-typedef struct ucp_ep_discard_lanes_arg {
-    unsigned     counter; /* How many discarding operations on UCT lanes are
-                           * in-progress if purging of the UCP endpoint is
-                           * required */
-    ucs_status_t status; /* Completion status of operations after discarding is
-                          * done */
-    ucp_ep_h     ucp_ep; /* UCP endpoint which should be discarded */
-} ucp_ep_discard_lanes_arg_t;
-
-
 int ucp_is_uct_ep_failed(uct_ep_h uct_ep);
 
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);
@@ -710,10 +697,6 @@ void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status);
 void
 ucp_ep_purge_lanes(ucp_ep_h ep, uct_pending_purge_callback_t purge_cb,
                    void *purge_arg);
-
-unsigned ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t discard_status,
-                              ucp_send_nbx_callback_t discard_cb,
-                              ucp_ep_discard_lanes_arg_t *discard_arg);
 
 void ucp_ep_register_disconnect_progress(ucp_request_t *req);
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -524,6 +524,11 @@ public:
         clear();
     }
 
+    operator const std::vector<T*>&() const
+    {
+        return m_vec;
+    }
+
     /** Add and take ownership */
     void push_back(T* ptr) {
         m_vec.push_back(ptr);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -517,14 +517,14 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
     /* flush all outstanding ops to allow keepalive to run */
     flush_worker(sender());
     if (get_variant_value() & WAKEUP) {
-        wait_for_wakeup({ sender().worker(), failing_receiver().worker() },
+        wait_for_wakeup({ &sender(), &failing_receiver() },
                         100, true);
     }
 
     /* kill EPs & ifaces */
     failing_receiver().close_all_eps(*this, 0, UCP_EP_CLOSE_MODE_FORCE);
     if (get_variant_value() & WAKEUP) {
-        wait_for_wakeup({ sender().worker() });
+        wait_for_wakeup({ &sender() });
     }
     wait_for_flag(&m_err_count);
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -213,7 +213,8 @@ public:
 private:
     static void set_ucp_config(ucp_config_t *config, const std::string& tls);
     static bool check_tls(const std::string& tls);
-    ucs_status_t request_process(void *req, int worker_index, bool wait);
+    ucs_status_t request_process(void *req, int worker_index, bool wait,
+                                 bool wakeup = false);
 
 protected:
     typedef void (*get_variants_func_t)(std::vector<ucp_test_variant>&);
@@ -226,20 +227,31 @@ protected:
     bool has_any_transport(const std::string *tls, size_t tl_size) const;
     entity* create_entity(bool add_in_front = false);
     entity* create_entity(bool add_in_front, const ucp_test_param& test_param);
+    unsigned progress(const std::vector<entity*> &entities,
+                      int worker_index = 0) const;
     unsigned progress(int worker_index = 0) const;
     void short_progress_loop(int worker_index = 0) const;
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);
     void flush_worker(const entity &e, int worker_index = 0);
     void flush_workers();
     void disconnect(entity& entity);
-    ucs_status_t request_wait(void *req, int worker_index = 0);
+    void check_events(const std::vector<entity*> &entities, bool wakeup,
+                      int worker_index = 0);
+    ucs_status_t
+    request_progress(void *req, const std::vector<entity*> &entities,
+                     double timeout = 10.0, int worker_index = 0);
+    ucs_status_t request_wait(void *req, int worker_index = 0, bool wakeup = false);
     ucs_status_t requests_wait(std::vector<void*> &reqs, int worker_index = 0);
+    ucs_status_t requests_wait(const std::initializer_list<void*> reqs_list,
+                               int worker_index = 0);
     ucp_tag_message_h message_wait(entity& e, ucp_tag_t tag, ucp_tag_t tag_mask,
                                    ucp_tag_recv_info_t *info, int remove = 1,
                                    int worker_index = 0);
     void request_release(void *req);
-    void wait_for_wakeup(const std::vector<ucp_worker_h> &workers,
-                         int poll_timeout = -1, bool drain = false);
+    void request_cancel(entity &e, void *req);
+    void wait_for_wakeup(const std::vector<entity*> &entities,
+                         int poll_timeout = -1, bool drain = false,
+                         int worker_index = 0);
     int max_connections();
     void set_tl_small_timeouts();
 


### PR DESCRIPTION
## What

Ensure request purging is done after destroying of UCT EPs.

## Why ?

Fixes potential data reading (as a part of RNDV) from the send buffer which is tied with already completed UCP requests.
Let's imagine we have the following scenario:
1. Connection established between two peers (`A` and `B`).
2. `A` sends some large buffer that goes to RNDV protocol.
3. `B` starts `RDMA_READ` operation to read it to the local receive buffer. After sending RTS, UCP EP on `A` adds requests to hlist which tracks the requests until ATS is received.
4. User decides to kill `A` by sending `SIGINT`. Application's signal handler forcibly closes UCP EP and waits for completion of all requests (and fills send buffers by `ffff`).
5. UCP EP's force close starts discard operation for all UCT EPs (but they are not completed in-place). Then it calls `ucp_ep_discoonected()` which purges all requests scheduled on UCP EP's hlist - i.e. it purges the request from stage "3". The send buffer will be invalidated in the completion callback.
6. UCP EP on the `B` doesn't detect error (since UCT EPs on `A` are not closed), but it reads the wrong data.

## How ?

1. Always pass discarded callback when does `ucp_ep_discard_lanes()` - i.e. now it is done in error-handling and FORCE close. This is needed to purge all requests after discarding of all lanes is completed.
2. Move calling `ucp_ep_reqs_purge()` from `ucp_ep_disconnected()` to `ucp_ep_cleanup_Lanes()` under condition which is true only if `ucp_ep_cleanup_Lanes()` clsoes UCT EPs (i.e. it is normal UCP EP closing - neither FORCE close nor error handling).
3. Move resetting UCP EP's flush_state prior connecting lanes to ensure it allows calling `ucp_ep_reqs_purge()` from `ucp_ep_cleanup_Lanes()` w/o assertion when connection fails.
4. Add some useful assertions.