### PR TITLE
UCP/CORE: Deprecate UCX_SOCKADDR_AUX_TLS configuration parameter

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -154,10 +154,10 @@ static ucs_config_field_t ucp_config_table[] = {
    "The '*' wildcard expands to all the available sockaddr transports.",
    ucs_offsetof(ucp_config_t, sockaddr_cm_tls), UCS_CONFIG_TYPE_STRING_ARRAY},
 
-  {"SOCKADDR_AUX_TLS", "ud",
-   "Transports to use for exchanging additional address information while\n"
-   "establishing client/server connection. ",
-   ucs_offsetof(ucp_config_t, sockaddr_aux_tls), UCS_CONFIG_TYPE_STRING_ARRAY},
+  {"SOCKADDR_AUX_TLS", "",
+   "The configuration parameter is deprecated. UCX_TLS should be used to\n"
+   "specify the transport for client/server connection establishment.",
+   UCS_CONFIG_DEPRECATED_FIELD_OFFSET, UCS_CONFIG_TYPE_DEPRECATED},
 
   {"SELECT_DISTANCE_MD", "cuda_cpy",
    "MD whose distance is queried when evaluating transport selection score",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -149,8 +149,6 @@ struct ucp_config {
     ucp_context_config_names_t             rndv_frag_sizes;
     /** Array of rendezvous fragment elems per allocation */
     ucp_context_config_names_t             rndv_frag_elems;
-    /** Array of transports for partial worker address to pack */
-    UCS_CONFIG_STRING_ARRAY_FIELD(aux_tls) sockaddr_aux_tls;
     /** Array of transports for client-server transports and port selection */
     UCS_CONFIG_STRING_ARRAY_FIELD(cm_tls)  sockaddr_cm_tls;
     /** Warn on invalid configuration */

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -618,11 +618,6 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
                                        ucp_request_callback_t flushed_cb,
                                        const char *debug_name);
 
-ucs_status_t
-ucp_ep_create_sockaddr_aux(ucp_worker_h worker, unsigned ep_init_flags,
-                           const ucp_unpacked_address_t *remote_address,
-                           ucp_ep_h *ep_p);
-
 void ucp_ep_config_key_set_err_mode(ucp_ep_config_key_t *key,
                                     unsigned ep_init_flags);
 


### PR DESCRIPTION
## What

Deprecate `UCX_SOCKADDR_AUX_TLS` configuration parameter.

## Why ?

It is not used by the new client/server connection establishment flow.

## How ?

1. Remove `sockaddr_aux_tls` field from `ucp_config_t`.
2. Use `UCS_CONFIG_DEPRECATED_FIELD_OFFSET` and `UCS_CONFIG_TYPE_DEPRECATED` to mark `UCX_SOCKADDR_AUX_TLS` as deprecated.