### PR TITLE
BINDINGS/GO: Use abs_top_srcdir to fix OOS build.

### DIFF
--- a/bindings/go/Makefile.am
+++ b/bindings/go/Makefile.am
@@ -7,7 +7,7 @@ if HAVE_GO
 
 GOOBJDIR=$(abs_top_builddir)/bindings/go/$(objdir)
 GOPATH=$(abs_top_srcdir)/bindings/go/
-CGOCFLAGS=-I$(abs_top_builddir)/src -I$(top_srcdir)/src
+CGOCFLAGS=-I$(abs_top_builddir)/src -I$(abs_top_srcdir)/src
 CGOLDFLAGS=-L$(abs_top_builddir)/src/ucp/$(objdir) -lucp -L$(abs_top_builddir)/src/ucs/$(objdir) -lucs
 UCX_SOPATH=$(abs_top_builddir)/src/ucp/$(objdir):$(abs_top_builddir)/src/ucs/$(objdir):$(abs_top_builddir)/src/ucm/$(objdir):$(abs_top_builddir)/src/uct/$(objdir)
 GOTMPDIR=$(GOOBJDIR)/tmp


### PR DESCRIPTION
## What
Use abs_top_srcdir to fix OOS build.

## Why ?
Fixes #7647 when OOS is outside of ucx directory.