### PR TITLE
UCP/CORE/WIREUP: Simplify resetting of UCP endpoint's flush state

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -596,6 +596,10 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
 
 void ucp_ep_delete(ucp_ep_h ep);
 
+void ucp_ep_flush_state_reset(ucp_ep_h ep);
+
+void ucp_ep_flush_state_invalidate(ucp_ep_h ep);
+
 void ucp_ep_release_id(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -229,28 +229,6 @@ static inline const char* ucp_ep_peer_name(ucp_ep_h ep)
 #endif
 }
 
-static inline void ucp_ep_flush_state_reset(ucp_ep_h ep)
-{
-    ucp_ep_flush_state_t *flush_state = &ucp_ep_ext_gen(ep)->flush_state;
-
-    ucs_assert(!(ep->flags & UCP_EP_FLAG_ON_MATCH_CTX));
-    ucs_assert(!(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID) ||
-               ((flush_state->send_sn == 0) &&
-                (flush_state->cmpl_sn == 0) &&
-                ucs_hlist_is_empty(&flush_state->reqs)));
-
-    flush_state->send_sn = 0;
-    flush_state->cmpl_sn = 0;
-    ucs_hlist_head_init(&flush_state->reqs);
-    ucp_ep_update_flags(ep, UCP_EP_FLAG_FLUSH_STATE_VALID, 0);
-}
-
-static inline void ucp_ep_flush_state_invalidate(ucp_ep_h ep)
-{
-    ucs_assert(ucs_hlist_is_empty(&ucp_ep_flush_state(ep)->reqs));
-    ucp_ep_update_flags(ep, 0, UCP_EP_FLAG_FLUSH_STATE_VALID);
-}
-
 /* get index of the local component which can reach a remote memory domain */
 static inline ucp_rsc_index_t
 ucp_ep_config_get_dst_md_cmpt(const ucp_ep_config_key_t *key,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -486,7 +486,6 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, ucp_ep_h ep,
     /* restore the EP here to avoid access to incomplete configuration before
        this point */
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
-    ucp_ep_flush_state_reset(ep);
 
     if (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
         ep_init_flags |= UCP_EP_INIT_ERR_MODE_PEER_FAILURE;
@@ -524,7 +523,6 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
     if (ep != NULL) {
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
         ucp_ep_update_remote_id(ep, msg->src_ep_id);
-        ucp_ep_flush_state_reset(ep);
         ep_init_flags |= UCP_EP_INIT_CREATE_AM_LANE;
     } else {
         ucs_assert(msg->dst_ep_id == UCS_PTR_MAP_KEY_INVALID);
@@ -551,10 +549,7 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
                              " requested on the context %p",
                              worker, ep, worker->context);
                 }
-                ucp_ep_flush_state_reset(ep);
             }
-        } else {
-            ucp_ep_flush_state_reset(ep);
         }
 
         ucp_ep_update_remote_id(ep, msg->src_ep_id);
@@ -670,7 +665,6 @@ ucp_wireup_process_reply(ucp_worker_h worker, ucp_ep_h ep,
 
     ucp_ep_match_remove_ep(worker, ep);
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
-    ucp_ep_flush_state_reset(ep);
 
     /* Connect p2p addresses to remote endpoint */
     if (!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED) ||
@@ -747,7 +741,6 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     }
 
     ucp_ep_update_remote_id(reply_ep, msg->src_ep_id);
-    ucp_ep_flush_state_reset(reply_ep);
     status = ucp_wireup_msg_send(reply_ep, UCP_WIREUP_MSG_EP_REMOVED,
                                  &ucp_tl_bitmap_min, NULL);
     if (status != UCS_OK) {

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1223,7 +1223,6 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
     }
 
     ucp_ep_update_remote_id(ep, sa_data->ep_id);
-    ucp_ep_flush_state_reset(ep);
 
     if (conn_request->listener->accept_cb == NULL) {
         goto out_free_request;


### PR DESCRIPTION
## What

Simplify resetting of UCP endpoint's flush state.

## Why ?

To reset UCP endpoint's flush state when:
- creating UCP EP
- retrieving from EP matching
- removing from EP matching

## How ?

1. Remove all places where `ucp_ep_flush_state_reset()` is called - remain them only in places listed above.
2. Move `ucp_ep_flush_state_reset()`/`ucp_ep_flush_state_invalidate()` to the `ucp_ep.c`/`ucp_ep.h` instead of `ucp_ep.inl` where it was declared as `inline`ed