### PR TITLE
[DNM] disable gtest for debug version

### DIFF
--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -12,7 +12,6 @@
 
 basedir=$(cd $(dirname $0) && pwd)
 $basedir/../configure \
-	--enable-gtest \
 	--enable-examples \
 	--with-valgrind \
 	--enable-profiling \


### PR DESCRIPTION
1. **ignore the CI failure**
2. **Never merge**
3. [Solve build ucx/1.11.2 debug version in CentOS6.10](https://gist.github.com/changchengx/f19c6de30b9a57d44edadf593f892122#gistcomment-3961413)