### PR TITLE
UCS: solve name shadow problem in CentOS6.x

### DIFF
--- a/src/ucs/arch/bitops.h
+++ b/src/ucs/arch/bitops.h
@@ -181,20 +181,20 @@ ucs_count_ptr_trailing_zero_bits(const void *ptr, uint64_t bit_length)
 static inline int
 ucs_bitwise_is_equal(const void *ptr1, const void *ptr2, uint64_t bit_length)
 {
-    size_t length      = bit_length / 8;
-    unsigned remainder = bit_length % 8;
+    size_t length          = bit_length / 8;
+    unsigned remainder_val = bit_length % 8;
 
     if (memcmp(ptr1, ptr2, length) != 0) {
         return 0;
     }
 
-    if (remainder == 0) {
+    if (remainder_val == 0) {
         return 1;
     }
 
     /* Compare up to 7 last bits */
-    return ((*((uint8_t*)ptr1 + length) & ~UCS_MASK(8 - remainder)) ==
-            (*((uint8_t*)ptr2 + length) & ~UCS_MASK(8 - remainder)));
+    return ((*((uint8_t*)ptr1 + length) & ~UCS_MASK(8 - remainder_val)) ==
+            (*((uint8_t*)ptr2 + length) & ~UCS_MASK(8 - remainder_val)));
 }
 
 END_C_DECLS

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -180,17 +180,17 @@ uct_ib_mlx5_inline_iov_copy(void *restrict dest, const uct_iov_t *iov,
                             size_t iovcnt, size_t length,
                             uct_ib_mlx5_txwq_t *wq)
 {
-    ptrdiff_t remainder;
+    ptrdiff_t remainder_val;
     ucs_iov_iter_t iov_iter;
 
     ucs_assert(dest != NULL);
 
     ucs_iov_iter_init(&iov_iter);
-    remainder = UCS_PTR_BYTE_DIFF(dest, wq->qend);
-    if (ucs_likely(length <= remainder)) {
+    remainder_val = UCS_PTR_BYTE_DIFF(dest, wq->qend);
+    if (ucs_likely(length <= remainder_val)) {
         uct_iov_to_buffer(iov, iovcnt, &iov_iter, dest, SIZE_MAX);
     } else {
-        uct_iov_to_buffer(iov, iovcnt, &iov_iter, dest, remainder);
+        uct_iov_to_buffer(iov, iovcnt, &iov_iter, dest, remainder_val);
         uct_iov_to_buffer(iov, iovcnt, &iov_iter, wq->qstart, SIZE_MAX);
     }
 }


### PR DESCRIPTION
There's below error when compiling code on CentOS 6.3 & 6.10:
    src/ucs/arch/bitops.h: In function 'ucs_bitwise_is_equal':
    src/ucs/arch/bitops.h:179: error: declaration of 'remainder' shadows a global declaration
    /usr/include/bits/mathcalls.h:289: error: shadowed declaration is here
    cc1: warnings being treated as errors
    In file included from src/ucs/sys/math.h:17,
    from util/sys.c:21:

Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>