### PR TITLE
UCT/COMPONENT: fixed typo

### DIFF
--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -176,7 +176,7 @@ struct uct_component {
         ucs_list_add_tail(&uct_components_list, &(_component)->list); \
     } \
     UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->md_config, &ucs_config_global_list); \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->cm_config, &ucs_config_global_list); \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->cm_config, &ucs_config_global_list);
 
 
 /**


### PR DESCRIPTION
- fixed copy-paste issue in macro definition
