### PR TITLE
IODEMO: fix progress loop

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -223,9 +223,10 @@ void UcxContext::progress(unsigned count)
 {
     int i = 0;
 
-    while ((i++ < count) && progress_worker_event()) {
+    progress_worker_event();
+    do {
         progress_io_message();
-    }
+    } while ((++i < count) && progress_worker_event());
 
     progress_timed_out_conns();
     progress_conn_requests();


### PR DESCRIPTION
## What
Fix progress loop in io_demo

## Why
Fixes a hang in io_demo test over shared memory transport

## How
If `progress_worker_event()` returns `false`, we don't progress the io message. We have to progress io_msg and worker at least once to avoid the situation when io_msg is completed on previous iteration of worker progress.
The issue is stable reproducible with shared memory transport