### PR TITLE
CONFIG/CUDA: show error messages if nvml not detected - v1.12.x

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -41,7 +41,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          LDFLAGS="$LDFLAGS $CUDA_LDFLAGS"
 
          # Check cuda header files
-         AC_CHECK_HEADERS([cuda.h cuda_runtime.h nvml.h],
+         AC_CHECK_HEADERS([cuda.h cuda_runtime.h],
                           [cuda_happy="yes"], [cuda_happy="no"])
 
          # Check cuda libraries
@@ -51,9 +51,21 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],
                              [CUDA_LIBS="$CUDA_LIBS -lcudart"], [cuda_happy="no"])])
+
+         # Check nvml header files
+         AC_CHECK_HEADERS([nvml.h],
+                          [cuda_happy="yes"],
+                          [AS_IF([test "x$with_cuda" != "xguess"],
+                                 [AC_MSG_ERROR([nvml header not found. Install appropriate cuda-nvml-devel package])])
+                           cuda_happy="no"])
+
+         # Check nvml library
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([nvidia-ml], [nvmlInit],
-                             [CUDA_LIBS="$CUDA_LIBS -lnvidia-ml"], [cuda_happy="no"])])
+                             [CUDA_LIBS="$CUDA_LIBS -lnvidia-ml"],
+                             [AS_IF([test "x$with_cuda" != "xguess"],
+                                    [AC_MSG_ERROR([libnvidia-ml not found. Install appropriate nvidia-driver package])])
+                              cuda_happy="no"])])
 
          LDFLAGS="$save_LDFLAGS"
 


### PR DESCRIPTION
## What/Why?

Configure step to show error if nvml isn't detected on the system.