### PR TITLE
UCT/IB/MLX5: Fix overriding CQE status in case of completion error

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -71,16 +71,17 @@ ucs_status_t uct_ib_mlx5_completion_with_err(uct_ib_iface_t *iface,
                                              uct_ib_mlx5_txwq_t *txwq,
                                              ucs_log_level_t log_level)
 {
-    ucs_status_t status = UCS_ERR_IO_ERROR;
-    char err_info[256]  = {};
-    char wqe_info[256]  = {};
-    char peer_info[128] = {};
-    uint16_t pi         = ntohs(ecqe->wqe_counter);
-    uint32_t qp_num     = ntohl(ecqe->s_wqe_opcode_qpn) &
-                          UCS_MASK(UCT_IB_QPN_ORDER);
+    ucs_status_t err_status = UCS_ERR_IO_ERROR;
+    char err_info[256]      = {};
+    char wqe_info[256]      = {};
+    char peer_info[128]     = {};
+    uint16_t pi             = ntohs(ecqe->wqe_counter);
+    uint32_t qp_num         = ntohl(ecqe->s_wqe_opcode_qpn) &
+                              UCS_MASK(UCT_IB_QPN_ORDER);
     void *wqe;
     struct ibv_ah_attr ah_attr;
     unsigned dest_qpn;
+    ucs_status_t status;
 
     switch (ecqe->syndrome) {
     case MLX5_CQE_SYNDROME_LOCAL_LENGTH_ERR:
@@ -95,8 +96,8 @@ ucs_status_t uct_ib_mlx5_completion_with_err(uct_ib_iface_t *iface,
     case MLX5_CQE_SYNDROME_WR_FLUSH_ERR:
         snprintf(err_info, sizeof(err_info),
                  "WR flushed because QP in error state");
-        log_level = UCS_LOG_LEVEL_TRACE;
-        status    = UCS_ERR_CANCELED;
+        log_level  = UCS_LOG_LEVEL_TRACE;
+        err_status = UCS_ERR_CANCELED;
         break;
     case MLX5_CQE_SYNDROME_MW_BIND_ERR:
         snprintf(err_info, sizeof(err_info), "Memory window bind");
@@ -112,23 +113,23 @@ ucs_status_t uct_ib_mlx5_completion_with_err(uct_ib_iface_t *iface,
         break;
     case MLX5_CQE_SYNDROME_REMOTE_ACCESS_ERR:
         snprintf(err_info, sizeof(err_info), "Remote access");
-        status = UCS_ERR_CONNECTION_RESET;
+        err_status = UCS_ERR_CONNECTION_RESET;
         break;
     case MLX5_CQE_SYNDROME_REMOTE_OP_ERR:
         snprintf(err_info, sizeof(err_info), "Remote OP");
-        status = UCS_ERR_CONNECTION_RESET;
+        err_status = UCS_ERR_CONNECTION_RESET;
         break;
     case MLX5_CQE_SYNDROME_TRANSPORT_RETRY_EXC_ERR:
         snprintf(err_info, sizeof(err_info), "Transport retry count exceeded");
-        status = UCS_ERR_ENDPOINT_TIMEOUT;
+        err_status = UCS_ERR_ENDPOINT_TIMEOUT;
         break;
     case MLX5_CQE_SYNDROME_RNR_RETRY_EXC_ERR:
         snprintf(err_info, sizeof(err_info), "Receive-no-ready retry count exceeded");
-        status = UCS_ERR_ENDPOINT_TIMEOUT;
+        err_status = UCS_ERR_ENDPOINT_TIMEOUT;
         break;
     case MLX5_CQE_SYNDROME_REMOTE_ABORTED_ERR:
         snprintf(err_info, sizeof(err_info), "Remote side aborted");
-        status = UCS_ERR_ENDPOINT_TIMEOUT;
+        err_status = UCS_ERR_ENDPOINT_TIMEOUT;
         break;
     default:
         snprintf(err_info, sizeof(err_info), "Generic");
@@ -170,7 +171,7 @@ ucs_status_t uct_ib_mlx5_completion_with_err(uct_ib_iface_t *iface,
             peer_info);
 
 out:
-    return status;
+    return err_status;
 }
 
 static unsigned uct_ib_mlx5_parse_dseg(void **dseg_p, void *qstart, void *qend,


### PR DESCRIPTION
## What

Fix overriding CQE status in case of completion error.

## Why ?

Querying QP peer info return `ucs_status_t` and it is overriding `status` which was already set to some error taking into account CQE error value.
It fixes reporting an incorrect completion status for a particular operation.

## How ?

1. Rename `status` to `ep_status` to use it for storing a CQE error value and return the function result.
2. Introduce new `status` to store the result of `uct_ib_mlx5_query_qp_peer_info()`.