### PR TITLE
GTEST/UCP: Handle possible reject/unreachable errors in sockaddr_protocols tests

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2104,6 +2104,9 @@ protected:
         bool err_handling_test = send_stop || recv_stop;
         unsigned num_iters     = err_handling_test ? 1 : m_num_iters;
 
+        // do small send-recv to check reachability of peers
+        send_recv(sender(), receiver(), SEND_RECV_TAG, false, cb_type());
+
         /* send multiple messages to test the protocol both before and after
          * connection establishment */
         for (int i = 0; i < num_iters; i++) {
@@ -2180,6 +2183,9 @@ protected:
 
     void test_stream_send_recv(size_t size, bool is_exp)
     {
+        // do small send-recv to check reachability of peers
+        send_recv(sender(), receiver(), SEND_RECV_STREAM, false, cb_type());
+
         /* send multiple messages to test the protocol both before and after
          * connection establishment */
         for (int i = 0; i < m_num_iters; i++) {

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -493,14 +493,16 @@ public:
         void *send_req = send(from, &send_data, sizeof(send_data),
                               send_recv_type, scomplete_cbx, NULL);
 
-        void *recv_req;
+        void *recv_req = NULL;
         if (send_recv_type == SEND_RECV_TAG) {
             recv_req = recv(to, &recv_data, sizeof(recv_data),
                             rtag_complete_cbx, NULL);
         } else if (send_recv_type == SEND_RECV_STREAM) {
             recv_req = recv(to, &recv_data, sizeof(recv_data),
                             rstream_complete_cbx, NULL);
-        } else if (send_recv_type != SEND_RECV_AM) {
+        } else if (send_recv_type == SEND_RECV_AM) {
+            recv_req = NULL; // to suppress compiler warning
+        } else {
             UCS_TEST_ABORT("unsupported communication type " +
                            std::to_string(send_recv_type));
         }


### PR DESCRIPTION
## What

Handle possible reject/unreachable errors in `sockaddr_protocols` tests

## Why ?

Fixes #7607 

## How ?

1. Move `request_process()` from `private` to `protected`.
2. Use `check_send_status()` to skip tests that are testing reject or tests that fail connection due to no IB devices.