### PR TITLE
BINDINGS/GO: disable module for goperftest.

### DIFF
--- a/bindings/go/Makefile.am
+++ b/bindings/go/Makefile.am
@@ -38,6 +38,7 @@ bench: $(GOTMPDIR)
 	LD_LIBRARY_PATH=$(UCX_SOPATH):${LD_LIBRARY_PATH} $(GO) test -v -bench=.
 
 goperftest: $(GOTMPDIR)
+	$(GO) env -w GO111MODULE=off ; \
 	cd $(abs_top_srcdir)/bindings/go/src/examples/perftest ;\
 	$(GO) build -o ${GOTMPDIR}/goperftest
 


### PR DESCRIPTION
## What
Fix `go: cannot find main module, but found .git/config in /tmp/ucx` when building goperftest before goucx

