### PR TITLE
APPS/IO-DEMO: Verify connection msg ID

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1304,9 +1304,7 @@ public:
                     << " conn " << conn;  
 
 #ifndef NDEBUG
-        if (conn->remote_id() == std::numeric_limits<uint64_t>::max()) {
-            conn->set_remote_id(msg->conn_id);
-        }
+        conn->set_remote_id(msg->conn_id);
 #endif
 
         assert(conn->ucx_status() == UCS_OK);

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1304,7 +1304,9 @@ public:
                     << " conn " << conn;  
 
 #ifndef NDEBUG
-        conn->set_remote_id(msg->conn_id);
+        if (conn->remote_id() == std::numeric_limits<uint64_t>::max()) {
+            conn->set_remote_id(msg->conn_id);
+        }
 #endif
 
         assert(conn->ucx_status() == UCS_OK);

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -948,7 +948,8 @@ protected:
         validate(conn, msg, iomsg_size);
     }
 
-    static inline void handle_io_msg(const iomsg_t *msg, UcxConnection *conn) {
+    static inline void check_conn_id(const iomsg_t *msg, UcxConnection *conn)
+    {
 #ifndef NDEBUG
         if (conn->use_am() && (msg->op == IO_READ_COMP)) {
             assert(conn->id() == msg->conn_id);
@@ -1287,7 +1288,7 @@ public:
 
         if (opts().validate) {
             assert(length == opts().iomsg_size);
-            handle_io_msg(msg, conn);
+            check_conn_id(msg, conn);
             validate(conn, msg, length);
         }
 
@@ -1313,7 +1314,7 @@ public:
 
         if (opts().validate) {
             assert(length == opts().iomsg_size);
-            handle_io_msg(msg, conn);
+            check_conn_id(msg, conn);
             validate(conn, msg, length);
         }
 
@@ -1512,7 +1513,7 @@ public:
                     // in place to avoid unneeded memory copy to this
                     // IoReadResponseCallback _buffer.
                     iomsg_t *msg = reinterpret_cast<iomsg_t*>(_buffer);
-                    handle_io_msg(msg, server_info.conn);
+                    check_conn_id(msg, server_info.conn);
                     validate(server_info.conn, msg, _sn, _buffer_size);
                 }
             }
@@ -1791,7 +1792,7 @@ public:
 
         if (opts().validate) {
             assert(length == opts().iomsg_size);
-            handle_io_msg(msg, conn);
+            check_conn_id(msg, conn);
             validate(conn, msg, opts().iomsg_size);
         }
 
@@ -1823,7 +1824,7 @@ public:
 
         if (opts().validate) {
             assert(length == opts().iomsg_size);
-            handle_io_msg(msg, conn);
+            check_conn_id(msg, conn);
             validate(conn, msg, opts().iomsg_size);
         }
 

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1237,7 +1237,6 @@ public:
                                     const UcxAmDesc &data_desc) {
         VERBOSE_LOG << "receiving AM IO write data";
         assert(msg->data_size != 0);
-        assert(msg->conn_id == conn->remote_id());
 
         BufferIov *iov             = _data_buffers_pool.get();
         IoWriteResponseCallback *w = _callback_pool.get();

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -754,7 +754,7 @@ UcxConnection::UcxConnection(UcxContext &context, bool use_am) :
     _establish_cb(NULL),
     _disconnect_cb(NULL),
     _conn_id(context.get_next_conn_id()),
-    _remote_conn_id(std::numeric_limits<uint64_t>::max()),
+    _remote_conn_id(0),
     _ep(NULL),
     _close_request(NULL),
     _ucx_status(UCS_INPROGRESS),
@@ -1053,11 +1053,11 @@ void UcxConnection::set_log_prefix(const struct sockaddr* saddr,
 
 void UcxConnection::connect_tag(UcxCallback *callback)
 {
-    const ucp_datatype_t dt = ucp_dt_make_contig(sizeof(uint64_t));
+    const ucp_datatype_t dt_int = ucp_dt_make_contig(sizeof(uint32_t));
     size_t recv_len;
 
     // receive remote connection id
-    void *rreq = ucp_stream_recv_nb(_ep, &_remote_conn_id, 1, dt,
+    void *rreq = ucp_stream_recv_nb(_ep, &_remote_conn_id, 1, dt_int,
                                     stream_recv_callback, &recv_len,
                                     UCP_STREAM_RECV_FLAG_WAITALL);
     if (UCS_PTR_IS_PTR(rreq)) {
@@ -1076,7 +1076,7 @@ void UcxConnection::connect_tag(UcxCallback *callback)
     }
 
     // send local connection id
-    void *sreq = ucp_stream_send_nb(_ep, &_conn_id, 1, dt,
+    void *sreq = ucp_stream_send_nb(_ep, &_conn_id, 1, dt_int,
                                     common_request_callback, 0);
     // we do not have to check the status here, in case if the endpoint is
     // failed we should handle it in ep_params.err_handler.cb set above
@@ -1132,9 +1132,7 @@ void UcxConnection::established(ucs_status_t status)
     _ucx_status = status;
 
     if (!_use_am && (status == UCS_OK)) {
-        /* Connection ID must be lower than maximal 32-bit value to be packed
-         * to TAG */
-        assert(_remote_conn_id <= std::numeric_limits<uint32_t>::max());
+        assert(_remote_conn_id != 0);
 
         ep_attr.field_mask = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR |
                              UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR;

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -1053,7 +1053,7 @@ void UcxConnection::set_log_prefix(const struct sockaddr* saddr,
 
 void UcxConnection::connect_tag(UcxCallback *callback)
 {
-    static const ucp_datatype_t dt = ucp_dt_make_contig(sizeof(uint64_t));
+    const ucp_datatype_t dt = ucp_dt_make_contig(sizeof(uint64_t));
     size_t recv_len;
 
     // receive remote connection id

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -316,6 +316,10 @@ public:
         _remote_conn_id = remote_conn_id;
     }
 
+    bool use_am() const {
+        return _use_am;
+    }
+
     ucs_status_t ucx_status() const {
         return _ucx_status;
     }

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 #include <sys/epoll.h>
+#include <limits>
+#include <cassert>
 
 #define MAX_LOG_PREFIX_SIZE   64
 
@@ -306,6 +308,16 @@ public:
 
     uint64_t id() const {
         return _conn_id;
+    }
+
+    uint64_t remote_id() const {
+        return _remote_conn_id;
+    }
+
+    void set_remote_id(uint64_t remote_conn_id) {
+        assert(_remote_conn_id == std::numeric_limits<uint64_t>::max());
+        assert(_use_am);
+        _remote_conn_id = remote_conn_id;
     }
 
     ucs_status_t ucx_status() const {

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -315,8 +315,7 @@ public:
     }
 
     void set_remote_id(uint64_t remote_conn_id) {
-        assert((_remote_conn_id == std::numeric_limits<uint64_t>::max()) ||
-               (_remote_conn_id == remote_conn_id));
+        assert(_remote_conn_id == std::numeric_limits<uint64_t>::max());
         assert(_use_am);
         _remote_conn_id = remote_conn_id;
     }

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 #include <sys/epoll.h>
-#include <limits>
-#include <cassert>
 
 #define MAX_LOG_PREFIX_SIZE   64
 
@@ -315,8 +313,6 @@ public:
     }
 
     void set_remote_id(uint64_t remote_conn_id) {
-        assert(_remote_conn_id == std::numeric_limits<uint64_t>::max());
-        assert(_use_am);
         _remote_conn_id = remote_conn_id;
     }
 

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -315,7 +315,8 @@ public:
     }
 
     void set_remote_id(uint64_t remote_conn_id) {
-        assert(_remote_conn_id == std::numeric_limits<uint64_t>::max());
+        assert((_remote_conn_id == std::numeric_limits<uint64_t>::max()) ||
+               (_remote_conn_id == remote_conn_id));
         assert(_use_am);
         _remote_conn_id = remote_conn_id;
     }


### PR DESCRIPTION
## What

Verify connection msg ID.

## Why ?

To make sure that IO-Demo receives an expected conn_id. 

## How ?

1. Add `assert()` check to compare remote conn_id and msg::conn_id.
2. Set remote conn_id in case of AM when receiving the first message in case of `NDEBUG` isn't defined.