### PR TITLE
TEST/IODEMO: remove build dependency on HAVE_GLIBCXX_NOTHROW

### DIFF
--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -8,9 +8,7 @@
 
 SUBDIRS = profiling
 
-if HAVE_GLIBCXX_NOTHROW
 SUBDIRS += iodemo
-endif
 
 if HAVE_CXX11
 SUBDIRS += sockaddr

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -300,30 +300,28 @@ const std::string UcxContext::sockaddr_str(const struct sockaddr* saddr,
                                            size_t addrlen)
 {
     char buf[128];
-    int port;
+    uint16_t port;
 
     if (saddr->sa_family != AF_INET) {
         return "<unknown address family>";
     }
 
-    struct sockaddr_storage addr = {0};
-    memcpy(&addr, saddr, addrlen);
-    switch (addr.ss_family) {
+    switch (saddr->sa_family) {
     case AF_INET:
-        inet_ntop(AF_INET, &((struct sockaddr_in*)&addr)->sin_addr,
+        inet_ntop(AF_INET, &((const struct sockaddr_in*)saddr)->sin_addr,
                   buf, sizeof(buf));
-        port = ntohs(((struct sockaddr_in*)&addr)->sin_port);
+        port = ntohs(((const struct sockaddr_in*)saddr)->sin_port);
         break;
     case AF_INET6:
-        inet_ntop(AF_INET6, &((struct sockaddr_in6*)&addr)->sin6_addr,
+        inet_ntop(AF_INET6, &((const struct sockaddr_in6*)saddr)->sin6_addr,
                   buf, sizeof(buf));
-        port = ntohs(((struct sockaddr_in6*)&addr)->sin6_port);
+        port = ntohs(((const struct sockaddr_in6*)saddr)->sin6_port);
         break;
     default:
         return "<invalid address>";
     }
 
-    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ":%d", port);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ":%u", port);
     return buf;
 }
 


### PR DESCRIPTION
## What
if use gcc 4.4.7 on centos6.10, IODEMO would not be compiled

## Why ?
HAVE_GLIBCXX_NOTHROW non-declared

## How ?
remove this dependency as iodemo does not depend on it anymore.
After removal, got below build errors when compiling ucx-1.11.2, hence changed lines to function call.

ucx_wrapper.cc: In static member function ‘static const std::string UcxContext::sockaddr_str(const sockaddr*, size_t)’:
ucx_wrapper.cc:298: error: dereferencing pointer ‘addr.108’ does break strict-aliasing rules
ucx_wrapper.cc:298: note: initialized from here
ucx_wrapper.cc:303: error: dereferencing pointer ‘addr.110’ does break strict-aliasing rules
ucx_wrapper.cc:303: note: initialized from here

test/apps/iodemo/ucx_wrapper.cc
 298         port = ntohs(((struct sockaddr_in*)&addr)->sin_port);

