### PR TITLE
UCP/CORE/GTEST: Fix possible purge of requests after discarding is in-progress after error handling

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1196,6 +1196,14 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t discard_status)
     ucp_lane_index_t lane;
     uct_ep_h uct_ep;
 
+    if (ep->flags & UCP_EP_FLAG_FAILED) {
+        /* Avoid calling ucp_ep_discard_lanes_callback() that will purge UCP
+         * endpoint's requests, if we already started discard and purge process
+         * this endpoint. Doing so could complete send requests before UCT lanes
+         * using them are flushed and destroyed. */
+        return;
+    }
+
     discard_arg = ucs_malloc(sizeof(*discard_arg), "discard_lanes_arg");
     if (discard_arg == NULL) {
         ucs_error("ep %p: failed to allocate memory for discarding lanes"


### PR DESCRIPTION
## What

Fix possible purge of requests after discarding is in-progress after error handling.

## Why ?

It fixes a new type of "iov data corruption" issue found by MTT/IO-Demo testing:
- client and server exchange data
- some network issues happen on some links, but some other links are still health
- client detects an issue while some RNDV operations are in-progress and RTS for them was sent
- `ucp_ep_set_failed` discards all UCT lanes (they operations are in-progress)
- `ucp_ep_set_failed` invokes a user's error callback which closes the failed endpoint with mode=FORCE
- `ucp_ep_reqs_purge` is called from `ucp_ep_discard_lanes`, since no lanes to discard
- send operations are canceled and their invalidate data
- server doesn't detect an issue and continues reading data using health links, but the data is invalid

## How ?

1. Save a pointer to `ucp_ep_discard_lanes_t` in the control extension of UCP endpoint.
2. When starting discarding of UCT lanes, check whether `discard_lanes` was already allocated: if so - use it, otherwise - allocate a new one. So all discarding operations will use the same `discard_lanes` argument and UCP EP protected from being purged before all UCT lanes are closed.
3. Write a test to test detecting UCP EP failure and FORCE_CLOSE during in-progress RNDV operation.