### PR TITLE
UCP/CORE: Get rid of CLOSE_REQ_VALID flag

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -203,9 +203,10 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
 #endif
     ucp_ep_ext_gen(ep)->user_data         = NULL;
     ucp_ep_ext_control(ep)->cm_idx        = UCP_NULL_RESOURCE;
-    ucp_ep_ext_control(ep)->err_cb        = NULL;
     ucp_ep_ext_control(ep)->local_ep_id   = UCS_PTR_MAP_KEY_INVALID;
     ucp_ep_ext_control(ep)->remote_ep_id  = UCS_PTR_MAP_KEY_INVALID;
+    ucp_ep_ext_control(ep)->err_cb        = NULL;
+    ucp_ep_ext_control(ep)->close_req     = NULL;
 #if UCS_ENABLE_ASSERT
     ucp_ep_ext_control(ep)->ka_last_round = 0;
 #endif
@@ -1264,11 +1265,10 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
 
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
         if (ucp_ep->flags & UCP_EP_FLAG_CLOSED) {
-            if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
+            if (ep_ext_control->close_req != NULL) {
                 /* Promote close operation to CANCEL in case of transport error,
                  * since the disconnect event may never arrive. */
-                close_req                        =
-                        ep_ext_control->close_req.req;
+                close_req                        = ep_ext_control->close_req;
                 close_req->send.flush.uct_flags |= UCT_FLUSH_FLAG_CANCEL;
                 ucp_ep_local_disconnect_progress(close_req);
             }
@@ -1412,11 +1412,10 @@ unsigned ucp_ep_local_disconnect_progress(void *arg)
 static void ucp_ep_set_close_request(ucp_ep_h ep, ucp_request_t *request,
                                      const char *debug_msg)
 {
+    ucs_assertv(ucp_ep_ext_control(ep)->close_req == NULL,
+                "ep=%p: close_req=%p", ep, ucp_ep_ext_control(ep)->close_req);
     ucs_trace("ep %p: setting close request %p, %s", ep, request, debug_msg);
-
-    ucp_ep_flush_state_invalidate(ep);
-    ucp_ep_ext_control(ep)->close_req.req = request;
-    ucp_ep_update_flags(ep, UCP_EP_FLAG_CLOSE_REQ_VALID, 0);
+    ucp_ep_ext_control(ep)->close_req = request;
 }
 
 void ucp_ep_register_disconnect_progress(ucp_request_t *req)
@@ -3238,9 +3237,8 @@ void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status)
     }
 
     if (/* Flush state is already valid (i.e. EP doesn't exist on matching
-         * context) and not invalidated yet, also remote EP ID is already set */
-        !(ucp_ep->flags &
-          (UCP_EP_FLAG_ON_MATCH_CTX | UCP_EP_FLAG_CLOSE_REQ_VALID))) {
+         * context) and not invalidated yet */
+        !(ucp_ep->flags & UCP_EP_FLAG_ON_MATCH_CTX)) {
         flush_state = ucp_ep_flush_state(ucp_ep);
 
         /* Adjust 'comp_sn' value to a value stored in 'send_sn' by emulating

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -72,8 +72,7 @@ enum {
     UCP_EP_FLAG_REMOTE_ID              = UCS_BIT(7), /* remote ID is valid */
     UCP_EP_FLAG_CONNECT_PRE_REQ_QUEUED = UCS_BIT(9), /* Pre-Connection request was queued */
     UCP_EP_FLAG_CLOSED                 = UCS_BIT(10),/* EP was closed */
-    UCP_EP_FLAG_CLOSE_REQ_VALID        = UCS_BIT(11),/* close protocol is started and
-                                                        close_req is valid */
+    /* 11 bit is vacant for a flag */
     UCP_EP_FLAG_ERR_HANDLER_INVOKED    = UCS_BIT(12),/* error handler was called */
     UCP_EP_FLAG_INTERNAL               = UCS_BIT(13),/* the internal EP which holds
                                                         temporary wireup configuration or
@@ -424,15 +423,6 @@ typedef struct {
 
 
 /**
- * Status of protocol-level remote completions
- */
-typedef struct {
-    ucp_request_t             *req;             /* Flush request which is
-                                                   used in close protocol */
-} ucp_ep_close_proto_req_t;
-
-
-/**
  * Endpoint extension for control data path
  */
 typedef struct {
@@ -440,7 +430,7 @@ typedef struct {
     ucs_ptr_map_key_t        local_ep_id; /* Local EP ID */
     ucs_ptr_map_key_t        remote_ep_id; /* Remote EP ID */
     ucp_err_handler_cb_t     err_cb; /* Error handler */
-    ucp_ep_close_proto_req_t close_req; /* Close protocol request */
+    ucp_request_t            *close_req; /* Close protocol request */
 #if UCS_ENABLE_ASSERT
     ucs_time_t               ka_last_round; /* Time of last KA round done */
 #endif

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -152,7 +152,6 @@ static UCS_F_ALWAYS_INLINE ucp_ep_flush_state_t* ucp_ep_flush_state(ucp_ep_h ep)
 {
     ucs_assert(ep->flags & UCP_EP_FLAG_FLUSH_STATE_VALID);
     ucs_assert(!(ep->flags & UCP_EP_FLAG_ON_MATCH_CTX));
-    ucs_assert(!(ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID));
     return &ucp_ep_ext_gen(ep)->flush_state;
 }
 

--- a/src/ucp/wireup/ep_match.c
+++ b/src/ucp/wireup/ep_match.c
@@ -135,11 +135,8 @@ void ucp_ep_match_remove_ep(ucp_worker_h worker, ucp_ep_h ep)
                                UCS_CONN_MATCH_QUEUE_EXP);
 
     ucp_ep_update_flags(ep, 0, UCP_EP_FLAG_ON_MATCH_CTX);
-    if (!(ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID)) {
-        /* Reset the endpoint's flush state to make it valid in case of
-         * discarding the endpoint during error handling. The flush state
-         * will be used to complete remote RMA requests during purging
-         * requests */
-        ucp_ep_flush_state_reset(ep);
-    }
+    /* Reset the endpoint's flush state to make it valid in case of discarding
+     * the endpoint during error handling. The flush state will be used to
+     * complete remote RMA requests during purging requests */
+    ucp_ep_flush_state_reset(ep);
 }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -820,9 +820,9 @@ static void ucp_ep_cm_remote_disconnect_progress(ucp_ep_h ucp_ep)
     ucs_assert(ucp_ep_get_cm_uct_ep(ucp_ep) != NULL);
 
     ucs_assert(ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
-    if (ucs_test_all_flags(ucp_ep->flags, UCP_EP_FLAG_CLOSED |
-                                          UCP_EP_FLAG_CLOSE_REQ_VALID)) {
-        ucp_request_complete_send(ucp_ep_ext_control(ucp_ep)->close_req.req,
+    if ((ucp_ep->flags & UCP_EP_FLAG_CLOSED) &&
+        (ucp_ep_ext_control(ucp_ep)->close_req != NULL)) {
+        ucp_request_complete_send(ucp_ep_ext_control(ucp_ep)->close_req,
                                   UCS_OK);
         return;
     }
@@ -867,17 +867,17 @@ static unsigned ucp_ep_cm_disconnect_progress(void *arg)
            - if close req is valid this is ucp_ep_close_nb request and it will
              be completed as the ep is destroyed, i.e. flushed and disconnected
              with any status */
-        if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
+        if (ucp_ep_ext_control(ucp_ep)->close_req != NULL) {
             ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
         }
     } else if (ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED) {
         ucp_ep_cm_remote_disconnect_progress(ucp_ep);
-    } else if (ucp_ep->flags & UCP_EP_FLAG_CLOSE_REQ_VALID) {
+    } else if (ucp_ep_ext_control(ucp_ep)->close_req != NULL) {
         /* if the EP is not local connected, the EP has been closed and flushed,
            CM lane is disconnected, complete close request and destroy EP */
         ucs_assert(ucp_ep->flags & UCP_EP_FLAG_CLOSED);
         ucp_ep_update_flags(ucp_ep, 0, UCP_EP_FLAG_REMOTE_CONNECTED);
-        close_req = ucp_ep_ext_control(ucp_ep)->close_req.req;
+        close_req = ucp_ep_ext_control(ucp_ep)->close_req;
         ucp_ep_local_disconnect_progress(close_req);
         /* don't touch UCP EP after local disconnect, since it is not valid
          * anymore */


### PR DESCRIPTION
## What

Get rid of `UCP_EP_CLOSE_REQ_VALID` flag.

## Why ?

To have one more free bit to use for another flag when it is needed.

## How ?

1. Remove `UCP_EP_CLOSE_REQ_VALID` flag and all places where it is used.
2. Remove `ucp_ep_close_proto_req_t` structure.
3. Initialize `close_req` to `NULL`.
4. Check `close_req != NULL` where `UCP_EP_CLOSE_REQ_VALID` flag was checked.
5. Don't check `close_req != NULL` fro flush_state and EP matching context, since they are not share the union anymore.