### PR TITLE
INFRA/CONSTRUCTORS: added ID to constructor/destructor macro

### DIFF
--- a/src/tools/perf/cuda/cuda_alloc.c
+++ b/src/tools/perf/cuda/cuda_alloc.c
@@ -142,7 +142,7 @@ static void* ucx_perf_cuda_memset(void *dst, int value, size_t count)
     return dst;
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(cuda_alloc) {
     static ucx_perf_allocator_t cuda_allocator = {
         .mem_type  = UCS_MEMORY_TYPE_CUDA,
         .init      = ucx_perf_cuda_init,
@@ -163,7 +163,7 @@ UCS_STATIC_INIT {
     ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA]         = &cuda_allocator;
     ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA_MANAGED] = &cuda_managed_allocator;
 }
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(cuda_alloc) {
     ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA]         = NULL;
     ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_CUDA_MANAGED] = NULL;
 

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -345,12 +345,12 @@ static ucm_event_installer_t ucm_cuda_initializer = {
     .get_existing_alloc = ucm_cudamem_get_existing_alloc
 };
 
-UCS_STATIC_INIT
+UCS_STATIC_INIT(cudamem)
 {
     ucs_list_add_tail(&ucm_event_installer_list, &ucm_cuda_initializer.list);
 }
 
-UCS_STATIC_CLEANUP
+UCS_STATIC_CLEANUP(cudamem)
 {
     ucs_list_del(&ucm_cuda_initializer.list);
 }

--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -660,7 +660,7 @@ ucs_status_t ucm_test_external_events(int events)
     return ucm_mmap_test_events(events & ucm_external_events, "external");
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(ucm_library) {
     UCS_CLEANUP_ONCE(&ucm_library_init_once) {
         kh_destroy_inplace(ucm_ptr_size, &ucm_shmat_ptrs);
         pthread_spin_destroy(&ucm_kh_lock);

--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -899,7 +899,7 @@ void ucm_malloc_state_reset(int default_mmap_thresh, int default_trim_thresh)
     ucm_malloc_set_env_mallopt();
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(malloc_hook) {
     ucs_recursive_spinlock_init(&ucm_malloc_hook_state.lock, 0);
     kh_init_inplace(mmap_ptrs, &ucm_malloc_hook_state.ptrs);
 }

--- a/src/ucm/rocm/rocmmem.c
+++ b/src/ucm/rocm/rocmmem.c
@@ -185,10 +185,10 @@ static ucm_event_installer_t ucm_rocm_initializer = {
     .get_existing_alloc = ucm_rocmmem_get_existing_alloc
 };
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(rockmem) {
     ucs_list_add_tail(&ucm_event_installer_list, &ucm_rocm_initializer.list);
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(rockmem) {
     ucs_list_del(&ucm_rocm_initializer.list);
 }

--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -289,6 +289,6 @@ void __ucm_log(const char *file, unsigned line, const char *function,
     }
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(log) {
     gethostname(ucm_log_hostname, sizeof(ucm_log_hostname));
 }

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -750,6 +750,6 @@ out_unlock:
     return status;
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(reloc) {
     kh_init_inplace(ucm_dl_info_hash, &ucm_dl_info_hash);
 }

--- a/src/ucp/am/eager.c
+++ b/src/ucp/am/eager.c
@@ -107,7 +107,7 @@ static ucp_proto_t ucp_eager_short_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_eager_short_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_short_proto);
+UCP_PROTO_REGISTER(eager_short, &ucp_eager_short_proto);
 
 static UCS_F_ALWAYS_INLINE void
 ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
@@ -214,4 +214,4 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_eager_bcopy_single_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
+UCP_PROTO_REGISTER(eager_bcopy_single, &ucp_eager_bcopy_single_proto);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -332,7 +332,7 @@ typedef struct ucp_tl_iface_atomic_flags {
  * Define UCP active message handler.
  */
 #define UCP_DEFINE_AM(_features, _id, _cb, _tracer, _flags) \
-    UCS_STATIC_INIT { \
+    UCS_STATIC_INIT(_cb) { \
         ucp_am_handlers[_id].features = _features; \
         ucp_am_handlers[_id].cb       = _cb; \
         ucp_am_handlers[_id].tracer   = _tracer; \
@@ -355,7 +355,7 @@ typedef struct ucp_tl_iface_atomic_flags {
         return ucp_am_handlers[_id].cb(wiface->worker, data, length, flags); \
     } \
     \
-    UCS_STATIC_INIT { \
+    UCS_STATIC_INIT(PROXY_##_id) { \
         ucp_am_handlers[_id].proxy_cb = ucp_am_##_id##_counting_proxy; \
     }
 

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -211,8 +211,8 @@ struct ucp_proto {
 /**
  * Register a protocol definition.
  */
-#define UCP_PROTO_REGISTER(_proto) \
-    UCS_STATIC_INIT { \
+#define UCP_PROTO_REGISTER(_id, _proto) \
+    UCS_STATIC_INIT(proto_##_id) { \
         ucs_assert_always(ucp_protocols_count < UCP_PROTO_MAX_COUNT); \
         ucp_protocols[ucp_protocols_count++] = (_proto); \
     }

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -94,4 +94,4 @@ static ucp_proto_t ucp_reconfig_proto = {
     .config_str = (ucp_proto_config_str_func_t)ucs_empty_function,
     .progress   = {ucp_proto_reconfig_progress}
 };
-UCP_PROTO_REGISTER(&ucp_reconfig_proto);
+UCP_PROTO_REGISTER(reconfig, &ucp_reconfig_proto);

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -202,7 +202,7 @@ static ucp_proto_t ucp_amo_proto_##_id = { \
     .progress   = {ucp_amo_progress_##_id} \
 }; \
 \
-UCP_PROTO_REGISTER(&ucp_amo_proto_##_id)
+UCP_PROTO_REGISTER(amo_##_id, &ucp_amo_proto_##_id)
 
 #define UCP_PROTO_AMO_REGISTER_MTYPE(_id, _op_id, _bits) \
     UCP_PROTO_AMO_REGISTER(_id,         _op_id, _bits, UCT_EP_OP_LAST,      offload) \

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -422,7 +422,7 @@ static ucp_proto_t ucp_get_amo_post_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_amo_sw_progress_post}
 };
-UCP_PROTO_REGISTER(&ucp_get_amo_post_proto);
+UCP_PROTO_REGISTER(get_amo_post, &ucp_get_amo_post_proto);
 
 static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
 {
@@ -449,4 +449,4 @@ static ucp_proto_t ucp_get_amo_fetch_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_amo_sw_progress_fetch}
 };
-UCP_PROTO_REGISTER(&ucp_get_amo_fetch_proto);
+UCP_PROTO_REGISTER(get_amo_fetch, &ucp_get_amo_fetch_proto);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -105,4 +105,4 @@ static ucp_proto_t ucp_get_am_bcopy_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_get_am_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_get_am_bcopy_proto);
+UCP_PROTO_REGISTER(get_am_bcopy, &ucp_get_am_bcopy_proto);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -111,7 +111,7 @@ static ucp_proto_t ucp_get_offload_bcopy_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_get_offload_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_get_offload_bcopy_proto);
+UCP_PROTO_REGISTER(get_offload_bcopy, &ucp_get_offload_bcopy_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
@@ -189,4 +189,4 @@ static ucp_proto_t ucp_get_offload_zcopy_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_get_offload_zcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_get_offload_zcopy_proto);
+UCP_PROTO_REGISTER(get_offload_zcopy, &ucp_get_offload_zcopy_proto);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -110,5 +110,5 @@ static ucp_proto_t ucp_put_am_bcopy_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_put_am_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_put_am_bcopy_proto);
+UCP_PROTO_REGISTER(put_am_bcopy, &ucp_put_am_bcopy_proto);
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -86,7 +86,7 @@ static ucp_proto_t ucp_put_offload_short_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_put_offload_short_progress}
 };
-UCP_PROTO_REGISTER(&ucp_put_offload_short_proto);
+UCP_PROTO_REGISTER(put_offload_short, &ucp_put_offload_short_proto);
 
 static size_t ucp_proto_put_offload_bcopy_pack(void *dest, void *arg)
 {
@@ -180,7 +180,7 @@ static ucp_proto_t ucp_put_offload_bcopy_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_put_offload_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_put_offload_bcopy_proto);
+UCP_PROTO_REGISTER(put_offload_bcopy, &ucp_put_offload_bcopy_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
@@ -258,4 +258,4 @@ static ucp_proto_t ucp_put_offload_zcopy_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_put_offload_zcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_put_offload_zcopy_proto);
+UCP_PROTO_REGISTER(put_offload_zcopy, &ucp_put_offload_zcopy_proto);

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -123,4 +123,4 @@ static ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_rndv_am_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_rndv_am_bcopy_proto);
+UCP_PROTO_REGISTER(rndv_am_bcopy, &ucp_rndv_am_bcopy_proto);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -151,7 +151,7 @@ static ucp_proto_t ucp_rndv_get_zcopy_proto = {
          [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     }
 };
-UCP_PROTO_REGISTER(&ucp_rndv_get_zcopy_proto);
+UCP_PROTO_REGISTER(rndv_get_zcopy, &ucp_rndv_get_zcopy_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_mtype_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
@@ -248,7 +248,7 @@ static ucp_proto_t ucp_rndv_get_mtype_proto = {
         [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
     }
 };
-UCP_PROTO_REGISTER(&ucp_rndv_get_mtype_proto);
+UCP_PROTO_REGISTER(rndv_get_mtype, &ucp_rndv_get_mtype_proto);
 
 
 static ucs_status_t
@@ -300,4 +300,4 @@ static ucp_proto_t ucp_rndv_ats_proto = {
     .config_str = ucp_proto_rndv_ack_config_str,
     .progress   = {ucp_proto_rndv_ats_progress}
 };
-UCP_PROTO_REGISTER(&ucp_rndv_ats_proto);
+UCP_PROTO_REGISTER(rndv_ats, &ucp_rndv_ats_proto);

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -267,7 +267,7 @@ static ucp_proto_t ucp_rndv_send_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_send_ppln_atp_progress,
     },
 };
-UCP_PROTO_REGISTER(&ucp_rndv_send_ppln_proto);
+UCP_PROTO_REGISTER(rndv_send_ppln, &ucp_rndv_send_ppln_proto);
 
 static ucs_status_t
 ucp_proto_rndv_recv_ppln_init(const ucp_proto_init_params_t *init_params)
@@ -301,4 +301,4 @@ static ucp_proto_t ucp_rndv_recv_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_recv_ppln_ats_progress,
     },
 };
-UCP_PROTO_REGISTER(&ucp_rndv_recv_ppln_proto);
+UCP_PROTO_REGISTER(rndv_recv_ppln, &ucp_rndv_recv_ppln_proto);

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -387,7 +387,7 @@ static ucp_proto_t ucp_rndv_put_zcopy_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
 };
-UCP_PROTO_REGISTER(&ucp_rndv_put_zcopy_proto);
+UCP_PROTO_REGISTER(rndv_put_zcopy, &ucp_rndv_put_zcopy_proto);
 
 
 static void ucp_proto_rndv_put_mtype_pack_completion(uct_completion_t *uct_comp)
@@ -512,4 +512,4 @@ static ucp_proto_t ucp_rndv_put_mtype_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
 };
-UCP_PROTO_REGISTER(&ucp_rndv_put_mtype_proto);
+UCP_PROTO_REGISTER(rndv_put_mtype, &ucp_rndv_put_mtype_proto);

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -159,5 +159,5 @@ static ucp_proto_t ucp_rndv_rkey_ptr_proto = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     }
 };
-UCP_PROTO_REGISTER(&ucp_rndv_rkey_ptr_proto);
+UCP_PROTO_REGISTER(rndv_rkey_ptr, &ucp_rndv_rkey_ptr_proto);
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -233,7 +233,7 @@ static ucp_proto_t ucp_rndv_rtr_proto = {
     .config_str = ucp_proto_rndv_ctrl_config_str,
     .progress   = {ucp_proto_rndv_rtr_progress}
 };
-UCP_PROTO_REGISTER(&ucp_rndv_rtr_proto);
+UCP_PROTO_REGISTER(rndv_rtr, &ucp_rndv_rtr_proto);
 
 
 static size_t ucp_proto_rndv_rtr_mtype_pack(void *dest, void *arg)
@@ -371,7 +371,7 @@ static ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .config_str = ucp_proto_rndv_ctrl_config_str,
     .progress   = {ucp_proto_rndv_rtr_mtype_progress}
 };
-UCP_PROTO_REGISTER(&ucp_rndv_rtr_mtype_proto);
+UCP_PROTO_REGISTER(rndv_rtr_mtype, &ucp_rndv_rtr_mtype_proto);
 
 ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,
                                            unsigned flags)

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -169,7 +169,7 @@ static ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_eager_bcopy_multi_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_multi_proto);
+UCP_PROTO_REGISTER(eager_bcopy_multi, &ucp_eager_bcopy_multi_proto);
 
 static ucs_status_t
 ucp_proto_eager_sync_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
@@ -244,7 +244,7 @@ static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_eager_sync_bcopy_multi_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_multi_proto);
+UCP_PROTO_REGISTER(eager_sync_bcopy_multi, &ucp_eager_sync_bcopy_multi_proto);
 
 static ucs_status_t
 ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
@@ -325,4 +325,4 @@ static ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .config_str = ucp_proto_multi_config_str,
     .progress   = {ucp_proto_eager_zcopy_multi_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_zcopy_multi_proto);
+UCP_PROTO_REGISTER(eager_zcopy_multi, &ucp_eager_zcopy_multi_proto);

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -82,7 +82,7 @@ static ucp_proto_t ucp_eager_short_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_eager_short_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_short_proto);
+UCP_PROTO_REGISTER(eager_short, &ucp_eager_short_proto);
 
 static size_t ucp_eager_single_pack(void *dest, void *arg)
 {
@@ -148,7 +148,7 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_eager_bcopy_single_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
+UCP_PROTO_REGISTER(eager_bcopy_single, &ucp_eager_bcopy_single_proto);
 
 static ucs_status_t
 ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
@@ -215,4 +215,4 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_eager_zcopy_single_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);
+UCP_PROTO_REGISTER(eager_zcopy_single, &ucp_eager_zcopy_single_proto);

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -79,7 +79,7 @@ static ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_eager_tag_offload_short_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_tag_offload_short_proto);
+UCP_PROTO_REGISTER(eager_tag_offload_short, &ucp_eager_tag_offload_short_proto);
 
 static size_t ucp_eager_tag_offload_pack(void *dest, void *arg)
 {
@@ -169,7 +169,7 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_eager_tag_offload_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
+UCP_PROTO_REGISTER(eager_bcopy_single, &ucp_eager_bcopy_single_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_eager_sync_tag_offload_bcopy_posted(ucp_request_t *req)
@@ -206,7 +206,7 @@ static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_eager_sync_tag_offload_bcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_single_proto);
+UCP_PROTO_REGISTER(eager_sync_bcopy_single, &ucp_eager_sync_bcopy_single_proto);
 
 static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init_common(
         const ucp_proto_init_params_t *init_params, ucp_proto_id_t op_id)
@@ -279,7 +279,7 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_eager_tag_offload_zcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);
+UCP_PROTO_REGISTER(eager_zcopy_single, &ucp_eager_zcopy_single_proto);
 
 static ucs_status_t ucp_proto_eager_sync_tag_offload_zcopy_init(
         const ucp_proto_init_params_t *init_params)
@@ -335,4 +335,4 @@ static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .config_str = ucp_proto_single_config_str,
     .progress   = {ucp_proto_eager_sync_tag_offload_zcopy_progress}
 };
-UCP_PROTO_REGISTER(&ucp_eager_sync_zcopy_single_proto);
+UCP_PROTO_REGISTER(eager_sync_zcopy_single, &ucp_eager_sync_zcopy_single_proto);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -155,4 +155,4 @@ static ucp_proto_t ucp_tag_rndv_proto = {
     .config_str = ucp_proto_rndv_ctrl_config_str,
     .progress   = {ucp_tag_rndv_rts_progress}
 };
-UCP_PROTO_REGISTER(&ucp_tag_rndv_proto);
+UCP_PROTO_REGISTER(tag_rndv, &ucp_tag_rndv_proto);

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -422,7 +422,7 @@ static ucs_status_t ucs_vfs_write_log_level(void *obj, const char *buffer,
  * UCS_STATIC_CLEANUP in global_opts.c could happen after execution of
  * UCS_STATIC_CLEANUP of vfs_obj.c file.
  */
-UCS_STATIC_INIT
+UCS_STATIC_INIT(global_opts)
 {
     ucs_vfs_obj_add_dir(NULL, &ucs_global_opts, "ucs/global_opts");
     ucs_vfs_obj_add_rw_file(&ucs_global_opts, ucs_vfs_read_log_level,

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1977,7 +1977,7 @@ int ucs_config_names_search(const ucs_config_names_array_t *config_names,
     return -1;
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(parser) {
     const char *key;
     char *value;
 

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -109,12 +109,12 @@ typedef struct ucs_config_bw_spec {
     }
 
 
-#define UCS_CONFIG_REGISTER_TABLE_ENTRY(_entry, _list) \
-    UCS_STATIC_INIT { \
+#define UCS_CONFIG_REGISTER_TABLE_ENTRY(_id, _entry, _list) \
+    UCS_STATIC_INIT(_id) { \
         ucs_list_add_tail(_list, &(_entry)->list); \
     } \
     \
-    UCS_STATIC_CLEANUP { \
+    UCS_STATIC_CLEANUP(_id) { \
         ucs_list_del(&(_entry)->list); \
     }
 
@@ -125,7 +125,7 @@ typedef struct ucs_config_bw_spec {
         .prefix = _prefix, \
         .size   = sizeof(_type) \
     }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&_table##_config_entry, _list);
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(_table, &_table##_config_entry, _list);
 
 extern ucs_list_link_t ucs_config_global_list;
 

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -119,7 +119,7 @@ static ucs_config_field_t ucm_global_config_table[] = {
 UCS_CONFIG_REGISTER_TABLE(ucm_global_config_table, "UCM", UCM_CONFIG_PREFIX,
                           ucm_global_config_t, &ucs_config_global_list)
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(ucm_opts) {
     ucm_global_config_t ucm_opts;
     (void)ucs_config_parser_fill_opts(&ucm_opts, ucm_global_config_table,
                                       UCS_DEFAULT_ENV_PREFIX, UCM_CONFIG_PREFIX,

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -398,11 +398,11 @@ static UCS_CLASS_CLEANUP_FUNC(ucs_memtype_cache_t)
     pthread_rwlock_destroy(&self->lock);
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(memory_cache) {
     ucs_spinlock_init(&ucs_memtype_cache_global_instance_lock, 0);
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(memory_cache) {
     ucs_spinlock_destroy(&ucs_memtype_cache_global_instance_lock);
 
     if (ucs_memtype_cache_global_instance) {

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -194,14 +194,14 @@
 /*
  * Define code which runs at global constructor phase
  */
-#define UCS_STATIC_INIT \
-    static void UCS_F_CTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_ctor)()
+#define UCS_STATIC_INIT(_id) \
+    static void UCS_F_CTOR UCS_PP_TOKENPASTE3(ucs_initializer_, _id, _ctor)()
 
 /*
  * Define code which runs at global destructor phase
  */
-#define UCS_STATIC_CLEANUP \
-    static void UCS_F_DTOR UCS_PP_APPEND_UNIQUE_ID(ucs_initializer_dtor)()
+#define UCS_STATIC_CLEANUP(_id) \
+    static void UCS_F_DTOR UCS_PP_TOKENPASTE3(ucs_initializer_, _id, _dtor)()
 
 /*
  * Check if the two types are the same

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -87,8 +87,7 @@ static void ucs_modules_load()
     UCS_MODULE_FRAMEWORK_LOAD(ucs, UCS_MODULE_LOAD_FLAG_GLOBAL);
 }
 
-static void UCS_F_CTOR ucs_init()
-{
+UCS_STATIC_INIT(ucs_init) {
     ucs_status_t status;
 
     ucs_check_cpu_flags();
@@ -118,7 +117,7 @@ static void UCS_F_CTOR ucs_init()
     ucs_modules_load();
 }
 
-static void UCS_F_DTOR ucs_cleanup(void)
+UCS_STATIC_CLEANUP(ucs_init)
 {
     ucs_topo_cleanup();
     ucs_async_global_cleanup();

--- a/src/ucs/vfs/base/vfs_obj.c
+++ b/src/ucs/vfs/base/vfs_obj.c
@@ -816,7 +816,7 @@ out_unlock:
     return status;
 }
 
-UCS_STATIC_CLEANUP
+UCS_STATIC_CLEANUP(ucs_vfs)
 {
     UCS_CLEANUP_ONCE(&ucs_vfs_init_once) {
         ucs_vfs_node_remove_children(&ucs_vfs_obj_context.root);

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -523,7 +523,7 @@ static void ucs_vfs_fuse_atfork_child()
     ucs_vfs_fuse_context.watch_desc = -1;
 }
 
-UCS_STATIC_INIT
+UCS_STATIC_INIT(vfs_fuse)
 {
     if (ucs_global_opts.vfs_enable) {
         pthread_atfork(NULL, NULL, ucs_vfs_fuse_atfork_child);
@@ -532,7 +532,7 @@ UCS_STATIC_INIT
     }
 }
 
-UCS_STATIC_CLEANUP
+UCS_STATIC_CLEANUP(vfs_fuse)
 {
     if (ucs_vfs_fuse_context.thread_id != -1) {
         ucs_fuse_thread_stop();

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -170,13 +170,15 @@ struct uct_component {
  *
  * @param [in] _component  Pointer to a global component structure to register.
  */
-#define UCT_COMPONENT_REGISTER(_component) \
+#define UCT_COMPONENT_REGISTER(_id, _component) \
     extern ucs_list_link_t uct_components_list; \
-    UCS_STATIC_INIT { \
+    UCS_STATIC_INIT(_id) { \
         ucs_list_add_tail(&uct_components_list, &(_component)->list); \
     } \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->md_config, &ucs_config_global_list); \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->cm_config, &ucs_config_global_list);
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(component_##_id##_md_config, \
+                                    &(_component)->md_config, &ucs_config_global_list); \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(component_##_id##_cm_config, \
+                                    &(_component)->cm_config, &ucs_config_global_list);
 
 
 /**

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -386,8 +386,10 @@ typedef struct uct_iface_local_addr_ns {
             .size           = sizeof(_cfg_struct), \
          } \
     }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(uct_##_name##_tl).config, &ucs_config_global_list); \
-    UCS_STATIC_INIT { \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(component_##_name, \
+                                    &(uct_##_name##_tl).config, \
+                                    &ucs_config_global_list); \
+    UCS_STATIC_INIT(tl_##_name) { \
         ucs_list_add_tail(&(_component)->tl_list, &(uct_##_name##_tl).list); \
     }
 

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -296,11 +296,11 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
                                            num_resources_p);
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(cuda_md) {
     ucs_spinlock_init(&uct_cuda_base_lock, 0);
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(cuda_md) {
     ucs_spinlock_destroy(&uct_cuda_base_lock);
 }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -252,4 +252,4 @@ uct_component_t uct_cuda_copy_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_cuda_copy_component);
+UCT_COMPONENT_REGISTER(cuda_copy, &uct_cuda_copy_component);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -411,12 +411,12 @@ void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache)
     ucs_free(cache);
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(cuda_ipc_cache) {
     ucs_recursive_spinlock_init(&uct_cuda_ipc_remote_cache.lock, 0);
     kh_init_inplace(cuda_ipc_rem_cache, &uct_cuda_ipc_remote_cache.hash);
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(cuda_ipc_cache) {
     uct_cuda_ipc_cache_t *rem_cache;
 
     kh_foreach_value(&uct_cuda_ipc_remote_cache.hash, rem_cache, {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -355,5 +355,5 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
     },
     .md                     = NULL,
 };
-UCT_COMPONENT_REGISTER(&uct_cuda_ipc_component.super);
+UCT_COMPONENT_REGISTER(cuda_ipc, &uct_cuda_ipc_component.super);
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -459,5 +459,5 @@ uct_component_t uct_gdr_copy_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_gdr_copy_component);
+UCT_COMPONENT_REGISTER(gdr_copy, &uct_gdr_copy_component);
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1902,4 +1902,4 @@ uct_component_t uct_ib_component = {
     .flags              = 0,
     .md_vfs_init        = uct_ib_md_vfs_init
 };
-UCT_COMPONENT_REGISTER(&uct_ib_component);
+UCT_COMPONENT_REGISTER(ib, &uct_ib_component);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -359,7 +359,7 @@ typedef struct uct_ib_md_ops_entry {
 
 #define UCT_IB_MD_OPS(_md_ops, _priority) \
     extern ucs_list_link_t uct_ib_md_ops_list; \
-    UCS_STATIC_INIT { \
+    UCS_STATIC_INIT(_md_ops) { \
         static uct_ib_md_ops_entry_t *p, entry = { \
             .name     = UCS_PP_MAKE_STRING(_md_ops), \
             .ops      = &_md_ops, \

--- a/src/uct/ib/rdmacm/rdmacm_component.c
+++ b/src/uct/ib/rdmacm/rdmacm_component.c
@@ -65,4 +65,4 @@ uct_component_t uct_rdmacm_component = {
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
 
-UCT_COMPONENT_REGISTER(&uct_rdmacm_component)
+UCT_COMPONENT_REGISTER(rdmacm, &uct_rdmacm_component)

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -397,5 +397,5 @@ uct_component_t uct_rocm_copy_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_rocm_copy_component);
+UCT_COMPONENT_REGISTER(rocm_copy, &uct_rocm_copy_component);
 

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -164,5 +164,5 @@ uct_component_t uct_rocm_gdr_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_rocm_gdr_component);
+UCT_COMPONENT_REGISTER(rocm_gdr, &uct_rocm_gdr_component);
 

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -185,5 +185,5 @@ uct_component_t uct_rocm_ipc_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_rocm_ipc_component);
+UCT_COMPONENT_REGISTER(rocm_ipc, &uct_rocm_ipc_component);
 

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -186,7 +186,7 @@ typedef struct uct_mm_component {
        }, \
        .md_ops                  = (_md_ops) \
     }; \
-    UCT_COMPONENT_REGISTER(&(_var).super); \
+    UCT_COMPONENT_REGISTER(mm_##_name, &(_var).super); \
 
 
 extern ucs_config_field_t uct_mm_md_config_table[];

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -76,12 +76,12 @@ static ucs_config_field_t uct_xpmem_iface_config_table[] = {
   {NULL}
 };
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(xpmem) {
     ucs_recursive_spinlock_init(&uct_xpmem_remote_mem_lock, 0);
     kh_init_inplace(xpmem_remote_mem, &uct_xpmem_remote_mem_hash);
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP(xpmem) {
     unsigned long num_leaked_segments;
     uct_xpmem_remote_mem_t *rmem;
 

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -202,4 +202,4 @@ uct_component_t uct_cma_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_cma_component);
+UCT_COMPONENT_REGISTER(cma, &uct_cma_component);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -427,4 +427,4 @@ uct_component_t uct_knem_component = {
     .flags              = 0,
     .md_vfs_init        = uct_knem_md_vfs_init
 };
-UCT_COMPONENT_REGISTER(&uct_knem_component);
+UCT_COMPONENT_REGISTER(knem, &uct_knem_component);

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -472,4 +472,4 @@ static uct_component_t uct_self_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_self_component);
+UCT_COMPONENT_REGISTER(self, &uct_self_component);

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -152,4 +152,4 @@ uct_component_t uct_tcp_component = {
     .flags              = UCT_COMPONENT_FLAG_CM,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_tcp_component)
+UCT_COMPONENT_REGISTER(tcp, &uct_tcp_component)

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -243,4 +243,4 @@ uct_component_t uct_ugni_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_ugni_component);
+UCT_COMPONENT_REGISTER(ugni, &uct_ugni_component);

--- a/test/gtest/ucs/test_module/test_module.c
+++ b/test/gtest/ucs/test_module/test_module.c
@@ -8,6 +8,6 @@
 
 extern int test_module_loaded;
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT(test_module) {
     ++test_module_loaded;
 }


### PR DESCRIPTION
## What
- added ID to STATIC_INIT/CLEANUP macro and other related macros

## Why
- this feature allows to eliminate __COUNTER__ macro from constructor
- in future it will allow to add INIT_ONCE wrapper to constructors to
  prevent multiple initializations
- will allow to generate list of constructors [automatically]
- will be used to initialize UCX static library
