### PR TITLE
UCP: Fix UCP address v2 packing/unpacking and usage of seg_size

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -88,12 +88,16 @@ static inline uct_iface_attr_t *ucp_ep_get_iface_attr(ucp_ep_h ep, ucp_lane_inde
 
 static inline size_t ucp_ep_get_max_bcopy(ucp_ep_h ep, ucp_lane_index_t lane)
 {
-    return ucp_ep_get_iface_attr(ep, lane)->cap.am.max_bcopy;
+    size_t max_bcopy = ucp_ep_get_iface_attr(ep, lane)->cap.am.max_bcopy;
+
+    return ucs_min(ucp_ep_config(ep)->key.lanes[lane].seg_size, max_bcopy);
 }
 
 static inline size_t ucp_ep_get_max_zcopy(ucp_ep_h ep, ucp_lane_index_t lane)
 {
-    return ucp_ep_get_iface_attr(ep, lane)->cap.am.max_zcopy;
+    size_t max_zcopy = ucp_ep_get_iface_attr(ep, lane)->cap.am.max_zcopy;
+
+    return ucs_min(ucp_ep_config(ep)->key.lanes[lane].seg_size, max_zcopy);
 }
 
 static inline size_t ucp_ep_get_max_iov(ucp_ep_h ep, ucp_lane_index_t lane)

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -13,6 +13,10 @@
 #include <ucs/sys/math.h>
 
 
+/* Multiplicator of ucp_address_v2_packed_iface_attr_t->seg_size value */
+#define UCP_ADDRESS_IFACE_SEG_SIZE_FACTOR 64
+
+
 /* Which iface flags would be packed in the address */
 enum {
     UCP_ADDRESS_IFACE_FLAGS =
@@ -250,5 +254,15 @@ uint64_t ucp_address_get_client_id(const void *address);
  *         0 if address has all lanes information.
  */
 uint8_t ucp_address_is_am_only(const void *address);
+
+
+/**
+ * Returns maximal AM fragment size which can be received by the iface.
+ *
+ * @param [in] iface_attr Interface attributes.
+ *
+ * @return Maximal AM fragment size.
+ */
+size_t ucp_address_iface_seg_size(const uct_iface_attr_t *iface_attr);
 
 #endif


### PR DESCRIPTION
## What
- Fixes for UCP address v2 packing/unpacking:
  - Do not pack unused MD flags to md_index byte
  - Fix packing of latency and overhead (need to pack nsecs) 

- Take into account remote segment size when checking `max_bcopy` and `max_zcopy` for  UCT AM sends in UCP protocols

