### PR TITLE
UCT/CUDA: cache cuda ctx and cleanup if correct ctx is set

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -99,24 +99,19 @@
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
-#define UCT_CUDADRV_CTX_ACTIVE(_state) \
-    { \
-        CUdevice _dev; \
-        CUcontext _ctx; \
-        int _flags; \
-        if (CUDA_SUCCESS == cuCtxGetDevice(&_dev)) { \
-            cuDevicePrimaryCtxGetState(_dev, &_flags, &_state); \
-            if (_state == 0) { \
-                /* need to retain for malloc purposes */ \
-                if (CUDA_SUCCESS != cuDevicePrimaryCtxRetain(&_ctx, _dev)) { \
-                    ucs_fatal("unable to retain ctx after detecting device"); \
-                } \
-            } \
-            _state = 1; \
-        } else { \
-            _state = 0; \
-        } \
-    }
+static UCS_F_ALWAYS_INLINE int uct_cuda_base_is_context_active()
+{
+    CUcontext ctx;
+
+    return (CUDA_SUCCESS == cuCtxGetCurrent(&ctx)) && (ctx != NULL);
+}
+
+
+static UCS_F_ALWAYS_INLINE int uct_cuda_base_context_match(CUcontext ctx1,
+                                                           CUcontext ctx2)
+{
+    return ((ctx1 != NULL) && (ctx1 == ctx2));
+}
 
 
 typedef enum uct_cuda_base_gen {

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -111,6 +111,15 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src,
         return UCS_OK;
     }
 
+    /* ensure context is set before creating events/streams */
+    if (iface->cuda_context == NULL) {
+        UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&iface->cuda_context));
+        if (iface->cuda_context == NULL) {
+            ucs_error("attempt to perform cuda memcpy without active context");
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
     src_type = uct_cuda_copy_get_mem_type(base_iface->md, src, length);
     dst_type = uct_cuda_copy_get_mem_type(base_iface->md, dst, length);
     q_desc   = &iface->queue_desc[src_type][dst_type];

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -35,6 +35,8 @@ typedef struct uct_cuda_copy_iface {
     ucs_queue_head_t            active_queue;
     /* stream used to issue short operations */
     cudaStream_t                short_stream;
+    /* stream used to issue short operations */
+    CUcontext                   cuda_context;
     /* array of queue descriptors for each src/dst memory type combination */
     uct_cuda_copy_queue_desc_t  queue_desc[UCS_MEMORY_TYPE_LAST][UCS_MEMORY_TYPE_LAST];
     /* config parameters to control cuda copy transport */
@@ -60,8 +62,8 @@ typedef struct uct_cuda_copy_iface_config {
 
 
 typedef struct uct_cuda_copy_event_desc {
-    cudaEvent_t event;
+    cudaEvent_t      event;
     uct_completion_t *comp;
-    ucs_queue_elem_t  queue;
+    ucs_queue_elem_t queue;
 } uct_cuda_copy_event_desc_t;
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -155,15 +155,14 @@ static ucs_status_t uct_cuda_copy_mem_alloc(uct_md_h md, size_t *length_p,
                                             uct_mem_h *memh_p)
 {
     ucs_status_t status;
-    int active;
 
     if ((mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED) &&
         (mem_type != UCS_MEMORY_TYPE_CUDA)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    UCT_CUDADRV_CTX_ACTIVE(active);
-    if (!active) {
+    if (!uct_cuda_base_is_context_active()) {
+        ucs_error("attempt to allocate cuda memory without active context");
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -79,11 +79,9 @@ uct_cuda_ipc_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
 
 static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
 {
+    int active = uct_cuda_base_is_context_active();
     uct_cuda_ipc_cache_region_t *region, *tmp;
     ucs_list_link_t region_list;
-    int active;
-
-    UCT_CUDADRV_CTX_ACTIVE(active);
 
     ucs_list_head_init(&region_list);
     ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -75,6 +75,15 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         return UCS_ERR_IO_ERROR;
     }
 
+    /* ensure context is set before creating events/streams */
+    if (iface->cuda_context == NULL) {
+        UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&iface->cuda_context));
+        if (iface->cuda_context == NULL) {
+            ucs_error("attempt to perform cuda memcpy without active context");
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
     offset          = (uintptr_t)remote_addr - (uintptr_t)key->d_bptr;
     mapped_rem_addr = (void *) ((uintptr_t) mapped_addr + offset);
     ucs_assert(offset <= key->b_len);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -25,6 +25,7 @@ typedef struct uct_cuda_ipc_iface {
     ucs_queue_head_t outstanding_d2d_event_q; /* stream for outstanding d2d */
     int              eventfd;              /* get event notifications */
     int              streams_initialized;     /* indicates if stream created */
+    CUcontext        cuda_context;
     CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
                                               /* per-peer stream */
     unsigned long    stream_refcount[UCT_CUDA_IPC_MAX_PEERS];

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -118,6 +118,10 @@ void mem_buffer::set_device_context()
 #if HAVE_CUDA
     if (is_cuda_supported()) {
         cudaSetDevice(0);
+        /* need to call free as context maybe lazily initialized when calling
+         * cudaSetDevice(0) but calling cudaFree(0) should guarantee context
+         * creation upon return */
+        cudaFree(0);
     }
 #endif
 


### PR DESCRIPTION
## What
- cache cuda context against which Stream/Event resources are created
- during cleanup, if calling thread has the ctx against which resources were allocated, then destroy Stream/Event resources
- Also, don't retain primary context even for cuMemAlloc. Assume higher layer sets the right context before making cuMemAlloc attempt