### PR TITLE
UCP/SELECT: Add mem access lanes for all supported memory types

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1334,10 +1334,6 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->mem_type_mask            = 0;
     context->num_mem_type_detect_mds  = 0;
 
-    for (i = 0; i < UCS_MEMORY_TYPE_LAST; ++i) {
-        UCS_BITMAP_CLEAR(&context->mem_type_access_tls[i]);
-    }
-
     ucs_string_set_init(&avail_tls);
     UCS_STATIC_ASSERT(UCT_DEVICE_TYPE_NET == 0);
     for (dev_type = UCT_DEVICE_TYPE_NET; dev_type < UCT_DEVICE_TYPE_LAST; ++dev_type) {
@@ -2040,4 +2036,22 @@ const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx)
 {
     ucs_assert(cm_idx != UCP_NULL_RESOURCE);
     return context->tl_cmpts[context->config.cm_cmpt_idxs[cm_idx]].attr.name;
+}
+
+void ucp_context_get_mem_access_tls(ucp_context_h context,
+                                    ucs_memory_type_t mem_type,
+                                    ucp_tl_bitmap_t *tl_bitmap)
+{
+    const uct_md_attr_t *md_attr;
+    ucp_md_index_t md_index;
+    ucp_rsc_index_t tl_id;
+
+    UCS_BITMAP_CLEAR(tl_bitmap);
+    UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, tl_id) {
+        md_index = context->tl_rscs[tl_id].md_index;
+        md_attr  = &context->tl_mds[md_index].attr;
+        if (md_attr->cap.access_mem_types & UCS_BIT(mem_type)) {
+            UCS_BITMAP_SET(*tl_bitmap, tl_id);
+        }
+    }
 }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -234,10 +234,6 @@ typedef struct ucp_context {
                                                * Not all resources may be used if unified
                                                * mode is enabled. */
     ucp_rsc_index_t               num_tls;    /* Number of resources in the array */
-
-    /* Mask of memory type communication resources */
-    ucp_tl_bitmap_t               mem_type_access_tls[UCS_MEMORY_TYPE_LAST];
-
     ucp_proto_id_mask_t           proto_bitmap;  /* Enabled protocols */
 
     struct {
@@ -563,5 +559,10 @@ ucp_config_modify_internal(ucp_config_t *config, const char *name,
 
 
 void ucp_apply_uct_config_list(ucp_context_h context, void *config);
+
+
+void ucp_context_get_mem_access_tls(ucp_context_h context,
+                                    ucs_memory_type_t mem_type,
+                                    ucp_tl_bitmap_t *tl_bitmap);
 
 #endif

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -542,18 +542,17 @@ ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker)
     ucs_status_t status;
     void *address_buffer;
     size_t address_length;
+    ucp_tl_bitmap_t mem_access_tls;
     char ep_name[UCP_WORKER_ADDRESS_NAME_MAX];
 
     ucs_memory_type_for_each(mem_type) {
+        ucp_context_get_mem_access_tls(context, mem_type, &mem_access_tls);
         if (UCP_MEM_IS_HOST(mem_type) ||
-            UCS_BITMAP_IS_ZERO_INPLACE(
-                    &context->mem_type_access_tls[mem_type])) {
+            UCS_BITMAP_IS_ZERO_INPLACE(&mem_access_tls)) {
             continue;
         }
 
-        status = ucp_address_pack(worker, NULL,
-                                  &context->mem_type_access_tls[mem_type],
-                                  pack_flags,
+        status = ucp_address_pack(worker, NULL, &mem_access_tls, pack_flags,
                                   context->config.ext.worker_addr_version, NULL,
                                   &address_length, &address_buffer);
         if (status != UCS_OK) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1236,7 +1236,6 @@ ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
 {
     ucp_context_h context            = worker->context;
     ucp_tl_resource_desc_t *resource = &context->tl_rscs[tl_id];
-    uint8_t mem_type_index;
     ucs_status_t status;
 
     ucs_assert(wiface != NULL);
@@ -1279,12 +1278,6 @@ ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,
         } else {
             ucp_worker_iface_activate(wiface, 0);
         }
-    }
-
-    ucs_for_each_bit(mem_type_index,
-        context->tl_mds[resource->md_index].attr.cap.access_mem_types) {
-        ucs_assert(mem_type_index < UCS_MEMORY_TYPE_LAST);
-        UCS_BITMAP_SET(context->mem_type_access_tls[mem_type_index], tl_id);
     }
 
     return UCS_OK;

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -43,6 +43,8 @@ typedef struct {
     uint64_t    remote_iface_flags; /* Required remote interface flags */
     uint64_t    local_event_flags;  /* Required local event flags */
     uint64_t    remote_event_flags; /* Required remote event flags */
+    uint64_t    alloc_mem_types;    /* Mandatory memory types for allocation */
+    uint64_t    reg_mem_types;      /* Mandatory memory types for registration */
 
     /**
      * Calculates score of a potential transport.


### PR DESCRIPTION
## Why
Make sure optimal memory-type transports are selected for intra-node endpoints, and not just host/ipc transports