### PR TITLE
APPS/IO-DEMO: Save and print request length

### DIFF
--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -1077,7 +1077,7 @@ void UcxConnection::connect_tag(UcxCallback *callback)
     }
 
     // send local connection id
-    void *sreq = ucp_stream_send_nb(_ep, &_conn_id, 1, dt_size,
+    void *sreq = ucp_stream_send_nb(_ep, &_conn_id, 1, dt_int,
                                     common_request_callback, 0);
     // we do not have to check the status here, in case if the endpoint is
     // failed we should handle it in ep_params.err_handler.cb set above

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -378,8 +378,8 @@ private:
 
     void ep_close(enum ucp_ep_close_mode mode);
 
-    bool process_request(const char *what, ucs_status_ptr_t ptr_status,
-                         UcxCallback* callback);
+    bool process_request(const char *what, size_t length,
+                         ucs_status_ptr_t ptr_status, UcxCallback* callback);
 
     static void invoke_callback(UcxCallback *&cb, ucs_status_t status);
 


### PR DESCRIPTION
## What

Save and print request length.

## Why ?

It helps to understand what kind of TAG/AM protocol was used for sending/receiving the data during IO read/write operations.

## How ?

1. Rename `recv_length` to `length`.
2. Set `length` if the operation was not completed in-place and passed to `process_request()` function.
3. Print `length` field every time printing information about completed/canceled request.