### PR TITLE
UCT/TOOLS: Print memory invalidate cap by ucx_info -d

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -457,6 +457,9 @@ static void print_md_info(uct_component_h component,
         if (md_attr.cap.flags & UCT_MD_FLAG_RKEY_PTR) {
             printf("#           rkey_ptr is supported\n");
         }
+        if (md_attr.cap.flags & UCT_MD_FLAG_INVALIDATE) {
+            printf("#           memory invalidation is supported\n");
+        }
     }
 
     if (num_resources == 0) {


### PR DESCRIPTION
## What
Print memory invalidation cap in the output of ucx_info -d

```
$ucx_info -d | grep -A 5 "Memory domain: mlx5_0"
# Memory domain: mlx5_0
#     Component: ib
#             register: unlimited, cost: 180 nsec
#           remote key: 8 bytes
#           local memory handle is required for zcopy
#           memory invalidation is supported
```

## Why ?
Better debugging experience