### PR TITLE
UCT/MD/KNEM: Fix mem registration cost

### DIFF
--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -379,8 +379,8 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
                                    &knem_md->rcache);
         if (status == UCS_OK) {
             knem_md->super.ops = &uct_knem_md_rcache_ops;
-            knem_md->reg_cost  = ucs_linear_func_make(md_config->rcache.overhead,
-                                                      0);
+            knem_md->reg_cost  = ucs_linear_func_make(
+                                 uct_md_rcache_overhead(&md_config->rcache), 0);
         } else {
             ucs_assert(knem_md->rcache == NULL);
             if (md_config->rcache_enable == UCS_YES) {


### PR DESCRIPTION
## What
Fix memory registration cost reported by knem md 

## Why ?
To correctly report mem registration cost by `uct_md_query` and by `ucx_info`

BEFORE:
```
$UCX_KNEM_RCACHE_OVERHEAD=16us ./src/tools/info/ucx_info -d | grep -A 3 "Memory domain: knem"
# Memory domain: knem
#     Component: knem
#             register: unlimited, cost: 38400000000000 nsec
#           remote key: 16 bytes
$UCX_KNEM_RCACHE=n ./src/tools/info/ucx_info -d | grep -A 3 "Memory domain: knem"
# Memory domain: knem
#     Component: knem
#             register: unlimited, cost: 1200 + 0.007 * N nsec
#           remote key: 16 bytes
$./src/tools/info/ucx_info -d | grep -A 3 "Memory domain: knem"
# Memory domain: knem
#     Component: knem
#             register: unlimited, cost: 18446744073709551616000000000 nsec
#           remote key: 16 bytes

```

AFTER:
```
$UCX_KNEM_RCACHE_OVERHEAD=16us ./src/tools/info/ucx_info -d | grep -A 3 "Memory domain: knem"
# Memory domain: knem
#     Component: knem
#             register: unlimited, cost: 16000 nsec
#           remote key: 16 bytes
$UCX_KNEM_RCACHE=n ./src/tools/info/ucx_info -d | grep -A 3 "Memory domain: knem"
# Memory domain: knem
#     Component: knem
#             register: unlimited, cost: 1200 + 0.007 * N nsec
#           remote key: 16 bytes
$./src/tools/info/ucx_info -d | grep -A 3 "Memory domain: knem"
# Memory domain: knem
#     Component: knem
#             register: unlimited, cost: 180 nsec
#           remote key: 16 bytes

```