### PR TITLE
UCT/IB: Fix purging of pending requests after error handling

### DIFF
--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -555,6 +555,9 @@ typedef ucs_status_t (*uct_pending_callback_t)(uct_pending_req_t *self);
  * @ingroup UCT_RESOURCE
  * @brief Callback to process peer failure.
  *
+ * @note User should purge a pending queue and do not post any TX operations
+ * and cancel all possible outstanding operations prior closing a UCT endpoint.
+ *
  * @param [in]  arg      User argument to be passed to the callback.
  * @param [in]  ep       Endpoint which has failed. Upon return from the callback,
  *                       this @a ep is no longer usable and all subsequent

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -121,7 +121,7 @@ uct_rc_mlx5_iface_update_tx_res(uct_rc_iface_t *rc_iface,
     ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
 
     uct_rc_iface_update_reads(rc_iface);
-    uct_rc_iface_add_cq_credits_dispatch(rc_iface, bb_num);
+    uct_rc_iface_add_cq_credits(rc_iface, bb_num);
 }
 
 static UCS_F_ALWAYS_INLINE unsigned
@@ -154,6 +154,7 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface)
     uct_rc_mlx5_txqp_process_tx_cqe(&ep->super.txqp, cqe, hw_ci);
     ucs_arbiter_group_schedule(&iface->super.tx.arbiter, &ep->super.arb_group);
     uct_rc_mlx5_iface_update_tx_res(&iface->super, ep, hw_ci);
+    uct_rc_iface_arbiter_dispatch(&iface->super);
     uct_ib_mlx5_update_db_cq_ci(&iface->cq[UCT_IB_DIR_TX]);
 
     return 1;
@@ -242,20 +243,17 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
 
     if (ep == NULL) {
         ucs_diag("ignoring failure on removed qpn 0x%x wqe[%d]", qp_num, pi);
-        uct_rc_iface_add_cq_credits_dispatch(iface, 1);
-        return;
+        uct_rc_iface_add_cq_credits(iface, 1);
+        goto out;
     }
 
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status, pi, 0);
-
-    /* Do not invoke pending requests on a failed endpoint */
-    ucs_arbiter_group_desched(&iface->tx.arbiter, &ep->super.arb_group);
     uct_rc_mlx5_iface_update_tx_res(iface, ep, pi);
     uct_ib_mlx5_txwq_update_flags(&ep->tx.wq, UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
 
     if (ep->super.flags & (UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED |
                            UCT_RC_EP_FLAG_FLUSH_CANCEL)) {
-        return;
+        goto out;
     }
 
     ep->super.flags |= UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED;
@@ -266,6 +264,9 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
                                                ep_status);
 
     uct_ib_mlx5_completion_with_err(ib_iface, arg, &ep->tx.wq, log_lvl);
+
+out:
+    uct_rc_iface_arbiter_dispatch(iface);
 }
 
 static void uct_rc_mlx5_iface_progress_enable(uct_iface_h tl_iface, unsigned flags)

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -382,8 +382,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
          * (otherwise it will be dispatched by tx progress) */
         if (cur_wnd <= 0) {
             ucs_arbiter_group_schedule(&iface->tx.arbiter, &ep->arb_group);
-            ucs_arbiter_dispatch(&iface->tx.arbiter, 1,
-                                 uct_rc_ep_process_pending, NULL);
+            uct_rc_iface_arbiter_dispatch(iface);
         }
         if  (fc_hdr == UCT_RC_EP_FC_PURE_GRANT) {
             /* Special FC grant message can't be bundled with any other FC
@@ -703,7 +702,8 @@ unsigned uct_rc_iface_qp_cleanup_progress(void *arg)
     ops->cleanup_qp(cleanup_ctx);
 
     if (cleanup_ctx->cq_credits > 0) {
-        uct_rc_iface_add_cq_credits_dispatch(iface, cleanup_ctx->cq_credits);
+        uct_rc_iface_add_cq_credits(iface, cleanup_ctx->cq_credits);
+        uct_rc_iface_arbiter_dispatch(iface);
     }
 
     ucs_list_del(&cleanup_ctx->list);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -438,6 +438,13 @@ ucs_arbiter_cb_result_t
 uct_rc_ep_process_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                           ucs_arbiter_elem_t *elem, void *arg);
 
+static UCS_F_ALWAYS_INLINE void
+uct_rc_iface_arbiter_dispatch(uct_rc_iface_t *iface)
+{
+    ucs_arbiter_dispatch(&iface->tx.arbiter, 1, uct_rc_ep_process_pending,
+                         NULL);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_rc_fc_ctrl(uct_ep_t *ep, unsigned op, uct_rc_pending_req_t *req)
 {
@@ -479,14 +486,12 @@ uct_rc_iface_update_reads(uct_rc_iface_t *iface)
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_rc_iface_add_cq_credits_dispatch(uct_rc_iface_t *iface, uint16_t cq_credits)
+uct_rc_iface_add_cq_credits(uct_rc_iface_t *iface, uint16_t cq_credits)
 {
     iface->tx.cq_available += cq_credits;
     ucs_assertv(iface->tx.cq_available <= iface->config.tx_cq_len,
                 "cq_available=%d tx_cq_len=%d cq_credits=%d",
                 iface->tx.cq_available, iface->config.tx_cq_len, cq_credits);
-    ucs_arbiter_dispatch(&iface->tx.arbiter, 1, uct_rc_ep_process_pending,
-                         NULL);
 }
 
 static UCS_F_ALWAYS_INLINE uct_rc_iface_send_op_t*

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -71,7 +71,7 @@ uct_rc_verbs_update_tx_res(uct_rc_iface_t *iface, uct_rc_verbs_ep_t *ep,
     ep->txcnt.ci += count;
     uct_rc_txqp_available_add(&ep->super.txqp, count);
     uct_rc_iface_update_reads(iface);
-    uct_rc_iface_add_cq_credits_dispatch(iface, count);
+    uct_rc_iface_add_cq_credits(iface, count);
 }
 
 static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
@@ -96,14 +96,11 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     count = uct_rc_verbs_get_tx_res_count(ep, wc);
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status,
                                   ep->txcnt.ci + count, 0);
-
-    /* Don't need to invoke UCT pending requests for a given UCT EP */
-    ucs_arbiter_group_desched(&iface->tx.arbiter, &ep->super.arb_group);
     uct_rc_verbs_update_tx_res(iface, ep, count);
 
     if (ep->super.flags & (UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED |
                            UCT_RC_EP_FLAG_FLUSH_CANCEL)) {
-        return;
+        goto out;
     }
 
     ep->super.flags |= UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED;
@@ -122,6 +119,9 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
             "send completion with error: %s [qpn 0x%x wrid 0x%lx"
             "vendor_err 0x%x]\n%s", ibv_wc_status_str(wc->status), wc->qp_num,
             wc->wr_id, wc->vendor_err, peer_info);
+
+out:
+    uct_rc_iface_arbiter_dispatch(iface);
 }
 
 static ucs_status_t uct_rc_verbs_wc_to_ucs_status(enum ibv_wc_status status)
@@ -172,6 +172,8 @@ uct_rc_verbs_iface_poll_tx(uct_rc_verbs_iface_t *iface)
         ucs_arbiter_group_schedule(&iface->super.tx.arbiter,
                                    &ep->super.arb_group);
         uct_rc_verbs_update_tx_res(&iface->super, ep, count);
+        ucs_arbiter_dispatch(&iface->super.tx.arbiter, 1, uct_rc_ep_process_pending,
+                             NULL);
     }
 
     return num_wcs;

--- a/test/gtest/uct/test_peer_failure.h
+++ b/test/gtest/uct/test_peer_failure.h
@@ -73,7 +73,8 @@ protected:
     size_t                           m_tx_window;
     size_t                           m_err_count;
     size_t                           m_am_count;
-    static size_t                    m_req_purge_count;
+    size_t                           m_req_purge_count;
+    size_t                           m_req_pending_count;
     static const uint64_t            m_required_caps;
 };
 


### PR DESCRIPTION
## What

Fix purging of pending requests after error handling in DC, RC MLX5/Verbs.

## Why ?

Fixes "timeout waiting for <N> replies" issues found by IO-demo testing. It happens that FLUSH_CANCEL couldn't be done and discarding of UCT EP was added to the pending queue. And discarding of this UCT EP is no longer completed.
The issue above happens because purging of requests scheduled on UCT EP doesn't work if UCT EP detects an error.
Descheduling of UCT EP arbiter group was added in https://github.com/openucx/ucx/pull/6549 PR to not invoke pending callback for a failed UCT EP, but https://github.com/openucx/ucx/pull/7080 PR removes dispatching arbiter when updating TX resources. So, it is no longer needed.
Also, UCP EP is able to handle purging of discarding operation when detecting error - it was implemented in https://github.com/openucx/ucx/pull/7041 PR.

## How ?

Remove calling of `ucs_arbiter_group_desched` from UCT transport when an error was detected since it is no longer needed.