### PR TITLE
BINDINGS/GO: Increase port range + make it dependent from agent_id.

### DIFF
--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -58,7 +58,7 @@ jobs:
         az_init_modules
         try_load_cuda_env
         az_module_load dev/go-latest
-        go_port=$((20000 + $RANDOM % 10000))
+        go_port=$((30000 + $(AZP_AGENT_ID) * 100))
         args="-p=$go_port"
         if [ "${{ parameters.name }}" == "gpu" ]; then
           args="-m=cuda"


### PR DESCRIPTION
## What
BINDINGS/GO: Increase port range + make it dependent from agent_id.

## Why ?
To fix failed pipelines like https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=31880&view=logs&j=3326af28-725b-5a76-d9b2-a6afcb2c442d&t=325b69bb-50d4-51fd-759e-eb1ff0fb9743&s=4d0c1fdc-6c5a-5c53-9fc6-e87124c468bb