### PR TITLE
UCT/IB/DC/RC: Purge internal pending ops to avoid dispatching them when EP failed

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1580,6 +1580,8 @@ void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,
     ucs_status_t status;
     ucs_log_level_t log_lvl;
 
+    uct_dc_mlx5_ep_pending_purge_internal(
+            ep, iface, uct_dc_mlx5_ep_arbiter_purge_internal_cb, NULL, NULL);
     if (ep->flags & (UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED |
                      UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL)) {
         return;

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -211,6 +211,18 @@ uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
 
 ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
                                         unsigned flags);
+
+ucs_arbiter_cb_result_t
+uct_dc_mlx5_ep_arbiter_purge_internal_cb(ucs_arbiter_t *arbiter,
+                                         ucs_arbiter_group_t *group,
+                                         ucs_arbiter_elem_t *elem, void *arg);
+
+int uct_dc_mlx5_ep_pending_purge_internal(uct_dc_mlx5_ep_t *ep,
+                                          uct_dc_mlx5_iface_t *iface,
+                                          ucs_arbiter_callback_t arbiter_cb,
+                                          uct_pending_purge_callback_t cb,
+                                          void *arg);
+
 void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, void *arg);
 
 void uct_dc_mlx5_ep_do_pending_fc(uct_dc_mlx5_ep_t *fc_ep,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -247,6 +247,7 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     }
 
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status, pi, 0);
+    uct_rc_ep_pending_purge_internal(&ep->super);
 
     /* Do not invoke pending requests on a failed endpoint */
     ucs_arbiter_group_desched(&iface->tx.arbiter, &ep->super.arb_group);

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -374,42 +374,66 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
     return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
 }
 
-ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
-                                                   ucs_arbiter_group_t *group,
-                                                   ucs_arbiter_elem_t *elem,
-                                                   void *arg)
+static UCS_F_ALWAYS_INLINE ucs_arbiter_cb_result_t
+uct_rc_ep_arbiter_purge_internal_cb(ucs_arbiter_t *arbiter,
+                                    ucs_arbiter_group_t *group,
+                                    ucs_arbiter_elem_t *elem, void *arg)
 {
-    uct_purge_cb_args_t *cb_args    = arg;
-    uct_pending_purge_callback_t cb = cb_args->cb;
-    uct_pending_req_t *req          = ucs_container_of(elem, uct_pending_req_t,
-                                                       priv);
-    uct_rc_ep_t UCS_V_UNUSED *ep    = ucs_container_of(group, uct_rc_ep_t,
-                                                       arb_group);
+    uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
+    uct_rc_ep_t *ep        = ucs_container_of(group, uct_rc_ep_t, arb_group);
     uct_rc_pending_req_t *freq;
 
     if (req->func == uct_rc_ep_check_progress) {
         ep->flags &= ~UCT_RC_EP_FLAG_KEEPALIVE_PENDING;
         ucs_mpool_put(req);
-    } else if (ucs_likely(req->func != uct_rc_ep_fc_grant)) {
+    } else if (req->func == uct_rc_ep_fc_grant) {
+        freq = ucs_derived_of(req, uct_rc_pending_req_t);
+        ucs_mpool_put(freq);
+    } else {
+        return UCS_ARBITER_CB_RESULT_RESCHED_GROUP;
+    }
+    return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
+}
+
+ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
+                                                   ucs_arbiter_group_t *group,
+                                                   ucs_arbiter_elem_t *elem,
+                                                   void *arg)
+{
+    uct_pending_req_t *req          = ucs_container_of(elem, uct_pending_req_t,
+                                                       priv);
+    uct_purge_cb_args_t *cb_args    = arg;
+    uct_pending_purge_callback_t cb = cb_args->cb;
+    uct_rc_ep_t UCS_V_UNUSED *ep    = ucs_container_of(group, uct_rc_ep_t,
+                                                       arb_group);
+    ucs_arbiter_cb_result_t result;
+
+    result = uct_rc_ep_arbiter_purge_internal_cb(arbiter, group, elem, arg);
+    if (ucs_likely(result != UCS_ARBITER_CB_RESULT_REMOVE_ELEM)) {
         /* Invoke user's callback only if it is not internal FC message */
         if (cb != NULL) {
             cb(req, cb_args->arg);
         } else {
             ucs_debug("ep=%p cancelling user pending request %p", ep, req);
         }
-    } else {
-        freq = ucs_derived_of(req, uct_rc_pending_req_t);
-        ucs_mpool_put(freq);
     }
     return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
+}
+
+void uct_rc_ep_pending_purge_internal(uct_rc_ep_t *ep)
+{
+    uct_rc_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                           uct_rc_iface_t);
+    ucs_arbiter_group_purge(&iface->tx.arbiter, &ep->arb_group,
+                            uct_rc_ep_arbiter_purge_internal_cb, NULL);
 }
 
 void uct_rc_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
                              void *arg)
 {
-    uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
-    uct_rc_ep_t *ep       = ucs_derived_of(tl_ep, uct_rc_ep_t);
-    uct_purge_cb_args_t  args = {cb, arg};
+    uct_rc_iface_t *iface    = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
+    uct_rc_ep_t *ep          = ucs_derived_of(tl_ep, uct_rc_ep_t);
+    uct_purge_cb_args_t args = {cb, arg};
 
     ucs_arbiter_group_purge(&iface->tx.arbiter, &ep->arb_group,
                             uct_rc_ep_arbiter_purge_cb, &args);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -255,6 +255,8 @@ ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
                                                    ucs_arbiter_elem_t *elem,
                                                    void *arg);
 
+void uct_rc_ep_pending_purge_internal(uct_rc_ep_t *ep);
+
 void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void*arg);
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -96,6 +96,7 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     count = uct_rc_verbs_get_tx_res_count(ep, wc);
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status,
                                   ep->txcnt.ci + count, 0);
+    uct_rc_ep_pending_purge_internal(&ep->super);
 
     /* Don't need to invoke UCT pending requests for a given UCT EP */
     ucs_arbiter_group_desched(&iface->tx.arbiter, &ep->super.arb_group);


### PR DESCRIPTION
## What

Purge internal pending ops to avoid dispatching them when EP failed.

## Why ?

Fixes:
```
[swx-ucx08:862  :0:862]   rc_mlx5.inl:457  Assertion `!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED)' failed

/hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5.inl: [ uct_rc_mlx5_common_post_send() ]
      ...
      454     if (opcode != MLX5_OPCODE_NOP) {
      455         /* If FAILED, allow only NOP sends to be posted (used by endpoint
      456          * flush operations) */
==>   457         ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
      458     }
      459
      460     ctrl = txwq->curr;

==== backtrace (tid:    862) ====
 0 0x0000000000089e48 uct_rc_mlx5_common_post_send()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:457
 1 0x0000000000089e48 uct_rc_mlx5_txqp_inline_post()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:617
 2 0x0000000000089e48 uct_rc_mlx5_ep_post_check()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5_ep.c:544
 3 0x0000000000038013 uct_rc_ep_check_internal()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_ep.c:549
 4 0x0000000000038088 uct_rc_ep_check_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_ep.c:562
 5 0x0000000000037223 uct_rc_iface_invoke_pending_cb()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_iface.h:592
 6 0x0000000000037223 uct_rc_ep_process_pending()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_ep.c:359
 7 0x00000000000550b3 ucs_arbiter_dispatch_nonempty()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/arbiter.c:321
 8 0x00000000000a1092 ucs_arbiter_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/arbiter.h:386
 9 0x00000000000ad274 uct_rc_iface_add_cq_credits_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_iface.h:488
10 0x00000000000ad274 uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:173
11 0x00000000000ad274 uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:178
12 0x000000000005f5a1 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
13 0x000000000006c49a uct_worker_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/api/uct.h:2589
14 0x0000000000404e04 UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:388
15 0x00000000004044b4 UcxContext::progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:226
16 0x0000000000416f24 DemoClient::wait_for_responses()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:1934
17 0x000000000041835a DemoClient::run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2204
18 0x000000000040f4b6 do_client()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2801
19 0x000000000040f8dc main()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2844
20 0x00000000000223d5 __libc_start_main()  ???:0
21 0x00000000004033b9 _start()  ???:0
=================================
```
EP check operation was scheduled on UCT EP internally, i.e. UCP EP doesn't put it on a pending queue, but then UCP EP failed.
And EP check operation stucked on UCT EP's pending queue and then it was dispatched and we got an assertion failure.

## How ?

1. Introduce the pending purge callback in RC and DC which purges only internal operations.
2. Dispatch arbiter with the pending purge callback to cancel internal operations when error detected on UCT endpoint.