### PR TITLE
UCP/CORE: Add debug infra for EP discarding

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -461,16 +461,33 @@ typedef struct {
 
 
 /**
+ * Argument for discarding UCP endpoint's lanes
+ */
+typedef struct ucp_ep_discard_lanes_arg {
+    unsigned        counter; /* How many discarding operations on UCT lanes are
+                              * in-progress if purging of the UCP endpoint is
+                              * required */
+    ucs_status_t    status; /* Completion status of operations after discarding is
+                             * done */
+    ucp_ep_h        ucp_ep; /* UCP endpoint which should be discarded */
+#if UCS_ENABLE_ASSERT
+    ucs_list_link_t reqs; /* List of discarding operation requests */
+#endif
+} ucp_ep_discard_lanes_arg_t;
+
+
+/**
  * Endpoint extension for control data path
  */
 typedef struct {
-    ucp_rsc_index_t          cm_idx; /* CM index */
-    ucs_ptr_map_key_t        local_ep_id; /* Local EP ID */
-    ucs_ptr_map_key_t        remote_ep_id; /* Remote EP ID */
-    ucp_err_handler_cb_t     err_cb; /* Error handler */
-    ucp_request_t            *close_req; /* Close protocol request */
+    ucp_rsc_index_t            cm_idx; /* CM index */
+    ucs_ptr_map_key_t          local_ep_id; /* Local EP ID */
+    ucs_ptr_map_key_t          remote_ep_id; /* Remote EP ID */
+    ucp_err_handler_cb_t       err_cb; /* Error handler */
+    ucp_request_t              *close_req; /* Close protocol request */
 #if UCS_ENABLE_ASSERT
-    ucs_time_t               ka_last_round; /* Time of last KA round done */
+    ucs_time_t                 ka_last_round; /* Time of last KA round done */
+    ucp_ep_discard_lanes_arg_t *discard_lanes_arg; /* Argument for discarding lanes */
 #endif
 } ucp_ep_ext_control_t;
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -315,6 +315,9 @@ struct ucp_request {
                     /* Progress ID, if it's UCS_CALLBACKQ_ID_NULL, no operations
                      * are in-progress */
                     uct_worker_cb_id_t cb_id;
+#if UCS_ENABLE_ASSERT
+                    ucs_list_link_t    elem;
+#endif
                 } discard_uct_ep;
 
                 struct {

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -388,12 +388,13 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep);
 int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep);
 
 /* must be called with async lock held */
-ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
-                                       unsigned ep_flush_flags,
-                                       uct_pending_purge_callback_t purge_cb,
-                                       void *purge_arg,
-                                       ucp_send_nbx_callback_t discarded_cb,
-                                       void *discarded_cb_arg);
+ucs_status_ptr_t
+ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                          unsigned ep_flush_flags,
+                          uct_pending_purge_callback_t purge_cb,
+                          void *purge_arg,
+                          ucp_send_nbx_callback_t discarded_cb,
+                          void *discarded_cb_arg);
 
 char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
                                 ucp_context_h context,


### PR DESCRIPTION
## What

Add debug infrastructure for EP discarding.

## Why ?

Simplifies debugging of EP discarding functionality.
It allows finding all scheduled discarding requests on a particular UCP EP.

## How ?

1. Add pointer to `ucp_ep_discard_lanes_arg_t` in UCP EP's control extension.
2. Save requests allocated for discarding to a list of requests in the `ucp_ep_discard_lanes_arg_t`.
3. Add useful assertions.