### PR TITLE
UCT/IB/DC/RC: Purge internal pending ops to avoid dispatching them when EP failed

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1579,6 +1579,13 @@ void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,
     uct_ib_iface_t *ib_iface = &iface->super.super.super;
     ucs_status_t status;
     ucs_log_level_t log_lvl;
+    ucs_arbiter_t *waitq;
+    ucs_arbiter_group_t *group;
+    uint8_t pool_index;
+
+    uct_dc_mlx5_get_arbiter_params(iface, ep, &waitq, &group, &pool_index);
+    ucs_arbiter_group_purge(waitq, group,
+                            uct_dc_mlx5_ep_arbiter_purge_internal_cb, ep);
 
     if (ep->flags & (UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED |
                      UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL)) {

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1115,7 +1115,8 @@ UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_ep_t)
                                                 uct_dc_mlx5_iface_t);
     khiter_t it;
 
-    uct_dc_mlx5_ep_pending_purge(&self->super.super, NULL, NULL);
+    uct_dc_mlx5_ep_pending_purge(&self->super.super,
+                                 uct_rc_ep_pending_purge_warn_cb, self);
     uct_dc_mlx5_ep_fc_cleanup(self);
     uct_dc_mlx5_ep_keepalive_cleanup(self);
 
@@ -1375,6 +1376,36 @@ uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
     return res;
 }
 
+ucs_arbiter_cb_result_t
+uct_dc_mlx5_ep_arbiter_purge_internal_cb(ucs_arbiter_t *arbiter,
+                                         ucs_arbiter_group_t *group,
+                                         ucs_arbiter_elem_t *elem, void *arg)
+{
+    uct_dc_mlx5_ep_t *ep         = arg;
+    uct_dc_mlx5_iface_t *iface   = ucs_derived_of(ep->super.super.iface,
+                                                  uct_dc_mlx5_iface_t);
+    uct_pending_req_t *req       = ucs_container_of(elem, uct_pending_req_t,
+                                                    priv);
+    uct_rc_pending_req_t *freq;
+
+    if (uct_dc_mlx5_iface_is_dci_rand(iface) &&
+        (uct_dc_mlx5_pending_req_priv(req)->ep != ep)) {
+        /* Element belongs to another ep - do not remove it */
+        return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
+    }
+
+    if (ucs_unlikely(req->func == uct_dc_mlx5_iface_fc_grant)) {
+        /* User callback should not be called for FC messages. Just return
+         * pending request memory to the pool */
+        freq = ucs_derived_of(req, uct_rc_pending_req_t);
+        ucs_mpool_put(freq);
+        return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
+    }
+
+    /* Non-internal request was found */
+    return UCS_ARBITER_CB_RESULT_RESCHED_GROUP;
+}
+
 static ucs_arbiter_cb_result_t
 uct_dc_mlx5_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                                 ucs_arbiter_elem_t *elem, void *arg)
@@ -1382,34 +1413,25 @@ uct_dc_mlx5_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *gro
     uct_purge_cb_args_t *cb_args = arg;
     void **priv_args             = cb_args->arg;
     uct_dc_mlx5_ep_t *ep         = priv_args[0];
-    uct_dc_mlx5_iface_t *iface   = ucs_derived_of(ep->super.super.iface,
-                                                  uct_dc_mlx5_iface_t);
-    uct_pending_req_t *req       = ucs_container_of(elem, uct_pending_req_t, priv);
-    uct_rc_pending_req_t *freq;
+    uct_pending_req_t *req       = ucs_container_of(elem, uct_pending_req_t,
+                                                    priv);
+    ucs_arbiter_cb_result_t result;
 
-    if (uct_dc_mlx5_iface_is_dci_rand(iface) &&
-        (uct_dc_mlx5_pending_req_priv(req)->ep != ep)) {
-        /* element belongs to another ep - do not remove it */
-        return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
-    }
-
-    if (ucs_likely(req->func != uct_dc_mlx5_iface_fc_grant)){
+    result = uct_dc_mlx5_ep_arbiter_purge_internal_cb(arbiter, group, elem, ep);
+    if (result == UCS_ARBITER_CB_RESULT_RESCHED_GROUP) {
         if (cb_args->cb != NULL) {
             cb_args->cb(req, priv_args[1]);
         } else {
             ucs_debug("ep=%p cancelling user pending request %p", ep, req);
         }
-    } else {
-        /* User callback should not be called for FC messages.
-         * Just return pending request memory to the pool */
-        freq = ucs_derived_of(req, uct_rc_pending_req_t);
-        ucs_mpool_put(freq);
+        return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     }
 
-    return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
+    return result;
 }
 
-void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, void *arg)
+void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep,
+                                  uct_pending_purge_callback_t cb, void *arg)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -211,6 +211,12 @@ uct_dc_mlx5_iface_dci_do_rand_pending_tx(ucs_arbiter_t *arbiter,
 
 ucs_status_t uct_dc_mlx5_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *r,
                                         unsigned flags);
+
+ucs_arbiter_cb_result_t
+uct_dc_mlx5_ep_arbiter_purge_internal_cb(ucs_arbiter_t *arbiter,
+                                         ucs_arbiter_group_t *group,
+                                         ucs_arbiter_elem_t *elem, void *arg);
+
 void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb, void *arg);
 
 void uct_dc_mlx5_ep_do_pending_fc(uct_dc_mlx5_ep_t *fc_ep,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -248,6 +248,8 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     }
 
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status, pi, 0);
+    ucs_arbiter_group_purge(&iface->tx.arbiter, &ep->super.arb_group,
+                            uct_rc_ep_arbiter_purge_internal_cb, NULL);
     uct_rc_mlx5_iface_update_tx_res(iface, ep, pi);
     uct_ib_mlx5_txwq_update_flags(&ep->tx.wq, UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
 

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -250,6 +250,11 @@ void uct_rc_ep_flush_op_completion_handler(uct_rc_iface_send_op_t *op,
 ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
                                    unsigned flags);
 
+ucs_arbiter_cb_result_t
+uct_rc_ep_arbiter_purge_internal_cb(ucs_arbiter_t *arbiter,
+                                    ucs_arbiter_group_t *group,
+                                    ucs_arbiter_elem_t *elem, void *arg);
+
 ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
                                                    ucs_arbiter_group_t *group,
                                                    ucs_arbiter_elem_t *elem,
@@ -276,6 +281,8 @@ uct_rc_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 void uct_rc_ep_cleanup_qp(uct_rc_ep_t *ep,
                           uct_rc_iface_qp_cleanup_ctx_t *cleanup_ctx,
                           uint32_t qp_num, uint16_t cq_credits);
+
+void uct_rc_ep_pending_purge_warn_cb(uct_pending_req_t *self, void *arg);
 
 void UCT_RC_DEFINE_ATOMIC_HANDLER_FUNC_NAME(32, 0)(uct_rc_iface_send_op_t *op,
                                                    const void *resp);

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -96,6 +96,8 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     count = uct_rc_verbs_get_tx_res_count(ep, wc);
     uct_rc_txqp_purge_outstanding(iface, &ep->super.txqp, ep_status,
                                   ep->txcnt.ci + count, 0);
+    ucs_arbiter_group_purge(&iface->tx.arbiter, &ep->super.arb_group,
+                            uct_rc_ep_arbiter_purge_internal_cb, NULL);
     uct_rc_verbs_update_tx_res(iface, ep, count);
 
     if (ep->super.flags & (UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED |


### PR DESCRIPTION
## What

Purge internal pending ops to avoid dispatching them when EP failed.

## Why ?

Fixes:
```
[swx-ucx08:862  :0:862]   rc_mlx5.inl:457  Assertion `!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED)' failed

/hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5.inl: [ uct_rc_mlx5_common_post_send() ]
      ...
      454     if (opcode != MLX5_OPCODE_NOP) {
      455         /* If FAILED, allow only NOP sends to be posted (used by endpoint
      456          * flush operations) */
==>   457         ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
      458     }
      459
      460     ctrl = txwq->curr;

==== backtrace (tid:    862) ====
 0 0x0000000000089e48 uct_rc_mlx5_common_post_send()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:457
 1 0x0000000000089e48 uct_rc_mlx5_txqp_inline_post()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5.inl:617
 2 0x0000000000089e48 uct_rc_mlx5_ep_post_check()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5_ep.c:544
 3 0x0000000000038013 uct_rc_ep_check_internal()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_ep.c:549
 4 0x0000000000038088 uct_rc_ep_check_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_ep.c:562
 5 0x0000000000037223 uct_rc_iface_invoke_pending_cb()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_iface.h:592
 6 0x0000000000037223 uct_rc_ep_process_pending()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_ep.c:359
 7 0x00000000000550b3 ucs_arbiter_dispatch_nonempty()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/arbiter.c:321
 8 0x00000000000a1092 ucs_arbiter_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/arbiter.h:386
 9 0x00000000000ad274 uct_rc_iface_add_cq_credits_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/base/rc_iface.h:488
10 0x00000000000ad274 uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:173
11 0x00000000000ad274 uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/ib/rc/accel/rc_mlx5_iface.c:178
12 0x000000000005f5a1 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
13 0x000000000006c49a uct_worker_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/api/uct.h:2589
14 0x0000000000404e04 UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:388
15 0x00000000004044b4 UcxContext::progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:226
16 0x0000000000416f24 DemoClient::wait_for_responses()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:1934
17 0x000000000041835a DemoClient::run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2204
18 0x000000000040f4b6 do_client()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2801
19 0x000000000040f8dc main()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2844
20 0x00000000000223d5 __libc_start_main()  ???:0
21 0x00000000004033b9 _start()  ???:0
=================================
```
EP check operation was scheduled on UCT EP internally, i.e. UCP EP doesn't put it on a pending queue, but then UCP EP failed.
And EP check operation stucked on UCT EP's pending queue and then it was dispatched and we got an assertion failure.

## How ?

1. Introduce the pending purge callback in RC and DC which purges only internal operations.
2. Dispatch arbiter with the pending purge callback to cancel internal operations when error detected on UCT endpoint.