### PR TITLE
UCP/CORE: Fix EP refcount overflow

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -197,7 +197,7 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
     ep->flags                                    = 0;
     ep->conn_sn                                  = UCP_EP_MATCH_CONN_SN_MAX;
     ucp_ep_ext_gen(ep)->user_data                = NULL;
-    ucp_ep_ext_control(ep)->refcount             = 0lu;
+    ucp_ep_ext_control(ep)->refcount             = 0u;
     ucp_ep_ext_control(ep)->cm_idx               = UCP_NULL_RESOURCE;
     ucp_ep_ext_control(ep)->local_ep_id          = UCS_PTR_MAP_KEY_INVALID;
     ucp_ep_ext_control(ep)->remote_ep_id         = UCS_PTR_MAP_KEY_INVALID;
@@ -208,7 +208,7 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
     ucp_ep_ext_control(ep)->refcounts.create     =
     ucp_ep_ext_control(ep)->refcounts.flush      =
     ucp_ep_ext_control(ep)->refcounts.discard    =
-    ucp_ep_ext_control(ep)->refcounts.invalidate = 0lu;
+    ucp_ep_ext_control(ep)->refcounts.invalidate = 0u;
 #endif
 
     UCS_STATIC_ASSERT(sizeof(ucp_ep_ext_gen(ep)->ep_match) >=
@@ -322,11 +322,11 @@ static int ucp_ep_remove_filter(const ucs_callbackq_elem_t *elem, void *arg)
 
 void ucp_ep_destroy_base(ucp_ep_h ep)
 {
-    ucp_ep_refcount_field_assert(ep, refcount, ==, 0lu);
-    ucp_ep_refcount_assert(ep, create, ==, 0lu);
-    ucp_ep_refcount_assert(ep, flush, ==, 0lu);
-    ucp_ep_refcount_assert(ep, discard, ==, 0lu);
-    ucp_ep_refcount_assert(ep, invalidate, ==, 0lu);
+    ucp_ep_refcount_field_assert(ep, refcount, ==, 0u);
+    ucp_ep_refcount_assert(ep, create, ==, 0u);
+    ucp_ep_refcount_assert(ep, flush, ==, 0u);
+    ucp_ep_refcount_assert(ep, discard, ==, 0u);
+    ucp_ep_refcount_assert(ep, invalidate, ==, 0u);
     ucs_assert(ucs_hlist_is_empty(&ucp_ep_ext_gen(ep)->proto_reqs));
 
     ucs_vfs_obj_remove(ep);
@@ -381,7 +381,7 @@ ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
     return UCS_OK;
 
 err_destroy_ep_base:
-    ucp_ep_refcount_assert(ep, create, ==, 1lu);
+    ucp_ep_refcount_assert(ep, create, ==, 1u);
     ucp_ep_refcount_remove(ep, create);
 err:
     return status;
@@ -397,7 +397,7 @@ void ucp_ep_delete(ucp_ep_h ep)
 
     ucp_ep_release_id(ep);
     ucs_list_del(&ucp_ep_ext_gen(ep)->ep_list);
-    ucp_ep_refcount_assert(ep, create, ==, 1lu);
+    ucp_ep_refcount_assert(ep, create, ==, 1u);
     ucp_ep_refcount_remove(ep, create);
 }
 
@@ -1114,7 +1114,7 @@ static void ucp_ep_check_lanes(ucp_ep_h ep)
 {
 #if UCS_ENABLE_ASSERT
     ucp_ep_ext_control_t *ep_cntrl_ext = ucp_ep_ext_control(ep);
-    size_t num_inprog                  = ep_cntrl_ext->refcounts.discard +
+    ucp_ep_refcount_t num_inprog       = ep_cntrl_ext->refcounts.discard +
                                          ep_cntrl_ext->refcounts.flush +
                                          ep_cntrl_ext->refcounts.invalidate +
                                          ep_cntrl_ext->refcounts.create;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -36,7 +36,7 @@ typedef uint16_t                   ucp_ep_flags_t;
 #if UCS_ENABLE_ASSERT
 #define UCP_EP_ASSERT_COUNTER_INC(_counter) \
     do { \
-        ucs_assert(*(_counter) < SIZE_MAX); \
+        ucs_assert(*(_counter) < UINT32_MAX); \
         ++(*(_counter)); \
     } while (0)
 
@@ -53,7 +53,7 @@ typedef uint16_t                   ucp_ep_flags_t;
 
 #define ucp_ep_refcount_add(_ep, _type) \
 ({ \
-    ucs_assert(ucp_ep_ext_control(_ep)->refcount < SIZE_MAX); \
+    ucs_assert(ucp_ep_ext_control(_ep)->refcount < UINT32_MAX); \
     ++ucp_ep_ext_control(_ep)->refcount; \
     UCP_EP_ASSERT_COUNTER_INC(&ucp_ep_ext_control(_ep)->refcounts._type); \
 })
@@ -75,7 +75,7 @@ typedef uint16_t                   ucp_ep_flags_t;
 
 #define ucp_ep_refcount_field_assert(_ep, _refcount_field, _cmp, _val) \
     ucs_assertv(ucp_ep_ext_control(_ep)->_refcount_field _cmp (_val), \
-                "ep=%p: %s=%zu vs %zu", (_ep), \
+                "ep=%p: %s=%u vs %u", (_ep), \
                 UCS_PP_MAKE_STRING(_refcount_field), \
                 ucp_ep_ext_control(_ep)->_refcount_field, _val);
 
@@ -442,11 +442,17 @@ typedef struct {
 
 
 /**
+ * UCP endpoint reference counter
+ */
+typedef uint32_t ucp_ep_refcount_t;
+
+
+/**
  * Endpoint extension for control data path
  */
 typedef struct {
     ucp_rsc_index_t          cm_idx; /* CM index */
-    size_t                   refcount; /* Reference counter: 0 - it is
+    ucp_ep_refcount_t        refcount; /* Reference counter: 0 - it is
                                           allowed to destroy EP */
     ucs_ptr_map_key_t        local_ep_id; /* Local EP ID */
     ucs_ptr_map_key_t        remote_ep_id; /* Remote EP ID */
@@ -456,16 +462,16 @@ typedef struct {
     ucs_time_t               ka_last_round; /* Time of last KA round done */
     struct {
         /* How many times the EP create was done */
-        size_t               create;
+        ucp_ep_refcount_t    create;
         /* How many Worker flush operations are in-progress where the EP is the
          * next EP for flushing */
-        size_t               flush;
+        ucp_ep_refcount_t    flush;
         /* How many UCT EP discarding operations are in-progress scheduled for
          * the EP */
-        size_t               discard;
+        ucp_ep_refcount_t    discard;
         /* How many UCP operations are in-progress scheduled for the memory
          * invalidation on the current EP */
-        size_t               invalidate;
+        ucp_ep_refcount_t    invalidate;
     } refcounts;
 #endif
 } ucp_ep_ext_control_t;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -412,7 +412,7 @@ struct ucp_ep_config {
  */
 typedef struct ucp_ep {
     ucp_worker_h                  worker;        /* Worker this endpoint belongs to */
-    /* Place for 1-byte field is vacant here */
+    /* Place for 2-bytes field is vacant here */
     ucp_worker_cfg_index_t        cfg_index;     /* Configuration index */
     ucp_ep_match_conn_sn_t        conn_sn;       /* Sequence number for remote connection */
     ucp_lane_index_t              am_lane;       /* Cached value */

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -382,7 +382,7 @@ void ucp_request_dt_invalidate(ucp_request_t *req, ucs_status_t status)
                UCP_ERR_HANDLING_MODE_NONE);
     ucs_assert(UCP_DT_IS_CONTIG(req->send.datatype));
 
-    /* Do not allow destroying UCP endpoint, since the memeroy invalidation
+    /* Do not allow destroying UCP endpoint, since the memory invalidation
      * depends on it */
     ucp_ep_refcount_add(req->send.ep, invalidate);
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -336,10 +336,8 @@ public:
                                              const ucp_tag_recv_info_t *tag_info,
                                              void *user_data)
     {
-        mem_buffer UCS_V_UNUSED *recv_buffer = reinterpret_cast<mem_buffer*>(user_data);
-
-        UCS_TEST_MESSAGE << "TAG receive operation completed: "
-                         << ucs_status_string(status);
+        mem_buffer UCS_V_UNUSED *recv_buffer =
+                reinterpret_cast<mem_buffer*>(user_data);
         if (status == UCS_OK) {
             recv_buffer->pattern_check(1, recv_buffer->size());
         }
@@ -2806,9 +2804,10 @@ protected:
      * on CONNECT_TO_IFACE transports with memory invalidation support: in case
      * if sender EP was killed right after sent RTS then receiver may get
      * incorrect/corrupted data */
-    void do_tag_rndv_killed_sender_test(size_t num_senders)
+    void do_tag_rndv_killed_sender_test(size_t num_senders,
+                                        size_t size = 64 * UCS_KBYTE,
+                                        size_t num_sends = 1)
     {
-        static constexpr size_t size = 64 * UCS_KBYTE;
         std::vector<ucp_tag_message_h> messages;
         std::vector<void*> reqs;
         ucs_status_t status;
@@ -2832,24 +2831,26 @@ protected:
             send_recv(sender(), receiver(), send_recv_type(), false, cb_type(),
                       sender_idx);
 
-            void *sreq = send(sender(), send_buf.ptr(), size, SEND_RECV_TAG,
-                              send_cb, NULL, sender_idx);
-            ASSERT_TRUE(UCS_PTR_IS_PTR(sreq));
-            ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
-            reqs.push_back(sreq);
+            for (size_t i = 0; i < num_sends; ++i) {
+                void *sreq = send(sender(), send_buf.ptr(), size,
+                                  SEND_RECV_TAG, send_cb, NULL, sender_idx);
+                ASSERT_TRUE(UCS_PTR_IS_PTR(sreq));
+                ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
+                reqs.push_back(sreq);
 
-            /* Allow receiver to get RTS notification, but do not receive message
-             * body */
-            ucp_tag_recv_info_t info;
-            ucp_tag_message_h message = message_wait(receiver(), 0, 0, &info);
-            ASSERT_NE((void*)NULL, message);
-            ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
+                /* Allow receiver to get RTS notification, but do not receive message
+                 * body */
+                ucp_tag_recv_info_t info;
+                ucp_tag_message_h message = message_wait(receiver(), 0, 0, &info);
+                ASSERT_NE((void*)NULL, message);
+                ASSERT_EQ(UCS_INPROGRESS, ucp_request_check_status(sreq));
 
-            messages.emplace_back(message);
+                messages.emplace_back(message);
+            }
         }
 
         /* Ignore all errors - it is expected */
-        scoped_log_handler slh(wrap_errors_logger);
+        scoped_log_handler slh(hide_errors_logger);
 
         /* Close the first sender's EP to force send operation to be completed
          * with CANCEL status */
@@ -2857,7 +2858,7 @@ protected:
 
         mem_buffer extra_recv_buf(size, UCS_MEMORY_TYPE_HOST);
         extra_recv_buf.pattern_fill(2, size);
-        for (size_t i = 1; i < messages.size(); ++i) {
+        for (size_t i = num_sends; i < messages.size(); ++i) {
             void *rreq = recv(receiver(), extra_recv_buf.ptr(), size,
                               messages[i], rtag_complete_always_ok_cbx, NULL);
             reqs.push_back(rreq);
@@ -2865,16 +2866,20 @@ protected:
 
         status = requests_wait(reqs);
         ASSERT_EQ(UCS_ERR_CANCELED, status);
+        ASSERT_TRUE(reqs.empty());
 
         /* Update send buffer by new data - emulation of free(buffer) */
         send_buf.pattern_fill(3, size);
 
-        /* Complete receive operation */
-        mem_buffer recv_buf(size, UCS_MEMORY_TYPE_HOST);
-        recv_buf.pattern_fill(2, size);
-        void *rreq = recv(receiver(), recv_buf.ptr(), size, messages[0],
-                          rtag_complete_check_data_cbx, recv_buf.ptr());
-        request_wait(rreq);
+        /* Complete receive operations */
+        for (size_t i = 0; i < num_sends; ++i) {
+            mem_buffer recv_buf(size, UCS_MEMORY_TYPE_HOST);
+            recv_buf.pattern_fill(2, size);
+            void *rreq = recv(receiver(), recv_buf.ptr(), size, messages[i],
+                              rtag_complete_check_data_cbx, recv_buf.ptr());
+            reqs.push_back(rreq);
+        }
+        requests_wait(reqs);
     }
 
 private:
@@ -2893,6 +2898,20 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
            "RNDV_SCHEME=get_zcopy")
 {
     do_tag_rndv_killed_sender_test(5);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
+           tag_rndv_killed_sender_multiple_sends, "RNDV_THRESH=0",
+           "RNDV_SCHEME=get_zcopy")
+{
+    do_tag_rndv_killed_sender_test(1, 128, 100000);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
+           tag_rndv_killed_sender_4_extra_senders_multiple_sends,
+           "RNDV_THRESH=0", "RNDV_SCHEME=get_zcopy")
+{
+    do_tag_rndv_killed_sender_test(4, 128, 100000);
 }
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err_sender)

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -11,6 +11,7 @@
 extern "C" {
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_worker.inl>
+#include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_request.h>
 #include <ucp/wireup/wireup_ep.h>
 #include <uct/base/uct_iface.h>
@@ -258,7 +259,7 @@ protected:
             EXPECT_EQ(NULL, eps[i].iface);
         }
 
-        EXPECT_EQ(1u, m_ucp_ep->refcount);
+        EXPECT_EQ(1lu, ucp_ep_ext_control(m_ucp_ep)->refcount);
 
 out:
         disconnect(sender());
@@ -278,12 +279,12 @@ out:
                 uct_invoke_completion(&req->send.state.uct_comp, UCS_ERR_CANCELED);
                 m_flush_comps.erase(iter);
                 EXPECT_EQ(m_ucp_ep, req->send.ep);
-                EXPECT_GT(m_ucp_ep->refcount, 0u);
+                EXPECT_GT(ucp_ep_ext_control(m_ucp_ep)->refcount, 0lu);
                 break;
             }
         }
 
-        EXPECT_GT(m_ucp_ep->refcount, 0u);
+        EXPECT_GT(ucp_ep_ext_control(m_ucp_ep)->refcount, 0lu);
 
         ep->iface = NULL;
         m_destroyed_ep_count++;


### PR DESCRIPTION
## What

Fix EP refcount overflow.

## Why ?

Fixes:
```
[swx-ucx02:61382:0:61382] ucp_request.c:387  Assertion `(req->send.ep)->refcount < (255)' failed

/hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_request.c: [ ucp_request_dt_invalidate() ]
      ...
      384
      385     /* Do not allow destroying UCP endpoint, since the memeroy invalidation
      386      * depends on it */
==>   387     ucp_ep_refcount_add(req->send.ep, invalidate);
      388
      389     req->send.state.uct_comp.count  = 1;
      390     req->send.state.uct_comp.func   = ucp_request_mem_invalidate_completion;

==== backtrace (tid:  61382) ====
 0 0x0000000000057b6c ucp_request_dt_invalidate()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_request.c:387
 1 0x000000000004b674 ucp_ep_req_purge_send()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:3145
 2 0x000000000004c152 ucp_ep_req_purge()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:3173
 3 0x000000000004da5b ucp_ep_reqs_purge()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:3232
 4 0x00000000000423e8 ucp_ep_discard_lanes_callback()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1166
 5 0x0000000000069744 ucp_worker_discard_uct_ep_complete()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c:2340
 6 0x0000000000069b6f ucp_worker_discard_uct_ep_destroy_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c:2365
 7 0x0000000000056c46 ucs_callbackq_slow_proxy()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/callbackq.c:402
 8 0x000000000005e207 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
 9 0x000000000006b100 uct_worker_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/api/uct.h:2589
10 0x0000000000404dee UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:388
11 0x000000000040449e UcxContext::progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:226
12 0x0000000000416dca DemoClient::wait_for_responses()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:1932
13 0x0000000000418200 DemoClient::run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2202
14 0x000000000040f37f do_client()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2791
15 0x000000000040f7a5 main()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2834
16 0x00000000000223d5 __libc_start_main()  ???:0
17 0x00000000004033b9 _start()  ???:0
=================================
```

## How ?

1. Move `refcount` field and `refcounts` structure to the control extension of UCP EP.
2. Change type of `refcount` field and `refcounts` structure's fields to `size_t`.