### PR TITLE
UCP/CORE: Fix EP refcount overflow [v2]

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -200,8 +200,7 @@ ucs_status_t ucp_ep_create_base(ucp_worker_h worker, const char *peer_name,
 #if UCS_ENABLE_ASSERT
     ep->refcounts.create                  =
     ep->refcounts.flush                   =
-    ep->refcounts.discard                 =
-    ep->refcounts.invalidate              = 0;
+    ep->refcounts.discard                 = 0;
 #endif
     ucp_ep_ext_gen(ep)->user_data         = NULL;
     ucp_ep_ext_control(ep)->cm_idx        = UCP_NULL_RESOURCE;
@@ -328,7 +327,6 @@ void ucp_ep_destroy_base(ucp_ep_h ep)
     ucp_ep_refcount_assert(ep, create, ==, 0);
     ucp_ep_refcount_assert(ep, flush, ==, 0);
     ucp_ep_refcount_assert(ep, discard, ==, 0);
-    ucp_ep_refcount_assert(ep, invalidate, ==, 0);
     ucs_assert(ucs_hlist_is_empty(&ucp_ep_ext_gen(ep)->proto_reqs));
 
     ucs_vfs_obj_remove(ep);
@@ -1116,7 +1114,7 @@ static void ucp_ep_check_lanes(ucp_ep_h ep)
 {
 #if UCS_ENABLE_ASSERT
     uint8_t num_inprog       = ep->refcounts.discard + ep->refcounts.flush +
-                               ep->refcounts.invalidate + ep->refcounts.create;
+                               ep->refcounts.create;
     uint8_t num_failed_tl_ep = 0;
     ucp_lane_index_t lane;
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -438,9 +438,6 @@ typedef struct ucp_ep {
         /* How many UCT EP discarding operations are in-progress scheduled for
          * the EP */
         unsigned                      discard;
-        /* How many UCP operations are in-progress scheduled for the memory
-         * invalidation on the current EP */
-        unsigned                      invalidate;
     } refcounts;
 #endif
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -133,7 +133,7 @@ struct ucp_request {
         /* "send" part - used for tag_send, am_send, stream_send, put, get, and atomic
          * operations */
         struct {
-            ucp_ep_h                ep;
+            ucp_ep_h                   ep;
             union {
                 void                   *buffer; /* Send buffer */
                 ucp_request_callback_t flushed_cb; /* Called when flushed */
@@ -306,6 +306,10 @@ struct ucp_request {
                     uint8_t            num_lanes; /* How many lanes are being flushed */
                     ucp_lane_map_t     started_lanes; /* Which lanes need were flushed */
                 } flush;
+
+                struct {
+                    ucp_worker_h       worker;
+                } invalidate;
 
                 struct {
                     /* UCT EP that should be flushed and destroyed */


### PR DESCRIPTION
## What

Fix EP refcount overflow.

## Why ?

Fixes:
```
[swx-ucx02:61382:0:61382] ucp_request.c:387  Assertion `(req->send.ep)->refcount < (255)' failed

/hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_request.c: [ ucp_request_dt_invalidate() ]
      ...
      384
      385     /* Do not allow destroying UCP endpoint, since the memeroy invalidation
      386      * depends on it */
==>   387     ucp_ep_refcount_add(req->send.ep, invalidate);
      388
      389     req->send.state.uct_comp.count  = 1;
      390     req->send.state.uct_comp.func   = ucp_request_mem_invalidate_completion;

==== backtrace (tid:  61382) ====
 0 0x0000000000057b6c ucp_request_dt_invalidate()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_request.c:387
 1 0x000000000004b674 ucp_ep_req_purge_send()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:3145
 2 0x000000000004c152 ucp_ep_req_purge()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:3173
 3 0x000000000004da5b ucp_ep_reqs_purge()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:3232
 4 0x00000000000423e8 ucp_ep_discard_lanes_callback()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1166
 5 0x0000000000069744 ucp_worker_discard_uct_ep_complete()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c:2340
 6 0x0000000000069b6f ucp_worker_discard_uct_ep_destroy_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c:2365
 7 0x0000000000056c46 ucs_callbackq_slow_proxy()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/callbackq.c:402
 8 0x000000000005e207 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
 9 0x000000000006b100 uct_worker_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/uct/api/uct.h:2589
10 0x0000000000404dee UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:388
11 0x000000000040449e UcxContext::progress()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/ucx_wrapper.cc:226
12 0x0000000000416dca DemoClient::wait_for_responses()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:1932
13 0x0000000000418200 DemoClient::run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2202
14 0x000000000040f37f do_client()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2791
15 0x000000000040f7a5 main()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/apps/iodemo/io_demo.cc:2834
16 0x00000000000223d5 __libc_start_main()  ???:0
17 0x00000000004033b9 _start()  ???:0
=================================
```

## How ?

1. Add `ep`/`worker` union in `ucp_request_t::send`.
2. Replace `ep` by `worker` when starting invalidation.