### PR TITLE
UCS/INIT: use single constructor entry

### DIFF
--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -222,7 +222,7 @@ typedef struct ucm_global_config {
 
 /*
  * Global UCM configuration to be set externally.
- * @deprecated replaced by @ref ucm_library_init.
+ * @deprecated replaced by @ref ucm_set_global_opts.
  */
 extern ucm_global_config_t ucm_global_opts;
 
@@ -266,14 +266,11 @@ typedef void (*ucm_event_callback_t)(ucm_event_type_t event_type,
 
 
 /**
- * Initialize UCM library and set its configuration.
+ * Set UCM library configuration.
  *
- * @param [in]  ucm_opts   UCM library global configuration. If NULL, default
- *                         configuration is applied.
- *
- * @note Calling this function more than once in the same process has no effect.
+ * @param [in]  ucm_opts   UCM library global configuration.
  */
-void ucm_library_init(const ucm_global_config_t *ucm_opts);
+void ucm_set_global_opts(const ucm_global_config_t *ucm_opts);
 
 
 /**

--- a/src/ucm/event/event.c
+++ b/src/ucm/event/event.c
@@ -469,17 +469,19 @@ int ucm_madvise(void *addr, size_t length, int advice)
     return event.madvise.result;
 }
 
-void ucm_library_init(const ucm_global_config_t *ucm_opts)
+void ucm_library_init()
 {
     UCS_INIT_ONCE(&ucm_library_init_once) {
-        if (ucm_opts != NULL) {
-            ucm_global_opts = *ucm_opts;
-        }
-
         pthread_spin_init(&ucm_kh_lock, PTHREAD_PROCESS_PRIVATE);
         kh_init_inplace(ucm_ptr_size, &ucm_shmat_ptrs);
         ucm_mmap_init();
     }
+}
+
+void ucm_set_global_opts(const ucm_global_config_t *ucm_opts)
+{
+    ucm_global_opts = *ucm_opts;
+    ucm_library_init();
 }
 
 void ucm_event_handler_add(ucm_event_handler_t *handler)
@@ -572,7 +574,7 @@ ucs_status_t ucm_set_event_handler(int events, int priority,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    ucm_library_init(NULL);
+    ucm_library_init();
 
     /* separate event flags from real events */
     flags   = events & (UCM_EVENT_FLAG_NO_INSTALL |
@@ -650,13 +652,13 @@ void ucm_unset_event_handler(int events, ucm_event_callback_t cb, void *arg)
 
 ucs_status_t ucm_test_events(int events)
 {
-    ucm_library_init(NULL);
+    ucm_library_init();
     return ucm_mmap_test_installed_events(events);
 }
 
 ucs_status_t ucm_test_external_events(int events)
 {
-    ucm_library_init(NULL);
+    ucm_library_init();
     return ucm_mmap_test_events(events & ucm_external_events, "external");
 }
 

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -89,6 +89,7 @@ noinst_HEADERS = \
 	arch/ppc64/cpu.h \
 	arch/x86_64/cpu.h \
 	arch/cpu.h \
+	config/ucm_opts.h \
 	datastruct/arbiter.h \
 	datastruct/bitmap.h \
 	datastruct/frag_list.h \

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -147,6 +147,7 @@ typedef struct {
 extern ucs_global_opts_t ucs_global_opts;
 
 void ucs_global_opts_init();
+void ucs_global_opts_cleanup();
 ucs_status_t ucs_global_opts_set_value(const char *name, const char *value);
 ucs_status_t ucs_global_opts_set_value_modifiable(const char *name,
                                                   const char *value);

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -119,13 +119,22 @@ typedef struct ucs_config_bw_spec {
     }
 
 #define UCS_CONFIG_REGISTER_TABLE(_table, _name, _prefix, _type, _list) \
+    UCS_CONFIG_DECLARE_TABLE(_table, _name, _prefix, _type) \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&_table##_config_entry, _list);
+
+#define UCS_CONFIG_DECLARE_TABLE(_table, _name, _prefix, _type) \
     static ucs_config_global_list_entry_t _table##_config_entry = { \
         .table  = _table, \
         .name   = _name, \
         .prefix = _prefix, \
         .size   = sizeof(_type) \
-    }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&_table##_config_entry, _list);
+    };
+
+#define UCS_CONFIG_ADD_TABLE(_table, _list) \
+    ucs_list_add_tail(_list, &(_table##_config_entry).list)
+
+#define UCS_CONFIG_REMOVE_TABLE(_table) \
+    ucs_list_del(&(_table##_config_entry).list)
 
 extern ucs_list_link_t ucs_config_global_list;
 

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -116,13 +116,22 @@ static ucs_config_field_t ucm_global_config_table[] = {
   {NULL}
 };
 
-UCS_CONFIG_REGISTER_TABLE(ucm_global_config_table, "UCM", UCM_CONFIG_PREFIX,
-                          ucm_global_config_t, &ucs_config_global_list)
+UCS_CONFIG_DECLARE_TABLE(ucm_global_config_table, "UCM", UCM_CONFIG_PREFIX,
+                         ucm_global_config_t)
 
-UCS_STATIC_INIT {
+void ucs_init_ucm_opts()
+{
     ucm_global_config_t ucm_opts;
+
+    UCS_CONFIG_ADD_TABLE(ucm_global_config_table, &ucs_config_global_list);
+
     (void)ucs_config_parser_fill_opts(&ucm_opts, ucm_global_config_table,
                                       UCS_DEFAULT_ENV_PREFIX, UCM_CONFIG_PREFIX,
                                       0);
-    ucm_library_init(&ucm_opts);
+    ucm_set_global_opts(&ucm_opts);
+}
+
+void ucs_opts_cleanup()
+{
+    UCS_CONFIG_REMOVE_TABLE(ucm_global_config_table);
 }

--- a/src/ucs/config/ucm_opts.h
+++ b/src/ucs/config/ucm_opts.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2021 Nvidia Corporation. All Rights Reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCM_OPTS_H_
+#define UCM_OPTS_H_
+
+#include <ucs/sys/compiler_def.h>
+
+BEGIN_C_DECLS
+
+void ucs_init_ucm_opts();
+void ucs_opts_cleanup();
+
+END_C_DECLS
+
+#endif

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -23,7 +23,7 @@
 #include <ucm/api/ucm.h>
 
 
-ucs_spinlock_t ucs_memtype_cache_global_instance_lock;
+static ucs_spinlock_t ucs_memtype_cache_global_instance_lock;
 ucs_memtype_cache_t *ucs_memtype_cache_global_instance = NULL;
 
 
@@ -398,11 +398,13 @@ static UCS_CLASS_CLEANUP_FUNC(ucs_memtype_cache_t)
     pthread_rwlock_destroy(&self->lock);
 }
 
-UCS_STATIC_INIT {
+void ucs_memtype_cache_global_init()
+{
     ucs_spinlock_init(&ucs_memtype_cache_global_instance_lock, 0);
 }
 
-UCS_STATIC_CLEANUP {
+void ucs_memtype_cache_cleanup()
+{
     ucs_spinlock_destroy(&ucs_memtype_cache_global_instance_lock);
 
     if (ucs_memtype_cache_global_instance) {

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -50,6 +50,10 @@ struct ucs_memtype_cache {
 };
 
 
+void ucs_memtype_cache_global_init();
+void ucs_memtype_cache_cleanup();
+
+
 /**
  * Find if address range is in memtype cache.
  *

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -12,6 +12,7 @@
 #include <ucs/sys/module.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/config/parser.h>
+#include <ucs/config/ucm_opts.h>
 #include <ucs/debug/debug_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack_int.h>
@@ -94,6 +95,8 @@ static void UCS_F_CTOR ucs_init()
     ucs_check_cpu_flags();
     ucs_log_early_init(); /* Must be called before all others */
     ucs_global_opts_init();
+    ucs_init_ucm_opts();
+    ucs_memtype_cache_global_init();
     ucs_cpu_init();
     ucs_log_init();
 #ifdef ENABLE_STATS
@@ -128,5 +131,8 @@ static void UCS_F_DTOR ucs_cleanup(void)
 #ifdef ENABLE_STATS
     ucs_stats_cleanup();
 #endif
+    ucs_memtype_cache_cleanup();
+    ucs_opts_cleanup();
+    ucs_global_opts_cleanup();
     ucs_log_cleanup();
 }

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -523,7 +523,7 @@ static void ucs_vfs_fuse_atfork_child()
     ucs_vfs_fuse_context.watch_desc = -1;
 }
 
-UCS_STATIC_INIT
+void UCS_F_CTOR ucs_vfs_fuse_init()
 {
     if (ucs_global_opts.vfs_enable) {
         pthread_atfork(NULL, NULL, ucs_vfs_fuse_atfork_child);
@@ -532,7 +532,7 @@ UCS_STATIC_INIT
     }
 }
 
-UCS_STATIC_CLEANUP
+void UCS_F_DTOR ucs_vfs_fuse_cleanup()
 {
     if (ucs_vfs_fuse_context.thread_id != -1) {
         ucs_fuse_thread_stop();

--- a/test/mpi/test_memhooks.c
+++ b/test/mpi/test_memhooks.c
@@ -108,7 +108,7 @@ static ucs_status_t set_event_handler(void *dl, int events)
 static ucs_status_t init_ucm_config(void *dl_ucm, int enable_hooks,
                                     ucm_mmap_hook_mode_t mmap_mode)
 {
-    void (*library_init)(const ucm_global_config_t *ucm_opts);
+    void (*library_init)();
     ucm_global_config_t *ucm_opts;
 
     DL_FIND_FUNC(dl_ucm, "ucm_library_init", library_init,
@@ -124,7 +124,7 @@ static ucs_status_t init_ucm_config(void *dl_ucm, int enable_hooks,
         ucm_opts->mmap_hook_mode      = UCM_MMAP_HOOK_NONE;
     }
 
-    library_init(NULL);
+    library_init();
 
     return UCS_OK;
 }


### PR DESCRIPTION
## What
- use single constructor/destructor entry to initialize UCS

## Why ?
- as part of activiti for UCX static build

## How ?
- use direct calls of initialisation routines
