### PR TITLE
UCP/TEST: API to pass pre-registered memory handle to UCP operations

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -696,6 +696,7 @@ typedef enum {
     UCP_OP_ATTR_FIELD_REPLY_BUFFER  = UCS_BIT(5),  /**< reply_buffer field */
     UCP_OP_ATTR_FIELD_MEMORY_TYPE   = UCS_BIT(6),  /**< memory type field */
     UCP_OP_ATTR_FIELD_RECV_INFO     = UCS_BIT(7),  /**< recv_info field */
+    UCP_OP_ATTR_FIELD_MEMH          = UCS_BIT(8),  /**< memory handle field */
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
     UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
@@ -1716,6 +1717,16 @@ typedef struct {
                                           Relevant for @a ucp_tag_recv_nbx
                                           function. */
     } recv_info;
+
+    /**
+     * Memory handle for pre-registered buffer.
+     * If the handle is provided, protocols that require registered memory can
+     * skip the registration step. As a result, the communication request
+     * overhead can be reduced and the request can be completed faster.
+     * The memory handle should be obtained by calling @ref ucp_mem_map.
+     */
+    ucp_mem_h memh;
+
 } ucp_request_param_t;
 
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1017,7 +1017,30 @@ unsigned ucp_test_base::entity::progress(int worker_index)
     return progress_count + ucp_worker_progress(ucp_worker);
 }
 
-int ucp_test_base::entity::get_num_workers() const {
+ucp_mem_h ucp_test_base::entity::mem_map(void *address, size_t length)
+{
+    ucp_mem_map_params_t params;
+
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address    = address;
+    params.length     = length;
+
+    ucp_mem_h memh;
+    ucs_status_t status = ucp_mem_map(ucph(), &params, &memh);
+    ASSERT_UCS_OK(status);
+
+    return memh;
+}
+
+void ucp_test_base::entity::mem_unmap(ucp_mem_h memh)
+{
+    ucs_status_t status = ucp_mem_unmap(ucph(), memh);
+    ASSERT_UCS_OK(status);
+}
+
+int ucp_test_base::entity::get_num_workers() const
+{
     return m_workers.size();
 }
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -127,6 +127,10 @@ public:
 
         unsigned progress(int worker_index = 0);
 
+        ucp_mem_h mem_map(void *address, size_t length);
+
+        void mem_unmap(ucp_mem_h memh);
+
         int get_num_workers() const;
 
         int get_num_eps(int worker_index = 0) const;


### PR DESCRIPTION
## Why
Optimization for zero-copy path, first stage of FR [internal link](https://redmine.mellanox.com/issues/2770592)
Allow passing pre-registered memory handle as a hint, to avoid memory cache lookup overhead.

## How
This PR adds API and gtests veriants for active message and tag-match, the implementation will be in a follow-up PR.
Active message tests were changed so all tests will run with and without pre-registration. So the test variant indexes had to be changed (add 1) since variant 0 is for prereg flag.

Replaces #7345 