### PR TITLE
UCM/INIT: use single constructor entry

### DIFF
--- a/src/ucm/malloc/malloc_hook.c
+++ b/src/ucm/malloc/malloc_hook.c
@@ -124,7 +124,7 @@ static ucm_malloc_hook_state_t ucm_malloc_hook_state = {
     .free             = NULL,
     .heap_start       = (void*)-1,
     .heap_end         = (void*)-1,
-    .ptrs             = {0},
+    .ptrs             = KHASH_STATIC_INITIALIZER,
     .env_lock         = PTHREAD_MUTEX_INITIALIZER,
     .env_strs         = NULL,
     .num_env_strs     = 0
@@ -899,7 +899,7 @@ void ucm_malloc_state_reset(int default_mmap_thresh, int default_trim_thresh)
     ucm_malloc_set_env_mallopt();
 }
 
-UCS_STATIC_INIT {
+void ucm_init_malloc_hook()
+{
     ucs_recursive_spinlock_init(&ucm_malloc_hook_state.lock, 0);
-    kh_init_inplace(mmap_ptrs, &ucm_malloc_hook_state.ptrs);
 }

--- a/src/ucm/malloc/malloc_hook.h
+++ b/src/ucm/malloc/malloc_hook.h
@@ -10,7 +10,7 @@
 #include <ucs/type/status.h>
 
 ucs_status_t ucm_malloc_install(int events);
-
+void ucm_init_malloc_hook();
 void ucm_malloc_state_reset(int default_mmap_thresh, int default_trim_thresh);
 
 #endif

--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -289,6 +289,7 @@ void __ucm_log(const char *file, unsigned line, const char *function,
     }
 }
 
-UCS_STATIC_INIT {
+void ucm_init_log()
+{
     gethostname(ucm_log_hostname, sizeof(ucm_log_hostname));
 }

--- a/src/ucm/util/log.h
+++ b/src/ucm/util/log.h
@@ -59,6 +59,8 @@
 extern const char *ucm_log_level_names[];
 
 
+void ucm_init_log();
+
 void __ucm_log(const char *file, unsigned line, const char *function,
                ucs_log_level_t level, const char *message, ...)
     UCS_F_PRINTF(5, 6);

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -68,7 +68,7 @@ KHASH_MAP_INIT_INT64(ucm_dl_info_hash, ucm_dl_info_t)
 static UCS_LIST_HEAD(ucm_reloc_patch_list);
 static pthread_mutex_t ucm_reloc_patch_list_lock = PTHREAD_MUTEX_INITIALIZER;
 
-static khash_t(ucm_dl_info_hash) ucm_dl_info_hash;
+static khash_t(ucm_dl_info_hash) ucm_dl_info_hash      = KHASH_STATIC_INITIALIZER;
 static ucm_reloc_dlopen_func_t  ucm_reloc_orig_dlopen  = NULL;
 static ucm_reloc_dlclose_func_t ucm_reloc_orig_dlclose = NULL;
 
@@ -748,8 +748,4 @@ ucs_status_t ucm_reloc_modify(ucm_reloc_patch_t *patch)
 out_unlock:
     pthread_mutex_unlock(&ucm_reloc_patch_list_lock);
     return status;
-}
-
-UCS_STATIC_INIT {
-    kh_init_inplace(ucm_dl_info_hash, &ucm_dl_info_hash);
 }

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -16,7 +16,9 @@
 
 #include <ucm/api/ucm.h>
 #include <ucm/util/log.h>
+#include <ucm/util/reloc.h>
 #include <ucm/mmap/mmap.h>
+#include <ucm/malloc/malloc_hook.h>
 #include <ucs/type/init_once.h>
 #include <ucs/sys/math.h>
 #include <linux/mman.h>
@@ -381,3 +383,10 @@ pid_t ucm_get_tid()
 {
     return syscall(SYS_gettid);
 }
+
+void UCS_F_CTOR ucm_init()
+{
+    ucm_init_log();
+    ucm_init_malloc_hook();
+}
+

--- a/src/ucs/datastruct/khash.h
+++ b/src/ucs/datastruct/khash.h
@@ -404,6 +404,8 @@ static const double __ac_HASH_UPPER = 0.77;
 #define KHASH_IMPL(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
 	__KHASH_IMPL(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
 
+#define KHASH_STATIC_INITIALIZER {0}
+
 /* --- BEGIN OF HASH FUNCTIONS --- */
 
 /*! @function

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -173,6 +173,7 @@ gtest_SOURCES = \
 	ucs/test_pgtable.cc \
 	ucs/test_profile.cc \
 	ucs/test_rcache.cc \
+	ucs/test_khash.cc \
 	ucs/test_memtype_cache.cc \
 	ucs/test_stats.cc \
 	ucs/test_strided_alloc.cc \

--- a/test/gtest/ucs/test_khash.cc
+++ b/test/gtest/ucs/test_khash.cc
@@ -1,0 +1,27 @@
+/**
+* Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+*/
+
+#include <common/test.h>
+#include <ucs/datastruct/khash.h>
+#include <string.h>
+
+KHASH_MAP_INIT_INT64(test_khash, size_t)
+
+class test_khash : public ucs::test {
+};
+
+UCS_TEST_F(test_khash, init_inplace) {
+    khash_t(test_khash) kh_static_init = KHASH_STATIC_INITIALIZER;
+    khash_t(test_khash) kh_init_inplace;
+
+    memset(&kh_init_inplace, -1, sizeof(kh_init_inplace));
+    kh_init_inplace(test_khash, &kh_init_inplace);
+
+    ASSERT_EQ(sizeof(kh_static_init), sizeof(kh_init_inplace));
+
+    /* Check that static initializer produces same result as kh_init_inplace */
+    EXPECT_EQ(0, memcmp(&kh_static_init, &kh_init_inplace,
+              sizeof(kh_static_init)));
+}
+


### PR DESCRIPTION
## What
- use single constructor entry to initialize UCM

## Why ?
- as part of activiti for UCX static build

## How ?
- use direct calls of initialisation routines