### PR TITLE
UCT/INIT: use single constructor entry

### DIFF
--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -145,3 +145,11 @@ err_free_bundle:
 err:
     return status;
 }
+
+void UCS_F_CTOR uct_init()
+{
+    uct_init_self_component();
+    uct_init_tcp_component();
+    uct_init_posix_tl();
+    uct_init_sysv_tl();
+}

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -164,6 +164,9 @@ struct uct_component {
 };
 
 
+extern ucs_list_link_t uct_components_list;
+
+
 /**
  * Register a component for usage, so it will be returned from
  * @ref uct_query_components.
@@ -171,12 +174,9 @@ struct uct_component {
  * @param [in] _component  Pointer to a global component structure to register.
  */
 #define UCT_COMPONENT_REGISTER(_component) \
-    extern ucs_list_link_t uct_components_list; \
-    UCS_STATIC_INIT { \
-        ucs_list_add_tail(&uct_components_list, &(_component)->list); \
-    } \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->md_config, &ucs_config_global_list); \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(_component)->cm_config, &ucs_config_global_list);
+    ucs_list_add_tail(&uct_components_list, &(_component).list); \
+    ucs_list_add_tail(&ucs_config_global_list, &(_component).md_config.list); \
+    ucs_list_add_tail(&ucs_config_global_list, &(_component).cm_config.list);
 
 
 /**
@@ -190,5 +190,10 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
                              ucs_config_field_t *config_table,
                              size_t config_size, const char *env_prefix,
                              const char *cfg_prefix);
+
+void uct_init_self_component(void);
+void uct_init_tcp_component(void);
+void uct_init_posix_tl();
+void uct_init_sysv_tl();
 
 #endif

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -362,7 +362,7 @@ typedef struct uct_iface_local_addr_ns {
 
 
 /**
- * Define a transport
+ * Register a transport
  *
  * @param _component      Component to add the transport to
  * @param _name           Name of the transport (should be a token, not a string)
@@ -372,24 +372,24 @@ typedef struct uct_iface_local_addr_ns {
  * @param _cfg_table      Transport configuration table
  * @param _cfg_struct     Struct type defining transport configuration
  */
-#define UCT_TL_DEFINE(_component, _name, _query_devices, _iface_class, \
-                      _cfg_prefix, _cfg_table, _cfg_struct) \
-    \
-    uct_tl_t uct_##_name##_tl = { \
-        .name               = #_name, \
-        .query_devices      = _query_devices, \
-        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
-        .config = { \
-            .name           = #_name" transport", \
-            .prefix         = _cfg_prefix, \
-            .table          = _cfg_table, \
-            .size           = sizeof(_cfg_struct), \
-         } \
-    }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(uct_##_name##_tl).config, &ucs_config_global_list); \
-    UCS_STATIC_INIT { \
+#define UCT_TL_REGISTER(_component, _name, _query_devices, _iface_class, \
+                        _cfg_prefix, _cfg_table, _cfg_struct) \
+    do { \
+        static uct_tl_t uct_##_name##_tl = { \
+            .name               = #_name, \
+            .query_devices      = _query_devices, \
+            .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
+            .config = { \
+                .name           = #_name" transport", \
+                .prefix         = _cfg_prefix, \
+                .table          = _cfg_table, \
+                .size           = sizeof(_cfg_struct), \
+             } \
+        }; \
+        ucs_list_add_tail(&ucs_config_global_list, \
+                          &(uct_##_name##_tl).config.list); \
         ucs_list_add_tail(&(_component)->tl_list, &(uct_##_name##_tl).list); \
-    }
+    } while(0)
 
 
 /**

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -18,6 +18,10 @@
 #include <ucs/profile/profile.h>
 #include <ucs/debug/log.h>
 #include <uct/cuda/cuda_copy/cuda_copy_md.h>
+#include <uct/cuda/cuda_copy/cuda_copy_iface.h>
+#include <uct/cuda/cuda_ipc/cuda_ipc_md.h>
+#include <uct/cuda/cuda_ipc/cuda_ipc_iface.h>
+#include <uct/cuda/cuda_ipc/cuda_ipc_cache.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
 
@@ -296,14 +300,22 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
                                            num_resources_p);
 }
 
-UCS_STATIC_INIT {
+void UCS_F_CTOR uct_init_cuda()
+{
     ucs_spinlock_init(&uct_cuda_base_lock, 0);
+    uct_init_cuda_copy_component();
+    uct_init_cuda_copy_tl();
+    uct_init_cuda_ipc_component();
+    uct_init_cuda_ipc_tl();
+    uct_init_cuda_ipc_cache();
 }
 
-UCS_STATIC_CLEANUP {
+void UCS_F_DTOR uct_cleanup_cuda()
+{
     ucs_spinlock_destroy(&uct_cuda_base_lock);
 }
 
+/* TODO: fixme for static lib */
 UCS_MODULE_INIT() {
     /* TODO make gdrcopy independent of cuda */
     UCS_MODULE_FRAMEWORK_DECLARE(uct_cuda);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -482,6 +482,10 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_cuda_copy_iface_t, uct_iface_t, uct_md_h, uct_work
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_copy_iface_t, uct_iface_t);
 
 
-UCT_TL_DEFINE(&uct_cuda_copy_component, cuda_copy, uct_cuda_base_query_devices,
-              uct_cuda_copy_iface_t, "CUDA_COPY_",
-              uct_cuda_copy_iface_config_table, uct_cuda_copy_iface_config_t);
+void uct_init_cuda_copy_tl()
+{
+    UCT_TL_REGISTER(&uct_cuda_copy_component, cuda_copy,
+                    uct_cuda_base_query_devices, uct_cuda_copy_iface_t,
+                    "CUDA_COPY_", uct_cuda_copy_iface_config_table,
+                    uct_cuda_copy_iface_config_t);
+}

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -66,4 +66,8 @@ typedef struct uct_cuda_copy_event_desc {
     uct_completion_t *comp;
     ucs_queue_elem_t queue;
 } uct_cuda_copy_event_desc_t;
+
+
+void uct_init_cuda_copy_tl();
+
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -8,6 +8,7 @@
 #endif
 
 #include "cuda_copy_md.h"
+#include "cuda_copy_iface.h"
 
 #include <string.h>
 #include <limits.h>
@@ -251,4 +252,8 @@ uct_component_t uct_cuda_copy_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_cuda_copy_component);
+
+void uct_init_cuda_copy_component()
+{
+    UCT_COMPONENT_REGISTER(uct_cuda_copy_component);
+}

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -34,4 +34,6 @@ typedef struct uct_cuda_copy_md_config {
     double                      max_reg_ratio;
 } uct_cuda_copy_md_config_t;
 
+void uct_init_cuda_copy_component();
+
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -409,7 +409,8 @@ void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache)
     ucs_free(cache);
 }
 
-UCS_STATIC_INIT {
+void uct_init_cuda_ipc_cache()
+{
     ucs_recursive_spinlock_init(&uct_cuda_ipc_remote_cache.lock, 0);
     kh_init_inplace(cuda_ipc_rem_cache, &uct_cuda_ipc_remote_cache.hash);
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -48,4 +48,5 @@ ucs_status_t
 uct_cuda_ipc_map_memhandle(const uct_cuda_ipc_key_t *key, void **mapped_addr);
 ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, uintptr_t d_bptr,
                                           void *mapped_addr, int cache_enabled);
+void uct_init_cuda_ipc_cache();
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -576,6 +576,10 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_cuda_ipc_iface_t, uct_iface_t, uct_md_h, uct_worke
                           const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_ipc_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_cuda_ipc_component.super, cuda_ipc,
-              uct_cuda_ipc_query_devices, uct_cuda_ipc_iface_t, "CUDA_IPC_",
-              uct_cuda_ipc_iface_config_table, uct_cuda_ipc_iface_config_t);
+void uct_init_cuda_ipc_tl()
+{
+    UCT_TL_REGISTER(&uct_cuda_ipc_component.super, cuda_ipc,
+                    uct_cuda_ipc_query_devices, uct_cuda_ipc_iface_t,
+                    "CUDA_IPC_", uct_cuda_ipc_iface_config_table,
+                    uct_cuda_ipc_iface_config_t);
+}

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -63,4 +63,7 @@ typedef struct uct_cuda_ipc_event_desc {
 
 
 ucs_status_t uct_cuda_ipc_iface_init_streams(uct_cuda_ipc_iface_t *iface);
+
+void uct_init_cuda_ipc_tl();
+
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -355,5 +355,9 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
     },
     .md                     = NULL,
 };
-UCT_COMPONENT_REGISTER(&uct_cuda_ipc_component.super);
+
+void uct_init_cuda_ipc_component()
+{
+    UCT_COMPONENT_REGISTER(uct_cuda_ipc_component.super);
+}
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -73,4 +73,7 @@ typedef struct uct_cuda_ipc_key {
         }                                                               \
     } while(0);
 
+
+void uct_init_cuda_ipc_component();
+
 #endif

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -200,6 +200,10 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_gdr_copy_iface_t, uct_iface_t, uct_md_h, uct_worke
                           const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_gdr_copy_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_gdr_copy_component, gdr_copy, uct_cuda_base_query_devices,
-              uct_gdr_copy_iface_t, "GDR_COPY_",
-              uct_gdr_copy_iface_config_table, uct_gdr_copy_iface_config_t);
+void uct_init_cuda_gdr_copy_tl()
+{
+    UCT_TL_REGISTER(&uct_gdr_copy_component, gdr_copy,
+                    uct_cuda_base_query_devices, uct_gdr_copy_iface_t,
+                    "GDR_COPY_", uct_gdr_copy_iface_config_table,
+                    uct_gdr_copy_iface_config_t);
+}

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.h
@@ -22,4 +22,7 @@ typedef struct uct_gdr_copy_iface_config {
     uct_iface_config_t      super;
 } uct_gdr_copy_iface_config_t;
 
+
+void uct_init_cuda_gdr_copy_tl();
+
 #endif

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -20,6 +20,7 @@
 #include <ucs/profile/profile.h>
 #include <ucm/api/ucm.h>
 #include <uct/cuda/base/cuda_iface.h>
+#include <uct/cuda/gdr_copy/gdr_copy_iface.h>
 
 #define UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN 65536
 
@@ -459,5 +460,10 @@ uct_component_t uct_gdr_copy_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_gdr_copy_component);
+
+void UCS_F_CTOR uct_init_cuda_gdr_copy_component()
+{
+    UCT_COMPONENT_REGISTER(uct_gdr_copy_component);
+    uct_init_cuda_gdr_copy_tl();
+}
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1881,7 +1881,10 @@ static uct_ib_md_ops_t uct_ib_verbs_md_ops = {
     .get_atomic_mr_id    = (uct_ib_md_get_atomic_mr_id_func_t)ucs_empty_function_return_unsupported,
 };
 
-UCT_IB_MD_OPS(uct_ib_verbs_md_ops, 0);
+static void uct_init_ib_verbs_md_ops()
+{
+    UCT_IB_MD_OPS(uct_ib_verbs_md_ops, 0);
+}
 
 uct_component_t uct_ib_component = {
     .query_md_resources = uct_ib_query_md_resources,
@@ -1902,4 +1905,43 @@ uct_component_t uct_ib_component = {
     .flags              = 0,
     .md_vfs_init        = uct_ib_md_vfs_init
 };
-UCT_COMPONENT_REGISTER(&uct_ib_component);
+
+void UCS_F_CTOR uct_init_ib_component()
+{
+    UCT_COMPONENT_REGISTER(uct_ib_component);
+
+    uct_init_ib_verbs_md_ops();
+
+#if HAVE_MLX5_DV
+    uct_init_ib_mlx5_md_ops();
+
+#if HAVE_DEVX
+    uct_init_ib_mlx5_devx_md_ops();
+#endif /* HAVE_DEVX */
+
+#endif /* HAVE_MLX5_DV */
+
+#if HAVE_EXP
+    uct_init_ib_mlx5_exp_md_ops();
+#endif /* HAVE_EXP */
+
+#if HAVE_TL_RC
+    uct_init_ib_rc_verbs_tl();
+#endif /* HAVE_TL_RC */
+
+#if HAVE_MLX5_HW
+    uct_init_ib_rc_mlx5_tl();
+#endif /* HAVE_MLX5_HW */
+
+#if HAVE_TL_DC
+    uct_init_ib_dc_mlx5_tl();
+#endif /* HAVE_TL_DC */
+
+#if HAVE_TL_UD
+    uct_init_ib_ud_verbs_tl();
+#endif /* HAVE_TL_UD */
+
+#if HAVE_MLX5_HW_UD
+    uct_init_ib_ud_mlx5_tl();
+#endif /* HAVE_MLX5_HW_UD */
+}

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -358,8 +358,7 @@ typedef struct uct_ib_md_ops_entry {
 } uct_ib_md_ops_entry_t;
 
 #define UCT_IB_MD_OPS(_md_ops, _priority) \
-    extern ucs_list_link_t uct_ib_md_ops_list; \
-    UCS_STATIC_INIT { \
+    do { \
         static uct_ib_md_ops_entry_t *p, entry = { \
             .name     = UCS_PP_MAKE_STRING(_md_ops), \
             .ops      = &_md_ops, \
@@ -372,9 +371,11 @@ typedef struct uct_ib_md_ops_entry {
             } \
         } \
         ucs_list_add_tail(&uct_ib_md_ops_list, &entry.list); \
-    }
+    } while(0)
 
 extern uct_component_t uct_ib_component;
+
+extern ucs_list_link_t uct_ib_md_ops_list;
 
 static inline uint32_t uct_ib_md_direct_rkey(uct_rkey_t uct_rkey)
 {
@@ -474,4 +475,38 @@ ucs_status_t uct_ib_reg_key_impl(uct_ib_md_t *md, void *address,
                                  size_t length, uint64_t access_flags,
                                  uct_ib_mem_t *memh, uct_ib_mr_t *mrs,
                                  uct_ib_mr_type_t mr_type, int silent);
+
+#if HAVE_TL_RC
+void uct_init_ib_rc_verbs_tl();
+#endif /* HAVE_TL_RC */
+
+#if HAVE_MLX5_HW
+void uct_init_ib_rc_mlx5_tl();
+#endif /* HAVE_MLX5_HW */
+
+#if HAVE_TL_DC
+void uct_init_ib_dc_mlx5_tl();
+#endif /* HAVE_TL_DC */
+
+#if HAVE_TL_UD
+void uct_init_ib_ud_verbs_tl();
+#endif /* HAVE_TL_UD */
+
+#if HAVE_MLX5_HW_UD
+void uct_init_ib_ud_mlx5_tl();
+#endif /* HAVE_MLX5_HW_UD */
+
+#if HAVE_MLX5_DV
+void uct_init_ib_mlx5_md_ops();
+
+#if HAVE_DEVX
+void uct_init_ib_mlx5_devx_md_ops();
+#endif /* HAVE_DEVX */
+
+#endif /* HAVE_MLX5_DV */
+
+#if HAVE_EXP
+void uct_init_ib_mlx5_exp_md_ops();
+#endif /* HAVE_EXP */
+
 #endif

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1453,9 +1453,13 @@ uct_dc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
                                      num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, dc_mlx5, uct_dc_mlx5_query_tl_devices,
-              uct_dc_mlx5_iface_t, "DC_MLX5_", uct_dc_mlx5_iface_config_table,
-              uct_dc_mlx5_iface_config_t);
+void uct_init_ib_dc_mlx5_tl()
+{
+    UCT_TL_REGISTER(&uct_ib_component, dc_mlx5, uct_dc_mlx5_query_tl_devices,
+                    uct_dc_mlx5_iface_t, "DC_MLX5_",
+                    uct_dc_mlx5_iface_config_table,
+                    uct_dc_mlx5_iface_config_t);
+}
 
 static void
 uct_dc_mlx5_dci_keepalive_handle_failure(uct_dc_mlx5_iface_t *iface,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -857,7 +857,10 @@ static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops = {
     .get_atomic_mr_id    = uct_ib_mlx5_md_get_atomic_mr_id,
 };
 
-UCT_IB_MD_OPS(uct_ib_mlx5_devx_md_ops, 2);
+void uct_init_ib_mlx5_devx_md_ops()
+{
+    UCT_IB_MD_OPS(uct_ib_mlx5_devx_md_ops, 2);
+}
 
 #endif
 
@@ -1067,5 +1070,7 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
     .get_atomic_mr_id    = (uct_ib_md_get_atomic_mr_id_func_t)ucs_empty_function_return_unsupported,
 };
 
-UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);
-
+void uct_init_ib_mlx5_md_ops()
+{
+    UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);
+}

--- a/src/uct/ib/mlx5/exp/ib_exp_md.c
+++ b/src/uct/ib/mlx5/exp/ib_exp_md.c
@@ -749,5 +749,7 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
     .get_atomic_mr_id    = uct_ib_mlx5_md_get_atomic_mr_id,
 };
 
-UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);
-
+void uct_init_ib_mlx5_exp_md_ops()
+{
+    UCT_IB_MD_OPS(uct_ib_mlx5_md_ops, 1);
+}

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -952,6 +952,10 @@ uct_rc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
                                      num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, rc_mlx5, uct_rc_mlx5_query_tl_devices,
-              uct_rc_mlx5_iface_t, "RC_MLX5_", uct_rc_mlx5_iface_config_table,
-              uct_rc_mlx5_iface_config_t);
+void uct_init_ib_rc_mlx5_tl()
+{
+    UCT_TL_REGISTER(&uct_ib_component, rc_mlx5, uct_rc_mlx5_query_tl_devices,
+                    uct_rc_mlx5_iface_t, "RC_MLX5_",
+                    uct_rc_mlx5_iface_config_table,
+                    uct_rc_mlx5_iface_config_t);
+}

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -574,6 +574,10 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
                                      num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, rc_verbs, uct_rc_verbs_query_tl_devices,
-              uct_rc_verbs_iface_t, "RC_VERBS_", uct_rc_verbs_iface_config_table,
-              uct_rc_verbs_iface_config_t);
+void uct_init_ib_rc_verbs_tl()
+{
+    UCT_TL_REGISTER(&uct_ib_component, rc_verbs, uct_rc_verbs_query_tl_devices,
+                    uct_rc_verbs_iface_t, "RC_VERBS_",
+                    uct_rc_verbs_iface_config_table,
+                    uct_rc_verbs_iface_config_t);
+}

--- a/src/uct/ib/rdmacm/rdmacm_component.c
+++ b/src/uct/ib/rdmacm/rdmacm_component.c
@@ -65,4 +65,7 @@ uct_component_t uct_rdmacm_component = {
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
 
-UCT_COMPONENT_REGISTER(&uct_rdmacm_component)
+void UCS_F_CTOR uct_init_rdmacm_component()
+{
+    UCT_COMPONENT_REGISTER(uct_rdmacm_component)
+}

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -903,6 +903,10 @@ uct_ud_mlx5_query_tl_devices(uct_md_h md,
                                      tl_devices_p, num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, ud_mlx5, uct_ud_mlx5_query_tl_devices,
-              uct_ud_mlx5_iface_t, "UD_MLX5_", uct_ud_mlx5_iface_config_table,
-              uct_ud_mlx5_iface_config_t);
+void uct_init_ib_ud_mlx5_tl()
+{
+    UCT_TL_REGISTER(&uct_ib_component, ud_mlx5, uct_ud_mlx5_query_tl_devices,
+                    uct_ud_mlx5_iface_t, "UD_MLX5_",
+                    uct_ud_mlx5_iface_config_table,
+                    uct_ud_mlx5_iface_config_t);
+}

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -742,6 +742,9 @@ uct_ud_verbs_query_tl_devices(uct_md_h md,
                                      num_tl_devices_p);
 }
 
-UCT_TL_DEFINE(&uct_ib_component, ud_verbs, uct_ud_verbs_query_tl_devices,
-              uct_ud_verbs_iface_t,  "UD_VERBS_",
-              uct_ud_verbs_iface_config_table, uct_ud_iface_config_t);
+void uct_init_ib_ud_verbs_tl()
+{
+    UCT_TL_REGISTER(&uct_ib_component, ud_verbs, uct_ud_verbs_query_tl_devices,
+                    uct_ud_verbs_iface_t,  "UD_VERBS_",
+                    uct_ud_verbs_iface_config_table, uct_ud_iface_config_t);
+}

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -10,6 +10,8 @@
 #include "rocm_base.h"
 
 #include <ucs/sys/module.h>
+#include <uct/rocm/copy/rocm_copy_iface.h>
+#include <uct/rocm/ipc/rocm_ipc_iface.h>
 
 #include <pthread.h>
 
@@ -279,8 +281,15 @@ ucs_status_t uct_rocm_base_get_link_type(hsa_amd_link_info_type_t *link_type)
     return UCS_OK;
 }
 
+/* TODO: fixme for static lib */
 UCS_MODULE_INIT() {
     UCS_MODULE_FRAMEWORK_DECLARE(uct_rocm);
     UCS_MODULE_FRAMEWORK_LOAD(uct_rocm, 0);
     return UCS_OK;
+}
+
+void UCS_F_CTOR uct_init_rocm()
+{
+    uct_init_rocm_copy_tl();
+    uct_init_rocm_ipc_tl();
 }

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -167,7 +167,10 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_copy_iface_t, uct_iface_t, uct_md_h, uct_work
                           const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_copy_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_rocm_copy_component, rocm_copy,
-              uct_rocm_base_query_devices, uct_rocm_copy_iface_t,
-              "ROCM_COPY_", uct_rocm_copy_iface_config_table,
-              uct_rocm_copy_iface_config_t);
+void uct_init_rocm_copy_tl()
+{
+    UCT_TL_REGISTER(&uct_rocm_copy_component, rocm_copy,
+                    uct_rocm_base_query_devices, uct_rocm_copy_iface_t,
+                    "ROCM_COPY_", uct_rocm_copy_iface_config_table,
+                    uct_rocm_copy_iface_config_t);
+}

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -30,4 +30,7 @@ typedef struct uct_rocm_copy_iface_config {
     size_t              h2d_thresh;
 } uct_rocm_copy_iface_config_t;
 
+
+void uct_init_rocm_copy_tl();
+
 #endif

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -397,5 +397,9 @@ uct_component_t uct_rocm_copy_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_rocm_copy_component);
+
+void UCS_F_CTOR uct_init_rocm_copy_component()
+{
+    UCT_COMPONENT_REGISTER(uct_rocm_copy_component);
+}
 

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -141,6 +141,10 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_gdr_iface_t, uct_iface_t, uct_md_h, uct_worke
                           const uct_iface_params_t*, const uct_iface_config_t*);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_gdr_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_rocm_gdr_component, rocm_gdr, uct_rocm_base_query_devices,
-              uct_rocm_gdr_iface_t, "ROCM_GDR_",
-              uct_rocm_gdr_iface_config_table, uct_rocm_gdr_iface_config_t);
+void UCS_F_CTOR uct_init_rocm_gdb_tl()
+{
+    UCT_TL_REGISTER(&uct_rocm_gdr_component, rocm_gdr,
+                    uct_rocm_base_query_devices, uct_rocm_gdr_iface_t,
+                    "ROCM_GDR_", uct_rocm_gdr_iface_config_table,
+                    uct_rocm_gdr_iface_config_t);
+}

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -164,5 +164,9 @@ uct_component_t uct_rocm_gdr_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_rocm_gdr_component);
+
+void UCS_F_CTOR uct_init_rocm_gdr_component()
+{
+    UCT_COMPONENT_REGISTER(uct_rocm_gdr_component);
+}
 

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -264,6 +264,11 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_ipc_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_ipc_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_rocm_ipc_component, rocm_ipc, uct_rocm_base_query_devices,
-              uct_rocm_ipc_iface_t, "ROCM_IPC_",
-              uct_rocm_ipc_iface_config_table, uct_rocm_ipc_iface_config_t);
+
+void uct_init_rocm_ipc_tl()
+{
+    UCT_TL_REGISTER(&uct_rocm_ipc_component, rocm_ipc,
+                    uct_rocm_base_query_devices, uct_rocm_ipc_iface_t,
+                    "ROCM_IPC_", uct_rocm_ipc_iface_config_table,
+                    uct_rocm_ipc_iface_config_t);
+}

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -30,4 +30,7 @@ typedef struct uct_rocm_ipc_iface_config {
     uct_iface_config_t super;
 } uct_rocm_ipc_iface_config_t;
 
+
+void uct_init_rocm_ipc_tl();
+
 #endif

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -185,5 +185,9 @@ uct_component_t uct_rocm_ipc_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_rocm_ipc_component);
+
+void UCS_F_CTOR uct_init_rocm_ipc_component()
+{
+    UCT_COMPONENT_REGISTER(uct_rocm_ipc_component);
+}
 

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -225,7 +225,7 @@ typedef struct uct_mm_iface {
 
 
 /*
- * Define a memory-mapper transport for MM.
+ * Register a memory-mapper transport for MM.
  *
  * @param _name         Component name token
  * @param _md_ops       Memory domain operations, of type uct_mm_md_ops_t
@@ -234,19 +234,19 @@ typedef struct uct_mm_iface {
  * @param _cfg_prefix   Prefix for configuration variables
  * @param _cfg_table    Configuration table
  */
-#define UCT_MM_TL_DEFINE(_name, _md_ops, _rkey_unpack, _rkey_release, \
-                         _cfg_prefix, _cfg_table) \
+#define UCT_MM_TL_REGISTER(_name, _md_ops, _rkey_unpack, _rkey_release, \
+                           _cfg_prefix, _cfg_table) \
     \
-    UCT_MM_COMPONENT_DEFINE(uct_##_name##_component, _name, _md_ops, \
-                            _rkey_unpack, _rkey_release, _cfg_prefix) \
+    UCT_MM_COMPONENT_REGISTER(uct_##_name##_component, _name, _md_ops, \
+                              _rkey_unpack, _rkey_release, _cfg_prefix); \
     \
-    UCT_TL_DEFINE(&(uct_##_name##_component).super, \
-                  _name, \
-                  uct_sm_base_query_tl_devices, \
-                  uct_mm_iface_t, \
-                  _cfg_prefix, \
-                  _cfg_table, \
-                  uct_mm_iface_config_t);
+    UCT_TL_REGISTER(&(uct_##_name##_component).super, \
+                    _name, \
+                    uct_sm_base_query_tl_devices, \
+                    uct_mm_iface_t, \
+                    _cfg_prefix, \
+                    _cfg_table, \
+                    uct_mm_iface_config_t);
 
 
 extern ucs_config_field_t uct_mm_iface_config_table[];

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -150,7 +150,7 @@ typedef struct uct_mm_component {
 
 
 /*
- * Define a memory-mapper component for MM.
+ * Register a memory-mapper component for MM.
  *
  * @param _var          Variable for MM component.
  * @param _name         String which is the component name.
@@ -159,8 +159,8 @@ typedef struct uct_mm_component {
  * @param _rkey_release Remote key release function.
  * @param _cfg_prefix   Prefix for configuration environment vars.
  */
-#define UCT_MM_COMPONENT_DEFINE(_var, _name, _md_ops, _rkey_unpack, \
-                                _rkey_release, _cfg_prefix) \
+#define UCT_MM_COMPONENT_REGISTER(_var, _name, _md_ops, _rkey_unpack, \
+                                  _rkey_release, _cfg_prefix) \
     \
     static uct_mm_component_t _var = { \
         .super = { \
@@ -186,7 +186,7 @@ typedef struct uct_mm_component {
        }, \
        .md_ops                  = (_md_ops) \
     }; \
-    UCT_COMPONENT_REGISTER(&(_var).super); \
+    UCT_COMPONENT_REGISTER((_var).super)
 
 
 extern ucs_config_field_t uct_mm_md_config_table[];

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -699,5 +699,9 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
     .is_reachable      = uct_posix_is_reachable
 };
 
-UCT_MM_TL_DEFINE(posix, &uct_posix_md_ops, uct_posix_rkey_unpack,
-                 uct_posix_rkey_release, "POSIX_", uct_posix_iface_config_table)
+void uct_init_posix_tl()
+{
+    UCT_MM_TL_REGISTER(posix, &uct_posix_md_ops, uct_posix_rkey_unpack,
+                       uct_posix_rkey_release, "POSIX_",
+                       uct_posix_iface_config_table);
+}

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -208,5 +208,9 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
     .is_reachable      = ucs_empty_function_return_one_int
 };
 
-UCT_MM_TL_DEFINE(sysv, &uct_sysv_md_ops, uct_sysv_rkey_unpack,
-                 uct_sysv_rkey_release, "SYSV_", uct_sysv_iface_config_table)
+void uct_init_sysv_tl()
+{
+    UCT_MM_TL_REGISTER(sysv, &uct_sysv_md_ops, uct_sysv_rkey_unpack,
+                       uct_sysv_rkey_release, "SYSV_",
+                       uct_sysv_iface_config_table);
+}

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -76,11 +76,6 @@ static ucs_config_field_t uct_xpmem_iface_config_table[] = {
   {NULL}
 };
 
-UCS_STATIC_INIT {
-    ucs_recursive_spinlock_init(&uct_xpmem_remote_mem_lock, 0);
-    kh_init_inplace(xpmem_remote_mem, &uct_xpmem_remote_mem_hash);
-}
-
 UCS_STATIC_CLEANUP {
     unsigned long num_leaked_segments;
     uct_xpmem_remote_mem_t *rmem;
@@ -571,5 +566,12 @@ static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
     .is_reachable      = ucs_empty_function_return_one_int
 };
 
-UCT_MM_TL_DEFINE(xpmem, &uct_xpmem_md_ops, uct_xpmem_rkey_unpack,
-                 uct_xpmem_rkey_release, "XPMEM_", uct_xpmem_iface_config_table)
+void UCS_F_CTOR uct_init_knem_tl()
+{
+    UCT_MM_TL_REGISTER(xpmem, &uct_xpmem_md_ops, uct_xpmem_rkey_unpack,
+                       uct_xpmem_rkey_release, "XPMEM_",
+                       uct_xpmem_iface_config_table);
+
+    ucs_recursive_spinlock_init(&uct_xpmem_remote_mem_lock, 0);
+    kh_init_inplace(xpmem_remote_mem, &uct_xpmem_remote_mem_hash);
+}

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -144,6 +144,9 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_cma_component, cma, uct_sm_base_query_tl_devices,
-              uct_cma_iface_t, "CMA_", uct_cma_iface_config_table,
-              uct_cma_iface_config_t);
+void uct_init_cma_tl()
+{
+    UCT_TL_REGISTER(&uct_cma_component, cma, uct_sm_base_query_tl_devices,
+                    uct_cma_iface_t, "CMA_", uct_cma_iface_config_table,
+                    uct_cma_iface_config_t);
+}

--- a/src/uct/sm/scopy/cma/cma_iface.h
+++ b/src/uct/sm/scopy/cma/cma_iface.h
@@ -24,4 +24,6 @@ typedef struct uct_cma_iface {
 } uct_cma_iface_t;
 
 
+void uct_init_cma_tl();
+
 #endif

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -20,6 +20,7 @@
 #include <ucs/sys/sys.h>
 #include <sys/prctl.h>
 #include <sys/uio.h>
+#include <cma_iface.h>
 #include <string.h>
 
 #if HAVE_SYS_CAPABILITY_H
@@ -247,4 +248,9 @@ uct_component_t uct_cma_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_cma_component);
+
+void UCS_F_CTOR uct_init_cma_component()
+{
+    UCT_COMPONENT_REGISTER(uct_cma_component);
+    uct_init_cma_tl();
+}

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -96,6 +96,9 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_knem_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_knem_component, knem, uct_sm_base_query_tl_devices,
-              uct_knem_iface_t, "KNEM_", uct_knem_iface_config_table,
-              uct_knem_iface_config_t);
+void uct_init_knem_tl()
+{
+    UCT_TL_REGISTER(&uct_knem_component, knem, uct_sm_base_query_tl_devices,
+                    uct_knem_iface_t, "KNEM_", uct_knem_iface_config_table,
+                    uct_knem_iface_config_t);
+}

--- a/src/uct/sm/scopy/knem/knem_iface.h
+++ b/src/uct/sm/scopy/knem/knem_iface.h
@@ -24,4 +24,6 @@ typedef struct uct_knem_iface {
 } uct_knem_iface_t;
 
 
+void uct_init_knem_tl();
+
 #endif

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -17,6 +17,7 @@
 #include <ucs/sys/sys.h>
 #include <ucm/api/ucm.h>
 #include <ucs/vfs/base/vfs_obj.h>
+#include <knem_iface.h>
 
 
 #define UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(_params) \
@@ -427,4 +428,9 @@ uct_component_t uct_knem_component = {
     .flags              = 0,
     .md_vfs_init        = uct_knem_md_vfs_init
 };
-UCT_COMPONENT_REGISTER(&uct_knem_component);
+
+void UCS_F_CTOR uct_init_knem_component()
+{
+    UCT_COMPONENT_REGISTER(uct_knem_component);
+    uct_init_knem_tl();
+}

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -379,8 +379,12 @@ static uct_iface_ops_t uct_self_iface_ops = {
     .iface_is_reachable       = uct_self_iface_is_reachable
 };
 
-UCT_TL_DEFINE(&uct_self_component, self, uct_self_query_tl_devices, uct_self_iface_t,
-              "SELF_", uct_self_iface_config_table, uct_self_iface_config_t);
+static void uct_init_self_tl()
+{
+    UCT_TL_REGISTER(&uct_self_component, self, uct_self_query_tl_devices,
+                    uct_self_iface_t, "SELF_", uct_self_iface_config_table,
+                    uct_self_iface_config_t);
+}
 
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
 {
@@ -472,4 +476,9 @@ static uct_component_t uct_self_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_self_component);
+
+void uct_init_self_component()
+{
+    UCT_COMPONENT_REGISTER(uct_self_component);
+    uct_init_self_tl();
+}

--- a/src/uct/tcp/tcp_base.h
+++ b/src/uct/tcp/tcp_base.h
@@ -43,6 +43,8 @@ typedef struct uct_tcp_send_recv_buf_config {
      (_offset) , UCS_CONFIG_TYPE_ULUNITS}
 
 
+void uct_init_tcp_tl();
+
 ucs_status_t ucs_tcp_base_set_syn_cnt(int fd, int tcp_syn_cnt);
 
 #endif /* UCT_TCP_BASE_H */

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -943,6 +943,9 @@ int uct_tcp_keepalive_is_enabled(uct_tcp_iface_t *iface)
 #endif /* UCT_TCP_EP_KEEPALIVE */
 }
 
-UCT_TL_DEFINE(&uct_tcp_component, tcp, uct_tcp_query_devices, uct_tcp_iface_t,
-              UCT_TCP_CONFIG_PREFIX, uct_tcp_iface_config_table,
-              uct_tcp_iface_config_t);
+void uct_init_tcp_tl()
+{
+    UCT_TL_REGISTER(&uct_tcp_component, tcp, uct_tcp_query_devices,
+                    uct_tcp_iface_t, UCT_TCP_CONFIG_PREFIX,
+                    uct_tcp_iface_config_table, uct_tcp_iface_config_t);
+}

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -152,4 +152,9 @@ uct_component_t uct_tcp_component = {
     .flags              = UCT_COMPONENT_FLAG_CM,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_tcp_component)
+
+void uct_init_tcp_component()
+{
+    UCT_COMPONENT_REGISTER(uct_tcp_component);
+    uct_init_tcp_tl();
+}

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -11,6 +11,9 @@
 #include "ugni_device.h"
 #include "ugni_iface.h"
 #include "ugni_md.h"
+#include <uct/ugni/rdma/ugni_rdma_iface.h>
+#include <uct/ugni/smsg/ugni_smsg_iface.h>
+#include <uct/ugni/udt/ugni_udt_iface.h>
 
 /* Forward declarations */
 
@@ -243,4 +246,12 @@ uct_component_t uct_ugni_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_ugni_component);
+
+void UCS_F_CTOR uct_init_ugni_component()
+{
+    UCT_COMPONENT_REGISTER(uct_ugni_component);
+
+    uct_init_ugni_rdma_tl();
+    uct_init_ugni_smsg_tl();
+    uct_init_ugni_udt_tl();
+}

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -376,6 +376,10 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_rdma_iface_t, uct_iface_t, uct_md_h,
                           uct_worker_h, const uct_iface_params_t*,
                           const uct_iface_config_t*);
 
-UCT_TL_DEFINE(&uct_ugni_component, ugni_rdma, uct_ugni_query_devices,
-              uct_ugni_rdma_iface_t, "UGNI_RDMA_",
-              uct_ugni_rdma_iface_config_table, uct_ugni_rdma_iface_config_t);
+void uct_init_ugni_rdma_tl()
+{
+    UCT_TL_REGISTER(&uct_ugni_component, ugni_rdma, uct_ugni_query_devices,
+                    uct_ugni_rdma_iface_t, "UGNI_RDMA_",
+                    uct_ugni_rdma_iface_config_table,
+                    uct_ugni_rdma_iface_config_t);
+}

--- a/src/uct/ugni/rdma/ugni_rdma_iface.h
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.h
@@ -64,4 +64,7 @@ typedef struct uct_ugni_rdma_fetch_desc {
     size_t tail;                    /**< Tail parameter to specify how many bytes at the end of a fma/rdma are garbage*/
 } uct_ugni_rdma_fetch_desc_t;
 
+
+void uct_init_ugni_rdma_tl();
+
 #endif

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -373,6 +373,9 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_smsg_iface_t, uct_iface_t, uct_md_h,
                           uct_worker_h, const uct_iface_params_t*,
                           const uct_iface_config_t *);
 
-UCT_TL_DEFINE(&uct_ugni_component, ugni_smsg, uct_ugni_query_devices,
-              uct_ugni_smsg_iface_t, "UGNI_SMSG_",
-              uct_ugni_smsg_iface_config_table, uct_ugni_iface_config_t);
+void uct_init_ugni_smsg_tl()
+{
+    UCT_TL_REGISTER(&uct_ugni_component, ugni_smsg, uct_ugni_query_devices,
+                    uct_ugni_smsg_iface_t, "UGNI_SMSG_",
+                    uct_ugni_smsg_iface_config_table, uct_ugni_iface_config_t);
+}

--- a/src/uct/ugni/smsg/ugni_smsg_iface.h
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.h
@@ -39,4 +39,6 @@ typedef struct uct_ugni_smsg_header {
 
 ucs_status_t progress_remote_cq(uct_ugni_smsg_iface_t *iface);
 
+void uct_init_ugni_smsg_tl();
+
 #endif

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -492,6 +492,9 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_udt_iface_t, uct_iface_t, uct_md_h,
                           uct_worker_h, const uct_iface_params_t*,
                           const uct_iface_config_t*);
 
-UCT_TL_DEFINE(&uct_ugni_component, ugni_udt, uct_ugni_query_devices,
-              uct_ugni_udt_iface_t, "UGNI_UDT_",
-              uct_ugni_udt_iface_config_table, uct_ugni_iface_config_t);
+void uct_init_ugni_udt_tl()
+{
+    UCT_TL_REGISTER(&uct_ugni_component, ugni_udt, uct_ugni_query_devices,
+                    uct_ugni_udt_iface_t, "UGNI_UDT_",
+                    uct_ugni_udt_iface_config_table, uct_ugni_iface_config_t);
+}

--- a/src/uct/ugni/udt/ugni_udt_iface.h
+++ b/src/uct/ugni/udt/ugni_udt_iface.h
@@ -79,6 +79,8 @@ if (ucs_unlikely(GNI_RC_SUCCESS != rc)) {                          \
 
 #define uct_ugni_udt_iface_nic_handle(_iface) uct_ugni_iface_nic_handle(&(_iface)->super)
 
+void uct_init_ugni_udt_tl();
+
 static inline void uct_ugni_udt_reset_desc(uct_ugni_udt_desc_t *desc, uct_ugni_udt_iface_t *iface)
 {
     uct_ugni_udt_header_t *sheader = uct_ugni_udt_get_sheader(desc, iface);


### PR DESCRIPTION
## What
- use single constructor/destructor entry to initialize UCT modules

## Why ?
- as part of activiti for UCX static build

## How ?
- use direct calls of initialisation routines
