### PR TITLE
UCT/IB: Choose PKEY index 0 for RoCE devices [v1.12]

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -43,6 +43,7 @@
 #define UCT_IB_MAX_MESSAGE_SIZE           (2UL << 30) /* Maximal IB message size */
 #define UCT_IB_PKEY_PARTITION_MASK        0x7fff /* IB partition number mask */
 #define UCT_IB_PKEY_MEMBERSHIP_MASK       0x8000 /* Full/send-only member */
+#define UCT_IB_PKEY_DEFAULT               0xffff /* Default PKEY */
 #define UCT_IB_DEV_MAX_PORTS              2
 #define UCT_IB_FABRIC_TIME_MAX            32
 #define UCT_IB_INVALID_RKEY               0xffffffffu

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -553,9 +553,12 @@ uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
 
 
 #define UCT_IB_IFACE_FMT \
-    "%s:%d"
+    "%s:%d/%s"
 #define UCT_IB_IFACE_ARG(_iface) \
-    uct_ib_device_name(uct_ib_iface_device(_iface)), (_iface)->config.port_num
+    uct_ib_device_name(uct_ib_iface_device(_iface)), \
+    (_iface)->config.port_num, \
+    uct_ib_iface_is_roce(_iface) ? "RoCE" : "IB"
+    
 
 
 #define UCT_IB_IFACE_VERBS_COMPLETION_ERR(_type, _iface, _i,  _wc) \

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -52,7 +52,10 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(dctc, dctc, cs_res, uct_ib_mlx5_qpc_cs_res(
                       iface->super.super.super.config.max_inl_cqe[UCT_IB_DIR_RX], 1));
     UCT_IB_MLX5DV_SET(dctc, dctc, atomic_mode, UCT_IB_MLX5_ATOMIC_MODE);
-    UCT_IB_MLX5DV_SET(dctc, dctc, pkey_index, iface->super.super.super.pkey_index);
+    if (!uct_ib_iface_is_roce(&iface->super.super.super)) {
+        UCT_IB_MLX5DV_SET(dctc, dctc, pkey_index,
+                          iface->super.super.super.pkey_index);
+    }
     UCT_IB_MLX5DV_SET(dctc, dctc, port, iface->super.super.super.config.port_num);
 
     UCT_IB_MLX5DV_SET(dctc, dctc, min_rnr_nak, iface->super.super.config.min_rnr_timer);
@@ -108,7 +111,10 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     qpc = UCT_IB_MLX5DV_ADDR_OF(rst2init_qp_in, in_2init, qpc);
     UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
     UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.vhca_port_num, iface->super.super.super.config.port_num);
-    UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index, iface->super.super.super.pkey_index);
+    if (!uct_ib_iface_is_roce(&iface->super.super.super)) {
+        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index,
+                          iface->super.super.super.pkey_index);
+    }
 
     status = uct_ib_mlx5_devx_modify_qp(qp, in_2init, sizeof(in_2init),
                                         out_2init, sizeof(out_2init));
@@ -166,7 +172,10 @@ ucs_status_t uct_dc_mlx5_iface_devx_set_srq_dc_params(uct_dc_mlx5_iface_t *iface
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(set_xrq_dc_params_entry_out)] = {};
     int ret;
 
-    UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, pkey_table_index, iface->super.super.super.pkey_index);
+    if (!uct_ib_iface_is_roce(&iface->super.super.super)) {
+        UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, pkey_table_index,
+                          iface->super.super.super.pkey_index);
+    }
     UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, mtu, iface->super.super.super.config.path_mtu);
     UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, sl, iface->super.super.super.config.sl);
     UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, reverse_sl, iface->super.super.super.config.sl);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -171,7 +171,10 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
         UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, qpn, qp->qp_num);
         UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.vhca_port_num, attr->super.port);
-        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index, iface->pkey_index);
+        if (!uct_ib_iface_is_roce(iface)) {
+            UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index,
+                              iface->pkey_index);
+        }
         UCT_IB_MLX5DV_SET(qpc, qpc, rwe, true);
 
         ret = mlx5dv_devx_obj_modify(qp->devx.obj, in_2init, sizeof(in_2init),

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -917,6 +917,7 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
 #if HAVE_DEVX
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md, uct_ib_mlx5_md_t);
 #endif
+    const char *dev_name = uct_ib_device_name(uct_ib_iface_device(iface));
     uint16_t ooo_sl_mask = 0;
     ucs_status_t status;
 
@@ -926,8 +927,8 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
                                    iface->config.port_num)) {
         /* Ethernet priority for RoCE devices can't be selected regardless
          * AR support requested by user, pass empty ooo_sl_mask */
-        return uct_ib_mlx5_select_sl(ib_config, UCS_NO, 0, 1,
-                                     UCT_IB_IFACE_ARG(iface),
+        return uct_ib_mlx5_select_sl(ib_config, UCS_NO, 0, 1, dev_name,
+                                     iface->config.port_num,
                                      &iface->config.sl);
     }
 
@@ -942,8 +943,8 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
 #endif
 
     return uct_ib_mlx5_select_sl(ib_config, ib_mlx5_config->ar_enable,
-                                 ooo_sl_mask, status == UCS_OK,
-                                 UCT_IB_IFACE_ARG(iface),
+                                 ooo_sl_mask, status == UCS_OK, dev_name,
+                                 iface->config.port_num,
                                  &iface->config.sl);
 }
 

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -160,11 +160,9 @@ ucs_status_t uct_ib_mlx5_completion_with_err(uct_ib_iface_t *iface,
     }
 
     ucs_log(log_level,
-            "%s on " UCT_IB_IFACE_FMT
-            "/%s (synd 0x%x vend 0x%x hw_synd %d/%d)\n"
+            "%s on " UCT_IB_IFACE_FMT " (synd 0x%x vend 0x%x hw_synd %d/%d)\n"
             "%s QP 0x%x wqe[%d]: %s %s",
-            err_info, UCT_IB_IFACE_ARG(iface),
-            uct_ib_iface_is_roce(iface) ? "RoCE" : "IB", ecqe->syndrome,
+            err_info, UCT_IB_IFACE_ARG(iface), ecqe->syndrome,
             ecqe->vendor_err_synd, ecqe->hw_synd_type >> 4, ecqe->hw_err_synd,
             uct_ib_qp_type_str(iface->config.qp_type), qp_num, pi, wqe_info,
             peer_info);


### PR DESCRIPTION
Porting #7724 to v1.12.x

## What
Choose PKEY index 0 for RoCE devices.

## Why ?
RoCE devices have `0xffff` PKEY set for index `0`.
Other indices are invalid.

## How ?
When initializing PKEY, check for RoCE and select PKEY index `0` and PKEY value `0xffff` if the device is RoCE.