### PR TITLE
GTEST/UCP: Reduce testing time of invalidation test under Valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2917,14 +2917,18 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
            tag_rndv_killed_sender_multiple_sends, "RNDV_THRESH=0",
            "RNDV_SCHEME=get_zcopy")
 {
-    do_tag_rndv_killed_sender_test(1, 128, 100000);
+    size_t num_sends = ucs_max(100, 100000 / ucs::test_time_multiplier() /
+                                    ucs::test_time_multiplier());
+    do_tag_rndv_killed_sender_test(1, 128, num_sends);
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
            tag_rndv_killed_sender_4_extra_senders_multiple_sends,
            "RNDV_THRESH=0", "RNDV_SCHEME=get_zcopy")
 {
-    do_tag_rndv_killed_sender_test(4, 128, 100000);
+    size_t num_sends = ucs_max(100, 100000 / ucs::test_time_multiplier() /
+                                    ucs::test_time_multiplier());
+    do_tag_rndv_killed_sender_test(4, 128, num_sends);
 }
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err_sender)


### PR DESCRIPTION
## What

Reduce testing time of invalidation test under Valgrind.

## Why ?

Fixes #7729 - It takes too much time for testing and the job was canceled.
Reduces testing time of some memory invalidation tests in `test_ucp_sockaddr_protocols_err_sender` test suite:
- before (376.7 seconds):
```
[ RUN      ] tcp/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_4_extra_senders_multiple_sends/0 <tcp,cuda_copy,rocm_copy/mt>
[     INFO ] server listening on 1.1.31.1:43814
[     INFO ] ignoring error Endpoint timeout on endpoint 0xc622000
[       OK ] tcp/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_4_extra_senders_multiple_sends/0 (376679 ms)
[----------] 1 test from tcp/test_ucp_sockaddr_protocols_err_sender (376699 ms total)
```
- after (3.1 seconds):
```
[ RUN      ] tcp/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_4_extra_senders_multiple_sends/0 <tcp,cuda_copy,rocm_copy/mt>
[     INFO ] server listening on 127.0.0.1:54716
[     INFO ] ignoring error Endpoint timeout on endpoint 0xc622000
[       OK ] tcp/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_4_extra_senders_multiple_sends/0 (3127 ms)
[----------] 1 test from tcp/test_ucp_sockaddr_protocols_err_sender (3136 ms total)
```

## How ?

1. By adjusting the number of sends done per each connection using `ucs::test_time_multiplier()`.
2. Also, set the minimum of the send operations done - 100.