### PR TITLE
UCS/FUSE/BUILD: better fit build standards

### DIFF
--- a/config/m4/fuse3.m4
+++ b/config/m4/fuse3.m4
@@ -30,42 +30,40 @@ AS_IF([test "x$with_fuse3" != "xno" -o "x$with_fuse3_static" != "xno"],
               ucx_fuse3_pkgconfig="$with_fuse3/lib$libsuff/pkgconfig"
               export PKG_CONFIG_PATH="$ucx_fuse3_pkgconfig:$PKG_CONFIG_PATH"])
 
-       FUSE3_CPPFLAGS=$(pkg-config --cflags-only-I fuse3)
-       FUSE3_LDFLAGS=$(pkg-config --libs-only-L fuse3)
        AS_IF([test "x$with_fuse3_static" != "xno"],
-             [FUSE3_LIBS=$(pkg-config --libs-only-l --static fuse3)
-              FUSE3_LIBS=${FUSE3_LIBS//"-lfuse3"/"-l:libfuse3.a"}],
-             [FUSE3_LIBS=$(pkg-config --libs-only-l fuse3)])
+             [PKG_CHECK_MODULES_STATIC([FUSE3], [fuse3],
+                                       [fuse3_happy="yes"], [fuse3_happy="no"])])
 
-       save_CPPFLAGS="$CPPFLAGS"
-       save_LDFLAGS="$LDFLAGS"
+       AS_IF([test "x$fuse3_happy" = "xyes"],
+             [FUSE3_LIBS=${FUSE3_LIBS//"-lfuse3"/"-Wl,-Bstatic,-lfuse3,-Bdynamic"}],
+             [PKG_CHECK_MODULES([FUSE3], [fuse3],
+                                [fuse3_happy="yes"], [fuse3_happy="no"])])
+
+       save_CFLAGS="$CFLAGS"
        save_LIBS="$LIBS"
 
-       CPPFLAGS="$FUSE3_CPPFLAGS $CPPFLAGS"
-       LDFLAGS="$FUSE3_LDFLAGS $LDFLAGS"
+       CFLAGS="$FUSE3_CFLAGS $CFLAGS"
        LIBS="$FUSE3_LIBS $LIBS"
 
-       fuse3_happy="yes"
-       AC_CHECK_DECLS([fuse_open_channel, fuse_mount, fuse_unmount],
-                      [AC_SUBST([FUSE3_CPPFLAGS], [$FUSE3_CPPFLAGS])
-                       AC_DEFINE([FUSE_USE_VERSION], 30, [Fuse API version])],
-                      [fuse3_happy="no"],
-                      [[#define FUSE_USE_VERSION 30
-                        #include <fuse.h>]])
+       AS_IF([test "x$fuse3_happy" = "xyes"],
+             [AC_CHECK_DECLS([fuse_open_channel, fuse_mount, fuse_unmount],
+                             [AC_SUBST([FUSE3_CFLAGS], [$FUSE3_CFLAGS])
+                              AC_DEFINE([FUSE_USE_VERSION], 30, [Fuse API version])],
+                             [fuse3_happy="no"],
+                             [[#define FUSE_USE_VERSION 30
+                               #include <fuse.h>]])])
 
        AS_IF([test "x$fuse3_happy" = "xyes"],
              [AC_CHECK_FUNCS([fuse_open_channel fuse_mount fuse_unmount],
-                             [AC_SUBST([FUSE3_LIBS], ["$FUSE3_LIBS"])
-                              AC_SUBST([FUSE3_LDFLAGS], [$FUSE3_LDFLAGS])],
+                             [AC_SUBST([FUSE3_LIBS], ["$FUSE3_LIBS"])],
                              [fuse3_happy="no"])])
 
        AS_IF([test "x$fuse3_happy" != "xyes" -a "x$with_fuse3" != "xguess"],
              [AC_MSG_ERROR([FUSEv3 requested but could not be found])])
 
-       CPPFLAGS="$save_CPPFLAGS"
-       LDFLAGS="$save_LDFLAGS"
+       CFLAGS="$save_CFLAGS"
        LIBS="$save_LIBS"
-       PKG_CONFIG_PATH="$save_PKG_CONFIG_PATH"
+       export PKG_CONFIG_PATH="$save_PKG_CONFIG_PATH"
     ],
     [AC_MSG_WARN([FUSEv3 was explicitly disabled])]
 )

--- a/config/m4/pkg.m4
+++ b/config/m4/pkg.m4
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2021, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([PKG_CHECK_MODULES_STATIC],
+         [AC_REQUIRE([PKG_PROG_PKG_CONFIG])
+          save_PKG_CONFIG=$PKG_CONFIG
+          PKG_CONFIG="$PKG_CONFIG --static"
+          PKG_CHECK_MODULES([$1], [$2], [$3], [$4])
+          PKG_CONFIG=$save_PKG_CONFIG
+         ])

--- a/src/tools/vfs/Makefile.am
+++ b/src/tools/vfs/Makefile.am
@@ -7,12 +7,11 @@
 if HAVE_FUSE3
 
 bin_PROGRAMS     = ucx_vfs
-ucx_vfs_CPPFLAGS = $(BASE_CPPFLAGS) $(FUSE3_CPPFLAGS)
-ucx_vfs_LDFLAGS  = $(FUSE3_LDFLAGS)
-ucx_vfs_CFLAGS   = $(BASE_CFLAGS)
+ucx_vfs_CPPFLAGS = $(BASE_CPPFLAGS)
+ucx_vfs_CFLAGS   = $(BASE_CFLAGS) $(FUSE3_CFLAGS)
 ucx_vfs_SOURCES  = vfs_main.c vfs_server.c
 noinst_HEADERS   = vfs_daemon.h
-ucx_vfs_LDADD    = $(FUSE3_LIBS) \
-                   $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la
+ucx_vfs_LDADD    = $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la \
+                   $(FUSE3_LIBS)
 
 endif

--- a/src/ucs/vfs/fuse/Makefile.am
+++ b/src/ucs/vfs/fuse/Makefile.am
@@ -7,12 +7,11 @@
 if HAVE_FUSE3
 
 module_LTLIBRARIES      = libucs_fuse.la
-libucs_fuse_la_CPPFLAGS = $(BASE_CPPFLAGS) $(FUSE3_CPPFLAGS)
-libucs_fuse_la_CFLAGS   = $(BASE_CFLAGS)
-libucs_fuse_la_LIBADD   = $(FUSE3_LIBS) \
-                          $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la \
+libucs_fuse_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libucs_fuse_la_CFLAGS   = $(BASE_CFLAGS) $(FUSE3_CFLAGS)
+libucs_fuse_la_LIBADD   = $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la \
                           $(top_builddir)/src/ucs/libucs.la
-libucs_fuse_la_LDFLAGS  = $(FUSE3_LDFLAGS) -version-info $(SOVERSION)
+libucs_fuse_la_LDFLAGS  = $(FUSE3_LIBS) -version-info $(SOVERSION)
 libucs_fuse_la_SOURCES  = vfs_fuse.c
 include $(top_srcdir)/config/module.am
 

--- a/src/ucs/vfs/sock/Makefile.am
+++ b/src/ucs/vfs/sock/Makefile.am
@@ -8,4 +8,3 @@ noinst_LTLIBRARIES          = libucs_vfs_sock.la
 libucs_vfs_sock_la_SOURCES  = vfs_sock.c
 noinst_HEADERS              = vfs_sock.h
 libucs_vfs_sock_la_CPPFLAGS = $(BASE_CPPFLAGS)
-libucs_vfs_sock_la_LDFLAGS  = $(BASE_LDFLAGS)


### PR DESCRIPTION
- added usage of PKG_CHECK_MODULES macro to identify fuse installed
- added PKG_CHECK_MODULES_STATIC macro
- updated build flags to fit PKG_CHECK_MODULES macro
