### PR TITLE
PPC/UCS: removed extra check for __ppc_get_timebase_freq

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -102,27 +102,10 @@ AC_CHECK_HEADERS([sys/platform/ppc.h])
 
 
 #
-# PowerPC query for getting TB frequency
+# PowerPC query for getting TB and frequency
 #
-AC_CHECK_DECL([__ppc_get_timebase_freq],
-              [AC_CHECK_FUNCS([__ppc_get_timebase_freq])], [],
-              [#include <sys/platform/ppc.h>])
-
-
-#
-# PowerPC query for getting TB.
-# Note: AC_CHECK_FUNCS doesn't work for checking __ppc_get_timebase()
-#
-AC_LINK_IFELSE([AC_LANG_SOURCE([[
-                #include <sys/platform/ppc.h>
-                int main(int argc, char** argv) {
-                    __ppc_get_timebase();
-                    return 0;
-                } ]])],
-                [AC_MSG_RESULT([no])
-                 AC_DEFINE([HAVE___PPC_GET_TIMEBASE], [1],
-                           [__ppc_get_timebase is defined in ppc.h])],
-                [AC_MSG_RESULT([no])])
+AC_CHECK_DECLS([__ppc_get_timebase_freq, __ppc_get_timebase], [], [],
+               [[#include <sys/platform/ppc.h>]])
 
 
 #

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -41,7 +41,7 @@ BEGIN_C_DECLS
 
 static inline uint64_t ucs_arch_read_hres_clock()
 {
-#ifdef HAVE___PPC_GET_TIMEBASE
+#if HAVE_DECL___PPC_GET_TIMEBASE
     return __ppc_get_timebase();
 #else
     uint64_t tb;

--- a/src/ucs/arch/ppc64/timebase.c
+++ b/src/ucs/arch/ppc64/timebase.c
@@ -19,7 +19,7 @@
 
 double ucs_arch_get_clocks_per_sec()
 {
-#ifdef HAVE___PPC_GET_TIMEBASE_FREQ
+#if HAVE_DECL___PPC_GET_TIMEBASE_FREQ
     return __ppc_get_timebase_freq();
 #else
     return ucs_get_cpuinfo_clock_freq("timebase", 1.0);


### PR DESCRIPTION
- removed double check for __ppc_get_timebase_freq function
