### PR TITLE
UCP/CORE: Fix memory cache lookup return value handling

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -497,25 +497,19 @@ ucp_memory_detect_internal(ucp_context_h context, const void *address,
     }
 
     status = ucs_memtype_cache_lookup(address, length, mem_info);
-    if (status != UCS_ERR_NO_ELEM) {
-        if (ucs_likely(status != UCS_OK)) {
-            ucs_assert(status == UCS_ERR_NO_ELEM);
-            goto out_host_mem;
-        }
-
-        if ((mem_info->type != UCS_MEMORY_TYPE_UNKNOWN) &&
-            ((mem_info->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN))) {
-            return;
-        }
-
-        /* Fall thru to slow-path memory type and system device detection by UCT
-         * memory domains. In any case, the memory type cache is not expected to
-         * return HOST memory type.
-         */
-        ucs_assert(mem_info->type != UCS_MEMORY_TYPE_HOST);
+    if (ucs_likely(status == UCS_ERR_NO_ELEM)) {
+        goto out_host_mem;
+    } else if ((status == UCS_ERR_UNSUPPORTED) ||
+               ((status == UCS_OK) &&
+                ((mem_info->type == UCS_MEMORY_TYPE_UNKNOWN) ||
+                 (mem_info->sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN)))) {
+        ucp_memory_detect_slowpath(context, address, length, mem_info);
+    } else {
+        ucs_assertv(status == UCS_OK, "%s (%d)", ucs_status_string(status),
+                    status);
     }
 
-    ucp_memory_detect_slowpath(context, address, length, mem_info);
+    /* Memory type and system device was detected successfully */
     return;
 
 out_host_mem:

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -325,7 +325,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
     ucs_status_t status;
 
     if (memtype_cache == NULL) {
-        return UCS_ERR_NO_ELEM;
+        return UCS_ERR_UNSUPPORTED;
     }
 
     pthread_rwlock_rdlock(&memtype_cache->lock);
@@ -344,6 +344,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
         ucs_memory_info_set_unknown(mem_info);
     }
     status = UCS_OK;
+
+    /* The memory type cache is not expected to return HOST memory type */
+    ucs_assertv(mem_info->type != UCS_MEMORY_TYPE_HOST, "%s (%d)",
+                ucs_memory_type_names[mem_info->type], mem_info->type);
 
 out_unlock:
     pthread_rwlock_unlock(&memtype_cache->lock);

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -60,7 +60,9 @@ struct ucs_memtype_cache {
  *                              means the memory type is an unknown non-host
  *                              memory, and should be detected in another way.
  *
- * @return Error code.
+ * @return UCS_OK              - an element was found and the memory info is valid.
+ * @return UCS_ERR_NO_ELEM     - an element was not found.
+ * @return UCS_ERR_UNSUPPORTED - the memory type cache is disabled.
  */
 ucs_status_t ucs_memtype_cache_lookup(const void *address, size_t size,
                                       ucs_memory_info_t *mem_info);

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -81,8 +81,12 @@ uct_cuda_copy_get_mem_type(uct_md_h md, void *address, size_t length)
     ucs_status_t status;
 
     status = ucs_memtype_cache_lookup(address, length, &mem_info);
-    if ((status == UCS_ERR_NO_ELEM) ||
-        ((mem_info.type == UCS_MEMORY_TYPE_UNKNOWN))) {
+    if (status == UCS_ERR_NO_ELEM) {
+        return UCS_MEMORY_TYPE_HOST;
+    }
+
+    if ((status == UCS_ERR_UNSUPPORTED) ||
+        (mem_info.type == UCS_MEMORY_TYPE_UNKNOWN)) {
         status = uct_cuda_base_detect_memory_type(md, address, length,
                                                   &mem_info.type);
         if (status != UCS_OK) {


### PR DESCRIPTION
## What

Fix memory cache lookup return value handling.

## Why ?

The return value could be either `UCS_OK` or `UCS_ERR_NO_ELEM`.

## How ?

1. Re-organize the code of branches.
2. Add useful assertions.
3. Remove incorrect assertion.
4. Remove extra brackets around a condition.