### PR TITLE
UCP/UCS/MEMORY/GTEST: Assign address and length if the memory was considered as HOST

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -425,6 +425,11 @@ const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
 void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
                                 size_t length, ucs_memory_info_t *mem_info);
 
+void ucp_context_get_reg_memory(ucp_context_h context, void *address,
+                                size_t length, void **reg_address_p,
+                                size_t *reg_length_p,
+                                ucs_memory_type_t mem_type);
+
 /**
  * Calculate a small value to overcome float imprecision
  * between two float values
@@ -520,7 +525,7 @@ ucp_memory_detect_internal(ucp_context_h context, const void *address,
 
 out_host_mem:
     /* Memory type cache lookup failed - assume it is host memory */
-    ucs_memory_info_set_host(mem_info);
+    ucs_memory_info_set(mem_info, UCS_MEMORY_TYPE_HOST, address, length);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -63,7 +63,6 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_datatype_iter_mem_reg_internal,
 {
     uct_mem_h tmp_reg[UCP_MAX_OP_MDS] = {UCT_MEM_HANDLE_NULL}; /* cppcheck */
     ucp_md_index_t md_index, memh_index, memh_index_old;
-    ucs_memory_info_t mem_info;
     ucs_log_level_t log_level;
     ucs_status_t status;
     void *reg_address;
@@ -84,16 +83,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_datatype_iter_mem_reg_internal,
         goto out;
     }
 
-    ucs_assert(address != NULL);
-    if (ucs_unlikely(context->config.ext.reg_whole_alloc_bitmap &
-                     UCS_BIT(mem_type))) {
-        ucp_memory_detect_internal(context, address, length, &mem_info);
-        reg_address = mem_info.base_address;
-        reg_length  = mem_info.alloc_length;
-    } else {
-        reg_address = address;
-        reg_length  = length;
-    }
+    ucp_context_get_reg_memory(context, address, length, &reg_address,
+                               &reg_length, mem_type);
 
     memh_index_old = 0;
     memh_index     = 0;

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -70,21 +70,14 @@ static UCS_F_ALWAYS_INLINE ucs_memtype_cache_t *ucs_memtype_cache_get_global()
     return ucs_memtype_cache_global_instance;
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucs_memory_info_set_unknown(ucs_memory_info_t *mem_info)
+void ucs_memory_info_set(ucs_memory_info_t *mem_info,
+                         ucs_memory_type_t mem_type, const void *address,
+                         size_t length)
 {
-    mem_info->type         = UCS_MEMORY_TYPE_UNKNOWN;
+    mem_info->type         = mem_type;
     mem_info->sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-    mem_info->base_address = NULL;
-    mem_info->alloc_length = -1;
-}
-
-void ucs_memory_info_set_host(ucs_memory_info_t *mem_info)
-{
-    mem_info->type         = UCS_MEMORY_TYPE_HOST;
-    mem_info->sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-    mem_info->base_address = NULL;
-    mem_info->alloc_length = -1;
+    mem_info->base_address = (void*)address;
+    mem_info->alloc_length = length;
 }
 
 static ucs_pgt_dir_t *ucs_memtype_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
@@ -271,7 +264,7 @@ void ucs_memtype_cache_remove(const void *address, size_t size)
 {
     ucs_memory_info_t mem_info;
 
-    ucs_memory_info_set_unknown(&mem_info);
+    ucs_memory_info_set(&mem_info, UCS_MEMORY_TYPE_UNKNOWN, NULL, SIZE_MAX);
     ucs_memtype_cache_update_internal(ucs_memtype_cache_global_instance,
                                       address, size, &mem_info,
                                       UCS_MEMTYPE_CACHE_ACTION_REMOVE);
@@ -341,7 +334,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucs_memtype_cache_lookup,
         region    = ucs_derived_of(pgt_region, ucs_memtype_cache_region_t);
         *mem_info = region->mem_info;
     } else {
-        ucs_memory_info_set_unknown(mem_info);
+        ucs_memory_info_set(mem_info, UCS_MEMORY_TYPE_UNKNOWN, address, size);
     }
     status = UCS_OK;
 

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -93,8 +93,13 @@ void ucs_memtype_cache_remove(const void *address, size_t size);
  * Helper function to set memory info structure to host memory type.
  *
  * @param [out] mem_info        Pointer to memory info structure.
+ * @param [in]  mem_type        Memory type.
+ * @param [in]  address         Address of the buffer.
+ * @param [in]  length          Size of the buffer.
  */
-void ucs_memory_info_set_host(ucs_memory_info_t *mem_info);
+void ucs_memory_info_set(ucs_memory_info_t *mem_info,
+                         ucs_memory_type_t mem_type, const void *address,
+                         size_t length);
 
 
 /**


### PR DESCRIPTION
## What

1. Assign address and length if the memory was considered as HOST.
2. Don't use the result of memory type detection if it is not the same as memory_type got from a user.
3. Write the test which reproduces the issue.

## Why ?

This is to allow users to use `UCX_TLS=ib` and GPUDirectRDMA capability without specifying any MDs (e.g. CUDA/ROCm) which are able to detect memory type.

## How ?

1. Update `ucs_memory_info_set_host`/`ucs_memory_info_set_unknown` to set address/length which is passed by user.
2. Introduce `ucp_context_get_reg_memory` function which check the result `ucp_memory_detect_internal` and if the memory types are not the same don't use its result.
3. Run `test_ucp_mmap` test without GPU awareness to catch possible errors when CUDA/ROCm memory buffers are registered. It reproduces the original issue that is going to be fixed by "1" and "2".