### PR TITLE
TOOLS/PERF: use cudaFree to set context and avoid cuda perftest failures

### DIFF
--- a/src/tools/perf/cuda/cuda_alloc.c
+++ b/src/tools/perf/cuda/cuda_alloc.c
@@ -36,6 +36,10 @@ static ucs_status_t ucx_perf_cuda_init(ucx_perf_context_t *perf)
         return UCS_ERR_NO_DEVICE;
     }
 
+    /* actually set device context as calling cudaSetDevice may result in
+     * context being initialized lazily */
+    cudaFree(0);
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What

Similar to https://github.com/openucx/ucx/pull/7679/files#diff-b1631cb616b57b17879df7eac53787b13fabb97c13f98e08f6ede217ad701371R124. Without this `ucx_perftest` with `-m cuda` were failing as perf allocator calls failed.
