### PR TITLE
GTEST/UCS: Fix memtype cache testing

### DIFF
--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -22,6 +22,8 @@ protected:
 
     virtual void init() {
         ucs::test_with_param<ucs_memory_type_t>::init();
+        // Trigger on-demand create of the global memtype cache instance
+        test_lookup_notfound(NULL, ucs_get_page_size());
     }
 
     virtual void cleanup() {


### PR DESCRIPTION
## What

Fix memtype cache testing.

## Why ?

Fixes #7745.

## How ?

Update `init()` function of `test_memtype_cache` test suite to allocate `mem_buffer` on HOST and call `test_lookup_notfound()` to allocate global memory cache for further successful adding elements.