### PR TITLE
UCT/IB/DC: Restore FC window size in case of error was detected

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -49,6 +49,7 @@ struct ibv_ravh {
 
 #define UCT_DC_MLX5_IFACE_TXQP_DCI_GET(_iface, _dci, _txqp, _txwq) \
     { \
+        ucs_assert(_dci != UCT_DC_MLX5_EP_NO_DCI); \
         _txqp = &(_iface)->tx.dcis[_dci].txqp; \
         _txwq = &(_iface)->tx.dcis[_dci].txwq; \
     }

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -404,6 +404,8 @@ uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
     ucs_arbiter_t *waitq;
     uint8_t pool_index;
 
+    ucs_assert(dci_index != UCT_DC_MLX5_EP_NO_DCI);
+
     if (uct_dc_mlx5_iface_is_dci_rand(iface) ||
         uct_dc_mlx5_iface_is_dci_keepalive(iface, dci_index)) {
         return;

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -259,6 +259,7 @@ uct_rc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     }
 
     ep->super.flags |= UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED;
+    uct_rc_fc_restore_wnd(iface, &ep->super.fc);
 
     status  = uct_iface_handle_ep_err(&iface->super.super.super,
                                       &ep->super.super.super, ep_status);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -327,6 +327,13 @@ int uct_rc_fc_has_resources(uct_rc_iface_t *iface, uct_rc_fc_t *fc)
     return (fc->fc_wnd > 0) || !iface->config.fc_enabled;
 }
 
+static UCS_F_ALWAYS_INLINE void uct_rc_fc_restore_wnd(uct_rc_iface_t *iface,
+                                                      uct_rc_fc_t *fc)
+{
+    fc->fc_wnd = iface->config.fc_wnd_size;
+    UCS_STATS_SET_COUNTER(fc->stats, UCT_RC_FC_STAT_FC_WND, fc->fc_wnd);
+}
+
 static UCS_F_ALWAYS_INLINE int uct_rc_ep_has_tx_resources(uct_rc_ep_t *ep)
 {
     uct_rc_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_rc_iface_t);

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -374,8 +374,7 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
         cur_wnd = ep->fc.fc_wnd;
 
         /* Peer granted resources, so update wnd */
-        ep->fc.fc_wnd = iface->config.fc_wnd_size;
-        UCS_STATS_SET_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_FC_WND, ep->fc.fc_wnd);
+        uct_rc_fc_restore_wnd(iface, &ep->fc);
 
         /* To preserve ordering we have to dispatch all pending
          * operations if current fc_wnd is <= 0

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -106,6 +106,7 @@ static void uct_rc_verbs_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     }
 
     ep->super.flags |= UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED;
+    uct_rc_fc_restore_wnd(iface, &ep->super.fc);
 
     status  = uct_iface_handle_ep_err(&iface->super.super.super,
                                       &ep->super.super.super, ep_status);


### PR DESCRIPTION
## What

Restore FC window size in case of error was detected.

## Why ?

To allow rescheduling DCI allocation for failed EP to do some pending operations (e.g. UCT EP flush(CANCEL)).

## How ?

1. Introduce `UCT_RC_RESTORE_FC_WND` to use it for restoring RC/DC FC window size.
2. Use `UCT_RC_RESTORE_FC_WND` to restore the window in case of error happened on DC.
3. Do `uct_dc_mlx5_iface_set_ep_failed` before `uct_dc_mlx5_iface_dci_put` to ensure restoring FC window.