### PR TITLE
UCT/IB/RC/STATS: Update FC to not allocate statistics if FC is disabled

### DIFF
--- a/src/ucs/stats/stats.h
+++ b/src/ucs/stats/stats.h
@@ -102,6 +102,9 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 #define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) \
     ucs_stats_node_alloc(_p_node, _class, _parent, ## __VA_ARGS__)
 
+#define UCS_STATS_NODE_RESET(_p_node) \
+    *(_p_node) = NULL
+
 #define UCS_STATS_NODE_FREE(_node) \
     ucs_stats_node_free(_node)
 
@@ -153,6 +156,7 @@ void ucs_stats_node_free(ucs_stats_node_t *node);
 #define UCS_STATS_NODE_DECLARE(_node)
 #define UCS_STATS_NODE_ALLOC(_p_node, _class, _parent, ...) \
         ucs_empty_function_return_success()
+#define UCS_STATS_NODE_RESET(_p_node)
 #define UCS_STATS_NODE_FREE(_node)
 #define UCS_STATS_UPDATE_COUNTER(_node, _index, _delta)
 #define UCS_STATS_SET_COUNTER(_node, _index, _value)

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -254,7 +254,7 @@ uct_dc_mlx5_ep_am_short_inline(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                                  uct_ib_mlx5_wqe_av_size(&ep->av),
                                  MLX5_WQE_CTRL_SOLICITED, INT_MAX);
 
-    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
+    UCT_RC_UPDATE_FC_WND(&ep->fc);
     UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, sizeof(hdr) + length);
     return UCS_OK;
 }
@@ -276,7 +276,7 @@ static ucs_status_t UCS_F_ALWAYS_INLINE uct_dc_mlx5_ep_am_short_iov_inline(
                                      iov, iovcnt, iov_length, id, &ep->av,
                                      uct_dc_mlx5_ep_get_grh(ep),
                                      uct_ib_mlx5_wqe_av_size(&ep->av));
-    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
+    UCT_RC_UPDATE_FC_WND(&ep->fc);
     UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, iov_length);
 
     return UCS_OK;
@@ -319,7 +319,7 @@ ucs_status_t uct_dc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
         return status;
     }
     UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, sizeof(cache.am_hdr) + length);
-    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
+    UCT_RC_UPDATE_FC_WND(&ep->fc);
     return UCS_OK;
 #endif
 }
@@ -356,7 +356,7 @@ ucs_status_t uct_dc_mlx5_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
         return status;
     }
 
-    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
+    UCT_RC_UPDATE_FC_WND(&ep->fc);
 
     return UCS_OK;
 #endif
@@ -381,7 +381,7 @@ ssize_t uct_dc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
                                  sizeof(uct_rc_mlx5_hdr_t) + length, 0, 0, desc,
                                  MLX5_WQE_CTRL_SOLICITED, 0, desc + 1, NULL);
 
-    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
+    UCT_RC_UPDATE_FC_WND(&ep->fc);
     UCT_TL_EP_STAT_OP(&ep->super, AM, BCOPY, length);
     return length;
 }
@@ -406,7 +406,7 @@ ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
                                  uct_rc_ep_send_op_completion_handler, 0,
                                  comp, MLX5_WQE_CTRL_SOLICITED);
 
-    UCT_RC_UPDATE_FC_WND(&iface->super.super, &ep->fc);
+    UCT_RC_UPDATE_FC_WND(&ep->fc);
     UCT_TL_EP_STAT_OP(&ep->super, AM, ZCOPY, header_length +
                       uct_iov_total_length(iov, iovcnt));
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -294,7 +294,7 @@ uct_dc_mlx5_ep_basic_init(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
         ep->dci = UCT_DC_MLX5_EP_NO_DCI;
     }
 
-    return uct_rc_fc_init(&ep->fc, iface->super.super.config.fc_wnd_size
+    return uct_rc_fc_init(&ep->fc, &iface->super.super
                           UCS_STATS_ARG(ep->super.stats));
 }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -96,7 +96,7 @@ uct_rc_mlx5_ep_am_short_inline(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                                  MLX5_WQE_CTRL_SOLICITED,
                                  INT_MAX);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(hdr) + length);
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
     return UCS_OK;
 }
 
@@ -111,7 +111,7 @@ static ucs_status_t UCS_F_ALWAYS_INLINE uct_rc_mlx5_ep_am_short_iov_inline(
                                      &ep->tx.wq, iov, iovcnt, iov_length, id,
                                      NULL, NULL, 0);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, iov_length);
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return UCS_OK;
 }
@@ -258,7 +258,6 @@ uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
 {
 #if HAVE_IBV_DM
     UCT_RC_MLX5_EP_DECL(tl_ep, iface, ep);
-    uct_rc_iface_t *rc_iface = &iface->super;
     ucs_status_t status;
     uct_rc_mlx5_dm_copy_data_t cache;
 
@@ -286,7 +285,7 @@ uct_rc_mlx5_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
     }
 
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(cache.am_hdr) + length);
-    UCT_RC_UPDATE_FC(rc_iface, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
     return UCS_OK;
 #endif
 }
@@ -319,7 +318,7 @@ ucs_status_t uct_rc_mlx5_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
         return status;
     }
 
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return UCS_OK;
 #endif
@@ -345,7 +344,7 @@ ssize_t uct_rc_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
                                        NULL, NULL, 0, MLX5_WQE_CTRL_SOLICITED,
                                        0, desc, desc + 1, NULL);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, length);
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return length;
 }
@@ -372,7 +371,7 @@ ucs_status_t uct_rc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
     if (ucs_likely(status >= 0)) {
         UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY,
                           header_length + uct_iov_total_length(iov, iovcnt));
-        UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+        UCT_RC_UPDATE_FC(&ep->super, id);
     }
     return status;
 }

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -148,15 +148,12 @@ enum {
     } \
 
 
-#define UCT_RC_UPDATE_FC_WND(_iface, _fc) \
+#define UCT_RC_UPDATE_FC_WND(_fc) \
     { \
         /* For performance reasons, prefer to update fc_wnd unconditionally */ \
         (_fc)->fc_wnd--; \
-        \
-        if ((_iface)->config.fc_enabled) { \
-            UCS_STATS_SET_COUNTER((_fc)->stats, UCT_RC_FC_STAT_FC_WND, \
-                                  (_fc)->fc_wnd); \
-        } \
+        UCS_STATS_SET_COUNTER((_fc)->stats, UCT_RC_FC_STAT_FC_WND, \
+                              (_fc)->fc_wnd); \
     }
 
 #define UCT_RC_CHECK_FC(_iface, _ep, _am_id) \
@@ -173,7 +170,7 @@ enum {
         (_am_id) |= uct_rc_fc_get_fc_hdr((_ep)->flags); /* take grant bit */ \
     }
 
-#define UCT_RC_UPDATE_FC(_iface, _ep, _fc_hdr) \
+#define UCT_RC_UPDATE_FC(_ep, _fc_hdr) \
     { \
         if ((_fc_hdr) & UCT_RC_EP_FLAG_FC_GRANT) { \
             UCS_STATS_UPDATE_COUNTER((_ep)->fc.stats, UCT_RC_FC_STAT_TX_GRANT, 1); \
@@ -186,7 +183,7 @@ enum {
         \
         (_ep)->flags &= ~UCT_RC_EP_FC_MASK; \
         \
-        UCT_RC_UPDATE_FC_WND(_iface, &(_ep)->fc) \
+        UCT_RC_UPDATE_FC_WND(&(_ep)->fc) \
     }
 
 #define UCT_RC_CHECK_RES_AND_FC(_iface, _ep, _am_id) \
@@ -263,7 +260,7 @@ ucs_arbiter_cb_result_t uct_rc_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
 void uct_rc_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
                              void*arg);
 
-ucs_status_t uct_rc_fc_init(uct_rc_fc_t *fc, int16_t winsize
+ucs_status_t uct_rc_fc_init(uct_rc_fc_t *fc, uct_rc_iface_t *iface
                             UCS_STATS_ARG(ucs_stats_node_t* stats_parent));
 void uct_rc_fc_cleanup(uct_rc_fc_t *fc);
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -272,7 +272,7 @@ ucs_status_t uct_rc_verbs_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, sizeof(hdr) + length);
     uct_rc_verbs_ep_post_send(iface, ep, &iface->inl_am_wr,
                               IBV_SEND_INLINE | IBV_SEND_SOLICITED, INT_MAX);
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return UCS_OK;
 }
@@ -291,7 +291,7 @@ ucs_status_t uct_rc_verbs_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, SHORT, uct_iov_total_length(iov, iovcnt));
     uct_rc_verbs_ep_post_send(iface, ep, &iface->inl_am_wr,
                               IBV_SEND_INLINE | IBV_SEND_SOLICITED, INT_MAX);
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return UCS_OK;
 }
@@ -317,7 +317,7 @@ ssize_t uct_rc_verbs_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
                                   wr.opcode);
     UCT_TL_EP_STAT_OP(&ep->super.super, AM, BCOPY, length);
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, IBV_SEND_SOLICITED, INT_MAX);
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return length;
 }
@@ -354,7 +354,7 @@ ucs_status_t uct_rc_verbs_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *he
 
     uct_rc_verbs_ep_post_send_desc(ep, &wr, desc, send_flags | IBV_SEND_SOLICITED,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
-    UCT_RC_UPDATE_FC(&iface->super, &ep->super, id);
+    UCT_RC_UPDATE_FC(&ep->super, id);
 
     return UCS_INPROGRESS;
 }


### PR DESCRIPTION
## What

Update FC to not allocate statistics if FC is disabled.

## Why ?

1. Don't allocate unnecessary memory for statistics.
2. Remove `if` from `UCT_RC_UPDATE_FC_WND` macro.

## How ?

1. Introduce some helpful macro in `UCS_STATS_NODE_*` to use them for manipulation with FC statistic node.
2. Remove `iface` parameter from `UCT_RC_UPDATE_FC_WND` and `UCT_RC_UPDATE_FC` macros.