### PR TITLE
UCT/IB/RC/DC: Don't check FC resources in case of flush(CANCEL)

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -595,6 +595,9 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
         if (status != UCS_OK) {
             return status;
         }
+
+        uct_ib_mlx5_txwq_update_flags(&ep->tx.wq, UCT_IB_MLX5_TXWQ_FLAG_FAILED,
+                                      0);
     }
 
     return uct_rc_txqp_add_flush_comp(&iface->super, &ep->super.super,


### PR DESCRIPTION
## What

Don't check FC resources in case of `flush(CANCEL)`.

## Why ?

It aligns DC's `flush(CANCEL)` with RC's one.
If `flush(CANCEL)` was issued when no error detected by the transport, but FC window is exhausted, `flush(CANCEL)` may be completed with `UCS_ERR_NO_RESOURCE` forever, since peer doesn't update our resources.

## How ?

1. Update `uct_dc_mlx5_iface_dci_ep_can_send` to accept `flush_cancel` boolean value.
2. Use `flush_cancel` boolean value to check whether we need to verify FC window or not.