### PR TITLE
DOCS: Add C++11 usage for tests

### DIFF
--- a/docs/CodeStyle.md
+++ b/docs/CodeStyle.md
@@ -2,26 +2,26 @@
 
 ## Style
   * 4 spaces, no tabs
-  * up to 80 columns
-  * single space around operators
-  * no spaces in the end-of-line
-  * indent function arguments on column
-  * indent structure fields on column
-  * scope: open on same line, except function body, which is on a new line.
-  * indent multiple consecutive assignments on the column
+  * Up to 80 columns
+  * Single space around operators
+  * No spaces in the end-of-line
+  * Indent function arguments on column
+  * Indent structure fields on column
+  * Scope: open on same line, except function body, which is on a new line.
+  * Indent multiple consecutive assignments on the column
   * 2 space lines between types and prototypes (header files)
   * 1 space line between functions (source files) 
 
 
 ## Naming convention:
-  * lower case, underscores
-  * names must begin with ucp_/uct_/ucs_/ucm_
-  * macro names must begin with UCP_/UCT_/UCS_/UCM_
-  * an output argument which is a pointer to a user variable has _p suffix
-  * value types (e.g struct types, integer types) have _t suffix
-  * pointer to structs, which are used as API handles, have _h suffix
-  * macro arguments begin with _ (e.g _value) to avoid confusion with variables
-  * no leading underscores in function names
+  * Lower case, underscores
+  * Names must begin with ucp_/uct_/ucs_/ucm_
+  * Macro names must begin with UCP_/UCT_/UCS_/UCM_
+  * An output argument which is a pointer to a user variable has _p suffix
+  * Value types (e.g struct types, integer types) have _t suffix
+  * Pointer to structs, which are used as API handles, have _h suffix
+  * Macro arguments begin with _ (e.g _value) to avoid confusion with variables
+  * No leading underscores in function names
   * ### Header file name suffixes:
      * _fwd.h   for a files with a types/function forward declarations
      * _types.h if contains a type declarations
@@ -30,9 +30,9 @@
 
 
 ## C++
-  * used only for unit testing
-  * lower-case class names (same as stl/boost)
-  * the unit tests in test/gtest are written using [C++11](https://en.cppreference.com/w/cpp/11). Whenever applicable, the usage of advanced language features is allowed and preferred over legacy code. For example:
+  * Used only for unit testing
+  * Lower-case class names (same as stl/boost)
+  * The unit tests in test/gtest are written using [C++11](https://en.cppreference.com/w/cpp/11). Whenever applicable, the usage of advanced language features is allowed and preferred over legacy code. For example:
     * Prefer references over pointers
     * `auto` for type deduction 
     * Use [move semantics](https://www.cprogramming.com/c++11/rvalue-references-and-move-semantics-in-c++11.html) where applicable
@@ -50,23 +50,23 @@
 
 
 ## Doxygen
-  * all interface H/C files should have doxygen documentation.
+  * All interface H/C files should have doxygen documentation.
  
 
 ## Error handling
-  * all internal error codes must be ucs_status_t
-  * a function which returns error should print a log message
-  * the function which prints the log message is the first one which decides which
+  * All internal error codes must be ucs_status_t
+  * A function which returns error should print a log message
+  * The function which prints the log message is the first one which decides which
     error it is. If a functions returns an error because it's callee returned 
     erroneous ucs_status_t, it does not have to print a log message.
-  * destructors are not able to propagate error code to the caller because they
+  * Destructors are not able to propagate error code to the caller because they
     return void. also, users are not ready to handle errors during cleanup flow.
     therefore a destructor should handle an error by printing a warning or an
     error message.
 
 
 ## Testing
-  * every major feature or bugfix must be accompanied with a unit test. In case
+  * Every major feature or bugfix must be accompanied with a unit test. In case
     of a fix, the test should fail without the fix.
 
 

--- a/docs/CodeStyle.md
+++ b/docs/CodeStyle.md
@@ -32,6 +32,14 @@
 ## C++
   * used only for unit testing
   * lower-case class names (same as stl/boost)
+  * the unit tests in test/gtest are written using [C++11](https://en.cppreference.com/w/cpp/11). Whenever applicable, the usage of advanced language features is allowed and preferred over legacy code. For example:
+    * Prefer references over pointers
+    * `auto` for type deduction 
+    * Use [move semantics](https://www.cprogramming.com/c++11/rvalue-references-and-move-semantics-in-c++11.html) where applicable
+    * `constexpr` for compile-time values, instead of `const` or `#define`
+    * `using` [instead of](https://en.cppreference.com/w/cpp/language/type_alias) `typedef`
+    * [List initialization](https://en.cppreference.com/w/cpp/language/list_initialization)
+    * [Range-based](https://en.cppreference.com/w/cpp/language/range-for) `for` loop
  
 
 ## Include order:


### PR DESCRIPTION
## What
Add C++11 usage for google tests in the code style guide.

## Why ?
Improve the code by making use of advanced language features.