### PR TITLE
UCT/TCP/UD: Don't purge pending requests during flush(CANCEL)

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1106,7 +1106,6 @@ ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h, unsigned flags,
     uct_ud_enter(iface);
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
-        uct_ep_pending_purge(ep_h, NULL, 0);
         uct_ud_iface_dispatch_async_comps(iface, ep);
         uct_ud_ep_purge(ep, UCS_ERR_CANCELED);
         /* FIXME make flush(CANCEL) operation truly non-blocking and wait until

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -2094,12 +2094,7 @@ ucs_status_t uct_tcp_ep_flush(uct_ep_h tl_ep, unsigned flags,
     ucs_status_t status;
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
-        /* TCP is able to cancel only pending operations, posted TX operations
-         * couldn't be canceled, since some data was already sent to the peer
-         * and the peer is waiting for the remaining part of the data */
-        uct_ep_pending_purge(tl_ep,
-                             (uct_pending_purge_callback_t)ucs_empty_function,
-                             0);
+        uct_tcp_ep_purge(ep, UCS_ERR_CANCELED);
         return UCS_OK;
     }
 


### PR DESCRIPTION
## What

1. Don't purge pending requests during `flush(CANCEL)` in TCP and UD transports.
2. Complete all outstanding operations in TCP transport.

## Why ?

1. Purging of pending requests mustn't be done since a user could potentially have some pending operations which are not TX.
2. Need to stop in-progress operations to not progress them anymore.

## How ?

1. Remove calling `uct_ep_pending_purge()` from TCP's and UD's `uct_ep_flush(CANCEL)`.
2. Call `uct_tcp_ep_purge()` which stops TX operations and completes all outstanding Zcopy operations..