### PR TITLE
UCT/UB/RC_MXL5: Always use sig_pi when flushing

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -569,7 +569,6 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                           uct_ib_mlx5_md_t);
     int already_canceled = ep->super.flags & UCT_RC_EP_FLAG_FLUSH_CANCEL;
     ucs_status_t status;
-    uint16_t sn;
 
     status = uct_rc_ep_flush(&ep->super, ep->tx.wq.bb_max, flags);
     if (status != UCS_INPROGRESS) {
@@ -577,7 +576,6 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     }
 
     if (uct_rc_txqp_unsignaled(&ep->super.txqp) != 0) {
-        sn = ep->tx.wq.sw_pi;
         UCT_RC_CHECK_RES(&iface->super, &ep->super);
         uct_rc_mlx5_txqp_inline_post(iface, IBV_QPT_RC,
                                      &ep->super.txqp, &ep->tx.wq,
@@ -586,8 +584,6 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                      0, 0,
                                      NULL, NULL, 0, 0,
                                      INT_MAX);
-    } else {
-        sn = ep->tx.wq.sig_pi;
     }
 
     if (ucs_unlikely((flags & UCT_FLUSH_FLAG_CANCEL) && !already_canceled)) {
@@ -598,7 +594,7 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
     }
 
     return uct_rc_txqp_add_flush_comp(&iface->super, &ep->super.super,
-                                      &ep->super.txqp, comp, sn);
+                                      &ep->super.txqp, comp, ep->tx.wq.sig_pi);
 }
 
 ucs_status_t uct_rc_mlx5_ep_fc_ctrl(uct_ep_t *tl_ep, unsigned op,


### PR DESCRIPTION
## What

Always use `sig_pi` when flushing.

## Why ?

`sig_pi` after sending NO-OP has the same value as `sw_pi` before sending NO-OP.
So, use `sig_pi` in both cases (neither has signaled operations or doesn't have) for simplicity reason.

## How ?

1. Remove declaration of `sn`.
2. Use directly `ep->tx.wq.sig_pi` when initializing flush completion.