### PR TITLE
replace -dynamic-list-data if unsupported

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -2,6 +2,7 @@
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 # Copyright (c) UT-Battelle, LLC. 2017. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016-2020.  ALL RIGHTS RESERVED.
+# Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -499,6 +500,13 @@ CHECK_COMPILER_FLAG([-pedantic], [-pedantic],
                     [CFLAGS_PEDANTIC="$CFLAGS_PEDANTIC -pedantic"],
                     [])
 
+#
+# Check if "-dynamic-list-data" flag is supported
+#
+CHECK_COMPILER_FLAG([-Wl,-dynamic-list-data], [-Wl,-dynamic-list-data],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                    [LDFLAGS_DYNAMIC_LIST_DATA="-Wl,-dynamic-list-data"],
+                    [LDFLAGS_DYNAMIC_LIST_DATA="-Wl,-export-dynamic"])
 
 #
 # Add strict compilation flags
@@ -537,6 +545,7 @@ ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-pointer-sign],
 AC_SUBST([BASE_CFLAGS])
 AC_SUBST([BASE_CXXFLAGS])
 AC_SUBST([CFLAGS_PEDANTIC])
+AC_SUBST([LDFLAGS_DYNAMIC_LIST_DATA])
 
 
 #

--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (C) The University of Tennessee and The University
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+# Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -24,7 +25,7 @@ ucx_perftest_SOURCES = \
 
 ucx_perftest_CPPFLAGS = $(BASE_CPPFLAGS) $(RTE_CPPFLAGS)
 ucx_perftest_CFLAGS   = $(BASE_CFLAGS) $(OPENMP_CFLAGS)
-ucx_perftest_LDFLAGS  = $(RTE_LDFLAGS) -Wl,-dynamic-list-data
+ucx_perftest_LDFLAGS  = $(RTE_LDFLAGS) $(LDFLAGS_DYNAMIC_LIST_DATA)
 ucx_perftest_LDADD    = \
 	$(abs_top_builddir)/src/uct/libuct.la \
 	$(abs_top_builddir)/src/ucp/libucp.la \

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -3,6 +3,7 @@
 * Copyright (C) The University of Tennessee and The University
 *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
+# Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -11,7 +12,9 @@
 #  include "config.h"
 #endif
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS /* For PRIu64 */
+#endif
 
 #include "libperf_int.h"
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -5,6 +5,7 @@
 # Copyright (C) Los Alamos National Security, LLC. 2018 ALL RIGHTS RESERVED.
 # Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
+# Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -70,7 +71,7 @@ gtest_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(OPENMP_CFLAGS)
 
-gtest_LDFLAGS  = $(GTEST_LDFLAGS) -no-install -Wl,-dynamic-list-data
+gtest_LDFLAGS  = $(GTEST_LDFLAGS) -no-install $(LDFLAGS_DYNAMIC_LIST_DATA)
 gtest_CFLAGS   = $(BASE_CFLAGS)
 gtest_CXXFLAGS = \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) -std=c++11 \

--- a/test/gtest/common/googletest/Makefile.am
+++ b/test/gtest/common/googletest/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (C) NVIDIA Corporation. 2021.  ALL RIGHTS RESERVED.
+# Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -18,7 +19,7 @@ libgtest_la_CPPFLAGS = \
 	$(GTEST_CPPFLAGS) \
 	$(OPENMP_CFLAGS)
 
-libgtest_la_LDFLAGS  = $(GTEST_LDFLAGS) -no-install -Wl,-dynamic-list-data
+libgtest_la_LDFLAGS  = $(GTEST_LDFLAGS) -no-install $(LDFLAGS_DYNAMIC_LIST_DATA)
 libgtest_la_CFLAGS   = $(BASE_CFLAGS)
 libgtest_la_CXXFLAGS = \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) -std=c++11

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
+# Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -13,7 +14,10 @@
 #include <stdint.h>
 #endif
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
+#endif
+
 #include <inttypes.h>
 
 #include "test_helpers.h"


### PR DESCRIPTION
## What
allowing replace of clang's unsupported -dynamic-list-data flag and replacing it with supported -dynamic-list

## Why ?
allowing clean clang builds

## How ?

- [x]  replace -dynamic-list-data if unsupported

- [x]  add def guards on __STDC_FORMAT_MACROS to prevent re-defs