### PR TITLE
UCP: Implement passing user memh in proto_v1

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -403,6 +403,9 @@ struct ucp_ep_config {
 
     /* Protocol selection data */
     ucp_proto_select_t            proto_select;
+
+    /* Bitmap of preregistration for am_bw lanes */
+    ucp_md_map_t                  am_bw_prereg_md_map;
 };
 
 

--- a/src/ucp/rndv/rndv.h
+++ b/src/ucp/rndv/rndv.h
@@ -91,7 +91,8 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
 
 ucs_status_t ucp_proto_progress_rndv_rtr(uct_pending_req_t *self);
 
-ucs_status_t ucp_rndv_reg_send_buffer(ucp_request_t *sreq);
+ucs_status_t
+ucp_rndv_reg_send_buffer(ucp_request_t *sreq, const ucp_request_param_t *param);
 
 ucp_mem_desc_t *
 ucp_rndv_mpool_get(ucp_worker_h worker, ucs_memory_type_t mem_type,

--- a/src/ucp/stream/stream_send.c
+++ b/src/ucp/stream/stream_send.c
@@ -67,7 +67,7 @@ ucp_stream_send_req(ucp_request_t *req, size_t count,
     ucs_status_t status = ucp_request_send_start(req, max_short, zcopy_thresh,
                                                  SIZE_MAX, count, 0,
                                                  req->send.length, msg_config,
-                                                 proto);
+                                                 proto, param);
     if (status != UCS_OK) {
         return UCS_STATUS_PTR(status);
     }

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -176,7 +176,8 @@ static ucs_status_t ucp_tag_eager_zcopy_multi(uct_pending_req_t *self)
                                  ucp_proto_am_zcopy_req_complete, 1);
 }
 
-ucs_status_t ucp_tag_send_start_rndv(uct_pending_req_t *self);
+ucs_status_t ucp_tag_send_start_rndv(uct_pending_req_t *self,
+                                     const ucp_request_param_t *param);
 
 const ucp_request_send_proto_t ucp_tag_eager_proto = {
     .contig_short            = ucp_tag_eager_contig_short,
@@ -276,7 +277,7 @@ static ucs_status_t ucp_tag_eager_sync_zcopy_multi(uct_pending_req_t *self)
                                      0ul, ucp_tag_eager_sync_zcopy_req_complete,
                                      1);
     }
-    
+
     first_hdr.super.super.super.tag = req->send.msg_proto.tag;
     first_hdr.super.total_len       = req->send.length;
     first_hdr.req.ep_id             = ucp_send_request_get_ep_remote_id(req);

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -633,7 +633,8 @@ void ucp_tag_offload_cancel_rndv(ucp_request_t *req)
     req->flags &= ~UCP_REQUEST_FLAG_OFFLOADED;
 }
 
-ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
+ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq,
+                                        const ucp_request_param_t *param)
 {
     ucp_ep_t      *ep      = sreq->send.ep;
     ucp_context_t *context = ep->worker->context;
@@ -665,7 +666,7 @@ ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq)
 
         /* RNDV will be performed by the SW - can register with SW RNDV lanes
          * to get multirail benefits */
-        status = ucp_rndv_reg_send_buffer(sreq);
+        status = ucp_rndv_reg_send_buffer(sreq, param);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -68,7 +68,8 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self);
 
 void ucp_tag_offload_cancel_rndv(ucp_request_t *req);
 
-ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq);
+ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq,
+                                        const ucp_request_param_t *param);
 
 ucs_status_t ucp_tag_offload_unexp_eager(void *arg, void *data, size_t length,
                                          unsigned flags, uct_tag_t stag,

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -86,7 +86,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_tag_rndv_rts, (self),
                              sizeof(ucp_rndv_rts_hdr_t));
 }
 
-ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
+ucs_status_t
+ucp_tag_send_start_rndv(ucp_request_t *sreq, const ucp_request_param_t *param)
 {
     ucp_ep_h ep = sreq->send.ep;
     ucs_status_t status;
@@ -104,11 +105,11 @@ ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *sreq)
     ucp_send_request_id_alloc(sreq);
 
     if (ucp_ep_config_key_has_tag_lane(&ucp_ep_config(ep)->key)) {
-        status = ucp_tag_offload_start_rndv(sreq);
+        status = ucp_tag_offload_start_rndv(sreq, param);
     } else {
         ucs_assert(sreq->send.lane == ucp_ep_get_am_lane(ep));
         sreq->send.uct.func = ucp_proto_progress_tag_rndv_rts;
-        status              = ucp_rndv_reg_send_buffer(sreq);
+        status              = ucp_rndv_reg_send_buffer(sreq, param);
     }
 
     return status;

--- a/src/ucp/tag/tag_rndv.h
+++ b/src/ucp/tag/tag_rndv.h
@@ -19,7 +19,8 @@
     })
 
 
-ucs_status_t ucp_tag_send_start_rndv(ucp_request_t *req);
+ucs_status_t
+ucp_tag_send_start_rndv(ucp_request_t *req, const ucp_request_param_t *param);
 
 void ucp_tag_rndv_matched(ucp_worker_h worker, ucp_request_t *req,
                           const ucp_rndv_rts_hdr_t *rts_hdr, size_t hdr_length);

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -85,7 +85,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
 
     status = ucp_request_send_start(req, max_short, zcopy_thresh, rndv_thresh,
                                     dt_count, 0, req->send.length, msg_config,
-                                    proto);
+                                    proto, param);
     if (ucs_likely(status == UCS_OK)) {
         /* Eager send initialized successfully */
         if (req->flags & UCP_REQUEST_FLAG_SYNC) {
@@ -97,7 +97,7 @@ ucp_tag_send_req(ucp_request_t *req, size_t dt_count,
     } else if (status == UCS_ERR_NO_PROGRESS) {
         /* RMA/AM rendezvous */
         ucs_assert(req->send.length >= rndv_thresh);
-        status = ucp_tag_send_start_rndv(req);
+        status = ucp_tag_send_start_rndv(req, param);
         if (status != UCS_OK) {
             return UCS_STATUS_PTR(status);
         }


### PR DESCRIPTION
## Why
Implement the performance optimization of passing user pre-registered memory handle, and bypassing registration cache lookup.

## How
- send: copy UCT handles from memo to dt_reg during send request initialization
- recv: cache memh in req->recv.user_memh, and copy it to dt_reg when we start a zero-copy rondo protocol and already know the relevant lanes and mds. it's done when starting ram_get and when sending RTR with keys to trigger ram_put (from sender).

Note: Need to retest after #7761 is merged