### PR TITLE
UCT/SM/CUDA: Fix common intra-node keepalive protocol

### DIFF
--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -91,14 +91,6 @@ typedef enum {
 } ucs_sys_vma_info_flags_t;
 
 
-/* file time information */
-typedef enum {
-    UCS_SYS_FILE_TIME_CTIME, /**< create time */
-    UCS_SYS_FILE_TIME_ATIME, /**< access time */
-    UCS_SYS_FILE_TIME_MTIME  /**< modification time */
-} ucs_sys_file_time_t;
-
-
 /* information about virtual memory area */
 typedef struct {
     unsigned long start;
@@ -597,19 +589,6 @@ ucs_status_t ucs_sys_enum_threads(ucs_sys_enum_threads_cb_t cb, void *ctx);
 
 
 /**
- * Get file time
- *
- * @param [in]  name  File name
- * @param [in]  type  Type of file time information
- * @param [out] ts    File time information
- *
- * @return UCS_OK if file is found and got information.
- */
-ucs_status_t ucs_sys_get_file_time(const char *name, ucs_sys_file_time_t type,
-                                   struct timespec *ts);
-
-
-/**
  * Check the per-process limit on the number of open file descriptors.
  *
  * @return UCS_OK if the limit has not been reached. UCS_ERR_EXCEEDS_LIMIT,
@@ -638,6 +617,16 @@ ucs_status_t ucs_pthread_create(pthread_t *thread_id_p,
  * @return number of CPUs, or -1 in case of error.
  */
 long ucs_sys_get_num_cpus();
+
+
+/*
+ * Get process creation time.
+ *
+ * @param [in] pid             Process id to get start time.
+ *
+ * @return The time the process started after system boot or 0 in case of error.
+ */
+unsigned long ucs_sys_get_proc_create_time(pid_t pid);
 
 END_C_DECLS
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -295,8 +295,7 @@ typedef struct uct_failed_iface {
  * Keepalive info used by EP
  */
 typedef struct uct_keepalive_info {
-    struct timespec start_time; /* Process start time */
-    char            proc[]; /* Process owner proc dir */
+    unsigned long start_time; /* Process start time */
 } uct_keepalive_info_t;
 
 
@@ -849,9 +848,9 @@ ucs_status_t uct_base_ep_am_short_iov(uct_ep_h ep, uint8_t id, const uct_iov_t *
 
 int uct_ep_get_process_proc_dir(char *buffer, size_t max_len, pid_t pid);
 
-ucs_status_t uct_ep_keepalive_create(pid_t pid, uct_keepalive_info_t **ka_p);
+ucs_status_t uct_ep_keepalive_init(uct_keepalive_info_t *ka, pid_t pid);
 
-ucs_status_t uct_ep_keepalive_check(uct_ep_h ep, uct_keepalive_info_t **ka_p,
+ucs_status_t uct_ep_keepalive_check(uct_ep_h ep, uct_keepalive_info_t *ka,
                                     pid_t pid, unsigned flags,
                                     uct_completion_t *comp);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -32,14 +32,12 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, const uct_ep_params_t *params)
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
 
     self->remote_pid = *(const pid_t*)params->iface_addr;
-    self->keepalive  = NULL;
 
-    return UCS_OK;
+    return uct_ep_keepalive_init(&self->keepalive, self->remote_pid);
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_ep_t)
 {
-    ucs_free(self->keepalive);
 }
 
 UCS_CLASS_DEFINE(uct_cuda_ipc_ep_t, uct_base_ep_t)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -14,7 +14,7 @@
 typedef struct uct_cuda_ipc_ep {
     uct_base_ep_t        super;
     pid_t                remote_pid;
-    uct_keepalive_info_t *keepalive; /* keepalive metadata */
+    uct_keepalive_info_t keepalive; /* keepalive metadata */
 } uct_cuda_ipc_ep_t;
 
 

--- a/src/uct/sm/mm/base/mm_ep.h
+++ b/src/uct/sm/mm/base/mm_ep.h
@@ -48,7 +48,7 @@ typedef struct uct_mm_ep {
        the interface as long as one of the endpoints is unable to send */
     ucs_arbiter_elem_t         arb_elem;
 
-    uct_keepalive_info_t       *keepalive; /* keepalive info */
+    uct_keepalive_info_t       keepalive; /* keepalive info */
 } uct_mm_ep_t;
 
 

--- a/src/uct/sm/scopy/cma/cma_ep.c
+++ b/src/uct/sm/scopy/cma/cma_ep.c
@@ -42,16 +42,14 @@ static UCS_CLASS_INIT_FUNC(uct_cma_ep_t, const uct_ep_params_t *params)
     UCT_EP_PARAMS_CHECK_DEV_IFACE_ADDRS(params);
     UCS_CLASS_CALL_SUPER_INIT(uct_scopy_ep_t, params);
 
-    self->remote_pid = *(const pid_t*)params->iface_addr &
-                       ~UCT_CMA_IFACE_ADDR_FLAG_PID_NS;
-    self->keepalive  = NULL;
+    self->remote_pid           = *(const pid_t*)params->iface_addr &
+                                 ~UCT_CMA_IFACE_ADDR_FLAG_PID_NS;
 
-    return UCS_OK;
+    return uct_ep_keepalive_init(&self->keepalive, self->remote_pid);
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cma_ep_t)
 {
-    ucs_free(self->keepalive);
 }
 
 UCS_CLASS_DEFINE(uct_cma_ep_t, uct_scopy_ep_t)

--- a/src/uct/sm/scopy/cma/cma_ep.h
+++ b/src/uct/sm/scopy/cma/cma_ep.h
@@ -15,7 +15,7 @@
 typedef struct uct_cma_ep {
     uct_scopy_ep_t       super;
     pid_t                remote_pid;
-    uct_keepalive_info_t *keepalive;
+    uct_keepalive_info_t keepalive;
 } uct_cma_ep_t;
 
 

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -461,23 +461,28 @@ UCT_INSTANTIATE_TEST_CASE(test_uct_peer_failure_multiple)
 class test_uct_keepalive : public uct_test {
 public:
     test_uct_keepalive() :
-        m_ka(NULL), m_pid(getpid()), m_entity(NULL), m_err_handler_count(0)
+        m_pid(getpid()), m_entity(NULL), m_err_handler_count(0)
     {
     }
 
     void init()
     {
-        ASSERT_UCS_OK(uct_ep_keepalive_create(m_pid, &m_ka));
-
         m_entity = create_entity(0, err_handler_cb);
         m_entity->connect(0, *m_entity, 0);
         m_entities.push_back(m_entity);
+        ASSERT_TRUE(has_mm());
     }
 
     void cleanup()
     {
         m_entities.clear();
-        ucs_free(m_ka);
+    }
+
+    uct_keepalive_info_t *m_ka()
+    {
+        uct_mm_ep_t *ep = ucs_derived_of(m_entity->ep(0), uct_mm_ep_t);
+
+        return &ep->keepalive;
     }
 
     static ucs_status_t
@@ -491,12 +496,11 @@ public:
 protected:
     void do_keepalive()
     {
-        ucs_status_t status = uct_ep_keepalive_check(m_entity->ep(0), &m_ka,
+        ucs_status_t status = uct_ep_keepalive_check(m_entity->ep(0), m_ka(),
                                                      m_pid, 0, NULL);
         EXPECT_UCS_OK(status);
     }
 
-    uct_keepalive_info_t *m_ka;
     pid_t                m_pid;
     entity               *m_entity;
     unsigned             m_err_handler_count;
@@ -510,7 +514,7 @@ UCS_TEST_P(test_uct_keepalive, ep_check)
     EXPECT_EQ(0u, m_err_handler_count);
 
     /* change start time saved in KA to force an error from EP check */
-    m_ka->start_time.tv_sec--;
+    m_ka()->start_time--;
 
     do_keepalive();
     EXPECT_EQ(0u, m_err_handler_count);
@@ -537,27 +541,18 @@ public:
          * peer EP, but instead we bit change process owner info to force
          * ep_check failure. Simulation of case when peer process is
          * terminated and PID is immediately reused by another process */
-        uct_ep_h tl_ep                = ep0();
-        uct_keepalive_info_t *ka_info = NULL;
 
         if (has_mm()) {
-            uct_mm_ep_t *ep = ucs_derived_of(tl_ep, uct_mm_ep_t);
-            ka_info         = ep->keepalive;
-            ASSERT_TRUE(ka_info != NULL);
+            uct_mm_ep_t *ep = ucs_derived_of(ep0(), uct_mm_ep_t);
+            ep->keepalive.start_time--;
         } else if (has_cuda_ipc()) {
 #if HAVE_CUDA
-            uct_cuda_ipc_ep_t *ep = ucs_derived_of(tl_ep, uct_cuda_ipc_ep_t);
-            ka_info               = ep->keepalive;
-            ASSERT_TRUE(ka_info != NULL);
+            uct_cuda_ipc_ep_t *ep = ucs_derived_of(ep0(), uct_cuda_ipc_ep_t);
+            ep->keepalive.start_time--;
 #endif
         } else if (has_cma()) {
-            uct_cma_ep_t *ep = ucs_derived_of(tl_ep, uct_cma_ep_t);
-            ka_info          = ep->keepalive;
-            ASSERT_TRUE(ka_info != NULL);
-        }
-
-        if (ka_info != NULL) {
-            ka_info->start_time.tv_sec--;
+            uct_cma_ep_t *ep = ucs_derived_of(ep0(), uct_cma_ep_t);
+            ep->keepalive.start_time--;
         }
 
         test_uct_peer_failure::kill_receiver();


### PR DESCRIPTION
## What
Implement intra-node keep-alive protocol based on _startime_ value from _/proc/pid/stat_

## Why ?
The current implementation relies on stat() info performed on /proc/pid dir. This is incorrect, because the files in /proc have no existence of their own, and the info returned by stat() is not persistent.  

