### PR TITLE
UCS/MEMORY: Removed redundant field from ucs_rcache structure.

### DIFF
--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -63,7 +63,6 @@ struct ucs_rcache {
                                               The head of the list is the least
                                               recently used region, and the tail
                                               is the most recently used region. */
-        unsigned long   count;           /**< Number of regions on list */
     } lru;
     
     char                *name;           /**< Name of the cache, for debug purpose */


### PR DESCRIPTION
## What
Removed field representing number of regions in list from ucs_rcache.lru structure.

## Why ?
Code cleanup. There is no need to have separate structure field to count items in list. It is used only in warning text message.