### PR TITLE
JAVA: Throw exception if ucp_mem_query failed

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -173,7 +173,10 @@ Java_org_openucx_jucx_ucp_UcpContext_memoryMapNative(JNIEnv *env, jobject ctx,
     attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS | UCP_MEM_ATTR_FIELD_LENGTH |
                       UCP_MEM_ATTR_FIELD_MEM_TYPE;
 
-    ucp_mem_query(memh, &attr);
+    status = ucp_mem_query(memh, &attr);
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+    }
 
     // Construct UcpMemory class
     jclass jucx_mem_cls = env->FindClass("org/openucx/jucx/ucp/UcpMemory");


### PR DESCRIPTION
## Why
Fix missed error  - if ucp_mem_query() fails, need to throw Java exception
ported from #7345 