### PR TITLE
TEST/UCP: Avoid setenv()/genenv() race

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2032,7 +2032,7 @@ static void ucp_warn_unused_uct_config(ucp_context_h context)
 
     if (num_unused_cached_kv > 0) {
         ucs_string_buffer_rtrim(&unused_cached_uct_cfg , ",");
-        ucs_warn("Invalid configuration%s: %s",
+        ucs_warn("invalid configuration%s: %s",
                  (num_unused_cached_kv > 1) ? "s" : "",
                  ucs_string_buffer_cstr(&unused_cached_uct_cfg));
     }

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -83,6 +83,14 @@ protected:
     virtual void test_body() = 0;
 
     static ucs_log_func_rc_t
+    common_logger(ucs_log_level_t log_level_to_handle, bool print,
+                  std::vector<std::string> &messages_vec, size_t limit,
+                  const char *file, unsigned line, const char *function,
+                  ucs_log_level_t level,
+                  const ucs_log_component_config_t *comp_conf,
+                  const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
     count_warns_logger(const char *file, unsigned line, const char *function,
                        ucs_log_level_t level,
                        const ucs_log_component_config_t *comp_conf,
@@ -139,14 +147,6 @@ private:
     static void push_debug_message_with_limit(std::vector<std::string>& vec,
                                               const std::string& message,
                                               const size_t limit);
-
-    static ucs_log_func_rc_t
-    common_logger(ucs_log_level_t log_level_to_handle, bool print,
-                  std::vector<std::string> &messages_vec, size_t limit,
-                  const char *file, unsigned line, const char *function,
-                  ucs_log_level_t level,
-                  const ucs_log_component_config_t *comp_conf,
-                  const char *message, va_list ap);
 
     static void *thread_func(void *arg);
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1089,9 +1089,10 @@ public:
         test_ucp_am_nbx::init();
 
         // Create new sender() with different segment size
-        m_env.push_back(new ucs::scoped_setenv("UCX_IB_SEG_SIZE", str_size.c_str()));
-        m_env.push_back(new ucs::scoped_setenv("UCX_MM_SEG_SIZE", str_size.c_str()));
-        m_env.push_back(new ucs::scoped_setenv("UCX_SCOPY_SEG_SIZE", str_size.c_str()));
+        modify_config("IB_SEG_SIZE", str_size, IGNORE_IF_NOT_EXIST);
+        modify_config("MM_SEG_SIZE", str_size, IGNORE_IF_NOT_EXIST);
+        modify_config("SCOPY_SEG_SIZE", str_size, IGNORE_IF_NOT_EXIST);
+        modify_config("TCP_SEG_SIZE", str_size, IGNORE_IF_NOT_EXIST);
 
         entity *ent = create_entity(true);
         ent->connect(&receiver(), get_ep_params());

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -174,6 +174,12 @@ public:
         static void reject_conn_cb(ucp_conn_request_h conn_req, void *arg);
 
         void set_ep(ucp_ep_h ep, int worker_index, int ep_index);
+
+        static ucs_log_func_rc_t
+        hide_config_warns_logger(const char *file, unsigned line,
+                                 const char *function, ucs_log_level_t level,
+                                 const ucs_log_component_config_t *comp_conf,
+                                 const char *message, va_list ap);
     };
 
     static bool is_request_completed(void *req);


### PR DESCRIPTION
## Why
Fix #7782 

## What
Do not call setenv() while UD progress thread may call getenv() through strerror()

## How
If we can ignore non-existing variables, might as well use ucp_config_modify() that also sets uct/ucs params [and ignore its return value] rather than ucp_config_modify_internal()