### PR TITLE
AZP/RELEASE: Add link to libnvidia-ml.so

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -16,11 +16,11 @@ resources:
     - container: centos8_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:2
     - container: ubuntu16_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5-cuda11:1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5-cuda11:3
     - container: ubuntu18_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:3
     - container: ubuntu20_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:3
 
 stages:
   - stage: Prepare

--- a/buildlib/dockers/docker-compose.yml
+++ b/buildlib/dockers/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         CUDA_VERSION: 11.4.0
         OS_VERSION: 8
   ubuntu16.04-mofed5-cuda11:
-    image: ubuntu16.04-mofed5-cuda11:1
+    image: ubuntu16.04-mofed5-cuda11:3
     build:
       context: .
       network: host
@@ -34,7 +34,7 @@ services:
         UBUNTU_VERSION: 16.04
         CUDA_VERSION: 11.2.0
   ubuntu18.04-mofed5-cuda11:
-    image: ubuntu18.04-mofed5-cuda11:2
+    image: ubuntu18.04-mofed5-cuda11:3
     build:
       context: .
       network: host
@@ -44,7 +44,7 @@ services:
         UBUNTU_VERSION: 18.04
         CUDA_VERSION: 11.4.0
   ubuntu20.04-mofed5-cuda11:
-    image: ubuntu20.04-mofed5-cuda11:2
+    image: ubuntu20.04-mofed5-cuda11:3
     build:
       context: .
       network: host

--- a/buildlib/dockers/ubuntu-release.Dockerfile
+++ b/buildlib/dockers/ubuntu-release.Dockerfile
@@ -45,3 +45,5 @@ ENV CPATH /usr/local/cuda/include:${CPATH}
 ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LD_LIBRARY_PATH}
 ENV LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LIBRARY_PATH}
 ENV PATH /usr/local/cuda/compat:${PATH}
+
+RUN ml_stub=$(find /usr -name libnvidia-ml.so) && ln -s $ml_stub /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1


### PR DESCRIPTION


## Why ?
Fail release pipeline 
ubuntu want to check libnvidia-ml.so libs 

## How ?
 libnvidia-ml.so is kernel driver 
 and need to create stub link
