### PR TITLE
UCT/GTEST: Enable tag offload recv for inlined data

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -973,8 +973,7 @@ static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
     iface_attr->cap.tag.rndv.max_iov         = 1;
     iface_attr->cap.tag.recv.max_zcopy       = port_attr->max_msg_sz;
     iface_attr->cap.tag.recv.max_iov         = 1;
-    iface_attr->cap.tag.recv.min_recv        =
-                       iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] + 1;
+    iface_attr->cap.tag.recv.min_recv        = 0;
     iface_attr->cap.tag.recv.max_outstanding = iface->tm.num_tags;
     iface_attr->cap.tag.eager.max_iov        = max_tag_eager_iov;
     iface_attr->cap.tag.eager.max_bcopy      = iface->tm.max_bcopy - eager_hdr_size;

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -758,14 +758,14 @@ public:
     }
 };
 
-UCS_TEST_P(test_ucp_tag_offload_stats, post, "TM_THRESH=128")
+UCS_TEST_P(test_ucp_tag_offload_stats, post, "TM_THRESH=1")
 {
     uint64_t tag = 0x11;
-    std::vector<char> dummy(256, 0);
+    uint64_t dummy;
 
     activate_offload(sender());
 
-    request *rreq = recv_nb(dummy.data(), dummy.size(), DATATYPE, tag,
+    request *rreq = recv_nb(&dummy, sizeof(dummy), DATATYPE, tag,
                             UCP_TAG_MASK_FULL);
 
     wait_counter(worker_offload_stats(receiver()),
@@ -777,10 +777,10 @@ UCS_TEST_P(test_ucp_tag_offload_stats, post, "TM_THRESH=128")
                  UCP_WORKER_STAT_TAG_OFFLOAD_CANCELED);
 }
 
-UCS_TEST_P(test_ucp_tag_offload_stats, block, "TM_THRESH=128")
+UCS_TEST_P(test_ucp_tag_offload_stats, block, "TM_THRESH=1")
 {
     uint64_t tag = 0x11;
-    std::vector<char> buf(256, 0);
+    std::vector<char> buf(64, 0);
 
     activate_offload(sender());
 
@@ -883,7 +883,7 @@ protected:
 };
 
 UCS_TEST_P(test_ucp_tag_offload_stats_gpu, block_gpu_no_gpu_direct,
-           "TM_THRESH=128")
+           "TM_THRESH=1")
 {
     activate_offload(sender());
 


### PR DESCRIPTION
## What
- Enable tag offload for small (inlined) data
- Update some tests to use small value 

## Why?
memcpy was removed from UCT, now it is handled correctly in UCP.
If data scattered to CQE, the CQE pointer will be provided to UCP and unpacked according to 

## How ?
set min_recv capability of UCT iface to 0
(rollback #5188)