### PR TITLE
GTEST/UCP: Fix sockaddr gtest usage of recv buffer

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2902,11 +2902,15 @@ protected:
         send_buf.pattern_fill(3, size);
 
         /* Complete receive operations */
+        ucs::ptr_vector<mem_buffer> recv_bufs;
         for (size_t i = 0; i < num_sends; ++i) {
-            mem_buffer recv_buf(size, UCS_MEMORY_TYPE_HOST);
-            recv_buf.pattern_fill(2, size);
-            void *rreq = recv(receiver(), recv_buf.ptr(), size, messages[i],
-                              rtag_complete_check_data_cbx, recv_buf.ptr());
+            mem_buffer *recv_buf = new mem_buffer(size, UCS_MEMORY_TYPE_HOST);
+            recv_buf->pattern_fill(2, size);
+            recv_bufs.push_back(recv_buf);
+
+            void *rreq = recv(receiver(), recv_buf->ptr(), size, messages[i],
+                              rtag_complete_check_data_cbx,
+                              reinterpret_cast<void*>(recv_buf));
             reqs.push_back(rreq);
         }
         requests_wait(reqs);


### PR DESCRIPTION
## What

Fix sockaddr gtest usage of recv buffer.

## Why ?

1. Fixes possible receive to already released buffer.
2. Fixes passing `recv_buf.ptr()` instead of `recv_buf` as user_data for receive operation.

## How ?

1. Introduce ptr_vector which holds all receive buffers, allocate `mem_buffer` for receive buffers on the heap.
2. Replace `recv_buf.ptr()` by `recv_buf` when calling `recv()`.