### PR TITLE
UCP/PROTO: error handling

### DIFF
--- a/src/ucp/am/eager.c
+++ b/src/ucp/am/eager.c
@@ -105,7 +105,8 @@ static ucp_proto_t ucp_eager_short_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_short_progress}
+    .progress   = {ucp_eager_short_progress},
+    .abort      = ucp_proto_request_bcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
@@ -212,6 +213,7 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_bcopy_single_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_bcopy_single_progress}
+    .progress   = {ucp_eager_bcopy_single_progress},
+    .abort      = ucp_request_complete_send
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -193,6 +193,16 @@ typedef void (*ucp_proto_config_str_func_t)(size_t min_length,
 
 
 /**
+ * Abort UCP request at any stage with error status.
+ *
+ * @param [in]  request Request to abort.
+ * @param [in]  status  Error completion status.
+ */
+typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
+                                         ucs_status_t status);
+
+
+/**
  * UCP base protocol definition
  */
 struct ucp_proto {
@@ -205,6 +215,13 @@ struct ucp_proto {
      * request lifetime to implement different stages
      */
     uct_pending_callback_t          progress[UCP_PROTO_STAGE_LAST];
+
+    /*
+     * Abort a request (which is currently not scheduled to a pending queue).
+     * The method should wait for UCT completions and release associated
+     * resources, such as memory handles, remote keys, request ID, etc.
+     */
+    ucp_request_abort_func_t        abort;
 };
 
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -938,14 +938,16 @@ void ucp_proto_common_zcopy_adjust_min_frag_always(ucp_request_t *req,
 void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status)
 {
     ucs_assert(UCS_STATUS_IS_ERR(status));
-    /*
-     * TODO add a method to ucp_proto_t to abort a request (which is currently
-     * not scheduled to a pending queue). The method should wait for UCT
-     * completions and release associated resources, such as memory handles,
-     * remote keys, request ID, etc.
-     */
-    ucs_fatal("abort request %p proto %s status %s: unimplemented", req,
+    ucs_debug("abort request %p proto %s status %s", req,
               req->send.proto_config->proto->name, ucs_status_string(status));
+
+    req->send.proto_config->proto->abort(req, status);
+}
+
+void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status)
+{
+    ucp_datatype_iter_cleanup(&request->send.state.dt_iter, UCP_DT_MASK_ALL);
+    ucp_request_complete_send(request, status);
 }
 
 int ucp_proto_is_short_supported(const ucp_proto_select_param_t *select_param)

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -305,6 +305,7 @@ void ucp_proto_common_zcopy_adjust_min_frag_always(ucp_request_t *req,
 
 void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status);
 
+void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status);
 
 ucs_linear_func_t
 ucp_proto_common_memreg_time(const ucp_proto_common_init_params_t *params,

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -92,6 +92,7 @@ static ucp_proto_t ucp_reconfig_proto = {
     .flags      = UCP_PROTO_FLAG_INVALID,
     .init       = ucp_proto_reconfig_init,
     .config_str = (ucp_proto_config_str_func_t)ucs_empty_function,
-    .progress   = {ucp_proto_reconfig_progress}
+    .progress   = {ucp_proto_reconfig_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_reconfig_proto);

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -420,7 +420,8 @@ static ucp_proto_t ucp_get_amo_post_proto = {
     .flags      = 0,
     .init       = ucp_proto_amo_sw_init_post,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_amo_sw_progress_post}
+    .progress   = {ucp_proto_amo_sw_progress_post},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_amo_post_proto);
 
@@ -447,6 +448,7 @@ static ucp_proto_t ucp_get_amo_fetch_proto = {
     .flags      = 0,
     .init       = ucp_proto_amo_sw_init_fetch,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_amo_sw_progress_fetch}
+    .progress   = {ucp_proto_amo_sw_progress_fetch},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_amo_fetch_proto);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -103,6 +103,7 @@ static ucp_proto_t ucp_get_am_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_get_am_bcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_get_am_bcopy_progress}
+    .progress   = {ucp_proto_get_am_bcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_am_bcopy_proto);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -109,7 +109,8 @@ static ucp_proto_t ucp_get_offload_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_get_offload_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_get_offload_bcopy_progress}
+    .progress   = {ucp_proto_get_offload_bcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_offload_bcopy_proto);
 
@@ -193,6 +194,7 @@ static ucp_proto_t ucp_get_offload_zcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_get_offload_zcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_get_offload_zcopy_progress}
+    .progress   = {ucp_proto_get_offload_zcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_offload_zcopy_proto);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -108,7 +108,8 @@ static ucp_proto_t ucp_put_am_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_put_am_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_put_am_bcopy_progress}
+    .progress   = {ucp_proto_put_am_bcopy_progress},
+    .abort      = ucp_proto_request_bcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_put_am_bcopy_proto);
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -84,7 +84,8 @@ static ucp_proto_t ucp_put_offload_short_proto = {
     .flags      = UCP_PROTO_FLAG_PUT_SHORT,
     .init       = ucp_proto_put_offload_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_put_offload_short_progress}
+    .progress   = {ucp_proto_put_offload_short_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_short_proto);
 
@@ -178,7 +179,8 @@ static ucp_proto_t ucp_put_offload_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_put_offload_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_put_offload_bcopy_progress}
+    .progress   = {ucp_proto_put_offload_bcopy_progress},
+    .abort      = ucp_proto_request_bcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_bcopy_proto);
 
@@ -251,11 +253,19 @@ ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
+static void ucp_put_offload_zcopy_abort(ucp_request_t *request,
+                                        ucs_status_t status)
+{
+    /* zcopy request starts from uct_comp.count = 1 */
+    ucp_invoke_uct_completion(&request->send.state.uct_comp, status);
+}
+
 static ucp_proto_t ucp_put_offload_zcopy_proto = {
     .name       = "put/offload/zcopy",
     .flags      = 0,
     .init       = ucp_proto_put_offload_zcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_put_offload_zcopy_progress}
+    .progress   = {ucp_proto_put_offload_zcopy_progress},
+    .abort      = ucp_put_offload_zcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_zcopy_proto);

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -289,7 +289,7 @@ ucp_proto_rndv_op_check(const ucp_proto_init_params_t *params,
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_rndv_recv_complete(ucp_request_t *req)
+ucp_proto_rndv_recv_complete_status(ucp_request_t *req, ucs_status_t status)
 {
     ucp_request_t *rreq = ucp_request_get_super(req);
 
@@ -300,9 +300,17 @@ ucp_proto_rndv_recv_complete(ucp_request_t *req)
 
     ucs_assert(!ucp_proto_rndv_request_is_ppln_frag(req));
 
-    ucp_request_complete_tag_recv(rreq, rreq->status);
+    ucp_request_complete_tag_recv(rreq, status);
     ucp_request_put(req);
     return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_rndv_recv_complete(ucp_request_t *req)
+{
+    ucp_request_t *rreq = ucp_request_get_super(req);
+
+    return ucp_proto_rndv_recv_complete_status(req, rreq->status);
 }
 
 #endif

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -121,6 +121,7 @@ static ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .flags      = 0,
     .init       = ucp_proto_rdnv_am_bcopy_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_rndv_am_bcopy_progress}
+    .progress   = {ucp_proto_rndv_am_bcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_am_bcopy_proto);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -145,6 +145,44 @@ ucp_proto_rndv_get_zcopy_fetch_progress(uct_pending_req_t *uct_req)
             ucp_proto_rndv_get_zcopy_fetch_completion);
 }
 
+static void
+ucp_proto_rndv_get_zcopy_fetch_err_completion(uct_completion_t *uct_comp)
+{
+    ucp_request_t *req  = ucs_container_of(uct_comp, ucp_request_t,
+                                          send.state.uct_comp);
+
+    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
+                                &req->send.state.dt_iter,
+                                UCS_BIT(UCP_DATATYPE_CONTIG));
+    ucp_proto_rndv_rkey_destroy(req);
+    ucp_proto_rndv_recv_complete_status(req, uct_comp->status);
+}
+
+static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
+                                           ucs_status_t status)
+{
+    ucp_request_t *rreq UCS_V_UNUSED;
+
+    switch (request->send.proto_stage) {
+    case UCP_PROTO_RNDV_GET_STAGE_FETCH:
+        /* The error completion handler is not sending ATS */
+        request->send.state.uct_comp.func =
+                ucp_proto_rndv_get_zcopy_fetch_err_completion;
+        ucp_invoke_uct_completion(&request->send.state.uct_comp, status);
+        break;
+    case UCP_PROTO_RNDV_GET_STAGE_ATS:
+        rreq = ucp_request_get_super(request);
+        /* Locally the data is received, can complete with OK */
+        ucs_assert(rreq->recv.length == rreq->recv.tag.info.length);
+        ucp_proto_rndv_recv_complete(request);
+        break;
+    default:
+        ucs_fatal("req %p: %s has invalid stage %d", request,
+                  request->send.proto_config->proto->name,
+                  request->send.proto_stage);
+    }
+}
+
 static ucp_proto_t ucp_rndv_get_zcopy_proto = {
     .name       = "rndv/get/zcopy",
     .flags      = 0,
@@ -153,7 +191,8 @@ static ucp_proto_t ucp_rndv_get_zcopy_proto = {
     .progress   = {
          [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_zcopy_fetch_progress,
          [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
-    }
+    },
+    .abort      = ucp_rndv_get_zcopy_proto_abort
 };
 UCP_PROTO_REGISTER(&ucp_rndv_get_zcopy_proto);
 
@@ -255,7 +294,8 @@ static ucp_proto_t ucp_rndv_get_mtype_proto = {
     .progress   = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,
         [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
-    }
+    },
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_get_mtype_proto);
 
@@ -307,6 +347,7 @@ static ucp_proto_t ucp_rndv_ats_proto = {
     .flags      = 0,
     .init       = ucp_proto_rndv_ats_init,
     .config_str = ucp_proto_rndv_ack_config_str,
-    .progress   = {ucp_proto_rndv_ats_progress}
+    .progress   = {ucp_proto_rndv_ats_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_ats_proto);

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -266,6 +266,7 @@ static ucp_proto_t ucp_rndv_send_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_send_ppln_atp_progress,
     },
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_send_ppln_proto);
 
@@ -300,5 +301,6 @@ static ucp_proto_t ucp_rndv_recv_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_recv_ppln_ats_progress,
     },
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_recv_ppln_proto);

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -386,6 +386,7 @@ static ucp_proto_t ucp_rndv_put_zcopy_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_put_zcopy_proto);
 
@@ -511,5 +512,6 @@ static ucp_proto_t ucp_rndv_put_mtype_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_put_mtype_proto);

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -157,7 +157,8 @@ static ucp_proto_t ucp_rndv_rkey_ptr_proto = {
     .progress   = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_FETCH] = ucp_proto_rndv_rkey_ptr_fetch_progress,
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress
-    }
+    },
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rkey_ptr_proto);
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -231,7 +231,8 @@ static ucp_proto_t ucp_rndv_rtr_proto = {
     .flags      = 0,
     .init       = ucp_proto_rndv_rtr_init,
     .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = {ucp_proto_rndv_rtr_progress}
+    .progress   = {ucp_proto_rndv_rtr_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rtr_proto);
 
@@ -369,7 +370,8 @@ static ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .flags      = 0,
     .init       = ucp_proto_rndv_rtr_mtype_init,
     .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = {ucp_proto_rndv_rtr_mtype_progress}
+    .progress   = {ucp_proto_rndv_rtr_mtype_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rtr_mtype_proto);
 

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -167,7 +167,8 @@ static ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_bcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_eager_bcopy_multi_progress}
+    .progress   = {ucp_proto_eager_bcopy_multi_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_multi_proto);
 
@@ -242,7 +243,8 @@ static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_sync_bcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_eager_sync_bcopy_multi_progress}
+    .progress   = {ucp_proto_eager_sync_bcopy_multi_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_multi_proto);
 
@@ -323,6 +325,7 @@ static ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_zcopy_multi_init,
     .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_eager_zcopy_multi_progress}
+    .progress   = {ucp_proto_eager_zcopy_multi_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_multi_proto);

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -80,7 +80,8 @@ static ucp_proto_t ucp_eager_short_proto = {
     .flags      = UCP_PROTO_FLAG_AM_SHORT,
     .init       = ucp_proto_eager_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_short_progress}
+    .progress   = {ucp_eager_short_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
@@ -146,7 +147,8 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_bcopy_single_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_bcopy_single_progress}
+    .progress   = {ucp_eager_bcopy_single_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
@@ -213,6 +215,7 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_zcopy_single_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_zcopy_single_progress}
+    .progress   = {ucp_proto_eager_zcopy_single_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -77,7 +77,8 @@ static ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .flags      = UCP_PROTO_FLAG_TAG_SHORT,
     .init       = ucp_proto_eager_tag_offload_short_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_tag_offload_short_progress}
+    .progress   = {ucp_proto_eager_tag_offload_short_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_tag_offload_short_proto);
 
@@ -167,7 +168,8 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_tag_offload_bcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_tag_offload_bcopy_progress}
+    .progress   = {ucp_proto_eager_tag_offload_bcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
@@ -204,7 +206,8 @@ static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_sync_tag_offload_bcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_sync_tag_offload_bcopy_progress}
+    .progress   = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_single_proto);
 
@@ -277,7 +280,8 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_tag_offload_zcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_tag_offload_zcopy_progress}
+    .progress   = {ucp_proto_eager_tag_offload_zcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);
 
@@ -333,6 +337,7 @@ static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .flags      = 0,
     .init       = ucp_proto_eager_sync_tag_offload_zcopy_init,
     .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_sync_tag_offload_zcopy_progress}
+    .progress   = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
+    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_zcopy_single_proto);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -148,11 +148,25 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
                             NULL);
 }
 
+static void ucp_tag_rndv_proto_abort(ucp_request_t *request,
+                                     ucs_status_t status)
+{
+    if (request->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) {
+        ucp_send_request_id_release(request);
+        ucp_datatype_iter_mem_dereg(request->send.ep->worker->context,
+                                    &request->send.state.dt_iter,
+                                    UCP_DT_MASK_ALL);
+    }
+
+    ucp_request_complete_send(request, status);
+}
+
 static ucp_proto_t ucp_tag_rndv_proto = {
     .name       = "tag/rndv",
     .flags      = 0,
     .init       = ucp_proto_rndv_rts_init,
     .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = {ucp_tag_rndv_rts_progress}
+    .progress   = {ucp_tag_rndv_rts_progress},
+    .abort      = ucp_tag_rndv_proto_abort
 };
 UCP_PROTO_REGISTER(&ucp_tag_rndv_proto);


### PR DESCRIPTION
## What
 - infrastructure for error handling of new protocols
 - ucp_rndv_get_zcopy_proto
 - ucp_tag_rndv_proto
 - ucp_eager_short_proto
 - ucp_eager_bcopy_single_proto
 - ucp_put_am_bcopy_proto
 - ucp_put_offload_bcopy_proto
 - ucp_put_offload_zcopy_proto

## Why ?
error handling support in new protocols

## How ?
`ucp_proto_t::abort`

```
UCX_PROTO_ENABLE=y test/gtest/gtest --gtest_filter=*test_ucp_peer_failure*:-*kill_receiver/0:*kill_receiver/1:*force_close/0:*force_close/2:*zcopy/0:*zcopy/2 --gtest_break_on_failure --gtest_shuffle
```
passed on jazz, skipped tests are AM/RNDV which is not implemented
