### PR TITLE
UCT/TCP: Fix having UCT EP pairs with only RX capability

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -175,7 +175,8 @@ typedef enum uct_tcp_cm_conn_event {
      * `UCT_TCP_CM_CONN_REQ` wasn't sent yet) and want to have RX capability
      * on a peer's EP in order to send AM data. */
     UCT_TCP_CM_CONN_ACK_WITH_REQ      = (UCT_TCP_CM_CONN_REQ |
-                                         UCT_TCP_CM_CONN_ACK)
+                                         UCT_TCP_CM_CONN_ACK),
+    UCT_TCP_CM_CONN_FIN               = UCS_BIT(2)
 } uct_tcp_cm_conn_event_t;
 
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -58,9 +58,9 @@ protected:
     void send_recv(ucp_ep_h send_ep, ucp_worker_h recv_worker, ucp_ep_h recv_ep,
                    size_t vecsize, int repeat);
 
-    void disconnect(ucp_ep_h ep);
+    void disconnect(ucp_ep_h ep, bool force = false);
 
-    void disconnect(ucp_test::entity &e);
+    void disconnect(ucp_test::entity &e, bool force = false);
 
     static void close_completion(void *request, ucs_status_t status,
                                  void *user_data);
@@ -375,16 +375,20 @@ void test_ucp_wireup::send_recv(ucp_ep_h send_ep, ucp_worker_h recv_worker,
     m_rkeys.clear();
 }
 
-void test_ucp_wireup::disconnect(ucp_ep_h ep) {
-    void *req = ucp_disconnect_nb(ep);
+void test_ucp_wireup::disconnect(ucp_ep_h ep, bool force) {
+    ucp_request_param_t param;
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = (force) ? UCP_EP_CLOSE_FLAG_FORCE : 0;
+
+    void *req = ucp_ep_close_nbx(ep, &param);
     if (!UCS_PTR_IS_PTR(req)) {
         ASSERT_UCS_OK(UCS_PTR_STATUS(req));
     }
     request_wait(req);
 }
 
-void test_ucp_wireup::disconnect(ucp_test::entity &e) {
-    disconnect(e.revoke_ep());
+void test_ucp_wireup::disconnect(ucp_test::entity &e, bool force) {
+    disconnect(e.revoke_ep(), force);
 }
 
 bool test_ucp_wireup::ep_iface_has_caps(const entity& e, const std::string& tl,
@@ -943,6 +947,31 @@ UCS_TEST_P(test_ucp_wireup_errh_peer, msg_before_ep_create) {
 
     send_recv(receiver().ep(), sender().worker(), receiver().ep(), 1, 1);
     flush_worker(receiver());
+}
+
+UCS_TEST_P(test_ucp_wireup_errh_peer, stress_connect_force_disconnect) {
+    int max_count = (int)ucs_max(10,
+                                 (1000.0 / (ucs::test_time_multiplier() *
+                                            ucs::test_time_multiplier())));
+    int count     = (get_variant_value() & NO_EP_MATCH) ?
+                    ucs_min(max_count, max_connections() / 2) : max_count;
+
+    for (int i = 0; i < count; ++i) {
+        sender().connect(&receiver(), get_ep_params());
+        send_recv(sender().ep(), receiver().worker(), receiver().ep(), 1, 1);
+        if (!is_loopback()) {
+            receiver().connect(&sender(), get_ep_params());
+            send_recv(receiver().ep(), sender().worker(), sender().ep(), 1, 1);
+        }
+
+        flush_worker(sender());
+        flush_worker(receiver());
+
+        disconnect(sender(), true);
+        if (!is_loopback()) {
+            disconnect(receiver(), true);
+        }
+    }
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_wireup_errh_peer)


### PR DESCRIPTION
## What

Fix having UCT EP pairs with only RX capability.

## Why ?

It might happen that UCT EP pairs with only RX capability remain functional, but they can do nothing since a user don't know about them.
The following situation leads to this:
- UCT_EP was created by a user on peer1
- UCT_EP was created by a user on peer2
- UCT_EP_1 and UCT_EP_2 are connected to each other
- `uct_ep_destroy()` was invoked for UCT_EP_1 - it wasn't destroyed, since it has RX capability
- `uct_ep_destroy()` was invoked for UCT_EP_2 - it wasn't destroyed, since it has RX capability
- UCT_EP_1 and UCT_EP_2 will live forever until either peer1 or peer2 will destroy UCT IFACE.

## How ?

1. Introduce new connection event - `UCT_TCP_CM_CONN_FIN`.
2. Update `uct_tcp_cm_trace_conn_pkt()` function to support `UCT_TCP_CM_CONN_FIN` and simplify it by using string_buffer.
3. Send `UCT_TCP_CM_CONN_FIN` connection packet from `uct_ep_destroy()` if UCT EP is not going to be fully destroyed due to having RX capability and `CONNECT_TO_IFACE`.
4. Handle `UCT_TCP_CM_CONN_FIN`: remove RX capability from UCT EP; destroy UCT EP, if there is no TX capability on it (e.g. `uct_ep_destroy()` was called for this EP).