### PR TITLE
IPC/CACHE: fixed range for invalidate page lookup

### DIFF
--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -75,7 +75,7 @@ static void uct_rocm_ipc_cache_invalidate_regions(uct_rocm_ipc_cache_t *cache,
 
     ucs_list_head_init(&region_list);
     ucs_pgtable_search_range(&cache->pgtable, (ucs_pgt_addr_t)from,
-                             (ucs_pgt_addr_t)to,
+                             (ucs_pgt_addr_t)to - 1,
                              uct_rocm_ipc_cache_region_collect_callback,
                              &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, list) {


### PR DESCRIPTION
- there was incorrect calculation of page range to invalidate:
  could be additional range invalidated
