### PR TITLE
UCT/IB: Remove device parameter from is_roce_v2 function

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1171,7 +1171,7 @@ static void uct_ib_iface_set_num_paths(uct_ib_iface_t *iface,
     }
 }
 
-int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface, uct_ib_device_t *dev)
+int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface)
 {
     return uct_ib_iface_is_roce(iface) &&
            (iface->gid_info.roce_info.ver == UCT_IB_DEVICE_ROCE_V2);
@@ -1404,7 +1404,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     }
 
     if (config->traffic_class == UCS_ULUNITS_AUTO) {
-        self->config.traffic_class = uct_ib_iface_is_roce_v2(self, dev) ?
+        self->config.traffic_class = uct_ib_iface_is_roce_v2(self) ?
                                      UCT_IB_DEFAULT_ROCEV2_DSCP : 0;
     } else {
         self->config.traffic_class = config->traffic_class;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -466,7 +466,7 @@ ucs_status_t
 uct_ib_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
 
 
-int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface, uct_ib_device_t *dev);
+int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface);
 
 
 /**

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -66,7 +66,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(dctc, dctc, tclass,
                       iface->super.super.super.config.traffic_class);
 
-    if (uct_ib_iface_is_roce_v2(&iface->super.super.super, dev)) {
+    if (uct_ib_iface_is_roce_v2(&iface->super.super.super)) {
         /* RoCE V2 sets DSCP */
         UCT_IB_MLX5DV_SET(dctc, dctc, dscp,
                           uct_ib_iface_roce_dscp(&iface->super.super.super));

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -337,7 +337,6 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
     char out_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_out)] = {};
     char in_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_in)]    = {};
     char out_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_out)]  = {};
-    uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super);
     uint32_t opt_param_mask = UCT_IB_MLX5_QP_OPTPAR_RRE |
                               UCT_IB_MLX5_QP_OPTPAR_RAE |
                               UCT_IB_MLX5_QP_OPTPAR_RWE;
@@ -373,7 +372,7 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                           ah_attr->grh.sgid_index);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           iface->super.super.config.sl);
-        if (uct_ib_iface_is_roce_v2(&iface->super.super, dev)) {
+        if (uct_ib_iface_is_roce_v2(&iface->super.super)) {
             ucs_assert(ah_attr->dlid >= UCT_IB_ROCE_UDP_SRC_PORT_BASE);
             UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.udp_sport,
                               ah_attr->dlid);


### PR DESCRIPTION
## What

Remove device parameter from `uct_ib_iface_is_roce_v2` function.

## Why ?

The parameter `dev` is not used.

## How ?

1. Remove `dev` from `uct_ib_iface_is_roce_v2` function declaration.
2. Fix all occurencies of `uct_ib_iface_is_roce_v2` function where `dev` is passed.