### PR TITLE
APPS/IO-DEMO: Remove excessive is_rndv branches in AM

### DIFF
--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -1309,12 +1309,8 @@ public:
         w->init(this, conn, msg->sn, msg->conn_id, iov,
                 &conn_stat.completions<IO_WRITE>());
         conn_stat.bytes<IO_WRITE>() += msg->data_size;
-        if (!ucx_am_is_rndv(data_desc)) {
-            conn->recv_am_data(NULL, 0, NULL, data_desc, w);
-        } else {
-            conn->recv_am_data((*iov)[0].buffer(), (*iov)[0].size(),
-                               (*iov)[0].memh(), data_desc, w);
-        }
+        conn->recv_am_data((*iov)[0].buffer(), (*iov)[0].size(),
+                           (*iov)[0].memh(), data_desc, w);
     }
 
     virtual void dispatch_connection_accepted(UcxConnection* conn) {
@@ -1886,12 +1882,8 @@ public:
 
             r->init(this, server_index, msg->sn, conn->id(), opts().validate,
                     iov, 0);
-            if (!ucx_am_is_rndv(data_desc)) {
-                conn->recv_am_data(NULL, 0, NULL, data_desc, r);
-            } else {
-                conn->recv_am_data((*iov)[0].buffer(), msg->data_size,
-                                   (*iov)[0].memh(), data_desc, r);
-            }
+            conn->recv_am_data((*iov)[0].buffer(), msg->data_size,
+                               (*iov)[0].memh(), data_desc, r);
         }
     }
 

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -963,7 +963,7 @@ bool UcxConnection::recv_am_data(void *buffer, size_t length, ucp_mem_h memh,
 {
     assert(_ep != NULL);
 
-    if (!(data_desc._param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV)) {
+    if (!_context.ucx_am_is_rndv(data_desc)) {
         (*callback)(UCS_OK);
         return true;
     }


### PR DESCRIPTION
## What

Remove excessive is_rndv branches in AM.

## Why ?

No need to check `is_rndv` prior calling `recv_am_data` method, since it is called inside `recv_am_data` method.

## How ?

Remove branch `!ucx_am_is_rndv(data_desc)` and its body.