### PR TITLE
UCP/CORE: deactivate iface when discard/cleanup lanes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1143,6 +1143,27 @@ static void ucp_ep_set_lanes_failed(ucp_ep_h ep, uct_ep_h *uct_eps)
     }
 }
 
+void ucp_ep_unprogress_uct_ep(ucp_ep_h ep, uct_ep_h uct_ep,
+                              ucp_rsc_index_t rsc_index)
+{
+    ucp_worker_iface_t *wiface;
+
+    if ((rsc_index == UCP_NULL_RESOURCE) ||
+        !ep->worker->context->config.ext.adaptive_progress ||
+        /* Do not unprogress an already failed lane */
+        ucp_is_uct_ep_failed(uct_ep) ||
+        ucp_wireup_ep_test(uct_ep)) {
+        return;
+    }
+
+    wiface = ucp_worker_iface(ep->worker, rsc_index);
+    ucs_debug("ep %p: unprogress iface %p " UCT_TL_RESOURCE_DESC_FMT,
+              ep, wiface->iface,
+              UCT_TL_RESOURCE_DESC_ARG(
+              &(ep->worker->context->tl_rscs[rsc_index].tl_rsc)));
+    ucp_worker_iface_unprogress_ep(wiface);
+}
+
 static void ucp_ep_discard_lanes_callback(void *request, ucs_status_t status,
                                           void *user_data)
 {
@@ -1201,7 +1222,9 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t discard_status)
         }
 
         ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
-        status = ucp_worker_discard_uct_ep(ep, uct_ep, ep_flush_flags,
+        status = ucp_worker_discard_uct_ep(ep, uct_ep,
+                                           ucp_ep_get_rsc_index(ep, lane),
+                                           ep_flush_flags,
                                            ucp_ep_err_pending_purge,
                                            UCS_STATUS_PTR(discard_status),
                                            ucp_ep_discard_lanes_callback,
@@ -1338,6 +1361,8 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
 
         ucs_debug("ep %p: pending & destroy uct_ep[%d]=%p", ep, lane, uct_ep);
         uct_ep_pending_purge(uct_ep, ucp_destroyed_ep_pending_purge, ep);
+        ucp_ep_unprogress_uct_ep(ep, uct_ep, ucp_ep_get_rsc_index(ep, lane));
+
         /* coverity wrongly resolves ucp_failed_tl_ep's no-op EP destroy
          * function to 'ucp_proxy_ep_destroy' */
         /* coverity[incorrect_free] */

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -648,6 +648,9 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status);
 void ucp_ep_set_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
                                 ucs_status_t status);
 
+void ucp_ep_unprogress_uct_ep(ucp_ep_h ep, uct_ep_h uct_ep,
+                              ucp_rsc_index_t rsc_index);
+
 void ucp_ep_cleanup_lanes(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,

--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -240,10 +240,11 @@ void ucp_proxy_ep_replace(ucp_proxy_ep_t *proxy_ep)
 }
 
 void ucp_proxy_ep_set_uct_ep(ucp_proxy_ep_t *proxy_ep, uct_ep_h uct_ep,
-                             int is_owner)
+                             int is_owner, ucp_rsc_index_t rsc_index)
 {
-    proxy_ep->uct_ep   = uct_ep;
-    proxy_ep->is_owner = is_owner;
+    proxy_ep->uct_ep    = uct_ep;
+    proxy_ep->is_owner  = is_owner;
+    proxy_ep->rsc_index = rsc_index;
 }
 
 UCS_CLASS_DEFINE(ucp_proxy_ep_t, void);

--- a/src/ucp/core/ucp_proxy_ep.h
+++ b/src/ucp/core/ucp_proxy_ep.h
@@ -24,11 +24,12 @@
  * TODO make sure it works with err handling and print_ucp_info
  */
 typedef struct ucp_proxy_ep {
-    uct_ep_t                  super;    /**< Derived from uct_ep */
-    uct_iface_t               iface;    /**< Embedded stub interface */
-    ucp_ep_h                  ucp_ep;   /**< Pointer to UCP endpoint */
-    uct_ep_h                  uct_ep;   /**< Underlying transport endpoint */
-    int                       is_owner; /**< Is uct_ep owned by this proxy ep */
+    uct_ep_t        super;     /**< Derived from uct_ep */
+    uct_iface_t     iface;     /**< Embedded stub interface */
+    ucp_ep_h        ucp_ep;    /**< Pointer to UCP endpoint */
+    uct_ep_h        uct_ep;    /**< Underlying transport endpoint */
+    int             is_owner;  /**< Is uct_ep owned by this proxy ep */
+    ucp_rsc_index_t rsc_index; /**< Resource index of underlying transport endpoint */
 } ucp_proxy_ep_t;
 
 
@@ -47,6 +48,6 @@ int ucp_proxy_ep_test(uct_ep_h ep);
 uct_ep_h ucp_proxy_ep_extract(uct_ep_h ep);
 
 void ucp_proxy_ep_set_uct_ep(ucp_proxy_ep_t *proxy_ep, uct_ep_h uct_ep,
-                             int is_owner);
+                             int is_owner, ucp_rsc_index_t rsc_index);
 
 #endif

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -319,6 +319,8 @@ struct ucp_request {
                     /* Progress ID, if it's UCS_CALLBACKQ_ID_NULL, no operations
                      * are in-progress */
                     uct_worker_cb_id_t cb_id;
+                    /* Index of UCT EP to be flushed and destroyed */
+                    ucp_rsc_index_t    rsc_index;
                 } discard_uct_ep;
 
                 struct {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2344,10 +2344,11 @@ static void ucp_worker_discard_uct_ep_complete(ucp_request_t *req)
 
 static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
 {
-    ucp_request_t *req  = (ucp_request_t*)arg;
-    uct_ep_h uct_ep     = req->send.discard_uct_ep.uct_ep;
-    ucp_ep_h ucp_ep     = req->send.ep;
-    ucp_worker_h worker = ucp_ep->worker;
+    ucp_request_t *req        = (ucp_request_t*)arg;
+    uct_ep_h uct_ep           = req->send.discard_uct_ep.uct_ep;
+    ucp_rsc_index_t rsc_index = req->send.discard_uct_ep.rsc_index;
+    ucp_ep_h ucp_ep           = req->send.ep;
+    ucp_worker_h worker       = ucp_ep->worker;
     khiter_t iter;
 
     ucp_trace_req(req, "destroy uct_ep=%p", uct_ep);
@@ -2362,6 +2363,7 @@ static unsigned ucp_worker_discard_uct_ep_destroy_progress(void *arg)
                   uct_ep, worker);
     }
 
+    ucp_ep_unprogress_uct_ep(ucp_ep, uct_ep, rsc_index);
     uct_ep_destroy(uct_ep);
     ucp_worker_discard_uct_ep_complete(req);
 
@@ -2532,9 +2534,14 @@ void ucp_worker_destroy(ucp_worker_h worker)
     uct_worker_progress_unregister_safe(worker->uct, &worker->keepalive.cb_id);
     ucp_worker_destroy_eps(worker, &worker->all_eps, "all");
     ucp_worker_destroy_eps(worker, &worker->internal_eps, "internal");
-    ucp_worker_remove_am_handlers(worker);
     ucp_am_cleanup(worker);
     ucp_worker_discard_uct_ep_cleanup(worker);
+    /* Put ucp_worker_remove_am_handlers after ucp_worker_discard_uct_ep_cleanup
+     * to make sure iface->am[] always cleared.
+     * ucp_worker_discard_uct_ep_cleanup might trigger ucp_worker_iface_deactivate
+     * which further set iface->am[UCP_AM_ID_WIREUP].
+     */
+    ucp_worker_remove_am_handlers(worker);
 
     if (worker->flush_ops_count != 0) {
         ucs_warn("worker %p: %u pending operations were not flushed", worker,
@@ -3155,6 +3162,7 @@ void ucp_worker_keepalive_remove_ep(ucp_ep_h ep)
 
 static ucs_status_t
 ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                             ucp_rsc_index_t rsc_index,
                              unsigned ep_flush_flags,
                              ucp_send_nbx_callback_t discarded_cb,
                              void *discarded_cb_arg)
@@ -3200,6 +3208,7 @@ ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     req->send.discard_uct_ep.uct_ep         = uct_ep;
     req->send.discard_uct_ep.ep_flush_flags = ep_flush_flags;
     req->send.discard_uct_ep.cb_id          = UCS_CALLBACKQ_ID_NULL;
+    req->send.discard_uct_ep.rsc_index      = rsc_index;
     ucp_request_set_user_callback(req, send.cb, discarded_cb, discarded_cb_arg);
 
     ucp_worker_discard_uct_ep_progress(req);
@@ -3238,6 +3247,7 @@ int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep)
 }
 
 ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                                       ucp_rsc_index_t rsc_index,
                                        unsigned ep_flush_flags,
                                        uct_pending_purge_callback_t purge_cb,
                                        void *purge_arg,
@@ -3258,7 +3268,7 @@ ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
         }
     }
 
-    return ucp_worker_discard_tl_uct_ep(ucp_ep, uct_ep, ep_flush_flags,
+    return ucp_worker_discard_tl_uct_ep(ucp_ep, uct_ep, rsc_index, ep_flush_flags,
                                         discarded_cb, discarded_cb_arg);
 }
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -389,6 +389,7 @@ int ucp_worker_is_uct_ep_discarding(ucp_worker_h worker, uct_ep_h uct_ep);
 
 /* must be called with async lock held */
 ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                                       ucp_rsc_index_t rsc_index,
                                        unsigned ep_flush_flags,
                                        uct_pending_purge_callback_t purge_cb,
                                        void *purge_arg,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -869,7 +869,8 @@ ucp_wireup_ep_lane_set_next_ep(ucp_ep_h ep, ucp_lane_index_t lane,
 {
     ucs_trace("ep %p: wireup uct_ep[%d]=%p next set to %p", ep, lane,
               ep->uct_eps[lane], uct_ep);
-    ucp_wireup_ep_set_next_ep(ep->uct_eps[lane], uct_ep);
+    ucp_wireup_ep_set_next_ep(ep->uct_eps[lane], uct_ep,
+                              ucp_ep_get_rsc_index(ep, lane));
 }
 
 static ucs_status_t
@@ -1251,7 +1252,8 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
             if (ep->uct_eps[lane] != NULL) {
                 ucs_assert(lane != ucp_ep_get_cm_lane(ep));
                 ucp_worker_discard_uct_ep(
-                        ep, ep->uct_eps[lane], UCT_FLUSH_FLAG_LOCAL,
+                        ep, ep->uct_eps[lane],
+                        UCP_NULL_RESOURCE, UCT_FLUSH_FLAG_LOCAL,
                         ucp_request_purge_enqueue_cb, replay_pending_queue,
                         (ucp_send_nbx_callback_t)ucs_empty_function, NULL);
                 ep->uct_eps[lane] = NULL;
@@ -1485,7 +1487,8 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane)
     uct_ep_pending_purge(uct_ep, ucp_request_purge_enqueue_cb, &tmp_q);
 
     /* the wireup ep should use the existing [am_lane] as next_ep */
-    ucp_wireup_ep_set_next_ep(ep->uct_eps[lane], uct_ep);
+    ucp_wireup_ep_set_next_ep(ep->uct_eps[lane], uct_ep,
+                              ucp_ep_get_rsc_index(ep, lane));
 
     if (!(ep->flags & UCP_EP_FLAG_CONNECT_REQ_QUEUED)) {
         status = ucp_wireup_send_request(ep);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -987,7 +987,7 @@ ucs_status_t ucp_ep_client_cm_create_uct_ep(ucp_ep_h ucp_ep)
         return status;
     }
 
-    ucp_wireup_ep_set_next_ep(&wireup_ep->super.super, cm_ep);
+    ucp_wireup_ep_set_next_ep(&wireup_ep->super.super, cm_ep, UCP_NULL_RESOURCE);
     ucs_trace("created cm_ep %p, wireup_ep %p, uct_ep %p, wireup_ep_from_uct_ep %p",
               cm_ep, wireup_ep, &wireup_ep->super.super, ucp_wireup_ep(&wireup_ep->super.super));
     return status;
@@ -1424,7 +1424,7 @@ ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
         goto err;
     }
 
-    ucp_wireup_ep_set_next_ep(ep->uct_eps[lane], uct_ep);
+    ucp_wireup_ep_set_next_ep(ep->uct_eps[lane], uct_ep, UCP_NULL_RESOURCE);
     ucp_ep_update_flags(ep, UCP_EP_FLAG_LOCAL_CONNECTED, 0);
     return UCS_OK;
 

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -110,7 +110,8 @@ void ucp_wireup_ep_discard_aux_ep(ucp_wireup_ep_t *wireup_ep,
 
 int ucp_wireup_ep_has_next_ep(ucp_wireup_ep_t *wireup_ep);
 
-void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep);
+void ucp_wireup_ep_set_next_ep(uct_ep_h uct_ep, uct_ep_h next_ep,
+                               ucp_rsc_index_t rsc_index);
 
 uct_ep_h ucp_wireup_ep_extract_next_ep(uct_ep_h uct_ep);
 

--- a/src/ucs/datastruct/callbackq.c
+++ b/src/ucs/datastruct/callbackq.c
@@ -271,6 +271,8 @@ static void ucs_callbackq_disable_proxy(ucs_callbackq_t *cbq)
 
     ucs_trace_func("cbq=%p slow_proxy_id=%d", cbq, priv->slow_proxy_id);
 
+    ucs_assert(priv->fast_remove_mask == 0);
+
     if (priv->slow_proxy_id == UCS_CALLBACKQ_ID_NULL) {
         return;
     }
@@ -455,8 +457,8 @@ void ucs_callbackq_cleanup(ucs_callbackq_t *cbq)
 {
     ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
 
-    ucs_callbackq_disable_proxy(cbq);
     ucs_callbackq_purge_fast(cbq);
+    ucs_callbackq_disable_proxy(cbq);
     ucs_callbackq_purge_slow(cbq);
 
     if ((priv->num_fast_elems) > 0 || (priv->num_slow_elems > 0)) {

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -126,7 +126,8 @@ protected:
                 ASSERT_UCS_OK(status);
 
                 wireup_eps.push_back(discard_ep);
-                ucp_wireup_ep_set_next_ep(discard_ep, &eps[i]);
+                ucp_wireup_ep_set_next_ep(discard_ep, &eps[i],
+                                          UCP_NULL_RESOURCE);
 
                 ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(discard_ep);
 
@@ -177,6 +178,7 @@ protected:
             UCS_ASYNC_BLOCK(&sender().worker()->async);
             ucp_worker_iface_progress_ep(wiface);
             ucp_worker_discard_uct_ep(m_ucp_ep, discard_ep, UCT_FLUSH_FLAG_LOCAL,
+                                      UCP_NULL_RESOURCE,
                                       ep_pending_purge_count_reqs_cb,
                                       &purged_reqs_count, discarded_cb,
                                       static_cast<void*>(&discarded_count));


### PR DESCRIPTION
## What
Deactivate UCT iface progress when there is no active ep for this iface.

## Why?
Optimize case when TCP connection is created and then closed: currently, uct_tcp_iface_progress() continues to waste CPU cycles calling epoll_wait(). After this fix, TCP progress will not be called when no TCP endpoint is active.

## How ?
Deactivate iface within ucp_ep_discard_lanes and ucp_ep_cleanup_lanes.
NOTE: This solves only client-server case.
