### PR TITLE
UCP/EP: move local_sockaddr to end of ucp_ep_params_t to fix ABI break

### DIFF
--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -733,15 +733,6 @@ typedef struct ucp_ep_params {
     ucs_sock_addr_t         sockaddr;
 
     /**
-     * The sockaddr to bind locally. Specifies the associated network device
-     * to bind locally to establish new connections.
-     * To retrieve the endpoint's local_sockaddr, use @ref ucp_ep_query.
-     * This setting is optional. To enable it, the corresponding - @ref
-     * UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR bit in the field mask must be set.
-     */
-    ucs_sock_addr_t         local_sockaddr;
-
-    /**
      * Connection request from client; this field should be set along with its
      * corresponding bit in the field_mask - @ref
      * UCP_EP_PARAM_FIELD_CONN_REQUEST and must be obtained from @ref
@@ -760,6 +751,16 @@ typedef struct ucp_ep_params {
      * unique name will be created for you.
      */
     const char              *name;
+
+    /**
+     * The sockaddr to bind locally. Specifies the associated network device
+     * to bind locally to establish new connections.
+     * To retrieve the endpoint's local_sockaddr, use @ref ucp_ep_query.
+     * This setting is optional. To enable it, the corresponding - @ref
+     * UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR bit in the field mask must be set.
+     */
+    ucs_sock_addr_t         local_sockaddr;
+
 } ucp_ep_params_t;
 
 


### PR DESCRIPTION
## What
PR #7623 breaks UCX ABI because the new field local_sockaddr was added to the middle of ucp_ep_params_t struct. Need to move it to the end.
It will ABI-break any application that uses conn_request or name fields (so pretty much any client/server application)

## Why ?
Fixes #7822

## How ?
move local_sockaddr to the end of ucp_ep_params_t.
