### PR TITLE
UCP/TAG/AM: Use alignment param for UCT AM rdesc init

### DIFF
--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -716,7 +716,7 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
             return UCS_ERR_NO_MEMORY;
         }
 
-        padding = ucs_padding((uintptr_t)(rdesc + 1), worker->am.alignment);
+        padding = ucs_padding((uintptr_t)(rdesc + 1), alignment);
         rdesc   = (ucp_recv_desc_t*)UCS_PTR_BYTE_OFFSET(rdesc, padding);
         rdesc->release_desc_offset = padding;
 


### PR DESCRIPTION
## What
Take alignment from the corresponding parameter in `ucp_recv_desc_init` (rather than from the worker directly) 

## Why ?
Fix typo, need to take alignment from argument (worker alignment is required for UCP AM only)