### PR TITLE
BUILD/TOOLS/INFO: Add extra version information

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,9 +8,11 @@
 #
 AC_PREREQ([2.63])
 
-define([ucx_ver_major], 1)
-define([ucx_ver_minor], 13)
-define([ucx_ver_patch], 0)
+define([ucx_ver_major], 1)  # Major version. Usually does not change.
+define([ucx_ver_minor], 13) # Minor version. Increased for each release.
+define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
+define([ucx_ver_extra], "") # Extra version string. Empty for a general release.
+
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
 
 # This is the API version (see libtool library versioning)
@@ -60,11 +62,13 @@ AC_SUBST(top_top_srcdir)
 MAJOR_VERSION=ucx_ver_major
 MINOR_VERSION=ucx_ver_minor
 PATCH_VERSION=ucx_ver_patch
-VERSION=$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION
+EXTRA_VERSION=ucx_ver_extra
+VERSION=$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION$EXTRA_VERSION
 SOVERSION=libucx_so_version
 AC_SUBST(MAJOR_VERSION)
 AC_SUBST(MINOR_VERSION)
 AC_SUBST(PATCH_VERSION)
+AC_SUBST(EXTRA_VERSION)
 AC_SUBST(SCM_VERSION)
 AC_SUBST(SOVERSION)
 

--- a/src/tools/info/build_info.c
+++ b/src/tools/info/build_info.c
@@ -15,8 +15,9 @@
 
 void print_version()
 {
-    printf("# UCT version=%s revision %s\n", UCT_VERNO_STRING, UCT_SCM_VERSION);
-    printf("# configured with: %s\n", UCX_CONFIGURE_FLAGS);
+    printf("# Version %s\n", UCT_VERNO_STRING);
+    printf("# Git branch '%s', revision %s\n", UCT_SCM_BRANCH, UCT_SCM_VERSION);
+    printf("# Configured with: %s\n", UCX_CONFIGURE_FLAGS);
 }
 
 void print_build_config()

--- a/src/uct/api/version.h.in
+++ b/src/uct/api/version.h.in
@@ -10,9 +10,12 @@
 
 #define UCT_VERNO_MAJOR            @MAJOR_VERSION@
 #define UCT_VERNO_MINOR            @MINOR_VERSION@
+#define UCT_VERNO_PATCH            @PATCH_VERSION@
+#define UCT_VERNO_EXTRA            "@EXTRA_VERSION@"
 #define UCT_VERNO_STRING           "@VERSION@"
 #define UCT_SCM_VERSION            "@SCM_VERSION@"
-                                   
+#define UCT_SCM_BRANCH             "@SCM_BRANCH@"
+
 #define UCT_MINOR_BIT              (16UL)
 #define UCT_MAJOR_BIT              (24UL)
 #define UCT_API                    ((@MAJOR_VERSION@L<<UCT_MAJOR_BIT)|(@MINOR_VERSION@L << UCT_MINOR_BIT))

--- a/ucx.pc.in
+++ b/ucx.pc.in
@@ -6,6 +6,6 @@ includedir = @includedir@
 
 Name: @PACKAGE@
 Description: Unified Communication X Library
-Version: @MAJOR_VERSION@.@MINOR_VERSION@
-Cflags: -I${includedir} 
+Version: @VERSION@
+Cflags: -I${includedir}
 Libs: -L${libdir} -lucs -luct -lucp


### PR DESCRIPTION
## Why?
- Print branch information in ucx_info
- Allow embedding custom version string in the UCX version string
