### PR TITLE
UCP/CORE: Support AM align offset

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -162,17 +162,18 @@ enum ucp_feature {
  * present. It is used to enable backward compatibility support.
  */
 enum ucp_worker_params_field {
-    UCP_WORKER_PARAM_FIELD_THREAD_MODE  = UCS_BIT(0), /**< UCP thread mode */
-    UCP_WORKER_PARAM_FIELD_CPU_MASK     = UCS_BIT(1), /**< Worker's CPU bitmap */
-    UCP_WORKER_PARAM_FIELD_EVENTS       = UCS_BIT(2), /**< Worker's events bitmap */
-    UCP_WORKER_PARAM_FIELD_USER_DATA    = UCS_BIT(3), /**< User data */
-    UCP_WORKER_PARAM_FIELD_EVENT_FD     = UCS_BIT(4), /**< External event file
-                                                           descriptor */
-    UCP_WORKER_PARAM_FIELD_FLAGS        = UCS_BIT(5), /**< Worker flags */
-    UCP_WORKER_PARAM_FIELD_NAME         = UCS_BIT(6), /**< Worker name */
-    UCP_WORKER_PARAM_FIELD_AM_ALIGNMENT = UCS_BIT(7), /**< Alignment of active
-                                                           messages on the receiver */
-    UCP_WORKER_PARAM_FIELD_CLIENT_ID    = UCS_BIT(8)  /**< Client id */
+    UCP_WORKER_PARAM_FIELD_THREAD_MODE     = UCS_BIT(0), /**< UCP thread mode */
+    UCP_WORKER_PARAM_FIELD_CPU_MASK        = UCS_BIT(1), /**< Worker's CPU bitmap */
+    UCP_WORKER_PARAM_FIELD_EVENTS          = UCS_BIT(2), /**< Worker's events bitmap */
+    UCP_WORKER_PARAM_FIELD_USER_DATA       = UCS_BIT(3), /**< User data */
+    UCP_WORKER_PARAM_FIELD_EVENT_FD        = UCS_BIT(4), /**< External event file
+                                                              descriptor */
+    UCP_WORKER_PARAM_FIELD_FLAGS           = UCS_BIT(5), /**< Worker flags */
+    UCP_WORKER_PARAM_FIELD_NAME            = UCS_BIT(6), /**< Worker name */
+    UCP_WORKER_PARAM_FIELD_AM_ALIGNMENT    = UCS_BIT(7), /**< Alignment of active
+                                                              messages on the receiver */
+    UCP_WORKER_PARAM_FIELD_CLIENT_ID       = UCS_BIT(8), /**< Client id */
+    UCP_WORKER_PARAM_FIELD_AM_ALIGN_OFFSET = UCS_BIT(9)  /**< Alignment offset */
 };
 
 
@@ -1310,6 +1311,14 @@ typedef struct ucp_worker_params {
     * using @ref ucp_conn_request_query.
     */
     uint64_t                client_id;
+
+    /**
+     * Align the active message data with this bytes offset. For example,
+     * specifying a value of 16 means offset 16 in the active message payload
+     * will be aligned to @ref am_alignment boundary.
+     * The default value is 0 (align the payload start address).
+     */
+    size_t                  am_align_offset;
 } ucp_worker_params_t;
 
 

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1254,7 +1254,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
          * provided in UCT descriptor, allocate new aligned data buffer from UCP
          * AM mpool instead of using UCT descriptor directly.
          */
-        if (ucs_unlikely((uintptr_t)data % worker->am.alignment)) {
+        if (ucs_unlikely(((uintptr_t)data + worker->am.align_offset) %
+                         worker->am.alignment)) {
             am_flags &= ~UCT_CB_PARAM_FLAG_DESC;
         }
 
@@ -1456,7 +1457,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
     ucp_ep_h ep;
     size_t total_length, padding;
     uint64_t recv_flags;
-    void *user_hdr;
+    void *user_hdr, *first_rdesc_data;
 
     first_ftr = UCS_PTR_BYTE_OFFSET(am_data, am_length - sizeof(*first_ftr));
 
@@ -1503,9 +1504,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
         return UCS_OK; /* release UCT desc */
     }
 
-    padding = ucs_padding((uintptr_t)UCS_PTR_BYTE_OFFSET(
-                                  first_rdesc + 1, UCP_AM_FIRST_FRAG_META_LEN),
-                          worker->am.alignment);
+    first_rdesc_data = UCS_PTR_BYTE_OFFSET(first_rdesc + 1,
+                                           UCP_AM_FIRST_FRAG_META_LEN +
+                                                   worker->am.align_offset);
+    padding = ucs_padding((uintptr_t)first_rdesc_data, worker->am.alignment);
 
     first_rdesc->payload_offset     = UCP_AM_FIRST_FRAG_META_LEN + padding;
     first_rdesc->am_first.remaining = first_ftr->total_size;

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -47,6 +47,7 @@ UCS_ARRAY_DECLARE_TYPE(ucp_am_cbs, unsigned, ucp_am_entry_t)
 
 typedef struct ucp_am_info {
     size_t                   alignment;
+    size_t                   align_offset;
     ucs_array_t(ucp_am_cbs)  cbs;
 } ucp_am_info_t;
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -799,7 +799,7 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
                    const char *name, ucp_recv_desc_t **rdesc_p)
 {
     ucp_recv_desc_t *rdesc;
-    void *data_hdr;
+    void *data_hdr, *rdesc_data;
     ucs_status_t status;
     size_t padding;
 
@@ -819,8 +819,10 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
             return UCS_ERR_NO_MEMORY;
         }
 
-        padding = ucs_padding((uintptr_t)(rdesc + 1), alignment);
-        rdesc   = (ucp_recv_desc_t*)UCS_PTR_BYTE_OFFSET(rdesc, padding);
+        rdesc_data = UCS_PTR_BYTE_OFFSET(rdesc + 1, worker->am.align_offset);
+        padding    = ucs_padding((uintptr_t)rdesc_data, alignment);
+        rdesc      = (ucp_recv_desc_t*)UCS_PTR_BYTE_OFFSET(rdesc, padding);
+
         rdesc->release_desc_offset = padding;
 
         /* No need to initialize rdesc->priv_length here, because it is only

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1168,7 +1168,9 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     if (worker->am.alignment > 1) {
         iface_params->field_mask     |= UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT |
                                         UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET;
-        iface_params->am_align_offset = sizeof(ucp_am_hdr_t);
+        iface_params->am_align_offset = sizeof(ucp_am_hdr_t) +
+                                        (worker->am.align_offset %
+                                         worker->am.alignment);
         iface_params->am_alignment    = worker->am.alignment;
     }
 
@@ -2175,6 +2177,8 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
                                            NULL);
     worker->am.alignment = UCP_PARAM_VALUE(WORKER, params, am_alignment,
                                            AM_ALIGNMENT, 1);
+    worker->am.align_offset = UCP_PARAM_VALUE(WORKER, params, am_align_offset,
+                                              AM_ALIGN_OFFSET, 0);
     worker->client_id    = UCP_PARAM_VALUE(WORKER, params, client_id, CLIENT_ID, 0);
     if ((params->field_mask & UCP_WORKER_PARAM_FIELD_NAME) &&
         (params->name != NULL)) {


### PR DESCRIPTION
## What
Support aligning AM data by a custom user-provided offset.

## Why ?
Configuration flexibility: allow aligning the UCT memory pool element, instead of aligning the data.
