### PR TITLE
GTEST/UCP: Add AM RNDV gtest

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -468,13 +468,25 @@ public:
     }
 
     struct rx_am_msg_arg {
+        entity &receiver;
         bool received;
         void *hdr;
         void *buf;
+        void *rreq;
 
-        rx_am_msg_arg(void *_hdr, void *_buf) :
-                received(false), hdr(_hdr), buf(_buf) { }
+        rx_am_msg_arg(entity &_receiver, void *_hdr, void *_buf) :
+                receiver(_receiver), received(false), hdr(_hdr), buf(_buf),
+                rreq(NULL) { }
     };
+
+    static void rx_am_msg_data_recv_cb(void *request, ucs_status_t status,
+                                       size_t length, void *user_data)
+    {
+        EXPECT_UCS_OK(status);
+        volatile rx_am_msg_arg *rx_arg =
+                reinterpret_cast<volatile rx_am_msg_arg*>(user_data);
+        rx_arg->received = true;
+    }
 
     static ucs_status_t rx_am_msg_cb(void *arg, const void *header,
                                      size_t header_length, void *data,
@@ -486,7 +498,22 @@ public:
         EXPECT_FALSE(rx_arg->received);
 
         memcpy(rx_arg->hdr, header, header_length);
-        memcpy(rx_arg->buf, data, length);
+        if (param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV) {
+            ucp_request_param_t recv_param;
+            recv_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                      UCP_OP_ATTR_FIELD_USER_DATA;
+            recv_param.cb.recv_am   = rx_am_msg_data_recv_cb;
+            recv_param.user_data    = const_cast<rx_am_msg_arg*>(rx_arg);
+
+            void *rreq = ucp_am_recv_data_nbx(rx_arg->receiver.worker(), data,
+                                              rx_arg->buf, length, &recv_param);
+            if (UCS_PTR_IS_PTR(rreq)) {
+                rx_arg->rreq = rreq;
+                return UCS_OK;
+            }
+        } else {
+            memcpy(rx_arg->buf, data, length);
+        }
 
         rx_arg->received = true;
         return UCS_OK;
@@ -514,7 +541,7 @@ public:
     {
         const uint64_t send_data = ucs_generate_uuid(0);
         uint64_t recv_data       = 0;
-        rx_am_msg_arg am_rx_arg(NULL, &recv_data);
+        rx_am_msg_arg am_rx_arg(to, NULL, &recv_data);
         ucs_status_t send_status;
 
         if (send_recv_type == SEND_RECV_AM) {
@@ -546,6 +573,7 @@ public:
         }
 
         if (send_recv_type == SEND_RECV_AM) {
+            request_wait(am_rx_arg.rreq);
             wait_for_flag(&am_rx_arg.received);
             set_am_data_handler(to, 0, NULL, NULL);
         } else {
@@ -2404,7 +2432,7 @@ protected:
             std::string shdr(hdr_size, 'x');
             std::string rhdr(hdr_size, 'y');
 
-            rx_am_msg_arg arg(&rhdr[0], &rb[0]);
+            rx_am_msg_arg arg(receiver(), &rhdr[0], &rb[0]);
             set_am_data_handler(receiver(), 0, rx_am_msg_cb, &arg);
 
             ucp_request_param_t param = {};
@@ -2413,6 +2441,9 @@ protected:
                                                         &sb[0], size, &param);
             request_wait(sreq);
             wait_for_flag(&arg.received);
+            // wait for receive request completion after 'received' flag set to
+            // make sure AM receive handler was invoked and 'rreq' was posted
+            request_wait(arg.rreq);
             EXPECT_TRUE(arg.received);
 
             compare_buffers(sb, rb);
@@ -2608,6 +2639,11 @@ UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_1k,
 
 UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_64k,
            "ZCOPY_THRESH=512", "RNDV_THRESH=inf")
+{
+    test_am_send_recv(64 * UCS_KBYTE);
+}
+
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_64k, "RNDV_THRESH=0")
 {
     test_am_send_recv(64 * UCS_KBYTE);
 }


### PR DESCRIPTION
## What

Add gtests for testing AM RNDV in sockaddr.

## Why ?

To cover AM RNDV functionality.
Fixes #7825

## How ?

1. Handle RNDV data in AM receive callback.
2. Add testing of the following scenarios in test_ucp_sockaddr_protocols:
- 1 KB
- 64 KB
- 2 MB