### PR TITLE
UCP/TAG/SEND: fixed datatype issue - v1.12

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@
 ##
 #
 
-## 1.12.0 (January 12, 2022)
+## 1.12.0 RC3 (January 11, 2022)
 ### Features:
 #### Core
 * Added beta-level support for Go language bindings
@@ -120,6 +120,7 @@
 * Multiple fixes in general error flow
 * Fixed fallback to PUT pipeline in rendezvous protocol
 * Reduced default value of keep-alive interval to 20 seconds
+* Fixes in tag_send datatype processing
 #### UCT
 * Fixed deadlock in TCP
 * Suppressed EHOSTUNREACH error in TCP sockcm

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -264,9 +264,15 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_send_nbx,
                                              contig_length, tag);
             ucp_request_send_check_status(status, ret, goto out);
         }
-    } else {
+    } else if (attr_mask == UCP_OP_ATTR_FLAG_NO_IMM_CMPL) {
         datatype      = ucp_dt_make_contig(1);
         contig_length = count;
+    } else {
+        /* UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL */
+        datatype = param->datatype;
+        if (UCP_DT_IS_CONTIG(datatype)) {
+            contig_length = ucp_contig_dt_length(datatype, count);
+        }
     }
 
     if (ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {


### PR DESCRIPTION
- added slow path where datatype is processed

back port from https://github.com/openucx/ucx/pull/7766

(cherry picked from commit fc4e270cbe355dd6c30c611d2247adab3ae2609f)
