### PR TITLE
UCP/TAG: Fix probe for multi-fragment eager

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -88,8 +88,15 @@ enum {
     UCP_RECV_DESC_FLAG_EAGER_LAST       = UCS_BIT(5), /* Last fragment of eager tag message.
                                                          Used by tag offload protocol. */
     UCP_RECV_DESC_FLAG_RNDV             = UCS_BIT(6), /* Rendezvous request */
-    UCP_RECV_DESC_FLAG_RECV_STARTED     = UCS_BIT(7), /* Receive operation on this descriptor
-                                                         was initiated by ucp_am_recv_data_nbx */
+    UCP_RECV_DESC_FLAG_RECV_STARTED     = UCS_BIT(7), /* Used in two different flows:
+                                                         1) AM: receive operation on this
+                                                            descriptor was initiated by
+                                                            ucp_am_recv_data_nbx
+                                                         2) TAG offload eager: multi fragment
+                                                            eager message is being received, but
+                                                            not all fragments received yet. Once
+                                                            all fragments arrive, this flag is cleared.
+                                                            Note: it is set for the first fragment only. */
     UCP_RECV_DESC_FLAG_MALLOC           = UCS_BIT(8), /* Descriptor was allocated with malloc
                                                          and must be freed, not returned to the
                                                          memory pool or UCT */

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -363,6 +363,7 @@ ucp_tag_offload_eager_middle_handler(ucp_worker_h worker, void *data,
     ucp_tag_frag_match_t *matchq       = ucs_unaligned_ptr(&priv_hdr->matchq);
     ucp_recv_desc_t *rdesc             = NULL;
     ucp_offload_ssend_hdr_t *sync_hdr;
+    ucp_recv_desc_t *first_rdesc;
     void *hdr;
     size_t hdr_length;
     ucs_status_t status;
@@ -374,7 +375,9 @@ ucp_tag_offload_eager_middle_handler(ucp_worker_h worker, void *data,
     priv_hdr->total_length += length;
 
     if (!(tl_flags & UCT_CB_PARAM_FLAG_MORE)) {
-        flags |= UCP_RECV_DESC_FLAG_EAGER_LAST;
+        first_rdesc         = (ucp_recv_desc_t*)priv_hdr - 1;
+        flags              |= UCP_RECV_DESC_FLAG_EAGER_LAST;
+        first_rdesc->flags &= ~UCP_RECV_DESC_FLAG_RECV_STARTED;
     }
 
     /* Last fragment may contain immediate data, indicating that it is
@@ -456,9 +459,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_offload_unexp_eager,
 
     if (tl_flags & UCT_CB_PARAM_FLAG_MORE) {
         /* First part of the fragmented message */
-        return ucp_tag_offload_eager_first_handler(worker, data, length,
-                                                   tl_flags, stag, flags,
-                                                   context);
+        return ucp_tag_offload_eager_first_handler(
+                   worker, data, length, tl_flags, stag,
+                   flags | UCP_RECV_DESC_FLAG_RECV_STARTED, context);
     }
 
     /* Sync eager only packet */

--- a/src/ucp/tag/probe.c
+++ b/src/ucp/tag/probe.c
@@ -33,7 +33,7 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
     ucs_trace_req("probe_nb tag %"PRIx64"/%"PRIx64" remove=%d", tag, tag_mask,
                   rem);
 
-    rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, rem, "probe");
+    rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 0, "probe");
     if (rdesc != NULL) {
         flags            = rdesc->flags;
         info->sender_tag = ucp_rdesc_get_tag(rdesc);
@@ -41,6 +41,15 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
         if (flags & UCP_RECV_DESC_FLAG_EAGER_ONLY) {
             info->length = rdesc->length - rdesc->payload_offset;
         } else if (flags & UCP_RECV_DESC_FLAG_EAGER) {
+            if (ucs_test_all_flags(flags, UCP_RECV_DESC_FLAG_EAGER_OFFLOAD |
+                                          UCP_RECV_DESC_FLAG_RECV_STARTED)) {
+                /* Do not return the rdesc, because not all fragments arrived
+                 * yet. Need to wait until last fragment arrives to know the
+                 * correct length of the message. */
+                rdesc = NULL;
+                goto out;
+            }
+
             UCS_STATIC_ASSERT(
                     ucs_offsetof(ucp_eager_first_hdr_t, total_len) ==
                     ucs_offsetof(ucp_offload_first_desc_t, total_length));
@@ -49,8 +58,13 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
             ucs_assert(flags & UCP_RECV_DESC_FLAG_RNDV);
             info->length = ucp_tag_rndv_rts_from_rdesc(rdesc)->size;
         }
+
+        if (rem) {
+             ucp_tag_unexp_remove(rdesc);
+        }
     }
 
+out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
 
     return rdesc;

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -374,9 +374,6 @@ UCS_TEST_P(test_ucp_tag_offload, eager_multi_probe,
 {
     activate_offload(sender());
 
-    // TODO: Update length to bigger value so that multi-fragment eager is used
-    //       when multi-eager offload probe issue is fixed (like below).
-    // size_t length = ucp_ep_config(sender().ep())->tag.rndv.am_thresh.remote - 1;
     size_t length = ucp_ep_config(sender().ep())->tag.rndv.am_thresh.remote - 1;
     ucp_tag_t tag = 0x11;
     std::vector<uint8_t> sendbuf(length);
@@ -389,7 +386,7 @@ UCS_TEST_P(test_ucp_tag_offload, eager_multi_probe,
     ucp_tag_message_h msg = NULL;
     ucs_time_t deadline = ucs::get_deadline();
     while ((msg == NULL) && (ucs_get_time() < deadline)) {
-        short_progress_loop();
+        progress();
         msg = ucp_tag_probe_nb(receiver().worker(), tag, 0xffff, 1, &info);
     }
     EXPECT_EQ(length, info.length);


### PR DESCRIPTION
## What
Fix `ucp_tag_probe_nb()` for multi-fragment eager protocol with tag offload

## Why ?
With tag_offload and multi eager the total message length is not known until all fragments arrive, because there is no room for the `total_length` in tag offload headers. Thus, without this fix, probe returns incorrect length for any found/probed message which is not fully arrived yet.

## How ?
1. Set `UCP_RECV_DESC_FLAG_RECV_STARTED` flag for the first eager fragment and clear it when the last fragment arrives.
2. When probe finds some message (note that only first fragments are added to the unexpected queue), this flag is checked. If it is present, the total_length is not known yet and probe returns `NULL`. Once it is cleared, it is safe to return the `rdesc`  from the probe
3. This should not introduce any ordering issues, because multi-rail is not supported with tag offload and fragments of the same message will not be mixed with any other data from the same sender


