### PR TITLE
DOCS/DOXYGEN: Fix PDF generation with doxygen 2019

### DIFF
--- a/docs/doxygen/header.tex.in
+++ b/docs/doxygen/header.tex.in
@@ -10,6 +10,7 @@
 \usepackage{makeidx}
 \usepackage{multicol}
 \usepackage{multirow}
+\usepackage{ifthen} % workaround doxygen 2019
 \PassOptionsToPackage{warn}{textcomp}
 \usepackage{textcomp}
 \usepackage[nointegrals]{wasysym}


### PR DESCRIPTION
## Why
Workaround "Undefined control sequence" error in doxygen doc generation, ref: doxygen/doxygen#7609