### PR TITLE
UCP/PROTO: Move protocol debugging code to new file: proto_debug.c

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -51,6 +51,7 @@ noinst_HEADERS = \
 	proto/proto_init.h \
 	proto/proto_common.h \
 	proto/proto_common.inl \
+	proto/proto_debug.h \
 	proto/proto_multi.h \
 	proto/proto_multi.inl \
 	proto/proto_select.h \
@@ -114,6 +115,7 @@ libucp_la_SOURCES = \
 	proto/proto_am.c \
 	proto/proto_init.c \
 	proto/proto_common.c \
+	proto/proto_debug.c \
 	proto/proto_reconfig.c \
 	proto/proto_multi.c \
 	proto/proto_select.c \

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -22,7 +22,7 @@
 #include <ucp/tag/eager.h>
 #include <ucp/tag/offload.h>
 #include <ucp/proto/proto_common.h>
-#include <ucp/proto/proto_select.h>
+#include <ucp/proto/proto_debug.h>
 #include <ucp/rndv/rndv.h>
 #include <ucp/stream/stream.h>
 #include <ucp/core/ucp_listener.h>

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -14,7 +14,7 @@
 #include "ucp_request.inl"
 
 #include <ucp/proto/proto_am.h>
-#include <ucp/proto/proto_select.h>
+#include <ucp/proto/proto_debug.h>
 #include <ucp/tag/tag_rndv.h>
 
 #include <ucs/datastruct/mpool.inl>

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -13,6 +13,7 @@
 #include "ucp_ep.inl"
 
 #include <ucp/rma/rma.h>
+#include <ucp/proto/proto_debug.h>
 #include <ucs/datastruct/mpool.inl>
 #include <ucs/profile/profile.h>
 #include <ucs/type/float8.h>

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -10,7 +10,6 @@
 #include "ucp_types.h"
 
 #include <ucp/core/ucp_context.h>
-#include <ucp/proto/proto_select.h>
 
 
 /**

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -8,7 +8,9 @@
 #  include "config.h"
 #endif
 
+#include "proto_debug.h"
 #include "proto_common.inl"
+
 #include <uct/api/v2/uct_v2.h>
 
 

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -13,38 +13,6 @@
 #include <uct/api/v2/uct_v2.h>
 
 
-/* Format string to display a protocol time */
-#define UCP_PROTO_TIME_FMT(_time_var) " " #_time_var ": %.2f ns"
-#define UCP_PROTO_TIME_ARG(_time_val) ((_time_val) * 1e9)
-
-/* Format string to display a protocol performance function time */
-#define UCP_PROTO_PERF_FUNC_TIME_FMT "%.2f+%.3f*N"
-#define UCP_PROTO_PERF_FUNC_TIME_ARG(_perf_func) \
-    ((_perf_func)->c * 1e9), ((_perf_func)->m * 1e9 * UCS_KBYTE)
-
-/* Format string to display a protocol performance function bandwidth */
-#define UCP_PROTO_PERF_FUNC_BW_FMT "%.2f"
-#define UCP_PROTO_PERF_FUNC_BW_ARG(_perf_func) \
-    (1.0 / ((_perf_func)->m * UCS_MBYTE))
-
-/* Format string to display a protocol performance function */
-#define UCP_PROTO_PERF_FUNC_FMT(_perf_var) " " #_perf_var ": " \
-    UCP_PROTO_PERF_FUNC_TIME_FMT " ns/KB, " \
-    UCP_PROTO_PERF_FUNC_BW_FMT " MB/s"
-#define UCP_PROTO_PERF_FUNC_ARG(_perf_func) \
-    UCP_PROTO_PERF_FUNC_TIME_ARG(_perf_func), \
-    UCP_PROTO_PERF_FUNC_BW_ARG(_perf_func)
-
-/* Format string to display a protocol performance estimations
- * of different types. See ucp_proto_perf_type_t */
-#define UCP_PROTO_PERF_FUNC_TYPES_FMT \
-    UCP_PROTO_PERF_FUNC_FMT(sigle) \
-    UCP_PROTO_PERF_FUNC_FMT(multi)
-#define UCP_PROTO_PERF_FUNC_TYPES_ARG(_perf_func) \
-    UCP_PROTO_PERF_FUNC_ARG((&(_perf_func)[UCP_PROTO_PERF_TYPE_SINGLE])), \
-    UCP_PROTO_PERF_FUNC_ARG((&(_perf_func)[UCP_PROTO_PERF_TYPE_MULTI]))
-
-
 /* Constant for "undefined"/"not-applicable" structure offset */
 #define UCP_PROTO_COMMON_OFFSET_INVALID PTRDIFF_MAX
 

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2022, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "proto_debug.h"
+#include "proto_select.inl"
+
+
+void ucp_proto_select_perf_str(const ucs_linear_func_t *perf, char *time_str,
+                               size_t time_str_max, char *bw_str,
+                               size_t bw_str_max)
+{
+    /* Estimated time per 1024 bytes */
+    ucs_snprintf_safe(time_str, time_str_max, UCP_PROTO_PERF_FUNC_TIME_FMT,
+                      UCP_PROTO_PERF_FUNC_TIME_ARG(perf));
+
+    /* Estimated bandwidth (MiB/s) */
+    ucs_snprintf_safe(bw_str, bw_str_max, UCP_PROTO_PERF_FUNC_BW_FMT,
+                      UCP_PROTO_PERF_FUNC_BW_ARG(perf));
+}
+
+void ucp_proto_select_init_trace_caps(
+        ucp_proto_id_t proto_id, const ucp_proto_init_params_t *init_params)
+{
+    ucp_proto_caps_t *proto_caps = init_params->caps;
+    const UCS_V_UNUSED ucs_linear_func_t *perf;
+    size_t UCS_V_UNUSED range_start, range_end;
+    ucs_string_buffer_t config_strb;
+    int UCS_V_UNUSED range_index;
+    char min_length_str[64];
+    char thresh_str[64];
+
+    ucs_string_buffer_init(&config_strb);
+    ucp_proto_id_call(proto_id, config_str, proto_caps->min_length, SIZE_MAX,
+                      init_params->priv, &config_strb);
+    ucs_trace("initialized protocol %s min_length %s cfg_thresh %s %s",
+              init_params->proto_name,
+              ucs_memunits_to_str(proto_caps->min_length, min_length_str,
+                                  sizeof(min_length_str)),
+              ucs_memunits_to_str(proto_caps->cfg_thresh, thresh_str,
+                                  sizeof(thresh_str)),
+              ucs_string_buffer_cstr(&config_strb));
+    ucs_string_buffer_cleanup(&config_strb);
+
+    ucs_log_indent(1);
+    range_start = 0;
+    for (range_index = 0; range_index < proto_caps->num_ranges; ++range_index) {
+        range_start = ucs_max(range_start, proto_caps->min_length);
+        range_end   = proto_caps->ranges[range_index].max_length;
+        if (range_end > range_start) {
+            perf = proto_caps->ranges[range_index].perf;
+            ucs_trace("range[%d] %s %s" UCP_PROTO_PERF_FUNC_TYPES_FMT,
+                      range_index, proto_caps->ranges[range_index].name,
+                      ucs_memunits_range_str(range_start, range_end, thresh_str,
+                                             sizeof(thresh_str)),
+                      UCP_PROTO_PERF_FUNC_TYPES_ARG(perf));
+        }
+        range_start = range_end + 1;
+    }
+    ucs_log_indent(-1);
+}
+
+void ucp_proto_select_dump_thresholds(
+        const ucp_proto_select_elem_t *select_elem, ucs_string_buffer_t *strb)
+{
+    static const char *proto_info_fmt = "    %-18s %-18s %s\n";
+    const ucp_proto_threshold_elem_t *thresh_elem;
+    ucs_string_buffer_t proto_config_strb;
+    size_t range_start, range_end;
+    char range_str[128];
+
+    range_start = 0;
+    thresh_elem = select_elem->thresholds;
+    ucs_string_buffer_appendf(strb, proto_info_fmt, "SIZE", "PROTOCOL",
+                              "CONFIGURATION");
+    do {
+        ucs_string_buffer_init(&proto_config_strb);
+
+        range_end = thresh_elem->max_msg_length;
+        thresh_elem->proto_config.proto->config_str(
+                range_start, range_end, thresh_elem->proto_config.priv,
+                &proto_config_strb);
+
+        ucs_memunits_range_str(range_start, range_end, range_str,
+                               sizeof(range_str));
+
+        ucs_string_buffer_appendf(strb, proto_info_fmt, range_str,
+                                  thresh_elem->proto_config.proto->name,
+                                  ucs_string_buffer_cstr(&proto_config_strb));
+
+        ucs_string_buffer_cleanup(&proto_config_strb);
+
+        range_start = range_end + 1;
+        ++thresh_elem;
+    } while (range_end != SIZE_MAX);
+}
+
+static void
+ucp_proto_select_dump_perf(const ucp_proto_select_elem_t *select_elem,
+                           ucp_proto_perf_type_t perf_type,
+                           ucs_string_buffer_t *strb)
+{
+    static const char *proto_info_fmt = "    %-16s %-20s %s\n";
+    const ucp_proto_select_range_t *range_elem;
+    size_t range_start, range_end;
+    char range_str[128];
+    char time_str[64];
+    char bw_str[64];
+
+    range_start = 0;
+    range_elem  = select_elem->perf_ranges;
+    ucs_string_buffer_appendf(strb, proto_info_fmt, "SIZE", "TIME (nsec)",
+                              "BANDWIDTH (MiB/s)");
+    do {
+        range_end = range_elem->super.max_length;
+
+        ucp_proto_select_perf_str(&range_elem->super.perf[perf_type], time_str,
+                                  sizeof(time_str), bw_str, sizeof(bw_str));
+        ucs_memunits_range_str(range_start, range_end, range_str,
+                               sizeof(range_str));
+
+        ucs_string_buffer_appendf(strb, proto_info_fmt, range_str, time_str,
+                                  bw_str);
+
+        range_start = range_end + 1;
+        ++range_elem;
+    } while (range_end != SIZE_MAX);
+}
+
+static void
+ucp_proto_select_elem_dump(ucp_worker_h worker,
+                           ucp_worker_cfg_index_t ep_cfg_index,
+                           ucp_worker_cfg_index_t rkey_cfg_index,
+                           const ucp_proto_select_param_t *select_param,
+                           const ucp_proto_select_elem_t *select_elem,
+                           ucs_string_buffer_t *strb)
+{
+    UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
+    size_t i;
+
+    ucp_proto_select_param_str(select_param, &sel_param_strb);
+
+    ucs_string_buffer_appendf(strb, "  %s\n  ",
+                              ucs_string_buffer_cstr(&sel_param_strb));
+    for (i = 0; i < ucs_string_buffer_length(&sel_param_strb); ++i) {
+        ucs_string_buffer_appendf(strb, "=");
+    }
+    ucs_string_buffer_appendf(strb, "\n");
+
+    ucs_string_buffer_appendf(strb, "\n  Selected protocols:\n");
+    ucp_proto_select_dump_thresholds(select_elem, strb);
+
+    ucs_string_buffer_appendf(strb, "\n  Performance estimation:\n");
+    ucp_proto_select_dump_perf(select_elem,
+                               ucp_proto_select_param_perf_type(select_param),
+                               strb);
+}
+
+void ucp_proto_select_dump(ucp_worker_h worker,
+                           ucp_worker_cfg_index_t ep_cfg_index,
+                           ucp_worker_cfg_index_t rkey_cfg_index,
+                           const ucp_proto_select_t *proto_select,
+                           ucs_string_buffer_t *strb)
+{
+    ucp_proto_select_elem_t select_elem;
+    ucp_proto_select_key_t key;
+    char info[256];
+
+    ucp_worker_print_used_tls(&worker->ep_config[ep_cfg_index].key,
+                              worker->context, ep_cfg_index, info,
+                              sizeof(info));
+    ucs_string_buffer_appendf(strb, "\nProtocol selection for %s", info);
+
+    if (rkey_cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
+        ucs_string_buffer_appendf(strb, "rkey_cfg[%d]: ", rkey_cfg_index);
+        ucp_rkey_config_dump_brief(&worker->rkey_config[rkey_cfg_index].key,
+                                   strb);
+    }
+    ucs_string_buffer_appendf(strb, "\n\n");
+
+    if (kh_size(&proto_select->hash) == 0) {
+        ucs_string_buffer_appendf(strb, "   (No elements)\n");
+        return;
+    }
+
+    kh_foreach(&proto_select->hash, key.u64, select_elem,
+               ucp_proto_select_elem_dump(worker, ep_cfg_index, rkey_cfg_index,
+                                          &key.param, &select_elem, strb))
+}
+
+void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
+                                 const char *name, ucs_string_buffer_t *strb)
+{
+    if (select_short->lane == UCP_NULL_LANE) {
+        return;
+    }
+
+    ucs_string_buffer_appendf(strb, "\n%s: ", name);
+
+    if (select_short->max_length_unknown_mem >= 0) {
+        ucs_string_buffer_appendf(strb, "<= %zd",
+                                  select_short->max_length_unknown_mem);
+    } else {
+        ucs_string_buffer_appendf(strb, "<= %zd and host memory",
+                                  select_short->max_length_host_mem);
+    }
+
+    ucs_string_buffer_appendf(strb, ", using lane %d rkey_index %d\n",
+                              select_short->lane, select_short->rkey_index);
+}
+
+void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
+                                ucs_string_buffer_t *strb)
+{
+    const char *sysdev_name;
+    uint32_t op_attr_mask;
+
+    op_attr_mask = ucp_proto_select_op_attr_from_flags(select_param->op_flags);
+    ucs_string_buffer_appendf(strb, "%s(",
+                              ucp_operation_names[select_param->op_id]);
+
+    ucs_string_buffer_appendf(strb, "%s",
+                              ucp_datatype_class_names[select_param->dt_class]);
+
+    if (select_param->sg_count > 1) {
+        ucs_string_buffer_appendf(strb, "[%d]", select_param->sg_count);
+    }
+
+    if (select_param->mem_type != UCS_MEMORY_TYPE_HOST) {
+        ucs_string_buffer_appendf(
+                strb, ", %s", ucs_memory_type_names[select_param->mem_type]);
+    }
+
+    if (select_param->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+        sysdev_name = ucs_topo_sys_device_get_name(select_param->sys_dev);
+        ucs_string_buffer_appendf(strb, ", %s", sysdev_name);
+    }
+
+    if (op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) {
+        ucs_string_buffer_appendf(strb, ", fast-completion");
+    }
+
+    if (op_attr_mask & UCP_OP_ATTR_FLAG_MULTI_SEND) {
+        ucs_string_buffer_appendf(strb, ", multi");
+    }
+
+    ucs_string_buffer_rtrim(strb, ",");
+    ucs_string_buffer_appendf(strb, ")");
+}
+
+void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
+                                  size_t min_length, size_t max_length,
+                                  ucs_string_buffer_t *strb)
+{
+    size_t range_start, range_end;
+    const ucp_proto_t *proto;
+    char str[64];
+
+    range_start = 0;
+    do {
+        range_end = thresh_elem->max_msg_length;
+
+        /* Print only protocols within the range provided by {min,max}_length */
+        if ((range_end >= min_length) && (range_start <= max_length)) {
+            proto = thresh_elem->proto_config.proto;
+            ucs_string_buffer_appendf(strb, "%s(", proto->name);
+            proto->config_str(ucs_max(range_start, min_length),
+                              ucs_min(range_end, max_length),
+                              thresh_elem->proto_config.priv, strb);
+            ucs_string_buffer_appendf(strb, ")");
+
+            if (range_end < max_length) {
+                ucs_memunits_to_str(thresh_elem->max_msg_length, str,
+                                    sizeof(str));
+                ucs_string_buffer_appendf(strb, "<=%s<", str);
+            }
+        }
+
+        ++thresh_elem;
+        range_start = range_end + 1;
+    } while (range_end < max_length);
+
+    ucs_string_buffer_rtrim(strb, "<");
+}
+
+void ucp_proto_select_config_str(ucp_worker_h worker,
+                                 const ucp_proto_config_t *proto_config,
+                                 size_t msg_length, ucs_string_buffer_t *strb)
+{
+    const ucp_proto_select_elem_t *select_elem;
+    ucp_worker_cfg_index_t new_key_cfg_index;
+    const ucp_proto_select_range_t *range;
+    ucp_proto_select_t *proto_select;
+    ucp_proto_perf_type_t perf_type;
+    double send_time;
+
+    ucs_assert(worker->context->config.ext.proto_enable);
+
+    /* Print selection parameters */
+    ucp_proto_select_param_str(&proto_config->select_param, strb);
+    ucs_string_buffer_appendf(strb, ": %s ", proto_config->proto->name);
+    proto_config->proto->config_str(msg_length, msg_length, proto_config->priv,
+                                    strb);
+
+    /* Find protocol selection root */
+    proto_select = ucp_proto_select_get(worker, proto_config->ep_cfg_index,
+                                        proto_config->rkey_cfg_index,
+                                        &new_key_cfg_index);
+    if (proto_select == NULL) {
+        return;
+    }
+
+    /* Emulate protocol selection process */
+    ucs_assert(new_key_cfg_index == proto_config->rkey_cfg_index);
+    select_elem = ucp_proto_select_lookup_slow(worker, proto_select,
+                                               proto_config->ep_cfg_index,
+                                               proto_config->rkey_cfg_index,
+                                               &proto_config->select_param);
+    if (select_elem == NULL) {
+        return;
+    }
+
+    /* Find the relevant performance range */
+    range = select_elem->perf_ranges;
+    while (range->super.max_length < msg_length) {
+        ++range;
+    }
+
+    perf_type = ucp_proto_select_param_perf_type(&proto_config->select_param);
+    send_time = ucs_linear_func_apply(range->super.perf[perf_type], msg_length);
+    ucs_string_buffer_appendf(strb, "  %.2f MBs / %.2f us",
+                              (msg_length / send_time) / UCS_MBYTE,
+                              send_time * UCS_USEC_PER_SEC);
+}

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCP_PROTO_DEBUG_H_
+#define UCP_PROTO_DEBUG_H_
+
+#include "proto_select.h"
+
+
+/* Format string to display a protocol time */
+#define UCP_PROTO_TIME_FMT(_time_var) " " #_time_var ": %.2f ns"
+#define UCP_PROTO_TIME_ARG(_time_val) ((_time_val) * 1e9)
+
+/* Format string to display a protocol performance function time */
+#define UCP_PROTO_PERF_FUNC_TIME_FMT "%.2f+%.3f*N"
+#define UCP_PROTO_PERF_FUNC_TIME_ARG(_perf_func) \
+    ((_perf_func)->c * 1e9), ((_perf_func)->m * 1e9 * UCS_KBYTE)
+
+/* Format string to display a protocol performance function bandwidth */
+#define UCP_PROTO_PERF_FUNC_BW_FMT "%.2f"
+#define UCP_PROTO_PERF_FUNC_BW_ARG(_perf_func) \
+    (1.0 / ((_perf_func)->m * UCS_MBYTE))
+
+/* Format string to display a protocol performance function */
+#define UCP_PROTO_PERF_FUNC_FMT(_perf_var) " " #_perf_var ": " \
+    UCP_PROTO_PERF_FUNC_TIME_FMT " ns/KB, " \
+    UCP_PROTO_PERF_FUNC_BW_FMT " MB/s"
+#define UCP_PROTO_PERF_FUNC_ARG(_perf_func) \
+    UCP_PROTO_PERF_FUNC_TIME_ARG(_perf_func), \
+    UCP_PROTO_PERF_FUNC_BW_ARG(_perf_func)
+
+/* Format string to display a protocol performance estimations
+ * of different types. See ucp_proto_perf_type_t */
+#define UCP_PROTO_PERF_FUNC_TYPES_FMT \
+    UCP_PROTO_PERF_FUNC_FMT(sigle) \
+    UCP_PROTO_PERF_FUNC_FMT(multi)
+#define UCP_PROTO_PERF_FUNC_TYPES_ARG(_perf_func) \
+    UCP_PROTO_PERF_FUNC_ARG((&(_perf_func)[UCP_PROTO_PERF_TYPE_SINGLE])), \
+    UCP_PROTO_PERF_FUNC_ARG((&(_perf_func)[UCP_PROTO_PERF_TYPE_MULTI]))
+
+
+void ucp_proto_select_perf_str(const ucs_linear_func_t *perf, char *time_str,
+                               size_t time_str_max, char *bw_str,
+                               size_t bw_str_max);
+
+
+void ucp_proto_select_init_trace_caps(
+        ucp_proto_id_t proto_id, const ucp_proto_init_params_t *init_params);
+
+
+void ucp_proto_select_dump_thresholds(
+        const ucp_proto_select_elem_t *select_elem, ucs_string_buffer_t *strb);
+
+
+void ucp_proto_select_dump(ucp_worker_h worker,
+                           ucp_worker_cfg_index_t ep_cfg_index,
+                           ucp_worker_cfg_index_t rkey_cfg_index,
+                           const ucp_proto_select_t *proto_select,
+                           ucs_string_buffer_t *strb);
+
+
+void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
+                                 const char *name, ucs_string_buffer_t *strb);
+
+
+void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
+                                ucs_string_buffer_t *strb);
+
+
+void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
+                                  size_t min_length, size_t max_length,
+                                  ucs_string_buffer_t *strb);
+
+
+/* Print protocol configuration info to a string buffer */
+void ucp_proto_select_config_str(ucp_worker_h worker,
+                                 const ucp_proto_config_t *proto_config,
+                                 size_t msg_length, ucs_string_buffer_t *strb);
+
+#endif

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -9,6 +9,7 @@
 #endif
 
 #include "proto_init.h"
+#include "proto_debug.h"
 #include "proto_select.inl"
 
 #include <ucs/datastruct/array.inl>
@@ -198,7 +199,7 @@ ucp_proto_perf_envelope_make(const ucp_proto_perf_envelope_t *list,
         new_elem->range.super.max_length  = midpoint;
         for (tmp_perf_type = 0; tmp_perf_type < UCP_PROTO_PERF_TYPE_LAST;
              tmp_perf_type++) {
-            new_elem->range.super.perf[tmp_perf_type] 
+            new_elem->range.super.perf[tmp_perf_type]
                 = best.elem->range.super.perf[tmp_perf_type];
         }
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -8,9 +8,10 @@
 #  include "config.h"
 #endif
 
+#include "proto_init.h"
+#include "proto_debug.h"
 #include "proto_common.inl"
 #include "proto_multi.inl"
-#include "proto_init.h"
 
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -8,10 +8,10 @@
 #  include "config.h"
 #endif
 
-#include "proto_select.h"
-#include "proto_select.inl"
-#include "proto_single.h"
 #include "proto_init.h"
+#include "proto_debug.h"
+#include "proto_single.h"
+#include "proto_select.inl"
 
 #include <ucp/core/ucp_context.h>
 #include <ucp/dt/dt.h>
@@ -66,20 +66,6 @@ ucp_proto_select_range_is_equal(const ucp_proto_select_range_t *range_elem1,
     return range_elem1->cfg_thresh == range_elem2->cfg_thresh;
 }
 
-static void ucp_proto_select_perf_str(const ucs_linear_func_t *perf,
-                                      char *time_str, size_t time_str_max,
-                                      char *bw_str, size_t bw_str_max)
-{
-    /* Estimated time per 1024 bytes */
-    ucs_snprintf_safe(time_str, time_str_max,
-                      UCP_PROTO_PERF_FUNC_TIME_FMT,
-                      UCP_PROTO_PERF_FUNC_TIME_ARG(perf));
-
-    /* Estimated bandwidth (MiB/s) */
-    ucs_snprintf_safe(bw_str, bw_str_max,
-                      UCP_PROTO_PERF_FUNC_BW_FMT,
-                      UCP_PROTO_PERF_FUNC_BW_ARG(perf));
-}
 
 /*
  * Select a protocol for 'msg_length', return last message length for the proto
@@ -227,49 +213,6 @@ out:
     ucs_array_cleanup_dynamic(&proto_list);
     return status;
 }
-
-static void
-ucp_proto_select_init_trace_caps(ucp_proto_id_t proto_id,
-                                 const ucp_proto_init_params_t *init_params)
-{
-    ucp_proto_caps_t *proto_caps = init_params->caps;
-    const UCS_V_UNUSED ucs_linear_func_t *perf;
-    size_t UCS_V_UNUSED range_start, range_end;
-    ucs_string_buffer_t config_strb;
-    int UCS_V_UNUSED range_index;
-    char min_length_str[64];
-    char thresh_str[64];
-
-    ucs_string_buffer_init(&config_strb);
-    ucp_proto_id_call(proto_id, config_str, proto_caps->min_length, SIZE_MAX,
-                      init_params->priv, &config_strb);
-    ucs_trace("initialized protocol %s min_length %s cfg_thresh %s %s",
-              init_params->proto_name,
-              ucs_memunits_to_str(proto_caps->min_length, min_length_str,
-                                  sizeof(min_length_str)),
-              ucs_memunits_to_str(proto_caps->cfg_thresh, thresh_str,
-                                  sizeof(thresh_str)),
-              ucs_string_buffer_cstr(&config_strb));
-    ucs_string_buffer_cleanup(&config_strb);
-
-    ucs_log_indent(1);
-    range_start = 0;
-    for (range_index = 0; range_index < proto_caps->num_ranges; ++range_index) {
-        range_start = ucs_max(range_start, proto_caps->min_length);
-        range_end   = proto_caps->ranges[range_index].max_length;
-        if (range_end > range_start) {
-            perf = proto_caps->ranges[range_index].perf;
-            ucs_trace("range[%d] %s %s" UCP_PROTO_PERF_FUNC_TYPES_FMT,
-                      range_index, proto_caps->ranges[range_index].name,
-                      ucs_memunits_range_str(range_start, range_end, thresh_str,
-                                             sizeof(thresh_str)),
-                      UCP_PROTO_PERF_FUNC_TYPES_ARG(perf));
-        }
-        range_start = range_end + 1;
-    }
-    ucs_log_indent(-1);
-}
-
 
 static ucs_status_t
 ucp_proto_select_init_protocols(ucp_worker_h worker,
@@ -479,6 +422,8 @@ static ucs_status_t ucp_proto_select_elem_init_thresh(
         }
     }
 
+    ucs_assert_always(!ucs_array_is_empty(&thresholds));
+
     select_elem->perf_ranges = ucs_array_extract_buffer(ucp_proto_ranges,
                                                         &perf_ranges);
     select_elem->thresholds  = ucs_array_extract_buffer(ucp_proto_thresh,
@@ -490,17 +435,6 @@ err:
     ucs_array_cleanup_dynamic(&perf_ranges);
     ucs_array_cleanup_dynamic(&thresholds);
     return status;
-}
-
-static ucp_proto_perf_type_t
-ucp_proto_select_param_perf_type(const ucp_proto_select_param_t *select_param)
-{
-    if (ucp_proto_select_op_attr_from_flags(select_param->op_flags) &
-        UCP_OP_ATTR_FLAG_MULTI_SEND) {
-        return UCP_PROTO_PERF_TYPE_MULTI;
-    } else {
-        return UCP_PROTO_PERF_TYPE_SINGLE;
-    }
 }
 
 static ucs_status_t
@@ -636,293 +570,6 @@ void ucp_proto_select_cleanup(ucp_proto_select_t *proto_select)
     kh_destroy_inplace(ucp_proto_select_hash, &proto_select->hash);
 }
 
-static ucs_status_t
-ucp_proto_select_dump_all(ucp_worker_h worker,
-                          ucp_worker_cfg_index_t ep_cfg_index,
-                          ucp_worker_cfg_index_t rkey_cfg_index,
-                          const ucp_proto_select_param_t *select_param,
-                          ucs_string_buffer_t *strb)
-{
-    static const char *proto_info_fmt =
-            "    %-18s %-18s %-20s %-18s %-12s %s\n";
-    ucp_proto_select_init_protocols_t *proto_init;
-    ucs_string_buffer_t config_strb;
-    ucp_proto_perf_type_t perf_type;
-    size_t range_start, range_end;
-    const ucp_proto_caps_t *caps;
-    ucp_proto_id_t proto_id;
-    ucs_status_t status;
-    char range_str[64];
-    char time_str[64];
-    char thresh_str[64];
-    char bw_str[64];
-    unsigned i;
-    void *priv;
-
-    /* Allocate on heap, since the structure is quite large */
-    proto_init = ucs_malloc(sizeof(*proto_init), "proto_init");
-    if (proto_init == NULL) {
-        status = UCS_ERR_NO_MEMORY;
-        goto out;
-    }
-
-    status = ucp_proto_select_init_protocols(worker, ep_cfg_index,
-                                             rkey_cfg_index, select_param,
-                                             proto_init);
-    if (status != UCS_OK) {
-        goto out_free;
-    }
-
-    perf_type = ucp_proto_select_param_perf_type(select_param);
-
-    ucs_string_buffer_appendf(strb, proto_info_fmt, "PROTOCOL", "SIZE",
-                              "TIME (nsec)", "BANDWIDTH (MiB/s)", "THRESHOLD",
-                              "CONFIGURATION");
-
-    ucs_for_each_bit(proto_id, proto_init->mask) {
-
-        priv = UCS_PTR_BYTE_OFFSET(proto_init->priv_buf,
-                                   proto_init->priv_offsets[proto_id]);
-        caps = &proto_init->caps[proto_id];
-
-        /* String for configured threshold */
-        ucs_memunits_to_str(caps->cfg_thresh, thresh_str, sizeof(thresh_str));
-
-        range_start = caps->min_length;
-        for (i = 0; i < caps->num_ranges; ++i) {
-            /* String for performance range */
-            range_end = caps->ranges[i].max_length;
-
-            ucs_memunits_range_str(range_start, range_end, range_str,
-                                   sizeof(range_str));
-            ucp_proto_select_perf_str(&caps->ranges[i].perf[perf_type],
-                                      time_str, sizeof(time_str), bw_str,
-                                      sizeof(bw_str));
-
-            /* Get protocol configuration */
-            ucs_string_buffer_init(&config_strb);
-            ucp_proto_id_call(proto_id, config_str, range_start, range_end,
-                              priv, &config_strb);
-
-            ucs_string_buffer_appendf(
-                    strb, proto_info_fmt,
-                    (i == 0) ? ucp_proto_id_field(proto_id, name) : "",
-                    range_str, time_str, bw_str, (i == 0) ? thresh_str : "",
-                    (i == 0) ? ucs_string_buffer_cstr(&config_strb) : "");
-
-            ucs_string_buffer_cleanup(&config_strb);
-            range_start = range_end + 1;
-        }
-
-    }
-
-    status = UCS_OK;
-
-    ucs_free(proto_init->priv_buf);
-out_free:
-    ucs_free(proto_init);
-out:
-    return status;
-}
-
-static void
-ucp_proto_select_dump_thresholds(const ucp_proto_select_elem_t *select_elem,
-                                 ucs_string_buffer_t *strb)
-{
-    static const char *proto_info_fmt = "    %-18s %-18s %s\n";
-    const ucp_proto_threshold_elem_t *thresh_elem;
-    ucs_string_buffer_t proto_config_strb;
-    size_t range_start, range_end;
-    char range_str[128];
-
-    range_start = 0;
-    thresh_elem = select_elem->thresholds;
-    ucs_string_buffer_appendf(strb, proto_info_fmt, "SIZE", "PROTOCOL",
-                              "CONFIGURATION");
-    do {
-        ucs_string_buffer_init(&proto_config_strb);
-
-        range_end = thresh_elem->max_msg_length;
-        thresh_elem->proto_config.proto->config_str(
-                range_start, range_end, thresh_elem->proto_config.priv,
-                &proto_config_strb);
-
-        ucs_memunits_range_str(range_start, range_end, range_str,
-                               sizeof(range_str));
-
-        ucs_string_buffer_appendf(strb, proto_info_fmt, range_str,
-                                  thresh_elem->proto_config.proto->name,
-                                  ucs_string_buffer_cstr(&proto_config_strb));
-
-        ucs_string_buffer_cleanup(&proto_config_strb);
-
-        range_start = range_end + 1;
-        ++thresh_elem;
-    } while (range_end != SIZE_MAX);
-}
-
-static void
-ucp_proto_select_dump_perf(const ucp_proto_select_elem_t *select_elem,
-                           ucp_proto_perf_type_t perf_type,
-                           ucs_string_buffer_t *strb)
-{
-    static const char *proto_info_fmt = "    %-16s %-20s %s\n";
-    const ucp_proto_select_range_t *range_elem;
-    size_t range_start, range_end;
-    char range_str[128];
-    char time_str[64];
-    char bw_str[64];
-
-    range_start = 0;
-    range_elem  = select_elem->perf_ranges;
-    ucs_string_buffer_appendf(strb, proto_info_fmt, "SIZE", "TIME (nsec)",
-                              "BANDWIDTH (MiB/s)");
-    do {
-        range_end = range_elem->super.max_length;
-
-        ucp_proto_select_perf_str(&range_elem->super.perf[perf_type], time_str,
-                                  sizeof(time_str), bw_str, sizeof(bw_str));
-        ucs_memunits_range_str(range_start, range_end, range_str,
-                               sizeof(range_str));
-
-        ucs_string_buffer_appendf(strb, proto_info_fmt, range_str, time_str,
-                                  bw_str);
-
-        range_start = range_end + 1;
-        ++range_elem;
-    } while (range_end != SIZE_MAX);
-}
-
-static void
-ucp_proto_select_elem_dump(ucp_worker_h worker,
-                           ucp_worker_cfg_index_t ep_cfg_index,
-                           ucp_worker_cfg_index_t rkey_cfg_index,
-                           const ucp_proto_select_param_t *select_param,
-                           const ucp_proto_select_elem_t *select_elem,
-                           ucs_string_buffer_t *strb)
-{
-    UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
-    ucs_status_t status;
-    size_t i;
-
-    ucp_proto_select_param_str(select_param, &sel_param_strb);
-
-    ucs_string_buffer_appendf(strb, "  %s\n  ",
-                              ucs_string_buffer_cstr(&sel_param_strb));
-    for (i = 0; i < ucs_string_buffer_length(&sel_param_strb); ++i) {
-        ucs_string_buffer_appendf(strb, "=");
-    }
-    ucs_string_buffer_appendf(strb, "\n");
-
-    ucs_string_buffer_appendf(strb, "\n  Selected protocols:\n");
-    ucp_proto_select_dump_thresholds(select_elem, strb);
-
-    ucs_string_buffer_appendf(strb, "\n  Performance estimation:\n");
-    ucp_proto_select_dump_perf(select_elem,
-                               ucp_proto_select_param_perf_type(select_param),
-                               strb);
-
-    ucs_string_buffer_appendf(strb, "\n  Candidates:\n");
-    status = ucp_proto_select_dump_all(worker, ep_cfg_index, rkey_cfg_index,
-                                       select_param, strb);
-    if (status != UCS_OK) {
-        ucs_string_buffer_appendf(strb, "<Error: %s>\n",
-                                  ucs_status_string(status));
-    }
-}
-
-void ucp_proto_select_dump(ucp_worker_h worker,
-                           ucp_worker_cfg_index_t ep_cfg_index,
-                           ucp_worker_cfg_index_t rkey_cfg_index,
-                           const ucp_proto_select_t *proto_select,
-                           ucs_string_buffer_t *strb)
-{
-    ucp_proto_select_elem_t select_elem;
-    ucp_proto_select_key_t key;
-    char info[256];
-
-    ucp_worker_print_used_tls(&worker->ep_config[ep_cfg_index].key,
-                              worker->context, ep_cfg_index, info,
-                              sizeof(info));
-    ucs_string_buffer_appendf(strb, "\nProtocol selection for %s", info);
-
-    if (rkey_cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
-        ucs_string_buffer_appendf(strb, "rkey_cfg[%d]: ", rkey_cfg_index);
-        ucp_rkey_config_dump_brief(&worker->rkey_config[rkey_cfg_index].key,
-                                   strb);
-    }
-    ucs_string_buffer_appendf(strb, "\n\n");
-
-    if (kh_size(&proto_select->hash) == 0) {
-        ucs_string_buffer_appendf(strb, "   (No elements)\n");
-        return;
-    }
-
-    kh_foreach(&proto_select->hash, key.u64, select_elem,
-               ucp_proto_select_elem_dump(worker, ep_cfg_index, rkey_cfg_index,
-                                          &key.param, &select_elem, strb))
-}
-
-void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
-                                 const char *name, ucs_string_buffer_t *strb)
-{
-    if (select_short->lane == UCP_NULL_LANE) {
-        return;
-    }
-
-    ucs_string_buffer_appendf(strb, "\n%s: ", name);
-
-    if (select_short->max_length_unknown_mem >= 0) {
-        ucs_string_buffer_appendf(strb, "<= %zd",
-                                  select_short->max_length_unknown_mem);
-    } else {
-        ucs_string_buffer_appendf(strb, "<= %zd and host memory",
-                                  select_short->max_length_host_mem);
-    }
-
-    ucs_string_buffer_appendf(strb, ", using lane %d rkey_index %d\n",
-                              select_short->lane, select_short->rkey_index);
-}
-
-void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
-                                ucs_string_buffer_t *strb)
-{
-    const char *sysdev_name;
-    uint32_t op_attr_mask;
-
-    op_attr_mask = ucp_proto_select_op_attr_from_flags(select_param->op_flags);
-    ucs_string_buffer_appendf(strb, "%s(",
-                              ucp_operation_names[select_param->op_id]);
-
-    ucs_string_buffer_appendf(strb, "%s",
-                              ucp_datatype_class_names[select_param->dt_class]);
-
-    if (select_param->sg_count > 1) {
-        ucs_string_buffer_appendf(strb, "[%d]", select_param->sg_count);
-    }
-
-    if (select_param->mem_type != UCS_MEMORY_TYPE_HOST) {
-        ucs_string_buffer_appendf(
-                strb, ", %s", ucs_memory_type_names[select_param->mem_type]);
-    }
-
-    if (select_param->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
-        sysdev_name = ucs_topo_sys_device_get_name(select_param->sys_dev);
-        ucs_string_buffer_appendf(strb, ", %s", sysdev_name);
-    }
-
-    if (op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) {
-        ucs_string_buffer_appendf(strb, ", fast-completion");
-    }
-
-    if (op_attr_mask & UCP_OP_ATTR_FLAG_MULTI_SEND) {
-        ucs_string_buffer_appendf(strb, ", multi");
-    }
-
-    ucs_string_buffer_rtrim(strb, ",");
-    ucs_string_buffer_appendf(strb, ")");
-}
-
 void ucp_proto_select_short_disable(ucp_proto_select_short_t *proto_short)
 {
     proto_short->max_length_unknown_mem = -1;
@@ -1052,41 +699,6 @@ int ucp_proto_select_get_valid_range(
     return found;
 }
 
-void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
-                                  size_t min_length, size_t max_length,
-                                  ucs_string_buffer_t *strb)
-{
-    size_t range_start, range_end;
-    const ucp_proto_t *proto;
-    char str[64];
-
-    range_start = 0;
-    do {
-        range_end = thresh_elem->max_msg_length;
-
-        /* Print only protocols within the range provided by {min,max}_length */
-        if ((range_end >= min_length) && (range_start <= max_length)) {
-            proto = thresh_elem->proto_config.proto;
-            ucs_string_buffer_appendf(strb, "%s(", proto->name);
-            proto->config_str(ucs_max(range_start, min_length),
-                              ucs_min(range_end, max_length),
-                              thresh_elem->proto_config.priv, strb);
-            ucs_string_buffer_appendf(strb, ")");
-
-            if (range_end < max_length) {
-                ucs_memunits_to_str(thresh_elem->max_msg_length, str,
-                                    sizeof(str));
-                ucs_string_buffer_appendf(strb, "<=%s<", str);
-            }
-        }
-
-        ++thresh_elem;
-        range_start = range_end + 1;
-    } while (range_end < max_length);
-
-    ucs_string_buffer_rtrim(strb, "<");
-}
-
 ucp_proto_select_t *
 ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
                      ucp_worker_cfg_index_t rkey_cfg_index,
@@ -1111,54 +723,4 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
 
         return &worker->rkey_config[*new_rkey_cfg_index].proto_select;
     }
-}
-
-void ucp_proto_select_config_str(ucp_worker_h worker,
-                                 const ucp_proto_config_t *proto_config,
-                                 size_t msg_length, ucs_string_buffer_t *strb)
-{
-    const ucp_proto_select_elem_t *select_elem;
-    ucp_worker_cfg_index_t new_key_cfg_index;
-    const ucp_proto_select_range_t *range;
-    ucp_proto_select_t *proto_select;
-    ucp_proto_perf_type_t perf_type;
-    double send_time;
-
-    ucs_assert(worker->context->config.ext.proto_enable);
-
-    /* Print selection parameters */
-    ucp_proto_select_param_str(&proto_config->select_param, strb);
-    ucs_string_buffer_appendf(strb, ": %s ", proto_config->proto->name);
-    proto_config->proto->config_str(msg_length, msg_length, proto_config->priv,
-                                    strb);
-
-    /* Find protocol selection root */
-    proto_select = ucp_proto_select_get(worker, proto_config->ep_cfg_index,
-                                        proto_config->rkey_cfg_index,
-                                        &new_key_cfg_index);
-    if (proto_select == NULL) {
-        return;
-    }
-
-    /* Emulate protocol selection process */
-    ucs_assert(new_key_cfg_index == proto_config->rkey_cfg_index);
-    select_elem = ucp_proto_select_lookup_slow(worker, proto_select,
-                                               proto_config->ep_cfg_index,
-                                               proto_config->rkey_cfg_index,
-                                               &proto_config->select_param);
-    if (select_elem == NULL) {
-        return;
-    }
-
-    /* Find the relevant performance range */
-    range = select_elem->perf_ranges;
-    while (range->super.max_length < msg_length) {
-        ++range;
-    }
-
-    perf_type = ucp_proto_select_param_perf_type(&proto_config->select_param);
-    send_time = ucs_linear_func_apply(range->super.perf[perf_type], msg_length);
-    ucs_string_buffer_appendf(strb, "  %.2f MBs / %.2f us",
-                              (msg_length / send_time) / UCS_MBYTE,
-                              send_time * UCS_USEC_PER_SEC);
 }

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -123,21 +123,6 @@ ucs_status_t ucp_proto_select_init(ucp_proto_select_t *proto_select);
 void ucp_proto_select_cleanup(ucp_proto_select_t *proto_select);
 
 
-void ucp_proto_select_dump(ucp_worker_h worker,
-                           ucp_worker_cfg_index_t ep_cfg_index,
-                           ucp_worker_cfg_index_t rkey_cfg_index,
-                           const ucp_proto_select_t *proto_select,
-                           ucs_string_buffer_t *strb);
-
-
-void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
-                                 const char *name, ucs_string_buffer_t *strb);
-
-
-void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
-                                ucs_string_buffer_t *strb);
-
-
 ucp_proto_select_elem_t *
 ucp_proto_select_lookup_slow(ucp_worker_h worker,
                              ucp_proto_select_t *proto_select,
@@ -168,21 +153,10 @@ int ucp_proto_select_get_valid_range(
         size_t *max_length_p);
 
 
-void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
-                                  size_t min_length, size_t max_length,
-                                  ucs_string_buffer_t *strb);
-
-
 /* Get the protocol selection hash for the endpoint or remote key config */
 ucp_proto_select_t *
 ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
                      ucp_worker_cfg_index_t rkey_cfg_index,
                      ucp_worker_cfg_index_t *new_rkey_cfg_index);
-
-
-/* Print protocol configuration info to a string buffer */
-void ucp_proto_select_config_str(ucp_worker_h worker,
-                                 const ucp_proto_config_t *proto_config,
-                                 size_t msg_length, ucs_string_buffer_t *strb);
 
 #endif

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -134,4 +134,15 @@ ucp_proto_select_is_short(ucp_ep_h ep,
             ucs_memtype_cache_is_empty());
 }
 
+static UCS_F_ALWAYS_INLINE ucp_proto_perf_type_t
+ucp_proto_select_param_perf_type(const ucp_proto_select_param_t *select_param)
+{
+    if (ucp_proto_select_op_attr_from_flags(select_param->op_flags) &
+        UCP_OP_ATTR_FLAG_MULTI_SEND) {
+        return UCP_PROTO_PERF_TYPE_MULTI;
+    } else {
+        return UCP_PROTO_PERF_TYPE_SINGLE;
+    }
+}
+
 #endif

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -10,8 +10,9 @@
 
 #include "proto_rndv.inl"
 
-#include <ucp/proto/proto_common.inl>
 #include <ucp/proto/proto_init.h>
+#include <ucp/proto/proto_debug.h>
+#include <ucp/proto/proto_common.inl>
 
 
 static void

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -10,6 +10,7 @@
 #include "proto_rndv.inl"
 
 #include <ucp/core/ucp_request.inl>
+#include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_multi.inl>
 #include <ucp/proto/proto_init.h>
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -13,7 +13,7 @@ extern "C" {
 #include <ucp/core/ucp_rkey.h>
 #include <ucp/dt/datatype_iter.inl>
 #include <ucp/proto/proto.h>
-#include <ucp/proto/proto_select.h>
+#include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_select.inl>
 #include <ucp/core/ucp_worker.inl>
 }


### PR DESCRIPTION
## Why
- Preparation for extending the debug/info abilities
- Separate debug code from initialization/runtime logic