### PR TITLE
UCT/UD: Fix completion callback not called for flush operation

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -215,6 +215,8 @@ static void uct_ud_ep_purge_outstanding(uct_ud_ep_t *ep)
     uct_ud_ctl_desc_t *cdesc;
     ucs_queue_iter_t iter;
 
+    ucs_trace_func("ep=%p", ep);
+
     ucs_queue_for_each_safe(cdesc, iter, &iface->tx.outstanding_q, queue) {
         if (cdesc->ep == ep) {
             ucs_queue_del_iter(&iface->tx.outstanding_q, iter);
@@ -229,6 +231,8 @@ static void uct_ud_ep_purge(uct_ud_ep_t *ep, ucs_status_t status)
 {
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                            uct_ud_iface_t);
+
+    ucs_trace_func("ep=%p", ep);
 
     uct_ud_iface_dispatch_async_comps(iface, ep);
 
@@ -1111,6 +1115,8 @@ ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h, unsigned flags,
                                            uct_ud_iface_t);
     ucs_status_t status;
 
+    ucs_trace_func("ep=%p", ep);
+
     uct_ud_enter(iface);
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
@@ -1673,6 +1679,8 @@ void uct_ud_ep_pending_purge(uct_ep_h ep_h, uct_pending_purge_callback_t cb,
     uct_ud_iface_t *iface    = ucs_derived_of(ep->super.super.iface,
                                               uct_ud_iface_t);
     uct_purge_cb_args_t args = {cb, arg};
+
+    ucs_trace_func("ep=%p", ep);
 
     uct_ud_enter(iface);
     ucs_arbiter_group_purge(&iface->tx.pending_q, &ep->tx.pending.group,


### PR DESCRIPTION
## What
Fix leak warning about ep_removed flush request (added by `ucp_wireup_send_ep_removed`, when the worker is destroyed. 

## Why?
Fix test [failures](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=35167&view=logs&j=73bd2a9e-6688-5c22-d122-7b1a0b6cbb81&t=cd3d3953-51ff-5d5c-c5ca-2864f3c1d670&s=8bfbeaae-4c8e-5f12-f154-edd305817000) like:
```
2022-01-17T17:25:13.3034557Z [ RUN      ] udx/test_ucp_wireup_errh_peer.stress_connect_force_disconnect/2 <ud_x/rma,no_ep_match>
2022-01-17T17:25:13.8430781Z [1642440313.842728] [swx-rdmz-ucx-gpu-01:5074 :0]           mpool.c:54   UCX  WARN  object 0x5494b40 {flags:0x200002 <no debug info>} was not returned to mpool ucp_requests
2022-01-17T17:25:13.8687245Z /scrap/azure/agent-11/AZP_WORKSPACE/1/s/contrib/../test/gtest/common/test.cc:344: Failure
2022-01-17T17:25:13.8689017Z Failed
2022-01-17T17:25:13.8689885Z Got 0 errors and 1 warnings during the test
2022-01-17T17:25:13.8691642Z [     INFO ] < /scrap/azure/agent-11/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/mpool.c:54 object 0x5494b40 {flags:0x200002 <no debug info>} was not returned to mpool ucp_requests >
2022-01-17T17:25:13.8693215Z [  FAILED  ] udx/test_ucp_wireup_errh_peer.stress_connect_force_disconnect/2, where GetParam() = ud_x/rma,no_ep_match (565 ms)
```

## How ?
Fix UD transport to not remove uct_completion_t descriptors from async queue without calling their callback
