### PR TITLE
UCP/CORE/TEST: Replace using UCP_AM_SEND_REPLY by UCP_AM_SEND_FLAG_REPLY

### DIFF
--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -591,7 +591,7 @@ typedef enum ucp_wakeup_event_types {
  *                       to be freed with @ref ucp_am_data_release.
  * @param [in]  length   Length of data.
  * @param [in]  reply_ep If the Active Message is sent with the
- *                       UCP_AM_SEND_REPLY flag, the sending ep
+ *                       UCP_AM_SEND_FLAG_REPLY flag, the sending ep
  *                       will be passed in. If not, NULL will be passed.
  * @param [in]  flags    If this flag is set to UCP_CB_PARAM_FLAG_DATA,
  *                       the callback can return UCS_INPROGRESS and

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -941,7 +941,7 @@ ucp_am_try_send_short(ucp_ep_h ep, uint16_t id, uint32_t flags,
 
     if (ucp_proto_is_inline(ep, max_eager_short, header_length + length)) {
         return ucp_am_send_short(ep, id, flags, header, header_length, buffer,
-                                 length, flags & UCP_AM_SEND_REPLY);
+                                 length, flags & UCP_AM_SEND_FLAG_REPLY);
     }
 
     return UCS_ERR_NO_RESOURCE;
@@ -974,7 +974,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
     attr_mask = param->op_attr_mask &
                 (UCP_OP_ATTR_FIELD_DATATYPE | UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
 
-    if (flags & UCP_AM_SEND_REPLY) {
+    if (flags & UCP_AM_SEND_FLAG_REPLY) {
         max_short = &ucp_ep_config(ep)->am_u.max_reply_eager_short;
         proto     = ucp_ep_config(ep)->am_u.reply_proto;
     } else {
@@ -1363,7 +1363,7 @@ static UCS_F_ALWAYS_INLINE uint64_t
 ucp_am_hdr_reply_ep(ucp_worker_h worker, uint16_t flags, ucp_ep_h ep,
                     ucp_ep_h *reply_ep_p)
 {
-    if (flags & UCP_AM_SEND_REPLY) {
+    if (flags & UCP_AM_SEND_FLAG_REPLY) {
         *reply_ep_p = ep;
         return UCP_AM_RECV_ATTR_FIELD_REPLY_EP;
     }

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -945,7 +945,7 @@ bool UcxConnection::send_am(const void *meta, size_t meta_length,
     param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK  |
                          UCP_OP_ATTR_FIELD_FLAGS;
     param.cb.send      = common_request_callback_nbx;
-    param.flags        = UCP_AM_SEND_REPLY;
+    param.flags        = UCP_AM_SEND_FLAG_REPLY;
     param.datatype     = 0; // make coverity happy
     if (memh) {
         param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -274,7 +274,7 @@ UCS_TEST_P(test_ucp_am, send_process_am)
     do_send_process_data_test(0, UCP_SEND_ID, 0);
 
     set_reply_handlers();
-    do_send_process_data_test(0, UCP_SEND_ID, UCP_AM_SEND_REPLY);
+    do_send_process_data_test(0, UCP_SEND_ID, UCP_AM_SEND_FLAG_REPLY);
 }
 
 UCS_TEST_P(test_ucp_am, send_process_am_rndv, "RNDV_THRESH=1")
@@ -283,7 +283,7 @@ UCS_TEST_P(test_ucp_am, send_process_am_rndv, "RNDV_THRESH=1")
     do_send_process_data_test(0, UCP_SEND_ID, 0);
 
     set_reply_handlers();
-    do_send_process_data_test(0, UCP_SEND_ID, UCP_AM_SEND_REPLY);
+    do_send_process_data_test(0, UCP_SEND_ID, UCP_AM_SEND_FLAG_REPLY);
 }
 
 UCS_TEST_P(test_ucp_am, send_process_am_release)
@@ -871,7 +871,7 @@ UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_short_am_on_closed_ep, "RNDV_THRESH=inf
 // receiver side, when its ep is closed
 UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_short_reply_am_on_closed_ep, "RNDV_THRESH=inf")
 {
-    test_recv_on_closed_ep(8, UCP_AM_SEND_REPLY);
+    test_recv_on_closed_ep(8, UCP_AM_SEND_FLAG_REPLY);
 }
 
 UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_long_am_on_closed_ep, "RNDV_THRESH=inf")
@@ -881,7 +881,7 @@ UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_long_am_on_closed_ep, "RNDV_THRESH=inf"
 
 UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_long_reply_am_on_closed_ep, "RNDV_THRESH=inf")
 {
-    test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_REPLY, true);
+    test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_FLAG_REPLY, true);
 }
 
 UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_rts_am_on_closed_ep, "RNDV_THRESH=32K")
@@ -891,7 +891,7 @@ UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_rts_am_on_closed_ep, "RNDV_THRESH=32K")
 
 UCS_TEST_P(test_ucp_am_nbx_closed_ep, rx_rts_reply_am_on_closed_ep, "RNDV_THRESH=32K")
 {
-    test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_REPLY);
+    test_recv_on_closed_ep(64 * UCS_KBYTE, UCP_AM_SEND_FLAG_REPLY);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx_closed_ep)
@@ -1035,7 +1035,7 @@ public:
     {
         add_variant_values(variants, test_ucp_am_base::get_test_variants, 0);
         add_variant_values(variants, test_ucp_am_base::get_test_variants,
-                           UCP_AM_SEND_REPLY, "reply");
+                           UCP_AM_SEND_FLAG_REPLY, "reply");
     }
 
     virtual unsigned get_send_flag()
@@ -1102,7 +1102,7 @@ public:
     {
         add_variant_values(variants, test_ucp_am_base::get_test_variants, 0);
         add_variant_values(variants, test_ucp_am_base::get_test_variants,
-                           UCP_AM_SEND_REPLY, "reply");
+                           UCP_AM_SEND_FLAG_REPLY, "reply");
     }
 
 protected:
@@ -1169,8 +1169,8 @@ public:
     static void get_test_dts_reply(std::vector<ucp_test_variant>& variants)
     {
         add_variant_values(variants, base_test_generator, 0);
-        add_variant_values(variants, base_test_generator, UCP_AM_SEND_REPLY,
-                           "reply");
+        add_variant_values(variants, base_test_generator,
+                           UCP_AM_SEND_FLAG_REPLY, "reply");
     }
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants)


### PR DESCRIPTION
## What

Replace using `UCP_AM_SEND_REPLY` by `UCP_AM_SEND_FLAG_REPLY`.

## Why ?

`UCP_AM_SEND_REPLY` is a part `ucp_send_am_flags_t` for backward compatibility.

## How ?

Use `UCP_AM_SEND_FLAG_REPLY` instead of `UCP_AM_SEND_REPLY`.