### PR TITLE
UCT/TAG: Try using MP XRQ by default

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -42,7 +42,7 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.seg_size),
    UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"TM_MP_SRQ_ENABLE", "no",
+  {"TM_MP_SRQ_ENABLE", "try",
    "Enable multi-packet SRQ support. Relevant for hardware tag-matching only.",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, tm.mp_enable),
    UCS_CONFIG_TYPE_TERNARY},


### PR DESCRIPTION
## What
Try using MP XRQ by default

## Why ?
Using MP XRQ improves tag offload performance and memory consumption.
It was disabled because of the bug fixed by #7849 
