### PR TITLE
UCS/TOPO: add topo module infrastructure

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -18,7 +18,7 @@
 #include <ucs/type/float8.h>
 #include <ucs/type/serialize.h>
 #include <ucs/sys/string.h>
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <inttypes.h>
 
 

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -62,7 +62,7 @@ nobase_dist_libucs_la_HEADERS = \
 	sys/preprocessor.h \
 	sys/string.h \
 	sys/sock.h \
-	sys/topo.h \
+	sys/topo/base/topo.h \
 	sys/stubs.h \
 	sys/uid.h \
 	time/time_def.h \
@@ -181,7 +181,7 @@ libucs_la_SOURCES = \
 	sys/iovec.c \
 	sys/lib.c \
 	sys/sock.c \
-	sys/topo.c \
+	sys/topo/base/topo.c \
 	sys/stubs.c \
 	sys/uid.c \
 	time/time.c \

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -49,6 +49,7 @@ ucs_global_opts_t ucs_global_opts = {
     .profile_file          = "",
     .stats_filter          = { NULL, 0 },
     .stats_format          = UCS_STATS_FULL,
+    .topo_prio             = { NULL, 0 },
     .vfs_enable            = 1,
     .vfs_thread_affinity   = 0,
     .rcache_check_pfn      = 0,
@@ -184,6 +185,11 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   " *     - load all modules\n"
   " ^cu*  - do not load modules that begin with 'cu'",
   ucs_offsetof(ucs_global_opts_t, modules), UCS_CONFIG_TYPE_ALLOW_LIST},
+
+ {"TOPO_PRIO", "sysfs,default",
+  "Comma-separated list of methods of detecting system topology.\n"
+  "The list order decides the priority of methods used.",
+  ucs_offsetof(ucs_global_opts_t, topo_prio), UCS_CONFIG_TYPE_STRING_ARRAY},
 
  {NULL}
 };

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -121,6 +121,9 @@ typedef struct {
     /* statistics format options */
     ucs_stats_formats_t        stats_format;
 
+    /* Topology detection modules to use */
+    ucs_config_names_array_t   topo_prio;
+
     /* Enable VFS monitoring */
     int                        vfs_enable;
 

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -13,7 +13,7 @@
 #include <ucs/datastruct/list.h>
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/sys/compiler_def.h>
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <pthread.h>
 
 

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -22,7 +22,7 @@
 #include <ucs/async/async.h>
 #include <ucs/sys/lib.h>
 #include <ucs/sys/sys.h>
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <ucs/sys/math.h>
 
 

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) NVIDIA Corporation. 2019.  ALL RIGHTS RESERVED.
+* Copyright (C) NVIDIA Corporation. 2019-2022.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -8,10 +8,11 @@
 #  include "config.h"
 #endif
 
-#include "topo.h"
-#include "string.h"
-#include "sys.h"
+#include <ucs/sys/topo/base/topo.h>
+#include <ucs/sys/string.h>
+#include <ucs/sys/sys.h>
 
+#include <ucs/config/global_opts.h>
 #include <ucs/datastruct/khash.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/debug/assert.h>
@@ -51,6 +52,58 @@ const ucs_sys_dev_distance_t ucs_topo_default_distance = {
 static ucs_topo_global_ctx_t ucs_topo_global_ctx;
 
 
+/* Global list of topology detectors */
+UCS_LIST_HEAD(ucs_sys_topo_methods_list);
+
+
+static ucs_sys_topo_method_t *ucs_sys_topo_get_method()
+{
+    static ucs_sys_topo_method_t *method = NULL;
+    ucs_sys_topo_method_t *list_method;
+    unsigned i;
+
+    if (method != NULL) {
+        return method;
+    }
+
+    for (i = 0; i < ucs_global_opts.topo_prio.count; ++i) {
+
+        ucs_list_for_each(list_method, &ucs_sys_topo_methods_list, list) {
+            if (!strcmp(ucs_global_opts.topo_prio.names[i],
+                        list_method->name)) {
+                method = list_method;
+                return method;
+            }
+        }
+    }
+
+    return method;
+}
+
+static ucs_status_t
+ucs_topo_get_distance_default(ucs_sys_device_t device1,
+                              ucs_sys_device_t device2,
+                              ucs_sys_dev_distance_t *distance)
+{
+    *distance = ucs_topo_default_distance;
+
+    return UCS_OK;
+}
+
+static ucs_sys_topo_method_t ucs_sys_topo_default_method = {
+    .name         = "default",
+    .get_distance = ucs_topo_get_distance_default,
+};
+
+ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
+                                   ucs_sys_device_t device2,
+                                   ucs_sys_dev_distance_t *distance)
+{
+    ucs_sys_topo_method_t *method = ucs_sys_topo_get_method();
+
+    return method->get_distance(device1, device2, distance);
+}
+
 static ucs_bus_id_bit_rep_t
 ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
 {
@@ -58,25 +111,6 @@ ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
             ((uint64_t)bus_id->bus << 16)    |
             ((uint64_t)bus_id->slot << 8)    |
             (bus_id->function));
-}
-
-void ucs_topo_init()
-{
-    ucs_spinlock_init(&ucs_topo_global_ctx.lock, 0);
-    kh_init_inplace(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash);
-    ucs_topo_global_ctx.num_devices = 0;
-}
-
-void ucs_topo_cleanup()
-{
-    ucs_topo_sys_device_info_t *device;
-    while (ucs_topo_global_ctx.num_devices-- > 0) {
-        device = &ucs_topo_global_ctx.devices[ucs_topo_global_ctx.num_devices];
-        ucs_free(device->name);
-    }
-    kh_destroy_inplace(bus_to_sys_dev,
-                       &ucs_topo_global_ctx.bus_to_sys_dev_hash);
-    ucs_spinlock_destroy(&ucs_topo_global_ctx.lock);
 }
 
 unsigned ucs_topo_num_devices()
@@ -234,9 +268,10 @@ static void ucs_topo_pci_root_distance(const char *path1, const char *path2,
                                   (19200.0 * UCS_MBYTE) / path_distance);
 }
 
-ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
-                                   ucs_sys_device_t device2,
-                                   ucs_sys_dev_distance_t *distance)
+static ucs_status_t
+ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
+                            ucs_sys_device_t device2,
+                            ucs_sys_dev_distance_t *distance)
 {
     char path1[PATH_MAX], path2[PATH_MAX], common_path[PATH_MAX];
     ucs_status_t status;
@@ -382,4 +417,37 @@ void ucs_topo_print_info(FILE *stream)
                                              sizeof(bdf_name)),
                 ucs_topo_global_ctx.devices[sys_dev].name);
     }
+}
+
+static ucs_sys_topo_method_t ucs_sys_topo_sysfs_method = {
+    .name         = "sysfs",
+    .get_distance = ucs_topo_get_distance_sysfs,
+};
+
+void ucs_topo_init()
+{
+    ucs_spinlock_init(&ucs_topo_global_ctx.lock, 0);
+    kh_init_inplace(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash);
+    ucs_topo_global_ctx.num_devices = 0;
+    ucs_list_add_tail(&ucs_sys_topo_methods_list,
+                      &ucs_sys_topo_default_method.list);
+    ucs_list_add_tail(&ucs_sys_topo_methods_list,
+                      &ucs_sys_topo_sysfs_method.list);
+}
+
+void ucs_topo_cleanup()
+{
+    ucs_topo_sys_device_info_t *device;
+
+    ucs_list_del(&ucs_sys_topo_sysfs_method.list);
+    ucs_list_del(&ucs_sys_topo_default_method.list);
+
+    while (ucs_topo_global_ctx.num_devices-- > 0) {
+        device = &ucs_topo_global_ctx.devices[ucs_topo_global_ctx.num_devices];
+        ucs_free(device->name);
+    }
+
+    kh_destroy_inplace(bus_to_sys_dev,
+                       &ucs_topo_global_ctx.bus_to_sys_dev_hash);
+    ucs_spinlock_destroy(&ucs_topo_global_ctx.lock);
 }

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -8,6 +8,7 @@
 #define UCS_TOPO_H
 
 #include <ucs/type/status.h>
+#include <ucs/datastruct/list.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -54,6 +55,35 @@ typedef struct ucs_sys_dev_distance {
 
 
 extern const ucs_sys_dev_distance_t ucs_topo_default_distance;
+
+
+/*
+ * Function pointer used to refer to specific implementations of
+ * ucs_topo_get_distance function by topology modules
+ */
+typedef ucs_status_t
+(*ucs_topo_get_distance_func_t)(ucs_sys_device_t device1,
+                                ucs_sys_device_t device2,
+                                ucs_sys_dev_distance_t *distance);
+
+
+/*
+ * Structure needed to define a topology module implementation
+ */
+typedef struct {
+
+    /* Name of the topology module */
+    const char                   *name;
+
+    /* Points to the module's ucs_topo_get_distance implementation */
+    ucs_topo_get_distance_func_t get_distance;
+
+    ucs_list_link_t              list;
+} ucs_sys_topo_method_t;
+
+
+/* Global list of topology detection methods */
+extern ucs_list_link_t ucs_sys_topo_methods_list;
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -23,7 +23,7 @@
 #include <ucs/type/cpu_set.h>
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/sys/compiler_def.h>
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 
 #include <sys/socket.h>
 #include <stdio.h>

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -11,7 +11,7 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/memory/memory_type.h>
 #include <uct/api/uct.h>
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 
 #include <stdint.h>
 

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -6,7 +6,7 @@
 
 #include <common/test.h>
 extern "C" {
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 }
 
 class test_topo : public ucs::test {

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -8,7 +8,7 @@
 #include <gtest/uct/uct_p2p_test.h>
 
 extern "C" {
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <uct/api/uct.h>
 #include <uct/api/v2/uct_v2.h>
 }


### PR DESCRIPTION
## What
- based on yosefe/wip/backtrace

## Why ?
- allows for topo detection logic to use external modules like nvml, hwloc