### PR TITLE
UCT/IB/DC: Increase max number of DCIs

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -53,8 +53,7 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      UCS_CONFIG_TYPE_TABLE(uct_ud_iface_common_config_table)},
 
     {"NUM_DCI", "8",
-     "Number of DC initiator QPs (DCI) used by the interface "
-     "(up to " UCS_PP_MAKE_STRING(UCT_DC_MLX5_IFACE_MAX_USER_DCIS) ").",
+     "Number of DC initiator QPs (DCI) used by the interface.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, ndci), UCS_CONFIG_TYPE_UINT},
 
     {"TX_POLICY", "dcs_quota",
@@ -818,6 +817,8 @@ void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface, int max)
         uct_rc_txqp_cleanup(&iface->super.super, &iface->tx.dcis[i].txqp);
         uct_ib_mlx5_destroy_qp(md, &iface->tx.dcis[i].txwq.super);
     }
+
+    ucs_free(iface->tx.dcis);
 }
 
 ucs_status_t
@@ -1294,18 +1295,13 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     uct_ib_iface_init_attr_t init_attr = {};
     ucs_status_t status;
     unsigned tx_cq_size;
+    int pool_index;
 
     ucs_trace_func("");
 
     if (config->ndci < 1) {
         ucs_error("dc interface must have at least 1 dci (requested: %d)",
                   config->ndci);
-        return UCS_ERR_INVALID_PARAM;
-    }
-
-    if (config->ndci > UCT_DC_MLX5_IFACE_MAX_USER_DCIS) {
-        ucs_error("dc interface can have at most %d dcis (requested: %d)",
-                  UCT_DC_MLX5_IFACE_MAX_USER_DCIS, config->ndci);
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -1368,10 +1364,30 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     }
     ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
 
+    /* allocate dcis arrays and stack */
+    self->tx.dcis = ucs_calloc((self->tx.ndci * self->tx.num_dci_pools) +
+                               UCT_DC_MLX5_KEEPALIVE_NUM_DCIS,
+                               sizeof(*self->tx.dcis),
+                               "dcis");
+    if (self->tx.dcis == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    for (pool_index = 0; pool_index < self->tx.num_dci_pools; pool_index++) {
+        self->tx.dci_pool[pool_index].stack = ucs_calloc(self->tx.ndci,
+                                                         sizeof(uint8_t),
+                                                         "dci pool stack");
+        if (self->tx.dci_pool[pool_index].stack == NULL) {
+            status = UCS_ERR_NO_MEMORY;
+            goto err_free_pools;
+        }
+    }
+
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self, config);
     if (status != UCS_OK) {
-        goto err;
+        goto err_free_pools;
     }
 
     /* create DC initiators */
@@ -1405,6 +1421,11 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
 err_destroy_dct:
     uct_dc_mlx5_destroy_dct(self);
+err_free_pools:
+    while (pool_index-- > 0) {
+        ucs_free(self->tx.dci_pool[pool_index].stack);
+    }
+    ucs_free(self->tx.dcis);
 err:
     return status;
 }
@@ -1428,6 +1449,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_iface_t)
 
     for (pool_index = 0; pool_index < self->tx.num_dci_pools; pool_index++) {
         ucs_arbiter_cleanup(&self->tx.dci_pool[pool_index].arbiter);
+        ucs_free(self->tx.dci_pool[pool_index].stack);
     }
 }
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -37,12 +37,8 @@ struct ibv_ravh {
 #  define UCT_DC_RNDV_HDR_LEN   0
 #endif
 
-#define UCT_DC_MLX5_IFACE_MAX_USER_DCIS 15
 #define UCT_DC_MLX5_KEEPALIVE_NUM_DCIS  1
 #define UCT_DC_MLX5_IFACE_MAX_DCI_POOLS 8
-#define UCT_DC_MLX5_IFACE_MAX_DCIS      ((UCT_DC_MLX5_IFACE_MAX_USER_DCIS * \
-                                          UCT_DC_MLX5_IFACE_MAX_DCI_POOLS) + \
-                                          UCT_DC_MLX5_KEEPALIVE_NUM_DCIS)
 
 #define UCT_DC_MLX5_IFACE_ADDR_TM_ENABLED(_addr) \
     (!!((_addr)->flags & UCT_DC_MLX5_IFACE_ADDR_HW_TM))
@@ -216,13 +212,12 @@ KHASH_MAP_INIT_INT64(uct_dc_mlx5_fc_hash, uct_dc_mlx5_ep_fc_entry_t);
  * ndci and these stacks are not intersected
  */
 typedef struct {
-    int8_t        stack_top;                               /* dci stack top */
-    uint8_t       stack[UCT_DC_MLX5_IFACE_MAX_USER_DCIS];  /* LIFO of indexes of available dcis */
-    ucs_arbiter_t arbiter;                                 /* queue of requests
-                                                              waiting for DCI */
-    int8_t        release_stack_top;                       /* releasing dci's stack,
-                                                              points to last DCI to release
-                                                              or -1 if no DCI's to release */
+    int8_t        stack_top;         /* dci stack top */
+    uint8_t       *stack;            /* LIFO of indexes of available dcis */
+    ucs_arbiter_t arbiter;           /* queue of requests waiting for DCI */
+    int8_t        release_stack_top; /* releasing dci's stack,
+                                        points to last DCI to release
+                                        or -1 if no DCI's to release */
 } uct_dc_mlx5_dci_pool_t;
 
 
@@ -230,7 +225,7 @@ struct uct_dc_mlx5_iface {
     uct_rc_mlx5_iface_common_t    super;
     struct {
         /* Array of dcis */
-        uct_dc_dci_t              dcis[UCT_DC_MLX5_IFACE_MAX_DCIS];
+        uct_dc_dci_t              *dcis;
 
         uint8_t                   ndci;                        /* Number of DCIs */
 


### PR DESCRIPTION
## What
increase UCT_DC_MLX5_IFACE_MAX_USER_DCIS.

## Why ?
UCX_DC_MLX5_NUM_DCI needs a larger value to gain better throughput in a large scale scenario. from our experiments, w/ UCX_DC_MLX5_NUM_DCI=60, io_demo could reach to 10GBs each direction in a scale of 89 nodes, 17.6k connections per node. w/ UCX_DC_MLX5_NUM_DCI=120, io_demo could surpass 10GBs.

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
