### PR TITLE
UCT/SM: refactoring for SM modules initialization

### DIFF
--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -180,6 +180,29 @@ struct uct_component {
 
 
 /**
+ * Component registration routines.
+ * @ref uct_query_components.
+ *
+ * @param [in] _component  Pointer to a global component structure to register.
+ * @param [in] _name       Component name used to generate ctors/dtors.
+ */
+#define UCT_COMPONENT_REGISTER_DEF(_component, _name) \
+    extern ucs_list_link_t uct_components_list; \
+    static void uct_component_##_name##_ctor(void) \
+    { \
+        ucs_list_add_tail(&uct_components_list, &(_component)->list); \
+        ucs_list_add_tail(&ucs_config_global_list, &(_component)->md_config.list); \
+        ucs_list_add_tail(&ucs_config_global_list, &(_component)->cm_config.list); \
+    } \
+    static void uct_component_##_name##_dtor(void) \
+    { \
+        /* TODO: add ucs_list_del(uct_components_list) */ \
+        ucs_list_del(&(_component)->md_config.list); \
+        ucs_list_del(&(_component)->cm_config.list); \
+    }
+
+
+/**
  * Helper macro to initialize component's transport list head.
  */
 #define UCT_COMPONENT_TL_LIST_INITIALIZER(_component) \

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -397,6 +397,75 @@ typedef struct uct_iface_local_addr_ns {
 
 
 /**
+ * Register component and TL
+ *
+ * @param [in] _name   Component and TL name
+ * @param [in] _scope  Scope for functions (e.g 'static inline')
+ */
+#define UCT_TL_INIT(_name) \
+    static void uct_component_tl_##_name##_ctor(void); \
+    void UCS_F_CTOR uct_##_name##_init(void) { \
+        uct_component_tl_##_name##_ctor(); \
+        uct_component_##_name##_ctor(); \
+        uct_tl_##_name##_ctor(); \
+    } \
+    void uct_component_tl_##_name##_ctor(void)
+
+
+/**
+ * Unregister component and TL
+ *
+ * @param [in] _name   Component and TL name
+ * @param [in] _scope  Scope for functions (e.g 'static inline')
+ */
+#define UCT_TL_CLEANUP(_name) \
+    static void uct_component_tl_##_name##_dtor(void); \
+    void UCS_F_DTOR uct_##_name##_cleanup(void) { \
+        uct_tl_##_name##_dtor(); \
+        uct_component_##_name##_dtor(); \
+        uct_component_tl_##_name##_dtor(); \
+    } \
+    void uct_component_tl_##_name##_dtor(void)
+
+
+/**
+ * Transport registration routines
+ *
+ * @param _component      Component to add the transport to
+ * @param _name           Name of the transport (should be a token, not a string)
+ * @param _query_devices  Function to query the list of available devices
+ * @param _iface_class    Struct type defining the uct_iface class
+ * @param _cfg_prefix     Prefix for configuration variables
+ * @param _cfg_table      Transport configuration table
+ * @param _cfg_struct     Struct type defining transport configuration
+ */
+#define UCT_TL_REGISTER_DEF(_component, _name, _query_devices, _iface_class, \
+                            _cfg_prefix, _cfg_table, _cfg_struct) \
+    \
+    static uct_tl_t uct_##_name##_tl = { \
+        .name               = #_name, \
+        .query_devices      = _query_devices, \
+        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
+        .config = { \
+            .name           = #_name" transport", \
+            .prefix         = _cfg_prefix, \
+            .table          = _cfg_table, \
+            .size           = sizeof(_cfg_struct), \
+         } \
+    }; \
+    static void uct_tl_##_name##_ctor(void) \
+    { \
+        ucs_list_add_tail(&ucs_config_global_list, &(uct_##_name##_tl).config.list); \
+        ucs_list_add_tail(&(_component)->tl_list, &(uct_##_name##_tl).list); \
+    } \
+    static void uct_tl_##_name##_dtor(void) \
+    { \
+        ucs_list_del(&(uct_##_name##_tl).config.list); \
+        /* TODO: add list_del from ucs_config_global_list */ \
+    }
+
+
+/**
  * "Base" structure which defines interface configuration options.
  * Specific transport extend this structure.
  */

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -236,17 +236,15 @@ typedef struct uct_mm_iface {
  */
 #define UCT_MM_TL_DEFINE(_name, _md_ops, _rkey_unpack, _rkey_release, \
                          _cfg_prefix, _cfg_table) \
-    \
     UCT_MM_COMPONENT_DEFINE(uct_##_name##_component, _name, _md_ops, \
                             _rkey_unpack, _rkey_release, _cfg_prefix) \
-    \
-    UCT_TL_DEFINE(&(uct_##_name##_component).super, \
-                  _name, \
-                  uct_sm_base_query_tl_devices, \
-                  uct_mm_iface_t, \
-                  _cfg_prefix, \
-                  _cfg_table, \
-                  uct_mm_iface_config_t);
+    UCT_TL_REGISTER_DEF(&(uct_##_name##_component).super, \
+                        _name, \
+                        uct_sm_base_query_tl_devices, \
+                        uct_mm_iface_t, \
+                        _cfg_prefix, \
+                        _cfg_table, \
+                        uct_mm_iface_config_t)
 
 
 extern ucs_config_field_t uct_mm_iface_config_table[];

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -186,7 +186,7 @@ typedef struct uct_mm_component {
        }, \
        .md_ops                  = (_md_ops) \
     }; \
-    UCT_COMPONENT_REGISTER(&(_var).super); \
+    UCT_COMPONENT_REGISTER_DEF(&(_var).super, _name); \
 
 
 extern ucs_config_field_t uct_mm_md_config_table[];

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -700,4 +700,14 @@ static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
 };
 
 UCT_MM_TL_DEFINE(posix, &uct_posix_md_ops, uct_posix_rkey_unpack,
-                 uct_posix_rkey_release, "POSIX_", uct_posix_iface_config_table)
+                 uct_posix_rkey_release, "POSIX_",
+                 uct_posix_iface_config_table);
+
+UCT_TL_INIT(posix)
+{
+}
+
+UCT_TL_CLEANUP(posix)
+{
+}
+

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -209,4 +209,14 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
 };
 
 UCT_MM_TL_DEFINE(sysv, &uct_sysv_md_ops, uct_sysv_rkey_unpack,
-                 uct_sysv_rkey_release, "SYSV_", uct_sysv_iface_config_table)
+                 uct_sysv_rkey_release, "SYSV_",
+                 uct_sysv_iface_config_table);
+
+UCT_TL_INIT(sysv)
+{
+}
+
+UCT_TL_CLEANUP(sysv)
+{
+}
+

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -145,6 +145,17 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_cma_component, cma, uct_sm_base_query_tl_devices,
-              uct_cma_iface_t, "CMA_", uct_cma_iface_config_table,
-              uct_cma_iface_config_t);
+UCT_COMPONENT_REGISTER_DEF(&uct_cma_component, cma);
+
+UCT_TL_REGISTER_DEF(&uct_cma_component, cma, uct_sm_base_query_tl_devices,
+                    uct_cma_iface_t, "CMA_", uct_cma_iface_config_table,
+                    uct_cma_iface_config_t);
+
+UCT_TL_INIT(cma)
+{
+}
+
+UCT_TL_CLEANUP(cma)
+{
+}
+

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -247,4 +247,3 @@ uct_component_t uct_cma_component = {
     .flags              = 0,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
-UCT_COMPONENT_REGISTER(&uct_cma_component);

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -97,6 +97,17 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_knem_iface_t, uct_iface_t, uct_md_h,
                                  const uct_iface_config_t *);
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
-UCT_TL_DEFINE(&uct_knem_component, knem, uct_sm_base_query_tl_devices,
-              uct_knem_iface_t, "KNEM_", uct_knem_iface_config_table,
-              uct_knem_iface_config_t);
+UCT_COMPONENT_REGISTER_DEF(&uct_knem_component, knem);
+
+UCT_TL_REGISTER_DEF(&uct_knem_component, knem, uct_sm_base_query_tl_devices,
+                    uct_knem_iface_t, "KNEM_", uct_knem_iface_config_table,
+                    uct_knem_iface_config_t);
+
+UCT_TL_INIT(knem)
+{
+}
+
+UCT_TL_CLEANUP(knem)
+{
+}
+

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -427,4 +427,3 @@ uct_component_t uct_knem_component = {
     .flags              = 0,
     .md_vfs_init        = uct_knem_md_vfs_init
 };
-UCT_COMPONENT_REGISTER(&uct_knem_component);


### PR DESCRIPTION
- implemented single constructor entries for
  SM modules: posix, sysv, xpmem, cma, knem
