### PR TITLE
UCM/UCS: Fail to create memtype cache if cannot patch Cuda driver API

### DIFF
--- a/config/m4/ucm.m4
+++ b/config/m4/ucm.m4
@@ -46,6 +46,13 @@ AC_CHECK_DECLS([MADV_FREE,
                [#include <sys/mman.h>])
 
 
+#
+# getauxval()
+#
+AC_CHECK_DECLS([getauxval], [], [],
+               [#include <sys/auxv.h>])
+
+
 # BISTRO hooks infrastructure
 #
 # SYS_xxx macro

--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -58,7 +58,6 @@
     ((UCM_MMAP_MAX_EVENT_NAME_LEN + 2) * \
     ucs_static_array_size(ucm_mmap_event_name))
 
-extern const char *ucm_mmap_hook_modes[];
 
 typedef struct ucm_mmap_func {
     ucm_reloc_patch_t    patch;
@@ -88,6 +87,15 @@ static ucm_mmap_func_t ucm_mmap_funcs[] = {
 
 static pthread_mutex_t ucm_mmap_install_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int ucm_mmap_installed_events = 0; /* events that were reported as installed */
+
+const char *ucm_mmap_hook_modes[] = {
+    [UCM_MMAP_HOOK_NONE]   = "none",
+    [UCM_MMAP_HOOK_RELOC]  = UCM_MMAP_HOOK_RELOC_STR,
+#if UCM_BISTRO_HOOKS
+    [UCM_MMAP_HOOK_BISTRO] = UCM_MMAP_HOOK_BISTRO_STR,
+#endif
+    [UCM_MMAP_HOOK_LAST]   = NULL
+};
 
 static const char *ucm_mmap_event_name[] = {
     /* Native events */

--- a/src/ucm/mmap/mmap.h
+++ b/src/ucm/mmap/mmap.h
@@ -39,6 +39,13 @@ ucs_status_t ucm_mmap_test_installed_events(int events);
 ucs_status_t ucm_mmap_test_events(int events, const char *event_type);
 void ucm_mmap_init();
 
+
+/**
+ * Memory hooks mode names.
+ */
+extern const char *ucm_mmap_hook_modes[];
+
+
 static UCS_F_ALWAYS_INLINE ucm_mmap_hook_mode_t ucm_mmap_hook_mode(void)
 {
     return ucm_get_hook_mode(ucm_global_opts.mmap_hook_mode);

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -29,6 +29,11 @@
 #include <link.h>
 #include <limits.h>
 
+#ifdef HAVE_DECL_GETAUXVAL
+#include <sys/auxv.h>
+#endif
+
+
 /* Ensure this macro is defined (from <link.h>) - otherwise, cppcheck might
    fail with an "unknown macro" warning */
 #ifndef ElfW
@@ -115,6 +120,14 @@ static ucs_status_t ucm_reloc_get_aux_phsize(int *phsize_p)
         *phsize_p = phsize;
         return UCS_OK;
     }
+
+#ifdef HAVE_DECL_GETAUXVAL
+    phsize = getauxval(AT_PHENT);
+    if (phsize > 0) {
+        *phsize_p = phsize;
+        return UCS_OK;
+    }
+#endif
 
     fd = open(proc_auxv_filename, O_RDONLY);
     if (fd < 0) {

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -37,7 +37,7 @@ ucs_global_opts_t ucs_global_opts = {
     .debug_signo           = SIGHUP,
     .log_level_trigger     = UCS_LOG_LEVEL_FATAL,
     .warn_unused_env_vars  = 1,
-    .enable_memtype_cache  = 1,
+    .enable_memtype_cache  = UCS_TRY,
     .async_max_events      = 64,
     .async_signo           = SIGALRM,
     .stats_dest            = "",
@@ -147,9 +147,9 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "configuration parser.",
   ucs_offsetof(ucs_global_opts_t, warn_unused_env_vars), UCS_CONFIG_TYPE_BOOL},
 
-  {"MEMTYPE_CACHE", "y",
+  {"MEMTYPE_CACHE", "try",
    "Enable memory type (cuda/rocm) cache",
-   ucs_offsetof(ucs_global_opts_t, enable_memtype_cache), UCS_CONFIG_TYPE_BOOL},
+   ucs_offsetof(ucs_global_opts_t, enable_memtype_cache), UCS_CONFIG_TYPE_TERNARY},
 
  {"ASYNC_MAX_EVENTS", "1024", /* TODO remove this; resize mpmc */
   "Maximal number of events which can be handled from one context",

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -80,7 +80,7 @@ typedef struct {
     unsigned                   async_max_events;
 
     /** Memtype cache */
-    int                        enable_memtype_cache;
+    ucs_ternary_auto_value_t   enable_memtype_cache;
 
     /* Destination for statistics: udp:host:port / file:path / stdout
      */

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -12,20 +12,12 @@
 
 #include <ucm/api/ucm.h>
 #include <ucm/util/log.h>
+#include <ucm/util/sys.h>
 #include <ucm/mmap/mmap.h>
 #include <ucs/sys/compiler.h>
 
 
 #define UCM_CONFIG_PREFIX   "MEM_"
-
-static const char *ucm_mmap_hook_modes[] = {
-    [UCM_MMAP_HOOK_NONE]   = "none",
-    [UCM_MMAP_HOOK_RELOC]  = UCM_MMAP_HOOK_RELOC_STR,
-#if UCM_BISTRO_HOOKS
-    [UCM_MMAP_HOOK_BISTRO] = UCM_MMAP_HOOK_BISTRO_STR,
-#endif
-    [UCM_MMAP_HOOK_LAST]   = NULL
-};
 
 static const char *ucm_module_unload_prevent_modes[] = {
     [UCM_UNLOAD_PREVENT_MODE_LAZY] = "lazy",
@@ -71,9 +63,10 @@ static ucs_config_field_t ucm_global_config_table[] = {
 
   {"CUDA_HOOK_MODE",
 #if UCM_BISTRO_HOOKS
-    UCM_MMAP_HOOK_BISTRO_STR ","
-#endif
+   UCM_MMAP_HOOK_BISTRO_STR,
+#else
    UCM_MMAP_HOOK_RELOC_STR,
+#endif
    "Cuda memory hook modes. A combination of:\n"
    " none   - Don't set Cuda hooks.\n"
    " reloc  - Use ELF relocation table to set hooks. In this mode, if any\n"

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -24,6 +24,7 @@
 
 
 static ucs_spinlock_t ucs_memtype_cache_global_instance_lock;
+static int ucs_memtype_cache_failed                    = 0;
 ucs_memtype_cache_t *ucs_memtype_cache_global_instance = NULL;
 
 
@@ -56,16 +57,23 @@ static UCS_F_ALWAYS_INLINE ucs_memtype_cache_t *ucs_memtype_cache_get_global()
     ucs_memtype_cache_t *memtype_cache = NULL;
     ucs_status_t status;
 
-    if (!ucs_global_opts.enable_memtype_cache) {
+    if (ucs_global_opts.enable_memtype_cache == UCS_NO) {
         return NULL;
     }
 
     /* Double-check lock scheme */
-    if (ucs_unlikely(ucs_memtype_cache_global_instance == NULL)) {
+    if (ucs_unlikely(ucs_memtype_cache_global_instance == NULL) &&
+        !ucs_memtype_cache_failed) {
         /* Create the memtype cache outside the lock, to avoid a Coverity error
            of lock inversion with UCS_INIT_ONCE from ucm_set_event_handler() */
         status = UCS_CLASS_NEW(ucs_memtype_cache_t, &memtype_cache);
         if (status != UCS_OK) {
+            /* If we failed to create the memtype cache once, do not try again */
+            ucs_memtype_cache_failed = 1;
+            if (ucs_global_opts.enable_memtype_cache == UCS_YES) {
+                ucs_warn("failed to create memtype cache: %s",
+                         ucs_status_string(status));
+            }
             return NULL;
         }
 
@@ -386,9 +394,9 @@ static UCS_CLASS_INIT_FUNC(ucs_memtype_cache_t)
                                    UCM_EVENT_FLAG_EXISTING_ALLOC,
                                    1000, ucs_memtype_cache_event_callback,
                                    self);
-    if ((status != UCS_OK) && (status != UCS_ERR_UNSUPPORTED)) {
-        ucs_error("failed to set UCM memtype event handler: %s",
-                  ucs_status_string(status));
+    if (status != UCS_OK) {
+        ucs_diag("failed to set UCM memtype event handler: %s",
+                 ucs_status_string(status));
         goto err_cleanup_pgtable;
     }
 

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -1294,6 +1294,8 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     status = ucm_set_event_handler(params->ucm_events, params->ucm_event_priority,
                                    ucs_rcache_unmapped_callback, self);
     if (status != UCS_OK) {
+        ucs_diag("rcache failed to install UCM event handler: %s",
+                 ucs_status_string(status));
         goto err_remove_vfs;
     }
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -45,13 +45,13 @@ protected:
         if (!expect_found || (expected_type == UCS_MEMORY_TYPE_HOST)) {
             /* memory type should be not found or unknown */
             if (status != UCS_ERR_NO_ELEM) {
-                ASSERT_UCS_OK(status, << "ptr=" << ptr << " size=" << size);
+                ASSERT_UCS_OK(status, << " ptr=" << ptr << " size=" << size);
                 EXPECT_EQ(UCS_MEMORY_TYPE_UNKNOWN, mem_info.type)
                         << "ptr=" << ptr << " size=" << size
                         << mem_buffer::mem_type_name(mem_info.type);
             }
         } else {
-            ASSERT_UCS_OK(status, << "ptr=" << ptr << " size=" << size);
+            ASSERT_UCS_OK(status, << " ptr=" << ptr << " size=" << size);
             EXPECT_TRUE((UCS_MEMORY_TYPE_UNKNOWN == mem_info.type) ||
                         (expected_type == mem_info.type))
                     << "ptr=" << ptr << " size=" << size

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -126,7 +126,7 @@ public:
     {
         void *address = NULL;
         ucs_status_t status = ucs_mmap_alloc(&length, &address, 0, "test_dummy");
-        ASSERT_UCS_OK(status, << "length = " << length);
+        ASSERT_UCS_OK(status, << " length = " << length);
         status = ucs_mmap_free(address, length);
         ASSERT_UCS_OK(status);
         /* coverity[use_after_free] */


### PR DESCRIPTION
## Why
Many Cuda applications use static link, so it's not safe to assume that relocation-based memory hooks on Cuda runtime API can be enough. To be on the safe safe, fail to create the registration cache and (by default) fallback to pointer-query based memory detection.
Note: As a side effect, this will also disable RDMA registration cache when could not install Cuda hooks, since not knowing about a Cuda memory release can lead to stale memory keys in the cache and a data corruption.

## How
- Use Cuda Bistro hooks by default
- UCX_MEMTYPE_CACHE can by yes/no/try (default: try). If set to yes and it could not be created - print a warning.
- Memtype cache fails to create if could not set memtype hooks

The logic is:
* `UCX_MEM_CUDA_HOOK_MODE=bistro (default)`:
    * If bistro hooks on driver API **fail** - registration cache and memory type cache are not created.
      If also `UCX_MEMTYPE_CACHE=y` (default is `try`) - a warning is printed.
* `UCX_MEM_CUDA_HOOK_MODE=reloc`:
   This method sets reloc hooks on both driver and runtime APIs.
   If either driver or runtime API reloc hooks fail (it's not expected) - memtype cache and rcache are disabled.
   This method is safe only if the application is dynamically linked to cuda runtime API (or using the driver API directly), so it's not the default.

## Debugging
Set "UCX_MEM_LOG_LEVEL=diag" to get more info if failed to install memory hooks.

Related to https://github.com/openucx/ucx/pull/7791#issuecomment-1016719453
cc @Akshay-Venkatesh @pentschev 