### PR TITLE
AZP: Add BF to CI

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -248,6 +248,11 @@ stages:
           - ucx_docker -equals yes
           - ucx_amd -equals no
         container: centos7
+    - template: tests.yml
+      parameters:
+        name: BlueField
+        demands: ucx_bf -equals yes
+        test_perf: 0
 
   - stage: io_demo
     dependsOn: [Static_check]

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1125,6 +1125,12 @@ run_gtest() {
 }
 
 run_gtest_armclang() {
+	if [[ $(hostname) =~ '-bf1' ]]
+	then
+		# Skip armclang test on SoC platform
+		return 0
+	fi
+
 	if module_load arm-compiler/arm-hpc-compiler && armclang -v
 	then
 		# Force using loaded gcc toolchain instead of host gcc, to avoid


### PR DESCRIPTION
## Why
Run UCX CI on BLueField2 SoC device