### PR TITLE
UCP/CORE/GTEST: Drain keeplive timer fd to not trigger unnecessary events on user's fd

### DIFF
--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -259,9 +259,8 @@ protected:
                                    int worker_index = 0);
     void request_release(void *req);
     void request_cancel(entity &e, void *req);
-    void wait_for_wakeup(const std::vector<entity*> &entities,
-                         int poll_timeout = -1, bool drain = false,
-                         int worker_index = 0);
+    int wait_for_wakeup(const std::vector<entity*> &entities,
+                        int poll_timeout = -1, int worker_index = 0);
     int max_connections();
     void set_tl_small_timeouts();
 


### PR DESCRIPTION
## What

Drain keeplive `timerfd` to not trigger unnecessary events on user's fd.

## Why ?

Fixes #7864.
`timerfd`  should be drained by doing 64-bit `read()` to not re-trigger events.

## How ?

1. Update keepalive gtest to reproduce the issue by draining wakeup FD after detecting error and closing fdailed EP.
2. Added `ucp_worker_fd_read()`, used it for `eventfd`.
3. Made keepalive `timerfd` non-blocking, to call `read()` in non-blocking manner inside `ucp_worker_do_keepalive_progress()`.
4. Used `ucp_worker_fd_read()` in a loop while `status == UCS_ERR_BUSY` to drain keepalive `timerfd`.
5. If wakeup feature is used, use `ucp_worker_do_keepalive_progress()` directly instead of `ucp_worker_keepalive_progress()` which skips some keepalive attempts.