### PR TITLE
CONTRIB/SCRIPTS: Fix name of VFS in QPs check script

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -12,6 +12,7 @@ pr:
     - .gitignore
     - .readthedocs.yaml
     - contrib/pr_merge_check.py
+    - contrib/check_qps.sh
     - docs/source
     - docs/CodeStyle.md
     - docs/LoggingStyle.md

--- a/contrib/check_qps.sh
+++ b/contrib/check_qps.sh
@@ -26,7 +26,7 @@ usage()
     echo "  "$0" [ options ]"
     echo " Options:"
     echo "  -a           Print all QPs"
-    echo "  -p <path>    Path to UCX CFS mount point (/tmp/ucx)"
+    echo "  -p <path>    Path to UCX VFS mount point (default: ${VFS_UCX_PATH})"
     echo "  -i <seconds> Interval to check QP state"
     exit 1
 }


### PR DESCRIPTION
## What

Fix name of VFS in QPs check script.

## Why ?

1. It should be "VFS" instead of "CFS".
2. Use default path "/tmp/ucx" from variable instead of duplication.

## How ?

1. Replace "VFS" by "CFS".
2. Print `${VFS_UCX_PATH}` instead of `/tmp/ucx`.
3. Excluded `contrib/check_qps.sh` from AZP CI.