### PR TITLE
UCT/IB: correct data structure to get member value

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -267,7 +267,7 @@ uct_ib_mlx5_devx_query_qp(uct_ib_mlx5_qp_t *qp, void *in, size_t inlen,
         if (ret) {
             ucs_error("mlx5dv_devx_qp_query(%x) failed, syndrome %x: %m",
                       UCT_IB_MLX5_CMD_OP_QUERY_QP,
-                      UCT_IB_MLX5DV_GET(modify_qp_out, out, syndrome));
+                      UCT_IB_MLX5DV_GET(query_qp_out, out, syndrome));
             return UCS_ERR_IO_ERROR;
         }
         break;
@@ -276,7 +276,7 @@ uct_ib_mlx5_devx_query_qp(uct_ib_mlx5_qp_t *qp, void *in, size_t inlen,
         if (ret) {
             ucs_error("mlx5dv_devx_obj_query(%x) failed, syndrome %x: %m",
                       UCT_IB_MLX5_CMD_OP_QUERY_QP,
-                      UCT_IB_MLX5DV_GET(modify_qp_out, out, syndrome));
+                      UCT_IB_MLX5DV_GET(query_qp_out, out, syndrome));
             return UCS_ERR_IO_ERROR;
         }
         break;


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
In uct_ib_mlx5_devx_query_qp, use uct_ib_mlx5_query_qp_out_bits to get syndrome instead of uct_ib_mlx5_modify_qp_out_bits