### PR TITLE
UCT/DC: initialize dci->path_index before setting port affinity

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -367,6 +367,9 @@ init_qp:
         goto err_qp;
     }
 
+    dci->pool_index = pool_index;
+    dci->path_index = path_index;
+
     status = uct_dc_mlx5_iface_dci_connect(iface, dci);
     if (status != UCS_OK) {
         goto err;
@@ -388,8 +391,6 @@ init_qp:
     }
 
     uct_rc_txqp_available_set(&dci->txqp, dci->txwq.bb_max);
-    dci->pool_index = pool_index;
-    dci->path_index = path_index;
 
     return UCS_OK;
 


### PR DESCRIPTION
Fix below RoCE LAG case when creating DCI under DEVX:
```
  uct_dc_mlx5_iface_create_dci
  |--> uct_ib_mlx5_devx_create_qp
  |--> uct_dc_mlx5_iface_dci_connect
       |--> uct_dc_mlx5_iface_devx_dci_connect
  	      |--> uct_ib_mlx5_devx_set_qpc_port_affinity(dci->path_index)
  |--> dci->path_index = path_index
```

Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
Correct set dci port affinity

## Why ?
It should use right value to set dci port affinity

## How ?
assign value to dci->path_index before using it.
