### PR TITLE
TEST/GTEST: Don't run sockaddr tests on bridge interfaces

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -438,6 +438,24 @@ bool is_inet_addr(const struct sockaddr* ifa_addr) {
            (ifa_addr->sa_family == AF_INET6);
 }
 
+static bool netif_has_sysfs_file(const char *ifa_name, const char *file_name)
+{
+    char path[PATH_MAX];
+    ucs_snprintf_safe(path, sizeof(path), "/sys/class/net/%s/%s", ifa_name,
+                      file_name);
+
+    struct stat st;
+    return stat(path, &st) >= 0;
+}
+
+bool is_interface_usable(struct ifaddrs *ifa)
+{
+    return ucs_netif_flags_is_active(ifa->ifa_flags) &&
+           ucs::is_inet_addr(ifa->ifa_addr) &&
+           !netif_has_sysfs_file(ifa->ifa_name, "bridge") &&
+           !netif_has_sysfs_file(ifa->ifa_name, "brport");
+}
+
 static std::vector<std::string> read_dir(const std::string& path)
 {
     std::vector<std::string> result;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -30,6 +30,7 @@
 #include <sys/socket.h>
 #include <dirent.h>
 #include <stdint.h>
+#include <ifaddrs.h>
 
 
 #ifndef UINT16_MAX
@@ -304,9 +305,15 @@ void safe_usleep(double usec);
 
 
 /**
- * Check if the given interface has an IPv4 or an IPv6 address.
+ * Check if the given network interface has an IPv4 or an IPv6 address.
  */
 bool is_inet_addr(const struct sockaddr* ifa_addr);
+
+
+/**
+ * Check if the given network interface should be used for testing.
+ */
+bool is_interface_usable(struct ifaddrs *ifa);
 
 
 /**

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -625,17 +625,17 @@ UCS_TEST_P(test_md, sockaddr_accessibility) {
     ASSERT_TRUE(getifaddrs(&ifaddr) != -1);
     /* go through a linked list of available interfaces */
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-        if (ucs::is_inet_addr(ifa->ifa_addr) &&
-            ucs_netif_flags_is_active(ifa->ifa_flags)) {
-            sock_addr.addr = ifa->ifa_addr;
-
-            UCS_TEST_MESSAGE << "Testing " << ifa->ifa_name << " with "
-                             << ucs::sockaddr_to_str(ifa->ifa_addr);
-            ASSERT_FALSE(uct_md_is_sockaddr_accessible(md(), &sock_addr,
-                                                       UCT_SOCKADDR_ACC_LOCAL));
-            ASSERT_FALSE(uct_md_is_sockaddr_accessible(md(), &sock_addr,
-                                                       UCT_SOCKADDR_ACC_REMOTE));
+        if (!ucs::is_interface_usable(ifa)) {
+            continue;
         }
+
+        sock_addr.addr = ifa->ifa_addr;
+        UCS_TEST_MESSAGE << "Testing " << ifa->ifa_name << " with "
+                         << ucs::sockaddr_to_str(ifa->ifa_addr);
+        ASSERT_FALSE(uct_md_is_sockaddr_accessible(md(), &sock_addr,
+                                                   UCT_SOCKADDR_ACC_LOCAL));
+        ASSERT_FALSE(uct_md_is_sockaddr_accessible(md(), &sock_addr,
+                                                   UCT_SOCKADDR_ACC_REMOTE));
     }
     freeifaddrs(ifaddr);
 }

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -15,7 +15,6 @@
 #ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
-#include <ifaddrs.h>
 
 
 std::string resource::name() const {
@@ -292,8 +291,7 @@ void uct_test::set_interface_rscs(uct_component_h cmpt, const char *cmpt_name,
 }
 
 bool uct_test::is_interface_usable(struct ifaddrs *ifa, const char *name) {
-    if (!(ucs_netif_flags_is_active(ifa->ifa_flags)) ||
-        !(ucs::is_inet_addr(ifa->ifa_addr))) {
+    if (!ucs::is_interface_usable(ifa)) {
         return false;
     }
 


### PR DESCRIPTION
## Why
Fix test failures when docker instances run on the same machine and create temporary bridge interfaces.

## How
Prevent sockaddr gtests from running on bridge interfaces