### PR TITLE
UCT/IB/DC: Fix error handling for keepalive DCI if EP has another DCI

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1558,13 +1558,13 @@ out:
     return status;
 }
 
-void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
+void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
+                                   struct mlx5_cqe64 *cqe,
                                    ucs_status_t ep_status)
 {
-    struct mlx5_cqe64 *cqe     = arg;
-    uct_iface_h tl_iface       = ep->super.super.iface;
+    uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                                uct_dc_mlx5_iface_t);
     uint8_t dci_index          = ep->dci;
-    uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
     uint16_t pi                = ntohs(cqe->wqe_counter);
     uint8_t pool_index;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -294,7 +294,8 @@ uct_dc_mlx5_ep_from_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
     return iface->tx.dcis[dci_index].ep;
 }
 
-void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
+void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
+                                   struct mlx5_cqe64 *cqe,
                                    ucs_status_t status);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t


### PR DESCRIPTION
## What

Fix error handling for keepalive DCI if EP has another DCI.

## Why ?

If got failure on keepalive DCI, don't update TX resources of normal DCI of the EP, because CQE is not related to this DCI.
It fixes:
```
[jazz17:136720:0:136720]   dc_mlx5.inl:21   Assertion `uct_rc_txqp_available(txqp) <= txwq->bb_max' failed

/hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.inl: [ uct_dc_mlx5_update_tx_res() ]
      ...
       18                           uct_rc_txqp_t *txqp, uint16_t hw_ci)
       19 {
       20     uct_rc_txqp_available_set(txqp, uct_ib_mlx5_txwq_update_bb(txwq, hw_ci));
==>    21     ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
       22
       23     uct_rc_iface_update_reads(&iface->super.super);
       24 }

==== backtrace (tid: 136720) ====
 0 0x00000000001341d2 uct_dc_mlx5_update_tx_res()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.inl:21
 1 0x00000000001341d2 uct_dc_mlx5_ep_handle_failure()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5_ep.c:1597
 2 0x000000000015b6a4 uct_dc_mlx5_dci_keepalive_handle_failure()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.c:1494
 3 0x000000000015a971 uct_dc_mlx5_iface_handle_failure()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.c:1215
 4 0x000000000002d6d8 uct_ib_mlx5_check_completion()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/mlx5/ib_mlx5.c:358
 5 0x000000000014c5cb uct_ib_mlx5_poll_cq()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/mlx5/ib_mlx5.inl:91
 6 0x000000000014c5cb uct_dc_mlx5_poll_tx()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.c:231
 7 0x000000000014c5cb uct_dc_mlx5_iface_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.c:275
 8 0x000000000014c5cb uct_dc_mlx5_iface_progress_ll()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/ib/dc/dc_mlx5.c:285
 9 0x000000000006121b ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/ucs/datastruct/callbackq.h:211
10 0x000000000006e114 uct_worker_progress()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/api/uct.h:2600
11 0x0000000000404ec6 UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/test/apps/iodemo/ucx_wrapper.cc:389
12 0x000000000040454d UcxContext::progress()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/test/apps/iodemo/ucx_wrapper.cc:223
13 0x0000000000414366 DemoServer::run()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/test/apps/iodemo/io_demo.cc:1224
14 0x0000000000410653 do_server()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/test/apps/iodemo/io_demo.cc:2869
15 0x0000000000410c38 main()  /hpc/mtr_scrap/users/dmitrygla/ucx_int3/test/apps/iodemo/io_demo.cc:2934
16 0x00000000000223d5 __libc_start_main()  ???:0
17 0x0000000000403459 _start()  ???:0
=================================
```

## How ?

1. Rename `uct_dc_mlx5_ep_handle_failure` to `uct_dc_mlx5_ep_failure_release_dci` which better reflects the idea of the function.
2. Move updating TX resources, purging outstanding and calling error callback outside of the function to be called by a caller for the CQE which was completed with error.
3. Update TX resources, purge outstanding, and invoke error callback prior to calling `uct_dc_mlx5_ep_failure_release_dci` in case of failure detected on normal DCI.
4. Invoke error callback and then do `uct_dc_mlx5_ep_failure_release_dci` (if EP has another DCI) and then update TX resources, purge outstanding operations in case of failure detected on keepalive DCI.