### PR TITLE
UCP/PROTO/RNDV: added alignemt for get zcopy

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -47,7 +47,8 @@ ucp_am_eager_multi_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
         .first.lane_type     = UCP_LANE_TYPE_AM,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_AM_BW,
-        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     if (!ucp_am_check_init_params(init_params, UCP_AM_OP_ID_MASK_ALL,
@@ -114,7 +115,7 @@ static size_t ucp_am_eager_multi_bcopy_pack_args_mid(void *dest, void *arg)
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_bcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
-        ucp_datatype_iter_t *next_iter)
+        ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
     size_t user_hdr_size = req->send.msg_proto.am.header.length;
 
@@ -207,7 +208,7 @@ ucp_am_eager_fill_middle_header(ucp_am_mid_hdr_t *hdr, ucp_request_t *req)
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_zcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
-        ucp_datatype_iter_t *next_iter)
+        ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
     size_t user_hdr_size = req->send.msg_proto.am.header.length;
     union {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -380,6 +380,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
   {"PROTO_INFO", "n", "Enable printing protocols information.",
    ucs_offsetof(ucp_context_config_t, proto_info), UCS_CONFIG_TYPE_BOOL},
 
+  {"RNDV_ALIGN_THRESH", "64kB",
+   "If the rendezvous payload size is larger than this value, it could be split\n"
+   "in order to optimize memory alignment",
+   ucs_offsetof(ucp_context_config_t, rndv_align_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"PROTO_INFO_DIR", "",
    "If non-empty, protocol selection information files will be written to this\n"
    "directory.",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -142,6 +142,8 @@ typedef struct ucp_context_config {
     int                                    rkey_mpool_max_md;
     /** Worker address format version */
     ucp_object_version_t                   worker_addr_version;
+    /** Threshold for enabling RNDV data split alignment */
+    size_t                                 rndv_align_thresh;
     /** Print protocols information */
     int                                    proto_info;
     /** MD to compare for transport selection scores */

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -94,7 +94,7 @@ typedef struct {
 
     /* Offset in uct_iface_attr_t structure of the field which specifies the
      * maximal number of iov elements for the UCT operation used by this
-    * protocol */
+     * protocol */
     ptrdiff_t               max_iov_offs;
 
     /* Header size on the first lane */
@@ -171,6 +171,10 @@ typedef void (*ucp_proto_init_cb_t)(ucp_request_t *req);
  */
 typedef ucs_status_t (*ucp_proto_complete_cb_t)(ucp_request_t *req);
 
+
+ucp_rsc_index_t
+ucp_proto_common_get_rsc_index(const ucp_proto_init_params_t *params,
+                               ucp_lane_index_t lane);
 
 void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *params,
                                      ucp_md_map_t md_map, ucp_lane_index_t lane,

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -127,6 +127,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     mpriv->num_lanes    = 0;
     mpriv->min_frag     = 0;
     mpriv->max_frag_sum = 0;
+    mpriv->align_thresh = 1;
     perf.max_frag       = SIZE_MAX;
     perf.min_length     = 0;
     weight_sum          = 0;
@@ -200,6 +201,9 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         mpriv->max_frag_sum += lpriv->max_frag;
         lpriv->weight_sum    = weight_sum;
         lpriv->max_frag_sum  = mpriv->max_frag_sum;
+        lpriv->opt_align     = ucp_proto_multi_get_lane_opt_align(params, lane);
+        mpriv->align_thresh  = ucs_max(mpriv->align_thresh,
+                                       lpriv->opt_align);
     }
     ucs_assert(mpriv->num_lanes == ucs_popcount(lane_map));
 

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -48,6 +48,9 @@ typedef struct {
 
     /* Sum of 'weight' on all previous lanes, inclusive */
     uint32_t                     weight_sum;
+
+    /* Optimal alignment for zero-copy buffer address */
+    size_t                       opt_align;
 } ucp_proto_multi_lane_priv_t;
 
 
@@ -60,6 +63,8 @@ typedef struct {
     size_t                      max_frag_sum; /* 'max_frag' sum of all lanes */
     ucp_lane_map_t              lane_map;     /* Map of used lanes */
     ucp_lane_index_t            num_lanes;    /* Number of lanes to use */
+    size_t                      align_thresh; /* Cached value of threshold for
+                                                 enabling data split alignment */
     ucp_proto_multi_lane_priv_t lanes[0];     /* Array of lanes */
 } ucp_proto_multi_priv_t;
 
@@ -76,6 +81,12 @@ typedef struct {
     /* MDs on which the buffer is expected to be already registered, so no need
        to account for the overhead of registering on them */
     ucp_md_map_t                   initial_reg_md_map;
+
+    /* Offset in uct_iface_attr_t structure of the field which specifies the
+     * optimal alignment for buffer address for the UCT operation used
+     * by this protocol */
+    ptrdiff_t                      opt_align_offs;
+
     struct {
         /* Required iface capabilities */
         uint64_t        tl_cap_flags;
@@ -98,7 +109,7 @@ typedef struct {
 
 typedef ucs_status_t (*ucp_proto_send_multi_cb_t)(
                 ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
-                ucp_datatype_iter_t *next_iter);
+                ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift);
 
 
 /**

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -25,7 +25,8 @@ static void ucp_proto_get_offload_bcopy_unpack(void *arg, const void *data,
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_get_offload_bcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter)
+                                      ucp_datatype_iter_t *next_iter,
+                                      ucp_lane_index_t *lane_shift)
 {
     uct_rkey_t tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
                                               lpriv->super.rkey_index);
@@ -98,6 +99,7 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
         .first.lane_type     = UCP_LANE_TYPE_RMA,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_GET_BCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_RMA,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
@@ -119,7 +121,8 @@ ucp_proto_t ucp_get_offload_bcopy_proto = {
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter)
+                                      ucp_datatype_iter_t *next_iter,
+                                      ucp_lane_index_t *lane_shift)
 {
     uct_rkey_t tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
                                               lpriv->super.rkey_index);
@@ -184,7 +187,8 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,
         .first.lane_type     = UCP_LANE_TYPE_RMA,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_GET_ZCOPY,
-        .middle.lane_type    = UCP_LANE_TYPE_RMA
+        .middle.lane_type    = UCP_LANE_TYPE_RMA,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -33,7 +33,8 @@ static size_t ucp_proto_put_am_bcopy_pack(void *dest, void *arg)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_put_am_bcopy_send_func(ucp_request_t *req,
                                  const ucp_proto_multi_lane_priv_t *lpriv,
-                                 ucp_datatype_iter_t *next_iter)
+                                 ucp_datatype_iter_t *next_iter,
+                                 ucp_lane_index_t *lane_shift)
 {
     ucp_proto_multi_pack_ctx_t pack_ctx = {
         .req         = req,
@@ -97,6 +98,7 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .first.lane_type     = UCP_LANE_TYPE_AM,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_AM,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -100,7 +100,8 @@ static size_t ucp_proto_put_offload_bcopy_pack(void *dest, void *arg)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_put_offload_bcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter)
+                                      ucp_datatype_iter_t *next_iter,
+                                      ucp_lane_index_t *lane_shift)
 {
     ucp_ep_t *ep                        = req->send.ep;
     ucp_proto_multi_pack_ctx_t pack_ctx = {
@@ -156,7 +157,7 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.min_iov       = 0,
         .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
         .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t,
-                                            cap.put.max_bcopy),
+                                           cap.put.max_bcopy),
         .super.max_iov_offs  = UCP_PROTO_COMMON_OFFSET_INVALID,
         .super.hdr_size      = 0,
         .super.send_op       = UCT_EP_OP_PUT_BCOPY,
@@ -169,6 +170,7 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
         .first.lane_type     = UCP_LANE_TYPE_RMA,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_PUT_BCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_RMA,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);
@@ -190,7 +192,8 @@ ucp_proto_t ucp_put_offload_bcopy_proto = {
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter)
+                                      ucp_datatype_iter_t *next_iter,
+                                      ucp_lane_index_t *lane_shift)
 {
     uct_rkey_t tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
                                               lpriv->super.rkey_index);
@@ -235,7 +238,7 @@ ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
         .super.max_length    = SIZE_MAX,
         .super.min_iov       = 1,
         .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t,
-                                            cap.put.min_zcopy),
+                                           cap.put.min_zcopy),
         .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t,
                                             cap.put.max_zcopy),
         .super.max_iov_offs  = ucs_offsetof(uct_iface_attr_t, cap.put.max_iov),
@@ -251,6 +254,7 @@ ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
         .first.lane_type     = UCP_LANE_TYPE_RMA,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_PUT_ZCOPY,
         .middle.lane_type    = UCP_LANE_TYPE_RMA,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
     };
 
     UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -517,6 +517,9 @@ ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
                          ucp_proto_rndv_bulk_priv_t *rpriv, const char *name,
                          const char *ack_name, size_t *priv_size_p)
 {
+    ucp_context_t *context        = init_params->super.super.worker->context;
+    size_t rndv_align_thresh      = context->config.ext.rndv_align_thresh;
+    ucp_proto_multi_priv_t *mpriv = &rpriv->mpriv;
     ucp_proto_multi_init_params_t bulk_params;
     ucp_proto_caps_t multi_caps;
     ucs_status_t status;
@@ -530,6 +533,10 @@ ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
     if (status != UCS_OK) {
         return status;
     }
+
+    /* Adjust align split threshold by user configuration */
+    mpriv->align_thresh = ucs_max(rndv_align_thresh,
+                                  mpriv->align_thresh + mpriv->min_frag);
 
     /* Update private data size based of ucp_proto_multi_priv_t variable size */
     *priv_size_p = ucs_offsetof(ucp_proto_rndv_bulk_priv_t, mpriv) + mpriv_size;

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -48,7 +48,7 @@ static size_t ucp_proto_rndv_am_bcopy_pack(void *dest, void *arg)
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_am_bcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
-        ucp_datatype_iter_t *next_iter)
+        ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
     static const size_t hdr_size        = sizeof(ucp_request_data_hdr_t);
     ucp_ep_t *ep                        = req->send.ep;
@@ -109,6 +109,7 @@ ucp_proto_rdnv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     return ucp_proto_rdnv_am_init_common(&params);

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -72,8 +72,9 @@ static ucs_status_t ucp_proto_eager_bcopy_multi_common_init(
         .super.send_op       = UCT_EP_OP_AM_BCOPY,
         .super.memtype_op    = UCT_EP_OP_GET_SHORT,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
-        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
     };
 
     return ucp_proto_eager_multi_init_common(&params, op_id);
@@ -107,7 +108,8 @@ ucp_proto_eager_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_eager_bcopy_multi_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter)
+                                      ucp_datatype_iter_t *next_iter,
+                                      ucp_lane_index_t *lane_shift)
 {
     return ucp_proto_eager_bcopy_multi_common_send_func(
             req, lpriv, next_iter, UCP_AM_ID_EAGER_FIRST,
@@ -162,7 +164,7 @@ static size_t ucp_eager_sync_bcopy_pack_first(void *dest, void *arg)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_eager_sync_bcopy_multi_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
-        ucp_datatype_iter_t *next_iter)
+        ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
     return ucp_proto_eager_bcopy_multi_common_send_func(
             req, lpriv, next_iter, UCP_AM_ID_EAGER_SYNC_FIRST,
@@ -234,8 +236,9 @@ ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
         .super.memtype_op    = UCT_EP_OP_LAST,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
-        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY
     };
 
     return ucp_proto_eager_multi_init_common(&params, UCP_OP_ID_TAG_SEND);
@@ -244,7 +247,8 @@ ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter)
+                                      ucp_datatype_iter_t *next_iter,
+                                      ucp_lane_index_t *lane_shift)
 {
     union {
         ucp_eager_first_hdr_t  first;


### PR DESCRIPTION
## Why ?
Fixes Proto v2 perf degradation for large message sizes in comparison with the old protocol.

## How ?
Calculating such size for the first fragment to ensure proper alignment for the following fragments.