### PR TITLE
AZP/STATIC_CHECK: Upload HTML report as artifact

### DIFF
--- a/buildlib/pr/static_checks.yml
+++ b/buildlib/pr/static_checks.yml
@@ -20,13 +20,19 @@ jobs:
           cppcheck --version
           ${WORKSPACE}/contrib/configure-release
 
+          report_dir=$(readlink -f $(System.DefaultWorkingDirectory)/static_check)
+          mkdir -p $report_dir
+          echo "##vso[task.setvariable variable=reportExists]True"
+          echo "##vso[task.setvariable variable=report_dir]$report_dir"
+
           export PATH="`csclng --print-path-to-wrap`:`cscppc --print-path-to-wrap`:`cswrap --print-path-to-wrap`:$PATH"
+          export CSCLNG_ADD_OPTS="-Xanalyzer:-analyzer-output=html:-o:$report_dir"
           set -o pipefail
-          make -j`nproc` |& tee compile.log
+          make -j`nproc` |& tee $report_dir/compile.log
           set +o pipefail
 
           cs_errors="cs.err"
-          cslinker --quiet compile.log \
+          cslinker --quiet $report_dir/compile.log \
             | csgrep --mode=json --path ${WORKSPACE} --strip-path-prefix ${WORKSPACE} \
             | csgrep --mode=json --invert-match --path 'conftest.c' \
             | csgrep --mode=grep --invert-match --event "internal warning" --prune-events=1 \
@@ -43,3 +49,8 @@ jobs:
         displayName: cstools reports
         env:
           BUILD_ID: "$(Build.BuildId)-$(Build.BuildNumber)"
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: $(report_dir)
+          artifactName: static_check
+        condition: and(failed(), eq(variables['reportExists'], 'True'))


### PR DESCRIPTION
## Why
When clang static checker fails in CI, it's not easy to understand the underlying reason.
This PR uploads HTML files with more details about the failure.

## How
- Add `-Xanalyzer:-analyzer-output=html` to cslng env var `CSCLNG_ADD_OPTS`
- Upload the resulting directory as AZP artifact