### PR TITLE
UCT/CUDA_IPC: add remote iface addr sys_dev map

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -17,10 +17,11 @@ uct_cuda_base_query_devices_common(
         uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p)
 {
     ucs_sys_device_t sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
+    ucs_sys_bus_id_t bus_id;
     CUdevice cuda_device;
 
     if (cuCtxGetDevice(&cuda_device) == CUDA_SUCCESS) {
-        uct_cuda_base_get_sys_dev(cuda_device, &sys_device);
+        uct_cuda_base_get_sys_dev(cuda_device, &sys_device, &bus_id);
     }
 
     return uct_single_device_resource(md, UCT_CUDA_DEV_NAME, dev_type,

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -133,6 +133,7 @@ uct_cuda_base_query_devices(
 
 ucs_status_t
 uct_cuda_base_get_sys_dev(CUdevice cuda_device,
-                          ucs_sys_device_t *sys_dev_p);
+                          ucs_sys_device_t *sys_dev_p,
+                          ucs_sys_bus_id_t *bus_id);
 
 #endif

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -13,7 +13,7 @@
 
 #include <ucs/sys/module.h>
 #include <ucs/sys/string.h>
-#include <ucs/sys/topo.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <ucs/memory/memtype_cache.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/profile/profile.h>

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -8,6 +8,21 @@
 
 #include <uct/base/uct_md.h>
 
+#define UCT_CUDA_DEV_NAME_MAX_LEN 64
+#define UCT_CUDA_MAX_DEVICES      16
+
+
+typedef struct uct_cuda_base_sys_dev_map {
+    pid_t pid;
+    uint8_t count;
+    ucs_sys_device_t sys_dev[UCT_CUDA_MAX_DEVICES];
+    uint8_t bus_id[UCT_CUDA_MAX_DEVICES];
+} uct_cuda_base_sys_dev_map_t;
+
+
+extern uct_cuda_base_sys_dev_map_t uct_cuda_sys_dev_bus_id_map;
+
+
 ucs_status_t uct_cuda_base_detect_memory_type(uct_md_h md, const void *address,
                                               size_t length,
                                               ucs_memory_type_t *mem_type_p);


### PR DESCRIPTION
## What
UCT perf_estimate API takes two system devices (local, remote) to provide bandwidth/latency estimates. In the case of cuda_ipc, local GPU's sys_dev and remote GPU's sys_dev. But remote GPU's sys_dev may not match the same bus_id on the local process because of the order in which sys_devices are populated. For this reason, we need a way to interpret remote sys_dev and translate to local sys_dev and use in cuda_ipc perf estimate to check if there are nvlinks between the devices or not. This PR creates and exchanges local sys_device_id->bus_id map with peers. 

## Why ?
Without this, remote sys_device_id cannot be used meaningfully to see if two cuda devices are nvlink/cuda_ipc reachable. Reachability (through non-zero bandwidth) is a requirement to decide if device bounce buffers can be used for pipeline protocols.