### PR TITLE
UCS/STRING/TEST: Fix ucs_string_buffer_rtrim() for empty string

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -146,7 +146,12 @@ void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset)
 {
     char *ptr = ucs_array_end(&strb->str);
 
-    while (ucs_array_length(&strb->str) > 0) {
+    if (ucs_array_is_empty(&strb->str)) {
+        /* If the string is empty, do not write '\0' terminator */
+        return;
+    }
+
+    do {
         --ptr;
         if (((charset == NULL) && !isspace(*ptr)) ||
             ((charset != NULL) && (strchr(charset, *ptr) == NULL))) {
@@ -155,7 +160,7 @@ void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset)
         }
 
         ucs_array_set_length(&strb->str, ucs_array_length(&strb->str) - 1);
-    }
+    } while (!ucs_array_is_empty(&strb->str));
 
     /* mark the new end of string */
     *(ptr + 1) = '\0';

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -156,7 +156,6 @@ protected:
     void check_extract_mem(ucs_string_buffer_t *strb);
 };
 
-
 UCS_TEST_F(test_string_buffer, appendf) {
     ucs_string_buffer_t strb;
 
@@ -199,6 +198,11 @@ UCS_TEST_F(test_string_buffer, append_long) {
 UCS_TEST_F(test_string_buffer, rtrim) {
     static const char *test_string = "wabbalubbadabdab";
     ucs_string_buffer_t strb;
+
+    ucs_string_buffer_init(&strb);
+    ucs_string_buffer_rtrim(&strb, "x");
+    EXPECT_EQ(std::string(""), ucs_string_buffer_cstr(&strb));
+    ucs_string_buffer_cleanup(&strb);
 
     ucs_string_buffer_init(&strb);
     ucs_string_buffer_appendf(&strb, "%s%s", test_string, ",,");


### PR DESCRIPTION
## Why
Fix corner case in ucs_string_buffer_rtrim