### PR TITLE
UCP/API/INFO: Add API to define endpoint scope name for debug info

### DIFF
--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -12,12 +12,20 @@
 
 #include <ucs/config/parser.h>
 #include <ucs/config/global_opts.h>
+#include <ucs/sys/string.h>
 #include <ucm/api/ucm.h>
 #include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 
+
+const char *proc_placement_names[] = {
+    [PROCESS_PLACEMENT_SELF]  = "self",
+    [PROCESS_PLACEMENT_INTRA] = "intra",
+    [PROCESS_PLACEMENT_INTER] = "inter",
+    [PROCESS_PLACEMENT_LAST]  = NULL
+};
 
 static void usage() {
     printf("Usage: ucx_info [options]\n");
@@ -198,15 +206,9 @@ int main(int argc, char **argv)
             }
             break;
         case 'P':
-            if (!strcasecmp(optarg, "intra")) {
-                /* Only Network and SHM devices are allowed for processes on the
-                 * same node */
-                proc_placement = PROCESS_PLACEMENT_INTRA;
-            } else if (!strcasecmp(optarg, "inter")) {
-                /* Only Network devices are allowed for processes on the
-                 * different node */
-                proc_placement = PROCESS_PLACEMENT_INTER;
-            } else if (strcasecmp(optarg, "self")) {
+            proc_placement = ucs_string_find_in_list(optarg,
+                                                     proc_placement_names, 0);
+            if (proc_placement == -1) {
                 usage();
                 return -1;
             }

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -32,9 +32,12 @@ enum {
 typedef enum {
     PROCESS_PLACEMENT_SELF,
     PROCESS_PLACEMENT_INTRA,
-    PROCESS_PLACEMENT_INTER
+    PROCESS_PLACEMENT_INTER,
+    PROCESS_PLACEMENT_LAST
 } process_placement_t;
 
+
+extern const char *proc_placement_names[];
 
 void print_version();
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -250,7 +250,8 @@ enum ucp_ep_params_field {
     /**< Connection request field */
     UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6),
     UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7), /**< Endpoint name */
-    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8)  /**< Local socket Address */
+    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8), /**< Local socket address */
+    UCP_EP_PARAM_FIELD_SCOPE_NAME        = UCS_BIT(9)  /**< Endpoint scope name */
 };
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -628,7 +628,7 @@ typedef ucs_status_t (*ucp_am_callback_t)(void *arg, void *data, size_t length,
  * @param [in]  header        User defined active message header.
  *                            If @a header_length is 0, this value is undefined
  *                            and must not be accessed.
- * @param [in]  header_length Active message header length in bytes. 
+ * @param [in]  header_length Active message header length in bytes.
  * @param [in]  data          Points to the received data if @a
  *                            UCP_AM_RECV_ATTR_FLAG_RNDV flag is not set in
  *                            @ref ucp_am_recv_param_t.recv_attr. Otherwise
@@ -760,6 +760,14 @@ typedef struct ucp_ep_params {
      * UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR bit in the field mask must be set.
      */
     ucs_sock_addr_t         local_sockaddr;
+
+    /**
+     * Endpoint scope name. if set, debug information about endpoint's
+     * transports and protocols configuration will be aggregated according to
+     * the scope name string.
+     * For example: "inter-node", "intra-node", "intra-process", etc.
+     */
+    const char              *scope_name;
 
 } ucp_ep_params_t;
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -229,6 +229,9 @@ struct ucp_ep_config_key {
 
     /* Error handling mode */
     ucp_err_handling_mode_t  err_mode;
+
+    /* User-defined endpoint scope name, or ucp_ep_default_scope_name */
+    char                     *scope_name;
 };
 
 
@@ -621,11 +624,12 @@ ucs_status_t
 ucp_ep_create_to_worker_addr(ucp_worker_h worker,
                              const ucp_tl_bitmap_t *local_tl_bitmap,
                              const ucp_unpacked_address_t *remote_address,
-                             unsigned ep_init_flags, const char *message,
-                             ucp_ep_h *ep_p);
+                             unsigned ep_init_flags, const char *scope_name,
+                             const char *message, ucp_ep_h *ep_p);
 
 ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
                                          const ucp_conn_request_h conn_request,
+                                         const char *scope_name,
                                          ucp_ep_h *ep_p);
 
 ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
@@ -786,5 +790,9 @@ void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status);
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_ep_query_sockaddr(ucp_ep_h ucp_ep, ucp_ep_attr_t *attr);
+
+
+/* Default endpoint scope name */
+extern char ucp_ep_scope_default[];
 
 #endif

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -274,4 +274,9 @@ static UCS_F_ALWAYS_INLINE int ucp_ep_use_indirect_id(ucp_ep_h ep)
     return ep->flags & UCP_EP_FLAG_INDIRECT_ID;
 }
 
+static UCS_F_ALWAYS_INLINE const char *ucp_ep_scope_name(ucp_ep_h ep)
+{
+    return ucp_worker_ep_config_scope_name(ep->worker, ep->cfg_index);
+}
+
 #endif

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -352,9 +352,10 @@ typedef struct ucp_worker {
 } ucp_worker_t;
 
 
-ucs_status_t
-ucp_worker_get_ep_config(ucp_worker_h worker, const ucp_ep_config_key_t *key,
-                         int print_cfg, ucp_worker_cfg_index_t *cfg_index_p);
+ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
+                                      const ucp_ep_config_key_t *key,
+                                      unsigned ep_init_flags,
+                                      ucp_worker_cfg_index_t *cfg_index_p);
 
 ucs_status_t
 ucp_worker_add_rkey_config(ucp_worker_h worker,
@@ -405,6 +406,9 @@ void ucp_worker_vfs_refresh(void *obj);
 void ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self);
 
 unsigned ucp_worker_discard_uct_ep_progress(void *arg);
+
+const char *ucp_worker_ep_config_scope_name(ucp_worker_h worker,
+                                            ucp_worker_cfg_index_t cfg_index);
 
 static UCS_F_ALWAYS_INLINE void
 ucp_worker_flush_ops_count_inc(ucp_worker_h worker)

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -128,6 +128,7 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             const ucp_address_entry_t *ae);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
+                                   const char *scope_name,
                                    const ucp_tl_bitmap_t *local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
                                    unsigned *addr_indices);

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -50,6 +50,7 @@ void ucp_cm_server_conn_request_cb(uct_listener_h listener, void *arg,
 
 ucs_status_t
 ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
+                                  const char *scope_name,
                                   const ucp_unpacked_address_t *remote_addr,
                                   ucp_conn_request_h conn_request,
                                   ucp_ep_h *ep_p);

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -339,6 +339,18 @@ char* ucs_string_split(char *str, const char *delim, int count, ...);
 extern const char *ucs_memunits_suffixes[];
 
 
+/**
+ * Checks if a string is empty.
+ *
+ * @param str String to check.
+ *
+ * @return Whether @str is an empty string.
+ */
+static inline int ucs_string_is_empty(const char *str)
+{
+    return *str == '\0';
+}
+
 END_C_DECLS
 
 #endif

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -24,6 +24,11 @@ protected:
     }
 };
 
+UCS_TEST_F(test_string, is_empty) {
+    EXPECT_TRUE(ucs_string_is_empty(""));
+    EXPECT_FALSE(ucs_string_is_empty("aaa"));
+}
+
 UCS_TEST_F(test_string, count_char) {
     static const char *str1 = "/foo";
     static const char *str2 = "/foo/bar";


### PR DESCRIPTION
## Why
Show which kind of endpoint are we printing the information for - "intra-node", "inter-node", "self".
The scope name will be set from the upper layer, for example - an MPI library.