### PR TITLE
UCP/PROTO: Extend protocol configuration query

### DIFF
--- a/src/ucp/am/eager.c
+++ b/src/ucp/am/eager.c
@@ -101,12 +101,12 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_eager_short_proto = {
-    .name       = "egr/am/short",
-    .flags      = 0,
-    .init       = ucp_proto_eager_short_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_short_progress},
-    .abort      = ucp_proto_request_bcopy_abort
+    .name     = "egr/am/short",
+    .flags    = 0,
+    .init     = ucp_proto_eager_short_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_eager_short_progress},
+    .abort    = ucp_proto_request_bcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
@@ -209,11 +209,11 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_eager_bcopy_single_proto = {
-    .name       = "egr/am/single/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_bcopy_single_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_bcopy_single_progress},
-    .abort      = ucp_request_complete_send
+    .name     = "egr/am/single/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_bcopy_single_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_eager_bcopy_single_progress},
+    .abort    = ucp_request_complete_send
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);

--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -10,6 +10,8 @@
 
 #include "proto.h"
 
+#include <ucs/sys/string.h>
+
 
 const ucp_proto_t *ucp_protocols[UCP_PROTO_MAX_COUNT] = {};
 unsigned ucp_protocols_count                          = 0;
@@ -19,3 +21,8 @@ const char *ucp_proto_perf_types[] = {
     [UCP_PROTO_PERF_TYPE_MULTI]  = "multi"
 };
 
+void ucp_proto_default_query(const ucp_proto_query_params_t *params,
+                             ucp_proto_query_attr_t *attr)
+{
+    ucs_strncpy_safe(attr->config, "", sizeof(attr->config));
+}

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -63,18 +63,6 @@ void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *param
     lane_priv->max_iov = ucs_min(uct_max_iov, UCP_MAX_IOV);
 }
 
-void ucp_proto_common_lane_priv_str(const ucp_proto_common_lane_priv_t *lpriv,
-                                    ucs_string_buffer_t *strb)
-{
-    ucs_string_buffer_appendf(strb, "ln:%d", lpriv->lane);
-    if (lpriv->memh_index != UCP_NULL_RESOURCE) {
-        ucs_string_buffer_appendf(strb, ",mh%d", lpriv->memh_index);
-    }
-    if (lpriv->rkey_index != UCP_NULL_RESOURCE) {
-        ucs_string_buffer_appendf(strb, ",rk%d", lpriv->rkey_index);
-    }
-}
-
 ucp_md_index_t
 ucp_proto_common_get_md_index(const ucp_proto_init_params_t *params,
                               ucp_lane_index_t lane)
@@ -618,8 +606,7 @@ void ucp_proto_trace_selected(ucp_request_t *req, size_t msg_length)
     const ucp_proto_config_t *proto_config = req->send.proto_config;
 
     ucp_proto_select_param_str(&proto_config->select_param, &sel_param_strb);
-    proto_config->proto->config_str(msg_length, msg_length, proto_config->priv,
-                                    &proto_config_strb);
+    ucp_proto_config_str(proto_config, msg_length, &proto_config_strb);
     ucp_trace_req(req, "%s length %zu using %s{%s}",
                   ucs_string_buffer_cstr(&sel_param_strb), msg_length,
                   proto_config->proto->name,

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -163,10 +163,6 @@ void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *param
                                      ucp_proto_common_lane_priv_t *lane_priv);
 
 
-void ucp_proto_common_lane_priv_str(const ucp_proto_common_lane_priv_t *lpriv,
-                                    ucs_string_buffer_t *strb);
-
-
 ucp_rsc_index_t
 ucp_proto_common_get_md_index(const ucp_proto_init_params_t *params,
                               ucp_lane_index_t lane);

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -176,7 +176,7 @@ ucp_proto_request_select_proto(ucp_request_t *req,
                                size_t msg_length)
 {
     const ucp_proto_threshold_elem_t *thresh_elem =
-            ucp_proto_thresholds_search(select_elem->thresholds, msg_length);
+            ucp_proto_select_thresholds_search(select_elem, msg_length);
     ucp_proto_request_set_proto(req, &thresh_elem->proto_config, msg_length);
 }
 

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -79,4 +79,8 @@ void ucp_proto_select_config_str(ucp_worker_h worker,
                                  const ucp_proto_config_t *proto_config,
                                  size_t msg_length, ucs_string_buffer_t *strb);
 
+
+void ucp_proto_config_str(const ucp_proto_config_t *proto_config,
+                          size_t msg_length, ucs_string_buffer_t *strb);
+
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -204,13 +204,13 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     return ucp_proto_common_init_caps(&params->super, &perf, reg_md_map);
 }
 
-void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
-                                const void *priv, ucs_string_buffer_t *strb)
+void ucp_proto_multi_query_config(const ucp_proto_query_params_t *params,
+                                  ucp_proto_query_attr_t *attr)
 {
-    const ucp_proto_multi_priv_t *mpriv = priv;
+    UCS_STRING_BUFFER_FIXED(strb, attr->config, sizeof(attr->config));
+    const ucp_proto_multi_priv_t *mpriv = params->priv;
     const ucp_proto_multi_lane_priv_t *lpriv;
     size_t percent, remaining;
-    char frag_size_buf[64];
     ucp_lane_index_t i;
 
     ucs_assert(mpriv->num_lanes <= UCP_MAX_LANES);
@@ -223,21 +223,18 @@ void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
         remaining -= percent;
 
         if (percent != 100) {
-            ucs_string_buffer_appendf(strb, "%zu%%*", percent);
+            ucs_string_buffer_appendf(&strb, "%zu%% on ", percent);
         }
 
-        ucp_proto_common_lane_priv_str(&lpriv->super, strb);
-
-        /* Print fragment size if it's small enough. For large fragments we can
-           skip the print because it has little effect on performance */
-        if (lpriv->max_frag < (64 * UCS_KBYTE)) {
-            ucs_memunits_to_str(lpriv->max_frag, frag_size_buf,
-                                sizeof(frag_size_buf));
-            ucs_string_buffer_appendf(strb, "<=%s", frag_size_buf);
-        }
-
-        if ((i + 1) < mpriv->num_lanes) {
-            ucs_string_buffer_appendf(strb, "|");
-        }
+        ucs_string_buffer_appendf(&strb, "lane[%d] ", lpriv->super.lane);
     }
+
+    ucs_string_buffer_rtrim(&strb, NULL);
+}
+
+void ucp_proto_multi_query(const ucp_proto_query_params_t *params,
+                           ucp_proto_query_attr_t *attr)
+{
+    ucp_proto_default_query(params, attr);
+    ucp_proto_multi_query_config(params, attr);
 }

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -119,7 +119,11 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                                   size_t *priv_size_p);
 
 
-void ucp_proto_multi_config_str(size_t min_length, size_t max_length,
-                                const void *priv, ucs_string_buffer_t *strb);
+void ucp_proto_multi_query_config(const ucp_proto_query_params_t *params,
+                                  ucp_proto_query_attr_t *attr);
+
+
+void ucp_proto_multi_query(const ucp_proto_query_params_t *params,
+                           ucp_proto_query_attr_t *attr);
 
 #endif

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -89,11 +89,11 @@ ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_reconfig_proto = {
-    .name       = "reconfig",
-    .flags      = UCP_PROTO_FLAG_INVALID,
-    .init       = ucp_proto_reconfig_init,
-    .config_str = (ucp_proto_config_str_func_t)ucs_empty_function,
-    .progress   = {ucp_proto_reconfig_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "reconfig",
+    .flags    = UCP_PROTO_FLAG_INVALID,
+    .init     = ucp_proto_reconfig_init,
+    .query    = ucp_proto_default_query,
+    .progress = {ucp_proto_reconfig_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_reconfig_proto);

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -724,3 +724,25 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
         return &worker->rkey_config[*new_rkey_cfg_index].proto_select;
     }
 }
+
+void ucp_proto_config_query(const ucp_proto_config_t *proto_config,
+                            size_t msg_length,
+                            ucp_proto_query_attr_t *proto_attr)
+{
+    ucp_proto_query_params_t params = {
+        .priv       = proto_config->priv,
+        .msg_length = msg_length
+    };
+
+    proto_config->proto->query(&params, proto_attr);
+}
+
+void ucp_proto_select_elem_query(const ucp_proto_select_elem_t *select_elem,
+                                 size_t msg_length,
+                                 ucp_proto_query_attr_t *proto_attr)
+{
+    const ucp_proto_threshold_elem_t *thresh_elem =
+            ucp_proto_select_thresholds_search(select_elem, msg_length);
+
+    ucp_proto_config_query(&thresh_elem->proto_config, msg_length, proto_attr);
+}

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -159,4 +159,14 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
                      ucp_worker_cfg_index_t rkey_cfg_index,
                      ucp_worker_cfg_index_t *new_rkey_cfg_index);
 
+
+void ucp_proto_config_query(const ucp_proto_config_t *proto_config,
+                            size_t msg_length,
+                            ucp_proto_query_attr_t *proto_attr);
+
+
+void ucp_proto_select_elem_query(const ucp_proto_select_elem_t *select_elem,
+                                 size_t msg_length,
+                                 ucp_proto_query_attr_t *proto_attr);
+
 #endif

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -28,10 +28,12 @@ KHASH_IMPL(ucp_proto_select_hash, khint64_t, ucp_proto_select_elem_t, 1,
            kh_int64_hash_func, kh_int64_hash_equal)
 
 
-static UCS_F_ALWAYS_INLINE const ucp_proto_threshold_elem_t*
-ucp_proto_thresholds_search(const ucp_proto_threshold_elem_t *thresholds,
-                            size_t msg_length)
+static UCS_F_ALWAYS_INLINE const ucp_proto_threshold_elem_t *
+ucp_proto_select_thresholds_search(const ucp_proto_select_elem_t *select_elem,
+                                   size_t msg_length)
 {
+    const ucp_proto_threshold_elem_t *thresholds = select_elem->thresholds;
+
 #define UCP_PROTO_THRESHOLDS_CHECK(_arg, _i) \
     if (ucs_likely(msg_length <= thresholds[_i].max_msg_length)) { \
         return &thresholds[_i]; \
@@ -93,7 +95,7 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
         proto_select->cache.value = select_elem;
     }
 
-    return ucp_proto_thresholds_search(select_elem->thresholds, msg_length);
+    return ucp_proto_select_thresholds_search(select_elem, msg_length);
 }
 
 /*

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -12,9 +12,8 @@
 #include "proto_common.h"
 #include "proto_init.h"
 
-#include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/sys/math.h>
+#include <ucs/sys/string.h>
 
 
 ucs_status_t
@@ -67,9 +66,12 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
     return UCS_OK;
 }
 
-void ucp_proto_single_config_str(size_t min_length, size_t max_length,
-                                 const void *priv, ucs_string_buffer_t *strb)
+void ucp_proto_single_query(const ucp_proto_query_params_t *params,
+                            ucp_proto_query_attr_t *attr)
 {
-    const ucp_proto_single_priv_t *spriv = priv;
-    ucp_proto_common_lane_priv_str(&spriv->super, strb);
+    const ucp_proto_single_priv_t *spriv = params->priv;
+
+    ucp_proto_default_query(params, attr);
+    ucs_snprintf_safe(attr->config, sizeof(attr->config), "lane[%d]",
+                      spriv->super.lane);
 }

--- a/src/ucp/proto/proto_single.h
+++ b/src/ucp/proto/proto_single.h
@@ -32,8 +32,8 @@ ucp_proto_single_init_priv(const ucp_proto_single_init_params_t *params,
                            ucp_proto_single_priv_t *spriv);
 
 
-void ucp_proto_single_config_str(size_t min_length, size_t max_length,
-                                 const void *priv, ucs_string_buffer_t *strb);
+void ucp_proto_single_query(const ucp_proto_query_params_t *params,
+                            ucp_proto_query_attr_t *attr);
 
 
 typedef ucs_status_t (*ucp_proto_send_single_cb_t)(

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -184,25 +184,26 @@ ucp_proto_amo_init(const ucp_proto_init_params_t *init_params,
 }
 
 #define UCP_PROTO_AMO_REGISTER(_id, _op_id, _bits, _memtype_op, _sub_id) \
-static ucs_status_t \
-ucp_amo_progress_##_id(uct_pending_req_t *self) { \
-    return ucp_proto_amo_progress_##_sub_id(self, (_op_id), (_bits) / 8); \
-} \
-\
-static ucs_status_t \
-ucp_amo_init_##_id(const ucp_proto_init_params_t *init_params) { \
-    return ucp_proto_amo_init(init_params, (_op_id), (_bits) / 8, \
-                              (_memtype_op)); \
-} \
-\
-static ucp_proto_t ucp_amo_proto_##_id = { \
-    .name       = "amo" #_bits "/" #_id "/" #_sub_id, \
-    .init       = ucp_amo_init_##_id, \
-    .config_str = ucp_proto_single_config_str, \
-    .progress   = {ucp_amo_progress_##_id} \
-}; \
-\
-UCP_PROTO_REGISTER(&ucp_amo_proto_##_id)
+    static ucs_status_t ucp_amo_progress_##_id(uct_pending_req_t *self) \
+    { \
+        return ucp_proto_amo_progress_##_sub_id(self, (_op_id), (_bits) / 8); \
+    } \
+    \
+    static ucs_status_t ucp_amo_init_##_id( \
+            const ucp_proto_init_params_t *init_params) \
+    { \
+        return ucp_proto_amo_init(init_params, (_op_id), (_bits) / 8, \
+                                  (_memtype_op)); \
+    } \
+    \
+    static ucp_proto_t ucp_amo_proto_##_id = { \
+        .name     = "amo" #_bits "/" #_id "/" #_sub_id, \
+        .init     = ucp_amo_init_##_id, \
+        .query    = ucp_proto_single_query, \
+        .progress = {ucp_amo_progress_##_id} \
+    }; \
+    \
+    UCP_PROTO_REGISTER(&ucp_amo_proto_##_id)
 
 #define UCP_PROTO_AMO_REGISTER_MTYPE(_id, _op_id, _bits) \
     UCP_PROTO_AMO_REGISTER(_id,         _op_id, _bits, UCT_EP_OP_LAST,      offload) \

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -416,12 +416,12 @@ ucp_proto_amo_sw_init_post(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_get_amo_post_proto = {
-    .name       = "amo/post/sw",
-    .flags      = 0,
-    .init       = ucp_proto_amo_sw_init_post,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_amo_sw_progress_post},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "amo/post/sw",
+    .flags    = 0,
+    .init     = ucp_proto_amo_sw_init_post,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_amo_sw_progress_post},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_amo_post_proto);
 
@@ -444,11 +444,11 @@ ucp_proto_amo_sw_init_fetch(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_get_amo_fetch_proto = {
-    .name       = "amo/fetch/sw",
-    .flags      = 0,
-    .init       = ucp_proto_amo_sw_init_fetch,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_amo_sw_progress_fetch},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "amo/fetch/sw",
+    .flags    = 0,
+    .init     = ucp_proto_amo_sw_init_fetch,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_amo_sw_progress_fetch},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_amo_fetch_proto);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -99,11 +99,11 @@ ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_get_am_bcopy_proto = {
-    .name       = "get/am/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_get_am_bcopy_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_get_am_bcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "get/am/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_get_am_bcopy_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_get_am_bcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_am_bcopy_proto);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -105,12 +105,12 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_get_offload_bcopy_proto = {
-    .name       = "get/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_get_offload_bcopy_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_get_offload_bcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "get/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_get_offload_bcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_get_offload_bcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_offload_bcopy_proto);
 
@@ -190,11 +190,11 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_get_offload_zcopy_proto = {
-    .name       = "get/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_get_offload_zcopy_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_get_offload_zcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "get/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_get_offload_zcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_get_offload_zcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_get_offload_zcopy_proto);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -104,12 +104,12 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_put_am_bcopy_proto = {
-    .name       = "put/am/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_put_am_bcopy_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_put_am_bcopy_progress},
-    .abort      = ucp_proto_request_bcopy_abort
+    .name     = "put/am/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_put_am_bcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_put_am_bcopy_progress},
+    .abort    = ucp_proto_request_bcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_put_am_bcopy_proto);
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -80,12 +80,12 @@ ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_put_offload_short_proto = {
-    .name       = "put/offload/short",
-    .flags      = UCP_PROTO_FLAG_PUT_SHORT,
-    .init       = ucp_proto_put_offload_short_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_put_offload_short_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "put/offload/short",
+    .flags    = UCP_PROTO_FLAG_PUT_SHORT,
+    .init     = ucp_proto_put_offload_short_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_put_offload_short_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_short_proto);
 
@@ -175,12 +175,12 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_put_offload_bcopy_proto = {
-    .name       = "put/offload/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_put_offload_bcopy_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_put_offload_bcopy_progress},
-    .abort      = ucp_proto_request_bcopy_abort
+    .name     = "put/offload/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_put_offload_bcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_put_offload_bcopy_progress},
+    .abort    = ucp_proto_request_bcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_bcopy_proto);
 
@@ -261,11 +261,11 @@ static void ucp_put_offload_zcopy_abort(ucp_request_t *request,
 }
 
 static ucp_proto_t ucp_put_offload_zcopy_proto = {
-    .name       = "put/offload/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_put_offload_zcopy_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_put_offload_zcopy_progress},
-    .abort      = ucp_put_offload_zcopy_abort
+    .name     = "put/offload/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_put_offload_zcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_put_offload_zcopy_progress},
+    .abort    = ucp_put_offload_zcopy_abort
 };
 UCP_PROTO_REGISTER(&ucp_put_offload_zcopy_proto);

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -284,25 +284,6 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params)
     return UCS_OK;
 }
 
-void ucp_proto_rndv_ctrl_config_str(size_t min_length, size_t max_length,
-                                    const void *priv, ucs_string_buffer_t *strb)
-{
-    const ucp_proto_rndv_ctrl_priv_t *rpriv = priv;
-    ucp_md_index_t md_index;
-
-    /* Print message lane and memory domains list */
-    ucs_string_buffer_appendf(strb, "ln:%d md:", rpriv->lane);
-    ucs_for_each_bit(md_index, rpriv->md_map) {
-        ucs_string_buffer_appendf(strb, "%d,", md_index);
-    }
-    ucs_string_buffer_rtrim(strb, ",");
-    ucs_string_buffer_appendf(strb, " ");
-
-    /* Print estimated remote protocols for each message size */
-    ucp_proto_threshold_elem_str(rpriv->remote_proto.thresholds, min_length,
-                                 max_length, strb);
-}
-
 ucs_status_t ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_h context                    = init_params->worker->context;
@@ -396,16 +377,6 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
     return UCS_OK;
 }
 
-void ucp_proto_rndv_ack_config_str(size_t min_length, size_t max_length,
-                                   const void *priv, ucs_string_buffer_t *strb)
-{
-    const ucp_proto_rndv_ack_priv_t *apriv = priv;
-
-    if (apriv->lane != UCP_NULL_LANE) {
-        ucs_string_buffer_appendf(strb, "aln:%d", apriv->lane);
-    }
-}
-
 ucs_status_t
 ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
                          ucp_proto_rndv_bulk_priv_t *rpriv, size_t *priv_size_p)
@@ -446,17 +417,16 @@ ucs_status_t ucp_proto_rndv_ats_progress(uct_pending_req_t *uct_req)
                                        ucp_proto_rndv_recv_complete);
 }
 
-void ucp_proto_rndv_bulk_config_str(size_t min_length, size_t max_length,
-                                    const void *priv, ucs_string_buffer_t *strb)
+void ucp_proto_rndv_bulk_query(const ucp_proto_query_params_t *params,
+                               ucp_proto_query_attr_t *attr)
 {
-    const ucp_proto_rndv_bulk_priv_t *rpriv = priv;
+    const ucp_proto_rndv_bulk_priv_t *rpriv     = params->priv;
+    ucp_proto_query_params_t multi_query_params = {
+        .priv       = &rpriv->mpriv,
+        .msg_length = params->msg_length
+    };
 
-    ucp_proto_multi_config_str(min_length, max_length, &rpriv->mpriv, strb);
-    if (rpriv->super.lane != UCP_NULL_LANE) {
-        ucs_string_buffer_appendf(strb, " ");
-        ucp_proto_rndv_ack_config_str(min_length, max_length, &rpriv->super,
-                                      strb);
-    }
+    ucp_proto_multi_query_config(&multi_query_params, attr);
 }
 
 static ucs_status_t

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -93,21 +93,12 @@ ucs_status_t
 ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params);
 
 
-void ucp_proto_rndv_ctrl_config_str(size_t min_length, size_t max_length,
-                                    const void *priv,
-                                    ucs_string_buffer_t *strb);
-
-
 ucs_status_t
 ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params);
 
 
 ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
                                      ucp_proto_rndv_ack_priv_t *apriv);
-
-
-void ucp_proto_rndv_ack_config_str(size_t min_length, size_t max_length,
-                                   const void *priv, ucs_string_buffer_t *strb);
 
 
 ucs_status_t
@@ -119,9 +110,8 @@ ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
 ucs_status_t ucp_proto_rndv_ats_progress(uct_pending_req_t *uct_req);
 
 
-void ucp_proto_rndv_bulk_config_str(size_t min_length, size_t max_length,
-                                    const void *priv,
-                                    ucs_string_buffer_t *strb);
+void ucp_proto_rndv_bulk_query(const ucp_proto_query_params_t *params,
+                               ucp_proto_query_attr_t *attr);
 
 
 void ucp_proto_rndv_receive_start(ucp_worker_h worker, ucp_request_t *recv_req,

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -117,11 +117,11 @@ ucp_proto_rdnv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_rndv_am_bcopy_proto = {
-    .name       = "rndv/am/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_rdnv_am_bcopy_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_rndv_am_bcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "rndv/am/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_rdnv_am_bcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_rndv_am_bcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_am_bcopy_proto);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -184,15 +184,15 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
 }
 
 static ucp_proto_t ucp_rndv_get_zcopy_proto = {
-    .name       = "rndv/get/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_get_zcopy_init,
-    .config_str = ucp_proto_rndv_bulk_config_str,
-    .progress   = {
+    .name     = "rndv/get/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_get_zcopy_init,
+    .query    = ucp_proto_rndv_bulk_query,
+    .progress = {
          [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_zcopy_fetch_progress,
          [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
-    .abort      = ucp_rndv_get_zcopy_proto_abort
+    .abort    = ucp_rndv_get_zcopy_proto_abort
 };
 UCP_PROTO_REGISTER(&ucp_rndv_get_zcopy_proto);
 
@@ -287,15 +287,15 @@ ucp_proto_rndv_get_mtype_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_rndv_get_mtype_proto = {
-    .name       = "rndv/get/mtype",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_get_mtype_init,
-    .config_str = ucp_proto_rndv_bulk_config_str,
-    .progress   = {
+    .name     = "rndv/get/mtype",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_get_mtype_init,
+    .query    = ucp_proto_rndv_bulk_query,
+    .progress = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,
         [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
     },
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_get_mtype_proto);
 
@@ -343,11 +343,11 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *params)
 }
 
 static ucp_proto_t ucp_rndv_ats_proto = {
-    .name       = "rndv/ats",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_ats_init,
-    .config_str = ucp_proto_rndv_ack_config_str,
-    .progress   = {ucp_proto_rndv_ats_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "rndv/ats",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_ats_init,
+    .query    = ucp_proto_default_query,
+    .progress = {ucp_proto_rndv_ats_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_ats_proto);

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -120,6 +120,14 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_rndv_ack_init(init_params, &rpriv->ack);
 }
 
+static void ucp_proto_rndv_ppln_query(const ucp_proto_query_params_t *params,
+                                      ucp_proto_query_attr_t *attr)
+{
+    const ucp_proto_rndv_ppln_priv_t *rpriv = params->priv;
+
+    ucp_proto_select_elem_query(&rpriv->frag_proto, params->msg_length, attr);
+}
+
 static void
 ucp_proto_rndv_ppln_frag_complete(ucp_request_t *freq, int send_ack,
                                   ucp_proto_complete_cb_t complete_func,
@@ -225,19 +233,6 @@ static size_t ucp_proto_rndv_ppln_pack_ack(void *dest, void *arg)
                                    req->send.rndv.ppln.ack_data_size);
 }
 
-static void ucp_proto_rndv_ppln_config_str(size_t min_length, size_t max_length,
-                                           const void *priv,
-                                           ucs_string_buffer_t *strb)
-{
-    const ucp_proto_rndv_ppln_priv_t *rpriv = priv;
-    char str[128];
-
-    ucs_memunits_to_str(rpriv->frag_size, str, sizeof(str));
-    ucs_string_buffer_appendf(strb, "fr:%s ", str);
-    ucp_proto_threshold_elem_str(rpriv->frag_proto.thresholds, rpriv->frag_size,
-                                 rpriv->frag_size, strb);
-}
-
 static ucs_status_t
 ucp_proto_rndv_send_ppln_init(const ucp_proto_init_params_t *init_params)
 {
@@ -260,15 +255,15 @@ ucp_proto_rndv_send_ppln_atp_progress(uct_pending_req_t *uct_req)
 }
 
 static ucp_proto_t ucp_rndv_send_ppln_proto = {
-    .name       = "rndv/send/ppln",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_send_ppln_init,
-    .config_str = ucp_proto_rndv_ppln_config_str,
-    .progress   = {
+    .name     = "rndv/send/ppln",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_send_ppln_init,
+    .query    = ucp_proto_rndv_ppln_query,
+    .progress = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_send_ppln_atp_progress,
     },
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_send_ppln_proto);
 
@@ -295,14 +290,14 @@ ucp_proto_rndv_recv_ppln_ats_progress(uct_pending_req_t *uct_req)
 }
 
 static ucp_proto_t ucp_rndv_recv_ppln_proto = {
-    .name       = "rndv/recv/ppln",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_recv_ppln_init,
-    .config_str = ucp_proto_rndv_ppln_config_str,
-    .progress   = {
+    .name     = "rndv/recv/ppln",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_recv_ppln_init,
+    .query    = ucp_proto_rndv_ppln_query,
+    .progress = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_recv_ppln_ats_progress,
     },
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_recv_ppln_proto);

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -150,15 +150,15 @@ ucp_proto_rndv_rkey_ptr_fetch_progress(uct_pending_req_t *uct_req)
 }
 
 static ucp_proto_t ucp_rndv_rkey_ptr_proto = {
-    .name       = "rndv/rkey_ptr",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_rkey_ptr_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {
+    .name     = "rndv/rkey_ptr",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_rkey_ptr_init,
+    .query    = ucp_proto_default_query,
+    .progress = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_FETCH] = ucp_proto_rndv_rkey_ptr_fetch_progress,
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rkey_ptr_proto);
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -226,13 +226,21 @@ ucp_proto_rndv_rtr_init(const ucp_proto_init_params_t *init_params)
     return UCS_OK;
 }
 
+static void ucp_proto_rndv_rtr_query(const ucp_proto_query_params_t *params,
+                                     ucp_proto_query_attr_t *attr)
+{
+    const ucp_proto_rndv_ctrl_priv_t *rpriv = params->priv;
+
+    ucp_proto_select_elem_query(&rpriv->remote_proto, params->msg_length, attr);
+}
+
 static ucp_proto_t ucp_rndv_rtr_proto = {
-    .name       = "rndv/rtr",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_rtr_init,
-    .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = {ucp_proto_rndv_rtr_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "rndv/rtr",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_rtr_init,
+    .query    = ucp_proto_rndv_rtr_query,
+    .progress = {ucp_proto_rndv_rtr_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rtr_proto);
 
@@ -365,13 +373,22 @@ ucp_proto_rndv_rtr_mtype_init(const ucp_proto_init_params_t *init_params)
     return UCS_OK;
 }
 
+static void
+ucp_proto_rndv_rtr_mtype_query(const ucp_proto_query_params_t *params,
+                               ucp_proto_query_attr_t *attr)
+{
+    const ucp_proto_rndv_ctrl_priv_t *rpriv = params->priv;
+
+    ucp_proto_select_elem_query(&rpriv->remote_proto, params->msg_length, attr);
+}
+
 static ucp_proto_t ucp_rndv_rtr_mtype_proto = {
-    .name       = "rndv/rtr/mtype",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_rtr_mtype_init,
-    .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = {ucp_proto_rndv_rtr_mtype_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "rndv/rtr/mtype",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_rtr_mtype_init,
+    .query    = ucp_proto_rndv_rtr_mtype_query,
+    .progress = {ucp_proto_rndv_rtr_mtype_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_rndv_rtr_mtype_proto);
 

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -163,12 +163,12 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
 }
 
 static ucp_proto_t ucp_eager_bcopy_multi_proto = {
-    .name       = "egr/multi/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_bcopy_multi_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_eager_bcopy_multi_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/multi/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_bcopy_multi_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_eager_bcopy_multi_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_multi_proto);
 
@@ -239,12 +239,12 @@ ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
 }
 
 static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
-    .name       = "egrsnc/multi/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_sync_bcopy_multi_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_eager_sync_bcopy_multi_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egrsnc/multi/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_sync_bcopy_multi_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_eager_sync_bcopy_multi_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_multi_proto);
 
@@ -321,11 +321,11 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
 }
 
 static ucp_proto_t ucp_eager_zcopy_multi_proto = {
-    .name       = "egr/multi/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_zcopy_multi_init,
-    .config_str = ucp_proto_multi_config_str,
-    .progress   = {ucp_proto_eager_zcopy_multi_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/multi/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_zcopy_multi_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_eager_zcopy_multi_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_multi_proto);

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -76,12 +76,12 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_eager_short_proto = {
-    .name       = "egr/short",
-    .flags      = UCP_PROTO_FLAG_AM_SHORT,
-    .init       = ucp_proto_eager_short_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_short_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/short",
+    .flags    = UCP_PROTO_FLAG_AM_SHORT,
+    .init     = ucp_proto_eager_short_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_eager_short_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
@@ -143,12 +143,12 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
 }
 
 static ucp_proto_t ucp_eager_bcopy_single_proto = {
-    .name       = "egr/single/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_bcopy_single_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_eager_bcopy_single_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/single/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_bcopy_single_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_eager_bcopy_single_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
@@ -211,11 +211,11 @@ ucp_proto_eager_zcopy_single_progress(uct_pending_req_t *self)
 }
 
 static ucp_proto_t ucp_eager_zcopy_single_proto = {
-    .name       = "egr/single/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_zcopy_single_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_zcopy_single_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/single/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_zcopy_single_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_eager_zcopy_single_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -73,12 +73,12 @@ static ucs_status_t ucp_proto_eager_tag_offload_short_init(
 }
 
 static ucp_proto_t ucp_eager_tag_offload_short_proto = {
-    .name       = "egr/offload/short",
-    .flags      = UCP_PROTO_FLAG_TAG_SHORT,
-    .init       = ucp_proto_eager_tag_offload_short_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_tag_offload_short_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/offload/short",
+    .flags    = UCP_PROTO_FLAG_TAG_SHORT,
+    .init     = ucp_proto_eager_tag_offload_short_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_eager_tag_offload_short_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_tag_offload_short_proto);
 
@@ -164,12 +164,12 @@ static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init(
 }
 
 static ucp_proto_t ucp_eager_bcopy_single_proto = {
-    .name       = "egr/offload/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_tag_offload_bcopy_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_tag_offload_bcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/offload/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_tag_offload_bcopy_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_eager_tag_offload_bcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
@@ -202,12 +202,12 @@ static ucs_status_t ucp_proto_eager_sync_tag_offload_bcopy_init(
 }
 
 static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
-    .name       = "egrsnc/offload/bcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_sync_tag_offload_bcopy_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egrsnc/offload/bcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_sync_tag_offload_bcopy_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_single_proto);
 
@@ -276,12 +276,12 @@ ucp_proto_eager_tag_offload_zcopy_progress(uct_pending_req_t *self)
 }
 
 static ucp_proto_t ucp_eager_zcopy_single_proto = {
-    .name       = "egr/offload/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_tag_offload_zcopy_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_tag_offload_zcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egr/offload/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_tag_offload_zcopy_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_eager_tag_offload_zcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);
 
@@ -333,11 +333,11 @@ ucp_proto_eager_sync_tag_offload_zcopy_progress(uct_pending_req_t *self)
 }
 
 static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
-    .name       = "egrsnc/offload/zcopy",
-    .flags      = 0,
-    .init       = ucp_proto_eager_sync_tag_offload_zcopy_init,
-    .config_str = ucp_proto_single_config_str,
-    .progress   = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
-    .abort      = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .name     = "egrsnc/offload/zcopy",
+    .flags    = 0,
+    .init     = ucp_proto_eager_sync_tag_offload_zcopy_init,
+    .query    = ucp_proto_single_query,
+    .progress = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 UCP_PROTO_REGISTER(&ucp_eager_sync_zcopy_single_proto);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -149,6 +149,14 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
                             NULL);
 }
 
+static void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
+                                     ucp_proto_query_attr_t *attr)
+{
+    const ucp_proto_rndv_ctrl_priv_t *rpriv = params->priv;
+
+    ucp_proto_select_elem_query(&rpriv->remote_proto, params->msg_length, attr);
+}
+
 static void ucp_tag_rndv_proto_abort(ucp_request_t *request,
                                      ucs_status_t status)
 {
@@ -163,11 +171,11 @@ static void ucp_tag_rndv_proto_abort(ucp_request_t *request,
 }
 
 static ucp_proto_t ucp_tag_rndv_proto = {
-    .name       = "tag/rndv",
-    .flags      = 0,
-    .init       = ucp_proto_rndv_rts_init,
-    .config_str = ucp_proto_rndv_ctrl_config_str,
-    .progress   = {ucp_tag_rndv_rts_progress},
-    .abort      = ucp_tag_rndv_proto_abort
+    .name     = "tag/rndv",
+    .flags    = 0,
+    .init     = ucp_proto_rndv_rts_init,
+    .query    = ucp_proto_rndv_rts_query,
+    .progress = {ucp_tag_rndv_rts_progress},
+    .abort    = ucp_tag_rndv_proto_abort
 };
 UCP_PROTO_REGISTER(&ucp_tag_rndv_proto);


### PR DESCRIPTION
## Why
Allow querying protocol high-level description and configuration per message size range.
Eventually, it will enable printing a summary of selected protocols like so:
```
[1643981592.078411] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  +----------------+--------------------------------------------------------------------------------------------------+
[1643981592.078428] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  | mpi intra-node | tagged message by ucp_tag_send*() from host memory                                               |
[1643981592.078432] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  +----------------+--------------------------------------------------+-----------------------------------------------+
[1643981592.078435] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  |        0..8248 | eager copy-in copy-out                           | posix/memory                                  |
[1643981592.078438] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  |    8249..92344 | eager copy-in copy-out                           | posix/memory                                  |
[1643981592.078442] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  |     92345..inf | (?) rendezvous zero-copy flushed write to remote | 66% on cma/memory and 34% on rc_mlx5/mlx5_0:1 |
[1643981592.078445] [vulcan02:3951 :0]     proto_debug.c:408  UCX  INFO  +----------------+--------------------------------------------------+-----------------------------------------------+

```
The range and description will be added in next PR due to large patch size.