### PR TITLE
UCP/UCT: Add profiling for rkey management routines

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -444,8 +444,8 @@ out:
     return status;
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack, (ep, rkey_buffer, rkey_p),
-                 ucp_ep_h ep, const void *rkey_buffer, ucp_rkey_h *rkey_p)
+ucs_status_t ucp_ep_rkey_unpack(ucp_ep_h ep, const void *rkey_buffer,
+                                ucp_rkey_h *rkey_p)
 {
     ucs_status_t status;
 

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -14,8 +14,9 @@
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/string.h>
-#include <sys/mman.h>
+#include <ucs/profile/profile.h>
 #include <ucs/sys/sys.h>
+#include <sys/mman.h>
 #include <sys/statvfs.h>
 
 
@@ -636,9 +637,10 @@ static void uct_posix_mem_detach(uct_mm_md_t *md, const uct_mm_remote_seg_t *rse
     uct_posix_mem_detach_common(rseg);
 }
 
-static ucs_status_t
-uct_posix_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
-                      uct_rkey_t *rkey_p, void **handle_p)
+UCS_PROFILE_FUNC(ucs_status_t, uct_posix_rkey_unpack,
+                 (component, rkey_buffer, rkey_p, handle_p),
+                 uct_component_t *component, const void *rkey_buffer,
+                 uct_rkey_t *rkey_p, void **handle_p)
 {
     const uct_posix_packed_rkey_t *packed_rkey = rkey_buffer;
     uct_mm_remote_seg_t *rseg;
@@ -663,8 +665,8 @@ uct_posix_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_posix_rkey_release(uct_component_t *component, uct_rkey_t rkey, void *handle)
+UCS_PROFILE_FUNC(ucs_status_t, uct_posix_rkey_release,(component, rkey, handle),
+                 uct_component_t *component, uct_rkey_t rkey, void *handle)
 {
     uct_mm_remote_seg_t *rseg = handle;
     ucs_status_t status;

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -13,6 +13,7 @@
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
+#include <ucs/profile/profile.h>
 
 
 #define UCT_MM_SYSV_PERM (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)
@@ -163,9 +164,10 @@ static void uct_sysv_mem_detach(uct_mm_md_t *md, const uct_mm_remote_seg_t *rseg
     ucs_sysv_free(rseg->address);
 }
 
-static ucs_status_t
-uct_sysv_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
-                     uct_rkey_t *rkey_p, void **handle_p)
+UCS_PROFILE_FUNC(ucs_status_t, uct_sysv_rkey_unpack,
+                 (component, rkey_buffer, rkey_p, handle_p),
+                 uct_component_t *component, const void *rkey_buffer,
+                 uct_rkey_t *rkey_p, void **handle_p)
 {
     const uct_sysv_packed_rkey_t *packed_rkey = rkey_buffer;
     ucs_status_t status;
@@ -181,8 +183,8 @@ uct_sysv_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_sysv_rkey_release(uct_component_t *component, uct_rkey_t rkey, void *handle)
+UCS_PROFILE_FUNC(ucs_status_t, uct_sysv_rkey_release, (component, rkey, handle),
+                 uct_component_t *component, uct_rkey_t rkey, void *handle)
 {
     return ucs_sysv_free(handle);
 }


### PR DESCRIPTION
## What
- Add profiling for rkey management routines in posix and sysv. They are quite intrusive and can be used on RMA or/and RNDV data-path
- remove profiling for `ucp_ep_rkey_unpack` because it is just a wrapper for `ucp_ep_rkey_unpack_internal` which is also profiled

## Why
better profiling experience