### PR TITLE
UCP/WIREUP: Respect show_error flag if no lanes selected

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1616,7 +1616,7 @@ ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
     }
 
     /* User should not create endpoints unless requested communication features */
-    if (select_ctx->num_lanes == 0) {
+    if (select_params->show_error && (select_ctx->num_lanes == 0)) {
         ucs_error("No transports selected to %s (features: 0x%"PRIx64")",
                   select_params->address->name,
                   ucp_ep_get_context_features(select_params->ep));


### PR DESCRIPTION
## What

Respect show_error flag if no lanes selected.

## Why ?

`show_error` flag is set to `0`, if selecting scalable transports. if they don't exist we shouldn't print any errors, because we should try selecting non-scalable transports.

## How ?

Print `ucs_error` that no lanes were selected only if `num_lanes == 0` and `show_error` is true.