### PR TITLE
GTEST/UCP: Fix the name of the transport printed which should be closed

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1196,7 +1196,7 @@ public:
             EXPECT_TRUE(worker_has_tls(worker, better_tl, i)) <<
                 " transport " << better_tl << " should not be closed";
             EXPECT_FALSE(worker_has_tls(worker, tl, i)) <<
-                " transport " << better_tl << " should be closed";
+                " transport " << tl << " should be closed";
         }
     }
 };


### PR DESCRIPTION
## What

Fix the name of the transport printed which should be closed.

## Why ?

We have two transports `tl` and `better_tl`, `tl` should be closed.
So, this transport should be mentioned in the corresponding message.

## How ?

Replace `better_tl` by `tl`.