### PR TITLE
UCP/PROTO: Query protocol description

### DIFF
--- a/src/ucp/am/eager.c
+++ b/src/ucp/am/eager.c
@@ -102,6 +102,7 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_eager_short_proto = {
     .name     = "egr/am/short",
+    .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_short_init,
     .query    = ucp_proto_single_query,
@@ -210,6 +211,7 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .name     = "egr/am/single/bcopy",
+    .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_bcopy_single_init,
     .query    = ucp_proto_single_query,

--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -24,5 +24,10 @@ const char *ucp_proto_perf_types[] = {
 void ucp_proto_default_query(const ucp_proto_query_params_t *params,
                              ucp_proto_query_attr_t *attr)
 {
+    ucs_assert(params->proto->desc != NULL);
+
+    attr->max_msg_length = SIZE_MAX;
+    attr->is_estimation  = 0;
+    ucs_strncpy_safe(attr->desc, params->proto->desc, sizeof(attr->desc));
     ucs_strncpy_safe(attr->config, "", sizeof(attr->config));
 }

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -34,6 +34,10 @@
 #define UCP_PROTO_ID_INVALID        ((ucp_proto_id_t)-1)
 
 
+/* Maximal length of protocol description string */
+#define UCP_PROTO_DESC_STR_MAX      64
+
+
 /* Maximal length of protocol configuration string */
 #define UCP_PROTO_CONFIG_STR_MAX    128
 
@@ -178,24 +182,42 @@ typedef ucs_status_t
 (*ucp_proto_init_func_t)(const ucp_proto_init_params_t *params);
 
 
-/**
- * Protocol query input parameters
- */
 typedef struct {
+    /* Protocol definition */
+    const ucp_proto_t              *proto;
+
     /* Protocol private configuration area */
-    const void *priv;
+    const void                     *priv;
+
+    /* Worker on which the protocol was initialized */
+    ucp_worker_h                   worker;
+
+    /* Protocol selection parameters */
+    const ucp_proto_select_param_t *select_param;
+
+    /* Endpoint configuration */
+    const ucp_ep_config_key_t      *ep_config_key;
 
     /* Get information about this message length */
-    size_t     msg_length;
+    size_t                         msg_length;
 } ucp_proto_query_params_t;
 
 
-/**
- * Protocol query output
- */
 typedef struct {
+    /* Maximal message size of the range started from 'msg_length' for
+       which the description and configuration information is relevant.
+       It must be > msg_length. */
+    size_t max_msg_length;
+
+    /* Whether the reported information is not definitive, and the actual used
+       protocol depends on remote side decision as well. */
+    int    is_estimation;
+
+    /* High-level description of what the protocol is doing in this range */
+    char   desc[UCP_PROTO_DESC_STR_MAX];
+
     /* Protocol configuration in the range, such as devices and transports */
-    char config[UCP_PROTO_CONFIG_STR_MAX];
+    char   config[UCP_PROTO_CONFIG_STR_MAX];
 } ucp_proto_query_attr_t;
 
 
@@ -226,6 +248,7 @@ typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
  */
 struct ucp_proto {
     const char               *name; /* Protocol name */
+    const char               *desc; /* Protocol description */
     unsigned                 flags; /* Protocol flags for special handling */
     ucp_proto_init_func_t    init;  /* Initialization function */
     ucp_proto_query_func_t   query; /* Query protocol information */

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -17,6 +17,13 @@
 #define UCP_PROTO_COMMON_OFFSET_INVALID PTRDIFF_MAX
 
 
+/* Common protocol description strings */
+#define UCP_PROTO_SHORT_DESC    "short"
+#define UCP_PROTO_COPY_IN_DESC  "copy-in"
+#define UCP_PROTO_COPY_OUT_DESC "copy-out"
+#define UCP_PROTO_ZCOPY_DESC    "zero-copy"
+
+
 typedef enum {
     /* Send buffer is used by zero-copy operations */
     UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY    = UCS_BIT(0),
@@ -161,6 +168,12 @@ typedef ucs_status_t (*ucp_proto_complete_cb_t)(ucp_request_t *req);
 void ucp_proto_common_lane_priv_init(const ucp_proto_common_init_params_t *params,
                                      ucp_md_map_t md_map, ucp_lane_index_t lane,
                                      ucp_proto_common_lane_priv_t *lane_priv);
+
+
+void ucp_proto_common_lane_priv_str(const ucp_proto_query_params_t *params,
+                                    const ucp_proto_common_lane_priv_t *lpriv,
+                                    int show_rsc, int show_path,
+                                    ucs_string_buffer_t *strb);
 
 
 ucp_rsc_index_t

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -59,8 +59,9 @@ void ucp_proto_select_init_trace_caps(
     ucs_log_indent(-1);
 }
 
-void ucp_proto_select_dump_thresholds(
-        const ucp_proto_select_elem_t *select_elem, ucs_string_buffer_t *strb)
+void ucp_proto_select_dump_thresholds(ucp_worker_h worker,
+                                      const ucp_proto_select_elem_t *select_elem,
+                                      ucs_string_buffer_t *strb)
 {
     static const char *proto_info_fmt = "    %-18s %-18s %s\n";
     const ucp_proto_threshold_elem_t *thresh_elem;
@@ -75,7 +76,7 @@ void ucp_proto_select_dump_thresholds(
     do {
         ucs_string_buffer_init(&proto_config_strb);
 
-        ucp_proto_config_str(&thresh_elem->proto_config, range_start,
+        ucp_proto_config_str(worker, &thresh_elem->proto_config, range_start,
                              &proto_config_strb);
         range_end = thresh_elem->max_msg_length;
 
@@ -146,7 +147,7 @@ ucp_proto_select_elem_dump(ucp_worker_h worker,
     ucs_string_buffer_appendf(strb, "\n");
 
     ucs_string_buffer_appendf(strb, "\n  Selected protocols:\n");
-    ucp_proto_select_dump_thresholds(select_elem, strb);
+    ucp_proto_select_dump_thresholds(worker, select_elem, strb);
 
     ucs_string_buffer_appendf(strb, "\n  Performance estimation:\n");
     ucp_proto_select_dump_perf(select_elem,
@@ -246,7 +247,8 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
     ucs_string_buffer_appendf(strb, ")");
 }
 
-void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
+void ucp_proto_threshold_elem_str(ucp_worker_h worker,
+                                  const ucp_proto_threshold_elem_t *thresh_elem,
                                   size_t min_length, size_t max_length,
                                   ucs_string_buffer_t *strb)
 {
@@ -262,7 +264,7 @@ void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
         if ((range_end >= min_length) && (range_start <= max_length)) {
             proto = thresh_elem->proto_config.proto;
             ucs_string_buffer_appendf(strb, "%s(", proto->name);
-            ucp_proto_config_str(&thresh_elem->proto_config,
+            ucp_proto_config_str(worker, &thresh_elem->proto_config,
                                  ucs_max(range_start, min_length), strb);
             ucs_string_buffer_appendf(strb, ")");
 
@@ -296,7 +298,7 @@ void ucp_proto_select_config_str(ucp_worker_h worker,
     /* Print selection parameters */
     ucp_proto_select_param_str(&proto_config->select_param, strb);
     ucs_string_buffer_appendf(strb, ": %s ", proto_config->proto->name);
-    ucp_proto_config_str(proto_config, msg_length, strb);
+    ucp_proto_config_str(worker, proto_config, msg_length, strb);
 
     /* Find protocol selection root */
     proto_select = ucp_proto_select_get(worker, proto_config->ep_cfg_index,
@@ -329,11 +331,13 @@ void ucp_proto_select_config_str(ucp_worker_h worker,
                               send_time * UCS_USEC_PER_SEC);
 }
 
-void ucp_proto_config_str(const ucp_proto_config_t *proto_config,
+void ucp_proto_config_str(ucp_worker_h worker,
+                          const ucp_proto_config_t *proto_config,
                           size_t msg_length, ucs_string_buffer_t *strb)
 {
     ucp_proto_query_attr_t proto_attr;
 
-    ucp_proto_config_query(proto_config, msg_length, &proto_attr);
-    ucs_string_buffer_appendf(strb, "%s", proto_attr.config);
+    ucp_proto_config_query(worker, proto_config, msg_length, &proto_attr);
+    ucs_string_buffer_appendf(strb, "%s (%s)", proto_attr.desc,
+                              proto_attr.config);
 }

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -50,8 +50,9 @@ void ucp_proto_select_init_trace_caps(
         ucp_proto_id_t proto_id, const ucp_proto_init_params_t *init_params);
 
 
-void ucp_proto_select_dump_thresholds(
-        const ucp_proto_select_elem_t *select_elem, ucs_string_buffer_t *strb);
+void ucp_proto_select_dump_thresholds(ucp_worker_h worker,
+                                      const ucp_proto_select_elem_t *select_elem,
+                                      ucs_string_buffer_t *strb);
 
 
 void ucp_proto_select_dump(ucp_worker_h worker,
@@ -69,7 +70,8 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
                                 ucs_string_buffer_t *strb);
 
 
-void ucp_proto_threshold_elem_str(const ucp_proto_threshold_elem_t *thresh_elem,
+void ucp_proto_threshold_elem_str(ucp_worker_h worker,
+                                  const ucp_proto_threshold_elem_t *thresh_elem,
                                   size_t min_length, size_t max_length,
                                   ucs_string_buffer_t *strb);
 
@@ -80,7 +82,8 @@ void ucp_proto_select_config_str(ucp_worker_h worker,
                                  size_t msg_length, ucs_string_buffer_t *strb);
 
 
-void ucp_proto_config_str(const ucp_proto_config_t *proto_config,
+void ucp_proto_config_str(ucp_worker_h worker,
+                          const ucp_proto_config_t *proto_config,
                           size_t msg_length, ucs_string_buffer_t *strb);
 
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -204,16 +204,49 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     return ucp_proto_common_init_caps(&params->super, &perf, reg_md_map);
 }
 
+static const ucp_ep_config_key_lane_t *
+ucp_proto_multi_ep_lane_cfg(const ucp_proto_query_params_t *params,
+                            ucp_lane_index_t lane_index)
+{
+    const ucp_proto_multi_priv_t *mpriv = params->priv;
+    const ucp_proto_multi_lane_priv_t *lpriv;
+
+    ucs_assert(lane_index < mpriv->num_lanes);
+    lpriv = &mpriv->lanes[lane_index];
+
+    ucs_assert(lpriv->super.lane < UCP_MAX_LANES);
+    return &params->ep_config_key->lanes[lpriv->super.lane];
+}
+
 void ucp_proto_multi_query_config(const ucp_proto_query_params_t *params,
                                   ucp_proto_query_attr_t *attr)
 {
     UCS_STRING_BUFFER_FIXED(strb, attr->config, sizeof(attr->config));
     const ucp_proto_multi_priv_t *mpriv = params->priv;
+    const ucp_ep_config_key_lane_t *cfg_lane, *cfg_lane0;
     const ucp_proto_multi_lane_priv_t *lpriv;
     size_t percent, remaining;
+    int same_rsc, same_path;
     ucp_lane_index_t i;
 
     ucs_assert(mpriv->num_lanes <= UCP_MAX_LANES);
+    ucs_assert(mpriv->num_lanes >= 1);
+
+    same_rsc  = 1;
+    same_path = 1;
+    cfg_lane0 = ucp_proto_multi_ep_lane_cfg(params, 0);
+    for (i = 1; i < mpriv->num_lanes; ++i) {
+        cfg_lane  = ucp_proto_multi_ep_lane_cfg(params, i);
+        same_rsc  = same_rsc && (cfg_lane->rsc_index == cfg_lane0->rsc_index);
+        same_path = same_path &&
+                    (cfg_lane->path_index == cfg_lane0->path_index);
+    }
+
+    if (same_rsc) {
+        ucp_proto_common_lane_priv_str(params, &mpriv->lanes[0].super, 1,
+                                       same_path, &strb);
+        ucs_string_buffer_appendf(&strb, " ");
+    }
 
     remaining = 100;
     for (i = 0; i < mpriv->num_lanes; ++i) {
@@ -226,7 +259,17 @@ void ucp_proto_multi_query_config(const ucp_proto_query_params_t *params,
             ucs_string_buffer_appendf(&strb, "%zu%% on ", percent);
         }
 
-        ucs_string_buffer_appendf(&strb, "lane[%d] ", lpriv->super.lane);
+        ucp_proto_common_lane_priv_str(params, &lpriv->super, !same_rsc,
+                                       !(same_rsc && same_path), &strb);
+
+        /* Print a string like "30% on A, 40% on B, and 30% on C" */
+        if (i != (mpriv->num_lanes - 1)) {
+            if (i == (mpriv->num_lanes - 2)) {
+                ucs_string_buffer_appendf(&strb, " and ");
+            } else {
+                ucs_string_buffer_appendf(&strb, ", ");
+            }
+        }
     }
 
     ucs_string_buffer_rtrim(&strb, NULL);

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -90,6 +90,7 @@ ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_reconfig_proto = {
     .name     = "reconfig",
+    .desc     = "stub protocol",
     .flags    = UCP_PROTO_FLAG_INVALID,
     .init     = ucp_proto_reconfig_init,
     .query    = ucp_proto_default_query,

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -160,12 +160,14 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
                      ucp_worker_cfg_index_t *new_rkey_cfg_index);
 
 
-void ucp_proto_config_query(const ucp_proto_config_t *proto_config,
+void ucp_proto_config_query(ucp_worker_h worker,
+                            const ucp_proto_config_t *proto_config,
                             size_t msg_length,
                             ucp_proto_query_attr_t *proto_attr);
 
 
-void ucp_proto_select_elem_query(const ucp_proto_select_elem_t *select_elem,
+void ucp_proto_select_elem_query(ucp_worker_h worker,
+                                 const ucp_proto_select_elem_t *select_elem,
                                  size_t msg_length,
                                  ucp_proto_query_attr_t *proto_attr);
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -12,8 +12,9 @@
 #include "proto_common.h"
 #include "proto_init.h"
 
+#include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
-#include <ucs/sys/string.h>
+#include <ucs/sys/math.h>
 
 
 ucs_status_t
@@ -69,9 +70,9 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
 void ucp_proto_single_query(const ucp_proto_query_params_t *params,
                             ucp_proto_query_attr_t *attr)
 {
+    UCS_STRING_BUFFER_FIXED(config_strb, attr->config, sizeof(attr->config));
     const ucp_proto_single_priv_t *spriv = params->priv;
 
     ucp_proto_default_query(params, attr);
-    ucs_snprintf_safe(attr->config, sizeof(attr->config), "lane[%d]",
-                      spriv->super.lane);
+    ucp_proto_common_lane_priv_str(params, &spriv->super, 1, 1, &config_strb);
 }

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -198,6 +198,7 @@ ucp_proto_amo_init(const ucp_proto_init_params_t *init_params,
     \
     static ucp_proto_t ucp_amo_proto_##_id = { \
         .name     = "amo" #_bits "/" #_id "/" #_sub_id, \
+        .desc     = #_sub_id, \
         .init     = ucp_amo_init_##_id, \
         .query    = ucp_proto_single_query, \
         .progress = {ucp_amo_progress_##_id} \

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -417,6 +417,7 @@ ucp_proto_amo_sw_init_post(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_get_amo_post_proto = {
     .name     = "amo/post/sw",
+    .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
     .init     = ucp_proto_amo_sw_init_post,
     .query    = ucp_proto_single_query,
@@ -445,6 +446,7 @@ ucp_proto_amo_sw_init_fetch(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_get_amo_fetch_proto = {
     .name     = "amo/fetch/sw",
+    .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
     .init     = ucp_proto_amo_sw_init_fetch,
     .query    = ucp_proto_single_query,

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -100,6 +100,7 @@ ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_get_am_bcopy_proto = {
     .name     = "get/am/bcopy",
+    .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
     .init     = ucp_proto_get_am_bcopy_init,
     .query    = ucp_proto_single_query,

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -106,6 +106,7 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_get_offload_bcopy_proto = {
     .name     = "get/bcopy",
+    .desc     = UCP_PROTO_COPY_OUT_DESC,
     .flags    = 0,
     .init     = ucp_proto_get_offload_bcopy_init,
     .query    = ucp_proto_multi_query,
@@ -191,6 +192,7 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_get_offload_zcopy_proto = {
     .name     = "get/zcopy",
+    .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_get_offload_zcopy_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -105,6 +105,7 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_put_am_bcopy_proto = {
     .name     = "put/am/bcopy",
+    .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
     .init     = ucp_proto_put_am_bcopy_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -81,6 +81,7 @@ ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_put_offload_short_proto = {
     .name     = "put/offload/short",
+    .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_PUT_SHORT,
     .init     = ucp_proto_put_offload_short_init,
     .query    = ucp_proto_single_query,
@@ -176,6 +177,7 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_put_offload_bcopy_proto = {
     .name     = "put/offload/bcopy",
+    .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
     .init     = ucp_proto_put_offload_bcopy_init,
     .query    = ucp_proto_multi_query,
@@ -262,6 +264,7 @@ static void ucp_put_offload_zcopy_abort(ucp_request_t *request,
 
 static ucp_proto_t ucp_put_offload_zcopy_proto = {
     .name     = "put/offload/zcopy",
+    .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_put_offload_zcopy_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -14,6 +14,9 @@
 #include <ucs/datastruct/ptr_map.h>
 
 
+#define UCP_PROTO_RMA_EMULATION_DESC "software emulation"
+
+
 /**
  * Defines functions for RMA protocol
  */

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -422,10 +422,16 @@ void ucp_proto_rndv_bulk_query(const ucp_proto_query_params_t *params,
 {
     const ucp_proto_rndv_bulk_priv_t *rpriv     = params->priv;
     ucp_proto_query_params_t multi_query_params = {
-        .priv       = &rpriv->mpriv,
-        .msg_length = params->msg_length
+        .proto         = params->proto,
+        .priv          = &rpriv->mpriv,
+        .worker        = params->worker,
+        .select_param  = params->select_param,
+        .ep_config_key = params->ep_config_key,
+        .msg_length    = params->msg_length
     };
 
+    attr->max_msg_length = SIZE_MAX;
+    attr->is_estimation  = 0;
     ucp_proto_multi_query_config(&multi_query_params, attr);
 }
 

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -118,6 +118,7 @@ ucp_proto_rdnv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .name     = "rndv/am/bcopy",
+    .desc     = "fragmented " UCP_PROTO_COPY_IN_DESC " " UCP_PROTO_COPY_OUT_DESC,
     .flags    = 0,
     .init     = ucp_proto_rdnv_am_bcopy_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -11,6 +11,7 @@
 #include "proto_rndv.inl"
 #include "rndv_mtype.inl"
 
+#define UCP_PROTO_RNDV_GET_DESC "read from remote"
 
 enum {
     UCP_PROTO_RNDV_GET_STAGE_FETCH = UCP_PROTO_STAGE_START,
@@ -104,6 +105,14 @@ ucp_proto_rndv_get_zcopy_init(const ucp_proto_init_params_t *init_params)
                                           0, 0);
 }
 
+static void
+ucp_proto_rndv_get_zcopy_query(const ucp_proto_query_params_t *params,
+                               ucp_proto_query_attr_t *attr)
+{
+    ucp_proto_default_query(params, attr);
+    ucp_proto_rndv_bulk_query(params, attr);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_rndv_get_zcopy_send_func(ucp_request_t *req,
                                    const ucp_proto_multi_lane_priv_t *lpriv,
@@ -185,9 +194,10 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
 
 static ucp_proto_t ucp_rndv_get_zcopy_proto = {
     .name     = "rndv/get/zcopy",
+    .desc     = UCP_PROTO_ZCOPY_DESC " " UCP_PROTO_RNDV_GET_DESC,
     .flags    = 0,
     .init     = ucp_proto_rndv_get_zcopy_init,
-    .query    = ucp_proto_rndv_bulk_query,
+    .query    = ucp_proto_rndv_get_zcopy_query,
     .progress = {
          [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_zcopy_fetch_progress,
          [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
@@ -286,11 +296,20 @@ ucp_proto_rndv_get_mtype_init(const ucp_proto_init_params_t *init_params)
                                           mdesc_md_map, 1);
 }
 
+static void
+ucp_proto_rndv_get_mtype_query(const ucp_proto_query_params_t *params,
+                               ucp_proto_query_attr_t *attr)
+{
+    ucp_proto_rndv_bulk_query(params, attr);
+    ucp_proto_rndv_mtype_query_desc(params, attr, UCP_PROTO_RNDV_GET_DESC);
+}
+
 static ucp_proto_t ucp_rndv_get_mtype_proto = {
     .name     = "rndv/get/mtype",
+    .desc     = NULL,
     .flags    = 0,
     .init     = ucp_proto_rndv_get_mtype_init,
-    .query    = ucp_proto_rndv_bulk_query,
+    .query    = ucp_proto_rndv_get_mtype_query,
     .progress = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,
         [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
@@ -344,6 +363,7 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *params)
 
 static ucp_proto_t ucp_rndv_ats_proto = {
     .name     = "rndv/ats",
+    .desc     = "no data fetch",
     .flags    = 0,
     .init     = ucp_proto_rndv_ats_init,
     .query    = ucp_proto_default_query,

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -25,6 +25,11 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
         return UCS_ERR_UNSUPPORTED;
     }
 
+    if ((init_params->select_param->op_id != UCP_OP_ID_RNDV_SEND) &&
+        (init_params->select_param->op_id != UCP_OP_ID_RNDV_RECV)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     status = ucp_mm_get_alloc_md_map(worker->context, mdesc_md_map_p);
     if (status != UCS_OK) {
         return status;
@@ -132,6 +137,30 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_mtype_copy(
     }
 
     return status;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_rndv_mtype_query_desc(const ucp_proto_query_params_t *params,
+                                ucp_proto_query_attr_t *attr,
+                                const char *xfer_desc)
+{
+    UCS_STRING_BUFFER_FIXED(strb, attr->desc, sizeof(attr->desc));
+    ucp_context_h context      = params->worker->context;
+    ucs_memory_type_t mem_type = params->select_param->mem_type;
+    ucp_ep_h mtype_ep          = params->worker->mem_type_ep[mem_type];
+    ucp_lane_index_t lane      = ucp_ep_config(mtype_ep)->key.rma_bw_lanes[0];
+    ucp_rsc_index_t rsc_index  = ucp_ep_get_rsc_index(mtype_ep, lane);
+    const char *tl_name        = context->tl_rscs[rsc_index].tl_rsc.tl_name;
+
+    if (params->select_param->op_id == UCP_OP_ID_RNDV_SEND) {
+        ucs_string_buffer_appendf(&strb, "%s, ", tl_name);
+    }
+
+    ucs_string_buffer_appendf(&strb, "%s", xfer_desc);
+
+    if (params->select_param->op_id == UCP_OP_ID_RNDV_RECV) {
+        ucs_string_buffer_appendf(&strb, ", %s", tl_name);
+    }
 }
 
 #endif

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -124,8 +124,24 @@ static void ucp_proto_rndv_ppln_query(const ucp_proto_query_params_t *params,
                                       ucp_proto_query_attr_t *attr)
 {
     const ucp_proto_rndv_ppln_priv_t *rpriv = params->priv;
+    ucp_proto_query_attr_t frag_attr;
 
-    ucp_proto_select_elem_query(&rpriv->frag_proto, params->msg_length, attr);
+    if (params->msg_length <= rpriv->frag_size) {
+        /* Message is smaller than fragment size */
+        ucp_proto_select_elem_query(params->worker, &rpriv->frag_proto,
+                                    params->msg_length, attr);
+        attr->max_msg_length = rpriv->frag_size;
+    } else {
+        /* Message is large and fragmented to frag_size */
+        ucp_proto_select_elem_query(params->worker, &rpriv->frag_proto,
+                                    rpriv->frag_size, &frag_attr);
+
+        attr->max_msg_length = SIZE_MAX;
+        attr->is_estimation  = 0;
+        ucs_snprintf_safe(attr->desc, sizeof(attr->desc), "pipeline %s",
+                          frag_attr.desc);
+        ucs_strncpy_safe(attr->config, frag_attr.config, sizeof(attr->config));
+    }
 }
 
 static void
@@ -256,6 +272,7 @@ ucp_proto_rndv_send_ppln_atp_progress(uct_pending_req_t *uct_req)
 
 static ucp_proto_t ucp_rndv_send_ppln_proto = {
     .name     = "rndv/send/ppln",
+    .desc     = NULL,
     .flags    = 0,
     .init     = ucp_proto_rndv_send_ppln_init,
     .query    = ucp_proto_rndv_ppln_query,
@@ -291,6 +308,7 @@ ucp_proto_rndv_recv_ppln_ats_progress(uct_pending_req_t *uct_req)
 
 static ucp_proto_t ucp_rndv_recv_ppln_proto = {
     .name     = "rndv/recv/ppln",
+    .desc     = NULL,
     .flags    = 0,
     .init     = ucp_proto_rndv_recv_ppln_init,
     .query    = ucp_proto_rndv_ppln_query,

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -75,6 +75,18 @@ ucp_proto_rndv_rkey_ptr_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_rndv_ack_init(init_params, &rpriv->ack);
 }
 
+static void
+ucp_proto_rndv_rkey_ptr_query(const ucp_proto_query_params_t *params,
+                              ucp_proto_query_attr_t *attr)
+{
+    UCS_STRING_BUFFER_FIXED(config_strb, attr->config, sizeof(attr->config));
+    const ucp_proto_rndv_rkey_ptr_priv_t *rpriv = params->priv;
+
+    ucp_proto_default_query(params, attr);
+    ucp_proto_common_lane_priv_str(params, &rpriv->spriv.super, 1, 0,
+                                   &config_strb);
+}
+
 static unsigned ucp_proto_rndv_progress_rkey_ptr(void *arg)
 {
     ucp_worker_h worker = (ucp_worker_h)arg;
@@ -151,9 +163,10 @@ ucp_proto_rndv_rkey_ptr_fetch_progress(uct_pending_req_t *uct_req)
 
 static ucp_proto_t ucp_rndv_rkey_ptr_proto = {
     .name     = "rndv/rkey_ptr",
+    .desc     = "copy from mapped remote memory",
     .flags    = 0,
     .init     = ucp_proto_rndv_rkey_ptr_init,
-    .query    = ucp_proto_default_query,
+    .query    = ucp_proto_rndv_rkey_ptr_query,
     .progress = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_FETCH] = ucp_proto_rndv_rkey_ptr_fetch_progress,
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -231,11 +231,14 @@ static void ucp_proto_rndv_rtr_query(const ucp_proto_query_params_t *params,
 {
     const ucp_proto_rndv_ctrl_priv_t *rpriv = params->priv;
 
-    ucp_proto_select_elem_query(&rpriv->remote_proto, params->msg_length, attr);
+    ucp_proto_select_elem_query(params->worker, &rpriv->remote_proto,
+                                params->msg_length, attr);
+    attr->is_estimation = 1;
 }
 
 static ucp_proto_t ucp_rndv_rtr_proto = {
     .name     = "rndv/rtr",
+    .desc     = NULL,
     .flags    = 0,
     .init     = ucp_proto_rndv_rtr_init,
     .query    = ucp_proto_rndv_rtr_query,
@@ -378,12 +381,20 @@ ucp_proto_rndv_rtr_mtype_query(const ucp_proto_query_params_t *params,
                                ucp_proto_query_attr_t *attr)
 {
     const ucp_proto_rndv_ctrl_priv_t *rpriv = params->priv;
+    ucp_proto_query_attr_t remote_attr;
 
-    ucp_proto_select_elem_query(&rpriv->remote_proto, params->msg_length, attr);
+    ucp_proto_select_elem_query(params->worker, &rpriv->remote_proto,
+                                params->msg_length, &remote_attr);
+
+    attr->is_estimation  = 1;
+    attr->max_msg_length = remote_attr.max_msg_length;
+    ucp_proto_rndv_mtype_query_desc(params, attr, remote_attr.desc);
+    ucs_strncpy_safe(attr->config, remote_attr.config, sizeof(attr->config));
 }
 
 static ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .name     = "rndv/rtr/mtype",
+    .desc     = NULL,
     .flags    = 0,
     .init     = ucp_proto_rndv_rtr_mtype_init,
     .query    = ucp_proto_rndv_rtr_mtype_query,

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -16,6 +16,12 @@
 #include <ucp/dt/dt.inl>
 
 
+/* Convenience macros for setting eager protocols descriptions  */
+#define UCP_PROTO_EAGER_BCOPY_DESC \
+    "eager " UCP_PROTO_COPY_IN_DESC " " UCP_PROTO_COPY_OUT_DESC
+#define UCP_PROTO_EAGER_ZCOPY_DESC \
+    "eager " UCP_PROTO_ZCOPY_DESC " " UCP_PROTO_COPY_OUT_DESC
+
 /*
  * EAGER_ONLY, EAGER_MIDDLE
  */

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -164,6 +164,7 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
 
 static ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .name     = "egr/multi/bcopy",
+    .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_bcopy_multi_init,
     .query    = ucp_proto_multi_query,
@@ -240,6 +241,7 @@ ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
 
 static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .name     = "egrsnc/multi/bcopy",
+    .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_sync_bcopy_multi_init,
     .query    = ucp_proto_multi_query,
@@ -322,6 +324,7 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
 
 static ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .name     = "egr/multi/zcopy",
+    .desc     = UCP_PROTO_EAGER_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_zcopy_multi_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -77,6 +77,7 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_eager_short_proto = {
     .name     = "egr/short",
+    .desc     = "eager " UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_AM_SHORT,
     .init     = ucp_proto_eager_short_init,
     .query    = ucp_proto_single_query,
@@ -144,6 +145,7 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
 
 static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .name     = "egr/single/bcopy",
+    .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_bcopy_single_init,
     .query    = ucp_proto_single_query,
@@ -212,6 +214,7 @@ ucp_proto_eager_zcopy_single_progress(uct_pending_req_t *self)
 
 static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .name     = "egr/single/zcopy",
+    .desc     = UCP_PROTO_EAGER_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_zcopy_single_init,
     .query    = ucp_proto_single_query,

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -12,6 +12,8 @@
 #include <ucp/tag/proto_eager.inl>
 #include <ucp/proto/proto_single.inl>
 
+#define UCP_PROTO_EAGER_OFFLOAD_DESC "eager offloaded"
+
 
 static ucs_status_t
 ucp_proto_eager_tag_offload_short_progress(uct_pending_req_t *self)
@@ -74,6 +76,7 @@ static ucs_status_t ucp_proto_eager_tag_offload_short_init(
 
 static ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .name     = "egr/offload/short",
+    .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_TAG_SHORT,
     .init     = ucp_proto_eager_tag_offload_short_init,
     .query    = ucp_proto_single_query,
@@ -165,6 +168,7 @@ static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init(
 
 static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .name     = "egr/offload/bcopy",
+    .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_tag_offload_bcopy_init,
     .query    = ucp_proto_single_query,
@@ -203,6 +207,7 @@ static ucs_status_t ucp_proto_eager_sync_tag_offload_bcopy_init(
 
 static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .name     = "egrsnc/offload/bcopy",
+    .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_sync_tag_offload_bcopy_init,
     .query    = ucp_proto_single_query,
@@ -277,6 +282,7 @@ ucp_proto_eager_tag_offload_zcopy_progress(uct_pending_req_t *self)
 
 static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .name     = "egr/offload/zcopy",
+    .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_tag_offload_zcopy_init,
     .query    = ucp_proto_single_query,
@@ -334,6 +340,7 @@ ucp_proto_eager_sync_tag_offload_zcopy_progress(uct_pending_req_t *self)
 
 static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .name     = "egrsnc/offload/zcopy",
+    .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_sync_tag_offload_zcopy_init,
     .query    = ucp_proto_single_query,

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -153,8 +153,17 @@ static void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
                                      ucp_proto_query_attr_t *attr)
 {
     const ucp_proto_rndv_ctrl_priv_t *rpriv = params->priv;
+    ucp_proto_query_attr_t remote_attr;
 
-    ucp_proto_select_elem_query(&rpriv->remote_proto, params->msg_length, attr);
+    ucp_proto_select_elem_query(params->worker, &rpriv->remote_proto,
+                                params->msg_length, &remote_attr);
+
+    attr->is_estimation  = 1;
+    attr->max_msg_length = SIZE_MAX;
+
+    ucs_snprintf_safe(attr->desc, sizeof(attr->desc), "rendezvous %s",
+                      remote_attr.desc);
+    ucs_strncpy_safe(attr->config, remote_attr.config, sizeof(attr->config));
 }
 
 static void ucp_tag_rndv_proto_abort(ucp_request_t *request,
@@ -172,6 +181,7 @@ static void ucp_tag_rndv_proto_abort(ucp_request_t *request,
 
 static ucp_proto_t ucp_tag_rndv_proto = {
     .name     = "tag/rndv",
+    .desc     = NULL,
     .flags    = 0,
     .init     = ucp_proto_rndv_rts_init,
     .query    = ucp_proto_rndv_rts_query,


### PR DESCRIPTION
## Why
Print protocol description for users, to show "what UCX is doing" for a given message type.

Example:
```console
$ UCX_LOG_LEVEL=info UCX_PROTO_ENABLE=y ./build-devel/src/tools/info/ucx_info -u t -e -P inter 
[1644513407.053874] [host:65512:0]     ucp_context.c:1776 UCX  INFO  UCP version is 1.13 (release 0)
[1644513407.222274] [host:65512:0]          parser.c:1911 UCX  WARN  unused env variable: UCX_PROTO_INFO_DIR (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1644513407.222288] [host:65512:0]          parser.c:1918 UCX  INFO  UCX_* env variables: UCX_PROTO_ENABLE=y UCX_LOG_LEVEL=info
[1644513407.255547] [host:65512:0]    proto_select.c:491  UCX  INFO      ep_cfg[0] tag_send(contiguous)
[1644513407.255559] [host:65512:0]    proto_select.c:492  UCX  INFO          SIZE               PROTOCOL           CONFIGURATION
[1644513407.255559] [host:65512:0]    proto_select.c:492  UCX  INFO          0..1733            egr/short          eager short (rc_mlx5/mlx5_bond_0:1)
[1644513407.255559] [host:65512:0]    proto_select.c:492  UCX  INFO          1734..8246         egr/single/zcopy   eager zero-copy copy-out (rc_mlx5/mlx5_bond_0:1)
[1644513407.255559] [host:65512:0]    proto_select.c:492  UCX  INFO          8247..13966        egr/multi/zcopy    eager zero-copy copy-out (rc_mlx5/mlx5_bond_0:1)
[1644513407.255559] [host:65512:0]    proto_select.c:492  UCX  INFO          13967..inf         tag/rndv           rendezvous zero-copy read from remote (50% on rc_mlx5/mlx5_bond_0:1 and 50% on rc_mlx5/mlx5_bond_0:1)
[1644513407.255578] [host:65512:0]      ucp_worker.c:1887 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1); 
[1644513407.261726] [host:65512:0]    proto_select.c:491  UCX  INFO      ep_cfg[0] tag_send(contiguous)
[1644513407.261739] [host:65512:0]    proto_select.c:492  UCX  INFO          SIZE               PROTOCOL           CONFIGURATION
[1644513407.261739] [host:65512:0]    proto_select.c:492  UCX  INFO          0..1733            egr/short          eager short (rc_mlx5/mlx5_bond_0:1)
[1644513407.261739] [host:65512:0]    proto_select.c:492  UCX  INFO          1734..8246         egr/single/zcopy   eager zero-copy copy-out (rc_mlx5/mlx5_bond_0:1)
[1644513407.261739] [host:65512:0]    proto_select.c:492  UCX  INFO          8247..13966        egr/multi/zcopy    eager zero-copy copy-out (rc_mlx5/mlx5_bond_0:1)
[1644513407.261739] [host:65512:0]    proto_select.c:492  UCX  INFO          13967..inf         tag/rndv           rendezvous zero-copy read from remote (50% on rc_mlx5/mlx5_bond_0:1 and 50% on rc_mlx5/mlx5_bond_0:1)
[1644513407.261757] [host:65512:0]      ucp_worker.c:1887 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1); 
```