### PR TITLE
UCP/CORE: Improve printing configuration

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -396,10 +396,10 @@ ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                        ucp_send_nbx_callback_t discarded_cb,
                                        void *discarded_cb_arg);
 
-char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
-                                ucp_context_h context,
-                                ucp_worker_cfg_index_t config_idx, char *info,
-                                size_t max);
+const char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
+                                      ucp_context_h context,
+                                      ucp_worker_cfg_index_t config_idx,
+                                      ucs_string_buffer_t *strb);
 
 void ucp_worker_vfs_refresh(void *obj);
 

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -169,12 +169,10 @@ void ucp_proto_select_dump(ucp_worker_h worker,
 {
     ucp_proto_select_elem_t select_elem;
     ucp_proto_select_key_t key;
-    char info[256];
 
+    ucs_string_buffer_appendf(strb, "\nProtocol selection for ");
     ucp_worker_print_used_tls(&worker->ep_config[ep_cfg_index].key,
-                              worker->context, ep_cfg_index, info,
-                              sizeof(info));
-    ucs_string_buffer_appendf(strb, "\nProtocol selection for %s", info);
+                              worker->context, ep_cfg_index, strb);
 
     if (rkey_cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
         ucs_string_buffer_appendf(strb, "rkey_cfg[%d]: ", rkey_cfg_index);


### PR DESCRIPTION
## What

Improve printing configuration:
Use UCS string buffer instead of `char*` and pointer arithmetic.

## Why ?

To simplify code and trim the trailing "; ".

Before:
```
[1644537002.052399] [swx-ucx01:42934:0]          parser.c:1918 UCX  INFO  UCX_* env variable: UCX_LOG_LEVEL=info
[1644537002.052738] [swx-ucx01:42934:0]      ucp_worker.c:1887 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1); rma(rc_mlx5/mlx5_bond_0:1); amo(rc_mlx5/mlx5_bond_0:1);
```
After:
```
[1644536631.543315] [swx-ucx01:56970:0]          parser.c:1918 UCX  INFO  UCX_* env variable: UCX_LOG_LEVEL=info
[1644536631.543668] [swx-ucx01:56970:0]      ucp_worker.c:1877 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1); rma(rc_mlx5/mlx5_bond_0:1); amo(rc_mlx5/mlx5_bond_0:1)
```


## How ?

Use UCS string buffer instead of `char*` storage for the string. When the string is fully built, trim "; " from the result string.