### PR TITLE
GTEST/UCP: Fix ep_pending_add/ep_flush which return busy/no_resource for discard only

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -691,8 +691,7 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
         ucp_request_mem_free(req);
     } else if (req->send.state.uct_comp.func == ucp_ep_flush_completion) {
         ucp_ep_flush_request_ff(req, status);
-    } else if (req->send.state.uct_comp.func ==
-               ucp_worker_discard_uct_ep_flush_comp) {
+    } else if (req->send.uct.func == ucp_worker_discard_uct_ep_pending_cb) {
         /* Discard operations with flush(LOCAL) could be started (e.g. closing
          * unneeded UCT EPs from intersection procedure), convert them to
          * flush(CANCEL) to avoid flushing failed UCT EPs

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2385,7 +2385,7 @@ static void ucp_worker_discard_uct_ep_progress_register(ucp_request_t *req,
                                       &req->send.discard_uct_ep.cb_id);
 }
 
-void ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
+static void ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
@@ -2399,8 +2399,7 @@ void ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self)
             req, ucp_worker_discard_uct_ep_destroy_progress);
 }
 
-static ucs_status_t
-ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self)
+ucs_status_t ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     uct_ep_h uct_ep    = req->send.discard_uct_ep.uct_ep;

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -403,7 +403,7 @@ char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
 
 void ucp_worker_vfs_refresh(void *obj);
 
-void ucp_worker_discard_uct_ep_flush_comp(uct_completion_t *self);
+ucs_status_t ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self);
 
 unsigned ucp_worker_discard_uct_ep_progress(void *arg);
 


### PR DESCRIPTION
## What

Fix `ep_pending_add`/`ep_flush` which return busy/no_resource for discard only

## Why ?

Fixes running of multiple iterations of `test_ucp_sockaddr.force_close_during_rndv` and `test_ucp_sockaddr.fail_and_force_close_during_rndv` tests over UD transport.
To fix hang due to hanging in `ucp_request_send` which tries to send `WIREUP_MSG/EP_REMOVED`:
- `uct_ep_am_bcopy` returns `UCS_ERR_NO_RESOURCE`
- `uct_ep_pending_add` return `UCS_ERR_NO_BUSY`
- it hangs always doing `uct_ep_am_bcopy`-`uct_ep_pending_add`.

The example of the issue described above:
```
#0  0x00007ffff7331b44 in ucp_wireup_msg_progress (self=0x36e32f8) at wireup/wireup.c:179
#1  0x00007ffff7332624 in ucp_request_try_send (req=0x36e3210) at /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_request.inl:334
#2  ucp_request_send (req=0x36e3210) at /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_request.inl:357
#3  ucp_wireup_msg_send (ep=0x7fffe8f850a0, type=5 '\005', tl_bitmap=0x14ecae0 <ucp_tl_bitmap_min>, lanes2remote=0x0) at wireup/wireup.c:257
#4  0x00007ffff73343fe in ucp_wireup_send_ep_removed (worker=0x2c02e50, msg=0x7ffff7f94f30, remote_address=0x7fffffffcce0) at wireup/wireup.c:741
#5  0x00007ffff7334d2b in ucp_wireup_msg_handler (arg=0x2c02e50, data=0x7ffff7f94f30, length=91, flags=1) at wireup/wireup.c:825
#6  0x00007ffff670ffdf in uct_iface_invoke_am (iface=0x2f1b080, id=1 '\001', data=0x7ffff7f94f30, length=91, flags=1) at /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/base/uct_iface.h:847
#7  0x00007ffff6716bac in uct_ib_iface_invoke_am_desc (ib_desc=0x7ffff7f94ecc, length=91, data=0x7ffff7f94f30, am_id=1 '\001', iface=0x2f1b080)
    at /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/ib/base/ib_iface.h:365
#8  uct_ud_ep_process_rx (iface=0x2f1b080, neth=0x7ffff7f94f28, byte_len=99, skb=0x7ffff7f94ecc, is_async=0) at ud/base/ud_ep.c:1014
#9  0x00007ffff6737f4f in uct_ud_mlx5_iface_poll_rx (is_async=0, iface=0x2f1b080) at ud/accel/ud_mlx5.c:507
#10 uct_ud_mlx5_iface_progress (tl_iface=0x2f1b080) at ud/accel/ud_mlx5.c:561
#11 0x00007ffff720e107 in ucs_callbackq_dispatch (cbq=0x2ab8610) at /auto/rdmzsysgwork/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
#12 0x00007ffff721b004 in uct_worker_progress (worker=0x2ab8610) at /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/api/uct.h:2600
#13 ucp_worker_progress (worker=0x2c02e50) at core/ucp_worker.c:2664
#14 0x0000000000a88fa6 in ucp_test_base::entity::progress (this=0x2abda30, worker_index=0) at ucp/ucp_test.cc:1047
#15 0x0000000000a83ad4 in ucp_test::progress (this=0x2aa3fc0, entities=std::vector of length 1, capacity 1 = {...}, worker_index=0) at ucp/ucp_test.cc:168
#16 0x0000000000a84054 in ucp_test::request_progress (this=0x2aa3fc0, req=0x39da058, entities=std::vector of length 1, capacity 1 = {...}, timeout=0.5, worker_index=0) at ucp/ucp_test.cc:266
#17 0x0000000000a21192 in test_ucp_sockaddr::do_force_close_during_rndv (this=0x2aa3fc0, fail_send_ep=false) at ucp/test_ucp_sockaddr.cc:950
#18 0x00000000009f6611 in test_ucp_sockaddr_force_close_during_rndv_Test::test_body (this=0x2aa3fc0) at ucp/test_ucp_sockaddr.cc:1186
#19 0x00000000005981be in ucs::test_base::run (this=0x2aa3fc0) at common/test.cc:356
#20 0x0000000000598381 in ucs::test_base::TestBodyProxy (this=0x2aa3fc0) at common/test.cc:382
#21 0x00000000007b44fa in ucp_test::TestBody (this=0x2aa3fc0) at ucp/ucp_test.h:202
#22 0x0000000000e1a88c in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (object=0x2aa4040, method=&virtual testing::Test::TestBody(), location=0xf7396b "the test body")
    at gtest.cc:2433
#23 0x0000000000e16716 in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=0x2aa4040, method=&virtual testing::Test::TestBody(), location=0xf7396b "the test body")
    at gtest.cc:2469
#24 0x0000000000e016e5 in testing::Test::Run (this=0x2aa4040) at gtest.cc:2509
#25 0x0000000000e01f4d in testing::TestInfo::Run (this=0x25278b0) at gtest.cc:2687
#26 0x0000000000e02606 in testing::TestSuite::Run (this=0x225e8b0) at gtest.cc:2819
#27 0x0000000000e0d804 in testing::internal::UnitTestImpl::RunAllTests (this=0x14f3500) at gtest.cc:5350
#28 0x0000000000e1b58f in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x14f3500,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0xe0d464 <testing::internal::UnitTestImpl::RunAllTests()>,
    location=0xf74360 "auxiliary test code (environments or event listeners)") at gtest.cc:2433
#29 0x0000000000e175ba in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x14f3500,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0xe0d464 <testing::internal::UnitTestImpl::RunAllTests()>,
    location=0xf74360 "auxiliary test code (environments or event listeners)") at gtest.cc:2469
#30 0x0000000000e0c2d0 in testing::UnitTest::Run (this=0x14f0980 <testing::UnitTest::GetInstance()::instance>) at gtest.cc:4940
#31 0x000000000057c01f in RUN_ALL_TESTS () at common/googletest/gtest.h:2473
#32 0x000000000057bcc0 in main (argc=1, argv=0x7fffffffe048) at common/main.cc:118
```

## How ?

1. Declare `ucp_worker_discard_uct_ep_pending_cb` in `ucp/core/ucp_worker.h` to use it from gtest.
2. Define `ep_pending_add` callback which return `UCS_ERR_BUSY` if `req->func` is `ucp_worker_discard_uct_ep_pending_cb`.
3. Define `ep_flush` callback which return `UCS_ERR_NO_RESOURSE` if `comp->func` is `ucp_worker_discard_uct_ep_flush_comp`.