### PR TITLE
UCP/WIREUP: Fix parsing AM_ONLY flag from the header of a worker address [v1.12.x]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,10 @@
 ##
 #
 
+## 1.12.1-rc2 (TBD)
+### Bugfixes
+* Fixed parsing header flags of worker address
+
 ## 1.12.1-rc1 (February 9, 2022)
 ### Bugfixes
 * Fixed memory hooks for Cuda 11.5

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -1088,9 +1088,11 @@ uint64_t ucp_address_get_client_id(const void *address)
 
 uint8_t ucp_address_is_am_only(const void *address)
 {
-    const uint8_t address_header = *(const uint8_t *)address;
+    uint8_t addr_flags;
+    ucp_object_version_t addr_version;
 
-    return address_header & UCP_ADDRESS_HEADER_FLAG_AM_ONLY;
+    ucp_address_unpack_header(address, &addr_version, &addr_flags);
+    return addr_flags & UCP_ADDRESS_HEADER_FLAG_AM_ONLY;
 }
 
 static ucs_status_t


### PR DESCRIPTION
porting of #7884 to `v1.12.x` branch targeting `v1.12.1-rc2`

## What

Fix parsing AM_ONLY flag from the header of a worker address.

## Why ?

`UCP_ADDRESS_HEADER_FLAG_AM_ONLY`  and other flags packed to the header in case of address_v1, but packed after header in case of address_v2.

## How ?

1. Update `ucp_address_is_am_only` function to unpack header and get `addr_flags` and `addr_version` from it.
2. Check that `addr_flags` has `UCP_ADDRESS_HEADER_FLAG_AM_ONLY` bit set.