### PR TITLE
UCP/UCT/UCS: Fix compiler warnings with -Og option

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -244,6 +244,8 @@ build_clang() {
 # Build with gcc-latest module
 #
 build_gcc() {
+	cflags=$1
+
 	#If the glibc version on the host is older than 2.14, don't run
 	#check the glibc version with the ldd version since it comes with glibc
 	#see https://www.linuxquestions.org/questions/linux-software-2/how-to-check-glibc-version-263103/
@@ -260,7 +262,7 @@ build_gcc() {
 		if az_module_load $GCC_MODULE
 		then
 			echo "==== Build with GCC compiler ($(gcc --version|head -1)) ===="
-			${WORKSPACE}/contrib/configure-devel --prefix=$ucx_inst
+			${WORKSPACE}/contrib/configure-devel CFLAGS="$cflags" CXXFLAGS="$cflags" --prefix=$ucx_inst
 			$MAKEP
 			$MAKEP install
 			az_module_unload $GCC_MODULE
@@ -268,6 +270,10 @@ build_gcc() {
 	else
 		azure_log_warning "Not building with gcc compiler, glibc version is too old ($ldd_ver)"
 	fi
+}
+
+build_gcc_debug_opt() {
+	build_gcc "-Og"
 }
 
 #
@@ -410,6 +416,7 @@ then
 	do_task 10 build_icc
 	do_task 10 build_pgi
 	do_task 10 build_gcc
+	do_task 10 build_gcc_debug_opt
 	do_task 10 build_clang
 	do_task 10 build_armclang
 fi

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2264,6 +2264,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             continue;
         }
 
+        rsc_index  = config->key.lanes[lane].rsc_index;
         iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
         if (iface_attr->cap.flags & UCT_IFACE_FLAG_AM_ZCOPY) {
             config->am_bw_prereg_md_map |= UCS_BIT(config->md_index[lane]);

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -665,13 +665,12 @@ ucp_mem_advise(ucp_context_h context, ucp_mem_h memh,
 static inline ucs_status_t
 ucp_mpool_malloc(ucp_worker_h worker, ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
 {
+    /* Need to get default flags from ucp_mem_map_params2uct_flags() */
+    ucp_mem_map_params_t mem_params = {};
     ucp_mem_desc_t *chunk_hdr;
     ucp_mem_h memh;
     ucs_status_t status;
-    ucp_mem_map_params_t mem_params;
 
-    /* Need to get default flags from ucp_mem_map_params2uct_flags() */
-    mem_params.field_mask = 0;
     status = ucp_mem_map_common(worker->context, NULL,
                                 *size_p + sizeof(*chunk_hdr), UCS_MEMORY_TYPE_HOST,
                                 ucp_mem_map_params2uct_flags(&mem_params),

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -815,6 +815,7 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
         rdesc = (ucp_recv_desc_t*)ucs_mpool_set_get_inline(&worker->am_mps,
                                                            length);
         if (rdesc == NULL) {
+            *rdesc_p = NULL; /* To suppress compiler warning */
             ucs_error("ucp recv descriptor is not allocated");
             return UCS_ERR_NO_MEMORY;
         }
@@ -1054,6 +1055,7 @@ ucp_send_request_get_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
 
     status = UCS_PTR_MAP_GET(request, &worker->request_map, id, extract, &ptr);
     if (ucs_unlikely((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS))) {
+        *req_p = NULL; /* To suppress compiler warning */
         return status;
     }
 

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -84,6 +84,7 @@ ucp_worker_get_ep_by_id(ucp_worker_h worker, ucs_ptr_map_key_t id,
     ucs_assert(id != UCS_PTR_MAP_KEY_INVALID);
     status = UCS_PTR_MAP_GET(ep, &worker->ep_map, id, 0, &ptr);
     if (ucs_unlikely((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS))) {
+        *ep_p = NULL; /* To supress compiler warning */
         return status;
     }
 

--- a/src/ucs/datastruct/ptr_map.inl
+++ b/src/ucs/datastruct/ptr_map.inl
@@ -65,6 +65,7 @@ ucs_ptr_hash_get(ucs_ptr_hash_t *hash, ucs_ptr_map_key_t key, int extract,
 
     iter = kh_get(ucs_ptr_map_impl, hash, key);
     if (ucs_unlikely(iter == kh_end(hash))) {
+        *ptr_p = NULL; /* To suppress compiler warning */
         return UCS_ERR_NO_ELEM;
     }
 

--- a/src/ucs/type/class.h
+++ b/src/ucs/type/class.h
@@ -154,9 +154,11 @@ struct ucs_class {
                 *(_obj) = (ucs_typeof(*(_obj)))obj; /* Success - assign pointer */ \
             } else { \
                 ucs_class_free(obj); /* Initialization failure */ \
+                *(_obj) = NULL; /* To suppress compiler warning */ \
             } \
         } else { \
             _status = UCS_ERR_NO_MEMORY; /* Allocation failure */ \
+            *(_obj) = NULL; /* To suppress compiler warning */ \
         } \
         \
         (_status); \

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -692,7 +692,7 @@ err_dofork:
     }
 err_free:
     ucs_free(buf);
-
+    *buf_p = NULL; /* To suppress compiler warning */
     return status;
 }
 


### PR DESCRIPTION
## What

Fix compiler warnings with `-Og` option

## Why ?

Fixes #7914

## How ?

1. Set a pointer to pointer to `NULL` in places where it is required to suppress compiler warning.
2. Fix real issue in `ucp_ep_config_init` where `rsc_index` wasn't set to a proper value before calling `ucp_worker_iface_get_attr` for it.
3. Set all fields of `ucp_mem_map_params_t` to `0`, because the compiler thinks that `flags` filed could be used even if `field_mask == 0`.
4. Added compilation with `-Og` to our AZP CI's `builds.sh` script.