### PR TITLE
UCT/IB: Use DC half-handshake with AR, when RDMA_WRITE is not used

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -72,21 +72,21 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      ucs_offsetof(uct_dc_mlx5_iface_config_t, tx_policy),
      UCS_CONFIG_TYPE_ENUM(uct_dc_tx_policy_names)},
 
-    {"DCI_FULL_HANDSHAKE", "off",
+    {"DCI_FULL_HANDSHAKE", "no",
      "Force full-handshake protocol for DC initiator. Enabling this mode\n"
      "increases network latency, but is more resilient to packet drops.\n"
      "Setting it to \"auto\" applies full-handshake on AR SLs.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, dci_full_handshake),
-     UCS_CONFIG_TYPE_ON_OFF_AUTO},
+     UCS_CONFIG_TYPE_TERNARY},
 
-    {"DCI_KA_FULL_HANDSHAKE", "off",
+    {"DCI_KA_FULL_HANDSHAKE", "no",
      "Force full-handshake protocol for DC keepalive initiator.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, dci_ka_full_handshake),
-     UCS_CONFIG_TYPE_ON_OFF_AUTO},
+     UCS_CONFIG_TYPE_TERNARY},
 
-    {"DCT_FULL_HANDSHAKE", "off", "Force full-handshake protocol for DC target.",
+    {"DCT_FULL_HANDSHAKE", "no", "Force full-handshake protocol for DC target.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, dct_full_handshake),
-     UCS_CONFIG_TYPE_ON_OFF_AUTO},
+     UCS_CONFIG_TYPE_TERNARY},
 
     {"RAND_DCI_SEED", "0",
      "Seed for DCI allocation when \"rand\" dci policy is used (0 - use default).",
@@ -198,6 +198,12 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     uct_rc_mlx5_iface_common_query(&iface->super.super.super, iface_attr,
                                    max_am_inline,
                                    UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(UCT_IB_MLX5_AV_FULL_SIZE));
+
+    if (iface->flags & UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT) {
+        iface_attr->cap.flags &= ~(UCT_IFACE_FLAG_PUT_SHORT |
+                                   UCT_IFACE_FLAG_PUT_BCOPY |
+                                   UCT_IFACE_FLAG_PUT_ZCOPY);
+    }
 
     /* Error handling is not supported with random dci policy
      * TODO: Fix */
@@ -315,8 +321,9 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_DCI) {
         attr.super.max_inl_cqe[UCT_IB_DIR_RX] = 0;
-        attr.uidx           = htonl(dci_index) >> UCT_IB_UIDX_SHIFT;
-        attr.full_handshake = full_handshake;
+        attr.uidx             = htonl(dci_index) >> UCT_IB_UIDX_SHIFT;
+        attr.full_handshake   = full_handshake;
+        attr.rdma_wr_disabled = iface->flags & UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT;
         status = uct_ib_mlx5_devx_create_qp(ib_iface, &dci->txwq.super,
                                             &dci->txwq, &attr);
         if (status != UCS_OK) {
@@ -400,16 +407,6 @@ err_qp:
     return status;
 }
 
-static int UCS_F_ALWAYS_INLINE
-uct_dc_mlx5_force_full_handshake(uct_dc_mlx5_iface_t *iface, int full_handshake_config)
-{
-    if (full_handshake_config == UCS_CONFIG_AUTO) {
-        return uct_ib_mlx5_iface_has_ar(&iface->super.super.super);
-    } else {
-        return full_handshake_config == UCS_CONFIG_ON;
-    }
-}
-
 #if HAVE_DC_DV
 ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
                                            uct_dc_dci_t *dci)
@@ -490,10 +487,7 @@ uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface,
     int ret;
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_DCT) {
-        return uct_dc_mlx5_iface_devx_create_dct(
-                iface,
-                uct_dc_mlx5_force_full_handshake(iface,
-                                                 config->dct_full_handshake));
+        return uct_dc_mlx5_iface_devx_create_dct(iface);
     }
 
     init_attr.comp_mask             = IBV_QP_INIT_ATTR_PD;
@@ -843,8 +837,7 @@ uct_dc_mlx5_iface_create_dcis(uct_dc_mlx5_iface_t *iface,
         for (i = 0; i < iface->tx.ndci; ++i) {
             status = uct_dc_mlx5_iface_create_dci(
                     iface, pool_index, dci_index, pool_index % num_paths,
-                    uct_dc_mlx5_force_full_handshake(
-                            iface, config->dci_full_handshake));
+                    iface->flags & UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE);
             if (status != UCS_OK) {
                 goto err;
             }
@@ -1395,9 +1388,17 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         self->flags           |= UCT_DC_MLX5_IFACE_FLAG_UIDX;
         self->tx.num_dci_pools = self->super.super.super.num_paths;
     }
-    if (uct_dc_mlx5_force_full_handshake(self, config->dci_ka_full_handshake)) {
-        self->flags |= UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE_FULL_HANDSHAKE;
+
+    if ((params->field_mask & UCT_IFACE_PARAM_FIELD_FEATURES) &&
+        !(params->features & UCT_IFACE_FEATURE_PUT)) {
+        self->flags |= UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT;
     }
+
+    UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dci, DCI, status, err);
+    UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dci_ka, KEEPALIVE,
+                                           status, err);
+    UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dct, DCT, status, err);
+
     ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
 
     /* allocate dcis arrays and stack */

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -50,6 +50,23 @@ struct ibv_ravh {
         _txwq = &(_iface)->tx.dcis[_dci].txwq; \
     }
 
+/**
+ * Set iface config flag for enabling full handshake on DCI/DCT,
+ * according to user configuration. Fail if the user requests to
+ * force full-handlshake, while the HW does not support it.
+ */
+#define UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(_self, _config, _config_name, \
+                                               _flag_name, _status, _err) \
+    if (!((_self)->version_flag & UCT_IB_DEVICE_FLAG_DC_V2) && \
+        ((_config)->_config_name##_full_handshake == UCS_YES)) { \
+        _status = UCS_ERR_UNSUPPORTED; \
+        goto _err; \
+    } \
+    if ((_config)->_config_name##_full_handshake != UCS_NO) { \
+        (_self)->flags |= UCT_DC_MLX5_IFACE_FLAG_##_flag_name##_FULL_HANDSHAKE; \
+    }
+
+
 typedef struct uct_dc_mlx5_ep     uct_dc_mlx5_ep_t;
 typedef struct uct_dc_mlx5_iface  uct_dc_mlx5_iface_t;
 
@@ -77,7 +94,16 @@ typedef enum {
     UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED             = UCS_BIT(3),
 
     /** Ignore DCI allocation reorder */
-    UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER      = UCS_BIT(4)
+    UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER      = UCS_BIT(4),
+
+    /** Enable full handshake for DCI */
+    UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE       = UCS_BIT(5),
+
+    /** Enable full handshake for DCT */
+    UCT_DC_MLX5_IFACE_FLAG_DCT_FULL_HANDSHAKE       = UCS_BIT(6),
+
+    /** Disable PUT capability (RDMA_WRITE) */
+    UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT              = UCS_BIT(7)
 } uct_dc_mlx5_iface_flags_t;
 
 
@@ -134,9 +160,9 @@ typedef struct uct_dc_mlx5_iface_config {
     uct_ud_iface_common_config_t        ud_common;
     int                                 ndci;
     int                                 tx_policy;
-    ucs_on_off_auto_value_t             dci_full_handshake;
-    ucs_on_off_auto_value_t             dci_ka_full_handshake;
-    ucs_on_off_auto_value_t             dct_full_handshake;
+    ucs_ternary_auto_value_t            dci_full_handshake;
+    ucs_ternary_auto_value_t            dci_ka_full_handshake;
+    ucs_ternary_auto_value_t            dct_full_handshake;
     unsigned                            quota;
     unsigned                            rand_seed;
     ucs_time_t                          fc_hard_req_timeout;
@@ -325,8 +351,7 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index);
 
 #if HAVE_DEVX
 
-ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface,
-                                               int full_handshake);
+ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface);
 
 ucs_status_t uct_dc_mlx5_iface_devx_set_srq_dc_params(uct_dc_mlx5_iface_t *iface);
 
@@ -336,8 +361,8 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
 
 #else
 
-static UCS_F_MAYBE_UNUSED ucs_status_t uct_dc_mlx5_iface_devx_create_dct(
-        uct_dc_mlx5_iface_t *iface, int full_handshake)
+static UCS_F_MAYBE_UNUSED ucs_status_t
+uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
 {
     return UCS_ERR_UNSUPPORTED;
 }

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -15,8 +15,7 @@
 #include <ucs/arch/bitops.h>
 
 
-ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface,
-                                               int full_handshake)
+ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
 {
     uct_ib_device_t *dev  = uct_ib_iface_device(&iface->super.super.super);
     struct mlx5dv_pd dvpd = {};
@@ -48,7 +47,9 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(dctc, dctc, rre, true);
     UCT_IB_MLX5DV_SET(dctc, dctc, rwe, true);
     UCT_IB_MLX5DV_SET(dctc, dctc, rae, true);
-    UCT_IB_MLX5DV_SET(dctc, dctc, force_full_handshake, !!full_handshake);
+    UCT_IB_MLX5DV_SET(dctc, dctc, force_full_handshake,
+                      !!(iface->flags &
+                         UCT_DC_MLX5_IFACE_FLAG_DCT_FULL_HANDSHAKE));
     UCT_IB_MLX5DV_SET(dctc, dctc, cs_res, uct_ib_mlx5_qpc_cs_res(
                       iface->super.super.super.config.max_inl_cqe[UCT_IB_DIR_RX], 1));
     UCT_IB_MLX5DV_SET(dctc, dctc, atomic_mode, UCT_IB_MLX5_ATOMIC_MODE);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -128,6 +128,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
         goto err_free_db;
     }
     UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
+    UCT_IB_MLX5DV_SET(qpc, qpc, rdma_wr_disabled, !!attr->rdma_wr_disabled);
     UCT_IB_MLX5DV_SET(qpc, qpc, pd, dvpd.pdn);
     UCT_IB_MLX5DV_SET(qpc, qpc, uar_page, uar->uar->page_id);
     ucs_assert((attr->super.srq == NULL) || (attr->super.srq_num != 0));

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -1243,7 +1243,7 @@ struct uct_ib_mlx5_qpc_bits {
     uint8_t         st[0x8];
     uint8_t         reserved_at_10[0x3];
     uint8_t         pm_state[0x2];
-    uint8_t         reserved_at_15[0x1];
+    uint8_t         rdma_wr_disabled[0x1];
     uint8_t         req_e2e_credit_mode[0x2];
     uint8_t         offload_type[0x4];
     uint8_t         end_padding_mode[0x2];

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -1108,25 +1108,6 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
                                  &iface->config.sl);
 }
 
-int uct_ib_mlx5_iface_has_ar(uct_ib_iface_t *iface)
-{
-#if HAVE_DEVX
-    uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md, uct_ib_mlx5_md_t);
-    uint16_t ooo_sl_mask = 0;
-    ucs_status_t status;
-
-    status = uct_ib_mlx5_devx_query_ooo_sl_mask(md, iface->config.port_num,
-                                                &ooo_sl_mask);
-    if (status != UCS_OK) {
-        return 0;
-    }
-
-    return (ooo_sl_mask & UCS_BIT(iface->config.sl)) != 0;
-#else
-    return 0;
-#endif
-}
-
 void uct_ib_mlx5_txwq_validate_always(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb,
                                       int hw_ci_updated)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -396,6 +396,7 @@ typedef struct uct_ib_mlx5_qp_attr {
     uct_ib_mlx5_mmio_mode_t     mmio_mode;
     uint32_t                    uidx;
     int                         full_handshake;
+    int                         rdma_wr_disabled;
 } uct_ib_mlx5_qp_attr_t;
 
 
@@ -678,12 +679,6 @@ ucs_status_t uct_ib_mlx5_devx_uar_init(uct_ib_mlx5_devx_uar_t *uar,
                                        uct_ib_mlx5_mmio_mode_t mmio_mode);
 
 void uct_ib_mlx5_devx_uar_cleanup(uct_ib_mlx5_devx_uar_t *uar);
-
-/**
- * Check whether the interface uses AR.
- */
-int uct_ib_mlx5_iface_has_ar(uct_ib_iface_t *iface);
-
 
 void uct_ib_mlx5_txwq_validate_always(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb,
                                       int hw_ci_updated);


### PR DESCRIPTION
## What
Use DC half-handshake with adaptive routing, when RDMA_WRITE is not used (if RNDV is only RDMA_READ, and no GPU memory).

## Why ?
Following https://github.com/openucx/ucx/pull/7511, we want to improve the logic by allowing DC half-handshake even with AR, in case RDMA_WRITE is not needed.

## How ?
Introduce "features" in UCT iface layer, which are filled by the UCP worker according to its features & config, before calling `uct_iface_open`.

Then, supported iface caps are limited according to the requested features. The UCP layer knows in advance, whether RDMA_WRITE will be needed, and is able to pass that information to the UCT layer.