### PR TITLE
UCT/IB/RC: Don't do FC on failed RC EP

### DIFF
--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -359,8 +359,10 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
 
     ucs_assert(iface->config.fc_enabled);
 
-    if ((ep == NULL) || (ep->flags & UCT_RC_EP_FLAG_FLUSH_CANCEL)) {
-        /* We get fc for ep which is being removed or cancelled, so should ignore it */
+    if ((ep == NULL) || (ep->flags & (UCT_RC_EP_FLAG_FLUSH_CANCEL |
+                                      UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED))) {
+        /* We get fc for ep which is being removed/cancelled/failed, so should
+         * ignore it */
         if (fc_hdr == UCT_RC_EP_FC_PURE_GRANT) {
             return UCS_OK;
         }


### PR DESCRIPTION
## What

Don't do FC operations on failed RC EP to not post send WQEs on QPs which are in error state.

## Why ?

Fixes:
```
[swx-ucx04:12780:0:12780]   rc_mlx5.inl:457  Assertion `!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED)' failed

/hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl: [ uct_rc_mlx5_common_post_send() ]
      ...
      454     if (opcode != MLX5_OPCODE_NOP) {
      455         /* If FAILED, allow only NOP sends to be posted (used by endpoint
      456          * flush operations) */
==>   457         ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
      458     }
      459 
      460     ctrl = txwq->curr;

==== backtrace (tid:  12780) ====
 0 0x000000000008e741 uct_rc_mlx5_common_post_send()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl:457
 1 0x000000000008e741 uct_rc_mlx5_txqp_inline_post()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl:617
 2 0x000000000008e741 uct_rc_mlx5_ep_fc_ctrl()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_ep.c:619
 3 0x0000000000038199 uct_rc_fc_ctrl()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_iface.h:454
 4 0x000000000003abf4 uct_rc_iface_fc_handler()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/base/rc_iface.c:413
 5 0x00000000000a57d3 uct_rc_mlx5_iface_common_am_handler()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl:418
 6 0x00000000000a57d3 uct_rc_mlx5_iface_common_poll_rx()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5.inl:1455
 7 0x00000000000a57d3 uct_rc_mlx5_iface_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:169
 8 0x00000000000a57d3 uct_rc_mlx5_iface_progress_cyclic()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/ib/rc/accel/rc_mlx5_iface.c:179
 9 0x00000000000620d0 ucs_callbackq_dispatch()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/ucs/datastruct/callbackq.h:211
10 0x000000000006efee uct_worker_progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/src/uct/api/uct.h:2600
11 0x0000000000404e74 UcxContext::progress_worker_event()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:388
12 0x0000000000404506 UcxContext::progress()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/test/apps/iodemo/ucx_wrapper.cc:225
13 0x000000000041acd5 DemoClient::destroy_servers()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2215
14 0x000000000041b406 DemoClient::run()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2328
15 0x0000000000411f0e do_client()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2930
16 0x0000000000412334 main()  /hpc/mtr_scrap/users/mtt/scratch/ucx_ompi/20220211_064053_52399_1008_swx-ucx02.swx.labs.mlnx/installs/QjC3/tests/io_demo/ucx.git/test/apps/iodemo/io_demo.cc:2973
17 0x00000000000223d5 __libc_start_main()  ???:0
18 0x0000000000403419 _start()  ???:0
=================================
```

## How ?

Stop FC operation handling if either `UCT_RC_EP_FLAG_ERR_HANDLER_INVOKED` or `UCT_RC_EP_FLAG_FLUSH_CANCEL` flag is set on RC EP.