### PR TITLE
UCP/CORE: Make ucp_ep_create_base mutually inverse to ucp_ep_destroy_base

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -673,7 +673,7 @@ ucp_ep_create_to_worker_addr(ucp_worker_h worker,
 
     /* allocate endpoint */
     status = ucp_ep_create_base(worker, ep_init_flags, remote_address->name,
-                                  message, &ep);
+                                message, &ep);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -600,11 +600,11 @@ void ucp_ep_config_lane_info_str(ucp_worker_h worker,
                                  ucp_rsc_index_t aux_rsc_index,
                                  ucs_string_buffer_t *buf);
 
-void ucp_ep_destroy_base(ucp_ep_h ep);
+ucs_status_t ucp_ep_create_base(ucp_worker_h worker, unsigned ep_init_flags,
+                                const char *peer_name, const char *message,
+                                ucp_ep_h *ep_p);
 
-ucs_status_t ucp_worker_create_ep(ucp_worker_h worker, unsigned ep_init_flags,
-                                  const char *peer_name, const char *message,
-                                  ucp_ep_h *ep_p);
+void ucp_ep_destroy_base(ucp_ep_h ep);
 
 void ucp_ep_delete(ucp_ep_h ep);
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -517,9 +517,9 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
                                    UCS_CONN_MATCH_QUEUE_EXP);
         if (ep == NULL) {
             /* Create a new endpoint if does not exist */
-            status = ucp_worker_create_ep(worker, ep_init_flags,
-                                          remote_address->name,
-                                          "remote-request", &ep);
+            status = ucp_ep_create_base(worker, ep_init_flags,
+                                        remote_address->name,
+                                        "remote-request", &ep);
             if (status != UCS_OK) {
                 return;
             }
@@ -723,8 +723,8 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 
     /* If endpoint does not exist - create a temporary endpoint to send a
      * UCP_WIREUP_MSG_EP_REMOVED reply */
-    status = ucp_worker_create_ep(worker, ep_init_flags, remote_address->name,
-                                  "wireup ep_check reply", &reply_ep);
+    status = ucp_ep_create_base(worker, ep_init_flags, remote_address->name,
+                                "wireup ep_check reply", &reply_ep);
     if (status != UCS_OK) {
         ucs_error("failed to create EP: %s", ucs_status_string(status));
         return;


### PR DESCRIPTION
## What

Align `ucp_ep_create_base` with `ucp_ep_destroy_base`.

## Why ?

`ucp_ep_destroy_base` is not align with `ucp_ep_create_base` after merging https://github.com/openucx/ucx/pull/7919.
`ucp_ep_destroy_base` should be called after `ucp_ep_create_base` without any additional actions, i.e. they are mutually inverse.

## How ?

1. Remove `ucp_worker_create_ep` function.
2. Align `ucp_ep_create_base` to make sure that `ucp_ep_destroy_base` is mutually inverse.
3. Add auxiliary functions: `ucp_ep_allocate`/`ucp_ep_deallocate`/`ucp_ep_shall_use_indirect_id` to simplify code and reduce duplications.