### PR TITLE
UCT/IB: Remove obsolete reg_mem_types initialization

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -299,7 +299,6 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
                              UCT_MD_FLAG_NEED_RKEY |
                              UCT_MD_FLAG_ADVISE    |
                              UCT_MD_FLAG_INVALIDATE;
-    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cap.alloc_mem_types  = 0;
     md_attr->cap.access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cap.detect_mem_types = 0;


### PR DESCRIPTION
## What
`reg_mem_types` is initialized by `md->reg_mem_types` below, no need to set it to `HOST` here