### PR TITLE
TOOLS/PERF: Limit warm-up time

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -194,6 +194,7 @@ typedef struct ucx_perf_params {
     size_t                 alignment;       /* Message buffer alignment */
     unsigned               max_outstanding; /* Maximal number of outstanding sends */
     ucx_perf_counter_t     warmup_iter;     /* Number of warm-up iterations */
+    double                 warmup_time;     /* Approximately how long to warm-up */
     ucx_perf_counter_t     max_iter;        /* Iterations limit, 0 - unlimited */
     double                 max_time;        /* Time limit (seconds), 0 - unlimited */
     double                 report_interval; /* Interval at which to call the report callback */

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -162,8 +162,9 @@ ucs_status_t ucx_perf_thread_spawn(ucx_perf_context_t *perf,
                                    ucx_perf_result_t* result);
 void ucx_perf_test_prepare_new_run(ucx_perf_context_t *perf,
                                    const ucx_perf_params_t *params);
-void ucx_perf_set_warmup(ucx_perf_context_t* perf,
-                         const ucx_perf_params_t* params);
+ucs_status_t
+ucx_perf_do_warmup(ucx_perf_context_t *perf, const ucx_perf_params_t *params);
+
 /**
  * Get the total length of the message size given by parameters
  */

--- a/src/tools/perf/lib/libperf_thread.c
+++ b/src/tools/perf/lib/libperf_thread.c
@@ -43,14 +43,9 @@ static ucs_status_t ucx_perf_thread_run_test(void* arg)
         }
     }
 
-    if (params->warmup_iter > 0) {
-        ucx_perf_set_warmup(perf, params);
-        status = ucx_perf_funcs[params->api].run(perf);
-        ucx_perf_funcs[params->api].barrier(perf);
-        if (UCS_OK != status) {
-            goto out;
-        }
-        ucx_perf_test_prepare_new_run(perf, params);
+    status = ucx_perf_do_warmup(perf, params);
+    if (UCS_OK != status) {
+        goto out;
     }
 
     /* Run test */

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -171,6 +171,7 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.wait_mode         = UCX_PERF_WAIT_MODE_LAST;
     params->super.max_outstanding   = 0;
     params->super.warmup_iter       = 10000;
+    params->super.warmup_time       = 100e-3;
     params->super.alignment         = ucs_get_page_size();
     params->super.max_iter          = 1000000l;
     params->super.max_time          = 0.0;

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -219,6 +219,7 @@ void test_perf::test_params_init(const test_spec &test,
                                           ucs::test_time_multiplier());
     }
 
+    params.warmup_time     = 100e-3;
     params.max_time        = 0.0;
     params.report_interval = 1.0;
     params.rte_group       = NULL;


### PR DESCRIPTION
## Why
When running ucx_perftest with a large buffer size, the default value of warmup iterations can be too high, so the test will not report results for a long time and appear "stuck". 

## How
Perform several warmup rounds, each round increasing the number of iterations by 2x, until we reached the time limit.
