### PR TITLE
UCP/PROTO: proto registration without CTOR

### DIFF
--- a/src/ucp/am/eager.c
+++ b/src/ucp/am/eager.c
@@ -103,7 +103,7 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_eager_short_proto = {
+ucp_proto_t ucp_am_eager_short_proto = {
     .name     = "egr/am/short",
     .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = 0,
@@ -112,7 +112,6 @@ static ucp_proto_t ucp_eager_short_proto = {
     .progress = {ucp_eager_short_progress},
     .abort    = ucp_proto_request_bcopy_abort
 };
-UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
 static UCS_F_ALWAYS_INLINE void
 ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
@@ -213,7 +212,7 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_eager_bcopy_single_proto = {
+ucp_proto_t ucp_am_eager_bcopy_single_proto = {
     .name     = "egr/am/single/bcopy",
     .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
@@ -222,7 +221,6 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .progress = {ucp_eager_bcopy_single_progress},
     .abort    = ucp_request_complete_send
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
 static ucs_status_t
 ucp_proto_eager_am_zcopy_single_init(const ucp_proto_init_params_t *init_params)
@@ -353,7 +351,7 @@ ucp_proto_eager_am_zcopy_single_progress(uct_pending_req_t *self)
             ucp_proto_request_eager_am_zcopy_single_init);
 }
 
-static ucp_proto_t ucp_eager_am_zcopy_single_proto = {
+ucp_proto_t ucp_eager_am_zcopy_single_proto = {
     .name     = "egr/am/single/zcopy",
     .flags    = 0,
     .init     = ucp_proto_eager_am_zcopy_single_init,
@@ -361,4 +359,3 @@ static ucp_proto_t ucp_eager_am_zcopy_single_proto = {
     .progress = {ucp_proto_eager_am_zcopy_single_progress},
     .abort    = ucp_proto_request_bcopy_abort
 };
-UCP_PROTO_REGISTER(&ucp_eager_am_zcopy_single_proto);

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1596,9 +1596,9 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
               context->config.ext.bcopy_bw);
 
     if (config->protos.mode == UCS_CONFIG_ALLOW_LIST_ALLOW_ALL) {
-        context->proto_bitmap = UCS_MASK(ucp_protocols_count);
+        context->proto_bitmap = UCS_MASK(ucp_protocols_count());
     } else {
-        for (proto_id = 0; proto_id < ucp_protocols_count; ++proto_id) {
+        for (proto_id = 0; proto_id < ucp_protocols_count(); ++proto_id) {
             match = ucs_config_names_search(&config->protos.array,
                                             ucp_proto_id_field(proto_id, name));
             if (((config->protos.mode == UCS_CONFIG_ALLOW_LIST_ALLOW) &&

--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -12,14 +12,75 @@
 
 #include <ucs/sys/string.h>
 
+#define UCP_PROTO_AMO_FOR_EACH(_macro, _id) \
+    _macro(ucp_amo_proto_##_id##32) \
+    _macro(ucp_amo_proto_##_id##64) \
+    _macro(ucp_amo_proto_##_id##32_mtype) \
+    _macro(ucp_amo_proto_##_id##64_mtype)
 
-const ucp_proto_t *ucp_protocols[UCP_PROTO_MAX_COUNT] = {};
-unsigned ucp_protocols_count                          = 0;
+#define UCP_PROTO_FOR_EACH(_macro) \
+    _macro(ucp_reconfig_proto) \
+    _macro(ucp_get_amo_post_proto) \
+    _macro(ucp_get_amo_fetch_proto) \
+    _macro(ucp_get_am_bcopy_proto) \
+    _macro(ucp_get_offload_bcopy_proto) \
+    _macro(ucp_get_offload_zcopy_proto) \
+    _macro(ucp_put_am_bcopy_proto) \
+    _macro(ucp_put_offload_short_proto) \
+    _macro(ucp_put_offload_bcopy_proto) \
+    _macro(ucp_put_offload_zcopy_proto) \
+    _macro(ucp_eager_bcopy_multi_proto) \
+    _macro(ucp_eager_sync_bcopy_multi_proto) \
+    _macro(ucp_eager_zcopy_multi_proto) \
+    _macro(ucp_eager_short_proto) \
+    _macro(ucp_eager_bcopy_single_proto) \
+    _macro(ucp_eager_am_zcopy_single_proto) \
+    _macro(ucp_eager_zcopy_single_proto) \
+    _macro(ucp_tag_rndv_proto) \
+    _macro(ucp_eager_tag_offload_short_proto) \
+    _macro(ucp_am_eager_bcopy_single_proto) \
+    _macro(ucp_eager_sync_bcopy_single_proto) \
+    _macro(ucp_tag_offload_eager_zcopy_single_proto) \
+    _macro(ucp_eager_sync_zcopy_single_proto) \
+    _macro(ucp_rndv_am_bcopy_proto) \
+    _macro(ucp_rndv_get_zcopy_proto) \
+    _macro(ucp_rndv_get_mtype_proto) \
+    _macro(ucp_rndv_ats_proto) \
+    _macro(ucp_rndv_rtr_proto) \
+    _macro(ucp_rndv_rtr_mtype_proto) \
+    _macro(ucp_rndv_send_ppln_proto) \
+    _macro(ucp_rndv_recv_ppln_proto) \
+    _macro(ucp_rndv_put_zcopy_proto) \
+    _macro(ucp_rndv_put_mtype_proto) \
+    _macro(ucp_rndv_rkey_ptr_proto) \
+    _macro(ucp_am_eager_short_proto) \
+    _macro(ucp_tag_offload_eager_bcopy_single_proto) \
+    UCP_PROTO_AMO_FOR_EACH(_macro, post) \
+    UCP_PROTO_AMO_FOR_EACH(_macro, fetch) \
+    UCP_PROTO_AMO_FOR_EACH(_macro, cswap)
+
+#define UCP_PROTO_DECL(_proto) extern ucp_proto_t _proto;
+
+#define UCP_PROTO_ENTRY(_proto) &_proto,
+
+/* Declare all proto objects */
+UCP_PROTO_FOR_EACH(UCP_PROTO_DECL)
+
+const ucp_proto_t *ucp_protocols[] = {
+    UCP_PROTO_FOR_EACH(UCP_PROTO_ENTRY)
+};
 
 const char *ucp_proto_perf_types[] = {
     [UCP_PROTO_PERF_TYPE_SINGLE] = "single",
     [UCP_PROTO_PERF_TYPE_MULTI]  = "multi"
 };
+
+unsigned ucp_protocols_count(void)
+{
+    UCS_STATIC_ASSERT(ucs_static_array_size(ucp_protocols) <
+                      UCP_PROTO_MAX_COUNT);
+    return ucs_static_array_size(ucp_protocols);
+}
 
 void ucp_proto_default_query(const ucp_proto_query_params_t *params,
                              ucp_proto_query_attr_t *attr)

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -268,16 +268,6 @@ struct ucp_proto {
 
 
 /**
- * Register a protocol definition.
- */
-#define UCP_PROTO_REGISTER(_proto) \
-    UCS_STATIC_INIT { \
-        ucs_assert_always(ucp_protocols_count < UCP_PROTO_MAX_COUNT); \
-        ucp_protocols[ucp_protocols_count++] = (_proto); \
-    }
-
-
-/**
  * Retrieve a protocol field by protocol id.
  */
 #define ucp_proto_id_field(_proto_id, _field) \
@@ -292,13 +282,14 @@ struct ucp_proto {
 
 
 /* Global array of all registered protocols */
-extern const ucp_proto_t *ucp_protocols[UCP_PROTO_MAX_COUNT];
-
-/* Number of globally registered protocols */
-extern unsigned ucp_protocols_count;
+extern const ucp_proto_t *ucp_protocols[];
 
 /* Performance types names */
 extern const char *ucp_proto_perf_types[];
+
+
+/* Get number of globally registered protocols */
+unsigned ucp_protocols_count(void);
 
 
 /* Default protocol query function: set max_msg_length to SIZE_MAX, take

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -88,7 +88,7 @@ ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
     return UCS_OK;
 }
 
-static ucp_proto_t ucp_reconfig_proto = {
+ucp_proto_t ucp_reconfig_proto = {
     .name     = "reconfig",
     .desc     = "stub protocol",
     .flags    = UCP_PROTO_FLAG_INVALID,
@@ -97,4 +97,3 @@ static ucp_proto_t ucp_reconfig_proto = {
     .progress = {ucp_proto_reconfig_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_reconfig_proto);

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -160,6 +160,8 @@ static ucs_status_t ucp_proto_thresholds_select_next(
 
         ucs_assert(max_prio_proto_id != UCP_PROTO_ID_INVALID);
         disabled_proto_mask |= UCS_BIT(proto_id);
+        ucs_assert(proto_id < ucp_protocols_count());
+        /* coverity[overrun-local] */
         ucs_trace("disable %s with priority %u: prefer %s with priority %u",
                   ucp_proto_id_field(proto_id, name),
                   proto_caps[proto_id].cfg_priority,
@@ -253,7 +255,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     proto_init->mask         = 0;
 
     /* Initialize protocols and get their capabilities */
-    proto_init->priv_buf = ucs_malloc(ucp_protocols_count * UCP_PROTO_PRIV_MAX,
+    proto_init->priv_buf = ucs_malloc(ucp_protocols_count() * UCP_PROTO_PRIV_MAX,
                                       "ucp_proto_priv");
     if (proto_init->priv_buf == NULL) {
         status = UCS_ERR_NO_MEMORY;
@@ -262,11 +264,13 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
 
     offset = 0;
     ucs_for_each_bit(proto_id, worker->context->proto_bitmap) {
+        ucs_assert(proto_id < ucp_protocols_count());
         proto_caps             = &proto_init->caps[proto_id];
         init_params.priv       = UCS_PTR_BYTE_OFFSET(proto_init->priv_buf,
                                                      offset);
         init_params.priv_size  = &priv_size;
         init_params.caps       = proto_caps;
+        /* coverity[overrun-local] */
         init_params.proto_name = ucp_proto_id_field(proto_id, name);
 
         ucs_trace("trying %s", ucp_proto_id_field(proto_id, name));

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -197,15 +197,13 @@ ucp_proto_amo_init(const ucp_proto_init_params_t *init_params,
                                   (_memtype_op)); \
     } \
     \
-    static ucp_proto_t ucp_amo_proto_##_id = { \
+    ucp_proto_t ucp_amo_proto_##_id = { \
         .name     = "amo" #_bits "/" #_id "/" #_sub_id, \
         .desc     = #_sub_id, \
         .init     = ucp_amo_init_##_id, \
         .query    = ucp_proto_single_query, \
         .progress = {ucp_amo_progress_##_id} \
-    }; \
-    \
-    UCP_PROTO_REGISTER(&ucp_amo_proto_##_id)
+    };
 
 #define UCP_PROTO_AMO_REGISTER_MTYPE(_id, _op_id, _bits) \
     UCP_PROTO_AMO_REGISTER(_id,         _op_id, _bits, UCT_EP_OP_LAST,      offload) \

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -416,7 +416,7 @@ ucp_proto_amo_sw_init_post(const ucp_proto_init_params_t *init_params)
     return ucp_proto_amo_sw_init(init_params, 0);
 }
 
-static ucp_proto_t ucp_get_amo_post_proto = {
+ucp_proto_t ucp_get_amo_post_proto = {
     .name     = "amo/post/sw",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
@@ -425,7 +425,6 @@ static ucp_proto_t ucp_get_amo_post_proto = {
     .progress = {ucp_proto_amo_sw_progress_post},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_get_amo_post_proto);
 
 static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
 {
@@ -445,7 +444,7 @@ ucp_proto_amo_sw_init_fetch(const ucp_proto_init_params_t *init_params)
                                  UCP_PROTO_COMMON_INIT_FLAG_RESPONSE);
 }
 
-static ucp_proto_t ucp_get_amo_fetch_proto = {
+ucp_proto_t ucp_get_amo_fetch_proto = {
     .name     = "amo/fetch/sw",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
@@ -454,4 +453,3 @@ static ucp_proto_t ucp_get_amo_fetch_proto = {
     .progress = {ucp_proto_amo_sw_progress_fetch},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_get_amo_fetch_proto);

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -99,7 +99,7 @@ ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_get_am_bcopy_proto = {
+ucp_proto_t ucp_get_am_bcopy_proto = {
     .name     = "get/am/bcopy",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
@@ -108,4 +108,3 @@ static ucp_proto_t ucp_get_am_bcopy_proto = {
     .progress = {ucp_proto_get_am_bcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_get_am_bcopy_proto);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -105,7 +105,7 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
-static ucp_proto_t ucp_get_offload_bcopy_proto = {
+ucp_proto_t ucp_get_offload_bcopy_proto = {
     .name     = "get/bcopy",
     .desc     = UCP_PROTO_COPY_OUT_DESC,
     .flags    = 0,
@@ -114,7 +114,6 @@ static ucp_proto_t ucp_get_offload_bcopy_proto = {
     .progress = {ucp_proto_get_offload_bcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_get_offload_bcopy_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
@@ -192,7 +191,7 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
-static ucp_proto_t ucp_get_offload_zcopy_proto = {
+ucp_proto_t ucp_get_offload_zcopy_proto = {
     .name     = "get/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
@@ -201,4 +200,3 @@ static ucp_proto_t ucp_get_offload_zcopy_proto = {
     .progress = {ucp_proto_get_offload_zcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_get_offload_zcopy_proto);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -104,7 +104,7 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
-static ucp_proto_t ucp_put_am_bcopy_proto = {
+ucp_proto_t ucp_put_am_bcopy_proto = {
     .name     = "put/am/bcopy",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
@@ -113,5 +113,4 @@ static ucp_proto_t ucp_put_am_bcopy_proto = {
     .progress = {ucp_proto_put_am_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort
 };
-UCP_PROTO_REGISTER(&ucp_put_am_bcopy_proto);
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -80,7 +80,7 @@ ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_put_offload_short_proto = {
+ucp_proto_t ucp_put_offload_short_proto = {
     .name     = "put/offload/short",
     .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_PUT_SHORT,
@@ -89,7 +89,6 @@ static ucp_proto_t ucp_put_offload_short_proto = {
     .progress = {ucp_proto_put_offload_short_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_put_offload_short_proto);
 
 static size_t ucp_proto_put_offload_bcopy_pack(void *dest, void *arg)
 {
@@ -177,7 +176,7 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
-static ucp_proto_t ucp_put_offload_bcopy_proto = {
+ucp_proto_t ucp_put_offload_bcopy_proto = {
     .name     = "put/offload/bcopy",
     .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
@@ -186,7 +185,6 @@ static ucp_proto_t ucp_put_offload_bcopy_proto = {
     .progress = {ucp_proto_put_offload_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort
 };
-UCP_PROTO_REGISTER(&ucp_put_offload_bcopy_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
@@ -265,7 +263,7 @@ static void ucp_put_offload_zcopy_abort(ucp_request_t *request,
     ucp_invoke_uct_completion(&request->send.state.uct_comp, status);
 }
 
-static ucp_proto_t ucp_put_offload_zcopy_proto = {
+ucp_proto_t ucp_put_offload_zcopy_proto = {
     .name     = "put/offload/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
@@ -274,4 +272,3 @@ static ucp_proto_t ucp_put_offload_zcopy_proto = {
     .progress = {ucp_proto_put_offload_zcopy_progress},
     .abort    = ucp_put_offload_zcopy_abort
 };
-UCP_PROTO_REGISTER(&ucp_put_offload_zcopy_proto);

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -117,7 +117,7 @@ ucp_proto_rdnv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_rdnv_am_init_common(&params);
 }
 
-static ucp_proto_t ucp_rndv_am_bcopy_proto = {
+ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .name     = "rndv/am/bcopy",
     .desc     = "fragmented " UCP_PROTO_COPY_IN_DESC " " UCP_PROTO_COPY_OUT_DESC,
     .flags    = 0,
@@ -126,4 +126,3 @@ static ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .progress = {ucp_proto_rndv_am_bcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_am_bcopy_proto);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -193,7 +193,7 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
     }
 }
 
-static ucp_proto_t ucp_rndv_get_zcopy_proto = {
+ucp_proto_t ucp_rndv_get_zcopy_proto = {
     .name     = "rndv/get/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC " " UCP_PROTO_RNDV_GET_DESC,
     .flags    = 0,
@@ -205,7 +205,6 @@ static ucp_proto_t ucp_rndv_get_zcopy_proto = {
     },
     .abort    = ucp_rndv_get_zcopy_proto_abort
 };
-UCP_PROTO_REGISTER(&ucp_rndv_get_zcopy_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_mtype_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
@@ -305,7 +304,7 @@ ucp_proto_rndv_get_mtype_query(const ucp_proto_query_params_t *params,
     ucp_proto_rndv_mtype_query_desc(params, attr, UCP_PROTO_RNDV_GET_DESC);
 }
 
-static ucp_proto_t ucp_rndv_get_mtype_proto = {
+ucp_proto_t ucp_rndv_get_mtype_proto = {
     .name     = "rndv/get/mtype",
     .desc     = NULL,
     .flags    = 0,
@@ -317,7 +316,6 @@ static ucp_proto_t ucp_rndv_get_mtype_proto = {
     },
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_get_mtype_proto);
 
 
 static ucs_status_t
@@ -362,7 +360,7 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *params)
     return ucp_proto_rndv_ack_init(params, params->priv);
 }
 
-static ucp_proto_t ucp_rndv_ats_proto = {
+ucp_proto_t ucp_rndv_ats_proto = {
     .name     = "rndv/ats",
     .desc     = "no data fetch",
     .flags    = 0,
@@ -371,4 +369,3 @@ static ucp_proto_t ucp_rndv_ats_proto = {
     .progress = {ucp_proto_rndv_ats_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_ats_proto);

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -270,7 +270,7 @@ ucp_proto_rndv_send_ppln_atp_progress(uct_pending_req_t *uct_req)
                                        ucp_proto_request_zcopy_complete_success);
 }
 
-static ucp_proto_t ucp_rndv_send_ppln_proto = {
+ucp_proto_t ucp_rndv_send_ppln_proto = {
     .name     = "rndv/send/ppln",
     .desc     = NULL,
     .flags    = 0,
@@ -282,7 +282,6 @@ static ucp_proto_t ucp_rndv_send_ppln_proto = {
     },
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_send_ppln_proto);
 
 static ucs_status_t
 ucp_proto_rndv_recv_ppln_init(const ucp_proto_init_params_t *init_params)
@@ -306,7 +305,7 @@ ucp_proto_rndv_recv_ppln_ats_progress(uct_pending_req_t *uct_req)
                                        ucp_proto_rndv_recv_complete);
 }
 
-static ucp_proto_t ucp_rndv_recv_ppln_proto = {
+ucp_proto_t ucp_rndv_recv_ppln_proto = {
     .name     = "rndv/recv/ppln",
     .desc     = NULL,
     .flags    = 0,
@@ -318,4 +317,3 @@ static ucp_proto_t ucp_rndv_recv_ppln_proto = {
     },
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_recv_ppln_proto);

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -397,7 +397,7 @@ ucp_proto_rndv_put_zcopy_query(const ucp_proto_query_params_t *params,
                       UCP_PROTO_ZCOPY_DESC, put_desc);
 }
 
-static ucp_proto_t ucp_rndv_put_zcopy_proto = {
+ucp_proto_t ucp_rndv_put_zcopy_proto = {
     .name     = "rndv/put/zcopy",
     .desc     = NULL,
     .flags    = 0,
@@ -411,7 +411,6 @@ static ucp_proto_t ucp_rndv_put_zcopy_proto = {
     },
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_put_zcopy_proto);
 
 
 static void ucp_proto_rndv_put_mtype_pack_completion(uct_completion_t *uct_comp)
@@ -533,7 +532,7 @@ ucp_proto_rndv_put_mtype_query(const ucp_proto_query_params_t *params,
     ucp_proto_rndv_mtype_query_desc(params, attr, put_desc);
 }
 
-static ucp_proto_t ucp_rndv_put_mtype_proto = {
+ucp_proto_t ucp_rndv_put_mtype_proto = {
     .name     = "rndv/put/mtype",
     .desc     = NULL,
     .flags    = 0,
@@ -548,4 +547,3 @@ static ucp_proto_t ucp_rndv_put_mtype_proto = {
     },
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_put_mtype_proto);

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -162,7 +162,7 @@ ucp_proto_rndv_rkey_ptr_fetch_progress(uct_pending_req_t *uct_req)
     return UCS_OK;
 }
 
-static ucp_proto_t ucp_rndv_rkey_ptr_proto = {
+ucp_proto_t ucp_rndv_rkey_ptr_proto = {
     .name     = "rndv/rkey_ptr",
     .desc     = "copy from mapped remote memory",
     .flags    = 0,
@@ -174,5 +174,4 @@ static ucp_proto_t ucp_rndv_rkey_ptr_proto = {
     },
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_rkey_ptr_proto);
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -236,7 +236,7 @@ static void ucp_proto_rndv_rtr_query(const ucp_proto_query_params_t *params,
     attr->is_estimation = 1;
 }
 
-static ucp_proto_t ucp_rndv_rtr_proto = {
+ucp_proto_t ucp_rndv_rtr_proto = {
     .name     = "rndv/rtr",
     .desc     = NULL,
     .flags    = 0,
@@ -245,7 +245,6 @@ static ucp_proto_t ucp_rndv_rtr_proto = {
     .progress = {ucp_proto_rndv_rtr_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_rtr_proto);
 
 
 static size_t ucp_proto_rndv_rtr_mtype_pack(void *dest, void *arg)
@@ -387,7 +386,7 @@ ucp_proto_rndv_rtr_mtype_query(const ucp_proto_query_params_t *params,
     ucs_strncpy_safe(attr->config, remote_attr.config, sizeof(attr->config));
 }
 
-static ucp_proto_t ucp_rndv_rtr_mtype_proto = {
+ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .name     = "rndv/rtr/mtype",
     .desc     = NULL,
     .flags    = 0,
@@ -396,7 +395,6 @@ static ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .progress = {ucp_proto_rndv_rtr_mtype_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_rndv_rtr_mtype_proto);
 
 ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,
                                            unsigned flags)

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -163,7 +163,7 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
             ucp_proto_request_bcopy_complete_success);
 }
 
-static ucp_proto_t ucp_eager_bcopy_multi_proto = {
+ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .name     = "egr/multi/bcopy",
     .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
@@ -172,7 +172,6 @@ static ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .progress = {ucp_proto_eager_bcopy_multi_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_multi_proto);
 
 static ucs_status_t
 ucp_proto_eager_sync_bcopy_multi_init(const ucp_proto_init_params_t *init_params)
@@ -240,7 +239,7 @@ ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
             ucp_proto_eager_sync_bcopy_send_completed);
 }
 
-static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
+ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .name     = "egrsnc/multi/bcopy",
     .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
@@ -249,7 +248,6 @@ static ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .progress = {ucp_proto_eager_sync_bcopy_multi_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_multi_proto);
 
 static ucs_status_t
 ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
@@ -324,7 +322,7 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
             ucp_proto_request_zcopy_completion);
 }
 
-static ucp_proto_t ucp_eager_zcopy_multi_proto = {
+ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .name     = "egr/multi/zcopy",
     .desc     = UCP_PROTO_EAGER_ZCOPY_DESC,
     .flags    = 0,
@@ -333,4 +331,3 @@ static ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .progress = {ucp_proto_eager_zcopy_multi_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_zcopy_multi_proto);

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -76,7 +76,7 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_eager_short_proto = {
+ucp_proto_t ucp_eager_short_proto = {
     .name     = "egr/short",
     .desc     = "eager " UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_AM_SHORT,
@@ -85,7 +85,6 @@ static ucp_proto_t ucp_eager_short_proto = {
     .progress = {ucp_eager_short_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_short_proto);
 
 static size_t ucp_eager_single_pack(void *dest, void *arg)
 {
@@ -145,7 +144,7 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_eager_bcopy_single_proto = {
+ucp_proto_t ucp_eager_bcopy_single_proto = {
     .name     = "egr/single/bcopy",
     .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
@@ -154,7 +153,6 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .progress = {ucp_eager_bcopy_single_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
 static ucs_status_t
 ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
@@ -215,7 +213,7 @@ ucp_proto_eager_zcopy_single_progress(uct_pending_req_t *self)
             ucp_proto_request_zcopy_completion, ucp_proto_request_zcopy_init);
 }
 
-static ucp_proto_t ucp_eager_zcopy_single_proto = {
+ucp_proto_t ucp_eager_zcopy_single_proto = {
     .name     = "egr/single/zcopy",
     .desc     = UCP_PROTO_EAGER_ZCOPY_DESC,
     .flags    = 0,
@@ -224,4 +222,3 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .progress = {ucp_proto_eager_zcopy_single_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -75,7 +75,7 @@ static ucs_status_t ucp_proto_eager_tag_offload_short_init(
     return ucp_proto_single_init(&params);
 }
 
-static ucp_proto_t ucp_eager_tag_offload_short_proto = {
+ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .name     = "egr/offload/short",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_TAG_SHORT,
@@ -84,7 +84,6 @@ static ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .progress = {ucp_proto_eager_tag_offload_short_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_tag_offload_short_proto);
 
 static size_t ucp_eager_tag_offload_pack(void *dest, void *arg)
 {
@@ -168,7 +167,7 @@ static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init(
                                                          UCP_OP_ID_TAG_SEND);
 }
 
-static ucp_proto_t ucp_eager_bcopy_single_proto = {
+ucp_proto_t ucp_tag_offload_eager_bcopy_single_proto = {
     .name     = "egr/offload/bcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
@@ -177,7 +176,6 @@ static ucp_proto_t ucp_eager_bcopy_single_proto = {
     .progress = {ucp_proto_eager_tag_offload_bcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_bcopy_single_proto);
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_eager_sync_tag_offload_bcopy_posted(ucp_request_t *req)
@@ -207,7 +205,7 @@ static ucs_status_t ucp_proto_eager_sync_tag_offload_bcopy_init(
             init_params, UCP_OP_ID_TAG_SEND_SYNC);
 }
 
-static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
+ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .name     = "egrsnc/offload/bcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
@@ -216,7 +214,6 @@ static ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .progress = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_sync_bcopy_single_proto);
 
 static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init_common(
         const ucp_proto_init_params_t *init_params, ucp_proto_id_t op_id)
@@ -284,7 +281,7 @@ ucp_proto_eager_tag_offload_zcopy_progress(uct_pending_req_t *self)
             ucp_proto_request_zcopy_completion, ucp_proto_request_zcopy_init);
 }
 
-static ucp_proto_t ucp_eager_zcopy_single_proto = {
+ucp_proto_t ucp_tag_offload_eager_zcopy_single_proto = {
     .name     = "egr/offload/zcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
@@ -293,7 +290,6 @@ static ucp_proto_t ucp_eager_zcopy_single_proto = {
     .progress = {ucp_proto_eager_tag_offload_zcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_zcopy_single_proto);
 
 static ucs_status_t ucp_proto_eager_sync_tag_offload_zcopy_init(
         const ucp_proto_init_params_t *init_params)
@@ -343,7 +339,7 @@ ucp_proto_eager_sync_tag_offload_zcopy_progress(uct_pending_req_t *self)
             ucp_proto_request_zcopy_init);
 }
 
-static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
+ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .name     = "egrsnc/offload/zcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
@@ -352,4 +348,3 @@ static ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .progress = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
-UCP_PROTO_REGISTER(&ucp_eager_sync_zcopy_single_proto);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -179,7 +179,7 @@ static void ucp_tag_rndv_proto_abort(ucp_request_t *request,
     ucp_request_complete_send(request, status);
 }
 
-static ucp_proto_t ucp_tag_rndv_proto = {
+ucp_proto_t ucp_tag_rndv_proto = {
     .name     = "tag/rndv",
     .desc     = NULL,
     .flags    = 0,
@@ -188,4 +188,3 @@ static ucp_proto_t ucp_tag_rndv_proto = {
     .progress = {ucp_tag_rndv_rts_progress},
     .abort    = ucp_tag_rndv_proto_abort
 };
-UCP_PROTO_REGISTER(&ucp_tag_rndv_proto);


### PR DESCRIPTION
- implemented proto registration without CTOR, using static
  initialization
