### PR TITLE
JUCX: Add request params class with memh hint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ config.log
 config.status
 libtool
 stamp-h1
+native_headers.stamp
 src/uct/api/version.h
 autom4te.cache
 depcomp

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpEndpoint.java
@@ -9,8 +9,6 @@ import org.openucx.jucx.*;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 
-import static org.openucx.jucx.ucs.UcsConstants.MEMORY_TYPE.UCS_MEMORY_TYPE_UNKNOWN;
-
 public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     private String paramsString;
     // Keep a reference to errorHandler to prevent it from GC and have valid ref
@@ -91,14 +89,22 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
                                      long remoteAddress, UcpRemoteKey remoteKey,
                                      UcxCallback callback) {
         return putNonBlocking(localAddress, size, remoteAddress, remoteKey, callback,
-            UCS_MEMORY_TYPE_UNKNOWN);
+            null);
     }
 
     public UcpRequest putNonBlocking(long localAddress, long size,
                                      long remoteAddress, UcpRemoteKey remoteKey,
                                      UcxCallback callback, int memoryType) {
+        return putNonBlocking(localAddress, size, remoteAddress, remoteKey, callback,
+                              new UcpRequestParams().setMemoryType(memoryType));
+    }
+
+    public UcpRequest putNonBlocking(long localAddress, long size,
+                                     long remoteAddress, UcpRemoteKey remoteKey,
+                                     UcxCallback callback, UcpRequestParams params) {
         return putNonBlockingNative(getNativeId(), localAddress,
-            size, remoteAddress, remoteKey.getNativeId(), callback, memoryType);
+                                    size, remoteAddress, remoteKey.getNativeId(),
+                                    callback, params);
     }
 
     /**
@@ -152,15 +158,23 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
                                      long localAddress, long size, UcxCallback callback) {
 
         return getNonBlocking(remoteAddress, remoteKey, localAddress, size, callback,
-            UCS_MEMORY_TYPE_UNKNOWN);
+            null);
     }
 
     public UcpRequest getNonBlocking(long remoteAddress, UcpRemoteKey remoteKey,
                                      long localAddress, long size, UcxCallback callback,
                                      int memoryType) {
 
+        return getNonBlocking(remoteAddress, remoteKey, localAddress, size, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
+    }
+
+    public UcpRequest getNonBlocking(long remoteAddress, UcpRemoteKey remoteKey,
+                                     long localAddress, long size, UcxCallback callback,
+                                     UcpRequestParams params) {
+
         return getNonBlockingNative(getNativeId(), remoteAddress, remoteKey.getNativeId(),
-            localAddress, size, callback, memoryType);
+            localAddress, size, callback, params);
     }
 
     /**
@@ -215,13 +229,20 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
 
     public UcpRequest sendTaggedNonBlocking(long localAddress, long size,
                                             long tag, UcxCallback callback) {
-        return sendTaggedNonBlocking(localAddress, size, tag, callback, UCS_MEMORY_TYPE_UNKNOWN);
+        return sendTaggedNonBlocking(localAddress, size, tag, callback, null);
     }
 
     public UcpRequest sendTaggedNonBlocking(long localAddress, long size,
                                             long tag, UcxCallback callback, int memoryType) {
-        return sendTaggedNonBlockingNative(getNativeId(), localAddress, size, tag, callback,
-            memoryType);
+        return sendTaggedNonBlocking(localAddress, size, tag, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
+    }
+
+    public UcpRequest sendTaggedNonBlocking(long localAddress, long size,
+                                            long tag, UcxCallback callback,
+                                            UcpRequestParams params) {
+        return sendTaggedNonBlockingNative(getNativeId(), localAddress, size, tag,
+            callback, params);
     }
 
     /**
@@ -235,18 +256,28 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     /**
      * Iov version of non blocking send operation
      */
+
+    public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
+                                            long tag, UcxCallback callback,
+                                            UcpRequestParams params) {
+        UcxParams.checkArraySizes(localAddresses, sizes);
+
+        return sendTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes,
+            tag, callback, params);
+    }
+
     public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
                                             long tag, UcxCallback callback, int memoryType) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return sendTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes,
-            tag, callback, memoryType);
+        return sendTaggedNonBlocking(localAddresses, sizes, tag, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest sendTaggedNonBlocking(long[] localAddresses, long[] sizes,
                                             long tag, UcxCallback callback) {
 
-        return sendTaggedNonBlocking(localAddresses, sizes, tag, callback, UCS_MEMORY_TYPE_UNKNOWN);
+        return sendTaggedNonBlocking(localAddresses, sizes, tag, callback, null);
     }
 
     /**
@@ -257,27 +288,41 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * completion of the send operation.
      */
     public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback) {
-        return sendStreamNonBlocking(localAddress, size, callback, UCS_MEMORY_TYPE_UNKNOWN);
+        return sendStreamNonBlocking(localAddress, size, callback, null);
+    }
+
+    public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback,
+                                            UcpRequestParams params) {
+        return sendStreamNonBlockingNative(getNativeId(), localAddress, size, callback, params);
     }
 
     public UcpRequest sendStreamNonBlocking(long localAddress, long size, UcxCallback callback,
                                             int memoryType) {
-        return sendStreamNonBlockingNative(getNativeId(), localAddress, size, callback, memoryType);
+        return sendStreamNonBlocking(localAddress, size, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
                                             UcxCallback callback) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return sendStreamNonBlocking(localAddresses, sizes, callback, UCS_MEMORY_TYPE_UNKNOWN);
+        return sendStreamNonBlocking(localAddresses, sizes, callback, null);
+    }
+
+    public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
+                                            UcxCallback callback, UcpRequestParams params) {
+        UcxParams.checkArraySizes(localAddresses, sizes);
+
+        return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback,
+            params);
     }
 
     public UcpRequest sendStreamNonBlocking(long[] localAddresses, long[] sizes,
                                             UcxCallback callback, int memoryType) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return sendStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, callback,
-            memoryType);
+        return sendStreamNonBlocking(localAddresses, sizes, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest sendStreamNonBlocking(ByteBuffer buffer, UcxCallback callback) {
@@ -293,29 +338,42 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      * and ready for application access.
      */
     public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
-                                            UcxCallback callback, int memoryType) {
+                                            UcxCallback callback, UcpRequestParams params) {
         return recvStreamNonBlockingNative(getNativeId(), localAddress, size, flags, callback,
-            memoryType);
+            params);
+    }
+
+    public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
+                                            UcxCallback callback, int memoryType) {
+        return recvStreamNonBlocking(localAddress, size, flags, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest recvStreamNonBlocking(long localAddress, long size, long flags,
                                             UcxCallback callback) {
-        return recvStreamNonBlocking(localAddress, size, flags, callback, UCS_MEMORY_TYPE_UNKNOWN);
+        return recvStreamNonBlocking(localAddress, size, flags, callback, null);
+    }
+
+    public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
+                                            UcxCallback callback, UcpRequestParams params) {
+        UcxParams.checkArraySizes(localAddresses, sizes);
+
+        return recvStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, flags,
+            callback, params);
     }
 
     public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
                                             UcxCallback callback, int memoryType) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return recvStreamIovNonBlockingNative(getNativeId(), localAddresses, sizes, flags,
-            callback, memoryType);
+        return recvStreamNonBlocking(localAddresses, sizes, flags, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest recvStreamNonBlocking(long[] localAddresses, long[] sizes, long flags,
                                             UcxCallback callback) {
 
-        return recvStreamNonBlocking(localAddresses, sizes, flags, callback,
-            UCS_MEMORY_TYPE_UNKNOWN);
+        return recvStreamNonBlocking(localAddresses, sizes, flags, callback, null);
     }
 
     public UcpRequest recvStreamNonBlocking(ByteBuffer buffer, long flags, UcxCallback callback) {
@@ -337,16 +395,23 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
      */
     public UcpRequest sendAmNonBlocking(int activeMessageId, long headerAddress, long headerLength,
                                         long dataAddress, long dataLength, long flags,
-                                        UcxCallback callback, int memoryType) {
+                                        UcxCallback callback, UcpRequestParams params) {
         return sendAmNonBlockingNative(getNativeId(), activeMessageId,
-            headerAddress, headerLength, dataAddress, dataLength, flags, callback, memoryType);
+            headerAddress, headerLength, dataAddress, dataLength, flags, callback, params);
+    }
+
+    public UcpRequest sendAmNonBlocking(int activeMessageId, long headerAddress, long headerLength,
+                                        long dataAddress, long dataLength, long flags,
+                                        UcxCallback callback, int memoryType) {
+        return sendAmNonBlocking(activeMessageId, headerAddress, headerLength, dataAddress,
+            dataLength, flags, callback, new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest sendAmNonBlocking(int activeMessageId, long headerAddress, long headerLength,
                                         long dataAddress, long dataLength, long flags,
                                         UcxCallback callback) {
         return sendAmNonBlocking(activeMessageId, headerAddress, headerLength,
-            dataAddress, dataLength, flags, callback, UCS_MEMORY_TYPE_UNKNOWN);
+            dataAddress, dataLength, flags, callback, null);
     }
 
     /**
@@ -385,7 +450,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     private static native UcpRequest putNonBlockingNative(long enpointId, long localAddress,
                                                           long size, long remoteAddr,
                                                           long ucpRkeyId, UcxCallback callback,
-                                                          int memoryType);
+                                                          UcpRequestParams params);
 
     private static native void putNonBlockingImplicitNative(long enpointId, long localAddress,
                                                             long size, long remoteAddr,
@@ -394,7 +459,7 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     private static native UcpRequest getNonBlockingNative(long enpointId, long remoteAddress,
                                                           long ucpRkeyId, long localAddress,
                                                           long size, UcxCallback callback,
-                                                          int memoryType);
+                                                          UcpRequestParams params);
 
     private static native void getNonBlockingImplicitNative(long enpointId, long remoteAddress,
                                                             long ucpRkeyId, long localAddress,
@@ -403,40 +468,40 @@ public class UcpEndpoint extends UcxNativeStruct implements Closeable {
     private static native UcpRequest sendTaggedNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long tag,
                                                                  UcxCallback callback,
-                                                                 int memoryType);
+                                                                 UcpRequestParams params);
 
     private static native UcpRequest sendTaggedIovNonBlockingNative(long enpointId,
                                                                     long[] localAddresses,
                                                                     long[] sizes, long tag,
                                                                     UcxCallback callback,
-                                                                    int memoryType);
+                                                                    UcpRequestParams params);
 
     private static native UcpRequest sendStreamNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, UcxCallback callback,
-                                                                 int memoryType);
+                                                                 UcpRequestParams params);
 
     private static native UcpRequest sendStreamIovNonBlockingNative(long enpointId,
                                                                     long[] localAddresses,
                                                                     long[] sizes,
                                                                     UcxCallback callback,
-                                                                    int memoryType);
+                                                                    UcpRequestParams params);
 
     private static native UcpRequest recvStreamNonBlockingNative(long enpointId, long localAddress,
                                                                  long size, long flags,
                                                                  UcxCallback callback,
-                                                                 int memoryType);
+                                                                 UcpRequestParams params);
 
     private static native UcpRequest recvStreamIovNonBlockingNative(long enpointId,
                                                                     long[] localAddresses,
                                                                     long[] sizes, long flags,
                                                                     UcxCallback callback,
-                                                                    int memoryType);
+                                                                    UcpRequestParams params);
 
     private static native UcpRequest sendAmNonBlockingNative(long enpointId, int activeMessageId,
                                                              long headerAddress, long headerLength,
                                                              long dataAddress, long dataLength,
                                                              long flags, UcxCallback callback,
-                                                             int memoryType);
+                                                             UcpRequestParams params);
 
     private static native UcpRequest flushNonBlockingNative(long enpointId, UcxCallback callback);
 

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequestParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpRequestParams.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.openucx.jucx.ucp;
+
+import static org.openucx.jucx.ucs.UcsConstants.MEMORY_TYPE.UCS_MEMORY_TYPE_UNKNOWN;
+
+/**
+ * Additional request parameters
+ */
+public class UcpRequestParams {
+
+    private int  memType;
+    private long memHandle;
+
+
+    public UcpRequestParams() {
+        this.memType = UCS_MEMORY_TYPE_UNKNOWN;
+    }
+
+    /**
+     * Memory type of the buffer.
+     * An optimization hint to avoid memory type detection for request buffer.
+     */
+    public UcpRequestParams setMemoryType(int memType) {
+        this.memType = memType;
+        return this;
+    }
+
+    /**
+     * Memory handle for pre-registered buffer.
+     * If the handle is provided, protocols that require registered memory can
+     * skip the registration step. As a result, the communication request
+     * overhead can be reduced and the request can be completed faster.
+     */
+    public UcpRequestParams setMemoryHandle(UcpMemory memHandle) {
+        this.memHandle = memHandle.getNativeId();
+        return this;
+    }
+
+}

--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpWorker.java
@@ -11,8 +11,6 @@ import java.util.HashMap;
 
 import org.openucx.jucx.*;
 
-import static org.openucx.jucx.ucs.UcsConstants.MEMORY_TYPE.UCS_MEMORY_TYPE_UNKNOWN;
-
 /**
  * UCP worker is an opaque object representing the communication context. The
  * worker represents an instance of a local communication resource and the
@@ -121,9 +119,15 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
      * The receive operation is considered completed when the message is delivered to the buffer.
      */
     public UcpRequest recvAmDataNonBlocking(long dataDesc, long address, long size,
-                                            UcxCallback callback, int memoryType) {
+                                            UcxCallback callback, UcpRequestParams params) {
         return recvAmDataNonBlockingNative(getNativeId(), dataDesc, address, size, callback,
-            memoryType);
+            params);
+    }
+
+    public UcpRequest recvAmDataNonBlocking(long dataDesc, long address, long size,
+                                            UcxCallback callback, int memoryType) {
+        return recvAmDataNonBlocking(dataDesc, address, size, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
 
@@ -206,14 +210,19 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
 
     public UcpRequest recvTaggedNonBlocking(long localAddress, long size, long tag, long tagMask,
                                             UcxCallback callback) {
-        return recvTaggedNonBlocking(localAddress, size, tag, tagMask, callback,
-            UCS_MEMORY_TYPE_UNKNOWN);
+        return recvTaggedNonBlocking(localAddress, size, tag, tagMask, callback, null);
     }
 
     public UcpRequest recvTaggedNonBlocking(long localAddress, long size, long tag, long tagMask,
                                             UcxCallback callback, int memoryType) {
+        return recvTaggedNonBlocking(localAddress, size, tag, tagMask, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
+    }
+
+    public UcpRequest recvTaggedNonBlocking(long localAddress, long size, long tag, long tagMask,
+                                            UcxCallback callback, UcpRequestParams params) {
         return recvTaggedNonBlockingNative(getNativeId(), localAddress, size,
-            tag, tagMask, callback, memoryType);
+            tag, tagMask, callback, params);
     }
 
     /**
@@ -230,7 +239,16 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
                                             UcxCallback callback) {
 
         return recvTaggedNonBlocking(localAddresses, sizes, tag, tagMask, callback,
-            UCS_MEMORY_TYPE_UNKNOWN);
+            null);
+    }
+
+    public UcpRequest recvTaggedNonBlocking(long[] localAddresses, long[] sizes,
+                                            long tag, long tagMask,
+                                            UcxCallback callback, UcpRequestParams params) {
+        UcxParams.checkArraySizes(localAddresses, sizes);
+
+        return recvTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes, tag,
+            tagMask, callback, params);
     }
 
     public UcpRequest recvTaggedNonBlocking(long[] localAddresses, long[] sizes,
@@ -238,8 +256,8 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
                                             UcxCallback callback, int memoryType) {
         UcxParams.checkArraySizes(localAddresses, sizes);
 
-        return recvTaggedIovNonBlockingNative(getNativeId(), localAddresses, sizes, tag,
-            tagMask, callback, memoryType);
+        return recvTaggedNonBlocking(localAddresses, sizes, tag, tagMask, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     /**
@@ -287,15 +305,20 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
      * If the receive operation cannot be stated the routine returns an error.
      */
     public UcpRequest recvTaggedMessageNonBlocking(long address, long size, UcpTagMessage message,
-                                                   UcxCallback callback, int memoryType) {
+                                                   UcxCallback callback, UcpRequestParams params) {
         return recvTaggedMessageNonBlockingNative(getNativeId(), address, size,
-            message.getNativeId(), callback, memoryType);
+            message.getNativeId(), callback, params);
+    }
+
+    public UcpRequest recvTaggedMessageNonBlocking(long address, long size, UcpTagMessage message,
+                                                   UcxCallback callback, int memoryType) {
+        return recvTaggedMessageNonBlocking(address, size, message, callback,
+            new UcpRequestParams().setMemoryType(memoryType));
     }
 
     public UcpRequest recvTaggedMessageNonBlocking(long address, long size, UcpTagMessage message,
                                                    UcxCallback callback) {
-        return recvTaggedMessageNonBlocking(address, size, message, callback,
-            UCS_MEMORY_TYPE_UNKNOWN);
+        return recvTaggedMessageNonBlocking(address, size, message, callback, null);
     }
 
     public UcpRequest recvTaggedMessageNonBlocking(ByteBuffer buffer, UcpTagMessage message,
@@ -362,21 +385,21 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     private static native UcpRequest recvAmDataNonBlockingNative(long workerId, long dataDesc,
                                                                  long address, long size,
                                                                  UcxCallback callback,
-                                                                 int memoryType);
+                                                                 UcpRequestParams params);
 
     private static native void amDataReleaseNative(long workerId, long dataAddress);
 
     private static native UcpRequest recvTaggedNonBlockingNative(long workerId, long localAddress,
                                                                  long size, long tag, long tagMask,
                                                                  UcxCallback callback,
-                                                                 int memoryType);
+                                                                 UcpRequestParams params);
 
     private static native UcpRequest recvTaggedIovNonBlockingNative(long workerId,
                                                                     long[] localAddresses,
                                                                     long[] sizes,
                                                                     long tag, long tagMask,
                                                                     UcxCallback callback,
-                                                                    int memoryType);
+                                                                    UcpRequestParams params);
 
     private static native UcpTagMessage tagProbeNonBlockingNative(long workerId, long tag,
                                                                   long tagMask, boolean remove);
@@ -384,7 +407,7 @@ public class UcpWorker extends UcxNativeStruct implements Closeable {
     private static native UcpRequest recvTaggedMessageNonBlockingNative(long workerId, long address,
                                                                         long size, long tagMsgId,
                                                                         UcxCallback callback,
-                                                                        int memoryType);
+                                                                        UcpRequestParams params);
 
     private static native void cancelRequestNative(long workerId, long requestId);
 }

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -122,7 +122,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_closeNonBlockingNative(JNIEnv *env, jclass
 {
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, NULL, &param, UCS_MEMORY_TYPE_UNKNOWN);
+    jobject jucx_request = jucx_request_allocate(env, NULL, &param, NULL);
 
     param.op_attr_mask |= UCP_OP_ATTR_FIELD_FLAGS;
     param.flags         = mode;
@@ -158,10 +158,10 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_putNonBlockingNative(JNIEnv *env, jclass c
                                                            jlong ep_ptr, jlong laddr,
                                                            jlong size, jlong raddr,
                                                            jlong rkey_ptr, jobject callback,
-                                                           jint memory_type)
+                                                           jobject request_params)
 {
     ucp_request_param_t param = {0};
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.cb.send         = jucx_request_callback;
 
@@ -194,11 +194,11 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass c
                                                            jlong ep_ptr, jlong raddr,
                                                            jlong rkey_ptr, jlong laddr,
                                                            jlong size, jobject callback,
-                                                           jint memory_type)
+                                                           jobject request_params)
 {
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.cb.send       = jucx_request_callback;
 
@@ -229,11 +229,12 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedNonBlockingNative(JNIEnv *env, jclass cls,
                                                                   jlong ep_ptr, jlong addr,
                                                                   jlong size, jlong tag,
-                                                                  jobject callback, jint memory_type)
+                                                                  jobject callback,
+                                                                  jobject request_params)
 {
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.cb.send = jucx_request_callback;
 
@@ -248,12 +249,13 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedIovNonBlockingNative(JNIEnv *env, jclass cls,
                                                                     jlong ep_ptr, jlongArray addresses,
                                                                     jlongArray sizes, jlong tag,
-                                                                    jobject callback, jint memory_type)
+                                                                    jobject callback,
+                                                                    jobject request_params)
 {
     int iovcnt;
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
     if (iovec == NULL) {
         return NULL;
@@ -277,11 +279,11 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, jclass cls,
                                                                   jlong ep_ptr, jlong addr,
                                                                   jlong size, jobject callback,
-                                                                  jint memory_type)
+                                                                  jobject request_params)
 {
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.cb.send        = jucx_request_callback;
 
@@ -296,12 +298,12 @@ JNIEXPORT jobject JNICALL
 Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamIovNonBlockingNative(JNIEnv *env, jclass cls,
                                                                      jlong ep_ptr, jlongArray addresses,
                                                                      jlongArray sizes, jobject callback,
-                                                                     jint memory_type)
+                                                                     jobject request_params)
 {
     int iovcnt;
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
     if (iovec == NULL) {
         return NULL;
@@ -325,11 +327,11 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamNonBlockingNative(JNIEnv *env, j
                                                                   jlong ep_ptr, jlong addr,
                                                                   jlong size, jlong flags,
                                                                   jobject callback,
-                                                                  jint memory_type)
+                                                                  jobject request_params)
 {
     size_t rlength;
     ucp_request_param_t param = {0};
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.op_attr_mask   |= UCP_OP_ATTR_FIELD_FLAGS;
     param.cb.recv_stream  = stream_recv_callback;
@@ -353,13 +355,13 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamIovNonBlockingNative(JNIEnv *env
                                                                      jlong ep_ptr,
                                                                      jlongArray addresses, jlongArray sizes,
                                                                      jlong flags, jobject callback,
-                                                                     jint memory_type)
+                                                                     jobject request_params)
 {
     size_t rlength;
     int iovcnt;
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
     if (iovec == NULL) {
         return NULL;
@@ -392,7 +394,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_flushNonBlockingNative(JNIEnv *env, jclass
 {
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, UCS_MEMORY_TYPE_UNKNOWN);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, NULL);
 
     param.cb.send = jucx_request_callback;
 
@@ -410,11 +412,11 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendAmNonBlockingNative(JNIEnv *env, jclas
                                                               jlong header_addr, jlong header_length,
                                                               jlong data_address, jlong data_length,
                                                               jlong flags, jobject callback,
-                                                              jint memory_type)
+                                                              jobject request_params)
 {
     ucp_request_param_t param = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.op_attr_mask |= UCP_OP_ATTR_FIELD_FLAGS;
     param.cb.send       = jucx_request_callback;

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -94,7 +94,7 @@ ucs_status_t am_recv_callback(void *arg, const void *header, size_t header_lengt
  * @brief Utility to allocate jucx request and set appropriate java callback in it.
  */
 jobject jucx_request_allocate(JNIEnv *env, jobject callback, ucp_request_param_t *param,
-                              jint memory_type);
+                              jobject request_params);
 
 /**
  * @ingroup JUCX_REQ

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -134,7 +134,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_flushNonBlockingNative(JNIEnv *env, jclass c
 {
     ucp_request_param_t param;
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, UCS_MEMORY_TYPE_UNKNOWN);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, NULL);
 
     param.cb.send = jucx_request_callback;
 
@@ -171,12 +171,13 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jcl
                                                                 jlong ucp_worker_ptr,
                                                                 jlong laddr, jlong size,
                                                                 jlong tag, jlong tag_mask,
-                                                                jobject callback, jint memory_type)
+                                                                jobject callback,
+                                                                jobject request_params)
 {
     ucp_request_param_t param = {0};
     ucp_tag_recv_info_t recv_info = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.op_attr_mask       |= UCP_OP_ATTR_FIELD_RECV_INFO;
     param.cb.recv             = recv_callback;
@@ -202,13 +203,13 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedIovNonBlockingNative(JNIEnv *env, 
                                                                    jlongArray addresses,
                                                                    jlongArray sizes, jlong tag,
                                                                    jlong tag_mask, jobject callback,
-                                                                   jint memory_type)
+                                                                   jobject request_params)
 {
     int iovcnt;
     ucp_request_param_t param = {0};
     ucp_tag_recv_info_t recv_info = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
     ucp_dt_iov_t* iovec = get_ucp_iov(env, addresses, sizes, iovcnt);
     if (iovec == NULL) {
         return NULL;
@@ -259,12 +260,12 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedMessageNonBlockingNative(JNIEnv *e
                                                                        jlong laddr, jlong size,
                                                                        jlong msg_ptr,
                                                                        jobject callback,
-                                                                       jint memory_type)
+                                                                       jobject request_params)
 {
     ucp_request_param_t param = {0};
     ucp_tag_recv_info_t recv_info = {0};
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.op_attr_mask       |= UCP_OP_ATTR_FIELD_RECV_INFO;
     param.cb.recv             = recv_callback;
@@ -327,13 +328,14 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvAmDataNonBlockingNative(JNIEnv *env, jcl
                                                                 jlong ucp_worker_ptr,
                                                                 jlong data_descr_ptr,
                                                                 jlong address, jlong length,
-                                                                jobject callback, jint memory_type)
+                                                                jobject callback,
+                                                                jobject request_params)
 {
     ucp_request_param_t param = {0};
     size_t recv_length;
 
 
-    jobject jucx_request = jucx_request_allocate(env, callback, &param, memory_type);
+    jobject jucx_request = jucx_request_allocate(env, callback, &param, request_params);
 
     param.op_attr_mask     |= UCP_OP_ATTR_FIELD_RECV_INFO;
     param.cb.recv_am        = stream_recv_callback;

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -98,9 +98,11 @@ public class UcpEndpointTest extends UcxTest {
 
         // Submit 2 get requests
         UcpRequest request1 = endpoint.getNonBlocking(memory1.getAddress(), rkey1,
-            dst1.getMemory().getAddress(), dst1.getMemory().getLength(), callback);
+            dst1.getMemory().getAddress(), dst1.getMemory().getLength(), callback,
+            new UcpRequestParams().setMemoryHandle(memory1).setMemoryType(memType));
         UcpRequest request2 = endpoint.getNonBlocking(memory2.getAddress(), rkey2,
-            dst2.getMemory().getAddress(), dst2.getMemory().getLength(), callback);
+            dst2.getMemory().getAddress(), dst2.getMemory().getLength(), callback,
+            new UcpRequestParams().setMemoryHandle(memory2).setMemoryType(memType));
 
         // Wait for 2 get operations to complete
         while (numCompletedRequests.get() != 2) {
@@ -175,7 +177,7 @@ public class UcpEndpointTest extends UcxTest {
                 public void onSuccess(UcpRequest request) {
                     receivedMessages.incrementAndGet();
                 }
-            });
+            }, new UcpRequestParams().setMemoryType(memType).setMemoryHandle(dst1.getMemory()));
 
         worker2.recvTaggedNonBlocking(dst2.getMemory().getAddress(), UcpMemoryTest.MEM_SIZE,
             1, tagSender, new UcxCallback() {
@@ -183,13 +185,15 @@ public class UcpEndpointTest extends UcxTest {
                 public void onSuccess(UcpRequest request) {
                     receivedMessages.incrementAndGet();
                 }
-            });
+            }, new UcpRequestParams().setMemoryType(memType).setMemoryHandle(dst2.getMemory()));
 
         UcpEndpoint ep = worker1.newEndpoint(new UcpEndpointParams().setName("testSendRecv")
             .setUcpAddress(worker2.getAddress()));
 
-        ep.sendTaggedNonBlocking(src1.getMemory().getAddress(), UcpMemoryTest.MEM_SIZE, 0, null);
-        ep.sendTaggedNonBlocking(src2.getMemory().getAddress(), UcpMemoryTest.MEM_SIZE, 1, null);
+        ep.sendTaggedNonBlocking(src1.getMemory().getAddress(), UcpMemoryTest.MEM_SIZE, 0, null,
+            new UcpRequestParams().setMemoryType(memType).setMemoryHandle(src1.getMemory()));
+        ep.sendTaggedNonBlocking(src2.getMemory().getAddress(), UcpMemoryTest.MEM_SIZE, 1, null,
+            new UcpRequestParams().setMemoryType(memType).setMemoryHandle(src2.getMemory()));
 
         while (receivedMessages.get() != 2) {
             worker1.progress();
@@ -712,16 +716,20 @@ public class UcpEndpointTest extends UcxTest {
                 public void onSuccess(UcpRequest request) {
                     assertTrue(request.isCompleted());
                 }
-            });
+            }, new UcpRequestParams().setMemoryType(memType)
+                .setMemoryHandle(sendData.getMemory()));
 
         requests[1] = worker2.recvTaggedNonBlocking(recvHeader, null);
         requests[4] = ep.sendAmNonBlocking(1, 0L, 0L,
             sendData.getMemory().getAddress(), dataSize,
-            UcpConstants.UCP_AM_SEND_FLAG_REPLY | UcpConstants.UCP_AM_SEND_FLAG_EAGER, null);
+            UcpConstants.UCP_AM_SEND_FLAG_REPLY | UcpConstants.UCP_AM_SEND_FLAG_EAGER, null,
+            new UcpRequestParams().setMemoryType(memType)
+                .setMemoryHandle(sendData.getMemory()));
 
         // Persistence data flow
         requests[5] = ep.sendAmNonBlocking(2, 0L, 0L,
-            sendData.getMemory().getAddress(), 2L, UcpConstants.UCP_AM_FLAG_PERSISTENT_DATA, null);
+            sendData.getMemory().getAddress(), 2L, UcpConstants.UCP_AM_FLAG_PERSISTENT_DATA, null,
+            new UcpRequestParams().setMemoryType(memType).setMemoryHandle(sendData.getMemory()));
 
         while (!Arrays.stream(requests).allMatch(r -> (r != null) && r.isCompleted())) {
             worker1.progress();


### PR DESCRIPTION
## What
Adding new class `UcpRequestParms` that contains additional request parameters (currently memory type and memory handle) 
and not breaking existing API.
TODO: next step would be to support external requests and move callback to request params.

## Why ?
To avoid memh detection from registration cache.
