### PR TITLE
UCT/BUILD: fixed config.h include

### DIFF
--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -5,11 +5,11 @@
  * See file LICENSE for terms.
  */
 
-#include "tcp.h"
-
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif
+
+#include "tcp.h"
 
 #include <ucs/sys/string.h>
 #include <linux/sockios.h>


### PR DESCRIPTION
- fixed missing and incorrect include config.h
