### PR TITLE
UCP/CORE: Fix not selecting AM short_iov protocol for UCP AM send

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -854,15 +854,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
     size_t zcopy_thresh;
     ucs_status_t status;
 
-    if (ucs_unlikely((count != 0) && (user_header_length != 0))) {
-        /*
-         * TODO: Remove when/if am_short with iovs defined in UCT
-         */
-        max_short = -1;
-    } else {
-        max_short = ucp_am_get_short_max(req, max_short);
-    }
-
+    max_short   = ucp_am_get_short_max(req, max_short);
     rndv_thresh = ucp_am_rndv_thresh(req, param, ep_config, flags, &max_short);
 
     if ((msg_config->max_iov == 1) ||


### PR DESCRIPTION
## What

 Fix not selecting AM short_iov protocol for UCP AM send.

## Why ?

AM short_iov should be selected if memtype is HOST and datatype is CONTIG.
Currently, AM short_iov is selected only if no `DATATYPE` and no `NO_IMM_CMPL` are set and only HOST memory type is supported. If at least one is true, it won't be selected.

## How ?

Update `ucp_am_send_req` function as follows:
1. Remove check for `(count != 0) && (user_header_length != 0)` and `TODO` comment.
2. Always set `max_short` from `ucp_am_get_short_max(req, max_short)`.