### PR TITLE
UCM/BISTRO: added static build mode support

### DIFF
--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -58,6 +58,13 @@
     ((UCM_MMAP_MAX_EVENT_NAME_LEN + 2) * \
     ucs_static_array_size(ucm_mmap_event_name))
 
+#define UCM_MMAP_RELOC_ENTRY(_name) \
+    { \
+        .symbol     = #_name, \
+        .value      = ucm_override_##_name, \
+        .prev_value = _name \
+    }
+
 
 typedef struct ucm_mmap_func {
     ucm_reloc_patch_t    patch;
@@ -72,17 +79,17 @@ typedef struct ucm_mmap_test_events_data {
 } ucm_mmap_test_events_data_t;
 
 static ucm_mmap_func_t ucm_mmap_funcs[] = {
-    { {"mmap",    ucm_override_mmap},    UCM_EVENT_MMAP,    UCM_EVENT_NONE},
-    { {"munmap",  ucm_override_munmap},  UCM_EVENT_MUNMAP,  UCM_EVENT_NONE},
+    { UCM_MMAP_RELOC_ENTRY(mmap),    UCM_EVENT_MMAP,    UCM_EVENT_NONE},
+    { UCM_MMAP_RELOC_ENTRY(munmap),  UCM_EVENT_MUNMAP,  UCM_EVENT_NONE},
 #if HAVE_MREMAP
-    { {"mremap",  ucm_override_mremap},  UCM_EVENT_MREMAP,  UCM_EVENT_NONE},
+    { UCM_MMAP_RELOC_ENTRY(mremap),  UCM_EVENT_MREMAP,  UCM_EVENT_NONE},
 #endif
-    { {"shmat",   ucm_override_shmat},   UCM_EVENT_SHMAT,   UCM_EVENT_NONE},
-    { {"shmdt",   ucm_override_shmdt},   UCM_EVENT_SHMDT,   UCM_EVENT_SHMAT},
-    { {"sbrk",    ucm_override_sbrk},    UCM_EVENT_SBRK,    UCM_EVENT_NONE},
-    { {"brk",     ucm_override_brk},     UCM_EVENT_BRK,     UCM_EVENT_NONE},
-    { {"madvise", ucm_override_madvise}, UCM_EVENT_MADVISE, UCM_EVENT_NONE},
-    { {NULL, NULL}, UCM_EVENT_NONE}
+    { UCM_MMAP_RELOC_ENTRY(shmat),   UCM_EVENT_SHMAT,   UCM_EVENT_NONE},
+    { UCM_MMAP_RELOC_ENTRY(shmdt),   UCM_EVENT_SHMDT,   UCM_EVENT_SHMAT},
+    { UCM_MMAP_RELOC_ENTRY(sbrk),    UCM_EVENT_SBRK,    UCM_EVENT_NONE},
+    { UCM_MMAP_RELOC_ENTRY(brk),     UCM_EVENT_BRK,     UCM_EVENT_NONE},
+    { UCM_MMAP_RELOC_ENTRY(madvise), UCM_EVENT_MADVISE, UCM_EVENT_NONE},
+    { {NULL, NULL, NULL}, UCM_EVENT_NONE}
 };
 
 static pthread_mutex_t ucm_mmap_install_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -377,6 +384,13 @@ static ucs_status_t ucs_mmap_install_reloc(int events)
             ucm_assert(ucm_mmap_hook_mode() == UCM_MMAP_HOOK_BISTRO);
             func_ptr = ucm_reloc_get_orig(entry->patch.symbol,
                                           entry->patch.value);
+            if ((func_ptr == NULL) && !ucs_sys_is_dynamic_lib()) {
+                /* prev_value is used to store pointer to libc function,
+                 * used in library static build when other ways to
+                 * find symbol were not successful */
+                func_ptr = entry->patch.prev_value;
+            }
+
             if (func_ptr == NULL) {
                 status = UCS_ERR_NO_ELEM;
             } else {


### PR DESCRIPTION
- added static build mode support: in case if library is built statically
  and symbol to patch could not be found then patch statically linked
  function
