### PR TITLE
STATIC/BUILD: suppress dlopen warning

### DIFF
--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -291,6 +291,7 @@ void ucm_strerror(int eno, char *buf, size_t max)
 
 void ucm_prevent_dl_unload()
 {
+#ifdef UCX_SHARED_LIB
     static ucs_init_once_t init_once = UCS_INIT_ONCE_INITIALIZER;
     int flags                        = RTLD_LOCAL | RTLD_NODELETE;
     Dl_info info;
@@ -330,6 +331,7 @@ void ucm_prevent_dl_unload()
         /* coverity[overwrite_var] */
         dl = NULL;
     }
+#endif /* UCX_SHARED_LIB */
 }
 
 char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *file)

--- a/src/ucs/sys/module.c
+++ b/src/ucs/sys/module.c
@@ -28,6 +28,8 @@
 #include <libgen.h>
 
 
+#ifdef UCX_SHARED_LIB
+
 #define UCS_MODULE_PATH_MEMTRACK_NAME   "module_path"
 #define UCS_MODULE_SRCH_PATH_MAX        2
 
@@ -260,10 +262,12 @@ static void ucs_module_load_one(const char *framework, const char *module_name,
 
     /* coverity[leaked_storage] : a loaded module is never unloaded */
 }
+#endif /* UCX_SHARED_LIB */
 
 void ucs_load_modules(const char *framework, const char *modules,
                       ucs_init_once_t *init_once, unsigned flags)
 {
+#ifdef UCX_SHARED_LIB
     char *modules_str;
     char *saveptr;
     char *module_name;
@@ -271,9 +275,7 @@ void ucs_load_modules(const char *framework, const char *modules,
     ucs_module_loader_init_paths();
 
     UCS_INIT_ONCE(init_once) {
-        if (!ucs_sys_is_dynamic_lib()) {
-            continue; /* do NOT break or return here */
-        }
+        ucs_assert(ucs_sys_is_dynamic_lib());
 
         ucs_module_debug("loading modules for %s", framework);
         modules_str = ucs_strdup(modules, "modules_list");
@@ -289,4 +291,5 @@ void ucs_load_modules(const char *framework, const char *modules,
             ucs_error("failed to allocate module names list");
         }
     }
+#endif /* UCX_SHARED_LIB */
 }


### PR DESCRIPTION
- suppress linker warning when building static application:
      warning: Using 'dlopen' in statically linked applications requires at
      runtime the shared libraries from the glibc version used for linking
- in static build mode exclude dlopen stuff by compiler preprocessor
