### PR TITLE
UCT/API/MM/UCP: Introduce PEER_CHECK AM Bcopy flag, resolve remote ID for UCP EP if PEER_FAILURE requested

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1004,6 +1004,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
         goto out;
     }
 
+    /* TODO: move from common code to specific protocols (REPLY_EP, multi-Eager
+     * Bcopy/Zcopy,RNDV) which use remote ID */
     status = ucp_ep_resolve_remote_id(ep, ep->am_lane);
     if (ucs_unlikely(status != UCS_OK)) {
         ret = UCS_STATUS_PTR(status);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -880,6 +880,7 @@ static ucs_status_t
 ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
                                  const ucp_ep_params_t *params, ucp_ep_h *ep_p)
 {
+    unsigned ep_init_flags = ucp_ep_init_flags(worker, params);
     ucp_unpacked_address_t remote_address;
     ucp_ep_match_conn_sn_t conn_sn;
     ucs_status_t status;
@@ -924,12 +925,11 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
         }
 
         ucp_stream_ep_activate(ep);
-        goto out_free_address;
+        goto out_resolve_remote_id;
     }
 
     status = ucp_ep_create_to_worker_addr(worker, &ucp_tl_bitmap_max,
-                                          &remote_address,
-                                          ucp_ep_init_flags(worker, params),
+                                          &remote_address, ep_init_flags,
                                           "from api call", &ep);
     if (status != UCS_OK) {
         goto out_free_address;
@@ -973,6 +973,16 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
 
     status = UCS_OK;
 
+out_resolve_remote_id:
+    if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
+        /* If PEER_FAILURE was requested, resolve remote endpoint ID prior to
+         * communicating with a peer to make sure that remote peer's endpoint
+         * won't be changed during runtime */
+        status = ucp_ep_resolve_remote_id(ep, ep->am_lane);
+        if (ucs_unlikely(status != UCS_OK)) {
+            goto out_free_address;
+        }
+    }
 out_free_address:
     ucs_free(remote_address.address_list);
 out:
@@ -3117,7 +3127,8 @@ ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     wireup_msg_iov[0].iov_len  = sizeof(wireup_msg);
 
     packed_len = uct_ep_am_bcopy(uct_ep, UCP_AM_ID_WIREUP,
-                                 ucp_wireup_msg_pack, wireup_msg_iov, 0);
+                                 ucp_wireup_msg_pack, wireup_msg_iov,
+                                 UCT_SEND_FLAG_PEER_CHECK);
     ucs_free(wireup_msg_iov[1].iov_base);
     return (packed_len > 0) ? UCS_OK : (ucs_status_t)packed_len;
 }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -540,11 +540,19 @@ enum uct_progress_types {
  * @brief Flags for active message send operation.
  */
 enum uct_msg_flags {
-    UCT_SEND_FLAG_SIGNALED = UCS_BIT(0) /**< Trigger @ref UCT_EVENT_RECV_SIG
-                                             event on remote side. Make best
-                                             effort attempt to avoid triggering
-                                             @ref UCT_EVENT_RECV event.
-                                             Ignored if not supported by interface. */
+    UCT_SEND_FLAG_SIGNALED   = UCS_BIT(0), /**< Trigger @ref UCT_EVENT_RECV_SIG
+                                                event on remote side. Make best
+                                                effort attempt to avoid
+                                                triggering @ref UCT_EVENT_RECV
+                                                event. Ignored if not supported
+                                                by interface. */
+    UCT_SEND_FLAG_PEER_CHECK = UCS_BIT(1)  /**< Forces checking connectivity to
+                                                a peer. If the connection is
+                                                not alive, an error callback
+                                                will be invoked. If the flag is
+                                                not set, there is no guarantee
+                                                that a connectivity error could
+                                                be detected.  */
 };
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -934,9 +934,8 @@ int uct_ep_get_process_proc_dir(char *buffer, size_t max_len, pid_t pid);
 
 ucs_status_t uct_ep_keepalive_init(uct_keepalive_info_t *ka, pid_t pid);
 
-ucs_status_t uct_ep_keepalive_check(uct_ep_h ep, uct_keepalive_info_t *ka,
-                                    pid_t pid, unsigned flags,
-                                    uct_completion_t *comp);
+void uct_ep_keepalive_check(uct_ep_h ep, uct_keepalive_info_t *ka, pid_t pid,
+                            unsigned flags, uct_completion_t *comp);
 
 void uct_ep_set_iface(uct_ep_h ep, uct_iface_t *iface);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -183,6 +183,7 @@ ucs_status_t uct_cuda_ipc_ep_check(const uct_ep_h tl_ep, unsigned flags,
 {
     uct_cuda_ipc_ep_t *ep = ucs_derived_of(tl_ep, uct_cuda_ipc_ep_t);
 
-    return uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->remote_pid, flags,
-                                  comp);
+    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
+    uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->remote_pid, flags, comp);
+    return UCS_OK;
 }

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -236,6 +236,23 @@ static inline void uct_mm_ep_update_cached_tail(uct_mm_ep_t *ep)
     ep->cached_tail = ep->fifo_ctl->tail;
 }
 
+static UCS_F_ALWAYS_INLINE void uct_mm_ep_peer_check(uct_mm_ep_t *ep,
+                                                     unsigned flags)
+{
+    if (ucs_unlikely(flags & UCT_SEND_FLAG_PEER_CHECK)) {
+        uct_ep_keepalive_check(&ep->super.super, &ep->keepalive,
+                               ep->fifo_ctl->pid, 0, NULL);
+    }
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_mm_ep_no_resources_handle(uct_mm_ep_t *ep, unsigned flags)
+{
+    UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
+    uct_mm_ep_peer_check(ep, flags);
+    return UCS_ERR_NO_RESOURCE;
+}
+
 /* A common mm active message sending function.
  * The first parameter indicates the origin of the call.
  */
@@ -243,7 +260,7 @@ static UCS_F_ALWAYS_INLINE ssize_t uct_mm_ep_am_common_send(
         uct_mm_send_op_t send_op, uct_mm_ep_t *ep, uct_mm_iface_t *iface,
         uint8_t am_id, size_t length, uint64_t header, const void *payload,
         uct_pack_callback_t pack_cb, void *arg, const uct_iov_t *iov,
-        size_t iovcnt)
+        size_t iovcnt, unsigned flags)
 {
     uct_mm_fifo_element_t *elem;
     ucs_status_t status;
@@ -261,20 +278,17 @@ retry:
     if (!UCT_MM_EP_IS_ABLE_TO_SEND(head, ep->cached_tail, iface->config.fifo_size)) {
         if (!ucs_arbiter_group_is_empty(&ep->arb_group)) {
             /* pending isn't empty. don't send now to prevent out-of-order sending */
-            UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES, 1);
-            return UCS_ERR_NO_RESOURCE;
+            return uct_mm_ep_no_resources_handle(ep, flags);
         } else {
-            /* pending is empty */
-            /* update the local copy of the tail to its actual value on the remote peer */
+            /* pending is empty. update the local copy of the tail to its
+             * actual value on the remote peer */
             uct_mm_ep_update_cached_tail(ep);
             if (!UCT_MM_EP_IS_ABLE_TO_SEND(head, ep->cached_tail, iface->config.fifo_size)) {
                 ucs_arbiter_group_push_head_elem_always(&ep->arb_group,
                                                         &ep->arb_elem);
                 ucs_arbiter_group_schedule_nonempty(&iface->arbiter,
                                                     &ep->arb_group);
-                UCS_STATS_UPDATE_COUNTER(ep->super.stats, UCT_EP_STAT_NO_RES,
-                                         1);
-                return UCS_ERR_NO_RESOURCE;
+                return uct_mm_ep_no_resources_handle(ep, flags);
             }
         }
     }
@@ -348,6 +362,8 @@ retry:
         uct_mm_ep_signal_remote(ep);
     }
 
+    uct_mm_ep_peer_check(ep, flags);
+
     switch (send_op) {
     case UCT_MM_SEND_AM_SHORT:
     case UCT_MM_SEND_AM_SHORT_IOV:
@@ -371,7 +387,8 @@ ucs_status_t uct_mm_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
 
     return (ucs_status_t)uct_mm_ep_am_common_send(UCT_MM_SEND_AM_SHORT, ep,
                                                   iface, id, length, header,
-                                                  payload, NULL, NULL, NULL, 0);
+                                                  payload, NULL, NULL, NULL, 0,
+                                                  0);
 }
 
 ucs_status_t uct_mm_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
@@ -387,7 +404,7 @@ ucs_status_t uct_mm_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
 
     return (ucs_status_t)uct_mm_ep_am_common_send(UCT_MM_SEND_AM_SHORT_IOV, ep,
                                                   iface, id, 0, 0, NULL, NULL,
-                                                  NULL, iov, iovcnt);
+                                                  NULL, iov, iovcnt, 0);
 }
 
 ssize_t uct_mm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_cb,
@@ -397,7 +414,7 @@ ssize_t uct_mm_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id, uct_pack_callback_t pack_
     uct_mm_ep_t *ep = ucs_derived_of(tl_ep, uct_mm_ep_t);
 
     return uct_mm_ep_am_common_send(UCT_MM_SEND_AM_BCOPY, ep, iface, id, 0, 0,
-                                    NULL, pack_cb, arg, NULL, 0);
+                                    NULL, pack_cb, arg, NULL, 0, flags);
 }
 
 static inline int uct_mm_ep_has_tx_resources(uct_mm_ep_t *ep)
@@ -535,6 +552,8 @@ uct_mm_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
 {
     uct_mm_ep_t *ep = ucs_derived_of(tl_ep, uct_mm_ep_t);
 
-    return uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->fifo_ctl->pid,
-                                  flags, comp);
+    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
+    uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->fifo_ctl->pid, flags,
+                           comp);
+    return UCS_OK;
 }

--- a/src/uct/sm/scopy/cma/cma_ep.c
+++ b/src/uct/sm/scopy/cma/cma_ep.c
@@ -128,6 +128,7 @@ ucs_status_t uct_cma_ep_check(const uct_ep_h tl_ep, unsigned flags,
 {
     uct_cma_ep_t *ep = ucs_derived_of(tl_ep, uct_cma_ep_t);
 
-    return uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->remote_pid, flags,
-                                  comp);
+    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
+    uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->remote_pid, flags, comp);
+    return UCS_OK;
 }

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -816,7 +816,7 @@ protected:
                                 bool rx_expected = false)
     {
         skip_loopback();
-        test_am_send_recv(0, max_am_hdr()); // warmup wireup
+        test_am_send_recv(0, 0); // warmup wireup
 
         m_am_received = false;
         std::vector<char> sbuf(size, 'd');

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -504,9 +504,7 @@ public:
 protected:
     void do_keepalive()
     {
-        ucs_status_t status = uct_ep_keepalive_check(m_entity->ep(0), m_ka(),
-                                                     m_pid, 0, NULL);
-        EXPECT_UCS_OK(status);
+        uct_ep_keepalive_check(m_entity->ep(0), m_ka(), m_pid, 0, NULL);
     }
 
     pid_t                m_pid;


### PR DESCRIPTION
## What

1. Resolve remote ID only when if the endpoint was created with `PEER_FAILURE` feature support.
2. Update `test_ucp_am_nbx_closed_ep` gtest to do `0`-length AM operation which only ensures that two peers are fully connected.
3. Introduce `UCT_SEND_FLAG_PEER_CHECK` AM Bcopy flag; use this flag when sending AM-base keepalive `EP_CHECK` message to a peer; handle the flag in UCT/MM to check remote peer existence.

## Why ?

1. To make sure that EP knows the correct ID of a remote peer prior to communicating with the peer.
2. To reproduce the issue when EP wasn't resolved during AM short and then `ucp_ep_close_nbx` is done for receiver's EP (other protocols resolve it - so they are not suitable).
3. `UCT_SEND_FLAG_PEER_CHECK` - forces checking connectivity to a peer during sending some data to it. All transports except MM transports support it natively. In the case of MM transports we should do `uct_ep_check()` which checks PID pf peer existence through proc fs.

## How ?

1. Add doing `ucp_ep_resolve_remote_id` in case of the user creates UCP EP with `PEER_FAILURE` support.
2. Replace doing warmup using UCP AM with `0`-length messages instead of maximum AM header.
3. Add new UCT API flag `UCT_SEND_FLAG_PEER_CHECK`; update uct_ep_am_bcopy to pass this flag when sending `WIREUP_MSG/EP_CHECK` in UCP; check `UCT_SEND_FLAG_PEER_CHECK` in `uct_mm_ep_am_common_send()` and do `uct_ep_check` if the flag was passed.