### PR TITLE
UCP/WIREUP: Fix not allocating indirect remote ID for internal EP if connected EP supports PEER_FAILURE

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -614,6 +614,10 @@ void ucp_ep_flush_state_invalidate(ucp_ep_h ep);
 
 void ucp_ep_release_id(ucp_ep_h ep);
 
+ucs_status_t
+ucp_ep_config_err_mode_check_mismatch(ucp_ep_h ep,
+                                      ucp_err_handling_mode_t err_mode);
+
 ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
                                        ucp_wireup_ep_t **wireup_ep);
 


### PR DESCRIPTION
## What

Fix not allocating indirect remote ID for internal EP if connected EP supports `PEER_FAILURE`.

## Why ?

To allocate indirect remote ID, since internal UCP EP is created with `PEER_FAILRUE` capability.
Currently, direct ID is always allocated for internal EP.

## How ?

1. Set ep_init_flags to `PEER_FAILURE` flag prior doing `ucp_worker_create_ep` where the type of remote ID is identified based on configuration and `PEER_FAILURE` flag.
2. Check that local and remote EPs don't have a mismatch in error mode.