### PR TITLE
UCP/CONTEXT: Improve version print

### DIFF
--- a/src/ucp/core/ucp_version.c.in
+++ b/src/ucp/core/ucp_version.c.in
@@ -14,5 +14,5 @@ void ucp_get_version(unsigned *major_version, unsigned *minor_version,
 
 const char *ucp_get_version_string()
 {
-	return "@MAJOR_VERSION@.@MINOR_VERSION@.@PATCH_VERSION@";
+	return "@VERSION@";
 }


### PR DESCRIPTION
## Why
Improve UCX version print to include canonical version string and library path

## How
### Before

* Correct version (+ `UCX_LOG_LEVEL=info`):
   ```
   [1645974996.154356] [myhost:31897:0]     ucp_context.c:1799 UCX  INFO  UCP version is 1.13 (release 0)
   ```

* Mismatch version:
   ```
   [1645975021.374097] [myhost:1397 :0]     ucp_context.c:1796 UCX  WARN  UCP version is incompatible, required: 1.13, actual: 1.12 (release 0)
   ```

### After

* Correct version (+ `UCX_LOG_LEVEL=info`):
   ```
   [1645974884.130258] [myhost:23614:0]     ucp_context.c:1810 UCX  INFO  Version 1.13.0 (loaded from /path/to/usr/lib64/libucp.so.0)
   ```

* Mismatch version:
   ```
   [1645974950.527876] [myhost:27319:0]     ucp_context.c:1810 UCX  WARN  UCP API version is incompatible: required >= 1.13, actual 1.12.0 (loaded from /path/to/usr/lib64/libucp.so.0)
   ```
