### PR TITLE
UCP/EP API changes to support extending ucp_ep_query to query endpoint transport information

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4595,7 +4595,8 @@ ucs_status_ptr_t ucp_worker_flush_nbx(ucp_worker_h worker,
 enum ucp_ep_attr_field {
     UCP_EP_ATTR_FIELD_NAME            = UCS_BIT(0), /**< UCP endpoint name */
     UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(1), /**< Sockaddr used by the endpoint */
-    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2)  /**< Sockaddr the endpoint is connected to */
+    UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2), /**< Sockaddr the endpoint is connected to */
+    UCP_EP_ATTR_FIELD_TRANSPORTS      = UCS_BIT(3)  /**< Transport and device used by endpoint */
 };
 
 
@@ -4636,6 +4637,14 @@ typedef struct ucp_ep_attr {
      * UCS_ERR_NOT_CONNECTED will be returned.
      */
     struct sockaddr_storage remote_sockaddr;
+
+    /**
+     * Structure defining an array containing transport and device names used 
+     * by this endpoint. The caller is responsible for allocation and 
+     * deallocation of this array.
+     */
+    ucp_transports_t        transports;
+
 } ucp_ep_attr_t;
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -771,5 +771,103 @@ typedef struct ucp_ep_params {
  */
 #define UCP_ENTITY_NAME_MAX 32
 
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief The @ref ucp_transports_t and @ref ucp_transport_entry_t structures
+ *        are used when @ref ucp_ep_query is called to return an array of
+ *        transport name and device name pairs that are used by an active
+ *        endpoint.
+ *
+ *        The ucp_transport_t structure specifies the characteristics of the
+ *        ucp_transport_entry_t array.
+ *
+ *        The caller is responsible for the allocation and de-allocation
+ *        of the ucp_transport_entry_t array.
+ *
+ * Example: Implementation of a function to query the set of transport and
+ *          device name pairs used by the specified endpoint.
+ *
+ * @code{.c}
+ *   int query_transports(ucp_ep_h ep)
+ *   {
+ *     ucs_status_t status;
+ *     ucp_transport_entry_t *transport_entries;
+ *     ucp_ep_attr_t ep_attrs;
+ *
+ *     ep_attrs.field_mask = UCP_EP_ATTR_FIELD_TRANSPORTS;
+ *     ep_attrs.transports.entries = (ucp_transport_entry_t *)
+ *              malloc(10 * sizeof(ucp_transport_entry_t));
+ *     ep_attrs.transports.num_entries = 10;
+ *     ep_attrs.transports.entry_size = sizeof(ucp_transport_entry_t);
+ *     status = ucp_ep_query(ep, &ep_attrs);
+ *     if (status == UCS_OK) {
+ *         // ep_attrs.transports.num_entries = number of returned entries 
+ *         // ... process transport info ... 
+ *     }
+ *   }
+ * @endcode
+ */
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief A transport name and device name pair used by this endpoint. The
+ * caller is responsible for the allocation and deallocation of an array of
+ * these structures large enough to contain the desired number of transport
+ * and device name pairs.
+ *
+ * If new fields are added to this structure, they must be added at the end
+ * of this structure.
+ */
+typedef struct {
+    /**
+     * The name of a transport layer used by this endpoint. This '\0'-terminated
+     * string is valid until the endpoint is closed using a
+     * @ref ucp_ep_close_nbx call. 
+     */
+    const char *transport_name;
+
+    /**
+     * The name of the device used with this transport by this endpoint.
+     * This '\0'-terminated string is valid until the endpoint is closed using
+     * a @ref ucp_ep_close_nbx call.
+     */
+    const char *device_name;
+
+} ucp_transport_entry_t;
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ * @brief Structure containing an array of transport layers and device names
+ * used by an endpoint.
+ *
+ * The caller is responsible for allocation and deallocation of 
+ * this structure.
+ */
+typedef struct {
+    /**
+      * Pointer to array of transport/device name pairs used by this endpoint.
+      * The caller is responsible for the allocation and deallocation of this
+      * array.
+      */
+    ucp_transport_entry_t *entries;
+
+    /**
+     * Number of transport/device name pairs. The caller must set this to
+     * the maximum number of pairs the structure can contain. On return,
+     * this is set to the actual number of transport and device name pairs used
+     * by the endpoint.
+     */
+    unsigned              num_entries;
+
+    /**
+     * Size of a single @ref ucp_transport_entry_t object. The caller sets this
+     * to the size of the ucp_transport_entry_t they are using. UCP code must
+     * not set any fields in the ucp_transport_entry_t structure beyond this
+     * size.
+     */
+    size_t                entry_size;
+
+} ucp_transports_t;
 
 #endif


### PR DESCRIPTION
## What
The purpose for this PR is to push the public API changes needed to implement an extension to the ucp_ep_query function so that the transport and device names associated with an endpoint can be queried.  

## Why ?
I am implementing a change to OpenMPI that will allow a user to query the UCX transport(s) and device name(s) used for OpenMPI to communicate between node pairs in the set of nodes used by the application.

The current version of these changes can be seen at https://github.com/drwootton/ompi/commit/2a01800e74004c0e07ae97e302e2b7bd37500928 where the changes that use the proposed ucp_ep_query change are contained in ompi/mca/pml/ucx/pml_ucx.c

## How ?
My intent is to follow up with a second PR that implements the changes needed to actually query the endpoint information in src/ucp/core/ucp_ep.c. The ucp_ep_query function will query the endpoint information if the new UCP_EP_ATTR_FIELD_TRANSPORTS bit is set in the ucp_ep_query attribute structure and return that information in the attribute structure.

Since the MPI application may run on a large number of nodes, I'm implementing this with the expectation that once the OpenMPI code no longer needs the ucp_ep_query attribute structure, the OpenMPI code frees the structure containing the transport information.

-----

Since this is my first attempt to implement changes to UCX code, I'm not sure I have it right and I have several questions.

I ran git-clang-format on my changes. It said it made no changes, so hopefully the code formatting is correct.

The implementation is in the UCP layer, but relies on some definitions in the UCT layer, which is why I added uct/api/uct_def.h to ucp_def.h. I'm not sure this is correct since I think this crosses the layer boundary, but I think it's preferable to defining some UCP defines that just duplicate what already exists for UCT. 

I'm defining the ucp_transports_t structure in ucp_def.h with a fixed number of array entries, currently 10,  to keep the allocation simple. I'm not sure 10 is a reasonable limit for an application running on a large cluster with possibly many transport/device combinations, but don't know what would be more realistic. Since each element is small, maybe a larger more realistic limit should be specified and the memory is not that significant, again because I'm expecting OpenMPI code to be serially querying endpoints and releasing each endpoint's structure fairly quickly. 
Signed-off-by: David Wootton <dwootton@us.ibm.com>
