### PR TITLE
Customer memory allocator/api

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1319,6 +1319,12 @@ typedef struct ucp_worker_params {
     ucs_user_mem_allocator_init_func_t user_mem_allocator_init;
 
     /**
+    * Release all the descriptors allocated by the specified memory allocator.
+    * This is optional parameter
+    */
+    ucs_user_mem_allocator_cleanup_func_t user_mem_allocator_cleanup;
+
+    /**
     * user memory allocator allocate descriptor
     */
     ucs_user_mem_allocator_malloc_func_t user_mem_allocator_malloc;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -17,6 +17,7 @@
 #include <ucs/config/types.h>
 #include <ucs/sys/compiler_def.h>
 #include <ucs/memory/memory_type.h>
+#include <ucs/memory/user_mem_allocator.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -172,7 +173,8 @@ enum ucp_worker_params_field {
     UCP_WORKER_PARAM_FIELD_NAME         = UCS_BIT(6), /**< Worker name */
     UCP_WORKER_PARAM_FIELD_AM_ALIGNMENT = UCS_BIT(7), /**< Alignment of active
                                                            messages on the receiver */
-    UCP_WORKER_PARAM_FIELD_CLIENT_ID    = UCS_BIT(8)  /**< Client id */
+    UCP_WORKER_PARAM_FIELD_CLIENT_ID    = UCS_BIT(8),  /**< Client id */
+    UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC  = UCS_BIT(9)  /**< User Memory Allocator */
 };
 
 
@@ -1310,6 +1312,21 @@ typedef struct ucp_worker_params {
     * using @ref ucp_conn_request_query.
     */
     uint64_t                client_id;
+
+    /**
+    * User defined memory allocator instance constructor.
+    */
+    ucs_user_mem_allocator_init_func_t user_mem_allocator_init;
+
+    /**
+    * user memory allocator allocate descriptor
+    */
+    ucs_user_mem_allocator_malloc_func_t user_mem_allocator_malloc;
+
+    /**
+    * user memory allocator free descriptor
+    */
+    ucs_user_mem_allocator_free_func_t user_mem_allocator_free;
 } ucp_worker_params_t;
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2192,6 +2192,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         }
 
         worker->user_allocator.ops.init = params->user_mem_allocator_init;
+        worker->user_allocator.ops.cleanup = params->user_mem_allocator_cleanup;
         worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
         worker->user_allocator.ops.free = params->user_mem_allocator_free;
         worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
@@ -2200,6 +2201,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     } else {
 
         worker->user_allocator.ops.init = NULL;
+        worker->user_allocator.ops.cleanup = NULL;
         worker->user_allocator.ops.malloc = NULL;
         worker->user_allocator.ops.free = NULL;
         worker->user_allocator.malloc_cb = NULL;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1790,6 +1790,12 @@ static void ucp_worker_destroy_mpools(ucp_worker_h worker)
                       !(worker->flags & UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK));
 }
 
+    static ucs_status_t ucp_worker_usr_allocator_malloc_cb(void* ucp_memh_p, unsigned md_index, uct_mem_h *memh) {
+    ucs_status_t status = UCS_OK;
+
+    return status;
+}
+
 static void
 ucp_worker_ep_config_short_init(ucp_worker_h worker, ucp_ep_config_t *ep_config,
                                 ucp_worker_cfg_index_t ep_cfg_index,
@@ -2187,6 +2193,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
         worker->user_allocator.ops.init = params->user_mem_allocator_init;
         worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
+        worker->user_allocator.ops.free = params->user_mem_allocator_free;
         worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
         worker->user_allocator.arg = NULL;
 
@@ -2194,6 +2201,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
         worker->user_allocator.ops.init = NULL;
         worker->user_allocator.ops.malloc = NULL;
+        worker->user_allocator.ops.free = NULL;
         worker->user_allocator.malloc_cb = NULL;
         worker->user_allocator.arg = NULL;
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1144,6 +1144,9 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     iface_params->err_handler_flags = UCT_CB_FLAG_ASYNC;
     iface_params->cpu_mask          = worker->cpu_mask;
 
+    memcpy(&iface_params->user_allocator, &worker->user_allocator, sizeof(uct_user_allocator_props_t));
+    iface_params->user_allocator.md_index = resource->md_index;
+
     if (context->config.features & UCP_FEATURE_TAG) {
         iface_params->eager_arg     = iface_params->rndv_arg = wiface;
         iface_params->eager_cb      = ucp_tag_offload_unexp_eager;
@@ -2169,6 +2172,30 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         ucs_strided_alloc_init(&worker->ep_alloc, sizeof(ucp_ep_t), 3);
     } else {
         ucs_strided_alloc_init(&worker->ep_alloc, sizeof(ucp_ep_t), 2);
+    }
+
+    if (params->field_mask & UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC) {
+
+        if (params->user_mem_allocator_init == NULL ||
+            params->user_mem_allocator_malloc == NULL ||
+            params->user_mem_allocator_free == NULL) {
+
+            ucs_error("Missing user allocator params");
+            status = UCS_ERR_INVALID_PARAM;
+            goto err_free;
+        }
+
+        worker->user_allocator.ops.init = params->user_mem_allocator_init;
+        worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
+        worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
+        worker->user_allocator.arg = NULL;
+
+    } else {
+
+        worker->user_allocator.ops.init = NULL;
+        worker->user_allocator.ops.malloc = NULL;
+        worker->user_allocator.malloc_cb = NULL;
+        worker->user_allocator.arg = NULL;
     }
 
     worker->user_data    = UCP_PARAM_VALUE(WORKER, params, user_data, USER_DATA,

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -349,6 +349,8 @@ typedef struct ucp_worker {
         /* Number of failed endpoints */
         uint64_t                     ep_failures;
     } counters;
+
+    uct_user_allocator_props_t user_allocator;
 } ucp_worker_t;
 
 

--- a/src/ucs/memory/user_mem_allocator.h
+++ b/src/ucs/memory/user_mem_allocator.h
@@ -45,9 +45,9 @@ typedef ucs_status_t (*ucs_user_mem_allocator_init_func_t)(const ucs_user_mem_al
 * @ingroup UCS_RESOURCE
 * @brief Free descriptor allocated using user memory allocator
 *
-* @param [in]   arg   Opaque object representing memory allocation instance implemented by the user
+* @param [in]   arg  Opaque object representing memory allocation instance implemented by the user
 *
-* @param [out]  desc  Allocated descriptor.
+* @param [in]  desc  Descriptor to free.
 *
 * @return Error code as defined by @ref ucs_status_t
 */

--- a/src/ucs/memory/user_mem_allocator.h
+++ b/src/ucs/memory/user_mem_allocator.h
@@ -1,0 +1,71 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) The University of Tennessee and The University
+*               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_USER_MEM_ALLOCATOR_H
+#define UCS_USER_MEM_ALLOCATOR_H
+
+#include <ucs/type/status.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+  * @ingroup UCS_RESOURCE
+ * @brief User Memory allocator initialization params.
+ *
+ * The structure defines the configuration of
+ * the needed memory allocator.
+ */
+typedef struct ucs_user_mem_allocator_params {
+    uint64_t field_mask;
+    size_t seg_size;
+    size_t data_offset;
+} ucs_user_mem_allocator_params_t;
+
+
+/**
+* @ingroup UCS_RESOURCE
+* @brief User defined memory allocation instance constructor.
+*
+* @param [in]  params  Memory allocator configuration.
+*
+* @param [out]  arg    Opaque object representing memory allocation instance implemented by the user
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_init_func_t)(const ucs_user_mem_allocator_params_t* params, void** arg);
+
+
+/**
+* @ingroup UCS_RESOURCE
+* @brief Free descriptor allocated using user memory allocator
+*
+* @param [in]   arg   Opaque object representing memory allocation instance implemented by the user
+*
+* @param [out]  desc  Allocated descriptor.
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_free_func_t)(void* arg, void *desc);
+
+
+/**
+* @ingroup UCS_RESOURCE
+* @brief Get descriptor from user defined memory allocation instance
+*
+* @param [in]   arg       Opaque object representing memory allocation instance implemented by the user
+*
+* @param [out]  desc      Allocated descriptor.
+*
+* @param [out]  ucp_memh  UCP Memory handle
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_malloc_func_t)(void* arg, void **desc, void **ucp_memh);
+
+#endif

--- a/src/ucs/memory/user_mem_allocator.h
+++ b/src/ucs/memory/user_mem_allocator.h
@@ -19,7 +19,7 @@
  * @brief User Memory allocator initialization params.
  *
  * The structure defines the configuration of
- * the needed memory allocator.
+ * the memory allocator.
  */
 typedef struct ucs_user_mem_allocator_params {
     uint64_t field_mask;

--- a/src/ucs/memory/user_mem_allocator.h
+++ b/src/ucs/memory/user_mem_allocator.h
@@ -43,6 +43,15 @@ typedef ucs_status_t (*ucs_user_mem_allocator_init_func_t)(const ucs_user_mem_al
 
 /**
 * @ingroup UCS_RESOURCE
+* @brief Cleanup the User defined memory allocation instance.
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_cleanup_func_t)(void* arg);
+
+
+/**
+* @ingroup UCS_RESOURCE
 * @brief Free descriptor allocated using user memory allocator
 *
 * @param [in]   arg  Opaque object representing memory allocation instance implemented by the user

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1125,6 +1125,9 @@ struct uct_iface_params {
      * +-------------------+
      */
     size_t                                       am_align_offset;
+
+    /*User defined memory allocator interface props*/
+    uct_user_allocator_props_t user_allocator;
 };
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -923,6 +923,8 @@ typedef struct uct_user_allocator_props {
     struct {
         /*Init user defined memory allocator*/
         ucs_user_mem_allocator_init_func_t init;
+        /*Release all the descriptors allocated by the specified memory allocator*/
+        user_mem_allocator_cleanup cleanup;
         /*Free memory descriptor*/
         ucs_user_mem_allocator_free_func_t free;
         /*Get memory descriptor from user*/

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -924,7 +924,7 @@ typedef struct uct_user_allocator_props {
         /*Init user defined memory allocator*/
         ucs_user_mem_allocator_init_func_t init;
         /*Release all the descriptors allocated by the specified memory allocator*/
-        user_mem_allocator_cleanup cleanup;
+        ucs_user_mem_allocator_cleanup_func_t cleanup;
         /*Free memory descriptor*/
         ucs_user_mem_allocator_free_func_t free;
         /*Get memory descriptor from user*/

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -9,6 +9,7 @@
 
 #include <ucs/config/types.h>
 #include <ucs/type/status.h>
+#include <ucs/memory/user_mem_allocator.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -894,5 +895,39 @@ typedef ucs_status_t (*uct_tag_unexp_rndv_cb_t)(void *arg, unsigned flags,
  */
 typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
 
+
+/**
+* @ingroup UCT_RESOURCE
+* @brief Callback function called after allocating descriptor using user memory allocator,
+         returns uct memory handle from the ucp memory handle.
+*
+* @param [in]   arg       Opaque object representing memory allocation instance implemented by the user
+*
+* @param [out]  desc      Allocated descriptor.
+*
+* @param [out]  ucp_memh  UCP Memory handle
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*uct_user_allocator_malloc_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Interface for allocating descriptors based on user defined implementation
+ */
+typedef struct uct_user_allocator_props {
+    unsigned md_index;
+    void* arg;
+    uct_user_allocator_malloc_cb_func_t malloc_cb;
+    struct {
+        /*Init user defined memory allocator*/
+        ucs_user_mem_allocator_init_func_t init;
+        /*Free memory descriptor*/
+        ucs_user_mem_allocator_free_func_t free;
+        /*Get memory descriptor from user*/
+        ucs_user_mem_allocator_malloc_func_t  malloc;
+    } ops;
+} uct_user_allocator_props_t;
 
 #endif

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -458,6 +458,13 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
     return UCS_OK;
 }
 
+static ucs_status_t uct_base_iface_set_usr_alloc_params(const uct_iface_params_t *params, uct_base_iface_t *iface) {
+
+    memcpy(&iface->user_allocator, &params->user_allocator, sizeof(uct_user_allocator_props_t));
+
+    return UCS_OK;
+}
+
 uct_iface_internal_ops_t uct_base_iface_internal_ops = {
     .iface_estimate_perf = uct_base_iface_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
@@ -526,6 +533,9 @@ UCS_CLASS_INIT_FUNC(uct_base_iface_t, uct_iface_ops_t *ops,
     self->err_handler_arg   = UCT_IFACE_PARAM_VALUE(params, err_handler_arg,
                                                     ERR_HANDLER_ARG, NULL);
     self->progress_flags    = 0;
+
+    uct_base_iface_set_usr_alloc_params(params, self);
+
     uct_worker_progress_init(&self->prog);
 
     for (id = 0; id < UCT_AM_ID_MAX; ++id) {

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -278,6 +278,8 @@ typedef struct uct_base_iface {
         size_t               max_num_eps;
     } config;
 
+    uct_user_allocator_props_t user_allocator;
+
     UCS_STATS_NODE_DECLARE(stats)            /* Statistics */
 } uct_base_iface_t;
 


### PR DESCRIPTION
## What
Proposed API for User defined memory allocator used by UCX.

## Why ?
Customer want to replace our Mpool implementation with his own memory allocation scheme
to control the allocation and release of RX Descriptors.

## How ?
As for the API - Passing 3 functions implemented by the user (init, malloc, free) from UCP to ifaces in UCT.
Function description can be found in the code ("src/ucs/memory/user_mem_allocator.h").
