### PR TITLE
Customer Memory allocator

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -17,6 +17,7 @@
 #include <ucs/config/types.h>
 #include <ucs/sys/compiler_def.h>
 #include <ucs/memory/memory_type.h>
+#include <ucs/memory/user_mem_allocator.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -1209,58 +1210,6 @@ typedef struct ucp_worker_attr {
 
 /**
  * @ingroup UCP_WORKER
- * @brief UCP worker attributes.
- *
- * The structure defines the configuration of
- * the needed memory allocator.
- */
-typedef struct ucp_user_mem_allocator_params {
-    uint64_t field_mask;
-    size_t seg_size;
-    size_t data_offset;
-} ucp_user_mem_allocator_params_t;
-
-/**
-* @ingroup UCP_WORKER
-* @brief User defined memory allocation instance constructor. 
-*
-* @param [in]  params  Memory allocator configuration.
-*
-* @param [out]  arg    Opaque object representing memory allocation instance implemented by the user
-*
-* @return Error code as defined by @ref ucs_status_t
-*/
-typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(const ucp_user_mem_allocator_params_t *params, void **arg);
-
-/**
-* @ingroup UCP_WORKER
-* @brief Get descriptor from user defined memory allocation instance 
-*
-* @param [in]   arg  Opaque object representing memory allocation instance implemented by the user
-* 
-* @param [out]  desc           Allocated descriptor.
-*
-* @param [out]  ucp_mem_h      UCP Memory handle 
-*
-* @return Error code as defined by @ref ucs_status_t
-*/
-typedef ucs_status_t (*ucp_user_mem_allocator_malloc_func_t)(void *arg, void** desc, ucp_mem_h *memh);
-
-/**
-* @ingroup UCP_WORKER
-* @brief Free descriptor allocated using user memory allocator
-*
-* @param [in]   arg  Opaque object representing memory allocation instance implemented by the user
-* 
-* @param [out]  desc           Allocated descriptor.
-*
-* @return Error code as defined by @ref ucs_status_t
-*/
-typedef ucs_status_t (*ucp_user_mem_allocator_free_func_t)(void *arg, void* desc);
-
-
-/**
- * @ingroup UCP_WORKER
  * @brief Tuning parameters for the UCP worker.
  *
  * The structure defines the parameters that are used for the
@@ -1367,17 +1316,17 @@ typedef struct ucp_worker_params {
     /**
     * User defined memory allocation instance constructor. 
     */
-    ucp_user_mem_allocator_init_func_t user_mem_allocator_init;
+    ucs_user_mem_allocator_init_func_t user_mem_allocator_init;
     
     /**
     * user memory allocation allocate descriptor
     */
-    ucp_user_mem_allocator_malloc_func_t user_mem_allocator_malloc;
+    ucs_user_mem_allocator_malloc_func_t user_mem_allocator_malloc;
     
     /**
     * user memory allocation free descriptor
     */
-    ucp_user_mem_allocator_free_func_t user_mem_allocator_free;
+    ucs_user_mem_allocator_free_func_t user_mem_allocator_free;
 } ucp_worker_params_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4652,6 +4652,32 @@ typedef struct ucp_ep_attr {
  */
 ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr);
 
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief Initilize the user allocator
+ *
+ * The user defined routine that initilize the user allocator
+ *
+ * @param [in]  seg_size      Descriptor size in bytes include header for lkey
+ * @param [out] usr_allocator Opaque object representing a memory allocatoer.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+/*ucs_status_t (*ucp_user_allocator_init_func_t)(size_t seg_size, void **usr_allocator);*/
+
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief Return descriptor allocated by the user and memory handle
+ *
+ * The user defined routine that return mapped descriptor and memory handle
+ *
+ * @param [in]  usr_allocator Opaque object representing a memory allocatoer.
+ * @param [out] desc          Allocated and mapped descriptor
+ * @param [out] memh          mem handle of the mapped block.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+/*ucs_status_t (*ucp_user_allocator_func_t) (void *usr_allocator, void** desc, ucp_mem_h *memh);*/
 
 /**
  * @example ucp_hello_world.c

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1206,19 +1206,31 @@ typedef struct ucp_worker_attr {
     size_t                max_debug_string;
 } ucp_worker_attr_t;
 
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief UCP worker attributes.
+ *
+ * The structure defines the configuration of
+ * the needed memory allocator.
+ */
+typedef struct ucp_user_mem_allocator_params {
+    uint64_t field_mask;
+    size_t seg_size;
+    size_t data_offset;
+} ucp_user_mem_allocator_params_t;
+
 /**
 * @ingroup UCP_WORKER
 * @brief User defined memory allocation instance constructor. 
 *
-* @param [in]  seg_size       Descriptors size to allocate
-*                             by this memory allocator instance.
-* @param [in]  data_offset    Data offset.
+* @param [in]  params  Memory allocator configuration.
 *
-* @param [out] arg  Opaque object representing memory allocation instance implemented by the user
+* @param [out]  arg    Opaque object representing memory allocation instance implemented by the user
 *
 * @return Error code as defined by @ref ucs_status_t
 */
-typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(size_t seg_size, size_t data_offset, void **arg);
+typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(const ucp_user_mem_allocator_params_t *params, void **arg);
 
 /**
 * @ingroup UCP_WORKER

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1214,7 +1214,7 @@ typedef struct ucp_worker_attr {
 *                             by this memory allocator instance.
 * @param [in]  data_offset    Data offset.
 *
-* @param [out] usr_allocator  Opaque object representing memory allocation instance implmented by the user
+* @param [out] usr_allocator  Opaque object representing memory allocation instance implemented by the user
 *
 * @return Error code as defined by @ref ucs_status_t
 */
@@ -1224,7 +1224,7 @@ typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(size_t seg_size, size
 * @ingroup UCP_WORKER
 * @brief Get descriptor from user defined memory allocation instance 
 *
-* @param [in]   usr_allocator  Opaque object representing memory allocation instance implmented by the user
+* @param [in]   usr_allocator  Opaque object representing memory allocation instance implemented by the user
 * 
 * @param [out]  desc           Allocated descriptor.
 *

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -4652,32 +4652,6 @@ typedef struct ucp_ep_attr {
  */
 ucs_status_t ucp_ep_query(ucp_ep_h ep, ucp_ep_attr_t *attr);
 
-/**
- * @ingroup UCP_DATATYPE
- * @brief Initilize the user allocator
- *
- * The user defined routine that initilize the user allocator
- *
- * @param [in]  seg_size      Descriptor size in bytes include header for lkey
- * @param [out] usr_allocator Opaque object representing a memory allocatoer.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-/*ucs_status_t (*ucp_user_allocator_init_func_t)(size_t seg_size, void **usr_allocator);*/
-
-/**
- * @ingroup UCP_DATATYPE
- * @brief Return descriptor allocated by the user and memory handle
- *
- * The user defined routine that return mapped descriptor and memory handle
- *
- * @param [in]  usr_allocator Opaque object representing a memory allocatoer.
- * @param [out] desc          Allocated and mapped descriptor
- * @param [out] memh          mem handle of the mapped block.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-/*ucs_status_t (*ucp_user_allocator_func_t) (void *usr_allocator, void** desc, ucp_mem_h *memh);*/
 
 /**
  * @example ucp_hello_world.c

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -162,17 +162,18 @@ enum ucp_feature {
  * present. It is used to enable backward compatibility support.
  */
 enum ucp_worker_params_field {
-    UCP_WORKER_PARAM_FIELD_THREAD_MODE  = UCS_BIT(0), /**< UCP thread mode */
-    UCP_WORKER_PARAM_FIELD_CPU_MASK     = UCS_BIT(1), /**< Worker's CPU bitmap */
-    UCP_WORKER_PARAM_FIELD_EVENTS       = UCS_BIT(2), /**< Worker's events bitmap */
-    UCP_WORKER_PARAM_FIELD_USER_DATA    = UCS_BIT(3), /**< User data */
-    UCP_WORKER_PARAM_FIELD_EVENT_FD     = UCS_BIT(4), /**< External event file
+    UCP_WORKER_PARAM_FIELD_THREAD_MODE    = UCS_BIT(0), /**< UCP thread mode */
+    UCP_WORKER_PARAM_FIELD_CPU_MASK       = UCS_BIT(1), /**< Worker's CPU bitmap */
+    UCP_WORKER_PARAM_FIELD_EVENTS         = UCS_BIT(2), /**< Worker's events bitmap */
+    UCP_WORKER_PARAM_FIELD_USER_DATA      = UCS_BIT(3), /**< User data */
+    UCP_WORKER_PARAM_FIELD_EVENT_FD       = UCS_BIT(4), /**< External event file
                                                            descriptor */
-    UCP_WORKER_PARAM_FIELD_FLAGS        = UCS_BIT(5), /**< Worker flags */
-    UCP_WORKER_PARAM_FIELD_NAME         = UCS_BIT(6), /**< Worker name */
-    UCP_WORKER_PARAM_FIELD_AM_ALIGNMENT = UCS_BIT(7), /**< Alignment of active
+    UCP_WORKER_PARAM_FIELD_FLAGS          = UCS_BIT(5), /**< Worker flags */
+    UCP_WORKER_PARAM_FIELD_NAME           = UCS_BIT(6), /**< Worker name */
+    UCP_WORKER_PARAM_FIELD_AM_ALIGNMENT   = UCS_BIT(7), /**< Alignment of active
                                                            messages on the receiver */
-    UCP_WORKER_PARAM_FIELD_CLIENT_ID    = UCS_BIT(8)  /**< Client id */
+    UCP_WORKER_PARAM_FIELD_CLIENT_ID      = UCS_BIT(8),  /**< Client id */
+    UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC  = UCS_BIT(9)  /**< User Memory Allocator */
 };
 
 
@@ -1205,6 +1206,34 @@ typedef struct ucp_worker_attr {
     size_t                max_debug_string;
 } ucp_worker_attr_t;
 
+/**
+* @ingroup UCP_WORKER
+* @brief User defined memory allocation instance constructor. 
+*
+* @param [in]  seg_size       Descriptors size to allocate
+*                             by this memory allocator instance.
+* @param [in]  data_offset    Data offset.
+*
+* @param [out] usr_allocator  Opaque object representing memory allocation instance implmented by the user
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(size_t seg_size, size_t data_offset, void **usr_allocator);
+
+/**
+* @ingroup UCP_WORKER
+* @brief Get descriptor from user defined memory allocation instance 
+*
+* @param [in]   usr_allocator  Opaque object representing memory allocation instance implmented by the user
+* 
+* @param [out]  desc           Allocated descriptor.
+*
+* @param [out]  ucp_mem_h      UCP Memory handle 
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucp_user_get_descriptor_func_t)(void *usr_allocator, void** desc, ucp_mem_h *memh);
+
 
 /**
  * @ingroup UCP_WORKER
@@ -1310,6 +1339,16 @@ typedef struct ucp_worker_params {
     * using @ref ucp_conn_request_query.
     */
     uint64_t                client_id;
+
+    /**
+    * User defined memory allocation instance constructor. 
+    */
+    ucp_user_mem_allocator_init_func_t user_mem_allocator_init;
+    
+    /**
+    * Get descriptor from user memory allocation instance
+    */
+    ucp_user_get_descriptor_func_t user_get_descriptor;
 } ucp_worker_params_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1314,17 +1314,23 @@ typedef struct ucp_worker_params {
     uint64_t                client_id;
 
     /**
-    * User defined memory allocation instance constructor. 
+    * User defined memory allocator instance constructor.
     */
     ucs_user_mem_allocator_init_func_t user_mem_allocator_init;
     
     /**
-    * user memory allocation allocate descriptor
+    * Release all the descriptors allocated by the specified memory allocator.
+    * This is optional parameter
+    */
+    ucs_user_mem_allocator_cleanup_func_t user_mem_allocator_cleanup;
+
+    /**
+    * user memory allocator allocate descriptor
     */
     ucs_user_mem_allocator_malloc_func_t user_mem_allocator_malloc;
     
     /**
-    * user memory allocation free descriptor
+    * user memory allocator free descriptor
     */
     ucs_user_mem_allocator_free_func_t user_mem_allocator_free;
 } ucp_worker_params_t;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1214,17 +1214,17 @@ typedef struct ucp_worker_attr {
 *                             by this memory allocator instance.
 * @param [in]  data_offset    Data offset.
 *
-* @param [out] usr_allocator  Opaque object representing memory allocation instance implemented by the user
+* @param [out] arg  Opaque object representing memory allocation instance implemented by the user
 *
 * @return Error code as defined by @ref ucs_status_t
 */
-typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(size_t seg_size, size_t data_offset, void **usr_allocator);
+typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(size_t seg_size, size_t data_offset, void **arg);
 
 /**
 * @ingroup UCP_WORKER
 * @brief Get descriptor from user defined memory allocation instance 
 *
-* @param [in]   usr_allocator  Opaque object representing memory allocation instance implemented by the user
+* @param [in]   arg  Opaque object representing memory allocation instance implemented by the user
 * 
 * @param [out]  desc           Allocated descriptor.
 *
@@ -1232,7 +1232,19 @@ typedef ucs_status_t (*ucp_user_mem_allocator_init_func_t)(size_t seg_size, size
 *
 * @return Error code as defined by @ref ucs_status_t
 */
-typedef ucs_status_t (*ucp_user_get_descriptor_func_t)(void *usr_allocator, void** desc, ucp_mem_h *memh);
+typedef ucs_status_t (*ucp_user_mem_allocator_malloc_func_t)(void *arg, void** desc, ucp_mem_h *memh);
+
+/**
+* @ingroup UCP_WORKER
+* @brief Free descriptor allocated using user memory allocator
+*
+* @param [in]   arg  Opaque object representing memory allocation instance implemented by the user
+* 
+* @param [out]  desc           Allocated descriptor.
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucp_user_mem_allocator_free_func_t)(void *arg, void* desc);
 
 
 /**
@@ -1346,9 +1358,14 @@ typedef struct ucp_worker_params {
     ucp_user_mem_allocator_init_func_t user_mem_allocator_init;
     
     /**
-    * Get descriptor from user memory allocation instance
+    * user memory allocation allocate descriptor
     */
-    ucp_user_get_descriptor_func_t user_get_descriptor;
+    ucp_user_mem_allocator_malloc_func_t user_mem_allocator_malloc;
+    
+    /**
+    * user memory allocation free descriptor
+    */
+    ucp_user_mem_allocator_free_func_t user_mem_allocator_free;
 } ucp_worker_params_t;
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1082,6 +1082,59 @@ ucp_worker_get_sys_device_distance(ucp_context_h context,
     return UCS_ERR_NO_RESOURCE;
 }
 
+ucs_status_t dummyUserInitAllocator(size_t seg_size, void **usr_allocator) {
+    ucs_status_t status = UCS_OK;
+
+    // Call to user init allocator
+
+    return status;
+}
+
+ucs_status_t dummyUserGetDesc(void *usr_allocator, void** desc, ucp_mem_h *memh) {
+    // ucp_context_t context;
+    // ucp_mem_map_params_t params;
+    ucs_status_t status = UCS_OK;
+//     void *address;
+//     size_t length;
+
+//     //Determine the right length, maybe pass it to function?
+//     length = 1024;
+//     //use malloc for example to allocate descriptor
+//     address = ucs_malloc(length, "Dummy user allocation");
+//     if (address == NULL) {
+//         status = UCS_ERR_NO_MEMORY;
+//         goto err;
+//     }
+
+//     params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+//                         UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+//     params.address    = address;
+//     params.length     = length;
+//     status = ucp_mem_map(&context, &params, memh);
+
+// err:
+    return status;
+}
+
+int ucp_worker_init_usr_allocator(size_t seg_size, uct_usr_mem_allocator_h* usr_allocator) {
+    return UCS_OK;
+}
+
+int ucp_worker_get_desc_from_usr(unsigned md_index, uct_usr_mem_allocator_h usr_allocator, uct_usr_desc_h* desc, uct_mem_h *memh) {
+    
+    ucp_mem_h ucp_memh;
+    dummyUserGetDesc((void*) usr_allocator, (void**)desc, &ucp_memh);
+
+    // User function call for ucp_mem_map and return ucp_mem_h
+    // This function need to return the ucp_mem_h with lkey
+
+    // memh = dummyUserGetDesc();
+    //need to find lkey here
+    printf("Dummy get descriptor callback\n");
+
+    return UCS_OK;
+}
+
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    uct_iface_params_t *iface_params,
                                    ucp_worker_iface_t **wiface_p)
@@ -1136,13 +1189,17 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER       |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS |
-                                      UCT_IFACE_PARAM_FIELD_CPU_MASK;
+                                      UCT_IFACE_PARAM_FIELD_CPU_MASK          |
+                                      UCT_IFACE_PARAM_FIELD_USR_ALLOC;
     iface_params->stats_root        = UCS_STATS_RVAL(worker->stats);
     iface_params->rx_headroom       = UCP_WORKER_HEADROOM_SIZE;
     iface_params->err_handler_arg   = worker;
     iface_params->err_handler       = ucp_worker_iface_error_handler;
     iface_params->err_handler_flags = UCT_CB_FLAG_ASYNC;
     iface_params->cpu_mask          = worker->cpu_mask;
+    iface_params->user_allocator.md_index = 0;
+    iface_params->user_allocator.ops.init_usr_mem_allocator = ucp_worker_init_usr_allocator;
+    iface_params->user_allocator.ops.get_desc_from_usr_callback = ucp_worker_get_desc_from_usr;
 
     if (context->config.features & UCP_FEATURE_TAG) {
         iface_params->eager_arg     = iface_params->rndv_arg = wiface;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2211,13 +2211,11 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC) {
-        worker->user_allocator.active = 1;
         worker->user_allocator.ops.init = params->user_mem_allocator_init;
         worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
         worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
         worker->user_allocator.arg = NULL;
     } else {
-        worker->user_allocator.active = 0;
         worker->user_allocator.ops.init = NULL;
         worker->user_allocator.ops.malloc = NULL;
         worker->user_allocator.malloc_cb = NULL;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1136,8 +1136,7 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER       |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS |
-                                      UCT_IFACE_PARAM_FIELD_CPU_MASK          ;
-                                      
+                                      UCT_IFACE_PARAM_FIELD_CPU_MASK;
     iface_params->stats_root        = UCS_STATS_RVAL(worker->stats);
     iface_params->rx_headroom       = UCP_WORKER_HEADROOM_SIZE;
     iface_params->err_handler_arg   = worker;
@@ -2220,16 +2219,20 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
             status = UCS_ERR_INVALID_PARAM;
             goto err_free;
         }
-        
+
         worker->user_allocator.ops.init = params->user_mem_allocator_init;
+        worker->user_allocator.ops.cleanup = params->user_mem_allocator_cleanup;
         worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
+        worker->user_allocator.ops.free = params->user_mem_allocator_free;
         worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
         worker->user_allocator.arg = NULL;
 
     } else {
 
         worker->user_allocator.ops.init = NULL;
+        worker->user_allocator.ops.cleanup = NULL;
         worker->user_allocator.ops.malloc = NULL;
+        worker->user_allocator.ops.free = NULL;
         worker->user_allocator.malloc_cb = NULL;
         worker->user_allocator.arg = NULL;
     }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1255,8 +1255,8 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_ARG   |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER       |
                                       UCT_IFACE_PARAM_FIELD_ERR_HANDLER_FLAGS |
-                                      UCT_IFACE_PARAM_FIELD_CPU_MASK          |
-                                      UCT_IFACE_PARAM_FIELD_USR_ALLOC;
+                                      UCT_IFACE_PARAM_FIELD_CPU_MASK          ;
+                                    //   UCT_IFACE_PARAM_FIELD_USR_ALLOC;
     iface_params->stats_root        = UCS_STATS_RVAL(worker->stats);
     iface_params->rx_headroom       = UCP_WORKER_HEADROOM_SIZE;
     iface_params->err_handler_arg   = worker;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1082,117 +1082,6 @@ ucp_worker_get_sys_device_distance(ucp_context_h context,
     return UCS_ERR_NO_RESOURCE;
 }
 
-typedef struct mock_mem_allocator {
-    size_t seg_size;
-    size_t data_offset;
-} mock_mem_allocator_t;
-
-static mock_mem_allocator_t mock_mem_allocators[65] = {{0}};
-
-ucs_status_t mockUserInitAllocator(size_t seg_size, size_t data_offset, void **usr_allocator) {
-    ucs_status_t status = UCS_OK;
-    mock_mem_allocator_t *new_usr_allocator = NULL;
-    int i;
-
-    if (mock_mem_allocators[UCP_MD_INDEX_BITS].seg_size == 0) {
-        mock_mem_allocators[UCP_MD_INDEX_BITS].seg_size = 8256;
-    }
-
-    for (i = 0; i < UCP_MD_INDEX_BITS; ++i) {
-        
-        if (mock_mem_allocators[i].seg_size == 0) {
-            break;
-        }
-
-        if (mock_mem_allocators[i].seg_size == seg_size) {
-            new_usr_allocator = &mock_mem_allocators[i];
-            break;
-        }
-    }
-
-    if (new_usr_allocator != NULL) {
-        
-        *usr_allocator = new_usr_allocator;
-
-    } else if (i > UCP_MD_INDEX_BITS) {
-        
-        printf("Error: Need more mem allocators\n");
-        *usr_allocator = &mock_mem_allocators[UCP_MD_INDEX_BITS];
-
-    } else {
-        
-        mock_mem_allocators[i].seg_size = seg_size;
-        *usr_allocator = &mock_mem_allocators[i];
-    }
-
-    return status;
-}
-
-static ucp_context_h usr_allocator_context = NULL;
-
-ucs_status_t mockUserGetDesc(void *usr_allocator, void** desc, ucp_mem_h *memh) {
-    ucp_mem_map_params_t params;
-    ucs_status_t status = UCS_OK;
-    void *address;
-    ucp_mem_h p;
-    size_t seg_size;
-
-    seg_size = ((mock_mem_allocator_t*)usr_allocator)->seg_size;
-    //use malloc for example to allocate descriptor
-    address = ucs_malloc(seg_size, "Mock user allocation");
-    if (address == NULL) {
-        status = UCS_ERR_NO_MEMORY;
-        return status;
-    }
-    memset(address, 0, 8);
-    
-    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    params.address    = address;
-    params.length     = seg_size;
-    status = ucp_mem_map(usr_allocator_context, &params, memh);
-    p = *memh;
-    *desc = p->address;
-
-    return status;
-}
-
-static ucs_status_t ucp_worker_get_desc_from_usr_cb(void* ucp_memh_p, unsigned md_index, uct_mem_h *memh) {
-    ucs_status_t status = UCS_OK;
-    static unsigned uct_memh_idx_mem[UCP_MD_INDEX_BITS] = {0};
-    unsigned md_bit_idx;
-    ucp_md_map_t md_map_p;
-    unsigned uct_memh_idx = 0;
-    ucp_mem_h ucp_memh = ucp_memh_p;
-
-    if (md_index >= UCP_MD_INDEX_BITS) {
-        status = UCS_ERR_NO_DEVICE;
-        return status;
-    }
-
-    md_map_p = ucp_memh->md_map;
-    if (!(md_map_p & UCS_BIT(md_index))) {
-        status = UCS_ERR_NO_RESOURCE;
-        return status;
-    }
-
-    if (!uct_memh_idx_mem[md_index]) {
-
-        ucs_for_each_bit(md_bit_idx, md_map_p) {
-            if (md_bit_idx == md_index) {
-                break;
-            }
-            ++uct_memh_idx;
-        }
-
-        uct_memh_idx_mem[md_index] = uct_memh_idx + 1;
-    }
-
-    *memh = ucp_memh->uct[uct_memh_idx_mem[md_index] - 1];
-
-    return status;  
-}
-
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
                                    uct_iface_params_t *iface_params,
                                    ucp_worker_iface_t **wiface_p)
@@ -2220,7 +2109,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
         return UCS_ERR_NO_MEMORY;
     }
 
-    usr_allocator_context = context;
     worker->context              = context;
     worker->uuid                 = ucs_generate_uuid((uintptr_t)worker);
     worker->flush_ops_count      = 0;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2211,15 +2211,27 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     }
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC) {
+
+        if (params->user_mem_allocator_init == NULL ||
+            params->user_mem_allocator_malloc == NULL ||
+            params->user_mem_allocator_free == NULL) {
+
+            ucs_error("Missing user allocator params");
+            status = UCS_ERR_INVALID_PARAM;
+            goto err_free;
+        }
+        
         worker->user_allocator.ops.init = params->user_mem_allocator_init;
         worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
         worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
         worker->user_allocator.arg = NULL;
+
     } else {
+
         worker->user_allocator.ops.init = NULL;
         worker->user_allocator.ops.malloc = NULL;
         worker->user_allocator.malloc_cb = NULL;
-        worker->user_allocator.arg = NULL;  
+        worker->user_allocator.arg = NULL;
     }
 
     worker->user_data    = UCP_PARAM_VALUE(WORKER, params, user_data, USER_DATA,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2212,8 +2212,8 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     if (params->field_mask & UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC) {
         worker->user_allocator.active = 1;
-        worker->user_allocator.ops.init = (uct_iface_user_allocator_init_func_t)params->user_mem_allocator_init;
-        worker->user_allocator.ops.malloc = (uct_iface_user_allocator_malloc_func_t)params->user_mem_allocator_malloc;
+        worker->user_allocator.ops.init = params->user_mem_allocator_init;
+        worker->user_allocator.ops.malloc = params->user_mem_allocator_malloc;
         worker->user_allocator.malloc_cb = ucp_worker_usr_allocator_malloc_cb;
         worker->user_allocator.arg = NULL;
     } else {

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -349,6 +349,8 @@ typedef struct ucp_worker {
         /* Number of failed endpoints */
         uint64_t                     ep_failures;
     } counters;
+
+    user_allocator_props_t user_allocator;
 } ucp_worker_t;
 
 

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -350,7 +350,7 @@ typedef struct ucp_worker {
         uint64_t                     ep_failures;
     } counters;
 
-    user_allocator_props_t user_allocator;
+    uct_user_allocator_props_t user_allocator;
 } ucp_worker_t;
 
 

--- a/src/ucs/memory/user_mem_allocator.h
+++ b/src/ucs/memory/user_mem_allocator.h
@@ -1,0 +1,71 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+* Copyright (C) The University of Tennessee and The University 
+*               of Tennessee Research Foundation. 2015. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_USER_MEM_ALLOCATOR_H
+#define UCS_USER_MEM_ALLOCATOR_H
+
+#include <ucs/type/status.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+  * @ingroup UCS_RESOURCE
+ * @brief User Memory allocator initialization params.
+ *
+ * The structure defines the configuration of
+ * the needed memory allocator.
+ */
+typedef struct ucs_user_mem_allocator_params {
+    uint64_t field_mask;
+    size_t seg_size;
+    size_t data_offset;
+} ucs_user_mem_allocator_params_t;
+
+
+/**
+* @ingroup UCS_RESOURCE
+* @brief User defined memory allocation instance constructor. 
+*
+* @param [in]  params  Memory allocator configuration.
+*
+* @param [out]  arg    Opaque object representing memory allocation instance implemented by the user
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_init_func_t)(const ucs_user_mem_allocator_params_t* params, void** arg);
+
+
+/**
+* @ingroup UCS_RESOURCE
+* @brief Free descriptor allocated using user memory allocator
+*
+* @param [in]   arg   Opaque object representing memory allocation instance implemented by the user
+* 
+* @param [out]  desc  Allocated descriptor.
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_free_func_t)(void* arg, void *desc);
+
+
+/**
+* @ingroup UCS_RESOURCE
+* @brief Get descriptor from user defined memory allocation instance 
+*
+* @param [in]   arg       Opaque object representing memory allocation instance implemented by the user
+* 
+* @param [out]  desc      Allocated descriptor.
+*
+* @param [out]  ucp_memh  UCP Memory handle 
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_malloc_func_t)(void* arg, void **desc, void **ucp_memh);
+
+#endif

--- a/src/ucs/memory/user_mem_allocator.h
+++ b/src/ucs/memory/user_mem_allocator.h
@@ -43,11 +43,20 @@ typedef ucs_status_t (*ucs_user_mem_allocator_init_func_t)(const ucs_user_mem_al
 
 /**
 * @ingroup UCS_RESOURCE
+* @brief Cleanup the User defined memory allocation instance.
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*ucs_user_mem_allocator_cleanup_func_t)(void* arg);
+
+
+/**
+* @ingroup UCS_RESOURCE
 * @brief Free descriptor allocated using user memory allocator
 *
-* @param [in]   arg   Opaque object representing memory allocation instance implemented by the user
-* 
-* @param [out]  desc  Allocated descriptor.
+* @param [in]   arg  Opaque object representing memory allocation instance implemented by the user
+*
+* @param [in]  desc  Descriptor to free.
 *
 * @return Error code as defined by @ref ucs_status_t
 */

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1128,7 +1128,7 @@ struct uct_iface_params {
     size_t                                       am_align_offset;
 
     /*User defined memory allocator interface props*/
-    user_allocator_props_t user_allocator;
+    uct_user_allocator_props_t user_allocator;
 };
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -655,7 +655,6 @@ enum uct_iface_params_field {
 
     /** Enables @ref uct_iface_params_t::am_align_offset */
     UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17)
-
 };
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -654,10 +654,8 @@ enum uct_iface_params_field {
     UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT       = UCS_BIT(16),
 
     /** Enables @ref uct_iface_params_t::am_align_offset */
-    UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17),
-    
-    /** Enables @ref uct_iface_params_t::user_allocator */
-    UCT_IFACE_PARAM_FIELD_USR_ALLOC     = UCS_BIT(18)
+    UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17)
+
 };
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -654,7 +654,10 @@ enum uct_iface_params_field {
     UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT       = UCS_BIT(16),
 
     /** Enables @ref uct_iface_params_t::am_align_offset */
-    UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17)
+    UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17),
+    
+    /** Enables @ref uct_iface_params_t::user_allocator */
+    UCT_IFACE_PARAM_FIELD_USR_ALLOC     = UCS_BIT(18)
 };
 
 /**
@@ -1125,6 +1128,9 @@ struct uct_iface_params {
      * +-------------------+
      */
     size_t                                       am_align_offset;
+
+    /*User defined memory allocator interface props*/
+    user_allocator_props_t user_allocator;
 };
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -923,6 +923,8 @@ typedef struct uct_user_allocator_props {
     struct {
         /*Init user defined memory allocator*/
         ucs_user_mem_allocator_init_func_t init;
+        /*Release all the descriptors allocated by the specified memory allocator*/
+        user_mem_allocator_cleanup cleanup;
         /*Free memory descriptor*/
         ucs_user_mem_allocator_free_func_t free;   
         /*Get memory descriptor from user*/

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -902,18 +902,9 @@ typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
  */
 typedef struct uct_usr_mem_allocator *uct_usr_mem_allocator_h;
 
+typedef ucs_status_t (*uct_iface_init_usr_allocator_func_t)(size_t seg_size, size_t data_offset, uct_usr_mem_allocator_h* usr_allocator);
 
-/**
- * @ingroup UCT_RESOURCE
- * @brief User allocated descriptor
- *
- * Opaque object representing memory allocation instance implmented by the suer
- */
-typedef struct uct_usr_desc *uct_usr_desc_h;
-
-typedef int (*uct_iface_init_usr_allocator_func_t)(size_t seg_size, uct_usr_mem_allocator_h* usr_allocator);
-
-typedef int (*uct_iface_get_desc_from_usr_func_t)(unsigned md_index, uct_usr_mem_allocator_h usr_allocator, uct_usr_desc_h *desc, uct_mem_h *memh);
+typedef ucs_status_t (*uct_iface_get_desc_from_usr_func_t)(unsigned md_index, uct_usr_mem_allocator_h usr_allocator, void **desc, uct_mem_h *memh);
 
 /**
  * @ingroup UCT_RESOURCE
@@ -921,6 +912,7 @@ typedef int (*uct_iface_get_desc_from_usr_func_t)(unsigned md_index, uct_usr_mem
  */
 typedef struct user_allocator_props {
     unsigned md_index;
+    uct_usr_mem_allocator_h usr_allocator;
     struct {
         /*Init user defined memory allocator*/
         uct_iface_init_usr_allocator_func_t init_usr_mem_allocator;   

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -894,5 +894,40 @@ typedef ucs_status_t (*uct_tag_unexp_rndv_cb_t)(void *arg, unsigned flags,
  */
 typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
 
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief User allocation indentifier 
+ *
+ * Opaque object representing memory allocation instance implmented by the suer
+ */
+typedef struct uct_usr_mem_allocator *uct_usr_mem_allocator_h;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief User allocated descriptor
+ *
+ * Opaque object representing memory allocation instance implmented by the suer
+ */
+typedef struct uct_usr_desc *uct_usr_desc_h;
+
+typedef int (*uct_iface_init_usr_allocator_func_t)(size_t seg_size, uct_usr_mem_allocator_h* usr_allocator);
+
+typedef int (*uct_iface_get_desc_from_usr_func_t)(unsigned md_index, uct_usr_mem_allocator_h usr_allocator, uct_usr_desc_h *desc, uct_mem_h *memh);
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Interface for allocating descriptors based on user defined implementation 
+ */
+typedef struct user_allocator_props {
+    unsigned md_index;
+    struct {
+        /*Init user defined memory allocator*/
+        uct_iface_init_usr_allocator_func_t init_usr_mem_allocator;   
+        /*Get memory descriptor from user*/
+        uct_iface_get_desc_from_usr_func_t  get_desc_from_usr_callback;   
+    } ops;
+} user_allocator_props_t;
+
 
 #endif

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -904,7 +904,8 @@ typedef struct uct_usr_mem_allocator *uct_usr_mem_allocator_h;
 
 typedef ucs_status_t (*uct_iface_init_usr_allocator_func_t)(size_t seg_size, size_t data_offset, uct_usr_mem_allocator_h* usr_allocator);
 
-typedef ucs_status_t (*uct_iface_get_desc_from_usr_func_t)(unsigned md_index, uct_usr_mem_allocator_h usr_allocator, void **desc, uct_mem_h *memh);
+typedef ucs_status_t (*uct_iface_get_desc_from_usr_func_t)(uct_usr_mem_allocator_h usr_allocator, void **desc, void **ucp_memh);
+typedef ucs_status_t (*uct_iface_get_desc_from_usr_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);
 
 /**
  * @ingroup UCT_RESOURCE
@@ -914,11 +915,12 @@ typedef struct user_allocator_props {
     int active;
     unsigned md_index;
     uct_usr_mem_allocator_h usr_allocator;
+    uct_iface_get_desc_from_usr_cb_func_t get_desc_from_usr_cb;
     struct {
         /*Init user defined memory allocator*/
         uct_iface_init_usr_allocator_func_t init_usr_mem_allocator;   
         /*Get memory descriptor from user*/
-        uct_iface_get_desc_from_usr_func_t  get_desc_from_usr_callback;   
+        uct_iface_get_desc_from_usr_func_t  get_desc_from_usr;   
     } ops;
 } user_allocator_props_t;
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -924,7 +924,7 @@ typedef struct uct_user_allocator_props {
         /*Init user defined memory allocator*/
         ucs_user_mem_allocator_init_func_t init;
         /*Release all the descriptors allocated by the specified memory allocator*/
-        user_mem_allocator_cleanup cleanup;
+        ucs_user_mem_allocator_cleanup_func_t cleanup;
         /*Free memory descriptor*/
         ucs_user_mem_allocator_free_func_t free;   
         /*Get memory descriptor from user*/

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -900,12 +900,12 @@ typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
  *
  * Opaque object representing memory allocation instance implemented by the suer
  */
-typedef struct uct_usr_mem_allocator *uct_usr_mem_allocator_h;
 
-typedef ucs_status_t (*uct_iface_init_usr_allocator_func_t)(size_t seg_size, size_t data_offset, uct_usr_mem_allocator_h* usr_allocator);
 
-typedef ucs_status_t (*uct_iface_get_desc_from_usr_func_t)(uct_usr_mem_allocator_h usr_allocator, void **desc, void **ucp_memh);
-typedef ucs_status_t (*uct_iface_get_desc_from_usr_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);
+typedef ucs_status_t (*uct_iface_user_allocator_init_func_t)(size_t seg_size, size_t data_offset, void** arg);
+typedef ucs_status_t (*uct_iface_user_allocator_free_func_t)(void* arg, void *desc);
+typedef ucs_status_t (*uct_iface_user_allocator_malloc_func_t)(void* arg, void **desc, void **ucp_memh);
+typedef ucs_status_t (*uct_iface_user_allocator_malloc_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);
 
 /**
  * @ingroup UCT_RESOURCE
@@ -914,15 +914,17 @@ typedef ucs_status_t (*uct_iface_get_desc_from_usr_cb_func_t)(void* ucp_memh, un
 typedef struct user_allocator_props {
     int active;
     unsigned md_index;
-    uct_usr_mem_allocator_h usr_allocator;
-    uct_iface_get_desc_from_usr_cb_func_t get_desc_from_usr_cb;
+    void* arg;
+    uct_iface_user_allocator_malloc_cb_func_t malloc_cb;
     struct {
         /*Init user defined memory allocator*/
-        uct_iface_init_usr_allocator_func_t init_usr_mem_allocator;   
+        uct_iface_user_allocator_init_func_t init;
+        /*Free memory descriptor*/
+        uct_iface_user_allocator_free_func_t free;   
         /*Get memory descriptor from user*/
-        uct_iface_get_desc_from_usr_func_t  get_desc_from_usr;   
+        uct_iface_user_allocator_malloc_func_t  malloc;   
     } ops;
-} user_allocator_props_t;
+} uct_user_allocator_props_t;
 
 
 #endif

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -898,7 +898,7 @@ typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
  * @ingroup UCT_RESOURCE
  * @brief User allocation indentifier 
  *
- * Opaque object representing memory allocation instance implmented by the suer
+ * Opaque object representing memory allocation instance implemented by the suer
  */
 typedef struct uct_usr_mem_allocator *uct_usr_mem_allocator_h;
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -9,6 +9,7 @@
 
 #include <ucs/config/types.h>
 #include <ucs/type/status.h>
+#include <ucs/memory/user_mem_allocator.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -894,42 +895,40 @@ typedef ucs_status_t (*uct_tag_unexp_rndv_cb_t)(void *arg, unsigned flags,
  */
 typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
 
-/**
- * @ingroup UCT_RESOURCE
- * @brief User allocation indentifier 
- *
- * The structure defines the configuration of
- * the needed memory allocator.
- */
-typedef struct uct_user_mem_allocator_params {
-    uint64_t field_mask;
-    size_t seg_size;
-    size_t data_offset;
-} uct_user_mem_allocator_params_t;
 
-typedef ucs_status_t (*uct_iface_user_allocator_init_func_t)(const uct_user_mem_allocator_params_t* params, void** arg);
-typedef ucs_status_t (*uct_iface_user_allocator_free_func_t)(void* arg, void *desc);
-typedef ucs_status_t (*uct_iface_user_allocator_malloc_func_t)(void* arg, void **desc, void **ucp_memh);
-typedef ucs_status_t (*uct_iface_user_allocator_malloc_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);
+/**
+* @ingroup UCT_RESOURCE
+* @brief Callback function called after allocating descriptor using user memory allocator,
+         returns uct memory handle from the ucp memory handle.
+*
+* @param [in]   arg       Opaque object representing memory allocation instance implemented by the user
+* 
+* @param [out]  desc      Allocated descriptor.
+*
+* @param [out]  ucp_memh  UCP Memory handle 
+*
+* @return Error code as defined by @ref ucs_status_t
+*/
+typedef ucs_status_t (*uct_user_allocator_malloc_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);
+
 
 /**
  * @ingroup UCT_RESOURCE
  * @brief Interface for allocating descriptors based on user defined implementation 
  */
-typedef struct user_allocator_props {
+typedef struct uct_user_allocator_props {
     int active;
     unsigned md_index;
     void* arg;
-    uct_iface_user_allocator_malloc_cb_func_t malloc_cb;
+    uct_user_allocator_malloc_cb_func_t malloc_cb;
     struct {
         /*Init user defined memory allocator*/
-        uct_iface_user_allocator_init_func_t init;
+        ucs_user_mem_allocator_init_func_t init;
         /*Free memory descriptor*/
-        uct_iface_user_allocator_free_func_t free;   
+        ucs_user_mem_allocator_free_func_t free;   
         /*Get memory descriptor from user*/
-        uct_iface_user_allocator_malloc_func_t  malloc;   
+        ucs_user_mem_allocator_malloc_func_t  malloc;   
     } ops;
 } uct_user_allocator_props_t;
-
 
 #endif

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -898,11 +898,16 @@ typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
  * @ingroup UCT_RESOURCE
  * @brief User allocation indentifier 
  *
- * Opaque object representing memory allocation instance implemented by the suer
+ * The structure defines the configuration of
+ * the needed memory allocator.
  */
+typedef struct uct_user_mem_allocator_params {
+    uint64_t field_mask;
+    size_t seg_size;
+    size_t data_offset;
+} uct_user_mem_allocator_params_t;
 
-
-typedef ucs_status_t (*uct_iface_user_allocator_init_func_t)(size_t seg_size, size_t data_offset, void** arg);
+typedef ucs_status_t (*uct_iface_user_allocator_init_func_t)(const uct_user_mem_allocator_params_t* params, void** arg);
 typedef ucs_status_t (*uct_iface_user_allocator_free_func_t)(void* arg, void *desc);
 typedef ucs_status_t (*uct_iface_user_allocator_malloc_func_t)(void* arg, void **desc, void **ucp_memh);
 typedef ucs_status_t (*uct_iface_user_allocator_malloc_cb_func_t)(void* ucp_memh, unsigned md_index, uct_mem_h *memh);

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -917,7 +917,6 @@ typedef ucs_status_t (*uct_user_allocator_malloc_cb_func_t)(void* ucp_memh, unsi
  * @brief Interface for allocating descriptors based on user defined implementation 
  */
 typedef struct uct_user_allocator_props {
-    int active;
     unsigned md_index;
     void* arg;
     uct_user_allocator_malloc_cb_func_t malloc_cb;

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -911,6 +911,7 @@ typedef ucs_status_t (*uct_iface_get_desc_from_usr_func_t)(unsigned md_index, uc
  * @brief Interface for allocating descriptors based on user defined implementation 
  */
 typedef struct user_allocator_props {
+    int active;
     unsigned md_index;
     uct_usr_mem_allocator_h usr_allocator;
     struct {

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -460,7 +460,7 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 
 static ucs_status_t uct_base_iface_set_usr_alloc_params(const uct_iface_params_t *params, uct_base_iface_t *iface) {
 
-    memcpy(&iface->user_allocator, &params->user_allocator, sizeof(user_allocator_props_t));
+    memcpy(&iface->user_allocator, &params->user_allocator, sizeof(uct_user_allocator_props_t));
     
     return UCS_OK;
 }

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -461,7 +461,7 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 static ucs_status_t uct_base_iface_set_usr_alloc_params(const uct_iface_params_t *params, uct_base_iface_t *iface) {
 
     memcpy(&iface->user_allocator, &params->user_allocator, sizeof(uct_user_allocator_props_t));
-    
+
     return UCS_OK;
 }
 
@@ -486,7 +486,7 @@ UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
     ucs_assert_always(ops->iface_query              != NULL);
     ucs_assert_always(ops->iface_get_device_address != NULL);
     ucs_assert_always(ops->iface_is_reachable       != NULL);
-    // ucs_log_print_backtrace(UCS_LOG_LEVEL_WARN);
+
     self->ops = *ops;
     return UCS_OK;
 }

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -460,8 +460,15 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 
 static ucs_status_t uct_base_iface_set_usr_alloc_params(const uct_iface_params_t *params, uct_base_iface_t *iface) {
     
+    //Default initialization 
+    iface->user_allocator.active = 0;
+    iface->user_allocator.usr_allocator = NULL;
+    iface->user_allocator.md_index = 0; //TODO - set proper default val
+    iface->user_allocator.ops.init_usr_mem_allocator = NULL; //TODO - set proper default val
+    iface->user_allocator.ops.get_desc_from_usr_callback = NULL; //TODO - set proper default val
+    
     if ((params->field_mask & UCT_IFACE_PARAM_FIELD_USR_ALLOC)) {
-        
+
         iface->user_allocator.md_index = params->user_allocator.md_index;
 
         if (params->user_allocator.ops.init_usr_mem_allocator == NULL) {
@@ -474,12 +481,7 @@ static ucs_status_t uct_base_iface_set_usr_alloc_params(const uct_iface_params_t
 
         iface->user_allocator.ops.init_usr_mem_allocator = params->user_allocator.ops.init_usr_mem_allocator;
         iface->user_allocator.ops.get_desc_from_usr_callback = params->user_allocator.ops.get_desc_from_usr_callback;
-
-    } else {
-
-        iface->user_allocator.md_index = 0; //TODO - set proper default val
-        iface->user_allocator.ops.init_usr_mem_allocator = NULL; //TODO - set proper default val
-        iface->user_allocator.ops.get_desc_from_usr_callback = NULL; //TODO - set proper default val
+        iface->user_allocator.active = 1;
     }
 
     return UCS_OK;

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -459,31 +459,9 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 }
 
 static ucs_status_t uct_base_iface_set_usr_alloc_params(const uct_iface_params_t *params, uct_base_iface_t *iface) {
+
+    memcpy(&iface->user_allocator, &params->user_allocator, sizeof(user_allocator_props_t));
     
-    //Default initialization 
-    iface->user_allocator.active = 0;
-    iface->user_allocator.usr_allocator = NULL;
-    iface->user_allocator.md_index = 0; //TODO - set proper default val
-    iface->user_allocator.ops.init_usr_mem_allocator = NULL; //TODO - set proper default val
-    iface->user_allocator.ops.get_desc_from_usr_callback = NULL; //TODO - set proper default val
-    
-    if ((params->field_mask & UCT_IFACE_PARAM_FIELD_USR_ALLOC)) {
-
-        iface->user_allocator.md_index = params->user_allocator.md_index;
-
-        if (params->user_allocator.ops.init_usr_mem_allocator == NULL) {
-            return UCS_ERR_INVALID_PARAM;
-        }
-
-        if (params->user_allocator.ops.get_desc_from_usr_callback == NULL) {
-            return UCS_ERR_INVALID_PARAM;
-        }
-
-        iface->user_allocator.ops.init_usr_mem_allocator = params->user_allocator.ops.init_usr_mem_allocator;
-        iface->user_allocator.ops.get_desc_from_usr_callback = params->user_allocator.ops.get_desc_from_usr_callback;
-        iface->user_allocator.active = 1;
-    }
-
     return UCS_OK;
 }
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -278,7 +278,7 @@ typedef struct uct_base_iface {
         size_t               max_num_eps;
     } config;
 
-    user_allocator_props_t user_allocator;
+    uct_user_allocator_props_t user_allocator;
 
     UCS_STATS_NODE_DECLARE(stats)            /* Statistics */
 } uct_base_iface_t;
@@ -460,12 +460,12 @@ typedef struct uct_iface_mpool_config {
 
 
 #define UCT_TL_EXPAND_USR_MEM_ALLOCATOR(_user_allocator_props) \
-    user_allocator_props_t *user_allocator_props = _user_allocator_props; \
+    uct_user_allocator_props_t *user_allocator_props = _user_allocator_props; \
     uct_mem_h user_allocator_memh; \
     void *ucp_memh = NULL; \
-    uct_iface_get_desc_from_usr_cb_func_t get_desc_from_user_allocator_cb = user_allocator_props->get_desc_from_usr_cb; \
-    uct_iface_get_desc_from_usr_func_t get_desc_from_user_allocator = user_allocator_props->ops.get_desc_from_usr; \
-    uct_usr_mem_allocator_h user_allocator_instance = user_allocator_props->usr_allocator; \
+    uct_iface_user_allocator_malloc_cb_func_t get_desc_from_user_allocator_cb = user_allocator_props->malloc_cb; \
+    uct_iface_user_allocator_malloc_func_t get_desc_from_user_allocator = user_allocator_props->ops.malloc; \
+    void* user_allocator_instance = user_allocator_props->arg; \
     unsigned user_allocator_md_index = user_allocator_props->md_index; \
     int user_allocator_active = user_allocator_props->active;
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -465,7 +465,7 @@ typedef struct uct_iface_mpool_config {
     uct_iface_get_desc_from_usr_func_t user_allocator_get_desc_from_usr = user_allocator_props->ops.get_desc_from_usr_callback; \
     uct_usr_mem_allocator_h user_allocator_instance = user_allocator_props->usr_allocator; \
     unsigned user_allocator_md_index = user_allocator_props->md_index; \
-    int user_allocator_exists = (user_allocator_instance != NULL);
+    int user_allocator_active = user_allocator_props->active;
 
 
 #define UCT_TL_IFACE_GET_RX_DESC_FROM_USER(_get_desc_from_usr, _usr_allocator, md_index, _desc, _memh, _failure) \

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -467,7 +467,7 @@ typedef struct uct_iface_mpool_config {
     ucs_user_mem_allocator_malloc_func_t get_desc_from_user_allocator = user_allocator_props->ops.malloc; \
     void* user_allocator_instance = user_allocator_props->arg; \
     unsigned user_allocator_md_index = user_allocator_props->md_index; \
-    int user_allocator_active = user_allocator_props->active;
+    int user_allocator_active = (get_desc_from_user_allocator != NULL);
 
 
 #define UCT_TL_IFACE_GET_RX_DESC_FROM_USER(_get_desc_from_usr_cb, _get_desc_from_usr, _usr_allocator, _md_index, _desc, _uct_memh, _failure) \

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -463,8 +463,8 @@ typedef struct uct_iface_mpool_config {
     uct_user_allocator_props_t *user_allocator_props = _user_allocator_props; \
     uct_mem_h user_allocator_memh; \
     void *ucp_memh = NULL; \
-    uct_iface_user_allocator_malloc_cb_func_t get_desc_from_user_allocator_cb = user_allocator_props->malloc_cb; \
-    uct_iface_user_allocator_malloc_func_t get_desc_from_user_allocator = user_allocator_props->ops.malloc; \
+    uct_user_allocator_malloc_cb_func_t get_desc_from_user_allocator_cb = user_allocator_props->malloc_cb; \
+    ucs_user_mem_allocator_malloc_func_t get_desc_from_user_allocator = user_allocator_props->ops.malloc; \
     void* user_allocator_instance = user_allocator_props->arg; \
     unsigned user_allocator_md_index = user_allocator_props->md_index; \
     int user_allocator_active = user_allocator_props->active;

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -278,6 +278,8 @@ typedef struct uct_base_iface {
         size_t               max_num_eps;
     } config;
 
+    user_allocator_props_t user_allocator;
+
     UCS_STATS_NODE_DECLARE(stats)            /* Statistics */
 } uct_base_iface_t;
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -261,8 +261,8 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
         return status;
     }
 
-    if (iface->super.user_allocator.ops.init_usr_mem_allocator) {
-        
+    if (iface->super.user_allocator.active) {
+
         return iface->super.user_allocator.ops.init_usr_mem_allocator(iface->config.seg_size, sizeof(uct_ib_iface_recv_desc_t), &iface->super.user_allocator.usr_allocator);
 
     } else {
@@ -1527,7 +1527,7 @@ int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
     count = 0;
     while (count < n) {
 
-        if (user_allocator_exists) {
+        if (user_allocator_active) {
             UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
         } else {
             UCT_TL_IFACE_GET_RX_DESC(&iface->super, mp, desc, break);

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1528,7 +1528,7 @@ int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
     while (count < n) {
 
         if (user_allocator_active) {
-            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
+            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(get_desc_from_user_allocator_cb, get_desc_from_user_allocator, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
         } else {
             UCT_TL_IFACE_GET_RX_DESC(&iface->super, mp, desc, break);
         }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1515,6 +1515,15 @@ int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
 {
     uct_ib_iface_recv_desc_t *desc;
     unsigned count;
+    unsigned md_index = 0;
+    uct_usr_mem_allocator_h usr_allocator = NULL;
+    uct_usr_desc_h usr_desc = NULL;
+    uct_mem_h memh = NULL;
+    uct_iface_get_desc_from_usr_func_t ucp_get_rx_desc_callback = iface->super.user_allocator.ops.get_desc_from_usr_callback;
+    
+    if (ucp_get_rx_desc_callback) {
+        ucp_get_rx_desc_callback(md_index, usr_allocator, &usr_desc, &memh);
+    }
 
     count = 0;
     while (count < n) {

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -239,7 +239,7 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
     size_t align_offset, alignment;
     ucs_status_t status;
     unsigned grow;
-    uct_user_mem_allocator_params_t mem_allocator_params;
+    ucs_user_mem_allocator_params_t mem_allocator_params;
 
     if (config->rx.queue_len < 1024) {
         grow = 1024;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -262,7 +262,7 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
         return status;
     }
 
-    if (iface->super.user_allocator.active) {
+    if (iface->super.user_allocator.ops.init) {
         
         mem_allocator_params.seg_size = iface->config.seg_size;
         mem_allocator_params.data_offset = sizeof(uct_ib_iface_recv_desc_t);

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -263,7 +263,7 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
 
     if (iface->super.user_allocator.active) {
 
-        return iface->super.user_allocator.ops.init_usr_mem_allocator(iface->config.seg_size, sizeof(uct_ib_iface_recv_desc_t), &iface->super.user_allocator.usr_allocator);
+        return iface->super.user_allocator.ops.init(iface->config.seg_size, sizeof(uct_ib_iface_recv_desc_t), &iface->super.user_allocator.arg);
 
     } else {
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -239,6 +239,7 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
     size_t align_offset, alignment;
     ucs_status_t status;
     unsigned grow;
+    uct_user_mem_allocator_params_t mem_allocator_params;
 
     if (config->rx.queue_len < 1024) {
         grow = 1024;
@@ -262,8 +263,10 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
     }
 
     if (iface->super.user_allocator.active) {
-
-        return iface->super.user_allocator.ops.init(iface->config.seg_size, sizeof(uct_ib_iface_recv_desc_t), &iface->super.user_allocator.arg);
+        
+        mem_allocator_params.seg_size = iface->config.seg_size;
+        mem_allocator_params.data_offset = sizeof(uct_ib_iface_recv_desc_t);
+        return iface->super.user_allocator.ops.init(&mem_allocator_params, &iface->super.user_allocator.arg);
 
     } else {
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -365,7 +365,7 @@ uct_ib_iface_invoke_am_desc(uct_ib_iface_t *iface, uint8_t am_id, void *data,
     status = uct_iface_invoke_am(&iface->super, am_id, data, length,
                                  UCT_CB_PARAM_FLAG_DESC);
     if (status == UCS_OK) {
-        if (!iface->super.user_allocator.active) {
+        if (!iface->super.user_allocator.ops.malloc) {
             ucs_mpool_put_inline(ib_desc);
         }
     } else {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -365,7 +365,9 @@ uct_ib_iface_invoke_am_desc(uct_ib_iface_t *iface, uint8_t am_id, void *data,
     status = uct_iface_invoke_am(&iface->super, am_id, data, length,
                                  UCT_CB_PARAM_FLAG_DESC);
     if (status == UCS_OK) {
-        ucs_mpool_put_inline(ib_desc);
+        if (!iface->super.user_allocator.active) {
+            ucs_mpool_put_inline(ib_desc);
+        }
     } else {
         uct_recv_desc(desc) = &iface->release_desc;
     }

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -98,7 +98,7 @@ uct_rc_mlx5_iface_srq_set_seg(uct_rc_mlx5_iface_common_t *iface,
     desc_map = ~seg->srq.ptr_mask & UCS_MASK(iface->tm.mp.num_strides);
     ucs_for_each_bit(i, desc_map) {
         if (user_allocator_active) {
-            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
+            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(get_desc_from_user_allocator_cb, get_desc_from_user_allocator, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
         } else {
             UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
                                      desc, return UCS_ERR_NO_MEMORY);

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -97,7 +97,7 @@ uct_rc_mlx5_iface_srq_set_seg(uct_rc_mlx5_iface_common_t *iface,
 
     desc_map = ~seg->srq.ptr_mask & UCS_MASK(iface->tm.mp.num_strides);
     ucs_for_each_bit(i, desc_map) {
-        if (user_allocator_exists) {
+        if (user_allocator_active) {
             UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
         } else {
             UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -682,7 +682,9 @@ err_cleanup_tx_ops:
 err_destroy_tx_mp:
     ucs_mpool_cleanup(&self->tx.mp, 1);
 err_destroy_rx_mp:
-    ucs_mpool_cleanup(&self->rx.mp, 1);
+    if (!self->super.super.user_allocator.active) {
+        ucs_mpool_cleanup(&self->rx.mp, 1);
+    }
 err:
     return status;
 }
@@ -743,7 +745,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_iface_t)
     ops->cleanup_rx(self);
     uct_rc_iface_tx_ops_cleanup(self);
     ucs_mpool_cleanup(&self->tx.mp, 1);
-    ucs_mpool_cleanup(&self->rx.mp, 0); /* Cannot flush SRQ */
+    if (!self->super.super.user_allocator.active) {
+        ucs_mpool_cleanup(&self->rx.mp, 0); /* Cannot flush SRQ */
+    }
     ucs_mpool_cleanup(&self->tx.pending_mp, 1);
 }
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -682,7 +682,7 @@ err_cleanup_tx_ops:
 err_destroy_tx_mp:
     ucs_mpool_cleanup(&self->tx.mp, 1);
 err_destroy_rx_mp:
-    if (!self->super.super.user_allocator.active) {
+    if (!self->super.super.user_allocator.ops.malloc) {
         ucs_mpool_cleanup(&self->rx.mp, 1);
     }
 err:
@@ -745,7 +745,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_iface_t)
     ops->cleanup_rx(self);
     uct_rc_iface_tx_ops_cleanup(self);
     ucs_mpool_cleanup(&self->tx.mp, 1);
-    if (!self->super.super.user_allocator.active) {
+    if (!self->super.super.user_allocator.ops.malloc) {
         ucs_mpool_cleanup(&self->rx.mp, 0); /* Cannot flush SRQ */
     }
     ucs_mpool_cleanup(&self->tx.pending_mp, 1);

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -176,6 +176,7 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
     struct mlx5_wqe_data_seg *rx_wqes;
     uint16_t pi, next_pi, count;
     uct_ib_iface_recv_desc_t *desc;
+    UCT_TL_EXPAND_USR_MEM_ALLOCATOR(&iface->super.super.super.user_allocator);
 
     rx_wqes = iface->rx.wq.wqes;
     pi      = iface->rx.wq.rq_wqe_counter & iface->rx.wq.mask;
@@ -183,8 +184,13 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
     for (count = 0; count < batch; count ++) {
         next_pi = (pi + 1) &  iface->rx.wq.mask;
         ucs_prefetch(rx_wqes + next_pi);
-        UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
+        if (user_allocator_exists) {
+            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
+        } else {
+            UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
                                  desc, break);
+        }
+        
         rx_wqes[pi].lkey = htonl(desc->lkey);
         rx_wqes[pi].addr = htobe64((uintptr_t)uct_ib_iface_recv_desc_hdr(&iface->super.super, desc));
         pi = next_pi;

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -185,7 +185,7 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
         next_pi = (pi + 1) &  iface->rx.wq.mask;
         ucs_prefetch(rx_wqes + next_pi);
         if (user_allocator_active) {
-            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
+            UCT_TL_IFACE_GET_RX_DESC_FROM_USER(get_desc_from_user_allocator_cb, get_desc_from_user_allocator, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
         } else {
             UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
                                  desc, break);

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -184,7 +184,7 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
     for (count = 0; count < batch; count ++) {
         next_pi = (pi + 1) &  iface->rx.wq.mask;
         ucs_prefetch(rx_wqes + next_pi);
-        if (user_allocator_exists) {
+        if (user_allocator_active) {
             UCT_TL_IFACE_GET_RX_DESC_FROM_USER(user_allocator_get_desc_from_usr, user_allocator_instance, user_allocator_md_index, desc, user_allocator_memh, break);
         } else {
             UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1005,7 +1005,7 @@ void uct_ud_ep_process_rx(uct_ud_iface_t *iface, uct_ud_neth_t *neth, unsigned b
     return;
 
 out:
-    if (!iface->super.super.user_allocator.active) {
+    if (!iface->super.super.user_allocator.ops.malloc) {
         ucs_mpool_put(skb);
     }
 }

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1005,7 +1005,9 @@ void uct_ud_ep_process_rx(uct_ud_iface_t *iface, uct_ud_neth_t *neth, unsigned b
     return;
 
 out:
-    ucs_mpool_put(skb);
+    if (!iface->super.super.user_allocator.active) {
+        ucs_mpool_put(skb);
+    }
 }
 
 ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -560,7 +560,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
     self->rx.available = ucs_min(config->ud_common.rx_queue_len_init,
                                  config->super.rx.queue_len);
     self->rx.quota     = config->super.rx.queue_len - self->rx.available;
-    if (!self->super.super.user_allocator.active) {
+    if (!self->super.super.user_allocator.ops.malloc) {
         ucs_mpool_grow(&self->rx.mp, self->rx.available);
     }
 
@@ -606,7 +606,7 @@ err_release_stats:
 err_tx_mpool:
     ucs_mpool_cleanup(&self->tx.mp, 1);
 err_rx_mpool:
-    if (!self->super.super.user_allocator.active) {
+    if (!self->super.super.user_allocator.ops.malloc) {
         ucs_mpool_cleanup(&self->rx.mp, 1);
     }
 err_qp:
@@ -644,7 +644,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_iface_t)
     ucs_mpool_cleanup(&self->tx.mp, 0);
     /* TODO: qp to error state and cleanup all wqes */
     uct_ud_iface_free_pending_rx(self);
-    if (!self->super.super.user_allocator.active) {
+    if (!self->super.super.user_allocator.ops.malloc) {
         ucs_mpool_cleanup(&self->rx.mp, 0);
     }
     uct_ud_iface_destroy_qp(self);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -404,7 +404,7 @@ uct_ud_verbs_iface_poll_rx(uct_ud_verbs_iface_t *iface, int is_async)
     UCT_IB_IFACE_VERBS_FOREACH_RXWQE(&iface->super.super, i, packet, wc, num_wcs) {
         if (!uct_ud_iface_check_grh(&iface->super, packet,
                                     wc[i].wc_flags & IBV_WC_GRH, wc[i].sl)) {
-            if (!iface->super.super.super.user_allocator.active) {
+            if (!iface->super.super.super.user_allocator.ops.malloc) {
                 ucs_mpool_put_inline((void*)wc[i].wr_id);
             }
             continue;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -404,7 +404,9 @@ uct_ud_verbs_iface_poll_rx(uct_ud_verbs_iface_t *iface, int is_async)
     UCT_IB_IFACE_VERBS_FOREACH_RXWQE(&iface->super.super, i, packet, wc, num_wcs) {
         if (!uct_ud_iface_check_grh(&iface->super, packet,
                                     wc[i].wc_flags & IBV_WC_GRH, wc[i].sl)) {
-            ucs_mpool_put_inline((void*)wc[i].wr_id);
+            if (!iface->super.super.super.user_allocator.active) {
+                ucs_mpool_put_inline((void*)wc[i].wr_id);
+            }
             continue;
         }
         uct_ib_log_recv_completion(&iface->super.super, &wc[i], packet,

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -717,6 +717,10 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
     }
 
+    static ucs_status_t mockUserAllocatorFree(void* arg, void *desc) {
+        return UCS_OK;
+    }
+
     static ucs_status_t mockUserInitAllocator(const ucs_user_mem_allocator_params_t *params, void **arg) {
         ucs_status_t status = UCS_OK;
         mock_mem_allocator_t *new_usr_allocator = NULL;
@@ -801,6 +805,7 @@ public:
         params.field_mask |= UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC;
         params.user_mem_allocator_init = (ucs_user_mem_allocator_init_func_t)mockUserInitAllocator;
         params.user_mem_allocator_malloc = (ucs_user_mem_allocator_malloc_func_t)mockUserGetDesc;
+        params.user_mem_allocator_free = (ucs_user_mem_allocator_free_func_t)mockUserAllocatorFree;
 
         return params;
     }

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -717,10 +717,11 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
     }
 
-    static ucs_status_t mockUserInitAllocator(size_t seg_size, size_t data_offset, void **arg) {
+    static ucs_status_t mockUserInitAllocator(const ucp_user_mem_allocator_params_t *params, void **arg) {
         ucs_status_t status = UCS_OK;
         mock_mem_allocator_t *new_usr_allocator = NULL;
         int i;
+        size_t seg_size = params->seg_size;
 
         if (mock_mem_allocators[UCP_MD_INDEX_BITS*2].seg_size == 0) {
             mock_mem_allocators[UCP_MD_INDEX_BITS*2].seg_size = 8256;

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -717,7 +717,7 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
     }
 
-    static ucs_status_t mockUserInitAllocator(const ucp_user_mem_allocator_params_t *params, void **arg) {
+    static ucs_status_t mockUserInitAllocator(const ucs_user_mem_allocator_params_t *params, void **arg) {
         ucs_status_t status = UCS_OK;
         mock_mem_allocator_t *new_usr_allocator = NULL;
         int i;
@@ -799,8 +799,8 @@ public:
         ucp_worker_params_t params = ucp_test::get_worker_params();
 
         params.field_mask |= UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC;
-        params.user_mem_allocator_init = (ucp_user_mem_allocator_init_func_t)mockUserInitAllocator;
-        params.user_mem_allocator_malloc = (ucp_user_mem_allocator_malloc_func_t)mockUserGetDesc;
+        params.user_mem_allocator_init = (ucs_user_mem_allocator_init_func_t)mockUserInitAllocator;
+        params.user_mem_allocator_malloc = (ucs_user_mem_allocator_malloc_func_t)mockUserGetDesc;
 
         return params;
     }

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -717,7 +717,7 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
     }
 
-    static ucs_status_t mockUserInitAllocator(size_t seg_size, size_t data_offset, void **usr_allocator) {
+    static ucs_status_t mockUserInitAllocator(size_t seg_size, size_t data_offset, void **arg) {
         ucs_status_t status = UCS_OK;
         mock_mem_allocator_t *new_usr_allocator = NULL;
         int i;
@@ -740,24 +740,24 @@ public:
 
         if (new_usr_allocator != NULL) {
             
-            *usr_allocator = new_usr_allocator;
+            *arg = new_usr_allocator;
 
         } else if (i > UCP_MD_INDEX_BITS) {
             
             UCS_TEST_MESSAGE << "Error: Need more mem allocators";
-            *usr_allocator = &mock_mem_allocators[UCP_MD_INDEX_BITS];
+            *arg = &mock_mem_allocators[UCP_MD_INDEX_BITS];
 
         } else {
             
             mock_mem_allocators[i].seg_size = seg_size;
             mock_mem_allocators[i].context = usr_allocators_context;
-            *usr_allocator = &mock_mem_allocators[i];
+            *arg = &mock_mem_allocators[i];
         }
 
         return status;
     }
 
-    static ucs_status_t mockUserGetDesc(void *usr_allocator, void** desc, ucp_mem_h *memh) {
+    static ucs_status_t mockUserGetDesc(void *arg, void** desc, ucp_mem_h *memh) {
         ucp_mem_map_params_t params;
         ucs_status_t status = UCS_OK;
         void *address;
@@ -765,8 +765,8 @@ public:
         size_t seg_size;
         ucp_context_h context;
 
-        seg_size = ((mock_mem_allocator_t*)usr_allocator)->seg_size;
-        context = ((mock_mem_allocator_t*)usr_allocator)->context;
+        seg_size = ((mock_mem_allocator_t*)arg)->seg_size;
+        context = ((mock_mem_allocator_t*)arg)->context;
         //use malloc to allocate descriptor
         address = ucs_malloc(seg_size, "Mock user allocation");
         if (address == NULL) {
@@ -799,7 +799,7 @@ public:
 
         params.field_mask |= UCP_WORKER_PARAM_FIELD_USR_MEM_ALLOC;
         params.user_mem_allocator_init = (ucp_user_mem_allocator_init_func_t)mockUserInitAllocator;
-        params.user_get_descriptor = (ucp_user_get_descriptor_func_t)mockUserGetDesc;
+        params.user_mem_allocator_malloc = (ucp_user_mem_allocator_malloc_func_t)mockUserGetDesc;
 
         return params;
     }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -667,6 +667,8 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param,
                                             ucp_config);
     }
 
+    test_owner->ucp_context_init_cb(m_ucph.get());
+
     m_workers.resize(num_workers);
     for (int i = 0; i < num_workers; i++) {
         /* We could have "invalid configuration" errors only when used
@@ -1182,6 +1184,8 @@ bool ucp_test_base::is_request_completed(void *request) {
     return (request == NULL) ||
            (ucp_request_check_status(request) != UCS_INPROGRESS);
 }
+
+void ucp_test_base::ucp_context_init_cb(ucp_context_h m_ucph) const {}
 
 ucp_test::mapped_buffer::mapped_buffer(size_t size, const entity& entity,
                                        int flags, ucs_memory_type_t mem_type) :

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -183,6 +183,9 @@ public:
     };
 
     static bool is_request_completed(void *req);
+
+    private:
+        virtual void ucp_context_init_cb(ucp_context_h m_ucph) const;
 };
 
 /**


### PR DESCRIPTION
What
Proposed API for User defined memory allocator used by UCX.

Why ?
Customer want to replace our Mpool implementation with his own memory allocation scheme
to control the allocation and release of RX Descriptors.

How ?
As for the API - Passing 3 functions implemented by the user (init, malloc, free) from UCP to ifaces in UCT.
Function description can be found in the code ("src/ucs/memory/user_mem_allocator.h").