### PR TITLE
AZP: Fix iodemo launch if hca in one subnet

### DIFF
--- a/buildlib/pr/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/pr/io_demo/az-stage-io-demo.yaml
@@ -13,6 +13,8 @@ parameters:
   default: 20
 - name: analyzer_allow_list_args
   default: ''
+- name: test_analyzer_args
+  default: ''
 
 steps:
 - bash: |
@@ -52,6 +54,10 @@ steps:
     export UCX_TLS=${{ parameters.iodemo_tls }}
     export UCX_RNDV_THRESH=4k
     export LD_LIBRARY_PATH=$(workspace)/install/lib:$LD_LIBRARY_PATH
+
+    IFS=, read host1 host2 <<< $(agent_hosts)
+    h2_ip=$(ssh $host2 "source ${PWD}/$(workspace)/buildlib/az-helpers.sh && get_ip ${{parameters.roce_iface}}" )
+
     $(workspace)/test/apps/iodemo/run_io_demo.sh \
         -H $(agent_hosts) \
         --tasks-per-node 1 \
@@ -69,6 +75,7 @@ steps:
             -i 0 \
             -w 16 \
             -t 60 \
+            -I ${h2_ip} \
             ${{ parameters.iodemo_args }}
   displayName: Launch with run_io_demo.sh ( ${{ parameters.name }} )
   timeoutInMinutes: 15
@@ -79,7 +86,11 @@ steps:
     analyzer_args="-d $(workspace)/${{ parameters.name }}"
     analyzer_args="$analyzer_args --duration ${{ parameters.duration }}"
     analyzer_args="$analyzer_args -t 3"
-    analyzer_args="$analyzer_args ${{ parameters.analyzer_allow_list_args }}"
+    if [[ ${{ parameters.test_analyzer_args }} == '--no-allow-list' ]]; then
+      analyzer_args="$analyzer_args ${{ parameters.test_analyzer_args }}"
+    else
+      analyzer_args="$analyzer_args ${{ parameters.analyzer_allow_list_args }}"
+    fi
     python ${analyzer} ${analyzer_args}
   displayName: Analyze for ${{ parameters.name }}
   timeoutInMinutes: 2

--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -23,30 +23,35 @@ parameters:
         interface: $(roce_iface_cx4)
         tls: "rc_x"
         test_name: tag_cx4_rc
+        analyzer: ""
       "tag match on CX6/RC":
         args: ""
         duration: 600
         interface: $(roce_iface_cx6)
         tls: "rc_x"
         test_name: tag_cx6_rc
+        analyzer: ""
       "active messages on CX6/RC":
         args: "-A"
         duration: 600
         interface: $(roce_iface_cx6)
         tls: "rc_x"
         test_name: am_cx6_rc
+        analyzer: ""
       "tag match on CX6/DC":
         args: ""
         duration: 600
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: tag_cx6_dc
+        analyzer: ""
       "active messages on CX6/DC with data validation":
         args: "-A -q"
         duration: 600
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: am_validate_cx6_dc
+        analyzer: ""
       "tag match on CX4 with user memh":
         args: "-z"
         initial_delay: 9999 # No interference
@@ -54,6 +59,7 @@ parameters:
         interface: $(roce_iface_cx4)
         tls: "rc_x"
         test_name: tag_umemh_cx4_rc
+        analyzer: "--no-allow-list"
       "active messages on CX6/DC with user memh":
         args: "-A -z"
         initial_delay: 9999 # No interference
@@ -61,6 +67,7 @@ parameters:
         interface: $(roce_iface_cx6)
         tls: "dc_x"
         test_name: am_umemh_cx6_dc
+        analyzer: "--no-allow-list"
 
 jobs:
   - job: io_build
@@ -122,6 +129,7 @@ jobs:
             test_intefrafe: ${{ test.Value.interface }}
             test_ucx_tls: ${{ test.Value.tls }}
             initial_delay: ${{ coalesce(test.Value.initial_delay, parameters.initial_delay) }}
+            test_analyzer: ${{ test.Value.analyzer }}
       maxParallel: 1
 
     variables:
@@ -149,6 +157,7 @@ jobs:
           roce_iface: $(test_intefrafe)
           iodemo_tls: $(test_ucx_tls)
           initial_delay: $(initial_delay)
+          test_analyzer_args: $(test_analyzer)
           ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
             analyzer_allow_list_args: '--allow_list $(System.PullRequest.TargetBranch)'
       - bash: |


### PR DESCRIPTION
## What
add source IP for client
add analyzer without allow list if test doesn't have  corrupter

## Why ?
if HCA is one subnet we didn't see traffic 

