### PR TITLE
UCT/IB/DEVX: invalidate MR thru UMR QP

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -926,6 +926,22 @@ uct_ib_device_query_gid_info(struct ibv_context *ctx, const char *dev_name,
     return UCS_ERR_INVALID_PARAM;
 }
 
+uct_ib_roce_version_t uct_ib_device_roce_version(uct_ib_device_t *dev,
+                                                 uint8_t port_num,
+                                                 unsigned gid_index)
+{
+    ucs_status_t status;
+    uct_ib_device_gid_info_t gid_info;
+
+    status = uct_ib_device_query_gid_info(dev->ibv_context,
+                                          uct_ib_device_name(dev),
+                                          port_num, gid_index, &gid_info);
+    ucs_assertv_always(status == UCS_OK, "query_gid_info failed: %s",
+                       ucs_status_string(status));
+
+    return gid_info.roce_info.ver;
+}
+
 int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
                                       const union ibv_gid *gid,
                                       uint8_t gid_index)
@@ -951,6 +967,11 @@ int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
 
     ibv_destroy_ah(ah);
     return 1;
+}
+
+uint8_t uct_ib_device_roce_dscp(uint8_t traffic_class)
+{
+    return traffic_class >> 2;
 }
 
 ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -407,9 +407,15 @@ ucs_status_t uct_ib_device_query_gid_info(struct ibv_context *ctx, const char *d
                                           uint8_t port_num, unsigned gid_index,
                                           uct_ib_device_gid_info_t *info);
 
+uct_ib_roce_version_t uct_ib_device_roce_version(uct_ib_device_t *dev,
+                                                 uint8_t port_num,
+                                                 unsigned gid_index);
+
 int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
                                       const union ibv_gid *gid,
                                       uint8_t gid_index);
+
+uint8_t uct_ib_device_roce_dscp(uint8_t traffic_class);
 
 ucs_status_t
 uct_ib_device_async_event_register(uct_ib_device_t *dev,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1177,6 +1177,12 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface)
            (iface->gid_info.roce_info.ver == UCT_IB_DEVICE_ROCE_V2);
 }
 
+uint8_t uct_ib_iface_roce_dscp(uct_ib_iface_t *iface)
+{
+    ucs_assert(uct_ib_iface_is_roce(iface));
+    return uct_ib_device_roce_dscp(iface->config.traffic_class);
+}
+
 ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
                                              size_t md_config_index)
 {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -468,6 +468,8 @@ uct_ib_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
 
 int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface);
 
+uint8_t uct_ib_iface_roce_dscp(uct_ib_iface_t *iface);
+
 
 /**
  * Select the IB gid index and RoCE version to use for a RoCE port.
@@ -634,13 +636,6 @@ uct_ib_cq_size(uct_ib_iface_t *iface, const uct_ib_iface_init_attr_t *init_attr,
     } else {
         return init_attr->cq_len[UCT_IB_DIR_TX];
     }
-}
-
-static UCS_F_ALWAYS_INLINE unsigned
-uct_ib_iface_roce_dscp(uct_ib_iface_t *iface)
-{
-    ucs_assert(uct_ib_iface_is_roce(iface));
-    return iface->config.traffic_class >> 2;
 }
 
 #if HAVE_DECL_IBV_CREATE_CQ_EX

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -192,7 +192,11 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "Enable relaxed ordering for PCIe transactions to improve performance on some systems.",
      ucs_offsetof(uct_ib_md_config_t, mr_relaxed_order), UCS_CONFIG_TYPE_ON_OFF_AUTO},
 
-    {NULL}
+    {"MAX_MR_DEREG_QUEUE_SIZE", "1024",
+     "Max size of memory region deregistration queue.",
+     ucs_offsetof(uct_ib_md_config_t, ext.max_mr_gc_queue), UCS_CONFIG_TYPE_UINT},
+
+     {NULL}
 };
 
 #ifdef ENABLE_STATS
@@ -1774,9 +1778,9 @@ void uct_ib_md_close(uct_md_h uct_md)
 {
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
 
+    uct_ib_md_release_reg_method(md);
     md->ops->cleanup(md);
     uct_ib_md_release_device_config(md);
-    uct_ib_md_release_reg_method(md);
     uct_ib_device_cleanup_ah_cached(&md->dev);
     ibv_dealloc_pd(md->pd);
     uct_ib_device_cleanup(&md->dev);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -86,6 +86,7 @@ typedef struct uct_ib_md_ext_config {
     size_t                   min_mt_reg;   /**< Multi-threaded registration threshold */
     size_t                   mt_reg_chunk; /**< Multi-threaded registration chunk */
     int                      mt_reg_bind;  /**< Multi-threaded registration bind to core */
+    unsigned                 max_mr_gc_queue;
 } uct_ib_md_ext_config_t;
 
 
@@ -100,6 +101,12 @@ typedef struct uct_ib_mem {
 typedef union uct_ib_mr {
     struct ibv_mr           *ib;
 } uct_ib_mr_t;
+
+
+typedef struct uct_ib_mr_gc_entry {
+    struct ibv_mr           *ib;
+    ucs_queue_elem_t        elem;
+} uct_ib_mr_gc_entry_t;
 
 
 typedef enum {

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -317,8 +317,9 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
         attr.super.max_inl_cqe[UCT_IB_DIR_RX] = 0;
         attr.uidx           = htonl(dci_index) >> UCT_IB_UIDX_SHIFT;
         attr.full_handshake = full_handshake;
-        status = uct_ib_mlx5_devx_create_qp(ib_iface, &dci->txwq.super,
-                                            &dci->txwq, &attr);
+        status = uct_rc_mlx5_iface_common_devx_create_qp(&iface->super,
+                                                         &dci->txwq.super,
+                                                         &dci->txwq, &attr);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -9,6 +9,7 @@
 #endif
 
 #include <uct/ib/mlx5/ib_mlx5.h>
+#include <uct/ib/rc/accel/rc_mlx5.inl>
 #include "ib_mlx5_ifc.h"
 
 #include <ucs/arch/bitops.h>
@@ -47,13 +48,91 @@ static ucs_status_t uct_ib_mlx5_reg_key(uct_ib_md_t *md, void *address,
                                &memh->mrs[mr_type].super, mr_type, silent);
 }
 
-static ucs_status_t uct_ib_mlx5_dereg_key(uct_ib_md_t *md,
+static void uct_ib_mlx5_md_umr_gc_init(uct_ib_mlx5_md_t *md)
+{
+    ucs_queue_head_init(&md->umr.md_gc);
+    md->umr.gc_count = 0;
+}
+
+static void uct_ib_mlx5_md_umr_gc_pop(uct_ib_mlx5_md_t *md)
+{
+    uct_ib_mr_gc_entry_t *gc_entry;
+
+    if (md->super.config.max_mr_gc_queue == 0) {
+        ucs_assert(md->umr.gc_count == 1);
+        md->umr.gc_count = 0;
+        return;
+    }
+
+    ucs_assert(md->umr.gc_count > 0);
+    ucs_assert(!ucs_queue_is_empty(&md->umr.md_gc));
+
+    --md->umr.gc_count;
+    gc_entry = ucs_queue_pull_elem_non_empty(&md->umr.md_gc,
+                                             uct_ib_mr_gc_entry_t, elem);
+    uct_ib_dereg_mr(gc_entry->ib);
+    ucs_free(gc_entry);
+
+    if (md->umr.gc_count == 0) {
+        ucs_assert(ucs_queue_is_empty(&md->umr.md_gc));
+    }
+}
+
+static ucs_status_t
+uct_ib_mlx5_md_umr_gc_push(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mr_t *mr)
+{
+    uct_ib_mr_gc_entry_t *gc_entry = ucs_malloc(sizeof(*gc_entry),
+                                                "mr_gc_entry");
+
+    if (gc_entry == NULL) {
+        ucs_error("Cannot allocate MR GC entry");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    if (++md->umr.gc_count > md->super.config.max_mr_gc_queue) {
+        uct_ib_mlx5_md_umr_gc_pop(md);
+    }
+
+    ucs_queue_push(&md->umr.md_gc, &gc_entry->elem);
+    gc_entry->ib = mr->super.ib;
+    mr->super.ib = NULL;
+    return UCS_OK;
+}
+
+
+static ucs_status_t uct_ib_mlx5_dereg_key(uct_ib_md_t *ib_md,
                                           uct_ib_mem_t *ib_memh,
                                           uct_ib_mr_type_t mr_type)
 {
     uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    uct_ib_mlx5_md_t  *md   = ucs_derived_of(ib_md, uct_ib_mlx5_md_t);
+    struct mlx5_cqe64 *cqe;
+    ucs_status_t status;
 
-    return uct_ib_dereg_mr(memh->mrs[mr_type].super.ib);
+    if (memh->mrs[mr_type].super.ib == NULL) {
+        return UCS_OK;
+    }
+
+    ucs_assert(md->umr.txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_DEVX);
+    ucs_assert(md->umr.txwq.super.devx.obj != NULL);
+
+    uct_rc_mlx5_txqp_inline_post(NULL, IBV_QPT_RC,
+                                 NULL, &md->umr.txwq,
+                                 MLX5_OPCODE_UMR, NULL, 0, 0, 0,
+                                 htobe32(memh->mrs[mr_type].super.ib->rkey), 0,
+                                 0, NULL, NULL, 0, 0, INT_MAX);
+
+    do {
+        cqe = uct_ib_mlx5_poll_cq(NULL, &md->umr.cq.mlx5);
+        /* TODO: handle err cqe */
+    } while (cqe == NULL);
+
+    status = uct_ib_mlx5_md_umr_gc_push(md, &memh->mrs[mr_type]);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return UCS_OK;
 }
 
 static ucs_status_t uct_ib_mlx5_reg_atomic_key(uct_ib_md_t *ibmd,
@@ -610,6 +689,116 @@ close_ctx:
 
 static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops;
 
+static ucs_status_t uct_ib_mlx5_devx_md_umr_qp_create(uct_ib_mlx5_md_t *md)
+{
+#if HAVE_DEVX
+    uct_ib_device_t *dev                          = &md->super.dev;
+    uint8_t port_num                              = dev->first_port;
+    struct ibv_port_attr *port_attr               =
+            uct_ib_device_port_attr(dev, port_num);
+    uct_ib_mlx5_qp_attr_t qp_attr                 = {
+        .super = {
+            .qp_type = IBV_QPT_RC,
+            .ibv     = {
+                .send_cq = md->umr.cq.ibv,
+                .recv_cq = md->umr.cq.ibv,
+                .pd      = md->super.pd
+            },
+            .cap = {
+                .max_inline_data = 128,
+                .max_send_wr     = 1024,
+                .max_send_sge    = 1,
+                .max_recv_wr     = 0,
+                .max_recv_sge    = 0
+            },
+            .srq                        = NULL,
+            .srq_num                    = 0,
+            .port                       = dev->first_port,
+            .max_inl_cqe[UCT_IB_DIR_TX] = 0,
+            .max_inl_cqe[UCT_IB_DIR_RX] = 0
+        },
+        .mmio_mode                        = UCT_IB_MLX5_MMIO_MODE_BF_POST,
+        .is_roce_dev                      =
+                uct_ib_device_is_port_roce(dev, port_num),
+        .pkey_index                       = 0,
+        .uidx                             = 0xffffffff
+    };
+    struct ibv_ah_attr ah_attr                    = {
+        .port_num  = port_num,
+        .dlid      = port_attr->lid,
+        .is_global = 1
+    };
+    uct_ib_mlx5_qp_connect_attr_t qp_connect_attr = {
+        .ah_attr          = &ah_attr,
+        .path_mtu         = IBV_MTU_512,
+        .path_index       = 0,
+        .is_roce_dev      = uct_ib_device_is_port_roce(dev, port_num),
+        .traffic_class    = 0,
+        .sl               = 0,
+        .min_rnr_timer    = 7,
+        .timeout          = 7,
+        .rnr_retry        = 7,
+        .retry_cnt        = 7,
+        .max_rd_atomic    = 1,
+        .exp_backoff      = 0,
+        .log_ack_req_freq = 8
+    };
+    ucs_status_t status;
+
+    qp_attr.uar = md->umr.uar = ucs_malloc(sizeof(*md->umr.uar), "umr_qp_uar");
+    if (md->umr.uar == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    status = uct_ib_mlx5_devx_uar_init(md->umr.uar, md, qp_attr.mmio_mode);
+    if (status != UCS_OK) {
+        goto err_uar_free;
+    }
+
+    status = uct_ib_mlx5_devx_create_qp(md, &md->umr.txwq.super,
+                                        &md->umr.txwq, &qp_attr);
+    ucs_assert(status == UCS_OK);
+    if (status != UCS_OK) {
+        goto err_uar_cleanup;
+    }
+
+    status = uct_ib_device_query_gid(dev, port_num,
+                                     UCT_IB_MD_DEFAULT_GID_INDEX,
+                                     &ah_attr.grh.dgid, UCS_LOG_LEVEL_ERROR);
+    if (status != UCS_OK) {
+        goto err_qp_destroy;
+    }
+
+    qp_connect_attr.dest_qp_num = md->umr.txwq.super.qp_num;
+    if (qp_connect_attr.is_roce_dev) {
+        qp_connect_attr.roce_ver =
+                uct_ib_device_roce_version(dev, port_num,
+                                           UCT_IB_MD_DEFAULT_GID_INDEX);
+    }
+
+    status = uct_ib_mlx5_devx_connect_rc_qp(md, &md->umr.txwq.super,
+                                            &qp_connect_attr);
+    if (status != UCS_OK) {
+        goto err_qp_destroy;
+    }
+
+    return UCS_OK;
+
+err_qp_destroy:
+    uct_ib_mlx5_devx_destroy_qp(md, &md->umr.txwq.super);
+err_uar_cleanup:
+    uct_ib_mlx5_devx_uar_cleanup(md->umr.uar);
+err_uar_free:
+    ucs_free(md->umr.uar);
+    md->umr.uar = NULL;
+err:
+    return status;
+#endif
+
+    return UCS_ERR_UNSUPPORTED;
+}
+
 static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
                                              const uct_ib_md_config_t *md_config,
                                              uct_ib_md_t **p_md)
@@ -660,7 +849,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     status = uct_ib_device_query(dev, ibv_device);
     if (status != UCS_OK) {
-        goto err_free;
+        goto err_free_md;
     }
 
     cap = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, out, capability);
@@ -677,7 +866,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
             ucs_error("mlx5dv_devx_general_cmd(QUERY_HCA_CAP) failed: %m");
             status = UCS_ERR_IO_ERROR;
         }
-        goto err_free;
+        goto err_free_md;
     }
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, log_max_msg) !=
@@ -685,7 +874,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         status = UCS_ERR_UNSUPPORTED;
         ucs_debug("Unexpected QUERY_HCA_CAP.log_max_msg %d\n",
                   UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, log_max_msg));
-        goto err_free;
+        goto err_free_md;
     }
 
     status = uct_ib_mlx5_devx_query_lag(md, &lag_state);
@@ -746,7 +935,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     status = uct_ib_mlx5_devx_check_odp(md, md_config, cap);
     if (status != UCS_OK) {
-        goto err_free;
+        goto err_free_md;
     }
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, atomic)) {
@@ -761,7 +950,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         if (ret != 0) {
             ucs_error("mlx5dv_devx_general_cmd(QUERY_HCA_CAP, ATOMIC) failed: %m");
             status = UCS_ERR_IO_ERROR;
-            goto err_free;
+            goto err_free_md;
         }
 
         arg_size = UCT_IB_MLX5DV_GET(atomic_caps, cap, atomic_size_qp);
@@ -800,7 +989,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     uct_ib_mlx5_parse_relaxed_order(md, md_config);
     status = uct_ib_md_open_common(&md->super, ibv_device, md_config);
     if (status != UCS_OK) {
-        goto err_free;
+        goto err_free_md;
     }
 
     ucs_recursive_spinlock_init(&md->dbrec_lock, 0);
@@ -810,7 +999,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
                             ucs_get_page_size() / UCS_SYS_CACHE_LINE_SIZE - 1,
                             UINT_MAX, &uct_ib_mlx5_dbrec_ops, "devx dbrec");
     if (status != UCS_OK) {
-        goto err_free;
+        goto err_free_md;
     }
 
     status = uct_ib_mlx5_md_buf_alloc(md, ucs_get_page_size(), 0, &md->zero_buf,
@@ -819,15 +1008,37 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         goto err_release_dbrec;
     }
 
+    md->umr.cq.ibv = ibv_create_cq(dev->ibv_context, /* TODO: cq_size */ 1024,
+                                   NULL, NULL, /* preferred_cpu */ 0);
+    if (md->umr.cq.ibv == NULL) {
+        ucs_fatal("device %p: failed to create UMR CQ", ibv_device);
+        status = UCS_ERR_IO_ERROR;
+        goto err_release_dbrec;
+    }
+
+    status = uct_ib_mlx5_get_cq(md->umr.cq.ibv, &md->umr.cq.mlx5);
+    if (status != UCS_OK) {
+        status = UCS_ERR_IO_ERROR;
+        goto err_cq_destroy;
+    }
+
+    uct_ib_mlx5_md_umr_gc_init(md);
+    status = uct_ib_mlx5_devx_md_umr_qp_create(md);
+    if (status != UCS_OK) {
+        goto err_cq_destroy;
+    }
+
     dev->flags |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->flags  |= UCT_IB_MLX5_MD_FLAG_DEVX;
     md->flags  |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
     *p_md       = &md->super;
     return status;
 
+err_cq_destroy:
+    ibv_destroy_cq(md->umr.cq.ibv);
 err_release_dbrec:
     ucs_mpool_cleanup(&md->dbrec_pool, 1);
-err_free:
+err_free_md:
     ucs_free(md);
 err_free_context:
     ibv_close_device(ctx);
@@ -839,6 +1050,12 @@ static void uct_ib_mlx5_devx_md_cleanup(uct_ib_md_t *ibmd)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
 
+    while (md->umr.gc_count > 0) {
+        uct_ib_mlx5_md_umr_gc_pop(md);
+    }
+
+    uct_ib_mlx5_devx_destroy_qp(md, &md->umr.txwq.super);
+    ibv_destroy_cq(md->umr.cq.ibv);
     uct_ib_mlx5_md_buf_free(md, md->zero_buf, &md->zero_mem);
     ucs_mpool_cleanup(&md->dbrec_pool, 1);
     ucs_recursive_spinlock_destroy(&md->dbrec_lock);

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -790,9 +790,7 @@ ucs_status_t uct_ib_mlx5_md_get_atomic_mr_id(uct_ib_md_t *ibmd, uint8_t *mr_id)
     uct_ib_mlx5_md_t *md = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
 
 #if HAVE_EXP_UMR
-    if ((md->umr_qp == NULL) || (md->umr_cq == NULL)) {
-        goto unsupported;
-    }
+    goto unsupported;
 #else
     if (!(md->flags & UCT_IB_MLX5_MD_FLAG_DEVX)) {
         goto unsupported;

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -275,6 +275,7 @@ static void uct_ib_mlx5_wqe_dump(uct_ib_iface_t *iface, void *wqe, void *qstart,
                                            UCT_IB_OPCODE_FLAG_HAS_RADDR|UCT_IB_OPCODE_FLAG_HAS_EXT_ATOMIC },
         [MLX5_OPCODE_ATOMIC_MASKED_FA] = { "MASKED_FETCH_ADD",
                                            UCT_IB_OPCODE_FLAG_HAS_RADDR|UCT_IB_OPCODE_FLAG_HAS_EXT_ATOMIC },
+        [MLX5_OPCODE_UMR]              = { "UMR", 0 }
    };
 
     struct mlx5_wqe_ctrl_seg *ctrl = wqe;
@@ -313,7 +314,7 @@ static void uct_ib_mlx5_wqe_dump(uct_ib_iface_t *iface, void *wqe, void *qstart,
         seg = qstart;
     }
 
-    if (uct_ib_mlx5_is_qp_require_av_seg(iface->config.qp_type)) {
+    if (iface && uct_ib_mlx5_is_qp_require_av_seg(iface->config.qp_type)) {
         is_eth = uct_ib_iface_is_roce(iface);
         dg_size = uct_ib_mlx5_dump_dgram(s, ends - s, seg, is_eth);
         s += strlen(s);

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -459,7 +459,7 @@ uct_rc_mlx5_common_post_send(uct_rc_mlx5_iface_common_t *iface, int qp_type,
 
     ctrl = txwq->curr;
 
-    if (opcode == MLX5_OPCODE_SEND_IMM) {
+    if ((opcode == MLX5_OPCODE_SEND_IMM) || (opcode == MLX5_OPCODE_UMR)) {
         uct_ib_mlx5_set_ctrl_seg_with_imm(ctrl, txwq->sw_pi, opcode, opmod,
                                           txwq->super.qp_num, fm_ce_se, wqe_size,
                                           imm);
@@ -468,7 +468,8 @@ uct_rc_mlx5_common_post_send(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                                  txwq->super.qp_num, fm_ce_se, wqe_size);
     }
 
-    ucs_assert(qp_type == iface->super.super.config.qp_type);
+    ucs_assert((iface == NULL) ||
+               (qp_type == iface->super.super.config.qp_type));
 
 #if HAVE_TL_DC
     if (qp_type == UCT_IB_QPT_DCI) {
@@ -476,7 +477,8 @@ uct_rc_mlx5_common_post_send(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     }
 #endif
 
-    uct_ib_mlx5_log_tx(&iface->super.super, ctrl, txwq->qstart, txwq->qend,
+    uct_ib_mlx5_log_tx((iface == NULL) ? NULL : &iface->super.super,
+                       ctrl, txwq->qstart, txwq->qend,
                        max_log_sge, log_sge,
                        ((opcode == MLX5_OPCODE_SEND) || (opcode == MLX5_OPCODE_SEND_IMM)) ?
                        uct_rc_mlx5_common_packet_dump : NULL);
@@ -492,6 +494,11 @@ uct_rc_mlx5_common_post_send(uct_rc_mlx5_iface_common_t *iface, int qp_type,
         return;
     }
 #endif
+
+    if (iface == NULL) {
+        /* TODO: res count on md */
+        return;
+    }
 
     uct_rc_txqp_posted(txqp, &iface->super, res_count, fm_ce_se & MLX5_WQE_CTRL_CQ_UPDATE);
 }
@@ -549,11 +556,13 @@ uct_rc_mlx5_txqp_inline_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                   /* AV   */ uct_ib_mlx5_base_av_t *av, struct mlx5_grh_av *grh_av,
                              size_t av_size, unsigned fm_ce_se, int max_log_sge)
 {
-    struct mlx5_wqe_ctrl_seg     *ctrl;
-    struct mlx5_wqe_raddr_seg    *raddr;
-    struct mlx5_wqe_inl_data_seg *inl;
-    uct_rc_mlx5_am_short_hdr_t   *am;
-    uct_rc_mlx5_hdr_t            *rc_hdr;
+    struct mlx5_wqe_ctrl_seg         *ctrl;
+    struct mlx5_wqe_raddr_seg        *raddr;
+    struct mlx5_wqe_inl_data_seg     *inl;
+    struct mlx5_wqe_umr_ctrl_seg     *umr_ctrl;
+    struct mlx5_wqe_mkey_context_seg *mkey_seg;
+    uct_rc_mlx5_am_short_hdr_t       *am;
+    uct_rc_mlx5_hdr_t                *rc_hdr;
     size_t wqe_size, ctrl_av_size;
     void *next_seg;
 
@@ -608,6 +617,22 @@ uct_rc_mlx5_txqp_inline_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
         inl              = next_seg;
         inl->byte_count  = htonl(MLX5_INLINE_SEG);
         fm_ce_se        |= MLX5_WQE_CTRL_CQ_UPDATE | MLX5_WQE_CTRL_FENCE;
+        break;
+
+    case MLX5_OPCODE_UMR:
+    case MLX5_OPCODE_LOCAL_INVAL:
+        wqe_size         = sizeof(*ctrl) + sizeof(*umr_ctrl) +
+                           sizeof(*mkey_seg);
+        umr_ctrl         = next_seg;
+        mkey_seg         = UCS_PTR_TYPE_OFFSET(umr_ctrl, *umr_ctrl);
+
+        memset(umr_ctrl, 0, sizeof(*umr_ctrl));
+        memset(mkey_seg, 0, sizeof(*mkey_seg));
+
+        umr_ctrl->flags     = MLX5_WQE_UMR_CTRL_FLAG_INLINE;
+        umr_ctrl->mkey_mask = htobe64(MLX5_WQE_UMR_CTRL_MKEY_MASK_FREE);
+        mkey_seg->free      = MLX5_WQE_MKEY_CONTEXT_FREE;
+        fm_ce_se           |= MLX5_WQE_CTRL_CQ_UPDATE;
         break;
 
     default:

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -285,10 +285,10 @@ uct_rc_mlx5_devx_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     attr.super.srq_num          = iface->rx.srq.srq_num;
     attr.super.port             = dev->first_port;
     attr.mmio_mode              = iface->tx.mmio_mode;
-    status = uct_ib_mlx5_devx_create_qp(&iface->super.super,
-                                        &iface->tm.cmd_wq.super.super,
-                                        &iface->tm.cmd_wq.super,
-                                        &attr);
+
+    status = uct_rc_mlx5_iface_common_devx_create_qp(
+            iface, &iface->tm.cmd_wq.super.super, &iface->tm.cmd_wq.super,
+            &attr);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -726,6 +726,11 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
 
 #if HAVE_DEVX
 ucs_status_t
+uct_rc_mlx5_iface_common_devx_create_qp(uct_rc_mlx5_iface_common_t *iface,
+                                        uct_ib_mlx5_qp_t *qp,
+                                        uct_ib_mlx5_txwq_t *tx,
+                                        uct_ib_mlx5_qp_attr_t *attr);
+ucs_status_t
 uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                                          uct_ib_mlx5_qp_t *qp,
                                          uint32_t dest_qp_num,
@@ -734,6 +739,15 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                                          uint8_t path_index);
 
 #else
+static UCS_F_MAYBE_UNUSED ucs_status_t
+uct_rc_mlx5_iface_common_devx_create_qp(uct_rc_mlx5_iface_common_t *iface,
+                                        uct_ib_mlx5_qp_t *qp,
+                                        uct_ib_mlx5_txwq_t *tx,
+                                        uct_ib_mlx5_qp_attr_t *attr)
+{
+    return UCS_ERR_UNSUPPORTED;
+}
+
 static UCS_F_MAYBE_UNUSED ucs_status_t
 uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                                          uct_ib_mlx5_qp_t *qp,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -299,7 +299,8 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP) {
         attr->uidx      = 0xffffff;
-        status = uct_ib_mlx5_devx_create_qp(ib_iface, qp, txwq, attr);
+        status = uct_rc_mlx5_iface_common_devx_create_qp(iface, qp, txwq,
+                                                         attr);
         if (status != UCS_OK) {
             return status;
         }


### PR DESCRIPTION
## What
Invalidate MR thru UMR QP with deffered deregistration.
This is a draft PR which is expected to be splitted up to generic UMR QP creation code and MR invalidation path.

## Why ?
To minizimize rkey collisions.
