### PR TITLE
TOOLS/PERF: Fix status exchange with multiple threads during warmup

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1299,8 +1299,16 @@ ucx_perf_do_warmup(ucx_perf_context_t *perf, const ucx_perf_params_t *params)
         /* Stop when reaching the deadline */
         stop_status = (ucs_get_time() > deadline) ? UCS_OK : UCS_INPROGRESS;
 
-        /* Synchronize on whether to continue or stop the warmup phase */
-        status = ucx_perf_test_exchange_status(perf, stop_status);
+        if (params->thread_count == 1) {
+            status = ucx_perf_test_exchange_status(perf, stop_status);
+        } else {
+#pragma omp barrier
+#pragma omp single copyprivate(status)
+            /* Synchronize on whether to continue or stop the warmup phase */
+            status = ucx_perf_test_exchange_status(perf, stop_status);
+#pragma omp barrier
+        }
+
         if (status != UCS_INPROGRESS) {
             return status;
         }


### PR DESCRIPTION
## Why
Fix race condition of multiple threads trying to send over the same socket
issue introduced by #7948 