### PR TITLE
TEST/GTEST: Limit test buffer sizes according to memory size

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -608,6 +608,12 @@ std::string exit_status_info(int exit_status)
     return ss.str().substr(2, std::string::npos);
 }
 
+size_t limit_buffer_size(size_t size)
+{
+    return std::min(size, std::min(ucs_get_phys_mem_size() / 16,
+                                   ucs_get_memfree_size() / 4));
+}
+
 sock_addr_storage::sock_addr_storage() :
         m_size(0), m_is_valid(false), m_is_rdmacm_netdev(false)
 {

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -346,6 +346,12 @@ std::string compact_string(const std::string &str, size_t length);
 std::string exit_status_info(int exit_status);
 
 
+/*
+ * Limit test buffer size according to available memory
+ */
+size_t limit_buffer_size(size_t size = std::numeric_limits<size_t>::max());
+
+
 /**
  * Return the IP address of the given interface address.
  */

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -271,8 +271,9 @@ UCS_TEST_F(test_mpool, leak_check) {
 }
 
 UCS_TEST_SKIP_COND_F(test_mpool, alloc_4g, RUNNING_ON_VALGRIND) {
-    const unsigned elems_per_chunk = 128;
     const size_t elem_size         = 32 * UCS_MBYTE;
+    const unsigned elems_per_chunk = ucs::limit_buffer_size(4 * UCS_GBYTE) /
+                                     elem_size;
     ucs_mpool_ops_t mpool_ops = {ucs_mpool_chunk_malloc, ucs_mpool_chunk_free,
                                  NULL, NULL, NULL};
     ucs_mpool_t mp;

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -182,11 +182,8 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     /* Trim at 4.1 GB */
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
 
-    /* Trim at max. phys memory */
-    max_length = ucs_min(max_length, ucs_get_phys_mem_size() / 8);
-
-    /* Trim when short of available memory */
-    max_length = ucs_min(max_length, ucs_get_memfree_size() / 4);
+    /* Trim by memory size */
+    max_length = ucs::limit_buffer_size(max_length);
 
     /* For large size, slow down if needed */
     if (max_length > UCS_MBYTE) {


### PR DESCRIPTION
## Why
Allow running on system with smaller memory size, such as BlueField SoC