### PR TITLE
UCT/IB: Fix subfunction device query

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -214,7 +214,9 @@ typedef struct uct_ib_device {
     int                         max_zcopy_log_sge; /* Maximum sges log for zcopy am */
     UCS_STATS_NODE_DECLARE(stats)
     struct ibv_port_attr        port_attr[UCT_IB_DEV_MAX_PORTS]; /* Cached port attributes */
-    uct_ib_pci_id_t             pci_id;
+    uct_ib_pci_id_t             pci_id;          /* PCI identifiers */
+    ucs_sys_device_t            sys_dev;         /* System device id */
+    double                      pci_bw;          /* Supported PCI bandwidth */
     unsigned                    flags;
     uint8_t                     atomic_arg_sizes;
     uint8_t                     atomic_arg_sizes_be;


### PR DESCRIPTION
## Why
Some properties of subfunction device (such the one inside BlueField SoC) were not read correctly from sysfs: device bus id and PCIe speed. Since bus id was not ready correctly, some unit tests failed when sys_dev of IB devices was UNKNOWN.
Before this fix, only PCIe identifiers (vendor and device) were adjusted to support subfunction devices.

## How
- Move PCIe code from ib_md.c to ib_device.c
- Read all device-related sysfs information in ib_device.c
- Discover sysfs path once (the correct directory should contain a file named "device") and use it throughout the initialization phase. 