### PR TITLE
AZP/CI: Skip representor devices

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -71,7 +71,20 @@ function get_ip() {
 
 # Get active RDMA interfaces
 function get_rdma_interfaces() {
-    echo `ibdev2netdev | grep Up | awk '{print $5}'`
+    ibdev2netdev | grep Up | while read line
+    do
+        ibdev=$(echo "${line}" | awk '{print $1}')
+        port=$(echo "${line}" | awk '{print $3}')
+        netif=$(echo "${line}" | awk '{print $5}')
+
+        # skip devices that do not have proper gid (representors)
+        if ! [ -e "/sys/class/infiniband/${ibdev}/ports/${port}/gids/0" ]
+        then
+            continue
+        fi
+
+        echo ${netif}
+    done | sort -u
 }
 
 # Prepend each line with a timestamp

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -175,6 +175,8 @@ def test_ucx_tls_positive(tls):
     print "Using UCX_TLS=" + tls + ", found TL: " + str(found_tl)
     if tls == 'all':
         return
+    if not found_tl:
+        sys.exit(1)
     tls = tls.split(',')
     if found_tl in tls or "\\" + found_tl in tls:
         return
@@ -257,6 +259,10 @@ port = "1"
 for dev in sorted(dev_list):
     status, dev_attrs = exec_cmd("ibv_devinfo -d " + dev + " -i " + port)
     if dev_attrs.find("PORT_ACTIVE") == -1:
+        continue
+
+    if not os.path.exists("/sys/class/infiniband/%s/ports/%s/gids/0" % (dev, port)):
+        print "Skipping dummy device: ", dev
         continue
 
     driver_name = os.path.basename(os.readlink("/sys/class/infiniband/%s/device/driver" % dev))


### PR DESCRIPTION
## Why
Fix several CI tests on BlueField SoC, that were failing because tried to run traffic over representor devices.

## How
Skip representor devices - they are detected by an empty GID table