### PR TITLE
CONTRIB/JENKINS: Limit io_demo retries to avoid infinite run

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -629,7 +629,7 @@ run_io_demo() {
 	do
 		echo "==== Running UCP IO demo with \"${mem_type}\" memory type ===="
 
-		test_args="$@ -o write,read -d 128:4194304 -P 2 -i 10000 -w 10 -m ${mem_type} -q"
+		test_args="$@ -o write,read -d 128:4194304 -P 2 -i 10000 -w 10 -c 5 -m ${mem_type} -q"
 		test_name=io_demo
 
 		for server_ip in $server_rdma_addr $server_nonrdma_addr


### PR DESCRIPTION
## Why
Do not let io_demo test run infinitely