### PR TITLE
Fixes for running CI on a BlueField device

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -829,7 +829,8 @@ run_mpi_tests() {
 	then
 		# Prevent our tests from using UCX libraries from hpcx module by prepending
 		# our local library path first
-		export LD_LIBRARY_PATH=${ucx_inst}/lib:$LD_LIBRARY_PATH
+		save_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+		export LD_LIBRARY_PATH=${ucx_inst}/lib:${LD_LIBRARY_PATH}
 
 		../contrib/configure-release --prefix=$ucx_inst --with-mpi # TODO check in -devel mode as well
 		make_clean
@@ -850,8 +851,11 @@ run_mpi_tests() {
 
 		test_malloc_hooks_mpi
 
-		make_clean distclean
+		# Restore LD_LIBRARY_PATH so subsequent tests will not take UCX libs
+		# from installation directory
+		export LD_LIBRARY_PATH=${save_LD_LIBRARY_PATH}
 
+		make_clean distclean
 		module unload hpcx-gcc
 	else
 		echo "==== Not running MPI tests ===="

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1083,7 +1083,7 @@ run_gtest_watchdog_test() {
 run_gtest() {
 	compiler_name=$1
 	shift
-	../contrib/configure-devel --prefix=$ucx_inst $@
+	../contrib/configure-devel --prefix=$ucx_inst "$@"
 	make_clean
 	$MAKEP
 
@@ -1170,8 +1170,19 @@ run_gtest_default() {
 run_gtest_armclang() {
 	if module_load arm-compiler/arm-hpc-compiler && armclang -v
 	then
-		# armclang has some old go compiler, disabling go build.
-		run_gtest "armclang" CC=armclang CXX=armclang++ --with-go=no
+		# Force using loaded gcc toolchain instead of host gcc, to avoid
+		# compatibility issues
+		ARMCLANG_CFLAGS=""
+		if [ -n ${GCC_DIR} ]; then
+			ARMCLANG_CFLAGS+=" --gcc-toolchain=${GCC_DIR}"
+		fi
+
+		# Disable go build, since armclang has some old go compiler.
+		run_gtest "armclang" \
+			CC=armclang \
+			CXX=armclang++ \
+			CFLAGS="${ARMCLANG_CFLAGS}" \
+			--without-go
 		module unload arm-compiler/arm-hpc-compiler
 	else
 		echo "==== Not running with armclang compiler ===="

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -365,8 +365,9 @@ void test_uct_peer_failure_multiple::init()
 {
     size_t tx_queue_len = get_tx_queue_len();
 
-    if (ucs_get_page_size() > 4096) {
-        /* NOTE: Too much receivers may cause failure of ibv_open_device */
+    if ((ucs_get_page_size() > 4096) ||
+        (ucs_arch_get_cpu_model() == UCS_CPU_MODEL_ARM_AARCH64)) {
+        /* NOTE: Too many receivers may cause failure of ibv_open_device */
         m_nreceivers = 10;
     } else {
         m_nreceivers = tx_queue_len;


### PR DESCRIPTION
## Why
Few small fixed, needed to make CI pass on BlueField SoC

## What
* Restore LD_LIBRARY_PATH after MPI tests. On latest Linux distros, DT_RPATH is replaced by DT_RUNPATH that has lower priority than LD_LIBRARY_PATH. So keeping that env var set later on makes gtest load UCX libraries from install dir rather than from build dir, which fails test_module gtest (since the test module is not installed).
* When using armclang compiler, force using GCC toolchain from module instead of from the local OS. By default, clang tries to take the one which is newer in some (but not all) cases. Without this fix, there are link issues with basic_string default constructor.
* Reduce number of concurrent IB contexts, otherwise device fails to open.
