### PR TITLE
CONFIG/GO: Don't fail configure if can't find go compiler

### DIFF
--- a/config/m4/go.m4
+++ b/config/m4/go.m4
@@ -19,12 +19,12 @@ AS_IF([test "x$with_go" != xno],
             AC_CHECK_PROG(GOBIN, go, yes)
             AS_IF([test "x${GOBIN}" = "xyes"],
                   [AS_VERSION_COMPARE([1.16], [`go version | awk '{print substr($3, 3, length($3)-2)}'`],
-                        [go_happy="yes"], [go_happy="yes"],
-                        [AC_MSG_ERROR([Need Go compiler of version 1.16 or newer.])])],
+                                      [go_happy="yes"], [go_happy="yes"], [go_happy=no])],
+                  [go_happy=no])
+            AS_IF([test "x$go_happy" == xno],
                   [AS_IF([test "x$with_go" = "xguess"],
-                        [AC_MSG_WARN([Disabling GO support - GO compiler not found.])],
-                        [AC_MSG_ERROR([GO support was explicitly requested, but go compiler not found.])])
-            ])
+                         [AC_MSG_WARN([Disabling GO support - GO compiler version 1.16 or newer not found.])],
+                         [AC_MSG_ERROR([GO support was explicitly requested, but go compiler not found.])])])
       ],
       [
             AC_MSG_WARN([GO support was explicitly disabled.])


### PR DESCRIPTION
## Why
Default ./configure command can fail if go compiler is too old