### PR TITLE
ARCH: Removing unused ucs_memory_bus_fence

### DIFF
--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -47,7 +47,6 @@ BEGIN_C_DECLS
  * of DSB. The barrier used for synchronization of access between write back
  * and device mapped memory (PCIe BAR).
  */
-#define ucs_memory_bus_fence()        ucs_aarch64_dmb(oshsy)
 #define ucs_memory_bus_store_fence()  ucs_aarch64_dmb(oshst)
 #define ucs_memory_bus_load_fence()   ucs_aarch64_dmb(oshld)
 

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -33,7 +33,6 @@ BEGIN_C_DECLS
  * In x86_64, there is strong ordering of each processor with respect to another
  * processor, but weak ordering with respect to the bus.
  */
-#define ucs_memory_bus_fence()        asm volatile ("mfence"::: "memory")
 #define ucs_memory_bus_store_fence()  asm volatile ("sfence" ::: "memory")
 #define ucs_memory_bus_load_fence()   asm volatile ("lfence" ::: "memory")
 #define ucs_memory_bus_cacheline_wc_flush()


### PR DESCRIPTION
Fixes #7997. Removed the macro for Arm and x86.
Power uses the macro in internal arch code.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>