### PR TITLE
UCT/CUDA_COPY: detect device transfers and report peak arch bandwidth

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -84,9 +84,13 @@ static double uct_cuda_ipc_iface_get_bw()
     int major_version;
     ucs_status_t status;
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cu_device, 0));
+    status = UCT_CUDA_FUNC_LOG_ERR(cuCtxGetDevice(&cu_device));
     if (status != UCS_OK) {
-        return 0;
+        /* did not find a context with the calling thread, try device 0 */
+        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cu_device, 0));
+        if (status != UCS_OK) {
+            return 0;
+        }
     }
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(


### PR DESCRIPTION
## What
Detect if remote/local memory types for perf estimate is of type cuda/cuda-managed. If so, report peak device memory bandwidth

## Why ?
Preparation for device staging pipeline protocols. Without this patch, only estimated peak host<->cuda bandwidth is reported which may not allow for device bounce buffer selection.