### PR TITLE
UCS/TOPO: generate sys-dev index based on device entry position in sysfs

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -117,6 +117,7 @@ static void print_sys_topo()
     static const int distance_width = 10;
     const char *distance_unit       = "MB/s";
     ucs_sys_device_t sys_dev1, sys_dev2;
+    ucs_sys_device_t actual_sys_dev1, actual_sys_dev2;
     ucs_sys_dev_distance_t distance;
     char distance_str[20];
     ucs_status_t status;
@@ -125,8 +126,9 @@ static void print_sys_topo()
     /* Get maximal width of device name */
     name_width = 2 + strlen(distance_unit);
     for (sys_dev1 = 0; sys_dev1 < num_devices; ++sys_dev1) {
-        name_width = ucs_max(
-                name_width, 2 + strlen(ucs_topo_sys_device_get_name(sys_dev1)));
+        actual_sys_dev1 = ucs_sys_topo_devices[sys_dev1];
+        name_width      = ucs_max(name_width,
+                                  2 + strlen(ucs_topo_sys_device_get_name(actual_sys_dev1)));
     }
 
     printf("#\n");
@@ -138,8 +140,9 @@ static void print_sys_topo()
     print_row_separator(distance_width, name_width, num_devices, ' ', '|');
     printf("# |%*s ", name_width - 1, distance_unit);
     for (sys_dev2 = 0; sys_dev2 < num_devices; ++sys_dev2) {
+        actual_sys_dev2 = ucs_sys_topo_devices[sys_dev2];
         printf("|%*s ", distance_width - 1,
-               ucs_topo_sys_device_get_name(sys_dev2));
+               ucs_topo_sys_device_get_name(actual_sys_dev2));
     }
     printf("|\n");
 
@@ -148,16 +151,19 @@ static void print_sys_topo()
 
     /* Print table content */
     for (sys_dev1 = 0; sys_dev1 < num_devices; ++sys_dev1) {
+        actual_sys_dev1 = ucs_sys_topo_devices[sys_dev1];
         print_row_separator(distance_width, name_width, num_devices, ' ', '|');
 
         printf("# |%*s ", name_width - 1,
-               ucs_topo_sys_device_get_name(sys_dev1));
+               ucs_topo_sys_device_get_name(actual_sys_dev1));
         for (sys_dev2 = 0; sys_dev2 < num_devices; ++sys_dev2) {
-            if (sys_dev1 == sys_dev2) {
+            actual_sys_dev2 = ucs_sys_topo_devices[sys_dev2];
+            if (actual_sys_dev1 == actual_sys_dev2) {
                 /* Do not print distance of device to itself */
                 strncpy(distance_str, "-", sizeof(distance_str));
             } else {
-                status = ucs_topo_get_distance(sys_dev1, sys_dev2, &distance);
+                status = ucs_topo_get_distance(actual_sys_dev1, actual_sys_dev2,
+                                               &distance);
                 if (status != UCS_OK) {
                     ucs_snprintf_safe(distance_str, sizeof(distance_str),
                                       "<error %d>", status);

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -127,6 +127,7 @@ ucp_rkey_pack_common(ucp_context_h context, ucp_md_map_t md_map,
     unsigned md_index, uct_memh_index;
     char UCS_V_UNUSED buf[128];
     ucs_sys_device_t sys_dev;
+    ucs_sys_device_t actual_sys_dev;
     size_t tl_rkey_size;
     ucs_status_t status;
     void *tl_rkey_buf;
@@ -175,7 +176,8 @@ ucp_rkey_pack_common(ucp_context_h context, ucp_md_map_t md_map,
 
     /* Pack distance from sys_dev to each device in distance_dev_map */
     ucs_for_each_bit(sys_dev, sys_dev_map) {
-        ucp_rkey_pack_distance(sys_dev, sys_distance++,
+        actual_sys_dev = ucs_sys_topo_devices[sys_dev];
+        ucp_rkey_pack_distance(actual_sys_dev, sys_distance++,
                                ucs_serialize_next(&p,
                                                   ucp_rkey_packed_distance_t));
     }

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -12,6 +12,7 @@
 #include <ucp/core/ucp_types.h>
 #include <ucs/datastruct/linear_func.h>
 #include <ucs/datastruct/string_buffer.h>
+#include <ucs/sys/topo/base/topo.h>
 
 
 /* Maximal number of lanes per protocol */
@@ -80,11 +81,11 @@ typedef struct {
     uint8_t                 op_flags;   /* Operation flags */
     uint8_t                 dt_class;   /* Datatype */
     uint8_t                 mem_type;   /* Memory type */
-    uint8_t                 sys_dev;    /* System device */
+    ucs_sys_device_t        sys_dev;    /* System device */
     uint8_t                 sg_count;   /* Number of non-contig scatter/gather
                                            entries. If the actual number is larger
                                            than UINT8_MAX, UINT8_MAX is used. */
-    uint8_t                 padding[2]; /* Make structure size be sizeof(uint64_t) */
+    uint8_t                 padding[1]; /* Make structure size be sizeof(uint64_t) */
 } UCS_S_PACKED ucp_proto_select_param_t;
 
 

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -136,7 +136,6 @@ ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
     select_param->sys_dev    = mem_info->sys_dev;
     select_param->sg_count   = sg_count;
     select_param->padding[0] = 0;
-    select_param->padding[1] = 0;
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -23,7 +23,7 @@
 #include <dirent.h>
 
 
-#define UCS_TOPO_MAX_SYS_DEVICES     256
+#define UCS_TOPO_MAX_SYS_DEVICES     UINT16_MAX
 #define UCS_TOPO_SYSFS_PCI_PREFIX    "/sys/bus/pci/devices/"
 #define UCS_TOPO_SYSFS_DEVICES_ROOT  "/sys/devices"
 #define UCS_TOPO_DEVICE_NAME_UNKNOWN "<unknown>"
@@ -138,16 +138,18 @@ static void ucs_topo_bus_id_str(const ucs_sys_bus_id_t *bus_id, int abbreviate,
     }
 }
 
-ucs_sys_device_t ucs_topo_get_sys_device_index(const ucs_sys_bus_id_t *bus_id)
+ucs_status_t ucs_topo_init_sys_dev_hash()
 {
     ucs_sys_device_t count = 0;
-    char target[PATH_MAX];
     DIR *d;
     struct dirent *dir;
+    int num_fields;
+    khiter_t hash_it;
+    ucs_kh_put_t kh_put_status;
+    ucs_sys_bus_id_t bus_id;
+    ucs_bus_id_bit_rep_t bus_id_bit_rep;
 
-    sprintf(target, "%04hx:%02hhx:%02hhx.%hhx", bus_id->domain, bus_id->bus,
-                                          bus_id->slot, bus_id->function);
-
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
     d = opendir(UCS_TOPO_SYSFS_PCI_PREFIX);
     if (d) {
         /* assumes that if directory contents remains the same, the ordering of
@@ -157,25 +159,51 @@ ucs_sys_device_t ucs_topo_get_sys_device_index(const ucs_sys_bus_id_t *bus_id)
                 (!strcmp(dir->d_name, "..")) ) {
                 continue;
             }
-            else if (!strcmp(dir->d_name, target)) {
-                closedir(d);
-                return count;
+            else {
+                num_fields = sscanf(dir->d_name, "%hx:%hhx:%hhx.%hhx", &bus_id.domain,
+                                    &bus_id.bus, &bus_id.slot, &bus_id.function);
+                if (num_fields != 4) {
+                    return UCS_ERR_IO_ERROR;
+                }
+
+                bus_id_bit_rep  = ucs_topo_get_bus_id_bit_repr(&bus_id);
+                hash_it = kh_put(bus_to_sys_dev,
+                                 &ucs_topo_global_ctx.bus_to_sys_dev_hash,
+                                 bus_id_bit_rep, &kh_put_status);
+                if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
+                    ucs_error("%s should not be in bus_to_sys_dev_hash",
+                              dir->d_name);
+                } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
+                           (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
+                    kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash,
+                             hash_it) = count;
+                    ucs_trace("added %s to bus_to_sys_dev_hash sys_dev = %u",
+                              dir->d_name, (unsigned)count);
+                }
             }
             count++;
         }
         closedir(d);
     }
 
-    return UCS_SYS_DEVICE_ID_UNKNOWN;
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+    return UCS_OK;
 }
 
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                                             ucs_sys_device_t *sys_dev)
 {
+    static int initialized = 0;
+    ucs_status_t status    = UCS_OK;
     ucs_bus_id_bit_rep_t bus_id_bit_rep;
     ucs_kh_put_t kh_put_status;
     khiter_t hash_it;
     char *name;
+
+    if (!initialized) {
+        ucs_topo_init_sys_dev_hash();
+        initialized = 1;
+    }
 
     bus_id_bit_rep  = ucs_topo_get_bus_id_bit_repr(bus_id);
 
@@ -185,21 +213,15 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
             &ucs_topo_global_ctx.bus_to_sys_dev_hash /*pointer to hashmap*/,
             bus_id_bit_rep /*key*/, &kh_put_status);
 
-    if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
-        *sys_dev = kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it);
-    } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
-               (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
+    if (kh_put_status != UCS_KH_PUT_KEY_PRESENT) {
+        status = UCS_ERR_NO_ELEM;
+        goto err;
+    } else {
         ucs_assert_always(ucs_topo_global_ctx.num_devices <
                           UCS_TOPO_MAX_SYS_DEVICES);
-        /* find entry number in UCS_TOPO_SYSFS_PCI_PREFIX */
-        *sys_dev = ucs_topo_get_sys_device_index(bus_id);
-        if (*sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
-            ucs_spin_unlock(&ucs_topo_global_ctx.lock);
-            return UCS_ERR_NO_RESOURCE;
-        }
-        ucs_sys_topo_devices[ucs_topo_global_ctx.num_devices++] = *sys_dev;
 
-        kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
+        *sys_dev = kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it);
+        ucs_sys_topo_devices[ucs_topo_global_ctx.num_devices++] = *sys_dev;
 
         /* Set default name to abbreviated BDF */
         name = ucs_malloc(UCS_SYS_BDF_NAME_MAX, "sys_dev_bdf_name");
@@ -213,8 +235,9 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
         ucs_debug("added sys_dev %d for bus id %s", *sys_dev, name);
     }
 
+err:
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
-    return UCS_OK;
+    return status;
 }
 
 ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -481,9 +481,9 @@ void ucs_topo_init()
     }
 
     ucs_topo_default_distance.latency   =
-        UCS_FP8_PACK(UCS_LATENCY,
+        UCS_FP8_PACK(UCS_LAT,
                      ucs_topo_default_distance.latency * UCS_NSEC_PER_SEC);
-    ucs_topo_default_distance.bandwidth = UCS_FP8_PACK(UCS_BANDWIDTH,
+    ucs_topo_default_distance.bandwidth = UCS_FP8_PACK(UCS_BW,
                                                        ucs_topo_default_distance.bandwidth);
 
     ucs_list_add_tail(&ucs_sys_topo_methods_list,

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -51,6 +51,7 @@ const ucs_sys_dev_distance_t ucs_topo_default_distance = {
     .bandwidth = DBL_MAX
 };
 static ucs_topo_global_ctx_t ucs_topo_global_ctx;
+ucs_sys_device_t ucs_sys_topo_devices[UCS_SYS_DEVICE_ID_MAX];
 
 
 /* Global list of topology detectors */
@@ -196,7 +197,7 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
             ucs_spin_unlock(&ucs_topo_global_ctx.lock);
             return UCS_ERR_NO_RESOURCE;
         }
-        ++ucs_topo_global_ctx.num_devices;
+        ucs_sys_topo_devices[ucs_topo_global_ctx.num_devices++] = *sys_dev;
 
         kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
 

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -139,8 +139,8 @@ static void ucs_topo_bus_id_str(const ucs_sys_bus_id_t *bus_id, int abbreviate,
 
 uint8_t ucs_topo_get_sys_device_index(const ucs_sys_bus_id_t *bus_id)
 {
-    char target[] = "0000:00:00.0";
     uint8_t count = 0;
+    char target[PATH_MAX];
     DIR *d;
     struct dirent *dir;
 

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -46,7 +46,7 @@ typedef struct ucs_topo_global_ctx {
 } ucs_topo_global_ctx_t;
 
 
-const ucs_sys_dev_distance_t ucs_topo_default_distance = {
+ucs_sys_dev_distance_t ucs_topo_default_distance = {
     .latency   = 0,
     .bandwidth = DBL_MAX
 };
@@ -479,6 +479,12 @@ void ucs_topo_init()
     for (i = 0; i < UCS_TOPO_MAX_SYS_DEVICES;i++) {
         ucs_topo_global_ctx.devices[i].name = NULL;
     }
+
+    ucs_topo_default_distance.latency   =
+        UCS_FP8_PACK(UCS_LATENCY,
+                     ucs_topo_default_distance.latency * UCS_NSEC_PER_SEC);
+    ucs_topo_default_distance.bandwidth = UCS_FP8_PACK(UCS_BANDWIDTH,
+                                                       ucs_topo_default_distance.bandwidth);
 
     ucs_list_add_tail(&ucs_sys_topo_methods_list,
                       &ucs_sys_topo_default_method.list);

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -138,9 +138,9 @@ static void ucs_topo_bus_id_str(const ucs_sys_bus_id_t *bus_id, int abbreviate,
     }
 }
 
-uint8_t ucs_topo_get_sys_device_index(const ucs_sys_bus_id_t *bus_id)
+ucs_sys_device_t ucs_topo_get_sys_device_index(const ucs_sys_bus_id_t *bus_id)
 {
-    uint8_t count = 0;
+    ucs_sys_device_t count = 0;
     char target[PATH_MAX];
     DIR *d;
     struct dirent *dir;

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -30,11 +30,11 @@ BEGIN_C_DECLS
 
 
 /* bandwidth precision as bytes/second, range: 512 MB/s to 4 TB/s */
-UCS_FP8_DECLARE_TYPE(UCS_BANDWIDTH, 512 * UCS_MBYTE, 4 * UCS_TBYTE)
+UCS_FP8_DECLARE_TYPE(UCS_BW, 512 * UCS_MBYTE, 4 * UCS_TBYTE)
 
 
 /* latency precision as nanoseconds, range: 16 nsec to 131 usec */
-UCS_FP8_DECLARE_TYPE(UCS_LATENCY, UCS_BIT(4), UCS_BIT(17))
+UCS_FP8_DECLARE_TYPE(UCS_LAT, UCS_BIT(4), UCS_BIT(17))
 
 
 typedef struct ucs_sys_bus_id {

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -9,6 +9,8 @@
 
 #include <ucs/type/status.h>
 #include <ucs/datastruct/list.h>
+#include <ucs/sys/math.h>
+#include <ucs/type/float8.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -25,6 +27,14 @@ BEGIN_C_DECLS
 
 /* Maximal size of BDF string */
 #define UCS_SYS_BDF_NAME_MAX 16
+
+
+/* bandwidth precision as bytes/second, range: 512 MB/s to 4 TB/s */
+UCS_FP8_DECLARE_TYPE(UCS_BANDWIDTH, 512 * UCS_MBYTE, 4 * UCS_TBYTE)
+
+
+/* latency precision as nanoseconds, range: 16 nsec to 131 usec */
+UCS_FP8_DECLARE_TYPE(UCS_LATENCY, UCS_BIT(4), UCS_BIT(17))
 
 
 typedef struct ucs_sys_bus_id {
@@ -54,7 +64,7 @@ typedef struct ucs_sys_dev_distance {
 } ucs_sys_dev_distance_t;
 
 
-extern const ucs_sys_dev_distance_t ucs_topo_default_distance;
+extern ucs_sys_dev_distance_t ucs_topo_default_distance;
 
 
 /*

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -85,6 +85,8 @@ typedef struct {
 /* Global list of topology detection methods */
 extern ucs_list_link_t ucs_sys_topo_methods_list;
 
+extern ucs_sys_device_t ucs_sys_topo_devices[];
+
 
 /**
  * Find system device by pci bus id.

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -17,11 +17,11 @@ BEGIN_C_DECLS
 
 
 /* Upper limit on system device id */
-#define UCS_SYS_DEVICE_ID_MAX UINT8_MAX
+#define UCS_SYS_DEVICE_ID_MAX UINT16_MAX
 
 /* Indicate that the ucs_sys_device_t for the device has no real bus_id
  * e.g. virtual devices like CMA/knem */
-#define UCS_SYS_DEVICE_ID_UNKNOWN UINT8_MAX
+#define UCS_SYS_DEVICE_ID_UNKNOWN UINT16_MAX
 
 /* Maximal size of BDF string */
 #define UCS_SYS_BDF_NAME_MAX 16
@@ -41,7 +41,7 @@ typedef struct ucs_sys_bus_id {
  * Obtained from a translation of the device bus id into a short integer
  * Refer ucs_topo_find_device_by_bus_id()
  */
-typedef uint8_t ucs_sys_device_t;
+typedef uint16_t ucs_sys_device_t;
 
 
 /*

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -12,10 +12,11 @@ extern "C" {
 class test_topo : public ucs::test {
 };
 
-uint8_t ucs_topo_get_bus_id(uint8_t index, ucs_sys_bus_id_t *bus_id)
+ucs_sys_device_t ucs_topo_get_bus_id(ucs_sys_device_t index,
+                                     ucs_sys_bus_id_t *bus_id)
 {
-    char bus_str[] = "0000:00:00.0";
-    uint8_t count = 0;
+    char bus_str[]         = "0000:00:00.0";
+    ucs_sys_device_t count = 0;
     int num_fields;
     DIR *d;
     struct dirent *dir;
@@ -46,7 +47,7 @@ uint8_t ucs_topo_get_bus_id(uint8_t index, ucs_sys_bus_id_t *bus_id)
 }
 
 UCS_TEST_F(test_topo, find_device_by_bus_id) {
-    uint8_t device_count = 0;
+    ucs_sys_device_t device_count = 0;
     ucs_status_t status;
     ucs_sys_device_t dev1;
     ucs_sys_device_t dev2;

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -12,7 +12,41 @@ extern "C" {
 class test_topo : public ucs::test {
 };
 
+uint8_t ucs_topo_get_bus_id(uint8_t index, ucs_sys_bus_id_t *bus_id)
+{
+    char bus_str[] = "0000:00:00.0";
+    uint8_t count = 0;
+    int num_fields;
+    DIR *d;
+    struct dirent *dir;
+
+    d = opendir("/sys/bus/pci/devices/");
+    if (d) {
+        while ((dir = readdir(d)) != NULL) {
+            if ((!strcmp(dir->d_name, ".")) ||
+                    (!strcmp(dir->d_name, "..")) ) {
+                continue;
+            }
+            else if (count >= index) {
+                strcpy(bus_str, dir->d_name);
+                num_fields = sscanf(bus_str, "%hx:%hhx:%hhx.%hhx", &bus_id->domain,
+                                    &bus_id->bus, &bus_id->slot, &bus_id->function);
+                if (num_fields != 4) {
+                    return UCS_SYS_DEVICE_ID_UNKNOWN;
+                }
+                closedir(d);
+                return count;
+            }
+            count++;
+        }
+        closedir(d);
+    }
+
+    return UCS_SYS_DEVICE_ID_UNKNOWN;
+}
+
 UCS_TEST_F(test_topo, find_device_by_bus_id) {
+    uint8_t device_count = 0;
     ucs_status_t status;
     ucs_sys_device_t dev1;
     ucs_sys_device_t dev2;
@@ -20,10 +54,9 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     ucs_sys_bus_id_t bus_id1;
     ucs_sys_bus_id_t bus_id2;
 
-    dummy_bus_id.domain   = 0xffff;
-    dummy_bus_id.bus      = 0xff;
-    dummy_bus_id.slot     = 0xff;
-    dummy_bus_id.function = 1;
+    dev1 = ucs_topo_get_bus_id(device_count, &dummy_bus_id);
+    ASSERT_NE(dev1, UCS_SYS_DEVICE_ID_UNKNOWN);
+    device_count++;
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev1);
     ASSERT_UCS_OK(status);
@@ -39,11 +72,12 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     EXPECT_EQ(bus_id1.slot, dummy_bus_id.slot);
     EXPECT_EQ(bus_id1.function, dummy_bus_id.function);
 
-    dummy_bus_id.function = 2;
+
+    dev1 = ucs_topo_get_bus_id(device_count, &dummy_bus_id);
+    ASSERT_NE(dev1, UCS_SYS_DEVICE_ID_UNKNOWN);
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev2);
     ASSERT_UCS_OK(status);
-    EXPECT_EQ((unsigned)dev1 + 1, dev2);
     EXPECT_LT(dev2, UCS_SYS_DEVICE_ID_MAX);
     status = ucs_topo_sys_device_set_name(dev2, "test_bus_id_2");
     ASSERT_UCS_OK(status);
@@ -78,7 +112,7 @@ UCS_TEST_F(test_topo, print_info) {
 }
 
 UCS_TEST_F(test_topo, bdf_name) {
-    static const char *bdf_name = "0002:8f:5c.0";
+    static const char *bdf_name = "0000:00:00.0";
     ucs_sys_device_t sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
 
     ucs_status_t status = ucs_topo_find_device_by_bdf_name(bdf_name, &sys_dev);
@@ -95,7 +129,7 @@ UCS_TEST_F(test_topo, bdf_name) {
 }
 
 UCS_TEST_F(test_topo, bdf_name_zero_domain) {
-    static const char *bdf_name = "0000:8f:5c.0";
+    static const char *bdf_name = "0000:00:00.0";
     ucs_sys_device_t sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
 
     const char *short_bdf = strchr(bdf_name, ':') + 1;


### PR DESCRIPTION
## What
Use entry position of given device in `/sys/bus/pci/devices` instead of device iteration count as seen by topo sys on the given process

## Why ?
Hopefully this ensures that all processes see the same sys device index on a given system irrespective of the order in which system devices are populated by each individual process on the system. This allows for system-unique system device index for a given domain:bdf addressed pci device and no exchange of system_device_t -> bus_id is required to meaningfully use a remote_sys_dev for the purposes of iface_estimate_perf. 