### PR TITLE
BINDINGS/GO: Disable go bindings in rpmbuild.

### DIFF
--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -114,7 +114,6 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_args+=" $(with_arg ugni)"
 	with_args+=" $(with_arg xpmem)"
 	with_args+=" $(with_arg fuse)"
-	with_args+=" $(with_arg java)"
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx
 fi

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -106,6 +106,7 @@ Provides header files and examples for developing with UCX.
            %{?debug:--enable-fault-injection} \
            %{?debug:--enable-debug-data} \
            %{?debug:--enable-mt} \
+           --without-go \
            --without-java \
            %_enable_arg cma cma \
            %_with_arg cuda cuda \


### PR DESCRIPTION
## What
Disables go bindings in rpmbuild scripts

## Why ?
To fix #8027 