### PR TITLE
UCT/MM: Disable PEER_FAILURE capability for XPMEM

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -173,6 +173,7 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
 
     status = uct_mm_md_mapper_ops(md)->query(&attach_shm_file);
     ucs_assert_always(status == UCS_OK);
+
     if (attach_shm_file) {
         /*
          * Only MM transports with attaching to SHM file can support error
@@ -181,6 +182,8 @@ static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
          * memory block of a peer leads to "bus" error in case of a peer is
          * down) */
         iface_attr->cap.flags |= UCT_IFACE_FLAG_EP_CHECK;
+    } else {
+        iface_attr->cap.flags &= ~UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
     }
 
     iface_attr->cap.event_flags         = UCT_IFACE_FLAG_EVENT_SEND_COMP     |


### PR DESCRIPTION
## What

Disable PEER_FAILURE capability for XPMEM.

## Why ?

XPMEM doesn't support neither KA mechanisms nor PEER_FAILURE capability.

## How ?

Remove `UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE` flag from iface's capability flags.