### PR TITLE
UCT/IB/TEST: Don't cross-connect RoCE devices in gtest

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1245,7 +1245,10 @@ run_tests() {
 	export UCX_ERROR_MAIL_FOOTER=$JOB_URL/$BUILD_NUMBER/console
 	export UCX_TCP_PORT_RANGE="$((33000 + EXECUTOR_NUMBER * 100))"-"$((34000 + EXECUTOR_NUMBER * 100))"
 	export UCX_TCP_CM_REUSEADDR=y
+
+	# Don't cross-connect RoCE devices
 	export UCX_IB_ROCE_LOCAL_SUBNET=y
+	export UCX_IB_ROCE_SUBNET_PREFIX_LEN=inf
 
 	# load cuda env only if GPU available for remaining tests
 	try_load_cuda_env

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -909,7 +909,7 @@ const uct_ib_device_spec_t* uct_ib_device_spec(uct_ib_device_t *dev)
                     default settings for unknown devices */
 }
 
-static size_t uct_ib_device_get_ib_gid_index(uct_ib_md_t *md)
+static unsigned long uct_ib_device_get_ib_gid_index(uct_ib_md_t *md)
 {
     if (md->config.gid_index == UCS_ULUNITS_AUTO) {
         return UCT_IB_MD_DEFAULT_GID_INDEX;
@@ -930,8 +930,8 @@ ucs_status_t uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num,
     const uct_ib_device_spec_t *dev_info;
     uint8_t required_dev_flags;
     ucs_status_t status;
+    unsigned gid_index;
     union ibv_gid gid;
-    int gid_index;
 
     if (port_num < dev->first_port || port_num >= dev->first_port + dev->num_ports) {
         return UCS_ERR_NO_DEVICE;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -179,7 +179,15 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "Use the local IP address and subnet mask of each network device to route RoCEv2 packets.\n"
    "If set to 'y', only addresses within the interface's subnet will be assumed as reachable.\n"
    "If set to 'n', every remote RoCEv2 IP address is assumed to be reachable from any port.",
-   ucs_offsetof(uct_ib_iface_config_t, rocev2_use_netmask), UCS_CONFIG_TYPE_BOOL},
+   ucs_offsetof(uct_ib_iface_config_t, rocev2_local_subnet), UCS_CONFIG_TYPE_BOOL},
+
+  {"ROCE_SUBNET_PREFIX_LEN", "auto",
+   "Length, in bits, of the subnet prefix to be used for reachability check\n"
+   "when UCX_IB_ROCE_LOCAL_SUBNET is enabled.\n"
+   " - auto  - Detect the subnet prefix length automatically from device address\n"
+   " - inf   - Allow connections only within the same machine and same device\n"
+   " - <num> - Specify a numeric bit-length value for the subnet prefix",
+   ucs_offsetof(uct_ib_iface_config_t, rocev2_subnet_pfx_len), UCS_CONFIG_TYPE_ULUNITS},
 
   {"ROCE_PATH_FACTOR", "1",
    "Multiplier for RoCE LAG UDP source port calculation. The UDP source port\n"
@@ -1178,91 +1186,121 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface)
 }
 
 ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
-                                             size_t md_config_index)
+                                             unsigned long cfg_gid_index)
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     uint8_t port_num     = iface->config.port_num;
 
     ucs_assert(uct_ib_iface_is_roce(iface));
 
-    if (md_config_index == UCS_ULUNITS_AUTO) {
+    if (cfg_gid_index == UCS_ULUNITS_AUTO) {
         return uct_ib_device_select_gid(dev, port_num, &iface->gid_info);
     }
 
-    return uct_ib_device_query_gid_info(dev->ibv_context, uct_ib_device_name(dev),
-                                        port_num, md_config_index,
-                                        &iface->gid_info);
+    return uct_ib_device_query_gid_info(dev->ibv_context,
+                                        uct_ib_device_name(dev), port_num,
+                                        cfg_gid_index, &iface->gid_info);
 }
 
-static void
-uct_ib_iface_init_roce_mask_info(uct_ib_iface_t *iface, size_t md_config_index)
+static ucs_status_t
+uct_ib_iface_init_roce_addr_prefix(uct_ib_iface_t *iface,
+                                   const uct_ib_iface_config_t *config)
 {
-    uct_ib_device_t *dev = uct_ib_iface_device(iface);
-    uint8_t port_num     = iface->config.port_num;
-
+    uct_ib_device_t *dev               = uct_ib_iface_device(iface);
+    uint8_t port_num                   = iface->config.port_num;
+    uct_ib_device_gid_info_t *gid_info = &iface->gid_info;
+    size_t addr_size, max_prefix_bits;
     struct sockaddr_storage mask;
     char ndev_name[IFNAMSIZ];
-    ucs_status_t status;
-    size_t addr_size;
     const void *mask_addr;
+    ucs_status_t status;
 
     ucs_assert(uct_ib_iface_is_roce(iface));
+
+    if ((gid_info->roce_info.ver != UCT_IB_DEVICE_ROCE_V2) ||
+        !config->rocev2_local_subnet) {
+        iface->addr_prefix_bits = 0;
+        return UCS_OK;
+    }
+
+    status = ucs_sockaddr_inet_addr_size(gid_info->roce_info.addr_family,
+                                         &addr_size);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    max_prefix_bits = 8 * addr_size;
+    ucs_assertv(max_prefix_bits <= UINT8_MAX, "max_prefix_bits=%zu",
+                max_prefix_bits);
+
+    if (config->rocev2_subnet_pfx_len == UCS_ULUNITS_INF) {
+        /* Maximal prefix length value */
+        iface->addr_prefix_bits = max_prefix_bits;
+        return UCS_OK;
+    } else if (config->rocev2_subnet_pfx_len != UCS_ULUNITS_AUTO) {
+        /* Configured prefix length value */
+        if (config->rocev2_subnet_pfx_len > max_prefix_bits) {
+            ucs_error("invalid parameter for ROCE_SUBNET_PREFIX_LEN: "
+                      "actual %zu, expected <= %zu",
+                      config->rocev2_subnet_pfx_len, max_prefix_bits);
+            return UCS_ERR_INVALID_PARAM;
+        }
+
+        iface->addr_prefix_bits = config->rocev2_subnet_pfx_len;
+        return UCS_OK;
+    }
 
     status = uct_ib_device_get_roce_ndev_name(dev, port_num,
                                               iface->gid_info.gid_index,
                                               ndev_name, sizeof(ndev_name));
     if (status != UCS_OK) {
-        goto mask_info_failed;
+        goto out_mask_info_failed;
     }
 
     status = ucs_netif_get_addr(ndev_name, AF_UNSPEC, NULL,
                                 (struct sockaddr*)&mask);
     if (status != UCS_OK) {
-        goto mask_info_failed;
-    }
-
-    status = ucs_sockaddr_inet_addr_sizeof((struct sockaddr*)&mask, &addr_size);
-    if (status != UCS_OK) {
-        goto mask_info_failed;
+        goto out_mask_info_failed;
     }
 
     mask_addr               = ucs_sockaddr_get_inet_addr((struct sockaddr*)&mask);
-    iface->addr_prefix_bits = (addr_size * 8) -
+    iface->addr_prefix_bits = max_prefix_bits -
                               ucs_count_ptr_trailing_zero_bits(mask_addr,
-                                                               addr_size * 8);
-    return;
+                                                               max_prefix_bits);
+    return UCS_OK;
 
-mask_info_failed:
+out_mask_info_failed:
     ucs_debug("failed to detect RoCE subnet mask prefix on "UCT_IB_IFACE_FMT
               " - ignoring mask", UCT_IB_IFACE_ARG(iface));
     iface->addr_prefix_bits = 0;
+    return UCS_OK;
 }
 
-static ucs_status_t uct_ib_iface_init_gid_info(uct_ib_iface_t *iface,
-                                               size_t md_config_index,
-                                               int rocev2_use_netmask)
+static ucs_status_t
+uct_ib_iface_init_gid_info(uct_ib_iface_t *iface,
+                           const uct_ib_iface_config_t *config)
 {
+    uct_ib_md_t *md                    = uct_ib_iface_md(iface);
+    unsigned long cfg_gid_index        = md->config.gid_index;
     uct_ib_device_gid_info_t *gid_info = &iface->gid_info;
     ucs_status_t status;
 
     /* Fill the gid index and the RoCE version */
     if (uct_ib_iface_is_roce(iface)) {
-        status = uct_ib_iface_init_roce_gid_info(iface, md_config_index);
+        status = uct_ib_iface_init_roce_gid_info(iface, cfg_gid_index);
         if (status != UCS_OK) {
             goto out;
         }
 
-        if ((gid_info->roce_info.ver == UCT_IB_DEVICE_ROCE_V2) &&
-            rocev2_use_netmask) {
-            uct_ib_iface_init_roce_mask_info(iface, md_config_index);
-        } else {
-            iface->addr_prefix_bits = 0;
+        status = uct_ib_iface_init_roce_addr_prefix(iface, config);
+        if (status != UCS_OK) {
+            goto out;
         }
     } else {
-        gid_info->gid_index             = (md_config_index ==
+        gid_info->gid_index             = (cfg_gid_index ==
                                            UCS_ULUNITS_AUTO) ?
                                           UCT_IB_MD_DEFAULT_GID_INDEX :
-                                          md_config_index;
+                                          cfg_gid_index;
         gid_info->roce_info.ver         = UCT_IB_DEVICE_ROCE_ANY;
         gid_info->roce_info.addr_family = 0;
     }
@@ -1392,8 +1430,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
         goto err;
     }
 
-    status = uct_ib_iface_init_gid_info(self, ib_md->config.gid_index,
-                                        config->rocev2_use_netmask);
+    status = uct_ib_iface_init_gid_info(self, config);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -154,8 +154,11 @@ struct uct_ib_iface_config {
     /* Number of paths to expose for the interface  */
     unsigned long           num_paths;
 
-    /* Whether to use local IP address and subnet mask for RoCE(v2) routing */
-    int                     rocev2_use_netmask;
+    /* Whether to check RoCEv2 reachability by IP address and local subnet */
+    int                     rocev2_local_subnet;
+
+    /* Length of subnet prefix for reachability check */
+    unsigned long           rocev2_subnet_pfx_len;
 
     /* Multiplier for RoCE LAG UDP source port calculation */
     unsigned                roce_path_factor;
@@ -476,7 +479,7 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface);
  * @param md_config_index       Gid index from the md configuration.
  */
 ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
-                                             size_t md_config_index);
+                                             unsigned long cfg_gid_index);
 
 
 static inline uct_ib_md_t* uct_ib_iface_md(uct_ib_iface_t *iface)
@@ -558,7 +561,6 @@ uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
     uct_ib_device_name(uct_ib_iface_device(_iface)), \
     (_iface)->config.port_num, \
     uct_ib_iface_is_roce(_iface) ? "RoCE" : "IB"
-    
 
 
 #define UCT_IB_IFACE_VERBS_COMPLETION_ERR(_type, _iface, _i,  _wc) \

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -81,7 +81,7 @@ typedef struct uct_ib_md_ext_config {
         size_t               max_size;     /**< Maximal memory region size for ODP */
     } odp;
 
-    size_t                   gid_index;    /**< IB GID index to use  */
+    unsigned long            gid_index;    /**< IB GID index to use */
 
     size_t                   min_mt_reg;   /**< Multi-threaded registration threshold */
     size_t                   mt_reg_chunk; /**< Multi-threaded registration chunk */


### PR DESCRIPTION
## Why
When running CI tests on machine with several interfaces without RoCEv2, and also on different subnets, need to prevent them from connecting to each other.