### PR TITLE
UCT/IB: Use DV QP create_flags only if needed - v1.12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ $ make -C test/gtest test
   OS distribution or build glibc from source using versions less than 2.25 or
   greater than 2.29.
 
+* Due to compatibility flaw when using UCX with rdma-core v22 setting
+  UCX_DC_MLX5_RX_INLINE=0 is unsupported and will make DC transport unavailable.
+  This issue is fixed in rdma-core v24 and backported to rdma-core-22.4-2.el7 rpm.
+  See [ucx issue 5749](https://github.com/openucx/ucx/issues/5749) for more
+  details.
+
 <hr>
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -1028,13 +1028,11 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
                                         unsigned scat2cqe_dir_mask)
 {
 #if HAVE_DECL_MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE
-    dv_attr->comp_mask   |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
-    dv_attr->create_flags = 0;
-
     if ((scat2cqe_dir_mask & UCS_BIT(UCT_IB_DIR_RX)) &&
         (iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] == 0)) {
         /* make sure responder scatter2cqe is disabled */
         dv_attr->create_flags |= MLX5DV_QP_CREATE_DISABLE_SCATTER_TO_CQE;
+        dv_attr->comp_mask    |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
     }
 #endif
 
@@ -1053,6 +1051,7 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
              * unless it was already disabled on responder side (otherwise
              * mlx5 driver check fails) */
             dv_attr->create_flags |= MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE;
+            dv_attr->comp_mask    |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
         }
 #endif
     }


### PR DESCRIPTION
## Why ?
Backport https://github.com/openucx/ucx/pull/7982 to v1.12.x
