### PR TITLE
UCP/CORE: Fix printing invalid configuration

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -397,11 +397,6 @@ ucs_status_t ucp_worker_discard_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
                                        ucp_send_nbx_callback_t discarded_cb,
                                        void *discarded_cb_arg);
 
-const char *ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
-                                      ucp_context_h context,
-                                      ucp_worker_cfg_index_t config_idx,
-                                      ucs_string_buffer_t *strb);
-
 void ucp_worker_vfs_refresh(void *obj);
 
 ucs_status_t ucp_worker_discard_uct_ep_pending_cb(uct_pending_req_t *self);


### PR DESCRIPTION
## What

Fix printing invalid configuration.
Now it is printed as follows:
```
[1647246206.076101] [swx-ucx07:40361:0]      ucp_worker.c:1899 UCX  INFO  ep_cfg[0]:
[1647246206.079982] [swx-ucx07:40361:0]      ucp_worker.c:1899 UCX  INFO  ep_cfg[1]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1) rma(rc_mlx5/mlx5_bond_0:1) amo(rc_mlx5/mlx5_bond_0:1)
[1647246206.086670] [swx-ucx07:40361:0]      ucp_worker.c:1899 UCX  INFO    ep_cfg[2]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1) rma(rc_mlx5/mlx5_bond_0:1) amo(rc_mlx5/mlx5_bond_0:1)
```

## Why ?

Fixes #8024
`print_cfg` parameter was removed from `ucp_worker_get_ep_config` function in 03e9f2b0052bf6e7e17c18c0c2d8cb6cf194acc0

## How ?

1. In `ucp_worker_get_ep_config`, check and add to lanes bitmap only valid TL resources.
2. In `ucp_worker_get_ep_config`, add AM lane for emualtion RMA/AMO lanes only if AM lane has value TL resource.
3. Add assertion in `ucp_worker_add_feature_rsc` to check that `rsc_idx` is valid.