### PR TITLE
APPS/IO-DEMO: Add usage of estimated number of EPs

### DIFF
--- a/test/apps/iodemo/run_io_demo.sh
+++ b/test/apps/iodemo/run_io_demo.sh
@@ -430,9 +430,10 @@ make_scripts()
 	collect_ip_addrs
 
 	#
-	# Create list of servers' addresses
+	# Create list of servers' addresses and calculate total number of clients
 	#
 	client_connect_list=""
+	num_clients=0
 	for host in $(split_list ${host_list})
 	do
 		for ((i=0;i<${num_servers_per_host[${host}]};++i))
@@ -440,6 +441,8 @@ make_scripts()
 			port_num=$((base_port_num + i))
 			client_connect_list+=" ${ip_address_per_host[${host}]}:${port_num}"
 		done
+
+		num_clients = $((num_clients + num_clients_per_host[${host}]))
 	done
 
 	#
@@ -628,6 +631,7 @@ make_scripts()
 				    env IODEMO_ROLE=server_${i} ${cmd_prefix} \\
 				        ${iodemo_exe} \\
 				            ${iodemo_server_args} -p ${port_num} \\
+				            -C ${num_clients} \\
 				            ${log_redirect} ${log_file} &
 				}
 

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -136,7 +136,7 @@ UcxContext::~UcxContext()
     }
 }
 
-bool UcxContext::init()
+bool UcxContext::init(unsigned est_num_eps)
 {
     if (_context && _worker) {
         UCX_LOG << "context is already initialized";
@@ -147,14 +147,17 @@ bool UcxContext::init()
     ucp_params_t ucp_params;
     ucp_params.field_mask   = UCP_PARAM_FIELD_FEATURES |
                               UCP_PARAM_FIELD_REQUEST_INIT |
-                              UCP_PARAM_FIELD_REQUEST_SIZE;
+                              UCP_PARAM_FIELD_REQUEST_SIZE |
+                              UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
     ucp_params.features     = _use_am ? UCP_FEATURE_AM :
                                         UCP_FEATURE_TAG | UCP_FEATURE_STREAM;
     if (_epoll_fd != -1) {
         ucp_params.features |= UCP_FEATURE_WAKEUP;
     }
-    ucp_params.request_init = request_init;
-    ucp_params.request_size = sizeof(ucx_request);
+    ucp_params.request_init      = request_init;
+    ucp_params.request_size      = sizeof(ucx_request);
+    ucp_params.estimated_num_eps = est_num_eps;
+
     ucs_status_t status = ucp_init(&ucp_params, NULL, &_context);
     if (status != UCS_OK) {
         UCX_LOG << "ucp_init() failed: " << ucs_status_string(status);

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -117,7 +117,7 @@ public:
 
     virtual ~UcxContext();
 
-    bool init();
+    bool init(unsigned est_num_eps);
 
     bool listen(const struct sockaddr* saddr, size_t addrlen);
 


### PR DESCRIPTION
## What

Add usage of estimated number of EPs.

## Why ?

To use estimated number of EPs for #7899 needs.

## How ?

1. Add `-C` option to specify estimated number of clients.
2. Use value from `-C` (server) or size of addresses vector (client) to set estimated number of EPs during `ucp_init`.
3. Update `run_io_demo.sh` script to specify `-C` for server's binaries.