### PR TITLE
UCT/IB/RC: Get rid of tx_ops_count which has the same value as tx_cq_len

### DIFF
--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -433,7 +433,7 @@ out:
 
 static ucs_status_t uct_rc_iface_tx_ops_init(uct_rc_iface_t *iface)
 {
-    const unsigned count = iface->config.tx_ops_count;
+    const unsigned count = iface->config.tx_cq_len;
     uct_rc_iface_send_op_t *op;
     ucs_status_t status;
 
@@ -464,7 +464,7 @@ static ucs_status_t uct_rc_iface_tx_ops_init(uct_rc_iface_t *iface)
 
 static void uct_rc_iface_tx_ops_cleanup(uct_rc_iface_t *iface)
 {
-    const unsigned total_count = iface->config.tx_ops_count;
+    const unsigned total_count = iface->config.tx_cq_len;
     uct_rc_iface_send_op_t *op;
     unsigned free_count;
 
@@ -473,7 +473,7 @@ static void uct_rc_iface_tx_ops_cleanup(uct_rc_iface_t *iface)
         ++free_count;
         ucs_assert(free_count <= total_count);
     }
-    if (free_count != iface->config.tx_ops_count) {
+    if (free_count != iface->config.tx_cq_len) {
         ucs_warn("rc_iface %p: %u/%d send ops were not released", iface,
                  total_count- free_count, total_count);
     }
@@ -547,7 +547,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     self->config.tx_min_sge     = config->super.tx.min_sge;
     self->config.tx_min_inline  = config->super.tx.min_inline;
     self->config.tx_poll_always = config->tx.poll_always;
-    self->config.tx_ops_count   = tx_cq_size;
+    self->config.tx_cq_len      = tx_cq_size;
     self->config.min_rnr_timer  = uct_ib_to_rnr_fabric_time(config->tx.rnr_timeout);
     self->config.timeout        = uct_ib_to_qp_fabric_time(config->tx.timeout);
     self->config.rnr_retry      = uct_rc_iface_config_limit_value(
@@ -561,7 +561,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     self->config.max_rd_atomic  = config->max_rd_atomic;
     self->config.ooo_rw         = config->ooo_rw;
 #if UCS_ENABLE_ASSERT
-    self->config.tx_cq_len      = tx_cq_size;
     self->tx.in_pending         = 0;
 #endif
     max_ib_msg_size             = uct_ib_iface_port_attr(&self->super)->max_msg_sz;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -270,7 +270,7 @@ struct uct_rc_iface {
         unsigned             tx_qp_len;
         unsigned             tx_min_sge;
         unsigned             tx_min_inline;
-        unsigned             tx_ops_count;
+        unsigned             tx_cq_len;
         uint16_t             tx_moderation;
         uint8_t              tx_poll_always;
 
@@ -292,9 +292,6 @@ struct uct_rc_iface {
         uint8_t              max_rd_atomic;
         /* Enable out-of-order RDMA data placement */
         uint8_t              ooo_rw;
-#if UCS_ENABLE_ASSERT
-        int                  tx_cq_len;
-#endif
         uct_rc_fence_mode_t  fence_mode;
         unsigned             exp_backoff;
         size_t               max_get_zcopy;
@@ -489,8 +486,9 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_iface_add_cq_credits(uct_rc_iface_t *iface, uint16_t cq_credits)
 {
     iface->tx.cq_available += cq_credits;
-    ucs_assertv(iface->tx.cq_available <= iface->config.tx_cq_len,
-                "cq_available=%d tx_cq_len=%d cq_credits=%d",
+    ucs_assertv((ssize_t)iface->tx.cq_available <=
+                (ssize_t)iface->config.tx_cq_len,
+                "cq_available=%d tx_cq_len=%u cq_credits=%d",
                 iface->tx.cq_available, iface->config.tx_cq_len, cq_credits);
 }
 


### PR DESCRIPTION
## What

Get rid of `tx_ops_count` which has the same value as `tx_cq_len`

## Why ?

`tx_ops_count` duplicates `tx_cq_len`, we could leave one of them.

## How ?

1. Move `tx_cq_len` away from `UCX_ENABLE_ASSERT` section.
2. Make `tx_cq_len` unsigned.
3. Remove `tx_ops_count` field and replace all its occurrences with `tx_cq_len`.