### PR TITLE
UCP/CORE/WIREUP: Allow selecting auxiliary transports when creating EP for sending EP_REMOVED

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -159,7 +159,9 @@ enum {
     UCP_EP_INIT_CONNECT_TO_IFACE_ONLY  = UCS_BIT(7),  /**< Select transports which
                                                            support CONNECT_TO_IFACE
                                                            mode only */
-    UCP_EP_INIT_CREATE_AM_LANE_ONLY    = UCS_BIT(8)   /**< Endpoint requires an AM lane only */
+    UCP_EP_INIT_CREATE_AM_LANE_ONLY    = UCS_BIT(8),  /**< Endpoint requires an AM lane only */
+    UCP_EP_INIT_ALLOW_AUX_TL_RSC       = UCS_BIT(9)   /**< Endpoint allows selecting of auxiliary
+                                                           transports for its configuration */
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -395,7 +395,8 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
                 &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
 
         if ((context->tl_rscs[rsc_index].flags & UCP_TL_RSC_FLAG_AUX) &&
-            !(criteria->tl_rsc_flags & UCP_TL_RSC_FLAG_AUX)) {
+            !(criteria->tl_rsc_flags & UCP_TL_RSC_FLAG_AUX) &&
+            !(select_params->ep_init_flags & UCP_EP_INIT_ALLOW_AUX_TL_RSC)) {
             continue;
         }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -722,12 +722,14 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
      *    WIREUP_MSG phase between peers which require a direct EP ID.
      * 3. Create UCP EP with AM lane only, because WIREUP_MSGs are sent using
      *    AM lane.
+     * 4. Allow selecting auxiliary transports for AM lane.
      */
     unsigned ep_init_flags = UCP_EP_INIT_ERR_MODE_PEER_FAILURE |
                              UCP_EP_INIT_FLAG_INTERNAL |
                              UCP_EP_INIT_CONNECT_TO_IFACE_ONLY |
                              UCP_EP_INIT_CREATE_AM_LANE |
-                             UCP_EP_INIT_CREATE_AM_LANE_ONLY;
+                             UCP_EP_INIT_CREATE_AM_LANE_ONLY |
+                             UCP_EP_INIT_ALLOW_AUX_TL_RSC;
     ucs_status_t status;
     ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];


### PR DESCRIPTION
## What

Allow selecting auxiliary transports when creating EP for sending `EP_REMOVED` packet.

## Why ?

If `ud` will be used as a keepalive lane for `UCX_TLS=rc` (where `ud` is defined as auxiliary transport), creating EP for sending `EP_REMOVED` will fail, because it couldn't select AM lane with `CONNECT_TO_IFACE` capability.

## How ?

1. Add new EP initialization flag - `UCP_EP_INIT_ALLOW_AUX_TL_RSC`.
2. Pass `UCP_EP_INIT_ALLOW_AUX_TL_RSC` flag to create UCP EP.
3. Update `ucp_wireup_select_transport` to allow selecting auxiliary transport in case of `UCP_EP_INIT_ALLOW_AUX_TL_RSC` flag specified.