### PR TITLE
UCT/IB/UD: Remove duplicated async dispatch

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -1131,7 +1131,6 @@ ucs_status_t uct_ud_ep_flush(uct_ep_h ep_h, unsigned flags,
     uct_ud_enter(iface);
 
     if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
-        uct_ud_iface_dispatch_async_comps(iface, ep);
         uct_ud_ep_purge(ep, UCS_ERR_CANCELED);
         /* FIXME make flush(CANCEL) operation truly non-blocking and wait until
          * all of the outstanding sends are completed. Without this, zero-copy


### PR DESCRIPTION
## What

Remove duplicated async dispatch.

## Why ?

`uct_ud_iface_dispatch_async_comps` is done in `uct_ud_ep_purge`, no need to do it twice.

## How ?

Remove `uct_ud_iface_dispatch_async_comps` in `uct_ud_ep_flush(CANCEL)`.