### PR TITLE
UCT/IB/UD: Fix flush(CANCEL)

### DIFF
--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -53,7 +53,7 @@ ucs_queue_is_tail(ucs_queue_head_t *queue, ucs_queue_elem_t *elem)
 /**
  * @return Whether the queue is empty.
  */
-static inline int ucs_queue_is_empty(ucs_queue_head_t *queue)
+static inline int ucs_queue_is_empty(const ucs_queue_head_t *queue)
 {
     return queue->ptail == &queue->head;
 }

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -301,7 +301,7 @@ ucs_status_t uct_ud_ep_flush(uct_ep_h ep, unsigned flags,
                              uct_completion_t *comp);
 /* internal flush */
 ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
-                                    uct_completion_t *comp);
+                                    unsigned flags, uct_completion_t *comp);
 
 ucs_status_t uct_ud_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -792,7 +792,7 @@ ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
     count = 0;
     ucs_ptr_array_for_each(ep, i, &iface->eps) {
         /* ud ep flush returns either ok or in progress */
-        status = uct_ud_ep_flush_nolock(iface, ep, NULL);
+        status = uct_ud_ep_flush_nolock(iface, ep, flags, NULL);
         if ((status == UCS_INPROGRESS) || (status == UCS_ERR_NO_RESOURCE)) {
             ++count;
         }
@@ -1063,12 +1063,11 @@ void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
 
         resent_skb->flags &= ~UCT_UD_SEND_SKB_FLAG_RESENDING;
         --cdesc->ep->tx.resend_count;
-
-        uct_ud_ep_window_release_completed(cdesc->ep, is_async);
     } else {
         ucs_assert(skb->flags & UCT_UD_SEND_SKB_FLAG_CTL_ACK);
     }
 
+    uct_ud_ep_window_release_completed(cdesc->ep, is_async);
     uct_ud_skb_release(skb, 0);
 
 }


### PR DESCRIPTION
## What

Fix `flush(CANCEL)` in UD transport.

## Why ?

`flush(CANCEL)` doesn't work correctly - it doesn't wait for all Zcopy TX operation completions.

## How ?

1. Send control messages with `SIGNALED` flag if `FLUSH_CANCEL` flag set on endpoint.
2. Release completed operations in TX window even if `resent_skb` isn't set in `cdesc`.
3. Remove `UCT_UD_SEND_SKB_FLAG_ACK_REQ` flag from SKB and always send `UCT_UD_EP_OP_ACK_REQ` to make sure it is send with `SIGNALED` flag.