### PR TITLE
UCP/CORE: fix occasional crash in finalize

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -726,7 +726,9 @@ static void ucp_worker_iface_deactivate(ucp_worker_iface_t *wiface, int force)
     ucp_worker_set_am_handlers(wiface, 1);
 
     /* Prepare for next receive event */
-    ucp_worker_iface_check_events(wiface, force);
+    if (wiface->attr.cap.event_flags & UCT_IFACE_FLAG_EVENT_RECV) {
+        ucp_worker_iface_check_events(wiface, force);
+    }
 }
 
 void ucp_worker_iface_progress_ep(ucp_worker_iface_t *wiface)


### PR DESCRIPTION
## What
This commit fixes an occasional crash observed in MPI_Finalize of Open MPI when using UCX with ROCm support.
The crash is triggered from ucp_worker_progress() - opal_common_ucx_mca_pmix_fence().
Root cause of the issue is that the rocm uct components do not set UCT_IFACE_FLAG_EVENT_RECV in the iface_query() functions.

##Why
Actual error message:
```
[ixt-sjc2-54:62513:0:62513]  ucp_worker.c:612  Assertion `wiface->attr.cap.event_flags & (1ul << (1))' failed
```
The line in question ucp_worker.c is :
``` 
     ucs_assert(wiface->attr.cap.event_flags & UCT_IFACE_FLAG_EVENT_RECV);
```
## How ?
Avoid calling ucp_worker_iface_check_events() if UCT_IFACE_FLAG_EVENT_RECV is not set.