### PR TITLE
UCM/UTIL: Fix HAVE_DECL_GETAUXVAL ifdefs

### DIFF
--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -29,7 +29,7 @@
 #include <link.h>
 #include <limits.h>
 
-#ifdef HAVE_DECL_GETAUXVAL
+#if HAVE_DECL_GETAUXVAL
 #include <sys/auxv.h>
 #endif
 
@@ -121,7 +121,7 @@ static ucs_status_t ucm_reloc_get_aux_phsize(int *phsize_p)
         return UCS_OK;
     }
 
-#ifdef HAVE_DECL_GETAUXVAL
+#if HAVE_DECL_GETAUXVAL
     phsize = getauxval(AT_PHENT);
     if (phsize > 0) {
         *phsize_p = phsize;


### PR DESCRIPTION
## What
Fixes a bug when getauxval is not available, in which case
HAVE_DECL_GETAUXVAL is defined to zero, so it needs to be checked with `if` and not `ifdef`.

## Why ?
See above.

## How ?

