### PR TITLE
UCT/IB/DEVX: invalidate MR using indirect key

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1137,6 +1137,8 @@ static ucs_status_t ucp_fill_tl_md(ucp_context_h context,
         return status;
     }
 
+    tl_md->pack_flags_mask = (tl_md->attr.cap.flags & UCT_MD_FLAG_INVALIDATE) ?
+                             UCT_MD_MKEY_PACK_FLAG_INVALIDATE : 0;
     return UCS_OK;
 }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -211,10 +211,30 @@ typedef struct ucp_tl_cmpt {
  * Memory domain.
  */
 typedef struct ucp_tl_md {
-    uct_md_h                      md;         /* Memory domain handle */
-    ucp_rsc_index_t               cmpt_index; /* Index of owning component */
-    uct_md_resource_desc_t        rsc;        /* Memory domain resource */
-    uct_md_attr_t                 attr;       /* Memory domain attributes */
+    /**
+     * Memory domain handle
+     */
+    uct_md_h               md;
+
+    /**
+     * Index of owning component
+     */
+    ucp_rsc_index_t        cmpt_index;
+
+    /**
+     * Memory domain resource
+     */
+    uct_md_resource_desc_t rsc;
+
+    /**
+     * Memory domain attributes
+     */
+    uct_md_attr_t          attr;
+
+    /**
+     * Flags mask parameter for @ref uct_md_mkey_pack_v2
+     */
+    unsigned               pack_flags_mask;
 } ucp_tl_md_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2361,6 +2361,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     config->tag.eager.zcopy_auto_thresh = 0;
     config->am.zcopy_auto_thresh        = 0;
     config->p2p_lanes                   = 0;
+    config->uct_rkey_pack_flags         = 0;
     if (context->config.ext.bcopy_thresh == UCS_MEMUNITS_AUTO) {
         config->bcopy_thresh = 0;
     } else {
@@ -2404,6 +2405,8 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             config->md_index[lane] = context->tl_rscs[rsc_index].md_index;
             if (ucp_ep_config_connect_p2p(worker, &config->key, rsc_index)) {
                 config->p2p_lanes |= UCS_BIT(lane);
+            } else if (config->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
+                config->uct_rkey_pack_flags |= UCT_MD_MKEY_PACK_FLAG_INVALIDATE;
             }
         } else {
             config->md_index[lane] = UCP_NULL_RESOURCE;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -347,6 +347,9 @@ struct ucp_ep_config {
      */
     ucp_lane_map_t          p2p_lanes;
 
+    /* Flags which has to be used @ref uct_md_mkey_pack_v2 */
+    unsigned                uct_rkey_pack_flags;
+
     /* Configuration for each lane that provides RMA */
     ucp_ep_rma_config_t     rma[UCP_MAX_LANES];
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -181,7 +181,7 @@ void ucp_rkey_packed_copy(ucp_context_h context, ucp_md_map_t md_map,
 ssize_t
 ucp_rkey_pack_uct(ucp_context_h context, ucp_md_map_t md_map,
                   const uct_mem_h *memh, const ucp_memory_info_t *mem_info,
-                  ucp_sys_dev_map_t sys_dev_map,
+                  ucp_sys_dev_map_t sys_dev_map, unsigned uct_flags,
                   const ucs_sys_dev_distance_t *sys_distance, void *buffer);
 
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -158,7 +158,8 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                                                     sizeof(*rndv_rts_hdr));
         packed_rkey_size      = ucp_rkey_pack_uct(
                 worker->context, sreq->send.state.dt.dt.contig.md_map,
-                sreq->send.state.dt.dt.contig.memh, &mem_info, 0, NULL,
+                sreq->send.state.dt.dt.contig.memh, &mem_info,
+                ucp_ep_config(sreq->send.ep)->uct_rkey_pack_flags, 0, NULL,
                 rkey_buf);
         if (packed_rkey_size < 0) {
             ucs_fatal("failed to pack rendezvous remote key: %s",
@@ -200,8 +201,9 @@ static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
         packed_rkey_size = ucp_rkey_pack_uct(ep->worker->context,
                                              rreq->recv.state.dt.contig.md_map,
                                              rreq->recv.state.dt.contig.memh,
-                                             &mem_info, 0, NULL,
-                                             rndv_rtr_hdr + 1);
+                                             &mem_info,
+                                             ucp_ep_config(ep)->uct_rkey_pack_flags,
+                                             0, NULL, rndv_rtr_hdr + 1);
         if (packed_rkey_size < 0) {
             return packed_rkey_size;
         }

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -334,10 +334,14 @@ ucs_status_t uct_md_mkey_pack_v2(uct_md_h md, uct_mem_h memh,
                                  const uct_md_mkey_pack_params_t *params,
                                  void *rkey_buffer)
 {
-    ucs_status_t status = uct_md_mkey_pack_params_check(md, memh, rkey_buffer);
+    ucs_status_t status;
 
-    return (status == UCS_OK) ?
-           md->ops->mkey_pack(md, memh, params, rkey_buffer) : status;
+    status = uct_md_mkey_pack_params_check(md, memh, rkey_buffer);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return md->ops->mkey_pack(md, memh, params, rkey_buffer);
 }
 
 ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -46,7 +46,7 @@
 #define UCT_IB_PKEY_DEFAULT               0xffff /* Default PKEY */
 #define UCT_IB_DEV_MAX_PORTS              2
 #define UCT_IB_FABRIC_TIME_MAX            32
-#define UCT_IB_INVALID_RKEY               0xffffffffu
+#define UCT_IB_INVALID_MKEY               0xffffffffu
 #define UCT_IB_KEY                        0x1ee7a330
 #define UCT_IB_LINK_LOCAL_PREFIX          be64toh(0xfe80000000000000ul) /* IBTA 4.1.1 12a */
 #define UCT_IB_SITE_LOCAL_PREFIX          be64toh(0xfec0000000000000ul) /* IBTA 4.1.1 12b */

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -644,7 +644,7 @@ void uct_rc_mlx5_handle_unexp_rndv(uct_rc_mlx5_iface_common_t *iface,
     memcpy((char*)rndv_usr_hdr - priv->length, &priv->data, priv->length);
 
     /* Create "packed" rkey to pass it in the callback */
-    uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_RKEY, packed_rkey);
+    uct_ib_md_pack_rkey(ntohl(rvh->rkey), UCT_IB_INVALID_MKEY, packed_rkey);
 
     /* Do not pass flags to cb, because rkey is allocated on stack */
     status = iface->tm.rndv_unexp.cb(iface->tm.rndv_unexp.arg, 0, tag,

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -227,6 +227,7 @@ static ucs_status_t uct_knem_rkey_unpack(uct_component_t *component,
         ucs_error("Failed to allocate memory for uct_knem_key_t");
         return UCS_ERR_NO_MEMORY;
     }
+
     key->cookie = packed->cookie;
     key->address = packed->address;
     *handle_p = NULL;

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -82,10 +82,10 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer,
 
     if ((amo_access && check_umr(ib_md)) || ib_md->relaxed_order) {
         EXPECT_TRUE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
-        EXPECT_TRUE(ib_memh->atomic_rkey != 0);
+        EXPECT_NE(UCT_IB_INVALID_MKEY, ib_memh->atomic_rkey);
     } else {
         EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
-        EXPECT_TRUE(ib_memh->atomic_rkey == 0);
+        EXPECT_EQ(UCT_IB_INVALID_MKEY, ib_memh->atomic_rkey);
     }
 #endif
 


### PR DESCRIPTION
## What
Invalidate MR using indirect key. Another approach of #8002

## Why ?
To minizimize rkey collisions.

