### PR TITLE
UCS/ARCH: auto enable relaxed order for AMD

### DIFF
--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -153,7 +153,14 @@ double ucs_cpu_get_memcpy_bw();
 
 static inline int ucs_cpu_prefer_relaxed_order()
 {
-    return ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM;
+    ucs_cpu_vendor_t cpu_vendor = ucs_arch_get_cpu_vendor();
+    ucs_cpu_model_t cpu_model   = ucs_arch_get_cpu_model();
+
+    return (cpu_vendor == UCS_CPU_VENDOR_FUJITSU_ARM) ||
+           ((cpu_vendor == UCS_CPU_VENDOR_AMD) &&
+            ((cpu_model == UCS_CPU_MODEL_AMD_NAPLES) ||
+             (cpu_model == UCS_CPU_MODEL_AMD_ROME) ||
+             (cpu_model == UCS_CPU_MODEL_AMD_MILAN)));
 }
 
 


### PR DESCRIPTION
## What
Automatically enable relaxed order for AMD model

## Why ?
to maximize performance for AMD model

## How ?
