### PR TITLE
UCP/WIREUP/CORE: Fix CM wireup fallback

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -579,7 +579,8 @@ ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker)
         status = ucp_ep_create_to_worker_addr(worker, &ucp_tl_bitmap_max,
                                               &local_address,
                                               UCP_EP_INIT_FLAG_MEM_TYPE |
-                                              UCP_EP_INIT_FLAG_INTERNAL,
+                                              UCP_EP_INIT_FLAG_INTERNAL |
+                                              UCP_EP_INIT_ALLOW_KA_AUX_TL,
                                               ep_name,
                                               &worker->mem_type_ep[mem_type]);
         if (status != UCS_OK) {
@@ -900,7 +901,8 @@ static ucs_status_t
 ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
                                  const ucp_ep_params_t *params, ucp_ep_h *ep_p)
 {
-    unsigned ep_init_flags = ucp_ep_init_flags(worker, params);
+    unsigned ep_init_flags = ucp_ep_init_flags(worker, params) |
+                             UCP_EP_INIT_ALLOW_KA_AUX_TL;
     ucp_unpacked_address_t remote_address;
     ucp_ep_match_conn_sn_t conn_sn;
     ucs_status_t status;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -160,8 +160,10 @@ enum {
                                                            support CONNECT_TO_IFACE
                                                            mode only */
     UCP_EP_INIT_CREATE_AM_LANE_ONLY    = UCS_BIT(8),  /**< Endpoint requires an AM lane only */
-    UCP_EP_INIT_ALLOW_AUX_TL_RSC       = UCS_BIT(9)   /**< Endpoint allows selecting of auxiliary
-                                                           transports for its configuration */
+    UCP_EP_INIT_ALLOW_KA_AUX_TL        = UCS_BIT(9),  /**< Endpoint allows selecting of auxiliary
+                                                           transports for keepalive lane */
+    UCP_EP_INIT_ALLOW_AM_AUX_TL        = UCS_BIT(10)  /**< Endpoint allows selecting of auxiliary
+                                                           transports for AM lane */
 };
 
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -462,6 +462,7 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, ucp_ep_h ep,
 {
     unsigned ep_init_flags = UCP_EP_INIT_CREATE_AM_LANE |
                              UCP_EP_INIT_CM_WIREUP_CLIENT |
+                             UCP_EP_INIT_ALLOW_KA_AUX_TL |
                              ucp_ep_err_mode_init_flags(msg->err_mode);
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_t status;
@@ -505,7 +506,8 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
 {
     uint64_t remote_uuid      = remote_address->uuid;
     int send_reply            = 0;
-    unsigned ep_init_flags    = ucp_ep_err_mode_init_flags(msg->err_mode);
+    unsigned ep_init_flags    = UCP_EP_INIT_ALLOW_KA_AUX_TL |
+                                ucp_ep_err_mode_init_flags(msg->err_mode);
     ucp_tl_bitmap_t tl_bitmap = UCS_BITMAP_ZERO;
     ucp_rsc_index_t lanes2remote[UCP_MAX_LANES];
     unsigned addr_indices[UCP_MAX_LANES];
@@ -729,7 +731,8 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                              UCP_EP_INIT_CONNECT_TO_IFACE_ONLY |
                              UCP_EP_INIT_CREATE_AM_LANE |
                              UCP_EP_INIT_CREATE_AM_LANE_ONLY |
-                             UCP_EP_INIT_ALLOW_AUX_TL_RSC;
+                             UCP_EP_INIT_ALLOW_AM_AUX_TL |
+                             UCP_EP_INIT_ALLOW_KA_AUX_TL;
     ucs_status_t status;
     ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];


### PR DESCRIPTION
## What

Fix CM wireup fallback.

## Why ?

To allow selecting multiple paths (if their are supported) in CM initial configuration. It was restricted by `AM_LANE_ONLY` flag 
during fallback, because `rc` and `dc` try to create CM configuration with auxiliary UD for keepalive.

## How ?

1. Introduce `UCP_EP_INIT_DISALLOW_AUX_TL_RSC` EP init flag to disallow selection of AUX transports at all.
2. Change order in EP init flags to have `UCP_EP_INIT_DISALLOW_AUX_TL_RSC` before `UCP_EP_INIT_CREATE_AM_LANE_ONLY` -  it is needed to prefer `UCP_EP_INIT_DISALLOW_AUX_TL_RSC` over `UCP_EP_INIT_CREATE_AM_LANE_ONLY` in `ucs_for_each_submask`.
3. Update `ucp_cm_client_uct_connect_progress` to do the following retries of initializing of CM configuration:
- `ep_init_flags` = `0`
- `ep_init_flags` = `UCP_EP_INIT_DISALLOW_AUX_TL_RSC`
- `ep_init_flags` = `UCP_EP_INIT_CREATE_AM_LANE_ONLY`
- `ep_init_flags` = `UCP_EP_INIT_DISALLOW_AUX_TL_RSC | UCP_EP_INIT_CREATE_AM_LANE_ONLY`.