### PR TITLE
UCT/API: uct_md_mkey_pack_v2

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -202,6 +202,15 @@ typedef enum {
 
 
 /**
+ * @ingroup UCT_MD
+ * @brief MD memory key pack parameters field mask.
+ */
+typedef enum {
+    UCT_MD_MKEY_PACK_FIELD_FLAGS = UCS_BIT(0)  /**< flags field */
+} uct_md_mkey_pack_field_mask_t;
+
+
+/**
  * @ingroup UCT_RESOURCE
  * @brief UCT endpoint attributes field mask.
  *
@@ -238,6 +247,23 @@ typedef enum {
      */
     UCT_MD_MEM_DEREG_FLAG_INVALIDATE = UCS_BIT(0)
 } uct_md_mem_dereg_flags_t;
+
+
+typedef enum {
+    /**
+     * The flag is used indicate that remote access to a memory region
+     * associated with the remote key must fail once the memory region is
+     * deregister using @ref uct_md_mem_dereg_v2 with
+     * @ref UCT_MD_MEM_DEREG_FLAG_INVALIDATE flag set. Using
+     * @ref uct_md_mem_dereg_v2 deregistration routine with
+     * @ref UCT_MD_MEM_DEREG_FLAG_INVALIDATE flag set on an rkey that was
+     * generated without @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag will
+     * not function correctly, and may result in data corruption. In other words
+     * in order for @ref UCT_MD_MEM_DEREG_FLAG_INVALIDATE flag to function
+     * the @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag must be set.
+     */
+    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0)
+} uct_md_mkey_pack_flags_t;
 
 
 /**
@@ -311,6 +337,22 @@ typedef struct uct_md_mem_dereg_params {
      */
     uct_completion_t             *comp;
 } uct_md_mem_dereg_params_t;
+
+
+typedef struct uct_md_mkey_pack_params {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_md_mkey_pack_field_mask_t. Fields not specified in this mask
+     * will be ignored. Provides ABI compatibility with respect to adding new
+     * fields.
+     */
+    uint64_t field_mask;
+
+    /**
+     * Remote key packing flags, using bits from @ref uct_md_mkey_pack_flags_t.
+     */
+    unsigned flags;
+} uct_md_mkey_pack_params_t;
 
 
 /**
@@ -390,6 +432,26 @@ uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
  */
 ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
                                  const uct_md_mem_dereg_params_t *params);
+
+
+/**
+ * @ingroup UCT_MD
+ *
+ * @brief Pack a remote key.
+ *
+ * @param [in]  md          Handle to memory domain.
+ * @param [in]  memh        Pack a remote key for this memory handle.
+ * @param [in]  params      Operation parameters, see @ref
+ *                          uct_md_mkey_pack_params_t.
+ * @param [out] rkey_buffer Pointer to a buffer to hold the packed remote key.
+ *                          The size of this buffer has should be at least
+ *                          @ref uct_md_attr_t::rkey_packed_size, as returned by
+ *                          @ref uct_md_query.
+ * @return                  Error code.
+ */
+ucs_status_t uct_md_mkey_pack_v2(uct_md_h md, uct_mem_h memh,
+                                 const uct_md_mkey_pack_params_t *params,
+                                 void *rkey_buffer);
 
 
 /**

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -319,9 +319,34 @@ ucs_status_t uct_config_modify(void *config, const char *name, const char *value
     return ucs_config_parser_set_value(bundle->data, bundle->table, name, value);
 }
 
+static ucs_status_t
+uct_md_mkey_pack_params_check(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
+{
+    if (ENABLE_PARAMS_CHECK) {
+        return ((md != NULL) && (memh != NULL) && (rkey_buffer != NULL)) ?
+               UCS_OK : UCS_ERR_INVALID_PARAM;
+    } else {
+        return UCS_OK;
+    }
+}
+
+ucs_status_t uct_md_mkey_pack_v2(uct_md_h md, uct_mem_h memh,
+                                 const uct_md_mkey_pack_params_t *params,
+                                 void *rkey_buffer)
+{
+    ucs_status_t status = uct_md_mkey_pack_params_check(md, memh, rkey_buffer);
+
+    return (status == UCS_OK) ?
+           md->ops->mkey_pack(md, memh, params, rkey_buffer) : status;
+}
+
 ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
 {
-    return md->ops->mkey_pack(md, memh, rkey_buffer);
+    uct_md_mkey_pack_params_t params = {
+        .field_mask = 0
+    };
+
+    return uct_md_mkey_pack_v2(md, memh, &params, rkey_buffer);
 }
 
 ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -105,8 +105,9 @@ typedef ucs_status_t (*uct_md_mem_query_func_t)(uct_md_h md,
                                                 size_t length,
                                                 uct_md_mem_attr_t *mem_attr);
 
-typedef ucs_status_t (*uct_md_mkey_pack_func_t)(uct_md_h md, uct_mem_h memh,
-                                                void *rkey_buffer);
+typedef ucs_status_t (*uct_md_mkey_pack_func_t)(
+        uct_md_h md, uct_mem_h memh, const uct_md_mkey_pack_params_t *params,
+        void *rkey_buffer);
 
 typedef int (*uct_md_is_sockaddr_accessible_func_t)(uct_md_h md,
                                                     const ucs_sock_addr_t *sockaddr,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -63,8 +63,10 @@ static ucs_status_t uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_cuda_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
-                                            void *rkey_buffer)
+static ucs_status_t
+uct_cuda_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
+                        const uct_md_mkey_pack_params_t *params,
+                        void *rkey_buffer)
 {
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -45,13 +45,15 @@ static ucs_status_t uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
-                                           void *rkey_buffer)
+static ucs_status_t
+uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
+                       const uct_md_mkey_pack_params_t *params,
+                       void *rkey_buffer)
 {
-    uct_cuda_ipc_key_t *packed   = (uct_cuda_ipc_key_t *) rkey_buffer;
-    uct_cuda_ipc_key_t *mem_hndl = (uct_cuda_ipc_key_t *) memh;
+    uct_cuda_ipc_key_t *packed   = rkey_buffer;
+    uct_cuda_ipc_key_t *mem_hndl = memh;
 
-    *packed          = *mem_hndl;
+    *packed = *mem_hndl;
 
     return UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetUuid(&packed->uuid,
                                                     mem_hndl->dev_num));

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -59,11 +59,13 @@ static ucs_status_t uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_gdr_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
-                                           void *rkey_buffer)
+static ucs_status_t
+uct_gdr_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
+                       const uct_md_mkey_pack_params_t *params,
+                       void *rkey_buffer)
 {
-    uct_gdr_copy_key_t *packed      = (uct_gdr_copy_key_t *)rkey_buffer;
-    uct_gdr_copy_mem_t *mem_hndl    = (uct_gdr_copy_mem_t *)memh;
+    uct_gdr_copy_key_t *packed   = rkey_buffer;
+    uct_gdr_copy_mem_t *mem_hndl = memh;
 
     packed->vaddr   = mem_hndl->info.va;
     packed->bar_ptr = mem_hndl->bar_ptr;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -874,11 +874,13 @@ uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
-                                     void *rkey_buffer)
+static ucs_status_t
+uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
+                 const uct_md_mkey_pack_params_t *params,
+                 void *rkey_buffer)
 {
-    uct_ib_md_t *md         = ucs_derived_of(uct_md, uct_ib_md_t);
-    uct_ib_mem_t *memh      = uct_memh;
+    uct_ib_md_t *md    = ucs_derived_of(uct_md, uct_ib_md_t);
+    uct_ib_mem_t *memh = uct_memh;
     uint32_t atomic_rkey;
     ucs_status_t status;
 

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -50,11 +50,13 @@ static ucs_status_t uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
-                                            void *rkey_buffer)
+static ucs_status_t
+uct_rocm_copy_mkey_pack(uct_md_h uct_md, uct_mem_h memh,
+                        const uct_md_mkey_pack_params_t *params,
+                        void *rkey_buffer)
 {
-    uct_rocm_copy_key_t *packed   = (uct_rocm_copy_key_t *)rkey_buffer;
-    uct_rocm_copy_mem_t *mem_hndl = (uct_rocm_copy_mem_t *)memh;
+    uct_rocm_copy_key_t *packed   = rkey_buffer;
+    uct_rocm_copy_mem_t *mem_hndl = memh;
 
     packed->vaddr   = (uint64_t) mem_hndl->vaddr;
     packed->dev_ptr = mem_hndl->dev_ptr;

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -40,11 +40,13 @@ static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
-                                           void *rkey_buffer)
+static ucs_status_t
+uct_rocm_ipc_mkey_pack(uct_md_h uct_md, uct_mem_h memh,
+                       const uct_md_mkey_pack_params_t *params,
+                       void *rkey_buffer)
 {
-    uct_rocm_ipc_key_t *packed   = (uct_rocm_ipc_key_t *) rkey_buffer;
-    uct_rocm_ipc_key_t *key = (uct_rocm_ipc_key_t *) memh;
+    uct_rocm_ipc_key_t *packed = rkey_buffer;
+    uct_rocm_ipc_key_t *key    = memh;
 
     *packed = *key;
 

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -608,10 +608,12 @@ static ucs_status_t uct_posix_iface_addr_pack(uct_mm_md_t *md, void *buffer)
 }
 
 static ucs_status_t
-uct_posix_md_mkey_pack(uct_md_h tl_md, uct_mem_h memh, void *rkey_buffer)
+uct_posix_md_mkey_pack(uct_md_h tl_md, uct_mem_h memh,
+                       const uct_md_mkey_pack_params_t *params,
+                       void *rkey_buffer)
 {
-    uct_mm_md_t                      *md = ucs_derived_of(tl_md, uct_mm_md_t);
-    uct_mm_seg_t                    *seg = memh;
+    uct_mm_md_t *md                      = ucs_derived_of(tl_md, uct_mm_md_t);
+    uct_mm_seg_t *seg                    = memh;
     uct_posix_packed_rkey_t *packed_rkey = rkey_buffer;
 
     packed_rkey->seg_id  = seg->seg_id;

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -136,7 +136,9 @@ static ucs_status_t uct_sysv_mem_free(uct_md_h tl_md, uct_mem_h memh)
 }
 
 static ucs_status_t
-uct_sysv_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
+uct_sysv_md_mkey_pack(uct_md_h md, uct_mem_h memh,
+                      const uct_md_mkey_pack_params_t *params,
+                      void *rkey_buffer)
 {
     uct_sysv_packed_rkey_t *packed_rkey = rkey_buffer;
     const uct_mm_seg_t     *seg         = memh;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -419,7 +419,9 @@ uct_xmpem_mem_dereg(uct_md_h md,
 }
 
 static ucs_status_t
-uct_xpmem_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
+uct_xpmem_mkey_pack(uct_md_h tl_md, uct_mem_h memh,
+                    const uct_md_mkey_pack_params_t *params,
+                    void *rkey_buffer)
 {
     uct_mm_seg_t                    *seg = memh;
     uct_xpmem_packed_rkey_t *packed_rkey = rkey_buffer;

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -200,11 +200,14 @@ static ucs_status_t uct_knem_mem_dereg(uct_md_h md,
     return status;
 }
 
-static ucs_status_t uct_knem_rkey_pack(uct_md_h md, uct_mem_h memh,
-                                       void *rkey_buffer)
+static ucs_status_t
+uct_knem_rkey_pack(uct_md_h md, uct_mem_h memh,
+                   const uct_md_mkey_pack_params_t *params,
+                   void *rkey_buffer)
 {
-    uct_knem_key_t *packed = (uct_knem_key_t*)rkey_buffer;
-    uct_knem_key_t *key = (uct_knem_key_t *)memh;
+    uct_knem_key_t *packed = rkey_buffer;
+    uct_knem_key_t *key    = memh;
+
     packed->cookie  = (uint64_t)key->cookie;
     packed->address = (uintptr_t)key->address;
     ucs_trace("packed rkey: cookie 0x%"PRIx64" address %"PRIxPTR,

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -117,11 +117,13 @@ static ucs_status_t uct_ugni_mem_dereg(uct_md_h md,
     return status;
 }
 
-static ucs_status_t uct_ugni_rkey_pack(uct_md_h md, uct_mem_h memh,
-                                       void *rkey_buffer)
+static ucs_status_t
+uct_ugni_rkey_pack(uct_md_h md, uct_mem_h memh,
+                   const uct_md_mkey_pack_params_t *params,
+                   void *rkey_buffer)
 {
-    gni_mem_handle_t *mem_hndl = (gni_mem_handle_t *) memh;
-    uint64_t *ptr = rkey_buffer;
+    gni_mem_handle_t *mem_hndl = memh;
+    uint64_t *ptr              = rkey_buffer;
 
     ptr[0] = UCT_UGNI_RKEY_MAGIC;
     ptr[1] = mem_hndl->qword1;


### PR DESCRIPTION
## What
Introduce forward compatible `uct_md_mkey_pack_v2`

## Why ?
UCT/IB/DEVX: invalidate MR using indirect key #8061 requires extra argument `flags` for `uct_md_mkey_pack`