### PR TITLE
UCT/RC/DC: Set max allowed rd_atomic_value

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -196,6 +196,8 @@ typedef struct uct_ib_iface_init_attr {
     unsigned    fc_req_size;            /* Flow control request size */
     int         qp_type;                /* IB QP type */
     int         flags;                  /* Various flags (see enum) */
+    /* The maximum number of outstanding RDMA Read/Atomic operations per QP */
+    unsigned    max_rd_atomic;
 } uct_ib_iface_init_attr_t;
 
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1325,7 +1325,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 {
     uct_dc_mlx5_iface_config_t *config = ucs_derived_of(tl_config,
                                                         uct_dc_mlx5_iface_config_t);
-    uct_ib_mlx5_md_t *md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_md_t *md               = ucs_derived_of(tl_md,
+                                                        uct_ib_mlx5_md_t);
     uct_ib_iface_init_attr_t init_attr = {};
     ucs_status_t status;
     unsigned tx_cq_size;
@@ -1339,10 +1340,11 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         return UCS_ERR_INVALID_PARAM;
     }
 
-    init_attr.qp_type     = UCT_IB_QPT_DCI;
-    init_attr.flags       = UCT_IB_CQ_IGNORE_OVERRUN |
-                            UCT_IB_TX_OPS_PER_PATH;
-    init_attr.fc_req_size = sizeof(uct_dc_fc_request_t);
+    init_attr.qp_type       = UCT_IB_QPT_DCI;
+    init_attr.flags         = UCT_IB_CQ_IGNORE_OVERRUN |
+                              UCT_IB_TX_OPS_PER_PATH;
+    init_attr.fc_req_size   = sizeof(uct_dc_fc_request_t);
+    init_attr.max_rd_atomic = md->max_rd_atomic_dc;
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DC_TM) {
         init_attr.flags  |= UCT_IB_TM_SUPPORTED;

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -616,6 +616,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     struct ibv_context *ctx;
     uct_ib_device_t *dev;
     uct_ib_mlx5_md_t *md;
+    unsigned max_rd_atomic_dc;
     void *cap;
     int ret;
 
@@ -693,6 +694,12 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     } else {
         dev->lag_level = UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, num_lag_ports);
     }
+
+    max_rd_atomic_dc = 1 << UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
+                                              log_max_ra_req_dc);
+    ucs_assertv(max_rd_atomic_dc < UINT8_MAX, "max_rd_atomic_dc=%u",
+                max_rd_atomic_dc);
+    md->max_rd_atomic_dc = max_rd_atomic_dc;
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dct) &&
          (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, lag_dct) || (lag_state == 0))) {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -240,6 +240,8 @@ typedef struct uct_ib_mlx5_md {
     void                     *zero_buf;
     uct_ib_mlx5_devx_umem_t  zero_mem;
 #endif
+    /* The maximum number of outstanding RDMA Read/Atomic operations per DC QP. */
+    uint8_t                  max_rd_atomic_dc;
 } uct_ib_mlx5_md_t;
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -861,6 +861,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
     init_attr.flags                 = UCT_IB_CQ_IGNORE_OVERRUN;
     init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx_cq_len;
     init_attr.qp_type               = IBV_QPT_RC;
+    init_attr.max_rd_atomic         = IBV_DEV_ATTR(&md->super.dev,
+                                                   max_qp_rd_atom);
 
     if (IBV_DEVICE_TM_FLAGS(&md->super.dev)) {
         init_attr.flags  |= UCT_IB_TM_SUPPORTED;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -147,7 +147,7 @@ typedef enum uct_rc_fence_mode {
 /* Common configuration used for rc verbs, rcx and dc transports */
 typedef struct uct_rc_iface_common_config {
     uct_ib_iface_config_t    super;
-    unsigned                 max_rd_atomic;
+    unsigned long            max_rd_atomic;
     int                      ooo_rw; /* Enable out-of-order RDMA data placement */
     int                      fence_mode;
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -271,6 +271,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     uct_rc_verbs_iface_config_t *config =
                     ucs_derived_of(tl_config, uct_rc_verbs_iface_config_t);
     uct_ib_iface_config_t *ib_config    = &config->super.super.super;
+    uct_ib_md_t *ib_md                  = ucs_derived_of(tl_md, uct_ib_md_t);
     uct_ib_iface_init_attr_t init_attr  = {};
     uct_ib_qp_attr_t attr               = {};
     const char *dev_name;
@@ -278,12 +279,13 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     struct ibv_qp *qp;
     uct_rc_hdr_t *hdr;
 
-    init_attr.fc_req_size            = sizeof(uct_rc_pending_req_t);
-    init_attr.rx_hdr_len             = sizeof(uct_rc_hdr_t);
-    init_attr.qp_type                = IBV_QPT_RC;
-    init_attr.cq_len[UCT_IB_DIR_RX]  = ib_config->rx.queue_len;
-    init_attr.cq_len[UCT_IB_DIR_TX]  = config->super.tx_cq_len;
-    init_attr.seg_size               = ib_config->seg_size;
+    init_attr.fc_req_size           = sizeof(uct_rc_pending_req_t);
+    init_attr.rx_hdr_len            = sizeof(uct_rc_hdr_t);
+    init_attr.qp_type               = IBV_QPT_RC;
+    init_attr.cq_len[UCT_IB_DIR_RX] = ib_config->rx.queue_len;
+    init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx_cq_len;
+    init_attr.seg_size              = ib_config->seg_size;
+    init_attr.max_rd_atomic         = IBV_DEV_ATTR(&ib_md->dev, max_qp_rd_atom);
 
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_iface_t, &uct_rc_verbs_iface_tl_ops,
                               &uct_rc_verbs_iface_ops, tl_md, worker, params,


### PR DESCRIPTION
## What
- Use maximal allowed `max_rd_atomic` value by default
- Print clear error when user requests `max_rd_atomic` value which is not supported

## Why
- Automatically pick-up maximal allowed by the HCA `max_rd_atomic` value for better performance
- Better user experience

Examples of error output if incorrect value is requested:
```
$UCX_TLS=dc UCX_RC_MAX_RD_ATOMIC=567 ./src/tools/info/ucx_info -e -ut
rc_iface.c:546  UCX  ERROR invalid max_rd_atomic value: 567, can be up to 16
<Failed to create UCP worker>

$UCX_TLS=dc UCX_RC_MAX_RD_ATOMIC=inf ./src/tools/info/ucx_info -e -ut
rc_iface.c:546  UCX  ERROR invalid max_rd_atomic value: inf, can be up to 16
<Failed to create UCP worker>
```