### PR TITLE
UCP/CORE: Print keepalive lane from the configuration

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1606,6 +1606,7 @@ static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
     ucp_lane_map_t amo_lanes_map    = 0;
     ucp_lane_map_t stream_lanes_map = 0;
     ucp_lane_map_t am_lanes_map     = 0;
+    ucp_lane_map_t ka_lanes_map     = 0;
     int rma_emul                    = 0;
     int amo_emul                    = 0;
     int num_valid_lanes             = 0;
@@ -1645,6 +1646,10 @@ static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
             stream_lanes_map |= UCS_BIT(lane);
         }
 
+        if (key->keepalive_lane == lane) {
+            ka_lanes_map |= UCS_BIT(lane);
+        }
+
         if ((ucp_ep_config_get_multi_lane_prio(key->rma_lanes, lane) >= 0)) {
             rma_lanes_map |= UCS_BIT(lane);
         }
@@ -1677,6 +1682,7 @@ static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
                                !amo_emul ? "amo" : "amo_am", &strb);
     ucp_worker_add_feature_rsc(context, key, am_lanes_map, "am", &strb);
     ucp_worker_add_feature_rsc(context, key, stream_lanes_map, "stream", &strb);
+    ucp_worker_add_feature_rsc(context, key, ka_lanes_map, "ka", &strb);
 
     ucs_string_buffer_rtrim(&strb, "; ");
 


### PR DESCRIPTION
## What

Print keepalive lane from the configuration.

## Why ?

To make sure that keepalive is done on a desired transport.
Before:
```
[1648584569.734329] [swx-ucx01:45206:0]      ucp_worker.c:1686 UCX  INFO  ep_cfg[1]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1) stream(rc_mlx5/mlx5_bond_0:1)
```
After:
```
[1648589358.246918] [swx-ucx01:62071:0]      ucp_worker.c:1690 UCX  INFO    ep_cfg[0]: tag(rc_mlx5/mlx5_bond_0:1 rc_mlx5/mlx5_bond_0:1) rma(rc_mlx5/mlx5_bond_0:1) amo_am(rc_mlx5/mlx5_bond_0:1) keepalive(ud_mlx5/mlx5_bond_0:1)
```

## How ?

Update `ucp_worker_print_used_tls` to print keepalive lane using `ucp_worker_add_feature_rsc` function.