### PR TITLE
UCP/CORE/INFO: Print stream API limits and handle stream feature in ucx_info

### DIFF
--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -40,6 +40,7 @@ static void usage() {
     printf("                    'a' : atomic operations\n");
     printf("                    'r' : remote memory access\n");
     printf("                    't' : tag matching \n");
+    printf("                    's' : stream \n");
     printf("                    'm' : active messages \n");
     printf("                  Modifiers to use in combination with above features:\n");
     printf("                    'w' : wakeup\n");
@@ -164,6 +165,9 @@ int main(int argc, char **argv)
                     break;
                 case 't':
                     ucp_features |= UCP_FEATURE_TAG;
+                    break;
+                case 's':
+                    ucp_features |= UCP_FEATURE_STREAM;
                     break;
                 case 'm':
                     ucp_features |= UCP_FEATURE_AM;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2929,6 +2929,14 @@ static void ucp_ep_config_print(FILE *stream, ucp_worker_h worker,
                                   config->tag.rndv.am_thresh.remote);
     }
 
+    if (context->config.features & UCP_FEATURE_STREAM) {
+        ucp_ep_config_print_proto(stream, "stream_send",
+                                  config->am.max_short,
+                                  config->am.zcopy_thresh[0],
+                                  /* disable rndv */
+                                  SIZE_MAX, SIZE_MAX);
+    }
+
     if (context->config.features & UCP_FEATURE_AM) {
         ucp_ep_config_print_proto(stream, "am_send",
                                   config->am_u.max_eager_short.memtype_on,


### PR DESCRIPTION
## What

1. Print stream API limits.
2. Handle stream feature in `ucx_info`.

## Why ?

To show stream API limits from `ucx_info` utility.
Before:
```
# UCP endpoint
#
#               peer: swx-ucx01:13591
#                 lane[0]:  1:rc_mlx5/mlx5_bond_0:1.0 md[0]  -> md[0]/ib/sysdev[255] rma_bw#0 am am_bw#0
#                 lane[1]:  1:rc_mlx5/mlx5_bond_0:1.1 md[0]  -> md[0]/ib/sysdev[255] rma_bw#1
#                 lane[2]:  3:ud_mlx5/mlx5_bond_0:1.0 md[0]  -> md[0]/ib/sysdev[255] keepalive wireup
#
#                tag_send: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..23258..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..227..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..23258..<rndv>..(inf)
#                 am_send: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..23258..<rndv>..(inf)
#
#                  rma_bw: mds [0] rndv_rkey_size 18
#
```
After:
```
# UCP endpoint
#
#               peer: swx-ucx01:45243
#                 lane[0]:  1:rc_mlx5/mlx5_bond_0:1.0 md[0]  -> md[0]/ib/sysdev[255] rma_bw#0 am am_bw#0
#                 lane[1]:  1:rc_mlx5/mlx5_bond_0:1.1 md[0]  -> md[0]/ib/sysdev[255] rma_bw#1
#                 lane[2]:  3:ud_mlx5/mlx5_bond_0:1.0 md[0]  -> md[0]/ib/sysdev[255] keepalive wireup
#
#                tag_send: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..23258..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..227..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..23258..<rndv>..(inf)
#             stream_send: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..(inf)
#                 am_send: 0..<egr/short>..227..<egr/bcopy>..1740..<egr/zcopy>..23258..<rndv>..(inf)
#
#                  rma_bw: mds [0] rndv_rkey_size 18
#
```

## How ?

1. Update `ucx_info` utility by setting `UCP_FEATURE_STREAM` to the bitmap of UCP features if `-u s` is specified.
2. Update `ucp_ep_config_print` function to print stream AP limits using AM message configuration limits (checked stream_send.c) and pass them to `ucp_ep_config_print_proto` function + disable RNDV by passing `SIZE_MAX`.