### PR TITLE
UCP/CORE: Minor code improvements.

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -374,7 +374,7 @@ ucp_memh_get_slow(ucp_context_h context, void *address, size_t length,
 
     if (context->rcache == NULL) {
         memh = ucs_calloc(1, sizeof(*memh) +
-                          (sizeof(uct_mem_h) * context->num_mds), "ucp rcache");
+                          (sizeof(uct_mem_h) * context->num_mds), "ucp_rcache");
         if (memh == NULL) {
             return UCS_ERR_NO_MEMORY;
         }
@@ -1029,7 +1029,7 @@ ucs_status_t ucp_mem_rcache_init(ucp_context_h context)
     rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
     rcache_params.alignment          = UCS_RCACHE_MIN_ALIGNMENT;
 
-    return ucs_rcache_create(&rcache_params, "ucp rcache",
+    return ucs_rcache_create(&rcache_params, "ucp_rcache",
                              ucs_stats_get_root(), &context->rcache);
 }
 

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -54,8 +54,7 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
     if ((select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         ((select_param->op_id != UCP_OP_ID_RNDV_SEND) &&
          (select_param->op_id != UCP_OP_ID_RNDV_RECV)) ||
-        (init_params->select_param->op_flags &
-         UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG)) {
+        ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
         return UCS_ERR_UNSUPPORTED;
     }
 


### PR DESCRIPTION
## What
Replaced space by underscore in rcache name because all other rcache names use underscore style, and in ucs_calloc because we mostly use underscore style in such cases.
Replaced expression by appropriate function call.

## Why
before:
![image](https://user-images.githubusercontent.com/74596089/160906298-ce4e581b-5f2d-4385-aeca-dab819429ccf.png)

after:
![image](https://user-images.githubusercontent.com/74596089/160906151-acd5b39a-5215-49aa-81b2-ef319e3bf25e.png)

list of some objects created by ucs_calloc/ucs_malloc:
![image](https://user-images.githubusercontent.com/74596089/160906475-adab3a92-a519-4f81-92f8-1d4cdb3447fb.png)




