### PR TITLE
UCS/ARCH/INFO: Measure x86 TSC value if can't read it from CPU model

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -179,6 +179,25 @@ static void print_sys_topo()
     printf("#\n");
 }
 
+static double measure_timer_accuracy()
+{
+    double elapsed, elapsed_accurate;
+    ucs_time_t time0, time1;
+    double sec0, sec1;
+
+    sec0  = ucs_get_accurate_time();
+    time0 = ucs_get_time();
+    usleep(100000);
+    sec1  = ucs_get_accurate_time();
+    time1 = ucs_get_time();
+
+    elapsed          = ucs_time_to_sec(time1 - time0);
+    elapsed_accurate = sec1 - sec0;
+
+    return ucs_min(elapsed, elapsed_accurate) /
+           ucs_max(elapsed, elapsed_accurate);
+}
+
 void print_sys_info(int print_opts)
 {
     size_t size;
@@ -186,6 +205,7 @@ void print_sys_info(int print_opts)
     if (print_opts & PRINT_SYS_INFO) {
         printf("# Timer frequency: %.3f MHz\n",
                ucs_get_cpu_clocks_per_sec() / 1e6);
+        printf("# Timer accuracy: %.3f %%\n", measure_timer_accuracy() * 100);
         printf("# CPU vendor: %s\n",
                cpu_vendor_names[ucs_arch_get_cpu_vendor()]);
         printf("# CPU model: %s\n", cpu_model_names[ucs_arch_get_cpu_model()]);

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -44,7 +44,7 @@ BEGIN_C_DECLS
 extern ucs_ternary_auto_value_t ucs_arch_x86_enable_rdtsc;
 
 double ucs_arch_get_clocks_per_sec();
-double ucs_x86_init_tsc_freq();
+void ucs_x86_init_tsc_freq();
 
 ucs_cpu_model_t ucs_arch_get_cpu_model() UCS_F_NOOPTIMIZE;
 ucs_cpu_flag_t ucs_arch_get_cpu_flag() UCS_F_NOOPTIMIZE;
@@ -53,28 +53,31 @@ void ucs_cpu_init();
 ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes);
 void ucs_x86_memcpy_sse_movntdqa(void *dst, const void *src, size_t len);
 
-static inline int ucs_arch_x86_rdtsc_enabled()
+static UCS_F_ALWAYS_INLINE int ucs_arch_x86_rdtsc_enabled()
 {
-    double UCS_V_UNUSED dummy_freq;
-
     if (ucs_unlikely(ucs_arch_x86_enable_rdtsc == UCS_TRY)) {
-        dummy_freq = ucs_x86_init_tsc_freq();
+        ucs_x86_init_tsc_freq();
         ucs_assert(ucs_arch_x86_enable_rdtsc != UCS_TRY);
     }
 
     return ucs_arch_x86_enable_rdtsc;
 }
 
-static inline uint64_t ucs_arch_read_hres_clock()
+static UCS_F_ALWAYS_INLINE uint64_t ucs_arch_x86_read_tsc()
 {
     uint32_t low, high;
 
+    asm volatile("rdtsc" : "=a"(low), "=d"(high));
+    return ((uint64_t)high << 32) | (uint64_t)low;
+}
+
+static UCS_F_ALWAYS_INLINE uint64_t ucs_arch_read_hres_clock()
+{
     if (ucs_unlikely(ucs_arch_x86_rdtsc_enabled() == UCS_NO)) {
         return ucs_arch_generic_read_hres_clock();
     }
 
-    asm volatile ("rdtsc" : "=a" (low), "=d" (high));
-    return ((uint64_t)high << 32) | (uint64_t)low;
+    return ucs_arch_x86_read_tsc();
 }
 
 #define ucs_arch_wait_mem ucs_arch_generic_wait_mem

--- a/src/ucs/time/time.c
+++ b/src/ucs/time/time.c
@@ -19,7 +19,7 @@ double ucs_get_cpu_clocks_per_sec()
 
     if (!initialized) {
         clocks_per_sec = ucs_arch_get_clocks_per_sec();
-        ucs_debug("measured arch clock speed: %.2f Hz", clocks_per_sec);
+        ucs_debug("arch clock frequency: %.2f Hz", clocks_per_sec);
         initialized = 1;
     }
     return clocks_per_sec;


### PR DESCRIPTION
## Why
Fix CPU frequency on AMD platforms.
before:
```
$ ucx_info -s
# Timer frequency: 3397.333 MHz
# CPU vendor: AMD
# CPU model: Rome
```

after:
```
$ ./src/tools/info/ucx_info -s
# Timer frequency: 2246.154 MHz
# Timer accuracy: 99.983 %
# CPU vendor: AMD
# CPU model: Rome
```

CPU info:
```
Model name:                      AMD EPYC 7742 64-Core Processor
Stepping:                        0
CPU MHz:                         3283.823
BogoMIPS:                        4491.52
```