### PR TITLE
UCT/IB/UD: Add missing locks in deferred timeout handler

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -252,15 +252,17 @@ static unsigned uct_ud_ep_deferred_timeout_handler(void *arg)
     uct_ud_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_ud_iface_t);
     ucs_status_t status;
 
+    uct_ud_enter(iface);
+
     if (ep->flags & UCT_UD_EP_FLAG_DISCONNECTED) {
         uct_ud_ep_purge(ep, UCS_ERR_ENDPOINT_TIMEOUT);
-        return 0;
+        goto out;
     }
 
     if (ep->flags & UCT_UD_EP_FLAG_PRIVATE) {
         ucs_assert(ucs_queue_is_empty(&ep->tx.window));
         uct_ep_destroy(&ep->super.super);
-        return 0;
+        goto out;
     }
 
     uct_ud_ep_purge(ep, UCS_ERR_ENDPOINT_TIMEOUT);
@@ -274,6 +276,8 @@ static unsigned uct_ud_ep_deferred_timeout_handler(void *arg)
                   ep, UCT_UD_EP_PEER_NAME_ARG(ep));
     }
 
+out:
+    uct_ud_leave(iface);
     return 1;
 }
 


### PR DESCRIPTION
## What

Add missing locks in deferred timeout handler.

## Why ?

Fixes potential data race of deferred timeout handler (which is called from application's thread) and UD async thread which polling TX/RX CQEs.
e.g.:
```
Program terminated with signal 11, Segmentation fault.
#0  0x00007f13f5013311 in ucs_arbiter_group_desched_nonempty (arbiter=0x279f648, group=0x47e7080) at datastruct/arbiter.c:231
231         ucs_arbiter_elem_t *head = group->tail->next;
(gdb) bt
#0  0x00007f13f5013311 in ucs_arbiter_group_desched_nonempty (arbiter=0x279f648, group=0x47e7080) at datastruct/arbiter.c:231
231         ucs_arbiter_elem_t *head = group->tail->next;
Missing separate debuginfos, use: debuginfo-install coreutils-8.22-23.el7.x86_64 fuse3-libs-3.6.1-2.el7.x86_64 glibc-2.17-260.el7.x86_64 libgcc-4.8.5-36.el7.x86_64 libibverbs-55mlnx37-1.55103.x86_64 libnl3-3.2.28-4.el7.x86_64 librdmacm-55mlnx37-1.55103.x86_64 libstdc++-4.8.5-36.el7.x86_64 numactl-libs-2.0.9-7.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) bt
#0  0x00007f13f5013311 in ucs_arbiter_group_desched_nonempty (arbiter=0x279f648, group=0x47e7080) at datastruct/arbiter.c:231
#1  0x00007f13f1c138e4 in ucs_arbiter_group_desched (arbiter=0x279f648, group=0x47e7080) at /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/ucs/datastruct/arbiter.h:317
#2  0x00007f13f1c15f1f in uct_ud_ep_purge (ep=0x47e7050, status=UCS_ERR_ENDPOINT_TIMEOUT) at ud/base/ud_ep.c:245
#3  0x00007f13f1c16089 in uct_ud_ep_deferred_timeout_handler (arg=0x47e7050) at ud/base/ud_ep.c:270
#4  0x00007f13f5015449 in ucs_callbackq_slow_proxy (arg=0x25b0e10) at datastruct/callbackq.c:404
#5  0x00007f13f49a9239 in ucs_callbackq_dispatch (cbq=0x25b0e10) at /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/ucs/datastruct/callbackq.h:211
#6  0x00007f13f49b61ff in uct_worker_progress (worker=0x25b0e10) at /hpc/mtr_scrap/users/dmitrygla/ucx_int3/src/uct/api/uct.h:2638
#7  ucp_worker_progress (worker=0x25f9020) at core/ucp_worker.c:2711
#8  0x0000000000404e24 in UcxContext::progress_worker_event (this=0x7fff433b2d00) at ucx_wrapper.cc:388
#9  0x00000000004044b6 in UcxContext::progress (this=0x7fff433b2d00, count=1) at ucx_wrapper.cc:225
#10 0x0000000000419d3a in DemoClient::wait_for_responses (this=0x7fff433b2d00, max_outstanding=0) at io_demo.cc:2006
#11 0x000000000041b313 in DemoClient::run (this=0x7fff433b2d00) at io_demo.cc:2308
#12 0x0000000000411ebf in do_client (test_opts=...) at io_demo.cc:2933
#13 0x00000000004122e5 in main (argc=65, argv=0x7fff433b3568) at io_demo.cc:2976
(gdb) f 0
#0  0x00007f13f5013311 in ucs_arbiter_group_desched_nonempty (arbiter=0x279f648, group=0x47e7080) at datastruct/arbiter.c:231
231         ucs_arbiter_elem_t *head = group->tail->next;
(gdb) p group->tail
$2 = (ucs_arbiter_elem_t *) 0x0
```
it happens that when entering `ucs_arbiter_group_desched` function `group->tail` isn't `NULL` (so `ucs_arbiter_group_is_empty` function returns `1`), but when entering `ucs_arbiter_group_desched_nonempty` - `group->tail` is `NULL` (it was set to `NULL` by asyn thread)

## How ?

1. Add missing `uct_ud_enter`/`uct_ud_level` to `uct_ud_ep_deferred_timeout_handler`.
2. Always return `1` from `uct_ud_ep_deferred_timeout_handler`, because at least EP's purge/destroy are done - which could be considered as some work.