### PR TITLE
UCT/IB: Make the memlock limit threshold configurable

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -44,6 +44,7 @@ ucs_global_opts_t ucs_global_opts = {
     .tuning_path           = "",
     .memtrack_dest         = "",
     .memtrack_limit        = UCS_MEMUNITS_INF,
+    .memlock_limit         = 500 * UCS_MBYTE,
     .stats_trigger         = "exit",
     .profile_mode          = 0,
     .profile_file          = "",
@@ -164,6 +165,15 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "Memory limit allocated by memtrack. In case if limit is reached then\n"
   "memtrack report is generated and process is terminated.",
   ucs_offsetof(ucs_global_opts_t, memtrack_limit), UCS_CONFIG_TYPE_MEMUNITS},
+
+ {"MEMLOCK_LIMIT", "512m",
+  "Locked memory limit threshold required for proper UCX work.\n"
+  "The default value guarantees the proper work of all dependent UCX parts\n"
+  "in most cases. But in some cases the proper work can be guaranteed\n"
+  "by more or less strict limit threshold.\n"
+  "Please change the limit threshold only if you cannot change \n"
+  "system locked memory limit (ulimit -S -l unlimited).",
+  ucs_offsetof(ucs_global_opts_t, memlock_limit), UCS_CONFIG_TYPE_MEMUNITS},
 
  {"RCACHE_CHECK_PFN", "0",
   "Registration cache to check that the physical pages frame number of a found\n"

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -44,7 +44,7 @@ ucs_global_opts_t ucs_global_opts = {
     .tuning_path           = "",
     .memtrack_dest         = "",
     .memtrack_limit        = UCS_MEMUNITS_INF,
-    .memlock_limit         = 500 * UCS_MBYTE,
+    .memlock_limit         = 512 * UCS_MBYTE,
     .stats_trigger         = "exit",
     .profile_mode          = 0,
     .profile_file          = "",
@@ -167,12 +167,10 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   ucs_offsetof(ucs_global_opts_t, memtrack_limit), UCS_CONFIG_TYPE_MEMUNITS},
 
  {"MEMLOCK_LIMIT", "512m",
-  "Locked memory limit threshold required for proper UCX work.\n"
-  "The default value guarantees the proper work of all dependent UCX parts\n"
-  "in most cases. But in some cases the proper work can be guaranteed\n"
-  "by more or less strict limit threshold.\n"
-  "Please change the limit threshold only if you cannot change \n"
-  "system locked memory limit (ulimit -S -l unlimited).",
+  "The system limit for maximum amount of locked memory must not be smaller\n"
+  "than this value. Otherwise some UCX transports may not function properly.\n"
+  "Please change this threshold only if you cannot change system locked memory\n"
+  "limit (ulimit -S -l unlimited).",
   ucs_offsetof(ucs_global_opts_t, memlock_limit), UCS_CONFIG_TYPE_MEMUNITS},
 
  {"RCACHE_CHECK_PFN", "0",

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -106,6 +106,9 @@ typedef struct {
     /* Memory limit handled by memtrack to abort application */
     size_t                     memtrack_limit;
 
+    /* Locked memory limit threshold required for proper UCX work */
+    size_t                     memlock_limit;
+
     /* Profiling mode */
     unsigned                   profile_mode;
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -31,7 +31,6 @@
 
 
 #define UCT_IB_MD_RCACHE_DEFAULT_ALIGN    16
-#define UCT_IB_MD_REQUIRED_MEMLOCK_LIMIIT (512 * UCS_MBYTE)
 
 
 static UCS_CONFIG_DEFINE_ARRAY(pci_bw,
@@ -1186,7 +1185,7 @@ static ucs_status_t uct_ib_query_md_resources(uct_component_t *component,
     if (num_resources != 0) {
         status = ucs_sys_get_memlock_rlimit(&memlock_limit);
         if ((status == UCS_OK) &&
-            (memlock_limit <= UCT_IB_MD_REQUIRED_MEMLOCK_LIMIIT)) {
+            (memlock_limit <= ucs_global_opts.memlock_limit)) {
             /* Disable the RDMA devices because of too strict locked memory limit*/
             ucs_diag("RDMA transports are disabled because max locked memory "
                      "limit (%llu kbytes) is too low. Please set max locked "


### PR DESCRIPTION
## What
Introducing the `UCX_MEMLOCK_LIMIT` user control that allows to set custom required memory locked limit level.

## Why ?
Now if system memory locked limit is less then 512M some parts of UCX (that depends on this limit, e.g. IB transports) are disabled. But in some cases the proper work of dependent UCX parts may be guaranteed by more or less strict limit. This patch introduces the control that allows to configure this threshold.