### PR TITLE
UCT/IB: Change the IB transports memlock message to warning

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1188,7 +1188,7 @@ static ucs_status_t uct_ib_query_md_resources(uct_component_t *component,
         if ((status == UCS_OK) &&
             (memlock_limit <= UCT_IB_MD_REQUIRED_MEMLOCK_LIMIIT)) {
             /* Disable the RDMA devices because of too strict locked memory limit*/
-            ucs_diag("RDMA transports are disabled because max locked memory "
+            ucs_warn("RDMA transports are disabled because max locked memory "
                      "limit (%llu kbytes) is too low. Please set max locked "
                      "memory (ulimit -l) to 'unlimited'",
                      (memlock_limit / UCS_KBYTE));


### PR DESCRIPTION
## What
Changes the message about "disabling IB transports due to memlock limit" to warning.

## Why ?
Now this message prints on diagnostic message. But some customers may consider the disabling of IB transports without may warning as a regression. So, this patch moves this message to the warning level.
