### PR TITLE
UCP/RMA: Initialize request send state in case of SW RMA/AMO

### DIFF
--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -263,6 +263,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_req_handler, (arg, data, length, am_fl
             ucs_fatal("invalid atomic length: %u", atomicreqh->length);
         }
 
+        ucp_request_send_state_init(req, ucp_dt_make_contig(1),
+                                    atomicreqh->length);
+
         req->flags                           = 0;
         req->send.ep                         = ep;
         req->send.atomic_reply.remote_req_id = atomicreqh->req.req_id;

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -138,6 +138,9 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep)
         return;
     }
 
+    ucp_request_send_state_init(req, ucp_dt_make_contig(1),
+                                sizeof(ucp_cmpl_hdr_t));
+
     req->flags         = 0;
     req->send.ep       = ep;
     req->send.uct.func = ucp_progress_rma_cmpl;
@@ -241,6 +244,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_get_req_handler, (arg, data, length, am_flags
         ucs_error("failed to allocate get reply");
         return UCS_OK;
     }
+
+    ucp_request_send_state_init(req, ucp_dt_make_contig(1), length);
 
     req->flags                        = 0;
     req->send.ep                      = ep;


### PR DESCRIPTION
## What

Initialize request's send state in case of SW RMA/AMO.

## Why ?

Fixes the following issue:
```
/auto/rdmzsysgwork/dmitrygla/ucx/src/ucs/sys/stubs.c: [ ucs_empty_function_do_assert_void() ]
      ...
       99
      100 void ucs_empty_function_do_assert_void()
      101 {
==>   102     ucs_assert_always(0);
      103 }

==== backtrace (tid:   9039) ====
 0 0x000000000008482b ucs_empty_function_do_assert_void()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucs/sys/stubs.c:102
 1 0x000000000006cc2c ucp_send_request_invoke_uct_completion()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_request.inl:453
 2 0x000000000006cc2c ucp_request_send_state_ff()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_request.c:710
 3 0x00000000000531f1 ucp_ep_err_pending_purge()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1176
 4 0x000000000016eefb uct_ud_ep_pending_purge_cb()  /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/ib/ud/base/ud_ep.c:1788
 5 0x00000000000551bd ucs_arbiter_group_purge()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucs/datastruct/arbiter.c:135
 6 0x000000000016f1d6 uct_ud_ep_pending_purge()  /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/ib/ud/base/ud_ep.c:1813
 7 0x0000000000082419 uct_ep_pending_purge()  /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/api/uct.h:3061
 8 0x0000000000053c38 ucp_ep_discard_lanes()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1329
 9 0x0000000000053f14 ucp_ep_set_failed()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1374
10 0x00000000000747eb ucp_worker_iface_handle_uct_ep_failure()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_worker.c:459
11 0x0000000000074c29 ucp_worker_iface_error_handler()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucp/core/ucp_worker.c:553
12 0x0000000000016856 uct_iface_handle_ep_err()  /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/base/uct_iface.c:347
13 0x0000000000166b12 uct_ud_ep_deferred_timeout_handler()  /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/ib/ud/base/ud_ep.c:296
14 0x00000000000575d8 ucs_callbackq_slow_proxy()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucs/datastruct/callbackq.c:404
15 0x00000000000714be ucs_callbackq_dispatch()  /auto/rdmzsysgwork/dmitrygla/ucx/src/ucs/datastruct/callbackq.h:211
16 0x000000000007e453 uct_worker_progress()  /auto/rdmzsysgwork/dmitrygla/ucx/src/uct/api/uct.h:2638
17 0x0000000000a89e4e ucp_test_base::entity::progress()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.cc:1047
18 0x0000000000a8497c ucp_test::progress()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.cc:168
19 0x0000000000a84d81 ucp_test::check_events()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.cc:249
20 0x0000000000a85047 ucp_test::request_process()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.cc:291
21 0x0000000000a8518b ucp_test::request_wait()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.cc:311
22 0x0000000000a851ca ucp_test::requests_wait()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.cc:320
23 0x000000000098737d test_ucp_wireup::send_recv()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/test_ucp_wireup.cc:374
24 0x00000000009905ca test_ucp_wireup_errh_peer_stress_connect_force_disconnect_Test::test_body()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/test_ucp_wireup.cc:964
25 0x0000000000594964 ucs::test_base::run()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/test.cc:356
26 0x0000000000594b27 ucs::test_base::TestBodyProxy()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/test.cc:382
27 0x00000000007b28da ucp_test::TestBody()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/ucp/ucp_test.h:202
28 0x0000000000e1c120 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2433
29 0x0000000000e17faa testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2469
30 0x0000000000e02d3d testing::Test::Run()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2509
31 0x0000000000e035a5 testing::TestInfo::Run()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2687
32 0x0000000000e03c5e testing::TestSuite::Run()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2819
33 0x0000000000e0ee5c testing::internal::UnitTestImpl::RunAllTests()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:5350
34 0x0000000000e1ce23 testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2433
35 0x0000000000e18e4e testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2469
36 0x0000000000e0d928 testing::UnitTest::Run()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:4940
37 0x000000000057bbff RUN_ALL_TESTS()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/googletest/gtest.h:2473
38 0x000000000057bafb main()  /auto/rdmzsysgwork/dmitrygla/ucx/test/gtest/common/main.cc:106
39 0x00000000000223d5 __libc_start_main()  ???:0
40 0x000000000057b279 _start()  ???:0
=================================
(gdb) p req->send.uct.func
$2 = (uct_pending_callback_t) 0x7ffff7262297 <ucp_progress_rma_cmpl>
(gdb) p req->send.state.uct_comp
$3 = {func = 0x7ffff7ab67fc <ucs_empty_function_do_assert_void>, count = 0, status = UCS_ERR_ENDPOINT_TIMEOUT}
```

## How ?

When UCP request was allocated, invoke `ucp_request_send_state_init` for it to make sure it is properly initialized.