### PR TITLE
UCT/IB: Improve DC full handshake logic

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -324,13 +324,16 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
         attr.super.max_inl_cqe[UCT_IB_DIR_RX] = 0;
         attr.uidx             = htonl(dci_index) >> UCT_IB_UIDX_SHIFT;
         attr.full_handshake   = full_handshake;
-        attr.rdma_wr_disabled = iface->flags & UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT;
+        attr.rdma_wr_disabled = (iface->flags & UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT) &&
+                                (md->flags & UCT_IB_MLX5_MD_FLAG_NO_RDMA_WR_OPTIMIZED);
         status = uct_ib_mlx5_devx_create_qp(ib_iface, &dci->txwq.super,
                                             &dci->txwq, &attr);
         if (status != UCS_OK) {
             return status;
         }
 
+        ucs_debug("created DevX DCI 0x%x, rdma_wr_disabled=%d", dci->txwq.super.qp_num,
+                  attr.rdma_wr_disabled);
         goto init_qp;
     }
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -57,7 +57,7 @@ struct ibv_ravh {
  */
 #define UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(_self, _config, _config_name, \
                                                _flag_name, _status, _err) \
-    if (!((_self)->version_flag & UCT_IB_DEVICE_FLAG_DC_V2) && \
+    if (!((_self)->version_flag & UCT_DC_MLX5_IFACE_ADDR_DC_V2) && \
         ((_config)->_config_name##_full_handshake == UCS_YES)) { \
         _status = UCS_ERR_UNSUPPORTED; \
         goto _err; \

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -272,7 +272,8 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    rc[0x1];
 
     uint8_t    uar_4k[0x1];
-    uint8_t    reserved_at_241[0x9];
+    uint8_t    dci_no_rdma_wr_optimized_performance[0x1];
+    uint8_t    reserved_at_242[0x8];
     uint8_t    uar_sz[0x6];
     uint8_t    reserved_at_250[0x8];
     uint8_t    log_pg_sz[0x8];

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -752,6 +752,11 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     }
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
+                          dci_no_rdma_wr_optimized_performance)) {
+        md->flags |= UCT_IB_MLX5_MD_FLAG_NO_RDMA_WR_OPTIMIZED;
+    }
+
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
                           ib_striding_wq_cq_first_indication)) {
         md->flags |= UCT_IB_MLX5_MD_FLAG_MP_XRQ_FIRST_MSG;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -164,29 +164,31 @@ struct mlx5_grh_av {
 
 enum {
     /* Device supports KSM */
-    UCT_IB_MLX5_MD_FLAG_KSM              = UCS_BIT(0),
+    UCT_IB_MLX5_MD_FLAG_KSM                  = UCS_BIT(0),
     /* Device supports DEVX */
-    UCT_IB_MLX5_MD_FLAG_DEVX             = UCS_BIT(1),
+    UCT_IB_MLX5_MD_FLAG_DEVX                 = UCS_BIT(1),
     /* Device supports TM DC */
-    UCT_IB_MLX5_MD_FLAG_DC_TM            = UCS_BIT(2),
+    UCT_IB_MLX5_MD_FLAG_DC_TM                = UCS_BIT(2),
     /* Device supports MP RQ */
-    UCT_IB_MLX5_MD_FLAG_MP_RQ            = UCS_BIT(3),
+    UCT_IB_MLX5_MD_FLAG_MP_RQ                = UCS_BIT(3),
     /* Device supports creation of indirect MR with atomics access rights */
-    UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS = UCS_BIT(4),
+    UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS     = UCS_BIT(4),
     /* Device supports RMP to create SRQ for AM */
-    UCT_IB_MLX5_MD_FLAG_RMP              = UCS_BIT(5),
+    UCT_IB_MLX5_MD_FLAG_RMP                  = UCS_BIT(5),
     /* Device supports querying bitmask of OOO (AR) states per SL */
-    UCT_IB_MLX5_MD_FLAG_OOO_SL_MASK      = UCS_BIT(6),
+    UCT_IB_MLX5_MD_FLAG_OOO_SL_MASK          = UCS_BIT(6),
     /* Device has LAG */
-    UCT_IB_MLX5_MD_FLAG_LAG              = UCS_BIT(7),
+    UCT_IB_MLX5_MD_FLAG_LAG                  = UCS_BIT(7),
     /* Device supports CQE V1 */
-    UCT_IB_MLX5_MD_FLAG_CQE_V1           = UCS_BIT(8),
+    UCT_IB_MLX5_MD_FLAG_CQE_V1               = UCS_BIT(8),
     /* Device supports first fragment indication for MP XRQ */
-    UCT_IB_MLX5_MD_FLAG_MP_XRQ_FIRST_MSG = UCS_BIT(9),
+    UCT_IB_MLX5_MD_FLAG_MP_XRQ_FIRST_MSG     = UCS_BIT(9),
     /* Device supports 64B CQE zipping */
-    UCT_IB_MLX5_MD_FLAG_CQE64_ZIP        = UCS_BIT(10),
+    UCT_IB_MLX5_MD_FLAG_CQE64_ZIP            = UCS_BIT(10),
     /* Device supports 128B CQE zipping */
-    UCT_IB_MLX5_MD_FLAG_CQE128_ZIP       = UCS_BIT(11),
+    UCT_IB_MLX5_MD_FLAG_CQE128_ZIP           = UCS_BIT(11),
+    /* Device performance is optimized when RDMA_WRITE is not used */
+    UCT_IB_MLX5_MD_FLAG_NO_RDMA_WR_OPTIMIZED = UCS_BIT(12),
 
     /* Object to be created by DevX */
     UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 16,


### PR DESCRIPTION
## What
1. Use address version flag.
2. Check whether HW reports better performance when no RDMA_WRITE

## Why ?
1. Currently device flag is used, which is a bug (incorrect value).
2. Only set `rdma_wr_disabled` bit when it has an impact.