### PR TITLE
UCP/WIREUP: Try fallback creating KA lane from exisiting lanes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -642,8 +642,7 @@ ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker)
         status = ucp_ep_create_to_worker_addr(worker, &ucp_tl_bitmap_max,
                                               &local_address,
                                               UCP_EP_INIT_FLAG_MEM_TYPE |
-                                              UCP_EP_INIT_FLAG_INTERNAL |
-                                              UCP_EP_INIT_ALLOW_KA_AUX_TL,
+                                              UCP_EP_INIT_FLAG_INTERNAL,
                                               ep_name,
                                               &worker->mem_type_ep[mem_type]);
         if (status != UCS_OK) {
@@ -964,8 +963,7 @@ static ucs_status_t
 ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
                                  const ucp_ep_params_t *params, ucp_ep_h *ep_p)
 {
-    unsigned ep_init_flags = ucp_ep_init_flags(worker, params) |
-                             UCP_EP_INIT_ALLOW_KA_AUX_TL;
+    unsigned ep_init_flags = ucp_ep_init_flags(worker, params);
     ucp_unpacked_address_t remote_address;
     ucp_ep_match_conn_sn_t conn_sn;
     ucs_status_t status;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -160,8 +160,8 @@ enum {
                                                            support CONNECT_TO_IFACE
                                                            mode only */
     UCP_EP_INIT_CREATE_AM_LANE_ONLY    = UCS_BIT(8),  /**< Endpoint requires an AM lane only */
-    UCP_EP_INIT_ALLOW_KA_AUX_TL        = UCS_BIT(9),  /**< Endpoint allows selecting of auxiliary
-                                                           transports for keepalive lane */
+    UCP_EP_INIT_KA_FROM_EXIST_LANES    = UCS_BIT(9),  /**< Use only existing lanes to create
+                                                           keepalive lane */
     UCP_EP_INIT_ALLOW_AM_AUX_TL        = UCS_BIT(10)  /**< Endpoint allows selecting of auxiliary
                                                            transports for AM lane */
 };

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -462,7 +462,6 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, ucp_ep_h ep,
 {
     unsigned ep_init_flags = UCP_EP_INIT_CREATE_AM_LANE |
                              UCP_EP_INIT_CM_WIREUP_CLIENT |
-                             UCP_EP_INIT_ALLOW_KA_AUX_TL |
                              ucp_ep_err_mode_init_flags(msg->err_mode);
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_t status;
@@ -506,8 +505,7 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
 {
     uint64_t remote_uuid      = remote_address->uuid;
     int send_reply            = 0;
-    unsigned ep_init_flags    = UCP_EP_INIT_ALLOW_KA_AUX_TL |
-                                ucp_ep_err_mode_init_flags(msg->err_mode);
+    unsigned ep_init_flags    = ucp_ep_err_mode_init_flags(msg->err_mode);
     ucp_tl_bitmap_t tl_bitmap = UCS_BITMAP_ZERO;
     ucp_rsc_index_t lanes2remote[UCP_MAX_LANES];
     unsigned addr_indices[UCP_MAX_LANES];
@@ -731,8 +729,7 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                              UCP_EP_INIT_CONNECT_TO_IFACE_ONLY |
                              UCP_EP_INIT_CREATE_AM_LANE |
                              UCP_EP_INIT_CREATE_AM_LANE_ONLY |
-                             UCP_EP_INIT_ALLOW_AM_AUX_TL |
-                             UCP_EP_INIT_ALLOW_KA_AUX_TL;
+                             UCP_EP_INIT_ALLOW_AM_AUX_TL;
     ucs_status_t status;
     ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -424,7 +424,7 @@ out:
 static unsigned ucp_cm_client_uct_connect_progress(void *arg)
 {
     static const unsigned ep_init_flags_prio[] = {
-        UCP_EP_INIT_ALLOW_KA_AUX_TL, 0, UCP_EP_INIT_CREATE_AM_LANE_ONLY
+        0, UCP_EP_INIT_KA_FROM_EXIST_LANES, UCP_EP_INIT_CREATE_AM_LANE_ONLY
     };
     ucp_ep_h ep                                = arg;
     ucp_worker_h worker                        = ep->worker;


### PR DESCRIPTION
## What

Add another fallback type by creating KA lane from already selected resources.

## Why ?

To not open additional resources in case of lack of space in CM private data to pack all addresses.

## How ?

1. Add `tl_bitmap` to UCP wireup select context and update it by adding `rsc_index` which were selected.
2. Introduce new EP init flag - `UCP_EP_INIT_KA_FROM_EXIST_LANES` to select transport fo keepalive lane from already selected lanes.
3. Add `UCP_EP_INIT_KA_FROM_EXIST_LANES` flag to fallback priority list.