### PR TITLE
UCT/DC: Fix max_rd_atomic_dc value for DV

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1062,7 +1062,8 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
         goto err_free;
     }
 
-    md->super.ops = &uct_ib_mlx5_md_ops;
+    md->super.ops        = &uct_ib_mlx5_md_ops;
+    md->max_rd_atomic_dc = IBV_DEV_ATTR(dev, max_qp_rd_atom);
 
     uct_ib_mlx5_parse_relaxed_order(md, md_config);
     status = uct_ib_md_open_common(&md->super, ibv_device, md_config);


### PR DESCRIPTION
## What
Fix max_rd_atomic_dc value for DV

## Why ?
Before
```
$UCX_IB_MLX5_DEVX=no UCX_TLS=dc UCX_DC_MLX5_MAX_RD_ATOMIC=16  ucx_info -e -ut
[1649332429.743654] [jazz07:34105:0]        rc_iface.c:549  UCX  ERROR invalid max_rd_atomic value: 16, can be up to 0
<Failed to create UCP worker>
```
After
```
$UCX_IB_MLX5_DEVX=no UCX_TLS=dc UCX_DC_MLX5_MAX_RD_ATOMIC=16  ucx_info -e -ut
#
# UCP endpoint
#
#               peer: jazz07:34043
#                 lane[0]:  0:dc_mlx5/mlx5_0:1.0 md[0]      -> md[0]/ib/sysdev[255] rma_bw#0 am am_bw#0
#                 lane[1]:  6:dc_mlx5/mlx5_4:1.0 md[3]      -> md[3]/ib/sysdev[255] rma_bw#1
#
#                tag_send: 0..<egr/short>..2039..<egr/zcopy>..21628..<rndv>..(inf)
#            tag_send_nbr: 0..<egr/short>..2039..<egr/bcopy>..262144..<rndv>..(inf)
#           tag_send_sync: 0..<egr/short>..2039..<egr/zcopy>..21628..<rndv>..(inf)
#
#                  rma_bw: mds [0] [3] rndv_rkey_size 27
#

```