### PR TITLE
DC/MLX5: disabled DC on verbs

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1777,7 +1777,8 @@ static ucs_status_t uct_ib_verbs_md_open(struct ibv_device *ibv_device,
         goto err_dev_cfg;
     }
 
-    md->dev.flags  = uct_ib_device_spec(&md->dev)->flags;
+    md->dev.flags = uct_ib_device_spec(&md->dev)->flags;
+    md->name      = UCT_IB_MD_NAME(verbs);
 
     *p_md = md;
     return UCS_OK;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -29,6 +29,8 @@
 #define UCT_IB_MEM_DEREG          0
 #define UCT_IB_CONFIG_PREFIX      "IB_"
 
+#define UCT_IB_MD_NAME(_x)        "ib_" UCS_PP_QUOTE(_x)
+
 
 /**
  * IB MD statistics counters
@@ -142,6 +144,7 @@ typedef struct uct_ib_md {
     size_t                   memh_struct_size;
     uint64_t                 reg_mem_types;
     uint64_t                 cap_flags;
+    char                     *name;
 } uct_ib_md_t;
 
 
@@ -489,4 +492,5 @@ ucs_status_t uct_ib_reg_key_impl(uct_ib_md_t *md, void *address,
                                  size_t length, uint64_t access_flags,
                                  uct_ib_mem_t *memh, uct_ib_mr_t *mrs,
                                  uct_ib_mr_type_t mr_type, int silent);
+
 #endif

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1516,6 +1516,10 @@ uct_dc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
     int flags;
 
+    if (strcmp(ib_md->name, UCT_IB_MD_NAME(mlx5))) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     flags = UCT_IB_DEVICE_FLAG_MLX5_PRM | UCT_IB_DEVICE_FLAG_DC |
             (ib_md->config.eth_pause ? 0 : UCT_IB_DEVICE_FLAG_LINK_IB);
     return uct_ib_device_query_ports(&ib_md->dev, flags, tl_devices_p,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1062,9 +1062,10 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     ucs_debug("%s: opened DEVX md", ibv_get_device_name(ibv_device));
 
-    dev->flags |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
-    md->flags  |= UCT_IB_MLX5_MD_FLAG_DEVX;
-    md->flags  |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
+    dev->flags     |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
+    md->flags      |= UCT_IB_MLX5_MD_FLAG_DEVX;
+    md->flags      |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
+    md->super.name  = UCT_IB_MD_NAME(mlx5);
 
     if (ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_KSM |
                                       UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS)) {
@@ -1307,7 +1308,8 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
         goto err_free;
     }
 
-    dev->flags |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
+    dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
+    md->super.name = UCT_IB_MD_NAME(mlx5);
 
     /* cppcheck-suppress autoVariables */
     *p_md = &md->super;

--- a/src/uct/ib/mlx5/exp/ib_exp_md.c
+++ b/src/uct/ib/mlx5/exp/ib_exp_md.c
@@ -710,8 +710,9 @@ static ucs_status_t uct_ib_mlx5_exp_md_open(struct ibv_device *ibv_device,
         goto err_free;
     }
 
-    dev->flags |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
-    *p_md = &md->super;
+    dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
+    md->super.name = UCT_IB_MD_NAME(mlx5);
+    *p_md          = &md->super;
     return UCS_OK;
 
 err_free:

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -979,6 +979,10 @@ uct_rc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
     int flags;
 
+    if (strcmp(ib_md->name, UCT_IB_MD_NAME(mlx5))) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     flags = UCT_IB_DEVICE_FLAG_MLX5_PRM |
             (ib_md->config.eth_pause ? 0 : UCT_IB_DEVICE_FLAG_LINK_IB);
     return uct_ib_device_query_ports(&ib_md->dev, flags, tl_devices_p,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -919,6 +919,11 @@ uct_ud_mlx5_query_tl_devices(uct_md_h md,
                              unsigned *num_tl_devices_p)
 {
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
+
+    if (strcmp(ib_md->name, UCT_IB_MD_NAME(mlx5))) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     return uct_ib_device_query_ports(&ib_md->dev, UCT_IB_DEVICE_FLAG_MLX5_PRM,
                                      tl_devices_p, num_tl_devices_p);
 }


### PR DESCRIPTION
- disabled DC on over pure verbs: added get_flags interface into IB ops
  to allow get ops configuration
