### PR TITLE
Add the option to disable rcache invalidation on fork

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -57,6 +57,10 @@ ucs_config_field_t uct_md_config_rcache_table[] = {
      ucs_offsetof(uct_md_rcache_config_t, max_unreleased),
      UCS_CONFIG_TYPE_MEMUNITS},
 
+    {"RCACHE_PURGE_ON_FORK", "y",
+     "Purge registration cache upon fork",
+     ucs_offsetof(uct_md_rcache_config_t, purge_on_fork), UCS_CONFIG_TYPE_BOOL},
+
     {NULL}
 };
 
@@ -523,6 +527,8 @@ void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
     rcache_params->max_regions        = rcache_config->max_regions;
     rcache_params->max_size           = rcache_config->max_size;
     rcache_params->max_unreleased     = rcache_config->max_unreleased;
+    rcache_params->flags              = !rcache_config->purge_on_fork ? 0 :
+                                        UCS_RCACHE_FLAG_PURGE_ON_FORK;
 }
 
 double uct_md_rcache_overhead(const uct_md_rcache_config_t *rcache_config)

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -54,6 +54,7 @@ typedef struct uct_md_rcache_config {
     unsigned long max_regions;    /**< Maximal number of rcache regions */
     size_t        max_size;       /**< Maximal size of mapped memory */
     size_t        max_unreleased; /**< Threshold for triggering a cleanup */
+    int           purge_on_fork;  /**< Enable/disable rcache purge on fork */
 } uct_md_rcache_config_t;
 
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1302,7 +1302,6 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md,
             }
             rcache_params.context            = md;
             rcache_params.ops                = &uct_ib_rcache_ops;
-            rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
 
             status = ucs_rcache_create(&rcache_params, uct_ib_device_name(&md->dev),
                                        UCS_STATS_RVAL(md->stats), &md->rcache);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -378,7 +378,6 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
         rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED;
         rcache_params.context            = knem_md;
         rcache_params.ops                = &uct_knem_rcache_ops;
-        rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
         status = ucs_rcache_create(&rcache_params, "knem", ucs_stats_get_root(),
                                    &knem_md->rcache);
         if (status == UCS_OK) {


### PR DESCRIPTION
## What
Add the option to disable rcache invalidation on fork.

## Why ?
rcache invalidation on fork can have performance overheads due to extra registration/deregistration. For IB in particular, and in presence of with ibv_fork_init, if the user knows that all buffers that are passed to UCX are page-aligned, there is no need to purge rcache on fork. This PR provides `UCX_IB_RCACHE_PURGE_ON_FORK` to disable IB rcache purge on fork.

