### PR TITLE
UCP/RNDV: Define min chunk size for multi-rail

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -55,6 +55,8 @@ typedef struct ucp_context_config {
     /** Maximal allowed ratio between slowest and fastest lane in a multi-lane
      *  protocol. Lanes slower than the specified ratio will not be used */
     double                                 multi_lane_max_ratio;
+    /* Bandwidth efficiency ratio */
+    double                                 multi_path_ratio;
     /** Threshold for switching UCP to zero copy protocol */
     size_t                                 zcopy_thresh;
     /** Communication scheme in RNDV protocol */
@@ -99,6 +101,9 @@ typedef struct ucp_context_config {
     unsigned                               max_eager_lanes;
     /** Rendezvous-get multi-lane support */
     unsigned                               max_rndv_lanes;
+    /** Minimum allowed chunk size when splitting rndv message over multiple
+     *  lanes */
+    size_t                                 min_rndv_chunk_size;
     /** Estimated number of endpoints */
     size_t                                 estimated_num_eps;
     /** Estimated number of processes per node */

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1535,9 +1535,9 @@ static void ucp_worker_init_cpu_atomics(ucp_worker_h worker)
 
 static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 {
-    ucp_context_h context    = worker->context;
-    ucp_tl_bitmap_t supp_tls = UCS_BITMAP_ZERO;
-    ucp_address_iface_attr_t dummy_iface_attr;
+    ucp_context_h context        = worker->context;
+    ucp_tl_bitmap_t supp_tls     = UCS_BITMAP_ZERO;
+    ucp_address_entry_t dummy_ae = {};
     ucp_tl_resource_desc_t *rsc, *best_rsc;
     uct_iface_attr_t *iface_attr;
     ucp_rsc_index_t rsc_index;
@@ -1554,12 +1554,12 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
 
     iface_cap_flags = UCT_IFACE_FLAG_ATOMIC_DEVICE;
 
-    dummy_iface_attr.bandwidth    = 1e12;
-    dummy_iface_attr.flags        = UINT64_MAX;
-    dummy_iface_attr.overhead     = 0;
-    dummy_iface_attr.priority     = 0;
-    dummy_iface_attr.lat_ovh      = 0;
-    dummy_iface_attr.addr_version = UCP_OBJECT_VERSION_V1;
+    dummy_ae.iface_attr.bandwidth    = 1e12;
+    dummy_ae.iface_attr.flags        = UINT64_MAX;
+    dummy_ae.iface_attr.overhead     = 0;
+    dummy_ae.iface_attr.priority     = 0;
+    dummy_ae.iface_attr.lat_ovh      = 0;
+    dummy_ae.iface_attr.addr_version = UCP_OBJECT_VERSION_V1;
 
     best_score    = -1;
     best_rsc      = NULL;
@@ -1587,7 +1587,7 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
         UCS_BITMAP_SET(supp_tls, rsc_index);
         priority  = iface_attr->priority;
 
-        score = ucp_wireup_amo_score_func(wiface, md_attr, &dummy_iface_attr);
+        score = ucp_wireup_amo_score_func(wiface, md_attr, &dummy_ae, NULL);
         if (ucp_is_scalable_transport(worker->context,
                                       iface_attr->max_num_eps) &&
             ((score > best_score) ||

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -52,13 +52,16 @@ typedef struct {
      *
      * @param [in]  wiface       UCP worker iface.
      * @param [in]  md_attr      Local MD attributes.
-     * @param [in]  remote_info  Remote peer attributes.
+     * @param [in]  remote_addr  Remote address info and attributes.
+     * @param [in]  arg          Custom argument.
      *
      * @return Transport score, the higher the better.
      */
     double      (*calc_score)(const ucp_worker_iface_t *wiface,
                               const uct_md_attr_t *md_attr,
-                              const ucp_address_iface_attr_t *remote_iface_attr);
+                              const ucp_address_entry_t *remote_addr,
+                              void *arg);
+    void        *arg; /* Custom argument of @a calc_score function */
     uint8_t     tl_rsc_flags; /* Flags that describe TL specifics */
 
     ucp_tl_iface_atomic_flags_t local_atomic_flags;
@@ -104,7 +107,8 @@ ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
 
 double ucp_wireup_amo_score_func(const ucp_worker_iface_t *wiface,
                                  const uct_md_attr_t *md_attr,
-                                 const ucp_address_iface_attr_t *remote_iface_attr);
+                                 const ucp_address_entry_t *remote_addr,
+                                 void *arg);
 
 size_t ucp_wireup_msg_pack(void *dest, void *arg);
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -167,6 +167,29 @@ ucs_status_t ucs_config_clone_ulong(const void *src, void *dest, const void *arg
     return UCS_OK;
 }
 
+int ucs_config_sscanf_pos_double(const char *buf, void *dest, const void *arg)
+{
+    if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
+        *(double*)dest = UCS_CONFIG_DBL_AUTO;
+        return 1;
+    }
+
+    return ucs_config_sscanf_double(buf, dest, arg) && (*(double*)dest > 0);
+}
+
+int ucs_config_sprintf_pos_double(char *buf, size_t max, const void *src,
+                                  const void *arg)
+{
+    double value = *(double*)src;
+
+    if (UCS_CONFIG_DBL_IS_AUTO(value)) {
+        ucs_strncpy_safe(buf, UCS_VALUE_AUTO_STR, max);
+        return 1;
+    }
+
+    return ucs_config_sprintf_double(buf, max, src, arg);
+}
+
 int ucs_config_sscanf_double(const char *buf, void *dest, const void *arg)
 {
     return sscanf(buf, "%lf", (double*)dest);
@@ -497,7 +520,7 @@ int ucs_config_sscanf_bw(const char *buf, void *dest, const void *arg)
     int     num_fields;
 
     if (!strcasecmp(buf, UCS_VALUE_AUTO_STR)) {
-        *dst = UCS_CONFIG_BW_AUTO;
+        *dst = UCS_CONFIG_DBL_AUTO;
         return 1;
     }
 
@@ -545,7 +568,7 @@ int ucs_config_sprintf_bw(char *buf, size_t max, const void *src,
     double value                  = *(double*)src;
     const char **suffix;
 
-    if (UCS_CONFIG_BW_IS_AUTO(value)) {
+    if (UCS_CONFIG_DBL_IS_AUTO(value)) {
         ucs_strncpy_safe(buf, UCS_VALUE_AUTO_STR, max);
         return 1;
     }

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -159,6 +159,9 @@ int ucs_config_sscanf_ulong(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_ulong(char *buf, size_t max, const void *src, const void *arg);
 ucs_status_t ucs_config_clone_ulong(const void *src, void *dest, const void *arg);
 
+int ucs_config_sscanf_pos_double(const char *buf, void *dest, const void *arg);
+int ucs_config_sprintf_pos_double(char *buf, size_t max, const void *src,
+                                  const void *arg);
 int ucs_config_sscanf_double(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_double(char *buf, size_t max, const void *src, const void *arg);
 ucs_status_t ucs_config_clone_double(const void *src, void *dest, const void *arg);
@@ -274,6 +277,11 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
                                     ucs_config_clone_double,     ucs_config_release_nop, \
                                     ucs_config_help_generic,     "floating point number"}
 
+#define UCS_CONFIG_TYPE_POS_DOUBLE {ucs_config_sscanf_pos_double, ucs_config_sprintf_pos_double, \
+                                    ucs_config_clone_double,      ucs_config_release_nop, \
+                                    ucs_config_help_generic, \
+                                    "positive floating point number or \"auto\""}
+
 #define UCS_CONFIG_TYPE_HEX        {ucs_config_sscanf_hex,       ucs_config_sprintf_hex, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
                                     ucs_config_help_generic, \
@@ -376,10 +384,11 @@ UCS_CONFIG_DECLARE_ARRAY(string)
 
 
 /**
- * Helpers for Bandwidth units (see UCS_CONFIG_TYPE_BW)
+ * Helpers for positive double and bandwidth units (see UCS_CONFIG_TYPE_BW)
  */
-#define UCS_CONFIG_BW_AUTO            ((double)-2)
-#define UCS_CONFIG_BW_IS_AUTO(_value) ((ssize_t)(_value) == UCS_CONFIG_BW_AUTO)
+#define UCS_CONFIG_DBL_AUTO            ((double)-2)
+#define UCS_CONFIG_DBL_IS_AUTO(_value) ((ssize_t)(_value) == \
+                                        UCS_CONFIG_DBL_AUTO)
 
 
 /**

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1476,7 +1476,7 @@ uct_ib_md_set_pci_bw(uct_ib_md_t *md, const uct_ib_md_config_t *md_config)
 
     for (i = 0; i < md_config->pci_bw.count; i++) {
         if (!strcmp(device_name, md_config->pci_bw.device[i].name)) {
-            if (UCS_CONFIG_BW_IS_AUTO(md_config->pci_bw.device[i].bw)) {
+            if (UCS_CONFIG_DBL_IS_AUTO(md_config->pci_bw.device[i].bw)) {
                 break; /* read data from system */
             }
 

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -444,7 +444,7 @@ UCS_TEST_F(test_config, parse_default) {
     EXPECT_EQ(UCS_MBYTE * 128.0, opts->bw_mbits);
     EXPECT_EQ(UCS_GBYTE * 128.0, opts->bw_gbits);
     EXPECT_EQ(UCS_TBYTE * 128.0, opts->bw_tbits);
-    EXPECT_TRUE(UCS_CONFIG_BW_IS_AUTO(opts->bw_auto));
+    EXPECT_TRUE(UCS_CONFIG_DBL_IS_AUTO(opts->bw_auto));
 
     EXPECT_EQ(UCS_TBYTE * 128.0, opts->can_pci_bw.bw);
     EXPECT_EQ(std::string("mlx5_0"), opts->can_pci_bw.name);


### PR DESCRIPTION
## What
Define minimal size of fragment when splitting message over multiple lanes

## Why ?
To not split the message into small chunks (which degrades performance)