### PR TITLE
UCP: Fix ucx_info -c formatting for rndv vars

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -215,7 +215,7 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.rndv_send_nbr_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_THRESH_FALLBACK", "inf",
-   "Message size to start using the rendezvous protocol in case the calculated threshold "
+   "Message size to start using the rendezvous protocol in case the calculated threshold\n"
    "is zero or negative",
    ucs_offsetof(ucp_config_t, ctx.rndv_thresh_fallback), UCS_CONFIG_TYPE_MEMUNITS},
 
@@ -225,7 +225,7 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.rndv_perf_diff), UCS_CONFIG_TYPE_DOUBLE},
 
   {"MULTI_LANE_MAX_RATIO", "4",
-   "Maximal allowed ratio between slowest and fastest lane in a multi-lane "
+   "Maximal allowed ratio between slowest and fastest lane in a multi-lane\n"
    "protocol. Lanes slower than the specified ratio will not be used.",
    ucs_offsetof(ucp_config_t, ctx.multi_lane_max_ratio), UCS_CONFIG_TYPE_DOUBLE},
 


### PR DESCRIPTION
## What
Fix `ucx_info` formatting of some rndv vars

## Why ?
Before
```
$ ucx_info -f | grep -B 5 MULTI_LANE_MAX_RATIO
#
# Maximal allowed ratio between slowest and fastest lane in a multi-lane protocol. Lanes slower than the specified ratio will not be used.
#
# syntax:    floating point number
#
UCX_MULTI_LANE_MAX_RATIO=4.000
```

After
```
$ ./src/tools/info/ucx_info -f | grep -B 5 MULTI_LANE_MAX_RATIO
# Maximal allowed ratio between slowest and fastest lane in a multi-lane
# protocol. Lanes slower than the specified ratio will not be used.
#
# syntax:    floating point number
#
UCX_MULTI_LANE_MAX_RATIO=4.000

```