### PR TITLE
UCS/ASYNC: Remove async_max_events limit

### DIFF
--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -34,7 +34,6 @@ struct ucs_async_context {
     };
 
     ucs_async_mode_t  mode;          /* Event delivery mode */
-    volatile uint32_t num_handlers;  /* Number of event and timer handlers */
     ucs_mpmc_queue_t  missed;        /* Miss queue */
     ucs_time_t        last_wakeup;   /* time of the last wakeup */
 };

--- a/src/ucs/async/thread.c
+++ b/src/ucs/async/thread.c
@@ -16,6 +16,7 @@
 #include <ucs/sys/checker.h>
 #include <ucs/sys/stubs.h>
 #include <ucs/sys/event_set.h>
+#include <ucs/sys/math.h>
 
 
 #define UCS_ASYNC_EPOLL_MAX_EVENTS      16

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -38,7 +38,6 @@ ucs_global_opts_t ucs_global_opts = {
     .log_level_trigger     = UCS_LOG_LEVEL_FATAL,
     .warn_unused_env_vars  = 1,
     .enable_memtype_cache  = UCS_TRY,
-    .async_max_events      = 64,
     .async_signo           = SIGALRM,
     .stats_dest            = "",
     .tuning_path           = "",
@@ -152,9 +151,10 @@ static ucs_config_field_t ucs_global_opts_table[] = {
    "Enable memory type (cuda/rocm) cache",
    ucs_offsetof(ucs_global_opts_t, enable_memtype_cache), UCS_CONFIG_TYPE_TERNARY},
 
- {"ASYNC_MAX_EVENTS", "1024", /* TODO remove this; resize mpmc */
-  "Maximal number of events which can be handled from one context",
-  ucs_offsetof(ucs_global_opts_t, async_max_events), UCS_CONFIG_TYPE_UINT},
+ {"ASYNC_MAX_EVENTS", "1024",
+  "The configuration parameter is deprecated.\n"
+  "Now unlimited number of events can be handled from one context.",
+  UCS_CONFIG_DEPRECATED_FIELD_OFFSET, UCS_CONFIG_TYPE_DEPRECATED},
 
  {"ASYNC_SIGNO", "SIGALRM",
   "Signal number used for async signaling.",

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -76,9 +76,6 @@ typedef struct {
     /* Issue warning about UCX_ env vars which were not used by config parser */
     int                        warn_unused_env_vars;
 
-    /* Max. events per context, will be removed in the future */
-    unsigned                   async_max_events;
-
     /** Memtype cache */
     ucs_ternary_auto_value_t   enable_memtype_cache;
 

--- a/src/ucs/datastruct/mpmc.c
+++ b/src/ucs/datastruct/mpmc.c
@@ -17,82 +17,62 @@
 #include <ucs/debug/memtrack_int.h>
 
 
-ucs_status_t ucs_mpmc_queue_init(ucs_mpmc_queue_t *mpmc, uint32_t length)
+ucs_status_t ucs_mpmc_queue_init(ucs_mpmc_queue_t *mpmc)
 {
-    uint32_t i;
-
-    mpmc->length   = ucs_roundup_pow2(length);
-    mpmc->shift    = ucs_ilog2(mpmc->length);
-    if (mpmc->shift >= UCS_MPMC_VALID_SHIFT) {
-        return UCS_ERR_INVALID_PARAM;
-    }
-
-    mpmc->consumer = 0;
-    mpmc->producer = 0;
-    mpmc->queue = ucs_malloc(sizeof(*mpmc->queue) * mpmc->length, "mpmc");
-    if (mpmc->queue == NULL) {
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    for (i = 0; i < mpmc->length; ++i) {
-        mpmc->queue[i] = UCS_BIT(UCS_MPMC_VALID_SHIFT);
-    }
-
-    return UCS_OK;
+    ucs_queue_head_init(&mpmc->queue);
+    return ucs_spinlock_init(&mpmc->lock, 0);
 }
 
 void ucs_mpmc_queue_cleanup(ucs_mpmc_queue_t *mpmc)
 {
-    ucs_free(mpmc->queue);
-}
+    ucs_mpmc_elem_t *elem;
 
-static inline uint64_t __ucs_mpmc_queue_valid_bit(ucs_mpmc_queue_t *mpmc, uint32_t location)
-{
-    return ((uint64_t)location >> mpmc->shift) & 1;
+    while (!ucs_queue_is_empty(&mpmc->queue)) {
+        elem = ucs_queue_pull_elem_non_empty(&mpmc->queue,
+                                             ucs_mpmc_elem_t, super);
+        ucs_free(elem);
+    }
 }
 
 ucs_status_t ucs_mpmc_queue_push(ucs_mpmc_queue_t *mpmc, uint64_t value)
 {
-    uint32_t location;
+    ucs_mpmc_elem_t *elem;
 
-    ucs_assert((value >> UCS_MPMC_VALID_SHIFT) == 0);
+    elem = ucs_malloc(sizeof(ucs_mpmc_elem_t), "mpmc elem");
+    if (elem == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
 
-    do {
-        location = mpmc->producer;
-        if (UCS_CIRCULAR_COMPARE32(location, >=, mpmc->consumer + mpmc->length)) {
-            /* Queue is full */
-            return UCS_ERR_EXCEEDS_LIMIT;
-        }
-    } while (ucs_atomic_cswap32(&mpmc->producer, location, location + 1) != location);
+    elem->value = value;
 
-    mpmc->queue[location & (mpmc->length - 1)] = value |
-                    (__ucs_mpmc_queue_valid_bit(mpmc, location) << UCS_MPMC_VALID_SHIFT);
+    ucs_spin_lock(&mpmc->lock);
+    ucs_queue_push(&mpmc->queue, &elem->super);
+    ucs_spin_unlock(&mpmc->lock);
+
     return UCS_OK;
 }
 
 
 ucs_status_t ucs_mpmc_queue_pull(ucs_mpmc_queue_t *mpmc, uint64_t *value_p)
 {
-    uint32_t location;
-    uint64_t value;
+    ucs_mpmc_elem_t *elem;
+    ucs_status_t status;
 
-    location = mpmc->consumer;
-    if (location == mpmc->producer) {
-        /* Producer not started yet */
+    if (ucs_queue_is_empty(&mpmc->queue)) {
         return UCS_ERR_NO_PROGRESS;
     }
 
-    value = mpmc->queue[location & (mpmc->length - 1)];
-    if ((value >> UCS_MPMC_VALID_SHIFT) != __ucs_mpmc_queue_valid_bit(mpmc, location)) {
-        /* Producer not finished yet */
-        return UCS_ERR_NO_PROGRESS;
+    ucs_spin_lock(&mpmc->lock);
+    if (!ucs_queue_is_empty(&mpmc->queue)) {
+        elem     = ucs_queue_pull_elem_non_empty(&mpmc->queue,
+                                                 ucs_mpmc_elem_t, super);
+        *value_p = elem->value;
+        status   = UCS_OK;
+        ucs_free(elem);
+    } else {
+        status = UCS_ERR_NO_PROGRESS;
     }
+    ucs_spin_unlock(&mpmc->lock);
 
-    if (ucs_atomic_cswap32(&mpmc->consumer, location, location + 1) != location) {
-        /* Someone else consumed */
-        return UCS_ERR_NO_PROGRESS;
-    }
-
-    *value_p = value & UCS_MASK(UCS_MPMC_VALID_SHIFT);
-    return UCS_OK;
+    return status;
 }

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -431,44 +431,6 @@ UCS_TEST_P(test_async, global_timer) {
     expect_count_GE(gt, COUNT);
 }
 
-UCS_TEST_P(test_async, max_events, "ASYNC_MAX_EVENTS=4") {
-    ucs_status_t status;
-    ucs_async_context_t async;
-
-    status = ucs_async_context_init(&async, GetParam());
-    ASSERT_UCS_OK(status);
-
-    /* 4 timers should be OK */
-    std::vector<int> timers;
-    for (unsigned count = 0; count < 4; ++count) {
-        int timer_id;
-        status = ucs_async_add_timer(GetParam(), ucs_time_from_sec(1.0),
-                                     (ucs_async_event_cb_t)ucs_empty_function,
-                                     NULL, &async, &timer_id);
-        ASSERT_UCS_OK(status);
-        timers.push_back(timer_id);
-    }
-
-    /* 5th timer should fail */
-    int timer_id;
-    status = ucs_async_add_timer(GetParam(), ucs_time_from_sec(1.0),
-                                 (ucs_async_event_cb_t)ucs_empty_function,
-                                 NULL, &async, &timer_id);
-    EXPECT_EQ(UCS_ERR_EXCEEDS_LIMIT, status);
-
-    if (status == UCS_OK) {
-        timers.push_back(timer_id);
-    }
-
-    /* Release timers */
-    for (std::vector<int>::iterator iter = timers.begin(); iter != timers.end(); ++iter) {
-        status = ucs_async_remove_handler(*iter, 1);
-        ASSERT_UCS_OK(status);
-    }
-
-    ucs_async_context_cleanup(&async);
-}
-
 UCS_TEST_P(test_async, many_timers) {
     const int max_iters  = ucs_max(200, 4010 / ucs::test_time_multiplier());
     const int max_timers = ucs_max(10, 250 / ucs::test_time_multiplier());

--- a/test/gtest/ucs/test_mpmc.cc
+++ b/test/gtest/ucs/test_mpmc.cc
@@ -14,7 +14,6 @@ extern "C" {
 
 class test_mpmc : public ucs::test {
 protected:
-    static const unsigned MPMC_SIZE = 100;
     static const uint64_t SENTINEL  = 0x7fffffffu;
     static const unsigned NUM_THREADS = 4;
 
@@ -65,7 +64,7 @@ UCS_TEST_F(test_mpmc, basic) {
     ucs_mpmc_queue_t mpmc;
     ucs_status_t status;
 
-    status = ucs_mpmc_queue_init(&mpmc, MPMC_SIZE);
+    status = ucs_mpmc_queue_init(&mpmc);
     ASSERT_UCS_OK(status);
 
     EXPECT_TRUE(ucs_mpmc_queue_is_empty(&mpmc));
@@ -110,7 +109,7 @@ UCS_TEST_F(test_mpmc, multi_threaded) {
     size_t total;
     void *retval;
 
-    status = ucs_mpmc_queue_init(&mpmc, MPMC_SIZE);
+    status = ucs_mpmc_queue_init(&mpmc);
     ASSERT_UCS_OK(status);
 
     for (unsigned i = 0; i < NUM_THREADS; ++i) {


### PR DESCRIPTION
## What
Remove async_max_events limit

## Why ?
To support unexpected high number of concurrent TCP connections for example

## How ?
By using ucs_queue instead of array inside mpmc queue
