### PR TITLE
UCP/CORE: Fix keepalive selection logic

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -773,19 +773,28 @@ ucp_ep_peer_mem_get(ucp_context_h context, ucp_ep_h ep, uint64_t address,
                     size_t size, void *rkey_buf, ucp_md_index_t md_index);
 
 /**
- * @brief Do keepalive operation for a specific UCT EP.
+ * @brief Indicates AM-based keepalive necessity.
+ * 
+ * @param [in] ep      UCP endpoint to check.
+ * @param [in] rsc_idx Resource index to check.
+ * @param [in] is_p2p  Flag that indicates whether UCT EP was created as p2p
+ *                     (i.e. CONNECT_TO_EP) or not.
+ *
+ * @return Whether AM-based keepalive is required or not.
+ */
+int ucp_ep_is_am_keepalive(ucp_ep_h ep, ucp_rsc_index_t rsc_idx, int is_p2p);
+
+/**
+ * @brief Do AM-based keepalive operation for a specific UCT EP.
  *
  * @param [in] ucp_ep  UCP Endpoint object to operate keepalive.
  * @param [in] uct_ep  UCT Endpoint object to do keepalive on.
  * @param [in] rsc_idx Resource index to check.
- * @param [in] flags   Flags for keepalive operation.
- * @param [in] comp    Pointer to keepalive completion object.
  *
  * @return Status of keepalive operation.
  */
-ucs_status_t ucp_ep_do_uct_ep_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
-                                        ucp_rsc_index_t rsc_idx, unsigned flags,
-                                        uct_completion_t *comp);
+ucs_status_t ucp_ep_do_uct_ep_am_keepalive(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
+                                           ucp_rsc_index_t rsc_idx);
 
 
 /**

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1252,9 +1252,11 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
          * messages exchange */
         new_key->wireup_msg_lane = new_key->cm_lane;
         reuse_lane               = old_key->wireup_msg_lane;
-        ucp_wireup_ep_set_aux(cm_wireup_ep,
-                              ucp_wireup_ep_extract_next_ep(ep->uct_eps[reuse_lane]),
-                              old_key->lanes[reuse_lane].rsc_index);
+        ucp_wireup_ep_set_aux(
+                cm_wireup_ep,
+                ucp_wireup_ep_extract_next_ep(ep->uct_eps[reuse_lane]),
+                old_key->lanes[reuse_lane].rsc_index,
+                ucp_ep_config(ep)->p2p_lanes & UCS_BIT(reuse_lane));
         ucp_wireup_ep_pending_queue_purge(ep->uct_eps[reuse_lane],
                                           ucp_request_purge_enqueue_cb,
                                           replay_pending_queue);

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -29,7 +29,10 @@ enum {
     UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED = UCS_BIT(2),
 
     /* Send client id */
-    UCP_WIREUP_EP_FLAG_SEND_CLIENT_ID   = UCS_BIT(3)
+    UCP_WIREUP_EP_FLAG_SEND_CLIENT_ID   = UCS_BIT(3),
+
+    /* Indicates that aux_ep is CONNECT_TO_EP */
+    UCP_WIREUP_EP_FLAG_AUX_P2P          = UCS_BIT(4)
 };
 
 
@@ -97,11 +100,7 @@ void ucp_wireup_ep_pending_queue_purge(uct_ep_h uct_ep,
                                        void *arg);
 
 void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
-                           ucp_rsc_index_t rsc_index);
-
-ucs_status_t
-ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep, unsigned ep_init_flags,
-                          const ucp_unpacked_address_t *remote_address);
+                           ucp_rsc_index_t rsc_index, int is_p2p);
 
 void ucp_wireup_ep_discard_aux_ep(ucp_wireup_ep_t *wireup_ep,
                                   unsigned ep_flush_flags,


### PR DESCRIPTION
## What

Fix keepalive selection logic.

## Why ?

UCP EP should select EP_CHECK only for lanes from `p2p_lanes` map, otherwise - use AM-based keepalive.

## How ?

1. Update `ucp_ep_is_am_keepalive` and `ucp_ep_do_uct_ep_keepalive` to accept lane on which keepalive should be done.
2. Update `ucp_ep_is_am_keepalive` to check whether `lane` exists in `p2p_lanes` or not. If doesn't exist there, use AM-based keepalive.