### PR TITLE
UCP/ENDPOINT: Implementation of API changes to query transport/endpoint pairs associated with an endpoint

### DIFF
--- a/test/gtest/ucp/test_ucp_ep.cc
+++ b/test/gtest/ucp/test_ucp_ep.cc
@@ -7,7 +7,6 @@
 #include "ucp_test.h"
 #include <ucp/core/ucp_context.h>
 
-
 class test_ucp_ep : public ucp_test {
 public:
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
@@ -60,6 +59,37 @@ UCS_TEST_P(test_ucp_ep, ucp_query_ep)
        size (which represents current calculation model) */
     EXPECT_FLOAT_EQ(attr.estimated_time - estimated_time_1000,
                     estimated_time_1000 - estimated_time_0);
+}
+
+UCS_TEST_P(test_ucp_ep, ucp_query_transport)
+{
+    ucs_status_t status;
+    int i;
+    ucp_ep_attr_t ep_attrs;
+    std::vector<ucp_transport_entry_t> transport_entries(100);
+
+    ep_attrs.field_mask             = UCP_EP_ATTR_FIELD_TRANSPORTS;
+    ep_attrs.transports.entries     = &transport_entries[0];
+    ep_attrs.transports.num_entries = transport_entries.size();
+    ep_attrs.transports.entry_size  = sizeof(ucp_transport_entry_t);
+    status                          = ucp_ep_query(sender().ep(), &ep_attrs);
+
+    // Verify ucp_ep_query completed successfully, that the number of
+    // transports is updated, since no system should reasonably have
+    // 100 transport/device name pairs, and verify returned strings are
+    // not empty.
+    ASSERT_UCS_OK(status);
+    EXPECT_LT(ep_attrs.transports.num_entries, 100);
+    UCS_TEST_MESSAGE << "Number of transport/device name pairs: "
+                     << ep_attrs.transports.num_entries;
+    for (i = 0; i < ep_attrs.transports.num_entries; i++) {
+        UCS_TEST_MESSAGE << "Transport[" << i << "] transport="
+                         << ep_attrs.transports.entries[i].transport_name
+                         << " device="
+                         << ep_attrs.transports.entries[i].device_name;
+        EXPECT_STRNE(ep_attrs.transports.entries[i].transport_name, "");
+        EXPECT_STRNE(ep_attrs.transports.entries[i].device_name, "");
+    }
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_ep);


### PR DESCRIPTION
## What
Implement a change to the API for the ucp_ep_query function so the caller can query the transport/device name pairs associated with an active endpoint. This implements the API header changes in pull request #7990.

## Why ?
OpenMPI users have requested the ability to query the transport and device name pairs used by an MPI task when the transport used by OpenMPI is UCX. This information is useful to OpenMPI users so they can verify that application tasks are actually using the transports that the user requested. 

## How ?
The ucp_ep_attr structure is modified by adding a new bitmask bit, UCP_EP_ATTR_FIELD_TRANSPORTS that the caller sets to request endpoint transport/device name pairs. The caller fills in the transports structure in ucp_ep_attrs to specify the attributes of the ucp_transport_entry_t array the caller allocated as well as setting the UCP_EP_ATTR_FIELD_TRANSPORTS bit and calls ucp_ep_query.

 The new ucp_ep_query_transport function is called by ucp_ep_query to iterate thru the transport structures to fill in the transport and device names.

The ucp_ep_query_transport function indexes the ucp_transport_entry_t array by multiplying its loop index by the size of one entry in this structure. This is done for forward/backward compatibility if the caller is using a different version of UCX with a different ucp_transport_entry_t definition.

Before this function updates a field in this structure, it ensures that the field's ending offset is not past the end of the ucp_transport_entry_t it was passed to avoid storage overlay problems.

Signed-off-by: David Wootton <dwootton@us.ibm.com>
