### PR TITLE
UCT/IB/DC: Fix resending FC_PURE_GRANT in case of failure

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1647,13 +1647,11 @@ void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,
     uct_ib_iface_t *ib_iface = &iface->super.super.super;
     ucs_status_t status;
     ucs_log_level_t log_lvl;
-    ucs_arbiter_t *waitq;
-    ucs_arbiter_group_t *group;
-    uint8_t pool_index;
 
-    uct_dc_mlx5_get_arbiter_params(iface, ep, &waitq, &group, &pool_index);
-    ucs_arbiter_group_purge(waitq, group,
-                            uct_dc_mlx5_ep_arbiter_purge_internal_cb, ep);
+    /* We don't purge an endpoint's pending queue, because only a FC endpoint
+     * could have internal TX operations scheduled there which shouldn't be
+     * purged - they need to be rescheduled when DCI will be recovered after an
+     * error */
 
     if (ep->flags & (UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED |
                      UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL)) {

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1310,9 +1310,10 @@ uct_dc_mlx5_iface_dci_do_common_pending_tx(uct_dc_mlx5_ep_t *ep,
      * arbiter group for which flush(CANCEL) was done */
     ucs_assert(!(ep->flags & UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL));
 
-    ucs_assertv(!uct_dc_mlx5_iface_dci_ep_can_send(ep),
-                "pending callback returned error, but send resources are"
-                " available");
+    ucs_assertv(!uct_dc_mlx5_iface_dci_ep_can_send(ep) ||
+                (ep == iface->tx.fc_ep),
+                "ep=%p: pending callback returned error, but send resources"
+                " are available and it is not fc_ep=%p", ep, iface->tx.fc_ep);
     return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
 }
 


### PR DESCRIPTION
## What

Fix resending `FC_PURE_GRANT` in case of failure of DCI.

## Why ?

Purging of pending queue of FC endpoints during error handling leads to removing `FC_PURE_GRANT` requests which were rescheduled to pending queue due to completing them with `WC_FLUSH_ERR` status.

## How ?

Don't release FC requests to mpool, need to collect them in a queue of FC pure grants and resend them after recovering DCI .