### PR TITLE
UCT/ROCM: increase max. number of hsa agents

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -14,12 +14,12 @@
 #include <pthread.h>
 
 
-#define MAX_AGENTS 16
+#define MAX_AGENTS 63
 static struct agents {
-    hsa_agent_t agents[MAX_AGENTS];
     int num;
-    hsa_agent_t gpu_agents[MAX_AGENTS];
+    hsa_agent_t agents[MAX_AGENTS];
     int num_gpu;
+    hsa_agent_t gpu_agents[MAX_AGENTS];
 } uct_rocm_base_agents;
 
 int uct_rocm_base_get_gpu_agents(hsa_agent_t **agents)


### PR DESCRIPTION
## What

Increase the max. number of hsa agents to 63 (from 16).  Furthermore, minor reorganization of the uct_rocm_base_agents structure to reduce the number of cache misses.

## Why ?
The max. number of hsa agents includes both CPUs + GPUs and was too low for today's systems.

## How ?
