### PR TITLE
UCT/IB/DC/RC: Add common update TX function for RC/DC

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -252,7 +252,8 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface)
                    iface, dci_index, txqp, hw_ci);
 
     uct_rc_mlx5_txqp_process_tx_cqe(txqp, cqe, hw_ci);
-    uct_dc_mlx5_update_tx_res(iface, txwq, txqp, hw_ci);
+    uct_rc_mlx5_common_iface_txwq_update_tx_res(&iface->super.super, txwq,
+                                                txqp, hw_ci);
 
     /**
      * Note: DCI is released after handling completion callbacks,

--- a/src/uct/ib/dc/dc_mlx5.inl
+++ b/src/uct/ib/dc/dc_mlx5.inl
@@ -14,16 +14,6 @@
 
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_update_tx_res(uct_dc_mlx5_iface_t *iface, uct_ib_mlx5_txwq_t *txwq,
-                          uct_rc_txqp_t *txqp, uint16_t hw_ci)
-{
-    uct_rc_txqp_available_set(txqp, uct_ib_mlx5_txwq_update_bb(txwq, hw_ci));
-    ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
-
-    uct_rc_iface_update_reads(&iface->super.super);
-}
-
-static UCS_F_ALWAYS_INLINE void
 uct_dc_mlx5_get_arbiter_params(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                ucs_arbiter_t **waitq_p,
                                ucs_arbiter_group_t **group_p,

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1589,7 +1589,8 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
 
     ucs_assert(!uct_dc_mlx5_iface_is_dci_rand(iface));
 
-    uct_dc_mlx5_update_tx_res(iface, txwq, txqp, pi);
+    uct_rc_mlx5_common_iface_txwq_update_tx_res(&iface->super.super, txwq,
+                                                txqp, pi);
     uct_rc_txqp_purge_outstanding(&iface->super.super, txqp, ep_status, pi, 0);
 
     /* Invoke a user's error callback and release TX/FC resources before

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -115,24 +115,10 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_iface_update_tx_res(uct_rc_iface_t *rc_iface,
                                 uct_rc_mlx5_ep_t *rc_mlx5_ep, uint16_t hw_ci)
 {
-    uct_ib_mlx5_txwq_t *txwq = &rc_mlx5_ep->tx.wq;
-    uct_rc_txqp_t *txqp      = &rc_mlx5_ep->super.txqp;
-    uint16_t bb_num;
-
-    bb_num = uct_ib_mlx5_txwq_update_bb(txwq, hw_ci) -
-             uct_rc_txqp_available(txqp);
-
-    /* Must always have positive number of released resources. The first
-     * completion will report bb_num=1 (because prev_sw_pi is initialized to -1)
-     * and all the rest report the amount of BBs the previous WQE has consumed.
-     */
-    ucs_assertv(bb_num > 0, "hw_ci=%d prev_sw_pi=%d available=%d bb_num=%d",
-                hw_ci, txwq->prev_sw_pi, txqp->available, bb_num);
-
-    uct_rc_txqp_available_add(txqp, bb_num);
-    ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
-
-    uct_rc_iface_update_reads(rc_iface);
+    uint16_t bb_num =
+            uct_rc_mlx5_common_iface_txwq_update_tx_res(
+                    rc_iface, &rc_mlx5_ep->tx.wq, &rc_mlx5_ep->super.txqp,
+                    hw_ci);
     uct_rc_iface_add_cq_credits(rc_iface, bb_num);
 }
 


### PR DESCRIPTION
## What

Add common update TX function for RC/DC.

## Why ?

To have a common code to update TX resources.

## How ?

1. Introduce `uct_rc_mlx5_common_iface_txwq_update_tx_res` function which includes coe from `uct_rc_mlx5_iface_update_tx_res`.
2. Remove `uct_dc_mlx5_update_tx_res` and use `uct_rc_mlx5_common_iface_txwq_update_tx_res` instead of it.