### PR TITLE
UCT/IB/DC: Remove assertion for sending FC grant

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -322,9 +322,8 @@ ucs_status_t uct_dc_mlx5_iface_init_fc_ep(uct_dc_mlx5_iface_t *iface);
 
 ucs_status_t uct_dc_mlx5_iface_fc_grant(uct_pending_req_t *self);
 
-ucs_status_t uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
-                                          uct_rc_hdr_t *hdr, unsigned length,
-                                          uint32_t imm_data, uint16_t lid, unsigned flags);
+const char *
+uct_dc_mlx5_fc_req_str(uct_dc_fc_request_t *dc_req, char *buf, size_t max);
 
 void uct_dc_mlx5_destroy_dct(uct_dc_mlx5_iface_t *iface);
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1040,19 +1040,15 @@ uct_dc_mlx5_ep_fc_pure_grant_send_completion(uct_rc_iface_send_op_t *send_op,
     uct_dc_fc_request_t *fc_req = (uct_dc_fc_request_t*)send_op->buffer;
     uct_dc_mlx5_ep_t *fc_ep     = ucs_derived_of(fc_req->super.ep,
                                                  uct_dc_mlx5_ep_t);
-    char gid_str[32];
+    char buf[128];
 
     if (ucs_likely(!(send_op->flags & UCT_RC_IFACE_SEND_OP_STATUS) ||
                    (send_op->status != UCS_ERR_CANCELED))) {
         /* Pure grant sent - release it */
         ucs_mpool_put(fc_req);
     } else {
-        ucs_trace("fc_ep %p: re-sending FC_PURE_GRANT (seq:%" PRIu64 ")"
-                  " to dct_num:0x%x, lid:%d, gid:%s",
-                  fc_ep,  fc_req->sender.payload.seq, fc_req->dct_num,
-                  fc_req->lid,
-                  uct_ib_gid_str(ucs_unaligned_ptr(&fc_req->sender.payload.gid),
-                                 gid_str, sizeof(gid_str)));
+        ucs_trace("fc_ep %p: re-sending %s", fc_ep,
+                  uct_dc_mlx5_fc_req_str(fc_req, buf, sizeof(buf)));
 
         /* Always add re-sending of FC_PURE_GRANT packet to the pending queue to
          * resend it when DCI will be restored after the failure */

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -70,8 +70,7 @@ static UCS_F_NOINLINE void
 uct_rc_mlx5_iface_hold_srq_desc(uct_rc_mlx5_iface_common_t *iface,
                                 uct_ib_mlx5_srq_seg_t *seg,
                                 struct mlx5_cqe64 *cqe, uint16_t wqe_ctr,
-                                ucs_status_t status, unsigned offset,
-                                uct_recv_desc_t *release_desc)
+                                unsigned offset, uct_recv_desc_t *release_desc)
 {
     void *udesc;
     int stride_idx;
@@ -116,9 +115,9 @@ uct_rc_mlx5_iface_release_srq_seg(uct_rc_mlx5_iface_common_t *iface,
      * But it respects srq size when srq topology is a linked-list. */
     wqe_index = wqe_ctr & srq->mask;
 
-    if (ucs_unlikely(status != UCS_OK)) {
-        uct_rc_mlx5_iface_hold_srq_desc(iface, seg, cqe, wqe_ctr, status,
-                                        offset, release_desc);
+    if (ucs_unlikely(status == UCS_INPROGRESS)) {
+        uct_rc_mlx5_iface_hold_srq_desc(iface, seg, cqe, wqe_ctr, offset,
+                                        release_desc);
     }
 
     if (UCT_RC_MLX5_MP_ENABLED(iface)) {
@@ -1264,6 +1263,10 @@ uct_rc_mlx5_iface_unexp_consumed(uct_rc_mlx5_iface_common_t *iface,
                                  uint16_t wqe_ctr, int poll_flags)
 {
     uct_ib_mlx5_srq_seg_t *seg;
+
+    ucs_assertv(!UCS_STATUS_IS_ERR(status), "iface=%p: %p or %p returned: %s",
+                iface, iface->tm.eager_unexp.cb, iface->tm.rndv_unexp.cb,
+                ucs_status_string(status));
 
     seg = uct_ib_mlx5_srq_get_wqe(&iface->rx.srq, wqe_ctr);
 

--- a/src/uct/ib/rc/verbs/rc_verbs_impl.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_impl.h
@@ -65,7 +65,8 @@ uct_rc_verbs_iface_handle_am(uct_rc_iface_t *iface, uct_rc_hdr_t *hdr,
         status = uct_iface_invoke_am(&iface->super.super, hdr->am_id, hdr + 1,
                                      length - sizeof(*hdr), UCT_CB_PARAM_FLAG_DESC);
     }
-    if (ucs_likely(status == UCS_OK)) {
+
+    if (ucs_likely(status != UCS_INPROGRESS)) {
         ucs_mpool_put_inline(desc);
     } else {
         udesc = (char*)desc + iface->super.config.rx_headroom_offset;


### PR DESCRIPTION
## What

Remove assertion which expects that sending FC grant will be completed with either `UCS_ERR_NO_RESOURCE` or `UCS_OK`.

## Why ?

This assertion could fail in case of `ibv_create_ah` fails during discovering some errors.

## How ?

1. Implement `uct_dc_mlx5_iface_fc_pure_grant_str` function to use for printing FC_PURE_GRANT request where it is needed.
2. Replace `ucs_assert_always` by `ucs_diag` for checking the result of `uct_dc_mlx5_iface_fc_grant`.