### PR TITLE
UCP/RNDV: Enabled non-contig datatypes in AM rendezvous.

### DIFF
--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -52,8 +52,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
 ucs_status_t ucp_am_rndv_rts_init(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_am_check_init_params(init_params, UCP_AM_OP_ID_MASK_ALL,
-                                  UCP_PROTO_SELECT_OP_FLAG_AM_EAGER) ||
-        (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
+                                  UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)) {
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -503,7 +503,11 @@ ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
                             (ucs_memory_type_t)dt_iter->mem_info.type, md_map,
                             uct_flags, &dt_iter->type.contig.memh);
     } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
-        return ucp_datatype_iter_iov_mem_reg(context, dt_iter, md_map, uct_flags);
+        return ucp_datatype_iter_iov_mem_reg(context, dt_iter, md_map,
+                                             uct_flags);
+    } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_GENERIC,
+                                          dt_mask)) {
+        return UCS_OK;
     } else {
         ucs_error("datatype %s does not support registration",
                   ucp_datatype_class_names[dt_iter->dt_class]);

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -657,7 +657,7 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
         ucs_assert(rtr->offset == 0);
 
         ucp_datatype_iter_mem_dereg(worker->context, &req->send.state.dt_iter,
-                                    UCS_BIT(UCP_DATATYPE_CONTIG));
+                                    UCP_DT_MASK_ALL);
         ucp_send_request_id_release(req);
         req->flags &= ~UCP_REQUEST_FLAG_PROTO_INITIALIZED;
 

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -48,8 +48,8 @@ ucp_proto_rndv_rts_request_init(ucp_request_t *req)
     status = ucp_datatype_iter_mem_reg(ep->worker->context,
                                        &req->send.state.dt_iter, rpriv->md_map,
                                        UCT_MD_MEM_ACCESS_RMA |
-                                       UCT_MD_MEM_FLAG_HIDE_ERRORS,
-                                       UCS_BIT(UCP_DATATYPE_CONTIG));
+                                               UCT_MD_MEM_FLAG_HIDE_ERRORS,
+                                       UCP_DT_MASK_ALL);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -77,9 +77,6 @@ ucp_proto_rndv_am_bcopy_complete(ucp_request_t *req)
     if (req->send.rndv.rkey != NULL) {
         ucp_proto_rndv_rkey_destroy(req);
     }
-    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
-                                &req->send.state.dt_iter,
-                                UCS_BIT(UCP_DATATYPE_CONTIG));
     return ucp_proto_request_bcopy_complete_success(req);
 }
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1287,12 +1287,6 @@ public:
     {
         m_status = UCS_OK;
         modify_config("RNDV_THRESH", "128");
-    }
-
-    virtual void init()
-    {
-        test_ucp_am_nbx::init();
-
         if (enable_proto()) {
             modify_config("PROTO_ENABLE", "y");
         }
@@ -1303,11 +1297,6 @@ public:
         add_variant_values(variants, test_ucp_am_nbx::get_test_variants, 0);
         add_variant_values(variants, test_ucp_am_nbx::get_test_variants, 1,
                            "proto");
-    }
-
-    virtual unsigned enable_proto()
-    {
-        return get_variant_value(1);
     }
 
     ucs_status_t am_data_handler(const void *header, size_t header_length,
@@ -1372,6 +1361,12 @@ public:
     }
 
     ucs_status_t m_status;
+
+private:
+    unsigned enable_proto()
+    {
+        return get_variant_value(1);
+    }
 };
 
 UCS_TEST_P(test_ucp_am_nbx_rndv, rndv_auto, "RNDV_SCHEME=auto")
@@ -1501,11 +1496,19 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx_rndv)
 
 class test_ucp_am_nbx_rndv_dts : public test_ucp_am_nbx_rndv {
 public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    static void get_test_variants_dts(std::vector<ucp_test_variant> &variants)
+    {
+        /* coverity[overrun-buffer-val] */
+        add_variant_values(variants, test_ucp_am_nbx_rndv::get_test_variants,
+                           test_ucp_am_nbx_dts::dts_bitmap,
+                           ucp_datatype_class_names);
+    }
+
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         /* push variant for the receive type, on top of existing dts variants */
         /* coverity[overrun-buffer-val] */
-        add_variant_values(variants, test_ucp_am_nbx_dts::get_test_dts,
+        add_variant_values(variants, get_test_variants_dts,
                            test_ucp_am_nbx_dts::dts_bitmap,
                            ucp_datatype_class_names);
     }
@@ -1514,8 +1517,8 @@ public:
     {
         test_ucp_am_nbx::init();
 
-        m_dt    = make_dt(get_variant_value(1));
-        m_rx_dt = make_dt(get_variant_value(2));
+        m_dt    = make_dt(get_variant_value(2));
+        m_rx_dt = make_dt(get_variant_value(3));
     }
 
     void cleanup()
@@ -1524,11 +1527,6 @@ public:
         destroy_dt(m_rx_dt);
 
         test_ucp_am_nbx::cleanup();
-    }
-
-    virtual unsigned enable_proto()
-    {
-        return 0;
     }
 };
 


### PR DESCRIPTION
## What
Enabled non-contig datatypes in AM rendezvous.

## Why ?
The changes are part of UCP transition to new infrastructure.
