### PR TITLE
UCP/CORE: Report an error if KA interval = 0

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -398,7 +398,7 @@ static ucs_config_field_t ucp_config_table[] = {
    ucs_offsetof(ucp_config_t, ctx.proto_enable), UCS_CONFIG_TYPE_BOOL},
 
   {"KEEPALIVE_INTERVAL", "20s",
-   "Time interval between keepalive rounds.",
+   "Time interval between keepalive rounds. Must be non-zero value.",
    ucs_offsetof(ucp_config_t, ctx.keepalive_interval),
    UCS_CONFIG_TYPE_TIME_UNITS},
 
@@ -1754,6 +1754,12 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
 
     if (context->config.ext.keepalive_num_eps == 0) {
         ucs_error("UCX_KEEPALIVE_NUM_EPS value must be greater than 0");
+        status = UCS_ERR_INVALID_PARAM;
+        goto err_free_alloc_methods;
+    }
+
+    if (context->config.ext.keepalive_interval == 0) {
+        ucs_error("UCX_KEEPALIVE_INTERVAL value must be greater than 0");
         status = UCS_ERR_INVALID_PARAM;
         goto err_free_alloc_methods;
     }


### PR DESCRIPTION
## What

Report an error if KA interval = 0.

## Why ?

Running `UCX_KEEPALIVE_INTERVAL=0 ./install/master/bin/ucx_info -eptw -u traew` fails with:
```
[swx-ucx01:8132 :0:8132]  ucp_worker.c:3110 Assertion `ka_interval > 0' failed

/hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c: [ ucp_worker_keepalive_timerfd_init() ]
      ...
     3107         ucs_debug("worker %p: removed keepalive current ep %p, moving to next",
     3108                   worker, ep);
     3109         worker->keepalive.lane_map = 0;
==>  3110         ucp_worker_keepalive_next_ep(worker);
     3111         ucs_assert(worker->keepalive.iter != &ucp_ep_ext_gen(ep)->ep_list);
     3112
     3113         if (worker->keepalive.iter == &worker->all_eps) {

==== backtrace (tid:   8132) ====
 0 0x0000000000084a50 ucp_worker_keepalive_timerfd_init()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c:3110
 1 0x0000000000084a50 ucp_worker_keepalive_add_ep()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_worker.c:3292
 2 0x00000000001bafd2 ucp_wireup_init_lanes()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/wireup/wireup.c:1417
 3 0x0000000000054e0d ucp_ep_create_to_worker_addr()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:761
 4 0x0000000000055679 ucp_ep_create_api_to_worker_addr()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1014
 5 0x0000000000055c84 ucp_ep_create()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_ep.c:1116
 6 0x0000000000402fc0 print_ucp_ep_info()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/tools/info/proto_info.c:292
 7 0x00000000004033e8 print_ucp_info()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/tools/info/proto_info.c:419
 8 0x000000000040720f main()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/tools/info/ucx_info.c:281
 9 0x00000000000223d5 __libc_start_main()  ???:0
10 0x0000000000402479 _start()  ???:0
=================================
```

## How ?

Allow `ka_interval >= 0`, otherwise - print error message and fail context creation.