### PR TITLE
UCP/WIREUP: Ensure doing KA for non-p2p lane when resolving ID

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1528,6 +1528,12 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane)
         }
     }
 
+    if (!ucp_ep_is_lane_p2p(ep, lane)) {
+        /* If lane is CONNECT_TO_IFACE, mark it as remote connected to ensure
+         * doing keepalive */
+        ucp_wireup_ep_remote_connected(ep->uct_eps[lane], 0);
+    }
+
     goto out_unlock;
 
 err_destroy_wireup_ep:

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -614,7 +614,7 @@ ucs_status_t uct_tcp_cm_send_event(uct_tcp_ep_t *ep,
                                    uct_tcp_cm_conn_event_t event,
                                    int log_error);
 
-unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t **ep_p, void *pkt, uint32_t length);
+unsigned uct_tcp_cm_handle_conn_pkt(uct_tcp_ep_t *ep, void *pkt, uint32_t length);
 
 unsigned uct_tcp_cm_conn_progress(void *arg);
 


### PR DESCRIPTION
## What

Ensure doing KA for non-p2p lane when resolving ID.

## Why ?

In case of CONNECT_TO_WORKER and error-handling mode, UCP endpoint resolves EP ID and replaces UCT EP by Wireup EP.
And if the lane is non-p2p (i.e. connected remotely as CONNECT_TO_IFACE), need to ensure that keepalive is done. If the lane is p2p, keepalive is done on auxiliary EP.
(found during code review)

## How ?

Update `ucp_wireup_connect_remote` to call `ucp_wireup_ep_remote_connected` for UCT EP if it is non-p2p lane.