### PR TITLE
UCP/WORKER: cleanup dt_invalidate CBs

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -313,7 +313,7 @@ int ucp_request_pending_add(ucp_request_t *req)
               ucs_status_string(status));
 }
 
-static unsigned ucp_request_dt_invalidate_progress(void *arg)
+unsigned ucp_request_dt_invalidate_progress(void *arg)
 {
     ucp_request_t *req = arg;
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -543,4 +543,6 @@ void ucp_request_purge_enqueue_cb(uct_pending_req_t *self, void *arg);
 
 ucs_status_t ucp_request_progress_wrapper(uct_pending_req_t *self);
 
+unsigned ucp_request_dt_invalidate_progress(void *arg);
+
 #endif


### PR DESCRIPTION
## What
cleanup dt_invalidate CBs

## Why ?
resource cleanup

## How ?
invoke `ucp_request_dt_invalidate_progress` to complete scheduled requests
