### PR TITLE
[WIP] UCP/API: Enforce strongly typed enums

### DIFF
--- a/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpParams.java
+++ b/bindings/java/src/main/java/org/openucx/jucx/ucp/UcpParams.java
@@ -24,7 +24,7 @@ import java.util.Map;
 public class UcpParams extends UcxParams {
 
     /**
-     * UCP ucp_feature "features" that are used for library
+     * UCP ucp_features_t "features" that are used for library
      * initialization. It is recommended for applications only to request
      * the features that are required for an optimal functionality
      * This field must be specified.

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -523,6 +523,21 @@ ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-missing-field-initializers],
                                 [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 
+
+ADD_COMPILER_FLAG_IF_SUPPORTED([-Wenum-conversion],
+                               [-Wenum-conversion],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                               [AS_MESSAGE([compiling with enum conversion warning])],
+                               [AS_MESSAGE([compiling without enum conversion warning])])
+
+
+
+ADD_COMPILER_FLAG_IF_SUPPORTED([-Wenum-compare],
+                               [-Wenum-compare],
+                               [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                               [AS_MESSAGE([compiling with enum compare warning])],
+                               [AS_MESSAGE([compiling without enum compare warning])])
+
 #
 # Set C++ optimization/debug flags to be the same as for C
 #

--- a/examples/ucp_hello_world.c
+++ b/examples/ucp_hello_world.c
@@ -61,11 +61,13 @@ struct ucx_context {
     int             completed;
 };
 
-enum ucp_test_mode_t {
+typedef enum {
     TEST_MODE_PROBE,
     TEST_MODE_WAIT,
     TEST_MODE_EVENTFD
-} ucp_test_mode = TEST_MODE_PROBE;
+} ucp_test_mode_t;
+
+ucp_test_mode_t ucp_test_mode = TEST_MODE_PROBE;
 
 typedef enum {
     FAILURE_MODE_NONE,
@@ -215,7 +217,7 @@ err:
 
 static void ep_close_err_mode(ucp_worker_h ucp_worker, ucp_ep_h ucp_ep)
 {
-    uint64_t ep_close_flags;
+    ucp_ep_close_flags_t ep_close_flags;
 
     if (err_handling_opt.ucp_err_mode == UCP_ERR_HANDLING_MODE_PEER) {
         ep_close_flags = UCP_EP_CLOSE_FLAG_FORCE;

--- a/examples/ucp_util.h
+++ b/examples/ucp_util.h
@@ -19,7 +19,7 @@
  * @param [in]  flags   Close UCP endpoint mode. Please see
  *                      @a ucp_ep_close_flags_t for details.
  */
-static void ep_close(ucp_worker_h ucp_worker, ucp_ep_h ep, uint64_t flags)
+static void ep_close(ucp_worker_h ucp_worker, ucp_ep_h ep, ucp_ep_close_flags_t flags)
 {
     ucp_request_param_t param;
     ucs_status_t status;

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -14,7 +14,7 @@
 #include <arpa/inet.h>
 
 
-enum {
+typedef enum {
     PRINT_VERSION        = UCS_BIT(0),
     PRINT_SYS_INFO       = UCS_BIT(1),
     PRINT_BUILD_CONFIG   = UCS_BIT(2),
@@ -26,7 +26,7 @@ enum {
     PRINT_MEM_MAP        = UCS_BIT(8),
     PRINT_SYS_TOPO       = UCS_BIT(9),
     PRINT_MEMCPY_BW      = UCS_BIT(10)
-};
+} ucx_info_modes_t;
 
 
 typedef enum {

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -75,7 +75,7 @@ typedef enum {
 } ucx_perf_wait_mode_t;
 
 
-enum ucx_perf_test_flags {
+typedef enum {
     UCX_PERF_TEST_FLAG_VALIDATE         = UCS_BIT(1), /* Validate data. Affects performance. */
     UCX_PERF_TEST_FLAG_ONE_SIDED        = UCS_BIT(2), /* For tests which involves only one side,
                                                          the responder should not call progress(). */
@@ -89,7 +89,7 @@ enum ucx_perf_test_flags {
     UCX_PERF_TEST_FLAG_ERR_HANDLING     = UCS_BIT(11), /* Create UCP eps with error handling support */
     UCX_PERF_TEST_FLAG_LOOPBACK         = UCS_BIT(12), /* Use loopback connection */
     UCX_PERF_TEST_FLAG_PREREG           = UCS_BIT(13) /* Pass pre-registered memory handle */
-};
+} ucx_perf_test_flags_t;
 
 
 enum {
@@ -182,7 +182,7 @@ typedef struct ucx_perf_params {
     ucx_perf_wait_mode_t   wait_mode;       /* How to wait */
     ucs_memory_type_t      send_mem_type;   /* Send memory type */
     ucs_memory_type_t      recv_mem_type;   /* Recv memory type */
-    unsigned               flags;           /* See ucx_perf_test_flags. */
+    unsigned               flags;           /* See ucx_perf_test_flags_t. */
 
     size_t                 *msg_size_list;  /* Test message sizes list. The size
                                                of the array is in msg_size_cnt */

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -23,7 +23,7 @@
 #define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lz"
 #define TEST_ID_UNDEFINED       -1
 
-enum {
+typedef enum {
     TEST_FLAG_PRINT_RESULTS    = UCS_BIT(0),
     TEST_FLAG_PRINT_TEST       = UCS_BIT(1),
     TEST_FLAG_SET_AFFINITY     = UCS_BIT(8),
@@ -31,7 +31,7 @@ enum {
     TEST_FLAG_PRINT_FINAL      = UCS_BIT(10),
     TEST_FLAG_PRINT_CSV        = UCS_BIT(11),
     TEST_FLAG_PRINT_EXTRA_INFO = UCS_BIT(12)
-};
+} test_flags_t;
 
 typedef struct sock_rte_group {
     int                          sendfd;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -116,7 +116,7 @@ BEGIN_C_DECLS
  * The enumeration allows specifying which fields in @ref ucp_params_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_params_field {
+typedef enum {
     UCP_PARAM_FIELD_FEATURES          = UCS_BIT(0), /**< features */
     UCP_PARAM_FIELD_REQUEST_SIZE      = UCS_BIT(1), /**< request_size */
     UCP_PARAM_FIELD_REQUEST_INIT      = UCS_BIT(2), /**< request_init */
@@ -126,7 +126,7 @@ enum ucp_params_field {
     UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6), /**< estimated_num_eps */
     UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7), /**< estimated_num_ppn */
     UCP_PARAM_FIELD_NAME              = UCS_BIT(8)  /**< name */
-};
+} ucp_params_fields_t;
 
 
 /**
@@ -137,7 +137,7 @@ enum ucp_params_field {
  * application can request the features using @ref ucp_params_t "UCP parameters"
  * during @ref ucp_init "UCP initialization" process.
  */
-enum ucp_feature {
+typedef enum {
     UCP_FEATURE_TAG          = UCS_BIT(0),  /**< Request tag matching
                                                  support */
     UCP_FEATURE_RMA          = UCS_BIT(1),  /**< Request remote memory
@@ -151,7 +151,7 @@ enum ucp_feature {
     UCP_FEATURE_STREAM       = UCS_BIT(5),  /**< Request stream support */
     UCP_FEATURE_AM           = UCS_BIT(6)   /**< Request Active Message
                                                  support */
-};
+} ucp_features_t;
 
 
 /**
@@ -161,7 +161,7 @@ enum ucp_feature {
  * The enumeration allows specifying which fields in @ref ucp_worker_params_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_worker_params_field {
+typedef enum {
     UCP_WORKER_PARAM_FIELD_THREAD_MODE  = UCS_BIT(0), /**< UCP thread mode */
     UCP_WORKER_PARAM_FIELD_CPU_MASK     = UCS_BIT(1), /**< Worker's CPU bitmap */
     UCP_WORKER_PARAM_FIELD_EVENTS       = UCS_BIT(2), /**< Worker's events bitmap */
@@ -173,7 +173,7 @@ enum ucp_worker_params_field {
     UCP_WORKER_PARAM_FIELD_AM_ALIGNMENT = UCS_BIT(7), /**< Alignment of active
                                                            messages on the receiver */
     UCP_WORKER_PARAM_FIELD_CLIENT_ID    = UCS_BIT(8)  /**< Client id */
-};
+} ucp_worker_params_fields_t;
 
 
 /**
@@ -196,7 +196,7 @@ typedef enum {
  * The enumeration allows specifying which fields in @ref ucp_listener_params_t
  * are present. It is used to enable backward compatibility support.
  */
-enum ucp_listener_params_field {
+typedef enum {
     /**
      * Sock address and length.
      */
@@ -210,7 +210,7 @@ enum ucp_listener_params_field {
     /**< User's callback and argument for handling the incoming connection
      *   request. */
     UCP_LISTENER_PARAM_FIELD_CONN_HANDLER        = UCS_BIT(2)
-};
+} ucp_listener_params_field_t;
 
 
 /**
@@ -237,7 +237,7 @@ typedef enum {
  * The enumeration allows specifying which fields in @ref ucp_ep_params_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_ep_params_field {
+typedef enum {
     UCP_EP_PARAM_FIELD_REMOTE_ADDRESS    = UCS_BIT(0), /**< Address of remote
                                                             peer */
     UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE = UCS_BIT(1), /**< Error handling mode.
@@ -251,7 +251,7 @@ enum ucp_ep_params_field {
     UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6),
     UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7), /**< Endpoint name */
     UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8)  /**< Local socket Address */
-};
+} ucp_ep_params_fields_t;
 
 
 /**
@@ -261,7 +261,7 @@ enum ucp_ep_params_field {
  * The enumeration list describes the endpoint's parameters flags supported by
  * @ref ucp_ep_create() function.
  */
-enum ucp_ep_params_flags_field {
+typedef enum {
     UCP_EP_PARAMS_FLAGS_CLIENT_SERVER  = UCS_BIT(0),  /**< Using a client-server
                                                            connection establishment
                                                            mechanism.
@@ -287,7 +287,7 @@ enum ucp_ep_params_flags_field {
                                                            can be obtained from
                                                            @ref ucp_conn_request_h using
                                                            @ref ucp_conn_request_query */
-};
+} ucp_ep_params_flags_fields_t;
 
 
 /**
@@ -327,7 +327,7 @@ typedef enum {
  *
  * The enumeration is used to specify the behavior of @ref ucp_ep_close_nb.
  */
-enum ucp_ep_close_mode {
+typedef enum {
     UCP_EP_CLOSE_MODE_FORCE         = 0, /**< @ref ucp_ep_close_nb releases
                                               the endpoint without any
                                               confirmation from the peer. All
@@ -344,7 +344,7 @@ enum ucp_ep_close_mode {
     UCP_EP_CLOSE_MODE_FLUSH         = 1  /**< @ref ucp_ep_close_nb schedules
                                               flushes on all outstanding
                                               operations. */
-};
+} ucp_ep_close_mode_t;
 
 
 /**
@@ -355,10 +355,10 @@ enum ucp_ep_close_mode {
  * present and operation flags are used. It is used to enable backward
  * compatibility support.
  */
-typedef enum ucp_ep_perf_param_field {
+typedef enum {
     /** Enables @ref ucp_ep_evaluate_perf_param_t::message_size */
     UCP_EP_PERF_PARAM_FIELD_MESSAGE_SIZE       = UCS_BIT(0)
-} ucp_ep_perf_param_field_t;
+} ucp_ep_perf_param_fields_t;
 
 
 /**
@@ -369,10 +369,10 @@ typedef enum ucp_ep_perf_param_field {
  * present and operation flags are used. It is used to enable backward
  * compatibility support.
  */
-typedef enum ucp_ep_perf_attr_field {
+typedef enum {
     /** Enables @ref ucp_ep_evaluate_perf_attr_t::estimated_time */
     UCP_EP_PERF_ATTR_FIELD_ESTIMATED_TIME = UCS_BIT(0)
-} ucp_ep_perf_attr_field_t;
+} ucp_ep_perf_attr_fields_t;
 
 
 /**
@@ -382,7 +382,7 @@ typedef enum ucp_ep_perf_attr_field {
  * The enumeration allows specifying which fields in @ref ucp_mem_map_params_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_mem_map_params_field {
+typedef enum {
     UCP_MEM_MAP_PARAM_FIELD_ADDRESS     = UCS_BIT(0), /**< Address of the memory that
                                                            will be used in the
                                                            @ref ucp_mem_map routine. */
@@ -393,7 +393,7 @@ enum ucp_mem_map_params_field {
     UCP_MEM_MAP_PARAM_FIELD_FLAGS       = UCS_BIT(2), /**< Allocation flags. */
     UCP_MEM_MAP_PARAM_FIELD_PROT        = UCS_BIT(3), /**< Memory protection mode. */
     UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE = UCS_BIT(4)  /**< Memory type. */
-};
+} ucp_mem_map_params_fields_t;
 
 /**
  * @ingroup UCP_MEM
@@ -402,11 +402,11 @@ enum ucp_mem_map_params_field {
  * The enumeration allows specifying which fields in @ref ucp_mem_advise_params_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_mem_advise_params_field {
+typedef enum {
     UCP_MEM_ADVISE_PARAM_FIELD_ADDRESS = UCS_BIT(0), /**< Address of the memory */
     UCP_MEM_ADVISE_PARAM_FIELD_LENGTH  = UCS_BIT(1), /**< The size of memory */
     UCP_MEM_ADVISE_PARAM_FIELD_ADVICE  = UCS_BIT(2)  /**< Advice on memory usage */
-};
+} ucp_mem_advise_params_field_t;
 
 
 /**
@@ -416,10 +416,10 @@ enum ucp_mem_advise_params_field {
  * The enumeration allows specifying which fields in @ref ucp_lib_attr_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_lib_attr_field {
+typedef enum {
     /**< UCP library maximum supported thread level flag */
     UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL = UCS_BIT(0)
-};
+} ucp_lib_attr_fields_t;
 
 
 /**
@@ -429,12 +429,12 @@ enum ucp_lib_attr_field {
  * The enumeration allows specifying which fields in @ref ucp_context_attr_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_context_attr_field {
+typedef enum {
     UCP_ATTR_FIELD_REQUEST_SIZE = UCS_BIT(0), /**< UCP request size */
     UCP_ATTR_FIELD_THREAD_MODE  = UCS_BIT(1), /**< UCP context thread flag */
     UCP_ATTR_FIELD_MEMORY_TYPES = UCS_BIT(2), /**< UCP supported memory types */
     UCP_ATTR_FIELD_NAME         = UCS_BIT(3)  /**< UCP context name */
-};
+} ucp_context_attr_fields_t;
 
 
 /**
@@ -444,7 +444,7 @@ enum ucp_context_attr_field {
  * The enumeration allows specifying which fields in @ref ucp_worker_attr_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_worker_attr_field {
+typedef enum {
     UCP_WORKER_ATTR_FIELD_THREAD_MODE     = UCS_BIT(0), /**< UCP thread mode */
     UCP_WORKER_ATTR_FIELD_ADDRESS         = UCS_BIT(1), /**< UCP address */
     UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS   = UCS_BIT(2), /**< UCP address flags */
@@ -453,7 +453,7 @@ enum ucp_worker_attr_field {
     UCP_WORKER_ATTR_FIELD_NAME            = UCS_BIT(4), /**< UCP worker name */
     UCP_WORKER_ATTR_FIELD_MAX_INFO_STRING = UCS_BIT(5)  /**< Maximum size of
                                                              info string */
-};
+} ucp_worker_attr_fields_t;
 
 
 /**
@@ -464,9 +464,9 @@ enum ucp_worker_attr_field {
  * @ref ucp_worker_address_attr_t are present. It is used to enable backward
  * compatibility support.
  */
-enum ucp_worker_address_attr_field {
+typedef enum {
     UCP_WORKER_ADDRESS_ATTR_FIELD_UID = UCS_BIT(0) /**< Unique id of the worker */
-};
+} ucp_worker_address_attr_fields_t;
 
 
 /**
@@ -476,9 +476,9 @@ enum ucp_worker_address_attr_field {
  * The enumeration allows specifying which fields in @ref ucp_listener_attr_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_listener_attr_field {
+typedef enum {
     UCP_LISTENER_ATTR_FIELD_SOCKADDR = UCS_BIT(0) /**< Sockaddr used for listening */
-};
+} ucp_listener_attr_fields_t;
 
 
 /**
@@ -488,10 +488,10 @@ enum ucp_listener_attr_field {
  * The enumeration allows specifying which fields in @ref ucp_conn_request_attr_t
  * are present. It is used to enable backward compatibility support.
  */
-enum ucp_conn_request_attr_field {
+typedef enum {
     UCP_CONN_REQUEST_ATTR_FIELD_CLIENT_ADDR = UCS_BIT(0), /**< Client's address */
     UCP_CONN_REQUEST_ATTR_FIELD_CLIENT_ID   = UCS_BIT(1)  /**< Remote client id */
-};
+} ucp_conn_request_attr_fields_t;
 
 
 /**
@@ -500,7 +500,7 @@ enum ucp_conn_request_attr_field {
  *
  * The enumeration list describes the datatypes supported by UCP.
  */
-enum ucp_dt_type {
+typedef enum {
     UCP_DATATYPE_CONTIG  = 0,      /**< Contiguous datatype */
     UCP_DATATYPE_STRIDED = 1,      /**< Strided datatype */
     UCP_DATATYPE_IOV     = 2,      /**< Scatter-gather list with multiple pointers */
@@ -510,7 +510,7 @@ enum ucp_dt_type {
                                         the datatype classification */
     UCP_DATATYPE_CLASS_MASK = UCS_MASK(UCP_DATATYPE_SHIFT) /**< Data-type class
                                                                 mask */
-};
+} ucp_dt_class_t;
 
 
 /**
@@ -520,7 +520,7 @@ enum ucp_dt_type {
  * The enumeration list describes the memory mapping flags supported by @ref
  * ucp_mem_map() function.
  */
-enum {
+typedef enum {
     UCP_MEM_MAP_NONBLOCK = UCS_BIT(0), /**< Complete the mapping faster, possibly by
                                             not populating the pages in the mapping
                                             up-front, and mapping them later when
@@ -534,7 +534,7 @@ enum {
                                             place the mapping at exactly that
                                             address. The address must be a multiple
                                             of the page size. */
-};
+} ucp_mem_map_flags_t;
 
 
 /**
@@ -544,12 +544,12 @@ enum {
  * The enumeration list describes the memory mapping protections supported by the @ref
  * ucp_mem_map() function.
  */
-enum {
+typedef enum {
     UCP_MEM_MAP_PROT_LOCAL_READ   = UCS_BIT(0),  /**< Enable local read access. */
     UCP_MEM_MAP_PROT_LOCAL_WRITE  = UCS_BIT(1),  /**< Enable local write access. */
     UCP_MEM_MAP_PROT_REMOTE_READ  = UCS_BIT(8),  /**< Enable remote read access. */
     UCP_MEM_MAP_PROT_REMOTE_WRITE = UCS_BIT(9)   /**< Enable remote write access. */
-};
+} ucp_mem_map_prot_modes_t;
 
 
 /**
@@ -558,7 +558,7 @@ enum {
  *
  * Flags that indicate how to handle UCP Active Messages.
  */
-enum ucp_am_cb_flags {
+typedef enum {
     /**
      * Indicates that the entire message will be handled in one callback.
      */
@@ -571,7 +571,7 @@ enum ucp_am_cb_flags {
      * @ref ucp_am_data_release is called.
      */
     UCP_AM_FLAG_PERSISTENT_DATA = UCS_BIT(1)
-};
+} ucp_am_cb_flags_t;
 
 
 /**
@@ -581,7 +581,7 @@ enum ucp_am_cb_flags {
  * Flags dictate the behavior of @ref ucp_am_send_nb and @ref ucp_am_send_nbx
  * routines.
  */
-enum ucp_send_am_flags {
+typedef enum {
     UCP_AM_SEND_FLAG_REPLY = UCS_BIT(0),             /**< Force relevant reply
                                                           endpoint to be passed to
                                                           the data callback on the
@@ -592,7 +592,7 @@ enum ucp_send_am_flags {
                                                           rendezvous protocol for
                                                           AM sends. */
     UCP_AM_SEND_REPLY      = UCP_AM_SEND_FLAG_REPLY  /**< Backward compatibility. */
-};
+} ucp_send_am_flags_t;
 
 
 /**
@@ -605,9 +605,9 @@ enum ucp_send_am_flags {
  * and the user has to call @ref ucp_am_data_release when data is
  * no longer needed.
  */
-enum ucp_cb_param_flags {
+typedef enum {
     UCP_CB_PARAM_FLAG_DATA = UCS_BIT(0)
-};
+} ucp_cb_param_flags_t;
 
 
 /**
@@ -774,7 +774,7 @@ typedef enum {
  * The enumeration allows specifying which fields in @ref ucp_am_handler_param_t
  * are present. It is used to enable backward compatibility support.
  */
-enum ucp_am_handler_param_field {
+typedef enum {
     /**
      * Indicates that @ref ucp_am_handler_param_t.id field is valid.
      */
@@ -791,7 +791,7 @@ enum ucp_am_handler_param_field {
      * Indicates that @ref ucp_am_handler_param_t.arg field is valid.
      */
     UCP_AM_HANDLER_PARAM_FIELD_ARG     = UCS_BIT(3)
-};
+} ucp_am_handler_param_fields_t;
 
 
 /**
@@ -967,7 +967,7 @@ typedef struct ucp_generic_dt_ops {
  * The structure defines the parameters that are used for
  * UCP library tuning during UCP library @ref ucp_init "initialization".
  *
- * @note UCP library implementation uses the @ref ucp_feature "features"
+ * @note UCP library implementation uses the @ref ucp_features_t "features"
  * parameter to optimize the library functionality that minimize memory
  * footprint. For example, if the application does not require send/receive
  * semantics UCP library may avoid allocation of expensive resources associated with
@@ -975,14 +975,14 @@ typedef struct ucp_generic_dt_ops {
  */
 typedef struct ucp_params {
     /**
-     * Mask of valid fields in this structure, using bits from @ref ucp_params_field.
+     * Mask of valid fields in this structure, using bits from @ref ucp_params_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
     uint64_t                           field_mask;
 
     /**
-     * UCP @ref ucp_feature "features" that are used for library
+     * UCP @ref ucp_features_t "features" that are used for library
      * initialization. It is recommended for applications only to request
      * the features that are required for an optimal functionality
      * This field must be specified.
@@ -1087,7 +1087,7 @@ typedef struct ucp_params {
 typedef struct ucp_lib_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_lib_attr_field.
+     * @ref ucp_lib_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1114,7 +1114,7 @@ typedef struct ucp_lib_attr {
 typedef struct ucp_context_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_context_attr_field.
+     * @ref ucp_context_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1156,7 +1156,7 @@ typedef struct ucp_context_attr {
 typedef struct ucp_worker_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_worker_attr_field.
+     * @ref ucp_worker_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1215,7 +1215,7 @@ typedef struct ucp_worker_attr {
  */
 typedef struct ucp_worker_params {
     /**
-     * Mask of valid fields in this structure, using bits from @ref ucp_worker_params_field.
+     * Mask of valid fields in this structure, using bits from @ref ucp_worker_params_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1322,7 +1322,7 @@ typedef struct ucp_worker_params {
 typedef struct ucp_worker_address_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_worker_address_attr_field.
+     * @ref ucp_worker_address_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1345,7 +1345,7 @@ typedef struct ucp_worker_address_attr {
 typedef struct {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_ep_perf_param_field_t.
+     * @ref ucp_ep_perf_param_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1369,7 +1369,7 @@ typedef struct {
 typedef struct {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_ep_perf_attr_field_t.
+     * @ref ucp_ep_perf_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1393,7 +1393,7 @@ typedef struct {
 typedef struct ucp_listener_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_listener_attr_field.
+     * @ref ucp_listener_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1417,7 +1417,7 @@ typedef struct ucp_listener_attr {
 typedef struct ucp_conn_request_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_conn_request_attr_field.
+     * @ref ucp_conn_request_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1447,7 +1447,7 @@ typedef struct ucp_conn_request_attr {
 typedef struct ucp_listener_params {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_listener_params_field.
+     * @ref ucp_listener_params_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1525,7 +1525,7 @@ typedef struct ucp_stream_poll_ep {
 typedef struct ucp_mem_map_params {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_mem_map_params_field.
+     * @ref ucp_mem_map_params_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -1788,7 +1788,7 @@ typedef struct ucp_am_handler_param {
     unsigned                 id;
 
     /**
-     * Handler flags as defined by @ref ucp_am_cb_flags.
+     * Handler flags as defined by @ref ucp_am_cb_flags_t.
      */
     uint32_t                 flags;
 
@@ -2252,7 +2252,7 @@ ssize_t ucp_stream_worker_poll(ucp_worker_h worker,
  * file descriptor obtained per worker (this function) and the second is the
  * @ref ucp_worker_wait function for waiting on the next event internally.
  *
- * @note UCP @ref ucp_feature "features" have to be triggered
+ * @note UCP @ref ucp_features_t "features" have to be triggered
  *   with @ref UCP_FEATURE_WAKEUP to select proper transport
  *
  * @param [in]  worker    Worker of notified events.
@@ -2284,7 +2284,7 @@ ucs_status_t ucp_worker_get_efd(ucp_worker_h worker, int *fd);
  * notification and may not progress some of the requests as it would when
  * calling @ref ucp_worker_progress (which is not invoked in that duration).
  *
- * @note UCP @ref ucp_feature "features" have to be triggered
+ * @note UCP @ref ucp_features_t "features" have to be triggered
  *   with @ref UCP_FEATURE_WAKEUP to select proper transport
  *
  * @param [in]  worker    Worker to wait for events on.
@@ -2375,7 +2375,7 @@ void ucp_worker_wait_mem(ucp_worker_h worker, void *address);
  * }
  * @endcode
  *
- * @note UCP @ref ucp_feature "features" have to be triggered
+ * @note UCP @ref ucp_features_t "features" have to be triggered
  *   with @ref UCP_FEATURE_WAKEUP to select proper transport
  *
  * @param [in]  worker    Worker of notified events.
@@ -2542,7 +2542,7 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  * process depends on the selected @a mode.
  *
  * @param [in]  ep      Handle to the endpoint to close.
- * @param [in]  mode    One from @ref ucp_ep_close_mode value.
+ * @param [in]  mode    One from @ref ucp_ep_close_mode_t value.
  *
  * @return UCS_OK           - The endpoint is closed successfully.
  * @return UCS_PTR_IS_ERR(_ptr) - The closure failed and an error code indicates
@@ -2886,7 +2886,7 @@ typedef enum ucp_mem_advice {
 typedef struct ucp_mem_advise_params {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_mem_advise_params_field. All fields are mandatory.
+     * @ref ucp_mem_advise_params_fields_t. All fields are mandatory.
      * Provides ABI compatibility with respect to adding new fields.
      */
     uint64_t                field_mask;
@@ -3083,7 +3083,7 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  */
 ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
                                        ucp_am_callback_t cb, void *arg,
-                                       uint32_t flags);
+                                       ucp_am_cb_flags_t flags);
 
 
 /**
@@ -3126,7 +3126,7 @@ ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
  * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
  * @param [in]  cb          Callback that is invoked upon completion of the
  *                          data transfer if it is not completed immediately.
- * @param [in]  flags       Operation flags as defined by @ref ucp_send_am_flags.
+ * @param [in]  flags       Operation flags as defined by @ref ucp_send_am_flags_t.
  *
  * @return NULL             Active Message was sent immediately.
  * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message.
@@ -3156,7 +3156,7 @@ ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
  *       it completes immediately.
  * @note This operation supports specific flags, which can be passed
  *       in @a param by @ref ucp_request_param_t.flags. The exact set of flags
- *       is defined by @ref ucp_send_am_flags.
+ *       is defined by @ref ucp_send_am_flags_t.
  *
  * @param [in]  ep            UCP endpoint where the Active Message will be run.
  * @param [in]  id            Active Message id. Specifies which registered
@@ -4592,11 +4592,11 @@ ucs_status_ptr_t ucp_worker_flush_nbx(ucp_worker_h worker,
  * The enumeration allows specifying which fields in @ref ucp_ep_attr_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_ep_attr_field {
+typedef enum {
     UCP_EP_ATTR_FIELD_NAME            = UCS_BIT(0), /**< UCP endpoint name */
     UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(1), /**< Sockaddr used by the endpoint */
     UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(2)  /**< Sockaddr the endpoint is connected to */
-};
+} ucp_ep_attr_fields_t;
 
 
 /**
@@ -4609,7 +4609,7 @@ enum ucp_ep_attr_field {
 typedef struct ucp_ep_attr {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_ep_attr_field.
+     * @ref ucp_ep_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -184,7 +184,7 @@ typedef struct ucp_listener              *ucp_listener_h;
  */
 typedef struct ucp_mem_attr {
    /**
-     * Mask of valid fields in this structure, using bits from @ref ucp_mem_attr_field.
+     * Mask of valid fields in this structure, using bits from @ref ucp_mem_attr_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -214,11 +214,11 @@ typedef struct ucp_mem_attr {
  * The enumeration allows specifying which fields in @ref ucp_mem_attr_t are
  * present. It is used to enable backward compatibility support.
  */
-enum ucp_mem_attr_field {
+typedef enum {
     UCP_MEM_ATTR_FIELD_ADDRESS  = UCS_BIT(0), /**< Virtual address */
     UCP_MEM_ATTR_FIELD_LENGTH   = UCS_BIT(1), /**< The size of memory region */
     UCP_MEM_ATTR_FIELD_MEM_TYPE = UCS_BIT(2)  /**< Type of allocated or registered memory */
-};
+} ucp_mem_attr_fields_t;
 
 
 /**
@@ -273,7 +273,7 @@ typedef struct ucp_recv_desc             *ucp_tag_message_h;
  * @brief UCP Datatype Identifier
  *
  * UCP datatype identifier is a 64bit object used for datatype identification.
- * Predefined UCP identifiers are defined by @ref ucp_dt_type.
+ * Predefined UCP identifiers are defined by @ref ucp_dt_class_t.
  */
 typedef uint64_t                         ucp_datatype_t;
 
@@ -683,7 +683,7 @@ typedef ucs_status_t (*ucp_am_recv_callback_t)(void *arg, const void *header,
 typedef struct ucp_ep_params {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref ucp_ep_params_field.
+     * @ref ucp_ep_params_fields_t.
      * Fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
@@ -715,7 +715,7 @@ typedef struct ucp_ep_params {
     void                    *user_data;
 
     /**
-     * Endpoint flags from @ref ucp_ep_params_flags_field.
+     * Endpoint flags from @ref ucp_ep_params_flags_fields_t.
      * This value is optional.
      * If it's not set (along with its corresponding bit in the field_mask -
      * @ref UCP_EP_PARAM_FIELD_FLAGS), the @ref ucp_ep_create() routine will

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -20,12 +20,12 @@
     })
 
 
-enum {
+typedef enum {
     UCP_AM_CB_PRIV_FIRST_FLAG = UCS_BIT(15),
 
     /* Indicates that cb was set with ucp_worker_set_am_recv_handler */
     UCP_AM_CB_PRIV_FLAG_NBX   = UCP_AM_CB_PRIV_FIRST_FLAG
-};
+} ucp_am_cb_priv_flags_t;
 
 
 /**

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -28,14 +28,14 @@
 #include <ucs/type/param.h>
 
 
-enum {
+typedef enum {
     /* The flag indicates that the resource may be used for auxiliary
      * wireup communications only */
     UCP_TL_RSC_FLAG_AUX      = UCS_BIT(0),
     /* The flag indicates that the resource may be used for client-server
      * connection establishment with a sockaddr */
     UCP_TL_RSC_FLAG_SOCKADDR = UCS_BIT(1)
-};
+} ucp_tl_rsc_flags_t;
 
 
 typedef struct ucp_context_config {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -898,7 +898,7 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
 {
     ucp_unpacked_address_t remote_addr;
     unsigned ep_init_flags;
-    uint64_t addr_flags;
+    ucp_address_pack_flags_t addr_flags;
     ucs_status_t status;
     const void *worker_addr;
     unsigned i;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -132,18 +132,18 @@ enum {
 /**
  * UCP endpoint statistics counters
  */
-enum {
+typedef enum {
     UCP_EP_STAT_TAG_TX_EAGER,
     UCP_EP_STAT_TAG_TX_EAGER_SYNC,
     UCP_EP_STAT_TAG_TX_RNDV,
     UCP_EP_STAT_LAST
-};
+} ucp_ep_stat_coutner_t;
 
 
 /**
  * Endpoint init flags
  */
-enum {
+typedef enum {
     UCP_EP_INIT_FLAG_MEM_TYPE          = UCS_BIT(0),  /**< Endpoint for local mem type transfers */
     UCP_EP_INIT_CREATE_AM_LANE         = UCS_BIT(1),  /**< Endpoint requires an AM lane */
     UCP_EP_INIT_CM_WIREUP_CLIENT       = UCS_BIT(2),  /**< Endpoint wireup protocol is based on CM,
@@ -164,7 +164,7 @@ enum {
                                                            keepalive lane */
     UCP_EP_INIT_ALLOW_AM_AUX_TL        = UCS_BIT(10)  /**< Endpoint allows selecting of auxiliary
                                                            transports for AM lane */
-};
+} ucp_ep_init_flags_t;
 
 
 #define UCP_EP_STAT_TAG_OP(_ep, _op) \
@@ -545,23 +545,23 @@ typedef struct {
 } ucp_ep_ext_proto_t;
 
 
-enum {
+typedef enum {
     UCP_WIREUP_SA_DATA_CM_ADDR   = UCS_BIT(1)  /* Sockaddr client data contains address
                                                   for CM based wireup: there is only
                                                   iface and ep address of transport
                                                   lanes, remote device address is
                                                   provided by CM and has to be added to
                                                   unpacked UCP address locally. */
-};
+} ucp_wireup_sa_addr_mode;
 
 
 /* Sockaddr data flags that are packed to the header field in
  * ucp_wireup_sockaddr_data_base_t structure.
  */
-enum {
+typedef enum {
     /* Indicates support of UCP_ERR_HANDLING_MODE_PEER error mode. */
     UCP_SA_DATA_FLAG_ERR_MODE_PEER = UCS_BIT(0)
-};
+} ucp_sa_data_flags_t;
 
 
 /* Basic sockaddr data. Version 1 uses some additional fields which are not

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -175,7 +175,7 @@ ucp_request_release_common(void *request, uint8_t cb_flag, const char *debug_nam
     ucp_request_t *req = (ucp_request_t*)request - 1;
     ucp_worker_h UCS_V_UNUSED worker = ucs_container_of(ucs_mpool_obj_owner(req),
                                                         ucp_worker_t, req_mp);
-    uint32_t flags;
+    ucp_request_flags_t flags;
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -33,7 +33,7 @@
 /**
  * Request flags
  */
-enum {
+typedef enum {
     UCP_REQUEST_FLAG_COMPLETED             = UCS_BIT(0),
     UCP_REQUEST_FLAG_RELEASED              = UCS_BIT(1),
     UCP_REQUEST_FLAG_PROTO_SEND            = UCS_BIT(2),
@@ -61,25 +61,25 @@ enum {
     UCP_REQUEST_DEBUG_FLAG_EXTERNAL        = 0,
     UCP_REQUEST_FLAG_SUPER_VALID           = 0
 #endif
-};
+} ucp_request_flags_t;
 
 
 /**
  * Protocols enumerator to work with send request state
  */
-enum {
+typedef enum {
     UCP_REQUEST_SEND_PROTO_BCOPY_AM = 0,
     UCP_REQUEST_SEND_PROTO_ZCOPY_AM,
     UCP_REQUEST_SEND_PROTO_RNDV_GET,
     UCP_REQUEST_SEND_PROTO_RNDV_PUT,
     UCP_REQUEST_SEND_PROTO_RMA
-};
+} ucp_request_send_proto_type_t;
 
 
 /**
  * Receive descriptor flags.
  */
-enum {
+typedef enum {
     UCP_RECV_DESC_FLAG_UCT_DESC         = UCS_BIT(0), /* Descriptor allocated by UCT */
     UCP_RECV_DESC_FLAG_EAGER            = UCS_BIT(1), /* Eager tag message */
     UCP_RECV_DESC_FLAG_EAGER_ONLY       = UCS_BIT(2), /* Eager tag message with single fragment */
@@ -106,16 +106,16 @@ enum {
                                                          initialized yet. */
     UCP_RECV_DESC_FLAG_RELEASED         = UCS_BIT(10) /* Indicates that the descriptor was
                                                          released and cannot be used. */
-};
+} ucp_recv_desc_flags_t;
 
 
 /**
  * Receive descriptor list pointers
  */
-enum {
+typedef enum {
     UCP_RDESC_HASH_LIST = 0,
     UCP_RDESC_ALL_LIST  = 1
-};
+} ucp_rdesc_ptr_t;
 
 
 /**

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -15,10 +15,10 @@
 /**
  * Rkey proto index
  */
-enum {
+typedef enum {
     UCP_RKEY_BASIC_PROTO,
     UCP_RKEY_SW_PROTO
-};
+} ucp_rkey_proto_t;
 
 
 typedef uint8_t ucp_rkey_proto_index_t;
@@ -37,10 +37,10 @@ typedef struct ucp_tl_rkey {
 /**
  * Rkey flags
  */
-enum {
+typedef enum {
     UCP_RKEY_DESC_FLAG_POOL       = UCS_BIT(0)  /* Descriptor was allocated from pool
                                                    and must be returned to pool, not free */
-};
+} ucp_rkey_flags_t;
 
 
 /**

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -75,7 +75,7 @@
 /**
  * UCP worker flags
  */
-enum {
+typedef enum {
     /** Internal worker flags start from this bit index, to co-exist with user
      * flags specified when worker is created */
     UCP_WORKER_INTERNAL_FLAGS_SHIFT = 32,
@@ -102,13 +102,13 @@ enum {
     /** Indicates that AM mpool was initialized on this worker */
     UCP_WORKER_FLAG_AM_MPOOL_INITIALIZED =
             UCS_BIT(UCP_WORKER_INTERNAL_FLAGS_SHIFT + 4)
-};
+} ucp_worker_internal_flags_t;
 
 
 /**
  * UCP iface flags
  */
-enum {
+typedef enum {
     UCP_WORKER_IFACE_FLAG_OFFLOAD_ACTIVATED = UCS_BIT(0), /**< UCP iface receives tag
                                                                offload messages */
     UCP_WORKER_IFACE_FLAG_ON_ARM_LIST       = UCS_BIT(1), /**< UCP iface is an element
@@ -118,13 +118,13 @@ enum {
     UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2)  /**< There is another UCP iface
                                                                with the same caps, but
                                                                with better performance */
-};
+} ucp_worker_iface_flags_t;
 
 
 /**
  * UCP worker statistics counters
  */
-enum {
+typedef enum {
     /* Total number of received eager messages */
     UCP_WORKER_STAT_TAG_RX_EAGER_MSG,
     UCP_WORKER_STAT_TAG_RX_EAGER_SYNC_MSG,
@@ -144,13 +144,13 @@ enum {
     UCP_WORKER_STAT_TAG_RX_RNDV_RKEY_PTR,
 
     UCP_WORKER_STAT_LAST
-};
+} ucp_worker_stat_counter_t;
 
 
 /**
  * UCP worker tag offload statistics counters
  */
-enum {
+typedef enum {
     UCP_WORKER_STAT_TAG_OFFLOAD_POSTED,
     UCP_WORKER_STAT_TAG_OFFLOAD_MATCHED,
     UCP_WORKER_STAT_TAG_OFFLOAD_MATCHED_SW_RNDV,
@@ -165,7 +165,7 @@ enum {
     UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_RNDV,
     UCP_WORKER_STAT_TAG_OFFLOAD_RX_UNEXP_SW_RNDV,
     UCP_WORKER_STAT_TAG_OFFLOAD_LAST
-};
+} ucp_worker_stat_counter;
 
 
 #define UCP_WORKER_STAT_EAGER_MSG(_worker, _flags) \

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -17,7 +17,7 @@
 
 static UCS_F_ALWAYS_INLINE int
 ucp_datatype_iter_is_class(const ucp_datatype_iter_t *dt_iter,
-                           enum ucp_dt_type dt_class, unsigned dt_mask)
+                           ucp_dt_class_t dt_class, unsigned dt_mask)
 {
     /* The following branch could be eliminated by the compiler if dt_mask and
      * the tested dt_class are constants, and dt_mask does not contain dt_class.

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -17,12 +17,6 @@
 
 
 /**
- * Datatype classification
- */
-typedef enum ucp_dt_type          ucp_dt_class_t;
-
-
-/**
  * Memory registration state of a buffer/operation
  */
 typedef struct ucp_dt_reg {

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -51,25 +51,25 @@ typedef uint64_t ucp_proto_id_mask_t;
 
 
 /* Protocol stage ID */
-enum {
+typedef enum {
     /* Initial stage. All protocols start from this stage. */
     UCP_PROTO_STAGE_START = 0,
 
     /* Stage ID must be lower than this value */
     UCP_PROTO_STAGE_LAST  = 8
-};
+} ucp_proto_stage_id_t;
 
 
 /**
  * Protocol flags for internal usage, to allow searching for specific protocols
  */
-enum {
+typedef enum {
     UCP_PROTO_FLAG_AM_SHORT  = UCS_BIT(0), /* The protocol uses only uct_ep_am_short() */
     UCP_PROTO_FLAG_PUT_SHORT = UCS_BIT(1), /* The protocol uses only uct_ep_put_short() */
     UCP_PROTO_FLAG_TAG_SHORT = UCS_BIT(2), /* The protocol uses only
                                               uct_ep_tag_eager_short() */
     UCP_PROTO_FLAG_INVALID   = UCS_BIT(3)  /* The protocol is a placeholder */
-};
+} ucp_proto_flags_t;
 
 
 /**

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -20,7 +20,7 @@
 #define UCP_PROTO_RNDV_PUT_DESC "write to remote"
 
 
-enum {
+typedef enum {
     /* Initial stage for put zcopy is sending the data */
     UCP_PROTO_RNDV_PUT_ZCOPY_STAGE_SEND = UCP_PROTO_STAGE_START,
 
@@ -38,7 +38,7 @@ enum {
 
     /* Memtype only: send the fragment to the remote side */
     UCP_PROTO_RNDV_PUT_MTYPE_STAGE_SEND
-};
+} ucp_proto_rndv_put_stage_t;
 
 typedef struct ucp_proto_rndv_put_priv {
     uct_completion_callback_t  put_comp_cb;

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -11,10 +11,10 @@
 #include "proto_rndv.inl"
 
 
-enum {
+typedef enum {
     UCP_PROTO_RNDV_RKEY_PTR_STAGE_FETCH = UCP_PROTO_STAGE_START,
     UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS
-};
+} ucp_proto_rndv_ptr_stage_t;
 
 
 typedef struct {

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -199,12 +199,12 @@ typedef struct {
 #define UCP_ADDRESS_DEFAULT_WORKER_UUID     0
 #define UCP_ADDRESS_DEFAULT_CLIENT_ID       0
 
-enum {
+typedef enum {
     UCP_ADDRESS_HEADER_FLAG_DEBUG_INFO  = UCS_BIT(0),  /* Address has debug info */
     UCP_ADDRESS_HEADER_FLAG_WORKER_UUID = UCS_BIT(1),  /* Worker unique id */
     UCP_ADDRESS_HEADER_FLAG_CLIENT_ID   = UCS_BIT(2),  /* Worker client id */
     UCP_ADDRESS_HEADER_FLAG_AM_ONLY     = UCS_BIT(3)   /* Only AM lane info */
-};
+} ucp_address_header_flags_t;
 
 static size_t ucp_address_iface_attr_size(ucp_worker_t *worker, uint64_t flags,
                                           ucp_object_version_t addr_version)

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -17,8 +17,17 @@
 #define UCP_ADDRESS_IFACE_SEG_SIZE_FACTOR 64
 
 
-/* Which iface flags would be packed in the address */
-enum {
+typedef enum {
+    UCP_ADDR_IFACE_FLAG_CONNECT_TO_IFACE = UCS_BIT(0),
+    UCP_ADDR_IFACE_FLAG_AM_SYNC          = UCS_BIT(1),
+    UCP_ADDR_IFACE_FLAG_CB_ASYNC         = UCS_BIT(2),
+    UCP_ADDR_IFACE_FLAG_PUT              = UCS_BIT(3),
+    UCP_ADDR_IFACE_FLAG_GET              = UCS_BIT(4),
+    UCP_ADDR_IFACE_FLAG_TAG_EAGER        = UCS_BIT(5),
+    UCP_ADDR_IFACE_FLAG_TAG_RNDV         = UCS_BIT(6),
+    UCP_ADDR_IFACE_FLAG_EVENT_RECV       = UCS_BIT(7),
+    UCP_ADDR_IFACE_FLAG_ATOMIC32         = UCS_BIT(8),
+    UCP_ADDR_IFACE_FLAG_ATOMIC64         = UCS_BIT(9),
     UCP_ADDRESS_IFACE_FLAGS =
          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
          UCT_IFACE_FLAG_CB_SYNC |
@@ -33,30 +42,16 @@ enum {
          UCT_IFACE_FLAG_TAG_EAGER_BCOPY |
          UCT_IFACE_FLAG_TAG_RNDV_ZCOPY  |
          UCT_IFACE_FLAG_PENDING
-};
-
-
-enum {
-    UCP_ADDR_IFACE_FLAG_CONNECT_TO_IFACE = UCS_BIT(0),
-    UCP_ADDR_IFACE_FLAG_AM_SYNC          = UCS_BIT(1),
-    UCP_ADDR_IFACE_FLAG_CB_ASYNC         = UCS_BIT(2),
-    UCP_ADDR_IFACE_FLAG_PUT              = UCS_BIT(3),
-    UCP_ADDR_IFACE_FLAG_GET              = UCS_BIT(4),
-    UCP_ADDR_IFACE_FLAG_TAG_EAGER        = UCS_BIT(5),
-    UCP_ADDR_IFACE_FLAG_TAG_RNDV         = UCS_BIT(6),
-    UCP_ADDR_IFACE_FLAG_EVENT_RECV       = UCS_BIT(7),
-    UCP_ADDR_IFACE_FLAG_ATOMIC32         = UCS_BIT(8),
-    UCP_ADDR_IFACE_FLAG_ATOMIC64         = UCS_BIT(9)
-};
+} ucp_address_iface_flags_t;
 
 
 /* Which iface event flags would be packed in the address */
-enum {
+typedef enum {
     UCP_ADDRESS_IFACE_EVENT_FLAGS = UCT_IFACE_FLAG_EVENT_RECV
-};
+} ucp_address_iface_event_flags_t;
 
 
-enum {
+typedef enum {
     /* Add worker UUID */
     UCP_ADDRESS_PACK_FLAG_WORKER_UUID = UCS_BIT(0),
 
@@ -98,7 +93,7 @@ enum {
 
     /* Suppress debug tracing */
     UCP_ADDRESS_PACK_FLAG_NO_TRACE    = UCS_BIT(16)
-};
+} ucp_address_pack_flags_t;
 
 
 /**
@@ -201,7 +196,7 @@ struct ucp_unpacked_address {
  */
 ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
                               const ucp_tl_bitmap_t *tl_bitmap,
-                              unsigned pack_flags,
+                              ucp_address_pack_flags_t pack_flags,
                               ucp_object_version_t addr_version,
                               const ucp_lane_index_t *lanes2remote,
                               size_t *size_p, void **buffer_p);
@@ -224,7 +219,7 @@ ucs_status_t ucp_address_pack(ucp_worker_h worker, ucp_ep_h ep,
  *       by ucs_free().
  */
 ucs_status_t ucp_address_unpack(ucp_worker_h worker, const void *buffer,
-                                unsigned unpack_flags,
+                                ucp_address_pack_flags_t unpack_flags,
                                 ucp_unpacked_address_t *unpacked_address);
 
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -22,7 +22,7 @@
 /**
  * Wireup message types
  */
-enum {
+typedef enum {
     UCP_WIREUP_MSG_PRE_REQUEST,
     UCP_WIREUP_MSG_REQUEST,
     UCP_WIREUP_MSG_REPLY,
@@ -30,7 +30,7 @@ enum {
     UCP_WIREUP_MSG_EP_CHECK,
     UCP_WIREUP_MSG_EP_REMOVED,
     UCP_WIREUP_MSG_LAST
-};
+} ucp_wireup_msg_type_t;
 
 
 /**

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -443,18 +443,21 @@ typedef enum uct_atomic_op {
  * supported by UCT iface event.
  * @{
    */
+
+typedef enum {
         /* Event types */
-#define UCT_IFACE_FLAG_EVENT_SEND_COMP UCS_BIT(0) /**< Event notification of send completion is
+    UCT_IFACE_FLAG_EVENT_SEND_COMP = UCS_BIT(0), /**< Event notification of send completion is
                                                        supported */
-#define UCT_IFACE_FLAG_EVENT_RECV      UCS_BIT(1) /**< Event notification of tag and active message
+    UCT_IFACE_FLAG_EVENT_RECV      = UCS_BIT(1), /**< Event notification of tag and active message
                                                        receive is supported */
-#define UCT_IFACE_FLAG_EVENT_RECV_SIG  UCS_BIT(2) /**< Event notification of signaled tag and active
+    UCT_IFACE_FLAG_EVENT_RECV_SIG  = UCS_BIT(2), /**< Event notification of signaled tag and active
                                                        message is supported */
         /* Event notification mechanisms */
-#define UCT_IFACE_FLAG_EVENT_FD        UCS_BIT(3) /**< Event notification through File Descriptor
+    UCT_IFACE_FLAG_EVENT_FD        = UCS_BIT(3), /**< Event notification through File Descriptor
                                                        is supported */
-#define UCT_IFACE_FLAG_EVENT_ASYNC_CB  UCS_BIT(4) /**< Event notification through asynchronous
+    UCT_IFACE_FLAG_EVENT_ASYNC_CB  = UCS_BIT(4), /**< Event notification through asynchronous
                                                        callback invocation is supported */
+} uct_iface_event_flags_t;
 /**
  * @}
  */

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -63,11 +63,11 @@ enum uct_am_trace_type {
  * the data is the first fragment of the message. The latter value means that
  * more fragments of the message yet to be delivered.
  */
-enum uct_cb_param_flags {
+typedef enum {
     UCT_CB_PARAM_FLAG_DESC  = UCS_BIT(0),
     UCT_CB_PARAM_FLAG_FIRST = UCS_BIT(1),
     UCT_CB_PARAM_FLAG_MORE  = UCS_BIT(2)
-};
+} uct_cb_param_flags_t;
 
 /**
  * @addtogroup UCT_RESOURCE

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -51,7 +51,7 @@ enum {
     UCT_UD_PACKET_PUT_SHIFT       = 28,
 };
 
-enum {
+typedef enum {
     UCT_UD_PACKET_FLAG_AM      = UCS_BIT(24),
     UCT_UD_PACKET_FLAG_ACK_REQ = UCS_BIT(25),
     UCT_UD_PACKET_FLAG_ECN     = UCS_BIT(26),
@@ -61,7 +61,7 @@ enum {
 
     UCT_UD_PACKET_AM_ID_MASK     = UCS_MASK(UCT_UD_PACKET_AM_ID_SHIFT),
     UCT_UD_PACKET_DEST_ID_MASK   = UCS_MASK(UCT_UD_PACKET_DEST_ID_SHIFT),
-};
+} uct_ud_packet_flags_t;
 
 enum {
     UCT_UD_PACKET_CREQ = 1,

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -164,7 +164,7 @@ do { \
  * are executed in time of progress along with
  * pending requests added by uct user.
  */
-enum {
+typedef enum {
     UCT_UD_EP_OP_NONE       = 0,
     UCT_UD_EP_OP_ACK        = UCS_BIT(0),  /* ack data */
     UCT_UD_EP_OP_ACK_REQ    = UCS_BIT(1),  /* request ack of sent packets */
@@ -172,7 +172,7 @@ enum {
     UCT_UD_EP_OP_CREP       = UCS_BIT(3),  /* send connection reply */
     UCT_UD_EP_OP_CREQ       = UCS_BIT(4),  /* send connection request */
     UCT_UD_EP_OP_NACK       = UCS_BIT(5),  /* send NACK */
-};
+} uct_ud_ep_ctl_ops_t;
 
 #define UCT_UD_EP_OP_CTL_LOW_PRIO (UCT_UD_EP_OP_ACK_REQ|UCT_UD_EP_OP_ACK)
 #define UCT_UD_EP_OP_CTL_HI_PRIO  (UCT_UD_EP_OP_CREQ|UCT_UD_EP_OP_CREP|UCT_UD_EP_OP_RESEND)

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -40,11 +40,11 @@ enum {
 
 
 /* flags for uct_ud_iface_send_ctl() */
-enum {
+typedef enum {
     UCT_UD_IFACE_SEND_CTL_FLAG_INLINE    = UCS_BIT(0),
     UCT_UD_IFACE_SEND_CTL_FLAG_SOLICITED = UCS_BIT(1),
     UCT_UD_IFACE_SEND_CTL_FLAG_SIGNALED  = UCS_BIT(2)
-};
+} uct_ud_iface_send_ctl_flags_t;
 
 
 /* TODO: maybe tx_moderation can be defined at compile-time since tx completions are used only to know how much space is there in tx qp */

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -82,7 +82,7 @@ typedef union uct_tcp_ep_cm_id {
 /**
  * TCP EP flags
  */
-enum {
+typedef enum {
     /* EP is connected to a peer to send data. This EP is managed
      * by a user and TCP mustn't free this EP even if connection
      * is broken. */
@@ -112,7 +112,7 @@ enum {
     UCT_TCP_EP_FLAG_ON_PTR_MAP         = UCS_BIT(9),
     /* EP has some operations done without flush */
     UCT_TCP_EP_FLAG_NEED_FLUSH         = UCS_BIT(10)
-};
+} uct_tcp_ep_flags_t;
 
 
 /**

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -1274,7 +1274,7 @@ void UcxConnection::handle_connection_error(ucs_status_t status)
     }
 }
 
-void UcxConnection::ep_close(enum ucp_ep_close_mode mode)
+void UcxConnection::ep_close(ucp_ep_close_mode_t mode)
 {
     static const char *mode_str[] = {"force", "flush"};
     if (_ep == NULL) {

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -389,7 +389,7 @@ private:
 
     void request_completed(ucx_request *r);
 
-    void ep_close(enum ucp_ep_close_mode mode);
+    void ep_close(ucp_ep_close_mode_t mode);
 
     bool process_request(const char *what, ucs_status_ptr_t ptr_status,
                          UcxCallback* callback);

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -732,7 +732,7 @@ public:
         EXPECT_EQ(m_test_addr, attr.local_sockaddr);
     }
 
-    void one_sided_disconnect(entity &e, enum ucp_ep_close_mode mode) {
+    void one_sided_disconnect(entity &e, ucp_ep_close_mode_t mode) {
         void *req           = e.disconnect_nb(0, 0, mode);
         ucs_time_t deadline = ucs::get_deadline();
         scoped_log_handler slh(detect_error_logger);
@@ -745,7 +745,7 @@ public:
         e.close_ep_req_free(req);
     }
 
-    void concurrent_disconnect(enum ucp_ep_close_mode mode) {
+    void concurrent_disconnect(ucp_ep_close_mode_t mode) {
         ASSERT_EQ(2ul, entities().size());
         ASSERT_EQ(1, sender().get_num_workers());
         ASSERT_EQ(1, sender().get_num_eps());

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -214,7 +214,7 @@ void ucp_test::disconnect(entity& e) {
     }
 
     for (int i = 0; i < e.get_num_workers(); i++) {
-        enum ucp_ep_close_mode close_mode;
+        ucp_ep_close_mode_t close_mode;
 
         if (has_failed_entity) {
             close_mode = UCP_EP_CLOSE_MODE_FORCE;
@@ -870,7 +870,7 @@ void ucp_test_base::entity::fence(int worker_index) const {
 }
 
 void *ucp_test_base::entity::disconnect_nb(int worker_index, int ep_index,
-                                           enum ucp_ep_close_mode mode) {
+                                           ucp_ep_close_mode_t mode) {
     ucp_ep_h ep = revoke_ep(worker_index, ep_index);
     if (ep == NULL) {
         return NULL;
@@ -906,7 +906,7 @@ void ucp_test_base::entity::close_ep_req_free(void *close_req) {
 }
 
 void ucp_test_base::entity::close_all_eps(const ucp_test &test, int worker_idx,
-                                          enum ucp_ep_close_mode mode) {
+                                          ucp_ep_close_mode_t mode) {
     for (int j = 0; j < get_num_eps(worker_idx); j++) {
         disconnect_nb(worker_idx, j, mode);
     }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -100,12 +100,12 @@ public:
         void fence(int worker_index = 0) const;
 
         void* disconnect_nb(int worker_index = 0, int ep_index = 0,
-                            enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
+                            ucp_ep_close_mode_t mode = UCP_EP_CLOSE_MODE_FLUSH);
 
         void close_ep_req_free(void *close_req);
 
         void close_all_eps(const ucp_test &test, int worker_idx,
-                           enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
+                           ucp_ep_close_mode_t mode = UCP_EP_CLOSE_MODE_FLUSH);
 
         void destroy_worker(int worker_index = 0);
 

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -914,8 +914,8 @@ size_t test_uct_event_ib::bcopy_pack_count = 0;
 UCS_TEST_SKIP_COND_P(test_uct_event_ib, tx_cq,
                      !check_caps(UCT_IFACE_FLAG_PUT_BCOPY |
                                  UCT_IFACE_FLAG_CB_SYNC) ||
-                     !check_event_caps(UCT_IFACE_FLAG_EVENT_SEND_COMP |
-                                       UCT_IFACE_FLAG_EVENT_RECV))
+                     !check_event_caps((uct_iface_event_flags_t)(UCT_IFACE_FLAG_EVENT_SEND_COMP |
+                                       UCT_IFACE_FLAG_EVENT_RECV)))
 {
     ucs_status_t status;
 
@@ -950,8 +950,8 @@ UCS_TEST_SKIP_COND_P(test_uct_event_ib, txrx_cq,
                      !check_caps(UCT_IFACE_FLAG_PUT_BCOPY |
                                  UCT_IFACE_FLAG_CB_SYNC   |
                                  UCT_IFACE_FLAG_AM_SHORT) ||
-                     !check_event_caps(UCT_IFACE_FLAG_EVENT_SEND_COMP |
-                                       UCT_IFACE_FLAG_EVENT_RECV))
+                     !check_event_caps((uct_iface_event_flags_t)(UCT_IFACE_FLAG_EVENT_SEND_COMP |
+                                       UCT_IFACE_FLAG_EVENT_RECV)))
 {
     const size_t msg_count = 1;
     ucs_status_t status;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -498,7 +498,7 @@ void uct_test::check_caps_skip(uint64_t required_flags, uint64_t invalid_flags) 
     }
 }
 
-bool uct_test::check_event_caps(uint64_t required_flags, uint64_t invalid_flags) {
+bool uct_test::check_event_caps(uct_iface_event_flags_t required_flags, uct_iface_event_flags_t invalid_flags) {
     FOR_EACH_ENTITY(iter) {
         if (!(*iter)->check_event_caps(required_flags, invalid_flags)) {
             return false;
@@ -1039,10 +1039,10 @@ bool uct_test::entity::check_caps(uint64_t required_flags,
             !(iface_flags & invalid_flags));
 }
 
-bool uct_test::entity::check_event_caps(uint64_t required_flags,
-                                        uint64_t invalid_flags)
+bool uct_test::entity::check_event_caps(uct_iface_event_flags_t required_flags,
+                                        uct_iface_event_flags_t invalid_flags)
 {
-    uint64_t iface_event_flags = iface_attr().cap.event_flags;
+    uct_iface_event_flags_t iface_event_flags = (uct_iface_event_flags_t)iface_attr().cap.event_flags;
     return (ucs_test_all_flags(iface_event_flags, required_flags) &&
             !(iface_event_flags & invalid_flags) &&
             /* iface has to support either event fd or event async

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -153,7 +153,7 @@ protected:
 
         bool is_caps_supported(uint64_t required_flags);
         bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
-        bool check_event_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
+        bool check_event_caps(uct_iface_event_flags_t required_flags, uct_iface_event_flags_t invalid_flags = (uct_iface_event_flags_t)0);
         bool check_atomics(uint64_t required_ops, atomic_mode mode);
 
         uct_md_h md() const;
@@ -368,7 +368,7 @@ protected:
     bool is_caps_supported(uint64_t required_flags);
     bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
     void check_caps_skip(uint64_t required_flags, uint64_t invalid_flags = 0);
-    bool check_event_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
+    bool check_event_caps(uct_iface_event_flags_t required_flags, uct_iface_event_flags_t invalid_flags = (uct_iface_event_flags_t)0);
     bool check_atomics(uint64_t required_ops, atomic_mode mode);
     const entity& ent(unsigned index) const;
     unsigned progress() const;


### PR DESCRIPTION
## What
Enforce types on enums, to the extent possible by the C standard and the compilers we use.

## Why ?
Prevent human errors caused by incorrect usage of enum values, therefore make our code more robust and idiot-proof.

## How ?
1.	Anonymous / named enums are now types (using `typedef`).
2.	Use typed enums wherever possible (vars, func params). Can’t use them in struct members, would be bad practice.
3.	Add compiler flags to enforce correct usage.
4.	Fix docs accordingly.

**The PR is not to be merged. Its purpose is to be a “demo” on a small part of the code of how the real change will look like – so that we can see whether it is appropriate, before proceeding to do more.**

