### PR TITLE
UCP/WIRUEP: Remove dead proxy_ep-related code

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1464,10 +1464,6 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
         ucs_debug("ep %p: pending & destroy uct_ep[%d]=%p", ep, lane, uct_ep);
         uct_ep_pending_purge(uct_ep, ucp_destroyed_ep_pending_purge, ep);
         ucp_ep_unprogress_uct_ep(ep, uct_ep, ucp_ep_get_rsc_index(ep, lane));
-
-        /* coverity wrongly resolves ucp_failed_tl_ep's no-op EP destroy
-         * function to 'ucp_proxy_ep_destroy' */
-        /* coverity[incorrect_free] */
         uct_ep_destroy(uct_ep);
     }
 }

--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -103,11 +103,10 @@ UCP_PROXY_EP_DEFINE_OP(void, pending_purge, uct_pending_purge_callback_t, void*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, flush, unsigned, uct_completion_t*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, fence, unsigned)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, check, unsigned, uct_completion_t*)
+UCP_PROXY_EP_DEFINE_OP(void, destroy)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, get_address, uct_ep_addr_t*)
 UCP_PROXY_EP_DEFINE_OP(ucs_status_t, connect_to_ep, const uct_device_addr_t*,
                        const uct_ep_addr_t*)
-static UCS_CLASS_DEFINE_NAMED_DELETE_FUNC(ucp_proxy_ep_destroy, ucp_proxy_ep_t,
-                                          uct_ep_t);
 
 static ucs_status_t ucp_proxy_ep_fatal(uct_iface_h iface, ...)
 {
@@ -183,11 +182,6 @@ static UCS_CLASS_CLEANUP_FUNC(ucp_proxy_ep_t)
     }
 }
 
-int ucp_proxy_ep_test(uct_ep_h uct_ep)
-{
-    return uct_ep->iface->ops.ep_destroy == ucp_proxy_ep_destroy;
-}
-
 uct_ep_h ucp_proxy_ep_extract(uct_ep_h ep)
 {
     ucp_proxy_ep_t *proxy_ep = ucs_derived_of(ep, ucp_proxy_ep_t);
@@ -198,42 +192,18 @@ uct_ep_h ucp_proxy_ep_extract(uct_ep_h ep)
     return uct_ep;
 }
 
-static void ucp_proxy_ep_replace_if_owned(uct_ep_h uct_ep, uct_ep_h owned_ep,
-                                          uct_ep_h replacement_ep)
-{
-    ucp_proxy_ep_t *proxy_ep;
-
-    if (ucp_proxy_ep_test(uct_ep)) {
-        proxy_ep = ucs_derived_of(uct_ep, ucp_proxy_ep_t);
-        if (proxy_ep->uct_ep == owned_ep) {
-            proxy_ep->uct_ep = replacement_ep;
-        }
-        ucs_assert(replacement_ep != NULL);
-    }
-}
-
 void ucp_proxy_ep_replace(ucp_proxy_ep_t *proxy_ep)
 {
     ucp_ep_h ucp_ep = proxy_ep->ucp_ep;
     ucp_lane_index_t lane;
-    uct_ep_h tl_ep = NULL;
 
     ucs_assert(proxy_ep->uct_ep != NULL);
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
         if (ucp_ep->uct_eps[lane] == &proxy_ep->super) {
             ucs_assert(proxy_ep->uct_ep != NULL);    /* make sure there is only one match */
             ucp_ep->uct_eps[lane] = proxy_ep->uct_ep;
-            tl_ep = ucp_ep->uct_eps[lane];
-            proxy_ep->uct_ep = NULL;
+            proxy_ep->uct_ep      = NULL;
         }
-    }
-
-    /* go through the lanes and check if the proxy ep that is being destroyed,
-     * is pointed to by another proxy ep. if so, redirect that other proxy ep
-     * to point to the underlying uct ep. */
-    for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
-        ucp_proxy_ep_replace_if_owned(ucp_ep->uct_eps[lane], &proxy_ep->super,
-                                      tl_ep);
     }
 
     uct_ep_destroy(&proxy_ep->super);

--- a/src/ucp/core/ucp_proxy_ep.h
+++ b/src/ucp/core/ucp_proxy_ep.h
@@ -43,8 +43,6 @@ UCS_CLASS_DECLARE(ucp_proxy_ep_t, const uct_iface_ops_t *ops, ucp_ep_h ucp_ep,
  */
 void ucp_proxy_ep_replace(ucp_proxy_ep_t *proxy_ep);
 
-int ucp_proxy_ep_test(uct_ep_h ep);
-
 uct_ep_h ucp_proxy_ep_extract(uct_ep_h ep);
 
 void ucp_proxy_ep_set_uct_ep(ucp_proxy_ep_t *proxy_ep, uct_ep_h uct_ep,

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1485,15 +1485,8 @@ ucs_status_t ucp_wireup_connect_remote(ucp_ep_h ep, ucp_lane_index_t lane)
         goto out_unlock;
     }
 
-    if (ucp_proxy_ep_test(ep->uct_eps[lane])) {
-        /* signaling ep is not needed now since we will send wireup request
-         * with signaling flag
-         */
-        uct_ep = ucp_proxy_ep_extract(ep->uct_eps[lane]);
-        uct_ep_destroy(ep->uct_eps[lane]);
-    } else {
-        uct_ep = ep->uct_eps[lane];
-    }
+    
+    uct_ep = ep->uct_eps[lane];
 
     ucs_assert(!(ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED));
 


### PR DESCRIPTION
## What

Remove dead proxy_ep-related code.

## Why ?

Removed some code which is not needed anymore, since signaled-proxy EP was removed.

## How ?

Remove `ucp_proxy_ep_destroy`, `ucp_proxy_ep_replace_if_owned`, `ucp_proxy_ep_test`.