### PR TITLE
UCT/RDMACM: Remove locking from event loop

### DIFF
--- a/src/ucs/async/async.h
+++ b/src/ucs/async/async.h
@@ -142,7 +142,7 @@ static inline int ucs_async_is_blocked(const ucs_async_context_t *async)
 
 
 /**
- * Try to block the async handler. If its currently locked by other thread
+ * Try to block the async handler. If it is currently locked by other thread
  * avoid CPU consuming wait and execute _quit.
  *
  * @param _async Event context to block events for.

--- a/src/ucs/datastruct/bitmap.h
+++ b/src/ucs/datastruct/bitmap.h
@@ -563,6 +563,7 @@ ucs_bitmap_ffs(const ucs_bitmap_word_t *bitmap_words, size_t num_words,
 }
 
 
+_UCS_BITMAP_DECLARE_TYPE(2)
 _UCS_BITMAP_DECLARE_TYPE(64)
 _UCS_BITMAP_DECLARE_TYPE(128)
 _UCS_BITMAP_DECLARE_TYPE(256)

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -805,9 +805,7 @@ static void uct_rdmacm_cm_event_handler(int fd, ucs_event_set_types_t events,
             return;
         }
 
-        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
         uct_rdmacm_cm_process_event(cm, event);
-        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_get_async(cm));
     }
 }
 
@@ -941,7 +939,7 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
     status = ucs_async_set_event_handler(worker_priv->async->mode,
                                          self->ev_ch->fd, UCS_EVENT_SET_EVREAD,
                                          uct_rdmacm_cm_event_handler, self,
-                                         worker_priv->async);
+                                         NULL);
     if (status != UCS_OK) {
         goto err_destroy_ev_ch;
     }

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -813,7 +813,7 @@ static void uct_rdmacm_cm_event_handler(int fd, ucs_event_set_types_t events,
     int                  ret;
 
     do {
-        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
+        UCS_ASYNC_TRY_BLOCK(uct_rdmacm_cm_get_async(cm), return);
 
         /* Fetch an event */
         ret = rdma_get_cm_event(cm->ev_ch, &event);

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -736,7 +736,9 @@ uct_rdmacm_cm_process_event(uct_rdmacm_cm_t *cm, struct rdma_cm_event *event)
         break;
     case RDMA_CM_EVENT_ROUTE_RESOLVED:
         /* Client side event */
+        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
         uct_rdmacm_cm_handle_event_route_resolved(event);
+        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_get_async(cm));
         break;
     case RDMA_CM_EVENT_CONNECT_REQUEST:
         /* Server side event */
@@ -773,7 +775,9 @@ uct_rdmacm_cm_process_event(uct_rdmacm_cm_t *cm, struct rdma_cm_event *event)
         /* client and server error events */
     case RDMA_CM_EVENT_REJECTED:
     case RDMA_CM_EVENT_CONNECT_ERROR:
+        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
         uct_rdmacm_cm_handle_error_event(event);
+        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_get_async(cm));
         break;
     default:
         ucs_warn("unexpected RDMACM event: %s", rdma_event_str(event->event));

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -83,10 +83,32 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
     uint64_t general_obj_types_caps;
     ucs_status_t status;
     void *cap;
-    int ret;
 #endif
+    struct ibv_port_attr port_attr;
+    struct ibv_device_attr dev_attr;
+    int ret;
+    int i;
 
     ctx->num_dummy_qps = 0;
+
+    ret = ibv_query_device(verbs, &dev_attr);
+    if (ret != 0) {
+        ucs_error("ibv_query_device(%s) failed: %m", dev_name);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ctx->is_eth = 0;
+    for (i = 0; i < dev_attr.phys_port_count; ++i) {
+        ret = ibv_query_port(verbs, i + 1, &port_attr);
+        if (ret != 0) {
+            ucs_error("ibv_query_port (%s) failed: %m", dev_name);
+            return UCS_ERR_IO_ERROR;
+        }
+
+        if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
+            ctx->is_eth |= UCS_BIT(i);
+        }
+    }
 
 #if HAVE_DECL_MLX5DV_IS_SUPPORTED
     if (cm->config.reserved_qpn == UCS_NO) {
@@ -402,15 +424,15 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(uct_rdmacm_cm_t *cm,
                                                  uct_device_addr_t **dev_addr_p,
                                                  size_t *dev_addr_len_p)
 {
+    uct_rdmacm_cm_device_context_t *ctx;
     uct_ib_address_pack_params_t params;
-    struct ibv_port_attr port_attr;
     uct_ib_address_t *dev_addr;
     struct ibv_qp_attr qp_attr;
     size_t addr_length;
     int qp_attr_mask;
-    char dev_name[UCT_DEVICE_NAME_MAX];
     char ah_attr_str[128];
     uct_ib_roce_version_info_t roce_info;
+    ucs_status_t status;
     int ret;
 
     params.flags = 0;
@@ -428,11 +450,9 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(uct_rdmacm_cm_t *cm,
         return UCS_ERR_CONNECTION_RESET;
     }
 
-    ret = ibv_query_port(cm_id->pd->context, cm_id->port_num, &port_attr);
-    if (ret) {
-        uct_rdmacm_cm_id_to_dev_name(cm_id, dev_name);
-        ucs_error("ibv_query_port (%s) failed: %m", dev_name);
-        return UCS_ERR_IO_ERROR;
+    status = uct_rdmacm_cm_get_device_context(cm, cm_id->pd->context, &ctx);
+    if (status != UCS_OK) {
+        return status;
     }
 
     if (qp_attr.ah_attr.is_global) {
@@ -448,7 +468,7 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(uct_rdmacm_cm_t *cm,
     params.flags   |= UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU;
     params.path_mtu = qp_attr.path_mtu;
 
-    if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
+    if (ctx->is_eth & UCS_BIT(cm_id->port_num - 1)) {
         /* Ethernet address */
         ucs_assert(qp_attr.ah_attr.is_global);
 
@@ -736,9 +756,7 @@ uct_rdmacm_cm_process_event(uct_rdmacm_cm_t *cm, struct rdma_cm_event *event)
         break;
     case RDMA_CM_EVENT_ROUTE_RESOLVED:
         /* Client side event */
-        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
         uct_rdmacm_cm_handle_event_route_resolved(event);
-        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_get_async(cm));
         break;
     case RDMA_CM_EVENT_CONNECT_REQUEST:
         /* Server side event */
@@ -775,9 +793,7 @@ uct_rdmacm_cm_process_event(uct_rdmacm_cm_t *cm, struct rdma_cm_event *event)
         /* client and server error events */
     case RDMA_CM_EVENT_REJECTED:
     case RDMA_CM_EVENT_CONNECT_ERROR:
-        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
         uct_rdmacm_cm_handle_error_event(event);
-        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_get_async(cm));
         break;
     default:
         ucs_warn("unexpected RDMACM event: %s", rdma_event_str(event->event));
@@ -809,7 +825,9 @@ static void uct_rdmacm_cm_event_handler(int fd, ucs_event_set_types_t events,
             return;
         }
 
+        UCS_ASYNC_BLOCK(uct_rdmacm_cm_get_async(cm));
         uct_rdmacm_cm_process_event(cm, event);
+        UCS_ASYNC_UNBLOCK(uct_rdmacm_cm_get_async(cm));
     }
 }
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -98,7 +98,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
     }
 
     ctx->is_eth = 0;
-    for (i = 0; i < dev_attr.phys_port_count; ++i) {
+    for (i = 0; i < dev_attr.phys_port_cnt; ++i) {
         ret = ibv_query_port(verbs, i + 1, &port_attr);
         if (ret != 0) {
             ucs_error("ibv_query_port (%s) failed: %m", dev_name);

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -97,7 +97,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
         return UCS_ERR_IO_ERROR;
     }
 
-    ctx->is_eth = 0;
+    UCS_BITMAP_CLEAR(&ctx->is_eth);
     for (i = 0; i < dev_attr.phys_port_cnt; ++i) {
         ret = ibv_query_port(verbs, i + 1, &port_attr);
         if (ret != 0) {
@@ -106,7 +106,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
         }
 
         if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
-            ctx->is_eth |= UCS_BIT(i);
+            UCS_BITMAP_SET(ctx->is_eth, 1);
         }
     }
 
@@ -468,7 +468,7 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(uct_rdmacm_cm_t *cm,
     params.flags   |= UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU;
     params.path_mtu = qp_attr.path_mtu;
 
-    if (ctx->is_eth & UCS_BIT(cm_id->port_num - 1)) {
+    if (UCS_BITMAP_GET(ctx->is_eth, 1)) {
         /* Ethernet address */
         ucs_assert(qp_attr.ah_attr.is_global);
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -106,7 +106,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
         }
 
         if (IBV_PORT_IS_LINK_LAYER_ETHERNET(&port_attr)) {
-            UCS_BITMAP_SET(ctx->is_eth, 1);
+            UCS_BITMAP_SET(ctx->is_eth, i);
         }
     }
 
@@ -468,7 +468,7 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(uct_rdmacm_cm_t *cm,
     params.flags   |= UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU;
     params.path_mtu = qp_attr.path_mtu;
 
-    if (UCS_BITMAP_GET(ctx->is_eth, 1)) {
+    if (UCS_BITMAP_GET(ctx->is_eth, cm_id->port_num - 1)) {
         /* Ethernet address */
         ucs_assert(qp_attr.ah_attr.is_global);
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -15,6 +15,7 @@
 #if HAVE_MLX5_DV
 #include <uct/ib/mlx5/ib_mlx5.h>
 #endif
+#include <uct/ib/base/ib_device.h>
 
 #include <rdma/rdma_cma.h>
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -77,6 +77,7 @@ typedef struct uct_rdmacm_cm_device_context {
     uint32_t        log_reserved_qpn_granularity;
     uint32_t        num_dummy_qps;
     struct ibv_cq   *cq;
+    uint8_t         is_eth;
 } uct_rdmacm_cm_device_context_t;
 
 

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -71,13 +71,13 @@ typedef struct uct_rdmacm_cm_reserved_qpn_blk {
 
 
 typedef struct uct_rdmacm_cm_device_context {
-    int             use_reserved_qpn;
-    ucs_spinlock_t  lock;                         /** Avoid competed condition on the qpn resource for multi-threads */
-    ucs_list_link_t blk_list;
-    uint32_t        log_reserved_qpn_granularity;
-    uint32_t        num_dummy_qps;
-    struct ibv_cq   *cq;
-    uint8_t         is_eth;
+    int                                use_reserved_qpn;
+    ucs_spinlock_t                     lock;                         /** Avoid competed condition on the qpn resource for multi-threads */
+    ucs_list_link_t                    blk_list;
+    uint32_t                           log_reserved_qpn_granularity;
+    uint32_t                           num_dummy_qps;
+    struct ibv_cq                      *cq;
+    ucs_bitmap_t(UCT_IB_DEV_MAX_PORTS) is_eth;
 } uct_rdmacm_cm_device_context_t;
 
 


### PR DESCRIPTION
## What ?
Remove long lock over all pending RDMA_CM events.

## Why ?
We don't want to block main thread for long time.

## How ?
Release async lock after each event processed.
Also cache ibv_query_port() requests.
Keep event reading and processing under same lock to avoid collision with RDMA_CM id destruction. 
