### PR TITLE
UCP/CORE/GTEST: Disable resolving remote EP ID when creating local EP by default [v1.13.x]

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -407,6 +407,13 @@ static ucs_config_field_t ucp_config_table[] = {
    "(inf - check all endpoints on every round, must be greater than 0)",
    ucs_offsetof(ucp_config_t, ctx.keepalive_num_eps), UCS_CONFIG_TYPE_UINT},
 
+  {"RESOLVE_REMOTE_EP_ID", "n",
+   "Defines whether resolving remote endpoint ID is required or not when\n"
+   "creating a local endpoint. 'auto' means resolving remote endpint ID only\n"
+   "in case of error handling and keepalive enabled.",
+   ucs_offsetof(ucp_config_t, ctx.resolve_remote_ep_id),
+   UCS_CONFIG_TYPE_ON_OFF_AUTO},
+
   {"PROTO_INDIRECT_ID", "auto",
    "Enable indirect IDs to object pointers (endpoint, request) in wire protocols.\n"
    "A value of 'auto' means to enable only if error handling is enabled on the\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -119,6 +119,9 @@ typedef struct ucp_context_config {
     /** Maximal number of endpoints to check on every keepalive round
      * (0 - disabled, inf - check all endpoints on every round) */
     unsigned                               keepalive_num_eps;
+    /** Defines whether resolving remote endpoint ID is required or not when
+     *  creating a local endpoint */
+    ucs_on_off_auto_value_t                resolve_remote_ep_id;
     /** Enable indirect IDs to object pointers in wire protocols */
     ucs_on_off_auto_value_t                proto_indirect_id;
     /** Bitmap of memory types whose allocations are registered fully */

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -801,6 +801,11 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx)
 
 class test_ucp_am_nbx_closed_ep : public test_ucp_am_nbx {
 public:
+    test_ucp_am_nbx_closed_ep()
+    {
+        modify_config("RESOLVE_REMOTE_EP_ID", "auto");
+    }
+
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant_values(variants, test_ucp_am_base::get_test_variants, 0);


### PR DESCRIPTION
## What

Disable resolving remote EP ID when creating local EP by default.

## Why ?

Backport of #8142.

## How ?

See #8142's description.