### PR TITLE
UCT/IB: remove unmeaningful var declaration

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -232,7 +232,6 @@ static uct_tl_t *uct_ib_tls[] = {
 
 extern uct_ib_md_ops_entry_t UCT_IB_MD_OPS_NAME(devx);
 extern uct_ib_md_ops_entry_t UCT_IB_MD_OPS_NAME(dv);
-extern uct_ib_md_ops_entry_t UCT_IB_MD_OPS_NAME(exp);
 static uct_ib_md_ops_entry_t UCT_IB_MD_OPS_NAME(verbs);
 
 static uct_ib_md_ops_entry_t *uct_ib_ops[] = {


### PR DESCRIPTION
Align with b6722f27:
    UCT/IB: Disable mlx5 over exp verbs

Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
var is not defined and there's no need to declare it.

## Why ?
exp verbs has been removed.
