### PR TITLE
UCT/IB/UD: Drop packets if EP is p2p and disconnected

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -669,17 +669,6 @@ uct_ud_mlx5_iface_peer_address_str(const uct_ud_iface_t *iface,
 }
 
 static ucs_status_t
-uct_ud_mlx5_ep_create(const uct_ep_params_t* params, uct_ep_h *ep_p)
-{
-    if (ucs_test_all_flags(params->field_mask, UCT_EP_PARAM_FIELD_DEV_ADDR |
-                                               UCT_EP_PARAM_FIELD_IFACE_ADDR)) {
-        return uct_ud_ep_create_connected_common(params, ep_p);
-    }
-
-    return uct_ud_mlx5_ep_t_new(params, ep_p);
-}
-
-static ucs_status_t
 uct_ud_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                       const uct_ib_iface_config_t *ib_config,
                       const uct_ib_iface_init_attr_t *init_attr,
@@ -787,6 +776,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     },
     .async_progress          = uct_ud_mlx5_iface_async_progress,
     .send_ctl                = uct_ud_mlx5_ep_send_ctl,
+    .ep_new                  = uct_ud_mlx5_ep_t_new,
     .ep_free                 = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_ep_t),
     .create_qp               = uct_ud_mlx5_iface_create_qp,
     .destroy_qp              = uct_ud_mlx5_iface_destroy_qp,
@@ -807,7 +797,7 @@ static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
     .ep_flush                 = uct_ud_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
     .ep_check                 = uct_ud_ep_check,
-    .ep_create                = uct_ud_mlx5_ep_create,
+    .ep_create                = uct_ud_ep_create,
     .ep_destroy               = uct_ud_ep_disconnect,
     .ep_get_address           = uct_ud_ep_get_address,
     .ep_connect_to_ep         = uct_ud_ep_connect_to_ep,

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -196,20 +196,21 @@ enum {
     UCT_UD_EP_FLAG_CONNECTED         = UCS_BIT(3),  /* EP was connected to the peer */
     UCT_UD_EP_FLAG_ON_CEP            = UCS_BIT(4),  /* EP was inserted to connection
                                                        matching context */
+    UCT_UD_EP_FLAG_CONNECT_TO_EP     = UCS_BIT(5),  /* EP was connected to peer's EP */
 
     /* debug flags */
-    UCT_UD_EP_FLAG_CREQ_RCVD         = UCS_BIT(5),  /* CREQ message was received */
-    UCT_UD_EP_FLAG_CREP_RCVD         = UCS_BIT(6),  /* CREP message was received */
-    UCT_UD_EP_FLAG_CREQ_SENT         = UCS_BIT(7),  /* CREQ message was sent */
-    UCT_UD_EP_FLAG_CREP_SENT         = UCS_BIT(8),  /* CREP message was sent */
-    UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(9),  /* CREQ message is NOT sent, because
+    UCT_UD_EP_FLAG_CREQ_RCVD         = UCS_BIT(6),  /* CREQ message was received */
+    UCT_UD_EP_FLAG_CREP_RCVD         = UCS_BIT(7),  /* CREP message was received */
+    UCT_UD_EP_FLAG_CREQ_SENT         = UCS_BIT(8),  /* CREQ message was sent */
+    UCT_UD_EP_FLAG_CREP_SENT         = UCS_BIT(9),  /* CREP message was sent */
+    UCT_UD_EP_FLAG_CREQ_NOTSENT      = UCS_BIT(10),  /* CREQ message is NOT sent, because
                                                        connection establishment process
                                                        is driven by remote side. */
-    UCT_UD_EP_FLAG_TX_NACKED         = UCS_BIT(10), /* Last psn was acked with NACK */
+    UCT_UD_EP_FLAG_TX_NACKED         = UCS_BIT(11), /* Last psn was acked with NACK */
 
     /* Endpoint is currently executing the pending queue */
 #if UCS_ENABLE_ASSERT
-    UCT_UD_EP_FLAG_IN_PENDING        = UCS_BIT(11)
+    UCT_UD_EP_FLAG_IN_PENDING        = UCS_BIT(12)
 #else
     UCT_UD_EP_FLAG_IN_PENDING        = 0
 #endif
@@ -306,6 +307,8 @@ ucs_status_t uct_ud_ep_flush_nolock(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
 ucs_status_t uct_ud_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 
 ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
+
+ucs_status_t uct_ud_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p);
 
 ucs_status_t uct_ud_ep_create_connected_common(const uct_ep_params_t *params,
                                                uct_ep_h *new_ep_p);

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -106,6 +106,8 @@ typedef struct uct_ud_iface_ops {
     uint16_t                  (*send_ctl)(uct_ud_ep_t *ud_ep, uct_ud_send_skb_t *skb,
                                           const uct_ud_iov_t *iov, uint16_t iovcnt,
                                           int flags, int max_log_sge);
+    ucs_status_t              (*ep_new)(const uct_ep_params_t* params,
+                                        uct_ep_h *ep_p);
     void                      (*ep_free)(uct_ep_h ep);
     ucs_status_t              (*create_qp)(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr,
                                            struct ibv_qp **qp_p);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -543,17 +543,6 @@ uct_ud_verbs_iface_peer_address_str(const uct_ud_iface_t *iface,
     return str;
 }
 
-static ucs_status_t
-uct_ud_verbs_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p)
-{
-    if (ucs_test_all_flags(params->field_mask, UCT_EP_PARAM_FIELD_DEV_ADDR |
-                                               UCT_EP_PARAM_FIELD_IFACE_ADDR)) {
-        return uct_ud_ep_create_connected_common(params, ep_p);
-    }
-
-    return uct_ud_verbs_ep_t_new(params, ep_p);
-}
-
 static void uct_ud_verbs_iface_destroy_qp(uct_ud_iface_t *ud_iface)
 {
     uct_ib_destroy_qp(ud_iface->qp);
@@ -576,6 +565,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     },
     .async_progress          = uct_ud_verbs_iface_async_progress,
     .send_ctl                = uct_ud_verbs_ep_send_ctl,
+    .ep_new                  = uct_ud_verbs_ep_t_new,
     .ep_free                 = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_ep_t),
     .create_qp               = uct_ib_iface_create_qp,
     .destroy_qp              = uct_ud_verbs_iface_destroy_qp,
@@ -596,7 +586,7 @@ static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {
     .ep_flush                 = uct_ud_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
     .ep_check                 = uct_ud_ep_check,
-    .ep_create                = uct_ud_verbs_ep_create,
+    .ep_create                = uct_ud_ep_create,
     .ep_destroy               = uct_ud_ep_disconnect,
     .ep_get_address           = uct_ud_ep_get_address,
     .ep_connect_to_ep         = uct_ud_ep_connect_to_ep,


### PR DESCRIPTION
## What

Drop packets if EP is p2p and disconnected.

## Why ?

Drop packets on EP which p2p and disconnected to not answer with ACK packets to a peer.
So, a peer will detect an error due to not receiving ACKs.

## How ?

1. Add UD verbs/mlx5 `ep_create` operation to use it for creating EPs and pass initial `flags` for EP (e.g. CONNECT_TO_EP).
2. Updated `uct_ud_ep_process_rx` to drop packets if `UCT_UD_EP_FLAG_DISCONNECTED` and `UCT_UD_EP_FLAG_CONNECT_TO_EP` flags are set on EP.