### PR TITLE
UCP/CORE: UCP EP config key copy improvement.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2300,17 +2300,27 @@ ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
 static ucs_status_t ucp_ep_config_key_copy(ucp_ep_config_key_t *dst,
                                            const ucp_ep_config_key_t *src)
 {
-    *dst = *src;
-    dst->dst_md_cmpts = ucs_calloc(ucs_popcount(src->reachable_md_map),
-                                   sizeof(*dst->dst_md_cmpts),
-                                   "ucp_dst_md_cmpts");
-    if (dst->dst_md_cmpts == NULL) {
-        ucs_error("failed to allocate ucp_ep dest component list");
+    int num_md_cmpts;
+    ucp_rsc_index_t *md_cmpts;
+
+    num_md_cmpts = ucs_popcount(src->reachable_md_map);
+    if (num_md_cmpts == 0) {
+        md_cmpts = NULL;
+        goto out;
+    }
+
+    md_cmpts = ucs_calloc(num_md_cmpts, sizeof(*dst->dst_md_cmpts),
+                          "ucp_dst_md_cmpts");
+    if (md_cmpts == NULL) {
+        ucs_error("failed to allocate ucp ep dest component list");
         return UCS_ERR_NO_MEMORY;
     }
 
-    memcpy(dst->dst_md_cmpts, src->dst_md_cmpts,
-           ucs_popcount(src->reachable_md_map) * sizeof(*dst->dst_md_cmpts));
+    memcpy(md_cmpts, src->dst_md_cmpts,
+           num_md_cmpts * sizeof(*dst->dst_md_cmpts));
+out:
+    *dst              = *src;
+    dst->dst_md_cmpts = md_cmpts;
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What
Updated UCP EP config key copy: changing destination config key only in error-free flow, checking number of reachable mds before copying data. 

## Why ?
To avoid unnecessary 0-size allocations and memory copies.