### PR TITLE
UCT/IB: correct reclaim resources at failure cases

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -298,18 +298,25 @@ ucs_status_t uct_ib_mlx5_iface_create_qp(uct_ib_iface_t *iface,
 {
     ucs_status_t status;
 
-    status = uct_ib_mlx5_iface_fill_attr(iface, qp, attr);
+    status = uct_ib_mlx5_iface_get_res_domain(iface, qp);
     if (status != UCS_OK) {
-        return status;
+        goto err;
     }
+
+    uct_ib_mlx5_iface_fill_attr(iface, qp, attr);
 
     status = uct_ib_iface_create_qp(iface, &attr->super, &qp->verbs.qp);
     if (status != UCS_OK) {
-        return status;
+        goto err_put_res_domain;
     }
 
     qp->qp_num = qp->verbs.qp->qp_num;
     return UCS_OK;
+
+err_put_res_domain:
+    uct_ib_mlx5_iface_put_res_domain(qp);
+err:
+    return status;
 }
 
 #if !HAVE_DEVX

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -570,18 +570,11 @@ uct_ib_mlx5_srq_get_wqe(uct_ib_mlx5_srq_t *srq, uint16_t wqe_index)
     return UCS_PTR_BYTE_OFFSET(srq->buf, (wqe_index & srq->mask) * srq->stride);
 }
 
-static ucs_status_t UCS_F_MAYBE_UNUSED
+static void UCS_F_MAYBE_UNUSED
 uct_ib_mlx5_iface_fill_attr(uct_ib_iface_t *iface,
                             uct_ib_mlx5_qp_t *qp,
                             uct_ib_mlx5_qp_attr_t *attr)
 {
-    ucs_status_t status;
-
-    status = uct_ib_mlx5_iface_get_res_domain(iface, qp);
-    if (status != UCS_OK) {
-        return status;
-    }
-
 #if HAVE_DECL_IBV_CREATE_QP_EX
     attr->super.ibv.comp_mask       = IBV_QP_INIT_ATTR_PD;
     if (qp->verbs.rd->pd != NULL) {
@@ -590,8 +583,6 @@ uct_ib_mlx5_iface_fill_attr(uct_ib_iface_t *iface,
         attr->super.ibv.pd          = uct_ib_iface_md(iface)->pd;
     }
 #endif
-
-    return UCS_OK;
 }
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -341,11 +341,12 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
         return UCS_OK;
     }
 
-    status = uct_ib_mlx5_iface_fill_attr(ib_iface, qp, attr);
+    status = uct_ib_mlx5_iface_get_res_domain(ib_iface, qp);
     if (status != UCS_OK) {
         return status;
     }
 
+    uct_ib_mlx5_iface_fill_attr(ib_iface, qp, attr);
     uct_ib_iface_fill_attr(ib_iface, &attr->super);
     uct_rc_mlx5_common_fill_dv_qp_attr(iface, &attr->super.ibv, &dv_attr,
                                        UCS_BIT(UCT_IB_DIR_TX) |
@@ -387,6 +388,11 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
 err_destory_qp:
     uct_ib_mlx5_destroy_qp(md, qp);
 err:
+#if HAVE_DECL_MLX5DV_CREATE_QP
+    if (!(md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP)) {
+        uct_ib_mlx5_iface_put_res_domain(qp);
+    }
+#endif
     return status;
 }
 

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -726,14 +726,14 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
 
     status = uct_ib_mlx5_iface_create_qp(ib_iface, qp, &attr);
     if (status != UCS_OK) {
-        goto err_destroy_qp;
+        return status;
     }
 
     status = uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
                                    iface->tx.mmio_mode, &iface->tx.wq,
                                    qp->verbs.qp);
     if (status != UCS_OK) {
-        return status;
+        goto err_destroy_qp;
     }
 
     *qp_p = qp->verbs.qp;


### PR DESCRIPTION
In case of failing to create QP to avoid segment fault

Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
check QP existence before destroying it.

## Why ?
It's possible that it failed to create QP and there's no need to destory the un-existed QP.

## How ?
Verify whethe the QP is created or not before destroying it.
