### PR TITLE
UCT/IB/UD: Remove unused constants in packet flags

### DIFF
--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -47,8 +47,7 @@ typedef struct uct_ud_iface_peer uct_ud_iface_peer_t;
 enum {
     UCT_UD_PACKET_ACK_REQ_SHIFT   = 25,
     UCT_UD_PACKET_AM_ID_SHIFT     = 27,
-    UCT_UD_PACKET_DEST_ID_SHIFT   = 24,
-    UCT_UD_PACKET_PUT_SHIFT       = 28,
+    UCT_UD_PACKET_DEST_ID_SHIFT   = 24
 };
 
 enum {
@@ -59,8 +58,7 @@ enum {
     UCT_UD_PACKET_FLAG_PUT     = UCS_BIT(28),
     UCT_UD_PACKET_FLAG_CTL     = UCS_BIT(29),
 
-    UCT_UD_PACKET_AM_ID_MASK     = UCS_MASK(UCT_UD_PACKET_AM_ID_SHIFT),
-    UCT_UD_PACKET_DEST_ID_MASK   = UCS_MASK(UCT_UD_PACKET_DEST_ID_SHIFT),
+    UCT_UD_PACKET_DEST_ID_MASK = UCS_MASK(UCT_UD_PACKET_DEST_ID_SHIFT)
 };
 
 enum {


### PR DESCRIPTION
## What

Remove unused constants in packet flags.

## Why ?

`UCT_UD_PACKET_PUT_SHIFT` and `UCT_UD_PACKET_AM_ID_MASK` are unused and could be removed.

## How ?

Remove `UCT_UD_PACKET_PUT_SHIFT` and `UCT_UD_PACKET_AM_ID_MASK`.