### PR TITLE
UCT/IB/UD: Remove unused EP cloning

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -481,15 +481,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_ep_t)
 
 UCS_CLASS_DEFINE(uct_ud_ep_t, uct_base_ep_t);
 
-void uct_ud_ep_clone(uct_ud_ep_t *old_ep, uct_ud_ep_t *new_ep)
-{
-    uct_ep_t *ep_h = &old_ep->super.super;
-    uct_iface_t *iface_h = ep_h->iface;
-
-    uct_ud_iface_replace_ep(ucs_derived_of(iface_h, uct_ud_iface_t), old_ep, new_ep);
-    memcpy(new_ep, old_ep, sizeof(uct_ud_ep_t));
-}
-
 ucs_status_t uct_ud_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
 {
     uct_ud_ep_t *ep = ucs_derived_of(tl_ep, uct_ud_ep_t);

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -330,8 +330,6 @@ ucs_arbiter_cb_result_t
 uct_ud_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
                      ucs_arbiter_elem_t *elem, void *arg);
 
-void uct_ud_ep_clone(uct_ud_ep_t *old_ep, uct_ud_ep_t *new_ep);
-
 static UCS_F_ALWAYS_INLINE void
 uct_ud_neth_set_type_am(uct_ud_ep_t *ep, uct_ud_neth_t *neth, uint8_t id)
 {

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -828,18 +828,6 @@ void uct_ud_iface_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
     }
 }
 
-void uct_ud_iface_replace_ep(uct_ud_iface_t *iface,
-                             uct_ud_ep_t *old_ep, uct_ud_ep_t *new_ep)
-{
-    void *p;
-    ucs_assert_always(old_ep != new_ep);
-    ucs_assert_always(old_ep->ep_id != new_ep->ep_id);
-    p = ucs_ptr_array_replace(&iface->eps, old_ep->ep_id, new_ep);
-    ucs_assert_always(p == (void *)old_ep);
-    ucs_trace("replace_ep: old(%p) id=%d new(%p) id=%d", old_ep, old_ep->ep_id, new_ep, new_ep->ep_id);
-    ucs_ptr_array_remove(&iface->eps, new_ep->ep_id);
-}
-
 uct_ud_send_skb_t *uct_ud_iface_ctl_skb_get(uct_ud_iface_t *iface)
 {
     uct_ud_send_skb_t *skb;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -251,8 +251,6 @@ void uct_ud_iface_add_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 
 void uct_ud_iface_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 
-void uct_ud_iface_replace_ep(uct_ud_iface_t *iface, uct_ud_ep_t *old_ep, uct_ud_ep_t *new_ep);
-
 ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                 uct_completion_t *comp);
 


### PR DESCRIPTION
## What

Remove unused EP cloning.

## Why ?

`uct_ud_ep_clone` and `uct_ud_iface_replace_ep` functions are unused.

## How ?

Remove `uct_ud_ep_clone` and `uct_ud_iface_replace_ep` functions.