### PR TITLE
DT/MEMPACK: changed error flow

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -587,8 +587,7 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
     cmpt   = context->tl_cmpts[tl_md->cmpt_index].cmpt;
 
     status = ucp_mem_rereg_mds(context, UCS_BIT(md_index), remote_addr, length,
-                               UCT_MD_MEM_ACCESS_ALL |
-                               UCT_MD_MEM_FLAG_HIDE_ERRORS,
+                               UCT_MD_MEM_ACCESS_ALL,
                                NULL, mem_type, NULL, memh, md_map);
     if (status != UCS_OK) {
         goto out;

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -63,35 +63,31 @@ typedef struct {
 /**
  * This type describes a datatype packing function, used to pack into
  * a contiguous buffer.
- * 
+ *
  * @param [in]  worker   UCP worker
  * @param [out] dest     Pack into this buffer
  * @param [in]  src      Source data to pack
  * @param [in]  length   Length of the data to pack
  * @param [in]  mem_type Memory type of the source data
- * 
- * @return Error code as defined by @ref ucs_status_t
  */
-typedef ucs_status_t (*ucp_dt_pack_func_t)(ucp_worker_h worker, void *dest,
-                                           const void *src, size_t length,
-                                           ucs_memory_type_t mem_type);
+typedef void (*ucp_dt_pack_func_t)(ucp_worker_h worker, void *dest,
+                                   const void *src, size_t length,
+                                   ucs_memory_type_t mem_type);
 
 
 /**
  * This type describes a datatype unpacking function, used to unpack from
  * a contiguous buffer.
- * 
+ *
  * @param [in]  worker   UCP worker
  * @param [out] dest     Unpack into this buffer
  * @param [in]  src      Source buffer to unpack
  * @param [in]  length   Length of the data to unpack
  * @param [in]  mem_type Memory type of the dest data
- * 
- * @return Error code as defined by @ref ucs_status_t
  */
-typedef ucs_status_t (*ucp_dt_unpack_func_t)(ucp_worker_h worker, void *dest,
-                                             const void *src, size_t length,
-                                             ucs_memory_type_t mem_type);
+typedef void (*ucp_dt_unpack_func_t)(ucp_worker_h worker, void *dest,
+                                     const void *src, size_t length,
+                                     ucs_memory_type_t mem_type);
 
 
 extern const char *ucp_datatype_class_names[];
@@ -100,21 +96,19 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
                    ucs_memory_type_t mem_type, void *dest, const void *src,
                    ucp_dt_state_t *state, size_t length);
 
-ucs_status_t ucp_mem_type_pack(ucp_worker_h worker, void *dest,
-                               const void *src, size_t length,
-                               ucs_memory_type_t mem_type);
+void ucp_mem_type_pack(ucp_worker_h worker, void *dest, const void *src,
+                       size_t length, ucs_memory_type_t mem_type);
 
-ucs_status_t ucp_mem_type_unpack(ucp_worker_h worker, void *buffer,
-                                 const void *recv_data, size_t recv_length,
-                                 ucs_memory_type_t mem_type);
+void ucp_mem_type_unpack(ucp_worker_h worker, void *buffer,
+                         const void *recv_data, size_t recv_length,
+                         ucs_memory_type_t mem_type);
 
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_ALWAYS_INLINE void
 ucp_memcpy_pack_unpack(ucp_worker_h worker, void *buffer, const void *data,
                        size_t length, ucs_memory_type_t mem_type)
 {
     UCS_PROFILE_CALL(ucs_memcpy_relaxed, buffer, data, length);
-    return UCS_OK;
 }
 
 


### PR DESCRIPTION
- due to no error processing in mem_pack/mem_unpack functions
  ucs_error macro is replaced by ucs_fatal
