### PR TITLE
UCT/EP_FLUSH: added flag for remote complete

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -503,8 +503,8 @@ enum uct_flush_flags {
     UCT_FLUSH_FLAG_LOCAL    = 0,            /**< Guarantees that the data
                                                  transfer is completed but the
                                                  target buffer may not be
-                                                 updated yet.*/
-    UCT_FLUSH_FLAG_CANCEL   = UCS_BIT(0)    /**< The library will make a best
+                                                 updated yet. */
+    UCT_FLUSH_FLAG_CANCEL   = UCS_BIT(0),   /**< The library will make a best
                                                  effort attempt to cancel all
                                                  uncompleted operations.
                                                  However, there is a chance that
@@ -519,6 +519,15 @@ enum uct_flush_flags {
                                                  error state, and it becomes
                                                  unusable for send operations
                                                  and should be destroyed. */
+    UCT_FLUSH_FLAG_REMOTE   = UCS_BIT(1)    /**< Guarantees that all previous
+                                                 UCP memory update operations
+                                                 (put, atomics, etc.) are
+                                                 completed, the target memory
+                                                 of these operation was updated,
+                                                 and the updated memory is
+                                                 globally visible for all
+                                                 processing elements in the
+                                                 system. */
 };
 
 


### PR DESCRIPTION
## What
Extend uct_ep_flush API to allow remote completion

## Why ?
For implementing multi-rail RMA fence functionality

## How ?
- added flag UCT_FLUSH_FLAG_REMOTE to notify UCT to update
  remote buffers