### PR TITLE
TEST/GTEST: Fix connect_and_send_recv in test_ucp_sockaddr

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -653,7 +653,7 @@ public:
     {
         {
             scoped_log_handler slh(detect_error_logger);
-            client_ep_connect(specify_src_addr);
+            client_ep_connect(0, specify_src_addr);
             if (!wait_for_server_ep(wakeup)) {
                 UCS_TEST_SKIP_R("cannot connect to server");
             }


### PR DESCRIPTION
## What
Fix arguments passing to `client_ep_connect`.

## Why ?
`specify_src_addr` is passed instead of `ep_index`, which is a bug.