### PR TITLE
UCP/ENDPOINT: Fix wording in comment in ucp_def.h

### DIFF
--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -815,8 +815,7 @@ typedef struct ucp_ep_params {
  * these structures large enough to contain the desired number of transport
  * and device name pairs.
  *
- * If new fields are added to this structure, they must be added at the end
- * of this structure.
+ * Any new fields must be added to the end of this structure.
  */
 typedef struct {
     /**


### PR DESCRIPTION
## What
Minor comment wording change in ucp_def.h

## Why ?
This change was requested in #7990 which had already been merged and closed

## How ?

Signed-off-by: David Wootton <dwootton@us.ibm.com>