### PR TITLE
UCT/IB/DC: Schedule EP for resending FC_HARD_REQ

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1164,6 +1164,16 @@ uct_dc_mlx5_fc_req_str(uct_dc_fc_request_t *fc_req, char *buf, size_t max)
     return buf;
 }
 
+void uct_dc_mlx5_fc_entry_iter_del(uct_dc_mlx5_iface_t *iface, khiter_t it)
+{
+    kh_del(uct_dc_mlx5_fc_hash, &iface->tx.fc_hash, it);
+    if (kh_size(&iface->tx.fc_hash) == 0) {
+        uct_worker_progress_unregister_safe(
+                &iface->super.super.super.super.worker->super,
+                &iface->tx.fc_hard_req_progress_cb_id);
+    }
+}
+
 static ucs_status_t
 uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
                              uct_rc_hdr_t *hdr, unsigned length,
@@ -1226,8 +1236,8 @@ uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
         /* Peer granted resources, so update wnd */
         uct_rc_fc_restore_wnd(rc_iface, &ep->fc);
 
-        /* Remove entry for flush to complete */
-        kh_del(uct_dc_mlx5_fc_hash, &iface->tx.fc_hash, it);
+        /* Remove FC entry to complete */
+        uct_dc_mlx5_fc_entry_iter_del(iface, it);
 
         UCS_STATS_UPDATE_COUNTER(ep->fc.stats, UCT_RC_FC_STAT_RX_PURE_GRANT, 1);
 
@@ -1425,6 +1435,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     self->tx.policy                        = (uct_dc_tx_policy_t)config->tx_policy;
     self->tx.fc_seq                        = 0;
     self->tx.fc_hard_req_timeout           = config->fc_hard_req_timeout;
+    self->tx.fc_hard_req_resend_time       = ucs_get_time();
+    self->tx.fc_hard_req_progress_cb_id    = UCS_CALLBACKQ_ID_NULL;
     self->tx.dci_release_prog_id           = UCS_CALLBACKQ_ID_NULL;
     self->keepalive_dci                    = -1;
     self->tx.num_dci_pools                 = 1;

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -277,6 +277,12 @@ struct uct_dc_mlx5_iface {
         /* Timeout for sending FC_HARD_REQ when FC window is empty */
         ucs_time_t                fc_hard_req_timeout;
 
+        /* Next time when FC_HARD_REQ operations should be resent */
+        ucs_time_t                fc_hard_req_resend_time;
+
+        /* Callback ID of FC_HARD_REQ resend operation */
+        uct_worker_cb_id_t        fc_hard_req_progress_cb_id;
+
         /* Seed used for random dci allocation */
         unsigned                  rand_seed;
 
@@ -324,6 +330,8 @@ ucs_status_t uct_dc_mlx5_iface_fc_grant(uct_pending_req_t *self);
 
 const char *
 uct_dc_mlx5_fc_req_str(uct_dc_fc_request_t *dc_req, char *buf, size_t max);
+
+void uct_dc_mlx5_fc_entry_iter_del(uct_dc_mlx5_iface_t *iface, khiter_t it);
 
 void uct_dc_mlx5_destroy_dct(uct_dc_mlx5_iface_t *iface);
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1153,7 +1153,7 @@ static void uct_dc_mlx5_ep_fc_cleanup(uct_dc_mlx5_ep_t *ep)
 
     it = kh_get(uct_dc_mlx5_fc_hash, &iface->tx.fc_hash, (uint64_t)ep);
     if (it != kh_end(&iface->tx.fc_hash)) {
-        kh_del(uct_dc_mlx5_fc_hash, &iface->tx.fc_hash, it);
+        uct_dc_mlx5_fc_entry_iter_del(iface, it);
     }
 }
 
@@ -1471,6 +1471,28 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep,
     }
 }
 
+unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
+{
+    uct_dc_mlx5_iface_t *iface = arg;
+    ucs_time_t now             = ucs_get_time();
+    uint64_t ep_key;
+    uct_dc_mlx5_ep_t *ep;
+
+    if (ucs_likely(now < iface->tx.fc_hard_req_resend_time)) {
+        return 0;
+    }
+
+    /* Go over all endpoints that are waiting for FC window being restored and
+     * resend FC_HARD_REQ packet to make sure a peer will resend FC_PURE_GRANT
+     * packet in case of failure on the remote FC endpoint */
+    kh_foreach_key(&iface->tx.fc_hash, ep_key, {
+        ep = (uct_dc_mlx5_ep_t*)ep_key;
+        uct_dc_mlx5_ep_schedule(iface, ep);
+    })
+
+    return 1;
+}
+
 ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface,
                                      uct_dc_mlx5_ep_t *ep)
 {
@@ -1523,6 +1545,12 @@ ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface,
 
         goto out;
     }
+
+    uct_worker_progress_register_safe(
+            &iface->super.super.super.super.worker->super,
+            uct_dc_mlx5_ep_fc_hard_req_progress, iface,
+            UCS_CALLBACKQ_FLAG_FAST,
+            &iface->tx.fc_hard_req_progress_cb_id);
 
 out_set_status:
     status = ucs_likely(ep->fc.fc_wnd > 0) ? UCS_OK : UCS_ERR_NO_RESOURCE;


### PR DESCRIPTION
## What

Schedule EP for resending `FC_HARD_REQ` packet.

## Why ?

To resend `FC_HARD_REQ` packets in case of sending `FC_PURE_GRANT` packet was failed on a remote FC endpoint.

## How ?

1. Implement `uct_dc_mlx5_ep_fc_hard_req_progress` which goes over FC hash and schedules EP to DCI waitq or TX waiq (if DCI was allocated).
2. Register `uct_dc_mlx5_ep_fc_hard_req_progress` callback in CBQ if FC hash isn't empty.
3. Deregister `uct_dc_mlx5_ep_fc_hard_req_progress` callback if FC hash becomes empty.