### PR TITLE
BUILD/UBUNTU: fixed io-demo build

### DIFF
--- a/test/apps/iodemo/Makefile.am
+++ b/test/apps/iodemo/Makefile.am
@@ -27,6 +27,7 @@ io_demo_CXXFLAGS = \
 io_demo_CPPFLAGS = $(BASE_CPPFLAGS) $(io_demo_CUDA_CPPFLAGS)
 
 io_demo_LDADD    = \
+	$(top_builddir)/src/ucm/libucm.la \
 	$(top_builddir)/src/ucs/libucs.la \
 	$(top_builddir)/src/uct/libuct.la \
 	$(top_builddir)/src/ucp/libucp.la \


### PR DESCRIPTION
- fixed build io-demo on Ubuntu 20.04
- on some Ubuntu distro autotools don't follow libs dependency

fixes https://github.com/openucx/ucx/issues/8178