### PR TITLE
UCP/CORE/GTEST: Fix not deallocating memory from ucp_mem_unmap if no rcache

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -134,7 +134,8 @@ ucs_status_t ucp_memh_get_slow(ucp_context_h context, void *address,
                                ucp_md_map_t reg_md_map, unsigned uct_flags,
                                ucp_mem_h *memh_p);
 
-void ucp_memh_dereg(ucp_context_h context, ucp_mem_h memh, ucp_md_map_t md_map);
+void ucp_memh_unmap(ucp_context_h context, ucp_mem_h memh,
+                    ucp_md_map_t md_map);
 
 ucs_status_t ucp_mem_rcache_init(ucp_context_h context);
 

--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -59,7 +59,7 @@ ucp_memh_put(ucp_context_h context, ucp_mem_h memh, int invalidate)
     }
 
     if (ucs_unlikely(context->rcache == NULL)) {
-        ucp_memh_dereg(context, memh, memh->md_map);
+        ucp_memh_unmap(context, memh, memh->md_map);
         ucs_free(memh);
         return;
     }

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -21,7 +21,8 @@ public:
     enum {
         VARIANT_DEFAULT,
         VARIANT_MAP_NONBLOCK,
-        VARIANT_PROTO_ENABLE
+        VARIANT_PROTO_ENABLE,
+        VARIANT_NO_RCACHE
     };
 
     static void
@@ -32,6 +33,8 @@ public:
                                "map_nb");
         add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_PROTO_ENABLE,
                                "proto");
+        add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_NO_RCACHE,
+                               "no_rcache");
     }
 
     virtual void init() {
@@ -43,6 +46,10 @@ public:
         sender().connect(&receiver(), get_ep_params());
         if (!is_loopback()) {
             receiver().connect(&sender(), get_ep_params());
+        }
+
+        if (get_variant_value() == VARIANT_NO_RCACHE) {
+            modify_config("RCACHE_ENABLE", "n");
         }
     }
 


### PR DESCRIPTION
## What

Fix not deallocating memory from ucp_mem_unmap if no rcache.

## Why ?

Backport of #8174

## How ?

See details in #8174.