### PR TITLE
UCS/PROFILE: Add UCS_PROFILE_xx_ALWAYS macros, enabled in release mode

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -364,12 +364,10 @@ void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
 
     if (region->flags & UCS_RCACHE_REGION_FLAG_REGISTERED) {
         UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_DEREGS, 1);
-        {
-            UCS_PROFILE_CODE("mem_dereg") {
-                rcache->params.ops->mem_dereg(rcache->params.context, rcache,
-                region);
-            }
-        }
+        UCS_PROFILE_NAMED_CALL_VOID_ALWAYS("mem_dereg",
+                                           rcache->params.ops->mem_dereg,
+                                           rcache->params.context, rcache,
+                                           region);
     }
 
     if (!(rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) &&
@@ -733,7 +731,7 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
              * TODO: currently rcache is optimized for the case where most of
              * the regions have same protection.
              */
-            mem_prot = UCS_PROFILE_CALL(ucs_get_mem_prot, *start, *end);
+            mem_prot = UCS_PROFILE_CALL_ALWAYS(ucs_get_mem_prot, *start, *end);
             if (!ucs_test_all_flags(mem_prot, *prot)) {
                 ucs_rcache_region_trace(rcache, region,
                                         "do not merge "UCS_RCACHE_PROT_FMT
@@ -897,10 +895,9 @@ retry:
     ++distribution_bin->count;
     distribution_bin->total_size += region_size;
 
-    region->status = status =
-        UCS_PROFILE_NAMED_CALL("mem_reg", rcache->params.ops->mem_reg,
-                               rcache->params.context, rcache, arg, region,
-                               merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
+    region->status = status = UCS_PROFILE_NAMED_CALL_ALWAYS(
+            "mem_reg", rcache->params.ops->mem_reg, rcache->params.context,
+            rcache, arg, region, merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
     if (status != UCS_OK) {
         if (merged) {
             /* failure may be due to merge, because memory of the merged

--- a/src/ucs/profile/profile_off.h
+++ b/src/ucs/profile/profile_off.h
@@ -11,21 +11,17 @@
 
 #include <ucs/sys/compiler_def.h>
 
-
-#define UCS_PROFILE(...)                                    UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_SAMPLE(_name)                           UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_SCOPE_BEGIN()                           UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_SCOPE_END(_name)                        UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_CODE(_name)
-#define UCS_PROFILE_FUNC(_ret_type, _name, _arglist, ...)   _ret_type _name(__VA_ARGS__)
-#define UCS_PROFILE_FUNC_VOID(_name, _arglist, ...)         void _name(__VA_ARGS__)
-#define UCS_PROFILE_NAMED_CALL(_name, _func, ...)           _func(__VA_ARGS__)
-#define UCS_PROFILE_CALL(_func, ...)                        _func(__VA_ARGS__)
-#define UCS_PROFILE_NAMED_CALL_VOID(_name, _func, ...)      _func(__VA_ARGS__)
-#define UCS_PROFILE_CALL_VOID(_func, ...)                   _func(__VA_ARGS__)
-#define UCS_PROFILE_REQUEST_NEW(...)                        UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_REQUEST_EVENT(...)                      UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(...)         UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_REQUEST_FREE(...)                       UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_SAMPLE(...)                     UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_CODE(_, _code)                  _code
+#define UCS_PROFILE_FUNC(_ret_type, _name, _, ...)  _ret_type _name(__VA_ARGS__)
+#define UCS_PROFILE_FUNC_VOID(_name, _, ...)        void _name(__VA_ARGS__)
+#define UCS_PROFILE_NAMED_CALL(_name, _func, ...)   _func(__VA_ARGS__)
+#define UCS_PROFILE_CALL(_func, ...)                _func(__VA_ARGS__)
+#define UCS_PROFILE_NAMED_CALL_VOID                 UCS_PROFILE_NAMED_CALL
+#define UCS_PROFILE_CALL_VOID                       UCS_PROFILE_CALL
+#define UCS_PROFILE_REQUEST_NEW(...)                UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_EVENT(...)              UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(...) UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_FREE(...)               UCS_EMPTY_STATEMENT
 
 #endif

--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -11,277 +11,18 @@
 
 #include <ucs/sys/compiler_def.h>
 #include <ucs/sys/preprocessor.h>
-#include <ucs/config/global_opts.h>
-
 
 BEGIN_C_DECLS
 
-/** @file profile_on.h */
-
-/* Helper macro */
-#define _UCS_PROFILE_CTX_RECORD(_ctx, _type, _name, _param64, _param32, _loc_id_p) \
-    { \
-        if (*(_loc_id_p) != 0) { \
-            ucs_profile_record((_ctx), (_type), (_name), (_param64), \
-                               (_param32), __FILE__, __LINE__, __FUNCTION__, \
-                               (_loc_id_p)); \
-        } \
-    }
-
-
-/* Helper macro */
-#define __UCS_PROFILE_CTX_CODE(_ctx, _name, _loop_var) \
-    int _loop_var ; \
-    for (({ UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); _loop_var = 1;}); \
-         _loop_var; \
-         ({ UCS_PROFILE_CTX_SCOPE_END((_ctx), (_name)); _loop_var = 0;}))
-
-
-/* Helper macro */
-#define _UCS_PROFILE_CTX_CODE(_ctx, _name, _var_suffix) \
-    __UCS_PROFILE_CTX_CODE(_ctx, _name, UCS_PP_TOKENPASTE(loop, _var_suffix))
-
-
-/**
- * Record a profiling event.
- *
- * @param _ctx      Profiling context.
- * @param _type     Event type.
- * @param _name     Event name.
- * @param _param32  Custom 32-bit parameter.
- * @param _param64  Custom 64-bit parameter.
- */
-#define UCS_PROFILE_CTX_RECORD(_ctx, _type, _name, _param32, _param64) \
-    { \
-        static int loc_id = -1; \
-        _UCS_PROFILE_CTX_RECORD((_ctx), (_type), (_name), (_param32), \
-                                (_param64), &loc_id); \
-    }
-
-
-/**
- * Record a profiling sample event.
- *
- * @param _name   Event name.
- */
-#define UCS_PROFILE_SAMPLE(_name) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_SAMPLE, \
-                           (_name), 0, 0)
-
-
-/**
- * Record a scope-begin profiling event.
- *
- * @param _ctx  Profiling context.
- */
-#define UCS_PROFILE_CTX_SCOPE_BEGIN(_ctx) \
-    { \
-        UCS_PROFILE_CTX_RECORD((_ctx), UCS_PROFILE_TYPE_SCOPE_BEGIN, "", 0, 0); \
-        ucs_compiler_fence(); \
-    }
-
-
-/**
- * Record a scope-end profiling event.
- *
- * @param _ctx  Profiling context.
- * @param _name Scope name.
- */
-#define UCS_PROFILE_CTX_SCOPE_END(_ctx, _name) \
-    { \
-        ucs_compiler_fence(); \
-        UCS_PROFILE_CTX_RECORD((_ctx), UCS_PROFILE_TYPE_SCOPE_END, _name, 0, 0); \
-    }
-
-
-/**
- * Declare a profiled scope of code.
- *
- * Usage:
- *  UCS_PROFILE_CODE(<name>) {
- *     <code>
- *  }
- *
- * @param _name   Scope name.
- */
-#define UCS_PROFILE_CODE(_name) \
-    _UCS_PROFILE_CTX_CODE(ucs_profile_default_ctx, _name, UCS_PP_UNIQUE_ID)
-
-
-/**
- * Create a profiled function.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_FUNC(ctx, <retval>, <name>, (a, b), int a, char b)
- *
- * @param _ctx        Profiling context.
- * @param _ret_type   Function return type.
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define _UCS_PROFILE_CTX_FUNC(_ctx, _ret_type, _name, _arglist, ...) \
-    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__); \
-    \
-    _ret_type _name(__VA_ARGS__) \
-    { \
-        _ret_type _ret; \
-        UCS_PROFILE_CTX_SCOPE_BEGIN(_ctx); \
-        _ret = _name##_inner _arglist; \
-        UCS_PROFILE_CTX_SCOPE_END(_ctx, #_name); \
-        return _ret; \
-    } \
-    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__)
-
-
-/**
- * Create a profiled function. Uses default profile context.
- *
- * Usage:
- *  UCS_PROFILE_FUNC(<retval>, <name>, (a, b), int a, char b)
- *
- * @param _ret_type   Function return type.
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define UCS_PROFILE_FUNC(_ret_type, _name, _arglist, ...) \
-    _UCS_PROFILE_CTX_FUNC(ucs_profile_default_ctx, _ret_type, _name, _arglist, ## __VA_ARGS__)
-
-
-/**
- * Create a profiled function whose return type is void.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_FUNC_VOID(ctx, <name>, (a, b), int a, char b)
- *
- * @param _ctx        Profiling context.
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define _UCS_PROFILE_CTX_FUNC_VOID(_ctx, _name, _arglist, ...) \
-    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__); \
-    \
-    void _name(__VA_ARGS__) { \
-        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
-        _name##_inner _arglist; \
-        UCS_PROFILE_CTX_SCOPE_END((_ctx), #_name); \
-    } \
-    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__)
-
-
-/**
- * Create a profiled function whose return type is void. Uses default profile
- * context.
- *
- * Usage:
- *  UCS_PROFILE_FUNC_VOID(<name>, (a, b), int a, char b)
- *
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define UCS_PROFILE_FUNC_VOID(_name, _arglist, ...) \
-    _UCS_PROFILE_CTX_FUNC_VOID(ucs_profile_default_ctx, _name, _arglist, ## __VA_ARGS__)
-
-
-/*
- * Profile a function call, and specify explicit name string for the profile.
- * Useful when calling a function by a pointer. Uses default profile context.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_NAMED_CALL(ctx, "name", function, arg1, arg2)
- *
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define _UCS_PROFILE_CTX_NAMED_CALL(_ctx, _name, _func, ...) \
-    ({ \
-        ucs_typeof(_func(__VA_ARGS__)) retval; \
-        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
-        retval = _func(__VA_ARGS__); \
-        UCS_PROFILE_CTX_SCOPE_END((_ctx), _name); \
-        retval; \
-    })
-
-
-/*
- * Profile a function call, and specify explicit name string for the profile.
- * Useful when calling a function by a pointer. Uses default profile context.
- *
- * Usage:
- *  UCS_PROFILE_NAMED_CALL("name", function, arg1, arg2)
- *
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_NAMED_CALL(_name, _func, ...) \
-    _UCS_PROFILE_CTX_NAMED_CALL(ucs_profile_default_ctx, _name, _func,  ## __VA_ARGS__)
-
-
-/*
- * Profile a function call.
- *
- * Usage:
- *  UCS_PROFILE_CALL(function, arg1, arg2)
- *
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_CALL(_func, ...) \
-    UCS_PROFILE_NAMED_CALL(#_func, _func, ## __VA_ARGS__)
-
-
-/*
- * Profile a function call which does not return a value, and specify explicit
- * name string for the profile. Useful when calling a function by a pointer.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_NAMED_CALL_VOID(ctx, "name", function, arg1, arg2)
- *
- * @param _ctx    Profiling context.
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define _UCS_PROFILE_CTX_NAMED_CALL_VOID(_ctx, _name, _func, ...) \
-    { \
-        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
-        _func(__VA_ARGS__); \
-        UCS_PROFILE_CTX_SCOPE_END((_ctx), _name); \
-    }
-
-
-/*
- * Profile a function call which does not return a value, and specify explicit
- * name string for the profile. Useful when calling a function by a pointer.
- * Uses default profile context.
- *
- * Usage:
- *  UCS_PROFILE_NAMED_CALL_VOID("name", function, arg1, arg2)
- *
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_NAMED_CALL_VOID(_name, _func, ...) \
-    _UCS_PROFILE_CTX_NAMED_CALL_VOID(ucs_profile_default_ctx, _name, _func, ## __VA_ARGS__)
-
-
-/*
- * Profile a function call which does not return a value.
- *
- * Usage:
- *  UCS_PROFILE_CALL_VOID(function, arg1, arg2)
- *
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_CALL_VOID(_func, ...) \
-    UCS_PROFILE_NAMED_CALL_VOID(#_func, _func, ## __VA_ARGS__)
+#define UCS_PROFILE_SAMPLE          UCS_PROFILE_SAMPLE_ALWAYS
+#define UCS_PROFILE_CODE            UCS_PROFILE_CODE_ALWAYS
+#define UCS_PROFILE_FUNC            UCS_PROFILE_FUNC_ALWAYS
+#define UCS_PROFILE_FUNC_VOID       UCS_PROFILE_FUNC_VOID_ALWAYS
+#define UCS_PROFILE_NAMED_CALL      UCS_PROFILE_NAMED_CALL_ALWAYS
+#define UCS_PROFILE_CALL            UCS_PROFILE_CALL_ALWAYS
+#define UCS_PROFILE_NAMED_CALL_VOID UCS_PROFILE_NAMED_CALL_VOID_ALWAYS
+#define UCS_PROFILE_CALL_VOID       UCS_PROFILE_CALL_VOID_ALWAYS
+#define UCS_PROFILE_REQUEST_EVENT   UCS_PROFILE_REQUEST_EVENT_ALWAYS
 
 
 /*
@@ -292,20 +33,9 @@ BEGIN_C_DECLS
  * @param _param32  Custom 32-bit parameter.
  */
 #define UCS_PROFILE_REQUEST_NEW(_req, _name, _param32) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_NEW, \
-                           (_name), (_param32), (uintptr_t)(_req));
-
-
-/*
- * Profile a request progress event.
- *
- * @param _req      Request pointer.
- * @param _name     Event name.
- * @param _param32  Custom 32-bit parameter.
- */
-#define UCS_PROFILE_REQUEST_EVENT(_req, _name, _param32) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_EVENT, \
-                           (_name), (_param32), (uintptr_t)(_req));
+    UCS_PROFILE_CTX_RECORD_ALWAYS(ucs_profile_default_ctx, \
+                                  UCS_PROFILE_TYPE_REQUEST_NEW, (_name), \
+                                  (_param32), (uintptr_t)(_req));
 
 
 /*
@@ -328,28 +58,9 @@ BEGIN_C_DECLS
  * @param _req      Request pointer.
  */
 #define UCS_PROFILE_REQUEST_FREE(_req) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_FREE, \
-                           "", 0, (uintptr_t)(_req));
-
-
-/*
- * Store a new record with the given data.
- * SHOULD NOT be used directly - use UCS_PROFILE macros instead.
- * @param [in]     ctx         Global profile context.
- * @param [in]     type        Location type.
- * @param [in]     name        Location name.
- * @param [in]     param32     custom 32-bit parameter.
- * @param [in]     param64     custom 64-bit parameter.
- * @param [in]     file        Source file name.
- * @param [in]     line        Source line number.
- * @param [in]     function    Calling function name.
- * @param [in,out] loc_id_p    Variable used to maintain the location ID.
- */
-void ucs_profile_record(ucs_profile_context_t *ctx, ucs_profile_type_t type,
-                        const char *name, uint32_t param32, uint64_t param64,
-                        const char *file, int line, const char *function,
-                        volatile int *loc_id_p);
-
+    UCS_PROFILE_CTX_RECORD_ALWAYS(ucs_profile_default_ctx, \
+                                  UCS_PROFILE_TYPE_REQUEST_FREE, "", 0, \
+                                  (uintptr_t)(_req));
 
 END_C_DECLS
 

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -440,8 +440,9 @@ static inline uct_iface_mp_priv_t* uct_iface_mp_priv(ucs_mpool_t *mp)
     return (uct_iface_mp_priv_t*)ucs_mpool_priv(mp);
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
-                 ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
+UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_iface_mp_chunk_alloc,
+                        (mp, size_p, chunk_p), ucs_mpool_t *mp, size_t *size_p,
+                        void **chunk_p)
 {
     uct_base_iface_t *iface = uct_iface_mp_priv(mp)->iface;
     uct_iface_mp_chunk_hdr_t *hdr;
@@ -469,8 +470,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
     return UCS_OK;
 }
 
-UCS_PROFILE_FUNC_VOID(uct_iface_mp_chunk_release, (mp, chunk),
-                      ucs_mpool_t *mp, void *chunk)
+UCS_PROFILE_FUNC_VOID_ALWAYS(uct_iface_mp_chunk_release, (mp, chunk),
+                             ucs_mpool_t *mp, void *chunk)
 {
     uct_base_iface_t *iface = uct_iface_mp_priv(mp)->iface;
     uct_iface_mp_chunk_hdr_t *hdr;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -17,6 +17,7 @@
 #include <uct/base/uct_md.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/arch/cpu.h>
+#include <ucs/profile/profile.h>
 #include <ucs/type/class.h>
 #include <ucs/type/cpu_set.h>
 #include <ucs/type/serialize.h>
@@ -962,9 +963,11 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
     uct_ib_iface_fill_attr(iface, attr);
 
 #if HAVE_DECL_IBV_CREATE_QP_EX
-    qp = ibv_create_qp_ex(dev->ibv_context, &attr->ibv);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp_ex, dev->ibv_context,
+                                 &attr->ibv);
 #else
-    qp = ibv_create_qp(uct_ib_iface_md(iface)->pd, &attr->ibv);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, uct_ib_iface_md(iface)->pd,
+                                 &attr->ibv);
 #endif
     if (qp == NULL) {
         ucs_error("iface=%p: failed to create %s QP "

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -16,6 +16,7 @@
 #include <uct/ib/base/ib_device.h>
 #include <uct/ib/base/ib_log.h>
 #include <uct/ib/mlx5/ib_mlx5_log.h>
+#include <ucs/profile/profile.h>
 #include <ucs/vfs/base/vfs_cb.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <uct/base/uct_md.h>
@@ -351,7 +352,8 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     dv_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
     uct_rc_mlx5_common_fill_dv_qp_attr(&iface->super, &attr.super.ibv, &dv_attr,
                                        UCS_BIT(UCT_IB_DIR_TX));
-    qp = mlx5dv_create_qp(dev->ibv_context, &attr.super.ibv, &dv_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
+                                 &attr.super.ibv, &dv_attr);
     if (qp == NULL) {
         ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT", DCI): failed: %m",
                   UCT_IB_IFACE_ARG(ib_iface));

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -193,9 +193,11 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md,
     UCT_IB_MLX5DV_SET64(mkc, mkc, len, length);
     UCT_IB_MLX5DV_SET(create_mkey_in, in, translations_octword_actual_size, list_size);
 
-    mr = mlx5dv_devx_obj_create(md->super.dev.ibv_context, in,
-                                uct_ib_mlx5_calc_mkey_inlen(list_size),
-                                out, sizeof(out));
+    mr = UCS_PROFILE_NAMED_CALL_ALWAYS("devx_create_mkey",
+                                       mlx5dv_devx_obj_create,
+                                       md->super.dev.ibv_context, in,
+                                       uct_ib_mlx5_calc_mkey_inlen(list_size),
+                                       out, sizeof(out));
     if (mr == NULL) {
         ucs_debug("mlx5dv_devx_obj_create(CREATE_MKEY, mode=KSM) failed, syndrome %x: %m",
                   UCT_IB_MLX5DV_GET(create_mkey_out, out, syndrome));
@@ -1169,7 +1171,7 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
     dv_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
 
     /* create DCT qp successful means DC is supported */
-    qp = mlx5dv_create_qp(ctx, &qp_attr, &dv_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, ctx, &qp_attr, &dv_attr);
     if (qp == NULL) {
         ucs_debug("%s: mlx5dv_create_qp(DCT) failed: %m",
                   uct_ib_device_name(dev));

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -14,6 +14,7 @@
 #include <uct/api/uct.h>
 #include <uct/ib/rc/base/rc_iface.h>
 #include <ucs/arch/bitops.h>
+#include <ucs/profile/profile.h>
 
 
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
@@ -341,7 +342,7 @@ uct_rc_mlx5_verbs_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     qp_init_attr.srq                 = iface->rx.srq.verbs.srq;
     qp_init_attr.cap.max_send_wr     = iface->tm.cmd_qp_len;
 
-    qp = ibv_create_qp(md->pd, &qp_init_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, md->pd, &qp_init_attr);
     if (qp == NULL) {
         ucs_error("failed to create TM control QP: %m");
         goto err_rd;

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -17,6 +17,7 @@
 #include <uct/base/uct_md.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
+#include <ucs/profile/profile.h>
 
 #include "rc_mlx5.inl"
 
@@ -349,7 +350,8 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
     uct_rc_mlx5_common_fill_dv_qp_attr(iface, &attr->super.ibv, &dv_attr,
                                        UCS_BIT(UCT_IB_DIR_TX) |
                                        UCS_BIT(UCT_IB_DIR_RX));
-    qp->verbs.qp = mlx5dv_create_qp(dev->ibv_context, &attr->super.ibv, &dv_attr);
+    qp->verbs.qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
+                                           &attr->super.ibv, &dv_attr);
     if (qp->verbs.qp == NULL) {
         ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT"): failed: %m",
                   UCT_IB_IFACE_ARG(ib_iface));

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -13,6 +13,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/sys/sock.h>
 #include <ucs/async/async.h>
+#include <ucs/profile/profile.h>
 
 
 const char* uct_rdmacm_cm_ep_str(uct_rdmacm_cm_ep_t *cep, char *str,
@@ -341,7 +342,7 @@ uct_rdmacm_cm_create_dummy_qp(uct_rdmacm_cm_device_context_t *ctx,
     qp_init_attr.cap.max_send_sge = 1;
     qp_init_attr.cap.max_recv_sge = 1;
 
-    qp = ibv_create_qp(cep->id->pd, &qp_init_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, cep->id->pd, &qp_init_attr);
     if (qp == NULL) {
         ucs_error("failed to create a dummy ud qp. %m");
         return UCS_ERR_IO_ERROR;

--- a/test/apps/profiling/ucx_profiling.c
+++ b/test/apps/profiling/ucx_profiling.c
@@ -17,16 +17,14 @@ UCS_PROFILE_FUNC(double, calc_pi, (count), int count) {
     pi_d_4 = 0.0;
 
     /* Profile a block of code */
-    {
-        UCS_PROFILE_CODE("leibnitz") {
-            for (n = 0; n < count; ++n) {
-                pi_d_4 += pow(-1.0, n) / (2 * n + 1);
+    UCS_PROFILE_CODE("leibnitz", {
+        for (n = 0; n < count; ++n) {
+            pi_d_4 += pow(-1.0, n) / (2 * n + 1);
 
-                /* create a timestamp for each step */
-                UCS_PROFILE_SAMPLE("step");
-            }
+            /* create a timestamp for each step */
+            UCS_PROFILE_SAMPLE("step");
         }
-    }
+    });
 
     return pi_d_4 * 4.0;
 }


### PR DESCRIPTION
## Why
- Enable profiling some slow-path functions, such as memory registration, also in release mode - so it could be used in the default binary distributions\
- Fix UCS_PROFILE_CODE macro to not require a nested scope

## How
- Add UCS_PROFILE_xx_ALWAYS() macros
- Reduce location id size to reduce memory footprint
- Add "always" profiling to some functions in IB component
- Update profiling unit tests to run also in release mode