### PR TITLE
UCT/IB: Fix log_ack_req_freq field initialization

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -430,7 +430,7 @@ typedef struct uct_rc_mlx5_iface_common_config {
         size_t                           mp_num_strides;
     } tm;
     unsigned                             exp_backoff;
-    uint8_t                              log_ack_req_freq;
+    unsigned                             log_ack_req_freq;
     UCS_CONFIG_STRING_ARRAY_FIELD(types) srq_topo;
 } uct_rc_mlx5_iface_common_config_t;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -760,7 +760,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     self->super.config.fence_mode  = (uct_rc_fence_mode_t)rc_config->fence_mode;
     self->super.rx.srq.quota       = self->rx.srq.mask + 1;
     self->super.config.exp_backoff = mlx5_config->exp_backoff;
-    self->config.log_ack_req_freq  = mlx5_config->log_ack_req_freq;
+    self->config.log_ack_req_freq  = ucs_min(mlx5_config->log_ack_req_freq,
+                                             UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ);
 
     if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
@@ -876,8 +877,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
 
     self->super.super.config.tx_moderation = ucs_min(config->super.tx_cq_moderation,
                                                      self->super.tx.bb_max / 4);
-    self->super.config.log_ack_req_freq    = ucs_min(config->super.log_ack_req_freq,
-                                                     UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ);
 
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -174,8 +174,6 @@ struct uct_rc_iface_config {
     unsigned                       tx_cq_moderation; /* How many TX messages are
                                                         batched to one CQE */
     unsigned                       tx_cq_len;
-    unsigned                       log_ack_req_freq; /* Log of requests ack
-                                                        frequency on DevX */
 };
 
 


### PR DESCRIPTION
## What
Fix initialization of the `log_ack_req_freq` field in RC MLX5 ifaces.

## Why ?
There is a bug - the field appears in 2 config types and gets overridden with 0 from the second (unused) config.
