### PR TITLE
UCT/IB: Fix thread domain

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -578,20 +578,6 @@ void uct_dc_mlx5_destroy_dct(uct_dc_mlx5_iface_t *iface)
 }
 #endif
 
-static void uct_dc_mlx5_iface_cleanup_dcis(uct_dc_mlx5_iface_t *iface)
-{
-    int num_dcis = uct_dc_mlx5_iface_total_ndci(iface);
-    int i;
-
-    for (i = 0; i < num_dcis; i++) {
-        if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
-            ucs_arbiter_group_cleanup(&iface->tx.dcis[i].arb_group);
-        }
-        uct_ib_mlx5_qp_mmio_cleanup(&iface->tx.dcis[i].txwq.super,
-                                    iface->tx.dcis[i].txwq.reg);
-    }
-}
-
 static ucs_status_t
 uct_dc_mlx5_init_rx(uct_rc_iface_t *rc_iface,
                     const uct_rc_iface_common_config_t *rc_config)
@@ -686,6 +672,12 @@ static void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface,
         uct_rc_txqp_cleanup(&iface->super.super,
                             &iface->tx.dcis[dci_index].txqp);
         uct_ib_mlx5_destroy_qp(md, &iface->tx.dcis[dci_index].txwq.super);
+
+        if (uct_dc_mlx5_iface_is_dci_rand(iface)) {
+            ucs_arbiter_group_cleanup(&iface->tx.dcis[dci_index].arb_group);
+        }
+        uct_ib_mlx5_qp_mmio_cleanup(&iface->tx.dcis[dci_index].txwq.super,
+                                    iface->tx.dcis[dci_index].txwq.reg);
     }
 
     for (pool_index = 0; pool_index < num_dci_pools; pool_index++) {
@@ -1376,7 +1368,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_iface_t)
     ucs_trace_func("");
     uct_base_iface_progress_disable(&self->super.super.super.super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-    uct_dc_mlx5_iface_cleanup_dcis(self);
 
     uct_dc_mlx5_destroy_dct(self);
     kh_destroy_inplace(uct_dc_mlx5_fc_hash, &self->tx.fc_hash);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -55,7 +55,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
 
     uct_ib_iface_fill_attr(iface, &attr->super);
 
-    status = uct_ib_mlx5_get_mmio_mode(iface->super.worker, attr->mmio_mode,
+    status = uct_ib_mlx5_get_mmio_mode(iface->super.worker, attr->mmio_mode, 0,
                                        UCT_IB_MLX5_BF_REG_SIZE, &mmio_mode);
     if (status != UCS_OK) {
         goto err;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -283,6 +283,8 @@ typedef enum {
     UCT_IB_MLX5_MMIO_MODE_BF_POST_MT, /* BF with order, can be used by multiple
                                          serialized threads */
     UCT_IB_MLX5_MMIO_MODE_DB,         /* 8-byte doorbell (with the mandatory flush) */
+    UCT_IB_MLX5_MMIO_MODE_DB_LOCK,    /* 8-byte doorbell with locking, can be
+                                         used by multiple concurrent threads */
     UCT_IB_MLX5_MMIO_MODE_AUTO,       /* Auto-select according to driver/HW capabilities
                                          and multi-thread support level */
     UCT_IB_MLX5_MMIO_MODE_LAST
@@ -399,6 +401,7 @@ typedef struct uct_ib_mlx5_mmio_reg {
         uintptr_t               uint;
     } addr;
     uct_ib_mlx5_mmio_mode_t     mode;
+    ucs_spinlock_t              db_lock;
 } uct_ib_mlx5_mmio_reg_t;
 
 
@@ -643,7 +646,7 @@ void uct_ib_mlx5_check_completion_with_err(uct_ib_iface_t *iface,
 ucs_status_t
 uct_ib_mlx5_get_mmio_mode(uct_priv_worker_t *worker,
                           uct_ib_mlx5_mmio_mode_t cfg_mmio_mode,
-                          unsigned bf_size,
+                          int need_lock, unsigned bf_size,
                           uct_ib_mlx5_mmio_mode_t *mmio_mode);
 
 /**

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -639,16 +639,16 @@ uct_rc_mlx5_iface_qp_cleanup(uct_rc_iface_qp_cleanup_ctx_t *rc_cleanup_ctx)
 
 #if IBV_HW_TM
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
+        uct_ib_mlx5_destroy_qp(md, &cleanup_ctx->tm_qp);
         /* Using uct_ib_mlx5_iface_put_res_domain and not
          * uct_ib_mlx5_qp_mmio_cleanup: in case of devx, we don't have uar,
          * and uct_ib_mlx5_qp_mmio_cleanup would try to release uar */
         uct_ib_mlx5_iface_put_res_domain(&cleanup_ctx->tm_qp);
-        uct_ib_mlx5_destroy_qp(md, &cleanup_ctx->tm_qp);
     }
 #endif
 
-    uct_ib_mlx5_qp_mmio_cleanup(&cleanup_ctx->qp, cleanup_ctx->reg);
     uct_ib_mlx5_destroy_qp(md, &cleanup_ctx->qp);
+    uct_ib_mlx5_qp_mmio_cleanup(&cleanup_ctx->qp, cleanup_ctx->reg);
 }
 
 static uint8_t uct_rc_mlx5_iface_get_address_type(uct_iface_h tl_iface)

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -751,8 +751,8 @@ static void uct_ud_mlx5_iface_destroy_qp(uct_ud_iface_t *ud_iface)
                                                 uct_ib_mlx5_md_t);
     uct_ib_mlx5_qp_t *qp       = &iface->tx.wq.super;
 
-    uct_ib_mlx5_qp_mmio_cleanup(qp, iface->tx.wq.reg);
     uct_ib_mlx5_destroy_qp(ib_md, qp);
+    uct_ib_mlx5_qp_mmio_cleanup(qp, iface->tx.wq.reg);
 }
 
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t)(uct_iface_t*);


### PR DESCRIPTION
## What
Fix using thread domain object in accelerated verbs flow

## Why ?
Thread domain provides per-thread IB verbs resources isolation.
When thread domain not supported - falling back to isolation in UCT layer.
