### PR TITLE
UCP/PROTO: Add op_attr_mask to rendezvous protocol selection

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1129,6 +1129,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
         req->recv.length   = ucp_dt_length(datatype, count, buffer,
                                            &req->recv.state);
         req->recv.mem_type = mem_type;
+        req->recv.op_attr  = param->op_attr_mask;
         req->recv.am.desc  = desc;
         rts                = data_desc;
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -378,6 +378,7 @@ struct ucp_request {
             ucp_datatype_t        datatype; /* Receive type */
             size_t                length;   /* Total length, in bytes */
             ucs_memory_type_t     mem_type; /* Memory type */
+            uint32_t              op_attr;  /* Operation attributes */
             ucp_dt_state_t        state;
             ucp_worker_t          *worker;
             uct_tag_context_t     uct_ctx;  /* Transport offload context */

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -132,7 +132,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                                             &req->recv.state);
     req->recv.mem_type      = ucp_request_get_memory_type(worker->context, buffer,
                                                          req->recv.length, param);
-
+    req->recv.op_attr       = param->op_attr_mask;
     req->recv.tag.tag       = tag;
     req->recv.tag.tag_mask  = tag_mask;
     if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {


### PR DESCRIPTION
## Why
Fix UCP_OP_ATTR_FLAG_MULTI_SEND flag was not passed to all RNDV protov2 initialization functions