### PR TITLE
UCP/API: Move deprecated functions to ucp_compat.h

### DIFF
--- a/examples/ucp_hello_world.c
+++ b/examples/ucp_hello_world.c
@@ -350,17 +350,12 @@ err:
     return ret;
 }
 
-static void flush_callback(void *request, ucs_status_t status, void *user_data)
-{
-}
-
 static ucs_status_t flush_ep(ucp_worker_h worker, ucp_ep_h ep)
 {
     ucp_request_param_t param;
     void *request;
 
-    param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK;
-    param.cb.send      = flush_callback;
+    param.op_attr_mask = 0;
     request            = ucp_ep_flush_nbx(ep, &param);
     if (request == NULL) {
         return UCS_OK;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -612,42 +612,6 @@ enum ucp_cb_param_flags {
 
 /**
  * @ingroup UCP_COMM
- * @brief Atomic operation requested for ucp_atomic_post
- *
- * This enumeration defines which atomic memory operation should be
- * performed by the ucp_atomic_post family of functions. All of these are
- * non-fetching atomics and will not result in a request handle.
- */
-typedef enum {
-    UCP_ATOMIC_POST_OP_ADD, /**< Atomic add */
-    UCP_ATOMIC_POST_OP_AND, /**< Atomic and */
-    UCP_ATOMIC_POST_OP_OR,  /**< Atomic or  */
-    UCP_ATOMIC_POST_OP_XOR, /**< Atomic xor */
-    UCP_ATOMIC_POST_OP_LAST
-} ucp_atomic_post_op_t;
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Atomic operation requested for ucp_atomic_fetch
- *
- * This enumeration defines which atomic memory operation should be performed
- * by the ucp_atomic_fetch family of functions. All of these functions
- * will fetch data from the remote node.
- */
-typedef enum {
-    UCP_ATOMIC_FETCH_OP_FADD,  /**< Atomic Fetch and add    */
-    UCP_ATOMIC_FETCH_OP_SWAP,  /**< Atomic swap             */
-    UCP_ATOMIC_FETCH_OP_CSWAP, /**< Atomic conditional swap */
-    UCP_ATOMIC_FETCH_OP_FAND,  /**< Atomic Fetch and and    */
-    UCP_ATOMIC_FETCH_OP_FOR,   /**< Atomic Fetch and or     */
-    UCP_ATOMIC_FETCH_OP_FXOR,  /**< Atomic Fetch and xor    */
-    UCP_ATOMIC_FETCH_OP_LAST
-} ucp_atomic_fetch_op_t;
-
-
-/**
- * @ingroup UCP_COMM
  * @brief Atomic operation requested for ucp_atomic_op_nbx
  *
  * This enumeration defines which atomic memory operation should be
@@ -2126,27 +2090,6 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream);
 
 /**
  * @ingroup UCP_WORKER
- * @brief Get the address of the worker object.
- *
- * This routine returns the address of the worker object.  This address can be
- * passed to remote instances of the UCP library in order to connect to this
- * worker. The memory for the address handle is allocated by this function, and
- * must be released by using @ref ucp_worker_release_address
- * "ucp_worker_release_address()" routine.
- *
- * @param [in]  worker            Worker object whose address to return.
- * @param [out] address_p         A pointer to the worker address.
- * @param [out] address_length_p  The size in bytes of the address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
-                                    ucp_address_t **address_p,
-                                    size_t *address_length_p);
-
-
-/**
- * @ingroup UCP_WORKER
  * @brief Release an address of the worker object.
  *
  * This routine release an @ref ucp_address_t "address handle" associated within
@@ -2538,35 +2481,6 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  *
  * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
  *
- * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
- * process depends on the selected @a mode.
- *
- * @param [in]  ep      Handle to the endpoint to close.
- * @param [in]  mode    One from @ref ucp_ep_close_mode value.
- *
- * @return UCS_OK           - The endpoint is closed successfully.
- * @return UCS_PTR_IS_ERR(_ptr) - The closure failed and an error code indicates
- *                                the transport level status. However, resources
- *                                are released and the @a endpoint can no longer
- *                                be used.
- * @return otherwise        - The closure process is started, and can be
- *                            completed at any point in time. A request handle
- *                            is returned to the application in order to track
- *                            progress of the endpoint closure. The application
- *                            is responsible for releasing the handle using the
- *                            @ref ucp_request_free routine.
- *
- * @note @ref ucp_ep_close_nb replaces deprecated @ref ucp_disconnect_nb and
- *       @ref ucp_ep_destroy
- */
-ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode);
-
-
-/**
- * @ingroup UCP_ENDPOINT
- *
- * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
- *
  * @param [in]  ep      Handle to the endpoint to close.
  * @param [in]  param   Operation parameters, see @ref ucp_request_param_t.
  *                      This operation supports specific flags, which can be
@@ -2633,32 +2547,26 @@ void ucp_ep_print_info(ucp_ep_h ep, FILE *stream);
  * @ref ucp_ep_h "endpoint" when this call returns.
  *
  * @param [in] ep        UCP endpoint.
- * @param [in] flags     Flags for flush operation. Reserved for future use.
- * @param [in] cb        Callback which will be called when the flush operation
- *                       completes.
+ * @param [in] param     Operation parameters, see @ref ucp_request_param_t.
  *
- * @return NULL             - The flush operation was completed immediately.
+ * @return NULL                 - The flush operation was completed immediately.
  * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
- * @return otherwise        - Flush operation was scheduled and can be completed
- *                          in any point in time. The request handle is returned
- *                          to the application in order to track progress. The
- *                          application is responsible for releasing the handle
- *                          using @ref ucp_request_free "ucp_request_free()"
- *                          routine.
+ * @return otherwise            - Flush operation was scheduled and can be
+ *                                completed in any point in time. The request
+ *                                handle is returned to the application in
+ *                                order to track progress.
  *
  *
  * The following example demonstrates how blocking flush can be implemented
  * using non-blocking flush:
  * @code {.c}
- * void empty_function(void *request, ucs_status_t status)
- * {
- * }
- *
  * ucs_status_t blocking_ep_flush(ucp_ep_h ep, ucp_worker_h worker)
  * {
+ *     ucp_request_param_t param;
  *     void *request;
  *
- *     request = ucp_ep_flush_nb(ep, 0, empty_function);
+ *     param.op_attr_mask = 0;
+ *     request            = ucp_ep_flush_nbx(ep, &param);
  *     if (request == NULL) {
  *         return UCS_OK;
  *     } else if (UCS_PTR_IS_ERR(request)) {
@@ -2673,31 +2581,7 @@ void ucp_ep_print_info(ucp_ep_h ep, FILE *stream);
  *         return status;
  *     }
  * }
- * @endcode */
-ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep, unsigned flags,
-                                 ucp_send_callback_t cb);
-
-
-/**
- * @ingroup UCP_ENDPOINT
- *
- * @brief Non-blocking flush of outstanding AMO and RMA operations on the
- * @ref ucp_ep_h "endpoint".
- *
- * This routine flushes all outstanding AMO and RMA communications on the
- * @ref ucp_ep_h "endpoint". All the AMO and RMA operations issued on the
- * @a ep prior to this call are completed both at the origin and at the target
- * @ref ucp_ep_h "endpoint" when this call returns.
- *
- * @param [in] ep        UCP endpoint.
- * @param [in] param     Operation parameters, see @ref ucp_request_param_t.
- *
- * @return NULL                 - The flush operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
- * @return otherwise            - Flush operation was scheduled and can be
- *                                completed in any point in time. The request
- *                                handle is returned to the application in
- *                                order to track progress.
+ * @endcode
  */
 ucs_status_ptr_t ucp_ep_flush_nbx(ucp_ep_h ep, const ucp_request_param_t *param);
 
@@ -3062,36 +2946,6 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  *
  * This routine installs a user defined callback to handle incoming Active
  * Messages with a specific id. This callback is called whenever an Active
- * Message that was sent from the remote peer by @ref ucp_am_send_nb is
- * received on this worker.
- *
- * @param [in]  worker      UCP worker on which to set the Active Message
- *                          handler.
- * @param [in]  id          Active Message id.
- * @param [in]  cb          Active Message callback. NULL to clear.
- * @param [in]  arg         Active Message argument, which will be passed
- *                          in to every invocation of the callback as the
- *                          arg argument.
- * @param [in]  flags       Dictates how an Active Message is handled on the
- *                          remote endpoint. Currently only
- *                          UCP_AM_FLAG_WHOLE_MSG is supported, which
- *                          indicates the callback will not be invoked
- *                          until all data has arrived.
- *
- * @return error code if the worker does not support Active Messages or
- *         requested callback flags.
- */
-ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
-                                       ucp_am_callback_t cb, void *arg,
-                                       uint32_t flags);
-
-
-/**
- * @ingroup UCP_WORKER
- * @brief Add user defined callback for Active Message.
- *
- * This routine installs a user defined callback to handle incoming Active
- * Messages with a specific id. This callback is called whenever an Active
  * Message that was sent from the remote peer by @ref ucp_am_send_nbx is
  * received on this worker.
  *
@@ -3108,35 +2962,6 @@ ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
  */
 ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
                                             const ucp_am_handler_param_t *param);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Send Active Message.
- *
- * This routine sends an Active Message to an ep. It does not support
- * CUDA memory.
- *
- * @param [in]  ep          UCP endpoint where the Active Message will be run.
- * @param [in]  id          Active Message id. Specifies which registered
- *                          callback to run.
- * @param [in]  buffer      Pointer to the data to be sent to the target node
- *                          of the Active Message.
- * @param [in]  count       Number of elements to send.
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  cb          Callback that is invoked upon completion of the
- *                          data transfer if it is not completed immediately.
- * @param [in]  flags       Operation flags as defined by @ref ucp_send_am_flags.
- *
- * @return NULL             Active Message was sent immediately.
- * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message.
- * @return otherwise        Pointer to request, and Active Message is known
- *                          to be completed after cb is run.
- */
-ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
-                                const void *buffer, size_t count,
-                                ucp_datatype_t datatype,
-                                ucp_send_callback_t cb, unsigned flags);
 
 
 /**
@@ -3263,49 +3088,6 @@ void ucp_am_data_release(ucp_worker_h worker, void *data);
  * @brief Non-blocking stream send operation.
  *
  * This routine sends data that is described by the local address @a buffer,
- * size @a count, and @a datatype object to the destination endpoint @a ep.
- * The routine is non-blocking and therefore returns immediately, however
- * the actual send operation may be delayed. The send operation is considered
- * completed when it is safe to reuse the source @e buffer. If the send
- * operation is completed immediately the routine returns UCS_OK and the
- * callback function @a cb is @b not invoked. If the operation is
- * @b not completed immediately and no error reported, then the UCP library will
- * schedule invocation of the callback @a cb upon completion of the send
- * operation. In other words, the completion of the operation will be signaled
- * either by the return code or by the callback.
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send.
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          send operation is completed. It is important to note
- *                          that the callback is only invoked in the event that
- *                          the operation cannot be completed in place.
- * @param [in]  flags       Reserved for future use.
- *
- * @return NULL             - The send operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
- * @return otherwise        - Operation was scheduled for send and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the message. The application is
- *                          responsible for releasing the handle using
- *                          @ref ucp_request_free routine.
- */
-ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
-                                    ucp_datatype_t datatype, ucp_send_callback_t cb,
-                                    unsigned flags);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking stream send operation.
- *
- * This routine sends data that is described by the local address @a buffer,
  * size @a count object to the destination endpoint @a ep. The routine is
  * non-blocking and therefore returns immediately, however the actual send
  * operation may be delayed. The send operation is considered completed when
@@ -3329,167 +3111,6 @@ ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t coun
  */
 ucs_status_ptr_t ucp_stream_send_nbx(ucp_ep_h ep, const void *buffer, size_t count,
                                      const ucp_request_param_t *param);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-send operations
- *
- * This routine sends a messages that is described by the local address @a
- * buffer, size @a count, and @a datatype object to the destination endpoint
- * @a ep. Each message is associated with a @a tag value that is used for
- * message matching on the @ref ucp_tag_recv_nb "receiver". The routine is
- * non-blocking and therefore returns immediately, however the actual send
- * operation may be delayed. The send operation is considered completed when
- * it is safe to reuse the source @e buffer. If the send operation is
- * completed immediately the routine return UCS_OK and the call-back function
- * @a cb is @b not invoked. If the operation is @b not completed immediately
- * and no error reported then the UCP library will schedule to invoke the
- * call-back @a cb whenever the send operation will be completed. In other
- * words, the completion of a message can be signaled by the return code or
- * the call-back.
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          send operation is completed. It is important to note
- *                          that the call-back is only invoked in a case when
- *                          the operation cannot be completed in place.
- *
- * @return NULL            - The send operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
- * @return otherwise        - Operation was scheduled for send and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the message. The application is
- *                          responsible for releasing the handle using
- *                          @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
-                                 ucp_datatype_t datatype, ucp_tag_t tag,
-                                 ucp_send_callback_t cb);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-send operations with user provided request
- *
- * This routine provides a convenient and efficient way to implement a
- * blocking send pattern. It also completes requests faster than
- * @ref ucp_tag_send_nb() because:
- * @li it always uses eager protocol to send data up to the
- *     rendezvous threshold.
- * @li its rendezvous threshold is higher than the one used by
- *     the @ref ucp_tag_send_nb(). The threshold is controlled by
- *     the @b UCX_SEND_NBR_RNDV_THRESH environment variable.
- * @li its request handling is simpler. There is no callback and no need
- *     to allocate and free requests. In fact request can be allocated by
- *     caller on the stack.
- *
- * This routine sends a messages that is described by the local address @a
- * buffer, size @a count, and @a datatype object to the destination endpoint
- * @a ep. Each message is associated with a @a tag value that is used for
- * message matching on the @ref ucp_tag_recv_nbr "receiver".
- *
- * The routine is non-blocking and therefore returns immediately, however
- * the actual send operation may be delayed. The send operation is considered
- * completed when it is safe to reuse the source @e buffer. If the send
- * operation is completed immediately the routine returns UCS_OK.
- *
- * If the operation is @b not completed immediately and no error reported
- * then the UCP library will fill a user provided @a req and
- * return UCS_INPROGRESS status. In order to monitor completion of the
- * operation @ref ucp_request_check_status() should be used.
- *
- * Following pseudo code implements a blocking send function:
- * @code
- * MPI_send(...)
- * {
- *     char *request;
- *     ucs_status_t status;
- *
- *     // allocate request on the stack
- *     // ucp_context_query() was used to get ucp_request_size
- *     request = alloca(ucp_request_size);
- *
- *     // note: make sure that there is enough memory before the
- *     // request handle
- *     status = ucp_tag_send_nbr(ep, ..., request + ucp_request_size);
- *     if (status != UCS_INPROGRESS) {
- *         return status;
- *     }
- *
- *     do {
- *         ucp_worker_progress(worker);
- *         status = ucp_request_check_status(request + ucp_request_size);
- *     } while (status == UCS_INPROGRESS);
- *
- *     return status;
- * }
- * @endcode
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- *
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag.
- * @param [in]  req         Request handle allocated by the user. There should
- *                          be at least UCP request size bytes of available
- *                          space before the @a req. The size of UCP request
- *                          can be obtained by @ref ucp_context_query function.
- *
- * @return UCS_OK           - The send operation was completed immediately.
- * @return UCS_INPROGRESS   - The send was not completed and is in progress.
- *                            @ref ucp_request_check_status() should be used to
- *                            monitor @a req status.
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_tag_send_nbr(ucp_ep_h ep, const void *buffer, size_t count,
-                              ucp_datatype_t datatype, ucp_tag_t tag, void *req);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking synchronous tagged-send operation.
- *
- * Same as @ref ucp_tag_send_nb, except the request completes only after there
- * is a remote tag match on the message (which does not always mean the remote
- * receive has been completed). This function never completes "in-place", and
- * always returns a request handle.
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- * @note Returns @ref UCS_ERR_UNSUPPORTED if @ref UCP_ERR_HANDLING_MODE_PEER is
- *       enabled. This is a temporary implementation-related constraint that
- *       will be addressed in future releases.
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          send operation is completed.
- *
- * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
- * @return otherwise        - Operation was scheduled for send and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the message. The application is
- *                          responsible for releasing the handle using
- *                          @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t count,
-                                      ucp_datatype_t datatype, ucp_tag_t tag,
-                                      ucp_send_callback_t cb);
 
 
 /**
@@ -3573,53 +3194,6 @@ ucs_status_ptr_t ucp_tag_send_sync_nbx(ucp_ep_h ep, const void *buffer,
  *        user-supplied buffer.
  *
  * This routine receives data that is described by the local address @a buffer,
- * size @a count, and @a datatype object on the endpoint @a ep. The routine is
- * non-blocking and therefore returns immediately. The receive operation is
- * considered complete when the message is delivered to the buffer. If data is
- * not immediately available, the operation will be scheduled for receive and
- * a request handle will be returned. In order to notify the application about
- * completion of a scheduled receive operation, the UCP library will invoke
- * the call-back @a cb when data is in the receive buffer and ready for
- * application access. If the receive operation cannot be started, the routine
- * returns an error.
- *
- * @param [in]     ep       UCP endpoint that is used for the receive operation.
- * @param [in]     buffer   Pointer to the buffer to receive the data.
- * @param [in]     count    Number of elements to receive into @a buffer.
- * @param [in]     datatype Datatype descriptor for the elements in the buffer.
- * @param [in]     cb       Callback function that is invoked whenever the
- *                          receive operation is completed and the data is ready
- *                          in the receive @a buffer. It is important to note
- *                          that the call-back is only invoked in a case when
- *                          the operation cannot be completed immediately.
- * @param [out]    length   Size of the received data in bytes. The value is
- *                          valid only if return code is UCS_OK.
- * @note                    The amount of data received, in bytes, is always an
- *                          integral multiple of the @a datatype size.
- * @param [in]     flags    Flags defined in @ref ucp_stream_recv_flags_t.
- *
- * @return NULL                 - The receive operation was completed
- *                                immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
- * @return otherwise            - Operation was scheduled for receive. A request
- *                                handle is returned to the application in order
- *                                to track progress of the operation.
- *                                The application is responsible for releasing
- *                                the handle by calling the
- *                                @ref ucp_request_free routine.
- */
-ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t count,
-                                    ucp_datatype_t datatype,
-                                    ucp_stream_recv_callback_t cb,
-                                    size_t *length, unsigned flags);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking stream receive operation of structured data into a
- *        user-supplied buffer.
- *
- * This routine receives data that is described by the local address @a buffer,
  * size @a count object on the endpoint @a ep. The routine is non-blocking
  * and therefore returns immediately. The receive operation is considered
  * complete when the message is delivered to the buffer. If the receive
@@ -3687,83 +3261,6 @@ ucs_status_ptr_t ucp_stream_recv_nbx(ucp_ep_h ep, void *buffer, size_t count,
  *       and thus avoiding extra memory copy operations.
  */
 ucs_status_ptr_t ucp_stream_recv_data_nb(ucp_ep_h ep, size_t *length);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-receive operation.
- *
- * This routine receives a message that is described by the local address @a
- * buffer, size @a count, and @a datatype object on the @a worker. The tag
- * value of the receive message has to match the @a tag and @a tag_mask values,
- * where the @a tag_mask indicates which bits of the tag have to be matched. The
- * routine is non-blocking and therefore returns immediately. The receive
- * operation is considered completed when the message is delivered to the @a
- * buffer.  In order to notify the application about completion of the receive
- * operation the UCP library will invoke the call-back @a cb when the received
- * message is in the receive buffer and ready for application access.  If the
- * receive operation cannot be stated the routine returns an error.
- *
- * @note This routine cannot return UCS_OK. It always returns a request
- *       handle or an error.
- *
- * @param [in]  worker      UCP worker that is used for the receive operation.
- * @param [in]  buffer      Pointer to the buffer to receive the data.
- * @param [in]  count       Number of elements to receive
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag to expect.
- * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
- *                          the matching of the incoming tag
- *                          against the expected tag.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          receive operation is completed and the data is ready
- *                          in the receive @a buffer.
- *
- * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
- * @return otherwise          - Operation was scheduled for receive. The request
- *                              handle is returned to the application in order
- *                              to track progress of the operation. The
- *                              application is responsible for releasing the
- *                              handle using @ref ucp_request_free
- *                              "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_recv_nb(ucp_worker_h worker, void *buffer, size_t count,
-                                 ucp_datatype_t datatype, ucp_tag_t tag,
-                                 ucp_tag_t tag_mask, ucp_tag_recv_callback_t cb);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-receive operation.
- *
- * This routine receives a message that is described by the local address @a
- * buffer, size @a count, and @a datatype object on the @a worker. The tag
- * value of the receive message has to match the @a tag and @a tag_mask values,
- * where the @a tag_mask indicates which bits of the tag have to be matched. The
- * routine is non-blocking and therefore returns immediately. The receive
- * operation is considered completed when the message is delivered to the @a
- * buffer. In order to monitor completion of the operation
- * @ref ucp_request_check_status or @ref ucp_tag_recv_request_test should be
- * used.
- *
- * @param [in]  worker      UCP worker that is used for the receive operation.
- * @param [in]  buffer      Pointer to the buffer to receive the data.
- * @param [in]  count       Number of elements to receive
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag to expect.
- * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
- *                          the matching of the incoming tag
- *                          against the expected tag.
- * @param [in]  req         Request handle allocated by the user. There should
- *                          be at least UCP request size bytes of available
- *                          space before the @a req. The size of UCP request
- *                          can be obtained by @ref ucp_context_query function.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_tag_recv_nbr(ucp_worker_h worker, void *buffer, size_t count,
-                              ucp_datatype_t datatype, ucp_tag_t tag,
-                              ucp_tag_t tag_mask, void *req);
 
 
 /**
@@ -3858,45 +3355,6 @@ ucp_tag_message_h ucp_tag_probe_nb(ucp_worker_h worker, ucp_tag_t tag,
  * @brief Non-blocking receive operation for a probed message.
  *
  * This routine receives a message that is described by the local address @a
- * buffer, size @a count, @a message handle, and @a datatype object on the @a
- * worker. The @a message handle can be obtained by calling the @ref
- * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nb
- * "ucp_tag_msg_recv_nb()" routine is non-blocking and therefore returns
- * immediately. The receive operation is considered completed when the message
- * is delivered to the @a buffer. In order to notify the application about
- * completion of the receive operation the UCP library will invoke the
- * call-back @a cb when the received message is in the receive buffer and ready
- * for application access. If the receive operation cannot be started the
- * routine returns an error.
- *
- * @param [in]  worker      UCP worker that is used for the receive operation.
- * @param [in]  buffer      Pointer to the buffer that will receive the data.
- * @param [in]  count       Number of elements to receive
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  message     Message handle.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          receive operation is completed and the data is ready
- *                          in the receive @a buffer.
- *
- * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
- * @return otherwise          - Operation was scheduled for receive. The request
- *                              handle is returned to the application in order
- *                              to track progress of the operation. The
- *                              application is responsible for releasing the
- *                              handle using @ref ucp_request_free
- *                              "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
-                                     size_t count, ucp_datatype_t datatype,
-                                     ucp_tag_message_h message,
-                                     ucp_tag_recv_callback_t cb);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking receive operation for a probed message.
- *
- * This routine receives a message that is described by the local address @a
  * buffer, size @a count, and @a message handle on the @a worker.
  * The @a message handle can be obtained by calling the @ref
  * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nbx
@@ -3925,82 +3383,6 @@ ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
 ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
                                       size_t count, ucp_tag_message_h message,
                                       const ucp_request_param_t *param);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking implicit remote memory put operation.
- *
- * This routine initiates a storage of contiguous block of data that is
- * described by the local address @a buffer in the remote contiguous memory
- * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
- * handle" @a rkey. The routine returns immediately and @b does @b not
- * guarantee re-usability of the source address @e buffer. If the operation is
- * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
- * or an error is returned to user.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
- * in order to guarantee re-usability of the source address @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local source address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           source address.
- * @param [in]  remote_addr  Pointer to the destination remote memory address
- *                           to write to.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
-                         uint64_t remote_addr, ucp_rkey_h rkey);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking remote memory put operation.
- *
- * This routine initiates a storage of contiguous block of data that is
- * described by the local address @a buffer in the remote contiguous memory
- * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
- * handle" @a rkey.  The routine returns immediately and @b does @b not
- * guarantee re-usability of the source address @e buffer. If the operation is
- * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
- * or an error is returned to user. If the put operation completes immediately,
- * the routine returns UCS_OK and the call-back routine @a cb is @b not
- * invoked. If the operation is @b not completed immediately and no error is
- * reported, then the UCP library will schedule invocation of the call-back
- * routine @a cb upon completion of the put operation. In other words, the
- * completion of a put operation can be signaled by the return code or
- * execution of the call-back.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
- * in order to guarantee re-usability of the source address @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local source address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           source address.
- * @param [in]  remote_addr  Pointer to the destination remote memory address
- *                           to write to.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- * @param [in]  cb           Call-back function that is invoked whenever the
- *                           put operation is completed and the local buffer
- *                           can be modified. Does not guarantee remote
- *                           completion.
- *
- * @return NULL                 - The operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
- * @return otherwise            - Operation was scheduled and can be
- *                              completed at any point in time. The request handle
- *                              is returned to the application in order to track
- *                              progress of the operation. The application is
- *                              responsible for releasing the handle using
- *                              @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
-                            uint64_t remote_addr, ucp_rkey_h rkey,
-                            ucp_send_callback_t cb);
 
 
 /**
@@ -4060,81 +3442,6 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
 
 /**
  * @ingroup UCP_COMM
- * @brief Non-blocking implicit remote memory get operation.
- *
- * This routine initiate a load of contiguous block of data that is described
- * by the remote memory address @a remote_addr and the @ref ucp_rkey_h "memory handle"
- * @a rkey in the local contiguous memory region described by @a buffer
- * address. The routine returns immediately and @b does @b not guarantee that
- * remote data is loaded and stored under the local address @e buffer.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()" in order
- * guarantee that remote data is loaded and stored under the local address
- * @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local destination address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           destination address.
- * @param [in]  remote_addr  Pointer to the source remote memory address
- *                           to read from.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
-                         uint64_t remote_addr, ucp_rkey_h rkey);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking remote memory get operation.
- *
- * This routine initiates a load of a contiguous block of data that is
- * described by the remote memory address @a remote_addr and the @ref ucp_rkey_h
- * "memory handle" @a rkey in the local contiguous memory region described
- * by @a buffer address. The routine returns immediately and @b does @b not
- * guarantee that remote data is loaded and stored under the local address @e
- * buffer. If the operation is completed immediately the routine return UCS_OK,
- * otherwise UCS_INPROGRESS or an error is returned to user. If the get
- * operation completes immediately, the routine returns UCS_OK and the
- * call-back routine @a cb is @b not invoked. If the operation is @b not
- * completed immediately and no error is reported, then the UCP library will
- * schedule invocation of the call-back routine @a cb upon completion of the
- * get operation. In other words, the completion of a get operation can be
- * signaled by the return code or execution of the call-back.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
- * in order to guarantee re-usability of the source address @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local destination address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           destination address.
- * @param [in]  remote_addr  Pointer to the source remote memory address
- *                           to read from.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- * @param [in]  cb           Call-back function that is invoked whenever the
- *                           get operation is completed and the data is
- *                           visible to the local process.
- *
- * @return NULL                 - The operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
- * @return otherwise            - Operation was scheduled and can be
- *                              completed at any point in time. The request handle
- *                              is returned to the application in order to track
- *                              progress of the operation. The application is
- *                              responsible for releasing the handle using
- *                              @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
-                            uint64_t remote_addr, ucp_rkey_h rkey,
-                            ucp_send_callback_t cb);
-
-
-/**
- * @ingroup UCP_COMM
  * @brief Non-blocking remote memory get operation.
  *
  * This routine initiates a load of a contiguous block of data that is
@@ -4182,84 +3489,6 @@ ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
 ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
                              uint64_t remote_addr, ucp_rkey_h rkey,
                              const ucp_request_param_t *param);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Post an atomic memory operation.
- *
- * This routine posts an atomic memory operation to a remote value.
- * The remote value is described by the combination of the remote
- * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
- * @a rkey.
- * Return from the function does not guarantee completion. A user must
- * call @ref ucp_ep_flush_nb or @ref ucp_worker_flush_nb to guarantee that the
- * remote value has been updated.
- *
- * @param [in] ep          UCP endpoint.
- * @param [in] opcode      One of @ref ucp_atomic_post_op_t.
- * @param [in] value       Source operand for the atomic operation.
- * @param [in] op_size     Size of value in bytes
- * @param [in] remote_addr Remote address to operate on.
- * @param [in] rkey        Remote key handle for the remote memory address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_atomic_post(ucp_ep_h ep, ucp_atomic_post_op_t opcode, uint64_t value,
-                             size_t op_size, uint64_t remote_addr, ucp_rkey_h rkey);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Post an atomic fetch operation.
- *
- * This routine will post an atomic fetch operation to remote memory.
- * The remote value is described by the combination of the remote
- * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
- * @a rkey.
- * The routine is non-blocking and therefore returns immediately. However the
- * actual atomic operation may be delayed. The atomic operation is not considered complete
- * until the values in remote and local memory are completed. If the atomic operation
- * completes immediately, the routine returns UCS_OK and the call-back routine
- * @a cb is @b not invoked. If the operation is @b not completed immediately and no
- * error is reported, then the UCP library will schedule invocation of the call-back
- * routine @a cb upon completion of the atomic operation. In other words, the completion
- * of an atomic operation can be signaled by the return code or execution of the call-back.
- *
- * @note The user should not modify any part of the @a result after this
- *       operation is called, until the operation completes.
- *
- * @param [in] ep          UCP endpoint.
- * @param [in] opcode      One of @ref ucp_atomic_fetch_op_t.
- * @param [in] value       Source operand for atomic operation. In the case of CSWAP
- *                         this is the conditional for the swap. For SWAP this is
- *                         the value to be placed in remote memory.
- * @param [inout] result   Local memory address to store resulting fetch to.
- *                         In the case of CSWAP the value in result will be
- *                         swapped into the @a remote_addr if the condition
- *                         is true.
- * @param [in] op_size     Size of value in bytes and pointer type for result
- * @param [in] remote_addr Remote address to operate on.
- * @param [in] rkey        Remote key handle for the remote memory address.
- * @param [in] cb          Call-back function that is invoked whenever the
- *                         send operation is completed. It is important to note
- *                         that the call-back function is only invoked in a case when
- *                         the operation cannot be completed in place.
- *
- * @return NULL                 - The operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
- * @return otherwise            - Operation was scheduled and can be
- *                              completed at any point in time. The request handle
- *                              is returned to the application in order to track
- *                              progress of the operation. The application is
- *                              responsible for releasing the handle using
- *                              @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t
-ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
-                    uint64_t value, void *result, size_t op_size,
-                    uint64_t remote_addr, ucp_rkey_h rkey,
-                    ucp_send_callback_t cb);
 
 
 /**
@@ -4386,6 +3615,7 @@ ucs_status_t ucp_tag_recv_request_test(void *request, ucp_tag_recv_info_t *info)
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_stream_recv_request_test(void *request, size_t *length_p);
+
 
 /**
  * @ingroup UCP_COMM
@@ -4539,39 +3769,6 @@ ucs_status_t ucp_worker_fence(ucp_worker_h worker);
  * @ref ucp_worker_fence "ucp_worker_fence()"
  *
  * @param [in] worker    UCP worker.
- * @param [in] flags     Flags for flush operation. Reserved for future use.
- * @param [in] cb        Callback which will be called when the flush operation
- *                       completes.
- *
- * @return NULL             - The flush operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
- * @return otherwise        - Flush operation was scheduled and can be completed
- *                          in any point in time. The request handle is returned
- *                          to the application in order to track progress. The
- *                          application is responsible for releasing the handle
- *                          using @ref ucp_request_free "ucp_request_free()"
- *                          routine.
- */
-ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker, unsigned flags,
-                                     ucp_send_callback_t cb);
-
-
-/**
- * @ingroup UCP_WORKER
- *
- * @brief Flush outstanding AMO and RMA operations on the @ref ucp_worker_h
- * "worker"
- *
- * This routine flushes all outstanding AMO and RMA communications on the
- * @ref ucp_worker_h "worker". All the AMO and RMA operations issued on the
- * @a worker prior to this call are completed both at the origin and at the
- * target when this call returns.
- *
- * @note For description of the differences between @ref ucp_worker_flush_nb
- * "flush" and @ref ucp_worker_fence "fence" operations please see
- * @ref ucp_worker_fence "ucp_worker_fence()"
- *
- * @param [in] worker    UCP worker.
  * @param [in] param     Operation parameters, see @ref ucp_request_param_t
  *
  * @return NULL                 - The flush operation was completed immediately.
@@ -4639,8 +3836,8 @@ typedef struct ucp_ep_attr {
     struct sockaddr_storage remote_sockaddr;
 
     /**
-     * Structure defining an array containing transport and device names used 
-     * by this endpoint. The caller is responsible for allocation and 
+     * Structure defining an array containing transport and device names used
+     * by this endpoint. The caller is responsible for allocation and
      * deallocation of this array.
      */
     ucp_transports_t        transports;

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -499,6 +499,868 @@ ucs_status_t ucp_atomic_cswap64(ucp_ep_h ep, uint64_t compare, uint64_t swap,
 ucs_status_ptr_t ucp_ep_modify_nb(ucp_ep_h ep, const ucp_ep_params_t *params);
 
 
+/**
+ * @ingroup UCP_WORKER
+ * @brief Get the address of the worker object.
+ *
+ * @deprecated Use @ref ucp_worker_query with the flag
+ *             @ref UCP_WORKER_ATTR_FIELD_ADDRESS in order to obtain the worker
+ *             address.
+ *
+ * This routine returns the address of the worker object.  This address can be
+ * passed to remote instances of the UCP library in order to connect to this
+ * worker. The memory for the address handle is allocated by this function, and
+ * must be released by using @ref ucp_worker_release_address
+ * "ucp_worker_release_address()" routine.
+ *
+ * @param [in]  worker            Worker object whose address to return.
+ * @param [out] address_p         A pointer to the worker address.
+ * @param [out] address_length_p  The size in bytes of the address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
+                                    ucp_address_t **address_p,
+                                    size_t *address_length_p);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ *
+ * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
+ *
+ * @deprecated Use @ref ucp_ep_close_nbx instead.
+ *
+ * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
+ * process depends on the selected @a mode.
+ *
+ * @param [in]  ep      Handle to the endpoint to close.
+ * @param [in]  mode    One from @ref ucp_ep_close_mode value.
+ *
+ * @return UCS_OK           - The endpoint is closed successfully.
+ * @return UCS_PTR_IS_ERR(_ptr) - The closure failed and an error code indicates
+ *                                the transport level status. However, resources
+ *                                are released and the @a endpoint can no longer
+ *                                be used.
+ * @return otherwise        - The closure process is started, and can be
+ *                            completed at any point in time. A request handle
+ *                            is returned to the application in order to track
+ *                            progress of the endpoint closure. The application
+ *                            is responsible for releasing the handle using the
+ *                            @ref ucp_request_free routine.
+ *
+ * @note @ref ucp_ep_close_nb replaces deprecated @ref ucp_disconnect_nb and
+ *       @ref ucp_ep_destroy
+ */
+ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ *
+ * @brief Non-blocking flush of outstanding AMO and RMA operations on the
+ * @ref ucp_ep_h "endpoint".
+ *
+ * @deprecated Use @ref ucp_ep_flush_nbx instead.
+ *
+ * This routine flushes all outstanding AMO and RMA communications on the
+ * @ref ucp_ep_h "endpoint". All the AMO and RMA operations issued on the
+ * @a ep prior to this call are completed both at the origin and at the target
+ * @ref ucp_ep_h "endpoint" when this call returns.
+ *
+ * @param [in] ep        UCP endpoint.
+ * @param [in] flags     Flags for flush operation. Reserved for future use.
+ * @param [in] cb        Callback which will be called when the flush operation
+ *                       completes.
+ *
+ * @return NULL             - The flush operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
+ * @return otherwise        - Flush operation was scheduled and can be completed
+ *                          in any point in time. The request handle is returned
+ *                          to the application in order to track progress. The
+ *                          application is responsible for releasing the handle
+ *                          using @ref ucp_request_free "ucp_request_free()"
+ *                          routine.
+ */
+ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep, unsigned flags,
+                                 ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief Add user defined callback for Active Message.
+ *
+ * @deprecated Use @ref ucp_worker_set_am_recv_handler instead.
+ *
+ * This routine installs a user defined callback to handle incoming Active
+ * Messages with a specific id. This callback is called whenever an Active
+ * Message that was sent from the remote peer by @ref ucp_am_send_nb is
+ * received on this worker.
+ *
+ * @param [in]  worker      UCP worker on which to set the Active Message
+ *                          handler.
+ * @param [in]  id          Active Message id.
+ * @param [in]  cb          Active Message callback. NULL to clear.
+ * @param [in]  arg         Active Message argument, which will be passed
+ *                          in to every invocation of the callback as the
+ *                          arg argument.
+ * @param [in]  flags       Dictates how an Active Message is handled on the
+ *                          remote endpoint. Currently only
+ *                          UCP_AM_FLAG_WHOLE_MSG is supported, which
+ *                          indicates the callback will not be invoked
+ *                          until all data has arrived.
+ *
+ * @return error code if the worker does not support Active Messages or
+ *         requested callback flags.
+ */
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
+                                       ucp_am_callback_t cb, void *arg,
+                                       uint32_t flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Send Active Message.
+ *
+ * @deprecated Use @ref ucp_am_send_nbx instead.
+ *
+ * This routine sends an Active Message to an ep. It does not support
+ * CUDA memory.
+ *
+ * @param [in]  ep          UCP endpoint where the Active Message will be run.
+ * @param [in]  id          Active Message id. Specifies which registered
+ *                          callback to run.
+ * @param [in]  buffer      Pointer to the data to be sent to the target node
+ *                          of the Active Message.
+ * @param [in]  count       Number of elements to send.
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  cb          Callback that is invoked upon completion of the
+ *                          data transfer if it is not completed immediately.
+ * @param [in]  flags       Operation flags as defined by @ref ucp_send_am_flags.
+ *
+ * @return NULL             Active Message was sent immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message.
+ * @return otherwise        Pointer to request, and Active Message is known
+ *                          to be completed after cb is run.
+ */
+ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
+                                const void *buffer, size_t count,
+                                ucp_datatype_t datatype,
+                                ucp_send_callback_t cb, unsigned flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking stream send operation.
+ *
+ * @deprecated Use @ref ucp_stream_send_nbx instead.
+ *
+ * This routine sends data that is described by the local address @a buffer,
+ * size @a count, and @a datatype object to the destination endpoint @a ep.
+ * The routine is non-blocking and therefore returns immediately, however
+ * the actual send operation may be delayed. The send operation is considered
+ * completed when it is safe to reuse the source @e buffer. If the send
+ * operation is completed immediately the routine returns UCS_OK and the
+ * callback function @a cb is @b not invoked. If the operation is
+ * @b not completed immediately and no error reported, then the UCP library will
+ * schedule invocation of the callback @a cb upon completion of the send
+ * operation. In other words, the completion of the operation will be signaled
+ * either by the return code or by the callback.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send.
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          send operation is completed. It is important to note
+ *                          that the callback is only invoked in the event that
+ *                          the operation cannot be completed in place.
+ * @param [in]  flags       Reserved for future use.
+ *
+ * @return NULL             - The send operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
+ * @return otherwise        - Operation was scheduled for send and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the message. The application is
+ *                          responsible for releasing the handle using
+ *                          @ref ucp_request_free routine.
+ */
+ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
+                                    ucp_datatype_t datatype, ucp_send_callback_t cb,
+                                    unsigned flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking stream receive operation of structured data into a
+ *        user-supplied buffer.
+ *
+ * @deprecated Use @ref ucp_stream_recv_nbx instead.
+ *
+ * This routine receives data that is described by the local address @a buffer,
+ * size @a count, and @a datatype object on the endpoint @a ep. The routine is
+ * non-blocking and therefore returns immediately. The receive operation is
+ * considered complete when the message is delivered to the buffer. If data is
+ * not immediately available, the operation will be scheduled for receive and
+ * a request handle will be returned. In order to notify the application about
+ * completion of a scheduled receive operation, the UCP library will invoke
+ * the call-back @a cb when data is in the receive buffer and ready for
+ * application access. If the receive operation cannot be started, the routine
+ * returns an error.
+ *
+ * @param [in]     ep       UCP endpoint that is used for the receive operation.
+ * @param [in]     buffer   Pointer to the buffer to receive the data.
+ * @param [in]     count    Number of elements to receive into @a buffer.
+ * @param [in]     datatype Datatype descriptor for the elements in the buffer.
+ * @param [in]     cb       Callback function that is invoked whenever the
+ *                          receive operation is completed and the data is ready
+ *                          in the receive @a buffer. It is important to note
+ *                          that the call-back is only invoked in a case when
+ *                          the operation cannot be completed immediately.
+ * @param [out]    length   Size of the received data in bytes. The value is
+ *                          valid only if return code is UCS_OK.
+ * @note                    The amount of data received, in bytes, is always an
+ *                          integral multiple of the @a datatype size.
+ * @param [in]     flags    Flags defined in @ref ucp_stream_recv_flags_t.
+ *
+ * @return NULL                 - The receive operation was completed
+ *                                immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise            - Operation was scheduled for receive. A request
+ *                                handle is returned to the application in order
+ *                                to track progress of the operation.
+ *                                The application is responsible for releasing
+ *                                the handle by calling the
+ *                                @ref ucp_request_free routine.
+ */
+ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t count,
+                                    ucp_datatype_t datatype,
+                                    ucp_stream_recv_callback_t cb,
+                                    size_t *length, unsigned flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-send operations
+ *
+ * @deprecated Use @ref ucp_tag_send_nbx instead.
+ *
+ * This routine sends a messages that is described by the local address @a
+ * buffer, size @a count, and @a datatype object to the destination endpoint
+ * @a ep. Each message is associated with a @a tag value that is used for
+ * message matching on the @ref ucp_tag_recv_nb "receiver". The routine is
+ * non-blocking and therefore returns immediately, however the actual send
+ * operation may be delayed. The send operation is considered completed when
+ * it is safe to reuse the source @e buffer. If the send operation is
+ * completed immediately the routine return UCS_OK and the call-back function
+ * @a cb is @b not invoked. If the operation is @b not completed immediately
+ * and no error reported then the UCP library will schedule to invoke the
+ * call-back @a cb whenever the send operation will be completed. In other
+ * words, the completion of a message can be signaled by the return code or
+ * the call-back.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          send operation is completed. It is important to note
+ *                          that the call-back is only invoked in a case when
+ *                          the operation cannot be completed in place.
+ *
+ * @return NULL            - The send operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
+ * @return otherwise        - Operation was scheduled for send and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the message. The application is
+ *                          responsible for releasing the handle using
+ *                          @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
+                                 ucp_datatype_t datatype, ucp_tag_t tag,
+                                 ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-send operations with user provided request
+ *
+ * @deprecated Use @ref ucp_tag_send_nbx with the flag
+ *             @ref UCP_OP_ATTR_FIELD_REQUEST instead.
+ *
+ * This routine provides a convenient and efficient way to implement a
+ * blocking send pattern. It also completes requests faster than
+ * @ref ucp_tag_send_nb() because:
+ * @li it always uses eager protocol to send data up to the
+ *     rendezvous threshold.
+ * @li its rendezvous threshold is higher than the one used by
+ *     the @ref ucp_tag_send_nb(). The threshold is controlled by
+ *     the @b UCX_SEND_NBR_RNDV_THRESH environment variable.
+ * @li its request handling is simpler. There is no callback and no need
+ *     to allocate and free requests. In fact request can be allocated by
+ *     caller on the stack.
+ *
+ * This routine sends a messages that is described by the local address @a
+ * buffer, size @a count, and @a datatype object to the destination endpoint
+ * @a ep. Each message is associated with a @a tag value that is used for
+ * message matching on the @ref ucp_tag_recv_nbr "receiver".
+ *
+ * The routine is non-blocking and therefore returns immediately, however
+ * the actual send operation may be delayed. The send operation is considered
+ * completed when it is safe to reuse the source @e buffer. If the send
+ * operation is completed immediately the routine returns UCS_OK.
+ *
+ * If the operation is @b not completed immediately and no error reported
+ * then the UCP library will fill a user provided @a req and
+ * return UCS_INPROGRESS status. In order to monitor completion of the
+ * operation @ref ucp_request_check_status() should be used.
+ *
+ * Following pseudo code implements a blocking send function:
+ * @code
+ * MPI_send(...)
+ * {
+ *     char *request;
+ *     ucs_status_t status;
+ *
+ *     // allocate request on the stack
+ *     // ucp_context_query() was used to get ucp_request_size
+ *     request = alloca(ucp_request_size);
+ *
+ *     // note: make sure that there is enough memory before the
+ *     // request handle
+ *     status = ucp_tag_send_nbr(ep, ..., request + ucp_request_size);
+ *     if (status != UCS_INPROGRESS) {
+ *         return status;
+ *     }
+ *
+ *     do {
+ *         ucp_worker_progress(worker);
+ *         status = ucp_request_check_status(request + ucp_request_size);
+ *     } while (status == UCS_INPROGRESS);
+ *
+ *     return status;
+ * }
+ * @endcode
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag.
+ * @param [in]  req         Request handle allocated by the user. There should
+ *                          be at least UCP request size bytes of available
+ *                          space before the @a req. The size of UCP request
+ *                          can be obtained by @ref ucp_context_query function.
+ *
+ * @return UCS_OK           - The send operation was completed immediately.
+ * @return UCS_INPROGRESS   - The send was not completed and is in progress.
+ *                            @ref ucp_request_check_status() should be used to
+ *                            monitor @a req status.
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_tag_send_nbr(ucp_ep_h ep, const void *buffer, size_t count,
+                              ucp_datatype_t datatype, ucp_tag_t tag, void *req);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking synchronous tagged-send operation.
+ *
+ * @deprecated Use @ref ucp_tag_send_sync_nbx instead.
+ *
+ * Same as @ref ucp_tag_send_nb, except the request completes only after there
+ * is a remote tag match on the message (which does not always mean the remote
+ * receive has been completed). This function never completes "in-place", and
+ * always returns a request handle.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ * @note Returns @ref UCS_ERR_UNSUPPORTED if @ref UCP_ERR_HANDLING_MODE_PEER is
+ *       enabled. This is a temporary implementation-related constraint that
+ *       will be addressed in future releases.
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          send operation is completed.
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
+ * @return otherwise        - Operation was scheduled for send and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the message. The application is
+ *                          responsible for releasing the handle using
+ *                          @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t count,
+                                      ucp_datatype_t datatype, ucp_tag_t tag,
+                                      ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-receive operation.
+ *
+ * @deprecated Use @ref ucp_tag_recv_nbx instead.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, and @a datatype object on the @a worker. The tag
+ * value of the receive message has to match the @a tag and @a tag_mask values,
+ * where the @a tag_mask indicates which bits of the tag have to be matched. The
+ * routine is non-blocking and therefore returns immediately. The receive
+ * operation is considered completed when the message is delivered to the @a
+ * buffer.  In order to notify the application about completion of the receive
+ * operation the UCP library will invoke the call-back @a cb when the received
+ * message is in the receive buffer and ready for application access.  If the
+ * receive operation cannot be stated the routine returns an error.
+ *
+ * @note This routine cannot return UCS_OK. It always returns a request
+ *       handle or an error.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer to receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag to expect.
+ * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
+ *                          the matching of the incoming tag
+ *                          against the expected tag.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          receive operation is completed and the data is ready
+ *                          in the receive @a buffer.
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise          - Operation was scheduled for receive. The request
+ *                              handle is returned to the application in order
+ *                              to track progress of the operation. The
+ *                              application is responsible for releasing the
+ *                              handle using @ref ucp_request_free
+ *                              "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_recv_nb(ucp_worker_h worker, void *buffer, size_t count,
+                                 ucp_datatype_t datatype, ucp_tag_t tag,
+                                 ucp_tag_t tag_mask, ucp_tag_recv_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-receive operation.
+ *
+ * @deprecated Use @ref ucp_tag_recv_nbx with the flag
+ *             @ref UCP_OP_ATTR_FIELD_REQUEST instead.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, and @a datatype object on the @a worker. The tag
+ * value of the receive message has to match the @a tag and @a tag_mask values,
+ * where the @a tag_mask indicates which bits of the tag have to be matched. The
+ * routine is non-blocking and therefore returns immediately. The receive
+ * operation is considered completed when the message is delivered to the @a
+ * buffer. In order to monitor completion of the operation
+ * @ref ucp_request_check_status or @ref ucp_tag_recv_request_test should be
+ * used.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer to receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag to expect.
+ * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
+ *                          the matching of the incoming tag
+ *                          against the expected tag.
+ * @param [in]  req         Request handle allocated by the user. There should
+ *                          be at least UCP request size bytes of available
+ *                          space before the @a req. The size of UCP request
+ *                          can be obtained by @ref ucp_context_query function.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_tag_recv_nbr(ucp_worker_h worker, void *buffer, size_t count,
+                              ucp_datatype_t datatype, ucp_tag_t tag,
+                              ucp_tag_t tag_mask, void *req);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking receive operation for a probed message.
+ *
+ * @deprecated Use @ref ucp_tag_recv_nbx instead.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, @a message handle, and @a datatype object on the @a
+ * worker. The @a message handle can be obtained by calling the @ref
+ * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nb
+ * "ucp_tag_msg_recv_nb()" routine is non-blocking and therefore returns
+ * immediately. The receive operation is considered completed when the message
+ * is delivered to the @a buffer. In order to notify the application about
+ * completion of the receive operation the UCP library will invoke the
+ * call-back @a cb when the received message is in the receive buffer and ready
+ * for application access. If the receive operation cannot be started the
+ * routine returns an error.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer that will receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  message     Message handle.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          receive operation is completed and the data is ready
+ *                          in the receive @a buffer.
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise          - Operation was scheduled for receive. The request
+ *                              handle is returned to the application in order
+ *                              to track progress of the operation. The
+ *                              application is responsible for releasing the
+ *                              handle using @ref ucp_request_free
+ *                              "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
+                                     size_t count, ucp_datatype_t datatype,
+                                     ucp_tag_message_h message,
+                                     ucp_tag_recv_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking implicit remote memory put operation.
+ *
+ * @deprecated Use @ref ucp_put_nbx without passing the flag
+ *             @ref UCP_OP_ATTR_FIELD_CALLBACK instead. If a request pointer
+ *             is returned, release it immediately by @ref ucp_request_free.
+ *
+ * This routine initiates a storage of contiguous block of data that is
+ * described by the local address @a buffer in the remote contiguous memory
+ * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
+ * handle" @a rkey. The routine returns immediately and @b does @b not
+ * guarantee re-usability of the source address @e buffer. If the operation is
+ * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
+ * or an error is returned to user.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local source address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           source address.
+ * @param [in]  remote_addr  Pointer to the destination remote memory address
+ *                           to write to.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
+                         uint64_t remote_addr, ucp_rkey_h rkey);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking remote memory put operation.
+ *
+ * @deprecated Use @ref ucp_put_nbx instead.
+ *
+ * This routine initiates a storage of contiguous block of data that is
+ * described by the local address @a buffer in the remote contiguous memory
+ * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
+ * handle" @a rkey.  The routine returns immediately and @b does @b not
+ * guarantee re-usability of the source address @e buffer. If the operation is
+ * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
+ * or an error is returned to user. If the put operation completes immediately,
+ * the routine returns UCS_OK and the call-back routine @a cb is @b not
+ * invoked. If the operation is @b not completed immediately and no error is
+ * reported, then the UCP library will schedule invocation of the call-back
+ * routine @a cb upon completion of the put operation. In other words, the
+ * completion of a put operation can be signaled by the return code or
+ * execution of the call-back.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local source address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           source address.
+ * @param [in]  remote_addr  Pointer to the destination remote memory address
+ *                           to write to.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ * @param [in]  cb           Call-back function that is invoked whenever the
+ *                           put operation is completed and the local buffer
+ *                           can be modified. Does not guarantee remote
+ *                           completion.
+ *
+ * @return NULL                 - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
+                            uint64_t remote_addr, ucp_rkey_h rkey,
+                            ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking implicit remote memory get operation.
+ *
+ * @deprecated Use @ref ucp_get_nbx without passing the flag
+ *             @ref UCP_OP_ATTR_FIELD_CALLBACK instead. If a request pointer
+ *             is returned, release it immediately by @ref ucp_request_free.
+ *
+ * This routine initiate a load of contiguous block of data that is described
+ * by the remote memory address @a remote_addr and the @ref ucp_rkey_h "memory handle"
+ * @a rkey in the local contiguous memory region described by @a buffer
+ * address. The routine returns immediately and @b does @b not guarantee that
+ * remote data is loaded and stored under the local address @e buffer.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()" in order
+ * guarantee that remote data is loaded and stored under the local address
+ * @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local destination address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           destination address.
+ * @param [in]  remote_addr  Pointer to the source remote memory address
+ *                           to read from.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
+                         uint64_t remote_addr, ucp_rkey_h rkey);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking remote memory get operation.
+ *
+ * @deprecated Use @ref ucp_get_nbx instead.
+ *
+ * This routine initiates a load of a contiguous block of data that is
+ * described by the remote memory address @a remote_addr and the @ref ucp_rkey_h
+ * "memory handle" @a rkey in the local contiguous memory region described
+ * by @a buffer address. The routine returns immediately and @b does @b not
+ * guarantee that remote data is loaded and stored under the local address @e
+ * buffer. If the operation is completed immediately the routine return UCS_OK,
+ * otherwise UCS_INPROGRESS or an error is returned to user. If the get
+ * operation completes immediately, the routine returns UCS_OK and the
+ * call-back routine @a cb is @b not invoked. If the operation is @b not
+ * completed immediately and no error is reported, then the UCP library will
+ * schedule invocation of the call-back routine @a cb upon completion of the
+ * get operation. In other words, the completion of a get operation can be
+ * signaled by the return code or execution of the call-back.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local destination address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           destination address.
+ * @param [in]  remote_addr  Pointer to the source remote memory address
+ *                           to read from.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ * @param [in]  cb           Call-back function that is invoked whenever the
+ *                           get operation is completed and the data is
+ *                           visible to the local process.
+ *
+ * @return NULL                 - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
+                            uint64_t remote_addr, ucp_rkey_h rkey,
+                            ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Atomic operation requested for ucp_atomic_post
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx and @ref ucp_atomic_op_t instead.
+ *
+ * This enumeration defines which atomic memory operation should be
+ * performed by the ucp_atomic_post family of functions. All of these are
+ * non-fetching atomics and will not result in a request handle.
+ */
+typedef enum {
+    UCP_ATOMIC_POST_OP_ADD, /**< Atomic add */
+    UCP_ATOMIC_POST_OP_AND, /**< Atomic and */
+    UCP_ATOMIC_POST_OP_OR,  /**< Atomic or  */
+    UCP_ATOMIC_POST_OP_XOR, /**< Atomic xor */
+    UCP_ATOMIC_POST_OP_LAST
+} ucp_atomic_post_op_t;
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Post an atomic memory operation.
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx without the flag
+ *             @ref UCP_OP_ATTR_FIELD_REPLY_BUFFER instead.
+ *
+ * This routine posts an atomic memory operation to a remote value.
+ * The remote value is described by the combination of the remote
+ * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
+ * @a rkey.
+ * Return from the function does not guarantee completion. A user must
+ * call @ref ucp_ep_flush_nb or @ref ucp_worker_flush_nb to guarantee that the
+ * remote value has been updated.
+ *
+ * @param [in] ep          UCP endpoint.
+ * @param [in] opcode      One of @ref ucp_atomic_post_op_t.
+ * @param [in] value       Source operand for the atomic operation.
+ * @param [in] op_size     Size of value in bytes
+ * @param [in] remote_addr Remote address to operate on.
+ * @param [in] rkey        Remote key handle for the remote memory address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_atomic_post(ucp_ep_h ep, ucp_atomic_post_op_t opcode, uint64_t value,
+                             size_t op_size, uint64_t remote_addr, ucp_rkey_h rkey);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Atomic operation requested for ucp_atomic_fetch
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx and @ref ucp_atomic_op_t instead.
+ *
+ * This enumeration defines which atomic memory operation should be performed
+ * by the ucp_atomic_fetch family of functions. All of these functions
+ * will fetch data from the remote node.
+ */
+typedef enum {
+    UCP_ATOMIC_FETCH_OP_FADD,  /**< Atomic Fetch and add    */
+    UCP_ATOMIC_FETCH_OP_SWAP,  /**< Atomic swap             */
+    UCP_ATOMIC_FETCH_OP_CSWAP, /**< Atomic conditional swap */
+    UCP_ATOMIC_FETCH_OP_FAND,  /**< Atomic Fetch and and    */
+    UCP_ATOMIC_FETCH_OP_FOR,   /**< Atomic Fetch and or     */
+    UCP_ATOMIC_FETCH_OP_FXOR,  /**< Atomic Fetch and xor    */
+    UCP_ATOMIC_FETCH_OP_LAST
+} ucp_atomic_fetch_op_t;
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Post an atomic fetch operation.
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx with the flag
+ *             @ref UCP_OP_ATTR_FIELD_REPLY_BUFFER instead.
+ *
+ * This routine will post an atomic fetch operation to remote memory.
+ * The remote value is described by the combination of the remote
+ * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
+ * @a rkey.
+ * The routine is non-blocking and therefore returns immediately. However the
+ * actual atomic operation may be delayed. The atomic operation is not considered complete
+ * until the values in remote and local memory are completed. If the atomic operation
+ * completes immediately, the routine returns UCS_OK and the call-back routine
+ * @a cb is @b not invoked. If the operation is @b not completed immediately and no
+ * error is reported, then the UCP library will schedule invocation of the call-back
+ * routine @a cb upon completion of the atomic operation. In other words, the completion
+ * of an atomic operation can be signaled by the return code or execution of the call-back.
+ *
+ * @note The user should not modify any part of the @a result after this
+ *       operation is called, until the operation completes.
+ *
+ * @param [in] ep          UCP endpoint.
+ * @param [in] opcode      One of @ref ucp_atomic_fetch_op_t.
+ * @param [in] value       Source operand for atomic operation. In the case of CSWAP
+ *                         this is the conditional for the swap. For SWAP this is
+ *                         the value to be placed in remote memory.
+ * @param [inout] result   Local memory address to store resulting fetch to.
+ *                         In the case of CSWAP the value in result will be
+ *                         swapped into the @a remote_addr if the condition
+ *                         is true.
+ * @param [in] op_size     Size of value in bytes and pointer type for result
+ * @param [in] remote_addr Remote address to operate on.
+ * @param [in] rkey        Remote key handle for the remote memory address.
+ * @param [in] cb          Call-back function that is invoked whenever the
+ *                         send operation is completed. It is important to note
+ *                         that the call-back function is only invoked in a case when
+ *                         the operation cannot be completed in place.
+ *
+ * @return NULL                 - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t
+ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
+                    uint64_t value, void *result, size_t op_size,
+                    uint64_t remote_addr, ucp_rkey_h rkey,
+                    ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_WORKER
+ *
+ * @brief Flush outstanding AMO and RMA operations on the @ref ucp_worker_h
+ * "worker"
+ *
+ * @deprecated Use @ref ucp_worker_flush_nbx instead.
+ *
+ * This routine flushes all outstanding AMO and RMA communications on the
+ * @ref ucp_worker_h "worker". All the AMO and RMA operations issued on the
+ * @a worker prior to this call are completed both at the origin and at the
+ * target when this call returns.
+ *
+ * @note For description of the differences between @ref ucp_worker_flush_nb
+ * "flush" and @ref ucp_worker_fence "fence" operations please see
+ * @ref ucp_worker_fence "ucp_worker_fence()"
+ *
+ * @param [in] worker    UCP worker.
+ * @param [in] flags     Flags for flush operation. Reserved for future use.
+ * @param [in] cb        Callback which will be called when the flush operation
+ *                       completes.
+ *
+ * @return NULL             - The flush operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
+ * @return otherwise        - Flush operation was scheduled and can be completed
+ *                          in any point in time. The request handle is returned
+ *                          to the application in order to track progress. The
+ *                          application is responsible for releasing the handle
+ *                          using @ref ucp_request_free "ucp_request_free()"
+ *                          routine.
+ */
+ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker, unsigned flags,
+                                     ucp_send_callback_t cb);
+
+
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
## Why
- Cleanup ucp.h
- Discourage using "_nb/_nbi/_nbr" APIs when there is an "_nbx" alternative

## How
- Move deprecated APIs to ucp_compat.h
- Add a deprecation note with the recommended replacement

## Note
The APIs and their documentation were copied as-is, except adding the `@deprecated` note.