### PR TITLE
UCP/CORE: Use AM Bcopy for all ranges to not break reconfiguration

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2034,7 +2034,7 @@ static ucs_status_t ucp_ep_config_set_am_rndv_thresh(
     ucs_assert(config->key.am_lane != UCP_NULL_LANE);
     ucs_assert(config->key.lanes[config->key.am_lane].rsc_index != UCP_NULL_RESOURCE);
 
-    if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
+    if (config->thresh.rndv == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the AM rndv threshold on its own.*/
         status = ucp_ep_config_calc_rndv_thresh(worker, config,
                                                 config->key.am_bw_lanes,
@@ -2047,8 +2047,8 @@ static ucs_status_t ucp_ep_config_set_am_rndv_thresh(
         rndv_local_thresh = context->config.ext.rndv_send_nbr_thresh;
         ucs_trace("active message rendezvous threshold is %zu", rndv_thresh);
     } else {
-        rndv_thresh       = context->config.ext.rndv_thresh;
-        rndv_local_thresh = context->config.ext.rndv_thresh;
+        rndv_thresh       = config->thresh.rndv;
+        rndv_local_thresh = config->thresh.rndv;
     }
 
     min_thresh     = ucs_max(iface_attr->cap.am.min_zcopy, min_rndv_thresh);
@@ -2084,7 +2084,7 @@ ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker, ucp_ep_config_t *config,
 
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
 
-    if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
+    if (config->thresh.rndv == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the RMA (get_zcopy) rndv threshold on its own.*/
         status = ucp_ep_config_calc_rndv_thresh(worker, config,
                                                 config->key.am_bw_lanes,
@@ -2095,8 +2095,8 @@ ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker, ucp_ep_config_t *config,
 
         rndv_local_thresh = context->config.ext.rndv_send_nbr_thresh;
     } else {
-        rndv_thresh       = context->config.ext.rndv_thresh;
-        rndv_local_thresh = context->config.ext.rndv_thresh;
+        rndv_thresh       = config->thresh.rndv;
+        rndv_local_thresh = config->thresh.rndv;
     }
 
     min_thresh = ucs_max(iface_attr->cap.get.min_zcopy, min_rndv_thresh);
@@ -2206,7 +2206,8 @@ void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
 }
 
 static ssize_t
-ucp_ep_config_max_short(ucp_context_t *context, uct_iface_attr_t *iface_attr,
+ucp_ep_config_max_short(ucp_context_t *context, const ucp_ep_config_t *config,
+                        const uct_iface_attr_t *iface_attr,
                         uint64_t short_flag, size_t max_short, unsigned hdr_len,
                         size_t zcopy_thresh,
                         const ucp_rndv_thresh_t *rndv_thresh)
@@ -2219,13 +2220,17 @@ ucp_ep_config_max_short(ucp_context_t *context, uct_iface_attr_t *iface_attr,
 
     cfg_max_short = max_short - hdr_len;
 
-    if ((context->config.ext.zcopy_thresh != UCS_MEMUNITS_AUTO)) {
+    if (config->thresh.bcopy != UCS_MEMUNITS_AUTO) {
+        /* Adjust max_short if bcopy_thresh is set externally */
+        ucp_ep_config_adjust_max_short(&cfg_max_short, config->thresh.bcopy);
+    }
+
+    if (config->thresh.zcopy != UCS_MEMUNITS_AUTO) {
         /* Adjust max_short if zcopy_thresh is set externally */
         ucp_ep_config_adjust_max_short(&cfg_max_short, zcopy_thresh);
     }
 
-    if ((rndv_thresh != NULL) &&
-        (context->config.ext.rndv_thresh != UCS_MEMUNITS_AUTO)) {
+    if ((rndv_thresh != NULL) && (config->thresh.rndv != UCS_MEMUNITS_AUTO)) {
         /* Adjust max_short if rndv_thresh is set externally. Note local and
          * remote threshold values are the same if set externally, so can
          * compare with just one of them. */
@@ -2237,7 +2242,9 @@ ucp_ep_config_max_short(ucp_context_t *context, uct_iface_attr_t *iface_attr,
 }
 
 static void
-ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
+ucp_ep_config_init_attrs(ucp_worker_t *worker,
+                         const ucp_ep_config_t *ep_config,
+                         ucp_rsc_index_t rsc_index,
                          ucp_ep_msg_config_t *config, size_t max_bcopy,
                          size_t max_zcopy, size_t max_iov, size_t max_hdr,
                          uint64_t bcopy_flag, uint64_t zcopy_flag,
@@ -2270,7 +2277,7 @@ ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
     config->max_hdr   = max_hdr;
     config->max_iov   = ucs_min(UCP_MAX_IOV, max_iov);
 
-    if (context->config.ext.zcopy_thresh == UCS_MEMUNITS_AUTO) {
+    if (ep_config->thresh.zcopy == UCS_MEMUNITS_AUTO) {
         config->zcopy_auto_thresh = 1;
         mem_type_zcopy_thresh     = 1;
         for (it = 0; it < UCP_MAX_IOV; ++it) {
@@ -2285,7 +2292,7 @@ ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
     } else {
         config->zcopy_auto_thresh    = 0;
         config->sync_zcopy_thresh[0] = config->zcopy_thresh[0] =
-                ucs_min(context->config.ext.zcopy_thresh, adjust_min_val);
+                ucs_min(ep_config->thresh.zcopy, adjust_min_val);
         mem_type_zcopy_thresh        = config->zcopy_thresh[0];
     }
 
@@ -2326,7 +2333,8 @@ out:
 }
 
 ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
-                                const ucp_ep_config_key_t *key)
+                                const ucp_ep_config_key_t *key,
+                                unsigned ep_init_flags)
 {
     ucp_context_h context              = worker->context;
     ucp_lane_index_t tag_lanes[2]      = {UCP_NULL_LANE, UCP_NULL_LANE};
@@ -2350,6 +2358,23 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
     memset(config, 0, sizeof(*config));
 
+    if (context->config.ext.cm_use_all_devices &&
+        (ep_init_flags & UCP_EP_INIT_CM_PHASE)) {
+        /* Always use BCOPY protocol (which is supported by all transports) for
+         * CM initial configuration. This ensures that replaying requests
+         * submitted before connection being fully established will be done
+         * successfully after reconfiguration to other transports which may not
+         * support some protocols or limits */
+        config->thresh.bcopy = 0;
+        config->thresh.zcopy = SIZE_MAX;
+        config->thresh.rndv  = SIZE_MAX;
+        config->flags       |= UCP_EP_CONFIG_TMP;
+    } else {
+        config->thresh.bcopy = context->config.ext.bcopy_thresh;
+        config->thresh.zcopy = context->config.ext.zcopy_thresh;
+        config->thresh.rndv  = context->config.ext.rndv_thresh;
+    }
+
     status = ucp_ep_config_key_copy(&config->key, key);
     if (status != UCS_OK) {
         goto err;
@@ -2372,11 +2397,6 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     config->am.zcopy_auto_thresh        = 0;
     config->p2p_lanes                   = 0;
     config->uct_rkey_pack_flags         = 0;
-    if (context->config.ext.bcopy_thresh == UCS_MEMUNITS_AUTO) {
-        config->bcopy_thresh = 0;
-    } else {
-        config->bcopy_thresh = context->config.ext.bcopy_thresh;
-    }
     config->tag.lane                    = UCP_NULL_LANE;
     config->tag.proto                   = &ucp_tag_eager_proto;
     config->tag.sync_proto              = &ucp_tag_eager_sync_proto;
@@ -2525,7 +2545,8 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         rsc_index = config->key.lanes[lane].rsc_index;
         if (rsc_index != UCP_NULL_RESOURCE) {
             iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
-            ucp_ep_config_init_attrs(worker, rsc_index, &config->tag.eager,
+            ucp_ep_config_init_attrs(worker, config, rsc_index,
+                                     &config->tag.eager,
                                      iface_attr->cap.tag.eager.max_bcopy,
                                      iface_attr->cap.tag.eager.max_zcopy,
                                      iface_attr->cap.tag.eager.max_iov, 0,
@@ -2567,7 +2588,8 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             }
 
             config->tag.eager.max_short = ucp_ep_config_max_short(
-                    worker->context, iface_attr, UCT_IFACE_FLAG_TAG_EAGER_SHORT,
+                    worker->context, config, iface_attr,
+                    UCT_IFACE_FLAG_TAG_EAGER_SHORT,
                     iface_attr->cap.tag.eager.max_short, 0,
                     config->tag.eager.zcopy_thresh[0],
                     &config->tag.rndv.am_thresh);
@@ -2586,7 +2608,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         if (rsc_index != UCP_NULL_RESOURCE) {
             iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
             md_attr    = &context->tl_mds[config->md_index[lane]].attr;
-            ucp_ep_config_init_attrs(worker, rsc_index, &config->am,
+            ucp_ep_config_init_attrs(worker, config, rsc_index, &config->am,
                                      iface_attr->cap.am.max_bcopy,
                                      iface_attr->cap.am.max_zcopy,
                                      iface_attr->cap.am.max_iov,
@@ -2599,9 +2621,9 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
              * STREAM protocol implementations, do not adjust max_short value by
              * zcopy and rndv thresholds. */
             config->am.max_short = ucp_ep_config_max_short(
-                    worker->context, iface_attr, UCT_IFACE_FLAG_AM_SHORT,
-                    iface_attr->cap.am.max_short, sizeof(ucp_eager_hdr_t),
-                    SIZE_MAX, NULL);
+                    worker->context, config, iface_attr,
+                    UCT_IFACE_FLAG_AM_SHORT, iface_attr->cap.am.max_short,
+                    sizeof(ucp_eager_hdr_t), SIZE_MAX, NULL);
 
             /* Calculate rendezvous thresholds which may be used by UCP AM
              * protocol. */
@@ -2627,9 +2649,10 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             }
 
             am_max_eager_short = ucp_ep_config_max_short(
-                    worker->context, iface_attr, UCT_IFACE_FLAG_AM_SHORT,
-                    iface_attr->cap.am.max_short, sizeof(ucp_am_hdr_t),
-                    config->am.zcopy_thresh[0], &config->rndv.am_thresh);
+                    worker->context, config, iface_attr,
+                    UCT_IFACE_FLAG_AM_SHORT, iface_attr->cap.am.max_short,
+                    sizeof(ucp_am_hdr_t), config->am.zcopy_thresh[0],
+                    &config->rndv.am_thresh);
 
             ucp_ep_config_set_memtype_thresh(&config->am_u.max_eager_short,
                                              am_max_eager_short,
@@ -2661,8 +2684,8 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
 
             /* Calculate max short threshold for UCP AM short reply protocol */
             am_max_eager_short = ucp_ep_config_max_short(
-                    worker->context, iface_attr, UCT_IFACE_FLAG_AM_SHORT,
-                    iface_attr->cap.am.max_short,
+                    worker->context, config, iface_attr,
+                    UCT_IFACE_FLAG_AM_SHORT, iface_attr->cap.am.max_short,
                     sizeof(ucp_am_hdr_t) + sizeof(ucp_am_reply_ftr_t),
                     config->am.zcopy_thresh[0], &config->rndv.am_thresh);
 
@@ -2710,11 +2733,11 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             }
             if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_ZCOPY) {
                 rma_config->max_put_zcopy = iface_attr->cap.put.max_zcopy;
-                if (context->config.ext.zcopy_thresh == UCS_MEMUNITS_AUTO) {
+                if (config->thresh.zcopy == UCS_MEMUNITS_AUTO) {
                     /* TODO: Use calculated value for PUT Zcopy threshold */
                     rma_config->put_zcopy_thresh = 16384;
                 } else {
-                    rma_config->put_zcopy_thresh = context->config.ext.zcopy_thresh;
+                    rma_config->put_zcopy_thresh = config->thresh.zcopy;
 
                     ucp_ep_config_adjust_max_short(&rma_config->max_put_short,
                                                    rma_config->put_zcopy_thresh);
@@ -2733,10 +2756,10 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             }
             if (iface_attr->cap.flags & UCT_IFACE_FLAG_GET_ZCOPY) {
                 rma_config->max_get_zcopy = iface_attr->cap.get.max_zcopy;
-                if (context->config.ext.zcopy_thresh == UCS_MEMUNITS_AUTO) {
+                if (config->thresh.zcopy == UCS_MEMUNITS_AUTO) {
                     rma_config->get_zcopy_thresh = rma_zcopy_thresh;
                 } else {
-                    rma_config->get_zcopy_thresh = context->config.ext.zcopy_thresh;
+                    rma_config->get_zcopy_thresh = config->thresh.zcopy;
 
                     ucp_ep_config_adjust_max_short(&rma_config->max_get_short,
                                                    rma_config->get_zcopy_thresh);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -162,8 +162,13 @@ enum {
     UCP_EP_INIT_CREATE_AM_LANE_ONLY    = UCS_BIT(8),  /**< Endpoint requires an AM lane only */
     UCP_EP_INIT_KA_FROM_EXIST_LANES    = UCS_BIT(9),  /**< Use only existing lanes to create
                                                            keepalive lane */
-    UCP_EP_INIT_ALLOW_AM_AUX_TL        = UCS_BIT(10)  /**< Endpoint allows selecting of auxiliary
+    UCP_EP_INIT_ALLOW_AM_AUX_TL        = UCS_BIT(10),  /**< Endpoint allows selecting of auxiliary
                                                            transports for AM lane */
+
+    UCP_EP_INIT_CM_PHASE_CLIENT        = UCP_EP_INIT_CM_WIREUP_CLIENT |
+                                         UCP_EP_INIT_CM_PHASE,
+    UCP_EP_INIT_CM_PHASE_SERVER        = UCP_EP_INIT_CM_WIREUP_SERVER |
+                                         UCP_EP_INIT_CM_PHASE,
 };
 
 
@@ -335,7 +340,15 @@ typedef struct {
 KHASH_DECLARE(ucp_ep_peer_mem_hash, uint64_t, ucp_ep_peer_mem_data_t);
 
 
+enum {
+    UCP_EP_CONFIG_TMP = UCS_BIT(0) /* Temporal configuration (if created during
+                                    * CM phase and CM_USE_ALL_DEVICES=y) */
+};
+
+
 struct ucp_ep_config {
+    /* Flags which describe the endpoint configuration */
+    uint8_t                 flags;
 
     /* A key which uniquely defines the configuration, and all other fields of
      * configuration (in the current worker) and defined only by it.
@@ -352,9 +365,6 @@ struct ucp_ep_config {
 
     /* Configuration for each lane that provides RMA */
     ucp_ep_rma_config_t     rma[UCP_MAX_LANES];
-
-    /* Threshold for switching from put_short to put_bcopy */
-    size_t                  bcopy_thresh;
 
     /* Configuration for AM lane */
     ucp_ep_msg_config_t     am;
@@ -429,6 +439,15 @@ struct ucp_ep_config {
         /* Maximal size for eager short with reply protocol */
         ucp_memtype_thresh_t             max_reply_eager_short;
     } am_u;
+
+    struct {
+        /* Threshold for switching from SHORT to BCOPY */
+        size_t bcopy;
+        /* Threshold for switching from BCOPY to ZCOPY */
+        size_t zcopy;
+        /* Threshold for switching from ZCOPY to RNDV */
+        size_t rndv;
+    } thresh;
 
     /* Protocol selection data */
     ucp_proto_select_t            proto_select;
@@ -680,7 +699,8 @@ void ucp_ep_unprogress_uct_ep(ucp_ep_h ep, uct_ep_h uct_ep,
 void ucp_ep_cleanup_lanes(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
-                                const ucp_ep_config_key_t *key);
+                                const ucp_ep_config_key_t *key,
+                                unsigned ep_init_flags);
 
 void ucp_ep_config_cleanup(ucp_worker_h worker, ucp_ep_config_t *config);
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1976,7 +1976,9 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
     /* Search for the given key in the ep_config array */
     for (ep_cfg_index = 0; ep_cfg_index < worker->ep_config_count;
          ++ep_cfg_index) {
-        if (ucp_ep_config_is_equal(&worker->ep_config[ep_cfg_index].key, key)) {
+        ep_config = &worker->ep_config[ep_cfg_index];
+        if (!(ep_config->flags & UCP_EP_CONFIG_TMP) &&
+            ucp_ep_config_is_equal(&ep_config->key, key)) {
             goto out;
         }
     }
@@ -1990,7 +1992,7 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
     /* Create new configuration */
     ep_cfg_index = worker->ep_config_count;
     ep_config    = &worker->ep_config[ep_cfg_index];
-    status       = ucp_ep_config_init(worker, ep_config, key);
+    status       = ucp_ep_config_init(worker, ep_config, key, ep_init_flags);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -28,9 +28,7 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
     ucs_assert(rkey->cache.ep_cfg_index == ep->cfg_index);
     ucs_assert(rkey->cache.rma_lane == lane);
 
-    if (((ssize_t)req->send.length <= rma_config->max_put_short) ||
-        (req->send.length <= ucp_ep_config(ep)->bcopy_thresh))
-    {
+    if ((ssize_t)req->send.length <= rma_config->max_put_short) {
         packed_len = ucs_min((ssize_t)req->send.length, rma_config->max_put_short);
         status     = UCS_PROFILE_CALL(uct_ep_put_short, ucp_ep_get_lane(ep, lane),
                                       req->send.buffer, packed_len,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -44,10 +44,10 @@ unsigned
 ucp_cm_ep_init_flags(const ucp_ep_params_t *params)
 {
     if (params->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR) {
-        return UCP_EP_INIT_CM_WIREUP_CLIENT | UCP_EP_INIT_CM_PHASE;
+        return UCP_EP_INIT_CM_PHASE_CLIENT;
     }
     if (params->field_mask & UCP_EP_PARAM_FIELD_CONN_REQUEST) {
-        return UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
+        return UCP_EP_INIT_CM_PHASE_SERVER;
     }
 
     return 0;
@@ -451,7 +451,7 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
     UCS_STATIC_ASSERT(ucs_static_array_size(ep_init_flags_prio) > 0);
 
     for (i = 0; i < ucs_static_array_size(ep_init_flags_prio); ++i) {
-        ep_init_flags = ep_init_flags_prio[i];
+        ep_init_flags = UCP_EP_INIT_CM_PHASE_CLIENT | ep_init_flags_prio[i];
 
         /* Cleanup the previously created UCP EP. The one that was created on
          * the previous call to this client's resolve_cb */
@@ -1212,7 +1212,7 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
     ucp_wireup_sockaddr_data_base_t *sa_data;
     ucp_object_version_t sa_data_version;
 
-    ep_init_flags |= UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
+    ep_init_flags |= UCP_EP_INIT_CM_PHASE_SERVER;
 
     ucp_context_dev_tl_bitmap(worker->context, conn_request->dev_name,
                               &tl_bitmap);

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2148,6 +2148,13 @@ UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_with_rma_atomic)
 
 class test_ucp_sockaddr_protocols : public test_ucp_sockaddr {
 public:
+    test_ucp_sockaddr_protocols()
+    {
+        /* To allow selecting MM transports when testing shm_ib/shm_tcp
+         * variants */
+        m_env.push_back(new ucs::scoped_setenv("UCX_MM_ERROR_HANDLING", "y"));
+    }
+
     virtual ~test_ucp_sockaddr_protocols() { }
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
@@ -2156,9 +2163,8 @@ public:
          * worker for atomic operations */
         uint64_t features = UCP_FEATURE_TAG | UCP_FEATURE_STREAM |
                             UCP_FEATURE_RMA | UCP_FEATURE_AM;
-
-        add_variant_with_value(variants, features, TEST_MODIFIER_MT,
-                               "mt", MULTI_THREAD_WORKER);
+        test_ucp_sockaddr::get_test_variants_cm_mode(variants, features,
+                                                     0, "all_features");
     }
 
     virtual void init() {
@@ -2666,8 +2672,9 @@ UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_64k, "RNDV_THRESH=0")
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, udx, "ud_x") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rc, "rc_v") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rcx, "rc_x") \
-    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ib, "ib") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib, "shm,ib") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, tcp, "tcp") \
+    UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_tcp, "shm,tcp") \
     UCP_INSTANTIATE_TEST_CASE_TLS(_test_case, all, "all")
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols)


### PR DESCRIPTION
## What

Use AM Bcopy for all ranges to not break reconfiguration.

## Why ?

Fixes #8180.

## How ?

1. If CM_USE_ALL_DEVICES=y and initializing EP configuration during CM phase, set `bcopy_thresh = 0`, `zcopy_thresh = SIZE_MAX`, `rndv_thresh = SIZE_MAX`.
2. Save thresholds to EP configuration.
3. Take into account `bcopy_thresh` when setting `max_short` (currently, we use only `zcopy_thresh` and `rndv_thresh`).