### PR TITLE
UCP/UCT/UD: Reduce error detection time

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -397,7 +397,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_config_t, ctx.proto_enable), UCS_CONFIG_TYPE_BOOL},
 
-  {"KEEPALIVE_INTERVAL", "20s",
+  {"KEEPALIVE_INTERVAL", "10s",
    "Time interval between keepalive rounds. Must be non-zero value.",
    ucs_offsetof(ucp_config_t, ctx.keepalive_interval),
    UCS_CONFIG_TYPE_TIME_UNITS},

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -149,6 +149,7 @@ enum {
  */
 typedef struct uct_ud_send_skb {
     ucs_queue_elem_t        queue;      /* in send window */
+    ucs_time_t              send_time;  /* time of sending */
     uint32_t                lkey;
     uint16_t                len;        /* data size */
     uint16_t                flags;

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -339,7 +339,7 @@ ucs_status_t uct_ud_iface_complete_init(uct_ud_iface_t *iface)
                         UCT_UD_IFACE_CEP_CONN_SN_MAX, &conn_match_ops);
 
     status = ucs_twheel_init(&iface->tx.timer, iface->tx.tick / 4,
-                             uct_ud_iface_get_time(iface));
+                             ucs_get_time());
     if (status != UCS_OK) {
         goto err;
     }
@@ -665,7 +665,7 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
      "Keep the connection open internally for this amount of time after closing it",
      ucs_offsetof(uct_ud_iface_config_t, linger_timeout), UCS_CONFIG_TYPE_TIME},
 
-    {"TIMEOUT", "30s",
+    {"TIMEOUT", "20s",
      "Consider the remote peer as unreachable if an acknowledgment was not received\n"
      "after this amount of time",
      ucs_offsetof(uct_ud_iface_config_t, peer_timeout), UCS_CONFIG_TYPE_TIME},

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -445,21 +445,6 @@ uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present,
 }
 
 
-/* get time of the last async wakeup */
-static UCS_F_ALWAYS_INLINE ucs_time_t
-uct_ud_iface_get_async_time(uct_ud_iface_t *iface)
-{
-    return iface->super.super.worker->async->last_wakeup;
-}
-
-
-static UCS_F_ALWAYS_INLINE ucs_time_t
-uct_ud_iface_get_time(uct_ud_iface_t *iface)
-{
-    return ucs_get_time();
-}
-
-
 static UCS_F_ALWAYS_INLINE void
 uct_ud_iface_twheel_sweep(uct_ud_iface_t *iface)
 {
@@ -471,7 +456,7 @@ uct_ud_iface_twheel_sweep(uct_ud_iface_t *iface)
         return;
     }
 
-    ucs_twheel_sweep(&iface->tx.timer, uct_ud_iface_get_time(iface));
+    ucs_twheel_sweep(&iface->tx.timer, ucs_get_time());
 }
 
 


### PR DESCRIPTION
## What

1. Reduce error detection time by setting `UCX_KEEPALIVE_INTERVAL=10s` and `UCX_UD_PEER_TIMEOUT=20s`.
2. Compare current time and time of last unacked SKB in TX window to check whether peer is unreachable or not.

## Why ?

1. To meet requirement of detecting an error wihtin 1 minute time limit.
It fixes the following case:
`1651857404` - switch port off
`1651857406` - [client] IO-demo traffic
`1651857406` - [client] did EP_CHECK on UD
`1651857424` - switch port on
<EP_CHECK was acked>
`1651857426` - [client] did EP_CHECK on UD
<EP_CHECK was acked>
`1651857427` - [server] detected error on RC (Retry count exceeded), server EP was destroyed
`1651857446` - [client] did EP_CHECK on UD
`1651857446` - [client] did EP_CHECK on UD
`1651857466` - [client] timeout waiting for replies after 1 minute
2. Using EP's `send_time` isn't correct, since the error could be not detected at all, if doing send operations every `[0..peer_timeout)` seconds.

## How ?

1. Set `UCX_KEEPALIVE_INTERVAL=10s` (instead of `20s`) and `UCX_UD_PEER_TIMEOUT=20s` (instead of `30s`, it aligns with RC/DC which detect an error in `~21s`).
2. To use SKB's `send_time` instead of EP's `send_time` do the following things:
- Remove unneeded code.
- Add `send_time` field to SKB.
- Set `ucs_get_time()` to SKB's `send_time` every time operation is done.
- Compare SKB's `send_time` and current time in `uct_ud_ep_timer` to check whether peer is unreachable or not.