### PR TITLE
UCT/IB/UD: Remove unused functions for getting time

### DIFF
--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -721,7 +721,7 @@ uct_ud_ep_process_ack(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     ucs_arbiter_group_schedule(&iface->tx.pending_q, &ep->tx.pending.group);
 
     ep->tx.tick      = iface->tx.tick;
-    ep->tx.send_time = uct_ud_iface_get_time(iface);
+    ep->tx.send_time = ucs_get_time();
 }
 
 static inline void uct_ud_ep_rx_put(uct_ud_neth_t *neth, unsigned byte_len)
@@ -1363,7 +1363,7 @@ static void uct_ud_ep_resend(uct_ud_ep_t *ep)
     skb->flags         = UCT_UD_SEND_SKB_FLAG_CTL_RESEND;
     sent_skb->flags   |= UCT_UD_SEND_SKB_FLAG_RESENDING;
     ep->resend.psn     = sent_skb->neth->psn;
-    ep->tx.resend_time = uct_ud_iface_get_time(iface);
+    ep->tx.resend_time = ucs_get_time();
 
     if (sent_skb->flags & UCT_UD_SEND_SKB_FLAG_ZCOPY) {
         /* copy neth + am header part */

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -339,7 +339,7 @@ ucs_status_t uct_ud_iface_complete_init(uct_ud_iface_t *iface)
                         UCT_UD_IFACE_CEP_CONN_SN_MAX, &conn_match_ops);
 
     status = ucs_twheel_init(&iface->tx.timer, iface->tx.tick / 4,
-                             uct_ud_iface_get_time(iface));
+                             ucs_get_time());
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -445,21 +445,6 @@ uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present,
 }
 
 
-/* get time of the last async wakeup */
-static UCS_F_ALWAYS_INLINE ucs_time_t
-uct_ud_iface_get_async_time(uct_ud_iface_t *iface)
-{
-    return iface->super.super.worker->async->last_wakeup;
-}
-
-
-static UCS_F_ALWAYS_INLINE ucs_time_t
-uct_ud_iface_get_time(uct_ud_iface_t *iface)
-{
-    return ucs_get_time();
-}
-
-
 static UCS_F_ALWAYS_INLINE void
 uct_ud_iface_twheel_sweep(uct_ud_iface_t *iface)
 {
@@ -471,7 +456,7 @@ uct_ud_iface_twheel_sweep(uct_ud_iface_t *iface)
         return;
     }
 
-    ucs_twheel_sweep(&iface->tx.timer, uct_ud_iface_get_time(iface));
+    ucs_twheel_sweep(&iface->tx.timer, ucs_get_time());
 }
 
 

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -158,8 +158,9 @@ static UCS_F_ALWAYS_INLINE void
 uct_ud_iface_complete_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
                              uct_ud_send_skb_t *skb)
 {
-    ucs_time_t now = uct_ud_iface_get_time(iface);
-    iface->tx.skb  = ucs_mpool_get(&iface->tx.mp);
+    ucs_time_t now = ucs_get_time();
+
+    iface->tx.skb = ucs_mpool_get(&iface->tx.mp);
     ep->tx.psn++;
 
     ucs_queue_push(&ep->tx.window, &skb->queue);


### PR DESCRIPTION
## What

Remove unused functions for getting time.

## Why ?

`uct_ud_iface_get_async_time` isn't used
`uct_ud_iface_get_time` can be removed and replaced by calling `ucs_get_time` directly.

## How ?

1. Replace `uct_ud_iface_get_time` by `ucs_get_time`.
2. Remove `uct_ud_iface_get_async_time`.