### PR TITLE
UCT/IB/RC: Fix always having STATUS flag in iface send op

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -470,9 +470,6 @@ void uct_rc_txqp_purge_outstanding(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
 
     ucs_queue_for_each_extract(op, &txqp->outstanding, queue,
                                UCS_CIRCULAR_COMPARE16(op->sn, <=, sn)) {
-        op->status = status;
-        op->flags |= UCT_RC_IFACE_SEND_OP_STATUS;
-
         if (op->handler != (uct_rc_send_handler_t)ucs_mpool_put) {
             /* Allow clean flush cancel op from destroy flow */
             if (warn &&
@@ -520,6 +517,8 @@ void uct_rc_txqp_purge_outstanding(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp,
             desc = ucs_derived_of(op, uct_rc_iface_send_desc_t);
             ucs_mpool_put(desc);
         } else {
+            op->status = status;
+            op->flags |= UCT_RC_IFACE_SEND_OP_STATUS;
             op->handler(op, NULL);
         }
     }

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -494,8 +494,8 @@ uct_rc_iface_add_cq_credits(uct_rc_iface_t *iface, uint16_t cq_credits)
 static UCS_F_ALWAYS_INLINE uct_rc_iface_send_op_t*
 uct_rc_iface_get_send_op(uct_rc_iface_t *iface)
 {
-    uct_rc_iface_send_op_t *op;
-    op = iface->tx.free_ops;
+    uct_rc_iface_send_op_t *op = iface->tx.free_ops;
+
     iface->tx.free_ops = op->next;
     return op;
 }
@@ -505,7 +505,8 @@ uct_rc_iface_put_send_op(uct_rc_iface_send_op_t *op)
 {
     uct_rc_iface_t *iface = op->iface;
 
-    ucs_assert(op->flags & UCT_RC_IFACE_SEND_OP_FLAG_IFACE);
+    ucs_assertv(op->flags == UCT_RC_IFACE_SEND_OP_FLAG_IFACE,
+                "op %p flags 0x%x", op, op->flags);
 
     op->next = iface->tx.free_ops;
     iface->tx.free_ops = op;


### PR DESCRIPTION
## What

Fix always having STATUS flag in IFACE send ops.

## Why ?

Send ops which belong to IFACE must have only `UCT_RC_IFACE_SEND_OP_FLAG_IFACE` flag set when kept in the free list.

## How ?

1. Move setting status and `UCT_RC_IFACE_SEND_OP_STATUS` flag to the place where we're calling `op`'s `handler` (only there the status could be read).
2. Add `assert`s to make sure only `UCT_RC_IFACE_SEND_OP_FLAG_IFACE` is set when doing put/get for IFACE send ops.