### PR TITLE
UCT/IB/UD: Add "available credits" data to UD iface vfs node

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -772,7 +772,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .super = {
         .super = {
             .iface_estimate_perf = uct_ib_iface_estimate_perf,
-            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
             .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate       = uct_ud_ep_invalidate
         },
@@ -866,7 +866,8 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
         return status;
     }
 
-    self->super.tx.available = self->tx.wq.bb_max;
+    self->super.tx.available     = self->tx.wq.bb_max;
+    self->super.config.tx_qp_len = self->tx.wq.bb_max;
     ucs_assert(init_attr.cq_len[UCT_IB_DIR_TX] >= self->tx.wq.bb_max);
 
     status = uct_ib_mlx5_get_rxwq(self->super.qp, &self->rx.wq);

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -18,6 +18,8 @@
 #include <ucs/debug/log.h>
 #include <ucs/type/class.h>
 #include <ucs/datastruct/queue.h>
+#include <ucs/vfs/base/vfs_obj.h>
+#include <ucs/vfs/base/vfs_cb.h>
 #include <sys/poll.h>
 
 
@@ -493,6 +495,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
 
     self->rx.available          = config->super.rx.queue_len;
     self->rx.quota              = 0;
+    self->config.rx_qp_len      = config->super.rx.queue_len;
     self->config.tx_qp_len      = config->super.tx.queue_len;
     self->config.min_poke_time  = ucs_time_from_sec(config->min_poke_time);
     self->config.check_grh_dgid = config->dgid_check &&
@@ -1039,6 +1042,27 @@ void uct_ud_iface_progress_disable(uct_iface_h tl_iface, unsigned flags)
     uct_ud_leave(iface);
 
     uct_base_iface_progress_disable(tl_iface, flags);
+}
+
+void uct_ud_iface_vfs_refresh(uct_iface_h iface)
+{
+    uct_ud_iface_t *ud_iface = ucs_derived_of(iface, uct_ud_iface_t);
+
+    ucs_vfs_obj_add_ro_file(ud_iface, ucs_vfs_show_primitive,
+                            &ud_iface->rx.available, UCS_VFS_TYPE_INT,
+                            "rx_available");
+
+    ucs_vfs_obj_add_ro_file(ud_iface, ucs_vfs_show_primitive,
+                            &ud_iface->tx.available, UCS_VFS_TYPE_SHORT,
+                            "tx_available");
+
+    ucs_vfs_obj_add_ro_file(ud_iface, ucs_vfs_show_primitive,
+                            &ud_iface->config.rx_qp_len, UCS_VFS_TYPE_INT,
+                            "rx_qp_len");
+
+    ucs_vfs_obj_add_ro_file(ud_iface, ucs_vfs_show_primitive,
+                            &ud_iface->config.tx_qp_len, UCS_VFS_TYPE_INT,
+                            "tx_qp_len");
 }
 
 void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -187,6 +187,7 @@ struct uct_ud_iface {
         ucs_time_t           peer_timeout;
         ucs_time_t           min_poke_time;
         unsigned             tx_qp_len;
+        unsigned             rx_qp_len;
         unsigned             max_inline;
         int                  check_grh_dgid;
         unsigned             max_window;
@@ -347,6 +348,8 @@ void uct_ud_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
 
 void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
                                    uct_ud_ctl_desc_t *cdesc, int is_async);
+
+void uct_ud_iface_vfs_refresh(uct_iface_h iface);
 
 void uct_ud_iface_send_completion(uct_ud_iface_t *iface, uint16_t sn,
                                   int is_async);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -554,7 +554,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .super = {
         .super = {
             .iface_estimate_perf = uct_ib_iface_estimate_perf,
-            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
             .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate       = uct_ud_ep_invalidate
         },


### PR DESCRIPTION
## What
Two new files were added to UD interface vfs node ("tx/available credits" and "rx/available credits"), which mirrors the current value of 
`uct_ud_iface_t->tx.available` and `uct_ud_iface_t->rx.available`.

## Why ?
Better debugging issues related to UD transport.
