### PR TITLE
UCP/CONTEXT/CONFIG: Use ucs_config_parser_clone_opts for copying config

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -139,6 +139,8 @@ typedef struct ucp_context_config {
     ucp_object_version_t                   worker_addr_version;
     /** Print protocols information */
     int                                    proto_info;
+    /** MD to compare for transport selection scores */
+    char                                   *select_distance_md;
 } ucp_context_config_t;
 
 
@@ -164,18 +166,16 @@ struct ucp_config {
     UCS_CONFIG_STRING_ARRAY_FIELD(cm_tls)  sockaddr_cm_tls;
     /** Warn on invalid configuration */
     int                                    warn_invalid_config;
-    /** This config environment prefix */
-    char                                   *env_prefix;
-    /** MD to compare for transport selection scores */
-    char                                   *selection_cmp;
-    /** Configuration saved directly in the context */
-    ucp_context_config_t                   ctx;
-    /** Save ucx configurations not listed in ucp_config_table **/
-    ucs_list_link_t                        cached_key_list;
     /** Array of worker memory pool sizes */
     UCS_CONFIG_ARRAY_FIELD(size_t, memunits) mpool_sizes;
     /** Memory registration cache */
     ucs_ternary_auto_value_t               enable_rcache;
+    /** Configuration saved directly in the context */
+    ucp_context_config_t                   ctx;
+    /** Save ucx configurations not listed in ucp_config_table **/
+    ucs_list_link_t                        cached_key_list;
+    /** This config environment prefix */
+    char                                   *env_prefix;
 };
 
 
@@ -318,8 +318,6 @@ typedef struct ucp_context {
         /* Config environment prefix used to create the context */
         char                      *env_prefix;
 
-        /* MD to compare for transport selection scores */
-        char                      *selection_cmp;
         struct {
            unsigned               count;
            size_t                 *sizes;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1171,7 +1171,7 @@ ucp_worker_get_sys_device_distance(ucp_context_h context,
     for (i = 0; i < context->num_tls; i++) {
         md_index = context->tl_rscs[i].md_index;
         if (strcmp(context->tl_mds[md_index].rsc.md_name,
-                   context->config.selection_cmp)) {
+                   context->config.ext.select_distance_md)) {
             continue;
         }
 


### PR DESCRIPTION
## Why
While adding new string configuration to ucp_context_config_t (proto_info_dir), it turned out we need to strdup() it manually. But a better method is to use ucs_config_parser_clone_opts().