### PR TITLE
UCT/IB/DC: Reopen IFACE if per DCI CQ length is less than bb_max

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -371,18 +371,18 @@ typedef struct uct_iface_local_addr_ns {
  * @param _component      Component to add the transport to
  * @param _name           Name of the transport (should be a token, not a string)
  * @param _query_devices  Function to query the list of available devices
- * @param _iface_class    Struct type defining the uct_iface class
+ * @param _iface_open     Function to open iface
  * @param _cfg_prefix     Prefix for configuration variables
  * @param _cfg_table      Transport configuration table
  * @param _cfg_struct     Struct type defining transport configuration
  */
-#define UCT_TL_DEFINE(_component, _name, _query_devices, _iface_class, \
+#define UCT_TL_DEFINE(_component, _name, _query_devices, _iface_open, \
                       _cfg_prefix, _cfg_table, _cfg_struct) \
     \
     uct_tl_t uct_##_name##_tl = { \
         .name               = #_name, \
         .query_devices      = _query_devices, \
-        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
+        .iface_open         = _iface_open, \
         .config = { \
             .name           = #_name" transport", \
             .prefix         = _cfg_prefix, \
@@ -458,18 +458,18 @@ typedef struct uct_iface_local_addr_ns {
  * @param _component      Component to add the transport to
  * @param _name           Name of the transport (should be a token, not a string)
  * @param _query_devices  Function to query the list of available devices
- * @param _iface_class    Struct type defining the uct_iface class
+ * @param _iface_open     Function to open iface
  * @param _cfg_prefix     Prefix for configuration variables
  * @param _cfg_table      Transport configuration table
  * @param _cfg_struct     Struct type defining transport configuration
  */
-#define UCT_TL_DEFINE_ENTRY(_component, _name, _query_devices, _iface_class, \
+#define UCT_TL_DEFINE_ENTRY(_component, _name, _query_devices, _iface_open, \
                             _cfg_prefix, _cfg_table, _cfg_struct) \
     \
     uct_tl_t UCT_TL_NAME(_name) = { \
         .name               = #_name, \
         .query_devices      = _query_devices, \
-        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
+        .iface_open         = _iface_open, \
         .config = { \
             .name           = #_name" transport", \
             .prefix         = _cfg_prefix, \

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -488,5 +488,5 @@ static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_copy_iface_t, uct_iface_t);
 
 
 UCT_TL_DEFINE(&uct_cuda_copy_component, cuda_copy, uct_cuda_base_query_devices,
-              uct_cuda_copy_iface_t, "CUDA_COPY_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_cuda_copy_iface_t), "CUDA_COPY_",
               uct_cuda_copy_iface_config_table, uct_cuda_copy_iface_config_t);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -567,5 +567,6 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_cuda_ipc_iface_t, uct_iface_t, uct_md_h, uct_worke
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_ipc_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE(&uct_cuda_ipc_component.super, cuda_ipc,
-              uct_cuda_ipc_query_devices, uct_cuda_ipc_iface_t, "CUDA_IPC_",
+              uct_cuda_ipc_query_devices,
+              UCS_CLASS_NEW_FUNC_NAME(uct_cuda_ipc_iface_t), "CUDA_IPC_",
               uct_cuda_ipc_iface_config_table, uct_cuda_ipc_iface_config_t);

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -206,5 +206,5 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_gdr_copy_iface_t, uct_iface_t, uct_md_h, uct_worke
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_gdr_copy_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE(&uct_gdr_copy_component, gdr_copy, uct_cuda_base_query_devices,
-              uct_gdr_copy_iface_t, "GDR_COPY_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_gdr_copy_iface_t), "GDR_COPY_",
               uct_gdr_copy_iface_config_table, uct_gdr_copy_iface_config_t);

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -991,5 +991,5 @@ uct_rc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
 }
 
 UCT_TL_DEFINE_ENTRY(&uct_ib_component, rc_mlx5, uct_rc_mlx5_query_tl_devices,
-                    uct_rc_mlx5_iface_t, "RC_MLX5_",
+                    UCS_CLASS_NEW_FUNC_NAME(uct_rc_mlx5_iface_t), "RC_MLX5_",
                     uct_rc_mlx5_iface_config_table, uct_rc_mlx5_iface_config_t);

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -581,6 +581,6 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
 }
 
 UCT_TL_DEFINE_ENTRY(&uct_ib_component, rc_verbs, uct_rc_verbs_query_tl_devices,
-                    uct_rc_verbs_iface_t, "RC_VERBS_",
+                    UCS_CLASS_NEW_FUNC_NAME(uct_rc_verbs_iface_t), "RC_VERBS_",
                     uct_rc_verbs_iface_config_table,
                     uct_rc_verbs_iface_config_t);

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -926,5 +926,5 @@ uct_ud_mlx5_query_tl_devices(uct_md_h md,
 }
 
 UCT_TL_DEFINE_ENTRY(&uct_ib_component, ud_mlx5, uct_ud_mlx5_query_tl_devices,
-                    uct_ud_mlx5_iface_t, "UD_MLX5_",
+                    UCS_CLASS_NEW_FUNC_NAME(uct_ud_mlx5_iface_t), "UD_MLX5_",
                     uct_ud_mlx5_iface_config_table, uct_ud_mlx5_iface_config_t);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -740,5 +740,5 @@ uct_ud_verbs_query_tl_devices(uct_md_h md,
 }
 
 UCT_TL_DEFINE_ENTRY(&uct_ib_component, ud_verbs, uct_ud_verbs_query_tl_devices,
-                    uct_ud_verbs_iface_t, "UD_VERBS_",
+                    UCS_CLASS_NEW_FUNC_NAME(uct_ud_verbs_iface_t), "UD_VERBS_",
                     uct_ud_verbs_iface_config_table, uct_ud_iface_config_t);

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -169,6 +169,6 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_copy_iface_t, uct_iface_t, uct_md_h, uct_work
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_copy_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE(&uct_rocm_copy_component, rocm_copy,
-              uct_rocm_base_query_devices, uct_rocm_copy_iface_t,
-              "ROCM_COPY_", uct_rocm_copy_iface_config_table,
-              uct_rocm_copy_iface_config_t);
+              uct_rocm_base_query_devices,
+              UCS_CLASS_NEW_FUNC_NAME(uct_rocm_copy_iface_t), "ROCM_COPY_",
+              uct_rocm_copy_iface_config_table, uct_rocm_copy_iface_config_t);

--- a/src/uct/rocm/gdr/rocm_gdr_iface.c
+++ b/src/uct/rocm/gdr/rocm_gdr_iface.c
@@ -143,5 +143,5 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_gdr_iface_t, uct_iface_t, uct_md_h, uct_worke
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_gdr_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE(&uct_rocm_gdr_component, rocm_gdr, uct_rocm_base_query_devices,
-              uct_rocm_gdr_iface_t, "ROCM_GDR_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_rocm_gdr_iface_t), "ROCM_GDR_",
               uct_rocm_gdr_iface_config_table, uct_rocm_gdr_iface_config_t);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -256,5 +256,5 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rocm_ipc_iface_t, uct_iface_t, uct_md_h,
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_ipc_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE(&uct_rocm_ipc_component, rocm_ipc, uct_rocm_base_query_devices,
-              uct_rocm_ipc_iface_t, "ROCM_IPC_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_rocm_ipc_iface_t), "ROCM_IPC_",
               uct_rocm_ipc_iface_config_table, uct_rocm_ipc_iface_config_t);

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -239,8 +239,9 @@ typedef struct uct_mm_iface {
     UCT_MM_COMPONENT_DEFINE(_name, _md_ops, _rkey_unpack, _rkey_release, \
                             _cfg_prefix) \
     UCT_TL_DEFINE_ENTRY(&UCT_COMPONENT_NAME(_name).super, _name, \
-                        uct_sm_base_query_tl_devices, uct_mm_iface_t, \
-                        _cfg_prefix, _cfg_table, uct_mm_iface_config_t)
+                        uct_sm_base_query_tl_devices, \
+                        UCS_CLASS_NEW_FUNC_NAME(uct_mm_iface_t), _cfg_prefix, \
+                        _cfg_table, uct_mm_iface_config_t)
 
 
 extern ucs_config_field_t uct_mm_iface_config_table[];

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -146,7 +146,7 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_cma_iface_t, uct_iface_t, uct_md_h,
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_cma_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE_ENTRY(&uct_cma_component, cma, uct_sm_base_query_tl_devices,
-                    uct_cma_iface_t, "CMA_", uct_cma_iface_config_table,
-                    uct_cma_iface_config_t);
+                    UCS_CLASS_NEW_FUNC_NAME(uct_cma_iface_t), "CMA_",
+                    uct_cma_iface_config_table, uct_cma_iface_config_t);
 
 UCT_SINGLE_TL_INIT(&uct_cma_component, cma, ctor,,)

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -98,7 +98,7 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_knem_iface_t, uct_iface_t, uct_md_h,
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
 UCT_TL_DEFINE_ENTRY(&uct_knem_component, knem, uct_sm_base_query_tl_devices,
-                    uct_knem_iface_t, "KNEM_", uct_knem_iface_config_table,
-                    uct_knem_iface_config_t);
+                    UCS_CLASS_NEW_FUNC_NAME(uct_knem_iface_t), "KNEM_",
+                    uct_knem_iface_config_table, uct_knem_iface_config_t);
 
 UCT_SINGLE_TL_INIT(&uct_knem_component, knem, ctor,,)

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -477,7 +477,7 @@ static uct_component_t uct_self_component = {
 };
 
 UCT_TL_DEFINE_ENTRY(&uct_self_component, self, uct_self_query_tl_devices,
-                    uct_self_iface_t, "SELF_", uct_self_iface_config_table,
-                    uct_self_iface_config_t);
+                    UCS_CLASS_NEW_FUNC_NAME(uct_self_iface_t), "SELF_",
+                    uct_self_iface_config_table, uct_self_iface_config_t);
 
 UCT_SINGLE_TL_INIT(&uct_self_component, self,,,)

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -944,7 +944,8 @@ int uct_tcp_keepalive_is_enabled(uct_tcp_iface_t *iface)
 }
 
 UCT_TL_DEFINE_ENTRY(&uct_tcp_component, tcp, uct_tcp_query_devices,
-                    uct_tcp_iface_t, UCT_TCP_CONFIG_PREFIX,
-                    uct_tcp_iface_config_table, uct_tcp_iface_config_t);
+                    UCS_CLASS_NEW_FUNC_NAME(uct_tcp_iface_t),
+                    UCT_TCP_CONFIG_PREFIX, uct_tcp_iface_config_table,
+                    uct_tcp_iface_config_t);
 
 UCT_SINGLE_TL_INIT(&uct_tcp_component, tcp,,,)

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -377,5 +377,5 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_rdma_iface_t, uct_iface_t, uct_md_h,
                           const uct_iface_config_t*);
 
 UCT_TL_DEFINE(&uct_ugni_component, ugni_rdma, uct_ugni_query_devices,
-              uct_ugni_rdma_iface_t, "UGNI_RDMA_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_ugni_rdma_iface_t), "UGNI_RDMA_",
               uct_ugni_rdma_iface_config_table, uct_ugni_rdma_iface_config_t);

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -374,5 +374,5 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_smsg_iface_t, uct_iface_t, uct_md_h,
                           const uct_iface_config_t *);
 
 UCT_TL_DEFINE(&uct_ugni_component, ugni_smsg, uct_ugni_query_devices,
-              uct_ugni_smsg_iface_t, "UGNI_SMSG_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_ugni_smsg_iface_t), "UGNI_SMSG_",
               uct_ugni_smsg_iface_config_table, uct_ugni_iface_config_t);

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -493,5 +493,5 @@ UCS_CLASS_DEFINE_NEW_FUNC(uct_ugni_udt_iface_t, uct_iface_t, uct_md_h,
                           const uct_iface_config_t*);
 
 UCT_TL_DEFINE(&uct_ugni_component, ugni_udt, uct_ugni_query_devices,
-              uct_ugni_udt_iface_t, "UGNI_UDT_",
+              UCS_CLASS_NEW_FUNC_NAME(uct_ugni_udt_iface_t), "UGNI_UDT_",
               uct_ugni_udt_iface_config_table, uct_ugni_iface_config_t);


### PR DESCRIPTION
## What

Reopen IFACE if per DCI CQ length is less than bb_max.

## Why ?

Fixes the following issue (discovered by `dcudx/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_4_extra_senders_multiple_sends/1`):
```
==14100== Invalid read of size 8
==14100==    at 0x65ED901: uct_rc_iface_get_send_op (rc_iface.h:499)
==14100==    by 0x65ED901: uct_rc_txqp_add_send_comp (rc_ep.h:377)
==14100==    by 0x65ED901: uct_dc_mlx5_iface_zcopy_post (dc_mlx5_ep.c:65)
==14100==    by 0x65ED901: uct_dc_mlx5_ep_get_zcopy (dc_mlx5_ep.c:575)
==14100==    by 0x59715AE: uct_ep_get_zcopy (uct.h:2830)
==14100==    by 0x59715AE: ucp_rndv_progress_rma_zcopy_common (rndv.c:554)
==14100==    by 0x598814F: ucp_rndv_progress_rma_get_zcopy_inner (rndv.c:2231)
==14100==    by 0x598814F: ucp_rndv_progress_rma_get_zcopy (rndv.c:2221)
==14100==    by 0x660C526: uct_rc_iface_invoke_pending_cb (rc_iface.h:594)
==14100==    by 0x660C526: uct_dc_mlx5_iface_dci_do_common_pending_tx (dc_mlx5_ep.c:1295)
==14100==    by 0x660CF8A: uct_dc_mlx5_iface_dci_do_dcs_pending_tx (dc_mlx5_ep.c:1377)
==14100==    by 0x508D96C: ucs_arbiter_dispatch_nonempty (arbiter.c:321)
==14100==    by 0x6611855: ucs_arbiter_dispatch (arbiter.h:386)
==14100==    by 0x66284BF: uct_dc_mlx5_iface_progress_pending (dc_mlx5_ep.h:363)
==14100==    by 0x66284BF: uct_dc_mlx5_poll_tx (dc_mlx5.c:263)
==14100==    by 0x66284BF: uct_dc_mlx5_iface_progress (dc_mlx5.c:282)
==14100==    by 0x66284BF: uct_dc_mlx5_iface_progress_ll (dc_mlx5.c:292)
==14100==    by 0x58D7E27: ucs_callbackq_dispatch (callbackq.h:211)
==14100==    by 0x58E4F7A: uct_worker_progress (uct.h:2638)
==14100==    by 0x58E4F7A: ucp_worker_progress (ucp_worker.c:2782)
==14100==    by 0xA8D7A3: ucp_test_base::entity::progress(int) (ucp_test.cc:1047)
==14100==    by 0xA882D1: ucp_test::progress(std::vector<ucp_test_base::entity*, std::allocator<ucp_test_base::entity*> > const&, int) const (ucp_test.cc:168)
==14100==    by 0xA886D6: ucp_test::check_events(std::vector<ucp_test_base::entity*, std::allocator<ucp_test_base::entity*> > const&, bool, int) (ucp_test.cc:249)
==14100==    by 0xA8899C: ucp_test::request_process(void*, int, bool, bool) (ucp_test.cc:291)
==14100==    by 0xA88AE0: ucp_test::request_wait(void*, int, bool) (ucp_test.cc:311)
==14100==    by 0xA88B1F: ucp_test::requests_wait(std::vector<void*, std::allocator<void*> >&, int) (ucp_test.cc:320)
==14100==    by 0xA3CA4F: test_ucp_sockaddr_protocols_err_sender::do_tag_rndv_killed_sender_test(unsigned long, unsigned long, unsigned long) (test_ucp_sockaddr.cc:2950)
==14100==    by 0xA0E9E2: test_ucp_sockaddr_protocols_err_sender_tag_rndv_killed_sender_4_extra_senders_multiple_sends_Test::test_body() (test_ucp_sockaddr.cc:3005)
==14100==    by 0x595133: ucs::test_base::run() (test.cc:356)
==14100==    by 0x5952F6: ucs::test_base::TestBodyProxy() (test.cc:382)
==14100==    by 0x7B46B5: ucp_test::TestBody() (ucp_test.h:202)
==14100==    by 0xE1ECD1: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2433)
==14100==    by 0xE1AB5B: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2469)
==14100==    by 0xE058EE: testing::Test::Run() (gtest.cc:2509)
==14100==    by 0xE06156: testing::TestInfo::Run() (gtest.cc:2687)
==14100==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```
It happens that DCI's QP length is greater than CQ length in DC. So, IFACE send op entries could be exhausted at some point, but we don't expect it. We should male sure that `num_dcis * qp_length <= cq_length`.

## How ?

1. Update `UCT_TL_DEFINE` and `UCT_TL_DEFINE_ENTRY` to accept `iface_open` instead of IFACE class name.
2. Fix all places where `UCT_TL_DEFINE` and `UCT_TL_DEFINE_ENTRY` are used.
3. Create wrapper for `iface_open` in DC to retry creating IFACE object in case of `per_dci_cq_len` is less than `bb_max`.