### PR TITLE
UCT/IB: Fix indirect key registration by using correct MR type

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -908,7 +908,11 @@ uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
         atomic_rkey = UCT_IB_INVALID_MKEY;
     }
 
-    if (flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE) {
+    /* Register indirect key, that does not support atomic operations, only if
+     * we have a dedicated atomic key or atomic support wasn't requested */
+    if ((flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE) &&
+        ((atomic_rkey != UCT_IB_INVALID_MKEY) ||
+         !(memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC))) {
         if (memh->indirect_rkey == UCT_IB_INVALID_MKEY) {
             status = md->ops->reg_indirect_key(md, memh);
             if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -159,7 +159,7 @@ static ucs_status_t uct_ib_mlx5_alloc_mkey_inbox(int list_size, char **in_p)
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md,
+static ucs_status_t uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md, int atomic,
                                              intptr_t addr, size_t length,
                                              int list_size, size_t entity_size,
                                              char *in,
@@ -179,7 +179,7 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md,
     UCT_IB_MLX5DV_SET(create_mkey_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_MKEY);
     mkc = UCT_IB_MLX5DV_ADDR_OF(create_mkey_in, in, memory_key_mkey_entry);
     UCT_IB_MLX5DV_SET(mkc, mkc, access_mode_1_0, UCT_IB_MLX5_MKC_ACCESS_MODE_KSM);
-    UCT_IB_MLX5DV_SET(mkc, mkc, a, 1);
+    UCT_IB_MLX5DV_SET(mkc, mkc, a, !!atomic);
     UCT_IB_MLX5DV_SET(mkc, mkc, rw, 1);
     UCT_IB_MLX5DV_SET(mkc, mkc, rr, 1);
     UCT_IB_MLX5DV_SET(mkc, mkc, lw, 1);
@@ -212,7 +212,7 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md,
 }
 
 static ucs_status_t
-uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md,
+uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md, int atomic,
                               uct_ib_mlx5_ksm_data_t *ksm_data,
                               size_t length, off_t off,
                               struct mlx5dv_devx_obj **mr_p,
@@ -236,16 +236,19 @@ uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md,
         klm = UCS_PTR_BYTE_OFFSET(klm, UCT_IB_MLX5DV_ST_SZ_BYTES(klm));
     }
 
-    status = uct_ib_mlx5_devx_reg_ksm(md, (intptr_t)ksm_data->mrs[0]->addr + off,
+    status = uct_ib_mlx5_devx_reg_ksm(md, atomic,
+                                      (intptr_t)ksm_data->mrs[0]->addr + off,
                                       length, ksm_data->mr_num,
-                                      ksm_data->mrs[0]->length, in, mr_p, mkey);
+                                      ksm_data->mrs[0]->length, in, mr_p,
+                                      mkey);
     ucs_free(in);
     return status;
 }
 
 static ucs_status_t
-uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mr_t *mr,
-                                     off_t off, struct mlx5dv_devx_obj **mr_p,
+uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md,
+                                     uct_ib_mlx5_mr_t *mr, off_t off,
+                                     int atomic, struct mlx5dv_devx_obj **mr_p,
                                      uint32_t *mkey)
 {
     intptr_t addr = (intptr_t)mr->super.ib->addr & ~(UCT_IB_MD_MAX_MR_SIZE - 1);
@@ -274,8 +277,9 @@ uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mr_t *mr,
         klm = UCS_PTR_BYTE_OFFSET(klm, UCT_IB_MLX5DV_ST_SZ_BYTES(klm));
     }
 
-    status = uct_ib_mlx5_devx_reg_ksm(md, addr + off, length, list_size,
-                                      UCT_IB_MD_MAX_MR_SIZE, in, mr_p, mkey);
+    status = uct_ib_mlx5_devx_reg_ksm(md, atomic, addr + off, length,
+                                      list_size, UCT_IB_MD_MAX_MR_SIZE, in,
+                                      mr_p, mkey);
     ucs_free(in);
     return status;
 }
@@ -436,10 +440,9 @@ static ucs_status_t uct_ib_mlx5_devx_reg_indirect_key(uct_ib_md_t *ibmd,
                                   UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS));
 
     do {
-        status = uct_ib_mlx5_devx_reg_ksm_data_contig(md,
-                                                      &memh->mrs[UCT_IB_MR_DEFAULT],
-                                                      0, &memh->indirect_dvmr,
-                                                      &memh->super.indirect_rkey);
+        status = uct_ib_mlx5_devx_reg_ksm_data_contig(
+                md, &memh->mrs[UCT_IB_MR_DEFAULT], 0, 0, &memh->indirect_dvmr,
+                &memh->super.indirect_rkey);
         if (status != UCS_OK) {
             break;
         }
@@ -513,16 +516,16 @@ static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
     }
 
     if (memh->super.flags & UCT_IB_MEM_MULTITHREADED) {
-        return uct_ib_mlx5_devx_reg_ksm_data(md, mr->ksm_data, mr->ksm_data->length,
+        return uct_ib_mlx5_devx_reg_ksm_data(md, 1, mr->ksm_data,
+                                             mr->ksm_data->length,
                                              uct_ib_md_atomic_offset(mr_id),
                                              &memh->atomic_dvmr,
                                              &memh->super.atomic_rkey);
     }
 
-    status = uct_ib_mlx5_devx_reg_ksm_data_contig(md, mr,
-                                                  uct_ib_md_atomic_offset(mr_id),
-                                                  &memh->atomic_dvmr,
-                                                  &memh->super.atomic_rkey);
+    status = uct_ib_mlx5_devx_reg_ksm_data_contig(
+            md, mr, uct_ib_md_atomic_offset(mr_id), 1, &memh->atomic_dvmr,
+            &memh->super.atomic_rkey);
     if (status != UCS_OK) {
         if (status == UCS_ERR_UNSUPPORTED) {
             md->flags &= ~UCT_IB_MLX5_MD_FLAG_KSM;
@@ -599,8 +602,9 @@ static ucs_status_t uct_ib_mlx5_devx_reg_multithreaded(uct_ib_md_t *ibmd,
         goto err;
     }
 
-    status = uct_ib_mlx5_devx_reg_ksm_data(md, ksm_data, length, 0,
-                                           &ksm_data->dvmr, &mkey);
+    status = uct_ib_mlx5_devx_reg_ksm_data(
+            md, memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC,
+            ksm_data, length, 0, &ksm_data->dvmr, &mkey);
     if (status != UCS_OK) {
         goto err_dereg;
     }


### PR DESCRIPTION
## What

Fix indirect key registration by using correct MR type.

## Why ?

We register KSM with `atomic` access flag set. So, if default MR has relaxed ordering, we should use special MR with strict ordering.
Fixes:
```
[ RUN      ] dc_ud/test_ucp_sockaddr.force_close_during_rndv/0 <dc_x,ud_v,ud_x,mm/tag>
[New Thread 0x7fffedd81700 (LWP 7649)]
[Thread 0x7fffedd81700 (LWP 7649) exited]
[New Thread 0x7fffedd81700 (LWP 7650)]
[Thread 0x7fffedd81700 (LWP 7650) exited]
[New Thread 0x7fffedd81700 (LWP 7655)]
[     INFO ] Testing 1.1.27.2:0
[     INFO ] server listening on 1.1.27.2:60349
[1651871131.827338] [swx-ucx02:9673 :0]    ib_mlx5dv_md.c:457  UCX  ERROR   mlx5_bond_0: LRU push returned Unsupported operation
[swx-ucx02:9673 :0:9673]        rndv.c:166  Fatal: failed to pack rendezvous remote key: Unsupported operation

/hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/rndv/rndv.c: [ ucp_rndv_rts_pack() ]
      ...
      162                 ucp_ep_config(sreq->send.ep)->uct_rkey_pack_flags, NULL,
      163                 rkey_buf);
      164         if (packed_rkey_size < 0) {
==>   165             ucs_fatal("failed to pack rendezvous remote key: %s",
      166                       ucs_status_string((ucs_status_t)packed_rkey_size));
      167         }
      168

==== backtrace (tid:   9673) ====
 0 0x000000000010cb7d ucp_rndv_rts_pack()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/rndv/rndv.c:165
 1 0x000000000017cc18 ucp_tag_rndv_rts_pack()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/tag/tag_rndv.c:74
 2 0x000000000008d6e3 ucp_do_am_single()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/proto/proto_am.c:69
 3 0x000000000010f57b ucp_rndv_send_rts()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/rndv/rndv.c:414
 4 0x000000000017ccb2 ucp_proto_progress_tag_rndv_rts_inner()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/tag/tag_rndv.c:82
 5 0x000000000019835e ucp_request_try_send()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_request.inl:334
 6 0x000000000019835e ucp_request_send()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/core/ucp_request.inl:357
 7 0x000000000019835e ucp_tag_send_req()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/tag/tag_send.c:116
 8 0x000000000019835e ucp_tag_send_nbx_inner()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/tag/tag_send.c:298
 9 0x000000000019835e ucp_tag_send_nbx()  /hpc/mtr_scrap/users/dmitrygla/ucx/src/ucp/tag/tag_send.c:229
10 0x0000000000a20c81 test_ucp_sockaddr::send()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:398
11 0x0000000000a21a81 test_ucp_sockaddr::send_recv()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:546
12 0x0000000000a228e5 test_ucp_sockaddr::connect_and_send_recv()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:664
13 0x0000000000a22c57 test_ucp_sockaddr::listen_and_communicate()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:696
14 0x0000000000a247a7 test_ucp_sockaddr::do_force_close_during_rndv()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:907
15 0x00000000009f9d73 test_ucp_sockaddr_force_close_during_rndv_Test::test_body()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/test_ucp_sockaddr.cc:1189
16 0x0000000000595154 ucs::test_base::run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/test.cc:356
17 0x0000000000595317 ucs::test_base::TestBodyProxy()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/test.cc:382
18 0x00000000007b46d6 ucp_test::TestBody()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/ucp/ucp_test.h:202
19 0x0000000000e1df5c testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2433
20 0x0000000000e19de6 testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2469
21 0x0000000000e04b79 testing::Test::Run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2509
22 0x0000000000e053e1 testing::TestInfo::Run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2687
23 0x0000000000e05a9a testing::TestSuite::Run()  /hpc/mtr_scrap/users/dmitrygla/ucx/test/gtest/common/googletest/gtest.cc:2819
```

## How ?

1. Select a correct MR by checking `RELAXED_ORDERING` flag on memory handle. MR type is calculated by `uct_ib_memh_get_atomic_base_mr_type` and then correct MR selected as `memh->mrs[mr_type]`.
2. Get atomic MR ID from `uct_ib_mlx5_md_get_atomic_mr_id`. MR ID is needed to select a correct atomic offset.
3. Register KSM using correct MR and atomic offset.