### PR TITLE
UCT/IB: Update mechanism to set CQ length and fix DC TX CQ length

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1001,7 +1001,7 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                     int preferred_cpu, size_t inl)
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
-    unsigned cq_size     = uct_ib_cq_size(iface, init_attr, dir);
+    unsigned cq_size     = uct_ib_cq_size(init_attr, dir);
     struct ibv_cq *cq;
     char message[128];
     int cq_errno;
@@ -1238,7 +1238,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
                     uct_ib_iface_ops_t *ops, uct_md_h md, uct_worker_h worker,
                     const uct_iface_params_t *params,
                     const uct_ib_iface_config_t *config,
-                    const uct_ib_iface_init_attr_t *init_attr)
+                    uct_ib_iface_init_attr_t *init_attr)
 {
     uct_ib_md_t *ib_md   = ucs_derived_of(md, uct_ib_md_t);
     uct_ib_device_t *dev = &ib_md->dev;
@@ -1347,6 +1347,11 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     if (status != UCS_OK) {
         goto err_destroy_comp_channel;
     }
+
+    init_attr->cq_len[UCT_IB_DIR_TX] = self->ops->get_cq_len(self, config,
+                                                             UCT_IB_DIR_TX);
+    init_attr->cq_len[UCT_IB_DIR_RX] = self->ops->get_cq_len(self, config,
+                                                             UCT_IB_DIR_RX);
 
     status = self->ops->create_cq(self, UCT_IB_DIR_TX, config, init_attr,
                                   preferred_cpu, config->inl[UCT_IB_DIR_TX]);

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1267,7 +1267,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     uint8_t num_dcis                   = config->ndci +
                                          UCT_DC_MLX5_KEEPALIVE_NUM_DCIS;
     ucs_status_t status;
-    unsigned dci_cq_len;
+    unsigned UCS_V_UNUSED dci_cq_len;
 
     ucs_trace_func("");
 

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -125,7 +125,7 @@ uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     int cq_errno;
 
     uct_ib_fill_cq_attr(&cq_attr, init_attr, iface, preferred_cpu,
-                        uct_ib_cq_size(iface, init_attr, dir));
+                        uct_ib_cq_size(init_attr, dir));
 
     dv_attr.comp_mask = MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE;
     dv_attr.cqe_size  = uct_ib_get_cqe_size(inl > 32 ? 128 : 64);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -709,6 +709,7 @@ void uct_ib_mlx5_devx_uar_cleanup(uct_ib_mlx5_devx_uar_t *uar);
 void uct_ib_mlx5_txwq_validate_always(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb,
                                       int hw_ci_updated);
 
+size_t uct_ib_mlx5_devx_wqe_size(size_t tx_min_sge, size_t tx_min_inline);
 
 /**
  * DEVX QP API

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -524,6 +524,15 @@ void uct_rc_mlx5_iface_common_tag_cleanup(uct_rc_mlx5_iface_common_t *iface)
     ucs_mpool_cleanup(&iface->tm.mp.tx_mp, 1);
 }
 
+unsigned uct_rc_mlx5_common_get_rx_cq_len(uct_rc_mlx5_iface_common_t *iface,
+                                          uct_rc_iface_common_config_t *config)
+{
+    return iface->tm.enabled ?
+           (config->super.rx.queue_len + iface->tm.num_tags * 3 +
+            config->super.rx.queue_len / IBV_DEVICE_MAX_UNEXP_COUNT) :
+           config->super.rx.queue_len;
+}
+
 void uct_rc_mlx5_iface_fill_attr(uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_qp_attr_t *qp_attr,
                                  unsigned max_send_wr,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -725,6 +725,10 @@ ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(uct_rc_mlx5_iface_common_t *
                                                     enum ibv_event_type event_type,
                                                     unsigned event_data);
 
+unsigned
+uct_rc_mlx5_common_get_rx_cq_len(uct_rc_mlx5_iface_common_t *iface,
+                                 uct_rc_iface_common_config_t *config);
+
 void uct_rc_mlx5_iface_fill_attr(uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_qp_attr_t *qp_attr,
                                  unsigned max_send_wr,

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -548,26 +548,17 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
                     uct_rc_iface_ops_t *ops, uct_md_h md, uct_worker_h worker,
                     const uct_iface_params_t *params,
                     const uct_rc_iface_common_config_t *config,
-                    const uct_ib_iface_init_attr_t *init_attr)
+                    uct_ib_iface_init_attr_t *init_attr)
 {
     uct_ib_device_t *dev = &ucs_derived_of(md, uct_ib_md_t)->dev;
     uint32_t max_ib_msg_size;
     ucs_status_t status;
     unsigned tx_cq_size;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, tl_ops, &ops->super, md, worker,
-                              params, &config->super, init_attr);
-
-    tx_cq_size                  = uct_ib_cq_size(&self->super, init_attr,
-                                                 UCT_IB_DIR_TX);
-    self->tx.cq_available       = tx_cq_size - 1;
-    self->rx.srq.available      = 0;
-    self->rx.srq.quota          = 0;
     self->config.tx_qp_len      = config->super.tx.queue_len;
     self->config.tx_min_sge     = config->super.tx.min_sge;
     self->config.tx_min_inline  = config->super.tx.min_inline;
     self->config.tx_poll_always = config->tx.poll_always;
-    self->config.tx_cq_len      = tx_cq_size;
     self->config.min_rnr_timer  = uct_ib_to_rnr_fabric_time(config->tx.rnr_timeout);
     self->config.timeout        = uct_ib_to_qp_fabric_time(config->tx.timeout);
     self->config.rnr_retry      = uct_rc_iface_config_limit_value(
@@ -582,7 +573,16 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
 #if UCS_ENABLE_ASSERT
     self->tx.in_pending         = 0;
 #endif
-    max_ib_msg_size             = uct_ib_iface_port_attr(&self->super)->max_msg_sz;
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, tl_ops, &ops->super, md, worker,
+                              params, &config->super, init_attr);
+
+    tx_cq_size             = uct_ib_cq_size(init_attr, UCT_IB_DIR_TX);
+    self->tx.cq_available  = tx_cq_size - 1;
+    self->rx.srq.available = 0;
+    self->rx.srq.quota     = 0;
+    self->config.tx_cq_len = tx_cq_size;
+    max_ib_msg_size        = uct_ib_iface_port_attr(&self->super)->max_msg_sz;
 
     status = uct_rc_iface_init_max_rd_atomic(self, config, init_attr);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -310,7 +310,7 @@ struct uct_rc_iface {
 UCS_CLASS_DECLARE(uct_rc_iface_t, uct_iface_ops_t*, uct_rc_iface_ops_t*,
                   uct_md_h, uct_worker_h, const uct_iface_params_t*,
                   const uct_rc_iface_common_config_t*,
-                  const uct_ib_iface_init_attr_t*);
+                  uct_ib_iface_init_attr_t*);
 
 
 struct uct_rc_iface_send_op {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -668,6 +668,18 @@ uct_ud_mlx5_iface_peer_address_str(const uct_ud_iface_t *iface,
     return str;
 }
 
+static unsigned
+uct_ud_mlx5_get_cq_len(const uct_ib_iface_t *ib_iface,
+                       const uct_ib_iface_config_t *ib_config,
+                       uct_ib_dir_t dir)
+{
+    if (dir == UCT_IB_DIR_TX) {
+        return ib_config->tx.queue_len * UCT_IB_MLX5_MAX_BB;
+    } else {
+        return ib_config->rx.queue_len;
+    }
+}
+
 static ucs_status_t
 uct_ud_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                       const uct_ib_iface_config_t *ib_config,
@@ -776,6 +788,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
             .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate       = uct_ud_ep_invalidate
         },
+        .get_cq_len     = uct_ud_mlx5_get_cq_len,
         .create_cq      = uct_ud_mlx5_create_cq,
         .arm_cq         = uct_ud_mlx5_iface_arm_cq,
         .event_cq       = uct_ud_mlx5_iface_event_cq,
@@ -836,10 +849,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
 
     ucs_trace_func("");
 
-    init_attr.flags                 = UCT_IB_CQ_IGNORE_OVERRUN;
-    init_attr.cq_len[UCT_IB_DIR_TX] = config->super.super.tx.queue_len * UCT_IB_MLX5_MAX_BB;
-    init_attr.cq_len[UCT_IB_DIR_RX] = config->super.super.rx.queue_len;
-
+    init_attr.flags        = UCT_IB_CQ_IGNORE_OVERRUN;
     self->tx.mmio_mode     = config->mlx5_common.mmio_mode;
     self->tx.wq.super.type = UCT_IB_MLX5_OBJ_TYPE_LAST;
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -550,6 +550,18 @@ static void uct_ud_verbs_iface_destroy_qp(uct_ud_iface_t *ud_iface)
 
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t)(uct_iface_t*);
 
+static unsigned
+uct_ud_verbs_get_cq_len(const uct_ib_iface_t *ib_iface,
+                        const uct_ib_iface_config_t *ib_config,
+                        uct_ib_dir_t dir)
+{
+    if (dir == UCT_IB_DIR_TX) {
+        return ib_config->tx.queue_len;
+    } else {
+        return ib_config->rx.queue_len;
+    }
+}
+
 static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .super = {
         .super = {
@@ -558,6 +570,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
             .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate       = uct_ud_ep_invalidate
         },
+        .get_cq_len     =  uct_ud_verbs_get_cq_len,
         .create_cq      = uct_ib_verbs_create_cq,
         .arm_cq         = uct_ib_iface_arm_cq,
         .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
@@ -669,9 +682,6 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
     ucs_status_t status;
 
     ucs_trace_func("");
-
-    init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx.queue_len;
-    init_attr.cq_len[UCT_IB_DIR_RX] = config->super.rx.queue_len;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_verbs_iface_ops, &uct_ud_verbs_iface_tl_ops, md,
                               worker, params, config, &init_attr);


### PR DESCRIPTION
## What

Update mechanism to set CQ length and fix DC TX CQ length.

## Why ?

Fixes the following issue (discovered by `dcudx/test_ucp_sockaddr_protocols_err_sender.tag_rndv_killed_sender_4_extra_senders_multiple_sends/1`):
```
==14100== Invalid read of size 8
==14100==    at 0x65ED901: uct_rc_iface_get_send_op (rc_iface.h:499)
==14100==    by 0x65ED901: uct_rc_txqp_add_send_comp (rc_ep.h:377)
==14100==    by 0x65ED901: uct_dc_mlx5_iface_zcopy_post (dc_mlx5_ep.c:65)
==14100==    by 0x65ED901: uct_dc_mlx5_ep_get_zcopy (dc_mlx5_ep.c:575)
==14100==    by 0x59715AE: uct_ep_get_zcopy (uct.h:2830)
==14100==    by 0x59715AE: ucp_rndv_progress_rma_zcopy_common (rndv.c:554)
==14100==    by 0x598814F: ucp_rndv_progress_rma_get_zcopy_inner (rndv.c:2231)
==14100==    by 0x598814F: ucp_rndv_progress_rma_get_zcopy (rndv.c:2221)
==14100==    by 0x660C526: uct_rc_iface_invoke_pending_cb (rc_iface.h:594)
==14100==    by 0x660C526: uct_dc_mlx5_iface_dci_do_common_pending_tx (dc_mlx5_ep.c:1295)
==14100==    by 0x660CF8A: uct_dc_mlx5_iface_dci_do_dcs_pending_tx (dc_mlx5_ep.c:1377)
==14100==    by 0x508D96C: ucs_arbiter_dispatch_nonempty (arbiter.c:321)
==14100==    by 0x6611855: ucs_arbiter_dispatch (arbiter.h:386)
==14100==    by 0x66284BF: uct_dc_mlx5_iface_progress_pending (dc_mlx5_ep.h:363)
==14100==    by 0x66284BF: uct_dc_mlx5_poll_tx (dc_mlx5.c:263)
==14100==    by 0x66284BF: uct_dc_mlx5_iface_progress (dc_mlx5.c:282)
==14100==    by 0x66284BF: uct_dc_mlx5_iface_progress_ll (dc_mlx5.c:292)
==14100==    by 0x58D7E27: ucs_callbackq_dispatch (callbackq.h:211)
==14100==    by 0x58E4F7A: uct_worker_progress (uct.h:2638)
==14100==    by 0x58E4F7A: ucp_worker_progress (ucp_worker.c:2782)
==14100==    by 0xA8D7A3: ucp_test_base::entity::progress(int) (ucp_test.cc:1047)
==14100==    by 0xA882D1: ucp_test::progress(std::vector<ucp_test_base::entity*, std::allocator<ucp_test_base::entity*> > const&, int) const (ucp_test.cc:168)
==14100==    by 0xA886D6: ucp_test::check_events(std::vector<ucp_test_base::entity*, std::allocator<ucp_test_base::entity*> > const&, bool, int) (ucp_test.cc:249)
==14100==    by 0xA8899C: ucp_test::request_process(void*, int, bool, bool) (ucp_test.cc:291)
==14100==    by 0xA88AE0: ucp_test::request_wait(void*, int, bool) (ucp_test.cc:311)
==14100==    by 0xA88B1F: ucp_test::requests_wait(std::vector<void*, std::allocator<void*> >&, int) (ucp_test.cc:320)
==14100==    by 0xA3CA4F: test_ucp_sockaddr_protocols_err_sender::do_tag_rndv_killed_sender_test(unsigned long, unsigned long, unsigned long) (test_ucp_sockaddr.cc:2950)
==14100==    by 0xA0E9E2: test_ucp_sockaddr_protocols_err_sender_tag_rndv_killed_sender_4_extra_senders_multiple_sends_Test::test_body() (test_ucp_sockaddr.cc:3005)
==14100==    by 0x595133: ucs::test_base::run() (test.cc:356)
==14100==    by 0x5952F6: ucs::test_base::TestBodyProxy() (test.cc:382)
==14100==    by 0x7B46B5: ucp_test::TestBody() (ucp_test.h:202)
==14100==    by 0xE1ECD1: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2433)
==14100==    by 0xE1AB5B: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2469)
==14100==    by 0xE058EE: testing::Test::Run() (gtest.cc:2509)
==14100==    by 0xE06156: testing::TestInfo::Run() (gtest.cc:2687)
==14100==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```
It happens that DCI's QP length is greater than CQ length in DC. So, IFACE send op entries could be exhausted at some point, but we don't expect it. We should male sure that `num_dcis * qp_length <= cq_length`.

## How ?

1. Introduce `get_cq_len` function in IB CQ ops to calculate TX/RX CQ length.
2. Fix CQ length calculation in DC to make sure that the `CQ_length / num_dcis` is equal to `tx.bb_max`.