### PR TITLE
UCT/GTEST: Get rid of stats (de)activation related methods duplication

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -8,6 +8,7 @@
 
 #include <ucs/config/parser.h>
 #include <ucs/config/global_opts.h>
+#include <ucs/stats/stats.h>
 #include <ucs/sys/sys.h>
 
 #include <memory>
@@ -149,6 +150,27 @@ void test_base::pop_config()
     ucs_global_opts_release();
     ucs_global_opts = m_config_stack.back();
     m_config_stack.pop_back();
+}
+
+void test_base::stats_activate()
+{
+#ifdef ENABLE_STATS
+    ucs_stats_cleanup();
+    push_config();
+    modify_config("STATS_DEST",    "file:/dev/null");
+    modify_config("STATS_TRIGGER", "exit");
+    ucs_stats_init();
+    ASSERT_TRUE(ucs_stats_is_active());
+#endif
+}
+
+void test_base::stats_restore()
+{
+#ifdef ENABLE_STATS
+    ucs_stats_cleanup();
+    pop_config();
+    ucs_stats_init();
+#endif
 }
 
 ucs_log_func_rc_t

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -56,6 +56,8 @@ public:
     virtual void push_config();
     virtual void pop_config();
 
+    void stats_activate();
+    void stats_restore();
 protected:
     class scoped_log_handler {
     public:

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -15,7 +15,6 @@ extern "C" {
 #include <uct/ib/ud/base/ud_iface.h>
 #endif
 #include <ucs/arch/atomic.h>
-#include <ucs/stats/stats.h>
 }
 
 #include <queue>
@@ -561,23 +560,6 @@ void ucp_test::modify_config(const std::string& name, const std::string& value,
                            << ucs_status_string(status));
         }
     }
-}
-
-void ucp_test::stats_activate()
-{
-    ucs_stats_cleanup();
-    push_config();
-    modify_config("STATS_DEST",    "file:/dev/null");
-    modify_config("STATS_TRIGGER", "exit");
-    ucs_stats_init();
-    ASSERT_TRUE(ucs_stats_is_active());
-}
-
-void ucp_test::stats_restore()
-{
-    ucs_stats_cleanup();
-    pop_config();
-    ucs_stats_init();
 }
 
 bool ucp_test::check_tls(const std::string& tls)

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -215,8 +215,6 @@ public:
 
     virtual void modify_config(const std::string& name, const std::string& value,
                                modify_config_mode_t mode = FAIL_IF_NOT_EXIST);
-    void stats_activate();
-    void stats_restore();
 
     void disable_keepalive();
 

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -810,20 +810,13 @@ class test_rcache_stats : public test_rcache {
 protected:
 
     virtual void init() {
-        ucs_stats_cleanup();
-        push_config();
-        modify_config("STATS_DEST",    "file:/dev/null");
-        modify_config("STATS_TRIGGER", "exit");
-        ucs_stats_init();
-        ASSERT_TRUE(ucs_stats_is_active());
+        stats_activate();
         test_rcache::init();
     }
 
     virtual void cleanup() {
         test_rcache::cleanup();
-        ucs_stats_cleanup();
-        pop_config();
-        ucs_stats_init();
+        stats_restore();
     }
 
     int get_counter(int stat) {

--- a/test/gtest/uct/ib/test_cqe_zipping.cc
+++ b/test/gtest/uct/ib/test_cqe_zipping.cc
@@ -67,9 +67,7 @@ public:
 
     virtual void init()
     {
-#ifdef ENABLE_STATS
         stats_activate();
-#endif
         modify_config("IB_CQE_ZIPPING_ENABLE", "y");
 
         test_uct_ib_with_specific_port::init();
@@ -104,9 +102,7 @@ private:
         test_uct_ib::cleanup();
         test_uct_ib_with_specific_port::cleanup();
 
-#ifdef ENABLE_STATS
         stats_restore();
-#endif
     }
 
     ucs_status_t am_zcopy()

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -173,18 +173,16 @@ public:
     }
 
     void init() {
-#ifdef ENABLE_STATS
         stats_activate();
-#endif
         test_rc::init();
     }
 
-#ifdef ENABLE_STATS
     void cleanup() {
         uct_test::cleanup();
         stats_restore();
     }
 
+#ifdef ENABLE_STATS
     uint64_t get_no_reads_stat_counter(entity *e) {
         uct_rc_iface_t *iface = ucs_derived_of(e->iface(), uct_rc_iface_t);
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -7,7 +7,6 @@
 #include "uct_test.h"
 #include "uct/api/uct_def.h"
 
-#include <ucs/stats/stats.h>
 #include <ucs/sys/sock.h>
 #include <ucs/sys/string.h>
 #include <common/test_helpers.h>
@@ -629,23 +628,6 @@ bool uct_test::has_ugni() const {
 bool uct_test::has_gpu() const {
     return (has_transport("cuda_copy") || has_transport("gdr_copy") ||
             has_transport("rocm_copy"));
-}
-
-void uct_test::stats_activate()
-{
-    ucs_stats_cleanup();
-    push_config();
-    modify_config("STATS_DEST",    "file:/dev/null");
-    modify_config("STATS_TRIGGER", "exit");
-    ucs_stats_init();
-    ASSERT_TRUE(ucs_stats_is_active());
-}
-
-void uct_test::stats_restore()
-{
-    ucs_stats_cleanup();
-    pop_config();
-    ucs_stats_init();
 }
 
 uct_test::entity *

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -351,8 +351,6 @@ protected:
     virtual void modify_config(const std::string& name, const std::string& value,
                                modify_config_mode_t mode = FAIL_IF_NOT_EXIST);
     bool get_config(const std::string& name, std::string& value) const;
-    void stats_activate();
-    void stats_restore();
 
     virtual bool has_transport(const std::string& tl_name) const;
     virtual bool has_ud() const;


### PR DESCRIPTION
## What
- Makes `stats_activate/restore` methods members of the `test_base` class
- Moves compile-time `ENABLE_STATS` macro checks inside `stats_activate/restore` methods

## Why ?
Now `uct_test` end `ucp_test` implementations fully duplicates the `stats_activate/restore` methods. This duplication is reduced by moving these methods to common base class.

