### PR TITLE
UCP/PROTO: Refactor protocol initialization ranges

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -69,6 +69,7 @@ SpaceAfterCStyleCast: false
 SortIncludes: false
 ForEachMacros: ['_UCS_BITMAP_FOR_EACH_WORD',
                 'FOR_EACH_ENTITY',
+                'ucs_carray_for_each',
                 'kh_foreach',
                 'kh_foreach_key',
                 'kh_foreach_value',

--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -76,7 +76,7 @@ const ucp_proto_t *ucp_protocols[] = {
     UCP_PROTO_FOR_EACH(UCP_PROTO_ENTRY)
 };
 
-const char *ucp_proto_perf_types[] = {
+const char *ucp_proto_perf_type_names[] = {
     [UCP_PROTO_PERF_TYPE_SINGLE] = "single",
     [UCP_PROTO_PERF_TYPE_MULTI]  = "multi"
 };

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -119,9 +119,6 @@ typedef enum {
  * Performance estimation for a range of message sizes.
  */
 typedef struct {
-    /* Protocol name */
-    const char        *name;
-
     /* Maximal payload size for this range */
     size_t            max_length;
 
@@ -292,7 +289,7 @@ extern const char *ucp_operation_descs[];
 
 
 /* Performance types names */
-extern const char *ucp_proto_perf_types[];
+extern const char *ucp_proto_perf_type_names[];
 
 
 /* Get number of globally registered protocols */
@@ -303,5 +300,21 @@ unsigned ucp_protocols_count(void);
    description from proto->desc, and set config to an empty string. */
 void ucp_proto_default_query(const ucp_proto_query_params_t *params,
                              ucp_proto_query_attr_t *attr);
+
+static inline void
+ucp_proto_perf_copy(ucs_linear_func_t dest[UCP_PROTO_PERF_TYPE_LAST],
+                    const ucs_linear_func_t src[UCP_PROTO_PERF_TYPE_LAST])
+{
+    dest[UCP_PROTO_PERF_TYPE_SINGLE] = src[UCP_PROTO_PERF_TYPE_SINGLE];
+    dest[UCP_PROTO_PERF_TYPE_MULTI]  = src[UCP_PROTO_PERF_TYPE_MULTI];
+}
+
+static inline void
+ucp_proto_perf_add(ucs_linear_func_t perf[UCP_PROTO_PERF_TYPE_LAST],
+                   ucs_linear_func_t func)
+{
+    ucs_linear_func_add_inplace(&perf[UCP_PROTO_PERF_TYPE_SINGLE], func);
+    ucs_linear_func_add_inplace(&perf[UCP_PROTO_PERF_TYPE_MULTI], func);
+}
 
 #endif

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -152,7 +152,6 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
     ucp_proto_query_attr_t proto_attr;
     ucp_proto_info_row_t *row_elem;
     size_t range_start, range_end;
-    ucs_status_t status;
     int proto_valid;
 
     ucp_proto_select_param_dump(worker, ep_cfg_index, rkey_cfg_index,
@@ -175,12 +174,8 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
             continue;
         }
 
-        status = ucs_array_append(ucp_proto_info_table, &table);
-        if (status != UCS_OK) {
-            break;
-        }
+        row_elem = ucs_array_append(ucp_proto_info_table, &table, break);
 
-        row_elem = ucs_array_last(&table);
         ucs_snprintf_safe(row_elem->desc, sizeof(row_elem->desc), "%s%s",
                           proto_attr.is_estimation ? "(?) " : "",
                           proto_attr.desc);
@@ -318,7 +313,7 @@ void ucp_proto_config_info_str(ucp_worker_h worker,
 {
     const ucp_proto_select_elem_t *select_elem;
     ucp_worker_cfg_index_t new_key_cfg_index;
-    const ucp_proto_select_range_t *range;
+    const ucp_proto_perf_range_t *range;
     ucp_proto_query_attr_t proto_attr;
     ucp_proto_select_t *proto_select;
     double bandwidth;
@@ -356,7 +351,7 @@ void ucp_proto_config_info_str(ucp_worker_h worker,
     /* Find the relevant performance range */
     range     = ucp_proto_perf_range_search(select_elem, msg_length);
     bandwidth = ucp_proto_select_calc_bandwidth(&proto_config->select_param,
-                                                &range->super, msg_length);
+                                                range, msg_length);
     ucs_string_buffer_appendf(strb, " %.1f MB/s %.2f us", bandwidth / UCS_MBYTE,
                               msg_length / bandwidth * UCS_USEC_PER_SEC);
 }

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -80,7 +80,6 @@ ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
     init_params->caps->min_length           = 0;
     init_params->caps->num_ranges           = 1;
     init_params->caps->ranges[0].max_length = SIZE_MAX;
-    init_params->caps->ranges[0].name       = "reconfig";
     for (perf_type = 0; perf_type < UCP_PROTO_PERF_TYPE_LAST; ++perf_type) {
         init_params->caps->ranges[0].perf[perf_type] =
                 ucs_linear_func_make(INFINITY, 0);

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -40,12 +40,6 @@
 #define UCP_PROTO_SELECT_PARAM_STR_MAX 128
 
 
-typedef struct {
-    ucp_proto_perf_range_t super;
-    size_t                 cfg_thresh; /* Configured protocol threshold */
-} ucp_proto_select_range_t;
-
-
 /**
  * Protocol and its private configuration
  */
@@ -55,6 +49,9 @@ typedef struct {
 
     /* Protocol private configuration space */
     const void               *priv;
+
+    /* Configured protocol threshold */
+    size_t                   cfg_thresh;
 
     /* Endpoint configuration index this protocol was selected on */
     ucp_worker_cfg_index_t   ep_cfg_index;
@@ -88,7 +85,7 @@ typedef struct {
     const ucp_proto_threshold_elem_t *thresholds;
 
     /* Estimated performance for the selected protocols */
-    const ucp_proto_select_range_t   *perf_ranges;
+    const ucp_proto_perf_range_t     *perf_ranges;
 
     /* Private configuration area for the selected protocols */
     void                             *priv_buf;

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -44,13 +44,13 @@ ucp_proto_select_thresholds_search(const ucp_proto_select_elem_t *select_elem,
     return ucp_proto_thresholds_search_slow(thresholds + 3, msg_length);
 }
 
-static UCS_F_ALWAYS_INLINE const ucp_proto_select_range_t *
+static UCS_F_ALWAYS_INLINE const ucp_proto_perf_range_t *
 ucp_proto_perf_range_search(const ucp_proto_select_elem_t *select_elem,
                             size_t msg_length)
 {
-    const ucp_proto_select_range_t *range;
+    const ucp_proto_perf_range_t *range;
 
-    for (range = select_elem->perf_ranges; range->super.max_length < msg_length;
+    for (range = select_elem->perf_ranges; range->max_length < msg_length;
          ++range)
         ;
     return range;

--- a/src/ucs/arch/bitops.h
+++ b/src/ucs/arch/bitops.h
@@ -123,10 +123,29 @@ BEGIN_C_DECLS
 #define ucs_count_leading_zero_bits(_n) \
     ((sizeof(_n) <= 4) ? __builtin_clz((uint32_t)(_n)) : __builtin_clzl(_n))
 
-/* Returns the number of 1-bits by _idx mask */
-#define ucs_bitmap2idx(_map, _idx) \
-    ucs_popcount((_map) & (UCS_MASK(_idx)))
+/* Returns the number of bits lower than 'bit_index' that are set in 'mask'
+ * For example: ucs_idx2bitmap(mask=0xF0, idx=6) returns 2
+ */
+static inline unsigned ucs_bitmap2idx(uint64_t mask, unsigned bit_index)
+{
+    return ucs_popcount(mask & UCS_MASK(bit_index));
+}
 
+/* Returns the bit index of the 'idx'-th set bit in 'mask'
+ * For example: ucs_idx2bitmap(mask=0xF0, idx=1) returns 5
+ */
+static inline unsigned ucs_idx2bitmap(uint64_t mask, int idx)
+{
+    unsigned bit_index = 0;
+
+    while ((mask != 0) && (idx >= 0)) {
+        bit_index = ucs_count_trailing_zero_bits(mask);
+        mask     &= ~UCS_BIT(bit_index);
+        --idx;
+    }
+
+    return bit_index;
+}
 
 /**
  * Count how many bits at the end of the buffer are equal to zero.

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -35,6 +35,9 @@ void ucs_string_buffer_init_fixed(ucs_string_buffer_t *strb, char *buffer,
                                   size_t capacity)
 {
     ucs_array_init_fixed(&strb->str, buffer, capacity);
+    if (capacity > 0) {
+        ucs_array_elem(&strb->str, 0) = '\0';
+    }
 }
 
 void ucs_string_buffer_cleanup(ucs_string_buffer_t *strb)

--- a/src/ucs/stats/stats.c
+++ b/src/ucs/stats/stats.c
@@ -480,17 +480,13 @@ static size_t ucs_stats_agrgt_sum_clsid_alloc(ucs_stats_node_t *node)
     uint32_t counter_index;
     size_t *offset;
     ucs_stats_aggrgt_counter_name_t *counter_name;
-    ucs_status_t status;
 
     /* Get current array length and update it in the node structure */
     node->cls->class_id = ucs_array_length(&ucs_stats_context.aggrt_class_offsets);
 
-    status = ucs_array_append(aggrt_class_offsets, &ucs_stats_context.aggrt_class_offsets);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    offset = ucs_array_last(&ucs_stats_context.aggrt_class_offsets);
+    offset = ucs_array_append(aggrt_class_offsets,
+                              &ucs_stats_context.aggrt_class_offsets,
+                              return UCS_ERR_NO_MEMORY);
 
     /* Initialize entry */
     *offset = ucs_array_length(&ucs_stats_context.aggrgt_counter_names);
@@ -498,14 +494,10 @@ static size_t ucs_stats_agrgt_sum_clsid_alloc(ucs_stats_node_t *node)
     ucs_for_each_bit(counter_index, filter_node->counters_bitmask) {
         ucs_list_for_each(temp_node, &filter_node->type_list_head,
                           type_list) {
-            status = ucs_array_append(aggrgt_counter_names,
-                                      &ucs_stats_context.aggrgt_counter_names);
-            if (status != UCS_OK) {
-                return status;
-            }
-
-            counter_name = ucs_array_last(&ucs_stats_context.aggrgt_counter_names);
-
+            counter_name =
+                    ucs_array_append(aggrgt_counter_names,
+                                     &ucs_stats_context.aggrgt_counter_names,
+                                     return UCS_ERR_NO_MEMORY);
             counter_name->counter_name = node->cls->counter_names[counter_index];
             counter_name->class_name   = node->cls->name;
         }

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -209,4 +209,10 @@
 #define ucs_same_type(_type1, _type2) \
     __builtin_types_compatible_p(_type1, _type2)
 
+/*
+ * Iterate over all elements of a C-array
+ */
+#define ucs_carray_for_each(_elem, _array, _length) \
+    for ((_elem) = (_array); (_elem) < ((_array) + (_length)); ++(_elem))
+
 #endif /* UCS_COMPILER_DEF_H */

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -1057,7 +1057,6 @@ UCS_TEST_F(test_array, dynamic_array_int_append) {
 
     ucs_array_t(test_1int) test_array;
     std::vector<int> vec;
-    ucs_status_t status;
 
     ucs_array_init_dynamic(&test_array);
     EXPECT_FALSE(ucs_array_is_fixed(&test_array));
@@ -1065,10 +1064,9 @@ UCS_TEST_F(test_array, dynamic_array_int_append) {
     /* push same elements to the array and the std::vector */
     for (size_t i = 0; i < NUM_ELEMS; ++i) {
         int value = ucs::rand();
-        status = ucs_array_append(test_1int, &test_array);
-        ASSERT_UCS_OK(status);
+        int *elem = ucs_array_append(test_1int, &test_array, FAIL());
         EXPECT_EQ(i + 1, ucs_array_length(&test_array));
-        *ucs_array_last(&test_array) = value;
+        *elem = value;
         vec.push_back(value);
     }
 
@@ -1107,16 +1105,13 @@ UCS_TEST_F(test_array, dynamic_array_int_append) {
 
 void test_array::test_fixed(ucs_array_t(test_1int) *array, size_t capacity)
 {
-    ucs_status_t status;
-
     /* check initial capacity */
     size_t initial_capacity = ucs_array_capacity(array);
     EXPECT_LE(initial_capacity, capacity);
     EXPECT_GE(initial_capacity, capacity - 1);
 
     /* append one element */
-    status = ucs_array_append(test_1int, array);
-    ASSERT_UCS_OK(status);
+    ucs_array_append(test_1int, array, FAIL());
 
     size_t idx = ucs_array_length(array) - 1;
     ucs_array_elem(array, idx) = 17;

--- a/test/gtest/ucs/test_math.cc
+++ b/test/gtest/ucs/test_math.cc
@@ -208,6 +208,19 @@ UCS_TEST_F(test_math, for_each_submask) {
     }
 }
 
+UCS_TEST_F(test_math, bitmap_idx)
+{
+    EXPECT_EQ(2, ucs_bitmap2idx(0xF0, 6));
+    EXPECT_EQ(0, ucs_bitmap2idx(0xF0, 4));
+    EXPECT_EQ(0, ucs_bitmap2idx(0xFF, 0));
+    EXPECT_EQ(63, ucs_bitmap2idx(UINT64_MAX, 63));
+
+    EXPECT_EQ(5, ucs_idx2bitmap(0xF0, 1));
+    EXPECT_EQ(0, ucs_idx2bitmap(0xFF, 0));
+    EXPECT_EQ(5, ucs_idx2bitmap(0xFF, 5));
+    EXPECT_EQ(63, ucs_idx2bitmap(UINT64_MAX, 63));
+}
+
 UCS_TEST_F(test_math, linear_func) {
     ucs_linear_func_t func[3];
     double x, y[3];

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -243,6 +243,7 @@ UCS_TEST_F(test_string_buffer, fixed_init) {
     char buf[17];
 
     ucs_string_buffer_init_fixed(&strb, buf, sizeof(buf));
+    EXPECT_EQ(std::string(""), ucs_string_buffer_cstr(&strb));
     test_fixed(&strb, sizeof(buf));
 }
 


### PR DESCRIPTION
## Why
Preparation for adding protocols performance debug info.
The main goal is to get rid of `ucp_proto_select_range_t` and unify the performance envelope / stages calculation functions.
Each performance range will (in next PR) contain a performance "tree node" so better remove this extra hierarchy.

## How
- Flatten performance range heirarchy by moving cfg_thresh from `ucp_proto_select_range_t` to `ucp_proto_config_t`
- Remove perf_range name field; it will be replaced by a performance tree node with detailed information
- `ucp_proto_perf_envelope_make()` now just calculates the envelope of linear functions and is not aware of perf ranges (for better abstraction)
- `ucp_proto_init_parallel_stages()` combines the logic of `ucp_proto_perf_envelope_append()` and `ucp_proto_common_add_perf_ranges()`
- Split `ucp_proto_select_elem_init_thresh()` to 3 parts: generate candidates, calculate envelope, and add the selected protocols from the envelope.
- Add helper function `ucp_proto_caps_range_find()`
- Make `ucs_array_append()` more convenieit.
