### PR TITLE
UCT/IB: Add hybrid SRQ topology

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -292,6 +292,11 @@ static unsigned uct_dc_mlx5_iface_progress_ll(void *arg)
     return uct_dc_mlx5_iface_progress(arg, UCT_RC_MLX5_POLL_FLAG_LINKED_LIST);
 }
 
+static unsigned uct_dc_mlx5_iface_progress_hybrid(void *arg)
+{
+    return uct_dc_mlx5_iface_progress(arg, UCT_RC_MLX5_POLL_FLAG_HYBRID);
+}
+
 static unsigned uct_dc_mlx5_iface_progress_tm(void *arg)
 {
     return uct_dc_mlx5_iface_progress(arg, UCT_RC_MLX5_POLL_FLAG_TM);
@@ -633,6 +638,8 @@ uct_dc_mlx5_init_rx(uct_rc_iface_t *rc_iface,
 
     if (iface->super.config.srq_topo == UCT_RC_MLX5_SRQ_TOPO_LIST) {
         iface->super.super.progress = uct_dc_mlx5_iface_progress_ll;
+    } else if (iface->super.config.srq_topo == UCT_RC_MLX5_SRQ_TOPO_HYBRID) {
+        iface->super.super.progress = uct_dc_mlx5_iface_progress_hybrid;
     } else {
         iface->super.super.progress = uct_dc_mlx5_iface_progress_cyclic;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -851,6 +851,7 @@ void uct_ib_mlx5_srq_buff_init(uct_ib_mlx5_srq_t *srq, uint32_t head,
     srq->sw_pi     = UINT16_MAX;
     srq->mask      = tail;
     srq->stride    = uct_ib_mlx5_srq_stride(sge_num);
+    srq->free_wait = 0;
 
     for (i = head; i <= tail; ++i) {
         seg = uct_ib_mlx5_srq_get_wqe(srq, i);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -69,6 +69,8 @@
 #define UCT_IB_MLX5_MP_RQ_FIRST_MSG_FLAG UCS_BIT(29) /* MP first packet indication */
 #define UCT_IB_MLX5_MP_RQ_LAST_MSG_FLAG  UCS_BIT(30) /* MP last packet indication */
 #define UCT_IB_MLX5_MP_RQ_FILLER_FLAG    UCS_BIT(31) /* Filler CQE indicator */
+#define UCT_IB_MLX5_SRQ_HYBRID_WAIT      1 /* Max wait counts before using noncontiguous
+                                              freed seg in SRQ hybrid topology */
 
 #if HAVE_DECL_MLX5DV_UAR_ALLOC_TYPE_BF
 #  define UCT_IB_MLX5_UAR_ALLOC_TYPE_WC MLX5DV_UAR_ALLOC_TYPE_BF
@@ -345,6 +347,9 @@ typedef struct uct_ib_mlx5_srq {
         } devx;
 #endif
     };
+    uint8_t                            free_wait;  /* have waited how many times before
+                                                      using a noncontiguous freed seg
+                                                      in hybrid topology */
 } uct_ib_mlx5_srq_t;
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -94,6 +94,7 @@ typedef enum {
     UCT_RC_MLX5_SRQ_TOPO_LIST,
     UCT_RC_MLX5_SRQ_TOPO_CYCLIC,
     UCT_RC_MLX5_SRQ_TOPO_CYCLIC_EMULATED,
+    UCT_RC_MLX5_SRQ_TOPO_HYBRID,
     UCT_RC_MLX5_SRQ_TOPO_LAST
 } uct_rc_mlx5_srq_topo_t;
 
@@ -133,7 +134,8 @@ enum {
     UCT_RC_MLX5_POLL_FLAG_TM                 = UCS_BIT(0),
     UCT_RC_MLX5_POLL_FLAG_HAS_EP             = UCS_BIT(1),
     UCT_RC_MLX5_POLL_FLAG_TAG_CQE            = UCS_BIT(2),
-    UCT_RC_MLX5_POLL_FLAG_LINKED_LIST        = UCS_BIT(3)
+    UCT_RC_MLX5_POLL_FLAG_LINKED_LIST        = UCS_BIT(3),
+    UCT_RC_MLX5_POLL_FLAG_HYBRID             = UCS_BIT(4)
 };
 
 
@@ -568,6 +570,7 @@ extern ucs_config_field_t uct_rc_mlx5_common_config_table[];
 
 unsigned uct_rc_mlx5_iface_srq_post_recv(uct_rc_mlx5_iface_common_t *iface);
 unsigned uct_rc_mlx5_iface_srq_post_recv_ll(uct_rc_mlx5_iface_common_t *iface);
+unsigned uct_rc_mlx5_iface_srq_post_recv_hybrid(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_iface_common_prepost_recvs(uct_rc_mlx5_iface_common_t *iface);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -198,6 +198,12 @@ static unsigned uct_rc_mlx5_iface_progress_ll(void *arg)
                                            UCT_RC_MLX5_POLL_FLAG_LINKED_LIST);
 }
 
+static unsigned uct_rc_mlx5_iface_progress_hybrid(void *arg)
+{
+    return uct_rc_mlx5_iface_progress(arg, UCT_RC_MLX5_POLL_FLAG_HAS_EP |
+                                           UCT_RC_MLX5_POLL_FLAG_HYBRID);
+}
+
 static unsigned uct_rc_mlx5_iface_progress_tm(void *arg)
 {
     return uct_rc_mlx5_iface_progress(arg, UCT_RC_MLX5_POLL_FLAG_HAS_EP |
@@ -436,6 +442,9 @@ uct_rc_mlx5_iface_parse_srq_topo(uct_ib_mlx5_md_t *md,
         } else if (!strcasecmp(config->srq_topo.types[i], "cyclic_emulated")) {
             *topo_p = UCT_RC_MLX5_SRQ_TOPO_CYCLIC_EMULATED;
             return UCS_OK;
+        } else if (!strcasecmp(config->srq_topo.types[i], "hybrid")) {
+            *topo_p = UCT_RC_MLX5_SRQ_TOPO_HYBRID;
+            return UCS_OK;
         }
     }
 
@@ -608,6 +617,8 @@ uct_rc_mlx5_iface_init_rx(uct_rc_iface_t *rc_iface,
 
     if (iface->config.srq_topo == UCT_RC_MLX5_SRQ_TOPO_LIST) {
         iface->super.progress = uct_rc_mlx5_iface_progress_ll;
+    } else if (iface->config.srq_topo == UCT_RC_MLX5_SRQ_TOPO_HYBRID) {
+        iface->super.progress = uct_rc_mlx5_iface_progress_hybrid;
     } else {
         iface->super.progress = uct_rc_mlx5_iface_progress_cyclic;
     }


### PR DESCRIPTION
## What
Add a new SRQ topology: hybrid

## Why ?
list topology is suboptimal while cyclic_emulated is stopping SRQ in case of error flows. we need a hybrid which behaves as cyclic_emulated in normal case and behaves as list in case of error flows.

## How ?
try to use segments in order. only use next noncontiguous segment if wait for a time limit.
