### PR TITLE
remove exp verbs cq moderation configs

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -137,10 +137,6 @@ struct uct_ib_iface_config {
         size_t              min_inline;      /* Inline space to reserve for sends */
         unsigned            min_sge;         /* How many SG entries to support */
         uct_iface_mpool_config_t mp;
-
-        /* Event moderation parameters */
-        unsigned            cq_moderation_count;
-        double              cq_moderation_period;
     } tx;
 
     struct {
@@ -148,10 +144,6 @@ struct uct_ib_iface_config {
         unsigned            max_batch;       /* How many buffers can be batched to one post receive */
         unsigned            max_poll;        /* How many wcs can be picked when polling rx cq */
         uct_iface_mpool_config_t mp;
-
-        /* Event moderation parameters */
-        unsigned            cq_moderation_count;
-        double              cq_moderation_period;
     } rx;
 
     /* Inline space to reserve in CQ */

--- a/test/gtest/uct/ib/test_cq_moderation.cc
+++ b/test/gtest/uct/ib/test_cq_moderation.cc
@@ -34,11 +34,6 @@ protected:
             set_config("RC_FC_ENABLE=n");
         }
 
-        set_config(std::string("IB_TX_EVENT_MOD_PERIOD=") +
-                   ucs::to_string(moderation_period_usec) + "us");
-        set_config(std::string("IB_RX_EVENT_MOD_PERIOD=") +
-                   ucs::to_string(moderation_period_usec) + "us");
-
         m_sender = uct_test::create_entity(0, NULL, NULL, NULL, NULL, NULL,
                                            send_async_event_handler, this);
         m_entities.push_back(m_sender);


### PR DESCRIPTION
## What
remove exp verbs cq moderation configurations.

## Why ?
exp verbs has been removed in PR#8158.

## How ?
Align with the changes in PR#8158.
