### PR TITLE
GTEST/UCT/UD: Reproduce issue with error detection if new operations are scheduled

### DIFF
--- a/test/gtest/uct/ib/ud_base.cc
+++ b/test/gtest/uct/ib/ud_base.cc
@@ -6,13 +6,18 @@ void ud_base_test::init()
 {
     uct_test::init();
 
-    m_e1 = uct_test::create_entity(0);
+    m_e1 = uct_test::create_entity(0, get_err_handler());
     m_entities.push_back(m_e1);
 
     check_skip_test();
 
-    m_e2 = uct_test::create_entity(0);
+    m_e2 = uct_test::create_entity(0, get_err_handler());
     m_entities.push_back(m_e2);
+}
+
+uct_error_handler_t ud_base_test::get_err_handler() const
+{
+    return NULL;
 }
 
 uct_ud_ep_t *ud_base_test::ep(entity *e)

--- a/test/gtest/uct/ib/ud_base.h
+++ b/test/gtest/uct/ib/ud_base.h
@@ -24,6 +24,8 @@ class ud_base_test : public uct_test {
 public:
     virtual void init();
 
+    virtual uct_error_handler_t get_err_handler() const;
+
     uct_ud_ep_t *ep(entity *e);
 
     uct_ud_ep_t *ep(entity *e, int i);


### PR DESCRIPTION
## What

Reproduce issue with error detection if new operations are scheduled

## Why ?

The PR adds test for the issue fixed in #8219.

## How ?

1. Introduce error handling in test_ud.cc if required.
2. Add the test which post EP_CHECK and AM operations when a receiver was killed.