### PR TITLE
UCT/IB/UD/GTEST: Fix error detection if new operations are scheduled [v1.13.x]

### DIFF
--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -162,6 +162,10 @@ uct_ud_iface_complete_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
     iface->tx.skb  = ucs_mpool_get(&iface->tx.mp);
     ep->tx.psn++;
 
+    if (ucs_queue_is_empty(&ep->tx.window)) {
+        ep->tx.send_time = now;
+    }
+
     ucs_queue_push(&ep->tx.window, &skb->queue);
     ep->tx.tick = iface->tx.tick;
 
@@ -169,8 +173,6 @@ uct_ud_iface_complete_tx_skb(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
         ucs_wtimer_add(&iface->tx.timer, &ep->timer,
                        now - ucs_twheel_get_time(&iface->tx.timer) + ep->tx.tick);
     }
-
-    ep->tx.send_time = now;
 }
 
 static UCS_F_ALWAYS_INLINE void


### PR DESCRIPTION
## What

Fix error detection if new operations are scheduled.

## Why ?

See #8219.

## How ?

See #8219..