### PR TITLE
UCT/ROCM: bring ROCm fixes over to v1.13 branch

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -176,6 +176,7 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
 {
     hsa_status_t status;
     hsa_amd_pointer_info_t info;
+    hsa_device_type_t dev_type;
 
     *mem_type_p = UCS_MEMORY_TYPE_HOST;
     if (addr == NULL) {
@@ -183,10 +184,16 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     }
 
     info.size = sizeof(hsa_amd_pointer_info_t);
-    status = hsa_amd_pointer_info((void*)addr, &info, NULL, NULL, NULL);
+    status    = hsa_amd_pointer_info((void*)addr, &info, NULL, NULL, NULL);
     if ((status == HSA_STATUS_SUCCESS) &&
-        (info.type != HSA_EXT_POINTER_TYPE_UNKNOWN)) {
-        *mem_type_p = UCS_MEMORY_TYPE_ROCM;
+        (info.type == HSA_EXT_POINTER_TYPE_HSA)) {
+        status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE,
+                                    &dev_type);
+        if ((status == HSA_STATUS_SUCCESS) &&
+            (dev_type == HSA_DEVICE_TYPE_GPU)) {
+            *mem_type_p = UCS_MEMORY_TYPE_ROCM;
+            return UCS_OK;
+        }
     }
 
     return UCS_OK;

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -14,12 +14,12 @@
 #include <pthread.h>
 
 
-#define MAX_AGENTS 16
+#define MAX_AGENTS 63
 static struct agents {
-    hsa_agent_t agents[MAX_AGENTS];
     int num;
-    hsa_agent_t gpu_agents[MAX_AGENTS];
+    hsa_agent_t agents[MAX_AGENTS];
     int num_gpu;
+    hsa_agent_t gpu_agents[MAX_AGENTS];
 } uct_rocm_base_agents;
 
 int uct_rocm_base_get_gpu_agents(hsa_agent_t **agents)


### PR DESCRIPTION
## What
This pr brings three fixes from the master repository over to the v1.13 branch.
The three Prs are:

UCT/ROCM: increase max. number of hsa agents
(cherry picked from commit https://github.com/openucx/ucx/commit/7baac93d8a046a3e305ebb1247bfa7849076eb39)

UCT/ROCM: fix memory type detection 
(cherry picked from commit https://github.com/openucx/ucx/commit/4a876b592bb0154b26562f84de6e1517c7341815)

UCT/ROCM/IPC: use remote_agent if available
(cherry picked from commit https://github.com/openucx/ucx/commit/79ea940bebe9308366dd467567f6867ccdcd16b7)

## Why ?
All three commits are required for correct execution of rocm/ucx jobs.

## How ?