### PR TITLE
UCT/IB: Fix CQ length calculation in UD/DC

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -211,6 +211,13 @@ typedef struct uct_ib_iface_init_attr {
 } uct_ib_iface_init_attr_t;
 
 
+#if HAVE_DECL_IBV_CREATE_QP_EX
+typedef struct ibv_qp_init_attr_ex uct_ib_qp_init_attr_t;
+#else
+typedef struct ibv_qp_init_attr uct_ib_qp_init_attr_t;
+#endif
+
+
 typedef struct uct_ib_qp_attr {
     int                         qp_type;
     struct ibv_qp_cap           cap;
@@ -219,11 +226,7 @@ typedef struct uct_ib_qp_attr {
     uint32_t                    srq_num;
     unsigned                    sq_sig_all;
     unsigned                    max_inl_cqe[UCT_IB_DIR_NUM];
-#if HAVE_DECL_IBV_CREATE_QP_EX
-    struct ibv_qp_init_attr_ex  ibv;
-#else
-    struct ibv_qp_init_attr     ibv;
-#endif
+    uct_ib_qp_init_attr_t       ibv;
 } uct_ib_qp_attr_t;
 
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -28,6 +28,108 @@ ucs_status_t uct_ib_mlx5dv_init_obj(uct_ib_mlx5dv_t *obj, uint64_t type)
 }
 #endif
 
+void uct_ib_mlx5dv_dc_qp_init_attr(struct mlx5dv_qp_init_attr *dv_attr,
+                                   enum mlx5dv_dc_type dc_type)
+{
+    dv_attr->comp_mask                   = MLX5DV_QP_INIT_ATTR_MASK_DC;
+    dv_attr->dc_init_attr.dc_type        = dc_type;
+    dv_attr->dc_init_attr.dct_access_key = UCT_IB_KEY;
+}
+
+void uct_ib_mlx5dv_dct_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
+                                    struct mlx5dv_qp_init_attr *dv_attr,
+                                    struct ibv_pd *pd, struct ibv_cq *cq,
+                                    struct ibv_srq *srq)
+{
+    qp_attr->comp_mask = IBV_QP_INIT_ATTR_PD;
+    qp_attr->pd        = pd;
+    qp_attr->recv_cq   = cq;
+    /* DCT can't send, but send_cq have to point to valid CQ */
+    qp_attr->send_cq   = cq;
+    qp_attr->srq       = srq;
+    qp_attr->qp_type   = IBV_QPT_DRIVER;
+    uct_ib_mlx5dv_dc_qp_init_attr(dv_attr, MLX5DV_DCTYPE_DCT);
+}
+
+ucs_status_t
+uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
+                                 uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs)
+{
+    struct ibv_srq_init_attr srq_attr = {};
+    ucs_status_t status;
+    int cq_errno;
+    char message[128];
+
+    qp_tmp_objs->cq = ibv_create_cq(dev->ibv_context, 1, NULL, NULL, 0);
+    if (qp_tmp_objs->cq == NULL) {
+        cq_errno = errno;
+        ucs_snprintf_safe(message, sizeof(message), "%s: ibv_create_cq()",
+                          uct_ib_device_name(dev));
+        uct_ib_mem_lock_limit_msg(message, cq_errno, UCS_LOG_LEVEL_ERROR);
+        status = UCS_ERR_IO_ERROR;
+        goto out;
+    }
+
+    srq_attr.attr.max_sge = 1;
+    srq_attr.attr.max_wr  = 1;
+    qp_tmp_objs->srq      = ibv_create_srq(pd, &srq_attr);
+    if (qp_tmp_objs->srq == NULL) {
+        ucs_error("%s: ibv_create_srq() failed: %m", uct_ib_device_name(dev));
+        status = UCS_ERR_IO_ERROR;
+        goto out_destroy_cq;
+    }
+
+    return UCS_OK;
+
+out_destroy_cq:
+    ibv_destroy_cq(qp_tmp_objs->cq);
+out:
+    return status;
+}
+
+void uct_ib_mlx5dv_qp_tmp_objs_destroy(uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs)
+{
+    uct_ib_destroy_srq(qp_tmp_objs->srq);
+    ibv_destroy_cq(qp_tmp_objs->cq);
+}
+
+size_t uct_ib_mlx5dv_calc_tx_wqe_ratio(struct ibv_qp *qp, uint32_t max_send_wr,
+                                       size_t *tx_wqe_ratio_p)
+{
+    uct_ib_mlx5dv_qp_t qp_info = {};
+    uct_ib_mlx5dv_t obj        = {};
+    ucs_status_t status;
+
+    obj.dv.qp.in  = qp;
+    obj.dv.qp.out = &qp_info.dv;
+
+    status = uct_ib_mlx5dv_init_obj(&obj, MLX5DV_OBJ_QP);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *tx_wqe_ratio_p = qp_info.dv.sq.wqe_cnt / max_send_wr;
+    return UCS_OK;
+}
+
+void uct_ib_mlx5dv_qp_init_attr(uct_ib_qp_init_attr_t *qp_init_attr,
+                                struct ibv_pd *pd,
+                                const uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs,
+                                enum ibv_qp_type qp_type, uint32_t max_recv_wr)
+{
+    qp_init_attr->send_cq         = qp_tmp_objs->cq;
+    qp_init_attr->recv_cq         = qp_tmp_objs->cq;
+    qp_init_attr->srq             = qp_tmp_objs->srq;
+    qp_init_attr->qp_type         = qp_type;
+    qp_init_attr->sq_sig_all      = 0;
+#if HAVE_DECL_IBV_CREATE_QP_EX
+    qp_init_attr->comp_mask       = IBV_QP_INIT_ATTR_PD;
+    qp_init_attr->pd              = pd;
+#endif
+    qp_init_attr->cap.max_send_wr = 128;
+    qp_init_attr->cap.max_recv_wr = max_recv_wr;
+}
+
 #if HAVE_DEVX
 ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
                                         uct_ib_mlx5_qp_t *qp,
@@ -48,7 +150,6 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
     int max_tx, max_rx, len_tx, len;
     uct_ib_mlx5_devx_uar_t *uar;
     ucs_status_t status;
-    int wqe_size;
     int dvflags;
     void *qpc;
     int ret;
@@ -72,15 +173,8 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
         goto err;
     }
 
-    wqe_size = sizeof(struct mlx5_wqe_ctrl_seg) +
-               sizeof(struct mlx5_wqe_umr_ctrl_seg) +
-               sizeof(struct mlx5_wqe_mkey_context_seg) +
-               ucs_max(sizeof(struct mlx5_wqe_umr_klm_seg), 64) +
-               ucs_max(attr->super.cap.max_send_sge * sizeof(struct mlx5_wqe_data_seg),
-                       ucs_align_up(sizeof(struct mlx5_wqe_inl_data_seg) +
-                                    attr->super.cap.max_inline_data, 16));
-    len_tx = ucs_roundup_pow2_or0(attr->super.cap.max_send_wr * wqe_size);
-    max_tx = len_tx / MLX5_SEND_WQE_BB;
+    max_tx = uct_ib_mlx5_devx_sq_length(attr->super.cap.max_send_wr);
+    len_tx = max_tx * MLX5_SEND_WQE_BB;
     max_rx = ucs_roundup_pow2_or0(attr->super.cap.max_recv_wr);
     len    = len_tx + max_rx * UCT_IB_MLX5_MAX_BB * UCT_IB_MLX5_WQE_SEG_SIZE;
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
@@ -28,10 +28,56 @@ typedef struct {
     struct mlx5dv_cq   dv;
 } uct_ib_mlx5dv_cq_t;
 
+typedef struct uct_ib_mlx5dv_qp_tmp_objs {
+    struct ibv_srq *srq;
+    struct ibv_cq  *cq;
+} uct_ib_mlx5dv_qp_tmp_objs_t;
+
+
 /**
  * Get internal verbs information.
  */
 ucs_status_t uct_ib_mlx5dv_init_obj(uct_ib_mlx5dv_t *obj, uint64_t type);
+
+/**
+ * Initialize DC-specific DV QP attributes.
+ */
+void uct_ib_mlx5dv_dc_qp_init_attr(struct mlx5dv_qp_init_attr *dv_attr,
+                                   enum mlx5dv_dc_type dc_type);
+
+/**
+ * Initialize DCT-specific QP attributes.
+ */
+void uct_ib_mlx5dv_dct_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
+                                    struct mlx5dv_qp_init_attr *dv_attr,
+                                    struct ibv_pd *pd, struct ibv_cq *cq,
+                                    struct ibv_srq *srq);
+
+/**
+ * Creates CQ and SRQ which are needed for creating QP.
+ */
+ucs_status_t
+uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
+                                 uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs);
+
+/**
+ * Closes CQ and SRQ which are needed for creating QP.
+ */
+void uct_ib_mlx5dv_qp_tmp_objs_destroy(uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs);
+
+/**
+ * Calculates TX WQE ratio.
+ */
+size_t uct_ib_mlx5dv_calc_tx_wqe_ratio(struct ibv_qp *qp, uint32_t max_send_wr,
+                                       size_t *tx_wqe_ratio_p);
+
+/**
+ * Sets QP initialization attributes.
+ */
+void uct_ib_mlx5dv_qp_init_attr(uct_ib_qp_init_attr_t *qp_init_attr,
+                                struct ibv_pd *pd,
+                                const uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs,
+                                enum ibv_qp_type qp_type, uint32_t max_recv_wr);
 
 /**
  * Update CI to support req_notify_cq

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -35,6 +35,7 @@ typedef struct uct_ib_mlx5_mem {
     uct_ib_mlx5_mr_t           mrs[];
 } uct_ib_mlx5_mem_t;
 
+
 static ucs_status_t uct_ib_mlx5_reg_key(uct_ib_md_t *md, void *address,
                                         size_t length, uint64_t access_flags,
                                         uct_ib_mem_t *ib_memh,
@@ -1130,18 +1131,14 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
 {
     ucs_status_t status = UCS_OK;
 #if HAVE_DC_DV
-    struct ibv_srq_init_attr srq_attr = {};
-    struct ibv_context *ctx = dev->ibv_context;
-    struct ibv_qp_init_attr_ex qp_attr = {};
+    struct ibv_context *ctx            = dev->ibv_context;
+    uct_ib_qp_init_attr_t qp_init_attr = {};
     struct mlx5dv_qp_init_attr dv_attr = {};
-    struct ibv_qp_attr attr = {};
-    struct ibv_srq *srq;
+    struct ibv_qp_attr attr            = {};
+    uct_ib_mlx5dv_qp_tmp_objs_t qp_tmp_objs;
     struct ibv_pd *pd;
-    struct ibv_cq *cq;
     struct ibv_qp *qp;
     int ret;
-    char message[128];
-    int cq_errno;
 
     pd = ibv_alloc_pd(ctx);
     if (pd == NULL) {
@@ -1150,43 +1147,22 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
         goto out;
     }
 
-    cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
-    if (cq == NULL) {
-        cq_errno = errno;
-        ucs_snprintf_safe(message, sizeof(message), "%s: ibv_create_cq()",
-                          uct_ib_device_name(dev));
-        uct_ib_mem_lock_limit_msg(message, cq_errno, UCS_LOG_LEVEL_ERROR);
-        status = UCS_ERR_IO_ERROR;
+    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, pd, &qp_tmp_objs);
+    if (status != UCS_OK) {
         goto out_dealloc_pd;
     }
 
-    srq_attr.attr.max_sge   = 1;
-    srq_attr.attr.max_wr    = 1;
-    srq = ibv_create_srq(pd, &srq_attr);
-    if (srq == NULL) {
-        ucs_error("%s: ibv_create_srq() failed: %m", uct_ib_device_name(dev));
-        status = UCS_ERR_IO_ERROR;
-        goto out_destroy_cq;
-    }
-
-    qp_attr.send_cq              = cq;
-    qp_attr.recv_cq              = cq;
-    qp_attr.qp_type              = IBV_QPT_DRIVER;
-    qp_attr.comp_mask            = IBV_QP_INIT_ATTR_PD;
-    qp_attr.pd                   = pd;
-    qp_attr.srq                  = srq;
-
-    dv_attr.comp_mask            = MLX5DV_QP_INIT_ATTR_MASK_DC;
-    dv_attr.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCT;
-    dv_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
+    uct_ib_mlx5dv_dct_qp_init_attr(&qp_init_attr, &dv_attr, pd, qp_tmp_objs.cq,
+                                   qp_tmp_objs.srq);
 
     /* create DCT qp successful means DC is supported */
-    qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, ctx, &qp_attr, &dv_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, ctx, &qp_init_attr,
+                                 &dv_attr);
     if (qp == NULL) {
         ucs_debug("%s: mlx5dv_create_qp(DCT) failed: %m",
                   uct_ib_device_name(dev));
         status = UCS_OK;
-        goto out_destroy_srq;
+        goto out_qp_tmp_objs_close;
     }
 
     attr.qp_state        = IBV_QPS_INIT;
@@ -1233,10 +1209,8 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
 
 out_destroy_qp:
     uct_ib_destroy_qp(qp);
-out_destroy_srq:
-    uct_ib_destroy_srq(srq);
-out_destroy_cq:
-    ibv_destroy_cq(cq);
+out_qp_tmp_objs_close:
+    uct_ib_mlx5dv_qp_tmp_objs_destroy(&qp_tmp_objs);
 out_dealloc_pd:
     ibv_dealloc_pd(pd);
 out:
@@ -1355,4 +1329,3 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
 };
 
 UCT_IB_MD_DEFINE_ENTRY(dv, uct_ib_mlx5_md_ops);
-

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -939,6 +939,11 @@ void uct_ib_mlx5_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp)
     }
 }
 
+size_t uct_ib_mlx5_devx_sq_length(size_t tx_qp_length)
+{
+    return ucs_roundup_pow2_or0(tx_qp_length * UCT_IB_MLX5_MAX_BB);
+}
+
 /* Keep the function as a separate to test SL selection */
 ucs_status_t
 uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -274,6 +274,10 @@ typedef struct uct_ib_mlx5_md {
 
     uint8_t                  mkey_tag;
 #endif
+    struct {
+        size_t dc;
+        size_t ud;
+    } dv_tx_wqe_ratio;
     /* The maximum number of outstanding RDMA Read/Atomic operations per DC QP. */
     uint8_t                  max_rd_atomic_dc;
 } uct_ib_mlx5_md_t;
@@ -845,6 +849,8 @@ uct_ib_mlx5_devx_query_qp_peer_info(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp,
 static inline void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp) { }
 
 #endif
+
+size_t uct_ib_mlx5_devx_sq_length(size_t tx_qp_length);
 
 ucs_status_t
 uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -1000,7 +1000,7 @@ void uct_rc_mlx5_iface_common_dm_cleanup(uct_rc_mlx5_iface_common_t *iface)
 
 #if HAVE_DECL_MLX5DV_CREATE_QP
 void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
-                                        struct ibv_qp_init_attr_ex *qp_attr,
+                                        uct_ib_qp_init_attr_t *qp_attr,
                                         struct mlx5dv_qp_init_attr *dv_attr,
                                         unsigned scat2cqe_dir_mask)
 {

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -688,7 +688,7 @@ uct_rc_mlx5_am_hdr_fill(uct_rc_mlx5_hdr_t *rch, uint8_t id)
 
 #if HAVE_DECL_MLX5DV_CREATE_QP
 void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
-                                        struct ibv_qp_init_attr_ex *qp_attr,
+                                        uct_ib_qp_init_attr_t *qp_attr,
                                         struct mlx5dv_qp_init_attr *dv_attr,
                                         unsigned scat2cqe_dir_mask);
 #endif


### PR DESCRIPTION
## What

Fix CQ length calculation in UD/DC.

## Why ?

CQ length could be less than:
- QP_length in UD
- num_dcis * QP_length in DC

## How ?

1. Calculate `tx_wqe_ratio` in case of DV by creating fake QP (UD or DCI) and getting `wqe_cnt / qp_init_attr.cap.max_send_wr`.
2. Remove `wqe_size` calculation in case of DEVX; use `UCT_IB_MLX5_MAX_BB` value which is `4` to calculate QP length.