### PR TITLE
UCT/CM: Fix destroying listener in parallel with conn_req_cb

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_listener.c
+++ b/src/uct/ib/rdmacm/rdmacm_listener.c
@@ -11,6 +11,7 @@
 #include "rdmacm_listener.h"
 
 #include <ucs/sys/sock.h>
+#include <ucs/async/async.h>
 
 
 #define UCS_RDMACM_MAX_BACKLOG_PATH        "/proc/sys/net/rdma_ucm/max_backlog"
@@ -128,8 +129,12 @@ ucs_status_t uct_rdmacm_listener_reject(uct_listener_h listener,
 
 UCS_CLASS_CLEANUP_FUNC(uct_rdmacm_listener_t)
 {
+    ucs_async_context_t *async = self->super.cm->iface.worker->async;
+
+    UCS_ASYNC_BLOCK(async);
     ucs_debug("listener %p: destroying rdma_cm_id %p", self, self->id);
     uct_rdmacm_cm_destroy_id(self->id);
+    UCS_ASYNC_UNBLOCK(async);
 }
 
 ucs_status_t uct_rdmacm_listener_query(uct_listener_h listener,

--- a/src/uct/tcp/tcp_listener.c
+++ b/src/uct/tcp/tcp_listener.c
@@ -145,7 +145,10 @@ err:
 
 UCS_CLASS_CLEANUP_FUNC(uct_tcp_listener_t)
 {
+    ucs_async_context_t *async = self->super.cm->iface.worker->async;
     ucs_status_t status;
+
+    UCS_ASYNC_BLOCK(async);
 
     status = ucs_async_remove_handler(self->listen_fd, 1);
     if (status != UCS_OK) {
@@ -154,6 +157,8 @@ UCS_CLASS_CLEANUP_FUNC(uct_tcp_listener_t)
     }
 
     ucs_close_fd(&self->listen_fd);
+
+    UCS_ASYNC_UNBLOCK(async);
 }
 
 ucs_status_t uct_tcp_listener_reject(uct_listener_h listener,

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -119,6 +119,7 @@ gtest_SOURCES = \
 	ucs/test_event_set.cc \
 	ucs/test_stats_filter.cc \
 	uct/test_peer_failure.cc \
+	uct/test_sockaddr.cc \
 	uct/test_tag.cc \
 	uct/tcp/test_tcp.cc \
 	\
@@ -227,10 +228,6 @@ endif
 if HAVE_MLX5_DV
 gtest_SOURCES += \
 	uct/ib/test_cqe_zipping.cc
-endif
-if HAVE_RDMACM
-gtest_SOURCES += \
-	uct/ib/test_sockaddr.cc
 endif
 endif # HAVE_IB
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1099,6 +1099,12 @@ uct_listener_h uct_test::entity::listener() const {
     return m_listener;
 }
 
+uct_listener_h uct_test::entity::revoke_listener() const {
+    uct_listener_h uct_listener = listener();
+    m_listener.revoke();
+    return uct_listener;
+}
+
 uct_iface_h uct_test::entity::iface() const {
     return m_iface;
 }

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -20,7 +20,7 @@
 #include <common/mem_buffer.h>
 #include <common/test.h>
 #include <vector>
-
+#include <atomic>
 
 
 #define DEFAULT_DELAY_MS           1.0
@@ -167,6 +167,8 @@ protected:
         const uct_cm_attr_t& cm_attr() const;
 
         uct_listener_h listener() const;
+
+        uct_listener_h revoke_listener() const;
 
         uct_iface_h iface() const;
 
@@ -319,7 +321,8 @@ protected:
         }
     }
 
-    void wait_for_bits(volatile uint64_t *flag, uint64_t mask,
+    template <typename FlagType, typename MaskType>
+    void wait_for_bits(FlagType *flag, MaskType mask,
                        double timeout = DEFAULT_TIMEOUT_SEC) const
     {
         ucs_time_t deadline = ucs_get_time() +


### PR DESCRIPTION
## What

Fix case when destroying listener in parallel with conn_req_cb invocation.

## Why ?

Reproduces and fixes the case when UCT listener is destroyed in parallel with conn_req_cb invocation.

## How ?

1. Add gtest which emulates destroying of UCT listener and conn_req_cb invocation in different threads simultaneously.
2. Add `UCS_ASYNC_BLOCK`/`UCS_ASYNC_UNBLOCK` in RDMACM's and TCP_SOCKM's listener destroy functions.