### PR TITLE
GTEST: Remove skipping of tests on DC due to DCI stuck issue

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -64,15 +64,6 @@ public:
         test_ucp_tag::cleanup();
     }
 
-    bool skip_on_ib_dc() {
-#if HAVE_DC_DV
-        // skip due to DCI stuck bug
-        return has_transport("dc_x");
-#else
-        return false;
-#endif
-    }
-
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         add_variant_with_value(variants, get_ctx_params(), VARIANT_DEFAULT, "");
@@ -608,8 +599,7 @@ UCS_TEST_P(test_ucp_tag_xfer, generic_err_exp) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic_err, true, false, false);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_tag_xfer, generic_err_unexp,
-                     skip_on_ib_dc()) {
+UCS_TEST_P(test_ucp_tag_xfer, generic_err_unexp) {
     test_xfer(&test_ucp_tag_xfer::test_xfer_generic_err, false, false, false);
 }
 

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -53,14 +53,6 @@ protected:
         m_sender->destroy_ep(0);
     }
 
-    bool skip_on_ib_dc() {
-#ifdef HAVE_DC_DV /* skip due to DCI stuck bug */
-        return has_transport("dc_mlx5");
-#else
-        return false;
-#endif
-    }
-
     struct test_ep_comp_t {
         uct_completion_t comp;
         test_uct_ep      *test;
@@ -106,8 +98,7 @@ protected:
 };
 
 UCS_TEST_SKIP_COND_P(test_uct_ep, disconnect_after_send,
-                     (!check_caps(UCT_IFACE_FLAG_AM_ZCOPY) ||
-                      skip_on_ib_dc())) {
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY)) {
     ucs_status_t status;
 
     create_sender();


### PR DESCRIPTION
## What

Remove skipping of tests on DC due to DCI stuck issue.

## Why ?

DCI stuck issues shouldn't appear anymore.

## How ?

1. Remove skip condition in `test_ucp_tag_xfer.generic_err_unexp`.
2. Remove skip condition in `test_uct_ep.disconnect_after_send`.