### PR TITLE
UCT/API: Introduce uct_mem_reg_v2

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -192,6 +192,15 @@ typedef struct {
 
 /**
  * @ingroup UCT_MD
+ * @brief MD memory registration operation flags.
+ */
+typedef enum {
+    UCT_MD_MEM_REG_FIELD_FLAGS = UCS_BIT(0)
+} uct_md_mem_reg_field_mask_t;
+
+
+/**
+ * @ingroup UCT_MD
  * @brief MD memory de-registration operation flags.
  */
 typedef enum {
@@ -310,6 +319,26 @@ typedef void (*uct_md_mem_invalidate_cb_t)(void *arg);
 
 /**
  * @ingroup UCT_MD
+ * @brief Operation parameters passed to @ref uct_md_mem_reg_v2.
+ */
+typedef struct uct_md_mem_reg_params {
+    /**
+     * Mask of valid fields in this structure and operation flags, using
+     * bits from @ref uct_md_mem_reg_field_mask_t. Fields not specified
+     * in this mask will be ignored. Provides ABI compatibility with respect
+     * to adding new fields.
+     */
+    uint64_t                     field_mask;
+
+    /**
+     * Operation specific flags, using bits from @ref uct_md_mem_flags_t.
+     */
+    uint64_t                     flags;
+} uct_md_mem_reg_params_t;
+
+
+/**
+ * @ingroup UCT_MD
  * @brief Operation parameters passed to @ref uct_md_mem_dereg_v2.
  */
 typedef struct uct_md_mem_dereg_params {
@@ -419,16 +448,39 @@ uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr);
 
 /**
  * @ingroup UCT_MD
- * @brief Undo the operation of @ref uct_md_mem_reg() and invalidate memory
- *        region.
+ * @brief Register memory for zero-copy sends and remote access.
+ *
+ * Register memory on the memory domain. In order to use this function, @a md
+ * must support the @ref UCT_MD_FLAG_REG flag.
+ *
+ * @param [in]  md          Memory domain that was used to register the memory.
+ * @param [in]  address     Memory to register.
+ * @param [in]  length      Size of memory to register. Must be > 0.
+ * @param [in]  params      Operation parameters, see @ref
+ *                          uct_md_mem_reg_params_t.
+ * @param [out] memh_p      Filled with handle for allocated region.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_md_mem_reg_v2(uct_md_h md, void *address, size_t length,
+                               const uct_md_mem_reg_params_t *params,
+                               uct_mem_h *memh_p);
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Undo the operation of @ref uct_md_mem_reg() or
+ *        @ref uct_md_mem_reg_v2() and invalidate memory region.
  *
  * This routine deregisters the memory region registered by @ref uct_md_mem_reg
- * and allow the memory region to be invalidated with callback called when the
+ * and allows the memory region to be invalidated with callback called when the
  * memory region is unregistered.
  *
  * @param [in]  md          Memory domain that was used to register the memory.
  * @param [in]  params      Operation parameters, see @ref
  *                          uct_md_mem_dereg_params_t.
+ *
+ * @return Error code.
  */
 ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
                                  const uct_md_mem_dereg_params_t *params);

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -25,6 +25,10 @@
     ucs_log(uct_md_reg_log_lvl(_flags), _fmt, ## __VA_ARGS__)
 
 
+#define UCT_MD_MEM_REG_FIELD_VALUE(_params, _name, _flag, _default) \
+    UCS_PARAM_VALUE(UCT_MD_MEM_REG, _params, _name, _flag, _default)
+
+
 #define UCT_MD_MEM_DEREG_FIELD_VALUE(_params, _name, _flag, _default) \
     UCS_PARAM_VALUE(UCT_MD_MEM_DEREG, _params, _name, _flag, _default)
 
@@ -92,10 +96,10 @@ typedef ucs_status_t (*uct_md_mem_advise_func_t)(uct_md_h md,
                                                  size_t length,
                                                  unsigned advice);
 
-typedef ucs_status_t (*uct_md_mem_reg_func_t)(uct_md_h md, void *address,
-                                              size_t length,
-                                              unsigned flags,
-                                              uct_mem_h *memh_p);
+typedef ucs_status_t
+(*uct_md_mem_reg_func_t)(uct_md_h md, void *address, size_t length,
+                         const uct_md_mem_reg_params_t *params,
+                         uct_mem_h *memh_p);
 
 typedef ucs_status_t
 (*uct_md_mem_dereg_func_t)(uct_md_h md,
@@ -220,6 +224,12 @@ ucs_status_t uct_mem_alloc_check_params(size_t length,
                                         unsigned num_methods,
                                         const uct_mem_alloc_params_t *params);
 
+ucs_status_t uct_md_dummy_mem_reg(uct_md_h md, void *address, size_t length,
+                                  const uct_md_mem_reg_params_t *params,
+                                  uct_mem_h *memh_p);
+
+ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
+                                    const uct_md_mem_dereg_params_t *params);
 
 void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
                               const uct_md_rcache_config_t *rcache_config);

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -88,19 +88,15 @@ static ucs_status_t uct_cuda_copy_rkey_release(uct_component_t *component,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
-                 (md, address, length, flags, memh_p),
+                 (md, address, length, params, memh_p),
                  uct_md_h md, void *address, size_t length,
-                 unsigned flags, uct_mem_h *memh_p)
+                 const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
+    uint64_t flags = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0);
     ucs_log_level_t log_level;
     CUmemorytype memType;
     CUresult result;
     ucs_status_t status;
-
-    if (address == NULL) {
-        *memh_p = address;
-        return UCS_OK;
-    }
 
     result = cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                    (CUdeviceptr)(address));

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -226,9 +226,7 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
     CUdevice cu_device;
     ucs_status_t status;
 
-    if (!length) {
-        return UCS_OK;
-    }
+    ucs_assert((addr != NULL) && (length != 0));
 
     log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
                 UCS_LOG_LEVEL_ERROR;
@@ -252,8 +250,9 @@ uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
     return UCS_OK;
 }
 
-static ucs_status_t uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
-                                         unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
+                     const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_cuda_ipc_key_t *key;
     ucs_status_t status;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -115,10 +115,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
     ucs_log_level_t log_level;
     int ret;
 
-    if (!length) {
-        memset(mem_hndl, 0, sizeof(*mem_hndl));
-        return UCS_OK;
-    }
+    ucs_assert((address != NULL) && (length != 0));
 
     log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
                 UCS_LOG_LEVEL_ERROR;
@@ -188,8 +185,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_dereg_internal,
     return UCS_OK;
 }
 
-static ucs_status_t uct_gdr_copy_mem_reg(uct_md_h uct_md, void *address, size_t length,
-                                         unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_gdr_copy_mem_reg(uct_md_h uct_md, void *address, size_t length,
+                     const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_gdr_copy_mem_t *mem_hndl = NULL;
     void *start, *end;
@@ -289,8 +287,11 @@ uct_gdr_copy_rache_region_from_memh(uct_mem_h memh)
 
 static ucs_status_t
 uct_gdr_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
-                            unsigned flags, uct_mem_h *memh_p)
+                            const uct_md_mem_reg_params_t *params,
+                            uct_mem_h *memh_p)
 {
+    uint64_t flags        = UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
+                                                       FIELD_FLAGS, 0);
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
     ucs_rcache_region_t *rregion;
     ucs_status_t status;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -752,9 +752,12 @@ err:
     return status;
 }
 
-static ucs_status_t uct_ib_mem_reg(uct_md_h uct_md, void *address, size_t length,
-                                   unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_ib_mem_reg(uct_md_h uct_md, void *address, size_t length,
+               const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
+    uint64_t flags  = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS,
+                                                 0);
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
     ucs_status_t status;
     uct_ib_mem_t *memh;
@@ -958,10 +961,12 @@ static inline uct_ib_rcache_region_t* uct_ib_rcache_region_from_memh(uct_mem_h m
     return ucs_container_of(memh, uct_ib_rcache_region_t, memh);
 }
 
-static ucs_status_t uct_ib_mem_rcache_reg(uct_md_h uct_md, void *address,
-                                          size_t length, unsigned flags,
-                                          uct_mem_h *memh_p)
+static ucs_status_t
+uct_ib_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
+                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
+    uint64_t flags  = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS,
+                                                 0);
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
     ucs_rcache_region_t *rregion;
     ucs_status_t status;
@@ -1083,16 +1088,19 @@ static ucs_status_t uct_ib_md_odp_query(uct_md_h uct_md, uct_md_attr_t *md_attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_ib_mem_global_odp_reg(uct_md_h uct_md, void *address,
-                                              size_t length, unsigned flags,
-                                              uct_mem_h *memh_p)
+static ucs_status_t
+uct_ib_mem_global_odp_reg(uct_md_h uct_md, void *address, size_t length,
+                          const uct_md_mem_reg_params_t *params,
+                          uct_mem_h *memh_p)
 {
-    uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    uint64_t flags     = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS,
+                                                    0);
+    uct_ib_md_t *md    = ucs_derived_of(uct_md, uct_ib_md_t);
     uct_ib_mem_t *memh = md->global_odp;
 
     ucs_assert(md->global_odp != NULL);
     if (flags & UCT_MD_MEM_FLAG_LOCK) {
-        return uct_ib_mem_reg(uct_md, address, length, flags, memh_p);
+        return uct_ib_mem_reg(uct_md, address, length, params, memh_p);
     }
 
     if (md->config.odp.prefetch) {

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -117,10 +117,7 @@ static ucs_status_t uct_rocm_copy_mem_reg_internal(
     ucs_status_t err;
     ucs_memory_type_t mem_type;
 
-    if(address == NULL) {
-        memset(mem_hndl, 0, sizeof(*mem_hndl));
-        return UCS_OK;
-    }
+    ucs_assert((address != NULL) && (length != 0));
 
     err = uct_rocm_base_detect_memory_type(uct_md, address, length, &mem_type);
     if (err != UCS_OK) {
@@ -150,8 +147,9 @@ static ucs_status_t uct_rocm_copy_mem_reg_internal(
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_copy_mem_reg(uct_md_h md, void *address, size_t length,
-                                          unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_rocm_copy_mem_reg(uct_md_h md, void *address, size_t length,
+                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_rocm_copy_mem_t *mem_hndl = NULL;
     ucs_status_t status;
@@ -238,9 +236,12 @@ uct_rocm_copy_rache_region_from_memh(uct_mem_h memh)
 }
 
 static ucs_status_t
-uct_rocm_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
-                             unsigned flags, uct_mem_h *memh_p)
+uct_rocm_copy_mem_rcache_reg(uct_md_h md, void *address, size_t length,
+                             const uct_md_mem_reg_params_t *params,
+                             uct_mem_h *memh_p)
 {
+    uint64_t flags         = UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
+                                                        FIELD_FLAGS, 0);
     uct_rocm_copy_md_t *md = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
     ucs_rcache_region_t *rregion;
     ucs_status_t status;

--- a/src/uct/rocm/gdr/rocm_gdr_md.c
+++ b/src/uct/rocm/gdr/rocm_gdr_md.c
@@ -82,8 +82,9 @@ static ucs_status_t uct_rocm_gdr_rkey_release(uct_component_t *component,
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_gdr_mem_reg(uct_md_h md, void *address, size_t length,
-                                         unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_rocm_gdr_mem_reg(uct_md_h md, void *address, size_t length,
+                     const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_rocm_gdr_mem_t *mem_hndl = NULL;
 

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -81,8 +81,9 @@ static hsa_status_t uct_rocm_ipc_pack_key(void *address, size_t length,
     return HSA_STATUS_SUCCESS;
 }
 
-static ucs_status_t uct_rocm_ipc_mem_reg(uct_md_h md, void *address, size_t length,
-                                         unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_rocm_ipc_mem_reg(uct_md_h md, void *address, size_t length,
+                     const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_rocm_ipc_key_t *key;
     hsa_status_t status;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -389,8 +389,9 @@ static void uct_xpmem_mem_detach_common(uct_xpmem_remote_region_t *xpmem_region)
     uct_xpmem_rmem_put(rmem);
 }
 
-static ucs_status_t uct_xmpem_mem_reg(uct_md_h md, void *address, size_t length,
-                                      unsigned flags, uct_mem_h *memh_p)
+static ucs_status_t
+uct_xmpem_mem_reg(uct_md_h md, void *address, size_t length,
+                  const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     ucs_status_t status;
     uct_mm_seg_t *seg;

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -151,7 +151,8 @@ uct_cma_query_md_resources(uct_component_t *component,
 }
 
 static ucs_status_t uct_cma_mem_reg(uct_md_h md, void *address, size_t length,
-                                    unsigned flags, uct_mem_h *memh_p)
+                                    const uct_md_mem_reg_params_t *params,
+                                    uct_mem_h *memh_p)
 {
     /* For testing we have to make sure that
      * memh_h != UCT_MEM_HANDLE_NULL

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -145,8 +145,10 @@ static ucs_status_t uct_knem_mem_reg_internal(uct_md_h md, void *address, size_t
 }
 
 static ucs_status_t uct_knem_mem_reg(uct_md_h md, void *address, size_t length,
-                                     unsigned flags, uct_mem_h *memh_p)
+                                     const uct_md_mem_reg_params_t *params,
+                                     uct_mem_h *memh_p)
 {
+    uint64_t flags = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0);
     uct_knem_key_t *key;
     ucs_status_t status;
 
@@ -259,10 +261,13 @@ static inline uct_knem_rcache_region_t* uct_knem_rcache_region_from_memh(uct_mem
     return ucs_container_of(memh, uct_knem_rcache_region_t, key);
 }
 
-static ucs_status_t uct_knem_mem_rcache_reg(uct_md_h uct_md, void *address,
-                                            size_t length, unsigned flags,
-                                            uct_mem_h *memh_p)
+static ucs_status_t
+uct_knem_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
+                        const uct_md_mem_reg_params_t *params,
+                        uct_mem_h *memh_p)
 {
+    uint64_t flags    = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS,
+                                                   0);
     uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
     ucs_rcache_region_t *rregion;
     ucs_status_t status;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -401,24 +401,6 @@ static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_t *attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_self_mem_reg(uct_md_h md, void *address, size_t length,
-                                     unsigned flags, uct_mem_h *memh_p)
-{
-    /* We have to emulate memory registration. Return dummy pointer */
-    *memh_p = (void *) 0xdeadbeef;
-    return UCS_OK;
-}
-
-static ucs_status_t uct_self_mem_dereg(uct_md_h uct_md,
-                                       const uct_md_mem_dereg_params_t *params)
-{
-    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
-
-    ucs_assert(params->memh == (void*)0xdeadbeef);
-
-    return UCS_OK;
-}
-
 static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_name,
                                      const uct_md_config_t *config, uct_md_h *md_p)
 {
@@ -428,8 +410,8 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .close              = ucs_empty_function,
         .query              = uct_self_md_query,
         .mkey_pack          = ucs_empty_function_return_success,
-        .mem_reg            = uct_self_mem_reg,
-        .mem_dereg          = uct_self_mem_dereg,
+        .mem_reg            = uct_md_dummy_mem_reg,
+        .mem_dereg          = uct_md_dummy_mem_dereg,
         .detect_memory_type = ucs_empty_function_return_unsupported
     };
 

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -40,24 +40,6 @@ static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_t *attr)
     return UCS_OK;
 }
 
-static ucs_status_t uct_tcp_md_mem_reg(uct_md_h md, void *address, size_t length,
-                                       unsigned flags, uct_mem_h *memh_p)
-{
-    /* We have to emulate memory registration. Return dummy pointer */
-    *memh_p = (void*)0xdeadbeef;
-    return UCS_OK;
-}
-
-static ucs_status_t uct_tcp_mem_dereg(uct_md_h uct_md,
-                                      const uct_md_mem_dereg_params_t *params)
-{
-    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
-
-    ucs_assert(params->memh == (void*)0xdeadbeef);
-
-    return UCS_OK;
-}
-
 static void uct_tcp_md_close(uct_md_h md)
 {
     uct_tcp_md_t *tcp_md = ucs_derived_of(md, uct_tcp_md_t);
@@ -68,8 +50,8 @@ static uct_md_ops_t uct_tcp_md_ops = {
     .close              = uct_tcp_md_close,
     .query              = uct_tcp_md_query,
     .mkey_pack          = ucs_empty_function_return_success,
-    .mem_reg            = uct_tcp_md_mem_reg,
-    .mem_dereg          = uct_tcp_mem_dereg,
+    .mem_reg            = uct_md_dummy_mem_reg,
+    .mem_dereg          = uct_md_dummy_mem_dereg,
     .detect_memory_type = ucs_empty_function_return_unsupported
 };
 

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -51,17 +51,13 @@ static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_t *md_attr)
 }
 
 static ucs_status_t uct_ugni_mem_reg(uct_md_h md, void *address, size_t length,
-                                     unsigned flags, uct_mem_h *memh_p)
+                                     const uct_md_mem_reg_params_t *params,
+                                     uct_mem_h *memh_p)
 {
     ucs_status_t status;
     gni_return_t ugni_rc;
     uct_ugni_md_t *ugni_md = ucs_derived_of(md, uct_ugni_md_t);
     gni_mem_handle_t * mem_hndl = NULL;
-
-    if (0 == length) {
-        ucs_error("Unexpected length %zu", length);
-        return UCS_ERR_INVALID_PARAM;
-    }
 
     mem_hndl = ucs_malloc(sizeof(gni_mem_handle_t), "gni_mem_handle_t");
     if (NULL == mem_hndl) {

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -42,9 +42,10 @@ protected:
     void check_memory(void *address, void *expect, size_t size,
                       ucs_memory_type_t mem_type);
     void free_memory(void *address, ucs_memory_type_t mem_type);
-    void test_registration();
     static bool is_device_detected(ucs_memory_type_t mem_type);
     static void* alloc_thread(void *arg);
+    ucs_status_t reg_mem(unsigned flags, void *address, size_t length,
+                         uct_mem_h *memh_p);
 
     uct_md_h md() const {
         return m_md;


### PR DESCRIPTION
## What

Introduced a new APIv2 function - `uct_mem_reg_v2`.

## Why ?

The `uct_mem_reg_v2` will close demand on extending memory registration routines. And it will extend already existing `uct_mem_dereg_v2` API function.

## How ?

1. Define `uct_md_mem_reg_field_mask_t` which could be extended in the future by new fields.
2. Define `uct_md_mem_reg_params_t` which could be extended in the future by new fields.
3. Update `uct_md_mem_dereg_v2` to mention `uct_md_mem_reg_v2` along with `uct_md_mem_reg` and describe return value for consistency.
4. Declare `uct_md_mem_reg_v2` and add its implementation.
5. Move implementation of `uct_md_mem_reg` to `uct_md_mem_reg_v2`. And implement `uct_md_mem_reg` on top of `uct_md_mem_reg_v2`.
6. Define `UCT_MD_MEM_REG_FIELD_VALUE` auxiliary macro for getting fields from registration parameters.
7. Update `mem_reg` MD ops in all transports to support `uct_md_mem_reg_v2`'s `params` and its further extensions.
8. Update gtests to use `uct_md_mem_reg_v2` instead of `uct_md_mem_reg` where `uct_md_mem_dereg_v2` is used.
9. Add gtest to check bad parameters passed to `uct_md_mem_reg_v2`.