### PR TITLE
TOOLS/INFO: Add runtime library version to ucx_info -v output

### DIFF
--- a/src/tools/info/Makefile.am
+++ b/src/tools/info/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2014.  ALL RIGHTS RESERVED.
 # Copyright (C) The University of Tennessee and the University of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+# Copyright (C) 2022, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -31,6 +32,7 @@ ucx_info_SOURCES  = \
 	sys_info.c \
 	tl_info.c \
 	type_info.c \
+	version_info.c \
 	ucx_info.c
 
 noinst_HEADERS = \

--- a/src/tools/info/build_info.c
+++ b/src/tools/info/build_info.c
@@ -13,13 +13,6 @@
 #include <ucs/sys/preprocessor.h>
 
 
-void print_version()
-{
-    printf("# Version %s\n", UCT_VERNO_STRING);
-    printf("# Git branch '%s', revision %s\n", UCT_SCM_BRANCH, UCT_SCM_VERSION);
-    printf("# Configured with: %s\n", UCX_CONFIGURE_FLAGS);
-}
-
 void print_build_config()
 {
     typedef struct {

--- a/src/tools/info/version_info.c
+++ b/src/tools/info/version_info.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ucx_info.h"
+
+#include <ucs/sys/lib.h>
+#include <ucs/sys/string.h>
+
+void print_version()
+{
+    const char *path = ucs_sys_get_lib_path();
+
+    printf("# Library version: %s\n", ucp_get_version_string());
+    printf("# Library path: %s\n", (path != NULL) ? path : "<unknown>");
+    printf("# API headers version: %s\n", UCT_VERNO_STRING);
+    printf("# Git branch '%s', revision %s\n", UCT_SCM_BRANCH, UCT_SCM_VERSION);
+    printf("# Configured with: %s\n", UCX_CONFIGURE_FLAGS);
+}


### PR DESCRIPTION
## What
Adding runtime linked libraries version to the `ucx_info -v` output.

## Why ?
Now `ucx_info -v` prints only version of the library headers that were used to compile this tool. But printing runtime libraries version may be useful too.

For example if customer has ucx shared objects but old `ucx_info` binary, then it still will report only the old version.
