### PR TITLE
UCT/IB/DEVX: Create CQ using DEVX

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -237,9 +237,14 @@ typedef ucs_status_t (*uct_ib_iface_create_cq_func_t)(uct_ib_iface_t *iface,
                                                       int preferred_cpu,
                                                       size_t inl);
 
+typedef void (*uct_ib_iface_destroy_cq_func_t)(uct_ib_iface_t *iface,
+                                               uct_ib_dir_t dir);
+
 typedef ucs_status_t (*uct_ib_iface_arm_cq_func_t)(uct_ib_iface_t *iface,
                                                    uct_ib_dir_t dir,
                                                    int solicited_only);
+
+typedef ucs_status_t (*uct_ib_iface_pre_arm_func_t)(uct_ib_iface_t *iface);
 
 typedef void (*uct_ib_iface_event_cq_func_t)(uct_ib_iface_t *iface,
                                              uct_ib_dir_t dir);
@@ -254,7 +259,9 @@ typedef ucs_status_t (*uct_ib_iface_set_ep_failed_func_t)(uct_ib_iface_t *iface,
 struct uct_ib_iface_ops {
     uct_iface_internal_ops_t           super;
     uct_ib_iface_create_cq_func_t      create_cq;
+    uct_ib_iface_destroy_cq_func_t     destroy_cq;
     uct_ib_iface_arm_cq_func_t         arm_cq;
+    uct_ib_iface_pre_arm_func_t        pre_arm;
     uct_ib_iface_event_cq_func_t       event_cq;
     uct_ib_iface_handle_failure_func_t handle_failure;
 };
@@ -559,6 +566,8 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                     const uct_ib_iface_config_t *config,
                                     const uct_ib_iface_init_attr_t *init_attr,
                                     int preferred_cpu, size_t inl);
+
+void uct_ib_verbs_destroy_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir);
 
 ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
                                     uct_ib_qp_attr_t *attr,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -55,6 +55,7 @@ static const char *uct_ib_devx_objs[] = {
     [UCT_IB_DEVX_OBJ_DCT]   = "dct",
     [UCT_IB_DEVX_OBJ_DCSRQ] = "dcsrq",
     [UCT_IB_DEVX_OBJ_DCI]   = "dci",
+    [UCT_IB_DEVX_OBJ_CQ]    = "cq",
     NULL
 };
 
@@ -163,7 +164,7 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "DEVX support\n",
      ucs_offsetof(uct_ib_md_config_t, devx), UCS_CONFIG_TYPE_TERNARY},
 
-    {"MLX5_DEVX_OBJECTS", "rcqp,rcsrq,dct,dcsrq,dci",
+    {"MLX5_DEVX_OBJECTS", "rcqp,rcsrq,dct,dcsrq,dci,cq",
      "Objects to be created by DEVX\n",
      ucs_offsetof(uct_ib_md_config_t, devx_objs),
      UCS_CONFIG_TYPE_BITMAP(uct_ib_devx_objs)},

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -63,7 +63,8 @@ enum {
     UCT_IB_DEVX_OBJ_RCSRQ,
     UCT_IB_DEVX_OBJ_DCT,
     UCT_IB_DEVX_OBJ_DCSRQ,
-    UCT_IB_DEVX_OBJ_DCI
+    UCT_IB_DEVX_OBJ_DCI,
+    UCT_IB_DEVX_OBJ_CQ
 };
 
 typedef struct uct_ib_md_ext_config {

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -568,9 +568,9 @@ uct_ib_mlx5_devx_query_qp_peer_info(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp,
     return UCS_OK;
 }
 
-static void
-uct_ib_mlx5_devx_fill_cq(uct_ib_mlx5_cq_t *cq, unsigned cq_size, int cqe_size,
-                        void *out) {
+static void uct_ib_mlx5_devx_fill_cq(uct_ib_mlx5_cq_t *cq, unsigned cq_size,
+                                     int cqe_size, void *out)
+{
     struct mlx5_cqe64 *cqe;
     int i;
 
@@ -600,7 +600,7 @@ uct_ib_mlx5_devx_fill_cq(uct_ib_mlx5_cq_t *cq, unsigned cq_size, int cqe_size,
      * MLX5_CQE_INVALID value anymore.
      */
     for (i = 0; i < cq->cq_length; ++i) {
-        cqe = uct_ib_mlx5_get_cqe(cq, i);
+        cqe          = uct_ib_mlx5_get_cqe(cq, i);
         cqe->op_own |= MLX5_CQE_OWNER_MASK;
         cqe->op_own |= MLX5_CQE_INVALID << 4;
     }
@@ -611,19 +611,18 @@ uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                            const uct_ib_mlx5_iface_config_t *mlx5_config,
                            const uct_ib_iface_config_t *ib_config,
                            const uct_ib_iface_init_attr_t *init_attr,
-                           uct_ib_mlx5_cq_t *cq, int preferred_cpu,
-                           size_t inl)
+                           uct_ib_mlx5_cq_t *cq, int preferred_cpu, size_t inl)
 {
-    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_in)] = {0};
+    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_in)]   = {0};
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_out)] = {0};
     void *cqctx = UCT_IB_MLX5DV_ADDR_OF(create_cq_in, in, cqc);
 
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md, uct_ib_mlx5_md_t);
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
 
-    unsigned cq_size   = ucs_roundup_pow2(uct_ib_cq_size(iface, init_attr, dir));
-    int log_cq_size    = ucs_ilog2(cq_size);
-    int cqe_size       = uct_ib_get_cqe_size(inl > 32 ? 128 : 64);
+    unsigned cq_size = ucs_roundup_pow2(uct_ib_cq_size(iface, init_attr, dir));
+    int log_cq_size  = ucs_ilog2(cq_size);
+    int cqe_size     = uct_ib_get_cqe_size(inl > 32 ? 128 : 64);
     size_t cq_umem_len = cqe_size * cq_size;
 
     ucs_status_t status;
@@ -654,8 +653,8 @@ uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                           UCT_IB_MLX5_DEVX_UAR_KEY,
                                           uct_ib_mlx5_devx_uar_t,
                                           uct_ib_mlx5_devx_uar_cmp,
-                                          uct_ib_mlx5_devx_uar_init,
-                                          md, UCT_IB_MLX5_MMIO_MODE_DB);
+                                          uct_ib_mlx5_devx_uar_init, md,
+                                          UCT_IB_MLX5_MMIO_MODE_DB);
     if (UCS_PTR_IS_ERR(cq->devx.uar)) {
         status = UCS_PTR_STATUS(cq->devx.uar);
         goto err_free_db;
@@ -704,7 +703,7 @@ err:
     return status;
 }
 
-void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t* cq)
+void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t *cq)
 {
     uct_ib_mlx5_devx_obj_destroy(cq->devx.obj, "CQ");
     uct_ib_mlx5_put_dbrec(cq->devx.dbrec);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -568,6 +568,141 @@ uct_ib_mlx5_devx_query_qp_peer_info(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp,
     return UCS_OK;
 }
 
+ucs_status_t
+uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
+                           const uct_ib_mlx5_iface_config_t *mlx5_config,
+                           const uct_ib_iface_config_t *ib_config,
+                           const uct_ib_iface_init_attr_t *init_attr,
+                           uct_ib_mlx5_cq_t* cq, int preferred_cpu, size_t inl)
+{
+    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_in)] = {0};
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_out)] = {0};
+    void *cqctx = UCT_IB_MLX5DV_ADDR_OF(create_cq_in, in, cqc);
+
+    uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md, uct_ib_mlx5_md_t);
+    uct_ib_device_t *dev  = uct_ib_iface_device(iface);
+    ucs_status_t status = UCS_OK;
+
+    int cq_size = ucs_roundup_pow2(uct_ib_cq_size(iface, init_attr, dir));
+    int log_cq_size = ucs_ilog2(cq_size);
+    int cqe_size = uct_ib_get_cqe_size(inl > 32 ? 128 : 64);
+    size_t cq_umem_len = cqe_size * cq_size;
+    uint32_t eqn;
+    int i;
+    struct mlx5_cqe64 *cqe;
+
+    UCT_IB_MLX5DV_SET(create_cq_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_CQ);
+
+    /* Set DB record umem related bits */
+    cq->devx.dbrec = uct_ib_mlx5_get_dbrec(md);
+    if (!cq->devx.dbrec) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+    UCT_IB_MLX5DV_SET(cqc, cqctx, dbr_umem_valid, 1);
+    UCT_IB_MLX5DV_SET(cqc, cqctx, dbr_umem_id, cq->devx.dbrec->mem_id);
+    UCT_IB_MLX5DV_SET64(cqc, cqctx, dbr_addr, cq->devx.dbrec->offset);
+
+    /* Set EQN related bits */
+    if (mlx5dv_devx_query_eqn(dev->ibv_context, preferred_cpu, &eqn) == 0) {
+        UCT_IB_MLX5DV_SET(cqc, cqctx, c_eqn, eqn);
+    } else {
+        status = UCS_ERR_IO_ERROR;
+        goto err_free_db;
+    }
+
+    /* Set UAR related bits */
+    cq->devx.uar = uct_worker_tl_data_get(iface->super.worker,
+                                          UCT_IB_MLX5_DEVX_UAR_KEY,
+                                          uct_ib_mlx5_devx_uar_t,
+                                          uct_ib_mlx5_devx_uar_cmp,
+                                          uct_ib_mlx5_devx_uar_init,
+                                          md, UCT_IB_MLX5_MMIO_MODE_DB);
+    if (UCS_PTR_IS_ERR(cq->devx.uar)) {
+        status = UCS_PTR_STATUS(cq->devx.uar);
+        goto err_free_db;
+    }
+    UCT_IB_MLX5DV_SET(cqc, cqctx, uar_page, cq->devx.uar->uar->page_id);
+
+    /* Set CQ umem related bits */
+    status = uct_ib_mlx5_md_buf_alloc(md, cq_umem_len, 0, &cq->devx.cq_buf,
+                                      &cq->devx.mem, IBV_ACCESS_LOCAL_WRITE,
+                                      "cq umem");
+    if (status != UCS_OK) {
+        goto err_uar;
+    }
+    memset(cq->devx.cq_buf, 0, cq_umem_len);
+
+    UCT_IB_MLX5DV_SET(create_cq_in, in, cq_umem_valid, 1);
+    UCT_IB_MLX5DV_SET(create_cq_in, in, cq_umem_id, cq->devx.mem.mem->umem_id);
+    UCT_IB_MLX5DV_SET64(create_cq_in, in, cq_umem_offset, 0);
+
+    UCT_IB_MLX5DV_SET(cqc, cqctx, log_cq_size, log_cq_size);
+    UCT_IB_MLX5DV_SET(cqc, cqctx, cqe_sz, (cqe_size == 128) ? 1 : 0);
+	UCT_IB_MLX5DV_SET(cqc, cqctx, cqe_comp_en, mlx5_config->cqe_zipping_enable);
+    if (!UCS_ENABLE_ASSERT && (init_attr->flags & UCT_IB_CQ_IGNORE_OVERRUN)) {
+        UCT_IB_MLX5DV_SET(cqc, cqctx, oi, 1);
+    }
+
+    cq->devx.obj = uct_ib_mlx5_devx_obj_create(dev->ibv_context, in, sizeof(in),
+                                               out, sizeof(out), "CQ");
+    if (!cq->devx.obj) {
+        status = UCS_ERR_IO_ERROR;
+        goto err_free_mem;
+    }
+
+    /* Fill the CQ structure */
+    cq->cq_buf    = cq->devx.cq_buf;
+    cq->cq_ci     = 0;
+    cq->cq_sn     = 0;
+    cq->cq_length = cq_size;
+    cq->cq_num    = UCT_IB_MLX5DV_GET(create_cq_out, out, cqn);
+    cq->uar       = cq->devx.uar->uar->base_addr;
+    cq->dbrec     = cq->devx.dbrec->db;
+
+    /* initializing memory is required for checking the cq_unzip.current_idx */
+    memset(&cq->cq_unzip, 0, sizeof(uct_ib_mlx5_cq_unzip_t));
+
+    /* Move buffer forward for 128b CQE, so we would get pointer to the 2nd
+     * 64b when polling.
+     */
+    cq->cq_buf = UCS_PTR_BYTE_OFFSET(cq->cq_buf,
+                                     cqe_size - sizeof(struct mlx5_cqe64));
+
+    cq->cqe_size_log = ucs_ilog2(cqe_size);
+    ucs_assert_always((1ul << cq->cqe_size_log) == cqe_size);
+
+    /* Set owner bit for all CQEs, so that CQE would look like it is in HW
+     * ownership. In this case CQ polling functions will return immediately if
+     * no any CQE ready, there is no need to check opcode for
+     * MLX5_CQE_INVALID value anymore.
+     */
+    for (i = 0; i < cq->cq_length; ++i) {
+        cqe = uct_ib_mlx5_get_cqe(cq, i);
+        cqe->op_own |= MLX5_CQE_OWNER_MASK;
+        cqe->op_own |= MLX5_CQE_INVALID << 4;
+    }
+
+    iface->config.max_inl_cqe[dir] = (inl > 0) ? (cqe_size / 2) : 0;
+
+    return UCS_OK;
+err_free_mem:
+    uct_ib_mlx5_md_buf_free(md, cq->devx.cq_buf, &cq->devx.mem);
+err_uar:
+    uct_worker_tl_data_put(cq->devx.uar, uct_ib_mlx5_devx_uar_cleanup);
+err_free_db:
+    uct_ib_mlx5_put_dbrec(cq->devx.dbrec);
+err:
+    return status;
+}
+
+void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t* cq)
+{
+    uct_ib_mlx5_devx_obj_destroy(cq->devx.obj, "CQ");
+    uct_ib_mlx5_put_dbrec(cq->devx.dbrec);
+    uct_worker_tl_data_put(cq->devx.uar, uct_ib_mlx5_devx_uar_cleanup);
+    uct_ib_mlx5_md_buf_free(md, cq->devx.cq_buf, &cq->devx.mem);
+}
 #endif
 
 ucs_status_t uct_ib_mlx5dv_arm_cq(uct_ib_mlx5_cq_t *cq, int solicited)

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -848,6 +848,18 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         goto err;
     }
 
+    if ((md_config->devx_objs & (1 << UCT_IB_DEVX_OBJ_CQ)) &&
+        !ucs_test_all_flags(md_config->devx_objs, (1 << UCT_IB_DEVX_OBJ_RCQP) |
+                                                  (1 << UCT_IB_DEVX_OBJ_RCSRQ) |
+                                                  (1 << UCT_IB_DEVX_OBJ_DCT) |
+                                                  (1 << UCT_IB_DEVX_OBJ_DCSRQ) |
+                                                  (1 << UCT_IB_DEVX_OBJ_DCI))) {
+        status = UCS_ERR_IO_ERROR;
+        ucs_error("Specifying cq in DEVX_OBJS requires creation all other "
+                  "entities(rcqp,rcsrq,dct,dcsrq,dci,cq) using DEVX too");
+        goto err;
+    }
+
     ctx = uct_ib_mlx5_devx_open_device(ibv_device);
     if (ctx == NULL) {
         if (md_config->devx == UCS_YES) {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -162,6 +162,21 @@ uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     return status;
 }
 
+void uct_ib_mlx5_destroy_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t* cq, 
+                            uct_ib_dir_t dir)
+{
+#if HAVE_DEVX
+    uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md,
+                                          uct_ib_mlx5_md_t);
+
+    if (cq->type == UCT_IB_MLX5_OBJ_TYPE_DEVX) {
+        uct_ib_mlx5_devx_destroy_cq(md, cq);
+        return;
+    }
+#endif
+    uct_ib_verbs_destroy_cq(iface, dir);
+}
+
 ucs_status_t uct_ib_mlx5_get_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq)
 {
     uct_ib_mlx5dv_cq_t dcq = {};

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -154,7 +154,7 @@ uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     }
 #endif
 
-    status = uct_ib_mlx5_get_cq(iface->cq[dir], mlx5_cq);
+    status = uct_ib_mlx5_fill_cq(iface->cq[dir], mlx5_cq);
     if (status != UCS_OK) {
         ibv_destroy_cq(iface->cq[dir]);
     }
@@ -177,7 +177,7 @@ void uct_ib_mlx5_destroy_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t* cq,
     uct_ib_verbs_destroy_cq(iface, dir);
 }
 
-ucs_status_t uct_ib_mlx5_get_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq)
+ucs_status_t uct_ib_mlx5_fill_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq)
 {
     uct_ib_mlx5dv_cq_t dcq = {};
     uct_ib_mlx5dv_t obj = {};

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -624,7 +624,7 @@ extern ucs_config_field_t uct_ib_mlx5_iface_config_table[];
 /**
  * Get internal CQ information.
  */
-ucs_status_t uct_ib_mlx5_get_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq);
+ucs_status_t uct_ib_mlx5_fill_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq);
 
 /**
  * Destroy CQ.

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -425,15 +425,15 @@ typedef struct uct_ib_mlx5_cq {
              * from uct_ib_iface that is never used. It will be useful after
              * introducing mlx5 related common iface.
              */
-            struct ibv_cq             *cq;
+            struct ibv_cq *cq;
         } verbs;
 #if HAVE_DEVX
         struct {
-            void                       *cq_buf;
-            uct_ib_mlx5_dbrec_t        *dbrec;
-            uct_ib_mlx5_devx_umem_t    mem;
-            struct mlx5dv_devx_obj     *obj;
-            uct_ib_mlx5_devx_uar_t     *uar;
+            void                    *cq_buf;
+            uct_ib_mlx5_dbrec_t     *dbrec;
+            uct_ib_mlx5_devx_umem_t mem;
+            struct mlx5dv_devx_obj  *obj;
+            uct_ib_mlx5_devx_uar_t  *uar;
         } devx;
 #endif
     };
@@ -629,7 +629,7 @@ ucs_status_t uct_ib_mlx5_fill_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq);
 /**
  * Destroy CQ.
  */
-void uct_ib_mlx5_destroy_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t* cq,
+void uct_ib_mlx5_destroy_cq(uct_ib_iface_t *iface, uct_ib_mlx5_cq_t *cq,
                             uct_ib_dir_t dir);
 
 /**
@@ -800,9 +800,9 @@ uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                            const uct_ib_mlx5_iface_config_t *mlx5_config,
                            const uct_ib_iface_config_t *ib_config,
                            const uct_ib_iface_init_attr_t *init_attr,
-                           uct_ib_mlx5_cq_t* cq, int preferred_cpu, size_t inl);
+                           uct_ib_mlx5_cq_t *cq, int preferred_cpu, size_t inl);
 
-void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t* cq);
+void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t *cq);
 
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -183,4 +183,6 @@ ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
 unsigned uct_rc_mlx5_ep_cleanup_qp(void *arg);
 
+ucs_status_t uct_rc_mlx5_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p);
+
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -1140,7 +1140,8 @@ uct_rc_mlx5_iface_common_arm_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
 #endif
 }
 
-static ucs_status_t uct_rc_mlx5_iface_devx_pre_arm(uct_ib_iface_t *ib_iface) {
+static ucs_status_t uct_rc_mlx5_iface_devx_pre_arm(uct_ib_iface_t *ib_iface)
+{
     ucs_status_t status = UCS_OK;
 #if HAVE_DEVX
     uct_rc_mlx5_iface_common_t *iface =
@@ -1168,7 +1169,8 @@ static ucs_status_t uct_rc_mlx5_iface_devx_pre_arm(uct_ib_iface_t *ib_iface) {
     return status;
 }
 
-ucs_status_t uct_rc_mlx5_iface_common_pre_arm(uct_ib_iface_t *iface) {
+ucs_status_t uct_rc_mlx5_iface_common_pre_arm(uct_ib_iface_t *iface)
+{
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md, uct_ib_mlx5_md_t);
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_CQ) {
@@ -1185,11 +1187,12 @@ void uct_rc_mlx5_iface_common_event_cq(uct_ib_iface_t *ib_iface,
     iface->cq[dir].cq_sn++;
 }
 
-void uct_rc_mlx5_iface_common_destroy_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir)
+void uct_rc_mlx5_iface_common_destroy_cq(uct_ib_iface_t *iface,
+                                         uct_ib_dir_t dir)
 {
     uct_rc_mlx5_iface_common_t *rc_mlx5_iface_common =
             ucs_derived_of(iface, uct_rc_mlx5_iface_common_t);
-    uct_ib_mlx5_cq_t* cq = &rc_mlx5_iface_common->cq[dir];
+    uct_ib_mlx5_cq_t *cq = &rc_mlx5_iface_common->cq[dir];
     uct_ib_mlx5_destroy_cq(iface, cq, dir);
 }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -708,14 +708,6 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                                          enum ibv_mtu path_mtu,
                                          uint8_t path_index);
 
-ucs_status_t
-uct_rc_mlx5_iface_common_devx_create_cq(
-        uct_ib_iface_t *iface, uct_ib_dir_t dir,
-        const uct_ib_mlx5_iface_config_t *mlx5_config,
-        const uct_ib_iface_config_t *ib_config,
-        const uct_ib_iface_init_attr_t *init_attr,
-        uct_ib_mlx5_cq_t* cq, int preferred_cpu, size_t inl);
-
 #else
 static UCS_F_MAYBE_UNUSED ucs_status_t
 uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
@@ -727,28 +719,15 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
 {
     return UCS_ERR_UNSUPPORTED;
 }
-
-static UCS_F_MAYBE_UNUSED ucs_status_t
-uct_rc_mlx5_iface_common_devx_create_cq(
-        uct_ib_iface_t *iface, uct_ib_dir_t dir,
-        const uct_ib_mlx5_iface_config_t *mlx5_config,
-        const uct_ib_iface_config_t *ib_config,
-        const uct_ib_iface_init_attr_t *init_attr,
-        uct_ib_mlx5_cq_t* cq, int preferred_cpu, size_t inl)
-{
-    return UCS_ERR_UNSUPPORTED;
-}
 #endif
 
 ucs_status_t uct_rc_mlx5_devx_iface_init_events(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_devx_iface_free_events(uct_rc_mlx5_iface_common_t *iface);
 
-ucs_status_t
-uct_rc_mlx5_devx_iface_subscribe_event(struct mlx5dv_devx_event_channel *channel,
-                                       struct mlx5dv_devx_obj *obj,
-                                       uint16_t event, uint64_t cookie,
-                                       char* msg_arg);
+ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(
+        struct mlx5dv_devx_event_channel *channel, struct mlx5dv_devx_obj *obj,
+        uint16_t event, uint64_t cookie, char *msg_arg);
 
 void uct_rc_mlx5_iface_fill_attr(uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_qp_attr_t *qp_attr,

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -16,11 +16,10 @@
 #include <uct/ib/rc/base/rc_iface.h>
 #include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
 
-ucs_status_t
-uct_rc_mlx5_devx_iface_subscribe_event(struct mlx5dv_devx_event_channel *channel,
-                                       struct mlx5dv_devx_obj *obj,
-                                       uint16_t event, uint64_t cookie,
-                                       char* msg_arg) {
+ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(
+        struct mlx5dv_devx_event_channel *channel, struct mlx5dv_devx_obj *obj,
+        uint16_t event, uint64_t cookie, char *msg_arg)
+{
 #if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT
     int ret;
 
@@ -75,13 +74,13 @@ uct_rc_mlx5_devx_iface_event_handler(int fd, ucs_event_set_types_t events,
 
 #if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT
 static ucs_status_t uct_rc_mlx5_devx_create_event_channel(
-    uct_rc_mlx5_iface_common_t *iface,
-    struct mlx5dv_devx_event_channel **event_channel_ptr,
-    int create_async_handler)
+        uct_rc_mlx5_iface_common_t *iface,
+        struct mlx5dv_devx_event_channel **event_channel_ptr,
+        int create_async_handler)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(uct_ib_iface_md(&iface->super.super),
                                           uct_ib_mlx5_md_t);
-    ucs_status_t status  = UCS_OK;
+    ucs_status_t status;
 
     *event_channel_ptr = mlx5dv_devx_create_event_channel(
             md->super.dev.ibv_context,
@@ -91,7 +90,6 @@ static ucs_status_t uct_rc_mlx5_devx_create_event_channel(
         ucs_error("mlx5dv_devx_create_event_channel() failed: %m");
         status = UCS_ERR_IO_ERROR;
         goto err;
-
     }
 
     status = ucs_sys_fcntl_modfl((*event_channel_ptr)->fd, O_NONBLOCK, 0);
@@ -119,10 +117,12 @@ err:
 }
 #endif
 
-ucs_status_t uct_rc_mlx5_devx_iface_init_events(uct_rc_mlx5_iface_common_t *iface)
+ucs_status_t
+uct_rc_mlx5_devx_iface_init_events(uct_rc_mlx5_iface_common_t *iface)
 {
+    ucs_status_t status = UCS_OK;
     uct_ib_mlx5_md_t *md;
-    ucs_status_t status     = UCS_OK;
+
     iface->event_channel    = NULL;
     iface->cq_event_channel = NULL;
 #if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -254,8 +254,8 @@ uct_rc_mlx5_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
 
 #if HAVE_DEVX
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_CQ) {
-        uct_cq->type       = UCT_IB_MLX5_OBJ_TYPE_DEVX;
-        ib_iface->cq[dir]  = NULL;
+        uct_cq->type      = UCT_IB_MLX5_OBJ_TYPE_DEVX;
+        ib_iface->cq[dir] = NULL;
         return uct_ib_mlx5_devx_create_cq(ib_iface, dir,
                                           &rc_mlx5_config->rc_mlx5_common.super,
                                           ib_config, init_attr, uct_cq,
@@ -714,8 +714,8 @@ int uct_rc_mlx5_iface_is_reachable(const uct_iface_h tl_iface,
 
 ucs_status_t uct_rc_mlx5_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
 {
-    uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(
-            tl_iface, uct_rc_mlx5_iface_common_t);
+    uct_rc_mlx5_iface_common_t *iface =
+            ucs_derived_of(tl_iface, uct_rc_mlx5_iface_common_t);
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.md,
                                           uct_ib_mlx5_md_t);
 
@@ -728,8 +728,9 @@ ucs_status_t uct_rc_mlx5_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
 }
 
 static ucs_status_t
-uct_rc_mlx5_iface_subscribe_cqs(uct_rc_mlx5_iface_common_t *iface) {
-    ucs_status_t status   = UCS_OK;
+uct_rc_mlx5_iface_subscribe_cqs(uct_rc_mlx5_iface_common_t *iface)
+{
+    ucs_status_t status = UCS_OK;
 #if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT
     uct_ib_mlx5_cq_t *scq = &iface->cq[UCT_IB_DIR_TX];
     uct_ib_mlx5_cq_t *rcq = &iface->cq[UCT_IB_DIR_RX];
@@ -742,18 +743,16 @@ uct_rc_mlx5_iface_subscribe_cqs(uct_rc_mlx5_iface_common_t *iface) {
 
     if (scq->type == UCT_IB_MLX5_OBJ_TYPE_DEVX) {
         status = uct_rc_mlx5_devx_iface_subscribe_event(iface->cq_event_channel,
-                                                        scq->devx.obj,
-                                                        0, UCT_IB_DIR_TX,
-                                                        "SCQ");
+                                                        scq->devx.obj, 0,
+                                                        UCT_IB_DIR_TX, "SCQ");
         if (status != UCS_OK) {
             return status;
         }
     }
     if (rcq->type == UCT_IB_MLX5_OBJ_TYPE_DEVX) {
         status = uct_rc_mlx5_devx_iface_subscribe_event(iface->cq_event_channel,
-                                                        rcq->devx.obj,
-                                                        0, UCT_IB_DIR_RX,
-                                                        "RCQ");
+                                                        rcq->devx.obj, 0,
+                                                        UCT_IB_DIR_RX, "RCQ");
     }
 #endif
     return status;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -938,7 +938,7 @@ ucs_status_t uct_rc_iface_common_event_arm(uct_iface_h tl_iface,
     int arm_rx_solicited, arm_rx_all;
     ucs_status_t status;
 
-    status = uct_ib_iface_pre_arm(&iface->super);
+    status = iface->super.ops->pre_arm(&iface->super);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -508,7 +508,9 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
             .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_verbs_create_cq,
+        .destroy_cq     = uct_ib_verbs_destroy_cq,
         .arm_cq         = uct_ib_iface_arm_cq,
+        .pre_arm        = uct_ib_iface_pre_arm,
         .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
         .handle_failure = uct_rc_verbs_handle_failure,
     },

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -680,6 +680,7 @@ uct_ud_mlx5_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_ud_mlx5_iface_t);
     uct_ib_mlx5_cq_t *uct_cq   = &iface->cq[dir];
 
+    uct_cq->type = UCT_IB_MLX5_OBJ_TYPE_VERBS;
     return uct_ib_mlx5_create_cq(ib_iface, dir, &ud_mlx5_config->mlx5_common,
                                  ib_config, init_attr, uct_cq, preferred_cpu,
                                  inl);
@@ -791,7 +792,9 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
             .ep_invalidate       = uct_ud_ep_invalidate
         },
         .create_cq      = uct_ud_mlx5_create_cq,
+        .destroy_cq     = uct_ib_verbs_destroy_cq,
         .arm_cq         = uct_ud_mlx5_iface_arm_cq,
+        .pre_arm        = uct_ib_iface_pre_arm,
         .event_cq       = uct_ud_mlx5_iface_event_cq,
         .handle_failure = uct_ud_mlx5_iface_handle_failure,
     },

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -270,7 +270,7 @@ static void uct_ud_iface_async_handler(int fd, ucs_event_set_types_t events,
      * if user asks to provide notifications for all completion
      * events by calling uct_iface_event_arm(), RX CQ will be
      * armed again with solicited flag = 0 */
-    uct_ib_iface_pre_arm(&iface->super);
+    iface->super.ops->pre_arm(&iface->super);
     iface->super.ops->arm_cq(&iface->super, UCT_IB_DIR_RX, 1);
 
     ucs_assert(iface->async.event_cb != NULL);
@@ -931,7 +931,7 @@ ucs_status_t uct_ud_iface_event_arm(uct_iface_h tl_iface, unsigned events)
 
     uct_ud_enter(iface);
 
-    status = uct_ib_iface_pre_arm(&iface->super);
+    status = iface->super.ops->pre_arm(&iface->super);
     if (status != UCS_OK) {
         ucs_trace("iface %p: pre arm failed status %s", iface,
                   ucs_status_string(status));

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -559,7 +559,9 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
             .ep_invalidate       = uct_ud_ep_invalidate
         },
         .create_cq      = uct_ib_verbs_create_cq,
+        .destroy_cq     = uct_ib_verbs_destroy_cq,
         .arm_cq         = uct_ib_iface_arm_cq,
+        .pre_arm        = uct_ib_iface_pre_arm,
         .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
         .handle_failure = (uct_ib_iface_handle_failure_func_t)ucs_empty_function_do_assert,
     },

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -56,8 +56,6 @@ void test_ucp_tag::enable_tag_mp_offload()
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MP_SRQ_ENABLE", "try"));
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MP_NUM_STRIDES", "8"));
-    m_env.push_back(new ucs::scoped_setenv("UCX_IB_MLX5_DEVX_OBJECTS",
-                                           "dct,dcsrq,rcsrq,rcqp,dci"));
 }
 
 void test_ucp_tag::request_init(void *request)

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1230,7 +1230,7 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_unified, rc_dc, "rc,dc")
 
 class select_ep_transport : public test_ucp_wireup {
 public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_RMA, TEST_RMA, "rma");
     }


### PR DESCRIPTION
## What
CQ creation via DEVX API + using DEVX event channel for handling completion events.

## Why ?
This way of creation CQ allows to support more FW features (e.g. enhanced CQE zipping)

## How ?

Before moving this PR out of draft state, several "preparation" requests were merged:
- #8297
- #8299
- #8300
- #8302

At this moment union with both verbs and DEVX cq representation was created inside `uct_ib_mlx5_cq_t`. There is no any practical sense of keeping verbs part there at this moment but it's there to save the consistency of storing corresponding objects on the same abstraction level. The question of removing verbs representation from that union can be discussed separately.