### PR TITLE
UCP/RNDV: fix lane weight calculation

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -546,6 +546,7 @@ public:
         RNDV_SCHEME_PUT_ZCOPY,
         RNDV_SCHEME_GET_ZCOPY,
         RNDV_SCHEME_LAST,
+        RNDV_GET_ZCOPY_ODD_LANES,
         PUT_ZCOPY_FLUSH = ENABLE_PROTO << 1
     };
 
@@ -557,6 +558,9 @@ public:
         modify_config("RNDV_THRESH", "0");
         modify_config("RNDV_SCHEME", rndv_schemes[rndv_scheme()]);
         modify_config("RNDV_PUT_FORCE_FLUSH", force_flush() ? "y" : "n");
+        if (get_variant_value() & RNDV_GET_ZCOPY_ODD_LANES) {
+            modify_config("MAX_RNDV_LANES", "3");
+        }
         test_ucp_tag_match::init();
     }
 
@@ -574,6 +578,11 @@ public:
                                RNDV_SCHEME_PUT_ZCOPY | ENABLE_PROTO |
                                        PUT_ZCOPY_FLUSH,
                                "rndv_put_flush,proto");
+        // Add variant with odd number of lanes
+        add_variant_with_value(variants, get_ctx_params(),
+                               RNDV_SCHEME_GET_ZCOPY | ENABLE_PROTO |
+                               RNDV_GET_ZCOPY_ODD_LANES,
+                               "rndv_get_zcopy,proto,odd_lanes");
     }
 
 protected:


### PR DESCRIPTION
## What
Fixes calculating RNDV lane weight.

## Why ?
The issue is stable to reproduced when run with odd number of lanes started from 3 (UCX_MAX_RNDV_LANES=3) and message size ~100K, also can be reproduced for 12 lanes. 
When all lanes have sent its fragment but the tail (several bytes) of the message still unsent, this causes the assertion to fail:
```C
[jazz10:23178:0:23178] proto_rndv.inl:256  Assertion `scaled_length >= total_offset' failed: req=0x25deac0 scaled_length=715816960 total_offset=2147451125 total_length=2147483648 weight_sum=34%
```
The fix is to always round up the lane weight when calculating.