### PR TITLE
UCP/PROTO: add abort impl for zcopy and reconfig protocols

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -273,5 +273,5 @@ ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .init     = ucp_am_eager_multi_zcopy_proto_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_zcopy_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort
 };

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -384,7 +384,7 @@ ucp_proto_t ucp_am_eager_single_zcopy_proto = {
     .init     = ucp_am_eager_single_zcopy_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_reply_proto_init(

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -700,6 +700,11 @@ void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status)
     ucp_request_complete_send(request, status);
 }
 
+void ucp_proto_request_zcopy_abort(ucp_request_t *request, ucs_status_t status)
+{
+    ucp_invoke_uct_completion(&request->send.state.uct_comp, status);
+}
+
 int ucp_proto_is_short_supported(const ucp_proto_select_param_t *select_param)
 {
     /* Short protocol requires contig/host */

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -261,6 +261,8 @@ void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status);
 
 void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status);
 
+void ucp_proto_request_zcopy_abort(ucp_request_t *request, ucs_status_t status);
+
 ucs_linear_func_t
 ucp_proto_common_memreg_time(const ucp_proto_common_init_params_t *params,
                              ucp_md_map_t reg_md_map);

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -95,5 +95,5 @@ ucp_proto_t ucp_reconfig_proto = {
     .init     = ucp_proto_reconfig_init,
     .query    = ucp_proto_default_query,
     .progress = {ucp_proto_reconfig_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_request_complete_send
 };

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -256,13 +256,6 @@ ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
-static void ucp_put_offload_zcopy_abort(ucp_request_t *request,
-                                        ucs_status_t status)
-{
-    /* zcopy request starts from uct_comp.count = 1 */
-    ucp_invoke_uct_completion(&request->send.state.uct_comp, status);
-}
-
 ucp_proto_t ucp_put_offload_zcopy_proto = {
     .name     = "put/offload/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
@@ -270,5 +263,5 @@ ucp_proto_t ucp_put_offload_zcopy_proto = {
     .init     = ucp_proto_put_offload_zcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_zcopy_progress},
-    .abort    = ucp_put_offload_zcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort
 };

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -178,7 +178,7 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
         /* The error completion handler is not sending ATS */
         request->send.state.uct_comp.func =
                 ucp_proto_rndv_get_zcopy_fetch_err_completion;
-        ucp_invoke_uct_completion(&request->send.state.uct_comp, status);
+        ucp_proto_request_zcopy_abort(request, status);
         break;
     case UCP_PROTO_RNDV_GET_STAGE_ATS:
         rreq = ucp_request_get_super(request);


### PR DESCRIPTION
## What
add abort impl for zcopy and reconfig protocols

## Why ?
 - missed  functionality
 - bugfix
