### PR TITLE
UCP/RCACHE: Avoid printing debug messages from rcache mpool

### DIFF
--- a/src/ucs/datastruct/mpool.h
+++ b/src/ucs/datastruct/mpool.h
@@ -81,6 +81,7 @@ struct ucs_mpool_data {
                                              * only take effect on grow_factor=1 */
     unsigned               elems_per_chunk; /* Number of elements per chunk */
     unsigned               quota;           /* How many more elements can be allocated */
+    int                    malloc_safe;     /* Avoid triggering malloc() during put/get */
     ucs_mpool_elem_t       *tail;           /* Free list tail */
     ucs_mpool_chunk_t      *chunks;         /* List of allocated chunks */
     const ucs_mpool_ops_t  *ops;            /* Memory pool operations */
@@ -165,6 +166,12 @@ typedef struct ucs_mpool_params {
      * Boundary to which align the given offset within the element.
      */
     size_t                alignment;
+
+    /**
+     * Avoid triggering malloc() during put/get operations, this makes the
+     * memory pool safe to use from memory hooks context.
+     */
+    int                   malloc_safe;
 
     /**
      * Number of elements in first chunk.

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -1208,6 +1208,7 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     ucs_mpool_params_reset(&mp_params);
     mp_params.elem_size       = mp_obj_size;
     mp_params.alignment       = mp_align;
+    mp_params.malloc_safe     = 1;
     mp_params.elems_per_chunk = 1024;
     mp_params.ops             = &ucs_rcache_mp_ops;
     mp_params.name            = "rcache_mp";


### PR DESCRIPTION
## Why
Fix a deadlock in rcache with `UCX_LOG_LEVEL=debug`, with the following call sequence (top to bottom):

- malloc() (holding heap lock)
- munmap() 
- rcache memory hook handler 
- allocate invalidation element from rcache->mp 
- ucs_mpool_get 
- ucs_mpool_grow 
- ucs_debug 
- allocate TLS element (needed for logging) 
- malloc() ---> deadlock since heap lock is held by the first malloc
