### PR TITLE
UCT/IB/DEVX: Set QP ts_format to default

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -141,6 +141,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
     UCT_IB_MLX5DV_SET64(qpc, qpc, dbr_addr, qp->devx.dbrec->offset);
     UCT_IB_MLX5DV_SET(qpc, qpc, dbr_umem_id, qp->devx.dbrec->mem_id);
     UCT_IB_MLX5DV_SET(qpc, qpc, user_index, attr->uidx);
+    UCT_IB_MLX5DV_SET(qpc, qpc, ts_format, UCT_IB_MLX5_QPC_TS_FORMAT_DEFAULT);
 
     if (qp->devx.wq_buf == NULL) {
         UCT_IB_MLX5DV_SET(qpc, qpc, no_sq, true);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -1245,6 +1245,12 @@ static inline unsigned uct_ib_mlx5_qpc_cs_res(unsigned size, int dc)
                          UCT_IB_MLX5_QPC_CS_RES_DISABLE;
 }
 
+enum {
+    UCT_IB_MLX5_QPC_TS_FORMAT_FREE_RUNNING = 0x0,
+    UCT_IB_MLX5_QPC_TS_FORMAT_DEFAULT      = 0x1,
+    UCT_IB_MLX5_QPC_TS_FORMAT_REAL_TIME    = 0x2
+};
+
 struct uct_ib_mlx5_qpc_bits {
     uint8_t         state[0x4];
     uint8_t         lag_tx_port_affinity[0x4];
@@ -1273,7 +1279,9 @@ struct uct_ib_mlx5_qpc_bits {
     uint8_t         log_rq_stride[0x3];
     uint8_t         no_sq[0x1];
     uint8_t         log_sq_size[0x4];
-    uint8_t         reserved_at_55[0x6];
+    uint8_t         reserved_at_55[0x3];
+    uint8_t         ts_format[0x2];
+    uint8_t         reserved_at_5a[0x1];
     uint8_t         rlky[0x1];
     uint8_t         ulp_stateless_offload_mode[0x4];
 


### PR DESCRIPTION
## What
Set QP `ts_format` to default to inherit timestamp format from the system configuration.

## Why ?
Some HCAs supports only "free running" or only "real time" ts format, and if `ts_format` configured to the "free running" value (0), but system supports only "real time" mode, QP creation fails. To avoid it we should set QP `ts_format` to default mode.

## Testing
- Tested manually on ConnectX-6 Dx