### PR TITLE
AZP: remove io_demo RC ECE to decrease test time

### DIFF
--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -32,14 +32,6 @@ parameters:
         tls: "rc_x"
         test_name: tag_cx6_rc
         extra_run_args: ""
-      "tag match on CX6/RC with auto ECE":
-        args: ""
-        duration: 600
-        interface: $(roce_iface_cx6)
-        tls: "rc_x"
-        ece: "auto"
-        test_name: tag_cx6_rc_auto_ece
-        extra_run_args: ""
       "active messages on CX6/RC":
         args: "-A"
         duration: 600


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
remove ```tag_cx6_rc_auto_ece``` io_demo tset case

## Why ?
It needs to decrease io_demo test time.
