### PR TITLE
UCS/MPOOL: add max_chunk_size check

### DIFF
--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -126,6 +126,24 @@ UCS_TEST_F(test_mpool, wrong_ops) {
     EXPECT_TRUE(status == UCS_ERR_INVALID_PARAM);
 }
 
+UCS_TEST_F(test_mpool, wrong_mpool_chuk_size) {
+    ucs_mpool_t mp;
+    ucs_mpool_ops_t ops = { 0 };
+    scoped_log_handler log_handler(mpool_log_handler);
+    ucs_mpool_params_t mp_params;
+
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = header_size + data_size;
+    mp_params.align_offset    = header_size;
+    mp_params.alignment       = align;
+    mp_params.elems_per_chunk = 1;
+    mp_params.max_chunk_size  = mp_params.elems_per_chunk * mp_params.elem_size;
+    mp_params.ops             = &ops;
+    mp_params.name            = "tests";
+    ucs_status_t status       = ucs_mpool_init(&mp_params, &mp);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+}
+
 UCS_TEST_F(test_mpool, basic) {
     ucs_status_t status;
     ucs_mpool_t mp;


### PR DESCRIPTION
## What
add max_chunk_size check in ucs_mpool_init()

## Why ?
mpool may allocate a chunk not enough for even one element and code may get segv at corner case such as element size is less than alignment.

## How ?
Calculate min_chunk_size and compare to max_chunk_size in ucs_mpool_init(), return fail creating the memory pool for invalid input max_chunk_size .
