### PR TITLE
UCP/CORE: Use getter/setter functions for UCT lanes in UCP endpoint

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -243,8 +243,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_zcopy_send_func(
     ucp_am_eager_zcopy_add_footer(req, footer_offset, lpriv->super.md_index,
                                   iov, &iov_count, footer_size);
 
-    return uct_ep_am_zcopy(req->send.ep->uct_eps[lpriv->super.lane], am_id,
-                           &hdr, sizeof(ucp_am_hdr_t), iov, iov_count, 0,
+    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
+                           am_id, &hdr, sizeof(ucp_am_hdr_t), iov, iov_count, 0,
                            &req->send.state.uct_comp);
 }
 

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -63,7 +63,8 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
         am_id = UCP_AM_ID_AM_SINGLE;
     }
 
-    status = uct_ep_am_short_iov(req->send.ep->uct_eps[spriv->super.lane],
+    status = uct_ep_am_short_iov(ucp_ep_get_lane(req->send.ep,
+                                                 spriv->super.lane),
                                  am_id, iov, iov_cnt);
     if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
         req->send.lane = spriv->super.lane; /* for pending add */
@@ -346,7 +347,7 @@ ucp_am_eager_single_zcopy_send_func(ucp_request_t *req,
     ucp_am_eager_zcopy_add_footer(req, 0, spriv->super.md_index, iov, &iovcnt,
                                   req->send.msg_proto.am.header_length);
 
-    return uct_ep_am_zcopy(req->send.ep->uct_eps[spriv->super.lane],
+    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
                            UCP_AM_ID_AM_SINGLE, &hdr, sizeof(hdr), iov, iovcnt,
                            0, &req->send.state.uct_comp);
 }
@@ -414,7 +415,7 @@ ucp_am_eager_single_zcopy_reply_send_func(ucp_request_t *req,
                                   req->send.msg_proto.am.header_length +
                                           sizeof(*ftr));
 
-    return uct_ep_am_zcopy(req->send.ep->uct_eps[spriv->super.lane],
+    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
                            UCP_AM_ID_AM_SINGLE_REPLY, &hdr, sizeof(hdr), iov,
                            iovcnt, 0, &req->send.state.uct_comp);
 }

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -24,9 +24,24 @@ static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
     return &ep->worker->ep_config[ep->cfg_index];
 }
 
+static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_lane(ucp_ep_h ep,
+                                                    ucp_lane_index_t lane_index)
+{
+    ucs_assert(lane_index != UCP_NULL_LANE);
+
+    return ep->uct_eps[lane_index];
+}
+
+static UCS_F_ALWAYS_INLINE void ucp_ep_set_lane(ucp_ep_h ep, size_t lane_index,
+                                                uct_ep_h uct_ep)
+{
+    ucs_assert(lane_index != UCP_NULL_LANE);
+
+    ep->uct_eps[lane_index] = uct_ep;
+}
+
 static inline ucp_lane_index_t ucp_ep_get_am_lane(ucp_ep_h ep)
 {
-    ucs_assert(ucp_ep_config(ep)->key.am_lane != UCP_NULL_LANE);
     return ep->am_lane;
 }
 
@@ -38,7 +53,6 @@ static inline ucp_lane_index_t ucp_ep_get_wireup_msg_lane(ucp_ep_h ep)
 
 static inline ucp_lane_index_t ucp_ep_get_tag_lane(ucp_ep_h ep)
 {
-    ucs_assert(ucp_ep_config(ep)->key.tag_lane != UCP_NULL_LANE);
     return ucp_ep_config(ep)->key.tag_lane;
 }
 
@@ -56,12 +70,12 @@ static inline int ucp_ep_config_key_has_tag_lane(const ucp_ep_config_key_t *key)
 
 static inline uct_ep_h ucp_ep_get_am_uct_ep(ucp_ep_h ep)
 {
-    return ep->uct_eps[ucp_ep_get_am_lane(ep)];
+    return ucp_ep_get_lane(ep, ucp_ep_get_am_lane(ep));
 }
 
 static inline uct_ep_h ucp_ep_get_tag_uct_ep(ucp_ep_h ep)
 {
-    return ep->uct_eps[ucp_ep_get_tag_lane(ep)];
+    return ucp_ep_get_lane(ep, ucp_ep_get_tag_lane(ep));
 }
 
 static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t lane)

--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -199,9 +199,9 @@ void ucp_proxy_ep_replace(ucp_proxy_ep_t *proxy_ep)
 
     ucs_assert(proxy_ep->uct_ep != NULL);
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
-        if (ucp_ep->uct_eps[lane] == &proxy_ep->super) {
+        if (ucp_ep_get_lane(ucp_ep, lane) == &proxy_ep->super) {
             ucs_assert(proxy_ep->uct_ep != NULL);    /* make sure there is only one match */
-            ucp_ep->uct_eps[lane] = proxy_ep->uct_ep;
+            ucp_ep_set_lane(ucp_ep, lane, proxy_ep->uct_ep);
             proxy_ep->uct_ep      = NULL;
         }
     }

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -293,10 +293,7 @@ int ucp_request_pending_add(ucp_request_t *req)
     ucs_status_t status;
     uct_ep_h uct_ep;
 
-    ucs_assertv(req->send.lane != UCP_NULL_LANE, "%s() did not set req->send.lane",
-                ucs_debug_get_symbol_name(req->send.uct.func));
-
-    uct_ep = req->send.ep->uct_eps[req->send.lane];
+    uct_ep = ucp_ep_get_lane(req->send.ep, req->send.lane);
     status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
     if (status == UCS_OK) {
         ucs_trace_data("ep %p: added pending uct request %p to lane[%d]=%p",

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -450,7 +450,7 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         return UCS_OK;
     }
 
-    wireup_ep = ucp_wireup_ep(ucp_ep->uct_eps[lane]);
+    wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ucp_ep, lane));
     if ((wireup_ep == NULL) ||
         !ucp_wireup_aux_ep_is_owner(wireup_ep, uct_ep) ||
         !ucp_ep_is_local_connected(ucp_ep)) {
@@ -3169,6 +3169,7 @@ static int ucp_worker_do_ep_keepalive(ucp_worker_h worker, ucs_time_t now)
     ucp_rsc_index_t rsc_index;
     ucs_status_t status;
     ucp_ep_h ep;
+    uct_ep_h uct_ep;
 
     UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(worker);
 
@@ -3184,6 +3185,7 @@ static int ucp_worker_do_ep_keepalive(ucp_worker_h worker, ucs_time_t now)
     }
 
     lane      = ucp_ep_config(ep)->key.keepalive_lane;
+    uct_ep    = ucp_ep_get_lane(ep, lane);
     rsc_index = ucp_ep_get_rsc_index(ep, lane);
 
     ucs_assertv((rsc_index != UCP_NULL_RESOURCE) ||
@@ -3192,26 +3194,23 @@ static int ucp_worker_do_ep_keepalive(ucp_worker_h worker, ucs_time_t now)
                 ep, ucp_ep_get_cm_lane(ep), lane, rsc_index);
 
     ucs_trace("ep %p: do keepalive on lane[%d]=%p ep->flags=0x%x", ep, lane,
-              ep->uct_eps[lane], ep->flags);
+              uct_ep, ep->flags);
 
     if (ucp_ep_is_am_keepalive(ep, rsc_index,
                                ucp_ep_config(ep)->p2p_lanes & UCS_BIT(lane))) {
-        status = ucp_ep_do_uct_ep_am_keepalive(ep, ep->uct_eps[lane],
-                                               rsc_index);
+        status = ucp_ep_do_uct_ep_am_keepalive(ep, uct_ep, rsc_index);
     } else {
-        status = uct_ep_check(ep->uct_eps[lane], 0, NULL);
+        status = uct_ep_check(uct_ep, 0, NULL);
     }
 
     if (status == UCS_ERR_NO_RESOURCE) {
         return 0;
     } else if (status != UCS_OK) {
-        ucs_diag("worker %p: keepalive failed on ep %p lane[%d]=%p: %s",
-                 worker, ep, lane, ep->uct_eps[lane],
-                 ucs_status_string(status));
+        ucs_diag("worker %p: keepalive failed on ep %p lane[%d]=%p: %s", worker,
+                 ep, lane, uct_ep, ucs_status_string(status));
     } else {
         ucs_trace("worker %p: keepalive done on ep %p lane[%d]=%p, now: <%lf"
-                  " sec>", worker, ep, lane, ep->uct_eps[lane],
-                  ucs_time_to_sec(now));
+                  " sec>", worker, ep, lane, uct_ep, ucs_time_to_sec(now));
     }
 
 #if UCS_ENABLE_ASSERT

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -53,7 +53,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
                   ucs_memory_type_names[mem_type]);
     }
 
-    status = uct_ep_put_short(ep->uct_eps[lane], recv_data, recv_length,
+    status = uct_ep_put_short(ucp_ep_get_lane(ep, lane), recv_data, recv_length,
                               (uint64_t)buffer, rkey_bundle.rkey);
     if (status != UCS_OK) {
         ucs_fatal("mem type unpack failed to uct_ep_put_short() %s",
@@ -91,7 +91,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
                   ucs_memory_type_names[mem_type]);
     }
 
-    status = uct_ep_get_short(ep->uct_eps[lane], dest, length,
+    status = uct_ep_get_short(ucp_ep_get_lane(ep, lane), dest, length,
                               (uint64_t)src, rkey_bundle.rkey);
     if (status != UCS_OK) {
         ucs_fatal("mem type pack failed to uct_ep_get_short() %s",

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -71,8 +71,9 @@ ucp_do_am_single(uct_pending_req_t *self, uint8_t am_id,
                     "packed_len=%zd max_packed_size=%zu", packed_len,
                     max_packed_size);
 
-        return uct_ep_am_short(ep->uct_eps[req->send.lane], am_id, buffer[0],
-                               &buffer[1], packed_len - sizeof(uint64_t));
+        return uct_ep_am_short(ucp_ep_get_lane(ep, req->send.lane), am_id,
+                               buffer[0], &buffer[1],
+                               packed_len - sizeof(uint64_t));
     } else {
         return ucp_do_am_bcopy_single(self, am_id, pack_cb);
     }

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -46,8 +46,8 @@ ucp_do_am_bcopy_single(uct_pending_req_t *self, uint8_t am_id,
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len     = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], am_id, pack_cb,
-                                     req, 0);
+    packed_len     = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+                                     am_id, pack_cb, req, 0);
     if (ucs_unlikely(packed_len < 0)) {
         /* Reset the state to the previous one */
         req->send.state.dt = state;
@@ -78,7 +78,7 @@ ucs_status_t ucp_do_am_bcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
     req->send.lane = (!enable_am_bw || (state.offset == 0)) ? /* first part of message must be sent */
                      ucp_ep_get_am_lane(ep) :                 /* via AM lane */
                      ucp_send_request_get_am_bw_lane(req);
-    uct_ep         = ep->uct_eps[req->send.lane];
+    uct_ep         = ucp_ep_get_lane(ep, req->send.lane);
 
     for (;;) {
         if (state.offset == 0) {
@@ -261,7 +261,7 @@ ucs_status_t ucp_am_zcopy_common(ucp_request_t *req, const void *hdr,
                              user_hdr_desc->memh->uct[md_idx], &iov_count);
     }
 
-    return uct_ep_am_zcopy(ep->uct_eps[req->send.lane], am_id, (void*)hdr,
+    return uct_ep_am_zcopy(ucp_ep_get_lane(ep, req->send.lane), am_id, (void*)hdr,
                            hdr_size, iov, iov_count, 0,
                            &req->send.state.uct_comp);
 }

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -89,7 +89,7 @@ ucp_proto_multi_no_resource(ucp_request_t *req, ucp_lane_index_t lane)
     }
 
     /* failed to send on another lane - add to its pending queue */
-    uct_ep = req->send.ep->uct_eps[lane];
+    uct_ep = ucp_ep_get_lane(req->send.ep, lane);
     status = uct_ep_pending_add(uct_ep, &req->send.uct, 0);
     if (status == UCS_ERR_BUSY) {
         /* try sending again */
@@ -270,7 +270,7 @@ ucp_proto_eager_bcopy_multi_common_send_func(
     }
     pack_ctx.max_payload = ucp_proto_multi_max_payload(req, lpriv, hdr_size);
 
-    packed_size = uct_ep_am_bcopy(ep->uct_eps[lpriv->super.lane], am_id,
+    packed_size = uct_ep_am_bcopy(ucp_ep_get_lane(ep, lpriv->super.lane), am_id,
                                   pack_cb, &pack_ctx, 0);
     if (ucs_likely(packed_size >= 0)) {
         ucs_assert(packed_size >= hdr_size);

--- a/src/ucp/proto/proto_single.inl
+++ b/src/ucp/proto/proto_single.inl
@@ -34,11 +34,11 @@ ucp_proto_am_bcopy_single_send(ucp_request_t *req, ucp_am_id_t am_id,
         ucs_assertv((packed_size >= 0) && (packed_size <= max_packed_size),
                     "packed_size=%zd max_packed_size=%zu", packed_size,
                     max_packed_size);
-        return uct_ep_am_short(ep->uct_eps[lane], am_id, buffer[0],
+        return uct_ep_am_short(ucp_ep_get_lane(ep, lane), am_id, buffer[0],
                                &buffer[1], packed_size - sizeof(buffer[0]));
     } else {
         /* Send as bcopy */
-        packed_size = uct_ep_am_bcopy(ep->uct_eps[lane], am_id, pack_func,
+        packed_size = uct_ep_am_bcopy(ucp_ep_get_lane(ep, lane), am_id, pack_func,
                                       pack_arg, 0);
         return ucs_likely(packed_size >= 0) ? UCS_OK : packed_size;
     }

--- a/src/ucp/rma/amo_basic.c
+++ b/src/ucp/rma/amo_basic.c
@@ -43,13 +43,13 @@ static ucs_status_t ucp_amo_basic_progress_post(uct_pending_req_t *self)
     req->send.lane = rkey->cache.amo_lane;
     if (req->send.length == sizeof(uint64_t)) {
         status = UCS_PROFILE_CALL(uct_ep_atomic64_post,
-                                  ep->uct_eps[req->send.lane], op, value,
-                                  remote_addr, rkey->cache.amo_rkey);
+                                  ucp_ep_get_lane(ep, req->send.lane), op,
+                                  value, remote_addr, rkey->cache.amo_rkey);
     } else {
         ucs_assert(req->send.length == sizeof(uint32_t));
         status = UCS_PROFILE_CALL(uct_ep_atomic32_post,
-                                  ep->uct_eps[req->send.lane], op, value,
-                                  remote_addr, rkey->cache.amo_rkey);
+                                  ucp_ep_get_lane(ep, req->send.lane), op,
+                                  value, remote_addr, rkey->cache.amo_rkey);
     }
 
     return ucp_amo_check_send_status(req, status);
@@ -64,34 +64,31 @@ static ucs_status_t ucp_amo_basic_progress_fetch(uct_pending_req_t *self)
     uint64_t *result      = req->send.buffer;
     uint64_t remote_addr  = req->send.amo.remote_addr;
     uct_atomic_op_t op    = req->send.amo.uct_op;
+    uct_ep_h uct_ep;
     ucs_status_t status;
 
     req->send.lane = rkey->cache.amo_lane;
+    uct_ep         = ucp_ep_get_lane(ep, req->send.lane);
     if (req->send.length == sizeof(uint64_t)) {
         if (op != UCT_ATOMIC_OP_CSWAP) {
-            status = uct_ep_atomic64_fetch(ep->uct_eps[req->send.lane],
-                                           op, value, result,
-                                           remote_addr,
-                                           rkey->cache.amo_rkey,
+            status = uct_ep_atomic64_fetch(uct_ep, op, value, result,
+                                           remote_addr, rkey->cache.amo_rkey,
                                            &req->send.state.uct_comp);
         } else {
-            status = uct_ep_atomic_cswap64(ep->uct_eps[req->send.lane],
-                                           value, *result,
-                                           remote_addr, rkey->cache.amo_rkey, result,
+            status = uct_ep_atomic_cswap64(uct_ep, value, *result, remote_addr,
+                                           rkey->cache.amo_rkey, result,
                                            &req->send.state.uct_comp);
         }
     } else {
         ucs_assert(req->send.length == sizeof(uint32_t));
         if (op != UCT_ATOMIC_OP_CSWAP) {
-            status = uct_ep_atomic32_fetch(ep->uct_eps[req->send.lane],
-                                           op, value, (uint32_t*)result,
-                                           remote_addr,
-                                           rkey->cache.amo_rkey,
+            status = uct_ep_atomic32_fetch(uct_ep, op, value, (uint32_t*)result,
+                                           remote_addr, rkey->cache.amo_rkey,
                                            &req->send.state.uct_comp);
         } else {
-            status = uct_ep_atomic_cswap32(ep->uct_eps[req->send.lane],
-                                           value, *(uint32_t*)result, remote_addr,
-                                           rkey->cache.amo_rkey, (uint32_t*)result,
+            status = uct_ep_atomic_cswap32(uct_ep, value, *(uint32_t*)result,
+                                           remote_addr, rkey->cache.amo_rkey,
+                                           (uint32_t*)result,
                                            &req->send.state.uct_comp);
         }
     }

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -55,11 +55,13 @@ ucp_proto_amo_progress(uct_pending_req_t *self, ucp_operation_id_t op_id,
     uct_atomic_op_t op                   = req->send.amo.uct_op;
     uint64_t *result64                   = req->send.buffer;
     uint32_t *result32                   = req->send.buffer;
+    uct_ep_h uct_ep;
     uint64_t value;
     ucs_status_t status;
     uct_rkey_t tl_rkey;
 
     req->send.lane = spriv->super.lane;
+    uct_ep         = ucp_ep_get_lane(ep, req->send.lane);
     tl_rkey        = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
                                           spriv->super.rkey_index);
 
@@ -77,36 +79,30 @@ ucp_proto_amo_progress(uct_pending_req_t *self, ucp_operation_id_t op_id,
 
     if (op_size == sizeof(uint64_t)) {
         if (op_id == UCP_OP_ID_AMO_POST) {
-            status = UCS_PROFILE_CALL(uct_ep_atomic64_post,
-                                      ep->uct_eps[req->send.lane], op, value,
+            status = UCS_PROFILE_CALL(uct_ep_atomic64_post, uct_ep, op, value,
                                       remote_addr, tl_rkey);
         } else if (op_id == UCP_OP_ID_AMO_FETCH) {
-            status = UCS_PROFILE_CALL(uct_ep_atomic64_fetch,
-                                      ep->uct_eps[req->send.lane], op, value,
+            status = UCS_PROFILE_CALL(uct_ep_atomic64_fetch, uct_ep, op, value,
                                       result64, remote_addr, tl_rkey,
                                       &req->send.state.uct_comp);
         } else {
             ucs_assert(op_id == UCP_OP_ID_AMO_CSWAP);
-            status = UCS_PROFILE_CALL(uct_ep_atomic_cswap64,
-                                      ep->uct_eps[req->send.lane], value,
+            status = UCS_PROFILE_CALL(uct_ep_atomic_cswap64, uct_ep, value,
                                       *result64, remote_addr, tl_rkey, result64,
                                       &req->send.state.uct_comp);
         }
     } else {
         ucs_assert(op_size == sizeof(uint32_t));
         if (op_id == UCP_OP_ID_AMO_POST) {
-            status = UCS_PROFILE_CALL(uct_ep_atomic32_post,
-                                      ep->uct_eps[req->send.lane], op, value,
+            status = UCS_PROFILE_CALL(uct_ep_atomic32_post, uct_ep, op, value,
                                       remote_addr, tl_rkey);
         } else if (op_id == UCP_OP_ID_AMO_FETCH) {
-            status = UCS_PROFILE_CALL(uct_ep_atomic32_fetch,
-                                      ep->uct_eps[req->send.lane], op, value,
+            status = UCS_PROFILE_CALL(uct_ep_atomic32_fetch, uct_ep, op, value,
                                       result32, remote_addr, tl_rkey,
                                       &req->send.state.uct_comp);
         } else {
             ucs_assert(op_id == UCP_OP_ID_AMO_CSWAP);
-            status = UCS_PROFILE_CALL(uct_ep_atomic_cswap32,
-                                      ep->uct_eps[req->send.lane], value,
+            status = UCS_PROFILE_CALL(uct_ep_atomic_cswap32, uct_ep, value,
                                       *result32, remote_addr, tl_rkey, result32,
                                       &req->send.state.uct_comp);
         }

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -133,8 +133,9 @@ static ucs_status_t ucp_progress_atomic_reply(uct_pending_req_t *self)
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_ATOMIC_REP,
-                                 ucp_amo_sw_pack_atomic_reply, req, 0);
+    packed_len     = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+                                     UCP_AM_ID_ATOMIC_REP,
+                                     ucp_amo_sw_pack_atomic_reply, req, 0);
 
     if (packed_len < 0) {
         return (ucs_status_t)packed_len;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -80,7 +80,7 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
 
         /* Search for next lane to start flush */
         lane   = ucs_ffs64(all_lanes & ~req->send.flush.started_lanes);
-        uct_ep = ep->uct_eps[lane];
+        uct_ep = ucp_ep_get_lane(ep, lane);
         if (uct_ep == NULL) {
             req->send.flush.started_lanes |= UCS_BIT(lane);
             --req->send.state.uct_comp.count;
@@ -201,10 +201,10 @@ ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
 
     ucs_assert(!(req->flags & UCP_REQUEST_FLAG_COMPLETED));
 
-    status = uct_ep_flush(ep->uct_eps[lane], req->send.flush.uct_flags,
+    status = uct_ep_flush(ucp_ep_get_lane(ep, lane), req->send.flush.uct_flags,
                           &req->send.state.uct_comp);
-    ucs_trace("flushing ep %p lane[%d]=%p: %s", ep, lane, ep->uct_eps[lane],
-              ucs_status_string(status));
+    ucs_trace("flushing ep %p lane[%d]=%p: %s", ep, lane,
+              ucp_ep_get_lane(ep, lane), ucs_status_string(status));
     if (status == UCS_OK) {
         --req->send.state.uct_comp.count; /* UCT endpoint is flushed */
     } else if (UCS_STATUS_IS_ERR(status) && (status != UCS_ERR_NO_RESOURCE)) {

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -35,10 +35,10 @@ ucp_proto_get_offload_bcopy_send_func(ucp_request_t *req,
     max_length = ucp_proto_multi_max_payload(req, lpriv, 0);
     length     = ucp_datatype_iter_next_ptr(&req->send.state.dt_iter,
                                             max_length, next_iter, &dest);
-    return uct_ep_get_bcopy(req->send.ep->uct_eps[lpriv->super.lane],
+    return uct_ep_get_bcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
                             ucp_proto_get_offload_bcopy_unpack, dest, length,
                             req->send.rma.remote_addr +
-                            req->send.state.dt_iter.offset,
+                                    req->send.state.dt_iter.offset,
                             tl_rkey, &req->send.state.uct_comp);
 }
 
@@ -135,9 +135,9 @@ ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
     mpriv = req->send.proto_config->priv;
     ucp_proto_common_zcopy_adjust_min_frag(req, mpriv->min_frag, iov.length,
                                            &iov, 1, &offset);
-    return uct_ep_get_zcopy(req->send.ep->uct_eps[lpriv->super.lane], &iov, 1,
-                            req->send.rma.remote_addr + offset, tl_rkey,
-                            &req->send.state.uct_comp);
+    return uct_ep_get_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
+                            &iov, 1, req->send.rma.remote_addr + offset,
+                            tl_rkey, &req->send.state.uct_comp);
 }
 
 static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self)

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -27,7 +27,7 @@ static ucs_status_t ucp_proto_put_offload_short_progress(uct_pending_req_t *self
     uct_rkey_t tl_rkey;
 
     tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey, spriv->super.rkey_index);
-    status  = uct_ep_put_short(ep->uct_eps[spriv->super.lane],
+    status  = uct_ep_put_short(ucp_ep_get_lane(ep, spriv->super.lane),
                                req->send.state.dt_iter.type.contig.buffer,
                                req->send.state.dt_iter.length,
                                req->send.rma.remote_addr, tl_rkey);
@@ -113,7 +113,7 @@ ucp_proto_put_offload_bcopy_send_func(ucp_request_t *req,
 
     tl_rkey     = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
                                        lpriv->super.rkey_index);
-    packed_size = uct_ep_put_bcopy(ep->uct_eps[lpriv->super.lane],
+    packed_size = uct_ep_put_bcopy(ucp_ep_get_lane(ep, lpriv->super.lane),
                                    ucp_proto_put_offload_bcopy_pack, &pack_ctx,
                                    req->send.rma.remote_addr +
                                    req->send.state.dt_iter.offset,
@@ -200,7 +200,8 @@ ucp_proto_put_offload_zcopy_send_func(ucp_request_t *req,
                                ucp_proto_multi_max_payload(req, lpriv, 0),
                                lpriv->super.md_index, UCP_DT_MASK_CONTIG_IOV,
                                next_iter, &iov, 1);
-    return uct_ep_put_zcopy(req->send.ep->uct_eps[lpriv->super.lane], &iov, 1,
+    return uct_ep_put_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
+                            &iov, 1,
                             req->send.rma.remote_addr +
                             req->send.state.dt_iter.offset,
                             tl_rkey, &req->send.state.uct_comp);

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -113,7 +113,8 @@ ucp_rma_sw_do_am_bcopy(ucp_request_t *req, uint8_t id, ucp_lane_index_t lane,
      * able to complete the remote request operation inside uct_ep_am_bcopy()
      * and decrement the flush_ops_count before it was incremented */
     ucp_worker_flush_ops_count_inc(ep->worker);
-    packed_len = uct_ep_am_bcopy(ep->uct_eps[lane], id, pack_cb, pack_arg, 0);
+    packed_len = uct_ep_am_bcopy(ucp_ep_get_lane(ep, lane),
+                                 id, pack_cb, pack_arg, 0);
     if (packed_len > 0) {
         if (packed_len_p != NULL) {
             *packed_len_p = packed_len;

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -32,17 +32,16 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
         (req->send.length <= ucp_ep_config(ep)->bcopy_thresh))
     {
         packed_len = ucs_min((ssize_t)req->send.length, rma_config->max_put_short);
-        status = UCS_PROFILE_CALL(uct_ep_put_short,
-                                  ep->uct_eps[lane],
-                                  req->send.buffer,
-                                  packed_len,
-                                  req->send.rma.remote_addr,
-                                  rkey->cache.rma_rkey);
+        status     = UCS_PROFILE_CALL(uct_ep_put_short, ucp_ep_get_lane(ep, lane),
+                                      req->send.buffer, packed_len,
+                                      req->send.rma.remote_addr,
+                                      rkey->cache.rma_rkey);
     } else if (ucs_likely(req->send.length < rma_config->put_zcopy_thresh)) {
         ucp_memcpy_pack_context_t pack_ctx;
         pack_ctx.src    = req->send.buffer;
         pack_ctx.length = ucs_min(req->send.length, rma_config->max_put_bcopy);
-        packed_len      = UCS_PROFILE_CALL(uct_ep_put_bcopy, ep->uct_eps[lane],
+        packed_len      = UCS_PROFILE_CALL(uct_ep_put_bcopy,
+                                           ucp_ep_get_lane(ep, lane),
                                            ucp_memcpy_pack_cb, &pack_ctx,
                                            req->send.rma.remote_addr,
                                            rkey->cache.rma_rkey);
@@ -58,10 +57,8 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
         iov.count  = 1;
         iov.memh   = req->send.state.dt.dt.contig.memh[0];
 
-        status = UCS_PROFILE_CALL(uct_ep_put_zcopy,
-                                  ep->uct_eps[lane],
-                                  &iov, 1,
-                                  req->send.rma.remote_addr,
+        status = UCS_PROFILE_CALL(uct_ep_put_zcopy, ucp_ep_get_lane(ep, lane),
+                                  &iov, 1, req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
     }
@@ -85,11 +82,9 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
 
     if (ucs_likely((ssize_t)req->send.length < rma_config->get_zcopy_thresh)) {
         frag_length = ucs_min(rma_config->max_get_bcopy, req->send.length);
-        status = UCS_PROFILE_CALL(uct_ep_get_bcopy,
-                                  ep->uct_eps[lane],
+        status = UCS_PROFILE_CALL(uct_ep_get_bcopy, ucp_ep_get_lane(ep, lane),
                                   (uct_unpack_callback_t)memcpy,
-                                  (void*)req->send.buffer,
-                                  frag_length,
+                                  (void*)req->send.buffer, frag_length,
                                   req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
@@ -101,10 +96,8 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
         iov.count   = 1;
         iov.memh    = req->send.state.dt.dt.contig.memh[0];
 
-        status = UCS_PROFILE_CALL(uct_ep_get_zcopy,
-                                  ep->uct_eps[lane],
-                                  &iov, 1,
-                                  req->send.rma.remote_addr,
+        status = UCS_PROFILE_CALL(uct_ep_get_zcopy, ucp_ep_get_lane(ep, lane),
+                                  &iov, 1, req->send.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
     }

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -221,7 +221,7 @@ ucp_put_send_short(ucp_ep_h ep, const void *buffer, size_t length,
 
     tl_rkey = ucp_rkey_get_tl_rkey(rkey, rkey_config->put_short.rkey_index);
     return UCS_PROFILE_CALL(uct_ep_put_short,
-                            ep->uct_eps[rkey_config->put_short.lane],
+                            ucp_ep_get_lane(ep, rkey_config->put_short.lane),
                             buffer, length, remote_addr, tl_rkey);
 }
 
@@ -286,8 +286,9 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
         if (ucs_likely(!(attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL) &&
                        ((ssize_t)count <= rkey->cache.max_put_short))) {
             status = UCS_PROFILE_CALL(uct_ep_put_short,
-                                      ep->uct_eps[rkey->cache.rma_lane], buffer,
-                                      count, remote_addr, rkey->cache.rma_rkey);
+                                      ucp_ep_get_lane(ep, rkey->cache.rma_lane),
+                                      buffer, count, remote_addr,
+                                      rkey->cache.rma_rkey);
             if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
                 ret = UCS_STATUS_PTR(status);
                 goto out_unlock;

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -117,8 +117,9 @@ static ucs_status_t ucp_progress_rma_cmpl(uct_pending_req_t *self)
 
     req->send.lane = ucp_ep_get_am_lane(ep);
 
-    packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_CMPL,
-                                 ucp_rma_sw_pack_rma_ack, req, 0);
+    packed_len = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+                                 UCP_AM_ID_CMPL, ucp_rma_sw_pack_rma_ack, req,
+                                 0);
     if (packed_len < 0) {
         return (ucs_status_t)packed_len;
     }
@@ -206,8 +207,9 @@ static ucs_status_t ucp_progress_get_reply(uct_pending_req_t *self)
     ssize_t packed_len, payload_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len = uct_ep_am_bcopy(ep->uct_eps[req->send.lane], UCP_AM_ID_GET_REP,
-                                 ucp_rma_sw_pack_get_reply, req, 0);
+    packed_len     = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+                                     UCP_AM_ID_GET_REP, ucp_rma_sw_pack_get_reply,
+                                     req, 0);
     if (packed_len < 0) {
         return (ucs_status_t)packed_len;
     }

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -483,6 +483,7 @@ ucp_rndv_progress_rma_zcopy_common(ucp_request_t *req, ucp_lane_index_t lane,
 {
     const size_t max_iovcnt = 1;
     ucp_ep_h ep             = req->send.ep;
+    uct_ep_h uct_ep         = ucp_ep_get_lane(ep, lane);
     ucp_ep_config_t *config = ucp_ep_config(ep);
     uct_iov_t iov[max_iovcnt];
     size_t iovcnt;
@@ -551,11 +552,11 @@ ucp_rndv_progress_rma_zcopy_common(ucp_request_t *req, ucp_lane_index_t lane,
 
     for (;;) {
         if (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) {
-            status = uct_ep_get_zcopy(ep->uct_eps[lane], iov, iovcnt,
+            status = uct_ep_get_zcopy(uct_ep, iov, iovcnt,
                                       req->send.rndv.remote_address + offset,
                                       uct_rkey, &req->send.state.uct_comp);
         } else {
-            status = uct_ep_put_zcopy(ep->uct_eps[lane], iov, iovcnt,
+            status = uct_ep_put_zcopy(uct_ep, iov, iovcnt,
                                       req->send.rndv.remote_address + offset,
                                       uct_rkey, &req->send.state.uct_comp);
         }

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -60,7 +60,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_am_bcopy_send_func(
 
     pack_ctx.max_payload = ucp_proto_multi_max_payload(req, lpriv, hdr_size);
 
-    packed_size = uct_ep_am_bcopy(ep->uct_eps[lpriv->super.lane],
+    packed_size = uct_ep_am_bcopy(ucp_ep_get_lane(ep, lpriv->super.lane),
                                   UCP_AM_ID_RNDV_DATA,
                                   ucp_proto_rndv_am_bcopy_pack, &pack_ctx, 0);
     if (ucs_unlikely(packed_size < 0)) {

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -80,8 +80,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_common_send(
                                                    lpriv->super.rkey_index);
     uint64_t remote_address = req->send.rndv.remote_address + offset;
 
-    return uct_ep_get_zcopy(req->send.ep->uct_eps[lpriv->super.lane], iov, 1,
-                            remote_address, tl_rkey, comp);
+    return uct_ep_get_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
+                            iov, 1, remote_address, tl_rkey, comp);
 }
 
 static void

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -109,7 +109,6 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_mtype_copy(
     ucs_status_t status;
     uct_iov_t iov;
 
-    ucs_assert(lane != UCP_NULL_LANE);
     ucs_assert(mdesc != NULL);
 
     ucp_trace_req(req, "mdesc %p copy-%s %p %s using memtype-ep %p lane[%d]",
@@ -124,7 +123,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_mtype_copy(
 
     /* Copy from mdesc to user buffer */
     ucs_assert(req->send.state.dt_iter.dt_class == UCP_DATATYPE_CONTIG);
-    status = copy_func(mtype_ep->uct_eps[lane], &iov, 1,
+    status = copy_func(ucp_ep_get_lane(mtype_ep, lane), &iov, 1,
                        (uintptr_t)req->send.state.dt_iter.type.contig.buffer,
                        UCT_INVALID_RKEY, &req->send.state.uct_comp);
     ucp_trace_req(req, "mdesc %p copy returned %s", mdesc,

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -68,8 +68,8 @@ ucp_proto_rndv_put_common_send(ucp_request_t *req,
     uint64_t remote_address = req->send.rndv.remote_address +
                               req->send.state.dt_iter.offset;
 
-    return uct_ep_put_zcopy(req->send.ep->uct_eps[lpriv->super.lane], iov, 1,
-                            remote_address, tl_rkey, comp);
+    return uct_ep_put_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
+                            iov, 1, remote_address, tl_rkey, comp);
 }
 
 static void
@@ -92,7 +92,8 @@ ucp_proto_rndv_put_common_flush_send(ucp_request_t *req, ucp_lane_index_t lane)
 
     ucp_trace_req(req, "flush lane[%d] " UCT_TL_RESOURCE_DESC_FMT, lane,
                   UCT_TL_RESOURCE_DESC_ARG(ucp_ep_get_tl_rsc(ep, lane)));
-    return uct_ep_flush(ep->uct_eps[lane], 0, &req->send.state.uct_comp);
+    return uct_ep_flush(ucp_ep_get_lane(ep, lane), 0,
+                        &req->send.state.uct_comp);
 }
 
 static ucs_status_t
@@ -155,7 +156,7 @@ ucp_proto_rndv_put_common_fenced_atp_send(ucp_request_t *req,
 {
     ucs_status_t status;
 
-    status = uct_ep_fence(req->send.ep->uct_eps[lane], 0);
+    status = uct_ep_fence(ucp_ep_get_lane(req->send.ep, lane), 0);
     if (ucs_unlikely(status != UCS_OK)) {
         return status;
     }

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -270,8 +270,8 @@ ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
                                              max_payload, lpriv->super.md_index,
                                              UCP_DT_MASK_CONTIG_IOV, next_iter,
                                              iov, lpriv->super.max_iov);
-    return uct_ep_am_zcopy(req->send.ep->uct_eps[lpriv->super.lane], am_id,
-                           &hdr, hdr_size, iov, iov_count, 0,
+    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
+                           am_id, &hdr, hdr_size, iov, iov_count, 0,
                            &req->send.state.uct_comp);
 }
 

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -26,7 +26,7 @@ static ucs_status_t ucp_eager_short_progress(uct_pending_req_t *self)
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
     ucs_status_t status;
 
-    status = uct_ep_am_short(req->send.ep->uct_eps[spriv->super.lane],
+    status = uct_ep_am_short(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
                              UCP_AM_ID_EAGER_ONLY, req->send.msg_proto.tag,
                              req->send.state.dt_iter.type.contig.buffer,
                              req->send.state.dt_iter.length);
@@ -197,7 +197,7 @@ ucp_proto_eager_zcopy_send_func(ucp_request_t *req,
         .super.tag = req->send.msg_proto.tag
     };
 
-    return uct_ep_am_zcopy(req->send.ep->uct_eps[spriv->super.lane],
+    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
                            UCP_AM_ID_EAGER_ONLY, &hdr, sizeof(hdr), iov, 1, 0,
                            &req->send.state.uct_comp);
 }

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -121,10 +121,9 @@ static ucs_status_t ucp_tag_eager_contig_short(uct_pending_req_t *self)
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    status         = uct_ep_am_short(ep->uct_eps[req->send.lane],
-                                     UCP_AM_ID_EAGER_ONLY,
-                                     req->send.msg_proto.tag, req->send.buffer,
-                                     req->send.length);
+    status         = uct_ep_am_short(ucp_ep_get_lane(ep, req->send.lane),
+                                     UCP_AM_ID_EAGER_ONLY, req->send.msg_proto.tag,
+                                     req->send.buffer, req->send.length);
     return ucp_am_short_handle_status_from_pending(req, status);
 }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -472,7 +472,7 @@ static ucs_status_t ucp_tag_offload_eager_short(uct_pending_req_t *self)
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_tag_lane(ep);
-    status         = uct_ep_tag_eager_short(ep->uct_eps[req->send.lane],
+    status         = uct_ep_tag_eager_short(ucp_ep_get_lane(ep, req->send.lane),
                                             req->send.msg_proto.tag,
                                             req->send.buffer,
                                             req->send.length);
@@ -490,7 +490,7 @@ ucp_do_tag_offload_bcopy(uct_pending_req_t *self, uint64_t imm_data)
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_tag_lane(ep);
-    packed_len     = uct_ep_tag_eager_bcopy(ep->uct_eps[req->send.lane],
+    packed_len     = uct_ep_tag_eager_bcopy(ucp_ep_get_lane(ep, req->send.lane),
                                             req->send.msg_proto.tag, imm_data,
                                             ucp_tag_offload_pack_eager, req, 0);
     if (packed_len < 0) {
@@ -517,7 +517,7 @@ ucp_do_tag_offload_zcopy(uct_pending_req_t *self, uint64_t imm_data,
                         req->send.buffer, req->send.datatype, req->send.length,
                         ucp_ep_md_index(ep, req->send.lane), NULL);
 
-    status = uct_ep_tag_eager_zcopy(ep->uct_eps[req->send.lane],
+    status = uct_ep_tag_eager_zcopy(ucp_ep_get_lane(ep, req->send.lane),
                                     req->send.msg_proto.tag, imm_data, iov,
                                     iovcnt, 0, &req->send.state.uct_comp);
 
@@ -558,7 +558,7 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     rndv_rts_hdr = ucs_alloca(rndv_hdr_len);
     packed_len   = ucp_tag_rndv_rts_pack(rndv_rts_hdr, req);
 
-    status = uct_ep_tag_rndv_request(ep->uct_eps[req->send.lane],
+    status = uct_ep_tag_rndv_request(ucp_ep_get_lane(ep, req->send.lane),
                                      req->send.msg_proto.tag, rndv_rts_hdr,
                                      packed_len, 0);
     return ucp_rndv_send_handle_status_from_pending(req, status);
@@ -601,7 +601,7 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
                         req->send.buffer, req->send.datatype, req->send.length,
                         ucp_ep_md_index(ep, req->send.lane), NULL);
 
-    rndv_op = uct_ep_tag_rndv_zcopy(ep->uct_eps[req->send.lane],
+    rndv_op = uct_ep_tag_rndv_zcopy(ucp_ep_get_lane(ep, req->send.lane),
                                     req->send.msg_proto.tag, &rndv_hdr,
                                     sizeof(rndv_hdr), iov, iovcnt, 0,
                                     &req->send.state.uct_comp);
@@ -624,7 +624,8 @@ void ucp_tag_offload_cancel_rndv(ucp_request_t *req)
     ucp_ep_t *ep = req->send.ep;
     ucs_status_t status;
 
-    status = uct_ep_tag_rndv_cancel(ep->uct_eps[ucp_ep_get_tag_lane(ep)],
+    status = uct_ep_tag_rndv_cancel(ucp_ep_get_lane(ep,
+                                                    ucp_ep_get_tag_lane(ep)),
                                     req->send.tag_offload.rndv_op);
     if (status != UCS_OK) {
         ucs_error("Failed to cancel tag rndv op %s", ucs_status_string(status));

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -23,7 +23,7 @@ ucp_proto_eager_tag_offload_short_progress(uct_pending_req_t *self)
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
     ucs_status_t status;
 
-    status = uct_ep_tag_eager_short(ep->uct_eps[spriv->super.lane],
+    status = uct_ep_tag_eager_short(ucp_ep_get_lane(ep, spriv->super.lane),
                                     req->send.msg_proto.tag,
                                     req->send.state.dt_iter.type.contig.buffer,
                                     req->send.state.dt_iter.length);
@@ -104,7 +104,8 @@ ucp_proto_eager_tag_offload_bcopy_common(ucp_request_t *req,
 {
     ssize_t packed_len;
 
-    packed_len = uct_ep_tag_eager_bcopy(req->send.ep->uct_eps[spriv->super.lane],
+    packed_len = uct_ep_tag_eager_bcopy(ucp_ep_get_lane(req->send.ep,
+                                                        spriv->super.lane),
                                         req->send.msg_proto.tag, imm_data,
                                         ucp_eager_tag_offload_pack, req, 0);
 
@@ -264,7 +265,8 @@ ucp_proto_tag_offload_zcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_single_priv_t *spriv,
                                       uct_iov_t *iov)
 {
-    return uct_ep_tag_eager_zcopy(req->send.ep->uct_eps[spriv->super.lane],
+    return uct_ep_tag_eager_zcopy(ucp_ep_get_lane(req->send.ep,
+                                                  spriv->super.lane),
                                   req->send.msg_proto.tag, 0ul, iov, 1, 0,
                                   &req->send.state.uct_comp);
 }
@@ -303,7 +305,8 @@ ucp_proto_tag_offload_zcopy_sync_send_func(ucp_request_t *req,
                                            const ucp_proto_single_priv_t *spriv,
                                            uct_iov_t *iov)
 {
-    return uct_ep_tag_eager_zcopy(req->send.ep->uct_eps[spriv->super.lane],
+    return uct_ep_tag_eager_zcopy(ucp_ep_get_lane(req->send.ep,
+                                                  spriv->super.lane),
                                   req->send.msg_proto.tag,
                                   ucp_send_request_get_ep_remote_id(req), iov,
                                   1, 0, &req->send.state.uct_comp);

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -1290,7 +1290,7 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
                                                      0);
 
                     /* pack ep address */
-                    status = uct_ep_get_address(ep->uct_eps[lane], ptr);
+                    status = uct_ep_get_address(ucp_ep_get_lane(ep, lane), ptr);
                     if (status != UCS_OK) {
                         return status;
                     }

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -645,9 +645,8 @@ int ucp_wireup_aux_ep_is_owner(ucp_wireup_ep_t *wireup_ep, uct_ep_h owned_ep)
 
     return (wireup_ep->aux_ep == owned_ep) ||
            /* Auxilliary EP can be WIREUP EP in case of it is on CM lane */
-           ((wireup_ep->aux_ep != NULL) &&
-            (cm_lane_idx != UCP_NULL_LANE) &&
-            (ucp_ep->uct_eps[cm_lane_idx] == &wireup_ep->super.super) &&
+           ((wireup_ep->aux_ep != NULL) && (cm_lane_idx != UCP_NULL_LANE) &&
+            (ucp_ep_get_lane(ucp_ep, cm_lane_idx) == &wireup_ep->super.super) &&
             ucp_wireup_ep_is_owner(wireup_ep->aux_ep, owned_ep));
 }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -932,7 +932,7 @@ protected:
                 continue;
             }
 
-            uct_iface_h uct_iface = ep->uct_eps[lane]->iface;
+            uct_iface_h uct_iface = ucp_ep_get_lane(ep, lane)->iface;
             auto res              = m_sender_uct_ops.emplace(uct_iface,
                                                              uct_iface->ops);
             if (res.second) {
@@ -1493,7 +1493,7 @@ protected:
         } else {
             /* Make sure that stub WIREUP_EP is updated */
             for (auto lane = 0; lane < ucp_ep_num_lanes(e.ep()); ++lane) {
-                set_iface_failure(e.ep()->uct_eps[lane]->iface,
+                set_iface_failure(ucp_ep_get_lane(e.ep(), lane)->iface,
                                   fail_wireup_type);
             }
             for (auto iface_id = 0; iface_id < worker->num_ifaces;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1047,7 +1047,7 @@ public:
 
         for (ucp_lane_index_t lane = 0;
              lane < ucp_ep_num_lanes(sender().ep()); lane++) {
-            uct_ep_h uct_ep = sender().ep()->uct_eps[lane];
+            uct_ep_h uct_ep = ucp_ep_get_lane(sender().ep(), lane);
             if (uct_ep == NULL) {
                 continue;
             }


### PR DESCRIPTION
## What
Introduce `ucp_ep_get_lane` and `ucp_ep_set_lane` instead of accessing `uct_eps` in `ucp_ep` directly.

## Why ?
Refactoring - preparation for supporting more lanes per EP, which will be done by adding an "extension", in addition to the existing `uct_eps` array.