### PR TITLE
UCP/HWTM/RNDV: Use correct max_iov for tag offload rndv

### DIFF
--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -577,13 +577,12 @@ ucs_status_t ucp_tag_offload_rndv_zcopy(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_ep_t *ep       = req->send.ep;
-    size_t max_iov     = ucp_ep_config(ep)->tag.eager.max_iov;
+    size_t max_iov     = ucp_ep_config(ep)->tag.offload.max_rndv_iov;
     uct_iov_t *iov     = ucs_alloca(max_iov * sizeof(uct_iov_t));
     size_t iovcnt      = 0;
     ucp_dt_state_t dt_state;
     void *rndv_op;
     ucs_status_t status;
-
 
     ucp_tag_offload_unexp_rndv_hdr_t rndv_hdr = {
         .ep_id    = ucp_send_request_get_ep_remote_id(req),


### PR DESCRIPTION
## What
Use correct `max_iov` limit for tag offload rendezvous

