### PR TITLE
UCT/IB: Fix CQ length calculation in UD/DC

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1273,7 +1273,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     }
 
     self->ops                       = ops;
-
+    self->config.tx_qp_len          = config->tx.queue_len;
     self->config.rx_payload_offset  = sizeof(uct_ib_iface_recv_desc_t) +
                                       ucs_max(sizeof(uct_recv_desc_t) +
                                               rx_headroom,

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -274,6 +274,7 @@ struct uct_ib_iface {
     uct_ib_device_gid_info_t  gid_info;
 
     struct {
+        unsigned              tx_qp_len;
         unsigned              rx_payload_offset;   /* offset from desc to payload */
         unsigned              rx_hdr_offset;       /* offset from desc to network header */
         unsigned              rx_headroom_offset;  /* offset from desc to user headroom */

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -48,7 +48,6 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
     int max_tx, max_rx, len_tx, len;
     uct_ib_mlx5_devx_uar_t *uar;
     ucs_status_t status;
-    int wqe_size;
     int dvflags;
     void *qpc;
 
@@ -71,15 +70,8 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
         goto err;
     }
 
-    wqe_size = sizeof(struct mlx5_wqe_ctrl_seg) +
-               sizeof(struct mlx5_wqe_umr_ctrl_seg) +
-               sizeof(struct mlx5_wqe_mkey_context_seg) +
-               ucs_max(sizeof(struct mlx5_wqe_umr_klm_seg), 64) +
-               ucs_max(attr->super.cap.max_send_sge * sizeof(struct mlx5_wqe_data_seg),
-                       ucs_align_up(sizeof(struct mlx5_wqe_inl_data_seg) +
-                                    attr->super.cap.max_inline_data, 16));
-    len_tx = ucs_roundup_pow2_or0(attr->super.cap.max_send_wr * wqe_size);
-    max_tx = len_tx / MLX5_SEND_WQE_BB;
+    max_tx = uct_ib_mlx5_sq_length(attr->super.cap.max_send_wr);
+    len_tx = max_tx * MLX5_SEND_WQE_BB;
     max_rx = ucs_roundup_pow2_or0(attr->super.cap.max_recv_wr);
     len    = len_tx + max_rx * UCT_IB_MLX5_MAX_BB * UCT_IB_MLX5_WQE_SEG_SIZE;
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -654,7 +654,7 @@ uct_ib_mlx5_get_mmio_mode(uct_priv_worker_t *worker,
 /**
  * Initialize txwq structure.
  */
-ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
+ucs_status_t uct_ib_mlx5_txwq_init(uct_ib_iface_t *iface,
                                    uct_ib_mlx5_mmio_mode_t cfg_mmio_mode,
                                    uct_ib_mlx5_txwq_t *txwq, struct ibv_qp *verbs_qp);
 
@@ -863,6 +863,8 @@ uct_ib_mlx5_devx_query_qp_peer_info(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp,
 static inline void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp) { }
 
 #endif
+
+size_t uct_ib_mlx5_sq_length(size_t tx_qp_length);
 
 ucs_status_t
 uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -414,8 +414,7 @@ uct_rc_mlx5_get_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     }
 #endif
     iface->tm.cmd_wq.super.super.qp_num = qp->qp_num;
-    return uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
-                                 iface->tx.mmio_mode,
+    return uct_ib_mlx5_txwq_init(&iface->super.super, iface->tx.mmio_mode,
                                  &iface->tm.cmd_wq.super, qp);
 }
 #endif
@@ -810,7 +809,7 @@ void uct_rc_mlx5_init_rx_tm_common(uct_rc_mlx5_iface_common_t *iface,
                                       sizeof(uct_rc_iface_send_desc_t),
                                       UCS_SYS_CACHE_LINE_SIZE,
                                       &config->super.tx.mp,
-                                      iface->super.config.tx_qp_len,
+                                      iface->super.super.config.tx_qp_len,
                                       uct_rc_iface_send_desc_init,
                                       "tag_eager_send_desc");
         if (status != UCS_OK) {

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -932,7 +932,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_ep_t, const uct_ep_params_t *params)
     ucs_status_t status;
 
     /* Need to create QP before super constructor to get QP number */
-    uct_rc_mlx5_iface_fill_attr(iface, &attr, iface->super.config.tx_qp_len,
+    uct_rc_mlx5_iface_fill_attr(iface, &attr,
+                                iface->super.super.config.tx_qp_len,
                                 &iface->rx.srq);
     status = uct_rc_mlx5_iface_create_qp(iface, &self->tx.wq.super, &self->tx.wq, &attr);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -374,7 +374,7 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
     }
 
     if (attr->super.cap.max_send_wr) {
-        status = uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
+        status = uct_ib_mlx5_txwq_init(&iface->super.super,
                                        iface->tx.mmio_mode, txwq,
                                        qp->verbs.qp);
         if (status != UCS_OK) {
@@ -800,7 +800,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
                                   sizeof(uct_rc_iface_send_desc_t) + UCT_IB_MAX_ATOMIC_SIZE,
                                   UCS_SYS_CACHE_LINE_SIZE,
                                   &rc_config->super.tx.mp,
-                                  self->super.config.tx_qp_len,
+                                  self->super.super.config.tx_qp_len,
                                   uct_rc_iface_send_desc_init,
                                   "rc_mlx5_atomic_desc");
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -577,7 +577,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     self->tx.cq_available       = tx_cq_size - 1;
     self->rx.srq.available      = 0;
     self->rx.srq.quota          = 0;
-    self->config.tx_qp_len      = config->super.tx.queue_len;
     self->config.tx_min_sge     = config->super.tx.min_sge;
     self->config.tx_min_inline  = config->super.tx.min_inline;
     self->config.tx_poll_always = config->tx.poll_always;
@@ -666,7 +665,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
                                   sizeof(uct_rc_iface_send_desc_t),
                                   UCS_SYS_CACHE_LINE_SIZE,
                                   &config->super.tx.mp,
-                                  self->config.tx_qp_len,
+                                  self->super.config.tx_qp_len,
                                   uct_rc_iface_send_desc_init,
                                   "rc_send_desc");
     if (status != UCS_OK) {
@@ -1001,11 +1000,11 @@ ucs_status_t uct_rc_iface_estimate_perf(uct_iface_h tl_iface,
     }
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS) {
-        ucs_assertv(iface->config.tx_cq_len >= iface->config.tx_qp_len,
+        ucs_assertv(iface->config.tx_cq_len >= iface->super.config.tx_qp_len,
                     "iface %p: tx_cq_len=%u tx_qp_len=%u", iface,
-                    iface->config.tx_cq_len, iface->config.tx_qp_len);
+                    iface->config.tx_cq_len, iface->super.config.tx_qp_len);
         perf_attr->max_inflight_eps =
-                iface->config.tx_cq_len / iface->config.tx_qp_len;
+                iface->config.tx_cq_len / iface->super.config.tx_qp_len;
     }
 
     return UCS_OK;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -264,7 +264,6 @@ struct uct_rc_iface {
     } rx;
 
     struct {
-        unsigned             tx_qp_len;
         unsigned             tx_min_sge;
         unsigned             tx_min_inline;
         unsigned             tx_cq_len;

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -599,7 +599,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_verbs_ep_t, const uct_ep_params_t *params)
     ucs_status_t status;
 
     status = uct_rc_iface_qp_create(&iface->super, &self->qp, &attr,
-                                    iface->super.config.tx_qp_len, iface->srq);
+                                    iface->super.super.config.tx_qp_len,
+                                    iface->srq);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -290,8 +290,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
                               &uct_rc_verbs_iface_ops, tl_md, worker, params,
                               &config->super.super, &init_attr);
 
-    self->config.tx_max_wr               = ucs_min(config->tx_max_wr,
-                                                   self->super.config.tx_qp_len);
+    self->config.tx_max_wr               = ucs_min(
+            config->tx_max_wr, self->super.super.config.tx_qp_len);
     self->super.config.tx_moderation     = ucs_min(config->super.tx_cq_moderation,
                                                    self->config.tx_max_wr / 4);
     self->super.config.fence_mode        = (uct_rc_fence_mode_t)config->super.super.fence_mode;
@@ -337,7 +337,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
                                   sizeof(uct_rc_iface_send_desc_t),
                                   UCS_SYS_CACHE_LINE_SIZE,
                                   &ib_config->tx.mp,
-                                  self->super.config.tx_qp_len,
+                                  self->super.super.config.tx_qp_len,
                                   uct_rc_iface_send_desc_init,
                                   "rc_verbs_short_desc");
     if (status != UCS_OK) {
@@ -354,7 +354,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
 
     /* Create a dummy QP in order to find out max_inline */
     status = uct_rc_iface_qp_create(&self->super, &qp, &attr,
-                                    self->super.config.tx_qp_len,
+                                    self->super.super.config.tx_qp_len,
                                     self->srq);
     if (status != UCS_OK) {
         goto err_common_cleanup;

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -729,9 +729,8 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
         return status;
     }
 
-    status = uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
-                                   iface->tx.mmio_mode, &iface->tx.wq,
-                                   qp->verbs.qp);
+    status = uct_ib_mlx5_txwq_init(&iface->super.super, iface->tx.mmio_mode,
+                                   &iface->tx.wq, qp->verbs.qp);
     if (status != UCS_OK) {
         goto err_destroy_qp;
     }
@@ -837,7 +836,8 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
     ucs_trace_func("");
 
     init_attr.flags                 = UCT_IB_CQ_IGNORE_OVERRUN;
-    init_attr.cq_len[UCT_IB_DIR_TX] = config->super.super.tx.queue_len * UCT_IB_MLX5_MAX_BB;
+    init_attr.cq_len[UCT_IB_DIR_TX] =
+            uct_ib_mlx5_sq_length(config->super.super.tx.queue_len);
     init_attr.cq_len[UCT_IB_DIR_RX] = config->super.super.rx.queue_len;
 
     self->tx.mmio_mode     = config->mlx5_common.mmio_mode;
@@ -866,8 +866,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
         return status;
     }
 
-    self->super.tx.available     = self->tx.wq.bb_max;
-    self->super.config.tx_qp_len = self->tx.wq.bb_max;
+    self->super.tx.available = self->tx.wq.bb_max;
     ucs_assert(init_attr.cq_len[UCT_IB_DIR_TX] >= self->tx.wq.bb_max);
 
     status = uct_ib_mlx5_get_rxwq(self->super.qp, &self->rx.wq);

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -576,7 +576,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
                                   sizeof(uct_ud_send_skb_t) + data_size,
                                   sizeof(uct_ud_send_skb_t),
                                   UCT_UD_SKB_ALIGN,
-                                  &config->super.tx.mp, self->config.tx_qp_len,
+                                  &config->super.tx.mp,
+                                  self->super.config.tx_qp_len,
                                   uct_ud_iface_send_skb_init, "ud_tx_skb");
     if (status != UCS_OK) {
         goto err_rx_mpool;
@@ -1061,8 +1062,8 @@ void uct_ud_iface_vfs_refresh(uct_iface_h iface)
                             "rx_qp_len");
 
     ucs_vfs_obj_add_ro_file(ud_iface, ucs_vfs_show_primitive,
-                            &ud_iface->config.tx_qp_len, UCS_VFS_TYPE_INT,
-                            "tx_qp_len");
+                            &ud_iface->super.config.tx_qp_len,
+                            UCS_VFS_TYPE_INT, "tx_qp_len");
 }
 
 void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,

--- a/test/gtest/uct/ib/test_ib_event.cc
+++ b/test/gtest/uct/ib/test_ib_event.cc
@@ -341,7 +341,7 @@ private:
             ucs_status_t status;
 
             uct_rc_mlx5_iface_fill_attr(m_iface, &attr,
-                                        m_iface->super.config.tx_qp_len,
+                                        m_iface->super.super.config.tx_qp_len,
                                         &m_iface->rx.srq);
             status = uct_rc_mlx5_iface_create_qp(m_iface, &m_txwq.super,
                                                  &m_txwq, &attr);
@@ -388,9 +388,9 @@ private:
             uct_ib_qp_attr_t attr = {};
             ucs_status_t status;
 
-            status = uct_rc_iface_qp_create(&m_iface->super, &m_ibqp, &attr,
-                                            m_iface->super.config.tx_qp_len,
-                                            m_iface->srq);
+            status = uct_rc_iface_qp_create(
+                    &m_iface->super, &m_ibqp, &attr,
+                    m_iface->super.super.config.tx_qp_len, m_iface->srq);
             ASSERT_UCS_OK(status);
 
             status = uct_rc_iface_qp_init(&m_iface->super, m_ibqp);


### PR DESCRIPTION
## What

Fix CQ length calculation in UD/DC.

## Why ?

CQ length could be less than:
* QP_length in UD
* num_dcis * QP_length in DC

`UCT_IB_MLX5_MAX_BB` multiplier could be used for TX QP length calculation, because `uct_ib_mlx5_post_send()` relies on the fact that `num_bb <= UCT_IB_MLX5_MAX_BB`:
https://github.com/openucx/ucx/blob/71120a2a2646068e1a52c087cc2d447f67ea3aba/src/uct/ib/mlx5/ib_mlx5.inl#L520

## How ?
 
1. Remove WQE size approximation in `uct_ib_mlx5_devx_create_qp`.
2. When calculating TX QP length in BBs, use `ucs_roundup_pow2_or0(tx_qp_length * UCT_IB_MLX5_MAX_BB)`.
3. Move `tx_qp_len` to the `uct_ib_iface_t` structure instead of `uct_rc_iface_t`/`uct_ud_iface_t`.
4. Use `tx_qp_len` from `uct_ib_iface_t` to verify that `wqe_cnt / tx_qp_len` took from DV <= `UCT_IB_MLX5_MAX_BB`.