### PR TITLE
UCP: minor code cleanup

### DIFF
--- a/src/ucp/am/ucp_am.inl
+++ b/src/ucp/am/ucp_am.inl
@@ -22,18 +22,6 @@ ucp_am_fill_header(ucp_am_hdr_t *hdr, ucp_request_t *req)
     hdr->header_length = req->send.msg_proto.am.header_length;
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
-{
-    ucp_dt_state_t hdr_state;
-
-    hdr_state.offset = 0ul;
-
-    ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
-                UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header,
-                &hdr_state, req->send.msg_proto.am.header_length);
-}
-
 static UCS_F_ALWAYS_INLINE int
 ucp_am_check_init_params(const ucp_proto_init_params_t *init_params,
                          uint64_t op_id_mask, uint16_t exclude_flags)

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -359,18 +359,6 @@ ucp_am_fill_first_footer(ucp_am_first_ftr_t *ftr, ucp_request_t *req)
     ftr->total_size = req->send.length;
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
-{
-    ucp_dt_state_t hdr_state;
-
-    hdr_state.offset = 0ul;
-
-    ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
-                UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header,
-                &hdr_state, req->send.msg_proto.am.header_length);
-}
-
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_am_zcopy_pack_user_header(ucp_request_t *req)
 {

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -604,4 +604,16 @@ ucp_am_bcopy_handle_status_from_pending(uct_pending_req_t *self, int multi,
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
+{
+    ucp_dt_state_t hdr_state;
+
+    hdr_state.offset = 0ul;
+
+    ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
+                UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header,
+                &hdr_state, req->send.msg_proto.am.header_length);
+}
+
 #endif

--- a/src/ucp/tag/probe.c
+++ b/src/ucp/tag/probe.c
@@ -22,7 +22,6 @@ UCS_PROFILE_FUNC(ucp_tag_message_h, ucp_tag_probe_nb,
                  ucp_worker_h worker, ucp_tag_t tag, ucp_tag_t tag_mask,
                  int rem, ucp_tag_recv_info_t *info)
 {
-    ucp_context_h UCS_V_UNUSED context = worker->context;
     ucp_recv_desc_t *rdesc;
     uint16_t flags;
 


### PR DESCRIPTION
## What
 - del copy-pasted `ucp_am_pack_user_header` and move one to common `.inl` file
 - del unused variable