### PR TITLE
UCP/PROTO: error handling

### DIFF
--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -114,6 +114,16 @@ ucp_proto_rdnv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_rdnv_am_init_common(&params);
 }
 
+static void
+ucp_proto_rndv_am_bcopy_abort(ucp_request_t *req, ucs_status_t status)
+{
+    if (req->send.rndv.rkey != NULL) {
+        ucp_proto_rndv_rkey_destroy(req);
+    }
+
+    ucp_proto_request_bcopy_abort(req,status);
+}
+
 ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .name     = "rndv/am/bcopy",
     .desc     = "fragmented " UCP_PROTO_COPY_IN_DESC " " UCP_PROTO_COPY_OUT_DESC,
@@ -121,5 +131,5 @@ ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .init     = ucp_proto_rdnv_am_bcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_rndv_am_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_proto_rndv_am_bcopy_abort
 };

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -93,6 +93,12 @@ ucp_proto_rndv_get_zcopy_fetch_completion(uct_completion_t *uct_comp)
     ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
                                 &req->send.state.dt_iter,
                                 UCS_BIT(UCP_DATATYPE_CONTIG));
+    if (ucs_unlikely(uct_comp->status != UCS_OK)) {
+        ucp_proto_rndv_rkey_destroy(req);
+        ucp_proto_rndv_recv_complete_status(req, uct_comp->status);
+        return;
+    }
+
     ucp_proto_rndv_recv_complete_with_ats(req, UCP_PROTO_RNDV_GET_STAGE_ATS);
 }
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -236,6 +236,15 @@ static void ucp_proto_rndv_rtr_query(const ucp_proto_query_params_t *params,
     attr->is_estimation = 1;
 }
 
+static void ucp_proto_rndv_rtr_abort(ucp_request_t *req, ucs_status_t status)
+{
+    const ucp_proto_rndv_rtr_priv_t *rpriv = req->send.proto_config->priv;
+    ucp_request_t *rreq                    = ucp_request_get_super(req);
+
+    rreq->status = status;
+    rpriv->data_received(req, 0);
+}
+
 ucp_proto_t ucp_rndv_rtr_proto = {
     .name     = "rndv/rtr",
     .desc     = NULL,
@@ -243,7 +252,7 @@ ucp_proto_t ucp_rndv_rtr_proto = {
     .init     = ucp_proto_rndv_rtr_init,
     .query    = ucp_proto_rndv_rtr_query,
     .progress = {ucp_proto_rndv_rtr_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_proto_rndv_rtr_abort
 };
 
 

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -83,7 +83,7 @@ ucp_proto_t ucp_eager_short_proto = {
     .init     = ucp_proto_eager_short_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_short_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_proto_request_bcopy_abort
 };
 
 static size_t ucp_eager_single_pack(void *dest, void *arg)
@@ -220,5 +220,5 @@ ucp_proto_t ucp_eager_zcopy_single_proto = {
     .init     = ucp_proto_eager_zcopy_single_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_zcopy_single_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_proto_request_zcopy_abort
 };


### PR DESCRIPTION
## What
 - add abort for eager short, eager zcopy and rndv rtr protocols
 - fix get zcopy completion

## Why ?
error handling support in proto v2
