### PR TITLE
UCT/IB/DC: Fix managing FC_HARD_REQ resend time [v1.13.x]

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1492,7 +1492,13 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep,
     }
 }
 
-unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
+static void uct_dc_mlx5_ep_fc_hard_req_init_resend(uct_dc_mlx5_iface_t *iface,
+                                                   ucs_time_t now)
+{
+    iface->tx.fc_hard_req_resend_time = now + iface->tx.fc_hard_req_timeout;
+}
+
+static unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
 {
     uct_dc_mlx5_iface_t *iface = arg;
     ucs_time_t now             = ucs_get_time();
@@ -1502,6 +1508,8 @@ unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
     if (ucs_likely(now < iface->tx.fc_hard_req_resend_time)) {
         return 0;
     }
+
+    uct_dc_mlx5_ep_fc_hard_req_init_resend(iface, now);
 
     /* Go over all endpoints that are waiting for FC window being restored and
      * resend FC_HARD_REQ packet to make sure a peer will resend FC_PURE_GRANT
@@ -1565,6 +1573,10 @@ ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface,
         }
 
         goto out;
+    }
+
+    if (iface->tx.fc_hard_req_progress_cb_id == UCS_CALLBACKQ_ID_NULL) {
+        uct_dc_mlx5_ep_fc_hard_req_init_resend(iface, now);
     }
 
     uct_worker_progress_register_safe(


### PR DESCRIPTION
## What

Fix managing `FC_HARD_REQ` resend time.

## Why ?

`iface->tx.fc_hard_req_resend_time` is initialized only, but then never updated. So, it always leads to invoking of `uct_dc_mlx5_ep_fc_hard_req_progress`.

## How ?

Backport of https://github.com/openucx/ucx/pull/8253