### PR TITLE
remove unused code and fix comment typos

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1970,7 +1970,7 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
  *
  * @note
  * @li Higher level protocols can add additional communication isolation, as
- * MPI does with it's communicator object. A single communication context may
+ * MPI does with its communicator object. A single communication context may
  * be used to support multiple MPI communicators.
  * @li The context can be used to isolate the communication that corresponds to
  * different protocols. For example, if MPI and OpenSHMEM are using UCP to

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1350,8 +1350,6 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
             goto out;
         }
 
-        /* If the MD does not have transport resources (device or sockaddr),
-         * don't use it */
         if (num_tl_resources > 0) {
             /* List of memory type MDs */
             mem_type_bitmap = context->tl_mds[md_index].attr.cap.detect_mem_types;
@@ -1372,6 +1370,8 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
 
             ++context->num_mds;
         } else {
+            /* If the MD does not have transport resources (device or sockaddr),
+             * don't use it */
             ucs_debug("closing md %s because it has no selected transport resources",
                       context->tl_mds[md_index].rsc.md_name);
             uct_md_close(context->tl_mds[md_index].md);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -185,7 +185,7 @@ typedef struct ucp_ep_config_key_lane {
 
 /*
  * Endpoint configuration key.
- * This is filled by to the transport selection logic, according to the local
+ * This is filled by the transport selection logic, according to the local
  * resources and set of remote addresses.
  */
 struct ucp_ep_config_key {
@@ -214,7 +214,7 @@ struct ucp_ep_config_key {
     /* Lanes for high-bw active messages, sorted by priority, highest first */
     ucp_lane_index_t         am_bw_lanes[UCP_MAX_LANES];
 
-    /* Local memory domains to send remote keys for in high-bw rma protocols
+    /* Local memory domains to send remote keys used by high-bw rma protocols
      * NOTE: potentially it can be different than what is imposed by rma_bw_lanes,
      * since these are the MDs used by remote side for accessing our memory. */
     ucp_md_map_t             rma_bw_md_map;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1952,7 +1952,7 @@ ucp_worker_ep_config_short_init(ucp_worker_h worker, ucp_ep_config_t *ep_config,
 }
 
 /* All the ucp endpoints will share the configurations. No need for every ep to
- * have it's own configuration (to save memory footprint). Same config can be used
+ * have its own configuration (to save memory footprint). Same config can be used
  * by different eps.
  * A 'key' identifies an entry in the ep_config array. An entry holds the key and
  * additional configuration parameters and thresholds.

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -429,8 +429,6 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
     ucp_context_h context                      = worker->context;
     ucp_wireup_ep_t *cm_wireup_ep              =
             ucp_ep_get_cm_wireup_ep(ep);
-    /* Set to NULL to call ucs_free safely */
-    void *ucp_addr                             = NULL;
     unsigned ep_init_flags;
     unsigned i;
     ucp_tl_bitmap_t tl_bitmap;
@@ -532,7 +530,6 @@ try_fallback:
 err:
     ucp_ep_set_failed(ep, ucp_ep_get_cm_lane(ep), status);
 out:
-    ucs_free(ucp_addr);
     UCS_ASYNC_UNBLOCK(&worker->async);
     return 1;
 }
@@ -623,7 +620,6 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     ucp_unpacked_address_t addr;
     ucp_tl_bitmap_t tl_bitmap;
     ucp_rsc_index_t dev_index;
-    ucp_rsc_index_t UCS_V_UNUSED rsc_index;
     unsigned addr_idx;
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -59,7 +59,7 @@ struct ucp_wireup_ep {
     /**< TLs which are available on client side resolved device */
     ucp_tl_bitmap_t           cm_resolve_tl_bitmap;
     /**< Destination resource indicies used for checking intersection between
-         between two configurations in case of CM */
+         two configurations in case of CM */
     ucp_rsc_index_t           dst_rsc_indices[UCP_MAX_LANES];
 };
 

--- a/src/ucs/datastruct/arbiter.h
+++ b/src/ucs/datastruct/arbiter.h
@@ -22,9 +22,9 @@
  * - "Group"   - queue of work elements which would be dispatched in-order
  *
  * The arbiter contains a double-linked list of the group head elements. The
- * next group head to dispatch is the first entry in the list. Whenever a group
- * is rescheduled it's moved to the tail of the list. At any point a group head
- * can be removed from the "middle" of the list.
+ * next group head to be dispatched is the first entry in the list. Whenever a
+ * group is rescheduled, it's moved to the tail of the list. At any point, a
+ * group head can be removed from the "middle" of the list.
  *
  * The groups and elements are arranged like this:
  *  - every arbitrated element points to the group (head).
@@ -34,9 +34,9 @@
  *    last one points to the first (next).
  *
  * Note:
- *  Every elements holds 4 pointers. It could be done with 3 pointers, so that
+ *  Every element holds 4 pointers. It could be done with 3 pointers, so that
  *  the pointer to the previous group is put instead of "next" pointer in the last
- *  element in the group, when it is put on the arbiter queue. However in makes
+ *  element in the group, when it is put on the arbiter queue. However, it makes
  *  the code much more complicated.
  *
  *

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -88,7 +88,7 @@ ucs_status_t uct_cm_ep_pack_cb(uct_cm_base_ep_t *cep, void *arg,
     *priv_data_ret = ret;
 out:
      return status;
- }
+}
 
 ucs_status_t uct_cm_ep_resolve_cb(uct_cm_base_ep_t *cep,
                                   const uct_cm_ep_resolve_args_t *args)

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -9,8 +9,6 @@
 #endif
 
 #include "dc_mlx5.inl"
-#include "dc_mlx5_ep.h"
-#include "dc_mlx5.h"
 
 #include <uct/ib/mlx5/ib_mlx5_log.h>
 #include <ucs/time/time.h>

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -948,7 +948,7 @@ uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
                       uint8_t *sl_p)
 {
     ucs_status_t status = UCS_OK;
-    const char UCS_V_UNUSED *sl_ar_support_str;
+    const char *sl_ar_support_str;
     uint16_t sl_allow_mask, sls_with_ar, sls_without_ar;
     ucs_string_buffer_t sls_with_ar_str, sls_without_ar_str;
     char sl_str[8];

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -863,7 +863,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
 {
     uct_rc_mlx5_iface_config_t *config = ucs_derived_of(tl_config,
                                                         uct_rc_mlx5_iface_config_t);
-    uct_ib_mlx5_md_t UCS_V_UNUSED *md  = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_md_t *md               = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
     uct_ib_iface_init_attr_t init_attr = {};
     ucs_status_t status;
 
@@ -977,7 +977,7 @@ static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {
     .iface_get_address        = uct_rc_mlx5_iface_get_address,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_rc_mlx5_iface_is_reachable
-    };
+};
 
 static ucs_status_t
 uct_rc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,


### PR DESCRIPTION
## What
- remove some unnecessary code and var attributions.
- fix some typos and refine comments

## Why ?
clean part of code to make it easy to be understood
