### PR TITLE
UCT/IB/DC: Always schedule DCI allocation during FC_HARD_REQ progress

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.inl
+++ b/src/uct/ib/dc/dc_mlx5.inl
@@ -41,7 +41,8 @@ uct_dc_mlx5_get_arbiter_params(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
+uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
+                        int force)
 {
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
         /* no dci:
@@ -49,7 +50,7 @@ uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
          * arbiter. This way we can assure fairness between all eps waiting for
          * dci allocation. Relevant for dcs and dcs_quota policies.
          */
-        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
+        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, force);
     } else {
         uct_dc_mlx5_iface_dci_sched_tx(iface, ep);
     }
@@ -83,5 +84,5 @@ uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
         return;
     }
 
-    uct_dc_mlx5_ep_schedule(iface, ep);
+    uct_dc_mlx5_ep_schedule(iface, ep, 0);
 }

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -377,13 +377,14 @@ static inline int uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
 }
 
 static UCS_F_ALWAYS_INLINE
-void uct_dc_mlx5_iface_schedule_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
+void uct_dc_mlx5_iface_schedule_dci_alloc(uct_dc_mlx5_iface_t *iface,
+                                          uct_dc_mlx5_ep_t *ep, int force)
 {
     ucs_arbiter_t *waitq;
 
-    /* If FC window is empty the group will be scheduled when
-     * grant is received */
-    if (uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
+    /* If FC window is empty and force scheduling wasn't requested, the group
+     * will be scheduled when grant is received */
+    if (force || uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
         waitq = uct_dc_mlx5_iface_dci_waitq(iface, uct_dc_mlx5_ep_pool_index(ep));
         ucs_arbiter_group_schedule(waitq, &ep->arb_group);
     }
@@ -471,7 +472,7 @@ uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
      * move the group to the 'wait for dci alloc' state
      */
     ucs_arbiter_group_desched(uct_dc_mlx5_iface_tx_waitq(iface), &ep->arb_group);
-    uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
+    uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, 0);
 }
 
 static inline void uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)


### PR DESCRIPTION
## What

 Always schedule DCI allocation during FC_HARD_REQ progress.

## Why ?

To fix not sending `FC_HARD_REQ` in case of no DCI is allocated for EP.

## How ?

1. Update `uct_dc_mlx5_ep_schedule` and `uct_dc_mlx5_iface_schedule_dci_alloc` to accept `force` parameter.
2. If `force` specified in `uct_dc_mlx5_iface_schedule_dci_alloc`, schedule EP on DCI wait queue.
3. Pass `force=1` to `uct_dc_mlx5_ep_schedule` in `uct_dc_mlx5_ep_fc_hard_req_progress`.