### PR TITLE
UCT/IFACE - Bug fix, Wrong setting of post recv desc size and UD seg_size

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -261,7 +261,7 @@ ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
     }
 
     return uct_iface_mpool_init(&iface->super, mp,
-                                iface->config.rx_payload_offset +
+                                iface->config.rx_hdr_offset +
                                         iface->config.seg_size,
                                 align_offset, alignment, &config->rx.mp, grow,
                                 uct_ib_iface_recv_desc_init, name);
@@ -1423,7 +1423,7 @@ int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
     while (count < n) {
         UCT_TL_IFACE_GET_RX_DESC(&iface->super, mp, desc, break);
         wrs[count].sg.addr   = (uintptr_t)uct_ib_iface_recv_desc_hdr(iface, desc);
-        wrs[count].sg.length = iface->config.rx_payload_offset + iface->config.seg_size;
+        wrs[count].sg.length = iface->config.seg_size;
         wrs[count].sg.lkey   = desc->lkey;
         wrs[count].ibwr.num_sge = 1;
         wrs[count].ibwr.wr_id   = (uintptr_t)desc;

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -886,8 +886,8 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
 
     /* write buffer sizes */
     for (i = 0; i <= self->rx.wq.mask; i++) {
-        self->rx.wq.wqes[i].byte_count = htonl(self->super.super.config.rx_payload_offset +
-                                               self->super.super.config.seg_size);
+        self->rx.wq.wqes[i].byte_count = 
+                htonl(self->super.super.config.seg_size);
     }
 
     while (self->super.rx.available >= self->super.super.config.rx_max_batch) {

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -122,6 +122,9 @@ typedef struct uct_ud_neth {
 } UCS_S_PACKED uct_ud_neth_t;
 
 
+#define UCT_UD_RX_HDR_LEN (UCT_IB_GRH_LEN + sizeof(uct_ud_neth_t))
+
+
 enum {
     UCT_UD_SEND_SKB_FLAG_ACK_REQ    = UCS_BIT(0), /* ACK was requested for this skb */
     UCT_UD_SEND_SKB_FLAG_COMP       = UCS_BIT(1), /* This skb contains a completion */

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -476,8 +476,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
 
     init_attr->rx_priv_len = sizeof(uct_ud_recv_skb_t) -
                              sizeof(uct_ib_iface_recv_desc_t);
-    init_attr->rx_hdr_len  = UCT_IB_GRH_LEN + sizeof(uct_ud_neth_t);
-    init_attr->seg_size    = ucs_min(mtu, config->super.seg_size);
+    init_attr->rx_hdr_len  = UCT_UD_RX_HDR_LEN;
+    init_attr->seg_size    = ucs_min(mtu, config->super.seg_size) + UCT_IB_GRH_LEN;
     init_attr->qp_type     = IBV_QPT_UD;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, tl_ops, &ops->super, md, worker,
@@ -739,9 +739,9 @@ ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
 
     iface_attr->cap.am.max_short       = uct_ib_iface_hdr_size(iface->config.max_inline,
                                                                sizeof(uct_ud_neth_t));
-    iface_attr->cap.am.max_bcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_bcopy       = iface->super.config.seg_size - UCT_UD_RX_HDR_LEN;
     iface_attr->cap.am.min_zcopy       = 0;
-    iface_attr->cap.am.max_zcopy       = iface->super.config.seg_size - sizeof(uct_ud_neth_t);
+    iface_attr->cap.am.max_zcopy       = iface->super.config.seg_size - UCT_UD_RX_HDR_LEN;
     iface_attr->cap.am.align_mtu       = uct_ib_mtu_value(uct_ib_iface_port_attr(&iface->super)->active_mtu);
     iface_attr->cap.am.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
     iface_attr->cap.am.max_iov         = am_max_iov;


### PR DESCRIPTION
## What
Fix bug - Wrong size of UD post receive buffers.
Fix inconsistency - seg_size should define the size of post recv buffers according to the description
Fix initialization of RX mpool elements size - can lead to confusion/memory waste in some transports (RC/DC).

## Why ?
Posting buffers with wrong size can cause unexpected behavior, buffer overrun when message is too big instead of "Not enough space" error code from HW
Fix UD seg size - Not meets seg_size definition, this creates a inconsistency in the meaning of seg_size between different transports.
Fix initialization of RX mpool elements size - Wrong element size can lead to confusion and a waste of memory.

## How ?
1. Make sure preparation of rx wqe's is done properly, with the right size.
2. Change UD seg_size to meet seg_size definition.
3. Change RX mpool element size accordingly.