### PR TITLE
UCT/CUDA: use right driver macro to log errors with drv fxns

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -117,7 +117,7 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src,
 
     /* ensure context is set before creating events/streams */
     if (iface->cuda_context == NULL) {
-        UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&iface->cuda_context));
+        UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&iface->cuda_context));
         if (iface->cuda_context == NULL) {
             ucs_error("attempt to perform cuda memcpy without active context");
             return UCS_ERR_IO_ERROR;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -310,7 +310,7 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
                                                         cuda_event_desc);
     CUcontext cuda_context;
 
-    UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
+    UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
     if (uct_cuda_base_context_match(cuda_context, iface->cuda_context)) {
         UCT_CUDA_FUNC_LOG_ERR(cudaEventDestroy(base->event));
     }
@@ -451,7 +451,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
 
-    UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
+    UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
     if (uct_cuda_base_context_match(cuda_context, self->cuda_context)) {
 
         for (src = 0; src < UCS_MEMORY_TYPE_LAST; ++src) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -75,7 +75,7 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
 
     /* ensure context is set before creating events/streams */
     if (iface->cuda_context == NULL) {
-        UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&iface->cuda_context));
+        UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&iface->cuda_context));
         if (iface->cuda_context == NULL) {
             ucs_error("attempt to perform cuda memcpy without active context");
             return UCS_ERR_IO_ERROR;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -442,7 +442,7 @@ static void uct_cuda_ipc_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
                                                        event_desc);
     CUcontext cuda_context;
 
-    UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
+    UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
     if (uct_cuda_base_context_match(cuda_context, iface->cuda_context)) {
         UCT_CUDA_FUNC_LOG_ERR(cudaEventDestroy(base->event));
     }
@@ -528,7 +528,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_iface_t)
     int i;
     CUcontext cuda_context;
 
-    UCT_CUDA_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
+    UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
 
     if (self->streams_initialized &&
         uct_cuda_base_context_match(cuda_context, self->cuda_context)) {


### PR DESCRIPTION
## Why ?
Fix issues reported by clang and cuda 11.7 reported here https://github.com/openucx/ucx/issues/8278
