### PR TITLE
UCT/IB/DEVX: Using UCX CQ structure during DEVX calls

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -17,20 +17,18 @@
 
 ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
 {
-    uct_ib_device_t *dev  = uct_ib_iface_device(&iface->super.super.super);
-    struct mlx5dv_pd dvpd = {};
-    struct mlx5dv_cq dvcq = {};
-    struct mlx5dv_obj dv  = {};
+    uct_ib_device_t *dev        = uct_ib_iface_device(&iface->super.super.super);
+    const uct_ib_mlx5_cq_t *cq  = &iface->super.cq[UCT_IB_DIR_RX];
+    struct mlx5dv_pd dvpd       = {};
+    struct mlx5dv_obj dv        = {};
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_dct_in)]   = {};
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_dct_out)] = {};
     int dvflags;
     void *dctc;
 
-    dvflags   = MLX5DV_OBJ_PD | MLX5DV_OBJ_CQ;
+    dvflags   = MLX5DV_OBJ_PD;
     dv.pd.in  = uct_ib_iface_md(&iface->super.super.super)->pd;
     dv.pd.out = &dvpd;
-    dv.cq.in  = iface->super.super.super.cq[UCT_IB_DIR_RX];
-    dv.cq.out = &dvcq;
     mlx5dv_init_obj(&dv, dvflags);
 
     UCT_IB_MLX5DV_SET(create_dct_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_DCT);
@@ -41,7 +39,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
     if (UCT_RC_MLX5_TM_ENABLED(&iface->super)) {
         UCT_IB_MLX5DV_SET(dctc, dctc, offload_type, UCT_IB_MLX5_QPC_OFFLOAD_TYPE_RNDV);
     }
-    UCT_IB_MLX5DV_SET(dctc, dctc, cqn, dvcq.cqn);
+    UCT_IB_MLX5DV_SET(dctc, dctc, cqn, cq->cq_num);
     UCT_IB_MLX5DV_SET64(dctc, dctc, dc_access_key, UCT_IB_KEY);
 
     UCT_IB_MLX5DV_SET(dctc, dctc, rre, true);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -593,7 +593,7 @@ uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                       const uct_ib_mlx5_iface_config_t *mlx5_config,
                       const uct_ib_iface_config_t *ib_config,
                       const uct_ib_iface_init_attr_t *init_attr,
-                      int preferred_cpu, size_t inl);
+                      uct_ib_mlx5_cq_t *mlx5_cq, int preferred_cpu, size_t inl);
 
 extern ucs_config_field_t uct_ib_mlx5_iface_config_table[];
 
@@ -719,6 +719,8 @@ void uct_ib_mlx5_txwq_validate_always(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb,
 #if HAVE_DEVX
 
 ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
+                                        const uct_ib_mlx5_cq_t *send_cq,
+                                        const uct_ib_mlx5_cq_t *recv_cq,
                                         uct_ib_mlx5_qp_t *qp,
                                         uct_ib_mlx5_txwq_t *tx,
                                         uct_ib_mlx5_qp_attr_t *attr);
@@ -833,6 +835,8 @@ uct_ib_mlx5_md_buf_free(uct_ib_mlx5_md_t *md, void *buf, uct_ib_mlx5_devx_umem_t
 
 static inline ucs_status_t
 uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
+                           const uct_ib_mlx5_cq_t *send_cq,
+                           const uct_ib_mlx5_cq_t *recv_cq,
                            uct_ib_mlx5_qp_t *qp,
                            uct_ib_mlx5_txwq_t *tx,
                            uct_ib_mlx5_qp_attr_t *attr)

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -287,6 +287,8 @@ uct_rc_mlx5_devx_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     attr.super.port             = dev->first_port;
     attr.mmio_mode              = iface->tx.mmio_mode;
     status = uct_ib_mlx5_devx_create_qp(&iface->super.super,
+                                        &iface->cq[UCT_IB_DIR_RX],
+                                        &iface->cq[UCT_IB_DIR_RX],
                                         &iface->tm.cmd_wq.super.super,
                                         &iface->tm.cmd_wq.super,
                                         &attr);

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -218,7 +218,6 @@ uct_rc_mlx5_devx_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
                                            uct_ib_mlx5_md_t);
     uct_ib_device_t *dev  = &md->super.dev;
     struct mlx5dv_pd dvpd = {};
-    struct mlx5dv_cq dvcq = {};
     struct mlx5dv_obj dv  = {};
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_xrq_in)]   = {};
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_xrq_out)] = {};
@@ -228,10 +227,8 @@ uct_rc_mlx5_devx_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     uct_rc_mlx5_init_rx_tm_common(iface, config, rndv_hdr_len);
 
     dv.pd.in  = uct_ib_iface_md(&iface->super.super)->pd;
-    dv.cq.in  = iface->super.super.cq[UCT_IB_DIR_RX];
     dv.pd.out = &dvpd;
-    dv.cq.out = &dvcq;
-    mlx5dv_init_obj(&dv, MLX5DV_OBJ_PD | MLX5DV_OBJ_CQ);
+    mlx5dv_init_obj(&dv, MLX5DV_OBJ_PD);
 
     UCT_IB_MLX5DV_SET(create_xrq_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_XRQ);
     xrqc = UCT_IB_MLX5DV_ADDR_OF(create_xrq_in, in, xrq_context);
@@ -241,7 +238,7 @@ uct_rc_mlx5_devx_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     UCT_IB_MLX5DV_SET(xrqc, xrqc, tag_matching_topology_context.log_matching_list_sz,
                                   ucs_ilog2(iface->tm.num_tags) + 1);
     UCT_IB_MLX5DV_SET(xrqc, xrqc, dc,       dc);
-    UCT_IB_MLX5DV_SET(xrqc, xrqc, cqn,      dvcq.cqn);
+    UCT_IB_MLX5DV_SET(xrqc, xrqc, cqn,      iface->cq[UCT_IB_DIR_RX].cq_num);
 
     status = uct_rc_mlx5_devx_init_rx_common(iface, md, config, &dvpd,
                                              UCT_IB_MLX5DV_ADDR_OF(xrqc, xrqc, wq));

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -669,16 +669,19 @@ uct_ud_mlx5_iface_peer_address_str(const uct_ud_iface_t *iface,
 }
 
 static ucs_status_t
-uct_ud_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
+uct_ud_mlx5_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
                       const uct_ib_iface_config_t *ib_config,
                       const uct_ib_iface_init_attr_t *init_attr,
                       int preferred_cpu, size_t inl)
 {
     uct_ud_mlx5_iface_config_t *ud_mlx5_config =
             ucs_derived_of(ib_config, uct_ud_mlx5_iface_config_t);
+    uct_ud_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_ud_mlx5_iface_t);
+    uct_ib_mlx5_cq_t *uct_cq   = &iface->cq[dir];
 
-    return uct_ib_mlx5_create_cq(iface, dir, &ud_mlx5_config->mlx5_common,
-                                 ib_config, init_attr, preferred_cpu, inl);
+    return uct_ib_mlx5_create_cq(ib_iface, dir, &ud_mlx5_config->mlx5_common,
+                                 ib_config, init_attr, uct_cq, preferred_cpu,
+                                 inl);
 }
 
 static ucs_status_t uct_ud_mlx5_iface_arm_cq(uct_ib_iface_t *ib_iface,
@@ -852,16 +855,6 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t,
     status = uct_ib_mlx5_iface_select_sl(&self->super.super,
                                          &config->mlx5_common,
                                          &config->super.super);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = uct_ib_mlx5_get_cq(self->super.super.cq[UCT_IB_DIR_TX], &self->cq[UCT_IB_DIR_TX]);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = uct_ib_mlx5_get_cq(self->super.super.cq[UCT_IB_DIR_RX], &self->cq[UCT_IB_DIR_RX]);
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
## What
Getting all required CQ related information during DEVX calls from the UCX structure (instead of IBV strucuture).

## Why ?
It's a part of bigger https://github.com/openucx/ucx/pull/8257 PR that adds ability to create CQ using DEVX. This patch is too big to be merged in one PR so it's one of the parts.

If CQ created using DEVX then there is no IBV CQ at all, so all information about CQs should be discovered from the common `uct_ib_mlx5_cq_t` entity.

## How? 

- Move `uct_ib_mlx5_get_cq` right after the CQ creation (inside `create_cq` function pointer) to make all CQ related info accessible earlier. It is required at least for XRQ creation via DEVX.
- Pass UCT CQ structures to all related APIs and get all required information from them.