### PR TITLE
UCT/IB/DEVX: Wrap missed DEVX obj destroy calls to UCX calls

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -594,7 +594,7 @@ void uct_dc_mlx5_destroy_dct(uct_dc_mlx5_iface_t *iface)
         break;
     case UCT_IB_MLX5_OBJ_TYPE_DEVX:
 #if HAVE_DEVX
-        mlx5dv_devx_obj_destroy(iface->rx.dct.devx.obj);
+        uct_ib_mlx5_devx_obj_destroy(iface->rx.dct.devx.obj, "DCT");
 #endif
         break;
     case UCT_IB_MLX5_OBJ_TYPE_LAST:

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -206,7 +206,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
     return UCS_OK;
 
 err_free:
-    mlx5dv_devx_obj_destroy(qp->devx.obj);
+    uct_ib_mlx5_devx_obj_destroy(qp->devx.obj, "QP");
 err_free_db:
     uct_ib_mlx5_put_dbrec(qp->devx.dbrec);
 err_free_mem:


### PR DESCRIPTION
## What

## Why ?
Some time ago all DEVX create/destroy/modify/general_cmd calls were already wrapped. But two destroy calls were missed for some reason. This patch fixes that.

P.S. Also if someone adds more `devx_obj_destroy` calls then coverity start fails with message that in these places return code of `devx_obj_destroy` isn't checked.
