### PR TITLE
UCT/IB/MLX5: Add access mode argument to md buf allocation

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -85,7 +85,7 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
 
     if (tx != NULL) {
         status = uct_ib_mlx5_md_buf_alloc(md, len, 0, &qp->devx.wq_buf,
-                                          &qp->devx.mem, "qp umem");
+                                          &qp->devx.mem, 0, "qp umem");
         if (status != UCS_OK) {
             goto err_uar;
         }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -649,7 +649,8 @@ static ucs_status_t uct_ib_mlx5_add_page(ucs_mpool_t *mp, size_t *size_p, void *
     uct_ib_mlx5_devx_umem_t mem;
     ucs_status_t status;
 
-    status = uct_ib_mlx5_md_buf_alloc(md, size, 1, (void **)&page, &mem, "devx dbrec");
+    status = uct_ib_mlx5_md_buf_alloc(md, size, 1, (void**)&page, &mem, 0,
+                                      "devx dbrec");
     if (status != UCS_OK) {
         return status;
     }
@@ -1055,7 +1056,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     }
 
     status = uct_ib_mlx5_md_buf_alloc(md, ucs_get_page_size(), 0, &md->zero_buf,
-                                      &md->zero_mem, "zero umem");
+                                      &md->zero_mem, 0, "zero umem");
     if (status != UCS_OK) {
         goto err_release_dbrec;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -766,7 +766,7 @@ uct_ib_mlx5_devx_query_qp_peer_info(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp,
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
                          void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
-                         char *name)
+                         int access_mode, char *name)
 {
     ucs_log_level_t level = silent ? UCS_LOG_LEVEL_DEBUG : UCS_LOG_LEVEL_ERROR;
     ucs_status_t status;
@@ -789,7 +789,8 @@ uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
     }
 
     mem->size = size;
-    mem->mem  = mlx5dv_devx_umem_reg(md->super.dev.ibv_context, buf, size, 0);
+    mem->mem  = mlx5dv_devx_umem_reg(md->super.dev.ibv_context, buf, size,
+                                     access_mode);
     if (mem->mem == NULL) {
         ucs_log(level, "mlx5dv_devx_umem_reg() failed: %m");
         status = UCS_ERR_NO_MEMORY;

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -154,7 +154,7 @@ uct_rc_mlx5_devx_init_rx_common(uct_rc_mlx5_iface_common_t *iface,
     len    = max * stride;
 
     status = uct_ib_mlx5_md_buf_alloc(md, len, 0, &iface->rx.srq.buf,
-                                      &iface->rx.srq.devx.mem, "srq buf");
+                                      &iface->rx.srq.devx.mem, 0, "srq buf");
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
## What

## Why ?
It's a part of bigger https://github.com/openucx/ucx/pull/8257 PR that adds ability to create CQ using DEVX. This patch is too big to be merged in one PR so it's one of the parts.

Creation CQ via DEVX requires passing non zero access mode to buffer allocation. This patch prepares `uct_ib_mlx5_md_buf_alloc` interface for the further using in CQ DEVX creation.