### PR TITLE
OFI uct transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ test/apps/profiling/ucx_profiling
 test/apps/uct_info/uct_info
 test/apps/uct_info/uct_info_static
 cmake/*.cmake
+*~
+\#*\#
+.\#*

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -7,7 +7,7 @@
 # See file LICENSE for terms.
 #
 
-SUBDIRS = . cuda ib rocm sm ugni
+SUBDIRS = . cuda ib rocm sm ugni ofi
 
 lib_LTLIBRARIES    = libuct.la
 libuct_la_CFLAGS   = $(BASE_CFLAGS)

--- a/src/uct/configure.m4
+++ b/src/uct/configure.m4
@@ -9,6 +9,7 @@ m4_include([src/uct/ib/configure.m4])
 m4_include([src/uct/rocm/configure.m4])
 m4_include([src/uct/sm/configure.m4])
 m4_include([src/uct/ugni/configure.m4])
+m4_include([src/uct/ofi/configure.m4])
 
 AC_DEFINE_UNQUOTED([uct_MODULES], ["${uct_modules}"], [UCT loadable modules])
 

--- a/src/uct/ofi/Makefile.am
+++ b/src/uct/ofi/Makefile.am
@@ -1,0 +1,34 @@
+#
+# Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+if HAVE_OFI
+
+module_LTLIBRARIES      = libuct_ofi.la
+libuct_ofi_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libuct_ofi_la_CFLAGS   = $(BASE_CFLAGS) -I/opt/cray/libfabric/1.11.0.4.75/include/
+libuct_ofi_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
+                          $(top_builddir)/src/uct/libuct.la
+libuct_ofi_la_LDFLAGS  = -L/opt/cray/libfabric/1.11.0.4.75/lib64/ -lfabric -version-info $(SOVERSION)
+
+noinst_HEADERS = \
+	base/ofi_def.h \
+	base/ofi_types.h \
+	base/ofi_md.h \
+	base/ofi_device.h \
+	base/ofi_iface.h \
+	base/ofi_ep.h
+
+libuct_ofi_la_SOURCES = \
+	base/ofi_md.c \
+	base/ofi_device.c \
+	base/ofi_iface.c \
+	base/ofi_ep.c
+
+PKG_CONFIG_NAME=ofi
+
+include $(top_srcdir)/config/module.am
+include $(top_srcdir)/config/module-pkg-config.am
+
+endif

--- a/src/uct/ofi/Makefile.am
+++ b/src/uct/ofi/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+# Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 

--- a/src/uct/ofi/base/ofi_def.h
+++ b/src/uct/ofi/base/ofi_def.h
@@ -1,3 +1,8 @@
+/**
+* Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+
 #ifndef UCT_OFI_DEF_H
 #define UCT_OFI_DEF_H
 

--- a/src/uct/ofi/base/ofi_def.h
+++ b/src/uct/ofi/base/ofi_def.h
@@ -1,0 +1,13 @@
+#ifndef UCT_OFI_DEF_H
+#define UCT_OFI_DEF_H
+
+#define UCT_OFI_MD_NAME "ofi"
+#define UCT_OFI_EPS_PER_AV 256
+
+#define UCT_OFI_CHECK_ERROR(_x, _error_str, _ret) do { \
+        if (_x) {                                      \
+            ucs_error("UCT OFI error: '%s' ofi error: '%s'", _error_str, fi_strerror(_x)); \
+            return (_ret);}                           \
+ } while(0)
+
+#endif

--- a/src/uct/ofi/base/ofi_device.c
+++ b/src/uct/ofi/base/ofi_device.c
@@ -1,0 +1,210 @@
+#include <ucs/sys/sys.h>
+#include <ucs/sys/string.h>
+#include <ucs/debug/log.h>
+#include <pthread.h>
+#include "ofi_device.h"
+static struct fi_info *all = NULL;
+static struct fi_info **nics = NULL;
+static int num_nics = -1;
+
+/* Info lock to keep mutliple threads from populating the above info all at once */
+pthread_mutex_t info_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static ucs_status_t uct_ofi_populate_all()
+{
+    struct fi_info hints = {0};
+    ucs_status_t ret;
+
+    ucs_debug("Populating fi_info structs");
+    /* TODO: Maybe FI_FENCE? */
+    hints.caps = FI_RMA | FI_ATOMIC | FI_TAGGED;
+    hints.addr_format = FI_FORMAT_UNSPEC;
+
+    ret = fi_getinfo(fi_version(), NULL, NULL, 0, &hints, &all);
+    if( ret != 0 || !all) {
+        ucs_debug("OFI No device was found");
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t uct_ofi_populate_nics()
+{
+    ucs_status_t ret = UCS_OK;
+    struct fi_info *unique[256];
+    int idx = 0, jdx;
+    struct fi_info *cur;
+    int dup;
+
+    pthread_mutex_lock(&info_lock);
+
+    if (num_nics != -1) {
+        goto err_out;
+    }
+    
+    if (!all) {
+        ret = uct_ofi_populate_all();
+        if (ret != UCS_OK) {
+            goto err_out;
+        }
+    }
+    cur = all;
+    ucs_debug("populating nic data structs");
+
+    memset(unique, 0, sizeof(struct fi_info*)*256);
+    ucs_debug("Starting with fabric %s", cur->domain_attr->name);
+
+    /* Assume fabrics without a nic structure are unintersting */
+    while (!cur->nic) {
+        ucs_trace("Fabric %s rejected, nic=NULL", cur->domain_attr->name);
+        if (!cur->next) {
+            ucs_debug("No nic structs found");
+            /* reached the end of the list with no nics */
+            /* TODO: Maybe instead stop at random TCP/IP address or lo? */
+            num_nics = 0;
+            ret = UCS_ERR_NO_DEVICE;
+            goto err_out;
+        }
+        cur = cur->next;
+    }
+
+    unique[0] = fi_dupinfo(cur);
+    cur = cur->next;
+    while (cur) {
+        for( jdx = 0, dup=0; jdx <= idx; jdx++) {
+            if ( !strcmp(cur->domain_attr->name, unique[jdx]->domain_attr->name) ) {
+                ucs_trace("OFI device search, rejecting duplicate %s", cur->domain_attr->name);
+                dup = 1;
+            }
+        }
+        if( dup ) {
+            cur = cur->next;
+            continue;
+        }
+        ucs_trace("Found new name '%s'", cur->domain_attr->name);
+        idx++;
+        unique[idx] = fi_dupinfo(cur);
+        cur = cur->next;
+        while (cur && !cur->nic) {
+            cur = cur->next;
+        }
+    }
+
+    num_nics = idx;
+    nics = ucs_calloc(idx, sizeof(struct fi_info**), "ofi info pointers");
+    memcpy(nics, unique, sizeof(struct fi_info**)*idx);
+    ucs_debug("Found %i ofi nics", idx);
+err_out:
+    pthread_mutex_unlock(&info_lock);
+    return ret;
+}
+
+
+ucs_status_t uct_ofi_destroy_fabric(uct_ofi_md_t *md)
+{
+    int ret;
+
+    ret = fi_close(&md->dom_ctx->fid);
+    UCT_OFI_CHECK_ERROR(ret, "Closing domain fid", UCS_ERR_INVALID_PARAM);
+
+    ret = fi_close(&md->fab_ctx->fid);
+    UCT_OFI_CHECK_ERROR(ret, "Closing frabric fid", UCS_ERR_INVALID_PARAM);
+
+    fi_freeinfo(all);
+
+    return UCS_OK;
+}
+
+/* TODO: more flexible in capabilities */
+ucs_status_t uct_ofi_init_fabric(uct_ofi_md_t *md, char *fabric_name)
+{
+    int ret = 1;
+
+    ucs_trace("Init fabric");
+
+    if (uct_ofi_populate_nics() != UCS_OK){
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    /* TODO: Make this work so fabrics can be selected by name */
+    if( fabric_name ) {
+        ucs_error("Selecting dev by name not yet supported");
+        return UCS_ERR_NO_DEVICE;
+    } else {
+        md->fab_info = fi_dupinfo(all);
+    }
+
+    /* TODO: version missmatch check here */
+    /* Third param is a context for async ops. Could be useful */
+    /* TODO: is fab_info needed after this? */
+    ret = fi_fabric(md->fab_info->fabric_attr, &md->fab_ctx, NULL);
+    UCT_OFI_CHECK_ERROR(ret, "No fabric found", UCS_ERR_NO_DEVICE);
+
+    /* this should be an iface */
+    /* or maybe not? */
+    ret = fi_domain(md->fab_ctx, md->fab_info, &md->dom_ctx, NULL);
+    UCT_OFI_CHECK_ERROR(ret, "Could not make domain", UCS_ERR_NO_DEVICE);
+    ucs_debug("Using fabric named: %s", md->fab_info->fabric_attr->name);
+    return UCS_OK;
+}
+
+static ucs_sys_device_t populate_sys_device(struct fi_info *info)
+{
+    ucs_sys_device_t sys_dev;
+    ucs_sys_bus_id_t bus_id;
+    ucs_status_t status;
+
+    if(!info->nic) {
+        return UCS_SYS_DEVICE_ID_UNKNOWN;
+    }
+
+    bus_id.domain   = info->nic->bus_attr->attr.pci.domain_id;
+    bus_id.bus      = info->nic->bus_attr->attr.pci.bus_id;
+    bus_id.slot     = info->nic->bus_attr->attr.pci.device_id;
+    bus_id.function = info->nic->bus_attr->attr.pci.function_id;
+
+    status = ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev);
+    if (status != UCS_OK) {
+        return UCS_SYS_DEVICE_ID_UNKNOWN;
+    }
+    return sys_dev;
+}
+
+static void fill_ofi_info(uct_tl_device_resource_t *tl_device,
+                          struct fi_info *info)
+{
+    ucs_snprintf_zero(tl_device->name, sizeof(tl_device->name), "%s",
+                      info->domain_attr->name);
+    tl_device->type       = UCT_DEVICE_TYPE_NET;
+    tl_device->sys_device = populate_sys_device(info);
+    ucs_trace("Filled device %s with sys_device %hhx", tl_device->name, tl_device->sys_device);
+}
+
+ucs_status_t uct_ofi_query_devices(uct_md_h tl_md,
+                                   uct_tl_device_resource_t **tl_devices_p,
+                                   unsigned *num_tl_devices_p)
+{
+    uct_tl_device_resource_t *resources;
+    int i;
+    ucs_status_t status = UCS_OK;
+
+    ucs_debug("Querying OFI devices");
+    status = uct_ofi_populate_nics();
+    resources = ucs_calloc(num_nics, sizeof(uct_tl_device_resource_t),
+                           "ofi uct_tl_device_resource_t");
+    for (i=0; i < num_nics; i++) {
+        fill_ofi_info(&resources[i], nics[i]);
+    }
+
+ error:
+    *num_tl_devices_p = num_nics;
+    *tl_devices_p     = resources;
+
+    return status;
+}
+
+ucs_status_t uct_ofi_iface_get_dev_address(uct_iface_t *tl_iface, uct_device_addr_t *addr)
+{
+    return UCS_ERR_UNSUPPORTED;
+}

--- a/src/uct/ofi/base/ofi_device.c
+++ b/src/uct/ofi/base/ofi_device.c
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS RESERVED.
+ */
+
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 #include <ucs/debug/log.h>

--- a/src/uct/ofi/base/ofi_device.h
+++ b/src/uct/ofi/base/ofi_device.h
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #ifndef UCT_OFI_DEV_H
 #define UCT_OFI_DEV_H
 #include <ucs/type/status.h>

--- a/src/uct/ofi/base/ofi_device.h
+++ b/src/uct/ofi/base/ofi_device.h
@@ -1,0 +1,14 @@
+#ifndef UCT_OFI_DEV_H
+#define UCT_OFI_DEV_H
+#include <ucs/type/status.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include "ofi_types.h"
+
+ucs_status_t uct_ofi_init_fabric(uct_ofi_md_t*, char*);
+ucs_status_t uct_ofi_query_devices(uct_md_h tl_md,
+                                   uct_tl_device_resource_t **tl_devices_p,
+                                   unsigned *num_tl_devices_p);
+
+ucs_status_t uct_ofi_iface_get_dev_address(uct_iface_t *tl_iface, uct_device_addr_t *addr);
+#endif

--- a/src/uct/ofi/base/ofi_ep.c
+++ b/src/uct/ofi/base/ofi_ep.c
@@ -1,0 +1,99 @@
+#include "ofi_iface.h"
+#include "ofi_ep.h"
+
+static uint64_t uct_ofi_gen_id()
+{
+    return ucs_generate_uuid(0);
+}
+
+UCS_CLASS_INIT_FUNC(uct_ofi_ep_t, const uct_ep_params_t *params)
+{
+    uct_ofi_iface_t *iface;
+    uct_ofi_name_t *address;
+    int ret;
+
+    UCT_EP_PARAMS_CHECK_DEV_IFACE_ADDRS(params);
+
+    iface = ucs_derived_of(params->iface, uct_ofi_iface_t);
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+    address = (uct_ofi_name_t *)params->iface_addr;
+    self->id = uct_ofi_gen_id();
+    self->av_index = uct_ofi_get_next_av(iface->av);
+
+    ret = fi_av_insert(iface->av->av, address, 1, &iface->av->table[self->av_index], 0, NULL);
+    if (ret) {
+        ucs_debug("Created OFI EP, id=%lu", self->id);
+        return UCS_OK;
+    } else {
+        ucs_error("Failed to create OFI EP");
+        return UCS_ERR_NO_DEVICE;
+    }
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_ofi_ep_t)
+{
+    uct_ofi_iface_t *iface =  ucs_derived_of(self->super.super.iface, uct_ofi_iface_t);
+    int status;
+
+    status = fi_av_remove(iface->av->av, &iface->av->table[self->av_index], 1, 0);
+    if (status) {
+        ucs_error("OFI: fi_av_remove() failed: %s", fi_strerror(status));
+    }
+}
+
+UCS_CLASS_DEFINE(uct_ofi_ep_t, uct_base_ep_t);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ofi_ep_t, uct_ep_t, const uct_ep_params_t *);
+UCS_CLASS_DEFINE_DELETE_FUNC(uct_ofi_ep_t, uct_ep_t);
+
+ucs_status_t uct_ofi_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
+{
+    ucs_debug("Getting OFI 'EP' address");
+    /* The underlying fi_getname() function exposes the same name for both */
+    return uct_ofi_iface_get_address(tl_ep->iface, (uct_iface_addr_t*)addr);
+}
+
+ucs_status_t uct_ofi_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
+                                       const void *payload, unsigned length)
+{
+    return UCS_ERR_NO_MEMORY;
+}
+
+ssize_t uct_ofi_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
+                                  uct_pack_callback_t pack_cb,
+                                  void *arg, unsigned flags)
+{
+    return 0;
+}
+
+ucs_status_t uct_ofi_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
+                                     unsigned flags)
+{
+    return UCS_ERR_NO_MEMORY;
+}
+
+void uct_ofi_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
+                               void *arg)
+{
+}
+
+ucs_arbiter_cb_result_t uct_ofi_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                    ucs_arbiter_group_t *group,
+                                                    ucs_arbiter_elem_t *elem,
+                                                    void *arg)
+{
+    return UCS_ARBITER_CB_RESULT_STOP;
+}
+
+ucs_arbiter_cb_result_t uct_ofi_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
+                                                     ucs_arbiter_group_t *group,
+                                                     ucs_arbiter_elem_t *elem,
+                                                     void *arg)
+{
+    return UCS_ARBITER_CB_RESULT_STOP;
+}
+
+ucs_status_t uct_ofi_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                               uct_completion_t *comp)
+{
+    return UCS_ERR_NO_MEMORY;
+}

--- a/src/uct/ofi/base/ofi_ep.c
+++ b/src/uct/ofi/base/ofi_ep.c
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #include "ofi_iface.h"
 #include "ofi_ep.h"
 

--- a/src/uct/ofi/base/ofi_ep.h
+++ b/src/uct/ofi/base/ofi_ep.h
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #ifndef UCT_OFI_EP_H
 #define UCT_OFI_EP_H
 

--- a/src/uct/ofi/base/ofi_ep.h
+++ b/src/uct/ofi/base/ofi_ep.h
@@ -1,0 +1,35 @@
+#ifndef UCT_OFI_EP_H
+#define UCT_OFI_EP_H
+
+#include "ofi_types.h"
+#include "ofi_ep.h"
+#include <uct/api/uct.h>
+#include <uct/base/uct_iface.h>
+#include <ucs/type/class.h>
+
+UCS_CLASS_DECLARE_NEW_FUNC(uct_ofi_ep_t, uct_ep_t, const uct_ep_params_t *);
+UCS_CLASS_DECLARE_DELETE_FUNC(uct_ofi_ep_t, uct_ep_t);
+
+ucs_status_t uct_ofi_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
+                                       const void *payload, unsigned length);
+ssize_t uct_ofi_am_bcopy(uct_ep_h tl_ep, uint8_t id,
+                                  uct_pack_callback_t pack_cb, void *arg,
+                                  unsigned flags);
+ucs_status_t uct_ofi_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
+
+ucs_status_t uct_ofi_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
+                                     unsigned flags);
+void uct_ofi_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t cb,
+                               void *arg);
+ucs_arbiter_cb_result_t uct_ofi_ep_process_pending(ucs_arbiter_t *arbiter,
+                                                    ucs_arbiter_group_t *group,
+                                                    ucs_arbiter_elem_t *elem,
+                                                    void *arg);
+ucs_arbiter_cb_result_t uct_ofi_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter,
+                                                     ucs_arbiter_group_t *group,
+                                                     ucs_arbiter_elem_t *elem,
+                                                     void *arg);
+ucs_status_t uct_ofi_ep_flush(uct_ep_h tl_ep, unsigned flags,
+                               uct_completion_t *comp);
+
+#endif

--- a/src/uct/ofi/base/ofi_iface.c
+++ b/src/uct/ofi/base/ofi_iface.c
@@ -1,0 +1,358 @@
+#include <rdma/fi_cm.h>
+#include <uct/base/uct_iface.h>
+#include "ofi_iface.h"
+#include "ofi_ep.h"
+
+
+static ucs_config_field_t uct_ofi_iface_config_table[] = {
+    {"", "ALLOC=huge,mmap,heap", NULL,
+     ucs_offsetof(uct_ofi_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
+
+     UCT_IFACE_MPOOL_CONFIG_FIELDS("OFI", -1, 0, "ofi",
+                                   ucs_offsetof(uct_ofi_iface_config_t, mpool),
+                                   "\nAttention: Setting this param with value != -1 is a dangerous thing\n"
+                                   "and could cause deadlock or performance degradation."),
+
+    {NULL}
+};
+
+/* Note: This isn't thread safe. Does it need to be? */
+/* TODO: Evaluate inlining this */
+int uct_ofi_get_next_av(uct_ofi_av_t *av)
+{
+    int idx = UCS_BITMAP_FFS(av->free);
+    if (idx > UCT_OFI_EPS_PER_AV) {
+        /* TODO: Is opening more AVs a valid way of handling this? */
+        ucs_error("Exceeded UCT_OFI_EPS_PER_AV!");
+        return idx;
+    }
+    UCS_BITMAP_UNSET(av->free, idx);
+    return idx;
+}
+
+
+void uct_ofi_free_av(uct_ofi_av_t *av, int idx)
+{
+    UCS_BITMAP_SET(av->free, idx);
+}
+
+
+ucs_status_t uct_ofi_iface_get_address(uct_iface_h tl_iface,
+                                 uct_iface_addr_t *tl_addr)
+{
+    uct_ofi_iface_t *iface = ucs_derived_of(tl_iface, uct_ofi_iface_t);
+    uct_ofi_name_t *addr = (uct_ofi_name_t *)tl_addr;
+    int status;
+
+    ucs_debug("OFI get iface address");
+    
+    status = fi_getname((fid_t)iface->local, &addr->name, &addr->size);
+    if( !status ) {
+        return UCS_OK;
+    } else {
+        return UCS_ERR_NO_DEVICE;
+    }
+}
+
+
+int uct_ofi_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, const uct_iface_addr_t *iface_addr)
+{
+    struct fi_info hints = {0};
+    struct fi_info *info;
+    uct_ofi_name_t *addr = (uct_ofi_name_t *)iface_addr;
+    int ret;
+    
+    hints.caps = FI_RMA | FI_ATOMIC | FI_TAGGED;
+
+    ucs_debug("OFI iface reachable");
+    ret = fi_getinfo(fi_version(), addr->name, NULL, 0, &hints, &info);
+
+    if (ret == -FI_ENODATA) {
+        ucs_trace("OFI could not reach address");
+        return 0;
+    } else {
+        ucs_trace("OFI can reach this address");
+        fi_freeinfo(info);
+        return 1;
+    }
+}
+
+
+static ucs_status_t uct_ofi_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+{
+    uct_ofi_iface_t *iface = ucs_derived_of(tl_iface, uct_ofi_iface_t);
+    uct_base_iface_query(&iface->super, iface_attr);
+    ucs_trace("Query OFI");
+    
+    iface_attr->cap.am.max_short       = 0;
+    iface_attr->cap.am.max_bcopy       = 0;
+    iface_attr->cap.am.opt_zcopy_align = 1;
+    iface_attr->cap.am.align_mtu       = iface_attr->cap.am.opt_zcopy_align;
+    iface_attr->device_addr_len        = 0;
+    iface_attr->iface_addr_len         = sizeof(uct_ofi_name_t);
+    iface_attr->ep_addr_len            = sizeof(uct_ofi_name_t);
+    iface_attr->max_conn_priv          = 0;
+    iface_attr->cap.flags              = 0;
+    iface_attr->overhead               = 1e-6;  /* 1 usec */
+    iface_attr->latency                = ucs_linear_func_make(40e-6, 0); /* 40 usec */
+    iface_attr->bandwidth.dedicated    = 1.0 * UCS_MBYTE; /* bytes */
+    iface_attr->bandwidth.shared       = 0;
+    iface_attr->priority               = 0;
+    
+    return UCS_OK;
+}
+
+
+ucs_status_t uct_ofi_flush(uct_iface_h tl_iface, unsigned flags,
+                                  uct_completion_t *comp)
+{
+    return  UCS_ERR_UNSUPPORTED;
+}
+
+static ucs_status_t handle_cq_error(struct fid_cq *cq, int ret)
+{
+    /* TODO: More sophisticated cq handling */
+    /* This function should return UCS_OK to tell the progress
+       thread to continue and UCS_ERR_* to stop progress. */
+    UCT_OFI_CHECK_ERROR(ret, "Err reading CQ", UCS_OK);
+    return UCS_OK;
+}
+
+static int progress_cq(struct fid_cq *cq)
+{
+    struct fi_cq_entry entry;
+    int ret, count=-1;
+    
+    do {
+        count++;
+        ret = fi_cq_read(cq, &entry, 1);
+        if (ret < 0 && ret != -FI_EAGAIN) {
+            handle_cq_error(cq, ret);
+        }
+    } while (ret != -FI_EAGAIN);
+
+    return count;
+}
+
+static unsigned uct_ofi_progress(void *arg)
+{
+    int count = 0;
+    uct_ofi_iface_t *iface = (uct_ofi_iface_t *)arg;
+
+    count = progress_cq(iface->tx_cq);
+    count += progress_cq(iface->rx_cq);
+
+    return count;
+}
+
+static void clean_av(uct_ofi_iface_t *iface)
+{
+    fi_close(&iface->av->av->fid);
+}
+
+static void clean_cq(uct_ofi_iface_t *iface)
+{
+    fi_close(&iface->tx_cq->fid);
+    fi_close(&iface->rx_cq->fid);
+}
+
+static void clean_ep(uct_ofi_iface_t *iface)
+{
+    fi_close(&iface->local->fid);
+}
+
+static void clean_info(uct_ofi_iface_t *iface)
+{
+    fi_freeinfo(iface->info);
+}
+
+void uct_ofi_cleanup_base_iface(uct_ofi_iface_t *iface)
+{
+    clean_ep(iface);
+    clean_cq(iface);
+    clean_av(iface);
+    clean_info(iface);
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_ofi_iface_t)
+{
+    uct_ofi_cleanup_base_iface(self);
+}
+
+extern ucs_class_t UCS_CLASS_DECL_NAME(uct_ofi_iface_t);
+static UCS_CLASS_DEFINE_DELETE_FUNC(uct_ofi_iface_t, uct_iface_t);
+
+static uct_iface_ops_t uct_ofi_iface_ops = {
+    .ep_pending_add           = uct_ofi_ep_pending_add,
+    .ep_pending_purge         = uct_ofi_ep_pending_purge,
+    .ep_flush                 = uct_ofi_ep_flush,
+    .ep_fence                 = uct_base_ep_fence,
+    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_ofi_ep_t),
+    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_ofi_ep_t),
+    .ep_get_address           = uct_ofi_ep_get_address,
+    .iface_flush              = uct_ofi_flush,
+    .iface_fence              = uct_base_iface_fence,
+    .iface_progress_enable    = ucs_empty_function,
+    .iface_progress_disable   = ucs_empty_function,
+    .iface_progress           = (void*)uct_ofi_progress,
+    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ofi_iface_t),
+    .iface_query              = uct_ofi_iface_query,
+    .iface_get_device_address = uct_ofi_iface_get_dev_address,
+    .iface_get_address        = uct_ofi_iface_get_address,
+    .iface_is_reachable       = uct_ofi_iface_is_reachable
+};
+
+static uct_iface_internal_ops_t uct_ofi_iface_internal_ops = {
+    .iface_estimate_perf = uct_base_iface_estimate_perf,
+    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported    
+};
+
+
+static ucs_status_t uct_ofi_setup_av(uct_ofi_md_t *md, uct_ofi_iface_t *iface)
+{
+    struct fi_av_attr av_attr = {0};
+    int status;
+
+    iface->av = ucs_malloc(sizeof(uct_ofi_av_t), "Address vector metadata");
+    iface->av->table = ucs_malloc(sizeof(fi_addr_t) * UCT_OFI_EPS_PER_AV, "Address vector");
+    av_attr.type = FI_AV_MAP;
+    status = fi_av_open(md->dom_ctx,
+                        &av_attr,
+                        &iface->av->av,
+                        NULL);
+    if (status) {
+        return UCS_ERR_NO_RESOURCE;
+    }
+    
+    status = fi_ep_bind(iface->local, &iface->av->av->fid, 0);
+    if(!status) {
+        UCS_BITMAP_SET_ALL(iface->av->free);
+        return UCS_OK;
+    } else {
+        return UCS_ERR_NO_RESOURCE;
+    }    
+}
+
+static ucs_status_t uct_ofi_setup_target(uct_ofi_md_t *md, uct_ofi_iface_t *iface)
+{
+    int status;
+    ucs_status_t ret = UCS_OK;
+
+    status = fi_endpoint(md->dom_ctx, iface->info, &iface->local, NULL);
+
+    if ( status ) {
+        ret = UCS_ERR_NO_RESOURCE;
+    }
+    
+    return ret;
+}
+
+static ucs_status_t uct_ofi_setup_cqs(uct_ofi_md_t *md, uct_ofi_iface_t *iface)
+{
+    struct fi_cq_attr attr = {0};
+    int status;
+
+    attr.format = FI_CQ_FORMAT_DATA;
+    attr.size = 0;
+    attr.wait_obj  = FI_WAIT_NONE;
+
+    ucs_trace("Opening CQs");
+    status = fi_cq_open(md->dom_ctx, &attr, &iface->tx_cq, NULL);
+    if (status) {
+        ucs_error("Could not open CQ: %s", fi_strerror(status));
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    status = fi_cq_open(md->dom_ctx, &attr, &iface->rx_cq, NULL);
+    if (status) {
+        ucs_error("Could not open CQ: %s", fi_strerror(status));
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    ucs_trace("Binding CQs");
+    status = fi_ep_bind(iface->local, &iface->tx_cq->fid, FI_TRANSMIT);
+    if (status) {
+        ucs_error("Could not open CQ: %s", fi_strerror(status));
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    status = fi_ep_bind(iface->local, &iface->rx_cq->fid, FI_RECV);
+    if (status) {
+        ucs_error("Could not open CQ: %s", fi_strerror(status));
+        return UCS_ERR_NO_RESOURCE;
+    }
+    
+    return UCS_OK;
+}
+
+static ucs_status_t uct_ofi_setup_fi_info(uct_ofi_md_t *md, uct_ofi_iface_t *iface, const uct_iface_params_t *params)
+{
+    struct fi_info hints = {0};
+    int ret;
+    
+    hints.caps = FI_RMA | FI_ATOMIC | FI_TAGGED;
+    ret = fi_getinfo(fi_version(), NULL, NULL, 0, &hints, &iface->info);
+    if ( ret ) {
+        /* TODO: Better return codes? */
+        return UCS_ERR_NO_MEMORY;
+    } else {
+        return UCS_OK;
+    }
+}
+
+UCS_CLASS_INIT_FUNC(uct_ofi_iface_t, uct_md_h tl_md, uct_worker_h worker,
+                    const uct_iface_params_t *params,
+                    const uct_iface_config_t *tl_config
+                    )
+{
+    ucs_status_t ret;
+    uct_ofi_md_t *md = ucs_derived_of(tl_md, uct_ofi_md_t);
+    
+    ucs_debug("OFI init iface");
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_ofi_iface_ops, &uct_ofi_iface_internal_ops, tl_md,
+                              worker, params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                              UCS_STATS_ARG("OFI_MD"));
+
+    ret = uct_ofi_setup_fi_info(md, self, params);
+    if( ret != UCS_OK ) {
+        goto out;
+    }
+    ucs_trace("OFI info allocated");
+    ret = uct_ofi_setup_target(md, self);
+    if( ret != UCS_OK ) {
+        goto out_info;
+    }
+    ucs_trace("OFI target ep setup");
+    ret = uct_ofi_setup_cqs(md, self);
+    if( ret != UCS_OK ) {
+        goto out_ep;
+    }
+    ucs_trace("OFI cqs setup");
+    ret = uct_ofi_setup_av(md, self);
+    if( ret != UCS_OK ) {
+        goto out_cq;
+    }
+    ucs_debug("OFI iface creation successful");
+    return UCS_OK;
+ 
+ out_cq:
+    clean_cq(self);
+ out_ep:
+    clean_ep(self);
+ out_info:
+    clean_info(self);
+ out:
+    return ret;
+}
+
+UCS_CLASS_DEFINE(uct_ofi_iface_t, uct_base_iface_t);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ofi_iface_t, uct_iface_t, uct_md_h, uct_worker_h,
+                          const uct_iface_params_t*,
+                          const uct_iface_config_t *);
+UCT_TL_DEFINE(&uct_ofi_component, ofi, uct_ofi_query_devices,
+              uct_ofi_iface_t, "OFI_",
+              uct_ofi_iface_config_table, uct_ofi_iface_config_t);

--- a/src/uct/ofi/base/ofi_iface.c
+++ b/src/uct/ofi/base/ofi_iface.c
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #include <rdma/fi_cm.h>
 #include <uct/base/uct_iface.h>
 #include "ofi_iface.h"

--- a/src/uct/ofi/base/ofi_iface.h
+++ b/src/uct/ofi/base/ofi_iface.h
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #ifndef UCT_OFI_IFACE_H
 #define UCT_OFI_IFACE_H
 

--- a/src/uct/ofi/base/ofi_iface.h
+++ b/src/uct/ofi/base/ofi_iface.h
@@ -1,0 +1,26 @@
+#ifndef UCT_OFI_IFACE_H
+#define UCT_OFI_IFACE_H
+
+#include "ofi_def.h"
+#include "ofi_types.h"
+#include "ofi_md.h"
+#include <uct/base/uct_iface.h>
+#include <uct/api/uct.h>
+
+/*
+UCS_CLASS_DECLARE(uct_ofi_iface_t, uct_md_h, uct_worker_h,
+                  const uct_iface_params_t*, uct_iface_ops_t*,
+                  const uct_iface_config_t*)
+    */
+
+ucs_status_t uct_ofi_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                  uct_completion_t *comp);
+ucs_status_t uct_ofi_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
+int uct_ofi_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
+                                const uct_iface_addr_t *iface_addr);
+void uct_ofi_base_desc_init(ucs_mpool_t *mp, void *obj, void *chunk);
+void uct_ofi_base_desc_key_init(uct_iface_h iface, void *obj, uct_mem_h memh);
+void uct_ofi_cleanup_base_iface(uct_ofi_iface_t *iface);
+int uct_ofi_get_next_av(uct_ofi_av_t *av);
+
+#endif

--- a/src/uct/ofi/base/ofi_md.c
+++ b/src/uct/ofi/base/ofi_md.c
@@ -1,0 +1,186 @@
+#include "ofi_md.h"
+#include "ofi_def.h"
+#include <ucs/debug/log.h>
+#include <stdint.h>
+
+/* separate MDs for system mem and hmem */
+/* TODO: Looks like RKEYs maynot be needed, need to adjust since right now I'm just assuming it does */
+/* FI_PROGRESS_UNSPEC */
+
+
+
+
+static ucs_status_t uct_ofi_query_md_resources(uct_component_h component,
+                           uct_md_resource_desc_t **resources_p,
+                           unsigned *num_resources_p)
+{
+    uct_md_resource_desc_t *resource;
+
+    ucs_trace("OFI query resources");
+    resource = ucs_malloc(sizeof(*resource)*1, "md resource");
+    if (resource == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    /* TODO: Query if hmem is available and make it selectable. Or is this
+     * the wrong approach?  */
+    ucs_snprintf_zero(resource[0].md_name, UCT_MD_NAME_MAX, "%s sys memory",
+                      component->name);
+
+    *resources_p     = resource;
+    *num_resources_p = 1;
+    return UCS_OK;
+}
+
+static ucs_status_t uct_ofi_md_query(uct_md_h tl_md, uct_md_attr_t *md_attr)
+{
+    uct_ofi_md_t *md = ucs_derived_of(tl_md, uct_ofi_md_t);
+
+    ucs_trace("OFI md query");
+    md_attr->cap.flags            = UCT_MD_FLAG_REG;
+    /* TODO: hmem option */
+    md_attr->cap.reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cap.alloc_mem_types  = 0;
+    md_attr->cap.access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    /* TODO: Can libfabric detect? */
+    md_attr->cap.detect_mem_types = 0;
+    md_attr->cap.max_alloc        = 0;
+    md_attr->cap.max_reg          = ULONG_MAX;
+    /* TODO: find correct measure */
+    md_attr->reg_cost             = ucs_linear_func_make(1000.0e-9, 0.007e-9);
+    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    md_attr->rkey_packed_size     = md->fab_info->domain_attr->mr_key_size;
+    return UCS_OK;
+}
+
+
+static void uct_ofi_md_close(uct_md_h md)
+{
+    uct_ofi_md_t *ofi_md = ucs_derived_of(md, uct_ofi_md_t);
+    ucs_trace("OFI md close");
+
+    ofi_md->ref_count--;
+    if (!ofi_md->ref_count) {
+        ucs_debug("Tearing down OFI domain");
+        
+	/* TODO: teardown code */
+    }
+}
+
+
+static ucs_status_t uct_ofi_mem_reg(uct_md_h md, void *address, size_t length,
+                                    unsigned flags, uct_mem_h *memh_p)
+{
+    uct_ofi_md_t *ofi_md = ucs_derived_of(md, uct_ofi_md_t);
+    int ret;
+    struct fid_mr **mr = (struct fid_mr **)memh_p;
+
+    ucs_debug("address=%p length=%zd", address, length);
+
+    ret = fi_mr_reg(ofi_md->dom_ctx, address, length, FI_REMOTE_WRITE | FI_REMOTE_READ | FI_READ | FI_WRITE,
+                    0, 0ULL, 0, mr, NULL);
+
+    UCT_OFI_CHECK_ERROR(ret, "fi_mr_reg", UCS_ERR_NO_MEMORY);
+    return UCS_OK;
+}
+
+
+static ucs_status_t uct_ofi_mem_dereg(uct_md_h md,
+                                      const uct_md_mem_dereg_params_t *params)
+{
+    int ret;
+    struct fid_mr *mr = (struct fid_mr *)params->memh;
+    ucs_trace("uct_ofi_mem_dereg");
+    if (params->field_mask & UCT_MD_MEM_DEREG_FIELD_FLAGS && params->flags & UCT_MD_MEM_DEREG_FLAG_INVALIDATE) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+    ret = fi_close(&mr->fid);
+    UCT_OFI_CHECK_ERROR(ret, "fi_close on mem dereg", UCS_ERR_IO_ERROR);
+    return UCS_OK;
+}
+
+
+static ucs_status_t uct_ofi_rkey_pack(uct_md_h md, uct_mem_h memh,
+                                      void *rkey_buffer)
+{
+    return UCS_ERR_NO_MEMORY;
+}
+
+
+static ucs_status_t uct_ofi_rkey_release(uct_component_t *component,
+                                         uct_rkey_t rkey, void *handle)
+{
+    return UCS_ERR_IO_ERROR;
+}
+
+
+static ucs_status_t uct_ofi_rkey_unpack(uct_component_t *component,
+                                        const void *rkey_buffer,
+                                        uct_rkey_t *rkey_p, void **handle_p)
+{
+    return UCS_ERR_UNSUPPORTED;
+}
+
+
+static ucs_status_t
+uct_ofi_md_open(uct_component_h component, const char *md_name,
+                 const uct_md_config_t *md_config, uct_md_h *md_p)
+{
+    ucs_status_t status = UCS_OK;
+    static uct_md_ops_t md_ops;
+    static uct_ofi_md_t md;
+
+    md_ops.close              = uct_ofi_md_close;
+    md_ops.query              = uct_ofi_md_query;
+    md_ops.mem_alloc          = (void*)ucs_empty_function;
+    md_ops.mem_free           = (void*)ucs_empty_function;
+    md_ops.mem_reg            = uct_ofi_mem_reg;
+    md_ops.mem_dereg          = uct_ofi_mem_dereg;
+    md_ops.mkey_pack          = uct_ofi_rkey_pack;
+    md_ops.detect_memory_type = ucs_empty_function_return_unsupported;
+    md_ops.is_sockaddr_accessible = ucs_empty_function_return_zero_int;
+
+    md.super.ops              = &md_ops;
+    md.super.component        = &uct_ofi_component;
+    md.ref_count              = 0;
+
+    *md_p = &md.super;
+
+    ucs_trace("OFI MD open");
+
+    if (!md.ref_count) {
+        /* TODO: Logic to let users request fabrics on the command line */
+        /* Hard coding NULL takes the first available domain. Can this be done smarter? */
+        status = uct_ofi_init_fabric(&md, NULL);
+        if (UCS_OK != status) {
+	    goto error;
+        } 
+    }
+
+    md.ref_count++;
+
+error:
+    return status;
+}
+
+
+uct_component_t uct_ofi_component = {
+    .query_md_resources = uct_ofi_query_md_resources,
+    .md_open            = uct_ofi_md_open,
+    .cm_open            = ucs_empty_function_return_unsupported,
+    .rkey_unpack        = uct_ofi_rkey_unpack,
+    .rkey_ptr           = ucs_empty_function_return_unsupported,
+    .rkey_release       = uct_ofi_rkey_release,
+    .name               = UCT_OFI_MD_NAME,
+    .md_config          = {
+        .name           = "Libfabric memory domain",
+        .prefix         = "FI_",
+	.table          = uct_md_config_table,
+        .size           = sizeof(uct_md_config_t),
+    },
+    .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
+    .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_ofi_component),
+    .flags              = 0,
+    .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
+};
+UCT_COMPONENT_REGISTER(&uct_ofi_component);

--- a/src/uct/ofi/base/ofi_md.c
+++ b/src/uct/ofi/base/ofi_md.c
@@ -1,9 +1,12 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #include "ofi_md.h"
 #include "ofi_def.h"
 #include <ucs/debug/log.h>
 #include <stdint.h>
 
-/* separate MDs for system mem and hmem */
 /* TODO: Looks like RKEYs maynot be needed, need to adjust since right now I'm just assuming it does */
 /* FI_PROGRESS_UNSPEC */
 

--- a/src/uct/ofi/base/ofi_md.h
+++ b/src/uct/ofi/base/ofi_md.h
@@ -1,0 +1,12 @@
+#ifndef UCT_OFI_MD_H
+#define UCT_OFI_MD_H
+
+#include "ofi_device.h"
+#include "ofi_types.h"
+#include <uct/base/uct_md.h>
+#include <ucs/sys/sys.h>
+#include <ucs/sys/string.h>
+
+extern uct_component_t uct_ofi_component;
+
+#endif

--- a/src/uct/ofi/base/ofi_md.h
+++ b/src/uct/ofi/base/ofi_md.h
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #ifndef UCT_OFI_MD_H
 #define UCT_OFI_MD_H
 

--- a/src/uct/ofi/base/ofi_types.h
+++ b/src/uct/ofi/base/ofi_types.h
@@ -1,0 +1,54 @@
+#ifndef UCT_UGNI_TYPES_H
+#define UCT_UGNI_TYPES_H
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <uct/api/uct.h>
+#include <uct/base/uct_md.h>
+#include <uct/base/uct_iface.h>
+#include <ucs/datastruct/arbiter.h>
+#include <ucs/datastruct/bitmap.h>
+#include "ofi_def.h"
+
+typedef struct uct_ofi_md {
+    uct_md_t           super; /**< Domain info */
+    int                ref_count;
+    struct fi_info    *fab_info;
+    struct fid_fabric *fab_ctx;
+    struct fid_domain *dom_ctx;
+} uct_ofi_md_t;
+
+typedef struct uct_ofi_av {
+    ucs_bitmap_t(256) free;
+    fi_addr_t     *table;
+    struct fid_av *av;
+} uct_ofi_av_t;
+
+typedef struct uct_ofi_iface {
+    uct_base_iface_t        super;
+    unsigned                outstanding; /**< Counter for outstanding packets */
+    ucs_arbiter_t           arbiter;     /**< arbiter structure for pending ops */
+    uct_ofi_av_t            *av;         /**< libfabric address vector */
+    struct fi_info          *info;
+    struct fid_ep *local;
+    struct fid_cq *tx_cq;
+    struct fid_cq *rx_cq;
+} uct_ofi_iface_t;
+
+typedef struct uct_ofi_iface_config {
+    uct_iface_config_t       super;
+    uct_iface_mpool_config_t mpool;
+} uct_ofi_iface_config_t;
+
+typedef struct uct_ofi_ep {
+    uct_base_ep_t           super;
+    uint64_t                id;
+    int                     av_index;
+} uct_ofi_ep_t;
+
+typedef struct uct_ofi_name {
+    size_t  size;
+    uint8_t name[FI_NAME_MAX];
+} uct_ofi_name_t;
+
+#endif

--- a/src/uct/ofi/base/ofi_types.h
+++ b/src/uct/ofi/base/ofi_types.h
@@ -1,3 +1,7 @@
+/**
+ * Copyright (C) UT-Battelle, LLC. 2022. ALL RIGHTS
+ */
+
 #ifndef UCT_UGNI_TYPES_H
 #define UCT_UGNI_TYPES_H
 

--- a/src/uct/ofi/configure.m4
+++ b/src/uct/ofi/configure.m4
@@ -1,0 +1,31 @@
+#
+# Copyright (C) UT-Battelle, LLC. 2014. ALL RIGHTS RESERVED.
+# Copyright (C) Mellanox Technologies Ltd. 2001-2018.  ALL RIGHTS RESERVED.
+# Copyright (C) ARM Ltd. 2020.  ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+ofi_supported=yes
+
+#AC_ARG_WITH([ugni],
+#            [AC_HELP_STRING([--with-ugni(=DIR)], [Build Cray UGNI support])], [], [])
+#
+#AS_IF([test "x$with_ugni" != "xno"],
+#      [AC_MSG_CHECKING([cray-ugni])
+#       AS_IF([$PKG_CONFIG --exists cray-ugni cray-pmi],
+#             [AC_MSG_RESULT([yes])
+#              AC_SUBST([CRAY_UGNI_CFLAGS], [`$PKG_CONFIG --cflags cray-ugni cray-pmi`])
+#              AC_SUBST([CRAY_UGNI_LIBS],   [`$PKG_CONFIG --libs   cray-ugni cray-pmi`])
+#              uct_modules="${uct_modules}:ugni"
+#              cray_ugni_supported=yes
+#              AC_DEFINE([HAVE_TL_UGNI], [1], [Defined if UGNI transport exists])
+#             ],
+#             [AC_MSG_RESULT([no])
+#              AS_IF([test "x$with_ugni" != "x"],
+#                    [AC_MSG_ERROR([UGNI support was requested but cray-ugni and cray-pmi packages cannot be found])])
+#             ])])
+
+uct_modules="${uct_modules}:ofi"
+AM_CONDITIONAL([HAVE_OFI], [test "x$ofi_supported" = xyes])
+AC_CONFIG_FILES([src/uct/ofi/Makefile
+                 src/uct/ofi/ucx-ofi.pc])

--- a/src/uct/ofi/opal_check_ofi.m4
+++ b/src/uct/ofi/opal_check_ofi.m4
@@ -1,0 +1,159 @@
+dnl -*- autoconf -*-
+dnl
+dnl Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl
+dnl OPAL_CHECK_OFI_VERSION_GE
+dnl
+dnl Check that the OFI API version number is >= a specific value.
+dnl
+dnl $1: version number to compare, in the form of "major,minor"
+dnl     (without quotes) -- i.e., a single token representing the
+dnl     arguments to FI_VERSION()
+dnl $2: action if OFI API version is >= $1
+dnl $3: action if OFI API version is < $1
+AC_DEFUN([OPAL_CHECK_OFI_VERSION_GE],[
+    OPAL_VAR_SCOPE_PUSH([opal_ofi_ver_ge_save_CPPFLAGS opal_ofi_ver_ge_happy])
+
+    AS_LITERAL_WORD_IF([$1], [], [m4_fatal([OPAL_CHECK_OFI_VERSION_GE called with non-literal first argument])])dnl
+    AS_VAR_PUSHDEF([version_cache_var], [opal_ofi_ver_ge_cv_$1])dnl
+    m4_pushdef([version_pretty_print], [m4_translit([$1], [,], [.])])dnl
+
+    AC_CACHE_CHECK([if OFI API version number is >= version_pretty_print],
+        [version_cache_var],
+        [opal_ofi_ver_ge_save_CPPFLAGS=$CPPFLAGS
+         CPPFLAGS=$opal_ofi_internal_CPPFLAGS
+
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                [[#include <rdma/fabric.h>
+]], [[
+#if !defined(FI_MAJOR_VERSION)
+#error "we cannot check the version -- sad panda"
+#elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION($1))
+#error "version is too low -- nopes"
+#endif
+]])],
+                      [version_cache_var=yes],
+                      [version_cache_var=no])])
+
+    AS_IF([test "${version_cache_var}" = "yes"],
+          [$2],
+          [$3])
+
+    CPPFLAGS=$opal_ofi_ver_ge_save_CPPFLAGS
+
+    m4_popdef([version_pretty_print])
+    AS_VAR_POPDEF([version_cache_var])
+    OPAL_VAR_SCOPE_POP
+])dnl
+
+
+dnl OPAL_CHECK_OFI(prefix, [action if found], [action if not found])
+dnl --------------------------------------------------------
+dnl Do the real work of checking for OFI libfabric.
+dnl Upon return:
+dnl
+dnl opal_ofi_{CPPFLAGS, LDFLAGS, LIBS} and prefix_{CPPFLAGS, LDFLAGS,
+dnl LIBS} will be set as needed.
+dnl
+dnl This macro intentionally leaks opal_ofi_happy = yes/no as well as
+dnl evaluating the action if found / action if not found
+dnl
+AC_DEFUN([OPAL_CHECK_OFI],[
+    OPAL_VAR_SCOPE_PUSH([opal_check_ofi_save_CPPFLAGS opal_check_ofi_save_LDFLAGS opal_check_ofi_save_LIBS opal_check_fi_info_pci])
+
+    m4_ifblank([$1], [m4_fatal([First argument must be set for call to OPAL_CHECK_OFI])])
+
+    # Add --with options
+    AC_ARG_WITH([libfabric],
+                [AS_HELP_STRING([--with-libfabric=DIR],
+                                [Deprecated synonym for --with-ofi])])
+    AC_ARG_WITH([libfabric-libdir],
+                [AS_HELP_STRING([--with-libfabric-libdir=DIR],
+                                [Deprecated synonym for --with-ofi-libdir])])
+
+    AC_ARG_WITH([ofi],
+                [AS_HELP_STRING([--with-ofi=DIR],
+                                [Specify location of OFI libfabric installation, adding DIR/include to the default search location for libfabric headers, and DIR/lib or DIR/lib64 to the default search location for libfabric libraries.  Error if libfabric support cannot be found.])])
+    AC_ARG_WITH([ofi-libdir],
+                [AS_HELP_STRING([--with-ofi-libdir=DIR],
+                                [Search for OFI libfabric libraries in DIR])])
+
+    AS_IF([test -z "${with_ofi}"], [with_ofi=${with_libfabric}])
+    AS_IF([test -z "${with_ofi_libdir}"], [with_ofi_libdir=${with_libfabric_libdir}])
+
+    opal_check_ofi_save_CPPFLAGS=${CPPFLAGS}
+    opal_check_ofi_save_LDFLAGS=${LDFLAGS}
+    opal_check_ofi_save_LIBS=${LIBS}
+
+    opal_check_fi_info_pci=0
+
+    dnl OMPI has used ofi everywhere for some time, but the pkg-config
+    dnl module name is libfabric.  Easier to set the pkg-config module
+    dnl name explicitly than change everything in OMPI.
+    m4_define([ofi_pkgconfig_module], [libfabric])
+    OAC_CHECK_PACKAGE([ofi],
+                      [$1],
+                      [rdma/fabric.h],
+                      [fabric],
+                      [fi_getinfo],
+                      [opal_ofi_happy=yes],
+                      [opal_ofi_happy=no])
+
+    OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${$1_CPPFLAGS}])
+
+    AS_IF([test $opal_ofi_happy = yes],
+          [AC_CHECK_HEADERS([rdma/fi_ext.h])
+
+           AC_CHECK_MEMBER([struct fi_info.nic],
+                           [opal_check_fi_info_pci=1],
+                           [opal_check_fi_info_pci=0],
+                           [[#include <rdma/fabric.h>]])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_PCI_DATA_AVAILABLE],
+                              [${opal_check_fi_info_pci}],
+                              [check if pci data is available in ofi])
+
+           AC_CHECK_DECLS([FI_OPT_FI_HMEM_P2P],
+                          [], [],
+                          [#include <rdma/fi_endpoint.h>])
+
+           AC_CHECK_TYPES([struct fi_ops_mem_monitor], [], [],
+                          [#ifdef HAVE_RDMA_FI_EXT_H
+#include <rdma/fi_ext.h>
+#endif
+                           ])
+
+           OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${opal_pmix_CPPFLAGS}])
+           AC_CHECK_DECLS([PMIX_PACKAGE_RANK],
+                          [],
+                          [],
+                          [#include <pmix.h>])])
+
+    CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
+    LDFLAGS=${opal_check_ofi_save_LDFLAGS}
+    LIBS=${opal_check_ofi_save_LIBS}
+
+    dnl for version compare tests
+    opal_ofi_internal_CPPFLAGS="${$1_CPPFLAGS}"
+
+    OPAL_SUMMARY_ADD([Transports], [OpenFabrics OFI Libfabric], [], [${$1_SUMMARY}])
+
+    AS_IF([test "${opal_ofi_happy}" = "yes"],
+          [$2],
+          [AS_IF([test -n "${with_ofi}" && test "${with_ofi}" != "no"],
+                 [AC_MSG_WARN([OFI libfabric support requested (via --with-ofi or --with-libfabric), but not found.])
+                  AC_MSG_ERROR([Cannot continue.])])
+           $3])
+
+    OPAL_VAR_SCOPE_POP
+])dnl

--- a/src/uct/ofi/ucx-ofi.pc.in
+++ b/src/uct/ofi/ucx-ofi.pc.in
@@ -1,0 +1,6 @@
+Name: @PACKAGE@-ofi
+Description: Unified Communication X Library UGNI module
+Version: @MAJOR_VERSION@.@MINOR_VERSION@
+Libs:
+Libs.private:
+

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -38,7 +38,8 @@ extern "C" {
                    ib, \
                    ugni, \
                    sockcm, \
-                   rdmacm \
+                   rdmacm, \
+                   ofi \
                    )
 
 void* test_md::alloc_thread(void *arg)

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -630,6 +630,10 @@ bool uct_test::has_gpu() const {
             has_transport("rocm_copy"));
 }
 
+bool uct_test::has_ofi() const {
+    return (has_transport("ofi"));
+}
+
 uct_test::entity *
 uct_test::create_entity(size_t rx_headroom, uct_error_handler_t err_handler,
                         uct_tag_unexp_eager_cb_t eager_cb,

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -365,6 +365,7 @@ protected:
     virtual bool has_cma() const;
     virtual bool has_ugni() const;
     virtual bool has_gpu() const;
+    virtual bool has_ofi() const;
 
     bool is_caps_supported(uint64_t required_flags);
     bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
@@ -461,7 +462,8 @@ protected:
     sysv,                    \
     xpmem,                   \
     cma,                     \
-    knem
+    knem,                    \
+    ofi \
 
 #define UCT_TEST_CUDA_MEM_TYPE_TLS \
     cuda_copy,              \


### PR DESCRIPTION
## What
Adding support to run UCX on top of a libfabrics transport. This implementation is incomplete but I wanted to do a WIP PR. I've implemented many of the low level details that the rest of the implementation should be down to implementing the message injection routines. I'm hoping that someone with more libfabric knowledge than me can help with this part.

Known deficiencies right now includes the inability to select with fabric to use specifically. It defaults to the first available fabric, which seems to be the most common/correct choice, but should be configurable.

Second, I'm not happy with how the EP to libfabric address vector mapping works. It 'works for now' but only at small sizes and definitely needs more work.

## Why ?
Adds functionality to allow UCX to run on such systems as Frontier.

## How ?
Implements the usual UCT APIs
