### PR TITLE
UCM/ROCM: delay memtype detection to md's

### DIFF
--- a/src/ucm/rocm/rocmmem.c
+++ b/src/ucm/rocm/rocmmem.c
@@ -111,17 +111,8 @@ hsa_status_t ucm_hsa_amd_memory_pool_allocate(
     hsa_amd_memory_pool_t memory_pool, size_t size,
     uint32_t flags, void** ptr)
 {
-    ucs_memory_type_t type = UCS_MEMORY_TYPE_ROCM;
-    uint32_t pool_flags    = 0;
+    ucs_memory_type_t type = UCS_MEMORY_TYPE_LAST;
     hsa_status_t status;
-
-    status = hsa_amd_memory_pool_get_info(memory_pool,
-                                          HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
-                                          &pool_flags);
-    if (status == HSA_STATUS_SUCCESS &&
-        !(pool_flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED)) {
-        type = UCS_MEMORY_TYPE_ROCM_MANAGED;
-    }
 
     ucm_event_enter();
 


### PR DESCRIPTION
## What
Delay the memtype detection to rocm md. Otherwise  the code path for the detection of rocm memory between
ucm/rocm and uct/rocm can easily diverge and lead to unintended consequences.

## Why ?
Fixes an issue observed with a testcase on rocm 5.1 with older linux kernels.