### PR TITLE
UCT/IB: ibv_reg_ms should be ibv_reg_mr

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -289,7 +289,7 @@ static void uct_ib_md_print_mem_reg_err_msg(void *address, size_t length,
     size_t page_size;
     size_t unused;
 
-    ucs_string_buffer_appendf(&msg, "ibv_reg_ms(address=%p, length=%zu, access=0x%lx)",
+    ucs_string_buffer_appendf(&msg, "ibv_reg_mr(address=%p, length=%zu, access=0x%lx)",
                               address, length, access_flags);
 
     if (err == EINVAL) {


### PR DESCRIPTION
## What
Fix a typo

## Why ?
ibv_reg_ms should be ibv_reg_mr

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
