### PR TITLE
UCS/CONFIG_PARSER: Unrecognized user vars will be fuzzy matched to provide some alternatives

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -973,6 +973,10 @@ test_unused_env_var() {
 	# We must create a UCP worker to get the warning about unused variables
 	echo "==== Running ucx_info env vars test ===="
 	UCX_IB_PORTS=mlx5_0:1 ./src/tools/info/ucx_info -epw -u t | grep "unused" | grep -q -E "UCX_IB_PORTS"
+	
+	# Check that suggestions for similar ucx env vars are printed
+	echo "==== Running fuzzy match test ===="
+	../test/apps/test_fuzzy_match.py --ucx_info ./src/tools/info/ucx_info
 }
 
 test_env_var_aliases() {

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -26,6 +26,7 @@ nobase_dist_libucs_la_HEADERS = \
 	arch/bitops.h \
 	algorithm/crc.h \
 	algorithm/qsort_r.h \
+	algorithm/string_distance.h \
 	async/async_fwd.h \
 	config/global_opts.h \
 	config/ini.h \
@@ -133,6 +134,7 @@ noinst_HEADERS = \
 libucs_la_SOURCES = \
 	algorithm/crc.c \
 	algorithm/qsort_r.c \
+	algorithm/string_distance.c \
 	arch/aarch64/cpu.c \
 	arch/aarch64/global_opts.c \
 	arch/ppc64/timebase.c \

--- a/src/ucs/algorithm/string_distance.c
+++ b/src/ucs/algorithm/string_distance.c
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2022 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "string_distance.h"
+#include <ucs/sys/math.h>
+#include <ucs/sys/sys.h>
+#include <string.h>
+
+
+size_t ucs_string_distance(const char *str1, const char *str2)
+{
+    const size_t len1 = strlen(str1);
+    const size_t len2 = strlen(str2);
+    size_t *distances = ucs_alloca((len1 + 1) * sizeof(*distances));
+    size_t distance_backup, distance_prev, min_prev, addition;
+    size_t i, j;
+
+    /* We explicitly init distances[len1] to prevent static
+     * analysis false positive (unintialized return value) */
+    distances[len1] = len1;
+    for (j = 1; j <= len1; ++j) {
+        distances[j] = j;
+    }
+
+    for (i = 1; i <= len2; ++i) {
+        distances[0]  = i;
+        distance_prev = i - 1;
+
+        for (j = 1; j <= len1; ++j) {
+            distance_backup = distances[j];
+            min_prev        = ucs_min(distances[j] + 1, distances[j - 1] + 1);
+            addition        = str1[j - 1] != str2[i - 1];
+            distances[j]    = ucs_min(min_prev, distance_prev + addition);
+            distance_prev   = distance_backup;
+        }
+    }
+
+    return distances[len1];
+}

--- a/src/ucs/algorithm/string_distance.h
+++ b/src/ucs/algorithm/string_distance.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2021 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_STRING_DISTANCE_H_
+#define UCS_STRING_DISTANCE_H_
+
+#include <ucs/sys/compiler_def.h>
+#include <stddef.h>
+
+BEGIN_C_DECLS
+
+/** @file string_distance.h */
+
+/**
+ * Calculate Levenshtein distance between two strings.
+ *
+ * @param [in]  str1  First NULL-terminated string.
+ * @param [in]  str2  Second NULL-terminated string.
+ *
+ * @return Distance between the strings.
+ */
+size_t ucs_string_distance(const char *str1, const char *str2);
+
+END_C_DECLS
+
+#endif

--- a/test/apps/test_fuzzy_match.py
+++ b/test/apps/test_fuzzy_match.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python2
+
+#
+# Copyright (C) 2022 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+
+import os
+import commands
+import re
+import argparse
+import sys
+import logging
+
+
+class Environment(object):
+    '''Handles environment variables setup and cleanup'''
+    def __init__(self, env_vars):
+        logging.info('Using env vars: %s' % env_vars)        
+        self.env_vars = env_vars;
+        
+    def __enter__(self):
+        self.cleanup()
+        for var_name in self.env_vars:
+            os.environ[var_name] = 'value'
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+        
+    def cleanup(self):
+        ucx_vars = [var for var in os.environ.keys() if var.startswith('UCX_')]
+        for var in ucx_vars:
+            del os.environ[var]
+
+    
+class TestRunner:
+    '''Main test runner'''
+    def __init__(self, ucx_info, verbose):
+        self.ucx_info = ucx_info
+        if verbose:
+            logging.basicConfig(level=logging.DEBUG)
+        
+    def run(self, expected):
+        with Environment(expected.keys()):
+            matches = self.get_fuzzy_matches()
+
+            if matches != expected:
+                raise Exception('Wrong fuzzy list: got: %s, expected: %s' % (matches, expected))
+        
+            logging.info('found all expected matches: %s' % expected)
+        
+    def exec_ucx_info(self):
+        cmd = self.ucx_info + ' -u m -w'
+        logging.info('running cmd: %s' % cmd)
+    
+        status, output = commands.getstatusoutput(cmd)
+        if status != 0:
+            raise Exception('Received unexpected exit code from ucx_info: ' + str(status))
+            
+        logging.info(output)
+        return output
+    
+    def get_fuzzy_matches(self):
+        output = self.exec_ucx_info()
+        warn_msg = output.splitlines()[0]
+        
+        # This text is printed from 'parser.c' file (updates should be synced properly).
+        warn_match = re.match('.*unused environment variables?: (.*)', warn_msg)
+        if not warn_match:
+            raise Exception('"unused vars" message was not found')
+            
+        output_vars = warn_match.group(1).split(';')
+        matches = [re.match(r'(\w+)(?: \(maybe: (.*)\?\))?', var.strip()) for var in output_vars]
+        if None in matches:
+            raise Exception('Unexpected warning message format: %s' % warn_msg)
+        
+        return {m.group(1) : [x.strip() for x in m.group(2).split(',')] if m.group(2) else [] for m in matches}
+    
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Tester for config vars fuzzy matching')
+    parser.add_argument('--ucx_info', help="Path to ucx_info binary", required=True)
+    parser.add_argument('-v', '--verbose', help="Add some debug prints", action='store_true', default=False)
+    args = parser.parse_args()
+
+    try:    
+        runner = TestRunner(args.ucx_info, args.verbose)
+        expected_list = [{'UCX_LOF_LEVEL' : ['UCX_LOG_LEVEL']}, 
+                         {'UCX_LOF_LEVEL' : ['UCX_LOG_LEVEL'], 'UCX_MOFULE_D' : ['UCX_MODULE_DIR', 'UCX_MODULES']},
+                         {'UCX_SOME_VAR' : [], 'UCX_SOME_VAR2' : [],  'UCX_SOME_VAR3' : [],  'UCX_SOME_VAR4' : []},
+                         {'UCX_SOME_VAR' : [], 'UCX_MOFULE_D' : ['UCX_MODULE_DIR', 'UCX_MODULES'], 'UCX_SOME_VAR2' : [], 'UCX_LOF_LEVEL' : ['UCX_LOG_LEVEL']},
+                         {'UCX_RC_VERBS_RX_MAX_BUF' : ['UCX_RC_VERBS_TX_MAX_BUFS', 'UCX_RC_VERBS_RX_MAX_BUFS', 'UCX_UD_VERBS_RX_MAX_BUFS']},
+                         {'UCX_RLS' : ['UCX_TLS']}]
+        
+        for expected in expected_list:
+            runner.run(expected)
+            
+    except Exception as e:
+        logging.error(str(e))
+        sys.exit(1)
+        

--- a/test/gtest/ucs/test_algorithm.cc
+++ b/test/gtest/ucs/test_algorithm.cc
@@ -8,6 +8,7 @@
 extern "C" {
 #include <ucs/algorithm/crc.h>
 #include <ucs/algorithm/qsort_r.h>
+#include <ucs/algorithm/string_distance.h>
 }
 #include <vector>
 
@@ -119,4 +120,38 @@ UCS_TEST_F(test_algorithm, crc32) {
 
     test_str = "0123456789";
     EXPECT_EQ(0xa684c7c6ul, ucs_crc32(0, test_str.c_str(), test_str.size()));
+}
+
+UCS_TEST_F(test_algorithm, string_distance) {
+    // Empty strings
+    EXPECT_EQ(0u, ucs_string_distance("", ""));
+
+    // First string empty
+    EXPECT_EQ(8u, ucs_string_distance("", "aabbccdd"));
+
+    // Second string empty
+    EXPECT_EQ(8u, ucs_string_distance("aabbccdd", ""));
+
+    // 2 identical strings
+    EXPECT_EQ(0u, ucs_string_distance("aabbccdd", "aabbccdd"));
+
+    // No common chars
+    EXPECT_EQ(8u, ucs_string_distance("aabbccdd", "eeffgghh"));
+
+    // Replace
+    EXPECT_EQ(2u, ucs_string_distance("aabbccdd", "aabeccfd"));
+
+    // Swap
+    EXPECT_EQ(2u, ucs_string_distance("aabbccdd", "aabcbcdd"));
+
+    // Subtract
+    EXPECT_EQ(2u, ucs_string_distance("aabbccdd", "aabcdd"));
+
+    // Add
+    EXPECT_EQ(2u, ucs_string_distance("aabbccdd", "aabbeeccdd"));
+
+    // Combinations
+    EXPECT_EQ(4u, ucs_string_distance("aabbccddee", "afbccdede"));
+    EXPECT_EQ(4u, ucs_string_distance("aabbccddeeff", "ababccdgedeff"));
+    EXPECT_EQ(6u, ucs_string_distance("aabbccddeeff", "aagbbhddefefii"));
 }

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -561,7 +561,7 @@ UCS_TEST_F(test_config, unused) {
     /* set to warn about unused env vars */
     ucs_global_opts.warn_unused_env_vars = 1;
 
-    const std::string warn_str    = "unused env variable";
+    const std::string warn_str    = "unused environment variable";
     const std::string unused_var1 = "UCX_UNUSED_VAR1";
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv env1(unused_var1.c_str(), "unused");


### PR DESCRIPTION
## What
Unrecognized user vars will be fuzzy matched to provide some alternatives

## Why ?
User may want to fix the mistyped env vars.

## How ?
We calculate levenstein distance between a given user env var and all UCX configuration vars.
Strings that have a small enough distance will be added to the suggestions list.
Current distance threshold is 3.

## Output Example
![image](https://user-images.githubusercontent.com/103439971/174813750-b3defb31-6dde-4220-9459-22e86586ea9a.png)


