### PR TITLE
UCT/ROCM/COPY: fix compilation problem

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -236,7 +236,7 @@ uct_rocm_copy_rache_region_from_memh(uct_mem_h memh)
 }
 
 static ucs_status_t
-uct_rocm_copy_mem_rcache_reg(uct_md_h md, void *address, size_t length,
+uct_rocm_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
                              const uct_md_mem_reg_params_t *params,
                              uct_mem_h *memh_p)
 {


### PR DESCRIPTION
## What
commit 604c3b05879576a936932dc31bfd696c9dbe148c (Introduce uct_mem_reg_v2) accidentally renamed a parameter in
uct_rocm_copy_mem_rcache_reg(), breaking the compilation of the rocm/copy component. This commit fixes it.


