### PR TITLE
CONTRIB/JENKINS: Do not freeze in case of fatal error

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1235,10 +1235,8 @@ run_release_mode_tests() {
 # Run all tests
 #
 run_tests() {
-	export UCX_HANDLE_ERRORS=freeze,bt
+	export UCX_HANDLE_ERRORS=bt
 	export UCX_ERROR_SIGNALS=SIGILL,SIGSEGV,SIGBUS,SIGFPE,SIGPIPE,SIGABRT
-	export UCX_ERROR_MAIL_TO=$ghprbActualCommitAuthorEmail
-	export UCX_ERROR_MAIL_FOOTER=$JOB_URL/$BUILD_NUMBER/console
 	export UCX_TCP_PORT_RANGE="$((33000 + EXECUTOR_NUMBER * 100))"-"$((34000 + EXECUTOR_NUMBER * 100))"
 	export UCX_TCP_CM_REUSEADDR=y
 


### PR DESCRIPTION
## Why
- Do not waste worker resource in case of fatal error
- Possible solution for 100% CPU usage of AzurePlugin