### PR TITLE
NEWS: 1.13.0 update for RC2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,16 @@
 ### Features:
 ### Bugfixes:
 
-## 1.13.0 (May 27, 2022)
+## 1.13.0-rc2 (June 27, 2022)
+#### Bugfixes
+##### RDMA CORE (IB, ROCE, etc.)
+* Fixed indirect key registration
+* Fixed flow control protocol for DC transport
+##### GPU (CUDA, ROCM)
+* Fixed CUDA module compilation with clang 13
+* Fixes in ROCm memory detection and performance estimation
+
+## 1.13.0-rc1 (May 27, 2022)
 #### Features
 ##### Core
 * Added new objects to VFS: local and remote address of endpoint, statistics of ucp_ep_create success/failure, failed/destroyed endpoints


### PR DESCRIPTION
## What
Update NEWS file for RC2 

## Why ?
Full list of changes since RC1:
 - ff64ffad7 AZP: remove HWI hosts from testing
 - 7e2df9171 UCT/CUDA: use right driver macro to log errors with drv fxns
 - 28b0f30b5 UCT/IB/DC: Always schedule DCI allocation during FC_HARD_REQ progress
 - f92b1727c TEST/UCT: Remove atomic access from invalidate tests
 - 5cec39013 UCT/IB: Fix indirect key registration by using correct MR type
 - a6c5a472f UCT/IB/DC: Fix managing FC_HARD_REQ resend time
