### PR TITLE
GTEST/UCP: Reduced number of tests in AM datatype test class.

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1231,27 +1231,15 @@ UCS_TEST_P(test_ucp_am_nbx_dts, short_send, "ZCOPY_THRESH=-1", "RNDV_THRESH=-1")
     test_am(1);
 }
 
-UCS_TEST_P(test_ucp_am_nbx_dts, short_bcopy_send, "ZCOPY_THRESH=-1",
-                                                  "RNDV_THRESH=-1")
+UCS_TEST_P(test_ucp_am_nbx_dts, bcopy_send, "ZCOPY_THRESH=-1", "RNDV_THRESH=-1")
 {
     test_am(4 * UCS_KBYTE);
-}
-
-UCS_TEST_P(test_ucp_am_nbx_dts, long_bcopy_send, "ZCOPY_THRESH=-1",
-                                                 "RNDV_THRESH=-1")
-{
     test_am(64 * UCS_KBYTE);
 }
 
-UCS_TEST_P(test_ucp_am_nbx_dts, short_zcopy_send, "ZCOPY_THRESH=1",
-                                                  "RNDV_THRESH=-1")
+UCS_TEST_P(test_ucp_am_nbx_dts, zcopy_send, "ZCOPY_THRESH=1", "RNDV_THRESH=-1")
 {
     test_am(4 * UCS_KBYTE);
-}
-
-UCS_TEST_P(test_ucp_am_nbx_dts, long_zcopy_send, "ZCOPY_THRESH=1",
-                                                 "RNDV_THRESH=-1")
-{
     test_am(64 * UCS_KBYTE);
 }
 


### PR DESCRIPTION
## What
Combined `test_ucp_am_nbx_dts` tests with overlapping functionality.

## Why ?
The changes reduces the number of redundant tests and the testing time as well.
Addressed https://github.com/openucx/ucx/pull/8323#discussion_r901125577 .