### PR TITLE
GTEST/ROCM and UCM/ROCM: fixes for the v1.13 release

### DIFF
--- a/src/ucm/rocm/rocmmem.c
+++ b/src/ucm/rocm/rocmmem.c
@@ -111,24 +111,14 @@ hsa_status_t ucm_hsa_amd_memory_pool_allocate(
     hsa_amd_memory_pool_t memory_pool, size_t size,
     uint32_t flags, void** ptr)
 {
-    ucs_memory_type_t type = UCS_MEMORY_TYPE_ROCM;
-    uint32_t pool_flags    = 0;
     hsa_status_t status;
-
-    status = hsa_amd_memory_pool_get_info(memory_pool,
-                                          HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
-                                          &pool_flags);
-    if (status == HSA_STATUS_SUCCESS &&
-        !(pool_flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED)) {
-        type = UCS_MEMORY_TYPE_ROCM_MANAGED;
-    }
 
     ucm_event_enter();
 
     status = ucm_orig_hsa_amd_memory_pool_allocate(memory_pool, size, flags, ptr);
     if (status == HSA_STATUS_SUCCESS) {
         ucm_trace("ucm_hsa_amd_memory_pool_allocate(ptr=%p size:%lu)", *ptr, size);
-        ucm_dispatch_mem_type_alloc(*ptr, size, type);
+        ucm_dispatch_mem_type_alloc(*ptr, size, UCS_MEMORY_TYPE_UNKNOWN);
     }
 
     ucm_event_leave();

--- a/test/gtest/ucm/rocm_hooks.cc
+++ b/test/gtest/ucm/rocm_hooks.cc
@@ -69,7 +69,8 @@ protected:
                                 int expect_mem_type = UCS_MEMORY_TYPE_ROCM)  {
         ASSERT_EQ(ptr, alloc_event.mem_type.address);
         ASSERT_EQ(size, alloc_event.mem_type.size);
-        ASSERT_EQ(expect_mem_type, alloc_event.mem_type.mem_type);
+        EXPECT_TRUE((alloc_event.mem_type.mem_type == expect_mem_type) ||
+                    (alloc_event.mem_type.mem_type == UCS_MEMORY_TYPE_UNKNOWN));
     }
 
     void check_mem_free_events(void *ptr, size_t size,
@@ -147,48 +148,4 @@ UCS_TEST_F(rocm_hooks, test_hipMallocPitch) {
     ret = hipFree(dptr);
     ASSERT_EQ(ret, hipSuccess);
     check_mem_free_events((void *)dptr, 0);
-}
-
-UCS_TEST_F(rocm_hooks, test_hip_Malloc_Free) {
-    hipError_t ret;
-    void *ptr, *ptr1;
-
-    /* small allocation */
-    ret = hipMalloc(&ptr, 64);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events(ptr, 64);
-
-    ret = hipFree(ptr);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_free_events(ptr, 64);
-
-    /* large allocation */
-    ret = hipMalloc(&ptr, (256 * UCS_MBYTE));
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events(ptr, (256 * UCS_MBYTE));
-
-    ret = hipFree(ptr);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_free_events(ptr, (256 * UCS_MBYTE));
-
-    /* multiple allocations, rocmfree in reverse order */
-    ret = hipMalloc(&ptr, (1 * UCS_MBYTE));
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events(ptr, (1 * UCS_MBYTE));
-
-    ret = hipMalloc(&ptr1, (1 * UCS_MBYTE));
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events(ptr1, (1 * UCS_MBYTE));
-
-    ret = hipFree(ptr1);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_free_events(ptr1, (1 * UCS_MBYTE));
-
-    ret = hipFree(ptr);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_free_events(ptr, (1 * UCS_MBYTE));
-
-    /* hipFree with NULL */
-    ret = hipFree(NULL);
-    ASSERT_EQ(ret, hipSuccess);
 }


### PR DESCRIPTION
This pr brings a couple of fixes for the rocm components from master to the v1.13 branch

Specifically:
GTEST/UCM/ROCM: Fix is_rocm_managed_supported gtest  
(cherry picked from commit  https://github.com/openucx/ucx/commit/a049c271a7bb494cde5f38cf7f66725e1f13aae7)

UCT/ROCM/COPY: implement estimate_perf function 
(cherry picked form commit https://github.com/openucx/ucx/commit/21ca9045d2f1cc837c125170c1724804b583f8ab)

UCM/ROCM: delay memtype detection to md's 
(cherry picked from commit https://github.com/openucx/ucx/commit/ee3aee9cf4893360196a98162bb2cec699c4c8d7)


## Why ?
fixes existing issues and makes rocm gtests pass.