### PR TITLE
TEST/JENKINS: fixes missed space in configure line

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -125,7 +125,7 @@ build() {
 	config_args="--prefix=$ucx_inst --without-java"
 	if [ "X$have_cuda" == "Xyes" ]
 	then
-		config_args+="--with-iodemo-cuda"
+		config_args+=" --with-iodemo-cuda"
 	fi
 
 	../contrib/configure-${mode} ${config_args} "$@"


### PR DESCRIPTION
## What
```bash
2022-06-06T16:28:55.4988449Z + ../contrib/configure-devel --prefix=/__w/1/s/install --without-java--with-iodemo-cuda --enable-gtest
2022-06-06T16:28:55.6078392Z configure: WARNING: unrecognized options: --without-java--with-iodemo-cuda
```
