### PR TITLE
TOOLS/PERF: Simplify send command selection

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -404,28 +404,18 @@ public:
         /* coverity[switch_selector_expr_is_constant] */
         switch (CMD) {
         case UCX_PERF_CMD_TAG:
+            request = ucp_tag_send_nbx(ep, buffer, length, TAG, param);
+            break;
         case UCX_PERF_CMD_TAG_SYNC:
+            request = ucp_tag_send_sync_nbx(ep, buffer, length, TAG, param);
+            break;
         case UCX_PERF_CMD_STREAM:
+            request = ucp_stream_send_nbx(ep, buffer, length, param);
+            break;
         case UCX_PERF_CMD_AM:
-            /* coverity[switch_selector_expr_is_constant] */
-            switch (CMD) {
-            case UCX_PERF_CMD_TAG:
-                request = ucp_tag_send_nbx(ep, buffer, length, TAG, param);
-                break;
-            case UCX_PERF_CMD_TAG_SYNC:
-                request = ucp_tag_send_sync_nbx(ep, buffer, length, TAG, param);
-                break;
-            case UCX_PERF_CMD_STREAM:
-                request = ucp_stream_send_nbx(ep, buffer, length, param);
-                break;
-            case UCX_PERF_CMD_AM:
-                request = ucp_am_send_nbx(ep, AM_ID, m_perf.ucp.am_hdr,
-                                          m_perf.params.ucp.am_hdr_size, buffer,
-                                          length, param);
-                break;
-            default:
-                return UCS_ERR_INVALID_PARAM;
-            }
+            request = ucp_am_send_nbx(ep, AM_ID, m_perf.ucp.am_hdr,
+                                      m_perf.params.ucp.am_hdr_size, buffer,
+                                      length, param);
             break;
         case UCX_PERF_CMD_PUT:
             /* coverity[switch_selector_expr_is_constant] */


### PR DESCRIPTION
## What

Simplify send command selection in PERF utility.

## Why ?

Remove overcomplicated double switch-case for selecting send command.

## How ?

Merge two switch-cases for TAG, TAG_SYNC, STREAM and AM commands.