### PR TITLE
AZP: Kill own iodemo process in CI

### DIFF
--- a/test/apps/iodemo/run_io_demo.sh
+++ b/test/apps/iodemo/run_io_demo.sh
@@ -538,7 +538,7 @@ make_scripts()
 			}
 
 			kill_iodemo() {
-			    pids="\$(list_pids)"
+			    pids="\$(list_pids_with_role all)"
 			    [ -n "\${pids}" ] && kill -9 \${pids}
 			}
 


### PR DESCRIPTION
## Why ?
run_io_demo.sh can kill iodemo process from other test

## How ?
grep by IODEMO_ROLE (it's applicable only for process which launch via run_io_demo.sh
