### PR TITLE
UCT/TCP_SOCKCM: Fix printing peer address

### DIFF
--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -599,7 +599,7 @@ ucs_status_t ucs_sockaddr_get_ip_local_port_range(ucs_range_spec_t *port_range);
 
 
 /**
- * Get IP address of a given sockaddr structure.
+ * Get string representation of IP address of a given sockaddr structure.
  *
  * @param [in]  addr     Pointer to the sockaddr structure.
  * @param [out] str      A string filled with the IP address.

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -645,12 +645,14 @@ uct_tcp_sockcm_ep_server_invoke_conn_req_cb(uct_tcp_sockcm_ep_t *cep)
     conn_req_args.client_address = client_saddr;
     ucs_strncpy_safe(conn_req_args.dev_name, ifname_str, UCT_DEVICE_NAME_MAX);
 
-    ucs_debug("fd %d: remote_data: (field_mask=%"PRIu64") "
-              "dev_addr: %s (length=%zu), conn_priv_data_length=%zu",
-              cep->fd, remote_data.field_mask,
-              ucs_sockaddr_str((const struct sockaddr*)remote_data.dev_addr,
-                               peer_str, UCS_SOCKADDR_STRING_LEN),
-              remote_data.dev_addr_length, remote_data.conn_priv_data_length);
+    status = ucs_sockaddr_get_ipstr(client_saddr.addr, peer_str,
+                                    UCS_SOCKADDR_STRING_LEN);
+    ucs_assert(status == UCS_OK);
+    ucs_debug("fd %d, dev_addr: flags 0x%x length %zu %s %s,"
+              " conn_priv_data_length=%zu",
+              cep->fd, remote_dev_addr->flags, remote_data.dev_addr_length,
+              ucs_sockaddr_address_family_str(remote_dev_addr->sa_family),
+              peer_str, remote_data.conn_priv_data_length);
 
     /* the endpoint, passed as the conn_request to the callback, will be passed
      * to uct_ep_create() which will be invoked by the user and therefore moving


### PR DESCRIPTION
## What

Fix printing peer address in TCP_SOCKCM.

## Why ?

Before:
```
[1656422715.765136] [ldev-doca-15-bf:744208:a]   tcp_sockcm_ep.c:648  UCX  DEBUG fd 27: remote_data: (field_mask=15) dev_addr: <invalid address family> (length=6), conn_priv_data_length=47
```
After:
```
[1656424136.071887] [ldev-doca-15-bf:751731:a]   tcp_sockcm_ep.c:648  UCX  DEBUG fd 27: remote_data: (field_mask=15) dev_addr: 192.168.101.3:38158 (length=6), conn_priv_data_length=47
```

## How ?

Use `saddr` instead of `remote_data.dev_addr`, because `saddr` is `sockaddr`, but `remote_data.dev_addr` is `in_addr`/`in6_addr`.