### PR TITLE
UCP/WIREUP: Always pack TL resource indices into CM private data

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -645,7 +645,7 @@ ucp_ep_create_to_worker_addr(ucp_worker_h worker,
                              const ucp_tl_bitmap_t *local_tl_bitmap,
                              const ucp_unpacked_address_t *remote_address,
                              unsigned ep_init_flags, const char *message,
-                             ucp_ep_h *ep_p);
+                             unsigned *addr_indices, ucp_ep_h *ep_p);
 
 ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
                                          const ucp_conn_request_h conn_request,

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -124,6 +124,11 @@ int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             ucp_rsc_index_t rsc_index,
                             const ucp_address_entry_t *ae);
+void
+ucp_wireup_get_dst_rsc_indices(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
+                               const ucp_unpacked_address_t *remote_address,
+                               const unsigned *addr_indices,
+                               ucp_rsc_index_t *dst_rsc_indices);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    const ucp_tl_bitmap_t *local_tl_bitmap,

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -26,15 +26,18 @@ int ucp_ep_init_flags_has_cm(unsigned ep_init_flags);
 
 unsigned ucp_cm_client_try_next_cm_progress(void *arg);
 
+unsigned ucp_cm_address_pack_flags(ucp_worker_h worker);
+
 void ucp_cm_client_restore_ep(ucp_wireup_ep_t *wireup_cm_ep, ucp_ep_h ucp_ep);
 
-ucs_status_t ucp_ep_cm_connect_server_lane(ucp_ep_h ep,
-                                           uct_listener_h uct_listener,
-                                           uct_conn_request_h uct_conn_req,
-                                           ucp_rsc_index_t cm_idx,
-                                           const char *dev_name,
-                                           unsigned ep_init_flags,
-                                           ucp_object_version_t sa_data_version);
+ucs_status_t
+ucp_ep_cm_connect_server_lane(ucp_ep_h ep, uct_listener_h uct_listener,
+                              uct_conn_request_h uct_conn_req,
+                              ucp_rsc_index_t cm_idx, const char *dev_name,
+                              unsigned ep_init_flags,
+                              ucp_object_version_t sa_data_version,
+                              const ucp_unpacked_address_t *remote_address,
+                              const unsigned *addr_indices);
 
 ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
                                             const ucp_ep_params_t *params);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -22,7 +22,7 @@
 #include <ucp/core/ucp_request.inl>
 
 
-UCS_CLASS_DECLARE(ucp_wireup_ep_t, ucp_ep_h);
+UCS_CLASS_DECLARE(ucp_wireup_ep_t, ucp_ep_h, const ucp_rsc_index_t*);
 
 
 static UCS_CLASS_DEFINE_DELETE_FUNC(ucp_wireup_ep_t, uct_ep_t);
@@ -257,7 +257,7 @@ static ssize_t ucp_wireup_ep_am_bcopy(uct_ep_h uct_ep, uint8_t id,
 
 
 UCS_CLASS_DEFINE_NAMED_NEW_FUNC(ucp_wireup_ep_create, ucp_wireup_ep_t, uct_ep_t,
-                                ucp_ep_h);
+                                ucp_ep_h, const ucp_rsc_index_t*);
 
 void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
                            ucp_rsc_index_t rsc_index, int is_p2p)
@@ -404,7 +404,8 @@ static ucs_status_t ucp_wireup_ep_check(uct_ep_h uct_ep, unsigned flags,
 }
 
 
-UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
+UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep,
+                    const ucp_rsc_index_t *dst_rsc_indices)
 {
     static uct_iface_ops_t ops = {
         .ep_connect_to_ep    = ucp_wireup_ep_connect_to_ep,
@@ -448,7 +449,9 @@ UCS_CLASS_INIT_FUNC(ucp_wireup_ep_t, ucp_ep_h ucp_ep)
     UCS_BITMAP_CLEAR(&self->cm_resolve_tl_bitmap);
 
     for (lane = 0; lane < UCP_MAX_LANES; ++lane) {
-        self->dst_rsc_indices[lane] = UCP_NULL_RESOURCE;
+        self->dst_rsc_indices[lane] = (dst_rsc_indices != NULL) ?
+                                      dst_rsc_indices[lane] :
+                                      UCP_NULL_RESOURCE;
     }
 
     UCS_ASYNC_BLOCK(&ucp_ep->worker->async);

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -67,7 +67,9 @@ struct ucp_wireup_ep {
 /**
  * Create a proxy endpoint for wireup.
  */
-ucs_status_t ucp_wireup_ep_create(ucp_ep_h ep, uct_ep_h *ep_p);
+ucs_status_t ucp_wireup_ep_create(ucp_ep_h ep,
+                                  const ucp_rsc_index_t *dst_rsc_indices,
+                                  uct_ep_h *ep_p);
 
 
 /**

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -317,6 +317,12 @@ bool is_interface_usable(struct ifaddrs *ifa);
 
 
 /**
+ * Return the name of the given network device if it is supported by rdmacm.
+ */
+std::string get_rdmacm_netdev(const char *ifa_name);
+
+
+/**
  * Check if the given network device is supported by rdmacm.
  */
 bool is_rdmacm_netdev(const char *ifa_name);
@@ -370,10 +376,13 @@ public:
     sock_addr_storage();
 
     sock_addr_storage(const ucs_sock_addr_t &ucs_sock_addr,
-                      bool is_rdmacm_netdev = false);
+                      bool is_rdmacm_netdev = false,
+                      std::string netdev_name = "",
+                      std::string rdmacm_netdev_name = "");
 
     void set_sock_addr(const struct sockaddr &addr, const size_t size,
-                       bool is_rdmacm_netdev = false);
+                       bool is_rdmacm_netdev = false,
+                       std::string netdev_name = "");
 
     void reset_to_any();
 
@@ -384,6 +393,8 @@ public:
     uint16_t get_port() const;
 
     bool is_rdmacm_netdev() const;
+
+    std::string netdev_name() const;
 
     size_t get_addr_size() const;
 
@@ -400,6 +411,7 @@ private:
     size_t                  m_size;
     bool                    m_is_valid;
     bool                    m_is_rdmacm_netdev;
+    std::string             m_netdev_name;
 };
 
 

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -122,7 +122,7 @@ protected:
             std::vector<ucp_request_t*> pending_reqs;
 
             if (i < wireup_ep_count) {
-                status = ucp_wireup_ep_create(m_ucp_ep, &discard_ep);
+                status = ucp_wireup_ep_create(m_ucp_ep, NULL, &discard_ep);
                 ASSERT_UCS_OK(status);
 
                 wireup_eps.push_back(discard_ep);


### PR DESCRIPTION
## What

Always pack TL resource indices into CM private data.

## Why ?

TL resources must be packed into CM private data to make sure that `ucp_wireup_init_lanes()` uses correct destination resource indices to check config intersections.
1. `dst_rsc_indices` stored in CM wireup endpoint are by `UCP_NULL_RESOURCE`s when client's EP was created.
2. `dst_rsc_indices` are set to the proper values on a client after receiving CM private data from a server.
3. `dst_rsc_indices` will be used to check config intersections during WIREUP_MSG phase, if `UCX_CM_USE_ALL_DEVICES=y`

## How ?

1. Update `ucp_ep_create_server_accept()` to use `ucp_cm_address_pack_flags()` for unpacking remote worker address to make sure the same flags are used for packing/unpacking CM private data.
2. Update `UCP_ADDRESS_PACK_FLAGS_CM_DEFAULT` to include `UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX`.
3. Update `ucp_wireup_check_config_intersect()` to check that packed `dst_rsc_index` isn't `UCP_NULL_RESOURCE` on worker address.