### PR TITLE
UCT/IB/DC: Resend FC_HARD_REQ instead of scheduling EP on waitq

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.inl
+++ b/src/uct/ib/dc/dc_mlx5.inl
@@ -41,8 +41,7 @@ uct_dc_mlx5_get_arbiter_params(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
-                        int force)
+uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
         /* no dci:
@@ -50,7 +49,7 @@ uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
          * arbiter. This way we can assure fairness between all eps waiting for
          * dci allocation. Relevant for dcs and dcs_quota policies.
          */
-        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, force);
+        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
     } else {
         uct_dc_mlx5_iface_dci_sched_tx(iface, ep);
     }
@@ -84,5 +83,5 @@ uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
         return;
     }
 
-    uct_dc_mlx5_ep_schedule(iface, ep, 0);
+    uct_dc_mlx5_ep_schedule(iface, ep);
 }

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1493,17 +1493,12 @@ static unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
      * resend FC_HARD_REQ packet to make sure a peer will resend FC_PURE_GRANT
      * packet in case of failure on the remote FC endpoint */
     kh_foreach_key(&iface->tx.fc_hash, ep_key, {
-        ep = (uct_dc_mlx5_ep_t*)ep_key;
-
-        /* Allocate DCI for the endpoint to schedule the endpoint to DCI wait
-         * queue if there is free DCI */
-        status = uct_dc_mlx5_iface_dci_get(iface, ep);
-        ucs_assertv((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE),
-                    "%s", ucs_status_string(status));
-
-        /* Force DCI scheduling, since FC resources may never become available
-         * unless we send FC_HARD_REQ packet */
-        uct_dc_mlx5_ep_schedule(iface, ep, 1);
+        ep     = (uct_dc_mlx5_ep_t*)ep_key;
+        status = uct_dc_mlx5_ep_check_fc(iface, ep);
+        if ((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE)) {
+            ucs_warn("ep %p: flow-control check failed: %s", ep,
+                     ucs_status_string(status));
+        }
     })
 
     return 1;
@@ -1623,7 +1618,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
             /* Since DCI isn't assigned for the FC endpoint, schedule DCI
              * allocation for progressing possible FC_PURE_GRANT re-sending
              * operation which are scheduled on the pending queue */
-            uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, 0);
+            uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
         }
     }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -378,13 +378,12 @@ static inline int uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
 
 static UCS_F_ALWAYS_INLINE
 void uct_dc_mlx5_iface_schedule_dci_alloc(uct_dc_mlx5_iface_t *iface,
-                                          uct_dc_mlx5_ep_t *ep, int force)
+                                          uct_dc_mlx5_ep_t *ep)
 {
     ucs_arbiter_t *waitq;
 
-    /* If FC window is empty and force scheduling wasn't requested, the group
-     * will be scheduled when grant is received */
-    if (force || uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
+    /* If FC window is empty the group will be scheduled when grant is received */
+    if (uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
         waitq = uct_dc_mlx5_iface_dci_waitq(iface, uct_dc_mlx5_ep_pool_index(ep));
         ucs_arbiter_group_schedule(waitq, &ep->arb_group);
     }
@@ -472,7 +471,7 @@ uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
      * move the group to the 'wait for dci alloc' state
      */
     ucs_arbiter_group_desched(uct_dc_mlx5_iface_tx_waitq(iface), &ep->arb_group);
-    uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, 0);
+    uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
 }
 
 static inline void uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)


### PR DESCRIPTION
## Why
Fix "timeout waiting for replies" in IO-demo (30 iterations passed successfully with the fix).
Happened because all DCIs were acquired by endpoints for sending FC hard requests, but did not actually send them, because no UCT-API operations were done on these endpoints.

## How 
1. Partially revert changes from #8169 and #8289 PRs.
2. Invoked `uct_dc_mlx5_ep_check_fc` from `uct_dc_mlx5_ep_fc_hard_req_progress`'s loop over all EPs added to FC hash.

## Details 
UCT user may not have pending operations scheduled, but FC_HARD_REQ could be posted and then resend.
If DC transport will acquire DCI, it couldn't be used at all if user doesn't post new operations and no pending operations scheduled.
The following scenario was observed:
`FC_HARD_LIMIT` was reached on DC endpoint and `FC_HARD_REQ` packet was sent. But it took some time to receive `FC_GRANT` from a peer, so the endpoint did resend of `FC_HARD_REQ`, but no pending operation were scheduled on the endpoint - so, DCI was acquired, but not released. And finally, `FC_GRANT` was received and FC window was restored on the endpoint. S, this DCI was acquired by the endpoint forever, because IO-demo did not schedule new operations.

