### PR TITLE
UCP/PROTO/RNDV: Fix order in sys_distance array

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -74,9 +74,11 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
             continue;
         }
 
-        mem_sys_dev   = params->super.super.select_param->sys_dev;
         *sys_dev_map |= UCS_BIT(ep_sys_dev);
+    }
 
+    mem_sys_dev = params->super.super.select_param->sys_dev;
+    ucs_for_each_bit(ep_sys_dev, *sys_dev_map) {
         status = ucs_topo_get_distance(mem_sys_dev, ep_sys_dev, sys_distance);
         ucs_assertv_always(status == UCS_OK, "mem_info->sys_dev=%d sys_dev=%d",
                            mem_sys_dev, ep_sys_dev);


### PR DESCRIPTION
## Why
Fix protocol v2 performance issue where cuda_ipc is not selected because it's "remote system" distance is considered lower than it actually is

## How
The issue is that the order in rpriv->sys_distance array is according to lanes order, but it should actually be according to the order of bits in sys_dev_map. This wrong order caused a mixup between the system distance of cuda_ipc and mlx5_0. This fix is to first generate the map, and then populate the distance array according to bits order.

cc @Akshay-Venkatesh 

Before:
![image](https://user-images.githubusercontent.com/2255631/177017207-650baf5e-8bd5-4c0e-8251-d4d6c35a7cf0.png)

After:
![image](https://user-images.githubusercontent.com/2255631/177017235-3fe09515-22c1-4ca3-be63-ce3a996479fd.png)
