### PR TITLE
UCT/IB/DC: Fix handling of return value of checking FC

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1574,7 +1574,7 @@ static unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
     kh_foreach_key(&iface->tx.fc_hash, ep_key, {
         ep     = (uct_dc_mlx5_ep_t*)ep_key;
         status = uct_dc_mlx5_ep_check_fc(iface, ep);
-        if ((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE)) {
+        if ((status != UCS_OK) && (status != UCS_ERR_NO_RESOURCE)) {
             ucs_warn("ep %p: flow-control check failed: %s", ep,
                      ucs_status_string(status));
         }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -666,7 +666,7 @@ void test_rc_flow_control::test_general(int wnd, int soft_thresh,
     flush();
 }
 
-void test_rc_flow_control::test_pending_grant(int wnd)
+void test_rc_flow_control::test_pending_grant(int wnd, uint64_t *wait_fc_seq)
 {
     /* Block send capabilities of m_e2 for fc grant to be
      * added to the pending queue. */
@@ -679,6 +679,12 @@ void test_rc_flow_control::test_pending_grant(int wnd)
      * should be in pending queue of m_e2. */
     send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
     EXPECT_LE(get_fc_ptr(m_e1)->fc_wnd, 0);
+
+    if (wait_fc_seq != NULL) {
+        uint64_t fc_seq_value = *wait_fc_seq;
+        wait_for_value(wait_fc_seq, fc_seq_value + 1, true);
+        EXPECT_GT(*wait_fc_seq, fc_seq_value);
+    }
 
     /* Enable send capabilities of m_e2 and send short put message to force
      * pending queue dispatch. Can't send AM message for that, because it may

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -136,7 +136,7 @@ public:
 
     void test_general(int wnd, int s_thresh, int h_thresh, bool is_fc_enabled);
 
-    void test_pending_grant(int wnd);
+    virtual void test_pending_grant(int wnd, uint64_t *wait_fc_seq = NULL);
 
     void test_pending_purge(int wnd, int num_pend_sends);
 


### PR DESCRIPTION
## What

Fix handling of return value of checking FC.

## Why ?

The if condition should be reverted.

## How ?

Replace `((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE))` by `((status != UCS_OK) && (status != UCS_ERR_NO_RESOURCE))`.