### PR TITLE
UCP/CORE: Support up to eight EP lanes

### DIFF
--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -63,8 +63,8 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
         am_id = UCP_AM_ID_AM_SINGLE;
     }
 
-    status = uct_ep_am_short_iov(ucp_ep_get_lane(req->send.ep,
-                                                 spriv->super.lane),
+    status = uct_ep_am_short_iov(ucp_ep_get_fast_lane(req->send.ep,
+                                                      spriv->super.lane),
                                  am_id, iov, iov_cnt);
     if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
         req->send.lane = spriv->super.lane; /* for pending add */
@@ -208,7 +208,7 @@ ucp_am_eager_single_bcopy_proto_progress(uct_pending_req_t *self)
     return ucp_proto_am_bcopy_single_progress(
             req, UCP_AM_ID_AM_SINGLE, spriv->super.lane,
             ucp_am_eager_single_bcopy_pack, req, SIZE_MAX,
-            ucp_proto_request_bcopy_complete_success);
+            ucp_proto_request_bcopy_complete_success, 1);
 }
 
 static ucs_status_t ucp_am_eager_single_bcopy_proto_init_common(
@@ -282,7 +282,7 @@ ucp_am_eager_single_bcopy_reply_proto_progress(uct_pending_req_t *self)
     return ucp_proto_am_bcopy_single_progress(
             req, UCP_AM_ID_AM_SINGLE_REPLY, spriv->super.lane,
             ucp_am_eager_single_bcopy_reply_pack, req, SIZE_MAX,
-            ucp_proto_request_bcopy_complete_success);
+            ucp_proto_request_bcopy_complete_success, 1);
 }
 
 ucp_proto_t ucp_am_eager_single_bcopy_reply_proto = {
@@ -350,7 +350,8 @@ ucp_am_eager_single_zcopy_send_func(ucp_request_t *req,
     ucp_am_eager_zcopy_add_footer(req, 0, spriv->super.md_index, iov, &iovcnt,
                                   req->send.msg_proto.am.header.length);
 
-    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
+    return uct_ep_am_zcopy(ucp_ep_get_fast_lane(req->send.ep,
+                                                spriv->super.lane),
                            UCP_AM_ID_AM_SINGLE, &hdr, sizeof(hdr), iov, iovcnt,
                            0, &req->send.state.uct_comp);
 }
@@ -418,7 +419,8 @@ ucp_am_eager_single_zcopy_reply_send_func(ucp_request_t *req,
                                   req->send.msg_proto.am.header.length +
                                           sizeof(*ftr));
 
-    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
+    return uct_ep_am_zcopy(ucp_ep_get_fast_lane(req->send.ep,
+                                                spriv->super.lane),
                            UCP_AM_ID_AM_SINGLE_REPLY, &hdr, sizeof(hdr), iov,
                            iovcnt, 0, &req->send.state.uct_comp);
 }

--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -46,7 +46,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
                    req->send.msg_proto.am.header.length;
     return UCS_PROFILE_CALL(ucp_proto_am_bcopy_single_progress, req,
                             UCP_AM_ID_RNDV_RTS, rpriv->lane,
-                            ucp_am_rndv_rts_pack, req, max_rts_size, NULL);
+                            ucp_am_rndv_rts_pack, req, max_rts_size, NULL, 0);
 }
 
 ucs_status_t ucp_am_rndv_rts_init(const ucp_proto_init_params_t *init_params)

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -492,6 +492,12 @@ typedef struct ucp_ep_ext {
         ucs_queue_head_t          mid_rdesc_q;    /* Queue of middle fragments, which
                                                      arrived before the first one */
     } am;
+
+    /**
+     * UCT endpoints for every slow-path lane that has no room in the base endpoint
+     * structure. TODO allocate this array dynamically.
+     */
+    uct_ep_h                      uct_eps[UCP_MAX_SLOW_PATH_LANES];
 } ucp_ep_ext_t;
 
 
@@ -507,9 +513,8 @@ typedef struct ucp_ep {
     ucp_ep_match_conn_sn_t        conn_sn;       /* Sequence number for remote connection */
     ucp_lane_index_t              am_lane;       /* Cached value */
     ucp_ep_flags_t                flags;         /* Endpoint flags */
-
-    /* TODO allocate ep dynamically according to number of lanes */
-    uct_ep_h                      uct_eps[UCP_MAX_LANES]; /* Transports for every lane */
+    /* Transports for every lane */
+    uct_ep_h                      uct_eps[UCP_MAX_FAST_PATH_LANES];
     ucp_ep_ext_t                  *ext;                   /* Endpoint extension */
 
 #if ENABLE_DEBUG_DATA

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -40,7 +40,10 @@ UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 
 /* Lanes */
-#define UCP_MAX_LANES                5
+#define UCP_MAX_LANES                8
+#define UCP_MAX_FAST_PATH_LANES      5
+#define UCP_MAX_SLOW_PATH_LANES      (UCP_MAX_LANES - UCP_MAX_FAST_PATH_LANES)
+
 #define UCP_NULL_LANE                ((ucp_lane_index_t)-1)
 typedef uint8_t                      ucp_lane_index_t;
 typedef uint8_t                      ucp_lane_map_t;

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -71,7 +71,7 @@ ucp_do_am_single(uct_pending_req_t *self, uint8_t am_id,
                     "packed_len=%zd max_packed_size=%zu", packed_len,
                     max_packed_size);
 
-        return uct_ep_am_short(ucp_ep_get_lane(ep, req->send.lane), am_id,
+        return uct_ep_am_short(ucp_ep_get_fast_lane(ep, req->send.lane), am_id,
                                buffer[0], &buffer[1],
                                packed_len - sizeof(uint64_t));
     } else {

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -46,7 +46,7 @@ ucp_do_am_bcopy_single(uct_pending_req_t *self, uint8_t am_id,
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len     = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+    packed_len     = uct_ep_am_bcopy(ucp_ep_get_fast_lane(ep, req->send.lane),
                                      am_id, pack_cb, req, 0);
     if (ucs_unlikely(packed_len < 0)) {
         /* Reset the state to the previous one */

--- a/src/ucp/rma/amo_basic.c
+++ b/src/ucp/rma/amo_basic.c
@@ -43,12 +43,12 @@ static ucs_status_t ucp_amo_basic_progress_post(uct_pending_req_t *self)
     req->send.lane = rkey->cache.amo_lane;
     if (req->send.length == sizeof(uint64_t)) {
         status = UCS_PROFILE_CALL(uct_ep_atomic64_post,
-                                  ucp_ep_get_lane(ep, req->send.lane), op,
+                                  ucp_ep_get_fast_lane(ep, req->send.lane), op,
                                   value, remote_addr, rkey->cache.amo_rkey);
     } else {
         ucs_assert(req->send.length == sizeof(uint32_t));
         status = UCS_PROFILE_CALL(uct_ep_atomic32_post,
-                                  ucp_ep_get_lane(ep, req->send.lane), op,
+                                  ucp_ep_get_fast_lane(ep, req->send.lane), op,
                                   value, remote_addr, rkey->cache.amo_rkey);
     }
 
@@ -68,7 +68,7 @@ static ucs_status_t ucp_amo_basic_progress_fetch(uct_pending_req_t *self)
     ucs_status_t status;
 
     req->send.lane = rkey->cache.amo_lane;
-    uct_ep         = ucp_ep_get_lane(ep, req->send.lane);
+    uct_ep         = ucp_ep_get_fast_lane(ep, req->send.lane);
     if (req->send.length == sizeof(uint64_t)) {
         if (op != UCT_ATOMIC_OP_CSWAP) {
             status = uct_ep_atomic64_fetch(uct_ep, op, value, result,

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -61,7 +61,7 @@ ucp_proto_amo_progress(uct_pending_req_t *self, ucp_operation_id_t op_id,
     uct_rkey_t tl_rkey;
 
     req->send.lane = spriv->super.lane;
-    uct_ep         = ucp_ep_get_lane(ep, req->send.lane);
+    uct_ep         = ucp_ep_get_fast_lane(ep, req->send.lane);
     tl_rkey        = ucp_rkey_get_tl_rkey(req->send.rma.rkey,
                                           spriv->super.rkey_index);
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -133,7 +133,7 @@ static ucs_status_t ucp_progress_atomic_reply(uct_pending_req_t *self)
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len     = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+    packed_len     = uct_ep_am_bcopy(ucp_ep_get_fast_lane(ep, req->send.lane),
                                      UCP_AM_ID_ATOMIC_REP,
                                      ucp_amo_sw_pack_atomic_reply, req, 0);
 

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -63,7 +63,7 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
     status = ucp_proto_am_bcopy_single_progress(
             req, UCP_AM_ID_GET_REQ, spriv->super.lane,
             ucp_proto_get_am_bcopy_pack, req, sizeof(ucp_get_req_hdr_t),
-            ucp_proto_get_am_bcopy_complete);
+            ucp_proto_get_am_bcopy_complete, 0);
     if (status != UCS_OK) {
         ucp_worker_flush_ops_count_dec(worker);
     }

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -27,7 +27,7 @@ static ucs_status_t ucp_proto_put_offload_short_progress(uct_pending_req_t *self
     uct_rkey_t tl_rkey;
 
     tl_rkey = ucp_rkey_get_tl_rkey(req->send.rma.rkey, spriv->super.rkey_index);
-    status  = uct_ep_put_short(ucp_ep_get_lane(ep, spriv->super.lane),
+    status  = uct_ep_put_short(ucp_ep_get_fast_lane(ep, spriv->super.lane),
                                req->send.state.dt_iter.type.contig.buffer,
                                req->send.state.dt_iter.length,
                                req->send.rma.remote_addr, tl_rkey);

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -113,7 +113,7 @@ ucp_rma_sw_do_am_bcopy(ucp_request_t *req, uint8_t id, ucp_lane_index_t lane,
      * able to complete the remote request operation inside uct_ep_am_bcopy()
      * and decrement the flush_ops_count before it was incremented */
     ucp_worker_flush_ops_count_inc(ep->worker);
-    packed_len = uct_ep_am_bcopy(ucp_ep_get_lane(ep, lane),
+    packed_len = uct_ep_am_bcopy(ucp_ep_get_fast_lane(ep, lane),
                                  id, pack_cb, pack_arg, 0);
     if (packed_len > 0) {
         if (packed_len_p != NULL) {

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -233,7 +233,8 @@ ucp_put_send_short(ucp_ep_h ep, const void *buffer, size_t length,
 
     tl_rkey = ucp_rkey_get_tl_rkey(rkey, rkey_config->put_short.rkey_index);
     return UCS_PROFILE_CALL(uct_ep_put_short,
-                            ucp_ep_get_lane(ep, rkey_config->put_short.lane),
+                            ucp_ep_get_fast_lane(ep,
+                                                 rkey_config->put_short.lane),
                             buffer, length, remote_addr, tl_rkey);
 }
 
@@ -297,10 +298,10 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
         /* Fast path for a single short message */
         if (ucs_likely(!(attr_mask & UCP_OP_ATTR_FLAG_NO_IMM_CMPL) &&
                        ((ssize_t)count <= rkey->cache.max_put_short))) {
-            status = UCS_PROFILE_CALL(uct_ep_put_short,
-                                      ucp_ep_get_lane(ep, rkey->cache.rma_lane),
-                                      buffer, count, remote_addr,
-                                      rkey->cache.rma_rkey);
+            status = UCS_PROFILE_CALL(
+                    uct_ep_put_short,
+                    ucp_ep_get_fast_lane(ep, rkey->cache.rma_lane), buffer,
+                    count, remote_addr, rkey->cache.rma_rkey);
             if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
                 ret = UCS_STATUS_PTR(status);
                 goto out_unlock;

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -117,7 +117,7 @@ static ucs_status_t ucp_progress_rma_cmpl(uct_pending_req_t *self)
 
     req->send.lane = ucp_ep_get_am_lane(ep);
 
-    packed_len = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+    packed_len = uct_ep_am_bcopy(ucp_ep_get_fast_lane(ep, req->send.lane),
                                  UCP_AM_ID_CMPL, ucp_rma_sw_pack_rma_ack, req,
                                  0);
     if (packed_len < 0) {
@@ -207,7 +207,7 @@ static ucs_status_t ucp_progress_get_reply(uct_pending_req_t *self)
     ssize_t packed_len, payload_len;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    packed_len     = uct_ep_am_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+    packed_len     = uct_ep_am_bcopy(ucp_ep_get_fast_lane(ep, req->send.lane),
                                      UCP_AM_ID_GET_REP, ucp_rma_sw_pack_get_reply,
                                      req, 0);
     if (packed_len < 0) {

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -138,7 +138,7 @@ static size_t UCS_F_ALWAYS_INLINE ucp_proto_rndv_ack_progress(
     return ucp_proto_am_bcopy_single_progress(req, am_id, apriv->lane,
                                               pack_func, req,
                                               sizeof(ucp_rndv_ack_hdr_t),
-                                              complete_func);
+                                              complete_func, 0);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -137,8 +137,8 @@ ucp_proto_rndv_put_common_atp_send(ucp_request_t *req, ucp_lane_index_t lane)
 
     return ucp_proto_am_bcopy_single_send(req, UCP_AM_ID_RNDV_ATP, lane,
                                           ucp_proto_rndv_put_common_pack_atp,
-                                          &pack_ctx,
-                                          sizeof(ucp_rndv_ack_hdr_t));
+                                          &pack_ctx, sizeof(ucp_rndv_ack_hdr_t),
+                                          0);
 }
 
 static ucs_status_t

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -91,7 +91,7 @@ static ucs_status_t ucp_proto_rndv_rtr_common_send(ucp_request_t *req)
     max_rtr_size = sizeof(ucp_rndv_rtr_hdr_t) + rpriv->super.packed_rkey_size;
     return ucp_proto_am_bcopy_single_progress(req, UCP_AM_ID_RNDV_RTR,
                                               rpriv->super.lane, rpriv->pack_cb,
-                                              req, max_rtr_size, NULL);
+                                              req, max_rtr_size, NULL, 0);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -26,7 +26,8 @@ static ucs_status_t ucp_eager_short_progress(uct_pending_req_t *self)
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
     ucs_status_t status;
 
-    status = uct_ep_am_short(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
+    status = uct_ep_am_short(ucp_ep_get_fast_lane(req->send.ep,
+                                                  spriv->super.lane),
                              UCP_AM_ID_EAGER_ONLY, req->send.msg_proto.tag,
                              req->send.state.dt_iter.type.contig.buffer,
                              req->send.state.dt_iter.length);
@@ -110,7 +111,7 @@ static ucs_status_t ucp_eager_bcopy_single_progress(uct_pending_req_t *self)
 
     return ucp_proto_am_bcopy_single_progress(
             req, UCP_AM_ID_EAGER_ONLY, spriv->super.lane, ucp_eager_single_pack,
-            req, SIZE_MAX, ucp_proto_request_bcopy_complete_success);
+            req, SIZE_MAX, ucp_proto_request_bcopy_complete_success, 1);
 }
 
 static ucs_status_t
@@ -199,7 +200,8 @@ ucp_proto_eager_zcopy_send_func(ucp_request_t *req,
         .super.tag = req->send.msg_proto.tag
     };
 
-    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
+    return uct_ep_am_zcopy(ucp_ep_get_fast_lane(req->send.ep,
+                                                spriv->super.lane),
                            UCP_AM_ID_EAGER_ONLY, &hdr, sizeof(hdr), iov, 1, 0,
                            &req->send.state.uct_comp);
 }

--- a/src/ucp/tag/eager_snd.c
+++ b/src/ucp/tag/eager_snd.c
@@ -121,7 +121,7 @@ static ucs_status_t ucp_tag_eager_contig_short(uct_pending_req_t *self)
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_am_lane(ep);
-    status         = uct_ep_am_short(ucp_ep_get_lane(ep, req->send.lane),
+    status         = uct_ep_am_short(ucp_ep_get_fast_lane(ep, req->send.lane),
                                      UCP_AM_ID_EAGER_ONLY, req->send.msg_proto.tag,
                                      req->send.buffer, req->send.length);
     return ucp_am_short_handle_status_from_pending(req, status);

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -472,10 +472,9 @@ static ucs_status_t ucp_tag_offload_eager_short(uct_pending_req_t *self)
     ucs_status_t status;
 
     req->send.lane = ucp_ep_get_tag_lane(ep);
-    status         = uct_ep_tag_eager_short(ucp_ep_get_lane(ep, req->send.lane),
-                                            req->send.msg_proto.tag,
-                                            req->send.buffer,
-                                            req->send.length);
+    status = uct_ep_tag_eager_short(ucp_ep_get_fast_lane(ep, req->send.lane),
+                                    req->send.msg_proto.tag, req->send.buffer,
+                                    req->send.length);
     if (status == UCS_OK) {
         ucp_request_complete_send(req, UCS_OK);
     }
@@ -490,7 +489,8 @@ ucp_do_tag_offload_bcopy(uct_pending_req_t *self, uint64_t imm_data)
     ssize_t packed_len;
 
     req->send.lane = ucp_ep_get_tag_lane(ep);
-    packed_len     = uct_ep_tag_eager_bcopy(ucp_ep_get_lane(ep, req->send.lane),
+    packed_len     = uct_ep_tag_eager_bcopy(ucp_ep_get_fast_lane(ep,
+                                                                 req->send.lane),
                                             req->send.msg_proto.tag, imm_data,
                                             ucp_tag_offload_pack_eager, req, 0);
     if (packed_len < 0) {
@@ -517,7 +517,7 @@ ucp_do_tag_offload_zcopy(uct_pending_req_t *self, uint64_t imm_data,
                         req->send.buffer, req->send.datatype, req->send.length,
                         ucp_ep_md_index(ep, req->send.lane), NULL);
 
-    status = uct_ep_tag_eager_zcopy(ucp_ep_get_lane(ep, req->send.lane),
+    status = uct_ep_tag_eager_zcopy(ucp_ep_get_fast_lane(ep, req->send.lane),
                                     req->send.msg_proto.tag, imm_data, iov,
                                     iovcnt, 0, &req->send.state.uct_comp);
 

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -23,7 +23,7 @@ ucp_proto_eager_tag_offload_short_progress(uct_pending_req_t *self)
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
     ucs_status_t status;
 
-    status = uct_ep_tag_eager_short(ucp_ep_get_lane(ep, spriv->super.lane),
+    status = uct_ep_tag_eager_short(ucp_ep_get_fast_lane(ep, spriv->super.lane),
                                     req->send.msg_proto.tag,
                                     req->send.state.dt_iter.type.contig.buffer,
                                     req->send.state.dt_iter.length);
@@ -105,8 +105,8 @@ ucp_proto_eager_tag_offload_bcopy_common(ucp_request_t *req,
 {
     ssize_t packed_len;
 
-    packed_len = uct_ep_tag_eager_bcopy(ucp_ep_get_lane(req->send.ep,
-                                                        spriv->super.lane),
+    packed_len = uct_ep_tag_eager_bcopy(ucp_ep_get_fast_lane(req->send.ep,
+                                                             spriv->super.lane),
                                         req->send.msg_proto.tag, imm_data,
                                         ucp_eager_tag_offload_pack, req, 0);
 
@@ -268,8 +268,8 @@ ucp_proto_tag_offload_zcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_single_priv_t *spriv,
                                       uct_iov_t *iov)
 {
-    return uct_ep_tag_eager_zcopy(ucp_ep_get_lane(req->send.ep,
-                                                  spriv->super.lane),
+    return uct_ep_tag_eager_zcopy(ucp_ep_get_fast_lane(req->send.ep,
+                                                       spriv->super.lane),
                                   req->send.msg_proto.tag, 0ul, iov, 1, 0,
                                   &req->send.state.uct_comp);
 }
@@ -308,8 +308,8 @@ ucp_proto_tag_offload_zcopy_sync_send_func(ucp_request_t *req,
                                            const ucp_proto_single_priv_t *spriv,
                                            uct_iov_t *iov)
 {
-    return uct_ep_tag_eager_zcopy(ucp_ep_get_lane(req->send.ep,
-                                                  spriv->super.lane),
+    return uct_ep_tag_eager_zcopy(ucp_ep_get_fast_lane(req->send.ep,
+                                                       spriv->super.lane),
                                   req->send.msg_proto.tag,
                                   ucp_send_request_get_ep_remote_id(req), iov,
                                   1, 0, &req->send.state.uct_comp);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -143,7 +143,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
     return UCS_PROFILE_CALL(ucp_proto_am_bcopy_single_progress, req,
                             UCP_AM_ID_RNDV_RTS, rpriv->lane,
                             ucp_tag_rndv_proto_rts_pack, req, max_rts_size,
-                            NULL);
+                            NULL, 0);
 }
 
 ucs_status_t ucp_tag_rndv_rts_init(const ucp_proto_init_params_t *init_params)

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -61,7 +61,6 @@ typedef struct {
     uint64_t              local_dev_bitmap;
     uint64_t              remote_dev_bitmap;
     ucp_md_map_t          md_map;
-    ucp_lane_type_t       lane_type;
     unsigned              max_lanes;
 } ucp_wireup_select_bw_info_t;
 
@@ -354,6 +353,13 @@ ucp_wireup_init_select_info(double score, unsigned addr_index,
     select_info->priority   = priority;
 }
 
+static size_t ucp_wireup_max_lanes(ucp_lane_type_t lane_type)
+{
+    return ucp_wireup_lane_type_is_fast_path(lane_type) ?
+                   UCP_MAX_FAST_PATH_LANES :
+                   UCP_MAX_LANES;
+}
+
 /**
  * Get bitmap of memory types that Memory Domain can be registered with taking
  * into account context's maps of Memory Domains that provide registration for
@@ -563,7 +569,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             continue;
         }
 
-        if (select_ctx->num_lanes < UCP_MAX_LANES) {
+        if (select_ctx->num_lanes < ucp_wireup_max_lanes(criteria->lane_type)) {
             /* If we have not reached the lanes limit, we can select any
                combination of rsc_index/addr_index */
             rsc_addr_index_map = addr_index_map;
@@ -677,6 +683,20 @@ ucp_wireup_tl_iface_latency(ucp_context_h context,
     }
 }
 
+static int ucp_wireup_has_slow_lanes(ucp_wireup_select_context_t *select_ctx)
+{
+    ucp_wireup_lane_desc_t *lane_desc;
+
+    ucs_carray_for_each(lane_desc, select_ctx->lane_descs,
+                        select_ctx->num_lanes) {
+        if (!ucp_wireup_lane_types_has_fast_path(lane_desc->lane_types)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_lane_desc(
         const ucp_wireup_select_info_t *select_info,
         ucp_md_index_t dst_md_index, ucs_sys_device_t dst_sys_dev,
@@ -720,7 +740,15 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_lane_desc(
         }
     }
 
-    if (select_ctx->num_lanes >= UCP_MAX_LANES) {
+    /* We rely on 'ucp_wireup_search_lanes' to add fast lanes before slow
+     * lanes, so that all fast lanes are inserted to the cached ucp_ep
+     * structure */
+    if (ucp_wireup_lane_type_is_fast_path(lane_type)) {
+        /* assert we don't have slow lanes until we finished with fast lanes */
+        ucs_assert_always(!ucp_wireup_has_slow_lanes(select_ctx));
+    }
+
+    if (select_ctx->num_lanes >= ucp_wireup_max_lanes(lane_type)) {
         log_level = show_error ? UCS_LOG_LEVEL_ERROR : UCS_LOG_LEVEL_DEBUG;
         ucs_log(log_level, "cannot add %s lane - reached limit (%d)",
                 ucp_lane_type_info[lane_type].short_name,
@@ -853,6 +881,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
     mem_criteria.local_md_flags  = UCT_MD_FLAG_REG | criteria->local_md_flags;
     mem_criteria.alloc_mem_types = 0;
     mem_criteria.reg_mem_types   = UCS_BIT(mem_type);
+    mem_criteria.lane_type       = lane_type;
 
     status = ucp_wireup_select_transport(select_ctx, select_params,
                                          &mem_criteria, tl_bitmap,
@@ -890,6 +919,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
     mem_criteria.local_md_flags  = UCT_MD_FLAG_ALLOC | criteria->local_md_flags;
     mem_criteria.alloc_mem_types = UCS_BIT(mem_type);
     mem_criteria.reg_mem_types   = 0;
+    mem_criteria.lane_type       = lane_type;
 
     for (;;) {
         status = ucp_wireup_select_transport(select_ctx, select_params,
@@ -986,6 +1016,7 @@ static void ucp_wireup_fill_aux_criteria(ucp_wireup_criteria_t *criteria,
     criteria->remote_event_flags      = 0;
     criteria->calc_score              = ucp_wireup_aux_score_func;
     criteria->tl_rsc_flags            = UCP_TL_RSC_FLAG_AUX; /* Can use aux transports */
+    criteria->lane_type               = UCP_LANE_TYPE_LAST;
 
     ucp_wireup_fill_peer_err_criteria(criteria, ep_init_flags);
 }
@@ -1294,14 +1325,15 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
     for (;;) {
         ucp_wireup_criteria_init(&criteria);
         criteria.title              = "active messages";
-        ucp_wireup_init_select_flags(&criteria.remote_iface_flags,
-                                     UCP_ADDR_IFACE_FLAG_AM_SYNC, 0);
         criteria.calc_score         = ucp_wireup_am_score_func;
+        criteria.lane_type          = UCP_LANE_TYPE_AM;
         criteria.tl_rsc_flags       =
                 (ep_init_flags & UCP_EP_INIT_ALLOW_AM_AUX_TL) ?
                 UCP_TL_RSC_FLAG_AUX : 0;
         ucp_wireup_init_select_flags(&criteria.local_iface_flags,
                                      UCT_IFACE_FLAG_AM_BCOPY, 0);
+        ucp_wireup_init_select_flags(&criteria.remote_iface_flags,
+                                     UCP_ADDR_IFACE_FLAG_AM_SYNC, 0);
         ucp_wireup_fill_peer_err_criteria(&criteria,
                                           ucp_wireup_ep_init_flags(select_params,
                                                                    select_ctx));
@@ -1403,9 +1435,9 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
             dev_index        = context->tl_rscs[rsc_index].dev_index;
             sinfo.path_index = dev_count.local[dev_index];
             show_error       = (num_lanes == 0);
-            status = ucp_wireup_add_lane(select_params, &sinfo,
-                                         bw_info->lane_type, show_error,
-                                         select_ctx);
+            status           = ucp_wireup_add_lane(select_params, &sinfo,
+                                                   bw_info->criteria.lane_type,
+                                                   show_error, select_ctx);
             if (status != UCS_OK) {
                 break;
             }
@@ -1466,6 +1498,7 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_wireup_criteria_init(&bw_info.criteria);
     bw_info.criteria.title              = "high-bw active messages";
     bw_info.criteria.calc_score         = ucp_wireup_am_bw_score_func;
+    bw_info.criteria.lane_type          = UCP_LANE_TYPE_AM_BW;
     ucp_wireup_init_select_flags(&bw_info.criteria.remote_iface_flags,
                                  UCP_ADDR_IFACE_FLAG_AM_SYNC, 0);
     ucp_wireup_init_select_flags(&bw_info.criteria.local_iface_flags,
@@ -1481,7 +1514,6 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
     bw_info.remote_dev_bitmap = UINT64_MAX;
     bw_info.md_map            = 0;
     bw_info.max_lanes         = context->config.ext.max_eager_lanes - 1;
-    bw_info.lane_type         = UCP_LANE_TYPE_AM_BW;
 
     /* am_bw_lane[0] is am_lane, so don't re-select it here */
     am_lane = UCP_NULL_LANE;
@@ -1611,9 +1643,9 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
          * Allow selecting additional lanes in case the remote memory will not be
          * registered with this memory domain, i.e with GPU memory.
          */
-        bw_info.lane_type                = UCP_LANE_TYPE_RKEY_PTR;
         bw_info.criteria.title           = "obtain remote memory pointer";
         bw_info.criteria.local_md_flags |= UCT_MD_FLAG_RKEY_PTR;
+        bw_info.criteria.lane_type       = UCP_LANE_TYPE_RKEY_PTR;
         bw_info.max_lanes                = 1;
 
         ucp_context_get_mem_access_tls(context, UCS_MEMORY_TYPE_HOST,
@@ -1622,8 +1654,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
                                 UCP_NULL_LANE, select_ctx);
     }
 
-    bw_info.lane_type               = UCP_LANE_TYPE_RMA_BW;
     bw_info.criteria.title          = "high-bw remote memory access";
+    bw_info.criteria.lane_type      = UCP_LANE_TYPE_RMA_BW;
     bw_info.max_lanes               = context->config.ext.max_rndv_lanes;
     bw_info.criteria.local_md_flags = md_reg_flag;
 
@@ -1701,6 +1733,7 @@ ucp_wireup_add_tag_lane(const ucp_wireup_select_params_t *select_params,
     criteria.title          = "tag_offload";
     criteria.local_md_flags = UCT_MD_FLAG_REG; /* needed for posting tags to HW */
     criteria.calc_score     = ucp_wireup_am_score_func;
+    criteria.lane_type      = UCP_LANE_TYPE_TAG;
     ucp_wireup_init_select_flags(&criteria.remote_iface_flags,
                                  UCP_ADDR_IFACE_FLAG_TAG_EAGER |
                                  UCP_ADDR_IFACE_FLAG_TAG_RNDV  |
@@ -1859,6 +1892,7 @@ ucp_wireup_add_keepalive_lane(const ucp_wireup_select_params_t *select_params,
     criteria.calc_score         = ucp_wireup_keepalive_score_func;
     /* Keepalive can also use auxiliary transports */
     criteria.tl_rsc_flags       = UCP_TL_RSC_FLAG_AUX;
+    criteria.lane_type          = UCP_LANE_TYPE_KEEPALIVE;
     ucp_wireup_fill_peer_err_criteria(&criteria, ep_init_flags);
 
     status = ucp_wireup_select_transport(select_ctx, select_params, &criteria,
@@ -1897,6 +1931,8 @@ ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
         return status;
     }
 
+    /* Add fast protocols first (so they'll fit in the cached-in part of
+     * ucp_ep. Fast protocols are: RMA/AM/AMO/TAG */
     status = ucp_wireup_add_rma_lanes(select_params, select_ctx);
     if (status != UCS_OK) {
         return status;
@@ -1914,13 +1950,14 @@ ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
         return status;
     }
 
-    status = ucp_wireup_add_rma_bw_lanes(select_params, select_ctx);
+    status = ucp_wireup_add_tag_lane(select_params, &am_info, err_mode,
+                                     select_ctx);
     if (status != UCS_OK) {
         return status;
     }
 
-    status = ucp_wireup_add_tag_lane(select_params, &am_info, err_mode,
-                                     select_ctx);
+    /* Add slow protocols on the remaining lanes */
+    status = ucp_wireup_add_rma_bw_lanes(select_params, select_ctx);
     if (status != UCS_OK) {
         return status;
     }
@@ -2033,8 +2070,9 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
     }
 
     /* Sort AM, RMA and AMO lanes according to score */
-    ucs_qsort_r(key->am_bw_lanes + 1, UCP_MAX_LANES - 1, sizeof(ucp_lane_index_t),
-                ucp_wireup_compare_lane_am_bw_score, select_ctx->lane_descs);
+    ucs_qsort_r(key->am_bw_lanes + 1, UCP_MAX_LANES - 1,
+                sizeof(ucp_lane_index_t), ucp_wireup_compare_lane_am_bw_score,
+                select_ctx->lane_descs);
     ucs_qsort_r(key->rma_lanes, UCP_MAX_LANES, sizeof(ucp_lane_index_t),
                 ucp_wireup_compare_lane_rma_score, select_ctx->lane_descs);
     ucs_qsort_r(key->rma_bw_lanes, UCP_MAX_LANES, sizeof(ucp_lane_index_t),

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1319,8 +1319,9 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
         ucs_assert(ucp_ep_get_lane(ep, lane) == NULL);
     }
 
-    ucs_assert(sizeof(new_uct_eps) == sizeof(ep->uct_eps));
-    memcpy(ep->uct_eps, new_uct_eps, sizeof(ep->uct_eps));
+    for (lane = 0; lane < UCP_MAX_LANES; ++lane) {
+        ucp_ep_set_lane(ep, lane, new_uct_eps[lane]);
+    }
 }
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -101,6 +101,7 @@ typedef struct {
     ucp_tl_iface_atomic_flags_t local_atomic_flags;
 
     ucp_tl_iface_atomic_flags_t remote_atomic_flags;
+    ucp_lane_type_t             lane_type;
 } ucp_wireup_criteria_t;
 
 
@@ -203,5 +204,18 @@ ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_lane_index_t *lanes2remote);
 
 uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane);
+
+static inline int ucp_wireup_lane_types_has_fast_path(ucp_lane_map_t lane_types)
+{
+    return lane_types &
+           (UCS_BIT(UCP_LANE_TYPE_AM) | UCS_BIT(UCP_LANE_TYPE_RMA) |
+            UCS_BIT(UCP_LANE_TYPE_AMO) | UCS_BIT(UCP_LANE_TYPE_CM) |
+            UCS_BIT(UCP_LANE_TYPE_TAG));
+}
+
+static inline int ucp_wireup_lane_type_is_fast_path(ucp_lane_type_t lane_type)
+{
+    return ucp_wireup_lane_types_has_fast_path(UCS_BIT(lane_type));
+}
 
 #endif

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,7 +50,7 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_ep_ext_t, 176);
+    EXPECTED_SIZE(ucp_ep_ext_t, 200);
 #if ENABLE_PARAMS_CHECK
     EXPECTED_SIZE(ucp_rkey_t, 32 + sizeof(ucp_ep_h));
 #else


### PR DESCRIPTION
## What
Max number of lanes for EP is now increased from 5 to 8.

## Why ?
Increase limit of EP lanes.

## How ?
In order to maintain fast path performance, we add the new 3 lanes in ep_extension struct.
The new lanes will be considered slow path, and will be used only for slow path protocols.
