### PR TITLE
UCT/CUDA: Improve performance estimation

### DIFF
--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -215,4 +215,17 @@
 #define ucs_carray_for_each(_elem, _array, _length) \
     for ((_elem) = (_array); (_elem) < ((_array) + (_length)); ++(_elem))
 
+/*
+ * Swap two variables values
+ */
+#define ucs_swap(_a, _b) \
+    { \
+        ucs_typeof(*(_a)) __tmp; \
+        \
+        UCS_STATIC_ASSERT(ucs_same_type(ucs_typeof(*(_a)), ucs_typeof(*(_b)))); \
+        __tmp = *(_a); \
+        *(_a) = *(_b); \
+        *(_b) = __tmp; \
+    }
+
 #endif /* UCS_COMPILER_DEF_H */

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -983,4 +983,12 @@ static UCS_F_ALWAYS_INLINE int uct_ep_op_is_zcopy(uct_ep_operation_t op)
                           UCS_BIT(UCT_EP_OP_EAGER_ZCOPY));
 }
 
+static UCS_F_ALWAYS_INLINE int uct_ep_op_is_fetch(uct_ep_operation_t op)
+{
+    return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_GET_SHORT) |
+                          UCS_BIT(UCT_EP_OP_GET_BCOPY) |
+                          UCS_BIT(UCT_EP_OP_GET_ZCOPY) |
+                          UCS_BIT(UCT_EP_OP_ATOMIC_FETCH));
+}
+
 #endif


### PR DESCRIPTION
## Why
- Remove the assumption that cuda_copy source is HOST and destination is DEVICE
- Set right CPU overhead/latency for sync/async operations