### PR TITLE
UCP/PROTO/IB: Improve performance estimations for short/bcopy/zcopy

### DIFF
--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -86,7 +86,7 @@ ucp_am_eager_short_proto_init_common(const ucp_proto_init_params_t *init_params,
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     ucp_proto_single_init_params_t params        = {
         .super.super         = *init_params,
-        .super.latency       = -150e-9,
+        .super.latency       = 0,
         .super.overhead      = 0,
         .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
         .super.cfg_priority  = 0,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -50,7 +50,7 @@ ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
 {
     ucp_proto_single_init_params_t params = {
         .super.super         = *init_params,
-        .super.latency       = -150e-9,
+        .super.latency       = 0,
         .super.overhead      = 0,
         .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
         .super.cfg_priority  = 0,

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -49,7 +49,7 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     ucp_proto_single_init_params_t params        = {
         .super.super         = *init_params,
-        .super.latency       = -150e-9, /* no extra mem access to fetch data */
+        .super.latency       = 0,
         .super.overhead      = 0,
         .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
         .super.cfg_priority  = 0,

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -47,7 +47,7 @@ static ucs_status_t ucp_proto_eager_tag_offload_short_init(
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     ucp_proto_single_init_params_t params        = {
         .super.super         = *init_params,
-        .super.latency       = -150e-9, /* no extra mem access to fetch data */
+        .super.latency       = 0,
         .super.overhead      = 0,
         .super.cfg_thresh    = UCS_MEMUNITS_AUTO,
         .super.cfg_priority  = 0,

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -975,11 +975,29 @@ void uct_tl_register(uct_component_t *component, uct_tl_t *tl);
 
 void uct_tl_unregister(uct_tl_t *tl);
 
+static UCS_F_ALWAYS_INLINE int uct_ep_op_is_short(uct_ep_operation_t op)
+{
+    return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_AM_SHORT) |
+                          UCS_BIT(UCT_EP_OP_PUT_SHORT) |
+                          UCS_BIT(UCT_EP_OP_GET_SHORT) |
+                          UCS_BIT(UCT_EP_OP_EAGER_SHORT) |
+                          UCS_BIT(UCT_EP_OP_ATOMIC_POST));
+}
+
+static UCS_F_ALWAYS_INLINE int uct_ep_op_is_bcopy(uct_ep_operation_t op)
+{
+    return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_AM_BCOPY) |
+                          UCS_BIT(UCT_EP_OP_PUT_BCOPY) |
+                          UCS_BIT(UCT_EP_OP_GET_BCOPY) |
+                          UCS_BIT(UCT_EP_OP_EAGER_BCOPY));
+}
+
 static UCS_F_ALWAYS_INLINE int uct_ep_op_is_zcopy(uct_ep_operation_t op)
 {
     return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_AM_ZCOPY) |
                           UCS_BIT(UCT_EP_OP_PUT_ZCOPY) |
                           UCS_BIT(UCT_EP_OP_GET_ZCOPY) |
+                          UCS_BIT(UCT_EP_OP_ATOMIC_FETCH) |
                           UCS_BIT(UCT_EP_OP_EAGER_ZCOPY));
 }
 


### PR DESCRIPTION
## Why
- Short protocol having lower latency should be implemented as UCT performance estimation and not assumptions on UCP layer
- Current IB latency estimation is actually the minimal value, so need to increase the cost of bcopy/zcopy rather than adding negative latency to short.