### PR TITLE
UCP/PROTO: Move memreg_time and buffer_copy_time to proto_init.c

### DIFF
--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -207,6 +207,11 @@ size_t ucp_proto_common_get_iface_attr_field(const uct_iface_attr_t *iface_attr,
                                              size_t dfl_value);
 
 
+void ucp_proto_common_lane_perf_node(ucp_context_h context,
+                                     ucp_rsc_index_t rsc_index,
+                                     const uct_perf_attr_t *perf_attr,
+                                     ucp_proto_perf_node_t **perf_node_p);
+
 ucs_status_t
 ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                ucp_lane_index_t lane,
@@ -262,20 +267,5 @@ void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status);
 
 
 void ucp_proto_request_zcopy_abort(ucp_request_t *request, ucs_status_t status);
-
-
-void ucp_proto_common_memreg_time(const ucp_proto_common_init_params_t *params,
-                                  ucp_md_map_t reg_md_map,
-                                  ucs_linear_func_t *memreg_time,
-                                  ucp_proto_perf_node_t **perf_node_p);
-
-
-ucs_status_t
-ucp_proto_common_buffer_copy_time(ucp_worker_h worker, const char *title,
-                                  ucs_memory_type_t local_mem_type,
-                                  ucs_memory_type_t remote_mem_type,
-                                  uct_ep_operation_t memtype_op,
-                                  ucs_linear_func_t *copy_time,
-                                  ucp_proto_perf_node_t **perf_node_p);
 
 #endif

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -12,6 +12,7 @@
 #include "proto_debug.h"
 #include "proto_select.inl"
 
+#include <ucp/core/ucp_ep.inl>
 #include <ucs/datastruct/array.inl>
 #include <ucs/sys/math.h>
 #include <ucs/sys/string.h>
@@ -293,6 +294,153 @@ out:
     return status;
 }
 
+void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,
+                                ucp_md_map_t reg_md_map,
+                                ucs_linear_func_t *memreg_time,
+                                ucp_proto_perf_node_t **perf_node_p)
+{
+    ucp_context_h context = params->super.worker->context;
+    ucp_proto_perf_node_t *perf_node;
+    const uct_md_attr_t *md_attr;
+    ucp_md_index_t md_index;
+    const char *md_name;
+
+    *memreg_time = UCS_LINEAR_FUNC_ZERO;
+
+    if (reg_md_map == 0) {
+        *perf_node_p = NULL;
+        return;
+    }
+
+    perf_node = ucp_proto_perf_node_new_data("mem reg", "");
+
+    /* Go over all memory domains */
+    ucs_for_each_bit(md_index, reg_md_map) {
+        md_attr = &context->tl_mds[md_index].attr;
+        md_name = context->tl_mds[md_index].rsc.md_name;
+        ucs_linear_func_add_inplace(memreg_time, md_attr->reg_cost);
+        ucs_trace("md %s" UCP_PROTO_PERF_FUNC_FMT(reg_cost), md_name,
+                  UCP_PROTO_PERF_FUNC_ARG(&md_attr->reg_cost));
+
+        ucp_proto_perf_node_add_data(perf_node, md_name, md_attr->reg_cost);
+    }
+
+    if (!ucs_is_pow2(reg_md_map)) {
+        /* Multiple memory domains */
+        ucp_proto_perf_node_add_data(perf_node, "total", *memreg_time);
+    }
+
+    *perf_node_p = perf_node;
+}
+
+ucs_status_t
+ucp_proto_init_buffer_copy_time(ucp_worker_h worker, const char *title,
+                                ucs_memory_type_t local_mem_type,
+                                ucs_memory_type_t remote_mem_type,
+                                uct_ep_operation_t memtype_op,
+                                ucs_linear_func_t *copy_time,
+                                ucp_proto_perf_node_t **perf_node_p)
+{
+    ucp_context_h context = worker->context;
+    ucs_memory_type_t src_mem_type, dst_mem_type;
+    ucp_proto_perf_node_t *perf_node, *tl_perf_node;
+    const ucp_ep_config_t *ep_config;
+    ucp_worker_iface_t *wiface;
+    uct_perf_attr_t perf_attr;
+    ucp_rsc_index_t rsc_index;
+    ucp_lane_index_t lane;
+    ucs_status_t status;
+
+    if (UCP_MEM_IS_HOST(local_mem_type) && UCP_MEM_IS_HOST(remote_mem_type)) {
+        *copy_time = ucs_linear_func_make(0,
+                                          1.0 / context->config.ext.bcopy_bw);
+
+        perf_node = ucp_proto_perf_node_new_data("memcpy", "");
+        ucp_proto_perf_node_add_bandwidth(perf_node, "bcopy_bw",
+                                          context->config.ext.bcopy_bw);
+        *perf_node_p = perf_node;
+        return UCS_OK;
+    }
+
+    if (worker->mem_type_ep[local_mem_type] != NULL) {
+        ep_config = ucp_ep_config(worker->mem_type_ep[local_mem_type]);
+    } else if (worker->mem_type_ep[remote_mem_type] != NULL) {
+        ep_config = ucp_ep_config(worker->mem_type_ep[remote_mem_type]);
+    } else {
+        ucs_debug("cannot copy memory between %s and %s",
+                  ucs_memory_type_names[local_mem_type],
+                  ucs_memory_type_names[remote_mem_type]);
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    /* Use the v2 API to query overhead and BW */
+    perf_attr.local_memory_type  = local_mem_type;
+    perf_attr.remote_memory_type = remote_mem_type;
+    perf_attr.operation          = memtype_op;
+
+    switch (memtype_op) {
+    case UCT_EP_OP_PUT_SHORT:
+    case UCT_EP_OP_GET_SHORT:
+        lane = ep_config->key.rma_lanes[0];
+        break;
+    case UCT_EP_OP_PUT_ZCOPY:
+    case UCT_EP_OP_GET_ZCOPY:
+        lane = ep_config->key.rma_bw_lanes[0];
+        break;
+    case UCT_EP_OP_LAST:
+        return UCS_ERR_UNSUPPORTED;
+    default:
+        ucs_fatal("invalid UCT copy operation: %d", memtype_op);
+    }
+
+    perf_attr.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
+                           UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE |
+                           UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE |
+                           UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD |
+                           UCT_PERF_ATTR_FIELD_SEND_POST_OVERHEAD |
+                           UCT_PERF_ATTR_FIELD_RECV_OVERHEAD |
+                           UCT_PERF_ATTR_FIELD_BANDWIDTH |
+                           UCT_PERF_ATTR_FIELD_LATENCY;
+    perf_attr.operation  = memtype_op;
+
+    rsc_index = ep_config->key.lanes[lane].rsc_index;
+    wiface    = ucp_worker_iface(worker, rsc_index);
+    status    = uct_iface_estimate_perf(wiface->iface, &perf_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* all allowed copy operations are one-sided */
+    ucs_assert(perf_attr.recv_overhead < 1e-15);
+    copy_time->c = ucp_tl_iface_latency(context, &perf_attr.latency) +
+                   perf_attr.send_pre_overhead + perf_attr.send_post_overhead +
+                   perf_attr.recv_overhead;
+    copy_time->m = 1.0 / ucp_tl_iface_bandwidth(context, &perf_attr.bandwidth);
+
+    if ((memtype_op == UCT_EP_OP_GET_SHORT) ||
+        (memtype_op == UCT_EP_OP_GET_ZCOPY)) {
+        src_mem_type = remote_mem_type;
+        dst_mem_type = local_mem_type;
+    } else {
+        src_mem_type = local_mem_type;
+        dst_mem_type = remote_mem_type;
+    }
+
+    perf_node = ucp_proto_perf_node_new_data(
+            title, "%s to %s", ucs_memory_type_names[src_mem_type],
+            ucs_memory_type_names[dst_mem_type]);
+
+    ucp_proto_perf_node_add_data(perf_node, "", *copy_time);
+
+    ucp_proto_common_lane_perf_node(context, rsc_index, &perf_attr,
+                                    &tl_perf_node);
+    ucp_proto_perf_node_own_child(perf_node, &tl_perf_node);
+
+    *perf_node_p = perf_node;
+
+    return UCS_OK;
+}
+
 static ucs_status_t
 ucp_proto_common_init_send_perf(const ucp_proto_common_init_params_t *params,
                                 const ucp_proto_common_tl_perf_t *tl_perf,
@@ -312,14 +460,14 @@ ucp_proto_common_init_send_perf(const ucp_proto_common_init_params_t *params,
 
     /* Calculate sender overhead */
     if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY) {
-        ucp_proto_common_memreg_time(params, reg_md_map, &send_overhead,
-                                     &child_perf_node);
+        ucp_proto_init_memreg_time(params, reg_md_map, &send_overhead,
+                                   &child_perf_node);
         ucp_proto_perf_node_own_child(send_perf->node, &child_perf_node);
     } else if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_RKEY_PTR) {
         send_overhead = UCS_LINEAR_FUNC_ZERO;
     } else {
         ucs_assert(reg_md_map == 0);
-        status = ucp_proto_common_buffer_copy_time(
+        status = ucp_proto_init_buffer_copy_time(
                 params->super.worker, "send copy", UCS_MEMORY_TYPE_HOST,
                 params->super.select_param->mem_type, params->memtype_op,
                 &send_overhead, &child_perf_node);
@@ -413,8 +561,8 @@ ucp_proto_common_init_recv_perf(const ucp_proto_common_init_params_t *params,
     } else {
         if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY) {
             /* Receiver has to register its buffer */
-            ucp_proto_common_memreg_time(params, reg_md_map, &recv_overhead,
-                                         &child_perf_node);
+            ucp_proto_init_memreg_time(params, reg_md_map, &recv_overhead,
+                                       &child_perf_node);
         } else {
             if (params->super.rkey_config_key == NULL) {
                 /* Assume same memory type as sender */
@@ -427,7 +575,7 @@ ucp_proto_common_init_recv_perf(const ucp_proto_common_init_params_t *params,
             recv_overhead = UCS_LINEAR_FUNC_ZERO;
 
             /* Receiver has to copy data */
-            status = ucp_proto_common_buffer_copy_time(
+            status = ucp_proto_init_buffer_copy_time(
                     params->super.worker, "recv copy", UCS_MEMORY_TYPE_HOST,
                     recv_mem_type, UCT_EP_OP_PUT_SHORT, &recv_overhead,
                     &child_perf_node);

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -86,6 +86,20 @@ ucp_proto_init_parallel_stages(const ucp_proto_init_params_t *params,
                                unsigned num_stages);
 
 
+void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,
+                                ucp_md_map_t reg_md_map,
+                                ucs_linear_func_t *memreg_time,
+                                ucp_proto_perf_node_t **perf_node_p);
+
+ucs_status_t
+ucp_proto_init_buffer_copy_time(ucp_worker_h worker, const char *title,
+                                ucs_memory_type_t local_mem_type,
+                                ucs_memory_type_t remote_mem_type,
+                                uct_ep_operation_t memtype_op,
+                                ucs_linear_func_t *copy_time,
+                                ucp_proto_perf_node_t **perf_node_p);
+
+
 ucs_status_t
 ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
                            const ucp_proto_common_tl_perf_t *tl_perf,

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -267,8 +267,8 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params)
         return status;
     }
 
-    ucp_proto_common_memreg_time(&params->super, rpriv->md_map, &memreg_time,
-                                 &memreg_perf_node);
+    ucp_proto_init_memreg_time(&params->super, rpriv->md_map, &memreg_time,
+                               &memreg_perf_node);
     ucp_proto_perf_node_own_child(ctrl_perf.node, &memreg_perf_node);
 
     ctrl_latency = send_time + receive_time + params->super.overhead * 2;

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -12,6 +12,7 @@
 #include "rndv_mtype.inl"
 
 #include <ucp/proto/proto_debug.h>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_single.inl>
 
 
@@ -348,7 +349,7 @@ ucp_proto_rndv_rtr_mtype_init(const ucp_proto_init_params_t *init_params)
         return status;
     }
 
-    status = ucp_proto_common_buffer_copy_time(
+    status = ucp_proto_init_buffer_copy_time(
             init_params->worker, "rtr/mtype unpack", UCS_MEMORY_TYPE_HOST,
             init_params->select_param->mem_type, UCT_EP_OP_PUT_ZCOPY,
             &unpack_time, &unpack_perf_node);


### PR DESCRIPTION
## Why
As preparation for extending these functions, since they are used for protocol initialization flow

## How
- Rename the functions
- Move without code changes to proto_init.c