### PR TITLE
UCP/CORE: Add missing release of RNDV receive descriptor

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1177,12 +1177,17 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
         ret = UCS_STATUS_PTR(status);
     }
 
-    /* Clear this flag, because receive operation is already completed and desc
-     * is not needed anymore. If receive operation was invoked from UCP AM
-     * callback, UCT AM handler would release this desc (by returning UCS_OK)
-     * back to UCT.
-     */
-    desc->flags &= ~UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
+    ucs_assert(status != UCS_INPROGRESS);
+    if (desc->flags & UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS) {
+        /* Clear this flag, because receive operation is already completed and
+         * desc is not needed anymore. If receive operation was invoked from
+         * UCP AM callback, UCT AM handler would release this desc (by
+         * returning UCS_OK) back to UCT.
+         */
+        desc->flags &= ~UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
+    } else {
+        ucp_recv_desc_release(desc);
+    }
 
 out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);


### PR DESCRIPTION
## What

Add missing release of RNDV receive descriptor for AM receive operation.

## Why ?

Fixes receive descriptor leak of AM RNDV operation for 0-lengh message.
```
[1657279884.508973] [swx-ucx01:45001:0]           mpool.c:55   UCX  WARN  object 0x8ebd40 {flags:0xc0 length:50 payload_offset:0 release_offset:0 name:am_rndv_process_rts} was not returned to mpool ucp_am_bufs
```

## How ?

Invoke `ucp_recv_desc_release` for 0-length RNDV descriptors from `ucp_am_recv_data_nbx` if the operation isn't issued from AM callback context.