### PR TITLE
UCS/ARRAY: Add method to remove last array element

### DIFF
--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -321,6 +321,18 @@ BEGIN_C_DECLS
 
 
 /**
+ * Remove the last element in the array (decrease length by 1)
+ *
+ * @param _array    Array from which to remove the last element
+ */
+#define ucs_array_pop_back(_array) \
+    ({ \
+        ucs_assert(ucs_array_length(_array) > 0); \
+        --(_array)->length; \
+    })
+
+
+/**
  * Extract array contents and reset the array
  */
 #define ucs_array_extract_buffer(_name, _array) \

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -1095,6 +1095,10 @@ UCS_TEST_F(test_array, dynamic_array_int_append) {
     ucs_array_set_length(&test_array, NUM_ELEMS);
     EXPECT_EQ(NUM_ELEMS, ucs_array_length(&test_array));
 
+    /* test pop_back */
+    ucs_array_pop_back(&test_array);
+    EXPECT_EQ(NUM_ELEMS - 1, ucs_array_length(&test_array));
+
     /* set length to max capacity */
     new_length = ucs_array_capacity(&test_array);
     ucs_array_set_length(&test_array, new_length);


### PR DESCRIPTION
## Why
For error flow of adding performance stage to an array: if something failed after adding the array element, this method allows to remove it