### PR TITLE
UCT/IB/DEVX: Create CQ using DEVX

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -55,6 +55,7 @@ static const char *uct_ib_devx_objs[] = {
     [UCT_IB_DEVX_OBJ_DCT]   = "dct",
     [UCT_IB_DEVX_OBJ_DCSRQ] = "dcsrq",
     [UCT_IB_DEVX_OBJ_DCI]   = "dci",
+    [UCT_IB_DEVX_OBJ_CQ]    = "cq",
     NULL
 };
 
@@ -163,7 +164,7 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "DEVX support\n",
      ucs_offsetof(uct_ib_md_config_t, devx), UCS_CONFIG_TYPE_TERNARY},
 
-    {"MLX5_DEVX_OBJECTS", "rcqp,rcsrq,dct,dcsrq,dci",
+    {"MLX5_DEVX_OBJECTS", "rcqp,rcsrq,dct,dcsrq,dci,cq",
      "Objects to be created by DEVX\n",
      ucs_offsetof(uct_ib_md_config_t, devx_objs),
      UCS_CONFIG_TYPE_BITMAP(uct_ib_devx_objs)},

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -65,7 +65,8 @@ enum {
     UCT_IB_DEVX_OBJ_RCSRQ,
     UCT_IB_DEVX_OBJ_DCT,
     UCT_IB_DEVX_OBJ_DCSRQ,
-    UCT_IB_DEVX_OBJ_DCI
+    UCT_IB_DEVX_OBJ_DCI,
+    UCT_IB_DEVX_OBJ_CQ
 };
 
 typedef struct uct_ib_md_ext_config {

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -149,13 +149,16 @@ AS_IF([test "x$with_ib" = "xyes"],
                        AC_CHECK_HEADERS([infiniband/mlx5dv.h],
                                [with_mlx5_dv=yes
                                 mlx5_include=mlx5dv.h], [], [ ])])
-
-              AS_IF([test "x$with_mlx5_dv" = "xyes" -a "x$have_cq_io" = "xyes" ], [
                        AC_CHECK_DECLS([
                            mlx5dv_init_obj,
                            mlx5dv_create_qp,
                            mlx5dv_is_supported,
-                           mlx5dv_devx_subscribe_devx_event,
+                           mlx5dv_devx_subscribe_devx_event], [],
+                          [with_mlx5_dv=no],
+                          [[#include <infiniband/mlx5dv.h>]])
+
+              AS_IF([test "x$with_mlx5_dv" = "xyes" -a "x$have_cq_io" = "xyes" ], [
+                       AC_CHECK_DECLS([
                            MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE,
                            MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE,
                            MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE,

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -360,6 +360,11 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
         goto init_qp;
     }
 
+    if (iface->super.cq[UCT_IB_DIR_TX].type != UCT_IB_MLX5_OBJ_TYPE_VERBS) {
+        ucs_error("cannot create verbs DCI with DEVX CQ");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     status = uct_ib_mlx5_iface_get_res_domain(ib_iface, &dci->txwq.super);
     if (status != UCS_OK) {
         return status;
@@ -529,6 +534,11 @@ uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface,
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_DCT) {
         return uct_dc_mlx5_iface_devx_create_dct(iface);
+    }
+
+    if (iface->super.cq[UCT_IB_DIR_RX].type != UCT_IB_MLX5_OBJ_TYPE_VERBS) {
+        ucs_error("cannot create verbs DCT with DEVX CQ");
+        return UCS_ERR_INVALID_PARAM;
     }
 
     uct_ib_mlx5dv_dct_qp_init_attr(&init_attr, &dv_init_attr, md->super.pd,
@@ -1170,24 +1180,6 @@ static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
     uct_dc_mlx5_ep_handle_failure(ep, cqe, status);
 }
 
-static ucs_status_t
-uct_dc_mlx5_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
-                      const uct_ib_iface_config_t *ib_config,
-                      const uct_ib_iface_init_attr_t *init_attr,
-                      int preferred_cpu, size_t inl)
-{
-    uct_dc_mlx5_iface_config_t *dc_mlx5_config =
-            ucs_derived_of(ib_config, uct_dc_mlx5_iface_config_t);
-    uct_rc_mlx5_iface_common_t *rc_mlx5_iface_common =
-            ucs_derived_of(ib_iface, uct_rc_mlx5_iface_common_t);
-    uct_ib_mlx5_cq_t *uct_cq = &rc_mlx5_iface_common->cq[dir];
-
-    return uct_ib_mlx5_create_cq(ib_iface, dir,
-                                 &dc_mlx5_config->rc_mlx5_common.super,
-                                 ib_config, init_attr, uct_cq, preferred_cpu,
-                                 inl);
-}
-
 static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
                                              void *arg, ucs_status_t status)
 {
@@ -1214,8 +1206,8 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
             .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate       = uct_dc_mlx5_ep_invalidate
         },
-        .create_cq      = uct_dc_mlx5_create_cq,
-        .arm_cq         = uct_rc_mlx5_iface_common_arm_cq,
+        .create_cq      = uct_rc_mlx5_iface_common_create_cq,
+        .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,
         .event_cq       = uct_rc_mlx5_iface_common_event_cq,
         .handle_failure = uct_dc_mlx5_iface_handle_failure,
     },
@@ -1261,8 +1253,8 @@ static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .iface_progress_enable    = uct_dc_mlx5_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_rc_iface_do_progress,
-    .iface_event_fd_get       = uct_ib_iface_event_fd_get,
-    .iface_event_arm          = uct_rc_iface_event_arm,
+    .iface_event_fd_get       = uct_rc_mlx5_iface_event_fd_get,
+    .iface_event_arm          = uct_rc_mlx5_iface_devx_arm,
     .ep_create                = uct_dc_mlx5_ep_create_connected,
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_ep_t),
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t),
@@ -1374,6 +1366,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     }
 
     init_attr.cq_len[UCT_IB_DIR_TX] = sq_length * num_dcis;
+    uct_ib_mlx5_parse_cqe_zipping(md, &config->rc_mlx5_common.super,
+                                  &init_attr);
 
     /* TODO check caps instead */
     UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
@@ -1595,15 +1589,8 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 
     ucs_assert(!uct_dc_mlx5_iface_dci_has_outstanding(iface, dci_index));
 
-    /* Synchronize CQ index with the driver, since it would remove pending
-     * completions for this QP (both send and receive) during ibv_destroy_qp().
-     */
-    uct_rc_mlx5_iface_common_update_cqs_ci(&iface->super,
-                                           &iface->super.super.super);
     status = uct_ib_mlx5_modify_qp_state(&iface->super.super.super,
                                          &txwq->super, IBV_QPS_RESET);
-    uct_rc_mlx5_iface_common_sync_cqs_ci(&iface->super,
-                                         &iface->super.super.super);
 
     uct_rc_mlx5_iface_commom_clean(&iface->super.cq[UCT_IB_DIR_TX], NULL,
                                    txwq->super.qp_num);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
@@ -80,16 +80,6 @@ void uct_ib_mlx5dv_qp_init_attr(uct_ib_qp_init_attr_t *qp_init_attr,
                                 enum ibv_qp_type qp_type, uint32_t max_recv_wr);
 
 /**
- * Update CI to support req_notify_cq
- */
-void uct_ib_mlx5_update_cq_ci(struct ibv_cq *cq, unsigned cq_ci);
-
-/**
- * Retrieve CI from the driver
- */
-unsigned uct_ib_mlx5_get_cq_ci(struct ibv_cq *cq);
-
-/**
  * Get internal AV information.
  */
 void uct_ib_mlx5_get_av(struct ibv_ah *ah, struct mlx5_wqe_av *av);

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -816,7 +816,6 @@ uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
 
     ibv_destroy_cq(cq);
 
-#if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT
     event_channel = mlx5dv_devx_create_event_channel(
             ctx, MLX5_IB_UAPI_DEVX_CR_EV_CH_FLAGS_OMIT_DATA);
     if (event_channel == NULL) {
@@ -826,7 +825,6 @@ uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
     }
 
     mlx5dv_devx_destroy_event_channel(event_channel);
-#endif
 
     return ctx;
 

--- a/src/uct/ib/rc/accel/rc_mlx5.h
+++ b/src/uct/ib/rc/accel/rc_mlx5.h
@@ -183,4 +183,6 @@ ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr);
 
 unsigned uct_rc_mlx5_ep_cleanup_qp(void *arg);
 
+ucs_status_t uct_rc_mlx5_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p);
+
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -405,9 +405,8 @@ typedef struct uct_rc_mlx5_iface_common {
                                                     const void *data, size_t length);
     } dm;
 #endif
-#if HAVE_DECL_MLX5DV_DEVX_SUBSCRIBE_DEVX_EVENT
     struct mlx5dv_devx_event_channel   *event_channel;
-#endif
+    struct mlx5dv_devx_event_channel   *cq_event_channel;
     struct {
         uint8_t                        atomic_fence_flag;
         uct_rc_mlx5_srq_topo_t         srq_topo;
@@ -588,18 +587,18 @@ void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
                                     uct_iface_attr_t *iface_attr,
                                     size_t max_inline, size_t max_tag_eager_iov);
 
-void uct_rc_mlx5_iface_common_update_cqs_ci(uct_rc_mlx5_iface_common_t *iface,
-                                            uct_ib_iface_t *ib_iface);
-
-void uct_rc_mlx5_iface_common_sync_cqs_ci(uct_rc_mlx5_iface_common_t *iface,
-                                          uct_ib_iface_t *ib_iface);
-
 ucs_status_t
-uct_rc_mlx5_iface_common_arm_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
-                                int solicited_only);
+uct_rc_mlx5_iface_common_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
+                                   const uct_ib_iface_init_attr_t *init_attr,
+                                   int preferred_cpu, size_t inl);
+
+ucs_status_t uct_rc_mlx5_iface_devx_arm(uct_iface_h tl_iface, unsigned events);
 
 void uct_rc_mlx5_iface_common_event_cq(uct_ib_iface_t *ib_iface,
                                        uct_ib_dir_t dir);
+
+void uct_rc_mlx5_iface_common_destroy_cq(uct_ib_iface_t *iface,
+                                         uct_ib_dir_t dir);
 
 int uct_rc_mlx5_iface_commom_clean(uct_ib_mlx5_cq_t *mlx5_cq,
                                    uct_ib_mlx5_srq_t *srq, uint32_t qpn);
@@ -701,7 +700,6 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                                          struct ibv_ah_attr *ah_attr,
                                          enum ibv_mtu path_mtu,
                                          uint8_t path_index);
-
 #else
 static UCS_F_MAYBE_UNUSED ucs_status_t
 uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
@@ -715,15 +713,16 @@ uct_rc_mlx5_iface_common_devx_connect_qp(uct_rc_mlx5_iface_common_t *iface,
 }
 #endif
 
-ucs_status_t uct_rc_mlx5_devx_iface_init_events(uct_rc_mlx5_iface_common_t *iface);
+ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(
+        uct_rc_mlx5_iface_common_t *iface,
+        struct mlx5dv_devx_event_channel *event_channel,
+        struct mlx5dv_devx_obj *obj, uint16_t event, uint64_t cookie,
+        char *msg_arg);
+
+ucs_status_t
+uct_rc_mlx5_devx_iface_init_events(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_devx_iface_free_events(uct_rc_mlx5_iface_common_t *iface);
-
-ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(uct_rc_mlx5_iface_common_t *iface,
-                                                    uct_ib_mlx5_qp_t *qp,
-                                                    unsigned event_num,
-                                                    enum ibv_event_type event_type,
-                                                    unsigned event_data);
 
 void uct_rc_mlx5_iface_fill_attr(uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_qp_attr_t *qp_attr,

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -935,50 +935,57 @@ ucs_status_t uct_rc_iface_qp_connect(uct_rc_iface_t *iface, struct ibv_qp *qp,
     return UCS_OK;
 }
 
-ucs_status_t uct_rc_iface_common_event_arm(uct_iface_h tl_iface,
-                                           unsigned events, int force_rx_all)
+uint64_t uct_rc_iface_arm_cq_check(uct_rc_iface_t *iface, unsigned events,
+                                   int *solicited_p)
+{
+    int arm_rx_solicited, arm_rx_all;
+    uint64_t dirs;
+
+    arm_rx_solicited = 0;
+    arm_rx_all       = 0;
+    dirs             = 0;
+    if (events & UCT_EVENT_RECV) {
+        arm_rx_solicited = 1; /* to wake up on active messages */
+    }
+    if ((events & UCT_EVENT_SEND_COMP) && iface->config.fc_enabled) {
+        arm_rx_all = 1; /* to wake up on FC grants (or if forced) */
+    }
+
+    if (events & UCT_EVENT_SEND_COMP) {
+        dirs |= UCS_BIT(UCT_IB_DIR_TX);
+    }
+
+    if (arm_rx_solicited || arm_rx_all) {
+        dirs |= UCS_BIT(UCT_IB_DIR_RX);
+    }
+
+    solicited_p[UCT_IB_DIR_TX] = 0;
+    solicited_p[UCT_IB_DIR_RX] = arm_rx_solicited && !arm_rx_all;
+    return dirs;
+}
+
+ucs_status_t uct_rc_iface_event_arm(uct_iface_h tl_iface, unsigned events)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
-    int arm_rx_solicited, arm_rx_all;
+    int solicited[UCT_IB_DIR_NUM], dir;
     ucs_status_t status;
+    uint64_t dirs;
 
     status = uct_ib_iface_pre_arm(&iface->super);
     if (status != UCS_OK) {
         return status;
     }
 
-    if (events & UCT_EVENT_SEND_COMP) {
-        status = iface->super.ops->arm_cq(&iface->super, UCT_IB_DIR_TX, 0);
-        if (status != UCS_OK) {
-            return status;
-        }
-    }
-
-    arm_rx_solicited = 0;
-    arm_rx_all       = 0;
-    if (events & UCT_EVENT_RECV) {
-        arm_rx_solicited = 1; /* to wake up on active messages */
-    }
-    if (((events & UCT_EVENT_SEND_COMP) && iface->config.fc_enabled) ||
-        force_rx_all) {
-        arm_rx_all       = 1; /* to wake up on FC grants (or if forced) */
-    }
-
-    if (arm_rx_solicited || arm_rx_all) {
-        status = iface->super.ops->arm_cq(&iface->super, UCT_IB_DIR_RX,
-                                          arm_rx_solicited && !arm_rx_all);
+    dirs = uct_rc_iface_arm_cq_check(iface, events, solicited);
+    ucs_for_each_bit(dir, dirs) {
+        ucs_assert(dir < UCT_IB_DIR_NUM);
+        status = uct_ib_iface_arm_cq(&iface->super, dir, solicited[dir]);
         if (status != UCS_OK) {
             return status;
         }
     }
 
     return UCS_OK;
-
-}
-
-ucs_status_t uct_rc_iface_event_arm(uct_iface_h tl_iface, unsigned events)
-{
-    return uct_rc_iface_common_event_arm(tl_iface, events, 0);
 }
 
 ucs_status_t uct_rc_iface_fence(uct_iface_h tl_iface, unsigned flags)

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -414,10 +414,10 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
 ucs_status_t uct_rc_init_fc_thresh(uct_rc_iface_config_t *rc_cfg,
                                    uct_rc_iface_t *iface);
 
-ucs_status_t uct_rc_iface_event_arm(uct_iface_h tl_iface, unsigned events);
+uint64_t uct_rc_iface_arm_cq_check(uct_rc_iface_t *iface, unsigned events,
+                                   int *solicited_p);
 
-ucs_status_t uct_rc_iface_common_event_arm(uct_iface_h tl_iface,
-                                           unsigned events, int force_rx_all);
+ucs_status_t uct_rc_iface_event_arm(uct_iface_h tl_iface, unsigned events);
 
 ucs_status_t uct_rc_iface_init_rx(uct_rc_iface_t *iface,
                                   const uct_rc_iface_common_config_t *config,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -508,7 +508,7 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
             .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported
         },
         .create_cq      = uct_ib_verbs_create_cq,
-        .arm_cq         = uct_ib_iface_arm_cq,
+        .destroy_cq     = uct_ib_verbs_destroy_cq,
         .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
         .handle_failure = uct_rc_verbs_handle_failure,
     },

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -671,39 +671,61 @@ uct_ud_mlx5_iface_peer_address_str(const uct_ud_iface_t *iface,
 
 static ucs_status_t
 uct_ud_mlx5_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,
-                      const uct_ib_iface_config_t *ib_config,
                       const uct_ib_iface_init_attr_t *init_attr,
                       int preferred_cpu, size_t inl)
 {
-    uct_ud_mlx5_iface_config_t *ud_mlx5_config =
-            ucs_derived_of(ib_config, uct_ud_mlx5_iface_config_t);
     uct_ud_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_ud_mlx5_iface_t);
     uct_ib_mlx5_cq_t *uct_cq   = &iface->cq[dir];
 
-    return uct_ib_mlx5_create_cq(ib_iface, dir, &ud_mlx5_config->mlx5_common,
-                                 ib_config, init_attr, uct_cq, preferred_cpu,
-                                 inl);
+    uct_cq->type = UCT_IB_MLX5_OBJ_TYPE_VERBS;
+    return uct_ib_mlx5_create_cq(ib_iface, dir, init_attr, uct_cq,
+                                 preferred_cpu, inl);
 }
 
-static ucs_status_t uct_ud_mlx5_iface_arm_cq(uct_ib_iface_t *ib_iface,
-                                             uct_ib_dir_t dir,
-                                             int solicited)
+static void
+uct_ud_mlx5_iface_async_handler(int fd, ucs_event_set_types_t events, void *arg)
 {
-    uct_ud_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_ud_mlx5_iface_t);
-    uct_ib_mlx5_md_t *ib_md    = ucs_derived_of(ib_iface->super.md,
-                                                uct_ib_mlx5_md_t);
+    uct_ud_mlx5_iface_t *iface = arg;
 
-    if (ucs_unlikely(ib_md->super.dev.flags & UCT_IB_DEVICE_FAILED)) {
-        return UCS_OK;
+    uct_ud_iface_async_progress(&iface->super);
+
+    uct_ib_iface_pre_arm(&iface->super.super);
+    uct_ib_mlx5dv_arm_cq(&iface->cq[UCT_IB_DIR_RX], 1);
+
+    ucs_assert(iface->super.async.event_cb != NULL);
+    iface->super.async.event_cb(iface->super.async.event_arg, 0);
+}
+
+ucs_status_t uct_ud_mlx5_iface_event_arm(uct_iface_h tl_iface, unsigned events)
+{
+    uct_ud_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_mlx5_iface_t);
+    uct_ib_mlx5_md_t *md       = ucs_derived_of(iface->super.super.super.md,
+                                                uct_ib_mlx5_md_t);
+    ucs_status_t status;
+    uint64_t dirs;
+    int dir;
+
+    uct_ud_enter(&iface->super);
+
+    status = uct_ud_iface_event_arm_common(&iface->super, events, &dirs);
+    if (status != UCS_OK) {
+        goto out;
     }
 
-#if HAVE_DECL_MLX5DV_INIT_OBJ
-    return uct_ib_mlx5dv_arm_cq(&iface->cq[dir], solicited);
-#else
-    uct_ib_mlx5_update_cq_ci(iface->super.super.cq[dir],
-                             iface->cq[dir].cq_ci);
-    return uct_ib_iface_arm_cq(ib_iface, dir, solicited);
-#endif
+    if (ucs_unlikely(md->super.dev.flags & UCT_IB_DEVICE_FAILED)) {
+        goto out;
+    }
+
+    ucs_for_each_bit(dir, dirs) {
+        ucs_assert(dir < UCT_IB_DIR_NUM);
+        uct_ib_mlx5dv_arm_cq(&iface->cq[dir], 0);
+    }
+
+    ucs_trace("iface %p: arm cq ok", iface);
+    status = UCS_OK;
+out:
+    uct_ud_leave(&iface->super);
+    return status;
 }
 
 static void uct_ud_mlx5_iface_event_cq(uct_ib_iface_t *ib_iface,
@@ -791,7 +813,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
             .ep_invalidate       = uct_ud_ep_invalidate
         },
         .create_cq      = uct_ud_mlx5_create_cq,
-        .arm_cq         = uct_ud_mlx5_iface_arm_cq,
+        .destroy_cq     = uct_ib_verbs_destroy_cq,
         .event_cq       = uct_ud_mlx5_iface_event_cq,
         .handle_failure = uct_ud_mlx5_iface_handle_failure,
     },
@@ -829,7 +851,7 @@ static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
     .iface_progress           = uct_ud_mlx5_iface_progress,
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)
                                 ucs_empty_function_return_unsupported,
-    .iface_event_arm          = uct_ud_iface_event_arm,
+    .iface_event_arm          = uct_ud_mlx5_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t),
     .iface_query              = uct_ud_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
@@ -914,6 +936,8 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
     init_attr.cq_len[UCT_IB_DIR_TX] = sq_length;
     init_attr.cq_len[UCT_IB_DIR_RX] = config->super.super.rx.queue_len;
 
+    uct_ib_mlx5_parse_cqe_zipping(md, &config->mlx5_common, &init_attr);
+
     self->tx.mmio_mode     = config->mlx5_common.mmio_mode;
     self->tx.wq.super.type = UCT_IB_MLX5_OBJ_TYPE_LAST;
 
@@ -950,7 +974,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
 
     /* write buffer sizes */
     for (i = 0; i <= self->rx.wq.mask; i++) {
-        self->rx.wq.wqes[i].byte_count = 
+        self->rx.wq.wqes[i].byte_count =
                 htonl(self->super.super.config.seg_size);
     }
 
@@ -958,7 +982,18 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
         uct_ud_mlx5_iface_post_recv(self);
     }
 
-    return uct_ud_iface_complete_init(&self->super);
+    status = uct_ud_iface_complete_init(&self->super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (self->super.async.event_cb != NULL) {
+        uct_ud_iface_set_event_cb(&self->super,
+                                  uct_ud_mlx5_iface_async_handler);
+        uct_ib_mlx5dv_arm_cq(&self->cq[UCT_IB_DIR_RX], 1);
+    }
+
+    return UCS_OK;
 }
 
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -259,6 +259,9 @@ ucs_status_t uct_ud_iface_flush(uct_iface_h tl_iface, unsigned flags,
 
 ucs_status_t uct_ud_iface_complete_init(uct_ud_iface_t *iface);
 
+ucs_status_t
+uct_ud_iface_set_event_cb(uct_ud_iface_t *iface, ucs_async_event_cb_t event_cb);
+
 void uct_ud_iface_remove_async_handlers(uct_ud_iface_t *iface);
 
 void uct_ud_dump_packet(uct_base_iface_t *iface, uct_am_trace_type_t type,
@@ -340,7 +343,8 @@ void uct_ud_iface_cep_remove_ep(uct_ud_iface_t *iface, uct_ud_ep_t *ep);
 
 unsigned uct_ud_iface_dispatch_pending_rx_do(uct_ud_iface_t *iface);
 
-ucs_status_t uct_ud_iface_event_arm(uct_iface_h tl_iface, unsigned events);
+ucs_status_t uct_ud_iface_event_arm_common(uct_ud_iface_t *iface,
+                                           unsigned events, uint64_t *dirs_p);
 
 void uct_ud_iface_progress_enable(uct_iface_h tl_iface, unsigned flags);
 

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -259,3 +259,20 @@ uct_ud_iov_to_skb(uct_ud_send_skb_t *skb, const uct_iov_t *iov, size_t iovcnt)
     skb->len += uct_iov_to_buffer(iov, iovcnt, &iov_iter, skb->neth + 1,
                                   SIZE_MAX);
 }
+
+static UCS_F_ALWAYS_INLINE void
+uct_ud_iface_async_progress(uct_ud_iface_t *iface)
+{
+    uct_ud_iface_ops_t *ops =
+        ucs_derived_of(iface->super.ops, uct_ud_iface_ops_t);
+    unsigned ev_count;
+
+    if (ucs_unlikely(iface->async.disable)) {
+        return;
+    }
+
+    ev_count = ops->async_progress(iface);
+    if (ev_count > 0) {
+        uct_ud_iface_raise_pending_async_ev(iface);
+    }
+}

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -56,8 +56,6 @@ void test_ucp_tag::enable_tag_mp_offload()
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MP_SRQ_ENABLE", "try"));
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_MP_NUM_STRIDES", "8"));
-    m_env.push_back(new ucs::scoped_setenv("UCX_IB_MLX5_DEVX_OBJECTS",
-                                           "dct,dcsrq,rcsrq,rcqp,dci"));
 }
 
 void test_ucp_tag::request_init(void *request)

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1230,7 +1230,7 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_wireup_unified, rc_dc, "rc,dc")
 
 class select_ep_transport : public test_ucp_wireup {
 public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_RMA, TEST_RMA, "rma");
     }


### PR DESCRIPTION
## What
CQ creation via DEVX API + using DEVX event channel for handling completion events.

## Why ?
This way of creation CQ allows to support more FW features (e.g. enhanced CQE zipping)

## How ?

Before moving this PR out of draft state, several "preparation" requests were merged:
- #8297
- #8299
- #8300
- #8302

At this moment union with both verbs and DEVX cq representation was created inside `uct_ib_mlx5_cq_t`. There is no any practical sense of keeping verbs part there at this moment but it's there to save the consistency of storing corresponding objects on the same abstraction level. The question of removing verbs representation from that union can be discussed separately.