### PR TITLE
UCT/IB/DC: Resend FC_HARD_REQ instead of scheduling EP on waitq [v1.13.x]

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -93,17 +93,14 @@ typedef enum {
     /** Flow control endpoint is using a DCI in error state */
     UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED             = UCS_BIT(3),
 
-    /** Ignore DCI allocation reorder */
-    UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER      = UCS_BIT(4),
-
     /** Enable full handshake for DCI */
-    UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE       = UCS_BIT(5),
+    UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE       = UCS_BIT(4),
 
     /** Enable full handshake for DCT */
-    UCT_DC_MLX5_IFACE_FLAG_DCT_FULL_HANDSHAKE       = UCS_BIT(6),
+    UCT_DC_MLX5_IFACE_FLAG_DCT_FULL_HANDSHAKE       = UCS_BIT(5),
 
     /** Disable PUT capability (RDMA_WRITE) */
-    UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT              = UCS_BIT(7)
+    UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT              = UCS_BIT(6)
 } uct_dc_mlx5_iface_flags_t;
 
 

--- a/src/uct/ib/dc/dc_mlx5.inl
+++ b/src/uct/ib/dc/dc_mlx5.inl
@@ -41,8 +41,7 @@ uct_dc_mlx5_get_arbiter_params(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
-                        int force)
+uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
         /* no dci:
@@ -50,7 +49,7 @@ uct_dc_mlx5_ep_schedule(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
          * arbiter. This way we can assure fairness between all eps waiting for
          * dci allocation. Relevant for dcs and dcs_quota policies.
          */
-        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, force);
+        uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
     } else {
         uct_dc_mlx5_iface_dci_sched_tx(iface, ep);
     }
@@ -84,5 +83,5 @@ uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
         return;
     }
 
-    uct_dc_mlx5_ep_schedule(iface, ep, 0);
+    uct_dc_mlx5_ep_schedule(iface, ep);
 }

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1518,7 +1518,7 @@ static unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
     kh_foreach_key(&iface->tx.fc_hash, ep_key, {
         ep     = (uct_dc_mlx5_ep_t*)ep_key;
         status = uct_dc_mlx5_ep_check_fc(iface, ep);
-        if ((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE)) {
+        if ((status != UCS_OK) && (status != UCS_ERR_NO_RESOURCE)) {
             ucs_warn("ep %p: flow-control check failed: %s", ep,
                      ucs_status_string(status));
         }

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1516,17 +1516,12 @@ static unsigned uct_dc_mlx5_ep_fc_hard_req_progress(void *arg)
      * resend FC_HARD_REQ packet to make sure a peer will resend FC_PURE_GRANT
      * packet in case of failure on the remote FC endpoint */
     kh_foreach_key(&iface->tx.fc_hash, ep_key, {
-        ep = (uct_dc_mlx5_ep_t*)ep_key;
-
-        /* Allocate DCI for the endpoint to schedule the endpoint to DCI wait
-         * queue if there is free DCI */
-        status = uct_dc_mlx5_iface_dci_get(iface, ep);
-        ucs_assertv((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE),
-                    "%s", ucs_status_string(status));
-
-        /* Force DCI scheduling, since FC resources may never become available
-         * unless we send FC_HARD_REQ packet */
-        uct_dc_mlx5_ep_schedule(iface, ep, 1);
+        ep     = (uct_dc_mlx5_ep_t*)ep_key;
+        status = uct_dc_mlx5_ep_check_fc(iface, ep);
+        if ((status == UCS_OK) || (status == UCS_ERR_NO_RESOURCE)) {
+            ucs_warn("ep %p: flow-control check failed: %s", ep,
+                     ucs_status_string(status));
+        }
     })
 
     return 1;
@@ -1646,7 +1641,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep, void *arg,
             /* Since DCI isn't assigned for the FC endpoint, schedule DCI
              * allocation for progressing possible FC_PURE_GRANT re-sending
              * operation which are scheduled on the pending queue */
-            uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, 0);
+            uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
         }
     }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -382,13 +382,12 @@ static inline int uct_dc_mlx5_iface_dci_ep_can_send(uct_dc_mlx5_ep_t *ep)
 
 static UCS_F_ALWAYS_INLINE
 void uct_dc_mlx5_iface_schedule_dci_alloc(uct_dc_mlx5_iface_t *iface,
-                                          uct_dc_mlx5_ep_t *ep, int force)
+                                          uct_dc_mlx5_ep_t *ep)
 {
     ucs_arbiter_t *waitq;
 
-    /* If FC window is empty and force scheduling wasn't requested, the group
-     * will be scheduled when grant is received */
-    if (force || uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
+    /* If FC window is empty the group will be scheduled when grant is received */
+    if (uct_rc_fc_has_resources(&iface->super.super, &ep->fc)) {
         waitq = uct_dc_mlx5_iface_dci_waitq(iface, uct_dc_mlx5_ep_pool_index(ep));
         ucs_arbiter_group_schedule(waitq, &ep->arb_group);
     }
@@ -476,7 +475,7 @@ uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
      * move the group to the 'wait for dci alloc' state
      */
     ucs_arbiter_group_desched(uct_dc_mlx5_iface_tx_waitq(iface), &ep->arb_group);
-    uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep, 0);
+    uct_dc_mlx5_iface_schedule_dci_alloc(iface, ep);
 }
 
 static inline void uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -600,10 +600,8 @@ uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
     }
 
     if (uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index)) {
-        if (!(iface->flags & UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER)) {
-            waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
-            ucs_assert(ucs_arbiter_is_empty(waitq));
-        }
+        waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
+        ucs_assert(ucs_arbiter_is_empty(waitq));
 
         uct_dc_mlx5_iface_dci_alloc(iface, ep);
         return UCS_OK;

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -619,7 +619,7 @@ void test_rc_flow_control::test_general(int wnd, int soft_thresh,
     flush();
 }
 
-void test_rc_flow_control::test_pending_grant(int wnd)
+void test_rc_flow_control::test_pending_grant(int wnd, uint64_t *wait_fc_seq)
 {
     /* Block send capabilities of m_e2 for fc grant to be
      * added to the pending queue. */
@@ -632,6 +632,12 @@ void test_rc_flow_control::test_pending_grant(int wnd)
      * should be in pending queue of m_e2. */
     send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
     EXPECT_LE(get_fc_ptr(m_e1)->fc_wnd, 0);
+
+    if (wait_fc_seq != NULL) {
+        uint64_t fc_seq_value = *wait_fc_seq;
+        wait_for_value(wait_fc_seq, fc_seq_value + 1, true);
+        EXPECT_GT(*wait_fc_seq, fc_seq_value);
+    }
 
     /* Enable send capabilities of m_e2 and send short put message to force
      * pending queue dispatch. Can't send AM message for that, because it may

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -136,7 +136,7 @@ public:
 
     void test_general(int wnd, int s_thresh, int h_thresh, bool is_fc_enabled);
 
-    void test_pending_grant(int wnd);
+    virtual void test_pending_grant(int wnd, uint64_t *wait_fc_seq = NULL);
 
     void test_pending_purge(int wnd, int num_pend_sends);
 


### PR DESCRIPTION
## What

Resend FC_HARD_REQ instead of scheduling EP on waitq.

## Why ?

To fix "timeout waiting for replies" errors seen on DC when running io-demo on large scale.

## How ?

Include commits from https://github.com/openucx/ucx/pull/8348 and https://github.com/openucx/ucx/pull/8351.
No merge conflicts.