### PR TITLE
UCP/WIREUP/SELECT: Update wireup lane bandwidth calculation

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1099,6 +1099,7 @@ ucp_wireup_iface_avail_bandwidth(const ucp_worker_iface_t *wiface,
 {
     ucp_context_h context     = wiface->worker->context;
     ucp_rsc_index_t dev_index = context->tl_rscs[wiface->rsc_index].dev_index;
+    double eps                = 1e-3;
     double local_bw, remote_bw;
 
     local_bw = ucp_tl_iface_bandwidth(context, &wiface->attr.bandwidth) *
@@ -1110,7 +1111,7 @@ ucp_wireup_iface_avail_bandwidth(const ucp_worker_iface_t *wiface,
                     context, remote_dev_count[remote_addr->dev_index],
                     remote_addr->dev_num_paths);
 
-    return ucs_min(local_bw, remote_bw);
+    return ucs_min(local_bw, remote_bw) + (eps * (local_bw + remote_bw));
 }
 
 static double


### PR DESCRIPTION
## What
Update lane bandwidth calculation in wireup.

## Why ?
Currently, we use the minimum of local and remote iface bandwidths to calculate lane scores. 
This can result in the same score for all lanes if the local (remote) ifaces have a lower bandwidth
than all remote (local) ifaces. This can lead to undesirable lane selections because the NIC-device
affinity on the remote (local) side is ignored.

## How ?
Add weighted sum of the local and remote iface bandwidths when calculating lane bandwidth for lane scores.
