### PR TITLE
add DC config to set lag_tx_port_affinity according to lag mode info

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -163,6 +163,7 @@ typedef struct uct_dc_mlx5_iface_config {
     uct_ud_iface_common_config_t        ud_common;
     int                                 ndci;
     int                                 tx_policy;
+    ucs_on_off_auto_value_t             tx_port_affinity;
     ucs_ternary_auto_value_t            dci_full_handshake;
     ucs_ternary_auto_value_t            dci_ka_full_handshake;
     ucs_ternary_auto_value_t            dct_full_handshake;
@@ -260,6 +261,8 @@ struct uct_dc_mlx5_iface {
         uct_dc_dci_t              *dcis;
 
         uint8_t                   ndci;                        /* Number of DCIs */
+
+        uint8_t                   port_affinity;               /* Whether to set port affinity */
 
         /* LIFO is only relevant for dcs allocation policy */
         uct_dc_mlx5_dci_pool_t    dci_pool[UCT_DC_MLX5_IFACE_MAX_DCI_POOLS];

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -136,8 +136,10 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     if (uct_ib_iface_is_roce(&rc_iface->super)) {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           rc_iface->super.config.sl);
-        uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
-                                               &opt_param_mask);
+        if (iface->tx.port_affinity) {
+            uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
+                                                   &opt_param_mask);
+        }
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl,
                           rc_iface->super.config.sl);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -8,9 +8,6 @@
 #  include "config.h"
 #endif
 
-#include "ib_mlx5_ifc.h"
-
-#include <uct/ib/mlx5/ib_mlx5.h>
 #include <uct/ib/mlx5/ib_mlx5.inl>
 #include <ucs/arch/bitops.h>
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -569,8 +569,20 @@ struct uct_ib_mlx5_query_hca_cap_in_bits {
     uint8_t    reserved_at_40[0x40];
 };
 
+typedef enum {
+    /* QP are associated with port affinity */
+    UCT_IB_MLX5_LAG_QUEUE_AFFINITY = 0x0,
+    /* packets go to egress port through FT */
+    UCT_IB_MLX5_LAG_PORT_SELECT_FT = 0x1,
+    /* FDB select packet flow egress port */
+    UCT_IB_MLX5_LAG_MULTI_PORT_ESW = 0x2,
+    UCT_IB_MLX5_LAG_INVALID_MODE   = 0xFF
+} uct_ib_port_select_mode_t;
+
 struct uct_ib_mlx5_lag_context_bits {
-    uint8_t    reserved_at_0[0x1d];
+    uint8_t    reserved_at_0[0x15];
+    uint8_t    port_select_mode[0x3];
+    uint8_t    reserved_at_18[0x5];
     uint8_t    lag_state[0x3];
     uint8_t    reserved_at_20[0x20];
 };

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -12,6 +12,7 @@
 #include <uct/base/uct_worker.h>
 #include <uct/ib/base/ib_log.h>
 #include <uct/ib/base/ib_device.h>
+#include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
 #include <ucs/type/status.h>
@@ -268,10 +269,11 @@ KHASH_MAP_INIT_INT(rkeys, uct_ib_mlx5_mem_lru_entry_t*);
  * MLX5 IB memory domain.
  */
 typedef struct uct_ib_mlx5_md {
-    uct_ib_md_t              super;
-    uint32_t                 flags;
-    ucs_mpool_t              dbrec_pool;
-    ucs_recursive_spinlock_t dbrec_lock;
+    uct_ib_md_t               super;
+    uint32_t                  flags;
+    ucs_mpool_t               dbrec_pool;
+    ucs_recursive_spinlock_t  dbrec_lock;
+    uct_ib_port_select_mode_t port_select_mode;
 #if HAVE_DEVX
     void                     *zero_buf;
     uct_ib_mlx5_devx_umem_t  zero_mem;

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -14,7 +14,6 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/async/async.h>
 #include <uct/ib/rc/base/rc_iface.h>
-#include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
 
 
 ucs_status_t uct_rc_mlx5_devx_iface_subscribe_event(

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -12,7 +12,6 @@
 #include <uct/ib/mlx5/ib_mlx5.h>
 #include <uct/ib/mlx5/ib_mlx5_log.h>
 #include <uct/ib/mlx5/dv/ib_mlx5_dv.h>
-#include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
 #include <uct/ib/base/ib_device.h>
 #include <uct/base/uct_md.h>
 #include <ucs/arch/cpu.h>


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <jerrliu@nvidia.com>

## What
Check lag mode info to decide set lag_tx_port_affinity or not.
Add configuration to ```force set```/```force not set```/```auto detect decision``` to configure DCI lag_tx_port_affinity.

## Why ?
In hash mode under non-switchdev, it's better to not set lag_tx_port_affinity to decrease explicit port flow table overhead.

## How ?
Define new IFC bits ```uct_ib_mlx5_lag_context_bits::port_select_mode``` to get lag mode info.
For lag device,
1. When ```UCX_DC_MLX5_LAG_PORT_SELECT=auto```(default)
In **hash mode** under non-switchdev, this PR does not set DCI lag_tx_port_affinity.
```if lag device supports bypass port select flow table```, it's better to not set lag_tx_port_affinity to decrease explicit port flow table overhead.
```if lag device does not support bypass port select flow table```, it's not effective to set lag_tx_port_affinity at all.
In **queue_affinity** mode, this PR decides to set lag_tx_port_affinity.

2. When ```UCX_DC_MLX5_LAG_PORT_SELECT=affinity```
In **hash mode** under non-switchdev, this PR do set DCI lag_tx_port_affinity.
```if lag device supports bypass port select flow table```,  it's effective to set the affinity.
```if lag device does not support bypass port select flow table```, it's not effective to set lag_tx_port_affinity at all. This doesn't matter.
In **queue_affinity** mode, it's effective to set the affinity.

3. When ```UCX_DC_MLX5_LAG_PORT_SELECT=hash```
In **hash mode** under non-switchdev, this PR does not set DCI lag_tx_port_affinity.
```if lag device supports bypass port select flow table```,  this is the expected configuration to avoid overload explicit flow table.
```if lag device does not support bypass port select flow table```, there's no extra effect at all because it's event not effective to set lag_tx_port_affinity in this case.
In **queue_affinity** mode, because it doesn't set lag_tx_port_affinity explicitly, FW will set it in round roubin method.