### PR TITLE
UCP/AM: refactor ucp_request_t::send::msg_proto::am

### DIFF
--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -59,6 +59,7 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
 {
     ucp_mem_desc_t *reg_desc;
 
+    /* reg_desc could already be allocated for a replayed request */
     if (req->send.msg_proto.am.header.reg_desc != NULL) {
         return UCS_OK;
     }
@@ -69,7 +70,7 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
     }
 
     if (req->send.msg_proto.am.header.length != 0) {
-        ucs_assert(req->send.msg_proto.am.header.usr_ptr != NULL);
+        ucs_assert(req->send.msg_proto.am.header.user_ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);
     }
 

--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -20,14 +20,14 @@
 static UCS_F_ALWAYS_INLINE size_t ucp_am_send_req_total_size(ucp_request_t *req)
 {
     return req->send.state.dt_iter.length +
-           req->send.msg_proto.am.header_length;
+           req->send.msg_proto.am.header.length;
 }
 
 static UCS_F_ALWAYS_INLINE ssize_t
 ucp_am_eager_bcopy_pack(void *buffer, ucp_request_t *req, size_t length,
                         ucp_datatype_iter_t *next_iter)
 {
-    unsigned user_header_length = req->send.msg_proto.am.header_length;
+    unsigned user_header_length = req->send.msg_proto.am.header.length;
     size_t total_length;
     void *user_hdr;
 
@@ -49,8 +49,8 @@ static void ucp_am_eager_zcopy_completion(uct_completion_t *self)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
 
-    ucs_assert(req->send.msg_proto.am.reg_desc != NULL);
-    ucs_mpool_put_inline(req->send.msg_proto.am.reg_desc);
+    ucs_assert(req->send.msg_proto.am.header.reg_desc != NULL);
+    ucs_mpool_put_inline(req->send.msg_proto.am.header.reg_desc);
     ucp_proto_request_zcopy_completion(self);
 }
 
@@ -59,18 +59,21 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
 {
     ucp_mem_desc_t *reg_desc;
 
+    if (req->send.msg_proto.am.header.reg_desc != NULL) {
+        return UCS_OK;
+    }
+
     reg_desc = ucp_worker_mpool_get(&req->send.ep->worker->reg_mp);
     if (ucs_unlikely(reg_desc == NULL)) {
         return UCS_ERR_NO_MEMORY;
     }
 
-    if (req->send.msg_proto.am.header_length != 0) {
-        ucs_assert(req->send.msg_proto.am.header != NULL);
+    if (req->send.msg_proto.am.header.length != 0) {
+        ucs_assert(req->send.msg_proto.am.header.usr_ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);
     }
 
-    req->send.msg_proto.am.reg_desc = reg_desc;
-
+    req->send.msg_proto.am.header.reg_desc = reg_desc;
     return UCS_OK;
 }
 
@@ -78,7 +81,7 @@ static UCS_F_ALWAYS_INLINE void ucp_am_eager_zcopy_add_footer(
         ucp_request_t *req, size_t offset, ucp_rsc_index_t md_index,
         uct_iov_t *iov, size_t *iovcnt, size_t footer_size)
 {
-    ucp_mem_desc_t *reg_desc = req->send.msg_proto.am.reg_desc;
+    ucp_mem_desc_t *reg_desc = req->send.msg_proto.am.header.reg_desc;
     void *buffer;
     uct_mem_h memh;
 

--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -116,7 +116,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_bcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter)
 {
-    size_t user_hdr_size = req->send.msg_proto.am.header_length;
+    size_t user_hdr_size = req->send.msg_proto.am.header.length;
 
     return ucp_proto_eager_bcopy_multi_common_send_func(
             req, lpriv, next_iter, UCP_AM_ID_AM_FIRST,
@@ -209,7 +209,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_zcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter)
 {
-    size_t user_hdr_size = req->send.msg_proto.am.header_length;
+    size_t user_hdr_size = req->send.msg_proto.am.header.length;
     union {
         ucp_am_hdr_t     first;
         ucp_am_mid_hdr_t middle;
@@ -229,7 +229,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_zcopy_send_func(
         ucp_am_fill_header(&hdr.first, req);
         /* The method also fills middle/last fragment footer. The footer can be
            reused by all fragments because it is immutable. */
-        ftr = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.reg_desc + 1,
+        ftr = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.header.reg_desc + 1,
                                   user_hdr_size);
         ucp_am_eager_fill_first_footer(ftr, req);
     } else {

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -28,7 +28,7 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
-    uint32_t header_length               = req->send.msg_proto.am.header_length;
+    uint32_t header_length               = req->send.msg_proto.am.header.length;
     size_t iov_cnt                       = 0ul;
     uct_iov_t iov[3];
     ucp_am_hdr_t am_hdr;
@@ -45,8 +45,8 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
                          &iov_cnt);
 
     if (header_length != 0) {
-        ucp_add_uct_iov_elem(iov,req->send.msg_proto.am.header, header_length,
-                             UCT_MEM_HANDLE_NULL, &iov_cnt);
+        ucp_add_uct_iov_elem(iov,req->send.msg_proto.am.header.usr_ptr,
+                             header_length, UCT_MEM_HANDLE_NULL, &iov_cnt);
     }
 
     if (is_reply) {
@@ -348,7 +348,7 @@ ucp_am_eager_single_zcopy_send_func(ucp_request_t *req,
     ucp_am_fill_header(&hdr, req);
 
     ucp_am_eager_zcopy_add_footer(req, 0, spriv->super.md_index, iov, &iovcnt,
-                                  req->send.msg_proto.am.header_length);
+                                  req->send.msg_proto.am.header.length);
 
     return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),
                            UCP_AM_ID_AM_SINGLE, &hdr, sizeof(hdr), iov, iovcnt,
@@ -408,14 +408,14 @@ ucp_am_eager_single_zcopy_reply_send_func(ucp_request_t *req,
     ucp_am_reply_ftr_t *ftr;
 
     ucp_am_fill_header(&hdr, req);
-    ucs_assert(req->send.msg_proto.am.reg_desc != NULL);
+    ucs_assert(req->send.msg_proto.am.header.reg_desc != NULL);
 
-    ftr = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.reg_desc + 1,
-                              req->send.msg_proto.am.header_length);
+    ftr = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.header.reg_desc + 1,
+                              req->send.msg_proto.am.header.length);
     ucp_am_eager_fill_reply_footer(ftr, req);
 
     ucp_am_eager_zcopy_add_footer(req, 0, spriv->super.md_index, iov, &iovcnt,
-                                  req->send.msg_proto.am.header_length +
+                                  req->send.msg_proto.am.header.length +
                                           sizeof(*ftr));
 
     return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, spriv->super.lane),

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -45,7 +45,7 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
                          &iov_cnt);
 
     if (header_length != 0) {
-        ucp_add_uct_iov_elem(iov,req->send.msg_proto.am.header.usr_ptr,
+        ucp_add_uct_iov_elem(iov,req->send.msg_proto.am.header.user_ptr,
                              header_length, UCT_MEM_HANDLE_NULL, &iov_cnt);
     }
 

--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -24,7 +24,7 @@ static size_t ucp_am_rndv_rts_pack(void *dest, void *arg)
     rts_size        = ucp_proto_rndv_rts_pack(req, rts_hdr, sizeof(*rts_hdr));
     ucp_am_pack_user_header(UCS_PTR_BYTE_OFFSET(rts_hdr, rts_size), req);
 
-    return rts_size + req->send.msg_proto.am.header_length;
+    return rts_size + req->send.msg_proto.am.header.length;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
@@ -43,7 +43,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
     }
 
     max_rts_size = sizeof(ucp_rndv_rts_hdr_t) + rpriv->packed_rkey_size +
-                   req->send.msg_proto.am.header_length;
+                   req->send.msg_proto.am.header.length;
     return UCS_PROFILE_CALL(ucp_proto_am_bcopy_single_progress, req,
                             UCP_AM_ID_RNDV_RTS, rpriv->lane,
                             ucp_am_rndv_rts_pack, req, max_rts_size, NULL);

--- a/src/ucp/am/ucp_am.inl
+++ b/src/ucp/am/ucp_am.inl
@@ -19,7 +19,7 @@ ucp_am_fill_header(ucp_am_hdr_t *hdr, ucp_request_t *req)
 {
     hdr->am_id         = req->send.msg_proto.am.am_id;
     hdr->flags         = req->send.msg_proto.am.flags;
-    hdr->header_length = req->send.msg_proto.am.header_length;
+    hdr->header_length = req->send.msg_proto.am.header.length;
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -370,7 +370,7 @@ ucp_am_zcopy_pack_user_header(ucp_request_t *req)
     }
 
     if (req->send.msg_proto.am.header.length != 0) {
-        ucs_assert(req->send.msg_proto.am.header.usr_ptr != NULL);
+        ucs_assert(req->send.msg_proto.am.header.user_ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);
     }
 
@@ -576,7 +576,7 @@ static ucs_status_t ucp_am_contig_short(uct_pending_req_t *self)
     req->send.lane = ucp_ep_get_am_lane(ep);
     status         = ucp_am_send_short(ep, req->send.msg_proto.am.am_id,
                                        req->send.msg_proto.am.flags,
-                                       req->send.msg_proto.am.header.usr_ptr,
+                                       req->send.msg_proto.am.header.user_ptr,
                                        req->send.msg_proto.am.header.length,
                                        req->send.buffer, req->send.length, 0);
     return ucp_am_short_handle_status_from_pending(req, status);
@@ -591,7 +591,7 @@ static ucs_status_t ucp_am_contig_short_reply(uct_pending_req_t *self)
     req->send.lane = ucp_ep_get_am_lane(ep);
     status         = ucp_am_send_short(ep, req->send.msg_proto.am.am_id,
                                        req->send.msg_proto.am.flags,
-                                       req->send.msg_proto.am.header.usr_ptr,
+                                       req->send.msg_proto.am.header.user_ptr,
                                        req->send.msg_proto.am.header.length,
                                        req->send.buffer, req->send.length, 1);
     return ucp_am_short_handle_status_from_pending(req, status);
@@ -794,7 +794,7 @@ static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
     req->send.ep                           = ep;
     req->send.msg_proto.am.am_id           = am_id;
     req->send.msg_proto.am.flags           = flags;
-    req->send.msg_proto.am.header.usr_ptr  = (void*)header;
+    req->send.msg_proto.am.header.user_ptr = (void*)header;
     req->send.msg_proto.am.header.reg_desc = NULL;
     req->send.msg_proto.am.header.length   = header_length;
     req->send.buffer                       = (void*)buffer;
@@ -1018,7 +1018,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
     if (worker->context->config.ext.proto_enable) {
         req->send.msg_proto.am.am_id           = id;
         req->send.msg_proto.am.flags           = flags;
-        req->send.msg_proto.am.header.usr_ptr  = (void*)header;
+        req->send.msg_proto.am.header.user_ptr = (void*)header;
         req->send.msg_proto.am.header.reg_desc = NULL;
         req->send.msg_proto.am.header.length   = header_length;
         ret = ucp_proto_request_send_op(ep, &ucp_ep_config(ep)->proto_select,

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -308,7 +308,7 @@ static UCS_F_ALWAYS_INLINE int ucp_am_recv_check_id(ucp_worker_h worker,
 static UCS_F_ALWAYS_INLINE size_t
 ucp_am_send_req_total_size(ucp_request_t *req)
 {
-    return req->send.length + req->send.msg_proto.am.header_length;
+    return req->send.length + req->send.msg_proto.am.header.length;
 }
 
 static UCS_F_ALWAYS_INLINE ssize_t
@@ -324,7 +324,7 @@ ucp_am_fill_header(ucp_am_hdr_t *hdr, ucp_request_t *req)
 {
     hdr->am_id         = req->send.msg_proto.am.am_id;
     hdr->flags         = req->send.msg_proto.am.flags;
-    hdr->header_length = req->send.msg_proto.am.header_length;
+    hdr->header_length = req->send.msg_proto.am.header.length;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -369,13 +369,12 @@ ucp_am_zcopy_pack_user_header(ucp_request_t *req)
         return UCS_ERR_NO_MEMORY;
     }
 
-    if (req->send.msg_proto.am.header_length != 0) {
-        ucs_assert(req->send.msg_proto.am.header != NULL);
+    if (req->send.msg_proto.am.header.length != 0) {
+        ucs_assert(req->send.msg_proto.am.header.usr_ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);
     }
 
-    req->send.msg_proto.am.reg_desc = reg_desc;
-
+    req->send.msg_proto.am.header.reg_desc = reg_desc;
     return UCS_OK;
 }
 
@@ -416,7 +415,7 @@ out:
 static UCS_F_ALWAYS_INLINE ssize_t
 ucp_am_bcopy_pack_data(void *buffer, ucp_request_t *req, size_t length)
 {
-    unsigned user_header_length = req->send.msg_proto.am.header_length;
+    unsigned user_header_length = req->send.msg_proto.am.header.length;
     size_t payload_length       = length - user_header_length;
     void *user_hdr;
 
@@ -577,8 +576,8 @@ static ucs_status_t ucp_am_contig_short(uct_pending_req_t *self)
     req->send.lane = ucp_ep_get_am_lane(ep);
     status         = ucp_am_send_short(ep, req->send.msg_proto.am.am_id,
                                        req->send.msg_proto.am.flags,
-                                       req->send.msg_proto.am.header,
-                                       req->send.msg_proto.am.header_length,
+                                       req->send.msg_proto.am.header.usr_ptr,
+                                       req->send.msg_proto.am.header.length,
                                        req->send.buffer, req->send.length, 0);
     return ucp_am_short_handle_status_from_pending(req, status);
 }
@@ -592,8 +591,8 @@ static ucs_status_t ucp_am_contig_short_reply(uct_pending_req_t *self)
     req->send.lane = ucp_ep_get_am_lane(ep);
     status         = ucp_am_send_short(ep, req->send.msg_proto.am.am_id,
                                        req->send.msg_proto.am.flags,
-                                       req->send.msg_proto.am.header,
-                                       req->send.msg_proto.am.header_length,
+                                       req->send.msg_proto.am.header.usr_ptr,
+                                       req->send.msg_proto.am.header.length,
                                        req->send.buffer, req->send.length, 1);
     return ucp_am_short_handle_status_from_pending(req, status);
 }
@@ -628,7 +627,7 @@ static UCS_F_ALWAYS_INLINE void ucp_am_zcopy_complete_common(ucp_request_t *req)
 {
     ucs_assert(req->send.state.uct_comp.count == 0);
 
-    ucs_mpool_put_inline(req->send.msg_proto.am.reg_desc);
+    ucs_mpool_put_inline(req->send.msg_proto.am.header.reg_desc);
     ucp_request_send_buffer_dereg(req); /* TODO register+lane change */
 }
 
@@ -671,8 +670,8 @@ static ucs_status_t ucp_am_zcopy_single(uct_pending_req_t *self)
     ucp_am_fill_header(&hdr, req);
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_AM_SINGLE, &hdr, sizeof(hdr),
-                                  req->send.msg_proto.am.reg_desc,
-                                  req->send.msg_proto.am.header_length,
+                                  req->send.msg_proto.am.header.reg_desc,
+                                  req->send.msg_proto.am.header.length,
                                   ucp_am_zcopy_req_complete);
 }
 
@@ -683,15 +682,16 @@ static ucs_status_t ucp_am_zcopy_single_reply(uct_pending_req_t *self)
     ucp_am_reply_ftr_t *ftr;
 
     ucp_am_fill_header(&hdr, req);
-    ucs_assert(req->send.msg_proto.am.reg_desc != NULL);
+    ucs_assert(req->send.msg_proto.am.header.reg_desc != NULL);
 
-    ftr        = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.reg_desc + 1,
-                                     req->send.msg_proto.am.header_length);
+    ftr        = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.header.reg_desc + 1,
+                                     req->send.msg_proto.am.header.length);
     ftr->ep_id = ucp_send_request_get_ep_remote_id(req);
 
     return ucp_do_am_zcopy_single(self, UCP_AM_ID_AM_SINGLE_REPLY, &hdr,
-                                  sizeof(hdr), req->send.msg_proto.am.reg_desc,
-                                  req->send.msg_proto.am.header_length +
+                                  sizeof(hdr),
+                                  req->send.msg_proto.am.header.reg_desc,
+                                  req->send.msg_proto.am.header.length +
                                           sizeof(*ftr),
                                   ucp_am_zcopy_req_complete);
 }
@@ -699,7 +699,7 @@ static ucs_status_t ucp_am_zcopy_single_reply(uct_pending_req_t *self)
 static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
 {
     ucp_request_t *req       = ucs_container_of(self, ucp_request_t, send.uct);
-    unsigned user_hdr_length = req->send.msg_proto.am.header_length;
+    unsigned user_hdr_length = req->send.msg_proto.am.header.length;
     ucp_am_hdr_t hdr;
     ucp_am_mid_hdr_t mid_hdr;
     ucp_am_first_ftr_t *first_ftr;
@@ -707,8 +707,8 @@ static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
     /* This footer is also used for middle fragments, because it contains
      * common persistent request info (ep id and msg id)
      */
-    first_ftr = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.reg_desc + 1,
-                                    req->send.msg_proto.am.header_length);
+    first_ftr = UCS_PTR_BYTE_OFFSET(req->send.msg_proto.am.header.reg_desc + 1,
+                                    req->send.msg_proto.am.header.length);
     ucp_am_fill_first_footer(first_ftr, req);
 
     if (req->send.state.dt.offset != 0) {
@@ -716,7 +716,7 @@ static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
         return ucp_do_am_zcopy_multi(self, UCP_AM_ID_AM_FIRST,
                                      UCP_AM_ID_AM_MIDDLE, NULL, 0ul, &mid_hdr,
                                      sizeof(mid_hdr),
-                                     req->send.msg_proto.am.reg_desc,
+                                     req->send.msg_proto.am.header.reg_desc,
                                      sizeof(first_ftr->super), user_hdr_length,
                                      ucp_am_zcopy_req_complete, 1);
     }
@@ -725,7 +725,7 @@ static ucs_status_t ucp_am_zcopy_multi(uct_pending_req_t *self)
 
     return ucp_do_am_zcopy_multi(self, UCP_AM_ID_AM_FIRST, UCP_AM_ID_AM_MIDDLE,
                                  &hdr, sizeof(hdr), NULL, 0ul,
-                                 req->send.msg_proto.am.reg_desc,
+                                 req->send.msg_proto.am.header.reg_desc,
                                  user_hdr_length + sizeof(*first_ftr), 0ul,
                                  ucp_am_zcopy_req_complete, 1);
 }
@@ -736,17 +736,17 @@ static size_t ucp_am_rndv_rts_pack(void *dest, void *arg)
     ucp_rndv_rts_hdr_t *rts_hdr = dest;
     size_t max_bcopy            = ucp_ep_get_max_bcopy(sreq->send.ep,
                                                        sreq->send.lane);
+    size_t hdr_size             = sreq->send.msg_proto.am.header.length;
     size_t rts_size, total_size;
 
     ucp_am_fill_header(ucp_am_hdr_from_rts(rts_hdr), sreq);
     rts_size = ucp_rndv_rts_pack(sreq, rts_hdr, UCP_RNDV_RTS_AM);
 
-    if (sreq->send.msg_proto.am.header_length == 0) {
+    if (hdr_size == 0) {
         return rts_size;
     }
 
-    total_size = rts_size + sreq->send.msg_proto.am.header_length;
-
+    total_size = rts_size + hdr_size;
     if (ucs_unlikely(total_size > max_bcopy)) {
         ucs_fatal("RTS is too big %lu, max %lu", total_size, max_bcopy);
     }
@@ -764,7 +764,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_am_rndv_rts, (self),
     /* RTS consists of: AM RTS header, packed rkeys and user header */
     return ucp_rndv_send_rts(sreq, ucp_am_rndv_rts_pack,
                              sizeof(ucp_rndv_rts_hdr_t) +
-                                     sreq->send.msg_proto.am.header_length);
+                                     sreq->send.msg_proto.am.header.length);
 }
 
 static ucs_status_t
@@ -790,16 +790,17 @@ static void ucp_am_send_req_init(ucp_request_t *req, ucp_ep_h ep,
                                  size_t count, uint16_t flags, uint16_t am_id,
                                  const ucp_request_param_t *param)
 {
-    req->flags                           = UCP_REQUEST_FLAG_SEND_AM;
-    req->send.ep                         = ep;
-    req->send.msg_proto.am.am_id         = am_id;
-    req->send.msg_proto.am.flags         = flags;
-    req->send.msg_proto.am.header        = (void*)header;
-    req->send.msg_proto.am.header_length = header_length;
-    req->send.buffer                     = (void*)buffer;
-    req->send.datatype                   = datatype;
-    req->send.lane                       = ep->am_lane;
-    req->send.pending_lane               = UCP_NULL_LANE;
+    req->flags                             = UCP_REQUEST_FLAG_SEND_AM;
+    req->send.ep                           = ep;
+    req->send.msg_proto.am.am_id           = am_id;
+    req->send.msg_proto.am.flags           = flags;
+    req->send.msg_proto.am.header.usr_ptr  = (void*)header;
+    req->send.msg_proto.am.header.reg_desc = NULL;
+    req->send.msg_proto.am.header.length   = header_length;
+    req->send.buffer                       = (void*)buffer;
+    req->send.datatype                     = datatype;
+    req->send.lane                         = ep->am_lane;
+    req->send.pending_lane                 = UCP_NULL_LANE;
 
     ucp_request_send_state_init(req, datatype, count);
     req->send.length   = ucp_dt_length(req->send.datatype, count,
@@ -836,7 +837,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
                 const ucp_request_send_proto_t *proto, ssize_t max_short,
                 uint32_t flags)
 {
-    unsigned user_header_length = req->send.msg_proto.am.header_length;
+    unsigned user_header_length = req->send.msg_proto.am.header.length;
     ucp_context_t *context      = req->send.ep->worker->context;
     ucp_ep_config_t *ep_config  = ucp_ep_config(req->send.ep);
     size_t rndv_thresh;
@@ -865,8 +866,7 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
                   " buffer=%p length=%zu header_length=%u max_short=%zd"
                   " rndv_thresh=%zu zcopy_thresh=%zu",
                   req, req->send.datatype, req->send.buffer, req->send.length,
-                  req->send.msg_proto.am.header_length, max_short, rndv_thresh,
-                  zcopy_thresh);
+                  user_header_length, max_short, rndv_thresh, zcopy_thresh);
 
     status = ucp_request_send_start(req, max_short, zcopy_thresh, rndv_thresh,
                                     count, !!user_header_length,
@@ -1016,10 +1016,11 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
                                  goto out;});
 
     if (worker->context->config.ext.proto_enable) {
-        req->send.msg_proto.am.am_id         = id;
-        req->send.msg_proto.am.flags         = flags;
-        req->send.msg_proto.am.header        = (void*)header;
-        req->send.msg_proto.am.header_length = header_length;
+        req->send.msg_proto.am.am_id           = id;
+        req->send.msg_proto.am.flags           = flags;
+        req->send.msg_proto.am.header.usr_ptr  = (void*)header;
+        req->send.msg_proto.am.header.reg_desc = NULL;
+        req->send.msg_proto.am.header.length   = header_length;
         ret = ucp_proto_request_send_op(ep, &ucp_ep_config(ep)->proto_select,
                                         UCP_WORKER_CFG_INDEX_NULL, req, op_id,
                                         buffer, count, datatype, contig_length,

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -184,7 +184,7 @@ struct ucp_request {
 
                         struct {
                             struct {
-                                void           *usr_ptr;
+                                void           *user_ptr;
                                 ucp_mem_desc_t *reg_desc; /* pointer to pre-registered buffer,
                                                              used for sending header with
                                                              zcopy protocol */

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -183,15 +183,14 @@ struct ucp_request {
                         ucp_tag_t tag;
 
                         struct {
-                            union {
-                                /* Can be union, because once header is packed to
-                                 * reg_desc, it is not accessed anymore. */
-                                void           *header;
+                            struct {
+                                void           *usr_ptr;
                                 ucp_mem_desc_t *reg_desc; /* pointer to pre-registered buffer,
                                                              used for sending header with
                                                              zcopy protocol */
-                            };
-                            uint32_t       header_length;
+                                uint32_t       length;
+                            } header UCS_S_PACKED; /* packed to avoid 32-bit
+                                                      padding */
                             uint16_t       am_id;
                             uint16_t       flags;
                         } am;

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -613,7 +613,7 @@ ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
 
     ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
                 UCS_MEMORY_TYPE_HOST, buffer,
-                req->send.msg_proto.am.header.usr_ptr, &hdr_state,
+                req->send.msg_proto.am.header.user_ptr, &hdr_state,
                 req->send.msg_proto.am.header.length);
 }
 

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -612,8 +612,9 @@ ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
     hdr_state.offset = 0ul;
 
     ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
-                UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header,
-                &hdr_state, req->send.msg_proto.am.header_length);
+                UCS_MEMORY_TYPE_HOST, buffer,
+                req->send.msg_proto.am.header.usr_ptr, &hdr_state,
+                req->send.msg_proto.am.header.length);
 }
 
 #endif


### PR DESCRIPTION
## What
refactor ucp_request_t::send::msg_proto::am

## Why ?
this is a preparation to re-initialization of protocol related part of request
from pending queue in case when ep is reconfigured during wireup.

## How?
replace union of user header and reg_desc with structure