### PR TITLE
GTEST/UCT/DC: Dispatch pending ops to fix DCI reordering

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -90,17 +90,14 @@ typedef enum {
     /** Flow control endpoint is using a DCI in error state */
     UCT_DC_MLX5_IFACE_FLAG_FC_EP_FAILED             = UCS_BIT(3),
 
-    /** Ignore DCI allocation reorder */
-    UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER      = UCS_BIT(4),
-
     /** Enable full handshake for DCI */
-    UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE       = UCS_BIT(5),
+    UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE       = UCS_BIT(4),
 
     /** Enable full handshake for DCT */
-    UCT_DC_MLX5_IFACE_FLAG_DCT_FULL_HANDSHAKE       = UCS_BIT(6),
+    UCT_DC_MLX5_IFACE_FLAG_DCT_FULL_HANDSHAKE       = UCS_BIT(5),
 
     /** Disable PUT capability (RDMA_WRITE) */
-    UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT              = UCS_BIT(7)
+    UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT              = UCS_BIT(6)
 } uct_dc_mlx5_iface_flags_t;
 
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -592,10 +592,8 @@ uct_dc_mlx5_iface_dci_get(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
     }
 
     if (uct_dc_mlx5_iface_dci_can_alloc(iface, pool_index)) {
-        if (!(iface->flags & UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER)) {
-            waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
-            ucs_assert(ucs_arbiter_is_empty(waitq));
-        }
+        waitq = uct_dc_mlx5_iface_dci_waitq(iface, pool_index);
+        ucs_assert(ucs_arbiter_is_empty(waitq));
 
         uct_dc_mlx5_iface_dci_alloc(iface, ep);
         return UCS_OK;


### PR DESCRIPTION
## What

Dispatch pending ops to fix DCI reordering.

## Why ?

Fixes #8381.
DCI/TX arbiters should be dispatched when resources become available.

## How ?

1. Update `test_dc_flow::enable_entity` to progress pending operations when DCIs become available.
2. Remove `UCT_DC_MLX5_IFACE_IGNORE_DCI_WAITQ_REORDER` flag and code places which set/check it, because it's no longer needed.