### PR TITLE
UCP/RMA/GTEST: Add support of user's memh for RMA operations

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -81,11 +81,11 @@ public class UcpEndpointTest extends UcxTest {
         src2.setData(UcpMemoryTest.RANDOM_TEXT + UcpMemoryTest.RANDOM_TEXT);
 
         // Register source buffers on context2
-        UcpMemory memory1 = src1.getMemory();
-        UcpMemory memory2 = src2.getMemory();
+        UcpMemory remote_memory1 = src1.getMemory();
+        UcpMemory remote_memory2 = src2.getMemory();
 
-        UcpRemoteKey rkey1 = endpoint.unpackRemoteKey(memory1.getRemoteKeyBuffer());
-        UcpRemoteKey rkey2 = endpoint.unpackRemoteKey(memory2.getRemoteKeyBuffer());
+        UcpRemoteKey rkey1 = endpoint.unpackRemoteKey(remote_memory1.getRemoteKeyBuffer());
+        UcpRemoteKey rkey2 = endpoint.unpackRemoteKey(remote_memory2.getRemoteKeyBuffer());
 
         AtomicInteger numCompletedRequests = new AtomicInteger(0);
 
@@ -96,13 +96,17 @@ public class UcpEndpointTest extends UcxTest {
             }
         };
 
+        // Register destination buffers on context1
+        UcpMemory local_memory1 = dst1.getMemory();
+        UcpMemory local_memory2 = dst2.getMemory();
+
         // Submit 2 get requests
-        UcpRequest request1 = endpoint.getNonBlocking(memory1.getAddress(), rkey1,
-            dst1.getMemory().getAddress(), dst1.getMemory().getLength(), callback,
-            new UcpRequestParams().setMemoryHandle(memory1).setMemoryType(memType));
-        UcpRequest request2 = endpoint.getNonBlocking(memory2.getAddress(), rkey2,
-            dst2.getMemory().getAddress(), dst2.getMemory().getLength(), callback,
-            new UcpRequestParams().setMemoryHandle(memory2).setMemoryType(memType));
+        UcpRequest request1 = endpoint.getNonBlocking(remote_memory1.getAddress(), rkey1,
+            local_memory1.getAddress(), local_memory1.getLength(), callback,
+            new UcpRequestParams().setMemoryHandle(local_memory1).setMemoryType(memType));
+        UcpRequest request2 = endpoint.getNonBlocking(remote_memory2.getAddress(), rkey2,
+            local_memory2.getAddress(), local_memory2.getLength(), callback,
+            new UcpRequestParams().setMemoryHandle(local_memory2).setMemoryType(memType));
 
         // Wait for 2 get operations to complete
         while (numCompletedRequests.get() != 2) {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -157,6 +157,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
     key->rkey_ptr_lane    = UCP_NULL_LANE;
     key->tag_lane         = UCP_NULL_LANE;
     key->rma_bw_md_map    = 0;
+    key->rma_md_map       = 0;
     key->reachable_md_map = 0;
     key->dst_md_cmpts     = NULL;
     key->err_mode         = UCP_ERR_HANDLING_MODE_NONE;
@@ -1779,6 +1780,7 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                sizeof(key1->rma_bw_lanes)) ||
         memcmp(key1->amo_lanes, key2->amo_lanes, sizeof(key1->amo_lanes)) ||
         (key1->rma_bw_md_map != key2->rma_bw_md_map) ||
+        (key1->rma_md_map != key2->rma_md_map) ||
         (key1->reachable_md_map != key2->reachable_md_map) ||
         (key1->am_lane != key2->am_lane) ||
         (key1->tag_lane != key2->tag_lane) ||
@@ -3034,11 +3036,16 @@ static void ucp_ep_config_print(FILE *stream, ucp_worker_h worker,
         }
     }
 
-    if (context->config.features &
-        (UCP_FEATURE_TAG | UCP_FEATURE_RMA | UCP_FEATURE_AM)) {
+    if (context->config.features & (UCP_FEATURE_TAG | UCP_FEATURE_AM)) {
         fprintf(stream, "#\n");
         fprintf(stream, "# %23s: mds ", "rma_bw");
         ucs_for_each_bit(md_index, config->key.rma_bw_md_map) {
+            fprintf(stream, "[%d] ", md_index);
+        }
+
+        fprintf(stream, "#\n");
+        fprintf(stream, "# %23s: mds ", "rma");
+        ucs_for_each_bit(md_index, config->key.rma_md_map) {
             fprintf(stream, "[%d] ", md_index);
         }
     }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -219,6 +219,9 @@ struct ucp_ep_config_key {
      * since these are the MDs used by remote side for accessing our memory. */
     ucp_md_map_t             rma_bw_md_map;
 
+    /* Local memory domains to use for RMA protocol. */
+    ucp_md_map_t             rma_md_map;
+
     /* Bitmap of remote mds which are reachable from this endpoint (with any set
      * of transports which could be selected in the future).
      */

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -123,13 +123,18 @@ static void ucp_rma_request_zcopy_completion(uct_completion_t *self)
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
                      size_t length, uint64_t remote_addr, ucp_rkey_h rkey,
-                     uct_pending_callback_t cb, size_t zcopy_thresh)
+                     uct_pending_callback_t cb, size_t zcopy_thresh,
+                     const ucp_request_param_t *param)
 {
+    ucp_context_h context = ep->worker->context;
+    ucs_status_t status;
+
     req->flags                = 0;
     req->send.ep              = ep;
     req->send.buffer          = (void*)buffer;
     req->send.datatype        = ucp_dt_make_contig(1);
-    req->send.mem_type        = UCS_MEMORY_TYPE_HOST;
+    req->send.mem_type        = ucp_request_get_memory_type(context, buffer,
+                                                            length, param);
     req->send.length          = length;
     req->send.rma.remote_addr = remote_addr;
     req->send.rma.rkey        = rkey;
@@ -148,6 +153,13 @@ ucp_rma_request_init(ucp_request_t *req, ucp_ep_h ep, const void *buffer,
         return UCS_OK;
     }
 
+    status = ucp_send_request_set_user_memh(req,
+                                            ucp_ep_config(ep)->key.rma_md_map,
+                                            param);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     return ucp_request_send_buffer_reg_lane(req, req->send.lane, 0);
 }
 
@@ -164,7 +176,7 @@ ucp_rma_nonblocking(ucp_ep_h ep, const void *buffer, size_t length,
                                 {return UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);});
 
     status = ucp_rma_request_init(req, ep, buffer, length, remote_addr, rkey,
-                                  progress_cb, zcopy_thresh);
+                                  progress_cb, zcopy_thresh, param);
     if (ucs_unlikely(status != UCS_OK)) {
         return UCS_STATUS_PTR(status);
     }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1969,6 +1969,16 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         key->rma_bw_md_map  |= UCS_BIT(md_index);
     }
 
+    /* add to map first UCP_MAX_OP_MDS fastest MD's */
+    for (i = 0;
+         (key->rma_lanes[i] != UCP_NULL_LANE) &&
+         (ucs_popcount(key->rma_md_map) < UCP_MAX_OP_MDS); i++) {
+        lane             = key->rma_lanes[i];
+        rsc_index        = select_ctx->lane_descs[lane].rsc_index;
+        md_index         = context->tl_rscs[rsc_index].md_index;
+        key->rma_md_map |= UCS_BIT(md_index);
+    }
+
     /* use AM lane first for eager AM transport to simplify processing single/middle
      * msg packets */
     key->am_bw_lanes[0] = key->am_lane;

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -43,8 +43,8 @@ public:
         ucs_memory_type_t recv_mem_type;
     };
 
-    void post(size_t size, void *target_ptr, ucp_rkey_h rkey,
-              void *expected_data, void *arg)
+    void post(size_t size, void *expected_data, ucp_mem_h memh,
+              void *target_ptr, ucp_rkey_h rkey, void *arg)
     {
         const send_func_data* data = (send_func_data*)arg;
         T value                    = (T)ucs::rand() * (T)ucs::rand();
@@ -66,8 +66,8 @@ public:
                             data->send_mem_type);
     }
 
-    void misaligned_post(size_t size, void *target_ptr, ucp_rkey_h rkey,
-                         void *expected_data, void *arg)
+    void misaligned_post(size_t size, void *expected_data, ucp_mem_h memh,
+                         void *target_ptr, ucp_rkey_h rkey, void *arg)
     {
         const send_func_data* data = (send_func_data*)arg;
         T value = 0;
@@ -84,8 +84,8 @@ public:
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
     }
 
-    void fetch(size_t size, void *target_ptr, ucp_rkey_h rkey,
-               void *expected_data, void *arg)
+    void fetch(size_t size, void *expected_data, ucp_mem_h memh,
+               void *target_ptr, ucp_rkey_h rkey, void *arg)
     {
         const send_func_data* data = (send_func_data*)arg;
         T value                    = (T)ucs::rand() * (T)ucs::rand();
@@ -263,7 +263,7 @@ private:
             ms << opcode_name(data.op) << " ";
             test_xfer(send_func, sizeof(T), num_iters, sizeof(T),
                       send_mem_type, recv_mem_type, 0,
-                      is_ep_flush, &data);
+                      is_ep_flush, 0, &data);
         }
     }
 };

--- a/test/gtest/ucp/test_ucp_memheap.h
+++ b/test/gtest/ucp/test_ucp_memheap.h
@@ -17,9 +17,10 @@ public:
      * Function type for memheap send operation
      *
      * @param [in]  size            Size of data to send
+     * @param [in]  expected_data   Buffer to fill with expected data at 'target_ptr'
+     * @param [in]  memh            Memory handle of local buffer
      * @param [in]  target_ptr      VA to perform the RMA operation to
      * @param [in]  rkey            RMA remote key
-     * @param [in]  expected_data   Buffer to fill with expected data at 'target_ptr'
      * @param [in]  arg             User-defined argument
      *
      * @note The expected data buffer memory type is 'send_mem_type' as passed
@@ -28,9 +29,9 @@ public:
      *       function itself, however it must be there after endpoint/worker flush.
      */
     typedef void
-    (test_ucp_memheap::* send_func_t)(size_t size, void *target_ptr,
-                                      ucp_rkey_h rkey, void *expected_data,
-                                      void *arg);
+    (test_ucp_memheap::* send_func_t)(size_t size, void *expected_data,
+                                      ucp_mem_h memh, void *target_ptr,
+                                      ucp_rkey_h rkey, void *arg);
 
 protected:
     virtual void init();
@@ -38,7 +39,7 @@ protected:
     void test_xfer(send_func_t send_func, size_t size, unsigned num_iters,
                    size_t alignment, ucs_memory_type_t send_mem_type,
                    ucs_memory_type_t target_mem_type, unsigned mem_map_flags,
-                   bool is_ep_flush, void *arg);
+                   bool is_ep_flush, bool user_memh, void *arg);
 };
 
 #endif


### PR DESCRIPTION
## What

Add support of user's memh for RMA operations.

## Why ?

Passing a pre-allocated memory handle could be used by some users to not rely on RCACHE or for XGVMI implementation in the future which always requires passing a memory handle to operations.

## How ?

1. Use `ucp_send_request_set_user_memh()` in `ucp_rma_request_init()` to set user's memory handle.
2. Introduce new variant in RMA gtests and update do_put/do_get send functions to accept `memh` to test passing user' memory handle.