### PR TITLE
UCP/CORE: Fixed memory handle registration.

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -11,6 +11,7 @@
 #endif
 
 #include "ucp_context.h"
+#include "ucp_mm.inl"
 #include "ucp_request.h"
 
 #include <ucs/config/parser.h>
@@ -1398,6 +1399,25 @@ out:
     return status;
 }
 
+static ucs_status_t ucp_context_reg_md_map_alloc(ucp_context_h context)
+{
+    ucs_status_t status;
+    ucp_mem_h memh;
+
+    /* Allocate dummy 1-byte buffer to get the expected md_map */
+    status = ucp_memh_alloc(context, NULL, 1, UCS_MEMORY_TYPE_HOST,
+                            UCT_MD_MEM_ACCESS_ALL | UCT_MD_MEM_FLAG_HIDE_ERRORS,
+                            "get_alloc_md_map", &memh);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    context->reg_md_map[UCS_MEMORY_TYPE_HOST] &= memh->md_map;
+    ucp_memh_put(context, memh, 1);
+
+    return UCS_OK;
+}
+
 static ucs_status_t ucp_fill_resources(ucp_context_h context,
                                        const ucp_config_t *config)
 {
@@ -1415,8 +1435,6 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->num_cmpts                = 0;
     context->tl_mds                   = NULL;
     context->num_mds                  = 0;
-    context->alloc_md_map_initialized = 0;
-    context->alloc_md_map             = 0;
     context->tl_rscs                  = NULL;
     context->num_tls                  = 0;
     context->mem_type_mask            = 0;
@@ -1496,6 +1514,14 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
         if (status != UCS_OK) {
             goto err_free_resources;
         }
+    }
+
+    /* Update registration memory domain map for host memory type taking into
+     * account result of ucp_memh_alloc. */
+    status = ucp_context_reg_md_map_alloc(context);
+    if (status != UCS_OK) {
+        ucs_error("could not update reg md map: %s", ucs_status_string(status));
+        goto err_free_resources;
     }
 
     /* If unified mode is enabled, initialize tl_bitmap to 0.

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -258,12 +258,6 @@ typedef struct ucp_context {
     ucp_tl_md_t                   *tl_mds;    /* Memory domain resources */
     ucp_md_index_t                num_mds;    /* Number of memory domains */
 
-    /* Map of memory domains that have valid memory keys for host memory
-       allocated with ucp_mem_mmap_common().
-       It's initialized on first access. */
-    int                           alloc_md_map_initialized;
-    ucp_md_map_t                  alloc_md_map;
-
     /* Map of MDs that provide registration for given memory type,
        ucp_mem_map() will register memory for all those domains. */
     ucp_md_map_t                  reg_md_map[UCS_MEMORY_TYPE_LAST];

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -85,8 +85,9 @@ void ucp_frag_mpool_free(ucs_mpool_t *mp, void *chunk);
 
 void ucp_frag_mpool_obj_init(ucs_mpool_t *mp, void *obj, void *chunk);
 
-ucs_status_t
-ucp_mm_get_alloc_md_map(ucp_context_h context, ucp_md_map_t *md_map_p);
+ucs_status_t ucp_memh_alloc(ucp_context_h context, void *address, size_t length,
+                            ucs_memory_type_t memory_type, unsigned uct_flags,
+                            const char *alloc_name, ucp_mem_h *memh_p);
 
 
 /**

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -17,8 +17,8 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
                           ucp_md_map_t *mdesc_md_map_p, size_t *frag_size_p)
 {
     ucp_worker_h worker        = init_params->worker;
+    ucp_context_h context      = worker->context;
     ucs_memory_type_t mem_type = init_params->select_param->mem_type;
-    ucs_status_t status;
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         (worker->mem_type_ep[mem_type] == NULL)) {
@@ -30,12 +30,8 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    status = ucp_mm_get_alloc_md_map(worker->context, mdesc_md_map_p);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    *frag_size_p = worker->context->config.ext.rndv_frag_size[UCS_MEMORY_TYPE_HOST];
+    *mdesc_md_map_p = context->reg_md_map[UCS_MEMORY_TYPE_HOST];
+    *frag_size_p    = context->config.ext.rndv_frag_size[UCS_MEMORY_TYPE_HOST];
     return UCS_OK;
 }
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -132,7 +132,8 @@ static ucs_status_t uct_knem_mem_reg_internal(uct_md_h md, void *address, size_t
             /* do not report error in silent mode: it called from rcache
              * internals, rcache will try to register memory again with
              * more accurate data */
-            ucs_error("KNEM create region failed: %m");
+            ucs_error("KNEM failed to create region address %p length %zi: %m",
+                      address, length);
         }
         return UCS_ERR_IO_ERROR;
     }


### PR DESCRIPTION
## What
Fixed memory handle registration.

## Why ?
`UCT_MD_MEM_FLAG_HIDE_ERRORS` flag should prevent from failing memory handler registration process in case of memory registration fail on a memory domain.
`ucp_memh_get_slow` should perform memory handler registration process with `UCT_MD_MEM_FLAG_HIDE_ERRORS` flag.
