### PR TITLE
UCP/MM: Make ucp_mem_map return unique memh

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1403,25 +1403,6 @@ out:
     return status;
 }
 
-static ucs_status_t ucp_context_reg_md_map_alloc(ucp_context_h context)
-{
-    ucs_status_t status;
-    ucp_mem_h memh;
-
-    /* Allocate dummy 1-byte buffer to get the expected md_map */
-    status = ucp_memh_alloc(context, NULL, 1, UCS_MEMORY_TYPE_HOST,
-                            UCT_MD_MEM_ACCESS_ALL | UCT_MD_MEM_FLAG_HIDE_ERRORS,
-                            "get_alloc_md_map", &memh);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    context->reg_md_map[UCS_MEMORY_TYPE_HOST] &= memh->md_map;
-    ucp_memh_put(context, memh, 1);
-
-    return UCS_OK;
-}
-
 static ucs_status_t ucp_fill_resources(ucp_context_h context,
                                        const ucp_config_t *config)
 {
@@ -1521,8 +1502,8 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     }
 
     /* Update registration memory domain map for host memory type taking into
-     * account result of ucp_memh_alloc. */
-    status = ucp_context_reg_md_map_alloc(context);
+     * account result of uct_md_mem_reg. */
+    status = ucp_mem_reg_md_map_update(context);
     if (status != UCS_OK) {
         ucs_error("could not update reg md map: %s", ucs_status_string(status));
         goto err_free_resources;

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -492,7 +492,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_datatype_memh_dereg(ucp_context_h context, ucp_mem_h *memh_p)
 {
     if (*memh_p != NULL) {
-        ucp_memh_put(context, *memh_p, 0);
+        ucp_memh_put(context, *memh_p);
         *memh_p = NULL;
     }
 }

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -455,8 +455,8 @@ UCS_TEST_P(test_ucp_mmap, rereg)
                                              &test_memh);
                 ASSERT_UCS_OK(status);
 
-                // Check that the same memory handle was returned from RCACHE
-                EXPECT_EQ(memh, test_memh);
+                // Check that unique memory handle was returned
+                EXPECT_NE(memh, test_memh);
 
                 status = ucp_mem_unmap(sender().ucph(), test_memh);
                 ASSERT_UCS_OK(status);


### PR DESCRIPTION
## Why ?
This way ucp_mem_unmap will match corresponding ucp_mem_map and will be able to unroll operations that should be unrolled (i.e. allocations, registrations of MDs which shouldn't be cached)

## How ?
ucp_mem_map() won't return memh from rcache but will wrap it in unique temporary memh. 
