### PR TITLE
UCS/SYS: Allow using IPv6 loopback address

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -133,8 +133,7 @@ ucs_status_t ucs_netif_get_addr(const char *if_name, sa_family_t af,
 
         if (ifa->ifa_addr->sa_family == AF_INET6) {
             saddr6 = (const struct sockaddr_in6*)ifa->ifa_addr;
-            if (IN6_IS_ADDR_LOOPBACK(&saddr6->sin6_addr) ||
-                IN6_IS_ADDR_LINKLOCAL(&saddr6->sin6_addr)) {
+            if (IN6_IS_ADDR_LINKLOCAL(&saddr6->sin6_addr)) {
                 continue;
             }
         }


### PR DESCRIPTION
## What

Allow using IPv6 loopback address for TCP transport.

## Why ?

Loopback with IPv6 wasn't available in the list of supported resources returned from TCP.

## How ?

Update `ucs_netif_get_addr` by removing `IN6_IS_ADDR_LOOPBACK(&saddr6->sin6_addr)` check.