### PR TITLE
UCP/PROTO/AM: impl ucp_proto_t::reset for eager protocols

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -146,7 +146,7 @@ ucp_proto_t ucp_am_eager_multi_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_bcopy_proto_progress},
     .abort    = ucp_request_complete_send,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static ucs_status_t
@@ -279,5 +279,5 @@ ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_zcopy_proto_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_am_proto_request_zcopy_reset
 };

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -136,7 +136,7 @@ ucp_proto_t ucp_am_eager_short_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_proto_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static ucs_status_t
@@ -162,7 +162,7 @@ ucp_proto_t ucp_am_eager_short_reply_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_reply_proto_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static UCS_F_ALWAYS_INLINE size_t
@@ -261,7 +261,7 @@ ucp_proto_t ucp_am_eager_single_bcopy_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_proto_progress},
     .abort    = ucp_request_complete_send,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static ucs_status_t ucp_am_eager_single_bcopy_reply_proto_init(
@@ -296,7 +296,7 @@ ucp_proto_t ucp_am_eager_single_bcopy_reply_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_reply_proto_progress},
     .abort    = ucp_request_complete_send,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_proto_init_common(
@@ -393,7 +393,7 @@ ucp_proto_t ucp_am_eager_single_zcopy_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_proto_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_am_proto_request_zcopy_reset
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_reply_proto_init(
@@ -447,6 +447,6 @@ ucp_proto_t ucp_am_eager_single_zcopy_reply_proto = {
     .init     = ucp_am_eager_single_zcopy_reply_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_reply_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .abort    = ucp_proto_request_zcopy_abort,
+    .reset    = ucp_am_proto_request_zcopy_reset
 };

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1737,3 +1737,12 @@ const ucp_request_send_proto_t ucp_am_reply_proto = {
     .zcopy_completion       = ucp_am_zcopy_completion,
     .only_hdr_size          = sizeof(ucp_am_hdr_t) + sizeof(ucp_am_reply_ftr_t)
 };
+
+void ucp_am_proto_request_zcopy_reset(ucp_request_t *request)
+{
+    ucs_assert(request->send.msg_proto.am.header.reg_desc != NULL);
+    ucs_mpool_put_inline(request->send.msg_proto.am.header.reg_desc);
+    request->send.msg_proto.am.header.reg_desc = NULL;
+
+    ucp_proto_request_zcopy_reset(request);
+}

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -134,4 +134,6 @@ ucs_status_t ucp_proto_progress_am_rndv_rts(uct_pending_req_t *self);
 ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
                                      unsigned tl_flags);
 
+void ucp_am_proto_request_zcopy_reset(ucp_request_t *request);
+
 #endif


### PR DESCRIPTION
## What
Implementation of `ucp_proto_t::reset` for eager protocols
Depends on https://github.com/openucx/ucx/pull/8386

## Why ?
The method was intoduced in https://github.com/openucx/ucx/pull/8386 and should be implemented for all protocols

