### PR TITLE
UCP/RNDV/GTEST: Fix RNDV GET_Zcopy initialization of user's memh

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -883,7 +883,7 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
     ucp_ep_h ep = rndv_req->send.ep;
     ucs_status_t status;
     uct_rkey_t uct_rkey;
-    ucp_lane_index_t lane;
+    ucp_lane_index_t lane, lane_idx;
     ucp_md_map_t md_map;
 
     ucp_trace_req(rndv_req, "start rma_get rreq %p", rreq);
@@ -916,8 +916,11 @@ static ucs_status_t ucp_rndv_req_send_rma_get(ucp_request_t *rndv_req,
     /* Copy user registration from receive request to rndv send request */
     if (rreq->flags & UCP_REQUEST_FLAG_USER_MEMH) {
         md_map = 0;
-        ucs_for_each_bit(lane, rndv_req->send.rndv.lanes_map_all) {
+        ucs_for_each_bit(lane_idx, rndv_req->send.rndv.lanes_map_all) {
+            ucs_assert(lane_idx < UCP_MAX_LANES);
+            lane = ucp_ep_config(ep)->rndv.get_zcopy.lanes[lane_idx];
             ucs_assert(lane < UCP_MAX_LANES);
+
             md_map |= UCS_BIT(ucp_ep_md_index(ep, lane));
         }
 


### PR DESCRIPTION
## What

Fix RNDV GET_Zcopy initialization of user's memh.

## Why ?

`req->send.rndv.lanes_map_all` contains indices of array RNDV GET Zcopy lanes.

## How ?

Go through `rndv_req->send.rndv.lanes_map_all` and lookup lane from `ucp_ep_config(ep)->rndv.get_zcopy.lanes` array.