### PR TITLE
JUCX: disable link local listener bindings.

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -46,6 +46,7 @@ public class UcpListenerTest  extends UcxTest {
         UcpListener result = null;
         List<InetAddress> addresses = getInterfaces().flatMap(iface ->
             Collections.list(iface.getInetAddresses()).stream())
+            .filter(addr -> !addr.isLinkLocalAddress())
             .collect(Collectors.toList());
         Collections.reverse(addresses);
         for (InetAddress address : addresses) {


### PR DESCRIPTION
## What
 Disable link local listener bindings.

## Why ?
Fails on TCP CM on link-local addresses
@hoopoepg please check on your PR


