### PR TITLE
UCT/API: Introduce exported mkey buffer

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -695,23 +695,58 @@ typedef enum {
  * @brief  Memory domain capability flags.
  */
 enum {
-    UCT_MD_FLAG_ALLOC      = UCS_BIT(0),  /**< MD supports memory allocation */
-    UCT_MD_FLAG_REG        = UCS_BIT(1),  /**< MD supports memory registration */
-    UCT_MD_FLAG_NEED_MEMH  = UCS_BIT(2),  /**< The transport needs a valid local
-                                               memory handle for zero-copy operations */
-    UCT_MD_FLAG_NEED_RKEY  = UCS_BIT(3),  /**< The transport needs a valid
-                                               remote memory key for remote memory
-                                               operations */
-    UCT_MD_FLAG_ADVISE     = UCS_BIT(4),  /**< MD supports memory advice */
-    UCT_MD_FLAG_FIXED      = UCS_BIT(5),  /**< MD supports memory allocation with
-                                               fixed address */
-    UCT_MD_FLAG_RKEY_PTR   = UCS_BIT(6),  /**< MD supports direct access to
-                                               remote memory via a pointer that
-                                               is returned by @ref uct_rkey_ptr */
-    UCT_MD_FLAG_SOCKADDR   = UCS_BIT(7),  /**< MD support for client-server
-                                               connection establishment via
-                                               sockaddr */
-    UCT_MD_FLAG_INVALIDATE = UCS_BIT(8)   /**< MD supports memory invalidation */
+    /**
+     * MD supports memory allocation
+     */
+    UCT_MD_FLAG_ALLOC         = UCS_BIT(0),
+
+    /** 
+     * MD supports memory registration
+     */
+    UCT_MD_FLAG_REG           = UCS_BIT(1),
+
+    /**
+     * The transport needs a valid local memory handle for zero-copy operations
+     */
+    UCT_MD_FLAG_NEED_MEMH     = UCS_BIT(2),
+
+    /**
+     * The transport needs a valid remote memory key for remote memory
+     * operations
+     */
+    UCT_MD_FLAG_NEED_RKEY     = UCS_BIT(3),
+
+    /**
+     * MD supports memory advice
+     */
+    UCT_MD_FLAG_ADVISE        = UCS_BIT(4),
+
+    /**
+     * MD supports memory allocation with fixed address
+     */
+    UCT_MD_FLAG_FIXED         = UCS_BIT(5),
+
+    /**
+     * MD supports direct access to remote memory via a pointer that is
+     * returned by @ref uct_rkey_ptr
+     */
+    UCT_MD_FLAG_RKEY_PTR      = UCS_BIT(6),
+
+    /**
+     * MD support for client-server connection establishment via sockaddr
+     */
+    UCT_MD_FLAG_SOCKADDR      = UCS_BIT(7),
+
+    /**
+     * MD supports memory invalidation
+     */
+    UCT_MD_FLAG_INVALIDATE    = UCS_BIT(8),
+
+    /**
+     * MD supports exporting memory keys with another process using the same
+     * device or attaching to an exported memory key.
+     */
+    UCT_MD_FLAG_EXPORTED_MKEY = UCS_BIT(9)
 };
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -16,6 +16,7 @@
 
 
 #define UCT_COMPONENT_NAME_MAX     16
+#define UCT_MD_GLOBAL_ID_MAX       256
 #define UCT_TL_NAME_MAX            10
 #define UCT_MD_NAME_MAX            16
 #define UCT_DEVICE_NAME_MAX        32

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -281,7 +281,13 @@ typedef enum {
      * in order for @ref UCT_MD_MEM_DEREG_FLAG_INVALIDATE flag to function
      * the @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag must be set.
      */
-    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0)
+    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0),
+
+    /**
+     * The flag is used to indicate that the memory region can be accessed
+     * by another process using the same device to perform UCT operations.
+     */
+    UCT_MD_MKEY_PACK_FLAG_EXPORT     = UCS_BIT(1)
 } uct_md_mkey_pack_flags_t;
 
 
@@ -549,43 +555,49 @@ ucs_status_t uct_md_mem_dereg_v2(uct_md_h md,
  */
 typedef enum uct_md_attr_field {
     /** Indicate max allocation size. */
-    UCT_MD_ATTR_FIELD_MAX_ALLOC        = UCS_BIT(0),
+    UCT_MD_ATTR_FIELD_MAX_ALLOC                 = UCS_BIT(0),
 
     /** Indicate max registration size. */
-    UCT_MD_ATTR_FIELD_MAX_REG          = UCS_BIT(1),
+    UCT_MD_ATTR_FIELD_MAX_REG                   = UCS_BIT(1),
 
     /** Indicate capability flags. */
-    UCT_MD_ATTR_FIELD_FLAGS            = UCS_BIT(2),
+    UCT_MD_ATTR_FIELD_FLAGS                     = UCS_BIT(2),
 
     /** Indicate memory types that the MD can register. */
-    UCT_MD_ATTR_FIELD_REG_MEM_TYPES    = UCS_BIT(3),
+    UCT_MD_ATTR_FIELD_REG_MEM_TYPES             = UCS_BIT(3),
 
-    /** Indicate memory types that the MD can register. */
-    UCT_MD_ATTR_FIELD_CACHE_MEM_TYPES  = UCS_BIT(4),
+    /** Indicate memory types that the MD can cache. */
+    UCT_MD_ATTR_FIELD_CACHE_MEM_TYPES           = UCS_BIT(4),
 
     /** Indicate memory types that the MD can detect. */
-    UCT_MD_ATTR_FIELD_DETECT_MEM_TYPES = UCS_BIT(5),
+    UCT_MD_ATTR_FIELD_DETECT_MEM_TYPES          = UCS_BIT(5),
 
     /** Indicate memory types that the MD can allocate. */
-    UCT_MD_ATTR_FIELD_ALLOC_MEM_TYPES  = UCS_BIT(6),
+    UCT_MD_ATTR_FIELD_ALLOC_MEM_TYPES           = UCS_BIT(6),
 
     /** Indicate memory types that the MD can access. */
-    UCT_MD_ATTR_FIELD_ACCESS_MEM_TYPES = UCS_BIT(7),
+    UCT_MD_ATTR_FIELD_ACCESS_MEM_TYPES          = UCS_BIT(7),
 
     /** Indicate memory types for which the MD can return a dmabuf_fd. */
-    UCT_MD_ATTR_FIELD_DMABUF_MEM_TYPES = UCS_BIT(8),
+    UCT_MD_ATTR_FIELD_DMABUF_MEM_TYPES          = UCS_BIT(8),
 
     /** Indicate registration cost. */
-    UCT_MD_ATTR_FIELD_REG_COST         = UCS_BIT(9),
+    UCT_MD_ATTR_FIELD_REG_COST                  = UCS_BIT(9),
 
     /** Indicate component name. */
-    UCT_MD_ATTR_FIELD_COMPONENT_NAME   = UCS_BIT(10),
+    UCT_MD_ATTR_FIELD_COMPONENT_NAME            = UCS_BIT(10),
 
     /** Indicate size of buffer needed for packed rkey. */
-    UCT_MD_ATTR_FIELD_RKEY_PACKED_SIZE = UCS_BIT(11),
+    UCT_MD_ATTR_FIELD_RKEY_PACKED_SIZE          = UCS_BIT(11),
 
-    /** Indicate CPUs near the resource. */
-    UCT_MD_ATTR_FIELD_LOCAL_CPUS       = UCS_BIT(12)
+    /** Indicate CPUs closest to the resource. */
+    UCT_MD_ATTR_FIELD_LOCAL_CPUS                = UCS_BIT(12),
+
+    /** Indicate size of buffer needed for packed exported memory key. */
+    UCT_MD_ATTR_FIELD_EXPORTED_MKEY_PACKED_SIZE = UCS_BIT(13),
+
+    /** Unique global identifier of the memory domain. */
+    UCT_MD_ATTR_FIELD_GLOBAL_ID                 = UCS_BIT(14)
 } uct_md_attr_field_t;
 
 
@@ -670,9 +682,22 @@ typedef struct {
     size_t            rkey_packed_size;
 
     /**
-     * Mask of CPUs near the resource.
+     * Mask of CPUs closest to the resource.
      */
     ucs_cpu_set_t     local_cpus;
+
+    /**
+     * Size of buffer needed for packing an exported mkey. Valid only if
+     * @ref UCT_MD_FLAG_EXPORTED_MKEY is supported by Memory Domain.
+     */
+    size_t            exported_mkey_packed_size;
+
+    /**
+     * Byte array that holds a globally unique device identifier (for example,
+     * a MAC address or a GUID). If global identifiers are equal, it means that
+     * Memory Domains belong to the same device.
+     */
+    char              global_id[UCT_MD_GLOBAL_ID_MAX];
 } uct_md_attr_v2_t;
 
 
@@ -690,21 +715,26 @@ ucs_status_t uct_md_query_v2(uct_md_h md, uct_md_attr_v2_t *md_attr);
 /**
  * @ingroup UCT_MD
  *
- * @brief Pack a remote key.
+ * @brief Pack a memory key as a remote or shared one.
+ *
+ * This routine packs a local memory handle registered by @ref uct_md_mem_reg
+ * into a memory buffer, which then could be deserialized by a peer and used in
+ * UCT operations.
  *
  * @param [in]  md          Handle to memory domain.
  * @param [in]  memh        Pack a remote key for this memory handle.
  * @param [in]  params      Operation parameters, see @ref
  *                          uct_md_mkey_pack_params_t.
- * @param [out] rkey_buffer Pointer to a buffer to hold the packed remote key.
- *                          The size of this buffer has should be at least
- *                          @ref uct_md_attr_t::rkey_packed_size, as returned by
- *                          @ref uct_md_query.
+ * @param [out] mkey_buffer Pointer to a buffer to hold the packed remote key.
+ *                          The size of this buffer should be at least
+ *                          @ref uct_md_attr_t::rkey_packed_size or
+ *                          @ref uct_md_attr_t::shared_mkey_packed_size, as
+ *                          returned by @ref uct_md_query.
  * @return                  Error code.
  */
 ucs_status_t uct_md_mkey_pack_v2(uct_md_h md, uct_mem_h memh,
                                  const uct_md_mkey_pack_params_t *params,
-                                 void *rkey_buffer);
+                                 void *mkey_buffer);
 
 
 /**
@@ -726,7 +756,7 @@ ucs_status_t uct_md_mkey_pack_v2(uct_md_h md, uct_mem_h memh,
  *
  * @return                    Error code.
  */
-ucs_status_t uct_md_mem_attach(uct_md_h md, void *mkey_buffer,
+ucs_status_t uct_md_mem_attach(uct_md_h md, const void *mkey_buffer,
                                uct_md_mem_attach_params_t *params,
                                uct_mem_h *memh_p);
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -337,10 +337,10 @@ ucs_status_t uct_config_modify(void *config, const char *name, const char *value
 }
 
 static ucs_status_t
-uct_md_mkey_pack_params_check(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
+uct_md_mkey_pack_params_check(uct_md_h md, uct_mem_h memh, void *mkey_buffer)
 {
     if (ENABLE_PARAMS_CHECK) {
-        return ((md != NULL) && (memh != NULL) && (rkey_buffer != NULL)) ?
+        return ((md != NULL) && (memh != NULL) && (mkey_buffer != NULL)) ?
                UCS_OK : UCS_ERR_INVALID_PARAM;
     } else {
         return UCS_OK;
@@ -349,16 +349,16 @@ uct_md_mkey_pack_params_check(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
 
 ucs_status_t uct_md_mkey_pack_v2(uct_md_h md, uct_mem_h memh,
                                  const uct_md_mkey_pack_params_t *params,
-                                 void *rkey_buffer)
+                                 void *mkey_buffer)
 {
     ucs_status_t status;
 
-    status = uct_md_mkey_pack_params_check(md, memh, rkey_buffer);
+    status = uct_md_mkey_pack_params_check(md, memh, mkey_buffer);
     if (status != UCS_OK) {
         return status;
     }
 
-    return md->ops->mkey_pack(md, memh, params, rkey_buffer);
+    return md->ops->mkey_pack(md, memh, params, mkey_buffer);
 }
 
 ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
@@ -370,7 +370,7 @@ ucs_status_t uct_md_mkey_pack(uct_md_h md, uct_mem_h memh, void *rkey_buffer)
     return uct_md_mkey_pack_v2(md, memh, &params, rkey_buffer);
 }
 
-ucs_status_t uct_md_mem_attach(uct_md_h md, void *mkey_buffer,
+ucs_status_t uct_md_mem_attach(uct_md_h md, const void *mkey_buffer,
                                uct_md_mem_attach_params_t *params,
                                uct_mem_h *memh_p)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -112,10 +112,10 @@ typedef ucs_status_t (*uct_md_mem_query_func_t)(uct_md_h md,
 
 typedef ucs_status_t (*uct_md_mkey_pack_func_t)(
         uct_md_h md, uct_mem_h memh, const uct_md_mkey_pack_params_t *params,
-        void *rkey_buffer);
+        void *buffer);
 
 typedef ucs_status_t
-(*uct_md_mem_attach_func_t)(uct_md_h md, void *mkey_buffer,
+(*uct_md_mem_attach_func_t)(uct_md_h md, const void *mkey_buffer,
                             uct_md_mem_attach_params_t *params,
                             uct_mem_h *memh_p);
 
@@ -247,7 +247,7 @@ extern ucs_config_field_t uct_md_config_table[];
 static inline ucs_log_level_t uct_md_reg_log_lvl(unsigned flags)
 {
     return (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DIAG :
-            UCS_LOG_LEVEL_ERROR;
+           UCS_LOG_LEVEL_ERROR;
 }
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -71,7 +71,7 @@ uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 static ucs_status_t
 uct_cuda_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
                         const uct_md_mkey_pack_params_t *params,
-                        void *rkey_buffer)
+                        void *mkey_buffer)
 {
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -50,9 +50,9 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 static ucs_status_t
 uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h memh,
                        const uct_md_mkey_pack_params_t *params,
-                       void *rkey_buffer)
+                       void *mkey_buffer)
 {
-    uct_cuda_ipc_key_t *packed   = rkey_buffer;
+    uct_cuda_ipc_key_t *packed   = mkey_buffer;
     uct_cuda_ipc_key_t *mem_hndl = memh;
 
     *packed = *mem_hndl;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -64,9 +64,9 @@ uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 static ucs_status_t
 uct_gdr_copy_mkey_pack(uct_md_h md, uct_mem_h memh,
                        const uct_md_mkey_pack_params_t *params,
-                       void *rkey_buffer)
+                       void *mkey_buffer)
 {
-    uct_gdr_copy_key_t *packed   = rkey_buffer;
+    uct_gdr_copy_key_t *packed   = mkey_buffer;
     uct_gdr_copy_mem_t *mem_hndl = memh;
 
     packed->vaddr   = mem_hndl->info.va;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -875,7 +875,7 @@ uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
 static ucs_status_t
 uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
                  const uct_md_mkey_pack_params_t *params,
-                 void *rkey_buffer)
+                 void *mkey_buffer)
 {
     uct_ib_md_t *md     = ucs_derived_of(uct_md, uct_ib_md_t);
     uct_ib_mem_t *memh  = uct_memh;
@@ -932,7 +932,7 @@ uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
         rkey = memh->rkey;
     }
 
-    uct_ib_md_pack_rkey(rkey, atomic_rkey, rkey_buffer);
+    uct_ib_md_pack_rkey(rkey, atomic_rkey, mkey_buffer);
     return UCS_OK;
 }
 

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -57,9 +57,9 @@ uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr_v2)
 static ucs_status_t
 uct_rocm_copy_mkey_pack(uct_md_h uct_md, uct_mem_h memh,
                         const uct_md_mkey_pack_params_t *params,
-                        void *rkey_buffer)
+                        void *mkey_buffer)
 {
-    uct_rocm_copy_key_t *packed   = rkey_buffer;
+    uct_rocm_copy_key_t *packed   = mkey_buffer;
     uct_rocm_copy_mem_t *mem_hndl = memh;
 
     packed->vaddr   = (uint64_t) mem_hndl->vaddr;

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -46,9 +46,9 @@ static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr,
 static ucs_status_t
 uct_rocm_ipc_mkey_pack(uct_md_h uct_md, uct_mem_h memh,
                        const uct_md_mkey_pack_params_t *params,
-                       void *rkey_buffer)
+                       void *mkey_buffer)
 {
-    uct_rocm_ipc_key_t *packed = rkey_buffer;
+    uct_rocm_ipc_key_t *packed = mkey_buffer;
     uct_rocm_ipc_key_t *key    = memh;
 
     *packed = *key;

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -612,11 +612,11 @@ static ucs_status_t uct_posix_iface_addr_pack(uct_mm_md_t *md, void *buffer)
 static ucs_status_t
 uct_posix_md_mkey_pack(uct_md_h tl_md, uct_mem_h memh,
                        const uct_md_mkey_pack_params_t *params,
-                       void *rkey_buffer)
+                       void *mkey_buffer)
 {
     uct_mm_md_t *md                      = ucs_derived_of(tl_md, uct_mm_md_t);
     uct_mm_seg_t *seg                    = memh;
-    uct_posix_packed_rkey_t *packed_rkey = rkey_buffer;
+    uct_posix_packed_rkey_t *packed_rkey = mkey_buffer;
 
     packed_rkey->seg_id  = seg->seg_id;
     packed_rkey->address = (uintptr_t)seg->address;

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -140,9 +140,9 @@ static ucs_status_t uct_sysv_mem_free(uct_md_h tl_md, uct_mem_h memh)
 static ucs_status_t
 uct_sysv_md_mkey_pack(uct_md_h md, uct_mem_h memh,
                       const uct_md_mkey_pack_params_t *params,
-                      void *rkey_buffer)
+                      void *mkey_buffer)
 {
-    uct_sysv_packed_rkey_t *packed_rkey = rkey_buffer;
+    uct_sysv_packed_rkey_t *packed_rkey = mkey_buffer;
     const uct_mm_seg_t     *seg         = memh;
 
     packed_rkey->shmid     = seg->seg_id;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -423,10 +423,10 @@ uct_xmpem_mem_dereg(uct_md_h md,
 static ucs_status_t
 uct_xpmem_mkey_pack(uct_md_h tl_md, uct_mem_h memh,
                     const uct_md_mkey_pack_params_t *params,
-                    void *rkey_buffer)
+                    void *mkey_buffer)
 {
     uct_mm_seg_t                    *seg = memh;
-    uct_xpmem_packed_rkey_t *packed_rkey = rkey_buffer;
+    uct_xpmem_packed_rkey_t *packed_rkey = mkey_buffer;
     xpmem_segid_t xsegid;
     ucs_status_t status;
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -205,11 +205,11 @@ static ucs_status_t uct_knem_mem_dereg(uct_md_h md,
 }
 
 static ucs_status_t
-uct_knem_rkey_pack(uct_md_h md, uct_mem_h memh,
+uct_knem_mkey_pack(uct_md_h md, uct_mem_h memh,
                    const uct_md_mkey_pack_params_t *params,
-                   void *rkey_buffer)
+                   void *mkey_buffer)
 {
-    uct_knem_key_t *packed = rkey_buffer;
+    uct_knem_key_t *packed = mkey_buffer;
     uct_knem_key_t *key    = memh;
 
     packed->cookie  = (uint64_t)key->cookie;
@@ -252,7 +252,7 @@ static ucs_status_t uct_knem_rkey_release(uct_component_t *component,
 static uct_md_ops_t md_ops = {
     .close              = uct_knem_md_close,
     .query              = uct_knem_md_query,
-    .mkey_pack          = uct_knem_rkey_pack,
+    .mkey_pack          = uct_knem_mkey_pack,
     .mem_reg            = uct_knem_mem_reg,
     .mem_dereg          = uct_knem_mem_dereg,
     .detect_memory_type = ucs_empty_function_return_unsupported,
@@ -303,7 +303,7 @@ uct_knem_mem_rcache_dereg(uct_md_h uct_md,
 static uct_md_ops_t uct_knem_md_rcache_ops = {
     .close                  = uct_knem_md_close,
     .query                  = uct_knem_md_query,
-    .mkey_pack              = uct_knem_rkey_pack,
+    .mkey_pack              = uct_knem_mkey_pack,
     .mem_reg                = uct_knem_mem_rcache_reg,
     .mem_dereg              = uct_knem_mem_rcache_dereg,
     .is_sockaddr_accessible = ucs_empty_function_return_zero_int,

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -116,12 +116,12 @@ static ucs_status_t uct_ugni_mem_dereg(uct_md_h md,
 }
 
 static ucs_status_t
-uct_ugni_rkey_pack(uct_md_h md, uct_mem_h memh,
+uct_ugni_mkey_pack(uct_md_h md, uct_mem_h memh,
                    const uct_md_mkey_pack_params_t *params,
-                   void *rkey_buffer)
+                   void *mkey_buffer)
 {
     gni_mem_handle_t *mem_hndl = memh;
-    uint64_t *ptr              = rkey_buffer;
+    uint64_t *ptr              = mkey_buffer;
 
     ptr[0] = UCT_UGNI_RKEY_MAGIC;
     ptr[1] = mem_hndl->qword1;
@@ -195,7 +195,7 @@ uct_ugni_md_open(uct_component_h component,const char *md_name,
     md_ops.mem_free           = (void*)ucs_empty_function;
     md_ops.mem_reg            = uct_ugni_mem_reg;
     md_ops.mem_dereg          = uct_ugni_mem_dereg;
-    md_ops.mkey_pack          = uct_ugni_rkey_pack;
+    md_ops.mkey_pack          = uct_ugni_mkey_pack;
     md_ops.detect_memory_type = ucs_empty_function_return_unsupported;
 
     md.super.ops              = &md_ops;


### PR DESCRIPTION
## What

Introduce shared mkey buffer in UCT.

## Why ?

Shared mkey buffer will be packed by `uct_md_mkey_pack_v2`.

## How ?

1. Introduce `UCT_MD_FLAG_SHARED_MKEY` MD capability flag.
2. Update `uct_md_mkey_pack_v2` to support packing shared mkey.
3. Introduce `shared_mkey_packed_size` and `global_id` MD attributes.
4. Update all transports to set `shared_mkey_packed_size` and `global_id`.