### PR TITLE
IB/MLX5: fixed macro arg

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -131,12 +131,12 @@ struct mlx5_grh_av {
       (_av_size) + \
       sizeof(struct mlx5_wqe_inl_data_seg)))
 
-#define UCT_IB_MLX5_SET_BASE_AV(to_base_av, from_base_av) \
+#define UCT_IB_MLX5_SET_BASE_AV(_to_base_av, _from_base_av) \
     do { \
-        (to_base_av)->dqp_dct      = (from_base_av)->dqp_dct; \
-        (to_base_av)->stat_rate_sl = (from_base_av)->stat_rate_sl; \
-        (to_base_av)->fl_mlid      = (from_base_av)->fl_mlid; \
-        (to_base_av)->rlid         = (from_base_av)->rlid; \
+        (_to_base_av)->dqp_dct      = (_from_base_av)->dqp_dct; \
+        (_to_base_av)->stat_rate_sl = (_from_base_av)->stat_rate_sl; \
+        (_to_base_av)->fl_mlid      = (_from_base_av)->fl_mlid; \
+        (_to_base_av)->rlid         = (_from_base_av)->rlid; \
     } while (0)
 
 #define UCT_IB_MLX5_AM_ZCOPY_MAX_HDR(_av_size) \


### PR DESCRIPTION
- fixed macro arg names to fit code guidelines (to eliminate
  variables shadowing)
