### PR TITLE
UCP/API: Introduce ucp_memh_pack API function

### DIFF
--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -72,6 +72,62 @@ ucs_status_t ucp_request_test(void *request, ucp_tag_recv_info_t *info);
 
 
 /**
+ * @ingroup UCP_MEM
+ * @deprecated Replaced by @ref ucp_memh_pack "ucp_memh_pack()".
+ * @brief Pack memory region remote access key.
+ *
+ * This routine allocates a memory buffer and packs a remote access key (RKEY)
+ * object into it. RKEY is an opaque object that provides the information that is
+ * necessary for remote memory access.
+ * This routine packs the RKEY object in a portable format such that the
+ * object can be @ref ucp_ep_rkey_unpack "unpacked" on any platform supported by the
+ * UCP library. In order to release the memory buffer allocated by this routine,
+ * the application is responsible for calling the @ref ucp_rkey_buffer_release
+ * "ucp_rkey_buffer_release()" routine.
+ *
+ *
+ * @note
+ * @li RKEYs for InfiniBand and Cray Aries networks typically include
+ * the InfiniBand and Aries key.
+ * @li In order to enable remote direct memory access to the memory associated
+ * with the memory handle, the application is responsible for sharing the RKEY with
+ * the peers that will initiate the access.
+ *
+ * @param [in]  context       Application @ref ucp_context_h "context" which was
+ *                            used to allocate/map the memory.
+ * @param [in]  memh          @ref ucp_mem_h "Handle" to the memory region.
+ * @param [out] rkey_buffer_p Memory buffer allocated by the library.
+ *                            The buffer contains the packed RKEY.
+ * @param [out] size_p        Size (in bytes) of the packed RKEY.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_rkey_pack(ucp_context_h context, ucp_mem_h memh,
+                           void **rkey_buffer_p, size_t *size_p);
+
+
+/**
+ * @ingroup UCP_MEM
+ * @deprecated Replaced by @ref ucp_memh_buffer_release
+ *             "ucp_memh_buffer_release()".
+ * @brief Release packed remote key buffer.
+ *
+ * This routine releases the buffer that was allocated using @ref ucp_rkey_pack
+ * "ucp_rkey_pack()".
+ *
+ * @warning
+ * @li Once memory is released, an access to the memory may cause undefined
+ * behavior.
+ * @li If the input memory address was not allocated using
+ * @ref ucp_rkey_pack "ucp_rkey_pack()" routine, the behavior of this routine
+ * is undefined.
+ *
+ * @param [in]  rkey_buffer   Buffer to release.
+ */
+void ucp_rkey_buffer_release(void *rkey_buffer);
+
+
+/**
  * @ingroup UCP_ENDPOINT
  * @deprecated Replaced by @ref ucp_ep_flush_nb.
  */

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -27,9 +27,10 @@
  */
 typedef struct ucp_mem {
     ucs_rcache_region_t super;
+    ucp_context_h       context;        /* UCP context that owns a memory handle */
     uct_alloc_method_t  alloc_method;   /* Method used to allocate the memory */
     ucs_memory_type_t   mem_type;       /* Type of allocated or registered memory */
-    ucp_md_index_t      alloc_md_index; /* Index of MD used to allocated the memory */
+    ucp_md_index_t      alloc_md_index; /* Index of MD used to allocate the memory */
     ucp_md_map_t        md_map;         /* Which MDs have valid memory handles */
     ucp_mem_h           parent;         /* - NULL if entry should be returned to rcache
                                            - pointer to self if rcache disabled


### PR DESCRIPTION
## What

Introduce `ucp_memh_pack` API function

## Why ?

`ucp_memh_pack` API function was introduced to replace already existing `ucp_rkey_pack` to make it extendable and support packing SHARED memory key in the future.

## How ?

1. Introduce `ucp_memh_pack` and `ucp_memh_buffer_release`.
2. Implement `ucp_rkey_pack` and `ucp_rkey_buffer_release` through `ucp_memh_pack` and `ucp_memh_buffer_release`.
3. Deprecate `ucp_rkey_pack` and `ucp_rkey_buffer_release`.
4. Use `ucp_memh_pack` and `ucp_memh_buffer_release` instead of `ucp_rkey_pack` and `ucp_rkey_buffer_release` in perftest/gtest/UCP code.