### PR TITLE
UCP/PROTO/AM: ucp_proto_t::reset for eager protocols and support new user header release API

### DIFF
--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -59,9 +59,10 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
 {
     ucp_mem_desc_t *reg_desc;
 
-    /* Request must be in initial state or after cleanup */
+    /* Request must be in initial state or after @ref ucp_proto_t::reset */
     ucs_assertv(req->send.msg_proto.am.header.reg_desc == NULL,
-                "req %p, double initialization of reg_desc", req);
+                "request %p: am.header.reg_desc=%p", req,
+                req->send.msg_proto.am.header.reg_desc);
 
     reg_desc = ucp_worker_mpool_get(&req->send.ep->worker->reg_mp);
     if (ucs_unlikely(reg_desc == NULL)) {

--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -59,10 +59,7 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
 {
     ucp_mem_desc_t *reg_desc;
 
-    /* reg_desc could already be allocated for a replayed request */
-    if (req->send.msg_proto.am.header.reg_desc != NULL) {
-        return UCS_OK;
-    }
+    ucs_assert(req->send.msg_proto.am.header.reg_desc == NULL);
 
     reg_desc = ucp_worker_mpool_get(&req->send.ep->worker->reg_mp);
     if (ucs_unlikely(reg_desc == NULL)) {

--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -59,7 +59,9 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
 {
     ucp_mem_desc_t *reg_desc;
 
-    ucs_assert(req->send.msg_proto.am.header.reg_desc == NULL);
+    /* Request must be in initial state or after cleanup */
+    ucs_assertv(req->send.msg_proto.am.header.reg_desc == NULL,
+                "req %p, double initialization of reg_desc", req);
 
     reg_desc = ucp_worker_mpool_get(&req->send.ep->worker->reg_mp);
     if (ucs_unlikely(reg_desc == NULL)) {

--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -144,7 +144,8 @@ ucp_proto_t ucp_am_eager_multi_bcopy_proto = {
     .init     = ucp_am_eager_multi_bcopy_proto_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_bcopy_proto_progress},
-    .abort    = ucp_request_complete_send
+    .abort    = ucp_request_complete_send,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t
@@ -276,5 +277,6 @@ ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .init     = ucp_am_eager_multi_zcopy_proto_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_zcopy_proto_progress},
-    .abort    = ucp_proto_request_zcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -145,7 +145,7 @@ ucp_proto_t ucp_am_eager_multi_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_bcopy_proto_progress},
     .abort    = ucp_request_complete_send,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t
@@ -278,5 +278,5 @@ ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_zcopy_proto_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -136,7 +136,7 @@ ucp_proto_t ucp_am_eager_short_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_proto_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t
@@ -162,7 +162,7 @@ ucp_proto_t ucp_am_eager_short_reply_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_reply_proto_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static UCS_F_ALWAYS_INLINE size_t
@@ -261,7 +261,7 @@ ucp_proto_t ucp_am_eager_single_bcopy_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_proto_progress},
     .abort    = ucp_request_complete_send,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t ucp_am_eager_single_bcopy_reply_proto_init(
@@ -296,7 +296,7 @@ ucp_proto_t ucp_am_eager_single_bcopy_reply_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_reply_proto_progress},
     .abort    = ucp_request_complete_send,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_proto_init_common(
@@ -393,7 +393,7 @@ ucp_proto_t ucp_am_eager_single_zcopy_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_proto_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_reply_proto_init(
@@ -448,5 +448,5 @@ ucp_proto_t ucp_am_eager_single_zcopy_reply_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_reply_proto_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -135,7 +135,8 @@ ucp_proto_t ucp_am_eager_short_proto = {
     .init     = ucp_am_eager_short_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t
@@ -160,7 +161,8 @@ ucp_proto_t ucp_am_eager_short_reply_proto = {
     .init     = ucp_am_eager_short_reply_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_reply_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static UCS_F_ALWAYS_INLINE size_t
@@ -258,7 +260,8 @@ ucp_proto_t ucp_am_eager_single_bcopy_proto = {
     .init     = ucp_am_eager_single_bcopy_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_proto_progress},
-    .abort    = ucp_request_complete_send
+    .abort    = ucp_request_complete_send,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t ucp_am_eager_single_bcopy_reply_proto_init(
@@ -292,7 +295,8 @@ ucp_proto_t ucp_am_eager_single_bcopy_reply_proto = {
     .init     = ucp_am_eager_single_bcopy_reply_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_reply_proto_progress},
-    .abort    = ucp_request_complete_send
+    .abort    = ucp_request_complete_send,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_proto_init_common(
@@ -388,7 +392,8 @@ ucp_proto_t ucp_am_eager_single_zcopy_proto = {
     .init     = ucp_am_eager_single_zcopy_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_proto_progress},
-    .abort    = ucp_proto_request_zcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t ucp_am_eager_single_zcopy_reply_proto_init(
@@ -442,5 +447,6 @@ ucp_proto_t ucp_am_eager_single_zcopy_reply_proto = {
     .init     = ucp_am_eager_single_zcopy_reply_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_reply_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -67,5 +67,5 @@ ucp_proto_t ucp_am_rndv_proto = {
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_am_rndv_proto_progress},
     .abort    = ucp_proto_rndv_rts_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -66,5 +66,6 @@ ucp_proto_t ucp_am_rndv_proto = {
     .init     = ucp_am_rndv_rts_init,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_am_rndv_proto_progress},
-    .abort    = ucp_proto_rndv_rts_abort
+    .abort    = ucp_proto_rndv_rts_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/am/ucp_am.inl
+++ b/src/ucp/am/ucp_am.inl
@@ -30,4 +30,10 @@ ucp_am_check_init_params(const ucp_proto_init_params_t *init_params,
            !(init_params->select_param->op_flags & exclude_flags);
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_config_is_am(const ucp_proto_config_t *proto_config)
+{
+    return UCS_BIT(proto_config->select_param.op_id) & UCP_AM_OP_ID_MASK_ALL;
+}
+
 #endif

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -480,6 +480,15 @@ ucp_datatype_iter_is_end_position(const ucp_datatype_iter_t *dt_iter,
 }
 
 /*
+ * Check if the iterator has start position
+ */
+static UCS_F_ALWAYS_INLINE int
+ucp_datatype_iter_is_begin(const ucp_datatype_iter_t *dt_iter)
+{
+    return dt_iter->offset == 0;
+}
+
+/*
  * Check if the iterator has reached the end
  */
 static UCS_F_ALWAYS_INLINE int

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -270,6 +270,14 @@ typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
 
 
 /**
+ * Clean UCP request to initial stage to be ready to start with other
+ * protocol or aborted.
+ *
+ * @param [in]  request Request to clean up.
+ */
+typedef void (*ucp_request_clean_func_t)(ucp_request_t *request);
+
+/**
  * UCP base protocol definition
  */
 struct ucp_proto {
@@ -290,6 +298,13 @@ struct ucp_proto {
      * resources, such as memory handles, remote keys, request ID, etc.
      */
     ucp_request_abort_func_t abort;
+
+    /*
+     * Clean up a request (which is scheduled to a pending queue).
+     * The method should release associated resources, such as memory handles,
+     * remote keys, request ID, etc.
+     */
+    ucp_request_clean_func_t clean;
 };
 
 

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -270,12 +270,13 @@ typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
 
 
 /**
- * Clean UCP request to initial stage to be ready to start with other
- * protocol or aborted.
+ * Reset UCP request to its initial state and release any resources related to
+ * the specific protocol. Used to switch a send request to a different protocol.
  *
  * @param [in]  request Request to clean up.
  */
 typedef void (*ucp_request_clean_func_t)(ucp_request_t *request);
+
 
 /**
  * UCP base protocol definition

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -273,7 +273,7 @@ typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
  * Reset UCP request to its initial state and release any resources related to
  * the specific protocol. Used to switch a send request to a different protocol.
  *
- * @param [in]  request Request to clean up.
+ * @param [in]  request Request to reset.
  */
 typedef void (*ucp_request_reset_func_t)(ucp_request_t *request);
 

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -275,7 +275,7 @@ typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
  *
  * @param [in]  request Request to clean up.
  */
-typedef void (*ucp_request_clean_func_t)(ucp_request_t *request);
+typedef void (*ucp_request_reset_func_t)(ucp_request_t *request);
 
 
 /**
@@ -301,11 +301,11 @@ struct ucp_proto {
     ucp_request_abort_func_t abort;
 
     /*
-     * Clean up a request (which is scheduled to a pending queue).
+     * Reset a request (which is scheduled to a pending queue).
      * The method should release associated resources, such as memory handles,
      * remote keys, request ID, etc.
      */
-    ucp_request_clean_func_t clean;
+    ucp_request_reset_func_t reset;
 };
 
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -720,8 +720,8 @@ ucs_status_t ucp_proto_request_init(ucp_request_t *req)
 }
 
 /**
- * Current implementation of @ref ucp_proto_t::reset supports the only case if
- * no data was sent yet.
+ * Current implementation of @ref ucp_proto_t::reset supports only the case
+ * that no data was sent yet.
  *
  * @param req   request to check
  */

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -268,10 +268,10 @@ void ucp_proto_request_restart(ucp_request_t *req);
 
 void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status);
 
-void ucp_proto_request_bcopy_clean(ucp_request_t *request);
+void ucp_proto_request_bcopy_reset(ucp_request_t *request);
 
 void ucp_proto_request_zcopy_abort(ucp_request_t *request, ucs_status_t status);
 
-void ucp_proto_request_zcopy_clean(ucp_request_t *request);
+void ucp_proto_request_zcopy_reset(ucp_request_t *request);
 
 #endif

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -262,10 +262,16 @@ void ucp_proto_common_zcopy_adjust_min_frag_always(ucp_request_t *req,
 
 void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status);
 
+ucs_status_t ucp_proto_request_init(ucp_request_t *req);
+
+void ucp_proto_request_restart(ucp_request_t *req);
 
 void ucp_proto_request_bcopy_abort(ucp_request_t *request, ucs_status_t status);
 
+void ucp_proto_request_bcopy_clean(ucp_request_t *request);
 
 void ucp_proto_request_zcopy_abort(ucp_request_t *request, ucs_status_t status);
+
+void ucp_proto_request_zcopy_clean(ucp_request_t *request);
 
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -70,7 +70,7 @@ ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_proto_request_zcopy_clean_by_mask(ucp_request_t *req, unsigned dt_mask)
+ucp_proto_request_zcopy_clean(ucp_request_t *req, unsigned dt_mask)
 {
     ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
                                 &req->send.state.dt_iter, dt_mask);
@@ -81,7 +81,7 @@ ucp_proto_request_zcopy_clean_by_mask(ucp_request_t *req, unsigned dt_mask)
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_request_zcopy_complete(ucp_request_t *req, ucs_status_t status)
 {
-    ucp_proto_request_zcopy_clean_by_mask(req, UCP_DT_MASK_CONTIG_IOV);
+    ucp_proto_request_zcopy_clean(req, UCP_DT_MASK_CONTIG_IOV);
     ucp_request_complete_send(req, status);
 }
 

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -70,17 +70,18 @@ ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_proto_request_zcopy_cleanup(ucp_request_t *req, unsigned dt_mask)
+ucp_proto_request_zcopy_clean_by_mask(ucp_request_t *req, unsigned dt_mask)
 {
     ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
                                 &req->send.state.dt_iter, dt_mask);
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, dt_mask);
+    req->flags &= ~UCP_REQUEST_FLAG_PROTO_INITIALIZED;
 }
 
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_request_zcopy_complete(ucp_request_t *req, ucs_status_t status)
 {
-    ucp_proto_request_zcopy_cleanup(req, UCP_DT_MASK_CONTIG_IOV);
+    ucp_proto_request_zcopy_clean_by_mask(req, UCP_DT_MASK_CONTIG_IOV);
     ucp_request_complete_send(req, status);
 }
 

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -19,27 +19,11 @@
 static ucs_status_t ucp_proto_reconfig_select_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req  = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_ep_h ep         = req->send.ep;
-    ucp_worker_h worker = ep->worker;
-    ucp_worker_cfg_index_t rkey_cfg_index;
-    ucp_proto_select_t *proto_select;
     ucs_status_t status;
 
-    proto_select = ucp_proto_select_get(worker, ep->cfg_index,
-                                        req->send.proto_config->rkey_cfg_index,
-                                        &rkey_cfg_index);
-    if (proto_select == NULL) {
-        return UCS_OK;
-    }
-
-    /* Select from protocol hash according to saved request parameters */
-    status = ucp_proto_request_lookup_proto(
-            worker, ep, req, proto_select, rkey_cfg_index,
-            &req->send.proto_config->select_param,
-            req->send.state.dt_iter.length);
-    if (status != UCS_OK) {
-        /* will try again later */
-        return UCS_ERR_NO_RESOURCE;
+    status = ucp_proto_request_init(req);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
     }
 
     return req->send.uct.func(&req->send.uct);
@@ -97,5 +81,6 @@ ucp_proto_t ucp_reconfig_proto = {
     .init     = ucp_proto_reconfig_init,
     .query    = ucp_proto_default_query,
     .progress = {ucp_proto_reconfig_progress},
-    .abort    = ucp_request_complete_send
+    .abort    = ucp_request_complete_send,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function
 };

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -83,5 +83,5 @@ ucp_proto_t ucp_reconfig_proto = {
     .query    = ucp_proto_default_query,
     .progress = {ucp_proto_reconfig_progress},
     .abort    = ucp_request_complete_send,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function
 };

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -23,7 +23,8 @@ static ucs_status_t ucp_proto_reconfig_select_progress(uct_pending_req_t *self)
 
     status = ucp_proto_request_init(req);
     if (ucs_unlikely(status != UCS_OK)) {
-        return status;
+        /* will try again later */
+        return UCS_ERR_NO_RESOURCE;
     }
 
     return req->send.uct.func(&req->send.uct);

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -426,8 +426,8 @@ ucp_proto_t ucp_get_amo_post_proto = {
     .init     = ucp_proto_amo_sw_init_post,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_amo_sw_progress_post},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
@@ -455,6 +455,6 @@ ucp_proto_t ucp_get_amo_fetch_proto = {
     .init     = ucp_proto_amo_sw_init_fetch,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_amo_sw_progress_fetch},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -426,7 +426,8 @@ ucp_proto_t ucp_get_amo_post_proto = {
     .init     = ucp_proto_amo_sw_init_post,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_amo_sw_progress_post},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
@@ -454,5 +455,6 @@ ucp_proto_t ucp_get_amo_fetch_proto = {
     .init     = ucp_proto_amo_sw_init_fetch,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_amo_sw_progress_fetch},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -107,6 +107,6 @@ ucp_proto_t ucp_get_am_bcopy_proto = {
     .init     = ucp_proto_get_am_bcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_get_am_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void,
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -107,5 +107,6 @@ ucp_proto_t ucp_get_am_bcopy_proto = {
     .init     = ucp_proto_get_am_bcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_get_am_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void,
 };

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -113,8 +113,8 @@ ucp_proto_t ucp_get_offload_bcopy_proto = {
     .init     = ucp_proto_get_offload_bcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -201,6 +201,6 @@ ucp_proto_t ucp_get_offload_zcopy_proto = {
     .init     = ucp_proto_get_offload_zcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_zcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -113,7 +113,8 @@ ucp_proto_t ucp_get_offload_bcopy_proto = {
     .init     = ucp_proto_get_offload_bcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -200,5 +201,6 @@ ucp_proto_t ucp_get_offload_zcopy_proto = {
     .init     = ucp_proto_get_offload_zcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_zcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -112,6 +112,7 @@ ucp_proto_t ucp_put_am_bcopy_proto = {
     .init     = ucp_proto_put_am_bcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_am_bcopy_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -113,6 +113,6 @@ ucp_proto_t ucp_put_am_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_am_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -87,7 +87,8 @@ ucp_proto_t ucp_put_offload_short_proto = {
     .init     = ucp_proto_put_offload_short_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_put_offload_short_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static size_t ucp_proto_put_offload_bcopy_pack(void *dest, void *arg)
@@ -184,7 +185,8 @@ ucp_proto_t ucp_put_offload_bcopy_proto = {
     .init     = ucp_proto_put_offload_bcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_bcopy_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -266,5 +268,6 @@ ucp_proto_t ucp_put_offload_zcopy_proto = {
     .init     = ucp_proto_put_offload_zcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_zcopy_progress},
-    .abort    = ucp_proto_request_zcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -87,8 +87,8 @@ ucp_proto_t ucp_put_offload_short_proto = {
     .init     = ucp_proto_put_offload_short_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_put_offload_short_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static size_t ucp_proto_put_offload_bcopy_pack(void *dest, void *arg)
@@ -186,7 +186,7 @@ ucp_proto_t ucp_put_offload_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -269,5 +269,5 @@ ucp_proto_t ucp_put_offload_zcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_zcopy_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -116,6 +116,7 @@ void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
 
 void ucp_proto_rndv_rts_abort(ucp_request_t *req, ucs_status_t status);
 
+
 ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *params,
                                      const char *name,
                                      const ucp_proto_caps_t *bulk_caps,

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -116,7 +116,6 @@ void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
 
 void ucp_proto_rndv_rts_abort(ucp_request_t *req, ucs_status_t status);
 
-
 ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *params,
                                      const char *name,
                                      const ucp_proto_caps_t *bulk_caps,

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -82,7 +82,7 @@ ucp_proto_rndv_ats_handler(void *arg, void *data, size_t length, unsigned flags)
     }
 
     ucp_send_request_id_release(req);
-    ucp_proto_request_zcopy_clean_by_mask(req, UCP_DT_MASK_ALL);
+    ucp_proto_request_zcopy_clean(req, UCP_DT_MASK_ALL);
     ucp_request_complete_send(req, status);
 
     return UCS_OK;

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -82,7 +82,7 @@ ucp_proto_rndv_ats_handler(void *arg, void *data, size_t length, unsigned flags)
     }
 
     ucp_send_request_id_release(req);
-    ucp_proto_request_zcopy_cleanup(req, UCP_DT_MASK_ALL);
+    ucp_proto_request_zcopy_clean_by_mask(req, UCP_DT_MASK_ALL);
     ucp_request_complete_send(req, status);
 
     return UCS_OK;

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -132,5 +132,5 @@ ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_rndv_am_bcopy_progress},
     .abort    = ucp_proto_rndv_am_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -131,5 +131,6 @@ ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .init     = ucp_proto_rdnv_am_bcopy_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_rndv_am_bcopy_progress},
-    .abort    = ucp_proto_rndv_am_bcopy_abort
+    .abort    = ucp_proto_rndv_am_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -213,7 +213,8 @@ ucp_proto_t ucp_rndv_get_zcopy_proto = {
          [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_zcopy_fetch_progress,
          [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
-    .abort    = ucp_rndv_get_zcopy_proto_abort
+    .abort    = ucp_rndv_get_zcopy_proto_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_mtype_send_func(
@@ -324,5 +325,6 @@ ucp_proto_t ucp_rndv_get_mtype_proto = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,
         [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -214,7 +214,7 @@ ucp_proto_t ucp_rndv_get_zcopy_proto = {
          [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
     .abort    = ucp_rndv_get_zcopy_proto_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_get_mtype_send_func(
@@ -325,6 +325,6 @@ ucp_proto_t ucp_rndv_get_mtype_proto = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,
         [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -281,7 +281,8 @@ ucp_proto_t ucp_rndv_send_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_send_ppln_atp_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t
@@ -316,5 +317,6 @@ ucp_proto_t ucp_rndv_recv_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_recv_ppln_ats_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -281,8 +281,8 @@ ucp_proto_t ucp_rndv_send_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_send_ppln_atp_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t
@@ -317,6 +317,6 @@ ucp_proto_t ucp_rndv_recv_ppln_proto = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
         [UCP_PROTO_RNDV_PPLN_STAGE_ACK]  = ucp_proto_rndv_recv_ppln_ats_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -412,8 +412,8 @@ ucp_proto_t ucp_rndv_put_zcopy_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 
@@ -549,6 +549,6 @@ ucp_proto_t ucp_rndv_put_mtype_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -412,7 +412,8 @@ ucp_proto_t ucp_rndv_put_zcopy_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 
@@ -548,5 +549,6 @@ ucp_proto_t ucp_rndv_put_mtype_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -179,6 +179,7 @@ ucp_proto_t ucp_rndv_rkey_ptr_proto = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_FETCH] = ucp_proto_rndv_rkey_ptr_fetch_progress,
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -179,7 +179,7 @@ ucp_proto_t ucp_rndv_rkey_ptr_proto = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_FETCH] = ucp_proto_rndv_rkey_ptr_fetch_progress,
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -242,9 +242,9 @@ ucp_proto_t ucp_rndv_rtr_proto = {
     .init     = ucp_proto_rndv_rtr_init,
     .query    = ucp_proto_rndv_rtr_query,
     .progress = {ucp_proto_rndv_rtr_progress},
-    .abort    = ucp_proto_rndv_rtr_abort
+    .abort    = ucp_proto_rndv_rtr_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
-
 
 static size_t ucp_proto_rndv_rtr_mtype_pack(void *dest, void *arg)
 {
@@ -392,7 +392,8 @@ ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .init     = ucp_proto_rndv_rtr_mtype_init,
     .query    = ucp_proto_rndv_rtr_mtype_query,
     .progress = {ucp_proto_rndv_rtr_mtype_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -243,7 +243,7 @@ ucp_proto_t ucp_rndv_rtr_proto = {
     .query    = ucp_proto_rndv_rtr_query,
     .progress = {ucp_proto_rndv_rtr_progress},
     .abort    = ucp_proto_rndv_rtr_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static size_t ucp_proto_rndv_rtr_mtype_pack(void *dest, void *arg)
@@ -392,8 +392,8 @@ ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .init     = ucp_proto_rndv_rtr_mtype_init,
     .query    = ucp_proto_rndv_rtr_mtype_query,
     .progress = {ucp_proto_rndv_rtr_mtype_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -135,7 +135,8 @@ ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .init     = ucp_proto_eager_bcopy_multi_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_eager_bcopy_multi_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t
@@ -205,6 +206,19 @@ ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
             ucp_proto_eager_sync_bcopy_send_completed);
 }
 
+static void ucp_proto_eager_sync_bcopy_request_clean(ucp_request_t *request)
+{
+    ucp_send_request_id_release(request);
+    ucp_proto_request_bcopy_clean(request);
+}
+
+static void ucp_proto_eager_sync_bcopy_request_abort(ucp_request_t *request,
+                                                     ucs_status_t status)
+{
+    ucp_send_request_id_release(request);
+    ucp_proto_request_bcopy_abort(request, status);
+}
+
 ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .name     = "egrsnc/multi/bcopy",
     .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
@@ -212,7 +226,8 @@ ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .init     = ucp_proto_eager_sync_bcopy_multi_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_eager_sync_bcopy_multi_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_proto_eager_sync_bcopy_request_abort,
+    .clean    = ucp_proto_eager_sync_bcopy_request_clean
 };
 
 static ucs_status_t
@@ -296,5 +311,6 @@ ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .init     = ucp_proto_eager_zcopy_multi_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_eager_zcopy_multi_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = ucp_proto_request_zcopy_abort,
+    .clean    = ucp_proto_request_zcopy_clean
 };

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -135,8 +135,8 @@ ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .init     = ucp_proto_eager_bcopy_multi_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_eager_bcopy_multi_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t
@@ -206,10 +206,10 @@ ucp_proto_eager_sync_bcopy_multi_progress(uct_pending_req_t *uct_req)
             ucp_proto_eager_sync_bcopy_send_completed);
 }
 
-static void ucp_proto_eager_sync_bcopy_request_clean(ucp_request_t *request)
+static void ucp_proto_eager_sync_bcopy_request_reset(ucp_request_t *request)
 {
     ucp_send_request_id_release(request);
-    ucp_proto_request_bcopy_clean(request);
+    ucp_proto_request_bcopy_reset(request);
 }
 
 static void ucp_proto_eager_sync_bcopy_request_abort(ucp_request_t *request,
@@ -227,7 +227,7 @@ ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_eager_sync_bcopy_multi_progress},
     .abort    = ucp_proto_eager_sync_bcopy_request_abort,
-    .clean    = ucp_proto_eager_sync_bcopy_request_clean
+    .reset    = ucp_proto_eager_sync_bcopy_request_reset
 };
 
 static ucs_status_t
@@ -312,5 +312,5 @@ ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_eager_zcopy_multi_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .clean    = ucp_proto_request_zcopy_clean
+    .reset    = ucp_proto_request_zcopy_reset
 };

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -155,7 +155,7 @@ ucp_proto_t ucp_eager_bcopy_single_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_bcopy_single_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static ucs_status_t

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -85,7 +85,7 @@ ucp_proto_t ucp_eager_short_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_short_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = ucp_proto_request_bcopy_clean
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static size_t ucp_eager_single_pack(void *dest, void *arg)
@@ -155,7 +155,7 @@ ucp_proto_t ucp_eager_bcopy_single_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_bcopy_single_progress},
     .abort    = ucp_proto_request_bcopy_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t
@@ -225,5 +225,5 @@ ucp_proto_t ucp_eager_zcopy_single_proto = {
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_zcopy_single_progress},
     .abort    = ucp_proto_request_zcopy_abort,
-    .clean    = ucp_proto_request_zcopy_clean
+    .reset    = ucp_proto_request_zcopy_reset
 };

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -84,7 +84,8 @@ ucp_proto_t ucp_eager_short_proto = {
     .init     = ucp_proto_eager_short_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_short_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = ucp_proto_request_bcopy_clean
 };
 
 static size_t ucp_eager_single_pack(void *dest, void *arg)
@@ -153,7 +154,8 @@ ucp_proto_t ucp_eager_bcopy_single_proto = {
     .init     = ucp_proto_eager_bcopy_single_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_bcopy_single_progress},
-    .abort    = ucp_proto_request_bcopy_abort
+    .abort    = ucp_proto_request_bcopy_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t
@@ -222,5 +224,6 @@ ucp_proto_t ucp_eager_zcopy_single_proto = {
     .init     = ucp_proto_eager_zcopy_single_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_zcopy_single_progress},
-    .abort    = ucp_proto_request_zcopy_abort
+    .abort    = ucp_proto_request_zcopy_abort,
+    .clean    = ucp_proto_request_zcopy_clean
 };

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -83,8 +83,8 @@ ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .init     = ucp_proto_eager_tag_offload_short_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_short_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static size_t ucp_eager_tag_offload_pack(void *dest, void *arg)
@@ -178,8 +178,8 @@ ucp_proto_t ucp_tag_offload_eager_bcopy_single_proto = {
     .init     = ucp_proto_eager_tag_offload_bcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -217,8 +217,8 @@ ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .init     = ucp_proto_eager_sync_tag_offload_bcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init_common(
@@ -296,8 +296,8 @@ ucp_proto_t ucp_tag_offload_eager_zcopy_single_proto = {
     .init     = ucp_proto_eager_tag_offload_zcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_zcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };
 
 static ucs_status_t ucp_proto_eager_sync_tag_offload_zcopy_init(
@@ -325,7 +325,7 @@ ucp_proto_eager_sync_tag_offload_zcopy_send_completion(uct_completion_t *self)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
 
-    ucp_proto_request_zcopy_clean_by_mask(req, UCS_BIT(UCP_DATATYPE_CONTIG));
+    ucp_proto_request_zcopy_clean(req, UCS_BIT(UCP_DATATYPE_CONTIG));
     ucp_proto_eager_sync_send_completed_common(req);
 }
 
@@ -356,6 +356,6 @@ ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .init     = ucp_proto_eager_sync_tag_offload_zcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_fatal_not_implemented_void,
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -83,7 +83,8 @@ ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .init     = ucp_proto_eager_tag_offload_short_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_short_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static size_t ucp_eager_tag_offload_pack(void *dest, void *arg)
@@ -177,7 +178,8 @@ ucp_proto_t ucp_tag_offload_eager_bcopy_single_proto = {
     .init     = ucp_proto_eager_tag_offload_bcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -215,7 +217,8 @@ ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .init     = ucp_proto_eager_sync_tag_offload_bcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init_common(
@@ -293,7 +296,8 @@ ucp_proto_t ucp_tag_offload_eager_zcopy_single_proto = {
     .init     = ucp_proto_eager_tag_offload_zcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_zcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };
 
 static ucs_status_t ucp_proto_eager_sync_tag_offload_zcopy_init(
@@ -321,7 +325,7 @@ ucp_proto_eager_sync_tag_offload_zcopy_send_completion(uct_completion_t *self)
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,
                                           send.state.uct_comp);
 
-    ucp_proto_request_zcopy_cleanup(req, UCS_BIT(UCP_DATATYPE_CONTIG));
+    ucp_proto_request_zcopy_clean_by_mask(req, UCS_BIT(UCP_DATATYPE_CONTIG));
     ucp_proto_eager_sync_send_completed_common(req);
 }
 
@@ -352,5 +356,6 @@ ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .init     = ucp_proto_eager_sync_tag_offload_zcopy_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
-    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
+    .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -164,5 +164,5 @@ ucp_proto_t ucp_tag_rndv_proto = {
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_tag_rndv_rts_progress},
     .abort    = ucp_proto_rndv_rts_abort,
-    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_fatal_not_implemented_void
 };

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -163,5 +163,6 @@ ucp_proto_t ucp_tag_rndv_proto = {
     .init     = ucp_tag_rndv_rts_init,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_tag_rndv_rts_progress},
-    .abort    = ucp_proto_rndv_rts_abort
+    .abort    = ucp_proto_rndv_rts_abort,
+    .clean    = (ucp_request_clean_func_t)ucs_empty_function_do_assert_void
 };

--- a/src/ucs/sys/stubs.c
+++ b/src/ucs/sys/stubs.c
@@ -101,3 +101,8 @@ void ucs_empty_function_do_assert_void()
 {
     ucs_assert_always(0);
 }
+
+void ucs_empty_function_fatal_not_implemented_void()
+{
+    ucs_fatal("%s", ucs_status_string(UCS_ERR_NOT_IMPLEMENTED));
+}

--- a/src/ucs/sys/stubs.h
+++ b/src/ucs/sys/stubs.h
@@ -38,6 +38,7 @@ ssize_t ucs_empty_function_return_bc_ep_timeout();
 ucs_status_t ucs_empty_function_return_busy();
 int ucs_empty_function_do_assert();
 void ucs_empty_function_do_assert_void();
+void ucs_empty_function_fatal_not_implemented_void();
 
 END_C_DECLS
 


### PR DESCRIPTION
## What
Add UCP request clean and reinit after wireup:
infrastructure and basic protocols

## Why ?
EP might be reconfigured during wireup, then initially selected protocols are not applicable for pending requests and should be re-selected, so the requests also should be re-inisialized.

## How ?
 - add `ucp_proto_t::clean`
 - restart requests from pending replay:
   - clean
   - init
   - send

- support AM user header release. description can be found [here](https://github.com/openucx/ucx/pull/8173#discussion_r928840502)
