### PR TITLE
UCT/AM: Change UCT AM handlers API to support additional optional par…

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -745,13 +745,14 @@ int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
  *
  * @param iface    Interface to invoke the handler for.
  * @param id       Active message ID.
- * @param data     Received data.
+ * @param msg_hdr  Received message header.
  * @param length   Length of received data.
  * @param flags    Mask with @ref uct_cb_param_flags
  */
-static inline ucs_status_t
-uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
-                    unsigned length, unsigned flags)
+static inline ucs_status_t uct_iface_invoke_am(uct_base_iface_t *iface,
+                                               uint8_t id, void *msg_hdr,
+                                               unsigned length, unsigned flags,
+                                               uct_am_callback_params_t *params)
 {
     ucs_status_t     status;
     uct_am_handler_t *handler;
@@ -763,13 +764,13 @@ uct_iface_invoke_am(uct_base_iface_t *iface, uint8_t id, void *data,
     UCS_STATS_UPDATE_COUNTER(iface->stats, UCT_IFACE_STAT_RX_AM_BYTES, length);
 
     handler = &iface->am[id];
-    status = handler->cb(handler->arg, data, length, flags);
+    status  = handler->cb(handler->arg, msg_hdr, length, flags, params);
     ucs_assertv((status == UCS_OK) ||
                 ((status == UCS_INPROGRESS) && (flags &
                                                 UCT_CB_PARAM_FLAG_DESC)),
                 "%s(arg=%p data=%p length=%u flags=0x%x) returned %s",
                 ucs_debug_get_symbol_name((void*)handler->cb), handler->arg,
-                data, length, flags, ucs_status_string(status));
+                msg_hdr, length, flags, ucs_status_string(status));
     return status;
 }
 


### PR DESCRIPTION
## What
Change UCT AM API to support additional optional parameters

## Why ?
Supporting user memory allocator and signature offload https://github.com/Mellanox/ucx/tree/io_offload requires passing additional parameters to
AM handlers.

## How ?
Defining new params struct that holds the additional required parameters and pass it to AM handler.
