### PR TITLE
UCT/FLUSH: enabled FLUSH_REMOTE feature

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -818,15 +818,16 @@ static uint64_t ucp_worker_get_uct_features(ucp_context_h context)
     }
 
     if (context->config.features & UCP_FEATURE_RMA) {
-        features |= UCT_IFACE_FEATURE_PUT | UCT_IFACE_FEATURE_GET;
+        features |= UCT_IFACE_FEATURE_PUT | UCT_IFACE_FEATURE_GET |
+                    UCT_IFACE_FEATURE_FLUSH_REMOTE;
     }
 
     if (context->config.features & UCP_FEATURE_AMO32) {
-        features |= UCT_IFACE_FEATURE_AMO32;
+        features |= UCT_IFACE_FEATURE_AMO32 | UCT_IFACE_FEATURE_FLUSH_REMOTE;
     }
 
     if (context->config.features & UCP_FEATURE_AMO64) {
-        features |= UCT_IFACE_FEATURE_AMO64;
+        features |= UCT_IFACE_FEATURE_AMO64 | UCT_IFACE_FEATURE_FLUSH_REMOTE;
     }
 
     if (context->num_mem_type_detect_mds > 0) {

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -686,7 +686,6 @@ uct_dc_mlx5_ep_flush_remote(uct_dc_mlx5_ep_t *ep, uct_completion_t *comp)
     return UCS_INPROGRESS;
 }
 
-
 ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                   uct_completion_t *comp)
 {
@@ -710,10 +709,12 @@ ucs_status_t uct_dc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
         goto out;
     }
 
-    if ((flags & UCT_FLUSH_FLAG_REMOTE) &&
-        ucs_test_all_flags(ep->flags, UCT_DC_MLX5_EP_FLAG_FLUSH_RKEY |
-                                      UCT_DC_MLX5_EP_FLAG_FLUSH_REMOTE)) {
-        return uct_dc_mlx5_ep_flush_remote(ep, comp);
+    if (flags & UCT_FLUSH_FLAG_REMOTE) {
+        UCT_RC_IFACE_CHECK_FLUSH_REMOTE(ep->flags & UCT_DC_MLX5_EP_FLAG_FLUSH_RKEY,
+                                        ep, &iface->super.super, dcx);
+        if (ep->flags & UCT_DC_MLX5_EP_FLAG_FLUSH_REMOTE) {
+            return uct_dc_mlx5_ep_flush_remote(ep, comp);
+        }
     }
 
     if (ep->dci == UCT_DC_MLX5_EP_NO_DCI) {

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -599,9 +599,13 @@ ucs_status_t uct_rc_mlx5_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                                UCT_FLUSH_FLAG_REMOTE),
                     "flush flags CANCEL and REMOTE are mutually exclusive");
 
-    if ((flags & UCT_FLUSH_FLAG_REMOTE) &&
-        uct_rc_ep_is_flush_remote(&ep->super)) {
-        return uct_rc_mlx5_ep_flush_remote(tl_ep, comp);
+    if (flags & UCT_FLUSH_FLAG_REMOTE) {
+        UCT_RC_IFACE_CHECK_FLUSH_REMOTE(
+                uct_ib_md_is_flush_rkey_valid(ep->super.flush_rkey), ep,
+                &iface->super, rcx);
+        if (ep->super.flags & UCT_RC_EP_FLAG_FLUSH_REMOTE) {
+            return uct_rc_mlx5_ep_flush_remote(tl_ep, comp);
+        }
     }
 
     status = uct_rc_ep_flush(&ep->super, ep->tx.wq.bb_max, flags);

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -547,10 +547,4 @@ uct_rc_ep_enable_flush_remote(uct_rc_ep_t *ep)
     ep->flags |= UCT_RC_EP_FLAG_FLUSH_REMOTE;
 }
 
-static UCS_F_ALWAYS_INLINE int uct_rc_ep_is_flush_remote(uct_rc_ep_t *ep)
-{
-    return (ep->flags & UCT_RC_EP_FLAG_FLUSH_REMOTE) &&
-           uct_ib_md_is_flush_rkey_valid(ep->flush_rkey);
-}
-
 #endif

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -730,9 +730,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
         self->config.fc_hard_thresh = 0;
     }
 
-    self->config.flush_remote = UCT_IFACE_PARAM_FEATURE(params, PUT) ||
-                                UCT_IFACE_PARAM_FEATURE(params, AMO32) ||
-                                UCT_IFACE_PARAM_FEATURE(params, AMO64);
+    self->config.flush_remote = UCT_IFACE_PARAM_FEATURE(params, FLUSH_REMOTE);
 
     return UCS_OK;
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -87,6 +87,16 @@
     _desc->super.user_comp = _comp;
 
 
+#define UCT_RC_IFACE_CHECK_FLUSH_REMOTE(_condition, _ep, _iface, _name) \
+    if (ENABLE_PARAMS_CHECK && !(_condition)) { \
+        ucs_error("%s endpoint %p on %s: flush(remote) is not supported", \
+                  UCS_PP_QUOTE(_name), \
+                  _ep, \
+                  uct_ib_device_name(uct_ib_iface_device(&(_iface)->super))); \
+        return UCS_ERR_UNSUPPORTED; \
+    }
+
+
 enum {
     UCT_RC_IFACE_STAT_NO_CQE,
     UCT_RC_IFACE_STAT_NO_READS,

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -479,9 +479,13 @@ ucs_status_t uct_rc_verbs_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                                UCT_FLUSH_FLAG_REMOTE),
                     "flush flags CANCEL and REMOTE are mutually exclusive");
 
-    if ((flags & UCT_FLUSH_FLAG_REMOTE) &&
-        uct_rc_ep_is_flush_remote(&ep->super)) {
-        return uct_rc_verbs_ep_flush_remote(ep, comp);
+    if (flags & UCT_FLUSH_FLAG_REMOTE) {
+        UCT_RC_IFACE_CHECK_FLUSH_REMOTE(
+                uct_ib_md_is_flush_rkey_valid(ep->super.flush_rkey), ep,
+                &iface->super, rcv);
+        if (ep->super.flags & UCT_RC_EP_FLAG_FLUSH_REMOTE) {
+            return uct_rc_verbs_ep_flush_remote(ep, comp);
+        }
     }
 
     status = uct_rc_ep_flush(&ep->super, iface->config.tx_max_wr, flags);


### PR DESCRIPTION
- enabled UCT_IFACE_FEATURE_FLUSH_REMOTE feature: iface will
  produce flush(remote) op only if feature was created with
  correcponding flag
- added FLUSH_REMOTE feature for iface_open when RMA
  functionality is requested
