### PR TITLE
UCP/CORE: 16 lanes support

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -499,7 +499,7 @@ typedef struct ucp_ep_ext {
      * UCT endpoints for every slow-path lane that has no room in the base endpoint
      * structure. TODO allocate this array dynamically.
      */
-    uct_ep_h                      uct_eps[UCP_MAX_SLOW_PATH_LANES];
+    uct_ep_h                     *uct_eps;
 } ucp_ep_ext_t;
 
 
@@ -828,5 +828,18 @@ void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status);
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_ep_query_sockaddr(ucp_ep_h ucp_ep, ucp_ep_attr_t *attr);
+
+/**
+ * @brief Realloc slow lanes according to current number of lanes.
+ *        Slow lanes number will be (new_num_lanes - MAX_FAST_PATH_LANES).
+ *        If new slow lanes are added, fill them with NULL.
+ *
+ * @param [in] ucp_ep           Endpoint object.
+ * @param [in] new_num_lanes    Number of total lanes required
+ *                              (including fast lanes).
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_ep_realloc_lanes(ucp_ep_h ep, unsigned new_num_lanes);
 
 #endif

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -245,9 +245,6 @@ struct ucp_request {
 
                             /* Actual lanes count */
                             uint8_t        lanes_count;
-
-                            /* Remote key index map */
-                            uint8_t        rkey_index[UCP_MAX_LANES];
                         };
 
                         /* Used by "new" rendezvous protocols, in proto_rndv.c */

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -40,13 +40,13 @@ UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 
 /* Lanes */
-#define UCP_MAX_LANES                8
+#define UCP_MAX_LANES                16
 #define UCP_MAX_FAST_PATH_LANES      5
 #define UCP_MAX_SLOW_PATH_LANES      (UCP_MAX_LANES - UCP_MAX_FAST_PATH_LANES)
 
 #define UCP_NULL_LANE                ((ucp_lane_index_t)-1)
 typedef uint8_t                      ucp_lane_index_t;
-typedef uint8_t                      ucp_lane_map_t;
+UCP_UINT_TYPE(UCP_MAX_LANES)         ucp_lane_map_t;
 
 
 /* System devices */

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -440,12 +440,39 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_request_send(rndv_req);
 }
 
+static uint8_t ucp_rndv_get_rkey_index(ucp_request_t *rndv_req, ucp_rkey_h rkey,
+                                       ucp_lane_index_t lane)
+{
+    ucp_ep_h ep                 = rndv_req->send.ep;
+    ucp_context_h context       = ep->worker->context;
+    ucp_ep_config_t *ep_config  = ucp_ep_config(ep);
+    ucp_md_index_t md_index     = ep_config->md_index[lane];
+    ucp_md_index_t dst_md_index = ep_config->key.lanes[lane].dst_md_index;
+    uint8_t mem_type            = rndv_req->send.mem_type;
+    uct_md_attr_v2_t *md_attr;
+
+    if ((md_index == UCP_NULL_RESOURCE) || (rkey == NULL)) {
+        return UCP_NULL_RESOURCE;
+    }
+
+    md_attr = &context->tl_mds[md_index].attr;
+    if (ucs_unlikely(!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY))) {
+        if ((md_attr->access_mem_types & UCS_BIT(mem_type)) &&
+            (mem_type == rkey->mem_type)) {
+            return UCP_NULL_RESOURCE;
+        }
+    }
+
+    return ucs_bitmap2idx(rkey->md_map, dst_md_index);
+}
+
 static ucp_lane_index_t ucp_rndv_zcopy_get_lane(ucp_request_t *rndv_req,
                                                 uct_rkey_t *uct_rkey,
                                                 unsigned proto)
 {
-    ucp_lane_index_t lane_idx;
-    ucp_ep_config_t *ep_config;
+    ucp_ep_h ep                = rndv_req->send.ep;
+    ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+    ucp_lane_index_t lane_idx, lane;
     ucp_rkey_h rkey;
     uint8_t rkey_index;
 
@@ -459,12 +486,14 @@ static ucp_lane_index_t ucp_rndv_zcopy_get_lane(ucp_request_t *rndv_req,
     lane_idx   = ucs_ffs64_safe(rndv_req->send.lanes_map_avail);
     ucs_assert(lane_idx < UCP_MAX_LANES);
     rkey       = rndv_req->send.rndv.rkey;
-    rkey_index = rndv_req->send.rndv.rkey_index[lane_idx];
+
+    lane = (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ?
+                   ep_config->rndv.get_zcopy.lanes[lane_idx] :
+                   ep_config->rndv.put_zcopy.lanes[lane_idx];
+
+    rkey_index = ucp_rndv_get_rkey_index(rndv_req, rkey, lane);
     *uct_rkey  = ucp_rkey_get_tl_rkey(rkey, rkey_index);
-    ep_config  = ucp_ep_config(rndv_req->send.ep);
-    return (proto == UCP_REQUEST_SEND_PROTO_RNDV_GET) ?
-           ep_config->rndv.get_zcopy.lanes[lane_idx] :
-           ep_config->rndv.put_zcopy.lanes[lane_idx];
+    return lane;
 }
 
 static void ucp_rndv_zcopy_next_lane(ucp_request_t *rndv_req)
@@ -694,7 +723,6 @@ static void ucp_rndv_req_init_zcopy_lane_map(ucp_request_t *rndv_req,
             /* Lane does not need rkey, can use the lane with invalid rkey  */
             if (!rkey || ((md_attr->access_mem_types & UCS_BIT(mem_type)) &&
                           (mem_type == rkey->mem_type))) {
-                rndv_req->send.rndv.rkey_index[i] = UCP_NULL_RESOURCE;
                 lane_map                         |= UCS_BIT(i);
                 max_lane_bw                       = ucs_max(max_lane_bw, lane_bw);
                 continue;
@@ -715,8 +743,6 @@ static void ucp_rndv_req_init_zcopy_lane_map(ucp_request_t *rndv_req,
         dst_md_index = ep_config->key.lanes[lane].dst_md_index;
         if (rkey && ucs_likely(rkey->md_map & UCS_BIT(dst_md_index))) {
             /* Return first matching lane */
-            rndv_req->send.rndv.rkey_index[i] = ucs_bitmap2idx(rkey->md_map,
-                                                               dst_md_index);
             lane_map                         |= UCS_BIT(i);
             max_lane_bw                       = ucs_max(max_lane_bw, lane_bw);
         }
@@ -748,7 +774,6 @@ static void ucp_rndv_req_init_zcopy_lane_map(ucp_request_t *rndv_req,
         if (((lane_bw / max_lane_bw) < max_ratio) ||
             (lanes_count > chunk_count)) {
             lane_map                                &= ~UCS_BIT(lane_idx);
-            rndv_req->send.rndv.rkey_index[lane_idx] = UCP_NULL_RESOURCE;
         }
     }
 
@@ -762,26 +787,14 @@ out:
 
 static void ucp_rndv_req_init(ucp_request_t *req, ucp_request_t *super_req,
                               ucp_lane_map_t lanes_map, uint8_t lanes_count,
-                              ucp_rkey_h rkey, uint64_t remote_address,
-                              uint8_t *rkey_index)
+                              ucp_rkey_h rkey, uint64_t remote_address)
 {
-    ucp_lane_index_t i;
-
     req->send.rndv.rkey           = rkey;
     req->send.rndv.remote_address = remote_address;
     req->send.pending_lane        = UCP_NULL_LANE;
 
     ucp_request_set_super(req, super_req);
     ucp_rndv_req_init_lanes(req, lanes_map, lanes_count);
-
-    if (rkey_index != NULL) {
-        memcpy(req->send.rndv.rkey_index, rkey_index,
-               sizeof(*req->send.rndv.rkey_index) * UCP_MAX_LANES);
-    } else {
-        for (i = 0; i < UCP_MAX_LANES; i++) {
-            req->send.rndv.rkey_index[i] = UCP_NULL_RESOURCE;
-        }
-    }
 }
 
 static void
@@ -830,7 +843,7 @@ ucp_rndv_rkey_ptr_get_mem_type(ucp_request_t *sreq, size_t length,
     freq->send.state.dt.dt.contig.md_map  = UCS_BIT(md_index);
 
     ucp_rndv_req_init(freq, sreq, lanes_map, ucs_popcount(lanes_map), NULL,
-                      remote_address, NULL);
+                      remote_address);
 
     UCP_WORKER_STAT_RNDV(freq->send.ep->worker, GET_ZCOPY, 1);
 
@@ -850,8 +863,7 @@ ucp_rndv_req_init_remote_from_super_req(ucp_request_t *req,
                       super_req->send.rndv.lanes_count,
                       super_req->send.rndv.rkey,
                       super_req->send.rndv.remote_address +
-                      remote_address_offset,
-                      super_req->send.rndv.rkey_index);
+                      remote_address_offset);
 }
 
 static void ucp_rndv_req_init_from_super_req(ucp_request_t *req,
@@ -1050,8 +1062,8 @@ ucp_rndv_recv_frag_put_mem_type(ucp_request_t *rreq, ucp_request_t *freq,
                                     ucp_rndv_progress_rma_put_zcopy);
 
     ucp_rndv_req_init(freq, rreq, 0, 0, NULL,
-                      (uintptr_t)UCS_PTR_BYTE_OFFSET(rreq->recv.buffer, offset),
-                      NULL);
+                      (uintptr_t)UCS_PTR_BYTE_OFFSET(rreq->recv.buffer,
+                                                     offset));
 
     ucp_rndv_req_init_zcopy_lane_map(freq, freq->send.mem_type,
                                      freq->send.length,
@@ -1066,7 +1078,6 @@ ucp_rndv_send_frag_update_get_rkey(ucp_worker_h worker, ucp_request_t *freq,
                                    ucs_memory_type_t mem_type)
 {
     ucp_rkey_h *rkey_p  = &freq->send.rndv.rkey;
-    uint8_t *rkey_index = freq->send.rndv.rkey_index;
     void *rkey_buffer;
     size_t rkey_size;
     ucs_status_t status;
@@ -1093,8 +1104,6 @@ ucp_rndv_send_frag_update_get_rkey(ucp_worker_h worker, ucp_request_t *freq,
     status = ucp_ep_rkey_unpack(mem_type_ep, rkey_buffer, rkey_p);
     ucs_assert_always(status == UCS_OK);
     ucp_rkey_buffer_release(rkey_buffer);
-
-    memset(rkey_index, 0, UCP_MAX_LANES * sizeof(uint8_t));
 }
 
 ucs_mpool_ops_t ucp_frag_mpool_ops = {
@@ -1156,13 +1165,13 @@ out_mp_get:
     return ucp_worker_mpool_get(mpool);
 }
 
-static void
-ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
-                                uint64_t remote_address,
-                                ucs_memory_type_t remote_mem_type,
-                                ucp_rkey_h rkey, uint8_t *rkey_index,
-                                ucp_lane_map_t lanes_map, int update_get_rkey,
-                                uct_completion_callback_t comp_cb)
+static void ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
+                                            uint64_t remote_address,
+                                            ucs_memory_type_t remote_mem_type,
+                                            ucp_rkey_h rkey,
+                                            ucp_lane_map_t lanes_map,
+                                            int update_get_rkey,
+                                            uct_completion_callback_t comp_cb)
 {
     ucp_worker_h worker             = sreq->send.ep->worker;
     ucs_memory_type_t frag_mem_type = worker->context->config.ext.rndv_frag_mem_type;
@@ -1189,7 +1198,7 @@ ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
                                     comp_cb, mdesc, remote_mem_type, length,
                                     ucp_rndv_progress_rma_get_zcopy);
     ucp_rndv_req_init(freq, sreq, lanes_map, ucs_popcount(lanes_map), rkey,
-                      remote_address, rkey_index);
+                      remote_address);
 
     if (update_get_rkey) {
         ucp_rndv_send_frag_update_get_rkey(worker, freq, mdesc, remote_mem_type);
@@ -1297,7 +1306,6 @@ ucp_rndv_recv_start_get_pipeline(ucp_worker_h worker, ucp_request_t *rndv_req,
                                         remote_address + offset,
                                         UCS_MEMORY_TYPE_HOST, /* TODO: find bounce buffer memory type */
                                         rndv_req->send.rndv.rkey,
-                                        rndv_req->send.rndv.rkey_index,
                                         rndv_req->send.rndv.lanes_map_all, 0,
                                         ucp_rndv_recv_frag_get_completion);
 
@@ -2227,9 +2235,8 @@ static ucs_status_t ucp_rndv_send_start_put_pipeline(ucp_request_t *sreq,
              */
             ucp_rndv_send_frag_get_mem_type(
                     fsreq, length,
-                    (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer,
-                                                  offset),
-                    fsreq->send.mem_type, NULL, NULL, UCS_BIT(0), 1,
+                    (uint64_t)UCS_PTR_BYTE_OFFSET(fsreq->send.buffer, offset),
+                    fsreq->send.mem_type, NULL, UCS_BIT(0), 1,
                     ucp_rndv_put_pipeline_frag_get_completion);
         }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -609,7 +609,7 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
     int send_reply            = 0;
     unsigned ep_init_flags    = ucp_ep_err_mode_init_flags(msg->err_mode);
     ucp_tl_bitmap_t tl_bitmap = UCS_BITMAP_ZERO;
-    ucp_rsc_index_t lanes2remote[UCP_MAX_LANES];
+    ucp_lane_index_t lanes2remote[UCP_MAX_LANES];
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_t status;
     int has_cm_lane;
@@ -736,15 +736,13 @@ err_set_ep_failed:
 static unsigned ucp_wireup_send_msg_ack(void *arg)
 {
     ucp_ep_h ep = (ucp_ep_h)arg;
-    ucp_rsc_index_t rsc_tli[UCP_MAX_LANES];
     ucs_status_t status;
 
     /* Send ACK without any address, we've already sent it as part of the request */
     ucs_trace("ep %p: sending wireup ack", ep);
 
-    memset(rsc_tli, UCP_NULL_RESOURCE, sizeof(rsc_tli));
     status = ucp_wireup_msg_send(ep, UCP_WIREUP_MSG_ACK, &ucp_tl_bitmap_min,
-                                 rsc_tli);
+                                 NULL);
     return (status == UCS_OK);
 }
 
@@ -1326,11 +1324,30 @@ ucp_wireup_get_dst_rsc_indices(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     }
 }
 
-static void
+static void ucp_wireup_discard_uct_eps(ucp_ep_h ep, uct_ep_h *uct_eps,
+                                       ucs_queue_head_t *replay_pending_queue)
+{
+    ucp_lane_index_t index;
+
+    for (index = 0; index < UCP_MAX_LANES; ++index) {
+        if (uct_eps[index] == NULL) {
+            continue;
+        }
+
+        ucp_worker_discard_uct_ep(ep, uct_eps[index], UCP_NULL_RESOURCE,
+                                  UCT_FLUSH_FLAG_LOCAL,
+                                  ucp_request_purge_enqueue_cb,
+                                  replay_pending_queue,
+                                  (ucp_send_nbx_callback_t)ucs_empty_function,
+                                  NULL);
+    }
+}
+
+static ucs_status_t
 ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
                                   const ucp_unpacked_address_t *remote_address,
                                   const unsigned *addr_indices,
-                                  ucp_lane_index_t *connect_lane_bitmap,
+                                  ucp_lane_map_t *connect_lane_bitmap,
                                   ucs_queue_head_t *replay_pending_queue)
 {
     uct_ep_h new_uct_eps[UCP_MAX_LANES]                = { NULL };
@@ -1340,6 +1357,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     ucp_ep_config_key_t *old_key;
     ucp_lane_index_t lane, reuse_lane;
     uct_ep_h uct_ep;
+    ucs_status_t status;
 
     *connect_lane_bitmap = UCS_MASK(new_key->num_lanes);
     ucs_queue_head_init(replay_pending_queue);
@@ -1347,7 +1365,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     if (!ucp_ep_has_cm_lane(ep) ||
         (ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL)) {
         /* nothing to intersect with */
-        return;
+        return ucp_ep_realloc_lanes(ep, new_key->num_lanes);
     }
 
     ucs_assert(!(ep->flags & UCP_EP_FLAG_INTERNAL));
@@ -1411,7 +1429,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         reuse_lane = reuse_lane_map[lane];
         uct_ep     = ucp_ep_get_lane(ep, lane);
-        if (reuse_lane == UCP_NULL_RESOURCE) {
+        if (reuse_lane == UCP_NULL_LANE) {
             if (uct_ep != NULL) {
                 ucs_assert(lane != ucp_ep_get_cm_lane(ep));
                 ucp_worker_discard_uct_ep(
@@ -1433,9 +1451,17 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
         ucs_assert(ucp_ep_get_lane(ep, lane) == NULL);
     }
 
-    for (lane = 0; lane < UCP_MAX_LANES; ++lane) {
+    status = ucp_ep_realloc_lanes(ep, new_key->num_lanes);
+    if (status != UCS_OK) {
+        ucp_wireup_discard_uct_eps(ep, new_uct_eps, replay_pending_queue);
+        return status;
+    }
+
+    for (lane = 0; lane < new_key->num_lanes; ++lane) {
         ucp_ep_set_lane(ep, lane, new_uct_eps[lane]);
     }
+
+    return UCS_OK;
 }
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
@@ -1448,7 +1474,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                                           worker->context->tl_bitmap,
                                                           UCP_MAX_RESOURCES);
     ucp_rsc_index_t cm_idx               = UCP_NULL_RESOURCE;
-    ucp_lane_index_t connect_lane_bitmap;
+    ucp_lane_map_t connect_lane_bitmap;
     ucp_ep_config_key_t key;
     ucp_worker_cfg_index_t new_cfg_index;
     ucp_lane_index_t lane;

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -469,6 +469,8 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
             goto try_fallback;
         }
 
+        ucp_ep_realloc_lanes(ep, key.num_lanes);
+
         status = ucp_worker_get_ep_config(worker, &key, ep_init_flags,
                                           &ep->cfg_index);
         if (status != UCS_OK) {

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -34,7 +34,7 @@ struct ibv_ravh {
 #endif
 
 #define UCT_DC_MLX5_KEEPALIVE_NUM_DCIS  1
-#define UCT_DC_MLX5_IFACE_MAX_DCI_POOLS 8
+#define UCT_DC_MLX5_IFACE_MAX_DCI_POOLS 16
 
 #define UCT_DC_MLX5_IFACE_ADDR_TM_ENABLED(_addr) \
     (!!((_addr)->flags & UCT_DC_MLX5_IFACE_ADDR_HW_TM))

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,7 +50,7 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_ep_ext_t, 200);
+    EXPECTED_SIZE(ucp_ep_ext_t, 184);
 #if ENABLE_PARAMS_CHECK
     EXPECTED_SIZE(ucp_rkey_t, 32 + sizeof(ucp_ep_h));
 #else

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1423,8 +1423,27 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup, compare_cm_and_wireup_configs,
     }
 }
 
-UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_wireup)
+class test_max_lanes : public test_ucp_sockaddr {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        get_test_variants_cm_mode(variants, UCP_FEATURE_TAG, CONN_REQ_TAG,
+                                  "tag");
+    }
+};
 
+UCS_TEST_SKIP_COND_P(test_max_lanes, 16_lanes_reconf, !cm_use_all_devices(),
+                     "MAX_RNDV_LANES=16", "MAX_EAGER_LANES=16",
+                     "IB_NUM_PATHS?=16", "TM_SW_RNDV=y")
+{
+    /* get configuration index for EP created through CM */
+    listen_and_communicate(false, SEND_DIRECTION_C2S);
+
+    ASSERT_EQ(16, ucp_ep_num_lanes(sender().ep()));
+    ASSERT_EQ(16, ucp_ep_num_lanes(receiver().ep()));
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_max_lanes, ib, "ib")
 
 class test_ucp_sockaddr_wireup_fail : public test_ucp_sockaddr_wireup {
 protected:


### PR DESCRIPTION
## What
Add support for a max of 16 lanes per ucp_ep. 

## Why ?
Allow more lanes to be selected, and thus better performance and utilization of resources.

## How ?
In order to preserve small EP memory signature, we dynamically allocate uct_eps array in ep extension.
