### PR TITLE
UCT/CUDA_IPC: use rcache instead of pgtable to cache mappings

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -292,7 +292,10 @@ ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_md_t *md,
     rcache_params.ucm_event_priority = 0;
     rcache_params.ops                = &uct_cuda_ipc_rcache_ops;
     rcache_params.context            = NULL;
-    rcache_params.flags              = UCS_RCACHE_FLAG_NO_PFN_CHECK;
+    rcache_params.flags              = 0;//UCS_RCACHE_FLAG_NO_PFN_CHECK;
+                                         /* TODO: when should PFN_CHECK be
+                                          * added? Not adding this flag for now
+                                          * as this results in no LRU eviction */
     rcache_params.max_regions        = md->rcache_max_regions;
     rcache_params.max_size           = md->rcache_max_size;
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -16,6 +16,7 @@
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>
+#include <ucs/memory/rcache.h>
 #include <ucs/datastruct/khash.h>
 
 
@@ -48,103 +49,59 @@ typedef struct uct_cuda_ipc_remote_cache {
 
 uct_cuda_ipc_remote_cache_t uct_cuda_ipc_remote_cache;
 
-static ucs_pgt_dir_t *uct_cuda_ipc_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
+static void uct_cuda_ipc_rcache_region_invalidate_cb(void *arg)
 {
-    void *ptr;
-    int ret;
-
-    ret = ucs_posix_memalign(&ptr,
-                             ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN),
-                             sizeof(ucs_pgt_dir_t), "cuda_ipc_cache_pgdir");
-    return (ret == 0) ? ptr : NULL;
 }
 
-static void uct_cuda_ipc_cache_pgt_dir_release(const ucs_pgtable_t *pgtable,
-                                               ucs_pgt_dir_t *dir)
+ucs_status_t uct_cuda_ipc_check_rcache(ucs_rcache_t *rcache,
+                                       uct_cuda_ipc_key_t *key,
+                                       uct_cuda_ipc_rcache_region_t **region_p)
 {
-    ucs_free(dir);
-}
-
-static void
-uct_cuda_ipc_cache_region_collect_callback(const ucs_pgtable_t *pgtable,
-                                           ucs_pgt_region_t *pgt_region,
-                                           void *arg)
-{
-    ucs_list_link_t *list = arg;
-    uct_cuda_ipc_cache_region_t *region;
-
-    region = ucs_derived_of(pgt_region, uct_cuda_ipc_cache_region_t);
-    ucs_list_add_tail(list, &region->list);
-}
-
-static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
-{
-    int active = uct_cuda_base_is_context_active();
-    uct_cuda_ipc_cache_region_t *region, *tmp;
-    ucs_list_link_t region_list;
-
-    ucs_list_head_init(&region_list);
-    ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,
-                      &region_list);
-    ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        if (active) {
-            UCT_CUDADRV_FUNC_LOG_ERR(
-                    cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
-        }
-        ucs_free(region);
-    }
-    ucs_trace("%s: cuda ipc cache purged", cache->name);
-}
-
-static ucs_status_t uct_cuda_ipc_open_memhandle(const uct_cuda_ipc_key_t *key,
-                                                CUdeviceptr *mapped_addr)
-{
-    const char *cu_err_str;
-    CUresult cuerr;
+    uintptr_t start, end;
+    ucs_rcache_region_t *rcache_region;
     ucs_status_t status;
 
-    cuerr = cuIpcOpenMemHandle(mapped_addr, key->ph,
-                               CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
-    if (cuerr == CUDA_SUCCESS) {
-        status = UCS_OK;
-    } else {
-        cuGetErrorString(cuerr, &cu_err_str);
-        ucs_debug("cuIpcOpenMemHandle() failed: %s", cu_err_str);
-        status = (cuerr == CUDA_ERROR_ALREADY_MAPPED) ? UCS_ERR_ALREADY_EXISTS :
-                                                        UCS_ERR_INVALID_PARAM;
+    start = ucs_align_down_pow2((uintptr_t)key->d_bptr, ucs_get_page_size());
+    end   = ucs_align_up_pow2  ((uintptr_t)key->d_bptr + key->b_len,
+                                ucs_get_page_size());
+
+    status = ucs_rcache_get(rcache, (void*)start, end - start,
+                            PROT_READ|PROT_WRITE, (void*)key, &rcache_region);
+    if (status != UCS_OK) {
+        return UCS_ERR_INVALID_PARAM;
     }
 
-    return status;
-}
+    *region_p = ucs_derived_of(rcache_region, uct_cuda_ipc_rcache_region_t);
 
-static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
-                                                  void *from, void *to)
-{
-    ucs_list_link_t region_list;
-    ucs_status_t status;
-    uct_cuda_ipc_cache_region_t *region, *tmp;
+    if (memcmp((const void *)&key->ph, (const void *)&((*region_p)->ipc_handle),
+                sizeof(key->ph))) {
+        /* VA recycling */
+        ucs_trace("VA recycling ocurred, removing region %p...%p",
+                  (void*)start, (void*)end);
 
-    ucs_list_head_init(&region_list);
-    ucs_pgtable_search_range(&cache->pgtable, (ucs_pgt_addr_t)from,
-                             (ucs_pgt_addr_t)to - 1,
-                             uct_cuda_ipc_cache_region_collect_callback,
-                             &region_list);
-    ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        status = ucs_pgtable_remove(&cache->pgtable, &region->super);
+        /* first decrease previous refcount on stale region */
+        ucs_rcache_region_put(rcache, rcache_region);
+
+        ucs_rcache_region_invalidate(rcache, rcache_region,
+                                     uct_cuda_ipc_rcache_region_invalidate_cb,
+                                     NULL);
+
+        status = ucs_rcache_get(rcache, (void*)start, end - start,
+                                PROT_READ|PROT_WRITE, (void*)key,
+                                &rcache_region);
         if (status != UCS_OK) {
-            ucs_error("failed to remove address:%p from cache (%s)",
-                      (void *)region->key.d_bptr, ucs_status_string(status));
+            return UCS_ERR_INVALID_PARAM;
         }
-        UCT_CUDADRV_FUNC_LOG_ERR(
-                cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
-        ucs_free(region);
+
+        *region_p = ucs_derived_of(rcache_region, uct_cuda_ipc_rcache_region_t);
     }
-    ucs_trace("%s: closed memhandles in the range [%p..%p]",
-              cache->name, from, to);
+
+    return UCS_OK;
 }
 
 static ucs_status_t
-uct_cuda_ipc_get_remote_cache(pid_t pid, uct_cuda_ipc_cache_t **cache)
+uct_cuda_ipc_get_remote_cache(uct_cuda_ipc_md_t *md,
+                              pid_t pid, uct_cuda_ipc_cache_t **cache)
 {
     ucs_status_t status = UCS_OK;
     char target_name[64];
@@ -163,7 +120,7 @@ uct_cuda_ipc_get_remote_cache(pid_t pid, uct_cuda_ipc_cache_t **cache)
         (khret == UCS_KH_PUT_BUCKET_CLEAR)) {
         ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%d:%d",
                           key.pid, key.cu_device);
-        status = uct_cuda_ipc_create_cache(cache, target_name);
+        status = uct_cuda_ipc_create_cache(md, cache, target_name);
         if (status != UCS_OK) {
             kh_del(cuda_ipc_rem_cache, &uct_cuda_ipc_remote_cache.hash, khiter);
             ucs_error("could not create create cuda ipc cache: %s",
@@ -183,186 +140,144 @@ err_unlock:
     return status;
 }
 
-ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, uintptr_t d_bptr,
-                                          void *mapped_addr, int cache_enabled)
+void uct_cuda_ipc_close_memhandle(void *mapped_addr,
+                                  uct_cuda_ipc_rcache_region_t *cuda_ipc_region)
 {
-    ucs_status_t status = UCS_OK;
-    uct_cuda_ipc_cache_t *cache;
-    ucs_pgt_region_t *pgt_region;
-    uct_cuda_ipc_cache_region_t *region;
+    CUresult cuerr;
 
-    status = uct_cuda_ipc_get_remote_cache(pid, &cache);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    /* use write lock because cache maybe modified */
-    pthread_rwlock_wrlock(&cache->lock);
-    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup, &cache->pgtable, d_bptr);
-    ucs_assert(pgt_region != NULL);
-    region = ucs_derived_of(pgt_region, uct_cuda_ipc_cache_region_t);
-
-    ucs_assert(region->refcount >= 1);
-    region->refcount--;
-
-    /*
-     * check refcount to see if an in-flight transfer is using the same mapping
-     */
-    if (!region->refcount && !cache_enabled) {
-        status = ucs_pgtable_remove(&cache->pgtable, &region->super);
-        if (status != UCS_OK) {
-            ucs_error("failed to remove address:%p from cache (%s)",
-                      (void *)region->key.d_bptr, ucs_status_string(status));
+    cuerr = cuIpcCloseMemHandle((CUdeviceptr)mapped_addr);
+    if (cuerr == CUDA_SUCCESS) {
+        if (cuda_ipc_region != NULL) {
+            cuda_ipc_region->rcache           = NULL;
+            cuda_ipc_region->rem_base_address = NULL;
+            cuda_ipc_region->rem_alloc_length = 0;
         }
-        ucs_assert(region->mapped_addr == mapped_addr);
-        status = UCT_CUDADRV_FUNC_LOG_ERR(
-                cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
-        ucs_free(region);
     }
-
-    pthread_rwlock_unlock(&cache->lock);
-    return status;
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle, (key, mapped_addr),
-                 const uct_cuda_ipc_key_t *key, void **mapped_addr)
+ucs_status_t
+uct_cuda_ipc_unmap_memhandle(uct_cuda_ipc_md_t *md,
+                             const uct_cuda_ipc_key_t *key,
+                             void *mapped_addr,
+                             uct_cuda_ipc_rcache_region_t *cuda_ipc_region)
+{
+    ucs_status_t status;
+    uct_cuda_ipc_cache_t *cache;
+
+    if (md->rcache_enable != UCS_NO) {
+        status = uct_cuda_ipc_get_remote_cache(md, key->pid, &cache);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        ucs_rcache_region_put(cache->rcache, &cuda_ipc_region->super);
+    } else {
+        uct_cuda_ipc_close_memhandle(mapped_addr, NULL);
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t uct_cuda_ipc_open_memhandle(void **mapped_addr,
+                                         const uct_cuda_ipc_key_t *key,
+                                         uct_cuda_ipc_rcache_region_t *cuda_ipc_region,
+                                         ucs_rcache_t *rcache)
+{
+    CUresult cuerr;
+    const char *cu_err_str;
+
+    cuerr = cuIpcOpenMemHandle((CUdeviceptr *)mapped_addr,
+                               key->ph, CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+    if ((cuerr == CUDA_SUCCESS) || (cuerr == CUDA_ERROR_ALREADY_MAPPED)) {
+        if (cuda_ipc_region != NULL) {
+            cuda_ipc_region->ipc_handle       = key->ph;
+            cuda_ipc_region->rcache           = rcache;
+            cuda_ipc_region->rem_base_address = (void*)key->d_bptr;
+            cuda_ipc_region->rem_alloc_length = key->b_len;
+        }
+        return UCS_OK;
+    } else {
+        cuGetErrorString(cuerr, &cu_err_str);
+        ucs_debug("cuIpcOpenMemHandle() failed: %s", cu_err_str);
+        return UCS_ERR_INVALID_PARAM;
+    }
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
+                 (md, key, mapped_addr, region_p),
+                 uct_cuda_ipc_md_t *md,
+                 const uct_cuda_ipc_key_t *key, void **mapped_addr,
+                 uct_cuda_ipc_rcache_region_t **region_p)
 {
     uct_cuda_ipc_cache_t *cache;
     ucs_status_t status;
-    ucs_pgt_region_t *pgt_region;
-    uct_cuda_ipc_cache_region_t *region;
-    int ret;
 
-    status = uct_cuda_ipc_get_remote_cache(key->pid, &cache);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    pthread_rwlock_wrlock(&cache->lock);
-    pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup,
-                                  &cache->pgtable, key->d_bptr);
-    if (ucs_likely(pgt_region != NULL)) {
-        region = ucs_derived_of(pgt_region, uct_cuda_ipc_cache_region_t);
-        if (memcmp((const void *)&key->ph, (const void *)&region->key.ph,
-                   sizeof(key->ph)) == 0) {
-            /*cache hit */
-            ucs_trace("%s: cuda_ipc cache hit addr:%p size:%lu region:"
-                      UCS_PGT_REGION_FMT, cache->name, (void *)key->d_bptr,
-                      key->b_len, UCS_PGT_REGION_ARG(&region->super));
-
-            *mapped_addr = region->mapped_addr;
-            ucs_assert(region->refcount < UINT64_MAX);
-            region->refcount++;
-            pthread_rwlock_unlock(&cache->lock);
-            return UCS_OK;
-        } else {
-            ucs_trace("%s: cuda_ipc cache remove stale region:"
-                      UCS_PGT_REGION_FMT " new_addr:%p new_size:%lu",
-                      cache->name, UCS_PGT_REGION_ARG(&region->super),
-                      (void *)key->d_bptr, key->b_len);
-
-            status = ucs_pgtable_remove(&cache->pgtable, &region->super);
-            if (status != UCS_OK) {
-                ucs_error("%s: failed to remove address:%p from cache",
-                          cache->name, (void *)key->d_bptr);
-                goto err;
-            }
-
-            /* close memhandle */
-            UCT_CUDADRV_FUNC_LOG_ERR(
-                    cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
-            ucs_free(region);
+    if (md->rcache_enable != UCS_NO) {
+        status = uct_cuda_ipc_get_remote_cache(md, key->pid, &cache);
+        if (status != UCS_OK) {
+            return status;
         }
-    }
 
-    status = uct_cuda_ipc_open_memhandle(key, (CUdeviceptr*)mapped_addr);
-    if (ucs_unlikely(status != UCS_OK)) {
-        if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
-            /* unmap all overlapping regions and retry*/
-            uct_cuda_ipc_cache_invalidate_regions(cache, (void *)key->d_bptr,
-                                                  UCS_PTR_BYTE_OFFSET(key->d_bptr,
-                                                                      key->b_len));
-            status = uct_cuda_ipc_open_memhandle(key,
-                                                 (CUdeviceptr*)mapped_addr);
-            if (ucs_unlikely(status != UCS_OK)) {
-                if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
-                    /* unmap all cache entries and retry */
-                    uct_cuda_ipc_cache_purge(cache);
-                    status =
-                        uct_cuda_ipc_open_memhandle(key,
-                                                    (CUdeviceptr*)mapped_addr);
-                    if (status != UCS_OK) {
-                        ucs_fatal("%s: failed to open ipc mem handle. addr:%p "
-                                  "len:%lu (%s)", cache->name,
-                                  (void *)key->d_bptr, key->b_len,
-                                  ucs_status_string(status));
-                    }
-                } else {
-                    ucs_fatal("%s: failed to open ipc mem handle. addr:%p len:%lu",
-                              cache->name, (void *)key->d_bptr, key->b_len);
-                }
-            }
-        } else {
-            ucs_debug("%s: failed to open ipc mem handle. addr:%p len:%lu",
-                      cache->name, (void *)key->d_bptr, key->b_len);
-            goto err;
+        status = uct_cuda_ipc_check_rcache(cache->rcache, (uct_cuda_ipc_key_t *)key, region_p);
+        if (status != UCS_OK) {
+            return status;
         }
+
+        *mapped_addr = (*region_p)->mapping_start;
+    } else {
+        status = uct_cuda_ipc_open_memhandle(mapped_addr, key, NULL, NULL);
     }
 
-    /*create new cache entry */
-    ret = ucs_posix_memalign((void **)&region,
-                             ucs_max(sizeof(void *), UCS_PGT_ENTRY_MIN_ALIGN),
-                             sizeof(uct_cuda_ipc_cache_region_t),
-                             "uct_cuda_ipc_cache_region");
-    if (ret != 0) {
-        ucs_warn("failed to allocate uct_cuda_ipc_cache region");
-        status = UCS_ERR_NO_MEMORY;
-        goto err;
-    }
-
-    region->super.start = ucs_align_down_pow2((uintptr_t)key->d_bptr,
-                                               UCS_PGT_ADDR_ALIGN);
-    region->super.end   = ucs_align_up_pow2  ((uintptr_t)key->d_bptr + key->b_len,
-                                               UCS_PGT_ADDR_ALIGN);
-    region->key         = *key;
-    region->mapped_addr = *mapped_addr;
-    region->refcount    = 1;
-
-    status = UCS_PROFILE_CALL(ucs_pgtable_insert,
-                              &cache->pgtable, &region->super);
-    if (status == UCS_ERR_ALREADY_EXISTS) {
-        /* overlapped region means memory freed at source. remove and try insert */
-        uct_cuda_ipc_cache_invalidate_regions(cache,
-                                              (void *)region->super.start,
-                                              (void *)region->super.end);
-        status = UCS_PROFILE_CALL(ucs_pgtable_insert,
-                                  &cache->pgtable, &region->super);
-    }
-    if (status != UCS_OK) {
-
-        ucs_error("%s: failed to insert region:"UCS_PGT_REGION_FMT" size:%lu :%s",
-                  cache->name, UCS_PGT_REGION_ARG(&region->super), key->b_len,
-                  ucs_status_string(status));
-        ucs_free(region);
-        goto err;
-    }
-
-    ucs_trace("%s: cuda_ipc cache new region:"UCS_PGT_REGION_FMT" size:%lu",
-              cache->name, UCS_PGT_REGION_ARG(&region->super), key->b_len);
-
-    status = UCS_OK;
-
-err:
-    pthread_rwlock_unlock(&cache->lock);
     return status;
 }
 
-ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
+static ucs_status_t
+uct_cuda_ipc_rcache_mem_reg(void *context, ucs_rcache_t *rcache, void *arg,
+                            ucs_rcache_region_t *region, uint16_t flags)
+{
+    uct_cuda_ipc_key_t *key                       = (uct_cuda_ipc_key_t*)arg;
+    uct_cuda_ipc_rcache_region_t *cuda_ipc_region =
+                    ucs_derived_of(region, uct_cuda_ipc_rcache_region_t);
+
+    return uct_cuda_ipc_open_memhandle(&cuda_ipc_region->mapping_start, key,
+                                       cuda_ipc_region, rcache);
+
+}
+
+static void uct_cuda_ipc_rcache_mem_dereg(void *context, ucs_rcache_t *rcache,
+                                          ucs_rcache_region_t *region)
+{
+    uct_cuda_ipc_rcache_region_t *cuda_ipc_region =
+                    ucs_derived_of(region, uct_cuda_ipc_rcache_region_t);
+
+    uct_cuda_ipc_close_memhandle(cuda_ipc_region->mapping_start, cuda_ipc_region);
+
+}
+
+static void uct_cuda_ipc_rcache_dump_region(void *context, ucs_rcache_t *rcache,
+                                            ucs_rcache_region_t *region, char *buf,
+                                            size_t max)
+{
+    uct_cuda_ipc_rcache_region_t *cuda_ipc_region =
+                    ucs_derived_of(region, uct_cuda_ipc_rcache_region_t);
+
+    snprintf(buf, max, "mapping_start %p", cuda_ipc_region->mapping_start);
+}
+
+static ucs_rcache_ops_t uct_cuda_ipc_rcache_ops = {
+    .mem_reg     = uct_cuda_ipc_rcache_mem_reg,
+    .mem_dereg   = uct_cuda_ipc_rcache_mem_dereg,
+    .dump_region = uct_cuda_ipc_rcache_dump_region
+};
+
+
+ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_md_t *md,
+                                       uct_cuda_ipc_cache_t **cache,
                                        const char *name)
 {
     ucs_status_t status;
     uct_cuda_ipc_cache_t *cache_desc;
-    int ret;
+    ucs_rcache_params_t rcache_params;
 
     cache_desc = ucs_malloc(sizeof(uct_cuda_ipc_cache_t), "uct_cuda_ipc_cache_t");
     if (cache_desc == NULL) {
@@ -370,31 +285,34 @@ ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
         return UCS_ERR_NO_MEMORY;
     }
 
-    ret = pthread_rwlock_init(&cache_desc->lock, NULL);
-    if (ret) {
-        ucs_error("pthread_rwlock_init() failed: %m");
-        status = UCS_ERR_INVALID_PARAM;
-        goto err;
-    }
+    rcache_params.region_struct_size = sizeof(uct_cuda_ipc_rcache_region_t);
+    rcache_params.alignment          = ucs_get_page_size();
+    rcache_params.max_alignment      = ucs_get_page_size();
+    rcache_params.ucm_events         = 0;
+    rcache_params.ucm_event_priority = 0;
+    rcache_params.ops                = &uct_cuda_ipc_rcache_ops;
+    rcache_params.context            = NULL;
+    rcache_params.flags              = UCS_RCACHE_FLAG_NO_PFN_CHECK;
+    rcache_params.max_regions        = md->rcache_max_regions;
+    rcache_params.max_size           = md->rcache_max_size;
 
-    status = ucs_pgtable_init(&cache_desc->pgtable,
-                              uct_cuda_ipc_cache_pgt_dir_alloc,
-                              uct_cuda_ipc_cache_pgt_dir_release);
+    status = ucs_rcache_create(&rcache_params, "cuda_ipc_remote_rcache",
+                               ucs_stats_get_root(), &cache_desc->rcache);
     if (status != UCS_OK) {
-        goto err_destroy_rwlock;
+        ucs_error("failed to create cuda_ipc remote cache: %s",
+                  ucs_status_string(status));
+        goto err;
     }
 
     cache_desc->name = strdup(name);
     if (cache_desc->name == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto err_destroy_rwlock;
+        goto err;
     }
 
     *cache = cache_desc;
     return UCS_OK;
 
-err_destroy_rwlock:
-    pthread_rwlock_destroy(&cache_desc->lock);
 err:
     free(cache_desc);
     return status;
@@ -402,9 +320,7 @@ err:
 
 void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache)
 {
-    uct_cuda_ipc_cache_purge(cache);
-    ucs_pgtable_cleanup(&cache->pgtable);
-    pthread_rwlock_destroy(&cache->lock);
+    ucs_rcache_destroy(cache->rcache);
     free(cache->name);
     ucs_free(cache);
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -17,27 +17,31 @@
 
 
 typedef struct uct_cuda_ipc_cache        uct_cuda_ipc_cache_t;
-typedef struct uct_cuda_ipc_cache_region uct_cuda_ipc_cache_region_t;
 typedef struct uct_cuda_ipc_rem_memh     uct_cuda_ipc_rem_memh_t;
 
 
-struct uct_cuda_ipc_cache_region {
-    ucs_pgt_region_t        super;        /**< Base class - page table region */
-    ucs_list_link_t         list;         /**< List element */
-    uct_cuda_ipc_key_t      key;          /**< Remote memory key */
-    void                    *mapped_addr; /**< Local mapped address */
-    uint64_t                refcount;     /**< Track inflight ops before unmapping*/
-};
+/**
+ * Structure associated with rcache region. ipc_handle is returned along with
+ * the start of the mapping to check if VA recycling has occurred.
+ */
+typedef struct uct_cuda_ipc_rcache_region {
+    ucs_rcache_region_t     super;
+    CUipcMemHandle          ipc_handle;
+    ucs_rcache_t            *rcache;
+    void                    *rem_base_address;
+    size_t                  rem_alloc_length;
+    void                    *mapping_start;
+} uct_cuda_ipc_rcache_region_t;
 
 
 struct uct_cuda_ipc_cache {
-    pthread_rwlock_t      lock;       /**< protests the page table */
-    ucs_pgtable_t         pgtable;    /**< Page table to hold the regions */
+    ucs_rcache_t          *rcache;    /**< rcache to hold local mappings of remote memory */
     char                  *name;      /**< Name */
 };
 
 
-ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
+ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_md_t *md,
+                                       uct_cuda_ipc_cache_t **cache,
                                        const char *name);
 
 
@@ -45,7 +49,13 @@ void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache);
 
 
 ucs_status_t
-uct_cuda_ipc_map_memhandle(const uct_cuda_ipc_key_t *key, void **mapped_addr);
-ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, uintptr_t d_bptr,
-                                          void *mapped_addr, int cache_enabled);
+uct_cuda_ipc_map_memhandle(uct_cuda_ipc_md_t *md,
+                           const uct_cuda_ipc_key_t *key,
+                           void **mapped_addr,
+                           uct_cuda_ipc_rcache_region_t **cuda_ipc_region);
+ucs_status_t
+uct_cuda_ipc_unmap_memhandle(uct_cuda_ipc_md_t *md,
+                             const uct_cuda_ipc_key_t *key,
+                             void *mapped_addr,
+                             uct_cuda_ipc_rcache_region_t *cuda_ipc_region);
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -51,8 +51,10 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
                                   const uct_iov_t *iov, uct_rkey_t rkey,
                                   uct_completion_t *comp, int direction)
 {
-    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cuda_ipc_iface_t);
-    uct_cuda_ipc_key_t *key     = (uct_cuda_ipc_key_t *) rkey;
+    uct_cuda_ipc_iface_t *iface  = ucs_derived_of(tl_ep->iface, uct_cuda_ipc_iface_t);
+    uct_base_iface_t *base_iface = ucs_derived_of(tl_ep->iface, uct_base_iface_t);
+    uct_cuda_ipc_md_t *md        = ucs_derived_of(base_iface->md, uct_cuda_ipc_md_t);
+    uct_cuda_ipc_key_t *key      = (uct_cuda_ipc_key_t*)rkey;
     void *mapped_rem_addr;
     void *mapped_addr;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
@@ -61,13 +63,14 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     CUdeviceptr dst, src;
     CUstream stream;
     size_t offset;
+    uct_cuda_ipc_rcache_region_t *cuda_ipc_region;
 
     if (0 == iov[0].length) {
         ucs_trace_data("Zero length request: skip it");
         return UCS_OK;
     }
 
-    status = uct_cuda_ipc_map_memhandle(key, &mapped_addr);
+    status = uct_cuda_ipc_map_memhandle(md, key, &mapped_addr, &cuda_ipc_region);
     if (status != UCS_OK) {
         return UCS_ERR_IO_ERROR;
     }
@@ -116,7 +119,10 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     }
 
     iface->stream_refcount[key->dev_num]++;
-    cuda_ipc_event->stream_id = key->dev_num;
+    cuda_ipc_event->stream_id       = key->dev_num;
+    cuda_ipc_event->key             = *key;
+    cuda_ipc_event->mapped_addr     = mapped_addr;
+    cuda_ipc_event->cuda_ipc_region = cuda_ipc_region;
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuEventRecord(cuda_ipc_event->event,
                                                     stream));
@@ -128,8 +134,6 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     ucs_queue_push(outstanding_queue, &cuda_ipc_event->queue);
     cuda_ipc_event->comp        = comp;
     cuda_ipc_event->mapped_addr = mapped_addr;
-    cuda_ipc_event->d_bptr      = (uintptr_t)key->d_bptr;
-    cuda_ipc_event->pid         = key->pid;
     ucs_trace("cuMemcpyDtoDAsync issued :%p dst:%p, src:%p  len:%ld",
              cuda_ipc_event, (void *) dst, (void *) src, iov[0].length);
     return UCS_INPROGRESS;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -33,11 +33,6 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
      "Max number of CUDA streams to make concurrent progress on",
       ucs_offsetof(uct_cuda_ipc_iface_config_t, max_streams), UCS_CONFIG_TYPE_UINT},
 
-    {"CACHE", "y",
-     "Enable remote endpoint IPC memhandle mapping cache",
-     ucs_offsetof(uct_cuda_ipc_iface_config_t, enable_cache),
-     UCS_CONFIG_TYPE_BOOL},
-
     {"ENABLE_GET_ZCOPY", "auto",
      "Enable get operations except for platforms known to have slower performance",
      ucs_offsetof(uct_cuda_ipc_iface_config_t, enable_get_zcopy),
@@ -296,6 +291,7 @@ static void CUDA_CB myHostCallback(CUstream hStream,  CUresult status,
 
 static UCS_F_ALWAYS_INLINE unsigned
 uct_cuda_ipc_progress_event_q(uct_cuda_ipc_iface_t *iface,
+                              uct_cuda_ipc_md_t *md,
                               ucs_queue_head_t *event_q)
 {
     unsigned count = 0;
@@ -317,10 +313,9 @@ uct_cuda_ipc_progress_event_q(uct_cuda_ipc_iface_t *iface,
             uct_invoke_completion(cuda_ipc_event->comp, UCS_OK);
         }
 
-        status = uct_cuda_ipc_unmap_memhandle(cuda_ipc_event->pid,
-                                              cuda_ipc_event->d_bptr,
+        status = uct_cuda_ipc_unmap_memhandle(md, &cuda_ipc_event->key,
                                               cuda_ipc_event->mapped_addr,
-                                              iface->config.enable_cache);
+                                              cuda_ipc_event->cuda_ipc_region);
         if (status != UCS_OK) {
             ucs_fatal("failed to unmap addr:%p", cuda_ipc_event->mapped_addr);
         }
@@ -340,21 +335,25 @@ uct_cuda_ipc_progress_event_q(uct_cuda_ipc_iface_t *iface,
 
 static unsigned uct_cuda_ipc_iface_progress(uct_iface_h tl_iface)
 {
-    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    uct_cuda_ipc_iface_t *iface  = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    uct_base_iface_t *base_iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+    uct_cuda_ipc_md_t *md        = ucs_derived_of(base_iface->md, uct_cuda_ipc_md_t);
 
-    return uct_cuda_ipc_progress_event_q(iface, &iface->outstanding_d2d_event_q);
+    return uct_cuda_ipc_progress_event_q(iface, md, &iface->outstanding_d2d_event_q);
 }
 
 static ucs_status_t uct_cuda_ipc_iface_event_fd_arm(uct_iface_h tl_iface,
                                                     unsigned events)
 {
-    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    uct_cuda_ipc_iface_t *iface  = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    uct_base_iface_t *base_iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+    uct_cuda_ipc_md_t *md        = ucs_derived_of(base_iface->md, uct_cuda_ipc_md_t);
     int ret;
     int i;
     uint64_t dummy;
     ucs_status_t status;
 
-    if (uct_cuda_ipc_progress_event_q(iface, &iface->outstanding_d2d_event_q)) {
+    if (uct_cuda_ipc_progress_event_q(iface, md, &iface->outstanding_d2d_event_q)) {
         return UCS_ERR_BUSY;
     }
 
@@ -497,7 +496,6 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
 
     self->config.max_poll            = config->max_poll;
     self->config.max_streams         = config->max_streams;
-    self->config.enable_cache        = config->enable_cache;
     self->config.enable_get_zcopy    = config->enable_get_zcopy;
     self->config.max_cuda_ipc_events = config->max_cuda_ipc_events;
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -33,7 +33,6 @@ typedef struct uct_cuda_ipc_iface {
         unsigned                max_poll;            /* query attempts w.o success */
         unsigned                max_streams;         /* # concurrent streams for || progress*/
         unsigned                max_cuda_ipc_events; /* max mpool entries */
-        int                     enable_cache;        /* enable/disable ipc handle cache */
         ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platorms */
     } config;
 } uct_cuda_ipc_iface_t;
@@ -43,7 +42,6 @@ typedef struct uct_cuda_ipc_iface_config {
     uct_iface_config_t      super;
     unsigned                max_poll;
     unsigned                max_streams;
-    int                     enable_cache;
     ucs_on_off_auto_value_t enable_get_zcopy;
     unsigned                max_cuda_ipc_events;
 } uct_cuda_ipc_iface_config_t;
@@ -56,8 +54,8 @@ typedef struct uct_cuda_ipc_event_desc {
     uct_completion_t  *comp;
     ucs_queue_elem_t  queue;
     uct_cuda_ipc_ep_t *ep;
-    uintptr_t         d_bptr;
-    pid_t             pid;
+    uct_cuda_ipc_key_t key;
+    uct_cuda_ipc_rcache_region_t *cuda_ipc_region;
 } uct_cuda_ipc_event_desc_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -22,6 +22,10 @@ typedef struct uct_cuda_ipc_md {
     ucs_ternary_auto_value_t *peer_accessible_cache;
     int                      uuid_map_size;
     int                      uuid_map_capacity;
+    ucs_ternary_auto_value_t rcache_enable;
+    double                   rcache_max_ratio;
+    size_t                   rcache_max_size;
+    unsigned long            rcache_max_regions;
 } uct_cuda_ipc_md_t;
 
 /**
@@ -38,7 +42,10 @@ extern uct_cuda_ipc_component_t uct_cuda_ipc_component;
  * @brief cuda ipc domain configuration.
  */
 typedef struct uct_cuda_ipc_md_config {
-    uct_md_config_t super;
+    uct_md_config_t          super;
+    ucs_ternary_auto_value_t rcache_enable;
+    uct_md_rcache_config_t   rcache;
+    double                   rcache_max_ratio;
 } uct_cuda_ipc_md_config_t;
 
 


### PR DESCRIPTION
## Why ?
Use native capabilities in rcache to limit the size of mappings that can be cached by cuda_ipc transport. For example, `UCX_CUDA_IPC_RCACHE_MAX_REGIONS=10 UCX_CUDA_IPC_RCACHE_MAX_SIZE=1mb` limits the maximum number of cachings to 10 and max size of mappings cached to 1MB. 

TODO: 
- PR still untested with applications
- PR untested with corner cases like max_regions = 0 or max_size = 0
- Add capability to set max ratio of device mem that can be used to cache remote mappings