### PR TITLE
UCS/DEBUG: replace PTR with void *

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -272,10 +272,10 @@ static int load_file(struct backtrace_file *file)
         goto err_close;
     }
 
-    symcount = bfd_read_minisymbols(file->abfd, 0, (PTR)&file->syms, &size);
+    symcount = bfd_read_minisymbols(file->abfd, 0, (void *)&file->syms, &size);
     if (symcount == 0) {
         free(file->syms);
-        symcount = bfd_read_minisymbols(file->abfd, 1, (PTR)&file->syms, &size);
+        symcount = bfd_read_minisymbols(file->abfd, 1, (void *)&file->syms, &size);
     }
     if (symcount < 0) {
         goto err_close;


### PR DESCRIPTION
The PTR macro is missing on the latest Arch linux.

## What
Replace the cast `(PTR)` with `(void *)` in `debug.c`.

## Why ?
The `PTR` macro is not defined in the latest Arch Linux bfd headers.

See reported error in the comment in https://aur.archlinux.org/packages/openucx

## How ?
`PTR` is probably a pointer to a specific type. Since we are casting here, casting to `void *` should work.
