### PR TITLE
UCT/IB/UD: Cleanup setting of packet_type

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -285,10 +285,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_ud_mlx5_ep_inline_iov_post(
     wqe_size       += sizeof(*inl) + inline_size;
 
     /* set network header */
-    neth              = (void*)(inl + 1);
-    neth->packet_type = (am_id << UCT_UD_PACKET_AM_ID_SHIFT) |
-                        ep->super.dest_ep_id |
-                        packet_flags;
+    neth = (void*)(inl + 1);
+    uct_ud_neth_set_packet_type(&ep->super, neth, am_id, packet_flags);
     uct_ud_neth_init_data(&ep->super, neth);
     if (!(packet_flags & UCT_UD_PACKET_FLAG_ACK_REQ)) {
         /* check for ACK_REQ, if not already enabled by packet_flags */

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -246,11 +246,6 @@ static inline uint8_t uct_ud_neth_get_am_id(uct_ud_neth_t *neth)
     return neth->packet_type >> UCT_UD_PACKET_AM_ID_SHIFT;
 }
 
-static inline void uct_ud_neth_set_am_id(uct_ud_neth_t *neth, uint8_t id)
-{
-    neth->packet_type |= (id << UCT_UD_PACKET_AM_ID_SHIFT);
-}
-
 static inline uct_ud_ctl_desc_t *uct_ud_ctl_desc(uct_ud_send_skb_t *skb)
 {
     ucs_assert(skb->flags & (UCT_UD_SEND_SKB_FLAG_CTL_ACK |

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -337,17 +337,11 @@ void uct_ud_ep_vfs_populate(uct_ud_ep_t *ep);
 
 
 static UCS_F_ALWAYS_INLINE void
-uct_ud_neth_set_type_am(uct_ud_ep_t *ep, uct_ud_neth_t *neth, uint8_t id)
+uct_ud_neth_set_packet_type(uct_ud_ep_t *ep, uct_ud_neth_t *neth, uint8_t id,
+                            uint32_t packet_flags)
 {
-    neth->packet_type = (id << UCT_UD_PACKET_AM_ID_SHIFT) |
-                        ep->dest_ep_id |
-                        UCT_UD_PACKET_FLAG_AM;
-}
-
-static UCS_F_ALWAYS_INLINE void
-uct_ud_neth_set_type_put(uct_ud_ep_t *ep, uct_ud_neth_t *neth)
-{
-    neth->packet_type = ep->dest_ep_id | UCT_UD_PACKET_FLAG_PUT;
+    neth->packet_type = (id << UCT_UD_PACKET_AM_ID_SHIFT) | ep->dest_ep_id |
+                        packet_flags;
 }
 
 void uct_ud_ep_process_rx(uct_ud_iface_t *iface,

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -211,8 +211,8 @@ uct_ud_am_skb_common(uct_ud_iface_t *iface, uct_ud_ep_t *ep, uint8_t id,
                 &ep->tx.pending.elem);
 
     neth = skb->neth;
+    uct_ud_neth_set_packet_type(ep, neth, id, UCT_UD_PACKET_FLAG_AM);
     uct_ud_neth_init_data(ep, neth);
-    uct_ud_neth_set_type_am(ep, neth, id);
     uct_ud_neth_ack_req(ep, neth);
 
     *skb_p = skb;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -332,8 +332,8 @@ ucs_status_t uct_ud_verbs_ep_put_short(uct_ep_h tl_ep,
     }
 
     neth = skb->neth;
+    uct_ud_neth_set_packet_type(&ep->super, neth, 0, UCT_UD_PACKET_FLAG_PUT);
     uct_ud_neth_init_data(&ep->super, neth);
-    uct_ud_neth_set_type_put(&ep->super, neth);
     uct_ud_neth_ack_req(&ep->super, neth);
 
     put_hdr = (uct_ud_put_hdr_t *)(neth+1);


### PR DESCRIPTION
## What

Cleanup setting of packet_type.

## Why ?

To make reuse common code and remove unneeded functions.

## How ?

1. Remove `uct_ud_neth_set_am_id` as it is unused.
2. Remove `uct_ud_neth_set_type_put` as it is used only once in UD/verbs code and could be replaced.
3. Introduce `uct_ud_neth_set_packet_type` and use it instead of `uct_ud_neth_set_type_am` and `uct_ud_neth_set_type_put`.