### PR TITLE
GTEST: fixed build with -O1 optimization

### DIFF
--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -567,7 +567,7 @@ UCS_TEST_SKIP_COND_P(test_tag, tag_hold_uct_desc,
     }
 
     std::for_each(m_uct_descs.begin(), m_uct_descs.end(),
-                  uct_iface_release_desc);
+                  [](void *desc) -> void {uct_iface_release_desc(desc);});
 
 }
 
@@ -1242,7 +1242,7 @@ UCS_TEST_P(test_tag_mp_xrq, desc_release)
     }
 
     std::for_each(m_uct_descs.begin(), m_uct_descs.end(),
-                  uct_iface_release_desc);
+                  [](void *desc) -> void {uct_iface_release_desc(desc);});
 }
 
 UCS_TEST_P(test_tag_mp_xrq, am)


### PR DESCRIPTION
- there is build issue when gtest is built with -O1 optimization
  flag:
  make[3]: Entering directory `/auto/mtrswgwork/sergeyo/vs-projects/ucx/test/gtest'
  CXX      uct/gtest-test_tag.o
In file included from uct/test_tag.cc:8:0:
/labhome/sergeyo/ucx/src/uct/api/uct.h: In member function ‘virtual void test_tag_tag_hold_uct_desc_Test::test_body()’:
/labhome/sergeyo/ucx/src/uct/api/uct.h:2725:21: error: inlining failed in call to always_inline ‘void uct_iface_release_desc(void*)’: indirect function call with a yet undetermined callee
 UCT_INLINE_API void uct_iface_release_desc(void *desc)
                     ^
In file included from /usr/include/c++/4.8.2/algorithm:62:0,
                 from ./common/googletest/internal/gtest-port.h:264,
                 from ./common/googletest/internal/gtest-internal.h:40,
                 from ./common/googletest/gtest.h:62,
                 from ./common/test_helpers.h:11,
                 from ./common/test.h:23,
                 from uct/test_tag.cc:10:

- added proxy call to hide force inline attribute
