### PR TITLE
UCP/PROTOV2/EAGER/SHORT: Bug fix - iov array is initialized with a wrong length

### DIFF
--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -36,7 +36,7 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
     const ucp_proto_single_priv_t *spriv = req->send.proto_config->priv;
     uint32_t header_length               = req->send.msg_proto.am.header.length;
     size_t iov_cnt                       = 0ul;
-    uct_iov_t iov[3];
+    uct_iov_t iov[4];
     ucp_am_hdr_t am_hdr;
     ucs_status_t status;
     uint8_t am_id;


### PR DESCRIPTION
## What
 - Fix a bug in proto V2 "short" send function that can cause segmentation fault 
 - Check why gtest missed it and make sure it won't happen again

## Why ?
- In "ucp_am_eager_short_proto_progress_common" iov array is initialized with size 3, but when sending AM
with user header and reply EP iov list contains 4 elements.
- @rakhmets found that gtest missed it because of the order we are running the tests. The test first sends message without header, and the message with the header is sent after, when wireup is completed, therefore the message with the header is sent using old proto, ucp_am_send_short, and there the iov list length is correct. 

## How ?
- Fix the iov length to be 4 instead of 3.
- Decide how to change the tests so we will not have another miss.
