### PR TITLE
UCP/WIRUEP: Fix printing missing capabilities during transport selection

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -442,6 +442,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
         ucs_assert(ucs_test_all_flags(UCP_ADDRESS_IFACE_EVENT_FLAGS,
                                       criteria->remote_event_flags));
 
+        ucs_string_buffer_reset(&missing_flags_str);
         if (!ucp_wireup_test_select_flags(&criteria->remote_iface_flags,
                                           ae->iface_attr.flags,
                                           ucp_wireup_peer_flags,


### PR DESCRIPTION
## What

Fix printing missing capabilities during transport selection.

## Why ?

Before:
```
[1660634021.508599] [swx-dgx02:12994:0]          select.c:451  UCX  TRACE   addr[0] tcp: no get
[1660634021.508601] [swx-dgx02:12994:0]          select.c:451  UCX  TRACE   addr[1] tcp: no getno get
[1660634021.508602] [swx-dgx02:12994:0]          select.c:451  UCX  TRACE   addr[2] tcp: no getno getno get
[1660634021.508603] [swx-dgx02:12994:0]          select.c:451  UCX  TRACE   addr[3] tcp: no getno getno getno get
[1660634021.508605] [swx-dgx02:12994:0]          select.c:451  UCX  TRACE   addr[4] tcp: no getno getno getno getno get
[1660634021.508606] [swx-dgx02:12994:0]          select.c:451  UCX  TRACE   addr[5] tcp: no getno getno getno getno getno get
```
After:
```
[1660635804.675492] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[15] ud_verbs: no get
[1660635804.675494] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[16] ud_mlx5: no get
[1660635804.675495] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[20] ud_verbs: no get
[1660635804.675496] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[21] ud_mlx5: no get
[1660635804.675497] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[25] ud_verbs: no get
[1660635804.675499] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[26] ud_mlx5: no get
[1660635824.459854] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[30] ud_verbs: no get
[1660635824.459857] [swx-dgx02:20696:0]          select.c:453  UCX  TRACE   addr[31] ud_mlx5: no get
```

## How ?

Invoke `ucs_string_buffer_reset` inside `ucp_wireup_test_select_flags` to reset the buffer and append new information to the begginging of the string.