### PR TITLE
UCP/WIREUP: Print EP configuration index which is used by EP

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -436,7 +436,7 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
         return;
     }
 
-    ucs_trace("ep %p: remote connected", ep);
+    ucs_trace("ep %p: remote connected, ep_cfg[%u]", ep, ep->cfg_index);
     if (!(ep->flags & UCP_EP_FLAG_CLOSED)) {
         /* set REMOTE_CONNECTED flag if an EP is not closed, otherwise -
          * just make UCT EPs remote connected to remove WIREUP_EP for them


### PR DESCRIPTION
## What

Print EP configuration index which is used by EP.

## Why ?

Printing EP configuration index is useful to investigate which configuration is used by EP as a final one. Currently, it isn't possible to understand.

## How ?

Update trace in `ucp_wireup_remote_connected` to print `ep->cfg_index`.