### PR TITLE
UCT/IB: Fix leak if some operations failed after uct_ib_md_open_common()

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -679,11 +679,12 @@ err:
     return status;
 }
 
-void uct_ib_device_cleanup_ah_cached(uct_ib_device_t *dev)
+static void uct_ib_device_cleanup_ah_cached(uct_ib_device_t *dev)
 {
     struct ibv_ah *ah;
 
     kh_foreach_value(&dev->ah_hash, ah, ibv_destroy_ah(ah));
+    kh_destroy_inplace(uct_ib_ah, &dev->ah_hash);
 }
 
 void uct_ib_device_cleanup(uct_ib_device_t *dev)
@@ -696,7 +697,7 @@ void uct_ib_device_cleanup(uct_ib_device_t *dev)
 
     kh_destroy_inplace(uct_ib_async_event, &dev->async_events_hash);
     ucs_spinlock_destroy(&dev->async_event_lock);
-    kh_destroy_inplace(uct_ib_ah, &dev->ah_hash);
+    uct_ib_device_cleanup_ah_cached(dev);
     ucs_recursive_spinlock_destroy(&dev->ah_lock);
 
     if (dev->async_events) {

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -387,8 +387,6 @@ uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                struct ibv_ah_attr *ah_attr, struct ibv_pd *pd,
                                const char *usage, struct ibv_ah **ah_p);
 
-void uct_ib_device_cleanup_ah_cached(uct_ib_device_t *dev);
-
 ucs_status_t uct_ib_device_get_roce_ndev_name(uct_ib_device_t *dev,
                                               uint8_t port_num,
                                               uint8_t gid_index,

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -591,9 +591,21 @@ int uct_ib_device_is_accessible(struct ibv_device *device);
 
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                    struct ibv_device *ib_device,
-                                   const uct_ib_md_config_t *md_config);
+                                   const uct_ib_md_config_t *md_config,
+                                   size_t mem_size, size_t mr_size);
+
+void uct_ib_md_close_common(uct_ib_md_t *md);
+
+void uct_ib_md_device_context_close(struct ibv_context *ctx);
+
+uct_ib_md_t* uct_ib_md_alloc(size_t size, const char *name,
+                             struct ibv_context *ctx);
+
+void uct_ib_md_free(uct_ib_md_t *md);
 
 void uct_ib_md_close(uct_md_h uct_md);
+
+void uct_ib_md_cleanup(uct_ib_md_t *md);
 
 ucs_status_t uct_ib_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
                            uint64_t access, int dmabuf_fd, size_t dmabuf_offset,
@@ -613,9 +625,6 @@ uct_ib_md_handle_mr_list_multithreaded(uct_ib_md_t *md, void *address,
                                        size_t length, uint64_t access,
                                        size_t chunk, struct ibv_mr **mrs,
                                        int silent);
-
-void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
-                                   const uct_ib_md_config_t *md_config);
 
 ucs_status_t uct_ib_reg_key_impl(uct_ib_md_t *md, void *address, size_t length,
                                  uint64_t access_flags, int dmabuf_fd,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -76,7 +76,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
 {
     const char *dev_name = ibv_get_device_name(verbs->device);
 
-#if HAVE_DECL_MLX5DV_IS_SUPPORTED
+#ifdef HAVE_DEVX
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out)] = {};
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)]   = {};
     uct_rdmacm_cm_reserved_qpn_blk_t *blk;
@@ -110,7 +110,7 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
         }
     }
 
-#if HAVE_DECL_MLX5DV_IS_SUPPORTED
+#ifdef HAVE_DEVX
     if (cm->config.reserved_qpn == UCS_NO) {
         goto dummy_qp_ctx_init;
     }
@@ -285,7 +285,7 @@ uct_rdmacm_cm_reserved_qpn_blk_alloc(uct_rdmacm_cm_device_context_t *ctx,
 {
     ucs_status_t status = UCS_ERR_UNSUPPORTED;
 
-#if HAVE_DECL_MLX5DV_IS_SUPPORTED
+#ifdef HAVE_DEVX
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_reserved_qpn_in)]   = {};
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(general_obj_out_cmd_hdr)] = {};
     uct_rdmacm_cm_reserved_qpn_blk_t *blk;
@@ -337,7 +337,7 @@ err_free_blk:
 void uct_rdmacm_cm_reserved_qpn_blk_release(
         uct_rdmacm_cm_reserved_qpn_blk_t *blk)
 {
-#if HAVE_DECL_MLX5DV_IS_SUPPORTED
+#ifdef HAVE_DEVX
     ucs_assert(blk->refcount == 0);
 
     uct_ib_mlx5_devx_obj_destroy(blk->obj, "RESERVED_QPN");

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -12,7 +12,7 @@
 #include <ucs/sys/string.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/datastruct/bitmap.h>
-#if HAVE_MLX5_DV
+#if HAVE_DEVX
 #include <uct/ib/mlx5/ib_mlx5.h>
 #endif
 
@@ -64,7 +64,7 @@ typedef struct uct_rdmacm_cm_reserved_qpn_blk {
     uint32_t               next_avail_qpn_offset; /** Offset of next available qpn */
     uint32_t               refcount;              /** The counter of qpns which were created and hasn't been destroyed */
     ucs_list_link_t        entry;                 /** List link of blocks */
-#if HAVE_DECL_MLX5DV_IS_SUPPORTED
+#ifdef HAVE_DEVX
     struct mlx5dv_devx_obj *obj;                  /** The devx obj used to create the block */
 #endif
 } uct_rdmacm_cm_reserved_qpn_blk_t;


### PR DESCRIPTION
## What

Fix leak if some operations failed after `uct_ib_md_open_common()`.

## Why ?

If some operations failed after `uct_ib_md_open_common()`, then we don't roll back changes done by `uct_ib_md_open_common()`.

## How ?

1. Introduce `uct_ib_md_close_common()` which performance reverse actions which could be done by `uct_ib_md_open_common()`.
2. Update `uct_ib_mlx5_devx_md_open()` and `uct_ib_mlx5dv_md_open()` to invoke `uct_ib_md_close_common()` if some operations failed after `uct_ib_md_open_common()` was invoked.