### PR TITLE
UCP: Fix AM BW lane score calculation

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1342,8 +1342,11 @@ ucp_wireup_am_bw_score_func(const ucp_worker_iface_t *wiface,
 {
     ucp_wireup_dev_usage_count *dev_count = arg;
 
-    /* best single MTU bandwidth */
-    double size = wiface->attr.cap.am.max_bcopy;
+    /* Best single MTU bandwidth, take into account remote segment size, which
+     * can be smaller than the local value (supported with worker address v2)
+     */
+    double size = ucs_min(wiface->attr.cap.am.max_bcopy,
+                          remote_addr->iface_attr.seg_size);
     double t    = (size /
                    ucp_wireup_iface_avail_bandwidth(
                        wiface, remote_addr, dev_count->local,


### PR DESCRIPTION
## What
Fixes AM BW lane score calculation

## Why ?
To avoid error like:
```
[ RUN      ] rcx/test_ucp_am_nbx_seg_size.single/7 <rc_x/prereg/proto/reply>
[     INFO ] seg size 1024 data size 512
[1661087849.623034] [swx-rain04:148009:0]          wireup.c:404  UCX  ERROR   ep 0x7f9aa897f000: no remote ep address for lane[2]->remote_lane[2]
[1661087859.654742] [swx-rain04:148009:0]       ucp_test.cc:301  UCX  ERROR request 0x4746750 completed with error Destination is unreachable
```
which happens because of asymmetrical lanes selection by peers

## How ?
Take into account remote segment size, which can be smaller than the local value.
note: different segment sizes are only supported with UCP worker address v2.
