### PR TITLE
UCT/IB/DC: Fix handling of AUTO value for FC_HARD_REQ_TIMEOUT

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1393,6 +1393,12 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         return UCS_ERR_INVALID_PARAM;
     }
 
+    if (config->fc_hard_req_timeout == UCS_ULUNITS_AUTO) {
+        ucs_error("timeout for resending of FC_HARD_REQ shouldn't be set to"
+                  " \"auto\"");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     uct_dc_mlx5_iface_init_version(self, tl_md);
 
     self->tx.ndci                          = config->ndci;


### PR DESCRIPTION
## What

Fix handling of `AUTO` value for `FC_HARD_REQ_TIMEOUT`.

## Why ?

If `UCX_DC_MLX5_FC_HARD_REQ_TIMEOUT=auto` is set, then fc_hard_req_timeout will be not a `5s` as expected to be, it will be the value of `UCS_ULUNITS_AUTO` which is `(unsigned long)-2`.

## How ?

1. Define `UCT_DC_MLX5_FC_HARD_REQ_TIMEOUT` macro and set value to `5s`.
2. Set ``UCT_DC_MLX5_FC_HARD_REQ_TIMEOUT`` as a default value for `FC_HARD_REQ_TIMEOUT` configuration parameter.
3. Update DC's `uct_iface_open()` to handle the case if config's fc_hard_req_timeout is `UCS_ULUNITS_AUTO` and set the `fc_hard_req_timeout` to `ucs_str_to_memunits(UCT_DC_MLX5_FC_HARD_REQ_TIMEOUT)`.