### PR TITLE
GTEST/UCP: Moved prereg variant to inherited classes.

### DIFF
--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -225,7 +225,8 @@ private:
                                  bool wakeup = false);
 
 protected:
-    typedef void (*get_variants_func_t)(std::vector<ucp_test_variant>&);
+    using variant_vec_t       = std::vector<ucp_test_variant>;
+    using get_variants_func_t = void (*)(variant_vec_t&);
 
     virtual void init();
     bool is_self() const;


### PR DESCRIPTION
## What
Moved memory preregistration variant of test from base class to inherited classes.

## Why ?
To get rid of redundant test variants.
