### PR TITLE
UCT/API: added uct_ep_connect_to_ep_v2 method

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -475,6 +475,19 @@ typedef struct uct_iface_is_reachable_params {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Parameters for connecting a UCT endpoint by @ref
+ * uct_ep_connect_to_ep_v2.
+ */
+typedef struct uct_ep_connect_to_ep_params {
+    /**
+     * Reserved, must be 0.
+     */
+    uint64_t                      field_mask;
+} uct_ep_connect_to_ep_params_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Get interface performance attributes, by memory types and operation.
  *        A pointer to uct_perf_attr_t struct must be passed, with the memory
  *        types and operation members initialized. Overhead and bandwidth
@@ -603,6 +616,30 @@ ucs_status_t uct_ep_query(uct_ep_h ep, uct_ep_attr_t *ep_attr);
  */
 int uct_iface_is_reachable_v2(uct_iface_h iface,
                               const uct_iface_is_reachable_params_t *params);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Connect endpoint to a remote endpoint.
+ *
+ * requires @ref UCT_IFACE_FLAG_CONNECT_TO_EP capability.
+ *
+ * @param [in] ep           Endpoint to connect.
+ * @param [in] device_addr  Remote device address.
+ * @param [in] iface_addr   Remote interface address or NULL if such address is
+ *                          not available.
+ * @param [in] ep_addr      Remote endpoint address.
+ * @param [in] params       Parameters as defined in @ref
+ *                          uct_ep_connect_to_ep_params_t.
+ *
+ * @return UCS_OK           Operation has been initiated successfully.
+ *         Other            Error codes as defined by @ref ucs_status_t.
+ */
+ucs_status_t uct_ep_connect_to_ep_v2(uct_ep_h ep,
+                                     const uct_device_addr_t *device_addr,
+                                     const uct_iface_addr_t *iface_addr,
+                                     const uct_ep_addr_t *ep_addr,
+                                     const uct_ep_connect_to_ep_params_t *params);
 
 END_C_DECLS
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -619,6 +619,18 @@ ucs_status_t uct_ep_connect_to_ep(uct_ep_h ep, const uct_device_addr_t *dev_addr
     return ep->iface->ops.ep_connect_to_ep(ep, dev_addr, ep_addr);
 }
 
+ucs_status_t uct_ep_connect_to_ep_v2(uct_ep_h ep,
+                                     const uct_device_addr_t *device_addr,
+                                     const uct_iface_addr_t *iface_addr,
+                                     const uct_ep_addr_t *ep_addr,
+                                     const uct_ep_connect_to_ep_params_t *params)
+{
+    const uct_base_iface_t *iface = ucs_derived_of(ep->iface, uct_base_iface_t);
+
+    return iface->internal_ops->ep_connect_to_ep_v2(ep, device_addr, iface_addr,
+                                                    ep_addr, params);
+}
+
 ucs_status_t uct_cm_client_ep_conn_notify(uct_ep_h ep)
 {
     return ep->iface->ops.cm_ep_conn_notify(ep);

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -247,6 +247,14 @@ typedef ucs_status_t (*uct_ep_query_func_t)(uct_ep_h ep, uct_ep_attr_t *ep_attr)
 /* Invalidate the ep to emulate transport level error */
 typedef ucs_status_t (*uct_ep_invalidate_func_t)(uct_ep_h ep, unsigned flags);
 
+/* Connect endpoint to remote endpoint */
+typedef ucs_status_t (*uct_ep_connect_to_ep_v2_func_t)(
+        uct_ep_h ep,
+        const uct_device_addr_t *device_addr,
+        const uct_iface_addr_t *iface_addr,
+        const uct_ep_addr_t *ep_addr,
+        const uct_ep_connect_to_ep_params_t *params);
+
 
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
@@ -254,6 +262,7 @@ typedef struct uct_iface_internal_ops {
     uct_iface_vfs_refresh_func_t   iface_vfs_refresh;
     uct_ep_query_func_t            ep_query;
     uct_ep_invalidate_func_t       ep_invalidate;
+    uct_ep_connect_to_ep_v2_func_t ep_connect_to_ep_v2;
 } uct_iface_internal_ops_t;
 
 


### PR DESCRIPTION
## What
Added uct_ep_connect_to_ep_v2 method and corresponding data type

## Why ?
Allow implementation of extended connect_to_ep

## How ?
Added extendable data set to pass into connect_to_ep routine
