### PR TITLE
UCM: Fix deprecated <sys/fcntl.h> includes

### DIFF
--- a/src/tools/profile/read_profile.c
+++ b/src/tools/profile/read_profile.c
@@ -13,12 +13,12 @@
 #include <ucs/sys/string.h>
 
 #include <sys/signal.h>
-#include <sys/fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <getopt.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
 #include <assert.h>

--- a/src/ucm/util/reloc.c
+++ b/src/ucm/util/reloc.c
@@ -17,7 +17,6 @@
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 
-#include <sys/fcntl.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -26,7 +26,6 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/uio.h>
-#include <sys/fcntl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/param.h>
@@ -36,6 +35,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>

--- a/test/apps/sockaddr/sa_tcp.cc
+++ b/test/apps/sockaddr/sa_tcp.cc
@@ -8,8 +8,8 @@
 
 #include <sys/socket.h>
 #include <sys/epoll.h>
-#include <sys/fcntl.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <cstring>
 #include <cerrno>

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -12,7 +12,7 @@ extern "C" {
 #include <ucs/vfs/sock/vfs_sock.h>
 }
 
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <time.h>
 
 


### PR DESCRIPTION
Fix deprecation warnings like:
```
In file included from /var/tmp/portage/sys-cluster/ucx-1.10.0_rc5/work/ucx-1.10.0-rc5/src/ucs/sys/sys.h:29,
                 from mmap/install.c:21:
/usr/include/sys/fcntl.h:1:2: error: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror=cpp[https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcpp]]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^~~~~~~
```

Bug: https://bugs.gentoo.org/832966
Signed-off-by: Sam James <sam@gentoo.org>## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
