### PR TITLE
UCP: Fix rndv lanes selections for memtypes

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2214,24 +2214,6 @@ const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx)
     return context->tl_cmpts[context->config.cm_cmpt_idxs[cm_idx]].attr.name;
 }
 
-void ucp_context_get_mem_access_tls(ucp_context_h context,
-                                    ucs_memory_type_t mem_type,
-                                    ucp_tl_bitmap_t *tl_bitmap)
-{
-    const uct_md_attr_t *md_attr;
-    ucp_md_index_t md_index;
-    ucp_rsc_index_t tl_id;
-
-    UCS_BITMAP_CLEAR(tl_bitmap);
-    UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, tl_id) {
-        md_index = context->tl_rscs[tl_id].md_index;
-        md_attr  = &context->tl_mds[md_index].attr;
-        if (md_attr->cap.access_mem_types & UCS_BIT(mem_type)) {
-            UCS_BITMAP_SET(*tl_bitmap, tl_id);
-        }
-    }
-}
-
 UCS_F_CTOR void ucp_global_init(void)
 {
     UCS_CONFIG_ADD_TABLE(ucp_config_table, &ucs_config_global_list);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -454,6 +454,22 @@ typedef struct ucp_tl_iface_atomic_flags {
     ucs_assert(ucp_memory_type_detect(_context, _buffer, _length) == (_mem_type))
 
 
+#define UCP_CONTEXT_MEM_CAP_TLS(_context, _mem_type, _cap_field, _tl_bitmap) \
+    { \
+        const uct_md_attr_t *md_attr; \
+        ucp_md_index_t md_index; \
+        ucp_rsc_index_t tl_id; \
+        UCS_BITMAP_CLEAR(&(_tl_bitmap)); \
+        UCS_BITMAP_FOR_EACH_BIT((_context)->tl_bitmap, tl_id) { \
+            md_index = (_context)->tl_rscs[tl_id].md_index; \
+            md_attr  = &(_context)->tl_mds[md_index].attr; \
+            if (md_attr->cap._cap_field & UCS_BIT(_mem_type)) { \
+                UCS_BITMAP_SET(_tl_bitmap, tl_id); \
+            } \
+        } \
+    }
+
+
 extern ucp_am_handler_t *ucp_am_handlers[];
 extern const char       *ucp_feature_str[];
 
@@ -615,10 +631,5 @@ ucp_config_modify_internal(ucp_config_t *config, const char *name,
 
 
 void ucp_apply_uct_config_list(ucp_context_h context, void *config);
-
-
-void ucp_context_get_mem_access_tls(ucp_context_h context,
-                                    ucs_memory_type_t mem_type,
-                                    ucp_tl_bitmap_t *tl_bitmap);
 
 #endif

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -612,7 +612,8 @@ ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker)
     unsigned addr_indices[UCP_MAX_LANES];
 
     ucs_memory_type_for_each(mem_type) {
-        ucp_context_get_mem_access_tls(context, mem_type, &mem_access_tls);
+        UCP_CONTEXT_MEM_CAP_TLS(context, mem_type, access_mem_types,
+                                mem_access_tls);
         if (UCP_MEM_IS_HOST(mem_type) ||
             UCS_BITMAP_IS_ZERO_INPLACE(&mem_access_tls)) {
             continue;


### PR DESCRIPTION
## What
Fix rma_bw lanes selection for different memory types. 

## Why ?
No need to search rma_bw lanes for different memory types on the same memory domains to avoid asymmetrical lanes selection  (e.g. when one node has nv_pee_mem loaded, while the other does not) 


## How ?
Partially revert #7683 
