### PR TITLE
Am user header release/support protov2 reset

### DIFF
--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -70,8 +70,9 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
     }
 
     if (req->send.msg_proto.am.header.length != 0) {
-        ucs_assert(req->send.msg_proto.am.header.user_ptr != NULL);
+        ucs_assert(req->send.msg_proto.am.header.ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);
+        ucp_am_release_user_header(req);
     }
 
     req->send.msg_proto.am.header.reg_desc = reg_desc;

--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -321,6 +321,6 @@ ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .init     = ucp_am_eager_multi_zcopy_proto_init,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_zcopy_proto_progress},
-    .abort    = ucp_proto_request_zcopy_abort,
+    .abort    = ucp_proto_am_request_zcopy_abort,
     .reset    = ucp_am_proto_request_zcopy_reset
 };

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -51,7 +51,7 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
                          &iov_cnt);
 
     if (header_length != 0) {
-        ucp_add_uct_iov_elem(iov,req->send.msg_proto.am.header.user_ptr,
+        ucp_add_uct_iov_elem(iov, req->send.msg_proto.am.header.ptr,
                              header_length, UCT_MEM_HANDLE_NULL, &iov_cnt);
     }
 
@@ -165,7 +165,7 @@ ucp_proto_t ucp_am_eager_short_reply_proto = {
     .init     = ucp_am_eager_short_reply_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_reply_proto_progress},
-    .abort    = ucp_proto_request_bcopy_abort,
+    .abort    = ucp_proto_am_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
 };
 
@@ -402,7 +402,7 @@ ucp_proto_t ucp_am_eager_single_zcopy_proto = {
     .init     = ucp_am_eager_single_zcopy_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_proto_progress},
-    .abort    = ucp_proto_request_zcopy_abort,
+    .abort    = ucp_proto_am_request_zcopy_abort,
     .reset    = ucp_am_proto_request_zcopy_reset
 };
 
@@ -458,6 +458,6 @@ ucp_proto_t ucp_am_eager_single_zcopy_reply_proto = {
     .init     = ucp_am_eager_single_zcopy_reply_proto_init,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_reply_proto_progress},
-    .abort    = ucp_proto_request_zcopy_abort,
+    .abort    = ucp_proto_am_request_zcopy_abort,
     .reset    = ucp_am_proto_request_zcopy_reset
 };

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -138,4 +138,6 @@ ucs_status_t ucp_am_proto_request_zcopy_reset(ucp_request_t *request);
 
 void ucp_proto_am_request_bcopy_abort(ucp_request_t *req, ucs_status_t status);
 
+void ucp_proto_am_request_zcopy_abort(ucp_request_t *req, ucs_status_t status);
+
 #endif

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -186,10 +186,20 @@ struct ucp_request {
 
                         struct {
                             struct {
-                                void           *user_ptr;
-                                ucp_mem_desc_t *reg_desc; /* pointer to pre-registered buffer,
-                                                             used for sending header with
-                                                             zcopy protocol */
+                                /* Pointer to buffer used for sending header.
+                                 * - When UCP_AM_SEND_FLAG_COPY_HEADER is set
+                                 *   and reg_desc is NULL ptr holds
+                                 *   address of ucx mpool buffer.
+                                 * - When UCP_AM_SEND_FLAG_COPY_HEADER is not set
+                                 *   ptr holds address of external buffer, provided
+                                 *   by the user, that is expected to be valid
+                                 *   during the send operation.
+                                 */
+                                void           *ptr;
+                                /* pointer to pre-registered buffer,
+                                 * used for sending header with zcopy protocol.
+                                 */
+                                ucp_mem_desc_t *reg_desc;
                                 uint32_t       length;
                             } header UCS_S_PACKED; /* packed to avoid 32-bit
                                                       padding */

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -132,10 +132,10 @@ ucs_status_t ucp_proto_am_req_copy_header(ucp_request_t *req)
         return UCS_ERR_NO_MEMORY;
     }
 
-    memcpy(user_header, req->send.msg_proto.am.header.user_ptr,
+    memcpy(user_header, req->send.msg_proto.am.header.ptr,
            req->send.msg_proto.am.header.length);
-    req->flags |= UCP_REQUEST_FLAG_USER_HEADER_COPIED;
-    req->send.msg_proto.am.header.user_ptr = user_header;
+    req->flags                       |= UCP_REQUEST_FLAG_USER_HEADER_COPIED;
+    req->send.msg_proto.am.header.ptr = user_header;
 
     return UCS_OK;
 }

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -45,9 +45,10 @@ static UCS_F_ALWAYS_INLINE void ucp_am_release_user_header(ucp_request_t *req)
 {
     if (ucs_unlikely(req->flags & UCP_REQUEST_FLAG_USER_HEADER_COPIED)) {
         ucs_assert(req->send.msg_proto.am.flags & UCP_AM_SEND_FLAG_COPY_HEADER);
-        ucs_mpool_set_put_inline(req->send.msg_proto.am.header.user_ptr);
+        ucs_mpool_set_put_inline(req->send.msg_proto.am.header.ptr);
+        req->flags &= ~UCP_REQUEST_FLAG_USER_HEADER_COPIED;
 #if UCS_ENABLE_ASSERT
-        req->send.msg_proto.am.header.user_ptr = NULL;
+        req->send.msg_proto.am.header.ptr = NULL;
 #endif
     }
 }
@@ -675,9 +676,8 @@ ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
     hdr_state.offset = 0ul;
 
     ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
-                UCS_MEMORY_TYPE_HOST, buffer,
-                req->send.msg_proto.am.header.user_ptr, &hdr_state,
-                req->send.msg_proto.am.header.length);
+                UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header.ptr,
+                &hdr_state, req->send.msg_proto.am.header.length);
 }
 
 #endif


### PR DESCRIPTION
## What
Support re-initialization of protocols with non persistent user header

## Why ?
#8386 
Zcopy clean function need to handle the case when user header is not persistent and need to be copied.

## How ?
[Description can be found here](https://github.com/openucx/ucx/pull/8173#discussion_r928840502)
