### PR TITLE
UCT/IB/DC: Don't allocate new sequence number for resending existing FC_HARD_REQ

### DIFF
--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -666,7 +666,11 @@ void test_rc_flow_control::test_general(int wnd, int soft_thresh,
     flush();
 }
 
-void test_rc_flow_control::test_pending_grant(int wnd, uint64_t *wait_fc_seq)
+void test_rc_flow_control::wait_fc_hard_resend(entity *e)
+{
+}
+
+void test_rc_flow_control::test_pending_grant(int16_t wnd)
 {
     /* Block send capabilities of m_e2 for fc grant to be
      * added to the pending queue. */
@@ -680,11 +684,7 @@ void test_rc_flow_control::test_pending_grant(int wnd, uint64_t *wait_fc_seq)
     send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
     EXPECT_LE(get_fc_ptr(m_e1)->fc_wnd, 0);
 
-    if (wait_fc_seq != NULL) {
-        uint64_t fc_seq_value = *wait_fc_seq;
-        wait_for_value(wait_fc_seq, fc_seq_value + 1, true);
-        EXPECT_GT(*wait_fc_seq, fc_seq_value);
-    }
+    wait_fc_hard_resend(m_e1);
 
     /* Enable send capabilities of m_e2 and send short put message to force
      * pending queue dispatch. Can't send AM message for that, because it may

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -136,7 +136,9 @@ public:
 
     void test_general(int wnd, int s_thresh, int h_thresh, bool is_fc_enabled);
 
-    virtual void test_pending_grant(int wnd, uint64_t *wait_fc_seq = NULL);
+    virtual void wait_fc_hard_resend(entity *e);
+
+    virtual void test_pending_grant(int16_t wnd);
 
     void test_pending_purge(int wnd, int num_pend_sends);
 

--- a/test/gtest/uct/ib/ud_base.cc
+++ b/test/gtest/uct/ib/ud_base.cc
@@ -35,9 +35,9 @@ uct_ud_iface_t *ud_base_test::iface(entity *e)
     return ucs_derived_of(e->iface(), uct_ud_iface_t);
 }
 
-void ud_base_test::short_progress_loop(double delta_ms) const
+void ud_base_test::short_progress_loop(double delta_ms, entity *e) const
 {
-    uct_test::short_progress_loop(delta_ms);
+    uct_test::short_progress_loop(delta_ms, e);
 }
 
 void ud_base_test::connect()

--- a/test/gtest/uct/ib/ud_base.h
+++ b/test/gtest/uct/ib/ud_base.h
@@ -46,7 +46,8 @@ public:
 
     void disable_async(entity *e);
 
-    virtual void short_progress_loop(double delta_ms=10.0) const;
+    virtual void
+    short_progress_loop(double delta_ms = 10.0, entity *e = NULL) const;
 
 protected:
     entity *m_e1, *m_e2;

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -754,10 +754,14 @@ void uct_test::flush(ucs_time_t deadline) const {
     EXPECT_TRUE(flushed) << "Timed out";
 }
 
-void uct_test::short_progress_loop(double delay_ms) const {
+void uct_test::short_progress_loop(double delay_ms, entity *e) const {
     ucs_time_t end_time = ucs_get_time() + ucs_time_from_msec(delay_ms * ucs::test_time_multiplier());
     while (ucs_get_time() < end_time) {
-        progress();
+        if (e == NULL) {
+            progress();
+        } else {
+            e->progress();
+        }
     }
 }
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -349,6 +349,25 @@ protected:
         }
     }
 
+    template <typename T>
+    void wait_for_value_change(volatile T *var, entity *e = NULL,
+                               bool progress = true,
+                               double timeout = DEFAULT_TIMEOUT_SEC) const
+    {
+        ucs_time_t deadline = ucs_get_time() +
+                              ucs_time_from_sec(timeout) *
+                              ucs::test_time_multiplier();
+        T initial_value     = *var;
+
+        while ((ucs_get_time() < deadline) && (*var == initial_value)) {
+            if (progress) {
+                short_progress_loop(DEFAULT_DELAY_MS, e);
+            } else {
+                twait();
+            }
+        }
+    }
+
     virtual void init();
     virtual void cleanup();
     virtual void modify_config(const std::string& name, const std::string& value,
@@ -374,7 +393,8 @@ protected:
     const entity& ent(unsigned index) const;
     unsigned progress() const;
     void flush(ucs_time_t deadline = ULONG_MAX) const;
-    virtual void short_progress_loop(double delay_ms = DEFAULT_DELAY_MS) const;
+    virtual void short_progress_loop(double delay_ms = DEFAULT_DELAY_MS,
+                                     entity *e = NULL) const;
     virtual void twait(int delta_ms = DEFAULT_DELAY_MS) const;
     static void set_cm_resources(std::vector<resource>& all_resources);
     static bool is_interface_usable(struct ifaddrs *ifa, const char *name);


### PR DESCRIPTION
## What

Don't allocate a new sequence number for resending an existing `FC_HARD_REQ` packet.

## Why ?

Not reusing a sequence number which was allocated for FC entry existed in FC hash could lead to always dropping `FC_PURE_GRANT` packets with "old" sequence numbers if a peer is not fast enough to send `FC_PURE_GRANT` back.
This PR fixes IO-demo's "timeout waiting for replies", because server can't send replies, since FC window is exhausted and not renewed by receiving `FC_PURE_GRANT` with an expected sequence number.

## How ?

1. If `kh_put` completed with `UCS_KH_PUT_KEY_PRESENT`, don't assign new FC sequence number. just reuse the existing one from a FC entry returned from `kh_put`.
2. Add useful assertions to make sure FC hash is used correctly, i.e. a FC entry should exist in FC hash only if endpoint's `fc_wnd` < `fc_hard_thresh` and a FC entry shouldn't exist if endpoint's `fc_wnd` == `fc_hard_thresh`.