### PR TITLE
UCT/MD/QUERY: Check that the size of dev/shm is not too small

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -82,6 +82,28 @@ static ucs_status_t uct_mm_iface_get_address(uct_iface_t *tl_iface,
     return uct_mm_md_mapper_ops(md)->iface_addr_pack(md, iface_addr + 1);
 }
 
+ucs_status_t
+uct_mm_iface_query_tl_devices(uct_md_h md,
+                              uct_tl_device_resource_t **tl_devices_p,
+                              unsigned *num_tl_devices_p)
+{
+    uct_md_attr_t md_attr;
+    ucs_status_t status;
+
+    status = uct_md_query(md, &md_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (!(md_attr.cap.flags & UCT_MD_FLAG_ALLOC)) {
+        *num_tl_devices_p = 0;
+        *tl_devices_p     = NULL;
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    return uct_sm_base_query_tl_devices(md, tl_devices_p, num_tl_devices_p);
+}
+
 static int
 uct_mm_iface_is_reachable(const uct_iface_h tl_iface,
                           const uct_device_addr_t *dev_addr,

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -224,6 +224,12 @@ typedef struct uct_mm_iface {
 } uct_mm_iface_t;
 
 
+ucs_status_t
+uct_mm_iface_query_tl_devices(uct_md_h md,
+                              uct_tl_device_resource_t **tl_devices_p,
+                              unsigned *num_tl_devices_p);
+
+
 /*
  * Define a memory-mapper transport for MM.
  *
@@ -239,7 +245,7 @@ typedef struct uct_mm_iface {
     UCT_MM_COMPONENT_DEFINE(_name, _md_ops, _rkey_unpack, _rkey_release, \
                             _cfg_prefix) \
     UCT_TL_DEFINE_ENTRY(&UCT_COMPONENT_NAME(_name).super, _name, \
-                        uct_sm_base_query_tl_devices, uct_mm_iface_t, \
+                        uct_mm_iface_query_tl_devices, uct_mm_iface_t, \
                         _cfg_prefix, _cfg_table, uct_mm_iface_config_t)
 
 


### PR DESCRIPTION
## What
Check that the size of /dev/shm is not "too small" according to UCX perspective and disqualify its md to prevent the TL from opening.

## Why ?
Machine running UCX can limit the size of /dev/shm. This can result in insufficient memory for the TL resources, for example receive buffers pool. 

## How ?
In uct_posix_md_query check that the size of /dev/shm is bigger than the min value expected by UCX.
A configurable parameter (UCX_POSIX_SHM_MIN_SIZE) was added to the UCX configuration. it's enforce shm minimum size. Default value is set to 16MB.
