### PR TITLE
UCP/CORE: User memh proto v2

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -49,6 +49,7 @@ typedef struct ucp_mem {
     uint8_t             flags;          /* Memory handle flags */
     ucp_context_h       context;        /* UCP context that owns a memory handle */
     uct_alloc_method_t  alloc_method;   /* Method used to allocate the memory */
+    ucs_sys_device_t    sys_dev;        /* System device index */
     ucs_memory_type_t   mem_type;       /* Type of allocated or registered memory */
     ucp_md_index_t      alloc_md_index; /* Index of MD used to allocate the memory */
     uint64_t            remote_uuid;    /* Remote UUID */

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -10,6 +10,7 @@
 #include "ucp_request.h"
 #include "ucp_worker.h"
 #include "ucp_ep.inl"
+#include "ucp_mm.inl"
 
 #include <ucp/dt/dt.h>
 #include <ucs/profile/profile.h>
@@ -17,6 +18,7 @@
 #include <ucs/datastruct/mpool_set.inl>
 #include <ucs/datastruct/ptr_map.inl>
 #include <ucs/debug/debug_int.h>
+#include <ucp/dt/datatype_iter.inl>
 #include <ucp/dt/dt.inl>
 #include <inttypes.h>
 

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -68,6 +68,8 @@ typedef struct {
     } type;
 } ucp_datatype_iter_t;
 
+ucs_status_t
+ucp_datatype_iter_set_iov_memh(ucp_datatype_iter_t *dt_iter, ucp_mem_h memh);
 
 ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
                                            ucp_datatype_iter_t *dt_iter,
@@ -85,8 +87,13 @@ size_t ucp_datatype_iter_iov_next_iov(const ucp_datatype_iter_t *dt_iter,
                                       ucp_datatype_iter_t *next_iter,
                                       uct_iov_t *iov, size_t max_iov);
 
+size_t ucp_datatype_iter_iov_count(const ucp_datatype_iter_t *dt_iter);
 
 void ucp_datatype_iter_str(const ucp_datatype_iter_t *dt_iter,
                            ucs_string_buffer_t *strb);
+
+ucs_status_t
+ucp_datatype_iter_is_user_memh_valid(const ucp_datatype_iter_t *dt_iter,
+                                     const ucp_mem_h memh);
 
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -246,9 +246,12 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
 
     ucp_proto_request_send_init(req, ep, 0);
 
-    UCS_PROFILE_CALL_VOID(ucp_datatype_iter_init, worker->context,
-                          (void*)buffer, count, datatype, contig_length, 1,
-                          &req->send.state.dt_iter, &sg_count);
+    status = UCS_PROFILE_CALL(ucp_datatype_iter_init, worker->context,
+                              (void*)buffer, count, datatype, contig_length, 1,
+                              &req->send.state.dt_iter, &sg_count, param);
+    if (status != UCS_OK) {
+        goto err;
+    }
 
     ucp_proto_select_param_init(&sel_param, op_id, param->op_attr_mask,
                                 op_flags, req->send.state.dt_iter.dt_class,
@@ -258,8 +261,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
                               proto_select, rkey_cfg_index, &sel_param,
                               req->send.state.dt_iter.length + header_length);
     if (status != UCS_OK) {
-        ucp_request_put_param(param, req);
-        return UCS_STATUS_PTR(status);
+        goto err;
     }
 
     UCS_PROFILE_CALL_VOID(ucp_request_send, req);
@@ -272,6 +274,10 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
     ucs_trace_req("returning send request %p: %s buffer %p count %zu",
                   req, ucp_operation_names[op_id], buffer, count);
     return req + 1;
+
+err:
+    ucp_request_put_param(param, req);
+    return UCS_STATUS_PTR(status);
 }
 
 static UCS_F_ALWAYS_INLINE size_t

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -83,9 +83,13 @@ protected:
         m_dt_desc.make(GetParam(), &m_dt_buffer[0], m_dt_buffer.size(), iovcnt);
 
         uint8_t sg_count;
+        /* Pass empty param argument to disable memh initialization */
+        ucp_request_param_t param;
+        param.op_attr_mask = 0;
+
         ucp_datatype_iter_init(m_ucph.get(), m_dt_desc.buf(), m_dt_desc.count(),
                                m_dt_desc.dt(), m_dt_buffer.size(), is_pack,
-                               &m_dt_iter, &sg_count);
+                               &m_dt_iter, &sg_count, &param);
         if (!UCP_DT_IS_GENERIC(GetParam())) {
             EXPECT_EQ(iovcnt, sg_count);
         }

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -82,8 +82,12 @@ void test_ucp_proto::test_dt_iter_mem_reg(ucs_memory_type_t mem_type,
 
     ucp_datatype_iter_t dt_iter;
     uint8_t sg_count;
+    /* Pass empty param argument to disable memh initialization */
+    ucp_request_param_t param;
+    param.op_attr_mask = 0;
+
     ucp_datatype_iter_init(context(), buffer.ptr(), size, UCP_DATATYPE_CONTIG,
-                           size, 1, &dt_iter, &sg_count);
+                           size, 1, &dt_iter, &sg_count, &param);
 
     ucs_time_t start_time = ucs_get_time();
     ucs_time_t deadline   = start_time + ucs_time_from_sec(test_time_sec);

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -15,6 +15,8 @@ extern "C" {
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucs/arch/atomic.h>
+#include <ucs/memory/rcache.h>
+#include <ucs/memory/rcache_int.h>
 }
 
 #include <sys/mman.h>
@@ -464,16 +466,83 @@ UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_limits)
 
 class test_ucp_tag_nbx : public test_ucp_tag {
 public:
+    class completion_value {
+    public:
+        completion_value() : m_address(nullptr), m_value(0)
+        {
+        }
+
+        completion_value(uint32_t *address, uint32_t value) :
+            m_address(address), m_value(value)
+        {
+        }
+
+        bool empty() const
+        {
+            return (m_address == nullptr) && (m_value == 0);
+        }
+
+        uint32_t *m_address;
+        uint32_t  m_value;
+    };
+
+    test_ucp_tag_nbx()
+    {
+        if (enable_proto()) {
+            modify_config("PROTO_ENABLE", "y");
+        }
+    }
+
     void init() {
-        /* forbid zcopy access because it will always fail due to read-only
-         * memory pages (will fail to register memory) */
-        modify_config("ZCOPY_THRESH", "inf");
+        stats_activate();
         test_ucp_tag::init();
+    }
+
+    virtual void cleanup()
+    {
+        test_ucp_tag::cleanup();
+        stats_restore();
+    }
+
+    static void
+    get_test_variants_prereg(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant_with_value(variants, UCP_FEATURE_TAG, 0, "");
+        add_variant_with_value(variants, UCP_FEATURE_TAG, 1, "prereg");
+    }
+
+    static void get_test_variants_proto(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant_values(variants, get_test_variants_prereg, 0);
+        add_variant_values(variants, get_test_variants_prereg, 1, "proto");
+    }
+
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant_values(variants, get_test_variants_proto, 0);
+        add_variant_values(variants, get_test_variants_proto, 1, "iov");
     }
 
 protected:
     static const size_t MSG_SIZE;
     static const ucp_request_param_t null_param;
+    static const completion_value null_completion;
+    static const size_t iov_count;
+
+    bool prereg() const
+    {
+        return get_variant_value(0);
+    }
+
+    bool enable_proto() const
+    {
+        return m_ucp_config->ctx.proto_enable || get_variant_value(1);
+    }
+
+    bool is_iov() const
+    {
+        return get_variant_value(2);
+    }
 
     static void send_callback(void *req, ucs_status_t status,
                               void *user_data)
@@ -490,79 +559,142 @@ protected:
         ucs_atomic_add32((volatile uint32_t*)user_data, 1);
     }
 
-    void test_recv_send(size_t size, const void *send_buffer, void *recv_buffer,
-                        bool prereg = false,
-                        const ucp_request_param_t &sparam = null_param,
-                        const ucp_request_param_t &rparam = null_param)
+    void do_send_recv(const ucp::data_type_desc_t &send_dt,
+                      ucp::data_type_desc_t &recv_dt,
+                      const ucp_request_param_t &sparam,
+                      const ucp_request_param_t &rparam)
     {
-        ucp_request_param_t send_param = sparam;
-        ucp_request_param_t recv_param = rparam;
-
-        if (prereg) {
-            send_param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
-            send_param.memh          = sender().mem_map(
-                                               const_cast<void*>(send_buffer),
-                                               size);
-
-            recv_param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
-            recv_param.memh          = receiver().mem_map(recv_buffer, size);
-        }
+        const ssize_t recv_size = recv_dt.extent();
+        ucs_assert(recv_size > 0);
 
         ucs_status_ptr_t recv_req = ucp_tag_recv_nbx(receiver().worker(),
-                                                     recv_buffer, size, 0, 0,
-                                                     &recv_param);
+                                                     recv_dt.buf(), recv_size,
+                                                     0, 0, &rparam);
         ASSERT_UCS_PTR_OK(recv_req);
 
-        ucs_status_ptr_t send_req = ucp_tag_send_nbx(sender().ep(), send_buffer,
-                                                     size, 0, &send_param);
+        const ssize_t send_size = send_dt.extent();
+        ucs_assert(send_size > 0);
+        ucs_status_ptr_t send_req = ucp_tag_send_nbx(sender().ep(),
+                                                     send_dt.buf(), send_size,
+                                                     0, &sparam);
         ASSERT_UCS_PTR_OK(send_req);
 
-        if (!(recv_param.op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
+        if (!(rparam.op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
             request_wait(recv_req);
         }
 
-        if (!(send_param.op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
+        if (!(sparam.op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST)) {
             request_wait(send_req);
         }
+    }
 
-        if (prereg) {
+    void test_prereg_rcache_stats(const ucp::data_type_desc_t &send_dt,
+                                  ucp::data_type_desc_t &recv_dt,
+                                  const ucp_request_param_t &sparam,
+                                  const ucp_request_param_t &rparam)
+    {
+        if (sparam.op_attr_mask & UCP_OP_ATTR_FIELD_REQUEST) {
+            /* Can't send multiple requests for a single user request memory
+               handle */
+            return;
+        }
+
+        int prev_rcache_get_count;
+        prev_rcache_get_count = UCS_STATS_GET_COUNTER(
+                sender().ucph()->rcache->stats, UCS_RCACHE_GETS);
+
+        for (int i = 0; i < 10; ++i) {
+            do_send_recv(send_dt, recv_dt, sparam, rparam);
+        }
+
+        int rcache_get_count;
+        rcache_get_count = UCS_STATS_GET_COUNTER(sender().ucph()->rcache->stats,
+                                                 UCS_RCACHE_GETS);
+
+        /* Compare counters before and after iterations */
+        EXPECT_EQ(prev_rcache_get_count, rcache_get_count);
+    }
+
+    void test_recv_send(size_t size, const void *send_buffer, void *recv_buffer,
+                        ucp_request_param_t send_param = null_param,
+                        ucp_request_param_t recv_param = null_param,
+                        completion_value completion = null_completion)
+    {
+        ucp_datatype_t datatype = is_iov() ? ucp_dt_make_iov() :
+                                             ucp_dt_make_contig(1);
+        ucp::data_type_desc_t send_dt(datatype, send_buffer, size, iov_count);
+
+        /* Currently recv side supports only contig datatype */
+        ucp::data_type_desc_t recv_dt(ucp_dt_make_contig(1), recv_buffer, size);
+
+        send_param.datatype      = datatype;
+        send_param.op_attr_mask |= UCP_OP_ATTR_FIELD_DATATYPE;
+
+        if (prereg()) {
+            send_param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+            recv_param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+            send_param.memh = sender().mem_map((void*)send_buffer, size);
+            recv_param.memh = receiver().mem_map(recv_buffer, size);
+        }
+
+        do_send_recv(send_dt, recv_dt, send_param, recv_param);
+
+        if (prereg() && !is_self()) {
+            /* Not relevant for 'self' because both sender and receiver are the same entity.
+               Must be called before request is freed by free_callback (wait_for_value). */
+            test_prereg_rcache_stats(send_dt, recv_dt, send_param, recv_param);
+        }
+
+        if (!completion.empty()) {
+            /* Wait for completion indication */
+            wait_for_value(completion.m_address, completion.m_value);
+        }
+
+        if (prereg()) {
             sender().mem_unmap(send_param.memh);
             receiver().mem_unmap(recv_param.memh);
         }
     }
 
-    void test_recv_send(size_t size = MSG_SIZE, bool prereg = false)
+    void test_recv_send(size_t size = MSG_SIZE)
     {
         std::vector<char> send_buffer(size);
         std::vector<char> recv_buffer(size);
-        test_recv_send(size, &send_buffer[0], &recv_buffer[0], prereg);
+        test_recv_send(size, &send_buffer[0], &recv_buffer[0]);
     }
 };
 
 const size_t test_ucp_tag_nbx::MSG_SIZE  = 4 * UCS_KBYTE * ucs_get_page_size();
 const ucp_request_param_t test_ucp_tag_nbx::null_param = {0};
-
+const test_ucp_tag_nbx::completion_value test_ucp_tag_nbx::null_completion =
+        {nullptr, 0};
+const size_t test_ucp_tag_nbx::iov_count               = 20;
 
 UCS_TEST_P(test_ucp_tag_nbx, basic)
 {
     test_recv_send();
 }
 
-UCS_TEST_P(test_ucp_tag_nbx, eager_zcopy_prereg, "ZCOPY_THRESH=0",
-           "RNDV_THRESH=inf")
+UCS_TEST_P(test_ucp_tag_nbx, eager_zcopy, "ZCOPY_THRESH=0", "RNDV_THRESH=inf")
 {
-    test_recv_send(4 * UCS_KBYTE, true);
+    test_recv_send(4 * UCS_KBYTE);
 }
 
-UCS_TEST_P(test_ucp_tag_nbx, rndv_prereg, "RNDV_THRESH=0")
+UCS_TEST_P(test_ucp_tag_nbx, rndv_bcopy, "ZCOPY_THRESH=inf", "RNDV_THRESH=0")
 {
-    test_recv_send(64 * UCS_KBYTE, true);
+    test_recv_send(64 * UCS_KBYTE);
 }
 
-UCS_TEST_P(test_ucp_tag_nbx, fallback)
+UCS_TEST_P(test_ucp_tag_nbx, rndv_zcopy, "ZCOPY_THRESH=0", "RNDV_THRESH=0")
 {
-    if (m_ucp_config->ctx.proto_enable) {
-        UCS_TEST_SKIP_R("FIXME: fallback is not implemented in proto_v2");
+    test_recv_send(64 * UCS_KBYTE);
+}
+
+UCS_TEST_P(test_ucp_tag_nbx, fallback, "ZCOPY_THRESH=inf")
+{
+    if (enable_proto() || prereg()) {
+        UCS_TEST_SKIP_R(
+                "protoV2/prereg are not supported for partial md reg failure");
     }
 
     /* allocate read-only pages - it force ibv_reg_mr() failure */
@@ -599,10 +731,10 @@ UCS_TEST_P(test_ucp_tag_nbx, external_request_free)
     std::vector<char> send_buffer(MSG_SIZE);
     std::vector<char> recv_buffer(MSG_SIZE);
 
-    test_recv_send(MSG_SIZE, &send_buffer[0], &recv_buffer[0], false,
-                   send_param, recv_param);
+    completion_value completion(&completed, 2u);
 
-    wait_for_value(&completed, 2u);
+    test_recv_send(MSG_SIZE, &send_buffer[0], &recv_buffer[0], send_param,
+                   recv_param, completion);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_tag_nbx)

--- a/test/gtest/ucp/ucp_datatype.h
+++ b/test/gtest/ucp/ucp_datatype.h
@@ -85,6 +85,18 @@ public:
         return m_count;
     };
 
+    ssize_t extent() const
+    {
+        if (UCP_DT_IS_CONTIG(m_dt) || UCP_DT_IS_GENERIC(m_dt)) {
+            return m_length;
+        } else if (UCP_DT_IS_IOV(m_dt)) {
+            return m_count;
+        }
+
+        ADD_FAILURE() << "Not supported datatype";
+        return -1;
+    }
+
 private:
     uintptr_t       m_origin;
     size_t          m_length;


### PR DESCRIPTION
## What
User memh proto v2 support.

## Why ?
Allow memory handle to be supplied from user in order to prevent multiple registration and improve performance.
