### PR TITLE
UCP/CORE: Use uct_md_query_v2 instead of uct_md_query

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1176,13 +1176,14 @@ static ucs_status_t ucp_fill_tl_md(ucp_context_h context,
 
     VALGRIND_MAKE_MEM_UNDEFINED(&tl_md->attr, sizeof(tl_md->attr));
     /* Save MD attributes */
-    status = uct_md_query(tl_md->md, &tl_md->attr);
+    tl_md->attr.field_mask = UINT64_MAX;
+    status                 = uct_md_query_v2(tl_md->md, &tl_md->attr);
     if (status != UCS_OK) {
         uct_md_close(tl_md->md);
         return status;
     }
 
-    tl_md->pack_flags_mask = (tl_md->attr.cap.flags & UCT_MD_FLAG_INVALIDATE) ?
+    tl_md->pack_flags_mask = (tl_md->attr.flags & UCT_MD_FLAG_INVALIDATE) ?
                              UCT_MD_MKEY_PACK_FLAG_INVALIDATE : 0;
     return UCS_OK;
 }
@@ -1343,7 +1344,7 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
     uint64_t mem_type_mask;
     uint64_t mem_type_bitmap;
     ucs_memory_type_t mem_type;
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
 
     /* List memory domain resources */
     uct_component_attr.field_mask   = UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES;
@@ -1377,7 +1378,7 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
 
         if (num_tl_resources > 0) {
             /* List of memory type MDs */
-            mem_type_bitmap = context->tl_mds[md_index].attr.cap.detect_mem_types;
+            mem_type_bitmap = context->tl_mds[md_index].attr.detect_mem_types;
             if (~mem_type_mask & mem_type_bitmap) {
                 context->mem_type_detect_mds[context->num_mem_type_detect_mds] = md_index;
                 ++context->num_mem_type_detect_mds;
@@ -1385,13 +1386,13 @@ static ucs_status_t ucp_add_component_resources(ucp_context_h context,
             }
 
             md_attr = &context->tl_mds[md_index].attr;
-            if (md_attr->cap.flags & UCT_MD_FLAG_REG) {
+            if (md_attr->flags & UCT_MD_FLAG_REG) {
                 ucs_memory_type_for_each(mem_type) {
-                    if (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
+                    if (md_attr->reg_mem_types & UCS_BIT(mem_type)) {
                         context->reg_md_map[mem_type] |= UCS_BIT(md_index);
                     }
 
-                    if (md_attr->cap.cache_mem_types & UCS_BIT(mem_type)) {
+                    if (md_attr->cache_mem_types & UCS_BIT(mem_type)) {
                         context->cache_md_map[mem_type] |= UCS_BIT(md_index);
                     }
                 }
@@ -2218,7 +2219,7 @@ void ucp_context_get_mem_access_tls(ucp_context_h context,
                                     ucs_memory_type_t mem_type,
                                     ucp_tl_bitmap_t *tl_bitmap)
 {
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
     ucp_md_index_t md_index;
     ucp_rsc_index_t tl_id;
 
@@ -2226,7 +2227,7 @@ void ucp_context_get_mem_access_tls(ucp_context_h context,
     UCS_BITMAP_FOR_EACH_BIT(context->tl_bitmap, tl_id) {
         md_index = context->tl_rscs[tl_id].md_index;
         md_attr  = &context->tl_mds[md_index].attr;
-        if (md_attr->cap.access_mem_types & UCS_BIT(mem_type)) {
+        if (md_attr->access_mem_types & UCS_BIT(mem_type)) {
             UCS_BITMAP_SET(*tl_bitmap, tl_id);
         }
     }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -243,7 +243,7 @@ typedef struct ucp_tl_md {
     /**
      * Memory domain attributes
      */
-    uct_md_attr_t          attr;
+    uct_md_attr_v2_t       attr;
 
     /**
      * Flags mask parameter for @ref uct_md_mkey_pack_v2

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1818,7 +1818,7 @@ static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,
     ucp_lane_index_t lane;
     ucp_rsc_index_t rsc_index;
     ucp_md_index_t md_index;
-    uct_md_attr_t *md_attr;
+    uct_md_attr_v2_t *md_attr;
     uct_iface_attr_t *iface_attr;
     ucp_worker_iface_t *wiface;
     uct_perf_attr_t perf_attr;
@@ -1841,7 +1841,7 @@ static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,
         if (!(md_map & UCS_BIT(md_index))) {
             md_map |= UCS_BIT(md_index);
             md_attr = &context->tl_mds[md_index].attr;
-            if (md_attr->cap.flags & UCT_MD_FLAG_REG) {
+            if (md_attr->flags & UCT_MD_FLAG_REG) {
                 params->reg_growth   += md_attr->reg_cost.m;
                 params->reg_overhead += md_attr->reg_cost.c;
                 params->overhead     += iface_attr->overhead;
@@ -1962,7 +1962,7 @@ ucp_ep_config_calc_rma_zcopy_thresh(ucp_worker_t *worker,
     ucp_context_h context = worker->context;
     double bcopy_bw       = context->config.ext.bcopy_bw;
     ucp_ep_thresh_params_t rma;
-    uct_md_attr_t *md_attr;
+    uct_md_attr_v2_t *md_attr;
     double numerator, denominator;
     double reg_overhead, reg_growth;
     ucs_status_t status;
@@ -1977,7 +1977,7 @@ ucp_ep_config_calc_rma_zcopy_thresh(ucp_worker_t *worker,
     }
 
     md_attr = &context->tl_mds[config->md_index[rma_lanes[0]]].attr;
-    if (md_attr->cap.flags & UCT_MD_FLAG_NEED_MEMH) {
+    if (md_attr->flags & UCT_MD_FLAG_NEED_MEMH) {
         reg_overhead = rma.reg_overhead;
         reg_growth   = rma.reg_growth;
     } else {
@@ -2024,8 +2024,9 @@ static void ucp_ep_config_init_short_thresh(ucp_memtype_thresh_t *thresh)
 
 static ucs_status_t ucp_ep_config_set_am_rndv_thresh(
         ucp_worker_h worker, uct_iface_attr_t *iface_attr,
-        uct_md_attr_t *md_attr, ucp_ep_config_t *config, size_t min_rndv_thresh,
-        size_t max_rndv_thresh, ucp_rndv_thresh_t *thresh)
+        uct_md_attr_v2_t *md_attr, ucp_ep_config_t *config,
+        size_t min_rndv_thresh, size_t max_rndv_thresh,
+        ucp_rndv_thresh_t *thresh)
 {
     ucp_context_h context = worker->context;
     size_t rndv_thresh, rndv_local_thresh, min_thresh;
@@ -2128,7 +2129,7 @@ static void ucp_ep_config_set_memtype_thresh(ucp_memtype_thresh_t *max_eager_sho
  * a caller of this function should suppress this false-positive warning */
 static void
 ucp_ep_config_rndv_zcopy_max_bw_update(ucp_context_t *context,
-                                       const uct_md_attr_t *md_attr,
+                                       const uct_md_attr_v2_t *md_attr,
                                        const uct_iface_attr_t *iface_attr,
                                        uint64_t cap_flag,
                                        double max_bw[UCS_MEMORY_TYPE_LAST])
@@ -2141,7 +2142,7 @@ ucp_ep_config_rndv_zcopy_max_bw_update(ucp_context_t *context,
     }
 
     bw = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth);
-    ucs_for_each_bit(mem_type_index, md_attr->cap.reg_mem_types) {
+    ucs_for_each_bit(mem_type_index, md_attr->reg_mem_types) {
         ucs_assert(mem_type_index < UCS_MEMORY_TYPE_LAST);
         max_bw[mem_type_index] = ucs_max(max_bw[mem_type_index], bw);
     }
@@ -2150,7 +2151,7 @@ ucp_ep_config_rndv_zcopy_max_bw_update(ucp_context_t *context,
 static void
 ucp_ep_config_rndv_zcopy_set(ucp_context_t *context, uint64_t cap_flag,
                              ucp_lane_index_t lane,
-                             const uct_md_attr_t *md_attr,
+                             const uct_md_attr_v2_t *md_attr,
                              const uct_iface_attr_t *iface_attr,
                              double max_bw[UCS_MEMORY_TYPE_LAST],
                              ucp_ep_rndv_zcopy_config_t *rndv_zcopy,
@@ -2174,7 +2175,7 @@ ucp_ep_config_rndv_zcopy_set(ucp_context_t *context, uint64_t cap_flag,
         max = iface_attr->cap.put.max_zcopy;
     }
 
-    ucs_for_each_bit(mem_type_index, md_attr->cap.reg_mem_types) {
+    ucs_for_each_bit(mem_type_index, md_attr->reg_mem_types) {
         ucs_assert(mem_type_index < UCS_MEMORY_TYPE_LAST);
         scale = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth) /
                 max_bw[mem_type_index];
@@ -2244,7 +2245,7 @@ ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
                          size_t adjust_min_val, size_t max_seg_size)
 {
     ucp_context_t *context = worker->context;
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
     uct_iface_attr_t *iface_attr;
     size_t it;
     size_t zcopy_thresh;
@@ -2261,8 +2262,8 @@ ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
 
     md_attr = &context->tl_mds[context->tl_rscs[rsc_index].md_index].attr;
     if (!(iface_attr->cap.flags & zcopy_flag) ||
-        ((md_attr->cap.flags & UCT_MD_FLAG_NEED_MEMH) &&
-         !(md_attr->cap.flags & UCT_MD_FLAG_REG))) {
+        ((md_attr->flags & UCT_MD_FLAG_NEED_MEMH) &&
+         !(md_attr->flags & UCT_MD_FLAG_REG))) {
         return;
     }
 
@@ -2292,7 +2293,7 @@ ucp_ep_config_init_attrs(ucp_worker_t *worker, ucp_rsc_index_t rsc_index,
     ucs_memory_type_for_each(mem_type) {
         if (UCP_MEM_IS_HOST(mem_type)) {
             config->mem_type_zcopy_thresh[mem_type] = config->zcopy_thresh[0];
-        } else if (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
+        } else if (md_attr->reg_mem_types & UCS_BIT(mem_type)) {
             config->mem_type_zcopy_thresh[mem_type] = mem_type_zcopy_thresh;
         }
     }
@@ -2335,7 +2336,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     ucp_lane_index_t put_zcopy_lane_count;
     ucp_ep_rma_config_t *rma_config;
     uct_iface_attr_t *iface_attr;
-    uct_md_attr_t *md_attr;
+    uct_md_attr_v2_t *md_attr;
     ucs_memory_type_t mem_type;
     ucp_rsc_index_t rsc_index;
     ucp_lane_index_t lane, i;
@@ -2433,7 +2434,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         }
 
         md_attr = &context->tl_mds[config->md_index[lane]].attr;
-        if (!ucs_test_all_flags(md_attr->cap.flags,
+        if (!ucs_test_all_flags(md_attr->flags,
                                 UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_MEMH)) {
             continue;
         }
@@ -2513,7 +2514,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     if (key->rkey_ptr_lane != UCP_NULL_LANE) {
         lane      = key->rkey_ptr_lane;
         md_attr   = &context->tl_mds[config->md_index[lane]].attr;
-        ucs_assert_always(md_attr->cap.flags & UCT_MD_FLAG_RKEY_PTR);
+        ucs_assert_always(md_attr->flags & UCT_MD_FLAG_RKEY_PTR);
 
         config->rndv.rkey_ptr_dst_mds =
                 UCS_BIT(config->key.lanes[lane].dst_md_index);

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -154,7 +154,8 @@ static inline uct_md_h ucp_ep_md(ucp_ep_h ep, ucp_lane_index_t lane)
     return context->tl_mds[ucp_ep_md_index(ep, lane)].md;
 }
 
-static inline const uct_md_attr_t* ucp_ep_md_attr(ucp_ep_h ep, ucp_lane_index_t lane)
+static inline const uct_md_attr_v2_t* ucp_ep_md_attr(ucp_ep_h ep,
+                                                     ucp_lane_index_t lane)
 {
     ucp_context_h context = ep->worker->context;
     return &context->tl_mds[ucp_ep_md_index(ep, lane)].attr;

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -345,7 +345,7 @@ static ucp_md_map_t ucp_request_get_invalidation_map(ucp_request_t *req)
         if (!ucp_ep_is_lane_p2p(ep, lane)) {
             ucs_assert(ucp_ep_get_iface_attr(ep, lane)->cap.flags &
                        UCT_IFACE_FLAG_GET_ZCOPY);
-            ucs_assert(ucp_ep_md_attr(ep, lane)->cap.flags &
+            ucs_assert(ucp_ep_md_attr(ep, lane)->flags &
                        UCT_MD_FLAG_INVALIDATE);
             inv_map |= UCS_BIT(ucp_ep_md_index(ep, lane));
         }

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -527,13 +527,11 @@ ucp_request_send_buffer_reg_lane_check(ucp_request_t *req, ucp_lane_index_t lane
 {
     ucp_md_map_t md_map;
 
-    if (!(ucp_ep_md_attr(req->send.ep,
-                         lane)->cap.flags & UCT_MD_FLAG_NEED_MEMH)) {
+    if (!(ucp_ep_md_attr(req->send.ep, lane)->flags & UCT_MD_FLAG_NEED_MEMH)) {
         return UCS_OK;
     }
 
-    ucs_assert(ucp_ep_md_attr(req->send.ep,
-                              lane)->cap.flags & UCT_MD_FLAG_REG);
+    ucs_assert(ucp_ep_md_attr(req->send.ep, lane)->flags & UCT_MD_FLAG_REG);
     md_map = UCS_BIT(ucp_ep_md_index(req->send.ep, lane)) | prev_md_map;
     return ucp_request_send_buffer_reg(req, md_map, uct_flags);
 }

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -609,7 +609,7 @@ ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
     ucp_md_index_t dst_md_index;
     ucp_lane_index_t lane;
     ucp_md_index_t md_index;
-    uct_md_attr_t *md_attr;
+    uct_md_attr_v2_t *md_attr;
     uint64_t mem_types;
     uint8_t rkey_index;
     int prio;
@@ -626,17 +626,17 @@ ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
         md_attr  = &context->tl_mds[md_index].attr;
 
         if ((md_index != UCP_NULL_RESOURCE) &&
-            (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY)))
+            (!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY)))
         {
             /* Lane does not need rkey, can use the lane with invalid rkey  */
-            if (!rkey || ((md_attr->cap.access_mem_types & UCS_BIT(mem_type)) &&
+            if (!rkey || ((md_attr->access_mem_types & UCS_BIT(mem_type)) &&
                           (mem_type == rkey->mem_type))) {
                 *uct_rkey_p = UCT_INVALID_RKEY;
                 return lane;
             }
         }
 
-        mem_types = md_attr->cap.reg_mem_types | md_attr->cap.alloc_mem_types;
+        mem_types = md_attr->reg_mem_types | md_attr->alloc_mem_types;
         if ((md_index != UCP_NULL_RESOURCE) && !(mem_types & UCS_BIT(mem_type))) {
             continue;
         }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1547,7 +1547,7 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
     double score, best_score;
     ucp_md_index_t md_index;
     ucp_worker_iface_t *wiface;
-    uct_md_attr_t *md_attr;
+    uct_md_attr_v2_t *md_attr;
     uint8_t priority, best_priority;
     ucp_tl_iface_atomic_flags_t atomic;
 
@@ -1575,7 +1575,7 @@ static void ucp_worker_init_device_atomics(ucp_worker_h worker)
         md_attr    = &context->tl_mds[md_index].attr;
         iface_attr = &wiface->attr;
 
-        if (!(md_attr->cap.flags & UCT_MD_FLAG_REG) ||
+        if (!(md_attr->flags & UCT_MD_FLAG_REG) ||
             !ucs_test_all_flags(iface_attr->cap.flags, iface_cap_flags)                        ||
             !ucs_test_all_flags(iface_attr->cap.atomic32.op_flags, atomic.atomic32.op_flags)   ||
             !ucs_test_all_flags(iface_attr->cap.atomic32.fop_flags, atomic.atomic32.fop_flags) ||

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -222,11 +222,11 @@ void ucp_dt_iov_copy_uct(ucp_context_h context, uct_iov_t *iov, size_t *iovcnt,
                          size_t length_max, ucp_md_index_t md_index,
                          ucp_mem_desc_t *mdesc)
 {
-    uint64_t md_flags = context->tl_mds[md_index].attr.cap.flags;
+    uint64_t md_flags = context->tl_mds[md_index].attr.flags;
     size_t length_it  = 0;
     ucp_md_index_t memh_index;
 
-    ucs_assert((context->tl_mds[md_index].attr.cap.flags & UCT_MD_FLAG_REG) ||
+    ucs_assert((context->tl_mds[md_index].attr.flags & UCT_MD_FLAG_REG) ||
                !(md_flags & UCT_MD_FLAG_NEED_MEMH));
 
     switch (datatype & UCP_DATATYPE_CLASS_MASK) {

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -385,7 +385,7 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
     const ucp_proto_select_param_t *select_param = params->select_param;
     const uct_iface_attr_t *iface_attr;
     ucp_lane_index_t lane, num_lanes;
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
     ucp_rsc_index_t rsc_index;
     ucp_md_index_t md_index;
     ucp_lane_map_t lane_map;
@@ -460,16 +460,16 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
 
         /* Check memory registration capabilities for zero-copy case */
         if (flags & UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY) {
-            if (md_attr->cap.flags & UCT_MD_FLAG_NEED_MEMH) {
+            if (md_attr->flags & UCT_MD_FLAG_NEED_MEMH) {
                 /* Memory domain must support registration on the relevant
                  * memory type */
-                if (!(md_attr->cap.flags & UCT_MD_FLAG_REG) ||
-                    !(md_attr->cap.reg_mem_types & UCS_BIT(select_param->mem_type))) {
+                if (!(md_attr->flags & UCT_MD_FLAG_REG) ||
+                    !(md_attr->reg_mem_types & UCS_BIT(select_param->mem_type))) {
                     ucs_trace("%s: no reg of mem type %s", lane_desc,
                               ucs_memory_type_names[select_param->mem_type]);
                     continue;
                 }
-            } else if (!(md_attr->cap.access_mem_types &
+            } else if (!(md_attr->access_mem_types &
                          UCS_BIT(select_param->mem_type))) {
                 /*
                  * Memory domain which does not require a registration for zero
@@ -489,7 +489,7 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
                 goto out;
             }
 
-            if (((md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY) ||
+            if (((md_attr->flags & UCT_MD_FLAG_NEED_RKEY) ||
                  (flags & UCP_PROTO_COMMON_INIT_FLAG_RKEY_PTR)) &&
                 !(rkey_config_key->md_map &
                   UCS_BIT(ep_config_key->lanes[lane].dst_md_index))) {
@@ -500,8 +500,8 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
                 continue;
             }
 
-            if (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY) &&
-                !(md_attr->cap.access_mem_types &
+            if (!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
+                !(md_attr->access_mem_types &
                   UCS_BIT(rkey_config_key->mem_type))) {
                 /* Remote memory domain without remote key must be able to
                  * access relevant memory type */
@@ -533,7 +533,7 @@ ucp_proto_common_reg_md_map(const ucp_proto_common_init_params_t *params,
 {
     ucp_context_h context                        = params->super.worker->context;
     const ucp_proto_select_param_t *select_param = params->super.select_param;
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
     ucp_md_index_t md_index;
     ucp_md_map_t reg_md_map;
     ucp_lane_index_t lane;
@@ -551,9 +551,9 @@ ucp_proto_common_reg_md_map(const ucp_proto_common_init_params_t *params,
         /* Register if the memory domain support registration for the relevant
            memory type, and needs a local memory handle for zero-copy
            communication */
-        if (ucs_test_all_flags(md_attr->cap.flags,
+        if (ucs_test_all_flags(md_attr->flags,
                                UCT_MD_FLAG_NEED_MEMH | UCT_MD_FLAG_REG) &&
-            (md_attr->cap.reg_mem_types & UCS_BIT(select_param->mem_type))) {
+            (md_attr->reg_mem_types & UCS_BIT(select_param->mem_type))) {
             reg_md_map |= UCS_BIT(md_index);
         }
     }

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -328,7 +328,7 @@ void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,
 {
     ucp_context_h context = params->super.worker->context;
     ucp_proto_perf_node_t *perf_node;
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
     ucp_md_index_t md_index;
     const char *md_name;
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -25,7 +25,7 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
     const ucp_ep_config_key_t *ep_config_key = params->super.super.ep_config_key;
     ucp_rsc_index_t mem_sys_dev, ep_sys_dev;
     const uct_iface_attr_t *iface_attr;
-    const uct_md_attr_t *md_attr;
+    const uct_md_attr_v2_t *md_attr;
     ucp_md_index_t md_index;
     ucp_lane_index_t lane;
     ucs_status_t status;
@@ -52,7 +52,7 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
         md_attr    = &worker->context->tl_mds[md_index].attr;
 
         /* Check the lane supports get_zcopy or rkey_ptr */
-        if (!(md_attr->cap.flags & UCT_MD_FLAG_RKEY_PTR) &&
+        if (!(md_attr->flags & UCT_MD_FLAG_RKEY_PTR) &&
             !(iface_attr->cap.flags &
               (UCT_IFACE_FLAG_GET_ZCOPY | UCT_IFACE_FLAG_PUT_ZCOPY))) {
             continue;
@@ -61,8 +61,8 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
         /* Check the memory domain requires remote key, and capable of
          * registering the memory type
          */
-        if (!(md_attr->cap.flags & UCT_MD_FLAG_NEED_RKEY) ||
-            !(md_attr->cap.reg_mem_types & UCS_BIT(params->mem_info.type))) {
+        if (!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) ||
+            !(md_attr->reg_mem_types & UCS_BIT(params->mem_info.type))) {
             continue;
         }
 

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -549,7 +549,7 @@ ucs_status_t ucp_tag_offload_sw_rndv(uct_pending_req_t *self)
     ucs_assert((UCP_DT_IS_CONTIG(req->send.datatype) &&
                (req->send.length > ucp_ep_config(ep)->tag.offload.max_rndv_zcopy)) ||
                !UCP_DT_IS_CONTIG(req->send.datatype) ||
-               !(ep->worker->context->tl_mds[ucp_ep_md_index(ep, req->send.lane)].attr.cap.
+               !(ep->worker->context->tl_mds[ucp_ep_md_index(ep, req->send.lane)].attr.
                  reg_mem_types & UCS_BIT(req->send.mem_type)) ||
                ep->worker->context->config.ext.tm_sw_rndv);
 
@@ -636,10 +636,10 @@ void ucp_tag_offload_cancel_rndv(ucp_request_t *req)
 ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq,
                                         const ucp_request_param_t *param)
 {
-    ucp_ep_t      *ep      = sreq->send.ep;
-    ucp_context_t *context = ep->worker->context;
-    ucp_md_index_t mdi     = ucp_ep_md_index(ep, sreq->send.lane);
-    uct_md_attr_t *md_attr = &context->tl_mds[mdi].attr;
+    ucp_ep_t      *ep         = sreq->send.ep;
+    ucp_context_t *context    = ep->worker->context;
+    ucp_md_index_t mdi        = ucp_ep_md_index(ep, sreq->send.lane);
+    uct_md_attr_v2_t *md_attr = &context->tl_mds[mdi].attr;
     ucs_status_t status;
 
     /* should be set by ucp_tag_send_req_init() */
@@ -648,7 +648,7 @@ ucs_status_t ucp_tag_offload_start_rndv(ucp_request_t *sreq,
     if (UCP_DT_IS_CONTIG(sreq->send.datatype) &&
         !context->config.ext.tm_sw_rndv       &&
         (sreq->send.length <= ucp_ep_config(ep)->tag.offload.max_rndv_zcopy) &&
-        (md_attr->cap.reg_mem_types & UCS_BIT(sreq->send.mem_type))) {
+        (md_attr->reg_mem_types & UCS_BIT(sreq->send.mem_type))) {
         ucp_request_send_state_reset(sreq, ucp_tag_offload_rndv_zcopy_completion,
                                      UCP_REQUEST_SEND_PROTO_RNDV_GET);
 

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -1188,7 +1188,7 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
 
         /* MD index */
         md_index      = context->tl_rscs[dev->rsc_index].md_index;
-        md_flags      = context->tl_mds[md_index].attr.cap.flags &
+        md_flags      = context->tl_mds[md_index].attr.flags &
                             md_flags_pack_mask;
         ptr           = ucp_address_pack_md_info(
                             ptr, UCS_BITMAP_IS_ZERO_INPLACE(&dev_tl_bitmap),

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -415,7 +415,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     char tls_info[256];
     char *p, *endp;
     uct_iface_attr_t *iface_attr;
-    uct_md_attr_t *md_attr;
+    uct_md_attr_v2_t *md_attr;
     int is_reachable;
     double score;
     uint8_t priority;
@@ -513,10 +513,10 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
         reg_mem_types = ucp_wireup_select_reg_mem_types(context, md_index);
 
         /* Check that local md and interface satisfy the criteria */
-        if (!ucp_wireup_check_flags(resource, md_attr->cap.flags,
+        if (!ucp_wireup_check_flags(resource, md_attr->flags,
                                     local_md_flags, criteria->title,
                                     ucp_wireup_md_flags, p, endp - p) ||
-            !ucp_wireup_check_flags(resource, md_attr->cap.alloc_mem_types,
+            !ucp_wireup_check_flags(resource, md_attr->alloc_mem_types,
                                     criteria->alloc_mem_types, criteria->title,
                                     ucs_memory_type_names, p, endp - p) ||
             !ucp_wireup_check_flags(resource, reg_mem_types,
@@ -971,7 +971,7 @@ static uint64_t ucp_ep_get_context_features(const ucp_ep_h ep)
 }
 
 static double ucp_wireup_rma_score_func(const ucp_worker_iface_t *wiface,
-                                        const uct_md_attr_t *md_attr,
+                                        const uct_md_attr_v2_t *md_attr,
                                         const ucp_address_entry_t *remote_addr,
                                         void *arg)
 {
@@ -998,7 +998,7 @@ static void ucp_wireup_fill_peer_err_criteria(ucp_wireup_criteria_t *criteria,
 }
 
 static double ucp_wireup_aux_score_func(const ucp_worker_iface_t *wiface,
-                                        const uct_md_attr_t *md_attr,
+                                        const uct_md_attr_v2_t *md_attr,
                                         const ucp_address_entry_t *remote_addr,
                                         void *arg)
 {
@@ -1142,7 +1142,7 @@ ucp_wireup_add_rma_lanes(const ucp_wireup_select_params_t *select_params,
 }
 
 double ucp_wireup_amo_score_func(const ucp_worker_iface_t *wiface,
-                                 const uct_md_attr_t *md_attr,
+                                 const uct_md_attr_v2_t *md_attr,
                                  const ucp_address_entry_t *remote_addr,
                                  void *arg)
 {
@@ -1198,7 +1198,7 @@ ucp_wireup_add_amo_lanes(const ucp_wireup_select_params_t *select_params,
 }
 
 static double ucp_wireup_am_score_func(const ucp_worker_iface_t *wiface,
-                                       const uct_md_attr_t *md_attr,
+                                       const uct_md_attr_v2_t *md_attr,
                                        const ucp_address_entry_t *remote_addr,
                                        void *arg)
 {
@@ -1249,7 +1249,7 @@ ucp_wireup_iface_avail_bandwidth(const ucp_worker_iface_t *wiface,
 
 static double
 ucp_wireup_rma_bw_score_func(const ucp_worker_iface_t *wiface,
-                             const uct_md_attr_t *md_attr,
+                             const uct_md_attr_v2_t *md_attr,
                              const ucp_address_entry_t *remote_addr,
                              void *arg)
 {
@@ -1384,7 +1384,7 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
 
 static double
 ucp_wireup_am_bw_score_func(const ucp_worker_iface_t *wiface,
-                            const uct_md_attr_t *md_attr,
+                            const uct_md_attr_v2_t *md_attr,
                             const ucp_address_entry_t *remote_addr,
                             void *arg)
 {
@@ -1855,7 +1855,7 @@ ucp_wireup_select_params_init(ucp_wireup_select_params_t *select_params,
 
 static double
 ucp_wireup_keepalive_score_func(const ucp_worker_iface_t *wiface,
-                                const uct_md_attr_t *md_attr,
+                                const uct_md_attr_v2_t *md_attr,
                                 const ucp_address_entry_t *remote_addr,
                                 void *arg)
 {
@@ -2129,7 +2129,7 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
 
         /* Pack remote key only if needed for RMA.
          * FIXME a temporary workaround to prevent the ugni uct from using rndv. */
-        if ((context->tl_mds[md_index].attr.cap.flags & UCT_MD_FLAG_NEED_RKEY) &&
+        if ((context->tl_mds[md_index].attr.flags & UCT_MD_FLAG_NEED_RKEY) &&
             !(strstr(context->tl_rscs[rsc_index].tl_rsc.tl_name, "ugni"))) {
             key->rma_bw_md_map |= UCS_BIT(md_index);
         }

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -88,7 +88,7 @@ typedef struct {
      * @return Transport score, the higher the better.
      */
     double                      (*calc_score)(const ucp_worker_iface_t *wiface,
-                                              const uct_md_attr_t *md_attr,
+                                              const uct_md_attr_v2_t *md_attr,
                                               const ucp_address_entry_t *remote_addr,
                                               void *arg);
 
@@ -142,7 +142,7 @@ ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
                                 ucp_wireup_select_info_t *select_info);
 
 double ucp_wireup_amo_score_func(const ucp_worker_iface_t *wiface,
-                                 const uct_md_attr_t *md_attr,
+                                 const uct_md_attr_v2_t *md_attr,
                                  const ucp_address_entry_t *remote_addr,
                                  void *arg);
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -54,11 +54,11 @@ ucp_md_map_t test_ucp_proto::get_md_map(ucs_memory_type_t mem_type)
 
     for (ucp_md_index_t md_index = 0; md_index < context()->num_mds;
          ++md_index) {
-        const uct_md_attr_t *md_attr = &context()->tl_mds[md_index].attr;
-        if ((md_attr->cap.flags & UCT_MD_FLAG_REG) &&
-            (md_attr->cap.reg_mem_types & UCS_BIT(mem_type)) &&
+        const uct_md_attr_v2_t *md_attr = &context()->tl_mds[md_index].attr;
+        if ((md_attr->flags & UCT_MD_FLAG_REG) &&
+            (md_attr->reg_mem_types & UCS_BIT(mem_type)) &&
             /* ucp_datatype_iter_mem_reg() always goes directly to registration cache */
-            (md_attr->cap.cache_mem_types & UCS_BIT(mem_type)) &&
+            (md_attr->cache_mem_types & UCS_BIT(mem_type)) &&
             (ucs_popcount(md_map) < UCP_MAX_OP_MDS)) {
             md_map |= UCS_BIT(md_index);
         }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -886,7 +886,7 @@ protected:
                 /* RNDV lanes should be selected if transport supports GET/PUT
                  * Zcopy and: */
                 (/* - either memory invalidation can be done on its MD */
-                 (ucp_ep_md_attr(ep, lane_idx)->cap.flags &
+                 (ucp_ep_md_attr(ep, lane_idx)->flags &
                   UCT_MD_FLAG_INVALIDATE) ||
                  /* - or CONNECT_TO_EP connection establishment mode is used */
                  (ucp_ep_is_lane_p2p(ep, lane_idx)))) {

--- a/test/gtest/ucp/test_ucp_stream.cc
+++ b/test/gtest/ucp/test_ucp_stream.cc
@@ -572,9 +572,9 @@ UCS_TEST_P(test_ucp_stream, send_exp_recv_32) {
 
 UCS_TEST_P(test_ucp_stream, send_exp_recv_64) {
     ucp_datatype_t datatype = ucp_dt_make_contig(sizeof(uint64_t));
-    const uct_md_attr_t *md_attr = ucp_ep_md_attr(sender().ep(), 0);
+    const uct_md_attr_v2_t *md_attr = ucp_ep_md_attr(sender().ep(), 0);
 
-    if (has_transport("shm") && (md_attr->cap.max_alloc < UCS_GBYTE)) {
+    if (has_transport("shm") && (md_attr->max_alloc < UCS_GBYTE)) {
         UCS_TEST_SKIP_R("Not enough shared memory");
     }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -997,14 +997,15 @@ public:
     }
 
     bool check_scalable_tls(const ucp_worker_h worker, size_t est_num_eps) {
+        ucp_context_h context = worker->context;
         ucp_rsc_index_t rsc_index;
 
         UCS_BITMAP_FOR_EACH_BIT(worker->context->tl_bitmap, rsc_index) {
-            ucp_md_index_t md_index      = worker->context->tl_rscs[rsc_index].md_index;
-            const uct_md_attr_t *md_attr = &worker->context->tl_mds[md_index].attr;
+            ucp_md_index_t md_index         = context->tl_rscs[rsc_index].md_index;
+            const uct_md_attr_v2_t *md_attr = &context->tl_mds[md_index].attr;
 
-            if ((worker->context->tl_rscs[rsc_index].flags & UCP_TL_RSC_FLAG_AUX) ||
-                (md_attr->cap.flags & UCT_MD_FLAG_SOCKADDR) ||
+            if ((context->tl_rscs[rsc_index].flags & UCP_TL_RSC_FLAG_AUX) ||
+                (md_attr->flags & UCT_MD_FLAG_SOCKADDR) ||
                 (worker->context->tl_rscs[rsc_index].tl_rsc.dev_type == UCT_DEVICE_TYPE_ACC)) {
                 // Skip TLs for wireup and CM and acceleration TLs
                 continue;

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1237,8 +1237,8 @@ void ucp_test::disable_keepalive()
 
 bool ucp_test::check_reg_mem_types(const entity& e, ucs_memory_type_t mem_type) {
     for (ucp_lane_index_t lane = 0; lane < ucp_ep_num_lanes(e.ep()); lane++) {
-        const uct_md_attr_t* attr = ucp_ep_md_attr(e.ep(), lane);
-        if (attr->cap.reg_mem_types & UCS_BIT(mem_type)) {
+        const uct_md_attr_v2_t* attr = ucp_ep_md_attr(e.ep(), lane);
+        if (attr->reg_mem_types & UCS_BIT(mem_type)) {
             return true;
         }
     }


### PR DESCRIPTION
## What

Use `uct_md_query_v2` instead of `uct_md_query`.

## Why ?

After merging #8428 UCP could use `uct_md_query_v2` instead of `uct_md_query` to make that new available MD attributes will be available.

## How ?

1. Replace all places where `uct_md_attr_t` is used by `uct_md_attr_v2_t`.
2. Query MD attributes by means of `uct_md_query_v2` instead of `uct_md_query`.