### PR TITLE
TEST/SOCKADDR: Add missing <cstdint> include for GCC 13

### DIFF
--- a/test/apps/sockaddr/sa_util.h
+++ b/test/apps/sockaddr/sa_util.h
@@ -7,6 +7,7 @@
 #ifndef SA_UTIL_H_
 #define SA_UTIL_H_
 
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Closes: https://github.com/openucx/ucx/issues/8347
Signed-off-by: Sam James <sam@gentoo.org>

## What
Add a missing include for `uint32_t`.

## Why ?
Fixes a build failure with GCC 13, as transient internal includes were changed in the compiler.