### PR TITLE
GTEST: skip not implemented UCP/proto_v2

### DIFF
--- a/test/gtest/common/test_perf.h
+++ b/test/gtest/common/test_perf.h
@@ -15,6 +15,17 @@
 class test_perf {
 protected:
     struct test_spec {
+        bool is_amo() const {
+            switch (command) {
+            case UCX_PERF_CMD_ADD:
+            case UCX_PERF_CMD_FADD:
+            case UCX_PERF_CMD_SWAP:
+            case UCX_PERF_CMD_CSWAP:
+                return true;
+            default:
+                return false;
+            }
+        }
         const char             *title;
         const char             *units;
         ucx_perf_api_t         api;

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2480,6 +2480,11 @@ protected:
          * packing */
         ASSERT_FALSE(send_prereg_memh & recv_prereg_memh);
 
+        if ((send_prereg_memh || recv_prereg_memh) &&
+            m_ucp_config->ctx.proto_enable) {
+            UCS_TEST_SKIP_R("FIXME: proto_v2 does not support prereh memh");
+        }
+
         /* send multiple messages to test the protocol both before and after
          * connection establishment */
         for (int i = 0; i < num_iters; i++) {

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -561,6 +561,10 @@ UCS_TEST_P(test_ucp_tag_nbx, rndv_prereg, "RNDV_THRESH=0")
 
 UCS_TEST_P(test_ucp_tag_nbx, fallback)
 {
+    if (m_ucp_config->ctx.proto_enable) {
+        UCS_TEST_SKIP_R("FIXME: fallback is not implemented in proto_v2");
+    }
+
     /* allocate read-only pages - it force ibv_reg_mr() failure */
     void *send_buffer = mmap(NULL, MSG_SIZE, PROT_READ,
                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -716,6 +716,10 @@ public:
 
     void init()
     {
+        if (m_ucp_config->ctx.proto_enable) {
+            UCS_TEST_SKIP_R("FIXME: RNDV is not implemented in HW_TM/proto_v2");
+        }
+
         stats_activate();
         test_ucp_tag_offload::init(); // No need for multi::init()
     }
@@ -751,7 +755,7 @@ public:
     {
         uint64_t cnt;
         cnt = UCS_STATS_GET_COUNTER(worker_offload_stats(receiver()), rx_cntr);
-        EXPECT_EQ(val, cnt);
+        EXPECT_EQ(val, cnt) << "RX counter";
     }
 
     void wait_counter(ucs_stats_node_t *stats, uint64_t cntr,

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1049,9 +1049,9 @@ public:
     void validate_counters(unsigned tx_counter, unsigned rx_counter) {
         uint64_t cnt;
         cnt = UCS_STATS_GET_COUNTER(ep_stats(sender()), tx_counter);
-        EXPECT_EQ(1ul, cnt);
+        EXPECT_EQ(1ul, cnt) << "TX counter";
         cnt = get_rx_stat(rx_counter);
-        EXPECT_EQ(1ul, cnt);
+        EXPECT_EQ(1ul, cnt) << "RX counter";
     }
 
     bool has_xpmem() {
@@ -1078,7 +1078,7 @@ public:
         if (has_xpmem()) {
             /* rkey_ptr expected to be selected if xpmem is available */
             EXPECT_EQ(1u, rkey_ptr);
-        } else if (has_get_zcopy()) {
+        } else if (has_get_zcopy() && !m_ucp_config->ctx.proto_enable) {
             /* if any transports supports get_zcopy, expect it to be used */
             EXPECT_EQ(1u, get_zcopy);
         } else {


### PR DESCRIPTION
## What
skip not implemented UCP/proto_v2 functionality

## Why ?
missed functionality found by `UCX_PROTO_ENABLE=y`, regular testing will be covered by https://github.com/openucx/ucx/pull/8509

