### PR TITLE
UCP/API: Make memh_pack/memh_buffer_release params const

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2970,8 +2970,9 @@ typedef struct ucp_memh_pack_params {
  *
  * @return Error code as defined by @ref ucs_status_t
  */
-ucs_status_t ucp_memh_pack(ucp_mem_h memh, ucp_memh_pack_params_t *params,
-                           void **buffer_p, size_t *buffer_size_p);
+ucs_status_t
+ucp_memh_pack(ucp_mem_h memh, const ucp_memh_pack_params_t *params,
+              void **buffer_p, size_t *buffer_size_p);
 
 
 /**
@@ -3011,7 +3012,7 @@ typedef struct ucp_memh_buffer_release_params {
  *                       @ref ucp_memh_buffer_release_params_t.
  */
 void ucp_memh_buffer_release(void *buffer,
-                             ucp_memh_buffer_release_params_t *params);
+                             const ucp_memh_buffer_release_params_t *params);
 
 
 /**

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -214,7 +214,7 @@ UCS_PROFILE_FUNC(ssize_t, ucp_rkey_pack_memh,
 }
 
 static ucs_status_t
-ucp_memh_pack_internal(ucp_mem_h memh, ucp_memh_pack_params_t *params,
+ucp_memh_pack_internal(ucp_mem_h memh, const ucp_memh_pack_params_t *params,
                        int rkey_compat, void **buffer_p, size_t *buffer_size_p)
 {
     ucp_context_h context = memh->context;
@@ -273,14 +273,15 @@ out:
     return status;
 }
 
-ucs_status_t ucp_memh_pack(ucp_mem_h memh, ucp_memh_pack_params_t *params,
-                           void **buffer_p, size_t *buffer_size_p)
+ucs_status_t
+ucp_memh_pack(ucp_mem_h memh, const ucp_memh_pack_params_t *params,
+              void **buffer_p, size_t *buffer_size_p)
 {
     return ucp_memh_pack_internal(memh, params, 0, buffer_p, buffer_size_p);
 }
 
 void ucp_memh_buffer_release(void *buffer,
-                             ucp_memh_buffer_release_params_t *params)
+                             const ucp_memh_buffer_release_params_t *params)
 {
     if (buffer == &ucp_mem_dummy_buffer) {
         /* Dummy key, just return */


### PR DESCRIPTION
## What

Make `ucp_memh_pack()`'s/`ucp_memh_buffer_release()`'s `params` as `const`

## Why ?

To align with other API functions which accept `params` as `const`, e.g. `ucp_mem_map()`

## How ?


Add `const` qualifier to `params` for `ucp_memh_pack()`, `ucp_memh_pack_internal()`, `ucp_memh_buffer_release()`.