### PR TITLE
UCT/API: fixup for uct_ep_connect_to_ep_v2

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -297,6 +297,23 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief uct_ep_connect_to_ep_v2 operation fields and flags
+ * 
+ * The enumeration allows specifying which fields in @ref
+ * uct_ep_connect_to_ep_params_t are present and operation flags are used. It is
+ * used to enable backward compatibility support.
+ */
+typedef enum {
+    /** Device address length */
+    UCT_EP_CONNECT_TO_EP_PARAM_FIELD_DEVICE_ADDR_LENGTH = UCS_BIT(0),
+
+    /** Endpoint address length */
+    UCT_EP_CONNECT_TO_EP_PARAM_FIELD_EP_ADDR_LENGTH     = UCS_BIT(1)
+} uct_ep_connect_to_ep_param_field_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Endpoint attributes, capabilities and limitations.
  */
 struct uct_ep_attr {
@@ -480,9 +497,24 @@ typedef struct uct_iface_is_reachable_params {
  */
 typedef struct uct_ep_connect_to_ep_params {
     /**
-     * Reserved, must be 0.
+     * Mask of valid fields in this structure and operation flags, using
+     * bits from @ref uct_ep_connect_to_ep_param_field_t. Fields not specified
+     * in this mask will be ignored. Provides ABI compatibility with respect to
+     * adding new fields.
      */
     uint64_t                      field_mask;
+
+    /**
+     * Device address length. If not provided, the transport will assume a
+     * default minimal length according to the address buffer contents.
+     */
+    size_t                        device_addr_length;
+
+    /**
+     * Endpoint address length. If not provided, the transport will assume a
+     * default minimal length according to the address buffer contents.
+     */
+    size_t                        ep_addr_length;
 } uct_ep_connect_to_ep_params_t;
 
 
@@ -784,7 +816,6 @@ int uct_iface_is_reachable_v2(uct_iface_h iface,
  */
 ucs_status_t uct_ep_connect_to_ep_v2(uct_ep_h ep,
                                      const uct_device_addr_t *device_addr,
-                                     const uct_iface_addr_t *iface_addr,
                                      const uct_ep_addr_t *ep_addr,
                                      const uct_ep_connect_to_ep_params_t *params);
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -621,14 +621,13 @@ ucs_status_t uct_ep_connect_to_ep(uct_ep_h ep, const uct_device_addr_t *dev_addr
 
 ucs_status_t uct_ep_connect_to_ep_v2(uct_ep_h ep,
                                      const uct_device_addr_t *device_addr,
-                                     const uct_iface_addr_t *iface_addr,
                                      const uct_ep_addr_t *ep_addr,
                                      const uct_ep_connect_to_ep_params_t *params)
 {
     const uct_base_iface_t *iface = ucs_derived_of(ep->iface, uct_base_iface_t);
 
-    return iface->internal_ops->ep_connect_to_ep_v2(ep, device_addr, iface_addr,
-                                                    ep_addr, params);
+    return iface->internal_ops->ep_connect_to_ep_v2(ep, device_addr, ep_addr,
+                                                    params);
 }
 
 ucs_status_t uct_cm_client_ep_conn_notify(uct_ep_h ep)

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -251,7 +251,6 @@ typedef ucs_status_t (*uct_ep_invalidate_func_t)(uct_ep_h ep, unsigned flags);
 typedef ucs_status_t (*uct_ep_connect_to_ep_v2_func_t)(
         uct_ep_h ep,
         const uct_device_addr_t *device_addr,
-        const uct_iface_addr_t *iface_addr,
         const uct_ep_addr_t *ep_addr,
         const uct_ep_connect_to_ep_params_t *params);
 


### PR DESCRIPTION
## What
Fixed backward compatibility issue

## How ?
- due to compatibility issue updated uct_ep_connect_to_ep_v2 routine parameters
- added uct_ep_connect_to_ep_param_field_t enum to add ep_address length
- iface address will not be used in ep_connect_to_ep routine