### PR TITLE
UCT/ROCM: make rocm components compile again

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -35,7 +35,7 @@ static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
 };
 
 static ucs_status_t
-uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr_v2)
+uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
     md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
     md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -22,8 +22,7 @@ static ucs_config_field_t uct_rocm_ipc_md_config_table[] = {
     {NULL}
 };
 
-static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_t *md_attr,
-                                          uct_md_attr_v2_t *md_attr_v2)
+static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
     md_attr->rkey_packed_size = sizeof(uct_rocm_ipc_key_t);
     md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;


### PR DESCRIPTION
## What
the md_attr_v2 commit broke the rocm compilation. This commit fixes the compilation part.

Note: gtest generates even with this fix a segfault in rocm_copy/test_p2p_rma_madvise, I will investigate that later this week.

