### PR TITLE
UCP: Fix access to local mds by remote md index

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -229,10 +229,10 @@ struct ucp_ep_config_key {
      */
     ucp_md_map_t             reachable_md_map;
 
-    /* Array with popcount(reachable_md_map) elements, each entry holds the local
-     * component index to be used for unpacking remote key from each set bit in
-     * reachable_md_map */
-    ucp_rsc_index_t          *dst_md_cmpts;
+    /* Array with popcount(reachable_md_map) elements, each entry holds the
+     * local md index from each set bit in reachable_md_map. It can also be used
+     * to find relevant local component index for unpacking remote key. */
+    ucp_md_index_t           *dst_to_local_mds;
 
     /* Error handling mode */
     ucp_err_handling_mode_t  err_mode;

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -235,14 +235,25 @@ static inline const char* ucp_ep_peer_name(ucp_ep_h ep)
 #endif
 }
 
-/* get index of the local component which can reach a remote memory domain */
-static inline ucp_rsc_index_t
-ucp_ep_config_get_dst_md_cmpt(const ucp_ep_config_key_t *key,
+/* Get index of the local md which can reach a remote md */
+static inline ucp_md_index_t
+ucp_ep_config_dst_to_local_md(const ucp_ep_config_key_t *key,
                               ucp_md_index_t dst_md_index)
 {
     unsigned idx = ucs_popcount(key->reachable_md_map & UCS_MASK(dst_md_index));
 
-    return key->dst_md_cmpts[idx];
+    return key->dst_to_local_mds[idx];
+}
+
+/* Get index of the local component which can reach a remote memory domain */
+static inline ucp_rsc_index_t
+ucp_ep_config_get_dst_md_cmpt(ucp_context_h context,
+                              const ucp_ep_config_key_t *key,
+                              ucp_md_index_t dst_md_index)
+{
+    ucp_md_index_t md_index = ucp_ep_config_dst_to_local_md(key, dst_md_index);
+
+    return context->tl_mds[md_index].cmpt_index;
 }
 
 static inline int

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -458,7 +458,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
 
         ucs_assert(rkey_index < md_count);
         tl_rkey       = &rkey->tl_rkey[rkey_index];
-        cmpt_index    = ucp_ep_config_get_dst_md_cmpt(&ep_config->key,
+        cmpt_index    = ucp_ep_config_get_dst_md_cmpt(worker->context,
+                                                      &ep_config->key,
                                                       remote_md_index);
         tl_rkey->cmpt = worker->context->tl_cmpts[cmpt_index].cmpt;
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1546,7 +1546,7 @@ ucp_rndv_get_frag_rkey_ptr(ucp_worker_h worker, ucp_ep_h ep,
     ucp_md_index_t rkey_ptr_md_index = UCP_NULL_RESOURCE;
     ucp_ep_peer_mem_data_t *ppln_data;
     ucp_md_map_t md_map;
-    ucp_md_index_t md_index;
+    ucp_md_index_t md_index, dst_md_index;
     const uct_md_attr_v2_t *md_attr;
     ucp_ep_h mem_type_ep;
     ucp_lane_index_t mem_type_rma_lane;
@@ -1568,8 +1568,10 @@ ucp_rndv_get_frag_rkey_ptr(ucp_worker_h worker, ucp_ep_h ep,
     md_map          = ucp_rkey_packed_md_map(rtr_hdr + 1) &
                       ucp_ep_config(ep)->key.reachable_md_map;
 
-    ucs_for_each_bit(md_index, md_map) {
-        md_attr = &context->tl_mds[md_index].attr;
+    ucs_for_each_bit(dst_md_index, md_map) {
+        md_index = ucp_ep_config_dst_to_local_md(&ucp_ep_config(ep)->key,
+                                                 dst_md_index);
+        md_attr  = &context->tl_mds[md_index].attr;
         if ((md_attr->flags & UCT_MD_FLAG_RKEY_PTR) &&
             /* Do not use xpmem, because cuda_copy registration will fail and
              * performance will not be optimal. */


### PR DESCRIPTION
## What
Save map of remote to local md indexes in the ep config

## Why ?
To fix wrong MD index usage, when remote md index is used to get an access to the local md (e. g. in 2-stage ppln protocol). 

