### PR TITLE
GTEST/UCP: Set RCACHE_ENABLE parameter prior creating entities

### DIFF
--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -42,14 +42,15 @@ public:
         if (enable_proto()) {
             modify_config("PROTO_ENABLE", "y");
         }
+
+        if (get_variant_value() == VARIANT_NO_RCACHE) {
+            modify_config("RCACHE_ENABLE", "n");
+        }
+
         ucp_test::init();
         sender().connect(&receiver(), get_ep_params());
         if (!is_loopback()) {
             receiver().connect(&sender(), get_ep_params());
-        }
-
-        if (get_variant_value() == VARIANT_NO_RCACHE) {
-            modify_config("RCACHE_ENABLE", "n");
         }
     }
 


### PR DESCRIPTION
## What

Set `RCACHE_ENABLE` parameter prior creating entities.

## Why ?

It should be done prior creating ucp_context to apply changes.

## How ?

Move `modify_config("RCACHE_ENABLE", "n")` to be set prior calling `ucp_test::init()`.