### PR TITLE
UCT/API: Get rid of EXPORTED MKEY pack flag and add EXPORT mkey registration flag

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -754,41 +754,77 @@ enum {
  * @brief  Memory allocation/registration flags.
  */
 enum uct_md_mem_flags {
-    UCT_MD_MEM_FLAG_NONBLOCK    = UCS_BIT(0), /**< Hint to perform non-blocking
-                                                   allocation/registration: page
-                                                   mapping may be deferred until
-                                                   it is accessed by the CPU or a
-                                                   transport. */
-    UCT_MD_MEM_FLAG_FIXED       = UCS_BIT(1), /**< Place the mapping at exactly
-                                                   defined address */
-    UCT_MD_MEM_FLAG_LOCK        = UCS_BIT(2), /**< Registered memory should be
-                                                   locked. May incur extra cost for
-                                                   registration, but memory access
-                                                   is usually faster. */
-    UCT_MD_MEM_FLAG_HIDE_ERRORS = UCS_BIT(3), /**< Hide errors on memory registration.
-                                                   In some cases registration failure
-                                                   is not an error (e. g. for merged
-                                                   memory regions). */
+    /**
+     * Hint to perform non-blocking allocation/registration: page mapping may
+     * be deferred until it is accessed by the CPU or a transport.
+     */
+    UCT_MD_MEM_FLAG_NONBLOCK        = UCS_BIT(0),
 
-    /* memory access flags */
-    UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(5), /**< enable remote put access */
-    UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(6), /**< enable remote get access */
-    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(7), /**< enable remote atomic access */
-    UCT_MD_MEM_ACCESS_LOCAL_READ    = UCS_BIT(8), /**< enable local read access */
-    UCT_MD_MEM_ACCESS_LOCAL_WRITE   = UCS_BIT(9), /**< enable local write access */
+    /**
+     * Place the mapping at exactly defined address.
+     */
+    UCT_MD_MEM_FLAG_FIXED           = UCS_BIT(1),
 
-    /** enable local and remote access for all operations */
-    UCT_MD_MEM_ACCESS_ALL =  (UCT_MD_MEM_ACCESS_REMOTE_PUT|
-                              UCT_MD_MEM_ACCESS_REMOTE_GET|
-                              UCT_MD_MEM_ACCESS_REMOTE_ATOMIC|
-                              UCT_MD_MEM_ACCESS_LOCAL_READ|
-                              UCT_MD_MEM_ACCESS_LOCAL_WRITE),
+    /**
+     * Registered memory should be locked. May incur extra cost for
+     * registration, but memory access is usually faster.
+     */
+    UCT_MD_MEM_FLAG_LOCK            = UCS_BIT(2),
 
-    /** enable local and remote access for put and get operations */
-    UCT_MD_MEM_ACCESS_RMA = (UCT_MD_MEM_ACCESS_REMOTE_PUT|
-                             UCT_MD_MEM_ACCESS_REMOTE_GET|
-                             UCT_MD_MEM_ACCESS_LOCAL_READ|
-                             UCT_MD_MEM_ACCESS_LOCAL_WRITE)
+    /**
+     * Hide errors on memory registration. In some cases registration failure
+     * is not an error (e. g. for merged memory regions).
+     */
+    UCT_MD_MEM_FLAG_HIDE_ERRORS     = UCS_BIT(3),
+
+    /**
+     * The flag is used to indicate that the memory region can be accessed by
+     * another process using the same device to perform UCT operations.
+     */
+    UCT_MD_MEM_FLAG_EXPORT          = UCS_BIT(4),
+
+    /* Memory access flags */
+    /**
+     * Enable remote put access.
+     */
+    UCT_MD_MEM_ACCESS_REMOTE_PUT    = UCS_BIT(5), 
+
+    /**
+     * Enable remote get access.
+     */
+    UCT_MD_MEM_ACCESS_REMOTE_GET    = UCS_BIT(6),
+
+    /**
+     * Enable remote atomic access.
+     */
+    UCT_MD_MEM_ACCESS_REMOTE_ATOMIC = UCS_BIT(7),
+
+    /**
+     * Enable local read access.
+     */
+    UCT_MD_MEM_ACCESS_LOCAL_READ    = UCS_BIT(8),
+
+    /**
+     * Enable local write access.
+     */
+    UCT_MD_MEM_ACCESS_LOCAL_WRITE   = UCS_BIT(9),
+
+    /**
+     * Enable local and remote access for all operations.
+     */
+    UCT_MD_MEM_ACCESS_ALL           = (UCT_MD_MEM_ACCESS_REMOTE_PUT |
+                                       UCT_MD_MEM_ACCESS_REMOTE_GET |
+                                       UCT_MD_MEM_ACCESS_REMOTE_ATOMIC |
+                                       UCT_MD_MEM_ACCESS_LOCAL_READ |
+                                       UCT_MD_MEM_ACCESS_LOCAL_WRITE),
+
+    /**
+     * Enable local and remote access for put and get operations.
+     */
+    UCT_MD_MEM_ACCESS_RMA           = (UCT_MD_MEM_ACCESS_REMOTE_PUT |
+                                       UCT_MD_MEM_ACCESS_REMOTE_GET |
+                                       UCT_MD_MEM_ACCESS_LOCAL_READ |
+                                       UCT_MD_MEM_ACCESS_LOCAL_WRITE)
 };
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -281,13 +281,7 @@ typedef enum {
      * in order for @ref UCT_MD_MEM_DEREG_FLAG_INVALIDATE flag to function
      * the @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag must be set.
      */
-    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0),
-
-    /**
-     * The flag is used to indicate that the memory region can be accessed
-     * by another process using the same device to perform UCT operations.
-     */
-    UCT_MD_MKEY_PACK_FLAG_EXPORT     = UCS_BIT(1)
+    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0)
 } uct_md_mkey_pack_flags_t;
 
 
@@ -725,7 +719,7 @@ ucs_status_t uct_md_query_v2(uct_md_h md, uct_md_attr_v2_t *md_attr);
  * @param [in]  memh        Pack a remote key for this memory handle.
  * @param [in]  params      Operation parameters, see @ref
  *                          uct_md_mkey_pack_params_t.
- * @param [out] mkey_buffer Pointer to a buffer to hold the packed remote key.
+ * @param [out] mkey_buffer Pointer to a buffer to hold the packed memory key.
  *                          The size of this buffer should be at least
  *                          @ref uct_md_attr_t::rkey_packed_size or
  *                          @ref uct_md_attr_t::shared_mkey_packed_size, as


### PR DESCRIPTION
## What

This PR changes exported MKEY UCT API.

## Why ?

#8422 API changes have been merged, but some issues were found.
We need to declare that a local memory key is "exportable" when it's created. Doing it when it's packed is already too late.

1. `UCT_MD_MEM_FLAG_EXPORT` registration flag wasn't added.
2. `UCT_MD_MKEY_PACK_FLAG_EXPORT` can be removed, because `UCT_MD_MEM_FLAG_EXPORT` flag can be saved during memory key registration and used when packing memory key.
3. Description of `uct_md_mkey_pack_v2`'s `mkey_buffer` is not correct.

## How ?

1. Fix comment formatting in `enum uct_md_mem_flags`, add `UCT_MD_MEM_FLAG_EXPORT` flag.
2. Remove `CT_MD_MKEY_PACK_FLAG_EXPORT` from `uct_md_mkey_pack_flags_t` enumeration.
3. `remote` -> `memory`.