### PR TITLE
UCT/BASE: Handle exported_mkey_packed_size and global_id field in uct_md_attr_v2_copy

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -439,6 +439,10 @@ uct_md_attr_v2_copy(uct_md_attr_v2_t *dst, const uct_md_attr_v2_t *src)
                               UCT_MD_ATTR_FIELD_LOCAL_CPUS);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, component_name,
                               UCT_MD_ATTR_FIELD_COMPONENT_NAME);
+    UCT_MD_ATTR_V2_FIELD_COPY(dst, src, exported_mkey_packed_size,
+                              UCT_MD_ATTR_FIELD_EXPORTED_MKEY_PACKED_SIZE);
+    UCT_MD_ATTR_V2_FIELD_COPY(dst, src, global_id,
+                              UCT_MD_ATTR_FIELD_GLOBAL_ID);
 }
 
 static ucs_status_t uct_md_attr_v2_init(uct_md_h md, uct_md_attr_v2_t *md_attr)


### PR DESCRIPTION
## What

Handle `exported_mkey_packed_size` and `global_id` fields in `uct_md_attr_v2_copy`.

## Why ?

They should be handle to make sure copying of MD attributes from temporary attributes to user's ones work correctly in `uct_md_attr_v2`.

## How ?

Invoke `UCT_MD_ATTR_V2_FIELD_COPY` for `exported_mkey_packed_size` and `global_id` field in `uct_md_attr_v2_copy` auxiliary function.