### PR TITLE
GTEST/UCT: Use uct_md_query_v2() instead of uct_md_query()

### DIFF
--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -51,7 +51,7 @@ protected:
         return m_md;
     }
 
-    const uct_md_attr_t& md_attr() const {
+    const uct_md_attr_v2_t& md_attr() const {
         return m_md_attr;
     }
 
@@ -71,7 +71,7 @@ protected:
 private:
     ucs::handle<uct_md_config_t*> m_md_config;
     ucs::handle<uct_md_h>         m_md;
-    uct_md_attr_t                 m_md_attr;
+    uct_md_attr_v2_t              m_md_attr;
     test_md_comp_t                m_comp;
 };
 

--- a/test/gtest/uct/test_mm.cc
+++ b/test/gtest/uct/test_mm.cc
@@ -112,7 +112,7 @@ public:
 
     bool check_md_caps(uint64_t flags) {
         FOR_EACH_ENTITY(iter) {
-            if (!(ucs_test_all_flags((*iter)->md_attr().cap.flags, flags))) {
+            if (!(ucs_test_all_flags((*iter)->md_attr().flags, flags))) {
                 return false;
             }
         }
@@ -221,7 +221,7 @@ UCS_TEST_SKIP_COND_P(test_uct_mm, open_for_posix,
 UCS_TEST_SKIP_COND_P(test_uct_mm, alloc,
                      !check_md_caps(UCT_MD_FLAG_ALLOC)) {
 
-    size_t size               = ucs_min(100000u, m_e1->md_attr().cap.max_alloc);
+    size_t size               = ucs_min(100000u, m_e1->md_attr().max_alloc);
     void *address             = NULL;
     uct_md_h md_ref           = m_e1->md();
     uct_alloc_method_t method = UCT_ALLOC_METHOD_MD;
@@ -253,7 +253,7 @@ UCS_TEST_SKIP_COND_P(test_uct_mm, alloc,
 UCS_TEST_SKIP_COND_P(test_uct_mm, reg,
                      !check_md_caps(UCT_MD_FLAG_REG)) {
 
-    size_t size = ucs_min(100000u, m_e1->md_attr().cap.max_reg);
+    size_t size = ucs_min(100000u, m_e1->md_attr().max_reg);
     ucs_status_t status;
 
     std::vector<uint8_t> buffer(size);

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -165,7 +165,7 @@ void uct_p2p_mix_test::run(unsigned count) {
     if (m_avail_send_funcs.size() == 0) {
         UCS_TEST_SKIP_R("unsupported");
     }
-    if (!(sender().md_attr().cap.access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+    if (!(sender().md_attr().access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
         UCS_TEST_SKIP_R("skipping on non-host memory");
     }
 

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -94,8 +94,8 @@ public:
         size_t size = ucs_max(min, ucs_min(64ul, max));
         uint8_t mem_type_index;
 
-        ucs_assert(sender().md_attr().cap.access_mem_types != 0);
-        mem_type_index = ucs_ffs64(sender().md_attr().cap.access_mem_types);
+        ucs_assert(sender().md_attr().access_mem_types != 0);
+        mem_type_index = ucs_ffs64(sender().md_attr().access_mem_types);
 
         lbuf = new mapped_buffer(size, 0, sender(), 0, (ucs_memory_type_t)mem_type_index);
         rbuf = new mapped_buffer(size, 0, receiver(), 0, (ucs_memory_type_t)mem_type_index);

--- a/test/gtest/uct/test_zcopy_comp.cc
+++ b/test/gtest/uct/test_zcopy_comp.cc
@@ -39,7 +39,7 @@ UCS_TEST_SKIP_COND_P(test_zcopy_comp, issue1440,
     size_t size_large = ucs_min(65536ul, m_sender->iface_attr().cap.put.max_zcopy);
     ucs_assert(size_large > size_small);
 
-    if (!(m_sender->md_attr().cap.access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+    if (!(m_sender->md_attr().access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
         std::stringstream ss;
         ss << "test_zcopy_comp is not supported by " << GetParam();
         UCS_TEST_SKIP_R(ss.str());

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -152,9 +152,9 @@ void uct_p2p_test::test_xfer_multi(send_func_t send, size_t min_length,
         /* test mem type if md supports mem type
          * (or) if HOST MD can register mem type
          */
-        if (!((sender().md_attr().cap.access_mem_types & UCS_BIT(mem_type)) ||
-            ((sender().md_attr().cap.access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST)) &&
-		sender().md_attr().cap.reg_mem_types & UCS_BIT(mem_type)))) {
+        if (!((sender().md_attr().access_mem_types & UCS_BIT(mem_type)) ||
+            ((sender().md_attr().access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST)) &&
+		sender().md_attr().reg_mem_types & UCS_BIT(mem_type)))) {
             continue;
         }
         if (mem_type == UCS_MEMORY_TYPE_CUDA) {
@@ -177,7 +177,7 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
 
     /* Trim at the max allocation available. Divide by 2 for
        2 buffers + 0.5 for spare capacity */
-    max_length = ucs_min(max_length, sender().md_attr().cap.max_alloc / 2.5);
+    max_length = ucs_min(max_length, sender().md_attr().max_alloc / 2.5);
 
     /* Trim at 4.1 GB */
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -14,6 +14,7 @@
 
 #include <poll.h>
 #include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/sys/sys.h>
 #include <ucs/async/async.h>
 #include <ucs/async/pipe.h>
@@ -158,7 +159,7 @@ protected:
 
         uct_md_h md() const;
 
-        const uct_md_attr& md_attr() const;
+        const uct_md_attr_v2_t& md_attr() const;
 
         uct_worker_h worker() const;
 
@@ -226,7 +227,7 @@ protected:
 
         const resource              m_resource;
         ucs::handle<uct_md_h>       m_md;
-        uct_md_attr_t               m_md_attr;
+        uct_md_attr_v2_t            m_md_attr;
         mutable async_wrapper       m_async;
         ucs::handle<uct_worker_h>   m_worker;
         ucs::handle<uct_cm_h>       m_cm;


### PR DESCRIPTION
## What

Use uct_md_query_v2() instead of uct_md_query().

## Why ?

To make sure that tests have an access to new fields introduced in `uct_md_query_v2`'s attributes.

## How ?

Find `uct_md_attr_t` and replace by `uct_md_attr_v2_t` and adopt its usage.