### PR TITLE
UCT/IFACE/CAPS: added relaxed ordering capability

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -427,6 +427,10 @@ typedef enum uct_atomic_op {
 #define UCT_IFACE_FLAG_TAG_EAGER_BCOPY UCS_BIT(51) /**< Hardware tag matching bcopy eager support */
 #define UCT_IFACE_FLAG_TAG_EAGER_ZCOPY UCS_BIT(52) /**< Hardware tag matching zcopy eager support */
 #define UCT_IFACE_FLAG_TAG_RNDV_ZCOPY  UCS_BIT(53) /**< Hardware tag matching rendezvous zcopy support */
+
+        /* Ordering flags */
+#define UCT_IFACE_FLAG_RELAXED_ORDERING UCS_BIT(54) /**< Interface can't guarantee data
+                                                         delivery ordering */
 /**
  * @}
  */


### PR DESCRIPTION
## What
Added UCT_IFACE_FLAG_RELAXED_ORDERING capability to mark ifaces where delivery ordering is not guaranteed

## Why ?
Some transports could not provide strong data delivery ordering and UCX has to use more robust algorithms
to provide data integrity

## How ?
Added new capability
