### PR TITLE
UCP/PROTO: add testing variable to force restart after wireup

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1305,6 +1305,7 @@ run_test_proto_enable() {
 	build devel --enable-gtest
 
 	export UCX_PROTO_ENABLE=y
+	export UCX_PROTO_REQUEST_RESET=y
 
 	# all are running gtest
 	run_gtest "default"

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -336,6 +336,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_context_config_t, proto_enable), UCS_CONFIG_TYPE_BOOL},
 
+  {"PROTO_REQUEST_RESET", "n",
+   "Experimental: forces reset of pending request when an endpoint has been\n"
+   "connected, useful for testing purposes only",
+   ucs_offsetof(ucp_context_config_t, proto_request_reset), UCS_CONFIG_TYPE_BOOL},
+
   {"KEEPALIVE_INTERVAL", "20s",
    "Time interval between keepalive rounds. Must be non-zero value.",
    ucs_offsetof(ucp_context_config_t, keepalive_interval),

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -122,6 +122,8 @@ typedef struct ucp_context_config {
     size_t                                 listener_backlog;
     /** Enable new protocol selection logic */
     int                                    proto_enable;
+    /** Force request reset after wireup */
+    int                                    proto_request_reset;
     /** Time period between keepalive rounds */
     ucs_time_t                             keepalive_interval;
     /** Maximal number of endpoints to check on every keepalive round


### PR DESCRIPTION
## What
add testing variable to force restart after wireup

## Why ?
test coverage
