### PR TITLE
UCP/CORE: Implement exported/imported memh

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -29,6 +29,17 @@
 #include <ucs/type/param.h>
 
 
+/* Hash map of rcaches which contain imported memory handles got from peers */
+KHASH_TYPE(ucp_context_imported_mem_rcaches_hash, uint64_t, ucs_rcache_t*);
+typedef khash_t(ucp_context_imported_mem_rcaches_hash) ucp_context_imported_mem_rcaches_t;
+
+#define ucp_context_imported_mem_rcaches_hash_key(_uuid) \
+    kh_int64_hash_func((uint64_t)(_uuid))
+
+KHASH_IMPL(ucp_context_imported_mem_rcaches_hash, uint64_t, ucs_rcache_t*, 1,
+           ucp_context_imported_mem_rcaches_hash_key, kh_int64_hash_equal);
+
+
 enum {
     /* The flag indicates that the resource may be used for auxiliary
      * wireup communications only */
@@ -270,6 +281,11 @@ typedef struct ucp_context {
     /* Map of MDs that require caching registrations for given memory type. */
     ucp_md_map_t                  cache_md_map[UCS_MEMORY_TYPE_LAST];
 
+    /* Map of MDs that provide registration of a memory buffer for a given
+       memory type to be shared among other processes which use the same MD.
+       ucp_mem_map() will register memory for all those domains. */
+    ucp_md_map_t                  export_md_map[UCS_MEMORY_TYPE_LAST];
+
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */
@@ -285,6 +301,8 @@ typedef struct ucp_context {
     /* Mem handle registration cache */
     ucs_rcache_t                  *rcache;
 
+    /* Hash of rcaches which contain imported memory handles got from peers */
+    ucp_context_imported_mem_rcaches_t *imported_mem_rcaches;
     struct {
 
         /* Bitmap of features supported by the context */
@@ -337,6 +355,12 @@ typedef struct ucp_context {
     ucp_mt_lock_t                 mt_lock;
 
     char                          name[UCP_ENTITY_NAME_MAX];
+
+    /* Global unique identifier */
+    uint64_t                      uuid;
+
+    /* Next memory handle registration identifier */
+    uint64_t                      next_memh_reg_id;
 
     /* Save cached uct configurations */
     ucs_list_link_t               cached_key_list;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -18,17 +18,22 @@
 #include <ucs/sys/math.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
+#include <ucs/type/serialize.h>
 #include <ucm/api/ucm.h>
 #include <string.h>
 #include <inttypes.h>
 
 
 ucp_mem_dummy_handle_t ucp_mem_dummy_handle = {
-    .memh = {
-        .alloc_method = UCT_ALLOC_METHOD_LAST,
+    .memh         = {
+        .alloc_method   = UCT_ALLOC_METHOD_LAST,
         .alloc_md_index = UCP_NULL_RESOURCE,
+        .flags          = UCP_MEM_FLAG_REGISTERED |
+                          UCP_MEM_FLAG_EXPORTED |
+                          UCP_MEM_FLAG_IMPORTED
     },
-    .uct = { UCT_MEM_HANDLE_NULL }
+    .uct          = { UCT_MEM_HANDLE_NULL },
+    .uct_exported = { UCT_MEM_HANDLE_NULL }
 };
 
 ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
@@ -202,17 +207,24 @@ static int ucp_is_md_selected_by_config(ucp_context_h context,
 static ucs_status_t
 ucp_mem_do_alloc(ucp_context_h context, void *address, size_t length,
                  unsigned uct_flags, ucs_memory_type_t mem_type,
-                 const char *name, uct_allocated_memory_t *mem)
+                 const char *name, uct_allocated_memory_t *mem,
+                 uint8_t memh_flags)
 {
     uct_alloc_method_t method;
     uct_mem_alloc_params_t params;
-    unsigned method_index, md_index, num_mds;
+    uct_md_attr_v2_t *md_attr;
+    ucp_md_index_t md_index;
+    unsigned method_index, num_mds;
     ucs_status_t status;
     uct_md_h *mds;
 
     mds = ucs_calloc(context->num_mds, sizeof(*mds), "temp mds");
     if (mds == NULL) {
         return UCS_ERR_NO_MEMORY;
+    }
+
+    if (memh_flags & UCP_MEM_FLAG_EXPORTED) {
+        uct_flags |= UCT_MD_MEM_FLAG_EXPORT;
     }
 
     for (method_index = 0; method_index < context->config.num_alloc_methods;
@@ -226,7 +238,11 @@ ucp_mem_do_alloc(ucp_context_h context, void *address, size_t length,
         num_mds = 0;
         if (method == UCT_ALLOC_METHOD_MD) {
             for (md_index = 0; md_index < context->num_mds; ++md_index) {
-                if (ucp_is_md_selected_by_config(context, method_index, md_index)) {
+                md_attr = &context->tl_mds[md_index].attr;
+                if (ucp_is_md_selected_by_config(context, method_index,
+                                                 md_index) &&
+                    (!(memh_flags & UCP_MEM_FLAG_EXPORTED) ||
+                     (md_attr->flags & UCT_MD_FLAG_EXPORTED_MKEY))) {
                     mds[num_mds++] = context->tl_mds[md_index].md;
                 }
             }
@@ -281,6 +297,7 @@ ucp_mem_map_params2uct_flags(const ucp_mem_map_params_t *params)
 
 static void ucp_memh_uct_deregister(ucp_context_h context, ucp_mem_h memh,
                                     ucp_md_index_t md_index,
+                                    ucp_md_index_t uct_memh_offset,
                                     ucp_md_map_t *md_map_p)
 {
     ucs_status_t status;
@@ -293,30 +310,41 @@ static void ucp_memh_uct_deregister(ucp_context_h context, ucp_mem_h memh,
     ucs_assert(context->tl_mds[md_index].attr.flags & UCT_MD_FLAG_REG);
 
     status = uct_md_mem_dereg(context->tl_mds[md_index].md,
-                              memh->uct[md_index]);
+                              memh->uct[uct_memh_offset + md_index]);
     if (status != UCS_OK) {
         ucs_warn("memh %p: failed to deregister from md[%d]=%s: %s", memh,
                  md_index, context->tl_mds[md_index].rsc.md_name,
                  ucs_status_string(status));
     }
 
-    memh->uct[md_index] = NULL;
-    *md_map_p          &= ~UCS_BIT(md_index);
+    memh->uct[uct_memh_offset + md_index] = NULL;
+    *md_map_p                            &= ~UCS_BIT(md_index);
 }
 
-static void ucp_memh_deregister(ucp_mem_h memh, ucp_md_map_t md_map)
+static void
+ucp_memh_deregister(ucp_context_h context, ucp_mem_h memh,
+                    ucp_md_map_t md_map, ucp_md_map_t export_md_map)
 {
     ucp_md_index_t md_index;
 
     /* Unregister from all memory domains */
     ucs_for_each_bit(md_index, md_map) {
-        ucp_memh_uct_deregister(memh->context, memh, md_index, &memh->md_map);
+        ucp_memh_uct_deregister(memh->context, memh, md_index, 0,
+                                &memh->md_map);
+    }
+
+    if (memh->flags & UCP_MEM_FLAG_EXPORTED) {
+        ucs_for_each_bit(md_index, export_md_map) {
+            ucp_memh_uct_deregister(context, memh, md_index, context->num_mds,
+                                    &memh->export_md_map);
+        }
     }
 }
 
 void ucp_memh_cleanup(ucp_context_h context, ucp_mem_h memh)
 {
-    ucp_md_map_t md_map = memh->md_map;
+    ucp_md_map_t md_map        = memh->md_map;
+    ucp_md_map_t export_md_map = memh->export_md_map;
     uct_allocated_memory_t mem;
     ucs_status_t status;
 
@@ -328,15 +356,25 @@ void ucp_memh_cleanup(ucp_context_h context, ucp_mem_h memh)
         ucs_assert(memh->alloc_md_index != UCP_NULL_RESOURCE);
         mem.md   = context->tl_mds[memh->alloc_md_index].md;
         mem.memh = memh->uct[memh->alloc_md_index];
-        md_map  &= ~UCS_BIT(memh->alloc_md_index);
+
+        if (memh->flags & UCP_MEM_FLAG_EXPORTED) {
+            export_md_map &= ~UCS_BIT(memh->alloc_md_index);
+        } else if (memh->flags & UCP_MEM_FLAG_REGISTERED) {
+            md_map &= ~UCS_BIT(memh->alloc_md_index);
+        } else {
+            ucs_fatal("unsupported combination of allocation method %u and "
+                      "flags of a memory handle 0x%x", mem.method,
+                      memh->flags);
+        }
     }
 
     /* Have a parent memory handle from rcache */
     if ((memh->parent != NULL) && (memh->parent != memh)) {
-        ucp_memh_deregister(memh, md_map & ~memh->parent->md_map);
+        ucp_memh_deregister(context, memh, md_map & ~memh->parent->md_map,
+                            export_md_map & ~memh->parent->export_md_map);
         ucp_memh_put(context, memh->parent);
     } else {
-        ucp_memh_deregister(memh, md_map);
+        ucp_memh_deregister(context, memh, md_map, export_md_map);
     }
 
     /* If the memory was also allocated, release it */
@@ -396,37 +434,54 @@ ucp_memh_uct_register(ucp_context_h context, ucp_mem_h memh,
 
 static ucs_status_t
 ucp_memh_register(ucp_context_h context, ucp_mem_h memh, ucp_md_map_t md_map,
-                  unsigned uct_flags)
+                  ucp_md_map_t export_md_map, unsigned uct_flags)
 {
     ucp_md_index_t md_index;
     ucs_status_t status;
 
-    ucs_for_each_bit(md_index, md_map) {
-        status = ucp_memh_uct_register(context, memh, uct_flags, md_index, 0,
-                                       "registration", &memh->md_map);
-        if (ucs_unlikely(status != UCS_OK)) {
-            goto err;
+    if (memh->flags & UCP_MEM_FLAG_REGISTERED) {
+        ucs_for_each_bit(md_index, md_map) {
+            status = ucp_memh_uct_register(context, memh, uct_flags, md_index,
+                                           0, "registration", &memh->md_map);
+            if (ucs_unlikely(status != UCS_OK)) {
+                goto err;
+            }
+        }
+    }
+
+    if (memh->flags & UCP_MEM_FLAG_EXPORTED) {
+        ucs_for_each_bit(md_index, export_md_map) {
+            status = ucp_memh_uct_register(context, memh,
+                                           uct_flags | UCT_MD_MEM_FLAG_EXPORT,
+                                           md_index, context->num_mds,
+                                           "exporting", &memh->export_md_map);
+            if (ucs_unlikely(status != UCS_OK)) {
+                goto err;
+            }
         }
     }
 
     return UCS_OK;
 
 err:
-    ucp_memh_deregister(memh, memh->md_map);
+    ucp_memh_deregister(context, memh, memh->md_map, memh->export_md_map);
     return status;
 }
 
 static size_t ucp_memh_size(ucp_context_h context)
 {
-    return sizeof(ucp_mem_t) + (sizeof(uct_mem_h) * context->num_mds);
+    /* Multiplier "2" is used to reserve space for registered/imported and
+     * exported UCT memory handles */
+    return sizeof(ucp_mem_t) + 2 * sizeof(uct_mem_h) * context->num_mds;
 }
 
 static void ucp_memh_set(ucp_mem_h memh, ucp_context_h context, void* address,
                          size_t length, ucs_memory_type_t mem_type,
-                         uct_alloc_method_t method)
+                         uint8_t memh_flags, uct_alloc_method_t method)
 {
     memh->super.super.start = (uintptr_t)address;
     memh->super.super.end   = (uintptr_t)address + length;
+    memh->flags             = memh_flags;
     memh->context           = context;
     memh->mem_type          = mem_type;
     memh->alloc_method      = method;
@@ -436,7 +491,7 @@ static void ucp_memh_set(ucp_mem_h memh, ucp_context_h context, void* address,
 static ucs_status_t
 ucp_memh_create(ucp_context_h context, void *address, size_t length,
                 ucs_memory_type_t mem_type, uct_alloc_method_t method,
-                ucp_mem_h *memh_p)
+                uint8_t memh_flags, ucp_mem_h *memh_p)
 {
     ucp_mem_h memh;
 
@@ -445,11 +500,15 @@ ucp_memh_create(ucp_context_h context, void *address, size_t length,
         return UCS_ERR_NO_MEMORY;
     }
 
-    ucp_memh_set(memh, context, address, length, mem_type, method);
+    ucp_memh_set(memh, context, address, length, mem_type, memh_flags, method);
 
     if (context->rcache == NULL) {
+        ucs_assert(context->imported_mem_rcaches == NULL);
+
         /* Point to self */
         memh->parent = memh;
+    } else {
+        ucs_assert(context->imported_mem_rcaches != NULL);
     }
 
     *memh_p = memh;
@@ -458,7 +517,8 @@ ucp_memh_create(ucp_context_h context, void *address, size_t length,
 
 static ucs_status_t
 ucp_memh_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
-                    ucs_memory_type_t mem_type, ucp_mem_h *memh_p)
+                    ucs_memory_type_t mem_type, uint8_t memh_flags,
+                    ucp_mem_h *memh_p)
 {
     ucp_mem_attr_t attr = {
         .mem_type = mem_type
@@ -472,13 +532,15 @@ ucp_memh_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
         return status;
     }
 
-    *memh_p = ucs_derived_of(rregion, ucp_mem_t);\
+    *memh_p          = ucs_derived_of(rregion, ucp_mem_t);
+    (*memh_p)->flags = UCP_MEM_FLAG_IN_RCACHE | memh_flags;
 
     return UCS_OK;
 }
 
 static ucs_status_t ucp_memh_create_from_mem(ucp_context_h context,
                                              const uct_allocated_memory_t *mem,
+                                             uint8_t memh_flags,
                                              ucp_mem_h *memh_p)
 {
     ucp_md_index_t md_index;
@@ -486,7 +548,7 @@ static ucs_status_t ucp_memh_create_from_mem(ucp_context_h context,
     ucp_mem_h memh;
 
     status = ucp_memh_create(context, mem->address, mem->length, mem->mem_type,
-                             mem->method, &memh);
+                             mem->method, memh_flags, &memh);
     if (status != UCS_OK) {
         return status;
     }
@@ -502,7 +564,15 @@ static ucs_status_t ucp_memh_create_from_mem(ucp_context_h context,
 
         memh->alloc_md_index = md_index;
         memh->uct[md_index]  = mem->memh;
-        memh->md_map        |= UCS_BIT(md_index);
+        if (memh_flags & UCP_MEM_FLAG_EXPORTED) {
+            memh->export_md_map |= UCS_BIT(md_index);
+        } else if (memh_flags & UCP_MEM_FLAG_REGISTERED) {
+            memh->md_map |= UCS_BIT(md_index);
+        } else {
+            ucs_fatal("unsupported combination of allocation method %u and "
+                      "flags of a memory handle 0x%x", memh->alloc_md_index,
+                      memh->flags);
+        }
         ucs_trace("allocated address %p length %zu on md[%d]=%s %p",
                   mem->address, mem->length, md_index,
                   context->tl_mds[md_index].rsc.md_name, memh->uct[md_index]);
@@ -531,45 +601,68 @@ out:
  */
 static UCS_F_ALWAYS_INLINE void
 ucp_memh_update_from_parent_memh(ucp_mem_h memh,
+                                 ucp_md_index_t uct_memh_offset,
                                  ucp_md_map_t cache_md_map,
                                  ucp_md_map_t *memh_md_map_p,
                                  ucp_md_map_t *md_map_p)
 {
-    ucp_md_index_t md_index;
+    ucp_md_index_t md_index, memh_index;
 
     ucs_for_each_bit(md_index, cache_md_map) {
-        memh->uct[md_index] = memh->parent->uct[md_index];
-        *memh_md_map_p     |= UCS_BIT(md_index);
-        *md_map_p          &= ~UCS_BIT(md_index);
+        memh_index            = md_index + uct_memh_offset;
+        memh->uct[memh_index] = memh->parent->uct[memh_index];
+        *memh_md_map_p       |= UCS_BIT(md_index);
+        *md_map_p            &= ~UCS_BIT(md_index);
     }
 }
 
 static ucs_status_t
 ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh, unsigned uct_flags)
 {
-    ucs_memory_type_t mem_type = memh->mem_type;
-    ucp_md_map_t reg_md_map    = context->reg_md_map[mem_type] & ~memh->md_map;
-    ucp_md_map_t cache_md_map  = context->cache_md_map[mem_type] & reg_md_map;
-    void *address              = ucp_memh_address(memh);
-    size_t length              = ucp_memh_length(memh);
+    ucs_memory_type_t mem_type       = memh->mem_type;
+    ucp_md_map_t reg_md_map          = context->reg_md_map[mem_type] &
+                                       ~memh->md_map;
+    ucp_md_map_t export_md_map       = context->export_md_map[mem_type] &
+                                       ~memh->export_md_map;
+    ucp_md_map_t cache_reg_md_map    = context->cache_md_map[mem_type] &
+                                       reg_md_map;
+    ucp_md_map_t cache_export_md_map = context->cache_md_map[mem_type] &
+                                       export_md_map;
+    void *address                    = ucp_memh_address(memh);
+    size_t length                    = ucp_memh_length(memh);
     ucs_status_t status;
 
     if (context->rcache == NULL) {
-        status = ucp_memh_register(context, memh, reg_md_map, uct_flags);
+        status = ucp_memh_register(context, memh, reg_md_map, export_md_map,
+                                   uct_flags);
         if (status != UCS_OK) {
             goto err;
         }
+
+        memh->reg_id = context->next_memh_reg_id++;
     } else {
-        status = ucp_memh_get(context, address, length, mem_type, cache_md_map,
-                              uct_flags, &memh->parent);
+        status = ucp_memh_get(context, address, length, mem_type,
+                              cache_reg_md_map, cache_export_md_map, uct_flags,
+                              memh->flags, &memh->parent);
         if (status != UCS_OK) {
             goto err;
         }
 
-        ucp_memh_update_from_parent_memh(memh, cache_md_map, &memh->md_map,
-                                         &reg_md_map);
+        memh->reg_id = memh->parent->reg_id;
+        if (memh->flags & UCP_MEM_FLAG_REGISTERED) {
+            ucp_memh_update_from_parent_memh(memh, 0, cache_reg_md_map,
+                                             &memh->md_map, &reg_md_map);
+        }
 
-        status = ucp_memh_register(context, memh, reg_md_map, uct_flags);
+        if (memh->flags & UCP_MEM_FLAG_EXPORTED) {
+            ucp_memh_update_from_parent_memh(memh, context->num_mds,
+                                             cache_export_md_map,
+                                             &memh->export_md_map,
+                                             &export_md_map);
+        }
+
+        status = ucp_memh_register(context, memh, reg_md_map, export_md_map,
+                                   uct_flags);
         if (status != UCS_OK) {
             goto err_put;
         }
@@ -586,7 +679,8 @@ err:
 ucs_status_t
 ucp_memh_get_slow(ucp_context_h context, void *address, size_t length,
                   ucs_memory_type_t mem_type, ucp_md_map_t reg_md_map,
-                  unsigned uct_flags, ucp_mem_h *memh_p)
+                  ucp_md_map_t export_md_map, unsigned uct_flags,
+                  uint8_t memh_flags, ucp_mem_h *memh_p)
 {
     ucp_mem_h memh = NULL; /* To suppress compiler warning */
     void *reg_address;
@@ -606,10 +700,10 @@ ucp_memh_get_slow(ucp_context_h context, void *address, size_t length,
     UCP_THREAD_CS_ENTER(&context->mt_lock);
     if (context->rcache == NULL) {
         status = ucp_memh_create(context, reg_address, reg_length, mem_type,
-                                 UCT_ALLOC_METHOD_LAST, &memh);
+                                 UCT_ALLOC_METHOD_LAST, memh_flags, &memh);
     } else {
         status = ucp_memh_rcache_get(context->rcache, reg_address, reg_length,
-                                     mem_type, &memh);
+                                     mem_type, memh_flags, &memh);
     }
 
     if (status != UCS_OK) {
@@ -619,10 +713,13 @@ ucp_memh_get_slow(ucp_context_h context, void *address, size_t length,
     ucs_assert(memh->mem_type == mem_type);
 
     status = ucp_memh_register(context, memh, ~memh->md_map & reg_md_map,
+                               ~memh->export_md_map & export_md_map,
                                uct_flags);
     if (status != UCS_OK) {
         goto err_free_memh;
     }
+
+    memh->reg_id = context->next_memh_reg_id++;
 
     ucs_trace("memh %p: registered address %p/%p length %zu/%zu md_map %"
               PRIx64 "/%" PRIx64, memh, reg_address, ucp_memh_address(memh),
@@ -646,19 +743,19 @@ err_free_memh:
 static ucs_status_t
 ucp_memh_alloc(ucp_context_h context, void *address, size_t length,
                ucs_memory_type_t mem_type, unsigned uct_flags,
-               const char *alloc_name, ucp_mem_h *memh_p)
+               uint8_t memh_flags, const char *alloc_name, ucp_mem_h *memh_p)
 {
     uct_allocated_memory_t mem;
     ucs_status_t status;
     ucp_mem_h memh;
 
     status = ucp_mem_do_alloc(context, address, length, uct_flags, mem_type,
-                              alloc_name, &mem);
+                              alloc_name, &mem, memh_flags);
     if (status != UCS_OK) {
         goto out;
     }
 
-    status = ucp_memh_create_from_mem(context, &mem, &memh);
+    status = ucp_memh_create_from_mem(context, &mem, memh_flags, &memh);
     if (status != UCS_OK) {
         goto err_dealloc;
     }
@@ -682,13 +779,13 @@ out:
 static ucs_status_t
 ucp_memh_normal_reg(ucp_context_h context, void *address, size_t length,
                     ucs_memory_type_t mem_type, unsigned uct_flags,
-                    ucp_mem_h *memh_p)
+                    uint8_t memh_flags, ucp_mem_h *memh_p)
 {
     ucs_status_t status;
     ucp_mem_h memh;
 
     status = ucp_memh_create(context, address, length, mem_type,
-                             UCT_ALLOC_METHOD_LAST, &memh);
+                             UCT_ALLOC_METHOD_LAST, memh_flags, &memh);
     if (status != UCS_OK) {
         goto out;
     }
@@ -708,6 +805,21 @@ out:
     return status;
 }
 
+static ucs_status_t
+ucp_memh_import(ucp_context_h context, const void *export_mkey_buffer,
+                ucp_mem_h *memh_p);
+
+static UCS_F_ALWAYS_INLINE int
+ucp_mem_map_is_zero(uint8_t memh_flags, size_t length,
+                    const void *exported_memh_buffer)
+{
+    if (!(memh_flags & UCP_MEM_FLAG_IMPORTED)) {
+        return length == 0;
+    }
+
+    return *(uint16_t*)exported_memh_buffer == sizeof(ucp_memh_dummy_buffer);
+}
+
 /* Matrix of behavior
  * |--------------------------------------------------------------------------------|
  * | parameter |                             value                                  |
@@ -723,24 +835,32 @@ out:
 ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *params,
                          ucp_mem_h *memh_p)
 {
+    uint8_t memh_flags = 0;
     ucs_memory_type_t mem_type;
     ucp_memory_info_t mem_info;
     ucs_status_t status;
     unsigned uct_flags;
     unsigned flags;
     void *address;
+    const void *exported_memh_buffer;
     size_t length;
     ucp_mem_h memh;
 
-    if (!(params->field_mask & UCP_MEM_MAP_PARAM_FIELD_LENGTH)) {
-        ucs_error("The length value for mapping memory isn't set: %s",
-                  ucs_status_string(UCS_ERR_INVALID_PARAM));
+    if (!(params->field_mask &
+          (UCP_MEM_MAP_PARAM_FIELD_LENGTH |
+           UCP_MEM_MAP_PARAM_FIELD_EXPORTED_MEMH_BUFFER))) {
+        ucs_error("the length value or exported_memh_buffer for mapping memory"
+                  " aren't set: %s", ucs_status_string(UCS_ERR_INVALID_PARAM));
         status = UCS_ERR_INVALID_PARAM;
         goto out;
     }
 
-    address = UCP_PARAM_VALUE(MEM_MAP, params, address, ADDRESS, NULL);
-    flags   = UCP_PARAM_VALUE(MEM_MAP, params, flags, FLAGS, 0);
+    address              = UCP_PARAM_VALUE(MEM_MAP, params, address, ADDRESS,
+                                           NULL);
+    length               = UCP_PARAM_VALUE(MEM_MAP, params, length, LENGTH, 0);
+    flags                = UCP_PARAM_VALUE(MEM_MAP, params, flags, FLAGS, 0);
+    exported_memh_buffer = UCP_PARAM_VALUE(MEM_MAP, params, exported_memh_buffer,
+                                           EXPORTED_MEMH_BUFFER, NULL);
 
     if ((flags & UCP_MEM_MAP_FIXED) &&
         ((uintptr_t)address % ucs_get_page_size())) {
@@ -748,28 +868,6 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         status = UCS_ERR_INVALID_PARAM;
         goto out;
     }
-
-    if (address == NULL) {
-        if (!(flags & UCP_MEM_MAP_ALLOCATE) && (params->length > 0)) {
-            ucs_error("Undefined address with nonzero length requires "
-                      "UCP_MEM_MAP_ALLOCATE flag");
-            status = UCS_ERR_INVALID_PARAM;
-            goto out;
-        }
-    } else if (!(flags & UCP_MEM_MAP_ALLOCATE) && (flags & UCP_MEM_MAP_FIXED)) {
-        ucs_error("Wrong combination of flags when address is defined");
-        status = UCS_ERR_INVALID_PARAM;
-        goto out;
-    }
-
-    if (params->length == 0) {
-        ucs_debug("mapping zero length buffer, return dummy memh");
-        *memh_p = &ucp_mem_dummy_handle.memh;
-        status  = UCS_OK;
-        goto out;
-    }
-
-    length = params->length;
 
     if (flags & UCP_MEM_MAP_ALLOCATE) {
         mem_type = UCP_PARAM_VALUE(MEM_MAP, params, memory_type, MEMORY_TYPE,
@@ -788,21 +886,63 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         mem_type = params->memory_type;
     }
 
+    if (flags & UCP_MEM_MAP_EXPORT) {
+        if (params->field_mask &
+            UCP_MEM_MAP_PARAM_FIELD_EXPORTED_MEMH_BUFFER) {
+            memh_flags |= UCP_MEM_FLAG_IMPORTED;
+        } else {
+            memh_flags |= UCP_MEM_FLAG_EXPORTED;
+            if (context->export_md_map[mem_type] == 0) {
+                ucs_diag("no UCT memory domain to make memory exported");
+                return UCS_ERR_UNSUPPORTED;
+            }
+        }
+    } else {
+        memh_flags |= UCP_MEM_FLAG_REGISTERED;
+    }
+
+    if (address == NULL) {
+        if (!(flags & UCP_MEM_MAP_ALLOCATE) && (length > 0)) {
+            ucs_error("undefined address with nonzero length requires "
+                      "UCP_MEM_MAP_ALLOCATE flag");
+            status = UCS_ERR_INVALID_PARAM;
+            goto out;
+        }
+    } else if ((!(flags & UCP_MEM_MAP_ALLOCATE) &&
+                (flags & UCP_MEM_MAP_FIXED))) {
+        ucs_error("wrong combination of flags when address is defined");
+        status = UCS_ERR_INVALID_PARAM;
+        goto out;
+    }
+
+    if (ucp_mem_map_is_zero(memh_flags, length, exported_memh_buffer)) {
+        ucs_assert(ucp_memh_address(&ucp_mem_dummy_handle.memh) == NULL);
+        ucs_assert(ucp_memh_length(&ucp_mem_dummy_handle.memh) == 0);
+
+        ucs_debug("mapping zero length buffer, return dummy memh");
+        *memh_p = &ucp_mem_dummy_handle.memh;
+        status  = UCS_OK;
+        goto out;
+    }
+
     uct_flags = ucp_mem_map_params2uct_flags(params);
 
-    if (flags & UCP_MEM_MAP_ALLOCATE) {
+    if (memh_flags & UCP_MEM_FLAG_IMPORTED) {
+        status = ucp_memh_import(context, exported_memh_buffer, &memh);
+    } else if (flags & UCP_MEM_MAP_ALLOCATE) {
         status = ucp_memh_alloc(context, address, length, mem_type,
-                                uct_flags, "user memory", &memh);
+                                uct_flags, memh_flags, "user memory",
+                                &memh);
     } else {
         status = ucp_memh_normal_reg(context, address, length, mem_type,
-                                     uct_flags, &memh);
+                                     uct_flags, memh_flags, &memh);
     }
 
     if (status != UCS_OK) {
         goto out;
     }
 
-    ucs_assert(memh->md_map != 0);
+    ucs_assert((memh->md_map != 0) || (memh->export_md_map != 0));
     ucs_assert(memh->parent != NULL);
 
     *memh_p = memh;
@@ -923,10 +1063,11 @@ static ucs_status_t ucp_advice2uct(unsigned ucp_advice, uct_mem_advice_t *uct_ad
 static ucs_status_t ucp_memh_uct_mem_advise(ucp_context_h context,
                                             ucp_mem_h memh,
                                             ucp_md_index_t md_index,
+                                            ucp_md_index_t uct_memh_offset,
                                             void *address, size_t length,
                                             uct_mem_advice_t uct_advice)
 {
-    uct_mem_h uct_memh = memh->uct[md_index];
+    uct_mem_h uct_memh = memh->uct[uct_memh_offset + md_index];
 
     if (!(context->tl_mds[md_index].attr.flags & UCT_MD_FLAG_ADVISE) ||
         (uct_memh == NULL)) {
@@ -976,10 +1117,17 @@ ucp_mem_advise(ucp_context_h context, ucp_mem_h memh,
 
     status = UCS_OK;
     for (md_index = 0; md_index < context->num_mds; ++md_index) {
-        tmp_status = ucp_memh_uct_mem_advise(context, memh, md_index,
+        tmp_status = ucp_memh_uct_mem_advise(context, memh, md_index, 0,
                                              params->address, params->length,
                                              uct_advice);
         if (tmp_status != UCS_OK) {
+            status = tmp_status;
+        }
+
+        tmp_status = ucp_memh_uct_mem_advise(context, memh, md_index,
+                                             context->num_mds, params->address,
+                                             params->length, uct_advice);
+        if ((tmp_status != UCS_OK) && (status == UCS_OK)) {
             status = tmp_status;
         }
     }
@@ -1000,7 +1148,7 @@ ucp_mpool_malloc(ucp_worker_h worker, ucs_mpool_t *mp, size_t *size_p, void **ch
     status = ucp_memh_alloc(worker->context, NULL,
                             *size_p + sizeof(*chunk_hdr), UCS_MEMORY_TYPE_HOST,
                             ucp_mem_map_params2uct_flags(&mem_params),
-                            ucs_mpool_name(mp), &memh);
+                            UCP_MEM_FLAG_REGISTERED, ucs_mpool_name(mp), &memh);
     if (status != UCS_OK) {
         goto out;
     }
@@ -1051,7 +1199,7 @@ ucp_rndv_frag_malloc_mpools(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
 
     /* payload; need to get default flags from ucp_mem_map_params2uct_flags() */
     status = ucp_memh_alloc(context, NULL, frag_size * num_elems, mem_type,
-                            UCT_MD_MEM_ACCESS_RMA, ucs_mpool_name(mp),
+                            UCT_MD_MEM_ACCESS_RMA, 0, ucs_mpool_name(mp),
                             &chunk_hdr->memh);
     if (status != UCS_OK) {
         return status;
@@ -1189,8 +1337,11 @@ ucp_mem_rcache_mem_reg_cb(void *ctx, ucs_rcache_t *rcache, void *arg,
     ucp_mem_h memh        = ucs_derived_of(rregion, ucp_mem_t);
     ucp_mem_attr_t *attr  = arg;
 
+    ucs_assert(&memh->export_md_map == &memh->remote_import_md_map);
+
     memh->context        = context;
     memh->md_map         = 0;
+    memh->export_md_map  = 0;
     memh->alloc_md_index = UCP_NULL_RESOURCE;
     memh->alloc_method   = UCT_ALLOC_METHOD_LAST;
     memh->mem_type       = attr->mem_type;
@@ -1230,7 +1381,9 @@ static ucs_rcache_ops_t ucp_mem_rcache_ops = {
     .dump_region = ucp_mem_rcache_dump_region_cb
 };
 
-ucs_status_t ucp_mem_rcache_init(ucp_context_h context)
+static ucs_status_t
+ucp_mem_rcache_create(ucp_context_h context, const char *name,
+                      ucs_rcache_t **rcache_p)
 {
     ucs_rcache_params_t rcache_params;
 
@@ -1247,35 +1400,443 @@ ucs_status_t ucp_mem_rcache_init(ucp_context_h context)
     rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
     rcache_params.alignment          = UCS_RCACHE_MIN_ALIGNMENT;
 
-    return ucs_rcache_create(&rcache_params, "ucp_rcache",
-                             ucs_stats_get_root(), &context->rcache);
+    return ucs_rcache_create(&rcache_params, name, ucs_stats_get_root(),
+                             rcache_p);
+}
+
+ucs_status_t ucp_mem_rcache_init(ucp_context_h context)
+{
+    ucs_status_t status;
+
+    status = ucp_mem_rcache_create(context, "ucp_rcache", &context->rcache);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    context->imported_mem_rcaches =
+            kh_init(ucp_context_imported_mem_rcaches_hash);
+    if (context->imported_mem_rcaches == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_rcache_destroy;
+    }
+
+    return UCS_OK;
+
+err_rcache_destroy:
+    ucs_rcache_destroy(context->rcache);
+err:
+    return status;
 }
 
 void ucp_mem_rcache_cleanup(ucp_context_h context)
 {
+    ucs_rcache_t *rcache;
+
     if (context->rcache != NULL) {
         ucs_rcache_destroy(context->rcache);
+    }
+
+    if (context->imported_mem_rcaches != NULL) {
+        kh_foreach_value(context->imported_mem_rcaches, rcache, {
+            ucs_rcache_destroy(rcache);
+        })
+        kh_destroy(ucp_context_imported_mem_rcaches_hash,
+                   context->imported_mem_rcaches);
     }
 }
 
 ucs_status_t ucp_mem_reg_md_map_update(ucp_context_h context)
 {
     ucp_mem_dummy_handle_t memh = {};
-    ucs_status_t status;
     uint8_t buff;
+    ucs_status_t status;
 
     ucp_memh_set(&memh.memh, context, &buff, sizeof(buff),
-                 UCS_MEMORY_TYPE_HOST, UCT_ALLOC_METHOD_LAST);
+                 UCS_MEMORY_TYPE_HOST,
+                 UCP_MEM_FLAG_REGISTERED | UCP_MEM_FLAG_EXPORTED,
+                 UCT_ALLOC_METHOD_LAST);
 
     status = ucp_memh_register(context, &memh.memh,
                                context->reg_md_map[UCS_MEMORY_TYPE_HOST],
+                               context->export_md_map[UCS_MEMORY_TYPE_HOST],
                                UCT_MD_MEM_ACCESS_ALL |
                                UCT_MD_MEM_FLAG_HIDE_ERRORS);
     if (status != UCS_OK) {
         return status;
     }
 
-    context->reg_md_map[UCS_MEMORY_TYPE_HOST] = memh.memh.md_map;
-    ucp_memh_deregister(&memh.memh, memh.memh.md_map);
+    context->reg_md_map[UCS_MEMORY_TYPE_HOST]    = memh.memh.md_map;
+    context->export_md_map[UCS_MEMORY_TYPE_HOST] = memh.memh.export_md_map;
+    ucp_memh_deregister(context, &memh.memh, memh.memh.md_map,
+                        memh.memh.export_md_map);
     return UCS_OK;
+}
+
+static ucp_md_map_t ucp_find_md_map(ucp_context_h context,
+                                    const void *component_name,
+                                    size_t component_name_size,
+                                    const void *global_id_buf,
+                                    size_t global_id_size)
+{
+    ucp_md_map_t md_map = 0;
+    ucp_md_index_t md_index;
+    uct_md_attr_v2_t *md_attr;
+    size_t component_name_cmp_size, global_id_cmp_size;
+
+    for (md_index = 0; md_index < context->num_mds; md_index++) {
+        md_attr                 = &context->tl_mds[md_index].attr;
+        component_name_cmp_size = ucs_min(strlen(md_attr->component_name),
+                                          component_name_size);
+        global_id_cmp_size      =
+                ucs_min(ucp_memh_global_id_packed_size(md_attr),
+                        global_id_size);
+
+        if ((memcmp(md_attr->component_name, component_name,
+                    component_name_cmp_size) == 0) &&
+            (memcmp(md_attr->global_id, global_id_buf,
+                    global_id_cmp_size) == 0)) {
+            md_map |= UCS_BIT(md_index);
+            continue;
+        }
+    }
+
+    return md_map;
+}
+
+static void
+ucp_memh_import_parse_tl_mkey_data(ucp_context_h context, 
+                                   const void **start_p,
+                                   const void **tl_mkey_buf_p,
+                                   ucp_md_map_t *md_map_p)
+{
+    const void *p = *start_p;
+    const void *next_tl_md_p, *end;
+    size_t tl_mkey_data_size;
+    size_t tl_mkey_size, component_name_size, global_id_size;
+    const void *tl_mkey_buf, *component_name_buf, *global_id_buf;
+    ucp_md_map_t md_map;
+
+    /* TL mkey data size */
+    tl_mkey_data_size = *ucs_serialize_next(&p, uint16_t);
+    end               = UCS_PTR_BYTE_OFFSET(*start_p, tl_mkey_data_size);
+    ucs_assertv((tl_mkey_data_size <= UINT16_MAX) && (tl_mkey_data_size != 0),
+                "tl_mkey_data_size %zu", tl_mkey_data_size);
+
+    /* TL mkey size */
+    tl_mkey_size = *ucp_memh_serialize_next(&p, uint8_t, end, 0u);
+    ucs_assertv((tl_mkey_size <= UINT8_MAX) && (tl_mkey_size != 0),
+                "tl_mkey_size %zu", tl_mkey_size);
+
+    /* TL mkey */
+    tl_mkey_buf = ucs_serialize_next_raw(&p, void, tl_mkey_size);
+
+    /* Size of component name */
+    component_name_size = *ucp_memh_serialize_next(&p, uint8_t, end, 0u);
+
+    /* Component name */
+    component_name_buf = ucs_serialize_next_raw(&p, void,
+                                                component_name_size);
+
+    /* Size of global MD identifier */
+    global_id_size = *ucp_memh_serialize_next(&p, uint8_t, end, 0u);
+
+    /* Global MD identifier */
+    global_id_buf = ucs_serialize_next_raw(&p, void, global_id_size);
+
+    /* Get local MD index which corresponds to the remote one */
+    md_map = ucp_find_md_map(context, component_name_buf,
+                             component_name_size, global_id_buf,
+                             global_id_size);
+
+    next_tl_md_p = end;
+    ucs_assertv(p <= next_tl_md_p, "p=%p, next_tl_md_p=%p", p, next_tl_md_p);
+
+    *start_p       = next_tl_md_p;
+    *tl_mkey_buf_p = tl_mkey_buf;
+    *md_map_p      = md_map;
+}
+
+typedef struct {
+    ucp_md_index_t md_index;
+    const void     *tl_mkey_buf;
+} ucp_memh_import_attach_params_t;
+
+static ucs_status_t
+ucp_memh_import_attach(ucp_context_h context, ucp_mem_h memh,
+                       ucp_memh_import_attach_params_t *attach_params_array,
+                       unsigned attach_params_num)
+{
+    ucp_md_index_t md_index = UCP_NULL_RESOURCE;
+    unsigned attach_params_iter;
+    const void *tl_mkey_buf;
+    uct_md_mem_attach_params_t attach_params;
+    uct_md_attr_v2_t *md_attr;
+    ucs_status_t status;
+    uct_mem_h uct_memh;
+
+    for (attach_params_iter = 0; attach_params_iter < attach_params_num;
+         ++attach_params_iter) {
+        md_index    = attach_params_array[attach_params_iter].md_index;
+        tl_mkey_buf = attach_params_array[attach_params_iter].tl_mkey_buf;
+        md_attr     = &context->tl_mds[md_index].attr;
+        ucs_assert_always(md_attr->flags & UCT_MD_FLAG_EXPORTED_MKEY);
+
+        attach_params.field_mask = UCT_MD_MEM_ATTACH_FIELD_FLAGS;
+        attach_params.flags      = UCT_MD_MEM_ATTACH_FLAG_HIDE_ERRORS;
+
+        status = uct_md_mem_attach(context->tl_mds[md_index].md, tl_mkey_buf,
+                                   &attach_params, &uct_memh);
+        if (ucs_unlikely(status != UCS_OK)) {
+            ucs_trace("failed to attach memory on '%s': %s",
+                      md_attr->component_name, ucs_status_string(status));
+            continue;
+        }
+
+        memh->uct[md_index] = uct_memh;
+
+        ucs_trace("imported address %p length %zu on md[%d]=%s: uct_memh %p",
+                  ucp_memh_address(memh), ucp_memh_length(memh), md_index,
+                  context->tl_mds[md_index].rsc.md_name,
+                  memh->uct[md_index]);
+        memh->md_map |= UCS_BIT(md_index);
+    }
+
+    if (memh->md_map == 0) {
+        ucs_error("no suitable UCT memory domains to perform importing on");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_memh_import_slow(ucp_context_h context, ucs_rcache_t *existing_rcache,
+                     ucp_mem_h user_memh, ucp_md_map_t remote_md_map,
+                     ucp_memh_import_attach_params_t *attach_params_array,
+                     unsigned attach_params_num, void *address, size_t length,
+                     uint64_t remote_uuid, ucs_memory_type_t mem_type,
+                     uint64_t reg_id)
+{
+    ucs_rcache_t *rcache;
+    ucs_status_t status;
+    ucp_mem_h memh;
+    char rcache_name[128];
+    khiter_t iter;
+    int ret;
+
+    ucs_assert(user_memh != NULL);
+
+    UCP_THREAD_CS_ENTER(&context->mt_lock);
+
+    if (ucs_likely(context->imported_mem_rcaches != NULL)) {
+        if (existing_rcache == NULL) {
+            ucs_snprintf_safe(rcache_name, sizeof(rcache_name),
+                              "ucp rcache[%zu] of imported memory buffer",
+                              remote_uuid);
+            status = ucp_mem_rcache_create(context, rcache_name, &rcache);
+            if (status != UCS_OK) {
+                goto err;
+            }
+
+            iter = kh_put(ucp_context_imported_mem_rcaches_hash,
+                          context->imported_mem_rcaches, remote_uuid, &ret);
+            ucs_assertv((ret != UCS_KH_PUT_FAILED) &&
+                        (ret != UCS_KH_PUT_KEY_PRESENT), "ret %d", ret);
+
+            kh_value(context->imported_mem_rcaches, iter) = rcache;
+        } else {
+            rcache = existing_rcache;
+        }
+
+        status = ucp_memh_rcache_get(rcache, address, length, mem_type,
+                                     UCP_MEM_FLAG_IMPORTED, &memh);
+        if (status != UCS_OK) {
+            goto err_rcache_destroy;
+        }
+
+        user_memh->parent = memh;
+    } else {
+        memh   = user_memh;
+        rcache = NULL;
+    }
+
+    memh->reg_id               = reg_id;
+    memh->remote_import_md_map = remote_md_map;
+    memh->remote_uuid          = remote_uuid;
+    status                     = ucp_memh_import_attach(context, memh,
+                                                        attach_params_array,
+                                                        attach_params_num);
+    if (status != UCS_OK) {
+        goto err_memh_free;
+    }
+
+    UCP_THREAD_CS_EXIT(&context->mt_lock);
+
+    return UCS_OK;
+
+err_memh_free:
+    if (rcache != NULL) {
+        ucs_rcache_region_put_unsafe(rcache, &memh->super);
+    }
+err_rcache_destroy:
+    if ((rcache != NULL) && (rcache != existing_rcache)) { 
+        /* Rcache was allocated here - remove it from hash and destroy */
+        iter = kh_get(ucp_context_imported_mem_rcaches_hash,
+                      context->imported_mem_rcaches, remote_uuid);
+        ucs_assert(iter != kh_end(context->imported_mem_rcaches));
+        kh_del(ucp_context_imported_mem_rcaches_hash,
+               context->imported_mem_rcaches, iter);
+        ucs_rcache_destroy(rcache);
+    }
+err:
+    UCP_THREAD_CS_EXIT(&context->mt_lock);
+    return status;
+}
+
+static ucs_status_t
+ucp_memh_import(ucp_context_h context, const void *export_mkey_buffer,
+                ucp_mem_h *memh_p)
+{
+    ucs_rcache_t *rcache = NULL;
+    const void *p        = export_mkey_buffer;
+    const void *end;
+    ucp_md_index_t md_index;
+    ucp_mem_h memh, rcache_memh;
+    ucp_md_index_t remote_md_index;
+    ucs_status_t status;
+    ucp_md_map_t remote_md_map, local_md_map, reg_md_map;
+    ucp_memh_import_attach_params_t *attach_params_array;
+    unsigned attach_params_num;
+    ucs_memory_type_t mem_type;
+    uint64_t UCS_V_UNUSED flags;
+    uint64_t UCS_V_UNUSED mem_info_parsed_size;
+    uint64_t remote_uuid;
+    const void *tl_mkey_buf;
+    ucs_rcache_region_t *rregion;
+    khiter_t iter;
+    void *address;
+    size_t length;
+    uint64_t memh_info_size;
+    uint64_t reg_id;
+
+    ucs_assert(export_mkey_buffer != NULL);
+
+    /* Common memory handle information */
+    memh_info_size = *ucs_serialize_next(&p, uint16_t);
+    end            = UCS_PTR_BYTE_OFFSET(export_mkey_buffer, memh_info_size);
+
+    flags          = *ucp_memh_serialize_next(&p, uint64_t, end, 0lu);
+    remote_md_map  = *ucp_memh_serialize_next(&p, ucp_md_map_t, end, 0u);
+    mem_type       = *ucp_memh_serialize_next(&p, uint8_t, end,
+                                              UCS_MEMORY_TYPE_HOST);
+
+    /* Exported memory handle stuff */
+    address     = (void*)*ucp_memh_serialize_next(&p, uint64_t, end, 0lu);
+    length      = *ucp_memh_serialize_next(&p, uint64_t, end, 0lu);
+    remote_uuid = *ucp_memh_serialize_next(&p, uint64_t, end, 0lu);
+    reg_id      = *ucp_memh_serialize_next(&p, uint64_t, end, UINT64_MAX);
+
+    if (ucs_unlikely(!(flags & UCP_MEMH_BUFFER_FLAG_EXPORTED))) {
+        ucs_error("passed memory handle buffer which does not contain exported"
+                  " memory handle: flags 0x%lx, address %p, length %" PRIu64,
+                  flags, (void*)address, length);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    ucs_assert(length != 0);
+
+    mem_info_parsed_size = UCS_PTR_BYTE_DIFF(export_mkey_buffer, p);
+    ucs_assertv(mem_info_parsed_size <= memh_info_size,
+                "mem_info: parsed_size=%" PRIu64 " packed_size=%" PRIu64,
+                mem_info_parsed_size, memh_info_size);
+    p = end;
+
+    attach_params_num   = 0;
+    attach_params_array = ucs_alloca(sizeof(*attach_params_array) *
+                                     ucs_popcount(remote_md_map) *
+                                     context->num_mds);
+
+    ucs_for_each_bit(remote_md_index, remote_md_map) {
+        ucp_memh_import_parse_tl_mkey_data(context, &p, &tl_mkey_buf,
+                                           &local_md_map);
+
+        if (local_md_map == 0) {
+            continue;
+        }
+
+        ucs_for_each_bit(md_index, local_md_map) {
+            attach_params_array[attach_params_num].md_index    = md_index;
+            attach_params_array[attach_params_num].tl_mkey_buf = tl_mkey_buf;
+            ++attach_params_num;
+        }
+    }
+
+    if (attach_params_num == 0) {
+        ucs_error("couldn't find local MDs which correspond to remote MDs");
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    status = ucp_memh_create(context, address, length, mem_type,
+                             UCT_ALLOC_METHOD_LAST, UCP_MEM_FLAG_IMPORTED,
+                             &memh);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    if (ucs_likely(context->imported_mem_rcaches != NULL)) {
+        /* Try to find rcache of imported memory buffers for the specific peer with
+         * UUID packed in the exported_mkey_buffer */
+        UCP_THREAD_CS_ENTER(&context->mt_lock);
+
+        iter = kh_get(ucp_context_imported_mem_rcaches_hash,
+                      context->imported_mem_rcaches, remote_uuid);
+        if (iter != kh_end(context->imported_mem_rcaches)) {
+            /* Found rcache for the specific peer */
+            rcache = kh_value(context->imported_mem_rcaches, iter);
+            ucs_assert(rcache != NULL);
+
+            rregion = ucs_rcache_lookup_unsafe(rcache, address, length,
+                                               PROT_READ | PROT_WRITE);
+            if (rregion != NULL) {
+                rcache_memh = ucs_derived_of(rregion, ucp_mem_t);
+                if (ucs_likely(ucp_memh_rcache_is_suitable(
+                            rcache_memh, address, length,
+                            UCP_MEM_FLAG_IMPORTED, remote_md_map, 0) &&
+                               (rcache_memh->reg_id == reg_id))) {
+                    memh->parent = rcache_memh;
+                    status       = UCS_OK;
+                    goto out_memh_update;
+                }
+
+                ucs_rcache_region_put_unsafe(rcache, rregion);
+            }
+        }
+
+        UCP_THREAD_CS_EXIT(&context->mt_lock);
+    }
+
+    status = ucp_memh_import_slow(context, rcache, memh, remote_md_map,
+                                  attach_params_array, attach_params_num,
+                                  address, length, remote_uuid, mem_type,
+                                  reg_id);
+    if (status != UCS_OK) {
+        goto err_memh_free;
+    }
+
+out_memh_update:
+    if (memh->parent != memh) {
+        memh->reg_id = memh->parent->reg_id;
+        reg_md_map   = memh->parent->md_map;
+        ucp_memh_update_from_parent_memh(memh, 0, memh->parent->md_map,
+                                         &memh->md_map, &reg_md_map);
+        ucs_assert(reg_md_map == 0);
+    }
+
+    *memh_p = memh;
+out:
+    return status;
+
+err_memh_free:
+    ucs_free(memh);
+    goto out;
 }

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -617,11 +617,6 @@ ucp_memh_get_slow(ucp_context_h context, void *address, size_t length,
         goto out;
     }
 
-    /* Reinitialize address and length, because they could be greater in case
-     * a region which includes the searched region was found in the rcache */
-    reg_address = ucp_memh_address(memh);
-    reg_length  = ucp_memh_length(memh);
-
     ucs_assert(memh->mem_type == mem_type);
 
     status = ucp_memh_register(context, memh, ~memh->md_map & reg_md_map,

--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -18,10 +18,47 @@ ucp_memh_is_zero_length(const ucp_mem_h memh)
     return memh == &ucp_mem_dummy_handle.memh;
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_memh_rcache_is_suitable(ucp_mem_h memh, void *address, size_t length,
+                            uint8_t memh_flags, ucp_md_map_t reg_md_map,
+                            ucp_md_map_t export_md_map)
+{
+    ucp_md_map_t memh_md_map;
+    ucp_md_map_t md_map;
+    const char UCS_V_UNUSED *type;
+
+    if (memh_flags & UCP_MEM_FLAG_REGISTERED) {
+        memh_md_map = memh->md_map;
+        md_map      = reg_md_map;
+        type        = "registration";
+    } else if (memh_flags & UCP_MEM_FLAG_IMPORTED) {
+        memh_md_map = memh->remote_import_md_map;
+        md_map      = reg_md_map;
+        type        = "importing";
+    } else if (memh_flags & UCP_MEM_FLAG_EXPORTED) {
+        memh_md_map = memh->export_md_map;
+        md_map      = export_md_map;
+        type        = "exporting";
+    } else {
+        ucs_fatal("unexpected memory handle flags 0x%x", memh_flags);
+    }
+
+    if (ucs_likely(ucs_test_all_flags(memh_md_map, md_map))) {
+        ucs_trace("memh %p: address %p/%p length %zu/%zu md_map %" PRIx64 "/%"
+                  PRIx64 " obtained from rcache for %s", memh, address,
+                  ucp_memh_address(memh), length, ucp_memh_length(memh),
+                  md_map, memh_md_map, type);
+        return 1;
+    }
+
+    return 0;
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_memh_get(ucp_context_h context, void *address, size_t length,
              ucs_memory_type_t mem_type, ucp_md_map_t reg_md_map,
-             unsigned uct_flags, ucp_mem_h *memh_p)
+             ucp_md_map_t export_md_map, unsigned uct_flags,
+             uint8_t memh_flags, ucp_mem_h *memh_p)
 {
     ucs_rcache_region_t *rregion;
     ucs_status_t status;
@@ -46,15 +83,18 @@ ucp_memh_get(ucp_context_h context, void *address, size_t length,
 
         memh = ucs_derived_of(rregion, ucp_mem_t);
 
-        if (ucs_likely(ucs_test_all_flags(memh->md_map, reg_md_map))) {
-            ucs_trace("memh %p: address %p/%p length %zu/%zu md_map %" PRIx64
-                      "/%" PRIx64 " obtained from rcache", memh, address,
-                      ucp_memh_address(memh), length, ucp_memh_length(memh),
-                      reg_md_map, memh->md_map);
+        if (ucs_likely(ucp_memh_rcache_is_suitable(memh, address, length,
+                                                   memh_flags, reg_md_map,
+                                                   export_md_map))) {
             *memh_p = memh;
             status = UCS_OK;
             goto out_unlock;
         }
+
+        /* If the memory handle was already registered or shared, we should
+         * restore these registrations */
+        memh_flags |= (memh->flags & (UCP_MEM_FLAG_REGISTERED |
+                                      UCP_MEM_FLAG_EXPORTED));
 
         ucs_rcache_region_put_unsafe(context->rcache, rregion);
 not_found:
@@ -62,7 +102,7 @@ not_found:
     }
 
     return ucp_memh_get_slow(context, address, length, mem_type, reg_md_map,
-                             uct_flags, memh_p);
+                             export_md_map, uct_flags, memh_flags, memh_p);
 out_unlock:
     UCP_THREAD_CS_EXIT(&context->mt_lock);
     return status;
@@ -71,6 +111,9 @@ out_unlock:
 static UCS_F_ALWAYS_INLINE void
 ucp_memh_put(ucp_context_h context, ucp_mem_h memh)
 {
+    ucs_rcache_t *rcache;
+    khiter_t iter;
+
     ucs_trace("memh %p: release address %p length %zu md_map %" PRIx64,
               memh, ucp_memh_address(memh), ucp_memh_length(memh),
               memh->md_map);
@@ -87,9 +130,20 @@ ucp_memh_put(ucp_context_h context, ucp_mem_h memh)
     }
 
     ucs_assert(context->rcache != NULL);
+    ucs_assert(context->imported_mem_rcaches != NULL);
 
     UCP_THREAD_CS_ENTER(&context->mt_lock);
-    ucs_rcache_region_put_unsafe(context->rcache, &memh->super);
+    if (!(memh->flags & UCP_MEM_FLAG_IMPORTED)) {
+        ucs_rcache_region_put_unsafe(context->rcache, &memh->super);
+    } else {
+        iter = kh_get(ucp_context_imported_mem_rcaches_hash,
+                      context->imported_mem_rcaches, memh->remote_uuid);
+        ucs_assert(iter != kh_end(context->imported_mem_rcaches));
+
+        rcache = kh_value(context->imported_mem_rcaches, iter);
+        ucs_assert(rcache != NULL);
+        ucs_rcache_region_put_unsafe(rcache, &memh->super);
+    }
     UCP_THREAD_CS_EXIT(&context->mt_lock);
 }
 

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -33,7 +33,12 @@ typedef struct {
 static struct {
     ucp_md_map_t md_map;
     uint8_t      mem_type;
-} UCS_S_PACKED ucp_mem_dummy_buffer = {0, UCS_MEMORY_TYPE_HOST};
+} UCS_S_PACKED ucp_memh_rkey_dummy_buffer = {0, UCS_MEMORY_TYPE_HOST};
+
+
+ucp_memh_dummy_buffer_t ucp_memh_dummy_buffer = { 
+    sizeof(ucp_memh_dummy_buffer)
+};
 
 const ucp_amo_proto_t *ucp_amo_proto_list[] = {
     [UCP_RKEY_BASIC_PROTO] = &ucp_amo_basic_proto,
@@ -44,6 +49,10 @@ const ucp_rma_proto_t *ucp_rma_proto_list[] = {
     [UCP_RKEY_BASIC_PROTO] = &ucp_rma_basic_proto,
     [UCP_RKEY_SW_PROTO]    = &ucp_rma_sw_proto
 };
+
+
+/* Storage for a default value returned from  */
+uint64_t memh_serialize_default_val = 0;
 
 
 size_t ucp_rkey_packed_size(ucp_context_h context, ucp_md_map_t md_map,
@@ -213,61 +222,305 @@ UCS_PROFILE_FUNC(ssize_t, ucp_rkey_pack_memh,
                                 sys_dev_map, sys_distance, buffer, 1, 0);
 }
 
+static size_t ucp_memh_common_packed_size()
+{
+    size_t size;
+
+    /* Size of mkey information which comes prior TL mkey data of all MDs */
+    size = sizeof(uint16_t);
+
+    /* Flags */
+    size += sizeof(uint64_t);
+
+    /* Memory domains map */
+    size += sizeof(ucp_md_map_t);
+
+    /* Memory type */
+    size += sizeof(uint8_t);
+
+    return size;
+}
+
+static void* ucp_memh_common_pack(const ucp_mem_h memh, void *buffer,
+                                  uint16_t **memh_info_size_p)
+{
+    ucp_context_h UCS_V_UNUSED context = memh->context;
+    void *p                            = buffer;
+
+    /* Check that md_map is valid */
+    ucs_assert(ucs_test_all_flags(UCS_MASK(context->num_mds), memh->md_map));
+
+    /* Size of mkey information which comes prior TL mkey data of all MDs */
+    *memh_info_size_p                 = p;
+    *ucs_serialize_next(&p, uint16_t) = ucp_memh_common_packed_size();
+
+    /* Flags */
+    *ucs_serialize_next(&p, uint64_t) = (memh->flags & UCP_MEM_FLAG_EXPORTED) ?
+                                        UCP_MEMH_BUFFER_FLAG_EXPORTED : 0;
+
+    /* Memory domains map */
+    *ucs_serialize_next(&p, ucp_md_map_t) = memh->export_md_map;
+
+    /* Memory type */
+    UCS_STATIC_ASSERT(UCS_MEMORY_TYPE_LAST <= 255);
+    *ucs_serialize_next(&p, uint8_t) = memh->mem_type;
+
+    return p;
+}
+
+size_t ucp_memh_global_id_packed_size(uct_md_attr_v2_t *md_attr)
+{
+    size_t size = UCT_MD_GLOBAL_ID_MAX;
+
+    while ((size != 0) && (md_attr->global_id[size - 1] == '\0')) {
+        --size;
+    }
+
+    ucs_assert(size < UCT_MD_GLOBAL_ID_MAX);
+    return size;
+}
+
+static size_t
+ucp_memh_exported_packed_size(ucp_context_h context, ucp_md_map_t md_map)
+{
+    size_t size = ucp_memh_common_packed_size();
+    uct_md_attr_v2_t *md_attr;
+    ucp_md_index_t md_index;
+
+    /* Address */
+    size += sizeof(uint64_t);
+
+    /* Length */
+    size += sizeof(uint64_t);
+
+    /* UCP uuid */
+    size += sizeof(uint64_t);
+
+    /* Registration ID */
+    size += sizeof(uint64_t);
+
+    ucs_for_each_bit(md_index, md_map) {
+        md_attr = &context->tl_mds[md_index].attr;
+
+        /* Size of packed TL mkey data */
+        size += sizeof(uint16_t);
+
+        /* TL mkey size */
+        size += sizeof(uint8_t);
+
+        /* TL mkey */
+        size += md_attr->exported_mkey_packed_size;
+
+        /* Size of component name */
+        size += sizeof(uint8_t);
+
+        /* Component name */
+        size += strlen(md_attr->component_name);
+
+        /* Size of global MD identifier */
+        size += sizeof(uint8_t);
+
+        /* Global MD identifier */
+        size += ucp_memh_global_id_packed_size(md_attr);
+    }
+
+    return size;
+}
+
+static ssize_t
+ucp_memh_exported_pack(const ucp_mem_h memh, void *buffer)
+{
+    ucp_context_h context            = memh->context;
+    uint64_t address                 = (uint64_t)ucp_memh_address(memh);
+    uint64_t length                  = ucp_memh_length(memh);
+    uct_mem_h *uct_memhs             = &memh->uct[context->num_mds];
+    void *p                          = buffer;
+    ucp_tl_md_t *tl_mds              = context->tl_mds;
+    uct_md_mkey_pack_params_t params = { 0 };
+    uct_md_attr_v2_t *md_attr;
+    void *md_data_p, *common_memh_info_p;
+    uint16_t *memh_info_size_p;
+    char UCS_V_UNUSED buf[128];
+    ucs_status_t status;
+    ssize_t result;
+    ucp_md_index_t md_index;
+    unsigned uct_memh_index;
+    size_t tl_mkey_size, component_name_size, global_id_size;
+    void *tl_mkey_buf, *component_name_buf, *global_id_buf;
+    size_t tl_mkey_data_size;
+
+    ucs_log_indent(1);
+
+    p                  = ucp_memh_common_pack(memh, p, &memh_info_size_p);
+    common_memh_info_p = p;
+
+    /* Address */
+    *ucs_serialize_next(&p, uint64_t) = address;
+
+    /* Length */
+    *ucs_serialize_next(&p, uint64_t) = length;
+
+    /* UCP uuid */
+    *ucs_serialize_next(&p, uint64_t) = context->uuid;
+
+    /* Registration ID */
+    *ucs_serialize_next(&p, uint64_t) = memh->reg_id;
+
+    /* Store the size of an exported memh information */
+    *memh_info_size_p += UCS_PTR_BYTE_DIFF(common_memh_info_p, p);
+
+    uct_memh_index = 0;
+    ucs_for_each_bit(md_index, memh->export_md_map) {
+        md_attr = &tl_mds[md_index].attr;
+
+        /* Save pointer to the begging of the TL mkey data to fill later by the
+         * resulted size of TL mkey data */
+        md_data_p                         = p;
+        *ucs_serialize_next(&p, uint16_t) = 0;
+
+        /* TL mkey size */
+        tl_mkey_size = md_attr->exported_mkey_packed_size;
+        ucs_assertv((tl_mkey_size <= UINT8_MAX) && (tl_mkey_size != 0),
+                    "tl_mkey_size %zu", tl_mkey_size);
+        *ucs_serialize_next(&p, uint8_t) = tl_mkey_size;
+
+        /* TL mkey */
+        tl_mkey_buf = ucs_serialize_next_raw(&p, void, tl_mkey_size);
+        status      = uct_md_mkey_pack_v2(tl_mds[md_index].md,
+                                          uct_memhs[md_index], &params,
+                                          tl_mkey_buf);
+        if (status != UCS_OK) {
+            result = status;
+            goto out;
+        }
+
+        /* Size of component name */
+        component_name_size              = strlen(md_attr->component_name);
+        *ucs_serialize_next(&p, uint8_t) = component_name_size;
+
+        /* Component name */
+        component_name_buf = ucs_serialize_next_raw(&p, void,
+                                                    component_name_size);
+        memcpy(component_name_buf, md_attr->component_name,
+               component_name_size);
+
+        /* Size of global MD identifier */
+        global_id_size                   =
+                ucp_memh_global_id_packed_size(md_attr);
+        *ucs_serialize_next(&p, uint8_t) = global_id_size;
+
+        /* Global MD identifier */
+        global_id_buf = ucs_serialize_next_raw(&p, void, global_id_size);
+        memcpy(global_id_buf, md_attr->global_id, global_id_size);
+
+        /* Size of TL mkey data */
+        tl_mkey_data_size = UCS_PTR_BYTE_DIFF(md_data_p, p);
+        ucs_assertv((tl_mkey_data_size <= UINT16_MAX) &&
+                    (tl_mkey_data_size != 0),
+                    "tl_mkey_data_size %zu", tl_mkey_data_size);
+        *(uint16_t*)md_data_p = tl_mkey_data_size;
+
+        ucs_trace("exported mkey[%d]=%s for md[%d]=%s", uct_memh_index,
+                  ucs_str_dump_hex(p, tl_mkey_size, buf, sizeof(buf),
+                                   SIZE_MAX),
+                  md_index, tl_mds[md_index].rsc.md_name);
+        ++uct_memh_index;
+    }
+
+    result = UCS_PTR_BYTE_DIFF(buffer, p);
+
+out:
+    ucs_log_indent(-1);
+    return result;
+}
+
+static size_t ucp_memh_packed_size(ucp_mem_h memh, int rkey_compat)
+{
+    ucp_context_h context = memh->context;
+
+    if (memh->flags & UCP_MEM_FLAG_EXPORTED) {
+        ucs_assert(!rkey_compat);
+        return ucp_memh_exported_packed_size(context, memh->export_md_map);
+    }
+    
+    if (rkey_compat) {
+        return ucp_rkey_packed_size(context, memh->md_map,
+                                    UCS_SYS_DEVICE_ID_UNKNOWN, 0);
+    }
+
+    ucs_fatal("packing rkey using ucp_memh_pack() is unsupported");
+}
+
+static ssize_t
+ucp_memh_do_pack(ucp_mem_h memh, int rkey_compat, void *memh_buffer)
+{
+    ucp_memory_info_t mem_info;
+
+    if (memh->flags & UCP_MEM_FLAG_EXPORTED) {
+        return ucp_memh_exported_pack(memh, memh_buffer);
+    }
+
+    if (rkey_compat) {
+        mem_info.type    = memh->mem_type;
+        mem_info.sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+        return ucp_rkey_pack_memh(memh->context, memh->md_map, memh, &mem_info,
+                                  0, NULL, memh_buffer);
+    }
+
+    ucs_fatal("packing rkey using ucp_memh_pack() is unsupported");
+}
+
 static ucs_status_t
 ucp_memh_pack_internal(ucp_mem_h memh, const ucp_memh_pack_params_t *params,
                        int rkey_compat, void **buffer_p, size_t *buffer_size_p)
 {
     ucp_context_h context = memh->context;
-    ucp_memory_info_t mem_info;
     ucs_status_t status;
     ssize_t packed_size;
-    void *rkey_buffer;
+    void *memh_buffer;
     size_t size;
 
-    ucs_trace("packing rkeys for buffer %p memh %p md_map 0x%"PRIx64,
-              ucp_memh_address(memh), memh, memh->md_map);
-
-    if (!rkey_compat) {
-        return UCS_ERR_UNSUPPORTED;
-    }
+    ucs_trace("packing memh %p for buffer %p md_map 0x%" PRIx64
+              " export_md_map 0x%" PRIx64, memh, ucp_memh_address(memh),
+              memh->md_map, memh->export_md_map);
 
     if (ucp_memh_is_zero_length(memh)) {
         /* Dummy memh, return dummy key */
-        *buffer_p      = &ucp_mem_dummy_buffer;
-        *buffer_size_p = sizeof(ucp_mem_dummy_buffer);
+        if (rkey_compat) {
+            *buffer_p      = &ucp_memh_rkey_dummy_buffer;
+            *buffer_size_p = sizeof(ucp_memh_rkey_dummy_buffer);
+        } else {
+            *buffer_p      = &ucp_memh_dummy_buffer;
+            *buffer_size_p = sizeof(ucp_memh_dummy_buffer);
+        }
         return UCS_OK;
     }
 
     UCP_THREAD_CS_ENTER(&context->mt_lock);
 
-    size        = ucp_rkey_packed_size(context, memh->md_map,
-                                       UCS_SYS_DEVICE_ID_UNKNOWN, 0);
-    rkey_buffer = ucs_malloc(size, "ucp_rkey_buffer");
-    if (rkey_buffer == NULL) {
+    size        = ucp_memh_packed_size(memh, rkey_compat);
+    memh_buffer = ucs_malloc(size, "ucp_memh_buffer");
+    if (memh_buffer == NULL) {
         status = UCS_ERR_NO_MEMORY;
         goto out;
     }
 
-    mem_info.type    = memh->mem_type;
-    mem_info.sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-
-    packed_size = ucp_rkey_pack_memh(context, memh->md_map, memh, &mem_info, 0,
-                                     NULL, rkey_buffer);
-
+    packed_size = ucp_memh_do_pack(memh, rkey_compat, memh_buffer);
     if (packed_size < 0) {
         status = (ucs_status_t)packed_size;
         goto err_destroy;
     }
 
-    ucs_assert(packed_size == size);
+    ucs_assertv(packed_size == size, "packed_size=%zd size=%zu", packed_size,
+                size);
 
-    *buffer_p      = rkey_buffer;
+    *buffer_p      = memh_buffer;
     *buffer_size_p = size;
     status         = UCS_OK;
     goto out;
 
 err_destroy:
-    ucs_free(rkey_buffer);
+    ucs_free(memh_buffer);
 out:
     UCP_THREAD_CS_EXIT(&context->mt_lock);
     return status;
@@ -283,7 +536,8 @@ ucp_memh_pack(ucp_mem_h memh, const ucp_memh_pack_params_t *params,
 void ucp_memh_buffer_release(void *buffer,
                              const ucp_memh_buffer_release_params_t *params)
 {
-    if (buffer == &ucp_mem_dummy_buffer) {
+    if ((buffer == &ucp_memh_dummy_buffer) ||
+        (buffer == &ucp_memh_rkey_dummy_buffer)) {
         /* Dummy key, just return */
         return;
     }

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -12,6 +12,22 @@
 #include <ucp/core/ucp_context.h>
 
 
+#define ucp_memh_serialize_next(_iter, _type, _end, _default) \
+    ({ \
+        _type *_ret; \
+        if (sizeof(_type) <= UCS_PTR_BYTE_DIFF(*_iter, _end)) { \
+            _ret = ucs_serialize_next(_iter, _type); \
+        } else { \
+            UCS_STATIC_ASSERT(sizeof(_type) <= \
+                              sizeof(memh_serialize_default_val)); \
+            _ret  = (_type*)&memh_serialize_default_val; \
+            *_ret = (_type)(_default); \
+        } \
+        _ret; \
+    })
+
+
+
 /**
  * Rkey proto index
  */
@@ -156,6 +172,9 @@ typedef struct ucp_rkey {
 #endif
 
 
+extern uint64_t memh_serialize_default_val;
+
+
 void ucp_rkey_resolve_inner(ucp_rkey_h rkey, ucp_ep_h ep);
 
 
@@ -190,6 +209,8 @@ ucp_rkey_pack_memh(ucp_context_h context, ucp_md_map_t md_map,
                    const ucp_mem_h memh, const ucp_memory_info_t *mem_info,
                    ucp_sys_dev_map_t sys_dev_map,
                    const ucs_sys_dev_distance_t *sys_distance, void *buffer);
+
+size_t ucp_memh_global_id_packed_size(uct_md_attr_v2_t *md_attr);
 
 
 ucs_status_t

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -61,8 +61,8 @@ ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
     for (iov_index = 0; iov_index < iov_count; ++iov_index) {
         iov    = ucp_datatype_iter_iov_at(dt_iter, iov_index);
         status = ucp_memh_get(context, iov->buffer, iov->length,
-                              dt_iter->mem_info.type, md_map, uct_flags,
-                              &iov_memh[iov_index]);
+                              dt_iter->mem_info.type, md_map, 0, uct_flags,
+                              UCP_MEM_FLAG_REGISTERED, &iov_memh[iov_index]);
         if (status != UCS_OK) {
             ucp_datatype_iter_iov_mem_dereg(context, dt_iter);
             return status;

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -556,7 +556,8 @@ ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
         return ucp_memh_get(context, dt_iter->type.contig.buffer,
                             dt_iter->length,
                             (ucs_memory_type_t)dt_iter->mem_info.type, md_map,
-                            uct_flags, &dt_iter->type.contig.memh);
+                            0, uct_flags, UCP_MEM_FLAG_REGISTERED,
+                            &dt_iter->type.contig.memh);
     } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
         return ucp_datatype_iter_iov_mem_reg(context, dt_iter, md_map,
                                              uct_flags);

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1005,6 +1005,15 @@ static void ucp_wireup_fill_peer_err_criteria(ucp_wireup_criteria_t *criteria,
     }
 }
 
+static void
+ucp_wireup_fill_exported_memh_criteria(ucp_context_h context,
+                                       ucp_wireup_criteria_t *criteria)
+{
+    if (context->config.features & UCP_FEATURE_EXPORTED_MEMH) {
+        criteria->local_md_flags |= UCT_MD_FLAG_EXPORTED_MKEY;
+    }
+}
+
 static double ucp_wireup_aux_score_func(const ucp_worker_iface_t *wiface,
                                         const uct_md_attr_v2_t *md_attr,
                                         const ucp_address_entry_t *remote_addr,
@@ -1069,9 +1078,11 @@ static void ucp_wireup_criteria_init(ucp_wireup_criteria_t *criteria)
 /**
  * Check whether emulation over AM is allowed for RMA/AMO lanes
  */
-static int ucp_wireup_allow_am_emulation_layer(unsigned ep_init_flags)
+static int ucp_wireup_allow_am_emulation_layer(ucp_context_h context,
+                                               unsigned ep_init_flags)
 {
-    return !(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE);
+    return !(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) &&
+           !(context->config.features & UCP_FEATURE_EXPORTED_MEMH);
 }
 
 static unsigned
@@ -1104,6 +1115,8 @@ static ucs_status_t
 ucp_wireup_add_rma_lanes(const ucp_wireup_select_params_t *select_params,
                          ucp_wireup_select_context_t *select_ctx)
 {
+    ucp_ep_h ep                    = select_params->ep;
+    ucp_context_h context          = ep->worker->context;
     unsigned ep_init_flags         = ucp_wireup_ep_init_flags(select_params,
                                                               select_ctx);
     ucp_wireup_criteria_t criteria = {};
@@ -1137,6 +1150,7 @@ ucp_wireup_add_rma_lanes(const ucp_wireup_select_params_t *select_params,
     }
     criteria.calc_score             = ucp_wireup_rma_score_func;
     ucp_wireup_fill_peer_err_criteria(&criteria, ep_init_flags);
+    ucp_wireup_fill_exported_memh_criteria(context, &criteria);
 
     tl_bitmap = ucp_tl_bitmap_max;
     for (mem_type = 0; mem_type < UCS_MEMORY_TYPE_LAST; ++mem_type) {
@@ -1189,6 +1203,7 @@ ucp_wireup_add_amo_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_wireup_init_select_flags(&criteria.local_iface_flags,
                                  UCT_IFACE_FLAG_PENDING, 0);
     ucp_wireup_fill_peer_err_criteria(&criteria, ep_init_flags);
+    ucp_wireup_fill_exported_memh_criteria(context, &criteria);
     ucp_context_uct_atomic_iface_flags(context, &criteria.remote_atomic_flags);
 
     /* We can use only non-p2p resources or resources which are explicitly
@@ -1652,6 +1667,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_wireup_init_select_flags(&bw_info.criteria.local_iface_flags,
                                  UCT_IFACE_FLAG_PENDING, 0);
     ucp_wireup_fill_peer_err_criteria(&bw_info.criteria, ep_init_flags);
+    ucp_wireup_fill_exported_memh_criteria(context, &bw_info.criteria);
 
     if (ucs_test_all_flags(ucp_ep_get_context_features(ep),
                            UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP)) {
@@ -1676,6 +1692,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         bw_info.criteria.local_cmpt_flags |= UCT_COMPONENT_FLAG_RKEY_PTR;
         bw_info.criteria.lane_type         = UCP_LANE_TYPE_RKEY_PTR;
         bw_info.max_lanes                  = 1;
+        ucp_wireup_fill_peer_err_criteria(&bw_info.criteria, ep_init_flags);
+        ucp_wireup_fill_exported_memh_criteria(context, &bw_info.criteria);
 
         UCP_CONTEXT_MEM_CAP_TLS(context, UCS_MEMORY_TYPE_HOST, access_mem_types,
                                 tl_bitmap);
@@ -1687,6 +1705,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     bw_info.criteria.lane_type        = UCP_LANE_TYPE_RMA_BW;
     bw_info.max_lanes                 = context->config.ext.max_rndv_lanes;
     bw_info.criteria.local_cmpt_flags = 0;
+    ucp_wireup_fill_peer_err_criteria(&bw_info.criteria, ep_init_flags);
+    ucp_wireup_fill_exported_memh_criteria(context, &bw_info.criteria);
 
     /* If error handling is requested we require memory invalidation
      * support to provide correct data integrity in case of error */
@@ -1713,6 +1733,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         /* Set the new iface RMA flags */
         ucp_wireup_criteria_iface_flags_add(&bw_info.criteria, &iface_rma_flags,
                                             &peer_rma_flags);
+        ucp_wireup_fill_peer_err_criteria(&bw_info.criteria, ep_init_flags);
+        ucp_wireup_fill_exported_memh_criteria(context, &bw_info.criteria);
 
         /* Add lanes that can access the memory by short operations */
         added_lanes = 0;
@@ -1868,7 +1890,8 @@ ucp_wireup_select_params_init(ucp_wireup_select_params_t *select_params,
     select_params->tl_bitmap     = tl_bitmap;
     select_params->address       = remote_address;
     select_params->allow_am      =
-            ucp_wireup_allow_am_emulation_layer(ep_init_flags);
+            ucp_wireup_allow_am_emulation_layer(ep->worker->context,
+                                                ep_init_flags);
     select_params->show_error    = show_error;
 }
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -19,21 +19,26 @@ extern "C" {
 class test_ucp_mmap : public ucp_test {
 public:
     enum {
-        VARIANT_DEFAULT,
-        VARIANT_MAP_NONBLOCK,
-        VARIANT_PROTO_ENABLE,
-        VARIANT_NO_RCACHE
+        VARIANT_MAP_NONBLOCK   = UCS_BIT(0),
+        VARIANT_PROTO_ENABLE   = UCS_BIT(1),
+        VARIANT_NO_SEND_RCACHE = UCS_BIT(2),
+        VARIANT_NO_RECV_RCACHE = UCS_BIT(3)
     };
 
     static void
     get_test_variants(std::vector<ucp_test_variant>& variants)
     {
-        add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_DEFAULT, "");
+        add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "");
         add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_MAP_NONBLOCK,
                                "map_nb");
         add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_PROTO_ENABLE,
                                "proto");
-        add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_NO_RCACHE,
+        add_variant_with_value(variants, UCP_FEATURE_RMA,
+                               VARIANT_NO_SEND_RCACHE, "no_send_rcache");
+        add_variant_with_value(variants, UCP_FEATURE_RMA,
+                               VARIANT_NO_RECV_RCACHE, "no_recv_rcache");
+        add_variant_with_value(variants, UCP_FEATURE_RMA,
+                               VARIANT_NO_SEND_RCACHE | VARIANT_NO_RECV_RCACHE,
                                "no_rcache");
     }
 
@@ -43,11 +48,20 @@ public:
             modify_config("PROTO_ENABLE", "y");
         }
 
-        if (get_variant_value() == VARIANT_NO_RCACHE) {
+        test_base::init();
+
+        if (get_variant_value() & VARIANT_NO_SEND_RCACHE) {
             modify_config("RCACHE_ENABLE", "n");
         }
+        create_entity(); // sender
 
-        ucp_test::init();
+        if (!is_self()) {
+            if (get_variant_value() & VARIANT_NO_RECV_RCACHE) {
+                modify_config("RCACHE_ENABLE", "n");
+            }
+            create_entity(); // receiver
+        }
+
         sender().connect(&receiver(), get_ep_params());
         if (!is_loopback()) {
             receiver().connect(&sender(), get_ep_params());
@@ -55,7 +69,7 @@ public:
     }
 
     unsigned mem_map_flags() const {
-        return (get_variant_value() == VARIANT_MAP_NONBLOCK) ?
+        return (get_variant_value() & VARIANT_MAP_NONBLOCK) ?
                        UCP_MEM_MAP_NONBLOCK :
                        0;
     }
@@ -75,12 +89,53 @@ public:
         return has_transport("shm");
     }
 
+    void compare_uct_memhs(const ucp_mem_h memh1, const ucp_mem_h memh2,
+                           bool equal = true)
+    {
+        ucp_md_index_t md_index;
+        ucp_md_map_t md_map;
+        ucp_md_index_t uct_memh_offset;
+
+        if (memh1->flags & UCP_MEM_FLAG_EXPORTED) {
+            md_map          = memh1->export_md_map;
+            uct_memh_offset = sender().ucph()->num_mds;
+        } else {
+            md_map          = memh1->md_map;
+            uct_memh_offset = 0;
+        }
+
+        EXPECT_NE(md_map, 0);
+        ucs_for_each_bit(md_index, md_map) {
+            if (equal) {
+                EXPECT_EQ(memh2->uct[uct_memh_offset + md_index],
+                          memh1->uct[uct_memh_offset + md_index]);
+            } else {
+                EXPECT_NE(memh2->uct[uct_memh_offset + md_index],
+                          memh1->uct[uct_memh_offset + md_index]);
+            }
+        }
+    }
+
+    void compare_memhs(const ucp_mem_h memh1, const ucp_mem_h memh2)
+    {
+        const uint8_t flags = UCP_MEM_FLAG_REGISTERED |
+                              UCP_MEM_FLAG_EXPORTED |
+                              UCP_MEM_FLAG_IMPORTED;
+
+        EXPECT_NE(memh1, memh2);
+        EXPECT_EQ(memh1->reg_id, memh2->reg_id);
+        EXPECT_EQ(memh2->flags & flags, memh1->flags & flags);
+
+        compare_uct_memhs(memh1, memh2);
+    }
+
 protected:
     bool resolve_rma(entity *e, ucp_rkey_h rkey);
     bool resolve_amo(entity *e, ucp_rkey_h rkey);
     bool resolve_rma_bw_get_zcopy(entity *e, ucp_rkey_h rkey);
     bool resolve_rma_bw_put_zcopy(entity *e, ucp_rkey_h rkey);
     void test_length0(unsigned flags);
+    void test_rereg(unsigned flags = 0, bool import_mem = false);
     void test_rkey_management(ucp_mem_h memh, bool is_dummy,
                               bool expect_rma_offload);
     bool enable_proto() const;
@@ -89,6 +144,9 @@ private:
     void expect_same_distance(const ucs_sys_dev_distance_t &dist1,
                               const ucs_sys_dev_distance_t &dist2);
     void test_rkey_proto(ucp_mem_h memh);
+    void test_rereg_local_mem(ucp_mem_h memh, void *ptr, size_t size,
+                              unsigned flags);
+    void test_rereg_imported_mem(ucp_mem_h memh, size_t size);
 };
 
 bool test_ucp_mmap::resolve_rma(entity *e, ucp_rkey_h rkey)
@@ -257,7 +315,7 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
 
 bool test_ucp_mmap::enable_proto() const
 {
-    return get_variant_value() == VARIANT_PROTO_ENABLE;
+    return get_variant_value() & VARIANT_PROTO_ENABLE;
 }
 
 void test_ucp_mmap::expect_same_distance(const ucs_sys_dev_distance_t &dist1,
@@ -417,61 +475,175 @@ UCS_TEST_P(test_ucp_mmap, reg_mem_type) {
     }
 }
 
-UCS_TEST_P(test_ucp_mmap, rereg)
+void test_ucp_mmap::test_rereg_local_mem(ucp_mem_h memh, void *ptr,
+                                         size_t size, unsigned flags)
+{
+    ucs_status_t status;
+    const int num_iters     = 4;
+    const void *end_address = UCS_PTR_BYTE_OFFSET(ptr, size);
+
+    for (int i = 0; i < num_iters; ++i) {
+        size_t offset       = (size != 0) ? ucs::rand() % size : 0;
+        void *start_address = UCS_PTR_BYTE_OFFSET(ptr, offset);
+        ucp_mem_h test_memh;
+        ucp_mem_map_params_t params;
+
+        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                            UCP_MEM_MAP_PARAM_FIELD_LENGTH  |
+                            UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+        params.flags      = mem_map_flags() | flags;
+        params.address    = start_address;
+        params.length     = UCS_PTR_BYTE_DIFF(start_address, end_address);
+        status            = ucp_mem_map(sender().ucph(), &params, &test_memh);
+        ASSERT_UCS_OK(status);
+
+        if (size == 0) {
+            EXPECT_EQ(memh, test_memh);
+            EXPECT_EQ(&ucp_mem_dummy_handle.memh, test_memh);
+        } else if (get_variant_value() & VARIANT_NO_SEND_RCACHE) {
+            EXPECT_NE(test_memh->reg_id, memh->reg_id);
+            compare_uct_memhs(test_memh, memh, false);
+        } else {
+            compare_memhs(test_memh, memh);
+        }
+
+        status = ucp_mem_unmap(sender().ucph(), test_memh);
+        ASSERT_UCS_OK(status);
+    }
+}
+
+void test_ucp_mmap::test_rereg_imported_mem(ucp_mem_h memh,
+                                            size_t size)
+{
+    const ucp_memh_pack_params_t pack_params              = { 0 };
+    const ucp_memh_buffer_release_params_t release_params = { 0 };
+    ucs_status_t status;
+    void *exported_memh_buf;
+    size_t exported_memh_buf_size;
+
+    status = ucp_memh_pack(memh, &pack_params, &exported_memh_buf,
+                           &exported_memh_buf_size);
+    ASSERT_UCS_OK(status);
+
+    ucp_mem_h imp_memh;
+    ucp_mem_map_params_t params;
+    params.field_mask           =
+            UCP_MEM_MAP_PARAM_FIELD_FLAGS |
+            UCP_MEM_MAP_PARAM_FIELD_EXPORTED_MEMH_BUFFER;
+    params.flags                = UCP_MEM_MAP_EXPORT;
+    params.exported_memh_buffer = exported_memh_buf;
+    status                      = ucp_mem_map(receiver().ucph(), &params,
+                                              &imp_memh);
+    ASSERT_UCS_OK(status);
+
+    ucp_mem_h test_imp_memh;
+
+    status = ucp_mem_map(receiver().ucph(), &params, &test_imp_memh);
+    ASSERT_UCS_OK(status);
+
+    ucp_memh_buffer_release(exported_memh_buf, &release_params);
+
+    if (size == 0) {
+        EXPECT_EQ(memh, test_imp_memh);
+        EXPECT_EQ(&ucp_mem_dummy_handle.memh, test_imp_memh);
+    } else if (get_variant_value() & (VARIANT_NO_SEND_RCACHE |
+                                      VARIANT_NO_RECV_RCACHE)) {
+        EXPECT_EQ(test_imp_memh->reg_id, memh->reg_id);
+        compare_uct_memhs(test_imp_memh, imp_memh, false);
+    } else {
+        EXPECT_EQ(test_imp_memh->reg_id, memh->reg_id);
+        compare_memhs(test_imp_memh, imp_memh);
+    }
+
+    status = ucp_mem_unmap(receiver().ucph(), test_imp_memh);
+    ASSERT_UCS_OK(status);
+
+    status = ucp_mem_unmap(receiver().ucph(), imp_memh);
+    ASSERT_UCS_OK(status);
+}
+
+void test_ucp_mmap::test_rereg(unsigned flags, bool import_mem)
 {
     ucs_status_t status;
 
     for (int i = 0; i < (100 / ucs::test_time_multiplier()); ++i) {
         size_t size = ucs::rand() % UCS_MBYTE;
-        mem_buffer buf(size, UCS_MEMORY_TYPE_HOST);
-        mem_buffer::pattern_fill(buf.ptr(), size, 0, UCS_MEMORY_TYPE_HOST);
+        mem_buffer *buf;
+        void *ptr;
+
+        if (flags & UCP_MEM_MAP_ALLOCATE) {
+            buf = NULL;
+            ptr = NULL;
+        } else {
+            buf = new mem_buffer(size, UCS_MEMORY_TYPE_HOST);
+            ptr = buf->ptr();
+        }
 
         ucp_mem_h memh;
         ucp_mem_map_params_t params;
         params.field_mask  = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                              UCP_MEM_MAP_PARAM_FIELD_LENGTH  |
                              UCP_MEM_MAP_PARAM_FIELD_FLAGS;
-        params.address     = buf.ptr();
+        params.address     = ptr;
         params.length      = size;
-        params.flags       = mem_map_flags();
+        params.flags       = mem_map_flags() | flags;
 
         status = ucp_mem_map(sender().ucph(), &params, &memh);
-        if (status == UCS_ERR_UNSUPPORTED) {
-            UCS_TEST_SKIP_R("memory sharing is unsupported");
+        if ((status == UCS_ERR_UNSUPPORTED) &&
+            (params.flags & UCP_MEM_MAP_EXPORT)) {
+            delete buf;
+            UCS_TEST_SKIP_R("memory exporting is unsupported");
         }
         ASSERT_UCS_OK(status);
 
-        if (get_variant_value() != VARIANT_NO_RCACHE) {
-            const int num_iters     = 4;
-            const void *end_address = UCS_PTR_BYTE_OFFSET(buf.ptr(), size);
+        ucp_mem_attr_t memh_attr;
+        memh_attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS;
+        status               = ucp_mem_query(memh, &memh_attr);
+        ASSERT_UCS_OK(status);
+        ptr = memh_attr.address;
 
-            for (int i = 0; i < num_iters; ++i) {
-                size_t offset       = (size == 0) ? 0 : (ucs::rand() % size);
-                void *start_address = UCS_PTR_BYTE_OFFSET(buf.ptr(), offset);
-                ucp_mem_h test_memh;
-
-                params.address = start_address;
-                params.length  = UCS_PTR_BYTE_DIFF(start_address, end_address);
-                status         = ucp_mem_map(sender().ucph(), &params,
-                                             &test_memh);
-                ASSERT_UCS_OK(status);
-
-                // Check that unique memory handle was returned
-                if (size != 0) {
-                    EXPECT_NE(memh, test_memh);
-                } else {
-                    EXPECT_EQ(memh, test_memh);
-                    EXPECT_EQ(&ucp_mem_dummy_handle.memh, test_memh);
-                }
-
-                status = ucp_mem_unmap(sender().ucph(), test_memh);
-                ASSERT_UCS_OK(status);
-            }
+        if (import_mem) {
+            test_rereg_imported_mem(memh, size);
+        } else {
+            test_rereg_local_mem(memh, ptr, size,
+                                 flags & ~UCP_MEM_MAP_ALLOCATE);
         }
 
         status = ucp_mem_unmap(sender().ucph(), memh);
         ASSERT_UCS_OK(status);
+
+        delete buf;
     }
+}
+
+UCS_TEST_P(test_ucp_mmap, rereg)
+{
+    test_rereg();
+}
+
+UCS_TEST_P(test_ucp_mmap, rereg_export_only)
+{
+    test_rereg(UCP_MEM_MAP_EXPORT);
+}
+
+UCS_TEST_P(test_ucp_mmap, reg_export_and_reimport)
+{
+    test_rereg(UCP_MEM_MAP_EXPORT, true);
+}
+
+UCS_TEST_P(test_ucp_mmap, alloc_rereg)
+{
+    test_rereg(UCP_MEM_MAP_ALLOCATE);
+}
+
+UCS_TEST_P(test_ucp_mmap, alloc_rereg_export_only)
+{
+    test_rereg(UCP_MEM_MAP_ALLOCATE | UCP_MEM_MAP_EXPORT);
+}
+
+UCS_TEST_P(test_ucp_mmap, alloc_reg_export_and_reimport)
+{
+    test_rereg(UCP_MEM_MAP_ALLOCATE | UCP_MEM_MAP_EXPORT, true);
 }
 
 void test_ucp_mmap::test_length0(unsigned flags)


### PR DESCRIPTION
## What

 Implement exported/imported memh.

## Why ?

To implement support of memory handles which could be used on DPU side to perform AM/TAG/RMA/AMO operations without involving HOST side into this process.

## How ?

1. Add implementation of API introduced in https://github.com/openucx/ucx/pull/8489.
2. Add RCACHE for exported/imported memory handles.