### PR TITLE
UCP/CORE/WIREUP: Replace err_mode by flags in EP config key and wireup_msg

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -168,7 +168,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
     key->rma_md_map       = 0;
     key->reachable_md_map = 0;
     key->dst_md_cmpts     = NULL;
-    key->err_mode         = UCP_ERR_HANDLING_MODE_NONE;
+    key->flags            = 0;
     memset(key->am_bw_lanes,  UCP_NULL_LANE, sizeof(key->am_bw_lanes));
     memset(key->rma_lanes,    UCP_NULL_LANE, sizeof(key->rma_lanes));
     memset(key->rma_bw_lanes, UCP_NULL_LANE, sizeof(key->rma_bw_lanes));
@@ -518,21 +518,25 @@ void ucp_ep_release_id(ucp_ep_h ep)
     ep->ext->local_ep_id = UCS_PTR_MAP_KEY_INVALID;
 }
 
-void ucp_ep_config_key_set_err_mode(ucp_ep_config_key_t *key,
-                                    unsigned ep_init_flags)
+void ucp_ep_config_key_set_flags(ucp_ep_config_key_t *key,
+                                 unsigned ep_init_flags)
 {
-    key->err_mode = (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) ?
-                    UCP_ERR_HANDLING_MODE_PEER : UCP_ERR_HANDLING_MODE_NONE;
+    if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
+        key->flags |= UCP_EP_CONFIG_KEY_FLAG_ERR_HANDLING_MODE_PEER;
+    }
 }
 
 ucs_status_t
 ucp_ep_config_err_mode_check_mismatch(ucp_ep_h ep,
                                       ucp_err_handling_mode_t err_mode)
 {
-    if (ucp_ep_config(ep)->key.err_mode != err_mode) {
+    ucp_err_handling_mode_t ep_config_err_mode =
+            ucp_ep_config_err_handling_mode(ucp_ep_config(ep));
+
+    if (ep_config_err_mode != err_mode) {
         ucs_error("ep %p: asymmetric endpoint configuration is not supported,"
                   " error handling level mismatch (expected: %d, got: %d)",
-                  ep, ucp_ep_config(ep)->key.err_mode, err_mode);
+                  ep, ep_config_err_mode, err_mode);
         return UCS_ERR_UNSUPPORTED;
     }
 
@@ -717,7 +721,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     ucs_assert(ucp_worker_num_cm_cmpts(ep->worker) != 0);
 
     ucp_ep_config_key_reset(&key);
-    ucp_ep_config_key_set_err_mode(&key, ep_init_flags);
+    ucp_ep_config_key_set_flags(&key, ep_init_flags);
 
     key.num_lanes = 1;
     /* all operations will use the first lane, which is a stub endpoint before
@@ -1335,11 +1339,13 @@ static void ucp_ep_failed_destroy(uct_ep_h ep)
 
 static void ucp_ep_discard_lanes(ucp_ep_h ep, ucs_status_t discard_status)
 {
-    unsigned ep_flush_flags         = (ucp_ep_config(ep)->key.err_mode ==
-                                       UCP_ERR_HANDLING_MODE_NONE) ?
-                                      UCT_FLUSH_FLAG_LOCAL :
-                                      UCT_FLUSH_FLAG_CANCEL;
-    uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
+     ucp_err_handling_mode_t err_mode =
+            ucp_ep_config_err_handling_mode(ucp_ep_config(ep));
+    unsigned ep_flush_flags          = (err_mode ==
+                                        UCP_ERR_HANDLING_MODE_NONE) ?
+                                       UCT_FLUSH_FLAG_LOCAL :
+                                       UCT_FLUSH_FLAG_CANCEL;
+    uct_ep_h uct_eps[UCP_MAX_LANES]  = { NULL };
     ucp_ep_discard_lanes_arg_t *discard_arg;
     ucs_status_t status;
     ucp_lane_index_t lane;
@@ -1438,7 +1444,7 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
         } else if (ep_ext->err_cb == NULL) {
             /* Print error if user requested error handling support but did not
                install a valid error handling callback */
-            err_mode  = ucp_ep_config(ucp_ep)->key.err_mode;
+            err_mode  = ucp_ep_config_err_handling_mode(ucp_ep_config(ucp_ep));
             log_level = (err_mode == UCP_ERR_HANDLING_MODE_NONE) ?
                                 UCS_LOG_LEVEL_DIAG :
                                 UCS_LOG_LEVEL_ERROR;
@@ -1641,12 +1647,14 @@ ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode)
 
 ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
 {
-    ucp_worker_h  worker = ep->worker;
-    void          *request = NULL;
+    ucp_worker_h worker              = ep->worker;
+    ucp_err_handling_mode_t err_mode =
+            ucp_ep_config_err_handling_mode(ucp_ep_config(ep));
+    void *request                    = NULL;
     ucp_request_t *close_req;
 
     if ((ucp_request_param_flags(param) & UCP_EP_CLOSE_FLAG_FORCE) &&
-        (ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_PEER)) {
+        (err_mode != UCP_ERR_HANDLING_MODE_PEER)) {
         return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);
     }
 
@@ -1837,7 +1845,7 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
         (key1->cm_lane != key2->cm_lane) ||
         (key1->keepalive_lane != key2->keepalive_lane) ||
         (key1->rkey_ptr_lane != key2->rkey_ptr_lane) ||
-        (key1->err_mode != key2->err_mode)) {
+        (key1->flags != key2->flags)) {
         return 0;
     }
 
@@ -2377,6 +2385,8 @@ out:
 ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                                 const ucp_ep_config_key_t *key)
 {
+    ucp_err_handling_mode_t err_mode   =
+            ucp_ep_config_err_handling_mode(config);
     ucp_context_h context              = worker->context;
     ucp_lane_index_t tag_lanes[2]      = {UCP_NULL_LANE, UCP_NULL_LANE};
     ucp_lane_index_t rkey_ptr_lanes[2] = {UCP_NULL_LANE, UCP_NULL_LANE};
@@ -2464,7 +2474,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             config->md_index[lane] = context->tl_rscs[rsc_index].md_index;
             if (ucp_ep_config_connect_p2p(worker, &config->key, rsc_index)) {
                 config->p2p_lanes |= UCS_BIT(lane);
-            } else if (config->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
+            } else if (err_mode == UCP_ERR_HANDLING_MODE_PEER) {
                 config->uct_rkey_pack_flags |= UCT_MD_MKEY_PACK_FLAG_INVALIDATE;
             }
         } else {
@@ -3357,7 +3367,7 @@ static void ucp_ep_req_purge_send(ucp_request_t *req, ucs_status_t status)
     ucs_assertv(UCS_STATUS_IS_ERR(status), "req %p: status %s", req,
                 ucs_status_string(status));
 
-    if ((ucp_ep_config(req->send.ep)->key.err_mode !=
+    if ((ucp_ep_config_err_handling_mode(ucp_ep_config(req->send.ep)) !=
          UCP_ERR_HANDLING_MODE_NONE) &&
         (req->flags & UCP_REQUEST_FLAG_RKEY_INUSE) &&
         !(req->flags & UCP_REQUEST_FLAG_USER_MEMH)) {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -185,12 +185,19 @@ typedef struct ucp_ep_config_key_lane {
 } ucp_ep_config_key_lane_t;
 
 
+typedef enum ucp_ep_config_key_flags {
+    UCP_EP_CONFIG_KEY_FLAG_ERR_HANDLING_MODE_PEER = UCS_BIT(0)
+} ucp_ep_config_key_flags_t;
+
+
 /*
  * Endpoint configuration key.
  * This is filled by the transport selection logic, according to the local
  * resources and set of remote addresses.
  */
 struct ucp_ep_config_key {
+    /* Flags which influence an endpoint configuration */
+    uint8_t                  flags;
 
     ucp_lane_index_t         num_lanes;       /* Number of active lanes */
     ucp_ep_config_key_lane_t lanes[UCP_MAX_LANES]; /* Active lanes */
@@ -233,9 +240,6 @@ struct ucp_ep_config_key {
      * component index to be used for unpacking remote key from each set bit in
      * reachable_md_map */
     ucp_rsc_index_t          *dst_md_cmpts;
-
-    /* Error handling mode */
-    ucp_err_handling_mode_t  err_mode;
 };
 
 
@@ -667,8 +671,8 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
                                        ucp_request_callback_t flushed_cb,
                                        const char *debug_name);
 
-void ucp_ep_config_key_set_err_mode(ucp_ep_config_key_t *key,
-                                    unsigned ep_init_flags);
+void ucp_ep_config_key_set_flags(ucp_ep_config_key_t *key,
+                                 unsigned ep_init_flags);
 
 void ucp_ep_err_pending_purge(uct_pending_req_t *self, void *arg);
 

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -30,6 +30,26 @@ static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_fast_lane(ucp_ep_h ep,
     return ep->uct_eps[lane_index];	
 }
 
+static UCS_F_ALWAYS_INLINE ucp_err_handling_mode_t
+ucp_ep_config_key_flags_err_handling_mode(uint8_t ep_config_key_flags)
+{
+    return (ep_config_key_flags &
+            UCP_EP_CONFIG_KEY_FLAG_ERR_HANDLING_MODE_PEER) ?
+           UCP_ERR_HANDLING_MODE_PEER : UCP_ERR_HANDLING_MODE_NONE;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_err_handling_mode_t
+ucp_ep_config_key_err_handling_mode(const ucp_ep_config_key_t *ep_config_key)
+{
+    return ucp_ep_config_key_flags_err_handling_mode(ep_config_key->flags);
+}
+
+static UCS_F_ALWAYS_INLINE ucp_err_handling_mode_t
+ucp_ep_config_err_handling_mode(const ucp_ep_config_t *ep_config)
+{
+    return ucp_ep_config_key_err_handling_mode(&ep_config->key);
+}
+
 static UCS_F_ALWAYS_INLINE uct_ep_h
 ucp_ep_get_lane(ucp_ep_h ep, ucp_lane_index_t lane_index)
 {

--- a/src/ucp/core/ucp_ep_vfs.c
+++ b/src/ucp/core/ucp_ep_vfs.c
@@ -111,7 +111,9 @@ static void ucp_ep_vfs_init_address(ucp_ep_h ep)
 
 void ucp_ep_vfs_init(ucp_ep_h ep)
 {
-    ucp_err_handling_mode_t err_mode;
+    ucp_err_handling_mode_t err_mode =
+            ucp_ep_config_key_flags_err_handling_mode(
+                    ucp_ep_config(ep)->key.flags);
 
 #if ENABLE_DEBUG_DATA
     ucs_vfs_obj_add_dir(ep->worker, ep, "ep/%s", ep->name);
@@ -124,7 +126,6 @@ void ucp_ep_vfs_init(ucp_ep_h ep)
     ucs_vfs_obj_add_ro_file(ep, ucp_ep_vfs_read_peer_name, NULL, 0,
                             "peer_name");
 
-    err_mode = ucp_ep_config(ep)->key.err_mode;
     ucs_vfs_obj_add_ro_file(ep, ucs_vfs_show_primitive,
                             (void*)ucp_err_handling_mode_names[err_mode],
                             UCS_VFS_TYPE_STRING, "error_mode");

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -373,7 +373,7 @@ void ucp_request_dt_invalidate(ucp_request_t *req, ucs_status_t status)
     unsigned memh_index;
 
     ucs_assert(status != UCS_OK);
-    ucs_assert(ucp_ep_config(req->send.ep)->key.err_mode !=
+    ucs_assert(ucp_ep_config_err_handling_mode(ucp_ep_config(req->send.ep)) !=
                UCP_ERR_HANDLING_MODE_NONE);
     ucs_assert(UCP_DT_IS_CONTIG(req->send.datatype));
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3310,7 +3310,7 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
     if (ucp_ep_config(ep)->key.keepalive_lane == UCP_NULL_LANE) {
         ucs_trace("ep %p flags 0x%x cfg_index %d err_mode %d: keepalive lane"
                   " is not set", ep, ep->flags, ep->cfg_index,
-                  ucp_ep_config(ep)->key.err_mode);
+                  ucp_ep_config_err_handling_mode(ucp_ep_config(ep)));
         return;
     }
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -42,9 +42,11 @@ ucp_ep_flush_request_update_uct_comp(ucp_request_t *req, int diff,
 static void ucp_ep_flush_error(ucp_request_t *req, ucp_lane_index_t lane,
                                ucs_status_t status)
 {
-    ucs_log_level_t level = (ucp_ep_config(req->send.ep)->key.err_mode ==
-                             UCP_ERR_HANDLING_MODE_PEER) ?
-                             UCS_LOG_LEVEL_TRACE_REQ : UCS_LOG_LEVEL_ERROR;
+    ucp_err_handling_mode_t err_mode =
+            ucp_ep_config_err_handling_mode(ucp_ep_config(req->send.ep));
+    ucs_log_level_t level            =
+            (err_mode == UCP_ERR_HANDLING_MODE_PEER) ?
+            UCS_LOG_LEVEL_TRACE_REQ : UCS_LOG_LEVEL_ERROR;
 
     ucs_assertv(lane != UCP_NULL_LANE, "req=%p ep=%p lane=%d status=%s",
                 req, req->send.ep, lane, ucs_status_string(status));

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2175,6 +2175,8 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
 {
     ucp_worker_h worker                = ep->worker;
     ucp_tl_bitmap_t scalable_tl_bitmap = worker->scalable_tl_bitmap;
+    ucp_err_handling_mode_t err_mode   =
+            ucp_ep_config_key_err_handling_mode(key);
     ucp_wireup_select_context_t select_ctx;
     ucp_wireup_select_params_t select_params;
     ucs_status_t status;
@@ -2184,7 +2186,7 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     if (!UCS_BITMAP_IS_ZERO_INPLACE(&scalable_tl_bitmap)) {
         ucp_wireup_select_params_init(&select_params, ep, ep_init_flags,
                                       remote_address, scalable_tl_bitmap, 0);
-        status = ucp_wireup_search_lanes(&select_params, key->err_mode,
+        status = ucp_wireup_search_lanes(&select_params, err_mode,
                                          &select_ctx);
         if (status == UCS_OK) {
             goto out;
@@ -2197,8 +2199,7 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
 
     ucp_wireup_select_params_init(&select_params, ep, ep_init_flags,
                                   remote_address, tl_bitmap, show_error);
-    status = ucp_wireup_search_lanes(&select_params, key->err_mode,
-                                     &select_ctx);
+    status = ucp_wireup_search_lanes(&select_params, err_mode, &select_ctx);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -110,8 +110,10 @@ typedef struct {
  */
 typedef struct ucp_wireup_msg {
     uint8_t                type; /* Message type */
-    uint8_t                err_mode; /* Peer error handling mode defined in
-                                        @ucp_err_handling_mode_t */
+    uint8_t                flags; /* Peer error handling mode defined in
+                                     @ucp_err_handling_mode_t and configuration
+                                     flags defined in
+                                     @ucp_ep_config_key_flags_t */
     ucp_ep_match_conn_sn_t conn_sn; /* Connection sequence number */
     uint64_t               src_ep_id; /* Endpoint ID of source */
     uint64_t               dst_ep_id; /* Endpoint ID of destination, can be

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -222,7 +222,7 @@ ucp_cm_ep_client_initial_config_get(ucp_ep_h ucp_ep, unsigned ep_init_flags,
 
     ucs_assert(unpacked_addr.address_count <= UCP_MAX_RESOURCES);
     ucp_ep_config_key_reset(key);
-    ucp_ep_config_key_set_err_mode(key, wireup_ep->ep_init_flags);
+    ucp_ep_config_key_set_flags(key, wireup_ep->ep_init_flags);
     status = ucp_wireup_select_lanes(ucp_ep,
                                      wireup_ep->ep_init_flags | ep_init_flags,
                                      *tl_bitmap, &unpacked_addr, addr_indices,
@@ -266,10 +266,12 @@ static void*
 ucp_cm_ep_sa_data_pack(ucp_ep_h ep, ucp_wireup_sockaddr_data_base_t *sa_data,
                        ucp_object_version_t sa_data_version)
 {
+    ucp_err_handling_mode_t err_mode =
+            ucp_ep_config_err_handling_mode(ucp_ep_config(ep));
     ucp_wireup_sockaddr_data_v1_t *sa_data_v1;
 
     if (sa_data_version == UCP_OBJECT_VERSION_V1) {
-        sa_data->header       = ucp_ep_config(ep)->key.err_mode;
+        sa_data->header       = err_mode;
         sa_data_v1            = ucs_derived_of(sa_data,
                                                ucp_wireup_sockaddr_data_v1_t);
         sa_data_v1->addr_mode = UCP_WIREUP_SA_DATA_CM_ADDR;
@@ -280,7 +282,7 @@ ucp_cm_ep_sa_data_pack(ucp_ep_h ep, ucp_wireup_sockaddr_data_base_t *sa_data,
                            "sa_data version: %u", sa_data_version);
         sa_data->header = UCP_OBJECT_VERSION_V2 <<
                           UCP_SA_DATA_HEADER_VERSION_SHIFT;
-        if (ucp_ep_config(ep)->key.err_mode == UCP_ERR_HANDLING_MODE_PEER) {
+        if (err_mode == UCP_ERR_HANDLING_MODE_PEER) {
             sa_data->header |= UCP_SA_DATA_FLAG_ERR_MODE_PEER;
         }
 
@@ -305,7 +307,8 @@ ucp_cm_ep_priv_data_pack(ucp_ep_h ep, const ucp_tl_bitmap_t *tl_bitmap,
     void *worker_addr_p;
     size_t ucp_addr_size, sa_data_length;
 
-    ucs_assert((int)ucp_ep_config(ep)->key.err_mode <= UINT8_MAX);
+    ucs_assert((uint64_t)ucp_ep_config_err_handling_mode(ucp_ep_config(ep)) <=
+               UINT8_MAX);
 
     if (ucp_ep_get_cm_wireup_ep(ep)->flags & UCP_WIREUP_EP_FLAG_SEND_CLIENT_ID) {
         pack_flags |= UCP_ADDRESS_PACK_FLAG_CLIENT_ID;


### PR DESCRIPTION
## What

Replace `err_mode` by `flags` in EP config key and WIREUP messages.

## Why ?

It is needed to add new flags which should be packed and sent to a peer to control transport selection, e.g. EXPORTED_MEMH feature.

## How ?

1. Replace `err_mode` by `flags` in `ucp_ep_config_key` and `ucp_wireup_msg` structures.
2. Calculate `err_mode` based on EP configuration's flags where it is needed. 