### PR TITLE
UCP/CORE: Apply user'e EP params when creating EP to accept CM connection

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -908,6 +908,7 @@ ucp_conn_request_unpack_sa_data(const ucp_conn_request_h conn_request,
  * Create an endpoint on the server side connected to the client endpoint.
  */
 ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
+                                         const ucp_ep_params_t *params,
                                          const ucp_conn_request_h conn_request,
                                          ucp_ep_h *ep_p)
 {
@@ -925,6 +926,10 @@ ucs_status_t ucp_ep_create_server_accept(ucp_worker_h worker,
         conn_request->listener->conn_reqs--;
         UCS_ASYNC_UNBLOCK(&worker->async);
         return status;
+    }
+
+    if (params != NULL) {
+        ep_init_flags |= ucp_ep_init_flags(worker, params);
     }
 
     if (ucp_address_is_am_only(worker_addr)) {
@@ -959,7 +964,7 @@ ucp_ep_create_api_conn_request(ucp_worker_h worker,
     ucp_ep_h           ep;
     ucs_status_t       status;
 
-    status = ucp_ep_create_server_accept(worker, conn_request, &ep);
+    status = ucp_ep_create_server_accept(worker, params, conn_request, &ep);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1062,7 +1062,7 @@ static unsigned ucp_cm_server_conn_request_progress(void *arg)
 
     ucs_assert(listener->accept_cb != NULL);
     UCS_ASYNC_BLOCK(&worker->async);
-    ucp_ep_create_server_accept(worker, conn_request, &ep);
+    ucp_ep_create_server_accept(worker, NULL, conn_request, &ep);
     UCS_ASYNC_UNBLOCK(&worker->async);
     return 1;
 }


### PR DESCRIPTION
## What

Apply user's EP params when creating EP when accepting CM connection to adjust `ep_init_flags`.

## Why ?

If user adds some `ep_init_flags` which needs to be applied to EP creating during accepting connection, they won't be considered as it is expected.

## How ?

1. Add `ucp_ep_params_t` argument to `ucp_ep_create_server_accept`.
2. Handle `ucp_ep_params_t` argument in `ucp_ep_create_server_accept` by applying `ep_init_flags`.