### PR TITLE
UCT/UCP/API: Add RKEY_PTR flag on component

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -458,7 +458,7 @@ static void print_md_info(uct_component_h component,
         if (md_attr.flags & UCT_MD_FLAG_NEED_MEMH) {
             printf("#           local memory handle is required for zcopy\n");
         }
-        if (md_attr.flags & UCT_MD_FLAG_RKEY_PTR) {
+        if (component_attr->flags & UCT_COMPONENT_FLAG_RKEY_PTR) {
             printf("#           rkey_ptr is supported\n");
         }
         if (md_attr.flags & UCT_MD_FLAG_INVALIDATE) {

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -549,6 +549,14 @@ ucp_tl_iface_bandwidth(ucp_context_h context, const uct_ppn_bandwidth_t *bandwid
            (bandwidth->shared / context->config.est_num_ppn);
 }
 
+static UCS_F_ALWAYS_INLINE const uct_component_attr_t*
+ucp_cmpt_attr_by_md_index(ucp_context_h context, ucp_md_index_t md_index)
+{
+    ucp_tl_md_t *tl_md = &context->tl_mds[md_index];
+
+    return &context->tl_cmpts[tl_md->cmpt_index].attr;
+}
+
 static UCS_F_ALWAYS_INLINE void
 ucp_memory_info_set_host(ucp_memory_info_t *mem_info)
 {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2385,6 +2385,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     ucp_ep_rma_config_t *rma_config;
     uct_iface_attr_t *iface_attr;
     uct_md_attr_v2_t *md_attr;
+    const uct_component_attr_t *cmpt_attr;
     ucs_memory_type_t mem_type;
     ucp_rsc_index_t rsc_index;
     ucp_lane_index_t lane, i;
@@ -2561,8 +2562,8 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     /* Rkey ptr */
     if (key->rkey_ptr_lane != UCP_NULL_LANE) {
         lane      = key->rkey_ptr_lane;
-        md_attr   = &context->tl_mds[config->md_index[lane]].attr;
-        ucs_assert_always(md_attr->flags & UCT_MD_FLAG_RKEY_PTR);
+        cmpt_attr = ucp_cmpt_attr_by_md_index(context, config->md_index[lane]);
+        ucs_assert_always(cmpt_attr->flags & UCT_COMPONENT_FLAG_RKEY_PTR);
 
         config->rndv.rkey_ptr_dst_mds =
                 UCS_BIT(config->key.lanes[lane].dst_md_index);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -56,6 +56,9 @@ typedef struct {
     /* Required local MD flags */
     uint64_t                    local_md_flags;
 
+    /* Required local component flags */
+    uint64_t                    local_cmpt_flags;
+
     /* Required local interface flags */
     ucp_wireup_select_flags_t   local_iface_flags;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -290,7 +290,13 @@ enum {
      * If set, the component supports @ref uct_cm_h functionality.
      * See @ref uct_cm_open for details.
      */
-    UCT_COMPONENT_FLAG_CM = UCS_BIT(0)
+    UCT_COMPONENT_FLAG_CM       = UCS_BIT(0),
+
+    /**
+     * If set, the component supports direct access to remote memory using a
+     * local pointer returned from @ref uct_rkey_ptr function.
+     */
+    UCT_COMPONENT_FLAG_RKEY_PTR = UCS_BIT(1)
 };
 
 
@@ -728,7 +734,9 @@ enum {
 
     /**
      * MD supports direct access to remote memory via a pointer that is
-     * returned by @ref uct_rkey_ptr
+     * returned by @ref uct_rkey_ptr.
+     * @note This flag is deprecated and replaced by
+     * @a UCT_COMPONENT_FLAG_RKEY_PTR.
      */
     UCT_MD_FLAG_RKEY_PTR      = UCS_BIT(6),
 
@@ -2676,8 +2684,8 @@ ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,
  * @brief Get a local pointer to remote memory.
  *
  * This routine returns a local pointer to the remote memory
- * described by the rkey bundle. The MD must support
- * @ref UCT_MD_FLAG_RKEY_PTR flag.
+ * described by the rkey bundle. The @a component must support
+ * @ref UCT_COMPONENT_FLAG_RKEY_PTR flag.
  *
  * @param [in]  component    Component on which to obtain the pointer to the
  *                           remote key.

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -180,7 +180,7 @@ typedef struct uct_mm_component {
             .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY, \
             .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER( \
                                       &UCT_COMPONENT_NAME(_name).super), \
-            .flags              = 0, \
+            .flags              = UCT_COMPONENT_FLAG_RKEY_PTR, \
             .md_vfs_init        = \
                     (uct_component_md_vfs_init_func_t)ucs_empty_function \
        }, \


### PR DESCRIPTION
## What
Introduce `UCT_COMPONENT_FLAG_RKEY_PTR` and use it instead of `UCT_MD_FLAG_RKEY_PTR`

## Why ?
`uct_rkey_ptr()` function is invoked for component (not memory domain),  so the flag indicating support for this API needs to be checked/present on component rather than md 
