### PR TITLE
UCS/CONFIG: Filter out not loaded config tables for unused vars message

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -592,8 +592,9 @@ ucs_status_t ucp_config_read(const char *env_prefix, const char *filename,
                           UCS_DEFAULT_ENV_PREFIX);
     }
 
-    status = ucs_config_parser_fill_opts(config, ucp_config_table,
-                                         config->env_prefix, NULL, 0);
+    status = ucs_config_parser_fill_opts(config,
+                                         UCS_CONFIG_GET_TABLE(ucp_config_table),
+                                         config->env_prefix, 0);
     if (status != UCS_OK) {
         goto err_free_prefix;
     }

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -424,16 +424,18 @@ void ucs_global_opts_init()
     UCS_CONFIG_ADD_TABLE(ucs_global_opts_read_only_table,
                          &ucs_config_global_list);
 
-    status = ucs_config_parser_fill_opts(&ucs_global_opts,
-                                         ucs_global_opts_read_only_table,
-                                         UCS_DEFAULT_ENV_PREFIX, NULL, 1);
+    status = ucs_config_parser_fill_opts(
+            &ucs_global_opts,
+            UCS_CONFIG_GET_TABLE(ucs_global_opts_read_only_table),
+            UCS_DEFAULT_ENV_PREFIX, 1);
     if (status != UCS_OK) {
         ucs_fatal("failed to parse global runtime read-only configuration");
     }
 
     status = ucs_config_parser_fill_opts(&ucs_global_opts,
-                                         ucs_global_opts_table,
-                                         UCS_DEFAULT_ENV_PREFIX, NULL, 1);
+                                         UCS_CONFIG_GET_TABLE(
+                                                 ucs_global_opts_table),
+                                         UCS_DEFAULT_ENV_PREFIX, 1);
     if (status != UCS_OK) {
         ucs_fatal("failed to parse global configuration");
     }

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -85,12 +85,22 @@ typedef struct ucs_range_spec {
 } ucs_range_spec_t;
 
 
+/**
+ * Configuration table flags
+ */
+typedef enum {
+    /* Table has been already loaded by config parser */
+    UCS_CONFIG_TABLE_FLAG_LOADED = UCS_BIT(0)
+} ucs_config_table_flags_t;
+
+
 typedef struct ucs_config_global_list_entry {
     const char               *name;    /* configuration table name */
     const char               *prefix;  /* configuration prefix */
     ucs_config_field_t       *table;   /* array of configuration fields */
     size_t                   size;     /* size of config structure */
     ucs_list_link_t          list;     /* entry in global list */
+    uint8_t                  flags;    /* config table flags */
 } ucs_config_global_list_entry_t;
 
 
@@ -127,8 +137,13 @@ typedef struct ucs_config_bw_spec {
         .table  = _table, \
         .name   = _name, \
         .prefix = _prefix, \
-        .size   = sizeof(_type) \
+        .size   = sizeof(_type), \
+        .flags  = 0 \
     };
+
+
+#define UCS_CONFIG_GET_TABLE(_table) &_table##_config_entry
+
 
 #define UCS_CONFIG_ADD_TABLE(_table, _list) \
     ucs_list_add_tail(_list, &(_table##_config_entry).list)
@@ -423,17 +438,16 @@ void ucs_config_parse_config_files();
  * Fill existing opts structure.
  *
  * @param opts           User-defined options structure to fill.
- * @param fields         Array of fields which define how to parse.
+ * @param entry          Global configuration list entry which contains
+ *                       relevant fields (eg. parser info, prefix etc).
  * @param env_prefix     Prefix to add to all environment variables,
  *                       env_prefix may consist of multiple sub prefixes
- * @param table_prefix   Optional prefix to add to the variables of top-level table.
  * @param ignore_errors  Whether to ignore parsing errors and continue parsing
  *                       other fields.
  */
-ucs_status_t ucs_config_parser_fill_opts(void *opts, ucs_config_field_t *fields,
-                                         const char *env_prefix,
-                                         const char *table_prefix,
-                                         int ignore_errors);
+ucs_status_t
+ucs_config_parser_fill_opts(void *opts, ucs_config_global_list_entry_t *entry,
+                            const char *env_prefix, int ignore_errors);
 
 /**
  * Perform deep copy of the options structure.

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -118,9 +118,10 @@ void ucs_init_ucm_opts()
 
     UCS_CONFIG_ADD_TABLE(ucm_global_config_table, &ucs_config_global_list);
 
-    (void)ucs_config_parser_fill_opts(&ucm_opts, ucm_global_config_table,
-                                      UCS_DEFAULT_ENV_PREFIX, UCM_CONFIG_PREFIX,
-                                      0);
+    (void)ucs_config_parser_fill_opts(&ucm_opts,
+                                      UCS_CONFIG_GET_TABLE(
+                                              ucm_global_config_table),
+                                      UCS_DEFAULT_ENV_PREFIX, 0);
     ucm_set_global_opts(&ucm_opts);
 }
 

--- a/src/uct/base/uct_cm.c
+++ b/src/uct/base/uct_cm.c
@@ -50,9 +50,7 @@ ucs_status_t uct_cm_config_read(uct_component_h component,
     uct_config_bundle_t *bundle = NULL;
     ucs_status_t status;
 
-    status = uct_config_read(&bundle, component->cm_config.table,
-                             component->cm_config.size, env_prefix,
-                             component->cm_config.prefix);
+    status = uct_config_read(&bundle, &component->cm_config, env_prefix);
     if (status != UCS_OK) {
         ucs_error("failed to read CM configuration");
         return status;

--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -124,19 +124,19 @@ ucs_status_t uct_component_query(uct_component_h component,
 }
 
 ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
-                             ucs_config_field_t *config_table,
-                             size_t config_size, const char *env_prefix,
-                             const char *cfg_prefix)
+                             ucs_config_global_list_entry_t *entry,
+                             const char *env_prefix)
 {
     char full_prefix[128] = UCS_DEFAULT_ENV_PREFIX;
     uct_config_bundle_t *config_bundle;
     ucs_status_t status;
 
-    if (config_table == NULL) {
+    if (entry->table == NULL) {
         return UCS_ERR_INVALID_PARAM;
     }
 
-    config_bundle = ucs_calloc(1, sizeof(*config_bundle) + config_size, "uct_config");
+    config_bundle = ucs_calloc(1, sizeof(*config_bundle) + entry->size,
+                               "uct_config");
     if (config_bundle == NULL) {
         status = UCS_ERR_NO_MEMORY;
         goto err;
@@ -148,14 +148,14 @@ ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
                           env_prefix, UCS_DEFAULT_ENV_PREFIX);
     }
 
-    status = ucs_config_parser_fill_opts(config_bundle->data, config_table,
-                                         full_prefix, cfg_prefix, 0);
+    status = ucs_config_parser_fill_opts(config_bundle->data, entry,
+                                         full_prefix, 0);
     if (status != UCS_OK) {
         goto err_free_bundle;
     }
 
-    config_bundle->table = config_table;
-    config_bundle->table_prefix = ucs_strdup(cfg_prefix, "uct_config");
+    config_bundle->table        = entry->table;
+    config_bundle->table_prefix = ucs_strdup(entry->prefix, "uct_config");
     if (config_bundle->table_prefix == NULL) {
         status = UCS_ERR_NO_MEMORY;
         goto err_free_bundle;

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -192,9 +192,8 @@ struct uct_component {
 
 
 ucs_status_t uct_config_read(uct_config_bundle_t **bundle,
-                             ucs_config_field_t *config_table,
-                             size_t config_size, const char *env_prefix,
-                             const char *cfg_prefix);
+                             ucs_config_global_list_entry_t *entry,
+                             const char *env_prefix);
 
 void uct_component_register(uct_component_t *component);
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -243,8 +243,7 @@ ucs_status_t uct_md_iface_config_read(uct_md_h md, const char *tl_name,
         return status;
     }
 
-    status = uct_config_read(&bundle, tl->config.table, tl->config.size,
-                             env_prefix, tl->config.prefix);
+    status = uct_config_read(&bundle, &tl->config, env_prefix);
     if (status != UCS_OK) {
         ucs_error("Failed to read iface config");
         return status;
@@ -300,9 +299,7 @@ ucs_status_t uct_md_config_read(uct_component_h component,
     uct_config_bundle_t *bundle = NULL;
     ucs_status_t status;
 
-    status = uct_config_read(&bundle, component->md_config.table,
-                             component->md_config.size, env_prefix,
-                             component->md_config.prefix);
+    status = uct_config_read(&bundle, &component->md_config, env_prefix);
     if (status != UCS_OK) {
         ucs_error("Failed to read MD config");
         return status;

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -339,11 +339,14 @@ protected:
 
             ucs_config_parse_config_files();
 
-            status = ucs_config_parser_fill_opts(&tmp,
-                                                 car_opts_table,
-                                                 env_prefix,
-                                                 table_prefix,
-                                                 0);
+            static ucs_config_global_list_entry_t entry;
+            entry.table  = car_opts_table;
+            entry.name   = "cars";
+            entry.prefix = table_prefix;
+            entry.size   = sizeof(car_opts_t);
+            entry.flags  = 0;
+
+            status = ucs_config_parser_fill_opts(&tmp, &entry, env_prefix, 0);
             ASSERT_UCS_OK(status);
             return tmp;
         }
@@ -702,14 +705,22 @@ UCS_TEST_F(test_config, test_config_file_parse_files) {
     ucs_status_t status;
 
     ucs_config_parse_config_file(TEST_CONFIG_DIR, TEST_CONFIG_FILE, 1);
-    status = ucs_config_parser_fill_opts(&opts, car_opts_table,
-                                         UCS_DEFAULT_ENV_PREFIX, NULL, 0);
+
+    ucs_config_global_list_entry_t entry;
+    entry.table  = car_opts_table;
+    entry.name   = "cars";
+    entry.prefix = NULL;
+    entry.size   = sizeof(car_opts_t);
+    entry.flags  = 0;
+
+    status = ucs_config_parser_fill_opts(&opts, &entry, UCS_DEFAULT_ENV_PREFIX,
+                                         0);
     EXPECT_EQ(200, opts.price);
     ucs_config_parser_release_opts(&opts, car_opts_table);
     
     ucs_config_parse_config_files();
-    status = ucs_config_parser_fill_opts(&opts, car_opts_table,
-                                         UCS_DEFAULT_ENV_PREFIX, NULL, 0);
+    status = ucs_config_parser_fill_opts(&opts, &entry, UCS_DEFAULT_ENV_PREFIX,
+                                         0);
     ASSERT_UCS_OK(status);
 
     /* Verify ucs_config_parse_config_files() overrides config */


### PR DESCRIPTION
## What
Filter out not loaded config tables for unused vars message

## Why ?
Avoid displaying wrong env var suggestions

