### PR TITLE
UCS: Add missing ZHAOXIN cpu bandwith

### DIFF
--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -77,7 +77,8 @@ const size_t ucs_cpu_est_bcopy_bw[UCS_CPU_VENDOR_LAST] = {
     [UCS_CPU_VENDOR_AMD]         = 5008 * UCS_MBYTE,
     [UCS_CPU_VENDOR_GENERIC_ARM] = 5800 * UCS_MBYTE,
     [UCS_CPU_VENDOR_GENERIC_PPC] = 5800 * UCS_MBYTE,
-    [UCS_CPU_VENDOR_FUJITSU_ARM] = 12000 * UCS_MBYTE
+    [UCS_CPU_VENDOR_FUJITSU_ARM] = 12000 * UCS_MBYTE,
+    [UCS_CPU_VENDOR_ZHAOXIN]     = 5800 * UCS_MBYTE
 };
 
 static void ucs_sysfs_get_cache_size()


### PR DESCRIPTION
## What
CPU bandwidth for ZHAOXIN is missing
The function ucs_cpu_get_memcpy_bw can be out of array range.
```
double ucs_cpu_get_memcpy_bw()                                                  
{                                                                               
    return ucs_cpu_est_bcopy_bw[ucs_arch_get_cpu_vendor()];                     
}  
```

## How ?
Add bandwidth for it.