### PR TITLE
UCT/RC/DC: Check tag seg size during iface creation

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -755,6 +755,12 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
         return UCS_ERR_INVALID_PARAM;
     }
 
+    if (mlx5_config->tm.seg_size > UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK) {
+        ucs_error("TM segment size is too big %ld, it must not exceed %d",
+                  mlx5_config->tm.seg_size, UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     status = uct_rc_mlx5_iface_preinit(self, tl_md, rc_config, mlx5_config,
                                        params, init_attr);
     if (status != UCS_OK) {


### PR DESCRIPTION
## What
Check the value of `UCX_RC_MLX5_TM_SEG_SIZE` during RC/DC iface creation.

## Why ?
In rcx and dc transport segments are limited by `UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK` value (in `uct_rc_mlx5_iface_common_poll_rx`). If the segment is bigger the behavior is undefined, because wrong length is reported to UCP when tag message arrives. Need to fail iface creation if the segment is bigger than allowed value
