### PR TITLE
UCP/CORE: Refactor memory registration to support export_md_map

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -617,11 +617,6 @@ ucp_memh_get_slow(ucp_context_h context, void *address, size_t length,
         goto out;
     }
 
-    /* Reinitialize address and length, because they could be greater in case
-     * a region which includes the searched region was found in the rcache */
-    reg_address = ucp_memh_address(memh);
-    reg_length  = ucp_memh_length(memh);
-
     ucs_assert(memh->mem_type == mem_type);
 
     status = ucp_memh_register(context, memh, ~memh->md_map & reg_md_map,


### PR DESCRIPTION
## What

Refactor memory registration to support export_md_map in the future.

## Why ?

New field `export_md_map` will be introduced in `ucp_mem_h` to save exported memory handles.
The main goal of this PR is to prepare memory registration code to have common code for normal `md_map` and `export_md_map` with minor changes.

## How ?

1. `ucp_memh_dereg` -> `ucp_memh_deregister` + `ucp_memh_uct_deregister` (`ucp_memh_uct_deregister` will be called for `export_md_map` in the future).
2. `ucp_memh_register` -> `ucp_memh_register` +  `ucp_memh_uct_register` (`ucp_memh_uct_register` will be called for `export_md_map` in the future).
3. Update `ucp_memh_rcache_get` to be able use another rcache, not only from `context->rcache` (`ucp_memh_rcache_get` will be used for rcache of imported memory handles).
4. Introduce new function `ucp_memh_update_from_parent_memh` to use inside `ucp_memh_init_uct_reg` (`ucp_memh_update_from_parent_memh` will be called for `export_md_map` in the future).
5. Introduce new function `ucp_memh_normal_reg` to use inside `ucp_mem_map` and simplify code.
6. `ucp_mem_advise` -> `ucp_mem_advise` + `ucp_memh_uct_mem_advise` (`ucp_memh_uct_mem_advise` will be called for `export_md_map` in the future).
7. Update `ucp_mem_reg_md_map_update` to use `ucp_memh_set` to initialize all required fields of memory handle and not miss ones by mistake.