### PR TITLE
BUILD: Change `prefix` to a relative path with `CMAKE_CURRENT_LIST_DIR`

### DIFF
--- a/cmake/ucx-targets.cmake.in
+++ b/cmake/ucx-targets.cmake.in
@@ -4,7 +4,7 @@
 # See file LICENSE for terms.
 #
 
-set(prefix "@prefix@")
+set(prefix ${CMAKE_CURRENT_LIST_DIR}/../../..)
 set(exec_prefix "@exec_prefix@")
 
 add_library(ucx::ucs SHARED IMPORTED)


### PR DESCRIPTION
## What
_Describe what this PR is doing._ 

Set `prefix` to a relative path with `CMAKE_CURRENT_LIST_DIR` so that users can move the UCX library to a path different from `prefix`.

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

It's possible that `prefix` and installation path are different. For example, in multi-stage docker builds,
we can build and install UCX in a different stage with `prefix` of "/build/ucx" and copy the artifacts to "/usr/local"  of the main container.
In this case, `ucx-targets.cmake`'s prefix would be "/build/ucx" but it won't work in the container.

You can check this kind of discrepancy in `nvcr.io/nvidia/pytorch:22.08-py3` container.

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
