### PR TITLE
UCT/ROCM: added memory allocation functions

### DIFF
--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -30,6 +30,7 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size, void **base_ptr,
                                         hsa_amd_pointer_type_t *hsa_mem_type,
                                         hsa_agent_t *agent,
                                         hsa_device_type_t *dev_type);
+ucs_status_t uct_rocm_base_get_last_device_pool(hsa_amd_memory_pool_t *pool);
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
                                               ucs_memory_type_t *mem_type_p);


### PR DESCRIPTION
## What
this pr is adding the `uct_rocm_copy_mem_alloc` and `uct_rocm_copy_mem_free` functions for use but the ucx_perftest.
Users who are running ucx_perftest on 1 node, will need to set ROCR_VISIBLE_DEVICES to different devices to ensure that the devices used are different per process


## Why ?
ucx_perftest has not been working with the ROCM components

