### PR TITLE
UCT/API: Replace UCT_MD_MEM_FLAG_EXPORT by UCT_MD_MKEY_PACK_FLAG_EXPORT

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -785,12 +785,6 @@ enum uct_md_mem_flags {
      */
     UCT_MD_MEM_FLAG_HIDE_ERRORS     = UCS_BIT(3),
 
-    /**
-     * The flag is used to indicate that the memory region can be accessed by
-     * another process using the same device to perform UCT operations.
-     */
-    UCT_MD_MEM_FLAG_EXPORT          = UCS_BIT(4),
-
     /* Memory access flags */
     /**
      * Enable remote put access.

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -281,7 +281,14 @@ typedef enum {
      * in order for @ref UCT_MD_MEM_DEREG_FLAG_INVALIDATE flag to function
      * the @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag must be set.
      */
-    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0)
+    UCT_MD_MKEY_PACK_FLAG_INVALIDATE = UCS_BIT(0),
+
+    /**
+     * The flag is used to indicate that the memory region should be packed in
+     * order to be accessed by another process using the same device to perform
+     * UCT operations.
+     */
+    UCT_MD_MKEY_PACK_FLAG_EXPORT     = UCS_BIT(1)
 } uct_md_mkey_pack_flags_t;
 
 
@@ -754,7 +761,7 @@ ucs_status_t uct_md_query_v2(uct_md_h md, uct_md_attr_v2_t *md_attr);
  * @param [out] mkey_buffer Pointer to a buffer to hold the packed memory key.
  *                          The size of this buffer should be at least
  *                          @ref uct_md_attr_t::rkey_packed_size or
- *                          @ref uct_md_attr_t::shared_mkey_packed_size, as
+ *                          @ref uct_md_attr_t::exported_mkey_packed_size, as
  *                          returned by @ref uct_md_query.
  * @return                  Error code.
  */


### PR DESCRIPTION
## What

 Replace `UCT_MD_MEM_FLAG_EXPORT` by `UCT_MD_MKEY_PACK_FLAG_EXPORT`.

## Why ?

This change makes possible packing the same memory handle as RKEY or EXPORTED memory handle.

## How ?

1. Remove `UCT_MD_MEM_FLAG_EXPORT` from `uct_md_mem_reg()`'s flags.
2. Add `UCT_MD_MKEY_PACK_FLAG_EXPORT` to `uct_md_mem_pack_v2()`'s flags.