### PR TITLE
UCP/API/TOOLS: Specify memory type when allocating with ucx_info tool

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -334,7 +334,7 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
                size_t estimated_num_eps, size_t estimated_num_ppn,
                unsigned dev_type_bitmap, process_placement_t proc_placement,
-               const char *mem_size, const char *ip_addr, sa_family_t af)
+               const char *mem_spec, const char *ip_addr, sa_family_t af)
 {
     ucp_worker_h peer_worker = NULL;
     ucp_config_t *config;
@@ -376,8 +376,8 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
         goto out_release_config;
     }
 
-    if ((print_opts & PRINT_MEM_MAP) && (mem_size != NULL)) {
-        ucp_mem_print_info(mem_size, context, stdout);
+    if ((print_opts & PRINT_MEM_MAP) && (mem_spec != NULL)) {
+        ucp_mem_print_info(mem_spec, context, stdout);
     }
 
     if (print_opts & PRINT_UCP_CONTEXT) {

--- a/src/tools/info/ucx_info.h
+++ b/src/tools/info/ucx_info.h
@@ -52,6 +52,6 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
                uint64_t ctx_features, const ucp_ep_params_t *base_ep_params,
                size_t estimated_num_eps, size_t estimated_num_ppn,
                unsigned dev_type_bitmap, process_placement_t proc_placement,
-               const char *mem_size, const char *ip_addr, sa_family_t af);
+               const char *mem_spec, const char *ip_addr, sa_family_t af);
 
 #endif

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -2864,11 +2864,16 @@ ucs_status_t ucp_mem_query(const ucp_mem_h memh, ucp_mem_attr_t *attr);
  * including the mapped memory length, the allocation method, and other useful
  * information associated with the memory handle.
  *
- * @param [in] mem_size     Size of the memory to map.
+ * @param [in] mem_spec     Size and optional type of the memory to map.
+ *                          The format of the string is: "<size>[,<type>]".
+ *                          For example:
+ *                           - "32768"   : allocate 32 kilobytes of host memory.
+ *                           - "1m,cuda" : allocate 1 megabayte of cuda memory.
  * @param [in] context      The context on which the memory is mapped.
  * @param [in] stream       Output stream on which to print the information.
  */
-void ucp_mem_print_info(const char *mem_size, ucp_context_h context, FILE *stream);
+void ucp_mem_print_info(const char *mem_spec, ucp_context_h context,
+                        FILE *stream);
 
 
 /**


### PR DESCRIPTION
## Why
- Basic test for dmabuf support: `ucx_info -m 1m,cuda` is expected to show that memory is registered with IB devices

## How
- Extend ucp_mem_print_info() function to accept memory type in addition to size. Since it's passed as a string, this change is backward compatible.
- Update ucx_info tool with correct help message and change variable names