### PR TITLE
UCT/API/CUDA/INFO: Implement dmabuf export

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -358,10 +358,18 @@ setting `UCX_MEMTYPE_CACHE=n`.
 #### Does UCX support zero-copy for GPU memory over RDMA?
 
 Yes. For large messages UCX can transfer GPU memory using zero-copy RDMA using
-rendezvous protocol. It requires the peer memory q for the relevant GPU type
-to be loaded on the system.
+rendezvous protocol. It requires a peer memory driver for the relevant GPU type
+to be loaded, or (starting with UCX v1.14.0) dmabuf support on the system.
+
 > **NOTE:** In some cases if the RDMA network device and the GPU are not on
 the same NUMA node, such zero-copy transfer is inefficient.
+
+#### What is needed for dmabuf support?
+- UCX v1.14.0 or later.
+- Linux kernel >= 5.12 (for example, Ubuntu 22.04).
+- Cuda 11.7 or later, installed with "-m=kernel-open" flag.
+> **NOTE:** Currently UCX code assumes that dmabuf support is uniform across all
+available GPU devices.
 
 ---
 <br/>

--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -56,6 +56,11 @@
         printf(" nsec\n"); \
     }
 
+#define PRINT_MD_MEM_TYPE(_strb, _md_attr, _mem_type, _cap) \
+    if ((_md_attr)._cap##_mem_types & UCS_BIT(_mem_type)) { \
+        ucs_string_buffer_appendf(_strb, UCS_PP_MAKE_STRING(_cap) ","); \
+    }
+
 
 static char *strduplower(const char *str)
 {
@@ -473,22 +478,24 @@ static void print_md_info(uct_component_h component,
 
             ucs_string_buffer_appendf(&strb, "%s",
                                       ucs_memory_type_names[mem_type]);
-            if (UCS_BIT(mem_type) &
-                (md_attr.cache_mem_types & ~md_attr.alloc_mem_types)) {
+            if (!(UCS_BIT(mem_type) &
+                  (md_attr.access_mem_types | md_attr.alloc_mem_types |
+                   md_attr.reg_mem_types | md_attr.cache_mem_types |
+                   md_attr.detect_mem_types | md_attr.dmabuf_mem_types))) {
                 ucs_string_buffer_appendf(&strb, ", ");
                 continue;
             }
 
             ucs_string_buffer_appendf(&strb, " (");
-            if (md_attr.alloc_mem_types & UCS_BIT(mem_type)) {
-                ucs_string_buffer_appendf(&strb, "alloc, ");
-            }
 
-            if (!(md_attr.cache_mem_types & UCS_BIT(mem_type))) {
-                ucs_string_buffer_appendf(&strb, "nocache, ");
-            }
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, access);
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, alloc);
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, reg);
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, cache);
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, detect);
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, dmabuf);
+            ucs_string_buffer_rtrim(&strb, ",");
 
-            ucs_string_buffer_rtrim(&strb, ", ");
             ucs_string_buffer_appendf(&strb, "), ");
         }
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1538,18 +1538,33 @@ struct uct_md_attr {
  * are present.
  */
 typedef enum uct_md_mem_attr_field {
-    UCT_MD_MEM_ATTR_FIELD_MEM_TYPE     = UCS_BIT(0), /**< Indicate if memory type
-                                                          is populated. E.g. CPU/GPU */
-    UCT_MD_MEM_ATTR_FIELD_SYS_DEV      = UCS_BIT(1), /**< Indicate if details of
-                                                          system device backing
-                                                          the pointer are populated.
-                                                          E.g. NUMA/GPU */
-    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS = UCS_BIT(2), /**< Request base address of the
-                                                          allocation to which the buffer
-                                                          belongs. */
-    UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH = UCS_BIT(3)  /**< Request the whole length of the
-                                                          allocation to which the buffer
-                                                          belongs. */
+    /** Indicate if memory type is populated. E.g. CPU/GPU */
+    UCT_MD_MEM_ATTR_FIELD_MEM_TYPE      = UCS_BIT(0),
+
+    /**
+     * Indicate if details of system device backing the pointer are populated.
+     * For example: GPU device, NUMA domain, etc.
+     */
+    UCT_MD_MEM_ATTR_FIELD_SYS_DEV       = UCS_BIT(1),
+
+    /** Request base address of the allocation to which the buffer belongs. */
+    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS  = UCS_BIT(2),
+
+    /** Request the whole length of the allocation to which the buffer belongs. */
+    UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH  = UCS_BIT(3),
+
+    /**
+     * Request a cross-device dmabuf file descriptor that represents a memory
+     * region, and can be used to register the region with another memory
+     * domain.
+     */
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_FD     = UCS_BIT(4),
+
+    /**
+     * Request the offset of the provided virtual address relative to the
+     * beginning of its backing dmabuf region.
+     */
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET = UCS_BIT(5)
 } uct_md_mem_attr_field_t;
 
 
@@ -1595,6 +1610,22 @@ typedef struct uct_md_mem_attr {
      * to uct_md_mem_query is returned as is.
      */
     size_t            alloc_length;
+
+    /**
+     * Dmabuf file descriptor to expose memory regions across devices. Refer
+     * (https://01.org/linuxgraphics/gfx-docs/drm/driver-api/dma-buf.html).
+     * If the md does not support querying the fd object associated with the
+     * region, then dmabuf_fd is set to UCT_DMABUF_FD_INVALID by
+     * uct_md_mem_query(). It is the responsibility of the user to close the
+     * returned fd using close (2) when it's no longer needed.
+     */
+    int               dmabuf_fd;
+
+    /**
+     * Offset of the given address from the start of the memory region
+     * (identified by dmabuf_fd) backing the memory region being queried.
+     */
+    size_t            dmabuf_offset;
 } uct_md_mem_attr_t;
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -27,6 +27,7 @@
 #define UCT_MEM_HANDLE_NULL        NULL
 #define UCT_INVALID_RKEY           ((uintptr_t)(-1))
 #define UCT_INLINE_API             static UCS_F_ALWAYS_INLINE
+#define UCT_DMABUF_FD_INVALID      -1
 
 
 /**

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -20,6 +20,9 @@
 #include <uct/api/v2/uct_v2.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
+#if CUDA_VERSION >= 11070
+#include <cudaTypedefs.h>
+#endif
 
 
 static ucs_config_field_t uct_cuda_copy_md_config_table[] = {
@@ -44,6 +47,35 @@ static ucs_config_field_t uct_cuda_copy_md_config_table[] = {
     {NULL}
 };
 
+static int uct_cuda_copy_md_is_dmabuf_supported()
+{
+    int dmabuf_supported = 0;
+    CUdevice cuda_device;
+    CUresult cu_err;
+
+    cu_err = cuDeviceGet(&cuda_device, 0);
+    if (cu_err != CUDA_SUCCESS) {
+        ucs_debug("cuDevuceGet(0) returned %d", cu_err);
+        return 0;
+    }
+
+    /* Assume dmabuf support is uniform across all devices */
+#if CUDA_VERSION >= 11070
+    cu_err = cuDeviceGetAttribute(&dmabuf_supported,
+                                  CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED,
+                                  cuda_device);
+    if (cu_err != CUDA_SUCCESS) {
+        ucs_debug("cuDeviceGetAttribute(DMA_BUF_SUPPORTED) returned %d",
+                  cu_err);
+        return 0;
+    }
+#endif
+
+    ucs_debug("dmabuf is%s supported on cuda device %d",
+              dmabuf_supported ? "" : " not", cuda_device);
+    return dmabuf_supported;
+}
+
 static ucs_status_t
 uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
@@ -60,6 +92,9 @@ uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                 UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
     md_attr->dmabuf_mem_types = 0;
+    if (uct_cuda_copy_md_is_dmabuf_supported()) {
+        md_attr->dmabuf_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    }
     md_attr->max_alloc        = SIZE_MAX;
     md_attr->max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size = 0;

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -227,6 +227,14 @@ ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
         mem_attr_p->alloc_length = length;
     }
 
+    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_FD) {
+        mem_attr->dmabuf_fd = UCT_DMABUF_FD_INVALID;
+    }
+
+    if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET) {
+        mem_attr->dmabuf_offset = 0;
+    }
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## Why
- Support dmabuf export - querying dmabuf_fd and dmabuf_offset

## How
- Extend uct_mem_query() API
- Implemend dmabuf query for cuda_copy transport
- Add dmabuf capabilities print to ucx_info

Replaces #7847