### PR TITLE
BUILD/DEBIAN: Fix format of debian/copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,13 +3,14 @@ Upstream-Name: UCX
 Source: http://www.openucx.org
 
 Files: *
-Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
-Copyright (c) 2014-2015      NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+Copyright:
+ 2014-2015      UT-Battelle, LLC. All rights reserved.
+ 2014-2015      NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 License: BSD
  Redistribution and use in source and binary forms, with or without 
  modification, are permitted provided that the following conditions 
  are met:
- 
+ .
  1. Redistributions of source code must retain the above copyright 
  notice, this list of conditions and the following disclaimer.
  2. Redistributions in binary form must reproduce the above copyright
@@ -18,7 +19,7 @@ License: BSD
  3. Neither the name of the copyright holder nor the names of its 
  contributors may be used to endorse or promote products derived from 
  this software without specific prior written permission.
- 
+ .
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 


### PR DESCRIPTION
See format definition in the URL in the first line of this file.
The file has generally a format similar to debian/control (inspired by mail headers).

No functional change. Fixes formatting for whatever tools that may attempt to figure out the licensing data automatically from this file.