### PR TITLE
UCT/API/IB: Add support for dmabuf registration

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -448,8 +448,12 @@ static void print_md_info(uct_component_h component,
                    size_limit_to_str(0, md_attr.max_alloc));
         }
         if (md_attr.flags & UCT_MD_FLAG_REG) {
-            printf("#             register: %s, cost: ",
+            printf("#             register: %s",
                    size_limit_to_str(0, md_attr.max_reg));
+            if (md_attr.flags & UCT_MD_FLAG_REG_DMABUF) {
+                printf(", dmabuf");
+            }
+            printf(", cost: ");
             PRINT_LINEAR_FUNC_NS(&md_attr.reg_cost);
         }
         if (md_attr.flags & UCT_MD_FLAG_NEED_RKEY) {

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -754,7 +754,12 @@ enum {
      * MD supports exporting memory keys with another process using the same
      * device or attaching to an exported memory key.
      */
-    UCT_MD_FLAG_EXPORTED_MKEY = UCS_BIT(9)
+    UCT_MD_FLAG_EXPORTED_MKEY = UCS_BIT(9),
+
+    /**
+     * MD supports registering a dmabuf file descriptor.
+     */
+    UCT_MD_FLAG_REG_DMABUF    = UCS_BIT(10)
 };
 
 /**

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -27,6 +27,7 @@
 #define UCT_MEM_HANDLE_NULL        NULL
 #define UCT_INVALID_RKEY           ((uintptr_t)(-1))
 #define UCT_INLINE_API             static UCS_F_ALWAYS_INLINE
+#define UCT_DMABUF_FD_INVALID      -1
 
 
 /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -195,7 +195,9 @@ typedef struct {
  * @brief MD memory registration operation flags.
  */
 typedef enum {
-    UCT_MD_MEM_REG_FIELD_FLAGS = UCS_BIT(0)
+    UCT_MD_MEM_REG_FIELD_FLAGS         = UCS_BIT(0),
+    UCT_MD_MEM_REG_FIELD_DMABUF_FD     = UCS_BIT(1),
+    UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET = UCS_BIT(2)
 } uct_md_mem_reg_field_mask_t;
 
 
@@ -378,6 +380,45 @@ typedef struct uct_md_mem_reg_params {
      * Operation specific flags, using bits from @ref uct_md_mem_flags_t.
      */
     uint64_t                     flags;
+
+    /**
+     * dmabuf file descriptor of the memory region to register.
+     *
+     * If is set (along with its corresponding bit in the field_mask -
+     * @ref UCT_MD_MEM_REG_FIELD_DMABUF_FD), the memory region will be
+     * registered using dmabuf mechanism.
+     * Can be used only if the memory domain supports dmabuf registration by
+     * returning @ref UCT_MD_FLAG_REG_DMABUF flag from @ref uct_md_query_v2.
+     *
+     * When registering memory using dmabuf mechanism, any memory type is supported
+     * (assuming a valid dmabuf file descriptor could be created).
+     * Therefore, @ref uct_md_attr_v2_t.reg_mem_types field is not relevant for
+     * such registrations.
+     *
+     * If not set, it's assumed to be @ref UCT_DMABUF_FD_INVALID, and the memory
+     * region will be registered without using dmabuf mechanism.
+     *
+     * More information about dmabuf registration can be found in
+     * https://01.org/linuxgraphics/gfx-docs/drm/driver-api/dma-buf.html
+     */
+    int                          dmabuf_fd;
+
+    /**
+     * When @ref uct_md_mem_reg_params_t.dmabuf_fd is provided, this field
+     * specifies the offset of the region to register relative to the start of
+     * the underlying dmabuf region.
+     *
+     * If not set (along with its corresponding bit in the field_mask -
+     * @ref UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET) it's assumed to be 0.
+     *
+     * @note The value of this field must be equal to the offset of the virtual
+     * address provided by the address parameter to @ref uct_md_mem_reg_v2 from
+     * the beginning of the memory region associated with
+     * @ref uct_md_mem_reg_params_t.dmabuf_fd.
+     * For example, if the virtual address is equal to the beginning of the
+     * dmabuf region, then this field must be omitted or set to 0.
+     */
+    size_t                       dmabuf_offset;
 } uct_md_mem_reg_params_t;
 
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -225,22 +225,28 @@ typedef void (*uct_ib_md_cleanup_func_t)(struct uct_ib_md *);
 /**
  * Memory domain method to register memory area.
  *
- * @param [in]  md      Memory domain.
+ * @param [in]  md             Memory domain.
  *
- * @param [in]  address Memory area start address.
+ * @param [in]  address        Memory area start address.
  *
- * @param [in]  length  Memory area length.
+ * @param [in]  length         Memory area length.
  *
- * @param [in]  access  IB verbs registration access flags
+ * @param [in]  access         IB verbs registration access flags.
  *
- * @param [in]  memh    Memory region handle.
- *                      Method should initialize lkey & rkey.
+ * @param [in]  dmabuf_fd      dmabuf file descriptor.
+ *
+ * @param [in]  dmabuf_offset  Offset of the registered memory region within the
+ *                             dmabuf backing region.
+ *
+ * @param [in]  memh           Memory region handle.
+ *                             The method must initialize lkey & rkey.
  *
  * @return UCS_OK on success or error code in case of failure.
  */
 typedef ucs_status_t (*uct_ib_md_reg_key_func_t)(struct uct_ib_md *md,
                                                  void *address, size_t length,
-                                                 uint64_t access,
+                                                 uint64_t access, int dmabuf_fd,
+                                                 size_t dmabuf_offset,
                                                  uct_ib_mem_t *memh,
                                                  uct_ib_mr_type_t mr_type,
                                                  int silent);
@@ -590,7 +596,8 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
 void uct_ib_md_close(uct_md_h uct_md);
 
 ucs_status_t uct_ib_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
-                           uint64_t access, struct ibv_mr **mr_p, int silent);
+                           uint64_t access, int dmabuf_fd, size_t dmabuf_offset,
+                           struct ibv_mr **mr_p, int silent);
 ucs_status_t uct_ib_dereg_mr(struct ibv_mr *mr);
 ucs_status_t uct_ib_dereg_mrs(struct ibv_mr **mrs, size_t mr_num);
 
@@ -610,9 +617,10 @@ uct_ib_md_handle_mr_list_multithreaded(uct_ib_md_t *md, void *address,
 void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                    const uct_ib_md_config_t *md_config);
 
-ucs_status_t uct_ib_reg_key_impl(uct_ib_md_t *md, void *address,
-                                 size_t length, uint64_t access_flags,
-                                 uct_ib_mem_t *memh, uct_ib_mr_t *mrs,
-                                 uct_ib_mr_type_t mr_type, int silent);
+ucs_status_t uct_ib_reg_key_impl(uct_ib_md_t *md, void *address, size_t length,
+                                 uint64_t access_flags, int dmabuf_fd,
+                                 size_t dmabuf_offset, uct_ib_mem_t *memh,
+                                 uct_ib_mr_t *mr, uct_ib_mr_type_t mr_type,
+                                 int silent);
 
 #endif

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -197,7 +197,8 @@ AS_IF([test "x$with_ib" = "xyes"],
                        IBV_EVENT_GID_CHANGE,
                        ibv_create_qp_ex,
                        ibv_create_cq_ex,
-                       ibv_create_srq_ex],
+                       ibv_create_srq_ex,
+                       ibv_reg_dmabuf_mr],
                       [], [], [[#include <infiniband/verbs.h>]])
 
        # Check ECE operation APIs are supported by rdma-core package

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -47,15 +47,15 @@ typedef struct uct_ib_mlx5_mem {
 
 static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
 
-static ucs_status_t uct_ib_mlx5_reg_key(uct_ib_md_t *md, void *address,
-                                        size_t length, uint64_t access_flags,
-                                        uct_ib_mem_t *ib_memh,
-                                        uct_ib_mr_type_t mr_type,
-                                        int silent)
+static ucs_status_t
+uct_ib_mlx5_reg_key(uct_ib_md_t *md, void *address, size_t length,
+                    uint64_t access_flags, int dmabuf_fd, size_t dmabuf_offset,
+                    uct_ib_mem_t *ib_memh, uct_ib_mr_type_t mr_type, int silent)
 {
     uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
 
-    return uct_ib_reg_key_impl(md, address, length, access_flags, ib_memh,
+    return uct_ib_reg_key_impl(md, address, length, access_flags, dmabuf_fd,
+                               dmabuf_offset, ib_memh,
                                &memh->mrs[mr_type].super, mr_type, silent);
 }
 
@@ -869,7 +869,8 @@ static ucs_status_t uct_ib_mlx5_devx_init_flush_mr(uct_ib_mlx5_md_t *md)
 
     status = uct_ib_reg_mr(md->super.pd, md->zero_buf,
                            UCT_IB_MD_FLUSH_REMOTE_LENGTH,
-                           UCT_IB_MEM_ACCESS_FLAGS, &md->flush_mr, 1);
+                           UCT_IB_MEM_ACCESS_FLAGS, UCT_DMABUF_FD_INVALID, 0,
+                           &md->flush_mr, 1);
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
## Why
As part of dmabuf support, add dambuf registration (import) support to UCT API and implement it for IB transport

## How
- API: Add `UCT_MD_FLAG_REG_DMABUF` md capability and `dmabuf_fd`,`dmabuf_offset` params to memory registration.
- IB: Check dmabuf support on startup, and pass dmabuf fd and offset to internal registration functions

This PR complements #8581 
cc @Akshay-Venkatesh 