### PR TITLE
A separate gdrcopy binary Deb package

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -36,3 +36,14 @@ Description: Unified Communication X - CUDA support
  pointers to UCX communication routines, and transports taking advantage
  of GPU-Direct technology for direct data transfer between GPU and RDMA
  devices.
+
+Package: ucx-gdrcopy
+Section: libs
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Architecture: any
+Build-Profiles: <cuda>
+Description: Unified Communication X - gdrcopy support
+ UCX is a communication library implementing high-performance messaging.
+ .
+ This package provides UCX support for using gdrcopy - A low-latency GPU
+ memory copy library based on NVIDIA GPUDirect RDMA technology.

--- a/debian/control.in
+++ b/debian/control.in
@@ -21,13 +21,15 @@ Depends: libc6, libgomp1, libnuma1
 Architecture: any
 Description: Unified Communication X
  UCX is a communication library implementing high-performance messaging.
+ .
+ This is the main package that includes the library as well as build headers.
 
 Package: ucx-cuda
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Architecture: any
 Build-Profiles: <cuda>
-Description: Unified Communication X
+Description: Unified Communication X - CUDA support
  UCX is a communication library implementing high-performance messaging.
  .
  Provide CUDA (NVIDIA GPU) support for UCX. Enables passing GPU memory

--- a/debian/ucx-cuda.install
+++ b/debian/ucx-cuda.install
@@ -1,2 +1,2 @@
 usr/lib/ucx/libucx_perftest_cuda.*
-usr/lib/ucx/libuc?_cuda*
+usr/lib/ucx/libuc?_cuda.*

--- a/debian/ucx-gdrcopy.install
+++ b/debian/ucx-gdrcopy.install
@@ -1,0 +1,1 @@
+usr/lib/ucx/libuct_cuda_gdrcopy.*


### PR DESCRIPTION
Move gdrcopy-dependent modules independent of the CUDA ones: it is  possible to have just CUDA without gdrcopy.

First commit slightly edits the descriptions of the other two binary deb packages. The second commit adds the new binary deb package ucx-gdrcopy and moves files to it from the original ucx-cuda package.