### PR TITLE
UCT/CUDA: move rt api -> drv api

### DIFF
--- a/src/uct/cuda/Makefile.am
+++ b/src/uct/cuda/Makefile.am
@@ -13,7 +13,7 @@ libuct_cuda_la_CFLAGS   = $(BASE_CFLAGS) $(CUDA_CFLAGS)
 libuct_cuda_la_LDFLAGS  = $(CUDA_LDFLAGS) -version-info $(SOVERSION)
 libuct_cuda_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                           $(top_builddir)/src/uct/libuct.la \
-                          $(CUDA_LIBS) $(CUDART_LIBS) $(NVML_LIBS)
+                          $(CUDA_LIBS) $(NVML_LIBS)
 
 noinst_HEADERS = \
 	base/cuda_md.h \

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -10,51 +10,11 @@
 #include <ucs/sys/preprocessor.h>
 #include <ucs/profile/profile.h>
 #include <ucs/async/eventfd.h>
-#include <cuda_runtime.h>
 #include <cuda.h>
 #include <nvml.h>
 
 
 const char *uct_cuda_base_cu_get_error_string(CUresult result);
-
-
-#if CUDART_VERSION >= 11010
-#define UCT_CUDA_FUNC_PTX_ERR(_result, _func, _err_str)         \
-    do {                                                        \
-        if (_result == cudaErrorUnsupportedPtxVersion) {        \
-            ucs_error("%s() failed: %s",                        \
-                      UCS_PP_MAKE_STRING(_func), _err_str);     \
-        }                                                       \
-    } while (0);
-#else
-#define UCT_CUDA_FUNC_PTX_ERR(_result, _func, _err_str)         \
-    do {                                                        \
-    } while (0);
-#endif
-
-
-#define UCT_CUDA_CALL(_log_level, _func, ...) \
-    ({ \
-        ucs_status_t _status = UCS_OK; \
-        { \
-            cudaError_t _result = UCS_PROFILE_CALL_ALWAYS(_func, __VA_ARGS__); \
-            if (cudaSuccess != _result) { \
-                if ((_log_level) != UCS_LOG_LEVEL_ERROR) { \
-                    UCT_CUDA_FUNC_PTX_ERR(_result, _func, \
-                                          cudaGetErrorString(_result)); \
-                } \
-                ucs_log((_log_level), "%s() failed: %s", \
-                        UCS_PP_MAKE_STRING(_func), \
-                        cudaGetErrorString(_result)); \
-                _status = UCS_ERR_IO_ERROR; \
-            } \
-        } \
-        _status; \
-    })
-
-
-#define UCT_CUDA_CALL_LOG_ERR(_func, ...) \
-    UCT_CUDA_CALL(UCS_LOG_LEVEL_ERROR, _func, __VA_ARGS__)
 
 
 #define UCT_NVML_FUNC(_func, _log_level) \

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -71,26 +71,43 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
     CUdevice cuda_device;
     ucs_status_t status;
     char device_name[10];
-    int num_gpus;
+    int i, num_gpus;
 
-    status = UCT_CUDA_CALL(UCS_LOG_LEVEL_DIAG, cudaGetDeviceCount, &num_gpus);
+    status = UCT_CUDADRV_FUNC(cuDeviceGetCount(&num_gpus), UCS_LOG_LEVEL_DIAG);
     if ((status != UCS_OK) || (num_gpus == 0)) {
         return uct_md_query_empty_md_resource(resources_p, num_resources_p);
     }
 
-    for (cuda_device = 0; cuda_device < num_gpus; ++cuda_device) {
-        uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
-        if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
-            ucs_snprintf_safe(device_name, sizeof(device_name), "GPU%d",
-                              cuda_device);
-            status = ucs_topo_sys_device_set_name(sys_dev, device_name,
-                                                  sys_device_priority);
-            ucs_assert_always(status == UCS_OK);
+    for (i = 0; i < num_gpus; ++i) {
+        status = UCT_CUDADRV_FUNC(cuDeviceGet(&cuda_device, i),
+                                  UCS_LOG_LEVEL_DIAG);
+        if (status != UCS_OK) {
+            continue;
         }
+
+        uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
+        if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
+            continue;
+        }
+
+        ucs_snprintf_safe(device_name, sizeof(device_name), "GPU%d",
+                          cuda_device);
+        status = ucs_topo_sys_device_set_name(sys_dev, device_name,
+                                              sys_device_priority);
+        ucs_assert_always(status == UCS_OK);
     }
 
     return uct_md_query_single_md_resource(component, resources_p,
                                            num_resources_p);
+}
+
+UCS_STATIC_INIT
+{
+    cuInit(0);
+}
+
+UCS_STATIC_CLEANUP
+{
 }
 
 UCS_MODULE_INIT() {

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -44,22 +44,21 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_cuda_copy_ep_t, uct_ep_t);
     ucs_trace_data("%s [ptr %p len %zu] to 0x%" PRIx64, _name, (_iov)->buffer, \
                    (_iov)->length, (_remote_addr))
 
-ucs_status_t uct_cuda_copy_init_stream(cudaStream_t *stream)
+ucs_status_t uct_cuda_copy_init_stream(CUstream *stream)
 {
     if (*stream != 0) {
         return UCS_OK;
     }
 
-    return UCT_CUDA_CALL_LOG_ERR(cudaStreamCreateWithFlags, stream,
-                                 cudaStreamNonBlocking);
+    return UCT_CUDADRV_FUNC_LOG_ERR(
+            cuStreamCreate(stream, CU_STREAM_NON_BLOCKING));
 }
 
-static UCS_F_ALWAYS_INLINE cudaStream_t *
+static UCS_F_ALWAYS_INLINE CUstream *
 uct_cuda_copy_get_stream(uct_cuda_copy_iface_t *iface,
-                         ucs_memory_type_t src_type,
-                         ucs_memory_type_t dst_type)
+                         ucs_memory_type_t src_type, ucs_memory_type_t dst_type)
 {
-    cudaStream_t *stream = NULL;
+    CUstream *stream = NULL;
     ucs_status_t status;
 
     ucs_assert((src_type < UCS_MEMORY_TYPE_LAST) &&
@@ -109,7 +108,7 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src,
     ucs_status_t status;
     ucs_memory_type_t src_type;
     ucs_memory_type_t dst_type;
-    cudaStream_t *stream;
+    CUstream *stream;
     ucs_queue_head_t *event_q;
 
     if (!length) {
@@ -143,10 +142,11 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src,
         return UCS_ERR_NO_MEMORY;
     }
 
-    status = UCT_CUDA_CALL_LOG_ERR(cudaMemcpyAsync, dst, src, length,
-                                   cudaMemcpyDefault, *stream);
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuMemcpyAsync((CUdeviceptr)dst, (CUdeviceptr)src, length, *stream));
 
-    status = UCT_CUDA_CALL_LOG_ERR(cudaEventRecord, cuda_event->event, *stream);
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuEventRecord(cuda_event->event, *stream));
     if (UCS_OK != status) {
         return UCS_ERR_IO_ERROR;
     }
@@ -212,7 +212,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_put_short,
                  uint64_t remote_addr, uct_rkey_t rkey)
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cuda_copy_iface_t);
-    cudaStream_t *stream         = &iface->short_stream;
+    CUstream *stream             = &iface->short_stream;
     ucs_status_t status;
 
     status = uct_cuda_copy_init_stream(stream);
@@ -220,9 +220,10 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_put_short,
         return status;
     }
 
-    UCT_CUDA_CALL_LOG_ERR(cudaMemcpyAsync, (void*)remote_addr, buffer, length,
-                          cudaMemcpyDefault, *stream);
-    status = UCT_CUDA_CALL_LOG_ERR(cudaStreamSynchronize, *stream);
+    UCT_CUDADRV_FUNC_LOG_ERR(cuMemcpyAsync((CUdeviceptr)remote_addr,
+                                           (CUdeviceptr)buffer, length,
+                                           *stream));
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuStreamSynchronize(*stream));
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, SHORT, length);
     ucs_trace_data("PUT_SHORT size %d from %p to %p",
@@ -236,7 +237,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_get_short,
                  uint64_t remote_addr, uct_rkey_t rkey)
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cuda_copy_iface_t);
-    cudaStream_t *stream         = &iface->short_stream;
+    CUstream *stream             = &iface->short_stream;
     ucs_status_t status;
 
     status = uct_cuda_copy_init_stream(stream);
@@ -244,9 +245,10 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_get_short,
         return status;
     }
 
-    UCT_CUDA_CALL_LOG_ERR(cudaMemcpyAsync, buffer, (void*)remote_addr, length,
-                          cudaMemcpyDefault, *stream);
-    status = UCT_CUDA_CALL_LOG_ERR(cudaStreamSynchronize, *stream);
+    UCT_CUDADRV_FUNC_LOG_ERR(cuMemcpyAsync((CUdeviceptr)buffer,
+                                           (CUdeviceptr)remote_addr, length,
+                                           *stream));
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuStreamSynchronize(*stream));
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, SHORT, length);
     ucs_trace_data("GET_SHORT size %d from %p to %p",

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -167,7 +167,7 @@ uct_cuda_copy_queue_head_ready(ucs_queue_head_t *queue_head)
     cuda_event = ucs_queue_head_elem_non_empty(queue_head,
                                                uct_cuda_copy_event_desc_t,
                                                queue);
-    return (cudaSuccess == cudaEventQuery(cuda_event->event));
+    return (CUDA_SUCCESS == cuEventQuery(cuda_event->event));
 }
 
 static UCS_F_ALWAYS_INLINE unsigned
@@ -179,7 +179,8 @@ uct_cuda_copy_progress_event_queue(uct_cuda_copy_iface_t *iface,
     uct_cuda_copy_event_desc_t *cuda_event;
 
     ucs_queue_for_each_extract(cuda_event, queue_head, queue,
-                               cudaEventQuery(cuda_event->event) == cudaSuccess) {
+                               cuEventQuery(cuda_event->event) ==
+                                       CUDA_SUCCESS) {
         ucs_queue_remove(queue_head, &cuda_event->queue);
         if (cuda_event->comp != NULL) {
             ucs_trace_data("cuda_copy event %p completed", cuda_event);
@@ -222,7 +223,7 @@ static ucs_status_t uct_cuda_copy_iface_event_fd_arm(uct_iface_h tl_iface,
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
     ucs_status_t status;
-    cudaStream_t *stream;
+    CUstream *stream;
     ucs_queue_head_t *event_q;
     uct_cuda_copy_queue_desc_t *q_desc;
     ucs_queue_iter_t iter;
@@ -299,10 +300,10 @@ static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chun
     ucs_status_t status;
 
     memset(base, 0 , sizeof(*base));
-    status = UCT_CUDA_CALL_LOG_ERR(cudaEventCreateWithFlags, &base->event,
-                                   cudaEventDisableTiming);
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuEventCreate(&base->event, CU_EVENT_DISABLE_TIMING));
     if (UCS_OK != status) {
-        ucs_error("cudaEventCreateWithFlags Failed");
+        ucs_error("cuEventCreate Failed");
     }
 }
 
@@ -316,7 +317,7 @@ static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 
     UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
     if (uct_cuda_base_context_match(cuda_context, iface->cuda_context)) {
-        UCT_CUDA_CALL_LOG_ERR(cudaEventDestroy, base->event);
+        UCT_CUDADRV_FUNC_LOG_ERR(cuEventDestroy(base->event));
     }
 }
 
@@ -458,7 +459,7 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
 {
-    cudaStream_t *stream;
+    CUstream *stream;
     CUcontext cuda_context;
     ucs_queue_head_t *event_q;
     ucs_memory_type_t src, dst;
@@ -482,12 +483,12 @@ static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
                     continue;
                 }
 
-                UCT_CUDA_CALL_LOG_ERR(cudaStreamDestroy, *stream);
+                UCT_CUDADRV_FUNC_LOG_ERR(cuStreamDestroy(*stream));
             }
         }
 
         if (self->short_stream) {
-            UCT_CUDA_CALL_LOG_ERR(cudaStreamDestroy, self->short_stream);
+            UCT_CUDADRV_FUNC_LOG_ERR(cuStreamDestroy(self->short_stream));
         }
     }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -17,7 +17,7 @@ typedef uint64_t uct_cuda_copy_iface_addr_t;
 
 typedef struct uct_cuda_copy_queue_desc {
     /* stream on which asynchronous memcpy operations are enqueued */
-    cudaStream_t                stream;
+    CUstream                    stream;
     /* queue of cuda events */
     ucs_queue_head_t            event_queue;
     /* needed to allow queue descriptor to be added to iface->active_queue */
@@ -34,7 +34,7 @@ typedef struct uct_cuda_copy_iface {
     /* list of queues which require progress */
     ucs_queue_head_t            active_queue;
     /* stream used to issue short operations */
-    cudaStream_t                short_stream;
+    CUstream                    short_stream;
     /* fd to get event notifications */
     int                         eventfd;
     /* stream used to issue short operations */
@@ -64,7 +64,7 @@ typedef struct uct_cuda_copy_iface_config {
 
 
 typedef struct uct_cuda_copy_event_desc {
-    cudaEvent_t      event;
+    CUevent          event;
     uct_completion_t *comp;
     ucs_queue_elem_t queue;
 } uct_cuda_copy_event_desc_t;

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -20,7 +20,6 @@
 #include <ucs/sys/math.h>
 #include <uct/cuda/base/cuda_iface.h>
 #include <uct/api/v2/uct_v2.h>
-#include <cuda_runtime.h>
 #include <cuda.h>
 #if CUDA_VERSION >= 11070
 #include <cudaTypedefs.h>
@@ -159,6 +158,11 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
     CUresult result;
     ucs_status_t status;
 
+    if (!uct_cuda_base_is_context_active()) {
+        ucs_debug("attempt to register memory without active context");
+        return uct_md_dummy_mem_reg(md, address, length, params, memh_p);
+    }
+
     result = cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                    (CUdeviceptr)(address));
     if ((result == CUDA_SUCCESS) && ((memType == CU_MEMORYTYPE_HOST)    ||
@@ -170,8 +174,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
 
     log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
                 UCS_LOG_LEVEL_ERROR;
-    status    = UCT_CUDA_CALL(log_level, cudaHostRegister, address, length,
-                              cudaHostRegisterPortable);
+    status    = UCT_CUDADRV_FUNC(cuMemHostRegister(address, length,
+                                                   CU_MEMHOSTREGISTER_PORTABLE),
+                                 log_level);
     if (status != UCS_OK) {
         return status;
     }
@@ -194,7 +199,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_dereg,
         return UCS_OK;
     }
 
-    status = UCT_CUDA_CALL_LOG_ERR(cudaHostUnregister, address);
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemHostUnregister(address));
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -13,7 +13,6 @@
 #include <ucs/type/spinlock.h>
 #include "cuda_ipc_md.h"
 #include <cuda.h>
-#include <cuda_runtime.h>
 
 
 typedef struct uct_cuda_ipc_cache        uct_cuda_ipc_cache_t;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -388,7 +388,7 @@ static void uct_cuda_ipc_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 
     UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
     if (uct_cuda_base_context_match(cuda_context, iface->cuda_context)) {
-        UCT_CUDA_CALL_LOG_ERR(cudaEventDestroy, base->event);
+        UCT_CUDADRV_FUNC_LOG_ERR(cuEventDestroy(base->event));
     }
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -9,7 +9,6 @@
 #include <uct/base/uct_iface.h>
 #include <uct/cuda/base/cuda_iface.h>
 #include <ucs/arch/cpu.h>
-#include <cuda_runtime.h>
 #include <cuda.h>
 
 #include "cuda_ipc_md.h"


### PR DESCRIPTION
## What/Why?
Replace remaining references to CUDA runtime API to reduce dependencies.
