### PR TITLE
TOOLS: Fix perftest init for external RTE

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -823,12 +823,9 @@ static ucs_status_t setup_mpi_rte(struct perftest_context *ctx)
     ctx->params.super.rte        = &mpi_rte;
     ctx->params.super.report_arg = ctx;
 #elif defined (HAVE_RTE)
-    ucs_trace_func("");
-
-    ctx->params.rte_group         = NULL;
-    ctx->params.rte               = &mpi_rte;
-    ctx->params.report_arg        = ctx;
     rte_group_t group;
+
+    ucs_trace_func("");
 
     rte_init(NULL, NULL, &group);
     /* Let the last rank print the results */


### PR DESCRIPTION
## What
Remove incorrect rte context initialization (added by mistake in #5013)