### PR TITLE
UCT/MD/QUERY: Bug Fix - Accidentally disqualified xpmem

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -95,7 +95,7 @@ uct_mm_iface_query_tl_devices(uct_md_h md,
         return status;
     }
 
-    if (!(md_attr.cap.flags & UCT_MD_FLAG_ALLOC)) {
+    if (!(md_attr.cap.flags & (UCT_MD_FLAG_ALLOC | UCT_MD_FLAG_REG))) {
         *num_tl_devices_p = 0;
         *tl_devices_p     = NULL;
         return UCS_ERR_NO_DEVICE;


### PR DESCRIPTION
## What
Bug caused by #8508 disqualified xpmem
fixes [#8597](https://github.com/openucx/ucx/issues/8597)

## Why ?
Disqualification of MD was based only on mem allocation capabilities and not take into account mem registration capabilities.
That cause xpmem to be disqualified.

## How ?
Check for mem registration capabilities. Only devices without mem registration capabilities nor mem allocation capabilities will be disqualified.

*This test is relevant only for POSIX/XPMEM/SYSV
