### PR TITLE
UCT/IB/DEVX: Set counter_set_id for DevX QP and DCT

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -193,6 +193,11 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    ucs_offsetof(uct_ib_iface_config_t, path_mtu),
                 UCS_CONFIG_TYPE_ENUM(uct_ib_mtu_values)},
 
+  {"COUNTER_SET_ID", "auto",
+   "Counter set ID to use for performance counters. A value of 'auto' will try to\n"
+   "detect the default value by creating a dummy QP." ,
+   ucs_offsetof(uct_ib_iface_config_t, counter_set_id), UCS_CONFIG_TYPE_ULUNITS},
+
   {NULL}
 };
 
@@ -1335,6 +1340,16 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     }
 
     uct_ib_iface_set_num_paths(self, config);
+
+    if (config->counter_set_id == UCS_ULUNITS_AUTO) {
+        self->config.counter_set_id = UCT_IB_COUNTER_SET_ID_INVALID;
+    } else if (config->counter_set_id < UINT8_MAX) {
+        self->config.counter_set_id = config->counter_set_id;
+    } else {
+        ucs_error("counter_set_id must be less than %d", UINT8_MAX);
+        status = UCS_ERR_INVALID_PARAM;
+        goto err;
+    }
 
     self->comp_channel = ibv_create_comp_channel(dev->ibv_context);
     if (self->comp_channel == NULL) {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -28,6 +28,8 @@
 #define UCT_IB_ADDRESS_INVALID_PKEY        0
 #define UCT_IB_ADDRESS_DEFAULT_PKEY        0xffff
 #define UCT_IB_SL_NUM                      16
+#define UCT_IB_COUNTER_SET_ID_INVALID      UINT8_MAX
+
 
 /* Forward declarations */
 typedef struct uct_ib_iface_config   uct_ib_iface_config_t;
@@ -184,6 +186,9 @@ struct uct_ib_iface_config {
 
     /* Path MTU size */
     uct_ib_mtu_t            path_mtu;
+
+    /* QP counter set ID */
+    unsigned long           counter_set_id;
 };
 
 
@@ -298,6 +303,7 @@ struct uct_ib_iface {
         uint8_t               qp_type;
         uint8_t               force_global_addr;
         enum ibv_mtu          path_mtu;
+        uint8_t               counter_set_id;
     } config;
 
     uct_ib_iface_ops_t        *ops;

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -1091,6 +1091,16 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
                                  &iface->config.sl);
 }
 
+uint8_t uct_ib_mlx5_iface_get_counter_set_id(uct_ib_iface_t *iface)
+{
+    if (iface->config.counter_set_id != UCT_IB_COUNTER_SET_ID_INVALID) {
+        return iface->config.counter_set_id;
+    }
+
+    return uct_ib_mlx5_devx_md_get_counter_set_id(uct_ib_mlx5_iface_md(iface),
+                                                  iface->config.port_num);
+}
+
 void uct_ib_mlx5_txwq_validate_always(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb,
                                       int hw_ci_updated)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -285,6 +285,9 @@ typedef struct uct_ib_mlx5_md {
     struct ibv_mr            *flush_mr;
     struct mlx5dv_devx_obj   *flush_dvmr;
     uint8_t                  mkey_tag;
+
+    /* Cached values of counter set id per port */
+    uint8_t                  port_counter_set_ids[UCT_IB_DEV_MAX_PORTS];
 #endif
     struct {
         size_t dc;
@@ -771,7 +774,10 @@ void uct_ib_mlx5_txwq_validate_always(uct_ib_mlx5_txwq_t *wq, uint16_t num_bb,
 
 #if HAVE_DEVX
 
-uint32_t uct_ib_mlx5_devx_get_pdn(uct_ib_mlx5_md_t *md);
+uint8_t
+uct_ib_mlx5_devx_md_get_counter_set_id(uct_ib_mlx5_md_t *md, uint8_t port_num);
+
+uint32_t uct_ib_mlx5_devx_md_get_pdn(uct_ib_mlx5_md_t *md);
 
 ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
                                         const uct_ib_mlx5_cq_t *send_cq,
@@ -948,6 +954,8 @@ ucs_status_t
 uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
                             const uct_ib_mlx5_iface_config_t *ib_mlx5_config,
                             const uct_ib_iface_config_t *ib_config);
+
+uint8_t uct_ib_mlx5_iface_get_counter_set_id(uct_ib_iface_t *iface);
 
 static inline uct_ib_mlx5_dbrec_t *uct_ib_mlx5_get_dbrec(uct_ib_mlx5_md_t *md)
 {

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -268,7 +268,7 @@ uct_rc_mlx5_devx_init_rx_common(uct_rc_mlx5_iface_common_t *iface,
     UCT_IB_MLX5DV_SET  (wq, wq, wq_type,       wq_type);
     UCT_IB_MLX5DV_SET  (wq, wq, log_wq_sz,     ucs_ilog2(max));
     UCT_IB_MLX5DV_SET  (wq, wq, log_wq_stride, ucs_ilog2(stride));
-    UCT_IB_MLX5DV_SET  (wq, wq, pd,            uct_ib_mlx5_devx_get_pdn(md));
+    UCT_IB_MLX5DV_SET  (wq, wq, pd,            uct_ib_mlx5_devx_md_get_pdn(md));
     UCT_IB_MLX5DV_SET  (wq, wq, dbr_umem_id,   iface->rx.srq.devx.dbrec->mem_id);
     UCT_IB_MLX5DV_SET64(wq, wq, dbr_addr,      iface->rx.srq.devx.dbrec->offset);
     UCT_IB_MLX5DV_SET  (wq, wq, wq_umem_id,    iface->rx.srq.devx.mem.mem->umem_id);


### PR DESCRIPTION
## Why
Fix NVIDIA internal issue [3139906](https://redmine.mellanox.com/issues/3139906)
When creating a DevX QP, attach it to the default port counters, so QP events would be reflected through sysfs.

## How
Create a dummy QP, modify it to INIT, and query its counter_set_id. Cache the counter_set_id per port.