### PR TITLE
UCP/PROTO: do not reinit iterator on restart request

### DIFF
--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -200,34 +200,6 @@ ucp_datatype_iter_is_begin(const ucp_datatype_iter_t *dt_iter)
     return dt_iter->offset == 0;
 }
 
-/*
- * Initialize a cleaned-up iterator, after it has already been initialized and
- * cleaned up by calling @ref ucp_datatype_iter_init and
- * @ref ucp_datatype_iter_cleanup.
- *
- * @note The current offset of the iterator must be 0, since we can't start
- *       the iterator from the middle.
- */
-static UCS_F_ALWAYS_INLINE void
-ucp_datatype_iter_restart(ucp_datatype_iter_t *dt_iter)
-{
-    ucp_dt_generic_t *dt_gen;
-    void *state;
-
-    ucs_assertv(ucp_datatype_iter_is_begin(dt_iter), "offset=%zu",
-                dt_iter->offset);
-
-    if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_GENERIC,
-                                   UCP_DT_MASK_ALL)) {
-        dt_gen = dt_iter->type.generic.dt_gen;
-        state  = dt_gen->ops.start_pack(dt_gen->context,
-                                        dt_iter->type.generic.buffer,
-                                        dt_iter->type.generic.count);
-
-        dt_iter->type.generic.state = state;
-    }
-}
-
 static UCS_F_ALWAYS_INLINE void
 ucp_datatype_iter_iov_check(const ucp_datatype_iter_t *dt_iter)
 {

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -743,7 +743,6 @@ void ucp_proto_request_restart(ucp_request_t *req)
 
     status = ucp_proto_request_init(req);
     if (status == UCS_OK) {
-        ucp_datatype_iter_restart(&req->send.state.dt_iter);
         ucp_request_send(req);
     } else {
         ucp_proto_request_abort(req, status);


### PR DESCRIPTION
## What
do not reinitialize datatype iterator on request restart 

## Why ?
there were design decision do not cleanup iterator on request reset
