### PR TITLE
UCP/PROTO: fix eager_zcopy_single seg size

### DIFF
--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -162,7 +162,7 @@ ucp_proto_t ucp_eager_bcopy_single_proto = {
 static ucs_status_t
 ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
 {
-    ucp_context_t *context               = init_params->worker->context;
+    ucp_context_t *context                = init_params->worker->context;
     ucp_proto_single_init_params_t params = {
         .super.super         = *init_params,
         .super.latency       = 0,
@@ -178,8 +178,9 @@ ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
         .super.hdr_size      = sizeof(ucp_tag_hdr_t),
         .super.send_op       = UCT_EP_OP_AM_ZCOPY,
         .super.memtype_op    = UCT_EP_OP_LAST,
-        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
-                               UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY  |
+                               UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG |
+                               UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_ZCOPY
     };


### PR DESCRIPTION
## What
fix eager_zcopy_single seg size

## Why ?
failure in test_ucp_address_v2.diff_seg_sizes with `UCX_PROTO_ENABLE=y`
