### PR TITLE
UCP/MM/PROTO: Register memory using dmabuf with protov2

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -272,9 +272,18 @@ typedef struct ucp_context {
     /* Map of MDs that require caching registrations for given memory type. */
     ucp_md_map_t                  cache_md_map[UCS_MEMORY_TYPE_LAST];
 
+    /* Map of MDs that support dmabuf registration */
+    ucp_md_map_t                  dmabuf_reg_md_map;
+
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */
+
+    /* Map of dmabuf providers per memory type. Each entry in the array is
+       either the index of the provider MD, or UCP_NULL_RESOURCE if no such MD
+       exists. */
+    ucp_md_index_t                dmabuf_mds[UCS_MEMORY_TYPE_LAST];
+
     uint64_t                      mem_type_mask;            /* Supported mem type mask */
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -636,6 +636,9 @@ ucp_lane_index_t ucp_rkey_find_rma_lane(ucp_context_h context,
             }
         }
 
+        /* Should not use md_attr->reg_mem_types with protov2 */
+        ucs_assert(!context->config.ext.proto_enable);
+
         mem_types = md_attr->reg_mem_types | md_attr->alloc_mem_types;
         if ((md_index != UCP_NULL_RESOURCE) && !(mem_types & UCS_BIT(mem_type))) {
             continue;

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -463,10 +463,10 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
             if (md_attr->flags & UCT_MD_FLAG_NEED_MEMH) {
                 /* Memory domain must support registration on the relevant
                  * memory type */
-                if (!(md_attr->flags & UCT_MD_FLAG_REG) ||
-                    !(md_attr->reg_mem_types &
-                      UCS_BIT(select_param->mem_type))) {
-                    ucs_trace("%s: no reg of mem type %s", lane_desc,
+                if (!(context->reg_md_map[select_param->mem_type] &
+                      UCS_BIT(md_index))) {
+                    ucs_trace("%s: md %s cannot register %s memory", lane_desc,
+                              context->tl_mds[md_index].rsc.md_name,
                               ucs_memory_type_names[select_param->mem_type]);
                     continue;
                 }
@@ -552,9 +552,8 @@ ucp_proto_common_reg_md_map(const ucp_proto_common_init_params_t *params,
         /* Register if the memory domain support registration for the relevant
            memory type, and needs a local memory handle for zero-copy
            communication */
-        if (ucs_test_all_flags(md_attr->flags,
-                               UCT_MD_FLAG_NEED_MEMH | UCT_MD_FLAG_REG) &&
-            (md_attr->reg_mem_types & UCS_BIT(select_param->mem_type))) {
+        if ((md_attr->flags & UCT_MD_FLAG_NEED_MEMH) &&
+            (context->reg_md_map[select_param->mem_type] & UCS_BIT(md_index))) {
             reg_md_map |= UCS_BIT(md_index);
         }
     }

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -21,8 +21,7 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
                                ucp_sys_dev_map_t *sys_dev_map,
                                ucs_sys_dev_distance_t *sys_distance)
 {
-    ucp_worker_h worker                      = params->super.super.worker;
-    ucp_context_h context                    = worker->context;
+    ucp_context_h context                    = params->super.super.worker->context;
     const ucp_ep_config_key_t *ep_config_key = params->super.super.ep_config_key;
     ucp_rsc_index_t mem_sys_dev, ep_sys_dev;
     const uct_iface_attr_t *iface_attr;
@@ -65,7 +64,7 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
          * registering the memory type
          */
         if (!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) ||
-            !(md_attr->reg_mem_types & UCS_BIT(params->mem_info.type))) {
+            !(context->reg_md_map[params->mem_info.type] & UCS_BIT(md_index))) {
             continue;
         }
 


### PR DESCRIPTION
## Why
Support dmabuf in UCP by querying dmabuf fd and providing it to memory registration function