### PR TITLE
UCP/PROTO: fix valgrind issues

### DIFF
--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -219,7 +219,8 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_atomic_op_nbx,
                 ep, &ucp_rkey_config(ep->worker, rkey)->proto_select,
                 rkey->cfg_index, req, op_id, buffer, 1, param->datatype,
                 op_size, param, 0, 0);
-        if (ucs_likely(req->flags & UCP_REQUEST_FLAG_PROTO_AMO_PACKED)) {
+        if (UCS_PTR_IS_PTR(status_p) &&
+            ucs_likely(req->flags & UCP_REQUEST_FLAG_PROTO_AMO_PACKED)) {
 #if ENABLE_ASSERT
             req->send.state.dt_iter.type.contig.buffer = NULL;
 #endif


### PR DESCRIPTION
## What
fix access to freed request

## Why ?
```
[ RUN      ] shm_ib/test_ucp_atomic32.post/4 <shm,ib,cuda_copy,rocm_copy/device/proto>
==31280== Invalid read of size 4
==31280==    at 0x58C73C8: ucs_mpool_put_inline (mpool.inl:82)
==31280==    by 0x58C73C8: ucp_request_put (ucp_request.inl:219)
==31280==    by 0x58C73C8: ucp_proto_request_send_op (proto_common.inl:261)
==31280==    by 0x58C73C8: ucp_atomic_op_nbx_inner (amo_send.c:218)
==31280==    by 0x58C73C8: ucp_atomic_op_nbx (amo_send.c:159)
==31280==    by 0x866C1C: test_ucp_atomic<unsigned int>::do_atomic(ucp_atomic_op_t, unsigned long, void*, ucp_rkey*, void*, ucp_request_param_t&) (test_ucp_atomic.cc:202)
==31280==    by 0x866E03: test_ucp_atomic<unsigned int>::post(unsigned long, void*, ucp_mem*, void*, ucp_rkey*, void*) (test_ucp_atomic.cc:63)
==31280==    by 0x87AC94: test_ucp_memheap::test_xfer(void (test_ucp_memheap::*)(unsigned long, void*, ucp_mem*, void*, ucp_rkey*, void*), unsigned long, unsigned int, unsigned long, ucs_memory_type, ucs_memory_type, unsigned int, bool, bool, void*) (test_ucp_memheap.cc:86)
==31280==    by 0x863E59: test_ucp_atomic<unsigned int>::test_all_opcodes(void (test_ucp_memheap::*)(unsigned long, void*, ucp_mem*, void*, ucp_rkey*, void*), unsigned int, unsigned long, int, ucs_memory_type, ucs_memory_type) (test_ucp_atomic.cc:264)
==31280==    by 0x864053: test_ucp_atomic<unsigned int>::test_mem_types(void (test_ucp_memheap::*)(unsigned long, void*, ucp_mem*, void*, ucp_rkey*, void*), unsigned int, unsigned long, int) (test_ucp_atomic.cc:242)
==31280==    by 0x85EF1F: test (test_ucp_atomic.cc:149)

```
and more in https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/52278/logs/629