### PR TITLE
UCT/DC: Fix HWTM initialization without MPXRQ

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -473,6 +473,7 @@ static ucs_status_t uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface,
     struct ibv_tmh tmh;
     int mtu;
     int tm_params;
+    unsigned md_mp_support_flags;
 #endif
     ucs_status_t status;
 
@@ -534,10 +535,18 @@ static ucs_status_t uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface,
         return UCS_OK;
     }
 
+    if (init_attr->qp_type == UCT_IB_QPT_DCI) {
+        md_mp_support_flags = UCT_IB_MLX5_MD_FLAG_DEVX_DC_SRQ |
+                              UCT_IB_MLX5_MD_FLAG_DEVX_DCI    |
+                              UCT_IB_MLX5_MD_FLAG_DEVX_DCT;
+    } else {
+        md_mp_support_flags = UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ |
+                              UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP;
+    }
+
     /* Multi-Packet XRQ initialization */
-    if (!ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_MP_RQ       |
-                                       UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ |
-                                       UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP)) {
+    if (!ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_MP_RQ |
+                            md_mp_support_flags)) {
         goto out_mp_disabled;
     }
 


### PR DESCRIPTION
## What
Fix initialization of DC iface with HWTM but without MPXRQ  

## Why ?
To avoid errors, like
```
rc_mlx5_common.c:863  Assertion `iface->tm.mp.num_strides == 1' failed
==== backtrace (tid:   5649) ====
 0 0x000000000005f382 uct_rc_mlx5_init_rx_tm()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/ib/rc/accel/rc_mlx5_common.c:863
 1 0x000000000008083d uct_dc_mlx5_init_rx()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/ib/dc/dc_mlx5.c:665
 2 0x0000000000036d81 uct_rc_iface_t_init()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/ib/rc/base/rc_iface.c:701
 3 0x0000000000055865 uct_rc_mlx5_iface_common_t_init()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/ib/rc/accel/rc_mlx5_iface.c:783
 4 0x000000000008a996 uct_dc_mlx5_iface_t_init()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/ib/dc/dc_mlx5.c:1402
 5 0x000000000008a996 uct_dc_mlx5_iface_t_new()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/ib/dc/dc_mlx5.c:1536
 6 0x0000000000013aab uct_iface_open()  /labhome/mikhailb/wgit/ucx-tmp/src/uct/base/uct_md.c:284

```