### PR TITLE
MD/MLX5: fixed crash on flush remote cleanup

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1252,6 +1252,11 @@ static void uct_ib_mlx5_devx_cleanup_flush_mr(uct_ib_mlx5_md_t *md)
 {
     ucs_status_t status;
 
+    if (!(md->flags & UCT_IB_MLX5_MD_FLAG_KSM) ||
+        !uct_ib_md_is_flush_rkey_valid(md->super.flush_rkey)) {
+        return;
+    }
+
     uct_ib_mlx5_devx_obj_destroy(md->flush_dvmr, "flush_dvmr");
 
     status = uct_ib_dereg_mr(md->flush_mr);


### PR DESCRIPTION
- fixed crash on configuration where MLX5 MD with KSM is not initialized
