### PR TITLE
TEST/COMPAT: Set UCX_IB_ROCE_LOCAL_SUBNET=y to fix connectivity

### DIFF
--- a/buildlib/pr/distro.yml
+++ b/buildlib/pr/distro.yml
@@ -157,8 +157,9 @@ jobs:
           ldd $(System.DefaultWorkingDirectory)/ucx_bin_$(Build.BuildId)/install/examples/hworld
 
           cmd_prefix="stdbuf -e0 -o0 timeout -s 9 120s"
-          export UCX_LOG_LEVEL=info  # print version and used transports
-          export UCX_TLS=^sm         # shared memory is not backward compatible
+          export UCX_LOG_LEVEL=info         # print version and used transports
+          export UCX_TLS=^sm                # shared memory is not backward compatible
+          export UCX_IB_ROCE_LOCAL_SUBNET=y # connect reachable devices
 
           env LD_LIBRARY_PATH=$UCX_PR_LIB_PATH \
             ${cmd_prefix} \


### PR DESCRIPTION
## Why
Fix [test failures](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=52689&view=logs&j=bbc87450-d2e1-51f2-95ed-08aac0f92777&t=d334a637-21ef-514c-a2c1-f970364dfd02) on swx-rain machines after merging https://github.com/openucx/ucx/pull/8527