### PR TITLE
TEST/CONFIG: Fixes #8593

### DIFF
--- a/config/m4/mpi.m4
+++ b/config/m4/mpi.m4
@@ -26,6 +26,8 @@ AS_IF([test "x$with_mpi" = xyes],
         [
         AC_ARG_VAR(MPICC,[MPI C compiler command])
         AC_PATH_PROGS(MPICC,mpicc mpiicc,"",$mpi_path)
+        AC_ARG_VAR(SHMEMCC,[SHMEM C compiler command])
+        AC_PATH_PROGS(SHMEMCC,shmemcc,"",$mpi_path)
         AC_ARG_VAR(MPIRUN,[MPI launch command])
         AC_PATH_PROGS(MPIRUN,mpirun mpiexec aprun orterun,"",$mpi_path)
         AS_IF([test -z "$MPIRUN"],
@@ -38,4 +40,5 @@ AS_IF([test -n "$MPICC"],
       [mpi_enable=disabled])
 AM_CONDITIONAL([HAVE_MPI],    [test -n "$MPIRUN"])
 AM_CONDITIONAL([HAVE_MPICC],  [test -n "$MPICC"])
+AM_CONDITIONAL([HAVE_SHMEMCC],[test -n "$SHMEMCC"])
 AM_CONDITIONAL([HAVE_MPIRUN], [test -n "$MPIRUN"])

--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_MPI], [false])
      AM_CONDITIONAL([HAVE_MPIRUN], [false])
      AM_CONDITIONAL([HAVE_MPICC], [false])
+     AM_CONDITIONAL([HAVE_SHMEMCC], [false])
      AM_CONDITIONAL([HAVE_PROFILING], [false])
      AM_CONDITIONAL([HAVE_UCM_PTMALLOC286], [false])
      AM_CONDITIONAL([HAVE_JAVA], [false])

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -8,29 +8,39 @@
 CC = $(MPICC)
 LD = $(MPICC)
 
-if HAVE_MPICC
 
 # Test application for memory hooks when running with MPI
 # (some MPIs have hooks of their own and we make sure ours still work)
-noinst_PROGRAMS       = test_memhooks shmem_pingpong
+noinst_PROGRAMS       =
+
+if HAVE_MPICC
+noinst_PROGRAMS      += test_memhooks
+endif
+
+if HAVE_SHMEMCC
+noinst_PROGRAMS      += shmem_pingpong
+endif
+
 AM_CPPFLAGS           = \
     $(BASE_CPPFLAGS) \
     -DUCM_LIB_DIR="$(abs_top_builddir)/src/ucm/.libs" \
     -DTEST_LIB_DIR="$(abs_builddir)/.libs"
 AM_CFLAGS             = $(BASE_CFLAGS)
+
+if HAVE_MPICC
 test_memhooks_SOURCES = test_memhooks.c
 test_memhooks_LDFLAGS = -ldl
-
 
 # A library we use for testing that memory hooks work in libraries loaded
 # after the hooks were installed
 noinst_LTLIBRARIES = libtest_memhooks.la
 libtest_memhooks_la_SOURCES = test_memhooks_lib.c
 libtest_memhooks_la_LDFLAGS = -rpath /nowhere  # Force shared library
+endif
 
 
+if HAVE_SHMEMCC
 # SHMEM ping-pong test
 shmem_pingpong_LDFLAGS = -loshmem
 shmem_pingpong_SOURCES = shmem_pingpong.c
-
 endif


### PR DESCRIPTION
Test that shmemcc is present as the part of MPI install.

## What
Fixing #8593 

## Why ?
The makefile should not assume that every MPI install comes with SHMEM.

## How ?
Check that shmemcc is part of MPI install, if not disable the build.