### PR TITLE
BUILD/DEBIAN: Use dep libnvidia-ml1 for ucx-cuda

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -29,5 +29,9 @@ override_dh_auto_install:
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+	if [ -e debian/ucx-cuda.substvars ]; then \
+	  sed -i -e 's/libnvidia-compute-\([0-9]\+\)/& | libnvidia-ml1/' \
+	    debian/ucx-cuda.substvars \
+	; fi
 
 override_dh_auto_clean:


### PR DESCRIPTION
The names of packages provided by NVidia in CUDA don't seem to follow the standard required by Debian (package per library), and therefore shlibdep creates dependencies that are too strict: on libnvidia-compute-515 instead of the actual name of the library.

So this commit fixes the generated dependency.

It seems that the name of the library, provided by all relevant packages, is "libnvidia-ml1". Use the standard dependency name of <specific> | <provides>.