### PR TITLE
BUILD/FLAGS: Turn 'unsupported option' ICC command line warning to error

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -282,11 +282,9 @@ AC_DEFUN([CHECK_DEPRECATED_DECL_FLAG],
 # Force ICC treat command line warnings as errors.
 # This evaluation should be called prior to all other compiler flags evals
 #
-CHECK_COMPILER_FLAG([-diag-error 10006], [-diag-error 10006],
-                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
-                    [BASE_CFLAGS="$BASE_CFLAGS -diag-error 10006"
-                     BASE_CXXFLAGS="$BASE_CXXFLAGS -diag-error 10006"],
-                    [])
+ADD_COMPILER_FLAGS_IF_SUPPORTED([[-diag-error 10006],
+                                 [-diag-error 10148]],
+                                [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 
 
 CHECK_DEPRECATED_DECL_FLAG([-diag-disable 1478], CFLAGS_NO_DEPRECATED) # icc


### PR DESCRIPTION
## What
Extend the warnings that will be shown as errors during compilation using icc.

## Why ?
Intel compiler reports unknown/unsupported compilation flags as warnings and therefore compilation still ends successfully. This logic prevents autoconf `AC_LINK_IFELSE` function from detection such compilation flags. The warning №10006 is already turned to workaround this issue. But there are different compiler options related warnings that can be reported by ICC and absence of support such options still cannot be detected by autoconf.

For example:
```
icc: command line warning #10148: option '-Wno-unused-label' not supported
```

## How ?
Turn all warnings to errors.
