### PR TITLE
TEST/UCP: Temporary disable select_transport_rma_bw test

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1333,6 +1333,9 @@ public:
 
 UCS_TEST_P(select_transport_rma_bw, select_rc, "NUM_EPS=56", "NUM_PPN=28")
 {
+    UCS_TEST_SKIP_R("FIXME: Disabled due to unresolved failure");
+
+    /* coverity[unreachable] */
     if (!has_resource(&sender(), "rc_mlx5")) {
         UCS_TEST_SKIP_R("no rc resources");
     }


### PR DESCRIPTION
## What
Temporary disable select_transport_rma_bw test.

## Why ?
Prevent occasional failure on CI.
