### PR TITLE
UCP/EP/WIREUP: Replay pending requests of wireup EP CM during connection establishment

### DIFF
--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -620,6 +620,35 @@ unsigned ucp_wireup_ep_pending_extract(ucp_wireup_ep_t *wireup_ep,
     return count;
 }
 
+void ucp_wireup_eps_pending_extract(ucp_ep_t *ucp_ep, ucs_queue_head_t *queue)
+{
+    int pending_count = 0;
+    ucp_lane_index_t lane_idx;
+    ucp_wireup_ep_t *wireup_ep;
+    uct_ep_h uct_ep;
+
+    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(ucp_ep->worker);
+    ucs_queue_head_init(queue);
+
+    if (ucp_ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
+        return;
+    }
+
+    for (lane_idx = 0; lane_idx < ucp_ep_num_lanes(ucp_ep); ++lane_idx) {
+        uct_ep = ucp_ep_get_lane(ucp_ep, lane_idx);
+        /* When creating EP with remote worker address
+         * EP is using transport lanes only, with no CM lane. */
+        if ((uct_ep == NULL) || (ucp_wireup_ep(uct_ep) == NULL)) {
+            continue;
+        }
+
+        wireup_ep      = ucp_wireup_ep(uct_ep);
+        pending_count += ucp_wireup_ep_pending_extract(wireup_ep, queue);
+    }
+
+    ucp_worker_flush_ops_count_add(ucp_ep->worker, -pending_count);
+}
+
 ucs_status_t
 ucp_wireup_ep_connect_to_ep_v2(uct_ep_h tl_ep,
                                const ucp_address_entry_t *address_entry,

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -134,6 +134,8 @@ ucp_wireup_ep_t *ucp_wireup_ep(uct_ep_h uct_ep);
 unsigned ucp_wireup_ep_pending_extract(ucp_wireup_ep_t *wireup_ep,
                                        ucs_queue_head_t *queue);
 
+void ucp_wireup_eps_pending_extract(ucp_ep_t *ucp_ep, ucs_queue_head_t *queue);
+
 ucs_status_t
 ucp_wireup_ep_connect_to_ep_v2(uct_ep_h tl_ep,
                                const ucp_address_entry_t *address_entry,


### PR DESCRIPTION
## What
Replay pending requests of wireup EP CM during connection establishment.

## Why ?
To prevent potential ordering issues and wrong configuration.

## How ?
During connection establishment phases replay all pending requests including Wireup EP CM.
