### PR TITLE
UCP/EP/PROTO: Print endpoint locality with protov2 select info

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -169,6 +169,15 @@ enum {
 };
 
 
+/**
+ * Endpoint configuration key flags
+ */
+enum {
+    UCP_EP_CONFIG_KEY_FLAG_SELF       = UCS_BIT(0), /** Endpoint is connected to own worker */
+    UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE = UCS_BIT(1)  /** Endpoint is within same node */
+};
+
+
 #define UCP_EP_STAT_TAG_OP(_ep, _op) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCP_EP_STAT_TAG_TX_##_op, 1);
 
@@ -236,6 +245,9 @@ struct ucp_ep_config_key {
 
     /* Error handling mode */
     ucp_err_handling_mode_t  err_mode;
+
+    /* Additional flags */
+    unsigned                 flags;
 };
 
 
@@ -707,6 +719,9 @@ void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *key1,
 
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2);
+
+void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
+                        ucs_string_buffer_t *strb);
 
 int ucp_ep_config_get_multi_lane_prio(const ucp_lane_index_t *lanes,
                                       ucp_lane_index_t lane);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1690,10 +1690,11 @@ static void ucp_worker_add_feature_rsc(ucp_context_h context,
     ucs_string_buffer_appendf(strb, ") ");
 }
 
-static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
-                                      ucp_context_h context,
-                                      ucp_worker_cfg_index_t config_idx)
+static void
+ucp_worker_print_used_tls(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index)
 {
+    const ucp_ep_config_key_t *key = &worker->ep_config[cfg_index].key;
+    ucp_context_h context          = worker->context;
     UCS_STRING_BUFFER_ONSTACK(strb, 256);
     ucp_lane_map_t tag_lanes_map    = 0;
     ucp_lane_map_t rma_lanes_map    = 0;
@@ -1706,7 +1707,7 @@ static void ucp_worker_print_used_tls(const ucp_ep_config_key_t *key,
     int num_valid_lanes             = 0;
     ucp_lane_index_t lane;
 
-    ucs_string_buffer_appendf(&strb, "ep_cfg[%d]: ", config_idx);
+    ucp_ep_config_name(worker, cfg_index, &strb);
 
     for (lane = 0; lane < key->num_lanes; ++lane) {
         if (key->lanes[lane].rsc_index == UCP_NULL_RESOURCE) {
@@ -2026,7 +2027,7 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
                                         UCP_PROTO_FLAG_AM_SHORT, key->am_lane,
                                         &ep_config->am_u.max_eager_short);
     } else {
-        ucp_worker_print_used_tls(key, context, ep_cfg_index);
+        ucp_worker_print_used_tls(worker, ep_cfg_index);
     }
 
 out:

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -147,10 +147,7 @@ ucp_proto_select_param_dump(ucp_worker_h worker,
                             ucs_string_buffer_t *ep_cfg_strb,
                             ucs_string_buffer_t *select_param_strb)
 {
-    if (!ucs_string_is_empty(worker->context->name)) {
-        ucs_string_buffer_appendf(ep_cfg_strb, "%s ", worker->context->name);
-    }
-    ucs_string_buffer_appendf(ep_cfg_strb, "ep_cfg[%d]", ep_cfg_index);
+    ucp_ep_config_name(worker, ep_cfg_index, ep_cfg_strb);
 
     /* Operation name and attributes */
     ucp_proto_select_info_str(worker, rkey_cfg_index, select_param,

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -553,14 +553,16 @@ ucp_proto_select_elem_init(ucp_worker_h worker,
                            ucp_proto_select_elem_t *select_elem)
 {
     UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
+    UCS_STRING_BUFFER_ONSTACK(config_name_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
     ucp_proto_select_init_protocols_t *proto_init;
     ucs_status_t status;
 
     ucp_proto_select_info_str(worker, rkey_cfg_index, select_param,
                               ucp_operation_names, &sel_param_strb);
+    ucp_ep_config_name(worker, ep_cfg_index, &config_name_strb);
 
-    ucs_trace("worker %p: select protocols for ep_cfg[%d] rkey[%d] for %s",
-              worker, ep_cfg_index, rkey_cfg_index,
+    ucs_trace("worker %p: select protocols %s rkey[%d] for %s", worker,
+              ucs_string_buffer_cstr(&config_name_strb), rkey_cfg_index,
               ucs_string_buffer_cstr(&sel_param_strb));
 
     ucs_log_indent(1);

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -851,7 +851,9 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
     addr_ns->super.id = ucs_get_system_id() &
                         ~UCT_IFACE_LOCAL_ADDR_FLAG_NS;
 
-    if (!ucs_sys_ns_is_default(sys_ns_type)) {
+    if (ucs_sys_ns_is_default(sys_ns_type)) {
+        addr_ns->sys_ns = 0;
+    } else {
         addr_ns->super.id |= UCT_IFACE_LOCAL_ADDR_FLAG_NS;
         addr_ns->sys_ns    = ucs_sys_get_ns(sys_ns_type);
     }

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -851,9 +851,7 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
     addr_ns->super.id = ucs_get_system_id() &
                         ~UCT_IFACE_LOCAL_ADDR_FLAG_NS;
 
-    if (ucs_sys_ns_is_default(sys_ns_type)) {
-        addr_ns->sys_ns = 0;
-    } else {
+    if (!ucs_sys_ns_is_default(sys_ns_type)) {
         addr_ns->super.id |= UCT_IFACE_LOCAL_ADDR_FLAG_NS;
         addr_ns->sys_ns    = ucs_sys_get_ns(sys_ns_type);
     }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -128,6 +128,7 @@ static ucs_status_t uct_tcp_iface_get_device_address(uct_iface_h tl_iface,
 
     if (ucs_sockaddr_is_inaddr_loopback(saddr)) {
         dev_addr->flags |= UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK;
+        memset(pack_ptr, 0, sizeof(uct_iface_local_addr_ns_t));
         uct_iface_get_local_address(pack_ptr, UCS_SYS_NS_TYPE_NET);
     } else {
         in_addr = ucs_sockaddr_get_inet_addr(saddr);


### PR DESCRIPTION
## Why
Improve protocol information output by printing endpoint locality information

Replaces #7902 

Example output:
```
+----------------+--------------------------------------------------------------------------------------------+
| mpi self cfg#0 | tagged message by ucp_tag_send*() from host memory                                         |
+----------------+-------------------------------------------+------------------------------------------------+
|        0..8184 | eager short                               | self/memory                                    |
|    8185..37142 | eager copy-in copy-out                    | self/memory                                    |
|     37143..inf | (?) rendezvous zero-copy read from remote | 68% on knem/memory and 32% on rc_mlx5/mlx5_0:1 |
+----------------+-------------------------------------------+------------------------------------------------+
+----------------------+--------------------------------------------------------------------------------------------+
| mpi intra-node cfg#1 | tagged message by ucp_tag_send*() from host memory                                         |
+----------------------+-------------------------------------------+------------------------------------------------+
|                0..92 | eager short                               | sysv/memory                                    |
|             93..8248 | eager copy-in copy-out                    | sysv/memory                                    |
|         8249..171045 | eager copy-in copy-out                    | sysv/memory                                    |
|          171046..inf | (?) rendezvous zero-copy read from remote | 68% on knem/memory and 32% on rc_mlx5/mlx5_0:1 |
+----------------------+-------------------------------------------+------------------------------------------------+
```