### PR TITLE
UCT/IB: reduce preprocess time without reading included files

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -9,8 +9,6 @@
 #endif
 
 #include "dc_mlx5.inl"
-#include "dc_mlx5.h"
-#include "dc_mlx5_ep.h"
 
 #include <uct/api/uct.h>
 #include <uct/ib/base/ib_device.h>

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -9,8 +9,6 @@
 #endif
 
 #include "dc_mlx5.inl"
-#include "dc_mlx5_ep.h"
-#include "dc_mlx5.h"
 
 #include <uct/ib/mlx5/ib_mlx5_log.h>
 #include <ucs/time/time.h>


### PR DESCRIPTION
Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>

## What
remove already included files to reduce preprocess time.