### PR TITLE
AZP: fixed env module issue (W/A for unstable rdmz network/autofs)

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -98,6 +98,8 @@ function add_timestamp() {
 function az_init_modules() {
     . /etc/profile.d/modules.sh
     export MODULEPATH="/hpc/local/etc/modulefiles:$MODULEPATH"
+    # Read module files (W/A if there're some network instabilities lead to autofs issues)
+    find /hpc/local/etc/modulefiles >/dev/null 2>&1
 }
 
 #

--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -34,6 +34,7 @@ jobs:
     - bash: |
         set -xeE
         source buildlib/az-helpers.sh
+        az_init_modules
         az_module_load dev/go-latest
         try_load_cuda_env
         ./autogen.sh


### PR DESCRIPTION
Signed-off-by: artemry-nv <artemry@nvidia.com>

## What
Fix for instabilities in env module loading (more likely caused by unstable autofs).

## Why ?
Regular UCX CI failures.

## How ?
Added missing env module init step. Added redundant env module files reading just to force autofs update corresponding file structures. 
