### PR TITLE
UCP: Add skip_md_map to UCP rkey_unpack

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -392,8 +392,11 @@ struct ucp_ep_config {
         ucp_rndv_thresh_t          am_thresh;
         /* Total size of packed rkey, according to high-bw md_map */
         size_t                     rkey_size;
-        /* Remote memory domains which support rkey_ptr */
-        ucp_md_map_t               rkey_ptr_dst_mds;
+        /* Remote memory domains which support rkey_ptr, excluding
+         * rkey_ptr_lane. Used by 2-stage pipeline rendezvous protocol. */
+        ucp_md_map_t               proto_rndv_rkey_skip_mds;
+        /* Remote memory domain corresponding to rkey_ptr_lane */
+        ucp_md_map_t               rkey_ptr_lane_dst_mds;
     } rndv;
 
     struct {

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -380,8 +380,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rkey_proto_resolve,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
-                 (ep, buffer, length, unpack_md_map, rkey_p), ucp_ep_h ep,
-                 const void *buffer, size_t length, ucp_md_map_t unpack_md_map,
+                 (ep, buffer, length, unpack_md_map, skip_md_map, rkey_p),
+                 ucp_ep_h ep, const void *buffer, size_t length,
+                 ucp_md_map_t unpack_md_map, ucp_md_map_t skip_md_map,
                  ucp_rkey_h *rkey_p)
 {
     ucp_worker_h worker              = ep->worker;
@@ -457,7 +458,18 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
         }
 
         ucs_assert(rkey_index < md_count);
-        tl_rkey       = &rkey->tl_rkey[rkey_index];
+        tl_rkey = &rkey->tl_rkey[rkey_index];
+
+        if (UCS_BIT(remote_md_index) & skip_md_map) {
+            tl_rkey->rkey.rkey   = UCT_INVALID_RKEY;
+            tl_rkey->rkey.handle = NULL;
+            tl_rkey->cmpt        = NULL;
+            ucs_trace("rkey[%d] for remote md %d is not unpacked",
+                      rkey_index, remote_md_index);
+            ++rkey_index;
+            continue;
+        }
+
         cmpt_index    = ucp_ep_config_get_dst_md_cmpt(&ep_config->key,
                                                       remote_md_index);
         tl_rkey->cmpt = worker->context->tl_cmpts[cmpt_index].cmpt;
@@ -583,8 +595,10 @@ void ucp_rkey_destroy(ucp_rkey_h rkey)
 
     rkey_index = 0;
     ucs_for_each_bit(remote_md_index, rkey->md_map) {
-        uct_rkey_release(rkey->tl_rkey[rkey_index].cmpt,
-                         &rkey->tl_rkey[rkey_index].rkey);
+        if (rkey->tl_rkey[rkey_index].rkey.rkey != UCT_INVALID_RKEY) {
+            uct_rkey_release(rkey->tl_rkey[rkey_index].cmpt,
+                             &rkey->tl_rkey[rkey_index].rkey);
+        }
         ++rkey_index;
     }
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -194,7 +194,8 @@ ucp_rkey_pack_memh(ucp_context_h context, ucp_md_map_t md_map,
 
 ucs_status_t
 ucp_ep_rkey_unpack_internal(ucp_ep_h ep, const void *buffer, size_t length,
-                            ucp_md_map_t unpack_md_map, ucp_rkey_h *rkey_p);
+                            ucp_md_map_t unpack_md_map,
+                            ucp_md_map_t skip_md_map, ucp_rkey_h *rkey_p);
 
 
 void ucp_rkey_dump_packed(const void *buffer, size_t length,

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -55,7 +55,7 @@ ucp_ep_rkey_unpack_reachable(ucp_ep_h ep, const void *buffer, size_t length,
 {
     ucp_ep_config_t *config = &ep->worker->ep_config[ep->cfg_index];
     return ucp_ep_rkey_unpack_internal(ep, buffer, length,
-                                       config->key.reachable_md_map, rkey_p);
+                                       config->key.reachable_md_map, 0, rkey_p);
 }
 
 #endif

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -627,7 +627,8 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
                           const void *rkey_buffer, size_t rkey_length,
                           uint8_t sg_count)
 {
-    ucp_ep_h ep = req->send.ep;
+    ucp_ep_h ep                = req->send.ep;
+    ucp_ep_config_t *ep_config = ucp_ep_config(ep);
     ucp_worker_cfg_index_t rkey_cfg_index;
     ucp_proto_select_param_t sel_param;
     ucp_proto_select_t *proto_select;
@@ -639,8 +640,14 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
 
     if (rkey_length > 0) {
         ucs_assert(rkey_buffer != NULL);
-        status = ucp_ep_rkey_unpack_reachable(ep, rkey_buffer, rkey_length,
-                                              &rkey);
+        /* Do not unpack rkeys from MDs with rkey_ptr capability, except
+         * rkey_ptr_lane. Examples are: sysv and posix. Such keys, if packed,
+         * are unpacked only once and cached in the peer_mem hash on ep. It is
+         * done by the specific protocols (if selected) which use them.
+         */
+        status = ucp_ep_rkey_unpack_internal(
+                  ep, rkey_buffer, rkey_length, ep_config->key.reachable_md_map,
+                  ep_config->rndv.proto_rndv_rkey_skip_mds, &rkey);
         if (status != UCS_OK) {
             goto err;
         }
@@ -649,7 +656,7 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
         rkey_cfg_index = rkey->cfg_index;
     } else {
         /* No remote key, use endpoint protocols */
-        proto_select   = &ucp_ep_config(ep)->proto_select;
+        proto_select   = &ep_config->proto_select;
         rkey_cfg_index = UCP_WORKER_CFG_INDEX_NULL;
         rkey           = NULL;
     }


### PR DESCRIPTION
## What
Add skip MD map to UCP rkey unpack routine

## Why ?
Preparation for 2-stage pipeline protocol with proto v2. With this protocol RTR packs shm or posix rkey, so that the sender can attach remote fragment memory and copy directly to it. Also this protocol caches unpacked key to avoid expensive memory attach for every operation. Thus, we do not need to unpack such keys in the common code rndv code - the corresponding protocol will take care of that.

ref #8668 