### PR TITLE
UCT/MLX5: CQE zipping user control per CQ direction

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -72,7 +72,7 @@ typedef enum uct_ib_mtu {
 typedef enum {
     UCT_IB_DIR_RX,
     UCT_IB_DIR_TX,
-    UCT_IB_DIR_NUM
+    UCT_IB_DIR_LAST
 } uct_ib_dir_t;
 
 enum {
@@ -149,7 +149,7 @@ struct uct_ib_iface_config {
     } rx;
 
     /* Inline space to reserve in CQ */
-    size_t                  inl[UCT_IB_DIR_NUM];
+    size_t                  inl[UCT_IB_DIR_LAST];
 
     /* Change the address type */
     int                     addr_type;
@@ -204,16 +204,16 @@ enum {
 
 
 typedef struct uct_ib_iface_init_attr {
-    unsigned    rx_priv_len;            /* Length of transport private data to reserve */
-    unsigned    rx_hdr_len;             /* Length of transport network header */
-    unsigned    cq_len[UCT_IB_DIR_NUM]; /* CQ length */
-    size_t      seg_size;               /* Transport segment size */
-    unsigned    fc_req_size;            /* Flow control request size */
-    int         qp_type;                /* IB QP type */
-    int         flags;                  /* Various flags (see enum) */
+    unsigned    rx_priv_len;             /* Length of transport private data to reserve */
+    unsigned    rx_hdr_len;              /* Length of transport network header */
+    unsigned    cq_len[UCT_IB_DIR_LAST]; /* CQ length */
+    size_t      seg_size;                /* Transport segment size */
+    unsigned    fc_req_size;             /* Flow control request size */
+    int         qp_type;                 /* IB QP type */
+    int         flags;                   /* Various flags (see enum) */
     /* The maximum number of outstanding RDMA Read/Atomic operations per QP */
     unsigned    max_rd_atomic;
-    uint8_t     cqe_zip_sizes;
+    uint8_t     cqe_zip_sizes[UCT_IB_DIR_LAST];
 } uct_ib_iface_init_attr_t;
 
 
@@ -231,7 +231,7 @@ typedef struct uct_ib_qp_attr {
     struct ibv_srq              *srq;
     uint32_t                    srq_num;
     unsigned                    sq_sig_all;
-    unsigned                    max_inl_cqe[UCT_IB_DIR_NUM];
+    unsigned                    max_inl_cqe[UCT_IB_DIR_LAST];
     uct_ib_qp_init_attr_t       ibv;
 } uct_ib_qp_attr_t;
 
@@ -273,7 +273,7 @@ struct uct_ib_iface_ops {
 struct uct_ib_iface {
     uct_base_iface_t          super;
 
-    struct ibv_cq             *cq[UCT_IB_DIR_NUM];
+    struct ibv_cq             *cq[UCT_IB_DIR_LAST];
     struct ibv_comp_channel   *comp_channel;
     uct_recv_desc_t           release_desc;
 
@@ -295,7 +295,7 @@ struct uct_ib_iface {
         unsigned              tx_max_poll;
         unsigned              seg_size;
         unsigned              roce_path_factor;
-        uint8_t               max_inl_cqe[UCT_IB_DIR_NUM];
+        uint8_t               max_inl_cqe[UCT_IB_DIR_LAST];
         uint8_t               port_num;
         uint8_t               sl;
         uint8_t               traffic_class;

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -630,7 +630,7 @@ uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     UCT_IB_MLX5DV_SET(cqc, cqctx, log_cq_size, log_cq_size);
     UCT_IB_MLX5DV_SET(cqc, cqctx, cqe_sz, (cqe_size == 128) ? 1 : 0);
 
-    if (init_attr->cqe_zip_sizes & cqe_size) {
+    if (init_attr->cqe_zip_sizes[dir] & cqe_size) {
         UCT_IB_MLX5DV_SET(cqc, cqctx, cqe_comp_en, 1);
         UCT_IB_MLX5DV_SET(cqc, cqctx, cqe_comp_layout, 1);
     }
@@ -651,7 +651,7 @@ uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                UCT_IB_MLX5DV_GET(create_cq_out, out, cqn),
                                cq->devx.cq_buf, cq->devx.uar->uar->base_addr,
                                cq->devx.dbrec->db,
-                               !!(init_attr->cqe_zip_sizes & cqe_size));
+                               !!(init_attr->cqe_zip_sizes[dir] & cqe_size));
 
     iface->config.max_inl_cqe[dir] = uct_ib_mlx5_inl_cqe(inl, cqe_size);
     iface->cq[dir]                 = NULL;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -322,7 +322,7 @@ typedef struct uct_ib_mlx5_iface_config {
 #endif
     uct_ib_mlx5_mmio_mode_t  mmio_mode;
     ucs_ternary_auto_value_t ar_enable;
-    int                      cqe_zipping_enable;
+    int                      cqe_zip_enable[UCT_IB_DIR_LAST];
 } uct_ib_mlx5_iface_config_t;
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -348,7 +348,7 @@ typedef struct uct_rc_mlx5_iface_common {
         uct_ib_mlx5_srq_t              srq;
         void                           *pref_ptr;
     } rx;
-    uct_ib_mlx5_cq_t                   cq[UCT_IB_DIR_NUM];
+    uct_ib_mlx5_cq_t                   cq[UCT_IB_DIR_LAST];
     struct {
         uct_rc_mlx5_cmd_wq_t           cmd_wq;
         uct_rc_mlx5_tag_entry_t        *head;

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -108,7 +108,7 @@ ucs_status_t uct_rc_mlx5_iface_devx_arm(uct_iface_h tl_iface, unsigned events)
         ucs_derived_of(tl_iface, uct_rc_mlx5_iface_common_t);
     uct_ib_mlx5_md_t *md              =
         uct_ib_mlx5_iface_md(&iface->super.super);
-    int solicited[UCT_IB_DIR_NUM], dir;
+    int solicited[UCT_IB_DIR_LAST], dir;
     ucs_status_t status;
     uint64_t dirs;
 
@@ -123,7 +123,7 @@ ucs_status_t uct_rc_mlx5_iface_devx_arm(uct_iface_h tl_iface, unsigned events)
 
     dirs = uct_rc_iface_arm_cq_check(&iface->super, events, solicited);
     ucs_for_each_bit(dir, dirs) {
-        ucs_assert(dir < UCT_IB_DIR_NUM);
+        ucs_assert(dir < UCT_IB_DIR_LAST);
         uct_ib_mlx5dv_arm_cq(&iface->cq[dir], solicited[dir]);
     }
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -966,7 +966,7 @@ uint64_t uct_rc_iface_arm_cq_check(uct_rc_iface_t *iface, unsigned events,
 ucs_status_t uct_rc_iface_event_arm(uct_iface_h tl_iface, unsigned events)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
-    int solicited[UCT_IB_DIR_NUM], dir;
+    int solicited[UCT_IB_DIR_LAST], dir;
     ucs_status_t status;
     uint64_t dirs;
 
@@ -977,7 +977,7 @@ ucs_status_t uct_rc_iface_event_arm(uct_iface_h tl_iface, unsigned events)
 
     dirs = uct_rc_iface_arm_cq_check(iface, events, solicited);
     ucs_for_each_bit(dir, dirs) {
-        ucs_assert(dir < UCT_IB_DIR_NUM);
+        ucs_assert(dir < UCT_IB_DIR_LAST);
         status = uct_ib_iface_arm_cq(&iface->super, dir, solicited[dir]);
         if (status != UCS_OK) {
             return status;

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -734,7 +734,7 @@ ucs_status_t uct_ud_mlx5_iface_event_arm(uct_iface_h tl_iface, unsigned events)
     }
 
     ucs_for_each_bit(dir, dirs) {
-        ucs_assert(dir < UCT_IB_DIR_NUM);
+        ucs_assert(dir < UCT_IB_DIR_LAST);
         uct_ib_mlx5dv_arm_cq(&iface->cq[dir], 0);
     }
 

--- a/src/uct/ib/ud/accel/ud_mlx5.h
+++ b/src/uct/ib/ud/accel/ud_mlx5.h
@@ -41,7 +41,7 @@ typedef struct {
     struct {
         uct_ib_mlx5_rxwq_t              wq;
     } rx;
-    uct_ib_mlx5_cq_t                    cq[UCT_IB_DIR_NUM];
+    uct_ib_mlx5_cq_t                    cq[UCT_IB_DIR_LAST];
     uct_ud_mlx5_iface_common_t          ud_mlx5_common;
 } uct_ud_mlx5_iface_t;
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -484,7 +484,7 @@ uct_ud_verbs_iface_event_arm(uct_iface_h tl_iface, unsigned events)
     }
 
     ucs_for_each_bit(dir, dirs) {
-        ucs_assert(dir < UCT_IB_DIR_NUM);
+        ucs_assert(dir < UCT_IB_DIR_LAST);
         status = uct_ib_iface_arm_cq(&iface->super, dir, 0);
         if (status != UCS_OK) {
             goto out;

--- a/test/gtest/uct/ib/test_cqe_zipping.cc
+++ b/test/gtest/uct/ib/test_cqe_zipping.cc
@@ -68,7 +68,8 @@ public:
     virtual void init()
     {
         stats_activate();
-        modify_config("IB_CQE_ZIPPING_ENABLE", "y");
+        modify_config("IB_TX_CQE_ZIP_ENABLE", "yes");
+        modify_config("IB_RX_CQE_ZIP_ENABLE", "yes");
 
         test_uct_ib_with_specific_port::init();
         test_uct_ib::init();


### PR DESCRIPTION
## What
Allows controlling CQE zipping per CQ RX/TX direction.

## Why ?
This option would help to control the UCX configuration more accurately. 
