### PR TITLE
UCP: Cache alloc md idx on context

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1471,9 +1471,10 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->num_mem_type_detect_mds  = 0;
 
     for (mem_type = 0; mem_type < UCS_MEMORY_TYPE_LAST; ++mem_type) {
-        context->reg_md_map[mem_type]   = 0;
-        context->cache_md_map[mem_type] = 0;
-        context->dmabuf_mds[mem_type]   = UCP_NULL_RESOURCE;
+        context->reg_md_map[mem_type]     = 0;
+        context->cache_md_map[mem_type]   = 0;
+        context->dmabuf_mds[mem_type]     = UCP_NULL_RESOURCE;
+        context->alloc_md_index[mem_type] = UCP_NULL_RESOURCE;
     }
 
     ucs_string_set_init(&avail_tls);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -267,6 +267,10 @@ typedef struct ucp_context {
     ucp_tl_md_t                   *tl_mds;    /* Memory domain resources */
     ucp_md_index_t                num_mds;    /* Number of memory domains */
 
+    /* Index of memory domain that is used to allocate memory of the given type
+     * using ucp_memh_alloc(). */
+    ucp_md_index_t                alloc_md_index[UCS_MEMORY_TYPE_LAST];
+
     /* Map of MDs that provide registration for given memory type,
        ucp_mem_map() will register memory for all those domains. */
     ucp_md_map_t                  reg_md_map[UCS_MEMORY_TYPE_LAST];

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1265,15 +1265,26 @@ void ucp_mem_rcache_cleanup(ucp_context_h context)
 ucs_status_t ucp_mem_reg_md_map_update(ucp_context_h context)
 {
     UCS_STRING_BUFFER_ONSTACK(strb, 256);
-    ucp_mem_dummy_handle_t memh = {
-        .memh.alloc_md_index = UCP_NULL_RESOURCE,
+    ucp_mem_dummy_handle_t reg_memh = {
+        .memh.alloc_md_index = UCP_NULL_RESOURCE
     };
+    ucp_mem_h alloc_memh;
     ucs_memory_type_t mem_type;
     ucp_md_index_t md_index;
     ucs_status_t status;
     uint8_t buff;
 
-    status = ucp_memh_register(context, &memh.memh,
+    status = ucp_memh_alloc(context, NULL, 1, UCS_MEMORY_TYPE_HOST,
+                            UCT_MD_MEM_ACCESS_ALL | UCT_MD_MEM_FLAG_HIDE_ERRORS,
+                            "get_alloc_md_id", &alloc_memh);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    context->alloc_md_index[UCS_MEMORY_TYPE_HOST] = alloc_memh->alloc_md_index;
+    ucp_memh_put(context, alloc_memh);
+
+    status = ucp_memh_register(context, &reg_memh.memh,
                                context->reg_md_map[UCS_MEMORY_TYPE_HOST],
                                &buff, sizeof(buff),
                                UCT_MD_MEM_ACCESS_ALL |
@@ -1282,8 +1293,8 @@ ucs_status_t ucp_mem_reg_md_map_update(ucp_context_h context)
         return status;
     }
 
-    context->reg_md_map[UCS_MEMORY_TYPE_HOST] = memh.memh.md_map;
-    ucp_memh_dereg(context, &memh.memh, memh.memh.md_map);
+    context->reg_md_map[UCS_MEMORY_TYPE_HOST] = reg_memh.memh.md_map;
+    ucp_memh_dereg(context, &reg_memh.memh, reg_memh.memh.md_map);
 
     /* If we have a dmabuf provider for a memory type, it means we can register
      * memory of this type with any md that supports dmabuf registration. */


### PR DESCRIPTION
## What
Cache host memory alloc md index during context creation

## Why ?
will be checked by 2-stage pipeline protocol to decide what MD keys need to be packed to RTR rkey

ref #8668 