### PR TITLE
UCP: Fix rcache dump function

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1219,13 +1219,21 @@ static void ucp_mem_rcache_dump_region_cb(void *rcontext, ucs_rcache_t *rcache,
     ucp_context_h context = rcontext;
     unsigned md_index;
 
+    if (memh->md_map == 0) {
+        ucs_string_buffer_appendf(&strb, "no mds");
+        return;
+    }
+
     ucs_for_each_bit(md_index, memh->md_map) {
-        ucs_string_buffer_appendf(&strb, " md[%d]=%s", md_index,
+        ucs_string_buffer_appendf(&strb, "md[%d]=%s", md_index,
                                   context->tl_mds[md_index].rsc.md_name);
         if (memh->alloc_md_index == md_index) {
             ucs_string_buffer_appendf(&strb, "(alloc)");
         }
+        ucs_string_buffer_appendf(&strb, " ");
     }
+
+    ucs_string_buffer_rtrim(&strb, NULL);
 }
 
 static ucs_rcache_ops_t ucp_mem_rcache_ops = {


### PR DESCRIPTION
## What
Fix dump function of UCP rcache to have correct traces

## Why ?
before (note 2 white spaces before the first md)
```
rcache.c:954  UCX  TRACE ucp_rcache: created region 0x48bb330 [0x5026390..0x5026410] gt rw ref 2 0��
rcache.c:954  UCX  TRACE ucp_rcache: created region 0x3fcb020 [0x3fcc550..0x3fcc5d0] gt rw ref 2  ��
rcache.inl:28   UCX  TRACE ucp_rcache: lru add region 0x48bb330 [0x5026390..0x5026410] gt rw ref 3  md[0]=mlx5_0 md[1]=mlx5_2 md[2]=mlx5_3 md[3]=mlx5_4
```

after
```
rcache.c:954  UCX  TRACE ucp_rcache: created region 0x51217a0 [0x5f296d0..0x5f29750] gt rw ref 2 no mds
rcache.c:954  UCX  TRACE ucp_rcache: created region 0x4948550 [0x4948420..0x49484a0] gt rw ref 2 no mds
rcache.inl:28   UCX  TRACE ucp_rcache: lru add region 0x51217a0 [0x5f296d0..0x5f29750] gt rw ref 3 md[0]=mlx5_0 md[1]=mlx5_2 md[2]=mlx5_3 md[3]=mlx5_4
[
```