### PR TITLE
UCP/RKEY: Avoid TLS log indent access in release mode

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -138,7 +138,7 @@ ucp_rkey_pack_common(ucp_context_h context, ucp_md_map_t md_map,
 
     ucs_trace("packing rkey type %s md_map 0x%" PRIx64 "dev_map 0x%" PRIx64,
               ucs_memory_type_names[mem_info->type], md_map, sys_dev_map);
-    ucs_log_indent(1);
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE, 1);
 
     UCS_STATIC_ASSERT(UCS_MEMORY_TYPE_LAST <= 255);
     *ucs_serialize_next(&p, ucp_md_map_t) = md_map;
@@ -185,7 +185,7 @@ ucp_rkey_pack_common(ucp_context_h context, ucp_md_map_t md_map,
 out_packed_size:
     result = UCS_PTR_BYTE_DIFF(buffer, p);
 out:
-    ucs_log_indent(-1);
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE, -1);
     return result;
 }
 

--- a/src/ucs/debug/log_def.h
+++ b/src/ucs/debug/log_def.h
@@ -53,6 +53,14 @@ BEGIN_C_DECLS
 #define ucs_trace_func(_fmt, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _fmt ")", __FUNCTION__, ## __VA_ARGS__)
 #define ucs_trace_poll(_fmt, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_POLL, _fmt, ## __VA_ARGS__)
 
+#define ucs_log_indent_level(_level, _delta) \
+    do { \
+        if (ucs_log_component_is_enabled(_level, \
+                                         &ucs_global_opts.log_component)) { \
+            ucs_log_indent(_delta); \
+        } \
+    } while (0)
+
 
 /**
  * Print a message regardless of current log level. Output can be


### PR DESCRIPTION
## Why
Reduce SW overhead for rkey unpack