### PR TITLE
AZP: updated coverity env module to tools/cov-2021.12

### DIFF
--- a/buildlib/tools/coverity.sh
+++ b/buildlib/tools/coverity.sh
@@ -4,7 +4,7 @@ realdir=$(realpath $(dirname $0))
 source ${realdir}/common.sh
 source ${realdir}/../az-helpers.sh
 
-COV_MODULE="tools/cov-2019.12"
+COV_MODULE="tools/cov-2021.12"
 
 #
 # Run Coverity and report errors

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -624,6 +624,7 @@ static ucs_status_t uct_perf_test_check_capabilities(ucx_perf_params_t *params,
 static ucs_status_t uct_perf_test_setup_endpoints(ucx_perf_context_t *perf)
 {
     const size_t buffer_size = ADDR_BUF_SIZE;
+    void *req                = NULL; /* make coverity happy */
     ucx_perf_ep_info_t info, *remote_info;
     unsigned group_size, i, group_index;
     uct_device_addr_t *dev_addr;
@@ -637,7 +638,6 @@ static ucs_status_t uct_perf_test_setup_endpoints(ucx_perf_context_t *perf)
     ucs_status_t status;
     struct iovec vec[5];
     void *buffer;
-    void *req;
 
     buffer = malloc(buffer_size);
     if (buffer == NULL) {

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -926,6 +926,7 @@ bool UcxConnection::recv_data(void *buffer, size_t length, ucp_mem_h memh,
         param.memh          = memh;
     }
 
+    /* coverity[uninit_use_in_call] */
     ucs_status_ptr_t status_ptr = ucp_tag_recv_nbx(_context.worker(), buffer,
                                                    length, tag, tag_mask,
                                                    &param);
@@ -946,12 +947,12 @@ bool UcxConnection::send_am(const void *meta, size_t meta_length,
                          UCP_OP_ATTR_FIELD_FLAGS;
     param.cb.send      = common_request_callback_nbx;
     param.flags        = UCP_AM_SEND_FLAG_REPLY;
-    param.datatype     = 0; // make coverity happy
     if (memh) {
         param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
         param.memh          = memh;
     }
 
+    /* coverity[uninit_use_in_call] */
     ucs_status_ptr_t sptr = ucp_am_send_nbx(_ep, AM_MSG_ID, meta, meta_length,
                                             buffer, length, &param);
     return process_request("ucp_am_send_nbx", sptr, callback);
@@ -1225,7 +1226,6 @@ bool UcxConnection::send_common(const void *buffer, size_t length,
 
     ucp_request_param_t param;
     param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK;
-    param.datatype     = 0; // make coverity happy
     param.cb.send      = (ucp_send_nbx_callback_t)common_request_callback;
 
     if (memh) {
@@ -1233,6 +1233,7 @@ bool UcxConnection::send_common(const void *buffer, size_t length,
         param.memh          = memh;
     }
 
+    /* coverity[uninit_use_in_call] */
     ucs_status_ptr_t status_ptr = ucp_tag_send_nbx(_ep, buffer, length, tag,
                                                    &param);
     return process_request("ucp_tag_send_nbx", status_ptr, callback);


### PR DESCRIPTION
Signed-off-by: artemry-nv <artemry@nvidia.com>

## Why
Updated Coverity env module from `tools/cov-2019.12` to `tools/cov-2021.12` due to licensing issues.
 
