### PR TITLE
UCP/RKEY: Remove double dt cleanup from rndv rkey proto

### DIFF
--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -125,7 +125,6 @@ static unsigned ucp_proto_rndv_progress_rkey_ptr(void *arg)
     }
 
     ucs_queue_pull_non_empty(&worker->rkey_ptr_reqs);
-    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UCP_DT_MASK_ALL);
 
     ucp_proto_rndv_recv_complete_with_ats(req,
                                           UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS);


### PR DESCRIPTION
## What
Now `dt_cleanup` can be called twice during `rndv/rkey` proto execution. This patch removes the redundant `dt_cleanup` call from `ucp_proto_rndv_progress_rkey_ptr` while other one from `ucp_proto_rndv_ats_progress` is still on the place.

Tested with xpmem manually.