### PR TITLE
UCP/PROTO: Fixed proto info output.

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -182,7 +182,7 @@ void ucp_am_eager_multi_bcopy_proto_abort(ucp_request_t *req,
 
 ucp_proto_t ucp_am_eager_multi_bcopy_proto = {
     .name     = "am/egr/multi/bcopy",
-    .desc     = UCP_PROTO_COPY_IN_DESC,
+    .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
     .init     = ucp_am_eager_multi_bcopy_proto_init,
     .query    = ucp_proto_multi_query,
@@ -316,7 +316,7 @@ ucp_am_eager_multi_zcopy_proto_progress(uct_pending_req_t *self)
 
 ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .name     = "am/egr/multi/zcopy",
-    .desc     = UCP_PROTO_ZCOPY_DESC,
+    .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_am_eager_multi_zcopy_proto_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -18,10 +18,11 @@
 
 
 /* Common protocol description strings */
-#define UCP_PROTO_SHORT_DESC    "short"
-#define UCP_PROTO_COPY_IN_DESC  "copy-in"
-#define UCP_PROTO_COPY_OUT_DESC "copy-out"
-#define UCP_PROTO_ZCOPY_DESC    "zero-copy"
+#define UCP_PROTO_SHORT_DESC      "short"
+#define UCP_PROTO_COPY_IN_DESC    "copy-in"
+#define UCP_PROTO_COPY_OUT_DESC   "copy-out"
+#define UCP_PROTO_ZCOPY_DESC      "zero-copy"
+#define UCP_PROTO_MULTI_FRAG_DESC "multi-frag"
 
 
 typedef enum {

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -329,19 +329,22 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
     ucs_string_buffer_appendf(strb, "%s", operation_names[select_param->op_id]);
 
     op_attr_mask = ucp_proto_select_op_attr_from_flags(op_flags);
-    ucs_string_buffer_appendf(strb, "(");
-    if (op_attr_mask & op_attr_bits) {
-        ucs_string_buffer_append_flags(strb, op_attr_mask & op_attr_bits,
-                                       op_attr_names);
-        ucs_string_buffer_appendf(strb, ",");
+
+    if ((op_attr_mask & op_attr_bits) || (op_flags & op_flag_bits)) {
+        ucs_string_buffer_appendf(strb, "(");
+        if (op_attr_mask & op_attr_bits) {
+            ucs_string_buffer_append_flags(strb, op_attr_mask & op_attr_bits,
+                                           op_attr_names);
+            ucs_string_buffer_appendf(strb, ",");
+        }
+        if (op_flags & op_flag_bits) {
+            ucs_string_buffer_append_flags(strb, op_flags & op_flag_bits,
+                                           op_flag_names);
+            ucs_string_buffer_appendf(strb, ",");
+        }
+        ucs_string_buffer_rtrim(strb, ",");
+        ucs_string_buffer_appendf(strb, ")");
     }
-    if (op_flags & op_flag_bits) {
-        ucs_string_buffer_append_flags(strb, op_flags & op_flag_bits,
-                                       op_flag_names);
-        ucs_string_buffer_appendf(strb, ",");
-    }
-    ucs_string_buffer_rtrim(strb, ",");
-    ucs_string_buffer_appendf(strb, ")");
 
     if (ucp_proto_op_is_fetch(select_param->op_id)) {
         ucs_string_buffer_appendf(strb, " into ");

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -218,7 +218,7 @@ static void ucp_proto_eager_sync_bcopy_request_abort(ucp_request_t *request,
 
 ucp_proto_t ucp_eager_sync_bcopy_multi_proto = {
     .name     = "egrsnc/multi/bcopy",
-    .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
+    .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_sync_bcopy_multi_init,
     .query    = ucp_proto_multi_query,
@@ -306,7 +306,7 @@ static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self
 
 ucp_proto_t ucp_eager_zcopy_multi_proto = {
     .name     = "egr/multi/zcopy",
-    .desc     = UCP_PROTO_EAGER_ZCOPY_DESC,
+    .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_EAGER_ZCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_zcopy_multi_init,
     .query    = ucp_proto_multi_query,

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -133,7 +133,7 @@ ucp_proto_eager_bcopy_multi_progress(uct_pending_req_t *uct_req)
 
 ucp_proto_t ucp_eager_bcopy_multi_proto = {
     .name     = "egr/multi/bcopy",
-    .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
+    .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
     .init     = ucp_proto_eager_bcopy_multi_init,
     .query    = ucp_proto_multi_query,


### PR DESCRIPTION
## What
Removed extra parenthesis.
Added prefix to distinguish multi- and single-fragment protocols.
