### PR TITLE
UCT/IB: Fix exported memh packing

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -102,10 +102,6 @@ enum {
     UCT_IB_MLX5_HCA_CAPS_2_CROSS_VHCA_OBJ_TO_OBJ_LOCAL_MKEY_TO_REMOTE_MKEY = 0x100
 };
 
-enum {
-    UCT_IB_MLX5_PAGE_SHIFT = 12
-};
-
 struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    reserved_at_0[0x30];
     uint8_t    vhca_id[0x10];

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1402,7 +1402,7 @@ uct_ib_mlx5_devx_reg_exported_key(uct_ib_md_t *ib_md, uct_ib_mem_t *ib_memh)
     struct mlx5dv_devx_umem_in umem_in;
     ucs_status_t status;
     void *access_key;
-    void *address;
+    void *address, *aligned_address;
     size_t length;
     void *mkc;
     int ret;
@@ -1414,7 +1414,8 @@ uct_ib_mlx5_devx_reg_exported_key(uct_ib_md_t *ib_md, uct_ib_mem_t *ib_memh)
     umem_in.addr        = address;
     umem_in.size        = length;
     umem_in.access      = UCT_IB_MLX5_MD_UMEM_ACCESS;
-    umem_in.pgsz_bitmap = UINT64_MAX & ~UCS_MASK(UCT_IB_MLX5_PAGE_SHIFT);
+    aligned_address     = ucs_align_down_pow2_ptr(address, ucs_get_page_size());
+    umem_in.pgsz_bitmap = UCS_MASK(ucs_ffs64((uint64_t)aligned_address) + 1);
     umem_in.comp_mask   = 0;
 
     ucs_assertv(memh->umem == NULL, "memh %p umem %p", memh, memh->umem);


### PR DESCRIPTION
## What
Create umem with default page size only

## Why ?
A temporary fix for packing exported mkeys. Fixes the following problem:
```
mlx5dv_devx_obj_create(MKEY) failed on mlx5_bond_1, syndrome 0x317175: Remote I/O error
```
where 0x317175 is _page offset of the starting point in the umem must match the page offset indicated by the mkey.start_address_

Also driver bug is created - [Nvidia internal link](https://redmine.mellanox.com/issues/3260653)