### PR TITLE
UCS/TOPO: Use registered Proto providers modules implementing Proto API

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -5,7 +5,7 @@
 # See file LICENSE for terms.
 #
 
-SUBDIRS = vfs/sock . vfs/fuse signal
+SUBDIRS = vfs/sock . vfs/fuse signal sys/topo/providers/sysfs sys/topo/providers/default
 
 AUTOMAKE_OPTIONS    = nostdinc # avoid collision with built-in debug.h
 lib_LTLIBRARIES     = libucs.la

--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -8,6 +8,7 @@
 ucs_modules=""
 m4_include([src/ucs/vfs/sock/configure.m4])
 m4_include([src/ucs/vfs/fuse/configure.m4])
+m4_include([src/ucs/sys/topo/providers/configure.m4])
 AC_DEFINE_UNQUOTED([ucs_MODULES], ["${ucs_modules}"], [UCS loadable modules])
 
 #

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -56,6 +56,16 @@ static ucs_topo_global_ctx_t ucs_topo_global_ctx;
 UCS_LIST_HEAD(ucs_sys_topo_methods_list);
 
 
+void ucs_sys_topo_lock_ctx()
+{
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+}
+
+void ucs_sys_topo_unlock_ctx()
+{
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+}
+
 static ucs_sys_topo_method_t *ucs_sys_topo_get_method()
 {
     static ucs_sys_topo_method_t *method = NULL;
@@ -80,21 +90,6 @@ static ucs_sys_topo_method_t *ucs_sys_topo_get_method()
     return method;
 }
 
-static ucs_status_t
-ucs_topo_get_distance_default(ucs_sys_device_t device1,
-                              ucs_sys_device_t device2,
-                              ucs_sys_dev_distance_t *distance)
-{
-    *distance = ucs_topo_default_distance;
-
-    return UCS_OK;
-}
-
-static ucs_sys_topo_method_t ucs_sys_topo_default_method = {
-    .name         = "default",
-    .get_distance = ucs_topo_get_distance_default,
-};
-
 ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
                                    ucs_sys_device_t device2,
                                    ucs_sys_dev_distance_t *distance)
@@ -111,6 +106,11 @@ ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
             ((uint64_t)bus_id->bus << 16)    |
             ((uint64_t)bus_id->slot << 8)    |
             (bus_id->function));
+}
+
+unsigned ucs_topo_num_devices_non_sync()
+{
+    return ucs_topo_global_ctx.num_devices;
 }
 
 unsigned ucs_topo_num_devices()
@@ -134,6 +134,13 @@ static void ucs_topo_bus_id_str(const ucs_sys_bus_id_t *bus_id, int abbreviate,
         ucs_snprintf_safe(str, max, "%04x:%02x:%02x.%d", bus_id->domain,
                           bus_id->bus, bus_id->slot, bus_id->function);
     }
+}
+
+void ucs_topo_device_bus_id_str(ucs_sys_device_t sys_dev, int abbreviate,
+                                char *str, size_t max)
+{
+    ucs_topo_bus_id_str(&ucs_topo_global_ctx.devices[sys_dev].bus_id,
+                        abbreviate, str, max);
 }
 
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
@@ -187,121 +194,6 @@ ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
     }
 
     *bus_id = ucs_topo_global_ctx.devices[sys_dev].bus_id;
-    return UCS_OK;
-}
-
-static ucs_status_t
-ucs_topo_get_sysfs_path(ucs_sys_device_t sys_dev, char *path, size_t max)
-{
-    const size_t prefix_length = strlen(UCS_TOPO_SYSFS_PCI_PREFIX);
-    char link_path[PATH_MAX];
-    ucs_status_t status;
-
-    if (max < PATH_MAX) {
-        status = UCS_ERR_BUFFER_TOO_SMALL;
-        goto out;
-    }
-
-    ucs_spin_lock(&ucs_topo_global_ctx.lock);
-
-    if (sys_dev >= ucs_topo_global_ctx.num_devices) {
-        ucs_error("system device %d is invalid (max: %d)", sys_dev,
-                  ucs_topo_global_ctx.num_devices);
-        status = UCS_ERR_INVALID_PARAM;
-        goto out_unlock;
-    }
-
-    ucs_strncpy_safe(link_path, UCS_TOPO_SYSFS_PCI_PREFIX, PATH_MAX);
-    ucs_topo_bus_id_str(&ucs_topo_global_ctx.devices[sys_dev].bus_id, 0,
-                        link_path + prefix_length, PATH_MAX - prefix_length);
-    if (realpath(link_path, path) == NULL) {
-        status = UCS_ERR_IO_ERROR;
-        goto out_unlock;
-    }
-
-    status = UCS_OK;
-
-out_unlock:
-    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
-out:
-    return status;
-}
-
-static int ucs_topo_is_sys_root(const char *path)
-{
-    return !strcmp(path, UCS_TOPO_SYSFS_DEVICES_ROOT);
-}
-
-static int ucs_topo_is_pci_root(const char *path)
-{
-    int count;
-    sscanf(path, UCS_TOPO_SYSFS_DEVICES_ROOT "/pci%*d:%*d%n", &count);
-    return count == strlen(path);
-}
-
-static void ucs_topo_sys_root_distance(ucs_sys_dev_distance_t *distance)
-{
-    distance->latency = 500e-9;
-    switch (ucs_arch_get_cpu_model()) {
-    case UCS_CPU_MODEL_AMD_ROME:
-    case UCS_CPU_MODEL_AMD_MILAN:
-        distance->bandwidth = 5100 * UCS_MBYTE;
-        break;
-    default:
-        distance->bandwidth = 220 * UCS_MBYTE;
-        break;
-    }
-}
-
-static void ucs_topo_pci_root_distance(const char *path1, const char *path2,
-                                       ucs_sys_dev_distance_t *distance)
-{
-    size_t path_distance = ucs_path_calc_distance(path1, path2);
-
-    ucs_trace_data("distance between '%s' and '%s' is %zu", path1, path2,
-                   path_distance);
-    ucs_assertv(path_distance > 0, "path1=%s path2=%s", path1, path2);
-
-    /* TODO set latency/bandwidth by CPU model */
-    distance->latency   = 300e-9;
-    distance->bandwidth = ucs_min(3500.0 * UCS_MBYTE,
-                                  (19200.0 * UCS_MBYTE) / path_distance);
-}
-
-static ucs_status_t
-ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
-                            ucs_sys_device_t device2,
-                            ucs_sys_dev_distance_t *distance)
-{
-    char path1[PATH_MAX], path2[PATH_MAX], common_path[PATH_MAX];
-    ucs_status_t status;
-
-    /* If one of the devices is unknown, we assume near topology */
-    if ((device1 == UCS_SYS_DEVICE_ID_UNKNOWN) ||
-        (device2 == UCS_SYS_DEVICE_ID_UNKNOWN) || (device1 == device2)) {
-        *distance = ucs_topo_default_distance;
-        return UCS_OK;
-    }
-
-    status = ucs_topo_get_sysfs_path(device1, path1, sizeof(path1));
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = ucs_topo_get_sysfs_path(device2, path2, sizeof(path2));
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    ucs_path_get_common_parent(path1, path2, common_path);
-    if (ucs_topo_is_sys_root(common_path)) {
-        ucs_topo_sys_root_distance(distance);
-    } else if (ucs_topo_is_pci_root(common_path)) {
-        ucs_topo_pci_root_distance(path1, path2, distance);
-    } else {
-        *distance = ucs_topo_default_distance;
-    }
-
     return UCS_OK;
 }
 
@@ -419,28 +311,26 @@ void ucs_topo_print_info(FILE *stream)
     }
 }
 
-static ucs_sys_topo_method_t ucs_sys_topo_sysfs_method = {
-    .name         = "sysfs",
-    .get_distance = ucs_topo_get_distance_sysfs,
-};
+void ucs_topo_register_provider(ucs_sys_topo_method_t *provider)
+{
+    ucs_list_add_tail(&ucs_sys_topo_methods_list, &provider->list);
+}
+
+void ucs_topo_unregister_provider(ucs_sys_topo_method_t *provider)
+{
+    ucs_list_del(&provider->list);
+}
 
 void ucs_topo_init()
 {
     ucs_spinlock_init(&ucs_topo_global_ctx.lock, 0);
     kh_init_inplace(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash);
     ucs_topo_global_ctx.num_devices = 0;
-    ucs_list_add_tail(&ucs_sys_topo_methods_list,
-                      &ucs_sys_topo_default_method.list);
-    ucs_list_add_tail(&ucs_sys_topo_methods_list,
-                      &ucs_sys_topo_sysfs_method.list);
 }
 
 void ucs_topo_cleanup()
 {
     ucs_topo_sys_device_info_t *device;
-
-    ucs_list_del(&ucs_sys_topo_sysfs_method.list);
-    ucs_list_del(&ucs_sys_topo_default_method.list);
 
     while (ucs_topo_global_ctx.num_devices-- > 0) {
         device = &ucs_topo_global_ctx.devices[ucs_topo_global_ctx.num_devices];

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -203,6 +203,15 @@ const char *ucs_topo_sys_device_get_name(ucs_sys_device_t sys_dev);
  *
  * @return Number of system devices.
  */
+unsigned ucs_topo_num_devices_non_sync();
+
+
+/**
+ * Get the number of registered system devices.
+ * This function is synchronic.
+ *
+ * @return Number of system devices.
+ */
 unsigned ucs_topo_num_devices();
 
 
@@ -223,6 +232,42 @@ void ucs_topo_init();
  * Cleanup UCS topology subsystem.
  */
 void ucs_topo_cleanup();
+
+
+/**
+ * Register topo provider.
+ *
+ */
+void ucs_topo_register_provider(ucs_sys_topo_method_t *provider);
+
+
+/**
+ * Unregister topo provider.
+ *
+ */
+void ucs_topo_unregister_provider(ucs_sys_topo_method_t *provider);
+
+
+/**
+ * lock proto context.
+ *
+ */
+void ucs_sys_topo_lock_ctx();
+
+
+/**
+ * unlock proto context.
+ *
+ */
+void ucs_sys_topo_unlock_ctx();
+
+
+/**
+ * Prints device's bus id.
+ *
+ */
+void ucs_topo_device_bus_id_str(ucs_sys_device_t sys_dev, int abbreviate,
+                                char *str, size_t max);
 
 END_C_DECLS
 

--- a/src/ucs/sys/topo/providers/configure.m4
+++ b/src/ucs/sys/topo/providers/configure.m4
@@ -1,0 +1,10 @@
+#
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+#
+
+
+ucs_modules="${ucs_modules}:topo_sysfs:topo_default"
+AC_CONFIG_FILES([src/ucs/sys/topo/providers/sysfs/Makefile
+                 src/ucs/sys/topo/providers/sysfs/ucx-topo-sysfs.pc
+                 src/ucs/sys/topo/providers/default/Makefile
+                 src/ucs/sys/topo/providers/default/ucx-topo-default.pc])

--- a/src/ucs/sys/topo/providers/default/Makefile.am
+++ b/src/ucs/sys/topo/providers/default/Makefile.am
@@ -1,0 +1,19 @@
+#
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+module_LTLIBRARIES              = libucs_topo_default.la
+libucs_topo_default_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libucs_topo_default_la_CFLAGS   = $(BASE_CFLAGS)
+libucs_topo_default_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la
+libucs_topo_default_la_LDFLAGS  = $(LDFLAGS) -version-info $(SOVERSION)
+
+libucs_topo_default_la_SOURCES  = \
+    provider.c
+
+PKG_CONFIG_NAME=topo-default
+
+include $(top_srcdir)/config/module.am
+include $(top_srcdir)/config/module-pkg-config.am

--- a/src/ucs/sys/topo/providers/default/provider.c
+++ b/src/ucs/sys/topo/providers/default/provider.c
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <ucs/sys/topo/base/topo.h>
+#include <ucs/sys/compiler.h>
+#include <ucs/sys/string.h>
+#include <ucs/sys/sys.h>
+#include <ucs/arch/cpu.h>
+#include <ucs/debug/log.h>
+
+static ucs_status_t
+ucs_topo_get_distance_default(ucs_sys_device_t device1,
+                              ucs_sys_device_t device2,
+                              ucs_sys_dev_distance_t *distance)
+{
+    *distance = ucs_topo_default_distance;
+
+    return UCS_OK;
+}
+
+static ucs_sys_topo_method_t ucs_sys_topo_default_method = {
+    .name         = "default",
+    .get_distance = ucs_topo_get_distance_default,
+};
+
+void UCS_F_CTOR ucs_topo_default_init()
+{
+    ucs_topo_register_provider(&ucs_sys_topo_default_method);
+}
+
+void UCS_F_DTOR ucs_topo_default_cleanup()
+{
+    ucs_topo_unregister_provider(&ucs_sys_topo_default_method);
+}

--- a/src/ucs/sys/topo/providers/default/ucx-topo-default.pc.in
+++ b/src/ucs/sys/topo/providers/default/ucx-topo-default.pc.in
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See file LICENSE for terms.
+#
+
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+libdir = @libdir@/ucx
+
+Name: @PACKAGE@-topo-default
+Description: Unified Communication X Library Default Topo Provider module
+Version: @VERSION@
+Libs:
+Libs.private: -L${libdir} -lucs_topo_default -Wl,--undefined=ucs_topo_default_init

--- a/src/ucs/sys/topo/providers/sysfs/Makefile.am
+++ b/src/ucs/sys/topo/providers/sysfs/Makefile.am
@@ -1,0 +1,19 @@
+#
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+module_LTLIBRARIES            = libucs_topo_sysfs.la
+libucs_topo_sysfs_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libucs_topo_sysfs_la_CFLAGS   = $(BASE_CFLAGS)
+libucs_topo_sysfs_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la
+libucs_topo_sysfs_la_LDFLAGS  = $(LDFLAGS) -version-info $(SOVERSION)
+
+libucs_topo_sysfs_la_SOURCES  = \
+    provider.c
+
+PKG_CONFIG_NAME=topo-sysfs
+
+include $(top_srcdir)/config/module.am
+include $(top_srcdir)/config/module-pkg-config.am

--- a/src/ucs/sys/topo/providers/sysfs/provider.c
+++ b/src/ucs/sys/topo/providers/sysfs/provider.c
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <ucs/sys/topo/base/topo.h>
+#include <ucs/sys/compiler.h>
+#include <ucs/sys/string.h>
+#include <ucs/sys/sys.h>
+#include <ucs/arch/cpu.h>
+#include <ucs/debug/log.h>
+
+#define UCS_TOPO_SYSFS_PCI_PREFIX   "/sys/bus/pci/devices/"
+#define UCS_TOPO_SYSFS_DEVICES_ROOT "/sys/devices"
+
+static ucs_status_t
+ucs_topo_get_sysfs_path(ucs_sys_device_t sys_dev, char *path, size_t max)
+{
+    const size_t prefix_length = strlen(UCS_TOPO_SYSFS_PCI_PREFIX);
+    char link_path[PATH_MAX];
+    unsigned num_devices;
+    ucs_status_t status;
+
+    if (max < PATH_MAX) {
+        status = UCS_ERR_BUFFER_TOO_SMALL;
+        goto out;
+    }
+
+    ucs_sys_topo_lock_ctx();
+
+    num_devices = ucs_topo_num_devices_non_sync();
+    if (sys_dev >= num_devices) {
+        ucs_error("system device %d is invalid (max: %d)", sys_dev,
+                  num_devices);
+        status = UCS_ERR_INVALID_PARAM;
+        goto out_unlock;
+    }
+
+    ucs_sys_topo_lock_ctx();
+
+    ucs_strncpy_safe(link_path, UCS_TOPO_SYSFS_PCI_PREFIX, PATH_MAX);
+    ucs_topo_device_bus_id_str(sys_dev, 0, link_path + prefix_length,
+                               PATH_MAX - prefix_length);
+    if (realpath(link_path, path) == NULL) {
+        status = UCS_ERR_IO_ERROR;
+        goto out_unlock;
+    }
+
+    status = UCS_OK;
+
+out_unlock:
+    ucs_sys_topo_unlock_ctx();
+out:
+    return status;
+}
+
+
+static int ucs_topo_is_pci_root(const char *path)
+{
+    int count;
+    sscanf(path, UCS_TOPO_SYSFS_DEVICES_ROOT "/pci%*d:%*d%n", &count);
+    return count == strlen(path);
+}
+
+static int ucs_topo_is_sys_root(const char *path)
+{
+    return !strcmp(path, UCS_TOPO_SYSFS_DEVICES_ROOT);
+}
+
+static void ucs_topo_sys_root_distance(ucs_sys_dev_distance_t *distance)
+{
+    distance->latency = 500e-9;
+    switch (ucs_arch_get_cpu_model()) {
+    case UCS_CPU_MODEL_AMD_ROME:
+    case UCS_CPU_MODEL_AMD_MILAN:
+        distance->bandwidth = 5100 * UCS_MBYTE;
+        break;
+    default:
+        distance->bandwidth = 220 * UCS_MBYTE;
+        break;
+    }
+}
+
+static void ucs_topo_pci_root_distance(const char *path1, const char *path2,
+                                       ucs_sys_dev_distance_t *distance)
+{
+    size_t path_distance = ucs_path_calc_distance(path1, path2);
+
+    ucs_trace_data("distance between '%s' and '%s' is %zu", path1, path2,
+                   path_distance);
+    ucs_assertv(path_distance > 0, "path1=%s path2=%s", path1, path2);
+
+    /* TODO set latency/bandwidth by CPU model */
+    distance->latency   = 300e-9;
+    distance->bandwidth = ucs_min(3500.0 * UCS_MBYTE,
+                                  (19200.0 * UCS_MBYTE) / path_distance);
+}
+
+static ucs_status_t
+ucs_topo_get_distance_sysfs(ucs_sys_device_t device1, ucs_sys_device_t device2,
+                            ucs_sys_dev_distance_t *distance)
+{
+    char path1[PATH_MAX], path2[PATH_MAX], common_path[PATH_MAX];
+    ucs_status_t status;
+
+    /* If one of the devices is unknown, we assume near topology */
+    if ((device1 == UCS_SYS_DEVICE_ID_UNKNOWN) ||
+        (device2 == UCS_SYS_DEVICE_ID_UNKNOWN) || (device1 == device2)) {
+        *distance = ucs_topo_default_distance;
+        return UCS_OK;
+    }
+
+    status = ucs_topo_get_sysfs_path(device1, path1, sizeof(path1));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = ucs_topo_get_sysfs_path(device2, path2, sizeof(path2));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_path_get_common_parent(path1, path2, common_path);
+    if (ucs_topo_is_sys_root(common_path)) {
+        ucs_topo_sys_root_distance(distance);
+    } else if (ucs_topo_is_pci_root(common_path)) {
+        ucs_topo_pci_root_distance(path1, path2, distance);
+    } else {
+        *distance = ucs_topo_default_distance;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_sys_topo_method_t ucs_sys_topo_sysfs_method = {
+    .name         = "sysfs",
+    .get_distance = ucs_topo_get_distance_sysfs,
+};
+
+void UCS_F_CTOR ucs_topo_sysfs_init()
+{
+    ucs_topo_register_provider(&ucs_sys_topo_sysfs_method);
+}
+
+void UCS_F_DTOR ucs_topo_sysfs_cleanup()
+{
+    ucs_topo_unregister_provider(&ucs_sys_topo_sysfs_method);
+}

--- a/src/ucs/sys/topo/providers/sysfs/ucx-topo-sysfs.pc.in
+++ b/src/ucs/sys/topo/providers/sysfs/ucx-topo-sysfs.pc.in
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See file LICENSE for terms.
+#
+
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+libdir = @libdir@/ucx
+
+Name: @PACKAGE@-topo-sysfs
+Description: Unified Communication X Library SYSFS Topo Provider module
+Version: @VERSION@
+Libs:
+Libs.private: -L${libdir} -lucs_topo_sysfs -Wl,--undefined=ucs_topo_sysfs_init


### PR DESCRIPTION
## What
Use registered Proto providers modules implementing Proto API to calculate the distance between devices

## Why ?
Service architecture that provides better encapsulation and runtime dependency of external libs.

## How ?
- Define API to be implemented by topo providers
- Define API to enable providers to registered themself as a service provider in UCS Topo.
- Create default provider and sysfs provider, export existing code from UCS Topo to the new providers.
