### PR TITLE
TEST/JENKINS: Disable osc/ucx component when using mpirun

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -855,6 +855,7 @@ run_mpi_tests() {
 					-x UCX_ERROR_SIGNALS \
 					-x UCX_HANDLE_ERRORS \
 					-mca pml ob1 \
+					-mca osc ^ucx \
 					-mca btl tcp,self \
 					-mca btl_tcp_if_include lo \
 					-mca orte_allowed_exit_without_sync 1 \
@@ -981,7 +982,7 @@ test_unused_env_var() {
 	# We must create a UCP worker to get the warning about unused variables
 	echo "==== Running ucx_info env vars test ===="
 	UCX_IB_PORTS=mlx5_0:1 ./src/tools/info/ucx_info -epw -u t | grep "unused" | grep -q -E "UCX_IB_PORTS"
-	
+
 	# Check that suggestions for similar ucx env vars are printed
 	echo "==== Running fuzzy match test ===="
 	../test/apps/test_fuzzy_match.py --ucx_info ./src/tools/info/ucx_info

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -23,6 +23,7 @@ endif
 
 AM_CPPFLAGS           = \
     $(BASE_CPPFLAGS) \
+    -DUCS_LIB_DIR="$(abs_top_builddir)/src/ucs/.libs" \
     -DUCM_LIB_DIR="$(abs_top_builddir)/src/ucm/.libs" \
     -DTEST_LIB_DIR="$(abs_builddir)/.libs"
 AM_CFLAGS             = $(BASE_CFLAGS)


### PR DESCRIPTION
## Why
Fix recent test failures like this:
```
+ mpirun --bind-to none -x UCX_ERROR_SIGNALS -x UCX_HANDLE_ERRORS -mca pml ob1 -mca btl tcp,self -mca btl_tcp_if_include lo -mca orte_allowed_exit_without_sync 1 -mca coll '^hcoll,ml' -np 1 ./test/mpi/test_memhooks -t flag_no_install -m reloc
==== Running memory hook (flag_no_install mode reloc) on MPI ====
flag_no_install: initialized
total_mapped=1048576
test_memhooks.c:432: Callback for mmap invoked, while hooks were not set
flag_no_install: FAIL
```

It happens because osc/ucx now calls ucp_init() during component_init, which triggers memory hooks install.