### PR TITLE
BUILD/CONFIG: Remove no use build configure.

### DIFF
--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -282,9 +282,6 @@ AS_IF([test "x$with_ib" = "xyes"],
                [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support])],
                [], [[#include <infiniband/verbs.h>]])])
 
-       AC_CHECK_DECLS([ibv_cmd_modify_qp],
-                      [], [], [[#include <infiniband/driver.h>]])
-
        mlnx_valg_libdir=$with_verbs/lib${libsuff}/mlnx_ofed/valgrind
        AC_MSG_NOTICE([Checking OFED valgrind libs $mlnx_valg_libdir])
 


### PR DESCRIPTION
Remove the configure of "_ibv_cmd_modify_qp_", because it's not used anymore.