### PR TITLE
UCT/CUDA: draft of using managed memory preferred location

### DIFF
--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -196,6 +196,7 @@ typedef union ucm_event {
         void               *address;
         size_t             size;
         ucs_memory_type_t  mem_type;
+        ucs_memory_type_t  preferred_mem_type;
     } mem_type;
 
 } ucm_event_t;

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -123,11 +123,14 @@ static void ucm_cuda_dispatch_mem_alloc(CUdeviceptr ptr, size_t length,
 {
     ucm_event_t event;
 
-    event.mem_type.address  = (void*)ptr;
-    event.mem_type.size     = length;
-    event.mem_type.mem_type = UCS_MEMORY_TYPE_LAST; /* indicate unknown type
-                                                       and let cuda_md detect
-                                                       attributes */
+    event.mem_type.address            = (void*)ptr;
+    event.mem_type.size               = length;
+    event.mem_type.mem_type           = UCS_MEMORY_TYPE_LAST; /* indicate unknown type
+                                                                 and let cuda_md detect
+                                                                 attributes */
+    event.mem_type.preferred_mem_type = UCS_MEMORY_TYPE_LAST; /* indicate unknown type
+                                                                 and let cuda_md detect
+                                                                 attributes */
     ucm_event_dispatch(UCM_EVENT_MEM_TYPE_ALLOC, &event);
 }
 
@@ -155,9 +158,10 @@ static void ucm_cuda_dispatch_mem_free(CUdeviceptr ptr,
         length = 1; /* set minimum length */
     }
 
-    event.mem_type.address  = (void*)ptr;
-    event.mem_type.size     = length;
-    event.mem_type.mem_type = mem_type;
+    event.mem_type.address            = (void*)ptr;
+    event.mem_type.size               = length;
+    event.mem_type.mem_type           = mem_type;
+    event.mem_type.preferred_mem_type = mem_type;
     ucm_event_dispatch(UCM_EVENT_MEM_TYPE_FREE, &event);
 }
 
@@ -376,9 +380,10 @@ static int ucm_cudamem_scan_regions_cb(void *arg, void *addr, size_t length,
     ucm_debug("dispatching initial memtype allocation for %p..%p %s", addr,
               UCS_PTR_BYTE_OFFSET(addr, length), path);
 
-    event.mem_type.address  = addr;
-    event.mem_type.size     = length;
-    event.mem_type.mem_type = UCS_MEMORY_TYPE_LAST; /* unknown memory type */
+    event.mem_type.address            = addr;
+    event.mem_type.size               = length;
+    event.mem_type.mem_type           = UCS_MEMORY_TYPE_LAST; /* unknown memory type */
+    event.mem_type.preferred_mem_type = UCS_MEMORY_TYPE_LAST; /* unknown memory type */
 
     ucm_event_enter();
     handler->cb(UCM_EVENT_MEM_TYPE_ALLOC, &event, handler->arg);

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2197,10 +2197,11 @@ void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
                       address, length, tl_md->rsc.md_name,
                       ucs_memory_type_names[mem_attr.mem_type],
                       ucs_topo_sys_device_get_name(mem_attr.sys_dev));
-        mem_info->type         = mem_attr.mem_type;
-        mem_info->sys_dev      = mem_attr.sys_dev;
-        mem_info->base_address = mem_attr.base_address;
-        mem_info->alloc_length = mem_attr.alloc_length;
+        mem_info->type           = mem_attr.mem_type;
+        mem_info->preferred_type = mem_attr.preferred_mem_type;
+        mem_info->sys_dev        = mem_attr.sys_dev;
+        mem_info->base_address   = mem_attr.base_address;
+        mem_info->alloc_length   = mem_attr.alloc_length;
         return;
     }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -580,8 +580,9 @@ ucp_cmpt_attr_by_md_index(ucp_context_h context, ucp_md_index_t md_index)
 static UCS_F_ALWAYS_INLINE void
 ucp_memory_info_set_host(ucp_memory_info_t *mem_info)
 {
-    mem_info->type    = UCS_MEMORY_TYPE_HOST;
-    mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+    mem_info->type           = UCS_MEMORY_TYPE_HOST;
+    mem_info->preferred_type = UCS_MEMORY_TYPE_HOST;
+    mem_info->sys_dev        = UCS_SYS_DEVICE_ID_UNKNOWN;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -632,8 +633,9 @@ ucp_memory_detect(ucp_context_h context, const void *address, size_t length,
 
     ucp_memory_detect_internal(context, address, length, &mem_info_internal);
 
-    mem_info->type    = mem_info_internal.type;
-    mem_info->sys_dev = mem_info_internal.sys_dev;
+    mem_info->type           = mem_info_internal.type;
+    mem_info->preferred_type = mem_info_internal.preferred_type;
+    mem_info->sys_dev        = mem_info_internal.sys_dev;
 }
 
 

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -55,8 +55,9 @@ typedef struct ucp_dt_state {
  * UCP layer memory information
  */
 typedef struct {
-    uint8_t          type;    /**< Memory type, use uint8 for compact size */
-    ucs_sys_device_t sys_dev; /**< System device index */
+    uint8_t          type;           /**< Memory type, use uint8 for compact size */
+    uint8_t          preferred_type; /**< Preferred memory type, use uint8 for compact size */
+    ucs_sys_device_t sys_dev;        /**< System device index */
 } ucp_memory_info_t;
 
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1176,6 +1176,9 @@ static void ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
 {
     ucp_worker_h worker             = sreq->send.ep->worker;
     ucs_memory_type_t frag_mem_type = worker->context->config.ext.rndv_frag_mem_type;
+#if 0
+    ucs_memory_info_t mem_info;
+#endif
     ucp_request_t *freq;
     ucp_mem_desc_t *mdesc;
 
@@ -1185,6 +1188,12 @@ static void ucp_rndv_send_frag_get_mem_type(ucp_request_t *sreq, size_t length,
     if (ucs_unlikely(freq == NULL)) {
         ucs_fatal("failed to allocate fragment receive request");
     }
+
+#if 0
+    ucp_memory_detect(sreq->send.ep->worker->context, sreq->send.buffer,
+                      sreq->send.length, &mem_info);
+    frag_mem_type = mem_info.preferred_type;
+#endif
 
     mdesc = ucp_rndv_mpool_get(worker, frag_mem_type,
                                UCS_SYS_DEVICE_ID_UNKNOWN);
@@ -1338,6 +1347,9 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
     unsigned memh_index;
     const uct_component_attr_t *cmpt_attr;
     ucp_md_map_t alloc_md_map;
+#if 0
+    ucs_memory_info_t mem_info;
+#endif
 
     ucp_trace_req(rreq, "using rndv pipeline protocol rndv_req %p", rndv_req);
 
@@ -1361,6 +1373,12 @@ static void ucp_rndv_send_frag_rtr(ucp_worker_h worker, ucp_request_t *rndv_req,
         if (frndv_req == NULL) {
             ucs_fatal("failed to allocate fragment rendezvous reply");
         }
+
+#if 0
+        ucp_memory_detect(context, rndv_req->send.buffer, rndv_req->send.length,
+                          &mem_info);
+        frag_mem_type = mem_info.preferred_type;
+#endif
 
         /* allocate fragment recv buffer desc*/
         mdesc = ucp_rndv_mpool_get(worker, frag_mem_type,

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -29,10 +29,11 @@ extern ucs_memtype_cache_t *ucs_memtype_cache_global_instance;
 
 /* Memory information record */
 typedef struct ucs_memory_info {
-    ucs_memory_type_t type;          /**< Memory type */
-    ucs_sys_device_t  sys_dev;       /**< System device index */
-    void              *base_address; /**< Base address of the underlying allocation */
-    size_t            alloc_length;  /**< Whole length of the underlying allocation */
+    ucs_memory_type_t type;           /**< Memory type */
+    ucs_memory_type_t preferred_type; /**< Preferred Memory type */
+    ucs_sys_device_t  sys_dev;        /**< System device index */
+    void              *base_address;  /**< Base address of the underlying allocation */
+    size_t            alloc_length;   /**< Whole length of the underlying allocation */
 } ucs_memory_info_t;
 
 
@@ -78,6 +79,7 @@ ucs_status_t ucs_memtype_cache_lookup(const void *address, size_t size,
  */
 void ucs_memtype_cache_update(const void *address, size_t size,
                               ucs_memory_type_t mem_type,
+                              ucs_memory_type_t preferred_mem_type,
                               ucs_sys_device_t sys_dev);
 
 
@@ -110,10 +112,11 @@ static UCS_F_ALWAYS_INLINE int ucs_memtype_cache_is_empty()
 static UCS_F_ALWAYS_INLINE void
 ucs_memory_info_set_host(ucs_memory_info_t *mem_info)
 {
-    mem_info->type         = UCS_MEMORY_TYPE_HOST;
-    mem_info->sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-    mem_info->base_address = NULL;
-    mem_info->alloc_length = -1;
+    mem_info->type           = UCS_MEMORY_TYPE_HOST;
+    mem_info->preferred_type = UCS_MEMORY_TYPE_HOST;
+    mem_info->sys_dev        = UCS_SYS_DEVICE_ID_UNKNOWN;
+    mem_info->base_address   = NULL;
+    mem_info->alloc_length   = -1;
 }
 
 END_C_DECLS

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1538,32 +1538,35 @@ struct uct_md_attr {
  */
 typedef enum uct_md_mem_attr_field {
     /** Indicate if memory type is populated. E.g. CPU/GPU */
-    UCT_MD_MEM_ATTR_FIELD_MEM_TYPE      = UCS_BIT(0),
+    UCT_MD_MEM_ATTR_FIELD_MEM_TYPE           = UCS_BIT(0),
 
     /**
      * Indicate if details of system device backing the pointer are populated.
      * For example: GPU device, NUMA domain, etc.
      */
-    UCT_MD_MEM_ATTR_FIELD_SYS_DEV       = UCS_BIT(1),
+    UCT_MD_MEM_ATTR_FIELD_SYS_DEV            = UCS_BIT(1),
 
     /** Request base address of the allocation to which the buffer belongs. */
-    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS  = UCS_BIT(2),
+    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS       = UCS_BIT(2),
 
     /** Request the whole length of the allocation to which the buffer belongs. */
-    UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH  = UCS_BIT(3),
+    UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH       = UCS_BIT(3),
 
     /**
      * Request a cross-device dmabuf file descriptor that represents a memory
      * region, and can be used to register the region with another memory
      * domain.
      */
-    UCT_MD_MEM_ATTR_FIELD_DMABUF_FD     = UCS_BIT(4),
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_FD          = UCS_BIT(4),
 
     /**
      * Request the offset of the provided virtual address relative to the
      * beginning of its backing dmabuf region.
      */
-    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET = UCS_BIT(5)
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET      = UCS_BIT(5),
+
+    /** Indicate if preferred memory type is populated. E.g. CPU/GPU */
+    UCT_MD_MEM_ATTR_FIELD_PREFERRED_MEM_TYPE = UCS_BIT(6)
 } uct_md_mem_attr_field_t;
 
 
@@ -1584,7 +1587,7 @@ typedef struct uct_md_mem_attr {
 
     /**
      * The type of memory. E.g. CPU/GPU memory or some other valid type.
-     * If the md does not support sys_dev query, then UCS_MEMORY_TYPE_UNKNOWN
+     * If the md does not support mem_dev query, then UCS_MEMORY_TYPE_UNKNOWN
      * is returned.
      */
     ucs_memory_type_t mem_type;
@@ -1625,6 +1628,22 @@ typedef struct uct_md_mem_attr {
      * (identified by dmabuf_fd) backing the memory region being queried.
      */
     size_t            dmabuf_offset;
+
+    /**
+     * For some memory types, a given memory range can have pages that reside
+     * in multiple locations. For example, UCS_MEMORY_TYPE_CUDA_MANAGED can have
+     * some pages reside on CPU memory and others on GPU memory. However,
+     * irrespective of the actual location, the user can request the runtime to
+     * set preferred location of the range to a specific location. Knowing the
+     * preferred location can help the communication runtime decide where to
+     * stage such memory for some protocols and improve performance. This
+     * attribute returns the preferred memory type as UCS_MEMORY_TYPE_HOST or
+     * UCS_MEMORY_TYPE_CUDA depending on the location preference set by the user
+     * (if set) for a memory range of type UCS_MEMORY_TYPE_CUDA_MANAGED. If the
+     * md does not support mem_dev query, then UCS_MEMORY_TYPE_UNKNOWN is
+     * returned.
+     */
+    ucs_memory_type_t preferred_mem_type;
 } uct_md_mem_attr_t;
 
 

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -279,6 +279,7 @@ protected:
         }
 
         ucs_memtype_cache_update(ptr, size, mem_type,
+                                 UCS_MEMORY_TYPE_LAST,
                                  UCS_SYS_DEVICE_ID_UNKNOWN);
     }
 


### PR DESCRIPTION
## What
Use preferred location if set by user for managed memory region.

## Why ?
If the user sets preferred location, then it is quite likely that memory of pages reside close to preferred location. If this is different from static decision of bounce buffer location, then performance will be sub-optimal for pipeline protocols.