### PR TITLE
UCS/TOPO: Replace numa_distance with sysfs based implementation

### DIFF
--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -16,7 +16,7 @@
 #include <ucs/sys/stubs.h>
 #include <ucs/type/init_once.h>
 
-#define UCS_CPU_CACHE_FILE_FMT   "/sys/devices/system/cpu/cpu%d/cache/index%d/%s"
+#define UCS_CPU_CACHE_FILE_FMT   UCS_SYS_FS_CPUS_PATH "/cpu%d/cache/index%d/%s"
 #define UCS_CPU_CACHE_LEVEL_FILE "level"
 #define UCS_CPU_CACHE_TYPE_FILE  "type"
 #define UCS_CPU_CACHE_SIZE_FILE  "size"

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -187,8 +187,8 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   ucs_offsetof(ucs_global_opts_t, modules), UCS_CONFIG_TYPE_ALLOW_LIST},
 
  {"TOPO_PRIO", "sysfs,default",
-  "Comma-separated list of methods of detecting system topology.\n"
-  "The list order decides the priority of methods used.",
+  "Comma-separated list of providers for detecting system topology.\n"
+  "The list order decides the priority of the providers.",
   ucs_offsetof(ucs_global_opts_t, topo_prio), UCS_CONFIG_TYPE_STRING_ARRAY},
 
  {NULL}

--- a/src/ucs/memory/numa.c
+++ b/src/ucs/memory/numa.c
@@ -10,10 +10,21 @@
 
 #include "numa.h"
 
+#include <ucs/datastruct/khash.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
+#include <ucs/sys/string.h>
+#include <ucs/sys/sys.h>
+#include <ucs/type/spinlock.h>
 #include <stdint.h>
 #include <sched.h>
+#include <dirent.h>
+
+#define UCS_NUMA_NODE_DEFAULT       0
+#define UCS_NUMA_NODE_MAX           UINT16_MAX
+#define UCS_NUMA_CORE_DIR_PATH      UCS_SYS_FS_CPUS_PATH "/cpu%d"
+#define UCS_NUMA_NODES_DIR_PATH     UCS_SYS_FS_SYSTEM_PATH "/node"
+#define UCS_NUMA_NODE_DISTANCE_PATH UCS_NUMA_NODES_DIR_PATH "/node%d/distance"
 
 
 const char *ucs_numa_policy_names[] = {
@@ -22,6 +33,21 @@ const char *ucs_numa_policy_names[] = {
     [UCS_NUMA_POLICY_BIND]      = "bind",
     [UCS_NUMA_POLICY_LAST]      = NULL,
 };
+
+KHASH_MAP_INIT_INT(numa_distance, ucs_numa_distance_t);
+
+typedef struct {
+    unsigned     max_index;
+    const char   *prefix;
+    const size_t prefix_length;
+} ucs_numa_get_max_dirent_ctx_t;
+
+typedef struct {
+    ucs_spinlock_t         lock;
+    khash_t(numa_distance) numa_distance_hash;
+} ucs_numa_global_ctx_t;
+
+static ucs_numa_global_ctx_t ucs_numa_global_ctx;
 
 #if HAVE_NUMA
 
@@ -72,3 +98,213 @@ int ucs_numa_node_of_cpu(int cpu)
 }
 
 #endif
+
+static inline uint32_t ucs_numa_distance_hash_key(const ucs_numa_node_t node1,
+                                                  const ucs_numa_node_t node2)
+{
+    static const uint8_t shift = sizeof(ucs_numa_node_t) * 8;
+
+    return (ucs_max(node1, node2) << shift) | ucs_min(node1, node2);
+}
+
+static ucs_status_t
+ucs_numa_get_max_dirent_cb(const struct dirent *entry, void *arg)
+{
+    ucs_numa_get_max_dirent_ctx_t *ctx = (ucs_numa_get_max_dirent_ctx_t*)arg;
+    unsigned entry_index;
+
+    if (!strncmp(entry->d_name, ctx->prefix, ctx->prefix_length)) {
+        entry_index    = strtoul(entry->d_name + ctx->prefix_length, 0, 0);
+        ctx->max_index = ucs_max(ctx->max_index, entry_index);
+    }
+
+    return UCS_OK;
+}
+
+/**
+ * Iterate the directory entries in @param path of the form
+ * @param prefix<index> and return the maximum index (positive number).
+ *
+ * @param [in]  path          Directory path.
+ * @param [in]  prefix        Consider only entries starting with this prefix.
+ * @param [in]  limit         Maximum legal value of index.
+ * @param [in]  default_value Default value to return in case of an error.
+ *
+ * @return Maximum index of the entries starting with prefix or -1 on error.
+ */
+static int ucs_numa_get_max_dirent(const char *path, const char *prefix,
+                                   unsigned limit, int default_value)
+{
+    ucs_numa_get_max_dirent_ctx_t ctx = {0, prefix, strlen(prefix)};
+
+    if (ucs_sys_readdir(path, ucs_numa_get_max_dirent_cb, &ctx) != UCS_OK) {
+        ucs_debug("failed to parse sysfs dir %s", path);
+        ctx.max_index = default_value;
+    } else if (ctx.max_index >= limit) {
+        ucs_debug("max index %s/%s%u exceeds limit (%d)", path, prefix,
+                  ctx.max_index, limit);
+        ctx.max_index = default_value;
+    }
+
+    return ctx.max_index;
+}
+
+unsigned ucs_numa_num_configured_nodes()
+{
+    static unsigned num_nodes = 0;
+    unsigned max_node;
+
+    if (num_nodes == 0) {
+        max_node  = ucs_numa_get_max_dirent(UCS_NUMA_NODES_DIR_PATH, "node",
+                                            UCS_NUMA_NODE_MAX,
+                                            UCS_NUMA_NODE_DEFAULT);
+        num_nodes = max_node + 1;
+    }
+
+    return num_nodes;
+}
+
+unsigned ucs_numa_num_configured_cpus()
+{
+    static unsigned num_cpus = 0;
+    unsigned max_cpu;
+
+    if (num_cpus == 0) {
+        max_cpu  = ucs_numa_get_max_dirent(UCS_SYS_FS_CPUS_PATH, "cpu",
+                                           __CPU_SETSIZE, 0);
+        num_cpus = max_cpu + 1;
+    }
+
+    return num_cpus;
+}
+
+ucs_numa_node_t ucs_numa_node_of_cpu_v2(int cpu)
+{
+    /* Used for caching to improve perfromance */
+    static ucs_numa_node_t cpu_numa_node[__CPU_SETSIZE] = {0};
+    ucs_numa_node_t node;
+    char core_dir_path[PATH_MAX];
+
+    ucs_assert(cpu < __CPU_SETSIZE);
+
+    if (cpu_numa_node[cpu] == 0) {
+        ucs_snprintf_safe(core_dir_path, PATH_MAX, UCS_NUMA_CORE_DIR_PATH, cpu);
+        node               = ucs_numa_get_max_dirent(core_dir_path, "node",
+                                                     ucs_numa_num_configured_nodes(),
+                                                     UCS_NUMA_NODE_DEFAULT);
+        cpu_numa_node[cpu] = node + 1;
+    }
+
+    return cpu_numa_node[cpu] - 1;
+}
+
+ucs_numa_node_t ucs_numa_node_of_device(const char *dev_path)
+{
+    long parsed_node;
+    ucs_status_t status;
+
+    status = ucs_read_file_number(&parsed_node, 0, "%s/numa_node", dev_path);
+
+    if ((status != UCS_OK) || (parsed_node < 0) ||
+        (parsed_node >= UCS_NUMA_NODE_MAX)) {
+        return UCS_NUMA_NODE_DEFAULT;
+    }
+
+    return parsed_node;
+}
+
+/**
+ * Parse and iterate the distance list of @param source.
+ * For each neighbor of source put distance(source, neighbor)
+ * in @ref numa_distance_hash.
+ *
+ * @param [in]  source source NUMA node
+ * @param [in]  dest   destination NUMA node
+ *
+ * @return Distance from @param source to @param dest
+ */
+static ucs_numa_distance_t
+ucs_numa_node_parse_distances(ucs_numa_node_t source, ucs_numa_node_t dest)
+{
+    ucs_numa_distance_t distance_to_dest = UCS_NUMA_MIN_DISTANCE;
+    ucs_numa_node_t node                 = 0;
+    ucs_numa_distance_t distance;
+    ucs_kh_put_t kh_put_status;
+    khiter_t hash_it;
+    FILE *distance_fp;
+
+    distance_fp = ucs_open_file("r", UCS_LOG_LEVEL_DEBUG,
+                                UCS_NUMA_NODE_DISTANCE_PATH, source);
+    if (distance_fp == NULL) {
+        return distance_to_dest;
+    }
+
+    while ((fscanf(distance_fp, "%u", &distance) > 0) &&
+           (node < UCS_NUMA_NODE_MAX)) {
+        if (distance < UCS_NUMA_MIN_DISTANCE) {
+            ucs_debug("node %u parsed NUMA distance %u is "
+                      "smaller than the lower bound (%u)",
+                      source, distance, UCS_NUMA_MIN_DISTANCE);
+            distance = UCS_NUMA_MIN_DISTANCE;
+        }
+
+        if (node == dest) {
+            distance_to_dest = distance;
+        }
+
+        hash_it = kh_put(numa_distance, &ucs_numa_global_ctx.numa_distance_hash,
+                         ucs_numa_distance_hash_key(source, node),
+                         &kh_put_status);
+        if ((kh_put_status != UCS_KH_PUT_FAILED) &&
+            (kh_put_status != UCS_KH_PUT_KEY_PRESENT)) {
+            kh_value(&ucs_numa_global_ctx.numa_distance_hash,
+                     hash_it) = distance;
+        }
+
+        node++;
+    }
+
+    if (node >= UCS_NUMA_NODE_MAX) {
+        ucs_diag("number of nodes in the system is out of range (%u)",
+                 UCS_NUMA_NODE_MAX);
+    }
+
+    fclose(distance_fp);
+    return distance_to_dest;
+}
+
+ucs_numa_distance_t
+ucs_numa_distance(ucs_numa_node_t node1, ucs_numa_node_t node2)
+{
+    ucs_numa_distance_t distance = UCS_NUMA_MIN_DISTANCE;
+    khiter_t hash_it;
+
+    ucs_assert(node1 < ucs_numa_num_configured_nodes());
+    ucs_assert(node2 < ucs_numa_num_configured_nodes());
+
+    ucs_spin_lock(&ucs_numa_global_ctx.lock);
+    hash_it = kh_get(numa_distance, &ucs_numa_global_ctx.numa_distance_hash,
+                     ucs_numa_distance_hash_key(node1, node2));
+
+    if (ucs_likely(hash_it !=
+                   kh_end(&ucs_numa_global_ctx.numa_distance_hash))) {
+        distance = kh_value(&ucs_numa_global_ctx.numa_distance_hash, hash_it);
+    } else {
+        distance = ucs_numa_node_parse_distances(node1, node2);
+    }
+
+    ucs_spin_unlock(&ucs_numa_global_ctx.lock);
+    return distance;
+}
+
+void ucs_numa_init()
+{
+    ucs_spinlock_init(&ucs_numa_global_ctx.lock, 0);
+    kh_init_inplace(numa_distance, &ucs_numa_global_ctx.numa_distance_hash);
+}
+
+void ucs_numa_cleanup()
+{
+    kh_destroy_inplace(numa_distance, &ucs_numa_global_ctx.numa_distance_hash);
+    ucs_spinlock_destroy(&ucs_numa_global_ctx.lock);
+}

--- a/src/ucs/memory/numa.h
+++ b/src/ucs/memory/numa.h
@@ -11,7 +11,7 @@
 #  include "config.h"
 #endif
 
-#include <ucs/debug/memtrack_int.h>
+#include <stdint.h>
 
 #if HAVE_NUMA
 #include <numaif.h>
@@ -56,10 +56,61 @@ typedef enum {
 } ucs_numa_policy_t;
 
 
+typedef int ucs_numa_distance_t;
+
+
+typedef uint16_t ucs_numa_node_t;
+
+
 extern const char *ucs_numa_policy_names[];
+
+
+void ucs_numa_init();
+
+
+void ucs_numa_cleanup();
 
 
 int ucs_numa_node_of_cpu(int cpu);
 
+
+/**
+ * @return The number of CPU cores in the system.
+ */
+unsigned ucs_numa_num_configured_cpus();
+
+
+/**
+ * @return The number of memory nodes in the system.
+ */
+unsigned ucs_numa_num_configured_nodes();
+
+
+/**
+ * @param [in]  cpu CPU to query.
+ *
+ * @return The NUMA node that the cpu belongs to.
+ */
+ucs_numa_node_t ucs_numa_node_of_cpu_v2(int cpu);
+
+
+/**
+ * @param [in]  dev_path sysfs path of the device.
+ *
+ * @return The node that the device belongs to.
+ */
+ucs_numa_node_t ucs_numa_node_of_device(const char *dev_path);
+
+
+/**
+ * Reports the distance between two nodes according to the machine topology.
+ * 
+ * @param [in]  node1 first NUMA node.
+ * @param [in]  node2 second NUMA node.
+ *
+ * @return NUMA distance between the two NUMA nodes.
+ */
+ucs_numa_distance_t
+ucs_numa_distance(ucs_numa_node_t node1, ucs_numa_node_t node2);
 
 #endif

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -18,6 +18,7 @@
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/memory/memtype_cache.h>
+#include <ucs/memory/numa.h>
 #include <ucs/stats/stats.h>
 #include <ucs/async/async.h>
 #include <ucs/sys/lib.h>
@@ -113,6 +114,7 @@ void UCS_F_CTOR ucs_init()
     }
 
     ucs_async_global_init();
+    ucs_numa_init();
     ucs_topo_init();
     ucs_rand_seed_init();
     ucs_debug("%s loaded at 0x%lx", ucs_sys_get_lib_path(),
@@ -124,6 +126,7 @@ void UCS_F_CTOR ucs_init()
 static void UCS_F_DTOR ucs_cleanup(void)
 {
     ucs_topo_cleanup();
+    ucs_numa_cleanup();
     ucs_async_global_cleanup();
     ucs_profile_cleanup(ucs_profile_default_ctx);
     ucs_debug_cleanup(0);

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1354,6 +1354,16 @@ int ucs_sys_getaffinity(ucs_sys_cpuset_t *cpuset)
     return ret;
 }
 
+ucs_status_t ucs_sys_pthread_getaffinity(ucs_sys_cpuset_t *cpuset)
+{
+    if (pthread_getaffinity_np(pthread_self(), sizeof(*cpuset), cpuset)) {
+        ucs_error("pthread_getaffinity_np() failed: %m");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
 void ucs_sys_cpuset_copy(ucs_cpu_set_t *dst, const ucs_sys_cpuset_t *src)
 {
     int c;
@@ -1479,12 +1489,14 @@ failed_no_mem:
     return res;
 }
 
-static ucs_status_t ucs_sys_enum_threads_cb(struct dirent *entry, void *_ctx)
+static ucs_status_t
+ucs_sys_enum_threads_cb(const struct dirent *entry, void *arg)
 {
-    ucs_sys_enum_threads_t *ctx = (ucs_sys_enum_threads_t*)_ctx;
+    ucs_sys_enum_threads_t *ctx = (ucs_sys_enum_threads_t*)arg;
 
     return strncmp(entry->d_name, ".", 1) ?
-           ctx->cb((pid_t)atoi(entry->d_name), ctx->ctx) : UCS_OK;
+                   ctx->cb((pid_t)atoi(entry->d_name), ctx->ctx) :
+                   UCS_OK;
 }
 
 ucs_status_t ucs_sys_enum_threads(ucs_sys_enum_threads_cb_t cb, void *ctx)

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -63,6 +63,9 @@ typedef cpuset_t ucs_sys_cpuset_t;
 #error "Port me"
 #endif
 
+#define UCS_SYS_FS_SYSTEM_PATH "/sys/devices/system"
+#define UCS_SYS_FS_CPUS_PATH   UCS_SYS_FS_SYSTEM_PATH "/cpu"
+
 
 BEGIN_C_DECLS
 
@@ -108,13 +111,14 @@ typedef void (*ucs_sys_vma_cb_t)(ucs_sys_vma_info_t *info, void *ctx);
 /**
  * Callback function type used in ucs_sys_readdir.
  */
-typedef ucs_status_t (*ucs_sys_readdir_cb_t)(struct dirent *entry, void *ctx);
+typedef ucs_status_t (*ucs_sys_readdir_cb_t)(const struct dirent *entry,
+                                             void *arg);
 
 
 /**
  * Callback function type used in ucs_sys_enum_threads.
  */
-typedef ucs_status_t (*ucs_sys_enum_threads_cb_t)(pid_t pid, void *ctx);
+typedef ucs_status_t (*ucs_sys_enum_threads_cb_t)(pid_t pid, void *arg);
 
 
 /**
@@ -545,6 +549,15 @@ int ucs_sys_setaffinity(ucs_sys_cpuset_t *cpuset);
 int ucs_sys_getaffinity(ucs_sys_cpuset_t *cpuset);
 
 /**
+ * Queries affinity for the current thread.
+ *
+ * @param [out] cpuset      Pointer to the cpuset to return result
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucs_sys_pthread_getaffinity(ucs_sys_cpuset_t *cpuset);
+
+/**
  * Copies ucs_sys_cpuset_t to ucs_cpu_set_t.
  *
  * @param [in]  src         Source
@@ -614,7 +627,7 @@ ucs_status_t ucs_sys_readdir(const char *path, ucs_sys_readdir_cb_t cb, void *ct
  *       returns value different from UCS_OK then function breaks
  *       immediately and this value is returned from ucs_sys_enum_threads.
  */
-ucs_status_t ucs_sys_enum_threads(ucs_sys_enum_threads_cb_t cb, void *ctx);
+ucs_status_t ucs_sys_enum_threads(ucs_sys_enum_threads_cb_t cb, void *arg);
 
 
 /**

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -8,6 +8,8 @@
 #  include "config.h"
 #endif
 
+#include <ucs/memory/numa.h>
+#include <ucs/sys/math.h>
 #include <ucs/sys/topo/base/topo.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
@@ -27,6 +29,40 @@
 #define UCS_TOPO_SYSFS_DEVICES_ROOT  "/sys/devices"
 #define UCS_TOPO_DEVICE_NAME_UNKNOWN "<unknown>"
 #define UCS_TOPO_DEVICE_NAME_INVALID "<invalid>"
+
+/*
+ * Function pointer used to refer to specific implementations of
+ * ucs_topo_get_memory_distance function by topology modules.
+ * This function estimates the distance between the device and the system
+ * memory used by the current thread according to its CPU affinity.
+ */
+typedef ucs_status_t (*ucs_topo_get_memory_distance_func_t)(
+        ucs_sys_device_t device, ucs_sys_dev_distance_t *distance);
+
+/*
+ * Topology API.
+ */
+typedef struct {
+    /* Provider's ucs_topo_get_distance implementation */
+    ucs_topo_get_distance_func_t        get_distance;
+
+    /* Provider's ucs_topo_get_memory_distance implementation */
+    ucs_topo_get_memory_distance_func_t get_memory_distance;
+} ucs_sys_topo_ops_t;
+
+
+/*
+ * Structure needed to define a topology module implementation
+ */
+typedef struct {
+    /* Name of the topology module */
+    const char         *name;
+
+    /* provider's ops */
+    ucs_sys_topo_ops_t ops;
+
+    ucs_list_link_t    list;
+} ucs_sys_topo_provider_t;
 
 typedef int64_t ucs_bus_id_bit_rep_t;
 
@@ -50,35 +86,44 @@ const ucs_sys_dev_distance_t ucs_topo_default_distance = {
     .latency   = 0,
     .bandwidth = DBL_MAX
 };
+
 static ucs_topo_global_ctx_t ucs_topo_global_ctx;
 
 
 /* Global list of topology detectors */
-UCS_LIST_HEAD(ucs_sys_topo_methods_list);
+UCS_LIST_HEAD(ucs_sys_topo_providers_list);
 
 
-static ucs_sys_topo_method_t *ucs_sys_topo_get_method()
+/* According to NUMA distance definition distances are normalized to 10
+ * and the relative distance correlates with the latency.
+ * The following translation formula assumes that
+ * access to main memory takes 100ns */
+static inline double ucs_topo_sysfs_numa_distance_to_latency(double distance)
 {
-    static ucs_sys_topo_method_t *method = NULL;
-    ucs_sys_topo_method_t *list_method;
+    return distance * 10e-9;
+}
+
+static ucs_sys_topo_provider_t *ucs_sys_topo_get_provider()
+{
+    static ucs_sys_topo_provider_t *provider = NULL;
+    ucs_sys_topo_provider_t *list_provider;
     unsigned i;
 
-    if (method != NULL) {
-        return method;
+    if (provider != NULL) {
+        return provider;
     }
 
     for (i = 0; i < ucs_global_opts.topo_prio.count; ++i) {
-
-        ucs_list_for_each(list_method, &ucs_sys_topo_methods_list, list) {
+        ucs_list_for_each(list_provider, &ucs_sys_topo_providers_list, list) {
             if (!strcmp(ucs_global_opts.topo_prio.names[i],
-                        list_method->name)) {
-                method = list_method;
-                return method;
+                        list_provider->name)) {
+                provider = list_provider;
+                return provider;
             }
         }
     }
 
-    return method;
+    return provider;
 }
 
 static ucs_status_t
@@ -91,18 +136,38 @@ ucs_topo_get_distance_default(ucs_sys_device_t device1,
     return UCS_OK;
 }
 
-static ucs_sys_topo_method_t ucs_sys_topo_default_method = {
-    .name         = "default",
-    .get_distance = ucs_topo_get_distance_default,
+static ucs_status_t
+ucs_topo_get_memory_distance_default(ucs_sys_device_t device,
+                                     ucs_sys_dev_distance_t *distance)
+{
+    *distance = ucs_topo_default_distance;
+
+    return UCS_OK;
+}
+
+static ucs_sys_topo_provider_t ucs_sys_topo_provider_default = {
+    .name = "default",
+    .ops = {
+        .get_distance        = ucs_topo_get_distance_default,
+        .get_memory_distance = ucs_topo_get_memory_distance_default,
+    }
 };
 
 ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
                                    ucs_sys_device_t device2,
                                    ucs_sys_dev_distance_t *distance)
 {
-    ucs_sys_topo_method_t *method = ucs_sys_topo_get_method();
+    const ucs_sys_topo_provider_t *provider = ucs_sys_topo_get_provider();
 
-    return method->get_distance(device1, device2, distance);
+    return provider->ops.get_distance(device1, device2, distance);
+}
+
+ucs_status_t ucs_topo_get_memory_distance(ucs_sys_device_t device,
+                                          ucs_sys_dev_distance_t *distance)
+{
+    const ucs_sys_topo_provider_t *provider = ucs_sys_topo_get_provider();
+
+    return provider->ops.get_memory_distance(device, distance);
 }
 
 static ucs_bus_id_bit_rep_t
@@ -236,7 +301,7 @@ static int ucs_topo_is_sys_root(const char *path)
 static int ucs_topo_is_pci_root(const char *path)
 {
     int count;
-    sscanf(path, UCS_TOPO_SYSFS_DEVICES_ROOT "/pci%*d:%*d%n", &count);
+    sscanf(path, UCS_TOPO_SYSFS_DEVICES_ROOT "/pci%*x:%*x%n", &count);
     return count == strlen(path);
 }
 
@@ -302,6 +367,55 @@ ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
     } else {
         *distance = ucs_topo_default_distance;
     }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucs_topo_get_memory_distance_sysfs(ucs_sys_device_t device,
+                                   ucs_sys_dev_distance_t *distance)
+{
+    double total_distance = 0;
+    int full_affinity     = 0;
+    ucs_sys_cpuset_t thread_cpuset;
+    unsigned cpu, num_cpus, cpuset_size;
+    char path[PATH_MAX];
+    ucs_numa_node_t dev_node;
+    ucs_status_t status;
+
+    /* If the device is unknown, we assume min distance */
+    if (device == UCS_SYS_DEVICE_ID_UNKNOWN) {
+        return ucs_topo_get_memory_distance_default(device, distance);
+    }
+
+    status = ucs_topo_get_sysfs_path(device, path, sizeof(path));
+    if (status != UCS_OK) {
+        return ucs_topo_get_memory_distance_default(device, distance);
+    }
+
+    status = ucs_sys_pthread_getaffinity(&thread_cpuset);
+    if (status != UCS_OK) {
+        /* If we failed to read thread affinity distance is calculated
+         * for a process with full CPU affinity */
+        full_affinity = 1;
+    }
+
+    dev_node = ucs_numa_node_of_device(path);
+    num_cpus = ucs_numa_num_configured_cpus();
+    for (cpu = 0; cpu < num_cpus; ++cpu) {
+        if (!full_affinity && !CPU_ISSET(cpu, &thread_cpuset)) {
+            continue;
+        }
+
+        total_distance += ucs_numa_distance(dev_node,
+                                            ucs_numa_node_of_cpu_v2(cpu));
+    }
+
+    /* Calculate root distance to get the correct BW value */
+    ucs_topo_sys_root_distance(distance);
+    cpuset_size       = full_affinity ? num_cpus : CPU_COUNT(&thread_cpuset);
+    distance->latency = ucs_topo_sysfs_numa_distance_to_latency(total_distance /
+                                                                cpuset_size);
 
     return UCS_OK;
 }
@@ -462,9 +576,12 @@ void ucs_topo_print_info(FILE *stream)
     }
 }
 
-static ucs_sys_topo_method_t ucs_sys_topo_sysfs_method = {
-    .name         = "sysfs",
-    .get_distance = ucs_topo_get_distance_sysfs,
+static ucs_sys_topo_provider_t ucs_sys_topo_provider_sysfs = {
+    .name = "sysfs",
+    .ops = {
+        .get_distance        = ucs_topo_get_distance_sysfs,
+        .get_memory_distance = ucs_topo_get_memory_distance_sysfs,
+    }
 };
 
 void ucs_topo_init()
@@ -472,18 +589,18 @@ void ucs_topo_init()
     ucs_spinlock_init(&ucs_topo_global_ctx.lock, 0);
     kh_init_inplace(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash);
     ucs_topo_global_ctx.num_devices = 0;
-    ucs_list_add_tail(&ucs_sys_topo_methods_list,
-                      &ucs_sys_topo_default_method.list);
-    ucs_list_add_tail(&ucs_sys_topo_methods_list,
-                      &ucs_sys_topo_sysfs_method.list);
+    ucs_list_add_tail(&ucs_sys_topo_providers_list,
+                      &ucs_sys_topo_provider_default.list);
+    ucs_list_add_tail(&ucs_sys_topo_providers_list,
+                      &ucs_sys_topo_provider_sysfs.list);
 }
 
 void ucs_topo_cleanup()
 {
     ucs_topo_sys_device_info_t *device;
 
-    ucs_list_del(&ucs_sys_topo_sysfs_method.list);
-    ucs_list_del(&ucs_sys_topo_default_method.list);
+    ucs_list_del(&ucs_sys_topo_provider_sysfs.list);
+    ucs_list_del(&ucs_sys_topo_provider_default.list);
 
     while (ucs_topo_global_ctx.num_devices-- > 0) {
         device = &ucs_topo_global_ctx.devices[ucs_topo_global_ctx.num_devices];

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -67,23 +67,8 @@ typedef ucs_status_t
                                 ucs_sys_dev_distance_t *distance);
 
 
-/*
- * Structure needed to define a topology module implementation
- */
-typedef struct {
-
-    /* Name of the topology module */
-    const char                   *name;
-
-    /* Points to the module's ucs_topo_get_distance implementation */
-    ucs_topo_get_distance_func_t get_distance;
-
-    ucs_list_link_t              list;
-} ucs_sys_topo_method_t;
-
-
 /* Global list of topology detection methods */
-extern ucs_list_link_t ucs_sys_topo_methods_list;
+extern ucs_list_link_t ucs_sys_topo_providers_list;
 
 
 /**
@@ -117,13 +102,25 @@ ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
  * @param [in]  device1   System device index of the first device.
  * @param [in]  device2   System device index of the second device.
  * @param [out] distance  Result populated with distance details between the two
-*                         devices.
+ *                        devices.
  *
  * @return UCS_OK or error in case distance cannot be determined.
  */
 ucs_status_t ucs_topo_get_distance(ucs_sys_device_t device1,
                                    ucs_sys_device_t device2,
                                    ucs_sys_dev_distance_t *distance);
+
+
+/**
+ * Find the memory distance of the device according to process affinity.
+ *
+ * @param [in]  device   System device index.
+ * @param [out] distance Result populated with the device memory distance.
+ *
+ * @return UCS_OK or error in case distance cannot be determined.
+ */
+ucs_status_t ucs_topo_get_memory_distance(ucs_sys_device_t device,
+                                          ucs_sys_dev_distance_t *distance);
 
 
 /**
@@ -192,6 +189,7 @@ ucs_topo_find_device_by_bdf_name(const char *name, ucs_sys_device_t *sys_dev);
 ucs_status_t ucs_topo_sys_device_set_name(ucs_sys_device_t sys_dev,
                                           const char *name, unsigned priority);
 
+
 /**
  * Calculates and returns a specific PCIe device BW.
  *
@@ -202,11 +200,12 @@ ucs_status_t ucs_topo_sys_device_set_name(ucs_sys_device_t sys_dev,
  */
 double ucs_topo_get_pci_bw(const char *dev_name, const char *sysfs_path);
 
+
 /**
  * Get the name of a given system device. If the name was never set, it defaults
  * to the BDF representation of the system device bus id.
  *
- * @param [in]  sys_dev  System device to set the name for.
+ * @param [in]  sys_dev System device's name to get.
  *
  * @return The name of the system device, or NULL if the system device is
  *         invalid.

--- a/src/ucs/ucx-ucs.pc.in
+++ b/src/ucs/ucx-ucs.pc.in
@@ -15,4 +15,4 @@ Description: Unified Communication X Library UCS module
 Version: @VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lucs -lucm
-Libs.private: -Wl,--undefined=ucs_init @BFD_LIBS@ @BFD_LDFLAGS@ @BFD_DEPS@ -ldl -lrt -lm -pthread
+Libs.private: -Wl,--undefined=ucs_init @BFD_LIBS@ @BFD_LDFLAGS@ @BFD_DEPS@ -ldl -lrt -lm -pthread @NUMA_LIBS@

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -365,11 +365,9 @@ uct_ib_md_handle_mr_list_multithreaded(uct_ib_md_t *md, void *address,
     char UCS_V_UNUSED affinity_str[64];
     int ret;
 
-    ret = pthread_getaffinity_np(pthread_self(), sizeof(ucs_sys_cpuset_t),
-                                 &parent_set);
-    if (ret != 0) {
-        ucs_error("pthread_getaffinity_np() failed: %m");
-        return UCS_ERR_INVALID_PARAM;
+    status = ucs_sys_pthread_getaffinity(&parent_set);
+    if (status != UCS_OK) {
+        return status;
     }
 
     thread_num = ucs_min(CPU_COUNT(&parent_set), mr_num);

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -6,6 +6,8 @@
 
 #include <common/test.h>
 extern "C" {
+#include <ucs/memory/numa.h>
+#include <ucs/sys/sys.h>
 #include <ucs/sys/topo/base/topo.h>
 }
 
@@ -127,4 +129,25 @@ UCS_TEST_F(test_topo, bdf_name_invalid) {
 
     status = ucs_topo_find_device_by_bdf_name("1:2:3", &sys_dev);
     EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+}
+
+UCS_TEST_F(test_topo, numa_distance) {
+    ucs_numa_node_t num_of_nodes;
+
+    num_of_nodes = ucs_numa_num_configured_nodes();
+    for (auto node1 = 0; node1 < num_of_nodes; ++node1) {
+        for (auto node2 = 0; node2 < num_of_nodes; ++node2) {
+            UCS_TEST_MESSAGE << "Test distance: node" << node1 << " to node"
+                             << node2;
+            if (node1 == node2) {
+                EXPECT_EQ(ucs_numa_distance(node1, node2), 10);
+            } else {
+                EXPECT_EQ(ucs_numa_distance(node1, node2),
+                          ucs_numa_distance(node2, node1));
+            }
+            
+            EXPECT_LE(ucs_numa_distance(node1, node1),
+                      ucs_numa_distance(node1, node2));
+        }
+    }
 }


### PR DESCRIPTION
## What
Implement `numa_distance` function to calculate the distance between IB devices and CPU's NUMA node.

## Why ?
- Remove UCX `libnuma` dependency

## How ?
- Extend Topo providers API to include method for calculating NUMA distance between IB devices and CPU's NUMA node.
- Remove/Replace `libnuma` dependent code.
- Remove `libnuma` from UCX
