### PR TITLE
UCP: Fix ep config info trace

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1918,7 +1918,7 @@ void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
         ucs_string_buffer_appendf(strb, "inter-node ");
     }
 
-    ucs_string_buffer_appendf(strb, "cfg#%d", cfg_index);
+    ucs_string_buffer_appendf(strb, "cfg#%d ", cfg_index);
 }
 
 static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,


### PR DESCRIPTION
## What
Fix  ucp ep config INFO trace

## Why ?
before
```
ucp_worker.c:1784 UCX  INFO    0x2d96740 self cfg#1tag(sysv/memory cma/memory cuda_copy/cuda) rma(sysv/memory)
ucp_worker.c:1784 UCX  INFO    0x2d96740 intra-node cfg#2tag(sysv/memory cma/memory) rma(sysv/memory)
ucp_worker.c:1784 UCX  INFO    0x2a719d0 self cfg#1tag(sysv/memory cma/memory cuda_copy/cuda) rma(sysv/memory)
ucp_worker.c:1784 UCX  INFO    0x2a719d0 intra-node cfg#2tag(sysv/memory cma/memory) rma(sysv/memory)
```

after
```
ucp_worker.c:1784 UCX  INFO    0x252d990 self cfg#1 tag(sysv/memory cma/memory cuda_copy/cuda) rma(sysv/memory)
ucp_worker.c:1784 UCX  INFO    0x252d990 intra-node cfg#2 tag(sysv/memory cma/memory) rma(sysv/memory)
ucp_worker.c:1784 UCX  INFO    0x1018750 self cfg#1 tag(sysv/memory cma/memory cuda_copy/cuda) rma(sysv/memory)
ucp_worker.c:1784 UCX  INFO    0x1018750 intra-node cfg#2 tag(sysv/memory cma/memory) rma(sysv/memory)
```