### PR TITLE
UCP/CORE: fix corner case for rkey_index - v.14.x

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -451,7 +451,8 @@ static uint8_t ucp_rndv_get_rkey_index(ucp_request_t *rndv_req, ucp_rkey_h rkey,
     uint8_t mem_type            = rndv_req->send.mem_type;
     uct_md_attr_v2_t *md_attr;
 
-    if ((md_index == UCP_NULL_RESOURCE) || (rkey == NULL)) {
+    if ((md_index == UCP_NULL_RESOURCE) || (rkey == NULL) ||
+        !(UCS_BIT(dst_md_index) & rkey->md_map)) {
         return UCP_NULL_RESOURCE;
     }
 


### PR DESCRIPTION
## What
fix a corner case for calculating the rkey_index in case the md_index is not part of the md_map.

## Why ?
Fixes issue https://github.com/openucx/ucx/issues/8627

## How ?
(cherry picked from commit 2034fbc0b911f7ccb3601312f090d28e11f30c6a)