### PR TITLE
UCP/PROTOV2: Pack rkey in rts/rtr when CMA is present

### DIFF
--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -101,7 +101,8 @@ static UCS_F_ALWAYS_INLINE size_t ucp_proto_rndv_rts_pack(
     rts->size        = req->send.state.dt_iter.length;
     rpriv            = req->send.proto_config->priv;
 
-    if ((rts->size == 0) || (rpriv->md_map == 0)) {
+    if ((rts->size == 0) ||
+        (req->send.state.dt_iter.dt_class != UCP_DATATYPE_CONTIG)) {
         rts->address = 0;
         rkey_size    = 0;
     } else {

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -216,10 +216,10 @@ ucp_proto_rndv_rtr_init(const ucp_proto_init_params_t *init_params)
 
     rpriv->data_received = ucp_proto_rndv_rtr_data_received;
 
-    if (rpriv->super.md_map == 0) {
-        rpriv->pack_cb = ucp_proto_rndv_rtr_pack_without_rkey;
-    } else {
+    if (init_params->select_param->dt_class == UCP_DATATYPE_CONTIG) {
         rpriv->pack_cb = ucp_proto_rndv_rtr_pack_with_rkey;
+    } else {
+        rpriv->pack_cb = ucp_proto_rndv_rtr_pack_without_rkey;
     }
 
     return UCS_OK;


### PR DESCRIPTION
## What
Pack rkey to RTR/RTS if CMA transport is present

## Why ?
Enable CMA for rendezvous transports when it is the only RMA capable transport on the system.
This way rndv pipeline protocol based on CMA can be selected when transferring data from device to host.
Gives ~10x speedup with `osu_bw -d cuda D H` and UCX_TLS=`sysv,cma,cuda_copy`
OR about 15% speedup with host memory


