### PR TITLE
TOOLS\PERF: Bump address size

### DIFF
--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -27,7 +27,7 @@ BEGIN_C_DECLS
 
 #define TIMING_QUEUE_SIZE    2048
 #define UCT_PERF_TEST_AM_ID  5
-#define ADDR_BUF_SIZE        2048
+#define ADDR_BUF_SIZE        4096
 #define EXTRA_INFO_SIZE      256
 
 #define UCX_PERF_TEST_FOREACH(perf) \


### PR DESCRIPTION
## What
Bump the buffer size for receiving ucp_address_t data in the perf library.

## Why ?
Came across a system that makes 3KB ucp_address_t structs. It has 18 ROCe ports. So it blows up the perf assert(). Fixable by passing params like UCX_UNIFIED_MODE, but blowing up with the default env is not good.

## How ?
Bump the address size macro.
