### PR TITLE
AZP: report roce_proto_enable failures as errors

### DIFF
--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -30,12 +30,7 @@ jobs:
           source ./buildlib/az-helpers.sh
           az_init_modules
           ./contrib/test_jenkins.sh
-          rc=$?
-          if [[ $rc != 0 && x'${{ parameters.proto_enable }}' == x'yes' ]]; then
-            azure_complete_with_issues "Test with PROTO_ENABLE=yes exit with expected error"
-          else
-            exit $rc
-          fi
+          exit $?
         displayName: Run ./contrib/test_jenkins.sh
         env:
           nworkers: ${{ parameters.num_workers }}


### PR DESCRIPTION
## What
report `roce_proto_enable` failures as errors

## Why ?
to highlight regressions
