### PR TITLE
UCT/MLX5: is_hw_owned simplification

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -211,15 +211,6 @@ void uct_ib_mlx5_fill_cq_common(uct_ib_mlx5_cq_t *cq,  unsigned cq_size,
 
     cq->cq_length_mask = UCS_MASK(cq->cq_length_log);
 
-    if (cq->zip) {
-        /* signature is in union with validity_iteration_count */
-        cq->own_field_offset = ucs_offsetof(struct mlx5_cqe64, signature);
-        cq->own_mask         = 0xff;
-    } else {
-        cq->own_field_offset = ucs_offsetof(struct mlx5_cqe64, op_own);
-        cq->own_mask         = MLX5_CQE_OWNER_MASK;
-    }
-
     /* Set owner bit for all CQEs, so that CQE would look like it is in HW
      * ownership. In this case CQ polling functions will return immediately if
      * no any CQE ready, there is no need to check opcode for

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -437,8 +437,6 @@ typedef struct uct_ib_mlx5_cq {
     void                   *uar;
     volatile uint32_t      *dbrec;
     int                    zip;
-    unsigned               own_field_offset;
-    unsigned               own_mask;
     uct_ib_mlx5_cq_unzip_t cq_unzip;
     union {
         struct {

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -28,14 +28,10 @@ static UCS_F_ALWAYS_INLINE int
 uct_ib_mlx5_cqe_is_hw_owned(uct_ib_mlx5_cq_t *cq, struct mlx5_cqe64 *cqe,
                             unsigned cqe_index, int poll_flags)
 {
-    uint8_t sw_it_count = cqe_index >> cq->cq_length_log;
-    uint8_t hw_it_count;
-
     if (poll_flags & UCT_IB_MLX5_POLL_FLAG_CQE_ZIP) {
-        hw_it_count = ((uint8_t *)cqe)[cq->own_field_offset];
-        return (sw_it_count ^ hw_it_count) & cq->own_mask;
+        return ((cqe_index >> cq->cq_length_log) ^ cqe->signature);
     } else {
-        return (sw_it_count ^ cqe->op_own) & MLX5_CQE_OWNER_MASK;
+        return ((cqe_index >> cq->cq_length_log) ^ cqe->op_own) & MLX5_CQE_OWNER_MASK;
     }
 }
 


### PR DESCRIPTION
## What
Minor `uct_ib_mlx5_cqe_is_hw_owned` simplification.
