### PR TITLE
Pass user-provided memory type to inline send check

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -596,11 +596,13 @@ ucp_proto_get_short_max(const ucp_request_t *req,
 
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_is_inline(ucp_ep_h ep, const ucp_memtype_thresh_t *max_eager_short,
-                    ssize_t length)
+                    ssize_t length, const ucp_request_param_t *param)
 {
     return (ucs_likely(length <= max_eager_short->memtype_off) ||
-            (length <= max_eager_short->memtype_on &&
-             ucs_memtype_cache_is_empty()));
+            ((length <= max_eager_short->memtype_on) &&
+             (ucs_memtype_cache_is_empty() ||
+              ((param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) &&
+               (param->memory_type == UCS_MEMORY_TYPE_HOST)))));
 }
 
 static UCS_F_ALWAYS_INLINE ucp_request_t*


### PR DESCRIPTION
## What
Pass user-provided memory type to the function that checks whether the buffer can be sent inline or not.

## Why ?
Inline send can be done for host memory only and we don't detect memory type in inline send path due to overheads. Therefore, on a GPU system, inline send is never used even for host memory buffers. However, if the memory type is already provided by the user and it is host memory, we can try inline send without any extra overhead.


## How ?
Pass the user-provided memory type to the function that checks whether the buffer can be sent inline or not.
Pass UCS_MEMORY_TYPE_UNKNOWN if user has not provided memory type.
