### PR TITLE
UCP/PROTO: workaround in error handling of rndv/get/zcopy

### DIFF
--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -198,8 +198,12 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
         break;
     case UCP_PROTO_RNDV_GET_STAGE_ATS:
         rreq = ucp_request_get_super(request);
-        /* Locally the data is received, can complete with OK */
         ucs_assert(rreq->recv.length == rreq->recv.tag.info.length);
+        /* Locally the data is received, can complete with OK, but memory
+         * invalidation is not implemented in DC, so need to fail request to
+         * avoid data corruption.
+         * FIXME: del next line when memory invalidation in DC is implemented */
+        ucp_request_get_super(request)->status = status;
         ucp_proto_rndv_recv_complete(request);
         break;
     default:


### PR DESCRIPTION
## What
fixes occasional failures of `dc_ud/test_ucp_sockaddr.force_close_during_rndv/*`
DC transport has missed memory invalidation on peer failure, so fail recv request on RTS failure even if get op was completed successfully.

## Why ?
https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/54652/logs/661
```
022-11-25T08:41:49.3071833Z [ RUN      ] dc_ud/test_ucp_sockaddr.force_close_during_rndv/2 <dc_x,ud_v,ud_x,mm/tag,sa_data_v2>
2022-11-25T08:41:49.6986992Z [     INFO ] Testing 2.1.5.4:0
2022-11-25T08:41:49.6990398Z [     INFO ] server listening on 2.1.5.4:47232
2022-11-25T08:41:50.2242459Z [     INFO ] ignoring error Connection reset by remote peer on endpoint 0x7f7b0676c000
2022-11-25T08:41:50.2249023Z /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/mem_buffer.cc:245: Failure
2022-11-25T08:41:50.2249917Z Pattern check failed at 0x3604000 offset 0: Expected: 0x1 Actual: 0x0
2022-11-25T08:41:50.2251453Z [1669365710.224890] [swx-rain04:428799:0]           mpool.c:55   UCX  WARN  object 0x109d5080 {flags:0x45 tag_send from host memory length 4096 rendezvous zero-copy read from remote dc_mlx5/mlx5_bond_1:1 50% on path0 and was not returned to mpool ucp_requests
2022-11-25T08:41:50.2445254Z [1669365710.244313] [swx-rain04:428799:0]           mpool.c:55   UCX  WARN  object 0x3db1fc0 {flags:0x400084 rndv_recv into host memory length 4096 zero-copy read from remote dc_mlx5/mlx5_bond_1:1 50% on path0 and 50% o was not returned to mpool ucp_requests
2022-11-25T08:41:50.2447190Z [1669365710.244332] [swx-rain04:428799:0]           mpool.c:55   UCX  WARN  object 0x3db2100 {flags:0x20041 rndv_recv into host memory length 4096 zero-copy read from remote dc_mlx5/mlx5_bond_1:1 50% on path0 and 50% on was not returned to mpool ucp_requests
2022-11-25T08:41:50.2596719Z [1669365710.259401] [swx-rain04:428799:0]        rc_iface.c:481  UCX  WARN  rc_iface 0xd5b5180: 1/9216 send ops were not released
2022-11-25T08:41:50.2629785Z [1669365710.262779] [swx-rain04:428799:0]        spinlock.c:29   UCX  WARN  ucs_recursive_spinlock_destroy() failed: busy
2022-11-25T08:41:50.2780545Z /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/test.cc:366: Failure
2022-11-25T08:41:50.2781377Z Failed
2022-11-25T08:41:50.2781834Z Got 0 errors and 5 warnings during the test
2022-11-25T08:41:50.2783135Z [     INFO ] < /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../src/ucs/datastruct/mpool.c:55 object 0x109d5080 {flags:0x45 tag_send from host memory length 4096 rendezvous zero-copy read from remote dc_mlx5/mlx5_bond_1:1 50% on path0 and was not returned to mpool ucp_requests >
2022-11-25T08:41:50.2784934Z [     INFO ] < /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../src/ucs/datastruct/mpool.c:55 object 0x3db1fc0 {flags:0x400084 rndv_recv into host memory length 4096 zero-copy read from remote dc_mlx5/mlx5_bond_1:1 50% on path0 and 50% o was not returned to mpool ucp_requests >
2022-11-25T08:41:50.2786691Z [     INFO ] < /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../src/ucs/datastruct/mpool.c:55 object 0x3db2100 {flags:0x20041 rndv_recv into host memory length 4096 zero-copy read from remote dc_mlx5/mlx5_bond_1:1 50% on path0 and 50% on was not returned to mpool ucp_requests >
2022-11-25T08:41:50.2788085Z [     INFO ] < /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../src/uct/ib/rc/base/rc_iface.c:481 rc_iface 0xd5b5180: 1/9216 send ops were not released >
2022-11-25T08:41:50.2789458Z [     INFO ] < /scrap/azure/agent-08/AZP_WORKSPACE/2/s/contrib/../src/ucs/type/spinlock.c:29 ucs_recursive_spinlock_destroy() failed: busy >
2022-11-25T08:41:50.2790355Z [  FAILED  ] dc_ud/test_ucp_sockaddr.force_close_during_rndv/2, where GetParam() = dc_x,ud_v,ud_x,mm/tag,sa_data_v2 (971 ms)
```
