### PR TITLE
UCT/IB: remove unused code used to support exp verbs

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
@@ -84,11 +84,6 @@ void uct_ib_mlx5dv_qp_init_attr(uct_ib_qp_init_attr_t *qp_init_attr,
  */
 void uct_ib_mlx5_get_av(struct ibv_ah *ah, struct mlx5_wqe_av *av);
 
-/**
- * Backports for legacy bare-metal support
- */
-struct ibv_qp *uct_dv_get_cmd_qp(struct ibv_srq *srq);
-
 void *uct_dv_get_info_uar0(void *uar);
 
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -400,18 +400,11 @@ static ucs_status_t
 uct_rc_mlx5_get_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
 {
     struct ibv_qp *qp;
-#ifdef HAVE_STRUCT_MLX5_SRQ_CMD_QP
-    iface->tm.cmd_wq.super.super.verbs.qp = NULL;
-    iface->tm.cmd_wq.super.super.verbs.rd = NULL;
-    iface->tm.cmd_wq.super.super.type     = UCT_IB_MLX5_OBJ_TYPE_LAST;
-    qp = uct_dv_get_cmd_qp(iface->rx.srq.verbs.srq);
-#else
     if (iface->rx.srq.type == UCT_IB_MLX5_OBJ_TYPE_DEVX) {
         return uct_rc_mlx5_devx_create_cmd_qp(iface);
     } else {
         qp = uct_rc_mlx5_verbs_create_cmd_qp(iface);
     }
-#endif
     iface->tm.cmd_wq.super.super.qp_num = qp->qp_num;
     return uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
                                  iface->tx.mmio_mode,


### PR DESCRIPTION
exp verbs were removed, remove this piece of unused code.

Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>

## What
remove exp verbs related code

## Why ?
exp verbs were removed at https://github.com/openucx/ucx/pull/8102 & https://github.com/openucx/ucx/pull/8158 & https://github.com/openucx/ucx/pull/8231
