### PR TITLE
UCM: avoid reading unnecessary header file

### DIFF
--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -16,7 +16,6 @@
 
 #include <ucm/api/ucm.h>
 #include <ucm/util/log.h>
-#include <ucm/util/reloc.h>
 #include <ucm/mmap/mmap.h>
 #include <ucm/malloc/malloc_hook.h>
 #include <ucs/type/init_once.h>


### PR DESCRIPTION
Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>

## What
Do not read unnecessary header file

## Why ?
Decrease  preprocess time without reading unnecessary file
