### PR TITLE
UCS: enable remove unused function by linker

### DIFF
--- a/src/ucm/util/reloc.h
+++ b/src/ucm/util/reloc.h
@@ -51,8 +51,8 @@ ucs_status_t ucm_reloc_modify(ucm_reloc_patch_t* patch);
  *
  * @return Original function pointer for 'symbol'.
  */
-static void* UCS_F_MAYBE_UNUSED
-ucm_reloc_get_orig(const char *symbol, void *replacement)
+static UCS_F_MAYBE_UNUSED
+void* ucm_reloc_get_orig(const char *symbol, void *replacement)
 {
     const char *error;
     void *func_ptr;

--- a/src/ucs/datastruct/ptr_array.c
+++ b/src/ucs/datastruct/ptr_array.c
@@ -80,7 +80,8 @@ ucs_ptr_array_freelist_element_set_free_ahead(ucs_ptr_array_elem_t *elem,
                                        ucs_ptr_array_freelist_get_next(*elem));
 }
 
-static void UCS_F_MAYBE_UNUSED ucs_ptr_array_dump(ucs_ptr_array_t *ptr_array)
+static UCS_F_MAYBE_UNUSED
+void ucs_ptr_array_dump(ucs_ptr_array_t *ptr_array)
 {
 #if UCS_ENABLE_ASSERT
     unsigned i;

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -49,8 +49,10 @@
 #define UCS_F_CTOR __attribute__((constructor))
 #define UCS_F_DTOR __attribute__((destructor))
 
-/* Silence "defined but not used" error for static function */
-#define UCS_F_MAYBE_UNUSED __attribute__((used))
+/* Silence "defined but not used" error for static function,
+ * remove it by linker if it's not used at all.
+ */
+#define UCS_F_MAYBE_UNUSED __attribute__((unused))
 
 /* Non-null return */
 #define UCS_F_NON_NULL __attribute__((nonnull))

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -610,7 +610,7 @@ uct_ib_mlx5_srq_get_wqe(uct_ib_mlx5_srq_t *srq, uint16_t wqe_index)
     return UCS_PTR_BYTE_OFFSET(srq->buf, (wqe_index & srq->mask) * srq->stride);
 }
 
-static void UCS_F_MAYBE_UNUSED
+static UCS_F_MAYBE_UNUSED void
 uct_ib_mlx5_iface_fill_attr(uct_ib_iface_t *iface,
                             uct_ib_mlx5_qp_t *qp,
                             uct_ib_mlx5_qp_attr_t *attr)

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -265,8 +265,8 @@ static ucs_stats_class_t uct_rc_mlx5_tag_stats_class = {
 #  endif
 
 
-static ucs_status_t UCS_F_MAYBE_UNUSED
-uct_rc_mlx5_devx_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
+static UCS_F_MAYBE_UNUSED
+ucs_status_t uct_rc_mlx5_devx_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
 {
     uct_ib_mlx5_md_t *md = uct_ib_mlx5_iface_md(&iface->super.super);
     uct_ib_device_t *dev = &md->super.dev;
@@ -312,7 +312,7 @@ err_destroy_qp:
     return status;
 }
 
-static struct ibv_qp * UCS_F_MAYBE_UNUSED
+static UCS_F_MAYBE_UNUSED struct ibv_qp*
 uct_rc_mlx5_verbs_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
 {
     uct_ib_md_t *md = uct_ib_iface_md(&iface->super.super);


### PR DESCRIPTION
"__attribute__((used))" prevents the compiler from generating warnings if the function is not referenced and avoids being removed by linker.
"__attribute__((unsed))" does not change the behavior of the unused function removal process .i.e. linker could remove the unused function.

Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>

## What
remove unused functions from the generated executable file.