### PR TITLE
UCP/MM: Fix passing uct_flags parameter in ucp_memh_alloc

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -691,7 +691,7 @@ ucp_memh_alloc(ucp_context_h context, void *address, size_t length,
         goto err_dealloc;
     }
 
-    status = ucp_memh_init_uct_reg(context, memh, UCT_MD_MEM_ACCESS_ALL);
+    status = ucp_memh_init_uct_reg(context, memh, uct_flags);
     if (status != UCS_OK) {
         goto err_free_memh;
     }


### PR DESCRIPTION
## Why
UCT flags parameter was not passed down to UCT memory registration.
For example, UCT_MD_MEM_FLAG_HIDE_ERRORS was not passed from ucp_mem_reg_md_map_update, leading to excessive error messages.