### PR TITLE
UCP/PROTO: reset rndv/recv/ppln and rndv/get/mtype

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1781,13 +1781,13 @@ const ucp_request_send_proto_t ucp_am_reply_proto = {
     .only_hdr_size          = sizeof(ucp_am_hdr_t) + sizeof(ucp_am_reply_ftr_t)
 };
 
-void ucp_am_proto_request_zcopy_reset(ucp_request_t *request)
+ucs_status_t ucp_am_proto_request_zcopy_reset(ucp_request_t *request)
 {
     ucs_assert(request->send.msg_proto.am.header.reg_desc != NULL);
     ucs_mpool_put_inline(request->send.msg_proto.am.header.reg_desc);
     request->send.msg_proto.am.header.reg_desc = NULL;
 
-    ucp_proto_request_zcopy_reset(request);
+    return ucp_proto_request_zcopy_reset(request);
 }
 
 void ucp_proto_am_request_bcopy_abort(ucp_request_t *req, ucs_status_t status)

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -134,7 +134,7 @@ ucs_status_t ucp_proto_progress_am_rndv_rts(uct_pending_req_t *self);
 ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
                                      unsigned tl_flags);
 
-void ucp_am_proto_request_zcopy_reset(ucp_request_t *request);
+ucs_status_t ucp_am_proto_request_zcopy_reset(ucp_request_t *request);
 
 void ucp_proto_am_request_bcopy_abort(ucp_request_t *req, ucs_status_t status);
 

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -274,8 +274,14 @@ typedef void (*ucp_request_abort_func_t)(ucp_request_t *request,
  * the specific protocol. Used to switch a send request to a different protocol.
  *
  * @param [in]  request Request to reset.
+ *
+ * @return UCS_OK           - The request was reset successfully and can be used
+ *                            to resend the operation.
+ *         UCS_ERR_CANCELED - The request was canceled and released, since it's
+ *                            a part of a higher-level operation and should not
+ *                            be reused.
  */
-typedef void (*ucp_request_reset_func_t)(ucp_request_t *request);
+typedef ucs_status_t (*ucp_request_reset_func_t)(ucp_request_t *request);
 
 
 /**

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -278,19 +278,21 @@ void ucp_proto_request_restart(ucp_request_t *req);
 
 void ucp_proto_request_bcopy_abort(ucp_request_t *req, ucs_status_t status);
 
-void ucp_proto_request_bcopy_reset(ucp_request_t *req);
+ucs_status_t ucp_proto_request_bcopy_reset(ucp_request_t *req);
 
-void ucp_proto_request_bcopy_id_reset(ucp_request_t *req);
+ucs_status_t ucp_proto_request_bcopy_id_reset(ucp_request_t *req);
 
 void ucp_proto_request_zcopy_abort(ucp_request_t *req, ucs_status_t status);
 
-void ucp_proto_request_zcopy_reset(ucp_request_t *req);
+ucs_status_t ucp_proto_request_zcopy_reset(ucp_request_t *req);
 
-void ucp_proto_request_zcopy_id_reset(ucp_request_t *req);
+ucs_status_t ucp_proto_request_zcopy_id_reset(ucp_request_t *req);
 
 void ucp_proto_abort_fatal_not_implemented(ucp_request_t *req,
                                            ucs_status_t status);
 
 void ucp_proto_reset_fatal_not_implemented(ucp_request_t *req);
+
+void ucp_proto_fatal_invalid_stage(ucp_request_t *req, const char *func_name);
 
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -100,6 +100,12 @@ ucp_proto_request_zcopy_complete_success(ucp_request_t *req)
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_common_multi_frag_is_completed(ucp_request_t *req)
+{
+    return req->send.state.completed_size == req->send.state.dt_iter.length;
+}
+
 /**
  * Add 'frag_size' to 'req->send.state.completed_size' and return nonzero if
  * completed_size reached dt_iter.length
@@ -115,11 +121,12 @@ ucp_proto_common_frag_complete(ucp_request_t *req, size_t frag_size,
                   req->send.state.dt_iter.length);
 
     ucs_assertv(req->send.state.completed_size <=
-                        req->send.state.dt_iter.length,
-                "completed_size=%zu dt_iter.length=%zu",
+                req->send.state.dt_iter.length,
+                "req %p: proto %s completed_size=%zu dt_iter.length=%zu", req,
+                req->send.proto_config->proto->name,
                 req->send.state.completed_size, req->send.state.dt_iter.length);
 
-    return req->send.state.completed_size == req->send.state.dt_iter.length;
+    return ucp_proto_common_multi_frag_is_completed(req);
 }
 
 /* Adjust a zero-copy operation to a minimal fragment size, by overlapping with

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -83,5 +83,5 @@ ucp_proto_t ucp_reconfig_proto = {
     .query    = ucp_proto_default_query,
     .progress = {ucp_proto_reconfig_progress},
     .abort    = ucp_request_complete_send,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_return_success
 };

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -438,14 +438,16 @@ void ucp_proto_rndv_rts_abort(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_send(req, status);
 }
 
-void ucp_proto_rndv_rts_reset(ucp_request_t *req)
+ucs_status_t ucp_proto_rndv_rts_reset(ucp_request_t *req)
 {
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        return;
+        return UCS_OK;
     }
 
+    ucs_assert(req->send.state.completed_size == 0);
     ucp_send_request_id_release(req);
     ucp_proto_request_zcopy_clean(req, UCP_DT_MASK_ALL);
+    return UCS_OK;
 }
 
 static ucs_status_t

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -116,7 +116,7 @@ void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
 
 void ucp_proto_rndv_rts_abort(ucp_request_t *req, ucs_status_t status);
 
-void ucp_proto_rndv_rts_reset(ucp_request_t *req);
+ucs_status_t ucp_proto_rndv_rts_reset(ucp_request_t *req);
 
 ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *params,
                                      const char *name,

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -140,7 +140,7 @@ ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_rndv_am_bcopy_progress},
     .abort    = ucp_proto_rndv_am_bcopy_abort,
-    .reset    = ucp_proto_reset_fatal_not_implemented
+    .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_rndv_am_zcopy_send_func(

--- a/src/ucp/rndv/rndv_ats.c
+++ b/src/ucp/rndv/rndv_ats.c
@@ -60,5 +60,5 @@ ucp_proto_t ucp_rndv_ats_proto = {
     .query    = ucp_proto_default_query,
     .progress = {ucp_proto_rndv_ats_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = (ucp_request_reset_func_t)ucs_empty_function
+    .reset    = (ucp_request_reset_func_t)ucs_empty_function_return_success
 };

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -213,10 +213,10 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
     }
 }
 
-static void ucp_rndv_get_zcopy_proto_reset(ucp_request_t *req)
+static ucs_status_t ucp_rndv_get_zcopy_proto_reset(ucp_request_t *req)
 {
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        return;
+        return UCS_OK;
     }
 
     req->flags &= ~UCP_REQUEST_FLAG_PROTO_INITIALIZED;
@@ -229,10 +229,10 @@ static void ucp_rndv_get_zcopy_proto_reset(ucp_request_t *req)
     case UCP_PROTO_RNDV_GET_STAGE_ATS:
         break;
     default:
-        ucs_fatal("req %p: %s has invalid stage %d", req,
-                  req->send.proto_config->proto->name, req->send.proto_stage);
-        break;
+        ucp_proto_fatal_invalid_stage(req, "reset");
     }
+
+    return UCS_OK;
 }
 
 ucp_proto_t ucp_rndv_get_zcopy_proto = {
@@ -347,6 +347,24 @@ ucp_proto_rndv_get_mtype_query(const ucp_proto_query_params_t *params,
     ucp_proto_rndv_mtype_query_desc(params, attr, UCP_PROTO_RNDV_GET_DESC);
 }
 
+static ucs_status_t ucp_proto_rndv_get_mtype_reset(ucp_request_t *req)
+{
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        return UCS_OK;
+    }
+
+    ucs_mpool_put_inline(req->send.rndv.mdesc);
+    req->send.rndv.mdesc = NULL;
+    req->flags          &= ~UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+
+    if ((req->send.proto_stage != UCP_PROTO_RNDV_GET_STAGE_FETCH) &&
+        (req->send.proto_stage != UCP_PROTO_RNDV_GET_STAGE_ATS)) {
+        ucp_proto_fatal_invalid_stage(req, "reset");
+    }
+
+    return UCS_OK;
+}
+
 ucp_proto_t ucp_rndv_get_mtype_proto = {
     .name     = "rndv/get/mtype",
     .desc     = NULL,
@@ -355,8 +373,8 @@ ucp_proto_t ucp_rndv_get_mtype_proto = {
     .query    = ucp_proto_rndv_get_mtype_query,
     .progress = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,
-        [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress,
+        [UCP_PROTO_RNDV_GET_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = ucp_proto_reset_fatal_not_implemented
+    .reset    = ucp_proto_rndv_get_mtype_reset
 };

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -417,7 +417,7 @@ ucp_proto_t ucp_rndv_put_zcopy_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = ucp_proto_reset_fatal_not_implemented
+    .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };
 
 
@@ -554,5 +554,5 @@ ucp_proto_t ucp_rndv_put_mtype_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = ucp_proto_reset_fatal_not_implemented
+    .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -180,6 +180,6 @@ ucp_proto_t ucp_rndv_rkey_ptr_proto = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_ATS]   = ucp_proto_rndv_ats_progress
     },
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = ucp_proto_reset_fatal_not_implemented
+    .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -309,15 +309,16 @@ ucp_proto_rndv_rtr_mtype_abort(ucp_request_t *req, ucs_status_t status)
     }
 }
 
-static void ucp_proto_rndv_rtr_mtype_reset(ucp_request_t *req)
+static ucs_status_t ucp_proto_rndv_rtr_mtype_reset(ucp_request_t *req)
 {
     ucs_mpool_put_inline(req->send.rndv.mdesc);
     if (ucp_proto_rndv_request_is_ppln_frag(req)) {
+        req->status = UCS_ERR_CANCELED;
         ucp_proto_rndv_ppln_recv_frag_clean(req);
-        ucp_proto_request_bcopy_id_reset(req);
-    } else {
-        ucp_proto_request_zcopy_id_reset(req);
+        return UCS_ERR_CANCELED;
     }
+
+    return ucp_proto_request_zcopy_id_reset(req);
 }
 
 static void ucp_proto_rndv_rtr_mtype_copy_completion(uct_completion_t *uct_comp)

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -60,6 +60,7 @@ public:
 
         if (variant_flags & VARIANT_PROTO) {
             modify_config("PROTO_ENABLE", "y");
+            modify_config("PROTO_REQUEST_RESET", "y");
         }
 
         int mem_type_pair_index = get_variant_value() % m_mem_type_pairs.size();


### PR DESCRIPTION
## What
reset implementation for rndv/recv/ppln and rndv/get/mtype protocols

## Why ?
missed functionality in protov2
