### PR TITLE
UCS/DEBUG: handle error return from ucs_debug_backtrace_create()

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -650,8 +650,13 @@ void ucs_debug_print_backtrace(FILE *stream, int strip)
     backtrace_h bckt;
     backtrace_line_h bckt_line;
     int i;
+    ucs_status_t status;
 
-    ucs_debug_backtrace_create(&bckt, strip);
+    status = ucs_debug_backtrace_create(&bckt, strip);
+    if (status != UCS_OK) {
+        return;
+    }
+
     fprintf(stream, "==== backtrace (tid:%7d) ====\n", ucs_get_tid());
     for (i = 0; ucs_debug_backtrace_next(bckt, &bckt_line); ++i) {
          fprintf(stream, UCS_DEBUG_BACKTRACE_LINE_FMT,


### PR DESCRIPTION
This will avoid to crash during signal-handling/stack-unwinding upon ENOMEM/failed memory alloc situation.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

## What
Add error handling in order to avoid crashes. 

## Why ?
For UCX Issue #8716 .

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
