### PR TITLE
UCP/DOC: add comments to UCP_OP_ATTR_FLAG_NO_IMM_CMPL

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -731,7 +731,12 @@ typedef enum {
     UCP_OP_ATTR_FIELD_RECV_INFO     = UCS_BIT(7),  /**< recv_info field */
     UCP_OP_ATTR_FIELD_MEMH          = UCS_BIT(8),  /**< memory handle field */
 
-    UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< deny immediate completion */
+    UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< Deny immediate completion,
+                                                        i.e NULL cannot be returned.
+                                                        If a completion callback is
+                                                        provided, it can be called
+                                                        before the function
+                                                        returns. */
     UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
                                                         even if it delays remote
                                                         data delivery. Note for


### PR DESCRIPTION
## What
Add comments to UCP_OP_ATTR_FLAG_NO_IMM_CMPL to make the doc clearer.

## Why ?
Users are confused that CB are called when UCP_OP_ATTR_FLAG_NO_IMM_CMPL is set.
They thought that UCP_OP_ATTR_FLAG_NO_IMM_CMPL means not call completion callback.

## How ?
Add some comments.
