### PR TITLE
GTEST: Limit max gtest message size to BAR1 size

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -153,7 +153,7 @@ size_t mem_buffer::get_bar1_free_size()
 {
     /* All gtest CUDA tests explicitly assume that all memory allocations are
      * done on the device 0. The same assumption is followed here. */
-    size_t max_availible_size = SIZE_MAX;
+    size_t availible_size = SIZE_MAX;
 
 #if HAVE_NVML_H
     nvmlReturn_t ret;
@@ -165,19 +165,19 @@ size_t mem_buffer::get_bar1_free_size()
         /* For whatever reason we cannot open device handle.
          * As a result let's assume there is no limit on the size
          * and in the worse case scenario gtest will fail in runtime */
-        return max_availible_size;
+        return availible_size;
     }
 
     ret = nvmlDeviceGetBAR1MemoryInfo(device, &bar1mem);
     if (ret != NVML_SUCCESS) {
         /* Similarly let's assume there is no limit on the size */
-        return max_availible_size;
+        return availible_size;
     }
 
-    max_availible_size = (size_t)bar1mem.bar1Free;
+    availible_size = (size_t)bar1mem.bar1Free;
 #endif
 
-    return max_availible_size;
+    return availible_size;
 }
 
 void *mem_buffer::allocate(size_t size, ucs_memory_type_t mem_type)

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -149,7 +149,7 @@ void mem_buffer::set_device_context()
     device_set = true;
 }
 
-const size_t mem_buffer::get_bar1_free_size()
+size_t mem_buffer::get_bar1_free_size()
 {
     /* All gtest CUDA tests explicitly assume that all memory allocations are
      * done on the device 0. The same assumption is followed here. */

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -32,6 +32,10 @@
 
 #endif
 
+#if HAVE_NVML_H
+#include <nvml.h>
+#endif
+
 #if HAVE_ROCM
 #  include <hip_runtime.h>
 
@@ -143,6 +147,37 @@ void mem_buffer::set_device_context()
 #endif
 
     device_set = true;
+}
+
+const size_t mem_buffer::get_bar1_free_size()
+{
+    /* All gtest CUDA tests explicitly assume that all memory allocations are
+     * done on the device 0. The same assumption is followed here. */
+    size_t max_availible_size = SIZE_MAX;
+
+#if HAVE_NVML_H
+    nvmlReturn_t ret;
+    nvmlDevice_t device;
+    nvmlBAR1Memory_t bar1mem;
+
+    ret = nvmlDeviceGetHandleByIndex(0, &device);
+    if (ret != NVML_SUCCESS) {
+        /* For whatever reason we cannot open device handle.
+         * As a result let's assume there is no limit on the size
+         * and in the worse case scenario gtest will fail in runtime */
+        return max_availible_size;
+    }
+
+    ret = nvmlDeviceGetBAR1MemoryInfo(device, &bar1mem);
+    if (ret != NVML_SUCCESS) {
+        /* Similarly let's assume there is no limit on the size */
+        return max_availible_size;
+    }
+
+    max_availible_size = (size_t)bar1mem.bar1Free;
+#endif
+
+    return max_availible_size;
 }
 
 void *mem_buffer::allocate(size_t size, ucs_memory_type_t mem_type)

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -88,6 +88,10 @@ public:
     /* returns whether ROCM device supports managed memory */
     static bool is_rocm_managed_supported();
 
+    /* Return free memory on the BAR1 / GPU. If GPU is not used
+     * SIZE_MAX is returned */
+    static const size_t get_bar1_free_size();
+
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     mem_buffer(size_t size, ucs_memory_type_t mem_type, uint64_t seed);
     virtual ~mem_buffer();

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -90,7 +90,7 @@ public:
 
     /* Return free memory on the BAR1 / GPU. If GPU is not used
      * SIZE_MAX is returned */
-    static const size_t get_bar1_free_size();
+    static size_t get_bar1_free_size();
 
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     mem_buffer(size_t size, ucs_memory_type_t mem_type, uint64_t seed);

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -183,10 +183,11 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
 
     /* Trim by BAR1 size if relevant */
-    if (mem_type == UCS_MEMORY_TYPE_CUDA ||
-        mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) {
+    if ((mem_type == UCS_MEMORY_TYPE_CUDA) ||
+        (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED)) {
+        /* Allocate 40% to accommodate send/receive buffers allocation */
         max_length = ucs_min(max_length,
-                (size_t)(0.8 * mem_buffer::get_bar1_free_size()));
+                (size_t)(0.4 * mem_buffer::get_bar1_free_size()));
     }
 
     /* Trim by memory size */

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -183,8 +183,11 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
 
     /* Trim by BAR1 size if relevant */
-    max_length = ucs_min(max_length,
-                         (size_t)(0.8 * mem_buffer::get_bar1_free_size()));
+    if (mem_type == UCS_MEMORY_TYPE_CUDA ||
+        mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) {
+        max_length = ucs_min(max_length,
+                (size_t)(0.8 * mem_buffer::get_bar1_free_size()));
+    }
 
     /* Trim by memory size */
     max_length = ucs::limit_buffer_size(max_length);

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -182,6 +182,10 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     /* Trim at 4.1 GB */
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
 
+    /* Trim by BAR1 size if relevant */
+    max_length = ucs_min(max_length,
+                         (size_t)(0.8 * mem_buffer::get_bar1_free_size()));
+
     /* Trim by memory size */
     max_length = ucs::limit_buffer_size(max_length);
 


### PR DESCRIPTION
## Why
Current max message size does not take in consideration the limitations of BAR1 size. For ML GPUs the BAR1 is very large and it has never been a limitation. For consumer class of GPUs the BAR1 size can be in a range of ~ megabytes. As a result, gtest can fail. 

## What 
This patch adds query for the BAR1 size and limits the max message size.

## How ?
NVML has an API to query Bar1 size
