### PR TITLE
CONFIG: Removing failt-injector option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,20 +246,6 @@ AS_IF([test "x$with_docs_only" = xyes],
 
 
      #
-     # Enable fault injection code
-     #
-     AC_ARG_ENABLE([fault-injection],
-         AS_HELP_STRING([--enable-fault-injection],
-                        [Enable fault injection code, default: NO]),
-         [],
-         [enable_fault_injection=no])
-     AS_IF([test "x$enable_fault_injection" = xyes],
-        [AS_MESSAGE([enabling with fault injection code])
-         AC_DEFINE([ENABLE_FAULT_INJECTION], [1], [Enable fault injection code])],
-        [:])
-
-
-     #
      # Disable checking user parameters
      #
      AC_ARG_ENABLE([params-check],

--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -18,7 +18,6 @@ $basedir/../configure \
 	--enable-profiling \
 	--enable-frame-pointer \
 	--enable-stats \
-	--enable-fault-injection \
 	--enable-debug-data \
 	--enable-mt \
 	"$@"

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -103,7 +103,6 @@ Provides header files and examples for developing with UCX.
            %{?debug:--enable-profiling} \
            %{?debug:--enable-frame-pointer} \
            %{?debug:--enable-stats} \
-           %{?debug:--enable-fault-injection} \
            %{?debug:--enable-debug-data} \
            %{?debug:--enable-mt} \
            --without-go \


### PR DESCRIPTION
## Why

The option has never been implemented. There is no reason to have it in configure. This can also mislead developers.