### PR TITLE
GTEST: fix test_ucp_wireup_2sided.multi_ep_2sided/rma

### DIFF
--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -352,15 +352,17 @@ void test_ucp_wireup::recv_b(ucp_worker_h worker, ucp_ep_h ep, size_t length,
     } else if (get_variant_value() & TEST_RMA) {
         wait_for_value(&m_recv_data[length], recv_data);
 
+        ucs_memory_cpu_load_fence();
         vec_type::iterator end = m_recv_data.begin() + length;
         vec_type::iterator it  = std::find_if(m_recv_data.begin(), end,
                                               [recv_data](uint64_t data) {
                                                   return data != recv_data;
                                               });
-        ASSERT_EQ(recv_data, *it) << "length " << length
-                                  << ", invalid data at index "
-                                  << std::distance(m_recv_data.begin(), it)
-                                  << ((it == end) ? " (control)" : "");
+        uint64_t data          = *it;
+        ASSERT_EQ(recv_data, data) << "length " << length
+                                   << ", invalid data at index "
+                                   << std::distance(m_recv_data.begin(), it)
+                                   << ((it == end) ? " (control)" : "");
     }
 }
 


### PR DESCRIPTION
## What
fix test_ucp_wireup_2sided.multi_ep_2sided/rma

## Why ?
```
[  FAILED  ] dcx/test_ucp_wireup_2sided.multi_ep_2sided/2, where GetParam() = dc_x/rma,no_ep_match
```
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=55233&view=logs&j=de7f2b91-0060-5c03-79ec-8e744740a59d&t=b4a9095b-911f-5006-fff5-4df2a89d16a4&s=8bfbeaae-4c8e-5f12-f154-edd305817000

