### PR TITLE
UCT/CUDA_IPC: Improve overhead estimation

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -216,10 +216,10 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
     iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
     iface_attr->cap.get.max_iov         = 1;
 
-    iface_attr->latency                 = ucs_linear_func_make(1e-9, 0);
+    iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
     iface_attr->bandwidth.shared        = uct_cuda_ipc_iface_get_bw();
-    iface_attr->overhead                = 0;
+    iface_attr->overhead                = 7.0e-6;
     iface_attr->priority                = 0;
 
     return UCS_OK;


### PR DESCRIPTION
## Why
Make gdrcopy path preferred over rndv/get/zcopy with cuda_ipc for intra-node small messages when using protocols v2

## How
Increase estimated overhead of cuda_ipc transfer - make it closer to actual performance.