### PR TITLE
UCP/CORE: Removed unused sockaddr code.

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -40,10 +40,7 @@ KHASH_IMPL(ucp_context_imported_mem_hash, uint64_t, ucs_rcache_t*, 1,
 enum {
     /* The flag indicates that the resource may be used for auxiliary
      * wireup communications only */
-    UCP_TL_RSC_FLAG_AUX      = UCS_BIT(0),
-    /* The flag indicates that the resource may be used for client-server
-     * connection establishment with a sockaddr */
-    UCP_TL_RSC_FLAG_SOCKADDR = UCS_BIT(1)
+    UCP_TL_RSC_FLAG_AUX = UCS_BIT(0)
 };
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1087,14 +1087,10 @@ static ucs_status_t ucp_worker_add_resource_ifaces(ucp_worker_h worker)
         iface_params.field_mask = UCT_IFACE_PARAM_FIELD_OPEN_MODE;
         resource = &context->tl_rscs[tl_id];
 
-        if (resource->flags & UCP_TL_RSC_FLAG_SOCKADDR) {
-            iface_params.open_mode            = UCT_IFACE_OPEN_MODE_SOCKADDR_CLIENT;
-        } else {
-            iface_params.open_mode            = UCT_IFACE_OPEN_MODE_DEVICE;
-            iface_params.field_mask          |= UCT_IFACE_PARAM_FIELD_DEVICE;
-            iface_params.mode.device.tl_name  = resource->tl_rsc.tl_name;
-            iface_params.mode.device.dev_name = resource->tl_rsc.dev_name;
-        }
+        iface_params.open_mode            = UCT_IFACE_OPEN_MODE_DEVICE;
+        iface_params.field_mask          |= UCT_IFACE_PARAM_FIELD_DEVICE;
+        iface_params.mode.device.tl_name  = resource->tl_rsc.tl_name;
+        iface_params.mode.device.dev_name = resource->tl_rsc.dev_name;
 
         status = ucp_worker_iface_open(worker, tl_id, &iface_params,
                                        &worker->ifaces[iface_id++]);
@@ -1213,7 +1209,6 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     uct_md_h md                      = context->tl_mds[resource->md_index].md;
     ucs_sys_dev_distance_t distance  = {.latency = 0, .bandwidth = 0};
     uct_iface_config_t *iface_config;
-    const char *cfg_tl_name;
     ucp_worker_iface_t *wiface;
     ucs_status_t status;
 
@@ -1232,12 +1227,8 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     wiface->flags            = 0;
 
     /* Read interface or md configuration */
-    if (resource->flags & UCP_TL_RSC_FLAG_SOCKADDR) {
-        cfg_tl_name = NULL;
-    } else {
-        cfg_tl_name = resource->tl_rsc.tl_name;
-    }
-    status = uct_md_iface_config_read(md, cfg_tl_name, NULL, NULL, &iface_config);
+    status = uct_md_iface_config_read(md, resource->tl_rsc.tl_name, NULL, NULL,
+                                      &iface_config);
     if (status != UCS_OK) {
         goto err_free_iface;
     }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -479,9 +479,6 @@ UCS_TEST_P(test_ucp_wireup_1sided, address) {
     UCS_BITMAP_FOR_EACH_BIT(sender().worker()->context->tl_bitmap, tl) {
         const ucp_tl_resource_desc_t &rsc =
                 sender().worker()->context->tl_rscs[tl];
-        if (rsc.flags & UCP_TL_RSC_FLAG_SOCKADDR) {
-            continue;
-        }
         packed_dev_priorities.insert(
                 ucp_worker_iface_get_attr(sender().worker(), tl)->priority);
         packed_sys_devices.insert(rsc.tl_rsc.sys_device);


### PR DESCRIPTION
## What
Removed unused code related to old `sockaddr` flow.

## Why ?
The code became unused after removing the single place where `UCP_TL_RSC_FLAG_SOCKADDR` is set. It was in `ucp_add_tl_resources` before, and removed by https://github.com/openucx/ucx/pull/6268
