### PR TITLE
UCT/IB: Make memlock limit settings non-fatal for md_open

### DIFF
--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -617,7 +617,7 @@ ucs_status_t uct_ib_dereg_mrs(struct ibv_mr **mrs, size_t mr_num);
 /**
  * Check if IB md device has ECE capability
  */
-ucs_status_t uct_ib_md_ece_check(uct_ib_md_t *md);
+void uct_ib_md_ece_check(uct_ib_md_t *md);
 
 
 ucs_status_t

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1303,7 +1303,7 @@ static ucs_status_t uct_dc_mlx5dv_calc_tx_wqe_ratio(uct_ib_mlx5_md_t *md)
         return UCS_OK;
     }
 
-    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, md->super.pd, &qp_tmp_objs);
+    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, md->super.pd, &qp_tmp_objs, 0);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -54,10 +54,12 @@ void uct_ib_mlx5dv_dct_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
 
 ucs_status_t
 uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
-                                 uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs)
+                                 uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs,
+                                 int silent)
 {
     struct ibv_srq_init_attr srq_attr = {};
-    ucs_status_t status;
+    ucs_log_level_t level             = silent ? UCS_LOG_LEVEL_DEBUG :
+                                                 UCS_LOG_LEVEL_ERROR;
     int cq_errno;
     char message[128];
 
@@ -66,8 +68,7 @@ uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
         cq_errno = errno;
         ucs_snprintf_safe(message, sizeof(message), "%s: ibv_create_cq()",
                           uct_ib_device_name(dev));
-        uct_ib_mem_lock_limit_msg(message, cq_errno, UCS_LOG_LEVEL_ERROR);
-        status = UCS_ERR_IO_ERROR;
+        uct_ib_mem_lock_limit_msg(message, cq_errno, level);
         goto out;
     }
 
@@ -75,8 +76,8 @@ uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
     srq_attr.attr.max_wr  = 1;
     qp_tmp_objs->srq      = ibv_create_srq(pd, &srq_attr);
     if (qp_tmp_objs->srq == NULL) {
-        ucs_error("%s: ibv_create_srq() failed: %m", uct_ib_device_name(dev));
-        status = UCS_ERR_IO_ERROR;
+        ucs_log(level, "%s: ibv_create_srq() failed: %m",
+                uct_ib_device_name(dev));
         goto out_destroy_cq;
     }
 
@@ -85,7 +86,7 @@ uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
 out_destroy_cq:
     ibv_destroy_cq(qp_tmp_objs->cq);
 out:
-    return status;
+    return UCS_ERR_IO_ERROR;
 }
 
 void uct_ib_mlx5dv_qp_tmp_objs_destroy(uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs)

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
@@ -58,7 +58,8 @@ void uct_ib_mlx5dv_dct_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
  */
 ucs_status_t
 uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
-                                 uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs);
+                                 uct_ib_mlx5dv_qp_tmp_objs_t *qp_tmp_objs,
+                                 int silent);
 
 /**
  * Closes CQ and SRQ which are needed for creating QP.

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1585,9 +1585,8 @@ UCT_IB_MD_DEFINE_ENTRY(devx, uct_ib_mlx5_devx_md_ops);
 
 #endif
 
-static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
+static void uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
 {
-    ucs_status_t status = UCS_OK;
 #if HAVE_DC_DV
     struct ibv_context *ctx            = dev->ibv_context;
     uct_ib_qp_init_attr_t qp_init_attr = {};
@@ -1596,16 +1595,16 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
     uct_ib_mlx5dv_qp_tmp_objs_t qp_tmp_objs;
     struct ibv_pd *pd;
     struct ibv_qp *qp;
+    ucs_status_t status;
     int ret;
 
     pd = ibv_alloc_pd(ctx);
     if (pd == NULL) {
-        ucs_error("%s: ibv_alloc_pd() failed: %m", uct_ib_device_name(dev));
-        status = UCS_ERR_IO_ERROR;
+        ucs_debug("%s: ibv_alloc_pd() failed: %m", uct_ib_device_name(dev));
         goto out;
     }
 
-    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, pd, &qp_tmp_objs);
+    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, pd, &qp_tmp_objs, 1);
     if (status != UCS_OK) {
         goto out_dealloc_pd;
     }
@@ -1619,7 +1618,6 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
     if (qp == NULL) {
         ucs_debug("%s: mlx5dv_create_qp(DCT) failed: %m",
                   uct_ib_device_name(dev));
-        status = UCS_OK;
         goto out_qp_tmp_objs_close;
     }
 
@@ -1635,7 +1633,6 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
     if (ret != 0) {
         ucs_debug("failed to ibv_modify_qp(DCT, INIT) on %s: %m",
                   uct_ib_device_name(dev));
-        status = UCS_OK;
         goto out_destroy_qp;
     }
 
@@ -1658,12 +1655,10 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
     if (ret != 0) {
         ucs_debug("%s: failed to ibv_modify_qp(DCT, RTR): %m",
                   uct_ib_device_name(dev));
-        status = UCS_OK;
         goto out_destroy_qp;
     }
 
     dev->flags |= UCT_IB_DEVICE_FLAG_DC;
-    status      = UCS_OK;
 
 out_destroy_qp:
     uct_ib_destroy_qp(qp);
@@ -1673,11 +1668,8 @@ out_dealloc_pd:
     ibv_dealloc_pd(pd);
 out:
 #endif
-    if (status == UCS_OK) {
-        ucs_debug("%s: DC %s supported", uct_ib_device_name(dev),
-                  (dev->flags & UCT_IB_DEVICE_FLAG_DC) ? "is" : "is not");
-    }
-    return status;
+    ucs_debug("%s: DC %s supported", uct_ib_device_name(dev),
+              (dev->flags & UCT_IB_DEVICE_FLAG_DC) ? "is" : "is not");
 }
 
 static uct_ib_md_ops_t uct_ib_mlx5_md_ops;
@@ -1731,10 +1723,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
 #endif
     }
 
-    status = uct_ib_mlx5dv_check_dc(dev);
-    if (status != UCS_OK) {
-        goto err_md_free;
-    }
+    uct_ib_mlx5dv_check_dc(dev);
 
     md->super.ops        = &uct_ib_mlx5_md_ops;
     md->max_rd_atomic_dc = IBV_DEV_ATTR(dev, max_qp_rd_atom);
@@ -1749,10 +1738,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->super.name = UCT_IB_MD_NAME(mlx5);
 
-    status = uct_ib_md_ece_check(&md->super);
-    if (status != UCS_OK) {
-        goto err_md_close_common;
-    }
+    uct_ib_md_ece_check(&md->super);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();
 
@@ -1760,12 +1746,6 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     *p_md = &md->super;
     return UCS_OK;
 
-err_md_close_common:
-    /* Coverity thinks that this goto label is unreachable, because "status"
-     * variable is always set to UCS_OK in case of ibv_set_ece() is unavailable
-     * in uct_ib_md_ece_check() */
-    /* coverity[unreachable] */
-    uct_ib_md_close_common(&md->super);
 err_md_free:
     uct_ib_md_free(&md->super);
 err_free_context:

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -539,7 +539,7 @@ uct_rc_verbs_can_create_qp(struct ibv_context *ctx, struct ibv_pd *pd)
 
     cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
     if (cq == NULL) {
-        ucs_error("failed to create cq %m");
+        ucs_debug("failed to create cq %m");
         status = UCS_ERR_IO_ERROR;
         goto err;
     }

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -889,7 +889,7 @@ static ucs_status_t uct_ud_mlx5dv_calc_tx_wqe_ratio(uct_ib_mlx5_md_t *md)
         return UCS_OK;
     }
 
-    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, md->super.pd, &qp_tmp_objs);
+    status = uct_ib_mlx5dv_qp_tmp_objs_create(dev, md->super.pd, &qp_tmp_objs, 0);
     if (status != UCS_OK) {
         goto out;
     }

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -68,7 +68,6 @@ protected:
 
     size_t                        m_comp_count;
 
-private:
     ucs::handle<uct_md_config_t*> m_md_config;
     ucs::handle<uct_md_h>         m_md;
     uct_md_attr_v2_t              m_md_attr;


### PR DESCRIPTION
## What
Removes hard errors in case of too strict memlock limit during md_open

## Why ?
Now if system has too strict memlock limit the md_open() will fail and error messages would be printed. That can confuse customers if they don't plan to use IB transport at all.

Should solve https://github.com/openucx/ucx/issues/8746