### PR TITLE
AZP: Add ubuntu20 container w/ rocm software stack

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -151,6 +151,8 @@ resources:
     - container: ubuntu20_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:1
       options: $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
+    - container: ubuntu2004_rocm_5_4_0
+      image: registry.hub.docker.com/rocm/ucx:rocm-5.4.0
 
 stages:
   - stage: Codestyle
@@ -204,6 +206,8 @@ stages:
               long_test: yes
             centos7:
               CONTAINER: centos7_ib
+            ubuntu2004_rocm:
+              CONTAINER: ubuntu2004_rocm_5_4_0
         container: $[ variables['CONTAINER'] ]
         timeoutInMinutes: 340
 

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -241,6 +241,19 @@ build_cuda() {
 }
 
 #
+# Build ROCm
+#
+build_rocm() {
+	if [ -f /opt/rocm/bin/rocminfo ]; then
+		echo "==== Build with enable rocm  ===="
+		${WORKSPACE}/contrib/configure-devel --prefix=$ucx_inst --with-rocm
+		$MAKEP
+	else
+		echo "==== Not building with rocm ===="
+	fi
+}
+
+#
 # Build with clang compiler
 #
 build_clang() {
@@ -419,6 +432,7 @@ do_task "${prog}" build_prof
 do_task "${prog}" build_ugni
 do_task "${prog}" build_disable_numa
 do_task "${prog}" build_cuda
+do_task "${prog}" build_rocm
 do_task "${prog}" build_no_verbs
 do_task "${prog}" build_release_pkg
 do_task "${prog}" build_cmake_examples


### PR DESCRIPTION
## What
add a rocm docker container for testing. Build only at the moment.

## Why ?
simplify code development and maintenance for rocm devices

