### PR TITLE
UCP/CORE: Removed test memory registration during UCP context initialization.

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -277,6 +277,7 @@ typedef struct ucp_context {
 
     /* Index of memory domain that is used to allocate memory of the given type
      * using ucp_memh_alloc(). */
+    int                           alloc_md_index_initialized;
     ucp_md_index_t                alloc_md_index[UCS_MEMORY_TYPE_LAST];
 
     /* Map of MDs that provide registration for given memory type,

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -163,7 +163,18 @@ ucs_status_t ucp_mem_rcache_init(ucp_context_h context);
 
 void ucp_mem_rcache_cleanup(ucp_context_h context);
 
-ucs_status_t ucp_mem_reg_md_map_update(ucp_context_h context);
+/**
+ * Get memory domain index that is used to allocate host memory type.
+ *
+ * @param [in]  context UCP context containing memory domain indexes to use for
+ *                      the memory allocation.
+ * @param [out] md_idx  Index of the memory domain that is used to allocate host
+ *                      memory.
+ * 
+ * @return Error code as defined by @ref ucs_status_t.
+ */
+ucs_status_t
+ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idx);
 
 static UCS_F_ALWAYS_INLINE ucp_md_map_t
 ucp_rkey_packed_md_map(const void *rkey_buffer)

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -379,6 +379,7 @@ ucp_proto_rndv_rtr_mtype_init(const ucp_proto_init_params_t *init_params)
     ucp_md_map_t md_map, dummy_md_map;
     ucs_status_t status;
     size_t frag_size;
+    ucp_md_index_t md_index;
 
     if (!ucp_proto_rndv_op_check(init_params, UCP_OP_ID_RNDV_RECV, 1)) {
         return UCS_ERR_UNSUPPORTED;
@@ -400,7 +401,12 @@ ucp_proto_rndv_rtr_mtype_init(const ucp_proto_init_params_t *init_params)
     /* Make sure that key of the md used to allocate a bounce buffer will be
      * packed to the RTR rkey
      */
-    md_map = UCS_BIT(context->alloc_md_index[UCS_MEMORY_TYPE_HOST]);
+    status = ucp_mm_get_alloc_md_index(context, &md_index);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    md_map = UCS_BIT(md_index);
     status = ucp_proto_rndv_rtr_common_init(init_params, rndv_modes, frag_size,
                                             unpack_time, unpack_perf_node,
                                             md_map, UCS_MEMORY_TYPE_HOST,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -365,26 +365,6 @@ static size_t ucp_wireup_max_lanes(ucp_lane_type_t lane_type)
 }
 
 /**
- * Get bitmap of memory types that Memory Domain can be registered with taking
- * into account context's maps of Memory Domains that provide registration for
- * given memory type.
- */
-static uint64_t
-ucp_wireup_select_reg_mem_types(ucp_context_h context, ucp_md_index_t md_index)
-{
-    uint64_t reg_mem_types = 0;
-    ucs_memory_type_t mem_type;
-
-    ucs_memory_type_for_each(mem_type) {
-        if (context->reg_md_map[mem_type] & UCS_BIT(md_index)) {
-            reg_mem_types |= UCS_BIT(mem_type);
-        }
-    }
-
-    return reg_mem_types;
-}
-
-/**
  * Select a local and remote transport
  */
 static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
@@ -423,7 +403,6 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     int is_reachable;
     double score;
     uint8_t priority;
-    uint64_t reg_mem_types;
     ucp_md_index_t md_index;
 
     p            = tls_info;
@@ -515,8 +494,6 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             local_md_flags &= ~UCT_MD_FLAG_INVALIDATE;
         }
 
-        reg_mem_types = ucp_wireup_select_reg_mem_types(context, md_index);
-
         /* Check that local md and interface satisfy the criteria */
         if (!ucp_wireup_check_flags(resource, md_attr->flags, local_md_flags,
                                     criteria->title, ucp_wireup_md_flags, p,
@@ -527,7 +504,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             !ucp_wireup_check_flags(resource, md_attr->alloc_mem_types,
                                     criteria->alloc_mem_types, criteria->title,
                                     ucs_memory_type_names, p, endp - p) ||
-            !ucp_wireup_check_flags(resource, reg_mem_types,
+            !ucp_wireup_check_flags(resource, md_attr->reg_mem_types,
                                     criteria->reg_mem_types, criteria->title,
                                     ucs_memory_type_names, p, endp - p) ||
             !ucp_wireup_check_select_flags(resource, iface_attr->cap.flags,


### PR DESCRIPTION
## What
Removed test memory registration during UCP context initialization.

Added test memory registration to KNEM memory domain query method.
Partially reverted https://github.com/openucx/ucx/pull/8392 (which was the original fix for KNEM memory registration issue).

## Why ?
Having test memory registration during UCP context initialization caused CUDA API calls. Which caused the creation of extra CUDA contexts.