### PR TITLE
TOOLS/PERF: Initial support for DPU daemons

### DIFF
--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -41,6 +41,23 @@ dist_perftest_DATA = \
 	$(top_srcdir)/contrib/ucx_perftest_config/test_types_ucp \
 	$(top_srcdir)/contrib/ucx_perftest_config/transports
 
+
+bin_PROGRAMS += ucx_perftest_daemon
+
+ucx_perftest_daemon_SOURCES = \
+	perftest_daemon.c
+
+ucx_perftest_daemon_CXXFLAGS = $(BASE_CXXFLAGS)
+ucx_perftest_daemon_CPPFLAGS = $(BASE_CPPFLAGS)
+ucx_perftest_daemon_CFLAGS   = $(BASE_CFLAGS) $(OPENMP_CFLAGS)
+ucx_perftest_daemon_LDFLAGS  = $(LDFLAGS_DYNAMIC_LIST_DATA)
+ucx_perftest_daemon_LDADD    = \
+	$(abs_top_builddir)/src/uct/libuct.la \
+	$(abs_top_builddir)/src/ucp/libucp.la \
+	$(abs_top_builddir)/src/ucs/libucs.la \
+	lib/libucxperf.la
+
+
 if HAVE_MPIRUN
 .PHONY: ucx test help
 
@@ -50,7 +67,7 @@ MPI_ARGS  = -n 2 -map-by node -mca pml ob1 -mca btl self,tcp,sm $(MPI_EXTRA)
 ucx:
 	$(MAKE) -C $(top_builddir)
 
-test: ucx ucx_perftest
+test: ucx ucx_perftest ucx_perftest_daemon
 	$(MPIRUN) $(MPI_ARGS) $(abs_builddir)/ucx_perftest$(EXEEXT) $(TEST_ARGS)
 
 help:

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -97,6 +97,19 @@ enum {
 };
 
 
+enum {
+    UCP_PERF_DAEMON_AM_ID_INIT      = 0,
+    UCP_PERF_DAEMON_AM_ID_PEER_INIT = 1,
+    UCP_PERF_DAEMON_AM_ID_REQ       = 2,
+    UCP_PERF_DAEMON_AM_ID_SEND_ACK  = 3,
+    UCP_PERF_DAEMON_AM_ID_RECV_ACK  = 4,
+    UCP_PERF_DAEMON_AM_ID_OP        = 5,
+    UCP_PERF_DAEMON_AM_ID_FIN       = 6
+};
+
+
+#define UCP_PERF_TEST_DAEMON_ADDRESS_MAX_NUMBER 2
+
 #define UCT_PERF_TEST_PARAMS_FMT             "%s/%s"
 #define UCT_PERF_TEST_PARAMS_ARG(_params)    (_params)->uct.tl_name, \
                                              (_params)->uct.dev_name
@@ -216,14 +229,22 @@ typedef struct ucx_perf_params {
     } uct;
 
     struct {
-        unsigned               nonblocking_mode; /* TBD */
-        ucp_perf_datatype_t    send_datatype;
-        ucp_perf_datatype_t    recv_datatype;
-        size_t                 am_hdr_size; /* UCP Active Message header size
-                                               (not included in message size) */
+        unsigned                nonblocking_mode; /* TBD */
+        ucp_perf_datatype_t     send_datatype;
+        ucp_perf_datatype_t     recv_datatype;
+        size_t                  am_hdr_size; /* UCP Active Message header size
+                                                (not included in message size) */
+        struct sockaddr_storage daemon_addrs[UCP_PERF_TEST_DAEMON_ADDRESS_MAX_NUMBER];
+        size_t                  daemon_addrs_num;
     } ucp;
 
 } ucx_perf_params_t;
+
+
+typedef struct {
+    uint64_t addr;
+    uint64_t length;
+} ucp_perf_daemon_req_t;
 
 
 /* Allocators for each memory type */

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -109,6 +109,11 @@ struct ucx_perf_context {
             unsigned long              remote_addr;
             ucp_mem_h                  send_memh;
             ucp_mem_h                  recv_memh;
+            void                       *send_exported_memh_buf;
+            void                       *recv_exported_memh_buf;
+            size_t                     send_exported_memh_buf_size;
+            size_t                     recv_exported_memh_buf_size;
+            ucp_perf_daemon_req_t      daemon_req;
             ucp_dt_iov_t               *send_iov;
             ucp_dt_iov_t               *recv_iov;
             void                       *am_hdr;

--- a/src/tools/perf/lib/libperf_memory.c
+++ b/src/tools/perf/lib/libperf_memory.c
@@ -44,8 +44,11 @@ static ucs_status_t ucp_perf_test_alloc_iov_mem(ucp_perf_datatype_t datatype,
 static ucs_status_t ucp_perf_mem_alloc(const ucx_perf_context_t *perf,
                                        size_t length,
                                        ucs_memory_type_t mem_type,
-                                       void **address_p, ucp_mem_h *memh_p)
+                                       void **address_p, ucp_mem_h *memh_p,
+                                       void **exported_memh_buf_p,
+                                       size_t *exported_memh_buf_size_p)
 {
+    ucp_memh_pack_params_t memh_pack_params;
     ucp_mem_map_params_t params;
     ucp_mem_attr_t attr;
     ucs_status_t status;
@@ -71,17 +74,40 @@ static ucs_status_t ucp_perf_mem_alloc(const ucx_perf_context_t *perf,
     status          = ucp_mem_query(*memh_p, &attr);
     if (status != UCS_OK) {
         ucp_mem_unmap(perf->ucp.context, *memh_p);
-        return status;
+        goto err_mem_unmap;
+    }
+
+    if (perf->params.ucp.daemon_addrs_num > 0) {
+        memh_pack_params.field_mask = UCP_MEMH_PACK_PARAM_FIELD_FLAGS;
+        memh_pack_params.flags      = UCP_MEMH_PACK_FLAG_EXPORT;
+        status                      = ucp_memh_pack(*memh_p,
+                                                    &memh_pack_params,
+                                                    exported_memh_buf_p,
+                                                    exported_memh_buf_size_p);
+        if (status != UCS_OK) {
+            goto err_mem_unmap;
+        }
+    } else {
+        *exported_memh_buf_p      = NULL;
+        *exported_memh_buf_size_p = 0;
     }
 
     *address_p = attr.address;
     return UCS_OK;
+
+err_mem_unmap:
+    /* coverity[check_return] */
+    ucp_mem_unmap(perf->ucp.context, *memh_p);
+    return status;
 }
 
-static void ucp_perf_mem_free(const ucx_perf_context_t *perf, ucp_mem_h memh)
+static void ucp_perf_mem_free(const ucx_perf_context_t *perf, ucp_mem_h memh,
+                              void *exported_memh_buf)
 {
+    ucp_memh_buffer_release_params_t memh_buffer_release_params = { 0 };
     ucs_status_t status;
 
+    ucp_memh_buffer_release(exported_memh_buf, &memh_buffer_release_params);
     status = ucp_mem_unmap(perf->ucp.context, memh);
     if (status != UCS_OK) {
         ucs_warn("ucp_mem_unmap() failed: %s", ucs_status_string(status));
@@ -103,15 +129,21 @@ ucs_status_t ucp_perf_test_alloc_mem(ucx_perf_context_t *perf)
     /* Allocate send buffer memory */
     status = ucp_perf_mem_alloc(perf, buffer_size * params->thread_count,
                                 params->send_mem_type, &perf->send_buffer,
-                                &perf->ucp.send_memh);
+                                &perf->ucp.send_memh,
+                                &perf->ucp.send_exported_memh_buf,
+                                &perf->ucp.send_exported_memh_buf_size);
     if (status != UCS_OK) {
         goto err;
     }
+    perf->ucp.daemon_req.addr   = (uint64_t)perf->send_buffer;
+    perf->ucp.daemon_req.length = buffer_size;
 
     /* Allocate receive buffer memory */
     status = ucp_perf_mem_alloc(perf, buffer_size * params->thread_count,
                                 params->recv_mem_type, &perf->recv_buffer,
-                                &perf->ucp.recv_memh);
+                                &perf->ucp.recv_memh,
+                                &perf->ucp.recv_exported_memh_buf,
+                                &perf->ucp.recv_exported_memh_buf_size);
     if (status != UCS_OK) {
         goto err_free_send_buffer;
     }
@@ -152,9 +184,11 @@ err_free_send_iov_buffers:
 err_free_am_hdr:
     free(perf->ucp.am_hdr);
 err_free_buffers:
-    ucp_perf_mem_free(perf, perf->ucp.recv_memh);
+    ucp_perf_mem_free(perf, perf->ucp.recv_memh,
+                      perf->ucp.recv_exported_memh_buf);
 err_free_send_buffer:
-    ucp_perf_mem_free(perf, perf->ucp.send_memh);
+    ucp_perf_mem_free(perf, perf->ucp.send_memh,
+                      perf->ucp.send_exported_memh_buf);
 err:
     return UCS_ERR_NO_MEMORY;
 }
@@ -164,8 +198,10 @@ void ucp_perf_test_free_mem(ucx_perf_context_t *perf)
     free(perf->ucp.recv_iov);
     free(perf->ucp.send_iov);
     free(perf->ucp.am_hdr);
-    ucp_perf_mem_free(perf, perf->ucp.recv_memh);
-    ucp_perf_mem_free(perf, perf->ucp.send_memh);
+    ucp_perf_mem_free(perf, perf->ucp.recv_memh,
+                      perf->ucp.recv_exported_memh_buf);
+    ucp_perf_mem_free(perf, perf->ucp.send_memh,
+                      perf->ucp.send_exported_memh_buf);
 }
 
 static void

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -47,7 +47,11 @@ public:
 
         ucs_assert_always(m_max_outstanding > 0);
 
-        set_am_handler(am_data_handler, this, UCP_AM_FLAG_WHOLE_MSG);
+        set_am_handler(UCP_PERF_DAEMON_AM_ID_SEND_ACK,
+                       am_daemon_send_ack_handler, this, UCP_AM_FLAG_WHOLE_MSG);
+        set_am_handler(UCP_PERF_DAEMON_AM_ID_RECV_ACK,
+                       am_daemon_recv_ack_handler, this, UCP_AM_FLAG_WHOLE_MSG);
+        set_am_handler(AM_ID, am_data_handler, this, UCP_AM_FLAG_WHOLE_MSG);
 
         if (CMD == UCX_PERF_CMD_ADD) {
             m_atomic_op = UCP_ATOMIC_OP_ADD;
@@ -64,17 +68,20 @@ public:
 
     ~ucp_perf_test_runner()
     {
-        set_am_handler(NULL, this, 0);
+        set_am_handler(AM_ID, NULL, this, 0);
+        set_am_handler(UCP_PERF_DAEMON_AM_ID_SEND_ACK, NULL, this, 0);
+        set_am_handler(UCP_PERF_DAEMON_AM_ID_RECV_ACK, NULL, this, 0);
     }
 
-    void set_am_handler(ucp_am_recv_callback_t cb, void *arg, unsigned flags)
+    void set_am_handler(unsigned id, ucp_am_recv_callback_t cb, void *arg,
+                        unsigned flags)
     {
         if (CMD == UCX_PERF_CMD_AM) {
             ucp_am_handler_param_t param;
             param.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
                                UCP_AM_HANDLER_PARAM_FIELD_CB |
                                UCP_AM_HANDLER_PARAM_FIELD_ARG;
-            param.id         = AM_ID;
+            param.id         = id;
             param.cb         = cb;
             param.arg        = arg;
 
@@ -320,6 +327,36 @@ public:
         return UCS_OK;
     }
 
+    static ucs_status_t
+    am_daemon_send_ack_handler(void *arg, const void *header,
+                               size_t header_length, void *data, size_t length,
+                               const ucp_am_recv_param_t *param)
+    {
+        ucp_perf_test_runner *test = (ucp_perf_test_runner*)arg;
+
+        ucs_assertv(length == 0ul, "length=%zu", length);
+        ucs_assert(!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV));
+
+        test->send_completed();
+
+        return UCS_OK;
+    }
+
+    static ucs_status_t
+    am_daemon_recv_ack_handler(void *arg, const void *header,
+                               size_t header_length, void *data, size_t length,
+                               const ucp_am_recv_param_t *param)
+    {
+        ucp_perf_test_runner *test = (ucp_perf_test_runner*)arg;
+
+        ucs_assertv(length == 0ul, "length=%zu", length);
+        ucs_assert(!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV));
+
+        test->recv_completed();
+
+        return UCS_OK;
+    }
+
     void UCS_F_ALWAYS_INLINE send_started()
     {
         ++m_sends_outstanding;
@@ -390,6 +427,28 @@ public:
         }
     }
 
+    UCS_F_ALWAYS_INLINE ucs_status_t
+    send_daemon_req(void *buffer, unsigned length)
+    {
+        ucp_ep_h ep               = m_perf.ucp.ep;
+        ucp_request_param_t param = {
+            .op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS,
+            .flags        = UCP_AM_SEND_FLAG_EAGER
+        };
+        ucs_status_ptr_t req;
+
+        ucs_assertv(CMD == UCX_PERF_CMD_AM, "cmd %d", CMD);
+
+        req = ucp_am_send_nbx(ep, UCP_PERF_DAEMON_AM_ID_REQ, NULL, 0,
+                              &m_perf.ucp.daemon_req,
+                              sizeof(m_perf.ucp.daemon_req), &param);
+        if (UCS_PTR_IS_PTR(req)) {
+            ucp_request_free(req);
+        }
+
+        return UCS_PTR_STATUS(req);
+    }
+
     ucs_status_t UCS_F_ALWAYS_INLINE
     send(ucp_ep_h ep, void *buffer, unsigned length, ucp_datatype_t datatype,
          psn_t sn, uint64_t remote_addr, ucp_rkey_h rkey, bool get_info = false)
@@ -398,8 +457,14 @@ public:
                                                 &m_send_params;
         uint64_t value             = 0;
         void *request;
+        ucs_status_t status;
 
         wait_send_window(1);
+
+        if (m_perf.params.ucp.daemon_addrs_num > 0) {
+            status = send_daemon_req(buffer, length);
+            goto out;
+        }
 
         /* coverity[switch_selector_expr_is_constant] */
         switch (CMD) {
@@ -445,19 +510,20 @@ public:
         default:
             return UCS_ERR_INVALID_PARAM;
         }
-
         if (!UCS_PTR_IS_PTR(request)) {
             /* coverity[overflow] */
             return UCS_PTR_STATUS(request);
         }
-
         if (get_info) {
             get_request_info(request);
             ucp_request_release(request);
         }
 
+        status = UCS_OK;
+
+    out:
         send_started();
-        return UCS_OK;
+        return status;
     }
 
     ucs_status_t UCS_F_ALWAYS_INLINE

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -189,6 +189,7 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.ucp.send_datatype = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.recv_datatype = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.am_hdr_size   = 0;
+    params->super.ucp.daemon_addrs_num = 0;
     strcpy(params->super.uct.dev_name, TL_RESOURCE_NAME_NONE);
     strcpy(params->super.uct.tl_name,  TL_RESOURCE_NAME_NONE);
 

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -18,7 +18,7 @@
 #define MAX_BATCH_FILES         32
 #define MAX_CPUS                1024
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lz"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lzZ:"
 #define TEST_ID_UNDEFINED       -1
 
 enum {

--- a/src/tools/perf/perftest_daemon.c
+++ b/src/tools/perf/perftest_daemon.c
@@ -1,0 +1,511 @@
+/**
+ * Copyright (C) NVIDIA 2022.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <ucp/api/ucp.h>
+#include <ucs/debug/log.h>
+#include <ucs/type/serialize.h>
+#include <tools/perf/api/libperf.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <signal.h>
+
+
+typedef struct ucp_perf_daemon_context_t {
+    ucp_context_h                      context;
+    ucp_worker_h                       worker;
+    ucp_listener_h                     listener;
+    uint16_t                           port;
+    ucp_ep_h                           client_ep;
+    ucp_ep_h                           peer_ep;
+    struct sockaddr_storage            peer_address;
+    ucp_mem_h                          send_memh;
+    ucp_mem_h                          recv_memh;
+    void                               *rx_address;
+} ucp_perf_daemon_context_t;
+
+static volatile int terminated = 0;
+
+static void
+ucp_perf_daemon_ep_close(ucp_perf_daemon_context_t *ctx, ucp_ep_h ep)
+{
+    ucp_request_param_t param;
+    ucs_status_ptr_t close_req;
+    ucs_status_t status;
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
+    close_req          = ucp_ep_close_nbx(ep, &param);
+
+    if (UCS_PTR_IS_PTR(close_req)) {
+        do {
+            ucp_worker_progress(ctx->worker);
+            status = ucp_request_check_status(close_req);
+        } while (status == UCS_INPROGRESS);
+        ucp_request_free(close_req);
+    } else {
+        status = UCS_PTR_STATUS(close_req);
+    }
+
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to close ep %p", ep);
+    }
+}
+
+static void ucp_perf_daemon_err_cb(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    terminated = 1;
+}
+
+static void
+ucp_perf_daemon_server_conn_handle_cb(ucp_conn_request_h conn_request,
+                                      void *arg)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    ucp_ep_params_t ep_params;
+    ucs_status_t status;
+    ucp_ep_h ep;
+
+    ep_params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLER  |
+                                UCP_EP_PARAM_FIELD_CONN_REQUEST |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.conn_request    = conn_request;
+    ep_params.err_handler.cb  = ucp_perf_daemon_err_cb;
+    ep_params.err_handler.arg = ctx;
+
+    status = ucp_ep_create(ctx->worker, &ep_params, &ep);
+    if (status != UCS_OK) {
+        ucs_error("failed to create an endpoint on the daemon: %s",
+                  ucs_status_string(status));
+    }
+}
+
+static void
+ucp_perf_daemon_set_am_recv_handler(ucp_worker_h worker, unsigned id,
+                                    ucp_am_recv_callback_t cb, void *arg)
+{
+    ucp_am_handler_param_t param;
+    ucs_status_t status;
+
+    param.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID    |
+                       UCP_AM_HANDLER_PARAM_FIELD_CB    |
+                       UCP_AM_HANDLER_PARAM_FIELD_FLAGS |
+                       UCP_AM_HANDLER_PARAM_FIELD_ARG;
+    param.id         = id;
+    param.cb         = cb;
+    param.arg        = arg;
+    param.flags      = UCP_AM_FLAG_WHOLE_MSG;
+    status           = ucp_worker_set_am_recv_handler(worker, &param);
+
+    ucs_assertv_always(status == UCS_OK, "status=%s", ucs_status_string(status));
+}
+
+static void ucp_perf_daemon_send_am_eager_msg(ucp_ep_h ep, unsigned am_id)
+{
+    ucp_request_param_t param = {};
+    ucs_status_ptr_t sptr;
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = UCP_AM_SEND_FLAG_REPLY | UCP_AM_SEND_FLAG_EAGER;
+
+    sptr = ucp_am_send_nbx(ep, am_id, NULL, 0ul, NULL, 0ul, &param);
+    if (UCS_PTR_IS_PTR(sptr)) {
+        ucp_request_free(sptr);
+    } else if (UCS_PTR_IS_ERR(sptr)) {
+        ucs_fatal("failed to send am id %u: %s", am_id,
+                  ucs_status_string(UCS_PTR_STATUS(sptr)));
+    }
+}
+
+static ucp_mem_h
+ucp_perf_daemon_memh_import(ucp_perf_daemon_context_t *ctx, void *packed_memh)
+{
+    ucp_mem_map_params_t params = {};
+    ucs_status_t status;
+    ucp_mem_h memh;
+
+    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_EXPORTED_MEMH_BUFFER;
+    params.exported_memh_buffer = packed_memh;
+    status                      = ucp_mem_map(ctx->context, &params,
+                                              &memh);
+    if (status != UCS_OK) {
+        ucs_error("failed to import memory (%s)", ucs_status_string(status));
+        return NULL;
+    }
+
+    return memh;
+}
+
+static void ucp_perf_daemon_send_cb(void *request, ucs_status_t status,
+                                    void *user_data)
+{
+    ucp_perf_daemon_context_t *ctx = user_data;
+
+    ucp_perf_daemon_send_am_eager_msg(ctx->client_ep,
+                                      UCP_PERF_DAEMON_AM_ID_SEND_ACK);
+    ucp_request_free(request);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_perf_daemon_handle_cmd_am_send(ucp_perf_daemon_context_t *ctx,
+                                   ucp_perf_daemon_req_t *daemon_req)
+{
+    ucp_request_param_t param = {};
+    ucs_status_ptr_t sptr;
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_MEMH      |
+                         UCP_OP_ATTR_FIELD_CALLBACK  |
+                         UCP_OP_ATTR_FIELD_USER_DATA |
+                         UCP_OP_ATTR_FIELD_FLAGS     |
+                         UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    param.memh         = ctx->send_memh;
+    param.cb.send      = ucp_perf_daemon_send_cb;
+    param.user_data    = ctx;
+    param.flags        = UCP_AM_SEND_FLAG_RNDV;
+
+    sptr = ucp_am_send_nbx(ctx->peer_ep, UCP_PERF_DAEMON_AM_ID_OP, NULL, 0ul,
+                           (void*)daemon_req->addr, (size_t)daemon_req->length,
+                           &param);
+
+    return UCS_PTR_STATUS(sptr);
+}
+
+static void ucp_perf_daemon_recv_cb(void *request, ucs_status_t status,
+                                    size_t length, void *user_data)
+{
+    ucp_perf_daemon_context_t *ctx = user_data;
+
+    ucp_perf_daemon_send_am_eager_msg(ctx->client_ep,
+                                      UCP_PERF_DAEMON_AM_ID_RECV_ACK);
+    ucp_request_free(request);
+}
+
+static void ucp_perf_daemon_ep_create(ucp_perf_daemon_context_t *ctx)
+{
+    ucp_ep_params_t ep_params;
+    ucs_status_t status;
+
+    ep_params.field_mask       = UCP_EP_PARAM_FIELD_FLAGS       |
+                                 UCP_EP_PARAM_FIELD_SOCK_ADDR   |
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLER |
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    ep_params.err_mode         = UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.err_handler.cb   = ucp_perf_daemon_err_cb;
+    ep_params.err_handler.arg  = ctx;
+    ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
+    ep_params.sockaddr.addr    = (struct sockaddr*)&ctx->peer_address;
+    ep_params.sockaddr.addrlen = sizeof(ctx->peer_address);
+
+    status = ucp_ep_create(ctx->worker, &ep_params, &ctx->peer_ep);
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to create an endpoint: %s",
+                  ucs_status_string(status));
+    }
+
+    ucp_perf_daemon_send_am_eager_msg(ctx->peer_ep,
+                                      UCP_PERF_DAEMON_AM_ID_PEER_INIT);
+}
+
+static void ucp_perf_daemon_check_am_msg(const ucp_am_recv_param_t *param,
+                                         size_t header_length,
+                                         int check_reply_ep)
+{
+    ucs_assert(!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV));
+    ucs_assertv(header_length == 0, "header_length %zu", header_length);
+
+    if (check_reply_ep) {
+        ucs_assert(param->recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP);
+    }
+}
+
+static ucs_status_t
+ucp_perf_daemon_init_handler(void *arg, const void *header,
+                             size_t header_length, void *data, size_t length,
+                             const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    void *p                        = data;
+    ucs_status_t status;
+    uint16_t address_length;
+    uint16_t send_memh_buf_size;
+    ucp_mem_attr_t attr;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 1);
+
+    if (ctx->peer_ep != NULL) {
+        ucs_fatal("duplicate daemon init req");
+        goto out;
+    }
+
+    ctx->client_ep = param->reply_ep;
+
+    address_length = *ucs_serialize_next(&p, uint16_t);
+
+    if (address_length != 0) {
+        memcpy(&ctx->peer_address,
+               ucs_serialize_next_raw(&p, void, address_length),
+               address_length);
+        ucp_perf_daemon_ep_create(ctx);
+    }
+
+    send_memh_buf_size = *ucs_serialize_next(&p, uint16_t);
+    ctx->send_memh     = ucp_perf_daemon_memh_import(ctx, p);
+    ucs_serialize_next_raw(&p, void, send_memh_buf_size);
+    ucs_serialize_next(&p, uint16_t); /*recv_memh_buf_size*/
+    ctx->recv_memh     = ucp_perf_daemon_memh_import(ctx, p);
+
+    attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS;
+    status          = ucp_mem_query(ctx->recv_memh, &attr);
+    if (status != UCS_OK) {
+        ucs_fatal("daemon failed to query memh: %s", ucs_status_string(status));
+    }
+
+    ctx->rx_address = attr.address;
+
+out:
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_init_peer_handler(void *arg, const void *header,
+                                  size_t header_length, void *data,
+                                  size_t length,
+                                  const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 1);
+
+    ctx->peer_ep = param->reply_ep;
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_req_handler(void *arg, const void *header, size_t header_length,
+                            void *data, size_t length,
+                            const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    ucp_perf_daemon_req_t *dreq    = data;
+    ucs_status_t status;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 0);
+    ucs_assertv(length >= sizeof(*dreq), "length=%lu", length);
+    ucs_assert(ctx->peer_ep != NULL);
+
+    status = ucp_perf_daemon_handle_cmd_am_send(ctx, dreq);
+
+    if (ucs_unlikely(UCS_STATUS_IS_ERR(status))) {
+        ucs_error("operation failed: %s", ucs_status_string(status));
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_op_handler(void *arg, const void *header, size_t header_length,
+                           void *data, size_t length,
+                           const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    ucp_request_param_t params;
+    ucs_status_ptr_t sptr;
+
+    if (!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV)) {
+        ucs_error("am message received with unsupported eager protocol");
+        return UCS_OK;
+    }
+
+    params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK  |
+                          UCP_OP_ATTR_FIELD_USER_DATA |
+                          UCP_OP_ATTR_FIELD_MEMH      |
+                          UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    params.user_data    = ctx;
+    params.cb.recv_am   = ucp_perf_daemon_recv_cb;
+    params.memh         = ctx->recv_memh;
+
+    sptr = ucp_am_recv_data_nbx(ctx->worker, data, ctx->rx_address, length,
+                                &params);
+    if (UCS_PTR_IS_ERR(sptr)) {
+        ucs_error("failed to receive data: %s",
+                  ucs_status_string(UCS_PTR_STATUS(sptr)));
+        return UCS_OK;
+    }
+
+    ucs_assert(UCS_PTR_IS_PTR(sptr));
+
+    return UCS_INPROGRESS;
+}
+
+static ucs_status_t
+ucp_perf_daemon_fin_handler(void *arg, const void *header, size_t header_length,
+                            void *data, size_t length,
+                            const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_check_am_msg(param, header_length, 0);
+
+    terminated = 1;
+
+    return UCS_OK;
+}
+
+static void ucp_perf_daemon_cleanup(ucp_perf_daemon_context_t *ctx)
+{
+    /* coverity[check_return] */
+    ucp_mem_unmap(ctx->context, ctx->send_memh);
+    /* coverity[check_return] */
+    ucp_mem_unmap(ctx->context, ctx->recv_memh);
+
+    ucp_perf_daemon_ep_close(ctx, ctx->peer_ep);
+    ucp_perf_daemon_ep_close(ctx, ctx->client_ep);
+    ucp_listener_destroy(ctx->listener);
+    ucp_worker_destroy(ctx->worker);
+    ucp_cleanup(ctx->context);
+}
+
+static int ucp_perf_daemon_init(ucp_perf_daemon_context_t *ctx)
+{
+    ucp_listener_params_t listen_params = {};
+    ucp_worker_params_t worker_params   = {};
+    ucp_params_t ucp_params;
+    struct sockaddr_in listen_addr;
+    ucp_config_t *config;
+    ucs_status_t status;
+
+    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ucp_params.features   = UCP_FEATURE_AM | UCP_FEATURE_EXPORTED_MEMH;
+
+    status = ucp_config_read(NULL, NULL, &config);
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to read UCP context: %s",
+                  ucs_status_string(status));
+        goto err;
+    }
+
+    status = ucp_init(&ucp_params, config, &ctx->context);
+    ucp_config_release(config);
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to init UCP: %s", ucs_status_string(status));
+        goto err;
+    }
+
+    status = ucp_worker_create(ctx->context, &worker_params, &ctx->worker);
+    if (status != UCS_OK) {
+        ucs_error("failed to create worker: %s", ucs_status_string(status));
+        goto err_free_ctx;
+    }
+
+    ucp_perf_daemon_set_am_recv_handler(ctx->worker, UCP_PERF_DAEMON_AM_ID_INIT,
+                                        ucp_perf_daemon_init_handler, ctx);
+
+    ucp_perf_daemon_set_am_recv_handler(ctx->worker,
+                                        UCP_PERF_DAEMON_AM_ID_PEER_INIT,
+                                        ucp_perf_daemon_init_peer_handler, ctx);
+
+    ucp_perf_daemon_set_am_recv_handler(ctx->worker, UCP_PERF_DAEMON_AM_ID_REQ,
+                                        ucp_perf_daemon_req_handler, ctx);
+
+    ucp_perf_daemon_set_am_recv_handler(ctx->worker, UCP_PERF_DAEMON_AM_ID_OP,
+                                        ucp_perf_daemon_op_handler, ctx);
+
+    ucp_perf_daemon_set_am_recv_handler(ctx->worker, UCP_PERF_DAEMON_AM_ID_FIN,
+                                        ucp_perf_daemon_fin_handler, ctx);
+
+    listen_addr.sin_family      = AF_INET;
+    listen_addr.sin_addr.s_addr = INADDR_ANY;
+    listen_addr.sin_port        = htons(ctx->port);
+
+    listen_params.field_mask       = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
+                                     UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
+    listen_params.sockaddr.addr    = (const struct sockaddr*)&listen_addr;
+    listen_params.sockaddr.addrlen = sizeof(listen_addr);
+    listen_params.conn_handler.cb  = ucp_perf_daemon_server_conn_handle_cb;
+    listen_params.conn_handler.arg = ctx;
+
+    status = ucp_listener_create(ctx->worker, &listen_params, &ctx->listener);
+    if (status != UCS_OK) {
+        ucs_error("failed to listen: %s", ucs_status_string(status));
+        goto err_free_worker;
+    }
+
+    return 0;
+
+err_free_worker:
+    ucp_worker_destroy(ctx->worker);
+err_free_ctx:
+    ucp_cleanup(ctx->context);
+err:
+    return -1;
+}
+
+static void ucp_perf_daemon_signal_terminate_handler(int signo)
+{
+    char msg[64];
+    ssize_t ret __attribute__((unused));
+
+    snprintf(msg, sizeof(msg), "Run-time signal handling: %d\n", signo);
+    ret = write(STDOUT_FILENO, msg, strlen(msg) + 1);
+
+    terminated = 1;
+}
+
+static int ucp_perf_daemon_parse_cmd(ucp_perf_daemon_context_t *ctx, int argc,
+                                     char *const argv[])
+{
+    int c = 0;
+
+    while ((c = getopt(argc, argv, "p:")) != -1) {
+        switch (c) {
+        case 'p':
+            ctx->port = (uint16_t)atoi(optarg);
+            break;
+        default:
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int main(int argc, char *const argv[])
+{
+    ucp_perf_daemon_context_t ctx = {};
+    struct sigaction new_sigaction;
+
+    ctx.port = 1338; /* default value */
+
+    if (ucp_perf_daemon_parse_cmd(&ctx, argc, argv) != 0) {
+        ucs_fatal("failed to parse parameters");
+    }
+
+    new_sigaction.sa_handler = ucp_perf_daemon_signal_terminate_handler;
+    new_sigaction.sa_flags   = 0;
+    sigemptyset(&new_sigaction.sa_mask);
+
+    sigaction(SIGINT, &new_sigaction, NULL);
+    sigaction(SIGHUP, &new_sigaction, NULL);
+    sigaction(SIGTERM, &new_sigaction, NULL);
+
+    if (ucp_perf_daemon_init(&ctx) != 0) {
+        ucs_fatal("failed to initalize");
+    }
+
+    while (!terminated) {
+        ucp_worker_progress(ctx.worker);
+    }
+
+    ucp_perf_daemon_cleanup(&ctx);
+
+    return 0;
+}
+

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -135,6 +135,8 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -H <size>      active message header size (%zu), not included in message size\n",
                                 ctx->params.super.ucp.am_hdr_size);
     printf("     -z             pass pre-registered memory handle\n");
+    printf("     -Z             comma-separated list of <IP-address>:<port> of local and remote\n"
+           "                    daemons to offload UCP operations on\n");
     printf("\n");
     printf("   NOTE: When running UCP tests, transport and device should be specified by\n");
     printf("         environment variables: UCX_TLS and UCX_[SELF|SHM|NET]_DEVICES.\n");
@@ -242,6 +244,147 @@ static ucs_status_t parse_ucp_datatype_params(const char *opt_arg,
         *datatype = UCP_PERF_DATATYPE_CONTIG;
     } else {
         return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t set_sockaddr(const char *ip_addr_str, uint16_t port,
+                          struct sockaddr *saddr)
+{
+    struct sockaddr_in* sa_in   = (struct sockaddr_in*)saddr;
+    struct sockaddr_in6* sa_in6 = (struct sockaddr_in6*)saddr;
+
+    if (inet_pton(AF_INET, ip_addr_str, &sa_in->sin_addr) == 1) {
+        sa_in->sin_family = AF_INET;
+        sa_in->sin_port   = htons(port);
+        return UCS_OK;
+    }
+
+    if (inet_pton(AF_INET6, ip_addr_str, &sa_in6->sin6_addr) == 1) {
+        sa_in6->sin6_family = AF_INET6;
+        sa_in6->sin6_port   = htons(port);
+        return UCS_OK;
+    }
+
+    ucs_error("invalid address '%s'", ip_addr_str);
+
+    return UCS_ERR_INVALID_PARAM;
+}
+
+static ucs_status_t parse_ip_addr_port(const char *str,
+                                       struct sockaddr_storage *addr)
+{
+    const char *delim = ":";
+    uint16_t port     = 0;
+    char *save_ptr, *token;
+    const char *ip_addr_str;
+
+    ip_addr_str = strtok_r((char*)str, delim, &save_ptr);
+    token       = strtok_r(NULL, delim, &save_ptr);
+    if (token != NULL) {
+        port = atoi(token);
+    }
+
+    set_sockaddr(ip_addr_str, port, (struct sockaddr*)addr);
+
+    return UCS_OK;
+}
+
+static ucs_status_t parse_ip_addr_port_params(const char *opt_arg,
+                                              struct sockaddr_storage *addrs,
+                                              size_t max_addrs,
+                                              size_t *num_addrs_p)
+{
+    const char *delim = ",";
+    char *save_ptr, *token;
+    ucs_status_t status;
+    size_t i;
+
+    token = strtok_r((char*)opt_arg, delim, &save_ptr);
+    for (i = 0; i < max_addrs; ++i) {
+        if (token == NULL) {
+            goto out;
+        }
+
+        status = parse_ip_addr_port(token, &addrs[i]);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        token = strtok_r(NULL, delim, &save_ptr);
+    }
+
+out:
+    *num_addrs_p = i;
+    return UCS_OK;
+}
+
+static ucs_status_t daemon_addrs_init(struct perftest_context *ctx)
+{
+    struct sockaddr *addr;
+    struct sockaddr_in *sa_in;
+    struct sockaddr_in6 *sa_in6;
+    size_t i;
+
+    if (ctx->params.super.ucp.daemon_addrs_num == 0) {
+        return UCS_OK;
+    }
+
+    for (i = 0; i < ctx->params.super.ucp.daemon_addrs_num; ++i) {
+        addr = (struct sockaddr*)&ctx->params.super.ucp.daemon_addrs[i];
+        switch (addr->sa_family) {
+        case AF_INET:
+            sa_in = (struct sockaddr_in*)addr;
+            if (sa_in->sin_port == 0) {
+                sa_in->sin_port = htons(ctx->port);
+            }
+            break;
+        case AF_INET6:
+            sa_in6 = (struct sockaddr_in6*)addr;
+            if (sa_in6->sin6_port == 0) {
+                sa_in6->sin6_port = htons(ctx->port);
+            }
+            break;
+        default:
+            ucs_error("unexpected address family %d", addr->sa_family);
+            break;
+        }
+    }
+
+    if (i == 1) {
+        memcpy(&ctx->params.super.ucp.daemon_addrs[1],
+               &ctx->params.super.ucp.daemon_addrs[0],
+               sizeof(ctx->params.super.ucp.daemon_addrs[0]));
+        ++ctx->params.super.ucp.daemon_addrs_num;
+    }
+
+    if ((ctx->params.super.ucp.send_datatype != UCP_PERF_DATATYPE_CONTIG) ||
+        (ctx->params.super.ucp.recv_datatype != UCP_PERF_DATATYPE_CONTIG)) {
+        ucs_error("only contiguous datatype is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if ((ctx->params.super.send_mem_type != UCS_MEMORY_TYPE_HOST) ||
+        (ctx->params.super.recv_mem_type != UCS_MEMORY_TYPE_HOST)) {
+        ucs_error("only HOST memory type is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (ctx->params.super.command != UCX_PERF_CMD_AM) {
+        ucs_error("only UCP AM API is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (ctx->params.super.ucp.am_hdr_size != 0) {
+        ucs_error("sending UCP AM with non-zero header size is not supported"
+                  " in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (ctx->params.super.thread_count > 1) {
+        ucs_error("only 1 thread is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
     }
 
     return UCS_OK;
@@ -417,6 +560,11 @@ ucs_status_t parse_test_params(perftest_params_t *params, char opt,
     case 'z':
         params->super.flags |= UCX_PERF_TEST_FLAG_PREREG;
         return UCS_OK;
+    case 'Z':
+        return parse_ip_addr_port_params(opt_arg,
+                                         params->super.ucp.daemon_addrs,
+                                         UCP_PERF_TEST_DAEMON_ADDRESS_MAX_NUMBER,
+                                         &params->super.ucp.daemon_addrs_num);
     default:
        return UCS_ERR_INVALID_PARAM;
     }
@@ -607,5 +755,5 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
         }
     }
 
-    return UCS_OK;
+    return daemon_addrs_init(ctx);
 }

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -238,6 +238,7 @@ void test_perf::test_params_init(const test_spec &test,
     params.ucp.recv_datatype    = (ucp_perf_datatype_t)test.data_layout;
     params.ucp.nonblocking_mode = 0;
     params.ucp.am_hdr_size      = 0;
+    params.ucp.daemon_addrs_num = 0;
 }
 
 test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsigned flags,

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -131,6 +131,7 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.so
 %{_libdir}/lib*.so.*
 %{_bindir}/ucx_info
 %{_bindir}/ucx_perftest
+%{_bindir}/ucx_perftest_daemon
 %{_bindir}/ucx_read_profile
 %if "%{debug}" == "1"
 %{_bindir}/ucs_stats_parser


### PR DESCRIPTION
## What
Initial support for offloading communication to DPU using exported memh feature 


## How ?
The way to start a benchmark is:
- Run daemons on client and server (can be on the same DPU or on a different ones):
` UCX_TLS=rc UCX_MAX_RNDV_LANES=1 UCX_RNDV_THRESH=0 ./src/tools/perf/ucx_perftest_daemon -p 1339`
` UCX_TLS=rc UCX_MAX_RNDV_LANES=1 UCX_RNDV_THRESH=0 ./src/tools/perf/ucx_perftest_daemon -p 1338`

- Run server:
` UCX_TLS=rc UCX_MAX_RNDV_LANES=1 UCX_RNDV_THRESH=0  ./src/tools/perf/ucx_perftest`

- Run client:
`UCX_TLS=rc UCX_MAX_RNDV_LANES=1 UCX_RNDV_THRESH=0  ./src/tools/perf/ucx_perftest -t ucp_am_bw -n 1000  -s 2097152 -Z ip_dpu1:1338,ip_dpu2:1339 ip_server`
where `ip_dpu1, ip_dpu2 and ip_server` are the real IP addresses of the corresponding cluster

