### PR TITLE
GTEST: skip test_ucp_tag_match under valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -37,6 +37,9 @@ public:
         if (use_proto()) {
             modify_config("PROTO_ENABLE", "y");
             modify_config("MAX_EAGER_LANES", "2");
+        } else if (RUNNING_ON_VALGRIND && m_ucp_config->ctx.proto_enable) {
+            UCS_TEST_SKIP_R("FIXME: skip forced UCX_PROTO_ENABLE=y because "
+                            "it does not completely support HWTM");
         } else {
             // TODO:
             // 1. test offload and offload MP as different variants


### PR DESCRIPTION
## What
skip test_ucp_tag_match under valgrind in case of forced UCX_PROTO_ENABLE and HWTM variants

## Why ?
workaround for  https://github.com/openucx/ucx/pull/8731, minimal reproducer is implemented in https://github.com/openucx/ucx/pull/8769
