### PR TITLE
GTEST: Don't run gtest on wireless interfaces

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -464,7 +464,8 @@ bool is_interface_usable(struct ifaddrs *ifa)
     return ucs_netif_flags_is_active(ifa->ifa_flags) &&
            ucs::is_inet_addr(ifa->ifa_addr) &&
            !netif_has_sysfs_file(ifa->ifa_name, "bridge") &&
-           !netif_has_sysfs_file(ifa->ifa_name, "brport");
+           !netif_has_sysfs_file(ifa->ifa_name, "brport") &&
+           !netif_has_sysfs_file(ifa->ifa_name, "wireless");
 }
 
 static std::vector<std::string> read_dir(const std::string& path)


### PR DESCRIPTION
## What
Don't run gtest on wireless interfaces

## Why ?
Makes it difficult to develop on desktops and workstations.
