### PR TITLE
UCP/WIREUP: Filter slow lanes in selection process

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -19,6 +19,7 @@
 #include <ucp/core/ucp_ep.inl>
 #include <string.h>
 #include <inttypes.h>
+#include <float.h>
 
 #define UCP_WIREUP_RMA_BW_TEST_MSG_SIZE    262144
 #define UCP_WIREUP_UCT_EVENT_CAP_FLAGS     (UCT_IFACE_FLAG_EVENT_SEND_COMP | \
@@ -1426,29 +1427,94 @@ ucp_wireup_is_md_map_count_valid(ucp_context_h context, ucp_md_map_t md_map)
            (ucs_popcount(md_map) < UCP_MAX_OP_MDS);
 }
 
+static double ucp_wireup_get_lane_progress_overhead(ucp_worker_h worker,
+                                                    ucp_rsc_index_t rsc_index)
+{
+    ucp_worker_iface_t *wiface = ucp_worker_iface(worker, rsc_index);
+    uct_perf_attr_t perf_attr;
+
+    perf_attr.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
+                           UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD;
+
+    /* We use AM_SHORT as a dummy operation because we don't know which
+        protocol will be selected (anyway it has no effect on the value of
+        progress_overhead). */
+    perf_attr.operation = UCT_EP_OP_AM_SHORT;
+
+    if (uct_iface_estimate_perf(wiface->iface, &perf_attr) != UCS_OK) {
+        /* Skip the overhead check if no value was retrieved */
+        return 0;
+    }
+
+    return perf_attr.progress_overhead;
+}
+
+static unsigned
+ucp_wireup_add_fast_lanes(const ucp_wireup_select_params_t *select_params,
+                          const ucp_wireup_select_info_t *sinfo_array,
+                          unsigned num_sinfo, ucp_worker_h worker,
+                          ucp_lane_type_t lane_type,
+                          ucp_wireup_select_context_t *select_ctx)
+{
+    unsigned num_lanes     = 0;
+    double min_overhead    = DBL_MAX;
+    ucp_context_h context  = worker->context;
+    const double max_ratio = 1. / context->config.ext.multi_lane_max_ratio;
+    ucs_status_t status;
+    int show_error;
+    unsigned sinfo_index;
+    double overhead;
+
+    /* Iterate over all elements and calculate minimum progress overhead */
+    for (sinfo_index = 0; sinfo_index < num_sinfo; ++sinfo_index) {
+        overhead     = ucp_wireup_get_lane_progress_overhead(
+                worker, sinfo_array[sinfo_index].rsc_index);
+        min_overhead = ucs_min(overhead, min_overhead);
+    }
+
+    /* Compare each element to minimum progress overhead and filter only fast lanes */
+    for (sinfo_index = 0; sinfo_index < num_sinfo; ++sinfo_index) {
+        overhead = ucp_wireup_get_lane_progress_overhead(
+                worker, sinfo_array[sinfo_index].rsc_index);
+        if ((min_overhead > 0) && ((min_overhead / overhead) < max_ratio)) {
+            continue;
+        }
+
+        show_error = (num_lanes == 0);
+        status = ucp_wireup_add_lane(select_params, &sinfo_array[sinfo_index],
+                                     lane_type, show_error, select_ctx);
+        if (status != UCS_OK) {
+            break;
+        }
+
+        num_lanes++;
+    }
+
+    return num_lanes;
+}
+
 static unsigned
 ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
                         ucp_wireup_select_bw_info_t *bw_info,
                         ucp_tl_bitmap_t tl_bitmap, ucp_lane_index_t excl_lane,
                         ucp_wireup_select_context_t *select_ctx)
 {
-    ucp_ep_h ep                          = select_params->ep;
-    ucp_context_h context                = ep->worker->context;
-    ucp_wireup_select_info_t sinfo       = {0};
-    ucp_wireup_dev_usage_count dev_count = {};
+    ucp_ep_h ep                                   = select_params->ep;
+    ucp_context_h context                         = ep->worker->context;
+    ucp_wireup_select_info_t sinfo[UCP_MAX_LANES] = {{0}};
+    ucp_wireup_dev_usage_count dev_count          = {};
     const uct_iface_attr_t *iface_attr;
     const ucp_address_entry_t *ae;
     ucs_status_t status;
-    unsigned num_lanes;
+    unsigned num_sinfo;
     uint64_t local_dev_bitmap;
     uint64_t remote_dev_bitmap;
     ucp_rsc_index_t dev_index;
     ucp_md_map_t md_map;
     ucp_rsc_index_t rsc_index;
     unsigned addr_index;
-    int show_error;
 
-    num_lanes             = 0;
+    num_sinfo             = 0;
     md_map                = bw_info->md_map;
     local_dev_bitmap      = bw_info->local_dev_bitmap;
     remote_dev_bitmap     = bw_info->remote_dev_bitmap;
@@ -1457,30 +1523,23 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
     /* lookup for requested number of lanes or limit of MD map
      * (we have to limit MD's number to avoid malloc in
      * memory registration) */
-    while ((num_lanes < bw_info->max_lanes) &&
+    while ((num_sinfo < bw_info->max_lanes) &&
            ucp_wireup_is_md_map_count_valid(context, md_map)) {
         if (excl_lane == UCP_NULL_LANE) {
             status = ucp_wireup_select_transport(select_ctx, select_params,
                                                  &bw_info->criteria, tl_bitmap,
                                                  UINT64_MAX, local_dev_bitmap,
-                                                 remote_dev_bitmap, 0, &sinfo);
+                                                 remote_dev_bitmap, 0,
+                                                 &sinfo[num_sinfo]);
             if (status != UCS_OK) {
                 break;
             }
 
-            rsc_index        = sinfo.rsc_index;
-            addr_index       = sinfo.addr_index;
-            dev_index        = context->tl_rscs[rsc_index].dev_index;
-            sinfo.path_index = dev_count.local[dev_index];
-            show_error       = (num_lanes == 0);
-            status           = ucp_wireup_add_lane(select_params, &sinfo,
-                                                   bw_info->criteria.lane_type,
-                                                   show_error, select_ctx);
-            if (status != UCS_OK) {
-                break;
-            }
-
-            num_lanes++;
+            rsc_index  = sinfo[num_sinfo].rsc_index;
+            addr_index = sinfo[num_sinfo].addr_index;
+            dev_index  = context->tl_rscs[rsc_index].dev_index;
+            sinfo[num_sinfo].path_index = dev_count.local[dev_index];
+            num_sinfo++;
         } else {
             /* disqualify/count lane_desc_idx */
             addr_index      = select_ctx->lane_descs[excl_lane].addr_index;
@@ -1510,7 +1569,9 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
 
     bw_info->criteria.arg = NULL; /* To suppress compiler warning */
 
-    return num_lanes;
+    return ucp_wireup_add_fast_lanes(select_params, sinfo, num_sinfo,
+                                     ep->worker, bw_info->criteria.lane_type,
+                                     select_ctx);
 }
 
 static ucs_status_t

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -86,14 +86,17 @@ enum uct_perf_attr_field {
     /** Enables @ref uct_perf_attr_t::recv_overhead */
     UCT_PERF_ATTR_FIELD_RECV_OVERHEAD      = UCS_BIT(7),
 
+    /** Enables @ref uct_perf_attr_t::progress_overhead */
+    UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD  = UCS_BIT(8),
+
     /** Enables @ref uct_perf_attr_t::bandwidth */
-    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(8),
+    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(9),
 
     /** Enables @ref uct_perf_attr_t::latency */
-    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(9),
+    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(10),
 
     /** Enable @ref uct_perf_attr_t::max_inflight_eps */
-    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10)
+    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(11)
 };
 
 
@@ -166,6 +169,12 @@ typedef struct {
      * This field is set by the UCT layer.
      */
     double              recv_overhead;
+
+    /**
+     * This is the time spent progressing the request, in seconds.
+     * This field is set by the UCT layer.
+     */
+    double              progress_overhead;
 
     /**
      * Bandwidth model. This field is set by the UCT layer.

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -441,6 +441,10 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->recv_overhead = iface_attr.overhead;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 0;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         perf_attr->bandwidth = iface_attr.bandwidth;
     }

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -370,6 +370,10 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->recv_overhead = 0;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 0;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
         /* In case of async mem copy, the latency is not part of the overhead
            and it's a standalone property */

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -135,6 +135,10 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->recv_overhead = 0;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 0;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
         perf_attr->latency = UCT_GDR_COPY_IFACE_LATENCY;
     }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1688,6 +1688,10 @@ uct_ib_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->recv_overhead = iface_attr.overhead;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 20e-9;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         perf_attr->bandwidth = iface_attr.bandwidth;
     }

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -172,6 +172,10 @@ uct_rocm_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->recv_overhead = 0;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 0;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
         perf_attr->latency = ucs_linear_func_make(10e-6, 0);
     }

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -560,6 +560,10 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->send_post_overhead = 0;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 0;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
         perf_attr->latency = UCT_MM_IFACE_LATENCY;
     }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -550,6 +550,24 @@ err:
     return status;
 }
 
+ucs_status_t
+uct_tcp_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+{
+    ucs_status_t status;
+
+    status = uct_base_iface_estimate_perf(iface, perf_attr);
+
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PROGRESS_OVERHEAD) {
+        perf_attr->progress_overhead = 100e-9;
+    }
+
+    return UCS_OK;
+}
+
 static ucs_mpool_ops_t uct_tcp_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,
@@ -559,7 +577,7 @@ static ucs_mpool_ops_t uct_tcp_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_tcp_iface_internal_ops = {
-    .iface_estimate_perf = uct_base_iface_estimate_perf,
+    .iface_estimate_perf = uct_tcp_iface_estimate_perf,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -209,6 +209,12 @@ protected:
         }
 
         flush_req = sender().flush_worker_nb(0);
+        if ((flush_req == NULL) &&
+            (get_variant_value() & TEST_DISCARD_DISABLED)) {
+            UCS_TEST_MESSAGE << "all EPs returned UCS_OK in 'flush_worker_nb'";
+            goto out;
+        }
+
         ASSERT_FALSE(flush_req == NULL);
         ASSERT_TRUE(UCS_PTR_IS_PTR(flush_req));
 


### PR DESCRIPTION
## What
Filter slow lanes in selection process.

## Why ?
Avoid selecting TCP lanes if we have IB lanes.
The filtering is done by removing lanes with a large enough progress overhead compared to the best lane.
By default, each lane with more than 0.25 of the minimum overhead is filtered out.


