### PR TITLE
GTEST: Adding explicit call to nvml init

### DIFF
--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -185,7 +185,7 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     /* Trim by BAR1 size if relevant */
     if ((mem_type == UCS_MEMORY_TYPE_CUDA) ||
         (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED)) {
-        /* Allocate 40% to accommodate send/receive buffers allocation */
+        /* Allocate 40% x 2 (RX/TX) to accommodate send/receive buffers allocation */
         max_length = ucs_min(max_length,
                 (size_t)(0.4 * mem_buffer::get_bar1_free_size()));
     }


### PR DESCRIPTION
There are gtest flows that do not call CUDA TL. As a result the nvml library does not get initialized. The side effect of this is that the trim function always returns the MAX size_t value.