### PR TITLE
JAVA/TEST: Don't run tests on docker interfaces

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpListenerTest.java
@@ -28,7 +28,9 @@ public class UcpListenerTest  extends UcxTest {
             return Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
                 .filter(iface -> {
                     try {
-                        return iface.isUp() && !iface.isLoopback();
+                        return iface.isUp() && !iface.isLoopback() &&
+                            !iface.isVirtual() &&
+                            !iface.getName().contains("docker");
                     } catch (SocketException e) {
                         return false;
                     }


### PR DESCRIPTION
## Why
Fix occasional failures in Java test on GPU test node