### PR TITLE
UCP/PROTO: Unite select_param->op_flags and select_param->op_id

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -52,7 +52,7 @@ ucp_am_eager_multi_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
-    if (!ucp_am_check_init_params(init_params, UCP_AM_OP_ID_MASK_ALL,
+    if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)) {
         return UCS_ERR_UNSUPPORTED;
     }
@@ -221,7 +221,7 @@ ucp_am_eager_multi_zcopy_proto_init(const ucp_proto_init_params_t *init_params)
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY
     };
 
-    if (!ucp_am_check_init_params(init_params, UCP_AM_OP_ID_MASK_ALL,
+    if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)) {
         return UCS_ERR_UNSUPPORTED;
     }

--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -61,7 +61,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
 
 ucs_status_t ucp_am_rndv_rts_init(const ucp_proto_init_params_t *init_params)
 {
-    if (!ucp_am_check_init_params(init_params, UCP_AM_OP_ID_MASK_ALL,
+    if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)) {
         return UCS_ERR_UNSUPPORTED;
     }

--- a/src/ucp/am/ucp_am.inl
+++ b/src/ucp/am/ucp_am.inl
@@ -8,9 +8,11 @@
 
 #include <ucp/core/ucp_am.h>
 #include <ucp/core/ucp_request.h>
+#include <ucp/proto/proto_init.h>
+#include <ucp/proto/proto_select.inl>
 
 
-#define UCP_AM_OP_ID_MASK_ALL \
+#define UCP_PROTO_AM_OP_ID_MASK \
     (UCS_BIT(UCP_OP_ID_AM_SEND) | UCS_BIT(UCP_OP_ID_AM_SEND_REPLY))
 
 
@@ -26,14 +28,15 @@ static UCS_F_ALWAYS_INLINE int
 ucp_am_check_init_params(const ucp_proto_init_params_t *init_params,
                          uint64_t op_id_mask, uint16_t exclude_flags)
 {
-    return (UCS_BIT(init_params->select_param->op_id) & op_id_mask) &&
-           !(init_params->select_param->op_flags & exclude_flags);
+    return ucp_proto_init_check_op(init_params, op_id_mask) &&
+           !(init_params->select_param->op_id_flags & exclude_flags);
 }
 
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_config_is_am(const ucp_proto_config_t *proto_config)
 {
-    return UCS_BIT(proto_config->select_param.op_id) & UCP_AM_OP_ID_MASK_ALL;
+    return UCS_BIT(ucp_proto_select_op_id(&proto_config->select_param)) &
+           UCP_PROTO_AM_OP_ID_MASK;
 }
 
 #endif

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -58,6 +58,10 @@ typedef uint64_t ucp_proto_id_mask_t;
 typedef struct ucp_proto_perf_node ucp_proto_perf_node_t;
 
 
+/* Key for selecting a protocol */
+typedef struct ucp_proto_select_param ucp_proto_select_param_t;
+
+
 /* Protocol stage ID */
 enum {
     /* Initial stage. All protocols start from this stage. */
@@ -78,23 +82,6 @@ enum {
                                               uct_ep_tag_eager_short() */
     UCP_PROTO_FLAG_INVALID   = UCS_BIT(3)  /* The protocol is a placeholder */
 };
-
-
-/**
- * Key for looking up protocol configuration by operation parameters
- */
-typedef struct {
-    uint8_t                 op_id;      /* Operation ID */
-    uint16_t                op_flags;   /* Operation flags */
-    uint8_t                 dt_class;   /* Datatype */
-    uint8_t                 mem_type;   /* Memory type */
-    uint8_t                 sys_dev;    /* System device */
-    uint8_t                 sg_count;   /* Number of non-contig scatter/gather
-                                           entries. If the actual number is larger
-                                           than UINT8_MAX, UINT8_MAX is used. */
-    uint8_t                 padding;    /* Make structure size be
-                                           sizeof(uint64_t) */
-} UCS_S_PACKED ucp_proto_select_param_t;
 
 
 /*

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -25,7 +25,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_request_bcopy_complete_success(ucp_request_t *req)
 {
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UCP_DT_MASK_ALL);
-    if (req->send.proto_config->select_param.op_id == UCP_OP_ID_TAG_SEND) {
+    if (ucp_proto_select_op_id(&req->send.proto_config->select_param) ==
+        UCP_OP_ID_TAG_SEND) {
         UCP_EP_STAT_TAG_OP(req->send.ep, EAGER)
     }
 
@@ -86,7 +87,8 @@ ucp_proto_request_zcopy_complete(ucp_request_t *req, ucs_status_t status)
 {
     ucp_proto_request_zcopy_clean(req, UCP_DT_MASK_CONTIG_IOV);
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UCP_DT_MASK_CONTIG_IOV);
-    if (req->send.proto_config->select_param.op_id == UCP_OP_ID_TAG_SEND) {
+    if (ucp_proto_select_op_id(&req->send.proto_config->select_param) ==
+        UCP_OP_ID_TAG_SEND) {
         UCP_EP_STAT_TAG_OP(req->send.ep, EAGER)
     }
 
@@ -237,7 +239,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
                           const void *buffer, size_t count,
                           ucp_datatype_t datatype, size_t contig_length,
                           const ucp_request_param_t *param,
-                          size_t header_length, uint16_t op_flags)
+                          size_t header_length, unsigned op_flags)
 {
     ucp_worker_h worker = ep->worker;
     ucp_proto_select_param_t sel_param;

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -11,6 +11,8 @@
 #include "proto_init.h"
 #include "proto_select.inl"
 
+#include <ucp/am/ucp_am.inl>
+#include <ucp/rndv/proto_rndv.h>
 #include <ucs/arch/atomic.h>
 #include <ucs/datastruct/array.inl>
 #include <fnmatch.h>
@@ -317,54 +319,73 @@ void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
                               select_short->lane, select_short->rkey_index);
 }
 
-static int ucp_proto_op_is_fetch(ucp_operation_id_t op_id)
+static int
+ucp_proto_select_is_fetch_op(const ucp_proto_select_param_t *select_param)
 {
-    return (op_id == UCP_OP_ID_GET) || (op_id == UCP_OP_ID_RNDV_RECV);
+    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
+           (UCS_BIT(UCP_OP_ID_GET) | UCS_BIT(UCP_OP_ID_RNDV_RECV));
+}
+
+static int
+ucp_proto_select_is_rndv_op(const ucp_proto_select_param_t *select_param)
+{
+    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
+           UCP_PROTO_AM_OP_ID_MASK;
+}
+
+static int
+ucp_proto_select_is_am_op(const ucp_proto_select_param_t *select_param)
+{
+    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
+           UCP_PROTO_RNDV_OP_ID_MASK;
 }
 
 void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
                                 const char **operation_names,
                                 ucs_string_buffer_t *strb)
 {
-    static const uint64_t op_attr_bits = UCP_OP_ATTR_FLAG_FAST_CMPL |
-                                         UCP_OP_ATTR_FLAG_MULTI_SEND;
-    static const char *op_attr_names[] = {
+    static const uint32_t op_attr_bits   = UCP_OP_ATTR_FLAG_FAST_CMPL |
+                                           UCP_OP_ATTR_FLAG_MULTI_SEND;
+    static const char *op_attr_names[]   = {
         [ucs_ilog2(UCP_OP_ATTR_FLAG_FAST_CMPL)]  = "fast-completion",
         [ucs_ilog2(UCP_OP_ATTR_FLAG_MULTI_SEND)] = "multi",
     };
-    static const uint64_t op_flag_bits = UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG |
-                                         UCP_PROTO_SELECT_OP_FLAG_AM_EAGER |
-                                         UCP_PROTO_SELECT_OP_FLAG_AM_RNDV;
-    static const char *op_flag_names[] = {
-        [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG)] = "frag",
-        [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)]  = "egr",
-        [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)]   = "rndv",
+    static const char *rndv_flag_names[] = {
+        [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG)] = "frag"
     };
-    unsigned op_flags                  = select_param->op_flags;
+    static const char *am_flag_names[]   = {
+        [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)] = "egr",
+        [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)]  = "rndv"
+    };
+    unsigned op_flags                    = select_param->op_id_flags &
+                                           (UCP_PROTO_SELECT_OP_FLAGS_BASE - 1);
     const char *sysdev_name;
     uint32_t op_attr_mask;
 
-    ucs_string_buffer_appendf(strb, "%s", operation_names[select_param->op_id]);
+    ucs_string_buffer_appendf(
+            strb, "%s", operation_names[ucp_proto_select_op_id(select_param)]);
 
-    op_attr_mask = ucp_proto_select_op_attr_from_flags(op_flags);
+    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr) &
+                   op_attr_bits;
 
-    if ((op_attr_mask & op_attr_bits) || (op_flags & op_flag_bits)) {
+    if (op_attr_mask || op_flags) {
         ucs_string_buffer_appendf(strb, "(");
-        if (op_attr_mask & op_attr_bits) {
-            ucs_string_buffer_append_flags(strb, op_attr_mask & op_attr_bits,
-                                           op_attr_names);
+        if (op_attr_mask) {
+            ucs_string_buffer_append_flags(strb, op_attr_mask, op_attr_names);
             ucs_string_buffer_appendf(strb, ",");
         }
-        if (op_flags & op_flag_bits) {
-            ucs_string_buffer_append_flags(strb, op_flags & op_flag_bits,
-                                           op_flag_names);
-            ucs_string_buffer_appendf(strb, ",");
+        if (op_flags) {
+            if (ucp_proto_select_is_rndv_op(select_param)) {
+                ucs_string_buffer_append_flags(strb, op_flags, rndv_flag_names);
+            } else if (ucp_proto_select_is_am_op(select_param)) {
+                ucs_string_buffer_append_flags(strb, op_flags, am_flag_names);
+            }
         }
         ucs_string_buffer_rtrim(strb, ",");
         ucs_string_buffer_appendf(strb, ")");
     }
 
-    if (ucp_proto_op_is_fetch(select_param->op_id)) {
+    if (ucp_proto_select_is_fetch_op(select_param)) {
         ucs_string_buffer_appendf(strb, " into ");
     } else {
         ucs_string_buffer_appendf(strb, " from ");
@@ -423,7 +444,7 @@ void ucp_proto_config_info_str(ucp_worker_h worker,
 
     /* Emulate protocol selection process */
     ucs_assert(new_key_cfg_index == proto_config->rkey_cfg_index);
-    select_elem = ucp_proto_select_lookup_slow(worker, proto_select,
+    select_elem = ucp_proto_select_lookup_slow(worker, proto_select, 1,
                                                proto_config->ep_cfg_index,
                                                proto_config->rkey_cfg_index,
                                                &proto_config->select_param);
@@ -451,7 +472,7 @@ void ucp_proto_select_info_str(ucp_worker_h worker,
         return;
     }
 
-    if (ucp_proto_op_is_fetch(select_param->op_id)) {
+    if (ucp_proto_select_is_fetch_op(select_param)) {
         ucs_string_buffer_appendf(strb, " from ");
     } else {
         ucs_string_buffer_appendf(strb, " to ");
@@ -948,10 +969,6 @@ void ucp_proto_select_elem_trace(ucp_worker_h worker,
 {
     ucs_string_buffer_t strb = UCS_STRING_BUFFER_INITIALIZER;
     char *line;
-
-    if (select_param->op_flags & UCP_PROTO_SELECT_OP_FLAG_INTERNAL) {
-        return;
-    }
 
     /* Print human-readable protocol selection table to the log */
     ucp_proto_select_elem_info(worker, ep_cfg_index, rkey_cfg_index,

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -530,7 +530,7 @@ ucp_proto_common_init_xfer_perf(const ucp_proto_common_init_params_t *params,
 
     xfer_perf->node = ucp_proto_perf_node_new_data("xfer", "");
 
-    op_attr_mask = ucp_proto_select_op_attr_from_flags(select_param->op_flags);
+    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr);
 
     if ((op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) &&
         !(params->flags & UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY)) {
@@ -580,7 +580,7 @@ ucp_proto_common_init_recv_perf(const ucp_proto_common_init_params_t *params,
 
     recv_perf->node = ucp_proto_perf_node_new_data("recv-ovrh", "");
 
-    op_attr_mask = ucp_proto_select_op_attr_from_flags(select_param->op_flags);
+    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr);
 
     if (/* Don't care about receiver time for one-sided remote access */
         (params->flags & UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS) ||
@@ -707,4 +707,11 @@ out_deref_send_perf:
 out_deref_xfer_perf:
     ucp_proto_perf_node_deref(&xfer_perf.node);
     return status;
+}
+
+int ucp_proto_init_check_op(const ucp_proto_init_params_t *init_params,
+                            uint64_t op_id_mask)
+{
+    return !!(UCS_BIT(ucp_proto_select_op_id(init_params->select_param)) &
+              op_id_mask);
 }

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -106,4 +106,17 @@ ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
                            ucp_proto_perf_node_t *const tl_perf_node,
                            ucp_md_map_t reg_md_map);
 
+
+/**
+ * Check if protocol initialization parameters contain one of the specified
+ * operations.
+ *
+ * @param [in] init_params   Protocol initialization parameters.
+ * @param [in] op_id_mask    Bitmap of operations to check.
+ *
+ * @return Nonzero if one of the operations is present.
+ */
+int ucp_proto_init_check_op(const ucp_proto_init_params_t *init_params,
+                            uint64_t op_id_mask);
+
 #endif

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -138,7 +138,8 @@ static ucs_status_t ucp_proto_thresholds_next_range(
     ucs_memunits_range_str(msg_length, max_length, range_str,
                            sizeof(range_str));
     ucs_trace("select best protocol for %s %s",
-              ucp_operation_names[select_param->op_id], range_str);
+              ucp_operation_names[ucp_proto_select_op_id(select_param)],
+              range_str);
 
     ucs_log_indent(1);
 
@@ -546,7 +547,7 @@ err:
 }
 
 static ucs_status_t
-ucp_proto_select_elem_init(ucp_worker_h worker,
+ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
                            ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
                            const ucp_proto_select_param_t *select_param,
@@ -586,8 +587,11 @@ ucp_proto_select_elem_init(ucp_worker_h worker,
         goto out_cleanup_proto_init;
     }
 
-    ucp_proto_select_elem_trace(worker, ep_cfg_index, rkey_cfg_index,
-                                select_param, select_elem);
+    if (!internal) {
+        ucp_proto_select_elem_trace(worker, ep_cfg_index, rkey_cfg_index,
+                                    select_param, select_elem);
+    }
+
     status = UCS_OK;
 
 out_cleanup_proto_init:
@@ -621,7 +625,7 @@ static void ucp_proto_select_cache_reset(ucp_proto_select_t *proto_select)
 
 ucp_proto_select_elem_t *
 ucp_proto_select_lookup_slow(ucp_worker_h worker,
-                             ucp_proto_select_t *proto_select,
+                             ucp_proto_select_t *proto_select, int internal,
                              ucp_worker_cfg_index_t ep_cfg_index,
                              ucp_worker_cfg_index_t rkey_cfg_index,
                              const ucp_proto_select_param_t *select_param)
@@ -639,8 +643,9 @@ ucp_proto_select_lookup_slow(ucp_worker_h worker,
         goto out;
     }
 
-    status = ucp_proto_select_elem_init(worker, ep_cfg_index, rkey_cfg_index,
-                                        select_param, &tmp_select_elem);
+    status = ucp_proto_select_elem_init(worker, internal, ep_cfg_index,
+                                        rkey_cfg_index, select_param,
+                                        &tmp_select_elem);
     if (status != UCS_OK) {
         return NULL;
     }

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -19,25 +19,41 @@
 #define UCP_PROTO_SELECT_OP_ATTR_BASE   UCP_OP_ATTR_FLAG_NO_IMM_CMPL
 #define UCP_PROTO_SELECT_OP_ATTR_MASK   (UCP_OP_ATTR_FLAG_FAST_CMPL | \
                                          UCP_OP_ATTR_FLAG_MULTI_SEND)
-#define UCP_PROTO_SELECT_OP_FLAGS_BASE  UCS_BIT(5)
+
+/* Operation flags start bit */
+#define UCP_PROTO_SELECT_OP_FLAGS_BASE UCS_BIT(4)
 
 
-/* Select a protocol for sending one fragment of a rendezvous pipeline */
+/* Select a protocol for sending one fragment of a rendezvous pipeline.
+ * Relevant for UCP_OP_ID_RNDV_SEND and UCP_OP_ID_RNDV_RECV. */
 #define UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG (UCP_PROTO_SELECT_OP_FLAGS_BASE << 0)
 
 
-/* Select a protocol as part of performance estimation of another protocol,
-   rather for actually sending a request */
-#define UCP_PROTO_SELECT_OP_FLAG_INTERNAL (UCP_PROTO_SELECT_OP_FLAGS_BASE << 1)
-
-
-/* Select eager/rendezvous protocol for Active Message sends */
-#define UCP_PROTO_SELECT_OP_FLAG_AM_EAGER (UCP_PROTO_SELECT_OP_FLAGS_BASE << 2)
-#define UCP_PROTO_SELECT_OP_FLAG_AM_RNDV  (UCP_PROTO_SELECT_OP_FLAGS_BASE << 3)
+/* Select eager/rendezvous protocol for Active Message sends.
+ * Relevant for UCP_OP_ID_AM_SEND and UCP_OP_ID_AM_SEND_REPLY. */
+#define UCP_PROTO_SELECT_OP_FLAG_AM_EAGER (UCP_PROTO_SELECT_OP_FLAGS_BASE << 0)
+#define UCP_PROTO_SELECT_OP_FLAG_AM_RNDV  (UCP_PROTO_SELECT_OP_FLAGS_BASE << 1)
 
 
 /** Maximal length of ucp_proto_select_param_str() */
 #define UCP_PROTO_SELECT_PARAM_STR_MAX 128
+
+
+/**
+ * Key for looking up protocol configuration by operation parameters
+ */
+struct ucp_proto_select_param {
+    uint8_t                 op_id_flags;/* Operation ID and flags */
+    uint8_t                 op_attr;    /* Operation attributes from params */
+    uint8_t                 dt_class;   /* Datatype */
+    uint8_t                 mem_type;   /* Memory type */
+    uint8_t                 sys_dev;    /* System device */
+    uint8_t                 sg_count;   /* Number of non-contig scatter/gather
+                                           entries. If the actual number is larger
+                                           than UINT8_MAX, UINT8_MAX is used. */
+    uint8_t                 padding[2]; /* Make structure size be
+                                           sizeof(uint64_t) */
+} UCS_S_PACKED;
 
 
 /**
@@ -138,7 +154,7 @@ void ucp_proto_select_caps_cleanup(ucp_proto_caps_t *caps);
 
 ucp_proto_select_elem_t *
 ucp_proto_select_lookup_slow(ucp_worker_h worker,
-                             ucp_proto_select_t *proto_select,
+                             ucp_proto_select_t *proto_select, int internal,
                              ucp_worker_cfg_index_t ep_cfg_index,
                              ucp_worker_cfg_index_t rkey_cfg_index,
                              const ucp_proto_select_param_t *select_param);

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -13,6 +13,7 @@
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_request.inl>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_single.inl>
 
 
@@ -172,9 +173,8 @@ ucp_proto_amo_init(const ucp_proto_init_params_t *init_params,
         .tl_cap_flags        = 0
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, op_id);
-
-    if (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) {
+    if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
+        !ucp_proto_init_check_op(init_params, UCS_BIT(op_id))) {
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -15,6 +15,7 @@
 #include <ucs/arch/atomic.h>
 #include <ucs/profile/profile.h>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_single.h>
 
 
@@ -416,9 +417,8 @@ static ucs_status_t ucp_proto_amo_sw_progress_post(uct_pending_req_t *self)
 static ucs_status_t
 ucp_proto_amo_sw_init_post(const ucp_proto_init_params_t *init_params)
 {
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_AMO_POST);
-
-    if (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) {
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_AMO_POST)) ||
+        (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
@@ -444,9 +444,10 @@ static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
 static ucs_status_t
 ucp_proto_amo_sw_init_fetch(const ucp_proto_init_params_t *init_params)
 {
-    if (((init_params->select_param->op_id != UCP_OP_ID_AMO_FETCH) &&
-         (init_params->select_param->op_id != UCP_OP_ID_AMO_CSWAP)) ||
-         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
+    if (!ucp_proto_init_check_op(init_params,
+                                 UCS_BIT(UCP_OP_ID_AMO_FETCH) |
+                                 UCS_BIT(UCP_OP_ID_AMO_CSWAP)) ||
+        (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -13,6 +13,7 @@
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_request.inl>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_single.inl>
 
 
@@ -96,7 +97,9 @@ ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_single_init(&params);
 }

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -12,6 +12,7 @@
 
 #include <ucp/core/ucp_request.inl>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_multi.inl>
 
 
@@ -103,7 +104,9 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_multi_init(&params, init_params->priv,
                                 init_params->priv_size);
@@ -194,7 +197,9 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_GET);
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_multi_init(&params, init_params->priv,
                                 init_params->priv_size);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -13,6 +13,7 @@
 
 #include <ucp/core/ucp_request.inl>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_multi.inl>
 
 
@@ -102,7 +103,9 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_multi_init(&params, init_params->priv,
                                 init_params->priv_size);

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -13,6 +13,7 @@
 
 #include <ucp/core/ucp_request.inl>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_multi.inl>
 #include <ucp/proto/proto_single.inl>
 
@@ -72,9 +73,8 @@ ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
         .tl_cap_flags        = UCT_IFACE_FLAG_PUT_SHORT
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);
-
-    if (!ucp_proto_is_short_supported(init_params->select_param)) {
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT)) ||
+        !ucp_proto_is_short_supported(init_params->select_param)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
@@ -176,7 +176,9 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_multi_init(&params, init_params->priv,
                                 init_params->priv_size);
@@ -262,7 +264,9 @@ ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
     };
 
-    UCP_RMA_PROTO_INIT_CHECK(init_params, UCP_OP_ID_PUT);
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     return ucp_proto_multi_init(&params, init_params->priv,
                                 init_params->priv_size);

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -97,12 +97,4 @@ void ucp_ep_flush_remote_completed(ucp_request_t *req);
 
 void ucp_rma_sw_send_cmpl(ucp_ep_h ep);
 
-/*
- * Check RMA protocol requirements
- */
-#define UCP_RMA_PROTO_INIT_CHECK(_init_params, _op_id) \
-    if ((_init_params)->select_param->op_id != (_op_id)) { \
-        return UCS_ERR_UNSUPPORTED; \
-    }
-
 #endif

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -169,7 +169,7 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
 
     rkey_config = &worker->rkey_config[rkey_cfg_index];
     select_elem = ucp_proto_select_lookup_slow(worker,
-                                               &rkey_config->proto_select,
+                                               &rkey_config->proto_select, 1,
                                                ep_cfg_index, rkey_cfg_index,
                                                remote_select_param);
     if (select_elem == NULL) {
@@ -228,7 +228,7 @@ ucp_proto_rndv_ctrl_init_priv(const ucp_proto_rndv_ctrl_init_params_t *params)
     const ucp_proto_select_param_t *select_param;
     ucp_proto_select_param_t remote_select_param;
     ucp_memory_info_t mem_info;
-    uint16_t op_flags;
+    uint32_t op_attr_mask;
 
     select_param                   = params->super.super.select_param;
     *params->super.super.priv_size = sizeof(ucp_proto_rndv_ctrl_priv_t);
@@ -239,16 +239,17 @@ ucp_proto_rndv_ctrl_init_priv(const ucp_proto_rndv_ctrl_init_params_t *params)
         return UCS_ERR_NO_ELEM;
     }
 
-    op_flags = UCP_PROTO_SELECT_OP_FLAG_INTERNAL |
-               (select_param->op_flags &
-                ucp_proto_select_op_attr_to_flags(UCP_OP_ATTR_FLAG_MULTI_SEND));
+    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr) &
+                   UCP_OP_ATTR_FLAG_MULTI_SEND;
 
     /* Construct select parameter for the remote protocol */
     if (params->super.super.rkey_config_key == NULL) {
         /* Remote buffer is unknown, assume same params as local */
-        remote_select_param          = *select_param;
-        remote_select_param.op_id    = params->remote_op_id;
-        remote_select_param.op_flags = op_flags;
+        mem_info.type    = select_param->mem_type;
+        mem_info.sys_dev = select_param->sys_dev;
+        ucp_proto_select_param_init(&remote_select_param, params->remote_op_id,
+                                    op_attr_mask, 0, select_param->dt_class,
+                                    &mem_info, select_param->sg_count);
     } else {
         /* If we know the remote buffer parameters, these are actually the local
          * parameters for the remote protocol
@@ -256,8 +257,8 @@ ucp_proto_rndv_ctrl_init_priv(const ucp_proto_rndv_ctrl_init_params_t *params)
         mem_info.sys_dev = params->super.super.rkey_config_key->sys_dev;
         mem_info.type    = params->super.super.rkey_config_key->mem_type;
         ucp_proto_select_param_init(&remote_select_param, params->remote_op_id,
-                                    0, op_flags, UCP_DATATYPE_CONTIG, &mem_info,
-                                    1);
+                                    op_attr_mask, 0, UCP_DATATYPE_CONTIG,
+                                    &mem_info, 1);
     }
 
     /* Initialize estimated memory registration map */
@@ -377,12 +378,11 @@ out:
 static size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params)
 {
     const ucp_proto_select_param_t *select_param = init_params->select_param;
-    uint32_t op_attr_mask           = ucp_proto_select_op_attr_from_flags(
-            select_param->op_flags);
     const ucp_context_config_t *cfg = &init_params->worker->context->config.ext;
 
     if ((cfg->rndv_thresh == UCS_MEMUNITS_AUTO) &&
-        (op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) &&
+        (ucp_proto_select_op_attr_unpack(select_param->op_attr) &
+         UCP_OP_ATTR_FLAG_FAST_CMPL) &&
         ucs_likely(UCP_MEM_IS_HOST(select_param->mem_type))) {
         return cfg->rndv_send_nbr_thresh;
     }
@@ -634,9 +634,8 @@ void ucp_proto_rndv_bulk_query(const ucp_proto_query_params_t *params,
 static ucs_status_t
 ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
                           ucp_operation_id_t op_id, uint32_t op_attr_mask,
-                          uint16_t op_flags, size_t length,
-                          const void *rkey_buffer, size_t rkey_length,
-                          uint8_t sg_count)
+                          size_t length, const void *rkey_buffer,
+                          size_t rkey_length, uint8_t sg_count)
 {
     ucp_ep_h ep                = req->send.ep;
     ucp_ep_config_t *ep_config = ucp_ep_config(ep);
@@ -672,7 +671,7 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
         rkey           = NULL;
     }
 
-    ucp_proto_select_param_init(&sel_param, op_id, op_attr_mask, op_flags,
+    ucp_proto_select_param_init(&sel_param, op_id, op_attr_mask, 0,
                                 req->send.state.dt_iter.dt_class,
                                 &req->send.state.dt_iter.mem_info, sg_count);
 
@@ -688,9 +687,11 @@ ucp_proto_rndv_send_reply(ucp_worker_h worker, ucp_request_t *req,
     req->send.rndv.rkey_buffer = rkey_buffer;
 
     ucp_trace_req(req,
-                  "%s rva 0x%" PRIx64 " length %zd rreq_id 0x%" PRIx64 " with protocol %s",
-                  ucp_operation_names[op_id], req->send.rndv.remote_address,
-                  length, req->send.rndv.remote_req_id,
+                  "%s rva 0x%" PRIx64 " length %zd rreq_id 0x%" PRIx64
+                  " with protocol %s",
+                  ucp_operation_names[ucp_proto_select_op_id(&sel_param)],
+                  req->send.rndv.remote_address, length,
+                  req->send.rndv.remote_req_id,
                   req->send.proto_config->proto->name);
     return UCS_OK;
 
@@ -760,7 +761,7 @@ void ucp_proto_rndv_receive_start(ucp_worker_h worker, ucp_request_t *recv_req,
     }
 
     status = ucp_proto_rndv_send_reply(worker, req, op_id,
-                                       recv_req->recv.op_attr, 0, rts->size,
+                                       recv_req->recv.op_attr, rts->size,
                                        rkey_buffer, rkey_length, sg_count);
     if (status != UCS_OK) {
         ucp_datatype_iter_cleanup(&req->send.state.dt_iter, UCP_DT_MASK_ALL);
@@ -777,9 +778,8 @@ void ucp_proto_rndv_receive_start(ucp_worker_h worker, ucp_request_t *recv_req,
 
 static ucs_status_t
 ucp_proto_rndv_send_start(ucp_worker_h worker, ucp_request_t *req,
-                          uint32_t op_attr_mask, uint32_t op_flags,
-                          const ucp_rndv_rtr_hdr_t *rtr, size_t header_length,
-                          uint8_t sg_count)
+                          uint32_t op_attr_mask, const ucp_rndv_rtr_hdr_t *rtr,
+                          size_t header_length, uint8_t sg_count)
 {
     ucs_status_t status;
     size_t rkey_length;
@@ -794,8 +794,8 @@ ucp_proto_rndv_send_start(ucp_worker_h worker, ucp_request_t *req,
 
     ucs_assert(rtr->size == req->send.state.dt_iter.length);
     status = ucp_proto_rndv_send_reply(worker, req, UCP_OP_ID_RNDV_SEND,
-                                       op_attr_mask, op_flags, rtr->size,
-                                       rtr + 1, rkey_length, sg_count);
+                                       op_attr_mask, rtr->size, rtr + 1,
+                                       rkey_length, sg_count);
     if (status != UCS_OK) {
         return status;
     }
@@ -825,9 +825,10 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
 {
     ucp_worker_h worker           = arg;
     const ucp_rndv_rtr_hdr_t *rtr = data;
+    const ucp_proto_select_param_t *select_param;
     ucp_request_t *req, *freq;
+    uint32_t op_attr_mask;
     ucs_status_t status;
-    uint32_t op_flags;
     uint8_t sg_count;
 
     UCP_SEND_REQUEST_GET_BY_ID(&req, worker, rtr->sreq_id, 0, return UCS_OK,
@@ -839,7 +840,8 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
     /* RTR covers the whole send request - use the send request directly */
     ucs_assert(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED);
 
-    op_flags = req->send.proto_config->select_param.op_flags;
+    select_param = &req->send.proto_config->select_param;
+    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr);
 
     if (rtr->size == req->send.state.dt_iter.length) {
         /* RTR covers the whole send request - use the send request directly */
@@ -848,8 +850,8 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
         ucp_send_request_id_release(req);
         ucp_proto_request_zcopy_clean(req, UCP_DT_MASK_ALL);
 
-        sg_count = req->send.proto_config->select_param.sg_count;
-        status   = ucp_proto_rndv_send_start(worker, req, 0, op_flags, rtr,
+        sg_count = select_param->sg_count;
+        status   = ucp_proto_rndv_send_start(worker, req, op_attr_mask, rtr,
                                              length, sg_count);
         if (status != UCS_OK) {
             goto err_request_fail;
@@ -879,8 +881,9 @@ ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
          * TODO can rndv/ppln be selected here (and not just single frag)?
          */
         status = ucp_proto_rndv_send_start(worker, freq,
+                                           op_attr_mask |
                                            UCP_OP_ATTR_FLAG_MULTI_SEND,
-                                           op_flags, rtr, length, sg_count);
+                                           rtr, length, sg_count);
         if (status != UCS_OK) {
             goto err_put_freq;
         }

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -19,6 +19,11 @@
 #define UCP_PROTO_RNDV_ATP_NAME "ATP"
 
 
+/* Mask of rendezvous operations */
+#define UCP_PROTO_RNDV_OP_ID_MASK \
+    (UCS_BIT(UCP_OP_ID_RNDV_SEND) | UCS_BIT(UCP_OP_ID_RNDV_RECV))
+
+
 /**
  * Rendezvous protocol which sends a control message to the remote peer, and not
  * actually transferring bulk data. The remote peer is expected to perform the

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -9,6 +9,7 @@
 
 #include "proto_rndv.h"
 
+#include <ucp/proto/proto_init.h>
 #include <ucp/core/ucp_rkey.inl>
 #include <ucp/proto/proto_am.inl>
 #include <ucp/proto/proto_single.inl>
@@ -319,21 +320,22 @@ ucp_proto_rndv_bulk_max_payload_align(ucp_request_t *req,
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_rndv_request_is_ppln_frag(ucp_request_t *req)
 {
-    return req->send.proto_config->select_param.op_flags &
+    return req->send.proto_config->select_param.op_id_flags &
            UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
 }
 
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_rndv_init_params_is_ppln_frag(const ucp_proto_init_params_t *params)
 {
-    return params->select_param->op_flags & UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
+    return params->select_param->op_id_flags &
+           UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
 }
 
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_rndv_op_check(const ucp_proto_init_params_t *params,
                         ucp_operation_id_t op_id, int support_ppln)
 {
-    return (params->select_param->op_id == op_id) &&
+    return ucp_proto_init_check_op(params, UCS_BIT(op_id)) &&
            (support_ppln || !ucp_proto_rndv_init_params_is_ppln_frag(params));
 }
 

--- a/src/ucp/rndv/rndv_ats.c
+++ b/src/ucp/rndv/rndv_ats.c
@@ -36,9 +36,10 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *init_params)
      * data, or a rendezvous receive which should ignore the data.
      * In either case, we just need to send an ATS.
      */
-    if (init_params->select_param->op_id == UCP_OP_ID_RNDV_RECV) {
+    if (ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_RNDV_RECV))) {
         range0->max_length = 0;
-    } else if (init_params->select_param->op_id == UCP_OP_ID_RNDV_RECV_DROP) {
+    } else if (ucp_proto_init_check_op(init_params,
+                                       UCS_BIT(UCP_OP_ID_RNDV_RECV_DROP))) {
         range0->max_length = SIZE_MAX;
     } else {
         return UCS_ERR_UNSUPPORTED;

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -21,12 +21,8 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
     ucs_memory_type_t mem_type = init_params->select_param->mem_type;
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
-        (worker->mem_type_ep[mem_type] == NULL)) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    if ((init_params->select_param->op_id != UCP_OP_ID_RNDV_SEND) &&
-        (init_params->select_param->op_id != UCP_OP_ID_RNDV_RECV)) {
+        (worker->mem_type_ep[mem_type] == NULL) ||
+        !ucp_proto_init_check_op(init_params, UCP_PROTO_RNDV_OP_ID_MASK)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
@@ -157,13 +153,13 @@ ucp_proto_rndv_mtype_query_desc(const ucp_proto_query_params_t *params,
     ucp_rsc_index_t rsc_index  = ucp_ep_get_rsc_index(mtype_ep, lane);
     const char *tl_name        = context->tl_rscs[rsc_index].tl_rsc.tl_name;
 
-    if (params->select_param->op_id == UCP_OP_ID_RNDV_SEND) {
+    if (ucp_proto_select_op_id(params->select_param) == UCP_OP_ID_RNDV_SEND) {
         ucs_string_buffer_appendf(&strb, "%s, ", tl_name);
     }
 
     ucs_string_buffer_appendf(&strb, "%s", xfer_desc);
 
-    if (params->select_param->op_id == UCP_OP_ID_RNDV_RECV) {
+    if (ucp_proto_select_op_id(params->select_param) == UCP_OP_ID_RNDV_RECV) {
         ucs_string_buffer_appendf(&strb, ", %s", tl_name);
     }
 }

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -13,6 +13,7 @@
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_request.h>
+#include <ucp/proto/proto_init.h>
 #include <ucp/dt/dt.inl>
 
 
@@ -90,7 +91,7 @@ static UCS_F_ALWAYS_INLINE int
 ucp_proto_eager_check_op_id(const ucp_proto_init_params_t *init_params,
                             ucp_operation_id_t op_id, int offload_enabled)
 {
-    return (init_params->select_param->op_id == op_id) &&
+    return ucp_proto_init_check_op(init_params, UCS_BIT(op_id)) &&
            (offload_enabled ==
             ucp_ep_config_key_has_tag_lane(init_params->ep_config_key));
 }

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -38,7 +38,7 @@ ucp_proto_eager_multi_init_common(ucp_proto_multi_init_params_t *params,
      * tag offload). I. e. would need to check one more condition below:
      * ucp_ep_config_key_has_tag_lane(params->super.super.ep_config_key)
      */
-    if (params->super.super.select_param->op_id != op_id) {
+    if (!ucp_proto_init_check_op(&params->super.super, UCS_BIT(op_id))) {
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -155,8 +155,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
 
 ucs_status_t ucp_tag_rndv_rts_init(const ucp_proto_init_params_t *init_params)
 {
-    if ((init_params->select_param->op_id != UCP_OP_ID_TAG_SEND) &&
-        (init_params->select_param->op_id != UCP_OP_ID_TAG_SEND_SYNC)) {
+    if (!ucp_proto_init_check_op(init_params,
+                                 UCS_BIT(UCP_OP_ID_TAG_SEND) |
+                                 UCS_BIT(UCP_OP_ID_TAG_SEND_SYNC))) {
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -111,13 +111,14 @@ UCS_TEST_P(test_ucp_proto, dump_protocols) {
     ucp_proto_select_param_t select_param;
     ucs_string_buffer_t strb;
 
-    select_param.op_id      = UCP_OP_ID_TAG_SEND;
-    select_param.op_flags   = 0;
-    select_param.dt_class   = UCP_DATATYPE_CONTIG;
-    select_param.mem_type   = UCS_MEMORY_TYPE_HOST;
-    select_param.sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
-    select_param.sg_count   = 1;
-    select_param.padding    = 0;
+    select_param.op_id_flags = UCP_OP_ID_TAG_SEND;
+    select_param.op_attr     = 0;
+    select_param.dt_class    = UCP_DATATYPE_CONTIG;
+    select_param.mem_type    = UCS_MEMORY_TYPE_HOST;
+    select_param.sys_dev     = UCS_SYS_DEVICE_ID_UNKNOWN;
+    select_param.sg_count    = 1;
+    select_param.padding[0]  = 0;
+    select_param.padding[1]  = 0;
 
     ucs_string_buffer_init(&strb);
     ucp_proto_select_param_str(&select_param, ucp_operation_names, &strb);


### PR DESCRIPTION
## Why
Free up more space in `ucp_proto_select_param_t` structure, so we could add reply_buffer.{mem_type, sys_dev} fields to it.
- We need to add reply_buffer mem info to fix atomic operations on GPU buffers, to take into account reply buffer memory type and not just send buffer memory type. UCP API supports any combination of memory types for send buffer and reply_buffer.
- Fix for atomic protocols v2 will be in next PR

## How
- Remove INTERNAL flag from select params - it could be a parameter for the protocol select functions, since it only affects debug tracing.
- The flags for different operations could overlap, so 4 upper bits in op_id field should suffice.
- Add helper functions to access flags and op_id
- Increase the reserved space (padding) to 2 bytes