### PR TITLE
UCS/STRING/TEST: Add ucs_string_buffer_rbrk() to split right token

### DIFF
--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -216,6 +216,23 @@ void ucs_string_buffer_rtrim(ucs_string_buffer_t *strb, const char *charset);
 
 
 /**
+ * Remove one token from the end of the string.
+ *
+ * @param [inout] strb     String buffer to remove characters from.
+ * @param [in]    delim    C-string with the set of characters that are used as
+ *                         token delimiters.
+ *                         If NULL, this function removes whitespace characters,
+ *                         as defined by isspace (3).
+ *
+ * This function removes characters from the end of the input string 'strb', up
+ * to and including the first character that appears in 'delim'.
+ * If none of the characters in 'strb' appears in 'delim', the string remains
+ * unchanged.
+ */
+void ucs_string_buffer_rbrk(ucs_string_buffer_t *strb, const char *delim);
+
+
+/**
  * Return a temporary pointer to a C-style string which represents the string
  * buffer. The returned string is valid only as long as no other operation is
  * done on the string buffer (including append).

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -223,6 +223,34 @@ UCS_TEST_F(test_string_buffer, rtrim) {
     ucs_string_buffer_cleanup(&strb);
 }
 
+UCS_TEST_F(test_string_buffer, rbrk) {
+    UCS_STRING_BUFFER_ONSTACK(strb, 128);
+
+    ucs_string_buffer_appendf(&strb, "one.two.three..");
+
+    ucs_string_buffer_rbrk(&strb, ".");
+    EXPECT_EQ(std::string("one.two.three."), ucs_string_buffer_cstr(&strb));
+
+    ucs_string_buffer_rbrk(&strb, ".");
+    EXPECT_EQ(std::string("one.two.three"), ucs_string_buffer_cstr(&strb));
+
+    ucs_string_buffer_rbrk(&strb, ".");
+    EXPECT_EQ(std::string("one.two"), ucs_string_buffer_cstr(&strb));
+
+    ucs_string_buffer_rbrk(&strb, ".");
+    EXPECT_EQ(std::string("one"), ucs_string_buffer_cstr(&strb));
+
+    ucs_string_buffer_rbrk(&strb, ".");
+    EXPECT_EQ(std::string("one"), ucs_string_buffer_cstr(&strb));
+}
+
+UCS_TEST_F(test_string_buffer, rbrk_empty) {
+    UCS_STRING_BUFFER_ONSTACK(strb, 128);
+
+    ucs_string_buffer_rbrk(&strb, ".");
+    EXPECT_EQ(std::string(""), ucs_string_buffer_cstr(&strb));
+}
+
 void test_string_buffer::test_fixed(ucs_string_buffer_t *strb, size_t capacity)
 {
     ucs_string_buffer_appendf(strb, "%s", "im");


### PR DESCRIPTION
## Why
Will be used for atomics protocols v2 query description