### PR TITLE
TOOLS/PERF/INFO: Pass context name parameter to ucp_init()

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -103,6 +103,9 @@ Java_org_openucx_jucx_ucp_UcpContext_createContextNative(JNIEnv *env, jclass cls
         jucx_map_apply_config(env, config, &config_map);
     }
 
+    ucp_params.field_mask |= UCP_PARAM_FIELD_NAME;
+    ucp_params.name = "jucx";
+
     status = ucp_init(&ucp_params, config, &ucp_context);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);

--- a/examples/ucp_client_server.c
+++ b/examples/ucp_client_server.c
@@ -1069,7 +1069,8 @@ static int init_context(ucp_context_h *ucp_context, ucp_worker_h *ucp_worker,
     memset(&ucp_params, 0, sizeof(ucp_params));
 
     /* UCP initialization */
-    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_NAME;
+    ucp_params.name       = "client_server";
 
     if (send_recv_type == CLIENT_SERVER_SEND_RECV_STREAM) {
         ucp_params.features = UCP_FEATURE_STREAM;

--- a/examples/ucp_hello_world.c
+++ b/examples/ucp_hello_world.c
@@ -562,13 +562,15 @@ int main(int argc, char **argv)
 
     ucp_params.field_mask   = UCP_PARAM_FIELD_FEATURES |
                               UCP_PARAM_FIELD_REQUEST_SIZE |
-                              UCP_PARAM_FIELD_REQUEST_INIT;
+                              UCP_PARAM_FIELD_REQUEST_INIT |
+                              UCP_PARAM_FIELD_NAME;
     ucp_params.features     = UCP_FEATURE_TAG;
     if (ucp_test_mode == TEST_MODE_WAIT || ucp_test_mode == TEST_MODE_EVENTFD) {
         ucp_params.features |= UCP_FEATURE_WAKEUP;
     }
     ucp_params.request_size    = sizeof(struct ucx_context);
     ucp_params.request_init    = request_init;
+    ucp_params.name            = "hello_world";
 
     status = ucp_init(&ucp_params, config, &ucp_context);
 

--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -353,10 +353,12 @@ print_ucp_info(int print_opts, ucs_config_print_flags_t print_flags,
     memset(&params, 0, sizeof(params));
     params.field_mask        = UCP_PARAM_FIELD_FEATURES |
                                UCP_PARAM_FIELD_ESTIMATED_NUM_EPS |
-                               UCP_PARAM_FIELD_ESTIMATED_NUM_PPN;
+                               UCP_PARAM_FIELD_ESTIMATED_NUM_PPN |
+                               UCP_PARAM_FIELD_NAME;
     params.features          = ctx_features;
     params.estimated_num_eps = estimated_num_eps;
     params.estimated_num_ppn = estimated_num_ppn;
+    params.name              = "ucx_info";
 
     get_resource_usage(&usage);
 

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1551,10 +1551,12 @@ static ucs_status_t ucp_perf_setup(ucx_perf_context_t *perf)
 
     ucp_params.field_mask   = UCP_PARAM_FIELD_FEATURES |
                               UCP_PARAM_FIELD_REQUEST_SIZE |
-                              UCP_PARAM_FIELD_REQUEST_INIT;
+                              UCP_PARAM_FIELD_REQUEST_INIT |
+                              UCP_PARAM_FIELD_NAME;
     ucp_params.features     = 0;
     ucp_params.request_size = sizeof(ucp_perf_request_t);
     ucp_params.request_init = ucp_perf_request_init;
+    ucp_params.name         = "perftest";
 
     if (perf->params.thread_count > 1) {
         /* when there is more than one thread, a ucp_worker would be created for

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -2928,7 +2928,7 @@ static int parse_args(int argc, char **argv, options_t *test_opts)
 static int do_server(const options_t& test_opts)
 {
     DemoServer server(test_opts);
-    if (!server.init()) {
+    if (!server.init("iodemo_server")) {
         return -1;
     }
 
@@ -2952,7 +2952,7 @@ static int do_client(options_t& test_opts)
     }
 
     DemoClient client(test_opts);
-    if (!client.init()) {
+    if (!client.init("iodemo_client")) {
         return -1;
     }
 

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -136,7 +136,7 @@ UcxContext::~UcxContext()
     }
 }
 
-bool UcxContext::init()
+bool UcxContext::init(const char *name)
 {
     if (_context && _worker) {
         UCX_LOG << "context is already initialized";
@@ -147,7 +147,8 @@ bool UcxContext::init()
     ucp_params_t ucp_params;
     ucp_params.field_mask   = UCP_PARAM_FIELD_FEATURES |
                               UCP_PARAM_FIELD_REQUEST_INIT |
-                              UCP_PARAM_FIELD_REQUEST_SIZE;
+                              UCP_PARAM_FIELD_REQUEST_SIZE |
+                              UCP_PARAM_FIELD_NAME;
     ucp_params.features     = _use_am ? UCP_FEATURE_AM :
                                         UCP_FEATURE_TAG | UCP_FEATURE_STREAM;
     if (_epoll_fd != -1) {
@@ -155,6 +156,8 @@ bool UcxContext::init()
     }
     ucp_params.request_init = request_init;
     ucp_params.request_size = sizeof(ucx_request);
+    ucp_params.name         = name;
+
     ucs_status_t status = ucp_init(&ucp_params, NULL, &_context);
     if (status != UCS_OK) {
         UCX_LOG << "ucp_init() failed: " << ucs_status_string(status);

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -117,7 +117,7 @@ public:
 
     virtual ~UcxContext();
 
-    bool init();
+    bool init(const char *name);
 
     bool listen(const struct sockaddr* saddr, size_t addrlen);
 


### PR DESCRIPTION
## Why
Improve protocols information output when using perftest, ucx_info, and jucx