### PR TITLE
Fix conflicting types for 'uct_md_mem_advise'

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -554,7 +554,7 @@ ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh)
 
 ucs_status_t
 uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr, size_t length,
-                  unsigned advice)
+                  uct_mem_advice_t advice)
 {
     if ((length == 0) || (addr == NULL)) {
         return UCS_ERR_INVALID_PARAM;


### PR DESCRIPTION
Fixes compilation error with >=gcc-13.
```C
base/uct_md.c:556:1: error: conflicting types for 'uct_md_mem_advise'
  due to enum/integer mismatch; have 'ucs_status_t(struct uct_md *, void *, void *, size_t,  unsigned int)'
    {aka 'ucs_status_t(struct uct_md *, void *, void *, long unsigned int,  unsigned int)'} [-Werror=enum-int-mismatch]
  556 | uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr, size_t length,
      | ^~~~~~~~~~~~~~~~~
In file included from base/uct_component.h:11,
                 from base/uct_md.h:14,
                 from base/uct_md.c:13:
src/uct/api/uct.h:2542:14: note: previous declaration of 'uct_md_mem_advise' with type 'ucs_status_t(struct uct_md *, void *, void *, size_t,  uct_mem_advice_t)' {aka 'ucs_status_t(struct uct_md *, void *, void *, long unsigned int,  uct_mem_advice_t)'}
 2542 | ucs_status_t uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr,
      |              ^~~~~~~~~~~~~~~~~
```
Co-authored by:  Sergei Trofimovich  (trofi)
https://github.com/openucx/ucx/pull/8732


