### PR TITLE
UCT/CUDA: Detect hopper architecture

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -136,7 +136,8 @@ static UCS_F_ALWAYS_INLINE int uct_cuda_base_context_match(CUcontext ctx1,
 typedef enum uct_cuda_base_gen {
     UCT_CUDA_BASE_GEN_P100 = 6,
     UCT_CUDA_BASE_GEN_V100 = 7,
-    UCT_CUDA_BASE_GEN_A100 = 8
+    UCT_CUDA_BASE_GEN_A100 = 8,
+    UCT_CUDA_BASE_GEN_H100 = 9
 } uct_cuda_base_gen_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -47,6 +47,10 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
      "Max number of cuda events. -1 is infinite",
      ucs_offsetof(uct_cuda_ipc_iface_config_t, max_cuda_ipc_events), UCS_CONFIG_TYPE_UINT},
 
+    {"BW", "auto",
+     "Effective p2p memory bandwidth",
+     ucs_offsetof(uct_cuda_ipc_iface_config_t, bandwidth), UCS_CONFIG_TYPE_BW},
+
     {NULL}
 };
 
@@ -106,6 +110,8 @@ static double uct_cuda_ipc_iface_get_bw()
         return 250000.0 * UCS_MBYTE;
     case UCT_CUDA_BASE_GEN_A100:
         return 300000.0 * UCS_MBYTE;
+    case UCT_CUDA_BASE_GEN_H100:
+        return 400000.0 * UCS_MBYTE;
     default:
         return 6911.0  * UCS_MBYTE;
     }
@@ -218,7 +224,7 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
 
     iface_attr->latency                 = ucs_linear_func_make(1e-6, 0);
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = uct_cuda_ipc_iface_get_bw();
+    iface_attr->bandwidth.shared        = iface->config.bandwidth;
     iface_attr->overhead                = 7.0e-6;
     iface_attr->priority                = 0;
 
@@ -500,6 +506,8 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
     self->config.enable_cache        = config->enable_cache;
     self->config.enable_get_zcopy    = config->enable_get_zcopy;
     self->config.max_cuda_ipc_events = config->max_cuda_ipc_events;
+    self->config.bandwidth           = UCS_CONFIG_DBL_IS_AUTO(config->bandwidth) ?
+                                       uct_cuda_ipc_iface_get_bw() : config->bandwidth;
 
     ucs_mpool_params_reset(&mp_params);
     mp_params.elem_size       = sizeof(uct_cuda_ipc_event_desc_t);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -35,6 +35,7 @@ typedef struct uct_cuda_ipc_iface {
         unsigned                max_cuda_ipc_events; /* max mpool entries */
         int                     enable_cache;        /* enable/disable ipc handle cache */
         ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platorms */
+        double                  bandwidth;
     } config;
 } uct_cuda_ipc_iface_t;
 
@@ -46,6 +47,7 @@ typedef struct uct_cuda_ipc_iface_config {
     int                     enable_cache;
     ucs_on_off_auto_value_t enable_get_zcopy;
     unsigned                max_cuda_ipc_events;
+    double                  bandwidth;
 } uct_cuda_ipc_iface_config_t;
 
 


### PR DESCRIPTION
## Why
Without this detection, `ib` gen5 is preferred over `cuda_ipc` which leads to lower bandwidth between p2p accessible Hopper GPUs. 

## What?

- Detect Hopper architecture and provide a more accurate cuda_ipc bandwidth estimation
- Add env var to allow user to explicitly set cuda_ipc bandwidth
