### PR TITLE
GTEST/UCP: skip HWTM with memtype protov2

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -49,6 +49,11 @@ public:
             enable_tag_mp_offload();
 
             if (RUNNING_ON_VALGRIND) {
+                if (m_ucp_config->ctx.proto_enable) {
+                    UCS_TEST_SKIP_R("FIXME: skip forced UCX_PROTO_ENABLE=y because "
+                                    "it does not completely support HWTM");
+                }
+
                 m_env.push_back(
                         new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
                 m_env.push_back(


### PR DESCRIPTION
## What
skip HWTM with memtype protov2

## Why ?
similar to https://github.com/openucx/ucx/pull/8770
