### PR TITLE
GTEST/UCP: disable HWTM protov2

### DIFF
--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -185,6 +185,19 @@ void test_ucp_tag::check_offload_support(bool offload_required)
     }
 }
 
+void test_ucp_tag::skip_external_protov2() const
+{
+    if (m_ucp_config->ctx.proto_enable) {
+        skip_protov2();
+    }
+}
+
+void test_ucp_tag::skip_protov2() const
+{
+    UCS_TEST_SKIP_R("FIXME: skip forced UCX_PROTO_ENABLE=y because it does not "
+                    "completely support HWTM");
+}
+
 int test_ucp_tag::get_worker_index(int buf_index)
 {
     int worker_index = 0;

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -125,6 +125,10 @@ protected:
 
     virtual bool is_external_request();
 
+    void skip_external_protov2() const;
+
+    void skip_protov2() const;
+
     static ucp_context_attr_t ctx_attr;
     ucs::ptr_vector<ucs::scoped_setenv> m_env;
 

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -37,10 +37,11 @@ public:
         if (use_proto()) {
             modify_config("PROTO_ENABLE", "y");
             modify_config("MAX_EAGER_LANES", "2");
-        } else if (RUNNING_ON_VALGRIND && m_ucp_config->ctx.proto_enable) {
-            UCS_TEST_SKIP_R("FIXME: skip forced UCX_PROTO_ENABLE=y because "
-                            "it does not completely support HWTM");
         } else {
+            if (RUNNING_ON_VALGRIND) {
+                skip_external_protov2();
+            }
+
             // TODO:
             // 1. test offload and offload MP as different variants
             // 2. Enable offload for new protocols as well when it is fully

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -49,10 +49,11 @@ public:
             enable_tag_mp_offload();
 
             if (RUNNING_ON_VALGRIND) {
-                if (m_ucp_config->ctx.proto_enable) {
-                    UCS_TEST_SKIP_R("FIXME: skip forced UCX_PROTO_ENABLE=y because "
-                                    "it does not completely support HWTM");
+                if (variant_flags & VARIANT_PROTO) {
+                    skip_protov2();
                 }
+
+                skip_external_protov2();
 
                 m_env.push_back(
                         new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -452,6 +452,8 @@ public:
 
     void init()
     {
+        skip_external_protov2();
+
         // The test checks that increase of active ifaces is handled
         // correctly. It needs to start with a single active iface, therefore
         // disable multi-rail.


### PR DESCRIPTION
## What
 + skip `test_ucp_tag_offload_multi` with proto_v2
 + del code duplication

## Why ?
similar to https://github.com/openucx/ucx/pull/8770
