### PR TITLE
TOOLS/PERF: Fix worker flush deadlock when using multiple workers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,12 +25,15 @@ doc_dir = $(pkgdatadir)/doc
 
 if !DOCS_ONLY
 perftest_dir = $(pkgdatadir)/perftest
-dist_perftest__DATA = contrib/ucx_perftest_config/msg_pow2 \
-					  contrib/ucx_perftest_config/msg_pow2_large \
-					  contrib/ucx_perftest_config/README \
-					  contrib/ucx_perftest_config/test_types_uct \
-					  contrib/ucx_perftest_config/test_types_ucp \
-					  contrib/ucx_perftest_config/transports
+dist_perftest__DATA = \
+	contrib/ucx_perftest_config/msg_pow2 \
+	contrib/ucx_perftest_config/msg_pow2_large \
+	contrib/ucx_perftest_config/README \
+	contrib/ucx_perftest_config/test_types_uct \
+	contrib/ucx_perftest_config/test_types_ucp \
+	contrib/ucx_perftest_config/test_types_ucp_rma \
+	contrib/ucx_perftest_config/transports
+
 SUBDIRS = \
 	src/ucm \
 	src/ucs \


### PR DESCRIPTION
## Why
After adding a missing perftest file `test_types_ucp_rma`, CI found a hang/deadlock in libperf - the workers of multiple threads have to be flushed in parallel. The hang happened with `UCX_TLS=tcp`.

Both processes hang in:
```
#0  0x00007f79fe379483 in epoll_wait () from /lib64/libc.so.6
#1  0x00007f79ffb4bb23 in ucs_event_set_wait (event_set=0xe4f3d0, 
    num_events=num_events@entry=0x7fff7db4e9f0, timeout_ms=timeout_ms@entry=0, 
    event_set_handler=event_set_handler@entry=0x7f79ffea4dc0 <uct_tcp_iface_handle_events>, 
    arg=arg@entry=0x7fff7db4e9e0) at <ucxdir>/src/ucs/sys/event_set.c:198
#2  0x00007f79ffea4d44 in uct_tcp_iface_progress (tl_iface=0xed40d0) at <ucxdir>/src/uct/tcp/tcp_iface.c:334
#3  0x00007f7a0012ef22 in ucs_callbackq_dispatch (cbq=<optimized out>) at <ucxdir>/src/ucs/datastruct/callbackq.h:211
#4  uct_worker_progress (worker=<optimized out>) at <ucxdir>/src/uct/api/uct.h:2768
#5  ucp_worker_progress (worker=worker@entry=0xe9de80) at <ucxdir>/src/ucp/core/ucp_worker.c:2799
#6  0x00007f7a00167a6e in ucp_rma_wait (op_name=0x7f7a001fe208 "flush", user_req=0xf16550,  worker=0xe9de80) at <ucxdir>/src/ucp/rma/rma.inl:74
#7  ucp_flush_wait (request=0xf16550, worker=0xe9de80) at <ucxdir>/src/ucp/rma/flush.c:663
#8  ucp_worker_flush_inner (worker=0xe9de80) at <ucxdir>/src/ucp/rma/flush.c:675
#9  ucp_worker_flush (worker=0xe9de80) at <ucxdir>/src/ucp/rma/flush.c:666
#10 0x000000000040b10e in ucp_perf_test_setup_endpoints (features=<optimized out>, perf=0xdf3f80) at <ucxdir>/src/tools/perf/lib/libperf.c:1242
#11 ucp_perf_setup (perf=0xdf3f80) at <ucxdir>/src/tools/perf/lib/libperf.c:1636
#12 0x0000000000409e8f in ucx_perf_run (params=params@entry=0x7fff7db4f180,  result=result@entry=0x7fff7db4ee30)
    at <ucxdir>/src/tools/perf/lib/libperf.c:1739
```