### PR TITLE
UCT/BASE: Fix conflicting types for 'uct_md_mem_advise'.

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017. ALL RIGHTS RESERVED.
+* Copyright (c) Triad National Security, LLC. 2023. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -554,7 +555,7 @@ ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh)
 
 ucs_status_t
 uct_md_mem_advise(uct_md_h md, uct_mem_h memh, void *addr, size_t length,
-                  unsigned advice)
+                  uct_mem_advice_t advice)
 {
     if ((length == 0) || (addr == NULL)) {
         return UCS_ERR_INVALID_PARAM;


### PR DESCRIPTION
Signed-off-by: Howard Pritchard <howardp@lanl.gov>

## What
fix so UCX can build with non-old GCC variants

## Why ?
Its nice if UCX can build with newer GCC variants

## How ?
this patch fixes this build issue
