### PR TITLE
Add rkey_ptr to self transport, tag matching performance improvement

### DIFF
--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -31,6 +31,7 @@ noinst_HEADERS = \
 	base/uct_iov.inl \
 	base/uct_vfs_attr.h \
 	sm/base/sm_ep.h \
+	sm/base/sm_md.h \
 	sm/base/sm_iface.h \
 	sm/mm/base/mm_iface.h \
 	sm/mm/base/mm_ep.h \
@@ -56,6 +57,7 @@ libuct_la_SOURCES = \
 	base/uct_cm.c \
 	base/uct_vfs_attr.c \
 	sm/base/sm_ep.c \
+	sm/base/sm_md.c \
 	sm/base/sm_iface.c \
 	sm/mm/base/mm_iface.c \
 	sm/mm/base/mm_ep.c \

--- a/src/uct/sm/base/sm_md.c
+++ b/src/uct/sm/base/sm_md.c
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2023 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "sm_md.h"
+
+
+ucs_status_t uct_sm_rkey_ptr(uct_component_t *component, uct_rkey_t rkey,
+                             void *handle, uint64_t raddr, void **laddr_p)
+{
+    /* rkey stores offset from the remote va */
+    *laddr_p = UCS_PTR_BYTE_OFFSET(raddr, (ptrdiff_t)rkey);
+    return UCS_OK;
+}

--- a/src/uct/sm/base/sm_md.h
+++ b/src/uct/sm/base/sm_md.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2023 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_SM_MD_H_
+#define UCT_SM_MD_H_
+
+#include <uct/base/uct_md.h>
+#include <ucs/config/types.h>
+#include <ucs/type/status.h>
+
+
+ucs_status_t uct_sm_rkey_ptr(uct_component_t *component, uct_rkey_t rkey,
+                             void *handle, uint64_t raddr, void **laddr_p);
+
+#endif

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -86,14 +86,6 @@ void uct_mm_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr, uint64_t max_alloc)
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
 }
 
-ucs_status_t uct_mm_rkey_ptr(uct_component_t *component, uct_rkey_t rkey,
-                             void *handle, uint64_t raddr, void **laddr_p)
-{
-    /* rkey stores offset from the remote va */
-    *laddr_p = UCS_PTR_BYTE_OFFSET(raddr, (ptrdiff_t)rkey);
-    return UCS_OK;
-}
-
 ucs_status_t uct_mm_md_open(uct_component_t *component, const char *md_name,
                             const uct_md_config_t *config, uct_md_h *md_p)
 {

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -9,6 +9,7 @@
 #define UCT_MM_MD_H_
 
 #include <uct/base/uct_md.h>
+#include <uct/sm/base/sm_md.h>
 #include <ucs/config/types.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/type/status.h>
@@ -168,7 +169,7 @@ typedef struct uct_mm_component {
             .md_open            = uct_mm_md_open, \
             .cm_open            = ucs_empty_function_return_unsupported, \
             .rkey_unpack        = _rkey_unpack, \
-            .rkey_ptr           = uct_mm_rkey_ptr, \
+            .rkey_ptr           = uct_sm_rkey_ptr, \
             .rkey_release       = _rkey_release, \
             .name               = #_name, \
             .md_config          = { \

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -12,6 +12,7 @@
 #include <uct/base/uct_iov.inl>
 #include <uct/sm/base/sm_ep.h>
 #include <uct/sm/base/sm_iface.h>
+#include <uct/sm/base/sm_md.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/string.h>
 #include <ucs/arch/cpu.h>
@@ -451,7 +452,7 @@ static uct_component_t uct_self_component = {
     .md_open            = uct_self_md_open,
     .cm_open            = ucs_empty_function_return_unsupported,
     .rkey_unpack        = uct_self_md_rkey_unpack,
-    .rkey_ptr           = ucs_empty_function_return_unsupported,
+    .rkey_ptr           = uct_sm_rkey_ptr,
     .rkey_release       = ucs_empty_function_return_success,
     .name               = UCT_SELF_NAME,
     .md_config          = {
@@ -462,7 +463,7 @@ static uct_component_t uct_self_component = {
     },
     .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
     .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_self_component),
-    .flags              = 0,
+    .flags              = UCT_MD_FLAG_RKEY_PTR,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
 


### PR DESCRIPTION
## What
Adding support for put_zcopy and get_zcopy on self transport (uct)

## Why ?
To avoid fallbacks to other transports when possible (proto v2).

## How ?
Implemented the API interface functions for put_zcopy and get_zcopy using memcpy, treating remote address as a local pointer
