### PR TITLE
UCT/IB: Improve memlock limit logging

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -971,13 +971,14 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
                                  &attr->ibv);
 #endif
     if (qp == NULL) {
-        ucs_error("iface=%p: failed to create %s QP "
-                  "TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d: %m",
-                  iface, uct_ib_qp_type_str(attr->qp_type),
-                  attr->cap.max_send_wr, attr->cap.max_send_sge,
-                  attr->cap.max_inline_data, attr->max_inl_cqe[UCT_IB_DIR_TX],
-                  attr->cap.max_recv_wr, attr->cap.max_recv_sge,
-                  attr->max_inl_cqe[UCT_IB_DIR_RX]);
+        uct_ib_check_memlock_limit_msg(
+                UCS_LOG_LEVEL_ERROR,
+                "iface=%p: failed to create %s QP "
+                "TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d: %m",
+                iface, uct_ib_qp_type_str(attr->qp_type), attr->cap.max_send_wr,
+                attr->cap.max_send_sge, attr->cap.max_inline_data,
+                attr->max_inl_cqe[UCT_IB_DIR_TX], attr->cap.max_recv_wr,
+                attr->cap.max_recv_sge, attr->max_inl_cqe[UCT_IB_DIR_RX]);
         return UCS_ERR_IO_ERROR;
     }
 
@@ -1003,8 +1004,6 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     unsigned cq_size     = uct_ib_cq_size(iface, init_attr, dir);
     struct ibv_cq *cq;
-    char message[128];
-    int cq_errno;
 #if HAVE_DECL_IBV_CREATE_CQ_EX
     struct ibv_cq_init_attr_ex cq_attr = {};
 
@@ -1020,10 +1019,8 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     }
 
     if (cq == NULL) {
-        cq_errno = errno;
-        ucs_snprintf_safe(message, sizeof(message), "ibv_create_cq(cqe=%d)",
-                          cq_size);
-        uct_ib_mem_lock_limit_msg(message, cq_errno, UCS_LOG_LEVEL_ERROR);
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "ibv_create_cq(cqe=%d)", cq_size);
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/uct/ib/base/ib_log.c
+++ b/src/uct/ib/base/ib_log.c
@@ -234,8 +234,7 @@ static void uct_ib_dump_send_wr(uct_ib_iface_t *iface, struct ibv_qp *qp,
                             data_dump, max_sge, s, ends - s);
 }
 
-void uct_ib_mem_lock_limit_msg(const char *message, int sys_errno,
-                               ucs_log_level_t level)
+void uct_ib_memlock_limit_msg(ucs_string_buffer_t *message, int sys_errno)
 {
     size_t memlock_limit;
     ucs_status_t status;
@@ -243,15 +242,13 @@ void uct_ib_mem_lock_limit_msg(const char *message, int sys_errno,
     if (sys_errno == ENOMEM) {
         status = ucs_sys_get_effective_memlock_rlimit(&memlock_limit);
         if ((status == UCS_OK) && (memlock_limit != SIZE_MAX)) {
-            ucs_log(level,
-                    "%s failed: %s. Please set max locked memory "
-                    "(ulimit -l) to 'unlimited' (current: %llu kbytes)",
-                    message, strerror(sys_errno), memlock_limit / UCS_KBYTE);
-            return;
+            ucs_string_buffer_appendf(
+                    message,
+                    " : Please set max locked memory (ulimit -l) to 'unlimited'"
+                    " (current: %llu kbytes)",
+                    memlock_limit / UCS_KBYTE);
         }
     }
-
-    ucs_log(level, "%s failed: %s", message, strerror(sys_errno));
 }
 
 void __uct_ib_log_post_send(const char *file, int line, const char *function,

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -400,8 +400,10 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
                                  &attr.super.ibv, &dv_attr);
     if (qp == NULL) {
-        ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT", DCI): failed: %m",
-                  UCT_IB_IFACE_ARG(ib_iface));
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "%s: mlx5dv_create_qp("UCT_IB_IFACE_FMT", DCI)",
+                                       uct_ib_device_name(dev),
+                                       UCT_IB_IFACE_ARG(ib_iface));
         status = UCS_ERR_IO_ERROR;
         goto err_put_res_domain;
     }
@@ -572,7 +574,9 @@ uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface,
     iface->rx.dct.verbs.qp = mlx5dv_create_qp(dev->ibv_context, &init_attr,
                                               &dv_init_attr);
     if (iface->rx.dct.verbs.qp == NULL) {
-        ucs_error("mlx5dv_create_qp(DCT) failed: %m");
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "%s: mlx5dv_create_qp(DCT)",
+                                       uct_ib_device_name(dev));
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -1324,8 +1328,9 @@ static ucs_status_t uct_dc_mlx5dv_calc_tx_wqe_ratio(uct_ib_mlx5_md_t *md)
     dci_qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
                                      &qp_init_attr, &dv_attr);
     if (dci_qp == NULL) {
-        ucs_error("%s: mlx5dv_create_qp(DCI) failed: %m",
-                  uct_ib_device_name(dev));
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "%s: mlx5dv_create_qp(DCI)",
+                                       uct_ib_device_name(dev));
         status = UCS_ERR_IO_ERROR;
         goto out_qp_tmp_objs_close;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -57,15 +57,11 @@ uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
     struct ibv_srq_init_attr srq_attr = {};
     ucs_log_level_t level             = silent ? UCS_LOG_LEVEL_DEBUG :
                                                  UCS_LOG_LEVEL_ERROR;
-    int cq_errno;
-    char message[128];
 
     qp_tmp_objs->cq = ibv_create_cq(dev->ibv_context, 1, NULL, NULL, 0);
     if (qp_tmp_objs->cq == NULL) {
-        cq_errno = errno;
-        ucs_snprintf_safe(message, sizeof(message), "%s: ibv_create_cq()",
-                          uct_ib_device_name(dev));
-        uct_ib_mem_lock_limit_msg(message, cq_errno, level);
+        uct_ib_check_memlock_limit_msg(level, "%s: ibv_create_cq()",
+                                       uct_ib_device_name(dev));
         goto out;
     }
 
@@ -73,8 +69,8 @@ uct_ib_mlx5dv_qp_tmp_objs_create(uct_ib_device_t *dev, struct ibv_pd *pd,
     srq_attr.attr.max_wr  = 1;
     qp_tmp_objs->srq      = ibv_create_srq(pd, &srq_attr);
     if (qp_tmp_objs->srq == NULL) {
-        ucs_log(level, "%s: ibv_create_srq() failed: %m",
-                uct_ib_device_name(dev));
+        uct_ib_check_memlock_limit_msg(level, "%s: ibv_create_srq()",
+                                       uct_ib_device_name(dev));
         goto out_destroy_cq;
     }
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -850,8 +850,9 @@ uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
 
     cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
     if (cq == NULL) {
-        ucs_debug("ibv_create_cq(%s) failed: %m",
-                  ibv_get_device_name(ibv_device));
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_DEBUG,
+                                       "%s: ibv_create_cq()",
+                                       ibv_get_device_name(ibv_device));
         goto close_ctx;
     }
 
@@ -1356,6 +1357,9 @@ uct_ib_mlx5_devx_md_get_counter_set_id(uct_ib_mlx5_md_t *md, uint8_t port_num)
 
     dummy_cq = ibv_create_cq(md->super.dev.ibv_context, 1, NULL, NULL, 0);
     if (dummy_cq == NULL) {
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_DEBUG,
+                                       "%s: ibv_create_cq()",
+                                       uct_ib_device_name(&md->super.dev));
         goto err;
     }
 
@@ -1369,6 +1373,9 @@ uct_ib_mlx5_devx_md_get_counter_set_id(uct_ib_mlx5_md_t *md, uint8_t port_num)
 
     dummy_qp = ibv_create_qp(md->super.pd, &qp_init_attr);
     if (dummy_qp == NULL) {
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_DEBUG,
+                                       "%s: ibv_create_qp()",
+                                       uct_ib_device_name(&md->super.dev));
         goto err_free_cq;
     }
 

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -114,8 +114,6 @@ uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     struct ibv_cq_init_attr_ex cq_attr = {};
     struct mlx5dv_cq_init_attr dv_attr = {};
     struct ibv_cq *cq;
-    char message[128];
-    int cq_errno;
 
     uct_ib_fill_cq_attr(&cq_attr, init_attr, iface, preferred_cpu,
                         uct_ib_cq_size(iface, init_attr, dir));
@@ -125,10 +123,9 @@ uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
 
     cq = ibv_cq_ex_to_cq(mlx5dv_create_cq(dev->ibv_context, &cq_attr, &dv_attr));
     if (cq == NULL) {
-        cq_errno = errno;
-        ucs_snprintf_safe(message, sizeof(message), "mlx5dv_create_cq(cqe=%d)",
-                          cq_attr.cqe);
-        uct_ib_mem_lock_limit_msg(message, cq_errno, UCS_LOG_LEVEL_ERROR);
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "%s: mlx5dv_create_cq(cqe=%d)",
+                                       uct_ib_device_name(dev), cq_attr.cqe);
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -867,7 +867,7 @@ uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
     mem->mem  = mlx5dv_devx_umem_reg(md->super.dev.ibv_context, buf, size,
                                      access_mode);
     if (mem->mem == NULL) {
-        ucs_log(level, "mlx5dv_devx_umem_reg() failed: %m");
+        uct_ib_check_memlock_limit_msg(level, "mlx5dv_devx_umem_reg()");
         status = UCS_ERR_NO_MEMORY;
         goto err_dofork;
     }

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -365,8 +365,10 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
     qp->verbs.qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
                                            &attr->super.ibv, &dv_attr);
     if (qp->verbs.qp == NULL) {
-        ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT"): failed: %m",
-                  UCT_IB_IFACE_ARG(ib_iface));
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "%s: mlx5dv_create_qp("UCT_IB_IFACE_FMT")",
+                                       uct_ib_device_name(dev),
+                                       UCT_IB_IFACE_ARG(ib_iface));
         status = UCS_ERR_IO_ERROR;
         goto err;
     }

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -505,8 +505,7 @@ ucs_status_t uct_rc_iface_init_rx(uct_rc_iface_t *iface,
     srq_init_attr.srq_context    = iface;
     srq                          = ibv_create_srq(pd, &srq_init_attr);
     if (srq == NULL) {
-        uct_ib_mem_lock_limit_msg("ibv_create_srq()", errno,
-                                  UCS_LOG_LEVEL_ERROR);
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR, "ibv_create_srq()");
         return UCS_ERR_IO_ERROR;
     }
     iface->rx.srq.quota          = srq_init_attr.attr.max_wr;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -539,7 +539,7 @@ uct_rc_verbs_can_create_qp(struct ibv_context *ctx, struct ibv_pd *pd)
 
     cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
     if (cq == NULL) {
-        ucs_debug("failed to create cq %m");
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_DEBUG, "ibv_create_cq()");
         status = UCS_ERR_IO_ERROR;
         goto err;
     }
@@ -549,6 +549,7 @@ uct_rc_verbs_can_create_qp(struct ibv_context *ctx, struct ibv_pd *pd)
 
     qp = ibv_create_qp(pd, &qp_init_attr);
     if (qp == NULL) {
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_DEBUG, "ibv_create_qp()");
         status = UCS_ERR_UNSUPPORTED;
         goto err_destroy_cq;
     }

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -10,6 +10,7 @@
 
 #include "rdmacm_cm_ep.h"
 #include <uct/ib/base/ib_iface.h>
+#include <uct/ib/base/ib_log.h>
 #include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
 #include <ucs/async/async.h>
 
@@ -182,7 +183,8 @@ dummy_qp_ctx_init:
     /* Create a dummy completion queue */
     ctx->cq = ibv_create_cq(verbs, 1, NULL, NULL, 0);
     if (ctx->cq == NULL) {
-        ucs_error("ibv_create_cq(%s) failed: %m", dev_name);
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR,
+                                       "%s: ibv_create_cq()", dev_name);
         return UCS_ERR_IO_ERROR;
     }
 

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -779,6 +779,7 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
 
     status = uct_ib_mlx5_iface_create_qp(ib_iface, qp, &attr);
     if (status != UCS_OK) {
+        uct_ib_check_memlock_limit_msg(UCS_LOG_LEVEL_ERROR, "ibv_create_qp()");
         return status;
     }
 


### PR DESCRIPTION
## What
Adds the additional logging to the places that can be affected by setting the locked memory limit.

## Why ?
Now we already have messages about too strict locked memory limit, but not all places were covered.
