### PR TITLE
UCT/TCP: Fixed sysfs_path expansion for TCP iface

### DIFF
--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -202,6 +202,19 @@ double ucs_topo_get_pci_bw(const char *dev_name, const char *sysfs_path);
 
 
 /**
+ * Returns sysfs path of a given device. for example:
+ * input:  '/sys/class/infiniband/mlx5_1'
+ * output: '/sys/devices/pci0000:80/0000:80:01.1/0000:83:00.0'
+ *
+ * @param [in]  dev_path    Device file path.
+ * @param [out] path_buffer Filled with the result path.
+ *
+ * @return Pointer to sysfs path or NULL on error.
+ */
+const char *
+ucs_topo_resolve_sysfs_path(const char *dev_path, char *path_buffer);
+
+/**
  * Get the name of a given system device. If the name was never set, it defaults
  * to the BDF representation of the system device bus id.
  *

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -858,56 +858,6 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
     }
 }
 
-const char *uct_iface_get_sysfs_path(const char *dev_path, const char *dev_name,
-                                     char *path_buffer)
-{
-    const char *detected_type = NULL;
-    char device_file_path[PATH_MAX];
-    char *sysfs_realpath;
-    struct stat st_buf;
-    char *sysfs_path;
-    int ret;
-
-    /* realpath name is expected to be like below:
-     * PF: /sys/devices/.../0000:03:00.0/<interface_type>/<dev_name>
-     * SF: /sys/devices/.../0000:03:00.0/<UUID>/<interface_type>/<dev_name>
-     */
-
-    sysfs_realpath = realpath(dev_path, path_buffer);
-    if (sysfs_realpath == NULL) {
-        goto out_undetected;
-    }
-
-    /* Try PF: strip 2 components */
-    sysfs_path = ucs_dirname(sysfs_realpath, 2);
-    ucs_snprintf_safe(device_file_path, sizeof(device_file_path), "%s/device",
-                      sysfs_path);
-    ret = stat(device_file_path, &st_buf);
-    if (ret == 0) {
-        detected_type = "PF";
-        goto out_detected;
-    }
-
-    /* Try SF: strip 3 components (one more) */
-    sysfs_path = ucs_dirname(sysfs_path, 1);
-    ucs_snprintf_safe(device_file_path, sizeof(device_file_path), "%s/device",
-                      sysfs_path);
-    ret = stat(device_file_path, &st_buf);
-    if (ret == 0) {
-        detected_type = "SF";
-        goto out_detected;
-    }
-
-out_undetected:
-    ucs_debug("%s: sysfs path undetected", dev_name);
-    return NULL;
-
-out_detected:
-    ucs_debug("%s: %s sysfs path is '%s'\n", dev_name, detected_type,
-              sysfs_path);
-    return sysfs_path;
-}
-
 int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
                                  ucs_sys_namespace_type_t sys_ns_type)
 {

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -856,19 +856,6 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
 int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
                                  ucs_sys_namespace_type_t sys_ns_type);
 
-/**
- * Returns sysfs path for the required device.
- *
- * @param [in]  dev_path    Device file path.
- * @param [in]  dev_name    Device Name.
- * @param [in]  path_buffer Allocated buffer to hold the string to be
- *                          returned.
- *
- * @return Pointer to sysfs path or NULL on error.
- */
-const char *uct_iface_get_sysfs_path(const char *dev_path, const char *dev_name,
-                                     char *path_buffer);
-
 /*
  * Invoke active message handler.
  *

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -542,7 +542,7 @@ ucs_status_t uct_ib_device_query(uct_ib_device_t *dev,
         }
     }
 
-    sysfs_path = uct_iface_get_sysfs_path(dev_path, dev_name, path_buffer);
+    sysfs_path   = ucs_topo_resolve_sysfs_path(dev_path, path_buffer);
     dev->sys_dev = ucs_topo_get_sysfs_dev(dev_name, sysfs_path,
                                           sys_device_priority);
     uct_ib_device_set_pci_id(dev, sysfs_path);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -218,6 +218,50 @@ static int uct_tcp_iface_is_reachable(const uct_iface_h tl_iface,
     return 1;
 }
 
+static ucs_status_t
+uct_tcp_iface_parse_virtual_dev(const struct dirent *entry, void *ctx)
+{
+    static const char *low_level_dev_prefix = "lower_";
+    ucs_string_buffer_t *dev_path           = ctx;
+
+    if (!strncmp(entry->d_name, low_level_dev_prefix,
+                 strlen(low_level_dev_prefix))) {
+        ucs_string_buffer_appendf(dev_path, "/%s", entry->d_name);
+        return UCS_ERR_CANCELED;
+    }
+
+    return UCS_OK;
+}
+
+static const char *
+uct_tcp_iface_get_sysfs_path(const char *dev_name, char *path_buffer)
+{
+    ucs_string_buffer_t dev_path = UCS_STRING_BUFFER_INITIALIZER;
+    const char *sysfs_path;
+    ucs_status_t status;
+
+    /* Find and return the correct device sysfs path:
+     * 1) For regular device, use regular sysfs form.
+     * 2) For virtual device (RoCE LAG/VLAN), search for symbolic link of the
+     *    form "lower_*" */
+    ucs_string_buffer_appendf(&dev_path, "%s/%s", UCT_TCP_IFACE_NETDEV_DIR,
+                              dev_name);
+
+    status = ucs_sys_readdir(ucs_string_buffer_cstr(&dev_path),
+                             uct_tcp_iface_parse_virtual_dev, &dev_path);
+    if (status != UCS_ERR_CANCELED) {
+        ucs_string_buffer_cleanup(&dev_path);
+        return NULL;
+    }
+
+    /* 'path_buffer' size is PATH_MAX */
+    sysfs_path = ucs_topo_resolve_sysfs_path(ucs_string_buffer_cstr(&dev_path),
+                                             path_buffer);
+
+    ucs_string_buffer_cleanup(&dev_path);
+    return sysfs_path;
+}
+
 static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
                                         uct_iface_attr_t *attr)
 {
@@ -226,8 +270,9 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
                              sizeof(uct_tcp_am_hdr_t);
     ucs_status_t status;
     int is_default;
-    char sysfs_path[PATH_MAX];
     double pci_bw, network_bw, calculated_bw;
+    char path_buffer[PATH_MAX];
+    const char *sysfs_path;
 
     uct_base_iface_query(&iface->super, attr);
 
@@ -236,8 +281,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
         return status;
     }
 
-    ucs_snprintf_safe(sysfs_path, PATH_MAX, "%s/%s/device",
-                      UCT_TCP_IFACE_NETDEV_DIR, iface->if_name);
+    sysfs_path             = uct_tcp_iface_get_sysfs_path(iface->if_name, path_buffer);
     pci_bw                 = ucs_topo_get_pci_bw(iface->if_name, sysfs_path);
     calculated_bw          = ucs_min(pci_bw, network_bw);
 
@@ -843,7 +887,7 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
     ucs_status_t status;
     DIR *dir;
     const char *sysfs_path;
-    char path_buffer[PATH_MAX], dev_path[PATH_MAX];
+    char path_buffer[PATH_MAX];
     ucs_sys_device_t sys_dev;
 
     dir = opendir(UCT_TCP_IFACE_NETDEV_DIR);
@@ -900,13 +944,9 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
         }
         devices = tmp;
 
-        ucs_snprintf_safe(dev_path, PATH_MAX, "%s/%s", UCT_TCP_IFACE_NETDEV_DIR,
-                          entry->d_name);
-        sysfs_path = uct_iface_get_sysfs_path(dev_path, entry->d_name,
-                                              path_buffer);
-
-        sys_dev = ucs_topo_get_sysfs_dev(entry->d_name, sysfs_path,
-                                         sys_device_priority);
+        sysfs_path = uct_tcp_iface_get_sysfs_path(entry->d_name, path_buffer);
+        sys_dev    = ucs_topo_get_sysfs_dev(entry->d_name, sysfs_path,
+                                            sys_device_priority);
 
         ucs_snprintf_zero(devices[num_devices].name,
                           sizeof(devices[num_devices].name),

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -490,7 +490,7 @@ ssize_t get_proc_self_status_field(const std::string &parameter)
     return -1;
 }
 
-static std::vector<std::string> read_dir(const std::string& path)
+std::vector<std::string> read_dir(const std::string &path)
 {
     std::vector<std::string> result;
     struct dirent *entry;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -322,6 +322,11 @@ bool is_interface_usable(struct ifaddrs *ifa);
 ssize_t get_proc_self_status_field(const std::string &parameter);
 
 /**
+ * Read directory contents and return a vector of file names.
+ */
+std::vector<std::string> read_dir(const std::string &path);
+
+/**
  * Return the name of the given network device if it is supported by rdmacm.
  */
 std::string get_rdmacm_netdev(const char *ifa_name);

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -840,3 +840,88 @@ UCS_TEST_P(test_ucp_modify_uct_cfg, verify_seg_size)
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_modify_uct_cfg, dcx, "dc_x")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_modify_uct_cfg, rc,  "rc_v")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_modify_uct_cfg, rcx, "rc_x")
+
+class test_pci_bw : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant_with_value(variants, UCP_FEATURE_TAG, 0, "tag");
+    }
+
+    std::string get_tcp_device(const std::string &dev_name) const
+    {
+        auto dev_path = "/sys/class/net/" + dev_name;
+
+        const auto sysfs_files = ucs::read_dir(dev_path);
+        if (sysfs_files.empty()) {
+            return "";
+        }
+
+        for (const auto &file : sysfs_files) {
+            if (file.find("slave_") != std::string::npos) {
+                dev_path += "/" + file;
+                break;
+            }
+        }
+
+        return dev_path;
+    }
+
+    std::string get_ib_device(const std::string &dev_name) const
+    {
+        /* Length of IB device name suffix (eg. ':1') */
+        static constexpr size_t suffix_length = 2;
+        static const std::string ib_root      = "/sys/class/infiniband/";
+
+        if (dev_name.size() <= suffix_length) {
+            return "";
+        }
+
+        /* Truncate dev name in order to remove port number suffix (assume it
+         * always ends with ':1') */
+        const auto ib_dev_path = ib_root +
+                                 dev_name.substr(0, dev_name.size() -
+                                                            suffix_length);
+
+        struct stat st;
+        if (!stat(ib_dev_path.c_str(), &st)) {
+            return ib_dev_path;
+        }
+
+        return "";
+    }
+
+    bool is_ib_device(const std::string &dev_name) const
+    {
+        return !get_ib_device(dev_name).empty();
+    }
+};
+
+UCS_TEST_P(test_pci_bw, get_pci_bw)
+{
+    ucp_worker_h worker = sender().worker();
+    ucp_context_h ctx   = worker->context;
+    char path_buffer[PATH_MAX];
+    const ucp_worker_iface_t *wiface;
+
+    for (auto i = 0; i < worker->num_ifaces; ++i) {
+        wiface                 = worker->ifaces[i];
+        const auto dev_name    = ctx->tl_rscs[wiface->rsc_index].tl_rsc.dev_name;
+        const auto tcp_device  = get_tcp_device(dev_name);
+        const auto dev_path    = !tcp_device.empty() ? tcp_device :
+                                                          get_ib_device(dev_name);
+        const char *sysfs_path = ucs_topo_resolve_sysfs_path(dev_path.c_str(),
+                                                             path_buffer);
+        const double pci_bw    = ucs_topo_get_pci_bw(dev_name, sysfs_path);
+
+        uct_iface_attr_t attr;
+        ASSERT_UCS_OK(uct_iface_query(wiface->iface, &attr));
+        ASSERT_LE(attr.bandwidth.shared + attr.bandwidth.dedicated, pci_bw);
+
+        if (ucs::is_rdmacm_netdev(dev_name) || is_ib_device(dev_name)) {
+            ASSERT_LT(pci_bw, std::numeric_limits<double>::max());
+        }
+    }
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_pci_bw, all, "all")


### PR DESCRIPTION
## What
Fixed sysfs_path expansion for TCP iface.

## Why ?
In order to find sysfs path for a device, there are few stages:
1) Getting the unresolved path from sys/class. (for example: `/sys/class/net/enp3s0f0s0`).
2) Removing all symbolic links. for example:
    `/sys/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0/mlx5_core.sf.2/net/enp3s0f0s0`
3) Find the sysfs root for the device:
   `/sys/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0`

For TCP iface, we didn't used this process, which caused some architectures to fail (ARM Blufield in this case).
This PR fixes this issue.