### PR TITLE
UCP/EP/WIREUP: use enumerated log level value as argument

### DIFF
--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1320,9 +1320,9 @@ ucp_ep_server_init_priv_data(ucp_ep_h ep, const char *dev_name,
     ucp_context_dev_tl_bitmap(worker->context, dev_name, &ctx_tl_bitmap);
     ucp_tl_bitmap_validate(&tl_bitmap, &ctx_tl_bitmap);
 
-    status = ucp_cm_ep_priv_data_pack(ep, &tl_bitmap, 0, sa_data_version,
-                                      (void**)data_buf_p, data_buf_size_p,
-                                      ep_init_flags);
+    status = ucp_cm_ep_priv_data_pack(ep, &tl_bitmap, UCS_LOG_LEVEL_ERROR,
+                                      sa_data_version, (void**)data_buf_p,
+                                      data_buf_size_p, ep_init_flags);
 
 out:
     UCS_ASYNC_UNBLOCK(&worker->async);


### PR DESCRIPTION
Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>

## What
use the default enumerated value as argument instead of using int value directly.

## Why ?
improve readability.
broken by https://github.com/openucx/ucx/pull/8144