### PR TITLE
ROCM/COPY: allow async progress for zcopy operations

### DIFF
--- a/src/uct/rocm/Makefile.am
+++ b/src/uct/rocm/Makefile.am
@@ -16,10 +16,12 @@ libuct_rocm_la_LDFLAGS  = $(ROCM_LDFLAGS) $(ROCM_LIBS) -version-info $(SOVERSION
                           $(patsubst %, -Xlinker %, -rpath $(ROCM_ROOT)/lib64)
 
 noinst_HEADERS = \
-	base/rocm_base.h
+	base/rocm_base.h \
+	base/rocm_signal.h
 
 libuct_rocm_la_SOURCES = \
-	base/rocm_base.c
+	base/rocm_base.c \
+	base/rocm_signal.c
 
 noinst_HEADERS += \
     copy/rocm_copy_md.h \

--- a/src/uct/rocm/base/rocm_signal.c
+++ b/src/uct/rocm/base/rocm_signal.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2023. ALL RIGHTS RESERVED.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <uct/rocm/base/rocm_base.h>
+#include <uct/rocm/base/rocm_signal.h>
+
+static void uct_rocm_base_signal_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
+{
+    uct_rocm_base_signal_desc_t *base = (uct_rocm_base_signal_desc_t*)obj;
+    hsa_status_t status;
+
+    memset(base, 0, sizeof(*base));
+    status = hsa_signal_create(1, 0, NULL, &base->signal);
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_fatal("fail to create signal");
+    }
+}
+
+static void uct_rocm_base_signal_desc_cleanup(ucs_mpool_t *mp, void *obj)
+{
+    uct_rocm_base_signal_desc_t *base = (uct_rocm_base_signal_desc_t*)obj;
+    hsa_status_t status;
+
+    status = hsa_signal_destroy(base->signal);
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_warn("fail to destroy signal");
+    }
+}
+
+ucs_mpool_ops_t uct_rocm_base_signal_desc_mpool_ops = {
+    .chunk_alloc   = ucs_mpool_chunk_malloc,
+    .chunk_release = ucs_mpool_chunk_free,
+    .obj_init      = uct_rocm_base_signal_desc_init,
+    .obj_cleanup   = uct_rocm_base_signal_desc_cleanup,
+    .obj_str       = NULL
+};
+
+unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
+{
+    static const unsigned max_signals = 16;
+    unsigned count                    = 0;
+    uct_rocm_base_signal_desc_t *rocm_signal;
+
+    ucs_queue_for_each_extract(rocm_signal, signal_queue, queue,
+			       (hsa_signal_load_scacquire(rocm_signal->signal) == 0) &&
+			       (count < max_signals)) {
+        if (rocm_signal->comp != NULL) {
+            uct_invoke_completion(rocm_signal->comp, UCS_OK);
+        }
+
+        ucs_trace_poll("rocm signal done :%p", rocm_signal);
+        ucs_mpool_put(rocm_signal);
+        count++;
+    }
+
+    return count;
+}
+

--- a/src/uct/rocm/base/rocm_signal.h
+++ b/src/uct/rocm/base/rocm_signal.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. 2023. ALL RIGHTS RESERVED.
+ */
+
+#include <ucs/arch/cpu.h>
+#include <ucs/type/class.h>
+#include <ucs/sys/string.h>
+
+
+typedef struct uct_rocm_base_signal_desc {
+    hsa_signal_t     signal;
+    void             *mapped_addr;
+    uct_completion_t *comp;
+    ucs_queue_elem_t queue;
+} uct_rocm_base_signal_desc_t;
+
+extern ucs_mpool_ops_t uct_rocm_base_signal_desc_mpool_ops;
+
+unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue);

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Advanced Micro Devices, Inc. 2019-2022. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2019-2023. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -13,13 +13,14 @@
 #include "rocm_copy_md.h"
 #include "rocm_copy_cache.h"
 
-
 #include <uct/rocm/base/rocm_base.h>
+#include <uct/rocm/base/rocm_signal.h>
 #include <uct/base/uct_log.h>
 #include <uct/base/uct_iov.inl>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/type/class.h>
 #include <ucs/arch/cpu.h>
+#include <ucs/profile/profile.h>
 
 #include <hsa_ext_amd.h>
 
@@ -87,16 +88,14 @@ uct_rocm_copy_get_mapped_host_ptr(uct_ep_h tl_ep, void *ptr, size_t size,
     return mapped_ptr;
 }
 
-ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
-                                    uint64_t remote_addr,
-                                    const uct_iov_t *iov,
-                                    uct_rkey_t rkey,
-                                    int is_put)
+ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
+                                    const uct_iov_t *iov, uct_rkey_t rkey,
+                                    int is_put, uct_completion_t *comp)
 {
     size_t size                        = uct_iov_get_length(iov);
     uct_rocm_copy_iface_t *iface       = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
-    hsa_signal_t signal                = iface->hsa_signal;
     uct_rocm_copy_key_t *rocm_copy_key = (uct_rocm_copy_key_t *) rkey;
+    ucs_status_t ret                   = UCS_INPROGRESS;
     void *remote_addr_mod = NULL, *iov_buffer_mod = NULL;
     bool remote_addr_is_host = 0, iov_buffer_is_host = 0;
     hsa_status_t status;
@@ -105,6 +104,7 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
     hsa_device_type_t dev_type;
     hsa_amd_pointer_type_t remote_addr_mem_type, iov_buffer_mem_type;
     size_t dev_size;
+    uct_rocm_base_signal_desc_t *rocm_copy_signal;
 
     ucs_trace("remote addr %p rkey %p size %zu",
               (void*)remote_addr, (void*)rkey, size);
@@ -200,16 +200,34 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
         dst_addr = iov_buffer_mod;
     }
 
-    hsa_signal_store_screlease(signal, 1);
-    status = hsa_amd_memory_async_copy(dst_addr, agent,
-                                       src_addr, agent,
-                                       size, 0, NULL, signal);
+    rocm_copy_signal = ucs_mpool_get(&iface->signal_pool);
+    hsa_signal_store_screlease(rocm_copy_signal->signal, 1);
 
-    while (hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, 1,
-                                     UINT64_MAX, HSA_WAIT_STATE_ACTIVE));
+    status = UCS_PROFILE_CALL_ALWAYS(hsa_amd_memory_async_copy, dst_addr, agent,
+                                     src_addr, agent, size, 0, NULL,
+                                     rocm_copy_signal->signal);
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("copy error");
+        ucs_mpool_put(rocm_copy_signal);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    if ((comp == NULL) || !iface->config.enable_async_zcopy) {
+        while (UCS_PROFILE_CALL_ALWAYS(hsa_signal_wait_scacquire,
+                                       rocm_copy_signal->signal,
+                                       HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX,
+                                       HSA_WAIT_STATE_ACTIVE));
+        ucs_mpool_put(rocm_copy_signal);
+        ret = UCS_OK;
+    } else {
+        rocm_copy_signal->comp        = comp;
+        rocm_copy_signal->mapped_addr = dst_addr;
+        ucs_queue_push(&iface->signal_queue, &rocm_copy_signal->queue);
+    }
+
     ucs_trace("hsa async copy from src %p to dst %p, len %ld status %d",
               src_addr, dst_addr, size, (int)status);
-    return UCS_OK;
+    return ret;
 }
 
 ucs_status_t uct_rocm_copy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
@@ -224,7 +242,8 @@ ucs_status_t uct_rocm_copy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, si
         uct_rocm_memcpy_d2h(iov->buffer, (void *)remote_addr, size);
         status = UCS_OK;
     } else {
-        status = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 0);
+        status = UCS_PROFILE_CALL_ALWAYS(uct_rocm_copy_ep_zcopy, tl_ep,
+                                         remote_addr, iov, rkey, 0, comp);
     }
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY,
@@ -246,7 +265,8 @@ ucs_status_t uct_rocm_copy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, si
         uct_rocm_memcpy_h2d((void *)remote_addr, iov->buffer, size);
         status = UCS_OK;
     } else {
-        status = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 1);
+        status = UCS_PROFILE_CALL_ALWAYS(uct_rocm_copy_ep_zcopy, tl_ep,
+                                         remote_addr, iov, rkey, 1, comp);
     }
 
     UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
@@ -277,7 +297,8 @@ ucs_status_t uct_rocm_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
         iov->buffer = (void*)buffer;
         iov->length = length;
         iov->count  = 1;
-        status      = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 1);
+        status      = UCS_PROFILE_CALL_ALWAYS(uct_rocm_copy_ep_zcopy, tl_ep,
+                                              remote_addr, iov, rkey, 1, NULL);
         if (status != UCS_OK) {
             ucs_error("error in uct_rocm_copy_ep_zcopy %s",
                       ucs_status_string(status));
@@ -312,7 +333,8 @@ ucs_status_t uct_rocm_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
         iov->buffer = buffer;
         iov->length = length;
         iov->count  = 1;
-        status      = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 0);
+        status      = UCS_PROFILE_CALL_ALWAYS(uct_rocm_copy_ep_zcopy, tl_ep,
+                                              remote_addr, iov, rkey, 0, NULL);
         if (status != UCS_OK) {
             ucs_error("error in uct_rocm_copy_ep_zcopy %s",
                       ucs_status_string(status));

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2019-2023. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -17,10 +17,12 @@ typedef uint64_t uct_rocm_copy_iface_addr_t;
 typedef struct uct_rocm_copy_iface {
     uct_base_iface_t            super;
     uct_rocm_copy_iface_addr_t  id;
-    hsa_signal_t                hsa_signal;
+    ucs_mpool_t                 signal_pool;
+    ucs_queue_head_t            signal_queue;
     struct {
         size_t                  d2h_thresh;
         size_t                  h2d_thresh;
+        int                     enable_async_zcopy;
     } config;
 } uct_rocm_copy_iface_t;
 
@@ -28,8 +30,7 @@ typedef struct uct_rocm_copy_iface_config {
     uct_iface_config_t  super;
     size_t              d2h_thresh;
     size_t              h2d_thresh;
-    size_t              short_d2h_thresh;
-    size_t              short_h2d_thresh;
+    int                 enable_async_zcopy;
 } uct_rocm_copy_iface_config_t;
 
 #endif

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2019-2023. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -12,13 +12,6 @@
 #include <hsa.h>
 
 #define UCT_ROCM_IPC_TL_NAME "rocm_ipc"
-
-typedef struct uct_rocm_ipc_signal_desc {
-    hsa_signal_t signal;
-    void *mapped_addr;
-    uct_completion_t *comp;
-    ucs_queue_elem_t queue;
-} uct_rocm_ipc_signal_desc_t;
 
 typedef struct uct_rocm_ipc_iface {
     uct_base_iface_t super;


### PR DESCRIPTION
## What
This commit introduces the ability to use asynchronous progress for the zcopy operations in the rocm/copy tl. 

## Why ?
Performance improvements.

## How ?
Move some common code from the rocm/ipc directory to rocm/base to minimize code duplication.
