### PR TITLE
UCT/IB/DC: support bigger DCI_NUM (>127)

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1437,7 +1437,7 @@ unsigned uct_dc_mlx5_ep_dci_release_progress(void *arg)
 {
     uct_dc_mlx5_iface_t *iface = arg;
     uint8_t pool_index;
-    uint8_t dci;
+    uint16_t dci;
     uct_dc_mlx5_dci_pool_t *dci_pool;
 
     ucs_assert(iface->tx.dci_release_prog_id != UCS_CALLBACKQ_ID_NULL);
@@ -1710,7 +1710,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                 uct_dc_mlx5_iface_t);
-    uint8_t dci_index          = ep->dci;
+    uint16_t dci_index         = ep->dci;
     uint16_t pi                = ntohs(cqe->wqe_counter);
     uint8_t pool_index;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -161,6 +161,12 @@ int test_dc::n_warnings         = 0;
 int test_dc::m_purge_count      = 0;
 uint32_t test_dc::m_am_rx_count = 0;
 
+UCS_TEST_P(test_dc, dcs_ep_dci_128, "DC_NUM_DCI=128") {
+}
+
+UCS_TEST_P(test_dc, dcs_ep_dci_256, "DC_NUM_DCI=256") {
+}
+
 UCS_TEST_P(test_dc, dcs_single) {
     ucs_status_t status;
     uct_dc_mlx5_ep_t *ep;


### PR DESCRIPTION
## What
Support bigger DCI_NUM (> 127).
Add checks/asserts of DCI number to avoid invalid environment variable values.

## Why ?
Cannot establish 4k connections with DCI_NUM set to 128.
Because the DCI index is stored in `int8_t` and the DCI num is stored in `uint8_t`,
the UCX doesn't support more than 127 DCIs each interface or 255 DCIs total.

## How ?
Change the data type of the DCI index/num.