### PR TITLE
change label to ucx_iodemo_without_interference

### DIFF
--- a/buildlib/pr/distro.yml
+++ b/buildlib/pr/distro.yml
@@ -52,7 +52,7 @@ jobs:
     pool:
       name: MLNX
       demands:
-      - ucx_docker -equals yes
+      - ucx_ci_without_interference -equals yes
     strategy:
       matrix:
         ubuntu20:


### PR DESCRIPTION
## What
change label ucx_docker to swx-rain03

## Why ?
failing builds [https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=52808&view=logs&j=5afb4f82-935f-5137-d62f-bc721755fb44&t=880ff2b6-670e-58f5-7dea-5da90e095d00&s=092fc06a-bf28-53e8-3671-20e6cafa6bc9](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdev.azure.com%2Fucfconsort%2Fucx%2F_build%2Fresults%3FbuildId%3D52808%26view%3Dlogs%26j%3D5afb4f82-935f-5137-d62f-bc721755fb44%26t%3D880ff2b6-670e-58f5-7dea-5da90e095d00%26s%3D092fc06a-bf28-53e8-3671-20e6cafa6bc9&data=05%7C01%7Cekaidrikov%40nvidia.com%7C8064fe04fd8248dacd8a08daf8717424%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C638095463404430960%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=5oDW5xYjJcMJfyQHl8k%2BgRzUII1z%2FAaVi06dT9%2Bh0M4%3D&reserved=0)

## How ?
HC in ucx/buildlib/pr/distro.yml
