### PR TITLE
JUCX: Fix leakage of jucx_request global references

### DIFF
--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -129,7 +129,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_closeNonBlockingNative(JNIEnv *env, jclass
     param.cb.send       = jucx_request_callback;
 
     ucs_status_ptr_t status = ucp_ep_close_nbx((ucp_ep_h)ep_ptr, &param);
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -168,7 +168,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_putNonBlockingNative(JNIEnv *env, jclass c
     ucs_status_ptr_t status = ucp_put_nbx((ucp_ep_h)ep_ptr, (void *)laddr, size, raddr,
                                           (ucp_rkey_h)rkey_ptr, &param);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     ucs_trace_req("JUCX: put_nb request %p, of size: %zu, raddr: %zu", status, size, raddr);
 
@@ -207,7 +207,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_getNonBlockingNative(JNIEnv *env, jclass c
     ucs_trace_req("JUCX: get_nb request %p, raddr: %zu, size: %zu, result address: %zu",
                   status, raddr, size, laddr);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
     return jucx_request;
 }
 
@@ -241,7 +241,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedNonBlockingNative(JNIEnv *env, j
     ucs_status_ptr_t status = ucp_tag_send_nbx((ucp_ep_h)ep_ptr, (void *)addr, size, tag, &param);
     ucs_trace_req("JUCX: send_tag_nb request %p, size: %zu, tag: %ld", status, size, tag);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
     return jucx_request;
 }
 
@@ -270,7 +270,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendTaggedIovNonBlockingNative(JNIEnv *env
     ucs_status_ptr_t status = ucp_tag_send_nbx((ucp_ep_h)ep_ptr, iovec, iovcnt, tag, &param);
     ucs_trace_req("JUCX: send_tag_iov_nb request %p, tag: %ld", status, tag);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -290,7 +290,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamNonBlockingNative(JNIEnv *env, j
     ucs_status_ptr_t status = ucp_stream_send_nbx((ucp_ep_h)ep_ptr, (void *)addr, size, &param);
     ucs_trace_req("JUCX: send_stream_nb request %p, size: %zu", status, size);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
     return jucx_request;
 }
 
@@ -318,7 +318,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendStreamIovNonBlockingNative(JNIEnv *env
     ucs_status_ptr_t status = ucp_stream_send_nbx((ucp_ep_h)ep_ptr, iovec, iovcnt, &param);
     ucs_trace_req("JUCX: send_stream_iov_nb request %p", status);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
     return jucx_request;
 }
 
@@ -345,7 +345,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamNonBlockingNative(JNIEnv *env, j
         jucx_request_update_recv_length(env, jucx_request, rlength);
     }
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -383,7 +383,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_recvStreamIovNonBlockingNative(JNIEnv *env
         jucx_request_update_recv_length(env, jucx_request, rlength);
     }
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -401,7 +401,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_flushNonBlockingNative(JNIEnv *env, jclass
     ucs_status_ptr_t status = ucp_ep_flush_nbx((ucp_ep_h)ep_ptr, &param);
     ucs_trace_req("JUCX: ucp_ep_flush_nbx request %p", status);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -426,6 +426,6 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_sendAmNonBlockingNative(JNIEnv *env, jclas
                                               (void*)data_address, data_length, &param);
     ucs_trace_req("JUCX: ucp_am_send_nbx request %p", status);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
     return jucx_request;
 }

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -393,12 +393,14 @@ jobject jucx_request_allocate(JNIEnv *env, const jobject callback,
     return jucx_request;
 }
 
-void process_request(JNIEnv *env, jobject jucx_request, ucs_status_ptr_t status)
+void process_request(JNIEnv *env, const ucp_request_param_t *request_params, ucs_status_ptr_t status)
 {
     // If status is error - throw an exception in java.
     if (UCS_PTR_IS_ERR(status)) {
         JNU_ThrowExceptionByStatus(env, UCS_PTR_STATUS(status));
     }
+
+    jobject jucx_request = reinterpret_cast<jobject>(request_params->user_data);
 
     if (UCS_PTR_IS_PTR(status)) {
       env->CallVoidMethod(jucx_request, jucx_set_native_id, (native_ptr)status);
@@ -411,6 +413,8 @@ void process_request(JNIEnv *env, jobject jucx_request, ucs_status_ptr_t status)
             // Remove callback reference from request.
             env->SetObjectField(jucx_request, request_callback, NULL);
         }
+
+        env->DeleteGlobalRef(jucx_request);
     }
 }
 

--- a/bindings/java/src/main/native/jucx_common_def.h
+++ b/bindings/java/src/main/native/jucx_common_def.h
@@ -123,7 +123,7 @@ void jucx_request_update_sender_tag(JNIEnv *env, jobject jucx_request, ucp_tag_t
 /**
  * @brief Function to handle result of ucx function submition, to handle immidiate completion.
  */
-void process_request(JNIEnv *env, jobject request, ucs_status_ptr_t status);
+void process_request(JNIEnv *env, const ucp_request_param_t *request_params, ucs_status_ptr_t status);
 
 void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg);
 

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -141,7 +141,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_flushNonBlockingNative(JNIEnv *env, jclass c
     ucs_status_ptr_t status = ucp_worker_flush_nbx((ucp_worker_h)ucp_worker_ptr, &param);
     ucs_trace_req("JUCX: ucp_worker_flush_nbx request %p", status);
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -215,7 +215,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedNonBlockingNative(JNIEnv *env, jcl
         jucx_request_update_sender_tag(env, jucx_request, recv_info.sender_tag);
     }
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -254,7 +254,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedIovNonBlockingNative(JNIEnv *env, 
         jucx_request_update_recv_length(env, jucx_request, recv_info.length);
         jucx_request_update_sender_tag(env, jucx_request, recv_info.sender_tag);
     }
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -306,7 +306,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvTaggedMessageNonBlockingNative(JNIEnv *e
         jucx_request_update_sender_tag(env, jucx_request, recv_info.sender_tag);
     }
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
 
     return jucx_request;
 }
@@ -373,7 +373,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_recvAmDataNonBlockingNative(JNIEnv *env, jcl
         jucx_request_update_recv_length(env, jucx_request, recv_length);
     }
 
-    process_request(env, jucx_request, status);
+    process_request(env, &param, status);
     return jucx_request;
 }
 


### PR DESCRIPTION
## What
JUCX allocates a global reference to each request, which is used as `user_data` for the request parameters. These global references are deleted inside the native callback. However, when requests are finished directly, the references are not deleted, causing a memory leak. This PR fixes the leakage of global references.

## Why ?
I ran a test application, which sends/receives small tagged messages in a ping-pong pattern using 12 connections (1 thread per connection) and monitored the allocated memory and GC activity:

![leak](https://user-images.githubusercontent.com/7222492/213724342-74a412a0-0dc0-4bce-b301-10286988279a.png)

After 1:25 minutes, the JVM heap is around 10 GB large and grows further, while the GC activity spikes well over 30%, negatively impacting performance.

With the fix applied, the heap size is stable at around 2 GB and the GC activity stays under 1%:

![fixed](https://user-images.githubusercontent.com/7222492/213723706-fcc0a3ae-9f81-49f5-990c-dc6c7000b27c.png)

## How ?
By deleting the global reference, when a request has finished directly. To have access to the reference inside `process_request`, I pass the global reference instead of `jucx_request`.
