### PR TITLE
AZP/RELEASE: Add Ubuntu 22.04 - v1.14.x

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -31,6 +31,9 @@ jobs:
         ubuntu20_cuda11:
           build_container: ubuntu20_cuda11
           artifact_name: $(POSTFIX)-ubuntu20.04-mofed5-cuda11.deb
+        ubuntu22_cuda11:
+          build_container: ubuntu22_cuda11
+          artifact_name: $(POSTFIX)-ubuntu22.04-mofed5-cuda11.deb
 
     container: $[ variables['build_container'] ]
 

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -25,6 +25,8 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:3
     - container: ubuntu20_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:3
+    - container: ubuntu22_cuda11
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda11:3
 
 stages:
   - stage: Prepare

--- a/buildlib/dockers/docker-compose.yml
+++ b/buildlib/dockers/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   centos7-mofed5-cuda11:
@@ -64,3 +64,13 @@ services:
         MOFED_VERSION: 5.0-1.0.0.0
         UBUNTU_VERSION: 20.04
         CUDA_VERSION: 11.4.0
+  ubuntu22.04-mofed5-cuda11:
+    image: ubuntu22.04-mofed5-cuda11:3
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.4-3.6.8.1
+        UBUNTU_VERSION: 22.04
+        CUDA_VERSION: 11.7.0

--- a/buildlib/dockers/ubuntu-release.Dockerfile
+++ b/buildlib/dockers/ubuntu-release.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
         udev \
         wget \
         environment-modules \
+        pkg-config \
     && apt-get remove -y openjdk-11-* || apt-get autoremove -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
What
Add ubuntu 22.04 to the release pipeline.

How ?
The new Ubuntu image was built with Dockerfile & docker-compose below.