### PR TITLE
UCP/CORE: Fixed proto info filename.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1918,7 +1918,7 @@ void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
         ucs_string_buffer_appendf(strb, "inter-node ");
     }
 
-    ucs_string_buffer_appendf(strb, "cfg#%d ", cfg_index);
+    ucs_string_buffer_appendf(strb, "cfg#%d", cfg_index);
 }
 
 static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1666,7 +1666,7 @@ static void ucp_worker_add_feature_rsc(ucp_context_h context,
         return;
     }
 
-    ucs_string_buffer_appendf(strb, "%s(", feature_str);
+    ucs_string_buffer_appendf(strb, " %s(", feature_str);
 
     ucs_for_each_bit(lane, lanes_bitmap) {
         ucs_assert(lane < UCP_MAX_LANES); /* make coverity happy */


### PR DESCRIPTION
## What
Fixed filename generated when using `UCX_PROTO_INFO_DIR`.

## Why ?
Changes from https://github.com/openucx/ucx/pull/8699 added an extra underscore to filenames generated using `UCX_PROTO_INFO_DIR`. E.g. `0x807be0_self_cfg_0__tag_send_from_host_memory_0_0.dot`.
