### PR TITLE
UCP/PROTO: Fixed operation flags in proto v2 info.

### DIFF
--- a/src/ucp/am/ucp_am.inl
+++ b/src/ucp/am/ucp_am.inl
@@ -29,14 +29,15 @@ ucp_am_check_init_params(const ucp_proto_init_params_t *init_params,
                          uint64_t op_id_mask, uint16_t exclude_flags)
 {
     return ucp_proto_init_check_op(init_params, op_id_mask) &&
-           !(init_params->select_param->op_id_flags & exclude_flags);
+           !(ucp_proto_select_op_flags(init_params->select_param) &
+             exclude_flags);
 }
 
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_config_is_am(const ucp_proto_config_t *proto_config)
 {
-    return UCS_BIT(ucp_proto_select_op_id(&proto_config->select_param)) &
-           UCP_PROTO_AM_OP_ID_MASK;
+    return ucp_proto_select_check_op(&proto_config->select_param,
+                                     UCP_PROTO_AM_OP_ID_MASK);
 }
 
 #endif

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -942,7 +942,7 @@ ucp_am_try_send_short(ucp_ep_h ep, uint16_t id, uint32_t flags,
     return UCS_ERR_NO_RESOURCE;
 }
 
-static UCS_F_ALWAYS_INLINE uint16_t ucp_am_send_nbx_get_op_flag(uint32_t flags)
+static UCS_F_ALWAYS_INLINE uint8_t ucp_am_send_nbx_get_op_flag(uint32_t flags)
 {
     if (flags & UCP_AM_SEND_FLAG_EAGER) {
         return UCP_PROTO_SELECT_OP_FLAG_AM_EAGER;

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -277,7 +277,7 @@ ucp_proto_request_send_op(ucp_ep_h ep, ucp_proto_select_t *proto_select,
                           const void *buffer, size_t count,
                           ucp_datatype_t datatype, size_t contig_length,
                           const ucp_request_param_t *param,
-                          size_t header_length, unsigned op_flags)
+                          size_t header_length, uint8_t op_flags)
 {
     ucp_worker_h worker = ep->worker;
     ucp_proto_select_param_t sel_param;

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -322,31 +322,31 @@ void ucp_proto_select_dump_short(const ucp_proto_select_short_t *select_short,
 static int
 ucp_proto_select_is_fetch_op(const ucp_proto_select_param_t *select_param)
 {
-    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
-           (UCS_BIT(UCP_OP_ID_GET) | UCS_BIT(UCP_OP_ID_RNDV_RECV) |
-            UCS_BIT(UCP_OP_ID_AMO_FETCH));
+    return ucp_proto_select_check_op(select_param,
+                                     UCS_BIT(UCP_OP_ID_GET) |
+                                     UCS_BIT(UCP_OP_ID_RNDV_RECV) |
+                                     UCS_BIT(UCP_OP_ID_AMO_FETCH));
 }
 
 static int
 ucp_proto_select_is_rndv_op(const ucp_proto_select_param_t *select_param)
 {
-    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
-           UCP_PROTO_AM_OP_ID_MASK;
+    return ucp_proto_select_check_op(select_param, UCP_PROTO_RNDV_OP_ID_MASK);
 }
 
 static int
 ucp_proto_select_is_am_op(const ucp_proto_select_param_t *select_param)
 {
-    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
-           UCP_PROTO_RNDV_OP_ID_MASK;
+    return ucp_proto_select_check_op(select_param, UCP_PROTO_AM_OP_ID_MASK);
 }
 
 static int
 ucp_proto_select_is_atomic_op(const ucp_proto_select_param_t *select_param)
 {
-    return UCS_BIT(ucp_proto_select_op_id(select_param)) &
-           (UCS_BIT(UCP_OP_ID_AMO_POST) | UCS_BIT(UCP_OP_ID_AMO_FETCH) |
-            UCS_BIT(UCP_OP_ID_AMO_CSWAP));
+    return ucp_proto_select_check_op(select_param,
+                                     UCS_BIT(UCP_OP_ID_AMO_POST) |
+                                     UCS_BIT(UCP_OP_ID_AMO_FETCH) |
+                                     UCS_BIT(UCP_OP_ID_AMO_CSWAP));
 }
 static void ucp_proto_debug_mem_info_str(ucs_string_buffer_t *strb,
                                          ucs_memory_type_t mem_type,
@@ -381,15 +381,14 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
         [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)] = "egr",
         [ucs_ilog2(UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)]  = "rndv"
     };
-    unsigned op_flags                    = select_param->op_id_flags &
-                                           (UCP_PROTO_SELECT_OP_FLAGS_BASE - 1);
-    uint32_t op_attr_mask;
+    uint32_t op_attr_mask, op_flags;
 
     ucs_string_buffer_appendf(
             strb, "%s", operation_names[ucp_proto_select_op_id(select_param)]);
 
     op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr) &
                    op_attr_bits;
+    op_flags     = ucp_proto_select_op_flags(select_param);
 
     if (op_attr_mask || op_flags) {
         ucs_string_buffer_appendf(strb, "(");

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -712,6 +712,5 @@ out_deref_xfer_perf:
 int ucp_proto_init_check_op(const ucp_proto_init_params_t *init_params,
                             uint64_t op_id_mask)
 {
-    return !!(UCS_BIT(ucp_proto_select_op_id(init_params->select_param)) &
-              op_id_mask);
+    return ucp_proto_select_check_op(init_params->select_param, op_id_mask);
 }

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -79,6 +79,19 @@ ucp_proto_select_op_id(const ucp_proto_select_param_t *select_param)
                                 (UCP_PROTO_SELECT_OP_FLAGS_BASE - 1));
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_select_check_op(const ucp_proto_select_param_t *select_param,
+                          uint64_t op_id_mask)
+{
+    return !!(UCS_BIT(ucp_proto_select_op_id(select_param)) & op_id_mask);
+}
+
+static UCS_F_ALWAYS_INLINE uint8_t
+ucp_proto_select_op_flags(const ucp_proto_select_param_t *select_param)
+{
+    return select_param->op_id_flags & ~(UCP_PROTO_SELECT_OP_FLAGS_BASE - 1);
+}
+
 static UCS_F_ALWAYS_INLINE const ucp_proto_threshold_elem_t*
 ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
                         ucp_worker_cfg_index_t ep_cfg_index,
@@ -122,7 +135,7 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
  */
 static UCS_F_ALWAYS_INLINE void ucp_proto_select_param_init_common(
         ucp_proto_select_param_t *select_param, ucp_operation_id_t op_id,
-        uint32_t op_attr_mask, unsigned op_flags, ucp_dt_class_t dt_class,
+        uint32_t op_attr_mask, uint8_t op_flags, ucp_dt_class_t dt_class,
         const ucp_memory_info_t *mem_info, uint8_t sg_count)
 {
     if (dt_class == UCP_DATATYPE_CONTIG) {
@@ -150,7 +163,7 @@ static UCS_F_ALWAYS_INLINE void ucp_proto_select_param_init_common(
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
                             ucp_operation_id_t op_id, uint32_t op_attr_mask,
-                            unsigned op_flags, ucp_dt_class_t dt_class,
+                            uint8_t op_flags, ucp_dt_class_t dt_class,
                             const ucp_memory_info_t *mem_info, uint8_t sg_count)
 {
     ucp_proto_select_param_init_common(select_param, op_id, op_attr_mask,
@@ -161,7 +174,7 @@ ucp_proto_select_param_init(ucp_proto_select_param_t *select_param,
 
 static UCS_F_ALWAYS_INLINE void ucp_proto_select_param_init_reply(
         ucp_proto_select_param_t *select_param, ucp_operation_id_t op_id,
-        uint32_t op_attr_mask, unsigned op_flags, ucp_dt_class_t dt_class,
+        uint32_t op_attr_mask, uint8_t op_flags, ucp_dt_class_t dt_class,
         const ucp_memory_info_t *mem_info, uint8_t sg_count,
         const ucp_memory_info_t *reply_mem_info)
 {

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -320,14 +320,14 @@ ucp_proto_rndv_bulk_max_payload_align(ucp_request_t *req,
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_rndv_request_is_ppln_frag(ucp_request_t *req)
 {
-    return req->send.proto_config->select_param.op_id_flags &
+    return ucp_proto_select_op_flags(&req->send.proto_config->select_param) &
            UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
 }
 
 static UCS_F_ALWAYS_INLINE int
 ucp_proto_rndv_init_params_is_ppln_frag(const ucp_proto_init_params_t *params)
 {
-    return params->select_param->op_id_flags &
+    return ucp_proto_select_op_flags(params->select_param) &
            UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
 }
 


### PR DESCRIPTION
## What
Fixed printing operation flags when using UCX_PROTO_INFO.

## Why ?
Before:
![image](https://user-images.githubusercontent.com/74596089/216106321-e6c86f1e-c419-4c8f-a1cd-62dec85a385a.png)

After:
![image](https://user-images.githubusercontent.com/74596089/216106356-53325191-312d-4853-b1cb-0e0f02895d8f.png)
