### PR TITLE
UCP/EP/WIREUP: avoid create extra uct_ep needed to be discarded

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -822,7 +822,7 @@ ucp_ep_create_to_worker_addr(ucp_worker_h worker,
         goto err_delete;
     }
 
-    ucp_ep_get_tl_bitmap(ep, &ep_tl_bitmap);
+    ucp_ep_get_tl_bitmap(&ucp_ep_config(ep)->key, &ep_tl_bitmap);
     ucp_tl_bitmap_validate(&ep_tl_bitmap, local_tl_bitmap);
 
     *ep_p = ep;
@@ -3327,18 +3327,19 @@ int ucp_ep_is_local_connected(ucp_ep_h ep)
     return is_local_connected;
 }
 
-void ucp_ep_get_tl_bitmap(ucp_ep_h ep, ucp_tl_bitmap_t *tl_bitmap)
+void ucp_ep_get_tl_bitmap(const ucp_ep_config_key_t *key,
+                          ucp_tl_bitmap_t *tl_bitmap)
 {
     ucp_lane_index_t lane;
     ucp_rsc_index_t rsc_idx;
 
     UCS_BITMAP_CLEAR(tl_bitmap);
-    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        if (lane == ucp_ep_get_cm_lane(ep)) {
+    for (lane = 0; lane < key->num_lanes; ++lane) {
+        if (lane == key->cm_lane) {
             continue;
         }
 
-        rsc_idx = ucp_ep_get_rsc_index(ep, lane);
+        rsc_idx = key->lanes[lane].rsc_index;
         if (rsc_idx == UCP_NULL_RESOURCE) {
             continue;
         }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -745,7 +745,8 @@ void ucp_worker_mem_type_eps_print_info(ucp_worker_h worker,
 
 ucp_wireup_ep_t * ucp_ep_get_cm_wireup_ep(ucp_ep_h ep);
 
-void ucp_ep_get_tl_bitmap(ucp_ep_h ep, ucp_tl_bitmap_t *tl_bitmap);
+void ucp_ep_get_tl_bitmap(const ucp_ep_config_key_t *key,
+                          ucp_tl_bitmap_t *tl_bitmap);
 
 uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep);
 

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -179,6 +179,27 @@ struct ucp_unpacked_address {
 
 
 /**
+ * Get multiple addresses length of resources specified in tl_bitmap.
+ * For every resource in tl_bitmap:
+ *    - if iface is CONNECT_TO_IFACE, get interface address length.
+ *    - if iface is CONNECT_TO_EP, get endpoint address length.
+ *
+ * @param [in]  worker        Worker object to get interface addresses length.
+ * @param [in]  key           Endpoint config key to get ep address length.
+ * @param [in]  tl_bitmap     Specifies the resources to get transport address
+ *                            length.
+ * @param [in]  pack_flags    UCP_ADDRESS_PACK_FLAG_xx flags to specify address
+ *                            format.
+ * @param [in]  addr_version  Address format version.
+ * @param [out] size_p        Filled with address length.
+ */
+ucs_status_t
+ucp_address_length(ucp_worker_h worker, const ucp_ep_config_key_t *key,
+                   const ucp_tl_bitmap_t *tl_bitmap, unsigned pack_flags,
+                   ucp_object_version_t addr_version, size_t *size_p);
+
+
+/**
  * Pack multiple addresses into a buffer, of resources specified in rsc_bitmap.
  * For every resource in rcs_bitmap:
  *    - if iface is CONNECT_TO_IFACE, pack interface address


### PR DESCRIPTION
Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>

## What
1. optimize using [ep_init_flags_prio](https://github.com/openucx/ucx/blob/v1.14.0-rc1/src/ucp/wireup/wireup_cm.c#L432) array member to get ep config before creating uct_eps.
2. Do not create uct_ep before fallback to use other CM

## Why ?
Different ep_init_flags_prio results in creating different uct_eps, after packing the ucp_ep address, the address length maybe out of connection channel data space. Then, the pre-created uct_ep needs to be discarded/destroyed. This is a resource & time consuming process. It needs to optimize the process of selecting ```ep_init_flags_prio``` array member to get the ep config and evaluate the ucp address length before creating the uct_ep.

## How ?
1. check whether the cm private data space is enough for ucp ep address under different ep_init_flags before creating the uct_ep.
2. Only extract pending request & create uct_ep & reply the pending request when the CM space is enough to pack ucp ep address.
