### PR TITLE
UCT/SM/SELF: Choosing self rndv/rkey_ptr for big messages in same-process communications

### DIFF
--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -122,7 +122,7 @@ static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t 
     attr->cap.am.max_iov          = SIZE_MAX;
 
     attr->latency                 = UCS_LINEAR_FUNC_ZERO;
-    attr->bandwidth.dedicated     = 6911.0 * UCS_MBYTE;
+    attr->bandwidth.dedicated     = 19360 * UCS_MBYTE;
     attr->bandwidth.shared        = 0;
     attr->overhead                = 10e-9;
     attr->priority                = 0;
@@ -463,7 +463,7 @@ static uct_component_t uct_self_component = {
     },
     .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
     .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_self_component),
-    .flags              = UCT_MD_FLAG_RKEY_PTR,
+    .flags              = UCT_COMPONENT_FLAG_RKEY_PTR,
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1091,8 +1091,8 @@ public:
                          << " rkey_ptr: " << rkey_ptr;
         EXPECT_EQ(1, get_zcopy + send_rtr + rkey_ptr);
 
-        if (has_xpmem()) {
-            /* rkey_ptr expected to be selected if xpmem is available */
+        if (has_xpmem() || is_self()) {
+            /* rkey_ptr expected to be selected if xpmem is available or self is being used */
             EXPECT_EQ(1u, rkey_ptr);
         } else if (has_get_zcopy() && !m_ucp_config->ctx.proto_enable) {
             /* if any transports supports get_zcopy, expect it to be used */

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -733,7 +733,9 @@ UCS_TEST_P(test_ucp_wireup_1sided, send_disconnect_reply2) {
     recv_b(sender().worker(), receiver().ep(), 8, 1);
 }
 
-UCS_TEST_P(test_ucp_wireup_1sided, disconnect_nb_onesided) {
+
+// Cannot disconnect only one side when using self (using the same ep)
+UCS_TEST_SKIP_COND_P(test_ucp_wireup_1sided, disconnect_nb_onesided, is_self()) {
     sender().connect(&receiver(), get_ep_params());
 
     std::vector<void*> sreqs;


### PR DESCRIPTION
## What
rkey_ptr was implemented in self but not being selected in proto v2

