### PR TITLE
RPM/SPEC: ucx-rdmacm to require ucx-ib subpackage

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -265,7 +265,7 @@ for large messages.
 
 %if %{with rdmacm}
 %package rdmacm
-Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: %{name}-ib%{?_isa} = %{version}-%{release}
 Summary: UCX RDMA connection manager support
 Group: System Environment/Libraries
 


### PR DESCRIPTION
## Why
Fix https://bugzilla.redhat.com/show_bug.cgi?id=2159661

Before this PR:
```
$ rpm -qRp <path>/ucx/build-devel/rpm-dist/x86_64/ucx-rdmacm-1.15.0-1.el7.x86_64.rpm | grep ucx
ucx(x86-64) = 1.15.0-1.el7
```

After:
```
$ rpm -qRp <path>/ucx/build-devel/rpm-dist/x86_64/ucx-rdmacm-1.15.0-1.el7.x86_64.rpm | grep ucx
ucx-ib(x86-64) = 1.15.0-1.el7
```