### PR TITLE
RPM/SPEC: Use pkgconfig for xpmem BuildRequires

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -55,7 +55,7 @@ BuildRequires: librdmacm-devel
 BuildRequires: hsa-rocr-dev
 %endif
 %if %{with xpmem}
-BuildRequires: xpmem-devel
+BuildRequires: pkgconfig(cray-xpmem)
 %endif
 %if %{with vfs}
 BuildRequires: fuse3-devel


### PR DESCRIPTION
## Why
Fix UCX RPM build on machines that have libxpmem-devel rpm from MLNX_OFED installation