### PR TITLE
UCT/IB: Introduce MD capability for non-blocking registration memory types

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -659,38 +659,41 @@ typedef enum uct_md_attr_field {
     /** Indicate memory types that the MD can register. */
     UCT_MD_ATTR_FIELD_REG_MEM_TYPES             = UCS_BIT(3),
 
+    /** Indicate memory types that are suitable for non-blocking registration. */
+    UCT_MD_ATTR_FIELD_REG_NONBLOCK_MEM_TYPES    = UCS_BIT(4),
+
     /** Indicate memory types that the MD can cache. */
-    UCT_MD_ATTR_FIELD_CACHE_MEM_TYPES           = UCS_BIT(4),
+    UCT_MD_ATTR_FIELD_CACHE_MEM_TYPES           = UCS_BIT(5),
 
     /** Indicate memory types that the MD can detect. */
-    UCT_MD_ATTR_FIELD_DETECT_MEM_TYPES          = UCS_BIT(5),
+    UCT_MD_ATTR_FIELD_DETECT_MEM_TYPES          = UCS_BIT(6),
 
     /** Indicate memory types that the MD can allocate. */
-    UCT_MD_ATTR_FIELD_ALLOC_MEM_TYPES           = UCS_BIT(6),
+    UCT_MD_ATTR_FIELD_ALLOC_MEM_TYPES           = UCS_BIT(7),
 
     /** Indicate memory types that the MD can access. */
-    UCT_MD_ATTR_FIELD_ACCESS_MEM_TYPES          = UCS_BIT(7),
+    UCT_MD_ATTR_FIELD_ACCESS_MEM_TYPES          = UCS_BIT(8),
 
     /** Indicate memory types for which the MD can return a dmabuf_fd. */
-    UCT_MD_ATTR_FIELD_DMABUF_MEM_TYPES          = UCS_BIT(8),
+    UCT_MD_ATTR_FIELD_DMABUF_MEM_TYPES          = UCS_BIT(9),
 
     /** Indicate registration cost. */
-    UCT_MD_ATTR_FIELD_REG_COST                  = UCS_BIT(9),
+    UCT_MD_ATTR_FIELD_REG_COST                  = UCS_BIT(10),
 
     /** Indicate component name. */
-    UCT_MD_ATTR_FIELD_COMPONENT_NAME            = UCS_BIT(10),
+    UCT_MD_ATTR_FIELD_COMPONENT_NAME            = UCS_BIT(11),
 
     /** Indicate size of buffer needed for packed rkey. */
-    UCT_MD_ATTR_FIELD_RKEY_PACKED_SIZE          = UCS_BIT(11),
+    UCT_MD_ATTR_FIELD_RKEY_PACKED_SIZE          = UCS_BIT(12),
 
     /** Indicate CPUs closest to the resource. */
-    UCT_MD_ATTR_FIELD_LOCAL_CPUS                = UCS_BIT(12),
+    UCT_MD_ATTR_FIELD_LOCAL_CPUS                = UCS_BIT(13),
 
     /** Indicate size of buffer needed for packed exported memory key. */
-    UCT_MD_ATTR_FIELD_EXPORTED_MKEY_PACKED_SIZE = UCS_BIT(13),
+    UCT_MD_ATTR_FIELD_EXPORTED_MKEY_PACKED_SIZE = UCS_BIT(14),
 
     /** Unique global identifier of the memory domain. */
-    UCT_MD_ATTR_FIELD_GLOBAL_ID                 = UCS_BIT(14)
+    UCT_MD_ATTR_FIELD_GLOBAL_ID                 = UCS_BIT(15)
 } uct_md_attr_field_t;
 
 
@@ -731,6 +734,11 @@ typedef struct {
      * Bitmap of memory types which the Memory Domain can be register.
      */
     uint64_t          reg_mem_types;
+
+    /**
+     * Bitmap of memory types that are suitable for non-blocking registration
+     */
+    uint64_t          reg_nonblock_mem_types;
 
     /**
      * Bitmap of memory types that can be cached for this memory domain.

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -420,6 +420,8 @@ uct_md_attr_v2_copy(uct_md_attr_v2_t *dst, const uct_md_attr_v2_t *src)
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, flags, UCT_MD_ATTR_FIELD_FLAGS);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, reg_mem_types,
                               UCT_MD_ATTR_FIELD_REG_MEM_TYPES);
+    UCT_MD_ATTR_V2_FIELD_COPY(dst, src, reg_nonblock_mem_types,
+                              UCT_MD_ATTR_FIELD_REG_NONBLOCK_MEM_TYPES);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, cache_mem_types,
                               UCT_MD_ATTR_FIELD_CACHE_MEM_TYPES);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, detect_mem_types,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -80,19 +80,20 @@ static int uct_cuda_copy_md_is_dmabuf_supported()
 static ucs_status_t
 uct_cuda_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->dmabuf_mem_types = 0;
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->dmabuf_mem_types       = 0;
     if (uct_cuda_copy_md_is_dmabuf_supported()) {
         md_attr->dmabuf_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -31,18 +31,19 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
 static ucs_status_t
 uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY |
-                                UCT_MD_FLAG_INVALIDATE;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->alloc_mem_types  = 0;
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = 0;
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->rkey_packed_size = sizeof(uct_cuda_ipc_key_t);
-    md_attr->reg_cost         = UCS_LINEAR_FUNC_ZERO;
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY |
+                                      UCT_MD_FLAG_INVALIDATE;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->alloc_mem_types        = 0;
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->detect_mem_types       = 0;
+    md_attr->dmabuf_mem_types       = 0;
+    md_attr->max_alloc              = 0;
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->rkey_packed_size       = sizeof(uct_cuda_ipc_key_t);
+    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -46,17 +46,18 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
 static ucs_status_t
 uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->alloc_mem_types  = 0;
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = 0;
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->rkey_packed_size = sizeof(uct_gdr_copy_key_t);
-    md_attr->reg_cost         = UCS_LINEAR_FUNC_ZERO;
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->alloc_mem_types        = 0;
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->detect_mem_types       = 0;
+    md_attr->dmabuf_mem_types       = 0;
+    md_attr->max_alloc              = 0;
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->rkey_packed_size       = sizeof(uct_gdr_copy_key_t);
+    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -280,6 +280,7 @@ static ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->detect_mem_types          = 0;
     md_attr->dmabuf_mem_types          = 0;
     md_attr->reg_mem_types             = md->reg_mem_types;
+    md_attr->reg_nonblock_mem_types    = md->reg_nonblock_mem_types;
     md_attr->cache_mem_types           = UCS_MASK(UCS_MEMORY_TYPE_LAST);
     md_attr->rkey_packed_size          = UCT_IB_MD_PACKED_RKEY_SIZE;
     md_attr->reg_cost                  = md->reg_cost;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -159,6 +159,7 @@ typedef struct uct_ib_md {
     int                      fork_init;
     size_t                   memh_struct_size;
     uint64_t                 reg_mem_types;
+    uint64_t                 reg_nonblock_mem_types;
     uint64_t                 cap_flags;
     char                     *name;
     /* flush_remote rkey is used as atomic_mr_id value (8-16 bits of rkey)

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -767,6 +767,8 @@ uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
         } else {
             md->super.config.odp.max_size = 1ul << 28;
         }
+
+        md->super.reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     }
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, fixed_buffer_size) &&

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -41,20 +41,21 @@ static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
 static ucs_status_t
 uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY |
-                                UCT_MD_FLAG_ALLOC;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = SIZE_MAX;
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->rkey_packed_size = sizeof(uct_rocm_copy_key_t);
-    md_attr->reg_cost         = UCS_LINEAR_FUNC_ZERO;
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY |
+                                      UCT_MD_FLAG_ALLOC;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->dmabuf_mem_types       = 0;
+    md_attr->max_alloc              = SIZE_MAX;
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->rkey_packed_size       = sizeof(uct_rocm_copy_key_t);
+    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -24,16 +24,17 @@ static ucs_config_field_t uct_rocm_ipc_md_config_table[] = {
 
 static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->rkey_packed_size = sizeof(uct_rocm_ipc_key_t);
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->alloc_mem_types  = 0;
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = 0;
-    md_attr->max_reg          = ULONG_MAX;
+    md_attr->rkey_packed_size       = sizeof(uct_rocm_ipc_key_t);
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->alloc_mem_types        = 0;
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->detect_mem_types       = 0;
+    md_attr->dmabuf_mem_types       = 0;
+    md_attr->max_alloc              = 0;
+    md_attr->max_reg                = ULONG_MAX;
 
     /* TODO: get accurate number */
     md_attr->reg_cost             = ucs_linear_func_make(9e-9, 0);

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -99,11 +99,12 @@ static ucs_status_t uct_xpmem_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
     uct_mm_md_query(md, md_attr, 0);
 
-    md_attr->flags           |= UCT_MD_FLAG_REG;
-    md_attr->reg_cost         = ucs_linear_func_make(60.0e-9, 0);
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->rkey_packed_size = sizeof(uct_xpmem_packed_rkey_t);
+    md_attr->flags                 |= UCT_MD_FLAG_REG;
+    md_attr->reg_cost               = ucs_linear_func_make(60.0e-9, 0);
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->rkey_packed_size       = sizeof(uct_xpmem_packed_rkey_t);
 
     return UCS_OK;
 }

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -216,17 +216,18 @@ ucs_status_t uct_cma_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_cma_md_t *md = ucs_derived_of(uct_md, uct_cma_md_t);
 
-    md_attr->rkey_packed_size = 0;
-    md_attr->flags            = UCT_MD_FLAG_REG | md->extra_caps;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->alloc_mem_types  = 0;
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = 0;
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->reg_cost         = ucs_linear_func_make(9e-9, 0);
+    md_attr->rkey_packed_size       = 0;
+    md_attr->flags                  = UCT_MD_FLAG_REG | md->extra_caps;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->alloc_mem_types        = 0;
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->detect_mem_types       = 0;
+    md_attr->dmabuf_mem_types       = 0;
+    md_attr->max_alloc              = 0;
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->reg_cost               = ucs_linear_func_make(9e-9, 0);
 
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -213,7 +213,6 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->max_alloc        = 0;
     md_attr->max_reg          = ULONG_MAX;
     md_attr->reg_cost         = md->reg_cost;
-
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -393,18 +393,19 @@ static uct_iface_ops_t uct_self_iface_ops = {
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->flags            = UCT_MD_FLAG_REG |
-                             UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
-    attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->alloc_mem_types  = 0;
-    attr->detect_mem_types = 0;
-    attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->dmabuf_mem_types = 0;
-    attr->max_alloc        = 0;
-    attr->max_reg          = ULONG_MAX;
-    attr->rkey_packed_size = 0;
-    attr->reg_cost         = UCS_LINEAR_FUNC_ZERO;
+    attr->flags                  = UCT_MD_FLAG_REG |
+                                   UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->alloc_mem_types        = 0;
+    attr->detect_mem_types       = 0;
+    attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->dmabuf_mem_types       = 0;
+    attr->max_alloc              = 0;
+    attr->max_reg                = ULONG_MAX;
+    attr->rkey_packed_size       = 0;
+    attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -27,18 +27,19 @@ static ucs_config_field_t uct_tcp_md_config_table[] = {
 static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->flags            = UCT_MD_FLAG_REG |
-                             UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
-    attr->max_alloc        = 0;
-    attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->alloc_mem_types  = 0;
-    attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->detect_mem_types = 0;
-    attr->dmabuf_mem_types = 0;
-    attr->max_reg          = ULONG_MAX;
-    attr->rkey_packed_size = 0;
-    attr->reg_cost         = UCS_LINEAR_FUNC_ZERO;
+    attr->flags                  = UCT_MD_FLAG_REG |
+                                   UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->max_alloc              = 0;
+    attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->alloc_mem_types        = 0;
+    attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->detect_mem_types       = 0;
+    attr->dmabuf_mem_types       = 0;
+    attr->max_reg                = ULONG_MAX;
+    attr->rkey_packed_size       = 0;
+    attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
     memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -36,18 +36,19 @@ uct_ugni_query_md_resources(uct_component_h component,
 
 static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->rkey_packed_size = 3 * sizeof(uint64_t);
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_MEMH |
-                                UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->alloc_mem_types  = 0;
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = 0;
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->reg_cost         = ucs_linear_func_make(1000.0e-9, 0.007e-9);
+    md_attr->rkey_packed_size       = 3 * sizeof(uint64_t);
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_MEMH |
+                                      UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->alloc_mem_types        = 0;
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->detect_mem_types       = 0;
+    md_attr->dmabuf_mem_types       = 0;
+    md_attr->max_alloc              = 0;
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->reg_cost               = ucs_linear_func_make(1000.0e-9, 0.007e-9);
     memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }


### PR DESCRIPTION
## What
Add `uct_md_attr_v2_t::odp_reg_mem_types` to fill the ODPable transports for each MD.

## Why ?
ODPv2 support. We are planning to introduce UCP interface that forces ODP memory registration for certain MDs and therefore we want to check availability of ODP registration.
