### PR TITLE
UCP: ODPv2 control configuration

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -494,6 +494,7 @@ static void print_md_info(uct_component_h component,
 
             PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, access);
             PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, alloc);
+            PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, reg_nonblock);
             PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, reg);
             PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, cache);
             PRINT_MD_MEM_TYPE(&strb, md_attr, mem_type, detect);

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -444,6 +444,12 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "directory.",
    ucs_offsetof(ucp_context_config_t, proto_info_dir), UCS_CONFIG_TYPE_STRING},
 
+  {"REG_NONBLOCK_MEM_TYPES", "",
+   "Perform only non-blocking memory registration for these memory types:\n"
+   "page registration may be deferred until it is accessed by the CPU or a transport.",
+   ucs_offsetof(ucp_context_config_t, reg_nb_mem_types),
+   UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
+
   {NULL}
 };
 
@@ -1507,6 +1513,11 @@ ucp_add_component_resources(ucp_context_h context, ucp_rsc_index_t cmpt_index,
             }
 
             ucs_memory_type_for_each(mem_type) {
+                if ((context->config.ext.reg_nb_mem_types & UCS_BIT(mem_type)) &&
+                    !(md_attr->reg_nonblock_mem_types & UCS_BIT(mem_type))) {
+                    continue;
+                }
+
                 if (md_attr->flags & UCT_MD_FLAG_REG) {
                     if (md_attr->reg_mem_types & UCS_BIT(mem_type)) {
                         context->reg_md_map[mem_type] |= UCS_BIT(md_index);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -162,6 +162,8 @@ typedef struct ucp_context_config {
     char                                   *select_distance_md;
     /** Directory to write protocol selection information */
     char                                   *proto_info_dir;
+    /** Memory types that perform non-blocking registration by default */
+    uint64_t                               reg_nb_mem_types;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -393,6 +393,10 @@ static ucs_status_t ucp_memh_register(ucp_context_h context, ucp_mem_h memh,
     err_level = (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DIAG :
                                                             UCS_LOG_LEVEL_ERROR;
 
+    if (context->config.ext.reg_nb_mem_types & UCS_BIT(mem_type)) {
+        uct_flags |= UCT_MD_MEM_FLAG_NONBLOCK;
+    }
+
     reg_params.flags         = uct_flags;
     reg_params.dmabuf_fd     = UCT_DMABUF_FD_INVALID;
     reg_params.dmabuf_offset = 0;
@@ -441,10 +445,12 @@ static ucs_status_t ucp_memh_register(ucp_context_h context, ucp_mem_h memh,
             goto out_close_dmabuf_fd;
         }
 
-        ucs_trace("register address %p length %zu dmabuf-fd %d on md[%d]=%s %p",
+        ucs_trace("register address %p length %zu dmabuf-fd %d flags %ld "
+                  "on md[%d]=%s %p",
                   address, length,
                   (dmabuf_md_map & UCS_BIT(md_index)) ? reg_params.dmabuf_fd :
                                                         UCT_DMABUF_FD_INVALID,
+                  reg_params.flags,
                   md_index, context->tl_mds[md_index].rsc.md_name,
                   memh->uct[md_index]);
         md_map_registered |= UCS_BIT(md_index);


### PR DESCRIPTION
## What
Add the user control that allow to force ODP registration for certain memory types.

## Why ?
At this moment it seems reasonable to force memory registration through ODP for certain memory types on some systems.
