### PR TITLE
AZP/RELEASE: Add CUDA support to Deb packages

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -69,7 +69,7 @@ jobs:
           tar -xzvf ${tarball}              # extract the sources in a subdirectory
           cd $(tar tf ${tarball} | head -1) # go to extracted tarball directory
           echo 10 > debian/compat   # https://www.debian.org/doc/manuals/maint-guide/dother.en.htmdpl#compat
-          dpkg-buildpackage -us -uc
+          dpkg-buildpackage -us -uc -Pcuda
           cd ..                             # Move back to the working directory
           find . -name '*.deb'
           find . -name '*.deb' -exec cp {} "${AZ_ARTIFACT_NAME}" \;


### PR DESCRIPTION

## What
Statically add cuda var to dpkg-buildpackage command, so cuda will be added to DEB_BUILD_PROFILES env var.
(Porting https://github.com/openucx/ucx/pull/8862 into master.)

## Why ?
CUDA support should always be added to the release package.

