### PR TITLE
UCP/CORE: refine get ep_init_flags

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -854,8 +854,7 @@ static ucs_status_t ucp_ep_create_to_sock_addr(ucp_worker_h worker,
 
     /* allocate endpoint */
     ucs_sockaddr_str(params->sockaddr.addr, peer_name, sizeof(peer_name));
-    ep_init_flags = ucp_ep_init_flags(worker, params) |
-                    ucp_cm_ep_init_flags(params);
+    ep_init_flags = ucp_ep_init_flags(worker, params);
 
     status = ucp_ep_create_base(worker, ep_init_flags, peer_name,
                                 "from api call", &ep);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1772,6 +1772,19 @@ ucp_ep_params_err_handling_mode(const ucp_ep_params_t *params)
            params->err_mode : UCP_ERR_HANDLING_MODE_NONE;
 }
 
+static unsigned
+ucp_cm_ep_init_flags(const ucp_ep_params_t *params)
+{
+    if (params->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR) {
+        return UCP_EP_INIT_CM_WIREUP_CLIENT | UCP_EP_INIT_CM_PHASE;
+    }
+    if (params->field_mask & UCP_EP_PARAM_FIELD_CONN_REQUEST) {
+        return UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
+    }
+
+    return 0;
+}
+
 unsigned ucp_ep_init_flags(const ucp_worker_h worker,
                            const ucp_ep_params_t *params)
 {

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -40,19 +40,6 @@
     } while (0)
 
 
-unsigned
-ucp_cm_ep_init_flags(const ucp_ep_params_t *params)
-{
-    if (params->field_mask & UCP_EP_PARAM_FIELD_SOCK_ADDR) {
-        return UCP_EP_INIT_CM_WIREUP_CLIENT | UCP_EP_INIT_CM_PHASE;
-    }
-    if (params->field_mask & UCP_EP_PARAM_FIELD_CONN_REQUEST) {
-        return UCP_EP_INIT_CM_WIREUP_SERVER | UCP_EP_INIT_CM_PHASE;
-    }
-
-    return 0;
-}
-
 int ucp_ep_init_flags_has_cm(unsigned ep_init_flags)
 {
     return !!(ep_init_flags & (UCP_EP_INIT_CM_WIREUP_CLIENT |

--- a/src/ucp/wireup/wireup_cm.h
+++ b/src/ucp/wireup/wireup_cm.h
@@ -20,8 +20,6 @@ typedef struct ucp_cm_client_connect_progress_arg {
 } ucp_cm_client_connect_progress_arg_t;
 
 
-unsigned ucp_cm_ep_init_flags(const ucp_ep_params_t *params);
-
 int ucp_ep_init_flags_has_cm(unsigned ep_init_flags);
 
 unsigned ucp_cm_client_try_next_cm_progress(void *arg);


### PR DESCRIPTION
ucp_cm_ep_init_flags is called in ucp_ep_init_flags.

Signed-off-by: Liu, Changcheng <jerrliu@nvidia.com>
