### PR TITLE
UCP/EP: Fix rendezvous threshold for multi-path

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1927,8 +1927,9 @@ static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,
                                               ucp_ep_thresh_params_t *params,
                                               int eager)
 {
-    ucp_context_h context = worker->context;
-    ucp_md_map_t md_map   = 0;
+    ucp_context_h context                = worker->context;
+    uint8_t num_paths[UCP_MAX_RESOURCES] = {};
+    ucp_md_map_t md_map                  = 0;
     ucp_lane_index_t lane;
     ucp_rsc_index_t rsc_index;
     ucp_md_index_t md_index;
@@ -1941,6 +1942,11 @@ static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,
     int i;
 
     memset(params, 0, sizeof(*params));
+
+    for (i = 0; (i < UCP_MAX_LANES) && (lanes[i] != UCP_NULL_LANE); i++) {
+        rsc_index = config->key.lanes[lanes[i]].rsc_index;
+        ++num_paths[rsc_index];
+    }
 
     for (i = 0; (i < UCP_MAX_LANES) && (lanes[i] != UCP_NULL_LANE); i++) {
         lane      = lanes[i];
@@ -1964,7 +1970,9 @@ static ucs_status_t ucp_ep_config_calc_params(ucp_worker_h worker,
             }
         }
 
-        bw = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth);
+        bw = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth) /
+             num_paths[rsc_index];
+
         if (eager && (iface_attr->cap.am.max_bcopy > 0)) {
             /* Eager protocol has overhead for each fragment */
             perf_attr.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |


### PR DESCRIPTION
## Why
Fix performance degradation due to using 2 paths on NDR400 by default

## How
Divide the estimated bandwidth of each lane by the number of paths on the resource.

This fix would be ported to v1.14.x branch.