### PR TITLE
UCP/WORKER: convert EP configs storage to dynamic array

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1904,7 +1904,8 @@ void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
                         ucs_string_buffer_t *strb)
 {
     ucp_context_h context          = worker->context;
-    const ucp_ep_config_key_t *key = &worker->ep_config[cfg_index].key;
+    const ucp_ep_config_key_t *key = &ucs_array_elem(&worker->ep_config,
+                                                     cfg_index).key;
 
     if (!ucs_string_is_empty(context->name)) {
         ucs_string_buffer_appendf(strb, "%s ", context->name);

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -20,7 +20,7 @@
 static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
 {
     ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
-    return &ep->worker->ep_config[ep->cfg_index];
+    return &ucs_array_elem(&ep->worker->ep_config, ep->cfg_index);
 }
 
 static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_fast_lane(ucp_ep_h ep,

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -53,7 +53,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_ep_rkey_unpack_reachable(ucp_ep_h ep, const void *buffer, size_t length,
                              ucp_rkey_h *rkey_p)
 {
-    ucp_ep_config_t *config = &ep->worker->ep_config[ep->cfg_index];
+    ucp_ep_config_t *config = &ucs_array_elem(&ep->worker->ep_config,
+                                              ep->cfg_index);
     return ucp_ep_rkey_unpack_internal(ep, buffer, length,
                                        config->key.reachable_md_map, 0, rkey_p);
 }

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -57,7 +57,7 @@ UCP_UINT_TYPE(UCP_MAX_SYS_DEVICES)   ucp_sys_dev_map_t;
 
 /* Worker configuration index for endpoint and rkey */
 typedef uint8_t                      ucp_worker_cfg_index_t;
-#define UCP_WORKER_MAX_EP_CONFIG     64
+#define UCP_WORKER_MAX_EP_CONFIG     UINT8_MAX
 #define UCP_WORKER_MAX_RKEY_CONFIG   128
 #define UCP_WORKER_CFG_INDEX_NULL    UINT8_MAX
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1684,7 +1684,8 @@ static void ucp_worker_add_feature_rsc(ucp_context_h context,
 static void
 ucp_worker_print_used_tls(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index)
 {
-    const ucp_ep_config_key_t *key = &worker->ep_config[cfg_index].key;
+    const ucp_ep_config_key_t *key = &ucs_array_elem(&worker->ep_config,
+                                                     cfg_index).key;
     ucp_context_h context          = worker->context;
     UCS_STRING_BUFFER_ONSTACK(strb, 256);
     ucp_lane_map_t tag_lanes_map    = 0;
@@ -1967,28 +1968,31 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
                        "empty endpoint configurations are not allowed");
 
     /* Search for the given key in the ep_config array */
-    for (ep_cfg_index = 0; ep_cfg_index < worker->ep_config_count;
-         ++ep_cfg_index) {
-        if (ucp_ep_config_is_equal(&worker->ep_config[ep_cfg_index].key, key)) {
+    ucs_array_for_each(ep_config, &worker->ep_config) {
+        if (ucp_ep_config_is_equal(&ep_config->key, key)) {
+            ep_cfg_index = ep_config - worker->ep_config.buffer;
             goto out;
         }
     }
 
-    if (worker->ep_config_count >= UCP_WORKER_MAX_EP_CONFIG) {
+    /* Create new configuration */
+    ucs_array_append(ep_config_arr, &worker->ep_config,
+                     return UCS_ERR_NO_MEMORY);
+    if (ucs_array_length(&worker->ep_config) >= UCP_WORKER_MAX_EP_CONFIG) {
+        ucs_array_pop_back(&worker->ep_config);
         ucs_error("too many ep configurations: %d (max: %d)",
-                  worker->ep_config_count, UCP_WORKER_MAX_EP_CONFIG);
+                  ucs_array_length(&worker->ep_config),
+                  UCP_WORKER_MAX_EP_CONFIG);
         return UCS_ERR_EXCEEDS_LIMIT;
     }
 
-    /* Create new configuration */
-    ep_cfg_index = worker->ep_config_count;
-    ep_config    = &worker->ep_config[ep_cfg_index];
-    status       = ucp_ep_config_init(worker, ep_config, key);
+    ep_config = ucs_array_last(&worker->ep_config);
+    status    = ucp_ep_config_init(worker, ep_config, key);
     if (status != UCS_OK) {
         return status;
     }
 
-    ++worker->ep_config_count;
+    ep_cfg_index = ucs_array_length(&worker->ep_config) - 1;
 
     if (ep_init_flags & UCP_EP_INIT_FLAG_INTERNAL) {
         /* Do not initialize short protocol thresholds for internal endpoints,
@@ -2032,7 +2036,8 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
                            const ucs_sys_dev_distance_t *lanes_distance,
                            ucp_worker_cfg_index_t *cfg_index_p)
 {
-    const ucp_ep_config_t *ep_config = &worker->ep_config[key->ep_cfg_index];
+    const ucp_ep_config_t *ep_config = &ucs_array_elem(&worker->ep_config,
+                                                       key->ep_cfg_index);
     ucp_worker_cfg_index_t rkey_cfg_index;
     ucp_rkey_config_t *rkey_config;
     ucp_lane_index_t lane;
@@ -2123,15 +2128,17 @@ static void ucp_worker_keepalive_reset(ucp_worker_h worker)
 
 static void ucp_worker_destroy_configs(ucp_worker_h worker)
 {
-    unsigned i;
+    ucp_ep_config_t *ep_config;
+    ucp_rkey_config_t *rkey_config;
 
-    for (i = 0; i < worker->ep_config_count; ++i) {
-        ucp_ep_config_cleanup(worker, &worker->ep_config[i]);
+    ucs_array_for_each(ep_config, &worker->ep_config) {
+        ucp_ep_config_cleanup(worker, ep_config);
     }
-    worker->ep_config_count = 0;
+    ucs_array_cleanup_dynamic(&worker->ep_config);
 
-    for (i = 0; i < worker->rkey_config_count; ++i) {
-        ucp_proto_select_cleanup(&worker->rkey_config[i].proto_select);
+    ucs_carray_for_each(rkey_config, worker->rkey_config,
+                        worker->rkey_config_count) {
+        ucp_proto_select_cleanup(&rkey_config->proto_select);
     }
     worker->rkey_config_count = 0;
 }
@@ -2242,7 +2249,6 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->flush_ops_count      = 0;
     worker->inprogress           = 0;
     worker->rkey_config_count    = 0;
-    worker->ep_config_count      = 0;
     worker->num_active_ifaces    = 0;
     worker->num_ifaces           = 0;
     worker->am_message_id        = ucs_generate_uuid(0);
@@ -2324,6 +2330,8 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     if (status != UCS_OK) {
         goto err_destroy_ep_map;
     }
+
+    ucs_array_init_dynamic(&worker->ep_config);
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&worker->stats, &ucp_worker_stats_class,

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -23,6 +23,8 @@
 #include <ucs/datastruct/ptr_map.h>
 #include <ucs/arch/bitops.h>
 
+#include <ucs/datastruct/array.inl>
+
 
 /* The size of the private buffer in UCT descriptor headroom, which UCP may
  * use for its own needs. This size does not include ucp_recv_desc_t length,
@@ -221,6 +223,9 @@ typedef struct ucp_worker_mpool_key {
 KHASH_TYPE(ucp_worker_mpool_hash, ucp_worker_mpool_key_t, ucs_mpool_t);
 typedef khash_t(ucp_worker_mpool_hash) ucp_worker_mpool_hash_t;
 
+/* EP configurations storage */
+UCS_ARRAY_DECLARE_TYPE(ep_config_arr, unsigned, ucp_ep_config_t);
+
 /**
  * UCP worker iface, which encapsulates UCT iface, its attributes and
  * some auxiliary info needed for tag matching offloads.
@@ -324,8 +329,7 @@ typedef struct ucp_worker {
     UCS_PTR_MAP_T(request)           request_map;         /* UCP requests key to
                                                              ptr mapping */
 
-    unsigned                         ep_config_count;     /* Current number of ep configurations */
-    ucp_ep_config_t                  ep_config[UCP_WORKER_MAX_EP_CONFIG];
+    ucs_array_t(ep_config_arr)       ep_config;           /* EP configurations storage */
 
     unsigned                         rkey_config_count;   /* Current number of rkey configurations */
     ucp_rkey_config_t                rkey_config[UCP_WORKER_MAX_RKEY_CONFIG];

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -22,6 +22,10 @@ KHASH_IMPL(ucp_worker_rkey_config, ucp_rkey_config_key_t,
            ucp_worker_cfg_index_t, 1, ucp_rkey_config_hash_func,
            ucp_rkey_config_is_equal);
 
+/* EP configurations storage */
+UCS_ARRAY_IMPL(ep_config_arr, unsigned, ucp_ep_config_t,
+               static UCS_F_ALWAYS_INLINE);
+
 /**
  * Resolve remote key configuration key to a remote key configuration index.
  *

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -217,7 +217,8 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     init_params.select_param   = select_param;
     init_params.ep_cfg_index   = ep_cfg_index;
     init_params.rkey_cfg_index = rkey_cfg_index;
-    init_params.ep_config_key  = &worker->ep_config[ep_cfg_index].key;
+    init_params.ep_config_key  = &ucs_array_elem(&worker->ep_config,
+                                                 ep_cfg_index).key;
 
     if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         init_params.rkey_config_key = NULL;
@@ -834,7 +835,7 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
 
     if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         *new_rkey_cfg_index = UCP_WORKER_CFG_INDEX_NULL;
-        return &worker->ep_config[ep_cfg_index].proto_select;
+        return &ucs_array_elem(&worker->ep_config, ep_cfg_index).proto_select;
     } else {
         rkey_config_key = worker->rkey_config[rkey_cfg_index].key;
 
@@ -860,7 +861,8 @@ void ucp_proto_config_query(ucp_worker_h worker,
         .priv          = proto_config->priv,
         .worker        = worker,
         .select_param  = &proto_config->select_param,
-        .ep_config_key = &worker->ep_config[proto_config->ep_cfg_index].key,
+        .ep_config_key = &ucs_array_elem(&worker->ep_config,
+                                         proto_config->ep_cfg_index).key,
         .msg_length    = msg_length
     };
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -105,7 +105,8 @@ ucp_proto_rndv_md_map_to_remote(const ucp_proto_rndv_ctrl_init_params_t *params,
     const ucp_ep_config_t *ep_config;
     uint64_t remote_md_map;
 
-    ep_config     = &worker->ep_config[params->super.super.ep_cfg_index];
+    ep_config     = &ucs_array_elem(&worker->ep_config,
+                                    params->super.super.ep_cfg_index);
     remote_md_map = 0;
 
     ucs_carray_for_each(lane_cfg, ep_config->key.lanes,
@@ -134,7 +135,8 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
 {
     ucp_worker_h worker                 = params->super.super.worker;
     ucp_worker_cfg_index_t ep_cfg_index = params->super.super.ep_cfg_index;
-    const ucp_ep_config_t *ep_config    = &worker->ep_config[ep_cfg_index];
+    const ucp_ep_config_t *ep_config    = &ucs_array_elem(&worker->ep_config,
+                                                          ep_cfg_index);
     ucs_sys_dev_distance_t lanes_distance[UCP_MAX_LANES];
     const ucp_proto_select_elem_t *select_elem;
     ucp_rkey_config_key_t rkey_config_key;

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -133,9 +133,11 @@ UCS_TEST_P(test_ucp_proto, dump_protocols) {
     ucp_worker_cfg_index_t ep_cfg_index   = sender().ep()->cfg_index;
     ucp_worker_cfg_index_t rkey_cfg_index = UCP_WORKER_CFG_INDEX_NULL;
 
-    auto select_elem = ucp_proto_select_lookup(
-            worker, &worker->ep_config[ep_cfg_index].proto_select, ep_cfg_index,
-            rkey_cfg_index, &select_param, 0);
+    auto proto_select = &ucs_array_elem(&worker->ep_config,
+                                        ep_cfg_index).proto_select;
+    auto select_elem  = ucp_proto_select_lookup(worker, proto_select,
+                                                ep_cfg_index, rkey_cfg_index,
+                                                &select_param, 0);
     EXPECT_NE(nullptr, select_elem);
 
     ucp_ep_print_info(sender().ep(), stdout);


### PR DESCRIPTION
## What
convert EP configurations storage to dynamic array

## Why ?
in some cases 64 EPs are not enough

## How ?
convert storage from static to dynamic array
