### PR TITLE
UCT/IB: Fix explicit ODP initialization

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -102,10 +102,6 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "Force prefetch of memory regions created with ODP.\n",
      ucs_offsetof(uct_ib_md_config_t, ext.odp.prefetch), UCS_CONFIG_TYPE_BOOL},
 
-    {"ODP_MAX_SIZE", "auto",
-     "Maximal memory region size to enable ODP for. 0 - disable.\n",
-     ucs_offsetof(uct_ib_md_config_t, ext.odp.max_size), UCS_CONFIG_TYPE_MEMUNITS},
-
     {"DEVICE_SPECS", "",
      "Array of custom device specification. Each element is a string of the following format:\n"
      "  <vendor-id>:<device-id>[:name[:<flags>[:<priority>]]]\n"
@@ -623,7 +619,7 @@ static uint64_t uct_ib_md_access_flags(uct_ib_md_t *md, unsigned flags,
     uint64_t access_flags = UCT_IB_MEM_ACCESS_FLAGS;
 
     if ((flags & UCT_MD_MEM_FLAG_NONBLOCK) && (length > 0) &&
-        (length <= md->config.odp.max_size)) {
+        (md->reg_nonblock_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
         access_flags |= IBV_ACCESS_ON_DEMAND;
     }
 
@@ -1606,10 +1602,6 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_NEED_MEMH |
                           UCT_MD_FLAG_NEED_RKEY |
                           UCT_MD_FLAG_ADVISE;
-
-    if (md->config.odp.max_size == UCS_MEMUNITS_AUTO) {
-        md->config.odp.max_size = 0;
-    }
 
     uct_ib_md_parse_relaxed_order(md, md_config);
     uct_ib_md_init_memh_size(md, memh_base_size, mr_size);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -92,7 +92,6 @@ typedef struct uct_ib_md_ext_config {
     struct {
         int                  prefetch;     /**< Auto-prefetch non-blocking memory
                                                 registrations / allocations */
-        size_t               max_size;     /**< Maximal memory region size for ODP */
     } odp;
 
     unsigned long            gid_index;    /**< IB GID index to use */

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -761,20 +761,12 @@ uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
         goto no_odp;
     }
 
-    if (md->super.config.odp.max_size == UCS_MEMUNITS_AUTO) {
-        if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, umr_extended_translation_offset)) {
-            md->super.config.odp.max_size = 1ul << 55;
-        } else {
-            md->super.config.odp.max_size = 1ul << 28;
-        }
-
-        md->super.reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    if (!UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, umr_extended_translation_offset)) {
+        goto no_odp;
     }
 
-    return UCS_OK;
-
+    md->super.reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
 no_odp:
-    md->super.config.odp.max_size = 0;
     return UCS_OK;
 }
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -197,8 +197,9 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
 
-    md_attr->flags         = UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types = 0;
+    md_attr->flags                  = UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types          = 0;
+    md_attr->reg_nonblock_mem_types = 0;
     if (uct_knem_md_check_mem_reg(uct_md)) {
         md_attr->flags         |= UCT_MD_FLAG_REG;
         md_attr->reg_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_HOST);

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -469,6 +469,27 @@ bool is_interface_usable(struct ifaddrs *ifa)
            !netif_has_sysfs_file(ifa->ifa_name, "wireless");
 }
 
+
+ssize_t get_proc_self_status_field(const std::string &parameter)
+{
+    const std::string path("/proc/self/status");
+    std::ifstream proc_stats(path);
+    std::string line, name;
+    ssize_t value;
+
+    while (std::getline(proc_stats, line)) {
+        if (!(std::istringstream(line) >> name >> value)) {
+            continue;
+        }
+        if (name == (parameter + ":")) {
+            return value;
+        }
+    }
+
+    UCS_TEST_MESSAGE << path << " does not contain " << parameter << " value";
+    return -1;
+}
+
 static std::vector<std::string> read_dir(const std::string& path)
 {
     std::vector<std::string> result;

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -22,6 +22,7 @@
 
 #include <errno.h>
 #include <iostream>
+#include <fstream>
 #include <stdexcept>
 #include <sstream>
 #include <vector>
@@ -315,6 +316,10 @@ bool is_inet_addr(const struct sockaddr* ifa_addr);
  */
 bool is_interface_usable(struct ifaddrs *ifa);
 
+/**
+ * Return the value of the requested /proc/self/status parameter
+ */
+ssize_t get_proc_self_status_field(const std::string &parameter);
 
 /**
  * Return the name of the given network device if it is supported by rdmacm.

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -52,6 +52,9 @@ protected:
                          uct_mem_h *memh_p);
     void test_reg_mem(unsigned access_mask, unsigned invalidate_flag);
 
+    void test_reg_advise(size_t size, size_t advise_size,
+                         size_t advice_offset, bool check_non_blocking = false);
+
     uct_md_h md() const {
         return m_md;
     }


### PR DESCRIPTION
## What
Fix the bug that causes absence of ODP registration even if `UCT_MD_MEM_FLAG_NONBLOCK` was passed to `uct_md_mem_reg`

## How ?
The current `uct_ib_mlx5_devx_md_open` flow that causes the issue:
1. `uct_ib_mlx5_devx_check_odp()` set `md->super.config.odp.max_size` to the certain value (see [here](https://github.com/openucx/ucx/compare/master...ivankochin:ucx:topic/uct/fix-explicit-odp-initialization?expand=1#diff-716148bcb0d4d7e0ef6be8f54003f7cc322baaca473baf9a442182c42830b7f8L768))
2. `uct_ib_md_open_common()` overwrites `md->super.config` by `md_config->ext` that contain the actual config values and therefore always set `md->config.odp.max_size` to 0. (see [here](https://github.com/openucx/ucx/compare/master...ivankochin:ucx:topic/uct/fix-explicit-odp-initialization?expand=1#diff-975534026ea952036f6617e7a106314af680d3ca405d777ab04e0af2b427499aR1832))

Solution:
1. Remove odp_max_size at all
2. Set corresponding property isntead of that