### PR TITLE
AZP/RELEASE: Publish CUDA DEBs - v1.14.x

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -5,7 +5,7 @@ jobs:
       ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
         POSTFIX: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
       ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-        POSTFIX: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/', '') }}
+        POSTFIX: ucx-${{ replace(variables['Build.SourceBranch'], 'refs/tags/v', '') }}
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         POSTFIX: ucx-pr$(System.PullRequest.PullRequestNumber)
 
@@ -24,16 +24,16 @@ jobs:
           artifact_name: $(POSTFIX)-centos8-mofed5-cuda11.tar.bz2
         ubuntu16_cuda11:
           build_container: ubuntu16_cuda11
-          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5-cuda11.deb
+          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5-cuda11.tar.bz2
         ubuntu18_cuda11:
           build_container: ubuntu18_cuda11
-          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5-cuda11.deb
+          artifact_name: $(POSTFIX)-ubuntu18.04-mofed5-cuda11.tar.bz2
         ubuntu20_cuda11:
           build_container: ubuntu20_cuda11
-          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5-cuda11.deb
+          artifact_name: $(POSTFIX)-ubuntu20.04-mofed5-cuda11.tar.bz2
         ubuntu22_cuda11:
           build_container: ubuntu22_cuda11
-          artifact_name: $(POSTFIX)-ubuntu22.04-mofed5-cuda11.deb
+          artifact_name: $(POSTFIX)-ubuntu22.04-mofed5-cuda11.tar.bz2
 
     container: $[ variables['build_container'] ]
 
@@ -72,8 +72,12 @@ jobs:
           dpkg-buildpackage -us -uc -Pcuda
           cd ..                             # Move back to the working directory
           find . -name '*.deb'
-          find . -name '*.deb' -exec cp {} "${AZ_ARTIFACT_NAME}" \;
-          dpkg-deb -I "${AZ_ARTIFACT_NAME}"
+          VER="${POSTFIX#ucx-}"   # Remove 'ucx' prefix from the POSTFIX string
+          # Rename DEB files
+          find . -name "ucx*.deb" -exec bash -c 'mv "$1" "${1%%_*}-'"${VER}"'.deb"' _ {} \;
+          dpkg-deb -I "ucx-${VER}.deb"
+          tar -cjf "${AZ_ARTIFACT_NAME}" *.deb  # Package all DEBs
+          tar -tjf "${AZ_ARTIFACT_NAME}"
         displayName: Build DEB package
         condition: and(succeeded(), contains(variables['artifact_name'], 'ubuntu'))
         env:


### PR DESCRIPTION
## What
Publish CUDA DEB files along with UCX DEB upon release. 

## Why ?
Since v1.14.0, the cuda packages will be a separate DEB file.

