### PR TITLE
UCT/IB/DC: default/random/explicit set RoCE lag DCT port affinity

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -347,6 +347,38 @@ int ucs_config_sprintf_enum(char *buf, size_t max,
     return 1;
 }
 
+int ucs_config_sscanf_uint_enum(const char *buf, void *dest, const void *arg)
+{
+    int i;
+
+    i = ucs_string_find_in_list(buf, (const char**)arg, 0);
+    if (i >= 0) {
+        *(unsigned*)dest = UCS_CONFIG_UINT_ENUM_INDEX(i);
+        return 1;
+    }
+
+    return sscanf(buf, "%u", (unsigned*)dest);
+}
+
+int ucs_config_sprintf_uint_enum(char *buf, size_t max,
+                                 const void *src, const void *arg)
+{
+   char* const *table = arg;
+   unsigned value, table_size;
+
+   for (table_size = 0; table[table_size] != NULL; table_size++) {
+       continue;
+   }
+
+   value = *(unsigned*)src;
+   if (UCS_CONFIG_UINT_ENUM_INDEX(table_size) < value) {
+        strncpy(buf, table[UCS_CONFIG_UINT_ENUM_INDEX(value)], max);
+        return 1;
+   }
+
+   return snprintf(buf, max, "%u", value);
+}
+
 static void __print_table_values(char * const *table, char *buf, size_t max)
 {
     char *ptr = buf, *end = buf + max;
@@ -364,6 +396,16 @@ static void __print_table_values(char * const *table, char *buf, size_t max)
 void ucs_config_help_enum(char *buf, size_t max, const void *arg)
 {
     __print_table_values(arg, buf, max);
+}
+
+void ucs_config_help_uint_enum(char *buf, size_t max, const void *arg)
+{
+    size_t len;
+
+    snprintf(buf, max, "a numerical value, or:");
+
+    len = strlen(buf);
+    __print_table_values(arg, buf + len, max - len);
 }
 
 ucs_status_t ucs_config_clone_log_comp(const void *src, void *dst, const void *arg)

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -153,6 +153,8 @@ typedef struct ucs_config_bw_spec {
 
 extern ucs_list_link_t ucs_config_global_list;
 
+#define UCS_CONFIG_UINT_ENUM_INDEX(_value) (UINT_MAX - (_value))
+
 /*
  * Parsing and printing different data types
  */
@@ -199,6 +201,10 @@ int ucs_config_sprintf_on_off_auto(char *buf, size_t max, const void *src, const
 int ucs_config_sscanf_enum(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_enum(char *buf, size_t max, const void *src, const void *arg);
 void ucs_config_help_enum(char *buf, size_t max, const void *arg);
+
+int ucs_config_sscanf_uint_enum(const char *buf, void *dest, const void *arg);
+int ucs_config_sprintf_uint_enum(char *buf, size_t max, const void *src, const void *arg);
+void ucs_config_help_uint_enum(char *buf, size_t max, const void *arg);
 
 int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_bitmap(char *buf, size_t max, const void *src, const void *arg);
@@ -325,6 +331,10 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_ENUM(t)    {ucs_config_sscanf_enum,      ucs_config_sprintf_enum, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
                                     ucs_config_help_enum,        t}
+
+#define UCS_CONFIG_TYPE_UINT_ENUM(t) {ucs_config_sscanf_uint_enum, ucs_config_sprintf_uint_enum, \
+                                      ucs_config_clone_uint,       ucs_config_release_nop, \
+                                      ucs_config_help_uint_enum,   t}
 
 #define UCS_CONFIG_TYPE_BITMAP(t)  {ucs_config_sscanf_bitmap,    ucs_config_sprintf_bitmap, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -161,6 +161,19 @@ typedef enum {
 } uct_dc_tx_policy_t;
 
 
+/**
+ * dct port affinity policies for RoCE LAG device
+ * - default: use the first physical port number for affinity
+ * - random : use random slave port number for affinity
+ * - [1, lag_level]: use given value as the slave port number for affinity
+ */
+typedef enum {
+    UCT_DC_MLX5_DCT_AFFINITY_DEFAULT,
+    UCT_DC_MLX5_DCT_AFFINITY_RANDOM,
+    UCT_DC_MLX5_DCT_AFFINITY_LAST
+} uct_dc_mlx5_dct_affinity_t;
+
+
 typedef struct uct_dc_mlx5_iface_config {
     uct_rc_iface_common_config_t        super;
     uct_rc_mlx5_iface_common_config_t   rc_mlx5_common;
@@ -171,6 +184,7 @@ typedef struct uct_dc_mlx5_iface_config {
     ucs_ternary_auto_value_t            dci_full_handshake;
     ucs_ternary_auto_value_t            dci_ka_full_handshake;
     ucs_ternary_auto_value_t            dct_full_handshake;
+    unsigned                            dct_affinity;
     unsigned                            quota;
     unsigned                            rand_seed;
     ucs_time_t                          fc_hard_req_timeout;
@@ -312,6 +326,8 @@ struct uct_dc_mlx5_iface {
 
     struct {
         uct_ib_mlx5_qp_t          dct;
+
+        uint8_t                   port_affinity;
     } rx;
 
     uint8_t                       version_flag;

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -50,7 +50,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
     if (!uct_ib_iface_is_roce(&iface->super.super.super)) {
         UCT_IB_MLX5DV_SET(dctc, dctc, pkey_index, ib_iface->pkey_index);
     }
-    UCT_IB_MLX5DV_SET(dctc, dctc, port, ib_iface->config.port_num);
+    UCT_IB_MLX5DV_SET(dctc, dctc, port, iface->rx.port_affinity);
     UCT_IB_MLX5DV_SET(dctc, dctc, min_rnr_nak,
                       iface->super.super.config.min_rnr_timer);
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1061,9 +1061,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     }
 
     status = uct_ib_mlx5_devx_query_lag(md, &lag_state);
-    if (status != UCS_OK) {
-        dev->lag_level = 0;
-    } else if (lag_state == 0) {
+    if ((status != UCS_OK) || (lag_state == 0)) {
         dev->lag_level = 1;
     } else {
         dev->lag_level = UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, num_lag_ports);


### PR DESCRIPTION
## What
add configuration to set RoCE lag dct port for response under queue affinity mode

## Why ?
On the device that has no hash lag function, for RDMA read operation, the target side return data traffic from the dct affiliated port to the initiator side. Without this option, the dct affiliated port is always the logic port number.

## How ?
Add ```UCX_DC_MLX5_DCT_PORT_AFFINITY``` to config the RoCE lag dct port affinity.
1) ```default```, use the default logic port number. This is default behavior.
2) ```random```, use ```random``` function to select the affinity.
3) ```other value```, use ```configured value``` to set the affinity.
