### PR TITLE
UCS/TOPO: perf estimate to identify remote dev using remote guid

### DIFF
--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -53,8 +53,11 @@ struct ucp_rkey_config_key {
     /* Endpoint configuration index */
     ucp_worker_cfg_index_t ep_cfg_index;
 
-    /* Remove system device id */
+    /* Remote system device id */
     ucs_sys_device_t       sys_dev;
+
+    /* Remote system device guid */
+    ucs_sys_device_guid_t  guid;
 
     /* Remote memory type */
     ucs_memory_type_t      mem_type;

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -10,6 +10,7 @@
 #include "ucp_rkey.h"
 #include "ucp_worker.h"
 #include "ucp_ep.h"
+#include <ucs/sys/topo/base/topo.h>
 
 
 static UCS_F_ALWAYS_INLINE khint_t
@@ -18,7 +19,7 @@ ucp_rkey_config_hash_func(ucp_rkey_config_key_t rkey_config_key)
     return (khint_t)rkey_config_key.md_map ^
            (rkey_config_key.ep_cfg_index << 8) ^
            (rkey_config_key.sys_dev << 16) ^
-           (rkey_config_key.mem_type << 24);
+           (rkey_config_key.mem_type << 24); /* ignore guid for hash fxn */
 }
 
 static UCS_F_ALWAYS_INLINE int
@@ -28,7 +29,9 @@ ucp_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
     return (rkey_config_key1.md_map == rkey_config_key2.md_map) &&
            (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
            (rkey_config_key1.sys_dev == rkey_config_key2.sys_dev) &&
-           (rkey_config_key1.mem_type == rkey_config_key2.mem_type);
+           (rkey_config_key1.mem_type == rkey_config_key2.mem_type) &&
+           ucs_topo_sys_device_guid_is_equal(rkey_config_key1.guid,
+                                             rkey_config_key2.guid);
 }
 
 static UCS_F_ALWAYS_INLINE ucp_rkey_config_t *

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -11,6 +11,7 @@
 #include <ucs/sys/topo/base/topo.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/uid.h>
 
 #include <ucs/config/global_opts.h>
 #include <ucs/datastruct/khash.h>
@@ -189,6 +190,48 @@ ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
 
     *bus_id = ucs_topo_global_ctx.devices[sys_dev].bus_id;
     return UCS_OK;
+}
+
+ucs_status_t ucs_topo_get_device_guid(ucs_sys_device_t sys_dev,
+                                      ucs_sys_device_guid_t *guid)
+{
+    ucs_status_t status;
+
+    status = ucs_topo_get_device_bus_id(sys_dev, &guid->bus_id);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    guid->machine_guid = ucs_get_system_id();
+
+    return UCS_OK;
+}
+
+ucs_status_t ucs_topo_get_unknown_device_guid(ucs_sys_device_guid_t *guid)
+{
+    guid->bus_id.domain   = UINT16_MAX;
+    guid->bus_id.bus      = UINT8_MAX;
+    guid->bus_id.slot     = UINT8_MAX;
+    guid->bus_id.function = UINT8_MAX;
+    guid->machine_guid    = ucs_get_system_id();
+
+    return UCS_OK;
+}
+
+unsigned ucs_topo_sys_bus_id_is_equal(ucs_sys_bus_id_t bus_id1,
+                                      ucs_sys_bus_id_t bus_id2)
+{
+    return (bus_id1.domain == bus_id2.domain) &&
+           (bus_id1.bus == bus_id2.bus) &&
+           (bus_id1.slot == bus_id2.slot) &&
+           (bus_id1.function == bus_id2.function);
+}
+
+unsigned ucs_topo_sys_device_guid_is_equal(ucs_sys_device_guid_t guid1,
+                                           ucs_sys_device_guid_t guid2)
+{
+    return (guid1.machine_guid == guid2.machine_guid) &&
+           ucs_topo_sys_bus_id_is_equal(guid1.bus_id, guid2.bus_id);
 }
 
 static ucs_status_t

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -44,6 +44,16 @@ typedef struct ucs_sys_bus_id {
 typedef uint8_t ucs_sys_device_t;
 
 
+/**
+ * @ingroup UCS_RESOURCE
+ * Globally Unique System Device Identifier
+ */
+typedef struct ucs_sys_device_guid {
+    ucs_sys_bus_id_t bus_id;
+    uint64_t         machine_guid;
+} ucs_sys_device_guid_t;
+
+
 /*
  * Captures the estimated latency and bandwidth between two system devices
  * referred by ucs_sys_device_t handle.
@@ -109,6 +119,28 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
                                         ucs_sys_bus_id_t *bus_id);
 
+
+/**
+ * Find guid of the given system device.
+ *
+ * @param [in]  sys_dev system device index.
+ * @param [out] pointer to guid to be populated.
+ *
+ * @return UCS_OK or error in case system device or its guid cannot be found.
+ */
+ucs_status_t ucs_topo_get_device_guid(ucs_sys_device_t sys_dev,
+                                      ucs_sys_device_guid_t *guid);
+
+
+/**
+ * Find guid for system device set to UCS_SYS_DEVICE_ID_UNKNOWN .
+ *
+ * @param [out] pointer to guid to be populated.
+ *
+ * @return UCS_OK with machine_guid field populated with local machine
+ * information.
+ */
+ucs_status_t ucs_topo_get_unknown_device_guid(ucs_sys_device_guid_t *guid);
 
 /**
  * Find the distance between two system devices (in terms of latency,
@@ -221,6 +253,29 @@ const char *ucs_topo_sys_device_get_name(ucs_sys_device_t sys_dev);
  */
 unsigned ucs_topo_num_devices();
 
+
+/**
+ * Check if bus_id of two system devices are identical.
+ *
+ * @param [in] bus_id1 bus_id of the first device.
+ * @param [in] bus_id2 bus_id of the second device.
+ *
+ * @return 1 if the bus_id of the two devices match.
+ */
+unsigned ucs_topo_sys_bus_id_is_equal(ucs_sys_bus_id_t bus_id1,
+                                      ucs_sys_bus_id_t bus_id2);
+
+
+/**
+ * Check if guid of two system devices are identical.
+ *
+ * @param [in] guid1 System device guid of the first device.
+ * @param [in] guid2 System device guid of the second device.
+ *
+ * @return 1 if the guid of the two devices match.
+ */
+unsigned ucs_topo_sys_device_guid_is_equal(ucs_sys_device_guid_t guid1,
+                                           ucs_sys_device_guid_t guid2);
 
 /**
  * Print a map indicating the topology information between system devices

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -93,7 +93,10 @@ enum uct_perf_attr_field {
     UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(9),
 
     /** Enable @ref uct_perf_attr_t::max_inflight_eps */
-    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10)
+    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10),
+
+    /** Enable @ref uct_perf_attr_t::remote_guid */
+    UCT_PERF_ATTR_FIELD_REMOTE_GUID        = UCS_BIT(11)
 };
 
 
@@ -109,47 +112,47 @@ typedef struct {
      * @ref uct_perf_attr_field. Fields not specified by this mask will be
      * ignored. This field must be initialized by the caller.
      */
-    uint64_t            field_mask;
+    uint64_t              field_mask;
 
     /**
      * Operation to report performance for.
      * This field must be initialized by the caller.
      */
-    uct_ep_operation_t  operation;
+    uct_ep_operation_t    operation;
 
     /**
      * Local memory type to use for determining performance.
      * This field must be initialized by the caller.
      */
-    ucs_memory_type_t   local_memory_type;
+    ucs_memory_type_t     local_memory_type;
 
     /**
      * Remote memory type to use for determining performance.
      * Relevant only for operations that have remote memory access.
      * This field must be initialized by the caller.
      */
-    ucs_memory_type_t   remote_memory_type;
+    ucs_memory_type_t     remote_memory_type;
 
     /**
      * System device where the local memory type resides.
      * Can be UCS_SYS_DEVICE_ID_UNKNOWN.
      * This field must be initialized by the caller.
      */
-    ucs_sys_device_t    local_sys_device;
+    ucs_sys_device_t      local_sys_device;
 
     /**
      * System device where the remote memory type resides.
      * Can be UCS_SYS_DEVICE_ID_UNKNOWN and be the same as local system device.
      * This field must be initialized by the caller.
      */
-    ucs_sys_device_t    remote_sys_device;
+    ucs_sys_device_t      remote_sys_device;
 
     /**
      * This is the time spent in the UCT layer to prepare message request and
      * pass it to the hardware or system software layers, in seconds.
      * This field is set by the UCT layer.
      */
-    double              send_pre_overhead;
+    double                send_pre_overhead;
 
     /**
      * This is the time spent in the UCT layer after the message request has
@@ -159,24 +162,24 @@ typedef struct {
      * remote side.
      * This field is set by the UCT layer.
      */
-    double              send_post_overhead;
+    double                send_post_overhead;
 
     /**
      * Message receive overhead time, in seconds.
      * This field is set by the UCT layer.
      */
-    double              recv_overhead;
+    double                recv_overhead;
 
     /**
      * Bandwidth model. This field is set by the UCT layer.
      */
-    uct_ppn_bandwidth_t bandwidth;
+    uct_ppn_bandwidth_t   bandwidth;
 
     /**
      * Latency as a function of number of endpoints.
      * This field is set by the UCT layer.
      */
-    ucs_linear_func_t   latency;
+    ucs_linear_func_t     latency;
 
     /**
      * Approximate maximum number of endpoints that could have outstanding
@@ -186,7 +189,13 @@ typedef struct {
      * large number of maximum inflight endpoints.
      * This field is set by the UCT layer.
      */
-    size_t              max_inflight_eps;
+    size_t                max_inflight_eps;
+
+    /**
+     * GUID of the system device where remote buffers reside. Refer to
+     * ucs_sys_device_guid_t. This field must be initialized by the caller.
+     */
+    ucs_sys_device_guid_t remote_guid;
 } uct_perf_attr_t;
 
 

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -29,6 +29,7 @@ UCS_TEST_P(test_uct_query, query_perf)
     perf_attr.field_mask         = UCT_PERF_ATTR_FIELD_OPERATION |
                                    UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE |
                                    UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE |
+                                   UCT_PERF_ATTR_FIELD_REMOTE_GUID |
                                    UCT_PERF_ATTR_FIELD_LOCAL_SYS_DEVICE |
                                    UCT_PERF_ATTR_FIELD_REMOTE_SYS_DEVICE |
                                    UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD |
@@ -40,6 +41,9 @@ UCS_TEST_P(test_uct_query, query_perf)
     perf_attr.remote_memory_type = UCS_MEMORY_TYPE_HOST;
     perf_attr.local_sys_device   = UCS_SYS_DEVICE_ID_UNKNOWN;
     perf_attr.remote_sys_device  = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    ucs_topo_get_unknown_device_guid(&perf_attr.remote_guid);
+
     status                       = uct_iface_estimate_perf(sender().iface(),
                                                            &perf_attr);
     EXPECT_EQ(status, UCS_OK);


### PR DESCRIPTION
## What/Why ?
Introduce remote GUID structure that can interpreted by uct_iface_estimate_perf API to provide accurate bandwidth/latency using remote device location. Example, cuda_ipc estimate_perf API can look at local and remote device (extracted from remote guid) and use nvml to provide nvlink vs pcie bandwidth.