### PR TITLE
TEST/UCP: Separate progress to avoid concurrent ucp_worker_progress

### DIFF
--- a/test/gtest/ucp/test_ucp_rma_mt.cc
+++ b/test/gtest/ucp/test_ucp_rma_mt.cc
@@ -101,7 +101,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
         void* req = ucp_put_nb(sender().ep(worker_index), &orig_data[i],
                                sizeof(uint64_t), (uintptr_t)((uint64_t*)memheap + i),
                                rkey[i], send_cb);
-        request_wait(req, worker_index);
+        request_wait(req, {}, worker_index);
 
         flush_worker(sender(), worker_index);
 
@@ -154,7 +154,7 @@ UCS_TEST_P(test_ucp_rma_mt, put_get) {
         void *req = ucp_get_nb(sender().ep(worker_index), &orig_data[i],
                                sizeof(uint64_t), (uintptr_t)((uint64_t*)memheap + i),
                                rkey[i], send_cb);
-        request_wait(req, worker_index);
+        request_wait(req, {}, worker_index);
 
         flush_worker(sender(), worker_index);
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -570,7 +570,7 @@ public:
         {
             // Suppress possible reject/unreachable errors
             scoped_log_handler slh(wrap_errors_logger);
-            send_status = request_wait(send_req, 0, wakeup);
+            send_status = request_wait(send_req, {}, 0, wakeup);
             if (!check_send_status(send_status, to, recv_req, cb_type)) {
                 return;
             }
@@ -581,7 +581,7 @@ public:
             wait_for_flag(&am_rx_arg.received);
             set_am_data_handler(to, 0, NULL, NULL);
         } else {
-            request_wait(recv_req, 0, wakeup);
+            request_wait(recv_req, {}, 0, wakeup);
         }
         EXPECT_EQ(send_data, recv_data);
     }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -222,7 +222,8 @@ private:
     static void set_ucp_config(ucp_config_t *config, const std::string& tls);
     static bool check_tls(const std::string& tls);
     ucs_status_t request_process(void *req, int worker_index, bool wait,
-                                 bool wakeup = false);
+                                 bool wakeup = false,
+                                 const std::vector<entity*> &entities = {});
 
 protected:
     using variant_vec_t       = std::vector<ucp_test_variant>;
@@ -241,7 +242,8 @@ protected:
     unsigned progress(int worker_index = 0) const;
     void short_progress_loop(int worker_index = 0) const;
     void flush_ep(const entity &e, int worker_index = 0, int ep_index = 0);
-    void flush_worker(const entity &e, int worker_index = 0);
+    void flush_worker(const entity &e, int worker_index = 0,
+                      const std::vector<entity*> &entities = {});
     void flush_workers();
     void disconnect(entity& entity);
     void check_events(const std::vector<entity*> &entities, bool wakeup,
@@ -249,7 +251,9 @@ protected:
     ucs_status_t
     request_progress(void *req, const std::vector<entity*> &entities,
                      double timeout = 10.0, int worker_index = 0);
-    ucs_status_t request_wait(void *req, int worker_index = 0, bool wakeup = false);
+    ucs_status_t request_wait(void *req,
+                              const std::vector<entity*> &entities = {},
+                              int worker_index = 0, bool wakeup = false);
     ucs_status_t requests_wait(std::vector<void*> &reqs, int worker_index = 0);
     ucs_status_t requests_wait(const std::initializer_list<void*> reqs_list,
                                int worker_index = 0);


### PR DESCRIPTION
## What
Fix assert failure below, on tests like `test_ucp_fence*`, when built without `--enable-mt`:
```
==>  2807     ucs_assert(worker->inprogress++ == 0);
```

## Why ?
The sender thread calls `request_wait()` or `flush_worker()` that eventually calls `check_events()`. That later one progresses all entities, so including the sender and the receiver workers. This is an issue because the main thread is already progressing the receiver worker.

## How ?
To fix, we make sure that the sender thread does not progress the receiver worker by adding one new parameter to restrict processing to a subset of the list of entities. In case of `self`, only the sender needs to progress.