### PR TITLE
BUILDLIB/PR: Retry on test failure

### DIFF
--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -32,6 +32,7 @@ jobs:
           ./contrib/test_jenkins.sh
           exit $?
         displayName: Run ./contrib/test_jenkins.sh
+        retryCountOnTaskFailure: 2
         env:
           nworkers: ${{ parameters.num_workers }}
           worker: $(worker_id)


### PR DESCRIPTION
## What
Add auto-retry count for flaky tests.

## Why ?
Some test failures are environmental, thus unrelated to the PR itself.