### PR TITLE
UCP/WIREUP: Use distance info in lane score calculation with new protocols

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1175,7 +1175,7 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
     UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
-static ucs_status_t
+static void
 ucp_worker_get_sys_device_distance(ucp_context_h context,
                                    ucp_rsc_index_t rsc_index,
                                    ucs_sys_dev_distance_t *distance)
@@ -1183,6 +1183,8 @@ ucp_worker_get_sys_device_distance(ucp_context_h context,
     ucs_sys_device_t device     = UCS_SYS_DEVICE_ID_UNKNOWN;
     ucs_sys_device_t cmp_device = UCS_SYS_DEVICE_ID_UNKNOWN;
     ucp_rsc_index_t md_index, i;
+
+    *distance = ucs_topo_default_distance;
 
     for (i = 0; i < context->num_tls; i++) {
         md_index = context->tl_rscs[i].md_index;
@@ -1194,10 +1196,8 @@ ucp_worker_get_sys_device_distance(ucp_context_h context,
         device     = context->tl_rscs[rsc_index].tl_rsc.sys_device;
         cmp_device = context->tl_rscs[i].tl_rsc.sys_device;
 
-        return ucs_topo_get_distance(device, cmp_device, distance);
+        ucs_topo_get_distance(device, cmp_device, distance);
     }
-
-    return UCS_ERR_NO_RESOURCE;
 }
 
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
@@ -1207,7 +1207,6 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
     ucp_context_h context            = worker->context;
     ucp_tl_resource_desc_t *resource = &context->tl_rscs[tl_id];
     uct_md_h md                      = context->tl_mds[resource->md_index].md;
-    ucs_sys_dev_distance_t distance  = {.latency = 0, .bandwidth = 0};
     uct_iface_config_t *iface_config;
     ucp_worker_iface_t *wiface;
     ucs_status_t status;
@@ -1304,16 +1303,14 @@ ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
         goto err_close_iface;
     }
 
+    ucp_worker_get_sys_device_distance(context, wiface->rsc_index,
+                                       &wiface->distance);
     if (!context->config.ext.proto_enable) {
-        status = ucp_worker_get_sys_device_distance(context, wiface->rsc_index,
-                                                    &distance);
-        if (status == UCS_OK) {
-            wiface->attr.latency.c          += distance.latency;
-            wiface->attr.bandwidth.shared    =
-                    ucs_min(wiface->attr.bandwidth.shared, distance.bandwidth);
-            wiface->attr.bandwidth.dedicated = ucs_min(
-                    wiface->attr.bandwidth.dedicated, distance.bandwidth);
-        }
+        wiface->attr.latency.c          += wiface->distance.latency;
+        wiface->attr.bandwidth.shared    = ucs_min(wiface->attr.bandwidth.shared,
+                                                   wiface->distance.bandwidth);
+        wiface->attr.bandwidth.dedicated = ucs_min(
+                wiface->attr.bandwidth.dedicated, wiface->distance.bandwidth);
     }
 
     ucs_debug("created interface[%d]=%p using "UCT_TL_RESOURCE_DESC_FMT" on worker %p",

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -236,6 +236,7 @@ struct ucp_worker_iface {
     ucp_worker_h                  worker;        /* The parent worker */
     ucs_list_link_t               arm_list;      /* Element in arm_ifaces list */
     ucp_rsc_index_t               rsc_index;     /* Resource index */
+    ucs_sys_dev_distance_t        distance;      /* Distance from given MD */
     int                           event_fd;      /* Event FD, or -1 if undefined */
     unsigned                      activate_count;/* How many times this iface has
                                                     been activated */

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -667,16 +667,15 @@ static uint64_t ucp_address_flags_from_iface_flags(uint64_t iface_cap_flags,
 }
 
 static unsigned
-ucp_address_pack_iface_attr_v1(ucp_worker_h worker, void *ptr,
-                               const uct_iface_attr_t *iface_attr,
+ucp_address_pack_iface_attr_v1(const ucp_worker_iface_t *wiface, void *ptr,
                                unsigned atomic_flags)
 {
+    const uct_iface_attr_t *iface_attr      = &wiface->attr;
     ucp_address_packed_iface_attr_t *packed = ptr;
 
-    packed->overhead       = iface_attr->overhead;
-    packed->bandwidth      = ucp_tl_iface_bandwidth(worker->context,
-                                                    &iface_attr->bandwidth);
-    packed->lat_ovh        = iface_attr->latency.c;
+    packed->lat_ovh   = ucp_wireup_iface_lat_distance_v1(wiface);
+    packed->bandwidth = ucp_wireup_iface_bw_distance(wiface);
+    packed->overhead  = iface_attr->overhead;
     /* Pack prio, capability and atomic flags */
     packed->prio_cap_flags = (uint8_t)iface_attr->priority |
                              ucp_address_pack_flags(iface_attr->cap.flags,
@@ -717,23 +716,24 @@ size_t ucp_address_iface_seg_size(const uct_iface_attr_t *iface_attr)
 }
 
 static unsigned
-ucp_address_pack_iface_attr_v2(ucp_worker_h worker, void *ptr,
-                               const uct_iface_attr_t *iface_attr,
+ucp_address_pack_iface_attr_v2(const ucp_worker_iface_t *wiface, void *ptr,
                                unsigned atomic_flags)
 {
+    const uct_iface_attr_t *iface_attr         = &wiface->attr;
     ucp_address_v2_packed_iface_attr_t *packed = ptr;
+
     uint64_t addr_iface_flags;
-    double latency_nsec, overhead_nsec;
+    double latency_nsec, overhead_nsec, latency, bandwidth;
     size_t seg_size;
 
-    latency_nsec  = ucp_tl_iface_latency(worker->context, &iface_attr->latency) *
-                    UCS_NSEC_PER_SEC;
+    latency   = ucp_wireup_iface_lat_distance_v2(wiface);
+    bandwidth = ucp_wireup_iface_bw_distance(wiface);
+
+    latency_nsec  = latency * UCS_NSEC_PER_SEC;
     overhead_nsec = iface_attr->overhead * UCS_NSEC_PER_SEC;
 
     packed->overhead  = UCS_FP8_PACK(OVERHEAD, overhead_nsec);
-    packed->bandwidth = UCS_FP8_PACK(BANDWIDTH,
-                                     ucp_tl_iface_bandwidth(worker->context,
-                                     &iface_attr->bandwidth));
+    packed->bandwidth = UCS_FP8_PACK(BANDWIDTH, bandwidth);
     packed->latency   = UCS_FP8_PACK(LATENCY, latency_nsec);
     packed->prio      = ucs_min(UINT8_MAX, iface_attr->priority);
     addr_iface_flags  = ucp_address_flags_from_iface_flags(
@@ -748,15 +748,17 @@ ucp_address_pack_iface_attr_v2(ucp_worker_h worker, void *ptr,
     return sizeof(*packed);
 }
 
-static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
-                                       ucp_rsc_index_t rsc_index,
-                                       const uct_iface_attr_t *iface_attr,
+static int ucp_address_pack_iface_attr(const ucp_worker_iface_t *wiface,
+                                       void *ptr, ucp_rsc_index_t rsc_index,
                                        unsigned pack_flags,
                                        ucp_object_version_t addr_version,
                                        int enable_atomics)
 {
-    unsigned atomic_flags = 0;
+    const uct_iface_attr_t *iface_attr = &wiface->attr;
+    ucp_worker_h worker                = wiface->worker;
+    unsigned atomic_flags              = 0;
     unsigned packed_len;
+    double lat_ovh;
     ucp_address_unified_iface_attr_t *unified;
 
     if (ucp_worker_is_unified_mode(worker)) {
@@ -766,8 +768,11 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
          * depends on device NUMA locality. */
         unified            = ptr;
         unified->rsc_index = rsc_index;
-        unified->lat_ovh   = enable_atomics ? -iface_attr->latency.c :
-                                               iface_attr->latency.c;
+        lat_ovh            = ucp_wireup_iface_lat_distance_v1(wiface);
+        if (enable_atomics) {
+            lat_ovh = -lat_ovh;
+        }
+        unified->lat_ovh = lat_ovh;
 
         return sizeof(*unified);
     }
@@ -788,11 +793,9 @@ static int ucp_address_pack_iface_attr(ucp_worker_h worker, void *ptr,
     }
 
     if (addr_version == UCP_OBJECT_VERSION_V1) {
-        packed_len = ucp_address_pack_iface_attr_v1(worker, ptr, iface_attr,
-                                                    atomic_flags);
+        packed_len = ucp_address_pack_iface_attr_v1(wiface, ptr, atomic_flags);
     } else {
-        packed_len = ucp_address_pack_iface_attr_v2(worker, ptr, iface_attr,
-                                                    atomic_flags);
+        packed_len = ucp_address_pack_iface_attr_v2(wiface, ptr, atomic_flags);
     }
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_TL_RSC_IDX) {
@@ -1270,9 +1273,9 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
 
             /* Transport information */
             enable_amo = UCS_BITMAP_GET(worker->atomic_tls, rsc_index);
-            attr_len   = ucp_address_pack_iface_attr(worker, ptr, rsc_index,
-                                                     iface_attr, pack_flags,
-                                                     addr_version, enable_amo);
+            attr_len   = ucp_address_pack_iface_attr(wiface, ptr, rsc_index,
+                                                     pack_flags, addr_version,
+                                                     enable_amo);
             if (attr_len < 0) {
                 return UCS_ERR_INVALID_ADDR;
             }

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -208,6 +208,12 @@ uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane);
 
 unsigned ucp_wireup_eps_progress(void *arg);
 
+double ucp_wireup_iface_lat_distance_v1(const ucp_worker_iface_t *wiface);
+
+double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface);
+
+double ucp_wireup_iface_bw_distance(const ucp_worker_iface_t *wiface);
+
 static inline int ucp_wireup_lane_types_has_fast_path(ucp_lane_map_t lane_types)
 {
     return lane_types &


### PR DESCRIPTION
## What
This PR adds support for using GPU-NIC distance information when calculating lane scores even if the new protocols are enabled.

## Why ?
During lane creation, GPU-NIC distance information and its impact on latency/bandwidth was used only if new protocols were NOT enabled. Otherwise, we could end up selecting sub-optimal NICs for GPU buffers.

## How ?
1. Add distance information to worker iface so we can use it for local iface.
2. Use distance-updated latency/bandwidth for remote iface attributes during address pack.
