### PR TITLE
AZP/RELEASE: New image tags & separate gdrcopy

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -15,18 +15,18 @@ variables:
 resources:
   containers:
     - container: centos7_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5-cuda11:2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5-cuda11:6
       options: $(DOCKER_OPT_VOLUMES)
     - container: centos8_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:2
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:6
     - container: ubuntu16_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5-cuda11:3
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5-cuda11:6
     - container: ubuntu18_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:3
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:6
     - container: ubuntu20_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:3
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:6
     - container: ubuntu22_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda11:3
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda11:6
 
 stages:
   - stage: Prepare

--- a/buildlib/dockers/docker-compose.yml
+++ b/buildlib/dockers/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   centos7-mofed5-cuda11:
-    image: centos7-mofed5-cuda11:2
+    image: centos7-mofed5-cuda11:6
     build:
       context: .
       network: host
@@ -13,7 +13,7 @@ services:
         CUDA_VERSION: 11.4.0
         OS_VERSION: 7
   centos7-mofed5.4-cuda11:
-    image: centos7-mofed5.4-cuda11
+    image: centos7-mofed5.4-cuda11:6
     build:
       context: .
       network: host
@@ -24,7 +24,7 @@ services:
         CUDA_VERSION: 11.2.0
         OS_VERSION: 7
   centos8-mofed5-cuda11:
-    image: centos8-mofed5-cuda11:2
+    image: centos8-mofed5-cuda11:6
     build:
       context: .
       network: host
@@ -35,7 +35,7 @@ services:
         CUDA_VERSION: 11.4.0
         OS_VERSION: 8
   ubuntu16.04-mofed5-cuda11:
-    image: ubuntu16.04-mofed5-cuda11:3
+    image: ubuntu16.04-mofed5-cuda11:6
     build:
       context: .
       network: host
@@ -45,7 +45,7 @@ services:
         UBUNTU_VERSION: 16.04
         CUDA_VERSION: 11.2.0
   ubuntu18.04-mofed5-cuda11:
-    image: ubuntu18.04-mofed5-cuda11:3
+    image: ubuntu18.04-mofed5-cuda11:6
     build:
       context: .
       network: host
@@ -55,7 +55,7 @@ services:
         UBUNTU_VERSION: 18.04
         CUDA_VERSION: 11.4.0
   ubuntu20.04-mofed5-cuda11:
-    image: ubuntu20.04-mofed5-cuda11:3
+    image: ubuntu20.04-mofed5-cuda11:6
     build:
       context: .
       network: host
@@ -65,7 +65,7 @@ services:
         UBUNTU_VERSION: 20.04
         CUDA_VERSION: 11.4.0
   ubuntu22.04-mofed5-cuda11:
-    image: ubuntu22.04-mofed5-cuda11:3
+    image: ubuntu22.04-mofed5-cuda11:6
     build:
       context: .
       network: host

--- a/buildlib/dockers/ubuntu-release.Dockerfile
+++ b/buildlib/dockers/ubuntu-release.Dockerfile
@@ -5,6 +5,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
     apt-get install -y \
+        apt-file \
         automake \
         default-jdk \
         dh-make \
@@ -16,10 +17,12 @@ RUN apt-get update && \
         libtool \
         make \
         maven \
+        libnvidia-compute-525 \
         udev \
         wget \
         environment-modules \
         pkg-config \
+    && apt-get remove -y cuda-compat* \
     && apt-get remove -y openjdk-11-* || apt-get autoremove -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +49,3 @@ ENV CPATH /usr/local/cuda/include:${CPATH}
 ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LD_LIBRARY_PATH}
 ENV LIBRARY_PATH /usr/local/cuda/lib64:/usr/local/cuda/compat:${LIBRARY_PATH}
 ENV PATH /usr/local/cuda/compat:${PATH}
-
-RUN ml_stub=$(find /usr -name libnvidia-ml.so) && ln -s $ml_stub /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1

--- a/debian/control.in
+++ b/debian/control.in
@@ -41,7 +41,7 @@ Package: ucx-gdrcopy
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Architecture: any
-Build-Profiles: <cuda>
+Build-Profiles: <gdrcopy>
 Description: Unified Communication X - gdrcopy support
  UCX is a communication library implementing high-performance messaging.
  .


### PR DESCRIPTION
## What
1. Switch to new release build images.
2. Uncouple the gdrcopy build profile from cuda profile.

## Why
Fix dependencies for CUDA build.