### PR TITLE
UCP/WIREUP: Set EP locality based on selected lanes

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2108,7 +2108,6 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
     ucp_worker_h worker = select_params->ep->worker;
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t rsc_index;
-    ucp_rsc_index_t iface_id;
     ucp_address_entry_t *ae;
     ucp_lane_index_t lane;
     ucs_status_t status;
@@ -2131,9 +2130,14 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
     }
 
     /* If the local context matching at least one remote device address, it's
-       intra-node */
-    for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        wiface = worker->ifaces[iface_id];
+       intra-node. Only selected lanes are compared to verify reachability. */
+    for (lane = 0; lane < key->num_lanes; ++lane) {
+        rsc_index = key->lanes[lane].rsc_index;
+        if (rsc_index == UCP_NULL_RESOURCE) {
+            continue;
+        }
+
+        wiface = ucp_worker_iface(worker, rsc_index);
         if (wiface->attr.device_addr_len == 0) {
             continue;
         }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1659,7 +1659,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_wireup_asymmetric_ib, different_pci_bw_connect,
 {
     /* Enable cross-dev connection */
     /* coverity[tainted_string_argument] */
-    ucs::scoped_setenv path_mtu_env("UCX_RC_PATH_MTU", "1024");
+    ucs::scoped_setenv path_mtu_env("UCX_IB_PATH_MTU", "1024");
 
     {
         std::string config_str = pci_bw_config(20, 20);


### PR DESCRIPTION
## What
Set EP locality based on selected lanes.

## Why ?
Prevent wrong EP locality as a result of internal TCP NICs (as observed in BlueField machines).
The issue was found during the following bug investigation:
https://redmine.mellanox.com/issues/3340697#change-25091571

