### PR TITLE
AZP/RELEASE: rm cuda-compat & separate gdrcopy"

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -22,9 +22,6 @@ jobs:
         centos8_cuda11:
           build_container: centos8_cuda11
           artifact_name: $(POSTFIX)-centos8-mofed5-cuda11.tar.bz2
-        ubuntu16_cuda11:
-          build_container: ubuntu16_cuda11
-          artifact_name: $(POSTFIX)-ubuntu16.04-mofed5-cuda11.tar.bz2
         ubuntu18_cuda11:
           build_container: ubuntu18_cuda11
           artifact_name: $(POSTFIX)-ubuntu18.04-mofed5-cuda11.tar.bz2
@@ -62,6 +59,8 @@ jobs:
 
       - bash: |
           set -eEx
+
+          # Build
           ./autogen.sh
           ./contrib/configure-release --with-cuda --with-java=no
           make dist
@@ -71,11 +70,20 @@ jobs:
           echo 10 > debian/compat   # https://www.debian.org/doc/manuals/maint-guide/dother.en.htmdpl#compat
           dpkg-buildpackage -us -uc -Pcuda
           cd ..                             # Move back to the working directory
-          find . -name '*.deb'
-          VER="${POSTFIX#ucx-}"   # Remove 'ucx' prefix from the POSTFIX string
-          # Rename DEB files
+
+          # Rename DEB files          
+          VER="${POSTFIX#ucx-}"     # Remove 'ucx-' prefix from the POSTFIX string
           find . -name "ucx*.deb" -exec bash -c 'mv "$1" "${1%%_*}-'"${VER}"'.deb"' _ {} \;
+          find . -name '*.deb'      # Show new names
+
+          # Remove superfluous dependency
+          dpkg-deb -R "ucx-cuda-${VER}.deb" tmp    # Extract
+          sed -i 's/libnvidia-compute-[0-9]* | libnvidia-ml1, //g' tmp/DEBIAN/control
+          dpkg-deb -b tmp "ucx-cuda-${VER}.deb"        # Rebuild
+          dpkg-deb -I "ucx-cuda-${VER}.deb"
           dpkg-deb -I "ucx-${VER}.deb"
+
+          # Package
           tar -cjf "${AZ_ARTIFACT_NAME}" *.deb  # Package all DEBs
           tar -tjf "${AZ_ARTIFACT_NAME}"
         displayName: Build DEB package

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -19,14 +19,12 @@ resources:
       options: $(DOCKER_OPT_VOLUMES)
     - container: centos8_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:2
-    - container: ubuntu16_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu16.04-mofed5-cuda11:3
     - container: ubuntu18_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu18.04-mofed5-cuda11:3
     - container: ubuntu20_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:3
     - container: ubuntu22_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda11:3
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu22.04-mofed5-cuda11:3
 
 stages:
   - stage: Prepare

--- a/buildlib/dockers/docker-compose.yml
+++ b/buildlib/dockers/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.4"
 
+# Find driver version based on CUDA version, OS and CPU arch (515 in this case):
+# https://developer.nvidia.com/cuda-11-7-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=runfile_local
+
 services:
   centos7-mofed5-cuda11:
     image: centos7-mofed5-cuda11:2
@@ -34,16 +37,6 @@ services:
         MOFED_OS: rhel8.2
         CUDA_VERSION: 11.4.0
         OS_VERSION: 8
-  ubuntu16.04-mofed5-cuda11:
-    image: ubuntu16.04-mofed5-cuda11:3
-    build:
-      context: .
-      network: host
-      dockerfile: ubuntu-release.Dockerfile
-      args:
-        MOFED_VERSION: 5.0-1.0.0.0
-        UBUNTU_VERSION: 16.04
-        CUDA_VERSION: 11.2.0
   ubuntu18.04-mofed5-cuda11:
     image: ubuntu18.04-mofed5-cuda11:3
     build:
@@ -54,6 +47,7 @@ services:
         MOFED_VERSION: 5.0-1.0.0.0
         UBUNTU_VERSION: 18.04
         CUDA_VERSION: 11.4.0
+        NV_DRIVER_VERSION: 470
   ubuntu20.04-mofed5-cuda11:
     image: ubuntu20.04-mofed5-cuda11:3
     build:
@@ -64,6 +58,7 @@ services:
         MOFED_VERSION: 5.0-1.0.0.0
         UBUNTU_VERSION: 20.04
         CUDA_VERSION: 11.4.0
+        NV_DRIVER_VERSION: 470
   ubuntu22.04-mofed5-cuda11:
     image: ubuntu22.04-mofed5-cuda11:3
     build:
@@ -74,3 +69,4 @@ services:
         MOFED_VERSION: 5.4-3.6.8.1
         UBUNTU_VERSION: 22.04
         CUDA_VERSION: 11.7.0
+        NV_DRIVER_VERSION: 515

--- a/buildlib/dockers/push-release-images.sh
+++ b/buildlib/dockers/push-release-images.sh
@@ -1,11 +1,11 @@
-#!/bin/bash -eE
+#!/bin/bash -eEx
 
 # shellcheck disable=SC2086
 basedir=$(cd "$(dirname $0)" && pwd)
 
 registry=harbor.mellanox.com/ucx
 
-images=$(awk '/image:/ {print $2}' "${basedir}/docker-compose.yml")
+images=$(awk '!/#/ && /image:/ {print $2}' "${basedir}/docker-compose.yml")
 for img in $images; do
     target_name="${registry}/${img}"
     docker tag ${img} ${target_name}

--- a/debian/control.in
+++ b/debian/control.in
@@ -41,7 +41,7 @@ Package: ucx-gdrcopy
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Architecture: any
-Build-Profiles: <cuda>
+Build-Profiles: <gdrcopy>
 Description: Unified Communication X - gdrcopy support
  UCX is a communication library implementing high-performance messaging.
  .


### PR DESCRIPTION
## What
1. Remove 'cuda-compat' from nvidia/cuda images.
2. Install 'libnvidia-compute' with driver version matching the CUDA runtime version [(e.g. driver ver 515 for CUDA 11.7)](https://developer.nvidia.com/cuda-11-7-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=runfile_local).
3. Drop libnvidia-ml.so linking hack, as it is provided by 'libnvidia-compute'.
4. Uncouple the gdrcopy build profile from cuda profile.
5. Push images script: exclude commented-out images.
6. Drop the unsupported Ubuntu16 release.
7. Drop superfluous dependencies from ucx-cuda DEB, as those are satisfied by default CUDA installation.

## Why
Fix dependencies for CUDA build.
Improve the image-building process.
##
Note: this solution replaces https://github.com/openucx/ucx/pull/8900
