### PR TITLE
UCT/IB/MLX5DV: fix not use defined var error under no DEVX

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -44,8 +44,6 @@ typedef struct uct_ib_mlx5_mem {
 } uct_ib_mlx5_mem_t;
 
 
-static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
-
 static ucs_status_t
 uct_ib_mlx5_reg_key(uct_ib_md_t *md, void *address, size_t length,
                     uint64_t access_flags, int dmabuf_fd, size_t dmabuf_offset,
@@ -133,6 +131,8 @@ static uint32_t uct_ib_mlx5_flush_rkey_make()
 }
 
 #if HAVE_DEVX
+
+static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
 
 typedef struct uct_ib_mlx5_dbrec_page {
     uct_ib_mlx5_devx_umem_t    mem;


### PR DESCRIPTION
fix below error when DEVX is not support in build environment
```
error: ‘uct_ib_mkey_token’ defined but not used [-Werror=unused-const-variable=]
 static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
                    ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```