### PR TITLE
ib_md: Fix potential dead store

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -426,7 +426,6 @@ uct_ib_md_handle_mr_list_multithreaded(uct_ib_md_t *md, void *address,
 
             CPU_ZERO(&thread_set);
             CPU_SET(cpu_id, &thread_set);
-            cpu_id++;
             pthread_attr_setaffinity_np(&attr, sizeof(ucs_sys_cpuset_t), &thread_set);
         }
 


### PR DESCRIPTION
## What
Fix the dead store warning detected by static analyse tool infer@facebook

## Why ?
**Warning Type**
Dead Store

**Component Name**
ucx/src/uct/ib/base/ib_md.c (line:429)

**Additional Information**
The value written to &cpu_id (type int) is never used.
