### PR TITLE
GTEST: Reduce test deadline

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -335,8 +335,9 @@ int test_time_multiplier()
 
 ucs_time_t get_deadline(double timeout_in_sec)
 {
-    return ucs_get_time() + ucs_time_from_sec(timeout_in_sec *
-                                              test_time_multiplier());
+    return ucs_get_time() +
+           ucs_time_from_sec(ucs_min(watchdog_get_timeout() * 0.75,
+                                     timeout_in_sec * test_time_multiplier()));
 }
 
 int max_tcp_connections()


### PR DESCRIPTION
## What
Reduce test timeout used when polling/waiting for flag

## Why ?
When running with Valgrind test deadline is multiplied by 20 and exceeds watchdog timeout. This can lead to a wrong report if the test fails, watchdog timeout instead of test timeout.

## How ?
Set upper limit to test deadline based on watchdog timeout.
