### PR TITLE
UCT/IB: Remove implicit On-Demand Paging logic

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -90,8 +90,7 @@ enum {
     UCT_IB_DEVICE_FLAG_AV       = UCS_BIT(8),   /* Device supports compact AV */
     UCT_IB_DEVICE_FLAG_DC       = UCT_IB_DEVICE_FLAG_DC_V1 |
                                   UCT_IB_DEVICE_FLAG_DC_V2, /* Device supports DC */
-    UCT_IB_DEVICE_FLAG_ODP_IMPLICIT = UCS_BIT(9),
-    UCT_IB_DEVICE_FAILED        = UCS_BIT(10)   /* Got fatal error */
+    UCT_IB_DEVICE_FAILED        = UCS_BIT(9)    /* Got fatal error */
 };
 
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -13,7 +13,6 @@
 
 #include <uct/base/uct_md.h>
 #include <ucs/stats/stats.h>
-#include <ucs/memory/numa.h>
 #include <ucs/memory/rcache.h>
 
 #define UCT_IB_MD_MAX_MR_SIZE        0x80000000UL
@@ -91,7 +90,6 @@ typedef struct uct_ib_md_ext_config {
     int                      enable_indirect_atomic; /** Enable indirect atomic */
 
     struct {
-        ucs_numa_policy_t    numa_policy;  /**< NUMA policy flags for ODP */
         int                  prefetch;     /**< Auto-prefetch non-blocking memory
                                                 registrations / allocations */
         size_t               max_size;     /**< Maximal memory region size for ODP */
@@ -140,7 +138,6 @@ typedef enum {
 typedef struct uct_ib_md {
     uct_md_t                 super;
     ucs_rcache_t             *rcache;   /**< Registration cache (can be NULL) */
-    uct_mem_h                global_odp;/**< Implicit ODP memory handle */
     struct ibv_pd            *pd;       /**< IB memory domain */
     uct_ib_device_t          dev;       /**< IB device */
     ucs_linear_func_t        reg_cost;  /**< Memory registration cost */

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -67,12 +67,6 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #endif
 
 
-#if HAVE_ODP_IMPLICIT
-#  define UCT_IB_HAVE_ODP_IMPLICIT(_attr)           ((_attr)->odp_caps.general_caps & IBV_ODP_SUPPORT_IMPLICIT)
-#else
-#  define UCT_IB_HAVE_ODP_IMPLICIT(_attr)           0
-#endif
-
 #if !HAVE_DECL_IBV_ACCESS_RELAXED_ORDERING
 #  define IBV_ACCESS_RELAXED_ORDERING               0
 #endif

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -222,18 +222,6 @@ AS_IF([test "x$with_ib" = "xyes"],
        AC_CHECK_MEMBERS([struct ibv_device_attr_ex.pci_atomic_caps],
                         [], [], [[#include <infiniband/verbs.h>]])
 
-       AC_CHECK_DECLS(IBV_ACCESS_ON_DEMAND, [with_odp=yes], [],
-                      [[#include <infiniband/verbs.h>]])
-
-       AS_IF([test "x$with_odp" = "xyes" ], [
-           AC_DEFINE([HAVE_ODP], 1, [ODP support])
-
-           AC_CHECK_DECLS(IBV_ODP_SUPPORT_IMPLICIT, [with_odp_i=yes], [],
-                          [[#include <infiniband/verbs.h>]])
-
-           AS_IF([test "x$with_odp_i" = "xyes" ], [
-               AC_DEFINE([HAVE_ODP_IMPLICIT], 1, [Implicit ODP support])])])
-
        AC_CHECK_DECLS([IBV_ACCESS_RELAXED_ORDERING,
                        IBV_QPF_GRH_REQUIRED],
                       [], [], [[#include <infiniband/verbs.h>]])

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -769,12 +769,6 @@ uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
         }
     }
 
-    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, fixed_buffer_size) &&
-        UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, null_mkey) &&
-        UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, umr_extended_translation_offset)) {
-        md->super.dev.flags |= UCT_IB_DEVICE_FLAG_ODP_IMPLICIT;
-    }
-
     return UCS_OK;
 
 no_odp:
@@ -1748,11 +1742,6 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     status = uct_ib_device_query(dev, ibv_device);
     if (status != UCS_OK) {
         goto err_md_free;
-    }
-
-    if (UCT_IB_HAVE_ODP_IMPLICIT(&dev->dev_attr) &&
-        !uct_ib_mlx5_has_roce_port(dev)) {
-        dev->flags |= UCT_IB_DEVICE_FLAG_ODP_IMPLICIT;
     }
 
     if (IBV_HAVE_ATOMIC_HCA(&dev->dev_attr)) {

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -3061,8 +3061,6 @@ protected:
 
     test_ucp_sockaddr_protocols_err_sender() {
         configure_peer_failure_settings();
-        m_env.push_back(new ucs::scoped_setenv("UCX_IB_REG_METHODS",
-                                               "rcache,odp,direct"));
     }
 
     void entity_disconnect(entity &e)

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -96,18 +96,6 @@ protected:
     }
 };
 
-#ifdef IMPLICIT_ODP_FIXED
-UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_odp,
-                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
-                                 UCT_IFACE_FLAG_GET_ZCOPY),
-                     "REG_METHODS=odp,direct",
-                     "MLX5_DEVX_OBJECTS=dct,dcsrq")
-{
-    test_put_zcopy();
-    test_get_zcopy();
-}
-#endif
-
 UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_alloc_methods, xfer_reg_rcache,
                      !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY |
                                  UCT_IFACE_FLAG_GET_ZCOPY),
@@ -139,14 +127,6 @@ UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_rma_test_alloc_methods)
 
 
 class uct_p2p_mix_test_alloc_methods : public uct_p2p_mix_test {};
-
-#ifdef IMPLICIT_ODP_FIXED
-UCS_TEST_P(uct_p2p_mix_test_alloc_methods, mix1000_odp,
-           "REG_METHODS=odp,direct", "MLX5_DEVX_OBJECTS=dct,dcsrq")
-{
-    run(1000);
-}
-#endif
 
 UCS_TEST_P(uct_p2p_mix_test_alloc_methods, mix1000_rcache,
            "REG_METHODS=rcache,direct")


### PR DESCRIPTION
## What
Remove implicit ODP support. Explicit ODP is still on the place since it would be used for future ODPv2 support feature.

## Why ?
Implicit ODP support probably will have different API in the future.

This pull request contains squashed and rebased changes that were previously made in https://github.com/openucx/ucx/pull/8685.