### PR TITLE
UCT/BASE: implement UCT_TL_DEFINE with UCT_TL_DEFINE_ENTRY

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -378,6 +378,36 @@ typedef struct uct_iface_local_addr_ns {
 } UCS_S_PACKED uct_iface_local_addr_ns_t;
 
 
+#define UCT_TL_NAME(_name) uct_##_name##_tl
+
+
+/**
+ * Transport registration routines
+ *
+ * @param _component      Component to add the transport to
+ * @param _name           Name of the transport (should be a token, not a string)
+ * @param _query_devices  Function to query the list of available devices
+ * @param _iface_class    Struct type defining the uct_iface class
+ * @param _cfg_prefix     Prefix for configuration variables
+ * @param _cfg_table      Transport configuration table
+ * @param _cfg_struct     Struct type defining transport configuration
+ */
+#define UCT_TL_DEFINE_ENTRY(_component, _name, _query_devices, _iface_class, \
+                            _cfg_prefix, _cfg_table, _cfg_struct) \
+    \
+    uct_tl_t UCT_TL_NAME(_name) = { \
+        .name               = #_name, \
+        .query_devices      = _query_devices, \
+        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
+        .config = { \
+            .name           = #_name" transport", \
+            .prefix         = _cfg_prefix, \
+            .table          = _cfg_table, \
+            .size           = sizeof(_cfg_struct), \
+         } \
+    };
+
+
 /**
  * Define a transport
  *
@@ -391,21 +421,12 @@ typedef struct uct_iface_local_addr_ns {
  */
 #define UCT_TL_DEFINE(_component, _name, _query_devices, _iface_class, \
                       _cfg_prefix, _cfg_table, _cfg_struct) \
+    UCT_TL_DEFINE_ENTRY(_component, _name, _query_devices, _iface_class, \
+                        _cfg_prefix, _cfg_table, _cfg_struct) \
     \
-    uct_tl_t uct_##_name##_tl = { \
-        .name               = #_name, \
-        .query_devices      = _query_devices, \
-        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
-        .config = { \
-            .name           = #_name" transport", \
-            .prefix         = _cfg_prefix, \
-            .table          = _cfg_table, \
-            .size           = sizeof(_cfg_struct), \
-         } \
-    }; \
-    UCS_CONFIG_REGISTER_TABLE_ENTRY(&(uct_##_name##_tl).config, &ucs_config_global_list); \
+    UCS_CONFIG_REGISTER_TABLE_ENTRY(&UCT_TL_NAME(_name).config, &ucs_config_global_list) \
     UCS_STATIC_INIT { \
-        ucs_list_add_tail(&(_component)->tl_list, &(uct_##_name##_tl).list); \
+        ucs_list_add_tail(&(_component)->tl_list, &UCT_TL_NAME(_name).list); \
     }
 
 
@@ -460,36 +481,6 @@ typedef struct uct_iface_local_addr_ns {
     UCT_TL_INIT(_component, _name, _scope, \
                 {_init_code; uct_component_register(_component);}, \
                 {uct_component_unregister(_component); _cleanup_code;})
-
-
-#define UCT_TL_NAME(_name) uct_##_name##_tl
-
-
-/**
- * Transport registration routines
- *
- * @param _component      Component to add the transport to
- * @param _name           Name of the transport (should be a token, not a string)
- * @param _query_devices  Function to query the list of available devices
- * @param _iface_class    Struct type defining the uct_iface class
- * @param _cfg_prefix     Prefix for configuration variables
- * @param _cfg_table      Transport configuration table
- * @param _cfg_struct     Struct type defining transport configuration
- */
-#define UCT_TL_DEFINE_ENTRY(_component, _name, _query_devices, _iface_class, \
-                            _cfg_prefix, _cfg_table, _cfg_struct) \
-    \
-    uct_tl_t UCT_TL_NAME(_name) = { \
-        .name               = #_name, \
-        .query_devices      = _query_devices, \
-        .iface_open         = UCS_CLASS_NEW_FUNC_NAME(_iface_class), \
-        .config = { \
-            .name           = #_name" transport", \
-            .prefix         = _cfg_prefix, \
-            .table          = _cfg_table, \
-            .size           = sizeof(_cfg_struct), \
-         } \
-    };
 
 
 /**


### PR DESCRIPTION
## What
implement ```UCT_TL_DEFINE``` with ```UCT_TL_DEFINE_ENTRY```

## Why ?
```UCT_TL_DEFINE_ENTRY``` define the object. ```UCT_TL_DEFINE``` needs to define the **exactly same** object, then register the object into resource.
