### PR TITLE
UCT/ROCM: fix device detection for host address - v1.14.x

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -175,8 +175,12 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size, void **base_ptr,
         *base_size = info.sizeInBytes;
     }
     if (dev_type != NULL) {
-        status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE,
-                                    dev_type);
+        if (info.type == HSA_EXT_POINTER_TYPE_UNKNOWN) {
+            *dev_type = HSA_DEVICE_TYPE_CPU;
+        } else {
+            status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE,
+                                        dev_type);
+        }
     }
 
     return status;


### PR DESCRIPTION
## What
no need to call the hsa functionality to determine device type if we know that we are dealing with a host pointer.

## Why ?
fixes an issue observed with a rocm version and the corresponding hsa functionality. But makes also logically sense and saves a function call into the hsa stack.

## How ?
(cherry picked from commit d25a3eee8cee5703711d1093c544f491fa8db1fa)
