### PR TITLE
UCS/MPOOL: Fix memory corruption when using UCX_MPOOL_FIFO=y

### DIFF
--- a/src/ucs/datastruct/mpool.c
+++ b/src/ucs/datastruct/mpool.c
@@ -287,11 +287,7 @@ void ucs_mpool_grow(ucs_mpool_t *mp, unsigned num_elems)
         if (data->ops->obj_init != NULL) {
             data->ops->obj_init(mp, elem + 1, chunk);
         }
-
-        ucs_mpool_add_to_freelist(mp, elem, 0);
-        if (data->tail == NULL) {
-            data->tail = elem;
-        }
+        ucs_mpool_add_to_freelist(mp, elem);
     }
 
     chunk->next  = data->chunks;

--- a/src/ucs/datastruct/mpool.inl
+++ b/src/ucs/datastruct/mpool.inl
@@ -35,12 +35,12 @@ static inline void *ucs_mpool_get_inline(ucs_mpool_t *mp)
     return obj;
 }
 
-static inline void ucs_mpool_add_to_freelist(ucs_mpool_t *mp, ucs_mpool_elem_t *elem,
-                                             int add_to_tail)
+static inline void
+ucs_mpool_add_to_freelist(ucs_mpool_t *mp, ucs_mpool_elem_t *elem)
 {
     ucs_mpool_elem_t *tail;
 
-    if (add_to_tail) {
+    if (ENABLE_DEBUG_DATA && ucs_global_opts.mpool_fifo) {
         elem->next = NULL;
         if (mp->freelist == NULL) {
             mp->freelist = elem;
@@ -76,8 +76,7 @@ static inline void ucs_mpool_put_inline(void *obj)
 
     elem = ucs_mpool_obj_to_elem(obj);
     mp   = elem->mpool;
-    ucs_mpool_add_to_freelist(mp, elem,
-                              ENABLE_DEBUG_DATA && ucs_global_opts.mpool_fifo);
+    ucs_mpool_add_to_freelist(mp, elem);
     VALGRIND_MAKE_MEM_NOACCESS(elem, sizeof *elem);
     VALGRIND_MEMPOOL_FREE(mp, obj);
 }


### PR DESCRIPTION
## What
Fixes memory corruption as below, when using `UCX_MPOOL_FIFO=y`:
```
#7  0x00007fda667b9e66 in ucs_error_signal_handler (signo=11, info=<optimized out>, context=<optimized out>) at /labhome/tvegas/share/srcs/ucx/contrib/../src/ucs/debug/debug.c:1075
#8  <signal handler called>
#9  0x00007fda67b27e53 in ucp_rndv_am_zcopy_send_req_complete (req=0x7ffd41c46e30, status=-128) at /labhome/tvegas/share/srcs/ucx/contrib/../src/ucp/rndv/rndv.c:1895
#10 0x00007fda67acbdc4 in ucp_proto_perf_envelope_make (perf_list=<optimized out>, range_start=<optimized out>, range_end=0, convex=<optimized out>, envelope_list=0x4d430000)
    at /labhome/tvegas/share/srcs/ucx/contrib/../src/ucp/proto/proto_init.c:171
#11 0x00007fda67b32ad8 in ucp_request_complete_am_recv (status=UCS_OK, req=0x7ffd41c47500) at /labhome/tvegas/share/srcs/ucx/contrib/../src/ucp/core/ucp_request.inl:872
#12 ucp_rndv_recv_req_complete (status=UCS_OK, req=0x7ffd41c47500) at /labhome/tvegas/share/srcs/ucx/contrib/../src/ucp/rndv/rndv.c:343
#13 ucp_rndv_recv_frag_put_completion_inner (self=0x0) at /labhome/tvegas/share/srcs/ucx/contrib/../src/ucp/rndv/rndv.c:1008
```

Command to reproduce:
```
mpirun -x UCX_MPOOL_FIFO=y -x UCX_TLS=xpmem -mca pml ucx -np 64 osu_alltoall -i 1
```

## Why ?
With mpool in FIFO mode, we fail to clear `mp->data->tail` when the free list is emptied. Later, an element is released which corrupts `tail->next`, leading to a crash when doing mpool put.

## How ?
Maintain `->tail` up to date, by making sure that `->tail` is eventually reset before adding a new chunk.