### PR TITLE
UCP/PROTO: Fixed operation attributes packing to select params.

### DIFF
--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -368,8 +368,6 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
                                 const char **operation_names,
                                 ucs_string_buffer_t *strb)
 {
-    static const uint32_t op_attr_bits   = UCP_OP_ATTR_FLAG_FAST_CMPL |
-                                           UCP_OP_ATTR_FLAG_MULTI_SEND;
     static const char *op_attr_names[]   = {
         [ucs_ilog2(UCP_OP_ATTR_FLAG_FAST_CMPL)]  = "fast-completion",
         [ucs_ilog2(UCP_OP_ATTR_FLAG_MULTI_SEND)] = "multi",
@@ -386,8 +384,7 @@ void ucp_proto_select_param_str(const ucp_proto_select_param_t *select_param,
     ucs_string_buffer_appendf(
             strb, "%s", operation_names[ucp_proto_select_op_id(select_param)]);
 
-    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr) &
-                   op_attr_bits;
+    op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr);
     op_flags     = ucp_proto_select_op_flags(select_param);
 
     if (op_attr_mask || op_flags) {

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -62,14 +62,14 @@ ucp_proto_select_op_attr_pack(uint32_t op_attr_mask)
     UCS_STATIC_ASSERT(
             (UCP_PROTO_SELECT_OP_ATTR_MASK / UCP_PROTO_SELECT_OP_ATTR_BASE) <
             UCP_PROTO_SELECT_OP_FLAGS_BASE);
-    return op_attr_mask / UCP_PROTO_SELECT_OP_ATTR_BASE;
+    return (op_attr_mask & UCP_PROTO_SELECT_OP_ATTR_MASK) /
+           UCP_PROTO_SELECT_OP_ATTR_BASE;
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t
 ucp_proto_select_op_attr_unpack(uint8_t op_attr)
 {
-    return (op_attr * UCP_PROTO_SELECT_OP_ATTR_BASE) &
-           UCP_PROTO_SELECT_OP_ATTR_MASK;
+    return op_attr * UCP_PROTO_SELECT_OP_ATTR_BASE;
 }
 
 static UCS_F_ALWAYS_INLINE ucp_operation_id_t


### PR DESCRIPTION
## What
Fixed operation attributes packing to select parameters.

## Why ?
Only flags in `UCP_PROTO_SELECT_OP_ATTR_MASK` should affect protocol selection.
Otherwise, we may have a cache miss, and print duplicating protocol information.
