### PR TITLE
UCP/PROTO: Fix short threshold calculation

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -749,7 +749,9 @@ typedef enum {
     UCP_OP_ATTR_FLAG_MULTI_SEND     = UCS_BIT(19)  /**< optimize for bandwidth of
                                                         multiple in-flight operations,
                                                         rather than for the latency
-                                                        of a single operation */
+                                                        of a single operation.
+                                                        This flag and UCP_OP_ATTR_FLAG_FAST_CMPL
+                                                        are mutually exclusive. */
 } ucp_op_attr_t;
 
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -177,10 +177,21 @@ UCS_PTR_MAP_IMPL(request, 0);
 
 
 #define UCP_REQUEST_CHECK_PARAM(_param) \
-    if (((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) && \
-        ((_param)->memory_type > UCS_MEMORY_TYPE_LAST)) { \
-        ucs_error("invalid memory type parameter: %d", (_param)->memory_type); \
-        return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM); \
+    if (ENABLE_PARAMS_CHECK) { \
+        if (((_param)->op_attr_mask & UCP_OP_ATTR_FIELD_MEMORY_TYPE) && \
+            ((_param)->memory_type > UCS_MEMORY_TYPE_LAST)) { \
+            ucs_error("invalid memory type parameter: %d", \
+                      (_param)->memory_type); \
+            return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM); \
+        } \
+        \
+        if (ucs_test_all_flags((_param)->op_attr_mask, \
+                               (UCP_OP_ATTR_FLAG_FAST_CMPL | \
+                                UCP_OP_ATTR_FLAG_MULTI_SEND))) { \
+            ucs_error("UCP_OP_ATTR_FLAG_FAST_CMPL and " \
+                      "UCP_OP_ATTR_FLAG_MULTI_SEND are mutually exclusive"); \
+            return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM); \
+        } \
     }
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1938,13 +1938,13 @@ ucp_worker_ep_config_short_init(ucp_worker_h worker, ucp_ep_config_t *ep_config,
     if (worker->context->config.features & feature_flag) {
         ucp_proto_select_short_init(worker, &ep_config->proto_select,
                                     ep_cfg_index, UCP_WORKER_CFG_INDEX_NULL,
-                                    op_id, 0, proto_flags, &proto_short);
+                                    op_id, proto_flags, &proto_short);
 
-         /* Short protocol should be either disabled, or use expected lane */
-         ucs_assertv((proto_short.max_length_host_mem < 0) ||
-                     (proto_short.lane == exp_lane),
-                     "max_length_host_mem %ld, lane %d",
-                     proto_short.max_length_host_mem, proto_short.lane);
+        /* Short protocol should be either disabled, or use expected lane */
+        ucs_assertv((proto_short.max_length_host_mem < 0) ||
+                            (proto_short.lane == exp_lane),
+                    "max_length_host_mem %ld, lane %d",
+                    proto_short.max_length_host_mem, proto_short.lane);
     } else {
         ucp_proto_select_short_disable(&proto_short);
     }
@@ -2104,8 +2104,7 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     if (worker->context->config.features & UCP_FEATURE_RMA) {
         ucp_proto_select_short_init(worker, &rkey_config->proto_select,
                                     key->ep_cfg_index, rkey_cfg_index,
-                                    UCP_OP_ID_PUT, UCP_OP_ATTR_FLAG_FAST_CMPL,
-                                    UCP_PROTO_FLAG_PUT_SHORT,
+                                    UCP_OP_ID_PUT, UCP_PROTO_FLAG_PUT_SHORT,
                                     &rkey_config->put_short);
     } else {
         ucp_proto_select_short_disable(&rkey_config->put_short);

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -152,13 +152,12 @@ ucp_proto_thresholds_search_slow(const ucp_proto_threshold_elem_t *thresholds,
 void ucp_proto_select_short_disable(ucp_proto_select_short_t *proto_short);
 
 
-void
-ucp_proto_select_short_init(ucp_worker_h worker, ucp_proto_select_t *proto_select,
-                            ucp_worker_cfg_index_t ep_cfg_index,
-                            ucp_worker_cfg_index_t rkey_cfg_index,
-                            ucp_operation_id_t op_id, uint32_t op_attr_mask,
-                            unsigned proto_flags,
-                            ucp_proto_select_short_t *proto_short);
+void ucp_proto_select_short_init(ucp_worker_h worker,
+                                 ucp_proto_select_t *proto_select,
+                                 ucp_worker_cfg_index_t ep_cfg_index,
+                                 ucp_worker_cfg_index_t rkey_cfg_index,
+                                 ucp_operation_id_t op_id, unsigned proto_flags,
+                                 ucp_proto_select_short_t *proto_short);
 
 
 int ucp_proto_select_get_valid_range(

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -170,6 +170,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_atomic_op_nbx,
     size_t op_size;
     int op_id;
 
+    UCP_REQUEST_CHECK_PARAM(param);
     if (ucs_unlikely(!(param->op_attr_mask & UCP_OP_ATTR_FIELD_DATATYPE))) {
         ucs_error("missing atomic operation datatype");
         return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM);

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -251,6 +251,7 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
     ucp_request_t *req;
     uint32_t attr_mask;
 
+    UCP_REQUEST_CHECK_PARAM(param);
     UCP_RMA_CHECK_PTR(worker->context, buffer, count);
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
@@ -368,6 +369,7 @@ ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
         return UCS_STATUS_PTR(UCS_ERR_NO_RESOURCE);
     }
 
+    UCP_REQUEST_CHECK_PARAM(param);
     UCP_RMA_CHECK_PTR(worker->context, buffer, count);
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 


### PR DESCRIPTION
## What
Fix short threshold calculation.

## Why ?
Short init threshold function didn't consider opt flags when calculating the short threshold, that cause send operation to enter short fast path, when the optimized protocol was different than short.

## How ?
Pass `UCP_OP_ATTR_FLAG_MULTI_SEND` optimization flag so the selection of the threshold will also consider short threshold of multi operation.
