### PR TITLE
UCP: use ucp_ep_get_rsc_index to get ep lane rsc_index

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -568,7 +568,7 @@ ucp_proto_get_zcopy_threshold(const ucp_request_t *req,
         } else {
             /* Calculate threshold */
             lane         = req->send.lane;
-            rsc_index    = ucp_ep_config(req->send.ep)->key.lanes[lane].rsc_index;
+            rsc_index    = ucp_ep_get_rsc_index(req->send.ep, lane);
             worker       = req->send.ep->worker;
             zcopy_thresh = ucp_ep_config_get_zcopy_auto_thresh(count,
                               &ucp_ep_md_attr(req->send.ep, lane)->reg_cost,

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1159,7 +1159,7 @@ bool ucp_test_base::entity::has_lane_with_caps(uint64_t caps) const
 
     for (lane = 0; lane < ucp_ep_config(ep)->key.num_lanes; lane++) {
         iface_attr = ucp_worker_iface_get_attr(worker,
-                                               ucp_ep_config(ep)->key.lanes[lane].rsc_index);
+                                               ucp_ep_get_rsc_index(ep, lane));
         if (ucs_test_all_flags(iface_attr->cap.flags, caps)) {
             return true;
         }


### PR DESCRIPTION
## What
use API to get ep lane rsc_index

## Why ?
better encapsulation

## How ?
use ```ucp_ep_get_rsc_index```
