### PR TITLE
UCT/BASE: Added base implementation to is_reachable_v2 API using intra/inter flag

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2110,8 +2110,7 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
     ucp_rsc_index_t rsc_index;
     ucp_address_entry_t *ae;
     ucp_lane_index_t lane;
-    ucs_status_t status;
-    void *dev_addr;
+    uct_iface_is_reachable_params_t params;
 
     if (select_params->address->uuid == worker->uuid) {
         key->flags |= UCP_EP_CONFIG_KEY_FLAG_SELF;
@@ -2142,29 +2141,25 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
             continue;
         }
 
-        dev_addr = ucs_malloc(wiface->attr.device_addr_len, "ucp_tmp_dev_addr");
-        if (dev_addr == NULL) {
-            ucs_error("failed to allocated device address of size %zu",
-                      wiface->attr.device_addr_len);
-            return UCS_ERR_NO_MEMORY;
-        }
-
-        status = uct_iface_get_device_address(wiface->iface, dev_addr);
-        if (status != UCS_OK) {
-            ucs_free(dev_addr);
-            return status;
-        }
-
         ucp_unpacked_address_for_each(ae, select_params->address) {
-            if ((wiface->attr.device_addr_len == ae->dev_addr_len) &&
-                !memcmp(ae->dev_addr, dev_addr, ae->dev_addr_len)) {
+            if ((wiface->attr.device_addr_len != ae->dev_addr_len) ||
+                (worker->context->tl_rscs[rsc_index].tl_name_csum !=
+                 ae->tl_name_csum)) {
+                continue;
+            }
+
+            params.field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                                 UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
+                                 UCT_IFACE_IS_REACHABLE_FIELD_SCOPE;
+            params.device_addr = ae->dev_addr;
+            params.iface_addr  = ae->iface_addr;
+            params.scope       = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
+
+            if (uct_iface_is_reachable_v2(wiface->iface, &params)) {
                 key->flags |= UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE;
-                ucs_free(dev_addr);
                 return UCS_OK;
             }
         }
-
-        ucs_free(dev_addr);
     }
 
     return UCS_OK;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -254,7 +254,8 @@ typedef enum {
     UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR        = UCS_BIT(0), /**< device_addr field */
     UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR         = UCS_BIT(1), /**< iface_addr field */
     UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING        = UCS_BIT(2), /**< info_string field */
-    UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING_LENGTH = UCS_BIT(3)  /**< info_string_length field */
+    UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING_LENGTH = UCS_BIT(3), /**< info_string_length field */
+    UCT_IFACE_IS_REACHABLE_FIELD_SCOPE              = UCS_BIT(4) /**<  scope field */
 } uct_iface_is_reachable_field_mask_t;
 
 
@@ -517,6 +518,20 @@ extern const char *uct_ep_operation_names[];
 
 
 /**
+ * @ingroup UCS_RESOURCE
+ * @brief Reachability scope
+ *
+ * Reachability scope. Can be one of the following values:
+ * Device scope: Checks if addresses describe the same device.
+ * Network scope: Checks reachability between different devices.
+ */
+typedef enum {
+    UCT_IFACE_REACHABILITY_SCOPE_DEVICE, /**< Local device scope */
+    UCT_IFACE_REACHABILITY_SCOPE_NETWORK /**< Network scope */
+} uct_iface_reachability_scope_t;
+
+
+/**
  * @ingroup UCT_RESOURCE
  * @brief Operation parameters passed to @ref uct_iface_is_reachable_v2.
  */
@@ -527,19 +542,19 @@ typedef struct uct_iface_is_reachable_params {
      * mask will be ignored. Provides ABI compatibility with respect to adding
      * new fields.
      */
-    uint64_t                     field_mask;
+    uint64_t                       field_mask;
 
     /**
      * Device address to check for reachability.
      * This field must not be passed if iface_attr.dev_addr_len == 0.
      */
-    const uct_device_addr_t      *device_addr;
+    const uct_device_addr_t       *device_addr;
 
     /**
      * Interface address to check for reachability.
      * This field must not be passed if iface_attr.iface_addr_len == 0.
      */
-    const uct_iface_addr_t       *iface_addr;
+    const uct_iface_addr_t        *iface_addr;
 
     /**
      * User-provided pointer to a string buffer.
@@ -547,13 +562,18 @@ typedef struct uct_iface_is_reachable_params {
      * null-terminated information string explaining why the remote address is
      * not reachable if the return value is 0.
      */
-    char                         *info_string;
+    char                          *info_string;
 
     /**
      * The length of the @a info_string is provided in bytes.
      * This value must be specified in conjunction with @a info_string.
      */
-    size_t                        info_string_length;
+    size_t                         info_string_length;
+
+    /**
+     * Reachability scope.
+     */
+    uct_iface_reachability_scope_t scope;
 } uct_iface_is_reachable_params_t;
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -255,13 +255,20 @@ typedef ucs_status_t (*uct_ep_connect_to_ep_v2_func_t)(
         const uct_ep_connect_to_ep_params_t *params);
 
 
+/* Check if remote iface address is reachable */
+typedef int (*uct_iface_is_reachable_v2_func_t)(
+        const uct_iface_h iface,
+        const uct_iface_is_reachable_params_t *params);
+
+
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
-    uct_iface_estimate_perf_func_t iface_estimate_perf;
-    uct_iface_vfs_refresh_func_t   iface_vfs_refresh;
-    uct_ep_query_func_t            ep_query;
-    uct_ep_invalidate_func_t       ep_invalidate;
-    uct_ep_connect_to_ep_v2_func_t ep_connect_to_ep_v2;
+    uct_iface_estimate_perf_func_t   iface_estimate_perf;
+    uct_iface_vfs_refresh_func_t     iface_vfs_refresh;
+    uct_ep_query_func_t              ep_query;
+    uct_ep_invalidate_func_t         ep_invalidate;
+    uct_ep_connect_to_ep_v2_func_t   ep_connect_to_ep_v2;
+    uct_iface_is_reachable_v2_func_t iface_is_reachable_v2;
 } uct_iface_internal_ops_t;
 
 
@@ -853,6 +860,10 @@ void uct_base_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
 
 ucs_status_t
 uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
+
+int
+uct_base_iface_is_reachable_v2(const uct_iface_h iface,
+                               const uct_iface_is_reachable_params_t *params);
 
 ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -388,11 +388,12 @@ static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
-    .iface_estimate_perf = uct_cuda_copy_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = uct_cuda_copy_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -468,11 +468,12 @@ static ucs_mpool_ops_t uct_cuda_ipc_event_desc_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
-    .iface_estimate_perf = uct_cuda_ipc_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = uct_cuda_ipc_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -168,11 +168,12 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
-    .iface_estimate_perf = uct_gdr_copy_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = uct_gdr_copy_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1239,11 +1239,12 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
 static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_estimate_perf = uct_dc_mlx5_iface_estimate_perf,
-            .iface_vfs_refresh   = uct_dc_mlx5_iface_vfs_refresh,
-            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-            .ep_invalidate       = uct_dc_mlx5_ep_invalidate,
-            .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+            .iface_estimate_perf   = uct_dc_mlx5_iface_estimate_perf,
+            .iface_vfs_refresh     = uct_dc_mlx5_iface_vfs_refresh,
+            .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+            .ep_invalidate         = uct_dc_mlx5_ep_invalidate,
+            .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -980,11 +980,12 @@ static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_mlx5_iface_t, uct_iface_t);
 static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_estimate_perf = uct_rc_iface_estimate_perf,
-            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh,
-            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-            .ep_invalidate       = uct_rc_mlx5_ep_invalidate,
-            .ep_connect_to_ep_v2 = uct_rc_mlx5_ep_connect_to_ep_v2
+            .iface_estimate_perf   = uct_rc_iface_estimate_perf,
+            .iface_vfs_refresh     = uct_rc_iface_vfs_refresh,
+            .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+            .ep_invalidate         = uct_rc_mlx5_ep_invalidate,
+            .ep_connect_to_ep_v2   = uct_rc_mlx5_ep_connect_to_ep_v2,
+            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -501,11 +501,12 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .super = {
         .super = {
-            .iface_estimate_perf = uct_rc_iface_estimate_perf,
-            .iface_vfs_refresh   = uct_rc_iface_vfs_refresh,
-            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-            .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-            .ep_connect_to_ep_v2 = uct_rc_verbs_ep_connect_to_ep_v2
+            .iface_estimate_perf   = uct_rc_iface_estimate_perf,
+            .iface_vfs_refresh     = uct_rc_iface_vfs_refresh,
+            .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+            .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+            .ep_connect_to_ep_v2   = uct_rc_verbs_ep_connect_to_ep_v2,
+            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -879,11 +879,12 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
-    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_unsupported,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = uct_rdmacm_ep_query,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_unsupported,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = uct_rdmacm_ep_query,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static ucs_status_t

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -825,11 +825,12 @@ static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_estimate_perf = uct_ib_iface_estimate_perf,
-            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
-            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-            .ep_invalidate       = uct_ud_ep_invalidate,
-            .ep_connect_to_ep_v2 = uct_ud_ep_connect_to_ep_v2
+            .iface_estimate_perf   = uct_ib_iface_estimate_perf,
+            .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
+            .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+            .ep_invalidate         = uct_ud_ep_invalidate,
+            .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
+            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
         },
         .create_cq      = uct_ud_mlx5_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -602,11 +602,12 @@ static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t)(uct_iface_t*);
 static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .super = {
         .super = {
-            .iface_estimate_perf = uct_ib_iface_estimate_perf,
-            .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
-            .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-            .ep_invalidate       = uct_ud_ep_invalidate,
-            .ep_connect_to_ep_v2 = uct_ud_ep_connect_to_ep_v2
+            .iface_estimate_perf   = uct_ib_iface_estimate_perf,
+            .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
+            .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+            .ep_invalidate         = uct_ud_ep_invalidate,
+            .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
+            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -220,11 +220,12 @@ uct_rocm_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 
 
 static uct_iface_internal_ops_t uct_rocm_copy_iface_internal_ops = {
-    .iface_estimate_perf = uct_rocm_copy_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = uct_rocm_copy_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -572,11 +572,12 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 }
 
 static uct_iface_internal_ops_t uct_mm_iface_internal_ops = {
-    .iface_estimate_perf = uct_mm_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = uct_mm_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static void uct_mm_iface_recv_desc_init(uct_iface_h tl_iface, void *obj,

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -114,11 +114,12 @@ static uct_iface_ops_t uct_cma_iface_tl_ops = {
 
 static uct_scopy_iface_ops_t uct_cma_iface_ops = {
     .super = {
-        .iface_estimate_perf = uct_base_iface_estimate_perf,
-        .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-        .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-        .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-        .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+        .iface_estimate_perf   = uct_base_iface_estimate_perf,
+        .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+        .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+        .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+        .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
     },
     .ep_tx = uct_cma_ep_tx,
 };

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -65,11 +65,12 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
 
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {
     .super = {
-        .iface_estimate_perf = uct_base_iface_estimate_perf,
-        .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-        .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-        .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-        .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+        .iface_estimate_perf   = uct_base_iface_estimate_perf,
+        .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+        .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+        .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+        .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+        .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
     },
     .ep_tx = uct_knem_ep_tx,
 };

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -567,11 +567,12 @@ static ucs_mpool_ops_t uct_tcp_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_tcp_iface_internal_ops = {
-    .iface_estimate_perf = uct_base_iface_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = uct_tcp_ep_connect_to_ep_v2
+    .iface_estimate_perf   = uct_base_iface_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = uct_tcp_ep_connect_to_ep_v2,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -194,11 +194,12 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {
-    .iface_estimate_perf = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_unsupported,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = uct_tcp_sockcm_ep_query,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = ucs_empty_function_return_unsupported
+    .iface_estimate_perf   = (uct_iface_estimate_perf_func_t)ucs_empty_function_return_unsupported,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = uct_tcp_sockcm_ep_query,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 UCS_CLASS_INIT_FUNC(uct_tcp_sockcm_t, uct_component_h component,

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -268,11 +268,12 @@ static ucs_mpool_ops_t uct_ugni_smsg_mbox_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_ugni_smsg_iface_internal_ops = {
-    .iface_estimate_perf = uct_base_iface_estimate_perf,
-    .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query            = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate       = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2 = uct_ugni_smsg_ep_connect_to_ep_v2
+    .iface_estimate_perf   = uct_base_iface_estimate_perf,
+    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = uct_ugni_smsg_ep_connect_to_ep_v2,
+    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h worker,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1498,10 +1498,10 @@ protected:
                             fail_injection);
         } else if (fail_wireup_type == FAIL_WIREUP_MSG_ADDR_PACK) {
             /* Emulate failure of preparation of WIREUP MSG sending by setting
-             * the device address getter to the function that always returns
+             * the iface address getter to the function that always returns
              * error */
-            iface->ops.iface_get_device_address =
-                    reinterpret_cast<uct_iface_get_device_address_func_t>(
+            iface->ops.iface_get_address =
+                    reinterpret_cast<uct_iface_get_address_func_t>(
                             fail_injection);
         }
     }


### PR DESCRIPTION
## What
Added base implementation to is_reachable_v2 API using intra/inter flag.

## Why ?
Support identifying intra/inter node communications.