### PR TITLE
UCT/RDMACM: reuse reserved qpn for connection management

### DIFF
--- a/buildlib/pr/io_demo/az-stage-io-demo.yaml
+++ b/buildlib/pr/io_demo/az-stage-io-demo.yaml
@@ -17,6 +17,8 @@ parameters:
   default: ''
 - name: interference
   default: 'Yes'
+- name: active_disconnect
+  default: 'No'
 - name: extra_run_args
   default: ''
 
@@ -111,6 +113,9 @@ steps:
     analyzer_args="$analyzer_args -t 3"
     if [ '${{ parameters.interference }}' == 'No' ] ; then
       analyzer_args="$analyzer_args --no-allow-list"
+    fi
+    if [ '${{ parameters.active_disconnect}}' == 'Yes' ] ; then
+      analyzer_args="$analyzer_args --allow-active-disconnect"
     fi
     analyzer_args="$analyzer_args ${{ parameters.analyzer_allow_list_args }}"
     python ${analyzer} ${analyzer_args}

--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -100,3 +100,9 @@ jobs:
           tls: "rc_x"
           test_name: am_cx6_num_path
           extra_run_args: "--env client UCX_IB_NUM_PATHS=1 --env server UCX_IB_NUM_PATHS=2"
+        "Reuse reserved qpn in rdmacm CM":
+          interface: $(roce_iface_cx6)
+          active_disconnect: 'Yes'
+          tls: "rc_x"
+          test_name: rdmacm_reuse_qpn
+          extra_run_args: "--tasks-per-node 2 --num-clients 2 --env server UCX_RDMA_CM_REUSE_QPN=ON --client_exit_times 10s,20s"

--- a/buildlib/pr/io_demo/jobs-io-demo.yaml
+++ b/buildlib/pr/io_demo/jobs-io-demo.yaml
@@ -23,6 +23,9 @@ parameters:
   - name: uptime
     type: number
     default: 180
+  - name: active_disconnect
+    type: string
+    default: 'No'
   - name: tests
     type: object
     default: []
@@ -52,6 +55,7 @@ jobs:
             test_extra_run_args: ${{ test.Value.extra_run_args }}
             initial_delay: ${{ coalesce(test.Value.initial_delay, parameters.initial_delay) }}
             test_interference: ${{ parameters.interference }}
+            test_active_disconnect: ${{ test.Value.active_disconnect }}
             test_with_ece: ${{ coalesce(test.Value.ece, parameters.ece) }}
       maxParallel: 1
 
@@ -81,6 +85,7 @@ jobs:
           iodemo_tls: $(test_ucx_tls)
           initial_delay: $(initial_delay)
           interference: $(test_interference)
+          active_disconnect: $(test_active_disconnect)
           extra_run_args: $(test_extra_run_args)
           ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
             analyzer_allow_list_args: '--allow_list $(System.PullRequest.TargetBranch)'

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -206,9 +206,19 @@ static void
 uct_rdmacm_cm_device_context_cleanup(uct_rdmacm_cm_device_context_t *ctx)
 {
     uct_rdmacm_cm_reserved_qpn_blk_t *blk, *tmp;
+    uct_rdmacm_cm_peer_dev_ctx_t *peer_dev_ctx;
     int ret;
 
     if (ctx->use_reserved_qpn) {
+        if (ctx->reuse_qpn) {
+            kh_foreach_value(&ctx->peer_dev_ctxs, peer_dev_ctx, {
+                ucs_free(peer_dev_ctx);
+            });
+
+            kh_destroy_inplace(uct_rdmacm_cm_peer_dev_ctxs,
+                               &ctx->peer_dev_ctxs);
+        }
+
         /* There can be some blks are not fully used, then they won't be
            destroyed in RDMACM CM EP, so need to be destroyed here. */
         ucs_list_for_each_safe(blk, tmp, &ctx->blk_list, entry) {

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -314,18 +314,18 @@ uct_rdmacm_cm_get_peer_dev_ctx(uct_rdmacm_cm_device_context_t *ctx,
     uct_rdmacm_cm_peer_dev_ctx_t *peer_dev_ctx;
     ucs_status_t status;
     khiter_t iter;
-    int ret;
+    ucs_kh_put_t ret;
 
     iter = kh_put(uct_rdmacm_cm_peer_dev_ctxs, &ctx->peer_dev_ctxs,
                   uct_rdmacm_cm_route_get_peer_interface_id(route), &ret);
-    if (ret == -1) {
+    if (ret == UCS_KH_PUT_FAILED) {
         ucs_error("ctx %p: cannot allocate hash entry for peer device context",
                   ctx);
         status = UCS_ERR_NO_MEMORY;
         goto out;
     }
 
-    if (ret == 0) {
+    if (ret == UCS_KH_PUT_KEY_PRESENT) {
         /* already exists so use it */
         peer_dev_ctx = kh_value(&ctx->peer_dev_ctxs, iter);
     } else {

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -171,6 +171,10 @@ uct_rdmacm_cm_device_context_init(uct_rdmacm_cm_device_context_t *ctx,
     ctx->use_reserved_qpn = 1;
     ctx->reuse_qpn        = cm->config.reuse_qpn;
 
+    if (ctx->reuse_qpn) {
+        kh_init_inplace(uct_rdmacm_cm_peer_dev_ctxs, &ctx->peer_dev_ctxs);
+    }
+
     ucs_spinlock_init(&ctx->lock, 0);
     ucs_list_head_init(&ctx->blk_list);
     return UCS_OK;

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -126,6 +126,11 @@ ucs_status_t uct_rdmacm_cm_get_device_context(uct_rdmacm_cm_t *cm,
                                               uct_rdmacm_cm_device_context_t **ctx_p);
 
 ucs_status_t
+uct_rdmacm_cm_get_peer_dev_ctx(uct_rdmacm_cm_device_context_t *ctx,
+                               const struct rdma_route *route,
+                               uct_rdmacm_cm_peer_dev_ctx_t **peer_dev_ctx_p);
+
+ucs_status_t
 uct_rdmacm_cm_reserved_qpn_blk_alloc(uct_rdmacm_cm_device_context_t *ctx,
                                      struct ibv_context *verbs,
                                      ucs_log_level_t err_level,

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -20,6 +20,7 @@
 
 
 KHASH_MAP_INIT_INT64(uct_rdmacm_cm_device_contexts, struct uct_rdmacm_cm_device_context*);
+KHASH_MAP_INIT_INT64(uct_rdmacm_cm_peer_dev_ctxs, struct uct_rdmacm_cm_peer_dev_ctx*);
 
 
 #define UCT_RDMACM_TCP_PRIV_DATA_LEN            56    /** See rdma_connect(3) */
@@ -81,7 +82,14 @@ typedef struct uct_rdmacm_cm_device_context {
     uint32_t        num_dummy_qps;
     struct ibv_cq   *cq;
     uint8_t         eth_ports;
+    khash_t(uct_rdmacm_cm_peer_dev_ctxs) peer_dev_ctxs;
 } uct_rdmacm_cm_device_context_t;
+
+
+typedef struct uct_rdmacm_cm_peer_dev_ctx {
+    uct_rdmacm_cm_reserved_qpn_blk_t *ref_qpn_blk;
+    uint32_t                         next_avail_qpn_offset;
+} uct_rdmacm_cm_peer_dev_ctx_t;
 
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rdmacm_cm_t, uct_cm_t, uct_component_h,

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -46,6 +46,7 @@ typedef struct uct_rdmacm_cm {
         struct sockaddr                    *src_addr;
         double                             timeout;
         ucs_ternary_auto_value_t           reserved_qpn;
+        int                                reuse_qpn;
     } config;
 } uct_rdmacm_cm_t;
 
@@ -55,6 +56,7 @@ typedef struct uct_rdmacm_cm_config {
     char                     *src_addr;
     double                   timeout;
     ucs_ternary_auto_value_t reserved_qpn;
+    int                      reuse_qpn;
 } uct_rdmacm_cm_config_t;
 
 
@@ -72,6 +74,7 @@ typedef struct uct_rdmacm_cm_reserved_qpn_blk {
 
 typedef struct uct_rdmacm_cm_device_context {
     int             use_reserved_qpn;
+    int             reuse_qpn;
     ucs_spinlock_t  lock;                         /** Avoid competed condition on the qpn resource for multi-threads */
     ucs_list_link_t blk_list;
     uint32_t        log_reserved_qpn_granularity;

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -263,7 +263,7 @@ uct_rdmacm_cm_ep_create_reserved_qpn(uct_rdmacm_cm_ep_t *cep,
                                      uct_rdmacm_cm_device_context_t *ctx)
 {
     uint32_t qpns_per_obj                      =
-        UCS_BIT(ctx->log_reserved_qpn_granularity);
+            UCS_BIT(ctx->log_reserved_qpn_granularity);
     uct_rdmacm_cm_peer_dev_ctx_t *peer_dev_ctx = NULL;
     uct_rdmacm_cm_reserved_qpn_blk_t *blk;
     ucs_status_t status;
@@ -290,6 +290,7 @@ uct_rdmacm_cm_ep_create_reserved_qpn(uct_rdmacm_cm_ep_t *cep,
             if (peer_dev_ctx->ref_qpn_blk->entry.next == &ctx->blk_list) {
                 RDMACM_CM_RESERVE_QPN_BLK(ctx, cep, status, blk, { goto out; });
             }
+
             blk                                 = ucs_list_next(&peer_dev_ctx->ref_qpn_blk->entry,
                                                                 uct_rdmacm_cm_reserved_qpn_blk_t, entry);
             peer_dev_ctx->ref_qpn_blk           = blk;

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -242,9 +242,18 @@ uct_rdmacm_cm_ep_create_reserved_qpn(uct_rdmacm_cm_ep_t *cep,
 {
     uint32_t qpns_per_obj = UCS_BIT(ctx->log_reserved_qpn_granularity);
     uct_rdmacm_cm_reserved_qpn_blk_t *blk;
+    uct_rdmacm_cm_peer_dev_ctx_t *peer_dev_ctx;
     ucs_status_t status;
 
     ucs_spin_lock(&ctx->lock);
+
+    if (ctx->reuse_qpn) {
+        status = uct_rdmacm_cm_get_peer_dev_ctx(ctx, &cep->id->route,
+                                                &peer_dev_ctx);
+        if (status != UCS_OK) {
+            goto out;
+        }
+    }
 
     blk = ucs_list_tail(&ctx->blk_list, uct_rdmacm_cm_reserved_qpn_blk_t, entry);
     if (ucs_list_is_empty(&ctx->blk_list) ||

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -262,9 +262,10 @@ static ucs_status_t
 uct_rdmacm_cm_ep_create_reserved_qpn(uct_rdmacm_cm_ep_t *cep,
                                      uct_rdmacm_cm_device_context_t *ctx)
 {
-    uint32_t qpns_per_obj = UCS_BIT(ctx->log_reserved_qpn_granularity);
+    uint32_t qpns_per_obj                      =
+        UCS_BIT(ctx->log_reserved_qpn_granularity);
+    uct_rdmacm_cm_peer_dev_ctx_t *peer_dev_ctx = NULL;
     uct_rdmacm_cm_reserved_qpn_blk_t *blk;
-    uct_rdmacm_cm_peer_dev_ctx_t *peer_dev_ctx;
     ucs_status_t status;
 
     ucs_spin_lock(&ctx->lock);
@@ -305,6 +306,7 @@ uct_rdmacm_cm_ep_create_reserved_qpn(uct_rdmacm_cm_ep_t *cep,
     }
 
     if (ctx->reuse_qpn) {
+        ucs_assert(peer_dev_ctx != NULL);
         cep->qpn                   = blk->first_qpn +
                                      peer_dev_ctx->next_avail_qpn_offset++;
         blk->next_avail_qpn_offset = ucs_max(blk->next_avail_qpn_offset,

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -262,8 +262,9 @@ uct_rdmacm_cm_device_ctx_get_shared_qpn(uct_rdmacm_cm_ep_t *cep,
     }
 
     if (peer_dev_ctx->ref_qpn_blk == NULL) {
-        blk                                 = ucs_list_next(&ctx->blk_list,
-                                                            uct_rdmacm_cm_reserved_qpn_blk_t, entry);
+        blk = ucs_list_next(&ctx->blk_list,
+                            uct_rdmacm_cm_reserved_qpn_blk_t, entry);
+
         peer_dev_ctx->ref_qpn_blk           = blk;
         peer_dev_ctx->next_avail_qpn_offset = 0;
     } else if (peer_dev_ctx->next_avail_qpn_offset >= qpns_per_obj) {
@@ -274,8 +275,9 @@ uct_rdmacm_cm_device_ctx_get_shared_qpn(uct_rdmacm_cm_ep_t *cep,
             }
         }
 
-        blk                                 = ucs_list_next(&peer_dev_ctx->ref_qpn_blk->entry,
-                                                            uct_rdmacm_cm_reserved_qpn_blk_t, entry);
+        blk = ucs_list_next(&peer_dev_ctx->ref_qpn_blk->entry,
+                            uct_rdmacm_cm_reserved_qpn_blk_t, entry);
+
         peer_dev_ctx->ref_qpn_blk           = blk;
         peer_dev_ctx->next_avail_qpn_offset = 0;
     } else {

--- a/src/uct/ib/rdmacm/rdmacm_component.c
+++ b/src/uct/ib/rdmacm/rdmacm_component.c
@@ -32,7 +32,8 @@ static ucs_config_field_t uct_rdmacm_cm_config_table[] = {
                   UCS_CONFIG_TYPE_TERNARY},
 
     {"REUSE_QPN", "no",
-     "Reuse reserved QPN for connection management:\n"
+     "Reuse reserved QPN for connection management, the parameter can be "
+     "enabled only if reserved qpn mode is used:\n"
      "  no  - Do not reuse qpn for connection management\n"
      "  yes - Reuse qpn for connection management",
      ucs_offsetof(uct_rdmacm_cm_config_t, reuse_qpn), UCS_CONFIG_TYPE_ON_OFF},

--- a/src/uct/ib/rdmacm/rdmacm_component.c
+++ b/src/uct/ib/rdmacm/rdmacm_component.c
@@ -31,6 +31,12 @@ static ucs_config_field_t uct_rdmacm_cm_config_table[] = {
      ucs_offsetof(uct_rdmacm_cm_config_t, reserved_qpn),
                   UCS_CONFIG_TYPE_TERNARY},
 
+    {"REUSE_QPN", "no",
+     "Reuse reserved QPN for connection management:\n"
+     "  no  - Do not reuse qpn for connection management\n"
+     "  yes - Reuse qpn for connection management",
+     ucs_offsetof(uct_rdmacm_cm_config_t, reuse_qpn), UCS_CONFIG_TYPE_ON_OFF},
+
     {NULL}
 };
 


### PR DESCRIPTION
The design is based on the assumption that one guid is bound with one ip for RoCEv2.
This design follows the existed UCX logic: do not used staled unused qpn per dgid::interface_id.
This feature could be only enabled when using reserved_qpn feature.

## What
1. Add ```UCX_RDMA_CM_REUSE_QPN=ON/OFF``` option to enable/disable reusing QPN for connection management.
    The default configuration is ```UCX_RDMA_CM_REUSE_QPN=OFF```, i.e. do not  reuse same QPN for connection management.
2. Implement function to reuse QPN for connection management.
    Use ```UCX_RDMA_CM_REUSE_QPN=ON``` to turn on using this feature.

## Why ?
1. QPs are limited resources in RNIC HCA.
2. It needs to use QPN in rdmacm for connection management.
4. The existed function is to use different QPN for connection management for different remote devices.
5. While establishing huge connections, QPs maybe not enough for connection management.
6. <QPN, guid> could be used to identify different connections, so it's able to use same QPN for different GUID devices for connection management.
7. In RoCEv2, this PR assumes that different GUIDs are bond with different IP(gid::interface_id) address.
8. In application running environment, if the ```7th``` assumption is not true, please do not use ```UCX_RDMA_CM_USE_SAME_QPN=ON``` to turn on using this feature.

## How ?
For every uct_rdmacm_cm_device_context, record the current reserved_qpn block that is used to allocate the reserved qpn to connect/disconnect with the peer device(differentiated by dgid::interface_id), allocate qpn from that block for connection management.
