### PR TITLE
UCP/CORE: Wake up UCT iface on send completion event.

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -22,8 +22,6 @@
 #include <inttypes.h>
 
 #define UCP_WIREUP_RMA_BW_TEST_MSG_SIZE    262144
-#define UCP_WIREUP_UCT_EVENT_CAP_FLAGS     (UCT_IFACE_FLAG_EVENT_SEND_COMP | \
-                                            UCT_IFACE_FLAG_EVENT_RECV)
 #define UCP_WIREUP_MAX_FLAGS_STRING_SIZE   50
 #define UCP_WIREUP_PATH_INDEX_UNDEFINED    UINT_MAX
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -32,6 +32,10 @@ typedef struct {
 #define UCP_WIREUP_EMPTY_PEER_NAME  "<no debug data>"
 
 
+#define UCP_WIREUP_UCT_EVENT_CAP_FLAGS \
+    (UCT_IFACE_FLAG_EVENT_SEND_COMP | UCT_IFACE_FLAG_EVENT_RECV)
+
+
 /**
  * Wireup message types
  */


### PR DESCRIPTION
## What
Added send completion event to list of events on which the UCT interface should wake up.

## Why ?
The example of the possible issue is in RC wire up procedure. RC uses UD to establish connection. However, the last message in wire up messaging is acknowledge reply, which is sent using RC. If RC interface's progress isn't enabled, and events are being checked, the RC interface can wake up only on send completion event.
