### PR TITLE
UCT/ROCM: move memh caches to iface

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -30,25 +30,14 @@
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_ep_t, const uct_ep_params_t *params)
 {
     uct_rocm_copy_iface_t *iface = ucs_derived_of(params->iface, uct_rocm_copy_iface_t);
-    char target_name[64];
-    ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
 
-    snprintf(target_name, sizeof(target_name), "dest:%d",
-             *(pid_t*)params->iface_addr);
-    status = uct_rocm_copy_create_cache(&self->local_memh_cache, target_name);
-    if (status != UCS_OK) {
-        ucs_error("could not create create rocm copy cache: %s",
-                  ucs_status_string(status));
-    }
-
-    return status;
+    return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rocm_copy_ep_t)
 {
-    uct_rocm_copy_destroy_cache(self->local_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_copy_ep_t, uct_base_ep_t)
@@ -60,11 +49,11 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_copy_ep_t, uct_ep_t);
                     (_rkey))
 
 static void *
-uct_rocm_copy_get_mapped_host_ptr(uct_ep_h tl_ep, void *ptr, size_t size,
+uct_rocm_copy_get_mapped_host_ptr(uct_rocm_copy_iface_t *iface, void *ptr,
+                                  size_t size,
                                   uct_rocm_copy_key_t *rocm_copy_key)
 {
-    uct_rocm_copy_ep_t *ep = ucs_derived_of(tl_ep, uct_rocm_copy_ep_t);
-    size_t offset          = 0;
+    size_t offset = 0;
     void *mapped_ptr;
     ucs_status_t status;
 
@@ -72,7 +61,7 @@ uct_rocm_copy_get_mapped_host_ptr(uct_ep_h tl_ep, void *ptr, size_t size,
         (((void*)rocm_copy_key->vaddr == rocm_copy_key->dev_ptr) &&
          ((void*)rocm_copy_key->vaddr != ptr))) {
         /* key contains rocm address information. Need to lock host address first */
-        status = uct_rocm_copy_cache_map_memhandle(ep->local_memh_cache,
+        status = uct_rocm_copy_cache_map_memhandle(iface->local_memh_cache,
                                                    (uint64_t)ptr, size,
                                                    &mapped_ptr);
         if ((status != UCS_OK) || (mapped_ptr == NULL)) {
@@ -131,7 +120,7 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
         remote_addr_mod     = dev_address;
     } else {
         remote_addr_is_host = 1;
-        remote_addr_mod     = uct_rocm_copy_get_mapped_host_ptr(tl_ep,
+        remote_addr_mod     = uct_rocm_copy_get_mapped_host_ptr(iface,
                                                                 (void*)remote_addr,
                                                                 size,
                                                                 rocm_copy_key);
@@ -164,7 +153,7 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
         iov_buffer_mod     = dev_address;
     } else {
         iov_buffer_is_host = 1;
-        iov_buffer_mod = uct_rocm_copy_get_mapped_host_ptr(tl_ep, iov->buffer,
+        iov_buffer_mod = uct_rocm_copy_get_mapped_host_ptr(iface, iov->buffer,
                                                            size, NULL);
         if (iov_buffer_mod == NULL) {
             ucs_error("failed to map host pointer %p to device address",

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -9,6 +9,7 @@
 #include <uct/base/uct_iface.h>
 
 #include <hsa.h>
+#include "rocm_copy_cache.h"
 
 #define UCT_ROCM_COPY_TL_NAME    "rocm_cpy"
 
@@ -19,6 +20,7 @@ typedef struct uct_rocm_copy_iface {
     uct_rocm_copy_iface_addr_t  id;
     ucs_mpool_t                 signal_pool;
     ucs_queue_head_t            signal_queue;
+    uct_rocm_copy_cache_t       *local_memh_cache;
     struct {
         size_t                  d2h_thresh;
         size_t                  h2d_thresh;

--- a/src/uct/rocm/ipc/rocm_ipc_ep.c
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.c
@@ -20,27 +20,16 @@
 static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_ep_t, const uct_ep_params_t *params)
 {
     uct_rocm_ipc_iface_t *iface = ucs_derived_of(params->iface, uct_rocm_ipc_iface_t);
-    char target_name[64];
-    ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
 
     self->remote_pid = *(const pid_t*)params->iface_addr;
-
-    snprintf(target_name, sizeof(target_name), "dest:%d", *(pid_t*)params->iface_addr);
-    status = uct_rocm_ipc_create_cache(&self->remote_memh_cache, target_name);
-    if (status != UCS_OK) {
-        ucs_error("could not create create rocm ipc cache: %s",
-                  ucs_status_string(status));
-        return status;
-    }
 
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rocm_ipc_ep_t)
 {
-    uct_rocm_ipc_destroy_cache(self->remote_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_ipc_ep_t, uct_base_ep_t);
@@ -58,14 +47,14 @@ ucs_status_t uct_rocm_ipc_ep_zcopy(uct_ep_h tl_ep,
                                    uct_completion_t *comp,
                                    int is_put)
 {
-    uct_rocm_ipc_ep_t *ep = ucs_derived_of(tl_ep, uct_rocm_ipc_ep_t);
+    uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                 uct_rocm_ipc_iface_t);
     hsa_status_t status;
     hsa_agent_t local_agent, remote_agent;
     hsa_agent_t dst_agent, src_agent;
     size_t size = uct_iov_get_length(iov);
     ucs_status_t ret = UCS_OK;
     void *base_addr, *local_addr = iov->buffer;
-    uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_ipc_iface_t);
     void *remote_base_addr, *remote_copy_addr;
     void *dst_addr, *src_addr;
     uct_rocm_base_signal_desc_t *rocm_ipc_signal;
@@ -94,7 +83,7 @@ ucs_status_t uct_rocm_ipc_ep_zcopy(uct_ep_h tl_ep,
         return UCS_ERR_INVALID_ADDR;
     }
 
-    ret = uct_rocm_ipc_cache_map_memhandle((void *)ep->remote_memh_cache, key,
+    ret = uct_rocm_ipc_cache_map_memhandle((void*)iface->remote_memh_cache, key,
                                            &remote_base_addr);
     if (ret != UCS_OK) {
         ucs_error("fail to attach ipc mem %p %d\n", (void *)key->address, ret);

--- a/src/uct/rocm/ipc/rocm_ipc_ep.h
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.h
@@ -15,7 +15,6 @@
 typedef struct uct_rocm_ipc_ep {
     uct_base_ep_t   super;
     pid_t           remote_pid;
-    uct_rocm_ipc_cache_t *remote_memh_cache;
 } uct_rocm_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rocm_ipc_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -161,6 +161,7 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 {
     ucs_status_t status;
     ucs_mpool_params_t mp_params;
+    char target_name[64];
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_ipc_iface_ops, 
                               &uct_base_iface_internal_ops,
@@ -182,6 +183,14 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 
     ucs_queue_head_init(&self->signal_queue);
 
+    ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%d", getpid());
+    status = uct_rocm_ipc_create_cache(&self->remote_memh_cache, target_name);
+    if (status != UCS_OK) {
+        ucs_error("could not create create rocm ipc cache: %s",
+                  ucs_status_string(status));
+        return status;
+    }
+
     return UCS_OK;
 }
 
@@ -191,6 +200,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rocm_ipc_iface_t)
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
     ucs_mpool_cleanup(&self->signal_pool, 1);
+    uct_rocm_ipc_destroy_cache(self->remote_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_ipc_iface_t, uct_base_iface_t);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -8,6 +8,7 @@
 #define ROCM_IPC_IFACE_H
 
 #include <uct/base/uct_iface.h>
+#include "rocm_ipc_cache.h"
 
 #include <hsa.h>
 
@@ -17,6 +18,7 @@ typedef struct uct_rocm_ipc_iface {
     uct_base_iface_t super;
     ucs_mpool_t signal_pool;
     ucs_queue_head_t signal_queue;
+    uct_rocm_ipc_cache_t *remote_memh_cache;
 } uct_rocm_ipc_iface_t;
 
 typedef struct uct_rocm_ipc_iface_config {


### PR DESCRIPTION
## What
move the memhandle caches from the endpoint to the iface structures. 

## Why ?
Improves scalability and reduces memory footprint
