### PR TITLE
BUILDLIB: PR on instict01 after re-install

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -133,6 +133,7 @@ function az_module_unload() {
 #
 # try load cuda modules if nvidia driver is installed
 #
+
 try_load_cuda_env() {
     num_gpus=0
     have_cuda=no

--- a/buildlib/pr/distro.yml
+++ b/buildlib/pr/distro.yml
@@ -52,7 +52,7 @@ jobs:
     pool:
       name: MLNX
       demands:
-      - ucx_docker -equals yes
+      - ucx_dummy -equals yes
     strategy:
       matrix:
         ubuntu20:


### PR DESCRIPTION
## What
Dummy pr for new azure agent node after re-installation of OS

## Why ?


## How ?
changing in buildlib/pr/distro.yaml to instict01 capabilities 
