### PR TITLE
AZP: Add workspace cleanup for gtest and jucx tests

### DIFF
--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -4,7 +4,9 @@ parameters:
 
 jobs:
   - job: ${{ parameters.name }}
-
+    workspace:
+      clean: all
+      
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}

--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -4,6 +4,8 @@ parameters:
 
 jobs:
   - job: ${{ parameters.name }}
+    workspace:
+      clean: all
 
     pool:
       name: MLNX


### PR DESCRIPTION
## What
Clean up the workspace before running tests.

## Why ?
CI hosts suffer from repeated disk space exhaustion due to gtest files piling up.
