### PR TITLE
AZP: Remove duplicate resource definition

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -138,9 +138,6 @@ resources:
     - container: ubuntu20_cuda_11_6
       image: nvidia/cuda:11.6.0-devel-ubuntu20.04
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos7_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5-cuda11:1
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: centos8_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:1
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)


### PR DESCRIPTION
## What
Container `centos7_cuda11` was defined twice.
The one removed was never actually used.

## Why ?
Clean up to prevent future confusion.
