### PR TITLE
AZP: Pull images from private registry

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -154,7 +154,7 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:1
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: ubuntu2004_rocm_5_4_0
-      image: registry.hub.docker.com/rocm/ucx:rocm-5.4.0
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2004:rocm_5_4_0
       options: $(DOCKER_OPT_ARGS)
 
 stages:


### PR DESCRIPTION
## What
Move a container image to the private registry.

## Why ?
Pulling from DockerHub by automation is highly discouraged.
We have hit the limit and have been blocked before.
