### PR TITLE
CI/AZP: do not build unrelated module in io_demo test cases

### DIFF
--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -20,7 +20,7 @@ jobs:
       - bash: |
           set -eEx
           ./autogen.sh
-          ./contrib/configure-devel --prefix=$(Build.Repository.LocalPath)/install
+          ./contrib/configure-devel --prefix=$(Build.Repository.LocalPath)/install --without-go --without-java --disable-gtest --disable-examples
           make -j`nproc`
           make install
         displayName: Build


### PR DESCRIPTION
## What
Do not build unrelated modules that are not needed to do io_demo test cases.

## Why ?
CI test cases are time consuming process. 
1. For the gtest TCs & examples TCs & java bind TCs & go bind TCs, they've already covered by other test cases.
2. io_demo TCs do not depend on these modules at all.
