### PR TITLE
UCX/CLANG_FORMAT: set AlignTrailingComments to true, to meet standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AlignAfterOpenBracket: true
 AlignOperands: true
 PointerAlignment: Right
 DerivePointerAlignment: false
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false


### PR DESCRIPTION
## Why?
To meet the project standard of comment style, aligned at the end of the line

