### PR TITLE
UCT/RDMACM: Shorten 'uct_rdmacm_priv_data_hdr_t' header to 1 byte

### DIFF
--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -30,7 +30,6 @@ KHASH_MAP_INIT_INT64(uct_rdmacm_cm_device_contexts, struct uct_rdmacm_cm_device_
 
 typedef struct uct_rdmacm_priv_data_hdr {
     uint8_t length;     /* length of the private data */
-    uint8_t status;
 } uct_rdmacm_priv_data_hdr_t;
 
 
@@ -123,4 +122,32 @@ uct_rdmacm_cm_reserved_qpn_blk_alloc(uct_rdmacm_cm_device_context_t *ctx,
 void uct_rdmacm_cm_reserved_qpn_blk_release(
         uct_rdmacm_cm_reserved_qpn_blk_t *blk);
 
+#define RDMACM_HDR_REJECT_BIT 7
+
+static UCS_F_ALWAYS_INLINE uint8_t
+uct_rdmacm_hdr_get_length(const uct_rdmacm_priv_data_hdr_t *hdr)
+{
+    return hdr->length & UCS_MASK(RDMACM_HDR_REJECT_BIT);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rdmacm_hdr_get_status(const uct_rdmacm_priv_data_hdr_t *hdr)
+{
+    if (hdr->length & UCS_BIT(RDMACM_HDR_REJECT_BIT)) {
+        return UCS_ERR_REJECTED;
+    }
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rdmacm_hdr_set_length(uct_rdmacm_priv_data_hdr_t *hdr, uint8_t length)
+{
+    hdr->length = length;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rdmacm_hdr_set_reject(uct_rdmacm_priv_data_hdr_t *hdr)
+{
+    hdr->length = UCS_BIT(RDMACM_HDR_REJECT_BIT);
+}
 #endif

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -653,8 +653,11 @@ uct_rdmacm_cm_ep_send_priv_data(uct_rdmacm_cm_ep_t *cep, const void *priv_data,
     conn_param.private_data_len = sizeof(*hdr) + priv_data_length;
 
     hdr         = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
-    hdr->status = UCS_OK;
-    hdr->length = priv_data_length;
+    uct_rdmacm_hdr_set_length(hdr, priv_data_length);
+
+    ucs_assertv(uct_rdmacm_hdr_get_status(hdr) == UCS_OK, "hdr status: %s",
+                ucs_status_string(uct_rdmacm_hdr_get_status(hdr)));
+
     if (priv_data != NULL) {
         memcpy(hdr + 1, priv_data, priv_data_length);
     }

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -650,16 +650,18 @@ uct_rdmacm_cm_ep_send_priv_data(uct_rdmacm_cm_ep_t *cep, const void *priv_data,
     }
 
     conn_param.private_data     = ucs_alloca(UCT_RDMACM_TCP_PRIV_DATA_LEN);
-    conn_param.private_data_len = sizeof(*hdr) + priv_data_length;
 
     hdr         = (uct_rdmacm_priv_data_hdr_t*)conn_param.private_data;
     uct_rdmacm_hdr_set_length(hdr, priv_data_length);
+
+    conn_param.private_data_len = uct_rdmacm_hdr_get_hdr_size(hdr) +
+        priv_data_length;
 
     ucs_assertv(uct_rdmacm_hdr_get_status(hdr) == UCS_OK, "hdr status: %s",
                 ucs_status_string(uct_rdmacm_hdr_get_status(hdr)));
 
     if (priv_data != NULL) {
-        memcpy(hdr + 1, priv_data, priv_data_length);
+        memcpy(uct_rdmacm_hdr_get_data(hdr), priv_data, priv_data_length);
     }
 
     if (cep->flags & UCT_RDMACM_CM_EP_ON_CLIENT) {


### PR DESCRIPTION
## What
Suggestion for an unblocking fix before longer term solution.

## Why ?
Add one more byte to `rdmacm` private data supported size by shrinking its header. Use that shorter header only when needed to break compatibility in a more targeted way.

## How ?
Only shrink header if absolutely needed. That way compatibility is only broken when interacting with old server.
Activation flags could be added a rdmacm ep create to selectively enable it.