### PR TITLE
UCP/PROTO: Activate wiface only for selected lanes.

### DIFF
--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -131,6 +131,7 @@ void ucp_proto_default_query(const ucp_proto_query_params_t *params,
 
     attr->max_msg_length = SIZE_MAX;
     attr->is_estimation  = 0;
+    attr->lane_map       = 0;
     ucs_strncpy_safe(attr->desc, params->proto->desc, sizeof(attr->desc));
     ucs_strncpy_safe(attr->config, "", sizeof(attr->config));
 }

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -231,6 +231,9 @@ typedef struct {
 
     /* Protocol configuration in the range, such as devices and transports */
     char   config[UCP_PROTO_CONFIG_STR_MAX];
+
+    /* Map of used lanes */
+    ucp_lane_map_t lane_map;
 } ucp_proto_query_attr_t;
 
 

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -235,12 +235,12 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
 
         proto_valid = ucp_proto_select_elem_query(worker, select_elem,
                                                   range_start, &proto_attr);
-        range_end   = proto_attr.max_msg_length;
         if (!proto_valid) {
-            continue;
+            break;
         }
 
-        row_elem = ucs_array_append(ucp_proto_info_table, &table, break);
+        range_end = proto_attr.max_msg_length;
+        row_elem  = ucs_array_append(ucp_proto_info_table, &table, break);
 
         ucs_snprintf_safe(row_elem->desc, sizeof(row_elem->desc), "%s%s",
                           proto_attr.is_estimation ? "(?) " : "",

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -311,6 +311,7 @@ void ucp_proto_multi_query_config(const ucp_proto_query_params_t *params,
     }
 
     ucs_string_buffer_rtrim(&strb, NULL);
+    attr->lane_map = mpriv->lane_map;
 }
 
 void ucp_proto_multi_query(const ucp_proto_query_params_t *params,

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -556,6 +556,58 @@ err:
     return status;
 }
 
+/**
+ * Get map of lanes used in the selected protocols.
+ */
+static ucp_lane_map_t
+ucp_proto_select_get_lane_map(ucp_worker_h worker,
+                              const ucp_proto_select_elem_t *select_elem)
+{
+    ucp_lane_map_t lane_map = 0;
+    size_t range_start, range_end;
+    ucp_proto_query_attr_t query_attr;
+
+    range_end = -1;
+    do {
+        range_start = range_end + 1;
+        if (!ucp_proto_select_elem_query(worker, select_elem, range_start,
+                                         &query_attr)) {
+            break;
+        }
+
+        range_end = query_attr.max_msg_length;
+        lane_map |= query_attr.lane_map;
+    } while (range_end != SIZE_MAX);
+
+    return lane_map;
+}
+
+/**
+ * Activate UCP worker interfaces corresponding to the resources of lanes used
+ * in the selected protocols.
+ */
+static void
+ucp_proto_select_wiface_activate(ucp_worker_h worker,
+                                 const ucp_proto_select_elem_t *select_elem,
+                                 ucp_worker_cfg_index_t ep_cfg_index)
+{
+    ucp_lane_map_t lane_map;
+    ucp_ep_config_key_t *ep_config_key;
+    ucp_lane_index_t lane;
+    ucp_rsc_index_t rsc_index;
+    ucp_worker_iface_t *wiface;
+
+    lane_map      = ucp_proto_select_get_lane_map(worker, select_elem);
+    ep_config_key = &ucs_array_elem(&worker->ep_config, ep_cfg_index).key;
+    ucs_for_each_bit(lane, lane_map) {
+        ucs_assertv(lane < UCP_MAX_LANES,
+                    "lane=%" PRIu8 ", lane_map=0x%" PRIx16, lane, lane_map);
+        rsc_index = ep_config_key->lanes[lane].rsc_index;
+        wiface    = ucp_worker_iface(worker, rsc_index);
+        ucp_worker_iface_progress_ep(wiface);
+    }
+}
+
 static ucs_status_t
 ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
                            ucp_worker_cfg_index_t ep_cfg_index,
@@ -596,6 +648,8 @@ ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
     if (status != UCS_OK) {
         goto out_cleanup_proto_init;
     }
+
+    ucp_proto_select_wiface_activate(worker, select_elem, ep_cfg_index);
 
     if (!internal) {
         ucp_proto_select_elem_trace(worker, ep_cfg_index, rkey_cfg_index,
@@ -876,14 +930,22 @@ int ucp_proto_select_elem_query(ucp_worker_h worker,
                                 size_t msg_length,
                                 ucp_proto_query_attr_t *proto_attr)
 {
-    const ucp_proto_threshold_elem_t *thresh_elem =
-            ucp_proto_select_thresholds_search(select_elem, msg_length);
+    const ucp_proto_threshold_elem_t *thresh_elem;
+    const ucp_proto_config_t *proto_config;
 
-    ucp_proto_config_query(worker, &thresh_elem->proto_config, msg_length,
-                           proto_attr);
+    thresh_elem  = ucp_proto_select_thresholds_search(select_elem, msg_length);
+    proto_config = &thresh_elem->proto_config;
+    if (proto_config->proto->flags & UCP_PROTO_FLAG_INVALID) {
+        return 0;
+    }
+
+    ucp_proto_config_query(worker, proto_config, msg_length, proto_attr);
+    ucs_assertv(proto_attr->lane_map != 0,
+                "%s protocol information query output contains empty lane map",
+                proto_config->proto->name);
 
     proto_attr->max_msg_length = ucs_min(proto_attr->max_msg_length,
                                          thresh_elem->max_msg_length);
 
-    return !(thresh_elem->proto_config.proto->flags & UCP_PROTO_FLAG_INVALID);
+    return 1;
 }

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -87,4 +87,5 @@ void ucp_proto_single_query(const ucp_proto_query_params_t *params,
 
     ucp_proto_default_query(params, attr);
     ucp_proto_common_lane_priv_str(params, &spriv->super, 1, 1, &config_strb);
+    attr->lane_map = UCS_BIT(spriv->super.lane);
 }

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -219,6 +219,7 @@ static void ucp_proto_amo_query(const ucp_proto_query_params_t *params,
 
     attr->max_msg_length = SIZE_MAX;
     attr->is_estimation  = 0;
+    attr->lane_map       = UCS_BIT(spriv->super.lane);
     ucp_proto_common_lane_priv_str(params, &spriv->super, 1, 1, &config_strb);
 }
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -440,6 +440,7 @@ void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
 
     attr->is_estimation  = 1;
     attr->max_msg_length = SIZE_MAX;
+    attr->lane_map       = UCS_BIT(rpriv->lane);
 
     ucs_snprintf_safe(attr->desc, sizeof(attr->desc), "rendezvous %s",
                       remote_attr.desc);
@@ -636,6 +637,7 @@ void ucp_proto_rndv_bulk_query(const ucp_proto_query_params_t *params,
     attr->max_msg_length = SIZE_MAX;
     attr->is_estimation  = 0;
     ucp_proto_multi_query_config(&multi_query_params, attr);
+    attr->lane_map |= UCS_BIT(rpriv->super.lane);
 }
 
 static ucs_status_t

--- a/src/ucp/rndv/rndv_ats.c
+++ b/src/ucp/rndv/rndv_ats.c
@@ -60,12 +60,21 @@ ucp_proto_rndv_ats_abort(ucp_request_t *request, ucs_status_t status)
     ucp_proto_rndv_ats_complete(request);
 }
 
+static void ucp_proto_rndv_ats_query(const ucp_proto_query_params_t *params,
+                                     ucp_proto_query_attr_t *attr)
+{
+    const ucp_proto_rndv_ack_priv_t *apriv = params->priv;
+
+    ucp_proto_default_query(params, attr);
+    attr->lane_map |= UCS_BIT(apriv->lane);
+}
+
 ucp_proto_t ucp_rndv_ats_proto = {
     .name     = "rndv/ats",
     .desc     = "no data fetch",
     .flags    = 0,
     .init     = ucp_proto_rndv_ats_init,
-    .query    = ucp_proto_default_query,
+    .query    = ucp_proto_rndv_ats_query,
     .progress = {ucp_proto_rndv_ats_progress},
     .abort    = ucp_proto_rndv_ats_abort,
     .reset    = (ucp_request_reset_func_t)ucs_empty_function_return_success

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -143,10 +143,13 @@ static void ucp_proto_rndv_ppln_query(const ucp_proto_query_params_t *params,
 
         attr->max_msg_length = SIZE_MAX;
         attr->is_estimation  = 0;
+        attr->lane_map       = frag_attr.lane_map;
         ucs_snprintf_safe(attr->desc, sizeof(attr->desc), "pipeline %s",
                           frag_attr.desc);
         ucs_strncpy_safe(attr->config, frag_attr.config, sizeof(attr->config));
     }
+
+    attr->lane_map |= UCS_BIT(rpriv->ack.lane);
 }
 
 static void

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -95,13 +95,24 @@ ucp_proto_rndv_rkey_ptr_init(const ucp_proto_init_params_t *init_params)
 }
 
 static void
+ucp_rndv_rkey_ptr_query_common(const ucp_proto_query_params_t *params,
+                               ucp_proto_query_attr_t *attr)
+{
+    const ucp_proto_rndv_rkey_ptr_priv_t *rpriv = params->priv;
+
+    ucp_proto_default_query(params, attr);
+    attr->lane_map = UCS_BIT(rpriv->spriv.super.lane) |
+                     UCS_BIT(rpriv->ack.lane);
+}
+
+static void
 ucp_proto_rndv_rkey_ptr_query(const ucp_proto_query_params_t *params,
                               ucp_proto_query_attr_t *attr)
 {
     UCS_STRING_BUFFER_FIXED(config_strb, attr->config, sizeof(attr->config));
     const ucp_proto_rndv_rkey_ptr_priv_t *rpriv = params->priv;
 
-    ucp_proto_default_query(params, attr);
+    ucp_rndv_rkey_ptr_query_common(params, attr);
     ucp_proto_common_lane_priv_str(params, &rpriv->spriv.super, 1, 0,
                                    &config_strb);
 }
@@ -340,7 +351,7 @@ ucp_proto_rndv_rkey_ptr_mtype_query(const ucp_proto_query_params_t *params,
 {
     const char *desc = UCP_PROTO_RNDV_RKEY_PTR_DESC;
 
-    ucp_proto_default_query(params, attr);
+    ucp_rndv_rkey_ptr_query_common(params, attr);
     ucp_proto_rndv_mtype_query_desc(params, attr, desc);
 }
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -236,6 +236,7 @@ static void ucp_proto_rndv_rtr_query(const ucp_proto_query_params_t *params,
     ucp_proto_select_elem_query(params->worker, &rpriv->remote_proto,
                                 params->msg_length, attr);
     attr->is_estimation = 1;
+    attr->lane_map      = UCS_BIT(rpriv->lane);
 }
 
 static void ucp_proto_rndv_rtr_abort(ucp_request_t *req, ucs_status_t status)
@@ -432,6 +433,7 @@ ucp_proto_rndv_rtr_mtype_query(const ucp_proto_query_params_t *params,
 
     attr->is_estimation  = 1;
     attr->max_msg_length = remote_attr.max_msg_length;
+    attr->lane_map       = UCS_BIT(rpriv->lane);
     ucp_proto_rndv_mtype_query_desc(params, attr, remote_attr.desc);
     ucs_strncpy_safe(attr->config, remote_attr.config, sizeof(attr->config));
 }

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         modify_config_for_valgrind("IB_TX_QUEUE_LEN", "128");
         modify_config_for_valgrind("IB_TX_BUFS_GROW", "64");
         modify_config_for_valgrind("UD_RX_QUEUE_LEN", "256");
-        modify_config_for_valgrind("UD_RX_QUEUE_LEN_INIT", "16");
+        modify_config_for_valgrind("UD_RX_QUEUE_LEN_INIT", "32");
         modify_config_for_valgrind("RC_TX_CQ_LEN", "128");
         modify_config_for_valgrind("RC_RX_QUEUE_LEN", "128");
         modify_config_for_valgrind("DC_TX_QUEUE_LEN", "16");


### PR DESCRIPTION
## What
Activate UCP worker interface only for selected lanes.

## Why ?
Activating UCP worker interface only for selected lanes prevents of enabling of unnecessary UCT interfaces.
Which [enabling of unnecessary UCT interfaces] may have a negative impact on performance.
