### PR TITLE
UCP/CORE: Ignore null uct_ep at sanity check while setting failed lanes

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1276,9 +1276,13 @@ static void ucp_ep_check_lanes(ucp_ep_h ep)
                                ep->refcounts.create;
     uint8_t num_failed_tl_ep = 0;
     ucp_lane_index_t lane;
+    uct_ep_h uct_ep;
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        num_failed_tl_ep += ucp_is_uct_ep_failed(ucp_ep_get_lane(ep, lane));
+        uct_ep = ucp_ep_get_lane(ep, lane);
+        if ((uct_ep != NULL) && ucp_is_uct_ep_failed(uct_ep)) {
+            num_failed_tl_ep++;
+        }
     }
 
     ucs_assert((num_failed_tl_ep == 0) ||


### PR DESCRIPTION
## What
When a test is failing, a crash is observed in the teardown path of some tests.

Found internally: [bug](https://redmine.mellanox.com/issues/3411534)

Reason for the test failing to be investigated separately.

## Why ?
A sanity check on the teardown path is dereferencing a null pointer.

## How ?
Skip null uct_ep while checking sanity on the failure path. After fix proper test failure is seen.

### Repro
Make sure tcp iface connect() fails. Stack trace is misleading as file line numbers are off.

```
GTEST_SHARD_INDEX=0 GTEST_TOTAL_SHARDS=2 UCX_HANDLE_ERRORS=bt gdb --args ./test/gtest/gtest --gtest_filter="tcp/test_ucp_sockaddr.listen/1"
```

```
[ RUN      ] tcp/test_ucp_sockaddr.listen/1 <tcp/tag,mt>
[     INFO ] Testing 10.210.0.169:0
[     INFO ] server listening on 10.210.0.169:51466
[1680279564.140259] [vulcan03:19146:0]       wireup_cm.c:1279 UCX  WARN  server ep 0x7efe93248000 failed to connect to remote address on device enp4s0f0, tl_bitmap 0x1 0x0, status Success
[vulcan03:19146:0:19146] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))

/labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c: [ kh_del_ucp_ep_peer_mem_hash() ]
...
38 #include <ucs/vfs/base/vfs_obj.h>
39 #include <string.h>
40
==>    41 __KHASH_IMPL(ucp_ep_peer_mem_hash, kh_inline, uint64_t,
42              ucp_ep_peer_mem_data_t, 1,
43              kh_int64_hash_func, kh_int64_hash_equal);
44

==== backtrace (tid:  19146) ====
0 0x00000000000465a0 kh_del_ucp_ep_peer_mem_hash()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:41
1 0x00000000000484c2 ucp_ep_check_lanes()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:1281
2 0x000000000004980e ucp_ep_cleanup_lanes()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:1551
3 0x00000000000499e1 ucp_ep_destroy_internal()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:1268
4 0x0000000000131d01 ucp_ep_cm_server_create_connected()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/wireup/wireup_cm.c:1310
5 0x0000000000048e22 ucp_ep_create_server_accept()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:989
6 0x000000000004e934 ucp_ep_create_api_conn_request()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:1004
7 0x000000000004e934 ucp_ep_create()  /labhome/tvegas/share/srcs/ucx_ppln/src/ucp/core/ucp_ep.c:1177
8 0x0000000000a859ba ucp_test_base::entity::accept()  /labhome/tvegas/share/srcs/ucx_ppln/test/gtest/ucp/ucp_test.cc:767
9 0x0000000000a85d54 ucp_test_base::entity::progress()  /labhome/tvegas/share/srcs/ucx_ppln/test/gtest/ucp/ucp_test.cc:1030
```