### PR TITLE
UCM/SYS: Convert self-load failure message from warning to diag

### DIFF
--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -321,7 +321,7 @@ void ucm_prevent_dl_unload()
         (void)dlerror();
         dl = dlopen(info.dli_fname, flags);
         if (dl == NULL) {
-            ucm_warn("failed to load '%s': %s", info.dli_fname, dlerror());
+            ucm_diag("failed to load '%s': %s", info.dli_fname, dlerror());
             continue;
         }
 


### PR DESCRIPTION
## Why
This failure is usually not causing any errors. It can happen if the application is linked statically.