### PR TITLE
UCT/MLX5: Only pack flush rkey when flush remote is enabled

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -721,4 +721,13 @@ uct_rc_mlx5_common_iface_init_rx(uct_rc_mlx5_iface_common_t *iface,
 
 void uct_rc_mlx5_destroy_srq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_srq_t *srq);
 
+static UCS_F_ALWAYS_INLINE int
+uct_rc_mlx5_iface_flush_rkey_enabled(uct_rc_mlx5_iface_common_t *iface)
+{
+    uct_ib_md_t *md = uct_ib_iface_md(&iface->super.super);
+
+    return iface->super.config.flush_remote &&
+           uct_ib_md_is_flush_rkey_valid(md->flush_rkey);
+}
+
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -684,7 +684,7 @@ ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
         uct_ib_pack_uint24(rc_addr->tm_qp_num, ep->tm_qp.qp_num);
     }
 
-    if (uct_ib_md_is_flush_rkey_valid(md->flush_rkey)) {
+    if (uct_rc_mlx5_iface_flush_rkey_enabled(iface)) {
         ext_addr                            = ucs_derived_of(rc_addr,
                                                              uct_rc_mlx5_ep_ext_address_t);
         ext_addr->flags                     = UCT_RC_MLX5_EP_ADDR_FLAG_FLUSH_RKEY;

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -143,6 +143,74 @@ UCS_TEST_P(test_rc_max_wr, send_limit)
 
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc_max_wr)
 
+
+class test_rc_iface_address : public uct_test {
+protected:
+    entity *m_entity;
+    entity *m_entity_flush_rkey;
+
+public:
+    static uct_iface_params_t iface_params()
+    {
+        uct_iface_params_t params = {};
+
+        params.field_mask |= UCT_IFACE_PARAM_FIELD_OPEN_MODE;
+        params.field_mask |= UCT_IFACE_PARAM_FIELD_FEATURES;
+
+        params.features  = UCT_IFACE_FEATURE_PUT;
+        params.open_mode = UCT_IFACE_OPEN_MODE_DEVICE;
+        return params;
+    }
+
+    void init()
+    {
+        uct_test::init();
+
+        uct_iface_params_t params = iface_params();
+        m_entity                  = uct_test::create_entity(params);
+
+        params.features    |= UCT_IFACE_FEATURE_FLUSH_REMOTE;
+        m_entity_flush_rkey = uct_test::create_entity(params);
+
+        m_entities.push_back(m_entity);
+        m_entities.push_back(m_entity_flush_rkey);
+    }
+
+    using map_size_t = std::map<std::string, std::pair<size_t, size_t>>;
+
+    void check_sizes(entity *e, const map_size_t &sizes)
+    {
+        auto it = sizes.find(GetParam()->tl_name);
+        ASSERT_NE(sizes.end(), it);
+
+        EXPECT_EQ(it->second.first, e->iface_attr().ep_addr_len);
+        EXPECT_EQ(it->second.second, e->iface_attr().iface_addr_len);
+    }
+};
+
+UCS_TEST_P(test_rc_iface_address, size_no_flush_remote)
+{
+    map_size_t sizes = {
+        {"rc_mlx5", {7, 1}},
+        {"dc_mlx5", {0, 5}},
+        {"rc_verbs", {7, 0}},
+    };
+    check_sizes(m_entity, sizes);
+}
+
+UCS_TEST_P(test_rc_iface_address, size_flush_remote)
+{
+    map_size_t sizes = {
+        {"rc_mlx5", {10, 1}},
+        {"dc_mlx5", {0, 7}},
+        {"rc_verbs", {7, 0}},
+    };
+    check_sizes(m_entity_flush_rkey, sizes);
+}
+
+UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_iface_address)
+
+
 class test_rc_get_limit : public test_rc {
 public:
     struct am_completion_t {


### PR DESCRIPTION
## What
Do not add the `flush_rkey` to the packed address when RMA and AMO32/64 are not there.

## Why ?
The flush rkey is making address too big for `rdmacm`.

## How ?
Use the existing flush remote flag to disable remote flush at interface instantiation. Handle it at `rc_mlx5` interface level as other transports are using the same memory domain.

### Tested
perftest `ucp_get` still contains the `flush_rkey`, io_demo skips it:
```
UCX_SOCKADDR_TLS_PRIORITY=rdmacm ./test/apps/iodemo/io_demo -C 12 -P 1000000 &
UCX_SOCKADDR_TLS_PRIORITY=rdmacm libtool --mode=execute  ./test/apps/iodemo/io_demo -C 12 -P 1000000 <ip address>
```
