### PR TITLE
UCM/SYS: Convert self-load failure message from warning to diag - v1.14.x

### DIFF
--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -322,7 +322,7 @@ void ucm_prevent_dl_unload()
         (void)dlerror();
         dl = dlopen(info.dli_fname, flags);
         if (dl == NULL) {
-            ucm_warn("failed to load '%s': %s", info.dli_fname, dlerror());
+            ucm_diag("failed to load '%s': %s", info.dli_fname, dlerror());
             continue;
         }
 


### PR DESCRIPTION
## Why
Cherry-pick #8991 to v1.14.x, no conflicts