### PR TITLE
JAVA/TEST: Wait for active message to arrive before checking data

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -735,7 +735,8 @@ public class UcpEndpointTest extends UcxTest {
             sendData.getMemory().getAddress(), 2L, UcpConstants.UCP_AM_FLAG_PERSISTENT_DATA, null,
             new UcpRequestParams().setMemoryType(memType).setMemoryHandle(sendData.getMemory()));
 
-        while (!Arrays.stream(requests).allMatch(r -> (r != null) && r.isCompleted())) {
+        while (!Arrays.stream(requests).allMatch(r -> (r != null) && r.isCompleted()) ||
+             (persistantAmData.get() == null)) {
             worker1.progress();
             worker2.progress();
         }


### PR DESCRIPTION
## Why
Potential fix for CI failures like this:
```
2023-04-08T19:19:55.6068083Z + make -C bindings/java/src/main/native test
...
2023-04-08T19:20:14.5005790Z Running org.openucx.jucx.UcpEndpointTest
2023-04-08T19:20:35.6360937Z Running testGetNB with memType: 0
2023-04-08T19:20:36.1680271Z Running testGetNB with memType: 1
2023-04-08T19:20:36.7147595Z Running testGetNB with memType: 2
2023-04-08T19:20:37.2901614Z Running testActiveMessages with memType: 0
2023-04-08T19:20:38.2809052Z Running testSendRecv with memType: 0
2023-04-08T19:20:38.2810158Z Running testSendRecv with memType: 1
2023-04-08T19:20:38.5802474Z Running testSendRecv with memType: 2
2023-04-08T19:20:39.0931438Z Tests run: 12, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 24.591 sec <<< FAILURE!
2023-04-08T19:20:39.0932814Z testActiveMessages(org.openucx.jucx.UcpEndpointTest)  Time elapsed: 0.388 sec  <<< FAILURE!
2023-04-08T19:20:39.0933776Z org.junit.experimental.theories.internal.ParameterizedAssertionError: testActiveMessages("0" <from memTypes[0]>)
2023-04-08T19:20:39.0935138Z 	at org.junit.experimental.theories.Theories$TheoryAnchor.reportParameterizedError(Theories.java:288)
2023-04-08T19:20:39.0936149Z 	at org.junit.experimental.theories.Theories$TheoryAnchor$1$1.evaluate(Theories.java:237)
2023-04-08T19:20:39.0937150Z 	at org.junit.experimental.theories.Theories$TheoryAnchor.runWithCompleteAssignment(Theories.java:218)
2023-04-08T19:20:39.0938162Z 	at org.junit.experimental.theories.Theories$TheoryAnchor.runWithAssignment(Theories.java:204)
2023-04-08T19:20:39.0939173Z 	at org.junit.experimental.theories.Theories$TheoryAnchor.runWithIncompleteAssignment(Theories.java:212)
2023-04-08T19:20:39.0940465Z 	at org.junit.experimental.theories.Theories$TheoryAnchor.runWithAssignment(Theories.java:202)
2023-04-08T19:20:39.0941407Z 	at org.junit.experimental.theories.Theories$TheoryAnchor.evaluate(Theories.java:187)
2023-04-08T19:20:39.0942283Z 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
2023-04-08T19:20:39.0943689Z 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
2023-04-08T19:20:39.0945047Z 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
2023-04-08T19:20:39.0946055Z 	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
2023-04-08T19:20:39.0946992Z 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
2023-04-08T19:20:39.0947813Z 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
2023-04-08T19:20:39.0948646Z 	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
2023-04-08T19:20:39.0949546Z 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
2023-04-08T19:20:39.0950495Z 	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
2023-04-08T19:20:39.0951505Z 	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
2023-04-08T19:20:39.0952704Z 	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
2023-04-08T19:20:39.0953923Z 	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
2023-04-08T19:20:39.0954891Z 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-04-08T19:20:39.0955776Z 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2023-04-08T19:20:39.0956764Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-04-08T19:20:39.0957668Z 	at java.lang.reflect.Method.invoke(Method.java:498)
2023-04-08T19:20:39.0958583Z 	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
2023-04-08T19:20:39.0959704Z 	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
2023-04-08T19:20:39.0960786Z 	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
2023-04-08T19:20:39.0961825Z 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
2023-04-08T19:20:39.0962815Z 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
2023-04-08T19:20:39.0963632Z Caused by: java.lang.NullPointerException
2023-04-08T19:20:39.0964440Z 	at org.openucx.jucx.UcpEndpointTest.testActiveMessages(UcpEndpointTest.java:753)
2023-04-08T19:20:39.0965324Z 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-04-08T19:20:39.0966201Z 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2023-04-08T19:20:39.0967191Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-04-08T19:20:39.0968091Z 	at java.lang.reflect.Method.invoke(Method.java:498)
2023-04-08T19:20:39.0968983Z 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
2023-04-08T19:20:39.0970082Z 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2023-04-08T19:20:39.0973444Z 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
2023-04-08T19:20:39.0974723Z 	at org.junit.experimental.theories.Theories$TheoryAnchor$2.evaluate(Theories.java:274)
2023-04-08T19:20:39.0976070Z 	at org.junit.experimental.theories.Theories$TheoryAnchor$1$1.evaluate(Theories.java:232)
2023-04-08T19:20:39.0977024Z 	... 26 more
```
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=61307&view=logs&j=c93d4a75-4c70-5e1a-b9da-38c6283c6dc4&t=8579879a-f713-50b0-8206-04b2b790b725&s=1f27aaa5-3d89-55e1-947d-81b3a55fe060