### PR TITLE
TEST/JENKINS: Run mpi with --allow-run-as-root

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -867,6 +867,7 @@ run_mpi_tests() {
 			$MAKEP installcheck
 
 			MPIRUN="mpirun \
+					--allow-run-as-root \
 					--bind-to none \
 					-x UCX_ERROR_SIGNALS \
 					-x UCX_HANDLE_ERRORS \


### PR DESCRIPTION
## Why
Fix CI failures when workers run as root user