### PR TITLE
Revert "UCT/ROCM: move memh caches to iface"

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -30,14 +30,25 @@
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_ep_t, const uct_ep_params_t *params)
 {
     uct_rocm_copy_iface_t *iface = ucs_derived_of(params->iface, uct_rocm_copy_iface_t);
+    char target_name[64];
+    ucs_status_t status;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
 
-    return UCS_OK;
+    snprintf(target_name, sizeof(target_name), "dest:%d",
+             *(pid_t*)params->iface_addr);
+    status = uct_rocm_copy_create_cache(&self->local_memh_cache, target_name);
+    if (status != UCS_OK) {
+        ucs_error("could not create create rocm copy cache: %s",
+                  ucs_status_string(status));
+    }
+
+    return status;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_rocm_copy_ep_t)
 {
+    uct_rocm_copy_destroy_cache(self->local_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_copy_ep_t, uct_base_ep_t)
@@ -49,11 +60,11 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_copy_ep_t, uct_ep_t);
                     (_rkey))
 
 static void *
-uct_rocm_copy_get_mapped_host_ptr(uct_rocm_copy_iface_t *iface, void *ptr,
-                                  size_t size,
+uct_rocm_copy_get_mapped_host_ptr(uct_ep_h tl_ep, void *ptr, size_t size,
                                   uct_rocm_copy_key_t *rocm_copy_key)
 {
-    size_t offset = 0;
+    uct_rocm_copy_ep_t *ep = ucs_derived_of(tl_ep, uct_rocm_copy_ep_t);
+    size_t offset          = 0;
     void *mapped_ptr;
     ucs_status_t status;
 
@@ -61,7 +72,7 @@ uct_rocm_copy_get_mapped_host_ptr(uct_rocm_copy_iface_t *iface, void *ptr,
         (((void*)rocm_copy_key->vaddr == rocm_copy_key->dev_ptr) &&
          ((void*)rocm_copy_key->vaddr != ptr))) {
         /* key contains rocm address information. Need to lock host address first */
-        status = uct_rocm_copy_cache_map_memhandle(iface->local_memh_cache,
+        status = uct_rocm_copy_cache_map_memhandle(ep->local_memh_cache,
                                                    (uint64_t)ptr, size,
                                                    &mapped_ptr);
         if ((status != UCS_OK) || (mapped_ptr == NULL)) {
@@ -120,7 +131,7 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
         remote_addr_mod     = dev_address;
     } else {
         remote_addr_is_host = 1;
-        remote_addr_mod     = uct_rocm_copy_get_mapped_host_ptr(iface,
+        remote_addr_mod     = uct_rocm_copy_get_mapped_host_ptr(tl_ep,
                                                                 (void*)remote_addr,
                                                                 size,
                                                                 rocm_copy_key);
@@ -153,7 +164,7 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
         iov_buffer_mod     = dev_address;
     } else {
         iov_buffer_is_host = 1;
-        iov_buffer_mod = uct_rocm_copy_get_mapped_host_ptr(iface, iov->buffer,
+        iov_buffer_mod = uct_rocm_copy_get_mapped_host_ptr(tl_ep, iov->buffer,
                                                            size, NULL);
         if (iov_buffer_mod == NULL) {
             ucs_error("failed to map host pointer %p to device address",

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -236,7 +236,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
                                                           uct_rocm_copy_iface_config_t);
     ucs_status_t status;
     ucs_mpool_params_t mp_params;
-    char target_name[64];
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_copy_iface_ops,
                               &uct_rocm_copy_iface_internal_ops,
@@ -263,13 +262,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
 
     ucs_queue_head_init(&self->signal_queue);
 
-    ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%ld", self->id);
-    status = uct_rocm_copy_create_cache(&self->local_memh_cache, target_name);
-    if (status != UCS_OK) {
-        ucs_error("could not create create rocm copy cache: %s",
-                  ucs_status_string(status));
-    }
-
     return UCS_OK;
 }
 
@@ -278,7 +270,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rocm_copy_iface_t)
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
     ucs_mpool_cleanup(&self->signal_pool, 1);
-    uct_rocm_copy_destroy_cache(self->local_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_copy_iface_t, uct_base_iface_t);

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -9,7 +9,6 @@
 #include <uct/base/uct_iface.h>
 
 #include <hsa.h>
-#include "rocm_copy_cache.h"
 
 #define UCT_ROCM_COPY_TL_NAME    "rocm_cpy"
 
@@ -20,7 +19,6 @@ typedef struct uct_rocm_copy_iface {
     uct_rocm_copy_iface_addr_t  id;
     ucs_mpool_t                 signal_pool;
     ucs_queue_head_t            signal_queue;
-    uct_rocm_copy_cache_t       *local_memh_cache;
     struct {
         size_t                  d2h_thresh;
         size_t                  h2d_thresh;

--- a/src/uct/rocm/ipc/rocm_ipc_ep.h
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.h
@@ -15,6 +15,7 @@
 typedef struct uct_rocm_ipc_ep {
     uct_base_ep_t   super;
     pid_t           remote_pid;
+    uct_rocm_ipc_cache_t *remote_memh_cache;
 } uct_rocm_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rocm_ipc_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -161,7 +161,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 {
     ucs_status_t status;
     ucs_mpool_params_t mp_params;
-    char target_name[64];
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_ipc_iface_ops, 
                               &uct_base_iface_internal_ops,
@@ -183,14 +182,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 
     ucs_queue_head_init(&self->signal_queue);
 
-    ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%d", getpid());
-    status = uct_rocm_ipc_create_cache(&self->remote_memh_cache, target_name);
-    if (status != UCS_OK) {
-        ucs_error("could not create create rocm ipc cache: %s",
-                  ucs_status_string(status));
-        return status;
-    }
-
     return UCS_OK;
 }
 
@@ -200,7 +191,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rocm_ipc_iface_t)
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
     ucs_mpool_cleanup(&self->signal_pool, 1);
-    uct_rocm_ipc_destroy_cache(self->remote_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_ipc_iface_t, uct_base_iface_t);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -8,7 +8,6 @@
 #define ROCM_IPC_IFACE_H
 
 #include <uct/base/uct_iface.h>
-#include "rocm_ipc_cache.h"
 
 #include <hsa.h>
 
@@ -18,7 +17,6 @@ typedef struct uct_rocm_ipc_iface {
     uct_base_iface_t super;
     ucs_mpool_t signal_pool;
     ucs_queue_head_t signal_queue;
-    uct_rocm_ipc_cache_t *remote_memh_cache;
 } uct_rocm_ipc_iface_t;
 
 typedef struct uct_rocm_ipc_iface_config {


### PR DESCRIPTION
## What
This reverts commit a5246b8b497d6d4d2899d288bec82274ed2afafc.

## Why ?
Commit a5246b8b4 moved the memhandle caches from the endpoints to the iface in rocm_copy and rocm_ipc.  
Both memhandle caches operate based on lookup of the virtual address. Different processes can use the same virtual address. While the memhandle cache does perform a comparison of the ipc keys in rocm_ipc, this will lead to thrashing of ipc registered regions across different processes if the same virtual address is used. 

I *think* the rocm_copy component  (which was the initial driver for the commit originally) does not have this problem, and the bug is/was trying to apply the same method to rocm_ipc. For the sake of simplicity lets revert the commit first before deciding whether to introduce a patch for rocm_copy only.
