### PR TITLE
UCT/ROCM: revert a5246b8 for rocm_ipc

### DIFF
--- a/src/uct/rocm/ipc/rocm_ipc_ep.h
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.h
@@ -15,6 +15,7 @@
 typedef struct uct_rocm_ipc_ep {
     uct_base_ep_t   super;
     pid_t           remote_pid;
+    uct_rocm_ipc_cache_t *remote_memh_cache;
 } uct_rocm_ipc_ep_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rocm_ipc_ep_t, uct_ep_t, const uct_ep_params_t *);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -161,7 +161,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 {
     ucs_status_t status;
     ucs_mpool_params_t mp_params;
-    char target_name[64];
 
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_rocm_ipc_iface_ops, 
                               &uct_base_iface_internal_ops,
@@ -183,14 +182,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
 
     ucs_queue_head_init(&self->signal_queue);
 
-    ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%d", getpid());
-    status = uct_rocm_ipc_create_cache(&self->remote_memh_cache, target_name);
-    if (status != UCS_OK) {
-        ucs_error("could not create create rocm ipc cache: %s",
-                  ucs_status_string(status));
-        return status;
-    }
-
     return UCS_OK;
 }
 
@@ -200,7 +191,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rocm_ipc_iface_t)
     uct_base_iface_progress_disable(&self->super.super,
                                     UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
     ucs_mpool_cleanup(&self->signal_pool, 1);
-    uct_rocm_ipc_destroy_cache(self->remote_memh_cache);
 }
 
 UCS_CLASS_DEFINE(uct_rocm_ipc_iface_t, uct_base_iface_t);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -8,7 +8,6 @@
 #define ROCM_IPC_IFACE_H
 
 #include <uct/base/uct_iface.h>
-#include "rocm_ipc_cache.h"
 
 #include <hsa.h>
 
@@ -18,7 +17,6 @@ typedef struct uct_rocm_ipc_iface {
     uct_base_iface_t super;
     ucs_mpool_t signal_pool;
     ucs_queue_head_t signal_queue;
-    uct_rocm_ipc_cache_t *remote_memh_cache;
 } uct_rocm_ipc_iface_t;
 
 typedef struct uct_rocm_ipc_iface_config {


### PR DESCRIPTION
## What
Commit a5246b8 moved the memhandle cache for rocm_copy and rocm_ipc from the endpoint datastructure to the iface data structure. While this is correct and beneficial for rocm_copy, it is actually detrimental for rocm_ipc.

The reason is that the memhandle cache is using virtual addresses for finding and identifying a registered memory region and ipc key. Multiple processes can use however the same virtual address, in which case the memhandle cache will find an entry, but will fail in the comparison of the ipc keys stored. Consequently, the operation will unmap the previous key, and map/open the current ipc key. Compared to the previous solution this can lead to thrashing of ipc registrations in case the same virtual address is used by multiple processes.

## How ?
This commit therefore reverts commit a5246b8 for rocm_ipc only, but keeps the changes for rocm_copy.
