### PR TITLE
GTEST/UCP: Removed deprecated ucp_ep_close_nb.

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1202,8 +1202,7 @@ protected:
             }
         }
 
-        void *close_req = receiver().disconnect_nb(0, 0,
-                                                   UCP_EP_CLOSE_MODE_FLUSH);
+        void *close_req     = receiver().disconnect_nb();
         ucs_time_t deadline = ucs::get_deadline(10);
         while (!is_request_completed(close_req) &&
                (ucs_get_time() < deadline)) {

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -389,7 +389,10 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
 
             m_failing_rkey.reset();
 
-            void *creq = ucp_ep_close_nb(ep, UCP_EP_CLOSE_MODE_FORCE);
+            ucp_request_param_t param;
+            param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+            param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
+            void *creq         = ucp_ep_close_nbx(ep, &param);
             request_wait(creq);
             short_progress_loop(); /* allow discard lanes & complete destroy EP */
 
@@ -539,7 +542,7 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
     }
 
     /* kill EPs & ifaces */
-    failing_receiver().close_all_eps(*this, 0, UCP_EP_CLOSE_MODE_FORCE);
+    failing_receiver().close_all_eps(*this, 0, UCP_EP_CLOSE_FLAG_FORCE);
     if (get_variant_value() & WAKEUP) {
         wakeup_drain_check_no_events({ &sender() });
     }
@@ -554,7 +557,10 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
     EXPECT_NE(0, m_err_count);
 
     ucp_ep_h ep = sender().revoke_ep(0, FAILING_EP_INDEX);
-    void *creq = ucp_ep_close_nb(ep, UCP_EP_CLOSE_MODE_FORCE);
+    ucp_request_param_t param;
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
+    void *creq         = ucp_ep_close_nbx(ep, &param);
     request_wait(creq);
 
     /* make sure no remaining events are returned from poll() */

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -389,10 +389,7 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
 
             m_failing_rkey.reset();
 
-            ucp_request_param_t param;
-            param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-            param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
-            void *creq         = ucp_ep_close_nbx(ep, &param);
+            void *creq = ep_close_nbx(ep, UCP_EP_CLOSE_FLAG_FORCE);
             request_wait(creq);
             short_progress_loop(); /* allow discard lanes & complete destroy EP */
 
@@ -557,10 +554,7 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
     EXPECT_NE(0, m_err_count);
 
     ucp_ep_h ep = sender().revoke_ep(0, FAILING_EP_INDEX);
-    ucp_request_param_t param;
-    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-    param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
-    void *creq         = ucp_ep_close_nbx(ep, &param);
+    void *creq  = ep_close_nbx(ep, UCP_EP_CLOSE_FLAG_FORCE);
     request_wait(creq);
 
     /* make sure no remaining events are returned from poll() */

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -957,10 +957,7 @@ protected:
             ucp_ep_set_failed(ep, UCP_NULL_LANE, UCS_ERR_CONNECTION_RESET);
             UCS_ASYNC_UNBLOCK(&ep->worker->async);
         }
-        ucp_request_param_t param;
-        param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-        param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
-        void *close_req    = ucp_ep_close_nbx(ep, &param);
+        void *close_req = ep_close_nbx(ep, UCP_EP_CLOSE_FLAG_FORCE);
 
         // Do some progress of sender's worker to check that it doesn't
         // complete UCP requests prior closing UCT endpoint from discarding

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -742,8 +742,9 @@ public:
         EXPECT_EQ(m_test_addr, attr.local_sockaddr);
     }
 
-    void one_sided_disconnect(entity &e, enum ucp_ep_close_mode mode) {
-        void *req           = e.disconnect_nb(0, 0, mode);
+    void one_sided_disconnect(entity &e, uint32_t flags = 0)
+    {
+        void *req           = e.disconnect_nb(0, 0, flags);
         ucs_time_t deadline = ucs::get_deadline();
         scoped_log_handler slh(detect_error_logger);
         while (!is_request_completed(req) && (ucs_get_time() < deadline)) {
@@ -755,15 +756,16 @@ public:
         e.close_ep_req_free(req);
     }
 
-    void concurrent_disconnect(enum ucp_ep_close_mode mode) {
+    void concurrent_disconnect(uint32_t flags = 0)
+    {
         ASSERT_EQ(2ul, entities().size());
         ASSERT_EQ(1, sender().get_num_workers());
         ASSERT_EQ(1, sender().get_num_eps());
         ASSERT_EQ(1, receiver().get_num_workers());
         ASSERT_EQ(1, receiver().get_num_eps());
 
-        void *sender_ep_close_req   = sender().disconnect_nb(0, 0, mode);
-        void *receiver_ep_close_req = receiver().disconnect_nb(0, 0, mode);
+        void *sender_ep_close_req   = sender().disconnect_nb(0, 0, flags);
+        void *receiver_ep_close_req = receiver().disconnect_nb(0, 0, flags);
 
         ucs_time_t deadline = ucs::get_deadline();
         scoped_log_handler slh(detect_error_logger);
@@ -955,7 +957,10 @@ protected:
             ucp_ep_set_failed(ep, UCP_NULL_LANE, UCS_ERR_CONNECTION_RESET);
             UCS_ASYNC_UNBLOCK(&ep->worker->async);
         }
-        void *close_req = ucp_ep_close_nb(ep, UCP_EP_CLOSE_MODE_FORCE);
+        ucp_request_param_t param;
+        param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+        param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
+        void *close_req    = ucp_ep_close_nbx(ep, &param);
 
         // Do some progress of sender's worker to check that it doesn't
         // complete UCP requests prior closing UCT endpoint from discarding
@@ -1030,22 +1035,22 @@ UCS_TEST_P(test_ucp_sockaddr, set_local_sockaddr)
 
 UCS_TEST_P(test_ucp_sockaddr, onesided_disconnect) {
     listen_and_communicate(false, 0);
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr, onesided_disconnect_c2s) {
     listen_and_communicate(false, SEND_DIRECTION_C2S);
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr, onesided_disconnect_s2c) {
     listen_and_communicate(false, SEND_DIRECTION_S2C);
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr, onesided_disconnect_bidi) {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr, close_callback) {
@@ -1077,49 +1082,49 @@ UCS_TEST_P(test_ucp_sockaddr, close_callback) {
 UCS_TEST_P(test_ucp_sockaddr, onesided_disconnect_bidi_wait_err_cb) {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
 
-    one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender());
     wait_for_flag(&m_err_count);
     EXPECT_EQ(1u, m_err_count);
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect) {
     listen_and_communicate(false, 0);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_c2s) {
     listen_and_communicate(false, SEND_DIRECTION_C2S);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_s2c) {
     listen_and_communicate(false, SEND_DIRECTION_S2C);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_bidi) {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_force) {
     listen_and_communicate(false, 0);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
+    concurrent_disconnect(UCP_EP_CLOSE_FLAG_FORCE);
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_force_c2s) {
     listen_and_communicate(false, SEND_DIRECTION_C2S);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
+    concurrent_disconnect(UCP_EP_CLOSE_FLAG_FORCE);
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_force_s2c) {
     listen_and_communicate(false, SEND_DIRECTION_S2C);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
+    concurrent_disconnect(UCP_EP_CLOSE_FLAG_FORCE);
 }
 
 UCS_TEST_P(test_ucp_sockaddr, concurrent_disconnect_force_bidi) {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
+    concurrent_disconnect(UCP_EP_CLOSE_FLAG_FORCE);
 }
 
 UCS_TEST_P(test_ucp_sockaddr, listen_inaddr_any) {
@@ -1573,9 +1578,9 @@ protected:
         wait_ep_err_or_wireup_msg_done(e);
 
         if (wait_cm_failure) {
-            one_sided_disconnect(e, UCP_EP_CLOSE_MODE_FORCE);
+            one_sided_disconnect(e, UCP_EP_CLOSE_FLAG_FORCE);
         } else {
-            concurrent_disconnect(UCP_EP_CLOSE_MODE_FORCE);
+            concurrent_disconnect(UCP_EP_CLOSE_FLAG_FORCE);
         }
     }
 
@@ -1908,7 +1913,7 @@ UCS_TEST_P(test_ucp_sockaddr_cm_private_data,
 {
     check_cm_fallback();
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCS_TEST_P(test_ucp_sockaddr_cm_private_data,
@@ -1917,7 +1922,7 @@ UCS_TEST_P(test_ucp_sockaddr_cm_private_data,
 {
     check_rdmacm();
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCS_TEST_P(test_ucp_sockaddr_cm_private_data,
@@ -1926,7 +1931,7 @@ UCS_TEST_P(test_ucp_sockaddr_cm_private_data,
 {
     check_cm_fallback();
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_sockaddr_cm_private_data, all, "all")
@@ -1944,7 +1949,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_check_lanes, check_rndv_lanes,
     EXPECT_EQ(has_rndv_lanes(sender().ep()),
               has_rndv_lanes(receiver().ep()));
 
-    concurrent_disconnect(UCP_EP_CLOSE_MODE_FLUSH);
+    concurrent_disconnect();
 }
 
 UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_check_lanes)
@@ -1972,7 +1977,7 @@ public:
     static void err_handler_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {
         test_ucp_sockaddr::err_handler_cb(arg, ep, status);
         entity *e = reinterpret_cast<entity *>(arg);
-        e->disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+        e->disconnect_nb(0, 0, UCP_EP_CLOSE_FLAG_FORCE);
     }
 };
 
@@ -1995,57 +2000,57 @@ UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, bidi) {
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_client_cforce) {
     listen_and_communicate(false, 0);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(receiver());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_c2s_cforce) {
     listen_and_communicate(false, SEND_DIRECTION_C2S);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(receiver());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_s2c_cforce) {
     listen_and_communicate(false, SEND_DIRECTION_S2C);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(receiver());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_bidi_cforce) {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(sender(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(receiver());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_client_sforce) {
     listen_and_communicate(false, 0);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(receiver(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_c2s_sforce) {
     listen_and_communicate(false, SEND_DIRECTION_C2S);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(receiver(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_s2c_sforce) {
     listen_and_communicate(false, SEND_DIRECTION_S2C);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(receiver(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(sender());
 }
 
 UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, onesided_bidi_sforce) {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
     scoped_log_handler slh(wrap_errors_logger);
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
-    one_sided_disconnect(sender(),   UCP_EP_CLOSE_MODE_FLUSH);
+    one_sided_disconnect(receiver(), UCP_EP_CLOSE_FLAG_FORCE);
+    one_sided_disconnect(sender());
 }
 
 /* The test check that a client disconnection works fine when a server received
@@ -2079,7 +2084,7 @@ UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, create_and_destroy_immediately)
 
         /* Disconnect from a peer while conenction is not fully established with
          * a peer */
-        one_sided_disconnect(sender(), UCP_EP_CLOSE_MODE_FORCE);
+        one_sided_disconnect(sender(), UCP_EP_CLOSE_FLAG_FORCE);
 
         /* Wait until either accepting a connection fails on a server side or
          * disconnection is detected by a server in case of a connection was
@@ -2095,7 +2100,7 @@ UCS_TEST_P(test_ucp_sockaddr_destroy_ep_on_err, create_and_destroy_immediately)
     }
 
     /* Disconnect from a client if a connection was established */
-    one_sided_disconnect(receiver(), UCP_EP_CLOSE_MODE_FORCE);
+    one_sided_disconnect(receiver(), UCP_EP_CLOSE_FLAG_FORCE);
 }
 
 UCP_INSTANTIATE_ALL_TEST_CASE(test_ucp_sockaddr_destroy_ep_on_err)
@@ -2283,7 +2288,7 @@ protected:
                                       &send_param);
         request_wait(sreq);
 
-        e.disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+        e.disconnect_nb(0, 0, UCP_EP_CLOSE_FLAG_FORCE);
     }
 
     void test_tag_send_recv(size_t size, bool is_exp, bool is_sync = false,
@@ -2522,7 +2527,7 @@ protected:
     };
 
     static void disconnect(test_ucp_sockaddr_protocols &test, entity &e) {
-        test.one_sided_disconnect(e, UCP_EP_CLOSE_MODE_FORCE);
+        test.one_sided_disconnect(e, UCP_EP_CLOSE_FLAG_FORCE);
         while (m_err_count == 0) {
             test.short_progress_loop();
         }
@@ -3065,7 +3070,7 @@ protected:
 
     void entity_disconnect(entity &e)
     {
-        void *close_req = e.disconnect_nb(0, 0, UCP_EP_CLOSE_MODE_FORCE);
+        void *close_req = e.disconnect_nb(0, 0, UCP_EP_CLOSE_FLAG_FORCE);
         if (UCS_PTR_IS_PTR(close_req)) {
             ucs_status_t status = request_progress(close_req, { &e });
             ASSERT_EQ(UCS_ERR_CANCELED, status);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -402,11 +402,7 @@ void test_ucp_wireup::send_recv(ucp_ep_h send_ep, ucp_worker_h recv_worker,
 }
 
 void test_ucp_wireup::disconnect(ucp_ep_h ep, bool force) {
-    ucp_request_param_t param;
-    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-    param.flags        = (force) ? UCP_EP_CLOSE_FLAG_FORCE : 0;
-
-    void *req = ucp_ep_close_nbx(ep, &param);
+    void *req = ep_close_nbx(ep, force ? UCP_EP_CLOSE_FLAG_FORCE : 0);
     if (!UCS_PTR_IS_PTR(req)) {
         ASSERT_UCS_OK(UCS_PTR_STATUS(req));
     }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -860,10 +860,7 @@ void *ucp_test_base::entity::disconnect_nb(int worker_index, int ep_index,
         return NULL;
     }
 
-    ucp_request_param_t param;
-    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-    param.flags        = close_flags;
-    void *req          = ucp_ep_close_nbx(ep, &param);
+    void *req = ep_close_nbx(ep, close_flags);
     if (UCS_PTR_IS_PTR(req)) {
         m_close_ep_reqs.push_back(req);
         return req;
@@ -1177,6 +1174,14 @@ bool ucp_test_base::entity::is_conn_reqs_queue_empty() const
 bool ucp_test_base::is_request_completed(void *request) {
     return (request == NULL) ||
            (ucp_request_check_status(request) != UCS_INPROGRESS);
+}
+
+void *ucp_test_base::ep_close_nbx(ucp_ep_h ep, uint32_t flags)
+{
+    ucp_request_param_t param;
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = flags;
+    return ucp_ep_close_nbx(ep, &param);
 }
 
 ucp_test::mapped_buffer::mapped_buffer(size_t size, const entity& entity,

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -99,13 +99,13 @@ public:
 
         void fence(int worker_index = 0) const;
 
-        void* disconnect_nb(int worker_index = 0, int ep_index = 0,
-                            enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
+        void *disconnect_nb(int worker_index = 0, int ep_index = 0,
+                            uint32_t close_flags = 0);
 
         void close_ep_req_free(void *close_req);
 
         void close_all_eps(const ucp_test &test, int worker_idx,
-                           enum ucp_ep_close_mode mode = UCP_EP_CLOSE_MODE_FLUSH);
+                           uint32_t close_flags = 0);
 
         void destroy_worker(int worker_index = 0);
 

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -183,6 +183,8 @@ public:
     };
 
     static bool is_request_completed(void *req);
+
+    static void *ep_close_nbx(ucp_ep_h ep, uint32_t flags);
 };
 
 /**


### PR DESCRIPTION
## What
Replaced deprecated ucp_ep_close_nb in gtest.
