### PR TITLE
UCT/CUDA: Set sys_dev to preferred location for managed mem

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -161,7 +161,7 @@ uct_cuda_base_query_devices(
         uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
         unsigned *num_tl_devices_p);
 
-ucs_status_t
+void
 uct_cuda_base_get_sys_dev(CUdevice cuda_device,
                           ucs_sys_device_t *sys_dev_p);
 

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -15,18 +15,19 @@
 #include <cuda.h>
 
 
-ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
-                                       ucs_sys_device_t *sys_dev_p)
+void uct_cuda_base_get_sys_dev(CUdevice cuda_device,
+                               ucs_sys_device_t *sys_dev_p)
 {
     ucs_sys_bus_id_t bus_id;
     CUresult cu_err;
     int attrib;
+    ucs_status_t status;
 
     /* PCI domain id */
     cu_err = cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID,
                                   cuda_device);
     if (cu_err != CUDA_SUCCESS) {
-         return UCS_ERR_IO_ERROR;
+        goto err;
     }
     bus_id.domain = (uint16_t)attrib;
 
@@ -34,7 +35,7 @@ ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
     cu_err = cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID,
                                   cuda_device);
     if (cu_err != CUDA_SUCCESS) {
-         return UCS_ERR_IO_ERROR;
+        goto err;
     }
     bus_id.bus = (uint8_t)attrib;
 
@@ -42,14 +43,22 @@ ucs_status_t uct_cuda_base_get_sys_dev(CUdevice cuda_device,
     cu_err = cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID,
                                   cuda_device);
     if (cu_err != CUDA_SUCCESS) {
-         return UCS_ERR_IO_ERROR;
+        goto err;
     }
     bus_id.slot = (uint8_t)attrib;
 
     /* Function - always 0 */
     bus_id.function = 0;
 
-    return ucs_topo_find_device_by_bus_id(&bus_id, sys_dev_p);
+    status = ucs_topo_find_device_by_bus_id(&bus_id, sys_dev_p);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    return;
+
+err:
+    *sys_dev_p = UCS_SYS_DEVICE_ID_UNKNOWN;
 }
 
 ucs_status_t
@@ -71,8 +80,8 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
     }
 
     for (cuda_device = 0; cuda_device < num_gpus; ++cuda_device) {
-        status = uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
-        if (status == UCS_OK) {
+        uct_cuda_base_get_sys_dev(cuda_device, &sys_dev);
+        if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
             ucs_snprintf_safe(device_name, sizeof(device_name), "GPU%d",
                               cuda_device);
             status = ucs_topo_sys_device_set_name(sys_dev, device_name,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -12,6 +12,13 @@
 
 extern uct_component_t uct_cuda_copy_component;
 
+typedef enum {
+    UCT_CUDA_PREF_LOC_CPU,
+    UCT_CUDA_PREF_LOC_GPU,
+    UCT_CUDA_PREF_LOC_LAST
+} uct_cuda_pref_loc_t;
+
+
 /**
  * @brief cuda_copy MD descriptor
  */
@@ -23,6 +30,7 @@ typedef struct uct_cuda_copy_md {
                                                     GPUs*/
         double                  max_reg_ratio;
         int                     dmabuf_supported;
+        uct_cuda_pref_loc_t     pref_loc;
     } config;
 } uct_cuda_copy_md_t;
 
@@ -34,6 +42,7 @@ typedef struct uct_cuda_copy_md_config {
     ucs_on_off_auto_value_t     alloc_whole_reg;
     double                      max_reg_ratio;
     ucs_ternary_auto_value_t    enable_dmabuf;
+    uct_cuda_pref_loc_t         pref_loc;
 } uct_cuda_copy_md_config_t;
 
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -260,7 +260,8 @@ void test_md::free_memory(void *address, ucs_memory_type_t mem_type)
 bool test_md::is_device_detected(ucs_memory_type_t mem_type)
 {
     return (mem_type != UCS_MEMORY_TYPE_ROCM) &&
-           (mem_type != UCS_MEMORY_TYPE_ROCM_MANAGED);
+           (mem_type != UCS_MEMORY_TYPE_ROCM_MANAGED) &&
+           (mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED);
 }
 
 void test_md::dereg_cb(uct_completion_t *comp)


### PR DESCRIPTION
## What/Why ?

If user sets preferred location of a range of managed memory allocation, then set sys_device attribute for that range to the preferred location. This allows protocols to make a better decision about where to stage managed memory by examining the sys_device associated with the range. The two cases to consider are:
1. memory = managed && preferred location = CPU, then use CPU staging buffers because managed memory buffers have backing pages that likely reside on the CPU. This decision helps avoid pcie traffic if staging buffer location was statically set to GPU. 
2. memory = managed && preferred location = GPUx, then use staging buffers on GPUx because managed memory buffers have backing pages that likely reside on that GPUx. This can reduce pcie traffic (if staging buffer location was statically set to CPU), can avoid peer-to-peer transfers (if original context associated with the managed memory allocation was another GPUy that was p2p reachable to GPUx).

