### PR TITLE
AZP: retry modules load when automount fails - v1.14.x

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -104,21 +104,30 @@ function az_init_modules() {
 
 #
 # Test if an environment module exists and load it if yes.
+# Retry 5 times in case of automount failure.
 # Otherwise, return error code.
 #
 function az_module_load() {
     module=$1
+    retries=5
 
-    if module avail -t 2>&1 | grep -q "^$module\$"
-    then
-        module load $module
-        return 0
-    else
-        echo "MODULEPATH='${MODULEPATH}'"
-        module avail || true
-        azure_log_warning "Module $module cannot be loaded"
-        return 1
-    fi
+    until module avail -t 2>&1 | grep -q "^$module\$"; do
+        if [ $retries -gt 1 ]; then
+            # Attempt to refresh automount
+            echo "Module $module not found, retrying..."
+            ls /hpc/local > /dev/null 2>&1
+            sleep 1
+        else
+            # Give up trying
+            echo "MODULEPATH='${MODULEPATH}'"
+            module avail || true
+            azure_log_warning "Module $module cannot be loaded"
+            return 1
+        fi
+        ((retries--))
+    done
+    module load $module
+    return 0
 }
 
 #


### PR DESCRIPTION
What
Workaround for automount availability issues while loading modules.

Why ?
Multiple job failures due to the on and off availability of automount shares.

How ?
Attempt to remount by accessing the NFS.