### PR TITLE
AZP: init modules before loading

### DIFF
--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -31,9 +31,11 @@ jobs:
         done
 
         exit 1
+      displayName: Check Go files
     - bash: |
         set -xeE
         source buildlib/az-helpers.sh
+        az_init_modules
         az_module_load dev/go-latest
         try_load_cuda_env
         ./autogen.sh


### PR DESCRIPTION
## What
Run modules init prior to module loading attempts.
'displayname' is a cosmetic change for better readable logs.

## Why ?
Failure to load modules otherwise. 
