### PR TITLE
UCP/PROTO: Increase epsilon for lanes score comparison

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -543,7 +543,7 @@ void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
 static UCS_F_ALWAYS_INLINE
 double ucp_calc_epsilon(double val1, double val2)
 {
-    return (val1 + val2) * (1e-6);
+    return (val1 + val2) * (1e-5);
 }
 
 /**


### PR DESCRIPTION
## What
Increase epsilon for the lanes calculation function for 10 times.

## Why ?
Epsilon value is supposed to detect the cases when floating point math operations shows different numbers for lanes with the same performance. I increased it since I detected that current value is not enough in some cases.

For example [this bug](https://redmine.mellanox.com/issues/3421919) caused by capping TCP lanes by configuration-defined threshold #8878 and after that lanes selection logic can select different lanes that have the same performance because error of calculation is little-bit overcome the epsilon. 
