### PR TITLE
TEST/GO: Fix passing port number to goperftest

### DIFF
--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -64,7 +64,7 @@ jobs:
         go_port=$((30000 + $(AZP_AGENT_ID) * 100))
         args="-p=$go_port"
         if [ "${{ parameters.name }}" == "gpu" ]; then
-          args="-m=cuda"
+          args="$args -m=cuda"
         fi
         LD_LIBRARY_PATH=$(Agent.TempDirectory)/ucx-$(Build.BuildId)/lib/:$LD_LIBRARY_PATH $(Agent.TempDirectory)/ucx-$(Build.BuildId)/bin/goperftest $args &
         sleep 5


### PR DESCRIPTION
## Why
Fix failures in go test
The [default port number](https://github.com/openucx/ucx/blob/master/bindings/go/src/examples/perftest/perftest.go#L340) of goperftest is used by Azure agent:
```
[root@swx-rdmz-ucx-gpu-02 ~]# netstat  -t -p|grep 36458
tcp6       0      0 swx-rdmz-ucx-gpu-:36458 13.107.42.20:https      ESTABLISHED 9587/Agent.Listener 
```