### PR TITLE
TEST/GO: Fix passing port number to goperftest - v1.14.x

### DIFF
--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -63,7 +63,7 @@ jobs:
         go_port=$((30000 + $(AZP_AGENT_ID) * 100))
         args="-p=$go_port"
         if [ "${{ parameters.name }}" == "gpu" ]; then
-          args="-m=cuda"
+          args="$args -m=cuda"
         fi
         LD_LIBRARY_PATH=$(Agent.TempDirectory)/ucx-$(Build.BuildId)/lib/:$LD_LIBRARY_PATH $(Agent.TempDirectory)/ucx-$(Build.BuildId)/bin/goperftest $args &
         sleep 5


### PR DESCRIPTION
## Why
Backport #9018