### PR TITLE
GTEST/UCP: Only use the first address of a given network interface

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -177,6 +177,7 @@ public:
     }
 
     void get_sockaddr() {
+        std::set<std::pair<sa_family_t, std::string>> added;
         std::vector<ucs::sock_addr_storage> saddrs;
         struct ifaddrs* ifaddrs;
         ucs_status_t status;
@@ -187,6 +188,12 @@ public:
         for (struct ifaddrs *ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
             if (!ucs::is_interface_usable(ifa) || is_skip_interface(ifa)) {
                 continue;
+            }
+
+            sa_family_t family = ifa->ifa_addr->sa_family;
+            const char *name   = ifa->ifa_name;
+            if (!added.insert({family, name}).second) {
+                continue; // we already have an address for that interface
             }
 
             saddrs.push_back(ucs::sock_addr_storage());


### PR DESCRIPTION
## What
Make sure that `test_ucp_sockaddr` only ever use the first network interface address for `sockcm` connection.

Follow-up for issue [3411534](https://redmine.mellanox.com/issues/3411534)

## Why ?
TCP UCT interfaces only listen on the first IP address of a given network interface. When the interface has multiple IP addresses, the test can end up using the second address for `sockcm` and also for the subsequent TCP UCT interface connection which then fails.

## How ?
Only add one address for a given address family / network interface.

### Repro

Interface has two addresses:
```
    inet 1.1.10.2/24 scope global ib0
       valid_lft forever preferred_lft forever
    inet 65.65.65.0/24 brd 65.65.65.255 scope global ib0
       valid_lft forever preferred_lft forever
```

UCT TCP interface is listening on first address:
```
tcp        0      0 1.1.10.2:36999          0.0.0.0:*               LISTEN      30661/./test/gtest/
```

Adversited port for `ib0` is 36999, but connector uses wrong source address:
```
[ RUN      ] tcp/test_ucp_sockaddr_protocols.tag_zcopy_64k_unexp/0 <tcp,cuda_copy,rocm_copy/mt>
[     INFO ] server listening on 65.65.65.0:53538
[1681734405.307035] [vulcan02:30661:0]            sock.c:325  UCX  ERROR   connect(fd=30, dest_addr=65.65.65.0:36999) failed: Connection refused
[1681734405.307059] [vulcan02:30661:0]       wireup_cm.c:1279 UCX  WARN  server ep 0x failed to connect to remote address on device ib0, tl_bitmap 0x4 0x0, status Destination is unreachable
```