### PR TITLE
JAVA/TEST: Wait for active message to arrive before checking data - v1.14.x

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -735,7 +735,8 @@ public class UcpEndpointTest extends UcxTest {
             sendData.getMemory().getAddress(), 2L, UcpConstants.UCP_AM_FLAG_PERSISTENT_DATA, null,
             new UcpRequestParams().setMemoryType(memType).setMemoryHandle(sendData.getMemory()));
 
-        while (!Arrays.stream(requests).allMatch(r -> (r != null) && r.isCompleted())) {
+        while (!Arrays.stream(requests).allMatch(r -> (r != null) && r.isCompleted()) ||
+             (persistantAmData.get() == null)) {
             worker1.progress();
             worker2.progress();
         }


### PR DESCRIPTION
## Why
Backport #9002 to fix CI failures