### PR TITLE
UCP/TAG: no need to assert after obvious check

### DIFF
--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -28,7 +28,6 @@ void ucp_tag_offload_iface_activate(ucp_worker_iface_t *iface)
     if (worker->tm.offload.iface == NULL) {
         ucs_assert(worker->tm.offload.thresh       == SIZE_MAX);
         ucs_assert(worker->tm.offload.zcopy_thresh == SIZE_MAX);
-        ucs_assert(worker->tm.offload.iface        == NULL);
 
         worker->tm.offload.thresh       = ucs_max(context->config.ext.tm_thresh,
                                                   iface->attr.cap.tag.recv.min_recv);


### PR DESCRIPTION
No need to write code like below.
```C
     if (worker->tm.offload.iface == NULL) {
         ucs_assert(worker->tm.offload.iface        == NULL);
```