### PR TITLE
GTEST/COMMON: Removed obsolete config from valgrind run.

### DIFF
--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -80,7 +80,6 @@ int main(int argc, char **argv) {
         modify_config_for_valgrind("RC_RX_QUEUE_LEN", "128");
         modify_config_for_valgrind("DC_TX_QUEUE_LEN", "16");
         modify_config_for_valgrind("DC_MLX5_NUM_DCI", "3");
-        modify_config_for_valgrind("CM_TIMEOUT", "600ms");
         modify_config_for_valgrind("TCP_TX_BUFS_GROW", "64");
         modify_config_for_valgrind("TCP_RX_BUFS_GROW", "64");
         modify_config_for_valgrind("TCP_RX_SEG_SIZE", "8k");


### PR DESCRIPTION
## What
Removed configuration of obsolete environment variable when running on valgrind.

## Why ?
The configuration field was removed by https://github.com/openucx/ucx/pull/6712.
