### PR TITLE
AZP: Kill zombie processes

### DIFF
--- a/buildlib/tools/zombie_killer.sh
+++ b/buildlib/tools/zombie_killer.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eEx
+
+# Search for zombie or defunct processes; kill them all
+out=$(ps -eo pid,stat | awk '$2 == "Z|defunct" {print $1}')
+if [ -z "$out" ]; then
+  echo "No zombies found"
+  exit 0
+else
+  for i in $out ; do
+    kill -9 "$i"
+  done
+fi
+
+# Search again; tell parents you killed their kids; kill parents
+out=$(ps -eo pid,stat | awk '$2 == "Z|defunct" {print $1}')
+for i in $out ; do
+  pid_parent=$(ps -o ppid=$i)
+  kill -s SIGCHLD $pid_parent
+  kill -9 $pid_parent
+done


### PR DESCRIPTION
## What
Clean up leftover zombie processes.

The script runs hourly on all CI hosts, scheduled via crontab.
The PR serves exclusively for visibility and documentation reasons.