### PR TITLE
BUILD/FLAGS: Add LCOV report generation target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ test/apps/profiling/ucx_profiling
 test/apps/uct_info/uct_info
 test/apps/uct_info/uct_info_static
 cmake/*.cmake
+*.gcno
+*.gcda
+lcov_data/

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,8 +84,28 @@ EXTRA_DIST += debian/rules
 EXTRA_DIST += debian/source/format
 EXTRA_DIST += ucx.pc.in
 EXTRA_DIST += LICENSE
+
 endif #!DOCS_ONLY
 EXTRA_DIST += docs/uml/uct.dot
+
+.PHONY: lcov lcov-clean
+
+if HAVE_LCOV
+distclean-local: lcov-clean
+	find . -name "*.gcno" -type f -exec rm -f {} \;
+
+LCOV_DIR = lcov_data
+LCOV_INFO = lcov.info
+
+lcov-clean:
+	$(RM) -r $(LCOV_DIR)
+	find . -name "*.gcda" -type f -exec rm -f {} \;
+
+lcov:
+	mkdir -p $(LCOV_DIR)
+	$(LCOVBIN) -c -d src -o $(LCOV_DIR)/$(LCOV_INFO)
+	$(GENHTMLBIN) -o $(LCOV_DIR) --legend $(LCOV_DIR)/$(LCOV_INFO)
+endif
 
 include $(srcdir)/docs/doxygen/doxygen.am
 

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -49,6 +49,16 @@ AS_IF([test "x$enable_debug" = xyes],
 
 
 #
+# Enable GCOV build
+#
+AC_ARG_ENABLE([gcov],
+        AS_HELP_STRING([--enable-gcov], [Enable code coverage instrumentation]),
+        [],
+        [enable_gcov=no])
+AM_CONDITIONAL([HAVE_GCOV],[test "x$enable_gcov" = xyes])
+
+
+#
 # Optimization level
 #
 AC_ARG_ENABLE(compiler-opt,
@@ -57,7 +67,7 @@ AC_ARG_ENABLE(compiler-opt,
         [enable_compiler_opt="none"])
 AS_IF([test "x$enable_compiler_opt" = "xyes"], [BASE_CFLAGS="-O3 $BASE_CFLAGS"],
       [test "x$enable_compiler_opt" = "xnone"],
-          [AS_IF([test "x$enable_debug" = xyes],
+          [AS_IF([test "x$enable_debug" = xyes -o "x$enable_gcov" = xyes],
                  [BASE_CFLAGS="-O0 $BASE_CFLAGS"
                   BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"],
                  [BASE_CFLAGS="-O3 $BASE_CFLAGS"
@@ -386,7 +396,7 @@ AC_ARG_ENABLE([frame-pointer],
                    [Compile with frame pointer, useful for profiling, default: NO]),
     [],
     [enable_frame_pointer=no])
-AS_IF([test "x$enable_frame_pointer" = xyes],
+AS_IF([test "x$enable_frame_pointer" = xyes -o "x$enable_gcov" = xyes],
       [ADD_COMPILER_FLAG_IF_SUPPORTED([-fno-omit-frame-pointer],
                                       [-fno-omit-frame-pointer],
                                       [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
@@ -399,6 +409,13 @@ ADD_COMPILER_FLAG_IF_SUPPORTED([-funwind-tables],
                                [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                                [AS_MESSAGE([compiling with unwind tables])],
                                [AS_MESSAGE([compiling without unwind tables])])
+
+
+AS_IF([test "x$enable_gcov" = xyes],
+      [ADD_COMPILER_FLAGS_IF_SUPPORTED([[-ftest-coverage],
+                                        [-fprofile-arcs]],
+                                       [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])])],
+      [:])
 
 
 #

--- a/config/m4/lcov.m4
+++ b/config/m4/lcov.m4
@@ -1,0 +1,33 @@
+#
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+#
+# Enable LCOV capable build
+#
+
+AC_ARG_ENABLE([lcov],
+    AS_HELP_STRING([--enable-lcov], [Enable code coverage reporting]),
+    [],
+    [enable_lcov=no])
+
+lcov_happy=no
+AS_IF([test "x$enable_lcov" = xno],
+    [AC_MSG_WARN([LCOV support is not enabled.])],
+    [
+        AC_CHECK_PROG([GCOVBIN], gcov, gcov, notfound)
+        AC_CHECK_PROG([LCOVBIN], lcov, lcov, notfound)
+        AC_CHECK_PROG([GENHTMLBIN], genhtml, genhtml, notfound)
+
+        lcov_happy=yes
+        AS_IF([test "x$GCOVBIN" = xnotfound], lcov_happy=no)
+        AS_IF([test "x$LCOVBIN" = xnotfound], lcov_happy=no)
+        AS_IF([test "x$GENHTMLBIN" = xnotfound], lcov_happy=no)
+
+        AS_IF([test "x$lcov_happy" != xyes],
+            [AC_MSG_ERROR([LCOV requested: gcov, lcov or genhtml not found])])
+    ])
+
+AM_CONDITIONAL([HAVE_LCOV], [test "x$lcov_happy" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,8 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_AARCH64_HI1620], [false])
      AM_CONDITIONAL([HAVE_FUSE3], [false])
      AM_CONDITIONAL([IODEMO_CUDA], [false])
+     AM_CONDITIONAL([HAVE_GCOV], [false])
+     AM_CONDITIONAL([HAVE_LCOV], [false])
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])
@@ -233,6 +235,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/cuda.m4])
      m4_include([config/m4/rocm.m4])
      m4_include([config/m4/gdrcopy.m4])
+     m4_include([config/m4/lcov.m4])
      m4_include([src/ucm/configure.m4])
      m4_include([src/ucs/configure.m4])
      m4_include([src/uct/configure.m4])


### PR DESCRIPTION
## What
Adds LCOV-based html coverage report generation.

## Why ?
Helpful to confirm what code paths are run, or what could be missing from testing.

## How ?
Use GCOV flags and LCOV.

Tested:
- tested without enabling: coverage disabled
- tested enabling without lcov/genhtml installed: failure
- tested `make distclean`: lcov files also removed
- tested `make lcov-clean`: generated files removed

### Usage
Build like:
```
yum install lcov
mkdir build && cd build
../contrib/configure-devel --enable-gcov --enable-lcov
```

Run:
```
./test/gtest/gtest --gtest_filter=*test_ucp_sockaddr*

make lcov
<browser: file://<path>/ucx/build/lcov_data/index.html>

make lcov-clean
```

<img src="https://user-images.githubusercontent.com/125344591/233620328-a927b49b-8dfd-4ace-ada8-61ba46386a92.png" width="500">