### PR TITLE
UCS/SYS: do not check errno if sysconf(3) was successful

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -255,7 +255,9 @@ static long ucs_sysconf(int name)
     errno = 0;
 
     rc = sysconf(name);
-    ucs_assert_always(errno == 0);
+    if (rc == -1) {
+        ucs_assert_always(errno == 0);
+    }
 
     return rc;
 }


### PR DESCRIPTION
From `man 3 sysconf`: "To distinguish an indeterminate limit from an error, set errno to zero before the call, and then check whether errno is nonzero when -1 is returned."

Fixes #9021
