### PR TITLE
UCT/IB: Fix 'reserved_at_' displayed offsets

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -491,13 +491,13 @@ struct uct_ib_mlx5_cmd_hca_cap_2_bits {
 
     uint8_t    multi_sl_qp[0x1];
     uint8_t    non_tunnel_reformat[0x1];
-    uint8_t    reserved_at_122[0x1];
+    uint8_t    reserved_at_c2[0x1];
     uint8_t    log_min_stride_wqe_sz[0x5];
-    uint8_t    reserved_at_128[0x3];
+    uint8_t    reserved_at_c8[0x3];
     uint8_t    log_conn_track_granularity[0x5];
-    uint8_t    reserved_at_130[0x3];
+    uint8_t    reserved_at_d0[0x3];
     uint8_t    log_conn_track_max_alloc[0x5];
-    uint8_t    reserved_at_138[0x3];
+    uint8_t    reserved_at_d8[0x3];
     uint8_t    log_max_conn_track_offload[0x5];
 
     uint8_t    cross_vhca_object_to_object_supported[0x20];
@@ -506,7 +506,7 @@ struct uct_ib_mlx5_cmd_hca_cap_2_bits {
 
     uint8_t    introspection_mkey[0x20];
 
-    uint8_t    reserved_at_220[0x6A0];
+    uint8_t    reserved_at_160[0x6a0];
 };
 
 struct uct_ib_mlx5_odp_per_transport_service_cap_bits {
@@ -537,7 +537,7 @@ struct uct_ib_mlx5_odp_cap_bits {
 
     struct uct_ib_mlx5_odp_per_transport_service_cap_bits dc_odp_caps;
 
-    uint8_t         reserved_at_100[0x700];
+    uint8_t         reserved_at_120[0x700];
 };
 
 union uct_ib_mlx5_hca_cap_union_bits {
@@ -641,22 +641,22 @@ struct uct_ib_mlx5_hca_vport_context_bits {
 
     uint8_t    ooo_sl_mask[0x10];
 
-    uint8_t    reserved_at_296[0x40];
+    uint8_t    reserved_at_2a0[0x40];
 
     uint8_t    lid[0x10];
-    uint8_t    reserved_at_310[0x4];
+    uint8_t    reserved_at_2f0[0x4];
     uint8_t    init_type_reply[0x4];
     uint8_t    lmc[0x3];
     uint8_t    subnet_timeout[0x5];
 
     uint8_t    sm_lid[0x10];
     uint8_t    sm_sl[0x4];
-    uint8_t    reserved_at_334[0xc];
+    uint8_t    reserved_at_314[0xc];
 
     uint8_t    qkey_violation_counter[0x10];
     uint8_t    pkey_violation_counter[0x10];
 
-    uint8_t    reserved_at_360[0xca0];
+    uint8_t    reserved_at_340[0xca0];
 };
 
 struct uct_ib_mlx5_query_hca_vport_context_out_bits {
@@ -1700,7 +1700,7 @@ struct uct_ib_mlx5_allow_other_vhca_access_in_bits {
 
     uint8_t         object_id_to_be_accessed[0x20];
 
-    uint8_t         reserved_at_a0[0x40];
+    uint8_t         reserved_at_c0[0x40];
 
     uint8_t         access_key[0x100];
 };
@@ -1797,7 +1797,7 @@ struct uct_ib_mlx5_cqc_bits {
     uint8_t         local_partition_id[0xc];
     uint8_t         process_id[0x14];
 
-    uint8_t         reserved_at_1A0[0x20];
+    uint8_t         reserved_at_1a0[0x20];
 
     uint8_t         dbr_addr[0x40];
 };


### PR DESCRIPTION
## What
Cosmetic fix of header declaration.

## Why ?
The structures are listing bytes but are actually used as bits. It can get confusing if the declared hexadecimal bit position for reserved areas is not accurate.

## How ?
List mismatched values:
`pahole --hex mlx5/dv/.libs/libuct_ib_la-ib_mlx5*o | grep reserved_at | grep -v "reserved_at_\([^\s\[]\+\).*\/\*\s\+0x\1\>`

### Before
```
        uint8_t                    reserved_at_0[48];    /*     0  0x30 */
        uint8_t                    reserved_at_0[64];    /*     0  0x40 */
        uint8_t                    reserved_at_0[128];   /*     0  0x80 */
        uint8_t                    reserved_at_122[1];   /*  0xc2   0x1 */
        uint8_t                    reserved_at_128[3];   /*  0xc8   0x3 */
        uint8_t                    reserved_at_130[3];   /*  0xd0   0x3 */
        uint8_t                    reserved_at_138[3];   /*  0xd8   0x3 */
        uint8_t                    reserved_at_220[1696]; /* 0x160 0x6a0 */
        uint8_t                    reserved_at_0[64];    /*     0  0x40 */
        uint8_t                    reserved_at_100[1792]; /* 0x120 0x700 */
        uint8_t                    reserved_at_0[21];    /*     0  0x15 */
        uint8_t                    reserved_at_0[1];     /*     0   0x1 */
        uint8_t                    reserved_at_a0[64];   /*  0xc0  0x40 */
        uint8_t                    reserved_at_296[64];  /* 0x2a0  0x40 */
        uint8_t                    reserved_at_310[4];   /* 0x2f0   0x4 */
        uint8_t                    reserved_at_334[12];  /* 0x314   0xc */
        uint8_t                    reserved_at_360[3232]; /* 0x340 0xca0 */
        uint8_t                    reserved_at_1A0[32];  /* 0x1a0  0x20 */
```
### After
```
uint8_t                    reserved_at_0[48];    /*     0  0x30 */
uint8_t                    reserved_at_0[64];    /*     0  0x40 */
uint8_t                    reserved_at_0[128];   /*     0  0x80 */
uint8_t                    reserved_at_0[64];    /*     0  0x40 */
uint8_t                    reserved_at_0[21];    /*     0  0x15 */
uint8_t                    reserved_at_0[1];     /*     0   0x1 */
```
