### PR TITLE
UCT/ROCM: add parameter to control dmabuf usage - v1.15.x

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.h
+++ b/src/uct/rocm/copy/rocm_copy_md.h
@@ -20,6 +20,7 @@ typedef struct uct_rocm_copy_md {
     uct_md_t            super;      /**< Domain info */
     ucs_rcache_t        *rcache;    /**< Registration cache (can be NULL) */
     ucs_linear_func_t   reg_cost;   /**< Memory registration cost */
+    int                 have_dmabuf; /**< Have dmabuf support */
 } uct_rocm_copy_md_t;
 
 
@@ -32,6 +33,7 @@ typedef struct uct_rocm_copy_md_config {
     uct_md_rcache_config_t      rcache;       /**< Registration cache config */
     ucs_linear_func_t           uc_reg_cost;  /**< Memory registration cost estimation
                                                    without using the cache */
+    ucs_ternary_auto_value_t    enable_dmabuf; /**< Turn using dmabuf on/off */
 } uct_rocm_copy_md_config_t;
 
 


### PR DESCRIPTION
## What
add a parameter that allows to control whether to use dmabuf in rocm md. The parameter is currently set by default to 'off', i.e. dmabuf will not be used. The plan is to turn it on starting from 1.16 release series.

## How ?
(cherry picked from commit 3194d12474de1436e68a3ecdff65209b1a472b04)
