### PR TITLE
UCP: wrap function to open interface on specific device

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -372,7 +372,6 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
                            ucp_worker_cfg_index_t *cfg_index_p);
 
 ucs_status_t ucp_worker_iface_open(ucp_worker_h worker, ucp_rsc_index_t tl_id,
-                                   uct_iface_params_t *iface_params,
                                    ucp_worker_iface_t **wiface);
 
 ucs_status_t ucp_worker_iface_init(ucp_worker_h worker, ucp_rsc_index_t tl_id,


### PR DESCRIPTION
## What
[UCP/CORE: Removed unused sockaddr code](https://github.com/openucx/ucx/pull/8752) removed the sockaddr open iface mode, then it only support ```UCT_IFACE_OPEN_MODE_DEVICE``` open iface mode. This PR wrapper the iface open parameters into ```ucp_worker_iface_open```.
