### PR TITLE
UCP/WIREUP: Init lanes: Also update selected when detected as same

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -405,6 +405,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     double score;
     uint8_t priority;
     ucp_md_index_t md_index;
+    bool selected;
 
     p            = tls_info;
     endp         = tls_info + sizeof(tls_info) - 1;
@@ -594,17 +595,19 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             priority     = iface_attr->priority + ae->iface_attr.priority;
             is_reachable = 1;
 
-            ucs_trace(UCT_TL_RESOURCE_DESC_FMT
-                      "->addr[%u] : %s score %.2f priority %d",
-                      UCT_TL_RESOURCE_DESC_ARG(resource),
-                      addr_index, criteria->title, score, priority);
 
-            if (!found || (ucp_score_prio_cmp(score, priority, sinfo.score,
-                                              sinfo.priority) > 0)) {
+            selected = ucp_score_prio_cmp(score, priority, sinfo.score,
+                                     sinfo.priority) >= 0;
+            if (!found || (selected != 0)) {
                 ucp_wireup_init_select_info(score, addr_index, rsc_index,
                                             priority, &sinfo);
                 found = 1;
             }
+            ucs_trace(UCT_TL_RESOURCE_DESC_FMT
+                      "->addr[%u] : %s score %.2f priority %d %s",
+                      UCT_TL_RESOURCE_DESC_ARG(resource),
+                      addr_index, criteria->title, score, priority,
+                      selected? "selected" : "");
         }
 
         /* If a local resource cannot reach any of the remote addresses,


### PR DESCRIPTION
## What
When two workers connect without CM, ep create leads to lane initialization with many addresses. Then one of the two send wireup request containing the addresses remaining as part of the selection. There are fewer addresses sent as only few lanes were used.
Then the lane initialization takes place again, but with epsilon value, the selection is skewed and lanes reconfiguration failure is triggered.

## Why?
See the scheme below, where 1) and 2) are considered the same because within epsilon range. Then as addr[1] is not part of selection, 1) is not there when receiving wireup request. Because of that 2) is then selected, which prevents 3) from being reselected as 2) and 3) are also within epsilon.

```
INIT LANES (ep create)
==============================
overall 6 addresses to check

1) p2p2->addr[1] 9.5051831065193042
     -> 9.5051  -> updated
2) p2p2->addr[3] 9.505313206307445
     -> 9.5053 -> too close not updated
3) ib3->addr[3]  9.505443313498283
     -> 9.5054  -> updated

<ib3 selected for keepalive>
<symmetric, ep to itself>, two addresses/lanes sent along with WIREUP REQ

INIT LANE (wireup handle request)
=================================
1) not there anymore, as addr[1] was never selected
2) p2p2->addr[3] 9.505313206307445
     -> 9.5053 -> now good, updated
3) ib3->addr[3] 9.505443313498283
     -> 9.5054 -> now TOO CLOSE from 2), skipped!

<p2p2 select for keepalive>
```

## How ?
When comparison returns equal, only keep the last one. When the score is very similar, it is more deterministic to select the last identical found.

This is exposed by #9017, visible on `tcp/test_ucp_am_nbx_closed_ep.rx_short_am_on_closed_ep/0` running on jazz.
