### PR TITLE
DOCS: bump up the Python ver for docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.8
    install:
    - requirements: docs/.readthedoc.requirements.txt 

--- a/docs/.readthedoc.requirements.txt
+++ b/docs/.readthedoc.requirements.txt
@@ -1,3 +1,4 @@
 breathe==4.30.0
 sphinx==4.0.2
 sphinx_rtd_theme==0.5.2
+urllib3<2.0


### PR DESCRIPTION
## What
Bump up the Python version used to build docs and limit the urllib3 ver.

## Why ?
Failure due to package version mismatch.
