### PR TITLE
UCP/PROTO/AZP: Enable new proto, address and sa_data versions

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -287,10 +287,10 @@ stages:
         test_perf: 0
     - template: tests.yml
       parameters:
-        name: roce_proto_enable
+        name: roce_proto_disable
         demands: ucx_roce -equals yes
         test_perf: 0
-        proto_enable: yes
+        proto_disable: yes
     - template: tests.yml
       parameters:
         name: BlueField

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -43,6 +43,6 @@ jobs:
           EXECUTOR_NUMBER: $(AZP_AGENT_ID)
           RUN_TESTS: yes
           JENKINS_TEST_PERF: ${{ parameters.test_perf }}
-          PROTO_ENABLE: ${{ parameters.proto_enable }}
+          PROTO_DISABLE: ${{ parameters.proto_disable }}
           JENKINS_NO_VALGRIND: ${{ parameters.valgrind_disable }}
           RUNNING_IN_AZURE: yes

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1282,6 +1282,8 @@ run_tests() {
 	export UCX_IB_ROCE_LOCAL_SUBNET=y
 	export UCX_IB_ROCE_SUBNET_PREFIX_LEN=inf
 
+	export UCX_PROTO_REQUEST_RESET=y
+
 	# load cuda env only if GPU available for remaining tests
 	try_load_cuda_env
 
@@ -1318,7 +1320,7 @@ run_tests() {
 	do_distributed_task 0 4 run_release_mode_tests
 }
 
-run_test_proto_enable() {
+run_test_proto_disable() {
 	export UCX_HANDLE_ERRORS=bt
 	export UCX_ERROR_SIGNALS=SIGILL,SIGSEGV,SIGBUS,SIGFPE,SIGPIPE,SIGABRT
 	export UCX_TCP_PORT_RANGE="$((33000 + EXECUTOR_NUMBER * 1000))-$((33999 + EXECUTOR_NUMBER * 1000))"
@@ -1331,8 +1333,7 @@ run_test_proto_enable() {
 	# build for devel tests and gtest
 	build devel --enable-gtest
 
-	export UCX_PROTO_ENABLE=y
-	export UCX_PROTO_REQUEST_RESET=y
+	export UCX_PROTO_ENABLE=n
 
 	# all are running gtest
 	run_gtest "default"
@@ -1344,8 +1345,8 @@ try_load_cuda_env
 if [ -n "$JENKINS_RUN_TESTS" ] || [ -n "$RUN_TESTS" ]
 then
     check_machine
-    if [[ "$PROTO_ENABLE" == "yes" ]]; then
-        run_test_proto_enable
+    if [[ "$PROTO_DISABLE" == "yes" ]]; then
+        run_test_proto_disable
     else
         run_tests
     fi

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -368,7 +368,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "would be cut to that maximal value.",
    ucs_offsetof(ucp_context_config_t, listener_backlog), UCS_CONFIG_TYPE_ULUNITS},
 
-  {"PROTO_ENABLE", "n",
+  {"PROTO_ENABLE", "y",
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_context_config_t, proto_enable), UCS_CONFIG_TYPE_BOOL},
 
@@ -408,7 +408,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "lane without waiting for remote completion.",
    ucs_offsetof(ucp_context_config_t, rndv_put_force_flush), UCS_CONFIG_TYPE_BOOL},
 
-  {"SA_DATA_VERSION", "v1",
+  {"SA_DATA_VERSION", "v2",
    "Defines the minimal header version the client will use for establishing\n"
    "client/server connection",
    ucs_offsetof(ucp_context_config_t, sa_client_min_hdr_version),
@@ -420,7 +420,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "dynamically allocated memory.",
    ucs_offsetof(ucp_context_config_t, rkey_mpool_max_md), UCS_CONFIG_TYPE_INT},
 
-  {"ADDRESS_VERSION", "v1",
+  {"ADDRESS_VERSION", "v2",
    "Defines UCP worker address format obtained with ucp_worker_get_address() or\n"
    "ucp_worker_query() routines.",
    ucs_offsetof(ucp_context_config_t, worker_addr_version),

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -121,9 +121,10 @@ enum {
                                                                of arm_ifaces list, so
                                                                it needs to be armed
                                                                in ucp_worker_arm(). */
-    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2)  /**< There is another UCP iface
+    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2), /**< There is another UCP iface
                                                                with the same caps, but
                                                                with better performance */
+    UCP_WORKER_IFACE_FLAG_WAS_USED          = UCS_BIT(3)
 };
 
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -605,6 +605,7 @@ ucp_proto_select_wiface_activate(ucp_worker_h worker,
         rsc_index = ep_config_key->lanes[lane].rsc_index;
         wiface    = ucp_worker_iface(worker, rsc_index);
         ucp_worker_iface_progress_ep(wiface);
+        wiface->flags |= UCP_WORKER_IFACE_FLAG_WAS_USED;
     }
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1015,11 +1015,23 @@ static int ucp_wireup_should_activate_wiface(ucp_worker_iface_t *wiface,
     /* Activate worker iface if: a) new protocol selection logic is disabled; or
      * b) stream support is requested, because stream API does not support new
      * protocol selection logic; or c) lane is used for checking a connection
-     * state; or d) the endpoint is a mem-type ep. */
+     * state; or d) the endpoint is a mem-type ep; or e) iface was activated
+     * before (some ep was created and later destroyed). The last check is
+     * needed to workaround the following problem with proto v2:
+     * 1. ep is created using some ep config
+     * 2. Some protocols are selected for some operations and this enables
+     *    progress for the affected lanes
+     * 3. ep is destroyed and progress is disabled for all corresponding ifaces
+     * 4. New ep is created with the same ep config used during step n1
+     * 5. Progress is not enabled, because protocols selection for these
+     *    parameters (and ep config) was already done on step n2.
+     * TODO: Reconsider this approach when progress enabling scheme changes. */
+
     return !context->config.ext.proto_enable ||
            (context->config.features & UCP_FEATURE_STREAM) ||
            (ucp_ep_config(ep)->key.keepalive_lane == lane) ||
-           (ep->flags & UCP_EP_FLAG_INTERNAL);
+           (ep->flags & UCP_EP_FLAG_INTERNAL) ||
+           (wiface->flags & UCP_WORKER_IFACE_FLAG_WAS_USED);
 }
 
 static ucs_status_t

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -33,15 +33,15 @@ class test_ucp_am_base : public ucp_test {
 public:
     test_ucp_am_base()
     {
-        if (is_proto_enabled()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (is_proto_disabled()) {
+            modify_config("PROTO_ENABLE", "n");
         }
     }
 
     static void get_test_variants(variant_vec_t &variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
-        add_variant_with_value(variants, UCP_FEATURE_AM, 1, "proto");
+        add_variant_with_value(variants, UCP_FEATURE_AM, 1, "proto_v1");
     }
 
     virtual void init()
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    bool is_proto_enabled() const
+    bool is_proto_disabled() const
     {
         return get_variant_value();
     }

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -17,8 +17,8 @@ class test_ucp_atomic : public test_ucp_memheap {
 public:
     /* Test variants */
     enum {
-        ATOMIC_MODE  = UCS_MASK(2),
-        ENABLE_PROTO = UCS_BIT(2)
+        ATOMIC_MODE   = UCS_MASK(2),
+        DISABLE_PROTO = UCS_BIT(2)
     };
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants,
@@ -34,7 +34,7 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         get_test_variants(variants, 0, "");
-        get_test_variants(variants, ENABLE_PROTO, "/proto");
+        get_test_variants(variants, DISABLE_PROTO, "/proto_v1");
     }
 
     struct send_func_data {
@@ -133,8 +133,8 @@ protected:
                         "";
         modify_config("ATOMIC_MODE", atomic_mode_cfg);
 
-        if (get_variant_value() & ENABLE_PROTO) {
-            modify_config("PROTO_ENABLE", "y");
+        if (get_variant_value() & DISABLE_PROTO) {
+            modify_config("PROTO_ENABLE", "n");
         }
 
         test_ucp_memheap::init();
@@ -214,7 +214,7 @@ private:
             ucs_memory_type_t send_mem_type = pairs[i][0], recv_mem_type = pairs[i][1];
             if (!UCP_MEM_IS_HOST(send_mem_type) || !UCP_MEM_IS_HOST(recv_mem_type)) {
                 /* Memory type atomics are fully supported only with new protocols */
-                if (!(get_variant_value() & ENABLE_PROTO)) {
+                if (get_variant_value() & DISABLE_PROTO) {
                     continue;
                 }
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -26,7 +26,7 @@ public:
     enum {
         VARIANT_DEFAULT,
         VARIANT_MAP_NONBLOCK,
-        VARIANT_PROTO_ENABLE,
+        VARIANT_PROTO_DISABLE,
         VARIANT_NO_RCACHE
     };
 
@@ -38,7 +38,7 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_RMA |extra_features,
                                VARIANT_MAP_NONBLOCK, "map_nb");
         add_variant_with_value(variants, UCP_FEATURE_RMA | extra_features,
-                               VARIANT_PROTO_ENABLE, "proto");
+                               VARIANT_PROTO_DISABLE, "proto_v1");
         add_variant_with_value(variants, UCP_FEATURE_RMA | extra_features,
                                VARIANT_NO_RCACHE, "no_rcache");
     }
@@ -86,8 +86,8 @@ public:
 
     virtual void init() {
         ucs::skip_on_address_sanitizer();
-        if (enable_proto()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (disable_proto()) {
+            modify_config("PROTO_ENABLE", "n");
         }
 
         if (get_variant_value() == VARIANT_NO_RCACHE) {
@@ -165,7 +165,7 @@ protected:
                     bool import_mem = false);
     void test_rkey_management(ucp_mem_h memh, bool is_dummy,
                               bool expect_rma_offload);
-    bool enable_proto() const;
+    bool disable_proto() const;
 
 private:
     void expect_same_distance(const ucs_sys_dev_distance_t &dist1,
@@ -351,9 +351,9 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
     ucp_rkey_buffer_release(rkey_buffer);
 }
 
-bool test_ucp_mmap::enable_proto() const
+bool test_ucp_mmap::disable_proto() const
 {
-    return get_variant_value() == VARIANT_PROTO_ENABLE;
+    return get_variant_value() == VARIANT_PROTO_DISABLE;
 }
 
 void test_ucp_mmap::expect_same_distance(const ucs_sys_dev_distance_t &dist1,
@@ -407,7 +407,7 @@ void test_ucp_mmap::test_rkey_proto(ucp_mem_h memh)
     ASSERT_UCS_OK(status);
 
     /* Check rkey configuration */
-    if (enable_proto()) {
+    if (!disable_proto()) {
         ucp_rkey_config_t *rkey_config = ucp_rkey_config(receiver().worker(),
                                                          rkey);
         ucp_ep_config_t *ep_config     = ucp_ep_config(receiver().ep());

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -24,14 +24,15 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "flush_worker");
         add_variant_with_value(variants, UCP_FEATURE_RMA, FLUSH_EP, "flush_ep");
         add_variant_with_value(variants, UCP_FEATURE_RMA,
-                               FLUSH_EP | ENABLE_PROTO, "flush_ep_proto");
+                               FLUSH_EP | DISABLE_PROTO, "flush_ep_proto");
         add_variant_with_value(variants, UCP_FEATURE_RMA, USER_MEMH,
                                "user_memh");
     }
 
     virtual void init() {
-        if (enable_proto()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (disable_proto()) {
+            modify_config("PROTO_ENABLE", "n");
+        } else {
             modify_config("MAX_RMA_LANES", "2");
         }
         test_ucp_memheap::init();
@@ -116,7 +117,7 @@ protected:
         for (size_t i = 0; i < pairs.size(); ++i) {
 
             /* Memory type put/get is fully supported only with new protocols */
-            if (!enable_proto() &&
+            if (disable_proto() &&
                 (!UCP_MEM_IS_HOST(pairs[i][0]) ||
                  !UCP_MEM_IS_HOST(pairs[i][1]))) {
                 continue;
@@ -131,8 +132,8 @@ protected:
                            UCS_MEMORY_TYPE_HOST, UCP_MEM_MAP_NONBLOCK);
     }
 
-    bool enable_proto() {
-        return get_variant_value() & ENABLE_PROTO;
+    bool disable_proto() {
+        return get_variant_value() & DISABLE_PROTO;
     }
 
     bool user_memh()
@@ -143,9 +144,9 @@ protected:
 private:
     /* Test variants */
     enum {
-        FLUSH_EP     = UCS_BIT(0), /* If not set, flush worker */
-        ENABLE_PROTO = UCS_BIT(1),
-        USER_MEMH    = UCS_BIT(2)
+        FLUSH_EP      = UCS_BIT(0), /* If not set, flush worker */
+        DISABLE_PROTO = UCS_BIT(1),
+        USER_MEMH     = UCS_BIT(2)
     };
 
     void init_iov(size_t size, ucp_dt_iov_t *iov, size_t iov_count,
@@ -280,7 +281,7 @@ UCS_TEST_P(test_ucp_rma, put_nonblocking) {
     test_mem_types(static_cast<send_func_t>(&test_ucp_rma::put_nbi));
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_rma, put_nonblocking_iov_zcopy, !enable_proto(),
+UCS_TEST_SKIP_COND_P(test_ucp_rma, put_nonblocking_iov_zcopy, disable_proto(),
                      "ZCOPY_THRESH=0") {
     if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
         UCS_TEST_SKIP_R("put_zcopy is not supported");
@@ -299,7 +300,7 @@ UCS_TEST_P(test_ucp_rma, get_nonblocking) {
     test_mem_types(static_cast<send_func_t>(&test_ucp_rma::get_nbi));
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_rma, get_nonblocking_iov_zcopy, !enable_proto(),
+UCS_TEST_SKIP_COND_P(test_ucp_rma, get_nonblocking_iov_zcopy, disable_proto(),
                      "ZCOPY_THRESH=0") {
     if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_GET_ZCOPY)) {
         UCS_TEST_SKIP_R("get_zcopy is not supported");

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -48,7 +48,7 @@ public:
         TEST_MODIFIER_MASK               = UCS_MASK(16),
         TEST_MODIFIER_MT                 = UCS_BIT(16),
         TEST_MODIFIER_CM_USE_ALL_DEVICES = UCS_BIT(17),
-        TEST_MODIFIER_SA_DATA_V2         = UCS_BIT(18)
+        TEST_MODIFIER_SA_DATA_V1         = UCS_BIT(18)
     };
 
     enum {
@@ -69,7 +69,7 @@ public:
         m_err_count = 0;
         modify_config("KEEPALIVE_INTERVAL", "5s");
         modify_config("CM_USE_ALL_DEVICES", cm_use_all_devices() ? "y" : "n");
-        modify_config("SA_DATA_VERSION", sa_data_version_v2() ? "v2" : "v1");
+        modify_config("SA_DATA_VERSION", sa_data_version_v1() ? "v1" : "v2");
         modify_config("RC_TIMEOUT", "100us", IGNORE_IF_NOT_EXIST);
         modify_config("RC_RETRY_COUNT", "3", IGNORE_IF_NOT_EXIST);
         modify_config("UD_TIMEOUT", "5s", IGNORE_IF_NOT_EXIST);
@@ -95,7 +95,7 @@ public:
                              modifier | TEST_MODIFIER_CM_USE_ALL_DEVICES, name);
         get_test_variants_mt(variants, features,
                              modifier | TEST_MODIFIER_CM_USE_ALL_DEVICES |
-                             TEST_MODIFIER_SA_DATA_V2, name + ",sa_data_v2");
+                             TEST_MODIFIER_SA_DATA_V1, name + ",sa_data_v2");
         get_test_variants_mt(variants, features, modifier, name + ",not_all_devs");
     }
 
@@ -881,8 +881,8 @@ protected:
         return get_variant_value() & TEST_MODIFIER_CM_USE_ALL_DEVICES;
     }
 
-    bool sa_data_version_v2() const {
-        return get_variant_value() & TEST_MODIFIER_SA_DATA_V2;
+    bool sa_data_version_v1() const {
+        return get_variant_value() & TEST_MODIFIER_SA_DATA_V1;
     }
 
     bool has_rndv_lanes(ucp_ep_h ep)
@@ -2738,32 +2738,32 @@ UCS_TEST_P(test_ucp_sockaddr_protocols,
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols,
-           am_rndv_64k_prereg_proto_v2_single_rndv_put_zcopy_lane,
+           am_rndv_64k_prereg_proto_v1_single_rndv_put_zcopy_lane,
            "RNDV_THRESH=0", "MAX_RNDV_LANES=1", "RNDV_SCHEME=put_zcopy",
-           "PROTO_ENABLE=y")
+           "PROTO_ENABLE=n")
 {
     test_am_send_recv(64 * UCS_KBYTE, 0, 2, true, true);
 }
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_short_reset, "PROTO_ENABLE=y",
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_short_reset, "PROTO_ENABLE=n",
            "ZCOPY_THRESH=inf")
 {
     test_am_send_recv(16, 8, 1, false, false, UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_bcopy_reset, "PROTO_ENABLE=y",
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_bcopy_reset, "PROTO_ENABLE=n",
            "ZCOPY_THRESH=inf")
 {
     test_am_send_recv(2 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_reset, "PROTO_ENABLE=y")
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_reset, "PROTO_ENABLE=n")
 {
     test_am_send_recv(16 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_reset, "PROTO_ENABLE=y",
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_reset, "PROTO_ENABLE=n",
            "RNDV_THRESH=0")
 {
     test_am_send_recv(16 * UCS_KBYTE, 8, 1, false, false,

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -501,8 +501,8 @@ public:
 
     test_ucp_tag_nbx()
     {
-        if (enable_proto()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (disable_proto()) {
+            modify_config("PROTO_ENABLE", "n");
         }
     }
 
@@ -527,7 +527,7 @@ public:
     static void get_test_variants_proto(std::vector<ucp_test_variant> &variants)
     {
         add_variant_values(variants, get_test_variants_prereg, 0);
-        add_variant_values(variants, get_test_variants_prereg, 1, "proto");
+        add_variant_values(variants, get_test_variants_prereg, 1, "proto_v1");
     }
 
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
@@ -547,9 +547,9 @@ protected:
         return get_variant_value(0);
     }
 
-    bool enable_proto() const
+    bool disable_proto() const
     {
-        return m_ucp_config->ctx.proto_enable || get_variant_value(1);
+        return get_variant_value(1);
     }
 
     bool is_iov() const
@@ -705,7 +705,7 @@ UCS_TEST_P(test_ucp_tag_nbx, rndv_zcopy, "ZCOPY_THRESH=0", "RNDV_THRESH=0")
 
 UCS_TEST_P(test_ucp_tag_nbx, fallback, "ZCOPY_THRESH=inf")
 {
-    if (enable_proto() || prereg()) {
+    if (!disable_proto() || prereg()) {
         UCS_TEST_SKIP_R(
                 "protoV2/prereg are not supported for partial md reg failure");
     }

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -21,7 +21,7 @@ using namespace ucs; /* For vector<char> serialization */
 class test_ucp_tag_match : public test_ucp_tag {
 public:
     enum {
-        ENABLE_PROTO = UCS_BIT(8)
+        DISABLE_PROTO = UCS_BIT(8)
     };
 
     test_ucp_tag_match() {
@@ -34,8 +34,8 @@ public:
     virtual void init()
     {
         modify_config("TM_THRESH", "1");
-        if (use_proto()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (use_old_proto()) {
+            modify_config("PROTO_ENABLE", "n");
             modify_config("MAX_EAGER_LANES", "2");
         } else {
             if (RUNNING_ON_VALGRIND) {
@@ -52,15 +52,15 @@ public:
     }
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
-        UCS_STATIC_ASSERT(!(ENABLE_PROTO & RECV_REQ_INTERNAL));
-        UCS_STATIC_ASSERT(!(ENABLE_PROTO & RECV_REQ_EXTERNAL));
+        UCS_STATIC_ASSERT(!(DISABLE_PROTO & RECV_REQ_INTERNAL));
+        UCS_STATIC_ASSERT(!(DISABLE_PROTO & RECV_REQ_EXTERNAL));
 
         add_variant_with_value(variants, get_ctx_params(), RECV_REQ_INTERNAL,
                                "req_int");
         add_variant_with_value(variants, get_ctx_params(), RECV_REQ_EXTERNAL,
                                "req_ext");
         add_variant_with_value(variants, get_ctx_params(),
-                               RECV_REQ_INTERNAL | ENABLE_PROTO, "req_int_proto");
+                               RECV_REQ_INTERNAL | DISABLE_PROTO, "req_int_proto_v1");
     }
 
     virtual bool is_external_request()
@@ -78,9 +78,9 @@ protected:
         m_req_status = status;
     }
 
-    bool use_proto() const
+    bool use_old_proto() const
     {
-        return get_variant_value() & ENABLE_PROTO;
+        return get_variant_value() & DISABLE_PROTO;
     }
 
     static ucs_status_t m_req_status;
@@ -553,14 +553,14 @@ public:
         RNDV_SCHEME_GET_ZCOPY,
         RNDV_SCHEME_LAST,
         RNDV_GET_ZCOPY_MANY_LANES,
-        PUT_ZCOPY_FLUSH = ENABLE_PROTO << 1
+        PUT_ZCOPY_FLUSH = DISABLE_PROTO << 1
     };
 
     static const std::string rndv_schemes[];
 
     void init() {
         ASSERT_LE(rndv_scheme(), (int)RNDV_SCHEME_GET_ZCOPY);
-        UCS_STATIC_ASSERT(!(ENABLE_PROTO & UCS_MASK(RNDV_SCHEME_LAST)));
+        UCS_STATIC_ASSERT(!(DISABLE_PROTO & UCS_MASK(RNDV_SCHEME_LAST)));
         modify_config("RNDV_THRESH", "0");
         modify_config("RNDV_SCHEME", rndv_schemes[rndv_scheme()]);
         modify_config("RNDV_PUT_FORCE_FLUSH", force_flush() ? "y" : "n");
@@ -575,27 +575,27 @@ public:
             add_variant_with_value(variants, get_ctx_params(), rndv_scheme,
                                    "rndv_" + rndv_schemes[rndv_scheme]);
             add_variant_with_value(variants, get_ctx_params(),
-                                   rndv_scheme | ENABLE_PROTO,
-                                   rndv_schemes[rndv_scheme] + ",proto");
+                                   rndv_scheme | DISABLE_PROTO,
+                                   rndv_schemes[rndv_scheme] + ",proto_v1");
         }
 
         // Add variant with force flush
         add_variant_with_value(variants, get_ctx_params(),
-                               RNDV_SCHEME_PUT_ZCOPY | ENABLE_PROTO |
+                               RNDV_SCHEME_PUT_ZCOPY | DISABLE_PROTO |
                                        PUT_ZCOPY_FLUSH,
-                               "rndv_put_flush,proto");
+                               "rndv_put_flush,proto_v1");
         // Add variant to check the RNDV lanes weight correctness for many lanes number
         add_variant_with_value(variants, get_ctx_params(),
-                               RNDV_SCHEME_GET_ZCOPY | ENABLE_PROTO |
+                               RNDV_SCHEME_GET_ZCOPY | DISABLE_PROTO |
                                        RNDV_GET_ZCOPY_MANY_LANES,
-                               "rndv_get_zcopy,proto,many_lanes");
+                               "rndv_get_zcopy,proto_v1,many_lanes");
     }
 
 protected:
     int rndv_scheme() const
     {
         int mask = ucs_roundup_pow2(static_cast<int>(RNDV_SCHEME_LAST) + 1) - 1;
-        ucs_assert(!(mask & ENABLE_PROTO));
+        ucs_assert(!(mask & DISABLE_PROTO));
         return get_variant_value() & mask;
     }
 
@@ -968,8 +968,8 @@ public:
     {
         for (int rndv_scheme = 0; rndv_scheme < RNDV_SCHEME_LAST; ++rndv_scheme) {
             add_variant_with_value(variants, get_ctx_params(),
-                                   rndv_scheme | ENABLE_PROTO,
-                                   rndv_schemes[rndv_scheme] + ",proto");
+                                   rndv_scheme | DISABLE_PROTO,
+                                   rndv_schemes[rndv_scheme] + ",proto_v1");
         }
     }
 protected:

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -49,7 +49,7 @@ public:
             enable_tag_mp_offload();
 
             if (RUNNING_ON_VALGRIND) {
-                if (variant_flags & VARIANT_PROTO) {
+                if (!(variant_flags & VARIANT_PROTO)) {
                     skip_protov2();
                 }
 
@@ -65,7 +65,8 @@ public:
         }
 
         if (variant_flags & VARIANT_PROTO) {
-            modify_config("PROTO_ENABLE", "y");
+            modify_config("PROTO_ENABLE", "n");
+        } else {
             modify_config("PROTO_REQUEST_RESET", "y");
         }
 
@@ -108,7 +109,7 @@ public:
         }
 
         if (variant_flags & VARIANT_PROTO) {
-            name += ",proto";
+            name += ",proto_v1";
         }
 
         add_variant_with_value(variants, get_ctx_params(), variant_value, name);

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -51,7 +51,7 @@ public:
         } else if (get_variant_value() == VARIANT_RNDV_GET_ZCOPY) {
             modify_config("RNDV_SCHEME", "get_zcopy");
         } else if (get_variant_value() == VARIANT_PROTO) {
-            modify_config("PROTO_ENABLE", "y");
+            modify_config("PROTO_ENABLE", "n");
         }
 
         /* Init number of lanes according to test requirement
@@ -82,7 +82,7 @@ public:
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_SEND_NBR, "send_nbr");
         add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO,
-                               "proto");
+                               "proto_v1");
     }
 
     virtual ucp_ep_params_t get_ep_params() {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1749,9 +1749,9 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_TAG,
-                               TEST_TAG | WORKER_ADDR_V1, "tag");
+                               TEST_TAG, "tag");
         add_variant_with_value(variants, UCP_FEATURE_TAG,
-                               TEST_TAG | WORKER_ADDR_V1 | UNIFIED_MODE,
+                               TEST_TAG | UNIFIED_MODE,
                                "tag,unified");
     }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -33,7 +33,7 @@ protected:
         UNIFIED_MODE   = UCS_BIT(3),
         TEST_AMO       = UCS_BIT(4),
         NO_EP_MATCH    = UCS_BIT(5),
-        WORKER_ADDR_V2 = UCS_BIT(6)
+        WORKER_ADDR_V1 = UCS_BIT(6)
     };
 
     typedef uint64_t               elem_type;
@@ -140,10 +140,10 @@ void test_ucp_wireup::get_test_variants(std::vector<ucp_test_variant>& variants,
                                TEST_TAG | UNIFIED_MODE | NO_EP_MATCH,
                                "tag,unified,no_ep_match");
         add_variant_with_value(variants, UCP_FEATURE_TAG,
-                               TEST_TAG | WORKER_ADDR_V2, "tag,addr_v2");
+                               TEST_TAG | WORKER_ADDR_V1, "tag,addr_v1");
         add_variant_with_value(variants, UCP_FEATURE_TAG,
-                               TEST_TAG | WORKER_ADDR_V2 | UNIFIED_MODE,
-                               "tag,unified,addr_v2");
+                               TEST_TAG | WORKER_ADDR_V1 | UNIFIED_MODE,
+                               "tag,unified,addr_v1");
     }
 
     if (features & UCP_FEATURE_STREAM) {
@@ -181,8 +181,8 @@ void test_ucp_wireup::init()
         modify_config("UNIFIED_MODE", "y");
     }
 
-    if (get_variant_value() & WORKER_ADDR_V2) {
-        modify_config("ADDRESS_VERSION", "v2");
+    if (get_variant_value() & WORKER_ADDR_V1) {
+        modify_config("ADDRESS_VERSION", "v1");
     }
 
     ucp_test::init();
@@ -452,8 +452,8 @@ public:
     }
 
     ucp_object_version_t address_version() const {
-        return (get_variant_value() & WORKER_ADDR_V2) ?
-               UCP_OBJECT_VERSION_V2 : UCP_OBJECT_VERSION_V1;
+        return (get_variant_value() & WORKER_ADDR_V1) ?
+               UCP_OBJECT_VERSION_V1 : UCP_OBJECT_VERSION_V2;
     }
 
     ucp_lane_index_t m_lanes2remote[UCP_MAX_LANES];
@@ -1749,9 +1749,9 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_TAG,
-                               TEST_TAG | WORKER_ADDR_V2, "tag");
+                               TEST_TAG | WORKER_ADDR_V1, "tag");
         add_variant_with_value(variants, UCP_FEATURE_TAG,
-                               TEST_TAG | WORKER_ADDR_V2 | UNIFIED_MODE,
+                               TEST_TAG | WORKER_ADDR_V1 | UNIFIED_MODE,
                                "tag,unified");
     }
 


### PR DESCRIPTION
## What
Enable by default:
- new proto version
- new worker address format
- new sa_data format

wire compatibility AZP CI check will be added in the separate PR