### PR TITLE
UCP: Limit the maximum iov account based on UCS_ALLOCA_MAX_SIZE

### DIFF
--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -433,7 +433,8 @@ ucs_status_t ucp_do_am_zcopy_multi(uct_pending_req_t *self, uint8_t am_id_first,
     }
 
     max_zcopy = ucp_ep_get_max_zcopy(ep, req->send.lane) - user_hdr_size;
-    max_iov   = ucp_ep_get_max_iov(ep, req->send.lane) - !!user_hdr_size;
+    max_iov   = ucs_min(ucp_ep_get_max_iov(ep, req->send.lane) - !!user_hdr_size,
+                        (UCS_ALLOCA_MAX_SIZE / sizeof(*iov)) - 1);
     iov       = ucs_alloca((max_iov + 1) * sizeof(uct_iov_t));
 
     for (;;) {

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -296,6 +296,11 @@ UCS_TEST_P(test_ucp_am, send_process_am_release)
     do_send_process_data_test(UCP_RELEASE, 0, 0);
 }
 
+UCS_TEST_P(test_ucp_am, send_process_iov_am_64k_size)
+{
+    do_send_process_data_iov_test(65536);
+}
+
 UCS_TEST_P(test_ucp_am, send_process_iov_am)
 {
     ucs::detail::message_stream ms("INFO");


### PR DESCRIPTION
## What
Fix assert abort in `ucp_do_am_zcopy_multi`.

## Why ?
To avoid stack overflow ucs_alloca only permits 1200 bytes for echo memory allocating request.
But in `ucp_do_am_zcopy_multi`, the request memory size is greater than 1200 bytes in some case (tcp in AM sending with 64k data size).

## How ?
Limit the maximum iov account based on UCS_ALLOCA_MAX_SIZE.