### PR TITLE
UCP/TOPO/BUG: Add memory distance only for relevant devices

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -380,7 +380,6 @@ static void ucs_topo_get_memory_distance_sysfs(ucs_sys_device_t device,
     char path[PATH_MAX];
     ucs_numa_node_t dev_node;
     ucs_status_t status;
-    const char *dev_name;
 
     /* If the device is unknown, we assume min distance */
     if (device == UCS_SYS_DEVICE_ID_UNKNOWN) {
@@ -412,8 +411,7 @@ static void ucs_topo_get_memory_distance_sysfs(ucs_sys_device_t device,
                                             ucs_numa_node_of_cpu(cpu));
     }
 
-    dev_name            = ucs_topo_sys_device_get_name(device);
-    distance->bandwidth = ucs_topo_get_pci_bw(dev_name, path);
+    distance->bandwidth = ucs_topo_default_distance.bandwidth;
     cpuset_size         = full_affinity ? num_cpus : CPU_COUNT(&thread_cpuset);
     distance->latency = ucs_topo_sysfs_numa_distance_to_latency(total_distance /
                                                                 cpuset_size);


### PR DESCRIPTION
## What
fixes https://github.com/openucx/ucx/issues/9072

## Why ?
Bug

## How ?
Fix perf estimation, Add NUMA latency only when it's relevant.

Results after applying the fix on Peter's setup:

**Old Proto**
<details>

```
+--------------+--------------+------------------------------+---------------------+-----------------------+
| API:          protocol layer                                                                             |
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
| Test:         tag match bandwidth                                                                        |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
| Data layout:  (automatic)                                                                                |
| Send memory:  cuda                                                                                       |
| Recv memory:  cuda                                                                                       |
| Message size: 64000000                                                                                   |
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+----------------------------------------------------------------------------------------------------------+
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
[thread 0]               412   2633.335  2434.670  2434.670    25069.17   25069.17         411         411
[thread 0]               792   2633.423  2639.592  2532.991    23122.95   24096.08         379         395
[thread 0]              1172   2633.401  2639.605  2567.559    23122.83   23771.67         379         389
[thread 0]              1552   2633.421  2639.602  2585.198    23122.86   23609.47         379         387
[thread 0]              1932   2633.404  2639.608  2595.900    23122.81   23512.14         379         385
[thread 0]              2312   2633.685  2639.605  2603.084    23122.83   23447.25         379         384
[thread 0]              2692   2634.004  2639.600  2608.238    23122.88   23400.91         379         383
Final:                  3000   2634.209  2914.269  2639.657    20943.55   23122.38         343         379
```

</details>

**Proto V2**
<details>

```
+--------------+--------------+------------------------------+---------------------+-----------------------+
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
+----------------------------------------------------------------------------------------------------------+
| API:          protocol layer                                                                             |
| Test:         tag match bandwidth                                                                        |
| Data layout:  (automatic)                                                                                |
| Send memory:  cuda                                                                                       |
| Recv memory:  cuda                                                                                       |
| Message size: 64000000                                                                                   |
+----------------------------------------------------------------------------------------------------------+
[thread 0]               412   2632.885  2434.422  2434.422    25071.72   25071.72         411         411
[thread 0]               792   2632.977  2639.242  2532.694    23126.02   24098.90         379         395
[thread 0]              1172   2633.022  2639.242  2567.241    23126.02   23774.61         379         390
[thread 0]              1552   2633.068  2639.242  2584.870    23126.02   23612.47         379         387
[thread 0]              1932   2633.073  2639.245  2595.565    23125.99   23515.17         379         385
[thread 0]              2312   2633.334  2639.250  2602.745    23125.95   23450.30         379         384
[thread 0]              2692   2633.621  2639.232  2607.895    23126.11   23403.99         379         383
Final:                  3000   2633.815  2913.854  2639.307    20946.54   23125.45         343         379
```

</details>
