### PR TITLE
UCP/GTEST: Enable protov2 by default (wire-compat is not addressed)

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -287,10 +287,10 @@ stages:
         test_perf: 0
     - template: tests.yml
       parameters:
-        name: roce_proto_enable
+        name: roce_proto_disable
         demands: ucx_roce -equals yes
         test_perf: 0
-        proto_enable: yes
+        proto_enable: no
     - template: tests.yml
       parameters:
         name: BlueField

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -4,6 +4,7 @@ parameters:
   demands: []
   name: subtest
   container:
+  proto_enable: yes
 
 jobs:
   - job: tests_${{ parameters.name }}

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1282,6 +1282,8 @@ run_tests() {
 	export UCX_IB_ROCE_LOCAL_SUBNET=y
 	export UCX_IB_ROCE_SUBNET_PREFIX_LEN=inf
 
+	export UCX_PROTO_REQUEST_RESET=y
+
 	# load cuda env only if GPU available for remaining tests
 	try_load_cuda_env
 
@@ -1318,7 +1320,7 @@ run_tests() {
 	do_distributed_task 0 4 run_release_mode_tests
 }
 
-run_test_proto_enable() {
+run_test_proto_disable() {
 	export UCX_HANDLE_ERRORS=bt
 	export UCX_ERROR_SIGNALS=SIGILL,SIGSEGV,SIGBUS,SIGFPE,SIGPIPE,SIGABRT
 	export UCX_TCP_PORT_RANGE="$((33000 + EXECUTOR_NUMBER * 1000))-$((33999 + EXECUTOR_NUMBER * 1000))"
@@ -1331,8 +1333,7 @@ run_test_proto_enable() {
 	# build for devel tests and gtest
 	build devel --enable-gtest
 
-	export UCX_PROTO_ENABLE=y
-	export UCX_PROTO_REQUEST_RESET=y
+	export UCX_PROTO_ENABLE=n
 
 	# all are running gtest
 	run_gtest "default"
@@ -1344,8 +1345,8 @@ try_load_cuda_env
 if [ -n "$JENKINS_RUN_TESTS" ] || [ -n "$RUN_TESTS" ]
 then
     check_machine
-    if [[ "$PROTO_ENABLE" == "yes" ]]; then
-        run_test_proto_enable
+    if [[ "$PROTO_ENABLE" == "no" ]]; then
+        run_test_proto_disable
     else
         run_tests
     fi

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -370,7 +370,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "would be cut to that maximal value.",
    ucs_offsetof(ucp_context_config_t, listener_backlog), UCS_CONFIG_TYPE_ULUNITS},
 
-  {"PROTO_ENABLE", "n",
+  {"PROTO_ENABLE", "y",
    "Experimental: enable new protocol selection logic",
    ucs_offsetof(ucp_context_config_t, proto_enable), UCS_CONFIG_TYPE_BOOL},
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -33,15 +33,15 @@ class test_ucp_am_base : public ucp_test {
 public:
     test_ucp_am_base()
     {
-        if (is_proto_enabled()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (is_proto_disabled()) {
+            modify_config("PROTO_ENABLE", "n");
         }
     }
 
     static void get_test_variants(variant_vec_t &variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
-        add_variant_with_value(variants, UCP_FEATURE_AM, 1, "proto");
+        add_variant_with_value(variants, UCP_FEATURE_AM, 1, "proto_v1");
     }
 
     virtual void init()
@@ -54,7 +54,7 @@ public:
     }
 
 protected:
-    bool is_proto_enabled() const
+    bool is_proto_disabled() const
     {
         return get_variant_value();
     }
@@ -510,7 +510,7 @@ protected:
     {
         std::vector<ucp_dt_type> dts = {UCP_DATATYPE_CONTIG};
 
-        if (is_proto_enabled()) {
+        if (!is_proto_disabled()) {
             dts.push_back(UCP_DATATYPE_IOV);
         }
 

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -17,8 +17,8 @@ class test_ucp_atomic : public test_ucp_memheap {
 public:
     /* Test variants */
     enum {
-        ATOMIC_MODE  = UCS_MASK(2),
-        ENABLE_PROTO = UCS_BIT(2)
+        ATOMIC_MODE   = UCS_MASK(2),
+        DISABLE_PROTO = UCS_BIT(2)
     };
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants,
@@ -34,7 +34,7 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         get_test_variants(variants, 0, "");
-        get_test_variants(variants, ENABLE_PROTO, "/proto");
+        get_test_variants(variants, DISABLE_PROTO, "/proto_v1");
     }
 
     struct send_func_data {
@@ -133,8 +133,8 @@ protected:
                         "";
         modify_config("ATOMIC_MODE", atomic_mode_cfg);
 
-        if (get_variant_value() & ENABLE_PROTO) {
-            modify_config("PROTO_ENABLE", "y");
+        if (get_variant_value() & DISABLE_PROTO) {
+            modify_config("PROTO_ENABLE", "n");
         }
 
         test_ucp_memheap::init();
@@ -214,7 +214,7 @@ private:
             ucs_memory_type_t send_mem_type = pairs[i][0], recv_mem_type = pairs[i][1];
             if (!UCP_MEM_IS_HOST(send_mem_type) || !UCP_MEM_IS_HOST(recv_mem_type)) {
                 /* Memory type atomics are fully supported only with new protocols */
-                if (!(get_variant_value() & ENABLE_PROTO)) {
+                if (get_variant_value() & DISABLE_PROTO) {
                     continue;
                 }
 

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -330,10 +330,6 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
     size_t max_iter = std::numeric_limits<size_t>::max();
     test_spec test  = tests[get_variant_value(VARIANT_TEST_TYPE)];
 
-    if (test.is_amo() && m_ucp_config->ctx.proto_enable) {
-        UCS_TEST_SKIP_R("FIXME: proto_v2 selects SW AMO when HW device is present");
-    }
-
     if (has_transport("tcp")) {
         check_perf = false;
         max_iter   = 1000lu;
@@ -377,10 +373,6 @@ class test_ucp_loopback : public test_ucp_perf {};
 UCS_TEST_P(test_ucp_loopback, envelope)
 {
     test_spec test = tests[get_variant_value(VARIANT_TEST_TYPE)];
-
-    if (test.is_amo() && m_ucp_config->ctx.proto_enable) {
-        UCS_TEST_SKIP_R("FIXME: proto_v2 selects SW AMO when HW device is present");
-    }
 
     test.send_mem_type = UCS_MEMORY_TYPE_HOST;
     test.recv_mem_type = UCS_MEMORY_TYPE_HOST;

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -7,9 +7,10 @@
 
 #include "test_ucp_memheap.h"
 
-#include <ucs/sys/sys.h>
 extern "C" {
+#include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_mm.h> /* for UCP_MEM_IS_ACCESSIBLE_FROM_CPU */
+#include <ucs/sys/sys.h>
 }
 
 
@@ -24,14 +25,15 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "flush_worker");
         add_variant_with_value(variants, UCP_FEATURE_RMA, FLUSH_EP, "flush_ep");
         add_variant_with_value(variants, UCP_FEATURE_RMA,
-                               FLUSH_EP | ENABLE_PROTO, "flush_ep_proto");
+                               FLUSH_EP | DISABLE_PROTO, "flush_ep_proto_v1");
         add_variant_with_value(variants, UCP_FEATURE_RMA, USER_MEMH,
                                "user_memh");
     }
 
     virtual void init() {
-        if (enable_proto()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (disable_proto()) {
+            modify_config("PROTO_ENABLE", "n");
+        } else {
             modify_config("MAX_RMA_LANES", "2");
         }
         test_ucp_memheap::init();
@@ -116,7 +118,7 @@ protected:
         for (size_t i = 0; i < pairs.size(); ++i) {
 
             /* Memory type put/get is fully supported only with new protocols */
-            if (!enable_proto() &&
+            if (!m_ucp_config->ctx.proto_enable &&
                 (!UCP_MEM_IS_HOST(pairs[i][0]) ||
                  !UCP_MEM_IS_HOST(pairs[i][1]))) {
                 continue;
@@ -131,8 +133,8 @@ protected:
                            UCS_MEMORY_TYPE_HOST, UCP_MEM_MAP_NONBLOCK);
     }
 
-    bool enable_proto() {
-        return get_variant_value() & ENABLE_PROTO;
+    bool disable_proto() {
+        return !m_ucp_config->ctx.proto_enable;
     }
 
     bool user_memh()
@@ -143,9 +145,9 @@ protected:
 private:
     /* Test variants */
     enum {
-        FLUSH_EP     = UCS_BIT(0), /* If not set, flush worker */
-        ENABLE_PROTO = UCS_BIT(1),
-        USER_MEMH    = UCS_BIT(2)
+        FLUSH_EP      = UCS_BIT(0), /* If not set, flush worker */
+        DISABLE_PROTO = UCS_BIT(1),
+        USER_MEMH     = UCS_BIT(2)
     };
 
     void init_iov(size_t size, ucp_dt_iov_t *iov, size_t iov_count,
@@ -280,7 +282,7 @@ UCS_TEST_P(test_ucp_rma, put_nonblocking) {
     test_mem_types(static_cast<send_func_t>(&test_ucp_rma::put_nbi));
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_rma, put_nonblocking_iov_zcopy, !enable_proto(),
+UCS_TEST_SKIP_COND_P(test_ucp_rma, put_nonblocking_iov_zcopy, disable_proto(),
                      "ZCOPY_THRESH=0") {
     if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
         UCS_TEST_SKIP_R("put_zcopy is not supported");
@@ -299,7 +301,7 @@ UCS_TEST_P(test_ucp_rma, get_nonblocking) {
     test_mem_types(static_cast<send_func_t>(&test_ucp_rma::get_nbi));
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_rma, get_nonblocking_iov_zcopy, !enable_proto(),
+UCS_TEST_SKIP_COND_P(test_ucp_rma, get_nonblocking_iov_zcopy, disable_proto(),
                      "ZCOPY_THRESH=0") {
     if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_GET_ZCOPY)) {
         UCS_TEST_SKIP_R("get_zcopy is not supported");

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2739,32 +2739,32 @@ UCS_TEST_P(test_ucp_sockaddr_protocols,
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols,
-           am_rndv_64k_prereg_proto_v2_single_rndv_put_zcopy_lane,
+           am_rndv_64k_prereg_proto_v1_single_rndv_put_zcopy_lane,
            "RNDV_THRESH=0", "MAX_RNDV_LANES=1", "RNDV_SCHEME=put_zcopy",
-           "PROTO_ENABLE=y")
+           "PROTO_ENABLE=n")
 {
     test_am_send_recv(64 * UCS_KBYTE, 0, 2, true, true);
 }
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_short_reset, "PROTO_ENABLE=y",
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_short_reset, "PROTO_ENABLE=n",
            "ZCOPY_THRESH=inf")
 {
     test_am_send_recv(16, 8, 1, false, false, UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_bcopy_reset, "PROTO_ENABLE=y",
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_bcopy_reset, "PROTO_ENABLE=n",
            "ZCOPY_THRESH=inf")
 {
     test_am_send_recv(2 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_reset, "PROTO_ENABLE=y")
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_reset, "PROTO_ENABLE=n")
 {
     test_am_send_recv(16 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_reset, "PROTO_ENABLE=y",
+UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_reset, "PROTO_ENABLE=n",
            "RNDV_THRESH=0")
 {
     test_am_send_recv(16 * UCS_KBYTE, 8, 1, false, false,

--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -125,10 +125,6 @@ protected:
 
     virtual bool is_external_request();
 
-    void skip_external_protov2() const;
-
-    void skip_protov2() const;
-
     static ucp_context_attr_t ctx_attr;
     ucs::ptr_vector<ucs::scoped_setenv> m_env;
 

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -21,7 +21,7 @@ using namespace ucs; /* For vector<char> serialization */
 class test_ucp_tag_match : public test_ucp_tag {
 public:
     enum {
-        ENABLE_PROTO = UCS_BIT(8)
+        DISABLE_PROTO = UCS_BIT(8)
     };
 
     test_ucp_tag_match() {
@@ -34,14 +34,10 @@ public:
     virtual void init()
     {
         modify_config("TM_THRESH", "1");
-        if (use_proto()) {
-            modify_config("PROTO_ENABLE", "y");
+        if (use_proto_v1()) {
+            modify_config("PROTO_ENABLE", "n");
             modify_config("MAX_EAGER_LANES", "2");
         } else {
-            if (RUNNING_ON_VALGRIND) {
-                skip_external_protov2();
-            }
-
             // TODO:
             // 1. test offload and offload MP as different variants
             // 2. Enable offload for new protocols as well when it is fully
@@ -52,15 +48,15 @@ public:
     }
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
-        UCS_STATIC_ASSERT(!(ENABLE_PROTO & RECV_REQ_INTERNAL));
-        UCS_STATIC_ASSERT(!(ENABLE_PROTO & RECV_REQ_EXTERNAL));
+        UCS_STATIC_ASSERT(!(DISABLE_PROTO & RECV_REQ_INTERNAL));
+        UCS_STATIC_ASSERT(!(DISABLE_PROTO & RECV_REQ_EXTERNAL));
 
         add_variant_with_value(variants, get_ctx_params(), RECV_REQ_INTERNAL,
                                "req_int");
         add_variant_with_value(variants, get_ctx_params(), RECV_REQ_EXTERNAL,
                                "req_ext");
         add_variant_with_value(variants, get_ctx_params(),
-                               RECV_REQ_INTERNAL | ENABLE_PROTO, "req_int_proto");
+                               RECV_REQ_INTERNAL | DISABLE_PROTO, "req_int_proto_v1");
     }
 
     virtual bool is_external_request()
@@ -78,9 +74,9 @@ protected:
         m_req_status = status;
     }
 
-    bool use_proto() const
+    bool use_proto_v1() const
     {
-        return get_variant_value() & ENABLE_PROTO;
+        return get_variant_value() & DISABLE_PROTO;
     }
 
     static ucs_status_t m_req_status;
@@ -553,14 +549,14 @@ public:
         RNDV_SCHEME_GET_ZCOPY,
         RNDV_SCHEME_LAST,
         RNDV_GET_ZCOPY_MANY_LANES,
-        PUT_ZCOPY_FLUSH = ENABLE_PROTO << 1
+        PUT_ZCOPY_FLUSH = DISABLE_PROTO << 1
     };
 
     static const std::string rndv_schemes[];
 
     void init() {
         ASSERT_LE(rndv_scheme(), (int)RNDV_SCHEME_GET_ZCOPY);
-        UCS_STATIC_ASSERT(!(ENABLE_PROTO & UCS_MASK(RNDV_SCHEME_LAST)));
+        UCS_STATIC_ASSERT(!(DISABLE_PROTO & UCS_MASK(RNDV_SCHEME_LAST)));
         modify_config("RNDV_THRESH", "0");
         modify_config("RNDV_SCHEME", rndv_schemes[rndv_scheme()]);
         modify_config("RNDV_PUT_FORCE_FLUSH", force_flush() ? "y" : "n");
@@ -575,27 +571,27 @@ public:
             add_variant_with_value(variants, get_ctx_params(), rndv_scheme,
                                    "rndv_" + rndv_schemes[rndv_scheme]);
             add_variant_with_value(variants, get_ctx_params(),
-                                   rndv_scheme | ENABLE_PROTO,
-                                   rndv_schemes[rndv_scheme] + ",proto");
+                                   rndv_scheme | DISABLE_PROTO,
+                                   rndv_schemes[rndv_scheme] + ",proto_v1");
         }
 
         // Add variant with force flush
         add_variant_with_value(variants, get_ctx_params(),
-                               RNDV_SCHEME_PUT_ZCOPY | ENABLE_PROTO |
+                               RNDV_SCHEME_PUT_ZCOPY | DISABLE_PROTO |
                                        PUT_ZCOPY_FLUSH,
-                               "rndv_put_flush,proto");
+                               "rndv_put_flush,proto_v1");
         // Add variant to check the RNDV lanes weight correctness for many lanes number
         add_variant_with_value(variants, get_ctx_params(),
-                               RNDV_SCHEME_GET_ZCOPY | ENABLE_PROTO |
+                               RNDV_SCHEME_GET_ZCOPY | DISABLE_PROTO |
                                        RNDV_GET_ZCOPY_MANY_LANES,
-                               "rndv_get_zcopy,proto,many_lanes");
+                               "rndv_get_zcopy,proto_v1,many_lanes");
     }
 
 protected:
     int rndv_scheme() const
     {
         int mask = ucs_roundup_pow2(static_cast<int>(RNDV_SCHEME_LAST) + 1) - 1;
-        ucs_assert(!(mask & ENABLE_PROTO));
+        ucs_assert(!(mask & DISABLE_PROTO));
         return get_variant_value() & mask;
     }
 
@@ -869,7 +865,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
     }
 }
 
-UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post)
+UCS_TEST_P(test_ucp_tag_match_rndv, bidir_multi_exp_post,
+           "PROTO_REQUEST_RESET=n")
 {
     const size_t sizes[] = {8 * UCS_KBYTE, 128 * UCS_KBYTE, 512 * UCS_KBYTE,
                             8 * UCS_MBYTE, 128 * UCS_MBYTE, 512 * UCS_MBYTE};
@@ -968,8 +965,8 @@ public:
     {
         for (int rndv_scheme = 0; rndv_scheme < RNDV_SCHEME_LAST; ++rndv_scheme) {
             add_variant_with_value(variants, get_ctx_params(),
-                                   rndv_scheme | ENABLE_PROTO,
-                                   rndv_schemes[rndv_scheme] + ",proto");
+                                   rndv_scheme | DISABLE_PROTO,
+                                   rndv_schemes[rndv_scheme] + ",proto_v1");
         }
     }
 protected:

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -23,7 +23,7 @@ public:
     enum {
         VARIANT_GDR_OFF     = UCS_BIT(0),
         VARIANT_TAG_OFFLOAD = UCS_BIT(1),
-        VARIANT_PROTO       = UCS_BIT(2),
+        VARIANT_PROTO_V1    = UCS_BIT(2),
         VARIANT_MAX         = UCS_BIT(3)
     };
 
@@ -49,12 +49,6 @@ public:
             enable_tag_mp_offload();
 
             if (RUNNING_ON_VALGRIND) {
-                if (variant_flags & VARIANT_PROTO) {
-                    skip_protov2();
-                }
-
-                skip_external_protov2();
-
                 m_env.push_back(
                         new ucs::scoped_setenv("UCX_RC_TM_SEG_SIZE", "8k"));
                 m_env.push_back(
@@ -64,8 +58,9 @@ public:
             }
         }
 
-        if (variant_flags & VARIANT_PROTO) {
-            modify_config("PROTO_ENABLE", "y");
+        if (variant_flags & VARIANT_PROTO_V1) {
+            modify_config("PROTO_ENABLE", "n");
+        } else {
             modify_config("PROTO_REQUEST_RESET", "y");
         }
 
@@ -107,8 +102,8 @@ public:
             name += ",offload";
         }
 
-        if (variant_flags & VARIANT_PROTO) {
-            name += ",proto";
+        if (variant_flags & VARIANT_PROTO_V1) {
+            name += ",proto_v1";
         }
 
         add_variant_with_value(variants, get_ctx_params(), variant_value, name);

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -28,7 +28,7 @@ public:
         VARIANT_RNDV_PUT_ZCOPY,
         VARIANT_RNDV_GET_ZCOPY,
         VARIANT_SEND_NBR,
-        VARIANT_PROTO
+        VARIANT_PROTO_V1
     };
 
     test_ucp_tag_xfer() {
@@ -50,8 +50,8 @@ public:
             modify_config("RNDV_SCHEME", "put_zcopy");
         } else if (get_variant_value() == VARIANT_RNDV_GET_ZCOPY) {
             modify_config("RNDV_SCHEME", "get_zcopy");
-        } else if (get_variant_value() == VARIANT_PROTO) {
-            modify_config("PROTO_ENABLE", "y");
+        } else if (get_variant_value() == VARIANT_PROTO_V1) {
+            modify_config("PROTO_ENABLE", "n");
         }
 
         /* Init number of lanes according to test requirement
@@ -81,8 +81,8 @@ public:
                                VARIANT_RNDV_GET_ZCOPY, "rndv_get_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_SEND_NBR, "send_nbr");
-        add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO,
-                               "proto");
+        add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO_V1,
+                               "proto_v1");
     }
 
     virtual ucp_ep_params_t get_ep_params() {
@@ -1210,6 +1210,10 @@ public:
 UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=16", "TM_SW_RNDV=y",
            "RNDV_THRESH=1", "MIN_RNDV_CHUNK_SIZE=1", "MULTI_PATH_RATIO=0.0001")
 {
+    if (m_ucp_config->ctx.proto_enable) {
+        UCS_TEST_SKIP_R("TM_SW_RNDV has no effect with proto v2");
+    }
+
     receiver().connect(&sender(), get_ep_params());
     test_run_xfer(true, true, true, true, false);
 


### PR DESCRIPTION
## What
Enable protov2 by default

## Why ?
Just enable proto v2 by default and update corresponding test.
All wire-compat issues will be updated in other PRs