### PR TITLE
UCP/TOPO/BUG: Add memory distance only for relevant devices - v1.15.x

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -1181,13 +1181,16 @@ static void ucp_worker_close_ifaces(ucp_worker_h worker)
     UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
+static const ucp_tl_resource_desc_t *
+ucp_worker_iface_get_tl_resource(const ucp_worker_iface_t *wiface)
+{
+    return &wiface->worker->context->tl_rscs[wiface->rsc_index];
+}
+
 static ucs_sys_device_t
 ucp_worker_iface_get_sys_device(const ucp_worker_iface_t *wiface)
 {
-    const ucp_context_h context     = wiface->worker->context;
-    const ucp_rsc_index_t rsc_index = wiface->rsc_index;
-
-    return context->tl_rscs[rsc_index].tl_rsc.sys_device;
+    return ucp_worker_iface_get_tl_resource(wiface)->tl_rsc.sys_device;
 }
 
 static void ucp_worker_iface_set_sys_device_distance(ucp_worker_iface_t *wiface)
@@ -1214,13 +1217,28 @@ static void ucp_worker_iface_set_sys_device_distance(ucp_worker_iface_t *wiface)
     }
 }
 
+static const ucp_tl_md_t *
+ucp_worker_iface_get_md(const ucp_worker_iface_t *wiface)
+{
+    const ucp_tl_resource_desc_t *rsc;
+
+    rsc = ucp_worker_iface_get_tl_resource(wiface);
+    return &wiface->worker->context->tl_mds[rsc->md_index];
+}
+
 static void
 ucp_worker_iface_get_memory_distance(const ucp_worker_iface_t *wiface,
                                      ucs_sys_dev_distance_t *distance)
 {
-    const ucs_sys_device_t sys_dev = ucp_worker_iface_get_sys_device(wiface);
+    const ucs_sys_device_t sys_dev  = ucp_worker_iface_get_sys_device(wiface);
+    const uct_md_attr_v2_t *md_attr = &ucp_worker_iface_get_md(wiface)->attr;
 
-    ucs_topo_get_memory_distance(sys_dev, distance);
+    if ((md_attr->access_mem_types | md_attr->reg_mem_types) &
+        UCS_BIT(UCS_MEMORY_TYPE_HOST)) {
+        ucs_topo_get_memory_distance(sys_dev, distance);
+    } else {
+        *distance = ucs_topo_default_distance;
+    }
 }
 
 void ucp_worker_iface_add_bandwidth(uct_ppn_bandwidth_t *ppn_bandwidth,

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -380,7 +380,6 @@ static void ucs_topo_get_memory_distance_sysfs(ucs_sys_device_t device,
     char path[PATH_MAX];
     ucs_numa_node_t dev_node;
     ucs_status_t status;
-    const char *dev_name;
 
     /* If the device is unknown, we assume min distance */
     if (device == UCS_SYS_DEVICE_ID_UNKNOWN) {
@@ -412,8 +411,7 @@ static void ucs_topo_get_memory_distance_sysfs(ucs_sys_device_t device,
                                             ucs_numa_node_of_cpu(cpu));
     }
 
-    dev_name            = ucs_topo_sys_device_get_name(device);
-    distance->bandwidth = ucs_topo_get_pci_bw(dev_name, path);
+    distance->bandwidth = ucs_topo_default_distance.bandwidth;
     cpuset_size         = full_affinity ? num_cpus : CPU_COUNT(&thread_cpuset);
     distance->latency = ucs_topo_sysfs_numa_distance_to_latency(total_distance /
                                                                 cpuset_size);


### PR DESCRIPTION
## Why
Backport #9083 to 1.15.x branch