### PR TITLE
UCP/PROTO/STREAM: Add stream/zcopy/multi protocol

### DIFF
--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -66,6 +66,7 @@
     _macro(ucp_am_eager_single_zcopy_reply_proto) \
     _macro(ucp_am_rndv_proto) \
     _macro(ucp_stream_multi_bcopy_proto) \
+    _macro(ucp_stream_multi_zcopy_proto) \
     UCP_PROTO_AMO_FOR_EACH(_macro, post) \
     UCP_PROTO_AMO_FOR_EACH(_macro, fetch) \
     UCP_PROTO_AMO_FOR_EACH(_macro, cswap)

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -144,24 +144,14 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_rndv_am_zcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
-    const size_t hdr_size    = sizeof(ucp_request_data_hdr_t);
-    const size_t max_payload = ucp_proto_multi_max_payload(req, lpriv,
-                                                           hdr_size);
     ucp_request_data_hdr_t hdr;
-    uct_iov_t iov[UCP_MAX_IOV];
-    size_t iov_count;
 
     ucp_rndv_am_fill_header(&hdr, req);
-
-    ucs_assert(lpriv->super.max_iov > 0);
-    iov_count = ucp_datatype_iter_next_iov(&req->send.state.dt_iter,
-                                           max_payload, lpriv->super.md_index,
-                                           UCP_DT_MASK_CONTIG_IOV, next_iter,
-                                           iov, lpriv->super.max_iov);
-
-    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
-                           UCP_AM_ID_RNDV_DATA, &hdr, hdr_size, iov, iov_count,
-                           0, &req->send.state.uct_comp);
+    return ucp_proto_am_zcopy_multi_common_send_func(req, lpriv, next_iter,
+                                                     UCP_AM_ID_RNDV_DATA, &hdr,
+                                                     sizeof(hdr),
+                                                     UCP_AM_ID_RNDV_DATA, &hdr,
+                                                     sizeof(hdr));
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/stream/stream_multi.c
+++ b/src/ucp/stream/stream_multi.c
@@ -16,8 +16,23 @@
 
 
 /* Convenience macros for setting eager protocols descriptions  */
+#define UCP_PROTO_STREAM_DESC "stream"
 #define UCP_PROTO_STREAM_BCOPY_DESC \
-    "stream " UCP_PROTO_COPY_IN_DESC " " UCP_PROTO_COPY_OUT_DESC
+    UCP_PROTO_STREAM_DESC " " UCP_PROTO_COPY_IN_DESC " " UCP_PROTO_COPY_OUT_DESC
+#define UCP_PROTO_STREAM_ZCOPY_DESC \
+    UCP_PROTO_STREAM_DESC " " UCP_PROTO_ZCOPY_DESC " " UCP_PROTO_COPY_OUT_DESC
+
+static ucs_status_t
+ucp_stream_multi_common_init(const ucp_proto_multi_init_params_t *params)
+{
+    if (!ucp_proto_init_check_op(&params->super.super,
+                                 UCS_BIT(UCP_OP_ID_STREAM_SEND))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return ucp_proto_multi_init(params, params->super.super.priv,
+                                params->super.super.priv_size);
+}
 
 static UCS_F_ALWAYS_INLINE void
 ucp_stream_set_hdr(ucp_request_t *req, ucp_stream_am_hdr_t *hdr)
@@ -38,7 +53,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_stream_multi_bcopy_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
-    return ucp_proto_eager_bcopy_multi_common_send_func(
+    return ucp_proto_am_bcopy_multi_common_send_func(
             req, lpriv, next_iter, UCP_AM_ID_STREAM_DATA, ucp_stream_bcopy_pack,
             sizeof(ucp_stream_am_hdr_t), UCP_AM_ID_STREAM_DATA,
             ucp_stream_bcopy_pack, sizeof(ucp_stream_am_hdr_t));
@@ -85,13 +100,7 @@ ucp_stream_multi_bcopy_init(const ucp_proto_init_params_t *init_params)
         .middle.lane_type    = UCP_LANE_TYPE_AM
     };
 
-    if (!ucp_proto_init_check_op(&params.super.super,
-                                 UCS_BIT(UCP_OP_ID_STREAM_SEND))) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    return ucp_proto_multi_init(&params, params.super.super.priv,
-                                params.super.super.priv_size);
+    return ucp_stream_multi_common_init(&params);
 }
 
 ucp_proto_t ucp_stream_multi_bcopy_proto = {
@@ -103,4 +112,77 @@ ucp_proto_t ucp_stream_multi_bcopy_proto = {
     .progress = {ucp_stream_multi_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
+};
+
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_stream_multi_zcopy_send_func(
+        ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
+        ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
+{
+    ucp_stream_am_hdr_t hdr;
+
+    ucp_stream_set_hdr(req, &hdr);
+    return ucp_proto_am_zcopy_multi_common_send_func(req, lpriv, next_iter,
+                                                     UCP_AM_ID_STREAM_DATA,
+                                                     &hdr, sizeof(hdr),
+                                                     UCP_AM_ID_STREAM_DATA,
+                                                     &hdr, sizeof(hdr));
+}
+
+static ucs_status_t ucp_stream_multi_zcopy_progress(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    /* coverity[tainted_data_downcast] */
+    return ucp_proto_multi_zcopy_progress(
+            req, req->send.proto_config->priv, NULL,
+            UCT_MD_MEM_ACCESS_LOCAL_READ, UCP_DT_MASK_CONTIG_IOV,
+            ucp_stream_multi_zcopy_send_func,
+            ucp_request_invoke_uct_completion_success,
+            ucp_proto_request_zcopy_completion);
+}
+
+static ucs_status_t
+ucp_stream_multi_zcopy_init(const ucp_proto_init_params_t *init_params)
+{
+    ucp_context_t *context               = init_params->worker->context;
+    ucp_proto_multi_init_params_t params = {
+        .super.super         = *init_params,
+        .super.latency       = 0,
+        .super.overhead      = 10e-9,
+        .super.cfg_thresh    = context->config.ext.zcopy_thresh,
+        .super.cfg_priority  = 30,
+        .super.min_length    = 0,
+        .super.max_length    = SIZE_MAX,
+        .super.min_iov       = 1,
+        .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.min_zcopy),
+        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.max_zcopy),
+        .super.max_iov_offs  = ucs_offsetof(uct_iface_attr_t, cap.am.max_iov),
+        .super.hdr_size      = sizeof(ucp_stream_am_hdr_t),
+        .super.send_op       = UCT_EP_OP_AM_ZCOPY,
+        .super.memtype_op    = UCT_EP_OP_LAST,
+        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
+                               UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
+                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+        .super.exclude_map   = 0,
+        .max_lanes           = 1,
+        .initial_reg_md_map  = 0,
+        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
+        .first.lane_type     = UCP_LANE_TYPE_AM,
+        .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY,
+        .middle.lane_type    = UCP_LANE_TYPE_AM
+    };
+
+    return ucp_stream_multi_common_init(&params);
+}
+
+ucp_proto_t ucp_stream_multi_zcopy_proto = {
+    .name     = "stream/multi/zcopy",
+    .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_STREAM_ZCOPY_DESC,
+    .flags    = 0,
+    .init     = ucp_stream_multi_zcopy_init,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_stream_multi_zcopy_progress},
+    .abort    = ucp_proto_request_zcopy_abort,
+    .reset    = ucp_proto_request_zcopy_reset
 };

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -108,7 +108,7 @@ ucp_proto_eager_bcopy_multi_send_func(ucp_request_t *req,
                                       ucp_datatype_iter_t *next_iter,
                                       ucp_lane_index_t *lane_shift)
 {
-    return ucp_proto_eager_bcopy_multi_common_send_func(
+    return ucp_proto_am_bcopy_multi_common_send_func(
             req, lpriv, next_iter, UCP_AM_ID_EAGER_FIRST,
             ucp_proto_eager_bcopy_pack_first, sizeof(ucp_eager_first_hdr_t),
             UCP_AM_ID_EAGER_MIDDLE, ucp_proto_eager_bcopy_pack_middle,
@@ -164,7 +164,7 @@ ucp_proto_eager_sync_bcopy_multi_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
-    return ucp_proto_eager_bcopy_multi_common_send_func(
+    return ucp_proto_am_bcopy_multi_common_send_func(
             req, lpriv, next_iter, UCP_AM_ID_EAGER_SYNC_FIRST,
             ucp_eager_sync_bcopy_pack_first, sizeof(ucp_eager_sync_first_hdr_t),
             UCP_AM_ID_EAGER_MIDDLE, ucp_proto_eager_bcopy_pack_middle,
@@ -245,40 +245,23 @@ ucp_proto_eager_zcopy_multi_init(const ucp_proto_init_params_t *init_params)
     return ucp_proto_eager_multi_init_common(&params, UCP_OP_ID_TAG_SEND);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_eager_zcopy_multi_send_func(ucp_request_t *req,
-                                      const ucp_proto_multi_lane_priv_t *lpriv,
-                                      ucp_datatype_iter_t *next_iter,
-                                      ucp_lane_index_t *lane_shift)
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_eager_zcopy_multi_send_func(
+        ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
+        ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {
-    union {
-        ucp_eager_first_hdr_t  first;
-        ucp_eager_middle_hdr_t middle;
-    } hdr;
-    uct_iov_t iov[UCP_MAX_IOV];
-    size_t max_payload;
-    ucp_am_id_t am_id;
-    size_t hdr_size;
-    size_t iov_count;
+    ucp_eager_middle_hdr_t hdr_middle;
+    ucp_eager_first_hdr_t hdr_first;
 
     if (req->send.state.dt_iter.offset == 0) {
-        am_id    = UCP_AM_ID_EAGER_FIRST;
-        hdr_size = sizeof(hdr.first);
-        ucp_proto_eager_set_first_hdr(req, &hdr.first);
+        ucp_proto_eager_set_first_hdr(req, &hdr_first);
     } else {
-        am_id    = UCP_AM_ID_EAGER_MIDDLE;
-        hdr_size = sizeof(hdr.middle);
-        ucp_proto_eager_set_middle_hdr(req, &hdr.middle);
+        ucp_proto_eager_set_middle_hdr(req, &hdr_middle);
     }
 
-    max_payload = ucp_proto_multi_max_payload(req, lpriv, hdr_size);
-    iov_count   = ucp_datatype_iter_next_iov(&req->send.state.dt_iter,
-                                             max_payload, lpriv->super.md_index,
-                                             UCP_DT_MASK_CONTIG_IOV, next_iter,
-                                             iov, lpriv->super.max_iov);
-    return uct_ep_am_zcopy(ucp_ep_get_lane(req->send.ep, lpriv->super.lane),
-                           am_id, &hdr, hdr_size, iov, iov_count, 0,
-                           &req->send.state.uct_comp);
+    return ucp_proto_am_zcopy_multi_common_send_func(
+            req, lpriv, next_iter, UCP_AM_ID_EAGER_FIRST, &hdr_first,
+            sizeof(hdr_first), UCP_AM_ID_EAGER_MIDDLE, &hdr_middle,
+            sizeof(hdr_middle));
 }
 
 static ucs_status_t ucp_proto_eager_zcopy_multi_progress(uct_pending_req_t *self)


### PR DESCRIPTION
## Why
Enable zero-copy for stream API protov2

## How
- Added stream/multi/zcopy protocol definitions
- Added `ucp_proto_eager_zcopy_multi_common_send_func()`, reuse it in stream, tag/eager, and rndv/data protocols