### PR TITLE
ARCH/X86: Add AMD Genoa CPU model

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -34,6 +34,7 @@ static const char *cpu_model_names[] = {
     [UCS_CPU_MODEL_AMD_NAPLES]         = "Naples",
     [UCS_CPU_MODEL_AMD_ROME]           = "Rome",
     [UCS_CPU_MODEL_AMD_MILAN]          = "Milan",
+    [UCS_CPU_MODEL_AMD_GENOA]          = "Genoa",
     [UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG] = "Zhangjiang",
     [UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU]   = "Wudaokou",
     [UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI]   = "Lujiazui"

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -32,6 +32,7 @@ typedef enum ucs_cpu_model {
     UCS_CPU_MODEL_AMD_NAPLES,
     UCS_CPU_MODEL_AMD_ROME,
     UCS_CPU_MODEL_AMD_MILAN,
+    UCS_CPU_MODEL_AMD_GENOA,
     UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG,
     UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU,
     UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI,
@@ -160,7 +161,8 @@ static inline int ucs_cpu_prefer_relaxed_order()
            ((cpu_vendor == UCS_CPU_VENDOR_AMD) &&
             ((cpu_model == UCS_CPU_MODEL_AMD_NAPLES) ||
              (cpu_model == UCS_CPU_MODEL_AMD_ROME) ||
-             (cpu_model == UCS_CPU_MODEL_AMD_MILAN)));
+             (cpu_model == UCS_CPU_MODEL_AMD_MILAN) ||
+             (cpu_model == UCS_CPU_MODEL_AMD_GENOA)));
 }
 
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -387,7 +387,8 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
     if (family == 0xf) {
         family += version.ext_family;
     }
-    if ((family == 0x6) || (family == 0x7) || (family == 0xf) || (family == 0x17)) {
+    if ((family == 0x6) || (family == 0x7) || (family == 0xf) ||
+        (family == 0x17) || (family == 0x19)) {
         model = (version.ext_model << 4) | model;
     }
 
@@ -472,6 +473,9 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
             case 0x00:
             case 0x01:
                 cpu_model = UCS_CPU_MODEL_AMD_MILAN;
+                break;
+            case 0x11:
+                cpu_model = UCS_CPU_MODEL_AMD_GENOA;
                 break;
             }
             break;

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -310,6 +310,7 @@ static void ucs_topo_sys_root_distance(ucs_sys_dev_distance_t *distance)
     switch (ucs_arch_get_cpu_model()) {
     case UCS_CPU_MODEL_AMD_ROME:
     case UCS_CPU_MODEL_AMD_MILAN:
+    case UCS_CPU_MODEL_AMD_GENOA:
         distance->bandwidth = 5100 * UCS_MBYTE;
         break;
     default:


### PR DESCRIPTION
## What
Use `ext_model` to build model value for AMD family 0x19.

This is a cosmetic fix without functional impact.

## Why ?
Without the `ext_model` part, AMD Genoa is detected as Milan, as seen on `ucx_info -s`, which can be misleading.

## How ?
### Tested
Both on Milan and Genoa as below.
```
Milan$ ucx_info -s
# Timer frequency: ...
# Timer accuracy: ...
# CPU vendor: AMD
# CPU model: Milan
```

```
Genoa$ ucx_info -s
# Timer frequency: ...
# Timer accuracy: ...
# CPU vendor: AMD
# CPU model: Genoa
```