### PR TITLE
UCP/UCT: Use the new callbackq oneshot API

### DIFF
--- a/src/ucp/core/ucp_listener.h
+++ b/src/ucp/core/ucp_listener.h
@@ -38,7 +38,6 @@ typedef struct ucp_listener {
                                                  requests */
     void                           *arg;      /* User's arg for the accept
                                                  callback */
-    uct_worker_cb_id_t             prog_id;   /* Slow-path callback */
 } ucp_listener_t;
 
 

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -354,13 +354,11 @@ static unsigned ucp_request_dt_invalidate_progress(void *arg)
 
 static void ucp_request_mem_invalidate_completion(void *arg)
 {
-    ucp_request_t *req         = arg;
-    uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
+    ucp_request_t *req  = arg;
+    ucp_worker_h worker = req->send.invalidate.worker;
 
-    uct_worker_progress_register_safe(req->send.invalidate.worker->uct,
-                                      ucp_request_dt_invalidate_progress,
-                                      req, UCS_CALLBACKQ_FLAG_ONESHOT,
-                                      &prog_id);
+    ucs_callbackq_add_oneshot(&worker->uct->progress_q, worker,
+                              ucp_request_dt_invalidate_progress, req);
 }
 
 static void ucp_request_dt_dereg(ucp_context_t *context, ucp_mem_h *memhs,

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -322,9 +322,8 @@ struct ucp_request {
 
                 struct {
                     unsigned           uct_flags; /* Flags to pass to @ref uct_ep_flush */
-                    uct_worker_cb_id_t prog_id; /* Progress callback ID */
-                    uint32_t           cmpl_sn; /* Sequence number of the remote completion
-                                                   this request is waiting for */
+                    uint32_t           cmpl_sn;   /* Sequence number of the remote completion
+                                                     this request is waiting for */
                     uint8_t            sw_started;
                     uint8_t            sw_done;
                     uint8_t            num_lanes; /* How many lanes are being flushed */
@@ -340,9 +339,6 @@ struct ucp_request {
                     uct_ep_h           uct_ep;
                     /* Flags that should be passed into @ref uct_ep_flush */
                     unsigned           ep_flush_flags;
-                    /* Progress ID, if it's UCS_CALLBACKQ_ID_NULL, no operations
-                     * are in-progress */
-                    uct_worker_cb_id_t cb_id;
                     /* Index of UCT EP to be flushed and destroyed */
                     ucp_rsc_index_t    rsc_index;
                 } discard_uct_ep;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -14,6 +14,7 @@
 
 #include "rma.inl"
 
+static unsigned ucp_ep_flush_resume_slow_path_callback(void *arg);
 
 static void
 ucp_ep_flush_request_update_uct_comp(ucp_request_t *req, int diff,
@@ -184,22 +185,26 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
     }
 }
 
-static void ucp_ep_flush_slow_path_remove(ucp_request_t *req)
+static int
+ucp_ep_flush_slow_path_remove_filter(const ucs_callbackq_elem_t *elem,
+                                     void *arg)
 {
-    ucp_ep_h ep = req->send.ep;
-    uct_worker_progress_unregister_safe(ep->worker->uct,
-                                        &req->send.flush.prog_id);
+    return (elem->cb == ucp_ep_flush_resume_slow_path_callback) &&
+           (elem->arg == arg);
 }
 
 static int ucp_flush_check_completion(ucp_request_t *req)
 {
+    ucp_worker_h worker = req->send.ep->worker;
+
     /* Check if flushed all lanes */
     if (!ucp_ep_flush_is_completed(req)) {
         return 0;
     }
 
     ucp_trace_req(req, "flush ep %p completed", req->send.ep);
-    ucp_ep_flush_slow_path_remove(req);
+    ucs_callbackq_remove_oneshot(&worker->uct->progress_q, req,
+                                 ucp_ep_flush_slow_path_remove_filter, req);
     req->send.flushed_cb(req);
     return 1;
 }
@@ -211,7 +216,6 @@ static unsigned ucp_ep_flush_resume_slow_path_callback(void *arg)
     ucp_trace_req(req, "resume slow path callback comp %d",
                   req->send.state.uct_comp.count);
 
-    ucp_ep_flush_slow_path_remove(req);
     ucp_ep_flush_progress(req);
     ucp_flush_check_completion(req);
     return 0;
@@ -248,9 +252,8 @@ static void ucp_ep_flush_request_resched(ucp_ep_h ep, ucp_request_t *req)
 
     ucp_trace_req(req, "flush ep %p adding slow-path callback to resume flush",
                   ep);
-    uct_worker_progress_register_safe(ep->worker->uct,
-                                      ucp_ep_flush_resume_slow_path_callback,
-                                      req, 0, &req->send.flush.prog_id);
+    ucs_callbackq_add_oneshot(&ep->worker->uct->progress_q, req,
+                              ucp_ep_flush_resume_slow_path_callback, req);
 }
 
 ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
@@ -391,7 +394,6 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
     req->status                     = UCS_OK;
     req->send.ep                    = ep;
     req->send.flushed_cb            = flushed_cb;
-    req->send.flush.prog_id         = UCS_CALLBACKQ_ID_NULL;
     req->send.flush.uct_flags       = (worker_req != NULL) ?
                                       worker_req->flush_worker.uct_flags :
                                       UCT_FLUSH_FLAG_LOCAL;

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -761,9 +761,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_base_ep_t)
     uct_base_iface_t *iface = ucs_derived_of(self->super.iface,
                                              uct_base_iface_t);
 
-    ucs_callbackq_remove_if(&iface->worker->super.progress_q,
-                            uct_iface_ep_conn_reset_handle_progress_remove,
-                            self);
+    ucs_callbackq_remove_oneshot(&iface->worker->super.progress_q, self,
+                                 uct_iface_ep_conn_reset_handle_progress_remove,
+                                 self);
     UCS_STATS_NODE_FREE(self->stats);
 }
 
@@ -870,9 +870,8 @@ static void uct_iface_schedule_ep_err(uct_ep_h ep)
         return;
     }
 
-    ucs_callbackq_add_safe(&iface->worker->super.progress_q,
-                           uct_iface_ep_conn_reset_handle_progress, ep,
-                           UCS_CALLBACKQ_FLAG_ONESHOT);
+    ucs_callbackq_add_oneshot(&iface->worker->super.progress_q, ep,
+                              uct_iface_ep_conn_reset_handle_progress, ep);
 }
 
 ucs_status_t uct_ep_keepalive_init(uct_keepalive_info_t *ka, pid_t pid)

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -250,7 +250,7 @@ KHASH_MAP_INIT_INT64(uct_dc_mlx5_fc_hash, uct_dc_mlx5_ep_fc_entry_t);
 
 /* DCI pool
  * same array is used to store DCI's to allocate and DCI's to release:
- * 
+ *
  * +--------------+-----+-------------+
  * | to release   |     | to allocate |
  * +--------------+-----+-------------+
@@ -258,7 +258,7 @@ KHASH_MAP_INIT_INT64(uct_dc_mlx5_fc_hash, uct_dc_mlx5_ep_fc_entry_t);
  * |              |     |             |
  * 0        release     stack      ndci
  *              top     top
- * 
+ *
  * Overall count of DCI's to release and allocated DCI's could not be more than
  * ndci and these stacks are not intersected
  */
@@ -314,8 +314,6 @@ struct uct_dc_mlx5_iface {
         unsigned                  rand_seed;
 
         ucs_arbiter_callback_t    pend_cb;
-
-        uct_worker_cb_id_t        dci_release_prog_id;
 
         uint8_t                   dci_pool_release_bitmap;
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1238,8 +1238,8 @@ UCS_CLASS_INIT_FUNC(uct_dc_mlx5_ep_t, uct_dc_mlx5_iface_t *iface,
                     const uct_dc_mlx5_iface_addr_t *if_addr,
                     uct_ib_mlx5_base_av_t *av, uint8_t path_index)
 {
-    const uct_dc_mlx5_iface_flush_addr_t *flush_addr = 
-        ucs_derived_of(if_addr, uct_dc_mlx5_iface_flush_addr_t);
+    const uct_dc_mlx5_iface_flush_addr_t *flush_addr =
+            ucs_derived_of(if_addr, uct_dc_mlx5_iface_flush_addr_t);
     uint32_t remote_dctn;
 
     ucs_trace_func("");
@@ -1440,7 +1440,6 @@ unsigned uct_dc_mlx5_ep_dci_release_progress(void *arg)
     uint8_t dci;
     uct_dc_mlx5_dci_pool_t *dci_pool;
 
-    ucs_assert(iface->tx.dci_release_prog_id != UCS_CALLBACKQ_ID_NULL);
     ucs_assert(!uct_dc_mlx5_iface_is_dci_shared(iface));
     UCS_STATIC_ASSERT((sizeof(iface->tx.dci_pool_release_bitmap) * 8) <=
                        UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
@@ -1473,7 +1472,6 @@ unsigned uct_dc_mlx5_ep_dci_release_progress(void *arg)
 
     ucs_assert(iface->tx.dci_pool_release_bitmap == 0);
     uct_dc_mlx5_iface_check_tx(iface);
-    iface->tx.dci_release_prog_id = UCS_CALLBACKQ_ID_NULL;
     return 1;
 }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -527,6 +527,7 @@ static inline void uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_d
 static UCS_F_ALWAYS_INLINE void
 uct_dc_mlx5_iface_dci_schedule_release(uct_dc_mlx5_iface_t *iface, uint8_t dci)
 {
+    uct_worker_h worker = &iface->super.super.super.super.worker->super;
     uint8_t pool_index = uct_dc_mlx5_iface_dci_pool_index(iface, dci);
     uint8_t stack_top;
 
@@ -540,10 +541,8 @@ uct_dc_mlx5_iface_dci_schedule_release(uct_dc_mlx5_iface_t *iface, uint8_t dci)
     iface->tx.dci_pool_release_bitmap              |= UCS_BIT(pool_index);
     iface->tx.dci_pool[pool_index].stack[stack_top] = dci;
 
-    uct_worker_progress_register_safe(
-            &iface->super.super.super.super.worker->super,
-            uct_dc_mlx5_ep_dci_release_progress, iface,
-            UCS_CALLBACKQ_FLAG_ONESHOT, &iface->tx.dci_release_prog_id);
+    ucs_callbackq_add_oneshot(&worker->progress_q, iface,
+                              uct_dc_mlx5_ep_dci_release_progress, iface);
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1722,8 +1722,9 @@ private:
         UCS_ASYNC_BLOCK(&e.worker()->async);
         uct_priv_worker_t *worker = ucs_derived_of(e.worker()->uct,
                                                    uct_priv_worker_t);
-        ucs_callbackq_remove_if(&worker->super.progress_q,
-                                find_try_next_cm_cb, &find_try_next_cm_arg);
+        ucs_callbackq_remove_oneshot(&worker->super.progress_q, e.ep(),
+                                     find_try_next_cm_cb,
+                                     &find_try_next_cm_arg);
         UCS_ASYNC_UNBLOCK(&e.worker()->async);
 
         return find_try_next_cm_arg.found;


### PR DESCRIPTION
## Why
Improve scalability of connection establishment and error handling

## How
Use the new callbackq oneshot API, to remove callbacks by key instead of going over the whole callbacks list.

Replaces #8812 