### PR TITLE
UCP: Fix ep config locality assignment

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2105,13 +2105,14 @@ static unsigned ucp_wireup_default_path_index(unsigned path_index)
 
 static ucs_status_t ucp_wireup_select_set_locality_flags(
         const ucp_wireup_select_params_t *select_params,
-        ucp_ep_config_key_t *key)
+        unsigned *addr_indices, ucp_ep_config_key_t *key)
 {
     ucp_worker_h worker = select_params->ep->worker;
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t rsc_index;
     ucp_address_entry_t *ae;
     ucp_lane_index_t lane;
+    unsigned addr_index;
     uct_iface_is_reachable_params_t params;
 
     if (select_params->address->uuid == worker->uuid) {
@@ -2130,36 +2131,37 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
         }
     }
 
-    /* If the local context matching at least one remote device address, it's
-       intra-node. Only selected lanes are compared to verify reachability. */
+    /* If the local context matching the corresponding remote device address,
+     * it's intra-node. Only selected lanes are compared to verify reachability.
+     */
     for (lane = 0; lane < key->num_lanes; ++lane) {
         rsc_index = key->lanes[lane].rsc_index;
         if (rsc_index == UCP_NULL_RESOURCE) {
             continue;
         }
 
+        if (key->cm_lane == lane) {
+            continue;
+        }
+
+        addr_index = addr_indices[lane];
+        ae         = &select_params->address->address_list[addr_index];
+
         wiface = ucp_worker_iface(worker, rsc_index);
         if (wiface->attr.device_addr_len == 0) {
             continue;
         }
 
-        ucp_unpacked_address_for_each(ae, select_params->address) {
-            if (worker->context->tl_rscs[rsc_index].tl_name_csum !=
-                ae->tl_name_csum) {
-                continue;
-            }
+        params.field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                             UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
+                             UCT_IFACE_IS_REACHABLE_FIELD_SCOPE;
+        params.device_addr = ae->dev_addr;
+        params.iface_addr  = ae->iface_addr;
+        params.scope       = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
 
-            params.field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
-                                 UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
-                                 UCT_IFACE_IS_REACHABLE_FIELD_SCOPE;
-            params.device_addr = ae->dev_addr;
-            params.iface_addr  = ae->iface_addr;
-            params.scope       = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
-
-            if (uct_iface_is_reachable_v2(wiface->iface, &params)) {
-                key->flags |= UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE;
-                return UCS_OK;
-            }
+        if (uct_iface_is_reachable_v2(wiface->iface, &params)) {
+            key->flags |= UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE;
+            return UCS_OK;
         }
     }
 
@@ -2298,7 +2300,8 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
      * msg packets */
     key->am_bw_lanes[0] = key->am_lane;
 
-    return ucp_wireup_select_set_locality_flags(select_params, key);
+    return ucp_wireup_select_set_locality_flags(select_params, addr_indices,
+                                                key);
 }
 
 ucs_status_t

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1234,6 +1234,9 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
         }
         ucs_log(log_level, "%s: %s", title, ucs_string_buffer_cstr(&strb));
     }
+
+    ucs_log(log_level, "%s: err mode %d, flags 0x%x", title, key->err_mode,
+            key->flags);
 }
 
 int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,


### PR DESCRIPTION
## What
Fix ep reconfiguration error, which happens because of wrong ep config locality assignment

```
[ RUN      ] dcx/test_ucp_perf.envelope/25 <dc_x/amo_swap/cpu>
[1684918078.644718] [jazz02:71503:p-0]          wireup.c:1237 UCX  ERROR   old: am_lane 0 wireup_msg_lane <none> cm_lane <none> keepalive_lane <none> reachable_mds 0xf
[1684918078.644741] [jazz02:71503:p-0]          wireup.c:1247 UCX  ERROR   old: lane[0]:  0:dc_mlx5/mlx5_0:1.0 md[0]      -> md[3]/ib/sysdev[255] am am_bw#0
[1684918078.644748] [jazz02:71503:p-0]          wireup.c:1251 UCX  ERROR   old: err mode 0 flags 0x2
[1684918078.644753] [jazz02:71503:p-0]          wireup.c:1237 UCX  ERROR   new: am_lane 0 wireup_msg_lane <none> cm_lane <none> keepalive_lane <none> reachable_mds 0xf
[jazz02:71503:p-0:71611]      wireup.c:1589 Fatal: endpoint reconfiguration not supported yet
[1684918078.644759] [jazz02:71503:p-0]          wireup.c:1247 UCX  ERROR   new: lane[0]:  0:dc_mlx5/mlx5_0:1.0 md[0]      -> md[3]/ib/sysdev[255] am am_bw#0
[1684918078.644764] [jazz02:71503:p-0]          wireup.c:1251 UCX  ERROR   new: err mode 0 flags 0x0

/labhome/mikhailb/wgit/ucx-tmp/src/ucp/wireup/wireup.c: [ ucp_wireup_init_lanes() ]
      ...
     1586                                 NULL, cm_idx, UCS_LOG_LEVEL_ERROR);
     1587         ucp_wireup_print_config(worker, &key, "new", NULL,
     1588                                 cm_idx, UCS_LOG_LEVEL_ERROR);
==>  1589         ucs_fatal("endpoint reconfiguration not supported yet");
     1590     }
     1591
     1592     ep->cfg_index = new_cfg_index;

==== backtrace (tid:  71611) ====
 0 0x00000000001fa61e ucp_wireup_init_lanes()  /labhome/mikhailb/wgit/ucx-tmp/src/ucp/wireup/wireup.c:1589
 1 0x00000000001f5ab4 ucp_wireup_process_request()  /labhome/mikhailb/wgit/ucx-tmp/src/ucp/wireup/wireup.c:682

```

## How ?
When checking whether ep config corresponds to intra-node eps need to check reachability between selected addresses only.

