### PR TITLE
TOOLS/INFO: Print sizes of ucp_request_t fields

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -75,14 +75,17 @@ static void print_size(const char *name, size_t size)
 {
     int i;
     printf("    sizeof(%s)%n = ", name, &i);
-    while (i++ < 40) {
+    while (i++ < 50) {
         printf(".");
     }
     printf(" %-6lu\n", size);
 }
 
-#define PRINT_SIZE(type) print_size(UCS_PP_QUOTE(type), sizeof(type))
+#define PRINT_SIZE(_type) print_size(UCS_PP_QUOTE(_type), sizeof(_type))
 
+#define PRINT_FIELD_SIZE(_type, _field) \
+    print_size(UCS_PP_QUOTE(_type) "." UCS_PP_QUOTE(_field), \
+               ucs_field_sizeof(_type, _field))
 
 void print_type_info(const char * tl_name)
 {
@@ -265,6 +268,22 @@ void print_type_info(const char * tl_name)
     PRINT_SIZE(ucp_ep_config_t);
     PRINT_SIZE(ucp_datatype_iter_t);
     PRINT_SIZE(ucp_request_t);
+    PRINT_FIELD_SIZE(ucp_request_t, send);
+    PRINT_FIELD_SIZE(ucp_request_t, send.state);
+    PRINT_FIELD_SIZE(ucp_request_t, send.state.dt_iter);
+    PRINT_FIELD_SIZE(ucp_request_t, send.state.dt);
+    PRINT_FIELD_SIZE(ucp_request_t, send.msg_proto);
+    PRINT_FIELD_SIZE(ucp_request_t, send.rma);
+    PRINT_FIELD_SIZE(ucp_request_t, send.proto);
+    PRINT_FIELD_SIZE(ucp_request_t, send.rndv);
+    PRINT_FIELD_SIZE(ucp_request_t, send.rkey_ptr);
+    PRINT_FIELD_SIZE(ucp_request_t, send.flush);
+    PRINT_FIELD_SIZE(ucp_request_t, send.amo);
+    PRINT_FIELD_SIZE(ucp_request_t, recv);
+    PRINT_FIELD_SIZE(ucp_request_t, recv.uct_ctx);
+    PRINT_FIELD_SIZE(ucp_request_t, recv.tag);
+    PRINT_FIELD_SIZE(ucp_request_t, recv.stream);
+    PRINT_FIELD_SIZE(ucp_request_t, flush_worker);
     PRINT_SIZE(ucp_recv_desc_t);
     PRINT_SIZE(ucp_tag_recv_info_t);
     PRINT_SIZE(ucp_mem_t);


### PR DESCRIPTION
## Why
Show sizes of different parts of ucp_request , to see what could be optimized