### PR TITLE
UCS/CALLBACKQ/TEST: Remove previous implementation of slowpath/oneshot

### DIFF
--- a/docs/doxygen/ucxdox
+++ b/docs/doxygen/ucxdox
@@ -794,18 +794,19 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          = ucp.h          \
-                         ucp_compat.h   \
-                         ucp_def.h      \
-                         uct.h          \
-                         uct_def.h      \
-                         status.h       \
-                         async_fwd.h    \
-                         compiler_def.h \
-                         time_def.h     \
-                         thread_mode.h  \
-                         memory_type.h  \
-                         callbackq.h    \
+FILE_PATTERNS          = ucp.h              \
+                         ucp_compat.h       \
+                         ucp_def.h          \
+                         uct.h              \
+                         uct_def.h          \
+                         status.h           \
+                         async_fwd.h        \
+                         compiler_def.h     \
+                         time_def.h         \
+                         thread_mode.h      \
+                         memory_type.h      \
+                         callbackq.h        \
+                         callbackq_compat.h \
                          types.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3403,8 +3403,7 @@ void ucp_worker_keepalive_add_ep(ucp_ep_h ep)
     ucs_trace("ep %p flags 0x%x: set keepalive lane to %u", ep,
               ep->flags, ucp_ep_config(ep)->key.keepalive_lane);
     uct_worker_progress_register_safe(worker->uct,
-                                      ucp_worker_keepalive_progress, worker,
-                                      UCS_CALLBACKQ_FLAG_FAST,
+                                      ucp_worker_keepalive_progress, worker, 0,
                                       &worker->keepalive.cb_id);
 }
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1514,10 +1514,8 @@ static void ucp_rndv_do_rkey_ptr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     UCP_WORKER_STAT_RNDV(ep->worker, RKEY_PTR, 1);
 
     ucs_queue_push(&worker->rkey_ptr_reqs, &rndv_req->send.rkey_ptr.queue_elem);
-    uct_worker_progress_register_safe(worker->uct,
-                                      ucp_rndv_progress_rkey_ptr,
-                                      rreq->recv.worker,
-                                      UCS_CALLBACKQ_FLAG_FAST,
+    uct_worker_progress_register_safe(worker->uct, ucp_rndv_progress_rkey_ptr,
+                                      rreq->recv.worker, 0,
                                       &worker->rkey_ptr_cb_id);
 }
 

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -184,8 +184,8 @@ ucp_proto_rndv_rkey_ptr_fetch_progress(uct_pending_req_t *uct_req)
     UCP_WORKER_STAT_RNDV(worker, RKEY_PTR, 1);
     ucs_queue_push(&worker->rkey_ptr_reqs, &req->send.rndv.rkey_ptr.queue_elem);
     uct_worker_progress_register_safe(worker->uct,
-            ucp_proto_rndv_progress_rkey_ptr, worker,
-            UCS_CALLBACKQ_FLAG_FAST, &worker->rkey_ptr_cb_id);
+                                      ucp_proto_rndv_progress_rkey_ptr, worker,
+                                      0, &worker->rkey_ptr_cb_id);
 
     return UCS_OK;
 }

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -35,6 +35,7 @@ nobase_dist_libucs_la_HEADERS = \
 	datastruct/array.h \
 	datastruct/array.inl \
 	datastruct/callbackq.h \
+	datastruct/callbackq_compat.h \
 	datastruct/hlist.h \
 	datastruct/khash.h \
 	datastruct/linear_func.h \

--- a/src/ucs/datastruct/callbackq.c
+++ b/src/ucs/datastruct/callbackq.c
@@ -13,6 +13,7 @@
 #include <ucs/arch/atomic.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/async/async.h>
+#include <ucs/datastruct/array.inl>
 #include <ucs/datastruct/hlist.h>
 #include <ucs/datastruct/khash.h>
 #include <ucs/debug/assert.h>
@@ -22,9 +23,16 @@
 #include "callbackq.h"
 
 
-#define UCS_CALLBACKQ_IDX_FLAG_SLOW  0x80000000u
-#define UCS_CALLBACKQ_IDX_MASK       0x7fffffffu
-#define UCS_CALLBACKQ_FAST_MAX       (UCS_CALLBACKQ_FAST_COUNT - 1)
+/* Reserve one slot for proxy callback */
+#define UCS_CALLBACKQ_FAST_MAX (UCS_CALLBACKQ_FAST_COUNT - 1)
+
+/*
+ * Callback element in the spill array
+ */
+typedef struct ucs_callbackq_spill_elem {
+    ucs_callbackq_elem_t super;
+    int                  id;
+} ucs_callbackq_spill_elem_t;
 
 /*
  * One-shot element in the hash table
@@ -41,324 +49,244 @@ typedef struct ucs_callbackq_oneshot_elem {
 KHASH_INIT(ucs_callbackq_oneshot_elems, ucs_callbackq_key_t, ucs_hlist_head_t,
            1, ucs_callbackq_oneshot_key_hash, kh_int64_hash_equal);
 
-typedef struct ucs_callbackq_priv {
-    ucs_recursive_spinlock_t lock;           /**< Protects adding / removing */
+UCS_ARRAY_DEFINE_INLINE(ucs_callbackq_idx, int, unsigned);
+UCS_ARRAY_DEFINE_INLINE(ucs_callbackq_spill_elems, unsigned,
+                        ucs_callbackq_spill_elem_t);
 
-    ucs_callbackq_elem_t     *slow_elems;    /**< Array of slow-path elements */
-    unsigned                 num_slow_elems; /**< Number of slow-path elements */
-    unsigned                 max_slow_elems; /**< Maximal number of slow-path elements */
-    int                      slow_proxy_id;  /**< ID of slow-path proxy in fast-path array.
-                                                  keep track while this moves around. */
+struct ucs_callbackq_priv {
+    /* Protects adding / removing */
+    ucs_recursive_spinlock_t               lock;
 
-    uint64_t                 fast_remove_mask; /**< Mask of which fast-path elements
-                                                    should be removed */
-    unsigned                 num_fast_elems; /**< Number of fast-path elements */
+    /* IDs of fast-path callbacks */
+    int                                    fast_ids[UCS_CALLBACKQ_FAST_COUNT];
 
-    /** Hash map of oneshot path elements, by key */
-    khash_t(ucs_callbackq_oneshot_elems) oneshot_elems;
+    /* Number of fast-path elements */
+    unsigned                               num_fast_elems;
 
-    /* Lookup table for callback IDs. This allows moving callbacks around in
-     * the arrays, while the user can always use a single ID to remove the
-     * callback in O(1).
-     */
-    int                      free_idx_id;    /**< Index of first free item in the list */
-    int                      num_idxs;       /**< Size of idxs array */
-    unsigned                 *idxs;          /**< ID-to-index lookup */
+    /* Mask of which fast-path elements should be removed */
+    uint64_t                               fast_remove_mask;
 
-} ucs_callbackq_priv_t;
+    /* Callback ID to index mapping */
+    ucs_array_t(ucs_callbackq_idx)         idxs;
+
+    /* Index of first free item in the freelist */
+    int                                    free_idx_id;
+
+    ucs_array_t(ucs_callbackq_spill_elems) spill_elems;
+
+    /* Hash map of oneshot path elements, by key */
+    khash_t(ucs_callbackq_oneshot_elems)   oneshot_elems;
+
+    /* ID of oneshot-path proxy in fast-path array */
+    int                                    proxy_cb_id;
+};
 
 
-static unsigned ucs_callbackq_slow_proxy(void *arg);
-
-static inline ucs_callbackq_priv_t* ucs_callbackq_priv(ucs_callbackq_t *cbq)
-{
-    UCS_STATIC_ASSERT(sizeof(cbq->priv) == sizeof(ucs_callbackq_priv_t));
-    return (void*)cbq->priv;
-}
+static void ucs_callbackq_proxy_enable(ucs_callbackq_t *cbq);
+static void ucs_callbackq_proxy_disable(ucs_callbackq_t *cbq);
 
 static void ucs_callbackq_enter(ucs_callbackq_t *cbq)
 {
-    ucs_recursive_spin_lock(&ucs_callbackq_priv(cbq)->lock);
+    ucs_recursive_spin_lock(&cbq->priv->lock);
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, 1);
 }
 
 static void ucs_callbackq_leave(ucs_callbackq_t *cbq)
 {
-    ucs_recursive_spin_unlock(&ucs_callbackq_priv(cbq)->lock);
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, -1);
+    ucs_recursive_spin_unlock(&cbq->priv->lock);
 }
 
-static void ucs_callbackq_elem_reset(ucs_callbackq_t *cbq,
-                                     ucs_callbackq_elem_t *elem)
+static void ucs_callbackq_fast_elem_set(ucs_callbackq_t *cbq, unsigned idx,
+                                        ucs_callback_t cb, void *arg, int id)
 {
-    elem->cb    = NULL;
-    elem->arg   = cbq;
-    elem->id    = UCS_CALLBACKQ_ID_NULL;
-    elem->flags = 0;
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    ucs_callbackq_elem_t *elem = &cbq->fast_elems[idx];
+
+    elem->cb            = cb;
+    elem->arg           = arg;
+    priv->fast_ids[idx] = id;
 }
 
-static void *ucs_callbackq_array_grow(ucs_callbackq_t *cbq, void *ptr,
-                                      size_t elem_size, int count,
-                                      int *new_count, const char *alloc_name)
+static void ucs_callbackq_elem_reset(ucs_callbackq_t *cbq, unsigned idx)
 {
-    void *new_ptr;
-
-    if (count == 0) {
-        *new_count = ucs_get_page_size() / elem_size;
-    } else {
-        *new_count = count * 2;
-    }
-
-    new_ptr = ucs_sys_realloc(ptr, elem_size * count, elem_size * *new_count);
-    if (new_ptr == NULL) {
-        ucs_fatal("cbq %p: could not allocate memory for %s", cbq, alloc_name);
-    }
-    return new_ptr;
-}
-
-static void ucs_callbackq_array_free(void *ptr, size_t elem_size, int count)
-{
-    ucs_sys_free(ptr, elem_size * count);
+    /* Set 'cbq' as the callback argument, in case we install the proxy callback
+       in this location */
+    ucs_callbackq_fast_elem_set(cbq, idx, NULL, cbq, UCS_CALLBACKQ_ID_NULL);
 }
 
 /*
  * @param [in]  id  ID to release in the lookup array.
  * @return index which this ID used to hold.
  */
-int ucs_callbackq_put_id(ucs_callbackq_t *cbq, int id)
+unsigned ucs_callbackq_put_id(ucs_callbackq_t *cbq, int id)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    unsigned idx_with_flag;
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    unsigned idx, *idx_elem;
 
     ucs_trace_func("cbq=%p id=%d", cbq, id);
 
     ucs_assert(id != UCS_CALLBACKQ_ID_NULL);
 
-    idx_with_flag     = priv->idxs[id];    /* Retrieve the index */
-    priv->idxs[id]    = priv->free_idx_id; /* Add ID to free-list head */
+    idx_elem          = &ucs_array_elem(&priv->idxs, id);
+    idx               = *idx_elem; /* Retrieve the index */
+    *idx_elem         = priv->free_idx_id; /* Add ID to free-list head */
     priv->free_idx_id = id;                /* Update free-list head */
 
-    return idx_with_flag;
-}
-
-int ucs_callbackq_put_id_noflag(ucs_callbackq_t *cbq, int id)
-{
-    return ucs_callbackq_put_id(cbq, id) & UCS_CALLBACKQ_IDX_MASK;
+    return idx;
 }
 
 /**
  * @param [in]  idx  Index to save in the lookup array.
  * @return unique ID which holds index 'idx'.
  */
-int ucs_callbackq_get_id(ucs_callbackq_t *cbq, unsigned idx)
+static int ucs_callbackq_get_id(ucs_callbackq_t *cbq, unsigned idx)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    int new_num_idxs;
+    ucs_callbackq_priv_t *priv = cbq->priv;
     int id;
 
     ucs_trace_func("cbq=%p idx=%u", cbq, idx);
 
     if (priv->free_idx_id == UCS_CALLBACKQ_ID_NULL) {
-        priv->idxs = ucs_callbackq_array_grow(cbq, priv->idxs, sizeof(*priv->idxs),
-                                              priv->num_idxs, &new_num_idxs,
-                                              "indexes");
-
-        /* Add new items to free-list */
-        for (id = priv->num_idxs; id < new_num_idxs; ++id) {
-            priv->idxs[id]    = priv->free_idx_id;
-            priv->free_idx_id = id;
-        }
-
-        priv->num_idxs = new_num_idxs;
+        id = ucs_array_length(&priv->idxs);
+        ucs_array_append(
+                ucs_callbackq_idx, &priv->idxs,
+                ucs_fatal("callback queue %p: could not grow indexes array",
+                          cbq));
+    } else {
+        /* Get free ID from the list and update free-list head */
+        id                = priv->free_idx_id;
+        priv->free_idx_id = ucs_array_elem(&priv->idxs, id);
     }
 
-    id = priv->free_idx_id;             /* Get free ID from the list */
-    ucs_assert(id != UCS_CALLBACKQ_ID_NULL);
-    priv->free_idx_id = priv->idxs[id]; /* Update free-list head */
-    priv->idxs[id]    = idx;            /* Install provided idx to array */
+    /* Install provided idx to array */
+    ucs_array_elem(&priv->idxs, id) = idx;
     return id;
 }
 
 static unsigned ucs_callbackq_get_fast_idx(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
     unsigned idx;
 
+    ucs_trace_func("cbq=%p num_fast_elems=%u", cbq, priv->num_fast_elems);
+
     idx = priv->num_fast_elems++;
-    ucs_assert(idx < UCS_CALLBACKQ_FAST_COUNT);
+    ucs_assertv(idx < UCS_CALLBACKQ_FAST_COUNT, "idx=%u", idx);
+
     return idx;
 }
 
-static int ucs_callbackq_add_fast(ucs_callbackq_t *cbq, ucs_callback_t cb,
-                                  void *arg, unsigned flags)
+static int
+ucs_callbackq_fast_elem_add(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
 {
     unsigned idx;
     int id;
 
-    ucs_trace_func("cbq=%p cb=%s arg=%p flags=%u", cbq,
-                   ucs_debug_get_symbol_name(cb), arg, flags);
-
-    ucs_assert(!(flags & UCS_CALLBACKQ_FLAG_ONESHOT));
+    ucs_trace_func("cbq=%p cb=%s arg=%p", cbq, ucs_debug_get_symbol_name(cb),
+                   arg);
 
     idx = ucs_callbackq_get_fast_idx(cbq);
     id  = ucs_callbackq_get_id(cbq, idx);
-    cbq->fast_elems[idx].cb    = cb;
-    cbq->fast_elems[idx].arg   = arg;
-    cbq->fast_elems[idx].flags = flags;
-    cbq->fast_elems[idx].id    = id;
+    ucs_callbackq_fast_elem_set(cbq, idx, cb, arg, id);
     return id;
 }
 
-/* should be called from dispatch thread only */
-static void ucs_callbackq_remove_fast(ucs_callbackq_t *cbq, unsigned idx)
+/* Should be called from dispatch thread only */
+static void ucs_callbackq_fast_elems_purge(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_priv_t *priv     = ucs_callbackq_priv(cbq);
-    ucs_callbackq_elem_t *dst_elem = &cbq->fast_elems[idx];
-    unsigned last_idx;
-    int id;
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    ucs_callbackq_elem_t *replace_elem;
+    unsigned idx, replace_idx;
+    int replace_id;
 
-    ucs_trace_func("cbq=%p idx=%u", cbq, idx);
+    ucs_trace_func("cbq=%p fast_remove_mask=0x%" PRIx64, cbq,
+                   priv->fast_remove_mask);
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, 1);
 
-    ucs_assert(priv->num_fast_elems > 0);
-    last_idx = --priv->num_fast_elems;
+    ucs_assertv(priv->num_fast_elems >= ucs_popcount(priv->fast_remove_mask),
+                "num_fast_elems=%u fast_remove_mask=0x%" PRIx64,
+                priv->num_fast_elems, priv->fast_remove_mask);
 
-    /* replace removed with last */
-    *dst_elem = cbq->fast_elems[last_idx];
-    ucs_callbackq_elem_reset(cbq, &cbq->fast_elems[last_idx]);
-
-    if (priv->fast_remove_mask & UCS_BIT(last_idx)) {
-        /* replaced by marked-for-removal element, still need to remove 'idx' */
-        ucs_assert(priv->fast_remove_mask & UCS_BIT(idx));
-        priv->fast_remove_mask &= ~UCS_BIT(last_idx);
-    } else {
-        /* replaced by a live element, remove from the mask and update 'idxs' */
-        priv->fast_remove_mask &= ~UCS_BIT(idx);
-        if (last_idx != idx) {
-            id = dst_elem->id;
-            ucs_assert(id != UCS_CALLBACKQ_ID_NULL);
-            priv->idxs[id] = idx;
-        }
-    }
-}
-
-/* should be called from dispatch thread only */
-static void ucs_callbackq_purge_fast(ucs_callbackq_t *cbq)
-{
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    unsigned idx;
-
-    ucs_trace_func("cbq=%p map=0x%"PRIx64, cbq, priv->fast_remove_mask);
-
-    /* Remove fast-path callbacks marked for removal */
     while (priv->fast_remove_mask) {
-        idx = ucs_ffs64(priv->fast_remove_mask);
-        ucs_callbackq_remove_fast(cbq, idx);
-    }
-}
+        ucs_assert(priv->num_fast_elems > 0);
 
-static void ucs_callbackq_enable_proxy(ucs_callbackq_t *cbq)
-{
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    unsigned idx;
-    int id;
+        idx                     = ucs_ilog2(priv->fast_remove_mask);
+        replace_idx             = --priv->num_fast_elems;
+        priv->fast_remove_mask &= ~UCS_BIT(idx);
 
-    ucs_trace_func("cbq=%p", cbq);
-
-    if (priv->slow_proxy_id != UCS_CALLBACKQ_ID_NULL) {
-        return;
-    }
-
-    ucs_assertv((priv->num_slow_elems > 0) || priv->fast_remove_mask ||
-                (kh_size(&priv->oneshot_elems) > 0),
-                "cbq=%p num_slow_elems=%u fast_remove_mask=0x%" PRIx64
-                " oneshot_elems=%u",
-                cbq, priv->num_slow_elems, priv->fast_remove_mask,
-                kh_size(&priv->oneshot_elems));
-
-    idx = ucs_callbackq_get_fast_idx(cbq);
-    id  = ucs_callbackq_get_id(cbq, idx);
-
-    ucs_assert(cbq->fast_elems[idx].arg == cbq);
-    cbq->fast_elems[idx].cb    = ucs_callbackq_slow_proxy;
-    cbq->fast_elems[idx].flags = 0;
-    cbq->fast_elems[idx].id    = id;
-    /* Avoid writing 'arg' because the dispatching thread may not see it in case
-     * of weak memory ordering. Instead, 'arg' is reset to 'cbq' for all free and
-     * removed elements, from the main thread.
-     */
-
-    priv->slow_proxy_id        = id;
-}
-
-static void ucs_callbackq_disable_proxy(ucs_callbackq_t *cbq)
-{
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    unsigned idx;
-
-    ucs_trace_func("cbq=%p slow_proxy_id=%d", cbq, priv->slow_proxy_id);
-
-    ucs_assert(priv->fast_remove_mask == 0);
-
-    if (priv->slow_proxy_id == UCS_CALLBACKQ_ID_NULL) {
-        return;
-    }
-
-    idx = ucs_callbackq_put_id(cbq, priv->slow_proxy_id);
-    ucs_callbackq_remove_fast(cbq, idx);
-    priv->slow_proxy_id = UCS_CALLBACKQ_ID_NULL;
-}
-
-static int ucs_callbackq_add_slow(ucs_callbackq_t *cbq, ucs_callback_t cb,
-                                  void *arg, unsigned flags)
-{
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    ucs_callbackq_elem_t *new_slow_elems;
-    int new_max_slow_elems;
-    unsigned idx;
-    int id;
-
-    ucs_trace_func("cbq=%p cb=%s arg=%p flags=%u", cbq,
-                   ucs_debug_get_symbol_name(cb), arg, flags);
-
-    /* Grow slow-path array if needed */
-    if (priv->num_slow_elems >= priv->max_slow_elems) {
-        new_slow_elems = ucs_callbackq_array_grow(cbq, priv->slow_elems,
-                                                  sizeof(*priv->slow_elems),
-                                                  priv->max_slow_elems,
-                                                  &new_max_slow_elems,
-                                                  "slow_elems");
-        for (idx = priv->max_slow_elems; idx < new_max_slow_elems; ++idx) {
-            ucs_callbackq_elem_reset(cbq, &new_slow_elems[idx]);
+        if (idx == replace_idx) {
+            /* Removing last element */
+            ucs_callbackq_elem_reset(cbq, replace_idx);
+            continue;
         }
 
-        priv->max_slow_elems = new_max_slow_elems;
-        priv->slow_elems     = new_slow_elems;
+        /*
+         * Since we iterate using ilog2 - from high bit to low - if we are not
+         * removing the last element, it means the last element is not part of
+         * the remove mask
+         */
+        ucs_assert(!(priv->fast_remove_mask & UCS_BIT(replace_idx)));
+
+        replace_id = priv->fast_ids[replace_idx];
+        ucs_assert(replace_id != UCS_CALLBACKQ_ID_NULL);
+        ucs_trace_func("cbq=%p replace fast idx=%u by idx=%u id=%d", cbq, idx,
+                       replace_idx, replace_id);
+
+        /* Replace removed element by last element */
+        replace_elem = &cbq->fast_elems[replace_idx];
+        ucs_callbackq_fast_elem_set(cbq, idx, replace_elem->cb,
+                                    replace_elem->arg, replace_id);
+        ucs_array_elem(&priv->idxs, replace_id) = idx;
+        ucs_callbackq_elem_reset(cbq, replace_idx);
     }
 
-    /* Add slow-path element to the queue */
-    idx = priv->num_slow_elems++;
-    id  = ucs_callbackq_get_id(cbq, idx | UCS_CALLBACKQ_IDX_FLAG_SLOW);
-    priv->slow_elems[idx].cb    = cb;
-    priv->slow_elems[idx].arg   = arg;
-    priv->slow_elems[idx].flags = flags;
-    priv->slow_elems[idx].id    = id;
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, -1);
+}
 
-    ucs_callbackq_enable_proxy(cbq);
+static int
+ucs_callbackq_spill_elem_add(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    ucs_callbackq_spill_elem_t *elem;
+    unsigned idx;
+    int id;
+
+    ucs_trace_func("cbq=%p cb=%s arg=%p", cbq, ucs_debug_get_symbol_name(cb),
+                   arg);
+
+    idx  = ucs_array_length(&priv->spill_elems);
+    elem = ucs_array_append(
+            ucs_callbackq_spill_elems, &priv->spill_elems,
+            ucs_fatal("callbackq %p: failed to allocate spill array", cbq));
+    id   = ucs_callbackq_get_id(cbq, idx + UCS_CALLBACKQ_FAST_COUNT);
+
+    elem->super.cb  = cb;
+    elem->super.arg = arg;
+    elem->id        = id;
+
+    ucs_callbackq_proxy_enable(cbq);
     return id;
 }
 
-static void ucs_callbackq_remove_slow(ucs_callbackq_t *cbq, unsigned idx)
+static void *ucs_callbackq_spill_elem_remove(ucs_callbackq_t *cbq, unsigned idx)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    ucs_callbackq_spill_elem_t *elem;
 
-    ucs_trace_func("cbq=%p idx=%u", cbq, idx);
+    ucs_assertv(idx < ucs_array_length(&priv->spill_elems), "idx=%u length=%u",
+                idx, ucs_array_length(&priv->spill_elems));
+    elem     = &ucs_array_elem(&priv->spill_elems, idx);
+    elem->id = UCS_CALLBACKQ_ID_NULL;
 
-    /* Mark for removal by ucs_callbackq_purge_slow() */
-    ucs_callbackq_elem_reset(cbq, &priv->slow_elems[idx]);
+    return elem->super.arg;
 }
 
-static void ucs_callbackq_purge_slow(ucs_callbackq_t *cbq)
+/* Should be called from dispatch thread only */
+static void ucs_callbackq_spill_elems_purge(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    ucs_callbackq_elem_t *src_elem;
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    ucs_callbackq_spill_elem_t *src_elem;
     unsigned src_idx, dst_idx;
 
     ucs_trace_func("cbq=%p", cbq);
@@ -370,25 +298,100 @@ static void ucs_callbackq_purge_slow(ucs_callbackq_t *cbq)
      * always be equal to dst_idx, so nothing will be actually copied/moved.
      */
     dst_idx = 0;
-    for (src_idx = 0; src_idx < priv->num_slow_elems; ++src_idx) {
-        src_elem = &priv->slow_elems[src_idx];
+    for (src_idx = 0; src_idx < ucs_array_length(&priv->spill_elems);
+         ++src_idx) {
+        src_elem = &ucs_array_elem(&priv->spill_elems, src_idx);
         if (src_elem->id != UCS_CALLBACKQ_ID_NULL) {
             ucs_assert(dst_idx <= src_idx);
             if (dst_idx != src_idx) {
-                priv->idxs[src_elem->id]  = dst_idx | UCS_CALLBACKQ_IDX_FLAG_SLOW;
-                priv->slow_elems[dst_idx] = *src_elem;
+                ucs_array_elem(&priv->idxs, src_elem->id) =
+                        dst_idx + UCS_CALLBACKQ_FAST_COUNT;
+                ucs_array_elem(&priv->spill_elems, dst_idx) = *src_elem;
             }
             ++dst_idx;
         }
     }
 
-    priv->num_slow_elems = dst_idx;
+    ucs_array_set_length(&priv->spill_elems, dst_idx);
+}
+
+static void ucs_callbackq_oneshot_elems_free(ucs_callbackq_t *cbq)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    ucs_callbackq_oneshot_elem_t *oneshot_elem;
+    ucs_hlist_head_t hlist;
+
+    kh_foreach_value(&priv->oneshot_elems, hlist, {
+        ucs_hlist_for_each_extract(oneshot_elem, &hlist, hlist) {
+            ucs_free(oneshot_elem);
+        }
+    });
+    kh_clear(ucs_callbackq_oneshot_elems, &priv->oneshot_elems);
+}
+
+static int ucs_callback_is_proxy_needed(ucs_callbackq_t *cbq)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+
+    return !ucs_array_is_empty(&priv->spill_elems) ||
+           (kh_size(&priv->oneshot_elems) > 0) || priv->fast_remove_mask;
+}
+
+/* Promote a spill element to fast-path array */
+static void ucs_callbackq_spill_elem_promote(ucs_callbackq_t *cbq, unsigned idx)
+{
+    ucs_callbackq_priv_t *priv       = cbq->priv;
+    ucs_callbackq_spill_elem_t *elem = &ucs_array_elem(&priv->spill_elems, idx);
+    unsigned fast_idx;
+
+    ucs_trace_func("cbq=%p idx=%u elem->id=%d", cbq, idx, elem->id);
+
+    fast_idx = ucs_callbackq_get_fast_idx(cbq);
+    ucs_callbackq_fast_elem_set(cbq, fast_idx, elem->super.cb, elem->super.arg,
+                                elem->id);
+    ucs_array_elem(&priv->idxs, elem->id) = fast_idx;
+    ucs_callbackq_spill_elem_remove(cbq, idx);
+}
+
+/* Lock must be held */
+static unsigned ucs_callbackq_spill_elems_dispatch(ucs_callbackq_t *cbq)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    unsigned num_spill_elems   = ucs_array_length(&priv->spill_elems);
+    unsigned count             = 0;
+    ucs_callbackq_spill_elem_t *spill_elem;
+    ucs_callbackq_elem_t tmp_elem;
+    unsigned spill_elem_idx;
+
+    /* Execute and update spill callbacks by num_oneshot_elems copy to avoid
+     * infinite loop if callback adds another one */
+    for (spill_elem_idx = 0; spill_elem_idx < num_spill_elems;
+         ++spill_elem_idx) {
+        spill_elem = &ucs_array_elem(&priv->spill_elems, spill_elem_idx);
+        if (spill_elem->id == UCS_CALLBACKQ_ID_NULL) {
+            continue;
+        }
+
+        tmp_elem = spill_elem->super;
+        if (priv->num_fast_elems < UCS_CALLBACKQ_FAST_MAX) {
+            ucs_callbackq_spill_elem_promote(cbq, spill_elem_idx);
+        }
+
+        ucs_callbackq_leave(cbq);
+
+        /* Execute callback without lock */
+        count += tmp_elem.cb(tmp_elem.arg);
+
+        ucs_callbackq_enter(cbq);
+    }
+
+    return count;
 }
 
 /* Lock must be held */
 static unsigned ucs_callbackq_oneshot_elems_dispatch(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
     unsigned count             = 0;
     ucs_callbackq_oneshot_elem_t *oneshot_elem;
     unsigned key_idx, num_keys;
@@ -464,65 +467,71 @@ static unsigned ucs_callbackq_oneshot_elems_dispatch(ucs_callbackq_t *cbq)
     return count;
 }
 
-static unsigned ucs_callbackq_slow_proxy(void *arg)
+static unsigned ucs_callbackq_proxy_callback(void *arg)
 {
-    ucs_callbackq_t      *cbq  = arg;
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    unsigned num_slow_elems    = priv->num_slow_elems;
-    unsigned count             = 0;
-    ucs_callbackq_elem_t *elem;
-    unsigned UCS_V_UNUSED removed_idx;
-    unsigned slow_idx, fast_idx;
-    ucs_callbackq_elem_t tmp_elem;
+    ucs_callbackq_t *cbq = arg;
+    unsigned count;
 
-    ucs_trace_poll("cbq=%p", cbq);
+    ucs_trace_poll("cbq=%p proxy_callback", cbq);
 
     ucs_callbackq_enter(cbq);
 
-    /* Execute and update slow-path callbacks by num_slow_elems copy to avoid
-     * infinite loop if callback adds another one */
-    for (slow_idx = 0; slow_idx < num_slow_elems; ++slow_idx) {
-        elem = &priv->slow_elems[slow_idx];
-        if (elem->id == UCS_CALLBACKQ_ID_NULL) {
-            continue;
-        }
+    count = ucs_callbackq_spill_elems_dispatch(cbq) +
+            ucs_callbackq_oneshot_elems_dispatch(cbq);
 
-        tmp_elem = *elem;
-        if (elem->flags & UCS_CALLBACKQ_FLAG_FAST) {
-            ucs_assert(!(elem->flags & UCS_CALLBACKQ_FLAG_ONESHOT));
-            if (priv->num_fast_elems < UCS_CALLBACKQ_FAST_MAX) {
-                fast_idx = ucs_callbackq_get_fast_idx(cbq);
-                cbq->fast_elems[fast_idx] = *elem;
-                priv->idxs[elem->id]      = fast_idx;
-                ucs_callbackq_remove_slow(cbq, slow_idx);
-            }
-        } else if (elem->flags & UCS_CALLBACKQ_FLAG_ONESHOT) {
-            removed_idx = ucs_callbackq_put_id_noflag(cbq, elem->id);
-            ucs_assert(removed_idx == slow_idx);
-            ucs_callbackq_remove_slow(cbq, slow_idx);
-        }
-
-        ucs_callbackq_leave(cbq);
-
-        count += tmp_elem.cb(tmp_elem.arg); /* Execute callback without lock */
-
-        ucs_callbackq_enter(cbq);
-    }
-
-    count += ucs_callbackq_oneshot_elems_dispatch(cbq);
-
-    ucs_callbackq_purge_fast(cbq);
-    ucs_callbackq_purge_slow(cbq);
+    /* Remove remaning callbacks */
+    ucs_callbackq_fast_elems_purge(cbq);
+    ucs_callbackq_spill_elems_purge(cbq);
 
     /* Disable this proxy if no more work to do */
-    if (!priv->fast_remove_mask && (priv->num_slow_elems == 0) &&
-        (kh_size(&priv->oneshot_elems) == 0)) {
-        ucs_callbackq_disable_proxy(cbq);
+    if (!ucs_callback_is_proxy_needed(cbq)) {
+        ucs_callbackq_proxy_disable(cbq);
     }
 
     ucs_callbackq_leave(cbq);
 
     return count;
+}
+
+static void ucs_callbackq_proxy_enable(ucs_callbackq_t *cbq)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+
+    ucs_trace_func("cbq=%p", cbq);
+
+    ucs_assertv(ucs_callback_is_proxy_needed(cbq), "cbq=%p", cbq);
+
+    if (priv->proxy_cb_id != UCS_CALLBACKQ_ID_NULL) {
+        /* Already enabled */
+        return;
+    }
+
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, 1);
+    priv->proxy_cb_id =
+            ucs_callbackq_fast_elem_add(cbq, ucs_callbackq_proxy_callback, cbq);
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, -1);
+}
+
+static void ucs_callbackq_proxy_disable(ucs_callbackq_t *cbq)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    unsigned idx;
+
+    ucs_trace_func("cbq=%p proxy_cb_id=%d", cbq, priv->proxy_cb_id);
+
+    if (priv->proxy_cb_id == UCS_CALLBACKQ_ID_NULL) {
+        /* Already disabled */
+        return;
+    }
+
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, 1);
+
+    idx                     = ucs_callbackq_put_id(cbq, priv->proxy_cb_id);
+    priv->proxy_cb_id       = UCS_CALLBACKQ_ID_NULL;
+    priv->fast_remove_mask |= UCS_BIT(idx);
+    ucs_callbackq_fast_elems_purge(cbq);
+
+    ucs_log_indent_level(UCS_LOG_LEVEL_TRACE_FUNC, -1);
 }
 
 static void
@@ -535,13 +544,14 @@ ucs_callbackq_elem_show(const char *title, const ucs_callbackq_elem_t *elem)
 static void ucs_callbackq_show_remaining_elems(ucs_callbackq_t *cbq)
 {
     const char *diag_log_str   = ", increase log level to diag for details";
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
     ucs_callbackq_oneshot_elem_t *oneshot_elem;
-    ucs_callbackq_elem_t *elem;
+    ucs_callbackq_spill_elem_t *spill_elem;
+    ucs_callbackq_elem_t *fast_elem;
     ucs_hlist_head_t hlist;
     unsigned total_elems;
 
-    total_elems = priv->num_fast_elems + priv->num_slow_elems;
+    total_elems = priv->num_fast_elems + ucs_array_length(&priv->spill_elems);
     kh_foreach_value(&priv->oneshot_elems, hlist, {
         ucs_hlist_for_each(oneshot_elem, &hlist, hlist) {
             ++total_elems;
@@ -560,11 +570,11 @@ static void ucs_callbackq_show_remaining_elems(ucs_callbackq_t *cbq)
 
     ucs_log_indent(1);
 
-    ucs_carray_for_each(elem, cbq->fast_elems, priv->num_fast_elems) {
-        ucs_callbackq_elem_show("fast-path", elem);
+    ucs_carray_for_each(fast_elem, cbq->fast_elems, priv->num_fast_elems) {
+        ucs_callbackq_elem_show("fast-path", fast_elem);
     }
-    ucs_carray_for_each(elem, priv->slow_elems, priv->num_slow_elems) {
-        ucs_callbackq_elem_show("slow", elem);
+    ucs_array_for_each(spill_elem, &priv->spill_elems) {
+        ucs_callbackq_elem_show("spill", &spill_elem->super);
     }
     kh_foreach_value(&priv->oneshot_elems, hlist, {
         ucs_hlist_for_each(oneshot_elem, &hlist, hlist) {
@@ -577,176 +587,151 @@ static void ucs_callbackq_show_remaining_elems(ucs_callbackq_t *cbq)
 
 ucs_status_t ucs_callbackq_init(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv;
     unsigned idx;
 
-    for (idx = 0; idx < UCS_CALLBACKQ_FAST_COUNT + 1; ++idx) {
-        ucs_callbackq_elem_reset(cbq, &cbq->fast_elems[idx]);
+    priv = ucs_malloc(sizeof(*priv), "ucs_callbackq_priv");
+    if (priv == NULL) {
+        ucs_error("failed to allocate ucs_callbackq_priv");
+        return UCS_ERR_NO_MEMORY;
     }
 
     ucs_recursive_spinlock_init(&priv->lock, 0);
+    ucs_array_init_dynamic(&priv->idxs);
+    ucs_array_init_dynamic(&priv->spill_elems);
     kh_init_inplace(ucs_callbackq_oneshot_elems, &priv->oneshot_elems);
-    priv->slow_elems        = NULL;
-    priv->num_slow_elems    = 0;
-    priv->max_slow_elems    = 0;
-    priv->slow_proxy_id     = UCS_CALLBACKQ_ID_NULL;
-    priv->fast_remove_mask  = 0;
-    priv->num_fast_elems    = 0;
-    priv->free_idx_id       = UCS_CALLBACKQ_ID_NULL;
-    priv->num_idxs          = 0;
-    priv->idxs              = NULL;
+    priv->num_fast_elems   = 0;
+    priv->fast_remove_mask = 0;
+    priv->free_idx_id      = UCS_CALLBACKQ_ID_NULL;
+    priv->proxy_cb_id      = UCS_CALLBACKQ_ID_NULL;
+    cbq->priv              = priv;
+
+    for (idx = 0; idx < UCS_CALLBACKQ_FAST_COUNT; ++idx) {
+        ucs_callbackq_elem_reset(cbq, idx);
+    }
+    cbq->fast_elems[UCS_CALLBACKQ_FAST_COUNT].cb = NULL;
+
     return UCS_OK;
 }
 
 void ucs_callbackq_cleanup(ucs_callbackq_t *cbq)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
 
-    ucs_callbackq_purge_fast(cbq);
-    ucs_callbackq_disable_proxy(cbq);
-    ucs_callbackq_purge_slow(cbq);
+    ucs_callbackq_fast_elems_purge(cbq);
+    ucs_callbackq_spill_elems_purge(cbq);
+    ucs_callbackq_proxy_disable(cbq);
     ucs_callbackq_show_remaining_elems(cbq);
 
+    ucs_callbackq_oneshot_elems_free(cbq);
     kh_destroy_inplace(ucs_callbackq_oneshot_elems, &priv->oneshot_elems);
-    ucs_callbackq_array_free(priv->slow_elems, sizeof(*priv->slow_elems),
-                             priv->max_slow_elems);
-    ucs_callbackq_array_free(priv->idxs, sizeof(*priv->idxs), priv->num_idxs);
+    ucs_array_cleanup_dynamic(&priv->spill_elems);
+    ucs_array_cleanup_dynamic(&priv->idxs);
+
+    ucs_free(priv);
 }
 
-int ucs_callbackq_add(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg,
-                      unsigned flags)
+int ucs_callbackq_add(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
     int id;
+
+    ucs_trace_func("cbq=%p cb=%s arg=%p", cbq, ucs_debug_get_symbol_name(cb),
+                   arg);
 
     ucs_callbackq_enter(cbq);
 
-    ucs_trace_func("cbq=%p cb=%s arg=%p flags=%u", cbq,
-                   ucs_debug_get_symbol_name(cb), arg, flags);
-
-    if ((flags & UCS_CALLBACKQ_FLAG_FAST) &&
-        (priv->num_fast_elems < UCS_CALLBACKQ_FAST_MAX))
-    {
-        id = ucs_callbackq_add_fast(cbq, cb, arg, flags);
+    if (ucs_likely(priv->num_fast_elems < UCS_CALLBACKQ_FAST_MAX)) {
+        id = ucs_callbackq_fast_elem_add(cbq, cb, arg);
     } else {
-        id = ucs_callbackq_add_slow(cbq, cb, arg, flags);
+        id = ucs_callbackq_spill_elem_add(cbq, cb, arg);
     }
 
     ucs_callbackq_leave(cbq);
     return id;
 }
 
-void ucs_callbackq_remove(ucs_callbackq_t *cbq, int id)
+void *ucs_callbackq_remove(ucs_callbackq_t *cbq, int id)
 {
-    unsigned idx_with_flag, idx;
-
-    ucs_callbackq_enter(cbq);
-
-    ucs_trace_func("cbq=%p id=%d", cbq, id);
-
-    ucs_callbackq_purge_fast(cbq);
-
-    idx_with_flag = ucs_callbackq_put_id(cbq, id);
-    idx           = idx_with_flag & UCS_CALLBACKQ_IDX_MASK;
-
-    if (idx_with_flag & UCS_CALLBACKQ_IDX_FLAG_SLOW) {
-        ucs_callbackq_remove_slow(cbq, idx);
-    } else {
-        ucs_callbackq_remove_fast(cbq, idx);
-    }
-
-    ucs_callbackq_leave(cbq);
-}
-
-int ucs_callbackq_add_safe(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg,
-                           unsigned flags)
-{
-    int id;
-
-    ucs_callbackq_enter(cbq);
-
-    ucs_trace_func("cbq=%p cb=%s arg=%p flags=%u", cbq,
-                   ucs_debug_get_symbol_name(cb), arg, flags);
-
-    /* Add callback to slow-path, and it may be upgraded to fast-path later by
-     * the proxy callback. It's not safe to add fast-path callback directly
-     * from this context.
-     */
-    id = ucs_callbackq_add_slow(cbq, cb, arg, flags);
-
-    ucs_callbackq_leave(cbq);
-    return id;
-}
-
-void ucs_callbackq_remove_safe(ucs_callbackq_t *cbq, int id)
-{
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    unsigned idx_with_flag, idx;
-
-    ucs_callbackq_enter(cbq);
-
-    ucs_trace_func("cbq=%p id=%d", cbq, id);
-
-    idx_with_flag = ucs_callbackq_put_id(cbq, id);
-    idx           = idx_with_flag & UCS_CALLBACKQ_IDX_MASK;
-
-    if (idx_with_flag & UCS_CALLBACKQ_IDX_FLAG_SLOW) {
-        ucs_callbackq_remove_slow(cbq, idx);
-    } else {
-        UCS_STATIC_ASSERT(UCS_CALLBACKQ_FAST_MAX <= 64);
-        ucs_assert(idx < priv->num_fast_elems);
-        priv->fast_remove_mask |= UCS_BIT(idx);
-        cbq->fast_elems[idx].id = UCS_CALLBACKQ_ID_NULL; /* for assertion */
-        ucs_callbackq_enable_proxy(cbq);
-    }
-
-    ucs_callbackq_leave(cbq);
-}
-
-void ucs_callbackq_remove_if(ucs_callbackq_t *cbq, ucs_callbackq_predicate_t pred,
-                             void *arg)
-{
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
-    ucs_callbackq_elem_t *elem;
+    ucs_callbackq_priv_t *priv = cbq->priv;
     unsigned idx;
+    void *cb_arg;
+
+    ucs_trace_func("cbq=%p id=%d", cbq, id);
 
     ucs_callbackq_enter(cbq);
 
-    ucs_trace_func("cbq=%p", cbq);
-
-    ucs_callbackq_purge_fast(cbq);
-
-    /* Mark matched fast-path elements to be removed  */
-    for (elem = cbq->fast_elems; elem->cb != NULL; ++elem) {
-        if (pred(elem, arg)) {
-            ucs_callbackq_remove_safe(cbq, elem->id);
-        }
-    }
-
-    /* Purge fast-path elements marked for removal.
-     * Elements are collected and then removed to suppress Coverity warning
-     * about using the element's argument after freeing it, Coverity wrongly
-     * assumes that reusing the same element for the next element could be
-     * harmful */
-    ucs_callbackq_purge_fast(cbq);
-
-    /* Remove slow-path elements */
-    for (elem = priv->slow_elems;
-         elem < (priv->slow_elems + priv->num_slow_elems); ++elem) {
-        if (pred(elem, arg)) {
-            idx = ucs_callbackq_put_id_noflag(cbq, elem->id);
-            ucs_assert(idx == (elem - priv->slow_elems));
-            ucs_callbackq_remove_slow(cbq, idx);
-        }
+    idx = ucs_callbackq_put_id(cbq, id);
+    if (idx < UCS_CALLBACKQ_FAST_COUNT) {
+        ucs_assertv(idx < priv->num_fast_elems, "idx=%u num_fast_elems=%u", idx,
+                    priv->num_fast_elems);
+        cb_arg                  = cbq->fast_elems[idx].arg;
+        priv->fast_remove_mask |= UCS_BIT(idx);
+        ucs_callbackq_fast_elems_purge(cbq);
+    } else {
+        cb_arg = ucs_callbackq_spill_elem_remove(
+                cbq, idx - UCS_CALLBACKQ_FAST_COUNT);
     }
 
     ucs_callbackq_leave(cbq);
+
+    return cb_arg;
+}
+
+int ucs_callbackq_add_safe(ucs_callbackq_t *cbq, ucs_callback_t cb, void *arg)
+{
+    int id;
+
+    ucs_trace_func("cbq=%p cb=%s arg=%p", cbq, ucs_debug_get_symbol_name(cb),
+                   arg);
+
+    ucs_callbackq_enter(cbq);
+
+    /* Add callback to spill elems, and it may be upgraded to fast-path later by
+     * the proxy callback. It's not safe to add to fast_elems directly.
+     */
+    id = ucs_callbackq_spill_elem_add(cbq, cb, arg);
+
+    ucs_callbackq_leave(cbq);
+    return id;
+}
+
+void *ucs_callbackq_remove_safe(ucs_callbackq_t *cbq, int id)
+{
+    ucs_callbackq_priv_t *priv = cbq->priv;
+    unsigned idx;
+    void *cb_arg;
+
+    ucs_trace_func("cbq=%p id=%d", cbq, id);
+
+    ucs_callbackq_enter(cbq);
+
+    idx = ucs_callbackq_put_id(cbq, id);
+    if (idx < UCS_CALLBACKQ_FAST_COUNT) {
+        UCS_STATIC_ASSERT(UCS_CALLBACKQ_FAST_MAX <= 64);
+        ucs_assertv(idx < priv->num_fast_elems, "idx=%u num_fast_elems=%u", idx,
+                    priv->num_fast_elems);
+        /* Make sure user callback will not be called in case we try to dispatch
+           the removed fast-path element before the proxy callback had a chance
+           to clean it up. */
+        cb_arg                  = cbq->fast_elems[idx].arg;
+        cbq->fast_elems[idx].cb = (ucs_callback_t)ucs_empty_function_return_zero;
+        priv->fast_remove_mask |= UCS_BIT(idx);
+        ucs_callbackq_proxy_enable(cbq);
+    } else {
+        cb_arg = ucs_callbackq_spill_elem_remove(
+                cbq, idx - UCS_CALLBACKQ_FAST_COUNT);
+    }
+
+    ucs_callbackq_leave(cbq);
+
+    return cb_arg;
 }
 
 void ucs_callbackq_add_oneshot(ucs_callbackq_t *cbq, ucs_callbackq_key_t key,
                                ucs_callback_t cb, void *arg)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
     ucs_callbackq_oneshot_elem_t *elem;
     ucs_hlist_head_t *hlist;
     khiter_t khiter;
@@ -779,7 +764,7 @@ void ucs_callbackq_add_oneshot(ucs_callbackq_t *cbq, ucs_callbackq_key_t key,
     }
 
     ucs_hlist_add_tail(hlist, &elem->hlist);
-    ucs_callbackq_enable_proxy(cbq);
+    ucs_callbackq_proxy_enable(cbq);
 
     ucs_callbackq_leave(cbq);
 }
@@ -787,7 +772,7 @@ void ucs_callbackq_add_oneshot(ucs_callbackq_t *cbq, ucs_callbackq_key_t key,
 void ucs_callbackq_remove_oneshot(ucs_callbackq_t *cbq, ucs_callbackq_key_t key,
                                   ucs_callbackq_predicate_t pred, void *arg)
 {
-    ucs_callbackq_priv_t *priv = ucs_callbackq_priv(cbq);
+    ucs_callbackq_priv_t *priv = cbq->priv;
     ucs_callbackq_oneshot_elem_t *elem, *telem;
     ucs_hlist_head_t *hlist, thead;
     khiter_t khiter;

--- a/src/ucs/datastruct/callbackq_compat.h
+++ b/src/ucs/datastruct/callbackq_compat.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_CALLBACKQ_COMPAT_H
+#define UCS_CALLBACKQ_COMPAT_H
+
+#include <ucs/sys/compiler_def.h>
+
+
+/**
+ * @ingroup UCS_RESOURCE
+ * Callback backward compatibility flags
+ */
+enum ucs_callbackq_flags {
+    UCS_CALLBACKQ_FLAG_FAST    = UCS_BIT(0), /**< Fast-path (best effort) */
+    UCS_CALLBACKQ_FLAG_ONESHOT = UCS_BIT(1)  /**< Call the callback only once
+                                                  (cannot be used with FAST) */
+};
+
+#endif

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -15,6 +15,7 @@
 #include <uct/api/version.h>
 #include <ucs/async/async_fwd.h>
 #include <ucs/datastruct/callbackq.h>
+#include <ucs/datastruct/callbackq_compat.h>
 #include <ucs/datastruct/linear_func.h>
 #include <ucs/memory/memory_type.h>
 #include <ucs/type/status.h>

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -326,11 +326,10 @@ void uct_base_iface_progress_enable_cb(uct_base_iface_t *iface,
         (iface->prog.id == UCS_CALLBACKQ_ID_NULL)) {
         if (thread_safe) {
             iface->prog.id = ucs_callbackq_add_safe(&worker->super.progress_q,
-                                                    cb, iface,
-                                                    UCS_CALLBACKQ_FLAG_FAST);
+                                                    cb, iface);
         } else {
             iface->prog.id = ucs_callbackq_add(&worker->super.progress_q, cb,
-                                               iface, UCS_CALLBACKQ_FLAG_FAST);
+                                               iface);
         }
     }
     iface->progress_flags |= flags;

--- a/src/uct/base/uct_worker.c
+++ b/src/uct/base/uct_worker.c
@@ -18,6 +18,20 @@
 #include <ucs/vfs/base/vfs_obj.h>
 
 
+/* Oneshot callbacks ID range, since their context needs to be released */
+#define UCT_WORKER_ONESHOT_ID_START (INT_MAX / 2)
+
+/*
+ * Context for callbacks registered with uct_worker_progress_register_safe and
+ * UCS_CALLBACKQ_FLAG_ONESHOT flag.
+ */
+typedef struct {
+    ucs_callback_t  func; /* Original user callback */
+    void            *arg; /* Original user argument */
+    ucs_callbackq_t *cbq; /* Callback queue for removing after dispatch */
+    int             id;   /* Callback id for removing after dispatch */
+} uct_worker_oneshot_cb_ctx_t;
+
 static UCS_CLASS_INIT_FUNC(uct_worker_t)
 {
     ucs_callbackq_init(&self->progress_q);
@@ -70,8 +84,7 @@ void uct_worker_progress_add_safe(uct_priv_worker_t *worker, ucs_callback_t cb,
 {
     UCS_ASYNC_BLOCK(worker->async);
     if (ucs_atomic_fadd32(&prog->refcount, 1) == 0) {
-        prog->id = ucs_callbackq_add_safe(&worker->super.progress_q, cb, arg,
-                                          UCS_CALLBACKQ_FLAG_FAST);
+        prog->id = ucs_callbackq_add_safe(&worker->super.progress_q, cb, arg);
     }
     UCS_ASYNC_UNBLOCK(worker->async);
 }
@@ -107,29 +120,87 @@ void uct_worker_progress_remove_all(uct_priv_worker_t *worker,
     UCS_ASYNC_UNBLOCK(worker->async);
 }
 
-void uct_worker_progress_register_safe(uct_worker_h tl_worker, ucs_callback_t func,
-                                       void *arg, unsigned flags,
-                                       uct_worker_cb_id_t *id_p)
+static unsigned uct_worker_oneshot_callback_proxy(void *arg)
+{
+    uct_worker_oneshot_cb_ctx_t *ctx = arg;
+    unsigned count;
+
+    count = ctx->func(ctx->arg);
+    ucs_callbackq_remove_safe(ctx->cbq, ctx->id);
+    ucs_free(ctx);
+
+    return count;
+}
+
+void uct_worker_progress_register_safe(uct_worker_h tl_worker,
+                                       ucs_callback_t func, void *arg,
+                                       unsigned flags, uct_worker_cb_id_t *id_p)
 {
     uct_priv_worker_t *worker = ucs_derived_of(tl_worker, uct_priv_worker_t);
+    uct_worker_oneshot_cb_ctx_t *ctx;
+    uct_worker_cb_id_t id;
 
-    if (*id_p == UCS_CALLBACKQ_ID_NULL) {
-        UCS_ASYNC_BLOCK(worker->async);
-        *id_p = ucs_callbackq_add_safe(&worker->super.progress_q, func, arg, flags);
-        ucs_assert(*id_p != UCS_CALLBACKQ_ID_NULL);
-        UCS_ASYNC_UNBLOCK(worker->async);
+    if (*id_p != UCS_CALLBACKQ_ID_NULL) {
+        return;
     }
+
+    UCS_ASYNC_BLOCK(worker->async);
+    if (flags & UCS_CALLBACKQ_FLAG_ONESHOT) {
+        /*
+         * Implement UCS_CALLBACKQ_FLAG_ONESHOT flag, for backward compatibility
+         * after removing flags parameter from ucs_callbackq. Since we have to
+         * return a callback id, we cannot use ucs_callbackq_add_oneshot() API,
+         * and we emulate oneshot behavior by making the callback remove itself.
+         */
+        ctx = ucs_malloc(sizeof(*ctx), "uct_worker_oneshot_cb_ctx");
+        if (ctx == NULL) {
+            ucs_error("failed to allocate oneshot callback element");
+            goto out;
+        }
+
+        ctx->func = func;
+        ctx->arg  = arg;
+        ctx->cbq  = &worker->super.progress_q;
+        ctx->id   = ucs_callbackq_add_safe(&worker->super.progress_q,
+                                           uct_worker_oneshot_callback_proxy,
+                                           ctx);
+
+        id = ctx->id + UCT_WORKER_ONESHOT_ID_START;
+        ucs_assertv(id >= UCT_WORKER_ONESHOT_ID_START, "id=%d", id);
+    } else {
+        /* Normal callback */
+        id = ucs_callbackq_add_safe(&worker->super.progress_q, func, arg);
+        ucs_assertv(id < UCT_WORKER_ONESHOT_ID_START, "id=%d", id);
+    }
+
+    ucs_assert(id != UCS_CALLBACKQ_ID_NULL);
+    *id_p = id;
+
+out:
+    UCS_ASYNC_UNBLOCK(worker->async);
 }
 
 void uct_worker_progress_unregister_safe(uct_worker_h tl_worker,
                                          uct_worker_cb_id_t *id_p)
 {
     uct_priv_worker_t *worker = ucs_derived_of(tl_worker, uct_priv_worker_t);
+    uct_worker_oneshot_cb_ctx_t *ctx;
 
-    if (*id_p != UCS_CALLBACKQ_ID_NULL) {
-        UCS_ASYNC_BLOCK(worker->async);
-        ucs_callbackq_remove_safe(&worker->super.progress_q, *id_p);
-        UCS_ASYNC_UNBLOCK(worker->async);
-        *id_p = UCS_CALLBACKQ_ID_NULL;
+    if (*id_p == UCS_CALLBACKQ_ID_NULL) {
+        return;
     }
+
+    UCS_ASYNC_BLOCK(worker->async);
+    if (*id_p < UCT_WORKER_ONESHOT_ID_START) {
+        /* Normal callback */
+        ucs_callbackq_remove_safe(&worker->super.progress_q, *id_p);
+    } else {
+        /* Oneshot with proxy callback */
+        ctx = ucs_callbackq_remove_safe(&worker->super.progress_q,
+                                        *id_p - UCT_WORKER_ONESHOT_ID_START);
+        ucs_free(ctx);
+    }
+    UCS_ASYNC_UNBLOCK(worker->async);
+
+    *id_p = UCS_CALLBACKQ_ID_NULL;
 }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -198,7 +198,7 @@ uct_ib_device_async_event_schedule_callback(uct_ib_device_t *dev,
     ucs_assert(ucs_spinlock_is_held(&dev->async_event_lock));
     ucs_assert(wait_ctx->cb_id == UCS_CALLBACKQ_ID_NULL);
     wait_ctx->cb_id = ucs_callbackq_add_safe(wait_ctx->cbq, wait_ctx->cb,
-                                             wait_ctx, 0);
+                                             wait_ctx);
 }
 
 static void

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1692,8 +1692,7 @@ ucs_status_t uct_dc_mlx5_ep_check_fc(uct_dc_mlx5_iface_t *iface,
 
     uct_worker_progress_register_safe(
             &iface->super.super.super.super.worker->super,
-            uct_dc_mlx5_ep_fc_hard_req_progress, iface,
-            UCS_CALLBACKQ_FLAG_FAST,
+            uct_dc_mlx5_ep_fc_hard_req_progress, iface, 0,
             &iface->tx.fc_hard_req_progress_cb_id);
 
 out_set_status:

--- a/src/uct/sm/scopy/base/scopy_ep.c
+++ b/src/uct/sm/scopy/base/scopy_ep.c
@@ -96,11 +96,10 @@ uct_scopy_ep_tx_init(uct_ep_h tl_ep, const uct_iov_t *iov,
     }
 
     if (ucs_unlikely(ucs_arbiter_is_empty(&iface->arbiter))) {
-        uct_worker_progress_register_safe(&iface->super.super.worker->super,
-                                          (ucs_callback_t)
-                                          iface->super.super.super.ops.iface_progress,
-                                          iface, UCS_CALLBACKQ_FLAG_FAST,
-                                          &iface->super.super.prog.id);
+        uct_worker_progress_register_safe(
+                &iface->super.super.worker->super,
+                (ucs_callback_t)iface->super.super.super.ops.iface_progress,
+                iface, 0, &iface->super.super.prog.id);
     }
 
     ucs_arbiter_group_push_elem(&ep->arb_group, &tx->arb_elem);

--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -445,6 +445,10 @@ void test_base::cleanup() {
 }
 
 bool test_base::barrier() {
+    if (num_threads() <= 1) {
+        return true;
+    }
+
     int ret = pthread_barrier_wait(&m_barrier);
     if (ret == 0) {
         return false;

--- a/test/gtest/ucs/test_callbackq.cc
+++ b/test/gtest/ucs/test_callbackq.cc
@@ -5,7 +5,7 @@
  */
 
 #include <common/test.h>
-#include <deque>
+#include <vector>
 
 extern "C" {
 #include <ucs/arch/atomic.h>
@@ -13,14 +13,12 @@ extern "C" {
 #include <ucs/datastruct/callbackq.h>
 }
 
-
-class test_callbackq :
-    public ucs::test_base,
-    public ::testing::TestWithParam<int> {
+class test_callbackq : public ucs::test {
 protected:
 
     enum {
         COMMAND_REMOVE_SELF,
+        COMMAND_REMOVE_SELF_SAFE,
         COMMAND_ENQUEUE_USER_ID,
         COMMAND_ADD_ANOTHER,
         COMMAND_ADD_ANOTHER_ONESHOT,
@@ -35,7 +33,6 @@ protected:
         int                       command;
         callback_ctx              *to_add;
         void                      *to_remove;
-        unsigned                  flags;
         void                      *key;
         int                       user_id;
     };
@@ -71,6 +68,9 @@ protected:
         case COMMAND_REMOVE_SELF:
             remove(ctx);
             break;
+        case COMMAND_REMOVE_SELF_SAFE:
+            remove_safe(ctx);
+            break;
         case COMMAND_ADD_ANOTHER:
             add(ctx->to_add);
             break;
@@ -98,42 +98,37 @@ protected:
         ctx->command     = COMMAND_NONE;
         ctx->to_add      = nullptr;
         ctx->to_remove   = nullptr;
-        ctx->flags       = 0;
         ctx->key         = key;
         ctx->user_id     = user_id;
     }
 
-    virtual unsigned cb_flags() {
-        return GetParam();
-    }
-
-    void add(callback_ctx *ctx, unsigned flags = 0)
+    void add(callback_ctx *ctx)
     {
         ctx->callback_id = ucs_callbackq_add(&m_cbq, callback_proxy,
-                                             reinterpret_cast<void*>(ctx),
-                                             ctx->flags | cb_flags() | flags);
+                                             reinterpret_cast<void*>(ctx));
     }
 
-    void remove(int callback_id)
+    void *remove(int callback_id)
     {
-        ucs_callbackq_remove(&m_cbq, callback_id);
+        return ucs_callbackq_remove(&m_cbq, callback_id);
     }
 
     void remove(callback_ctx *ctx)
     {
-        remove(ctx->callback_id);
+        void *arg = remove(ctx->callback_id);
+        EXPECT_EQ(reinterpret_cast<void*>(ctx), arg);
     }
 
-    void add_safe(callback_ctx *ctx, unsigned flags = 0)
+    void add_safe(callback_ctx *ctx)
     {
         ctx->callback_id = ucs_callbackq_add_safe(&m_cbq, callback_proxy,
-                                                  reinterpret_cast<void*>(ctx),
-                                                  cb_flags() | flags);
+                                                  reinterpret_cast<void*>(ctx));
     }
 
     void remove_safe(callback_ctx *ctx)
     {
-        ucs_callbackq_remove_safe(&m_cbq, ctx->callback_id);
+        void *arg = ucs_callbackq_remove_safe(&m_cbq, ctx->callback_id);
+        EXPECT_EQ(reinterpret_cast<void*>(ctx), arg);
     }
 
     static int remove_pred(const ucs_callbackq_elem_t *elem, void *arg)
@@ -143,12 +138,6 @@ protected:
 
         /* remove callbacks with the given key */
         return (elem->cb == callback_proxy) && (ctx->user_id == user_id);
-    }
-
-    void remove_if(int user_id)
-    {
-        ucs_callbackq_remove_if(&m_cbq, remove_pred,
-                                reinterpret_cast<void*>(&user_id));
     }
 
     void add_oneshot(callback_ctx *ctx)
@@ -177,7 +166,7 @@ protected:
     std::vector<int> m_user_id_queue;
 };
 
-UCS_TEST_P(test_callbackq, single) {
+UCS_TEST_F(test_callbackq, single) {
     callback_ctx ctx;
 
     init_ctx(&ctx);
@@ -187,7 +176,7 @@ UCS_TEST_P(test_callbackq, single) {
     EXPECT_EQ(1u, ctx.count);
 }
 
-UCS_TEST_P(test_callbackq, count) {
+UCS_TEST_F(test_callbackq, count) {
     callback_ctx ctx;
 
     init_ctx(&ctx);
@@ -198,7 +187,7 @@ UCS_TEST_P(test_callbackq, count) {
     EXPECT_EQ(1u, count);
 }
 
-UCS_TEST_P(test_callbackq, multi) {
+UCS_TEST_F(test_callbackq, multi) {
     for (unsigned count = 0; count < 20; ++count) {
         callback_ctx ctx[count];
         for (unsigned i = 0; i < count; ++i) {
@@ -215,7 +204,7 @@ UCS_TEST_P(test_callbackq, multi) {
     }
 }
 
-UCS_TEST_P(test_callbackq, remove_self) {
+UCS_TEST_F(test_callbackq, remove_self) {
     callback_ctx ctx;
 
     init_ctx(&ctx);
@@ -229,7 +218,24 @@ UCS_TEST_P(test_callbackq, remove_self) {
     EXPECT_EQ(1u, ctx.count);
 }
 
-UCS_TEST_P(test_callbackq, add_another) {
+UCS_TEST_F(test_callbackq, remove_self_safe) {
+    callback_ctx ctx1;
+    init_ctx(&ctx1);
+    add(&ctx1);
+    remove_safe(&ctx1); /* This can add proxy as 2nd fast elem */
+
+    callback_ctx ctx2;
+    init_ctx(&ctx2);
+    ctx2.command = COMMAND_REMOVE_SELF_SAFE;
+    add(&ctx2);
+
+    dispatch(1000);
+
+    EXPECT_EQ(0u, ctx1.count);
+    EXPECT_EQ(1u, ctx2.count);
+}
+
+UCS_TEST_F(test_callbackq, add_another) {
     callback_ctx ctx, ctx2;
 
     init_ctx(&ctx);
@@ -244,9 +250,7 @@ UCS_TEST_P(test_callbackq, add_another) {
     ctx.command = COMMAND_NONE;
 
     unsigned count = ctx.count;
-    if (cb_flags() & UCS_CALLBACKQ_FLAG_FAST) {
-        count++; /* fast CBs are executed immediately after "add" */
-    }
+    count++; /* fast CBs are executed immediately after "add" */
 
     dispatch();
     EXPECT_EQ(2u, ctx.count);
@@ -262,8 +266,7 @@ UCS_TEST_P(test_callbackq, add_another) {
     EXPECT_EQ(count + 1, ctx2.count);
 }
 
-UCS_MT_TEST_P(test_callbackq, threads, 10) {
-
+UCS_MT_TEST_F(test_callbackq, threads, 10) {
     static unsigned COUNT = 2000;
     if (barrier()) {
         for (unsigned i = 0; i < COUNT; ++i) {
@@ -304,7 +307,7 @@ UCS_MT_TEST_P(test_callbackq, threads, 10) {
     }
 }
 
-UCS_MT_TEST_P(test_callbackq, remove, 10) {
+UCS_MT_TEST_F(test_callbackq, remove, 10) {
     static callback_ctx ctx1;
 
     init_ctx(&ctx1);
@@ -346,140 +349,7 @@ UCS_MT_TEST_P(test_callbackq, remove, 10) {
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(fast_path, test_callbackq, ::
-                        testing::Values(static_cast<int>(UCS_CALLBACKQ_FLAG_FAST)));
-INSTANTIATE_TEST_SUITE_P(slow_path, test_callbackq, ::testing::Values(0));
-
-
-class test_callbackq_noflags : public test_callbackq {
-protected:
-    virtual unsigned cb_flags() {
-        return 0;
-    }
-};
-
-UCS_TEST_F(test_callbackq_noflags, oneshot) {
-    callback_ctx ctx;
-
-    init_ctx(&ctx);
-    ctx.command = COMMAND_NONE;
-
-    add(&ctx, UCS_CALLBACKQ_FLAG_ONESHOT);
-    dispatch(100);
-    EXPECT_EQ(1u, ctx.count);
-}
-
-UCS_TEST_F(test_callbackq_noflags, oneshot_recursive) {
-    callback_ctx ctx;
-
-    init_ctx(&ctx);
-    ctx.command = COMMAND_ADD_ANOTHER;
-    ctx.flags   = UCS_CALLBACKQ_FLAG_ONESHOT;
-    ctx.to_add  = &ctx;
-
-    add(&ctx);
-
-    for (unsigned i = 0; i < 10; ++i) {
-        dispatch(1);
-        EXPECT_LE(i + 1, ctx.count);
-    }
-
-    remove(ctx.callback_id);
-}
-
-UCS_TEST_F(test_callbackq_noflags, remove_if) {
-    const size_t count = 1000;
-    const int num_keys = 10;
-    std::vector<callback_ctx> ctx(count);
-    size_t key_counts[num_keys] = {0};
-
-    for (size_t i = 0; i < count; ++i) {
-        init_ctx(&ctx[i], nullptr, ucs::rand() % num_keys);
-        add(&ctx[i], (i % 2) ? UCS_CALLBACKQ_FLAG_FAST : 0);
-        ++key_counts[ctx[i].user_id];
-    }
-
-    /* calculate how many callbacks expected to remain after removing each of
-     * the keys.
-     */
-    size_t exp_count[num_keys] = {0};
-    for (int key = num_keys - 2; key >= 0; --key) {
-        exp_count[key] = exp_count[key + 1] + key_counts[key + 1];
-    }
-
-    /* remove keys one after another and make sure the exact expected number
-     * of callbacks is being called after every removal.
-     */
-    for (int key = 0; key < num_keys; ++key) {
-        remove_if(key);
-
-        /* count how many different callbacks were called */
-        size_t num_cbs = 0;
-        dispatch(1000);
-        for (size_t i = 0; i < count; ++i) {
-            num_cbs += !!ctx[i].count;
-            ctx[i].count = 0; /* reset for next iteration */
-        }
-
-        EXPECT_EQ(exp_count[key], num_cbs) << "key=" << key;
-    }
-}
-
-UCS_TEST_F(test_callbackq_noflags, ordering) {
-    static const int UNUSED_CB_USER_ID = -1;
-    static const int num_callbacks     = 100;
-    std::vector<callback_ctx> ctxs(num_callbacks);
-    std::deque<int> gc_list;
-    std::vector<int> oneshot_callback_keys;
-
-    for (int i = 0; i < num_callbacks; ++i) {
-        callback_ctx &r_ctx = ctxs[i];
-
-        // randomize: either permanent callback with key=i or oneshot callback
-        // with key=-1
-        init_ctx(&r_ctx);
-        unsigned cb_flags = 0;
-        if (ucs::rand() % 2) {
-            // oneshot callback, which must stay in order
-            r_ctx.user_id = i;
-            r_ctx.command = COMMAND_ENQUEUE_USER_ID;
-            cb_flags      = UCS_CALLBACKQ_FLAG_ONESHOT;
-            oneshot_callback_keys.push_back(i);
-        } else {
-            // permanent
-            r_ctx.user_id = UNUSED_CB_USER_ID;
-            if (ucs::rand() % 2) {
-                // do-nothing callback
-                r_ctx.command = COMMAND_NONE;
-            } else {
-                // non-one-shot callback which removes itself - for more fun
-                r_ctx.command = COMMAND_REMOVE_SELF;
-            }
-        }
-
-        add(&r_ctx, cb_flags);
-
-        if (r_ctx.command == COMMAND_NONE) {
-            // we need to remove callbacks which don't remove themselves in the
-            // end of the test
-            gc_list.push_back(r_ctx.callback_id);
-        }
-    }
-
-    dispatch(10);
-
-    // make sure the ONESHOT callbacks were executed in order
-    EXPECT_EQ(oneshot_callback_keys, m_user_id_queue);
-
-    // remove remaining callbacks
-    while (!gc_list.empty()) {
-        remove(gc_list.front());
-        gc_list.pop_front();
-    }
-}
-
-UCS_MT_TEST_F(test_callbackq_noflags, oneshot_mt, 10)
-{
+UCS_MT_TEST_F(test_callbackq, oneshot_mt, 10) {
     callback_ctx ctx;
 
     init_ctx(&ctx);
@@ -490,7 +360,7 @@ UCS_MT_TEST_F(test_callbackq_noflags, oneshot_mt, 10)
     EXPECT_EQ(1u, ctx.count);
 }
 
-UCS_TEST_F(test_callbackq_noflags, oneshot_add_recursive) {
+UCS_TEST_F(test_callbackq, oneshot_add_recursive) {
     callback_ctx ctx;
 
     init_ctx(&ctx);
@@ -506,7 +376,7 @@ UCS_TEST_F(test_callbackq_noflags, oneshot_add_recursive) {
     remove_oneshot();
 }
 
-UCS_TEST_F(test_callbackq_noflags, oneshot_remove_self) {
+UCS_TEST_F(test_callbackq, oneshot_remove_self) {
     void *key = this;
 
     callback_ctx ctx1;
@@ -519,7 +389,7 @@ UCS_TEST_F(test_callbackq_noflags, oneshot_remove_self) {
     EXPECT_EQ(1, ctx1.count);
 }
 
-UCS_TEST_F(test_callbackq_noflags, oneshot_remove_another) {
+UCS_TEST_F(test_callbackq, oneshot_remove_another) {
     int dummy[2];
     void *key1 = &dummy[0];
     void *key2 = &dummy[1];
@@ -545,7 +415,7 @@ UCS_TEST_F(test_callbackq_noflags, oneshot_remove_another) {
     EXPECT_EQ(1, ctx1.count + ctx2.count);
 }
 
-UCS_TEST_F(test_callbackq_noflags, oneshot_remove_by_key) {
+UCS_TEST_F(test_callbackq, oneshot_remove_by_key) {
     const size_t count = 1000;
     const int num_keys = 10;
     std::vector<callback_ctx> ctx(count);
@@ -578,7 +448,7 @@ UCS_TEST_F(test_callbackq_noflags, oneshot_remove_by_key) {
     EXPECT_EQ(remaining_count, m_total_count);
 }
 
-UCS_TEST_F(test_callbackq_noflags, oneshot_ordering) {
+UCS_TEST_F(test_callbackq, oneshot_ordering) {
     static const int count = 1000;
     void *key              = nullptr;
     std::vector<callback_ctx> ctx(count);

--- a/test/gtest/uct/test_progress.cc
+++ b/test/gtest/uct/test_progress.cc
@@ -13,14 +13,36 @@ extern "C" {
 
 class test_uct_progress : public uct_test {
 public:
-    virtual void init() {
+    virtual void init()
+    {
         uct_test::init();
         m_entities.push_back(create_entity(0));
     }
+
+protected:
+    uct_worker_h worker(unsigned index = 0)
+    {
+        return ent(index).worker();
+    }
+
+    uct_iface_h iface(unsigned index = 0)
+    {
+        return ent(index).iface();
+    }
+
+    static unsigned count_progress(void *arg)
+    {
+        test_uct_progress *self = reinterpret_cast<test_uct_progress*>(arg);
+        ++self->m_count;
+        return 1;
+    }
+
+    unsigned m_count{0};
 };
 
 
-UCS_TEST_P(test_uct_progress, random_enable_disable) {
+UCS_TEST_P(test_uct_progress, random_enable_disable)
+{
     for (int i = 0; i < 100; ++i) {
         unsigned flags = 0;
         if (ucs::rand() % 2) {
@@ -30,14 +52,45 @@ UCS_TEST_P(test_uct_progress, random_enable_disable) {
             flags |= UCT_PROGRESS_RECV;
         }
         if (ucs::rand() % 2) {
-            uct_iface_progress_enable(ent(0).iface(), flags);
+            uct_iface_progress_enable(iface(), flags);
         } else {
-            uct_iface_progress_disable(ent(0).iface(), flags);
+            uct_iface_progress_disable(iface(), flags);
         }
         progress();
     }
-
 }
 
+UCS_TEST_P(test_uct_progress, oneshot_progress)
+{
+    int prog_id = UCS_CALLBACKQ_ID_NULL;
+    uct_worker_progress_register_safe(worker(), count_progress, this,
+                                      UCS_CALLBACKQ_FLAG_ONESHOT, &prog_id);
+    EXPECT_NE(UCS_CALLBACKQ_ID_NULL, prog_id);
+
+    EXPECT_EQ(0, m_count);
+    unsigned count = progress();
+    EXPECT_GE(count, 1);
+
+    /* The callback should be removed by now */
+    count = progress();
+    EXPECT_EQ(0, count);
+
+    EXPECT_EQ(1, m_count);
+}
+
+UCS_TEST_P(test_uct_progress, oneshot_progress_remove)
+{
+    int prog_id = UCS_CALLBACKQ_ID_NULL;
+    uct_worker_progress_register_safe(worker(), count_progress, this,
+                                      UCS_CALLBACKQ_FLAG_ONESHOT, &prog_id);
+    EXPECT_NE(UCS_CALLBACKQ_ID_NULL, prog_id);
+
+    uct_worker_progress_unregister_safe(worker(), &prog_id);
+    EXPECT_EQ(UCS_CALLBACKQ_ID_NULL, prog_id);
+
+    unsigned count = progress();
+    EXPECT_EQ(0, count);
+    EXPECT_EQ(0, m_count);
+}
 
 UCT_INSTANTIATE_TEST_CASE(test_uct_progress);


### PR DESCRIPTION
## Why
Code cleanup of callbackq