### PR TITLE
UCP/PROTOV2: Activate progress for amo proto lanes

### DIFF
--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -232,15 +232,15 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
     range_end    = -1;
     do {
         range_start = range_end + 1;
-
         proto_valid = ucp_proto_select_elem_query(worker, select_elem,
                                                   range_start, &proto_attr);
+        range_end   = proto_attr.max_msg_length;
+
         if (!proto_valid) {
-            break;
+            continue;
         }
 
-        range_end = proto_attr.max_msg_length;
-        row_elem  = ucs_array_append(ucp_proto_info_table, &table, break);
+        row_elem = ucs_array_append(ucp_proto_info_table, &table, break);
 
         ucs_snprintf_safe(row_elem->desc, sizeof(row_elem->desc), "%s%s",
                           proto_attr.is_estimation ? "(?) " : "",

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -570,10 +570,8 @@ ucp_proto_select_get_lane_map(ucp_worker_h worker,
     range_end = -1;
     do {
         range_start = range_end + 1;
-        if (!ucp_proto_select_elem_query(worker, select_elem, range_start,
-                                         &query_attr)) {
-            break;
-        }
+        ucp_proto_select_elem_query(worker, select_elem, range_start,
+                                    &query_attr);
 
         range_end = query_attr.max_msg_length;
         lane_map |= query_attr.lane_map;
@@ -935,17 +933,11 @@ int ucp_proto_select_elem_query(ucp_worker_h worker,
 
     thresh_elem  = ucp_proto_select_thresholds_search(select_elem, msg_length);
     proto_config = &thresh_elem->proto_config;
-    if (proto_config->proto->flags & UCP_PROTO_FLAG_INVALID) {
-        return 0;
-    }
 
     ucp_proto_config_query(worker, proto_config, msg_length, proto_attr);
-    ucs_assertv(proto_attr->lane_map != 0,
-                "%s protocol information query output contains empty lane map",
-                proto_config->proto->name);
 
     proto_attr->max_msg_length = ucs_min(proto_attr->max_msg_length,
                                          thresh_elem->max_msg_length);
 
-    return 1;
+    return !(thresh_elem->proto_config.proto->flags & UCP_PROTO_FLAG_INVALID);
 }


### PR DESCRIPTION
## What
- Go thru all ranges when obtain lane map for progress activation
- print atomic protocols info (need to also consider all existing ranges)

## Why ?
 For atomic protocols Stub (invalid) protocol  can be chosen not only for the last range, so need to process other ranges as well.
Otherwise progress will not be enabled for the amo lanes and amo operations will take lots of time. Also atomic proto info output was not correct. After the fix it is like below:
```
[ RUN      ] dcx/test_ucp_perf.envelope/26 <dc_x/amo_swap/device>
[1684941213.249486] [jazz02:22262:p-1]   +---------------------------+--------------------------------------------------------------------------------------------+
[1684941213.249501] [jazz02:22262:p-1]   | perftest intra-node cfg#0 | fetching atomic by ucp_atomic_op*(multi) into host memory from host, arg in host memory    |
[1684941213.249503] [jazz02:22262:p-1]   +---------------------------+-------------------------------------------------------------------------+------------------+
[1684941213.249506] [jazz02:22262:p-1]   |                      0..3 | stub protocol                                                           |                  |
[1684941213.249509] [jazz02:22262:p-1]   |                         4 | atomic fetch                                                            | dc_mlx5/mlx5_4:1 |
[1684941213.249511] [jazz02:22262:p-1]   |                      5..7 | stub protocol                                                           |                  |
[1684941213.249513] [jazz02:22262:p-1]   |                         8 | atomic fetch                                                            | dc_mlx5/mlx5_4:1 |
[1684941213.249516] [jazz02:22262:p-1]   |                    9..inf | stub protocol                                                           |                  |
[1684941213.249518] [jazz02:22262:p-1]   +---------------------------+-------------------------------------------------------------------------+------------------+
[1684941213.249810] [jazz02:22262:p-1]   +---------------------------+-------------------------------------------------------------------------------------+
[1684941213.249816] [jazz02:22262:p-1]   | perftest intra-node cfg#0 | fetching atomic by ucp_atomic_op* into host memory from host, arg in host memory    |
[1684941213.249818] [jazz02:22262:p-1]   +---------------------------+------------------------------------------------------------------+------------------+
[1684941213.249820] [jazz02:22262:p-1]   |                      0..3 | stub protocol                                                    |                  |
[1684941213.249822] [jazz02:22262:p-1]   |                         4 | atomic fetch                                                     | dc_mlx5/mlx5_4:1 |
[1684941213.249824] [jazz02:22262:p-1]   |                      5..7 | stub protocol                                                    |                  |
[1684941213.249826] [jazz02:22262:p-1]   |                         8 | atomic fetch                                                     | dc_mlx5/mlx5_4:1 |
[1684941213.249828] [jazz02:22262:p-1]   |                    9..inf | stub protocol                                                    |                  |
[1684941213.249830] [jazz02:22262:p-1]   +---------------------------+------------------------------------------------------------------+------------------+

```

