### PR TITLE
UCP/PROTOV2: Fix progress enabling for selected lanes

### DIFF
--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -121,9 +121,10 @@ enum {
                                                                of arm_ifaces list, so
                                                                it needs to be armed
                                                                in ucp_worker_arm(). */
-    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2)  /**< There is another UCP iface
+    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2), /**< There is another UCP iface
                                                                with the same caps, but
                                                                with better performance */
+    UCP_WORKER_IFACE_FLAG_KEEP_ACTIVE       = UCS_BIT(3)  /**< Progress should be activated */
 };
 
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -605,6 +605,7 @@ ucp_proto_select_wiface_activate(ucp_worker_h worker,
         rsc_index = ep_config_key->lanes[lane].rsc_index;
         wiface    = ucp_worker_iface(worker, rsc_index);
         ucp_worker_iface_progress_ep(wiface);
+        wiface->flags |= UCP_WORKER_IFACE_FLAG_KEEP_ACTIVE;
     }
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1015,11 +1015,23 @@ static int ucp_wireup_should_activate_wiface(ucp_worker_iface_t *wiface,
     /* Activate worker iface if: a) new protocol selection logic is disabled; or
      * b) stream support is requested, because stream API does not support new
      * protocol selection logic; or c) lane is used for checking a connection
-     * state; or d) the endpoint is a mem-type ep. */
+     * state; or d) the endpoint is a mem-type ep; or e) iface was activated
+     * before (some ep was created and later destroyed). The last check is
+     * needed to workaround the following problem with proto v2:
+     * 1. ep is created using some ep config
+     * 2. Some protocols are selected for some operations and this enables
+     *    progress for the affected lanes
+     * 3. ep is destroyed and progress is disabled for all corresponding ifaces
+     * 4. New ep is created with the same ep config used during step n1
+     * 5. Progress is not enabled, because protocols selection for these
+     *    parameters (and ep config) was already done on step n2.
+     * TODO: Reconsider this approach when progress enabling scheme changes. */
+
     return !context->config.ext.proto_enable ||
            (context->config.features & UCP_FEATURE_STREAM) ||
            (ucp_ep_config(ep)->key.keepalive_lane == lane) ||
-           (ep->flags & UCP_EP_FLAG_INTERNAL);
+           (ep->flags & UCP_EP_FLAG_INTERNAL) ||
+           (wiface->flags & UCP_WORKER_IFACE_FLAG_KEEP_ACTIVE);
 }
 
 static ucs_status_t


### PR DESCRIPTION
## What
This patch fixes the following problem:
1. ep is created using some ep config
2. Some protocols are selected for some operations and this enables progress for the affected lanes
3. ep is destroyed and progress is disabled for all corresponding ifaces
4. New ep is created with the same ep config used during step n1
5. Progress is not enabled, because protocols selection for these parameters (and ep config) was already done on step n2 (and corresponding protos are already hashed).
