### PR TITLE
UCM/LOG: fixed potential overrun on log message gen

### DIFF
--- a/src/ucm/util/log.c
+++ b/src/ucm/util/log.c
@@ -268,21 +268,20 @@ void __ucm_log(const char *file, unsigned line, const char *function,
 
     gettimeofday(&tv, NULL);
     pid = getpid();
-    ucm_log_snprintf(buf, UCM_LOG_BUF_SIZE - 1,
+    ucm_log_snprintf(buf, UCM_LOG_BUF_SIZE,
                      "[%lu.%06lu] [%s:%d:%d] %18s:%-4d UCX  %s ",
                      tv.tv_sec, tv.tv_usec, ucm_log_hostname, pid,
                      ucm_get_tid() - pid, ucs_basename(file), line,
                      ucm_log_level_names[level]);
-    buf[UCM_LOG_BUF_SIZE - 1] = '\0';
 
-    length = strlen(buf);
+    length = strnlen(buf, UCM_LOG_BUF_SIZE);
     va_start(ap, message);
     ucm_log_vsnprintf(buf + length, UCM_LOG_BUF_SIZE - length, message, ap);
     va_end(ap);
-    strncat(buf, "\n", UCM_LOG_BUF_SIZE - 1);
+    strncat(buf, "\n", UCM_LOG_BUF_SIZE - strnlen(buf, UCM_LOG_BUF_SIZE));
 
     /* Use write to avoid potential calls to malloc() in buffered IO functions */
-    nwrite = write(ucm_log_fileno, buf, strlen(buf));
+    nwrite = write(ucm_log_fileno, buf, strnlen(buf, UCM_LOG_BUF_SIZE));
     (void)nwrite;
 
     if (level <= UCS_LOG_LEVEL_FATAL) {


### PR DESCRIPTION
## What
- fixed potential overrun on log message gen

## Why ?
- there was potential issue on generation of long log message: due to incorrect strncat limit memory after buffer may be overwritten, issue could lead incorrect memory access

## How ?
- changed strncat string limit
