### PR TITLE
AZP: Show the actual file availability

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -122,6 +122,7 @@ function az_module_load() {
             # Give up trying
             echo "MODULEPATH='${MODULEPATH}'"
             module avail || true
+            ls -l /hpc/local/etc/modulefiles/"$module" || true
             azure_log_warning "Module $module cannot be loaded"
             return 1
         fi


### PR DESCRIPTION
## What
Show a module file availability on FS in case of module load failure. 

## Why ?
Intermittent failures while attempting to load modules.

