### PR TITLE
UCT/IB - porting MEMIC support

### DIFF
--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -33,4 +33,3 @@ const char *ucs_memory_type_descs[] = {
     [UCS_MEMORY_TYPE_RDMA]         = "RDMA device memory",
     [UCS_MEMORY_TYPE_LAST]         = "unknown"
 };
-

--- a/src/uct/ib/Makefile.am
+++ b/src/uct/ib/Makefile.am
@@ -20,7 +20,8 @@ noinst_HEADERS = \
 	base/ib_iface.h \
 	base/ib_log.h \
 	base/ib_md.h \
-	base/ib_verbs.h
+	base/ib_verbs.h \
+	base/ib_alloc.h
 
 libuct_ib_la_SOURCES = \
 	base/ib_device.c \

--- a/src/uct/ib/base/ib_alloc.h
+++ b/src/uct/ib/base/ib_alloc.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_IB_ALLOC_H_
+#define UCT_IB_ALLOC_H_
+
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <uct/api/uct.h>
+#include <uct/ib/base/ib_md.h>
+
+BEGIN_C_DECLS
+
+
+#if HAVE_IBV_DM
+
+/**
+ * IB device memory allocation parameters
+ */
+typedef struct {
+    size_t        length;      /* [in, out] allocation size*/
+    unsigned      flags;       /* [in]      access flags*/
+    const char    *alloc_name; /* [in]      allocation name*/
+    void          *address;    /* [out]     device allocation mapped address */
+    uct_ib_mem_t  *memh;       /* [out]     struct containing allocated device memory 
+                                            and registered mr keys*/
+} ucs_alloc_device_mem_params_t;
+
+
+ucs_status_t uct_ib_md_alloc_device_mem(uct_md_h uct_md, ucs_alloc_device_mem_params_t *params);
+
+ucs_status_t uct_ib_md_release_device_mem(uct_md_h uct_md, uct_ib_mem_t *memh);
+#endif
+
+END_C_DECLS
+
+#endif

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -159,6 +159,8 @@ AS_IF([test "x$with_ib" = "xyes"],
                            mlx5dv_devx_subscribe_devx_event], [],
                           [with_mlx5_dv=no],
                           [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_DECL(mlx5dv_dm_map_op_addr, [], [], 
+                                     [[#include <infiniband/mlx5dv.h]])
 
               AS_IF([test "x$with_mlx5_dv" = "xyes" -a "x$have_cq_io" = "xyes" ], [
                        AC_CHECK_DECLS([

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -718,4 +718,20 @@ ucs_status_t uct_ib_mlx5_get_compact_av(uct_ib_iface_t *iface, int *compact_av)
     *compact_av = !!(uct_ib_iface_device(iface)->flags & UCT_IB_DEVICE_FLAG_AV);
     return UCS_OK;
 }
+
+void uct_ib_mlx5dv_create_mkey(struct ibv_pd *pd, uint16_t max_entries,
+                               struct mlx5dv_mkey **mkey)
+{
+    struct mlx5dv_mkey_init_attr mkey_init_attr = {
+        .pd           = pd,
+        .create_flags = MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT,
+        .max_entries  = max_entries
+    };
+    *mkey = mlx5dv_create_mkey(&mkey_init_attr);
+}
+
+void uct_ib_mlx5dv_destroy_mkey(struct mlx5dv_mkey *mkey)
+{
+    mlx5dv_destroy_mkey(mkey);
+}
 #endif

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.h
@@ -87,4 +87,9 @@ void uct_ib_mlx5_get_av(struct ibv_ah *ah, struct mlx5_wqe_av *av);
 
 void *uct_dv_get_info_uar0(void *uar);
 
+void uct_ib_mlx5dv_create_mkey(struct ibv_pd *pd, uint16_t max_entries,
+                               struct mlx5dv_mkey **mkey);
+
+void uct_ib_mlx5dv_destroy_mkey(struct mlx5dv_mkey *mkey);
+
 #endif

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -40,6 +40,7 @@ protected:
     virtual void modify_config(const std::string& name, const std::string& value,
                                modify_config_mode_t mode);
     bool check_caps(uint64_t flags) const;
+    bool has_enough_memory(size_t required_memory_size);
     bool check_reg_mem_type(ucs_memory_type_t mem_type);
     void alloc_memory(void **address, size_t size, char *fill,
                       ucs_memory_type_t mem_type);
@@ -54,6 +55,9 @@ protected:
 
     void test_reg_advise(size_t size, size_t advise_size,
                          size_t advice_offset, bool check_non_blocking = false);
+
+    void test_md_alloc_advise(size_t size, size_t advise_size);
+
 
     uct_md_h md() const {
         return m_md;


### PR DESCRIPTION
## What
Porting changes from #3559 with updated mlx5 / verbs API

## Why?
To support the usage of MEMIC, enhancing atomic operations performance.

