### PR TITLE
AZP: Fix ROCM building and testing

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -176,7 +176,7 @@ resources:
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: ubuntu2004_rocm_5_4_0
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2004:rocm_5_4_0
-      options: $(DOCKER_OPT_ARGS)
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
 
 stages:
   - stage: Codestyle

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -201,6 +201,11 @@ build_ugni() {
 # Build CUDA
 #
 build_cuda() {
+	if [[ $CONTAINER == *"rocm"* ]]; then
+		echo "==== Not building with cuda flags ===="
+		return
+	fi
+
 	if az_module_load $CUDA_MODULE
 	then
 		if az_module_load $GDRCOPY_MODULE


### PR DESCRIPTION
## What

1. Add volume mapping for ROCM container.
2. Skip building CUDA with ROCM.

## Why ?
Failure to load env modules served as a canary, unearthing a bigger problem of dysfunctional ROCM job.
