### PR TITLE
UCT/API: Device memory allocation flags

### DIFF
--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -15,20 +15,22 @@
 
 const char *ucs_memory_type_names[] = {
     [UCS_MEMORY_TYPE_HOST]         = "host",
-    [UCS_MEMORY_TYPE_CUDA]         = "cuda" ,
+    [UCS_MEMORY_TYPE_CUDA]         = "cuda",
     [UCS_MEMORY_TYPE_CUDA_MANAGED] = "cuda-managed",
     [UCS_MEMORY_TYPE_ROCM]         = "rocm",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "rocm-managed",
+    [UCS_MEMORY_TYPE_RDMA]         = "rdma",
     [UCS_MEMORY_TYPE_LAST]         = "unknown",
     [UCS_MEMORY_TYPE_LAST + 1]     = NULL
 };
 
 const char *ucs_memory_type_descs[] = {
     [UCS_MEMORY_TYPE_HOST]         = "System memory",
-    [UCS_MEMORY_TYPE_CUDA]         = "NVIDIA GPU memory" ,
+    [UCS_MEMORY_TYPE_CUDA]         = "NVIDIA GPU memory",
     [UCS_MEMORY_TYPE_CUDA_MANAGED] = "NVIDIA GPU managed/unified memory",
     [UCS_MEMORY_TYPE_ROCM]         = "AMD/ROCm GPU memory",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "AMD/ROCm GPU managed memory",
+    [UCS_MEMORY_TYPE_RDMA]         = "RDMA device memory",
     [UCS_MEMORY_TYPE_LAST]         = "unknown"
 };
 

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -40,6 +40,7 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_CUDA_MANAGED,  /**< NVIDIA CUDA managed (or unified) memory */
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
+    UCS_MEMORY_TYPE_RDMA,          /**< RDMA device memory */
     UCS_MEMORY_TYPE_LAST,
     UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;


### PR DESCRIPTION
## What
New memory allocation flags in UCT API, to enable device memory support.

## Why?
Those flags will indicate the memory type and capabilities required by the memic feature.
