### PR TITLE
README: Fix rdma-core note placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ make -C test/gtest test
     * posix, sysv, [cma](https://dl.acm.org/citation.cfm?id=2616532), [knem](http://knem.gforge.inria.fr/), and [xpmem](https://github.com/hjelmn/xpmem)
 * TCP/IP
 
-  **NOTE:** UCX >= 1.12.0 requires rdma-core >= 28.0 or MLNX_OFED >= 5.0 for [Infiniband](https://www.infinibandta.org/) and [RoCE](http://www.roceinitiative.org/) transports support.
+**NOTE:** UCX >= 1.12.0 requires rdma-core >= 28.0 or MLNX_OFED >= 5.0 for [Infiniband](https://www.infinibandta.org/) and [RoCE](http://www.roceinitiative.org/) transports support.
 <hr>
 
 ## Supported CPU Architectures


### PR DESCRIPTION
## Why ?
Fix rdma-core note so it would not look like it's under "TCP" transport

Before:
![image](https://github.com/openucx/ucx/assets/2255631/89c52b00-5c9c-452c-9432-443425d19f8f)

After:
![image](https://github.com/openucx/ucx/assets/2255631/0251e35b-4fbe-4dc1-b3f6-0f642d310b06)
