### PR TITLE
UCP/MM: Remove context param from ucp_memh_put()

### DIFF
--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -73,8 +73,10 @@ not_found:
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_memh_put(ucp_context_h context, ucp_mem_h memh)
+ucp_memh_put(ucp_mem_h memh)
 {
+    ucp_context_h context = memh->context;
+
     ucs_trace("memh %p: release address %p length %zu md_map %" PRIx64,
               memh, ucp_memh_address(memh), ucp_memh_length(memh),
               memh->md_map);

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -537,8 +537,8 @@ ucp_request_memory_reg(ucp_context_t *context, ucp_md_map_t md_map,
                        ucp_dt_state_t *state, ucs_memory_type_t mem_type,
                        ucp_request_t *req, unsigned uct_flags);
 
-void ucp_request_memory_dereg(ucp_context_t *context, ucp_datatype_t datatype,
-                              ucp_dt_state_t *state, ucp_request_t *req);
+void ucp_request_memory_dereg(ucp_datatype_t datatype, ucp_dt_state_t *state,
+                              ucp_request_t *req);
 
 void ucp_request_dt_invalidate(ucp_request_t *req, ucs_status_t status);
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -563,14 +563,12 @@ ucp_request_recv_buffer_reg(ucp_request_t *req, ucp_md_map_t md_map,
 
 static UCS_F_ALWAYS_INLINE void ucp_request_send_buffer_dereg(ucp_request_t *req)
 {
-    ucp_request_memory_dereg(req->send.ep->worker->context, req->send.datatype,
-                             &req->send.state.dt, req);
+    ucp_request_memory_dereg(req->send.datatype, &req->send.state.dt, req);
 }
 
 static UCS_F_ALWAYS_INLINE void ucp_request_recv_buffer_dereg(ucp_request_t *req)
 {
-    ucp_request_memory_dereg(req->recv.worker->context, req->recv.datatype,
-                             &req->recv.state, req);
+    ucp_request_memory_dereg(req->recv.datatype, &req->recv.state, req);
 }
 
 /* Returns whether user-provided memory handle can be used. If the result is 0,

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -102,7 +102,7 @@ ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
                               dt_iter->mem_info.type, md_map, uct_flags,
                               &dt_iter->type.iov.memh[iov_index]);
         if (status != UCS_OK) {
-            ucp_datatype_iter_iov_mem_dereg(context, dt_iter);
+            ucp_datatype_iter_iov_mem_dereg(dt_iter);
             return status;
         }
     }
@@ -110,8 +110,7 @@ ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
     return UCS_OK;
 }
 
-void ucp_datatype_iter_iov_mem_dereg(ucp_context_h context,
-                                     ucp_datatype_iter_t *dt_iter)
+void ucp_datatype_iter_iov_mem_dereg(ucp_datatype_iter_t *dt_iter)
 {
     ucp_mem_h *memh = dt_iter->type.iov.memh;
     size_t iov_index, length;
@@ -121,7 +120,7 @@ void ucp_datatype_iter_iov_mem_dereg(ucp_context_h context,
     }
 
     ucp_datatype_iter_iov_for_each(iov_index, length, dt_iter) {
-        ucp_datatype_memh_dereg(context, memh + iov_index);
+        ucp_datatype_memh_dereg(memh + iov_index);
     }
 
     ucs_free(memh);

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -77,8 +77,7 @@ ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
                                            unsigned uct_flags);
 
 
-void ucp_datatype_iter_iov_mem_dereg(ucp_context_h context,
-                                     ucp_datatype_iter_t *dt_iter);
+void ucp_datatype_iter_iov_mem_dereg(ucp_datatype_iter_t *dt_iter);
 
 
 size_t ucp_datatype_iter_iov_next_iov(const ucp_datatype_iter_t *dt_iter,

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -562,7 +562,7 @@ ucp_datatype_iter_is_end(const ucp_datatype_iter_t *dt_iter)
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_datatype_memh_dereg(ucp_context_h context, ucp_mem_h *memh_p)
+ucp_datatype_memh_dereg(ucp_mem_h *memh_p)
 {
     if (*memh_p == NULL) {
         return;
@@ -573,7 +573,7 @@ ucp_datatype_memh_dereg(ucp_context_h context, ucp_mem_h *memh_p)
         return;
     }
 
-    ucp_memh_put(context, *memh_p);
+    ucp_memh_put(*memh_p);
     *memh_p = NULL;
 }
 
@@ -643,13 +643,12 @@ ucp_datatype_iter_mem_reg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
  * De-register memory and update iterator state
  */
 static UCS_F_ALWAYS_INLINE void
-ucp_datatype_iter_mem_dereg(ucp_context_h context, ucp_datatype_iter_t *dt_iter,
-                            unsigned dt_mask)
+ucp_datatype_iter_mem_dereg(ucp_datatype_iter_t *dt_iter, unsigned dt_mask)
 {
     if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_CONTIG, dt_mask)) {
-        ucp_datatype_memh_dereg(context, &dt_iter->type.contig.memh);
+        ucp_datatype_memh_dereg(&dt_iter->type.contig.memh);
     } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
-        ucp_datatype_iter_iov_mem_dereg(context, dt_iter);
+        ucp_datatype_iter_iov_mem_dereg(dt_iter);
     }
 }
 

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -79,8 +79,7 @@ ucp_proto_request_zcopy_init(ucp_request_t *req, ucp_md_map_t md_map,
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_request_zcopy_clean(ucp_request_t *req, unsigned dt_mask)
 {
-    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
-                                &req->send.state.dt_iter, dt_mask);
+    ucp_datatype_iter_mem_dereg(&req->send.state.dt_iter, dt_mask);
     req->flags &= ~UCP_REQUEST_FLAG_PROTO_INITIALIZED;
 }
 

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -97,8 +97,7 @@ ucp_proto_rndv_get_zcopy_fetch_completion(uct_completion_t *uct_comp)
     ucp_request_t *req = ucs_container_of(uct_comp, ucp_request_t,
                                           send.state.uct_comp);
 
-    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
-                                &req->send.state.dt_iter,
+    ucp_datatype_iter_mem_dereg(&req->send.state.dt_iter,
                                 UCS_BIT(UCP_DATATYPE_CONTIG));
     if (ucs_unlikely(uct_comp->status != UCS_OK)) {
         ucp_proto_rndv_rkey_destroy(req);
@@ -178,8 +177,7 @@ ucp_proto_rndv_get_zcopy_fetch_err_completion(uct_completion_t *uct_comp)
     ucp_request_t *req  = ucs_container_of(uct_comp, ucp_request_t,
                                           send.state.uct_comp);
 
-    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
-                                &req->send.state.dt_iter,
+    ucp_datatype_iter_mem_dereg(&req->send.state.dt_iter,
                                 UCS_BIT(UCP_DATATYPE_CONTIG));
     ucp_proto_rndv_rkey_destroy(req);
     ucp_proto_rndv_recv_complete_status(req, uct_comp->status);
@@ -224,8 +222,7 @@ static ucs_status_t ucp_rndv_get_zcopy_proto_reset(ucp_request_t *req)
 
     switch (req->send.proto_stage) {
     case UCP_PROTO_RNDV_GET_STAGE_FETCH:
-        ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
-                                    &req->send.state.dt_iter, UCP_DT_MASK_ALL);
+        ucp_datatype_iter_mem_dereg(&req->send.state.dt_iter, UCP_DT_MASK_ALL);
         /* Fall through */
     case UCP_PROTO_RNDV_GET_STAGE_ATS:
         break;

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -121,8 +121,7 @@ ucp_proto_rndv_rtr_hdr_pack(ucp_request_t *req, ucp_rndv_rtr_hdr_t *rtr,
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_rndv_rtr_common_complete(ucp_request_t *req, unsigned dt_mask)
 {
-    ucp_datatype_iter_mem_dereg(req->send.ep->worker->context,
-                                &req->send.state.dt_iter, dt_mask);
+    ucp_datatype_iter_mem_dereg(&req->send.state.dt_iter, dt_mask);
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, dt_mask);
     if (req->send.rndv.rkey != NULL) {
         ucp_proto_rndv_rkey_destroy(req);

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -302,8 +302,8 @@ ucp_tag_offload_do_post(ucp_request_t *req)
             !(req->recv.state.dt.contig.memh->md_map & UCS_BIT(mdi))) {
             /* Can't register this buffer on the offload iface */
             if (status == UCS_OK) {
-                ucp_request_memory_dereg(context, req->recv.datatype,
-                                         &req->recv.state, req);
+                ucp_request_memory_dereg(req->recv.datatype, &req->recv.state,
+                                         req);
             }
             UCP_WORKER_STAT_TAG_OFFLOAD(worker, BLOCK_MEM_REG);
             return status;

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -71,7 +71,7 @@ void test_ucp_proto::do_mem_reg(ucp_datatype_iter_t *dt_iter,
 {
     ucp_datatype_iter_mem_reg(context(), dt_iter, md_map, UCT_MD_MEM_ACCESS_ALL,
                               UCP_DT_MASK_ALL);
-    ucp_datatype_iter_mem_dereg(context(), dt_iter, UCP_DT_MASK_ALL);
+    ucp_datatype_iter_mem_dereg(dt_iter, UCP_DT_MASK_ALL);
 }
 
 void test_ucp_proto::test_dt_iter_mem_reg(ucs_memory_type_t mem_type,


### PR DESCRIPTION
## Why
Optimization - no need to pass context parameter to ucp_memh_put() since it's already a field in memh