### PR TITLE
UCS/RCACHE: Disable atfork hooks before forking and attaching a debugger

### DIFF
--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -12,6 +12,7 @@
 #include "log.h"
 
 #include <ucs/datastruct/khash.h>
+#include <ucs/memory/rcache_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/sys/checker.h>
 #include <ucs/sys/string.h>
@@ -735,6 +736,8 @@ static void ucs_debugger_attach()
     pid_t pid, debug_pid;
     int fd, ret, narg;
     char UCS_V_UNUSED *self_exe;
+
+    ucs_rcache_atfork_disable();
 
     /* Fork a process which will execute gdb and attach to the current process.
      * We must avoid trigerring calls to malloc/free, since the heap may be corrupted.

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -1153,6 +1153,11 @@ static void ucs_rcache_global_list_remove(ucs_rcache_t *rcache)
     ucs_async_pipe_destroy(&pipe);
 }
 
+void ucs_rcache_atfork_disable()
+{
+    ucs_list_head_init(&ucs_rcache_global_context.list);
+}
+
 size_t ucs_rcache_distribution_get_num_bins()
 {
     return ucs_ilog2(ucs_rcache_stat_max_pow2() / UCS_RCACHE_STAT_MIN_POW2) + 2;

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -118,6 +118,10 @@ struct ucs_rcache {
 void ucs_rcache_vfs_init(ucs_rcache_t *rcache);
 
 
+/* Disable any atfork hooks created by registration caches in the program */
+void ucs_rcache_atfork_disable();
+
+
 /**
  * @brief Get number of bins in the distribution of registration cache region
  *        sizes.


### PR DESCRIPTION
## Why
Fix deadlock when forked debugger is attached during an error in rcache operation