### PR TITLE
UCP/RCACHE: Move rcache config to ucs and use for ucp_rcache

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -550,6 +550,10 @@ static ucs_config_field_t ucp_config_table[] = {
   {"RCACHE_ENABLE", "try", "Use user space memory registration cache.",
    ucs_offsetof(ucp_config_t, enable_rcache), UCS_CONFIG_TYPE_TERNARY},
 
+  {"", "RCACHE_PURGE_ON_FORK=y;RCACHE_MEM_PRIO=500;", NULL,
+   ucs_offsetof(ucp_config_t, rcache_config),
+   UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
+
   {"", "", NULL,
    ucs_offsetof(ucp_config_t, ctx),
    UCS_CONFIG_TYPE_TABLE(ucp_context_config_table)},
@@ -2171,7 +2175,7 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
     context->next_memh_reg_id = 0;
 
     if (config->enable_rcache != UCS_NO) {
-        status = ucp_mem_rcache_init(context);
+        status = ucp_mem_rcache_init(context, &config->rcache_config);
         if (status != UCS_OK) {
             if (config->enable_rcache == UCS_YES) {
                 ucs_error("could not create UCP registration cache: %s",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -193,6 +193,8 @@ struct ucp_config {
     UCS_CONFIG_ARRAY_FIELD(size_t, memunits) mpool_sizes;
     /** Memory registration cache */
     ucs_ternary_auto_value_t               enable_rcache;
+    /* Registration cache configuration */
+    ucs_rcache_config_t                    rcache_config;
     /** Configuration saved directly in the context */
     ucp_context_config_t                   ctx;
     /** Save ucx configurations not listed in ucp_config_table **/

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1393,32 +1393,28 @@ static ucs_rcache_ops_t ucp_mem_rcache_ops = {
 
 static ucs_status_t
 ucp_mem_rcache_create(ucp_context_h context, const char *name,
-                      ucs_rcache_t **rcache_p)
+                      ucs_rcache_t **rcache_p, ucs_rcache_params_t *rcache_params)
 {
-    ucs_rcache_params_t rcache_params;
+    rcache_params->region_struct_size = ucp_memh_size(context);
+    rcache_params->ucm_events         = UCM_EVENT_VM_UNMAPPED |
+                                        UCM_EVENT_MEM_TYPE_FREE;
+    rcache_params->context            = context;
+    rcache_params->ops                = &ucp_mem_rcache_ops;
 
-    rcache_params.region_struct_size = ucp_memh_size(context);
-    rcache_params.max_alignment      = ucs_get_page_size();
-    rcache_params.max_unreleased     = SIZE_MAX;
-    rcache_params.max_regions        = -1;
-    rcache_params.max_size           = -1;
-    rcache_params.ucm_event_priority = 500; /* Default UCT pri - 1000 */
-    rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED |
-                                       UCM_EVENT_MEM_TYPE_FREE;
-    rcache_params.context            = context;
-    rcache_params.ops                = &ucp_mem_rcache_ops;
-    rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
-    rcache_params.alignment          = UCS_RCACHE_MIN_ALIGNMENT;
-
-    return ucs_rcache_create(&rcache_params, name, ucs_stats_get_root(),
+    return ucs_rcache_create(rcache_params, name, ucs_stats_get_root(),
                              rcache_p);
 }
 
-ucs_status_t ucp_mem_rcache_init(ucp_context_h context)
+ucs_status_t ucp_mem_rcache_init(ucp_context_h context,
+                                 const ucs_rcache_config_t *rcache_config)
 {
     ucs_status_t status;
+    ucs_rcache_params_t rcache_params;
 
-    status = ucp_mem_rcache_create(context, "ucp_rcache", &context->rcache);
+    ucs_rcache_set_params(&rcache_params, rcache_config);
+
+    status = ucp_mem_rcache_create(context, "ucp_rcache", &context->rcache,
+                                   &rcache_params);
     if (status != UCS_OK) {
         goto err;
     }
@@ -1540,6 +1536,7 @@ ucp_memh_import_slow(ucp_context_h context, ucs_rcache_t *existing_rcache,
                      ucp_unpacked_exported_memh_t *unpacked)
 {
     ucs_rcache_t *rcache;
+    ucs_rcache_params_t rcache_params;
     ucs_status_t status;
     ucp_mem_h memh;
     char rcache_name[128];
@@ -1555,7 +1552,11 @@ ucp_memh_import_slow(ucp_context_h context, ucs_rcache_t *existing_rcache,
             ucs_snprintf_safe(rcache_name, sizeof(rcache_name),
                               "ucp_import_rcache[0x%" PRIx64 "]",
                               unpacked->remote_uuid);
-            status = ucp_mem_rcache_create(context, rcache_name, &rcache);
+
+            ucs_rcache_set_default_params(&rcache_params);
+
+            status = ucp_mem_rcache_create(context, rcache_name, &rcache,
+                                           &rcache_params);
             if (status != UCS_OK) {
                 goto out;
             }

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -170,7 +170,8 @@ void ucp_memh_invalidate(ucp_context_h context, ucp_mem_h memh,
 
 void ucp_memh_put_slow(ucp_context_h context, ucp_mem_h memh);
 
-ucs_status_t ucp_mem_rcache_init(ucp_context_h context);
+ucs_status_t ucp_mem_rcache_init(ucp_context_h context,
+                                 const ucs_rcache_config_t *rcache_config);
 
 void ucp_mem_rcache_cleanup(ucp_context_h context);
 

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -17,6 +17,8 @@
 #include <ucs/datastruct/queue_types.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/stats/stats_fwd.h>
+#include <ucs/time/time_def.h>
+#include <ucs/config/parser.h>
 #include <sys/mman.h>
 
 
@@ -35,6 +37,7 @@ typedef struct ucs_rcache         ucs_rcache_t;
 typedef struct ucs_rcache_ops     ucs_rcache_ops_t;
 typedef struct ucs_rcache_params  ucs_rcache_params_t;
 typedef struct ucs_rcache_region  ucs_rcache_region_t;
+typedef struct ucs_rcache_config  ucs_rcache_config_t;
 
 /*
  * Memory region flags.
@@ -67,6 +70,7 @@ enum {
 };
 
 
+extern ucs_config_field_t ucs_config_rcache_table[];
 typedef void (*ucs_rcache_invalidate_comp_func_t)(void *arg);
 
 
@@ -141,6 +145,20 @@ struct ucs_rcache_params {
     unsigned long          max_regions;         /**< Maximal number of regions */
     size_t                 max_size;            /**< Maximal total size of regions */
     size_t                 max_unreleased;      /**< Threshold for triggering a cleanup */
+};
+
+
+/*
+ * Registration cache configuration parameters.
+ */
+struct ucs_rcache_config {
+    size_t        alignment;      /**< Force address alignment */
+    unsigned      event_prio;     /**< Memory events priority */
+    ucs_time_t    overhead;       /**< Lookup overhead estimation */
+    unsigned long max_regions;    /**< Maximal number of rcache regions */
+    size_t        max_size;       /**< Maximal size of mapped memory */
+    size_t        max_unreleased; /**< Threshold for triggering a cleanup */
+    int           purge_on_fork;  /**< Enable/disable rcache purge on fork */
 };
 
 
@@ -240,6 +258,26 @@ void ucs_rcache_region_invalidate(ucs_rcache_t *rcache,
                                   ucs_rcache_region_t *region,
                                   ucs_rcache_invalidate_comp_func_t cb,
                                   void *arg);
+
+
+/**
+ * Set rcache parameters based on fields in rcache configuration.
+ *
+ * @param [out] rcache_params On success, rcache_params fields are populated
+ *                            with default values.
+ */
+void ucs_rcache_set_default_params(ucs_rcache_params_t *rcache_params);
+
+
+/**
+ * Set rcache parameters based on fields in rcache configuration.
+ *
+ * @param [out] rcache_params On success, rcache_params fields are populated
+ *                            with values provided in rcache_config.
+ * @param [in]  rcache_config Configuration used to populate rcache parameters.
+ */
+void ucs_rcache_set_params(ucs_rcache_params_t *rcache_params,
+                           const ucs_rcache_config_t *rcache_config);
 
 
 #endif

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -44,40 +44,6 @@ ucs_config_field_t uct_md_config_table[] = {
   {NULL}
 };
 
-ucs_config_field_t uct_md_config_rcache_table[] = {
-    {"RCACHE_MEM_PRIO", "1000", "Registration cache memory event priority",
-     ucs_offsetof(uct_md_rcache_config_t, event_prio), UCS_CONFIG_TYPE_UINT},
-
-    {"RCACHE_OVERHEAD", "auto", "Registration cache lookup overhead",
-     ucs_offsetof(uct_md_rcache_config_t, overhead), UCS_CONFIG_TYPE_TIME_UNITS},
-
-    {"RCACHE_ADDR_ALIGN", UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE),
-     "Registration cache address alignment, must be power of 2\n"
-     "between " UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN) "and system page size",
-     ucs_offsetof(uct_md_rcache_config_t, alignment), UCS_CONFIG_TYPE_UINT},
-
-    {"RCACHE_MAX_REGIONS", "inf",
-     "Maximal number of regions in the registration cache",
-     ucs_offsetof(uct_md_rcache_config_t, max_regions),
-     UCS_CONFIG_TYPE_ULUNITS},
-
-    {"RCACHE_MAX_SIZE", "inf",
-     "Maximal total size of registration cache regions",
-     ucs_offsetof(uct_md_rcache_config_t, max_size), UCS_CONFIG_TYPE_MEMUNITS},
-
-    {"RCACHE_MAX_UNRELEASED", "512M",
-     "Maximal size of total memory regions in invalidate queue and garbage,\n"
-     "after which a cleanup is triggered.",
-     ucs_offsetof(uct_md_rcache_config_t, max_unreleased),
-     UCS_CONFIG_TYPE_MEMUNITS},
-
-    {"RCACHE_PURGE_ON_FORK", "y",
-     "Purge registration cache upon fork",
-     ucs_offsetof(uct_md_rcache_config_t, purge_on_fork), UCS_CONFIG_TYPE_BOOL},
-
-    {NULL}
-};
-
 
 const char *uct_device_type_names[] = {
     [UCT_DEVICE_TYPE_NET]  = "network",
@@ -630,19 +596,7 @@ ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
     return UCS_OK;
 }
 
-void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
-                              const uct_md_rcache_config_t *rcache_config)
-{
-    rcache_params->alignment          = rcache_config->alignment;
-    rcache_params->ucm_event_priority = rcache_config->event_prio;
-    rcache_params->max_regions        = rcache_config->max_regions;
-    rcache_params->max_size           = rcache_config->max_size;
-    rcache_params->max_unreleased     = rcache_config->max_unreleased;
-    rcache_params->flags              = !rcache_config->purge_on_fork ? 0 :
-                                        UCS_RCACHE_FLAG_PURGE_ON_FORK;
-}
-
-double uct_md_rcache_overhead(const uct_md_rcache_config_t *rcache_config)
+double uct_md_rcache_overhead(const ucs_rcache_config_t *rcache_config)
 {
     if (rcache_config->overhead == UCS_TIME_AUTO) {
         if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM) {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -59,18 +59,6 @@
     }
 
 
-typedef struct uct_md_rcache_config {
-    size_t        alignment;      /**< Force address alignment */
-    unsigned      event_prio;     /**< Memory events priority */
-    ucs_time_t    overhead;       /**< Lookup overhead estimation */
-    unsigned long max_regions;    /**< Maximal number of rcache regions */
-    size_t        max_size;       /**< Maximal size of mapped memory */
-    size_t        max_unreleased; /**< Threshold for triggering a cleanup */
-    int           purge_on_fork;  /**< Enable/disable rcache purge on fork */
-} uct_md_rcache_config_t;
-
-
-extern ucs_config_field_t uct_md_config_rcache_table[];
 extern const char *uct_device_type_names[];
 
 /**
@@ -244,10 +232,7 @@ ucs_status_t uct_md_dummy_mem_reg(uct_md_h md, void *address, size_t length,
 ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
                                     const uct_md_mem_dereg_params_t *params);
 
-void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
-                              const uct_md_rcache_config_t *rcache_config);
-
-double uct_md_rcache_overhead(const uct_md_rcache_config_t *rcache_config);
+double uct_md_rcache_overhead(const ucs_rcache_config_t *rcache_config);
 
 extern ucs_config_field_t uct_md_config_table[];
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -32,7 +32,7 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
 
     {"", "RCACHE_ADDR_ALIGN=" UCS_PP_MAKE_STRING(UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN), NULL,
      ucs_offsetof(uct_gdr_copy_md_config_t, rcache),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
+     UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
 
     {"MEM_REG_OVERHEAD", "16us", "Memory registration overhead", /* TODO take default from device */
      ucs_offsetof(uct_gdr_copy_md_config_t, uc_reg_cost.m), UCS_CONFIG_TYPE_TIME},
@@ -412,13 +412,14 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
     }
 
     if (md_config->enable_rcache != UCS_NO) {
-        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
+        ucs_rcache_set_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_gdr_copy_rcache_region_t);
         rcache_params.max_alignment      = UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN;
         rcache_params.ucm_events         = UCM_EVENT_MEM_TYPE_FREE;
         rcache_params.context            = md;
         rcache_params.ops                = &uct_gdr_copy_rcache_ops;
         rcache_params.flags              = 0;
+
         status = ucs_rcache_create(&rcache_params, "gdr_copy", NULL, &md->rcache);
         if (status == UCS_OK) {
             md->super.ops = &md_rcache_ops;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -32,7 +32,7 @@ typedef struct uct_gdr_copy_md {
 typedef struct uct_gdr_copy_md_config {
     uct_md_config_t         super;
     int                     enable_rcache;/**< Enable registration cache */
-    uct_md_rcache_config_t  rcache;       /**< Registration cache config */
+    ucs_rcache_config_t     rcache;       /**< Registration cache config */
     ucs_linear_func_t       uc_reg_cost;  /**< Memory registration cost estimation
                                              without using the cache */
 } uct_gdr_copy_md_config_t;

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -31,9 +31,9 @@ static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
      ucs_offsetof(uct_rocm_copy_md_config_t, enable_rcache),
      UCS_CONFIG_TYPE_TERNARY},
 
-    {"", "", NULL,
+    {"", "RCACHE_ADDR_ALIGN=" UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE), NULL,
      ucs_offsetof(uct_rocm_copy_md_config_t, rcache),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
+     UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
 
     {"DMABUF", "no",
      "Enable using cross-device dmabuf file descriptor",
@@ -427,7 +427,7 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
     }
 
     if (md_config->enable_rcache != UCS_NO) {
-        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
+        ucs_rcache_set_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_rocm_copy_rcache_region_t);
         rcache_params.alignment          = ucs_get_page_size();
         rcache_params.max_alignment      = ucs_get_page_size();
@@ -436,6 +436,7 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
         rcache_params.context            = md;
         rcache_params.ops                = &uct_rocm_copy_rcache_ops;
         rcache_params.flags              = 0;
+
         status = ucs_rcache_create(&rcache_params, "rocm_copy", NULL, &md->rcache);
         if (status == UCS_OK) {
             md->super.ops = &md_rcache_ops;

--- a/src/uct/rocm/copy/rocm_copy_md.h
+++ b/src/uct/rocm/copy/rocm_copy_md.h
@@ -30,7 +30,7 @@ typedef struct uct_rocm_copy_md {
 typedef struct uct_rocm_copy_md_config {
     uct_md_config_t             super;
     ucs_ternary_auto_value_t    enable_rcache;/**< Enable registration cache */
-    uct_md_rcache_config_t      rcache;       /**< Registration cache config */
+    ucs_rcache_config_t         rcache;       /**< Registration cache config */
     ucs_linear_func_t           uc_reg_cost;  /**< Memory registration cost estimation
                                                    without using the cache */
     ucs_ternary_auto_value_t    enable_dmabuf; /**< Turn using dmabuf on/off */


### PR DESCRIPTION
## Why
UCP rcache does not allow setting limits on max_size, max_regions, etc. As IB registrations may need to be limited for specific platforms (for example where amount memory that can be pinned is not unlimited), having user set limits on IB through UCP rcache is useful. The PR moves rcache params initialization logic to UCS and uses it in UCP rcache initialization. 
