### PR TITLE
UCT/IB/MLX5: Fix invalid access error to strict-order key with offset

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -234,10 +234,12 @@ int ucs_config_sprintf_hex(char *buf, size_t max,
 
 int ucs_config_sscanf_bool(const char *buf, void *dest, const void *arg)
 {
-    if (!strcasecmp(buf, "y") || !strcasecmp(buf, "yes") || !strcmp(buf, "1")) {
+    if (!strcasecmp(buf, "y") || !strcasecmp(buf, "yes") ||
+        !strcmp(buf, "on") || !strcmp(buf, "1")) {
         *(int*)dest = 1;
         return 1;
-    } else if (!strcasecmp(buf, "n") || !strcasecmp(buf, "no") || !strcmp(buf, "0")) {
+    } else if (!strcasecmp(buf, "n") || !strcasecmp(buf, "no") ||
+               !strcmp(buf, "off") || !strcmp(buf, "0")) {
         *(int*)dest = 0;
         return 1;
     } else {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -192,7 +192,7 @@ typedef struct uct_ib_md_config {
 
     unsigned                 devx;         /**< DEVX support */
     unsigned                 devx_objs;    /**< Objects to be created by DevX */
-    ucs_on_off_auto_value_t  mr_relaxed_order; /**< Allow reorder memory accesses */
+    ucs_ternary_auto_value_t mr_relaxed_order; /**< Allow reorder memory accesses */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
 } uct_ib_md_config_t;
 
@@ -611,6 +611,10 @@ uct_ib_md_is_flush_rkey_valid(uint32_t flush_rkey) {
 
 ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
                             const uct_md_config_t *uct_md_config, uct_md_h *md_p);
+
+void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
+                                   const uct_ib_md_config_t *md_config,
+                                   int is_supported);
 
 int uct_ib_device_is_accessible(struct ibv_device *device);
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -503,9 +503,7 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_key(uct_ib_md_t *ibmd,
 static int
 uct_ib_mlx5_devx_use_atomic_ksm(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mem_t *memh)
 {
-    /* User needs atomic access and MD supports atomic KSM */
-    return (memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) &&
-           ucs_test_all_flags(md->flags,
+    return ucs_test_all_flags(md->flags,
                               UCT_IB_MLX5_MD_FLAG_KSM |
                               UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS);
 }
@@ -519,9 +517,12 @@ static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
     uct_ib_mlx5_mr_t *mr     = &memh->mrs[mr_type];
     ucs_status_t status;
     uint8_t mr_id;
+    int is_atomic;
 
     if (!uct_ib_mlx5_devx_use_atomic_ksm(md, memh)) {
-        return uct_ib_mlx5_reg_atomic_key(ibmd, ib_memh);
+        /* We cannot return a direct key, since the requestor may try to use it
+           with non-zero atomic offset */
+        return UCS_ERR_UNSUPPORTED;
     }
 
     status = uct_ib_mlx5_md_get_atomic_mr_id(ibmd, &mr_id);
@@ -529,8 +530,10 @@ static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
         return status;
     }
 
+    is_atomic = memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;
+
     if (memh->super.flags & UCT_IB_MEM_MULTITHREADED) {
-        return uct_ib_mlx5_devx_reg_ksm_data(md, 1, mr->ksm_data,
+        return uct_ib_mlx5_devx_reg_ksm_data(md, is_atomic, mr->ksm_data,
                                              mr->ksm_data->length,
                                              uct_ib_md_atomic_offset(mr_id),
                                              &memh->atomic_dvmr,
@@ -538,15 +541,16 @@ static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
     }
 
     status = uct_ib_mlx5_devx_reg_ksm_data_contig(
-            md, mr, uct_ib_md_atomic_offset(mr_id), 1, &memh->atomic_dvmr,
-            &memh->super.atomic_rkey);
+            md, mr, uct_ib_md_atomic_offset(mr_id), is_atomic,
+            &memh->atomic_dvmr, &memh->super.atomic_rkey);
     if (status != UCS_OK) {
         return status;
     }
 
-    ucs_debug("KSM registered memory %p..%p offset 0x%x on %s rkey 0x%x",
-              mr->super.ib->addr, UCS_PTR_BYTE_OFFSET(mr->super.ib->addr,
-              mr->super.ib->length), uct_ib_md_atomic_offset(mr_id),
+    ucs_debug("KSM registered memory %p..%p offset 0x%x%s on %s rkey 0x%x",
+              mr->super.ib->addr,
+              UCS_PTR_BYTE_OFFSET(mr->super.ib->addr, mr->super.ib->length),
+              uct_ib_md_atomic_offset(mr_id), is_atomic ? " atomic" : "",
               uct_ib_device_name(&md->super.dev), memh->super.atomic_rkey);
     return status;
 }
@@ -1017,6 +1021,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     int ret;
     ucs_log_level_t log_level;
     ucs_mpool_params_t mp_params;
+    int ksm_atomic;
 
     if (!mlx5dv_is_supported(ibv_device)) {
         status = UCS_ERR_UNSUPPORTED;
@@ -1270,14 +1275,20 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     memcpy(md->super.vhca_id, vhca_id, sizeof(vhca_id));
 
+    ksm_atomic = 0;
     if (md->flags & UCT_IB_MLX5_MD_FLAG_KSM) {
         md->super.cap_flags |= UCT_MD_FLAG_INVALIDATE_RMA;
 
         if (md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS) {
             md->super.cap_flags |= UCT_MD_FLAG_INVALIDATE_AMO |
                                    UCT_MD_FLAG_INVALIDATE;
+            ksm_atomic           = 1;
         }
     }
+
+    /* Enable relaxed order only if we would be able to create an indirect key
+       (with offset) for strict order access */
+    uct_ib_md_parse_relaxed_order(&md->super, md_config, ksm_atomic);
 
     uct_ib_mlx5_devx_init_flush_mr(md);
 
@@ -1832,6 +1843,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->super.name = UCT_IB_MD_NAME(mlx5);
 
+    uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
     uct_ib_md_ece_check(&md->super);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -136,7 +136,7 @@ UCS_TEST_P(test_ib_md, ib_md_umr_ksm) {
     ib_md_umr_check(&rkey_buffer[0], has_ksm(), UCT_IB_MD_MAX_MR_SIZE + 0x1000);
 }
 
-UCS_TEST_P(test_ib_md, relaxed_order, "PCI_RELAXED_ORDERING=on") {
+UCS_TEST_P(test_ib_md, relaxed_order, "PCI_RELAXED_ORDERING=try") {
     std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
 
     ib_md_umr_check(&rkey_buffer[0], false);

--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -10,11 +10,15 @@
 
 class uct_p2p_rma_test_xfer : public uct_p2p_rma_test {};
 
-UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_xfer, fence,
-                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY)) {
+UCS_TEST_SKIP_COND_P(uct_p2p_rma_test_xfer, fence_relaxed_order,
+                     !check_caps(UCT_IFACE_FLAG_PUT_BCOPY),
+                     "PCI_RELAXED_ORDERING=try") {
+    size_t size = ucs_min(ucs_get_page_size(),
+                          sender().iface_attr().cap.put.max_bcopy);
 
-    mapped_buffer sendbuf(64, 0, sender());
-    mapped_buffer recvbuf(64, 0, receiver());
+    mapped_buffer sendbuf(size, 0, sender());
+    mapped_buffer recvbuf(size, 0, receiver(), 0, UCS_MEMORY_TYPE_HOST,
+                          UCT_MD_MEM_ACCESS_RMA);
 
     blocking_send(static_cast<send_func_t>(&uct_p2p_rma_test::put_bcopy),
                   sender_ep(), sendbuf, recvbuf, true);

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -137,11 +137,12 @@ protected:
         entity(const resource& resource, uct_md_config_t *md_config,
                uct_cm_config_t *cm_config);
 
-        void mem_alloc_host(size_t length, uct_allocated_memory_t *mem) const;
+        void mem_alloc_host(size_t length, unsigned mem_flags,
+                            uct_allocated_memory_t *mem) const;
 
         void mem_free_host(const uct_allocated_memory_t *mem) const;
 
-        void mem_type_reg(uct_allocated_memory_t *mem) const;
+        void mem_type_reg(uct_allocated_memory_t *mem, unsigned flags) const;
 
         void mem_type_dereg(uct_allocated_memory_t *mem) const;
 
@@ -239,9 +240,10 @@ protected:
 
     class mapped_buffer {
     public:
-        mapped_buffer(size_t size, uint64_t seed, const entity& entity,
+        mapped_buffer(size_t size, uint64_t seed, const entity &entity,
                       size_t offset = 0,
-                      ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST);
+                      ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
+                      unsigned mem_flags = UCT_MD_MEM_ACCESS_ALL);
         virtual ~mapped_buffer();
 
         void *ptr() const;


### PR DESCRIPTION
## Why
Fix remote access error when running ucx_perftest on ConnectX-5 like so:
`UCX_RNDV_THRESH=3074 UCX_IB_PCI_RELAXED_ORDERING=on UCX_NET_DEVICES=mlx5_0:1 UCX_RNDV_SCHEME=put_zcopy ./build-devel/src/tools/perf/ucx_perftest cascade1  -t ucp_am_bw  -s 4096 -w 0 -n 1 -O 1`

## How
Avoid creating a relaxed-order key on DevX MD if KSM/atomic is not supported.
Currently, if KSM/atomic is not supported, we are sending the direct key, and the requestor will try to access it with atomic offset resulting in out-of-bounds access.
On the other hand, if strict ordering is enabled, the default key does not guarantee order.

Edit: Tested that the performance degradation fixed by #9077 is not happening again with this PR
cc @jithinjosepkl
