### PR TITLE
UCT/IB: unify function to check flush rkey

### DIFF
--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -743,13 +743,4 @@ uct_rc_mlx5_common_iface_init_rx(uct_rc_mlx5_iface_common_t *iface,
 
 void uct_rc_mlx5_destroy_srq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_srq_t *srq);
 
-static UCS_F_ALWAYS_INLINE int
-uct_rc_mlx5_iface_flush_rkey_enabled(uct_rc_mlx5_iface_common_t *iface)
-{
-    uct_ib_md_t *md = uct_ib_iface_md(&iface->super.super);
-
-    return iface->super.config.flush_remote &&
-           uct_ib_md_is_flush_rkey_valid(md->flush_rkey);
-}
-
 #endif

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -684,7 +684,7 @@ ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
         uct_ib_pack_uint24(rc_addr->tm_qp_num, ep->tm_qp.qp_num);
     }
 
-    if (uct_rc_mlx5_iface_flush_rkey_enabled(iface)) {
+    if (uct_rc_iface_flush_rkey_enabled(&iface->super)) {
         ext_addr                            = ucs_derived_of(rc_addr,
                                                              uct_rc_mlx5_ep_ext_address_t);
         ext_addr->flags                     = UCT_RC_MLX5_EP_ADDR_FLAG_FLUSH_RKEY;

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -241,7 +241,7 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
         return status;
     }
 
-    if (uct_rc_mlx5_iface_flush_rkey_enabled(iface)) {
+    if (uct_rc_iface_flush_rkey_enabled(&iface->super)) {
         ep_addr_len = sizeof(uct_rc_mlx5_ep_ext_address_t) + sizeof(uint16_t);
     } else {
         ep_addr_len = sizeof(uct_rc_mlx5_ep_address_t);

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -585,6 +585,15 @@ uct_rc_iface_fence_relaxed_order(uct_iface_h tl_iface)
     return uct_rc_iface_fence(tl_iface, 0);
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_rc_iface_flush_rkey_enabled(uct_rc_iface_t *iface)
+{
+    uct_ib_md_t *md = uct_ib_iface_md(&iface->super);
+
+    return iface->config.flush_remote &&
+           uct_ib_md_is_flush_rkey_valid(md->flush_rkey);
+}
+
 static UCS_F_ALWAYS_INLINE void
 uct_rc_iface_check_pending(uct_rc_iface_t *iface, ucs_arbiter_group_t *arb_group)
 {

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -589,10 +589,8 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
     rc_addr->super.flags = 0;
     uct_ib_pack_uint24(rc_addr->super.qp_num, ep->qp->qp_num);
 
-    if (uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id) == UCS_OK) {
-        ucs_assertv(uct_ib_md_is_flush_rkey_valid(md->flush_rkey),
-                    "invalid flush_rkey %x for device %s", md->flush_rkey,
-                    uct_ib_device_name(&md->dev));
+    uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id);
+    if (uct_rc_iface_flush_rkey_enabled(&iface->super)) {
         rc_addr->super.flags  |= UCT_RC_VERBS_ADDR_HAS_ATOMIC_MR;
         rc_addr->atomic_mr_id  = mr_id;
         rc_addr->flush_rkey_hi = md->flush_rkey >> 16;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -211,8 +211,6 @@ static void uct_rc_verbs_iface_init_inl_wrs(uct_rc_verbs_iface_t *iface)
 static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_verbs_iface_t);
-    uct_ib_md_t *md             = uct_ib_iface_md(ucs_derived_of(iface, uct_ib_iface_t));
-    uint8_t mr_id;
     ucs_status_t status;
 
     status = uct_rc_iface_query(&iface->super, iface_attr,
@@ -230,10 +228,9 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->latency.m += 1e-9;  /* 1 ns per each extra QP */
     iface_attr->overhead   = 75e-9; /* Software overhead */
 
-    iface_attr->ep_addr_len =
-            (uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id) == UCS_OK) ?
-                    sizeof(uct_rc_verbs_ep_flush_addr_t) :
-                    sizeof(uct_rc_verbs_ep_addr_t);
+    iface_attr->ep_addr_len = uct_rc_iface_flush_rkey_enabled(&iface->super) ?
+                              sizeof(uct_rc_verbs_ep_flush_addr_t) :
+                              sizeof(uct_rc_verbs_ep_addr_t);
 
     return UCS_OK;
 }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -150,6 +150,12 @@ protected:
     entity *m_entity_flush_rkey;
 
 public:
+    int rc_iface_flush_rkey_enabled(entity *e)
+    {
+        uct_rc_iface_t *rc_iface = ucs_derived_of(e->iface(), uct_rc_iface_t);
+        return uct_rc_iface_flush_rkey_enabled(rc_iface);
+    }
+
     static uct_iface_params_t iface_params()
     {
         uct_iface_params_t params = {};
@@ -193,17 +199,18 @@ UCS_TEST_P(test_rc_iface_address, size_no_flush_remote)
     map_size_t sizes = {
         {"rc_mlx5", {7, 1}},
         {"dc_mlx5", {0, 5}},
-        {"rc_verbs", {7, 0}},
+        {"rc_verbs", {4, 0}},
     };
     check_sizes(m_entity, sizes);
 }
 
 UCS_TEST_P(test_rc_iface_address, size_flush_remote)
 {
+    int flush_rkey_enabled = rc_iface_flush_rkey_enabled(m_entity_flush_rkey);
     map_size_t sizes = {
-        {"rc_mlx5", {10, 1}},
-        {"dc_mlx5", {0, 7}},
-        {"rc_verbs", {7, 0}},
+        {"rc_mlx5", {flush_rkey_enabled ? 10 : 7, 1}},
+        {"dc_mlx5", {0, flush_rkey_enabled ? 7 : 5}},
+        {"rc_verbs", {flush_rkey_enabled ? 7 : 4, 0}},
     };
     check_sizes(m_entity_flush_rkey, sizes);
 }


### PR DESCRIPTION
## What
Unify function to check iface flush rkey.

## Why ?
make verbs & dv & devx to use one function to check iface flush rkey and related function.
