### PR TITLE
UCM/BISTRO: Add locking step while hooking library functions

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -974,6 +974,25 @@ test_ucp_dlopen() {
 	fi
 }
 
+test_ucm_hooks() {
+    total=30
+    echo "==== Running UCM Bistro hook test ===="
+    for i in $(seq 1 $total); do
+        threads=$(((RANDOM % (2 * `nproc`)) + 1))
+
+        echo "iteration $i/$total: $threads threads"
+        timeout 10 ./test/apps/test_hooks -n $threads >test_hooks.log 2>&1 || \
+            { \
+                echo "ERROR running bistro hook test:"; \
+                cat test_hooks.log; \
+                exit 1; \
+            }
+    done
+
+    echo "SUCCESS running bistro hook test:"
+    cat test_hooks.log
+}
+
 test_init_mt() {
 	echo "==== Running multi-thread init ===="
 	# Each thread requires 5MB. Cap threads number by total available shared memory.
@@ -1267,6 +1286,7 @@ run_release_mode_tests() {
 	test_ucs_load
 	test_ucp_dlopen
 	run_gtest_release
+	test_ucm_hooks
 }
 
 #

--- a/src/ucm/bistro/bistro_aarch64.h
+++ b/src/ucm/bistro/bistro_aarch64.h
@@ -35,4 +35,17 @@ ucs_status_t ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
                               void **orig_func_p,
                               ucm_bistro_restore_point_t **rp);
 
+/* Instruction type */
+typedef uint32_t ucm_bistro_inst_t;
+
+/* Lock implementation */
+typedef struct {
+    ucm_bistro_inst_t b; /* either self branch, or no-op branch */
+} UCS_S_PACKED ucm_bistro_lock_t;
+
+/**
+ * Helper functions to improve atomicity of function patching
+ */
+void ucm_bistro_patch_lock(void *dst);
+
 #endif

--- a/src/ucm/bistro/bistro_int.h
+++ b/src/ucm/bistro/bistro_int.h
@@ -30,6 +30,11 @@
 
 ucs_status_t ucm_bistro_apply_patch(void *dst, void *patch, size_t len);
 
+ucs_status_t
+ucm_bistro_apply_patch_atomic(void *dst, const void *patch, size_t len);
+
+void ucm_bistro_modify_code(void *dst, const ucm_bistro_lock_t *bytes);
+
 ucs_status_t ucm_bistro_create_restore_point(void *addr, size_t len,
                                              ucm_bistro_restore_point_t **rp);
 

--- a/src/ucm/bistro/bistro_x86_64.h
+++ b/src/ucm/bistro/bistro_x86_64.h
@@ -36,4 +36,14 @@ ucs_status_t ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
                               void **orig_func_p,
                               ucm_bistro_restore_point_t **rp);
 
+/* Patching lock for other flows exclusion */
+typedef struct ucm_bistro_lock {
+    uint8_t jmp[2]; /* jmp self or immediate next instruction */
+} UCS_S_PACKED ucm_bistro_lock_t;
+
+/**
+ * Helper functions to improve atomicity of function patching
+ */
+void ucm_bistro_patch_lock(void *dst);
+
 #endif

--- a/src/ucm/util/sys.h
+++ b/src/ucm/util/sys.h
@@ -10,6 +10,7 @@
 
 #include <ucm/api/ucm.h>
 #include <ucs/sys/checker.h>
+#include <ucs/time/time.h>
 #include <sys/types.h>
 #include <stddef.h>
 
@@ -129,6 +130,20 @@ ucm_get_hook_mode(ucm_mmap_hook_mode_t config_mode)
 
     return config_mode;
 #endif
+}
+
+
+/**
+ * Get current time without depending on UCS library code
+ *
+ * @return The current time value in seconds
+ */
+static UCS_F_ALWAYS_INLINE double ucm_get_time()
+{
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+    return (double)tv.tv_sec + ((double)tv.tv_usec / UCS_USEC_PER_SEC);
 }
 
 #endif

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -72,7 +72,6 @@ static inline double ucs_time_sec_value()
     return ucs_get_cpu_clocks_per_sec();
 }
 
-
 /**
  * Convert seconds to UCS time units.
  */

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -21,9 +21,16 @@ noinst_PROGRAMS = \
 	test_link_map \
 	test_dlopen_cfg_print \
 	test_init_mt \
-	test_memtrack_limit
+	test_memtrack_limit \
+	test_hooks
 
 objdir = $(shell sed -n -e 's/^objdir=\(.*\)$$/\1/p' $(LIBTOOL))
+
+test_hooks_SOURCES  = test_hooks.c
+test_hooks_CPPFLAGS = $(BASE_CPPFLAGS) \
+                      -DLIB_PATH=$(abs_top_builddir)/src/ucs/$(objdir)/libucs.so
+test_hooks_CFLAGS   = $(BASE_CFLAGS)
+test_hooks_LDADD    = -ldl
 
 test_ucs_dlopen_SOURCES  = test_ucs_dlopen.c
 test_ucs_dlopen_CPPFLAGS = $(BASE_CPPFLAGS) \

--- a/test/apps/test_hooks.c
+++ b/test/apps/test_hooks.c
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include <ucs/sys/preprocessor.h>
+#include <ucm/api/ucm.h>
+#include <ucm/util/sys.h>
+
+
+#define DEFAULT_THREAD_COUNT   16
+#define DEFAULT_THREAD_TIMEOUT 1
+
+
+typedef struct {
+    const char   *libname;
+    int          thread_count;
+    pthread_t    *threads;
+    volatile int stop;
+    double       thread_timeout;
+    void         *dl_handle;
+} context_t;
+
+static ucs_status_t ctx_init(context_t *ctx, const char *filename,
+                             int thread_count, int thread_timeout)
+{
+    pthread_t *threads;
+
+    threads = calloc(thread_count, sizeof(*threads));
+    if (threads == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ctx->dl_handle      = NULL;
+    ctx->libname        = filename;
+    ctx->thread_count   = thread_count;
+    ctx->threads        = threads;
+    ctx->stop           = 0;
+    ctx->thread_timeout = thread_timeout;
+
+    return UCS_OK;
+}
+
+static ucs_status_t ctx_load_library(context_t *ctx)
+{
+    printf("loading library to trigger hooks installation\n");
+
+    dlerror();
+    ctx->dl_handle = dlopen(ctx->libname, RTLD_NOW);
+    if (ctx->dl_handle == NULL) {
+        printf("dlopen(filename=\"%s\", RTLD_NOW) failed: %s\n", ctx->libname,
+               dlerror());
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+static void *thread_handler(void *arg)
+{
+    context_t *ctx  = arg;
+    double deadline = ucm_get_time() + ctx->thread_timeout;
+
+    /*
+     * Many threads racing for read lock are preventing ucm to finish testing
+     * the installed hooks, so we make sure to stop the threads after
+     * reasonable time.
+     */
+    do {
+        if (mmap(NULL, 0, PROT_READ | PROT_WRITE, MAP_PRIVATE, -1, 0) !=
+            MAP_FAILED) {
+            printf("failed to return mmap_call() failure\n");
+            exit(EXIT_FAILURE);
+        }
+    } while (!ctx->stop &&
+             ((ctx->thread_timeout == 0) || (ucm_get_time() < deadline)));
+
+    return NULL;
+}
+
+static void ctx_stop_threads(context_t *ctx, int count)
+{
+    int i;
+
+    printf("stopping %d threads\n", count);
+
+    ctx->stop = 1;
+    for (i = 0; i < count; i++) {
+        pthread_join(ctx->threads[i], NULL);
+    }
+}
+
+static ucs_status_t ctx_start_threads(context_t *ctx)
+{
+    int i, ret;
+
+    for (i = 0; i < ctx->thread_count; i++) {
+        ret = pthread_create(&ctx->threads[i], NULL, thread_handler, ctx);
+        if (ret < 0) {
+            printf("pthread_create(thread #%d) failed: %m\n", i);
+            goto err;
+        }
+    }
+
+    printf("started %d threads\n", ctx->thread_count);
+    return UCS_OK;
+
+err:
+    ctx_stop_threads(ctx, i);
+    return UCS_ERR_NO_RESOURCE;
+}
+
+static void ctx_free(context_t *ctx)
+{
+    if (ctx->dl_handle != NULL) {
+        dlclose(ctx->dl_handle);
+    }
+    free(ctx->threads);
+}
+
+static void usage(const char *argv0)
+{
+    printf("Usage: %s [options]\n", argv0);
+    printf("Options:\n");
+    printf("  -n :  Number of threads racing with function patching (default: "
+           "%d)\n",
+           DEFAULT_THREAD_COUNT);
+    printf("  -d :  Disable thread timeout (default %d sec)\n",
+           DEFAULT_THREAD_TIMEOUT);
+    printf("  -h :  Display help message\n");
+    printf("\n");
+}
+
+int main(int argc, char **argv)
+{
+    int thread_count   = DEFAULT_THREAD_COUNT;
+    int thread_timeout = DEFAULT_THREAD_TIMEOUT;
+    int delay_usec     = 200 * 1000;
+    int c, ret;
+    context_t ctx;
+    ucs_status_t status;
+
+    while ((c = getopt(argc, argv, "n:dh")) != -1) {
+        switch (c) {
+        case 'n':
+            thread_count = atoi(optarg);
+            break;
+        case 'd':
+            thread_timeout = 0;
+            break;
+        case 'h':
+        default:
+            usage(argv[0]);
+            return -1;
+        }
+    }
+
+    status = ctx_init(&ctx, UCS_PP_MAKE_STRING(LIB_PATH), thread_count,
+                      thread_timeout);
+    if (status != UCS_OK) {
+        return -1;
+    }
+
+    printf("thread timeout: %d sec\n", thread_timeout);
+
+    status = ctx_start_threads(&ctx);
+    if (status != UCS_OK) {
+        printf("failed to start threads\n");
+        ret = -1;
+        goto out;
+    }
+
+    usleep(delay_usec); /* make sure threads are running */
+
+    /* trigger ucm memory patching */
+    status = ctx_load_library(&ctx);
+    if (status != UCS_OK) {
+        printf("failed to load library\n");
+        ret = -1;
+        goto out_stop_threads;
+    }
+
+    usleep(delay_usec); /* make sure threads have time to race */
+
+    ret = 0;
+
+out_stop_threads:
+    ctx_stop_threads(&ctx, ctx.thread_count);
+out:
+    ctx_free(&ctx);
+    return ret;
+}


### PR DESCRIPTION
## What
Adds a locking step and grace period while patching the hooked functions to narrow existing race condition.

## Why ?
Race conditions could be seen when ucm bistro code is being invoked through a `dlopen()` call.

## How ?
After inserting a lock, we wait for existing parallel code flows to complete. The lock itself is eventually removed so that we don't grow the patch size. For instance, including the first instruction after the syscall instruction under the patched area could lead to corruption, as a system call could take longer to complete than the grace period.

Added a test program to exercise the busy loop locking/unlocking sequence.

### Tested
Built in release and tested:
- `while :; do ./test/apps/test_hooks || break; done`
  - test on x86_64 (short and long patch) and aarch64
- repro with and without fix on aarch64