### PR TITLE
UCS/DATASTURCT: LRU cache

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -100,7 +100,8 @@ ForEachMacros: ['_UCS_BITMAP_FOR_EACH_WORD',
                 'UCT_RC_VERBS_IFACE_FOREACH_TXWQE',
                 'UCS_INIT_ONCE',
                 'UCS_TEST_F',
-                'UCX_PERF_TEST_FOREACH']
+                'UCX_PERF_TEST_FOREACH',
+		'ucs_lru_for_each']
 StatementMacros : []
 TypenameMacros: ['khash_t', 'ucs_array_t']
 WhitespaceSensitiveMacros: []

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -94,6 +94,7 @@ noinst_HEADERS = \
 	datastruct/arbiter.h \
 	datastruct/bitmap.h \
 	datastruct/frag_list.h \
+        datastruct/lru.h \
 	datastruct/mpmc.h \
 	datastruct/mpool.inl \
 	datastruct/mpool_set.inl \
@@ -156,6 +157,7 @@ libucs_la_SOURCES = \
 	datastruct/array.c \
 	datastruct/callbackq.c \
 	datastruct/frag_list.c \
+	datastruct/lru.c \
 	datastruct/mpmc.c \
 	datastruct/mpool.c \
 	datastruct/mpool_set.c \

--- a/src/ucs/datastruct/lru.c
+++ b/src/ucs/datastruct/lru.c
@@ -1,0 +1,61 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "lru.h"
+
+#include <ucs/datastruct/list.h>
+#include <ucs/debug/log.h>
+#include <ucs/debug/memtrack_int.h>
+
+
+ucs_status_t ucs_lru_create(size_t capacity, ucs_lru_h *lru_p)
+{
+    ucs_lru_h lru;
+    ucs_status_t status;
+
+    if (capacity == 0) {
+        status = UCS_ERR_INVALID_PARAM;
+        goto err;
+    }
+
+    lru = ucs_calloc(1, sizeof(*lru), "ucs_lru");
+    if (lru == NULL) {
+        ucs_error("failed to allocate LRU (capacity: %lu)", capacity);
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    kh_init_inplace(ucs_lru_hash, &lru->hash);
+
+    /* Resize the cache to the required capacity. Need to allocate extra space
+     * in order to avoid collisions in the hash table. */
+    if (kh_resize(ucs_lru_hash, &lru->hash, capacity * 2) < 0) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_free;
+    }
+
+    ucs_list_head_init(&lru->list);
+
+    lru->capacity = capacity;
+    *lru_p        = lru;
+    return UCS_OK;
+
+err_free:
+    ucs_free(lru);
+err:
+    return status;
+}
+
+void ucs_lru_destroy(ucs_lru_h lru)
+{
+    kh_destroy_inplace(ucs_lru_hash, &lru->hash);
+    ucs_free(lru);
+}
+

--- a/src/ucs/datastruct/lru.h
+++ b/src/ucs/datastruct/lru.h
@@ -1,0 +1,132 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2023. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_LRU_H_
+#define UCS_LRU_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+
+#include <ucs/datastruct/khash.h>
+#include <ucs/datastruct/list.h>
+#include <ucs/debug/assert.h>
+#include <ucs/type/status.h>
+
+/* LRU element data structure */
+typedef struct {
+    /* Key to use as hash table input */
+    void           *key;
+    /* Linked list item */
+    ucs_list_link_t list;
+} ucs_lru_element_t;
+
+
+KHASH_INIT(ucs_lru_hash, uint64_t, ucs_lru_element_t, 1, kh_int64_hash_func,
+           kh_int64_hash_equal)
+
+
+/* Hash table type for LRU cache */
+typedef khash_t(ucs_lru_hash) ucs_lru_hash_t;
+
+
+/* LRU cache data structure */
+typedef struct ucs_lru {
+    /* Hash table of addresses as keys */
+    ucs_lru_hash_t  hash;
+    /* Linked list ordered by most recently accessed */
+    ucs_list_link_t list;
+    /* Number of elements currently in cache */
+    size_t          capacity;
+} ucs_lru_t;
+
+
+typedef struct ucs_lru *ucs_lru_h;
+
+
+/**
+ * @brief Create a new LRU cache object.
+ *
+ * @param [in]    capacity  Cache capacity.
+ * @param [inout] lru_p     Pointer to the allocated LRU struct. Filled with the
+ *                          LRU handle.
+ *
+ * @return UCS_OK if successful, or an error code as defined by
+ * @ref ucs_status_t otherwise.
+ */
+ucs_status_t ucs_lru_create(size_t capacity, ucs_lru_h *lru_p);
+
+
+/**
+ * @brief Destroys an LRU cache object.
+ *
+ * @param [in] lru  Handle to the LRU cache.
+ */
+void ucs_lru_destroy(ucs_lru_h lru);
+
+
+static UCS_F_ALWAYS_INLINE void ucs_lru_pop(ucs_lru_h lru)
+{
+    ucs_lru_element_t *tail;
+    khint_t iter;
+
+    tail = ucs_list_tail(&lru->list, ucs_lru_element_t, list);
+    iter = kh_get(ucs_lru_hash, &lru->hash, (uint64_t)tail->key);
+
+    ucs_list_del(&tail->list);
+    kh_del(ucs_lru_hash, &lru->hash, iter);
+}
+
+
+/**
+ * @brief Insert or update an element in the cache.
+ *
+ * @param [in] lru  Handle to the LRU cache.
+ * @param [in] key  Element's key.
+ *
+ */
+static UCS_F_ALWAYS_INLINE void ucs_lru_put(ucs_lru_h lru, void *key)
+{
+    khint_t iter;
+    int ret;
+    ucs_lru_element_t *elem;
+
+    iter = kh_put(ucs_lru_hash, &lru->hash, (uint64_t)key, &ret);
+    ucs_assert(ret != UCS_KH_PUT_FAILED);
+
+    elem      = &kh_val(&lru->hash, iter);
+    elem->key = key;
+
+    if (ucs_likely(ret == UCS_KH_PUT_KEY_PRESENT)) {
+        ucs_list_del(&elem->list);
+    } else if (kh_size(&lru->hash) > lru->capacity) {
+        ucs_lru_pop(lru);
+    }
+
+    ucs_list_add_head(&lru->list, &elem->list);
+}
+
+
+static UCS_F_ALWAYS_INLINE void **ucs_lru_next_key(ucs_list_link_t *elem)
+{
+    return &ucs_container_of(elem->next, ucs_lru_element_t, list)->key;
+}
+
+
+/**
+ * Iterate over elements of the LRU.
+ *
+ * @param [in] _elem  Pointer to the current key (void**).
+ * @param [in] _lru   Handle to the LRU cache.
+ */
+#define ucs_lru_for_each(_elem, _lru) \
+    for (_elem = ucs_lru_next_key(&(_lru)->list); \
+         &ucs_container_of((_elem), ucs_lru_element_t, key)->list != \
+         &(_lru)->list; \
+         _elem = ucs_lru_next_key( \
+                 &ucs_container_of((_elem), ucs_lru_element_t, key)->list))
+
+#endif

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -167,6 +167,7 @@ gtest_SOURCES = \
 	ucs/test_datatype.cc \
 	ucs/test_bitops.cc \
 	ucs/test_debug.cc \
+        ucs/test_lru.cc \
 	ucs/test_memtrack.cc \
 	ucs/test_math.cc \
 	ucs/test_mpmc.cc \

--- a/test/gtest/ucs/test_lru.cc
+++ b/test/gtest/ucs/test_lru.cc
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include "ucs/datastruct/lru.h"
+}
+
+class test_lru : public ucs::test {
+protected:
+    virtual void init()
+    {
+        ucs::test::init();
+        ASSERT_UCS_OK(ucs_lru_create(m_capacity, &m_lru));
+    }
+
+    virtual void cleanup()
+    {
+        ucs_lru_destroy(m_lru);
+        ucs::test::cleanup();
+    }
+
+    void run(std::vector<int> &elements)
+    {
+        for (size_t i = 0; i < m_capacity * 10; ++i) {
+            ucs_lru_put(m_lru, &elements[i % elements.size()]);
+        }
+
+        int elem_index = 0;
+        void **item;
+
+        ucs_lru_for_each(item, m_lru) {
+            EXPECT_EQ((int*)*item,
+                      &elements[elements.size() - 1 - elem_index]);
+            elem_index++;
+        }
+
+        size_t capacity  = m_capacity;
+        int result_count = std::min(capacity, elements.size());
+        EXPECT_EQ(elem_index, result_count);
+    }
+
+    static constexpr size_t m_capacity = 10;
+    ucs_lru_h               m_lru      = NULL;
+};
+
+UCS_TEST_F(test_lru, full_capacity) {
+    std::vector<int> elements(m_capacity * 2);
+    run(elements);
+}
+
+UCS_TEST_F(test_lru, partial_capacity) {
+    std::vector<int> elements(m_capacity / 2);
+    run(elements);
+}
+
+UCS_TEST_F(test_lru, combined) {
+    std::vector<int> elements1(m_capacity);
+    run(elements1);
+
+    std::vector<int> elements2(m_capacity);
+    run(elements2);
+}


### PR DESCRIPTION
## What
Added LRU cache infrastructure.

## Why ?
Satisfy various LRU needs in the system (for example, will be used for RCDC selection).