### PR TITLE
UCP/LOG: Fix printing protov2 lanes information

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3141,6 +3141,11 @@ static void ucp_ep_config_print(FILE *stream, ucp_worker_h worker,
         }
         fprintf(stream, "#                 %s\n", ucs_string_buffer_cstr(&strb));
     }
+
+    if (worker->context->config.ext.proto_enable) {
+        return;
+    }
+
     fprintf(stream, "#\n");
 
     if (context->config.features & UCP_FEATURE_TAG) {
@@ -3246,7 +3251,7 @@ static void ucp_ep_print_info_internal(ucp_ep_h ep, const char *name,
     if (worker->context->config.ext.proto_enable) {
         ucs_string_buffer_init(&strb);
         ucp_proto_select_info(worker, ep->cfg_index, UCP_WORKER_CFG_INDEX_NULL,
-                              &config->proto_select, &strb);
+                              &config->proto_select, 1, &strb);
         ucs_string_buffer_dump(&strb, "# ", stream);
         ucs_string_buffer_cleanup(&strb);
     }

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -1174,5 +1174,5 @@ void ucp_rkey_proto_select_dump(ucp_worker_h worker,
 
     ucp_proto_select_dump_short(&rkey_config->put_short, "put_short", strb);
     ucp_proto_select_info(worker, rkey_config->key.ep_cfg_index, rkey_cfg_index,
-                          &rkey_config->proto_select, strb);
+                          &rkey_config->proto_select, 0, strb);
 }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2116,9 +2116,9 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
                                         UCP_FEATURE_AM, UCP_OP_ID_AM_SEND,
                                         UCP_PROTO_FLAG_AM_SHORT, key->am_lane,
                                         &ep_config->am_u.max_eager_short);
-    } else {
-        ucp_worker_print_used_tls(worker, ep_cfg_index);
     }
+
+    ucp_worker_print_used_tls(worker, ep_cfg_index);
 
 out:
     *cfg_index_p = ep_cfg_index;

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -687,7 +687,7 @@ void ucp_proto_request_select_error(ucp_request_t *req,
 
     ucp_proto_select_param_str(sel_param, ucp_operation_names, &sel_param_strb);
     ucp_proto_select_info(ep->worker, ep->cfg_index, rkey_cfg_index,
-                          proto_select, &proto_select_strb);
+                          proto_select, 1, &proto_select_strb);
     ucs_fatal("req %p on ep %p to %s: could not find a protocol for %s "
               "length %zu\navailable protocols:\n%s\n",
               req, ep, ucp_ep_peer_name(ep),

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -203,7 +203,7 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
                            ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
                            const ucp_proto_select_param_t *select_param,
-                           ucp_proto_select_elem_t *select_elem,
+                           ucp_proto_select_elem_t *select_elem, int show_all,
                            ucs_string_buffer_t *strb)
 {
     UCS_STRING_BUFFER_ONSTACK(ep_cfg_strb, UCP_PROTO_CONFIG_STR_MAX);
@@ -219,7 +219,8 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
     ucp_proto_select_param_dump(worker, ep_cfg_index, rkey_cfg_index,
                                 select_param, ucp_operation_descs, &ep_cfg_strb,
                                 &sel_param_strb);
-    if (!ucp_proto_debug_is_info_enabled(
+    if (!show_all &&
+        !ucp_proto_debug_is_info_enabled(
                 worker->context, ucs_string_buffer_cstr(&sel_param_strb))) {
         return;
     }
@@ -286,7 +287,7 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
 void ucp_proto_select_info(ucp_worker_h worker,
                            ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
-                           const ucp_proto_select_t *proto_select,
+                           const ucp_proto_select_t *proto_select, int show_all,
                            ucs_string_buffer_t *strb)
 {
     ucp_proto_select_elem_t select_elem;
@@ -294,7 +295,8 @@ void ucp_proto_select_info(ucp_worker_h worker,
 
     kh_foreach(&proto_select->hash, key.u64, select_elem,
                ucp_proto_select_elem_info(worker, ep_cfg_index, rkey_cfg_index,
-                                          &key.param, &select_elem, strb);
+                                          &key.param, &select_elem, show_all,
+                                          strb);
                ucs_string_buffer_appendf(strb, "\n"))
 }
 
@@ -1006,7 +1008,7 @@ void ucp_proto_select_elem_trace(ucp_worker_h worker,
 
     /* Print human-readable protocol selection table to the log */
     ucp_proto_select_elem_info(worker, ep_cfg_index, rkey_cfg_index,
-                               select_param, select_elem, &strb);
+                               select_param, select_elem, 0, &strb);
     ucs_string_buffer_for_each_token(line, &strb, "\n") {
         ucs_log_print_compact(line);
     }

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -66,7 +66,7 @@ void ucp_proto_select_init_trace_caps(
 void ucp_proto_select_info(ucp_worker_h worker,
                            ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
-                           const ucp_proto_select_t *proto_select,
+                           const ucp_proto_select_t *proto_select, int show_all,
                            ucs_string_buffer_t *strb);
 
 


### PR DESCRIPTION
## Why
Adjust information printing after enabling protov2 by default

## How
- Print lanes configuration with UCX_LOG_LEVEL=info
- Don't print protov1 thresholds
- Print protov2 info by `ucx_info -u t -e` command