### PR TITLE
UCP/RNDV: Fix "rndv through am" thresholds definition

### DIFF
--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -55,6 +55,10 @@ ucp_datatype_iter_set_iov_memh(ucp_datatype_iter_t *dt_iter, ucp_mem_h memh)
     size_t iov_index;
     ucs_status_t status;
 
+    if (iov_count == 0) {
+        return UCS_OK;
+    }
+
     status = ucp_datatype_iter_iov_allocate_memh(dt_iter, iov_count);
     if (status != UCS_OK) {
         return status;
@@ -78,7 +82,7 @@ ucs_status_t ucp_datatype_iter_iov_mem_reg(ucp_context_h context,
     ucs_status_t status;
     size_t iov_index;
 
-    if (md_map == 0) {
+    if ((md_map == 0) || (iov_count == 0)) {
         return UCS_OK;
     }
 

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -11,6 +11,21 @@
 #include "proto_rndv.inl"
 
 
+static size_t
+ucp_rndv_am_cfg_thresh(ucp_context_t *context, size_t am_thresh)
+{
+    size_t cfg_thresh = ucp_proto_rndv_cfg_thresh(context,
+                                                  UCS_BIT(UCP_RNDV_MODE_AM));
+
+    if (cfg_thresh == UCS_MEMUNITS_AUTO) {
+        cfg_thresh = am_thresh;
+    } else if (cfg_thresh != UCS_MEMUNITS_INF) {
+        cfg_thresh = ucs_max(cfg_thresh, am_thresh);
+    }
+
+    return cfg_thresh;
+}
+
 static ucs_status_t
 ucp_proto_rndv_am_init_common(ucp_proto_multi_init_params_t *params)
 {
@@ -104,7 +119,8 @@ ucp_proto_rndv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
-        .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_thresh    = ucp_rndv_am_cfg_thresh(context,
+                                                      context->config.ext.bcopy_thresh),
         .super.cfg_priority  = 20,
         .super.min_iov       = 0,
         .super.min_frag_offs = UCP_PROTO_COMMON_OFFSET_INVALID,
@@ -180,7 +196,8 @@ ucp_rndv_am_zcopy_proto_init(const ucp_proto_init_params_t *init_params)
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
-        .super.cfg_thresh    = context->config.ext.zcopy_thresh,
+        .super.cfg_thresh    = ucp_rndv_am_cfg_thresh(context,
+                                                      context->config.ext.zcopy_thresh),
         .super.cfg_priority  = 30,
         .super.min_iov       = 1,
         .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t, cap.am.min_zcopy),

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -27,6 +27,8 @@ public:
         VARIANT_ERR_HANDLING,
         VARIANT_RNDV_PUT_ZCOPY,
         VARIANT_RNDV_GET_ZCOPY,
+        VARIANT_RNDV_AM_BCOPY,
+        VARIANT_RNDV_AM_ZCOPY,
         VARIANT_SEND_NBR,
         VARIANT_PROTO_V1
     };
@@ -54,6 +56,12 @@ public:
             modify_config("RNDV_SCHEME", "put_zcopy");
         } else if (get_variant_value() == VARIANT_RNDV_GET_ZCOPY) {
             modify_config("RNDV_SCHEME", "get_zcopy");
+        } else if (get_variant_value() == VARIANT_RNDV_AM_BCOPY) {
+            modify_config("RNDV_SCHEME", "am");
+            modify_config("ZCOPY_THRESH", "inf");
+        } else if (get_variant_value() == VARIANT_RNDV_AM_ZCOPY) {
+            modify_config("RNDV_SCHEME", "am");
+            modify_config("ZCOPY_THRESH", "0");
         } else if (get_variant_value() == VARIANT_PROTO_V1) {
             modify_config("PROTO_ENABLE", "n");
         }
@@ -83,6 +91,10 @@ public:
                                VARIANT_RNDV_PUT_ZCOPY, "rndv_put_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_RNDV_GET_ZCOPY, "rndv_get_zcopy");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_RNDV_AM_BCOPY, "rndv_am_bcopy");
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_RNDV_AM_ZCOPY, "rndv_am_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_SEND_NBR, "send_nbr");
         add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO_V1,


### PR DESCRIPTION
## What
Allows to define RNDV/AM scheme via RNDV_SCHEME control and applies this new option to protocols. 

## Why ?
Now RNDV/AM protos can be chosen even if RNDV_SCHEME is defined to different value.