### PR TITLE
UCT/IB: Unify md operation and partial cleanup

### DIFF
--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -602,7 +602,7 @@ ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,
 int uct_md_is_sockaddr_accessible(uct_md_h md, const ucs_sock_addr_t *sockaddr,
                                   uct_sockaddr_accessibility_t mode)
 {
-    return md->ops->is_sockaddr_accessible(md, sockaddr, mode);
+    return 0; /* Retained for API backward compatibility */
 }
 
 ucs_status_t uct_md_detect_memory_type(uct_md_h md, const void *addr, size_t length,

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -151,7 +151,6 @@ struct uct_md_ops {
     uct_md_mem_query_func_t              mem_query;
     uct_md_mkey_pack_func_t              mkey_pack;
     uct_md_mem_attach_func_t             mem_attach;
-    uct_md_is_sockaddr_accessible_func_t is_sockaddr_accessible;
     uct_md_detect_memory_type_func_t     detect_memory_type;
 };
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -556,17 +556,16 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_md_detect_memory_type,
 }
 
 static uct_md_ops_t md_ops = {
-    .close                  = uct_cuda_copy_md_close,
-    .query                  = uct_cuda_copy_md_query,
-    .mem_alloc              = uct_cuda_copy_mem_alloc,
-    .mem_free               = uct_cuda_copy_mem_free,
-    .mkey_pack              = uct_cuda_copy_mkey_pack,
-    .mem_reg                = uct_cuda_copy_mem_reg,
-    .mem_dereg              = uct_cuda_copy_mem_dereg,
-    .mem_attach             = ucs_empty_function_return_unsupported,
-    .mem_query              = uct_cuda_copy_md_mem_query,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = uct_cuda_copy_md_detect_memory_type
+    .close              = uct_cuda_copy_md_close,
+    .query              = uct_cuda_copy_md_query,
+    .mem_alloc          = uct_cuda_copy_mem_alloc,
+    .mem_free           = uct_cuda_copy_mem_free,
+    .mkey_pack          = uct_cuda_copy_mkey_pack,
+    .mem_reg            = uct_cuda_copy_mem_reg,
+    .mem_dereg          = uct_cuda_copy_mem_dereg,
+    .mem_attach         = ucs_empty_function_return_unsupported,
+    .mem_query          = uct_cuda_copy_md_mem_query,
+    .detect_memory_type = uct_cuda_copy_md_detect_memory_type
 };
 
 static ucs_status_t

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -31,7 +31,7 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
 static ucs_status_t
 uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags                  = UCT_MD_FLAG_REG | 
+    md_attr->flags                  = UCT_MD_FLAG_REG |
                                       UCT_MD_FLAG_NEED_RKEY |
                                       UCT_MD_FLAG_INVALIDATE |
                                       UCT_MD_FLAG_INVALIDATE_RMA |
@@ -304,14 +304,13 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
                      const uct_md_config_t *config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close                  = uct_cuda_ipc_md_close,
-        .query                  = uct_cuda_ipc_md_query,
-        .mkey_pack              = uct_cuda_ipc_mkey_pack,
-        .mem_reg                = uct_cuda_ipc_mem_reg,
-        .mem_dereg              = uct_cuda_ipc_mem_dereg,
-        .mem_attach             = ucs_empty_function_return_unsupported,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-        .detect_memory_type     = ucs_empty_function_return_unsupported
+        .close              = uct_cuda_ipc_md_close,
+        .query              = uct_cuda_ipc_md_query,
+        .mkey_pack          = uct_cuda_ipc_mkey_pack,
+        .mem_reg            = uct_cuda_ipc_mem_reg,
+        .mem_dereg          = uct_cuda_ipc_mem_dereg,
+        .mem_attach         = ucs_empty_function_return_unsupported,
+        .detect_memory_type = ucs_empty_function_return_unsupported
     };
 
     int num_devices;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -273,14 +273,13 @@ static void uct_gdr_copy_md_close(uct_md_h uct_md)
 }
 
 static uct_md_ops_t md_ops = {
-    .close                  = uct_gdr_copy_md_close,
-    .query                  = uct_gdr_copy_md_query,
-    .mkey_pack              = uct_gdr_copy_mkey_pack,
-    .mem_reg                = uct_gdr_copy_mem_reg,
-    .mem_dereg              = uct_gdr_copy_mem_dereg,
-    .mem_attach             = ucs_empty_function_return_unsupported,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = ucs_empty_function_return_unsupported
+    .close              = uct_gdr_copy_md_close,
+    .query              = uct_gdr_copy_md_query,
+    .mkey_pack          = uct_gdr_copy_mkey_pack,
+    .mem_reg            = uct_gdr_copy_mem_reg,
+    .mem_dereg          = uct_gdr_copy_mem_dereg,
+    .mem_attach         = ucs_empty_function_return_unsupported,
+    .detect_memory_type = ucs_empty_function_return_unsupported
 };
 
 static inline uct_gdr_copy_rcache_region_t*

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -138,7 +138,6 @@ typedef struct uct_ib_md {
     struct ibv_pd            *pd;       /**< IB memory domain */
     uct_ib_device_t          dev;       /**< IB device */
     ucs_linear_func_t        reg_cost;  /**< Memory registration cost */
-    struct uct_ib_md_ops     *ops;
     UCS_STATS_NODE_DECLARE(stats)
     uct_ib_md_ext_config_t   config;    /* IB external configuration */
     struct {
@@ -210,13 +209,6 @@ typedef struct uct_ib_md_config {
 typedef ucs_status_t (*uct_ib_md_open_func_t)(struct ibv_device *ibv_device,
                                               const uct_ib_md_config_t *md_config,
                                               struct uct_ib_md **md_p);
-
-/**
- * Memory domain destructor.
- *
- * @param [in]  md      Memory domain.
- */
-typedef void (*uct_ib_md_cleanup_func_t)(struct uct_ib_md *);
 
 /**
  * Memory domain method to register memory area.
@@ -367,27 +359,9 @@ typedef ucs_status_t (*uct_ib_md_reg_exported_key_func_t)(
         uct_ib_md_t *ib_md, uct_ib_mem_t *ib_memh);
 
 
-/**
- * Memory domain method to register crossing mkey for memory area.
- *
- * @param [in]  ib_md          Memory domain.
- * @param [in]  flags          UCT memory attach flags.
- * @param [in]  target_vhca_id Target vHCA ID.
- * @param [in]  target_mkey    Target mkey this mkey refers to.
- * @param [out] ib_memh        Memory region handle.
- *                             Method should initialize lkey and rkey.
- *
- * @return UCS_OK on success or error code in case of failure.
- */
-typedef ucs_status_t (*uct_ib_md_import_key_func_t)(
-        uct_ib_md_t *ib_md, uint64_t flags,
-        const uct_ib_uint128_t *target_vhca_id, uint32_t target_mkey,
-        uct_ib_mem_t *ib_memh);
-
-
 typedef struct uct_ib_md_ops {
+    uct_md_ops_t                         super;
     uct_ib_md_open_func_t                open;
-    uct_ib_md_cleanup_func_t             cleanup;
     uct_ib_md_reg_key_func_t             reg_key;
     uct_ib_md_reg_indirect_key_func_t    reg_indirect_key;
     uct_ib_md_dereg_key_func_t           dereg_key;
@@ -397,7 +371,6 @@ typedef struct uct_ib_md_ops {
     uct_ib_md_dereg_multithreaded_func_t dereg_multithreaded;
     uct_ib_md_get_atomic_mr_id_func_t    get_atomic_mr_id;
     uct_ib_md_reg_exported_key_func_t    reg_exported_key;
-    uct_ib_md_import_key_func_t          import_exported_key;
 } uct_ib_md_ops_t;
 
 
@@ -428,24 +401,6 @@ extern uct_component_t uct_ib_component;
 static UCS_F_ALWAYS_INLINE uint32_t uct_ib_md_direct_rkey(uct_rkey_t uct_rkey)
 {
     return (uint32_t)uct_rkey;
-}
-
-
-static UCS_F_ALWAYS_INLINE uint32_t
-uct_ib_md_lkey(const void *exported_mkey_buffer)
-{
-    const uct_ib_md_packed_mkey_t *mkey =
-            (const uct_ib_md_packed_mkey_t*)exported_mkey_buffer;
-    return mkey->lkey;
-}
-
-
-static UCS_F_ALWAYS_INLINE const uct_ib_uint128_t*
-uct_ib_md_vhca_id(const void *exported_mkey_buffer)
-{
-    const uct_ib_md_packed_mkey_t *mkey =
-            (const uct_ib_md_packed_mkey_t*)exported_mkey_buffer;
-    return &mkey->vhca_id;
 }
 
 
@@ -584,6 +539,10 @@ uct_ib_md_mem_dereg_params_invalidate_check(
             md->cap_flags & UCT_MD_FLAG_INVALIDATE_AMO);
 }
 
+static UCS_F_ALWAYS_INLINE const uct_ib_md_ops_t *uct_ib_md_ops(uct_ib_md_t *md)
+{
+    return ucs_derived_of(md->super.ops, uct_ib_md_ops_t);
+}
 
 static UCS_F_ALWAYS_INLINE int
 uct_ib_md_is_flush_rkey_valid(uint32_t flush_rkey) {
@@ -597,6 +556,24 @@ ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
 void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                    const uct_ib_md_config_t *md_config,
                                    int is_supported);
+
+ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr);
+
+ucs_status_t uct_ib_mem_reg(uct_md_h uct_md, void *address, size_t length,
+                            const uct_md_mem_reg_params_t *params,
+                            uct_mem_h *memh_p);
+
+ucs_status_t
+uct_ib_mem_dereg(uct_md_h uct_md, const uct_md_mem_dereg_params_t *params);
+
+ucs_status_t uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
+                               size_t length, unsigned advice);
+
+ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
+                              const uct_md_mkey_pack_params_t *params,
+                              void *mkey_buffer);
+
+uct_ib_mem_t *uct_ib_memh_alloc(uct_ib_md_t *md, uint32_t flags);
 
 int uct_ib_device_is_accessible(struct ibv_device *device);
 
@@ -614,9 +591,7 @@ uct_ib_md_t* uct_ib_md_alloc(size_t size, const char *name,
 
 void uct_ib_md_free(uct_ib_md_t *md);
 
-void uct_ib_md_close(uct_md_h uct_md);
-
-void uct_ib_md_cleanup(uct_ib_md_t *md);
+void uct_ib_md_close(uct_md_h tl_md);
 
 ucs_status_t uct_ib_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
                            uint64_t access, int dmabuf_fd, size_t dmabuf_offset,

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -589,7 +589,7 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
     rc_addr->super.flags = 0;
     uct_ib_pack_uint24(rc_addr->super.qp_num, ep->qp->qp_num);
 
-    if (md->ops->get_atomic_mr_id(md, &mr_id) == UCS_OK) {
+    if (uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id) == UCS_OK) {
         ucs_assertv(uct_ib_md_is_flush_rkey_valid(md->flush_rkey),
                     "invalid flush_rkey %x for device %s", md->flush_rkey,
                     uct_ib_device_name(&md->dev));

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -230,9 +230,10 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->latency.m += 1e-9;  /* 1 ns per each extra QP */
     iface_attr->overhead   = 75e-9; /* Software overhead */
 
-    iface_attr->ep_addr_len = (md->ops->get_atomic_mr_id(md, &mr_id) == UCS_OK) ?
-                              sizeof(uct_rc_verbs_ep_flush_addr_t) :
-                              sizeof(uct_rc_verbs_ep_addr_t);
+    iface_attr->ep_addr_len =
+            (uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id) == UCS_OK) ?
+                    sizeof(uct_rc_verbs_ep_flush_addr_t) :
+                    sizeof(uct_rc_verbs_ep_addr_t);
 
     return UCS_OK;
 }

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -282,17 +282,16 @@ static ucs_status_t uct_rocm_copy_mem_free(uct_md_h md, uct_mem_h memh)
 }
 
 static uct_md_ops_t md_ops = {
-    .close                  = uct_rocm_copy_md_close,
-    .query                  = uct_rocm_copy_md_query,
-    .mkey_pack              = uct_rocm_copy_mkey_pack,
-    .mem_alloc              = uct_rocm_copy_mem_alloc,
-    .mem_free               = uct_rocm_copy_mem_free,
-    .mem_reg                = uct_rocm_copy_mem_reg,
-    .mem_dereg              = uct_rocm_copy_mem_dereg,
-    .mem_attach             = ucs_empty_function_return_unsupported,
-    .mem_query              = uct_rocm_base_mem_query,
-    .detect_memory_type     = uct_rocm_base_detect_memory_type,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+    .close              = uct_rocm_copy_md_close,
+    .query              = uct_rocm_copy_md_query,
+    .mkey_pack          = uct_rocm_copy_mkey_pack,
+    .mem_alloc          = uct_rocm_copy_mem_alloc,
+    .mem_free           = uct_rocm_copy_mem_free,
+    .mem_reg            = uct_rocm_copy_mem_reg,
+    .mem_dereg          = uct_rocm_copy_mem_dereg,
+    .mem_attach         = ucs_empty_function_return_unsupported,
+    .mem_query          = uct_rocm_base_mem_query,
+    .detect_memory_type = uct_rocm_base_detect_memory_type,
 };
 
 static inline uct_rocm_copy_rcache_region_t*
@@ -340,17 +339,16 @@ uct_rocm_copy_mem_rcache_dereg(uct_md_h uct_md,
 }
 
 static uct_md_ops_t md_rcache_ops = {
-    .close                  = uct_rocm_copy_md_close,
-    .query                  = uct_rocm_copy_md_query,
-    .mem_alloc              = uct_rocm_copy_mem_alloc,
-    .mem_free               = uct_rocm_copy_mem_free,
-    .mkey_pack              = uct_rocm_copy_mkey_pack,
-    .mem_reg                = uct_rocm_copy_mem_rcache_reg,
-    .mem_dereg              = uct_rocm_copy_mem_rcache_dereg,
-    .mem_attach             = ucs_empty_function_return_unsupported,
-    .mem_query              = uct_rocm_base_mem_query,
-    .detect_memory_type     = uct_rocm_base_detect_memory_type,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+    .close              = uct_rocm_copy_md_close,
+    .query              = uct_rocm_copy_md_query,
+    .mem_alloc          = uct_rocm_copy_mem_alloc,
+    .mem_free           = uct_rocm_copy_mem_free,
+    .mkey_pack          = uct_rocm_copy_mkey_pack,
+    .mem_reg            = uct_rocm_copy_mem_rcache_reg,
+    .mem_dereg          = uct_rocm_copy_mem_rcache_dereg,
+    .mem_attach         = ucs_empty_function_return_unsupported,
+    .mem_query          = uct_rocm_base_mem_query,
+    .detect_memory_type = uct_rocm_base_detect_memory_type,
 };
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -129,15 +129,14 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
                      const uct_md_config_t *uct_md_config, uct_md_h *md_p)
 {
     static uct_md_ops_t md_ops = {
-        .close                  = (uct_md_close_func_t)ucs_empty_function,
-        .query                  = uct_rocm_ipc_md_query,
-        .mkey_pack              = uct_rocm_ipc_mkey_pack,
-        .mem_reg                = uct_rocm_ipc_mem_reg,
-        .mem_dereg              = uct_rocm_ipc_mem_dereg,
-        .mem_attach             = ucs_empty_function_return_unsupported,
-        .mem_query              = ucs_empty_function_return_unsupported,
-        .detect_memory_type     = ucs_empty_function_return_unsupported,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
+        .close              = (uct_md_close_func_t)ucs_empty_function,
+        .query              = uct_rocm_ipc_md_query,
+        .mkey_pack          = uct_rocm_ipc_mkey_pack,
+        .mem_reg            = uct_rocm_ipc_mem_reg,
+        .mem_dereg          = uct_rocm_ipc_mem_dereg,
+        .mem_attach         = ucs_empty_function_return_unsupported,
+        .mem_query          = ucs_empty_function_return_unsupported,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     static uct_md_t md = {
         .ops       = &md_ops,

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -698,17 +698,16 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_posix_rkey_release,(component, rkey, handle),
 
 static uct_mm_md_mapper_ops_t uct_posix_md_ops = {
     .super = {
-        .close                  = uct_mm_md_close,
-        .query                  = uct_posix_md_query,
-        .mem_alloc              = uct_posix_mem_alloc,
-        .mem_free               = uct_posix_mem_free,
-        .mem_advise             = ucs_empty_function_return_unsupported,
-        .mem_reg                = ucs_empty_function_return_unsupported,
-        .mem_dereg              = ucs_empty_function_return_unsupported,
-        .mem_attach             = ucs_empty_function_return_unsupported,
-        .mkey_pack              = uct_posix_md_mkey_pack,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-        .detect_memory_type     = ucs_empty_function_return_unsupported
+        .close              = uct_mm_md_close,
+        .query              = uct_posix_md_query,
+        .mem_alloc          = uct_posix_mem_alloc,
+        .mem_free           = uct_posix_mem_free,
+        .mem_advise         = ucs_empty_function_return_unsupported,
+        .mem_reg            = ucs_empty_function_return_unsupported,
+        .mem_dereg          = ucs_empty_function_return_unsupported,
+        .mem_attach         = ucs_empty_function_return_unsupported,
+        .mkey_pack          = uct_posix_md_mkey_pack,
+        .detect_memory_type = ucs_empty_function_return_unsupported
     },
     .query             = uct_posix_query,
     .iface_addr_length = uct_posix_iface_addr_length,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -204,7 +204,6 @@ static uct_mm_md_mapper_ops_t uct_sysv_md_ops = {
         .mem_dereg              = ucs_empty_function_return_unsupported,
         .mem_attach             = ucs_empty_function_return_unsupported,
         .mkey_pack              = uct_sysv_md_mkey_pack,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
         .detect_memory_type     = ucs_empty_function_return_unsupported
     },
     .query             = uct_sysv_query,

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -532,17 +532,16 @@ uct_xpmem_rkey_release(uct_component_t *component, uct_rkey_t rkey, void *handle
 
 static uct_mm_md_mapper_ops_t uct_xpmem_md_ops = {
     .super = {
-        .close                  = uct_mm_md_close,
-        .query                  = uct_xpmem_md_query,
-        .mem_alloc              = ucs_empty_function_return_unsupported,
-        .mem_free               = ucs_empty_function_return_unsupported,
-        .mem_advise             = ucs_empty_function_return_unsupported,
-        .mem_reg                = uct_xmpem_mem_reg,
-        .mem_dereg              = uct_xmpem_mem_dereg,
-        .mem_attach             = ucs_empty_function_return_unsupported,
-        .mkey_pack              = uct_xpmem_mkey_pack,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-        .detect_memory_type     = ucs_empty_function_return_unsupported
+        .close              = uct_mm_md_close,
+        .query              = uct_xpmem_md_query,
+        .mem_alloc          = ucs_empty_function_return_unsupported,
+        .mem_free           = ucs_empty_function_return_unsupported,
+        .mem_advise         = ucs_empty_function_return_unsupported,
+        .mem_reg            = uct_xmpem_mem_reg,
+        .mem_dereg          = uct_xmpem_mem_dereg,
+        .mem_attach         = ucs_empty_function_return_unsupported,
+        .mkey_pack          = uct_xpmem_mkey_pack,
+        .detect_memory_type = ucs_empty_function_return_unsupported
     },
     .query             = uct_xpmem_query,
     .iface_addr_length = uct_xpmem_iface_addr_length,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -184,16 +184,15 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
     const uct_cma_md_config_t *md_config = ucs_derived_of(uct_md_config,
                                                           uct_cma_md_config_t);
     static uct_md_ops_t md_ops = {
-        .close                  = uct_cma_md_close,
-        .query                  = uct_cma_md_query,
-        .mem_alloc              = (uct_md_mem_alloc_func_t)ucs_empty_function_return_success,
-        .mem_free               = (uct_md_mem_free_func_t)ucs_empty_function_return_success,
-        .mkey_pack              = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
-        .mem_reg                = uct_cma_mem_reg,
-        .mem_dereg              = uct_cma_mem_dereg,
-        .mem_attach             = ucs_empty_function_return_unsupported,
-        .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-        .detect_memory_type     = ucs_empty_function_return_unsupported,
+        .close              = uct_cma_md_close,
+        .query              = uct_cma_md_query,
+        .mem_alloc          = (uct_md_mem_alloc_func_t)ucs_empty_function_return_success,
+        .mem_free           = (uct_md_mem_free_func_t)ucs_empty_function_return_success,
+        .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
+        .mem_reg            = uct_cma_mem_reg,
+        .mem_dereg          = uct_cma_mem_dereg,
+        .mem_attach         = ucs_empty_function_return_unsupported,
+        .detect_memory_type = ucs_empty_function_return_unsupported,
     };
     uct_cma_md_t *cma_md;
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -306,9 +306,9 @@ uct_knem_mem_rcache_dereg(uct_md_h uct_md,
 {
     uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
     uct_knem_rcache_region_t *region;
- 
+
     UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(params);
- 
+
     region = uct_knem_rcache_region_from_memh(params->memh);
 
     ucs_rcache_region_put(md->rcache, &region->super);
@@ -316,14 +316,13 @@ uct_knem_mem_rcache_dereg(uct_md_h uct_md,
 }
 
 static uct_md_ops_t uct_knem_md_rcache_ops = {
-    .close                  = uct_knem_md_close,
-    .query                  = uct_knem_md_query,
-    .mkey_pack              = uct_knem_mkey_pack,
-    .mem_reg                = uct_knem_mem_rcache_reg,
-    .mem_dereg              = uct_knem_mem_rcache_dereg,
-    .mem_attach             = ucs_empty_function_return_unsupported,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = ucs_empty_function_return_unsupported,
+    .close              = uct_knem_md_close,
+    .query              = uct_knem_md_query,
+    .mkey_pack          = uct_knem_mkey_pack,
+    .mem_reg            = uct_knem_mem_rcache_reg,
+    .mem_dereg          = uct_knem_mem_rcache_dereg,
+    .mem_attach         = ucs_empty_function_return_unsupported,
+    .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
 

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -361,7 +361,7 @@ public:
         ucs_status_t status;
         uint8_t gid_index;
 
-        UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_ib_md_close, uct_ib_md_open,
+        UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_md_close, uct_md_open,
                                &uct_ib_component,
                                ibv_get_device_name(m_ibctx->device), m_md_config);
 
@@ -414,7 +414,7 @@ public:
         ucs_status_t status;
         ucs::handle<uct_md_h> uct_md;
 
-        UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_ib_md_close, uct_ib_md_open,
+        UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_md_close, uct_md_open,
                                &uct_ib_component,
                                ibv_get_device_name(m_ibctx->device),
                                m_md_config);
@@ -757,7 +757,7 @@ UCS_TEST_F(test_uct_ib_sl_utils, query_ooo_sl_mask) {
             continue;
         }
 
-        status = uct_ib_md_open(&uct_ib_component, dev_name, md_config, &md);
+        status = uct_md_open(&uct_ib_component, dev_name, md_config, &md);
         EXPECT_UCS_OK(status);
         if (status != UCS_OK) {
             goto out_md_config_release;
@@ -784,7 +784,7 @@ UCS_TEST_F(test_uct_ib_sl_utils, query_ooo_sl_mask) {
             ucs_string_buffer_cleanup(&strb);
         }
 
-        uct_ib_md_close(md);
+        uct_md_close(md);
 
 out_md_config_release:
         uct_config_release(md_config);


### PR DESCRIPTION
## Why
- Preparation for removing most of ib_md operations

## How
- Remove unused is_sockaddr_accessible
- Make uct_md_ops_t  the super of uct_ib_md_ops_t, so uct_md_ops_t could be defined for verbs/dv/devx md implementations
- Move gross-gvmi import to devx
- Move cleanup operation to specific md

