### PR TITLE
GTEST: use std=c++17 for compiling hip gtests

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -94,7 +94,11 @@ bool mem_buffer::is_rocm_managed_supported()
         return false;
     }
 
-    hipFree(dptr);
+    ret = hipFree(dptr);
+    if (ret != hipSuccess) {
+        return false;
+    }
+
     return attr.memoryType == hipMemoryTypeUnified;
 #else
     return false;
@@ -142,7 +146,7 @@ void mem_buffer::set_device_context()
 
 #if HAVE_ROCM
     if (is_rocm_supported()) {
-        hipSetDevice(0);
+        ROCM_CALL(hipSetDevice(0));
     }
 #endif
 


### PR DESCRIPTION
## What

hip_runtime.h contains in some rocm releases a C++17 feature. Prior to this commit, we forced using gnu++11 using HIP_CXXFLAGS in UCX, but combined with the `-Werror` flag of UCX this leads now to a compilation error in gtests.

## How

This commits adds the configure logic to check for `-std=c++17`,  and uses this flag instead of `-std=gnu++11` if available. Forcing using the `-std=c++17` flag revealed a second issue regarding ignoring error codes in a gtest routine. 
This commit fixes this issue as well.