### PR TITLE
UCT/CUDA: Don't pass null pointer to logging function

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -10,6 +10,22 @@
 
 #include "cuda_iface.h"
 
+#include <ucs/sys/string.h>
+
+
+const char *uct_cuda_base_cu_get_error_string(CUresult result)
+{
+    static __thread char buf[64];
+    const char *error_str;
+
+    if (cuGetErrorString(result, &error_str) != CUDA_SUCCESS) {
+        ucs_snprintf_safe(buf, sizeof(buf), "unrecognized error code %d",
+                          result);
+        error_str = buf;
+    }
+
+    return error_str;
+}
 
 ucs_status_t
 uct_cuda_base_query_devices_common(

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -99,7 +99,6 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
 static ucs_status_t uct_cuda_ipc_open_memhandle(const uct_cuda_ipc_key_t *key,
                                                 CUdeviceptr *mapped_addr)
 {
-    const char *cu_err_str;
     CUresult cuerr;
     ucs_status_t status;
 
@@ -108,8 +107,8 @@ static ucs_status_t uct_cuda_ipc_open_memhandle(const uct_cuda_ipc_key_t *key,
     if (cuerr == CUDA_SUCCESS) {
         status = UCS_OK;
     } else {
-        cuGetErrorString(cuerr, &cu_err_str);
-        ucs_debug("cuIpcOpenMemHandle() failed: %s", cu_err_str);
+        ucs_debug("cuIpcOpenMemHandle() failed: %s",
+                  uct_cuda_base_cu_get_error_string(cuerr));
         status = (cuerr == CUDA_ERROR_ALREADY_MAPPED) ? UCS_ERR_ALREADY_EXISTS :
                                                         UCS_ERR_INVALID_PARAM;
     }


### PR DESCRIPTION
## What
Make sure that the error string is always non-null.

## Why ?
Crash report #9099.

## How ?
Wrap the call and use similar default string in driver API as done in applicative API.