### PR TITLE
UCP: Restrict unselected lanes during second initialization - v1.15.x

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -543,7 +543,7 @@ void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
 static UCS_F_ALWAYS_INLINE
 double ucp_calc_epsilon(double val1, double val2)
 {
-    return (val1 + val2) * (1e-5);
+    return (val1 + val2) * (1e-6);
 }
 
 /**

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -62,8 +62,8 @@ BEGIN_C_DECLS
     ucs_fatal_error_format(__FILE__, __LINE__, __FUNCTION__, \
                            "Bug: " _fmt, ## __VA_ARGS__)
 
-#define ucs_assert(...)       ucs_assert_always(__VA_ARGS__)
-#define ucs_assertv(...)      ucs_assertv_always(__VA_ARGS__)
+#define ucs_assert  ucs_assert_always
+#define ucs_assertv ucs_assertv_always
 
 #else
 


### PR DESCRIPTION
## What

Backport of #9141 to v1.15.x