### PR TITLE
GTEST: Yield CPU during UCT sockaddr tests

### DIFF
--- a/test/gtest/uct/test_sockaddr.cc
+++ b/test/gtest/uct/test_sockaddr.cc
@@ -620,7 +620,7 @@ protected:
 
         while (((*server_cnt < val) || (*client_cnt < val)) &&
                (ucs_get_time() < deadline)) {
-            progress();
+            progress_mt();
         }
     }
 
@@ -1348,7 +1348,7 @@ UCS_TEST_P(test_uct_sockaddr_stress, many_clients_to_one_server)
                                 ucs::test_time_multiplier();
 
     while ((m_ep_init_disconnect_cnt != 0) && (ucs_get_time() < deadline)) {
-        progress();
+        progress_mt();
     }
     EXPECT_EQ(0, m_ep_init_disconnect_cnt);
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -728,6 +728,15 @@ const uct_test::entity& uct_test::ent(unsigned index) const {
     return m_entities.at(index);
 }
 
+unsigned uct_test::progress_mt() const
+{
+    if (RUNNING_ON_VALGRIND) {
+        sched_yield();
+    }
+
+    return progress();
+}
+
 unsigned uct_test::progress() const {
     unsigned count = 0;
     FOR_EACH_ENTITY(iter) {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -331,7 +331,7 @@ protected:
                               ucs::test_time_multiplier();
         while ((ucs_get_time() < deadline) && (!ucs_test_all_flags(*flag, mask))) {
             /* Don't do short_progress_loop() to avoid extra timings */
-            progress();
+            progress_mt();
         }
     }
 
@@ -393,6 +393,7 @@ protected:
     bool check_atomics(uint64_t required_ops, atomic_mode mode);
     const entity& ent(unsigned index) const;
     unsigned progress() const;
+    unsigned progress_mt() const;
     void flush(ucs_time_t deadline = ULONG_MAX) const;
     virtual void short_progress_loop(double delay_ms = DEFAULT_DELAY_MS,
                                      entity *e = NULL) const;


### PR DESCRIPTION
## What
In the UCT sockaddr code, make sure to yield the CPU when running on valgrind.

## Why ?
Valgrind serializes the OS threads anyways so we need to manually yield them to help in client/server senario involving multiple threads.

On the test subset evaluated, the duration is:
- 69 sec without fix
- 17 sec with the fix

## How ?
Make small independent PRs and run/test them individually through CI as they could cause other issues.

### Tested gain
Parameters: `jazz, SHARD=1/4, --gtest_filter=*tcp/test_uct_sockaddr*`
Without fix:
```
[2023-06-29 15:07:45] [==========] 95 tests from 5 test suites ran. (69270 ms total)
[2023-06-29 15:07:45] [  PASSED  ] 95 tests.
```

With fix:
```
[2023-06-29 15:57:34] [==========] 95 tests from 5 test suites ran. (17316 ms total)
[2023-06-29 15:57:34] [  PASSED  ] 95 tests.
```
