### PR TITLE
TOOLS/PERF: removing allocators and using uct api instead

### DIFF
--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -214,15 +214,6 @@ static void ucx_perf_test_init(ucx_perf_context_t *perf,
                                const ucx_perf_params_t *params)
 {
     perf->params = *params;
-
-    ucs_debug("set send allocator by send mem type %s",
-              ucs_memory_type_names[params->send_mem_type]);
-    perf->send_allocator = ucx_perf_mem_type_allocators[params->send_mem_type];
-
-    ucs_debug("set recv allocator by recv mem type %s",
-              ucs_memory_type_names[params->recv_mem_type]);
-    perf->recv_allocator = ucx_perf_mem_type_allocators[params->recv_mem_type];
-
     ucx_perf_test_prepare_new_run(perf, params);
 }
 
@@ -1752,41 +1743,43 @@ ucs_status_t ucx_perf_run(const ucx_perf_params_t *params,
 
     ucx_perf_test_init(perf, params);
 
-    if ((perf->send_allocator == NULL) || (perf->recv_allocator == NULL)) {
-        ucs_error("Unsupported memory types %s<->%s",
-                  ucs_memory_type_names[params->send_mem_type],
-                  ucs_memory_type_names[params->recv_mem_type]);
-        status = UCS_ERR_UNSUPPORTED;
-        goto out_free;
-    }
+        //TODO: Perf cleanup allocators
 
-    if (params->api == UCX_PERF_API_UCT) {
-        if (perf->send_allocator->mem_type != UCS_MEMORY_TYPE_HOST) {
-            ucs_diag("UCT tests also copy one-byte value from %s memory to "
-                     "%s send memory, which may impact performance results",
-                     ucs_memory_type_names[UCS_MEMORY_TYPE_HOST],
-                     ucs_memory_type_names[perf->send_allocator->mem_type]);
-        }
+    // if ((perf->send_allocator == NULL) || (perf->recv_allocator == NULL)) {
+    //     ucs_error("Unsupported memory types %s<->%s",
+    //               ucs_memory_type_names[params->send_mem_type],
+    //               ucs_memory_type_names[params->recv_mem_type]);
+    //     status = UCS_ERR_UNSUPPORTED;
+    //     goto out_free;
+    // }
 
-        if (perf->recv_allocator->mem_type != UCS_MEMORY_TYPE_HOST) {
-            ucs_diag("UCT tests also copy one-byte value from %s recv memory "
-                     "to %s memory, which may impact performance results",
-                     ucs_memory_type_names[perf->recv_allocator->mem_type],
-                     ucs_memory_type_names[UCS_MEMORY_TYPE_HOST]);
-        }
-    }
+    // if (params->api == UCX_PERF_API_UCT) {
+    //     if (perf->send_allocator->mem_type != UCS_MEMORY_TYPE_HOST) {
+    //         ucs_diag("UCT tests also copy one-byte value from %s memory to "
+    //                  "%s send memory, which may impact performance results",
+    //                  ucs_memory_type_names[UCS_MEMORY_TYPE_HOST],
+    //                  ucs_memory_type_names[perf->send_allocator->mem_type]);
+    //     }
 
-    status = perf->send_allocator->init(perf);
-    if (status != UCS_OK) {
-        goto out_free;
-    }
+    //     if (perf->recv_allocator->mem_type != UCS_MEMORY_TYPE_HOST) {
+    //         ucs_diag("UCT tests also copy one-byte value from %s recv memory "
+    //                  "to %s memory, which may impact performance results",
+    //                  ucs_memory_type_names[perf->recv_allocator->mem_type],
+    //                  ucs_memory_type_names[UCS_MEMORY_TYPE_HOST]);
+    //     }
+    // }
 
-    if (perf->send_allocator != perf->recv_allocator) {
-        status = perf->recv_allocator->init(perf);
-        if (status != UCS_OK) {
-            goto out_free;
-        }
-    }
+    // status = perf->send_allocator->init(perf);
+    // if (status != UCS_OK) {
+    //     goto out_free;
+    // }
+
+    // if (perf->send_allocator != perf->recv_allocator) {
+    //     status = perf->recv_allocator->init(perf);
+    //     if (status != UCS_OK) {
+    //         goto out_free;
+    //     }
+    // }
 
     status = ucx_perf_funcs[params->api].setup(perf);
     if (status != UCS_OK) {

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -81,10 +81,6 @@ struct ucx_perf_context {
 
     ucs_time_t                   timing_queue[TIMING_QUEUE_SIZE];
     unsigned                     timing_queue_head;
-
-    const ucx_perf_allocator_t   *send_allocator;
-    const ucx_perf_allocator_t   *recv_allocator;
-
     char                         extra_info[EXTRA_INFO_SIZE];
 
     union {
@@ -164,6 +160,11 @@ void ucx_perf_test_prepare_new_run(ucx_perf_context_t *perf,
                                    const ucx_perf_params_t *params);
 ucs_status_t
 ucx_perf_do_warmup(ucx_perf_context_t *perf, const ucx_perf_params_t *params);
+
+ucs_status_t uct_perf_test_memcpy(ucx_perf_context_t *perf, void *dst,
+                                  ucs_memory_type_t dst_mem_type,
+                                  const void *src,
+                                  ucs_memory_type_t src_mem_type, size_t size);
 
 /**
  * Get the total length of the message size given by parameters

--- a/src/tools/perf/lib/libperf_memory.c
+++ b/src/tools/perf/lib/libperf_memory.c
@@ -303,6 +303,9 @@ ucs_status_t uct_perf_test_memcpy(ucx_perf_context_t *perf, void *dst,
         memcpy(dst, src, size);
         return UCS_OK;
     }
+
+    ucs_error("BAD MEMCPY!");
+
     return UCS_ERR_NO_MEMORY;
 
 

--- a/src/tools/perf/lib/libperf_memory.c
+++ b/src/tools/perf/lib/libperf_memory.c
@@ -209,33 +209,6 @@ static void uct_perf_test_free_host(const ucx_perf_context_t *perf,
 ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf)
 {
     ucx_perf_params_t *params          = &perf->params;
-    uint64_t alloc_field_mask          = UCT_MEM_ALLOC_PARAM_FIELD_FLAGS |
-                                         UCT_MEM_ALLOC_PARAM_FIELD_ADDRESS |
-                                         UCT_MEM_ALLOC_PARAM_FIELD_MEM_TYPE |
-                                         UCT_MEM_ALLOC_PARAM_FIELD_MDS |
-                                         UCT_MEM_ALLOC_PARAM_FIELD_NAME;
-    uct_mem_alloc_params_t send_params = {
-        .field_mask = alloc_field_mask,
-        .address    = NULL,
-        .mem_type   = params->send_mem_type,
-        .mds        = {.mds   = &perf->uct.md,
-                .count = 1},
-        .name       = "uct_perftest_send"
-    };
-
-    uct_mem_alloc_params_t recv_params = {
-        .field_mask = alloc_field_mask,
-        .address    = NULL,
-        .mem_type   = params->recv_mem_type,
-        .mds        = {.mds   = &perf->uct.md,
-                       .count = 1},
-        .name       = "uct_perftest_recv"
-    };
-    uct_alloc_method_t alloc_methods[5] = {UCT_ALLOC_METHOD_MD,
-                                           UCT_ALLOC_METHOD_HEAP,
-                                           UCT_ALLOC_METHOD_MMAP,
-                                           UCT_ALLOC_METHOD_THP,
-                                           UCT_ALLOC_METHOD_HUGE};
     ucs_status_t status;
     unsigned flags;
     size_t buffer_size;
@@ -255,20 +228,9 @@ ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf)
     flags |= UCT_MD_MEM_ACCESS_RMA;
 
     /* Allocate send buffer memory */
-    if (perf->uct.send_mem.mem_type == UCS_MEMORY_TYPE_HOST) {
-        status = uct_iface_mem_alloc(perf->uct.iface, buffer_size, flags,
-                                     "uct perftest sender",
-                                     &perf->uct.send_mem);
-    } else {
-        status = uct_mem_alloc(buffer_size, alloc_methods, 5, &send_params,
-                               &perf->uct.send_mem);
-
-        if (perf->uct.send_mem.method == UCT_ALLOC_METHOD_MD &&
-            perf->uct.send_mem.memh == UCT_MEM_HANDLE_NULL) {
-            uct_md_mem_reg(perf->uct.md, perf->uct.send_mem.address,
-                           buffer_size, flags, &perf->uct.send_mem.memh);
-        }
-    }
+    status = uct_iface_mem_alloc(perf->uct.iface, buffer_size, flags,
+                                    "uct perftest sender",
+                                    &perf->uct.send_mem);
 
     if (status != UCS_OK) {
         ucs_error("Failed allocate send buffer(%lu) buffer: %s", buffer_size,
@@ -280,21 +242,8 @@ ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf)
 
     /* Allocate receive buffer memory */
 
-    if (perf->uct.recv_mem.mem_type == UCS_MEMORY_TYPE_HOST) {
-        status = uct_iface_mem_alloc(perf->uct.iface, buffer_size, flags,
-                                    "uct perftest sender", &perf->uct.recv_mem);
-    }
-    else {
-        status = uct_mem_alloc(buffer_size, alloc_methods, 5, &recv_params,
-                               &perf->uct.recv_mem);
-
-
-        if (perf->uct.recv_mem.method == UCT_ALLOC_METHOD_MD &&
-            perf->uct.recv_mem.memh == UCT_MEM_HANDLE_NULL) {
-            uct_md_mem_reg(perf->uct.md, perf->uct.recv_mem.address,
-                           buffer_size, flags, &perf->uct.recv_mem.memh);
-        }
-    }
+    status = uct_iface_mem_alloc(perf->uct.iface, buffer_size, flags,
+                                "uct perftest sender", &perf->uct.recv_mem);
 
     if (status != UCS_OK) {
         ucs_error("Failed allocate recv buffer(%lu) buffer: %s", buffer_size,
@@ -341,45 +290,47 @@ ucs_status_t uct_perf_test_memcpy(ucx_perf_context_t *perf, void *dst,
                                   const void *src,
                                   ucs_memory_type_t src_mem_type, size_t size)
 {
-    unsigned group_size             = rte_call(perf, group_size);
-    unsigned group_index            = rte_call(perf, group_index);
-    unsigned peer_index             = rte_peer_index(group_size, group_index);
-    uct_rkey_t rkey                 = perf->uct.peers[peer_index].rkey.rkey;
-    uct_ep_h ep                     = perf->uct.peers[peer_index].ep;
-    ucs_status_t status;
-    void *buffer;
+    // unsigned group_size             = rte_call(perf, group_size);
+    // unsigned group_index            = rte_call(perf, group_index);
+    // unsigned peer_index             = rte_peer_index(group_size, group_index);
+    // uct_rkey_t rkey                 = perf->uct.peers[peer_index].rkey.rkey;
+    // uct_ep_h ep                     = perf->uct.peers[peer_index].ep;
+    // ucs_status_t status;
+    // void *buffer;
 
     if (src_mem_type == UCS_MEMORY_TYPE_HOST &&
         dst_mem_type == UCS_MEMORY_TYPE_HOST) {
         memcpy(dst, src, size);
         return UCS_OK;
     }
+    return UCS_ERR_NO_MEMORY;
+
 
     /* device to host */
-    if (dst_mem_type == UCS_MEMORY_TYPE_HOST) {
-        return uct_ep_get_short(ep, dst, size, (uint64_t)src, rkey);
-    }
+    // if (dst_mem_type == UCS_MEMORY_TYPE_HOST) {
+    //     return uct_ep_get_short(ep, dst, size, (uint64_t)src, rkey);
+    // }
 
-    /* host to device */
-    if (src_mem_type == UCS_MEMORY_TYPE_HOST) {
-        return uct_ep_put_short(ep, src, size, (uint64_t)dst, rkey);
-    }
+    // /* host to device */
+    // if (src_mem_type == UCS_MEMORY_TYPE_HOST) {
+    //     return uct_ep_put_short(ep, src, size, (uint64_t)dst, rkey);
+    // }
 
-    /* device to device TODO: Maybe not necessary at all?*/
-    buffer = malloc(size);
+    // /* device to device TODO: Maybe not necessary at all?*/
+    // buffer = malloc(size);
 
-    if (buffer == NULL) {
-        return UCS_ERR_NO_MEMORY;
-    }
-    status = uct_ep_get_short(ep, buffer, size, (uint64_t)src, rkey);
-    if (status != UCS_OK) {
-        goto err_free_buffer;
-    }
-    return uct_ep_put_short(ep, buffer, size, (uint64_t)dst, rkey);
+//     if (buffer == NULL) {
+//         return UCS_ERR_NO_MEMORY;
+//     }
+//     status = uct_ep_get_short(ep, buffer, size, (uint64_t)src, rkey);
+//     if (status != UCS_OK) {
+//         goto err_free_buffer;
+//     }
+//     return uct_ep_put_short(ep, buffer, size, (uint64_t)dst, rkey);
 
-err_free_buffer:
-    free(buffer);
-    return status;
+// err_free_buffer:
+//     free(buffer);
+//     return status;
 }
 
 void ucx_perf_global_init()

--- a/src/tools/perf/lib/libperf_thread.c
+++ b/src/tools/perf/lib/libperf_thread.c
@@ -30,18 +30,19 @@ static ucs_status_t ucx_perf_thread_run_test(void* arg)
     ucx_perf_params_t* params       = &perf->params;
     ucs_status_t status;
 
+        //TODO: Perf cleanup allocators
     /* new threads need explicit device association */
-    status = perf->send_allocator->init(perf);
-    if (status != UCS_OK) {
-        goto out;
-    }
+    // status = perf->send_allocator->init(perf);
+    // if (status != UCS_OK) {
+    //     goto out;
+    // }
 
-    if (perf->send_allocator != perf->recv_allocator) {
-        status = perf->recv_allocator->init(perf);
-        if (status != UCS_OK) {
-            goto out;
-        }
-    }
+    // if (perf->send_allocator != perf->recv_allocator) {
+    //     status = perf->recv_allocator->init(perf);
+    //     if (status != UCS_OK) {
+    //         goto out;
+    //     }
+    // }
 
     status = ucx_perf_do_warmup(perf, params);
     if (UCS_OK != status) {

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -375,24 +375,23 @@ public:
         if (mem_type == UCS_MEMORY_TYPE_HOST) {
             return *(const volatile psn_t*)ptr;
         } else {
-            m_perf.recv_allocator->memcpy(&sn, UCS_MEMORY_TYPE_HOST, ptr,
-                                          mem_type, sizeof(sn));
+            uct_perf_test_memcpy(&m_perf, &sn, UCS_MEMORY_TYPE_HOST, ptr,
+                                 mem_type, sizeof(sn));
             return sn;
         }
     }
 
     UCS_F_ALWAYS_INLINE void
     write_sn(void *buffer, ucs_memory_type_t mem_type,
-             size_t length, psn_t sn,
-             const ucx_perf_allocator_t *allocator)
+             size_t length, psn_t sn)
     {
         void *ptr = sn_ptr(buffer, length);
 
         if (mem_type == UCS_MEMORY_TYPE_HOST) {
             *(volatile psn_t*)ptr = sn;
         } else {
-            allocator->memcpy(ptr, mem_type, &sn, UCS_MEMORY_TYPE_HOST,
-                              sizeof(sn));
+            uct_perf_test_memcpy(&m_perf, ptr, mem_type, &sn,
+                                 UCS_MEMORY_TYPE_HOST, sizeof(sn));
         }
     }
 
@@ -428,8 +427,7 @@ public:
             switch (TYPE) {
             case UCX_PERF_TEST_TYPE_PINGPONG:
             case UCX_PERF_TEST_TYPE_PINGPONG_WAIT_MEM:
-                write_sn(buffer, m_perf.params.send_mem_type, length, sn,
-                         m_perf.send_allocator);
+                write_sn(buffer, m_perf.params.send_mem_type, length, sn);
                 break;
             case UCX_PERF_TEST_TYPE_STREAM_UNI:
                 break;
@@ -567,12 +565,10 @@ public:
         /* Make sure that doing the last opetarion will write 1 to the end of
            the remote buffer */
         if (CMD == UCX_PERF_CMD_PUT) {
-            write_sn(buffer, m_perf.params.send_mem_type, size, LAST_ITER_SN,
-                     m_perf.send_allocator);
+            write_sn(buffer, m_perf.params.send_mem_type, size, LAST_ITER_SN);
         } else if (is_atomic()) {
             atomic_value = 0;
-            write_sn(&atomic_value, UCS_MEMORY_TYPE_HOST, size, LAST_ITER_SN,
-                     NULL);
+            write_sn(&atomic_value, UCS_MEMORY_TYPE_HOST, size, LAST_ITER_SN);
             atomic_param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
                                         UCP_OP_ATTR_FIELD_CALLBACK |
                                         UCP_OP_ATTR_FIELD_USER_DATA;
@@ -649,10 +645,8 @@ public:
             return;
         }
 
-        write_sn(m_perf.send_buffer, m_perf.params.send_mem_type, length, sn,
-                 m_perf.send_allocator);
-        write_sn(m_perf.recv_buffer, m_perf.params.recv_mem_type, length, sn,
-                 m_perf.recv_allocator);
+        write_sn(m_perf.send_buffer, m_perf.params.send_mem_type, length, sn);
+        write_sn(m_perf.recv_buffer, m_perf.params.recv_mem_type, length, sn);
     }
 
     ucs_status_t run_pingpong()

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -665,11 +665,13 @@ public:
             recv_mem_type  = UCS_MEMORY_TYPE_HOST;
             recv_sn        = &m_last_recvd_sn;
         } else if (direction_to_responder) {
-            recv_mem_type  = m_perf.uct.recv_mem.mem_type;
-            recv_sn        = (psn_t*)m_perf.recv_buffer;
+            recv_mem_type = m_perf.uct.recv_mem.mem_type;
+            recv_sn       = (psn_t*)m_perf.recv_buffer;
+            // Recv allocator = Recv Allocator
         } else {
-            recv_mem_type  = m_perf.uct.send_mem.mem_type;
-            recv_sn        = (psn_t*)m_perf.send_buffer;
+            recv_mem_type = m_perf.uct.send_mem.mem_type;
+            recv_sn       = (psn_t*)m_perf.send_buffer;
+            // Recv Allocator = Send Allocator
         }
 
         uct_perf_barrier(&m_perf);


### PR DESCRIPTION
## What
Memory allocation using `uct_mem_alloc` / `uct_iface_mem_alloc` in `ucx_perftest`, replacing the use of allocators which didn't use UCX APIs.

## Why ?
We want to use UCX APIs when measuring the performance of the different memory types such as CUDA and ROCM.

