### PR TITLE
UCT/IB: Added IB iface is_reachable_v2 - v1.15

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2144,9 +2144,8 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
         }
 
         ucp_unpacked_address_for_each(ae, select_params->address) {
-            if ((wiface->attr.device_addr_len != ae->dev_addr_len) ||
-                (worker->context->tl_rscs[rsc_index].tl_name_csum !=
-                 ae->tl_name_csum)) {
+            if (worker->context->tl_rscs[rsc_index].tl_name_csum !=
+                ae->tl_name_csum) {
                 continue;
             }
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -248,6 +248,23 @@ uct_base_iface_is_reachable_v2(const uct_iface_h iface,
 {
     uct_iface_reachability_scope_t scope;
 
+    if (!uct_iface_is_reachable(iface, params->device_addr,
+                                params->iface_addr)) {
+        return 0;
+    }
+
+    scope = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params, scope, SCOPE,
+                            UCT_IFACE_REACHABILITY_SCOPE_NETWORK);
+
+    return (scope == UCT_IFACE_REACHABILITY_SCOPE_NETWORK) ||
+           uct_iface_is_same_device(iface, params->device_addr);
+}
+
+int uct_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                              const uct_iface_is_reachable_params_t *params)
+{
+    const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+
     if (!ucs_test_all_flags(params->field_mask,
                             UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
                             UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR)) {
@@ -260,19 +277,6 @@ uct_base_iface_is_reachable_v2(const uct_iface_h iface,
         params->info_string[0] = '\0';
     }
 
-    scope = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params, scope, SCOPE,
-                            UCT_IFACE_REACHABILITY_SCOPE_NETWORK);
-
-    return (scope == UCT_IFACE_REACHABILITY_SCOPE_NETWORK) ?
-                   uct_iface_is_reachable(iface, params->device_addr,
-                                          params->iface_addr) :
-                   uct_iface_is_same_device(iface, params->device_addr);
-}
-
-int uct_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                              const uct_iface_is_reachable_params_t *params)
-{
-    const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
     return iface->internal_ops->iface_is_reachable_v2(tl_iface, params);
 }
 

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -477,6 +477,10 @@ ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
 int uct_ib_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
                               const uct_iface_addr_t *iface_addr);
 
+
+int uct_ib_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                 const uct_iface_is_reachable_params_t *params);
+
 /*
  * @param xport_hdr_len       How many bytes this transport adds on top of IB header (LRH+BTH+iCRC+vCRC)
  */

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1263,7 +1263,7 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_dc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -988,7 +988,7 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_rc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_rc_mlx5_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -508,7 +508,7 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
             .ep_connect_to_ep_v2   = uct_rc_verbs_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -830,7 +830,7 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_ud_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
         },
         .create_cq      = uct_ud_mlx5_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -607,7 +607,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_ud_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1664,7 +1664,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_wireup_asymmetric_ib, different_pci_bw_connect,
 {
     /* Enable cross-dev connection */
     /* coverity[tainted_string_argument] */
-    ucs::scoped_setenv path_mtu_env("UCX_IB_PATH_MTU", "1024");
+    ucs::scoped_setenv path_mtu_env("UCX_RC_PATH_MTU", "1024");
 
     {
         std::string config_str = pci_bw_config(20, 20);


### PR DESCRIPTION
## What
Backport of #9032 

## Why ?
To fix valgrind errors in #9179

## How ?

Moving `uct_iface_is_reachable` check inside `uct_base_iface_is_reachable_v2` earlier makes valgrind happy.
