### PR TITLE
UCP/CORE: align macro for am frag first and mid meta len

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -15,14 +15,6 @@
 #include <ucp/proto/proto_multi.inl>
 
 
-#define UCP_AM_FIRST_FRAG_META_LEN \
-    (sizeof(ucp_am_hdr_t) + sizeof(ucp_am_first_ftr_t))
-
-
-#define UCP_AM_MID_FRAG_META_LEN \
-    (sizeof(ucp_am_hdr_t) + sizeof(ucp_am_mid_ftr_t))
-
-
 static ucs_status_t
 ucp_am_eager_multi_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
 {

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -24,13 +24,6 @@
 #include <ucs/datastruct/array.inl>
 
 
-#define UCP_AM_FIRST_FRAG_META_LEN \
-    (sizeof(ucp_am_hdr_t) + sizeof(ucp_am_first_ftr_t))
-
-#define UCP_AM_MID_FRAG_META_LEN \
-    (sizeof(ucp_am_hdr_t) + sizeof(ucp_am_mid_ftr_t))
-
-
 UCS_ARRAY_IMPL(ucp_am_cbs, unsigned, ucp_am_entry_t, static)
 
 ucs_status_t ucp_am_init(ucp_worker_h worker)

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -119,6 +119,14 @@ typedef struct {
 } ucp_am_first_desc_t;
 
 
+#define UCP_AM_FIRST_FRAG_META_LEN \
+    (sizeof(ucp_am_hdr_t) + sizeof(ucp_am_first_ftr_t))
+
+
+#define UCP_AM_MID_FRAG_META_LEN \
+    (sizeof(ucp_am_hdr_t) + sizeof(ucp_am_mid_ftr_t))
+
+
 ucs_status_t ucp_am_init(ucp_worker_h worker);
 
 void ucp_am_cleanup(ucp_worker_h worker);


### PR DESCRIPTION
## What
unify palace to define same macro with same meaning
