### PR TITLE
CONTRIB/MODULEFILE: Provide development modulefile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -355,6 +355,7 @@ AC_CONFIG_FILES([
                  ucx.spec
                  ucx.pc
                  contrib/rpmdef.sh
+                 contrib/ucx
                  debian/rules
                  debian/control
                  debian/changelog

--- a/contrib/ucx.in
+++ b/contrib/ucx.in
@@ -1,0 +1,30 @@
+#%Module1.0#####################################################################
+##
+## Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+##
+## See file LICENSE for terms.
+
+##
+## modulefiles/ucx
+##
+## Usage:
+## - module load ./contrib/ucx
+## - module unload ucx
+
+proc ModulesHelp { } {
+        puts stderr "\tThis is ucx generic module file\n"
+}
+
+set     root            "@prefix@"
+set     module_prefix   $root
+
+module-whatis   "ucx"
+prepend-path    PATH                    $root/bin
+prepend-path    LD_LIBRARY_PATH         $root/lib
+prepend-path    LIBRARY_PATH            $root/lib
+prepend-path    C_INCLUDE_PATH          $root/include
+prepend-path    CPLUS_INCLUDE_PATH      $root/include
+prepend-path    INCLUDE                 $root/include
+prepend-path    CPATH                   $root/include
+prepend-path    FPATH                   $root/include
+prepend-path    PKG_CONFIG_PATH         $root/lib/pkgconfig


### PR DESCRIPTION
## What
Proposal to have a development based UCX modulefile.

## Why ?
Could not find an equivalent functionality, so when testing I need to make symlinks `ucx/lib -> my_ucx/rfs/lib`, and/or use environment variables (PATH, LD_PRELOAD, LIBRARY_PATH...) which is not handy.

## How ?
Use a parametrized modulefile on some random non-dev machine like below.
```
./configure --prefix=`pwd`/rfs && make && make install

module load ./contrib/ucx-dev
module unload ucx-dev
```

