### PR TITLE
UCP/PROTO: Adapt FIFO size and RTS message to help at high parallelis…

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -414,7 +414,7 @@ ucs_status_t ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params)
     ucp_proto_rndv_ctrl_init_params_t params = {
         .super.super         = *init_params,
         .super.latency       = 0,
-        .super.overhead      = 350e-9,
+        .super.overhead      = 275e-9,
         .super.cfg_thresh    = ucp_proto_rndv_thresh(init_params),
         .super.cfg_priority  = 60,
         .super.min_length    = 0,

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -31,7 +31,7 @@ ucs_config_field_t uct_mm_iface_config_table[] = {
      ucs_offsetof(uct_mm_iface_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_sm_iface_config_table)},
 
-    {"FIFO_SIZE", "64",
+    {"FIFO_SIZE", "256",
      "Size of the receive FIFO in the memory-map UCTs.",
      ucs_offsetof(uct_mm_iface_config_t, fifo_size), UCS_CONFIG_TYPE_UINT},
 


### PR DESCRIPTION
…m alltoall

## What
Improve alltoall latency at parallelism superior to 128.

## Why ?
Performance is not optimal at higher scale.

## How ?
Previous patch #9025 raised the threshold, present patch is slightly taking it back.

### Tests
vader not built with xpmem, proto v2 only:
- np 8, all sizes: ob1/ucx/ucx patched, no algo specified, no regression
- np 128, all sizes: ob1/ucx/ucx patched, no algo specified, no regression
- size 2048: forcing algo 1 with patch brings gain seen below (without forcing, no loss but no gain between np 64 to 120)
  - can be x2.8 gain