### PR TITLE
TOOLS/PERF: align AM Header size info width with other output

### DIFF
--- a/src/tools/perf/perftest_run.c
+++ b/src/tools/perf/perftest_run.c
@@ -154,7 +154,7 @@ static void print_header(struct perftest_context *ctx)
 
         if ((test->api == UCX_PERF_API_UCP) &&
             (test->command == UCX_PERF_CMD_AM)) {
-            printf("| AM header size: %-60zu             |\n",
+            printf("| AM header size: %-60zu                             |\n",
                    ctx->params.super.ucp.am_hdr_size);
         }
     }


### PR DESCRIPTION
## What
use same column width for the header output.
