### PR TITLE
Fix memory corruption for relaxed memory order mode of the memory domain.

### DIFF
--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -555,7 +555,8 @@ ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
 
 void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                    const uct_ib_md_config_t *md_config,
-                                   int is_supported);
+                                   int is_supported,
+                                   size_t memh_base_size, size_t mr_size);
 
 ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr);
 
@@ -579,8 +580,7 @@ int uct_ib_device_is_accessible(struct ibv_device *device);
 
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                    struct ibv_device *ib_device,
-                                   const uct_ib_md_config_t *md_config,
-                                   size_t mem_size, size_t mr_size);
+                                   const uct_ib_md_config_t *md_config);
 
 void uct_ib_md_close_common(uct_ib_md_t *md);
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1210,9 +1210,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     md->super.super.ops = &uct_ib_mlx5_devx_md_ops.super;
 
-    status = uct_ib_md_open_common(&md->super, ibv_device, md_config,
-                                   sizeof(uct_ib_mlx5_mem_t),
-                                   sizeof(uct_ib_mlx5_mr_t));
+    status = uct_ib_md_open_common(&md->super, ibv_device, md_config);
     if (status != UCS_OK) {
         goto err_lru_cleanup;
     }
@@ -1259,7 +1257,9 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     /* Enable relaxed order only if we would be able to create an indirect key
        (with offset) for strict order access */
-    uct_ib_md_parse_relaxed_order(&md->super, md_config, ksm_atomic);
+    uct_ib_md_parse_relaxed_order(&md->super, md_config, ksm_atomic,
+                                  sizeof(uct_ib_mlx5_mem_t),
+                                  sizeof(uct_ib_mlx5_mr_t));
 
     uct_ib_mlx5_devx_init_flush_mr(md);
 
@@ -1830,9 +1830,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     md->super.super.ops  = &uct_ib_mlx5_md_ops.super;
     md->max_rd_atomic_dc = IBV_DEV_ATTR(dev, max_qp_rd_atom);
     status               = uct_ib_md_open_common(&md->super, ibv_device,
-                                                 md_config,
-                                                 sizeof(uct_ib_mlx5_mem_t),
-                                                 sizeof(uct_ib_mlx5_mr_t));
+                                                 md_config);
     if (status != UCS_OK) {
         goto err_md_free;
     }
@@ -1840,7 +1838,9 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->super.name = UCT_IB_MD_NAME(mlx5);
 
-    uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
+    uct_ib_md_parse_relaxed_order(&md->super, md_config, 0,
+                                  sizeof(uct_ib_mlx5_mem_t),
+                                  sizeof(uct_ib_mlx5_mr_t));
     uct_ib_md_ece_check(&md->super);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();


### PR DESCRIPTION
## What
Fix memory corruption for relaxed memory order mode of the memory domain.

## Why ?
bug

## How ?
    Fix memh size calculation if relaxed order is enabled
    
    The issue was observed on AMD EPYC 73F3 16-Core Processor CPU
    where the `ucs_cpu_prefer_relaxed_order()` returns true.
    
    The issue is that memory order is being calculated after the
    memh size is determined. This causes memory corruption
    via buffer overflow.
    In relaxed order case memh must have two elements in mrs field
    and because of the issue above only one was allocated.
    
    The problem was detected and debugged using Address Sanitizer.
