### PR TITLE
BUILD/DEBIAN: Remove inbox packages on install - v1.15.x

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -19,6 +19,8 @@ Package: @PACKAGE@
 Section: libs
 Depends: libc6, libgomp1
 Architecture: any
+Conflicts: libucx0 (<< ${binary:Version}), libucx-dev (<< ${binary:Version}), ucx-utils (<< ${binary:Version})
+Replaces:  libucx0 (<< ${binary:Version}), libucx-dev (<< ${binary:Version}), ucx-utils (<< ${binary:Version})
 Description: Unified Communication X
  UCX is a communication library implementing high-performance messaging.
  .


### PR DESCRIPTION
Add Replaces and Conflicts to mark that the main ucx package has the same role as the inbox package libucx0, libucx-dev and ucx-utils.

A versioned dependency in case we'll want to switch to packages with same names as the current inbox ones.
