### PR TITLE
UCT/IB: Fix RELAXED_ORDERING assertion - v1.15.x

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -905,7 +905,9 @@ uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
     if (memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR) {
         atomic_rkey = memh->atomic_rkey;
     } else {
-        ucs_assert(!(memh->flags & UCT_IB_MEM_FLAG_RELAXED_ORDERING));
+        if (!(flags & UCT_MD_MKEY_PACK_FLAG_EXPORT)) {
+            ucs_assert(!(memh->flags & UCT_IB_MEM_FLAG_RELAXED_ORDERING));
+        }
         atomic_rkey = UCT_IB_INVALID_MKEY;
     }
 


### PR DESCRIPTION
## Why
Fix gtest failure:
```
[ RUN      ] ib/test_md.exported_mkey/0 <mlx5_0>
[     INFO ] allocated 0x7f44c92bf000 of size 192512
[rock21:15720:0:15720]       ib_md.c:908  Assertion `!(memh->flags & UCT_IB_MEM_FLAG_RELAXED_ORDERING)' failed
[rock21:15720:0:15720] Process frozen, press Enter to attach a debugger...
```