### PR TITLE
UCT/IB: Fix remote access error with rc_verbs transport

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -493,9 +493,10 @@ ucs_status_t uct_ib_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
     *mr_p = mr;
 
     /* to prevent clang dead code */
-    ucs_trace("%s(pd=%p addr=%p len=%zu fd=%d offset=%zu): mr=%p took %.3f ms",
-              title, pd, addr, length, dmabuf_fd, dmabuf_offset, mr,
-              ucs_time_to_msec(ucs_get_time() - start_time));
+    ucs_trace("%s(pd=%p addr=%p len=%zu fd=%d offset=%zu access=0x%lx): mr=%p "
+              "lkey=0x%x took %.3f ms",
+              title, pd, addr, length, dmabuf_fd, dmabuf_offset, access, mr,
+              mr->lkey, ucs_time_to_msec(ucs_get_time() - start_time));
     return UCS_OK;
 }
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -550,6 +550,17 @@ uct_ib_md_is_flush_rkey_valid(uint32_t flush_rkey) {
     return (flush_rkey & UCT_IB_MD_INVALID_FLUSH_RKEY) == 0;
 }
 
+static UCS_F_ALWAYS_INLINE uint8_t uct_ib_md_get_atomic_mr_id(uct_ib_md_t *md)
+{
+    uint8_t mr_id;
+
+    if (uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id) == UCS_OK) {
+        return mr_id;
+    }
+
+    return 0;
+}
+
 ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
                             const uct_md_config_t *uct_md_config, uct_md_h *md_p);
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -944,7 +944,7 @@ uct_dc_mlx5_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr
         addr->super.flags |= UCT_DC_MLX5_IFACE_ADDR_HW_TM;
     }
 
-    uct_ib_md_ops(md)->get_atomic_mr_id(md, &addr->super.atomic_mr_id);
+    addr->super.atomic_mr_id = uct_ib_md_get_atomic_mr_id(md);
     if (uct_rc_iface_flush_rkey_enabled(&iface->super.super)) {
         addr->flush_rkey_hi = md->flush_rkey >> 16;
         addr->super.flags  |= UCT_DC_MLX5_IFACE_ADDR_FLUSH_RKEY;

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -517,11 +517,13 @@ static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
         return status;
     }
 
-    ucs_debug("KSM registered memory %p..%p offset 0x%x%s on %s rkey 0x%x",
+    ucs_debug("KSM registered memory %p..%p lkey 0x%x offset 0x%x%s on %s rkey "
+              "0x%x",
               mr->super.ib->addr,
               UCS_PTR_BYTE_OFFSET(mr->super.ib->addr, mr->super.ib->length),
-              uct_ib_md_atomic_offset(mr_id), is_atomic ? " atomic" : "",
-              uct_ib_device_name(&md->super.dev), memh->super.atomic_rkey);
+              mr->super.ib->lkey, uct_ib_md_atomic_offset(mr_id),
+              is_atomic ? " atomic" : "", uct_ib_device_name(&md->super.dev),
+              memh->super.atomic_rkey);
     return status;
 }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -678,7 +678,7 @@ ucs_status_t uct_rc_mlx5_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
     void *ptr;
 
     uct_ib_pack_uint24(rc_addr->qp_num, ep->tx.wq.super.qp_num);
-    uct_ib_mlx5_md_get_atomic_mr_id(md, &rc_addr->atomic_mr_id);
+    rc_addr->atomic_mr_id = uct_ib_md_get_atomic_mr_id(md);
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         uct_ib_pack_uint24(rc_addr->tm_qp_num, ep->tm_qp.qp_num);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -82,9 +82,10 @@ uct_rc_verbs_ep_post_send_desc(uct_rc_verbs_ep_t* ep, struct ibv_send_wr *wr,
 static inline ucs_status_t
 uct_rc_verbs_ep_rdma_zcopy(uct_rc_verbs_ep_t *ep, const uct_iov_t *iov,
                            size_t iovcnt, size_t iov_total_length,
-                           uint64_t remote_addr, uct_rkey_t rkey,
-                           uct_completion_t *comp, uct_rc_send_handler_t handler,
-                           uint16_t op_flags, int opcode)
+                           uint64_t remote_addr, uint32_t rkey,
+                           uct_completion_t *comp,
+                           uct_rc_send_handler_t handler, uint16_t op_flags,
+                           int opcode)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(ep->super.super.super.iface,
                                                  uct_rc_verbs_iface_t);
@@ -588,9 +589,8 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
 
     rc_addr->super.flags = 0;
     uct_ib_pack_uint24(rc_addr->super.qp_num, ep->qp->qp_num);
-
-    uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id);
-    if (uct_rc_iface_flush_rkey_enabled(&iface->super)) {
+    mr_id = uct_ib_md_get_atomic_mr_id(md);
+    if (uct_rc_iface_flush_rkey_enabled(&iface->super) || (mr_id != 0)) {
         rc_addr->super.flags  |= UCT_RC_VERBS_ADDR_HAS_ATOMIC_MR;
         rc_addr->atomic_mr_id  = mr_id;
         rc_addr->flush_rkey_hi = md->flush_rkey >> 16;

--- a/src/uct/ib/rc/verbs/rc_verbs_impl.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_impl.h
@@ -162,9 +162,9 @@ uct_rc_verbs_iface_fill_inl_am_sge_iov(uct_rc_verbs_iface_t *iface, uint8_t id,
 
 #define UCT_RC_VERBS_FILL_INL_PUT_WR(_iface, _raddr, _rkey, _buf, _len) \
     _iface->inl_rwrite_wr.wr.rdma.remote_addr = _raddr; \
-    _iface->inl_rwrite_wr.wr.rdma.rkey        = uct_ib_md_direct_rkey(_rkey); \
-    _iface->inl_sge[0].addr      = (uintptr_t)_buf; \
-    _iface->inl_sge[0].length    = _len;
+    _iface->inl_rwrite_wr.wr.rdma.rkey        = _rkey; \
+    _iface->inl_sge[0].addr                   = (uintptr_t)_buf; \
+    _iface->inl_sge[0].length                 = _len;
 
 #define UCT_RC_VERBS_FILL_AM_BCOPY_WR(_wr, _sge, _length, _wr_opcode) \
     UCT_RC_VERBS_FILL_SGE(_wr, _sge, _length) \

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -156,6 +156,13 @@ public:
         return uct_rc_iface_flush_rkey_enabled(rc_iface);
     }
 
+    int rc_iface_mr_id(entity *e)
+    {
+        uct_rc_iface_t *rc_iface = ucs_derived_of(e->iface(), uct_rc_iface_t);
+        uct_ib_md_t *md          = uct_ib_iface_md(&rc_iface->super);
+        return uct_ib_md_get_atomic_mr_id(md);
+    }
+
     static uct_iface_params_t iface_params()
     {
         uct_iface_params_t params = {};
@@ -199,7 +206,7 @@ UCS_TEST_P(test_rc_iface_address, size_no_flush_remote)
     map_size_t sizes = {
         {"rc_mlx5", {7, 1}},
         {"dc_mlx5", {0, 5}},
-        {"rc_verbs", {4, 0}},
+        {"rc_verbs", {7, 0}},
     };
     check_sizes(m_entity, sizes);
 }
@@ -207,10 +214,11 @@ UCS_TEST_P(test_rc_iface_address, size_no_flush_remote)
 UCS_TEST_P(test_rc_iface_address, size_flush_remote)
 {
     int flush_rkey_enabled = rc_iface_flush_rkey_enabled(m_entity_flush_rkey);
+    int mr_id              = rc_iface_mr_id(m_entity_flush_rkey);
     map_size_t sizes = {
         {"rc_mlx5", {flush_rkey_enabled ? 10 : 7, 1}},
         {"dc_mlx5", {0, flush_rkey_enabled ? 7 : 5}},
-        {"rc_verbs", {flush_rkey_enabled ? 7 : 4, 0}},
+        {"rc_verbs", {flush_rkey_enabled || (mr_id != 0) ? 7 : 4, 0}},
     };
     check_sizes(m_entity_flush_rkey, sizes);
 }


### PR DESCRIPTION
## Why
Fix an issue [1] introduced by #9147
rc_verbs transport did not pass mr_id value in its address, so the initiator assumed mr_id==0, and did not apply an offset when issuing RDMA_WRITE operation to a KSM indirect key (with strict ordering)

[1]
On a machine with relaxed ordering enabled by default (AMD Milan):
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from rc/test_ucp_tag_match_rndv
[ RUN      ] rc/test_ucp_tag_match_rndv.bidir_multi_exp_post/0 <rc_v/rndv_auto>
[rock01:33412:0:33412] rc_verbs_iface.c:123  send completion with error: Work Request Flushed Error [qpn 0x1a5ef wrid 0x110 vendor_err 0xf4]
[rock01:33412:0:33412] rc_verbs_iface.c:123  [rqpn 0x1a5f1 dlid=20 sl=0 port=1 src_path_bits=0]
[rock01:33412:0:33412] Process frozen, press Enter to attach a debugger...
```