### PR TITLE
UCP/WIREUP/TEST: Remove UCP_MAX_OP_MDS limit

### DIFF
--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -36,7 +36,6 @@ typedef uint8_t                      ucp_rsc_index_t;
 typedef ucp_rsc_index_t              ucp_md_index_t;
 #define UCP_MAX_MDS                  ((UCP_MD_INDEX_BITS < UCP_MAX_RESOURCES) ? \
                                       UCP_MD_INDEX_BITS : UCP_MAX_RESOURCES)
-#define UCP_MAX_OP_MDS               4  /* maximal number of MDs per single op */
 UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -58,8 +58,7 @@ ucp_md_map_t test_ucp_proto::get_md_map(ucs_memory_type_t mem_type)
         if ((md_attr->flags & UCT_MD_FLAG_REG) &&
             (md_attr->reg_mem_types & UCS_BIT(mem_type)) &&
             /* ucp_datatype_iter_mem_reg() always goes directly to registration cache */
-            (md_attr->cache_mem_types & UCS_BIT(mem_type)) &&
-            (ucs_popcount(md_map) < UCP_MAX_OP_MDS)) {
+            (md_attr->cache_mem_types & UCS_BIT(mem_type))) {
             md_map |= UCS_BIT(md_index);
         }
     }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1448,8 +1448,8 @@ UCS_TEST_SKIP_COND_P(test_max_lanes, 16_lanes_reconf, !cm_use_all_devices(),
     /* get configuration index for EP created through CM */
     listen_and_communicate(false, SEND_DIRECTION_C2S);
 
-    ASSERT_EQ(16, ucp_ep_num_lanes(sender().ep()));
-    ASSERT_EQ(16, ucp_ep_num_lanes(receiver().ep()));
+    ASSERT_EQ(16, (int)ucp_ep_num_lanes(sender().ep()));
+    ASSERT_EQ(16, (int)ucp_ep_num_lanes(receiver().ep()));
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_max_lanes, ib, "ib")

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1238,11 +1238,18 @@ UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=16", "TM_SW_RNDV=y",
     ASSERT_EQ(num_lanes, max_lanes);
 
     for (int i = 0; i < num_lanes; ++i) {
+        UCS_TEST_MESSAGE << "sender lane[" << i
+                         << "] : " << get_bytes_sent(sender().ep(), i)
+                         << " bytes";
+        UCS_TEST_MESSAGE << "receiver lane[" << i
+                         << "] : " << get_bytes_sent(receiver().ep(), i)
+                         << " bytes";
+
         uint64_t bytes_sent = get_bytes_sent(sender().ep(), i) +
                               get_bytes_sent(receiver().ep(), i);
 
         /* Verify that each lane sent something */
-        ASSERT_GE(bytes_sent, 50000 / ucs::test_time_multiplier());
+        EXPECT_GE(bytes_sent, 50000 / ucs::test_time_multiplier());
     }
 }
 


### PR DESCRIPTION
## Why
Fix test failures:
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ib/test_max_lanes
[ RUN      ] ib/test_max_lanes.16_lanes_reconf/3 <ib/tag,sa_data_v2,mt>
[     INFO ] Testing 2.1.5.4:0
[     INFO ] server listening on 2.1.5.4:40636
/labhome/yosefe/work/ucx/contrib/../test/gtest/ucp/test_ucp_sockaddr.cc:1451: Failure
Expected equality of these values:
  16
  (int)ucp_ep_num_lanes(sender().ep())
    Which is: 10
[     INFO ] ignoring error Connection reset by remote peer on endpoint 0x7f9bc0024000
[  FAILED  ] ib/test_max_lanes.16_lanes_reconf/3, where GetParam() = ib/tag,sa_data_v2,mt (2312 ms)
[----------] 1 test from ib/test_max_lanes (2312 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2312 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ib/test_max_lanes.16_lanes_reconf/3, where GetParam() = ib/tag,sa_data_v2,mt
```