### PR TITLE
UCP/PROTO: Assert in case of invalid user header size.

### DIFF
--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -66,6 +66,11 @@ ucp_proto_multi_max_payload(ucp_request_t *req,
     size_t max_frag = lpriv->max_frag - hdr_size;
     size_t max_payload;
 
+    ucs_assertv(lpriv->max_frag > hdr_size,
+                "max_frag=%zu hdr_size=%zu am_max_header_size=%zu",
+                lpriv->max_frag, hdr_size,
+                ucp_am_max_header_size(req->send.ep->worker));
+
     /* Do not split very small sends to chunks, it's not worth it, and
        generic datatype may not be able to pack to a smaller buffer */
     if (length < UCP_MIN_BCOPY) {


### PR DESCRIPTION
## What
Added assert catching invalid size of AM user header.
