### PR TITLE
GTEST/UCP: Skipped AM datatype test for ud_v and ud_x.

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1510,8 +1510,12 @@ private:
     }
 };
 
-UCS_TEST_P(test_ucp_am_nbx_dts, short_bcopy_send, "ZCOPY_THRESH=-1",
-           "RNDV_THRESH=-1")
+/* Skip tests for ud_v and ud_x because of unstable reproducible failures during
+ * roce on worker CI jobs. The test fails with invalid am_bcopy length. */
+UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, short_bcopy_send,
+                     !is_proto_disabled() &&
+                             has_any_transport({"ud_v", "ud_x"}),
+                     "ZCOPY_THRESH=-1", "RNDV_THRESH=-1")
 {
     test_datatypes([&]() {
         test_am(1);
@@ -1520,7 +1524,10 @@ UCS_TEST_P(test_ucp_am_nbx_dts, short_bcopy_send, "ZCOPY_THRESH=-1",
     });
 }
 
-UCS_TEST_P(test_ucp_am_nbx_dts, zcopy_send, "ZCOPY_THRESH=1", "RNDV_THRESH=-1")
+UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, zcopy_send,
+                     !is_proto_disabled() &&
+                             has_any_transport({"ud_v", "ud_x"}),
+                     "ZCOPY_THRESH=1", "RNDV_THRESH=-1")
 {
     test_datatypes([&]() {
         test_am(4 * UCS_KBYTE);


### PR DESCRIPTION
## What
Skip `test_ucp_am_nbx_dts.short_bcopy_send` and `test_ucp_am_nbx_dts.zcopy_send` for UD transports in new proto infrastructure.

## Why
There are unstable reproducible failures during `roce on worker` jobs. The failures look like:
```
[ RUN      ] ud/test_ucp_am_nbx_dts.short_bcopy_send/0 <ud_v>
[1689063810.082094] [swx-rain04:448254:0]        ud_verbs.c:255  UCX  ERROR Invalid am_bcopy length: 5944 (expected: <= 4096)
[1689063820.115899] [swx-rain04:448254:0]       ucp_test.cc:280  UCX  ERROR operation returned error: Invalid parameter
```
```
[ RUN      ] udx/test_ucp_am_nbx_dts.zcopy_send/0 <ud_x>
[1689075622.531834] [swx-rain04:334703:0]         ud_mlx5.c:269  UCX  ERROR Invalid am_zcopy payload length: 5944 (expected: <= 4096)
[1689075632.566755] [swx-rain04:334703:0]       ucp_test.cc:280  UCX  ERROR operation returned error: Invalid parameter
```