### PR TITLE
Poll multiple CQEs for rc_mlx5 and dc_mlx5

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -261,7 +261,7 @@ static void uct_dc_mlx5_iface_progress_enable(uct_iface_h tl_iface, unsigned fla
 }
 
 static UCS_F_ALWAYS_INLINE unsigned
-uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
+uct_dc_mlx5_poll_tx_one(uct_dc_mlx5_iface_t *iface, int poll_flags)
 {
     uint8_t dci_index;
     struct mlx5_cqe64 *cqe;
@@ -301,6 +301,19 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
     uct_ib_mlx5_update_db_cq_ci(&iface->super.cq[UCT_IB_DIR_TX]);
 
     return 1;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
+{
+    unsigned count       = 0;
+    unsigned tx_max_poll = iface->super.super.super.config.tx_max_poll;
+
+    while (tx_max_poll-- && uct_dc_mlx5_poll_tx_one(iface, poll_flags)) {
+        count++;
+    }
+
+    return count;
 }
 
 static UCS_F_ALWAYS_INLINE unsigned

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -1394,12 +1394,11 @@ uct_rc_mlx5_iface_handle_filler_cqe(uct_rc_mlx5_iface_common_t *iface,
 #endif /* IBV_HW_TM */
 
 static UCS_F_ALWAYS_INLINE unsigned
-uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *iface,
-                                 int poll_flags)
+uct_rc_mlx5_iface_common_poll_rx_one(uct_rc_mlx5_iface_common_t *iface,
+                                     int poll_flags)
 {
     struct mlx5_cqe64 *cqe;
     unsigned byte_len;
-    uint16_t max_batch;
     unsigned count;
     void *rc_hdr;
     unsigned flags;
@@ -1528,7 +1527,22 @@ uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *iface,
 out_update_db:
     uct_ib_mlx5_update_db_cq_ci(&iface->cq[UCT_IB_DIR_RX]);
 out:
-    max_batch = iface->super.super.config.rx_max_batch;
+    return count;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *iface,
+                                 int poll_flags)
+{
+    unsigned count       = 0;
+    unsigned rx_max_poll = iface->super.super.config.rx_max_poll;
+    uint16_t max_batch   = iface->super.super.config.rx_max_batch;
+
+    while (rx_max_poll-- &&
+           uct_rc_mlx5_iface_common_poll_rx_one(iface, poll_flags)) {
+        count++;
+    }
+
     if (ucs_unlikely(iface->super.rx.srq.available >= max_batch)) {
         if (poll_flags & UCT_IB_MLX5_POLL_FLAG_LINKED_LIST) {
             uct_rc_mlx5_iface_srq_post_recv_ll(iface);
@@ -1536,6 +1550,7 @@ out:
             uct_rc_mlx5_iface_srq_post_recv(iface);
         }
     }
+
     return count;
 }
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -139,7 +139,7 @@ uct_rc_mlx5_iface_update_tx_res(uct_rc_iface_t *rc_iface,
 }
 
 static UCS_F_ALWAYS_INLINE unsigned
-uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface, int poll_flags)
+uct_rc_mlx5_iface_poll_tx_one(uct_rc_mlx5_iface_common_t *iface, int poll_flags)
 {
     struct mlx5_cqe64 *cqe;
     uct_rc_mlx5_ep_t *ep;
@@ -173,6 +173,19 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface, int poll_flags)
     uct_ib_mlx5_update_db_cq_ci(&iface->cq[UCT_IB_DIR_TX]);
 
     return 1;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface, int poll_flags)
+{
+    unsigned count       = 0;
+    unsigned tx_max_poll = iface->super.super.config.tx_max_poll;
+
+    while (tx_max_poll-- && uct_rc_mlx5_iface_poll_tx_one(iface, poll_flags)) {
+        count++;
+    }
+
+    return count;
 }
 
 static UCS_F_ALWAYS_INLINE unsigned


### PR DESCRIPTION
## What
This PR enables mlx5 transports to poll more than one CQE each time the iface is progressed.
