### PR TITLE
UCP/CORE: Check length of user header in ucp_am_send_nbx.

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -87,52 +87,6 @@ void ucp_am_ep_cleanup(ucp_ep_h ep)
                    " dropped on ep %p", ep->worker, count, ep);
 }
 
-size_t ucp_am_max_header_size(ucp_worker_h worker)
-{
-    ucp_context_h context = worker->context;
-    uct_iface_attr_t *if_attr;
-    ucp_rsc_index_t iface_id;
-    size_t max_am_header, max_uct_fragment;
-    size_t max_rts_size, max_ucp_header;
-
-    if (!(context->config.features & UCP_FEATURE_AM)) {
-        return 0ul;
-    }
-
-    max_am_header  = SIZE_MAX;
-    max_rts_size   = sizeof(ucp_rndv_rts_hdr_t) +
-                     ucp_rkey_packed_size(context, UCS_MASK(context->num_mds),
-                                          UCS_SYS_DEVICE_ID_UNKNOWN, 0);
-    max_ucp_header = ucs_max(max_rts_size, UCP_AM_FIRST_FRAG_META_LEN);
-
-    /* Make sure maximal AM header can fit into one bcopy fragment
-     * together with RTS or first eager header (whatever is bigger)
-     */
-    for (iface_id = 0; iface_id < worker->num_ifaces; ++iface_id) {
-        if_attr = &worker->ifaces[iface_id]->attr;
-
-        /* UCT_IFACE_FLAG_AM_BCOPY is required by UCP AM feature, therefore
-         * at least one interface should support it.
-         * Make sure that except user header single UCT fragment can fit
-         * first fragment header and footer and at least 1 byte of data. It is
-         * needed to correctly use generic AM based multi-fragment protocols,
-         * which expect some amount of payload to be packed to the first
-         * fragment.
-         * TODO: fix generic AM based multi-fragment protocols, so that this
-         * trick is not needed.
-         */
-        if (if_attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) {
-            max_uct_fragment = ucs_max(if_attr->cap.am.max_bcopy,
-                                       max_ucp_header - 1) - max_ucp_header - 1;
-            max_am_header    = ucs_min(max_am_header, max_uct_fragment);
-        }
-    }
-
-    ucs_assert(max_am_header < SIZE_MAX);
-
-    return ucs_min(max_am_header, UINT32_MAX);
-}
-
 static void ucp_am_rndv_send_ats(ucp_worker_h worker, ucp_rndv_rts_hdr_t *rts,
                                  ucs_status_t status)
 {
@@ -969,6 +923,19 @@ ucp_am_params_check_memh(const ucp_request_param_t *param, uint32_t *flags_p)
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_am_send_nbx_check_header_length(ucp_worker_h worker, size_t header_length)
+{
+    if (ENABLE_PARAMS_CHECK && (header_length > worker->max_am_header)) {
+        ucs_error("active message header length (%zi) is greater than maximum "
+                  "allowed header size (%zi)",
+                  header_length, worker->max_am_header);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
 UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
                  (ep, id, header, header_length, buffer, count, param),
                  ucp_ep_h ep, unsigned id, const void *header,
@@ -992,6 +959,12 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
     UCP_REQUEST_CHECK_PARAM(param);
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
+
+    status = ucp_am_send_nbx_check_header_length(worker, header_length);
+    if (status != UCS_OK) {
+        ret = UCS_STATUS_PTR(status);
+        goto out;
+    }
 
     flags     = ucp_request_param_flags(param);
     attr_mask = param->op_attr_mask &

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -135,8 +135,6 @@ void ucp_am_ep_init(ucp_ep_h ep);
 
 void ucp_am_ep_cleanup(ucp_ep_h ep);
 
-size_t ucp_am_max_header_size(ucp_worker_h worker);
-
 ucs_status_t ucp_proto_progress_am_rndv_rts(uct_pending_req_t *self);
 
 ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -316,6 +316,9 @@ typedef struct ucp_worker {
     ucp_tag_match_t                  tm;                  /* Tag-matching queues and offload info */
     ucp_am_info_t                    am;                  /* Array of AM callbacks and their data */
     uint64_t                         am_message_id;       /* For matching long AMs */
+    size_t                           max_am_header;       /* Maximum allowed
+                                                             header size used by
+                                                             UCP AM */
     ucp_ep_h                         mem_type_ep[UCS_MEMORY_TYPE_LAST]; /* Memory type EPs */
 
     UCS_STATS_NODE_DECLARE(stats)

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -66,10 +66,8 @@ ucp_proto_multi_max_payload(ucp_request_t *req,
     size_t max_frag = lpriv->max_frag - hdr_size;
     size_t max_payload;
 
-    ucs_assertv(lpriv->max_frag > hdr_size,
-                "max_frag=%zu hdr_size=%zu am_max_header_size=%zu",
-                lpriv->max_frag, hdr_size,
-                ucp_am_max_header_size(req->send.ep->worker));
+    ucs_assertv(lpriv->max_frag > hdr_size, "max_frag=%zu hdr_size=%zu",
+                lpriv->max_frag, hdr_size);
 
     /* Do not split very small sends to chunks, it's not worth it, and
        generic datatype may not be able to pack to a smaller buffer */

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -776,6 +776,19 @@ UCS_TEST_P(test_ucp_am_nbx, max_am_header)
     EXPECT_LT(max_am_hdr(), min_am_bcopy);
 }
 
+#if ENABLE_PARAMS_CHECK
+UCS_TEST_P(test_ucp_am_nbx, am_header_error)
+{
+    scoped_log_handler wrap_err(wrap_errors_logger);
+
+    ucp_request_param_t param;
+    param.op_attr_mask    = 0ul;
+    ucs_status_ptr_t sptr = ucp_am_send_nbx(sender().ep(), TEST_AM_NBX_ID, NULL,
+                                            max_am_hdr() + 1, NULL, 0, &param);
+    EXPECT_EQ(UCS_PTR_STATUS(sptr), UCS_ERR_INVALID_PARAM);
+}
+#endif
+
 UCS_TEST_P(test_ucp_am_nbx, zero_send)
 {
     test_am_send_recv(0, max_am_hdr());


### PR DESCRIPTION
## What
Added check for the length of user defined Active Message header.
`ucp_am_send_nbx` returns error if the length of the user header is greater than the length the maximum allowed header size, which is available via `ucp_worker_query`.

Added gtest.

Removed printing the return value of `ucp_am_max_header_size` in assert in method `ucp_proto_multi_max_payload`. Because the value is a feature of Active Message, but the method is not.

## Why ?
Follow up on https://github.com/openucx/ucx/pull/9211
