### PR TITLE
UCT: no need to specify default CPU mask field without mask CPU

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -129,8 +129,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
         .field_mask            = UCT_IFACE_PARAM_FIELD_OPEN_MODE   |
                                  UCT_IFACE_PARAM_FIELD_DEVICE      |
                                  UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
-                                 UCT_IFACE_PARAM_FIELD_RX_HEADROOM |
-                                 UCT_IFACE_PARAM_FIELD_CPU_MASK,
+                                 UCT_IFACE_PARAM_FIELD_RX_HEADROOM,
         .open_mode             = UCT_IFACE_OPEN_MODE_DEVICE,
         .mode.device.tl_name   = resource->tl_name,
         .mode.device.dev_name  = resource->dev_name,
@@ -143,7 +142,6 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
     ucs_status_t status;
     uct_iface_h iface;
 
-    UCS_CPU_ZERO(&iface_params.cpu_mask);
     status = uct_md_iface_config_read(md, resource->tl_name, NULL, NULL, &iface_config);
     if (status != UCS_OK) {
         return;

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1486,15 +1486,13 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf)
     uct_iface_params_t iface_params = {
         .field_mask           = UCT_IFACE_PARAM_FIELD_OPEN_MODE   |
                                 UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
-                                UCT_IFACE_PARAM_FIELD_RX_HEADROOM |
-                                UCT_IFACE_PARAM_FIELD_CPU_MASK,
+                                UCT_IFACE_PARAM_FIELD_RX_HEADROOM,
         .open_mode            = UCT_IFACE_OPEN_MODE_DEVICE,
         .mode.device.tl_name  = params->uct.tl_name,
         .mode.device.dev_name = params->uct.dev_name,
         .stats_root           = ucs_stats_get_root(),
         .rx_headroom          = 0
     };
-    UCS_CPU_ZERO(&iface_params.cpu_mask);
 
     if (params->thread_count > 1) {
         ucs_error("UCT tests do not support multi-thread mode");

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1301,7 +1301,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     if (params->field_mask & UCT_IFACE_PARAM_FIELD_CPU_MASK) {
         cpu_mask = params->cpu_mask;
     } else {
-        memset(&cpu_mask, 0, sizeof(cpu_mask));
+        UCS_CPU_ZERO(&cpu_mask);
     }
 
     preferred_cpu = ucs_cpu_set_find_lcs(&cpu_mask);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -830,10 +830,8 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
         params->mode.device.dev_name = resource.dev_name.c_str();
     }
 
-    params->field_mask |= UCT_IFACE_PARAM_FIELD_STATS_ROOT |
-                          UCT_IFACE_PARAM_FIELD_CPU_MASK;
+    params->field_mask |= UCT_IFACE_PARAM_FIELD_STATS_ROOT;
     params->stats_root  = ucs_stats_get_root();
-    UCS_CPU_ZERO(&params->cpu_mask);
 
     UCS_TEST_CREATE_HANDLE(uct_worker_h, m_worker, uct_worker_destroy,
                            uct_worker_create, &m_async.m_async,


### PR DESCRIPTION
## What
There's no need to specify CPU mask if using the default cpu mask.