### PR TITLE
TEST/TAG: Fix multi_rail_max.max_lanes test

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1237,19 +1237,18 @@ UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=16", "TM_SW_RNDV=y",
     ASSERT_EQ(ucp_ep_num_lanes(receiver().ep()), num_lanes);
     ASSERT_EQ(num_lanes, max_lanes);
 
-    for (int i = 0; i < num_lanes; ++i) {
-        UCS_TEST_MESSAGE << "sender lane[" << i
-                         << "] : " << get_bytes_sent(sender().ep(), i)
-                         << " bytes";
-        UCS_TEST_MESSAGE << "receiver lane[" << i
-                         << "] : " << get_bytes_sent(receiver().ep(), i)
-                         << " bytes";
+    for (ucp_lane_index_t lane = 0; lane < num_lanes; ++lane) {
+        size_t sender_tx   = get_bytes_sent(sender().ep(), lane);
+        size_t receiver_tx = get_bytes_sent(receiver().ep(), lane);
+        UCS_TEST_MESSAGE << "lane[" << static_cast<int>(lane) << "] : "
+                         << "sender " << sender_tx << " receiver " << sender_tx;
 
-        uint64_t bytes_sent = get_bytes_sent(sender().ep(), i) +
-                              get_bytes_sent(receiver().ep(), i);
-
-        /* Verify that each lane sent something */
-        EXPECT_GE(bytes_sent, 50000 / ucs::test_time_multiplier());
+        /* Verify that each lane sent something, except the active message lane
+           that could be used only for control messages */
+        if (lane != ucp_ep_get_am_lane(sender().ep())) {
+            EXPECT_GE(sender_tx + receiver_tx,
+                      50000 / ucs::test_time_multiplier());
+        }
     }
 }
 


### PR DESCRIPTION
## Why
Fix test failures that look like [1]
The issue happens when running with protov1 (test is skipped on protov2) and on swx-rain[03-04] machines on NUMA1.
In this case, am_lane is selected as mlx5_bond_0 and is not used as rma_bw lane, so it does not send the data.

[1]
```
[ RUN      ] ib/multi_rail_max.max_lanes/7 <ib/proto_v1>
[     INFO ] sender lane[0] : 68 bytes
[     INFO ] receiver lane[0] : 65 bytes
/labhome/yosefe/work/ucx/contrib/../test/gtest/ucp/test_ucp_tag_xfer.cc:1252: Failure
Expected: (bytes_sent) >= (50000 / ucs::test_time_multiplier()), actual: 133 vs 50000
[     INFO ] sender lane[1] : 0 bytes
[     INFO ] receiver lane[1] : 77312 bytes
...
[     INFO ] sender lane[15] : 0 bytes
[     INFO ] receiver lane[15] : 72704 bytes
[  FAILED  ] ib/multi_rail_max.max_lanes/7, where GetParam() = ib/proto_v1 (2589 ms)
[----------] 1 test from ib/multi_rail_max (2589 ms total)
```