### PR TITLE
UCP: Fix fp8 packing

### DIFF
--- a/src/ucs/type/float8.h
+++ b/src/ucs/type/float8.h
@@ -120,13 +120,13 @@ static UCS_F_ALWAYS_INLINE ucs_fp8_t ucs_fp8_pack(double value, uint64_t min,
         exponent                  = max_exponent - min_exponent;
         ieee_value.ieee.mantissa0 = 0;
         ieee_value.ieee.mantissa1 = 0;
-    } else if (ucs_unlikely(ieee_value.ieee.exponent <
+    } else if (ucs_unlikely(ieee_value.ieee.exponent <=
                             min_exponent + _UCS_FP8_EXPONENT_OFFSET)) {
         if (ucs_unlikely(value == 0)) {
             /* 0 maps to a special value for 0 */
             exponent = 0;
         } else {
-            /* A number below the max supported is rounded up */
+            /* A number below the min supported is rounded up */
             exponent                  = 1;
             ieee_value.ieee.mantissa0 = 0;
             ieee_value.ieee.mantissa1 = 0;

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -118,9 +118,12 @@ UCS_TEST_F(test_type, pack_float) {
     EXPECT_TRUE(isnan(unpacked));
 
     /* Below min -> min */
-    EXPECT_EQ(UCS_FP8_UNPACK(TEST_LATENCY,
-                             UCS_FP8_PACK(TEST_LATENCY, UCS_BIT(7))),
-              UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, 15)));
+    for (uint64_t min_val = UCS_BIT(0); min_val <= UCS_BIT(7); min_val <<= 1) {
+        UCS_TEST_MESSAGE << " Pack/unpack " << min_val;
+        EXPECT_EQ(
+         UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, UCS_BIT(7))),
+         UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, min_val)));
+    }
 
     /* Precision test throughout the whole range */
     for (std::vector<double>::const_iterator it = values.begin();


### PR DESCRIPTION
## What
Fix fp8 packing function

## Why ?
Values with exponent equal to `min_exp - 1` are packed (and therefore unpacked) with 0 exponent, while they need to be rounded up to `min_exp` value
E.g.:
UCP packs BW as `UCS_FP8_DECLARE_TYPE(BANDWIDTH, 512 * UCS_MBYTE, 4 * UCS_TBYTE)`
So, without this fix, values from  `[256 * UCS_MBYTE, 512 * UCS_MBYTE)` range are packed as zeroes. 
