### PR TITLE
UCM/BISTRO: Fix conditional jump translation

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1132,6 +1132,17 @@ run_malloc_hook_gtest() {
 		MALLOC_MMAP_THRESHOLD_=16384 \
 		GTEST_FILTER=malloc_hook_cplusplus.mmap_ptrs \
 			make -C test/gtest test
+
+	echo "==== Running cuda hooks, $compiler_name compiler ===="
+	$AFFINITY $TIMEOUT env \
+		GTEST_FILTER='cuda_hooks.*' \
+			make -C test/gtest test
+
+	echo "==== Running cuda hooks with far jump, $compiler_name compiler ===="
+	$AFFINITY $TIMEOUT env \
+		UCM_BISTRO_FORCE_FAR_JUMP=y \
+		GTEST_FILTER='cuda_hooks.*' \
+			make -C test/gtest test
 }
 
 #

--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -218,6 +218,7 @@ typedef struct ucm_global_config {
     size_t               alloc_alignment;             /* Alignment for memory allocations */
     int                  dlopen_process_rpath;        /* Process RPATH section in dlopen hook */
     int                  module_unload_prevent_mode;  /* Module unload prevention mode */
+    int                  bistro_force_far_jump;       /* Force far jump with bistro pathcing */
 } ucm_global_config_t;
 
 

--- a/src/ucm/bistro/bistro_x86_64.c
+++ b/src/ucm/bistro/bistro_x86_64.c
@@ -59,13 +59,10 @@ typedef struct {
 } UCS_S_PACKED ucm_bistro_cmp_xlt_t;
 
 typedef struct {
-    uint8_t jmp_rel[2];
-    uint8_t jmp_out[2];
-    struct {
-        uint8_t  push_imm;
-        uint32_t value;
-    } UCS_S_PACKED hi, lo;
-    uint8_t        ret;
+    uint8_t                   jmp_rel[2];
+    uint8_t                   jmp_out[2];
+    ucm_bistro_jmp_indirect_t jmp_rip;
+    uint64_t                  addr;
 } UCS_S_PACKED ucm_bistro_jcc_xlt_t;
 
 
@@ -135,10 +132,8 @@ ucs_status_t ucm_bistro_relocate_one(ucm_bistro_relocate_context_t *ctx)
     };
     ucm_bistro_jcc_xlt_t jcc = {
         .jmp_rel = {0x00, 0x02},
-        .jmp_out = {0xeb, 0x0b},
-        .hi      = {0x68, 0},
-        .lo      = {0x68, 0},
-        .ret     = 0xc3
+        .jmp_out = {0xeb, 0x0e},
+        .jmp_rip = {0xff, 0x25, 0}
     };
     uint8_t rex, opcode, modrm, mod;
     size_t dst_length;
@@ -226,16 +221,14 @@ ucs_status_t ucm_bistro_relocate_one(ucm_bistro_relocate_context_t *ctx)
          * to:
          *        jCC L1
          *    L1: jmp L2        ; condition 'CC' did not hold
-         *        push $addrhi
-         *        push $addrlo
-         *        ret           ; 64-bit jump to destination
+         *        jmp *(%rip)
+         *   .long $addr          ; 64-bit jump to destination
          *    L2:               ; continue execution
          */
         disp8          = *ucs_serialize_next(&ctx->src_p, const int8_t);
         jmpdest        = (uintptr_t)UCS_PTR_BYTE_OFFSET(ctx->src_p, disp8);
         jcc.jmp_rel[0] = opcode; /* keep original jump condition */
-        jcc.hi.value   = jmpdest >> 32;
-        jcc.lo.value   = jmpdest & UCS_MASK(32);
+        jcc.addr       = jmpdest;
         copy_src       = &jcc;
         dst_length     = sizeof(jcc);
         /* Prevent patching past jump target */

--- a/src/ucm/bistro/bistro_x86_64.c
+++ b/src/ucm/bistro/bistro_x86_64.c
@@ -334,17 +334,17 @@ ucs_status_t ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
 
     jmp_base = UCS_PTR_BYTE_OFFSET(func_ptr, sizeof(jmp_near));
     jmp_disp = UCS_PTR_BYTE_DIFF(jmp_base, hook);
-    if (labs(jmp_disp) < INT32_MAX) {
+    if (ucm_global_opts.bistro_force_far_jump || (labs(jmp_disp) > INT32_MAX)) {
+        jmp_rax.ptr = hook;
+        patch       = &jmp_rax;
+        patch_len   = sizeof(jmp_rax);
+    } else {
         /* if 32-bit near jump is possible, use it, since it's a short 5-byte
          * instruction which reduces the chances of racing with other thread
          */
         jmp_near.disp = jmp_disp;
         patch         = &jmp_near;
         patch_len     = sizeof(jmp_near);
-    } else {
-        jmp_rax.ptr = hook;
-        patch       = &jmp_rax;
-        patch_len   = sizeof(jmp_rax);
     }
 
     if (orig_func_p != NULL) {

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -46,7 +46,8 @@ ucm_global_config_t ucm_global_opts = {
                                   UCS_BIT(UCM_MMAP_HOOK_RELOC),
     .enable_dynamic_mmap_thresh = 1,
     .alloc_alignment            = 16,
-    .dlopen_process_rpath       = 1
+    .dlopen_process_rpath       = 1,
+    .bistro_force_far_jump      = 0,
 };
 
 size_t ucm_get_page_size()

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -103,8 +103,14 @@ static ucs_config_field_t ucm_global_config_table[] = {
    "Module unload prevention mode\n"
    " lazy - use RTLD_LAZY flag to add reference to module.\n"
    " now  - use RTLD_NOW flag to add reference to module.\n"
-   " none - don't prevent module unload, use it for debug purposes only."
-   ,ucs_offsetof(ucm_global_config_t, module_unload_prevent_mode), UCS_CONFIG_TYPE_ENUM(ucm_module_unload_prevent_modes)},
+   " none - don't prevent module unload, use it for debug purposes only.",
+   ucs_offsetof(ucm_global_config_t, module_unload_prevent_mode),
+   UCS_CONFIG_TYPE_ENUM(ucm_module_unload_prevent_modes)},
+
+  {"BISTRO_FORCE_FAR_JUMP", "n",
+   "Force far jump when applying bistro patches. Used for testing purpose.",
+   ucs_offsetof(ucm_global_config_t, bistro_force_far_jump),
+   UCS_CONFIG_TYPE_BOOL},
 
   {NULL}
 };


### PR DESCRIPTION
## Why
Fix conditional jump patching: push instruction sign-extends the 32-bit operand to 64-bit, so "push, push, ret" does not really jump to the destination address. Replace by indirect absolute jump "jmp *(%rip), .long addr"

To be backported for v1.15.x