### PR TITLE
UCT/RC/VERBS: Fix ep address management

### DIFF
--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -585,12 +585,13 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
     uct_rc_verbs_ep_t *ep                 = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
     uct_ib_md_t *md                       = uct_ib_iface_md(&iface->super.super);
     uct_rc_verbs_ep_flush_addr_t *rc_addr = (uct_rc_verbs_ep_flush_addr_t*)addr;
+    ucs_status_t status;
     uint8_t mr_id;
 
     rc_addr->super.flags = 0;
     uct_ib_pack_uint24(rc_addr->super.qp_num, ep->qp->qp_num);
-    mr_id = uct_ib_md_get_atomic_mr_id(md);
-    if (uct_rc_iface_flush_rkey_enabled(&iface->super) || (mr_id != 0)) {
+    status = uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id);
+    if (uct_rc_iface_flush_rkey_enabled(&iface->super) || (status == UCS_OK)) {
         rc_addr->super.flags  |= UCT_RC_VERBS_ADDR_HAS_ATOMIC_MR;
         rc_addr->atomic_mr_id  = mr_id;
         rc_addr->flush_rkey_hi = md->flush_rkey >> 16;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -214,6 +214,7 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_verbs_iface_t);
     uct_ib_md_t *md             = uct_ib_iface_md(&iface->super.super);
     ucs_status_t status;
+    uint8_t UCS_V_UNUSED mr_id;
 
     status = uct_rc_iface_query(&iface->super, iface_attr,
                                 iface->config.max_inline,
@@ -230,8 +231,9 @@ static ucs_status_t uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_att
     iface_attr->latency.m += 1e-9;  /* 1 ns per each extra QP */
     iface_attr->overhead   = 75e-9; /* Software overhead */
 
+    status                  = uct_ib_md_ops(md)->get_atomic_mr_id(md, &mr_id);
     iface_attr->ep_addr_len = (uct_rc_iface_flush_rkey_enabled(&iface->super) ||
-                               (uct_ib_md_get_atomic_mr_id(md) != 0)) ?
+                               (status == UCS_OK)) ?
                                       sizeof(uct_rc_verbs_ep_flush_addr_t) :
                                       sizeof(uct_rc_verbs_ep_addr_t);
 


### PR DESCRIPTION
## What
Fix regression introduced by #9209 

## Why ?
Low byte of flush mkey (aka atomic mr_id) can be 0. When unified mode is used, UCP uses local iface query to know the length of ep address. If one of the peers atomic mr_id is 0 while another is not, UCP uses wrong ep address length and incorrectly unpacks UCP address.

## How ?
Do not rely on the fact that low byte of flush mkey can't be zero