### PR TITLE
UCT/CUDA/CUDA_IPC: Show diag message when nvmlInit fails.

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -78,19 +78,21 @@ const char *uct_cuda_base_cu_get_error_string(CUresult result);
     UCT_CUDA_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
-#define UCT_NVML_FUNC(_func, _log_level)                        \
-    ({                                                          \
-        ucs_status_t _status = UCS_OK;                          \
-        do {                                                    \
-            nvmlReturn_t _err = (_func);                        \
-            if (NVML_SUCCESS != _err) {                         \
-                ucs_log((_log_level), "%s failed: %s",          \
-                        UCS_PP_MAKE_STRING(_func),              \
-                        nvmlErrorString(_err));                 \
-                _status = UCS_ERR_IO_ERROR;                     \
-            }                                                   \
-        } while (0);                                            \
-        _status;                                                \
+#define UCT_NVML_FUNC(_func, _log_level) \
+    ({ \
+        ucs_status_t _status = UCS_OK; \
+        do { \
+            nvmlReturn_t _err = (_func); \
+            if (NVML_SUCCESS != _err) { \
+                ucs_log((_log_level), "%s failed: %s", \
+                        UCS_PP_MAKE_STRING(_func), \
+                        (NVML_ERROR_DRIVER_NOT_LOADED != _err) ? \
+                                nvmlErrorString(_err) : \
+                                "nvml is a stub library"); \
+                _status = UCS_ERR_IO_ERROR; \
+            } \
+        } while (0); \
+        _status; \
     })
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -132,7 +132,7 @@ static int uct_cuda_ipc_get_device_nvlinks(int ordinal)
         return num_nvlinks;
     }
 
-    status = UCT_NVML_FUNC_LOG_ERR(nvmlInit_v2());
+    status = UCT_NVML_FUNC(nvmlInit_v2(), UCS_LOG_LEVEL_DIAG);
     if (status != UCS_OK) {
         goto err;
     }


### PR DESCRIPTION
## What
Show diagnostic message when `nvmlInit_v2` returns error.

## Why ?
This is a workaround when user runs application using UCX on an environment where libnvidia-ml.so is only available via stubs.
Please expand the Details section to find the difference in the behavior before and after the changes: 
<details>

Before:
```
$ LD_PRELOAD=<path_to_cuda>/lib64/stubs/libnvidia-ml.so ucx_info -d -t cuda_ipc
...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING:

You should always run with libnvidia-ml.so that is installed with your
NVIDIA Display Driver. By default it's installed in /usr/lib and /usr/lib64.
libnvidia-ml.so in GDK package is a stub library that is attached only for
build purposes (e.g. machine that you build your application doesn't have
to have Display Driver installed).
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Linked to libnvidia-ml library at wrong path : <path_to_cuda>/targets/x86_64-linux/lib/stubs/libnvidia-ml.so

cuda_ipc_iface.c:135  UCX  ERROR nvmlInit_v2() failed: 
cuda_ipc_iface.c:135  UCX  ERROR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
cuda_ipc_iface.c:135  UCX  ERROR WARNING:
cuda_ipc_iface.c:135  UCX  ERROR You should always run with libnvidia-ml.so that is installed with your
cuda_ipc_iface.c:135  UCX  ERROR NVIDIA Display Driver. By default it's installed in /usr/lib and /usr/lib64.
cuda_ipc_iface.c:135  UCX  ERROR libnvidia-ml.so in GDK package is a stub library that is attached only for
cuda_ipc_iface.c:135  UCX  ERROR build purposes (e.g. machine that you build your application doesn't have
cuda_ipc_iface.c:135  UCX  ERROR to have Display Driver installed).
cuda_ipc_iface.c:135  UCX  ERROR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
...
```

After:
```
$ LD_PRELOAD=<path_to_cuda>/lib64/stubs/libnvidia-ml.so ucx_info -d -t cuda_ipc
...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING:

You should always run with libnvidia-ml.so that is installed with your
NVIDIA Display Driver. By default it's installed in /usr/lib and /usr/lib64.
libnvidia-ml.so in GDK package is a stub library that is attached only for
build purposes (e.g. machine that you build your application doesn't have
to have Display Driver installed).
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Linked to libnvidia-ml library at wrong path : <path_to_cuda>/targets/x86_64-linux/lib/stubs/libnvidia-ml.so
...
```

, and with enabled diagnostics:

```
$ UCX_LOG_LEVEL=diag LD_PRELOAD=<path_to_cuda>/lib64/stubs/libnvidia-ml.so ucx_info -d -t cuda_ipc
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING:

You should always run with libnvidia-ml.so that is installed with your
NVIDIA Display Driver. By default it's installed in /usr/lib and /usr/lib64.
libnvidia-ml.so in GDK package is a stub library that is attached only for
build purposes (e.g. machine that you build your application doesn't have
to have Display Driver installed).
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Linked to libnvidia-ml library at wrong path : <path_to_cuda>/targets/x86_64-linux/lib/stubs/libnvidia-ml.so

cuda_ipc_iface.c:135  UCX  DIAG  nvmlInit_v2() failed: nvml is a stub library
...
```

</details>