### PR TITLE
UCP/TEST: test_ucp_sockaddr test tag/stream without separate variants

### DIFF
--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1869,6 +1869,10 @@ protected:
         test_base::init();
         // entities will be created in a test
     }
+
+    void cleanup() {
+        ucp_test::cleanup();
+    }
 };
 
 


### PR DESCRIPTION
## What
Test both tag and stream interfaces during the one test case.

## Why ?
To reduce valgrind CI time.
