### PR TITLE
TEST: Disable protov1 testing with valgrind

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -41,7 +41,9 @@ public:
     static void get_test_variants(variant_vec_t &variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
-        add_variant_with_value(variants, UCP_FEATURE_AM, 1, "proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_with_value(variants, UCP_FEATURE_AM, 1, "proto_v1");
+        }
     }
 
     virtual void init()

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -34,7 +34,9 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         get_test_variants(variants, 0, "");
-        get_test_variants(variants, DISABLE_PROTO, "/proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            get_test_variants(variants, DISABLE_PROTO, "/proto_v1");
+        }
     }
 
     struct send_func_data {

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -37,8 +37,10 @@ public:
         add_variant_with_value(variants, UCP_FEATURE_RMA | extra_features, 0, "");
         add_variant_with_value(variants, UCP_FEATURE_RMA |extra_features,
                                VARIANT_MAP_NONBLOCK, "map_nb");
-        add_variant_with_value(variants, UCP_FEATURE_RMA | extra_features,
-                               VARIANT_PROTO_DISABLE, "proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_with_value(variants, UCP_FEATURE_RMA | extra_features,
+                                   VARIANT_PROTO_DISABLE, "proto_v1");
+        }
         add_variant_with_value(variants, UCP_FEATURE_RMA | extra_features,
                                VARIANT_NO_RCACHE, "no_rcache");
     }
@@ -87,9 +89,6 @@ public:
     virtual void init() {
         ucs::skip_on_address_sanitizer();
         if (disable_proto()) {
-            if (RUNNING_ON_VALGRIND) {
-                UCS_TEST_SKIP_R("Skip proto v1 with valgrind");
-            }
             modify_config("PROTO_ENABLE", "n");
         }
 

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -24,8 +24,11 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
         add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "flush_worker");
         add_variant_with_value(variants, UCP_FEATURE_RMA, FLUSH_EP, "flush_ep");
-        add_variant_with_value(variants, UCP_FEATURE_RMA,
-                               FLUSH_EP | DISABLE_PROTO, "flush_ep_proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_with_value(variants, UCP_FEATURE_RMA,
+                                   FLUSH_EP | DISABLE_PROTO,
+                                   "flush_ep_proto_v1");
+        }
         add_variant_with_value(variants, UCP_FEATURE_RMA, USER_MEMH,
                                "user_memh");
     }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2718,34 +2718,37 @@ UCS_TEST_P(test_ucp_sockaddr_protocols,
     test_am_send_recv(64 * UCS_KBYTE, 0, 2 /* warmup + test */, true, false);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols,
-           am_rndv_64k_prereg_proto_v1_single_rndv_put_zcopy_lane,
-           "RNDV_THRESH=0", "MAX_RNDV_LANES=1", "RNDV_SCHEME=put_zcopy",
-           "PROTO_ENABLE=n")
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_protocols,
+                     am_rndv_64k_prereg_proto_v1_single_rndv_put_zcopy_lane,
+                     RUNNING_ON_VALGRIND,
+                     "RNDV_THRESH=0", "MAX_RNDV_LANES=1",
+                     "RNDV_SCHEME=put_zcopy", "PROTO_ENABLE=n")
 {
     test_am_send_recv(64 * UCS_KBYTE, 0, 2, true, true);
 }
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_short_reset, "PROTO_ENABLE=n",
-           "ZCOPY_THRESH=inf")
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_protocols, am_short_reset,
+                     RUNNING_ON_VALGRIND, "PROTO_ENABLE=n", "ZCOPY_THRESH=inf")
 {
     test_am_send_recv(16, 8, 1, false, false, UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_bcopy_reset, "PROTO_ENABLE=n",
-           "ZCOPY_THRESH=inf")
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_protocols, am_bcopy_reset,
+                     RUNNING_ON_VALGRIND,
+                     "PROTO_ENABLE=n", "ZCOPY_THRESH=inf")
 {
     test_am_send_recv(2 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_zcopy_reset, "PROTO_ENABLE=n")
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_protocols, am_zcopy_reset,
+                     RUNNING_ON_VALGRIND, "PROTO_ENABLE=n")
 {
     test_am_send_recv(16 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);
 }
 
-UCS_TEST_P(test_ucp_sockaddr_protocols, am_rndv_reset, "PROTO_ENABLE=n",
-           "RNDV_THRESH=0")
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_protocols, am_rndv_reset,
+                     RUNNING_ON_VALGRIND, "PROTO_ENABLE=n", "RNDV_THRESH=0")
 {
     test_am_send_recv(16 * UCS_KBYTE, 8, 1, false, false,
                       UCP_AM_SEND_FLAG_COPY_HEADER);

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -515,7 +515,10 @@ public:
     static void get_test_variants_proto(std::vector<ucp_test_variant> &variants)
     {
         add_variant_values(variants, get_test_variants_prereg, 0);
-        add_variant_values(variants, get_test_variants_prereg, 1, "proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_values(variants, get_test_variants_prereg, 1,
+                               "proto_v1");
+        }
     }
 
     static void get_test_variants(std::vector<ucp_test_variant> &variants)

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -55,8 +55,11 @@ public:
                                "req_int");
         add_variant_with_value(variants, get_ctx_params(), RECV_REQ_EXTERNAL,
                                "req_ext");
-        add_variant_with_value(variants, get_ctx_params(),
-                               RECV_REQ_INTERNAL | DISABLE_PROTO, "req_int_proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_with_value(variants, get_ctx_params(),
+                                   RECV_REQ_INTERNAL | DISABLE_PROTO,
+                                   "req_int_proto_v1");
+        }
     }
 
     virtual bool is_external_request()

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -29,8 +29,11 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant_values(variants, test_ucp_tag::get_test_variants, 0);
-        add_variant_values(variants, test_ucp_tag::get_test_variants, 1,
-                           "proto_v1");
+
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_values(variants, test_ucp_tag::get_test_variants, 1,
+                               "proto_v1");
+        }
     }
 
     void init()
@@ -907,9 +910,9 @@ UCS_TEST_P(test_ucp_tag_offload_stats, sw_rndv, "RNDV_THRESH=1000")
     test_send_recv(size, true, {UCP_WORKER_STAT_TAG_OFFLOAD_MATCHED_SW_RNDV});
 }
 
-UCS_TEST_P(test_ucp_tag_offload_stats, force_sw_rndv, "TM_SW_RNDV=y",
-                                                      "RNDV_THRESH=1000",
-                                                      "PROTO_ENABLE=n")
+UCS_TEST_SKIP_COND_P(test_ucp_tag_offload_stats, force_sw_rndv,
+                     RUNNING_ON_VALGRIND,
+                     "TM_SW_RNDV=y", "RNDV_THRESH=1000", "PROTO_ENABLE=n")
 {
     size_t size = 2048; // Size bigger than RNDV thresh
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -48,10 +48,6 @@ public:
     }
 
     virtual void init() {
-        if (RUNNING_ON_VALGRIND && (get_variant_value() == VARIANT_PROTO_V1)) {
-            UCS_TEST_SKIP_R("Skip proto v1 with valgrind");
-        }
-
         if (get_variant_value() == VARIANT_RNDV_PUT_ZCOPY) {
             modify_config("RNDV_SCHEME", "put_zcopy");
         } else if (get_variant_value() == VARIANT_RNDV_GET_ZCOPY) {
@@ -97,8 +93,10 @@ public:
                                VARIANT_RNDV_AM_ZCOPY, "rndv_am_zcopy");
         add_variant_with_value(variants, get_ctx_params(),
                                VARIANT_SEND_NBR, "send_nbr");
-        add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO_V1,
-                               "proto_v1");
+        if (!RUNNING_ON_VALGRIND) {
+            add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO_V1,
+                                   "proto_v1");
+        }
     }
 
     virtual ucp_ep_params_t get_ep_params() {


### PR DESCRIPTION
## What
Disables testing protov1 with valgrind.

## Why ?
To reduce CI valgrind time.
