### PR TITLE
UCT/API: Introducing uct_ep_is_connected API

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -343,6 +343,25 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief field mask of @ref uct_ep_is_connected_params_t
+ *
+ * The enumeration allows specifying which fields in @ref
+ * uct_ep_is_connected_params_t are present.
+ */
+typedef enum {
+    /** Device address */
+    UCT_EP_IS_CONNECTED_FIELD_DEVICE_ADDR = UCS_BIT(0),
+
+    /** Interface address */
+    UCT_EP_IS_CONNECTED_FIELD_IFACE_ADDR  = UCS_BIT(1),
+
+    /** Endpoint address */
+    UCT_EP_IS_CONNECTED_FIELD_EP_ADDR     = UCS_BIT(2)
+} uct_ep_is_connected_field_mask_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Endpoint attributes, capabilities and limitations.
  */
 struct uct_ep_attr {
@@ -575,6 +594,45 @@ typedef struct uct_iface_is_reachable_params {
      */
     uct_iface_reachability_scope_t scope;
 } uct_iface_is_reachable_params_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Operation parameters passed to @ref uct_ep_is_connected.
+ *
+ * This struct is used to pass the required arguments to
+ * @ref uct_ep_is_connected.
+ */
+typedef struct uct_ep_is_connected_params {
+    /**
+     * Mask of valid fields in this structure, using
+     * bits from @ref uct_ep_is_connected_field_mask_t. Fields not specified
+     * in this mask will be ignored. Provides ABI compatibility with respect to
+     * adding new fields.
+     */
+    uint64_t                 field_mask;
+
+    /**
+     * Device address to check for connectivity.
+     * This field must be passed if @ref uct_iface_query returned
+     * @ref uct_iface_attr_t::dev_addr_len > 0 on the remote side.
+     */
+    const uct_device_addr_t *device_addr;
+
+    /**
+     * Interface address to check for connectivity.
+     * This field must be passed if this endpoint was created by calling
+     * @ref uct_ep_create with @ref uct_ep_params_t::iface_addr.
+     */
+    const uct_iface_addr_t  *iface_addr;
+
+    /**
+     * Endpoint address to check for connectivity.
+     * This field must be passed if @ref uct_ep_connect_to_ep_v2 was
+     * called on this endpoint.
+     */
+    const uct_ep_addr_t     *ep_addr;
+} uct_ep_is_connected_params_t;
 
 
 /**
@@ -962,6 +1020,21 @@ ucs_status_t uct_ep_connect_to_ep_v2(uct_ep_h ep,
                                      const uct_device_addr_t *device_addr,
                                      const uct_ep_addr_t *ep_addr,
                                      const uct_ep_connect_to_ep_params_t *params);
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Checks if an endpoint is connected to a remote address.
+ *
+ * This function checks if a local endpoint is connected to a remote address.
+ *
+ * @param [in] ep      Endpoint to check.
+ * @param [in] params  Parameters as defined in @ref
+ *                     uct_ep_is_connected_params_t.
+ *
+ * @return Nonzero if connected, 0 otherwise.
+ */
+int uct_ep_is_connected(uct_ep_h ep,
+                        const uct_ep_is_connected_params_t *params);
 
 END_C_DECLS
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -307,6 +307,13 @@ int uct_base_iface_is_reachable(const uct_iface_h tl_iface,
     return uct_iface_is_reachable_v2(tl_iface, &params);
 }
 
+int uct_ep_is_connected(uct_ep_h ep, const uct_ep_is_connected_params_t *params)
+{
+    const uct_base_iface_t *iface = ucs_derived_of(ep->iface, uct_base_iface_t);
+
+    return iface->internal_ops->ep_is_connected(ep, params);
+}
+
 ucs_status_t uct_ep_check(const uct_ep_h ep, unsigned flags,
                           uct_completion_t *comp)
 {

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -261,6 +261,11 @@ typedef int (*uct_iface_is_reachable_v2_func_t)(
         const uct_iface_is_reachable_params_t *params);
 
 
+/* Check if a remote endpoint is connected */
+typedef int (*uct_ep_is_connected_func_t)(
+        uct_ep_h ep, const uct_ep_is_connected_params_t *params);
+
+
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
     uct_iface_estimate_perf_func_t   iface_estimate_perf;
@@ -269,6 +274,7 @@ typedef struct uct_iface_internal_ops {
     uct_ep_invalidate_func_t         ep_invalidate;
     uct_ep_connect_to_ep_v2_func_t   ep_connect_to_ep_v2;
     uct_iface_is_reachable_v2_func_t iface_is_reachable_v2;
+    uct_ep_is_connected_func_t       ep_is_connected;
 } uct_iface_internal_ops_t;
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -401,7 +401,8 @@ static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_cuda_copy_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_cuda_copy_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -476,7 +476,8 @@ static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_cuda_ipc_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_cuda_ipc_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -185,7 +185,8 @@ static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_gdr_copy_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_gdr_copy_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1271,6 +1271,7 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
             .ep_invalidate         = uct_dc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
             .iface_is_reachable_v2 = uct_dc_mlx5_iface_is_reachable_v2,
+            .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -1011,7 +1011,8 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_rc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_rc_mlx5_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_rc_mlx5_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_rc_mlx5_iface_is_reachable_v2,
+            .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -510,7 +510,8 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
             .ep_connect_to_ep_v2   = uct_rc_verbs_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
+            .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -884,7 +884,8 @@ static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
     .ep_query              = uct_rdmacm_ep_query,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero
+    .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static ucs_status_t

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -830,7 +830,8 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_ud_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
+            .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
         },
         .create_cq      = uct_ud_mlx5_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -607,7 +607,8 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_ud_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
+            .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -240,7 +240,8 @@ static uct_iface_internal_ops_t uct_rocm_copy_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_rocm_copy_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_rocm_copy_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -579,7 +579,8 @@ static uct_iface_internal_ops_t uct_mm_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_mm_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_mm_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static void uct_mm_iface_recv_desc_init(uct_iface_h tl_iface, void *obj,

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -141,7 +141,8 @@ static uct_scopy_iface_ops_t uct_cma_iface_ops = {
         .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
         .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-        .iface_is_reachable_v2 = uct_cma_iface_is_reachable_v2
+        .iface_is_reachable_v2 = uct_cma_iface_is_reachable_v2,
+        .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
     },
     .ep_tx = uct_cma_ep_tx,
 };

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -80,7 +80,8 @@ static uct_scopy_iface_ops_t uct_knem_iface_ops = {
         .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
         .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-        .iface_is_reachable_v2 = uct_knem_iface_is_reachable_v2
+        .iface_is_reachable_v2 = uct_knem_iface_is_reachable_v2,
+        .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
     },
     .ep_tx = uct_knem_ep_tx,
 };

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -602,7 +602,8 @@ static uct_iface_internal_ops_t uct_tcp_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = uct_tcp_ep_connect_to_ep_v2,
-    .iface_is_reachable_v2 = uct_tcp_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_tcp_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -199,7 +199,8 @@ static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {
     .ep_query              = uct_tcp_sockcm_ep_query,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero
+    .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 UCS_CLASS_INIT_FUNC(uct_tcp_sockcm_t, uct_component_h component,

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -274,7 +274,8 @@ static uct_iface_internal_ops_t uct_ugni_smsg_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = uct_ugni_smsg_ep_connect_to_ep_v2,
-    .iface_is_reachable_v2 = uct_ugni_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_ugni_iface_is_reachable_v2,
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h worker,


### PR DESCRIPTION
## What
Introducing uct_ep_is_connected API

## Why ?
In order to use it in later EP reconfiguration intersection (replace dst_rsc_index).