### PR TITLE
GTEST/UCP: Fix msg info in mrail test

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -144,6 +144,7 @@ protected:
                          bool expected, bool sync);
 
     void test_xfer_len_offset();
+    size_t get_msg_size();
 
     /* Init number of lanes which will be used */
     virtual unsigned num_lanes()
@@ -153,7 +154,6 @@ protected:
 
 private:
     request* do_send(const void *sendbuf, size_t count, ucp_datatype_t dt, bool sync);
-    size_t get_msg_size();
 
     static const uint64_t SENDER_TAG = 0x111337;
     static const uint64_t RECV_MASK  = 0xffff;
@@ -1237,17 +1237,20 @@ UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=16", "TM_SW_RNDV=y",
     ASSERT_EQ(ucp_ep_num_lanes(receiver().ep()), num_lanes);
     ASSERT_EQ(num_lanes, max_lanes);
 
+    size_t chunk_size = get_msg_size() / num_lanes;
+
     for (ucp_lane_index_t lane = 0; lane < num_lanes; ++lane) {
         size_t sender_tx   = get_bytes_sent(sender().ep(), lane);
         size_t receiver_tx = get_bytes_sent(receiver().ep(), lane);
         UCS_TEST_MESSAGE << "lane[" << static_cast<int>(lane) << "] : "
-                         << "sender " << sender_tx << " receiver " << sender_tx;
+                         << "sender " << sender_tx << " receiver " << receiver_tx;
 
         /* Verify that each lane sent something, except the active message lane
            that could be used only for control messages */
-        if (lane != ucp_ep_get_am_lane(sender().ep())) {
-            EXPECT_GE(sender_tx + receiver_tx,
-                      50000 / ucs::test_time_multiplier());
+        if (lane == num_lanes - 1) {
+            EXPECT_GT(sender_tx + receiver_tx, 0); // last lane sends the rest
+        } else if (lane != ucp_ep_get_am_lane(sender().ep())) {
+            EXPECT_GE(sender_tx + receiver_tx, chunk_size);
         }
     }
 }


### PR DESCRIPTION
## What
Fix test output

## Why ?
This test failed in CI a couple of times (e.g. [here](https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/66549/logs/852)). 
The correct info can give some hint (the issue is not reproduced manually)