### PR TITLE
UCT/IB: fix vhca_id length to be 16bits

### DIFF
--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -160,13 +160,13 @@ typedef struct uct_ib_md {
      * means that flush_rkey is invalid and flush_remote operation could not
      * be initiated.  */
     uint32_t                 flush_rkey;
-    uct_ib_uint128_t         vhca_id;
+    uint16_t                 vhca_id;
 } uct_ib_md_t;
 
 
 typedef struct uct_ib_md_packed_mkey {
-    uint32_t         lkey;
-    uct_ib_uint128_t vhca_id;
+    uint32_t lkey;
+    uint16_t vhca_id;
 } UCS_S_PACKED uct_ib_md_packed_mkey_t;
 
 
@@ -426,8 +426,8 @@ uct_ib_md_pack_exported_mkey(uct_ib_md_t *md, uint32_t lkey, void *buffer)
 {
     uct_ib_md_packed_mkey_t *mkey = (uct_ib_md_packed_mkey_t*)buffer;
 
-    mkey->lkey = lkey;
-    memcpy(mkey->vhca_id, md->vhca_id, sizeof(md->vhca_id));
+    mkey->lkey    = lkey;
+    mkey->vhca_id = md->vhca_id;
 
     ucs_trace("packed exported mkey on %s: lkey 0x%x",
               uct_ib_device_name(&md->dev), lkey);

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -101,7 +101,6 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #endif
 
 typedef uint8_t uct_ib_uint24_t[3];
-typedef uint8_t uct_ib_uint128_t[0x10];
 
 static inline void uct_ib_pack_uint24(uct_ib_uint24_t buf, uint32_t val)
 {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -986,7 +986,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     uint8_t lag_state                                      = 0;
     uint64_t cap_flags                                     = 0;
     uint8_t log_max_qp;
-    uct_ib_uint128_t vhca_id;
+    uint16_t vhca_id;
     struct ibv_context *ctx;
     uct_ib_device_t *dev;
     uct_ib_mlx5_md_t *md;
@@ -1151,8 +1151,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         md->flags |= UCT_IB_MLX5_MD_FLAG_MP_XRQ_FIRST_MSG;
     }
 
-    memcpy(vhca_id, UCT_IB_MLX5DV_ADDR_OF(cmd_hca_cap, cap, vhca_id),
-           sizeof(vhca_id));
+    vhca_id = UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, vhca_id);
 
     if (uct_ib_mlx5_is_xgvmi_alias_supported(ctx)) {
         md->flags |= UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
@@ -1245,8 +1244,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     md->flags           |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
     md->super.name       = UCT_IB_MD_NAME(mlx5);
     md->super.cap_flags |= cap_flags;
-
-    memcpy(md->super.vhca_id, vhca_id, sizeof(vhca_id));
+    md->super.vhca_id    = vhca_id;
 
     ksm_atomic = 0;
     if (md->flags & UCT_IB_MLX5_MD_FLAG_KSM) {
@@ -1605,7 +1603,6 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     void *hdr, *alias_ctx;
     ucs_status_t status;
     void *access_key;
-    void *target_vhca_id_p;
     int ret;
 
     ib_memh = uct_ib_memh_alloc(&md->super, UCT_IB_MEM_FLAG_NO_RCACHE);
@@ -1628,11 +1625,8 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
                       UCT_IB_MLX5_OBJ_TYPE_MKEY);
     UCT_IB_MLX5DV_SET(general_obj_in_cmd_hdr, hdr, alias_object, 1);
 
-    target_vhca_id_p = UCT_IB_MLX5DV_ADDR_OF(alias_context, alias_ctx,
-                                             vhca_id_to_be_accessed);
-    memcpy(target_vhca_id_p, packed_mkey->vhca_id,
-           sizeof(packed_mkey->vhca_id));
-
+    UCT_IB_MLX5DV_SET(alias_context, alias_ctx, vhca_id_to_be_accessed,
+                      packed_mkey->vhca_id);
     UCT_IB_MLX5DV_SET(alias_context, alias_ctx, object_id_to_be_accessed,
                       packed_mkey->lkey >> 8);
     UCT_IB_MLX5DV_SET(alias_context, alias_ctx, metadata_1,


### PR DESCRIPTION
## What
```vhca_id``` is 16 bits. Update it.