### PR TITLE
UCT/IB/MLX5: Rename devx memh structs and pass size during allocation

### DIFF
--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -61,8 +61,8 @@ enum {
     UCT_IB_MEM_FLAG_RELAXED_ORDERING = UCS_BIT(4), /**< The memory region will issue
                                                         PCIe writes with relaxed order
                                                         attribute */
-    UCT_IB_MEM_FLAG_NO_RCACHE        = UCS_BIT(5), /**< Memory handle wasn't stored
-                                                        in RCACHE */
+    UCT_IB_MEM_FLAG_IMPORTED         = UCS_BIT(5), /**< The memory handle was
+                                                        created by mem_attach */
 #if ENABLE_PARAMS_CHECK
     UCT_IB_MEM_ACCESS_REMOTE_RMA     = UCS_BIT(6) /**< RMA access was requested
                                                         for the memory region */
@@ -104,7 +104,7 @@ typedef struct uct_ib_md_ext_config {
 } uct_ib_md_ext_config_t;
 
 
-typedef struct uct_ib_mem {
+typedef struct {
     uint32_t                lkey;
     uint32_t                exported_lkey;
     uint32_t                rkey;
@@ -114,7 +114,7 @@ typedef struct uct_ib_mem {
 } uct_ib_mem_t;
 
 
-typedef union uct_ib_mr {
+typedef struct {
     struct ibv_mr           *ib;
 } uct_ib_mr_t;
 
@@ -149,7 +149,6 @@ typedef struct uct_ib_md {
     double                   pci_bw;
     int                      relaxed_order;
     int                      fork_init;
-    size_t                   memh_struct_size;
     uint64_t                 reg_mem_types;
     uint64_t                 reg_nonblock_mem_types;
     uint64_t                 cap_flags;
@@ -562,13 +561,13 @@ ucs_status_t uct_ib_md_open(uct_component_t *component, const char *md_name,
 
 void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                    const uct_ib_md_config_t *md_config,
-                                   int is_supported,
-                                   size_t memh_base_size, size_t mr_size);
+                                   int is_supported);
 
 ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr);
 
 ucs_status_t uct_ib_mem_reg(uct_md_h uct_md, void *address, size_t length,
                             const uct_md_mem_reg_params_t *params,
+                            size_t memh_base_size, size_t mr_size,
                             uct_mem_h *memh_p);
 
 ucs_status_t
@@ -580,8 +579,6 @@ ucs_status_t uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
 ucs_status_t uct_ib_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
                               const uct_md_mkey_pack_params_t *params,
                               void *mkey_buffer);
-
-uct_ib_mem_t *uct_ib_memh_alloc(uct_ib_md_t *md, uint32_t flags);
 
 int uct_ib_device_is_accessible(struct ibv_device *device);
 
@@ -639,8 +636,8 @@ ucs_status_t uct_ib_verbs_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
                                     const uct_md_mkey_pack_params_t *params,
                                     void *mkey_buffer);
 
-ucs_status_t uct_ib_memh_new(uct_ib_md_t *md, size_t length, unsigned mem_flags,
-                             size_t memh_base_size, size_t mr_size,
-                             uct_ib_mem_t **memh_p);
+ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
+                               unsigned mem_flags, size_t memh_base_size,
+                               size_t mr_size, uct_ib_mem_t **memh_p);
 
 #endif

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -20,30 +20,6 @@
     (IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE)
 
 
-typedef struct {
-    struct mlx5dv_devx_obj     *dvmr;
-    int                        mr_num;
-    size_t                     length;
-    struct ibv_mr              *mrs[];
-} uct_ib_mlx5_ksm_data_t;
-
-typedef union uct_ib_mlx5_mr {
-    uct_ib_mr_t                super;
-    uct_ib_mlx5_ksm_data_t     *ksm_data;
-} uct_ib_mlx5_mr_t;
-
-typedef struct uct_ib_mlx5_mem {
-    uct_ib_mem_t               super;
-#if HAVE_DEVX
-    struct mlx5dv_devx_obj     *atomic_dvmr;
-    struct mlx5dv_devx_obj     *indirect_dvmr;
-    struct mlx5dv_devx_umem    *umem;
-    struct mlx5dv_devx_obj     *cross_mr;
-#endif
-    uct_ib_mlx5_mr_t           mrs[];
-} uct_ib_mlx5_mem_t;
-
-
 static uint32_t uct_ib_mlx5_flush_rkey_make()
 {
     return ((getpid() & 0xff) << 8) | UCT_IB_MD_INVALID_FLUSH_RKEY;
@@ -55,7 +31,8 @@ uct_ib_mlx5_reg_key(uct_ib_md_t *md, void *address, size_t length,
                     uint64_t access_flags, int dmabuf_fd, size_t dmabuf_offset,
                     uct_ib_mem_t *ib_memh, uct_ib_mr_type_t mr_type, int silent)
 {
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
 
     return uct_ib_reg_key_impl(md, address, length, access_flags, dmabuf_fd,
                                dmabuf_offset, ib_memh,
@@ -66,7 +43,8 @@ static ucs_status_t uct_ib_mlx5_dereg_key(uct_ib_md_t *md,
                                           uct_ib_mem_t *ib_memh,
                                           uct_ib_mr_type_t mr_type)
 {
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
 
     return uct_ib_dereg_mr(memh->mrs[mr_type].super.ib);
 }
@@ -152,8 +130,8 @@ uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md, int atomic, uintptr_t address,
 
 static ucs_status_t
 uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md, int atomic,
-                              uct_ib_mlx5_ksm_data_t *ksm_data, size_t length,
-                              off_t off, const char *reason,
+                              uct_ib_mlx5_devx_ksm_data_t *ksm_data,
+                              size_t length, off_t off, const char *reason,
                               struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
 {
     ucs_status_t status;
@@ -214,9 +192,12 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm_data_addr(
     return status;
 }
 
-static ucs_status_t uct_ib_mlx5_devx_reg_ksm_data_contig(
-        uct_ib_mlx5_md_t *md, uct_ib_mlx5_mr_t *mr, off_t offset, int atomic,
-        const char *reason, struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
+static ucs_status_t
+uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md,
+                                     uct_ib_mlx5_devx_mr_t *mr, off_t offset,
+                                     int atomic, const char *reason,
+                                     struct mlx5dv_devx_obj **mr_p,
+                                     uint32_t *mkey)
 {
     uintptr_t mr_address = (uintptr_t)mr->super.ib->addr;
     uintptr_t ksm_address;
@@ -381,8 +362,9 @@ static void uct_ib_mlx5_devx_mr_lru_cleanup(uct_ib_mlx5_md_t *md)
 static ucs_status_t uct_ib_mlx5_devx_reg_indirect_key(uct_ib_md_t *ibmd,
                                                       uct_ib_mem_t *ib_memh)
 {
-    uct_ib_mlx5_md_t *md    = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    uct_ib_mlx5_md_t *md         = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
     ucs_status_t status;
 
     ucs_assertv(md->flags & UCT_IB_MLX5_MD_FLAG_KSM, "md %p: name %s", md,
@@ -417,8 +399,9 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_key(uct_ib_md_t *ibmd,
                                                uct_ib_mem_t *ib_memh,
                                                uct_ib_mr_type_t mr_type)
 {
-    uct_ib_mlx5_md_t *md    = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    uct_ib_mlx5_md_t *md         = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
     ucs_status_t ret_status = UCS_OK;
     ucs_status_t status;
     int ret;
@@ -453,16 +436,18 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_key(uct_ib_md_t *ibmd,
         memh->umem = NULL;
     }
 
-    status = uct_ib_mlx5_dereg_key(ibmd, ib_memh, mr_type);
-    if (ret_status == UCS_OK) {
-        ret_status = status;
+    if (!(memh->super.flags & UCT_IB_MEM_FLAG_IMPORTED)) {
+        status = uct_ib_mlx5_dereg_key(ibmd, ib_memh, mr_type);
+        if (ret_status == UCS_OK) {
+            ret_status = status;
+        }
     }
 
     return ret_status;
 }
 
-static int
-uct_ib_mlx5_devx_use_atomic_ksm(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mem_t *memh)
+static int uct_ib_mlx5_devx_use_atomic_ksm(uct_ib_mlx5_md_t *md,
+                                           uct_ib_mlx5_devx_mem_t *memh)
 {
     return ucs_test_all_flags(md->flags,
                               UCT_IB_MLX5_MD_FLAG_KSM |
@@ -472,10 +457,11 @@ uct_ib_mlx5_devx_use_atomic_ksm(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mem_t *memh)
 static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
                                                     uct_ib_mem_t *ib_memh)
 {
-    uct_ib_mr_type_t mr_type = uct_ib_md_get_atomic_mr_type(ibmd);
-    uct_ib_mlx5_mem_t *memh  = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
-    uct_ib_mlx5_md_t *md     = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
-    uct_ib_mlx5_mr_t *mr     = &memh->mrs[mr_type];
+    uct_ib_mr_type_t mr_type     = uct_ib_md_get_atomic_mr_type(ibmd);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
+    uct_ib_mlx5_md_t *md         = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_devx_mr_t *mr    = &memh->mrs[mr_type];
     ucs_status_t status;
     uint8_t mr_id;
     int is_atomic;
@@ -522,8 +508,9 @@ static ucs_status_t uct_ib_mlx5_devx_reg_atomic_key(uct_ib_md_t *ibmd,
 static ucs_status_t uct_ib_mlx5_devx_dereg_atomic_key(uct_ib_md_t *ibmd,
                                                       uct_ib_mem_t *ib_memh)
 {
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
-    uct_ib_mlx5_md_t *md    = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_md_t *md         = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
 
     if (!uct_ib_mlx5_devx_use_atomic_ksm(md, memh)) {
         return UCS_OK;
@@ -538,13 +525,14 @@ uct_ib_mlx5_devx_reg_mt(uct_ib_md_t *ibmd, void *address, size_t length,
                         uct_ib_mr_type_t mr_type, int silent)
 
 {
-    uct_ib_mlx5_md_t *md    = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
-    size_t chunk            = md->super.config.mt_reg_chunk;
-    const int is_atomic     = memh->super.flags &
-                              UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;
+    uct_ib_mlx5_md_t *md         = ucs_derived_of(ibmd, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
+    size_t chunk                 = md->super.config.mt_reg_chunk;
+    const int is_atomic          = memh->super.flags &
+                                   UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;
+    uct_ib_mlx5_devx_ksm_data_t *ksm_data;
     uct_md_mem_reg_params_t params;
-    uct_ib_mlx5_ksm_data_t *ksm_data;
     ucs_status_t status;
     uint32_t mkey;
     int mr_num;
@@ -604,8 +592,9 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_mt(uct_ib_md_t *ibmd,
                                               uct_ib_mem_t *ib_memh,
                                               uct_ib_mr_type_t mr_type)
 {
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
-    uct_ib_mlx5_ksm_data_t *ksm_data = memh->mrs[mr_type].ksm_data;
+    uct_ib_mlx5_devx_mem_t *memh          = ucs_derived_of(ib_memh,
+                                                           uct_ib_mlx5_devx_mem_t);
+    uct_ib_mlx5_devx_ksm_data_t *ksm_data = memh->mrs[mr_type].ksm_data;
     ucs_status_t status;
     struct ibv_mr **mr;
 
@@ -633,6 +622,16 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_mt(uct_ib_md_t *ibmd,
 
     ucs_free(ksm_data);
     return status;
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
+                         const uct_md_mem_reg_params_t *params,
+                         uct_mem_h *memh_p)
+{
+    return uct_ib_mem_reg(uct_md, address, length, params,
+                          sizeof(uct_ib_mlx5_devx_mem_t),
+                          sizeof(uct_ib_mlx5_devx_mr_t), memh_p);
 }
 
 static ucs_status_t uct_ib_mlx5_add_page(ucs_mpool_t *mp, size_t *size_p, void **page_p)
@@ -1261,9 +1260,7 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     /* Enable relaxed order only if we would be able to create an indirect key
        (with offset) for strict order access */
-    uct_ib_md_parse_relaxed_order(&md->super, md_config, ksm_atomic,
-                                  sizeof(uct_ib_mlx5_mem_t),
-                                  sizeof(uct_ib_mlx5_mr_t));
+    uct_ib_md_parse_relaxed_order(&md->super, md_config, ksm_atomic);
 
     uct_ib_mlx5_devx_init_flush_mr(md);
 
@@ -1434,10 +1431,10 @@ err:
     return 0;
 }
 
-static ucs_status_t uct_ib_mlx5_devx_allow_xgvmi_access(uct_ib_mlx5_md_t *md,
-                                                        uct_ib_mlx5_mem_t *memh,
-                                                        uint32_t exported_lkey,
-                                                        int silent)
+static ucs_status_t
+uct_ib_mlx5_devx_allow_xgvmi_access(uct_ib_mlx5_md_t *md,
+                                    uct_ib_mlx5_devx_mem_t *memh,
+                                    uint32_t exported_lkey, int silent)
 {
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(allow_other_vhca_access_in)]   = {0};
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(allow_other_vhca_access_out)] = {0};
@@ -1459,8 +1456,8 @@ static ucs_status_t uct_ib_mlx5_devx_allow_xgvmi_access(uct_ib_mlx5_md_t *md,
                                         "ALLOW_OTHER_VHCA_ACCESS", silent);
 }
 
-static ucs_status_t
-uct_ib_mlx5_devx_xgvmi_umem_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mem_t *memh)
+static ucs_status_t uct_ib_mlx5_devx_xgvmi_umem_mr(uct_ib_mlx5_md_t *md,
+                                                   uct_ib_mlx5_devx_mem_t *memh)
 {
 #if HAVE_DECL_MLX5DV_DEVX_UMEM_REG_EX
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_mkey_in)]   = {0};
@@ -1549,8 +1546,9 @@ err_out:
 static ucs_status_t
 uct_ib_mlx5_devx_reg_exported_key(uct_ib_md_t *ib_md, uct_ib_mem_t *ib_memh)
 {
-    uct_ib_mlx5_md_t *md    = ucs_derived_of(ib_md, uct_ib_mlx5_md_t);
-    uct_ib_mlx5_mem_t *memh = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    uct_ib_mlx5_md_t *md         = ucs_derived_of(ib_md, uct_ib_mlx5_md_t);
+    uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
+                                                  uct_ib_mlx5_devx_mem_t);
     struct mlx5dv_devx_obj *cross_mr;
     uint32_t exported_lkey;
     ucs_status_t status;
@@ -1600,7 +1598,7 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     const uint64_t flags = UCT_MD_MEM_ATTACH_FIELD_VALUE(params, flags,
                                                          FIELD_FLAGS, 0);
     const uct_ib_md_packed_mkey_t *packed_mkey = mkey_buffer;
-    uct_ib_mlx5_mem_t *memh;
+    uct_ib_mlx5_devx_mem_t *memh;
     uct_ib_mem_t *ib_memh;
     void *hdr, *alias_ctx;
     ucs_status_t status;
@@ -1608,16 +1606,12 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     void *target_vhca_id_p;
     int ret;
 
-    ib_memh = uct_ib_memh_alloc(&md->super, UCT_IB_MEM_FLAG_NO_RCACHE);
-    if (ib_memh == NULL) {
-        uct_md_log_mem_attach_error(flags,
-                                    "md %p: failed to allocate memory handle",
-                                    md);
-        status = UCS_ERR_NO_MEMORY;
+    status = uct_ib_memh_alloc(&md->super, 0, 0, sizeof(*memh), 0, &ib_memh);
+    if (status != UCS_OK) {
         goto err;
     }
 
-    memh      = ucs_derived_of(ib_memh, uct_ib_mlx5_mem_t);
+    memh      = ucs_derived_of(ib_memh, uct_ib_mlx5_devx_mem_t);
     hdr       = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, hdr);
     alias_ctx = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, alias_ctx);
 
@@ -1658,11 +1652,12 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
         goto err_cross_mr_destroy;
     }
 
-    memh->super.lkey = (UCT_IB_MLX5DV_GET(create_alias_obj_out, out,
-                                          hdr.obj_id) << 8) |
-                        md->mkey_tag;
-    memh->super.rkey = memh->super.lkey;
-    *memh_p          = ib_memh;
+    memh->super.lkey   = (UCT_IB_MLX5DV_GET(create_alias_obj_out, out,
+                                            hdr.obj_id) << 8) |
+                         md->mkey_tag;
+    memh->super.rkey   = memh->super.lkey;
+    memh->super.flags |= UCT_IB_MEM_FLAG_IMPORTED;
+    *memh_p            = ib_memh;
     return UCS_OK;
 
 err_cross_mr_destroy:
@@ -1677,7 +1672,7 @@ static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops = {
     .super = {
         .close              = uct_ib_mlx5_devx_md_close,
         .query              = uct_ib_md_query,
-        .mem_reg            = uct_ib_mem_reg,
+        .mem_reg            = uct_ib_mlx5_devx_mem_reg,
         .mem_dereg          = uct_ib_mem_dereg,
         .mem_attach         = uct_ib_mlx5_devx_mem_attach,
         .mem_advise         = uct_ib_mem_advise,
@@ -1846,9 +1841,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->super.name = UCT_IB_MD_NAME(mlx5);
 
-    uct_ib_md_parse_relaxed_order(&md->super, md_config, 0,
-                                  sizeof(uct_ib_mlx5_mem_t),
-                                  sizeof(uct_ib_mlx5_mr_t));
+    uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
     uct_ib_md_ece_check(&md->super);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -229,7 +229,31 @@ enum {
 
 
 #if HAVE_DEVX
-typedef struct uct_ib_mlx5_devx_umem {
+typedef struct {
+    struct mlx5dv_devx_obj *dvmr;
+    int                    mr_num;
+    size_t                 length;
+    struct ibv_mr          *mrs[];
+} uct_ib_mlx5_devx_ksm_data_t;
+
+
+typedef union {
+    uct_ib_mr_t                 super;
+    uct_ib_mlx5_devx_ksm_data_t *ksm_data;
+} uct_ib_mlx5_devx_mr_t;
+
+
+typedef struct {
+    uct_ib_mem_t            super;
+    struct mlx5dv_devx_obj  *atomic_dvmr;
+    struct mlx5dv_devx_obj  *indirect_dvmr;
+    struct mlx5dv_devx_umem *umem;
+    struct mlx5dv_devx_obj  *cross_mr;
+    uct_ib_mlx5_devx_mr_t   mrs[];
+} uct_ib_mlx5_devx_mem_t;
+
+
+typedef struct {
     struct mlx5dv_devx_umem  *mem;
     size_t                   size;
 } uct_ib_mlx5_devx_umem_t;


### PR DESCRIPTION
## Why
Next step of ib md refactoring: 
- Rename mlx5 structs to mlx5_devx - since they are used only by devx and contain devx objects
- Pass memh struct size to ibv_reg_mr instead of keeping in on the md