### PR TITLE
UCM/BISTRO: Use appropriate atomic swap for size of update

### DIFF
--- a/src/ucm/bistro/bistro.c
+++ b/src/ucm/bistro/bistro.c
@@ -50,12 +50,18 @@ static ucs_status_t ucm_bistro_protect(void *addr, size_t len, int prot)
 
 void ucm_bistro_modify_code(void *dst, const ucm_bistro_lock_t *bytes)
 {
-    uint32_t value;
+    uint16_t value16;
+    uint32_t value32;
 
-    UCS_STATIC_ASSERT(sizeof(*bytes) <= sizeof(value));
-    memcpy(&value, dst, sizeof(value));
-    memcpy(&value, bytes, sizeof(*bytes));
-    (void)ucs_atomic_swap32(dst, value);
+    UCS_STATIC_ASSERT((sizeof(*bytes) == 2) || (sizeof(*bytes) == 4));
+
+    if (sizeof(*bytes) == 2) {
+        memcpy(&value16, bytes, sizeof(*bytes));
+        (void)ucs_atomic_swap16(dst, value16);
+    } else {
+        memcpy(&value32, bytes, sizeof(*bytes));
+        (void)ucs_atomic_swap32(dst, value32);
+    }
 }
 
 ucs_status_t


### PR DESCRIPTION
On RISC-V for an atomic update the destination must be naturally aligned with the size of the type. Since the destinations in this case are addresses of library functions to patch we cannot control the addresses. Fortunately the instructions must be aligned to a 16-bit alignment which also matches the potential size of the patch on RISC-V (compressed J instruction.)

For other architectures the size of patch is either 4 bytes (aarch64) or 2 bytes (x86-64) which are both handled by this patch.

## What
Use atomic updates that match size of data to be updated

## Why ?
For RISC-V (and potentially for other architectures) the target address for atomic instructions should be naturally aligned with the size of the value.

## How ?
Check the size of the value and use the atomic update function that matches the size.
