### PR TITLE
UCT/CUDA: Moved declaration of commonly used methods to the separate header file.

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -211,13 +211,20 @@ build_cuda() {
 		if az_module_load $GDRCOPY_MODULE
 		then
 			echo "==== Build with enable cuda, gdr_copy ===="
-			${WORKSPACE}/contrib/configure-devel --prefix=$ucx_inst --with-cuda --with-gdrcopy
-			$MAKEP
-			make_clean distclean
-
 			${WORKSPACE}/contrib/configure-release --prefix=$ucx_inst --with-cuda --with-gdrcopy
 			$MAKEP
 			make_clean distclean
+
+			echo "==== Build with enable cuda, gdr_copy by ./configure parameter ===="
+			# Use path to CUDA instead of loading CUDA as module, to check
+			# GDRCopy subcomponent does not include CUDA headers
+			cuda_path=$(dirname $(dirname $(which nvcc)))
+			az_module_unload $CUDA_MODULE
+			${WORKSPACE}/contrib/configure-devel --prefix=$ucx_inst --with-cuda=$cuda_path --with-gdrcopy
+			$MAKEP
+			make_clean distclean
+			az_module_load $CUDA_MODULE
+
 			az_module_unload $GDRCOPY_MODULE
 		fi
 

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1486,7 +1486,8 @@ static ucs_status_t uct_perf_setup(ucx_perf_context_t *perf)
     uct_iface_params_t iface_params = {
         .field_mask           = UCT_IFACE_PARAM_FIELD_OPEN_MODE   |
                                 UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
-                                UCT_IFACE_PARAM_FIELD_RX_HEADROOM,
+                                UCT_IFACE_PARAM_FIELD_RX_HEADROOM |
+                                UCT_IFACE_PARAM_FIELD_DEVICE,
         .open_mode            = UCT_IFACE_OPEN_MODE_DEVICE,
         .mode.device.tl_name  = params->uct.tl_name,
         .mode.device.dev_name = params->uct.dev_name,

--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -9,8 +9,12 @@
 #endif
 
 #include "cuda_iface.h"
+#include "cuda_md.h"
 
 #include <ucs/sys/string.h>
+
+
+#define UCT_CUDA_DEV_NAME "cuda"
 
 
 const char *uct_cuda_base_cu_get_error_string(CUresult result)
@@ -78,6 +82,20 @@ ucs_status_t uct_cuda_base_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
     }
 
     *fd_p = iface->eventfd;
+    return UCS_OK;
+}
+
+ucs_status_t uct_cuda_base_check_device_name(const uct_iface_params_t *params)
+{
+    UCT_CHECK_PARAM(params->field_mask & UCT_IFACE_PARAM_FIELD_DEVICE,
+                    "UCT_IFACE_PARAM_FIELD_DEVICE is not defined");
+
+    if (strncmp(params->mode.device.dev_name, UCT_CUDA_DEV_NAME,
+                strlen(UCT_CUDA_DEV_NAME)) != 0) {
+        ucs_error("no device was found: %s", params->mode.device.dev_name);
+        return UCS_ERR_NO_DEVICE;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -17,8 +17,6 @@
 
 const char *uct_cuda_base_cu_get_error_string(CUresult result);
 
-#define UCT_CUDA_DEV_NAME       "cuda"
-
 
 #if CUDART_VERSION >= 11010
 #define UCT_CUDA_FUNC_PTX_ERR(_result, _func, _err_str)         \
@@ -138,11 +136,6 @@ ucs_status_t
 uct_cuda_base_query_devices_common(
         uct_md_h md, uct_device_type_t dev_type,
         uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p);
-
-ucs_status_t
-uct_cuda_base_query_devices(
-        uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
-        unsigned *num_tl_devices_p);
 
 void
 uct_cuda_base_get_sys_dev(CUdevice cuda_device,

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -6,6 +6,7 @@
 #ifndef UCT_CUDA_MD_H
 #define UCT_CUDA_MD_H
 
+#include <uct/base/uct_iface.h>
 #include <uct/base/uct_md.h>
 
 
@@ -13,5 +14,32 @@ ucs_status_t
 uct_cuda_base_query_md_resources(uct_component_t *component,
                                  uct_md_resource_desc_t **resources_p,
                                  unsigned *num_resources_p);
+
+
+/**
+ * Query the list of available cuda devices.
+ *
+ * @param [in]  md               Memory domain to run the query on.
+ * @param [out] tl_devices_p     List of available devices on the md.
+ * @param [out] num_tl_devices_p Number of available devices on the md.
+ *
+ * @return UCS_OK if successful, or UCS_ERR_NO_MEMORY if failed to allocate the
+ *         array of device resources.
+ */
+ucs_status_t
+uct_cuda_base_query_devices(uct_md_h md,
+                            uct_tl_device_resource_t **tl_devices_p,
+                            unsigned *num_tl_devices_p);
+
+
+/**
+ * Check the device name of interface parameter.
+ *
+ * @param [in]  params           Interface parameters to check.
+ *
+ * @return UCS_OK if successful, or UCS_ERR_NO_DEVICE if the device name is
+ *         invalid.
+ */
+ucs_status_t uct_cuda_base_check_device_name(const uct_iface_params_t *params);
 
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -410,10 +410,9 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
                               &uct_cuda_copy_iface_internal_ops, md, worker,
                               params, tl_config, "cuda_copy");
 
-    if (strncmp(params->mode.device.dev_name,
-                UCT_CUDA_DEV_NAME, strlen(UCT_CUDA_DEV_NAME)) != 0) {
-        ucs_error("no device was found: %s", params->mode.device.dev_name);
-        return UCS_ERR_NO_DEVICE;
+    status = uct_cuda_base_check_device_name(params);
+    if (status != UCS_OK) {
+        return status;
     }
 
     self->id                     = ucs_generate_uuid((uintptr_t)self);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -12,6 +12,7 @@
 #include "cuda_ipc_ep.h"
 
 #include <uct/cuda/base/cuda_iface.h>
+#include <uct/cuda/base/cuda_md.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/string.h>
 #include <ucs/debug/assert.h>
@@ -489,10 +490,9 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
                               &uct_cuda_ipc_iface_internal_ops, md, worker, params,
                               tl_config, "cuda_ipc");
 
-    if (strncmp(params->mode.device.dev_name,
-                UCT_CUDA_DEV_NAME, strlen(UCT_CUDA_DEV_NAME)) != 0) {
-        ucs_error("No device was found: %s", params->mode.device.dev_name);
-        return UCS_ERR_NO_DEVICE;
+    status = uct_cuda_base_check_device_name(params);
+    if (status != UCS_OK) {
+        return status;
     }
 
     self->config.max_poll            = config->max_poll;

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -11,7 +11,7 @@
 #include "gdr_copy_md.h"
 #include "gdr_copy_ep.h"
 
-#include <uct/cuda/base/cuda_iface.h>
+#include <uct/cuda/base/cuda_md.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/string.h>
 
@@ -184,16 +184,17 @@ static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worke
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
+    ucs_status_t status;
+
     UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_gdr_copy_iface_ops,
                               &uct_gdr_copy_iface_internal_ops, md, worker,
                               params,
                               tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG("gdr_copy"));
 
-    if (strncmp(params->mode.device.dev_name,
-                UCT_CUDA_DEV_NAME, strlen(UCT_CUDA_DEV_NAME)) != 0) {
-        ucs_error("No device was found: %s", params->mode.device.dev_name);
-        return UCS_ERR_NO_DEVICE;
+    status = uct_cuda_base_check_device_name(params);
+    if (status != UCS_OK) {
+        return status;
     }
 
     self->id = ucs_generate_uuid((uintptr_t)self);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -19,7 +19,7 @@
 #include <ucs/profile/profile.h>
 #include <ucm/api/ucm.h>
 #include <uct/api/v2/uct_v2.h>
-#include <uct/cuda/base/cuda_iface.h>
+#include <uct/cuda/base/cuda_md.h>
 
 #define UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN 65536
 
@@ -114,7 +114,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
                  unsigned flags, uct_gdr_copy_mem_t *mem_hndl)
 {
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
-    CUdeviceptr d_ptr     = ((CUdeviceptr )(char *) address);
+    unsigned long d_ptr   = ((unsigned long)(char*)address);
     ucs_log_level_t log_level;
     int ret;
 


### PR DESCRIPTION
## What
Created cuda_base.h to include the file in gdr_copy subcomponent to get rid of including of CUDA Runtime header.
Moved uct_cuda_base_query_devices to cuda_base.h.
Added uct_cuda_base_check_device_name to cuda_base.h, and moved macro UCT_CUDA_DEV_NAME from cuda_iface.h to cuda_iface.c to incapsulate the usage of the string constant.
Replaced `CUdeviceptr` by `unsigned long` to pass the type used by gdr copy API.
Replaced cuda_iface.h by cuda_md.h in gdr_copy_md.c because only a method from cuda_md.h is used.

## Why ?
The PR fixes build issues https://github.com/openucx/ucx/issues/9260 introduced by https://github.com/openucx/ucx/pull/9233, completing removing dependency on CUDA headers and libraries from gdr_copy subcomponent .
