### PR TITLE
UCP/MM: Use rcache in mem type pack

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -943,12 +943,12 @@ ucs_status_t ucp_mem_unmap(ucp_context_h context, ucp_mem_h memh)
 
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,
-                                      ucp_md_index_t md_index, uct_mem_h *memh,
-                                      ucp_md_map_t *md_map,
+                                      ucp_md_index_t md_index, ucp_mem_h *memh_p,
                                       uct_rkey_bundle_t *rkey_bundle)
 {
     ucp_context_h context           = worker->context;
     const uct_md_attr_v2_t *md_attr = &context->tl_mds[md_index].attr;
+    ucp_mem_h memh                  = NULL; /* To suppress compiler warning */
     uct_component_h cmpt;
     ucp_tl_md_t *tl_md;
     ucs_status_t status;
@@ -964,15 +964,14 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
     tl_md  = &context->tl_mds[md_index];
     cmpt   = context->tl_cmpts[tl_md->cmpt_index].cmpt;
 
-    status = ucp_mem_rereg_mds(context, UCS_BIT(md_index), remote_addr, length,
-                               UCT_MD_MEM_ACCESS_ALL,
-                               NULL, mem_type, NULL, memh, md_map);
+    status = ucp_memh_get(context, remote_addr, length, mem_type,
+                          UCS_BIT(md_index), UCT_MD_MEM_ACCESS_ALL, &memh);
     if (status != UCS_OK) {
         goto out;
     }
 
     rkey_buffer = ucs_alloca(md_attr->rkey_packed_size);
-    status      = uct_md_mkey_pack(tl_md->md, memh[0], rkey_buffer);
+    status      = uct_md_mkey_pack(tl_md->md, memh->uct[md_index], rkey_buffer);
     if (status != UCS_OK) {
         ucs_error("failed to pack key from md[%d]: %s",
                   md_index, ucs_status_string(status));
@@ -986,20 +985,17 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
         goto out_dereg_mem;
     }
 
+    *memh_p = memh;
     return UCS_OK;
 
 out_dereg_mem:
-    ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL, mem_type, NULL,
-                      memh, md_map);
+    ucp_memh_put(memh);
 out:
-    *memh = UCT_MEM_HANDLE_NULL;
     return status;
 }
 
-void ucp_mem_type_unreg_buffers(ucp_worker_h worker, ucs_memory_type_t mem_type,
-                                ucp_md_index_t md_index, uct_mem_h *memh,
-                                ucp_md_map_t *md_map,
-                                uct_rkey_bundle_t *rkey_bundle)
+void ucp_mem_type_unreg_buffers(ucp_worker_h worker, ucp_md_index_t md_index,
+                                ucp_mem_h memh, uct_rkey_bundle_t *rkey_bundle)
 {
     ucp_context_h context = worker->context;
     ucp_rsc_index_t cmpt_index;
@@ -1007,10 +1003,8 @@ void ucp_mem_type_unreg_buffers(ucp_worker_h worker, ucs_memory_type_t mem_type,
     if (rkey_bundle->rkey != UCT_INVALID_RKEY) {
         cmpt_index = context->tl_mds[md_index].cmpt_index;
         uct_rkey_release(context->tl_cmpts[cmpt_index].cmpt, rkey_bundle);
+        ucp_memh_put(memh);
     }
-
-    ucp_mem_rereg_mds(context, 0, NULL, 0, 0, NULL, mem_type, NULL,
-                      memh, md_map);
 }
 
 ucs_status_t ucp_mem_query(const ucp_mem_h memh, ucp_mem_attr_t *attr)

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -147,14 +147,11 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
 
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,
-                                      ucp_md_index_t md_index, uct_mem_h *memh,
-                                      ucp_md_map_t *md_map,
+                                      ucp_md_index_t md_index, ucp_mem_h *memh_p,
                                       uct_rkey_bundle_t *rkey_bundle);
 
-void ucp_mem_type_unreg_buffers(ucp_worker_h worker, ucs_memory_type_t mem_type,
-                                ucp_md_index_t md_index, uct_mem_h *memh,
-                                ucp_md_map_t *md_map,
-                                uct_rkey_bundle_t *rkey_bundle);
+void ucp_mem_type_unreg_buffers(ucp_worker_h worker, ucp_md_index_t md_index,
+                                ucp_mem_h memh, uct_rkey_bundle_t *rkey_bundle);
 
 ucs_status_t ucp_memh_get_slow(ucp_context_h context, void *address,
                                size_t length, ucs_memory_type_t mem_type,

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -31,10 +31,9 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
                       size_t recv_length, ucs_memory_type_t mem_type)
 {
     ucp_ep_h ep         = worker->mem_type_ep[mem_type];
-    ucp_md_map_t md_map = 0;
     ucp_lane_index_t lane;
     unsigned md_index;
-    uct_mem_h memh[1];
+    ucp_mem_h memh;
     ucs_status_t status;
     uct_rkey_bundle_t rkey_bundle;
 
@@ -45,9 +44,8 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
     lane     = ucp_ep_config(ep)->key.rma_lanes[0];
     md_index = ucp_ep_md_index(ep, lane);
 
-    status = ucp_mem_type_reg_buffers(worker, buffer, recv_length,
-                                      mem_type, md_index, memh, &md_map,
-                                      &rkey_bundle);
+    status = ucp_mem_type_reg_buffers(worker, buffer, recv_length, mem_type,
+                                      md_index, &memh, &rkey_bundle);
     if (status != UCS_OK) {
         ucs_fatal("failed to register buffer with mem type domain %s",
                   ucs_memory_type_names[mem_type]);
@@ -60,8 +58,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
                   ucs_status_string(status));
     }
 
-    ucp_mem_type_unreg_buffers(worker, mem_type, md_index, memh,
-                               &md_map, &rkey_bundle);
+    ucp_mem_type_unreg_buffers(worker, md_index, memh, &rkey_bundle);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
@@ -70,11 +67,10 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
                       size_t length, ucs_memory_type_t mem_type)
 {
     ucp_ep_h ep         = worker->mem_type_ep[mem_type];
-    ucp_md_map_t md_map = 0;
     ucp_lane_index_t lane;
     ucp_md_index_t md_index;
     ucs_status_t status;
-    uct_mem_h memh[1];
+    ucp_mem_h memh;
     uct_rkey_bundle_t rkey_bundle;
 
     if (length == 0) {
@@ -85,7 +81,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
     md_index = ucp_ep_md_index(ep, lane);
 
     status = ucp_mem_type_reg_buffers(worker, (void *)src, length, mem_type,
-                                      md_index, memh, &md_map, &rkey_bundle);
+                                      md_index, &memh, &rkey_bundle);
     if (status != UCS_OK) {
         ucs_fatal("failed to register buffer with mem type domain %s",
                   ucs_memory_type_names[mem_type]);
@@ -98,8 +94,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
                   ucs_status_string(status));
     }
 
-    ucp_mem_type_unreg_buffers(worker, mem_type, md_index, memh,
-                               &md_map, &rkey_bundle);
+    ucp_mem_type_unreg_buffers(worker, md_index, memh, &rkey_bundle);
 }
 
 size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,


### PR DESCRIPTION
## Why
This approach caches memory registration for memory needing special treatment like CUDA. It also facilitates the removal of gdrcopy rcache, replacing it with UCP rcache.
