### PR TITLE
UCM/BISTRO: Use constant size in memcpy for ucm_bistro_modify_code

### DIFF
--- a/src/ucm/bistro/bistro.c
+++ b/src/ucm/bistro/bistro.c
@@ -53,13 +53,14 @@ void ucm_bistro_modify_code(void *dst, const ucm_bistro_lock_t *bytes)
     uint16_t value16;
     uint32_t value32;
 
-    UCS_STATIC_ASSERT((sizeof(*bytes) == 2) || (sizeof(*bytes) == 4));
+    UCS_STATIC_ASSERT((sizeof(*bytes) == sizeof(value16)) ||
+                      (sizeof(*bytes) == sizeof(value32)));
 
-    if (sizeof(*bytes) == 2) {
-        memcpy(&value16, bytes, sizeof(*bytes));
+    if (sizeof(*bytes) == sizeof(value16)) {
+        memcpy(&value16, bytes, sizeof(value16));
         (void)ucs_atomic_swap16(dst, value16);
     } else {
-        memcpy(&value32, bytes, sizeof(*bytes));
+        memcpy(&value32, bytes, sizeof(value32));
         (void)ucs_atomic_swap32(dst, value32);
     }
 }


### PR DESCRIPTION
By using the static constant value we can be sure that the compiler will not generate an out of bounds error even for code that is unreachable.

e.g If sizeof(ucm_bistro_lock_t) == 4 the compiler generates an out of bounds error for the copy of bytes into the uint16_t (as 4 > 2) even though that code is unreachable.

Fixes: #9269

## What
Using constant values for memcpy to avoid compiler error for unreachable code.

## Why ?
Fix for #9269

## How ?
Using a constant value will prevent the out-of-bounds since the number of bytes is the same as the size of the type.