### PR TITLE
UCP/WORKER: Destroy mem_type EPs in case of worker creation error

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2576,7 +2576,7 @@ err_tag_match_cleanup:
 err_destroy_mpools:
     ucp_worker_destroy_mpools(worker);
 err_destroy_memtype_eps:
-    ucp_worker_mem_type_eps_create(worker);
+    ucp_worker_mem_type_eps_destroy(worker);
 err_close_cms:
     ucp_worker_close_cms(worker);
 err_close_ifaces:


### PR DESCRIPTION
## What
Call `ucp_worker_mem_type_eps_destroy` instead of `ucp_worker_mem_type_eps_create` during `ucp_worker_cleanup` cleanup.
