### PR TITLE
UCP/FLUSH: Align assertion check with connect_lane_to_iface logic

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -226,7 +226,8 @@ static void ucp_ep_flush_request_resched(ucp_ep_h ep, ucp_request_t *req)
     if (ep->flags & UCP_EP_FLAG_BLOCK_FLUSH) {
         /* Request was detached from pending and should be scheduled again */
         if (ucp_ep_has_cm_lane(ep) ||
-            ep->worker->context->config.ext.proto_request_reset) {
+            (ucp_ep_config(ep)->p2p_lanes &&
+             ep->worker->context->config.ext.proto_request_reset)) {
             ucs_assertv(!req->send.flush.started_lanes,
                         "req=%p flush started_lanes=0x%x", req,
                         req->send.flush.started_lanes);


### PR DESCRIPTION
## Why
Fix test failure:
```
[ RUN      ] dcx/test_ucp_rma.get_nonblocking/3 <dc_x,cuda_copy,rocm_copy/user_memh>
[swx-rain04:256279:0:256279]       flush.c:232  Assertion `!req->send.flush.started_lanes' failed: req=0x5511540 flush started_lanes=0x1
```

## How
Align the flush assertion check with:
https://github.com/openucx/ucx/blob/5221a5c2cf4265b6a83da3cd540f5d4898fa6f70/src/ucp/wireup/wireup.c#L1075-L1076