### PR TITLE
UCP/WIREUP: Use UCT is_reachable_v2 and adapt corresponding UCT trans…

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1252,12 +1252,18 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
 {
     ucp_context_h context      = ep->worker->context;
     ucp_worker_iface_t *wiface = ucp_worker_iface(ep->worker, rsc_index);
+    uct_iface_is_reachable_params_t params = {
+        .field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                       UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR,
+        .device_addr = ae->dev_addr,
+        .iface_addr  = ae->iface_addr,
+    };
 
     return (context->tl_rscs[rsc_index].tl_name_csum == ae->tl_name_csum) &&
            (/* assume reachability is checked by CM, if EP selects lanes
              * during CM phase */
             (ep_init_flags & UCP_EP_INIT_CM_PHASE) ||
-            uct_iface_is_reachable(wiface->iface, ae->dev_addr, ae->iface_addr));
+            uct_iface_is_reachable_v2(wiface->iface, &params));
 }
 
 static void

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -242,11 +242,38 @@ static int uct_iface_is_same_device(const uct_iface_h iface,
     return !memcmp(device_addr, dev_addr, attr.device_addr_len);
 }
 
-int
-uct_base_iface_is_reachable_v2(const uct_iface_h iface,
-                               const uct_iface_is_reachable_params_t *params)
+int uct_iface_is_reachable_params_valid(
+        const uct_iface_is_reachable_params_t *params, uint64_t flags)
+{
+    if (!ucs_test_all_flags(params->field_mask, flags)) {
+        ucs_error("uct_iface_is_reachable: missing params "
+                  "(field_mask: %lu, expected: %lu)",
+                  params->field_mask, flags);
+        return 0;
+    }
+
+    if (params->field_mask & UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING) {
+        if (params->info_string == NULL) {
+            ucs_error("uct_iface_is_reachable: null info_string passed");
+            return 0;
+        }
+
+        params->info_string[0] = '\0';
+    }
+
+    return 1;
+}
+
+int uct_base_iface_is_reachable_v2(
+        const uct_iface_h iface, const uct_iface_is_reachable_params_t *params)
 {
     uct_iface_reachability_scope_t scope;
+
+    if (!uct_iface_is_reachable_params_valid(params,
+                            UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
+                            UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR)) {
+        return 0;
+    }
 
     if (!uct_iface_is_reachable(iface, params->device_addr,
                                 params->iface_addr)) {
@@ -265,19 +292,21 @@ int uct_iface_is_reachable_v2(const uct_iface_h tl_iface,
 {
     const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
 
-    if (!ucs_test_all_flags(params->field_mask,
-                            UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
-                            UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR)) {
-        ucs_error("missing params (field_mask: %lu), both device_addr and "
-                  "iface_addr should be supplied.", params->field_mask);
-        return 0;
-    }
-
-    if (params->field_mask & UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING) {
-        params->info_string[0] = '\0';
-    }
-
     return iface->internal_ops->iface_is_reachable_v2(tl_iface, params);
+}
+
+int uct_base_iface_is_reachable(const uct_iface_h tl_iface,
+                                const uct_device_addr_t *dev_addr,
+                                const uct_iface_addr_t *iface_addr)
+{
+    uct_iface_is_reachable_params_t params = {
+        .field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                       UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR,
+        .device_addr = dev_addr,
+        .iface_addr  = iface_addr
+    };
+
+    return uct_iface_is_reachable_v2(tl_iface, &params);
 }
 
 ucs_status_t uct_ep_check(const uct_ep_h ep, unsigned flags,

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -856,6 +856,10 @@ int
 uct_base_iface_is_reachable_v2(const uct_iface_h iface,
                                const uct_iface_is_reachable_params_t *params);
 
+int uct_base_iface_is_reachable(const uct_iface_h tl_iface,
+                                const uct_device_addr_t *dev_addr,
+                                const uct_iface_addr_t *iface_addr);
+
 ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);
 
@@ -866,6 +870,9 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
 
 int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
                                  ucs_sys_namespace_type_t sys_ns_type);
+
+int uct_iface_is_reachable_params_valid(
+        const uct_iface_is_reachable_params_t *params, uint64_t flags);
 
 /*
  * Invoke active message handler.

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -474,10 +474,6 @@ const char *uct_ib_address_str(const uct_ib_address_t *ib_addr, char *buf,
 ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
                                              uct_device_addr_t *dev_addr);
 
-int uct_ib_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
-                              const uct_iface_addr_t *iface_addr);
-
-
 int uct_ib_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                  const uct_iface_is_reachable_params_t *params);
 
@@ -578,7 +574,6 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface,
                             uct_ib_qp_attr_t *attr);
 
 uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
-
 
 #define UCT_IB_IFACE_FMT \
     "%s:%d/%s"

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -913,21 +913,27 @@ void uct_dc_mlx5_iface_init_version(uct_dc_mlx5_iface_t *iface, uct_md_h md)
     }
 }
 
-int uct_dc_mlx5_iface_is_reachable(const uct_iface_h tl_iface,
-                                   const uct_device_addr_t *dev_addr,
-                                   const uct_iface_addr_t *iface_addr)
+static int
+uct_dc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                  const uct_iface_is_reachable_params_t *params)
 {
-    uct_dc_mlx5_iface_addr_t *addr = (uct_dc_mlx5_iface_addr_t *)iface_addr;
-    uct_dc_mlx5_iface_t *iface;
+    uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
+    const uct_dc_mlx5_iface_addr_t *addr;
+    int same_tm, same_version;
 
-    iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
-    ucs_assert_always(iface_addr != NULL);
+    addr = (const uct_dc_mlx5_iface_addr_t*)UCS_PARAM_VALUE(
+            UCT_IFACE_IS_REACHABLE_FIELD, params, iface_addr, IFACE_ADDR, NULL);
+    if (addr != NULL) {
+        same_tm      = (UCT_DC_MLX5_IFACE_ADDR_TM_ENABLED(addr) ==
+                        UCT_RC_MLX5_TM_ENABLED(&iface->super));
+        same_version = ((addr->flags & UCT_DC_MLX5_IFACE_ADDR_DC_VERS) ==
+                        iface->version_flag);
+        if (!same_version || !same_tm) {
+            return 0;
+        }
+    }
 
-    return ((addr->flags & UCT_DC_MLX5_IFACE_ADDR_DC_VERS) ==
-            iface->version_flag) &&
-           (UCT_DC_MLX5_IFACE_ADDR_TM_ENABLED(addr) ==
-            UCT_RC_MLX5_TM_ENABLED(&iface->super)) &&
-           uct_ib_iface_is_reachable(tl_iface, dev_addr, iface_addr);
+    return uct_ib_iface_is_reachable_v2(tl_iface, params);
 }
 
 ucs_status_t
@@ -1264,7 +1270,7 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_dc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_dc_mlx5_iface_is_reachable_v2,
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,
@@ -1320,7 +1326,7 @@ static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t),
     .iface_query              = uct_dc_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_is_reachable       = uct_dc_mlx5_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable,
     .iface_get_address        = uct_dc_mlx5_iface_get_address,
 };
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -345,10 +345,6 @@ ucs_status_t
 uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface,
                              const uct_dc_mlx5_iface_config_t *config);
 
-int uct_dc_mlx5_iface_is_reachable(const uct_iface_h tl_iface,
-                                   const uct_device_addr_t *dev_addr,
-                                   const uct_iface_addr_t *iface_addr);
-
 ucs_status_t uct_dc_mlx5_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr);
 
 ucs_status_t uct_dc_mlx5_iface_flush(uct_iface_h tl_iface, unsigned flags, uct_completion_t *comp);

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -703,17 +703,21 @@ static ucs_status_t uct_rc_mlx5_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-int uct_rc_mlx5_iface_is_reachable(const uct_iface_h tl_iface,
-                                   const uct_device_addr_t *dev_addr,
-                                   const uct_iface_addr_t *iface_addr)
+static int
+uct_rc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                  const uct_iface_is_reachable_params_t *params)
 {
     uint8_t my_type = uct_rc_mlx5_iface_get_address_type(tl_iface);
+    const uct_iface_addr_t *iface_addr;
 
+    iface_addr = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
+                                 iface_addr, IFACE_ADDR, NULL);
+    /* Check hardware tag matching compatibility */
     if ((iface_addr != NULL) && (my_type != *(uint8_t*)iface_addr)) {
         return 0;
     }
 
-    return uct_ib_iface_is_reachable(tl_iface, dev_addr, iface_addr);
+    return uct_ib_iface_is_reachable_v2(tl_iface, params);
 }
 
 ucs_status_t uct_rc_mlx5_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
@@ -1007,7 +1011,7 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
             .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate         = uct_rc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_rc_mlx5_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2
+            .iface_is_reachable_v2 = uct_rc_mlx5_iface_is_reachable_v2
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,
@@ -1069,7 +1073,7 @@ static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {
     .iface_query              = uct_rc_mlx5_iface_query,
     .iface_get_address        = uct_rc_mlx5_iface_get_address,
     .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_is_reachable       = uct_rc_mlx5_iface_is_reachable
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static ucs_status_t

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -500,7 +500,7 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
     .iface_query              = uct_rc_verbs_iface_query,
     .iface_get_address        = ucs_empty_function_return_success,
     .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_is_reachable       = uct_ib_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable,
 };
 
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -876,7 +876,7 @@ static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
     .iface_query              = uct_ud_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
-    .iface_is_reachable       = uct_ib_iface_is_reachable
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static ucs_status_t uct_ud_mlx5dv_calc_tx_wqe_ratio(uct_ib_mlx5_md_t *md)

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -653,7 +653,7 @@ static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {
     .iface_query              = uct_ud_verbs_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
-    .iface_is_reachable       = uct_ib_iface_is_reachable
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static UCS_F_NOINLINE void

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -27,6 +27,17 @@ protected:
         EXPECT_TRUE(check_pkey(m_e2->iface(), m_pkey[1], m_pkey_index[1]));
     }
 
+    int check_is_reachable(const uct_iface_h tl_iface,
+                           const uct_device_addr_t *dev_addr)
+    {
+        uct_iface_is_reachable_params_t params = {
+            .field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR,
+            .device_addr = dev_addr
+        };
+
+        return uct_iface_is_reachable_v2(tl_iface, &params);
+    }
+
     void cleanup_entities() {
         m_e1->destroy_eps();
         m_e2->destroy_eps();
@@ -207,12 +218,11 @@ UCS_TEST_P(test_uct_ib_pkey, test_pkey_pairs) {
                     !((pkey1 | pkey2) & UCT_IB_PKEY_MEMBERSHIP_MASK) ||
                     /* the PKEYs are not equal */
                     ((pkey1 ^ pkey2) & UCT_IB_PKEY_PARTITION_MASK));
-        EXPECT_EQ(res, uct_ib_iface_is_reachable(m_e1->iface(),
-                                                 (uct_device_addr_t*)ib_addr2,
-                                                 NULL));
-        EXPECT_EQ(res, uct_ib_iface_is_reachable(m_e2->iface(),
-                                                 (uct_device_addr_t*)ib_addr1,
-                                                 NULL));
+
+        EXPECT_EQ(res, check_is_reachable(m_e1->iface(),
+                                          (uct_device_addr_t*)ib_addr2));
+        EXPECT_EQ(res, check_is_reachable(m_e2->iface(),
+                                          (uct_device_addr_t*)ib_addr1));
 
         if (res) {
             test_uct_ib::send_recv_short();


### PR DESCRIPTION
## What
Use UCT is_reachable_v2 in UCP code.

## Why ?
We will need to add new fields for reachability test.

## How ?
Use v2 UCT API without requesting for scoping, which is equivalent to v1 API.

Only two IB transports are not using strictly identical reachability tests between v1 and v2, so we fix and cleanup by:
- moving any missing check to v2 functions
- making sure IB is_reachable is actually using IB is_reachable_v2
