### PR TITLE
UCT/IB: Avoid using ibv_mr::addr field

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -245,6 +245,7 @@ typedef union {
 
 typedef struct {
     uct_ib_mem_t            super;
+    void                    *address;
     struct mlx5dv_devx_obj  *atomic_dvmr;
     struct mlx5dv_devx_obj  *indirect_dvmr;
     struct mlx5dv_devx_umem *umem;


### PR DESCRIPTION
## What
Stores memory region address explicitly and separately of `ibv_mr` to avoid using `ibv_mr::addr` field.

## Why
For some reason `ibv_reg_dmabuf_mr` stores offset instead of address to the output structure (https://github.com/linux-rdma/rdma-core/blob/master/libibverbs/verbs.c#L411). So we need to avoid using it, since it leads to incorrect KSM creation.