### PR TITLE
UCP/RCACHE: move rcache config to ucs and use for ucp_rcache - v1.15.x

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -545,6 +545,10 @@ static ucs_config_field_t ucp_config_table[] = {
   {"RCACHE_ENABLE", "try", "Use user space memory registration cache.",
    ucs_offsetof(ucp_config_t, enable_rcache), UCS_CONFIG_TYPE_TERNARY},
 
+  {"", "RCACHE_PURGE_ON_FORK=y;RCACHE_MEM_PRIO=500;", NULL,
+   ucs_offsetof(ucp_config_t, rcache_config),
+   UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
+
   {"", "", NULL,
    ucs_offsetof(ucp_config_t, ctx),
    UCS_CONFIG_TYPE_TABLE(ucp_context_config_table)},
@@ -2167,7 +2171,7 @@ ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_ver
     context->next_memh_reg_id = 0;
 
     if (config->enable_rcache != UCS_NO) {
-        status = ucp_mem_rcache_init(context);
+        status = ucp_mem_rcache_init(context, &config->rcache_config);
         if (status != UCS_OK) {
             if (config->enable_rcache == UCS_YES) {
                 ucs_error("could not create UCP registration cache: %s",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -193,6 +193,8 @@ struct ucp_config {
     UCS_CONFIG_ARRAY_FIELD(size_t, memunits) mpool_sizes;
     /** Memory registration cache */
     ucs_ternary_auto_value_t               enable_rcache;
+    /* Registration cache configuration */
+    ucs_rcache_config_t                    rcache_config;
     /** Configuration saved directly in the context */
     ucp_context_config_t                   ctx;
     /** Save ucx configurations not listed in ucp_config_table **/

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1328,32 +1328,28 @@ static ucs_rcache_ops_t ucp_mem_rcache_ops = {
 
 static ucs_status_t
 ucp_mem_rcache_create(ucp_context_h context, const char *name,
-                      ucs_rcache_t **rcache_p)
+                      ucs_rcache_t **rcache_p, ucs_rcache_params_t *rcache_params)
 {
-    ucs_rcache_params_t rcache_params;
+    rcache_params->region_struct_size = ucp_memh_size(context);
+    rcache_params->ucm_events         = UCM_EVENT_VM_UNMAPPED |
+                                        UCM_EVENT_MEM_TYPE_FREE;
+    rcache_params->context            = context;
+    rcache_params->ops                = &ucp_mem_rcache_ops;
 
-    rcache_params.region_struct_size = ucp_memh_size(context);
-    rcache_params.max_alignment      = ucs_get_page_size();
-    rcache_params.max_unreleased     = SIZE_MAX;
-    rcache_params.max_regions        = -1;
-    rcache_params.max_size           = -1;
-    rcache_params.ucm_event_priority = 500; /* Default UCT pri - 1000 */
-    rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED |
-                                       UCM_EVENT_MEM_TYPE_FREE;
-    rcache_params.context            = context;
-    rcache_params.ops                = &ucp_mem_rcache_ops;
-    rcache_params.flags              = UCS_RCACHE_FLAG_PURGE_ON_FORK;
-    rcache_params.alignment          = UCS_RCACHE_MIN_ALIGNMENT;
-
-    return ucs_rcache_create(&rcache_params, name, ucs_stats_get_root(),
+    return ucs_rcache_create(rcache_params, name, ucs_stats_get_root(),
                              rcache_p);
 }
 
-ucs_status_t ucp_mem_rcache_init(ucp_context_h context)
+ucs_status_t ucp_mem_rcache_init(ucp_context_h context,
+                                 const ucs_rcache_config_t *rcache_config)
 {
     ucs_status_t status;
+    ucs_rcache_params_t rcache_params;
 
-    status = ucp_mem_rcache_create(context, "ucp_rcache", &context->rcache);
+    ucs_rcache_set_params(&rcache_params, rcache_config);
+
+    status = ucp_mem_rcache_create(context, "ucp_rcache", &context->rcache,
+                                   &rcache_params);
     if (status != UCS_OK) {
         goto err;
     }
@@ -1475,6 +1471,7 @@ ucp_memh_import_slow(ucp_context_h context, ucs_rcache_t *existing_rcache,
                      ucp_unpacked_exported_memh_t *unpacked)
 {
     ucs_rcache_t *rcache;
+    ucs_rcache_params_t rcache_params;
     ucs_status_t status;
     ucp_mem_h memh;
     char rcache_name[128];
@@ -1490,7 +1487,11 @@ ucp_memh_import_slow(ucp_context_h context, ucs_rcache_t *existing_rcache,
             ucs_snprintf_safe(rcache_name, sizeof(rcache_name),
                               "ucp_import_rcache[0x%" PRIx64 "]",
                               unpacked->remote_uuid);
-            status = ucp_mem_rcache_create(context, rcache_name, &rcache);
+
+            ucs_rcache_set_default_params(&rcache_params);
+
+            status = ucp_mem_rcache_create(context, rcache_name, &rcache,
+                                           &rcache_params);
             if (status != UCS_OK) {
                 goto out;
             }

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -160,7 +160,8 @@ ucs_status_t ucp_memh_get_slow(ucp_context_h context, void *address,
 
 void ucp_memh_cleanup(ucp_context_h context, ucp_mem_h memh);
 
-ucs_status_t ucp_mem_rcache_init(ucp_context_h context);
+ucs_status_t ucp_mem_rcache_init(ucp_context_h context,
+                                 const ucs_rcache_config_t *rcache_config);
 
 void ucp_mem_rcache_cleanup(ucp_context_h context);
 

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -17,6 +17,8 @@
 #include <ucs/datastruct/queue_types.h>
 #include <ucs/datastruct/mpool.h>
 #include <ucs/stats/stats_fwd.h>
+#include <ucs/time/time_def.h>
+#include <ucs/config/parser.h>
 #include <sys/mman.h>
 
 
@@ -35,6 +37,7 @@ typedef struct ucs_rcache         ucs_rcache_t;
 typedef struct ucs_rcache_ops     ucs_rcache_ops_t;
 typedef struct ucs_rcache_params  ucs_rcache_params_t;
 typedef struct ucs_rcache_region  ucs_rcache_region_t;
+typedef struct ucs_rcache_config  ucs_rcache_config_t;
 
 /*
  * Memory region flags.
@@ -67,6 +70,7 @@ enum {
 };
 
 
+extern ucs_config_field_t ucs_config_rcache_table[];
 typedef void (*ucs_rcache_invalidate_comp_func_t)(void *arg);
 
 
@@ -141,6 +145,17 @@ struct ucs_rcache_params {
     unsigned long          max_regions;         /**< Maximal number of regions */
     size_t                 max_size;            /**< Maximal total size of regions */
     size_t                 max_unreleased;      /**< Threshold for triggering a cleanup */
+};
+
+
+struct ucs_rcache_config {
+    size_t        alignment;      /**< Force address alignment */
+    unsigned      event_prio;     /**< Memory events priority */
+    ucs_time_t    overhead;       /**< Lookup overhead estimation */
+    unsigned long max_regions;    /**< Maximal number of rcache regions */
+    size_t        max_size;       /**< Maximal size of mapped memory */
+    size_t        max_unreleased; /**< Threshold for triggering a cleanup */
+    int           purge_on_fork;  /**< Enable/disable rcache purge on fork */
 };
 
 
@@ -240,6 +255,26 @@ void ucs_rcache_region_invalidate(ucs_rcache_t *rcache,
                                   ucs_rcache_region_t *region,
                                   ucs_rcache_invalidate_comp_func_t cb,
                                   void *arg);
+
+
+/**
+ * Set rcache parameters based on fields in rcache configuration.
+ *
+ * @param [out] rcache_params On success, rcache_params fields are populated
+ *                            with default values.
+ */
+void ucs_rcache_set_default_params(ucs_rcache_params_t *rcache_params);
+
+
+/**
+ * Set rcache parameters based on fields in rcache configuration.
+ *
+ * @param [out] rcache_params On success, rcache_params fields are populated
+ *                            with values provided in rcache_config.
+ * @param [in]  rcache_config Configuration used to populate rcache parameters.
+ */
+void ucs_rcache_set_params(ucs_rcache_params_t *rcache_params,
+                           const ucs_rcache_config_t *rcache_config);
 
 
 #endif

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -44,40 +44,6 @@ ucs_config_field_t uct_md_config_table[] = {
   {NULL}
 };
 
-ucs_config_field_t uct_md_config_rcache_table[] = {
-    {"RCACHE_MEM_PRIO", "1000", "Registration cache memory event priority",
-     ucs_offsetof(uct_md_rcache_config_t, event_prio), UCS_CONFIG_TYPE_UINT},
-
-    {"RCACHE_OVERHEAD", "auto", "Registration cache lookup overhead",
-     ucs_offsetof(uct_md_rcache_config_t, overhead), UCS_CONFIG_TYPE_TIME_UNITS},
-
-    {"RCACHE_ADDR_ALIGN", UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE),
-     "Registration cache address alignment, must be power of 2\n"
-     "between " UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN) "and system page size",
-     ucs_offsetof(uct_md_rcache_config_t, alignment), UCS_CONFIG_TYPE_UINT},
-
-    {"RCACHE_MAX_REGIONS", "inf",
-     "Maximal number of regions in the registration cache",
-     ucs_offsetof(uct_md_rcache_config_t, max_regions),
-     UCS_CONFIG_TYPE_ULUNITS},
-
-    {"RCACHE_MAX_SIZE", "inf",
-     "Maximal total size of registration cache regions",
-     ucs_offsetof(uct_md_rcache_config_t, max_size), UCS_CONFIG_TYPE_MEMUNITS},
-
-    {"RCACHE_MAX_UNRELEASED", "512M",
-     "Maximal size of total memory regions in invalidate queue and garbage,\n"
-     "after which a cleanup is triggered.",
-     ucs_offsetof(uct_md_rcache_config_t, max_unreleased),
-     UCS_CONFIG_TYPE_MEMUNITS},
-
-    {"RCACHE_PURGE_ON_FORK", "y",
-     "Purge registration cache upon fork",
-     ucs_offsetof(uct_md_rcache_config_t, purge_on_fork), UCS_CONFIG_TYPE_BOOL},
-
-    {NULL}
-};
-
 
 const char *uct_device_type_names[] = {
     [UCT_DEVICE_TYPE_NET]  = "network",
@@ -630,19 +596,7 @@ ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
     return UCS_OK;
 }
 
-void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
-                              const uct_md_rcache_config_t *rcache_config)
-{
-    rcache_params->alignment          = rcache_config->alignment;
-    rcache_params->ucm_event_priority = rcache_config->event_prio;
-    rcache_params->max_regions        = rcache_config->max_regions;
-    rcache_params->max_size           = rcache_config->max_size;
-    rcache_params->max_unreleased     = rcache_config->max_unreleased;
-    rcache_params->flags              = !rcache_config->purge_on_fork ? 0 :
-                                        UCS_RCACHE_FLAG_PURGE_ON_FORK;
-}
-
-double uct_md_rcache_overhead(const uct_md_rcache_config_t *rcache_config)
+double uct_md_rcache_overhead(const ucs_rcache_config_t *rcache_config)
 {
     if (rcache_config->overhead == UCS_TIME_AUTO) {
         if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM) {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -59,18 +59,6 @@
     }
 
 
-typedef struct uct_md_rcache_config {
-    size_t        alignment;      /**< Force address alignment */
-    unsigned      event_prio;     /**< Memory events priority */
-    ucs_time_t    overhead;       /**< Lookup overhead estimation */
-    unsigned long max_regions;    /**< Maximal number of rcache regions */
-    size_t        max_size;       /**< Maximal size of mapped memory */
-    size_t        max_unreleased; /**< Threshold for triggering a cleanup */
-    int           purge_on_fork;  /**< Enable/disable rcache purge on fork */
-} uct_md_rcache_config_t;
-
-
-extern ucs_config_field_t uct_md_config_rcache_table[];
 extern const char *uct_device_type_names[];
 
 /**
@@ -245,10 +233,7 @@ ucs_status_t uct_md_dummy_mem_reg(uct_md_h md, void *address, size_t length,
 ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
                                     const uct_md_mem_dereg_params_t *params);
 
-void uct_md_set_rcache_params(ucs_rcache_params_t *rcache_params,
-                              const uct_md_rcache_config_t *rcache_config);
-
-double uct_md_rcache_overhead(const uct_md_rcache_config_t *rcache_config);
+double uct_md_rcache_overhead(const ucs_rcache_config_t *rcache_config);
 
 extern ucs_config_field_t uct_md_config_table[];
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -32,7 +32,7 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
 
     {"", "RCACHE_ADDR_ALIGN=" UCS_PP_MAKE_STRING(UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN), NULL,
      ucs_offsetof(uct_gdr_copy_md_config_t, rcache),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
+     UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
 
     {"MEM_REG_OVERHEAD", "16us", "Memory registration overhead", /* TODO take default from device */
      ucs_offsetof(uct_gdr_copy_md_config_t, uc_reg_cost.m), UCS_CONFIG_TYPE_TIME},
@@ -413,13 +413,14 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
     }
 
     if (md_config->enable_rcache != UCS_NO) {
-        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
+        ucs_rcache_set_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_gdr_copy_rcache_region_t);
         rcache_params.max_alignment      = UCT_GDR_COPY_MD_RCACHE_DEFAULT_ALIGN;
         rcache_params.ucm_events         = UCM_EVENT_MEM_TYPE_FREE;
         rcache_params.context            = md;
         rcache_params.ops                = &uct_gdr_copy_rcache_ops;
         rcache_params.flags              = 0;
+
         status = ucs_rcache_create(&rcache_params, "gdr_copy", NULL, &md->rcache);
         if (status == UCS_OK) {
             md->super.ops = &md_rcache_ops;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -32,7 +32,7 @@ typedef struct uct_gdr_copy_md {
 typedef struct uct_gdr_copy_md_config {
     uct_md_config_t         super;
     int                     enable_rcache;/**< Enable registration cache */
-    uct_md_rcache_config_t  rcache;       /**< Registration cache config */
+    ucs_rcache_config_t     rcache;       /**< Registration cache config */
     ucs_linear_func_t       uc_reg_cost;  /**< Memory registration cost estimation
                                              without using the cache */
 } uct_gdr_copy_md_config_t;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -74,7 +74,7 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
 
     {"", "RCACHE_ADDR_ALIGN=" UCS_PP_MAKE_STRING(UCT_IB_MD_RCACHE_DEFAULT_ALIGN), NULL,
      ucs_offsetof(uct_ib_md_config_t, rcache),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
+     UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
 
     {"MEM_REG_OVERHEAD", "16us", "Memory registration overhead", /* TODO take default from device */
      ucs_offsetof(uct_ib_md_config_t, uc_reg_cost.c), UCS_CONFIG_TYPE_TIME},
@@ -1268,7 +1268,7 @@ uct_ib_md_parse_reg_methods(uct_ib_md_t *md,
 
     for (i = 0; i < md_config->reg_methods.count; ++i) {
         if (!strcasecmp(md_config->reg_methods.rmtd[i], "rcache")) {
-            uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
+            ucs_rcache_set_params(&rcache_params, &md_config->rcache);
             rcache_params.region_struct_size = sizeof(ucs_rcache_region_t) +
                                                md->memh_struct_size;
             rcache_params.max_alignment      = ucs_get_page_size();

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -183,7 +183,7 @@ typedef struct uct_ib_md_config {
     /** List of registration methods in order of preference */
     UCS_CONFIG_STRING_ARRAY_FIELD(rmtd) reg_methods;
 
-    uct_md_rcache_config_t   rcache;       /**< Registration cache config */
+    ucs_rcache_config_t      rcache;       /**< Registration cache config */
     ucs_linear_func_t        uc_reg_cost;  /**< Memory registration cost estimation
                                                 without using the cache */
     unsigned                 fork_init;    /**< Use ibv_fork_init() */

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -31,9 +31,9 @@ static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
      ucs_offsetof(uct_rocm_copy_md_config_t, enable_rcache),
      UCS_CONFIG_TYPE_TERNARY},
 
-    {"", "", NULL,
+    {"", "RCACHE_ADDR_ALIGN=" UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE), NULL,
      ucs_offsetof(uct_rocm_copy_md_config_t, rcache),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
+     UCS_CONFIG_TYPE_TABLE(ucs_config_rcache_table)},
 
     {"DMABUF", "no",
      "Enable using cross-device dmabuf file descriptor",
@@ -429,7 +429,8 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
     }
 
     if (md_config->enable_rcache != UCS_NO) {
-        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
+
+        ucs_rcache_set_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_rocm_copy_rcache_region_t);
         rcache_params.alignment          = ucs_get_page_size();
         rcache_params.max_alignment      = ucs_get_page_size();
@@ -438,6 +439,7 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
         rcache_params.context            = md;
         rcache_params.ops                = &uct_rocm_copy_rcache_ops;
         rcache_params.flags              = 0;
+
         status = ucs_rcache_create(&rcache_params, "rocm_copy", NULL, &md->rcache);
         if (status == UCS_OK) {
             md->super.ops = &md_rcache_ops;

--- a/src/uct/rocm/copy/rocm_copy_md.h
+++ b/src/uct/rocm/copy/rocm_copy_md.h
@@ -30,7 +30,7 @@ typedef struct uct_rocm_copy_md {
 typedef struct uct_rocm_copy_md_config {
     uct_md_config_t             super;
     ucs_ternary_auto_value_t    enable_rcache;/**< Enable registration cache */
-    uct_md_rcache_config_t      rcache;       /**< Registration cache config */
+    ucs_rcache_config_t         rcache;       /**< Registration cache config */
     ucs_linear_func_t           uc_reg_cost;  /**< Memory registration cost estimation
                                                    without using the cache */
     ucs_ternary_auto_value_t    enable_dmabuf; /**< Turn using dmabuf on/off */

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -26,13 +26,6 @@ static ucs_config_field_t uct_knem_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_knem_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
 
-    {"RCACHE", "try", "Enable using memory registration cache",
-     ucs_offsetof(uct_knem_md_config_t, rcache_enable), UCS_CONFIG_TYPE_TERNARY},
-
-    {"", "", NULL,
-     ucs_offsetof(uct_knem_md_config_t, rcache),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
-
     {NULL}
 };
 
@@ -79,9 +72,6 @@ out_empty:
 static void uct_knem_md_close(uct_md_h md)
 {
     uct_knem_md_t *knem_md = ucs_derived_of(md, uct_knem_md_t);
-    if (knem_md->rcache != NULL) {
-        ucs_rcache_destroy(knem_md->rcache);
-    }
     close(knem_md->knem_fd);
     ucs_free(knem_md);
 }
@@ -110,9 +100,6 @@ static ucs_status_t uct_knem_mem_reg_internal(uct_md_h md, void *address, size_t
     rc = ioctl(knem_fd, KNEM_CMD_CREATE_REGION, &create);
     if (rc < 0) {
         if (!silent && !(flags & UCT_MD_MEM_FLAG_HIDE_ERRORS)) {
-            /* do not report error in silent mode: it called from rcache
-             * internals, rcache will try to register memory again with
-             * more accurate data */
             ucs_error("KNEM failed to create region address %p length %zi: %m",
                       address, length);
         }
@@ -273,108 +260,11 @@ static uct_md_ops_t md_ops = {
     .detect_memory_type = ucs_empty_function_return_unsupported,
 };
 
-static inline uct_knem_rcache_region_t* uct_knem_rcache_region_from_memh(uct_mem_h memh)
-{
-    return ucs_container_of(memh, uct_knem_rcache_region_t, key);
-}
-
-static ucs_status_t
-uct_knem_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
-                        const uct_md_mem_reg_params_t *params,
-                        uct_mem_h *memh_p)
-{
-    uint64_t flags    = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS,
-                                                   0);
-    uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
-    ucs_rcache_region_t *rregion;
-    ucs_status_t status;
-
-    status = ucs_rcache_get(md->rcache, address, length, PROT_READ|PROT_WRITE,
-                            &flags, &rregion);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    ucs_assert(rregion->refcount > 0);
-    *memh_p = &ucs_derived_of(rregion, uct_knem_rcache_region_t)->key;
-    return UCS_OK;
-}
-
-static ucs_status_t
-uct_knem_mem_rcache_dereg(uct_md_h uct_md,
-                          const uct_md_mem_dereg_params_t *params)
-{
-    uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
-    uct_knem_rcache_region_t *region;
- 
-    UCT_KNEM_MD_MEM_DEREG_CHECK_PARAMS(params);
- 
-    region = uct_knem_rcache_region_from_memh(params->memh);
-
-    ucs_rcache_region_put(md->rcache, &region->super);
-    return UCS_OK;
-}
-
-static uct_md_ops_t uct_knem_md_rcache_ops = {
-    .close                  = uct_knem_md_close,
-    .query                  = uct_knem_md_query,
-    .mkey_pack              = uct_knem_mkey_pack,
-    .mem_reg                = uct_knem_mem_rcache_reg,
-    .mem_dereg              = uct_knem_mem_rcache_dereg,
-    .mem_attach             = ucs_empty_function_return_unsupported,
-    .is_sockaddr_accessible = ucs_empty_function_return_zero_int,
-    .detect_memory_type     = ucs_empty_function_return_unsupported,
-};
-
-
-static ucs_status_t uct_knem_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache,
-                                               void *arg, ucs_rcache_region_t *rregion,
-                                               uint16_t rcache_mem_reg_flags)
-{
-    uct_knem_rcache_region_t *region = ucs_derived_of(rregion, uct_knem_rcache_region_t);
-    uct_knem_md_t *md                = context;
-    int *flags                       = arg;
-
-    return uct_knem_mem_reg_internal(&md->super, (void*)region->super.super.start,
-                                     region->super.super.end - region->super.super.start,
-                                     *flags,
-                                     rcache_mem_reg_flags & UCS_RCACHE_MEM_REG_HIDE_ERRORS,
-                                     &region->key);
-}
-
-static void uct_knem_rcache_mem_dereg_cb(void *context, ucs_rcache_t *rcache,
-                                         ucs_rcache_region_t *rregion)
-{
-    uct_knem_rcache_region_t *region = ucs_derived_of(rregion, uct_knem_rcache_region_t);
-    uct_knem_md_t            *md     = context;
-
-    uct_knem_mem_dereg_internal(&md->super, &region->key);
-}
-
-static void uct_knem_rcache_dump_region_cb(void *context, ucs_rcache_t *rcache,
-                                           ucs_rcache_region_t *rregion, char *buf,
-                                           size_t max)
-{
-    uct_knem_rcache_region_t *region = ucs_derived_of(rregion, uct_knem_rcache_region_t);
-    uct_knem_key_t *key = &region->key;
-
-    snprintf(buf, max, "cookie %"PRIu64" addr %p", key->cookie, (void*)key->address);
-}
-
-static ucs_rcache_ops_t uct_knem_rcache_ops = {
-    .mem_reg     = uct_knem_rcache_mem_reg_cb,
-    .mem_dereg   = uct_knem_rcache_mem_dereg_cb,
-    .dump_region = uct_knem_rcache_dump_region_cb
-};
-
 static ucs_status_t
 uct_knem_md_open(uct_component_t *component, const char *md_name,
                  const uct_md_config_t *uct_md_config, uct_md_h *md_p)
 {
-    const uct_knem_md_config_t *md_config = ucs_derived_of(uct_md_config, uct_knem_md_config_t);
     uct_knem_md_t *knem_md;
-    ucs_rcache_params_t rcache_params;
-    ucs_status_t status;
 
     knem_md = ucs_malloc(sizeof(uct_knem_md_t), "uct_knem_md_t");
     if (NULL == knem_md) {
@@ -385,7 +275,6 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
     knem_md->super.ops       = &md_ops;
     knem_md->super.component = &uct_knem_component;
     knem_md->reg_cost        = ucs_linear_func_make(1200.0e-9, 0.007e-9);
-    knem_md->rcache          = NULL;
 
     knem_md->knem_fd = open("/dev/knem", O_RDWR);
     if (knem_md->knem_fd < 0) {
@@ -394,44 +283,8 @@ uct_knem_md_open(uct_component_t *component, const char *md_name,
         return UCS_ERR_IO_ERROR;
     }
 
-    if (md_config->rcache_enable != UCS_NO) {
-        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
-        rcache_params.region_struct_size = sizeof(uct_knem_rcache_region_t);
-        rcache_params.max_alignment      = ucs_get_page_size();
-        rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED;
-        rcache_params.context            = knem_md;
-        rcache_params.ops                = &uct_knem_rcache_ops;
-        status = ucs_rcache_create(&rcache_params, "knem", ucs_stats_get_root(),
-                                   &knem_md->rcache);
-        if (status == UCS_OK) {
-            knem_md->super.ops = &uct_knem_md_rcache_ops;
-            knem_md->reg_cost  = ucs_linear_func_make(
-                                 uct_md_rcache_overhead(&md_config->rcache), 0);
-        } else {
-            ucs_assert(knem_md->rcache == NULL);
-            if (md_config->rcache_enable == UCS_YES) {
-                ucs_error("Failed to create registration cache: %s",
-                          ucs_status_string(status));
-                uct_knem_md_close(&knem_md->super);
-                return status;
-            } else {
-                ucs_debug("Could not create registration cache: %s",
-                          ucs_status_string(status));
-            }
-        }
-    }
-
     *md_p = (uct_md_h)knem_md;
     return UCS_OK;
-}
-
-static void uct_knem_md_vfs_init(uct_md_h md)
-{
-    uct_knem_md_t *knem_md = (uct_knem_md_t*)md;
-
-    if (knem_md->rcache != NULL) {
-        ucs_vfs_obj_add_sym_link(md, knem_md->rcache, "rcache");
-    }
 }
 
 uct_component_t uct_knem_component = {
@@ -451,5 +304,5 @@ uct_component_t uct_knem_component = {
     .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
     .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_knem_component),
     .flags              = 0,
-    .md_vfs_init        = uct_knem_md_vfs_init
+    .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function 
 };

--- a/src/uct/sm/scopy/knem/knem_md.h
+++ b/src/uct/sm/scopy/knem/knem_md.h
@@ -11,7 +11,6 @@
 #include <ucs/config/types.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/type/status.h>
-#include <ucs/memory/rcache.h>
 #include <uct/base/uct_md.h>
 #include <uct/api/v2/uct_v2.h>
 
@@ -24,7 +23,6 @@ ucs_status_t uct_knem_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr);
 typedef struct uct_knem_md {
     struct uct_md       super;    /**< Domain info */
     int                 knem_fd;  /**< File descriptor for /dev/knem */
-    ucs_rcache_t       *rcache;   /**< Registration cache (can be NULL) */
     ucs_linear_func_t   reg_cost; /**< Memory registration cost */
 } uct_knem_md_t;
 
@@ -41,16 +39,6 @@ typedef struct uct_knem_key {
  */
 typedef struct uct_knem_md_config {
     uct_md_config_t          super;
-    ucs_ternary_auto_value_t rcache_enable;
-    uct_md_rcache_config_t   rcache;
 } uct_knem_md_config_t;
-
-/**
- * KNEM memory region in the registration cache.
- */
-typedef struct uct_knem_rcache_region {
-    ucs_rcache_region_t super;
-    uct_knem_key_t      key;      /**<  exposed to the user as the memh */
-} uct_knem_rcache_region_t;
 
 #endif

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -94,7 +94,6 @@ public:
             modify_config("RCACHE_ENABLE", "n");
             ucs::scoped_setenv ib_reg_methods_env("UCX_IB_REG_METHODS",
                                                   "direct");
-            ucs::scoped_setenv knem_rcache_env("UCX_KNEM_RCACHE", "no");
             ucp_test::init(); // Init UCP with rcache disabled
         } else {
             ucp_test::init();


### PR DESCRIPTION
## What

Backport of https://github.com/openucx/ucx/pull/9134. Used https://github.com/openucx/ucx/pull/9267 to remove rcache in knem.