### PR TITLE
UCT/BASE: Remove base is reachable v2 forwarding function

### DIFF
--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -264,24 +264,22 @@ int uct_iface_is_reachable_params_valid(
     return 1;
 }
 
-int uct_base_iface_is_reachable_v2(
-        const uct_iface_h iface, const uct_iface_is_reachable_params_t *params)
+int uct_iface_is_reachable_params_addrs_valid(
+        const uct_iface_is_reachable_params_t *params)
 {
-    uct_iface_reachability_scope_t scope;
+    return uct_iface_is_reachable_params_valid(
+            params, UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
+                            UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR);
+}
 
-    if (!uct_iface_is_reachable_params_valid(params,
-                            UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
-                            UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR)) {
-        return 0;
-    }
+int uct_iface_scope_is_reachable(const uct_iface_h iface,
+                                 const uct_iface_is_reachable_params_t *params)
+{
+    uct_iface_reachability_scope_t scope =
+        UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params, scope, SCOPE,
+                        UCT_IFACE_REACHABILITY_SCOPE_NETWORK);
 
-    if (!uct_iface_is_reachable(iface, params->device_addr,
-                                params->iface_addr)) {
-        return 0;
-    }
-
-    scope = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params, scope, SCOPE,
-                            UCT_IFACE_REACHABILITY_SCOPE_NETWORK);
+    ucs_assert(params->field_mask & UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR);
 
     return (scope == UCT_IFACE_REACHABILITY_SCOPE_NETWORK) ||
            uct_iface_is_same_device(iface, params->device_addr);
@@ -537,15 +535,6 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 
     return UCS_OK;
 }
-
-uct_iface_internal_ops_t uct_base_iface_internal_ops = {
-    .iface_estimate_perf   = uct_base_iface_estimate_perf,
-    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
-};
 
 UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
 {

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -768,9 +768,6 @@ typedef struct {
 extern ucs_config_field_t uct_iface_config_table[];
 
 
-extern uct_iface_internal_ops_t uct_base_iface_internal_ops;
-
-
 /**
  * Initialize a memory pool for buffers used by TL interface.
  *
@@ -852,13 +849,12 @@ void uct_base_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
 ucs_status_t
 uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
 
-int
-uct_base_iface_is_reachable_v2(const uct_iface_h iface,
-                               const uct_iface_is_reachable_params_t *params);
-
 int uct_base_iface_is_reachable(const uct_iface_h tl_iface,
                                 const uct_device_addr_t *dev_addr,
                                 const uct_iface_addr_t *iface_addr);
+
+int uct_iface_scope_is_reachable(const uct_iface_h iface,
+                                 const uct_iface_is_reachable_params_t *params);
 
 ucs_status_t uct_base_ep_flush(uct_ep_h tl_ep, unsigned flags,
                                uct_completion_t *comp);
@@ -873,6 +869,9 @@ int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
 
 int uct_iface_is_reachable_params_valid(
         const uct_iface_is_reachable_params_t *params, uint64_t flags);
+
+int uct_iface_is_reachable_params_addrs_valid(
+        const uct_iface_is_reachable_params_t *params);
 
 /*
  * Invoke active message handler.

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -58,14 +58,22 @@ static ucs_status_t uct_cuda_copy_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static int uct_cuda_copy_iface_is_reachable(const uct_iface_h tl_iface,
-                                            const uct_device_addr_t *dev_addr,
-                                            const uct_iface_addr_t *iface_addr)
+static int uct_cuda_copy_iface_is_reachable_v2(
+        const uct_iface_h tl_iface,
+        const uct_iface_is_reachable_params_t *params)
 {
-    uct_cuda_copy_iface_t  *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
-    uct_cuda_copy_iface_addr_t *addr = (uct_cuda_copy_iface_addr_t*)iface_addr;
+    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface,
+                                                  uct_cuda_copy_iface_t);
+    uct_cuda_copy_iface_addr_t *addr;
 
-    return (addr != NULL) && (iface->id == *addr);
+    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
+        return 0;
+    }
+
+    addr = (uct_cuda_copy_iface_addr_t*)params->iface_addr;
+
+    return (addr != NULL) && (iface->id == *addr) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
@@ -282,7 +290,7 @@ static uct_iface_ops_t uct_cuda_copy_iface_ops = {
     .iface_query              = uct_cuda_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_cuda_copy_iface_get_address,
-    .iface_is_reachable       = uct_cuda_copy_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
@@ -393,7 +401,7 @@ static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_cuda_copy_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -74,12 +74,14 @@ static ucs_status_t uct_cuda_ipc_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static int uct_cuda_ipc_iface_is_reachable(const uct_iface_h tl_iface,
-                                           const uct_device_addr_t *dev_addr,
-                                           const uct_iface_addr_t *iface_addr)
+static int
+uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                   const uct_iface_is_reachable_params_t *params)
 {
-    return (ucs_get_system_id() == *((const uint64_t*)dev_addr)) &&
-           (getpid() != *(pid_t*)iface_addr);
+    return uct_iface_is_reachable_params_addrs_valid(params) &&
+           (ucs_get_system_id() == *((const uint64_t*)params->device_addr)) &&
+           (getpid() != *(pid_t*)params->iface_addr) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static double uct_cuda_ipc_iface_get_bw()
@@ -365,7 +367,7 @@ static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
     .iface_query              = uct_cuda_ipc_iface_query,
     .iface_get_device_address = uct_cuda_ipc_iface_get_device_address,
     .iface_get_address        = uct_cuda_ipc_iface_get_address,
-    .iface_is_reachable       = uct_cuda_ipc_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable,
 };
 
 static void uct_cuda_ipc_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
@@ -474,7 +476,7 @@ static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_cuda_ipc_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -42,14 +42,22 @@ static ucs_status_t uct_gdr_copy_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static int uct_gdr_copy_iface_is_reachable(const uct_iface_h tl_iface,
-                                           const uct_device_addr_t *dev_addr,
-                                           const uct_iface_addr_t *iface_addr)
+static int
+uct_gdr_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                   const uct_iface_is_reachable_params_t *params)
 {
-    uct_gdr_copy_iface_t  *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
-    uct_gdr_copy_iface_addr_t *addr = (uct_gdr_copy_iface_addr_t*)iface_addr;
+    uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface,
+                                                 uct_gdr_copy_iface_t);
+    uct_gdr_copy_iface_addr_t *addr;
 
-    return (addr != NULL) && (iface->id == *addr);
+    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
+        return 0;
+    }
+
+    addr = (uct_gdr_copy_iface_addr_t*)params->iface_addr;
+
+    return (addr != NULL) && (iface->id == *addr) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t
@@ -168,7 +176,7 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
     .iface_query              = uct_gdr_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_gdr_copy_iface_get_address,
-    .iface_is_reachable       = uct_gdr_copy_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable,
 };
 
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
@@ -177,7 +185,7 @@ static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_gdr_copy_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -875,7 +875,7 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
-    .iface_is_reachable       = (uct_iface_is_reachable_func_t)ucs_empty_function_return_zero
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
@@ -884,7 +884,7 @@ static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
     .ep_query              = uct_rdmacm_ep_query,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero
 };
 
 static ucs_status_t

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -58,14 +58,22 @@ static ucs_status_t uct_rocm_copy_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static int uct_rocm_copy_iface_is_reachable(const uct_iface_h tl_iface,
-                                            const uct_device_addr_t *dev_addr,
-                                            const uct_iface_addr_t *iface_addr)
+static int uct_rocm_copy_iface_is_reachable_v2(
+        const uct_iface_h tl_iface,
+        const uct_iface_is_reachable_params_t *params)
 {
-    uct_rocm_copy_iface_t  *iface = ucs_derived_of(tl_iface, uct_rocm_copy_iface_t);
-    uct_rocm_copy_iface_addr_t *addr = (uct_rocm_copy_iface_addr_t*)iface_addr;
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface,
+                                                  uct_rocm_copy_iface_t);
+    uct_rocm_copy_iface_addr_t *addr;
 
-    return (addr != NULL) && (iface->id == *addr);
+    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
+        return 0;
+    }
+
+    addr = (uct_rocm_copy_iface_addr_t*)params->iface_addr;
+
+    return (addr != NULL) && (iface->id == *addr) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
@@ -168,7 +176,7 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
     .iface_query              = uct_rocm_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_rocm_copy_iface_get_address,
-    .iface_is_reachable       = uct_rocm_copy_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 
@@ -232,7 +240,7 @@ static uct_iface_internal_ops_t uct_rocm_copy_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_rocm_copy_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -49,8 +49,7 @@ uct_sm_iface_get_device_address(uct_iface_t *tl_iface, uct_device_addr_t *addr)
 }
 
 int uct_sm_iface_is_reachable(const uct_iface_h tl_iface,
-                              const uct_device_addr_t *dev_addr,
-                              const uct_iface_addr_t *iface_addr)
+                              const uct_device_addr_t *dev_addr)
 {
     return uct_iface_local_is_reachable((uct_iface_local_addr_ns_t*)dev_addr,
                                         UCS_SYS_NS_TYPE_IPC);

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -39,8 +39,8 @@ uct_sm_base_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
 ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
                                              uct_device_addr_t *addr);
 
-int uct_sm_iface_is_reachable(const uct_iface_h tl_iface, const uct_device_addr_t *dev_addr,
-                              const uct_iface_addr_t *iface_addr);
+int uct_sm_iface_is_reachable(const uct_iface_h tl_iface,
+                              const uct_device_addr_t *dev_addr);
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags);
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -105,21 +105,23 @@ uct_mm_iface_query_tl_devices(uct_md_h md,
 }
 
 static int
-uct_mm_iface_is_reachable(const uct_iface_h tl_iface,
-                          const uct_device_addr_t *dev_addr,
-                          const uct_iface_addr_t *tl_iface_addr)
+uct_mm_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                             const uct_iface_is_reachable_params_t *params)
 {
-    uct_mm_iface_t      *iface      = ucs_derived_of(tl_iface, uct_mm_iface_t);
-    uct_mm_md_t         *md         = ucs_derived_of(iface->super.super.md,
-                                                     uct_mm_md_t);
-    uct_mm_iface_addr_t *iface_addr = (void*)tl_iface_addr;
+    uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
+    uct_mm_md_t *md       = ucs_derived_of(iface->super.super.md, uct_mm_md_t);
+    uct_mm_iface_addr_t *iface_addr;
 
-    if (!uct_sm_iface_is_reachable(tl_iface, dev_addr, tl_iface_addr)) {
+    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
         return 0;
     }
 
-    return uct_mm_md_mapper_ops(md)->is_reachable(md, iface_addr->fifo_seg_id,
-                                                  iface_addr + 1);
+    iface_addr = (void*)params->iface_addr;
+
+    return uct_sm_iface_is_reachable(tl_iface, params->device_addr) &&
+           uct_mm_md_mapper_ops(md)->is_reachable(md, iface_addr->fifo_seg_id,
+                                                  iface_addr + 1) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 void uct_mm_iface_release_desc(uct_recv_desc_t *self, void *desc)
@@ -501,7 +503,7 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .iface_query              = uct_mm_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_get_address        = uct_mm_iface_get_address,
-    .iface_is_reachable       = uct_mm_iface_is_reachable
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static ucs_status_t
@@ -577,7 +579,7 @@ static uct_iface_internal_ops_t uct_mm_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_mm_iface_is_reachable_v2
 };
 
 static void uct_mm_iface_recv_desc_init(uct_iface_h tl_iface, void *obj,

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -38,6 +38,16 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
+static int
+uct_knem_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                               const uct_iface_is_reachable_params_t *params)
+{
+    return uct_iface_is_reachable_params_valid(
+                   params, UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR) &&
+           uct_sm_iface_is_reachable(tl_iface, params->device_addr) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
+}
+
 static UCS_CLASS_DECLARE_DELETE_FUNC(uct_knem_iface_t, uct_iface_t);
 
 static uct_iface_ops_t uct_knem_iface_tl_ops = {
@@ -60,7 +70,7 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
     .iface_query              = uct_knem_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_get_address        = ucs_empty_function_return_success,
-    .iface_is_reachable       = uct_sm_iface_is_reachable,
+    .iface_is_reachable       = uct_base_iface_is_reachable,
 };
 
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {
@@ -70,7 +80,7 @@ static uct_scopy_iface_ops_t uct_knem_iface_ops = {
         .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
         .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-        .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+        .iface_is_reachable_v2 = uct_knem_iface_is_reachable_v2
     },
     .ep_tx = uct_knem_ep_tx,
 };

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -190,7 +190,7 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
     .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
-    .iface_is_reachable       = (uct_iface_is_reachable_func_t)ucs_empty_function_return_zero
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {
@@ -199,7 +199,7 @@ static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {
     .ep_query              = uct_tcp_sockcm_ep_query,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero
 };
 
 UCS_CLASS_INIT_FUNC(uct_tcp_sockcm_t, uct_component_h component,

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -47,6 +47,14 @@ int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *d
     return 1;
 }
 
+int uct_ugni_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                   const uct_iface_is_reachable_params_t *params)
+{
+    return uct_iface_is_reachable_params_valid(
+                   params, UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
+}
+
 static ucs_mpool_ops_t uct_ugni_flush_mpool_ops = {
     .chunk_alloc   = ucs_mpool_chunk_malloc,
     .chunk_release = ucs_mpool_chunk_free,

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -20,6 +20,8 @@ ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
 ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
 int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, 
 				const uct_iface_addr_t *iface_addr);
+int uct_ugni_iface_is_reachable_v2(
+        const uct_iface_h iface, const uct_iface_is_reachable_params_t *params);
 void uct_ugni_base_desc_init(ucs_mpool_t *mp, void *obj, void *chunk);
 void uct_ugni_base_desc_key_init(uct_iface_h iface, void *obj, uct_mem_h memh);
 void uct_ugni_cleanup_base_iface(uct_ugni_iface_t *iface);

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -248,7 +248,7 @@ static uct_iface_ops_t uct_ugni_smsg_iface_ops = {
     .iface_query              = uct_ugni_smsg_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
-    .iface_is_reachable       = uct_ugni_iface_is_reachable
+    .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
 static ucs_mpool_ops_t uct_ugni_smsg_desc_mpool_ops = {
@@ -273,7 +273,7 @@ static uct_iface_internal_ops_t uct_ugni_smsg_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = uct_ugni_smsg_ep_connect_to_ep_v2,
-    .iface_is_reachable_v2 = uct_base_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_ugni_iface_is_reachable_v2
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h worker,


### PR DESCRIPTION
## What
Convert all users of `uct_base_iface_is_reachable_v2()` to users of `uct_base_iface_is_reachable()` instead. This means that corresponding transports will now forward v1 is reachable calls to v2 is reachable actual implementations.

## Why ?
This is a step towards removing the v1 is reachable structure member.

## How ?
Combine the scope and param validity checks in a common UCT base function, that transports can use to reduce duplication.

Build:
```
./contrib/configure-devel --prefix=$(pwd)/rfs \
    --with-ugni=yes --with-verbs=yes --with-knem=yes \
    --with-gdrcopy=yes --with-cuda=yes --with-rocm=yes --with-xpmem=yes
```