### PR TITLE
UCS/DATASTRUCT: Include ucs_status in array.inl

### DIFF
--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -9,6 +9,7 @@
 
 #include <ucs/sys/compiler_def.h>
 #include <ucs/sys/preprocessor.h>
+#include <ucs/type/status.h>
 
 BEGIN_C_DECLS
 


### PR DESCRIPTION
## What
Include ucs_status in array.inl

## Why ?
Array class uses ucs_status_t


