### PR TITLE
UCP/RNDV: Use only reachable MDs for protocol selection.

### DIFF
--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -58,6 +58,9 @@ struct ucp_rkey_config_key {
 
     /* Remote memory type */
     ucs_memory_type_t      mem_type;
+
+    /* MDs for which rkey is not reachable */
+    ucp_md_map_t           unreachable_md_map;
 };
 
 

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -15,7 +15,9 @@
 static UCS_F_ALWAYS_INLINE khint_t
 ucp_rkey_config_hash_func(ucp_rkey_config_key_t rkey_config_key)
 {
-    return (khint_t)rkey_config_key.md_map ^
+    return kh_int64_hash_func(
+            rkey_config_key.md_map ^
+            (rkey_config_key.unreachable_md_map << 32)) ^
            (rkey_config_key.ep_cfg_index << 8) ^
            (rkey_config_key.sys_dev << 16) ^
            (rkey_config_key.mem_type << 24);
@@ -28,7 +30,9 @@ ucp_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
     return (rkey_config_key1.md_map == rkey_config_key2.md_map) &&
            (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
            (rkey_config_key1.sys_dev == rkey_config_key2.sys_dev) &&
-           (rkey_config_key1.mem_type == rkey_config_key2.mem_type);
+           (rkey_config_key1.mem_type == rkey_config_key2.mem_type) &&
+           (rkey_config_key1.unreachable_md_map ==
+            rkey_config_key2.unreachable_md_map);
 }
 
 static UCS_F_ALWAYS_INLINE ucp_rkey_config_t *

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -46,6 +46,8 @@ protected:
     ucp_worker_h worker() {
         return sender().worker();
     }
+
+    static ucp_rkey_config_key_t create_rkey_config_key(ucp_md_map_t md_map);
 };
 
 ucp_md_map_t test_ucp_proto::get_md_map(ucs_memory_type_t mem_type)
@@ -110,6 +112,20 @@ void test_ucp_proto::test_dt_iter_mem_reg(ucs_memory_type_t mem_type,
                      << " nsec";
 }
 
+ucp_rkey_config_key_t
+test_ucp_proto::create_rkey_config_key(ucp_md_map_t md_map)
+{
+    ucp_rkey_config_key_t rkey_config_key;
+
+    rkey_config_key.ep_cfg_index       = 0;
+    rkey_config_key.md_map             = md_map;
+    rkey_config_key.mem_type           = UCS_MEMORY_TYPE_HOST;
+    rkey_config_key.sys_dev            = UCS_SYS_DEVICE_ID_UNKNOWN;
+    rkey_config_key.unreachable_md_map = 0;
+
+    return rkey_config_key;
+}
+
 UCS_TEST_P(test_ucp_proto, dump_protocols) {
     ucp_proto_select_param_t select_param;
     ucs_string_buffer_t strb;
@@ -143,13 +159,7 @@ UCS_TEST_P(test_ucp_proto, dump_protocols) {
 }
 
 UCS_TEST_P(test_ucp_proto, rkey_config) {
-    ucp_rkey_config_key_t rkey_config_key;
-
-    rkey_config_key.ep_cfg_index = 0;
-    rkey_config_key.md_map       = 0;
-    rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
-    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-
+    ucp_rkey_config_key_t rkey_config_key = create_rkey_config_key(0);
     ucs_status_t status;
 
     /* similar configurations should return same index */
@@ -165,10 +175,7 @@ UCS_TEST_P(test_ucp_proto, rkey_config) {
 
     EXPECT_EQ(static_cast<int>(cfg_index1), static_cast<int>(cfg_index2));
 
-    rkey_config_key.ep_cfg_index = 0;
-    rkey_config_key.md_map       = 1;
-    rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
-    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+    rkey_config_key = create_rkey_config_key(1);
 
     /* different configuration should return different index */
     ucp_worker_cfg_index_t cfg_index3;
@@ -181,14 +188,8 @@ UCS_TEST_P(test_ucp_proto, rkey_config) {
 
 UCS_TEST_P(test_ucp_proto, worker_print_info_rkey)
 {
-    ucp_rkey_config_key_t rkey_config_key;
+    ucp_rkey_config_key_t rkey_config_key = create_rkey_config_key(0);
 
-    rkey_config_key.ep_cfg_index = 0;
-    rkey_config_key.md_map       = 0;
-    rkey_config_key.mem_type     = UCS_MEMORY_TYPE_HOST;
-    rkey_config_key.sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-
-    /* similar configurations should return same index */
     ucp_worker_cfg_index_t cfg_index;
     ucs_status_t status = ucp_worker_rkey_config_get(worker(), &rkey_config_key,
                                                      NULL, &cfg_index);


### PR DESCRIPTION
## What
Enhanced remote protocol selection during rendezvous initialization, taking into account reachability of memory domains.
The reachability is checking during remote key unpacking.

## Why ?
Ignoring this information can lead to performance issues. E.g. RTR protocol can be mistakenly selected as a remote protocol, even if there is no valid MD for the protocol. Which leads to fallback to rndv/am protocol.