### PR TITLE
UCT/IB: Added support for device memory allocation (memic/rdma)

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -110,6 +110,7 @@ static size_t ucp_rndv_frag_default_sizes[] = {
     [UCS_MEMORY_TYPE_CUDA_MANAGED] = 4 * UCS_MBYTE,
     [UCS_MEMORY_TYPE_ROCM]         = 4 * UCS_MBYTE,
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = 4 * UCS_MBYTE,
+    [UCS_MEMORY_TYPE_RDMA]         = 0,
     [UCS_MEMORY_TYPE_LAST]         = 0
 };
 
@@ -119,6 +120,7 @@ static size_t ucp_rndv_frag_default_num_elems[] = {
     [UCS_MEMORY_TYPE_CUDA_MANAGED] = 128,
     [UCS_MEMORY_TYPE_ROCM]         = 128,
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = 128,
+    [UCS_MEMORY_TYPE_RDMA]         = 0,
     [UCS_MEMORY_TYPE_LAST]         = 0
 };
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -358,7 +358,8 @@ void uct_ib_md_close(uct_md_h tl_md);
 
 ucs_status_t uct_ib_reg_mr(uct_ib_md_t *md, void *address, size_t length,
                            const uct_md_mem_reg_params_t *params,
-                           uint64_t access_flags, struct ibv_mr **mr_p);
+                           uint64_t access_flags, struct ibv_dm *dm,
+                           struct ibv_mr **mr_p);
 
 ucs_status_t uct_ib_dereg_mr(struct ibv_mr *mr);
 

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -111,6 +111,11 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #  define uct_ib_grh_required(_attr)                0
 #endif
 
+/* Dummy structure declaration, when not present in verbs.h */
+#if !HAVE_IBV_DM
+    struct ibv_dm;
+#endif
+
 typedef uint8_t uct_ib_uint24_t[3];
 
 static inline void uct_ib_pack_uint24(uct_ib_uint24_t buf, uint32_t val)

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -253,6 +253,10 @@ typedef struct {
     struct mlx5dv_devx_umem *umem;
     struct mlx5dv_devx_obj  *cross_mr;
     struct mlx5dv_devx_obj  *smkey_mr;
+    struct mlx5dv_devx_obj  *dm_addr_dvmr;
+#if HAVE_IBV_DM
+    struct ibv_dm           *dm;
+#endif
     uint32_t                atomic_rkey;
     uint32_t                indirect_rkey;
     uint32_t                exported_lkey;

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -54,6 +54,7 @@ protected:
 
     void test_reg_advise(size_t size, size_t advise_size,
                          size_t advice_offset, bool check_non_blocking = false);
+    void test_alloc_advise(ucs_memory_type_t mem_type);
 
     uct_md_h md() const {
         return m_md;

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -107,6 +107,11 @@ UCS_TEST_P(test_mem, md_alloc) {
         status = uct_md_query(md, &md_attr);
         ASSERT_UCS_OK(status);
 
+        if (md_attr.cap.max_alloc < min_length) {
+            uct_md_close(md);
+            continue;
+        }
+
         ucs_for_each_bit(mem_type, md_attr.cap.alloc_mem_types) {
             params.mem_type = (ucs_memory_type_t)mem_type;
             for (nonblock = 0; nonblock <= 1; ++nonblock) {


### PR DESCRIPTION
## What
Porting changes from https://github.com/openucx/ucx/pull/3559 with updated mlx5 / verbs API
## Why ?
To support the usage of MEMIC, enhancing atomic operations performance.

## How ?
Using verbs mlx5 and devx libs
