### PR TITLE
Revert "UCS/DISTANCE: Update Intel Ice Lake sys root bandwidth"

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -308,9 +308,6 @@ static void ucs_topo_sys_root_distance(ucs_sys_dev_distance_t *distance)
 {
     distance->latency = 500e-9;
     switch (ucs_arch_get_cpu_model()) {
-    case UCS_CPU_MODEL_INTEL_ICELAKE:
-        distance->bandwidth = 8350 * UCS_MBYTE;
-        break;
     case UCS_CPU_MODEL_AMD_ROME:
     case UCS_CPU_MODEL_AMD_MILAN:
     case UCS_CPU_MODEL_AMD_GENOA:


### PR DESCRIPTION
## What
This reverts commit f33c9aa514891a38a8d416960e6b2809a3bd7100.

## Why ?
This commit was merged by mistake. See [comment](https://github.com/openucx/ucx/pull/9307#issuecomment-1691472650).
