### PR TITLE
UCT/UGNI: Fix UGNI build

### DIFF
--- a/src/uct/ugni/rdma/ugni_rdma_ep.c
+++ b/src/uct/ugni/rdma/ugni_rdma_ep.c
@@ -11,6 +11,7 @@
 #include "ugni_rdma_ep.h"
 #include "ugni_rdma_iface.h"
 #include <uct/ugni/base/ugni_device.h>
+#include <ucs/sys/math.h>
 
 #define UCT_CHECK_PARAM_IOV(_iov, _iovcnt, _buffer, _length, _memh) \
     void     *_buffer; \

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -13,6 +13,7 @@
 #include <uct/ugni/base/ugni_def.h>
 #include <uct/ugni/base/ugni_md.h>
 #include <uct/ugni/base/ugni_device.h>
+#include <ucs/sys/math.h>
 
 static ucs_config_field_t uct_ugni_rdma_iface_config_table[] = {
     /* This tuning controls the allocation priorities for bouncing buffers */

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -14,6 +14,7 @@
 #include <uct/ugni/base/ugni_md.h>
 #include <uct/ugni/base/ugni_device.h>
 #include <ucs/arch/cpu.h>
+#include <ucs/sys/math.h>
 
 
 extern ucs_class_t UCS_CLASS_DECL_NAME(uct_ugni_smsg_iface_t);

--- a/src/uct/ugni/udt/ugni_udt_iface.h
+++ b/src/uct/ugni/udt/ugni_udt_iface.h
@@ -14,6 +14,7 @@
 #include <uct/base/uct_md.h>
 #include <ucs/async/async.h>
 #include <ucs/async/pipe.h>
+#include <ucs/sys/math.h>
 
 typedef void uct_ugni_udt_desc_t;
 


### PR DESCRIPTION
## What
Fix ugni build.

## Why ?
Seems ugni build just started failing even when using much older commits (tooling/env?).

## How ?
Add needed include as close as possible to the error.
Failure seen on old 472553769d1cb6ba358d5bd4465cdadba63e4960 configured with `./contrib/configure-release --with-ugni=yes`

Failure (gcc 4.8.5):
```
  CC       rdma/libuct_ugni_la-ugni_rdma_iface.lo
rdma/ugni_rdma_iface.c: In function ‘uct_ugni_rdma_iface_query’:
rdma/ugni_rdma_iface.c:98:48: error: ‘UCS_MBYTE’ undeclared (first use in this function)
     iface_attr->bandwidth.dedicated = 6911.0 * UCS_MBYTE; /* bytes */
                                                ^
rdma/ugni_rdma_iface.c:98:48: note: each undeclared identifier is reported only once for each function it appears in
make[3]: *** [rdma/libuct_ugni_la-ugni_rdma_iface.lo] Error 1
  CC       rdma/libuct_ugni_la-ugni_rdma_ep.lo
rdma/ugni_rdma_ep.c: In function ‘uct_ugni_format_get_fma’:
rdma/ugni_rdma_ep.c:527:5: error: implicit declaration of function ‘ucs_padding_pow2’ [-Werror=implicit-function-declaration]
     fma_desc->padding      = ucs_padding_pow2(remote_addr, UGNI_GET_ALIGN);
     ^
rdma/ugni_rdma_ep.c:527:5: error: nested extern declaration of ‘ucs_padding_pow2’ [-Werror=nested-externs]
rdma/ugni_rdma_ep.c:534:5: error: implicit declaration of function ‘ucs_check_if_align_pow2’ [-Werror=implicit-function-declaration]
     align_length = ucs_check_if_align_pow2(length + fma_desc->padding, UGNI_GET_ALIGN) ?
     ^
rdma/ugni_rdma_ep.c:534:5: error: nested extern declaration of ‘ucs_check_if_align_pow2’ [-Werror=nested-externs]
rdma/ugni_rdma_ep.c:535:9: error: implicit declaration of function ‘ucs_align_up_pow2’ [-Werror=implicit-function-declaration]
         ucs_align_up_pow2((length + fma_desc->padding), UGNI_GET_ALIGN):length + fma_desc->padding;
         ^
rdma/ugni_rdma_ep.c:535:9: error: nested extern declaration of ‘ucs_align_up_pow2’ [-Werror=nested-externs]
rdma/ugni_rdma_ep.c: In function ‘uct_ugni_format_unaligned_rdma’:
rdma/ugni_rdma_ep.c:559:5: error: implicit declaration of function ‘ucs_align_down’ [-Werror=implicit-function-declaration]
     addr = ucs_align_down(remote_addr, UGNI_GET_ALIGN);
```