### PR TITLE
UCT/API: Remove iface_is_reachable member from iface ops

### DIFF
--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -170,7 +170,6 @@ UCS_CLASS_INIT_FUNC(ucp_proxy_ep_t, const uct_iface_ops_t *ops, ucp_ep_h ucp_ep,
     self->iface.ops.iface_query              = (uct_iface_query_func_t)ucp_proxy_ep_fatal;
     self->iface.ops.iface_get_device_address = (uct_iface_get_device_address_func_t)ucp_proxy_ep_fatal;
     self->iface.ops.iface_get_address        = (uct_iface_get_address_func_t)ucp_proxy_ep_fatal;
-    self->iface.ops.iface_is_reachable       = (uct_iface_is_reachable_func_t)ucp_proxy_ep_fatal;
 
     return UCS_OK;
 }

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -282,10 +282,6 @@ typedef ucs_status_t (*uct_iface_get_device_address_func_t)(uct_iface_h iface,
 typedef ucs_status_t (*uct_iface_get_address_func_t)(uct_iface_h iface,
                                                      uct_iface_addr_t *addr);
 
-typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
-                                                      const uct_device_addr_t *dev_addr,
-                                                      const uct_iface_addr_t *iface_addr);
-
 
 /**
  * Transport interface operations.
@@ -370,7 +366,6 @@ typedef struct uct_iface_ops {
     /* interface - connection establishment */
     uct_iface_get_device_address_func_t iface_get_device_address;
     uct_iface_get_address_func_t        iface_get_address;
-    uct_iface_is_reachable_func_t       iface_is_reachable;
 
 } uct_iface_ops_t;
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -215,6 +215,19 @@ enum {
 
 
 /**
+ * Common default initializer where only reachabilty can be customized
+ */
+#define UCT_IFACE_INTERNAL_OPS_INITIALIZER(_is_reachable_v2) \
+    { \
+        .iface_estimate_perf   = uct_base_iface_estimate_perf, \
+        .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function, \
+        .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported, \
+        .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported, \
+        .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported, \
+        .iface_is_reachable_v2 = _is_reachable_v2 \
+    }
+
+/**
  * Declare classes for structures defined in api/tl.h
  */
 UCS_CLASS_DECLARE(uct_iface_h, uct_iface_ops_t, uct_md_h);
@@ -848,10 +861,6 @@ void uct_base_iface_progress_disable(uct_iface_h tl_iface, unsigned flags);
 
 ucs_status_t
 uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
-
-int uct_base_iface_is_reachable(const uct_iface_h tl_iface,
-                                const uct_device_addr_t *dev_addr,
-                                const uct_iface_addr_t *iface_addr);
 
 int uct_iface_scope_is_reachable(const uct_iface_h iface,
                                  const uct_iface_is_reachable_params_t *params);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -289,8 +289,7 @@ static uct_iface_ops_t uct_cuda_copy_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_iface_t),
     .iface_query              = uct_cuda_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
-    .iface_get_address        = uct_cuda_copy_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_cuda_copy_iface_get_address
 };
 
 static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -366,8 +366,7 @@ static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_iface_t),
     .iface_query              = uct_cuda_ipc_iface_query,
     .iface_get_device_address = uct_cuda_ipc_iface_get_device_address,
-    .iface_get_address        = uct_cuda_ipc_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable,
+    .iface_get_address        = uct_cuda_ipc_iface_get_address
 };
 
 static void uct_cuda_ipc_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -175,8 +175,7 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_gdr_copy_iface_t),
     .iface_query              = uct_gdr_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
-    .iface_get_address        = uct_gdr_copy_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable,
+    .iface_get_address        = uct_gdr_copy_iface_get_address
 };
 
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1326,7 +1326,6 @@ static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t),
     .iface_query              = uct_dc_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable,
     .iface_get_address        = uct_dc_mlx5_iface_get_address,
 };
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -1072,8 +1072,7 @@ static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_mlx5_iface_t),
     .iface_query              = uct_rc_mlx5_iface_query,
     .iface_get_address        = uct_rc_mlx5_iface_get_address,
-    .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_device_address = uct_ib_iface_get_device_address
 };
 
 static ucs_status_t

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -498,8 +498,7 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_verbs_iface_t),
     .iface_query              = uct_rc_verbs_iface_query,
     .iface_get_address        = ucs_empty_function_return_success,
-    .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable,
+    .iface_get_device_address = uct_ib_iface_get_device_address
 };
 
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -874,8 +874,7 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_close              = ucs_empty_function,
     .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
-    .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported
 };
 
 static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -875,8 +875,7 @@ static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t),
     .iface_query              = uct_ud_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_get_address        = uct_ud_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_ud_iface_get_address
 };
 
 static ucs_status_t uct_ud_mlx5dv_calc_tx_wqe_ratio(uct_ib_mlx5_md_t *md)

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -652,8 +652,7 @@ static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t),
     .iface_query              = uct_ud_verbs_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
-    .iface_get_address        = uct_ud_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_ud_iface_get_address
 };
 
 static UCS_F_NOINLINE void

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -175,8 +175,7 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_copy_iface_t),
     .iface_query              = uct_rocm_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
-    .iface_get_address        = uct_rocm_copy_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_rocm_copy_iface_get_address
 };
 
 

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -135,14 +135,8 @@ static unsigned uct_rocm_ipc_iface_progress(uct_iface_h tl_iface)
     return uct_rocm_base_progress(&iface->signal_queue);
 }
 
-static uct_iface_internal_ops_t uct_rocm_ipc_iface_internal_ops = {
-    .iface_estimate_perf   = uct_base_iface_estimate_perf,
-    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_rocm_ipc_iface_is_reachable_v2
-};
+static uct_iface_internal_ops_t uct_rocm_ipc_iface_internal_ops =
+    UCT_IFACE_INTERNAL_OPS_INITIALIZER(uct_rocm_ipc_iface_is_reachable_v2);
 
 static uct_iface_ops_t uct_rocm_ipc_iface_ops = {
     .ep_put_zcopy             = uct_rocm_ipc_ep_put_zcopy,
@@ -161,8 +155,7 @@ static uct_iface_ops_t uct_rocm_ipc_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_ipc_iface_t),
     .iface_query              = uct_rocm_ipc_iface_query,
     .iface_get_address        = uct_rocm_ipc_iface_get_address,
-    .iface_get_device_address = uct_rocm_ipc_iface_get_device_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_device_address = uct_rocm_ipc_iface_get_device_address
 };
 
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -502,8 +502,7 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_mm_iface_t),
     .iface_query              = uct_mm_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
-    .iface_get_address        = uct_mm_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_mm_iface_get_address
 };
 
 static ucs_status_t

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -116,8 +116,7 @@ static uct_iface_ops_t uct_cma_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
     .iface_query              = uct_cma_iface_query,
     .iface_get_address        = uct_cma_iface_get_address,
-    .iface_get_device_address = uct_sm_iface_get_device_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable,
+    .iface_get_device_address = uct_sm_iface_get_device_address
 };
 
 static uct_scopy_iface_ops_t uct_cma_iface_ops = {

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -69,8 +69,7 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
     .iface_query              = uct_knem_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
-    .iface_get_address        = ucs_empty_function_return_success,
-    .iface_is_reachable       = uct_base_iface_is_reachable,
+    .iface_get_address        = ucs_empty_function_return_success
 };
 
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -366,14 +366,8 @@ ssize_t uct_self_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     return length;
 }
 
-static uct_iface_internal_ops_t uct_self_iface_internal_ops = {
-    .iface_estimate_perf   = uct_base_iface_estimate_perf,
-    .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
-    .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
-    .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
-    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_self_iface_is_reachable_v2
-};
+static uct_iface_internal_ops_t uct_self_iface_internal_ops =
+        UCT_IFACE_INTERNAL_OPS_INITIALIZER(uct_self_iface_is_reachable_v2);
 
 static uct_iface_ops_t uct_self_iface_ops = {
     .ep_put_short             = uct_sm_ep_put_short,
@@ -403,8 +397,7 @@ static uct_iface_ops_t uct_self_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_self_iface_t),
     .iface_query              = uct_self_iface_query,
     .iface_get_device_address = ucs_empty_function_return_success,
-    .iface_get_address        = uct_self_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_self_iface_get_address
 };
 
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_v2_t *attr)

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -486,8 +486,7 @@ static uct_iface_ops_t uct_tcp_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_tcp_iface_t),
     .iface_query              = uct_tcp_iface_query,
     .iface_get_address        = uct_tcp_iface_get_address,
-    .iface_get_device_address = uct_tcp_iface_get_device_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_device_address = uct_tcp_iface_get_device_address
 };
 
 static ucs_status_t uct_tcp_iface_server_init(uct_tcp_iface_t *iface)

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -189,8 +189,7 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
     .iface_close              = ucs_empty_function,
     .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
-    .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported
 };
 
 static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {

--- a/src/uct/ugni/base/ugni_iface.c
+++ b/src/uct/ugni/base/ugni_iface.c
@@ -42,11 +42,6 @@ ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, const uct_iface_addr_t *iface_addr)
-{
-    return 1;
-}
-
 int uct_ugni_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                    const uct_iface_is_reachable_params_t *params)
 {
@@ -70,6 +65,9 @@ void uct_ugni_cleanup_base_iface(uct_ugni_iface_t *iface)
     uct_ugni_destroy_cq(iface->local_cq, &iface->cdm);
     uct_ugni_destroy_cdm(&iface->cdm);
 }
+
+uct_iface_internal_ops_t uct_ugni_base_iface_internal_ops =
+        UCT_IFACE_INTERNAL_OPS_INITIALIZER(uct_ugni_iface_is_reachable_v2);
 
 UCS_CLASS_INIT_FUNC(uct_ugni_iface_t, uct_md_h md, uct_worker_h worker,
                     const uct_iface_params_t *params,

--- a/src/uct/ugni/base/ugni_iface.h
+++ b/src/uct/ugni/base/ugni_iface.h
@@ -18,8 +18,6 @@ UCS_CLASS_DECLARE(uct_ugni_iface_t, uct_md_h, uct_worker_h,
 ucs_status_t uct_ugni_iface_flush(uct_iface_h tl_iface, unsigned flags,
                                   uct_completion_t *comp);
 ucs_status_t uct_ugni_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr);
-int uct_ugni_iface_is_reachable(uct_iface_h tl_iface, const uct_device_addr_t *dev_addr, 
-				const uct_iface_addr_t *iface_addr);
 int uct_ugni_iface_is_reachable_v2(
         const uct_iface_h iface, const uct_iface_is_reachable_params_t *params);
 void uct_ugni_base_desc_init(ucs_mpool_t *mp, void *obj, void *chunk);
@@ -28,4 +26,6 @@ void uct_ugni_cleanup_base_iface(uct_ugni_iface_t *iface);
 #define uct_ugni_iface_device(_iface) ((_iface)->cdm.dev)
 #define uct_ugni_iface_nic_handle(_iface) ((_iface)->cdm.nic_handle)
 #define uct_ugni_check_device_type(_iface, _type) ((_iface)->cdm.dev->type == _type)
+
+extern uct_iface_internal_ops_t uct_ugni_base_iface_internal_ops;
 #endif

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -208,7 +208,6 @@ static uct_iface_ops_t uct_ugni_aries_rdma_iface_ops = {
     .iface_query              = uct_ugni_rdma_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
-    .iface_is_reachable       = uct_ugni_iface_is_reachable
 };
 
 static uct_iface_ops_t uct_ugni_gemini_rdma_iface_ops = {
@@ -235,7 +234,6 @@ static uct_iface_ops_t uct_ugni_gemini_rdma_iface_ops = {
     .iface_query              = uct_ugni_rdma_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
-    .iface_is_reachable       = uct_ugni_iface_is_reachable
 };
 
 static ucs_mpool_ops_t uct_ugni_rdma_desc_mpool_ops = {
@@ -275,7 +273,8 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
         status = UCS_ERR_NO_DEVICE;
         goto exit;
     }
-    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params, ops, NULL,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params, ops,
+                              &uct_ugni_base_iface_internal_ops,
                               &config->super UCS_STATS_ARG(NULL));
     /* Setting initial configuration */
     self->config.fma_seg_size  = UCT_UGNI_MAX_FMA;

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -247,8 +247,7 @@ static uct_iface_ops_t uct_ugni_smsg_iface_ops = {
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_smsg_iface_t),
     .iface_query              = uct_ugni_smsg_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
-    .iface_get_address        = uct_ugni_iface_get_address,
-    .iface_is_reachable       = uct_base_iface_is_reachable
+    .iface_get_address        = uct_ugni_iface_get_address
 };
 
 static ucs_mpool_ops_t uct_ugni_smsg_desc_mpool_ops = {

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -372,7 +372,6 @@ static uct_iface_ops_t uct_ugni_udt_iface_ops = {
     .iface_query              = uct_ugni_udt_iface_query,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
-    .iface_is_reachable       = uct_ugni_iface_is_reachable
 };
 
 static ucs_mpool_ops_t uct_ugni_udt_desc_mpool_ops = {
@@ -395,7 +394,8 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
     ucs_mpool_params_t mp_params;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params,
-                              &uct_ugni_udt_iface_ops, NULL,
+                              &uct_ugni_udt_iface_ops,
+                              &uct_ugni_base_iface_internal_ops,
                               &config->super UCS_STATS_ARG(NULL));
 
     /* Setting initial configuration */


### PR DESCRIPTION
## What
Remove `->iface_is_reachable` member of iface ops structure and make API call directly invoke the v2 callback.

## Why ?
Moving to v2.

## How ?
UGNI and proxy ep needs careful review.