### PR TITLE
UCP/DT/TEST: Use datatype_iter for receive requests

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -280,6 +280,7 @@ void print_type_info(const char * tl_name)
     PRINT_FIELD_SIZE(ucp_request_t, send.flush);
     PRINT_FIELD_SIZE(ucp_request_t, send.amo);
     PRINT_FIELD_SIZE(ucp_request_t, recv);
+    PRINT_FIELD_SIZE(ucp_request_t, recv.dt_iter);
     PRINT_FIELD_SIZE(ucp_request_t, recv.uct_ctx);
     PRINT_FIELD_SIZE(ucp_request_t, recv.tag);
     PRINT_FIELD_SIZE(ucp_request_t, recv.stream);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -659,21 +659,6 @@ ucp_memory_detect(ucp_context_h context, const void *address, size_t length,
     mem_info->sys_dev = mem_info_internal.sys_dev;
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_memory_detect_param(ucp_context_h context, const void *address,
-                        size_t length, const ucp_request_param_t *param,
-                        ucp_memory_info_t *mem_info)
-{
-    if (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMH) {
-        ucs_assert(param->memh != NULL);
-        mem_info->sys_dev = param->memh->sys_dev;
-        mem_info->type    = param->memh->mem_type;
-    } else {
-        ucp_memory_detect(context, address, length, mem_info);
-    }
-}
-
-
 void
 ucp_context_dev_tl_bitmap(ucp_context_h context, const char *dev_name,
                           ucp_tl_bitmap_t *tl_bitmap);

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -29,7 +29,6 @@ static const char *ucp_request_flag_names[] = {
     [ucs_ilog2(UCP_REQUEST_FLAG_COMPLETED)]             = "cpml",
     [ucs_ilog2(UCP_REQUEST_FLAG_RELEASED)]              = "rls",
     [ucs_ilog2(UCP_REQUEST_FLAG_PROTO_SEND)]            = "proto",
-    [ucs_ilog2(UCP_REQUEST_FLAG_USER_MEMH)]             = "memh",
     [ucs_ilog2(UCP_REQUEST_FLAG_SYNC_LOCAL_COMPLETED)]  = "loc_cmpl",
     [ucs_ilog2(UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED)] = "rm_cmpl",
     [ucs_ilog2(UCP_REQUEST_FLAG_CALLBACK)]              = "cb",
@@ -62,7 +61,7 @@ static ucs_memory_type_t ucp_request_get_mem_type(ucp_request_t *req)
         return req->send.mem_type;
     } else if (req->flags &
                (UCP_REQUEST_FLAG_RECV_AM | UCP_REQUEST_FLAG_RECV_TAG)) {
-        return req->recv.mem_type;
+        return req->recv.dt_iter.mem_info.type;
     } else {
         return UCS_MEMORY_TYPE_UNKNOWN;
     }
@@ -111,11 +110,12 @@ ucp_request_str(ucp_request_t *req, ucp_worker_h worker,
         if (req->recv.proto_rndv_config != NULL) {
             /* Print the send protocol of the rendezvous request */
             ucp_proto_config_info_str(worker, req->recv.proto_rndv_config,
-                                      req->recv.length, strb);
+                                      req->recv.dt_iter.length, strb);
             return;
         }
 #endif
-        ucs_string_buffer_appendf(strb, "recv length %zu ", req->recv.length);
+        ucs_string_buffer_appendf(strb, "recv length %zu ",
+                                  req->recv.dt_iter.length);
     } else {
         ucs_string_buffer_appendf(strb, "<no debug info>");
         return;
@@ -401,29 +401,28 @@ void ucp_request_dt_invalidate(ucp_request_t *req, ucs_status_t status)
     ucp_ep_h ep           = req->send.ep;
     ucp_worker_h worker   = ep->worker;
     ucp_context_h context = worker->context;
+    ucp_mem_h memh        = req->send.state.dt.dt.contig.memh;
     ucp_md_map_t invalidate_map;
 
     ucs_assert(status != UCS_OK);
     ucs_assert(ucp_ep_config(ep)->key.err_mode != UCP_ERR_HANDLING_MODE_NONE);
     ucs_assert(UCP_DT_IS_CONTIG(req->send.datatype));
-    ucs_assert(!(req->flags & UCP_REQUEST_FLAG_USER_MEMH));
 
     req->send.ep                = NULL;
     req->send.invalidate.worker = worker;
     req->status                 = status;
 
-    if (req->send.state.dt.dt.contig.memh == NULL) {
+    if ((memh == NULL) || ucp_memh_is_user_memh(memh)) {
         ucp_request_complete_send(req, status);
         return;
     }
 
     invalidate_map = ucp_request_get_invalidation_map(ep);
     ucp_trace_req(req, "mem invalidate buffer md_map 0x%" PRIx64 "/0x%" PRIx64,
-                  invalidate_map, req->send.state.dt.dt.contig.memh->md_map);
-    ucp_memh_invalidate(context, req->send.state.dt.dt.contig.memh,
-                        ucp_request_mem_invalidate_completion, req,
-                        invalidate_map);
-    ucp_memh_put(req->send.state.dt.dt.contig.memh);
+                  invalidate_map, memh->md_map);
+    ucp_memh_invalidate(context, memh, ucp_request_mem_invalidate_completion,
+                        req, invalidate_map);
+    ucp_memh_put(memh);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_request_memory_reg,
@@ -697,17 +696,10 @@ void ucp_request_send_state_ff(ucp_request_t *req, ucs_status_t status)
 ucs_status_t ucp_request_recv_msg_truncated(ucp_request_t *req, size_t length,
                                             size_t offset)
 {
-    ucp_dt_generic_t *dt_gen;
-
     ucs_debug("message truncated: recv_length %zu offset %zu buffer_size %zu",
-              length, offset, req->recv.length);
+              length, offset, req->recv.dt_iter.length);
 
-    if (UCP_DT_IS_GENERIC(req->recv.datatype)) {
-        dt_gen = ucp_dt_to_generic(req->recv.datatype);
-        UCS_PROFILE_NAMED_CALL_VOID("dt_finish", dt_gen->ops.finish,
-                                    req->recv.state.dt.generic.state);
-    }
-
+    ucp_datatype_iter_cleanup(&req->recv.dt_iter, 0, UCP_DT_MASK_ALL);
     return UCS_ERR_MESSAGE_TRUNCATED;
 }
 

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -37,7 +37,6 @@ enum {
     UCP_REQUEST_FLAG_COMPLETED             = UCS_BIT(0),
     UCP_REQUEST_FLAG_RELEASED              = UCS_BIT(1),
     UCP_REQUEST_FLAG_PROTO_SEND            = UCS_BIT(2),
-    UCP_REQUEST_FLAG_USER_MEMH             = UCS_BIT(3),
     UCP_REQUEST_FLAG_SYNC_LOCAL_COMPLETED  = UCS_BIT(4),
     UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED = UCS_BIT(5),
     UCP_REQUEST_FLAG_CALLBACK              = UCS_BIT(6),
@@ -388,25 +387,17 @@ struct ucp_request {
 
         /* "receive" part - used for tag_recv, am_recv and stream_recv operations */
         struct {
-            ucs_queue_elem_t      queue;    /* Expected queue element */
-            void                  *buffer;  /* Buffer to receive data to */
-            ucp_datatype_t        datatype; /* Receive type */
-            size_t                length;   /* Total length, in bytes */
-            ucs_memory_type_t     mem_type; /* Memory type */
             uint32_t              op_attr;  /* Operation attributes */
-            ucp_dt_state_t        state;
+            ucp_datatype_iter_t   dt_iter;
             ucp_worker_t          *worker;
             uct_tag_context_t     uct_ctx;  /* Transport offload context */
+
             union {
+                /* Expected queue element */
+                ucs_queue_elem_t queue;
+
                 /* How much more data to be received */
-                ssize_t   remaining;
-
-                /* Offset in recv buffer for multi fragment tag offload flow */
-                size_t    offset;
-
-                /* User-defined memory handle supplied to ucp_[tag|am)_recv_nbx,
-                   valid if UCP_REQUEST_FLAG_USER_MEMH is set */
-                ucp_mem_h user_memh;
+                ssize_t          remaining;
             };
 
             /* Remote request ID received from a peer */
@@ -446,7 +437,7 @@ struct ucp_request {
 
                 struct {
                     ucp_stream_recv_nbx_callback_t cb;     /* Completion callback */
-                    size_t                         offset; /* Receive data offset */
+                    size_t                         elem_size;
                     size_t                         length; /* Completion info to fill */
                 } stream;
 

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -203,42 +203,36 @@ ucp_datatype_iter_init_null(ucp_datatype_iter_t *dt_iter, size_t length,
     ucp_memory_info_set_host(&dt_iter->mem_info);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_datatype_iter_init_from_dt_state(ucp_context_h context, void *buffer,
-                                     size_t length, ucp_datatype_t datatype,
-                                     const ucp_dt_state_t *dt_state,
-                                     ucp_datatype_iter_t *dt_iter,
-                                     uint8_t *sg_count)
+/* Move the datatype iterator state from 'src' to 'dst', reset 'src', and
+   return sg_count for protocol selection */
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_move(ucp_datatype_iter_t *dst_iter,
+                       ucp_datatype_iter_t *src_iter, size_t length,
+                       uint8_t *sg_count)
 {
-    static const ucp_request_param_t dummy_param = {0};
-    ucs_status_t status;
+    size_t iov_count;
 
-    dt_iter->offset   = 0;
-    dt_iter->dt_class = ucp_datatype_class(datatype);
+    ucs_assertv(src_iter->offset == 0, "offset=%zu", src_iter->offset);
 
-    if (ucs_likely(dt_iter->dt_class == UCP_DATATYPE_CONTIG)) {
-        ucp_datatype_contig_iter_init(context, buffer, length, dt_iter,
-                                      &dummy_param);
+    dst_iter->dt_class = src_iter->dt_class;
+    dst_iter->mem_info = src_iter->mem_info;
+    dst_iter->length   = length;
+    dst_iter->offset   = 0;
+    dst_iter->type     = src_iter->type;
+
+    if (src_iter->dt_class == UCP_DATATYPE_CONTIG) {
         *sg_count = 1;
-    } else if (dt_iter->dt_class == UCP_DATATYPE_IOV) {
-        ucp_datatype_iter_iov_set_sg_count(sg_count, dt_state->dt.iov.iovcnt);
-        status = ucp_datatype_iov_iter_init(context, buffer,
-                                            dt_state->dt.iov.iovcnt, length,
-                                            dt_iter, &dummy_param);
-        if (status != UCS_OK) {
-            return status;
-        }
+    } else if (src_iter->dt_class == UCP_DATATYPE_IOV) {
+        iov_count = ucp_datatype_iter_iov_count(src_iter);
+        ucp_datatype_iter_iov_set_sg_count(sg_count, iov_count);
     } else {
-        ucs_assert(dt_iter->dt_class == UCP_DATATYPE_GENERIC);
-        /* Transfer ownership from dt_state to dt_iter */
-        dt_iter->length              = length;
-        dt_iter->type.generic.dt_gen = ucp_dt_to_generic(datatype);
-        dt_iter->type.generic.state  = dt_state->dt.generic.state;
-        ucp_memory_info_set_host(&dt_iter->mem_info);
         *sg_count = 0;
     }
 
-    return UCS_OK;
+    /* Invalidate source iterator */
+#if UCS_ENABLE_ASSERT
+    src_iter->dt_class = UCP_DATATYPE_CLASS_MASK;
+#endif
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -632,6 +626,16 @@ static UCS_F_ALWAYS_INLINE int
 ucp_datatype_iter_is_end(const ucp_datatype_iter_t *dt_iter)
 {
     return ucp_datatype_iter_is_end_position(dt_iter, dt_iter);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_rewind(ucp_datatype_iter_t *dt_iter, unsigned dt_mask)
+{
+    dt_iter->offset = 0;
+    if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
+        dt_iter->type.iov.iov_index  = 0;
+        dt_iter->type.iov.iov_offset = 0;
+    }
 }
 
 /*

--- a/src/ucp/dt/dt_iov.c
+++ b/src/ucp/dt/dt_iov.c
@@ -146,26 +146,3 @@ ucs_status_t ucp_dt_iov_memtype_check(ucp_context_h context,
 
     return UCS_OK;
 }
-
-ucs_status_t ucp_dt_iov_memtype_detect(ucp_context_h context,
-                                       const ucp_dt_iov_t *iov, size_t iovcnt,
-                                       const ucp_request_param_t *param,
-                                       uint8_t *sg_count,
-                                       ucp_memory_info_t *mem_info)
-{
-    if (ucs_unlikely(iovcnt == 0)) {
-        ucp_memory_info_set_host(mem_info);
-        *sg_count = 1;
-        return UCS_OK;
-    }
-
-    ucp_memory_detect_param(context, iov->buffer, iov->length, param, mem_info);
-
-    *sg_count = ucs_min(iovcnt, (size_t)UINT8_MAX);
-
-    if (ENABLE_PARAMS_CHECK) {
-        return ucp_dt_iov_memtype_check(context, iov + 1, iovcnt - 1, mem_info);
-    }
-
-    return UCS_OK;
-}

--- a/src/ucp/dt/dt_iov.h
+++ b/src/ucp/dt/dt_iov.h
@@ -125,11 +125,4 @@ ucs_status_t ucp_dt_iov_memtype_check(ucp_context_h context,
                                       const ucp_dt_iov_t *iov, size_t iovcnt,
                                       const ucp_memory_info_t *mem_info);
 
-
-ucs_status_t ucp_dt_iov_memtype_detect(ucp_context_h context,
-                                       const ucp_dt_iov_t *iov, size_t iovcnt,
-                                       const ucp_request_param_t *param,
-                                       uint8_t *sg_count,
-                                       ucp_memory_info_t *mem_info);
-
 #endif

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -345,16 +345,16 @@ ucp_proto_rndv_op_check(const ucp_proto_init_params_t *params,
 }
 
 static UCS_F_ALWAYS_INLINE void
-ucp_proto_rndv_recv_super_complete_status(ucp_request_t *super_req,
-                                          ucs_status_t status)
+ucp_proto_rndv_recv_req_complete(ucp_request_t *recv_req, ucs_status_t status)
 {
-    ucp_trace_req(super_req, "rndv_recv_complete super_req=%p", super_req);
+    ucp_trace_req(recv_req, "rndv_recv_req_complete status '%s'",
+                  ucs_status_string(status));
 
-    if (super_req->flags & UCP_REQUEST_FLAG_RECV_AM) {
-        ucp_request_complete_am_recv(super_req, status);
+    if (recv_req->flags & UCP_REQUEST_FLAG_RECV_AM) {
+        ucp_request_complete_am_recv(recv_req, status);
     } else {
-        ucs_assert(super_req->flags & UCP_REQUEST_FLAG_RECV_TAG);
-        ucp_request_complete_tag_recv(super_req, status);
+        ucs_assert(recv_req->flags & UCP_REQUEST_FLAG_RECV_TAG);
+        ucp_request_complete_tag_recv(recv_req, status);
     }
 }
 
@@ -365,8 +365,7 @@ ucp_proto_rndv_recv_complete_status(ucp_request_t *req, ucs_status_t status)
     ucs_assert(req->send.rndv.rkey == NULL);
     ucs_assert(!ucp_proto_rndv_request_is_ppln_frag(req));
 
-    ucp_proto_rndv_recv_super_complete_status(ucp_request_get_super(req),
-                                              status);
+    ucp_proto_rndv_recv_req_complete(ucp_request_get_super(req), status);
     ucp_request_put(req);
     return UCS_OK;
 }

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -99,6 +99,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_rndv_am_bcopy_complete(ucp_request_t *req)
 {
     ucp_rndv_am_destroy_rkey(req);
+    ucp_datatype_iter_mem_dereg(&req->send.state.dt_iter, UCP_DT_MASK_ALL);
     return ucp_proto_request_bcopy_complete_success(req);
 }
 

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -197,7 +197,7 @@ static void ucp_rndv_get_zcopy_proto_abort(ucp_request_t *request,
         break;
     case UCP_PROTO_RNDV_GET_STAGE_ATS:
         rreq = ucp_request_get_super(request);
-        ucs_assert(rreq->recv.length == rreq->recv.tag.info.length);
+        ucs_assert(rreq->recv.dt_iter.length == rreq->recv.tag.info.length);
         /* Locally the data is received, can complete with OK, but memory
          * invalidation is not implemented in DC, so need to fail request to
          * avoid data corruption.

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -171,6 +171,8 @@ ucp_proto_rndv_ppln_frag_complete(ucp_request_t *freq, int send_ack, int abort,
         ucp_proto_rndv_rkey_destroy(req);
     }
 
+    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, 1, UCP_DT_MASK_ALL);
+
     if ((req->send.rndv.ppln.ack_data_size > 0) && !abort) {
         ucp_proto_request_set_stage(req, UCP_PROTO_RNDV_PPLN_STAGE_ACK);
         ucp_request_send(req);
@@ -265,7 +267,7 @@ static ucs_status_t ucp_proto_rndv_ppln_progress(uct_pending_req_t *uct_req)
 
         ucp_trace_req(req, "send freq %p offset %zu size %zu", freq,
                       freq->send.rndv.offset, freq->send.state.dt_iter.length);
-        ucp_request_send(freq);
+        UCS_PROFILE_CALL_VOID_ALWAYS(ucp_request_send, freq);
 
         ucp_datatype_iter_copy_position(&req->send.state.dt_iter, &next_iter,
                                         UCS_BIT(UCP_DATATYPE_CONTIG));

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -55,7 +55,7 @@ ucp_eager_offload_handler(void *arg, void *data, size_t length,
     if (req != NULL) {
         ucp_eager_common_matched(worker, req, data, length, recv_tag, flags);
         req->recv.tag.info.length = length;
-        status = ucp_request_recv_data_unpack(req, data, length, 0, 1);
+        status = ucp_request_recv_data_unpack(req, data, length, 0, 0, 1);
         ucp_request_complete_tag_recv(req, status);
         status = UCS_OK;
     } else {
@@ -103,7 +103,8 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
 
         if (flags & UCP_RECV_DESC_FLAG_EAGER_ONLY) {
             req->recv.tag.info.length = recv_len;
-            status = ucp_request_recv_data_unpack(req, payload, recv_len, 0, 1);
+            status = ucp_request_recv_data_unpack(req, payload, recv_len, 0, 0,
+                                                  1);
             ucp_request_complete_tag_recv(req, status);
         } else {
             /* Multi fragment tag offload flow does not use this handler */
@@ -341,7 +342,8 @@ ucp_tag_offload_eager_first_handler(ucp_worker_h worker, void *data,
 
     req = ucp_tag_exp_search(&worker->tm, stag);
     if (req != NULL) {
-        req->recv.offset = 0ul;
+        ucs_assertv(req->recv.dt_iter.offset == 0, "req=%p offset=%zu", req,
+                    req->recv.dt_iter.offset);
         ucp_tag_frag_hash_init_exp(matchq, req);
         ucp_eager_common_matched(worker, req, data, length, stag, flags);
         ucp_request_recv_offload_data(req, data, length, flags);

--- a/src/ucp/tag/offload.h
+++ b/src/ucp/tag/offload.h
@@ -100,7 +100,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_tag_offload_try_post(ucp_worker_t *worker, ucp_request_t *req,
                          ucp_request_queue_t *req_queue)
 {
-    if (ucs_unlikely(req->recv.length >= worker->tm.offload.thresh)) {
+    if (ucs_unlikely(req->recv.dt_iter.length >= worker->tm.offload.thresh)) {
         if (ucp_tag_offload_post(req, req_queue)) {
             return;
         }

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -55,11 +55,10 @@ static void ucp_tag_recv_eager_multi(ucp_worker_h worker, ucp_request_t *req,
     }
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_ptr_t
-ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
-                    uintptr_t datatype, ucp_tag_t tag, ucp_tag_t tag_mask,
-                    ucp_request_t *req, ucp_recv_desc_t *rdesc,
-                    const ucp_request_param_t *param, const char *debug_name)
+static UCS_F_ALWAYS_INLINE ucs_status_ptr_t ucp_tag_recv_common(
+        ucp_worker_h worker, void *buffer, size_t count, ucp_tag_t tag,
+        ucp_tag_t tag_mask, ucp_request_t *req, ucp_recv_desc_t *rdesc,
+        const ucp_request_param_t *param, const char *debug_name)
 {
     uint32_t req_flags = (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) ?
                          UCP_REQUEST_FLAG_CALLBACK : 0;
@@ -67,8 +66,10 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     size_t hdr_len, recv_len;
     ucs_status_t status;
 
-    ucp_trace_req(req, "%s buffer %p dt 0x%lx count %zu tag %"PRIx64"/%"PRIx64,
-                  debug_name, buffer, datatype, count, tag, tag_mask);
+    ucp_trace_req(req,
+                  "%s buffer %p dt 0x%lx count %zu tag %" PRIx64 "/%" PRIx64,
+                  debug_name, buffer, ucp_request_param_datatype(param), count,
+                  tag, tag_mask);
 
 #if ENABLE_DEBUG_DATA
     req->recv.proto_rndv_config = NULL;
@@ -115,21 +116,18 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
     /* Initialize receive request */
     req->status             = UCS_OK;
     req->recv.worker        = worker;
-    req->recv.buffer        = buffer;
-    req->recv.datatype      = datatype;
     req->flags              = UCP_REQUEST_FLAG_RECV_TAG | req_flags;
 
-    ucp_dt_recv_state_init(&req->recv.state, buffer, datatype, count);
+    status = ucp_datatype_iter_init_unpack(worker->context, buffer, count,
+                                           &req->recv.dt_iter, param);
+    if (status != UCS_OK) {
+        goto err;
+    }
 
-    if (!UCP_DT_IS_CONTIG(datatype)) {
+    if (req->recv.dt_iter.dt_class != UCP_DATATYPE_CONTIG) {
         req->flags         |= UCP_REQUEST_FLAG_BLOCK_OFFLOAD;
     }
 
-    req->recv.length        = ucp_dt_length(datatype, count, buffer,
-                                            &req->recv.state);
-    req->recv.mem_type      = ucp_request_get_memory_type(
-                                  worker->context, buffer, count, datatype,
-                                  req->recv.length, param);
     req->recv.op_attr       = param->op_attr_mask;
     req->recv.tag.tag       = tag;
     req->recv.tag.tag_mask  = tag_mask;
@@ -140,11 +138,6 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
 
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_REQ)) {
         req->recv.tag.info.sender_tag = 0;
-    }
-
-    status = ucp_recv_request_set_user_memh(req, param);
-    if (status != UCS_OK) {
-        goto err;
     }
 
     if (ucs_unlikely(rdesc == NULL)) {
@@ -224,7 +217,6 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
     ucp_recv_desc_t *rdesc;
     ucs_status_ptr_t ret;
     ucp_request_t *req;
-    ucp_datatype_t datatype;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
@@ -232,14 +224,14 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_recv_nbx,
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    datatype = ucp_request_param_datatype(param);
-    req      = ucp_request_get_param(worker, param,
-                                     {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-                                      goto out;});
+    req = ucp_request_get_param(worker, param, {
+        ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+        goto out;
+    });
 
-    rdesc    = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nbx");
-    ret      = ucp_tag_recv_common(worker, buffer, count, datatype, tag,
-                                   tag_mask, req, rdesc, param, "recv_nbx");
+    rdesc = ucp_tag_unexp_search(&worker->tm, tag, tag_mask, 1, "recv_nbx");
+    ret   = ucp_tag_recv_common(worker, buffer, count, tag, tag_mask, req,
+                                rdesc, param, "recv_nbx");
 
 out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
@@ -269,7 +261,6 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_msg_recv_nbx,
     ucp_recv_desc_t *rdesc = message;
     ucs_status_ptr_t ret;
     ucp_request_t *req;
-    ucp_datatype_t datatype;
 
     UCP_CONTEXT_CHECK_FEATURE_FLAGS(worker->context, UCP_FEATURE_TAG,
                                     return UCS_STATUS_PTR(UCS_ERR_INVALID_PARAM));
@@ -277,13 +268,12 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_tag_msg_recv_nbx,
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    req      = ucp_request_get_param(worker, param,
-                                     {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
-                                     goto out;});
-    datatype = ucp_request_param_datatype(param);
-    ret      =  ucp_tag_recv_common(worker, buffer, count, datatype,
-                                    ucp_rdesc_get_tag(rdesc), UCP_TAG_MASK_FULL,
-                                    req, rdesc, param, "msg_recv_nbx");
+    req = ucp_request_get_param(worker, param,
+                                {ret = UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);
+                                 goto out;});
+    ret = ucp_tag_recv_common(worker, buffer, count, ucp_rdesc_get_tag(rdesc),
+                              UCP_TAG_MASK_FULL, req, rdesc, param,
+                              "msg_recv_nbx");
 
 out:
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);

--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -785,7 +785,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, post_larger_recv)
         wait(my_recv_req);
 
         EXPECT_EQ(sendbuf.size(), my_recv_req->info.length);
-        EXPECT_EQ(recvbuf.size(), ((ucp_request_t*)my_recv_req - 1)->recv.length);
+        EXPECT_EQ(recvbuf.size(),
+                  ((ucp_request_t*)my_recv_req - 1)->recv.dt_iter.length);
         EXPECT_EQ((ucp_tag_t)0x111337, my_recv_req->info.sender_tag);
         EXPECT_TRUE(my_recv_req->completed);
         EXPECT_NE(sendbuf, recvbuf);


### PR DESCRIPTION
## Why
- Part of moving to protocols v2 - unify datatype processing code to use datatype_iter infra
- Simplify user memory handle support
- When protov1 is removed, more datatype handling code can be removed

## How
- Replace recv.dt by recv.dt_iter
- Adjust protocols accordingly