### PR TITLE
AZP: OAuth-based service connector

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -20,7 +20,7 @@ resources:
   - repository: PerfX
     type: github
     name: Mellanox-lab/PerfX
-    endpoint: Al3xR01
+    endpoint: Mellanox-lab
     ref: master
 
 stages:


### PR DESCRIPTION
## What
Switch to an OAuth-based service connector instead of a personal token-based one.
