### PR TITLE
UCS/MEMORY: Introduce auto memory type

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -449,7 +449,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "directory.",
    ucs_offsetof(ucp_context_config_t, proto_info_dir), UCS_CONFIG_TYPE_STRING},
 
-  {"REG_NONBLOCK_MEM_TYPES", "",
+  {"REG_NONBLOCK_MEM_TYPES", "auto",
    "Perform only non-blocking memory registration for these memory types:\n"
    "page registration may be deferred until it is accessed by the CPU or a transport.",
    ucs_offsetof(ucp_context_config_t, reg_nb_mem_types),
@@ -2023,6 +2023,12 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                      context->config.ext.tm_max_bb_size,
                      context->config.ext.seg_size);
         }
+    }
+
+    if ((context->config.ext.reg_nb_mem_types & UCS_BIT(UCS_MEMORY_TYPE_AUTO))) {
+        /* overwrite ext.reg_nb_mem_types with mem_types relevant for this
+         * platform. For now, leave it as previous default. */
+        context->config.ext.reg_nb_mem_types = 0;
     }
 
     if (context->config.ext.keepalive_num_eps == 0) {

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -457,10 +457,6 @@ ucs_status_t ucp_memh_register(ucp_context_h context, ucp_mem_h memh,
     err_level = (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DIAG :
                                                             UCS_LOG_LEVEL_ERROR;
 
-    if (context->config.ext.reg_nb_mem_types & UCS_BIT(mem_type)) {
-        uct_flags |= UCT_MD_MEM_FLAG_NONBLOCK;
-    }
-
     reg_params.flags         = uct_flags;
     reg_params.dmabuf_fd     = UCT_DMABUF_FD_INVALID;
     reg_params.dmabuf_offset = 0;

--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -20,6 +20,7 @@ const char *ucs_memory_type_names[] = {
     [UCS_MEMORY_TYPE_ROCM]         = "rocm",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "rocm-managed",
     [UCS_MEMORY_TYPE_RDMA]         = "rdma",
+    [UCS_MEMORY_TYPE_AUTO]         = "auto",
     [UCS_MEMORY_TYPE_LAST]         = "unknown",
     [UCS_MEMORY_TYPE_LAST + 1]     = NULL
 };
@@ -31,6 +32,7 @@ const char *ucs_memory_type_descs[] = {
     [UCS_MEMORY_TYPE_ROCM]         = "AMD/ROCm GPU memory",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "AMD/ROCm GPU managed memory",
     [UCS_MEMORY_TYPE_RDMA]         = "RDMA device memory",
+    [UCS_MEMORY_TYPE_AUTO]         = "Special value reserved for ODP use",
     [UCS_MEMORY_TYPE_LAST]         = "unknown"
 };
 

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -41,6 +41,7 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
     UCS_MEMORY_TYPE_RDMA,          /**< RDMA device memory */
+    UCS_MEMORY_TYPE_AUTO,          /**< Special value reserved for ODP use */
     UCS_MEMORY_TYPE_LAST,
     UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;


### PR DESCRIPTION
## What
Introduce special value `UCS_MEMORY_TYPE_AUTO` which when used with `UCX_REG_NONBLOCK_MEM_TYPES=auto` can result in automatically setting the right memory types that should be registered using on demand paging flag when using ibv_reg_mr with non-ucp_mem_map memory. For memory ranges that are passed to `ucp_mem_map`, ODP registrations are forced only when using the flag UCP_MEM_MAP_NONBLOCK.
