### PR TITLE
TOOLS/INFO: Add Icelake CPU model name

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -31,6 +31,7 @@ static const char *cpu_model_names[] = {
     [UCS_CPU_MODEL_INTEL_HASWELL]      = "Haswell",
     [UCS_CPU_MODEL_INTEL_BROADWELL]    = "Broadwell",
     [UCS_CPU_MODEL_INTEL_SKYLAKE]      = "Skylake",
+    [UCS_CPU_MODEL_INTEL_ICELAKE]      = "Icelake",
     [UCS_CPU_MODEL_ARM_AARCH64]        = "ARM 64-bit",
     [UCS_CPU_MODEL_AMD_NAPLES]         = "Naples",
     [UCS_CPU_MODEL_AMD_ROME]           = "Rome",

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -455,6 +455,8 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
                 cpu_model = UCS_CPU_MODEL_INTEL_SKYLAKE;
                 break;
             case 0x6a:
+            case 0x6c:
+            case 0x7e:
                 cpu_model = UCS_CPU_MODEL_INTEL_ICELAKE;
                 break;
             }


### PR DESCRIPTION
## What
Define ucx_info name for Icelake CPUs.
