### PR TITLE
PERF: Disable parallel execution

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -1,4 +1,5 @@
-trigger: none
+trigger: 
+  batch: true
 pr:
   branches:
     include:


### PR DESCRIPTION
## What
Disable parallel perf testing execution over the same environment, to prevent interference.

### Documentation
https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#batching-ci-runs
