### PR TITLE
UCT/CUDA/CUDA_IPC: Check memory registration availability.

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -35,7 +35,10 @@ static int uct_cuda_ipc_md_check_mem_reg()
     int value;
     int ret;
 
-    if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&dev)) != UCS_OK) {
+    if ((UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&dev)) != UCS_OK) &&
+        /* Context may be not set yet. Check attribute for 0 device, assuming
+         * support is uniform across all devices. */
+        (UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&dev, 0)) != UCS_OK)) {
         return 0;
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -33,11 +33,9 @@ static int uct_cuda_ipc_md_check_mem_reg();
 static ucs_status_t
 uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags                  = UCT_MD_FLAG_NEED_RKEY |
-                                      UCT_MD_FLAG_INVALIDATE |
-                                      UCT_MD_FLAG_INVALIDATE_RMA |
-                                      UCT_MD_FLAG_INVALIDATE_AMO;
-    md_attr->reg_mem_types          = 0;
+    md_attr->flags         = UCT_MD_FLAG_NEED_RKEY | UCT_MD_FLAG_INVALIDATE |
+                             UCT_MD_FLAG_INVALIDATE_RMA | UCT_MD_FLAG_INVALIDATE_AMO;
+    md_attr->reg_mem_types = 0;
     if (uct_cuda_ipc_md_check_mem_reg()) {
         md_attr->flags         |= UCT_MD_FLAG_REG;
         md_attr->reg_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_CUDA);
@@ -227,9 +225,9 @@ static ucs_status_t uct_cuda_ipc_rkey_release(uct_component_t *component,
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_cuda_ipc_mem_reg_internal(void *addr, size_t length, unsigned flags,
-                              uct_cuda_ipc_key_t *key)
+static ucs_status_t uct_cuda_ipc_mem_reg_internal(void *addr, size_t length,
+                                                  unsigned flags,
+                                                  uct_cuda_ipc_key_t *key)
 {
     ucs_log_level_t log_level;
     CUdevice cu_device;
@@ -294,7 +292,7 @@ uct_cuda_ipc_mem_dereg(uct_md_h md,
 
 static int uct_cuda_ipc_md_check_mem_reg()
 {
-    int ret                    = 0;
+    int ret = 0;
 #if CUDA_VERSION >= 12000
     CUdevice dev;
     CUdevice_attribute attribute;
@@ -327,11 +325,11 @@ static int uct_cuda_ipc_md_check_mem_reg()
             goto out;
         }
 
-        if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxCreate(&ctx, 0, dev))  != UCS_OK) {
-             goto out;
+        if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxCreate(&ctx, 0, dev)) != UCS_OK) {
+            goto out;
         }
 
-        if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxSetCurrent(ctx))  != UCS_OK) {
+        if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxSetCurrent(ctx)) != UCS_OK) {
             goto destroy_ctx;
         }
     }
@@ -340,8 +338,9 @@ static int uct_cuda_ipc_md_check_mem_reg()
         goto destroy_ctx;
     }
 
-    ret = (uct_cuda_ipc_mem_reg_internal(
-            (void *)dptr, length, UCT_MD_MEM_FLAG_HIDE_ERRORS, &key) == UCS_OK);
+    ret = (uct_cuda_ipc_mem_reg_internal((void*)dptr, length,
+                                         UCT_MD_MEM_FLAG_HIDE_ERRORS,
+                                         &key) == UCS_OK);
 
     UCT_CUDADRV_FUNC_LOG_DEBUG(cuMemFree(dptr));
 


### PR DESCRIPTION
## What
Added device attributes check to identify memory registration capability of cuda_ipc transport.

## Why ?
Memory registration method of cuda_ipc memory domain uses cuIpcGetMemHandle. Users can test their device for IPC functionality by calling cuDeviceGetAttribute with CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED. However, the attribute was added in CUDA 12. Test memory registration for 1 byte allocated on device in case of previous CUDA versions.
