### PR TITLE
UCP/API: Implement rkey compare and symmetric key backends

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -302,6 +302,10 @@ ucp_mem_map_params2uct_flags(const ucp_context_h context,
         if (params->flags & UCP_MEM_MAP_FIXED) {
             flags |= UCT_MD_MEM_FLAG_FIXED;
         }
+
+        if (params->flags & UCP_MEM_MAP_SYMMETRIC_RKEY) {
+            flags |= UCT_MD_MEM_SYMMETRIC_RKEY;
+        }
     }
 
     return flags;

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -1187,7 +1187,7 @@ ucp_rkey_compare(ucp_context_h context, ucp_rkey_h rkey1, ucp_rkey_h rkey2,
                  const ucp_rkey_compare_params_t *params, int *result)
 {
     uct_rkey_compare_params_t uct_params = {};
-    ucs_status_t status;
+    ucs_status_t status                  = UCS_OK;
     uct_component_h cmpt;
     ucp_md_index_t remote_md_index;
     unsigned i;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -914,7 +914,13 @@ typedef enum {
      * packed key by @ref uct_md_mkey_pack_v2 with
      * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag.
      */
-    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12)
+    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12),
+
+    /**
+     * MD supports symmetric remote keys. With that hint, the keys that compare
+     * equal with @a uct_rkey_compare can be used interchangeably.
+     */
+    UCT_MD_FLAG_SYMMETRIC_RKEY = UCS_BIT(13)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -9,6 +9,7 @@
 #define UCT_COMPONENT_H_
 
 #include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/config/parser.h>
 #include <ucs/datastruct/list.h>
 
@@ -135,6 +136,23 @@ typedef ucs_status_t (*uct_component_rkey_release_func_t)(
 
 
 /**
+ * Component method to compare two unpacked remote keys
+ *
+ * @param [in]  component               Compare remote keys on this component
+ * @param [in]  rkey1                   First remote key to compare
+ * @param [in]  rkey2                   Second remote key to compare
+ * @param [out] result                  Comparison result, < 0, 0 or > 0
+ *
+ * @return Error code or UCS_OK if result is valid. If rkey1 is lower, equal or
+ *         greater than rkey2, result is respectively lower, equal or greater
+ *         than 0.
+ */
+typedef ucs_status_t (*uct_component_rkey_compare_func_t)(
+        uct_component_t *component, uct_rkey_t rkey1, uct_rkey_t rkey2,
+        const uct_rkey_compare_params_t *params, int *result);
+
+
+/**
  * Component method to initialize VFS for memory domain.
  *
  * @param [in]  md                      Handle to the opened memory domain.
@@ -156,6 +174,7 @@ struct uct_component {
     uct_component_rkey_unpack_func_t        rkey_unpack;        /**< Remote key unpack method */
     uct_component_rkey_ptr_func_t           rkey_ptr;           /**< Remote key access pointer method */
     uct_component_rkey_release_func_t       rkey_release;       /**< Remote key release method */
+    uct_component_rkey_compare_func_t       rkey_compare;       /**< Remote key comparison method */
     ucs_config_global_list_entry_t          md_config;          /**< MD configuration entry */
     ucs_config_global_list_entry_t          cm_config;          /**< CM configuration entry */
     ucs_list_link_t                         tl_list;            /**< List of transports */

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -141,6 +141,7 @@ typedef ucs_status_t (*uct_component_rkey_release_func_t)(
  * @param [in]  component               Compare remote keys on this component
  * @param [in]  rkey1                   First remote key to compare
  * @param [in]  rkey2                   Second remote key to compare
+ * @param [in]  params                  Parameters for the comparison
  * @param [out] result                  Comparison result, < 0, 0 or > 0
  *
  * @return Error code or UCS_OK if result is valid. If rkey1 is lower, equal or

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -362,10 +362,24 @@ ucs_status_t uct_rkey_release(uct_component_h component,
 }
 
 ucs_status_t
+uct_base_rkey_compare_as_same(uct_component_t *component, uct_rkey_t rkey1,
+                              uct_rkey_t rkey2,
+                              const uct_rkey_compare_params_t *params,
+                              int *result)
+{
+    *result = 0;
+    return UCS_OK;
+}
+
+ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result)
 {
-    return UCS_ERR_UNSUPPORTED;
+    if ((params->field_mask != 0) || (result == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return component->rkey_compare(component, rkey1, rkey2, params, result);
 }
 
 static void uct_md_attr_from_v2(uct_md_attr_t *dst, const uct_md_attr_v2_t *src)

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -217,6 +217,17 @@ ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
                                      void **handle_p);
 
 /**
+ * @brief Remote key comparison that always returns a match
+ *
+ */
+ucs_status_t
+uct_base_rkey_compare_as_same(uct_component_t *component, uct_rkey_t rkey1,
+                              uct_rkey_t rkey2,
+                              const uct_rkey_compare_params_t *params,
+                              int *result);
+
+
+/**
  * Check allocation parameters and return an appropriate error if parameters
  * cannot be used for an allocation
  */

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -101,7 +101,9 @@ uct_cuda_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
 
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->flags                  = UCT_MD_FLAG_REG   |
+                                      UCT_MD_FLAG_ALLOC |
+                                      UCT_MD_FLAG_SYMMETRIC_RKEY;
     md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
                                       UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                       UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
@@ -614,6 +616,7 @@ uct_component_t uct_cuda_copy_component = {
     .rkey_unpack        = uct_cuda_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_cuda_copy_rkey_release,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = "cuda_cpy",
     .md_config          = {
         .name           = "Cuda-copy memory domain",

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -223,6 +223,15 @@ static ucs_status_t uct_cuda_ipc_rkey_release(uct_component_t *component,
 }
 
 static ucs_status_t
+uct_cuda_ipc_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                          uct_rkey_t rkey2,
+                          const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_cuda_ipc_key_t));
+    return UCS_OK;
+}
+
+static ucs_status_t
 uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                               unsigned flags, uct_cuda_ipc_key_t *key)
 {
@@ -342,6 +351,7 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
         .rkey_unpack        = uct_cuda_ipc_rkey_unpack,
         .rkey_ptr           = ucs_empty_function_return_unsupported,
         .rkey_release       = uct_cuda_ipc_rkey_release,
+        .rkey_compare       = uct_cuda_ipc_rkey_compare,
         .name               = "cuda_ipc",
         .md_config          = {
             .name           = "Cuda-IPC memory domain",

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -84,7 +84,7 @@ static ucs_status_t uct_gdr_copy_rkey_unpack(uct_component_t *component,
     uct_gdr_copy_key_t *packed = (uct_gdr_copy_key_t *)rkey_buffer;
     uct_gdr_copy_key_t *key;
 
-    key = ucs_malloc(sizeof(uct_gdr_copy_key_t), "uct_gdr_copy_key_t");
+    key = ucs_calloc(1, sizeof(uct_gdr_copy_key_t), "uct_gdr_copy_key_t");
     if (NULL == key) {
         ucs_error("failed to allocate memory for uct_gdr_copy_key_t");
         return UCS_ERR_NO_MEMORY;
@@ -105,6 +105,15 @@ static ucs_status_t uct_gdr_copy_rkey_release(uct_component_t *component,
 {
     ucs_assert(NULL == handle);
     ucs_free((void *)rkey);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_gdr_copy_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                          uct_rkey_t rkey2,
+                          const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_gdr_copy_key_t));
     return UCS_OK;
 }
 
@@ -454,6 +463,7 @@ uct_component_t uct_gdr_copy_component = {
     .rkey_unpack        = uct_gdr_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_gdr_copy_rkey_release,
+    .rkey_compare       = uct_gdr_copy_rkey_compare,
     .name               = "gdr_copy",
     .md_config          = {
         .name           = "GDR-copy memory domain",

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -718,6 +718,23 @@ static ucs_status_t uct_ib_rkey_unpack(uct_component_t *component,
     return UCS_OK;
 }
 
+static ucs_status_t uct_ib_rkey_compare(uct_component_t *component,
+                                        uct_rkey_t rkey1, uct_rkey_t rkey2,
+                                        const uct_rkey_compare_params_t *params,
+                                        int *result)
+{
+    uint32_t a = uct_ib_md_direct_rkey(rkey1);
+    uint32_t b = uct_ib_md_direct_rkey(rkey2);
+
+    if (a == b) {
+        a = uct_ib_md_atomic_rkey(rkey1);
+        b = uct_ib_md_atomic_rkey(rkey2);
+    }
+
+    *result = (int)(a - b);
+    return UCS_OK;
+}
+
 static const char *uct_ib_device_transport_type_name(struct ibv_device *device)
 {
     switch (device->transport_type) {
@@ -1429,6 +1446,7 @@ uct_component_t uct_ib_component = {
     .rkey_unpack        = uct_ib_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = uct_ib_rkey_compare,
     .name               = "ib",
     .md_config          = {
         .name           = "IB memory domain",

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -155,7 +155,7 @@ typedef struct uct_ib_md {
     uint16_t                 vhca_id;
     struct {
         uint32_t base;
-        size_t   size; /* Feature is activated when size is non-zero */
+        size_t   size;
     } mkey_by_name_reserve;
 } uct_ib_md_t;
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -153,6 +153,10 @@ typedef struct uct_ib_md {
      * be initiated.  */
     uint32_t                 flush_rkey;
     uint16_t                 vhca_id;
+    struct {
+        uint32_t base;
+        size_t   size; /* Feature is activated when size is non-zero */
+    } mkey_by_name_reserve;
 } uct_ib_md_t;
 
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -506,7 +506,13 @@ struct uct_ib_mlx5_cmd_hca_cap_2_bits {
 
     uint8_t    introspection_mkey[0x20];
 
-    uint8_t    reserved_at_160[0x6a0];
+    uint8_t    reserved_at_160[0x260];
+    uint8_t    mkey_by_name_reserve[0x1];
+    uint8_t    reserved_at_3c1[0x1];
+    uint8_t    mkey_by_name_reserve_log_size[0x6];
+    uint8_t    mkey_by_name_reserve_base[0x18];
+
+    uint8_t    reserved_at_3e0[0x420];
 };
 
 struct uct_ib_mlx5_odp_per_transport_service_cap_bits {
@@ -770,7 +776,8 @@ struct uct_ib_mlx5_create_mkey_in_bits {
     uint8_t    reserved_at_20[0x10];
     uint8_t    op_mod[0x10];
 
-    uint8_t    reserved_at_40[0x20];
+    uint8_t    reserved_at_40[0x8];
+    uint8_t    input_mkey_index[0x18];
 
     uint8_t    pg_access[0x1];
     uint8_t    mkey_umem_valid[0x1];
@@ -788,7 +795,13 @@ struct uct_ib_mlx5_create_mkey_in_bits {
 
     uint8_t    mkey_umem_offset[0x40];
 
-    uint8_t    reserved_at_380[0x500];
+    uint8_t    bsf_octword_actual_size[0x20];
+
+    uint8_t    reserved_at_380[0x8];
+
+    uint8_t    input_mkey_index_last[0x18];
+
+    uint8_t    reserved_at_3c0[0x4c0];
 
     uint8_t    klm_pas_mtt[0][0x20];
 };

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -57,14 +57,17 @@ static ucs_status_t uct_ib_mlx5_alloc_mkey_inbox(int list_size, char **in_p)
 static ucs_status_t
 uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md, int atomic, uintptr_t address,
                          size_t length, int list_size, size_t entity_size,
-                         char *in, const char *reason,
-                         struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
+                         char *in, uint32_t mkey_first, uint32_t mkey_last,
+                         const char *reason, struct mlx5dv_devx_obj **mr_p,
+                         uint32_t *mkey)
 {
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_mkey_out)] = {};
     struct mlx5dv_devx_obj *mr;
     void *mkc;
 
     UCT_IB_MLX5DV_SET(create_mkey_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_MKEY);
+    UCT_IB_MLX5DV_SET(create_mkey_in, in, input_mkey_index, mkey_first);
+    UCT_IB_MLX5DV_SET(create_mkey_in, in, input_mkey_index_last, mkey_last);
     mkc = UCT_IB_MLX5DV_ADDR_OF(create_mkey_in, in, memory_key_mkey_entry);
     UCT_IB_MLX5DV_SET(mkc, mkc, access_mode_1_0, UCT_IB_MLX5_MKC_ACCESS_MODE_KSM);
     UCT_IB_MLX5DV_SET(mkc, mkc, a, !!atomic);
@@ -108,7 +111,8 @@ uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md, int atomic, uintptr_t address,
 static ucs_status_t
 uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md, int atomic, void *address,
                               uct_ib_mlx5_devx_ksm_data_t *ksm_data,
-                              size_t length, off_t off, const char *reason,
+                              size_t length, off_t off, uint32_t index,
+                              const char *reason,
                               struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
 {
     void *mr_address = address;
@@ -134,7 +138,7 @@ uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md, int atomic, void *address,
     status = uct_ib_mlx5_devx_reg_ksm(md, atomic,
                                       (uintptr_t)address + off,
                                       length, ksm_data->mr_num,
-                                      ksm_data->mrs[0]->length, in, reason,
+                                      ksm_data->mrs[0]->length, in, index, 0, reason,
                                       mr_p, mkey);
     ucs_free(in);
     return status;
@@ -143,7 +147,8 @@ uct_ib_mlx5_devx_reg_ksm_data(uct_ib_mlx5_md_t *md, int atomic, void *address,
 static ucs_status_t uct_ib_mlx5_devx_reg_ksm_data_addr(
         uct_ib_mlx5_md_t *md, struct ibv_mr *mr, uintptr_t address,
         size_t length, uintptr_t iova, int atomic, int list_size,
-        const char *reason, struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
+        uint32_t index_first, uint32_t index_last, const char *reason,
+        struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
 {
     int i;
     char *in;
@@ -164,19 +169,16 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm_data_addr(
     }
 
     status = uct_ib_mlx5_devx_reg_ksm(md, atomic, iova, length, list_size,
-                                      UCT_IB_MD_MAX_MR_SIZE, in, reason, mr_p,
-                                      mkey);
+                                      UCT_IB_MD_MAX_MR_SIZE, in, index_first,
+                                      index_last, reason, mr_p, mkey);
     ucs_free(in);
     return status;
 }
 
-static ucs_status_t
-uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md,
-                                     uct_ib_mlx5_devx_mr_t *mr, off_t offset,
-                                     void *address, int atomic,
-                                     const char *reason,
-                                     struct mlx5dv_devx_obj **mr_p,
-                                     uint32_t *mkey)
+static ucs_status_t uct_ib_mlx5_devx_reg_ksm_data_contig(
+        uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mr_t *mr, off_t offset,
+        void *address, int atomic, uint32_t index_first, uint32_t index_last,
+        const char *reason, struct mlx5dv_devx_obj **mr_p, uint32_t *mkey)
 {
     size_t mr_length = mr->super.ib->length;
     uintptr_t ksm_address;
@@ -195,8 +197,8 @@ uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md,
 
     return uct_ib_mlx5_devx_reg_ksm_data_addr(md, mr->super.ib, ksm_address,
                                               ksm_length, ksm_address + offset,
-                                              atomic, list_size, reason, mr_p,
-                                              mkey);
+                                              atomic, list_size, index_first,
+                                              index_last, reason, mr_p, mkey);
 }
 
 /**
@@ -352,7 +354,7 @@ UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_indirect_key,
 
     do {
         status = uct_ib_mlx5_devx_reg_ksm_data_contig(
-                md, &memh->mrs[UCT_IB_MR_DEFAULT], 0, memh->address, 0,
+                md, &memh->mrs[UCT_IB_MR_DEFAULT], 0, memh->address, 0, 0, 0,
                 "indirect key", &memh->indirect_dvmr, &memh->indirect_rkey);
         if (status != UCS_OK) {
             break;
@@ -382,8 +384,14 @@ UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_atomic_key,
     uct_ib_mr_type_t mr_type  = uct_ib_md_get_atomic_mr_type(&md->super);
     uct_ib_mlx5_devx_mr_t *mr = &memh->mrs[mr_type];
     uint8_t mr_id             = uct_ib_md_get_atomic_mr_id(&md->super);
+    uint32_t index            = 0;
     ucs_status_t status;
     int is_atomic;
+
+    if (memh->smkey_mr != NULL) {
+        index = md->super.mkey_by_name_reserve.size / 2 +
+                (memh->symmetric_rkey >> 8);
+    }
 
     is_atomic = memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC;
 
@@ -391,6 +399,7 @@ UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_atomic_key,
         return uct_ib_mlx5_devx_reg_ksm_data(md, is_atomic, memh->address,
                                              mr->ksm_data, mr->ksm_data->length,
                                              uct_ib_md_atomic_offset(mr_id),
+                                             index,
                                              "multi-thread atomic key",
                                              &memh->atomic_dvmr,
                                              &memh->atomic_rkey);
@@ -398,7 +407,7 @@ UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_atomic_key,
 
     status = uct_ib_mlx5_devx_reg_ksm_data_contig(
             md, mr, uct_ib_md_atomic_offset(mr_id), memh->address, is_atomic,
-            "atomic key", &memh->atomic_dvmr, &memh->atomic_rkey);
+            index, 0, "atomic key", &memh->atomic_dvmr, &memh->atomic_rkey);
     if (status != UCS_OK) {
         return status;
     }
@@ -457,7 +466,7 @@ uct_ib_mlx5_devx_reg_mt(uct_ib_mlx5_md_t *md, void *address, size_t length,
     }
 
     status = uct_ib_mlx5_devx_reg_ksm_data(md, is_atomic, address, ksm_data,
-                                           length, 0, "multi-thread key",
+                                           length, 0, 0, "multi-thread key",
                                            &ksm_data->dvmr, mkey_p);
     if (status != UCS_OK) {
         goto err_dereg;
@@ -567,29 +576,41 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
                          uct_mem_h *memh_p)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(uct_md, uct_ib_mlx5_md_t);
+    unsigned flags = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0);
     uct_ib_mlx5_devx_mem_t *memh;
     uct_ib_mem_t *ib_memh;
     ucs_status_t status;
     uint32_t dummy_mkey;
 
-    status = uct_ib_memh_alloc(&md->super, length,
-                               UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
-                                                          FIELD_FLAGS, 0),
-                               sizeof(*memh), sizeof(memh->mrs[0]), &ib_memh);
+    status = uct_ib_memh_alloc(&md->super, length, flags, sizeof(*memh),
+                               sizeof(memh->mrs[0]), &ib_memh);
     if (status != UCS_OK) {
         goto err;
     }
 
-    memh                = ucs_derived_of(ib_memh, uct_ib_mlx5_devx_mem_t);
-    memh->exported_lkey = UCT_IB_INVALID_MKEY;
-    memh->atomic_rkey   = UCT_IB_INVALID_MKEY;
-    memh->indirect_rkey = UCT_IB_INVALID_MKEY;
+    memh                 = ucs_derived_of(ib_memh, uct_ib_mlx5_devx_mem_t);
+    memh->exported_lkey  = UCT_IB_INVALID_MKEY;
+    memh->atomic_rkey    = UCT_IB_INVALID_MKEY;
+    memh->indirect_rkey  = UCT_IB_INVALID_MKEY;
+    memh->symmetric_rkey = UCT_IB_INVALID_MKEY;
 
     status = uct_ib_mlx5_devx_reg_mr(md, memh, address, length, params,
                                      UCT_IB_MR_DEFAULT, UINT64_MAX,
                                      &memh->super.lkey, &memh->super.rkey);
     if (status != UCS_OK) {
         goto err_memh_free;
+    }
+
+    if ((md->flags & UCT_IB_MLX5_MD_FLAG_MKEY_BY_NAME_RESERVE) &&
+        (flags & UCT_MD_MEM_SYMMETRIC_RKEY)) {
+        /* Best effort */
+        (void)uct_ib_mlx5_devx_reg_ksm_data_contig(
+                md, &memh->mrs[UCT_IB_MR_DEFAULT], 0, address,
+                (memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC),
+                md->super.mkey_by_name_reserve.base,
+                md->super.mkey_by_name_reserve.base +
+                        (md->super.mkey_by_name_reserve.size / 2) - 1,
+                "symmetric key", &memh->smkey_mr, &memh->symmetric_rkey);
     }
 
     if (md->super.relaxed_order) {
@@ -702,6 +723,17 @@ uct_ib_mlx5_devx_mem_dereg(uct_md_h uct_md,
                   memh->indirect_rkey);
         status = uct_ib_mlx5_devx_obj_destroy(memh->indirect_dvmr,
                                               "MKEY, INDIRECT");
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    if (memh->smkey_mr != NULL) {
+        ucs_trace("%s: destroy smkey_mr %p with key %x",
+                  uct_ib_device_name(&md->super.dev), memh->smkey_mr,
+                  memh->symmetric_rkey);
+        status = uct_ib_mlx5_devx_obj_destroy(memh->smkey_mr,
+                                              "MKEY, SYMMETRIC");
         if (status != UCS_OK) {
             return status;
         }
@@ -993,7 +1025,7 @@ static void uct_ib_mlx5_devx_init_flush_mr(uct_ib_mlx5_md_t *md)
     status = uct_ib_mlx5_devx_reg_ksm_data_addr(md, md->flush_mr,
                                                 (uintptr_t)md->zero_buf,
                                                 UCT_IB_MD_FLUSH_REMOTE_LENGTH,
-                                                0, 0, 1, "flush mr",
+                                                0, 0, 1, 0, 0, "flush mr",
                                                 &md->flush_dvmr,
                                                 &md->super.flush_rkey);
     if (status != UCS_OK) {
@@ -1014,16 +1046,13 @@ err:
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();
 }
 
-static int uct_ib_mlx5_is_xgvmi_alias_supported(struct ibv_context *ctx)
+static ucs_status_t
+uct_ib_mlx5_query_cap_2(struct ibv_context *ctx, void *out, size_t size)
 {
-    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out)] = {};
-    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)]   = {};
-    uint64_t object_for_other_vhca;
-    uint32_t object_to_object;
-    void *cap;
-    ucs_status_t status;
+    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)] = {};
 
-    cap = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, out, capability);
+    ucs_assertv(size == UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out),
+                "size=%zu", size);
 
     /* query HCA CAP 2 */
     UCT_IB_MLX5DV_SET(query_hca_cap_in, in, opcode,
@@ -1031,9 +1060,16 @@ static int uct_ib_mlx5_is_xgvmi_alias_supported(struct ibv_context *ctx)
     UCT_IB_MLX5DV_SET(query_hca_cap_in, in, op_mod,
                       UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR |
                               (UCT_IB_MLX5_CAP_2_GENERAL << 1));
-    status = uct_ib_mlx5_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out),
-                                          "QUERY_HCA_CAP", 1);
-    if (status != UCS_OK) {
+    return uct_ib_mlx5_devx_general_cmd(ctx, in, sizeof(in), out, size,
+                                        "QUERY_HCA_CAP, CAP2", 1);
+}
+
+static int uct_ib_mlx5_is_xgvmi_alias_supported(void *cap)
+{
+    uint64_t object_for_other_vhca;
+    uint32_t object_to_object;
+
+    if (cap == NULL) {
         return 0;
     }
 
@@ -1046,6 +1082,29 @@ static int uct_ib_mlx5_is_xgvmi_alias_supported(struct ibv_context *ctx)
             UCT_IB_MLX5_HCA_CAPS_2_CROSS_VHCA_OBJ_TO_OBJ_LOCAL_MKEY_TO_REMOTE_MKEY) &&
            (object_for_other_vhca &
             UCT_IB_MLX5_HCA_CAPS_2_ALLOWED_OBJ_FOR_OTHER_VHCA_ACCESS_MKEY);
+}
+
+static int uct_ib_mlx5_mkey_by_name_reserve_set(uct_ib_mlx5_md_t *md, void *cap)
+{
+    int log_size;
+
+    ucs_assert(md->super.mkey_by_name_reserve.size == 0);
+
+    if (cap == NULL) {
+        return 0;
+    }
+
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap_2, cap, mkey_by_name_reserve) == 0) {
+        return 0;
+    }
+
+    log_size = UCT_IB_MLX5DV_GET(cmd_hca_cap_2, cap,
+                                 mkey_by_name_reserve_log_size);
+
+    md->super.mkey_by_name_reserve.base =
+            UCT_IB_MLX5DV_GET(cmd_hca_cap_2, cap, mkey_by_name_reserve_base);
+    md->super.mkey_by_name_reserve.size = UCS_BIT(log_size);
+    return 1;
 }
 
 static void uct_ib_mlx5_md_port_counter_set_id_init(uct_ib_mlx5_md_t *md)
@@ -1078,9 +1137,11 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 {
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out)] = {};
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)]   = {};
+    char cap_2_out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out)] = {};
     ucs_status_t status                                    = UCS_OK;
     uint8_t lag_state                                      = 0;
     uint64_t cap_flags                                     = 0;
+    void *cap_2                                            = NULL;
     uint8_t log_max_qp;
     uint16_t vhca_id;
     struct ibv_context *ctx;
@@ -1249,13 +1310,29 @@ static ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
     vhca_id = UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, vhca_id);
 
-    if (uct_ib_mlx5_is_xgvmi_alias_supported(ctx)) {
+    status = uct_ib_mlx5_query_cap_2(ctx, cap_2_out, sizeof(cap_2_out));
+    if (status == UCS_OK) {
+        cap_2 = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, cap_2_out, capability);
+    }
+
+    if (uct_ib_mlx5_is_xgvmi_alias_supported(cap_2)) {
         md->flags |= UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
         cap_flags |= UCT_MD_FLAG_EXPORTED_MKEY;
         ucs_debug("%s: cross gvmi alias mkey is supported",
                   uct_ib_device_name(dev));
     } else {
         ucs_debug("%s: crossing_vhca_mkey is not supported",
+                  uct_ib_device_name(dev));
+    }
+
+    if (uct_ib_mlx5_mkey_by_name_reserve_set(md, cap_2)) {
+        md->flags |= UCT_IB_MLX5_MD_FLAG_MKEY_BY_NAME_RESERVE;
+        cap_flags |= UCT_MD_FLAG_SYMMETRIC_RKEY;
+        ucs_debug("%s: mkey_by_name_reserve is supported, base=%08x size=%zu)",
+                  uct_ib_device_name(dev), md->super.mkey_by_name_reserve.base,
+                  md->super.mkey_by_name_reserve.size);
+    } else {
+        ucs_debug("%s: mkey_by_name_reserve is not supported",
                   uct_ib_device_name(dev));
     }
 
@@ -1655,9 +1732,9 @@ UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_exported_key,
 
     status = uct_ib_mlx5_devx_reg_ksm_data_contig(md,
                                                   &memh->mrs[UCT_IB_MR_DEFAULT],
-                                                  0, memh->address,
-                                                  0, "exported key",
-                                                  &cross_mr, &exported_lkey);
+                                                  0, memh->address, 0, 0, 0,
+                                                  "exported key", &cross_mr,
+                                                  &exported_lkey);
     if (status != UCS_OK) {
         return status;
     }
@@ -1767,6 +1844,8 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
         }
 
         rkey = memh->indirect_rkey;
+    } else if (memh->symmetric_rkey != UCT_IB_INVALID_MKEY) {
+        rkey = memh->symmetric_rkey;
     } else {
         rkey = memh->super.rkey;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -190,6 +190,8 @@ enum {
     /* Device supports indirect xgvmi MR. This flag is removed if xgvmi access
      * command fails */
     UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI       = UCS_BIT(13),
+    /* Device supports symmetric key creation */
+    UCT_IB_MLX5_MD_FLAG_MKEY_BY_NAME_RESERVE = UCS_BIT(14),
 
     /* Object to be created by DevX */
     UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 16,
@@ -250,9 +252,11 @@ typedef struct {
     struct mlx5dv_devx_obj  *indirect_dvmr;
     struct mlx5dv_devx_umem *umem;
     struct mlx5dv_devx_obj  *cross_mr;
+    struct mlx5dv_devx_obj  *smkey_mr;
     uint32_t                atomic_rkey;
     uint32_t                indirect_rkey;
     uint32_t                exported_lkey;
+    uint32_t                symmetric_rkey;
     uct_ib_mlx5_devx_mr_t   mrs[];
 } uct_ib_mlx5_devx_mem_t;
 

--- a/src/uct/ib/rdmacm/rdmacm_component.c
+++ b/src/uct/ib/rdmacm/rdmacm_component.c
@@ -51,6 +51,7 @@ uct_component_t uct_rdmacm_component = {
     .rkey_unpack        = ucs_empty_function_return_unsupported,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = "rdmacm",
     .md_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
     .cm_config          = {

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -92,7 +92,7 @@ static ucs_status_t uct_rocm_copy_rkey_unpack(uct_component_t *component,
     uct_rocm_copy_key_t *packed = (uct_rocm_copy_key_t *)rkey_buffer;
     uct_rocm_copy_key_t *key;
 
-    key = ucs_malloc(sizeof(uct_rocm_copy_key_t), "uct_rocm_copy_key_t");
+    key = ucs_calloc(1, sizeof(uct_rocm_copy_key_t), "uct_rocm_copy_key_t");
     if (NULL == key) {
         ucs_error("failed to allocate memory for uct_rocm_copy_key_t");
         return UCS_ERR_NO_MEMORY;
@@ -112,6 +112,15 @@ static ucs_status_t uct_rocm_copy_rkey_release(uct_component_t *component,
 {
     ucs_assert(NULL == handle);
     ucs_free((void *)rkey);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_rocm_copy_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                           uct_rkey_t rkey2,
+                           const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_rocm_copy_key_t));
     return UCS_OK;
 }
 
@@ -469,6 +478,7 @@ uct_component_t uct_rocm_copy_component = {
     .rkey_unpack        = uct_rocm_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_rocm_copy_rkey_release,
+    .rkey_compare       = uct_rocm_copy_rkey_compare,
     .name               = "rocm_cpy",
     .md_config          = {
         .name           = "ROCm-copy memory domain",

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -175,6 +175,15 @@ static ucs_status_t uct_rocm_ipc_rkey_release(uct_component_t *component,
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_rocm_ipc_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                          uct_rkey_t rkey2,
+                          const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_rocm_ipc_key_t));
+    return UCS_OK;
+}
+
 uct_component_t uct_rocm_ipc_component = {
     .query_md_resources = uct_rocm_base_query_md_resources,
     .md_open            = uct_rocm_ipc_md_open,
@@ -182,6 +191,7 @@ uct_component_t uct_rocm_ipc_component = {
     .rkey_unpack        = uct_rocm_ipc_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_rocm_ipc_rkey_release,
+    .rkey_compare       = uct_rocm_ipc_rkey_compare,
     .name               = "rocm_ipc",
     .md_config          = {
         .name           = "ROCm-IPC memory domain",

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -139,3 +139,12 @@ void uct_mm_md_close(uct_md_h md)
     ucs_free(mm_md->config);
     ucs_free(mm_md);
 }
+
+ucs_status_t uct_mm_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                                 uct_rkey_t rkey2,
+                                 const uct_rkey_compare_params_t *params,
+                                 int *result)
+{
+    *result = rkey1 > rkey2 ? 1 : rkey1 < rkey2 ? -1 : 0;
+    return UCS_OK;
+}

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -171,6 +171,7 @@ typedef struct uct_mm_component {
             .rkey_unpack        = _rkey_unpack, \
             .rkey_ptr           = uct_sm_rkey_ptr, \
             .rkey_release       = _rkey_release, \
+            .rkey_compare       = uct_mm_rkey_compare, \
             .name               = #_name, \
             .md_config          = { \
                 .name           = #_name " memory domain", \
@@ -212,5 +213,10 @@ uct_mm_md_make_rkey(void *local_address, uintptr_t remote_address,
 {
     *rkey_p = (uintptr_t)local_address - remote_address;
 }
+
+ucs_status_t uct_mm_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                                 uct_rkey_t rkey2,
+                                 const uct_rkey_compare_params_t *params,
+                                 int *result);
 
 #endif

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -218,7 +218,9 @@ ucs_status_t uct_cma_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     uct_cma_md_t *md = ucs_derived_of(uct_md, uct_cma_md_t);
 
     md_attr->rkey_packed_size       = 0;
-    md_attr->flags                  = UCT_MD_FLAG_REG | md->extra_caps;
+    md_attr->flags                  = UCT_MD_FLAG_REG            |
+                                      UCT_MD_FLAG_SYMMETRIC_RKEY |
+                                      md->extra_caps;
     md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -241,6 +243,7 @@ uct_component_t uct_cma_component = {
     .rkey_unpack        = uct_md_stub_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = "cma",
     .md_config          = {
         .name           = "CMA memory domain",

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -228,7 +228,7 @@ static ucs_status_t uct_knem_rkey_unpack(uct_component_t *component,
     uct_knem_key_t *packed = (uct_knem_key_t *)rkey_buffer;
     uct_knem_key_t *key;
 
-    key = ucs_malloc(sizeof(uct_knem_key_t), "uct_knem_key_t");
+    key = ucs_calloc(1, sizeof(uct_knem_key_t), "uct_knem_key_t");
     if (NULL == key) {
         ucs_error("Failed to allocate memory for uct_knem_key_t");
         return UCS_ERR_NO_MEMORY;
@@ -240,6 +240,15 @@ static ucs_status_t uct_knem_rkey_unpack(uct_component_t *component,
     *rkey_p = (uintptr_t)key;
     ucs_trace("unpacked rkey: key %p cookie 0x%"PRIx64" address %"PRIxPTR,
               key, key->cookie, key->address);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_knem_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                      uct_rkey_t rkey2, const uct_rkey_compare_params_t *params,
+                      int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_knem_key_t));
     return UCS_OK;
 }
 
@@ -295,6 +304,7 @@ uct_component_t uct_knem_component = {
     .rkey_unpack        = uct_knem_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_knem_rkey_release,
+    .rkey_compare       = uct_knem_rkey_compare,
     .name               = "knem",
     .md_config          = {
         .name           = "KNEM memory domain",

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -410,8 +410,9 @@ static uct_iface_ops_t uct_self_iface_ops = {
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->flags                  = UCT_MD_FLAG_REG |
-                                   UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->flags                  = UCT_MD_FLAG_REG       |
+                                   UCT_MD_FLAG_NEED_RKEY | /* TODO ignore rkey in rma/amo ops */
+                                   UCT_MD_FLAG_SYMMETRIC_RKEY;
     attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -472,6 +473,7 @@ static uct_component_t uct_self_component = {
     .rkey_unpack        = uct_self_md_rkey_unpack,
     .rkey_ptr           = uct_sm_rkey_ptr,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = UCT_SELF_NAME,
     .md_config          = {
         .name           = "Self memory domain",

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -27,8 +27,9 @@ static ucs_config_field_t uct_tcp_md_config_table[] = {
 static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->flags                  = UCT_MD_FLAG_REG |
-                                   UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->flags                  = UCT_MD_FLAG_REG       |
+                                   UCT_MD_FLAG_NEED_RKEY | /* TODO ignore rkey in rma/amo ops */
+                                   UCT_MD_FLAG_SYMMETRIC_RKEY;
     attr->max_alloc              = 0;
     attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -121,6 +122,7 @@ uct_component_t uct_tcp_component = {
     .rkey_unpack        = uct_tcp_md_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = UCT_TCP_NAME,
     .md_config          = {
         .name           = "TCP memory domain",

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -155,7 +155,7 @@ static ucs_status_t uct_ugni_rkey_unpack(uct_component_t *component,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    mem_hndl = ucs_malloc(sizeof(gni_mem_handle_t), "gni_mem_handle_t");
+    mem_hndl = ucs_calloc(1, sizeof(gni_mem_handle_t), "gni_mem_handle_t");
     if (NULL == mem_hndl) {
         ucs_error("Failed to allocate memory for gni_mem_handle_t");
         return UCS_ERR_NO_MEMORY;
@@ -165,6 +165,15 @@ static ucs_status_t uct_ugni_rkey_unpack(uct_component_t *component,
     mem_hndl->qword2 = ptr[2];
     *rkey_p = (uintptr_t)mem_hndl;
     *handle_p = NULL;
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ugni_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                      uct_rkey_t rkey2, const uct_rkey_compare_params_t *params,
+                      int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(gni_mem_handle_t));
     return UCS_OK;
 }
 
@@ -233,6 +242,7 @@ uct_component_t uct_ugni_component = {
     .rkey_unpack        = uct_ugni_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_ugni_rkey_release,
+    .rkey_compare       = uct_ugni_rkey_compare,
     .name               = UCT_UGNI_MD_NAME,
     .md_config          = {
         .name           = "UGNI memory domain",

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -1036,10 +1036,10 @@ UCS_TEST_SKIP_COND_P(test_ucp_rkey_compare, rkey_compare_different_config,
     ASSERT_UCS_OK(status);
     ASSERT_EQ(0, result);
 
-    if (disable_proto()) {
-        cfg_index = &rkey1->cache.ep_cfg_index;
-    } else {
+    if (m_ucp_config->ctx.proto_enable) {
         cfg_index = &rkey1->cfg_index;
+    } else {
+        cfg_index = &rkey1->cache.ep_cfg_index;
     }
 
     (*cfg_index)++;

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -959,6 +959,7 @@ void test_ucp_rkey_compare::mem_chunk::destroy()
 test_ucp_rkey_compare::mem_chunk
 test_ucp_rkey_compare::mem_chunk::create(ucp_context_h context)
 {
+    void *rkey_buffer           = NULL;
     size_t size                 = 4096;
     ucp_mem_map_params_t params = {
         .field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
@@ -970,7 +971,6 @@ test_ucp_rkey_compare::mem_chunk::create(ucp_context_h context)
     };
     ucs_status_t status;
     ucp_mem_h memh;
-    void *rkey_buffer;
     size_t rkey_size;
 
     status = ucp_mem_map(context, &params, &memh);
@@ -981,7 +981,8 @@ test_ucp_rkey_compare::mem_chunk::create(ucp_context_h context)
 
     status = ucp_rkey_pack(context, memh, &rkey_buffer, &rkey_size);
     if (status != UCS_OK) {
-        ucp_mem_unmap(context, memh);
+        status = ucp_mem_unmap(context, memh);
+        ASSERT_UCS_OK(status);
         memh = NULL;
         goto out;
     }

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -23,11 +23,16 @@ protected:
                          size_t size = 8192, bool aligned = false);
     bool has_ksm() const;
 
+    ucs_status_t reg_pack(void *buffer, size_t size,
+                          uct_ib_mlx5_devx_mem_t **memh,
+                          uct_rkey_t *rkey_p = NULL);
+    void check_smkeys(uct_rkey_t rkey1, uct_rkey_t rkey2);
+
 private:
 #ifdef HAVE_MLX5_DV
     uint32_t m_mlx5_flags = 0;
 #endif
-    void check_mlx5_atomic_mr(uct_ib_mem_t *ib_memh, bool is_expected);
+    void check_mlx5_mr(uct_ib_mem_t *ib_memh, bool is_expected);
 };
 
 void test_ib_md::init() {
@@ -45,7 +50,7 @@ const uct_ib_md_t &test_ib_md::ib_md() const {
     return *ucs_derived_of(md(), uct_ib_md_t);
 }
 
-void test_ib_md::check_mlx5_atomic_mr(uct_ib_mem_t *ib_memh, bool is_expected)
+void test_ib_md::check_mlx5_mr(uct_ib_mem_t *ib_memh, bool is_expected)
 {
 #if HAVE_DEVX
     uct_ib_mlx5_devx_mem_t *memh = ucs_derived_of(ib_memh,
@@ -57,6 +62,9 @@ void test_ib_md::check_mlx5_atomic_mr(uct_ib_mem_t *ib_memh, bool is_expected)
         EXPECT_EQ(nullptr, memh->atomic_dvmr);
         EXPECT_EQ(UCT_IB_INVALID_MKEY, memh->atomic_rkey);
     }
+
+    EXPECT_EQ(nullptr, memh->smkey_mr);
+    EXPECT_EQ(UCT_IB_INVALID_MKEY, memh->symmetric_rkey);
 #endif
 }
 
@@ -109,15 +117,14 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access,
         EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC);
     }
 
-    check_mlx5_atomic_mr(ib_memh, false);
+    check_mlx5_mr(ib_memh, false);
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
-    check_mlx5_atomic_mr(ib_memh,
-                         (amo_access && has_ksm()) || ib_md().relaxed_order);
+    check_mlx5_mr(ib_memh, (amo_access && has_ksm()) || ib_md().relaxed_order);
 
     status = uct_md_mem_dereg(md(), memh);
     EXPECT_UCS_OK(status);
@@ -153,6 +160,102 @@ UCS_TEST_P(test_ib_md, aligned) {
     std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
     size_t size = RUNNING_ON_VALGRIND ? 8192 : UCT_IB_MD_MAX_MR_SIZE;
     ib_md_umr_check(&rkey_buffer[0], true, size, true);
+}
+
+UCS_TEST_SKIP_COND_P(test_ib_md, smkey_fw,
+                     !check_caps(UCT_MD_FLAG_SYMMETRIC_RKEY))
+{
+    // FW has hardcoded values
+    EXPECT_EQ(0x3ff000, ib_md().mkey_by_name_reserve.base);
+    EXPECT_EQ(4096, ib_md().mkey_by_name_reserve.size);
+}
+
+ucs_status_t test_ib_md::reg_pack(void *buffer, size_t size,
+                                  uct_ib_mlx5_devx_mem_t **memh,
+                                  uct_rkey_t *rkey_p)
+{
+    std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
+    uct_rkey_bundle_t bundle;
+
+    ucs_status_t status = uct_md_mem_reg(md(), buffer, size,
+                                         UCT_MD_MEM_ACCESS_REMOTE_ATOMIC |
+                                         UCT_MD_MEM_SYMMETRIC_RKEY,
+                                         (void**)memh);
+    if (status == UCS_OK) {
+        status = uct_md_mkey_pack(md(), &(*memh)->super, &rkey_buffer[0]);
+        if ((status == UCS_OK) && (rkey_p != NULL)) {
+            status = uct_rkey_unpack(md()->component, &rkey_buffer[0], &bundle);
+            if (status == UCS_OK) {
+                *rkey_p = bundle.rkey;
+                status  = uct_rkey_release(md()->component, &bundle);
+            }
+        }
+    }
+
+    return status;
+}
+
+// Symmetric keys properties for the generic IB transport
+void test_ib_md::check_smkeys(uct_rkey_t rkey1, uct_rkey_t rkey2)
+{
+    EXPECT_NE(UCT_IB_INVALID_MKEY, uct_ib_md_atomic_rkey(rkey1));
+    EXPECT_NE(UCT_IB_INVALID_MKEY, uct_ib_md_direct_rkey(rkey1));
+    EXPECT_NE(UCT_IB_INVALID_MKEY, uct_ib_md_atomic_rkey(rkey2));
+    EXPECT_NE(UCT_IB_INVALID_MKEY, uct_ib_md_direct_rkey(rkey2));
+    EXPECT_EQ(uct_ib_md_atomic_rkey(rkey1) - uct_ib_md_direct_rkey(rkey1),
+              uct_ib_md_atomic_rkey(rkey2) - uct_ib_md_direct_rkey(rkey2));
+    EXPECT_EQ(uct_ib_md_direct_rkey(rkey1) + 0x100,
+              uct_ib_md_direct_rkey(rkey2));
+}
+
+UCS_TEST_SKIP_COND_P(test_ib_md, smkey_reg_atomic,
+                     !check_caps(UCT_MD_FLAG_SYMMETRIC_RKEY))
+{
+    size_t size = 8192;
+    int ret;
+    void *buffer;
+    ucs_status_t status;
+    uct_ib_mlx5_devx_mem_t *memh1, *memh2, *memh3;
+    uct_rkey_t rkey1, rkey2, rkey3;
+
+    ret = ucs_posix_memalign(&buffer, size, size, "smkey_reg_atomic");
+    ASSERT_EQ(0, ret);
+
+    status = reg_pack(buffer, size, &memh1, &rkey1);
+    EXPECT_UCS_OK(status);
+    status = reg_pack(buffer, size, &memh2, &rkey2);
+    EXPECT_UCS_OK(status);
+    check_smkeys(rkey1, rkey2);
+
+#ifdef HAVE_DEVX
+    EXPECT_NE(nullptr, memh1->smkey_mr);
+    EXPECT_NE(nullptr, memh2->smkey_mr);
+    EXPECT_NE(UCT_IB_INVALID_MKEY, memh1->symmetric_rkey);
+    EXPECT_NE(UCT_IB_INVALID_MKEY, memh1->atomic_rkey);
+    EXPECT_NE(UCT_IB_INVALID_MKEY, memh2->symmetric_rkey);
+    EXPECT_NE(UCT_IB_INVALID_MKEY, memh2->atomic_rkey);
+    EXPECT_EQ(memh1->symmetric_rkey - memh1->atomic_rkey,
+              memh2->symmetric_rkey - memh2->atomic_rkey);
+    EXPECT_EQ(memh1->symmetric_rkey + 0x100, memh2->symmetric_rkey);
+#endif
+
+    status = uct_md_mem_dereg(md(), memh1);
+    EXPECT_UCS_OK(status);
+    status = reg_pack(buffer, size, &memh1, &rkey1);
+    EXPECT_UCS_OK(status);
+    check_smkeys(rkey1, rkey2); // Confirm lower mkey context was selected
+
+    status = reg_pack(buffer, size, &memh3, &rkey3);
+    EXPECT_UCS_OK(status);
+    check_smkeys(rkey2, rkey3); // Confirm first available position selected
+
+    status = uct_md_mem_dereg(md(), memh1);
+    EXPECT_UCS_OK(status);
+    status = uct_md_mem_dereg(md(), memh2);
+    EXPECT_UCS_OK(status);
+    status = uct_md_mem_dereg(md(), memh3);
+    EXPECT_UCS_OK(status);
+    ucs_mmap_free(buffer, size);
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)

--- a/test/gtest/uct/test_amo_add_xor.cc
+++ b/test/gtest/uct/test_amo_add_xor.cc
@@ -11,13 +11,15 @@ class uct_amo_add_xor_test : public uct_amo_test {
 public:
 
     template <typename T, uct_atomic_op_t opcode>
-    void test_op(T (*op)(T, T)) {
+    void test_op(T (*op)(T, T), unsigned flags = 0) {
         /*
          * Method: Add/xor may random values from multiple workers running at the same
          * time. We expect the final result to be the sum/xor of all these values.
          */
 
-        mapped_buffer recvbuf(sizeof(T), 0, receiver());
+        mapped_buffer recvbuf(sizeof(T), flags, receiver(), 0,
+                              UCS_MEMORY_TYPE_HOST,
+                              UCT_MD_MEM_ACCESS_ALL | flags);
 
         T value = rand64();
         *(T*)recvbuf.ptr() = value;
@@ -45,6 +47,14 @@ public:
 UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, add32,
                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32)) {
     test_op<uint32_t, UCT_ATOMIC_OP_ADD>(add_op<uint32_t>);
+}
+
+// Make sure registration has atomic capability, and non supporting transports
+// perform anyways
+UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, addr32_symmetric_key,
+                     !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), OP32)) {
+    test_op<uint32_t, UCT_ATOMIC_OP_ADD>(add_op<uint32_t>,
+                                         UCT_MD_MEM_SYMMETRIC_RKEY);
 }
 
 UCS_TEST_SKIP_COND_P(uct_amo_add_xor_test, add64,

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -1086,7 +1086,7 @@ void test_md_rkey_compare::mem_chunk::destroy()
 
 uct_rkey_t test_md_rkey_compare::mem_chunk::unpack()
 {
-    uct_rkey_bundle_t bundle;
+    uct_rkey_bundle_t bundle = {};
     ucs_status_t status;
 
     status = uct_rkey_unpack(component, rkey_buffer, &bundle);


### PR DESCRIPTION
## What
Add ucp_rkey_compare, uct_rkey_compare, comparison for all transports and ib symmetric enablement.

## Why ?
Added at once with tests, to run sanities.

## How ?
Could be later split in multiple parts if needed.