### PR TITLE
TOOLS/PERF: make ucp perftest independent from allocators

### DIFF
--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -112,6 +112,9 @@ struct ucx_perf_context {
             ucp_dt_iov_t               *send_iov;
             ucp_dt_iov_t               *recv_iov;
             void                       *am_hdr;
+            ucp_ep_h                   self_ep;
+            ucp_rkey_h                 self_send_rkey;
+            ucp_rkey_h                 self_recv_rkey;
         } ucp;
     };
 };
@@ -172,6 +175,7 @@ size_t ucx_perf_get_message_size(const ucx_perf_params_t *params);
 
 void ucx_perf_report(ucx_perf_context_t *perf);
 
+ucs_status_t ucx_perf_allocators_init_thread(ucx_perf_context_t *perf);
 
 static UCS_F_ALWAYS_INLINE int ucx_perf_context_done(ucx_perf_context_t *perf)
 {

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -21,11 +21,8 @@ static void print_memory_type_usage(void)
     ucs_memory_type_t it;
 
     ucs_memory_type_for_each(it) {
-        if (ucx_perf_mem_type_allocators[it] != NULL) {
-            printf("                        %s - %s\n",
-                   ucs_memory_type_names[it],
-                   ucs_memory_type_descs[it]);
-        }
+        printf("                        %s - %s\n", ucs_memory_type_names[it],
+               ucs_memory_type_descs[it]);
     }
 }
 
@@ -162,8 +159,7 @@ static ucs_status_t parse_mem_type(const char *opt_arg,
     }
 
     ucs_memory_type_for_each(it) {
-        if(!strcmp(opt_arg, ucs_memory_type_names[it]) &&
-           (ucx_perf_mem_type_allocators[it] != NULL)) {
+        if (!strcmp(opt_arg, ucs_memory_type_names[it])) {
             *mem_type = it;
             return UCS_OK;
         }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -2137,7 +2137,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    if (flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA) {
+    if ((flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA) || (memh->dm != NULL)) {
         if (ucs_unlikely(memh->indirect_dvmr == NULL)) {
             status = uct_ib_mlx5_devx_reg_indirect_key(md, memh);
             if (status != UCS_OK) {


### PR DESCRIPTION
## What
Removing usage of allocators in ucp perftest.

## Why ?
So adding new memory types will be easier as memory handling will be managed only through UCP / UCT api's

## How ?
perftest object will have a pointer to `memcpy` function, anything else related to allocators will be used only in UCT perftest.