### PR TITLE
UCT/API: Add uct_rkey_compare() member with temporary stubs

### DIFF
--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -9,6 +9,7 @@
 #define UCT_COMPONENT_H_
 
 #include <uct/api/uct.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/config/parser.h>
 #include <ucs/datastruct/list.h>
 
@@ -135,6 +136,24 @@ typedef ucs_status_t (*uct_component_rkey_release_func_t)(
 
 
 /**
+ * Component method to compare two unpacked remote keys
+ *
+ * @param [in]  component               Compare remote keys on this component
+ * @param [in]  rkey1                   First remote key to compare
+ * @param [in]  rkey2                   Second remote key to compare
+ * @param [in]  params                  Parameters for the comparison
+ * @param [out] result                  Comparison result, < 0, 0 or > 0
+ *
+ * @return Error code or UCS_OK if result is valid. If rkey1 is lower, equal or
+ *         greater than rkey2, result is respectively lower, equal or greater
+ *         than 0.
+ */
+typedef ucs_status_t (*uct_component_rkey_compare_func_t)(
+        uct_component_t *component, uct_rkey_t rkey1, uct_rkey_t rkey2,
+        const uct_rkey_compare_params_t *params, int *result);
+
+
+/**
  * Component method to initialize VFS for memory domain.
  *
  * @param [in]  md                      Handle to the opened memory domain.
@@ -156,6 +175,7 @@ struct uct_component {
     uct_component_rkey_unpack_func_t        rkey_unpack;        /**< Remote key unpack method */
     uct_component_rkey_ptr_func_t           rkey_ptr;           /**< Remote key access pointer method */
     uct_component_rkey_release_func_t       rkey_release;       /**< Remote key release method */
+    uct_component_rkey_compare_func_t       rkey_compare;       /**< Remote key comparison method */
     ucs_config_global_list_entry_t          md_config;          /**< MD configuration entry */
     ucs_config_global_list_entry_t          cm_config;          /**< CM configuration entry */
     ucs_list_link_t                         tl_list;            /**< List of transports */

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -365,7 +365,11 @@ ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result)
 {
-    return UCS_ERR_UNSUPPORTED;
+    if ((params->field_mask != 0) || (result == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return component->rkey_compare(component, rkey1, rkey2, params, result);
 }
 
 static void uct_md_attr_from_v2(uct_md_attr_t *dst, const uct_md_attr_v2_t *src)

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -614,6 +614,7 @@ uct_component_t uct_cuda_copy_component = {
     .rkey_unpack        = uct_cuda_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_cuda_copy_rkey_release,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "cuda_cpy",
     .md_config          = {
         .name           = "Cuda-copy memory domain",

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -342,6 +342,7 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
         .rkey_unpack        = uct_cuda_ipc_rkey_unpack,
         .rkey_ptr           = ucs_empty_function_return_unsupported,
         .rkey_release       = uct_cuda_ipc_rkey_release,
+        .rkey_compare       = ucs_empty_function_return_unsupported,
         .name               = "cuda_ipc",
         .md_config          = {
             .name           = "Cuda-IPC memory domain",

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -454,6 +454,7 @@ uct_component_t uct_gdr_copy_component = {
     .rkey_unpack        = uct_gdr_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_gdr_copy_rkey_release,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "gdr_copy",
     .md_config          = {
         .name           = "GDR-copy memory domain",

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1429,6 +1429,7 @@ uct_component_t uct_ib_component = {
     .rkey_unpack        = uct_ib_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "ib",
     .md_config          = {
         .name           = "IB memory domain",

--- a/src/uct/ib/rdmacm/rdmacm_component.c
+++ b/src/uct/ib/rdmacm/rdmacm_component.c
@@ -51,6 +51,7 @@ uct_component_t uct_rdmacm_component = {
     .rkey_unpack        = ucs_empty_function_return_unsupported,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "rdmacm",
     .md_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
     .cm_config          = {

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -469,6 +469,7 @@ uct_component_t uct_rocm_copy_component = {
     .rkey_unpack        = uct_rocm_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_rocm_copy_rkey_release,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "rocm_cpy",
     .md_config          = {
         .name           = "ROCm-copy memory domain",

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -182,6 +182,7 @@ uct_component_t uct_rocm_ipc_component = {
     .rkey_unpack        = uct_rocm_ipc_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_rocm_ipc_rkey_release,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "rocm_ipc",
     .md_config          = {
         .name           = "ROCm-IPC memory domain",

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -171,6 +171,7 @@ typedef struct uct_mm_component {
             .rkey_unpack        = _rkey_unpack, \
             .rkey_ptr           = uct_sm_rkey_ptr, \
             .rkey_release       = _rkey_release, \
+            .rkey_compare       = ucs_empty_function_return_unsupported, \
             .name               = #_name, \
             .md_config          = { \
                 .name           = #_name " memory domain", \

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -241,6 +241,7 @@ uct_component_t uct_cma_component = {
     .rkey_unpack        = uct_md_stub_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "cma",
     .md_config          = {
         .name           = "CMA memory domain",

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -295,6 +295,7 @@ uct_component_t uct_knem_component = {
     .rkey_unpack        = uct_knem_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_knem_rkey_release,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = "knem",
     .md_config          = {
         .name           = "KNEM memory domain",

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -472,6 +472,7 @@ static uct_component_t uct_self_component = {
     .rkey_unpack        = uct_self_md_rkey_unpack,
     .rkey_ptr           = uct_sm_rkey_ptr,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = UCT_SELF_NAME,
     .md_config          = {
         .name           = "Self memory domain",

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -121,6 +121,7 @@ uct_component_t uct_tcp_component = {
     .rkey_unpack        = uct_tcp_md_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = UCT_TCP_NAME,
     .md_config          = {
         .name           = "TCP memory domain",

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -233,6 +233,7 @@ uct_component_t uct_ugni_component = {
     .rkey_unpack        = uct_ugni_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_ugni_rkey_release,
+    .rkey_compare       = ucs_empty_function_return_unsupported,
     .name               = UCT_UGNI_MD_NAME,
     .md_config          = {
         .name           = "UGNI memory domain",


### PR DESCRIPTION
## What
Add `.rkey_compare` member and corresponding temporary stubs.

## Why ?
This will enable the start of parallel PRs

## How ?
The unsupported stubs are temporary and they will all be replaced by full implementation.