### PR TITLE
UCS/MEMORY: Make fail of numa node file opening silent.

### DIFF
--- a/src/ucs/memory/numa.c
+++ b/src/ucs/memory/numa.c
@@ -147,7 +147,7 @@ ucs_numa_node_t ucs_numa_node_of_device(const char *dev_path)
     long parsed_node;
     ucs_status_t status;
 
-    status = ucs_read_file_number(&parsed_node, 0, "%s/numa_node", dev_path);
+    status = ucs_read_file_number(&parsed_node, 1, "%s/numa_node", dev_path);
 
     if ((status != UCS_OK) || (parsed_node < 0) ||
         (parsed_node >= UCS_NUMA_NODE_MAX)) {

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -418,6 +418,8 @@ FILE *ucs_open_file(const char *mode, ucs_log_level_t err_log_level,
 static ssize_t ucs_read_file_vararg(char *buffer, size_t max, int silent,
                                     const char *filename_fmt, va_list ap)
 {
+    ucs_log_level_t err_level = silent ? UCS_LOG_LEVEL_DEBUG :
+                                         UCS_LOG_LEVEL_ERROR;
     char filename[MAXPATHLEN];
     ssize_t read_bytes;
     int fd;
@@ -426,18 +428,14 @@ static ssize_t ucs_read_file_vararg(char *buffer, size_t max, int silent,
 
     fd = open(filename, O_RDONLY);
     if (fd < 0) {
-        if (!silent) {
-            ucs_error("failed to open %s: %m", filename);
-        }
+        ucs_log(err_level, "failed to open %s: %m", filename);
         read_bytes = -1;
         goto out;
     }
 
     read_bytes = read(fd, buffer, max - 1);
     if (read_bytes < 0) {
-        if (!silent) {
-            ucs_error("failed to read from %s: %m", filename);
-        }
+        ucs_log(err_level, "failed to read from %s: %m", filename);
         goto out_close;
     }
 


### PR DESCRIPTION
## What
 Make fail of numa node file opening silent.

## Why ?
There is no need to print error message here, because the case is handled on the next lines by returning `UCS_NUMA_NODE_DEFAULT`.
