### PR TITLE
UCT/SM: Add rkey_compare implementation for shared memory transports

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -914,7 +914,13 @@ typedef enum {
      * packed key by @ref uct_md_mkey_pack_v2 with
      * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag.
      */
-    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12)
+    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12),
+
+    /**
+     * MD supports symmetric remote keys. When set, the memory domain supports
+     * best-effort memory registration using @ref UCT_MD_MEM_SYMMETRIC_RKEY.
+     */
+    UCT_MD_FLAG_SYMMETRIC_RKEY = UCS_BIT(13)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -362,6 +362,16 @@ ucs_status_t uct_rkey_release(uct_component_h component,
 }
 
 ucs_status_t
+uct_base_rkey_compare_as_same(uct_component_t *component, uct_rkey_t rkey1,
+                              uct_rkey_t rkey2,
+                              const uct_rkey_compare_params_t *params,
+                              int *result)
+{
+    *result = 0;
+    return UCS_OK;
+}
+
+ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -217,6 +217,17 @@ ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
                                      void **handle_p);
 
 /**
+ * @brief Remote key comparison that always returns a match
+ *
+ */
+ucs_status_t
+uct_base_rkey_compare_as_same(uct_component_t *component, uct_rkey_t rkey1,
+                              uct_rkey_t rkey2,
+                              const uct_rkey_compare_params_t *params,
+                              int *result);
+
+
+/**
  * Check allocation parameters and return an appropriate error if parameters
  * cannot be used for an allocation
  */

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -139,3 +139,12 @@ void uct_mm_md_close(uct_md_h md)
     ucs_free(mm_md->config);
     ucs_free(mm_md);
 }
+
+ucs_status_t uct_mm_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                                 uct_rkey_t rkey2,
+                                 const uct_rkey_compare_params_t *params,
+                                 int *result)
+{
+    *result = rkey1 > rkey2 ? 1 : rkey1 < rkey2 ? -1 : 0;
+    return UCS_OK;
+}

--- a/src/uct/sm/mm/base/mm_md.h
+++ b/src/uct/sm/mm/base/mm_md.h
@@ -171,7 +171,7 @@ typedef struct uct_mm_component {
             .rkey_unpack        = _rkey_unpack, \
             .rkey_ptr           = uct_sm_rkey_ptr, \
             .rkey_release       = _rkey_release, \
-            .rkey_compare       = ucs_empty_function_return_unsupported, \
+            .rkey_compare       = uct_mm_rkey_compare, \
             .name               = #_name, \
             .md_config          = { \
                 .name           = #_name " memory domain", \
@@ -213,5 +213,10 @@ uct_mm_md_make_rkey(void *local_address, uintptr_t remote_address,
 {
     *rkey_p = (uintptr_t)local_address - remote_address;
 }
+
+ucs_status_t uct_mm_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                                 uct_rkey_t rkey2,
+                                 const uct_rkey_compare_params_t *params,
+                                 int *result);
 
 #endif

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -218,7 +218,9 @@ ucs_status_t uct_cma_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     uct_cma_md_t *md = ucs_derived_of(uct_md, uct_cma_md_t);
 
     md_attr->rkey_packed_size       = 0;
-    md_attr->flags                  = UCT_MD_FLAG_REG | md->extra_caps;
+    md_attr->flags                  = UCT_MD_FLAG_REG            |
+                                      UCT_MD_FLAG_SYMMETRIC_RKEY |
+                                      md->extra_caps;
     md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -241,7 +243,7 @@ uct_component_t uct_cma_component = {
     .rkey_unpack        = uct_md_stub_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = "cma",
     .md_config          = {
         .name           = "CMA memory domain",

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -228,7 +228,7 @@ static ucs_status_t uct_knem_rkey_unpack(uct_component_t *component,
     uct_knem_key_t *packed = (uct_knem_key_t *)rkey_buffer;
     uct_knem_key_t *key;
 
-    key = ucs_malloc(sizeof(uct_knem_key_t), "uct_knem_key_t");
+    key = ucs_calloc(1, sizeof(uct_knem_key_t), "uct_knem_key_t");
     if (NULL == key) {
         ucs_error("Failed to allocate memory for uct_knem_key_t");
         return UCS_ERR_NO_MEMORY;
@@ -240,6 +240,15 @@ static ucs_status_t uct_knem_rkey_unpack(uct_component_t *component,
     *rkey_p = (uintptr_t)key;
     ucs_trace("unpacked rkey: key %p cookie 0x%"PRIx64" address %"PRIxPTR,
               key, key->cookie, key->address);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_knem_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                      uct_rkey_t rkey2, const uct_rkey_compare_params_t *params,
+                      int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_knem_key_t));
     return UCS_OK;
 }
 
@@ -295,7 +304,7 @@ uct_component_t uct_knem_component = {
     .rkey_unpack        = uct_knem_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_knem_rkey_release,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_knem_rkey_compare,
     .name               = "knem",
     .md_config          = {
         .name           = "KNEM memory domain",

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -410,8 +410,9 @@ static uct_iface_ops_t uct_self_iface_ops = {
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->flags                  = UCT_MD_FLAG_REG |
-                                   UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->flags                  = UCT_MD_FLAG_REG       |
+                                   UCT_MD_FLAG_NEED_RKEY | /* TODO ignore rkey in rma/amo ops */
+                                   UCT_MD_FLAG_SYMMETRIC_RKEY;
     attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -472,7 +473,7 @@ static uct_component_t uct_self_component = {
     .rkey_unpack        = uct_self_md_rkey_unpack,
     .rkey_ptr           = uct_sm_rkey_ptr,
     .rkey_release       = ucs_empty_function_return_success,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = UCT_SELF_NAME,
     .md_config          = {
         .name           = "Self memory domain",


### PR DESCRIPTION
## What
Add rkey_compare implementation for shared memory transports.

## Why ?
All transports must implement a valid comparison function. UCT tests coming when all transports will implement rkey_compare.

## How ?
- Using memcmp with clearing any padding byte seems more future proof.
- Add MD flag attribute to set expectations. This can be used, for instance, by testing infra to set proper expectations when comparing keys unpacked twice, for instance.
