### PR TITLE
UCT/API: Add rkey_compare for non-ib, non-sm transports

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -914,7 +914,13 @@ typedef enum {
      * packed key by @ref uct_md_mkey_pack_v2 with
      * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag.
      */
-    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12)
+    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12),
+
+    /**
+     * MD supports symmetric remote keys. When set, the memory domain supports
+     * best-effort memory registration using @ref UCT_MD_MEM_SYMMETRIC_RKEY.
+     */
+    UCT_MD_FLAG_SYMMETRIC_RKEY = UCS_BIT(13)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -362,6 +362,16 @@ ucs_status_t uct_rkey_release(uct_component_h component,
 }
 
 ucs_status_t
+uct_base_rkey_compare_as_same(uct_component_t *component, uct_rkey_t rkey1,
+                              uct_rkey_t rkey2,
+                              const uct_rkey_compare_params_t *params,
+                              int *result)
+{
+    *result = 0;
+    return UCS_OK;
+}
+
+ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result)
 {

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -217,6 +217,17 @@ ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
                                      void **handle_p);
 
 /**
+ * @brief Remote key comparison that always returns a match
+ *
+ */
+ucs_status_t
+uct_base_rkey_compare_as_same(uct_component_t *component, uct_rkey_t rkey1,
+                              uct_rkey_t rkey2,
+                              const uct_rkey_compare_params_t *params,
+                              int *result);
+
+
+/**
  * Check allocation parameters and return an appropriate error if parameters
  * cannot be used for an allocation
  */

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -101,7 +101,9 @@ uct_cuda_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
 
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->flags                  = UCT_MD_FLAG_REG   |
+                                      UCT_MD_FLAG_ALLOC |
+                                      UCT_MD_FLAG_SYMMETRIC_RKEY;
     md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
                                       UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                       UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
@@ -614,7 +616,7 @@ uct_component_t uct_cuda_copy_component = {
     .rkey_unpack        = uct_cuda_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_cuda_copy_rkey_release,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = "cuda_cpy",
     .md_config          = {
         .name           = "Cuda-copy memory domain",

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -223,6 +223,15 @@ static ucs_status_t uct_cuda_ipc_rkey_release(uct_component_t *component,
 }
 
 static ucs_status_t
+uct_cuda_ipc_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                          uct_rkey_t rkey2,
+                          const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_cuda_ipc_key_t));
+    return UCS_OK;
+}
+
+static ucs_status_t
 uct_cuda_ipc_mem_reg_internal(uct_md_h uct_md, void *addr, size_t length,
                               unsigned flags, uct_cuda_ipc_key_t *key)
 {
@@ -342,7 +351,7 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
         .rkey_unpack        = uct_cuda_ipc_rkey_unpack,
         .rkey_ptr           = ucs_empty_function_return_unsupported,
         .rkey_release       = uct_cuda_ipc_rkey_release,
-        .rkey_compare       = ucs_empty_function_return_unsupported,
+        .rkey_compare       = uct_cuda_ipc_rkey_compare,
         .name               = "cuda_ipc",
         .md_config          = {
             .name           = "Cuda-IPC memory domain",

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -84,7 +84,7 @@ static ucs_status_t uct_gdr_copy_rkey_unpack(uct_component_t *component,
     uct_gdr_copy_key_t *packed = (uct_gdr_copy_key_t *)rkey_buffer;
     uct_gdr_copy_key_t *key;
 
-    key = ucs_malloc(sizeof(uct_gdr_copy_key_t), "uct_gdr_copy_key_t");
+    key = ucs_calloc(1, sizeof(uct_gdr_copy_key_t), "uct_gdr_copy_key_t");
     if (NULL == key) {
         ucs_error("failed to allocate memory for uct_gdr_copy_key_t");
         return UCS_ERR_NO_MEMORY;
@@ -105,6 +105,15 @@ static ucs_status_t uct_gdr_copy_rkey_release(uct_component_t *component,
 {
     ucs_assert(NULL == handle);
     ucs_free((void *)rkey);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_gdr_copy_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                          uct_rkey_t rkey2,
+                          const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_gdr_copy_key_t));
     return UCS_OK;
 }
 
@@ -454,7 +463,7 @@ uct_component_t uct_gdr_copy_component = {
     .rkey_unpack        = uct_gdr_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_gdr_copy_rkey_release,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_gdr_copy_rkey_compare,
     .name               = "gdr_copy",
     .md_config          = {
         .name           = "GDR-copy memory domain",

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -92,7 +92,7 @@ static ucs_status_t uct_rocm_copy_rkey_unpack(uct_component_t *component,
     uct_rocm_copy_key_t *packed = (uct_rocm_copy_key_t *)rkey_buffer;
     uct_rocm_copy_key_t *key;
 
-    key = ucs_malloc(sizeof(uct_rocm_copy_key_t), "uct_rocm_copy_key_t");
+    key = ucs_calloc(1, sizeof(uct_rocm_copy_key_t), "uct_rocm_copy_key_t");
     if (NULL == key) {
         ucs_error("failed to allocate memory for uct_rocm_copy_key_t");
         return UCS_ERR_NO_MEMORY;
@@ -112,6 +112,15 @@ static ucs_status_t uct_rocm_copy_rkey_release(uct_component_t *component,
 {
     ucs_assert(NULL == handle);
     ucs_free((void *)rkey);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_rocm_copy_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                           uct_rkey_t rkey2,
+                           const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_rocm_copy_key_t));
     return UCS_OK;
 }
 
@@ -469,7 +478,7 @@ uct_component_t uct_rocm_copy_component = {
     .rkey_unpack        = uct_rocm_copy_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_rocm_copy_rkey_release,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_rocm_copy_rkey_compare,
     .name               = "rocm_cpy",
     .md_config          = {
         .name           = "ROCm-copy memory domain",

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -175,6 +175,15 @@ static ucs_status_t uct_rocm_ipc_rkey_release(uct_component_t *component,
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_rocm_ipc_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                          uct_rkey_t rkey2,
+                          const uct_rkey_compare_params_t *params, int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(uct_rocm_ipc_key_t));
+    return UCS_OK;
+}
+
 uct_component_t uct_rocm_ipc_component = {
     .query_md_resources = uct_rocm_base_query_md_resources,
     .md_open            = uct_rocm_ipc_md_open,
@@ -182,7 +191,7 @@ uct_component_t uct_rocm_ipc_component = {
     .rkey_unpack        = uct_rocm_ipc_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_rocm_ipc_rkey_release,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_rocm_ipc_rkey_compare,
     .name               = "rocm_ipc",
     .md_config          = {
         .name           = "ROCm-IPC memory domain",

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -27,8 +27,9 @@ static ucs_config_field_t uct_tcp_md_config_table[] = {
 static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
     /* Dummy memory registration provided. No real memory handling exists */
-    attr->flags                  = UCT_MD_FLAG_REG |
-                                   UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
+    attr->flags                  = UCT_MD_FLAG_REG       |
+                                   UCT_MD_FLAG_NEED_RKEY | /* TODO ignore rkey in rma/amo ops */
+                                   UCT_MD_FLAG_SYMMETRIC_RKEY;
     attr->max_alloc              = 0;
     attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -121,7 +122,7 @@ uct_component_t uct_tcp_component = {
     .rkey_unpack        = uct_tcp_md_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = ucs_empty_function_return_success,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_base_rkey_compare_as_same,
     .name               = UCT_TCP_NAME,
     .md_config          = {
         .name           = "TCP memory domain",

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -155,7 +155,7 @@ static ucs_status_t uct_ugni_rkey_unpack(uct_component_t *component,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    mem_hndl = ucs_malloc(sizeof(gni_mem_handle_t), "gni_mem_handle_t");
+    mem_hndl = ucs_calloc(1, sizeof(gni_mem_handle_t), "gni_mem_handle_t");
     if (NULL == mem_hndl) {
         ucs_error("Failed to allocate memory for gni_mem_handle_t");
         return UCS_ERR_NO_MEMORY;
@@ -165,6 +165,15 @@ static ucs_status_t uct_ugni_rkey_unpack(uct_component_t *component,
     mem_hndl->qword2 = ptr[2];
     *rkey_p = (uintptr_t)mem_hndl;
     *handle_p = NULL;
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ugni_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
+                      uct_rkey_t rkey2, const uct_rkey_compare_params_t *params,
+                      int *result)
+{
+    *result = memcmp((void*)rkey1, (void*)rkey2, sizeof(gni_mem_handle_t));
     return UCS_OK;
 }
 
@@ -233,7 +242,7 @@ uct_component_t uct_ugni_component = {
     .rkey_unpack        = uct_ugni_rkey_unpack,
     .rkey_ptr           = ucs_empty_function_return_unsupported,
     .rkey_release       = uct_ugni_rkey_release,
-    .rkey_compare       = ucs_empty_function_return_unsupported,
+    .rkey_compare       = uct_ugni_rkey_compare,
     .name               = UCT_UGNI_MD_NAME,
     .md_config          = {
         .name           = "UGNI memory domain",


### PR DESCRIPTION
## What
Add rkey_compare implementation for non-shared memory and non-ib transports.

## Why ?
All transports must implement a valid comparison function. UCT tests coming when all transports will implement rkey_compare.

## How ?
- Using memcmp with clearing any padding byte seems more future proof.
- Add MD flag attribute to set expectations. This can be used, for instance, by testing infra to set proper expectations when comparing keys unpacked twice, for instance.
