### PR TITLE
UCT/CUDA/CUDA_COPY: Set device context within mem alloc.

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -205,13 +205,47 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_dereg,
     return UCS_OK;
 }
 
-static ucs_status_t uct_cuda_copy_mem_alloc(uct_md_h md, size_t *length_p,
-                                            void **address_p,
-                                            ucs_memory_type_t mem_type,
-                                            unsigned flags,
-                                            const char *alloc_name,
-                                            uct_mem_h *memh_p)
+static ucs_status_t uct_cuda_copy_md_set_ctx(uct_cuda_copy_md_t *md)
 {
+    ucs_status_t status;
+    CUdevice dev;
+    CUcontext ctx;
+
+    ucs_assertv(!md->cuda_ctx_retained,
+                "md %p: cuda primary context has already been retained", md);
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&dev, 0));
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDevicePrimaryCtxRetain(&ctx, dev));
+    if (status != UCS_OK) {
+        goto err;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxSetCurrent(ctx));
+    if (status != UCS_OK) {
+        goto err_release;
+    }
+
+    md->cuda_ctx_retained = 1;
+    ucs_debug("md %p: cuda primary context retained on gpu %d", md, dev);
+
+    return UCS_OK;
+
+err_release:
+    UCT_CUDADRV_FUNC_LOG_ERR(cuDevicePrimaryCtxRelease(dev));
+err:
+    return status;
+}
+
+static ucs_status_t
+uct_cuda_copy_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
+                        ucs_memory_type_t mem_type, unsigned flags,
+                        const char *alloc_name, uct_mem_h *memh_p)
+{
+    uct_cuda_copy_md_t *md = ucs_derived_of(tl_md, uct_cuda_copy_md_t);
     ucs_status_t status;
 
     if ((mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED) &&
@@ -220,8 +254,10 @@ static ucs_status_t uct_cuda_copy_mem_alloc(uct_md_h md, size_t *length_p,
     }
 
     if (!uct_cuda_base_is_context_active()) {
-        ucs_error("attempt to allocate cuda memory without active context");
-        return UCS_ERR_NO_DEVICE;
+        status = uct_cuda_copy_md_set_ctx(md);
+        if (status != UCS_OK) {
+            return UCS_ERR_NO_DEVICE;
+        }
     }
 
     if (mem_type == UCS_MEMORY_TYPE_CUDA) {
@@ -250,6 +286,13 @@ static ucs_status_t uct_cuda_copy_mem_free(uct_md_h md, uct_mem_h memh)
 
 static void uct_cuda_copy_md_close(uct_md_h uct_md) {
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
+    CUdevice dev;
+
+    if (md->cuda_ctx_retained &&
+        (UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&dev, 0)) == UCS_OK) &&
+        (UCT_CUDADRV_FUNC_LOG_ERR(cuDevicePrimaryCtxRelease(dev)) == UCS_OK)) {
+        ucs_debug("md %p: cuda primary context released on gpu %d", md, dev);
+    }
 
     ucs_free(md);
 }
@@ -585,6 +628,7 @@ uct_cuda_copy_md_open(uct_component_t *component, const char *md_name,
     md->config.max_reg_ratio    = config->max_reg_ratio;
     md->config.pref_loc         = config->pref_loc;
     md->config.dmabuf_supported = 0;
+    md->cuda_ctx_retained       = 0;
 
     dmabuf_supported = uct_cuda_copy_md_is_dmabuf_supported();
     if ((config->enable_dmabuf == UCS_YES) && !dmabuf_supported) {

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -24,6 +24,7 @@ typedef enum {
  */
 typedef struct uct_cuda_copy_md {
     struct uct_md               super;           /* Domain info */
+    int                         cuda_ctx_retained;
     struct {
         ucs_on_off_auto_value_t alloc_whole_reg; /* force return of allocation
                                                     range even for small bar


### PR DESCRIPTION
## What
Set primary device context as current context for the calling thread, if there is no active context during memory allocation.
