### PR TITLE
UCT/ROCM: include sys/arch/cpu.h

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -16,6 +16,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>
+#include <ucs/arch/cpu.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucm/api/ucm.h>
 #include <ucs/type/class.h>


### PR DESCRIPTION
## What
include sys/arch/cpu.h in rocm_copy_md.c 

## Why ?
A recent change in ucx left UCS_SYS_CACHE_LINE_SIZE not being set correctly in rocm_copy_md.c, which leads to an error at runtime (not at compile time). Including this header fixes the issue.