### PR TITLE
UCT/CUDA/BASE: Removed extra parentheses.

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -86,7 +86,7 @@ const char *uct_cuda_base_cu_get_error_string(CUresult result);
             if (CUDA_ERROR_NOT_READY == _result) { \
                 _status = UCS_INPROGRESS; \
             } else if (CUDA_SUCCESS != _result) { \
-                ucs_log((_log_level), "%s() failed: %s", \
+                ucs_log((_log_level), "%s failed: %s", \
                         UCS_PP_MAKE_STRING(_func), \
                         uct_cuda_base_cu_get_error_string(_result)); \
                 _status = UCS_ERR_IO_ERROR; \


### PR DESCRIPTION
## What
Removed extra parentheses.

## Why ?
Before:
```
cuda_copy_md.c:265  UCX  ERROR   cuMemAlloc_v2((CUdeviceptr*)address_p, *length_p)() failed: invalid device context
```
After:
```
cuda_copy_md.c:265  UCX  ERROR   cuMemAlloc_v2((CUdeviceptr*)address_p, *length_p) failed: invalid device context
```
