### PR TITLE
UCT/IB: Add check for ATOMIC_GLOB device attribute

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1360,8 +1360,14 @@ static ucs_status_t uct_ib_verbs_md_open(struct ibv_device *ibv_device,
         goto err_md_free;
     }
 
-    if (IBV_DEVICE_ATOMIC_HCA(dev)) {
+    if (IBV_DEVICE_ATOMIC_HCA(dev) ||
+        IBV_DEVICE_ATOMIC_GLOB(dev)) {
         dev->atomic_arg_sizes = sizeof(uint64_t);
+    }
+
+    if (IBV_DEVICE_ATOMIC_GLOB(dev)) {
+        dev->pci_fadd_arg_sizes = sizeof(uint64_t);
+        dev->pci_cswap_arg_sizes = sizeof(uint64_t);
     }
 
     status  = uct_ib_md_parse_device_config(md, md_config);

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -85,6 +85,7 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
  * Atomics support
  */
 #define IBV_DEVICE_ATOMIC_HCA(dev)              (IBV_DEV_ATTR(dev, atomic_cap) == IBV_ATOMIC_HCA)
+#define IBV_DEVICE_ATOMIC_GLOB(dev)             (IBV_DEV_ATTR(dev, atomic_cap) == IBV_ATOMIC_GLOB)
 
 
 /* Ethernet link layer */


### PR DESCRIPTION
## What
To add check for ATOMIC_GLOB device attribute 

## Why ?
Devices with GLOB atomic support can make use of UCX framework