### PR TITLE
UCT/IB: Check dev_attr.odp_caps for ODP support

### DIFF
--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -87,6 +87,16 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #define IBV_DEVICE_ATOMIC_HCA(dev)              (IBV_DEV_ATTR(dev, atomic_cap) == IBV_ATOMIC_HCA)
 
 
+/*
+ * On-demand paging support
+ */
+#if HAVE_STRUCT_IBV_DEVICE_ATTR_EX_ODP_CAPS
+#  define IBV_DEVICE_HAS_ODP(_dev)                  ((_dev)->dev_attr.odp_caps.general_caps & IBV_ODP_SUPPORT)
+#else
+#  define IBV_DEVICE_HAS_ODP(_dev)                  0
+#endif
+
+
 /* Ethernet link layer */
 #if HAVE_DECL_IBV_LINK_LAYER_ETHERNET
 #  define IBV_PORT_IS_LINK_LAYER_ETHERNET(_attr)    ((_attr)->link_layer == IBV_LINK_LAYER_ETHERNET)

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -219,7 +219,8 @@ AS_IF([test "x$with_ib" = "xyes"],
                             [have upstream ibv_query_device_ex])])],
                             [], [[#include <infiniband/verbs.h>]])
 
-       AC_CHECK_MEMBERS([struct ibv_device_attr_ex.pci_atomic_caps],
+       AC_CHECK_MEMBERS([struct ibv_device_attr_ex.pci_atomic_caps,
+                         struct ibv_device_attr_ex.odp_caps],
                         [], [], [[#include <infiniband/verbs.h>]])
 
        AC_CHECK_DECLS([IBV_ACCESS_RELAXED_ORDERING,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -810,6 +810,11 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
         goto no_odp;
     }
 
+    if (!IBV_DEVICE_HAS_ODP(&md->super.dev)) {
+        reason = "device does not support ODP";
+        goto no_odp;
+    }
+
     if (!UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, pg)) {
         reason = "cap.pg is not supported";
         goto no_odp;


### PR DESCRIPTION
## Why
Fix CI failures on BlueField nodes with new MLNX_OFED

```
2023-09-12T05:05:00.5641027Z [----------] 2 tests from ib/test_md_non_blocking
2023-09-12T05:05:00.5643035Z [ RUN      ] ib/test_md_non_blocking.reg_advise/0 <mlx5_0>
2023-09-12T05:05:00.5700802Z [1694495100.569296] [swx-rain04-bf1:3038825:4]           ib_md.c:292  UCX  ERROR ibv_reg_mr(address=0xaaaaf4b06390, length=1024, access=0x4f) failed: Operation not supported
2023-09-12T05:05:00.5704854Z /scrap/azure/agent-01/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/test_md.cc:648: Failure
2023-09-12T05:05:00.5706559Z Error: Input/output error
2023-09-12T05:05:00.5720382Z /scrap/azure/agent-01/AZP_WORKSPACE/1/s/contrib/../test/gtest/common/test.cc:366: Failure
2023-09-12T05:05:00.5723714Z Failed
2023-09-12T05:05:00.5725726Z Got 1 errors and 0 warnings during the test
2023-09-12T05:05:00.5729670Z [     INFO ] < /scrap/azure/agent-01/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/base/ib_md.c:292 ibv_reg_mr(address=0xaaaaf4b06390, length=1024, access=0x4f) failed: Operation not supported >
2023-09-12T05:05:00.5732569Z [  FAILED  ] ib/test_md_non_blocking.reg_advise/0, where GetParam() = mlx5_0 (9 ms)
2023-09-12T05:05:00.5734749Z [ RUN      ] ib/test_md_non_blocking.reg/0 <mlx5_0>
2023-09-12T05:05:00.5789338Z [1694495100.578295] [swx-rain04-bf1:3038825:4]           ib_md.c:292  UCX  ERROR ibv_reg_mr(address=0xaaaaf28249a0, length=1024, access=0x4f) failed: Operation not supported
2023-09-12T05:05:00.5792001Z /scrap/azure/agent-01/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/test_md.cc:648: Failure
2023-09-12T05:05:00.5794389Z Error: Input/output error
2023-09-12T05:05:00.5810802Z /scrap/azure/agent-01/AZP_WORKSPACE/1/s/contrib/../test/gtest/common/test.cc:366: Failure
2023-09-12T05:05:00.5812488Z Failed
2023-09-12T05:05:00.5813657Z Got 1 errors and 0 warnings during the test
2023-09-12T05:05:00.5816080Z [     INFO ] < /scrap/azure/agent-01/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/base/ib_md.c:292 ibv_reg_mr(address=0xaaaaf28249a0, length=1024, access=0x4f) failed: Operation not supported >
2023-09-12T05:05:00.5817866Z [  FAILED  ] ib/test_md_non_blocking.reg/0, where GetParam() = mlx5_0 (9 ms)
```