### PR TITLE
UCT/ROCM: Add parameter to control max elements in sigpool

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -196,6 +196,12 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
     }
 
     rocm_copy_signal = ucs_mpool_get(&iface->signal_pool);
+    if (rocm_copy_signal == NULL) {
+        ucs_error("increase the maximum number of signal pool elements with "
+                  "UCX_ROCM_COPY_SIGPOOL_MAX_ELEMS");
+        return UCS_ERR_IO_ERROR;
+    }
+
     hsa_signal_store_screlease(rocm_copy_signal->signal, 1);
 
     status = UCS_PROFILE_CALL_ALWAYS(hsa_amd_memory_async_copy, dst_addr, agent,

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -42,6 +42,11 @@ static ucs_config_field_t uct_rocm_copy_iface_config_table[] = {
      ucs_offsetof(uct_rocm_copy_iface_config_t, latency),
      UCS_CONFIG_TYPE_TIME},
 
+    {"SIGPOOL_MAX_ELEMS", "1024",
+     "Maximum number of elements in signal pool",
+     ucs_offsetof(uct_rocm_copy_iface_config_t, sigpool_max_elems),
+     UCS_CONFIG_TYPE_UINT},
+
     {NULL}
 };
 
@@ -269,7 +274,7 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
     ucs_mpool_params_reset(&mp_params);
     mp_params.elem_size       = sizeof(uct_rocm_base_signal_desc_t);
     mp_params.elems_per_chunk = 128;
-    mp_params.max_elems       = 1024;
+    mp_params.max_elems       = config->sigpool_max_elems;
     mp_params.ops             = &uct_rocm_base_signal_desc_mpool_ops;
     mp_params.name            = "ROCM_COPY signal objects";
     status                    = ucs_mpool_init(&mp_params, &self->signal_pool);

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -35,6 +35,7 @@ typedef struct uct_rocm_copy_iface_config {
     size_t              h2d_thresh;
     int                 enable_async_zcopy;
     double              latency;
+    unsigned            sigpool_max_elems;
 } uct_rocm_copy_iface_config_t;
 
 #endif


### PR DESCRIPTION
## What
Adds parameter (UCX_ROCM_COPY_SIGPOOL_MAX_ELEMS) to control the maximum number of elements in hsa signal pool (ucs_mpool_params). Changes from 1024 (default) to parameter.

## Why ?
Running the osu_bw benchmark beyond the standard 4MB message length for D-H communication leads to an error due to the uct/rocm_copy component running out of pre-allocated hsa-signals. Increasing the number of pre-allocated signals fixes the problem. This PR introduces a parameter for controlling the number of elements in the signal pool.

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

@edgargabriel 