### PR TITLE
UCP/RNDV: Do not use recv ppln with generic send buf - v1.15.x

### DIFF
--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -122,15 +122,15 @@ ucp_rndv_is_put_pipeline_needed(uintptr_t remote_address, size_t length,
                                 const ucp_ep_rndv_zcopy_config_t *put_zcopy,
                                 int is_get_zcopy_failed)
 {
-    if ((remote_address != 0) &&
+    if ((remote_address == 0) ||
         (ucp_rkey_packed_mem_type(rkey_buf) == UCS_MEMORY_TYPE_HOST)) {
         return 0;
     }
 
     /* Fallback to PUT pipeline if: */
     return /* Remote mem type is non-HOST memory OR can't do GET ZCOPY */
-           ((remote_address == 0) || (get_zcopy->max == 0) ||
-            (length < get_zcopy->min) || is_get_zcopy_failed) &&
+           ((get_zcopy->max == 0) || (length < get_zcopy->min) ||
+            is_get_zcopy_failed) &&
            /* AND can do PUT assuming that configurations are symmetric */
            ((put_zcopy->max != 0) && (length >= put_zcopy->min));
 }


### PR DESCRIPTION
## What

Do not use recv ppln protocols if send user buffer is non-contig

fixes #9373 