### PR TITLE
BINDINGS/GO: Change perftest server completions counting logic

### DIFF
--- a/bindings/go/src/examples/perftest/perftest.go
+++ b/bindings/go/src/examples/perftest/perftest.go
@@ -258,21 +258,18 @@ func serverStart() error {
 		perfTest.perThreadWorkers[t+1].SetAmRecvHandler(t, UCP_AM_FLAG_WHOLE_MSG, serverAmRecvHandler)
 	}
 
-	for i := uint(0); i < perfTestParams.numIterations; i += 1 {
-		perfTest.numCompletedRequests = 0
-
-		perfTest.wg.Add(int(perfTestParams.numThreads + 1))
-		for t := uint(0); t < perfTestParams.numThreads+1; t += 1 {
-			go func(tid uint) {
-				for perfTest.numCompletedRequests < uint32(perfTestParams.numThreads) {
-					progressWorker(int(tid))
-				}
-				perfTest.wg.Done()
-			}(t)
-		}
-
-		perfTest.wg.Wait()
+	totalNumRequests := uint32((perfTestParams.warmUpIter + perfTestParams.numIterations) * perfTestParams.numThreads)
+	perfTest.wg.Add(int(perfTestParams.numThreads + 1))
+	for t := uint(0); t < perfTestParams.numThreads+1; t += 1 {
+		go func(tid uint) {
+			for atomic.LoadUint32(&perfTest.numCompletedRequests) < totalNumRequests {
+				progressWorker(int(tid))
+			}
+			perfTest.wg.Done()
+		}(t)
 	}
+	perfTest.wg.Wait()
+
 	close()
 	return nil
 }


### PR DESCRIPTION
## What
Changes the counting of completed requests inside the go perftest logic to avoid hanging on the server side.

## Why ?
`progressWorker` call the `ucp_worker_progress` until it returns `0`. So during one `progressWorker` call we can increase `perfTest.numCompletedRequests` several times, but after end of the `WaitGroup.Wait()` we increase `i` only by `1`. So we can miss some completed requests if they were handled during one `progressWorker` call.

Also, the server side didn't take warmup iterations into attention.

## How ?
Increase `i` by number of completed requests
