### PR TITLE
BINDINGS/GO: Improve perftest error detection

### DIFF
--- a/bindings/go/src/examples/perftest/perftest.go
+++ b/bindings/go/src/examples/perftest/perftest.go
@@ -136,7 +136,8 @@ func initWorker(i int) {
 
 func epErrorHandling(ep *UcpEp, status UcsStatus) {
 	if status != UCS_ERR_CONNECTION_RESET {
-		fmt.Printf("Endpoint error: %v \n", status.String())
+		errorString := fmt.Sprintf("Endpoint error: %v", status.String())
+		panic(errorString)
 	}
 }
 
@@ -287,6 +288,10 @@ func clientThreadDoIter(i int, t uint) {
 
 	for request.GetStatus() == UCS_INPROGRESS {
 		progressWorker(int(t))
+	}
+	if request.GetStatus() != UCS_OK {
+		errorString := fmt.Sprintf("Request completion error: %v", request.GetStatus().String())
+		panic(errorString)
 	}
 	perfTest.completionTime[t] = time.Since(start)
 	request.Close()


### PR DESCRIPTION
## What
Add panic failures in case of errors.

## Why ?
Currently, Golang perftest client can end successfully even if endpoint error happened and all the requests returns error status.
