### PR TITLE
UCT/ROCM: don't check buffer size during key-packing

### DIFF
--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -67,7 +67,7 @@ static hsa_status_t uct_rocm_ipc_pack_key(void *address, size_t length,
 
     status = uct_rocm_base_get_ptr_info(address, length, &base_ptr, &size,
                                         &mem_type, &agent, NULL);
-    if ((status != HSA_STATUS_SUCCESS) || (size < length) ||
+    if ((status != HSA_STATUS_SUCCESS) ||
         (mem_type == HSA_EXT_POINTER_TYPE_UNKNOWN)) {
         ucs_error("failed to get base ptr for %p/%lx, ROCm returned %p/%lx",
                    address, length, base_ptr, size);


### PR DESCRIPTION
## What
The ROCr runtime returns  in the hsa ptr_info function as the buffer size the exact length that was allocated. The length provided as an input to the rocm_ipc_pack_key routine might however have been adjusted by up to 64 bytes (if my math is correct) when using the rcache. So comparing the input buffer lengths vs. the size returned by the hsa_ptr_info function can be inaccurate. In addition, I do not see what the comparison of the 'expected' size vs. 'real' size gives us from the functionality perspective in this routine.

## Why ?
The issue was exposed while running the UCC testsuite with UCX master (with v2 protocols).  Not entirely sure why it was not a problem with previous ucx releases.
