### PR TITLE
UCT/IB: Use non-zero inline data size for UD mlx5

### DIFF
--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -755,11 +755,10 @@ static void uct_ud_mlx5_iface_event_cq(uct_ib_iface_t *ib_iface,
 
 static void uct_ud_mlx5_qp_update_caps(struct ibv_qp_cap *qp_caps)
 {
-    /* Set minimal possible values for max_send_sge, max_recv_sge and
-     * max_inline_data to minimize WQE length */
+    /* Set minimal possible values for max_send_sge, max_recv_sge */
     qp_caps->max_recv_sge    = 1;
     qp_caps->max_send_sge    = 2; /* UD header + payload */
-    qp_caps->max_inline_data = 0;
+    qp_caps->max_inline_data = uct_ud_mlx5_max_inline();
 }
 
 int uct_ud_mlx5_ep_is_connected(const uct_ep_h tl_ep,


### PR DESCRIPTION
## What
Use non-zero inline data size parameter for UD mlx5.

## Why ?
Suspecting corruption related to inline data size.

Issue observed when running on valgrind in CI but is also visible on standard run with smaller lengths. At some point test is stuck with `uct_ud_iface_can_tx(iface)` always returning false although all tx'd have been rx'd.

## How ?
Issue not visible with `ud_verbs`.

### Repro
Patch test `main.cc` like ` if (1 || RUNNING_ON_VALGRIND) {` to force smaller length, use recent FW and run (was built with `--enable-valgrind`):
- ` ./test/gtest/gtest --gtest_filter=ud_mlx5/uct_p2p_mix_test.mix_10000/2 --gtest_repeat=100000`

### Typical CI failure
```
[----------] 1 test from ud_mlx5/uct_p2p_mix_test
[ RUN      ] ud_mlx5/uct_p2p_mix_test.mix_10000/2 <ud_mlx5/mlx5_bond_1:1>
/scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../test/gtest/common/test_helpers.cc:55: Failure
Failed
Connection timed out - abort testing
[swx-rain03:45177:0:45177] Caught signal 6 (Aborted: tkill(2) or tgkill(2))
...
==== backtrace (tid:  45177) ====
 0 0x0000000000700f75 uct_p2p_mix_test::am_short_iov()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/test_p2p_mix.cc:99
 1 0x0000000000701253 uct_p2p_mix_test::random_op()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/test_p2p_mix.cc:147
 2 0x0000000000706502 uct_p2p_mix_test::run()  /scrap/azure/agent-10/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/test_p2p_mix.cc:176
```