### PR TITLE
UCT/API: Add reg_alignment

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -472,6 +472,10 @@ static void print_md_info(uct_component_h component,
             printf("#           memory invalidation is supported\n");
         }
 
+        if (md_attr.reg_alignment != 0) {
+            printf("#            alignment: %zx\n", md_attr.reg_alignment);
+        }
+
         ucs_memory_type_for_each(mem_type) {
             if (!(UCS_BIT(mem_type) &
                   (md_attr.reg_mem_types | md_attr.alloc_mem_types))) {

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -784,7 +784,10 @@ typedef enum uct_md_attr_field {
     UCT_MD_ATTR_FIELD_EXPORTED_MKEY_PACKED_SIZE = UCS_BIT(14),
 
     /** Unique global identifier of the memory domain. */
-    UCT_MD_ATTR_FIELD_GLOBAL_ID                 = UCS_BIT(15)
+    UCT_MD_ATTR_FIELD_GLOBAL_ID                 = UCS_BIT(15),
+
+    /** Indicate registration alignment. */
+    UCT_MD_ATTR_FIELD_REG_ALIGNMENT             = UCS_BIT(16)
 } uct_md_attr_field_t;
 
 
@@ -890,6 +893,11 @@ typedef struct {
      * Memory Domains belong to the same device.
      */
     char              global_id[UCT_MD_GLOBAL_ID_MAX];
+
+    /**
+     * Registration alignment.
+     */
+    size_t            reg_alignment;
 } uct_md_attr_v2_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -429,6 +429,8 @@ uct_md_attr_v2_copy(uct_md_attr_v2_t *dst, const uct_md_attr_v2_t *src)
                               UCT_MD_ATTR_FIELD_EXPORTED_MKEY_PACKED_SIZE);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, global_id,
                               UCT_MD_ATTR_FIELD_GLOBAL_ID);
+    UCT_MD_ATTR_V2_FIELD_COPY(dst, src, reg_alignment,
+                              UCT_MD_ATTR_FIELD_REG_ALIGNMENT);
 }
 
 static ucs_status_t uct_md_attr_v2_init(uct_md_h md, uct_md_attr_v2_t *md_attr)


### PR DESCRIPTION
## Why
In order to remove the registration cache from gdrcopy transport, need UCP (rcache) to respect its memory registration alignment requirements.