### PR TITLE
UCS/TOPO: Calculate distance for common NUMA node separately

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -55,6 +55,7 @@ nobase_dist_libucs_la_HEADERS = \
 	memory/rcache.h \
 	memory/memory_type.h \
 	memory/memtype_cache.h \
+	memory/numa.h \
 	profile/profile_defs.h \
 	profile/profile_off.h \
 	profile/profile_on.h \

--- a/src/ucs/memory/numa.c
+++ b/src/ucs/memory/numa.c
@@ -21,8 +21,7 @@
 #include <dirent.h>
 
 #define UCS_NUMA_MIN_DISTANCE       10
-#define UCS_NUMA_NODE_DEFAULT       0
-#define UCS_NUMA_NODE_MAX           UINT16_MAX
+#define UCS_NUMA_NODE_MAX           INT16_MAX
 #define UCS_NUMA_CORE_DIR_PATH      UCS_SYS_FS_CPUS_PATH "/cpu%d"
 #define UCS_NUMA_NODES_DIR_PATH     UCS_SYS_FS_SYSTEM_PATH "/node"
 #define UCS_NUMA_NODE_DISTANCE_PATH UCS_NUMA_NODES_DIR_PATH "/node%d/distance"
@@ -151,7 +150,10 @@ ucs_numa_node_t ucs_numa_node_of_device(const char *dev_path)
 
     if ((status != UCS_OK) || (parsed_node < 0) ||
         (parsed_node >= UCS_NUMA_NODE_MAX)) {
-        return UCS_NUMA_NODE_DEFAULT;
+        ucs_debug("failed to discover numa node for device: %s, status %s, \
+                  parsed_node %ld", dev_path, ucs_status_string(status),
+                  parsed_node);
+        return UCS_NUMA_NODE_UNDEFINED;
     }
 
     return parsed_node;

--- a/src/ucs/memory/numa.h
+++ b/src/ucs/memory/numa.h
@@ -7,17 +7,15 @@
 #ifndef UCS_NUMA_H_
 #define UCS_NUMA_H_
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
 #include <stdint.h>
 
+#define UCS_NUMA_NODE_DEFAULT    0
+#define UCS_NUMA_NODE_UNDEFINED -1
 
 typedef int ucs_numa_distance_t;
 
 
-typedef uint16_t ucs_numa_node_t;
+typedef int16_t ucs_numa_node_t;
 
 
 extern const char *ucs_numa_policy_names[];

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -9,6 +9,7 @@
 
 #include <ucs/type/status.h>
 #include <ucs/datastruct/list.h>
+#include <ucs/memory/numa.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -224,6 +225,14 @@ ucs_topo_resolve_sysfs_path(const char *dev_path, char *path_buffer);
  */
 const char *ucs_topo_sys_device_get_name(ucs_sys_device_t sys_dev);
 
+/**
+ * Get the closest NUMA node for a given system device.
+ *
+ * @param [in] sys_dev input system device.
+ *
+ * @return The number of NUMA node closest to given device.
+ */
+ucs_numa_node_t ucs_topo_sys_device_get_numa_node(ucs_sys_device_t sys_dev);
 
 /**
  * Get the number of registered system devices.


### PR DESCRIPTION
## What
Detect the case when two devices have no common PCI root but belong to one NUMA.

## Why ?
BW in cross-NUMA and intra-NUMA cases differs significantly.

## How ?
Check `numa_node` file content inside PCI device path.
