### PR TITLE
GTEST/UCT: Skip invalidate and rkey_compare tests for rocm_ipc

### DIFF
--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -75,6 +75,8 @@ protected:
 
     static void dereg_cb(uct_completion_t *comp);
 
+    bool is_gpu_ipc() const;
+
     const unsigned md_flags_remote_rma = UCT_MD_MEM_ACCESS_REMOTE_PUT |
                                          UCT_MD_MEM_ACCESS_REMOTE_GET;
 


### PR DESCRIPTION
## What
Skip 2 tests (`rocm_ipc/test_md.invalidate` and `rocm_ipc/test_md.rkey_compare`) in gtest for rocm_ipc as rocm_ipc only works with device memory. These tests pass with rocm_cpy.

@edgargabriel