### PR TITLE
UCP/PROTOV2: Prefer native proto implementation

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -455,6 +455,13 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, reg_nb_mem_types),
    UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
 
+  {"PREFER_OFFLOAD", "y",
+   "Prefer transports capable of remote memory access for RMA and AMO operations.\n"
+   "The value is interpreted as follows:\n"
+   " 'y' : Prefer transports with native RMA/AMO support (if available)\n"
+   " 'n' : Select RMA/AMO lanes according to performance charasteristics",
+   ucs_offsetof(ucp_context_config_t, prefer_offload), UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -164,6 +164,8 @@ typedef struct ucp_context_config {
     char                                   *proto_info_dir;
     /** Memory types that perform non-blocking registration by default */
     uint64_t                               reg_nb_mem_types;
+    /** Prefer native RMA transports for RMA/AMO protocols */
+    int                                    prefer_offload;
 } ucp_context_config_t;
 
 

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -408,7 +408,7 @@ ucp_proto_amo_sw_init(const ucp_proto_init_params_t *init_params, unsigned flags
         .super.super         = *init_params,
         .super.latency       = 1.2e-6,
         .super.overhead      = 40e-9,
-        .super.cfg_thresh    = 0,
+        .super.cfg_thresh    = ucp_proto_sw_rma_cfg_thresh(worker->context, 0),
         .super.cfg_priority  = 20,
         .super.min_length    = sizeof(uint32_t),
         .super.max_length    = sizeof(uint64_t),

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -79,7 +79,8 @@ ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.latency       = 0,
         .super.overhead      = 40e-9,
-        .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_thresh    = ucp_proto_sw_rma_cfg_thresh(
+                                   context, context->config.ext.bcopy_thresh),
         .super.cfg_priority  = 20,
         .super.min_length    = 0,
         .super.max_length    = SIZE_MAX,

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -81,7 +81,8 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.latency       = 0,
         .super.overhead      = 40e-9,
-        .super.cfg_thresh    = context->config.ext.bcopy_thresh,
+        .super.cfg_thresh    = ucp_proto_sw_rma_cfg_thresh(
+                                   context, context->config.ext.bcopy_thresh),
         .super.cfg_priority  = 20,
         .super.min_length    = 0,
         .super.max_length    = SIZE_MAX,

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -136,4 +136,12 @@ ucp_amo_request_reply_mem_type(ucp_request_t *req)
     return req->send.proto_config->select_param.op.reply.mem_type;
 }
 
+static UCS_F_ALWAYS_INLINE size_t
+ucp_proto_sw_rma_cfg_thresh(ucp_context_h context, size_t default_value)
+{
+    return (context->config.ext.prefer_offload == UCS_YES) ?
+           UCS_MEMUNITS_INF: /* used only as last resort */
+           default_value;
+}
+
 #endif


### PR DESCRIPTION
Prefer native RMA and AMO protocols over emulations to avoid selections like below:
```
 7543 [1696516991.258413] [jazz20:103988:0]   +----------------------------+-------------------------------------------------------------+
 7544 [1696516991.258425] [jazz20:103988:0]   | 0x2d0aca0 intra-node cfg#2 | remote memory write by ucp_put* from host memory to host    |
 7545 [1696516991.258428] [jazz20:103988:0]   +----------------------------+------------------------------------------+------------------+
 7546 [1696516991.258430] [jazz20:103988:0]   |                     0..220 | short                                    | rc_mlx5/mlx5_0:1 |
 7547 [1696516991.258433] [jazz20:103988:0]   |                   221..349 | software emulation                       | rc_mlx5/mlx5_0:1 |
 7548 [1696516991.258435] [jazz20:103988:0]   |                   350..inf | zero-copy                                | knem/memory      |
 7549 [1696516991.258438] [jazz20:103988:0]   +----------------------------+------------------------------------------+------------------+

```


