### PR TITLE
ARCH/X86: Introduce non temporal buffer transfer

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1051,6 +1051,18 @@ run_release_mode_tests() {
 	test_ucm_hooks
 }
 
+#
+# Run nt_buffer_transfer tests
+#
+run_nt_buffer_transfer_tests() {
+    if lscpu | grep -q 'AuthenticAMD'
+    then
+	    build release --enable-gtest --enable-optimizations
+	    echo "==== Running nt_buffer_transfer tests ===="
+	    ./test/gtest/gtest --gtest_filter="test_arch.nt_buffer_transfer_*"
+    fi
+}
+
 set_ucx_common_test_env() {
 	export UCX_HANDLE_ERRORS=bt
 	export UCX_ERROR_SIGNALS=SIGILL,SIGSEGV,SIGBUS,SIGFPE,SIGPIPE,SIGABRT
@@ -1102,6 +1114,9 @@ run_tests() {
 
 	# release mode tests
 	do_distributed_task 0 4 run_release_mode_tests
+
+	# nt_buffer_transfer tests
+	do_distributed_task 0 4 run_nt_buffer_transfer_tests
 }
 
 run_test_proto_disable() {

--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -46,7 +47,7 @@ static double measure_memcpy_bandwidth(size_t size)
     iter = 0;
     start_time = ucs_get_time();
     do {
-        ucs_memcpy_relaxed(dst, src, size);
+        ucs_memcpy_relaxed(dst, src, size, UCS_ARCH_MEMCPY_NT_NONE, size);
         end_time = ucs_get_time();
         ++iter;
     } while (end_time < start_time + ucs_time_from_sec(0.5));

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -1350,7 +1351,7 @@ ucp_am_copy_data_fragment(ucp_recv_desc_t *first_rdesc, void *data,
 {
     UCS_PROFILE_NAMED_CALL("am_memcpy_recv", ucs_memcpy_relaxed,
                            UCS_PTR_BYTE_OFFSET(first_rdesc + 1, offset),
-                           data, length);
+                           data, length, UCS_ARCH_MEMCPY_NT_SOURCE, length);
     first_rdesc->am_first.remaining -= length;
 }
 
@@ -1507,11 +1508,13 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
     /* Copy first fragment and base headers before the data, it will be needed
      * for middle fragments processing. */
     UCS_PROFILE_NAMED_CALL("am_memcpy_recv", ucs_memcpy_relaxed,
-                           first_rdesc + 1, first_ftr, sizeof(*first_ftr));
+                           first_rdesc + 1, first_ftr, sizeof(*first_ftr),
+                           UCS_ARCH_MEMCPY_NT_SOURCE, sizeof(*first_ftr));
     UCS_PROFILE_NAMED_CALL("am_memcpy_recv", ucs_memcpy_relaxed,
                            UCS_PTR_BYTE_OFFSET(first_rdesc + 1,
                                                sizeof(*first_ftr)),
-                           hdr, sizeof(*hdr));
+                           hdr, sizeof(*hdr), UCS_ARCH_MEMCPY_NT_SOURCE,
+                           sizeof(*hdr));
 
     /* Copy user header to the end of message */
     user_hdr = UCS_PTR_BYTE_OFFSET(first_ftr, -user_hdr_length);
@@ -1519,7 +1522,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
                            UCS_PTR_BYTE_OFFSET(first_rdesc + 1,
                                                first_rdesc->payload_offset +
                                                        first_ftr->total_size),
-                           user_hdr, user_hdr_length);
+                           user_hdr, user_hdr_length,
+                           UCS_ARCH_MEMCPY_NT_SOURCE, user_hdr_length);
 
     /* Copy all already arrived middle fragments to the data buffer */
     ucs_queue_for_each_safe(mid_rdesc, iter, &ep_ext->am.mid_rdesc_q,

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -378,7 +379,8 @@ ucp_datatype_iter_next_pack(const ucp_datatype_iter_t *dt_iter,
         src    = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer,
                                      dt_iter->offset);
         ucp_dt_contig_pack(worker, dest, src, length,
-                           (ucs_memory_type_t)dt_iter->mem_info.type);
+                           (ucs_memory_type_t)dt_iter->mem_info.type,
+                           dt_iter->length);
         break;
     case UCP_DATATYPE_IOV:
         ucp_datatype_iter_iov_check(dt_iter);
@@ -389,7 +391,8 @@ ucp_datatype_iter_next_pack(const ucp_datatype_iter_t *dt_iter,
                               dt_iter->type.iov.iov, length,
                               &next_iter->type.iov.iov_offset,
                               &next_iter->type.iov.iov_index,
-                              (ucs_memory_type_t)dt_iter->mem_info.type);
+                              (ucs_memory_type_t)dt_iter->mem_info.type,
+                              dt_iter->length);
         break;
     case UCP_DATATYPE_GENERIC:
         if (max_length != 0) {
@@ -443,7 +446,8 @@ ucp_datatype_iter_unpack(ucp_datatype_iter_t *dt_iter, ucp_worker_h worker,
         ucs_assert(dt_iter->mem_info.type < UCS_MEMORY_TYPE_LAST);
         dest = UCS_PTR_BYTE_OFFSET(dt_iter->type.contig.buffer, offset);
         ucp_dt_contig_unpack(worker, dest, src, length,
-                             (ucs_memory_type_t)dt_iter->mem_info.type);
+                             (ucs_memory_type_t)dt_iter->mem_info.type,
+                             dt_iter->length);
         status = UCS_OK;
         break;
     case UCP_DATATYPE_IOV:
@@ -453,7 +457,8 @@ ucp_datatype_iter_unpack(ucp_datatype_iter_t *dt_iter, ucp_worker_h worker,
                                            length,
                                            &dt_iter->type.iov.iov_offset,
                                            &dt_iter->type.iov.iov_index,
-                                           (ucs_memory_type_t)dt_iter->mem_info.type);
+                                           (ucs_memory_type_t)dt_iter->mem_info.type,
+                                           dt_iter->length);
         ucs_assert(unpacked_length <= length);
         dt_iter->offset += unpacked_length;
         status           = UCS_OK;

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2017. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -112,14 +113,14 @@ size_t ucp_dt_pack(ucp_worker_h worker, ucp_datatype_t datatype,
     case UCP_DATATYPE_CONTIG:
         ucp_dt_contig_pack(worker, dest,
                            UCS_PTR_BYTE_OFFSET(src, state->offset),
-                           length, mem_type);
+                           length, mem_type, length);
         result_len = length;
         break;
 
     case UCP_DATATYPE_IOV:
         UCS_PROFILE_CALL_VOID(ucp_dt_iov_gather, worker, dest, src, length,
                               &state->dt.iov.iov_offset,
-                              &state->dt.iov.iovcnt_offset, mem_type);
+                              &state->dt.iov.iovcnt_offset, mem_type, length);
         result_len = length;
         break;
 

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2016. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -68,11 +69,19 @@ void ucp_mem_type_unpack(ucp_worker_h worker, void *buffer,
 
 
 static UCS_F_ALWAYS_INLINE void
-ucp_memcpy_pack_unpack(void *buffer, const void *data, size_t length,
-                       const char *name)
+ucp_memcpy_pack(void *buffer, const void *data, size_t length,
+                size_t total_len, const char *name)
 {
-    UCS_PROFILE_NAMED_CALL(name, ucs_memcpy_relaxed, buffer, data, length);
+    UCS_PROFILE_NAMED_CALL(name, ucs_memcpy_relaxed, buffer, data, length,
+                           UCS_ARCH_MEMCPY_NT_DEST, total_len);
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_memcpy_unpack(void *buffer, const void *data, size_t length,
+                  size_t total_len, const char *name)
+{
+    UCS_PROFILE_NAMED_CALL(name, ucs_memcpy_relaxed, buffer, data, length,
+                           UCS_ARCH_MEMCPY_NT_SOURCE, total_len);
+}
 
 #endif /* UCP_DT_H_ */

--- a/src/ucp/dt/dt_contig.h
+++ b/src/ucp/dt/dt_contig.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -37,10 +38,10 @@ static UCS_F_ALWAYS_INLINE size_t ucp_contig_dt_length(ucp_datatype_t datatype,
 
 static UCS_F_ALWAYS_INLINE void
 ucp_dt_contig_pack(ucp_worker_h worker, void *dest, const void *src,
-                   size_t length, ucs_memory_type_t mem_type)
+                   size_t length, ucs_memory_type_t mem_type, size_t total_len)
 {
     if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type))) {
-        ucp_memcpy_pack_unpack(dest, src, length, "memcpy_pack");
+        ucp_memcpy_pack(dest, src, length, total_len, "memcpy_pack");
     } else {
         ucp_mem_type_pack(worker, dest, src, length, mem_type);
     }
@@ -49,10 +50,10 @@ ucp_dt_contig_pack(ucp_worker_h worker, void *dest, const void *src,
 
 static UCS_F_ALWAYS_INLINE void
 ucp_dt_contig_unpack(ucp_worker_h worker, void *dest, const void *src,
-                     size_t length, ucs_memory_type_t mem_type)
+                     size_t length, ucs_memory_type_t mem_type, size_t total_len)
 {
     if (ucs_likely(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(mem_type))) {
-        ucp_memcpy_pack_unpack(dest, src, length, "memcpy_unpack");
+        ucp_memcpy_unpack(dest, src, length, total_len, "memcpy_unpack");
     } else {
         ucp_mem_type_unpack(worker, dest, src, length, mem_type);
     }

--- a/src/ucp/dt/dt_iov.c
+++ b/src/ucp/dt/dt_iov.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -24,7 +25,7 @@
 
 void ucp_dt_iov_gather(ucp_worker_h worker, void *dest, const ucp_dt_iov_t *iov,
                        size_t length, size_t *iov_offset, size_t *iovcnt_offset,
-                       ucs_memory_type_t mem_type)
+                       ucs_memory_type_t mem_type, size_t total_len)
 {
     size_t length_it = 0;
     size_t item_len, item_reminder, item_len_to_copy;
@@ -39,7 +40,7 @@ void ucp_dt_iov_gather(ucp_worker_h worker, void *dest, const ucp_dt_iov_t *iov,
         ucp_dt_contig_pack(worker, UCS_PTR_BYTE_OFFSET(dest, length_it),
                            UCS_PTR_BYTE_OFFSET(iov[*iovcnt_offset].buffer,
                                                *iov_offset),
-                           item_len_to_copy, mem_type);
+                           item_len_to_copy, mem_type, total_len);
         length_it += item_len_to_copy;
 
         ucs_assert(length_it <= length);
@@ -55,7 +56,7 @@ void ucp_dt_iov_gather(ucp_worker_h worker, void *dest, const ucp_dt_iov_t *iov,
 size_t ucp_dt_iov_scatter(ucp_worker_h worker, const ucp_dt_iov_t *iov,
                           size_t iovcnt, const void *src, size_t length,
                           size_t *iov_offset, size_t *iovcnt_offset,
-                          ucs_memory_type_t mem_type)
+                          ucs_memory_type_t mem_type, size_t total_len)
 {
     size_t length_it = 0;
     size_t item_len, item_len_to_copy;
@@ -70,7 +71,7 @@ size_t ucp_dt_iov_scatter(ucp_worker_h worker, const ucp_dt_iov_t *iov,
                              UCS_PTR_BYTE_OFFSET(iov[*iovcnt_offset].buffer,
                                                  *iov_offset),
                              UCS_PTR_BYTE_OFFSET(src, length_it),
-                             item_len_to_copy, mem_type);
+                             item_len_to_copy, mem_type, total_len);
         length_it += item_len_to_copy;
 
         ucs_assert(length_it <= length);

--- a/src/ucp/dt/dt_iov.h
+++ b/src/ucp/dt/dt_iov.h
@@ -55,7 +55,7 @@ static inline size_t ucp_dt_iov_length(const ucp_dt_iov_t *iov, size_t iovcnt)
  */
 void ucp_dt_iov_gather(ucp_worker_h worker, void *dest, const ucp_dt_iov_t *iov,
                        size_t length, size_t *iov_offset, size_t *iovcnt_offset,
-                       ucs_memory_type_t mem_type);
+                       ucs_memory_type_t mem_type, size_t total_len);
 
 
 /**
@@ -81,7 +81,7 @@ void ucp_dt_iov_gather(ucp_worker_h worker, void *dest, const ucp_dt_iov_t *iov,
 size_t ucp_dt_iov_scatter(ucp_worker_h worker, const ucp_dt_iov_t *iov,
                           size_t iovcnt, const void *src, size_t length,
                           size_t *iov_offset, size_t *iovcnt_offset,
-                          ucs_memory_type_t mem_type);
+                          ucs_memory_type_t mem_type, size_t total_len);
 
 
 /**

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -22,7 +23,8 @@ ucp_amo_memtype_unpack_reply_buffer(ucp_request_t *req)
 {
     ucp_dt_contig_unpack(req->send.ep->worker, req->send.amo.reply_buffer,
                          &req->send.amo.result, req->send.state.dt_iter.length,
-                         ucp_amo_request_reply_mem_type(req));
+                         ucp_amo_request_reply_mem_type(req),
+                         req->send.state.dt_iter.length);
 }
 
 static void ucp_proto_amo_completion(uct_completion_t *self)
@@ -71,7 +73,7 @@ ucp_proto_amo_progress(uct_pending_req_t *self, ucp_operation_id_t op_id,
                                     UCS_MEMORY_TYPE_HOST;
             ucp_dt_contig_pack(req->send.ep->worker, &req->send.amo.value,
                                req->send.state.dt_iter.type.contig.buffer,
-                               op_size, mem_type);
+                               op_size, mem_type, op_size);
             req->flags |= UCP_REQUEST_FLAG_PROTO_AMO_PACKED;
         }
 
@@ -84,7 +86,7 @@ ucp_proto_amo_progress(uct_pending_req_t *self, ucp_operation_id_t op_id,
         if (op_id == UCP_OP_ID_AMO_CSWAP) {
             ucp_dt_contig_pack(ep->worker, &req->send.amo.result,
                                req->send.amo.reply_buffer, op_size,
-                               ucp_amo_request_reply_mem_type(req));
+                               ucp_amo_request_reply_mem_type(req), op_size);
         }
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
  * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -38,10 +39,10 @@ static size_t ucp_amo_sw_pack(void *dest, ucp_request_t *req, int fetch,
 
     if (worker->context->config.ext.proto_enable) {
         ucp_dt_contig_pack(worker, atomich + 1, &req->send.amo.value, size,
-                           UCS_MEMORY_TYPE_HOST);
+                           UCS_MEMORY_TYPE_HOST, size);
         if (req->send.amo.uct_op == UCT_ATOMIC_OP_CSWAP) {
             ucp_dt_contig_pack(worker, cswaph, req->send.amo.reply_buffer, size,
-                               ucp_amo_request_reply_mem_type(req));
+                               ucp_amo_request_reply_mem_type(req), size);
             length += size;
         }
     } else {
@@ -303,7 +304,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_atomic_rep_handler, (arg, data, length, am_fl
 
     if (worker->context->config.ext.proto_enable) {
         ucp_dt_contig_unpack(worker, req->send.amo.reply_buffer, hdr + 1,
-                             frag_length, ucp_amo_request_reply_mem_type(req));
+                             frag_length, ucp_amo_request_reply_mem_type(req),
+                             frag_length);
     } else {
         memcpy(req->send.buffer, hdr + 1, frag_length);
     }

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -20,7 +21,7 @@ static void ucp_proto_get_offload_bcopy_unpack(void *arg, const void *data,
                                                size_t length)
 {
     void *dest = arg;
-    ucs_memcpy_relaxed(dest, data, length);
+    ucs_memcpy_relaxed(dest, data, length, UCS_ARCH_MEMCPY_NT_SOURCE, length);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
  * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -161,7 +162,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_put_handler, (arg, data, length, am_flags),
     UCP_WORKER_GET_EP_BY_ID(&ep, worker, puth->ep_id, return UCS_OK,
                             "SW PUT request");
     ucp_dt_contig_unpack(worker, (void*)puth->address, puth + 1,
-                         length - sizeof(*puth), puth->mem_type);
+                         length - sizeof(*puth), puth->mem_type,
+                         length - sizeof(*puth));
     ucp_rma_sw_send_cmpl(ep);
     return UCS_OK;
 }
@@ -195,7 +197,7 @@ static size_t ucp_rma_sw_pack_get_reply(void *dest, void *arg)
     hdr->offset = req->send.state.dt_iter.offset;
     ucp_dt_contig_pack(req->send.ep->worker, hdr + 1,
                        (char*)req->send.buffer + hdr->offset, length,
-                       req->send.mem_type);
+                       req->send.mem_type, req->send.length);
 
     return sizeof(*hdr) + length;
 }

--- a/src/ucp/tag/tag_match.inl
+++ b/src/ucp/tag/tag_match.inl
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -274,7 +275,7 @@ ucp_request_recv_offload_data(ucp_request_t *req, const void *data,
     }
 
     ucp_dt_contig_unpack(req->recv.worker, UCS_PTR_BYTE_OFFSET(buffer, offset),
-                         data, length, req->recv.dt_iter.mem_info.type);
+                         data, length, req->recv.dt_iter.mem_info.type, length);
     req->status = UCS_OK;
 
 out:

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2020.  ALL RIGHTS RESERVED.
 * Copyright (C) Stony Brook University. 2016-2020.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -269,7 +270,9 @@ static inline void *memcpy_aarch64_sve(void *dest, const void *src, size_t len)
 }
 #endif
 
-static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len)
+static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
+                                       ucs_arch_memcpy_hint_t hint,
+                                       size_t total_len)
 {
 #if defined(HAVE_AARCH64_THUNDERX2)
     return __memcpy_thunderx2(dst, src, len);

--- a/src/ucs/arch/generic/cpu.h
+++ b/src/ucs/arch/generic/cpu.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -11,6 +12,28 @@
 #include <sys/time.h>
 #include <stdint.h>
 
+/**
+ * These hints can be used with the ucs_memcpy_relaxed() function
+ * to optimize memory copy performance. Hints are derived based
+ * on the total length of the buffer transfer or the temporal locality
+ * of the data.
+ *
+ * If the total length of data transfer is more or closer
+ * to the size of last level cache, it is safe to assume the destination
+ * buffer is non-temporal.
+ *
+ * If the source buffer is no longer needed or not usable in the CPU that
+ * performs the buffer transfer, it is safe to assume the source buffer
+ * is non-temporal. The same is true for destination buffer as well.
+ */
+typedef enum {
+    /* Both the source and destination buffers can be temporal */
+    UCS_ARCH_MEMCPY_NT_NONE   = 0,
+    /* Source buffer is of non-temporal nature */
+    UCS_ARCH_MEMCPY_NT_SOURCE = UCS_BIT(0),
+    /* Destination buffer is of non-temporal nature */
+    UCS_ARCH_MEMCPY_NT_DEST   = UCS_BIT(1),
+} ucs_arch_memcpy_hint_t;
 
 static inline uint64_t ucs_arch_generic_read_hres_clock(void)
 {

--- a/src/ucs/arch/ppc64/cpu.h
+++ b/src/ucs/arch/ppc64/cpu.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2013. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -80,7 +81,9 @@ static inline void ucs_arch_clear_cache(void *start, void *end)
 }
 #endif
 
-static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len)
+static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
+                                       ucs_arch_memcpy_hint_t hint,
+                                       size_t total_len)
 {
     return memcpy(dst, src, len);
 }

--- a/src/ucs/arch/rv64/cpu.h
+++ b/src/ucs/arch/rv64/cpu.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
 * Copyright (C) Rivos Inc. 2023
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -97,7 +98,9 @@ static inline void ucs_arch_clear_cache(void *start, void *end)
 }
 #endif
 
-static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len)
+static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
+                                       ucs_arch_memcpy_hint_t hint,
+                                       size_t total_len)
 {
     return memcpy(dst, src, len);
 }

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -1,6 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
-* Copyright (C) Advanced Micro Devices, Inc. 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2019-2024. ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -588,6 +588,28 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 }
 #endif
 
+static size_t ucs_cpu_nt_bt_thresh_min(size_t user_val)
+{
+    if (user_val != UCS_MEMUNITS_AUTO) {
+        return user_val;
+    }
+
+    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD) {
+        return ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3) * 3 / 4;
+    } else {
+        return UCS_MEMUNITS_INF;
+    }
+}
+
+static size_t ucs_cpu_nt_dest_thresh()
+{
+    if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD) {
+        return ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3) * 29 / 32;
+    } else {
+        return UCS_MEMUNITS_INF;
+    }
+}
+
 void ucs_cpu_init()
 {
 #if ENABLE_BUILTIN_MEMCPY
@@ -598,6 +620,9 @@ void ucs_cpu_init()
         ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max,
                               ucs_cpu_builtin_memcpy[ucs_arch_get_cpu_vendor()].max);
 #endif
+    ucs_global_opts.arch.nt_buffer_transfer_min =
+        ucs_cpu_nt_bt_thresh_min(ucs_global_opts.arch.nt_buffer_transfer_min);
+    ucs_global_opts.arch.nt_dest_threshold = ucs_cpu_nt_dest_thresh();
 }
 
 ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
@@ -706,6 +731,317 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
 
     return cache_count == UCS_CPU_CACHE_LAST ? UCS_OK : UCS_ERR_UNSUPPORTED;
 }
+
+#ifdef __AVX__
+static UCS_F_ALWAYS_INLINE
+size_t ucs_x86_nt_dst_buffer_transfer(void *dst, const void *src, size_t len,
+                                      unsigned int hint, size_t total_len)
+{
+    const size_t switch_to_nt_store_size = 1464;
+    __m256i y0, y1, y2, y3;
+    size_t offset;
+
+    ucs_nt_write_prefetch(dst);
+    /* copy enough to make destination address 32 byte aligned */
+    offset = 64 - ((uintptr_t)dst & 0x1f);
+    y2     = _mm256_loadu_si256(src);
+    y3     = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset - 32));
+    _mm256_storeu_si256(dst, y2);
+    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset - 32), y3);
+
+    len -= offset;
+
+    if (ucs_unlikely(total_len > switch_to_nt_store_size)) {
+        if (ucs_likely((size_t)UCS_PTR_BYTE_OFFSET(src, offset) & 0x1f)) {
+            /* src address is not aligned to 32 byte */
+            while (len >= 128) {
+                y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+                y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+                y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
+                y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
+
+                if (ucs_unlikely(hint & UCS_ARCH_MEMCPY_NT_SOURCE)) {
+                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
+                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
+                } else {
+                    if (len > 256) {
+                        ucs_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
+                        ucs_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
+                    }
+                }
+
+                offset += 128;
+                len    -= 128;
+            }
+        } else {
+            /* src address aligned to 32 byte */
+            while (len >= 128) {
+                y0 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+                y1 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+                y2 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
+                y3 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
+                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
+
+                if (ucs_unlikely(hint & UCS_ARCH_MEMCPY_NT_SOURCE)) {
+                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
+                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
+                } else {
+                    if (len > 256) {
+                        ucs_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
+                        ucs_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
+                    }
+                }
+
+                offset += 128;
+                len    -= 128;
+            }
+        }
+
+        if (len >= 64) {
+            y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+            y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+            offset += 64;
+            len    -= 64;
+        }
+
+        if (len) {
+            ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset));
+        }
+
+        /* make the writes visible to the other core */
+        ucs_memory_bus_store_fence();
+    } else {
+        ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset));
+        ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (1 * 64)));
+
+        while (len >= 128) {
+            y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+            y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+            y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
+            y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
+
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
+
+            if (len > 128) {
+                ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (2 * 64)));
+                if (len > 192) {
+                    ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (3 * 64)));
+                }
+            }
+
+            offset += 128;
+            len    -= 128;
+        }
+
+        if (len >= 64) {
+            y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+            y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+            len -= 64;
+        }
+    }
+
+    /* Handle the remaining bytes <= 63 */
+    return len;
+}
+
+static UCS_F_ALWAYS_INLINE
+size_t ucs_x86_nt_src_buffer_transfer(void *dst, const void *src, size_t len)
+{
+    __m256i y0, y1, y2, y3;
+    size_t offset;
+
+    ucs_nt_read_prefetch(src);
+    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 64));
+    offset = 128 - ((uintptr_t)src & 0x3f);
+    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset));
+
+    /* copy the first misaligned bytes. 65 < offset < 128 */
+    y0 = _mm256_loadu_si256(src);
+    y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 32));
+    y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset - 64));
+    y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset - 32));
+    _mm256_storeu_si256(dst, y0);
+    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 32), y1);
+    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset - 64), y2);
+    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset - 32), y3);
+
+    len -= offset;
+    if (len > 64) {
+        ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (1 * 64)));
+        if (len > 128) {
+            ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (2 * 64)));
+        }
+    }
+
+    if (ucs_likely((size_t)UCS_PTR_BYTE_OFFSET(dst, offset) & 0x1f)) {
+        while (len >= 128) {
+            /* Can we use streaming loads on normal memory type? */
+            y0 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+            y1 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+            y2 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
+            y3 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
+            _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+            _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+            _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
+            _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
+
+            if (len > 192) {
+                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
+                ucs_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (3 * 64)));
+                if (len > 256) {
+                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
+                    ucs_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (4 * 64)));
+                }
+            }
+
+            offset += 128;
+            len    -= 128;
+        }
+    } else {
+        while (len >= 128) {
+            /* Can we use streaming loads on normal memory type? */
+            y0 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset));
+            y1 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
+            y2 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
+            y3 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
+            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
+
+            if (len > 192) {
+                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
+                ucs_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (3 * 64)));
+                if (len > 256) {
+                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
+                    ucs_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (4 * 64)));
+                }
+            }
+
+            offset += 128;
+            len    -= 128;
+        }
+    }
+
+    /* Handle the remaining bytes <= 127 */
+    return len;
+}
+
+static UCS_F_ALWAYS_INLINE
+void ucs_x86_copy_bytes_le_128(void *dst, const void *src, size_t len)
+{
+#if defined (__LZCNT__)
+    __m256i y0, y1, y2, y3;
+    /* Handle lengths that fall usually within eager short range */
+    switch (_lzcnt_u32(len)) {
+    /* 0 */
+    case 32:
+        break;
+    /* 1 */
+    case 31:
+        *(uint8_t *)dst = *(uint8_t *)src;
+        break;
+    /* 2 - 3 */
+    case 30:
+        *(uint16_t *)dst = *(uint16_t *)src;
+        *(uint16_t *)UCS_PTR_BYTE_OFFSET(dst, len - 2) = \
+            *(uint16_t *)UCS_PTR_BYTE_OFFSET(src, len - 2);
+        break;
+    /* 4 - 7 */
+    case 29:
+        *(uint32_t *)dst = *(uint32_t *)src;
+        *(uint32_t *)UCS_PTR_BYTE_OFFSET(dst, len - 4) = \
+            *(uint32_t *)UCS_PTR_BYTE_OFFSET(src, len - 4);
+        break;
+    /* 8 - 15 */
+    case 28:
+        *(uint64_t *)dst = *(uint64_t *)src;
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 8) = \
+            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 8);
+        break;
+    /* 16 - 31 */
+    case 27:
+        *(uint64_t *)dst = *(uint64_t *)src;
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, 8) = \
+            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, 8);
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 16) = \
+            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 16);
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 8) = \
+            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 8);
+        break;
+    /* 32 - 63 */
+    case 26:
+        y0 = _mm256_loadu_si256(src);
+        y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src,  len - 32));
+        _mm256_storeu_si256(dst, y0);
+        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 32), y1);
+        break;
+    /* 64 - 128 */
+    default:
+        y0 = _mm256_loadu_si256(src);
+        y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 32));
+        y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, len - 64));
+        y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, len - 32));
+        _mm256_storeu_si256(dst, y0);
+        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 32), y1);
+        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 64), y2);
+        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 32), y3);
+        break;
+    }
+#else
+    memcpy(dst, src, len);
+#endif
+}
+
+/* This is an adaptation of the memcpy code from https://github.com/amd/aocl-libmem
+ * TODO: Provide an option to copy from backwards, in this way
+ * application can choose the cache hotness of the final buffer
+ */
+void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
+                                ucs_arch_memcpy_hint_t hint, size_t total_len)
+{
+    size_t tail_bytes;
+
+    if (ucs_likely(len <= 128)) {
+        goto copy_bytes_le_128;
+    }
+
+    /* Give precedence to non temporal destination */
+    if (ucs_unlikely(total_len > ucs_global_opts.arch.nt_dest_threshold)) {
+        hint |= UCS_ARCH_MEMCPY_NT_DEST;
+    }
+
+    if (hint & UCS_ARCH_MEMCPY_NT_DEST) {
+        tail_bytes = ucs_x86_nt_dst_buffer_transfer(dst, src, len, hint, total_len);
+    } else if (hint & UCS_ARCH_MEMCPY_NT_SOURCE) {
+        tail_bytes = ucs_x86_nt_src_buffer_transfer(dst, src, len);
+    } else {
+        memcpy(dst, src, len);
+        tail_bytes = 0;
+    }
+
+    dst = UCS_PTR_BYTE_OFFSET(dst, len - tail_bytes);
+    src = UCS_PTR_BYTE_OFFSET(src, len - tail_bytes);
+    len = tail_bytes;
+
+copy_bytes_le_128:
+    ucs_x86_copy_bytes_le_128(dst, src, len);
+}
+#endif
 
 void ucs_x86_memcpy_sse_movntdqa(void *dst, const void *src, size_t len)
 {

--- a/src/ucs/arch/x86_64/global_opts.c
+++ b/src/ucs/arch/x86_64/global_opts.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -17,28 +18,44 @@ ucs_config_field_t ucs_arch_global_opts_table[] = {
 #if ENABLE_BUILTIN_MEMCPY
   {"BUILTIN_MEMCPY_MIN", "auto",
    "Minimal threshold of buffer length for using built-in memcpy.",
-   ucs_offsetof(ucs_arch_global_opts_t, builtin_memcpy_min), UCS_CONFIG_TYPE_MEMUNITS},
+   ucs_offsetof(ucs_arch_global_opts_t, builtin_memcpy_min),
+   UCS_CONFIG_TYPE_MEMUNITS},
 
   {"BUILTIN_MEMCPY_MAX", "auto",
    "Maximal threshold of buffer length for using built-in memcpy.",
-   ucs_offsetof(ucs_arch_global_opts_t, builtin_memcpy_max), UCS_CONFIG_TYPE_MEMUNITS},
+   ucs_offsetof(ucs_arch_global_opts_t, builtin_memcpy_max),
+   UCS_CONFIG_TYPE_MEMUNITS},
 #endif
+  {"NT_BUFFER_TRANSFER_MIN", "auto",
+   "Minimal threshold of buffer length for using non-temporal buffer transfer.",
+   ucs_offsetof(ucs_arch_global_opts_t, nt_buffer_transfer_min),
+   UCS_CONFIG_TYPE_MEMUNITS},
   {NULL}
 };
 
 
 void ucs_arch_print_memcpy_limits(ucs_arch_global_opts_t *config)
 {
-#if ENABLE_BUILTIN_MEMCPY
     char min_thresh_str[32];
-    char max_thresh_str[32];
+    char dest_thresh_str[32];
 
+#if ENABLE_BUILTIN_MEMCPY
+    char max_thresh_str[32];
     ucs_config_sprintf_memunits(min_thresh_str, sizeof(min_thresh_str),
                                 &config->builtin_memcpy_min, NULL);
     ucs_config_sprintf_memunits(max_thresh_str, sizeof(max_thresh_str),
                                 &config->builtin_memcpy_max, NULL);
-    printf("# Using built-in memcpy() for size %s..%s\n", min_thresh_str, max_thresh_str);
+    printf("# Using built-in memcpy() for size %s..%s\n",
+           min_thresh_str, max_thresh_str);
 #endif
-}
 
+    ucs_config_sprintf_memunits(min_thresh_str, sizeof(min_thresh_str),
+                                &config->nt_buffer_transfer_min, NULL);
+    ucs_config_sprintf_memunits(dest_thresh_str, sizeof(dest_thresh_str),
+                                &config->nt_dest_threshold, NULL);
+    printf("# Using nt-buffer-transfer for sizes from %s\n",
+           min_thresh_str);
+    printf("# Using nt-destination-hint for sizes from %s\n",
+           dest_thresh_str);
+}
 #endif

--- a/src/ucs/arch/x86_64/global_opts.h
+++ b/src/ucs/arch/x86_64/global_opts.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -13,15 +14,19 @@
 
 BEGIN_C_DECLS
 
-#define UCS_ARCH_GLOBAL_OPTS_INITALIZER {   \
-    .builtin_memcpy_min = UCS_MEMUNITS_AUTO, \
-    .builtin_memcpy_max = UCS_MEMUNITS_AUTO  \
+#define UCS_ARCH_GLOBAL_OPTS_INITALIZER { \
+    .builtin_memcpy_min     = UCS_MEMUNITS_AUTO, \
+    .builtin_memcpy_max     = UCS_MEMUNITS_AUTO, \
+    .nt_buffer_transfer_min = UCS_MEMUNITS_AUTO, \
+    .nt_dest_threshold      = UCS_MEMUNITS_AUTO  \
 }
 
-/* built-in memcpy config */
+/* built-in memcpy & nt-buffer-transfer config */
 typedef struct ucs_arch_global_opts {
     size_t builtin_memcpy_min;
     size_t builtin_memcpy_max;
+    size_t nt_buffer_transfer_min;
+    size_t nt_dest_threshold;
 } ucs_arch_global_opts_t;
 
 END_C_DECLS

--- a/src/ucs/datastruct/ptr_array.h
+++ b/src/ucs/datastruct/ptr_array.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2013. ALL RIGHTS RESERVED.
 * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -240,7 +241,7 @@ __ucs_ptr_array_for_each_get_step_size(ucs_ptr_array_t *ptr_array,
     }
 
     /* Prefetch the next item */
-    ucs_prefetch(&ptr_array->start[element_index + size_elem]);
+    ucs_read_prefetch(&ptr_array->start[element_index + size_elem]);
 
     return size_elem;
 }

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2017. ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) Arm, Ltd. 2021. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -199,7 +200,11 @@
 /**
  * Prefetch cache line
  */
-#define ucs_prefetch(p)            __builtin_prefetch(p)
+#define ucs_read_prefetch(p)       __builtin_prefetch(p, 0, 3)
+#define ucs_write_prefetch(p)      __builtin_prefetch(p, 1, 3)
+
+#define ucs_nt_read_prefetch(p)    __builtin_prefetch(p, 0, 0)
+#define ucs_nt_write_prefetch(p)   __builtin_prefetch(p, 1, 0)
 
 /* Branch prediction */
 #define ucs_likely(x)              __builtin_expect(x, 1)

--- a/src/ucs/sys/iovec.c
+++ b/src/ucs/sys/iovec.c
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -10,6 +11,7 @@
 
 #include <ucs/sys/iovec.h>
 #include <ucs/sys/math.h>
+#include <ucs/arch/cpu.h>
 
 #include <string.h>
 #include <sys/uio.h>
@@ -40,10 +42,13 @@ size_t ucs_iov_copy(const struct iovec *iov, size_t iov_cnt,
         len     -= iov_offset;
 
         len = ucs_min(len, max_copy);
+
         if (dir == UCS_IOV_COPY_FROM_BUF) {
-            memcpy(iov_buf, UCS_PTR_BYTE_OFFSET(buf, copied), len);
+            ucs_memcpy_relaxed(iov_buf, UCS_PTR_BYTE_OFFSET(buf, copied), len,
+                               UCS_ARCH_MEMCPY_NT_SOURCE, len);
         } else if (dir == UCS_IOV_COPY_TO_BUF) {
-            memcpy(UCS_PTR_BYTE_OFFSET(buf, copied), iov_buf, len);
+            ucs_memcpy_relaxed(UCS_PTR_BYTE_OFFSET(buf, copied), iov_buf, len,
+                               UCS_ARCH_MEMCPY_NT_DEST, len);
         }
 
         iov_offset  = 0;

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2021. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -9,6 +10,7 @@
 
 #include "uct_worker.h"
 
+#include <ucs/arch/cpu.h>
 #include <uct/api/uct.h>
 #include <uct/base/uct_component.h>
 #include <ucs/config/parser.h>
@@ -978,7 +980,7 @@ void uct_invoke_completion(uct_completion_t *comp, ucs_status_t status)
  */
 static UCS_F_ALWAYS_INLINE
 void uct_am_short_fill_data(void *buffer, uint64_t header, const void *payload,
-                            size_t length)
+                            size_t length, ucs_arch_memcpy_hint_t hint)
 {
     /**
      * Helper structure to fill send buffer of short messages for
@@ -992,7 +994,7 @@ void uct_am_short_fill_data(void *buffer, uint64_t header, const void *payload,
     packet->header = header;
     /* suppress false positive diagnostic from uct_mm_ep_am_common_send call */
     /* cppcheck-suppress ctunullpointer */
-    memcpy(packet->payload, payload, length);
+    ucs_memcpy_relaxed(packet->payload, payload, length, hint, length);
 }
 
 

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -271,7 +272,7 @@ static UCS_F_ALWAYS_INLINE struct mlx5_cqe64*
 uct_rc_mlx5_iface_poll_rx_cq(uct_rc_mlx5_iface_common_t *iface, int poll_flags)
 {
     /* Prefetch the descriptor if it was scheduled */
-    ucs_prefetch(iface->rx.pref_ptr);
+    ucs_read_prefetch(iface->rx.pref_ptr);
 
     return uct_ib_mlx5_poll_cq(&iface->super.super, &iface->cq[UCT_IB_DIR_RX],
                                poll_flags,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -200,7 +201,7 @@ uct_ud_mlx5_iface_post_recv(uct_ud_mlx5_iface_t *iface)
 
     for (count = 0; count < batch; count ++) {
         next_pi = (pi + 1) &  iface->rx.wq.mask;
-        ucs_prefetch(rx_wqes + next_pi);
+        ucs_read_prefetch(rx_wqes + next_pi);
         UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
                                  desc, break);
         rx_wqes[pi].lkey = htonl(desc->lkey);
@@ -489,7 +490,7 @@ uct_ud_mlx5_iface_poll_rx(uct_ud_mlx5_iface_t *iface, int is_async)
 
     ci            = iface->rx.wq.cq_wqe_counter & iface->rx.wq.mask;
     packet        = (void *)be64toh(iface->rx.wq.wqes[ci].addr);
-    ucs_prefetch(UCS_PTR_BYTE_OFFSET(packet, UCT_IB_GRH_LEN));
+    ucs_read_prefetch(UCS_PTR_BYTE_OFFSET(packet, UCT_IB_GRH_LEN));
     rx_hdr_offset = iface->super.super.config.rx_hdr_offset;
     desc          = UCS_PTR_BYTE_OFFSET(packet, -rx_hdr_offset);
 

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -63,7 +64,7 @@ uct_ud_send_skb_t *uct_ud_iface_get_tx_skb(uct_ud_iface_t *iface,
     }
     VALGRIND_MAKE_MEM_DEFINED(&skb->lkey, sizeof(skb->lkey));
     skb->flags = 0;
-    ucs_prefetch(skb->neth);
+    ucs_read_prefetch(skb->neth);
     return skb;
 }
 

--- a/src/uct/sm/mm/base/mm_ep.c
+++ b/src/uct/sm/mm/base/mm_ep.c
@@ -2,6 +2,7 @@
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -320,7 +321,8 @@ retry:
     switch (send_op) {
     case UCT_MM_SEND_AM_SHORT:
         /* write to the remote FIFO */
-        uct_am_short_fill_data(elem + 1, header, payload, length);
+        uct_am_short_fill_data(elem + 1, header, payload, length,
+                               UCS_ARCH_MEMCPY_NT_DEST);
 
         elem_flags   = UCT_MM_FIFO_ELEM_FLAG_INLINE;
         elem->length = length + sizeof(header);

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2021. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -313,7 +314,8 @@ ucs_status_t uct_self_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
     UCT_CHECK_LENGTH(total_length, 0, iface->send_size, "am_short");
 
     send_buffer = UCT_SELF_IFACE_SEND_BUFFER_GET(iface);
-    uct_am_short_fill_data(send_buffer, header, payload, length);
+    uct_am_short_fill_data(send_buffer, header, payload, length,
+                           UCS_ARCH_MEMCPY_NT_NONE);
 
     UCT_TL_EP_STAT_OP(&ep->super, AM, SHORT, total_length);
     uct_self_iface_sendrecv_am(iface, id, send_buffer, total_length, "SHORT");

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -1781,7 +1782,8 @@ ucs_status_t uct_tcp_ep_am_short(uct_ep_h uct_ep, uint8_t am_id, uint64_t header
     hdr->length = payload_length = length + sizeof(header);
 
     if (length <= iface->config.sendv_thresh) {
-        uct_am_short_fill_data(hdr + 1, header, payload, length);
+        uct_am_short_fill_data(hdr + 1, header, payload, length,
+                               UCS_ARCH_MEMCPY_NT_NONE);
         status = uct_tcp_ep_am_send(ep, hdr);
     } else {
         iov[0].iov_base = hdr;

--- a/src/uct/ugni/smsg/ugni_smsg_ep.c
+++ b/src/uct/ugni/smsg/ugni_smsg_ep.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -233,7 +234,6 @@ exit_no_res:
 ucs_status_t uct_ugni_smsg_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t header,
                                        const void *payload, unsigned length)
 {
-
     uct_ugni_smsg_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_ugni_smsg_iface_t);
     uct_ugni_smsg_ep_t *ep = ucs_derived_of(tl_ep, uct_ugni_smsg_ep_t);
     uct_ugni_smsg_header_t *smsg_header;
@@ -253,7 +253,8 @@ ucs_status_t uct_ugni_smsg_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t head
     smsg_header = (uct_ugni_smsg_header_t *)(desc+1);
     smsg_header->length = length + sizeof(header);
 
-    uct_am_short_fill_data(smsg_header + 1, header, payload, length);
+    uct_am_short_fill_data(smsg_header + 1, header, payload, length,
+                           UCS_ARCH_MEMCPY_NT_NONE);
 
     uct_iface_trace_am(&iface->super.super, UCT_AM_TRACE_TYPE_SEND,
                        id, smsg_header + 1, length, "TX: AM_SHORT");

--- a/src/uct/ugni/udt/ugni_udt_ep.c
+++ b/src/uct/ugni/udt/ugni_udt_ep.c
@@ -1,6 +1,7 @@
 /**
 * Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -187,7 +188,7 @@ uct_ugni_udt_ep_am_common_send(const unsigned is_short, uct_ugni_udt_ep_t *ep, u
 
     if (is_short) {
         uct_am_short_fill_data(uct_ugni_udt_get_spayload(desc, iface),
-                               header, payload, length);
+                               header, payload, length, UCS_ARCH_MEMCPY_NT_NONE);
         sheader->length = length + sizeof(header);
         msg_length      = sheader->length + sizeof(*sheader);
         UCT_TL_EP_STAT_OP(ucs_derived_of(ep, uct_base_ep_t), AM, SHORT, sizeof(header) + length);

--- a/test/gtest/ucs/arch/test_x86_64.cc
+++ b/test/gtest/ucs/arch/test_x86_64.cc
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -21,7 +22,7 @@ protected:
      * not be used as template argument */
     static inline void *memcpy_relaxed(void *dst, const void *src, size_t size)
     {
-        return ucs_memcpy_relaxed(dst, src, size);
+        return ucs_memcpy_relaxed(dst, src, size, UCS_ARCH_MEMCPY_NT_NONE, size);
     }
 
     template <void* (C)(void*, const void*, size_t)>
@@ -61,6 +62,60 @@ protected:
         munmap(src, size);
     out:
         return result;
+    }
+
+    void nt_buffer_transfer_test(ucs_arch_memcpy_hint_t hint) {
+#ifndef __AVX__
+        UCS_TEST_SKIP_R("Built without AVX support");
+#else
+        int i, j, result;
+        char *test_window_src, *test_window_dst, *src, *dst, *dup;
+        size_t len, total_size, test_window_size, hole_size, align;
+
+        align            = 64;
+        test_window_size = 2 * 1024;
+        hole_size        = 2 * align;
+
+        /*
+         * Allocate a hole above and below the test_window_size
+         * to check for writes beyond the designated area.
+         */
+        total_size = test_window_size + (2 * hole_size);
+
+        posix_memalign((void **)&test_window_src, align, total_size);
+        posix_memalign((void **)&test_window_dst, align, total_size);
+        posix_memalign((void **)&dup, align, total_size);
+
+        src = test_window_src + hole_size;
+        dst = test_window_dst + hole_size;
+
+        /* Initialize the regions with known patterns */
+        memset(dup, 0x0, total_size);
+        memset(test_window_src, 0xdeaddead, total_size);
+        memset(test_window_dst, 0x0, total_size);
+
+        for (len = 0; len < test_window_size; len++) {
+            for (i = 0; i < align; i++) {
+                for (j = 0; j < align; j++) {
+                    /* Perform the transfer */
+                    ucs_x86_nt_buffer_transfer(dst + i, src + j, len, hint, len);
+                    result = memcmp(src + j, dst + i, len);
+                    EXPECT_EQ(0, result);
+
+                    /* reset the copied region back to zero */
+                    memset(dst + i, 0x0, len);
+
+                    /* check for any modifications in the holes */
+                    result = memcmp(test_window_dst, dup, total_size);
+                    EXPECT_EQ(0, result);
+                }
+            }
+        }
+
+        free(test_window_src);
+        free(test_window_dst);
+        free(dup);
+#endif
     }
 };
 
@@ -102,4 +157,17 @@ UCS_TEST_SKIP_COND_F(test_arch, memcpy, RUNNING_ON_VALGRIND || !ucs::perf_retry_
     }
 }
 
+UCS_TEST_F(test_arch, nt_buffer_transfer_nt_src) {
+    nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
+}
+
+UCS_TEST_F(test_arch, nt_buffer_transfer_nt_dst) {
+    nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_DEST);
+}
+
+UCS_TEST_F(test_arch, nt_buffer_transfer_nt_src_dst) {
+    /* Make nt_dest_threshold zero to test the combination of hints */
+    ucs_global_opts.arch.nt_dest_threshold = 0;
+    nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
+}
 #endif


### PR DESCRIPTION
Processors based on AMD's Zen 3/4 architecture typically organize CPU cores into clusters of 8 or more cores. Within each cluster, these cores share a unified L3 cache, optimizing data transfer speeds among them. However, when data needs to travel between cores located in different clusters that do not share a common L3 cache, the transfer speed can be significantly reduced, potentially becoming 2-3 orders of magnitude slower.

To leverage this microarchitecture effectively
MPI applications often employ 'n-ranks X m-threads' configuration.

   n <= Number of unified L3caches in system
   m >= Number of cores within a cluster

When UCX is used as the underlying data transfer mechanism, depending on the rendezvous threshold two ranks/processes use either CICO(copy-in copy-out) or SCOPY(single copy) to move data between them in an intra-node scenario.
This patch improves the data transfer speed/application-performance on AMD's Zen 3/4 architecture for both CICO and SCOPY when sender and receiver processes are pinned to cores that don't share a common L3 cache.

a)CICO

              Sender                      Receiver
         +-------------+               +------------+
         +.............+               +............+
         +    sbuf     +               +   rbuf     +
         +.............+               +............+
         +             +               +            +
         +             +               +            +
         +             +               +            +
         +.............+>>>>>>>>>>>>>>>+............+
         +   rshmem    +  POSIX/SYSV   +            +
         +   mapped    +   mapping     +  rshmem    +
         +   area      +               +            +
         +.............+<<<<<<<<<<<<<<<+............+
         +             +               +            +
         +-------------+               +------------+

In the current method, the sender process first moves the data from source buffer(sbuf) to the remote shared memory (rshmem) using the glibc's memcpy and informs the receiver process about the presence of new data. The receiver process then proceeds to copy the data from rshmem to its local buffer(rbuf) once again utilizing glibc's memcpy, thus completing the transfer.

In contrast, the new approach optimizes this by using distinct memory copy techniques. It utilizes
'nontemporal store' or 'store with PREFETCHNTA' when copying data from sbuf to rshmem and employs 'loads with PREFETCHNTA' when copying data from rshmem to rbuf. This optimization effectively reduces data transfer latency by circumventing cache-to-cache data transfers, which tend to be slower, especially when cores are situated in different clusters. Additionally, this method helps in minimizing cache pollution on both the sender and receiver sides,
further enhancing overall performance.

b)SCOPY (only xpmem is considered as other methods use memcpy inside kernel)

              Sender                          Receiver
         +-------------+               +--------------------+
         +             +               +....................+
         +             +               +       rbuf         +
         +             +               +....................+
         +             +               +                    +
         +             +               +                    +
         +             +               +                    +
         +.............+>>>>>>>>>>>>>>>+....................+
         +    sbuf     +               +   sbuf_xpmem_map   +
         +.............+>>>>>>>>>>>>>>>+                    +
         +             +               + physical pages of  +
         +             +               + sbuf mapped to     +
         +             +               + receiver's virtual +
         +             +               + memory by fault    +
         +             +               + handler in xpmem.ko+
         +             +               +....................+
         +             +               +                    +
         +             +               +                    +
         +-------------+               +--------------------+

The new method replaces glibc's memcpy of the receiver's data from sbuf_xpmem_map (src) to rbuf (dst) with 'loads with PREFETCHNTA'. This minimizes cache pollution inside receiver's core(sbuf pages are mapped with rw flags in the receiver process).


Acked-by: Edgar Gabriel <edgar.gabriel@amd.com>


How to build
---------------
use "--enable-builtin-memcpy=no  --enable-optimizations --enable-nt-buffer-transfer" while configuring  

Eg:
$./contrib/configure-release --prefix=/install_path --with-xpmem=/xpmem_path  --enable-builtin-memcpy=no  --enable-optimizations --enable-nt-buffer-transfer

How to run
-------------
During mpirun nt-buffer-transfer is dynamically selected according to the table below.

![ntbt_selection_criteria](https://github.com/openucx/ucx/assets/146521248/48b30c71-92e4-4296-9f74-571296c2abe2)


use "-x UCX_NT_BUFFER_TRANSFER_MIN=0" during mpirun for a workload that doesn't have more than one rank in the L3 domain

Below is the comparison of latency when two ranks are in 2 different numa domains (From a Milan:Zen3 node)
-------------------------------------------------------------------------------------------------------------------------

cmd: mpirun -np 2 --map-by numa --bind-to core --mca pml ucx  --mca opal_common_ucx_tls any --mca opal_common_ucx_devices any -x UCX_TLS=^ib -x UCX_NT_BUFFER_TRANSFER_MIN=0 ./osu_latency -m 1:268435456 -i 50000 -x 5000

![latancy_compare](https://github.com/openucx/ucx/assets/146521248/42f04dee-ef1c-4c93-bf4a-cf8e9a574d87)


**_Note: The default threshold values for selecting the nt-buffer-transfer for an individual transfer are set at 3/4 the size of L3 cache to address MPI Binding, where multiple ranks share a common L3 cache. If the MPI workload has only one rank in L3, nt-buffer-transfer can be used for all lengths, and the user can enforce this by passing "-x UCX_NT_BUFFER_TRANSFER_MIN=0" in the command line. ._**

--Arun