### PR TITLE
UCP/RNDV/TEST: Fix rndv counters expectation for protov2

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -82,15 +82,16 @@ static ucs_stats_class_t ucp_worker_stats_class = {
     .num_counters   = UCP_WORKER_STAT_LAST,
     .class_id       = UCS_STATS_CLASS_ID_INVALID,
     .counter_names  = {
-        [UCP_WORKER_STAT_TAG_RX_EAGER_MSG]         = "rx_eager_msg",
-        [UCP_WORKER_STAT_TAG_RX_EAGER_SYNC_MSG]    = "rx_sync_msg",
-        [UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP]   = "rx_eager_chunk_exp",
-        [UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP] = "rx_eager_chunk_unexp",
-        [UCP_WORKER_STAT_TAG_RX_RNDV_EXP]          = "rx_rndv_rts_exp",
-        [UCP_WORKER_STAT_TAG_RX_RNDV_UNEXP]        = "rx_rndv_rts_unexp",
-        [UCP_WORKER_STAT_TAG_RX_RNDV_GET_ZCOPY]    = "rx_rndv_get_zcopy",
-        [UCP_WORKER_STAT_TAG_RX_RNDV_SEND_RTR]     = "rx_rndv_send_rtr",
-        [UCP_WORKER_STAT_TAG_RX_RNDV_RKEY_PTR]     = "rx_rndv_rkey_ptr"
+        [UCP_WORKER_STAT_TAG_RX_EAGER_MSG]         = "tag_rx_eager_msg",
+        [UCP_WORKER_STAT_TAG_RX_EAGER_SYNC_MSG]    = "tag_rx_sync_msg",
+        [UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP]   = "tag_rx_eager_chunk_exp",
+        [UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP] = "tag_rx_eager_chunk_unexp",
+        [UCP_WORKER_STAT_RNDV_RX_EXP]              = "rndv_rx_exp",
+        [UCP_WORKER_STAT_RNDV_RX_UNEXP]            = "rndv_rx_unexp",
+        [UCP_WORKER_STAT_RNDV_PUT_ZCOPY]           = "rndv_put_zcopy",
+        [UCP_WORKER_STAT_RNDV_GET_ZCOPY]           = "rndv_get_zcopy",
+        [UCP_WORKER_STAT_RNDV_RTR]                 = "rndv_rtr",
+        [UCP_WORKER_STAT_RNDV_RKEY_PTR]            = "rndv_rkey_ptr"
     }
 };
 #endif

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -143,12 +143,13 @@ enum {
     UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_EXP,
     UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_UNEXP,
 
-    UCP_WORKER_STAT_TAG_RX_RNDV_EXP,
-    UCP_WORKER_STAT_TAG_RX_RNDV_UNEXP,
+    UCP_WORKER_STAT_RNDV_RX_EXP,
+    UCP_WORKER_STAT_RNDV_RX_UNEXP,
 
-    UCP_WORKER_STAT_TAG_RX_RNDV_GET_ZCOPY,
-    UCP_WORKER_STAT_TAG_RX_RNDV_SEND_RTR,
-    UCP_WORKER_STAT_TAG_RX_RNDV_RKEY_PTR,
+    UCP_WORKER_STAT_RNDV_PUT_ZCOPY,
+    UCP_WORKER_STAT_RNDV_GET_ZCOPY,
+    UCP_WORKER_STAT_RNDV_RTR,
+    UCP_WORKER_STAT_RNDV_RKEY_PTR,
 
     UCP_WORKER_STAT_LAST
 };
@@ -186,8 +187,8 @@ enum {
                              UCP_WORKER_STAT_TAG_RX_EAGER_CHUNK_##_is_exp, 1);
 
 #define UCP_WORKER_STAT_RNDV(_worker, _is_exp, _value) \
-    UCS_STATS_UPDATE_COUNTER((_worker)->stats, \
-                             UCP_WORKER_STAT_TAG_RX_RNDV_##_is_exp, _value);
+    UCS_STATS_UPDATE_COUNTER((_worker)->stats, UCP_WORKER_STAT_RNDV_##_is_exp, \
+                             _value);
 
 #define UCP_WORKER_STAT_TAG_OFFLOAD(_worker, _name) \
     UCS_STATS_UPDATE_COUNTER((_worker)->tm_offload_stats, \

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -432,7 +432,7 @@ static void ucp_rndv_req_send_rtr(ucp_request_t *rndv_req, ucp_request_t *rreq,
     ucp_request_reset_super(rndv_req);
     ucp_request_send_state_reset(rndv_req, NULL,
                                  UCP_REQUEST_SEND_PROTO_BCOPY_AM);
-    UCP_WORKER_STAT_RNDV(rndv_req->send.ep->worker, SEND_RTR, +1);
+    UCP_WORKER_STAT_RNDV(rndv_req->send.ep->worker, RTR, +1);
 
     rreq->recv.remote_req_id       = sender_req_id;
     rndv_req->send.lane            = ucp_ep_get_am_lane(rndv_req->send.ep);

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -62,6 +62,7 @@ static UCS_F_ALWAYS_INLINE void
 ucp_proto_rndv_put_common_complete(ucp_request_t *req)
 {
     ucp_trace_req(req, "rndv_put_common_complete");
+    UCP_WORKER_STAT_RNDV(req->send.ep->worker, PUT_ZCOPY, +1);
     ucp_proto_rndv_rkey_destroy(req);
     ucp_proto_request_zcopy_complete(req, req->send.state.uct_comp.status);
 }

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -100,7 +100,7 @@ static ucs_status_t ucp_proto_rndv_rtr_common_send(ucp_request_t *req)
                                                       rpriv->pack_cb, req,
                                                       max_rtr_size, NULL, 0);
     if (status == UCS_OK) {
-        UCP_WORKER_STAT_RNDV(worker, SEND_RTR, +1);
+        UCP_WORKER_STAT_RNDV(worker, RTR, +1);
     }
 
     return status;

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -159,7 +159,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_ptr_t ucp_tag_recv_common(
     if (ucs_unlikely(rdesc->flags & UCP_RECV_DESC_FLAG_RNDV)) {
         ucp_tag_rndv_matched(worker, req, ucp_tag_rndv_rts_from_rdesc(rdesc),
                              rdesc->length);
-        UCP_WORKER_STAT_RNDV(worker, UNEXP, 1);
+        UCP_WORKER_STAT_RNDV(worker, RX_UNEXP, 1);
         ucp_recv_desc_release(rdesc);
     } else {
         ucp_tag_recv_eager_multi(worker, req, rdesc);

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -45,7 +45,7 @@ ucs_status_t ucp_tag_rndv_process_rts(ucp_worker_h worker,
         ucp_tag_offload_try_cancel(worker, rreq, UCP_TAG_OFFLOAD_CANCEL_FORCE);
         ucp_tag_rndv_matched(worker, rreq, rts_hdr, length);
 
-        UCP_WORKER_STAT_RNDV(worker, EXP, 1);
+        UCP_WORKER_STAT_RNDV(worker, RX_EXP, 1);
         return UCS_OK;
     }
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1072,6 +1072,10 @@ public:
         return e.worker()->stats;
     }
 
+    unsigned get_tx_stat(unsigned counter) {
+        return UCS_STATS_GET_COUNTER(worker_stats(sender()), counter);
+    }
+
     unsigned get_rx_stat(unsigned counter) {
         return UCS_STATS_GET_COUNTER(worker_stats(receiver()), counter);
     }
@@ -1088,7 +1092,7 @@ public:
         return ucp_context_find_tl_md(receiver().ucph(), "xpmem") != NULL;
     }
 
-    bool has_get_zcopy() {
+    bool has_rma_zcopy() {
         return has_transport("rc_v") || has_transport("rc_x") ||
                has_transport("dc_x") ||
                (ucp_context_find_tl_md(receiver().ucph(), "cma")  != NULL) ||
@@ -1096,30 +1100,42 @@ public:
     }
 
     void validate_rndv_counters() {
-        unsigned get_zcopy = get_rx_stat(UCP_WORKER_STAT_TAG_RX_RNDV_GET_ZCOPY);
-        unsigned send_rtr  = get_rx_stat(UCP_WORKER_STAT_TAG_RX_RNDV_SEND_RTR);
-        unsigned rkey_ptr  = get_rx_stat(UCP_WORKER_STAT_TAG_RX_RNDV_RKEY_PTR);
+        unsigned get_zcopy = get_rx_stat(UCP_WORKER_STAT_RNDV_GET_ZCOPY);
+        unsigned put_zcopy = get_tx_stat(UCP_WORKER_STAT_RNDV_PUT_ZCOPY);
+        unsigned rtr       = get_rx_stat(UCP_WORKER_STAT_RNDV_RTR);
+        unsigned rkey_ptr  = get_rx_stat(UCP_WORKER_STAT_RNDV_RKEY_PTR);
 
-        UCS_TEST_MESSAGE << "get_zcopy: " << get_zcopy
-                         << " send_rtr: " << send_rtr
+        UCS_TEST_MESSAGE << "get_zcopy: " << get_zcopy << " rtr: " << rtr
                          << " rkey_ptr: " << rkey_ptr;
-        EXPECT_EQ(1, get_zcopy + send_rtr + rkey_ptr);
+        EXPECT_EQ(1, get_zcopy + rtr + rkey_ptr);
+        EXPECT_LE(put_zcopy, rtr);
 
-        if (has_xpmem() || is_self()) {
-            /* rkey_ptr expected to be selected if xpmem is available or self is being used */
-            EXPECT_EQ(1u, rkey_ptr);
-        } else if (has_get_zcopy() && !m_ucp_config->ctx.proto_enable) {
-            /* if any transports supports get_zcopy, expect it to be used */
-            EXPECT_EQ(1u, get_zcopy);
+        if (m_ucp_config->ctx.proto_enable) {
+            if (has_xpmem() || is_self() || has_rma_zcopy()) {
+                /* Expect one of the bulk transfer protocols */
+                EXPECT_EQ(1u, rkey_ptr + get_zcopy + put_zcopy);
+                return;
+            }
         } else {
-            /* Could be a transport which supports get_zcopy that wasn't
-             * accounted for, or fallback to RTR. In any case, rkey_ptr is not
-             * expected to be used.
-             */
-            EXPECT_EQ(1u, send_rtr + get_zcopy);
-        }
-    }
+            if (has_xpmem() || is_self()) {
+                /* rkey_ptr expected to be selected if xpmem is available or
+                   self is being used */
+                EXPECT_EQ(1u, rkey_ptr);
+                return;
+            }
 
+            if (has_rma_zcopy()) {
+                /* If any transports supports get_zcopy, expect it to be used */
+                EXPECT_EQ(1u, get_zcopy);
+                return;
+            }
+        }
+
+        /* Could be a transport which supports get_zcopy that wasn't accounted
+         * for, or fallback to RTR. Anyway, rkey_ptr is not expected to be used.
+         */
+        EXPECT_EQ(1u, rtr + get_zcopy);
+    }
 };
 
 
@@ -1174,16 +1190,14 @@ UCS_TEST_P(test_ucp_tag_stats, sync_unexpected, "RNDV_THRESH=1248576") {
 UCS_TEST_P(test_ucp_tag_stats, rndv_expected, "RNDV_THRESH=1000") {
     check_offload_support(false);
     test_run_xfer(true, true, true, false, false);
-    validate_counters(UCP_EP_STAT_TAG_TX_RNDV,
-                      UCP_WORKER_STAT_TAG_RX_RNDV_EXP);
+    validate_counters(UCP_EP_STAT_TAG_TX_RNDV, UCP_WORKER_STAT_RNDV_RX_EXP);
     validate_rndv_counters();
 }
 
 UCS_TEST_P(test_ucp_tag_stats, rndv_unexpected, "RNDV_THRESH=1000") {
     check_offload_support(false);
     test_run_xfer(true, true, false, false, false);
-    validate_counters(UCP_EP_STAT_TAG_TX_RNDV,
-                      UCP_WORKER_STAT_TAG_RX_RNDV_UNEXP);
+    validate_counters(UCP_EP_STAT_TAG_TX_RNDV, UCP_WORKER_STAT_RNDV_RX_UNEXP);
     validate_rndv_counters();
 }
 


### PR DESCRIPTION
## Why
Fix test failures like:
```
[ RUN      ] shm_ib/test_ucp_tag_stats.rndv_expected/0 <shm,ib>
[     INFO ] get_zcopy: 0 send_rtr: 1 rkey_ptr: 0
ucp/test_ucp_tag_xfer.cc:1110: Failure
Expected equality of these values:
  1u
    Which is: 1
  rkey_ptr
    Which is: 0
[  FAILED  ] shm_ib/test_ucp_tag_stats.rndv_expected/0, where GetParam() = shm,ib (270 ms)
```

The test failed because with protov2, when NIC bandwidth is high, xpmem is not selected for rendezvous.

Fixes internal issue [3581178](https://redmine.mellanox.com/issues/3581178)

## How
* Add put_zcopy rndv statistics counter
* With protov2, expect either put_zcopy/get_zcopy/rkey_ptr to be selected when have xpmem or zcopy support.