### PR TITLE
UCP/WIREUP: Don't select allocated memory access lanes for non-host

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -925,6 +925,12 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
         select_ctx->ucp_ep_init_flags |= UCP_EP_INIT_CREATE_AM_LANE;
     }
 
+    if (mem_type != UCS_MEMORY_TYPE_HOST) {
+        /* Select transports for allocated memory only for host mem, to keep
+           wire compatibility of lane selection */
+        return UCS_OK;
+    }
+
     /* Select additional transports which can access allocated memory, but
      * only if their scores are better. We need this because a remote memory
      * block can be potentially allocated using one of them, and we might get

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -16,6 +16,14 @@
 #include <uct/sm/base/sm_iface.h>
 
 
+/* Default overhead for iface_query, changing this value can break wire
+  compatibility */
+#define UCT_SCOPY_IFACE_DEFAULT_OVERHEAD 2e-6
+
+/* Overhead value used for estimate_perf */
+#define UCT_SCOPY_IFACE_OVERHEAD 500e-9
+
+
 ucs_config_field_t uct_scopy_iface_config_table[] = {
     {"SM_", "", NULL,
      ucs_offsetof(uct_scopy_iface_config_t, super),
@@ -84,7 +92,28 @@ void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_att
     iface_attr->latency                 = ucs_linear_func_make(80e-9, 0); /* 80 ns */
     iface_attr->overhead                = (ucs_arch_get_cpu_vendor() ==
                                            UCS_CPU_VENDOR_FUJITSU_ARM) ?
-                                          6e-6 : 500e-9;
+                                          6e-6 : UCT_SCOPY_IFACE_DEFAULT_OVERHEAD;
+}
+
+ucs_status_t
+uct_scopy_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+{
+    ucs_status_t status;
+
+    status = uct_base_iface_estimate_perf(iface, perf_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {
+        perf_attr->send_pre_overhead = UCT_SCOPY_IFACE_OVERHEAD;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_RECV_OVERHEAD) {
+        perf_attr->recv_overhead = UCT_SCOPY_IFACE_OVERHEAD;
+    }
+
+    return UCS_OK;
 }
 
 UCS_CLASS_INIT_FUNC(uct_scopy_iface_t, uct_iface_ops_t *ops,

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -61,6 +61,9 @@ typedef struct uct_scopy_iface_ops {
 
 void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr);
 
+ucs_status_t
+uct_scopy_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);
+
 UCS_CLASS_DECLARE(uct_scopy_iface_t, uct_iface_ops_t*, uct_scopy_iface_ops_t*,
                   uct_md_h, uct_worker_h, const uct_iface_params_t*,
                   const uct_iface_config_t*);

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -136,7 +136,7 @@ static uct_iface_ops_t uct_cma_iface_tl_ops = {
 
 static uct_scopy_iface_ops_t uct_cma_iface_ops = {
     .super = {
-        .iface_estimate_perf   = uct_base_iface_estimate_perf,
+        .iface_estimate_perf   = uct_scopy_iface_estimate_perf,
         .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
         .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -75,7 +75,7 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
 
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {
     .super = {
-        .iface_estimate_perf   = uct_base_iface_estimate_perf,
+        .iface_estimate_perf   = uct_scopy_iface_estimate_perf,
         .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
         .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,


### PR DESCRIPTION
## Why
Fix #9413 

## How
Avoid adding extra lanes for accessing RDMA memory type