### PR TITLE
UCP/HWTM: Fix memory corruption by proper memh handling in rndv cb

### DIFF
--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -230,9 +230,7 @@ ucp_datatype_iter_move(ucp_datatype_iter_t *dst_iter,
     }
 
     /* Invalidate source iterator */
-#if UCS_ENABLE_ASSERT
     src_iter->dt_class = UCP_DATATYPE_CLASS_MASK;
-#endif
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/tag/offload.c
+++ b/src/ucp/tag/offload.c
@@ -150,8 +150,9 @@ UCS_PROFILE_FUNC_VOID(ucp_tag_offload_rndv_cb,
 
     --req->recv.tag.wiface->post_count;
     if (ucs_unlikely(status != UCS_OK)) {
+        ucp_tag_offload_release_buf(req);
         ucp_request_complete_tag_recv(req, status);
-        goto out;
+        return;
     }
 
     ucs_assert(header_length >= sizeof(ucp_rndv_rts_hdr_t));
@@ -170,7 +171,6 @@ UCS_PROFILE_FUNC_VOID(ucp_tag_offload_rndv_cb,
                              header_length);
     }
 
-out:
     ucp_tag_offload_release_buf(req);
 }
 


### PR DESCRIPTION
## What
When tag offlowd SW rndv request complets in HW, UCP takes RVH from user buffer and handles it in SW. SW protocol copies memh from recv req (in `ucp_proto_rndv_receive_start`/`ucp_datatype_iter_move`), but this memh is later released in `ucp_tag_offload_rndv_cb`. Thus, need to deregister recv req memh in `ucp_tag_offload_rndv_cb` before handling this req in SW (`ucp_tag_rndv_matched`).

## Why ?
Fixes [RM3602178](https://redmine.mellanox.com/issues/3602178) ( (internal link))