### PR TITLE
AZP: rm non-existing img reference

### DIFF
--- a/buildlib/pr/cuda/cuda.yml
+++ b/buildlib/pr/cuda/cuda.yml
@@ -43,8 +43,6 @@ jobs:
           CONTAINER: centos7_cuda_11_3
         centos7_cuda_11_4:
           CONTAINER: centos7_cuda_11_4
-        centos8_cuda_11_0:
-          CONTAINER: centos8_cuda_11_0
         centos8_cuda_11_1:
           CONTAINER: centos8_cuda_11_1
         centos8_cuda_11_2:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -81,9 +81,6 @@ resources:
     - container: centos7_cuda_11_4
       image: nvidia/cuda:11.4.3-devel-centos7
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos8_cuda_11_0
-      image: nvidia/cuda:11.0.3-devel-centos8
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
     - container: centos8_cuda_11_1
       image: nvidia/cuda:11.1.1-devel-centos8
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)


### PR DESCRIPTION
## What
The image `nvidia/cuda:11.4.3-devel-centos` is no longer available at DockerHub.
