### PR TITLE
Add oneAPI Level-Zero (ZE) support

### DIFF
--- a/config/m4/ze.m4
+++ b/config/m4/ze.m4
@@ -1,0 +1,70 @@
+#
+# Copyright (c) Intel Corporation, 2023. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([UCX_CHECK_ZE],[
+
+AS_IF([test "x$ze_checked" != "xyes"],
+   [
+    AC_ARG_WITH([ze],
+                [AS_HELP_STRING([--with-ze=(DIR)], [Enable the use of ZE (default is guess).])],
+                [], [with_ze=guess])
+
+    AS_IF([test "x$with_ze" = "xno"],
+        [
+         ze_happy="no"
+        ],
+        [
+         save_CPPFLAGS="$CPPFLAGS"
+         save_LDFLAGS="$LDFLAGS"
+         save_LIBS="$LIBS"
+
+         ZE_CPPFLAGS=""
+         ZE_LDFLAGS=""
+         ZE_LIBS=""
+
+         AS_IF([test ! -z "$with_ze" -a "x$with_ze" != "xyes" -a "x$with_ze" != "xguess"],
+               [ucx_check_ze_dir="$with_ze"
+                AS_IF([test -d "$with_ze/lib64"], [libsuff="64"], [libsuff=""])
+                ucx_check_ze_libdir="$with_ze/lib$libsuff"
+                ZE_CPPFLAGS="-I$with_ze/include"
+                ZE_LDFLAGS="-L$ucx_check_ze_libdir -L$ucx_check_ze_libdir/stubs"])
+
+         AS_IF([test ! -z "$with_ze_libdir" -a "x$with_ze_libdir" != "xyes"],
+               [ucx_check_ze_libdir="$with_ze_libdir"
+                ZE_LDFLAGS="-L$ucx_check_ze_libdir -L$ucx_check_ze_libdir/stubs"])
+
+         CPPFLAGS="$CPPFLAGS $ZE_CPPFLAGS"
+         LDFLAGS="$LDFLAGS $ZE_LDFLAGS"
+
+         # Check ze header files
+         AC_CHECK_HEADERS([level_zero/ze_api.h],
+                          [ze_happy="yes"], [ze_happy="no"])
+
+         # Check ze libraries
+         AS_IF([test "x$ze_happy" = "xyes"],
+               [AC_CHECK_LIB([ze_loader], [zeInit],
+                             [ZE_LIBS="$ZE_LIBS -lze_loader"], [ze_happy="no"])])
+
+         CPPFLAGS="$save_CPPFLAGS"
+         LDFLAGS="$save_LDFLAGS"
+         LIBS="$save_LIBS"
+
+         AS_IF([test "x$ze_happy" = "xyes"],
+               [AC_SUBST([ZE_CPPFLAGS], ["$ZE_CPPFLAGS"])
+                AC_SUBST([ZE_LDFLAGS], ["$ZE_LDFLAGS"])
+                AC_SUBST([ZE_LIBS], ["$ZE_LIBS"])
+                AC_DEFINE([HAVE_ZE], 1, [Enable ZE support])],
+               [AS_IF([test "x$with_ze" != "xguess"],
+                      [AC_MSG_ERROR([ZE support is requested but ze packages cannot be found])],
+                      [AC_MSG_WARN([ZE not found])])])
+
+        ]) # "x$with_ze" = "xno"
+
+        ze_checked=yes
+        AM_CONDITIONAL([HAVE_ZE], [test "x$ze_happy" != xno])
+
+   ]) # "x$ze_checked" != "xyes"
+
+]) # UCX_CHECK_ZE

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@
 # Copyright (C) The University of Tennessee and The University
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016-2019.  ALL RIGHTS RESERVED.
+# Copyright (C) Intel Corporation. 2023.  ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 AC_PREREQ([2.63])
@@ -224,6 +225,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([IODEMO_CUDA], [false])
      AM_CONDITIONAL([HAVE_GCOV], [false])
      AM_CONDITIONAL([HAVE_LCOV], [false])
+     AM_CONDITIONAL([HAVE_ZE], [false])
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])
@@ -236,6 +238,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/java.m4])
      m4_include([config/m4/cuda.m4])
      m4_include([config/m4/rocm.m4])
+     m4_include([config/m4/ze.m4])
      m4_include([config/m4/gdrcopy.m4])
      m4_include([config/m4/mad.m4])
      m4_include([config/m4/lcov.m4])

--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -5,11 +5,12 @@
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 # Copyright (C) NextSilicon Ltd. 2021.  ALL RIGHTS RESERVED.
+# Copyright (c) Intel Corporation, 2023. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
 
-SUBDIRS = cuda rocm lib mad
+SUBDIRS = cuda rocm ze lib mad
 CC      = $(UCX_PERFTEST_CC)
 
 noinst_HEADERS = \

--- a/src/tools/perf/configure.m4
+++ b/src/tools/perf/configure.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2024. ALL RIGHTS RESERVED.
+# Copyright (c) Intel Corporation, 2023. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -8,6 +9,7 @@ ucx_perftest_modules=""
 m4_include([src/tools/perf/lib/configure.m4])
 m4_include([src/tools/perf/cuda/configure.m4])
 m4_include([src/tools/perf/rocm/configure.m4])
+m4_include([src/tools/perf/ze/configure.m4])
 m4_include([src/tools/perf/mad/configure.m4])
 AC_DEFINE_UNQUOTED([ucx_perftest_MODULES], ["${ucx_perftest_modules}"],
                    [Perftest loadable modules])

--- a/src/tools/perf/ze/Makefile.am
+++ b/src/tools/perf/ze/Makefile.am
@@ -1,0 +1,17 @@
+#
+# Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+if HAVE_ZE
+
+module_LTLIBRARIES             = libucx_perftest_ze.la
+libucx_perftest_ze_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ZE_CPPFLAGS)
+libucx_perftest_ze_la_CFLAGS   = $(BASE_CFLAGS) $(ZE_CFLAGS)
+libucx_perftest_ze_la_LDFLAGS  = $(ZE_LDFLAGS) $(ZE_LIBS) -version-info $(SOVERSION)
+libucx_perftest_ze_la_SOURCES  = ze_alloc.c
+
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/tools/perf/ze/configure.m4
+++ b/src/tools/perf/ze/configure.m4
@@ -1,0 +1,11 @@
+#
+# Copyright (C) Intel Corporation, 2023.  ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+UCX_CHECK_ZE
+
+AS_IF([test "x$ze_happy" = "xyes"], [ucx_perftest_modules="${ucx_perftest_modules}:ze"])
+
+AC_CONFIG_FILES([src/tools/perf/ze/Makefile])

--- a/src/tools/perf/ze/ze_alloc.c
+++ b/src/tools/perf/ze/ze_alloc.c
@@ -1,0 +1,264 @@
+/**
+ * Copyright (C) Intel Corporation, 2023-2024.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <tools/perf/lib/libperf_int.h>
+
+#include <level_zero/ze_api.h>
+#include <ucs/sys/compiler.h>
+
+#define UCX_PERF_ZE_MAX_DEVICES 4
+
+static const size_t gpu_page_size = 65536;
+static ze_driver_handle_t gpu_driver;
+static ze_context_handle_t gpu_context;
+static ze_device_handle_t gpu_devices[UCX_PERF_ZE_MAX_DEVICES];
+static ze_command_list_handle_t gpu_cmdlists[UCX_PERF_ZE_MAX_DEVICES];
+static unsigned gpu_count;
+static unsigned gpu_index;
+static int ze_initialized;
+
+static ze_result_t ze_init_devices(void)
+{
+    ze_context_desc_t ctxt_desc = {};
+    ze_result_t ret;
+    uint32_t count;
+
+    if (ze_initialized)
+        return ZE_RESULT_SUCCESS;
+
+    ret = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    count = 1;
+    ret   = zeDriverGet(&count, &gpu_driver);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    count = UCX_PERF_ZE_MAX_DEVICES;
+    ret = zeDeviceGet(gpu_driver, &count, gpu_devices);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    ret = zeContextCreate(gpu_driver, &ctxt_desc, &gpu_context);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    gpu_count = count;
+    ze_initialized = 1;
+    return ZE_RESULT_SUCCESS;
+}
+
+static ucs_status_t ucx_perf_ze_init(ucx_perf_context_t *perf)
+{
+    ze_command_queue_desc_t cmdq_desc = {
+        .stype    = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+        .ordinal  = 0,
+        .index    = 0,
+        .flags    = 0,
+        .mode     = ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS,
+        .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+    };
+    unsigned group_index, i;
+    ze_result_t ret;
+
+    ret = ze_init_devices();
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    group_index = rte_call(perf, group_index);
+    i           = group_index % gpu_count;
+
+    if (!gpu_cmdlists[i]) {
+        ret = zeCommandListCreateImmediate(gpu_context, gpu_devices[i],
+                                           &cmdq_desc, &gpu_cmdlists[i]);
+        if (ret != ZE_RESULT_SUCCESS) {
+            return UCS_ERR_NO_DEVICE;
+        }
+    }
+
+    gpu_index = i;
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucx_perf_ze_alloc(size_t length, ucs_memory_type_t mem_type, void **address_p)
+{
+    ze_device_mem_alloc_desc_t dev_desc = {};
+    ze_host_mem_alloc_desc_t host_desc  = {};
+    ze_result_t ret;
+
+    ucs_assert((mem_type == UCS_MEMORY_TYPE_ZE_HOST) ||
+               (mem_type == UCS_MEMORY_TYPE_ZE_DEVICE) ||
+               (mem_type == UCS_MEMORY_TYPE_ZE_MANAGED));
+
+    if (mem_type == UCS_MEMORY_TYPE_ZE_HOST)
+        ret = zeMemAllocHost(gpu_context, &host_desc, length, gpu_page_size,
+                             address_p);
+    else if (mem_type == UCS_MEMORY_TYPE_ZE_DEVICE)
+        ret = zeMemAllocDevice(gpu_context, &dev_desc, length, gpu_page_size,
+                               gpu_devices[0], address_p);
+    else
+        ret = zeMemAllocShared(gpu_context, &dev_desc, &host_desc, length,
+                               gpu_page_size, gpu_devices[0], address_p);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucs_error("failed to allocate memory");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_perf_ze_alloc_reg_mem(const ucx_perf_context_t *perf, size_t length,
+                          ucs_memory_type_t mem_type, unsigned flags,
+                          uct_allocated_memory_t *alloc_mem)
+{
+    ucs_status_t status;
+
+    status = ucx_perf_ze_alloc(length, mem_type, &alloc_mem->address);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_md_mem_reg(perf->uct.md, alloc_mem->address, length, flags,
+                            &alloc_mem->memh);
+    if (status != UCS_OK) {
+        zeMemFree(gpu_context, alloc_mem->address);
+        ucs_error("failed to register memory");
+        return status;
+    }
+
+    alloc_mem->mem_type = mem_type;
+    alloc_mem->md       = perf->uct.md;
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_perf_ze_host_alloc(const ucx_perf_context_t *perf,
+                                           size_t length, unsigned flags,
+                                           uct_allocated_memory_t *alloc_mem)
+{
+    return uct_perf_ze_alloc_reg_mem(perf, length, UCS_MEMORY_TYPE_ZE_HOST,
+                                     flags, alloc_mem);
+}
+
+static ucs_status_t uct_perf_ze_device_alloc(const ucx_perf_context_t *perf,
+                                             size_t length, unsigned flags,
+                                             uct_allocated_memory_t *alloc_mem)
+{
+    return uct_perf_ze_alloc_reg_mem(perf, length, UCS_MEMORY_TYPE_ZE_DEVICE,
+                                     flags, alloc_mem);
+}
+
+static ucs_status_t uct_perf_ze_managed_alloc(const ucx_perf_context_t *perf,
+                                              size_t length, unsigned flags,
+                                              uct_allocated_memory_t *alloc_mem)
+{
+    return uct_perf_ze_alloc_reg_mem(perf, length, UCS_MEMORY_TYPE_ZE_MANAGED,
+                                     flags, alloc_mem);
+}
+
+static void uct_perf_ze_free(const ucx_perf_context_t *perf,
+                             uct_allocated_memory_t *alloc_mem)
+{
+    ucs_status_t status;
+
+    ucs_assert(alloc_mem->md == perf->uct.md);
+
+    status = uct_md_mem_dereg(perf->uct.md, alloc_mem->memh);
+    if (status != UCS_OK) {
+        ucs_error("failed to deregister memory");
+    }
+
+    zeMemFree(gpu_context, alloc_mem->address);
+}
+
+static void ucx_perf_ze_memcpy(void *dst, ucs_memory_type_t dst_mem_type,
+                               const void *src, ucs_memory_type_t src_mem_type,
+                               size_t count)
+{
+    ze_result_t ret;
+
+    ret = zeCommandListAppendMemoryCopy(gpu_cmdlists[gpu_index], dst, src,
+                                        count, NULL, 0, NULL);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucs_error("failed to copy memory: error code %x", ret);
+    }
+
+    ret = zeCommandListReset(gpu_cmdlists[gpu_index]);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucs_error("failed to reset command list: error code %x", ret);
+    }
+}
+
+static void *ucx_perf_ze_memset(void *dst, int value, size_t count)
+{
+    ze_result_t ret;
+
+    ret = zeCommandListAppendMemoryFill(gpu_cmdlists[gpu_index], dst, &value, 1,
+                                        count, NULL, 0, NULL);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucs_error("failed to set memory: error code %x", ret);
+    }
+
+    ret = zeCommandListReset(gpu_cmdlists[gpu_index]);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucs_error("failed to reset command list: error code %x", ret);
+    }
+
+    return dst;
+}
+
+UCS_STATIC_INIT
+{
+    static ucx_perf_allocator_t ze_host_allocator    = {
+        .mem_type  = UCS_MEMORY_TYPE_ZE_HOST,
+        .init      = ucx_perf_ze_init,
+        .uct_alloc = uct_perf_ze_host_alloc,
+        .uct_free  = uct_perf_ze_free,
+        .memcpy    = ucx_perf_ze_memcpy,
+        .memset    = ucx_perf_ze_memset
+    };
+    static ucx_perf_allocator_t ze_device_allocator  = {
+        .mem_type  = UCS_MEMORY_TYPE_ZE_DEVICE,
+        .init      = ucx_perf_ze_init,
+        .uct_alloc = uct_perf_ze_device_alloc,
+        .uct_free  = uct_perf_ze_free,
+        .memcpy    = ucx_perf_ze_memcpy,
+        .memset    = ucx_perf_ze_memset
+    };
+    static ucx_perf_allocator_t ze_managed_allocator = {
+        .mem_type  = UCS_MEMORY_TYPE_ZE_MANAGED,
+        .init      = ucx_perf_ze_init,
+        .uct_alloc = uct_perf_ze_managed_alloc,
+        .uct_free  = uct_perf_ze_free,
+        .memcpy    = ucx_perf_ze_memcpy,
+        .memset    = ucx_perf_ze_memset
+    };
+
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_ZE_HOST] = &ze_host_allocator;
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_ZE_DEVICE] =
+            &ze_device_allocator;
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_ZE_MANAGED] =
+            &ze_managed_allocator;
+}
+
+UCS_STATIC_CLEANUP
+{
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_ZE_HOST]    = NULL;
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_ZE_DEVICE]  = NULL;
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_ZE_MANAGED] = NULL;
+}

--- a/src/ucm/Makefile.am
+++ b/src/ucm/Makefile.am
@@ -1,11 +1,12 @@
 #
 # Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
 # Copyright (c) UT-Battelle, LLC. 2017. ALL RIGHTS RESERVED.
+# Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
 
-SUBDIRS = . cuda rocm
+SUBDIRS = . cuda rocm ze
 
 lib_LTLIBRARIES    = libucm.la
 libucm_ladir       = $(includedir)/ucm

--- a/src/ucm/configure.m4
+++ b/src/ucm/configure.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
+# Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
@@ -31,6 +32,7 @@ LDFLAGS="$SAVE_LDFLAGS"
 ucm_modules=""
 m4_include([src/ucm/cuda/configure.m4])
 m4_include([src/ucm/rocm/configure.m4])
+m4_include([src/ucm/ze/configure.m4])
 AC_DEFINE_UNQUOTED([ucm_MODULES], ["${ucm_modules}"], [UCM loadable modules])
 
 AC_CONFIG_FILES([src/ucm/Makefile])

--- a/src/ucm/ze/Makefile.am
+++ b/src/ucm/ze/Makefile.am
@@ -1,0 +1,25 @@
+#
+# Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+if HAVE_ZE
+
+module_LTLIBRARIES    = libucm_ze.la
+libucm_ze_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ZE_CPPFLAGS)
+libucm_ze_la_CFLAGS   = $(BASE_CFLAGS) $(ZE_CFLAGS)
+libucm_ze_la_LIBADD   = ../libucm.la $(ZE_LIBS)
+libucm_ze_la_LDFLAGS  = $(UCM_MODULE_LDFLAGS) \
+                          $(patsubst %, -Xlinker %, $(ZE_LDFLAGS)) \
+                          -version-info $(SOVERSION)
+
+noinst_HEADERS = \
+	zemem.h
+
+libucm_ze_la_SOURCES = \
+	zemem.c
+
+include $(top_srcdir)/config/module.am
+
+endif

--- a/src/ucm/ze/configure.m4
+++ b/src/ucm/ze/configure.m4
@@ -1,0 +1,9 @@
+#
+# Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
+#
+# See file LICENSE for terms.
+#
+
+UCX_CHECK_ZE
+AS_IF([test "x$ze_happy" = "xyes"], [ucm_modules="${ucm_modules}:ze"])
+AC_CONFIG_FILES([src/ucm/ze/Makefile])

--- a/src/ucm/ze/zemem.c
+++ b/src/ucm/ze/zemem.c
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "zemem.h"
+#include <ucm/event/event.h>
+#include <ucm/util/log.h>
+#include <ucm/util/reloc.h>
+#include <ucm/util/replace.h>
+#include <ucs/debug/assert.h>
+#include <ucm/util/sys.h>
+#include <ucs/sys/compiler.h>
+#include <ucs/sys/preprocessor.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+UCM_DEFINE_REPLACE_DLSYM_FUNC(zeMemAllocHost, ze_result_t, -1,
+                              ze_context_handle_t,
+                              const ze_host_mem_alloc_desc_t*, size_t, size_t,
+                              void**)
+UCM_DEFINE_REPLACE_DLSYM_FUNC(zeMemAllocDevice, ze_result_t, -1,
+                              ze_context_handle_t,
+                              const ze_device_mem_alloc_desc_t*, size_t, size_t,
+                              ze_device_handle_t, void**)
+UCM_DEFINE_REPLACE_DLSYM_FUNC(zeMemAllocShared, ze_result_t, -1,
+                              ze_context_handle_t,
+                              const ze_device_mem_alloc_desc_t*,
+                              const ze_host_mem_alloc_desc_t*, size_t, size_t,
+                              ze_device_handle_t, void**)
+UCM_DEFINE_REPLACE_DLSYM_FUNC(zeMemFree, ze_result_t, -1, ze_context_handle_t,
+                              void*)
+
+static UCS_F_ALWAYS_INLINE void
+ucm_dispatch_mem_type_alloc(void *addr, size_t length,
+                            ucs_memory_type_t mem_type)
+{
+    ucm_event_t event;
+
+    event.mem_type.address  = addr;
+    event.mem_type.size     = length;
+    event.mem_type.mem_type = mem_type;
+    ucm_event_dispatch(UCM_EVENT_MEM_TYPE_ALLOC, &event);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucm_dispatch_mem_type_free(void *addr, size_t length,
+                           ucs_memory_type_t mem_type)
+{
+    ucm_event_t event;
+
+    event.mem_type.address  = addr;
+    event.mem_type.size     = length;
+    event.mem_type.mem_type = mem_type;
+    ucm_event_dispatch(UCM_EVENT_MEM_TYPE_FREE, &event);
+}
+
+static void
+ucm_zeMemFree_dispatch_events(ze_context_handle_t ze_context, void *ptr)
+{
+    ze_result_t ret;
+    size_t size = 1; /* minimum size by default */
+    ucs_memory_type_t mem_type;
+    ze_memory_allocation_properties_t props = {};
+
+    if (ptr == NULL) {
+        return;
+    }
+
+    ret = zeMemGetAllocProperties(ze_context, ptr, &props, NULL);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucm_warn("zeMemGetAllocProperties(ptr=%p) failed", ptr);
+        mem_type = UCS_MEMORY_TYPE_HOST;
+    } else {
+        switch (props.type) {
+        case ZE_MEMORY_TYPE_HOST:
+            mem_type = UCS_MEMORY_TYPE_ZE_HOST;
+            break;
+        case ZE_MEMORY_TYPE_DEVICE:
+            mem_type = UCS_MEMORY_TYPE_ZE_DEVICE;
+            break;
+        case ZE_MEMORY_TYPE_SHARED:
+            mem_type = UCS_MEMORY_TYPE_ZE_MANAGED;
+            break;
+        default:
+            mem_type = UCS_MEMORY_TYPE_HOST;
+            break;
+        }
+        (void)zeMemGetAddressRange(ze_context, ptr, NULL, &size);
+    }
+
+out:
+    ucm_dispatch_mem_type_free(ptr, size, mem_type);
+}
+
+ze_result_t ucm_zeMemAllocHost(ze_context_handle_t context,
+                               const ze_host_mem_alloc_desc_t *host_desc,
+                               size_t size, size_t alignment, void **ptr)
+{
+    ze_result_t ret;
+
+    ucm_event_enter();
+
+    ret = ucm_orig_zeMemAllocHost(context, host_desc, size, alignment, ptr);
+    if (ret == ZE_RESULT_SUCCESS) {
+        ucm_trace("ucm_zeMemAllocHost(ptr=%p size:%lu)", *ptr, size);
+        ucm_dispatch_mem_type_alloc(*ptr, size, UCS_MEMORY_TYPE_ZE_HOST);
+    }
+
+    ucm_event_leave();
+    return ret;
+}
+
+ze_result_t ucm_zeMemAllocDevice(ze_context_handle_t context,
+                                 const ze_device_mem_alloc_desc_t *device_desc,
+                                 size_t size, size_t alignment,
+                                 ze_device_handle_t device, void **ptr)
+{
+    ze_result_t ret;
+
+    ucm_event_enter();
+
+    ret = ucm_orig_zeMemAllocDevice(context, device_desc, size, alignment,
+                                    device, ptr);
+    if (ret == ZE_RESULT_SUCCESS) {
+        ucm_trace("ucm_zeMemAllocDevice(ptr=%p size:%lu)", *ptr, size);
+        ucm_dispatch_mem_type_alloc(*ptr, size, UCS_MEMORY_TYPE_ZE_DEVICE);
+    }
+
+    ucm_event_leave();
+    return ret;
+}
+
+ze_result_t ucm_zeMemAllocShared(ze_context_handle_t context,
+                                 const ze_device_mem_alloc_desc_t *device_desc,
+                                 const ze_host_mem_alloc_desc_t *host_desc,
+                                 size_t size, size_t alignment,
+                                 ze_device_handle_t device, void **ptr)
+{
+    ze_result_t ret;
+
+    ucm_event_enter();
+
+    ret = ucm_orig_zeMemAllocShared(context, device_desc, host_desc, size,
+                                    alignment, device, ptr);
+    if (ret == ZE_RESULT_SUCCESS) {
+        ucm_trace("ucm_zeMemAllocShared(ptr=%p size:%lu)", *ptr, size);
+        ucm_dispatch_mem_type_alloc(*ptr, size, UCS_MEMORY_TYPE_ZE_MANAGED);
+    }
+
+    ucm_event_leave();
+    return ret;
+}
+
+ze_result_t ucm_zeMemFree(ze_context_handle_t context, void *ptr)
+{
+    ze_result_t ret;
+
+    ucm_event_enter();
+
+    ucm_trace("ucm_zeMemFree(context=%p, ptr=%p)", context, ptr);
+
+    ucm_zeMemFree_dispatch_events(context, ptr);
+
+    ret = ucm_orig_zeMemFree(context, ptr);
+
+    ucm_event_leave();
+    return ret;
+}
+
+static ucm_reloc_patch_t patches[] = {{"zeMemAllocHost", ucm_zeMemAllocHost},
+                                      {"zeMemAllocDevice",
+                                       ucm_zeMemAllocDevice},
+                                      {"zeMemAllocShared",
+                                       ucm_zeMemAllocShared},
+                                      {"zeMemFree", ucm_zeMemFree},
+                                      {NULL, NULL}};
+
+static ucs_status_t ucm_zemem_install(int events)
+{
+    static int ucm_zemem_installed       = 0;
+    static pthread_mutex_t install_mutex = PTHREAD_MUTEX_INITIALIZER;
+    ucm_reloc_patch_t *patch;
+    ucs_status_t status = UCS_OK;
+
+    if (!(events & (UCM_EVENT_MEM_TYPE_ALLOC | UCM_EVENT_MEM_TYPE_FREE))) {
+        goto out;
+    }
+
+    pthread_mutex_lock(&install_mutex);
+
+    if (ucm_zemem_installed) {
+        goto out_unlock;
+    }
+
+    for (patch = patches; patch->symbol != NULL; ++patch) {
+        status = ucm_reloc_modify(patch);
+        if (status != UCS_OK) {
+            ucm_warn("failed to install relocation table entry for '%s'",
+                     patch->symbol);
+            goto out_unlock;
+        }
+    }
+
+    ucm_info("ze hooks are ready");
+    ucm_zemem_installed = 1;
+
+out_unlock:
+    pthread_mutex_unlock(&install_mutex);
+out:
+    return status;
+}
+
+static int ucm_zemem_scan_regions_cb(void *arg, void *addr, size_t length,
+                                     int prot, const char *path)
+{
+    static const char *ze_path_pattern = "/dev/dri";
+    ucm_event_handler_t *handler       = arg;
+    ucm_event_t event;
+
+    if ((prot & (PROT_READ | PROT_WRITE | PROT_EXEC)) &&
+        strncmp(path, ze_path_pattern, strlen(ze_path_pattern))) {
+        return 0;
+    }
+
+    ucm_debug("dispatching initial memtype allocation for %p..%p %s", addr,
+              UCS_PTR_BYTE_OFFSET(addr, length), path);
+
+    event.mem_type.address  = addr;
+    event.mem_type.size     = length;
+    event.mem_type.mem_type = UCS_MEMORY_TYPE_LAST; /* unknown memory type */
+
+    ucm_event_enter();
+    handler->cb(UCM_EVENT_MEM_TYPE_ALLOC, &event, handler->arg);
+    ucm_event_leave();
+
+    return 0;
+}
+
+static void ucm_zemem_get_existing_alloc(ucm_event_handler_t *handler)
+{
+    if (handler->events & UCM_EVENT_MEM_TYPE_ALLOC) {
+        ucm_parse_proc_self_maps(ucm_zemem_scan_regions_cb, handler);
+    }
+}
+
+static ucm_event_installer_t ucm_ze_initializer = {
+    .install            = ucm_zemem_install,
+    .get_existing_alloc = ucm_zemem_get_existing_alloc
+};
+
+UCS_STATIC_INIT
+{
+    ucs_list_add_tail(&ucm_event_installer_list, &ucm_ze_initializer.list);
+}
+
+UCS_STATIC_CLEANUP
+{
+    ucs_list_del(&ucm_ze_initializer.list);
+}

--- a/src/ucm/ze/zemem.h
+++ b/src/ucm/ze/zemem.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCM_ZEMEM_H_
+#define UCM_ZEMEM_H_
+
+#include <level_zero/ze_api.h>
+
+
+ze_result_t ucm_zeMemAllocHost(ze_context_handle_t context,
+                               const ze_host_mem_alloc_desc_t *host_desc,
+                               size_t size, size_t alignment, void **pptr);
+
+
+ze_result_t ucm_zeMemAllocDevice(ze_context_handle_t context,
+                                 const ze_device_mem_alloc_desc_t *device_desc,
+                                 size_t size, size_t alignment,
+                                 ze_device_handle_t device, void **pptr);
+
+
+ze_result_t ucm_zeMemAllocShared(ze_context_handle_t context,
+                                 const ze_device_mem_alloc_desc_t *device_desc,
+                                 const ze_host_mem_alloc_desc_t *host_desc,
+                                 size_t size, size_t alignment,
+                                 ze_device_handle_t device, void **pptr);
+
+
+ze_result_t ucm_zeMemFree(ze_context_handle_t context, void *ptr);
+
+
+#endif

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
  * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2023.  ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -112,6 +113,9 @@ static size_t ucp_rndv_frag_default_sizes[] = {
     [UCS_MEMORY_TYPE_ROCM]         = 4 * UCS_MBYTE,
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = 4 * UCS_MBYTE,
     [UCS_MEMORY_TYPE_RDMA]         = 0,
+    [UCS_MEMORY_TYPE_ZE_HOST]      = 4 * UCS_MBYTE,
+    [UCS_MEMORY_TYPE_ZE_DEVICE]    = 4 * UCS_MBYTE,
+    [UCS_MEMORY_TYPE_ZE_MANAGED]   = 4 * UCS_MBYTE,
     [UCS_MEMORY_TYPE_LAST]         = 0
 };
 
@@ -122,6 +126,9 @@ static size_t ucp_rndv_frag_default_num_elems[] = {
     [UCS_MEMORY_TYPE_ROCM]         = 128,
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = 128,
     [UCS_MEMORY_TYPE_RDMA]         = 0,
+    [UCS_MEMORY_TYPE_ZE_HOST]      = 128,
+    [UCS_MEMORY_TYPE_ZE_DEVICE]    = 128,
+    [UCS_MEMORY_TYPE_ZE_MANAGED]   = 128,
     [UCS_MEMORY_TYPE_LAST]         = 0
 };
 
@@ -152,7 +159,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
 
   {"MEMTYPE_REG_WHOLE_ALLOC_TYPES", "cuda",
    "Memory types which have whole allocations registered.\n"
-   "Allowed memory types: cuda, rocm, rocm-managed",
+   "Allowed memory types: cuda, rocm, rocm-managed, ze-host, ze-device, ze-managed",
    ucs_offsetof(ucp_context_config_t, reg_whole_alloc_bitmap),
    UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
 
@@ -343,7 +350,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
 
   {"RNDV_FRAG_MEM_TYPE", "host",
    "Memory type of fragments used for RNDV pipeline protocol.\n"
-   "Allowed memory types is one of: host, cuda, rocm",
+   "Allowed memory types is one of: host, cuda, rocm, ze-host, ze-device",
    ucs_offsetof(ucp_context_config_t, rndv_frag_mem_type),
    UCS_CONFIG_TYPE_ENUM(ucs_memory_type_names)},
 
@@ -536,6 +543,7 @@ static ucs_config_field_t ucp_config_table[] = {
    " - tcp     : sockets over TCP/IP.\n"
    " - cuda    : CUDA (NVIDIA GPU) memory support.\n"
    " - rocm    : ROCm (AMD GPU) memory support.\n"
+   " - ze      : ZE (Intel GPU) memory support.\n"
    " Using a \\ prefix before a transport name treats it as an explicit transport name\n"
    " and disables aliasing.",
    ucs_offsetof(ucp_config_t, tls), UCS_CONFIG_TYPE_ALLOW_LIST},
@@ -620,6 +628,7 @@ static ucp_tl_alias_t ucp_tl_aliases[] = {
   { "ugni",  { "ugni_smsg", UCP_TL_AUX("ugni_udt"), "ugni_rdma", NULL } },
   { "cuda",  { "cuda_copy", "cuda_ipc", "gdr_copy", NULL } },
   { "rocm",  { "rocm_copy", "rocm_ipc", "rocm_gdr", NULL } },
+  { "ze",    { "ze_copy", "ze_ipc", "ze_gdr", NULL } },
   { NULL }
 };
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -225,12 +226,18 @@ static UCS_F_ALWAYS_INLINE size_t ucp_memh_length(const ucp_mem_h memh)
 #define UCP_MEM_IS_HOST(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_HOST)
 #define UCP_MEM_IS_ROCM(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ROCM)
 #define UCP_MEM_IS_CUDA(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_CUDA)
+#define UCP_MEM_IS_ZE_HOST(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ZE_HOST)
+#define UCP_MEM_IS_ZE_DEVICE(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ZE_DEVICE)
 #define UCP_MEM_IS_CUDA_MANAGED(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_CUDA_MANAGED)
 #define UCP_MEM_IS_ROCM_MANAGED(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ROCM_MANAGED)
+#define UCP_MEM_IS_ZE_MANAGED(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_ZE_MANAGED)
 #define UCP_MEM_IS_ACCESSIBLE_FROM_CPU(_mem_type) \
     (UCS_BIT(_mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)
-#define UCP_MEM_IS_GPU(_mem_type) ((_mem_type) == UCS_MEMORY_TYPE_CUDA || \
-                                   (_mem_type) == UCS_MEMORY_TYPE_CUDA_MANAGED || \
-                                   (_mem_type) == UCS_MEMORY_TYPE_ROCM)
+#define UCP_MEM_IS_GPU(_mem_type) (UCS_BIT(_mem_type) & \
+                                   (UCS_BIT(UCS_MEMORY_TYPE_CUDA) | \
+                                    UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED) | \
+                                    UCS_BIT(UCS_MEMORY_TYPE_ROCM) | \
+                                    UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) | \
+                                    UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED)))
 
 #endif

--- a/src/ucs/memory/memory_type.c
+++ b/src/ucs/memory/memory_type.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -20,6 +21,9 @@ const char *ucs_memory_type_names[] = {
     [UCS_MEMORY_TYPE_ROCM]         = "rocm",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "rocm-managed",
     [UCS_MEMORY_TYPE_RDMA]         = "rdma",
+    [UCS_MEMORY_TYPE_ZE_HOST]      = "ze-host",
+    [UCS_MEMORY_TYPE_ZE_DEVICE]    = "ze-device",
+    [UCS_MEMORY_TYPE_ZE_MANAGED]   = "ze-managed",
     [UCS_MEMORY_TYPE_LAST]         = "unknown",
     [UCS_MEMORY_TYPE_LAST + 1]     = NULL
 };
@@ -31,6 +35,8 @@ const char *ucs_memory_type_descs[] = {
     [UCS_MEMORY_TYPE_ROCM]         = "AMD/ROCm GPU memory",
     [UCS_MEMORY_TYPE_ROCM_MANAGED] = "AMD/ROCm GPU managed memory",
     [UCS_MEMORY_TYPE_RDMA]         = "RDMA device memory",
+    [UCS_MEMORY_TYPE_ZE_HOST]      = "Intel/Ze USM host memory",
+    [UCS_MEMORY_TYPE_ZE_DEVICE]    = "Intel/Ze GPU memory",
+    [UCS_MEMORY_TYPE_ZE_MANAGED]   = "Intel/Ze GPU managed memory",
     [UCS_MEMORY_TYPE_LAST]         = "unknown"
 };
-

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -17,8 +18,8 @@ BEGIN_C_DECLS
  * Memory types accessible from CPU
  */
 #define UCS_MEMORY_TYPES_CPU_ACCESSIBLE \
-    (UCS_BIT(UCS_MEMORY_TYPE_HOST) | \
-     UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED))
+    (UCS_BIT(UCS_MEMORY_TYPE_HOST) | UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED) | \
+     UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) | UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED))
 
 
 /**
@@ -41,6 +42,9 @@ typedef enum ucs_memory_type {
     UCS_MEMORY_TYPE_ROCM,          /**< AMD ROCM memory */
     UCS_MEMORY_TYPE_ROCM_MANAGED,  /**< AMD ROCM managed system memory */
     UCS_MEMORY_TYPE_RDMA,          /**< RDMA device memory */
+    UCS_MEMORY_TYPE_ZE_HOST,       /**< Intel ZE memory (USM host) */
+    UCS_MEMORY_TYPE_ZE_DEVICE,     /**< Intel ZE memory (USM device) */
+    UCS_MEMORY_TYPE_ZE_MANAGED,    /**< Intel ZE managed memory (USM shared) */
     UCS_MEMORY_TYPE_LAST,
     UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
 } ucs_memory_type_t;

--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -3,10 +3,11 @@
 # Copyright (c) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
 # Copyright (c) The University of Tennesse and the University of Tennessee
 #               Research Foundation. 2016.  ALL RIGHTS RESERVED.
+# Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
-SUBDIRS = . cuda ib rocm sm ugni
+SUBDIRS = . cuda ib rocm sm ugni ze
 
 lib_LTLIBRARIES    = libuct.la
 libuct_la_CFLAGS   = $(BASE_CFLAGS)

--- a/src/uct/configure.m4
+++ b/src/uct/configure.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
+# Copyright (C) Intel Corporation, 2023. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -9,6 +10,7 @@ m4_include([src/uct/ib/configure.m4])
 m4_include([src/uct/rocm/configure.m4])
 m4_include([src/uct/sm/configure.m4])
 m4_include([src/uct/ugni/configure.m4])
+m4_include([src/uct/ze/configure.m4])
 
 AC_DEFINE_UNQUOTED([uct_MODULES], ["${uct_modules}"], [UCT loadable modules])
 

--- a/src/uct/ze/Makefile.am
+++ b/src/uct/ze/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+if HAVE_ZE
+
+SUBDIRS = .
+
+module_LTLIBRARIES    = libuct_ze.la
+libuct_ze_la_CPPFLAGS = $(BASE_CPPFLAGS) $(ZE_CPPFLAGS)
+libuct_ze_la_CFLAGS   = $(BASE_CFLAGS)
+libuct_ze_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
+                          $(top_builddir)/src/uct/libuct.la
+libuct_ze_la_LDFLAGS  = $(ZE_LDFLAGS) $(ZE_LIBS) -version-info $(SOVERSION) \
+                          $(patsubst %, -Xlinker %, -L$(ZE_ROOT)/lib -rpath $(ZE_ROOT)/hip/lib -rpath $(ZE_ROOT)/lib) \
+                          $(patsubst %, -Xlinker %, --enable-new-dtags) \
+                          $(patsubst %, -Xlinker %, -rpath $(ZE_ROOT)/lib64)
+
+noinst_HEADERS = \
+	base/ze_base.h
+
+libuct_ze_la_SOURCES = \
+	base/ze_base.c
+
+noinst_HEADERS += \
+    copy/ze_copy_md.h \
+    copy/ze_copy_iface.h \
+    copy/ze_copy_ep.h
+
+libuct_ze_la_SOURCES += \
+    copy/ze_copy_md.c \
+    copy/ze_copy_iface.c \
+    copy/ze_copy_ep.c
+
+PKG_CONFIG_NAME=ze
+
+include $(top_srcdir)/config/module.am
+# TODO: enable pkg-config processing when module static build is enabled
+# include $(top_srcdir)/config/module-pkg-config.am
+
+endif

--- a/src/uct/ze/base/ze_base.c
+++ b/src/uct/ze/base/ze_base.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ze_base.h"
+
+#include <ucs/sys/module.h>
+
+#include <pthread.h>
+
+#define UCT_ZE_MAX_DEVICES 32
+
+static struct {
+    ze_driver_handle_t driver;
+    ze_device_handle_t devices[UCT_ZE_MAX_DEVICES];
+    int                num_devices;
+} uct_ze_base_info;
+
+ze_result_t uct_ze_base_init(void)
+{
+    static ucs_init_once_t init = UCS_INIT_ONCE_INITIALIZER;
+    ze_result_t ret = ZE_RESULT_SUCCESS;
+    unsigned count;
+
+    UCS_INIT_ONCE(&init) {
+        ret = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+        if (ret != ZE_RESULT_SUCCESS) {
+            ucs_debug("failure to initialize ze library: 0x%x", ret);
+            continue;
+        }
+
+        count = 1;
+        ret   = zeDriverGet(&count, &uct_ze_base_info.driver);
+        if (ret != ZE_RESULT_SUCCESS) {
+            ucs_debug("failure to get ze driver: 0x%x", ret);
+            continue;
+        }
+
+        count = UCT_ZE_MAX_DEVICES;
+        ret   = zeDeviceGet(uct_ze_base_info.driver, &count,
+                            uct_ze_base_info.devices);
+        if (ret != ZE_RESULT_SUCCESS) {
+            ucs_debug("failure to get ze driver: 0x%x", ret);
+            continue;
+        }
+
+        uct_ze_base_info.num_devices = count;
+    }
+
+    return ret;
+}
+
+ze_driver_handle_t uct_ze_base_get_driver(void)
+{
+    if (uct_ze_base_init() != ZE_RESULT_SUCCESS) {
+        return NULL;
+    }
+
+    return uct_ze_base_info.driver;
+}
+
+ze_device_handle_t uct_ze_base_get_device(int dev_num)
+{
+    if (uct_ze_base_init() != ZE_RESULT_SUCCESS) {
+        return NULL;
+    }
+
+    if (dev_num < 0 || dev_num >= uct_ze_base_info.num_devices) {
+        return NULL;
+    }
+
+    return uct_ze_base_info.devices[dev_num];
+}
+
+ucs_status_t
+uct_ze_base_query_md_resources(uct_component_h component,
+                               uct_md_resource_desc_t **resources_p,
+                               unsigned *num_resources_p)
+{
+    if (uct_ze_base_init() != ZE_RESULT_SUCCESS) {
+        ucs_debug("could not initialize ZE support");
+        return uct_md_query_empty_md_resource(resources_p, num_resources_p);
+    }
+
+    return uct_md_query_single_md_resource(component, resources_p,
+                                           num_resources_p);
+}
+
+ucs_status_t uct_ze_base_query_devices(uct_md_h md,
+                                       uct_tl_device_resource_t **tl_devices_p,
+                                       unsigned *num_tl_devices_p)
+{
+    return uct_single_device_resource(md, md->component->name,
+                                      UCT_DEVICE_TYPE_ACC,
+                                      UCS_SYS_DEVICE_ID_UNKNOWN, tl_devices_p,
+                                      num_tl_devices_p);
+}
+
+UCS_MODULE_INIT()
+{
+    return UCS_OK;
+}

--- a/src/uct/ze/base/ze_base.h
+++ b/src/uct/ze/base/ze_base.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef ZE_BASE_H
+#define ZE_BASE_H
+
+#include <uct/base/uct_iface.h>
+#include <uct/base/uct_md.h>
+#include <level_zero/ze_api.h>
+
+
+#define UCT_ZE_FUNC(_func, _log_level) \
+    ({ \
+        ucs_status_t _status = UCS_OK; \
+        do { \
+            ze_result_t _ret = (_func); \
+            if (_ret == ZE_RESULT_NOT_READY) { \
+                _status = UCS_INPROGRESS; \
+            } else if (_ret != ZE_RESULT_SUCCESS) { \
+                ucs_log((_log_level), "%s failed: 0x%x", \
+                        UCS_PP_MAKE_STRING(_func), _ret); \
+                _status = UCS_ERR_IO_ERROR; \
+            } \
+        } while (0); \
+        _status; \
+    })
+
+
+#define UCT_ZE_FUNC_LOG_ERR(_func) UCT_ZE_FUNC(_func, UCS_LOG_LEVEL_ERROR)
+
+
+#define UCT_ZE_FUNC_LOG_DEBUG(_func) UCT_ZE_FUNC(_func, UCS_LOG_LEVEL_DEBUG)
+
+
+ze_result_t uct_ze_base_init(void);
+
+
+ze_driver_handle_t uct_ze_base_get_driver(void);
+
+
+ze_device_handle_t uct_ze_base_get_device(int dev_num);
+
+
+ucs_status_t
+uct_ze_base_query_md_resources(uct_component_h component,
+                               uct_md_resource_desc_t **resources_p,
+                               unsigned *num_resources_p);
+
+
+ucs_status_t uct_ze_base_query_devices(uct_md_h md,
+                                       uct_tl_device_resource_t **tl_devices_p,
+                                       unsigned *num_tl_devices_p);
+
+
+#endif

--- a/src/uct/ze/configure.m4
+++ b/src/uct/ze/configure.m4
@@ -1,0 +1,10 @@
+#
+# Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+UCX_CHECK_ZE
+
+AS_IF([test "x$ze_happy" = "xyes"], [uct_modules="${uct_modules}:ze"])
+AC_CONFIG_FILES([src/uct/ze/Makefile
+                 src/uct/ze/ucx-ze.pc])

--- a/src/uct/ze/copy/ze_copy_ep.c
+++ b/src/uct/ze/copy/ze_copy_ep.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) Intell Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ze_copy_ep.h"
+#include "ze_copy_iface.h"
+#include "ze_copy_md.h"
+
+#include <uct/ze/base/ze_base.h>
+#include <uct/base/uct_log.h>
+#include <uct/base/uct_iov.inl>
+#include <ucs/debug/memtrack_int.h>
+#include <ucs/type/class.h>
+#include <ucs/arch/cpu.h>
+
+#include <level_zero/ze_api.h>
+
+static UCS_CLASS_INIT_FUNC(uct_ze_copy_ep_t, const uct_ep_params_t *params)
+{
+    uct_ze_copy_iface_t *iface = ucs_derived_of(params->iface,
+                                                uct_ze_copy_iface_t);
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super);
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_ze_copy_ep_t)
+{
+}
+
+UCS_CLASS_DEFINE(uct_ze_copy_ep_t, uct_base_ep_t)
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ze_copy_ep_t, uct_ep_t, const uct_ep_params_t*);
+UCS_CLASS_DEFINE_DELETE_FUNC(uct_ze_copy_ep_t, uct_ep_t);
+
+ucs_status_t uct_ze_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
+                                  const uct_iov_t *iov, uct_rkey_t rkey,
+                                  int is_put)
+{
+    size_t size                = uct_iov_get_length(iov);
+    uct_ze_copy_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                uct_ze_copy_iface_t);
+    ze_result_t ret;
+    void *src, *dst;
+
+    ucs_trace("remote addr %p rkey %p size %zu", (void*)remote_addr,
+              (void*)rkey, size);
+
+    if (is_put) {
+        src = iov->buffer;
+        dst = (void*)remote_addr;
+    } else {
+        src = (void*)remote_addr;
+        dst = iov->buffer;
+    }
+
+    ret = zeCommandListAppendMemoryCopy(iface->ze_cmdl, dst, src, size, NULL, 0,
+                                        NULL);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ret = zeCommandListClose(iface->ze_cmdl);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ret = zeCommandQueueExecuteCommandLists(iface->ze_cmdq, 1, &iface->ze_cmdl,
+                                            NULL);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ret = zeCommandQueueSynchronize(iface->ze_cmdq, UINT32_MAX);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ret = zeCommandListReset(iface->ze_cmdl);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ucs_trace("ze memory copy from src %p to dst %p, len %ld", src, dst, size);
+
+    return UCS_OK;
+}
+
+ucs_status_t uct_ze_copy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                      size_t iovcnt, uint64_t remote_addr,
+                                      uct_rkey_t rkey, uct_completion_t *comp)
+{
+    ucs_status_t status;
+
+    status = uct_ze_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 0);
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, ZCOPY,
+                      uct_iov_total_length(iov, iovcnt));
+    ucs_trace_data("GET_ZCOPY size %zu from %p (%+ld)",
+                   uct_iov_total_length(iov, iovcnt), (void *)remote_addr,
+                   rkey);
+    return status;
+}
+
+ucs_status_t uct_ze_copy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                      size_t iovcnt, uint64_t remote_addr,
+                                      uct_rkey_t rkey, uct_completion_t *comp)
+{
+    ucs_status_t status;
+
+    status = uct_ze_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 1);
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
+                      uct_iov_total_length(iov, iovcnt));
+    ucs_trace_data("PUT_ZCOPY size %zu to %p (%+ld)",
+                   uct_iov_total_length(iov, iovcnt), (void *)remote_addr,
+                   rkey);
+    return status;
+}
+
+ucs_status_t uct_ze_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
+                                      unsigned length, uint64_t remote_addr,
+                                      uct_rkey_t rkey)
+{
+    uct_iov_t iov = {
+        .buffer = (void*)buffer,
+        .length = length,
+        .count  = 1,
+    };
+    ucs_status_t status;
+
+    status = uct_ze_copy_ep_zcopy(tl_ep, remote_addr, &iov, rkey, 1);
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, SHORT, length);
+    ucs_trace_data("PUT_SHORT size %u from %p to %p", length, buffer,
+                   (void*)remote_addr);
+    return status;
+}
+
+ucs_status_t uct_ze_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
+                                      unsigned length, uint64_t remote_addr,
+                                      uct_rkey_t rkey)
+{
+    uct_iov_t iov = {
+        .buffer = buffer,
+        .length = length,
+        .count  = 1,
+    };
+    ucs_status_t status;
+
+    status = uct_ze_copy_ep_zcopy(tl_ep, remote_addr, &iov, rkey, 0);
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), GET, SHORT, length);
+    ucs_trace_data("GET_SHORT size %u from %p to %p", length,
+                   (void*)remote_addr, buffer);
+    return status;
+}

--- a/src/uct/ze/copy/ze_copy_ep.h
+++ b/src/uct/ze/copy/ze_copy_ep.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_ZE_COPY_EP_H
+#define UCT_ZE_COPY_EP_H
+
+#include <uct/api/uct.h>
+#include <uct/base/uct_iface.h>
+#include <ucs/type/class.h>
+
+
+typedef struct uct_ze_copy_ep_addr {
+    int ep_id;
+} uct_ze_copy_ep_addr_t;
+
+
+typedef struct uct_ze_copy_ep {
+    uct_base_ep_t         super;
+} uct_ze_copy_ep_t;
+
+
+UCS_CLASS_DECLARE_NEW_FUNC(uct_ze_copy_ep_t, uct_ep_t, const uct_ep_params_t*);
+
+
+UCS_CLASS_DECLARE_DELETE_FUNC(uct_ze_copy_ep_t, uct_ep_t);
+
+
+ucs_status_t uct_ze_copy_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                      size_t iovcnt, uint64_t remote_addr,
+                                      uct_rkey_t rkey, uct_completion_t *comp);
+
+
+ucs_status_t uct_ze_copy_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
+                                      size_t iovcnt, uint64_t remote_addr,
+                                      uct_rkey_t rkey, uct_completion_t *comp);
+
+
+ucs_status_t uct_ze_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
+                                      unsigned length, uint64_t remote_addr,
+                                      uct_rkey_t rkey);
+
+
+ucs_status_t uct_ze_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
+                                      unsigned length, uint64_t remote_addr,
+                                      uct_rkey_t rkey);
+
+#endif

--- a/src/uct/ze/copy/ze_copy_iface.c
+++ b/src/uct/ze/copy/ze_copy_iface.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ze_copy_iface.h"
+#include "ze_copy_md.h"
+#include "ze_copy_ep.h"
+
+#include <uct/ze/base/ze_base.h>
+#include <ucs/type/class.h>
+#include <ucs/sys/string.h>
+
+
+/* Forward declaration for the delete function */
+static void UCS_CLASS_DELETE_FUNC_NAME(uct_ze_copy_iface_t)(uct_iface_t*);
+
+
+static ucs_status_t uct_ze_copy_iface_get_address(uct_iface_h tl_iface,
+                                                  uct_iface_addr_t *iface_addr)
+{
+    uct_ze_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_ze_copy_iface_t);
+
+    *(uct_ze_copy_iface_addr_t*)iface_addr = iface->id;
+    return UCS_OK;
+}
+
+static int
+uct_ze_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
+                                  const uct_iface_is_reachable_params_t *params)
+{
+    uct_ze_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_ze_copy_iface_t);
+    uct_ze_copy_iface_addr_t *addr;
+
+    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
+        return 0;
+    }
+
+    addr = (uct_ze_copy_iface_addr_t*)params->iface_addr;
+    return (addr != NULL) && (iface->id == *addr) &&
+           uct_iface_scope_is_reachable(tl_iface, params);
+}
+
+static ucs_status_t
+uct_ze_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+{
+    uct_ze_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_ze_copy_iface_t);
+
+    uct_base_iface_query(&iface->super, iface_attr);
+
+    iface_attr->iface_addr_len  = sizeof(uct_ze_copy_iface_addr_t);
+    iface_attr->device_addr_len = 0;
+    iface_attr->ep_addr_len     = 0;
+    iface_attr->cap.flags       = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                  UCT_IFACE_FLAG_GET_SHORT |
+                                  UCT_IFACE_FLAG_PUT_SHORT |
+                                  UCT_IFACE_FLAG_GET_ZCOPY |
+                                  UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_PENDING;
+
+    iface_attr->cap.put.max_short       = UINT_MAX;
+    iface_attr->cap.put.max_bcopy       = 0;
+    iface_attr->cap.put.min_zcopy       = 0;
+    iface_attr->cap.put.max_zcopy       = SIZE_MAX;
+    iface_attr->cap.put.opt_zcopy_align = 1;
+    iface_attr->cap.put.align_mtu       = iface_attr->cap.put.opt_zcopy_align;
+    iface_attr->cap.put.max_iov         = 1;
+
+    iface_attr->cap.get.max_short       = UINT_MAX;
+    iface_attr->cap.get.max_bcopy       = 0;
+    iface_attr->cap.get.min_zcopy       = 0;
+    iface_attr->cap.get.max_zcopy       = SIZE_MAX;
+    iface_attr->cap.get.opt_zcopy_align = 1;
+    iface_attr->cap.get.align_mtu       = iface_attr->cap.get.opt_zcopy_align;
+    iface_attr->cap.get.max_iov         = 1;
+
+    iface_attr->cap.am.max_short       = 0;
+    iface_attr->cap.am.max_bcopy       = 0;
+    iface_attr->cap.am.min_zcopy       = 0;
+    iface_attr->cap.am.max_zcopy       = 0;
+    iface_attr->cap.am.opt_zcopy_align = 1;
+    iface_attr->cap.am.align_mtu       = iface_attr->cap.am.opt_zcopy_align;
+    iface_attr->cap.am.max_hdr         = 0;
+    iface_attr->cap.am.max_iov         = 1;
+
+    iface_attr->latency             = ucs_linear_func_make(10e-6, 0);
+    iface_attr->bandwidth.dedicated = 50000.0 * UCS_MBYTE;
+    iface_attr->bandwidth.shared    = 0;
+    iface_attr->overhead            = 0;
+    iface_attr->priority            = 0;
+
+    return UCS_OK;
+}
+
+static uct_iface_ops_t uct_ze_copy_iface_ops = {
+    .ep_get_short             = uct_ze_copy_ep_get_short,
+    .ep_put_short             = uct_ze_copy_ep_put_short,
+    .ep_get_zcopy             = uct_ze_copy_ep_get_zcopy,
+    .ep_put_zcopy             = uct_ze_copy_ep_put_zcopy,
+    .ep_pending_add           = ucs_empty_function_return_busy,
+    .ep_pending_purge         = ucs_empty_function,
+    .ep_flush                 = uct_base_ep_flush,
+    .ep_fence                 = uct_base_ep_fence,
+    .ep_create                = uct_ep_create,
+    .ep_destroy               = uct_ep_destroy,
+    .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_ze_copy_ep_t),
+    .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_ze_copy_ep_t),
+    .iface_flush              = uct_base_iface_flush,
+    .iface_fence              = uct_base_iface_fence,
+    .iface_progress_enable    = ucs_empty_function,
+    .iface_progress_disable   = ucs_empty_function,
+    .iface_progress           = ucs_empty_function_return_zero,
+    .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ze_copy_iface_t),
+    .iface_query              = uct_ze_copy_iface_query,
+    .iface_get_device_address = ucs_empty_function_return_success,
+    .iface_get_address        = uct_ze_copy_iface_get_address,
+    .iface_is_reachable       = uct_base_iface_is_reachable,
+};
+
+
+static ucs_status_t
+uct_ze_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
+{
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
+        perf_attr->bandwidth.dedicated = 0;
+        if (!(perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OPERATION)) {
+            perf_attr->bandwidth.shared = 0;
+        } else {
+            switch (perf_attr->operation) {
+            case UCT_EP_OP_GET_SHORT:
+                perf_attr->bandwidth.shared = 2000.0 * UCS_MBYTE;
+                break;
+            case UCT_EP_OP_GET_ZCOPY:
+                perf_attr->bandwidth.shared = 8000.0 * UCS_MBYTE;
+                break;
+            case UCT_EP_OP_PUT_SHORT:
+                perf_attr->bandwidth.shared = 10500.0 * UCS_MBYTE;
+                break;
+            case UCT_EP_OP_PUT_ZCOPY:
+                perf_attr->bandwidth.shared = 9500.0 * UCS_MBYTE;
+                break;
+            default:
+                perf_attr->bandwidth.shared = 0;
+                break;
+            }
+        }
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {
+        perf_attr->send_pre_overhead = 0;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_POST_OVERHEAD) {
+        perf_attr->send_post_overhead = 0;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_RECV_OVERHEAD) {
+        perf_attr->recv_overhead = 0;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
+        perf_attr->latency = ucs_linear_func_make(10e-6, 0);
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS) {
+        perf_attr->max_inflight_eps = SIZE_MAX;
+    }
+
+    return UCS_OK;
+}
+
+
+static uct_iface_internal_ops_t uct_ze_copy_iface_internal_ops = {
+    .iface_estimate_perf   = uct_ze_copy_estimate_perf,
+    .iface_vfs_refresh     = ucs_empty_function,
+    .ep_query              = ucs_empty_function_return_unsupported,
+    .ep_invalidate         = ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2 = uct_ze_copy_iface_is_reachable_v2,
+    .ep_is_connected       = uct_base_ep_is_connected
+};
+
+static UCS_CLASS_INIT_FUNC(uct_ze_copy_iface_t, uct_md_h md,
+                           uct_worker_h worker,
+                           const uct_iface_params_t *params,
+                           const uct_iface_config_t *tl_config)
+{
+    uct_ze_copy_md_t *ze_md         = ucs_derived_of(md, uct_ze_copy_md_t);
+    ze_command_queue_desc_t cq_desc = {};
+    ze_command_list_desc_t cl_desc  = {};
+    ze_device_handle_t device;
+    ze_command_queue_handle_t cmdq;
+    ze_command_list_handle_t cmdl;
+    ze_result_t ret;
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_base_iface_t, &uct_ze_copy_iface_ops,
+                              &uct_ze_copy_iface_internal_ops, md, worker,
+                              params,
+                              tl_config UCS_STATS_ARG(params->stats_root)
+                                      UCS_STATS_ARG(UCT_ZE_COPY_TL_NAME));
+
+    /* TODO: choose device based on params */
+    device = uct_ze_base_get_device(0);
+    if (device == NULL) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    ret = zeCommandQueueCreate(ze_md->ze_context, device, &cq_desc, &cmdq);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    ret = zeCommandListCreate(ze_md->ze_context, device, &cl_desc, &cmdl);
+    if (ret != ZE_RESULT_SUCCESS) {
+        zeCommandQueueDestroy(cmdq);
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    self->ze_cmdq = cmdq;
+    self->ze_cmdl = cmdl;
+    self->id      = ucs_generate_uuid((uintptr_t)self);
+
+    return UCS_OK;
+}
+
+static UCS_CLASS_CLEANUP_FUNC(uct_ze_copy_iface_t)
+{
+    zeCommandListDestroy(self->ze_cmdl);
+    zeCommandQueueDestroy(self->ze_cmdq);
+}
+
+UCS_CLASS_DEFINE(uct_ze_copy_iface_t, uct_base_iface_t);
+UCS_CLASS_DEFINE_NEW_FUNC(uct_ze_copy_iface_t, uct_iface_t, uct_md_h,
+                          uct_worker_h, const uct_iface_params_t*,
+                          const uct_iface_config_t*);
+static UCS_CLASS_DEFINE_DELETE_FUNC(uct_ze_copy_iface_t, uct_iface_t);
+
+UCT_TL_DEFINE(&uct_ze_copy_component, ze_copy, uct_ze_base_query_devices,
+              uct_ze_copy_iface_t, "ZE_COPY_", uct_iface_config_table,
+              uct_iface_config_t);

--- a/src/uct/ze/copy/ze_copy_iface.h
+++ b/src/uct/ze/copy/ze_copy_iface.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_ZE_COPY_IFACE_H
+#define UCT_ZE_COPY_IFACE_H
+
+#include <uct/base/uct_iface.h>
+#include <level_zero/ze_api.h>
+
+
+#define UCT_ZE_COPY_TL_NAME "ze_cpy"
+
+
+typedef uint64_t uct_ze_copy_iface_addr_t;
+
+
+typedef struct uct_ze_copy_iface {
+    uct_base_iface_t          super;
+    uct_ze_copy_iface_addr_t  id;
+    ze_command_queue_handle_t ze_cmdq;
+    ze_command_list_handle_t  ze_cmdl;
+} uct_ze_copy_iface_t;
+
+#endif

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ze_copy_md.h"
+
+#include <uct/ze/base/ze_base.h>
+
+#include <string.h>
+#include <limits.h>
+#include <ucm/api/ucm.h>
+#include <ucs/debug/log.h>
+#include <ucs/sys/sys.h>
+#include <ucs/sys/math.h>
+#include <ucs/debug/memtrack_int.h>
+#include <ucs/type/class.h>
+#include <ucs/memory/memtype_cache.h>
+
+
+static ucs_config_field_t uct_ze_copy_md_config_table[] = {
+    {"", "", NULL, ucs_offsetof(uct_ze_copy_md_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
+
+    {"DEVICE_ORDINAL", "0",
+     "Ordinal of the GPU device to allocate memory from.",
+     ucs_offsetof(uct_ze_copy_md_config_t, device_ordinal),
+     UCS_CONFIG_TYPE_INT},
+
+    {NULL}
+};
+
+static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
+{
+    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->reg_nonblock_mem_types = 0;
+    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->dmabuf_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE);
+    md_attr->max_alloc              = SIZE_MAX;
+    md_attr->max_reg                = ULONG_MAX;
+    md_attr->rkey_packed_size       = 0;
+    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
+    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ze_copy_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
+                      ucs_memory_type_t mem_type, unsigned flags,
+                      const char *alloc_name, uct_mem_h *memh_p)
+{
+    uct_ze_copy_md_t *md = ucs_derived_of(tl_md, uct_ze_copy_md_t);
+    ze_host_mem_alloc_desc_t host_desc  = {};
+    ze_device_mem_alloc_desc_t dev_desc = {};
+    size_t alignment                    = ucs_get_page_size();
+    ucs_status_t status;
+
+    switch (mem_type) {
+    case UCS_MEMORY_TYPE_ZE_HOST:
+        status = UCT_ZE_FUNC_LOG_ERR(zeMemAllocHost(md->ze_context, &host_desc,
+                                                    *length_p, alignment,
+                                                    address_p));
+        break;
+    case UCS_MEMORY_TYPE_ZE_DEVICE:
+        status = UCT_ZE_FUNC_LOG_ERR(zeMemAllocDevice(md->ze_context, &dev_desc,
+                                                      *length_p, alignment,
+                                                      md->ze_device,
+                                                      address_p));
+        break;
+    case UCS_MEMORY_TYPE_ZE_MANAGED:
+        status = UCT_ZE_FUNC_LOG_ERR(zeMemAllocShared(md->ze_context, &dev_desc,
+                                                      &host_desc, *length_p,
+                                                      alignment, md->ze_device,
+                                                      address_p));
+        break;
+    default:
+        ucs_debug("unsupported mem_type: %d", mem_type);
+        status = UCS_ERR_UNSUPPORTED;
+        break;
+    }
+
+    if (status == UCS_OK) {
+        *memh_p = *address_p;
+    }
+
+    return status;
+}
+
+static ucs_status_t uct_ze_copy_mem_free(uct_md_h tl_md, uct_mem_h memh)
+{
+    uct_ze_copy_md_t *md = ucs_derived_of(tl_md, uct_ze_copy_md_t);
+
+    return UCT_ZE_FUNC_LOG_ERR(zeMemFree(md->ze_context, (void*)memh));
+}
+
+static ucs_status_t uct_ze_copy_rkey_unpack(uct_component_t *component,
+                                            const void *rkey_buffer,
+                                            uct_rkey_t *rkey_p, void **handle_p)
+{
+    *handle_p = NULL;
+    *rkey_p   = 0xdeadbeef;
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ze_copy_mem_reg(uct_md_h md, void *address, size_t length,
+                    const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
+{
+    /* memory registration it not needed for ZE */
+    *memh_p = (uct_mem_h)0xdeadbeef;
+    return UCS_OK;
+}
+
+static void uct_ze_copy_md_close(uct_md_h uct_md)
+{
+    uct_ze_copy_md_t *md = ucs_derived_of(uct_md, uct_ze_copy_md_t);
+
+    zeContextDestroy(md->ze_context);
+    ucs_free(md);
+}
+
+static ucs_status_t
+uct_ze_copy_md_query_attributes(uct_md_h md, const void *addr, size_t length,
+                                ucs_memory_info_t *mem_info, int *dmabuf_fd)
+{
+    uct_ze_copy_md_t *ze_md = ucs_derived_of(md, uct_ze_copy_md_t);
+    ze_external_memory_export_fd_t export_fd = {
+        .stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_FD,
+        .flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF
+    };
+    ze_memory_allocation_properties_t props  = {
+        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
+        .pNext = dmabuf_fd ? &export_fd : NULL
+    };
+    ze_result_t ret;
+    void *base_address;
+    size_t alloc_length;
+
+    ret = zeMemGetAllocProperties(ze_md->ze_context, addr, &props, NULL);
+    if ((ret != ZE_RESULT_SUCCESS) || (props.type == ZE_MEMORY_TYPE_UNKNOWN)) {
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    ret = zeMemGetAddressRange(ze_md->ze_context, addr, &base_address,
+                               &alloc_length);
+    if (ret != ZE_RESULT_SUCCESS) {
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    if (props.type == ZE_MEMORY_TYPE_HOST) {
+        mem_info->type = UCS_MEMORY_TYPE_ZE_HOST;
+    } else if (props.type == ZE_MEMORY_TYPE_DEVICE) {
+        mem_info->type = UCS_MEMORY_TYPE_ZE_DEVICE;
+    } else {
+        mem_info->type = UCS_MEMORY_TYPE_ZE_MANAGED;
+    }
+    mem_info->base_address = base_address;
+    mem_info->alloc_length = alloc_length;
+    mem_info->sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+    if (dmabuf_fd) {
+        *dmabuf_fd = export_fd.fd;
+    }
+    return UCS_OK;
+}
+
+static ucs_status_t uct_ze_copy_md_mem_query(uct_md_h md, const void *addr,
+                                             const size_t length,
+                                             uct_md_mem_attr_t *mem_attr_p)
+{
+    int dmabuf_fd = UCT_DMABUF_FD_INVALID;
+    ucs_status_t status;
+    ucs_memory_info_t mem_info;
+
+    status = uct_ze_copy_md_query_attributes(md, addr, length, &mem_info,
+                                             &dmabuf_fd);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_memtype_cache_update(mem_info.base_address, mem_info.alloc_length,
+                             mem_info.type, mem_info.sys_dev);
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_MEM_TYPE) {
+        mem_attr_p->mem_type = mem_info.type;
+    }
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_SYS_DEV) {
+        mem_attr_p->sys_dev = mem_info.sys_dev;
+    }
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS) {
+        mem_attr_p->base_address = mem_info.base_address;
+    }
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH) {
+        mem_attr_p->alloc_length = mem_info.alloc_length;
+    }
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_FD) {
+        mem_attr_p->dmabuf_fd = dup(dmabuf_fd);
+    }
+
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET) {
+        mem_attr_p->dmabuf_offset = UCS_PTR_BYTE_DIFF(mem_info.base_address,
+                                                      addr);
+    }
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ze_copy_md_detect_memory_type(uct_md_h md, const void *addr, size_t length,
+                                  ucs_memory_type_t *mem_type_p)
+{
+    uct_md_mem_attr_t mem_attr;
+    ucs_status_t status;
+
+    mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE;
+    status = uct_ze_copy_md_mem_query(md, addr, length, &mem_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *mem_type_p = mem_attr.mem_type;
+    return UCS_OK;
+}
+
+static uct_md_ops_t md_ops = {
+    .close              = uct_ze_copy_md_close,
+    .query              = uct_ze_copy_md_query,
+    .mem_alloc          = uct_ze_copy_mem_alloc,
+    .mem_free           = uct_ze_copy_mem_free,
+    .mkey_pack          = ucs_empty_function_return_success,
+    .mem_reg            = uct_ze_copy_mem_reg,
+    .mem_dereg          = ucs_empty_function_return_success,
+    .mem_attach         = ucs_empty_function_return_unsupported,
+    .mem_query          = uct_ze_copy_md_mem_query,
+    .detect_memory_type = uct_ze_copy_md_detect_memory_type,
+};
+
+static ucs_status_t
+uct_ze_copy_md_open(uct_component_h component, const char *md_name,
+                    const uct_md_config_t *md_config, uct_md_h *md_p)
+{
+    uct_ze_copy_md_config_t *config = ucs_derived_of(md_config,
+                                                     uct_ze_copy_md_config_t);
+    uct_ze_copy_md_t *md;
+    ze_driver_handle_t ze_driver;
+    ze_context_desc_t context_desc = {};
+    ze_result_t ret;
+
+    ze_driver = uct_ze_base_get_driver();
+    if (ze_driver == NULL) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    md = ucs_malloc(sizeof(uct_ze_copy_md_t), "uct_ze_copy_md_t");
+    if (NULL == md) {
+        ucs_error("Failed to allocate memory for uct_ze_copy_md_t");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    md->ze_device = uct_ze_base_get_device(config->device_ordinal);
+    if (md->ze_device == NULL) {
+        ucs_error("Failed to get device at ordial %d", config->device_ordinal);
+        ucs_free(md);
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    ret = zeContextCreate(ze_driver, &context_desc, &md->ze_context);
+    if (ret != ZE_RESULT_SUCCESS) {
+        ucs_error("zeContextCreate failed with error %x", ret);
+        ucs_free(md);
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    md->super.ops       = &md_ops;
+    md->super.component = &uct_ze_copy_component;
+
+    *md_p = (uct_md_h)md;
+    return UCS_OK;
+}
+
+uct_component_t uct_ze_copy_component = {
+    .query_md_resources = uct_ze_base_query_md_resources,
+    .md_open            = uct_ze_copy_md_open,
+    .cm_open            = ucs_empty_function_return_unsupported,
+    .rkey_unpack        = uct_ze_copy_rkey_unpack,
+    .rkey_ptr           = ucs_empty_function_return_unsupported,
+    .rkey_release       = ucs_empty_function_return_success,
+    .name               = "ze_cpy",
+    .md_config = {
+        .name       = "ze-copy memory domain",
+        .prefix     = "ZE_COPY_",
+        .table      = uct_ze_copy_md_config_table,
+        .size       = sizeof(uct_ze_copy_md_config_t),
+    },
+    .cm_config      = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
+    .tl_list        = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_ze_copy_component),
+    .flags          = 0,
+    .md_vfs_init    = (uct_component_md_vfs_init_func_t)ucs_empty_function
+};
+UCT_COMPONENT_REGISTER(&uct_ze_copy_component);

--- a/src/uct/ze/copy/ze_copy_md.h
+++ b/src/uct/ze/copy/ze_copy_md.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_ZE_COPY_MD_H
+#define UCT_ZE_COPY_MD_H
+
+#include <level_zero/ze_api.h>
+#include <uct/base/uct_md.h>
+#include <ucs/config/types.h>
+
+
+extern uct_component_t uct_ze_copy_component;
+
+
+/*
+ * @brief ze_copy MD descriptor
+ */
+typedef struct uct_ze_copy_md {
+    uct_md_t            super; /**< Domain info */
+    ze_context_handle_t ze_context;
+    ze_device_handle_t  ze_device;
+} uct_ze_copy_md_t;
+
+
+/**
+ * ze copy domain configuration.
+ */
+typedef struct uct_ze_copy_md_config {
+    uct_md_config_t super;
+    int             device_ordinal;
+} uct_ze_copy_md_config_t;
+
+
+#endif

--- a/src/uct/ze/ucx-ze.pc.in
+++ b/src/uct/ze/ucx-ze.pc.in
@@ -1,0 +1,12 @@
+#
+# Copyright (C) Intel Corporation, 2023. All rights reserved.
+#
+# See file LICENSE for terms.
+#
+
+Name: @PACKAGE@-ze
+Description: Unified Communication X Library ZE module
+Version: @VERSION@
+Libs:
+Libs.private:
+

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -10,6 +10,7 @@
 %bcond_with    xpmem
 %bcond_with    vfs
 %bcond_with    mad
+%bcond_with    ze
 
 Name: ucx
 Version: @VERSION@
@@ -55,6 +56,9 @@ BuildRequires: pkgconfig(cray-xpmem)
 %endif
 %if %{with vfs}
 BuildRequires: fuse3-devel
+%endif
+%if %{with ze}
+BuildRequires: level-zero-devel
 %endif
 %if "%{debug}" == "1"
 BuildRequires: valgrind-devel
@@ -117,6 +121,7 @@ Provides header files and examples for developing with UCX.
            %_with_arg vfs fuse3 \
            %_with_arg ugni ugni \
            %_with_arg mad mad \
+           %_with_arg ze ze \
            %{?configure_options}
 make %{?_smp_mflags} V=1
 
@@ -360,6 +365,20 @@ library internals, protocol objects, transports status, and more.
 %files vfs
 %{_libdir}/ucx/libucs_fuse.so.*
 %{_bindir}/ucx_vfs
+%endif
+
+%if %{with ze}
+%package ze
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Summary: UCX ZE GPU support
+Group: System Environment/Libraries
+
+%description ze
+Provides oneAPI Level Zero (ZE) Runtime support for UCX.
+
+%files ze
+%{_libdir}/ucx/libuct_ze.so.*
+%{_libdir}/ucx/libucm_ze.so.*
 %endif
 
 %changelog


### PR DESCRIPTION
This PR add support for oneAPI Level-Zero (ZE) library that is used by Intel GPU.  

Existing code already support CUDA and ROCM. Adding ZE support allows the
software to work on more GPUs.

The infrastructure is already there. To support ZE, new memory types are added,
new memory hooks are defined, a new transport is added, and some minor changes
are made to UCP core to accommodate the new memory types. New memory
allocators are also added for the performance test tool.