### PR TITLE
UCT/MM: fix possible sending in out-of-order.

### DIFF
--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) UT-Battelle, LLC. 2014-2015. ALL RIGHTS RESERVED.
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2021. ALL RIGHTS RESERVED.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2023. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -243,6 +244,10 @@ uct_mm_progress_fifo_tail(uct_mm_iface_t *iface)
     if (iface->read_index & iface->fifo_release_factor_mask) {
         return;
     }
+
+    /* memory barrier - make sure that the memory is flushed before update the
+     * FIFO tail */
+    ucs_memory_cpu_store_fence();
 
     iface->recv_fifo_ctl->tail = iface->read_index;
 }


### PR DESCRIPTION
## What
I found that osu_gatherv sometimes hangs when using UCX_TLS=sm in a single aarch64 node (Kunpeng 920). 
Command is below:
`mpirun -np 128 -x UCX_TLS=sm osu_gatherv -m 65536:65535`
When I reduced the fifo size, the probability increased.
`mpirun -np 128 -x UCX_TLS=sm -x UCX_MM_FIFO_SIZE=2 osu_gatherv -m 65536:65535`

## Why ?
When receiver invoked am callback return not OK in function `uct_mm_iface_process_recv`, here ucx will assign a new receive descriptor to FIFO element and update fifo tail. In aarch64 machine, the sender may get the new tail while pack data to a old FIFO element.

## How ?
memory fence should be added before tail update.
