### PR TITLE
UCP: Fix proto select hash race

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2517,6 +2517,10 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
 
     ucs_array_init_dynamic(&worker->ep_config);
 
+    /* Reserve 32 elements for ep configs, which should be enough for most
+     * of the use-cases. Will be extended automatically otherwise. */
+    ucs_array_reserve(ep_config_arr, &worker->ep_config, 32);
+
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&worker->stats, &ucp_worker_stats_class,
                                   ucs_stats_get_root(), "-%p", worker);

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -293,7 +293,7 @@ void ucp_proto_select_info(ucp_worker_h worker,
     ucp_proto_select_elem_t select_elem;
     ucp_proto_select_key_t key;
 
-    kh_foreach(&proto_select->hash, key.u64, select_elem,
+    kh_foreach(proto_select->hash, key.u64, select_elem,
                ucp_proto_select_elem_info(worker, ep_cfg_index, rkey_cfg_index,
                                           &key.param, &select_elem, show_all,
                                           strb);

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -128,7 +128,7 @@ KHASH_TYPE(ucp_proto_select_hash, khint64_t, ucp_proto_select_elem_t)
  */
 typedef struct {
     /* Lookup from protocol selection key to thresholds array */
-    khash_t(ucp_proto_select_hash)    hash;
+    khash_t(ucp_proto_select_hash)    *hash;
 
     /* cache the last used protocol, for fast lookup */
     struct {

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -109,10 +109,10 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
     if (ucs_likely(proto_select->cache.key == key.u64)) {
         select_elem = proto_select->cache.value;
     } else {
-        khiter = kh_get(ucp_proto_select_hash, &proto_select->hash, key.u64);
-        if (ucs_likely(khiter != kh_end(&proto_select->hash))) {
+        khiter = kh_get(ucp_proto_select_hash, proto_select->hash, key.u64);
+        if (ucs_likely(khiter != kh_end(proto_select->hash))) {
             /* key was found in hash - select by message size */
-            select_elem = &kh_value(&proto_select->hash, khiter);
+            select_elem = &kh_value(proto_select->hash, khiter);
         } else {
             select_elem = ucp_proto_select_lookup_slow(worker, proto_select, 0,
                                                        ep_cfg_index,


### PR DESCRIPTION
## What
When the ucp_ep_config array is extended by the async thread, the main thread may modify ep_config->proto_select.hash by adding new protocol selections. These newly added elements will not be reflected in the new ep_config_array and will be released together with the old ep_config array. Using a pointer to the hash in proto_select fixes this issue because the hash will persist in memory regardless of ep_config array reallocations.


## Why ?
Fixes [RM3633376](https://redmine.mellanox.com/issues/3633376) (internal link)
