### PR TITLE
UCT/MD/IB: Fix indirect key creation for MT registered memory

### DIFF
--- a/test/gtest/uct/ib/test_ib_xfer.cc
+++ b/test/gtest/uct/ib/test_ib_xfer.cc
@@ -7,6 +7,10 @@
 #include <uct/test_p2p_rma.h>
 #include <uct/test_p2p_mix.h>
 
+#include <uct/ib/base/ib_md.h>
+#ifdef HAVE_MLX5_DV
+#include <uct/ib/mlx5/ib_mlx5.h>
+#endif
 
 class uct_p2p_rma_test_xfer : public uct_p2p_rma_test {};
 
@@ -130,13 +134,92 @@ UCS_TEST_P(uct_p2p_mix_test_alloc_methods, mix1000)
     run(1000);
 }
 
-UCS_TEST_P(uct_p2p_mix_test_alloc_methods, mix1000_multithreaded,
-           "IB_REG_MT_THRESH=1", "IB_REG_MT_CHUNK=1K", "IB_REG_MT_BIND=y")
+UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_alloc_methods)
+
+
+class uct_p2p_mix_test_mt : public uct_p2p_mix_test {
+protected:
+    bool is_page_size_aligned(const mapped_buffer &buffer)
+    {
+        return ucs_padding((size_t)buffer.reg_addr(), ucs_get_page_size()) == 0;
+    }
+
+    mapped_buffer alloc_buffer(const entity &entity, size_t offset) override
+    {
+        mapped_buffer buf = uct_p2p_mix_test::alloc_buffer(entity, offset);
+        if (!is_page_size_aligned(buf)) {
+            UCS_TEST_SKIP_R("Skip MT registration for unaligned buffers");
+        }
+
+        auto *ib_memh = static_cast<uct_ib_mem_t*>(buf.memh());
+        EXPECT_TRUE(ib_memh->flags & UCT_IB_MEM_MULTITHREADED);
+        return buf;
+    }
+
+    bool check_md_flags()
+    {
+#if HAVE_DEVX
+        auto *ib_md = ucs_derived_of(sender().md(), uct_ib_md_t);
+        if (strcmp(ib_md->name, UCT_IB_MD_NAME(mlx5))) {
+            return false;
+        }
+
+        auto *ib_mlx5_md = ucs_derived_of(sender().md(), uct_ib_mlx5_md_t);
+        return (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_KSM) &&
+               (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS);
+#else
+        return false;
+#endif
+    }
+
+    virtual void init() override
+    {
+        push_config();
+        modify_config("IB_REG_MT_THRESH", ucs::to_string(reg_mt_chunk + 1));
+        modify_config("IB_REG_MT_CHUNK", ucs::to_string(reg_mt_chunk));
+
+        uct_p2p_mix_test::init();
+
+        if (!check_md_flags()) {
+            UCS_TEST_SKIP_R("KSM and indirect atomics are required for MT "
+                            "registration");
+        }
+
+        /* Too many chunks causes MT registration failure since DEVX
+         * input structure became too big */
+        m_buffer_size = ucs_min(m_buffer_size, 256 * reg_mt_chunk);
+        /* We need at least two chunks */
+        m_buffer_size = ucs_max(m_buffer_size, reg_mt_chunk + 1);
+    }
+
+    virtual void cleanup() override
+    {
+        uct_p2p_mix_test::cleanup();
+        pop_config();
+    }
+
+    constexpr static size_t reg_mt_chunk = 16 * UCS_KBYTE;
+};
+
+constexpr size_t uct_p2p_mix_test_mt::reg_mt_chunk;
+
+UCS_TEST_P(uct_p2p_mix_test_mt, mix1000_alloc_methods, "IB_REG_MT_BIND=y")
 {
     run(1000);
 }
 
-UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_alloc_methods)
+UCS_TEST_P(uct_p2p_mix_test_mt, mix1000)
+{
+    run(1000);
+}
+
+UCS_TEST_P(uct_p2p_mix_test_mt, mix1000_last_byte_offset)
+{
+    /* Alloc 2 chunks buffer, but perform the operations on the last 8 bytes */
+    run(1000, (reg_mt_chunk * 2) - 8, 8);
+}
+
+UCT_INSTANTIATE_IB_TEST_CASE(uct_p2p_mix_test_mt)
 
 
 class uct_p2p_mix_test_indirect_atomic : public uct_p2p_mix_test {};

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -101,7 +101,7 @@ void test_md::test_reg_mem(unsigned access_mask,
     params.flags       = UCT_MD_MEM_DEREG_FLAG_INVALIDATE;
     params.comp        = &comp().comp;
 
-    if (!is_supported_reg_mem_flags(access_mask)) {
+    if (!check_invalidate_support(access_mask)) {
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_COMPLETION |
                             UCT_MD_MEM_DEREG_FIELD_FLAGS |
                             UCT_MD_MEM_DEREG_FIELD_MEMH;
@@ -173,7 +173,7 @@ test_md::test_md()
     /* coverity[uninit_member] */
 }
 
-bool test_md::is_supported_reg_mem_flags(unsigned reg_flags) const
+bool test_md::check_invalidate_support(unsigned reg_flags) const
 {
     return (reg_flags & md_flags_remote_rma) ?
            check_caps(UCT_MD_FLAG_INVALIDATE_RMA) :

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -30,7 +30,7 @@ public:
 
     test_md();
 
-    bool is_supported_reg_mem_flags(unsigned reg_flags) const;
+    bool check_invalidate_support(unsigned reg_flags) const;
 
     bool is_bf_arm() const;
 

--- a/test/gtest/uct/test_p2p_mix.h
+++ b/test/gtest/uct/test_p2p_mix.h
@@ -41,6 +41,8 @@ protected:
                            const mapped_buffer &recvbuf,
                            uct_completion_t *comp);
 
+    static size_t pack_bcopy(void *dest, void *arg);
+
     ucs_status_t put_bcopy(const mapped_buffer &sendbuf,
                            const mapped_buffer &recvbuf,
                            uct_completion_t *comp);
@@ -58,16 +60,28 @@ protected:
 
     void random_op(const mapped_buffer &sendbuf, const mapped_buffer &recvbuf);
 
-    void run(unsigned count);
+    virtual mapped_buffer alloc_buffer(const entity &entity, size_t offset);
+
+    void run(unsigned count, size_t offset = 0, size_t size_cap = SIZE_MAX);
 
     virtual void init();
 
     virtual void cleanup();
 
+    size_t max_buffer_size() const;
+
+    size_t                   m_buffer_size;
+
 private:
     std::vector<send_func_t> m_avail_send_funcs;
-    size_t                   m_send_size;
+    size_t                   m_max_short, m_max_bcopy, m_max_zcopy;
+
     static uint32_t          am_pending;
+
+    struct bcopy_pack_arg {
+        const mapped_buffer *sendbuf;
+        size_t              max_bcopy;
+    };
 };
 
 #endif

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1367,40 +1367,53 @@ std::ostream& operator<<(std::ostream& os, const uct_tl_resource_desc_t& resourc
     return os << resource.tl_name << "/" << resource.dev_name;
 }
 
+void uct_test::mapped_buffer::reset()
+{
+    m_mem.method   = UCT_ALLOC_METHOD_LAST;
+    m_mem.address  = NULL;
+    m_mem.md       = NULL;
+    m_mem.memh     = UCT_MEM_HANDLE_NULL;
+    m_mem.mem_type = UCS_MEMORY_TYPE_HOST;
+    m_mem.length   = 0;
+    m_buf          = NULL;
+    m_end          = NULL;
+    m_iov.buffer   = NULL;
+    m_iov.length   = 0;
+    m_iov.count    = 1;
+    m_iov.stride   = 0;
+    m_iov.memh     = UCT_MEM_HANDLE_NULL;
+    m_rkey.rkey    = UCT_INVALID_RKEY;
+    m_rkey.handle  = NULL;
+    m_rkey.type    = NULL;
+}
+
 uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
                                        const entity &entity, size_t offset,
                                        ucs_memory_type_t mem_type,
                                        unsigned mem_flags) :
     m_entity(entity)
 {
-    if (size > 0)  {
-        size_t alloc_size = size + offset;
-        if (mem_type == UCS_MEMORY_TYPE_HOST) {
-            m_entity.mem_alloc_host(alloc_size, mem_flags, &m_mem);
-        } else {
-            m_mem.method   = UCT_ALLOC_METHOD_LAST;
-            m_mem.address  = mem_buffer::allocate(alloc_size, mem_type);
-            m_mem.length   = alloc_size;
-            m_mem.mem_type = mem_type;
-            m_mem.memh     = UCT_MEM_HANDLE_NULL;
-            m_mem.md       = NULL;
-            m_entity.mem_type_reg(&m_mem, mem_flags);
-        }
-        m_buf = (char*)m_mem.address + offset;
-        m_end = (char*)m_buf         + size;
-        pattern_fill(seed);
-    } else {
-        m_mem.method  = UCT_ALLOC_METHOD_LAST;
-        m_mem.address = NULL;
-        m_mem.md      = NULL;
-        m_mem.memh    = UCT_MEM_HANDLE_NULL;
-        m_mem.mem_type= UCS_MEMORY_TYPE_HOST;
-        m_mem.length  = 0;
-        m_buf         = NULL;
-        m_end         = NULL;
-        m_rkey.rkey   = UCT_INVALID_RKEY;
-        m_rkey.handle = NULL;
+    if (size == 0)  {
+        reset();
+        return;
     }
+
+    size_t alloc_size = size + offset;
+    if (mem_type == UCS_MEMORY_TYPE_HOST) {
+        m_entity.mem_alloc_host(alloc_size, mem_flags, &m_mem);
+    } else {
+        m_mem.method   = UCT_ALLOC_METHOD_LAST;
+        m_mem.address  = mem_buffer::allocate(alloc_size, mem_type);
+        m_mem.length   = alloc_size;
+        m_mem.mem_type = mem_type;
+        m_mem.memh     = UCT_MEM_HANDLE_NULL;
+        m_mem.md       = NULL;
+        m_entity.mem_type_reg(&m_mem, mem_flags);
+    }
+
+    m_buf = (char*)m_mem.address + offset;
+    m_end = (char*)m_buf         + size;
+    pattern_fill(seed);
     m_iov.buffer = ptr();
     m_iov.length = length();
     m_iov.count  = 1;
@@ -1409,6 +1422,13 @@ uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
 
     m_entity.rkey_unpack(&m_mem, &m_rkey);
     m_rkey.type  = NULL;
+}
+
+uct_test::mapped_buffer::mapped_buffer(mapped_buffer &&other) :
+    m_entity(other.m_entity), m_buf(other.m_buf), m_end(other.m_end),
+    m_rkey(other.m_rkey), m_mem(other.m_mem), m_iov(other.m_iov)
+{
+    other.reset();
 }
 
 uct_test::mapped_buffer::~mapped_buffer() {
@@ -1451,6 +1471,16 @@ uct_mem_h uct_test::mapped_buffer::memh() const {
     return m_mem.memh;
 }
 
+ucs_memory_type_t uct_test::mapped_buffer::mem_type() const
+{
+    return m_mem.mem_type;
+}
+
+void *uct_test::mapped_buffer::reg_addr() const
+{
+    return m_mem.address;
+}
+
 uct_rkey_t uct_test::mapped_buffer::rkey() const {
     return m_rkey.rkey;
 }
@@ -1461,7 +1491,7 @@ const uct_iov_t*  uct_test::mapped_buffer::iov() const {
 
 size_t uct_test::mapped_buffer::pack(void *dest, void *arg) {
     const mapped_buffer* buf = (const mapped_buffer*)arg;
-    mem_buffer::copy_from(dest, buf->ptr(), buf->length(), buf->m_mem.mem_type);
+    mem_buffer::copy_from(dest, buf->ptr(), buf->length(), buf->mem_type());
     return buf->length();
 }
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -246,10 +246,14 @@ protected:
                       unsigned mem_flags = UCT_MD_MEM_ACCESS_ALL);
         virtual ~mapped_buffer();
 
+        mapped_buffer(mapped_buffer &&other);
+
         void *ptr() const;
         uintptr_t addr() const;
         size_t length() const;
         uct_mem_h memh() const;
+        ucs_memory_type_t mem_type() const;
+        void *reg_addr() const;
         uct_rkey_t rkey() const;
         const uct_iov_t* iov() const;
 
@@ -260,6 +264,7 @@ protected:
         static size_t pack(void *dest, void *arg);
 
     private:
+        void reset();
 
         const uct_test::entity& m_entity;
 


### PR DESCRIPTION
## What
Support indirect keys creation for memory regions that were created by multiple treads.

## Why ?
MT memory registration can happen (or not) implicitly for large buffers, but the current code doesn't support indirect keys creation for such registration (it always assumes that MR was registered as contig buffer by one thread)

## How ?
Create `uct_ib_mlx5_devx_reg_ksm_data` wrapper that separates KSM creation method by MR flags.