### PR TITLE
UCP/RNDV: Fixed rendezvous protocol query.

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -462,7 +462,7 @@ void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
                                 params->msg_length, &remote_attr);
 
     attr->is_estimation  = 1;
-    attr->max_msg_length = SIZE_MAX;
+    attr->max_msg_length = remote_attr.max_msg_length;
     attr->lane_map       = UCS_BIT(rpriv->lane);
 
     ucs_snprintf_safe(attr->desc, sizeof(attr->desc), "rendezvous %s",


### PR DESCRIPTION
## What
Fixed rendezvous protocol query.

## Why ?
Fixed proto info output.
Before:
```
+---------------------------+--------------------------------------------------------------+
| perftest intra-node cfg#2 | active message by ucp_am_send* from host memory              |
+---------------------------+-----------------------------------------------+--------------+
|                     0..92 | short                                         | sysv/memory  |
|                  93..2824 | copy-in                                       | sysv/memory  |
|                 2825..inf | (?) rendezvous copy from mapped remote memory | xpmem/memory |
+---------------------------+-----------------------------------------------+--------------+
+---------------------------+--------------------------------------------------------+
| perftest intra-node cfg#2 | active message by ucp_am_send*(rndv) from cuda/GPU0    |
+---------------------------+-----------------------------------------------------+--+
|                    0..inf | (?) rendezvous no data fetch                        |  |
+---------------------------+-----------------------------------------------------+--+
```
After:
```
+---------------------------+---------------------------------------------------------------------------------------------------------+
| perftest intra-node cfg#2 | active message by ucp_am_send* from host memory                                                         |
+---------------------------+--------------------------------------------------+------------------------------------------------------+
|                     0..92 | short                                            | sysv/memory                                          |
|                  93..2824 | copy-in                                          | sysv/memory                                          |
|               2825..91537 | (?) rendezvous copy from mapped remote memory    | xpmem/memory                                         |
|  91538..5713982720063549K | (?) rendezvous zero-copy flushed write to remote | 35% on knem/memory and 65% on rc_mlx5/mlx5_0:1/path0 |
|  5851118305345074177..inf | (?) rendezvous zero-copy read from remote        | 35% on knem/memory and 65% on rc_mlx5/mlx5_0:1/path0 |
+---------------------------+--------------------------------------------------+------------------------------------------------------+
+---------------------------+--------------------------------------------------------------------------------------------------------------------+
| perftest intra-node cfg#2 | active message by ucp_am_send*(rndv) from cuda/GPU0                                                                |
+---------------------------+--------------------------------------------------+-----------------------------------------------------------------+
|                         0 | (?) rendezvous no data fetch                     |                                                                 |
|                    1..159 | (?) rendezvous fragmented copy-in copy-out       | sysv/memory                                                     |
|                160..27214 | (?) rendezvous zero-copy read from remote        | 50% on rc_mlx5/mlx5_0:1/path0 and 50% on rc_mlx5/mlx5_1:1/path0 |
|                27215..inf | (?) rendezvous zero-copy flushed write to remote | cuda_ipc/cuda                                                   |
+---------------------------+--------------------------------------------------+-----------------------------------------------------------------+
```