### PR TITLE
AZP: Handle multiple log files

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -101,17 +101,14 @@ stages:
             workingDirectory: $(WorkDir)
 
           - bash: |
-              set -x
-              cat perfx.log
-            displayName: Print raw log
+              set -xe
+              sep_line="######################"
+              for file in *.log; do
+                  echo -e "$sep_line $file $sep_line"
+                  cat "$file"
+              done
+            displayName: Print logs
             workingDirectory: $(WorkDir)/PerfX
-            condition: always()
-
-          - task: PublishBuildArtifacts@1
-            inputs:
-              pathToPublish: '$(WorkDir)/PerfX/perfx.log'
-              artifactName: perfx.log
-            displayName: Publish raw log
             condition: always()
 
 

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -22,6 +22,7 @@ pr:
     - AUTHORS
     - buildlib/azure-pipelines-perf.yml
     - buildlib/tools/perf_results.py
+    - buildlib/tools/perf-common.yml
 
 extends:
   template: pr/main.yml

--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -40,5 +40,13 @@ steps:
         --after "$SHA_After" \
         --config ucx-rdmz.yml \
         "${perfxParams[@]}" | tee $(WorkDir)/results-${{ parameters.Name }}.txt
+      mv $(WorkDir)/PerfX/perfx.log $(WorkDir)/PerfX/${{ parameters.Name }}.log
     displayName: ${{ parameters.Name }}
     workingDirectory: $(WorkDir)
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: $(WorkDir)/PerfX/${{ parameters.Name }}.log
+      artifactName: perfx_logs
+    displayName: Publish log
+    condition: always()


### PR DESCRIPTION
## What
Save PerfX log file per job. 
Preserve as artifacts and show in the build log.

### Before:
perfx.log got overwritten, so only the last one was handled.