### PR TITLE
UCT/IB/MLX5/DV: turning off memic feature temporarily until fixing related proto issues

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1384,7 +1384,7 @@ static void uct_ib_mlx5dv_check_dm_ksm_reg(uct_ib_mlx5_md_t *md)
     }
 
     /* Indicates we can allocate device memory */
-    md->super.cap_flags |= UCT_MD_FLAG_ALLOC;
+    /*TODO: md->super.cap_flags |= UCT_MD_FLAG_ALLOC; */
 #endif
 }
 


### PR DESCRIPTION
## What
Turning off device memory allocation feature

## Why ?
Currently ib being able to alloc memory is causing issues in the ucp/proto level

## How ?
disabling UCT_MD_FLAG_ALLOC for now until finding a proper solution, as the main purpose of this feature depends on FW update
