### PR TITLE
AZP: rm Centos8 refs to DockerHub - v1.15.x

### DIFF
--- a/buildlib/pr/cuda/cuda.yml
+++ b/buildlib/pr/cuda/cuda.yml
@@ -43,16 +43,6 @@ jobs:
           CONTAINER: centos7_cuda_11_3
         centos7_cuda_11_4:
           CONTAINER: centos7_cuda_11_4
-        centos8_cuda_11_0:
-          CONTAINER: centos8_cuda_11_0
-        centos8_cuda_11_1:
-          CONTAINER: centos8_cuda_11_1
-        centos8_cuda_11_2:
-          CONTAINER: centos8_cuda_11_2
-        centos8_cuda_11_3:
-          CONTAINER: centos8_cuda_11_3
-        centos8_cuda_11_4:
-          CONTAINER: centos8_cuda_11_4
         ubi8_cuda_11_5:
           CONTAINER: ubi8_cuda_11_5
         ubi8_cuda_11_6:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -75,21 +75,6 @@ resources:
     - container: centos7_cuda_11_4
       image: nvidia/cuda:11.4.3-devel-centos7
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos8_cuda_11_0
-      image: nvidia/cuda:11.0.3-devel-centos8
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos8_cuda_11_1
-      image: nvidia/cuda:11.1.1-devel-centos8
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos8_cuda_11_2
-      image: nvidia/cuda:11.2.2-devel-centos8
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos8_cuda_11_3
-      image: nvidia/cuda:11.3.1-devel-centos8
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
-    - container: centos8_cuda_11_4
-      image: nvidia/cuda:11.4.3-devel-centos8
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
     - container: ubi8_cuda_11_5
       image: nvidia/cuda:11.5.2-devel-ubi8
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)


### PR DESCRIPTION
## What
Porting https://github.com/openucx/ucx/pull/9422 to v1.15.x
CentOS 8 cuda images were removed from DockerHub.