### PR TITLE
UCS/CONFIG: Cleanup the configuration parser after profiler cleanup

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -2119,7 +2119,8 @@ void ucs_config_parser_get_env_vars(ucs_string_buffer_t *env_strb,
     });
 }
 
-UCS_STATIC_CLEANUP {
+void ucs_config_parser_cleanup()
+{
     const char *key;
     char *value;
 

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -558,11 +558,17 @@ int ucs_config_names_search(const ucs_config_names_array_t *config_names,
                             const char *str);
 
 /**
- * @param   strb      An initiated ucs_string_buffer_t which will contain the env variables 
+ * @param   strb      An initiated ucs_string_buffer_t which will contain the env variables
  * @param   delimiter String that will seperate between each 2 env variables
 */
 void ucs_config_parser_get_env_vars(ucs_string_buffer_t *env_strb,
                                     const char *delimiter);
+
+
+/**
+ * Global cleanup of the configuration parser.
+ */
+void ucs_config_parser_cleanup();
 
 
 END_C_DECLS

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -130,6 +130,7 @@ static void UCS_F_DTOR ucs_cleanup(void)
     ucs_async_global_cleanup();
     ucs_profile_cleanup(ucs_profile_default_ctx);
     ucs_debug_cleanup(0);
+    ucs_config_parser_cleanup();
     ucs_memtrack_cleanup();
 #ifdef ENABLE_STATS
     ucs_stats_cleanup();


### PR DESCRIPTION
## Why
Fixes #9426
Fixes #9388