### PR TITLE
UCP/TAG: Populate tag_info on immediate completion

### DIFF
--- a/test/gtest/ucp/test_ucp_tag.h
+++ b/test/gtest/ucp/test_ucp_tag.h
@@ -26,7 +26,8 @@ public:
         RECV_NB,
         RECV_NBR,
         RECV_B,
-        RECV_BR
+        RECV_BR,
+        RECV_IMM
     };
 
 protected:
@@ -104,6 +105,10 @@ protected:
                         ucp_tag_t tag, ucp_tag_t tag_mask,
                         ucp_tag_recv_info_t *info, void *user_data = NULL,
                         int buf_index = 0);
+    ucs_status_t recv_imm(void *buffer, size_t count, ucp_datatype_t datatype,
+                          ucp_tag_t tag, ucp_tag_t tag_mask,
+                          ucp_tag_recv_info_t *info, void *user_data = NULL,
+                          int buf_index = 0);
 
     ucs_status_t recv_req_b(void *buffer, size_t count, ucp_datatype_t datatype,
                             ucp_tag_t tag, ucp_tag_t tag_mask,


### PR DESCRIPTION
## What
Return `tag_info` data on immediate completion when requested.

Fixes #9425 

## Why ?
Match existing documentation:
`NULL - The receive operation was completed immediately. In this case, if param->recv_info.tag_info is specified in the param, the value to which it points is updated with the information about the received message.`
## How ?
Populate field on immediate completion when receive info is passed and immediate completion is not prevented.