### PR TITLE
UCS/RCACHE: Add support for dynamic region alignment

### DIFF
--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -50,8 +50,8 @@ ucp_memh_get(ucp_context_h context, void *address, size_t length,
 
     if (ucs_likely(context->rcache != NULL)) {
         UCP_THREAD_CS_ENTER(&context->mt_lock);
-        rregion = ucs_rcache_lookup_unsafe(context->rcache, address, length,
-                                           PROT_READ | PROT_WRITE);
+        rregion   = ucs_rcache_lookup_unsafe(context->rcache, address, length,
+                                             1, PROT_READ | PROT_WRITE);
         if (rregion == NULL) {
             goto not_found;
         }

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -102,11 +102,6 @@ ucs_config_field_t ucs_config_rcache_table[] = {
     {"RCACHE_OVERHEAD", "auto", "Registration cache lookup overhead",
      ucs_offsetof(ucs_rcache_config_t, overhead), UCS_CONFIG_TYPE_TIME_UNITS},
 
-    {"RCACHE_ADDR_ALIGN", UCS_PP_MAKE_STRING(UCS_SYS_CACHE_LINE_SIZE),
-     "Registration cache address alignment, must be power of 2\n"
-     "between " UCS_PP_MAKE_STRING(UCS_PGT_ADDR_ALIGN) "and system page size",
-     ucs_offsetof(ucs_rcache_config_t, alignment), UCS_CONFIG_TYPE_MEMUNITS},
-
     {"RCACHE_MAX_REGIONS", "inf",
      "Maximal number of regions in the registration cache",
      ucs_offsetof(ucs_rcache_config_t, max_regions),
@@ -184,8 +179,6 @@ void ucs_rcache_region_log(const char *file, int line, const char *function,
 void ucs_rcache_set_default_params(ucs_rcache_params_t *rcache_params)
 {
     rcache_params->region_struct_size = sizeof(ucs_rcache_region_t);
-    rcache_params->alignment          = UCS_RCACHE_MIN_ALIGNMENT;
-    rcache_params->max_alignment      = ucs_get_page_size();
     rcache_params->ucm_events         = 0;
     rcache_params->ucm_event_priority = 1000;
     rcache_params->ops                = NULL;
@@ -201,7 +194,6 @@ void ucs_rcache_set_params(ucs_rcache_params_t *rcache_params,
 {
     ucs_rcache_set_default_params(rcache_params);
 
-    rcache_params->alignment          = rcache_config->alignment;
     rcache_params->ucm_event_priority = rcache_config->event_prio;
     rcache_params->max_regions        = rcache_config->max_regions;
     rcache_params->max_size           = rcache_config->max_size;
@@ -373,7 +365,7 @@ static void ucs_rcache_region_collect_callback(const ucs_pgtable_t *pgtable,
 static void ucs_rcache_find_regions(ucs_rcache_t *rcache, ucs_pgt_addr_t from,
                                     ucs_pgt_addr_t to, ucs_list_link_t *list)
 {
-    ucs_list_head_init(list);
+    ucs_trace("%s: find regions in 0x%lx..0x%lx", rcache->name, from, to);
     ucs_pgtable_search_range(&rcache->pgtable, from, to,
                              ucs_rcache_region_collect_callback, list);
 }
@@ -546,6 +538,7 @@ static void ucs_rcache_invalidate_range(ucs_rcache_t *rcache, ucs_pgt_addr_t sta
 
     ucs_trace_func("rcache=%s, start=0x%lx, end=0x%lx", rcache->name, start, end);
 
+    ucs_list_head_init(&region_list);
     ucs_rcache_find_regions(rcache, start, end - 1, &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, tmp_list) {
         /* all regions on the list are in the page table */
@@ -765,13 +758,84 @@ static void ucs_rcache_lru_evict(ucs_rcache_t *rcache)
 
 /* Lock must be held */
 static ucs_status_t
+ucs_rcache_check_overlap_one(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
+                             ucs_pgt_addr_t *end, size_t *alignment, int *prot,
+                             ucs_rcache_region_t *region)
+{
+    int mem_prot;
+
+    UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_MERGES, 1);
+    /*
+     * If we don't provide some of the permissions the other region had,
+     * we might want to expand our permissions to support them. We can
+     * do that only if the memory range actually has those permissions.
+     *  This will prevent the users of the other region to kick us out
+     * the next time.
+     */
+    if (!ucs_test_all_flags(*prot, region->prot)) {
+        /* A slow path because searching /proc/maps in order to
+         * check memory protection is very expensive.
+         *
+         * TODO: currently rcache is optimized for the case where most of
+         * the regions have same protection.
+         */
+        mem_prot = UCS_PROFILE_CALL_ALWAYS(ucs_get_mem_prot, *start, *end);
+        if (!ucs_test_all_flags(mem_prot, *prot)) {
+            ucs_rcache_region_trace(rcache, region,
+                                    "do not merge "UCS_RCACHE_PROT_FMT
+                                    " with mem "UCS_RCACHE_PROT_FMT,
+                                    UCS_RCACHE_PROT_ARG(*prot),
+                                    UCS_RCACHE_PROT_ARG(mem_prot));
+            /* The memory protection can not satisfy that of the
+             * region. However mem_reg still may be able to deal with it.
+             * Do the safest thing: invalidate cached region
+             */
+            ucs_rcache_region_invalidate_internal(
+                    rcache, region, UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
+            return UCS_ERR_CANCELED;
+        } else if (ucs_test_all_flags(mem_prot, region->prot)) {
+            *prot |= region->prot;
+        } else {
+            /* Could not support other region's permissions - so do not merge
+             * with it. If anybody will use the other region, this will kick
+             * out our region, and may potentially lead to ineffective use
+             * of the cache. We can't solve it as long as we have only one
+             * page table, since it does not allow overlap.
+             */
+            ucs_rcache_region_trace(rcache, region,
+                                    "do not merge mem "UCS_RCACHE_PROT_FMT" with",
+                                    UCS_RCACHE_PROT_ARG(mem_prot));
+            ucs_rcache_region_invalidate_internal(
+                    rcache, region, UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
+            return UCS_ERR_CANCELED;
+        }
+    }
+
+    ucs_rcache_region_trace(rcache, region,
+                            "merge 0x%lx..0x%lx "UCS_RCACHE_PROT_FMT" with",
+                            *start, *end, UCS_RCACHE_PROT_ARG(*prot));
+    *alignment = ucs_max(*alignment, region->alignment);
+    *start     = ucs_min(*start, region->super.start);
+    *end       = ucs_max(*end, region->super.end);
+
+    /* coverity[double_unlock] */
+    /* coverity[double_lock] */
+    ucs_rcache_region_invalidate_internal(
+            rcache, region, UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
+
+    return UCS_OK;
+}
+
+/* Lock must be held */
+static ucs_status_t
 ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
-                         ucs_pgt_addr_t *end, int *prot, int *merged,
-                         ucs_rcache_region_t **region_p)
+                         ucs_pgt_addr_t *end, size_t *alignment, int *prot,
+                         int *merged, ucs_rcache_region_t **region_p)
 {
     ucs_rcache_region_t *region, *tmp;
+    ucs_pgt_addr_t old_start, old_end;
     ucs_list_link_t region_list;
-    int mem_prot;
+    ucs_status_t status;
 
     ucs_trace_func("rcache=%s, *start=0x%lx, *end=0x%lx", rcache->name, *start,
                    *end);
@@ -780,78 +844,43 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
     /* coverity[double_unlock] */
     ucs_rcache_check_gc_list(rcache, 1);
 
+    ucs_list_head_init(&region_list);
     ucs_rcache_find_regions(rcache, *start, *end - 1, &region_list);
 
+    region = ucs_list_next(&region_list, ucs_rcache_region_t, tmp_list);
+    if (ucs_list_is_only(&region_list, &region->tmp_list) &&
+        (*start >= region->super.start) && (*end <= region->super.end) &&
+        ucs_rcache_region_test(region, *prot, *alignment)) {
+        /* Found a region which contains the given address range */
+        ucs_rcache_region_hold(rcache, region);
+        *region_p = region;
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
     /* TODO check if any of the regions is locked */
+    do {
+        old_start = *start;
+        old_end   = *end;
 
-    ucs_list_for_each_safe(region, tmp, &region_list, tmp_list) {
-        if ((*start >= region->super.start) && (*end <= region->super.end) &&
-            ucs_rcache_region_test(region, *prot))
-        {
-            /* Found a region which contains the given address range */
-            ucs_rcache_region_hold(rcache, region);
-            *region_p = region;
-            return UCS_ERR_ALREADY_EXISTS;
-        }
-
-        UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_MERGES, 1);
-        /*
-         * If we don't provide some of the permissions the other region had,
-         * we might want to expand our permissions to support them. We can
-         * do that only if the memory range actually has those permissions.
-         *  This will prevent the users of the other region to kick us out
-         * the next time.
-         */
-        if (!ucs_test_all_flags(*prot, region->prot)) {
-            /* A slow path because searching /proc/maps in order to
-             * check memory protection is very expensive.
-             *
-             * TODO: currently rcache is optimized for the case where most of
-             * the regions have same protection.
-             */
-            mem_prot = UCS_PROFILE_CALL_ALWAYS(ucs_get_mem_prot, *start, *end);
-            if (!ucs_test_all_flags(mem_prot, *prot)) {
-                ucs_rcache_region_trace(rcache, region,
-                                        "do not merge "UCS_RCACHE_PROT_FMT
-                                        " with mem "UCS_RCACHE_PROT_FMT,
-                                        UCS_RCACHE_PROT_ARG(*prot),
-                                        UCS_RCACHE_PROT_ARG(mem_prot));
-                /* The memory protection can not satisfy that of the
-                 * region. However mem_reg still may be able to deal with it.
-                 * Do the safest thing: invalidate cached region
-                 */
-                ucs_rcache_region_invalidate_internal(
-                        rcache, region, UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
-                continue;
-            } else if (ucs_test_all_flags(mem_prot, region->prot)) {
-                *prot |= region->prot;
-            } else {
-                /* Could not support other region's permissions - so do not merge
-                 * with it. If anybody will use the other region, this will kick
-                 * out our region, and may potentially lead to ineffective use
-                 * of the cache. We can't solve it as long as we have only one
-                 * page table, since it does not allow overlap.
-                 */
-                ucs_rcache_region_trace(rcache, region,
-                                        "do not merge mem "UCS_RCACHE_PROT_FMT" with",
-                                        UCS_RCACHE_PROT_ARG(mem_prot));
-                ucs_rcache_region_invalidate_internal(
-                        rcache, region, UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
-                continue;
+        ucs_list_for_each_safe(region, tmp, &region_list, tmp_list) {
+            status = ucs_rcache_check_overlap_one(rcache, start, end, alignment,
+                                                  prot, region);
+            if (status == UCS_OK) {
+                *merged = 1;
             }
         }
 
-        ucs_rcache_region_trace(rcache, region,
-                                "merge 0x%lx..0x%lx "UCS_RCACHE_PROT_FMT" with",
-                                *start, *end, UCS_RCACHE_PROT_ARG(*prot));
-        *start  = ucs_min(*start, region->super.start);
-        *end    = ucs_max(*end,   region->super.end);
-        *merged = 1;
-        /* coverity[double_unlock] */
-        /* coverity[double_lock] */
-        ucs_rcache_region_invalidate_internal(
-                rcache, region, UCS_RCACHE_REGION_PUT_FLAG_IN_PGTABLE);
-    }
+        *start = ucs_align_down_pow2(*start, *alignment);
+        *end   = ucs_align_up_pow2(*end, *alignment);
+
+        /* Overlapping regions might necessitate a larger alignment, which,
+         * in turn, can result in even more overlapping regions.
+         */
+        ucs_list_head_init(&region_list);
+        ucs_rcache_find_regions(rcache, *start, old_start - 1, &region_list);
+        ucs_rcache_find_regions(rcache, old_end, *end - 1, &region_list);
+    } while (!ucs_list_is_empty(&region_list));
+
     return UCS_OK;
 }
 
@@ -887,9 +916,9 @@ static ucs_status_t ucs_rcache_fill_pfn(ucs_rcache_region_t *region)
     return status;
 }
 
-ucs_status_t
-ucs_rcache_create_region(ucs_rcache_t *rcache, void *address, size_t length,
-                         int prot, void *arg, ucs_rcache_region_t **region_p)
+ucs_status_t ucs_rcache_create_region(ucs_rcache_t *rcache, void *address,
+                                      size_t length, size_t alignment, int prot,
+                                      void *arg, ucs_rcache_region_t **region_p)
 {
     ucs_rcache_region_t *region;
     ucs_pgt_addr_t start, end;
@@ -905,17 +934,15 @@ ucs_rcache_create_region(ucs_rcache_t *rcache, void *address, size_t length,
 
 retry:
     /* Align to page size */
-    start  = ucs_align_down_pow2((uintptr_t)address,
-                                 rcache->params.alignment);
-    end    = ucs_align_up_pow2  ((uintptr_t)address + length,
-                                 rcache->params.alignment);
+    start  = ucs_align_down_pow2((uintptr_t)address, alignment);
+    end    = ucs_align_up_pow2  ((uintptr_t)address + length, alignment);
     region = NULL;
     merged = 0;
 
     /* Check overlap with existing regions */
     /* coverity[double_lock] */
     status = UCS_PROFILE_CALL(ucs_rcache_check_overlap, rcache, &start, &end,
-                              &prot, &merged, &region);
+                              &alignment, &prot, &merged, &region);
     if (status == UCS_ERR_ALREADY_EXISTS) {
         /* Found a matching region (it could have been added after we released
          * the lock)
@@ -965,6 +992,7 @@ retry:
     region->lru_flags = 0;
     region->refcount  = 1;
     region->status    = UCS_INPROGRESS;
+    region->alignment = alignment;
 
     ++rcache->num_regions;
 
@@ -1033,7 +1061,8 @@ void ucs_rcache_region_hold(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
 }
 
 ucs_status_t ucs_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
-                            int prot, void *arg, ucs_rcache_region_t **region_p)
+                            size_t alignment, int prot, void *arg,
+                            ucs_rcache_region_t **region_p)
 {
     ucs_pgt_addr_t start = (uintptr_t)address;
     ucs_pgt_region_t *pgt_region;
@@ -1050,8 +1079,7 @@ ucs_status_t ucs_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
         if (ucs_likely(pgt_region != NULL)) {
             region = ucs_derived_of(pgt_region, ucs_rcache_region_t);
             if (((start + length) <= region->super.end) &&
-                ucs_rcache_region_test(region, prot))
-            {
+                ucs_rcache_region_test(region, prot, alignment)) {
                 ucs_rcache_region_hold(rcache, region);
                 ucs_rcache_region_validate_pfn(rcache, region);
                 ucs_rcache_region_lru_get(rcache, region);
@@ -1070,7 +1098,7 @@ ucs_status_t ucs_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
      * - found unregistered region
      */
     return UCS_PROFILE_CALL(ucs_rcache_create_region, rcache, address, length,
-                            prot, arg, region_p);
+                            alignment, prot, arg, region_p);
 }
 
 void ucs_rcache_region_put(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
@@ -1237,18 +1265,6 @@ static UCS_CLASS_INIT_FUNC(ucs_rcache_t, const ucs_rcache_params_t *params,
     ucs_mpool_params_t mp_params;
 
     if (params->region_struct_size < sizeof(ucs_rcache_region_t)) {
-        status = UCS_ERR_INVALID_PARAM;
-        goto err;
-    }
-
-    if (!ucs_is_pow2(params->alignment) ||
-        (params->alignment < UCS_RCACHE_MIN_ALIGNMENT) ||
-        (params->alignment > params->max_alignment))
-    {
-        ucs_error("invalid regcache alignment (%zu): must be a power of 2 "
-                  "between %zu and %zu",
-                  params->alignment, UCS_RCACHE_MIN_ALIGNMENT,
-                  params->max_alignment);
         status = UCS_ERR_INVALID_PARAM;
         goto err;
     }

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -130,10 +130,6 @@ struct ucs_rcache_params {
     size_t                 region_struct_size;  /**< Size of memory region structure,
                                                      must be at least the size
                                                      of @ref ucs_rcache_region_t */
-    size_t                 alignment;           /**< Force-align regions to this size.
-                                                     Must be smaller or equal to
-                                                     system page size. */
-    size_t                 max_alignment;       /**< Maximum alignment */
     int                    ucm_events;          /**< UCM events to register. Currently
                                                      UCM_EVENT_VM_UNMAPPED and
                                                      UCM_EVENT_MEM_TYPE_FREE are supported */
@@ -167,6 +163,7 @@ struct ucs_rcache_region {
     ucs_list_link_t        lru_list;  /**< LRU list element */
     ucs_list_link_t        tmp_list;  /**< Temp list element */
     ucs_list_link_t        comp_list; /**< Completion list element */
+    size_t                 alignment;
     volatile uint32_t      refcount;  /**< Reference count, including +1 if it's
                                            in the page table */
     ucs_status_t           status;    /**< Current status code */
@@ -210,6 +207,7 @@ void ucs_rcache_destroy(ucs_rcache_t *rcache);
  * @param [in]  rcache      Memory registration cache.
  * @param [in]  address     Address to register or resolve.
  * @param [in]  length      Length of buffer to register or resolve.
+ * @param [in]  alignment   Alignment for registration buffer.
  * @param [in]  prot        Requested access flags, PROT_xx (same as passed to mmap).
  * @param [in]  arg         Custom argument passed down to memory registration
  *                          callback, if a memory registration happens during
@@ -223,7 +221,8 @@ void ucs_rcache_destroy(ucs_rcache_t *rcache);
  * @return Error code.
  */
 ucs_status_t ucs_rcache_get(ucs_rcache_t *rcache, void *address, size_t length,
-                            int prot, void *arg, ucs_rcache_region_t **region_p);
+                            size_t alignment, int prot, void *arg,
+                            ucs_rcache_region_t **region_p);
 
 
 /**

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -131,11 +131,6 @@ void ucs_rcache_atfork_disable();
 size_t ucs_rcache_distribution_get_num_bins();
 
 
-ucs_status_t
-ucs_rcache_create_region(ucs_rcache_t *rcache, void *address, size_t length,
-                         int prot, void *arg, ucs_rcache_region_t **region_p);
-
-
 void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
                                      ucs_rcache_region_t *region,
                                      int drop_lock);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -185,7 +185,6 @@ uct_gdr_copy_mem_reg(uct_md_h uct_md, void *address, size_t length,
                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_gdr_copy_mem_t *mem_hndl = NULL;
-    void *start, *end;
     ucs_status_t status;
 
     mem_hndl = ucs_malloc(sizeof(uct_gdr_copy_mem_t), "gdr_copy handle");
@@ -194,13 +193,10 @@ uct_gdr_copy_mem_reg(uct_md_h uct_md, void *address, size_t length,
         return UCS_ERR_NO_MEMORY;
     }
 
-    start = ucs_align_down_pow2_ptr(address, GPU_PAGE_SIZE);
-    end   = ucs_align_up_pow2_ptr(UCS_PTR_BYTE_OFFSET(address, length), GPU_PAGE_SIZE);
-    ucs_assert_always(start <= end);
-
-    status = uct_gdr_copy_mem_reg_internal(uct_md, start,
-                                           UCS_PTR_BYTE_DIFF(start, end),
-                                           0, mem_hndl);
+    ucs_assert(ucs_padding((intptr_t)address, GPU_PAGE_SIZE) == 0);
+    ucs_assert(ucs_padding(length, GPU_PAGE_SIZE) == 0);
+    status = uct_gdr_copy_mem_reg_internal(uct_md, address, length, 0,
+                                           mem_hndl);
     if (status != UCS_OK) {
         ucs_free(mem_hndl);
         return status;

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -314,8 +314,9 @@ uct_rocm_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
     ucs_status_t status;
     uct_rocm_copy_mem_t *memh;
 
-    status = ucs_rcache_get(md->rcache, (void *)address, length, PROT_READ|PROT_WRITE,
-                            &flags, &rregion);
+    status = ucs_rcache_get(md->rcache, (void *)address, length,
+                            ucs_get_page_size(), PROT_READ | PROT_WRITE, &flags,
+                            &rregion);
     if (status != UCS_OK) {
         return status;
     }
@@ -431,8 +432,6 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
     if (md_config->enable_rcache != UCS_NO) {
         ucs_rcache_set_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_rocm_copy_rcache_region_t);
-        rcache_params.alignment          = ucs_get_page_size();
-        rcache_params.max_alignment      = ucs_get_page_size();
         rcache_params.ucm_events         = UCM_EVENT_MEM_TYPE_FREE;
         rcache_params.ucm_event_priority = md_config->rcache.event_prio;
         rcache_params.context            = md;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -248,8 +248,6 @@ uct_xpmem_rmem_add(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     }
 
     rcache_params.region_struct_size = sizeof(uct_xpmem_remote_region_t);
-    rcache_params.alignment          = ucs_get_page_size();
-    rcache_params.max_alignment      = ucs_get_page_size();
     rcache_params.ucm_events         = 0;
     rcache_params.ucm_event_priority = 0;
     rcache_params.ops                = &uct_xpmem_rcache_ops;
@@ -370,7 +368,8 @@ uct_xpmem_mem_attach_common(xpmem_segid_t xsegid, uintptr_t remote_address,
     end   = ucs_align_up_pow2  (remote_address + length, ucs_get_page_size());
 
     status = ucs_rcache_get(rmem->rcache, (void*)start, end - start,
-                            PROT_READ|PROT_WRITE, NULL, &rcache_region);
+			    ucs_get_page_size(), PROT_READ | PROT_WRITE, NULL,
+			    &rcache_region);
     if (status != UCS_OK) {
         goto err_rmem_put;
     }

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -59,7 +59,7 @@ UCS_TEST_F(test_obj_size, size) {
     /* TODO reduce request size to 240 or less after removing old protocols state */
     EXPECTED_SIZE(ucp_request_t, 264);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
-    EXPECTED_SIZE(ucp_mem_t, 152);
+    EXPECTED_SIZE(ucp_mem_t, 160);
     EXPECTED_SIZE(uct_ep_t, 8);
     EXPECTED_SIZE(uct_base_ep_t, 8);
     EXPECTED_SIZE(uct_rkey_bundle_t, 24);

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -20,8 +20,6 @@ static ucs_rcache_params_t
 get_default_rcache_params(void *context, const ucs_rcache_ops_t *ops)
 {
     ucs_rcache_params_t params = {sizeof(ucs_rcache_region_t),
-                                  UCS_PGT_ADDR_ALIGN,
-                                  ucs_get_page_size(),
                                   UCM_EVENT_VM_UNMAPPED,
                                   1000,
                                   ops,
@@ -102,10 +100,13 @@ protected:
         return params;
     }
 
-    region *get(void *address, size_t length, int prot = PROT_READ|PROT_WRITE) {
+    region *get(void *address, size_t length, int prot = PROT_READ | PROT_WRITE,
+                size_t alignment = UCS_PGT_ADDR_ALIGN)
+    {
         ucs_status_t status;
         ucs_rcache_region_t *r;
-        status = ucs_rcache_get(m_rcache, address, length, prot, NULL, &r);
+        status = ucs_rcache_get(m_rcache, address, length, alignment, prot,
+                                NULL, &r);
         ASSERT_UCS_OK(status);
         EXPECT_TRUE(r != NULL);
         struct region *region = ucs_derived_of(r, struct region);
@@ -401,6 +402,66 @@ UCS_MT_TEST_F(test_rcache, merge, 6) {
     munmap(mem, size1 + pad + size2);
 }
 
+UCS_TEST_F(test_rcache, merge_aligned)
+{
+    /*
+     * 0         4     5         9
+     * +---------+-----+---------+
+     * | region1 | pad | region2 |         13
+     * +---+-----+-----+----+----+----------+
+     *                           |  region3 |
+     * +--------------------+----+----------+----+
+     * |     merged         |      aligned       |
+     * +--------------------+--------------------+
+     * 0                    8                   16
+     */
+    static const size_t size       = 4 * ucs_get_page_size();
+    static const size_t align      = 8 * ucs_get_page_size();
+    static const size_t total_size = 16 * ucs_get_page_size();
+    void *mem                      = NULL;
+
+    region *region1, *region2, *region3, *region1_2, *region2_2, *region3_2;
+    void *ptr1, *ptr2, *ptr3;
+
+    EXPECT_EQ(posix_memalign(&mem, align, total_size), 0);
+    memset(mem, 0, total_size);
+
+    /* Create region1 */
+    ptr1    = (char*)mem;
+    region1 = get(ptr1, size);
+
+    /* Create region2 */
+    ptr2    = (char*)mem + 5 * ucs_get_page_size();
+    region2 = get(ptr2, size);
+
+    /* Create region3 which should merge region1 and region2 */
+    ptr3    = (char*)mem + 9 * ucs_get_page_size();
+    region3 = get(ptr3, size);
+
+    region3_2 = get(ptr3, size, PROT_READ | PROT_WRITE, align);
+    EXPECT_NE(region3, region3_2) << /* should be different */
+        "region3 0x" << std::hex << region3->super.super.start << "..0x" <<
+        region3->super.super.end << " region3_2 0x" <<
+        region3_2->super.super.start << "..0x" << region3_2->super.super.end;
+
+    EXPECT_EQ(region3_2->super.super.start, (uintptr_t)mem);
+    EXPECT_EQ(region3_2->super.super.end, (uintptr_t)mem + total_size);
+
+    region1_2 = get(ptr1, size);
+    region2_2 = get(ptr2, size);
+    EXPECT_EQ(region3_2, region2_2); /* should be merged */
+    EXPECT_EQ(region3_2, region1_2); /* should be merged too */
+
+    put(region1_2);
+    put(region2_2);
+    put(region3_2);
+    put(region1);
+    put(region2);
+    put(region3);
+
+    free(mem);
+}
+
 UCS_MT_TEST_F(test_rcache, merge_inv, 6) {
     /*
      * Merge with another region which causes immediate invalidation of the
@@ -655,7 +716,8 @@ UCS_MT_TEST_F(test_rcache_no_register, register_failure, 10) {
 
     ucs_status_t status;
     ucs_rcache_region_t *r;
-    status = ucs_rcache_get(m_rcache, ptr, size, PROT_READ|PROT_WRITE, NULL, &r);
+    status = ucs_rcache_get(m_rcache, ptr, size, UCS_PGT_ADDR_ALIGN,
+                            PROT_READ | PROT_WRITE, NULL, &r);
     EXPECT_EQ(UCS_ERR_IO_ERROR, status);
     EXPECT_EQ(0u, m_reg_count);
 
@@ -701,7 +763,8 @@ UCS_MT_TEST_F(test_rcache_no_register, merge_invalid_prot_slow, 5)
     ucs_status_t status;
     ucs_rcache_region_t *r;
 
-    status = ucs_rcache_get(m_rcache, ptr2, size2, PROT_WRITE, NULL, &r);
+    status = ucs_rcache_get(m_rcache, ptr2, size2, UCS_PGT_ADDR_ALIGN,
+                            PROT_WRITE, NULL, &r);
     EXPECT_EQ(UCS_ERR_IO_ERROR, status);
 
     barrier();
@@ -717,7 +780,6 @@ protected:
         ucs_rcache_params_t params = test_rcache::rcache_params();
         params.max_regions         = 2;
         params.max_size            = 1000;
-        params.alignment           = 16;
         return params;
     }
 


### PR DESCRIPTION
## Why ?
Some transports (e.g. gdrcopy) require special alignment. 

## How ?
Regions in the UCP rcache will select the maximum alignment from the MD registrations they comprise. When merging regions, the rcache will also choose the maximum alignment.