### PR TITLE
UCP/GTEST: Use strong fence with protov2

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2061,7 +2061,8 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     context->config.worker_strong_fence =
             (context->config.ext.fence_mode == UCP_FENCE_MODE_STRONG) ||
             ((context->config.ext.fence_mode == UCP_FENCE_MODE_AUTO) &&
-             (context->config.ext.max_rma_lanes > 1));
+             ((context->config.ext.max_rma_lanes > 1) ||
+              context->config.ext.proto_enable));
 
     return UCS_OK;
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -304,12 +304,18 @@ void test_ucp_wireup::send_nb(ucp_ep_h ep, size_t length, int repeat,
             reqs.push_back(req);
         }
 
-        ucs_status_t status = ucp_worker_fence(ep->worker);
-        ASSERT_UCS_OK(status);
+        /* FIXME: using flush here instead of fence, because strong fence
+         * implementation is currently blocking and may hang if target side
+         * is not progressed. Need to use fence here as soon as strong fence
+         * implementation is updated to be non-blocking. */
+        ucp_request_param_t param = {};
+        void *req = ucp_ep_flush_nbx(ep, &param);
+        ASSERT_UCS_PTR_OK(req);
+        reqs.push_back(req);
 
-        void *req = ucp_put_nb(ep, &m_send_data[0], sizeof(m_send_data[0]),
-                               (uintptr_t)&m_recv_data[length], rkey,
-                               send_completion);
+        req = ucp_put_nb(ep, &m_send_data[0], sizeof(m_send_data[0]),
+                         (uintptr_t)&m_recv_data[length], rkey,
+                         send_completion);
         ASSERT_UCS_PTR_OK(req);
         reqs.push_back(req);
     }

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1236,6 +1236,14 @@ ucs::handle<ucp_rkey_h> ucp_test::mapped_buffer::rkey(const entity& entity) cons
     return ucs::handle<ucp_rkey_h>(rkey, ucp_rkey_destroy);
 }
 
+void ucp_test::mapped_buffer::rkey(const entity& entity, ucs::handle<ucp_rkey_h> &rkey) const
+{
+    ucp_rkey_h ucp_rkey;
+
+    ASSERT_UCS_OK(ucp_ep_rkey_unpack(entity.ep(), m_rkey_buffer, &ucp_rkey));
+    rkey.reset(ucp_rkey, ucp_rkey_destroy);
+}
+
 ucp_mem_h ucp_test::mapped_buffer::memh() const
 {
     return m_memh;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -366,6 +366,7 @@ protected:
         virtual ~mapped_buffer();
 
         ucs::handle<ucp_rkey_h> rkey(const entity& entity) const;
+        void rkey(const entity& entity, ucs::handle<ucp_rkey_h> &rkey) const;
 
         ucp_mem_h memh() const;
 


### PR DESCRIPTION
## What
Use strong fence with proto V2

## Why ?
With proto v2 UCP can use different RMA lanes for different sizes, thus fence can't be a no-op