### PR TITLE
UCP: Fix RMA lanes selection for exported memh

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -918,7 +918,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
 
     /* If could not find registered memory access lane, try to use emulation */
     if (status != UCS_OK) {
-        if (!select_params->allow_am) {
+        if (!allow_am) {
             return status;
         }
 


### PR DESCRIPTION
## What
Minor fix in RMA selection code (affects exported memh feature only)
found by code-review

