### PR TITLE
UCT/IB: Skip multi-thread memory registration for symmetric key

### DIFF
--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -27,6 +27,8 @@ protected:
                                 uct_rkey_t *rkey_p = NULL);
     void check_smkeys(uct_rkey_t rkey1, uct_rkey_t rkey2);
 
+    void test_smkey_reg_atomic(void);
+
 private:
 #ifdef HAVE_MLX5_DV
     uint32_t m_mlx5_flags = 0;
@@ -197,7 +199,7 @@ void test_ib_md::check_smkeys(uct_rkey_t rkey1, uct_rkey_t rkey2)
               uct_ib_md_atomic_rkey(rkey2) - uct_ib_md_direct_rkey(rkey2));
 }
 
-UCS_TEST_P(test_ib_md, smkey_reg_atomic)
+void test_ib_md::test_smkey_reg_atomic(void)
 {
     static const size_t size = 8192;
     void *buffer;
@@ -220,6 +222,17 @@ UCS_TEST_P(test_ib_md, smkey_reg_atomic)
     EXPECT_UCS_OK(uct_md_mem_dereg(md(), memh2));
     EXPECT_UCS_OK(uct_md_mem_dereg(md(), memh3));
     ucs_mmap_free(buffer, size);
+}
+
+UCS_TEST_P(test_ib_md, smkey_reg_atomic)
+{
+    test_smkey_reg_atomic();
+}
+
+UCS_TEST_P(test_ib_md, smkey_reg_atomic_mt, "REG_MT_THRESH=1k",
+           "REG_MT_CHUNK=1k")
+{
+    test_smkey_reg_atomic();
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)


### PR DESCRIPTION
## What
Skip multi-threaded memory registration when symmetric key is requested and FW supports it.

## Why ?
Simplest approach, could later be improved to generate KSM(MT) with specific mkey_index using KSM wrapper introduced by related #9424.

## How ?
Add corresponding tests and assertion.