### PR TITLE
UCT/MD/IB: Support MT KSM registration for unaligned buffers

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -230,6 +230,7 @@ typedef struct {
     uct_ib_md_t                   *md;
     void                          *address;
     size_t                        length;
+    size_t                        first_mr_size;
     const uct_md_mem_reg_params_t *params;
     uint64_t                      access_flags;
     struct ibv_mr                 **mrs;
@@ -297,14 +298,14 @@ uct_ib_md_print_mem_reg_err_msg(const char *title, void *address, size_t length,
 void *uct_ib_md_mem_handle_thread_func(void *arg)
 {
     uct_ib_md_mem_reg_thread_t *ctx = arg;
-    size_t max_chunk                = ctx->md->config.mt_reg_chunk;
+    size_t chunk_size               = ctx->md->config.mt_reg_chunk;
     ucs_time_t UCS_V_UNUSED t0      = ucs_get_time();
+    void UCS_V_UNUSED *start        = ctx->address;
     int mr_idx                      = 0;
+    size_t length                   = ctx->first_mr_size;
     ucs_status_t status;
-    size_t length;
 
     while (ctx->length > 0) {
-        length = ucs_min(ctx->length, max_chunk);
         if (ctx->params != NULL) {
             status = uct_ib_reg_mr(ctx->md, ctx->address, length, ctx->params,
                                    ctx->access_flags, NULL, &ctx->mrs[mr_idx]);
@@ -319,12 +320,13 @@ void *uct_ib_md_mem_handle_thread_func(void *arg)
         }
         ctx->address = UCS_PTR_BYTE_OFFSET(ctx->address, length);
         ctx->length -= length;
+        length       = ucs_min(ctx->length, chunk_size);
         mr_idx++;
     }
 
-    ucs_trace("%s %p..%p took %f usec\n",
+    ucs_trace("%s %p..%p (first_mr_size %zu) took %f usec\n",
               (ctx->params != NULL) ? "reg_mr" : "dereg_mr",
-              ctx->mrs[0]->addr, ctx->address,
+              start, ctx->address, ctx->first_mr_size,
               ucs_time_to_usec(ucs_get_time() - t0));
     return UCS_STATUS_PTR(UCS_OK);
 
@@ -339,10 +341,10 @@ err:
 ucs_status_t
 uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
                             const uct_md_mem_reg_params_t *params,
-                            uint64_t access_flags, struct ibv_mr **mrs)
+                            uint64_t access_flags, size_t mr_num,
+                            struct ibv_mr **mrs)
 {
     size_t chunk_size = md->config.mt_reg_chunk;
-    int mr_num        = ucs_div_round_up(length, chunk_size);
     int thread_num_mrs, thread_num, thread_idx, mr_idx, cpu_id;
     ucs_sys_cpuset_t parent_set, thread_set;
     uct_ib_md_mem_reg_thread_t *ctxs, *ctx;
@@ -350,6 +352,8 @@ uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
     pthread_attr_t attr;
     ucs_status_t status;
     void *thread_status;
+    uint64_t offset;
+    size_t padding;
     int ret;
 
     status = ucs_sys_pthread_getaffinity(&parent_set);
@@ -378,6 +382,7 @@ uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
     status = UCS_OK;
     mr_idx = 0;
     cpu_id = 0;
+    offset = 0;
     for (thread_idx = 0; thread_idx < thread_num; thread_idx++) {
         /* calculate number of mrs for each thread so each one will
          * get proportional amount */
@@ -385,12 +390,23 @@ uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
                                              thread_num - thread_idx);
         ctx               = &ctxs[thread_idx];
         ctx->md           = md;
-        ctx->address      = UCS_PTR_BYTE_OFFSET(address, mr_idx * chunk_size);
-        ctx->length       = ucs_min(thread_num_mrs * chunk_size,
-                                    length - (mr_idx * chunk_size));
+        ctx->address      = UCS_PTR_BYTE_OFFSET(address, offset);
         ctx->params       = params;
         ctx->access_flags = access_flags;
         ctx->mrs          = &mrs[mr_idx];
+
+        /* First MR size can be different to align further MRs */
+        padding            = ucs_padding((uintptr_t)ctx->address, chunk_size);
+        ctx->first_mr_size = (padding > 0) ? padding : chunk_size;
+        ctx->first_mr_size = ucs_min(ctx->first_mr_size, length - offset);
+        ucs_assertv((ctx->address == address) || (padding == 0),
+                    "thread_idx=%d address=%p padding=%zu",
+                    thread_idx, address, padding);
+
+        ctx->length        = (thread_num_mrs - 1) * chunk_size +
+                             ctx->first_mr_size;
+        ctx->length        = ucs_min(ctx->length, length - offset);
+        offset            += ctx->length;
 
         if (md->config.mt_reg_bind) {
             while (!CPU_ISSET(cpu_id, &parent_set)) {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -372,7 +372,8 @@ void uct_ib_md_ece_check(uct_ib_md_t *md);
 ucs_status_t
 uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
                             const uct_md_mem_reg_params_t *params,
-                            uint64_t access_flags, struct ibv_mr **mrs);
+                            uint64_t access_flags, size_t mr_num,
+                            struct ibv_mr **mrs);
 
 uint64_t uct_ib_memh_access_flags(uct_ib_md_t *md, uct_ib_mem_t *memh);
 

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -232,7 +232,6 @@ void test_ib_md::test_mkey_pack_mt_internal(unsigned access_mask,
     constexpr size_t size = UCS_MBYTE;
     unsigned pack_flags, dereg_flags;
     void *buffer;
-    int ret;
     uct_mem_h memh;
 
     if (!check_invalidate_support(access_mask)) {
@@ -243,8 +242,8 @@ void test_ib_md::test_mkey_pack_mt_internal(unsigned access_mask,
         UCS_TEST_SKIP_R("KSM is required for MT registration");
     }
 
-    ret = ucs_posix_memalign(&buffer, size, size, "mkey_pack_mt");
-    ASSERT_EQ(0, ret) << "Allocation failed";
+    buffer = ucs_malloc(size, "mkey_pack_mt");
+    ASSERT_NE(buffer, nullptr) << "Allocation failed";
 
     if (invalidate) {
         pack_flags  = UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA;


### PR DESCRIPTION
## What
Now we do multithreading registration without alignment of the memory region which can cause errors during KSM creation. This patch would register chunk with regard to the alignement.

Current state:
![image](https://github.com/openucx/ucx/assets/22097249/a6f7dfa7-942b-4639-81f7-8f3b8ee4c476)

After the patch:
![image](https://github.com/openucx/ucx/assets/22097249/5d571a6d-2591-4fea-b5a1-83e475f854c9)

# How?

1. Register first direct MR up to `md->config.mt_reg_chunk` alignment to meet this alignment for all further MRs.
2. Register N bytes before first direct MR to meet `md->dev.atomic_align` alignement.
