### PR TITLE
UCT/IB: added atomic_mem_types attributes to md_query_v2

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -567,13 +567,7 @@ enum {
      * received from different peers are compared equal, they can be used
      * interchangeably, avoiding the need to keep all of them in memory.
      */
-    UCP_MEM_MAP_SYMMETRIC_RKEY = UCS_BIT(3),
-
-    /**
-     * (?) Indicating that allocated memory type should support atomic operations
-     * only available when setting UCP_MEM_MAP_ALLOCATE
-    */
-    UCP_MEM_MAP_DEVICE_MEMORY_ATOMICS = UCS_BIT(4),
+    UCP_MEM_MAP_SYMMETRIC_RKEY = UCS_BIT(3)
 };
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -567,7 +567,13 @@ enum {
      * received from different peers are compared equal, they can be used
      * interchangeably, avoiding the need to keep all of them in memory.
      */
-    UCP_MEM_MAP_SYMMETRIC_RKEY = UCS_BIT(3)
+    UCP_MEM_MAP_SYMMETRIC_RKEY = UCS_BIT(3),
+
+    /**
+     * (?) Indicating that allocated memory type should support atomic operations
+     * only available when setting UCP_MEM_MAP_ALLOCATE
+    */
+    UCP_MEM_MAP_DEVICE_MEMORY_ATOMICS = UCS_BIT(4),
 };
 
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -507,25 +507,40 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
                           "not present");
                 goto out;
             }
-
             if (((md_attr->flags & UCT_MD_FLAG_NEED_RKEY) ||
                  (flags & UCP_PROTO_COMMON_INIT_FLAG_RKEY_PTR)) &&
-                !(rkey_config_key->md_map &
-                  UCS_BIT(ep_config_key->lanes[lane].dst_md_index))) {
+                (!(rkey_config_key->md_map &
+                   UCS_BIT(ep_config_key->lanes[lane].dst_md_index))) &&
+                (!(md_attr->alloc_mem_types &
+                   UCS_BIT(rkey_config_key->mem_type)))) {
                 /* If remote key required remote memory domain should be
                  * available */
-                ucs_trace("%s: no support of dst md map 0x%" PRIx64,
-                          lane_desc, rkey_config_key->md_map);
+                ucs_trace("%s: no support of dst md map 0x%" PRIx64, lane_desc,
+                          rkey_config_key->md_map);
                 continue;
             }
 
-            if (!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
+            if (
+                //!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
                 !(md_attr->access_mem_types &
-                  UCS_BIT(rkey_config_key->mem_type))) {
+                  UCS_BIT(rkey_config_key->mem_type)) &&
+                (!(md_attr->alloc_mem_types &
+                   UCS_BIT(rkey_config_key->mem_type)))) {
                 /* Remote memory domain without remote key must be able to
                  * access relevant memory type */
                 ucs_trace("%s: no access to remote mem type %s", lane_desc,
                           ucs_memory_type_names[rkey_config_key->mem_type]);
+                continue;
+            }
+
+            if ((lane_type == UCP_LANE_TYPE_AMO) &&
+                !(md_attr->atomic_mem_types &
+                  UCS_BIT(rkey_config_key->mem_type))) {
+                ucs_warn("%s: no atomics to remote mem type %s, "
+                         "atomic_mem_types: %lu",
+                         lane_desc,
+                         ucs_memory_type_names[rkey_config_key->mem_type],
+                         md_attr->atomic_mem_types);
                 continue;
             }
         }

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -510,40 +510,43 @@ static ucp_lane_index_t ucp_proto_common_find_lanes_internal(
             if (((md_attr->flags & UCT_MD_FLAG_NEED_RKEY) ||
                  (flags & UCP_PROTO_COMMON_INIT_FLAG_RKEY_PTR)) &&
                 (!(rkey_config_key->md_map &
-                   UCS_BIT(ep_config_key->lanes[lane].dst_md_index))) &&
+                   UCS_BIT(ep_config_key->lanes[lane].dst_md_index))) 
+                   &&
                 (!(md_attr->alloc_mem_types &
-                   UCS_BIT(rkey_config_key->mem_type)))) {
+                   UCS_BIT(rkey_config_key->mem_type)))
+                   ) {
                 /* If remote key required remote memory domain should be
                  * available */
-                ucs_trace("%s: no support of dst md map 0x%" PRIx64, lane_desc,
+                ucs_warn("%s: no support of dst md map 0x%" PRIx64, lane_desc,
                           rkey_config_key->md_map);
                 continue;
             }
 
             if (
-                //!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
-                !(md_attr->access_mem_types &
-                  UCS_BIT(rkey_config_key->mem_type)) &&
-                (!(md_attr->alloc_mem_types &
-                   UCS_BIT(rkey_config_key->mem_type)))) {
+                    !(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
+                    !(md_attr->access_mem_types &
+                      UCS_BIT(rkey_config_key->mem_type)) &&
+                    (!(md_attr->alloc_mem_types&
+                       UCS_BIT(rkey_config_key->mem_type)))) {
                 /* Remote memory domain without remote key must be able to
                  * access relevant memory type */
-                ucs_trace("%s: no access to remote mem type %s", lane_desc,
+                ucs_warn("%s: no access to remote mem type %s", lane_desc,
                           ucs_memory_type_names[rkey_config_key->mem_type]);
                 continue;
             }
 
-            if ((lane_type == UCP_LANE_TYPE_AMO) &&
-                !(md_attr->atomic_mem_types &
-                  UCS_BIT(rkey_config_key->mem_type))) {
-                ucs_warn("%s: no atomics to remote mem type %s, "
-                         "atomic_mem_types: %lu",
-                         lane_desc,
-                         ucs_memory_type_names[rkey_config_key->mem_type],
-                         md_attr->atomic_mem_types);
-                continue;
-            }
         }
+
+            // if ((lane_type == UCP_LANE_TYPE_AMO) &&
+            //     !(md_attr->atomic_mem_types &
+            //       UCS_BIT(rkey_config_key->mem_type))) {
+            //     ucs_warn("%s: no atomics to remote mem type %s, "
+            //              "atomic_mem_types: %lu",
+            //              lane_desc,
+            //              ucs_memory_type_names[rkey_config_key->mem_type],
+            //              md_attr->atomic_mem_types);
+            //     continue;
+            // }
 
         max_iov = ucp_proto_common_get_iface_attr_field(iface_attr,
                                                         max_iov_offs, SIZE_MAX);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -82,6 +82,9 @@ typedef struct {
     /* Mandatory memory types for registration */
     uint64_t                    reg_mem_types;
 
+    /* Mandatory memory types for atomics */
+    uint64_t                    atomic_mem_types;
+
     /* Required support of keepalive mechanism */
     int                         is_keepalive;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1536,6 +1536,7 @@ struct uct_md_attr {
         uint64_t             detect_mem_types; /**< Bitmap of memory types that Memory Domain can detect if address belongs to it */
         uint64_t             alloc_mem_types;  /**< Bitmap of memory types that Memory Domain can allocate memory on */
         uint64_t             access_mem_types; /**< Memory types that Memory Domain can access */
+        uint64_t             atomic_mem_types; /**< Memory types that Memory Domain can perform atomic operations on*/
     } cap;
 
     ucs_linear_func_t        reg_cost;  /**< Memory registration cost estimation

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -787,7 +787,10 @@ typedef enum uct_md_attr_field {
     UCT_MD_ATTR_FIELD_GLOBAL_ID                 = UCS_BIT(15),
 
     /** Indicate registration alignment. */
-    UCT_MD_ATTR_FIELD_REG_ALIGNMENT             = UCS_BIT(16)
+    UCT_MD_ATTR_FIELD_REG_ALIGNMENT             = UCS_BIT(16),
+
+    /** Indicate memory types that the MD can perform atomic operations on */
+    UCT_MD_ATTR_FIELD_ATOMIC_MEM_TYPES          = UCS_BIT(17)
 } uct_md_attr_field_t;
 
 
@@ -859,6 +862,11 @@ typedef struct {
      * Memory types for which MD can provide DMABUF fd.
      */
     uint64_t          dmabuf_mem_types;
+
+    /**
+     * Memory types for which MD can perform atomic operations on.
+     */
+    uint64_t          atomic_mem_types;
 
     /**
      * Memory registration cost estimation (time,seconds) as a linear function

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -390,6 +390,7 @@ static void uct_md_attr_from_v2(uct_md_attr_t *dst, const uct_md_attr_v2_t *src)
     dst->cap.detect_mem_types = src->detect_mem_types;
     dst->cap.alloc_mem_types  = src->alloc_mem_types;
     dst->cap.access_mem_types = src->access_mem_types;
+    dst->cap.atomic_mem_types = src->atomic_mem_types;
     dst->reg_cost             = src->reg_cost;
     dst->rkey_packed_size     = src->rkey_packed_size;
 
@@ -416,6 +417,8 @@ uct_md_attr_v2_copy(uct_md_attr_v2_t *dst, const uct_md_attr_v2_t *src)
                               UCT_MD_ATTR_FIELD_ALLOC_MEM_TYPES);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, access_mem_types,
                               UCT_MD_ATTR_FIELD_ACCESS_MEM_TYPES);
+    UCT_MD_ATTR_V2_FIELD_COPY(dst, src, atomic_mem_types,
+                              UCT_MD_ATTR_FIELD_ATOMIC_MEM_TYPES);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, dmabuf_mem_types,
                               UCT_MD_ATTR_FIELD_DMABUF_MEM_TYPES);
     UCT_MD_ATTR_V2_FIELD_COPY(dst, src, reg_cost, UCT_MD_ATTR_FIELD_REG_COST);

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -152,9 +152,11 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
                                           mem_type, flags, alloc_name,
                                           &memh);
                 if (status != UCS_OK) {
-                    ucs_error("failed to allocate %zu bytes using md %s for %s: %s",
-                              alloc_length, md->component->name,
-                              alloc_name, ucs_status_string(status));
+                    ucs_error("failed to allocate %zu bytes of %s using md %s "
+                              "for %s: %s",
+                              alloc_length, ucs_memory_type_names[mem_type],
+                              md->component->name, alloc_name,
+                              ucs_status_string(status));
                     goto out;
                 }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -116,6 +116,7 @@ uct_cuda_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
                                       UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
     md_attr->dmabuf_mem_types       = md->config.dmabuf_supported ?
                                       UCS_BIT(UCS_MEMORY_TYPE_CUDA) : 0;
+    md_attr->atomic_mem_types       = 0;
     md_attr->max_alloc        = SIZE_MAX;
     md_attr->max_reg          = ULONG_MAX;
     md_attr->rkey_packed_size = 0;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -43,6 +43,7 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->detect_mem_types       = 0;
     md_attr->dmabuf_mem_types       = 0;
+    md_attr->atomic_mem_types       = 0;
     md_attr->max_alloc              = 0;
     md_attr->max_reg                = ULONG_MAX;
     md_attr->rkey_packed_size       = sizeof(uct_cuda_ipc_key_t);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -46,6 +46,7 @@ uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     md_attr->detect_mem_types       = 0;
     md_attr->dmabuf_mem_types       = 0;
     md_attr->max_alloc              = 0;
+    md_attr->atomic_mem_types       = 0;
     md_attr->max_reg                = ULONG_MAX;
     md_attr->rkey_packed_size       = sizeof(uct_gdr_copy_key_t);
     md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -81,16 +81,17 @@ typedef enum uct_ib_roce_version {
 
 
 enum {
-    UCT_IB_DEVICE_FLAG_MLX4_PRM = UCS_BIT(1),   /* Device supports mlx4 PRM */
-    UCT_IB_DEVICE_FLAG_MLX5_PRM = UCS_BIT(2),   /* Device supports mlx5 PRM */
-    UCT_IB_DEVICE_FLAG_MELLANOX = UCS_BIT(3),   /* Mellanox device */
-    UCT_IB_DEVICE_FLAG_LINK_IB  = UCS_BIT(5),   /* Require only IB */
-    UCT_IB_DEVICE_FLAG_DC_V1    = UCS_BIT(6),   /* Device supports DC ver 1 */
-    UCT_IB_DEVICE_FLAG_DC_V2    = UCS_BIT(7),   /* Device supports DC ver 2 */
-    UCT_IB_DEVICE_FLAG_AV       = UCS_BIT(8),   /* Device supports compact AV */
+    UCT_IB_DEVICE_FLAG_MLX4_PRM = UCS_BIT(1), /* Device supports mlx4 PRM */
+    UCT_IB_DEVICE_FLAG_MLX5_PRM = UCS_BIT(2), /* Device supports mlx5 PRM */
+    UCT_IB_DEVICE_FLAG_MELLANOX = UCS_BIT(3), /* Mellanox device */
+    UCT_IB_DEVICE_FLAG_LINK_IB  = UCS_BIT(5), /* Require only IB */
+    UCT_IB_DEVICE_FLAG_DC_V1    = UCS_BIT(6), /* Device supports DC ver 1 */
+    UCT_IB_DEVICE_FLAG_DC_V2    = UCS_BIT(7), /* Device supports DC ver 2 */
+    UCT_IB_DEVICE_FLAG_AV       = UCS_BIT(8), /* Device supports compact AV */
     UCT_IB_DEVICE_FLAG_DC       = UCT_IB_DEVICE_FLAG_DC_V1 |
                                   UCT_IB_DEVICE_FLAG_DC_V2, /* Device supports DC */
-    UCT_IB_DEVICE_FAILED        = UCS_BIT(9)    /* Got fatal error */
+    UCT_IB_DEVICE_FAILED        = UCS_BIT(9), /* Got fatal error */
+    UCT_IB_DEVICE_FLAG_DM_ATOMICS = UCS_BIT(10)
 };
 
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1448,6 +1448,12 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
 
     self->addr_size  = uct_ib_iface_address_size(self);
 
+    if (params->features &
+                (UCT_IFACE_FEATURE_AMO32 | UCT_IFACE_FEATURE_AMO64) &&
+        !(ib_md->dev.flags & UCT_IB_DEVICE_FLAG_DM_ATOMICS)) {
+        ib_md->cap_flags &= ~UCT_MD_FLAG_ALLOC;
+    }
+
     ucs_debug("created uct_ib_iface_t headroom_ofs %d payload_ofs %d hdr_ofs %d data_sz %d",
               self->config.rx_headroom_offset, self->config.rx_payload_offset,
               self->config.rx_hdr_offset, self->config.seg_size);

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -255,6 +255,7 @@ ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->rkey_packed_size          = UCT_IB_MD_PACKED_RKEY_SIZE;
     md_attr->reg_cost                  = md->reg_cost;
     md_attr->exported_mkey_packed_size = sizeof(uct_ib_md_packed_mkey_t);
+    md_attr->atomic_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
 
     ucs_sys_cpuset_copy(&md_attr->local_cpus, &md->dev.local_cpus);
     UCS_STATIC_ASSERT(sizeof(guid) <=

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -192,8 +192,6 @@ enum {
     UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI       = UCS_BIT(13),
     /* Device supports symmetric key creation */
     UCT_IB_MLX5_MD_FLAG_MKEY_BY_NAME_RESERVE = UCS_BIT(14),
-    /* Devuce supports device memory indirect atomics*/
-    UCT_IB_MLX5_MD_FLAG_DM_INDIRECT_ATOMICS  = UCS_BIT(15),
 
     /* Object to be created by DevX */
     UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 16,

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -192,6 +192,8 @@ enum {
     UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI       = UCS_BIT(13),
     /* Device supports symmetric key creation */
     UCT_IB_MLX5_MD_FLAG_MKEY_BY_NAME_RESERVE = UCS_BIT(14),
+    /* Devuce supports device memory indirect atomics*/
+    UCT_IB_MLX5_MD_FLAG_DM_INDIRECT_ATOMICS  = UCS_BIT(15),
 
     /* Object to be created by DevX */
     UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 16,

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -59,6 +59,7 @@ uct_rocm_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->atomic_mem_types       = 0;
     md_attr->dmabuf_mem_types       = 0;
     if (md->have_dmabuf) {
         md_attr->dmabuf_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_ROCM);

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -33,6 +33,7 @@ static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr
     md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->detect_mem_types       = 0;
     md_attr->dmabuf_mem_types       = 0;
+    md_attr->atomic_mem_types       = 0;
     md_attr->max_alloc              = 0;
     md_attr->max_reg                = ULONG_MAX;
 

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -75,6 +75,7 @@ void uct_mm_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr, uint64_t max_alloc)
     md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->atomic_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->detect_mem_types = 0;
     md_attr->dmabuf_mem_types = 0;
 

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -204,6 +204,7 @@ ucs_status_t uct_cma_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->detect_mem_types       = 0;
     md_attr->dmabuf_mem_types       = 0;
+    md_attr->atomic_mem_types       = 0;
     md_attr->max_alloc              = 0;
     md_attr->max_reg                = ULONG_MAX;
     md_attr->reg_cost               = ucs_linear_func_make(9e-9, 0);

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -199,6 +199,7 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->detect_mem_types = 0;
     md_attr->dmabuf_mem_types = 0;
+    md_attr->atomic_mem_types = 0;
     md_attr->max_alloc        = 0;
     md_attr->max_reg          = ULONG_MAX;
     md_attr->reg_cost         = md->reg_cost;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -418,6 +418,7 @@ static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
     attr->alloc_mem_types        = 0;
     attr->detect_mem_types       = 0;
     attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    attr->atomic_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->dmabuf_mem_types       = 0;
     attr->max_alloc              = 0;
     attr->max_reg                = ULONG_MAX;

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -46,6 +46,7 @@ static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->detect_mem_types       = 0;
     md_attr->dmabuf_mem_types       = 0;
+    md_attr->atomic_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->max_alloc              = 0;
     md_attr->max_reg                = ULONG_MAX;
     md_attr->reg_cost               = ucs_linear_func_make(1000.0e-9, 0.007e-9);


### PR DESCRIPTION
## What
added atomic_mem_types attributes to md_query_v2 and validated memory types selected for atomic operations supporting it.

## Why ?
Device memory (`UCS_MEMORY_TYPE_RDMA`) might support allocation but not atomic operations on certain MOFED firmware versions.

## How ?
Adding atomic_mem_type attribute, so in md_query_v2 we would know which memory types supports atomics

## Issue
When the allocated memory type has no md that supports atomics for that memory type, no proto would be selected for atomic operations and we will fallback to reconfig proto failure