### PR TITLE
CONFIG/SPEC: Bump version to 1.17.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@
 AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)  # Major version. Usually does not change.
-define([ucx_ver_minor], 16) # Minor version. Increased for each release.
+define([ucx_ver_minor], 17) # Minor version. Increased for each release.
 define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -343,6 +343,8 @@ library internals, protocol objects, transports status, and more.
 %endif
 
 %changelog
+* Tue Oct 31 2023 Yossi Itigin <yosefe@nvidia.com> 1.17.0-1
+- Bump version to 1.17.0
 * Fri Apr 28 2023 Yossi Itigin <yosefe@nvidia.com> 1.16.0-1
 - Bump version to 1.16.0
 * Mon Oct 24 2022 Yossi Itigin <yosefe@mellanox.com> 1.15.0-1


### PR DESCRIPTION
## Why
Bump version to 1.17.0 after creating v1.16.x branch