### PR TITLE
(v1.15.x) CONFIGURE/ROCM: modify HIP_CPPFLAGS for ROCm 6.0

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -39,7 +39,7 @@ AC_DEFUN([ROCM_BUILD_FLAGS],
 # Parse value of ARG into appropriate LIBS, LDFLAGS, and
 # CPPFLAGS variables.
 AC_DEFUN([HIP_BUILD_FLAGS],
-    $4="-D__HIP_PLATFORM_HCC__ -I$1/include/hip -I$1/include"
+    $4="-D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__ -I$1/include/hip -I$1/include"
     $3="-L$1/hip/lib -L$1/lib"
     $2="-lamdhip64"
 )


### PR DESCRIPTION
## What
Add `-D__HIP_PLATFORM_AMD__` to HIP_CPPFLAGS as `-D__HIP_PLATFORM_HCC__` is removed in ROCm 6.0, which affects configure checks for hip_runtime and breaks UCX gtest for ROCm.
We keep `-D__HIP_PLATFORM_HCC__` for compatibility with older ROCm versions.
