### PR TITLE
AZP: Add wire-compat check for perf caps

### DIFF
--- a/buildlib/pr/wire_compat.yml
+++ b/buildlib/pr/wire_compat.yml
@@ -53,9 +53,9 @@ jobs:
     ${{ if parameters.container }}:
       container: ${{ parameters.container }}
     variables:
-        ucx_current: ucx_current_$(Build.BuildId)_${{ parameters.name }}
-        ucx_legacy: ucx_$(ucx_tag)_$(Build.BuildId)_${{ parameters.name }}
-        test_dir: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/examples
+      ucx_current: ucx_current_$(Build.BuildId)_${{ parameters.name }}
+      ucx_legacy: ucx_$(ucx_tag)_$(Build.BuildId)_${{ parameters.name }}
+      test_dir: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/examples
     steps:
       - checkout: self
         clean: true
@@ -65,6 +65,7 @@ jobs:
         inputs:
           artifactName: $(ucx_current)
           downloadPath: $(System.DefaultWorkingDirectory)
+      - bash: chmod u+rwx $(System.DefaultWorkingDirectory)/$(ucx_current)/bin/ucx_info
       - bash: |
           set -eEx
           ucx_dir=$(System.DefaultWorkingDirectory)/$(ucx_legacy)
@@ -79,6 +80,12 @@ jobs:
           gcc -I${ucx_dir}/include -L${ucx_dir}/lib -o client_server ucp_client_server.c -lm -lucs -lucp
           gcc -I${ucx_dir}/include -L${ucx_dir}/lib -o ucp_hworld ucp_hello_world.c -lm -lucs -lucp
         displayName: Build ucx artifact
+      - bash: buildlib/tools/check_tls_perf_caps.sh
+        env:
+          UCX_PR_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)
+          UCX_LEGACY_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)
+        displayName: compare tls performance characteristics
+        condition: ne(variables.ucx_tag, 'v1.14.0')
       - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a
         env:
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib

--- a/buildlib/tools/check_tls_perf_caps.sh
+++ b/buildlib/tools/check_tls_perf_caps.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eE
+#
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See file LICENSE for terms.
+#
+
+realdir="$(realpath "$(dirname "$0")")"
+source "${realdir}"/../az-helpers.sh
+
+# check that correct UCX versions are used
+LD_LIBRARY_PATH=${UCX_LEGACY_PATH}/lib "${UCX_LEGACY_PATH}"/bin/ucx_info -v
+LD_LIBRARY_PATH=${UCX_PR_PATH}/lib "${UCX_PR_PATH}"/bin/ucx_info -v
+
+LD_LIBRARY_PATH=${UCX_LEGACY_PATH}/lib old_out=$("${UCX_LEGACY_PATH}"/bin/ucx_info -d)
+LD_LIBRARY_PATH=${UCX_PR_PATH}/lib new_out=$("${UCX_PR_PATH}"/bin/ucx_info -d)
+
+res=true
+for tl_name in $(echo "${old_out}" | grep Transport | awk '{print $3}')
+do
+    old_tl_caps=$(echo "$old_out" | grep -A 8 "Transport: $tl_name")
+    new_tl_caps=$(echo "$new_out" | grep -A 8 "Transport: $tl_name")
+    for device in $(echo "${old_tl_caps}" | grep Device | awk '{print $3}')
+    do
+      old_caps=$(echo "$old_tl_caps" | grep -A 7 "Device: $device")
+      new_caps=$(echo "$new_tl_caps" | grep -A 7 "Device: $device")
+      for cap in bandwidth latency overhead
+      do
+        old_cap=$(echo "$old_caps" | grep $cap | sed -e "s/^[^:]*:[ \t]*//")
+        new_cap=$(echo "$new_caps" | grep $cap | sed -e "s/^[^:]*:[ \t]*//")
+        if [ "$old_cap" != "$new_cap" ]
+        then
+          azure_log_error "Fail: (${device}/${tl_name}/${cap}) ${old_cap} != ${new_cap}"
+          res=false
+        else
+          echo "${device}/${tl_name}/${cap}: ${old_cap}"
+        fi
+       done
+    done
+done
+
+$res


### PR DESCRIPTION
## What
Add comparision of transport performance charasteristics reported by `ucx_info -d`

## Why
Wire-compatibility check. Diffferent values of the same perf capability between different UCX versions may result in ep reconfiguration error