### PR TITLE
UCP: Fix lane selection for wireup ack message

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -78,18 +78,21 @@ const char* ucp_wireup_msg_str(uint8_t msg_type)
 
 static ucp_lane_index_t ucp_wireup_get_msg_lane(ucp_ep_h ep, uint8_t msg_type)
 {
-    ucp_context_h   context           = ep->worker->context;
-    ucp_ep_config_t *ep_config        = ucp_ep_config(ep);
-    ucp_lane_index_t lane             = UCP_NULL_LANE;
+    ucp_context_h   context    = ep->worker->context;
+    ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+    ucp_lane_index_t lane, fallback_lane;
 
-    if (msg_type != UCP_WIREUP_MSG_ACK) {
+    if (msg_type == UCP_WIREUP_MSG_ACK) {
+        lane          = ep_config->key.am_lane;
+        fallback_lane = ep_config->key.wireup_msg_lane;
+    } else {
         /* for request/response, try wireup_msg_lane first */
-        lane = ep_config->key.wireup_msg_lane;
+        lane          = ep_config->key.wireup_msg_lane;
+        fallback_lane = ep_config->key.am_lane;
     }
 
     if (lane == UCP_NULL_LANE) {
-        /* fallback to active messages lane */
-        lane = ep_config->key.am_lane;
+        lane = fallback_lane;
     }
 
     if (lane == UCP_NULL_LANE) {


### PR DESCRIPTION
## What
Wireup ack can only be sent with wireup lane If AM lane is not requested

## Why ?
Fixes [3655964](https://redmine.mellanox.com/issues/3655964) (internal link)

Problem popped up after #9445, because with that fix AM is not always selected (if not requested)
