### PR TITLE
UCP/PROTO: Replace ucp protocol in the middle of send operation (offset > 0)

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -34,7 +34,8 @@ ucp_am_eager_multi_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
         .super.send_op       = UCT_EP_OP_AM_BCOPY,
         .super.memtype_op    = UCT_EP_OP_GET_SHORT,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
-                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
         .max_lanes           = context->config.ext.max_eager_lanes,
         .initial_reg_md_map  = 0,

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -407,6 +407,8 @@ struct ucp_request {
             /* For rendezvous receive with new protocols: selected protocol for
                fetching remote data */
             const ucp_proto_config_t *proto_rndv_config;
+            /* Internal rndv request for rendezvous receive */
+            const ucp_request_t      *proto_rndv_request;
 #endif
 
             union {

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -715,7 +715,9 @@ void ucp_proto_common_zcopy_adjust_min_frag_always(ucp_request_t *req,
     }
 }
 
-ucs_status_t ucp_proto_request_init(ucp_request_t *req)
+ucs_status_t
+ucp_proto_request_init(ucp_request_t *req,
+                       const ucp_proto_select_param_t *select_param)
 {
     ucp_ep_h ep         = req->send.ep;
     ucp_worker_h worker = ep->worker;
@@ -736,40 +738,32 @@ ucs_status_t ucp_proto_request_init(ucp_request_t *req)
     }
 
     /* Select from protocol hash according to saved request parameters */
-    return ucp_proto_request_lookup_proto(
-            worker, ep, req, proto_select, rkey_cfg_index,
-            &req->send.proto_config->select_param, msg_length);
-}
-
-/**
- * Current implementation of @ref ucp_proto_t::reset supports only the case
- * that no data was sent yet.
- *
- * @param req   request to check
- */
-void ucp_proto_request_check_reset_state(const ucp_request_t *req)
-{
-    ucs_assertv_always(
-            ucp_datatype_iter_is_begin(&req->send.state.dt_iter),
-            "request %p: cannot reset the state after sending %zu bytes", req,
-            req->send.state.dt_iter.offset);
+    return ucp_proto_request_lookup_proto(worker, ep, req, proto_select,
+                                          rkey_cfg_index, select_param,
+                                          msg_length);
 }
 
 void ucp_proto_request_restart(ucp_request_t *req)
 {
+    const ucp_proto_config_t *proto_config = req->send.proto_config;
+    ucp_proto_select_param_t select_param  = proto_config->select_param;
     ucs_status_t status;
 
     ucp_trace_req(req, "proto %s at stage %d restarting",
-                  req->send.proto_config->proto->name, req->send.proto_stage);
+                  proto_config->proto->name, req->send.proto_stage);
 
-    ucp_proto_request_check_reset_state(req);
-    status = req->send.proto_config->proto->reset(req);
+    status = proto_config->proto->reset(req);
     if (status != UCS_OK) {
         ucs_assert_always(status == UCS_ERR_CANCELED);
         return;
     }
 
-    status = ucp_proto_request_init(req);
+    /* Select a protocol with resume request support */
+    if (!ucp_datatype_iter_is_begin(&req->send.state.dt_iter)) {
+        select_param.op_id_flags |= UCP_PROTO_SELECT_OP_FLAG_RESUME;
+    }
+
+    status = ucp_proto_request_init(req, &select_param);
     if (status == UCS_OK) {
         ucp_request_send(req);
     } else {

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -57,7 +57,10 @@ typedef enum {
     UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE  = UCS_BIT(8),
 
     /* Supports error handling */
-    UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING  = UCS_BIT(9)
+    UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING  = UCS_BIT(9),
+
+    /* Supports starting the request when its datatype iterator offset is > 0 */
+    UCP_PROTO_COMMON_INIT_FLAG_RESUME        = UCS_BIT(10),
 } ucp_proto_common_init_flags_t;
 
 
@@ -284,7 +287,9 @@ void ucp_proto_common_zcopy_adjust_min_frag_always(ucp_request_t *req,
 
 void ucp_proto_request_abort(ucp_request_t *req, ucs_status_t status);
 
-ucs_status_t ucp_proto_request_init(ucp_request_t *req);
+ucs_status_t
+ucp_proto_request_init(ucp_request_t *req,
+                       const ucp_proto_select_param_t *select_param);
 
 void ucp_proto_request_check_reset_state(const ucp_request_t *req);
 

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -46,6 +46,10 @@ ucp_proto_bcopy_send_func_status(ssize_t packed_size)
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_msg_multi_request_init(ucp_request_t *req)
 {
+    if (!ucp_datatype_iter_is_begin(&req->send.state.dt_iter)) {
+        return;
+    }
+
     req->send.msg_proto.message_id = req->send.ep->worker->am_message_id++;
 }
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -41,6 +41,12 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     ucs_assert(params->max_lanes >= 1);
     ucs_assert(params->max_lanes <= UCP_PROTO_MAX_LANES);
 
+    if ((ucp_proto_select_op_flags(params->super.super.select_param) &
+         UCP_PROTO_SELECT_OP_FLAG_RESUME) &&
+        !(params->super.flags & UCP_PROTO_COMMON_INIT_FLAG_RESUME)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     if (!ucp_proto_common_init_check_err_handling(&params->super)) {
         return UCS_ERR_UNSUPPORTED;
     }

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -21,7 +21,7 @@ static ucs_status_t ucp_proto_reconfig_select_progress(uct_pending_req_t *self)
     ucp_request_t *req  = ucs_container_of(self, ucp_request_t, send.uct);
     ucs_status_t status;
 
-    status = ucp_proto_request_init(req);
+    status = ucp_proto_request_init(req, &req->send.proto_config->select_param);
     if (ucs_unlikely(status != UCS_OK)) {
         /* will try again later */
         return UCS_ERR_NO_RESOURCE;

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -23,16 +23,18 @@
 /* Operation flags start bit */
 #define UCP_PROTO_SELECT_OP_FLAGS_BASE UCS_BIT(4)
 
+/* Select protocol which supports resume request after reset. */
+#define UCP_PROTO_SELECT_OP_FLAG_RESUME (UCP_PROTO_SELECT_OP_FLAGS_BASE << 0)
 
 /* Select a protocol for sending one fragment of a rendezvous pipeline.
  * Relevant for UCP_OP_ID_RNDV_SEND and UCP_OP_ID_RNDV_RECV. */
-#define UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG (UCP_PROTO_SELECT_OP_FLAGS_BASE << 0)
+#define UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG (UCP_PROTO_SELECT_OP_FLAGS_BASE << 1)
 
 
 /* Select eager/rendezvous protocol for Active Message sends.
  * Relevant for UCP_OP_ID_AM_SEND and UCP_OP_ID_AM_SEND_REPLY. */
-#define UCP_PROTO_SELECT_OP_FLAG_AM_EAGER (UCP_PROTO_SELECT_OP_FLAGS_BASE << 0)
-#define UCP_PROTO_SELECT_OP_FLAG_AM_RNDV  (UCP_PROTO_SELECT_OP_FLAGS_BASE << 1)
+#define UCP_PROTO_SELECT_OP_FLAG_AM_EAGER (UCP_PROTO_SELECT_OP_FLAGS_BASE << 1)
+#define UCP_PROTO_SELECT_OP_FLAG_AM_RNDV  (UCP_PROTO_SELECT_OP_FLAGS_BASE << 2)
 
 
 /** Maximal length of ucp_proto_select_param_str() */

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -113,6 +113,19 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
+static void ucp_proto_get_offload_reset(ucp_request_t *req)
+{
+    /* get_am protocol will use this field after reset, so it must be
+     * initialized */
+    req->send.state.completed_size = 0;
+}
+
+static ucs_status_t ucp_proto_get_offload_bcopy_reset(ucp_request_t *req)
+{
+    ucp_proto_get_offload_reset(req);
+    return ucp_proto_request_bcopy_reset(req);
+}
+
 ucp_proto_t ucp_get_offload_bcopy_proto = {
     .name     = "get/bcopy",
     .desc     = UCP_PROTO_COPY_OUT_DESC,
@@ -121,7 +134,7 @@ ucp_proto_t ucp_get_offload_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_bcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = ucp_proto_request_bcopy_reset
+    .reset    = ucp_proto_get_offload_bcopy_reset
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -206,6 +219,12 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
                                 init_params->priv_size);
 }
 
+static ucs_status_t ucp_proto_get_offload_zcopy_reset(ucp_request_t *req)
+{
+    ucp_proto_get_offload_reset(req);
+    return ucp_proto_request_zcopy_reset(req);
+}
+
 ucp_proto_t ucp_get_offload_zcopy_proto = {
     .name     = "get/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
@@ -214,5 +233,5 @@ ucp_proto_t ucp_get_offload_zcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_zcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
-    .reset    = ucp_proto_request_zcopy_reset
+    .reset    = ucp_proto_get_offload_zcopy_reset
 };

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -94,7 +94,8 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.send_op       = UCT_EP_OP_AM_BCOPY,
         .super.memtype_op    = UCT_EP_OP_GET_SHORT,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
-                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -813,7 +813,8 @@ UCS_PROFILE_FUNC_VOID(ucp_proto_rndv_receive_start,
     }
 
 #if ENABLE_DEBUG_DATA
-    recv_req->recv.proto_rndv_config = req->send.proto_config;
+    recv_req->recv.proto_rndv_config  = req->send.proto_config;
+    recv_req->recv.proto_rndv_request = req;
 #endif
 
     UCS_PROFILE_CALL_VOID(ucp_request_send, req);

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -112,6 +112,28 @@ typedef struct {
 /* Return rendezvous threshold for the provided configuration */
 size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params);
 
+/* rndv_put stages */
+enum {
+    /* Initial stage for put zcopy is sending the data */
+    UCP_PROTO_RNDV_PUT_ZCOPY_STAGE_SEND = UCP_PROTO_STAGE_START,
+
+    /* Initial stage for put memtype is copy the data to the fragment */
+    UCP_PROTO_RNDV_PUT_MTYPE_STAGE_COPY = UCP_PROTO_STAGE_START,
+
+    /* Flush all lanes to ensure remote delivery */
+    UCP_PROTO_RNDV_PUT_STAGE_FLUSH,
+
+    /* Send ATP without fence (could be done after a flush) */
+    UCP_PROTO_RNDV_PUT_STAGE_ATP,
+
+    /* Send ATP with fence (could be done if using send lanes for ATP) */
+    UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP,
+
+    /* Memtype only: send the fragment to the remote side */
+    UCP_PROTO_RNDV_PUT_MTYPE_STAGE_SEND
+};
+
+
 /* Initializes protocol which sends rendezvous control message using AM lane
  * (e.g. RTS and ATS). */
 ucs_status_t

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -130,7 +130,8 @@ ucp_proto_rndv_am_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.send_op       = UCT_EP_OP_AM_BCOPY,
         .super.memtype_op    = UCT_EP_OP_GET_SHORT,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
-                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
@@ -154,7 +155,7 @@ ucp_proto_t ucp_rndv_am_bcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_rndv_am_bcopy_progress},
     .abort    = ucp_proto_rndv_am_bcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
+    .reset    = ucp_proto_request_bcopy_reset
 };
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_rndv_am_zcopy_send_func(
@@ -231,5 +232,5 @@ ucp_proto_t ucp_rndv_am_zcopy_proto = {
     .query    = ucp_proto_multi_query,
     .progress = {ucp_rndv_am_zcopy_proto_progress},
     .abort    = ucp_rndv_am_zcopy_proto_abort,
-    .reset    = ucp_am_proto_request_zcopy_reset
+    .reset    = ucp_proto_request_zcopy_reset
 };

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -19,27 +19,6 @@
 
 #define UCP_PROTO_RNDV_PUT_DESC "write to remote"
 
-
-enum {
-    /* Initial stage for put zcopy is sending the data */
-    UCP_PROTO_RNDV_PUT_ZCOPY_STAGE_SEND = UCP_PROTO_STAGE_START,
-
-    /* Initial stage for put memtype is copy the data to the fragment */
-    UCP_PROTO_RNDV_PUT_MTYPE_STAGE_COPY = UCP_PROTO_STAGE_START,
-
-    /* Flush all lanes to ensure remote delivery */
-    UCP_PROTO_RNDV_PUT_STAGE_FLUSH,
-
-    /* Send ATP without fence (could be done after a flush) */
-    UCP_PROTO_RNDV_PUT_STAGE_ATP,
-
-    /* Send ATP with fence (could be done if using send lanes for ATP) */
-    UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP,
-
-    /* Memtype only: send the fragment to the remote side */
-    UCP_PROTO_RNDV_PUT_MTYPE_STAGE_SEND
-};
-
 typedef struct ucp_proto_rndv_put_priv {
     uct_completion_callback_t  put_comp_cb;
     uct_completion_callback_t  atp_comp_cb;
@@ -428,6 +407,23 @@ ucp_proto_rndv_put_zcopy_query(const ucp_proto_query_params_t *params,
                       UCP_PROTO_ZCOPY_DESC, put_desc);
 }
 
+static ucs_status_t ucp_proto_rndv_put_zcopy_reset(ucp_request_t *request)
+{
+    const ucp_proto_rndv_put_priv_t *rpriv = request->send.proto_config->priv;
+    ucp_datatype_iter_t *dt_iter           = &request->send.state.dt_iter;
+    ucp_lane_map_t acked_map;
+
+    if (request->send.rndv.put.atp_map != 0) {
+        acked_map       = request->send.rndv.put.atp_map ^ rpriv->atp_map;
+        dt_iter->offset = ucs_popcount(acked_map);
+    } else {
+        dt_iter->offset = dt_iter->length;
+    }
+
+    request->flags &= ~UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+    return UCS_OK;
+}
+
 ucp_proto_t ucp_rndv_put_zcopy_proto = {
     .name     = "rndv/put/zcopy",
     .desc     = NULL,
@@ -441,7 +437,7 @@ ucp_proto_t ucp_rndv_put_zcopy_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
     .abort    = ucp_proto_request_zcopy_abort,
-    .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
+    .reset    = ucp_proto_rndv_put_zcopy_reset
 };
 
 

--- a/src/ucp/stream/stream_multi.c
+++ b/src/ucp/stream/stream_multi.c
@@ -90,7 +90,8 @@ ucp_stream_multi_bcopy_init(const ucp_proto_init_params_t *init_params)
         .super.send_op       = UCT_EP_OP_AM_BCOPY,
         .super.memtype_op    = UCT_EP_OP_GET_SHORT,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
-                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -67,7 +67,8 @@ static ucs_status_t ucp_proto_eager_bcopy_multi_common_init(
         .super.send_op       = UCT_EP_OP_AM_BCOPY,
         .super.memtype_op    = UCT_EP_OP_GET_SHORT,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
-                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
@@ -188,8 +189,11 @@ void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
 {
+    if (!(req->flags & UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED)) {
+        ucp_send_request_id_alloc(req);
+    }
+
     ucp_proto_msg_multi_request_init(req);
-    ucp_send_request_id_alloc(req);
 }
 
 static ucs_status_t

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -72,7 +72,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_ptr_t ucp_tag_recv_common(
                   tag, tag_mask);
 
 #if ENABLE_DEBUG_DATA
-    req->recv.proto_rndv_config = NULL;
+    req->recv.proto_rndv_config  = NULL;
+    req->recv.proto_rndv_request = NULL;
 #endif
 
     /* First, check the fast path case - single fragment

--- a/test/gtest/ucp/test_ucp_request.cc
+++ b/test/gtest/ucp/test_ucp_request.cc
@@ -11,6 +11,7 @@ extern "C" {
 #include <ucp/core/ucp_request.inl>
 #include <ucp/core/ucp_worker.h>
 #include <ucp/proto/proto_common.h>
+#include <ucp/rndv/proto_rndv.h>
 }
 
 
@@ -117,7 +118,7 @@ public:
     {
     }
 
-    void init() override
+    virtual void init() override
     {
         if (!m_ucp_config->ctx.proto_enable) {
             UCS_TEST_SKIP_R("reset is not supported for proto v1");
@@ -130,13 +131,15 @@ public:
         ucp_test::init();
         modify_config("TCP_SNDBUF", "8K", IGNORE_IF_NOT_EXIST);
         modify_config("IB_TX_QUEUE_LEN", "65", IGNORE_IF_NOT_EXIST);
+        modify_config("MM_FIFO_SIZE", "64", IGNORE_IF_NOT_EXIST);
         create_entity(true);
+        create_entity();
 
         sender().connect(&receiver(), get_ep_params());
         receiver().connect(&sender(), get_ep_params());
     }
 
-    void cleanup() override
+    virtual void cleanup() override
     {
         m_rkeys.clear();
         m_rbufs.clear();
@@ -248,6 +251,7 @@ public:
         ASSERT_FALSE(UCS_PTR_IS_ERR(request));
         if (request != NULL) {
             wait_for_value(&m_completed, true);
+            ASSERT_TRUE(m_completed);
             ucp_request_release(request);
         }
 
@@ -255,12 +259,8 @@ public:
 
         UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
         for (auto &req : m_pending) {
-            if (req->send.state.dt_iter.offset > 0) {
-                ucp_request_send(req);
-            } else {
-                ucp_proto_request_restart(req);
-                restart_count++;
-            }
+            ucp_proto_request_restart(req);
+            restart_count++;
         }
         UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
 
@@ -284,7 +284,6 @@ public:
             rreq = ucp_tag_recv_nbx(receiver().worker(), rbuf->ptr(),
                                     rbuf->size(), 0, 0, &param);
             ASSERT_FALSE(UCS_PTR_IS_ERR(rreq));
-            reqs.push_back(rreq);
             break;
         case RMA_GET:
             param.op_attr_mask = UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
@@ -310,16 +309,20 @@ public:
 
         ASSERT_FALSE(UCS_PTR_IS_ERR(sreq));
         reqs.push_back(sreq);
+        reqs.push_back(rreq);
     }
 
-    void wait_recv(operation_t op, std::vector<void*> &reqs)
+    void wait_reqs(operation_t op, std::vector<void*> &reqs)
     {
+        size_t reqs_count = reqs.size() / 2;
+
         if (op == STREAM) {
-            for (unsigned i = 0; i < reqs.size(); ++i) {
+            for (unsigned i = 0; i < reqs_count; ++i) {
                 get_stream_data(*m_rbufs[i].get());
             }
         } else if (op == AM) {
-            wait_for_value(&m_am_cb_cnt, reqs.size());
+            wait_for_value(&m_am_cb_cnt, reqs_count);
+            ASSERT_EQ(m_am_cb_cnt, reqs_count);
         }
 
         requests_wait(reqs);
@@ -336,10 +339,44 @@ public:
         }
     }
 
-    void reset_protocol(operation_t op, bool sync = false)
+    virtual void wait_and_restart(const std::vector<void*> &reqs)
     {
-        static const unsigned reqs_count = 1000;
-        static const size_t msg_size     = UCS_KBYTE * 64;
+        wait_any(reqs, [this](const void *ureq) {
+            const ucp_request_t *req = get_request(ureq, true);
+            if (req == NULL) {
+                return false;
+            }
+
+            return is_request_in_the_middle(req);
+        });
+
+        restart(sender().ep());
+    }
+
+    typedef std::function<bool(const void*)> predicate_t;
+
+    void wait_any(const std::vector<void*> &reqs, const predicate_t &predicate)
+    {
+        const double timeout      = 10;
+        const ucs_time_t deadline = ucs::get_deadline(timeout);
+
+        while (ucs_get_time() < deadline) {
+            for (auto &req : reqs) {
+                if (predicate(req)) {
+                    return;
+                }
+            }
+
+            progress();
+        }
+
+        ASSERT_LT(ucs_get_time(), deadline);
+    }
+
+    void reset_protocol(operation_t op, bool sync = false,
+                        unsigned reqs_count = 1000)
+    {
+        static const size_t msg_size = UCS_KBYTE * 70;
 
         for (int i = 0; i < reqs_count; ++i) {
             mapped_buffer *rbuf = new mapped_buffer(msg_size, receiver());
@@ -352,12 +389,12 @@ public:
            data */
         std::vector<void*> reqs;
         send_requests(1, reqs, op, sync);
-        wait_recv(op, reqs);
+        wait_reqs(op, reqs);
 
         /* Send all messages */
         send_requests(reqs_count, reqs, op, sync);
-        restart(sender().ep());
-        wait_recv(op, reqs);
+        wait_and_restart(reqs);
+        wait_reqs(op, reqs);
         flush_ep(sender());
 
         for (int i = 0; i < reqs_count; ++i) {
@@ -387,6 +424,22 @@ public:
         }
     }
 
+    unsigned count_tl_with_caps(uint64_t capability)
+    {
+        /* EPs with no RMA transport use single type protocol */
+        const auto config  = ucp_ep_config(sender().ep());
+        unsigned rma_count = 0;
+
+        for (ucp_lane_index_t lane = 0; lane < config->key.num_lanes; ++lane) {
+            if (ucp_ep_get_iface_attr(sender().ep(), lane)->cap.flags &
+                capability) {
+                rma_count++;
+            }
+        }
+
+        return rma_count;
+    }
+
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant_with_value(variants,
@@ -396,6 +449,25 @@ public:
     }
 
 protected:
+    bool is_request_in_the_middle(const ucp_request_t *req)
+    {
+        const ucp_datatype_iter_t *dt_iter = &req->send.state.dt_iter;
+
+        return !ucp_datatype_iter_is_begin(dt_iter) &&
+               !ucp_datatype_iter_is_end(dt_iter);
+    }
+
+    const ucp_request_t *get_request(const void *ureq, bool is_send)
+    {
+        if (ureq == NULL) {
+            return NULL;
+        }
+
+        ucp_request_t *req = (ucp_request_t*)ureq - 1;
+        return (!!(req->flags & UCP_REQUEST_FLAG_PROTO_SEND) == is_send) ? req :
+                                                                           NULL;
+    }
+
     std::vector<std::vector<uint8_t>>           m_sbufs;
     std::vector<std::unique_ptr<mapped_buffer>> m_rbufs;
     std::vector<ucs::handle<ucp_rkey_h>>        m_rkeys;
@@ -410,15 +482,19 @@ UCS_TEST_P(test_proto_reset, tag_eager_multi_bcopy, "ZCOPY_THRESH=inf",
     reset_protocol(TAG);
 }
 
-UCS_TEST_P(test_proto_reset, get_offload_bcopy_to_get_am_bcopy,
-           "ZCOPY_THRESH=inf", "RNDV_THRESH=inf")
+UCS_TEST_P(test_proto_reset, get_offload_bcopy, "ZCOPY_THRESH=inf",
+           "RNDV_THRESH=inf")
 {
+    if (count_tl_with_caps(UCT_IFACE_FLAG_GET_BCOPY) == 0) {
+        UCS_TEST_SKIP_R("no RMA transports found");
+    }
+
     skip_no_pending_rma();
     reset_protocol(RMA_GET);
 }
 
-UCS_TEST_P(test_proto_reset, put_offload_bcopy_to_put_am_bcopy,
-           "ZCOPY_THRESH=inf", "RNDV_THRESH=inf")
+UCS_TEST_P(test_proto_reset, put_offload_bcopy, "ZCOPY_THRESH=inf",
+           "RNDV_THRESH=inf", "RMA_ZCOPY_MAX_SEG_SIZE=1024")
 {
     skip_no_pending_rma();
     reset_protocol(RMA_PUT);
@@ -448,47 +524,208 @@ UCS_TEST_P(test_proto_reset, am_eager_multi_bcopy, "ZCOPY_THRESH=inf",
     reset_protocol(AM);
 }
 
-UCS_TEST_P(test_proto_reset, tag_eager_multi_zcopy_to_bcopy, "ZCOPY_THRESH=0",
+UCS_TEST_P(test_proto_reset, tag_eager_multi_zcopy, "ZCOPY_THRESH=0",
            "RNDV_THRESH=inf")
 {
     reset_protocol(TAG);
 }
 
-UCS_TEST_P(test_proto_reset, get_offload_zcopy_to_get_am_bcopy,
-           "ZCOPY_THRESH=0", "RNDV_THRESH=inf")
+UCS_TEST_P(test_proto_reset, get_offload_zcopy, "ZCOPY_THRESH=0",
+           "RNDV_THRESH=inf", "RMA_ZCOPY_MAX_SEG_SIZE=1024")
 {
+    if (count_tl_with_caps(UCT_IFACE_FLAG_GET_ZCOPY) == 0) {
+        UCS_TEST_SKIP_R("no RMA transports found");
+    }
+
     skip_no_pending_rma();
     reset_protocol(RMA_GET);
 }
 
-UCS_TEST_P(test_proto_reset, put_offload_zcopy_to_put_am_bcopy,
-           "ZCOPY_THRESH=0", "RNDV_THRESH=inf")
+UCS_TEST_P(test_proto_reset, put_offload_zcopy, "ZCOPY_THRESH=0",
+           "RNDV_THRESH=inf", "RMA_ZCOPY_MAX_SEG_SIZE=1024")
 {
     skip_no_pending_rma();
     reset_protocol(RMA_PUT);
 }
 
-UCS_TEST_P(test_proto_reset, stream_multi_zcopy_to_bcopy, "ZCOPY_THRESH=0",
+UCS_TEST_P(test_proto_reset, stream_multi_zcopy, "ZCOPY_THRESH=0",
            "RNDV_THRESH=inf")
 {
     reset_protocol(STREAM);
 }
 
-UCS_TEST_P(test_proto_reset, rndv_am_zcopy_to_bcopy, "ZCOPY_THRESH=0",
-           "RNDV_THRESH=0", "RNDV_SCHEME=am")
+UCS_TEST_P(test_proto_reset, rndv_am_zcopy, "ZCOPY_THRESH=0", "RNDV_THRESH=0",
+           "RNDV_SCHEME=am")
 {
     reset_protocol(TAG);
 }
 
-UCS_TEST_P(test_proto_reset, am_eager_multi_zcopy_to_bcopy, "ZCOPY_THRESH=0",
+UCS_TEST_P(test_proto_reset, am_eager_multi_zcopy, "ZCOPY_THRESH=0",
            "RNDV_THRESH=inf")
 {
     reset_protocol(AM);
 }
 
-UCS_TEST_P(test_proto_reset, rndv_put, "RNDV_THRESH=0", "RNDV_SCHEME=put_zcopy")
+UCS_TEST_P(test_proto_reset, rndv_put, "RNDV_THRESH=0", "RNDV_SCHEME=put_zcopy",
+           "RMA_ZCOPY_MAX_SEG_SIZE=1024")
 {
+    skip_no_pending_rma();
     reset_protocol(TAG);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_proto_reset)
+
+/* The following tests require ENABLE_DEBUG_DATA flag in order to access
+ * req->recv.proto_rndv_request, which is only present with this flag. */
+#if ENABLE_DEBUG_DATA
+class test_proto_reset_rndv_get : public test_proto_reset {
+protected:
+    void wait_and_restart(const std::vector<void*> &reqs) override
+    {
+        wait_any(reqs, [this](const void *ureq) {
+            const ucp_request_t *req = get_request(ureq, false);
+            if (req == NULL) {
+                return false;
+            }
+
+            const ucp_request_t *rndv_req = req->recv.proto_rndv_request;
+            if (rndv_req == NULL) {
+                return false;
+            }
+
+            return is_request_in_the_middle(rndv_req);
+        });
+
+        restart(receiver().ep());
+    }
+};
+
+UCS_TEST_P(test_proto_reset_rndv_get, rndv_get, "RNDV_THRESH=0",
+           "RNDV_SCHEME=get_zcopy", "RMA_ZCOPY_MAX_SEG_SIZE=1024")
+{
+    if (count_tl_with_caps(UCT_IFACE_FLAG_GET_ZCOPY) == 0) {
+        UCS_TEST_SKIP_R("no RMA transports found");
+    }
+
+    skip_no_pending_rma();
+    reset_protocol(TAG);
+}
+
+UCP_INSTANTIATE_TEST_CASE(test_proto_reset_rndv_get)
+
+/* This test is intended to check resetting request during ATP phase for
+ * RNDV_PUT protocol.
+ * We use uct hooks on some UCT level functions in order to simulate the
+ * required scenario.
+ * The request is paused after the first ATP was sent, and then get reset.
+ * We need at least 2 lanes to send the data, in order for multiple ATP
+ * messages to be sent. */
+class test_proto_reset_atp : public test_proto_reset {
+public:
+    void cleanup() override
+    {
+        m_pending_reqs.clear();
+        m_ops.clear();
+        m_atp_count = 0;
+        test_proto_reset::cleanup();
+    }
+
+private:
+    void hook_uct_cbs()
+    {
+        ucp_ep_h ep                = sender().ep();
+        ucp_lane_index_t num_lanes = ucp_ep_config(ep)->key.num_lanes;
+        uct_ep_h uct_ep;
+        uct_iface_ops_t *ops;
+
+        for (ucp_lane_index_t lane = 0; lane < num_lanes; ++lane) {
+            uct_ep                = ucp_ep_get_lane(ep, lane);
+            m_ops[uct_ep]         = uct_ep->iface->ops;
+            ops                   = &uct_ep->iface->ops;
+            ops->ep_pending_add   = add_pending;
+            ops->ep_pending_purge = purge_pending;
+            ops->ep_am_short      = uct_am_short;
+        }
+    }
+
+    void restore_uct_cbs()
+    {
+        ucp_ep_h ep                = sender().ep();
+        ucp_lane_index_t num_lanes = ucp_ep_config(ep)->key.num_lanes;
+
+        for (ucp_lane_index_t lane = 0; lane < num_lanes; ++lane) {
+            uct_ep_h uct_ep    = ucp_ep_get_lane(ep, lane);
+            uct_ep->iface->ops = m_ops[uct_ep];
+        }
+    }
+
+    static ucs_status_t uct_am_short(uct_ep_h ep, uint8_t id, uint64_t header,
+                                     const void *payload, unsigned length)
+    {
+        if ((id == UCP_AM_ID_RNDV_ATP) && (++m_atp_count == 2)) {
+            return UCS_ERR_NO_RESOURCE;
+        }
+
+        return m_ops[ep].ep_am_short(ep, id, header, payload, length);
+    }
+
+    static ucs_status_t
+    add_pending(uct_ep_h tl_ep, uct_pending_req_t *n, unsigned flag)
+    {
+        m_pending_reqs.push_back(n);
+        return UCS_OK;
+    }
+
+    static void
+    purge_pending(uct_ep_h ep, uct_pending_purge_callback_t cb, void *arg)
+    {
+        for (auto &req : m_pending_reqs) {
+            cb(req, arg);
+        }
+
+        m_pending_reqs.clear();
+    }
+
+protected:
+    void wait_and_restart(const std::vector<void*> &reqs) override
+    {
+        hook_uct_cbs();
+
+        /* Wait until first ATP was sent */
+        wait_any(reqs, [](const void *ureq) {
+            if (ureq == NULL) {
+                return false;
+            }
+
+            ucp_request_t *req = (ucp_request_t*)ureq - 1;
+            return (req->flags & UCP_REQUEST_FLAG_PROTO_SEND) &&
+                   (req->send.proto_stage ==
+                    UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP);
+        });
+
+        restart(sender().ep());
+        restore_uct_cbs();
+    }
+
+    static unsigned m_atp_count;
+    static std::vector<uct_pending_req_t*> m_pending_reqs;
+    static std::map<uct_ep_h, uct_iface_ops> m_ops;
+};
+
+std::vector<uct_pending_req_t*> test_proto_reset_atp::m_pending_reqs;
+std::map<uct_ep_h, uct_iface_ops> test_proto_reset_atp::m_ops;
+unsigned test_proto_reset_atp::m_atp_count;
+
+UCS_TEST_P(test_proto_reset_atp, rndv_put, "RNDV_THRESH=0",
+           "RNDV_SCHEME=put_zcopy", "RMA_ZCOPY_MAX_SEG_SIZE=1024")
+{
+    if (count_tl_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY) < 2) {
+        UCS_TEST_SKIP_R("not enough RMA lanes were found");
+    }
+
+    reset_protocol(TAG, false, 1);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_proto_reset_atp, ib, "ib")
+
+#endif


### PR DESCRIPTION
## What
Support replacing ucp protocol in the middle of send operation (offset > 0).

## Why ?
Needed for several features: RC/DC, memic, EP reconfig.
