### PR TITLE
UCS/TOPO: Report NUMA node distance for sys root only

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -410,14 +410,17 @@ ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
     if (ucs_topo_is_pci_root(common_path)) {
         ucs_topo_pci_root_distance(path1, path2, distance);
         return UCS_OK;
-    } else if (ucs_topo_is_same_numa_node(device1, device2)) {
-        ucs_topo_common_numa_node_distance(distance);
-        return UCS_OK;
     } else if (ucs_topo_is_sys_root(common_path)) {
+        if (ucs_topo_is_same_numa_node(device1, device2)) {
+            ucs_topo_common_numa_node_distance(distance);
+            return UCS_OK;
+        }
+
         ucs_topo_sys_root_distance(distance);
         return UCS_OK;
     }
 
+    /* Report best perf for common PCI bridge or sysfs parsing error */
 default_distance:
     return ucs_topo_get_distance_default(device1, device2, distance);
 }


### PR DESCRIPTION
## What
Detect same NUMA distance when devices has common sys root part only.

## Why ?
When devices have distance distance closer then sys_root and pci (e.g. PXB), NUMA distance is reported, when the right thing is to report default distance.
