### PR TITLE
UCT/IB/MLX5: using vst4q_u64 vector copy (SIMD) for arm neon

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -507,7 +507,7 @@ static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
 #if defined( __SSE4_2__)
     UCS_WORD_COPY(__m128i, dst, __m128i, src, MLX5_SEND_WQE_BB);
 #elif defined(__ARM_NEON)
-    UCS_WORD_COPY(int16x8_t, dst, int16x8_t, src, MLX5_SEND_WQE_BB);
+    vst4q_u64(dst, vld4q_u64(src));
 #else /* NO SIMD support */
     UCS_WORD_COPY(uint64_t, dst, uint64_t, src, MLX5_SEND_WQE_BB);
 #endif


### PR DESCRIPTION
## What
using `vst4q_u64` vector copy (SIMD) for arm neon instead of `int16x8_t` word copy in `bf_copy_bb`

## Why ?
Matching [rdma-core ](https://github.com/linux-rdma/rdma-core/blob/f16330dc0e079a6670a31fa54e89abb52994fd9d/util/mmio.h#L215) blueflame copy
