### PR TITLE
UCT/IB: Support select gid by ndev

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -893,7 +893,7 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
         for (i = 0; i < gid_tbl_len; i++) {
             if (!ucs_string_is_empty(ndev_name)) {
                 status = uct_ib_device_get_roce_ndev_name(
-                    dev, port_num, i, ndev_name_tmp, sizeof(ndev_name_tmp));
+                        dev, port_num, i, ndev_name_tmp, sizeof(ndev_name_tmp));
                 if ((status != UCS_OK) ||
                     (strcmp(ndev_name, ndev_name_tmp) != 0)) {
                     continue;

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -894,7 +894,8 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
             if (!ucs_string_is_empty(ndev_name)) {
                 status = uct_ib_device_get_roce_ndev_name(
                     dev, port_num, i, ndev_name_tmp, sizeof(ndev_name_tmp));
-                if ((status != UCS_OK) || (strcmp(ndev_name, ndev_name_tmp) != 0)) {
+                if ((status != UCS_OK) ||
+                    (strcmp(ndev_name, ndev_name_tmp) != 0)) {
                     continue;
                 }
             }

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -890,7 +890,6 @@ uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
 
     ucs_assert(uct_ib_device_is_port_roce(dev, port_num));
 
-    memset(&gid_info_tmp, 0, sizeof(gid_info_tmp));
     /* search for matching GID table entries, according to the order defined
      * in priorities array
      */
@@ -911,6 +910,8 @@ uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
 
                 gid_info->gid_index = i;
                 gid_info->roce_info = gid_info_tmp.roce_info;
+                ucs_strncpy_zero(gid_info->ndev_name, gid_info_tmp.ndev_name,
+                                 sizeof(gid_info->ndev_name));
                 goto out_print;
             }
         }
@@ -919,6 +920,7 @@ uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
     gid_info->gid_index             = UCT_IB_MD_DEFAULT_GID_INDEX;
     gid_info->roce_info.ver         = UCT_IB_DEVICE_ROCE_V1;
     gid_info->roce_info.addr_family = AF_INET;
+    gid_info->ndev_name[0]          = '\0';
 
 out_print:
     ucs_debug("%s:%d using gid_index %d", uct_ib_device_name(dev), port_num,

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -930,8 +930,8 @@ uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
     gid_info->ndev_name[0]          = '\0';
 
 out_print:
-    ucs_debug("%s:%d using gid_index %d", uct_ib_device_name(dev), port_num,
-              gid_info->gid_index);
+    ucs_debug("%s:%d using gid_index %d ndev %s", uct_ib_device_name(dev),
+              port_num, gid_info->gid_index, gid_info->ndev_name);
 out:
     return status;
 }

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -252,6 +252,7 @@ typedef struct {
     union ibv_gid              gid;
     uint8_t                    gid_index;    /* IB/RoCE GID index to use */
     uct_ib_roce_version_info_t roce_info;    /* For a RoCE port */
+    char                       ndev_name[IFNAMSIZ];
 } uct_ib_device_gid_info_t;
 
 
@@ -318,6 +319,22 @@ const uct_ib_device_spec_t* uct_ib_device_spec(uct_ib_device_t *dev);
 ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
                                       uint8_t port_num,
                                       uct_ib_device_gid_info_t *gid_info);
+
+
+/**
+ * Select the best gid to use and set its information on the RoCE port -
+ * gid index, RoCE version and address family.
+ *
+ * @param [in]  dev             IB device.
+ * @param [in]  port_num        Port number.
+ * @param [in]  ndev_name       Network device name.
+ * @param [out] gid_info        Filled with the selected gid index and the
+ *                              port's RoCE version and address family.
+ */
+ucs_status_t 
+uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
+                                 char* ndev_name,
+                                 uct_ib_device_gid_info_t *gid_info);
 
 
 /**

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -328,8 +328,9 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
  * @param [in]  dev             IB device.
  * @param [in]  port_num        Port number.
  * @param [in]  ndev_name       Network device name.
- * @param [out] gid_info        Filled with the selected gid index and the
- *                              port's RoCE version and address family.
+ * @param [out] gid_info        Filled with the selected gid index, the port's
+ *                              RoCE version and address family and the network
+ *                              device name.
  */
 ucs_status_t 
 uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -252,7 +252,6 @@ typedef struct {
     union ibv_gid              gid;
     uint8_t                    gid_index;    /* IB/RoCE GID index to use */
     uct_ib_roce_version_info_t roce_info;    /* For a RoCE port */
-    char                       ndev_name[IFNAMSIZ];
 } uct_ib_device_gid_info_t;
 
 
@@ -313,10 +312,10 @@ const uct_ib_device_spec_t* uct_ib_device_spec(uct_ib_device_t *dev);
  *
  * @param [in]  dev             IB device.
  * @param [in]  port_num        Port number.
- * @param [in]  ndev_name       Network device name. Could be null.
- * @param [out] gid_info        Filled with the selected gid index, the port's
- *                              RoCE version and address family and the network
- *                              device name.
+ * @param [in]  ndev_name       Filter network device by name. No filter if
+ *                              empty.
+ * @param [out] gid_info        Filled with the selected gid index and the
+ *                              port's RoCE version and address family.
  */
 ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
                                       char *ndev_name,
@@ -387,10 +386,6 @@ ucs_status_t
 uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                struct ibv_ah_attr *ah_attr, struct ibv_pd *pd,
                                const char *usage, struct ibv_ah **ah_p);
-
-ucs_status_t uct_ib_device_get_ndev_name(const char *dev_name, uint8_t port_num,
-                                         uint8_t gid_index, char *ndev_name,
-                                         size_t max);
 
 ucs_status_t uct_ib_device_get_roce_ndev_name(uct_ib_device_t *dev,
                                               uint8_t port_num,

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -333,7 +333,7 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
  */
 ucs_status_t 
 uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
-                                 char* ndev_name,
+                                 char *ndev_name,
                                  uct_ib_device_gid_info_t *gid_info);
 
 

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -332,7 +332,7 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
  *                              RoCE version and address family and the network
  *                              device name.
  */
-ucs_status_t 
+ucs_status_t
 uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
                                  char *ndev_name,
                                  uct_ib_device_gid_info_t *gid_info);

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -313,29 +313,14 @@ const uct_ib_device_spec_t* uct_ib_device_spec(uct_ib_device_t *dev);
  *
  * @param [in]  dev             IB device.
  * @param [in]  port_num        Port number.
- * @param [out] gid_info        Filled with the selected gid index and the
- *                              port's RoCE version and address family.
- */
-ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
-                                      uint8_t port_num,
-                                      uct_ib_device_gid_info_t *gid_info);
-
-
-/**
- * Select the best gid to use and set its information on the RoCE port -
- * gid index, RoCE version and address family.
- *
- * @param [in]  dev             IB device.
- * @param [in]  port_num        Port number.
- * @param [in]  ndev_name       Network device name.
+ * @param [in]  ndev_name       Network device name. Could be null.
  * @param [out] gid_info        Filled with the selected gid index, the port's
  *                              RoCE version and address family and the network
  *                              device name.
  */
-ucs_status_t
-uct_ib_device_select_gid_by_ndev(uct_ib_device_t *dev, uint8_t port_num,
-                                 char *ndev_name,
-                                 uct_ib_device_gid_info_t *gid_info);
+ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
+                                      char *ndev_name,
+                                      uct_ib_device_gid_info_t *gid_info);
 
 
 /**
@@ -402,6 +387,10 @@ ucs_status_t
 uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                struct ibv_ah_attr *ah_attr, struct ibv_pd *pd,
                                const char *usage, struct ibv_ah **ah_p);
+
+ucs_status_t uct_ib_device_get_ndev_name(const char *dev_name, uint8_t port_num,
+                                         uint8_t gid_index, char *ndev_name,
+                                         size_t max);
 
 ucs_status_t uct_ib_device_get_roce_ndev_name(uct_ib_device_t *dev,
                                               uint8_t port_num,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1134,7 +1134,7 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface)
 
 ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
                                              unsigned long cfg_gid_index,
-                                             char* cfg_gid_ndev)
+                                             char *cfg_gid_ndev)
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     uint8_t port_num     = iface->config.port_num;
@@ -1235,7 +1235,7 @@ uct_ib_iface_init_gid_info(uct_ib_iface_t *iface,
 {
     uct_ib_md_t *md                    = uct_ib_iface_md(iface);
     unsigned long cfg_gid_index        = md->config.gid_index;
-    char* cfg_gid_ndev                 = md->config.gid_ndev;
+    char *cfg_gid_ndev                 = md->config.gid_ndev;
     uct_ib_device_gid_info_t *gid_info = &iface->gid_info;
     ucs_status_t status;
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1148,11 +1148,11 @@ ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
     }
 
     if (strnlen(cfg_gid_ndev, 1) != 0) {
-        return uct_ib_device_select_gid_by_ndev(dev, port_num, cfg_gid_ndev,
-                                                &iface->gid_info);
+        return uct_ib_device_select_gid(dev, port_num, cfg_gid_ndev,
+                                        &iface->gid_info);
     }
 
-    return uct_ib_device_select_gid(dev, port_num, &iface->gid_info);
+    return uct_ib_device_select_gid(dev, port_num, NULL, &iface->gid_info);
 }
 
 static ucs_status_t

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1141,14 +1141,14 @@ ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
 
     ucs_assert(uct_ib_iface_is_roce(iface));
 
-    if (cfg_gid_index != UCS_ULUNITS_AUTO) {
-        return uct_ib_device_query_gid_info(dev->ibv_context,
-                                            uct_ib_device_name(dev), port_num,
-                                            cfg_gid_index, &iface->gid_info);
+    if (cfg_gid_index == UCS_ULUNITS_AUTO) {
+        return uct_ib_device_select_gid(dev, port_num, cfg_gid_ndev,
+                                        &iface->gid_info);
     }
 
-    return uct_ib_device_select_gid(dev, port_num, cfg_gid_ndev,
-                                    &iface->gid_info);
+    return uct_ib_device_query_gid_info(dev->ibv_context,
+                                        uct_ib_device_name(dev), port_num,
+                                        cfg_gid_index, &iface->gid_info);
 }
 
 static ucs_status_t

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1231,14 +1231,13 @@ uct_ib_iface_init_gid_info(uct_ib_iface_t *iface,
 {
     uct_ib_md_t *md                    = uct_ib_iface_md(iface);
     unsigned long cfg_gid_index        = md->config.gid_index;
-    char *cfg_gid_ndev                 = md->config.gid_ndev;
     uct_ib_device_gid_info_t *gid_info = &iface->gid_info;
     ucs_status_t status;
 
     /* Fill the gid index and the RoCE version */
     if (uct_ib_iface_is_roce(iface)) {
         status = uct_ib_iface_init_roce_gid_info(iface, cfg_gid_index,
-                                                 cfg_gid_ndev);
+                                                 md->config.gid_ndev);
         if (status != UCS_OK) {
             goto out;
         }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1147,12 +1147,8 @@ ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
                                             cfg_gid_index, &iface->gid_info);
     }
 
-    if (strnlen(cfg_gid_ndev, 1) != 0) {
-        return uct_ib_device_select_gid(dev, port_num, cfg_gid_ndev,
-                                        &iface->gid_info);
-    }
-
-    return uct_ib_device_select_gid(dev, port_num, NULL, &iface->gid_info);
+    return uct_ib_device_select_gid(dev, port_num, cfg_gid_ndev,
+                                    &iface->gid_info);
 }
 
 static ucs_status_t

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -501,7 +501,8 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface);
  * @param md_config_index       Gid index from the md configuration.
  */
 ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
-                                             unsigned long cfg_gid_index);
+                                             unsigned long cfg_gid_index,
+                                             char* cfg_gid_ndev);
 
 
 static inline uct_ib_md_t* uct_ib_iface_md(uct_ib_iface_t *iface)

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -502,7 +502,7 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface);
  */
 ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
                                              unsigned long cfg_gid_index,
-                                             char* cfg_gid_ndev);
+                                             char *cfg_gid_ndev);
 
 
 static inline uct_ib_md_t* uct_ib_iface_md(uct_ib_iface_t *iface)

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -108,6 +108,10 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      "Port GID index to use.",
      ucs_offsetof(uct_ib_md_config_t, ext.gid_index), UCS_CONFIG_TYPE_ULUNITS},
 
+    {"GID_NDEV", "",
+     "Port GID network device to use, empty means let ucx choose automatically.",
+     ucs_offsetof(uct_ib_md_config_t, gid_ndev), UCS_CONFIG_TYPE_STRING},
+
     {"SUBNET_PREFIX", "",
      "Infiniband subnet prefix to filter ports by, empty means no filter. "
      "Relevant for IB link layer only\n"
@@ -1168,6 +1172,8 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_ADVISE;
     md->reg_cost        = md_config->reg_cost;
     md->relaxed_order   = 0;
+    ucs_strncpy_zero(md->config.gid_ndev, md_config->gid_ndev,
+                     sizeof(md->config.gid_ndev));
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1174,7 +1174,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
     md->relaxed_order   = 0;
 
     ucs_strncpy_zero(md->config.gid_ndev, md_config->gid_ndev,
-	                 sizeof(md->config.gid_ndev));
+                     sizeof(md->config.gid_ndev));
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1173,13 +1173,8 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
     md->reg_cost        = md_config->reg_cost;
     md->relaxed_order   = 0;
 
-    if (strnlen(md_config->gid_ndev, 1) == 0) {
-        md->config.gid_ndev = NULL;
-    } else {
-        ucs_strncpy_zero(md->config.ndev_name, md_config->gid_ndev,
-                         sizeof(md->config.ndev_name));
-        md->config.gid_ndev = md->config.ndev_name;
-    }
+    ucs_strncpy_zero(md->config.gid_ndev, md_config->gid_ndev,
+	                 sizeof(md->config.gid_ndev));
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1172,8 +1172,14 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_ADVISE;
     md->reg_cost        = md_config->reg_cost;
     md->relaxed_order   = 0;
-    ucs_strncpy_zero(md->config.gid_ndev, md_config->gid_ndev,
-                     sizeof(md->config.gid_ndev));
+
+    if (strnlen(md_config->gid_ndev, 1) == 0) {
+        md->config.gid_ndev = NULL;
+    } else {
+        ucs_strncpy_zero(md->config.ndev_name, md_config->gid_ndev,
+                         sizeof(md->config.ndev_name));
+        md->config.gid_ndev = md->config.ndev_name;
+    }
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -88,6 +88,7 @@ typedef struct uct_ib_md_ext_config {
     } odp;
 
     unsigned long            gid_index;    /**< IB GID index to use */
+    char                     gid_ndev[IFNAMSIZ]; /**< IB GID network device to use */
 
     size_t                   min_mt_reg;   /**< Multi-threaded registration threshold */
     size_t                   mt_reg_chunk; /**< Multi-threaded registration chunk */
@@ -178,6 +179,7 @@ typedef struct uct_ib_md_config {
     int                      async_events; /**< Whether async events should be delivered */
 
     uct_ib_md_ext_config_t   ext;          /**< External configuration */
+    char*                    gid_ndev;     /**< IB GID network device to use */
 
     UCS_CONFIG_STRING_ARRAY_FIELD(spec) custom_devices; /**< Custom device specifications */
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -88,8 +88,7 @@ typedef struct uct_ib_md_ext_config {
     } odp;
 
     unsigned long            gid_index;    /**< IB GID index to use */
-    char                     *gid_ndev;    /**< IB GID network device to use */
-    char                     ndev_name[IFNAMSIZ]; /**< IB GID network device to use */
+    char                     gid_ndev[IFNAMSIZ]; /**< IB GID network device to use */
 
     size_t                   min_mt_reg;   /**< Multi-threaded registration threshold */
     size_t                   mt_reg_chunk; /**< Multi-threaded registration chunk */

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -179,7 +179,7 @@ typedef struct uct_ib_md_config {
     int                      async_events; /**< Whether async events should be delivered */
 
     uct_ib_md_ext_config_t   ext;          /**< External configuration */
-    char*                    gid_ndev;     /**< IB GID network device to use */
+    char                     *gid_ndev;    /**< IB GID network device to use */
 
     UCS_CONFIG_STRING_ARRAY_FIELD(spec) custom_devices; /**< Custom device specifications */
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -88,7 +88,8 @@ typedef struct uct_ib_md_ext_config {
     } odp;
 
     unsigned long            gid_index;    /**< IB GID index to use */
-    char                     gid_ndev[IFNAMSIZ]; /**< IB GID network device to use */
+    char                     *gid_ndev;    /**< IB GID network device to use */
+    char                     ndev_name[IFNAMSIZ]; /**< IB GID network device to use */
 
     size_t                   min_mt_reg;   /**< Multi-threaded registration threshold */
     size_t                   mt_reg_chunk; /**< Multi-threaded registration chunk */

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -89,6 +89,8 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    ep->dci_channel_index,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
+    ucs_info("@I if %p dci %d qp %x cnt %lu len %lu", iface, (int)ep->dci,
+              iface->tx.dcis[ep->dci].txwq.super.qp_num, iovcnt, iov_total_length);
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
                               op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov,
                               iovcnt, iov_total_length);

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -89,8 +89,6 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    ep->dci_channel_index,
                                    UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
-    ucs_info("@I if %p dci %d qp %x cnt %lu len %lu", iface, (int)ep->dci,
-              iface->tx.dcis[ep->dci].txwq.super.qp_num, iovcnt, iov_total_length);
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
                               op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov,
                               iovcnt, iov_total_length);

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -382,6 +382,10 @@ public:
         status = uct_ib_iface_init_roce_gid_info(&dummy_ib_iface,
                                                  md_config->ext.gid_index,
                                                  md_config->gid_ndev);
+        if ((!ucs_string_is_empty(md_config->gid_ndev)) && (status != UCS_OK)) {
+            UCS_TEST_SKIP_R("device not found " +
+                            std::string(md_config->gid_ndev));
+        }
         ASSERT_UCS_OK(status);
 
         gid_index = dummy_ib_iface.gid_info.gid_index;
@@ -409,97 +413,11 @@ UCS_TEST_P(test_uct_ib_gid_idx, non_default_gid_idx, "GID_INDEX=1") {
     send_recv_short();
 }
 
-UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib_gid_idx);
-
-
-class test_uct_ib_gid_ndev : public test_uct_ib_with_specific_port {
-public:
-    void init() {
-        test_uct_ib_with_specific_port::init();
-        test_uct_ib::init();
-    }
-
-    void cleanup() {
-        test_uct_ib::cleanup();
-        test_uct_ib_with_specific_port::cleanup();
-    }
-
-    void check_port_attr() {
-        std::stringstream device_str;
-        device_str << ibv_get_device_name(m_ibctx->device) << ":" << m_port;
-
-        if (!IBV_PORT_IS_LINK_LAYER_ETHERNET(&m_port_attr)) {
-            UCS_TEST_SKIP_R(device_str.str() + " is not Ethernet");
-        }
-
-        union ibv_gid gid;
-        uct_ib_md_config_t *md_config = ucs_derived_of(m_md_config,
-                                                       uct_ib_md_config_t);
-        ucs::handle<uct_md_h> uct_md;
-        uct_ib_iface_t dummy_ib_iface;
-        uct_ib_md_t *ib_md;
-        ucs_status_t status;
-        char gid_ndev[IFNAMSIZ];
-        uint8_t gid_index;
-
-        UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_md_close, uct_md_open,
-                               &uct_ib_component,
-                               ibv_get_device_name(m_ibctx->device),
-                               m_md_config);
-
-        ib_md = ucs_derived_of(uct_md, uct_ib_md_t);
-
-        dummy_ib_iface.config.port_num = m_port;
-        dummy_ib_iface.super.md        = &ib_md->super;
-
-        ASSERT_EQ(&ib_md->dev, uct_ib_iface_device(&dummy_ib_iface));
-
-        /* uct_ib_iface_init_roce_gid_info() requires only the port from the
-         * ib_iface so we can use a dummy one here.
-         * this function will set the gid_index in the dummy ib_iface. */
-        status = uct_ib_iface_init_roce_gid_info(&dummy_ib_iface,
-                                                 md_config->ext.gid_index,
-                                                 md_config->gid_ndev);
-
-        device_str << " gid_ndev " << md_config->gid_ndev;
-        if (status != UCS_OK) {
-            UCS_TEST_SKIP_R("failed to init on " + device_str.str());
-        }
-
-        gid_index = dummy_ib_iface.gid_info.gid_index;
-
-        /* check the gid ndev */
-        status = uct_ib_device_get_roce_ndev_name(
-            uct_ib_iface_device(&dummy_ib_iface),
-            dummy_ib_iface.config.port_num, gid_index, gid_ndev,
-            sizeof(gid_ndev));
-
-        ASSERT_UCS_OK(status);
-        EXPECT_STREQ(md_config->gid_ndev, gid_ndev);
-
-        /* check the gid index */
-        if (ibv_query_gid(m_ibctx, m_port, gid_index, &gid) != 0) {
-            UCS_TEST_SKIP_R("failed to query " + device_str.str());
-        }
-
-        /* check if the gid is valid to use */
-        if (uct_ib_device_is_gid_raw_empty(gid.raw)) {
-            UCS_TEST_SKIP_R(device_str.str() + " is empty");
-        }
-
-        if (!uct_ib_device_test_roce_gid_index(&ib_md->dev, m_port, &gid,
-                                               gid_index)) {
-            UCS_TEST_SKIP_R("failed to create address handle on " +
-                            device_str.str());
-        }
-    }
-};
-
-UCS_TEST_P(test_uct_ib_gid_ndev, non_default_gid_idx, "GID_NDEV=bond0") {
+UCS_TEST_P(test_uct_ib_gid_idx, non_default_gid_ndev, "GID_NDEV=bond0") {
     send_recv_short();
 }
 
-UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib_gid_ndev);
+UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib_gid_idx);
 
 
 #if HAVE_DEVX

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -433,18 +433,19 @@ public:
         }
 
         union ibv_gid gid;
-        uct_ib_md_config_t *md_config =
-            ucs_derived_of(m_md_config, uct_ib_md_config_t);
+        uct_ib_md_config_t *md_config = ucs_derived_of(m_md_config,
+                                                       uct_ib_md_config_t);
         ucs::handle<uct_md_h> uct_md;
         uct_ib_iface_t dummy_ib_iface;
         uct_ib_md_t *ib_md;
         ucs_status_t status;
-        char* gid_ndev;
+        char *gid_ndev;
         uint8_t gid_index;
 
         UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_md_close, uct_md_open,
                                &uct_ib_component,
-                               ibv_get_device_name(m_ibctx->device), m_md_config);
+                               ibv_get_device_name(m_ibctx->device),
+                               m_md_config);
 
         ib_md = ucs_derived_of(uct_md, uct_ib_md_t);
 
@@ -461,7 +462,7 @@ public:
                                                  md_config->gid_ndev);
         ASSERT_UCS_OK(status);
 
-        gid_ndev = dummy_ib_iface.gid_info.ndev_name;
+        gid_ndev  = dummy_ib_iface.gid_info.ndev_name;
         gid_index = dummy_ib_iface.gid_info.gid_index;
         device_str << " gid ndev " << gid_ndev;
 


### PR DESCRIPTION
## What
Support to select gid by network device name.

## Why ?

For `vxlan` and `bond` using the same IP address, ucx doesn't choose the gid index of `bond1` as we expect.
The gid index for `vxlan` and `bond` might be different for different physical nodes in 1 cluster.

``` sh
DEV     PORT    INDEX   GID                                     IPv4            VER     DEV
---     ----    -----   ---                                     ------------    ---     ---
mlx5_bond_0     1       0       fe80:0000:0000:0000:0ac0:ebff:fe79:391a                 v1      bond1
mlx5_bond_0     1       1       fe80:0000:0000:0000:0ac0:ebff:fe79:391a                 v2      bond1
mlx5_bond_0     1       2       0000:0000:0000:0000:0000:ffff:1e99:0aaf 30.153.10.175   v1      b3.vxlan.30100
mlx5_bond_0     1       3       0000:0000:0000:0000:0000:ffff:1e99:0aaf 30.153.10.175   v2      b3.vxlan.30100
mlx5_bond_0     1       4       0000:0000:0000:0000:0000:ffff:1e99:0aaf 30.153.10.175   v1      bond1
mlx5_bond_0     1       5       0000:0000:0000:0000:0000:ffff:1e99:0aaf 30.153.10.175   v2      bond1
```

## How ?
Add environment variable named GID_NDEV to allow UCT select gid by network device name.
