### PR TITLE
UCT/IB/DC: add env for reverse_sl (default: same value of sl)

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -197,6 +197,10 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "detect the default value by creating a dummy QP." ,
    ucs_offsetof(uct_ib_iface_config_t, counter_set_id), UCS_CONFIG_TYPE_ULUNITS},
 
+  {"REVERSE_SL", "auto",
+   "Reverse Service level. 'auto' will set the same value of sl\n",
+   ucs_offsetof(uct_ib_iface_config_t, reverse_sl), UCS_CONFIG_TYPE_ULUNITS},
+
   {NULL}
 };
 
@@ -1299,6 +1303,17 @@ uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config)
     return (uint8_t)ib_config->sl;
 }
 
+uint8_t
+uct_ib_iface_config_select_reverse_sl(const uct_ib_iface_config_t *ib_config)
+{
+    if (ib_config->reverse_sl == UCS_ULUNITS_AUTO) {
+        return ib_config->sl;
+    }
+
+    ucs_assert(ib_config->reverse_sl < UCT_IB_SL_NUM);
+    return (uint8_t)ib_config->reverse_sl;
+}
+
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
                     uct_ib_iface_ops_t *ops, uct_md_h md, uct_worker_h worker,
                     const uct_iface_params_t *params,
@@ -1361,6 +1376,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     self->config.port_num           = port_num;
     /* initialize to invalid value */
     self->config.sl                 = UCT_IB_SL_NUM;
+    self->config.reverse_sl         = UCT_IB_SL_NUM;
     self->config.hop_limit          = config->hop_limit;
     self->release_desc.cb           = uct_ib_iface_release_desc;
     self->config.qp_type            = init_attr->qp_type;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -189,6 +189,9 @@ struct uct_ib_iface_config {
 
     /* QP counter set ID */
     unsigned long           counter_set_id;
+
+    /* IB reverse SL (default: AUTO - same value as sl) */
+    unsigned long           reverse_sl;
 };
 
 
@@ -292,6 +295,7 @@ struct uct_ib_iface {
         uint8_t               max_inl_cqe[UCT_IB_DIR_LAST];
         uint8_t               port_num;
         uint8_t               sl;
+        uint8_t               reverse_sl;
         uint8_t               traffic_class;
         uint8_t               hop_limit;
         uint8_t               qp_type;
@@ -577,6 +581,9 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface,
                             uct_ib_qp_attr_t *attr);
 
 uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
+
+uint8_t
+uct_ib_iface_config_select_reverse_sl(const uct_ib_iface_config_t *ib_config);
 
 #define UCT_IB_IFACE_FMT \
     "%s:%d/%s"

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -184,8 +184,10 @@ ucs_status_t uct_dc_mlx5_iface_devx_set_srq_dc_params(uct_dc_mlx5_iface_t *iface
     }
     UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, mtu, iface->super.super.super.config.path_mtu);
     UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, sl, iface->super.super.super.config.sl);
-    UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, reverse_sl, iface->super.super.super.config.sl);
-    UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, cnak_reverse_sl, iface->super.super.super.config.sl);
+    UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, reverse_sl,
+                      iface->super.super.super.config.reverse_sl);
+    UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, cnak_reverse_sl,
+                      iface->super.super.super.config.reverse_sl);
     UCT_IB_MLX5DV_SET(set_xrq_dc_params_entry_in, in, ack_timeout, iface->super.super.config.timeout);
     UCT_IB_MLX5DV_SET64(set_xrq_dc_params_entry_in, in, dc_access_key, UCT_IB_KEY);
     ucs_assert(iface->super.rx.srq.srq_num != 0);

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -14,6 +14,9 @@
 #include <ucs/time/time.h>
 
 
+#define REVERSE_SL_MASK   UCS_MASK(4)
+
+
 static UCS_F_ALWAYS_INLINE void
 uct_dc_mlx5_add_flush_remote(uct_dc_mlx5_ep_t *ep)
 {
@@ -35,6 +38,11 @@ uct_dc_mlx5_set_dgram_seg(uct_ib_mlx5_txwq_t *txwq,
     to_av->stat_rate_sl = iface->super.super.super.config.sl;
     to_av->fl_mlid      = iface->tx.av_fl_mlid;
     to_av->rlid         = av->rlid;
+
+    /* Setting reverse_sl */
+    to_av->dqp_dct &= ~(REVERSE_SL_MASK);
+    to_av->dqp_dct |= (iface->super.super.super.config.reverse_sl &
+                       REVERSE_SL_MASK);
 
     return uct_ib_mlx5_set_dgram_seg_grh(seg, grh_av);
 }

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -826,6 +826,11 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     status = uct_ib_mlx5_iface_select_sl(&self->super.super,
                                          &mlx5_config->super,
                                          &rc_config->super);
+    self->super.super.config.reverse_sl = (rc_config->super.reverse_sl ==
+                                           UCS_ULUNITS_AUTO) ?
+                                                  self->super.super.config.sl :
+                                                  rc_config->super.reverse_sl;
+
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -298,6 +298,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     self->super.config.fence_mode        = (uct_rc_fence_mode_t)config->super.super.fence_mode;
     self->super.progress                 = uct_rc_verbs_iface_progress;
     self->super.super.config.sl          = uct_ib_iface_config_select_sl(ib_config);
+    self->super.super.config.reverse_sl = uct_ib_iface_config_select_reverse_sl(
+            ib_config);
 
     if ((config->super.super.fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         (config->super.super.fence_mode == UCT_RC_FENCE_MODE_AUTO)) {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -998,6 +998,10 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
     if (status != UCS_OK) {
         return status;
     }
+    self->super.super.config.reverse_sl =
+            (config->super.super.reverse_sl == UCS_ULUNITS_AUTO) ?
+                    self->super.super.config.sl :
+                    config->super.super.reverse_sl;
 
     self->super.tx.available     = self->tx.wq.bb_max;
     self->super.config.tx_qp_len = self->tx.wq.bb_max;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -757,7 +757,9 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_verbs_iface_ops, &uct_ud_verbs_iface_tl_ops, md,
                               worker, params, config, &init_attr);
 
-    self->super.super.config.sl       = uct_ib_iface_config_select_sl(&config->super);
+    self->super.super.config.sl = uct_ib_iface_config_select_sl(&config->super);
+    self->super.super.config.reverse_sl = uct_ib_iface_config_select_reverse_sl(
+            &config->super);
 
     memset(&self->tx.wr_inl, 0, sizeof(self->tx.wr_inl));
     self->tx.wr_inl.opcode            = IBV_WR_SEND;


### PR DESCRIPTION
## What
Set reverse_sl to the same value of sl (service level) configured by `UCX_IB_SL` env.

## Why ?
Currently on certain device configurations reverse_sl is 0 if not set.