### PR TITLE
TEST/RKEY: Check rkey distance with accordance to fp8 precision

### DIFF
--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -117,16 +117,23 @@ extern const ucp_tl_bitmap_t ucp_tl_bitmap_min;
                    UCP_MAX_RESOURCES)
 
 
+#define UCS_FP8_MIN_BW  (512 * UCS_MBYTE)
+#define UCS_FP8_MAX_BW  (4 * UCS_TBYTE)
+#define UCS_FP8_MIN_LAT UCS_BIT(4)
+#define UCS_FP8_MAX_LAT UCS_BIT(17)
+#define UCS_FP8_MIN_OVH UCS_BIT(0)
+#define UCS_FP8_MAX_OVH UCS_BIT(12)
+
 /* Pack bandwidth as bytes/second, range: 512 MB/s to 4 TB/s */
-UCS_FP8_DECLARE_TYPE(BANDWIDTH, 512 * UCS_MBYTE, 4 * UCS_TBYTE)
+UCS_FP8_DECLARE_TYPE(BANDWIDTH, UCS_FP8_MIN_BW, UCS_FP8_MAX_BW)
 
 
 /* Pack latency as nanoseconds, range: 16 nsec to 131 usec */
-UCS_FP8_DECLARE_TYPE(LATENCY, UCS_BIT(4), UCS_BIT(17))
+UCS_FP8_DECLARE_TYPE(LATENCY, UCS_FP8_MIN_LAT, UCS_FP8_MAX_LAT)
 
 
 /* Pack overhead as nanoseconds, range: 1 nsec to 4 usec */
-UCS_FP8_DECLARE_TYPE(OVERHEAD, UCS_BIT(0), UCS_BIT(12))
+UCS_FP8_DECLARE_TYPE(OVERHEAD, UCS_FP8_MIN_OVH, UCS_FP8_MAX_OVH)
 
 
 /**

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -14,7 +14,10 @@ extern "C" {
 #include <ucp/core/ucp_rkey.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/dt/dt.h>
+#include <ucs/type/float8.h>
 }
+
+#include <cmath>
 
 class test_ucp_mmap : public ucp_test {
 public:
@@ -167,8 +170,8 @@ protected:
     bool disable_proto() const;
 
 private:
-    void expect_same_distance(const ucs_sys_dev_distance_t &dist1,
-                              const ucs_sys_dev_distance_t &dist2);
+    void check_distance_precision(double rkey_value, double topo_value,
+                                  size_t pack_min, size_t pack_max);
     void test_rkey_proto(ucp_mem_h memh);
     void test_rereg_local_mem(ucp_mem_h memh, void *ptr, size_t size,
                               unsigned map_flags);
@@ -355,18 +358,32 @@ bool test_ucp_mmap::disable_proto() const
     return get_variant_value() == VARIANT_PROTO_DISABLE;
 }
 
-void test_ucp_mmap::expect_same_distance(const ucs_sys_dev_distance_t &dist1,
-                                         const ucs_sys_dev_distance_t &dist2)
+void test_ucp_mmap::check_distance_precision(double rkey_value,
+                                             double topo_value,
+                                             size_t pack_min,
+                                             size_t pack_max)
 {
     /* Expect the implementation to always provide a reasonable precision w.r.t.
      * real-world bandwidth and latency ballpark numbers.
      */
-    EXPECT_NEAR(dist1.bandwidth, dist2.bandwidth, 600e6); /* 600 MBs accuracy */
-    EXPECT_NEAR(dist1.latency, dist2.latency, 20e-9); /* 20 nsec accuracy */
+    double allowed_diff_ratio = 1 - UCS_FP8_PRECISION;
+
+    if (rkey_value == pack_min) {
+        /* Capped by pack_min, no cache entry */
+        EXPECT_LE(std::lround(topo_value), pack_min);
+    } else if (rkey_value == pack_max) {
+        /* Capped by pack_max, no cache entry */
+        EXPECT_GE(std::lround(topo_value), pack_max);
+    } else {
+        /* Inside the borders or cache entry */
+        EXPECT_NEAR(rkey_value, topo_value, topo_value * allowed_diff_ratio);
+    }
 }
 
 void test_ucp_mmap::test_rkey_proto(ucp_mem_h memh)
 {
+    ucs_sys_dev_distance_t rkey_dist, topo_dist;
+    ucs_sys_device_t sys_dev;
     ucs_status_t status;
 
     /* Detect system device of the allocated memory */
@@ -419,11 +436,15 @@ void test_ucp_mmap::test_rkey_proto(ucp_mem_h memh)
         /* Compare original system distance and unpacked rkey system distance */
         for (ucp_lane_index_t lane = 0; lane < ep_config->key.num_lanes;
              ++lane) {
-            ucs_sys_device_t sys_dev = ep_config->key.lanes[lane].dst_sys_dev;
-            expect_same_distance(rkey_config->lanes_distance[lane],
-                                 (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ?
-                                         ucs_topo_default_distance :
-                                         sys_distance[sys_dev]);
+            sys_dev   = ep_config->key.lanes[lane].dst_sys_dev;
+            rkey_dist = rkey_config->lanes_distance[lane];
+            topo_dist = (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ?
+                        ucs_topo_default_distance : sys_distance[sys_dev];
+
+            check_distance_precision(rkey_dist.bandwidth, topo_dist.bandwidth,
+                                     UCS_FP8_MIN_BW, UCS_FP8_MAX_BW);
+            check_distance_precision(rkey_dist.latency, topo_dist.latency,
+                                     UCS_FP8_MIN_LAT, UCS_FP8_MAX_LAT);
         }
     }
 


### PR DESCRIPTION
## What
Check rkey and topo distance difference doesn't cross `UCS_FP8_PRECISION` ratio.

## Why ?
Now test uses hardcoded values, but with big BW difference can be more then 600 MB/s

Can be tested on rock partition by the following command: `GTEST_FILTER=*rc/test_ucp_mmap.reg_mem_type/0* ./test/gtest/gtest`

