### PR TITLE
UCP/PROTO: Do not change multi-fragment perf for 1 fragment range

### DIFF
--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -32,6 +32,8 @@ void ucp_proto_common_add_ppln_range(const ucp_proto_init_params_t *init_params,
     ucp_proto_caps_t *caps             = init_params->caps;
     ucp_proto_perf_range_t *ppln_range = &caps->ranges[caps->num_ranges];
     size_t frag_size                   = frag_range->max_length;
+    ucs_linear_func_t *ppln_perf       = ppln_range->perf;
+    ucp_proto_perf_type_t perf_type;
     double frag_overhead;
     char frag_str[64];
 
@@ -39,27 +41,30 @@ void ucp_proto_common_add_ppln_range(const ucp_proto_init_params_t *init_params,
     ppln_range->node = ucp_proto_perf_node_new_data("pipeline", "frag size: %s",
                                                     frag_str);
 
+    UCP_PROTO_PERF_TYPE_FOREACH(perf_type) {
+        /* For multi-fragment protocols, we need to apply the fragment
+         * size to the performance function linear factor.
+         */
+        ppln_perf[perf_type]    = frag_range->perf[perf_type];
+        ppln_perf[perf_type].m += frag_range->perf[perf_type].c / frag_size;
+    }
+
     /* Overhead of sending one fragment before starting the pipeline */
+    /* Calculation of frag-overhead should be based on frag_range->perf
+     * but it causes significant performance degradation in the current perf
+     * prediction scheme */
     frag_overhead =
-            ucs_linear_func_apply(frag_range->perf[UCP_PROTO_PERF_TYPE_SINGLE],
-                                  frag_size) -
-            ucs_linear_func_apply(frag_range->perf[UCP_PROTO_PERF_TYPE_MULTI],
-                                  frag_size);
+            ucs_linear_func_apply(ppln_perf[UCP_PROTO_PERF_TYPE_SINGLE], frag_size) -
+            ucs_linear_func_apply(ppln_perf[UCP_PROTO_PERF_TYPE_MULTI], frag_size);
+    ucs_assert(frag_overhead >= 0);
 
     ucs_trace("frag-size: %zd" UCP_PROTO_TIME_FMT(frag_overhead), frag_size,
               UCP_PROTO_TIME_ARG(frag_overhead));
 
     /* Apply the pipelining effect when sending multiple fragments */
-    ppln_range->perf[UCP_PROTO_PERF_TYPE_SINGLE] =
-            ucs_linear_func_add(frag_range->perf[UCP_PROTO_PERF_TYPE_MULTI],
+    ppln_perf[UCP_PROTO_PERF_TYPE_SINGLE] =
+            ucs_linear_func_add(ppln_perf[UCP_PROTO_PERF_TYPE_MULTI],
                                 ucs_linear_func_make(frag_overhead, 0));
-
-    /* Multiple send performance is the same */
-    ppln_range->perf[UCP_PROTO_PERF_TYPE_MULTI] =
-            frag_range->perf[UCP_PROTO_PERF_TYPE_MULTI];
-
-    ppln_range->perf[UCP_PROTO_PERF_TYPE_CPU] =
-            frag_range->perf[UCP_PROTO_PERF_TYPE_CPU];
 
     ppln_range->max_length = max_length;
 
@@ -187,18 +192,16 @@ ucp_proto_init_parallel_stages(const ucp_proto_init_params_t *params,
                                size_t range_start, size_t range_end,
                                size_t frag_size, double bias,
                                const ucp_proto_perf_range_t **stages,
-                               unsigned num_stages, unsigned flags)
+                               unsigned num_stages)
 {
     ucp_proto_caps_t *caps      = params->caps;
     ucs_linear_func_t bias_func = ucs_linear_func_make(0.0, 1.0 - bias);
     UCS_ARRAY_DEFINE_ONSTACK(ucp_proto_perf_envelope_t, concave, 16);
     UCS_ARRAY_DEFINE_ONSTACK(ucp_proto_perf_list_t, stage_list, 16);
-    ucs_linear_func_t perf[UCP_PROTO_PERF_TYPE_LAST];
     ucs_linear_func_t sum_single_perf, sum_cpu_perf;
     const ucp_proto_perf_range_t **stage_elem;
     ucp_proto_perf_envelope_elem_t *elem;
     ucp_proto_perf_node_t *stage_node;
-    ucp_proto_perf_type_t perf_type;
     ucp_proto_perf_range_t *range;
     ucs_linear_func_t *perf_elem;
     char frag_size_str[64];
@@ -215,27 +218,16 @@ ucp_proto_init_parallel_stages(const ucp_proto_init_params_t *params,
     sum_single_perf = UCS_LINEAR_FUNC_ZERO;
     sum_cpu_perf    = UCS_LINEAR_FUNC_ZERO;
     ucs_carray_for_each(stage_elem, stages, num_stages) {
-        UCP_PROTO_PERF_TYPE_FOREACH(perf_type) {
-            perf[perf_type] = (*stage_elem)->perf[perf_type];
-            /* For multi-fragment protocols, we need to apply the fragment
-             * size to the performance function linear factor.
-             */
-            if (!(flags & UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG) &&
-                (frag_size > 0)) {
-                perf[perf_type].m += perf[perf_type].c / frag_size;
-            }
-        }
-
         /* Summarize single and CPU time */
         ucs_linear_func_add_inplace(&sum_single_perf,
-                                    perf[UCP_PROTO_PERF_TYPE_SINGLE]);
+                                    (*stage_elem)->perf[UCP_PROTO_PERF_TYPE_SINGLE]);
         ucs_linear_func_add_inplace(&sum_cpu_perf,
-                                    perf[UCP_PROTO_PERF_TYPE_CPU]);
+                                    (*stage_elem)->perf[UCP_PROTO_PERF_TYPE_CPU]);
 
         /* Add all multi perf ranges to envelope array */
         perf_elem  = ucs_array_append(&stage_list, status = UCS_ERR_NO_MEMORY;
-                                     goto out);
-        *perf_elem = perf[UCP_PROTO_PERF_TYPE_MULTI];
+                                      goto out);
+        *perf_elem = (*stage_elem)->perf[UCP_PROTO_PERF_TYPE_MULTI];
 
         ucs_trace("stage[%zu] %s " UCP_PROTO_PERF_FUNC_TYPES_FMT
                   UCP_PROTO_PERF_FUNC_FMT(perf_elem),
@@ -678,8 +670,7 @@ ucp_proto_init_single_frag_ranges(const ucp_proto_common_init_params_t *params,
 
     /* Add ranges representing sending single fragment */
     status = ucp_proto_init_parallel_stages(&params->super, range_start, frag_size,
-                                            frag_size, 0.0, parallel_stages, 3,
-                                            params->flags);
+                                            frag_size, 0.0, parallel_stages, 3);
 
     ucp_proto_perf_node_deref(&recv_perf.node);
 out_deref_send_perf:

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -79,7 +79,7 @@ ucp_proto_init_parallel_stages(const ucp_proto_init_params_t *params,
                                size_t range_start, size_t range_end,
                                size_t frag_size, double bias,
                                const ucp_proto_perf_range_t **stages,
-                               unsigned num_stages, unsigned flags);
+                               unsigned num_stages);
 
 
 void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -369,8 +369,7 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
                                                 min_length,
                                                 range_max_length, SIZE_MAX,
                                                 params->perf_bias,
-                                                parallel_stages, 2,
-                                                params->super.flags);
+                                                parallel_stages, 2);
         if (status != UCS_OK) {
             goto out_deref_perf_node;
         }
@@ -570,7 +569,7 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
 
         status = ucp_proto_init_parallel_stages(init_params, min_length,
                                                 ack_range.max_length, SIZE_MAX,
-                                                0, parallel_stages, 2, flags);
+                                                0, parallel_stages, 2);
         if (status != UCS_OK) {
             break;
         }


### PR DESCRIPTION
## What
Move additional multi-fragment overheads to multi-fragment ranges.

## Why ?
Currently multi-fragmented protocols changes perf by applying the fragment size to the performance function linear factor even for 1 fragment range which is wrong. We should calculate one-fragment perf using the provided untouched data for all the protocols and apply the additional PPLN overheads on multi-frag ranges.
