### PR TITLE
UCP: Fine-grained intra/inter config for rendezvous

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -169,9 +169,26 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Threshold for switching from eager to rendezvous protocol",
    ucs_offsetof(ucp_context_config_t, rndv_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"RNDV_INTRA_THRESH", UCS_VALUE_AUTO_STR,
+   "Threshold for switching from eager to rendezvous protocol for intra-node\n"
+   "communication.\n"
+   " auto   - Threshold is defined by UCX_RNDV_THRESH\n"
+   " 0..inf - Explicit threshold for intra-node communication, has precedence\n"
+   "          over UCX_RNDV_THRESH config",
+   ucs_offsetof(ucp_context_config_t, rndv_intra_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
+  {"RNDV_INTER_THRESH", UCS_VALUE_AUTO_STR,
+   "Threshold for switching from eager to rendezvous protocol for inter-node\n"
+   "communication.\n"
+   " auto   - Threshold is defined by UCX_RNDV_THRESH\n"
+   " 0..inf - Explicit threshold for inter-node communication, has precedence\n"
+   "          over UCX_RNDV_THRESH config",
+   ucs_offsetof(ucp_context_config_t, rndv_inter_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"RNDV_SEND_NBR_THRESH", "256k",
    "Threshold for switching from eager to rendezvous protocol in ucp_tag_send_nbr().\n"
-   "Relevant only if UCX_RNDV_THRESH is set to \"auto\".",
+   "Relevant only if UCX_RNDV_THRESH (or corresponding fine-grained config\n"
+   "UCX_RNDV_INTRA_THRESH/UCX_RNDV_INTER_THRESH) is set to \"auto\".",
    ucs_offsetof(ucp_context_config_t, rndv_send_nbr_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_THRESH_FALLBACK", "inf",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -49,6 +49,10 @@ typedef struct ucp_context_config {
     size_t                                 bcopy_thresh;
     /** Threshold for switching UCP to rendezvous protocol */
     size_t                                 rndv_thresh;
+    /** Threshold for switching UCP to rendezvous protocol for intra-node */
+    size_t                                 rndv_intra_thresh;
+    /** Threshold for switching UCP to rendezvous protocol for inter-node */
+    size_t                                 rndv_inter_thresh;
     /** Threshold for switching UCP to rendezvous protocol
      *  in ucp_tag_send_nbr() */
     size_t                                 rndv_send_nbr_thresh;

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -27,7 +27,7 @@ static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_fast_lane(ucp_ep_h ep,
                                                          ucp_lane_index_t lane_index)
 {
     ucs_assertv(lane_index < UCP_MAX_FAST_PATH_LANES, "lane=%d", lane_index);
-    return ep->uct_eps[lane_index];
+    return ep->uct_eps[lane_index];	
 }
 
 static UCS_F_ALWAYS_INLINE uct_ep_h
@@ -254,8 +254,8 @@ ucp_ep_config_key_has_cm_lane(const ucp_ep_config_key_t *config_key)
 static UCS_F_ALWAYS_INLINE int
 ucp_ep_config_key_is_inter_node(const ucp_ep_config_key_t *config_key)
 {
-    return (!(config_key->flags & (UCP_EP_CONFIG_KEY_FLAG_SELF |
-                                   UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE)));
+    return !(config_key->flags & (UCP_EP_CONFIG_KEY_FLAG_SELF |
+                                  UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE));
 }
 
 static inline int ucp_ep_has_cm_lane(ucp_ep_h ep)

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -27,7 +27,7 @@ static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_fast_lane(ucp_ep_h ep,
                                                          ucp_lane_index_t lane_index)
 {
     ucs_assertv(lane_index < UCP_MAX_FAST_PATH_LANES, "lane=%d", lane_index);
-    return ep->uct_eps[lane_index];	
+    return ep->uct_eps[lane_index];
 }
 
 static UCS_F_ALWAYS_INLINE uct_ep_h
@@ -249,6 +249,13 @@ static inline int
 ucp_ep_config_key_has_cm_lane(const ucp_ep_config_key_t *config_key)
 {
     return config_key->cm_lane != UCP_NULL_LANE;
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_ep_config_key_is_inter_node(const ucp_ep_config_key_t *config_key)
+{
+    return (!(config_key->flags & (UCP_EP_CONFIG_KEY_FLAG_SELF |
+                                   UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE)));
 }
 
 static inline int ucp_ep_has_cm_lane(ucp_ep_h ep)

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -393,6 +393,19 @@ static size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params)
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     const ucp_context_config_t *cfg = &init_params->worker->context->config.ext;
 
+    /* Explicit configuration for rendezvous threshold (either fine-grained or
+     * coarse-grained) has precedence over rndv_send_nbr_thresh
+     */
+    if (ucp_ep_config_key_is_inter_node(init_params->ep_config_key)) {
+        if (cfg->rndv_inter_thresh != UCS_MEMUNITS_AUTO) {
+            return cfg->rndv_inter_thresh;
+        }
+    } else {
+        if (cfg->rndv_intra_thresh != UCS_MEMUNITS_AUTO) {
+            return cfg->rndv_intra_thresh;
+        }
+    }
+
     if ((cfg->rndv_thresh == UCS_MEMUNITS_AUTO) &&
         (ucp_proto_select_op_attr_unpack(select_param->op_attr) &
          UCP_OP_ATTR_FLAG_FAST_CMPL) &&


### PR DESCRIPTION
## What
Introduced intra/inter-node fine-grained configuration for rendezvous switching.

## Why ?
Current implementation provides coarse-grained config (`UCX_RNDV_THRESH`) to set rendezvous switching threshold. There is a demand from some clients to introduce fine-grained config allowing to set this threshold separately for intra-node and inter-node communication.

## How ?
We introduce 2 new fine-grained configs for intra-node (`UCX_RNDV_INTRA_THRESH`) and inter-node (`UCX_RNDV_INTER_THRESH`) communication. If these configs are set to non-auto values, they have precedence over coarse-grained value (`UCX_RNDV_THRESH`).

**Testing**
Currently there is no easy way to test inter-node endpoint in gtest. So manual testing was performed to make sure the proper rendezvous thresholds are applied (with `ucp_client_server` and `ucp_hello_world`)