### PR TITLE
UCP: Fine-grained intra/inter config for rendezvous

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -166,8 +166,14 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, bcopy_thresh), UCS_CONFIG_TYPE_MEMUNITS},
 
   {"RNDV_THRESH", UCS_VALUE_AUTO_STR,
-   "Threshold for switching from eager to rendezvous protocol",
-   ucs_offsetof(ucp_context_config_t, rndv_thresh), UCS_CONFIG_TYPE_MEMUNITS},
+   "Threshold for switching from eager to rendezvous protocol", 0,
+    UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_MEMUNITS,
+        {"intra", "threshold for intra-node communication",
+         ucs_offsetof(ucp_context_config_t, rndv_intra_thresh)},
+        {"inter", "threshold for inter-node communication",
+         ucs_offsetof(ucp_context_config_t, rndv_inter_thresh)},
+        {NULL}
+  )},
 
   {"RNDV_SEND_NBR_THRESH", "256k",
    "Threshold for switching from eager to rendezvous protocol in ucp_tag_send_nbr().\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -47,8 +47,10 @@ enum {
 typedef struct ucp_context_config {
     /** Threshold for switching UCP to buffered copy(bcopy) protocol */
     size_t                                 bcopy_thresh;
-    /** Threshold for switching UCP to rendezvous protocol */
-    size_t                                 rndv_thresh;
+    /** Threshold for switching UCP to rendezvous protocol for intra-node */
+    size_t                                 rndv_intra_thresh;
+    /** Threshold for switching UCP to rendezvous protocol for inter-node */
+    size_t                                 rndv_inter_thresh;
     /** Threshold for switching UCP to rendezvous protocol
      *  in ucp_tag_send_nbr() */
     size_t                                 rndv_send_nbr_thresh;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2183,7 +2183,7 @@ ucp_ep_config_set_am_rndv_thresh(ucp_worker_h worker,
     ucs_assert(config->key.am_lane != UCP_NULL_LANE);
     ucs_assert(config->key.lanes[config->key.am_lane].rsc_index != UCP_NULL_RESOURCE);
 
-    if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
+    if (context->config.ext.rndv_inter_thresh == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the AM rndv threshold on its own.*/
         status = ucp_ep_config_calc_rndv_thresh(worker, config,
                                                 config->key.am_bw_lanes,
@@ -2196,8 +2196,8 @@ ucp_ep_config_set_am_rndv_thresh(ucp_worker_h worker,
         rndv_local_thresh = context->config.ext.rndv_send_nbr_thresh;
         ucs_trace("active message rendezvous threshold is %zu", rndv_thresh);
     } else {
-        rndv_thresh       = context->config.ext.rndv_thresh;
-        rndv_local_thresh = context->config.ext.rndv_thresh;
+        rndv_thresh       = context->config.ext.rndv_inter_thresh;
+        rndv_local_thresh = context->config.ext.rndv_inter_thresh;
     }
 
     min_thresh     = ucs_max(iface_attr->cap.am.min_zcopy, min_rndv_thresh);
@@ -2233,7 +2233,7 @@ ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker, ucp_ep_config_t *config,
 
     iface_attr = ucp_worker_iface_get_attr(worker, rsc_index);
 
-    if (context->config.ext.rndv_thresh == UCS_MEMUNITS_AUTO) {
+    if (context->config.ext.rndv_inter_thresh == UCS_MEMUNITS_AUTO) {
         /* auto - Make UCX calculate the RMA (get_zcopy) rndv threshold on its own.*/
         status = ucp_ep_config_calc_rndv_thresh(worker, config,
                                                 config->key.am_bw_lanes,
@@ -2244,8 +2244,8 @@ ucp_ep_config_set_rndv_thresh(ucp_worker_t *worker, ucp_ep_config_t *config,
 
         rndv_local_thresh = context->config.ext.rndv_send_nbr_thresh;
     } else {
-        rndv_thresh       = context->config.ext.rndv_thresh;
-        rndv_local_thresh = context->config.ext.rndv_thresh;
+        rndv_thresh       = context->config.ext.rndv_inter_thresh;
+        rndv_local_thresh = context->config.ext.rndv_inter_thresh;
     }
 
     min_thresh = ucs_max(iface_attr->cap.get.min_zcopy, min_rndv_thresh);
@@ -2371,8 +2371,8 @@ ucp_ep_config_max_short(ucp_context_t *context, uct_iface_attr_t *iface_attr,
     }
 
     if ((rndv_thresh != NULL) &&
-        (context->config.ext.rndv_thresh != UCS_MEMUNITS_AUTO)) {
-        /* Adjust max_short if rndv_thresh is set externally. Note local and
+        (context->config.ext.rndv_inter_thresh != UCS_MEMUNITS_AUTO)) {
+        /* Adjust max_short if rndv_inter_thresh is set externally. Note local and
          * remote threshold values are the same if set externally, so can
          * compare with just one of them. */
         ucs_assert(rndv_thresh->remote == rndv_thresh->local);

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -251,6 +251,13 @@ ucp_ep_config_key_has_cm_lane(const ucp_ep_config_key_t *config_key)
     return config_key->cm_lane != UCP_NULL_LANE;
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_ep_config_is_inter_node(const ucp_ep_config_key_t *config_key)
+{
+    return !(config_key->flags & (UCP_EP_CONFIG_KEY_FLAG_SELF |
+                                  UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE));
+}
+
 static inline int ucp_ep_has_cm_lane(ucp_ep_h ep)
 {
     return (ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL) &&

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -331,7 +331,8 @@ static ucs_status_t ucp_worker_wakeup_init(ucp_worker_h worker,
      */
     if ((events & UCP_WAKEUP_TAG_SEND) ||
         ((events & UCP_WAKEUP_TAG_RECV) &&
-         (context->config.ext.rndv_thresh != UCS_MEMUNITS_INF)))
+         ((context->config.ext.rndv_intra_thresh != UCS_MEMUNITS_INF) ||
+          (context->config.ext.rndv_inter_thresh != UCS_MEMUNITS_INF))))
     {
         worker->uct_events |= UCT_EVENT_SEND_COMP;
     }
@@ -2159,6 +2160,11 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
                                         UCP_FEATURE_AM, UCP_OP_ID_AM_SEND,
                                         UCP_PROTO_FLAG_AM_SHORT, key->am_lane,
                                         &ep_config->am_u.max_eager_short);
+
+        ucp_worker_ep_config_short_init(worker, ep_config, ep_cfg_index,
+                                        UCP_FEATURE_AM, UCP_OP_ID_AM_SEND_REPLY,
+                                        UCP_PROTO_FLAG_AM_SHORT, key->am_lane,
+                                        &ep_config->am_u.max_reply_eager_short);
     }
 
     ucp_worker_print_used_tls(worker, ep_cfg_index);

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -109,6 +109,8 @@ typedef struct {
 
 } ucp_proto_rndv_ctrl_init_params_t;
 
+/* Return rendezvous threshold for the provided configuration */
+size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params);
 
 /* Initializes protocol which sends rendezvous control message using AM lane
  * (e.g. RTS and ATS). */

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -27,7 +27,7 @@ ucp_tag_rndv_offload_proto_init(const ucp_proto_init_params_t *init_params)
        .super.super         = *init_params,
        .super.latency       = 0,
        .super.overhead      = 40e-9,
-       .super.cfg_thresh    = context->config.ext.rndv_thresh,
+       .super.cfg_thresh    = ucp_proto_rndv_thresh(init_params),
        .super.cfg_priority  = 60,
        .super.min_length    = ucp_ep_tag_offload_min_rndv_thresh(
                                   context, init_params->ep_config_key),
@@ -158,7 +158,7 @@ ucp_tag_rndv_offload_sw_proto_init(const ucp_proto_init_params_t *init_params)
         .super.super         = *init_params,
         .super.latency       = 0,
         .super.overhead      = 40e-9,
-        .super.cfg_thresh    = context->config.ext.rndv_thresh,
+        .super.cfg_thresh    = ucp_proto_rndv_thresh(init_params),
         .super.cfg_priority  = 60,
         .super.min_length    = ucp_ep_tag_offload_min_rndv_thresh(
                                    context, init_params->ep_config_key),


### PR DESCRIPTION
## What
Introduced intra/inter-node fine-grained configuration for rendezvous switching.
This change is **only supported by proto v2**. For proto v1 only coarse grained config is supported (e.g. `UCX_RNDV_THRESH=1000`)

## Why ?
Current implementation provides coarse-grained config (`UCX_RNDV_THRESH`) to set rendezvous switching threshold. There is a demand from some clients to introduce fine-grained config allowing to set this threshold separately for intra-node and inter-node communication.

## How ?
We use newly developed key-value parser in the config, that is used to configure fine-grained thresholds for intra and inter communication. Coarse-grained config (value for all) is still acceptable. Fine-grained config has precedence over coarse-grained one
```
UCX_RNDV_THRESH=1000  // 1000 is the limit for intra and inter
UCX_RNDV_THRESH=1000,intra:500  // 500 is the limit for intra, 1000 for inter
UCX_RNDV_THRESH=intra:100,inter:200  // explicit
```

**Testing**
Currently there is no easy way to test inter-node endpoint in gtest. So manual testing was performed to make sure the proper rendezvous thresholds are applied (with `ucp_client_server` and `ucp_hello_world`)