### PR TITLE
BINDINGS/GO: Fixed make install.

### DIFF
--- a/bindings/go/Makefile.am
+++ b/bindings/go/Makefile.am
@@ -56,7 +56,7 @@ run-perftest:
 	cd $(abs_top_srcdir)/bindings/go/src/examples/perftest ;\
 	LD_LIBRARY_PATH=$(UCX_SOPATH):${LD_LIBRARY_PATH} ${GOTMPDIR}/goperftest ${ARGS}
 
-install-exec-hook:
+install-exec-hook: goperftest
 	$(INSTALL) ${GOTMPDIR}/goperftest $(DESTDIR)$(bindir)
 
 all: goperftest build


### PR DESCRIPTION
## What
Fixed `make install` command failure with enabled GO UCX bindings.

```
/usr/bin/install: cannot stat '/root/ucx/build/bindings/go/.libs/tmp/goperftest': No such file or directory
```
