### PR TITLE
UCT/IB: fixed reverse_sl feature - removed code-dup and parentheses

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1303,15 +1303,16 @@ uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config)
     return (uint8_t)ib_config->sl;
 }
 
-uint8_t
-uct_ib_iface_config_select_reverse_sl(const uct_ib_iface_config_t *ib_config)
+void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
+                                 const uct_ib_iface_config_t *ib_config)
 {
     if (ib_config->reverse_sl == UCS_ULUNITS_AUTO) {
-        return ib_config->sl;
+        ib_iface->config.reverse_sl = ib_iface->config.sl;
+        return;
     }
 
     ucs_assert(ib_config->reverse_sl < UCT_IB_SL_NUM);
-    return (uint8_t)ib_config->reverse_sl;
+    ib_iface->config.reverse_sl = (uint8_t)ib_config->reverse_sl;
 }
 
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -582,8 +582,8 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface,
 
 uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
 
-uint8_t
-uct_ib_iface_config_select_reverse_sl(const uct_ib_iface_config_t *ib_config);
+void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
+                                 const uct_ib_iface_config_t *ib_config);
 
 #define UCT_IB_IFACE_FMT \
     "%s:%d/%s"

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -40,9 +40,9 @@ uct_dc_mlx5_set_dgram_seg(uct_ib_mlx5_txwq_t *txwq,
     to_av->rlid         = av->rlid;
 
     /* Setting reverse_sl */
-    to_av->dqp_dct &= ~(REVERSE_SL_MASK);
-    to_av->dqp_dct |= (iface->super.super.super.config.reverse_sl &
-                       REVERSE_SL_MASK);
+    to_av->dqp_dct &= ~REVERSE_SL_MASK;
+    to_av->dqp_dct |= iface->super.super.super.config.reverse_sl &
+                      REVERSE_SL_MASK;
 
     return uct_ib_mlx5_set_dgram_seg_grh(seg, grh_av);
 }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -988,12 +988,11 @@ uct_ib_mlx5_devx_md_get_counter_set_id(uct_ib_mlx5_md_t *md, uint8_t port_num)
 
 size_t uct_ib_mlx5_devx_sq_length(size_t tx_qp_length);
 
-ucs_status_t
-uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
-                      ucs_ternary_auto_value_t ar_enable,
-                      uint16_t hw_sl_mask, int have_sl_mask_cap,
-                      const char *dev_name, uint8_t port_num,
-                      uint8_t *sl_p);
+ucs_status_t uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
+                                   ucs_ternary_auto_value_t ar_enable,
+                                   uint16_t hw_sl_mask, int have_sl_mask_cap,
+                                   const char *dev_name, uint8_t port_num,
+                                   uint8_t *sl_p);
 
 ucs_status_t
 uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -826,10 +826,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     status = uct_ib_mlx5_iface_select_sl(&self->super.super,
                                          &mlx5_config->super,
                                          &rc_config->super);
-    self->super.super.config.reverse_sl = (rc_config->super.reverse_sl ==
-                                           UCS_ULUNITS_AUTO) ?
-                                                  self->super.super.config.sl :
-                                                  rc_config->super.reverse_sl;
 
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -298,8 +298,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     self->super.config.fence_mode        = (uct_rc_fence_mode_t)config->super.super.fence_mode;
     self->super.progress                 = uct_rc_verbs_iface_progress;
     self->super.super.config.sl          = uct_ib_iface_config_select_sl(ib_config);
-    self->super.super.config.reverse_sl = uct_ib_iface_config_select_reverse_sl(
-            ib_config);
+    uct_ib_iface_set_reverse_sl(&self->super.super, ib_config);
 
     if ((config->super.super.fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         (config->super.super.fence_mode == UCT_RC_FENCE_MODE_AUTO)) {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -998,10 +998,6 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
     if (status != UCS_OK) {
         return status;
     }
-    self->super.super.config.reverse_sl =
-            (config->super.super.reverse_sl == UCS_ULUNITS_AUTO) ?
-                    self->super.super.config.sl :
-                    config->super.super.reverse_sl;
 
     self->super.tx.available     = self->tx.wq.bb_max;
     self->super.config.tx_qp_len = self->tx.wq.bb_max;

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -758,8 +758,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
                               worker, params, config, &init_attr);
 
     self->super.super.config.sl = uct_ib_iface_config_select_sl(&config->super);
-    self->super.super.config.reverse_sl = uct_ib_iface_config_select_reverse_sl(
-            &config->super);
+    uct_ib_iface_set_reverse_sl(&self->super.super, &config->super);
 
     memset(&self->tx.wr_inl, 0, sizeof(self->tx.wr_inl));
     self->tx.wr_inl.opcode            = IBV_WR_SEND;


### PR DESCRIPTION
## What
Fixing code duplication when setting reverse_sl in different ib transports.

## Why ?
PR https://github.com/openucx/ucx/pull/9489 was already merged
