### PR TITLE
UCS/RCACHE: Synchronize events

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1435,6 +1435,7 @@ ucp_mem_rcache_create(ucp_context_h context, const char *name,
                       ucs_rcache_t **rcache_p, ucs_rcache_params_t *rcache_params)
 {
     rcache_params->region_struct_size = ucp_memh_size(context);
+    rcache_params->flags             |= UCS_RCACHE_FLAG_SYNC_EVENTS;
     rcache_params->ucm_events         = UCM_EVENT_VM_UNMAPPED |
                                         UCM_EVENT_MEM_TYPE_FREE;
     rcache_params->context            = context;
@@ -1716,13 +1717,12 @@ ucp_memh_import(ucp_context_h context, const void *export_mkey_buffer,
                  * exists in the RCACHE of imported regions, it means that
                  * an exported memory handle has already been destroyed for a
                  * given address, but an imported memory handle hasn't been
-                 * retrieved from the RCACHE yet. So, it should have reference
-                 * counter == 1, since ucp_mem_unmap() should be invoked for
-                 * unused imported memory handles and then - for corresponding
-                 * exported ones */
-                ucs_assertv(rregion->refcount == 1, "%u", rregion->refcount);
+                 * removed from the RCACHE yet. So, it had refcount == 1 and
+                 * now it should be 2. */
+                ucs_assertv(rregion->refcount == 2, "%u", rregion->refcount);
                 ucs_rcache_region_invalidate(rcache, rregion,
                                              ucs_empty_function, NULL);
+                ucs_rcache_region_put_unsafe(rcache, rregion);
             }
         }
 

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -646,7 +646,8 @@ static void ucs_rcache_unmapped_callback(ucm_event_type_t event_type,
      * This way we avoid queuing endless events on the invalidation queue when
      * no rcache operations are performed to clean it.
      */
-    if (!pthread_rwlock_trywrlock(&rcache->pgt_lock)) {
+    if (!(rcache->params.flags & UCS_RCACHE_FLAG_SYNC_EVENTS) &&
+        !pthread_rwlock_trywrlock(&rcache->pgt_lock)) {
         /* coverity[double_lock] */
         ucs_rcache_invalidate_range(rcache, start, end,
                                     UCS_RCACHE_REGION_PUT_FLAG_ADD_TO_GC);

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -60,6 +60,7 @@ enum {
 enum {
     UCS_RCACHE_FLAG_NO_PFN_CHECK  = UCS_BIT(0), /**< PFN check not supported for this rcache */
     UCS_RCACHE_FLAG_PURGE_ON_FORK = UCS_BIT(1), /**< purge rcache on fork */
+    UCS_RCACHE_FLAG_SYNC_EVENTS   = UCS_BIT(2), /**< Synchronize memory events handling */
 };
 
 /*

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -628,17 +628,16 @@ uint16_t get_port() {
     return port;
 }
 
-void *mmap_fixed_address(size_t length) {
-    void *ptr = mmap(NULL, length, PROT_READ | PROT_WRITE,
-                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (ptr == MAP_FAILED) {
-        return nullptr;
+mmap_fixed_address::mmap_fixed_address(size_t length) : m_length(length) {
+    m_ptr = mmap(NULL, m_length, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (m_ptr == MAP_FAILED) {
+        UCS_TEST_ABORT("mmap failed to allocate memory region");
     }
+}
 
-    munmap(ptr, length);
-
-    /* coverity[use_after_free] */
-    return ptr;
+mmap_fixed_address::~mmap_fixed_address() {
+    munmap(m_ptr, m_length);
 }
 
 std::string compact_string(const std::string &str, size_t length)

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -347,7 +347,15 @@ uint16_t get_port();
 /**
  * Address to use for mmap(FIXED)
  */
-void *mmap_fixed_address(size_t length);
+class mmap_fixed_address {
+public:
+    mmap_fixed_address(size_t length);
+    ~mmap_fixed_address();
+    void* operator*() const { return m_ptr; }
+private:
+    void *m_ptr;
+    size_t m_length;
+};
 
 
 /*

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -861,10 +861,7 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size = (i + 1) * ((i % 2) ? 1000 : 1);
-        void *ptr   = ucs::mmap_fixed_address(size);
-        if (ptr == nullptr) {
-            UCS_TEST_ABORT("mmap failed to allocate memory region");
-        }
+        ucs::mmap_fixed_address ptr(size);
 
         ucp_mem_h memh;
         ucp_mem_map_params_t params;
@@ -872,13 +869,13 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
         params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                             UCP_MEM_MAP_PARAM_FIELD_LENGTH |
                             UCP_MEM_MAP_PARAM_FIELD_FLAGS;
-        params.address    = ptr;
+        params.address    = *ptr;
         params.length     = size;
         params.flags      = UCP_MEM_MAP_FIXED | UCP_MEM_MAP_ALLOCATE;
 
         status = ucp_mem_map(sender().ucph(), &params, &memh);
         ASSERT_UCS_OK(status);
-        EXPECT_EQ(ucp_memh_address(memh), ptr);
+        EXPECT_EQ(ucp_memh_address(memh), *ptr);
         EXPECT_GE(ucp_memh_length(memh), size);
 
         is_dummy = (size == 0);

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -154,10 +154,7 @@ UCS_TEST_P(test_mem, md_fixed) {
     uct_alloc_method_t       meth;
     size_t                   length      = 1;
     size_t                   n_success;
-    void*                    p_addr      = ucs::mmap_fixed_address(page_size * 2 * n_tryes);
-    if (p_addr == nullptr) {
-        UCS_TEST_ABORT("mmap failed to allocate memory region");
-    }
+    ucs::mmap_fixed_address  p_addr(page_size * 2 * n_tryes);
 
     uct_allocated_memory_t  uct_mem;
     ucs_status_t            status;
@@ -189,7 +186,7 @@ UCS_TEST_P(test_mem, md_fixed) {
 
         if ((md_attr.cap.flags & UCT_MD_FLAG_ALLOC) &&
             (md_attr.cap.flags & UCT_MD_FLAG_FIXED)) {
-            void* curr_addr = p_addr;
+            void* curr_addr = *p_addr;
             n_success       = 0;
 
             for (j = 0; j < n_tryes; ++j) {
@@ -230,10 +227,8 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     uct_alloc_method_t      meth;
     size_t                  length      = 1;
     size_t                  n_success;
-    void*                   p_addr      = ucs::mmap_fixed_address(page_size * 2 * (n_tryes + 1));
-    if (p_addr == nullptr) {
-        UCS_TEST_ABORT("mmap failed to allocate memory region");
-    }
+    ucs::mmap_fixed_address p_addr(page_size * 2 * (n_tryes + 1));
+    void*                   curr_addr;
 
     uct_allocated_memory_t  uct_mem;
     ucs_status_t            status;
@@ -248,20 +243,21 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     params.mem_type        = UCS_MEMORY_TYPE_HOST;
 
     n_success = 0;
+    curr_addr = *p_addr;
 
     for (i = 0; i < n_tryes; ++i) {
         meth                   = (i % 2) ? UCT_ALLOC_METHOD_MMAP : UCT_ALLOC_METHOD_HUGE;
-        params.address         = p_addr;
+        params.address         = curr_addr;
 
         status = uct_mem_alloc(length, &meth, 1, &params, &uct_mem);
         if (status == UCS_OK) {
             ++n_success;
             EXPECT_EQ(meth, uct_mem.method);
-            EXPECT_EQ(p_addr, uct_mem.address);
+            EXPECT_EQ(curr_addr, uct_mem.address);
             EXPECT_GE(uct_mem.length, (size_t)1);
             /* touch the page */
             memset(uct_mem.address, 'c', uct_mem.length);
-            EXPECT_EQ(*(char*)p_addr, 'c');
+            EXPECT_EQ(*(char*)curr_addr, 'c');
             status = uct_mem_free(&uct_mem);
             if (status != UCS_OK) {
                 UCS_TEST_ABORT("uct_mem_free failed to release memory region");
@@ -269,7 +265,7 @@ UCS_TEST_P(test_mem, mmap_fixed) {
         } else {
             EXPECT_EQ(status, UCS_ERR_NO_MEMORY);
         }
-        p_addr = (char*)p_addr + (2 * page_size);
+        curr_addr = (char*)curr_addr + (2 * page_size);
     }
 }
 


### PR DESCRIPTION
## Why ?
The UCP rcache currently depends on UCP synchronization, making the pgt_lock unreliable for memory event handling.

## How ?
Always queue event's inv_q to handle it by upcoming region creation process.
