### PR TITLE
BUILD/CONFIG: Introduce Address Sanitizer flag option

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -411,6 +411,31 @@ ADD_COMPILER_FLAG_IF_SUPPORTED([-funwind-tables],
                                [AS_MESSAGE([compiling without unwind tables])])
 
 
+#
+# ASAN support
+#
+AC_ARG_ENABLE([asan],
+        AS_HELP_STRING([--enable-asan], [Enable address sanitized check]),
+        [],
+        [enable_asan=no])
+
+AS_IF([test "x$enable_asan" = xyes],
+      [ADD_COMPILER_FLAG_IF_SUPPORTED([-fsanitize=address -fno-omit-frame-pointer],
+                                     [-fsanitize=address -fno-omit-frame-pointer],
+                                     [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                                     [AS_MESSAGE([compiling with sanitizer])
+                                      BASE_CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer $BASE_CXXFLAGS"
+                                      LDFLAGS="-fsanitize=address -fno-omit-frame-pointer $LDFLAGS"],
+                                     [AC_MSG_ERROR([ASAN check is requested but not supported. Check libasan package existance])])
+
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],
+                                     [[void *p = malloc(7); return 0;]])],
+                                     [AC_MSG_ERROR([ASAN cannot detect simple memory leak, consider installing newer compiler version])],
+                                     [AS_MESSAGE([sanitizer runtime leak detection check passed])]
+                    )],
+      [])
+
+
 AS_IF([test "x$enable_gcov" = xyes],
       [ADD_COMPILER_FLAGS_IF_SUPPORTED([[-ftest-coverage],
                                         [-fprofile-arcs]],


### PR DESCRIPTION
## What
Introduces `--enable-asan` option which checks the Address Sanitizer availability and passes corresponding flags during compilation and linkage.

## Why
Address Sanitizer is significantly faster then Valgrind and can detect more types of memory errors. For details go to the link: https://github.com/google/sanitizers/wiki/AddressSanitizerComparisonOfMemoryTools

Testing with GCC-7.2.0 on RHEL 7.6 detected false-positive buffer underflow errors during `ucs_container_of` call.
Testing with GCC-11 on Ubuntu-22.04 detected the following issues:
- https://github.com/openucx/ucx/pull/9518
- https://github.com/openucx/ucx/pull/9527
- https://github.com/openucx/ucx/pull/9534

So it is important to test with fresh OS/compiler. 

## TODO:

- [ ] Define `ASAN_OPTIONS=protect_shadow_gap=0` if cuda support enabled. See details here: https://github.com/google/sanitizers/issues/629
- [ ] libcuda causes false positive leaks, consider creation `lsan.supp` (with one string: `leak:libcuda`) and passing `LSAN_OPTIONS=suppressions=<path_to_lsan.supp>` if cuda is enabled.
- [ ] If cuda leaks are suppressed for ASAN, CUDA can be tested through [compute sanitizer](https://developer.nvidia.com/blog/debugging-cuda-more-efficiently-with-nvidia-compute-sanitizer/).
- [ ] UCM is disabled if ASAN is enabled, and therefore rcache is disabled too. Can UCM or rcache be used with ASAN?