### PR TITLE
UCP/AM: Allow AM handlers registration in any order

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -199,8 +199,12 @@ static ucs_status_t ucp_worker_set_am_handler_common(ucp_worker_h worker,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    ucs_array_resize(&worker->am.cbs, id + 1, empty_am_handler,
-                     return UCS_ERR_NO_MEMORY);
+    /* User handlers may be registered in any order, we need to resize the
+     * lookup array only when new ID is equal or above the current length */
+    if (id >= ucs_array_length(&worker->am.cbs)) {
+        ucs_array_resize(&worker->am.cbs, id + 1, empty_am_handler,
+                         return UCS_ERR_NO_MEMORY);
+    }
     return UCS_OK;
 }
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -324,6 +324,17 @@ UCS_TEST_P(test_ucp_am, set_am_handler_realloc)
     do_set_am_handler_realloc_test();
 }
 
+UCS_TEST_P(test_ucp_am, set_am_handler_out_of_order)
+{
+    set_handlers(UCP_SEND_ID + 20);
+    set_handlers(UCP_SEND_ID);
+    set_handlers(UCP_SEND_ID + 10);
+
+    do_send_process_data_test(0, UCP_SEND_ID, 0);
+    do_send_process_data_test(0, UCP_SEND_ID + 10, 0);
+    do_send_process_data_test(0, UCP_SEND_ID + 20, 0);
+}
+
 UCP_INSTANTIATE_TEST_CASE(test_ucp_am)
 
 


### PR DESCRIPTION
## What
Fix the issue introduced recently in https://github.com/openucx/ucx/pull/9415 
The issue happens when registering AM handlers out of message ID order. For example, when client registers AM handlers in the order IDs [3, 4, 1], then only the last ID remains in the AM handlers array. Handlers [3, 4] are sliced away, which is manifested as
```
ucp_am.c:234  UCX  WARN  UCP Active Message was received with id : 3, but there is no registered callback for that id
ucp_am.c:234  UCX  WARN  UCP Active Message was received with id : 4, but there is no registered callback for that id
```

## Why ?
This happens because in current logic we unconditionally resize an array of AM handlers when adding new element to it. This works in most of the cases, when we register handlers ordered by message ID. However, if we register messages out of order, then the handlers array is truncated to the last registered ID.

Issue exists only in master, not exposed to v1.16 or below
