### PR TITLE
UCP/WIREUP: Define UCT_MD_FLAG_INVALIDATE_RMA description

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -108,6 +108,7 @@ static const char *ucp_wireup_md_flags[] = {
     [ucs_ilog2(UCT_MD_FLAG_ALLOC)]               = "memory allocation",
     [ucs_ilog2(UCT_MD_FLAG_REG)]                 = "memory registration",
     [ucs_ilog2(UCT_MD_FLAG_INVALIDATE)]          = "memory invalidation",
+    [ucs_ilog2(UCT_MD_FLAG_INVALIDATE_RMA)]      = "RMA memory invalidation"
 };
 
 static const char *ucp_wireup_iface_flags[] = {


### PR DESCRIPTION
## What
Add `ucp_wireup_md_flags` entry for `UCT_MD_FLAG_INVALIDATE_RMA`

## Why
`ucp_wireup_add_rma_bw_lanes` can set `UCT_MD_FLAG_INVALIDATE_RMA` in `criteria.local_md_flags` and if there is no such flag for some MD, the `ucp_wireup_get_missing_flag_desc` would try to access it's definition through index in `ucp_wireup_md_flags`.

Found by ASAN.
