### PR TITLE
UCT/CUDA/BASE: Do not use cuda device 0 if no context is active

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -36,23 +36,21 @@ uct_cuda_base_query_devices_common(
         uct_md_h md, uct_device_type_t dev_type,
         uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p)
 {
-    ucs_sys_device_t sys_device;
+    ucs_sys_device_t sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
     CUdevice cuda_device;
     ucs_status_t status;
 
     if (uct_cuda_base_is_context_active()) {
         status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&cuda_device));
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        uct_cuda_base_get_sys_dev(cuda_device, &sys_device);
     } else {
-        ucs_debug("using locality information of cuda device 0 as no context is"
+        ucs_debug("set cuda sys_device to `unknown` as no context is"
                   " currently active");
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_device, 0));
     }
-
-    if (status != UCS_OK) {
-        return UCS_ERR_NO_DEVICE;
-    }
-
-    uct_cuda_base_get_sys_dev(cuda_device, &sys_device);
 
     return uct_single_device_resource(md, UCT_CUDA_DEV_NAME, dev_type,
                                       sys_device, tl_devices_p,


### PR DESCRIPTION
## What
Avoid using locality information of cuda device 0 if no active context detected.

## Why ?
Usage of 0 device breaks the wire compatibility because master now detect the distance to the CUDA device even if there is no active context. But older version cannot detect such distance and set it to default now which causes incompatibility.

Fixes the following issue (reproduces only on swx-rdmz-ucx-gpu-01): https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=72705&view=logs&j=fd287c5c-dcf2-52b8-cd0f-25b007d2717e&t=64aaf147-dfa5-5aa9-0220-0479128fc8a3