### PR TITLE
UCP: Report invalidation error if no rcache

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2503,14 +2503,6 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     if (status != UCS_OK) {
         goto err;
     }
-
-    if ((key->err_mode == UCP_ERR_HANDLING_MODE_PEER) &&
-        (context->rcache == NULL)) {
-        ucs_warn("worker %p: memory invalidation is requested but not supported"
-                 " since rcache isn't initialized. Invalidation case will cause"
-                 " runtime failure.", worker);
-    }
-
     if (config->key.flags & UCP_EP_CONFIG_KEY_FLAG_INTERMEDIATE) {
         short_am_cap_flag  = 0;
         short_tag_cap_flag = 0;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2503,6 +2503,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     if (status != UCS_OK) {
         goto err;
     }
+
     if (config->key.flags & UCP_EP_CONFIG_KEY_FLAG_INTERMEDIATE) {
         short_am_cap_flag  = 0;
         short_tag_cap_flag = 0;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2504,6 +2504,13 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         goto err;
     }
 
+    if ((key->err_mode == UCP_ERR_HANDLING_MODE_PEER) &&
+        (context->rcache == NULL)) {
+        ucs_warn("worker %p: memory invalidation is requested but not supported"
+                 " since rcache isn't initialized. Invalidation case will cause"
+                 " runtime failure.", worker);
+    }
+
     if (config->key.flags & UCP_EP_CONFIG_KEY_FLAG_INTERMEDIATE) {
         short_am_cap_flag  = 0;
         short_tag_cap_flag = 0;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -370,6 +370,8 @@ void ucp_memh_invalidate(ucp_context_h context, ucp_mem_h memh,
 
     ucs_assert(memh->parent == NULL);
     ucs_assert(!(memh->flags & UCP_MEMH_FLAG_IMPORTED));
+    ucs_assertv_always(context->rcache != NULL,
+                       "rcache is required for memory invalidation");
 
     UCP_THREAD_CS_ENTER(&context->mt_lock);
     memh->inv_md_map |= inv_md_map;


### PR DESCRIPTION
## What
Add assert that tell user about memory invalidation unavailability if no rcache is presented.

## Why ?
If no rcache was initialized, memory invalidation is unsupported. Without this checks, `ucp_memh_invalidate` would fail with segfault in this case.