### PR TITLE
TEST/UCP: Meet aligned_alloc requirements for requested size

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -246,9 +246,9 @@ void test_ucp_tag_xfer::test_xfer_prepare_bufs(uint8_t *sendbuf, uint8_t *recvbu
 
 size_t test_ucp_tag_xfer::get_msg_size()
 {
-    size_t raw_size   = 1148544 / ucs::test_time_multiplier();
-    size_t chunk_size = num_lanes() * UCS_SYS_PCI_MAX_PAYLOAD;
-    return ucs_div_round_up(raw_size, chunk_size) * chunk_size;
+    size_t raw_size = 1148544 / ucs::test_time_multiplier();
+
+    return ucs_align_up(raw_size, ucs_get_page_size()) * num_lanes();
 }
 
 void test_ucp_tag_xfer::test_run_xfer(bool send_contig, bool recv_contig,

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -247,8 +247,7 @@ void test_ucp_tag_xfer::test_xfer_prepare_bufs(uint8_t *sendbuf, uint8_t *recvbu
 size_t test_ucp_tag_xfer::get_msg_size()
 {
     size_t raw_size = 1148544 / ucs::test_time_multiplier();
-
-    return ucs_align_up(raw_size, ucs_get_page_size()) * num_lanes();
+    return ucs_align_up(raw_size, ucs_get_page_size() * num_lanes());
 }
 
 void test_ucp_tag_xfer::test_run_xfer(bool send_contig, bool recv_contig,


### PR DESCRIPTION
## What
Make message size divisible to page size.

## Why ?
`aligned_alloc` requires that allocated size should be divisible to alignment

[cppreference](https://en.cppreference.com/w/c/memory/aligned_alloc):

> Allocate size bytes of uninitialized storage whose alignment is specified by alignment. The size parameter must be an integral multiple of alignment.

Found by ASAN.
