### PR TITLE
GO/TESTS: Removed goroutine from UCP EP AM test.

### DIFF
--- a/bindings/go/tests/utils.go
+++ b/bindings/go/tests/utils.go
@@ -6,7 +6,6 @@ package goucxtests
 
 import (
 	. "ucx"
-	. "cuda"
 	"unsafe"
 )
 
@@ -15,12 +14,6 @@ const selfEpTag uint64 = ^uint64(0)
 func memoryAllocate(entity *TestEntity, size uint64, memoryType UcsMemoryType) unsafe.Pointer {
 	mmapParams := &UcpMmapParams{}
 	mmapParams.Allocate().SetLength(size).SetMemoryType(memoryType)
-
-	if memoryType == UCS_MEMORY_TYPE_CUDA {
-		if err := CudaSetDevice(); err != nil {
-			entity.t.Fatalf("%v", err)
-		}
-	}
 
 	result, err := entity.context.MemMap(mmapParams)
 	if err != nil {
@@ -80,18 +73,5 @@ func memoryGet(entity *TestEntity) []byte {
 		recvMem := AllocateNativeMemory(memAttr.Length)
 		sendRecv(entity, memAttr.Address, memAttr.Length, memAttr.MemType, recvMem, memAttr.Length, UCS_MEMORY_TYPE_HOST)
 		return GoBytes(recvMem, memAttr.Length)
-	}
-}
-
-// Progress thread that progress a worker until it receives quit signal from channel.
-func progressThread(quit chan bool, worker *UcpWorker) {
-	for {
-		select {
-		case <-quit:
-			close(quit)
-			return
-		default:
-			worker.Progress()
-		}
 	}
 }


### PR DESCRIPTION
## What
Removed starting of goroutine from TestUcpEpAm.

## Why ?
This is an attempt to fix the following failure:
```
=== RUN   TestUcpEpAm
    endpoint_test.go:177: Testing AM host -> host
    endpoint_test.go:177: Testing AM host -> cuda
[1701710374.879682] [swx-rdmz-ucx-gpu-01:620  :0]    cuda_copy_ep.c:122  UCX  ERROR attempt to perform cuda memcpy without active context
[swx-rdmz-ucx-gpu-01:620  :0:1590]    rndv_put.c:491  Assertion `req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED' failed
```

Goroutine is an abstraction which allows to develop multi-threaded applications. There is no guarantee that goroutine will be executed on the same CPU thread for the entire time. What can result an issue, because CUDA device (aka cuContext) can be bound to the calling CPU thread.
