### PR TITLE
TOOLS/PERF: Skeleton for DPU daemon

### DIFF
--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -17,7 +17,7 @@ noinst_HEADERS = \
 	perftest_mad.h \
 	api/libperf.h
 
-bin_PROGRAMS = ucx_perftest
+bin_PROGRAMS = ucx_perftest ucx_perftest_daemon
 
 ucx_perftest_SOURCES = \
 	perftest.c \
@@ -51,6 +51,19 @@ dist_perftest_DATA = \
 	$(top_srcdir)/contrib/ucx_perftest_config/test_types_ucp \
 	$(top_srcdir)/contrib/ucx_perftest_config/transports
 
+
+ucx_perftest_daemon_SOURCES = \
+	perftest_daemon.c
+
+ucx_perftest_daemon_CXXFLAGS = $(BASE_CXXFLAGS)
+ucx_perftest_daemon_CPPFLAGS = $(BASE_CPPFLAGS)
+ucx_perftest_daemon_CFLAGS   = $(BASE_CFLAGS)
+ucx_perftest_daemon_LDADD    = \
+	$(abs_top_builddir)/src/ucp/libucp.la \
+	$(abs_top_builddir)/src/ucs/libucs.la \
+	lib/libucxperf.la
+
+
 if HAVE_MPIRUN
 .PHONY: ucx test help
 
@@ -60,7 +73,7 @@ MPI_ARGS  = -n 2 -map-by node -mca pml ob1 -mca btl self,tcp,sm $(MPI_EXTRA)
 ucx:
 	$(MAKE) -C $(top_builddir)
 
-test: ucx ucx_perftest
+test: ucx ucx_perftest ucx_perftest_daemon
 	$(MPIRUN) $(MPI_ARGS) $(abs_builddir)/ucx_perftest$(EXEEXT) $(TEST_ARGS)
 
 help:

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -217,11 +217,14 @@ typedef struct ucx_perf_params {
     } uct;
 
     struct {
-        unsigned               nonblocking_mode; /* TBD */
-        ucp_perf_datatype_t    send_datatype;
-        ucp_perf_datatype_t    recv_datatype;
-        size_t                 am_hdr_size; /* UCP Active Message header size
-                                               (not included in message size) */
+        ucp_perf_datatype_t     send_datatype;
+        ucp_perf_datatype_t     recv_datatype;
+        size_t                  am_hdr_size; /* UCP Active Message header size
+                                                (not included in message size) */
+        struct sockaddr_storage dmn_local_addr;  /* IP and port of local daemon,
+                                                    used to offload communication */
+        struct sockaddr_storage dmn_remote_addr; /* IP and port of remote daemon,
+                                                    used to offload communication */
     } ucp;
 
 } ucx_perf_params_t;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -167,6 +167,8 @@ static int safe_recv(int sock, void *data, size_t size,
 
 ucs_status_t init_test_params(perftest_params_t *params)
 {
+    static const struct sockaddr_storage empty_addr = {};
+
     memset(params, 0, sizeof(*params));
     params->super.api               = UCX_PERF_API_LAST;
     params->super.command           = UCX_PERF_CMD_LAST;
@@ -194,6 +196,8 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.ucp.send_datatype = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.recv_datatype = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.am_hdr_size   = 0;
+    params->super.ucp.dmn_local_addr  = empty_addr;
+    params->super.ucp.dmn_remote_addr = empty_addr;
     strcpy(params->super.uct.dev_name, TL_RESOURCE_NAME_NONE);
     strcpy(params->super.uct.tl_name,  TL_RESOURCE_NAME_NONE);
 

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -10,6 +10,8 @@
 #include "api/libperf.h"
 #include "lib/libperf_int.h"
 
+#include <getopt.h>
+
 #if defined (HAVE_MPI)
 #  include <mpi.h>
 #endif
@@ -18,8 +20,12 @@
 #define MAX_BATCH_FILES         32
 #define MAX_CPUS                1024
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lyz"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lyzg:G:"
 #define TEST_ID_UNDEFINED       -1
+
+#define DEFAULT_DAEMON_PORT     1338
+
+extern const struct option TEST_PARAMS_ARGS_LONG[];
 
 enum {
     TEST_FLAG_PRINT_RESULTS    = UCS_BIT(0),
@@ -57,7 +63,7 @@ typedef struct perftest_params {
 struct perftest_context {
     perftest_params_t            params;
     const char                   *server_addr;
-    int                          port;
+    uint16_t                     port;
     sa_family_t                  af;
     int                          mpi;
     unsigned                     num_cpus;

--- a/src/tools/perf/perftest_daemon.c
+++ b/src/tools/perf/perftest_daemon.c
@@ -1,0 +1,251 @@
+/**
+ * Copyright (C) NVIDIA 2024.  ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "perftest.h"
+
+#include <ucp/api/ucp.h>
+#include <ucs/debug/log.h>
+#include <ucs/sys/sock.h>
+#include <ucs/sys/string.h>
+#include <ucs/type/serialize.h>
+#include <tools/perf/api/libperf.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <signal.h>
+
+typedef struct ucp_perf_daemon_context_t {
+    ucp_context_h                      context;
+    ucp_worker_h                       worker;
+    ucp_listener_h                     listener;
+    uint16_t                           port;
+    ucp_ep_h                           host_ep;
+    ucp_ep_h                           peer_ep;
+    struct sockaddr_storage            peer_address;
+    ucp_mem_h                          send_memh;
+    ucp_mem_h                          recv_memh;
+    void                               *rx_address;
+} ucp_perf_daemon_context_t;
+
+static volatile int terminated = 0;
+
+static void
+ucp_perf_daemon_ep_close(ucp_perf_daemon_context_t *ctx, ucp_ep_h ep)
+{
+    ucp_request_param_t param;
+    ucs_status_ptr_t close_req;
+    ucs_status_t status;
+
+    if (NULL == ep) {
+        return;
+    }
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
+    close_req          = ucp_ep_close_nbx(ep, &param);
+
+    if (UCS_PTR_IS_PTR(close_req)) {
+        do {
+            ucp_worker_progress(ctx->worker);
+            status = ucp_request_check_status(close_req);
+        } while (status == UCS_INPROGRESS);
+        ucp_request_free(close_req);
+    } else {
+        status = UCS_PTR_STATUS(close_req);
+    }
+
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to close ep %p", ep);
+    }
+}
+
+static void ucp_perf_daemon_err_cb(void *arg, ucp_ep_h ep, ucs_status_t status)
+{
+    terminated = 1;
+}
+
+static void
+ucp_perf_daemon_server_conn_handle_cb(ucp_conn_request_h conn_request,
+                                      void *arg)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    ucp_ep_params_t ep_params;
+    ucs_status_t status;
+    ucp_ep_h ep;
+
+    ep_params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLER  |
+                                UCP_EP_PARAM_FIELD_CONN_REQUEST |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.conn_request    = conn_request;
+    ep_params.err_handler.cb  = ucp_perf_daemon_err_cb;
+    ep_params.err_handler.arg = ctx;
+
+    status = ucp_ep_create(ctx->worker, &ep_params, &ep);
+    if (status != UCS_OK) {
+        ucs_error("failed to create an endpoint on the daemon: %s",
+                  ucs_status_string(status));
+    }
+}
+
+static void ucp_perf_daemon_cleanup(ucp_perf_daemon_context_t *ctx)
+{
+    if (NULL != ctx->send_memh) {
+        /* coverity[check_return] */
+        ucp_mem_unmap(ctx->context, ctx->send_memh);
+    }
+
+    if (NULL != ctx->recv_memh) {
+        /* coverity[check_return] */
+        ucp_mem_unmap(ctx->context, ctx->recv_memh);
+    }
+
+    ucp_perf_daemon_ep_close(ctx, ctx->peer_ep);
+    ucp_perf_daemon_ep_close(ctx, ctx->host_ep);
+    ucp_listener_destroy(ctx->listener);
+    ucp_worker_destroy(ctx->worker);
+    ucp_cleanup(ctx->context);
+}
+
+static ucs_status_t ucp_perf_daemon_init(ucp_perf_daemon_context_t *ctx)
+{
+    ucp_listener_params_t listen_params = {};
+    ucp_worker_params_t worker_params   = {};
+    ucp_params_t ucp_params;
+    struct sockaddr_in listen_addr;
+    ucp_config_t *config;
+    ucs_status_t status;
+
+    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ucp_params.features   = UCP_FEATURE_AM | UCP_FEATURE_EXPORTED_MEMH;
+
+    status = ucp_config_read(NULL, NULL, &config);
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to read UCP context: %s",
+                  ucs_status_string(status));
+        goto err;
+    }
+
+    status = ucp_init(&ucp_params, config, &ctx->context);
+    ucp_config_release(config);
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to init UCP: %s", ucs_status_string(status));
+        goto err;
+    }
+
+    status = ucp_worker_create(ctx->context, &worker_params, &ctx->worker);
+    if (status != UCS_OK) {
+        ucs_error("failed to create worker: %s", ucs_status_string(status));
+        goto err_free_ctx;
+    }
+
+    listen_addr.sin_family      = AF_INET;
+    listen_addr.sin_addr.s_addr = INADDR_ANY;
+    listen_addr.sin_port        = htons(ctx->port);
+
+    listen_params.field_mask       = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
+                                     UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
+    listen_params.sockaddr.addr    = (const struct sockaddr*)&listen_addr;
+    listen_params.sockaddr.addrlen = sizeof(listen_addr);
+    listen_params.conn_handler.cb  = ucp_perf_daemon_server_conn_handle_cb;
+    listen_params.conn_handler.arg = ctx;
+
+    status = ucp_listener_create(ctx->worker, &listen_params, &ctx->listener);
+    if (status != UCS_OK) {
+        ucs_error("failed to listen: %s", ucs_status_string(status));
+        goto err_free_worker;
+    }
+
+    return UCS_OK;
+
+err_free_worker:
+    ucp_worker_destroy(ctx->worker);
+err_free_ctx:
+    ucp_cleanup(ctx->context);
+err:
+    return status;
+}
+
+static void ucp_perf_daemon_signal_terminate_handler(int signo)
+{
+    char msg[64];
+    ssize_t ret __attribute__((unused));
+
+    snprintf(msg, sizeof(msg), "Run-time signal handling: %d\n", signo);
+    ret = write(STDOUT_FILENO, msg, strlen(msg) + 1);
+
+    terminated = 1;
+}
+
+static ucs_status_t ucp_perf_daemon_parse_cmd(ucp_perf_daemon_context_t *ctx,
+                                              int argc, char *const argv[])
+{
+    int c = 0;
+
+    while ((c = getopt(argc, argv, "p:")) != -1) {
+        switch (c) {
+        case 'p':
+            if (UCS_OK != ucs_sock_port_from_string(optarg, &ctx->port)) {
+                return UCS_ERR_INVALID_PARAM;
+            }
+            break;
+        default:
+            return UCS_ERR_INVALID_PARAM;
+        }
+    }
+
+    return UCS_OK;
+}
+
+static void usage(const ucp_perf_daemon_context_t *ctx, const char *program)
+{
+    printf("  Usage: %s [ options ]\n", program);
+    printf("\n");
+    printf("  Common options:\n");
+    printf("\n");
+    printf("     -p <port>      TCP port to use for data exchange (%d)\n"
+           "                    default value: (%d)\n",
+           ctx->port, DEFAULT_DAEMON_PORT);
+    printf("\n");
+}
+
+int main(int argc, char *const argv[])
+{
+    ucp_perf_daemon_context_t ctx = {};
+    struct sigaction new_sigaction;
+
+    ctx.port = DEFAULT_DAEMON_PORT; /* default value */
+
+    if (ucp_perf_daemon_parse_cmd(&ctx, argc, argv) != UCS_OK) {
+        usage(&ctx, ucs_basename(argv[0]));
+        return EXIT_FAILURE;
+    }
+
+    new_sigaction.sa_handler = ucp_perf_daemon_signal_terminate_handler;
+    new_sigaction.sa_flags   = 0;
+    sigemptyset(&new_sigaction.sa_mask);
+
+    sigaction(SIGINT, &new_sigaction, NULL);
+    sigaction(SIGHUP, &new_sigaction, NULL);
+    sigaction(SIGTERM, &new_sigaction, NULL);
+
+    if (ucp_perf_daemon_init(&ctx) != UCS_OK) {
+        ucs_error("failed to initalize");
+        return EXIT_FAILURE;
+    }
+
+    while (!terminated) {
+        ucp_worker_progress(ctx.worker);
+    }
+
+    ucp_perf_daemon_cleanup(&ctx);
+    return EXIT_SUCCESS;
+}

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -15,6 +15,12 @@
 #include <ucs/sys/sock.h>
 #include <ucs/debug/log.h>
 
+const struct option TEST_PARAMS_ARGS_LONG[] =
+{
+    {"daemon-local",  required_argument, 0, 'g'},
+    {"daemon-remote", required_argument, 0, 'G'},
+    {0, 0, 0, 0}
+};
 
 static void print_memory_type_usage(void)
 {
@@ -142,6 +148,14 @@ static void usage(const struct perftest_context *ctx, const char *program)
                                 ctx->params.super.ucp.am_hdr_size);
     printf("     -y             do additional memcopy to the user memory in active message receive handler\n");
     printf("     -z             pass pre-registered memory handle\n");
+    printf("     -g <IP>[:<port>], --daemon-local <IP>[:<port>]\n");
+    printf("                    IP address and port of the local daemon to offload UCP operations to\n");
+    printf("                    Port is optional, by default daemon port is (%d)\n",
+                                DEFAULT_DAEMON_PORT);
+    printf("     -G <IP>[:<port>], --daemon-remote <IP>[:<port>]\n");
+    printf("                    IP address and port of the remote daemon to offload UCP operations to\n");
+    printf("                    Port is optional, by default daemon port is (%d)\n",
+                                DEFAULT_DAEMON_PORT);
     printf("\n");
     printf("   NOTE: When running UCP tests, transport and device should be specified by\n");
     printf("         environment variables: UCX_TLS and UCX_[SELF|SHM|NET]_DEVICES.\n");
@@ -248,6 +262,54 @@ static ucs_status_t parse_ucp_datatype_params(const char *opt_arg,
         *datatype = UCP_PERF_DATATYPE_CONTIG;
     } else {
         return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t verify_daemon_params(ucx_perf_params_t *params)
+{
+    struct sockaddr_storage *local_addr  = &params->ucp.dmn_local_addr;
+    struct sockaddr_storage *remote_addr = &params->ucp.dmn_remote_addr;
+
+    /* Return if both daemon addresses are not configured */
+    if ((0 == local_addr->ss_family) && (0 == remote_addr->ss_family)) {
+        return UCS_OK;
+    }
+
+    /* If only one address is specified, use it in both cases */
+    if (0 == local_addr->ss_family) {
+        memcpy(local_addr, remote_addr, sizeof(*local_addr));
+    } else if (0 == remote_addr->ss_family) {
+        memcpy(remote_addr, local_addr, sizeof(*remote_addr));
+    }
+
+    if ((params->ucp.send_datatype != UCP_PERF_DATATYPE_CONTIG) ||
+        (params->ucp.recv_datatype != UCP_PERF_DATATYPE_CONTIG)) {
+        ucs_error("only contiguous datatype is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if ((params->send_mem_type != UCS_MEMORY_TYPE_HOST) ||
+        (params->recv_mem_type != UCS_MEMORY_TYPE_HOST)) {
+        ucs_error("only HOST memory type is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (params->command != UCX_PERF_CMD_AM) {
+        ucs_error("only UCP AM API is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (params->ucp.am_hdr_size != 0) {
+        ucs_error("sending UCP AM with non-zero header size is not supported"
+                  " in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (params->thread_count > 1) {
+        ucs_error("only 1 thread is supported in offloaded mode");
+        return UCS_ERR_UNSUPPORTED;
     }
 
     return UCS_OK;
@@ -426,6 +488,12 @@ ucs_status_t parse_test_params(perftest_params_t *params, char opt,
     case 'z':
         params->super.flags |= UCX_PERF_TEST_FLAG_PREREG;
         return UCS_OK;
+    case 'g': /* handles daemon-local long option as well */
+        return ucs_sock_ipportstr_to_sockaddr(opt_arg, DEFAULT_DAEMON_PORT,
+                                              &params->super.ucp.dmn_local_addr);
+    case 'G': /* handles daemon-remote long option as well */
+        return ucs_sock_ipportstr_to_sockaddr(opt_arg, DEFAULT_DAEMON_PORT,
+                                              &params->super.ucp.dmn_remote_addr);
     default:
        return UCS_ERR_INVALID_PARAM;
     }
@@ -557,11 +625,14 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
     ctx->mad_port        = NULL;
 
     optind = 1;
-    while ((c = getopt(argc, argv, "p:b:6NfvIc:P:hK:" TEST_PARAMS_ARGS)) !=
-           -1) {
+    while ((c = getopt_long(argc, argv, "p:b:6NfvIc:P:hK:" TEST_PARAMS_ARGS,
+                            TEST_PARAMS_ARGS_LONG, NULL)) != -1) {
         switch (c) {
         case 'p':
-            ctx->port = atoi(optarg);
+            status = ucs_sock_port_from_string(optarg, &ctx->port);
+            if (status != UCS_OK) {
+                goto err;
+            }
             break;
         case '6':
             ctx->af = AF_INET6;
@@ -630,7 +701,7 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
         }
     }
 
-    return UCS_OK;
+    return verify_daemon_params(&ctx->params.super);
 
 err:
     release_msg_size_list(&ctx->params);

--- a/src/tools/perf/perftest_run.c
+++ b/src/tools/perf/perftest_run.c
@@ -241,7 +241,8 @@ static ucs_status_t read_batch_file(FILE *batch_file, const char *file_name,
                       "in batch file '%s' line %d: ", file_name, *line_num);
 
     optind = 1;
-    while ((c = getopt (argc, argv, TEST_PARAMS_ARGS)) != -1) {
+    while ((c = getopt_long(argc, argv, TEST_PARAMS_ARGS,
+                            TEST_PARAMS_ARGS_LONG, NULL)) != -1) {
         status = parse_test_params(params, c, optarg);
         if (status != UCS_OK) {
             ucs_error("%s-%c %s: %s", error_prefix, c, optarg,

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -436,6 +436,39 @@ ucs_status_t ucs_sock_ipstr_to_sockaddr(const char *ip_str,
 
 
 /**
+ * Extract the IP address and port from a given string and return it as a
+ * sockaddr storage. The supported formats are (as per RFCs 3986, 5952):
+ * IPv4:port,   e.g. 127.0.0.1:1338
+ * [IPv6]:port  e.g. [::1]:1339
+ *
+ * Port is optional parameter in string, if not set, default_port is used
+ *
+ * @param [in]  ip_port_str  A string to take IP address and port from.
+ * @param [in]  default_port Default port to use if string doesn't have it.
+ * @param [out] sa_storage   sockaddr storage filled with the IP address,
+ *                           address family and port.
+ *
+ * @return UCS_OK if @a ip_port_str has a valid IP address,
+ *         UCS_ERR_INVALID_ADDR otherwise.
+ */
+ucs_status_t ucs_sock_ipportstr_to_sockaddr(const char *ip_port_str,
+                                            uint16_t default_port,
+                                            struct sockaddr_storage *sa_storage);
+
+
+/**
+ * Extract port from a given string and validate it.
+ *
+ * @param [in]  port_str A string to take port from.
+ * @param [out] port     Variable to store parsed port.
+ *
+ * @return UCS_OK if @a port_str has a valid port,
+ *         UCS_ERR_INVALID_ADDR otherwise.
+ */
+ucs_status_t ucs_sock_port_from_string(const char *port_str, uint16_t *port);
+
+
+/**
  * Check if the address family of the given sockaddr is IPv4 or IPv6
  *
  * @param [in] sa       Pointer to sockaddr structure.

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -241,8 +241,9 @@ void test_perf::test_params_init(const test_spec &test,
     params.iov_stride           = test.msg_stride;
     params.ucp.send_datatype    = (ucp_perf_datatype_t)test.data_layout;
     params.ucp.recv_datatype    = (ucp_perf_datatype_t)test.data_layout;
-    params.ucp.nonblocking_mode = 0;
     params.ucp.am_hdr_size      = 0;
+    params.ucp.dmn_local_addr   = {};
+    params.ucp.dmn_remote_addr  = {};
 }
 
 test_perf::test_result test_perf::run_multi_threaded(const test_spec &test, unsigned flags,

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -126,6 +126,7 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.so
 %{_libdir}/lib*.so.*
 %{_bindir}/ucx_info
 %{_bindir}/ucx_perftest
+%{_bindir}/ucx_perftest_daemon
 %{_bindir}/ucx_read_profile
 %if "%{debug}" == "1"
 %{_bindir}/ucs_stats_parser


### PR DESCRIPTION
## What
This is the first part of the "Support XGVMI in ucx perftest" story (original PR: https://github.com/openucx/ucx/pull/8767). 
The scope of this change-set is:
 - daemon skeleton implementation
 - appropriate config options for perftest
 - address existing comments from the original PR

## Why ?
The overall goal is to provide initial support for offloading communication to DPU using exported memh feature. We split the original change-set into several parts not exceeding 500 LOC limit, so that it's easier to review.