### PR TITLE
AZP/RELEASE: Fix JUCX with ARM build

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -103,6 +103,7 @@ set-version:
 repack-jar: $(jarfile)
 	$(RM) -r $(java_build_dir)/repack_dir
 	unzip -o $(jarfile) -d $(java_build_dir)/repack_dir
+	\cp -v $(topdir)/libjucx_*.so/libjucx_*.so $(topdir)/bindings/java/resources
 	\cp -v $(topdir)/libjucx_*.so/libjucx_*.so $(java_build_dir)/repack_dir
 	jar -cf $(jarfile) -C $(java_build_dir)/repack_dir .
 	jar tf $(jarfile)
@@ -111,14 +112,21 @@ multi-arch:
 	@make set-version JUCX_VERSION=${JUCX_VERSION}
 	@make repack-jar
 
+check-jar:
+	@test $(shell jar tf $(jarfile) | grep -q libjucx_amd64.so)
+	@test $(shell jar tf $(jarfile) | grep -q libjucx_aarch64.so)
+
 # Publish JUCX jar to maven central
 publish-snapshot:
 	@make set-version JUCX_VERSION=@VERSION@-SNAPSHOT
+	@make repack-jar
+	@make check-jar
 	@make publish
 
 publish-release:
 	@make set-version JUCX_VERSION=${JUCX_VERSION}
 	@make repack-jar
+	@make check-jar
 	@make publish
 
 publish:

--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -41,6 +41,7 @@ jobs:
         displayName: Build ucx
 
       - bash: |
+          set -exE
           source buildlib/az-helpers.sh
           az_init_modules
           az_module_load dev/mvn
@@ -77,6 +78,7 @@ jobs:
         name: publicKey
 
       - bash: |
+          set -exE
           source buildlib/az-helpers.sh
           az_init_modules
           az_module_load dev/mvn


### PR DESCRIPTION
## What
Fix JUCX package publishing, so it will include support for ARM.

## How ?
1. Copy both libraries into the resources folder to match the resources section in pom.xml.
2. Copy specific files, not a wildcard, so `make `will fail if one of them is missing.
3. Added a validation target to check the final Jar before publishing.