### PR TITLE
GTEST/UCT: Do not query BAR1 memory using NVML under valgrind.

### DIFF
--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -183,8 +183,8 @@ void uct_p2p_test::test_xfer_multi_mem_type(send_func_t send, size_t min_length,
     max_length = ucs_min(max_length, (size_t)(4.1 * (double)UCS_GBYTE));
 
     /* Trim by BAR1 size if relevant */
-    if ((mem_type == UCS_MEMORY_TYPE_CUDA) ||
-        (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED)) {
+    if (!RUNNING_ON_VALGRIND && ((mem_type == UCS_MEMORY_TYPE_CUDA) ||
+        (mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED))) {
         /* Allocate 40% x 2 (RX/TX) to accommodate send/receive buffers allocation */
         max_length = ucs_min(max_length,
                 (size_t)(0.4 * mem_buffer::get_bar1_free_size()));


### PR DESCRIPTION
## What
Removed querying BAR1 memory information using NVML API when running with valgrind.

## Why ?
Workaround for the https://github.com/openucx/ucx/issues/9531

It seems that we may hang in nvmlnit under specific conditions.
Removed the limitation obtained by the call to `get_bar1_free_size`, since we do not exceed 1MB limit with valgrind.