### PR TITLE
TEST/UCM/CUDA: Include assert header

### DIFF
--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -3,6 +3,7 @@
 * See file LICENSE for terms.
 */
 #include <ucm/api/ucm.h>
+#include <ucs/debug/assert.h>
 #include <common/test.h>
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
## Why ?
`ucs_assertv` is being used.
