### PR TITLE
AZP/PERF: ignore errors removing the crontab

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -185,6 +185,6 @@ stages:
         steps:
           - checkout: none
           - bash: |
-              set -xeE
-              crontab -r
+              set -x
+              crontab -r || true
             displayName: remove warning


### PR DESCRIPTION
## What
An attempt to remove a crontab fails when jobs are restarted because it has already been removed previously.
We can safely ignore the error in such cases.


