### PR TITLE
AZP/RELEASE: Do not publish JUCX for RCs

### DIFF
--- a/buildlib/jucx/jucx-publish.yml
+++ b/buildlib/jucx/jucx-publish.yml
@@ -9,7 +9,9 @@ jobs:
     dependsOn:
     - jucx_build_amd64
     - jucx_build_aarch64
-    condition: succeeded()
+    # Do not run if a GH tag contains 'rc':
+    condition: and(succeeded(), not(contains(variables['Build.SourceBranch'], 'rc')))
+
 
     pool:
       name: MLNX


### PR DESCRIPTION
## What
Skip the JUCX publish job for RC tags.