### PR TITLE
CI fixes

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -226,11 +226,6 @@ run_client_server_app() {
 run_hello() {
 	api=$1
 	shift
-	if [[ $1 == "proto" ]]
-	then
-		export UCX_PROTO_ENABLE=y
-		shift
-	fi
 
 	test_args="$@"
 	test_name=${api}_hello_world
@@ -290,7 +285,7 @@ run_ucp_hello() {
 	for tls in all tcp,cuda shm,cuda
 	do
 		export UCX_TLS=${tls}
-		for test_mode in -w -f -b -erecv -esend -ekeepalive proto
+		for test_mode in -w -f -b -erecv -esend -ekeepalive
 		do
 			for mem_type in $mem_types_list
 			do
@@ -410,9 +405,6 @@ run_io_demo() {
 
 		for server_ip in $server_rdma_addr $server_nonrdma_addr
 		do
-			export UCX_PROTO_ENABLE=y
-			run_client_server_app "./test/apps/iodemo/${test_name}" "${test_args}" "${server_ip}" 1 0
-			unset UCX_PROTO_ENABLE
 			run_client_server_app "./test/apps/iodemo/${test_name}" "${test_args}" "${server_ip}" 1 0
 		done
 
@@ -561,9 +553,7 @@ run_ucx_perftest() {
 			unset UCX_TLS
 		done
 
-		echo "==== Running ucx_perf with cuda memory and new protocols ===="
-
-		export UCX_PROTO_ENABLE=y
+		echo "==== Running ucx_perf one-sided with cuda memory ===="
 
 		# Add RMA tests to the list of tests
 		cat $ucx_inst_ptest/test_types_ucp_rma | grep cuda | sort -R >> $ucx_inst_ptest/test_types_short_ucp
@@ -576,7 +566,6 @@ run_ucx_perftest() {
 				      -n 1000 -w 1"
 		run_client_server_app "$ucx_perftest" "$ucp_test_args_atomic" "$(hostname)" 0 0
 
-		unset UCX_PROTO_ENABLE
 		unset CUDA_VISIBLE_DEVICES
 	fi
 }

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -631,7 +631,7 @@ size_t ucp_proto_rndv_common_pack_ack(void *dest, void *arg)
 
 ucs_status_t ucp_proto_rndv_ats_complete(ucp_request_t *req)
 {
-    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, 0, UCP_DT_MASK_ALL);
+    ucp_datatype_iter_cleanup(&req->send.state.dt_iter, 1, UCP_DT_MASK_ALL);
     return ucp_proto_rndv_recv_complete(req);
 }
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -24,7 +24,7 @@ namespace ucs {
 
 typedef std::pair<std::string, ::testing::TimeInMillis> test_result_t;
 
-const double test_timeout_in_sec = 60.;
+const double test_timeout_in_sec = 180.;
 
 double watchdog_timeout = 900.; // 15 minutes
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -33,7 +33,7 @@ class test_ucp_am_base : public ucp_test {
 public:
     test_ucp_am_base()
     {
-        if (is_proto_disabled()) {
+        if (get_variant_value()) {
             modify_config("PROTO_ENABLE", "n");
         }
     }
@@ -53,12 +53,6 @@ public:
         ucp_test::init();
         sender().connect(&receiver(), get_ep_params());
         receiver().connect(&sender(), get_ep_params());
-    }
-
-protected:
-    bool is_proto_disabled() const
-    {
-        return get_variant_value();
     }
 };
 
@@ -525,7 +519,7 @@ protected:
     {
         std::vector<ucp_dt_type> dts = {UCP_DATATYPE_CONTIG};
 
-        if (!is_proto_disabled()) {
+        if (is_proto_enabled()) {
             dts.push_back(UCP_DATATYPE_IOV);
         }
 
@@ -1099,7 +1093,7 @@ private:
 };
 
 /**
- * Self transport always has resources to perform the send operation, 
+ * Self transport always has resources to perform the send operation,
  * so its not returning pending request. For this reason with
  * self tl the test can't verify the copy header functionality.
  * The test is still used as a stress test for the Self transport,
@@ -1533,8 +1527,7 @@ private:
 /* Skip tests for ud_v and ud_x because of unstable reproducible failures during
  * roce on worker CI jobs. The test fails with invalid am_bcopy length. */
 UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, short_bcopy_send,
-                     !is_proto_disabled() &&
-                             has_any_transport({"ud_v", "ud_x"}),
+                     is_proto_enabled() && has_any_transport({"ud_v", "ud_x"}),
                      "ZCOPY_THRESH=-1", "RNDV_THRESH=-1")
 {
     test_datatypes([&]() {
@@ -1545,8 +1538,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, short_bcopy_send,
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, zcopy_send,
-                     !is_proto_disabled() &&
-                             has_any_transport({"ud_v", "ud_x"}),
+                     is_proto_enabled() && has_any_transport({"ud_v", "ud_x"}),
                      "ZCOPY_THRESH=1", "RNDV_THRESH=-1")
 {
     skip_no_am_lane_caps(UCT_IFACE_FLAG_AM_ZCOPY, "am_zcopy is not supported");

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -17,8 +17,7 @@ class test_ucp_atomic : public test_ucp_memheap {
 public:
     /* Test variants */
     enum {
-        ATOMIC_MODE   = UCS_MASK(2),
-        DISABLE_PROTO = UCS_BIT(2)
+        ATOMIC_MODE = UCS_MASK(2)
     };
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants,
@@ -34,9 +33,6 @@ public:
     static void get_test_variants(std::vector<ucp_test_variant>& variants)
     {
         get_test_variants(variants, 0, "");
-        if (!RUNNING_ON_VALGRIND) {
-            get_test_variants(variants, DISABLE_PROTO, "/proto_v1");
-        }
     }
 
     struct send_func_data {
@@ -134,11 +130,6 @@ protected:
                         (atomic_mode == UCP_ATOMIC_MODE_GUESS)  ? "guess" :
                         "";
         modify_config("ATOMIC_MODE", atomic_mode_cfg);
-
-        if (get_variant_value() & DISABLE_PROTO) {
-            modify_config("PROTO_ENABLE", "n");
-        }
-
         test_ucp_memheap::init();
     }
 
@@ -216,7 +207,7 @@ private:
             ucs_memory_type_t send_mem_type = pairs[i][0], recv_mem_type = pairs[i][1];
             if (!UCP_MEM_IS_HOST(send_mem_type) || !UCP_MEM_IS_HOST(recv_mem_type)) {
                 /* Memory type atomics are fully supported only with new protocols */
-                if (get_variant_value() & DISABLE_PROTO) {
+                if (!is_proto_enabled()) {
                     continue;
                 }
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -91,7 +91,7 @@ public:
 
     virtual void init() {
         ucs::skip_on_address_sanitizer();
-        if (disable_proto()) {
+        if (get_variant_value() == VARIANT_PROTO_DISABLE) {
             modify_config("PROTO_ENABLE", "n");
         }
 
@@ -167,7 +167,6 @@ protected:
                     bool import_mem = false);
     void test_rkey_management(ucp_mem_h memh, bool is_dummy,
                               bool expect_rma_offload);
-    bool disable_proto() const;
 
 private:
     void check_distance_precision(double rkey_value, double topo_value,
@@ -297,7 +296,7 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
     EXPECT_TRUE(ucs_test_all_flags(memh->md_map, rkey->md_map));
 
     /* Test remote key protocols selection */
-    if (m_ucp_config->ctx.proto_enable) {
+    if (is_proto_enabled()) {
         test_rkey_proto(memh);
     } else {
         bool have_rma              = resolve_rma(&receiver(), rkey);
@@ -351,11 +350,6 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
 
     ucp_rkey_destroy(rkey);
     ucp_rkey_buffer_release(rkey_buffer);
-}
-
-bool test_ucp_mmap::disable_proto() const
-{
-    return get_variant_value() == VARIANT_PROTO_DISABLE;
 }
 
 void test_ucp_mmap::check_distance_precision(double rkey_value,
@@ -424,7 +418,7 @@ void test_ucp_mmap::test_rkey_proto(ucp_mem_h memh)
     ASSERT_UCS_OK(status);
 
     /* Check rkey configuration */
-    if (!disable_proto() && m_ucp_config->ctx.proto_enable) {
+    if (is_proto_enabled()) {
         ucp_rkey_config_t *rkey_config = ucp_rkey_config(receiver().worker(),
                                                          rkey);
         ucp_ep_config_t *ep_config     = ucp_ep_config(receiver().ep());

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -831,38 +831,36 @@ protected:
 test_ucp_peer_failure_rndv_abort *test_ucp_peer_failure_rndv_abort::self = nullptr;
 
 UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort, get_zcopy,
-                     !m_ucp_config->ctx.proto_enable, "RNDV_THRESH=0",
+                     !is_proto_enabled(), "RNDV_THRESH=0",
                      "RNDV_SCHEME=get_zcopy")
 {
     rndv_progress_failure_test(rndv_mode::rndv_get, true);
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort, put_zcopy_force_flush,
-                     !m_ucp_config->ctx.proto_enable, "RNDV_THRESH=0",
+                     !is_proto_enabled(), "RNDV_THRESH=0",
                      "RNDV_SCHEME=put_zcopy", "RNDV_PUT_FORCE_FLUSH=y")
 {
     rndv_progress_failure_test(rndv_mode::rndv_put, true);
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort,
-                     get_zcopy_memory_invalidation,
-                     !m_ucp_config->ctx.proto_enable, "RNDV_THRESH=0",
-                     "RNDV_SCHEME=get_zcopy")
+                     get_zcopy_memory_invalidation, !is_proto_enabled(),
+                     "RNDV_THRESH=0", "RNDV_SCHEME=get_zcopy")
 {
     rndv_progress_failure_test(rndv_mode::rndv_get, false);
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort,
-                     put_zcopy_memory_invalidation,
-                     !m_ucp_config->ctx.proto_enable, "RNDV_THRESH=0",
-                     "RNDV_SCHEME=put_zcopy")
+                     put_zcopy_memory_invalidation, !is_proto_enabled(),
+                     "RNDV_THRESH=0", "RNDV_SCHEME=put_zcopy")
 {
     rndv_progress_failure_test(rndv_mode::rndv_put, false);
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort,
                      put_zcopy_force_flush_memory_invalidation,
-                     !m_ucp_config->ctx.proto_enable, "RNDV_THRESH=0",
+                     !is_proto_enabled(), "RNDV_THRESH=0",
                      "RNDV_SCHEME=put_zcopy", "RNDV_PUT_FORCE_FLUSH=y")
 {
     rndv_progress_failure_test(rndv_mode::rndv_put, false);

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -33,13 +33,13 @@ public:
                                "user_memh");
     }
 
-    virtual void init() {
-        if (disable_proto()) {
+    test_ucp_rma()
+    {
+        if (get_variant_value() & DISABLE_PROTO) {
             modify_config("PROTO_ENABLE", "n");
         } else {
             modify_config("MAX_RMA_LANES", "2");
         }
-        test_ucp_memheap::init();
     }
 
     void do_nbi_iov(iov_op_t op, size_t size, void *expected_data,
@@ -128,9 +128,8 @@ protected:
         for (size_t i = 0; i < pairs.size(); ++i) {
 
             /* Memory type put/get is fully supported only with new protocols */
-            if (!m_ucp_config->ctx.proto_enable &&
-                (!UCP_MEM_IS_HOST(pairs[i][0]) ||
-                 !UCP_MEM_IS_HOST(pairs[i][1]))) {
+            if (!is_proto_enabled() && (!UCP_MEM_IS_HOST(pairs[i][0]) ||
+                                        !UCP_MEM_IS_HOST(pairs[i][1]))) {
                 continue;
             }
 
@@ -179,10 +178,6 @@ protected:
                 break;
             }
         }
-    }
-
-    bool disable_proto() {
-        return !m_ucp_config->ctx.proto_enable;
     }
 
     bool user_memh()
@@ -292,8 +287,9 @@ UCS_TEST_P(test_ucp_rma, put_nonblocking) {
     test_mem_types(static_cast<send_func_t>(&test_ucp_rma::put_nbi));
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_rma, put_nonblocking_iov_zcopy, disable_proto(),
-                     "ZCOPY_THRESH=0") {
+UCS_TEST_SKIP_COND_P(test_ucp_rma, put_nonblocking_iov_zcopy,
+                     !is_proto_enabled(), "ZCOPY_THRESH=0")
+{
     if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
         UCS_TEST_SKIP_R("put_zcopy is not supported");
     }
@@ -311,8 +307,9 @@ UCS_TEST_P(test_ucp_rma, get_nonblocking) {
     test_mem_types(static_cast<send_func_t>(&test_ucp_rma::get_nbi));
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_rma, get_nonblocking_iov_zcopy, disable_proto(),
-                     "ZCOPY_THRESH=0") {
+UCS_TEST_SKIP_COND_P(test_ucp_rma, get_nonblocking_iov_zcopy,
+                     !is_proto_enabled(), "ZCOPY_THRESH=0")
+{
     if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_GET_ZCOPY)) {
         UCS_TEST_SKIP_R("get_zcopy is not supported");
     }

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -663,7 +663,7 @@ protected:
 
         do_send_recv(send_dt, recv_dt, send_param, recv_param);
 
-        if (prereg() && !is_self() && (!is_iov() || m_ucp_config->ctx.proto_enable)) {
+        if (prereg() && !is_self() && (!is_iov() || is_proto_enabled())) {
             /* Not relevant for 'self' because both sender and receiver are the same entity.
                Must be called before request is freed by free_callback (wait_for_value). */
             /* User-provided memh on iov supported only with proto_v2 */

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1110,7 +1110,7 @@ public:
         EXPECT_EQ(1, get_zcopy + rtr + rkey_ptr);
         EXPECT_LE(put_zcopy, rtr);
 
-        if (m_ucp_config->ctx.proto_enable) {
+        if (is_proto_enabled()) {
             if (has_xpmem() || is_self() || has_rma_zcopy()) {
                 /* Expect one of the bulk transfer protocols */
                 EXPECT_EQ(1u, rkey_ptr + get_zcopy + put_zcopy);
@@ -1238,7 +1238,7 @@ public:
 UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=16", "TM_SW_RNDV=y",
            "RNDV_THRESH=1", "MIN_RNDV_CHUNK_SIZE=1", "MULTI_PATH_RATIO=0.0001")
 {
-    if (m_ucp_config->ctx.proto_enable) {
+    if (is_proto_enabled()) {
         UCS_TEST_SKIP_R("TM_SW_RNDV has no effect with proto v2");
     }
 

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -409,6 +409,11 @@ void ucp_test::configure_peer_failure_settings()
     m_env.push_back(new ucs::scoped_setenv("UCX_RC_RETRY_COUNT", "2"));
 }
 
+bool ucp_test::is_proto_enabled() const
+{
+    return m_ucp_config->ctx.proto_enable;
+}
+
 void ucp_test::set_ucp_config(ucp_config_t *config, const std::string& tls)
 {
     ucs_status_t status;

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -268,6 +268,7 @@ protected:
                         int poll_timeout = -1, int worker_index = 0);
     int max_connections();
     void configure_peer_failure_settings();
+    bool is_proto_enabled() const;
 
     static bool check_reg_mem_types(const entity& e, ucs_memory_type_t mem_type);
 


### PR DESCRIPTION
## Why
1. Fix assertion in rcx/test_ucp_tag_mem_type.reuse_buffers_mrail/15. The receive buffer could have been registered as part of tag offload and moved from recv iterator to rndv send request iterator.
2. Fix the condition that enable testing protov2 specific features: need to check UCP configuration rather than test variant, since protov2 can be disabled by env var UCX_PROTO_ENABLE=n

cc @shasson5 