### PR TITLE
UCT/CUDA-IPC: Ignore ka failure during ep creation

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -1588,7 +1588,7 @@ unsigned long ucs_sys_get_proc_create_time(pid_t pid)
     }
 
 scan_err:
-    ucs_error("failed to scan "UCS_PROCCESS_STAT_FMT, pid);
+    ucs_debug("failed to scan "UCS_PROCCESS_STAT_FMT, pid);
 err:
     return 0ul;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -32,7 +32,12 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, const uct_ep_params_t *params)
 
     self->remote_pid = *(const pid_t*)params->iface_addr;
 
-    return uct_ep_keepalive_init(&self->keepalive, self->remote_pid);
+    /* Ignore return status, because error handling may not be needed
+     * (it will fail during first check anyway)
+     */
+    uct_ep_keepalive_init(&self->keepalive, self->remote_pid);
+
+    return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_ep_t)


### PR DESCRIPTION
## What
Error handling is not always needed by the UCT user (e.g. MPI apps). Ignore ka initialization failure, which enables cuda-ipc multinode for MPI flows.
