### PR TITLE
UCP/PROTO: Max seg size can be configured by user for RMA/ZCOPY

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -221,6 +221,10 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "multiple rails. Must be greater than 0.",
    ucs_offsetof(ucp_context_config_t, min_rndv_chunk_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"RMA_ZCOPY_MAX_SEG_SIZE", "auto",
+   "Max size of a segment for rma/rndv zcopy.",
+   ucs_offsetof(ucp_context_config_t, rma_zcopy_max_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"RNDV_SCHEME", "auto",
    "Communication scheme in RNDV protocol.\n"
    " get_zcopy - use get_zcopy scheme in RNDV protocol.\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -166,6 +166,8 @@ typedef struct ucp_context_config {
     uint64_t                               reg_nb_mem_types;
     /** Prefer native RMA transports for RMA/AMO protocols */
     int                                    prefer_offload;
+    /** RMA zcopy segment size */
+    size_t                                 rma_zcopy_max_seg_size;
 } ucp_context_config_t;
 
 


### PR DESCRIPTION
## What
Max seg size can be configured by user for RMA/ZCOPY

## Why ?
Better control seg size and enable simulate complex multi fragment scenarios.

