### PR TITLE
AZP: add ubuntu 22.04 container w/ rocm6.0 stack

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -168,6 +168,9 @@ resources:
     - container: ubuntu2004_rocm_5_4_0
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2004:rocm_5_4_0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2204_rocm_6_0_0
+      image: registry.hub.docker.com/rocm/ucx:rocm-6.0.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
 
 stages:
   - stage: Codestyle
@@ -227,6 +230,8 @@ stages:
               CONTAINER: centos7_ib
             ubuntu2004_rocm:
               CONTAINER: ubuntu2004_rocm_5_4_0
+            ubuntu2204_rocm:
+              CONTAINER: ubuntu2204_rocm_6_0_0
         container: $[ variables['CONTAINER'] ]
         timeoutInMinutes: 340
 


### PR DESCRIPTION
## What
Add a compilation step for ROCm 6.0 on a ubuntu 22.04 docker image

## Why ?
test compilation of ROCm 6.0 in UCX CI
