### PR TITLE
UCS/CONFIG: Key-value config parser

### DIFF
--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -46,6 +46,7 @@ typedef struct ucs_config_parser {
     ucs_status_t             (*clone)(const void *src, void *dest, const void *arg);
     void                     (*release)(void *ptr, const void *arg);
     void                     (*help)(char *buf, size_t max, const void *arg);
+    void                     (*doc)(ucs_string_buffer_t *strb, const void *arg);
     const void               *arg;
 } ucs_config_parser_t;
 
@@ -63,6 +64,23 @@ typedef struct ucs_config_field {
     size_t                   offset;
     ucs_config_parser_t      parser;
 } ucs_config_field_t;
+
+
+typedef struct {
+    const char               *name;   /* Key name */
+    const char               *doc;    /* Documentation */
+    size_t                   offset;  /* Storage offset */
+} ucs_config_key_field_t;
+
+
+/**
+ * Describes structure that is passed to key-value parser functions as an
+ * argument.
+ */
+typedef struct {
+    ucs_config_parser_t          parser;  /* Parser impl */
+    const ucs_config_key_field_t *keys;   /* Array of allowed key fields */
+} ucs_config_key_value_param_t;
 
 
 typedef struct ucs_config_cached_key {
@@ -259,9 +277,18 @@ ucs_status_t ucs_config_clone_table(const void *src, void *dest, const void *arg
 void ucs_config_release_table(void *ptr, const void *arg);
 void ucs_config_help_table(char *buf, size_t max, const void *arg);
 
+/* Key-value parser functions */
+int ucs_config_sscanf_key_value(const char *buf, void *dest, const void *arg);
+int ucs_config_sprintf_key_value(char *buf, size_t max, const void *src, const void *arg);
+ucs_status_t ucs_config_clone_key_value(const void *src, void *dest, const void *arg);
+void ucs_config_release_key_value(void *ptr, const void *arg);
+void ucs_config_help_key_value(char *buf, size_t max, const void *arg);
+void ucs_config_doc_key_value(ucs_string_buffer_t *strb, const void *arg);
+
 ucs_status_t ucs_config_clone_log_comp(const void *src, void *dst, const void *arg);
 
 void ucs_config_release_nop(void *ptr, const void *arg);
+void ucs_config_doc_nop(ucs_string_buffer_t *strb, const void *arg);
 void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 
 #define UCS_CONFIG_DEPRECATED_FIELD_OFFSET SIZE_MAX
@@ -276,129 +303,161 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 
 #define UCS_CONFIG_TYPE_STRING     {ucs_config_sscanf_string,    ucs_config_sprintf_string, \
                                     ucs_config_clone_string,     ucs_config_release_string, \
-                                    ucs_config_help_generic,     "string"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "string"}
 
 #define UCS_CONFIG_TYPE_INT        {ucs_config_sscanf_int,       ucs_config_sprintf_int, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "integer"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "integer"}
 
 #define UCS_CONFIG_TYPE_UINT       {ucs_config_sscanf_uint,      ucs_config_sprintf_uint, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "unsigned integer"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "unsigned integer"}
 
 #define UCS_CONFIG_TYPE_ULONG      {ucs_config_sscanf_ulong,     ucs_config_sprintf_ulong, \
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "unsigned long"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "unsigned long"}
 
 #define UCS_CONFIG_TYPE_ULUNITS    {ucs_config_sscanf_ulunits,   ucs_config_sprintf_ulunits, \
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
-                                    ucs_config_help_generic, \
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
                                     "unsigned long: <number>, \"inf\", or \"auto\""}
 
 #define UCS_CONFIG_TYPE_DOUBLE     {ucs_config_sscanf_double,    ucs_config_sprintf_double, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "floating point number"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "floating point number"}
 
 #define UCS_CONFIG_TYPE_POS_DOUBLE {ucs_config_sscanf_pos_double, ucs_config_sprintf_pos_double, \
                                     ucs_config_clone_double,      ucs_config_release_nop, \
-                                    ucs_config_help_generic, \
+                                    ucs_config_help_generic,      ucs_config_doc_nop, \
                                     "positive floating point number or \"auto\""}
 
 #define UCS_CONFIG_TYPE_HEX        {ucs_config_sscanf_hex,       ucs_config_sprintf_hex, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
-                                    ucs_config_help_generic, \
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
                                     "hex representation of a number or \"auto\""}
 
 #define UCS_CONFIG_TYPE_BOOL       {ucs_config_sscanf_bool,      ucs_config_sprintf_bool, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "<y|n>"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "<y|n>"}
 
 #define UCS_CONFIG_TYPE_TERNARY    {ucs_config_sscanf_ternary, ucs_config_sprintf_ternary_auto, \
                                     ucs_config_clone_int,      ucs_config_release_nop, \
-                                    ucs_config_help_generic,   "<yes|no|try>"}
+                                    ucs_config_help_generic,   ucs_config_doc_nop, \
+                                    "<yes|no|try>"}
 
 #define UCS_CONFIG_TYPE_TERNARY_AUTO {ucs_config_sscanf_ternary_auto, ucs_config_sprintf_ternary_auto, \
                                       ucs_config_clone_int,           ucs_config_release_nop, \
-                                      ucs_config_help_generic,        "<yes|no|try|auto>"}
+                                      ucs_config_help_generic,        ucs_config_doc_nop, \
+                                      "<yes|no|try|auto>"}
 
 #define UCS_CONFIG_TYPE_ON_OFF     {ucs_config_sscanf_on_off,    ucs_config_sprintf_on_off_auto, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "<on|off>"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "<on|off>"}
 
 #define UCS_CONFIG_TYPE_ON_OFF_AUTO {ucs_config_sscanf_on_off_auto, ucs_config_sprintf_on_off_auto, \
                                      ucs_config_clone_int,          ucs_config_release_nop, \
-                                     ucs_config_help_generic,       "<on|off|auto>"}
+                                     ucs_config_help_generic,       ucs_config_doc_nop, \
+                                     "<on|off|auto>"}
 
 #define UCS_CONFIG_TYPE_ENUM(t)    {ucs_config_sscanf_enum,      ucs_config_sprintf_enum, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
-                                    ucs_config_help_enum,        t}
+                                    ucs_config_help_enum,        ucs_config_doc_nop, \
+                                    t}
 
 #define UCS_CONFIG_TYPE_UINT_ENUM(t) {ucs_config_sscanf_uint_enum, ucs_config_sprintf_uint_enum, \
                                       ucs_config_clone_uint,       ucs_config_release_nop, \
-                                      ucs_config_help_uint_enum,   t}
+                                      ucs_config_help_uint_enum,   ucs_config_doc_nop, \
+                                      t}
 
 #define UCS_CONFIG_TYPE_BITMAP(t)  {ucs_config_sscanf_bitmap,    ucs_config_sprintf_bitmap, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
-                                    ucs_config_help_bitmap,      t}
+                                    ucs_config_help_bitmap,      ucs_config_doc_nop, \
+                                    t}
 
 #define UCS_CONFIG_TYPE_BITMASK    {ucs_config_sscanf_bitmask,   ucs_config_sprintf_bitmask, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "bit count"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "bit count"}
 
 #define UCS_CONFIG_TYPE_TIME       {ucs_config_sscanf_time,      ucs_config_sprintf_time, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "time value: <number>[s|us|ms|ns]"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "time value: <number>[s|us|ms|ns]"}
 
 #define UCS_CONFIG_TYPE_TIME_UNITS {ucs_config_sscanf_time_units, ucs_config_sprintf_time_units, \
                                     ucs_config_clone_ulong,       ucs_config_release_nop, \
-                                    ucs_config_help_generic, \
+                                    ucs_config_help_generic,      ucs_config_doc_nop, \
                                     "time value: <number>[s|us|ms|ns], \"inf\", or \"auto\""}
 
 #define UCS_CONFIG_TYPE_BW         {ucs_config_sscanf_bw,        ucs_config_sprintf_bw, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \
-                                    ucs_config_help_generic,     \
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
                                     "bandwidth value: <number>[T|G|M|K]B|b[[p|/]s] or \"auto\""}
 
 #define UCS_CONFIG_TYPE_BW_SPEC    {ucs_config_sscanf_bw_spec,   ucs_config_sprintf_bw_spec, \
                                     ucs_config_clone_bw_spec,    ucs_config_release_bw_spec, \
-                                    ucs_config_help_generic,     \
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
                                     "device_name:<number>[T|G|M|K]B|b[[p|/]s] or device_name:auto"}
 
 #define UCS_CONFIG_TYPE_LOG_COMP   {ucs_config_sscanf_enum,      ucs_config_sprintf_enum, \
                                     ucs_config_clone_log_comp,   ucs_config_release_nop, \
-                                    ucs_config_help_enum,        ucs_log_level_names}
+                                    ucs_config_help_enum,        ucs_config_doc_nop, \
+                                    ucs_log_level_names}
 
 #define UCS_CONFIG_TYPE_SIGNO      {ucs_config_sscanf_signo,     ucs_config_sprintf_signo, \
                                     ucs_config_clone_int,        ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "system signal (number or SIGxxx)"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "system signal (number or SIGxxx)"}
 
 #define UCS_CONFIG_TYPE_MEMUNITS   {ucs_config_sscanf_memunits,  ucs_config_sprintf_memunits, \
                                     ucs_config_clone_ulong,      ucs_config_release_nop, \
-                                    ucs_config_help_generic,     \
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
                                     "memory units: <number>[b|kb|mb|gb], \"inf\", or \"auto\""}
 
 #define UCS_CONFIG_TYPE_ARRAY(a)   {ucs_config_sscanf_array,     ucs_config_sprintf_array, \
                                     ucs_config_clone_array,      ucs_config_release_array, \
-                                    ucs_config_help_array,       &ucs_config_array_##a}
+                                    ucs_config_help_array,       ucs_config_doc_nop, \
+                                    &ucs_config_array_##a}
 
 #define UCS_CONFIG_TYPE_ALLOW_LIST {ucs_config_sscanf_allow_list,     ucs_config_sprintf_allow_list, \
                                     ucs_config_clone_allow_list,      ucs_config_release_allow_list, \
-                                    ucs_config_help_allow_list,       &ucs_config_array_string}
+                                    ucs_config_help_allow_list,       ucs_config_doc_nop, \
+                                    &ucs_config_array_string}
 
 #define UCS_CONFIG_TYPE_TABLE(t)   {ucs_config_sscanf_table,     NULL, \
                                     ucs_config_clone_table,      ucs_config_release_table, \
-                                    ucs_config_help_table,       t}
+                                    ucs_config_help_table,       ucs_config_doc_nop, \
+                                    t}
 
 #define UCS_CONFIG_TYPE_RANGE_SPEC {ucs_config_sscanf_range_spec,ucs_config_sprintf_range_spec, \
                                     ucs_config_clone_range_spec, ucs_config_release_nop, \
-                                    ucs_config_help_generic,     "numbers range: <number>-<number>"}
+                                    ucs_config_help_generic,     ucs_config_doc_nop, \
+                                    "numbers range: <number>-<number>"}
 
 #define UCS_CONFIG_TYPE_DEPRECATED {(ucs_field_type(ucs_config_parser_t, read))   ucs_empty_function_do_assert, \
                                     (ucs_field_type(ucs_config_parser_t, write))  ucs_empty_function_do_assert, \
                                     (ucs_field_type(ucs_config_parser_t, clone))  ucs_empty_function_do_assert, \
                                     (ucs_field_type(ucs_config_parser_t, release))ucs_empty_function_do_assert, \
                                     (ucs_field_type(ucs_config_parser_t, help))   ucs_empty_function_do_assert, \
+                                    ucs_config_doc_nop, \
                                     ""}
+
+#define UCS_CONFIG_TYPE_KEY_VALUE(_value, ...) \
+    {ucs_config_sscanf_key_value, ucs_config_sprintf_key_value, \
+     ucs_config_clone_key_value,  ucs_config_release_key_value, \
+     ucs_config_help_key_value,   ucs_config_doc_key_value, \
+        (const ucs_config_key_value_param_t[]) { \
+            {_value, (const ucs_config_key_field_t[]){ __VA_ARGS__ }} \
+        } \
+    }
+
 
 /**
  * Helpers for using an array of strings

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -94,6 +94,11 @@ typedef struct {
     ucs_time_t      time_auto;
     ucs_time_t      time_inf;
     ucs_config_allow_list_t allow_list;
+
+    int             temp_front;
+    int             temp_rear;
+
+    const char      *passengers[3];
 } car_opts_t;
 
 
@@ -224,6 +229,21 @@ ucs_config_field_t car_opts_table[] = {
   {"ALLOW_LIST", "all", "Allow-list: \"all\" OR \"val1,val2\" OR \"^val1,val2\"",
    ucs_offsetof(car_opts_t, allow_list), UCS_CONFIG_TYPE_ALLOW_LIST},
 
+  {"TEMP", "20", "Temperature", 0,
+    UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_UINT,
+        {"front", "front temperature", ucs_offsetof(car_opts_t, temp_front)},
+        {"rear",  "rear temperature",  ucs_offsetof(car_opts_t, temp_rear)},
+        {NULL}
+    )},
+
+  {"PASSENGERS", "None", "Passengers", 0,
+    UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_STRING,
+        {"first",  "First passenger",  ucs_offsetof(car_opts_t, passengers[0])},
+        {"second", "Second passenger", ucs_offsetof(car_opts_t, passengers[1])},
+        {"third",  "Third passenger",  ucs_offsetof(car_opts_t, passengers[2])},
+        {NULL}
+    )},
+
   {NULL}
 };
 
@@ -245,7 +265,7 @@ protected:
                          const char *message, va_list ap)
     {
         // Ignore errors that invalid input parameters as it is expected
-        if (level == UCS_LOG_LEVEL_WARN) {
+        if ((level == UCS_LOG_LEVEL_WARN) || (level == UCS_LOG_LEVEL_ERROR)) {
             std::string err_str = format_message(message, ap);
 
             for (size_t i = 0; i < config_err_exp_str.size(); i++) {
@@ -307,9 +327,9 @@ protected:
             delete [] m_value;
         }
 
-        void set(const char *name, const char *value) {
-            ucs_config_parser_set_value(&m_opts, car_opts_table, NULL, name,
-                                        value);
+        ucs_status_t set(const char *name, const char *value) {
+            return ucs_config_parser_set_value(&m_opts, car_opts_table, NULL,
+                                               name, value);
         }
 
         const char* get(const char *name) {
@@ -328,6 +348,27 @@ protected:
         car_opts_t* operator*() {
             return &m_opts;
         }
+
+        std::string dump(ucs_config_print_flags_t flags) const {
+            char *dump_data = NULL;
+            size_t dump_size;
+            char line_buf[1024];
+            std::string res;
+
+            FILE *file = open_memstream(&dump_data, &dump_size);
+            ucs_config_parser_print_opts(file, "", &m_opts, car_opts_table,
+                                         NULL, UCS_DEFAULT_ENV_PREFIX, flags);
+            fseek(file, 0, SEEK_SET);
+
+            while (fgets(line_buf, sizeof(line_buf), file)) {
+                res += line_buf;
+            }
+
+            fclose(file);
+            free(dump_data);
+            return res;
+        }
+
     private:
 
         static car_opts_t parse(const char *env_prefix,
@@ -462,6 +503,13 @@ UCS_TEST_F(test_config, parse_default) {
     EXPECT_EQ(UCS_TIME_INFINITY, opts->time_inf);
     EXPECT_EQ(UCS_CONFIG_ALLOW_LIST_ALLOW_ALL, opts->allow_list.mode);
     EXPECT_EQ(0, opts->allow_list.array.count);
+
+    EXPECT_EQ(20, opts->temp_front);
+    EXPECT_EQ(20, opts->temp_rear);
+
+    EXPECT_STREQ("None", opts->passengers[0]);
+    EXPECT_STREQ("None", opts->passengers[1]);
+    EXPECT_STREQ("None", opts->passengers[2]);
 }
 
 UCS_TEST_F(test_config, clone) {
@@ -473,18 +521,28 @@ UCS_TEST_F(test_config, clone) {
         ucs::scoped_setenv env1("UCX_COLOR", "white");
         /* coverity[tainted_string_argument] */
         ucs::scoped_setenv env2("UCX_PRICE_ALIAS", "0");
-        
+        /* coverity[tainted_string_argument] */
+        ucs::scoped_setenv env3("UCX_TEMP", "30");
+
         car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
         EXPECT_EQ(COLOR_WHITE, opts->color);
         EXPECT_EQ(0U, opts->price);
+        EXPECT_EQ(30, opts->temp_front);
+        EXPECT_EQ(30, opts->temp_rear);
+        EXPECT_EQ(UCS_OK, opts.set("PASSENGERS", "Unknown,third:3"));
 
         /* coverity[tainted_string_argument] */
-        ucs::scoped_setenv env3("UCX_COLOR", "black");
+        ucs::scoped_setenv env4("UCX_COLOR", "black");
         opts_clone_ptr = new car_opts(opts);
     }
 
     EXPECT_EQ(COLOR_WHITE, (*opts_clone_ptr)->color);
     EXPECT_EQ(UCS_CONFIG_ALLOW_LIST_ALLOW_ALL, (*opts_clone_ptr)->allow_list.mode);
+    EXPECT_EQ(30, (*opts_clone_ptr)->temp_front);
+    EXPECT_EQ(30, (*opts_clone_ptr)->temp_rear);
+    EXPECT_STREQ("Unknown", (*opts_clone_ptr)->passengers[0]);
+    EXPECT_STREQ("Unknown", (*opts_clone_ptr)->passengers[1]);
+    EXPECT_STREQ("3", (*opts_clone_ptr)->passengers[2]);
     delete opts_clone_ptr;
 }
 
@@ -600,23 +658,23 @@ UCS_TEST_F(test_config, unused) {
 
 UCS_TEST_F(test_config, dump) {
     /* aliases must not be counted here */
-    test_config_print_opts(UCS_CONFIG_PRINT_CONFIG, 32u);
+    test_config_print_opts(UCS_CONFIG_PRINT_CONFIG, 34u);
 }
 
 UCS_TEST_F(test_config, dump_hidden) {
     /* aliases must be counted here */
-    test_config_print_opts(UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HIDDEN, 39u);
+    test_config_print_opts(UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HIDDEN, 41u);
 }
 
 UCS_TEST_F(test_config, dump_hidden_check_alias_name) {
     /* aliases must be counted here */
     test_config_print_opts(
         UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HIDDEN | UCS_CONFIG_PRINT_DOC,
-        39u);
+        41u);
 
     test_config_print_opts(
         UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HIDDEN | UCS_CONFIG_PRINT_DOC,
-        39u, "TEST_");
+        41u, "TEST_");
 }
 
 UCS_TEST_F(test_config, deprecated) {
@@ -685,6 +743,143 @@ UCS_TEST_F(test_config, test_allow_list_negative)
                                            &ucs_config_array_string), 0);
 }
 
+UCS_TEST_F(test_config, test_key_value_generic_value) {
+    /* coverity[tainted_string_argument] */
+    ucs::scoped_setenv env1("UCX_TEMP", "42");
+
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+    EXPECT_EQ(42, opts->temp_front);
+    EXPECT_EQ(42, opts->temp_rear);
+
+    EXPECT_EQ(UCS_OK, opts.set("PASSENGERS", "Unknown"));
+    EXPECT_STREQ("Unknown", opts->passengers[0]);
+    EXPECT_STREQ("Unknown", opts->passengers[1]);
+    EXPECT_STREQ("Unknown", opts->passengers[2]);
+}
+
+UCS_TEST_F(test_config, test_key_value_mixed) {
+    /* coverity[tainted_string_argument] */
+    ucs::scoped_setenv env1("UCX_TEMP", "15,rear:51");
+
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+    EXPECT_EQ(15, opts->temp_front);
+    EXPECT_EQ(51, opts->temp_rear);
+
+    EXPECT_EQ(UCS_OK, opts.set("PASSENGERS", "Unknown,second:Some Name"));
+    EXPECT_STREQ("Unknown", opts->passengers[0]);
+    EXPECT_STREQ("Some Name", opts->passengers[1]);
+    EXPECT_STREQ("Unknown", opts->passengers[2]);
+}
+
+UCS_TEST_F(test_config, test_key_value_empty_string_key) {
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+
+    EXPECT_EQ(UCS_OK, opts.set("PASSENGERS", ""));
+    EXPECT_STREQ("", opts->passengers[0]);
+    EXPECT_STREQ("", opts->passengers[1]);
+    EXPECT_STREQ("", opts->passengers[2]);
+
+    EXPECT_EQ(UCS_OK, opts.set("PASSENGERS", ",second:2"));
+    EXPECT_STREQ("", opts->passengers[0]);
+    EXPECT_STREQ("2", opts->passengers[1]);
+    EXPECT_STREQ("", opts->passengers[2]);
+}
+
+UCS_TEST_F(test_config, test_key_value_explicit) {
+    /* coverity[tainted_string_argument] */
+    ucs::scoped_setenv env1("UCX_TEMP", "rear:51,front:15");
+
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+    EXPECT_EQ(15, opts->temp_front);
+    EXPECT_EQ(51, opts->temp_rear);
+
+    EXPECT_EQ(UCS_OK, opts.set("PASSENGERS", "third:3,second:2,first:1"));
+    EXPECT_STREQ("1", opts->passengers[0]);
+    EXPECT_STREQ("2", opts->passengers[1]);
+    EXPECT_STREQ("3", opts->passengers[2]);
+}
+
+UCS_TEST_F(test_config, test_key_value_wrong_syntax) {
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+    EXPECT_EQ(UCS_OK, opts.set("TEMP", "17"));
+    EXPECT_EQ(17, opts->temp_front);
+    EXPECT_EQ(17, opts->temp_rear);
+
+    {
+        config_err_exp_str = {"key 'unknown' is not supported",
+                              "Invalid value for TEMP: 'unknown:10'"};
+
+        scoped_log_handler log_handler_vars(config_error_handler);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, opts.set("TEMP", "unknown:10"));
+        EXPECT_EQ(17, opts->temp_front);
+        EXPECT_EQ(17, opts->temp_rear);
+
+        config_err_exp_str.clear();
+    }
+    {
+        config_err_exp_str = {"Invalid value for TEMP: ''"};
+
+        scoped_log_handler log_handler_vars(config_error_handler);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, opts.set("TEMP", ""));
+        EXPECT_EQ(17, opts->temp_front);
+        EXPECT_EQ(17, opts->temp_rear);
+
+        config_err_exp_str.clear();
+    }
+    {
+        config_err_exp_str = {"no value configured for key 'first'",
+                              "Invalid value for PASSENGERS: "};
+
+        scoped_log_handler log_handler_vars(config_error_handler);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, opts.set("PASSENGERS", "second:2"));
+        EXPECT_STREQ("None", opts->passengers[0]);
+        EXPECT_STREQ("None", opts->passengers[1]);
+        EXPECT_STREQ("None", opts->passengers[2]);
+
+        config_err_exp_str.clear();
+    }
+}
+
+UCS_TEST_F(test_config, test_key_value_dump_config) {
+    /* coverity[tainted_string_argument] */
+    ucs::scoped_setenv env1("UCX_TEMP", "rear:16,front:17");
+
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+    std::string dump = opts.dump(UCS_CONFIG_PRINT_CONFIG);
+
+    size_t it = dump.find("\nUCX_TEMP=front:17,rear:16\n");
+    EXPECT_NE(it, std::string::npos);
+
+    it = dump.find("\nUCX_PASSENGERS=first:None,second:None,third:None\n");
+    EXPECT_NE(it, std::string::npos);
+}
+
+UCS_TEST_F(test_config, test_key_value_dump_full) {
+    /* coverity[tainted_string_argument] */
+    ucs::scoped_setenv env1("UCX_TEMP", "rear:16,front:17");
+
+    car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
+
+    int flags = UCS_CONFIG_PRINT_CONFIG |
+                UCS_CONFIG_PRINT_HEADER |
+                UCS_CONFIG_PRINT_DOC    |
+                UCS_CONFIG_PRINT_HIDDEN |
+                UCS_CONFIG_PRINT_COMMENT_DEFAULT;
+    std::string dump = opts.dump((ucs_config_print_flags_t)flags);
+
+    size_t it = dump.find("# Temperature\n"
+                          "#  front     - front temperature\n"
+                          "#  rear      - rear temperature\n"
+                          "#\n"
+                          "# syntax:    comma-separated list of value or key:"
+                          "value pairs, where key is one of [front,rear] and "
+                          "value is: unsigned integer. A value without a key is"
+                          " the default.\n"
+                          "#\n"
+                          "UCX_TEMP=front:17,rear:16\n");
+    EXPECT_NE(it, std::string::npos);
+}
+
 UCS_TEST_F(test_config, test_config_file) {
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv env1("UCX_BRAND", "Ford");
@@ -717,8 +912,10 @@ UCS_TEST_F(test_config, test_config_file_parse_files) {
     status = ucs_config_parser_fill_opts(&opts, &entry, UCS_DEFAULT_ENV_PREFIX,
                                          0);
     EXPECT_EQ(200, opts.price);
+    EXPECT_EQ(15, opts.temp_front);
+    EXPECT_EQ(10, opts.temp_rear);
     ucs_config_parser_release_opts(&opts, car_opts_table);
-    
+
     ucs_config_parse_config_files();
     status = ucs_config_parser_fill_opts(&opts, &entry, UCS_DEFAULT_ENV_PREFIX,
                                          0);

--- a/test/gtest/ucs/ucx_test.conf
+++ b/test/gtest/ucs/ucx_test.conf
@@ -1,2 +1,3 @@
 UCX_PRICE=200
 UCX_BRAND=Mazda
+UCX_TEMP=10,front:15


### PR DESCRIPTION
## What
Advanced key-value parser for UCX config.

Usage example:
```
  {"TEMP", "20", "Temperature", 0,
    UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_UINT,
        {"front", "front temperature", ucs_offsetof(car_opts_t, temp_front)},
        {"rear",  "rear temperature",  ucs_offsetof(car_opts_t, temp_rear)},
        {NULL}
    )},
```

## Why ?
There are several use cases when config environment variables may contain multiple values (e.g. `RNDV_FRAG_ALLOC_COUNT= host:128,cuda:128`). However there are several drawbacks with current implementation: storing intermediate strings, 2-phase processing, syntax is not enforced.
Advanced key-value config parser aims to solve these issues.

## How ?
[Design considerations document](https://nvidia.sharepoint.com/:p:/r/sites/NBU-UCX/_layouts/15/Doc.aspx?sourcedoc=%7B232d86f5-c9e1-4a3c-8e40-7b6a6f3cf161%7D&action=edit&wdPreviousSession=61b5f70b-d600-ddd5-ef57-aaed06ac60c2&wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1702363341203&web=1).

Some considerations:
1. Outer config has an offset which is supposed to be zero. One idea was to hide it with macro and enforce to be 0, e.g.:
```
UCS_CONFIG_KEY_VALUE("TEMP", "20", "Temperature", UCS_CONFIG_TYPE_UINT,
        {"front", "front temperature", ucs_offsetof(car_opts_t, temp_front)},
        {"rear",  "rear temperature",  ucs_offsetof(car_opts_t, temp_rear)},
        {NULL}
),
```
For now I decided not implement it, because: a) config becomes less intuitive b) common offset may be useful? c) IMO macro syntax is overkill here

2. Default value is set only in outer config, which may contain both generic value and/or fine-grained configs
3. **Partial setting is NOT allowed**. E.g. `TEMP=rear:10` is not accepted, value must initialize all keys
4. Config is parsed into a temporary buffer and applied exactly once per key. This is done to avoid re-allocation for dynamic values.