### PR TITLE
UCT/IB: Adding support for priorities in IB

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -969,7 +969,10 @@ enum uct_ep_params_field {
     UCT_EP_PARAM_FIELD_PRIV_DATA_LENGTH           = UCS_BIT(15),
 
     /** Enables @ref uct_ep_params::local_sockaddr */
-    UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR             = UCS_BIT(16)
+    UCT_EP_PARAM_FIELD_LOCAL_SOCKADDR             = UCS_BIT(16),
+
+    /** Enables @ref uct_ep_params::priority */
+    UCT_EP_PARAM_FIELD_PRIORITY                   = UCS_BIT(17)
 };
 
 
@@ -1420,6 +1423,10 @@ struct uct_ep_params {
      * @ref UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR capability.
      */
     const ucs_sock_addr_t             *local_sockaddr;
+    /**
+     * Message Priority
+     */
+    unsigned                                 priority;
 };
 
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -205,6 +205,10 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "Reverse Service level. 'auto' will set the same value of sl\n",
    ucs_offsetof(uct_ib_iface_config_t, reverse_sl), UCS_CONFIG_TYPE_ULUNITS},
 
+  {"HIGH_PRIORITY_SL", "auto",
+   "High priority service level. 'auto' will set the same value of sl\n",
+   ucs_offsetof(uct_ib_iface_config_t, priority_sl), UCS_CONFIG_TYPE_ULUNITS},
+
   {NULL}
 };
 
@@ -1437,6 +1441,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     /* initialize to invalid value */
     self->config.sl                 = UCT_IB_SL_NUM;
     self->config.reverse_sl         = UCT_IB_SL_NUM;
+    self->config.priority_sl        = UCT_IB_SL_NUM;
     self->config.hop_limit          = config->hop_limit;
     self->release_desc.cb           = uct_ib_iface_release_desc;
     self->config.qp_type            = init_attr->qp_type;
@@ -1838,4 +1843,12 @@ ucs_status_t uct_ib_iface_arm_cq(uct_ib_iface_t *iface,
         return UCS_ERR_IO_ERROR;
     }
     return UCS_OK;
+}
+
+uint8_t uct_ib_iface_get_ep_sl(const uct_ib_iface_t *iface, const uct_ep_params_t *params)
+{
+    return (params->field_mask & UCT_EP_PARAM_FIELD_PRIORITY) &&
+                           (params->priority > 0) ?
+                   iface->config.priority_sl :
+                   iface->config.sl;
 }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1378,6 +1378,25 @@ void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
     ib_iface->config.reverse_sl = (uint8_t)ib_config->reverse_sl;
 }
 
+void uct_ib_iface_set_priority_sl(uct_ib_iface_t *ib_iface,
+                                  const uct_ib_iface_config_t *ib_config)
+{
+    if (ib_config->priority_sl == UCS_ULUNITS_AUTO) {
+        ib_iface->config.priority_sl = ib_iface->config.sl;
+        return;
+    }
+
+    ucs_assert(ib_config->priority_sl < UCT_IB_SL_NUM);
+    ib_iface->config.priority_sl = (uint8_t)ib_config->priority_sl;
+}
+
+void uct_ib_iface_set_configured_sls(uct_ib_iface_t *ib_iface,
+                                     const uct_ib_iface_config_t *ib_config)
+{
+    uct_ib_iface_set_reverse_sl(ib_iface, ib_config);
+    uct_ib_iface_set_priority_sl(ib_iface, ib_config);
+}
+
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
                     uct_ib_iface_ops_t *ops, uct_md_h md, uct_worker_h worker,
                     const uct_iface_params_t *params,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -814,16 +814,17 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                             const union ibv_gid *gid,
                                             uint8_t gid_index,
                                             unsigned path_index,
-                                            struct ibv_ah_attr *ah_attr)
+                                            struct ibv_ah_attr *ah_attr,
+                                            uint8_t sl)
 {
     uint8_t path_bits;
     char buf[128];
 
     memset(ah_attr, 0, sizeof(*ah_attr));
 
-    ucs_assert(iface->config.sl < UCT_IB_SL_NUM);
+    ucs_assert(sl < UCT_IB_SL_NUM);
 
-    ah_attr->sl                = iface->config.sl;
+    ah_attr->sl                = sl;
     ah_attr->port_num          = iface->config.port_num;
     ah_attr->grh.traffic_class = iface->config.traffic_class;
 
@@ -882,7 +883,8 @@ void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
                                          const uct_ib_address_t *ib_addr,
                                          unsigned path_index,
                                          struct ibv_ah_attr *ah_attr,
-                                         enum ibv_mtu *path_mtu)
+                                         enum ibv_mtu *path_mtu,
+                                         uint8_t sl)
 {
     union ibv_gid *gid = NULL;
     uint16_t lid, flid = 0;
@@ -916,7 +918,7 @@ void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
 
     lid = (flid == 0) ? params.lid : flid;
     uct_ib_iface_fill_ah_attr_from_gid_lid(iface, lid, gid, params.gid_index,
-                                           path_index, ah_attr);
+                                           path_index, ah_attr, sl);
 }
 
 static ucs_status_t uct_ib_iface_init_pkey(uct_ib_iface_t *iface,
@@ -1875,8 +1877,7 @@ ucs_status_t uct_ib_iface_arm_cq(uct_ib_iface_t *iface,
 
 uint8_t uct_ib_iface_get_ep_sl(const uct_ib_iface_t *iface, const uct_ep_params_t *params)
 {
-    return (params->field_mask & UCT_EP_PARAM_FIELD_PRIORITY) &&
-                           (params->priority > 0) ?
+    return (params->field_mask & UCT_EP_PARAM_FIELD_PRIORITY) ?
                    iface->config.priority_sls[params->priority] :
                    iface->config.sl;
 }

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -209,7 +209,7 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    ucs_offsetof(uct_ib_iface_config_t, reverse_sl), UCS_CONFIG_TYPE_ULUNITS},
 
   {"PRIORITY_SLS", "0",
-   "High priority service level. 'auto' will set the same value of sl\n",
+   "List of SLs separated by comma, order determines which priority is using which SL\n",
    ucs_offsetof(uct_ib_iface_config_t, priority_sls), 
    UCS_CONFIG_TYPE_ARRAY(priority_sls)},
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -33,6 +33,9 @@ static UCS_CONFIG_DEFINE_ARRAY(path_bits_spec,
                                sizeof(ucs_range_spec_t),
                                UCS_CONFIG_TYPE_RANGE_SPEC);
 
+static UCS_CONFIG_DEFINE_ARRAY(priority_sls, sizeof(uint8_t),
+                               UCS_CONFIG_TYPE_UINT);
+
 const char *uct_ib_mtu_values[] = {
     [UCT_IB_MTU_DEFAULT]    = "default",
     [UCT_IB_MTU_512]        = "512",
@@ -205,9 +208,10 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "Reverse Service level. 'auto' will set the same value of sl\n",
    ucs_offsetof(uct_ib_iface_config_t, reverse_sl), UCS_CONFIG_TYPE_ULUNITS},
 
-  {"HIGH_PRIORITY_SL", "auto",
+  {"PRIORITY_SLS", "0",
    "High priority service level. 'auto' will set the same value of sl\n",
-   ucs_offsetof(uct_ib_iface_config_t, priority_sl), UCS_CONFIG_TYPE_ULUNITS},
+   ucs_offsetof(uct_ib_iface_config_t, priority_sls), 
+   UCS_CONFIG_TYPE_ARRAY(priority_sls)},
 
   {NULL}
 };
@@ -1378,23 +1382,26 @@ void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
     ib_iface->config.reverse_sl = (uint8_t)ib_config->reverse_sl;
 }
 
-void uct_ib_iface_set_priority_sl(uct_ib_iface_t *ib_iface,
-                                  const uct_ib_iface_config_t *ib_config)
+static void
+uct_ib_iface_set_priority_sls(uct_ib_iface_t *ib_iface,
+                              const uct_ib_iface_config_t *ib_config)
 {
-    if (ib_config->priority_sl == UCS_ULUNITS_AUTO) {
-        ib_iface->config.priority_sl = ib_iface->config.sl;
-        return;
-    }
+    int i;
 
-    ucs_assert(ib_config->priority_sl < UCT_IB_SL_NUM);
-    ib_iface->config.priority_sl = (uint8_t)ib_config->priority_sl;
+    memset(ib_iface->config.priority_sls, ib_iface->config.sl, UCT_IB_SL_NUM);
+
+    for (i = 0; i < ib_config->priority_sls.count; ++i) {
+        ucs_assert(ib_config->priority_sls.priority_sls[i] < UCT_IB_SL_NUM);
+        ib_iface->config.priority_sls[i] =
+                (uint8_t)ib_config->priority_sls.priority_sls[i];
+    }
 }
 
 void uct_ib_iface_set_configured_sls(uct_ib_iface_t *ib_iface,
                                      const uct_ib_iface_config_t *ib_config)
 {
     uct_ib_iface_set_reverse_sl(ib_iface, ib_config);
-    uct_ib_iface_set_priority_sl(ib_iface, ib_config);
+    uct_ib_iface_set_priority_sls(ib_iface, ib_config);
 }
 
 UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
@@ -1460,11 +1467,13 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     /* initialize to invalid value */
     self->config.sl                 = UCT_IB_SL_NUM;
     self->config.reverse_sl         = UCT_IB_SL_NUM;
-    self->config.priority_sl        = UCT_IB_SL_NUM;
     self->config.hop_limit          = config->hop_limit;
     self->release_desc.cb           = uct_ib_iface_release_desc;
     self->config.qp_type            = init_attr->qp_type;
     self->config.flid_enabled       = config->flid_enabled;
+
+    memset(self->config.priority_sls, UCT_IB_SL_NUM, UCT_IB_SL_NUM);
+
     uct_ib_iface_set_path_mtu(self, config);
 
     if (ucs_derived_of(worker, uct_priv_worker_t)->thread_mode == UCS_THREAD_MODE_MULTI) {
@@ -1868,6 +1877,6 @@ uint8_t uct_ib_iface_get_ep_sl(const uct_ib_iface_t *iface, const uct_ep_params_
 {
     return (params->field_mask & UCT_EP_PARAM_FIELD_PRIORITY) &&
                            (params->priority > 0) ?
-                   iface->config.priority_sl :
+                   iface->config.priority_sls[params->priority] :
                    iface->config.sl;
 }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -195,6 +195,9 @@ struct uct_ib_iface_config {
 
     /* IB reverse SL (default: AUTO - same value as sl) */
     unsigned long           reverse_sl;
+
+    /* IB high priority SL (default: AUTO - same value as sl) */
+    unsigned long           priority_sl;
 };
 
 
@@ -299,6 +302,7 @@ struct uct_ib_iface {
         uint8_t               port_num;
         uint8_t               sl;
         uint8_t               reverse_sl;
+        uint8_t               priority_sl;
         uint8_t               traffic_class;
         uint8_t               hop_limit;
         uint8_t               qp_type;
@@ -591,6 +595,8 @@ void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
 
 uint16_t uct_ib_iface_resolve_remote_flid(uct_ib_iface_t *iface,
                                           const union ibv_gid *gid);
+
+uint8_t uct_ib_iface_get_ep_sl(const uct_ib_iface_t *iface, const uct_ep_params_t *params);
 
 #define UCT_IB_IFACE_FMT \
     "%s:%d/%s"

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -197,7 +197,7 @@ struct uct_ib_iface_config {
     unsigned long           reverse_sl;
 
     /* IB high priority SL (default: AUTO - same value as sl) */
-    unsigned long           priority_sl;
+    UCS_CONFIG_ARRAY_FIELD(u_int8_t, priority_sls) priority_sls;
 };
 
 
@@ -302,7 +302,7 @@ struct uct_ib_iface {
         uint8_t               port_num;
         uint8_t               sl;
         uint8_t               reverse_sl;
-        uint8_t               priority_sl;
+        uint8_t               priority_sls[UCT_IB_SL_NUM];
         uint8_t               traffic_class;
         uint8_t               hop_limit;
         uint8_t               qp_type;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -590,8 +590,8 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface,
 
 uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
 
-void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
-                                 const uct_ib_iface_config_t *ib_config);
+void uct_ib_iface_set_configured_sls(uct_ib_iface_t *ib_iface,
+                                     const uct_ib_iface_config_t *ib_config);
 
 uint16_t uct_ib_iface_resolve_remote_flid(uct_ib_iface_t *iface,
                                           const union ibv_gid *gid);

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -559,13 +559,15 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                             const union ibv_gid *gid,
                                             uint8_t gid_index,
                                             unsigned path_index,
-                                            struct ibv_ah_attr *ah_attr);
+                                            struct ibv_ah_attr *ah_attr,
+                                            uint8_t sl);
 
 void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
                                          const uct_ib_address_t *ib_addr,
                                          unsigned path_index,
                                          struct ibv_ah_attr *ah_attr,
-                                         enum ibv_mtu *path_mtu);
+                                         enum ibv_mtu *path_mtu,
+                                         uint8_t sl);
 
 ucs_status_t uct_ib_iface_pre_arm(uct_ib_iface_t *iface);
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -169,6 +169,7 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
     uct_ib_mlx5_base_av_t av;
     struct mlx5_grh_av grh_av;
     unsigned path_index;
+    uint8_t sl;
 
     ucs_trace_func("");
 
@@ -176,10 +177,12 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
     ib_addr    = (const uct_ib_address_t *)params->dev_addr;
     if_addr    = (const uct_dc_mlx5_iface_addr_t *)params->iface_addr;
     path_index = UCT_EP_PARAMS_GET_PATH_INDEX(params);
+    sl         = uct_ib_iface_get_ep_sl(&iface->super.super.super, params);
 
     status = uct_ud_mlx5_iface_get_av(&iface->super.super.super,
                                       &iface->ud_common, ib_addr, path_index,
-                                      "DC ep create", &av, &grh_av, &is_global);
+                                      "DC ep create", &av, &grh_av, &is_global,
+                                      sl);
     if (status != UCS_OK) {
         return UCS_ERR_INVALID_ADDR;
     }
@@ -189,7 +192,7 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
                              path_index, &grh_av);
     } else {
         return UCS_CLASS_NEW(uct_dc_mlx5_ep_t, ep_p, iface, if_addr, &av,
-                             path_index);
+                             path_index, sl);
     }
 }
 

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -77,6 +77,7 @@ struct uct_dc_mlx5_ep {
     uct_rc_fc_t           fc;
     uct_dc_mlx5_base_av_t av;
     uint8_t               dci_channel_index;
+    uint8_t               sl;
 };
 
 typedef struct {
@@ -91,7 +92,7 @@ typedef struct {
 
 
 UCS_CLASS_DECLARE(uct_dc_mlx5_ep_t, uct_dc_mlx5_iface_t *, const uct_dc_mlx5_iface_addr_t *,
-                  uct_ib_mlx5_base_av_t *, uint8_t);
+                  uct_ib_mlx5_base_av_t *, uint8_t, uint8_t);
 
 UCS_CLASS_DECLARE(uct_dc_mlx5_grh_ep_t, uct_dc_mlx5_iface_t *,
                   const uct_dc_mlx5_iface_addr_t *,

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -371,7 +371,8 @@ ucs_status_t uct_ib_mlx5_get_compact_av(uct_ib_iface_t *iface, int *compact_av)
         return status;
     }
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, 0, &ah_attr, &path_mtu);
+    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, 0, &ah_attr, &path_mtu,
+                                        iface->config.sl);
     ah_attr.is_global = iface->config.force_global_addr;
     status = uct_ib_iface_create_ah(iface, &ah_attr, "compact AV check", &ah);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -1065,7 +1065,7 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
             goto out;
         }
 
-        uct_ib_iface_set_reverse_sl(iface, ib_config);
+        uct_ib_iface_set_configured_sls(iface, ib_config);
         return status;
     }
 
@@ -1086,7 +1086,7 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
         goto out;
     }
 
-    uct_ib_iface_set_reverse_sl(iface, ib_config);
+    uct_ib_iface_set_configured_sls(iface, ib_config);
 
 out:
     return status;

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -424,8 +424,7 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
                           mlx5_av.hop_limit);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.src_addr_index,
                           ah_attr->grh.sgid_index);
-        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
-                          iface->super.super.config.sl);
+        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio, ah_attr->sl);
         if (uct_ib_iface_is_roce_v2(&iface->super.super)) {
             ucs_assert(ah_attr->dlid >= UCT_IB_ROCE_UDP_SRC_PORT_BASE);
             UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.udp_sport,
@@ -441,8 +440,7 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.rlid, ah_attr->dlid);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.mlid,
                           ah_attr->src_path_bits & 0x7f);
-        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl,
-                          iface->super.super.config.sl);
+        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl, ah_attr->sl);
 
         if (ah_attr->is_global) {
             UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.src_addr_index,

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -802,8 +802,6 @@ uct_rc_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
     ah_attr.sl = ep->super.sl;
 
-    ucs_warn("PRIORITY SL: %u", ep->super.sl);
-
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         /* For HW TM we need 2 QPs, one of which will be used by the device for
          * RNDV offload (for issuing RDMA reads and sending RNDV ACK). No WQEs

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -798,7 +798,7 @@ uct_rc_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
 
     uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr,
                                         ep->super.path_index, &ah_attr,
-                                        &path_mtu);
+                                        &path_mtu, ep->super.sl);
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
     ah_attr.sl = ep->super.sl;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_ep.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_ep.c
@@ -800,6 +800,9 @@ uct_rc_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
                                         ep->super.path_index, &ah_attr,
                                         &path_mtu);
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
+    ah_attr.sl = ep->super.sl;
+
+    ucs_warn("PRIORITY SL: %u", ep->super.sl);
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         /* For HW TM we need 2 QPs, one of which will be used by the device for

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -827,6 +827,11 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
                                          &mlx5_config->super,
                                          &rc_config->super);
 
+    self->super.super.config.priority_sl = (rc_config->super.priority_sl ==
+                                            UCS_ULUNITS_AUTO) ?
+                                                   self->super.super.config.sl :
+                                                   rc_config->super.priority_sl;
+
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -827,11 +827,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
                                          &mlx5_config->super,
                                          &rc_config->super);
 
-    self->super.super.config.priority_sl = (rc_config->super.priority_sl ==
-                                            UCS_ULUNITS_AUTO) ?
-                                                   self->super.super.config.sl :
-                                                   rc_config->super.priority_sl;
-
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -147,8 +147,12 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
         return status;
     }
 
+
     self->path_index = UCT_EP_PARAMS_GET_PATH_INDEX(params);
     self->flags      = 0;
+    self->sl         = uct_ib_iface_get_ep_sl(&iface->super, params);
+
+    ucs_warn("EP PRIORITY: %u, SELECTED_SL: %u", params->priority, self->sl);
 
     status = uct_rc_fc_init(&self->fc, iface UCS_STATS_ARG(self->super.stats));
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -147,12 +147,9 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
         return status;
     }
 
-
     self->path_index = UCT_EP_PARAMS_GET_PATH_INDEX(params);
     self->flags      = 0;
     self->sl         = uct_ib_iface_get_ep_sl(&iface->super, params);
-
-    ucs_warn("EP PRIORITY: %u, SELECTED_SL: %u", params->priority, self->sl);
 
     status = uct_rc_fc_init(&self->fc, iface UCS_STATS_ARG(self->super.stats));
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -221,6 +221,7 @@ struct uct_rc_ep {
     uint16_t            atomic_mr_offset;
     uint8_t             path_index;
     uint8_t             flags;
+    uint8_t             sl;
 };
 
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -640,6 +640,7 @@ uct_rc_verbs_ep_connect_to_ep_v2(uct_ep_h tl_ep,
                                         ep->super.path_index, &ah_attr,
                                         &path_mtu);
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
+    ah_attr.sl = ep->super.sl;
 
     qp_num = uct_ib_unpack_uint24(rc_addr->super.qp_num);
     status = uct_rc_iface_qp_connect(iface, ep->qp, qp_num, &ah_attr, path_mtu);

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -638,7 +638,7 @@ uct_rc_verbs_ep_connect_to_ep_v2(uct_ep_h tl_ep,
 
     uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
                                         ep->super.path_index, &ah_attr,
-                                        &path_mtu);
+                                        &path_mtu, ep->super.sl);
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
     ah_attr.sl = ep->super.sl;
 

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -298,7 +298,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     self->super.config.fence_mode        = (uct_rc_fence_mode_t)config->super.super.fence_mode;
     self->super.progress                 = uct_rc_verbs_iface_progress;
     self->super.super.config.sl          = uct_ib_iface_config_select_sl(ib_config);
-    uct_ib_iface_set_reverse_sl(&self->super.super, ib_config);
+
+    uct_ib_iface_set_configured_sls(&self->super.super, ib_config);
 
     if ((config->super.super.fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         (config->super.super.fence_mode == UCT_RC_FENCE_MODE_AUTO)) {

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -636,7 +636,8 @@ static ucs_status_t
 uct_ud_mlx5_iface_unpack_peer_address(uct_ud_iface_t *ud_iface,
                                       const uct_ib_address_t *ib_addr,
                                       const uct_ud_iface_addr_t *if_addr,
-                                      int path_index, void *address_p)
+                                      int path_index, void *address_p,
+                                      uint8_t sl)
 {
     uct_ud_mlx5_iface_t *iface                  =
         ucs_derived_of(ud_iface, uct_ud_mlx5_iface_t);
@@ -650,7 +651,7 @@ uct_ud_mlx5_iface_unpack_peer_address(uct_ud_iface_t *ud_iface,
     status = uct_ud_mlx5_iface_get_av(&ud_iface->super, &iface->ud_mlx5_common,
                                       ib_addr, path_index, "UD mlx5 connect",
                                       &peer_address->av, &peer_address->grh_av,
-                                      &is_global);
+                                      &is_global, sl);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/ud/accel/ud_mlx5_common.c
+++ b/src/uct/ib/ud/accel/ud_mlx5_common.c
@@ -37,7 +37,7 @@ uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
                          uct_ud_mlx5_iface_common_t *ud_common_iface,
                          const uct_ib_address_t *ib_addr, unsigned path_index,
                          const char *usage, uct_ib_mlx5_base_av_t *base_av,
-                         struct mlx5_grh_av *grh_av, int *is_global)
+                         struct mlx5_grh_av *grh_av, int *is_global, uint8_t sl)
 {
     ucs_status_t        status;
     struct ibv_ah      *ah;
@@ -46,7 +46,7 @@ uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
     enum ibv_mtu        path_mtu;
 
     uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, path_index, &ah_attr,
-                                        &path_mtu);
+                                        &path_mtu, sl);
     status = uct_ib_iface_create_ah(iface, &ah_attr, usage, &ah);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/ud/accel/ud_mlx5_common.h
+++ b/src/uct/ib/ud/accel/ud_mlx5_common.h
@@ -35,6 +35,6 @@ uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
                          uct_ud_mlx5_iface_common_t *ud_common_iface,
                          const uct_ib_address_t *ib_addr, unsigned path_index,
                          const char *usage, uct_ib_mlx5_base_av_t *base_av,
-                         struct mlx5_grh_av *grh_av, int *is_global);
+                         struct mlx5_grh_av *grh_av, int *is_global, uint8_t sl);
 
 #endif

--- a/src/uct/ib/ud/base/ud_ep.h
+++ b/src/uct/ib/ud/base/ud_ep.h
@@ -261,6 +261,7 @@ struct uct_ud_ep {
     uint8_t               path_index;
     ucs_wtimer_t          timer;
     ucs_time_t            close_time;   /* timestamp of closure */
+    uint8_t               sl;
     UCS_STATS_NODE_DECLARE(stats)
     UCT_UD_EP_HOOK_DECLARE(timer_hook)
 #if ENABLE_DEBUG_DATA

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -45,11 +45,11 @@ ucs_status_t
 uct_ud_iface_cep_get_peer_address(uct_ud_iface_t *iface,
                                   const uct_ib_address_t *ib_addr,
                                   const uct_ud_iface_addr_t *if_addr,
-                                  int path_index, void *address_p)
+                                  int path_index, void *address_p, uint8_t sl)
 {
     ucs_status_t status = uct_ud_iface_unpack_peer_address(iface, ib_addr,
                                                            if_addr, path_index,
-                                                           address_p);
+                                                           address_p, sl);
 
     if (status != UCS_OK) {
         ucs_diag("iface %p: failed to get peer address", iface);
@@ -69,14 +69,14 @@ uct_ud_iface_cep_ep_queue_type(uct_ud_ep_t *ep)
 ucs_status_t
 uct_ud_iface_cep_get_conn_sn(uct_ud_iface_t *iface,
                              const uct_ib_address_t *ib_addr,
-                             const uct_ud_iface_addr_t *if_addr,
-                             int path_index, uct_ud_ep_conn_sn_t *conn_sn_p)
+                             const uct_ud_iface_addr_t *if_addr, int path_index,
+                             uct_ud_ep_conn_sn_t *conn_sn_p, uint8_t sl)
 {
     void *peer_address = ucs_alloca(iface->conn_match_ctx.address_length);
     ucs_status_t status;
-    
+
     status = uct_ud_iface_cep_get_peer_address(iface, ib_addr, if_addr,
-                                               path_index, peer_address);
+                                               path_index, peer_address, sl);
     if (status != UCS_OK) {
         return status;
     } 
@@ -101,7 +101,8 @@ uct_ud_iface_cep_insert_ep(uct_ud_iface_t *iface,
     queue_type   = uct_ud_iface_cep_ep_queue_type(ep);
     peer_address = ucs_alloca(iface->conn_match_ctx.address_length);
     status       = uct_ud_iface_cep_get_peer_address(iface, ib_addr, if_addr,
-                                                     path_index, peer_address);
+                                                     path_index, peer_address,
+                                                     ep->sl);
     if (status != UCS_OK) {
         return status;
     }
@@ -131,9 +132,9 @@ uct_ud_ep_t *uct_ud_iface_cep_get_ep(uct_ud_iface_t *iface,
     ucs_status_t status;
 
     peer_address = ucs_alloca(iface->conn_match_ctx.address_length);
-    status       = uct_ud_iface_cep_get_peer_address(iface, ib_addr,
-                                                     if_addr, path_index,
-                                                     peer_address);
+    status       = uct_ud_iface_cep_get_peer_address(iface, ib_addr, if_addr,
+                                                     path_index, peer_address,
+                                                     iface->super.config.sl);
     if (status != UCS_OK) {
         return NULL;
     }

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -115,7 +115,8 @@ typedef struct uct_ud_iface_ops {
     ucs_status_t              (*unpack_peer_address)(uct_ud_iface_t *iface,
                                                      const uct_ib_address_t *ib_addr,
                                                      const uct_ud_iface_addr_t *if_addr,
-                                                     int path_index, void *address_p);
+                                                     int path_index, void *address_p,
+                                                     uint8_t sl);
     void*                     (*ep_get_peer_address)(uct_ud_ep_t *ud_ep);
     size_t                    (*get_peer_address_length)();
     const char*               (*peer_address_str)(const uct_ud_iface_t *iface,
@@ -322,8 +323,8 @@ void uct_ud_iface_cep_cleanup(uct_ud_iface_t *iface);
 ucs_status_t
 uct_ud_iface_cep_get_conn_sn(uct_ud_iface_t *iface,
                              const uct_ib_address_t *ib_addr,
-                             const uct_ud_iface_addr_t *if_addr,
-                             int path_index, uct_ud_ep_conn_sn_t *conn_sn_p);
+                             const uct_ud_iface_addr_t *if_addr, int path_index,
+                             uct_ud_ep_conn_sn_t *conn_sn_p, uint8_t sl);
 
 ucs_status_t uct_ud_iface_cep_insert_ep(uct_ud_iface_t *iface,
                                         const uct_ib_address_t *ib_addr,
@@ -517,12 +518,13 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_ud_iface_unpack_peer_address(uct_ud_iface_t *iface,
                                  const uct_ib_address_t *ib_addr,
                                  const uct_ud_iface_addr_t *if_addr,
-                                 unsigned path_index, void *address_p)
+                                 unsigned path_index, void *address_p,
+                                 uint8_t sl)
 {
     uct_ud_iface_ops_t *ud_ops = ucs_derived_of(iface->super.ops,
                                                 uct_ud_iface_ops_t);
     return ud_ops->unpack_peer_address(iface, ib_addr, if_addr,
-                                       path_index, address_p);
+                                       path_index, address_p, sl);
 }
 
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -544,7 +544,8 @@ static ucs_status_t
 uct_ud_verbs_iface_unpack_peer_address(uct_ud_iface_t *iface,
                                        const uct_ib_address_t *ib_addr,
                                        const uct_ud_iface_addr_t *if_addr,
-                                       int path_index, void *address_p)
+                                       int path_index, void *address_p,
+                                       uint8_t sl)
 {
     uct_ib_iface_t *ib_iface                     = &iface->super;
     uct_ud_verbs_ep_peer_address_t *peer_address =
@@ -556,7 +557,7 @@ uct_ud_verbs_iface_unpack_peer_address(uct_ud_iface_t *iface,
     memset(peer_address, 0, sizeof(*peer_address));
 
     uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, path_index,
-                                        &ah_attr, &path_mtu);
+                                        &ah_attr, &path_mtu, sl);
     status = uct_ib_iface_create_ah(ib_iface, &ah_attr, "UD verbs connect",
                                     &peer_address->ah);
     if (status != UCS_OK) {
@@ -592,7 +593,7 @@ int uct_ud_verbs_ep_is_connected(const uct_ep_h tl_ep,
 
     ib_addr = (uct_ib_address_t*)params->device_addr;
     uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, ep->super.path_index,
-                                        &ah_attr, &path_mtu);
+                                        &ah_attr, &path_mtu, ep->super.sl);
 
     status = uct_ib_device_get_ah_cached(uct_ib_iface_device(ib_iface),
                                          &ah_attr, &ah);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -758,7 +758,7 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
                               worker, params, config, &init_attr);
 
     self->super.super.config.sl = uct_ib_iface_config_select_sl(&config->super);
-    uct_ib_iface_set_reverse_sl(&self->super.super, &config->super);
+    uct_ib_iface_set_configured_sls(&self->super.super, &config->super);
 
     memset(&self->tx.wr_inl, 0, sizeof(self->tx.wr_inl));
     self->tx.wr_inl.opcode            = IBV_WR_SEND;


### PR DESCRIPTION
## What
Adding support for priority uct eps in IB

## Why ?
Support for the new priority messages feature: https://github.com/openucx/ucx/pull/9504 

## How ?
The user will set a dedicated SL by setting `UCX_IB_HIGH_PRIORITY_SL` env/config, UCP layer will create additional UCT priority eps in the supported transports.