### PR TITLE
UCS/BITMAP/TEST: Initial implementation of dynamic bitmap structure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -105,7 +105,8 @@ ForEachMacros: ['_UCS_BITMAP_FOR_EACH_WORD',
 		'ucs_lru_for_each']
 StatementMacros : []
 TypenameMacros: ['khash_t',
-                 'ucs_array_s']
+                 'ucs_array_s',
+                 'ucs_static_bitmap_s']
 WhitespaceSensitiveMacros: []
 
 # CPP

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -98,6 +98,7 @@ noinst_HEADERS = \
 	config/ucm_opts.h \
 	datastruct/arbiter.h \
 	datastruct/bitmap.h \
+	datastruct/dynamic_bitmap.h \
 	datastruct/frag_list.h \
         datastruct/lru.h \
 	datastruct/mpmc.h \
@@ -110,6 +111,7 @@ noinst_HEADERS = \
 	datastruct/conn_match.h \
 	datastruct/ptr_map.h \
 	datastruct/ptr_map.inl \
+	datastruct/static_bitmap.h \
 	datastruct/usage_tracker.h \
 	debug/assert.h \
 	debug/debug_int.h \

--- a/src/ucs/datastruct/dynamic_bitmap.h
+++ b/src/ucs/datastruct/dynamic_bitmap.h
@@ -1,0 +1,151 @@
+
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_DYNAMIC_BITMAP_H_
+#define UCS_DYNAMIC_BITMAP_H_
+
+#include <ucs/datastruct/array.h>
+#include <ucs/datastruct/bitmap.h>
+#include <ucs/sys/math.h>
+
+BEGIN_C_DECLS
+
+/* Variable-size dynamic bitmap, backed by ucs_array. */
+UCS_ARRAY_DECLARE_TYPE(ucs_dynamic_bitmap_t, size_t, ucs_bitmap_word_t);
+
+
+/**
+ * Initilaize a dynamic bitmap.
+ *
+ * @param [out] bitmap   Bitmap to initialize.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_dynamic_bitmap_init(ucs_dynamic_bitmap_t *bitmap)
+{
+    ucs_array_init_dynamic(bitmap);
+}
+
+
+/**
+ * Cleanup a dynamic bitmap and release its memory.
+ *
+ * @param [inout] bitmap   Bitmap to clean up.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_dynamic_bitmap_cleanup(ucs_dynamic_bitmap_t *bitmap)
+{
+    ucs_array_cleanup_dynamic(bitmap)
+}
+
+
+/**
+ * Reset all bitmap bits to 0.
+ *
+ * @param [inout] bitmap   Bitmap to reset.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_dynamic_bitmap_reset_all(ucs_dynamic_bitmap_t *bitmap)
+{
+    ucs_bitmap_bits_reset_all(ucs_array_begin(bitmap),
+                              ucs_array_length(bitmap));
+}
+
+
+/**
+ * Reserve space in a bitmap, setting the newly allocated bits to 0.
+ *
+ * @param [inout] bitmap   Bitmap to reserve space in.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_dynamic_bitmap_reserve(ucs_dynamic_bitmap_t *bitmap, size_t num_bits)
+{
+    size_t num_words = ucs_div_round_up(num_bits, UCS_BITMAP_BITS_IN_WORD);
+
+    if (num_words > ucs_array_length(bitmap)) {
+        ucs_array_resize(bitmap, num_words, 0,
+                         ucs_fatal("failed to reserve space in a bitmap"));
+    }
+}
+
+
+/* Helper function to check if a bit_index is within the allocated size of the
+   bitmap */
+static UCS_F_ALWAYS_INLINE int
+ucs_dynamic_bitmap_is_in_range(const ucs_dynamic_bitmap_t *bitmap,
+                               size_t bit_index)
+{
+    return bit_index < (UCS_BITMAP_BITS_IN_WORD * ucs_array_length(bitmap));
+}
+
+
+/**
+ * Get the value of a bit in the bitmap.
+ *
+ * @param [in] bitmap    Read value from this bitmap.
+ * @param [in] bit_index Bit index to read.
+ *
+ * @return Bit value (0 or 1)
+ */
+static UCS_F_ALWAYS_INLINE size_t
+ucs_dynamic_bitmap_get(const ucs_dynamic_bitmap_t *bitmap, size_t bit_index)
+{
+    if (!ucs_dynamic_bitmap_is_in_range(bitmap, bit_index)) {
+        return 0;
+    }
+
+    return ucs_bitmap_bits_get(ucs_array_begin(bitmap),
+                               ucs_array_length(bitmap), bit_index);
+}
+
+
+/**
+ * Set a bit in the bitmap to 1.
+ *
+ * @param [inout] bitmap    Set value in this bitmap.
+ * @param [in]    bit_index Bit index to set.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_dynamic_bitmap_set(ucs_dynamic_bitmap_t *bitmap, size_t bit_index)
+{
+    ucs_dynamic_bitmap_reserve(bitmap, bit_index + 1);
+    ucs_bitmap_bits_set(ucs_array_begin(bitmap), ucs_array_length(bitmap),
+                        bit_index);
+}
+
+
+/**
+ * Set a bit in the bitmap to 0.
+ *
+ * @param [inout] bitmap    Set value in this bitmap.
+ * @param [in]    bit_index Bit index to set.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_dynamic_bitmap_reset(ucs_dynamic_bitmap_t *bitmap, size_t bit_index)
+{
+    ucs_dynamic_bitmap_reserve(bitmap, bit_index + 1);
+    ucs_bitmap_bits_reset(ucs_array_begin(bitmap), ucs_array_length(bitmap),
+                          bit_index);
+}
+
+
+/**
+ * Check whether all bits of a given bitmap are set to 0.
+ *
+ * @param [in] bitmap Check bits of this bitmap.
+ *
+ * @return Whether this bitmap consists only of bits set to 0.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_dynamic_bitmap_is_zero(const ucs_dynamic_bitmap_t *bitmap)
+{
+    return ucs_bitmap_bits_is_zero(ucs_array_begin(bitmap),
+                                   ucs_array_length(bitmap));
+}
+
+END_C_DECLS
+
+#endif

--- a/src/ucs/datastruct/static_bitmap.h
+++ b/src/ucs/datastruct/static_bitmap.h
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCS_STATIC_BITMAP_H_
+#define UCS_STATIC_BITMAP_H_
+
+#include "bitmap.h"
+
+#include <ucs/debug/assert.h>
+#include <ucs/sys/math.h>
+#include <ucs/sys/preprocessor.h>
+
+BEGIN_C_DECLS
+
+
+/**
+ * Define a static bitmap structure.
+ *
+ * @param _num_bits Number of bits in the bitmap.
+ */
+#define ucs_static_bitmap_s(_num_bits) \
+    struct { \
+        ucs_bitmap_word_t \
+                bits[ucs_div_round_up(_num_bits, UCS_BITMAP_BITS_IN_WORD)]; \
+    }
+
+
+/**
+ * Initialize a static bitmap structure to zero.
+ */
+#define UCS_STATIC_BITMAP_ZERO_INITIALIZER \
+    { \
+        .bits = { 0 } \
+    }
+
+
+/**
+ * Get the number of words in a given bitmap
+ *
+ * @param _bitmap Bitmap variable to get words number
+ *
+ * @return Number of words
+ */
+#define UCS_STATIC_BITMAP_NUM_WORDS(_bitmap) \
+    ucs_static_array_size((_bitmap).bits)
+
+
+/* Helper macro to pass bitmap words array and number of words to a function. */
+#define UCS_STATIC_BITMAP_BITS_ARGS(_bitmap_ptr) \
+    ((ucs_bitmap_word_t*)(_bitmap_ptr)->bits), \
+            UCS_STATIC_BITMAP_NUM_WORDS(*(_bitmap_ptr))
+
+
+/* Helper macro to pass bitmap words as a constant array and number of words to
+   a function. */
+#define UCS_STATIC_BITMAP_BITS_CARGS(_bitmap_ptr) \
+    ((const ucs_bitmap_word_t*)(_bitmap_ptr)->bits), \
+            UCS_STATIC_BITMAP_NUM_WORDS(*(_bitmap_ptr))
+
+
+/* Helper macro to a function on a bitmap words array and number of words, while
+   converting the input argument from an r-value to an l-value */
+#define _UCS_STATIC_BITMAP_FUNC_CALL(_uid, _bitmap, _func, ...) \
+    ({ \
+        ucs_typeof(_bitmap) _b_##_uid = (_bitmap); \
+        \
+        _func(UCS_STATIC_BITMAP_BITS_CARGS(&_b_##_uid), ##__VA_ARGS__); \
+    })
+#define UCS_STATIC_BITMAP_FUNC_CALL(_uid, _bitmap, _func, ...) \
+    _UCS_STATIC_BITMAP_FUNC_CALL(_uid, _bitmap, _func, ##__VA_ARGS__)
+
+
+/**
+ * Reset all bitmap bits to 0.
+ *
+ * @param [inout] _bitmap_ptr   Bitmap to reset.
+ */
+#define UCS_STATIC_BITMAP_RESET_ALL(_bitmap_ptr) \
+    ucs_bitmap_bits_reset_all(UCS_STATIC_BITMAP_BITS_ARGS(_bitmap_ptr))
+
+
+/**
+ * Set all bitmap bits to 1.
+ *
+ * @param [inout] _bitmap_ptr   Bitmap to set to 1.
+ */
+#define UCS_STATIC_BITMAP_SET_ALL(_bitmap_ptr) \
+    ucs_bitmap_bits_set_all(UCS_STATIC_BITMAP_BITS_ARGS(_bitmap_ptr))
+
+
+/**
+ * Get the value of a bit in the bitmap.
+ *
+ * @param _bitmap    Read value from this bitmap.
+ * @param _bit_index Bit index to read.
+ *
+ * @return Bit value (0 or 1)
+ */
+#define UCS_STATIC_BITMAP_GET(_bitmap, _bit_index) \
+    UCS_STATIC_BITMAP_FUNC_CALL(UCS_PP_UNIQUE_ID, _bitmap, \
+                                ucs_bitmap_bits_get, _bit_index)
+
+
+/**
+ * Set a bit in the bitmap to 1.
+ *
+ * @param _bitmap    Set value in this bitmap.
+ * @param _bit_index Bit index to set.
+ */
+#define UCS_STATIC_BITMAP_SET(_bitmap_ptr, _bit_index) \
+    ucs_bitmap_bits_set(UCS_STATIC_BITMAP_BITS_ARGS(_bitmap_ptr), _bit_index)
+
+
+/**
+ * Set a bit in the bitmap to 0.
+ *
+ * @param _bitmap    Set value in this bitmap.
+ * @param _bit_index Bit index to set.
+ */
+#define UCS_STATIC_BITMAP_RESET(_bitmap_ptr, _bit_index) \
+    ucs_bitmap_bits_reset(UCS_STATIC_BITMAP_BITS_ARGS(_bitmap_ptr), _bit_index)
+
+
+/**
+ * Check whether all bits of a given lvalue bitmap are set to 0.
+ *
+ * @param _bitmap Check bits of this bitmap.
+ *
+ * @return Whether this bitmap consists only of bits set to 0.
+ */
+#define UCS_STATIC_BITMAP_IS_ZERO(_bitmap) \
+    UCS_STATIC_BITMAP_FUNC_CALL(UCS_PP_UNIQUE_ID, _bitmap, \
+                                ucs_bitmap_bits_is_zero)
+
+END_C_DECLS
+
+#endif /* UCS_STATIC_BITMAP_H_ */

--- a/test/gtest/ucs/test_bitmap.cc
+++ b/test/gtest/ucs/test_bitmap.cc
@@ -6,6 +6,8 @@
 
 #include <common/test.h>
 #include <ucs/datastruct/bitmap.h>
+#include <ucs/datastruct/dynamic_bitmap.h>
+#include <ucs/datastruct/static_bitmap.h>
 
 class test_ucs_bitmap : public ucs::test {
 public:
@@ -251,7 +253,7 @@ UCS_TEST_F(test_ucs_bitmap, test_for_each_bit)
         i++;
         bits[bit_index]++;
     }
-    
+
     EXPECT_EQ(i, 4);
     EXPECT_EQ(bits[0], 1);
     EXPECT_EQ(bits[25], 1);
@@ -261,7 +263,7 @@ UCS_TEST_F(test_ucs_bitmap, test_for_each_bit)
     /* Test FOREACH on an empty bitmap */
     UCS_BITMAP_CLEAR(&bitmap);
     i = 0;
-    
+
     UCS_BITMAP_FOR_EACH_BIT(bitmap, bit_index) {
         i++;
     }
@@ -288,4 +290,81 @@ UCS_TEST_F(test_ucs_bitmap, test_for_each_bit_single_word) {
 UCS_TEST_F(test_ucs_bitmap, test_compose) {
     /* The result is irrelevant, the code only needs to compile */
     UCS_BITMAP_AND(UCS_BITMAP_NOT(bitmap, 128), bitmap, 128);
+}
+
+class test_static_bitmap : public ucs::test {
+public:
+    virtual void init()
+    {
+        UCS_STATIC_BITMAP_RESET_ALL(&m_bitmap);
+    }
+
+protected:
+    using bitmap_t = ucs_static_bitmap_s(128);
+
+    void test_set_get_unset(uint64_t offset)
+    {
+        UCS_STATIC_BITMAP_SET(&m_bitmap, offset);
+        EXPECT_EQ(1, UCS_STATIC_BITMAP_GET(m_bitmap, offset));
+        EXPECT_EQ(m_bitmap.bits[offset >= UCS_BITMAP_BITS_IN_WORD],
+                  UCS_BIT(offset % 64));
+        EXPECT_EQ(0, m_bitmap.bits[offset < UCS_BITMAP_BITS_IN_WORD]);
+        EXPECT_FALSE(UCS_STATIC_BITMAP_IS_ZERO(m_bitmap));
+
+        UCS_STATIC_BITMAP_RESET(&m_bitmap, offset);
+        EXPECT_EQ(0, m_bitmap.bits[0]);
+        EXPECT_EQ(0, m_bitmap.bits[1]);
+        EXPECT_EQ(0, UCS_STATIC_BITMAP_GET(m_bitmap, offset));
+    }
+
+protected:
+    bitmap_t m_bitmap;
+};
+
+UCS_TEST_F(test_static_bitmap, test_get_set_clear)
+{
+    const uint64_t offset = 15;
+
+    EXPECT_EQ(0, m_bitmap.bits[0]);
+    EXPECT_EQ(0, m_bitmap.bits[1]);
+    EXPECT_EQ(0, UCS_STATIC_BITMAP_GET(m_bitmap, offset));
+
+    test_set_get_unset(offset);
+    test_set_get_unset(offset + 64);
+
+    UCS_STATIC_BITMAP_RESET_ALL(&m_bitmap);
+    for (int i = 0; i < 128; i++) {
+        EXPECT_EQ(0, UCS_STATIC_BITMAP_GET(m_bitmap, i));
+    }
+}
+
+class test_dynamic_bitmap : public ucs::test {
+public:
+    virtual void init()
+    {
+        ucs_dynamic_bitmap_init(&m_bitmap);
+    }
+
+    virtual void cleanup()
+    {
+        ucs_dynamic_bitmap_cleanup(&m_bitmap);
+    }
+
+protected:
+    ucs_dynamic_bitmap_t m_bitmap;
+};
+
+UCS_TEST_F(test_dynamic_bitmap, test_get_set_reset)
+{
+    const size_t bit_index = 1237;
+
+    EXPECT_TRUE(ucs_dynamic_bitmap_is_zero(&m_bitmap));
+
+    EXPECT_EQ(0, ucs_dynamic_bitmap_get(&m_bitmap, bit_index));
+    ucs_dynamic_bitmap_set(&m_bitmap, bit_index);
+    EXPECT_EQ(1, ucs_dynamic_bitmap_get(&m_bitmap, bit_index));
+    ucs_dynamic_bitmap_reset(&m_bitmap, bit_index);
+    EXPECT_EQ(0, ucs_dynamic_bitmap_get(&m_bitmap, bit_index));
+
+    EXPECT_TRUE(ucs_dynamic_bitmap_is_zero(&m_bitmap));
 }


### PR DESCRIPTION
## Why
Initial implementation of dynamic bitmap based on ucs_array and sharing common code with static bitmap.
Dynamic bitmap is needed for adding protocol variants (since total number of instantiated protocol variants is not known in advance)
