### PR TITLE
AZP/RELEASE: MVN publish wo rebulding jar

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -130,7 +130,7 @@ publish-release:
 	@make publish
 
 publish:
-	$(MVNCMD) deploy -DskipTests ${ARGS}
+	$(MVNCMD) deploy:deploy-file -Dfile=$(jarfile) -DskipTests ${ARGS}
 
 test:
 	$(MVNCMD) test -DargLine="-XX:OnError='cat hs_err_pid%p.log'"


### PR DESCRIPTION
## What
Specify the file to publish to skip rebuilding the jar file.

## Why
Maven publish target rebuilds the jar, effectively overriding any attempts to include ARM support.