### PR TITLE
UCP: set FLAG_PROTO_INITIALIZED before mtype_copy

### DIFF
--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -472,13 +472,13 @@ ucp_proto_rndv_put_mtype_copy_progress(uct_pending_req_t *uct_req)
     }
 
     ucp_proto_rndv_put_common_request_init(req);
+    req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     ucp_proto_rndv_mtype_copy(req, req->send.rndv.mdesc->ptr,
                               ucp_proto_rndv_mtype_get_req_memh(req),
                               uct_ep_get_zcopy,
                               ucp_proto_rndv_put_mtype_pack_completion,
                               "in from");
 
-    req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     return UCS_OK;
 }
 

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -324,12 +324,12 @@ ucp_proto_rndv_rkey_ptr_mtype_copy_progress(uct_pending_req_t *uct_req)
         return UCS_OK;
     }
 
+    req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     ucp_proto_rndv_mtype_copy(req, ppln_data->local_ptr, ppln_data->uct_memh,
                               uct_ep_get_zcopy,
                               ucp_proto_rndv_rkey_ptr_mtype_copy_completion,
                               "in from");
 
-    req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What
set the UCP_REQUEST_FLAG_PROTO_INITIALIZE flag in `ucp_proto_rndv_put_mtype_copy_progress()` before calling `ucp_proto_rndv_mtype_copy()`. In case the mytpe_pack/copy operation reports immediate completion, the progress function invoked later might fail because the UCP_REQUEST_FLAG_PROTO_INITIALIZED flag has not yet been set on the request otherwise

## Why ?
Fixes issue #9570
