### PR TITLE
UCT: Add uct_iface_query_v2

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -274,9 +274,6 @@ typedef void         (*uct_iface_close_func_t)(uct_iface_h iface);
 typedef ucs_status_t (*uct_iface_query_func_t)(uct_iface_h iface,
                                                uct_iface_attr_t *iface_attr);
 
-typedef ucs_status_t (*uct_iface_query_v2_func_t)(
-        uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
-
 /* interface - connection establishment */
 
 typedef ucs_status_t (*uct_iface_get_device_address_func_t)(uct_iface_h iface,

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -274,6 +274,9 @@ typedef void         (*uct_iface_close_func_t)(uct_iface_h iface);
 typedef ucs_status_t (*uct_iface_query_func_t)(uct_iface_h iface,
                                                uct_iface_attr_t *iface_attr);
 
+typedef ucs_status_t (*uct_iface_query_v2_func_t)(
+        uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
+
 /* interface - connection establishment */
 
 typedef ucs_status_t (*uct_iface_get_device_address_func_t)(uct_iface_h iface,

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1146,6 +1146,8 @@ typedef enum {
 
 } uct_iface_attr_field_t;
 
+#define UCT_IFACE_ATTR_V1_BITMASK UCS_MASK(46)
+
 typedef struct uct_iface_attr_v2 {
     /**
      * Mask of valid fields in this structure, using bits from

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1132,17 +1132,17 @@ typedef enum {
     UCT_IFACE_ATTR_FIELD_CAP_FLAGS                     = UCS_BIT(33),
     UCT_IFACE_ATTR_FIELD_CAP_EVENT_FLAGS               = UCS_BIT(34),
 
-    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN               = UCS_BIT(43),
-    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN                = UCS_BIT(44),
-    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN                   = UCS_BIT(206),
-    UCT_IFACE_ATTR_FIELD_MAX_CONN_PRIV                 = UCS_BIT(46),
-    UCT_IFACE_ATTR_FIELD_LISTEN_SOCKADDR               = UCS_BIT(47),
-    UCT_IFACE_ATTR_FIELD_OVERHEAD                      = UCS_BIT(48),
-    UCT_IFACE_ATTR_FIELD_BANDWIDTH                     = UCS_BIT(49),
-    UCT_IFACE_ATTR_FIELD_LATENCY                       = UCS_BIT(50),
-    UCT_IFACE_ATTR_FIELD_PRIORITY                      = UCS_BIT(51),
-    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS                   = UCS_BIT(52),
-    UCT_IFACE_ATTR_FIELD_DEV_NUM_PATHS                 = UCS_BIT(53),
+    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN               = UCS_BIT(35),
+    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN                = UCS_BIT(36),
+    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN                   = UCS_BIT(37),
+    UCT_IFACE_ATTR_FIELD_MAX_CONN_PRIV                 = UCS_BIT(38),
+    UCT_IFACE_ATTR_FIELD_LISTEN_SOCKADDR               = UCS_BIT(39),
+    UCT_IFACE_ATTR_FIELD_OVERHEAD                      = UCS_BIT(40),
+    UCT_IFACE_ATTR_FIELD_BANDWIDTH                     = UCS_BIT(41),
+    UCT_IFACE_ATTR_FIELD_LATENCY                       = UCS_BIT(42),
+    UCT_IFACE_ATTR_FIELD_PRIORITY                      = UCS_BIT(43),
+    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS                   = UCS_BIT(44),
+    UCT_IFACE_ATTR_FIELD_DEV_NUM_PATHS                 = UCS_BIT(45),
 
 } uct_iface_attr_field_t;
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1083,6 +1083,207 @@ ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result);
 
+typedef enum {
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_MAX_SHORT             = UCS_BIT(0),
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_MAX_BCOPY             = UCS_BIT(1),
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_MIN_ZCOPY             = UCS_BIT(2),
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_MAX_ZCOPY             = UCS_BIT(3),
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_OPT_ZCOPY_ALIGN       = UCS_BIT(4),
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_ALIGN_MTU             = UCS_BIT(5),
+    UCT_IFACE_ATTR_FIELD_CAP_PUT_ALIGN_MAX_IOV         = UCS_BIT(6),
+
+    UCT_IFACE_ATTR_FIELD_CAP_GET_MAX_SHORT             = UCS_BIT(7),
+    UCT_IFACE_ATTR_FIELD_CAP_GET_MAX_BCOPY             = UCS_BIT(8),
+    UCT_IFACE_ATTR_FIELD_CAP_GET_MIN_ZCOPY             = UCS_BIT(9),
+    UCT_IFACE_ATTR_FIELD_CAP_GET_MAX_ZCOPY             = UCS_BIT(10),
+    UCT_IFACE_ATTR_FIELD_CAP_GET_OPT_ZCOPY_ALIGN       = UCS_BIT(11),
+    UCT_IFACE_ATTR_FIELD_CAP_GET_ALIGN_MTU             = UCS_BIT(12),
+    UCT_IFACE_ATTR_FIELD_CAP_GET_ALIGN_MAX_IOV         = UCS_BIT(13),
+
+    UCT_IFACE_ATTR_FIELD_CAP_AM_MAX_SHORT              = UCS_BIT(14),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_MAX_BCOPY              = UCS_BIT(15),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_MIN_ZCOPY              = UCS_BIT(16),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_MAX_ZCOPY              = UCS_BIT(17),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_OPT_ZCOPY_ALIGN        = UCS_BIT(18),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_ALIGN_MTU              = UCS_BIT(19),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_ALIGN_MAX_HDR          = UCS_BIT(20),
+    UCT_IFACE_ATTR_FIELD_CAP_AM_ALIGN_MAX_IOV          = UCS_BIT(21),
+
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RECV_MIN_RECV         = UCS_BIT(22),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RECV_MAX_ZCOPY        = UCS_BIT(23),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RECV_MAX_IOV          = UCS_BIT(24),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RECV_MAX_OUTSTANDING  = UCS_BIT(25),
+
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_EAGER_MAX_SHORT       = UCS_BIT(22),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_EAGER_MAX_BCOPY       = UCS_BIT(23),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_EAGER_MAX_ZCOPY       = UCS_BIT(24),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_EAGER_MAX_IOV         = UCS_BIT(25),
+
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RNDV_MAX_ZCOPY        = UCS_BIT(26),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RNDV_MAX_HDR          = UCS_BIT(27),
+    UCT_IFACE_ATTR_FIELD_CAP_TAG_RNDV_MAX_IOV          = UCS_BIT(28),
+
+    UCT_IFACE_ATTR_FIELD_CAP_ATOMIC32_OP_FLAGS         = UCS_BIT(29),
+    UCT_IFACE_ATTR_FIELD_CAP_ATOMIC32_FOP_FLAGS        = UCS_BIT(30),
+
+    UCT_IFACE_ATTR_FIELD_CAP_ATOMIC64_OP_FLAGS         = UCS_BIT(31),
+    UCT_IFACE_ATTR_FIELD_CAP_ATOMIC64_FOP_FLAGS        = UCS_BIT(32),
+
+    UCT_IFACE_ATTR_FIELD_CAP_FLAGS                     = UCS_BIT(33),
+    UCT_IFACE_ATTR_FIELD_CAP_EVENT_FLAGS               = UCS_BIT(34),
+
+    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN               = UCS_BIT(43),
+    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN                = UCS_BIT(44),
+    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN                   = UCS_BIT(206),
+    UCT_IFACE_ATTR_FIELD_MAX_CONN_PRIV                 = UCS_BIT(46),
+    UCT_IFACE_ATTR_FIELD_LISTEN_SOCKADDR               = UCS_BIT(47),
+    UCT_IFACE_ATTR_FIELD_OVERHEAD                      = UCS_BIT(48),
+    UCT_IFACE_ATTR_FIELD_BANDWIDTH                     = UCS_BIT(49),
+    UCT_IFACE_ATTR_FIELD_LATENCY                       = UCS_BIT(50),
+    UCT_IFACE_ATTR_FIELD_PRIORITY                      = UCS_BIT(51),
+    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS                   = UCS_BIT(52),
+    UCT_IFACE_ATTR_FIELD_DEV_NUM_PATHS                 = UCS_BIT(53),
+
+} uct_iface_attr_field_t;
+
+typedef struct {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_iface_attr_field_t.
+     */
+    uint64_t          field_mask;
+
+    struct {
+        struct {
+            size_t           max_short;  /**< Maximal size for put_short */
+            size_t           max_bcopy;  /**< Maximal size for put_bcopy */
+            size_t           min_zcopy;  /**< Minimal size for put_zcopy (total
+                                              of @ref uct_iov_t::length of the
+                                              @a iov parameter) */
+            size_t           max_zcopy;  /**< Maximal size for put_zcopy (total
+                                              of @ref uct_iov_t::length of the
+                                              @a iov parameter) */
+            size_t           opt_zcopy_align; /**< Optimal alignment for zero-copy
+                                              buffer address */
+            size_t           align_mtu;       /**< MTU used for alignment */
+            size_t           max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref ::uct_ep_put_zcopy
+                                              @anchor uct_iface_attr_cap_put_max_iov */
+        } put;                           /**< Attributes for PUT operations */
+
+        struct {
+            size_t           max_short;  /**< Maximal size for get_short */
+            size_t           max_bcopy;  /**< Maximal size for get_bcopy */
+            size_t           min_zcopy;  /**< Minimal size for get_zcopy (total
+                                              of @ref uct_iov_t::length of the
+                                              @a iov parameter) */
+            size_t           max_zcopy;  /**< Maximal size for get_zcopy (total
+                                              of @ref uct_iov_t::length of the
+                                              @a iov parameter) */
+            size_t           opt_zcopy_align; /**< Optimal alignment for zero-copy
+                                              buffer address */
+            size_t           align_mtu;       /**< MTU used for alignment */
+            size_t           max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref uct_ep_get_zcopy
+                                              @anchor uct_iface_attr_cap_get_max_iov */
+        } get;                           /**< Attributes for GET operations */
+
+        struct {
+            size_t           max_short;  /**< Total maximum size (incl. the header)
+                                              @anchor uct_iface_attr_cap_am_max_short */
+            size_t           max_bcopy;  /**< Total maximum size (incl. the header) */
+            size_t           min_zcopy;  /**< Minimal size for am_zcopy (incl. the
+                                              header and total of @ref uct_iov_t::length
+                                              of the @a iov parameter) */
+            size_t           max_zcopy;  /**< Total max. size (incl. the header
+                                              and total of @ref uct_iov_t::length
+                                              of the @a iov parameter) */
+            size_t           opt_zcopy_align; /**< Optimal alignment for zero-copy
+                                              buffer address */
+            size_t           align_mtu;       /**< MTU used for alignment */
+            size_t           max_hdr;    /**< Max. header size for zcopy */
+            size_t           max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref ::uct_ep_am_zcopy
+                                              @anchor uct_iface_attr_cap_am_max_iov */
+        } am;                            /**< Attributes for AM operations */
+
+        struct {
+            struct {
+                size_t       min_recv;   /**< Minimal allowed length of posted receive buffer */
+                size_t       max_zcopy;  /**< Maximal allowed data length in
+                                              @ref uct_iface_tag_recv_zcopy */
+                size_t       max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref uct_iface_tag_recv_zcopy
+                                              @anchor uct_iface_attr_cap_tag_recv_iov */
+                size_t       max_outstanding; /**< Maximal number of simultaneous
+                                                   receive operations */
+            } recv;
+
+            struct {
+                  size_t     max_short;  /**< Maximal allowed data length in
+                                              @ref uct_ep_tag_eager_short */
+                  size_t     max_bcopy;  /**< Maximal allowed data length in
+                                              @ref uct_ep_tag_eager_bcopy */
+                  size_t     max_zcopy;  /**< Maximal allowed data length in
+                                              @ref uct_ep_tag_eager_zcopy */
+                  size_t     max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref uct_ep_tag_eager_zcopy */
+            } eager;                     /**< Attributes related to eager protocol */
+
+            struct {
+                  size_t     max_zcopy;  /**< Maximal allowed data length in
+                                              @ref uct_ep_tag_rndv_zcopy */
+                  size_t     max_hdr;    /**< Maximal allowed header length in
+                                              @ref uct_ep_tag_rndv_zcopy and
+                                              @ref uct_ep_tag_rndv_request */
+                  size_t     max_iov;    /**< Maximal @a iovcnt parameter in
+                                              @ref uct_ep_tag_rndv_zcopy */
+            } rndv;                      /**< Attributes related to rendezvous protocol */
+        } tag;                           /**< Attributes for TAG operations */
+
+        struct {
+            uint64_t         op_flags;   /**< Attributes for atomic-post operations */
+            uint64_t         fop_flags;  /**< Attributes for atomic-fetch operations */
+        } atomic32, atomic64;            /**< Attributes for atomic operations */
+
+        uint64_t             flags;      /**< Flags from @ref UCT_RESOURCE_IFACE_CAP */
+        uint64_t             event_flags;/**< Flags from @ref UCT_RESOURCE_IFACE_EVENT_CAP */
+    } cap;                               /**< Interface capabilities */
+
+    size_t                   device_addr_len;/**< Size of device address */
+    size_t                   iface_addr_len; /**< Size of interface address */
+    size_t                   ep_addr_len;    /**< Size of endpoint address */
+    size_t                   max_conn_priv;  /**< Max size of the iface's private data.
+                                                  used for connection
+                                                  establishment with sockaddr */
+    struct sockaddr_storage  listen_sockaddr; /**< Sockaddr on which this iface
+                                                   is listening. */
+    /*
+     * The following fields define expected performance of the communication
+     * interface, this would usually be a combination of device and system
+     * characteristics and determined at run time.
+     */
+    double                   overhead;     /**< Message overhead, seconds */
+    uct_ppn_bandwidth_t      bandwidth;    /**< Bandwidth model */
+    ucs_linear_func_t        latency;      /**< Latency as function of number of
+                                                active endpoints */
+    uint8_t                  priority;     /**< Priority of device */
+    size_t                   max_num_eps;  /**< Maximum number of endpoints */
+    unsigned                 dev_num_paths;/**< How many network paths can be
+                                                utilized on the device used by
+                                                this interface for optimal
+                                                performance. Endpoints that connect
+                                                to the same remote address but use
+                                                different paths can potentially
+                                                achieve higher total bandwidth
+                                                compared to using only a single
+                                                endpoint. */
+
+} uct_iface_attr_v2_t;
+
+ucs_status_t
+uct_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
+
 END_C_DECLS
 
 #endif

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1146,7 +1146,7 @@ typedef enum {
 
 } uct_iface_attr_field_t;
 
-typedef struct {
+typedef struct uct_iface_attr_v2 {
     /**
      * Mask of valid fields in this structure, using bits from
      * @ref uct_iface_attr_field_t.

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -192,7 +192,21 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
 
 ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 {
+    uct_iface_attr_v2_t iface_attr_v2;
+    ucs_status_t status;
+
+    status = uct_iface_query_v2(iface, &iface_attr_v2);
+    if(status != UCS_OK) {
+        return status;
+    }
+
     return iface->ops.iface_query(iface, iface_attr);
+}
+
+ucs_status_t
+uct_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
+{
+    return iface->ops.iface_query_v2(iface, iface_attr);
 }
 
 ucs_status_t

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -22,6 +22,7 @@
 #include <ucs/debug/debug_int.h>
 #include <ucs/vfs/base/vfs_obj.h>
 
+/**
 #define UCT_IFACE_ATTR_V2_FIELD_COPY(_md_attr_dst, _md_attr_src, _field_name, \
                                      _field_flag) \
     { \
@@ -32,6 +33,7 @@
                    sizeof((_md_attr_src)->_field_name)); \
         } \
     }
+    */
 
 const char *uct_ep_operation_names[] = {
     [UCT_EP_OP_AM_SHORT]     = "am_short",
@@ -199,7 +201,8 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
                                        NULL);
 }
 
-static void uct_iface_attr_v2_to_v1(uct_iface_attr_t *dest, uct_iface_attr_v2_t *src)
+static void
+uct_iface_attr_v2_to_v1(uct_iface_attr_t *dest, const uct_iface_attr_v2_t *src)
 {
     /* PUT attributes */
     dest->cap.put.max_short       = src->cap.put.max_short;
@@ -266,6 +269,13 @@ static void uct_iface_attr_v2_to_v1(uct_iface_attr_t *dest, uct_iface_attr_v2_t 
     dest->dev_num_paths   = src->dev_num_paths;
 }
 
+ucs_status_t
+uct_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
+{
+    return UCS_OK;
+    // return iface->ops.->iface_query_v2(iface, iface_attr);
+}
+
 ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 {
     uct_iface_attr_v2_t iface_attr_v2;
@@ -278,14 +288,7 @@ ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 
     uct_iface_attr_v2_to_v1(iface_attr, &iface_attr_v2);
 
-    return status;
-}
-
-ucs_status_t
-uct_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
-{
-    return UCS_OK;
-    // return iface->ops.->iface_query_v2(iface, iface_attr);
+    return iface->ops.iface_query(iface, iface_attr  );
 }
 
 ucs_status_t

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -189,6 +189,9 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
                                        NULL);
 }
 
+static void uct_iface_attr_v2_to_v1(uct_iface_attr_t *iface_attr, uct_iface_attr_v2_t *iface_attr)
+{
+}
 
 ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 {
@@ -206,7 +209,7 @@ ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
 ucs_status_t
 uct_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
 {
-    return iface->ops.iface_query_v2(iface, iface_attr);
+    return iface->internal_ops->iface_query_v2(iface, iface_attr);
 }
 
 ucs_status_t

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -299,6 +299,10 @@ typedef int (*uct_iface_is_reachable_v2_func_t)(
 typedef int (*uct_ep_is_connected_func_t)(
         uct_ep_h ep, const uct_ep_is_connected_params_t *params);
 
+/* Query iface attributes v2 */
+typedef ucs_status_t (*uct_iface_query_v2_func_t)(
+        uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
+
 
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
@@ -309,6 +313,7 @@ typedef struct uct_iface_internal_ops {
     uct_ep_connect_to_ep_v2_func_t   ep_connect_to_ep_v2;
     uct_iface_is_reachable_v2_func_t iface_is_reachable_v2;
     uct_ep_is_connected_func_t       ep_is_connected;
+    uct_iface_query_v2_func_t        query_v2;
 } uct_iface_internal_ops_t;
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -300,8 +300,8 @@ typedef int (*uct_ep_is_connected_func_t)(
         uct_ep_h ep, const uct_ep_is_connected_params_t *params);
 
 /* Query iface attributes v2 */
-// typedef ucs_status_t (*uct_iface_query_v2_func_t)(
-//         uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
+typedef ucs_status_t (*uct_iface_query_v2_func_t)(
+        uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
 
 
 /* Internal operations, not exposed by the external API */
@@ -313,7 +313,7 @@ typedef struct uct_iface_internal_ops {
     uct_ep_connect_to_ep_v2_func_t   ep_connect_to_ep_v2;
     uct_iface_is_reachable_v2_func_t iface_is_reachable_v2;
     uct_ep_is_connected_func_t       ep_is_connected;
-    // uct_iface_query_v2_func_t        query_v2;
+    uct_iface_query_v2_func_t        iface_query_v2;
 } uct_iface_internal_ops_t;
 
 
@@ -871,7 +871,7 @@ uct_iface_param_am_alignment(const uct_iface_params_t *params, size_t elem_size,
                              size_t base_offset, size_t payload_offset,
                              size_t *align, size_t *align_offset);
 
-void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr);
+void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_v2_t *iface_attr);
 
 ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
                                         uct_device_type_t dev_type,

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -300,8 +300,8 @@ typedef int (*uct_ep_is_connected_func_t)(
         uct_ep_h ep, const uct_ep_is_connected_params_t *params);
 
 /* Query iface attributes v2 */
-typedef ucs_status_t (*uct_iface_query_v2_func_t)(
-        uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
+// typedef ucs_status_t (*uct_iface_query_v2_func_t)(
+//         uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
 
 
 /* Internal operations, not exposed by the external API */
@@ -313,7 +313,7 @@ typedef struct uct_iface_internal_ops {
     uct_ep_connect_to_ep_v2_func_t   ep_connect_to_ep_v2;
     uct_iface_is_reachable_v2_func_t iface_is_reachable_v2;
     uct_ep_is_connected_func_t       ep_is_connected;
-    uct_iface_query_v2_func_t        query_v2;
+    // uct_iface_query_v2_func_t        query_v2;
 } uct_iface_internal_ops_t;
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -77,7 +77,7 @@ static int uct_cuda_copy_iface_is_reachable_v2(
 }
 
 static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
-                                              uct_iface_attr_t *iface_attr)
+                                              uct_iface_attr_v2_t *iface_attr)
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
 
@@ -288,7 +288,6 @@ static uct_iface_ops_t uct_cuda_copy_iface_ops = {
     .iface_event_fd_get       = uct_cuda_base_iface_event_fd_get,
     .iface_event_arm          = uct_cuda_copy_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_iface_t),
-    .iface_query              = uct_cuda_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_cuda_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -403,7 +402,8 @@ static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_cuda_copy_iface_is_reachable_v2,
-    .ep_is_connected       = uct_base_ep_is_connected
+    .ep_is_connected       = uct_base_ep_is_connected,
+    .iface_query_v2        = uct_cuda_copy_iface_query
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -190,7 +190,7 @@ static size_t uct_cuda_ipc_iface_get_max_get_zcopy(uct_cuda_ipc_iface_t *iface)
 }
 
 static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
-                                             uct_iface_attr_t *iface_attr)
+                                             uct_iface_attr_v2_t *iface_attr)
 {
     uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
 
@@ -364,7 +364,6 @@ static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
     .iface_event_fd_get       = uct_cuda_base_iface_event_fd_get,
     .iface_event_arm          = uct_cuda_ipc_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_iface_t),
-    .iface_query              = uct_cuda_ipc_iface_query,
     .iface_get_device_address = uct_cuda_ipc_iface_get_device_address,
     .iface_get_address        = uct_cuda_ipc_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -478,6 +477,7 @@ static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_cuda_ipc_iface_is_reachable_v2,
     .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
+    .iface_query_v2        = uct_cuda_ipc_iface_query,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -61,7 +61,7 @@ uct_gdr_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
 }
 
 static ucs_status_t
-uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
 
@@ -168,7 +168,6 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
     .iface_progress_disable   = ucs_empty_function,
     .iface_progress           = ucs_empty_function_return_zero,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_gdr_copy_iface_t),
-    .iface_query              = uct_gdr_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_gdr_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -181,7 +180,8 @@ static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_gdr_copy_iface_is_reachable_v2,
-    .ep_is_connected       = uct_base_ep_is_connected
+    .ep_is_connected       = uct_base_ep_is_connected,
+    .iface_query_v2        = uct_gdr_copy_iface_query
 };
 
 static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1590,7 +1590,7 @@ int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
 }
 
 ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
-                                uct_iface_attr_t *iface_attr)
+                                uct_iface_attr_v2_t *iface_attr)
 {
     static const uint8_t ib_port_widths[] =
             {[1] = 1, [2] = 4, [4] = 8, [8] = 12, [16] = 2};

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -492,7 +492,7 @@ int uct_ib_iface_is_reachable_v2(const uct_iface_h tl_iface,
  * @param xport_hdr_len       How many bytes this transport adds on top of IB header (LRH+BTH+iCRC+vCRC)
  */
 ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface, size_t xport_hdr_len,
-                                uct_iface_attr_t *iface_attr);
+                                uct_iface_attr_v2_t *iface_attr);
 
 
 ucs_status_t

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -193,7 +193,8 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
     }
 }
 
-static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
     size_t max_am_inline       = UCT_IB_MLX5_AM_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE);
@@ -1275,7 +1276,8 @@ static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
             .ep_invalidate         = uct_dc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
             .iface_is_reachable_v2 = uct_dc_mlx5_iface_is_reachable_v2,
-            .ep_is_connected       = uct_dc_mlx5_ep_is_connected
+            .ep_is_connected       = uct_dc_mlx5_ep_is_connected,
+            .iface_query_v2        = uct_dc_mlx5_iface_query
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,
@@ -1329,7 +1331,6 @@ static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .ep_create                = uct_dc_mlx5_ep_create_connected,
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_ep_t),
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t),
-    .iface_query              = uct_dc_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
     .iface_get_address        = uct_dc_mlx5_iface_get_address,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -908,7 +908,7 @@ void uct_rc_mlx5_tag_cleanup(uct_rc_mlx5_iface_common_t *iface)
 }
 
 static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
-                                  uct_iface_attr_t *iface_attr,
+                                  uct_iface_attr_v2_t *iface_attr,
                                   size_t max_inline, size_t max_tag_eager_iov)
 {
 #if IBV_HW_TM
@@ -1022,7 +1022,7 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
 #endif
 
 void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
-                                    uct_iface_attr_t *iface_attr,
+                                    uct_iface_attr_v2_t *iface_attr,
                                     size_t max_inline, size_t max_tag_eager_iov)
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ib_iface,

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -576,8 +576,9 @@ ucs_status_t uct_rc_mlx5_iface_common_dm_init(uct_rc_mlx5_iface_common_t *iface,
 void uct_rc_mlx5_iface_common_dm_cleanup(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
-                                    uct_iface_attr_t *iface_attr,
-                                    size_t max_inline, size_t max_tag_eager_iov);
+                                    uct_iface_attr_v2_t *iface_attr,
+                                    size_t max_inline,
+                                    size_t max_tag_eager_iov);
 
 ucs_status_t
 uct_rc_mlx5_iface_common_create_cq(uct_ib_iface_t *ib_iface, uct_ib_dir_t dir,

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -214,7 +214,8 @@ static unsigned uct_rc_mlx5_iface_progress_tm(void *arg)
                                            UCT_IB_MLX5_POLL_FLAG_CQE_ZIP);
 }
 
-static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(tl_iface, uct_rc_mlx5_iface_common_t);
     uct_rc_iface_t *rc_iface   = &iface->super;
@@ -1013,7 +1014,8 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
             .ep_invalidate         = uct_rc_mlx5_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_rc_mlx5_ep_connect_to_ep_v2,
             .iface_is_reachable_v2 = uct_rc_mlx5_iface_is_reachable_v2,
-            .ep_is_connected       = uct_rc_mlx5_ep_is_connected
+            .ep_is_connected       = uct_rc_mlx5_ep_is_connected,
+            .iface_query_v2        = uct_rc_mlx5_iface_query,
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,
@@ -1072,7 +1074,6 @@ static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {
     .iface_event_fd_get       = uct_rc_mlx5_iface_event_fd_get,
     .iface_event_arm          = uct_rc_mlx5_iface_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_mlx5_iface_t),
-    .iface_query              = uct_rc_mlx5_iface_query,
     .iface_get_address        = uct_rc_mlx5_iface_get_address,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -165,7 +165,7 @@ static ucs_mpool_ops_t uct_rc_send_op_mpool_ops = {
 };
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
                                 size_t am_min_hdr, size_t rma_max_iov)

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -374,7 +374,7 @@ extern ucs_config_field_t uct_rc_iface_common_config_table[];
 unsigned uct_rc_iface_do_progress(uct_iface_h tl_iface);
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
                                 size_t am_min_hdr, size_t rma_max_iov);

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -210,7 +210,7 @@ static void uct_rc_verbs_iface_init_inl_wrs(uct_rc_verbs_iface_t *iface)
 }
 
 static ucs_status_t
-uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_rc_verbs_iface_t);
@@ -497,7 +497,6 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
     .iface_event_fd_get       = uct_ib_iface_event_fd_get,
     .iface_event_arm          = uct_rc_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_verbs_iface_t),
-    .iface_query              = uct_rc_verbs_iface_query,
     .iface_get_address        = ucs_empty_function_return_success,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -512,7 +511,8 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
             .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
             .ep_connect_to_ep_v2   = uct_rc_verbs_ep_connect_to_ep_v2,
             .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
-            .ep_is_connected       = uct_rc_verbs_ep_is_connected
+            .ep_is_connected       = uct_rc_verbs_ep_is_connected,
+            .iface_query_v2        = uct_rc_verbs_iface_query
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -872,7 +872,6 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucs_empty_function_return_unsupported,
     .iface_event_arm          = (uct_iface_event_arm_func_t)ucs_empty_function_return_unsupported,
     .iface_close              = ucs_empty_function,
-    .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -885,7 +884,8 @@ static uct_iface_internal_ops_t uct_rdmacm_cm_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero,
-    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int,
+    .iface_query_v2        = (uct_iface_query_v2_func_t)ucs_empty_function_return_unsupported
 };
 
 static ucs_status_t

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -613,7 +613,7 @@ static unsigned uct_ud_mlx5_iface_async_progress(uct_ud_iface_t *ud_iface)
 }
 
 static ucs_status_t
-uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ud_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_iface_t);
     ucs_status_t status;
@@ -855,7 +855,8 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
             .ep_invalidate         = uct_ud_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
             .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
-            .ep_is_connected       = uct_ud_mlx5_ep_is_connected
+            .ep_is_connected       = uct_ud_mlx5_ep_is_connected,
+            .iface_query_v2        = uct_ud_mlx5_iface_query,
         },
         .create_cq      = uct_ud_mlx5_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,
@@ -898,7 +899,6 @@ static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
                                 ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_ud_mlx5_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t),
-    .iface_query              = uct_ud_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -672,7 +672,7 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
 
 
 ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t am_max_iov, size_t am_max_hdr)
 {
     ucs_status_t status;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -243,7 +243,7 @@ extern ucs_config_field_t uct_ud_iface_config_table[];
 
 
 ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t am_max_iov, size_t am_max_hdr);
 
 void uct_ud_iface_release_desc(uct_recv_desc_t *self, void *desc);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -518,7 +518,7 @@ static void uct_ud_verbs_iface_async_handler(int fd,
 }
 
 static ucs_status_t
-uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ud_verbs_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_verbs_iface_t);
     size_t am_max_hdr;
@@ -637,7 +637,8 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
             .ep_invalidate         = uct_ud_ep_invalidate,
             .ep_connect_to_ep_v2   = uct_ud_ep_connect_to_ep_v2,
             .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
-            .ep_is_connected       = uct_ud_verbs_ep_is_connected
+            .ep_is_connected       = uct_ud_verbs_ep_is_connected,
+            .iface_query_v2        = uct_ud_verbs_iface_query
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,
@@ -680,7 +681,6 @@ static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {
                                 ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_ud_verbs_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t),
-    .iface_query              = uct_ud_verbs_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -81,8 +81,8 @@ static int uct_rocm_copy_iface_is_reachable_v2(
            uct_iface_scope_is_reachable(tl_iface, params);
 }
 
-static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
-                                              uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_rocm_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_copy_iface_t);
 
@@ -178,7 +178,6 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_rocm_copy_iface_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_copy_iface_t),
-    .iface_query              = uct_rocm_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_rocm_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -247,6 +246,7 @@ static uct_iface_internal_ops_t uct_rocm_copy_iface_internal_ops = {
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_rocm_copy_iface_is_reachable_v2,
     .ep_is_connected       = uct_base_ep_is_connected
+    .iface_query_v2        = uct_rocm_copy_iface_query,
 };
 
 static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -70,8 +70,8 @@ uct_rocm_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
            uct_iface_scope_is_reachable(tl_iface, params);
 }
 
-static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
-                                             uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_rocm_ipc_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_ipc_iface_t);
 
@@ -141,7 +141,8 @@ static uct_iface_internal_ops_t uct_rocm_ipc_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_rocm_ipc_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_rocm_ipc_iface_is_reachable_v2,
+    .iface_query_v2        = uct_rocm_ipc_iface_query
 };
 
 static uct_iface_ops_t uct_rocm_ipc_iface_ops = {
@@ -159,7 +160,6 @@ static uct_iface_ops_t uct_rocm_ipc_iface_ops = {
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_rocm_ipc_iface_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_ipc_iface_t),
-    .iface_query              = uct_rocm_ipc_iface_query,
     .iface_get_address        = uct_rocm_ipc_iface_get_address,
     .iface_get_device_address = uct_rocm_ipc_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -145,8 +145,8 @@ ucs_status_t uct_mm_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_OK;
 }
 
-static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
-                                       uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_mm_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
     uct_mm_md_t    *md    = ucs_derived_of(iface->super.super.md, uct_mm_md_t);
@@ -505,7 +505,6 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .iface_event_fd_get       = uct_mm_iface_event_fd_get,
     .iface_event_arm          = uct_mm_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_mm_iface_t),
-    .iface_query              = uct_mm_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_get_address        = uct_mm_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -585,7 +584,8 @@ static uct_iface_internal_ops_t uct_mm_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_mm_iface_is_reachable_v2,
-    .ep_is_connected       = uct_mm_ep_is_connected
+    .ep_is_connected       = uct_mm_ep_is_connected,
+    .iface_query_v2        = uct_mm_iface_query
 };
 
 static void uct_mm_iface_recv_desc_init(uct_iface_h tl_iface, void *obj,

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -62,7 +62,8 @@ static ucs_mpool_ops_t uct_scopy_mpool_ops = {
     .obj_str       = NULL
 };
 
-void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr)
+void uct_scopy_iface_query(uct_scopy_iface_t *iface,
+                           uct_iface_attr_v2_t *iface_attr)
 {
     uct_base_iface_query(&iface->super.super, iface_attr);
 

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -59,7 +59,8 @@ typedef struct uct_scopy_iface_ops {
 } uct_scopy_iface_ops_t;
 
 
-void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr);
+void uct_scopy_iface_query(uct_scopy_iface_t *iface,
+                           uct_iface_attr_v2_t *iface_attr);
 
 ucs_status_t
 uct_scopy_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -49,8 +49,8 @@ static ucs_status_t uct_cma_iface_get_address(uct_iface_t *tl_iface,
     return UCS_OK;
 }
 
-static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
-                                        uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_cma_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_cma_iface_t *iface = ucs_derived_of(tl_iface, uct_cma_iface_t);
 
@@ -128,7 +128,6 @@ static uct_iface_ops_t uct_cma_iface_tl_ops = {
     .iface_event_fd_get       = ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_scopy_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
-    .iface_query              = uct_cma_iface_query,
     .iface_get_address        = uct_cma_iface_get_address,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -142,7 +141,8 @@ static uct_scopy_iface_ops_t uct_cma_iface_ops = {
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
         .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
         .iface_is_reachable_v2 = uct_cma_iface_is_reachable_v2,
-        .ep_is_connected       = uct_cma_ep_is_connected
+        .ep_is_connected       = uct_cma_ep_is_connected,
+        .iface_query_v2        = uct_cma_iface_query
     },
     .ep_tx = uct_cma_ep_tx,
 };

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -24,8 +24,8 @@ static ucs_config_field_t uct_knem_iface_config_table[] = {
     {NULL}
 };
 
-static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
-                                         uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_knem_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_knem_iface_t *iface = ucs_derived_of(tl_iface, uct_knem_iface_t);
 
@@ -67,7 +67,6 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
     .iface_event_fd_get       = ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_scopy_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
-    .iface_query              = uct_knem_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_get_address        = ucs_empty_function_return_success,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -81,7 +80,8 @@ static uct_scopy_iface_ops_t uct_knem_iface_ops = {
         .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
         .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
         .iface_is_reachable_v2 = uct_knem_iface_is_reachable_v2,
-        .ep_is_connected       = uct_base_ep_is_connected
+        .ep_is_connected       = uct_base_ep_is_connected,
+        .iface_query_v2        = uct_knem_iface_query
     },
     .ep_tx = uct_knem_ep_tx,
 };

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -62,7 +62,8 @@ static ucs_config_field_t uct_self_md_config_table[] = {
 };
 
 
-static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *attr)
+static ucs_status_t
+uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *attr)
 {
     uct_self_iface_t *iface = ucs_derived_of(tl_iface, uct_self_iface_t);
 
@@ -372,7 +373,8 @@ static uct_iface_internal_ops_t uct_self_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_self_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_self_iface_is_reachable_v2,
+    .iface_query_v2        = uct_self_iface_query,
 };
 
 static uct_iface_ops_t uct_self_iface_ops = {
@@ -401,7 +403,6 @@ static uct_iface_ops_t uct_self_iface_ops = {
     .iface_progress_disable   = ucs_empty_function,
     .iface_progress           = ucs_empty_function_return_zero,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_self_iface_t),
-    .iface_query              = uct_self_iface_query,
     .iface_get_device_address = ucs_empty_function_return_success,
     .iface_get_address        = uct_self_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -246,8 +246,8 @@ uct_tcp_iface_get_sysfs_path(const char *dev_name, char *path_buffer)
     return sysfs_path;
 }
 
-static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
-                                        uct_iface_attr_t *attr)
+static ucs_status_t
+uct_tcp_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *attr)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
     size_t am_buf_size     = iface->config.tx_seg_size -
@@ -484,7 +484,6 @@ static uct_iface_ops_t uct_tcp_iface_ops = {
     .iface_event_fd_get       = uct_tcp_iface_event_fd_get,
     .iface_event_arm          = ucs_empty_function_return_success,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_tcp_iface_t),
-    .iface_query              = uct_tcp_iface_query,
     .iface_get_address        = uct_tcp_iface_get_address,
     .iface_get_device_address = uct_tcp_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -603,7 +602,8 @@ static uct_iface_internal_ops_t uct_tcp_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = uct_tcp_ep_connect_to_ep_v2,
     .iface_is_reachable_v2 = uct_tcp_iface_is_reachable_v2,
-    .ep_is_connected       = uct_tcp_ep_is_connected
+    .ep_is_connected       = uct_tcp_ep_is_connected,
+    .iface_query_v2        = uct_tcp_iface_query
 };
 
 static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -187,7 +187,6 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucs_empty_function_return_unsupported,
     .iface_event_arm          = (uct_iface_event_arm_func_t)ucs_empty_function_return_unsupported,
     .iface_close              = ucs_empty_function,
-    .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -200,7 +199,8 @@ static uct_iface_internal_ops_t uct_tcp_sockcm_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_zero,
-    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int,
+    .iface_query_v2        = (uct_iface_query_v2_func_t)ucs_empty_function_return_unsupported
 };
 
 UCS_CLASS_INIT_FUNC(uct_tcp_sockcm_t, uct_component_h component,

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -28,7 +28,8 @@ static ucs_config_field_t uct_ugni_rdma_iface_config_table[] = {
     {NULL}
 };
 
-static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_rdma_iface_t);
 
@@ -206,7 +207,6 @@ static uct_iface_ops_t uct_ugni_aries_rdma_iface_ops = {
     .iface_progress_disable   = ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_rdma_iface_t),
-    .iface_query              = uct_ugni_rdma_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_is_reachable       = uct_ugni_iface_is_reachable
@@ -233,10 +233,13 @@ static uct_iface_ops_t uct_ugni_gemini_rdma_iface_ops = {
     .iface_progress_disable   = ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_rdma_iface_t),
-    .iface_query              = uct_ugni_rdma_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_is_reachable       = uct_ugni_iface_is_reachable
+};
+
+static uct_iface_internal_ops_t uct_ugni_rdma_internal_ops = {
+    .iface_query_v2 = uct_ugni_rdma_iface_query
 };
 
 static ucs_mpool_ops_t uct_ugni_rdma_desc_mpool_ops = {
@@ -276,7 +279,8 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
         status = UCS_ERR_NO_DEVICE;
         goto exit;
     }
-    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params, ops, NULL,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params, ops,
+                              &uct_ugni_rdma_internal_ops,
                               &config->super UCS_STATS_ARG(NULL));
     /* Setting initial configuration */
     self->config.fma_seg_size  = UCT_UGNI_MAX_FMA;

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -189,7 +189,8 @@ static unsigned uct_ugni_smsg_progress(void *arg)
     return count - 2;
 }
 
-static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ugni_smsg_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_smsg_iface_t);
 
@@ -246,7 +247,6 @@ static uct_iface_ops_t uct_ugni_smsg_iface_ops = {
     .iface_progress_disable   = ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_smsg_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_smsg_iface_t),
-    .iface_query              = uct_ugni_smsg_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -275,7 +275,8 @@ static uct_iface_internal_ops_t uct_ugni_smsg_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = uct_ugni_smsg_ep_connect_to_ep_v2,
     .iface_is_reachable_v2 = uct_ugni_iface_is_reachable_v2,
-    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
+    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int,
+    .iface_query_v2        = uct_ugni_smsg_iface_query
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_smsg_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -160,7 +160,8 @@ static void uct_ugni_udt_iface_release_desc(uct_recv_desc_t *self, void *desc)
     ucs_mpool_put(ugni_desc);
 }
 
-static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t
+uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ugni_udt_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_udt_iface_t);
 
@@ -369,10 +370,13 @@ static uct_iface_ops_t uct_ugni_udt_iface_ops = {
     .iface_progress_disable   = ucs_empty_function,
     .iface_progress        = (void*)uct_ugni_udt_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_udt_iface_t),
-    .iface_query              = uct_ugni_udt_iface_query,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_is_reachable       = uct_ugni_iface_is_reachable
+};
+
+static uct_iface_internal_ops_t uct_ugni_udt_internal_ops = {
+    .iface_query_v2 = uct_ugni_udt_iface_query,
 };
 
 static ucs_mpool_ops_t uct_ugni_udt_desc_mpool_ops = {


### PR DESCRIPTION
## What
Add uct_iface_query_v2, which is expandable thanks to the field mask

## Why ?
We want to enable adding new fields to be queried using iface_query, and in order to remain backward compatible we need to use a field mask, the "old" uct_iface_query will call uct_iface_query_v2 and copy the values back into the v1 attr struct.