### PR TITLE
UCT/API/V2: Introduce uct_iface_query_v2 API

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1119,8 +1119,10 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface operations attributes, capabilities and limitations
- * Capabilities and limitations of operations such as put, get, am and tag.
+ * @brief Capabilities and limitations for a single operation on @ref uct_iface_t.
+ * 
+ * A structure that describes capabilities and limitations for short/bcopy/zcopy modes,
+ * as well as header sizes and alignment, for a single communication operation.
  */
 typedef struct uct_iface_op_attr {
     /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1114,9 +1114,6 @@ typedef enum {
 
     /** Enables @ref uct_iface_op_attr::max_iov */
     UCT_IFACE_OP_ATTR_FIELD_MAX_IOV         = UCS_BIT(7),
-
-    /** Enables @ref uct_iface_op_attr::max_outstanding */
-    UCT_IFACE_OP_ATTR_FIELD_MAX_OUTSTANDING = UCS_BIT(8)
 } uct_iface_op_attr_field_t;
 
 
@@ -1151,8 +1148,6 @@ typedef struct uct_iface_op_attr {
     size_t   max_zcopy_hdr;
     /** Maximal @a iovcnt  */
     size_t   max_iov;
-    /** Maximal number of simultaneous receive operations */
-    size_t   max_outstanding;
 } uct_iface_op_attr_t;
 
 
@@ -1193,23 +1188,26 @@ typedef enum {
     /** Enables @ref uct_iface_attr_v2_t::tag::receive */
     UCT_IFACE_ATTR_FIELD_TAG_RECEIVE        = UCS_BIT(9),
 
+    /** Enables @ref uct_iface_attr_v2_t::tag::max_outstanding */
+    UCT_IFACE_ATTR_FIELD_MAX_OUTSTANDING    = UCS_BIT(10),
+
     /** Enables @ref uct_iface_attr_v2_t::tag::eager */
-    UCT_IFACE_ATTR_FIELD_TAG_EAGER          = UCS_BIT(10),
-
-    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */
-    UCT_IFACE_ATTR_FIELD_TAG_RNDV           = UCS_BIT(11),
-
+    UCT_IFACE_ATTR_FIELD_TAG_EAGER          = UCS_BIT(11),
+                                                        
+    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */  
+    UCT_IFACE_ATTR_FIELD_TAG_RNDV           = UCS_BIT(12),
+                                                        
     /** Enables @ref uct_iface_attr_v2_t::atomic32::op_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS  = UCS_BIT(12),
-
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS  = UCS_BIT(13),
+                                                        
     /** Enables @ref uct_iface_attr_v2_t::atomic32::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS = UCS_BIT(13),
-
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS = UCS_BIT(14),
+                                                        
     /** Enables @ref uct_iface_attr_v2_t::atomic64::op_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(14),
-
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(15),
+                                                        
     /** Enables @ref uct_iface_attr_v2_t::atomic64::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(15)
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(16)
 } uct_iface_attr_field_t;
 
 /**
@@ -1254,6 +1252,9 @@ typedef struct uct_iface_attr_v2 {
     struct {
         /** Attributes related to receive protocol */
         uct_iface_op_attr_t *recv;
+
+        /** Maximal number of simultaneous receive operations */
+        size_t              max_outstanding;
 
         /** Attributes related to eager protocol */
         uct_iface_op_attr_t *eager;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1116,61 +1116,6 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface attributes capabilities field mask flags 
- */
-typedef enum {
-    /** Enables @ref uct_iface_attr_v2_t::put */
-    UCT_IFACE_ATTR_FIELD_PUT                = UCS_BIT(0),
-
-    /** Enables @ref uct_iface_attr_v2_t::get */
-    UCT_IFACE_ATTR_FIELD_GET                = UCS_BIT(1),
-
-    /** Enables @ref uct_iface_attr_v2_t::am */
-    UCT_IFACE_ATTR_FIELD_AM                 = UCS_BIT(2),
-
-    /** Enables @ref uct_iface_attr_v2_t::tag::receive */
-    UCT_IFACE_ATTR_FIELD_TAG_RECEIVE        = UCS_BIT(3),
-
-    /** Enables @ref uct_iface_attr_v2_t::tag::eager */
-    UCT_IFACE_ATTR_FIELD_TAG_EAGER          = UCS_BIT(4),
-
-    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */
-    UCT_IFACE_ATTR_FIELD_TAG_RNDV           = UCS_BIT(5),
-
-    /** Enables @ref uct_iface_attr_v2_t::atomic32::op_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS  = UCS_BIT(6),
-
-    /** Enables @ref uct_iface_attr_v2_t::atomic32::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS = UCS_BIT(7),
-
-    /** Enables @ref uct_iface_attr_v2_t::atomic64::op_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(8),
-
-    /** Enables @ref uct_iface_attr_v2_t::atomic64::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(9),
-
-    /** Enables @ref uct_iface_attr_v2_t::flags*/
-    UCT_IFACE_ATTR_FIELD_FLAGS              = UCS_BIT(10),
-
-    /** Enables @ref uct_iface_attr_v2_t::event_flags*/
-    UCT_IFACE_ATTR_FIELD_EVENT_FLAGS        = UCS_BIT(11),
-
-    /** Enables @ref uct_iface_attr_v2_t::device_addr_len */
-    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN    = UCS_BIT(12),
-
-    /** Enables @ref uct_iface_attr_v2_t::iface_addr_len */
-    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN     = UCS_BIT(13),
-
-    /** Enables @ref uct_iface_attr_v2_t::ep_addr_len*/
-    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN        = UCS_BIT(14),
-
-    /** Enables @ref uct_iface_attr_v2_t::max_num_eps */
-    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS        = UCS_BIT(15),
-} uct_iface_attr_field_t;
-
-
-/**
- * @ingroup UCT_RESOURCE
  * @brief Interface specific operations attributes, capabilities and limitations
  */
 typedef struct uct_iface_op_attr {
@@ -1202,6 +1147,60 @@ typedef struct uct_iface_op_attr {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Interface attributes capabilities field mask flags 
+ */
+typedef enum {
+    /** Enables @ref uct_iface_attr_v2_t::flags*/
+    UCT_IFACE_ATTR_FIELD_FLAGS              = UCS_BIT(0),
+
+    /** Enables @ref uct_iface_attr_v2_t::event_flags*/
+    UCT_IFACE_ATTR_FIELD_EVENT_FLAGS        = UCS_BIT(1),
+
+    /** Enables @ref uct_iface_attr_v2_t::device_addr_len */
+    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN    = UCS_BIT(2),
+
+    /** Enables @ref uct_iface_attr_v2_t::iface_addr_len */
+    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN     = UCS_BIT(3),
+
+    /** Enables @ref uct_iface_attr_v2_t::ep_addr_len*/
+    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN        = UCS_BIT(4),
+
+    /** Enables @ref uct_iface_attr_v2_t::max_num_eps */
+    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS        = UCS_BIT(5),
+
+    /** Enables @ref uct_iface_attr_v2_t::put */
+    UCT_IFACE_ATTR_FIELD_PUT                = UCS_BIT(6),
+
+    /** Enables @ref uct_iface_attr_v2_t::get */
+    UCT_IFACE_ATTR_FIELD_GET                = UCS_BIT(7),
+
+    /** Enables @ref uct_iface_attr_v2_t::am */
+    UCT_IFACE_ATTR_FIELD_AM                 = UCS_BIT(8),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::receive */
+    UCT_IFACE_ATTR_FIELD_TAG_RECEIVE        = UCS_BIT(9),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::eager */
+    UCT_IFACE_ATTR_FIELD_TAG_EAGER          = UCS_BIT(10),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */
+    UCT_IFACE_ATTR_FIELD_TAG_RNDV           = UCS_BIT(11),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic32::op_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS  = UCS_BIT(12),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic32::fop_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS = UCS_BIT(13),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic64::op_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(14),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic64::fop_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(15),
+} uct_iface_attr_field_t;
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Interface attributes: capabilities and limitations.
  */
 typedef struct uct_iface_attr_v2 {
@@ -1210,6 +1209,24 @@ typedef struct uct_iface_attr_v2 {
      * @ref uct_iface_attr_field_t.
      */
     uint64_t            field_mask;
+
+    /** Flags from @ref UCT_RESOURCE_IFACE_CAP */
+    uint64_t flags;
+
+    /** Flags from @ref UCT_RESOURCE_IFACE_EVENT_CAP */
+    uint64_t event_flags;
+
+    /** Size of device address */
+    size_t   device_addr_len;
+
+    /** Size of interface address */
+    size_t   iface_addr_len;
+
+    /** Size of endpoint address */
+    size_t   ep_addr_len;
+
+    /** Maximum number of endpoints */
+    size_t   max_num_eps;
 
     /** Attributes for PUT operations */
     uct_iface_op_attr_t *put;
@@ -1239,24 +1256,6 @@ typedef struct uct_iface_attr_v2 {
         /** Attributes for atomic-fetch operations */
         uint64_t fop_flags;
     } atomic32, atomic64;
-
-    /** Flags from @ref UCT_RESOURCE_IFACE_CAP */
-    uint64_t flags;
-
-    /** Flags from @ref UCT_RESOURCE_IFACE_EVENT_CAP */
-    uint64_t event_flags;
-
-    /** Size of device address */
-    size_t   device_addr_len;
-
-    /** Size of interface address */
-    size_t   iface_addr_len;
-
-    /** Size of endpoint address */
-    size_t   ep_addr_len;
-
-    /** Maximum number of endpoints */
-    size_t   max_num_eps;
 } uct_iface_attr_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1083,6 +1083,10 @@ ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result);
 
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Interface operations capabilities and limitation field mask flags
+ */
 typedef enum {
     /** Enables @ref uct_iface_op_attr::max_short */
     UCT_IFACE_OP_ATTR_FIELD_MAX_SHORT       = UCS_BIT(0),
@@ -1102,39 +1106,18 @@ typedef enum {
     /** Enables @ref uct_iface_op_attr::align_mtu */
     UCT_IFACE_OP_ATTR_FIELD_ALIGN_MTU       = UCS_BIT(5),
 
-    /** Enables @ref uct_iface_op_attr::max_hdr */
-    UCT_IFACE_OP_ATTR_FIELD_MAX_HDR         = UCS_BIT(6),
+    /** Enables @ref uct_iface_op_attr::max_zcopy_hdr */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_ZCOPY_HDR   = UCS_BIT(6),
 
     /** Enables @ref uct_iface_op_attr::max_iov */
     UCT_IFACE_OP_ATTR_FIELD_MAX_IOV         = UCS_BIT(7)
 } uct_iface_op_attr_field_t;
 
-typedef struct uct_iface_op_attr {
-    /**
-     * Mask of valid fields in this structure, using bits from
-     * @ref uct_iface_op_attr_field_t.
-     */
-    uint64_t field_mask;
-    /** Maximal size for short */
-    size_t   max_short;
-    /** Maximal size for bcopy */
-    size_t   max_bcopy;
-    /** Minimal size for zcopy (total of
-     * @ref uct_iov_t::length of the @a iov parameter) */
-    size_t   min_zcopy;
-    /** Maximal size for zcopy (total of
-     * @ref uct_iov_t::length of the @a iov parameter) */
-    size_t   max_zcopy;
-    /** Optimal alignment for zero-copy buffer address */
-    size_t   opt_zcopy_align;
-    /** MTU used for alignment */
-    size_t   align_mtu;
-    /** Max. header size for zcopy */
-    size_t   max_hdr;
-    /** Maximal @a iovcnt  */
-    size_t   max_iov;
-} uct_iface_op_attr_t;
 
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Interface attributes capabilities field mask flags 
+ */
 typedef enum {
     /** Enables @ref uct_iface_attr_v2_t::put */
     UCT_IFACE_ATTR_FIELD_PUT                = UCS_BIT(0),
@@ -1184,6 +1167,38 @@ typedef enum {
     /** Enables @ref uct_iface_attr_v2_t::max_num_eps */
     UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS        = UCS_BIT(15),
 } uct_iface_attr_field_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Interface specific operations attributes, capabilities and limitations
+ */
+typedef struct uct_iface_op_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_iface_op_attr_field_t.
+     */
+    uint64_t field_mask;
+    /** Maximal size for short */
+    size_t   max_short;
+    /** Maximal size for bcopy */
+    size_t   max_bcopy;
+    /** Minimal size for zcopy (total of
+     * @ref uct_iov_t::length of the @a iov parameter) */
+    size_t   min_zcopy;
+    /** Maximal size for zcopy (total of
+     * @ref uct_iov_t::length of the @a iov parameter) */
+    size_t   max_zcopy;
+    /** Optimal alignment for zero-copy buffer address */
+    size_t   opt_zcopy_align;
+    /** MTU used for alignment */
+    size_t   align_mtu;
+    /** Max. header size for zcopy */
+    size_t   max_zcopy_hdr;
+    /** Maximal @a iovcnt  */
+    size_t   max_iov;
+} uct_iface_op_attr_t;
+
 
 /**
  * @ingroup UCT_RESOURCE

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1159,55 +1159,55 @@ typedef struct uct_iface_op_attr {
  */
 typedef enum {
     /** Enables @ref uct_iface_attr_v2_t::flags*/
-    UCT_IFACE_ATTR_FIELD_FLAGS              = UCS_BIT(0),
+    UCT_IFACE_ATTR_FIELD_FLAGS                    = UCS_BIT(0),
 
     /** Enables @ref uct_iface_attr_v2_t::event_flags*/
-    UCT_IFACE_ATTR_FIELD_EVENT_FLAGS        = UCS_BIT(1),
+    UCT_IFACE_ATTR_FIELD_EVENT_FLAGS              = UCS_BIT(1),
 
     /** Enables @ref uct_iface_attr_v2_t::device_addr_len */
-    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN    = UCS_BIT(2),
+    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN          = UCS_BIT(2),
 
     /** Enables @ref uct_iface_attr_v2_t::iface_addr_len */
-    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN     = UCS_BIT(3),
+    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN           = UCS_BIT(3),
 
     /** Enables @ref uct_iface_attr_v2_t::ep_addr_len*/
-    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN        = UCS_BIT(4),
+    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN              = UCS_BIT(4),
 
     /** Enables @ref uct_iface_attr_v2_t::max_num_eps */
-    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS        = UCS_BIT(5),
+    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS              = UCS_BIT(5),
 
     /** Enables @ref uct_iface_attr_v2_t::put */
-    UCT_IFACE_ATTR_FIELD_PUT                = UCS_BIT(6),
+    UCT_IFACE_ATTR_FIELD_PUT                      = UCS_BIT(6),
 
     /** Enables @ref uct_iface_attr_v2_t::get */
-    UCT_IFACE_ATTR_FIELD_GET                = UCS_BIT(7),
+    UCT_IFACE_ATTR_FIELD_GET                      = UCS_BIT(7),
 
     /** Enables @ref uct_iface_attr_v2_t::am */
-    UCT_IFACE_ATTR_FIELD_AM                 = UCS_BIT(8),
+    UCT_IFACE_ATTR_FIELD_AM                       = UCS_BIT(8),
 
     /** Enables @ref uct_iface_attr_v2_t::tag::receive */
-    UCT_IFACE_ATTR_FIELD_TAG_RECEIVE        = UCS_BIT(9),
+    UCT_IFACE_ATTR_FIELD_TAG_RECEIVE              = UCS_BIT(9),
 
     /** Enables @ref uct_iface_attr_v2_t::tag::max_outstanding */
-    UCT_IFACE_ATTR_FIELD_MAX_OUTSTANDING    = UCS_BIT(10),
+    UCT_IFACE_ATTR_FIELD_TAG_RECV_MAX_OUTSTANDING = UCS_BIT(10),
 
     /** Enables @ref uct_iface_attr_v2_t::tag::eager */
-    UCT_IFACE_ATTR_FIELD_TAG_EAGER          = UCS_BIT(11),
-                                                        
-    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */  
-    UCT_IFACE_ATTR_FIELD_TAG_RNDV           = UCS_BIT(12),
-                                                        
+    UCT_IFACE_ATTR_FIELD_TAG_EAGER                = UCS_BIT(11),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */
+    UCT_IFACE_ATTR_FIELD_TAG_RNDV                 = UCS_BIT(12),
+
     /** Enables @ref uct_iface_attr_v2_t::atomic32::op_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS  = UCS_BIT(13),
-                                                        
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS        = UCS_BIT(13),
+
     /** Enables @ref uct_iface_attr_v2_t::atomic32::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS = UCS_BIT(14),
-                                                        
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS       = UCS_BIT(14),
+
     /** Enables @ref uct_iface_attr_v2_t::atomic64::op_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(15),
-                                                        
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS        = UCS_BIT(15),
+
     /** Enables @ref uct_iface_attr_v2_t::atomic64::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(16)
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS       = UCS_BIT(16)
 } uct_iface_attr_field_t;
 
 /**
@@ -1254,7 +1254,7 @@ typedef struct uct_iface_attr_v2 {
         uct_iface_op_attr_t *recv;
 
         /** Maximal number of simultaneous receive operations */
-        size_t              max_outstanding;
+        size_t              recv_max_outstanding;
 
         /** Attributes related to eager protocol */
         uct_iface_op_attr_t *eager;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1083,6 +1083,182 @@ ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result);
 
+typedef enum {
+    /** Enables @ref uct_iface_op_attr::max_short */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_SHORT       = UCS_BIT(0),
+
+    /** Enables @ref uct_iface_op_attr::max_bcopy */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_BCOPY       = UCS_BIT(1),
+
+    /** Enables @ref uct_iface_op_attr::min_zcopy */
+    UCT_IFACE_OP_ATTR_FIELD_MIN_ZCOPY       = UCS_BIT(2),
+
+    /** Enables @ref uct_iface_op_attr::max_zcopy */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_ZCOPY       = UCS_BIT(3),
+
+    /** Enables @ref uct_iface_op_attr::opt_zcopy_align */
+    UCT_IFACE_OP_ATTR_FIELD_OPT_ZCOPY_ALIGN = UCS_BIT(4),
+
+    /** Enables @ref uct_iface_op_attr::align_mtu */
+    UCT_IFACE_OP_ATTR_FIELD_ALIGN_MTU       = UCS_BIT(5),
+
+    /** Enables @ref uct_iface_op_attr::max_hdr */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_HDR         = UCS_BIT(6),
+
+    /** Enables @ref uct_iface_op_attr::max_iov */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_IOV         = UCS_BIT(7)
+} uct_iface_op_attr_field_t;
+
+typedef struct uct_iface_op_attr {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_iface_op_attr_field_t.
+     */
+    uint64_t field_mask;
+    /** Maximal size for short */
+    size_t   max_short;
+    /** Maximal size for bcopy */
+    size_t   max_bcopy;
+    /** Minimal size for zcopy (total of
+     * @ref uct_iov_t::length of the @a iov parameter) */
+    size_t   min_zcopy;
+    /** Maximal size for zcopy (total of
+     * @ref uct_iov_t::length of the @a iov parameter) */
+    size_t   max_zcopy;
+    /** Optimal alignment for zero-copy buffer address */
+    size_t   opt_zcopy_align;
+    /** MTU used for alignment */
+    size_t   align_mtu;
+    /** Max. header size for zcopy */
+    size_t   max_hdr;
+    /** Maximal @a iovcnt  */
+    size_t   max_iov;
+} uct_iface_op_attr_t;
+
+typedef enum {
+    /** Enables @ref uct_iface_attr_v2_t::put */
+    UCT_IFACE_ATTR_FIELD_PUT                = UCS_BIT(0),
+
+    /** Enables @ref uct_iface_attr_v2_t::get */
+    UCT_IFACE_ATTR_FIELD_GET                = UCS_BIT(1),
+
+    /** Enables @ref uct_iface_attr_v2_t::am */
+    UCT_IFACE_ATTR_FIELD_AM                 = UCS_BIT(2),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::receive */
+    UCT_IFACE_ATTR_FIELD_TAG_RECEIVE        = UCS_BIT(3),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::eager */
+    UCT_IFACE_ATTR_FIELD_TAG_EAGER          = UCS_BIT(4),
+
+    /** Enables @ref uct_iface_attr_v2_t::tag::rndv */
+    UCT_IFACE_ATTR_FIELD_TAG_RNDV           = UCS_BIT(5),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic32::op_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_OP_FLAGS  = UCS_BIT(6),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic32::fop_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC32_FOP_FLAGS = UCS_BIT(7),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic64::op_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(8),
+
+    /** Enables @ref uct_iface_attr_v2_t::atomic64::fop_flags */
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(9),
+
+    /** Enables @ref uct_iface_attr_v2_t::flags*/
+    UCT_IFACE_ATTR_FIELD_FLAGS              = UCS_BIT(10),
+
+    /** Enables @ref uct_iface_attr_v2_t::event_flags*/
+    UCT_IFACE_ATTR_FIELD_EVENT_FLAGS        = UCS_BIT(11),
+
+    /** Enables @ref uct_iface_attr_v2_t::device_addr_len */
+    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR_LEN    = UCS_BIT(12),
+
+    /** Enables @ref uct_iface_attr_v2_t::iface_addr_len */
+    UCT_IFACE_ATTR_FIELD_IFACE_ADDR_LEN     = UCS_BIT(13),
+
+    /** Enables @ref uct_iface_attr_v2_t::ep_addr_len*/
+    UCT_IFACE_ATTR_FIELD_EP_ADDR_LEN        = UCS_BIT(14),
+
+    /** Enables @ref uct_iface_attr_v2_t::max_num_eps */
+    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS        = UCS_BIT(15),
+} uct_iface_attr_field_t;
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Interface attributes: capabilities and limitations.
+ */
+typedef struct uct_iface_attr_v2 {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_iface_attr_field_t.
+     */
+    uint64_t            field_mask;
+
+    /** Attributes for PUT operations */
+    uct_iface_op_attr_t *put;
+
+    /** Attributes for GET operations */
+    uct_iface_op_attr_t *get;
+
+    /** Attributes for AM operations */
+    uct_iface_op_attr_t *am;
+
+    /** Attributes for TAG operations */
+    struct {
+        /** Attributes related to receive protocol */
+        uct_iface_op_attr_t *recv;
+
+        /** Attributes related to eager protocol */
+        uct_iface_op_attr_t *eager;
+
+        /** Attributes related to rendezvous protocol */
+        uct_iface_op_attr_t *rndv;
+    } tag;
+
+    /** Attributes for atomic operations */
+    struct {
+        /** Attributes for atomic-post operations */
+        uint64_t op_flags;
+        /** Attributes for atomic-fetch operations */
+        uint64_t fop_flags;
+    } atomic32, atomic64;
+
+    /** Flags from @ref UCT_RESOURCE_IFACE_CAP */
+    uint64_t flags;
+
+    /** Flags from @ref UCT_RESOURCE_IFACE_EVENT_CAP */
+    uint64_t event_flags;
+
+    /** Size of device address */
+    size_t   device_addr_len;
+
+    /** Size of interface address */
+    size_t   iface_addr_len;
+
+    /** Size of endpoint address */
+    size_t   ep_addr_len;
+
+    /** Maximum number of endpoints */
+    size_t   max_num_eps;
+} uct_iface_attr_v2_t;
+
+
+/**
+ *
+ * @ingroup UCT_RESOURCE
+ * @brief Get interface selected attributes.
+ *
+ * Retreives attributes specified by the @ref uct_iface_attr_v2_t::field_mask
+ *
+ * @param [in]  iface      Interface to query.
+ * @param [out] iface_attr Filled with interface attributes.
+ */
+ucs_status_t
+uct_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr);
+
+
 END_C_DECLS
 
 #endif

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1113,7 +1113,10 @@ typedef enum {
     UCT_IFACE_OP_ATTR_FIELD_MAX_ZCOPY_HDR   = UCS_BIT(6),
 
     /** Enables @ref uct_iface_op_attr::max_iov */
-    UCT_IFACE_OP_ATTR_FIELD_MAX_IOV         = UCS_BIT(7)
+    UCT_IFACE_OP_ATTR_FIELD_MAX_IOV         = UCS_BIT(7),
+
+    /** Enables @ref uct_iface_op_attr::max_outstanding */
+    UCT_IFACE_OP_ATTR_FIELD_MAX_OUTSTANDING = UCS_BIT(8)
 } uct_iface_op_attr_field_t;
 
 
@@ -1148,6 +1151,8 @@ typedef struct uct_iface_op_attr {
     size_t   max_zcopy_hdr;
     /** Maximal @a iovcnt  */
     size_t   max_iov;
+    /** Maximal number of simultaneous receive operations */
+    size_t   max_outstanding;
 } uct_iface_op_attr_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1083,9 +1083,12 @@ ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result);
 
+
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface operations capabilities and limitation field mask flags
+ * @brief @ref uct_iface_op_attr_t field mask flags
+ * The enumeration allows specifying which fields in @ref uct_iface_op_attr_t are
+ * present. It is used to enable backward compatibility support.
  */
 typedef enum {
     /** Enables @ref uct_iface_op_attr::max_short */
@@ -1116,7 +1119,8 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface specific operations attributes, capabilities and limitations
+ * @brief Interface operations attributes, capabilities and limitations
+ * Capabilities and limitations of operations such as put, get, am and tag.
  */
 typedef struct uct_iface_op_attr {
     /**
@@ -1147,7 +1151,9 @@ typedef struct uct_iface_op_attr {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface attributes capabilities field mask flags 
+ * @brief @ref uct_iface_attr_v2_t field mask flags 
+ * The enumeration allows specifying which fields in @ref uct_iface_attr_v2_t are
+ * present. It is used to enable backward compatibility support.
  */
 typedef enum {
     /** Enables @ref uct_iface_attr_v2_t::flags*/
@@ -1196,7 +1202,7 @@ typedef enum {
     UCT_IFACE_ATTR_FIELD_ATOMIC64_OP_FLAGS  = UCS_BIT(14),
 
     /** Enables @ref uct_iface_attr_v2_t::atomic64::fop_flags */
-    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(15),
+    UCT_IFACE_ATTR_FIELD_ATOMIC64_FOP_FLAGS = UCS_BIT(15)
 } uct_iface_attr_field_t;
 
 /**
@@ -1211,22 +1217,22 @@ typedef struct uct_iface_attr_v2 {
     uint64_t            field_mask;
 
     /** Flags from @ref UCT_RESOURCE_IFACE_CAP */
-    uint64_t flags;
+    uint64_t            flags;
 
     /** Flags from @ref UCT_RESOURCE_IFACE_EVENT_CAP */
-    uint64_t event_flags;
+    uint64_t            event_flags;
 
     /** Size of device address */
-    size_t   device_addr_len;
+    size_t              device_addr_len;
 
     /** Size of interface address */
-    size_t   iface_addr_len;
+    size_t              iface_addr_len;
 
     /** Size of endpoint address */
-    size_t   ep_addr_len;
+    size_t              ep_addr_len;
 
     /** Maximum number of endpoints */
-    size_t   max_num_eps;
+    size_t              max_num_eps;
 
     /** Attributes for PUT operations */
     uct_iface_op_attr_t *put;


### PR DESCRIPTION
## What
API PR for uct_iface_query_v2 

## Why ?
To enable adding new fields to be queried by uct_iface_query without breaking compatibility (field_mask)
We plan to add new field to specify the number of supported active message priorities.