### PR TITLE
UCT/IB: add UCX_IB_PRIORITY_SLS env configuration

### DIFF
--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -195,6 +195,10 @@ struct uct_ib_iface_config {
 
     /* IB reverse SL (default: AUTO - same value as sl) */
     unsigned long           reverse_sl;
+
+    /* IB priority SLs array, mapping SLs by priorities as index 
+       (default: AUTO - the entire array will be set to value of sl) */
+    UCS_CONFIG_ARRAY_FIELD(unsigned long, priority_sls) priority_sls;
 };
 
 
@@ -299,6 +303,7 @@ struct uct_ib_iface {
         uint8_t               port_num;
         uint8_t               sl;
         uint8_t               reverse_sl;
+        uint8_t               priority_sls[UCT_IB_SL_NUM];
         uint8_t               traffic_class;
         uint8_t               hop_limit;
         uint8_t               qp_type;
@@ -586,8 +591,9 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface,
 
 uint8_t uct_ib_iface_config_select_sl(const uct_ib_iface_config_t *ib_config);
 
-void uct_ib_iface_set_reverse_sl(uct_ib_iface_t *ib_iface,
-                                 const uct_ib_iface_config_t *ib_config);
+ucs_status_t
+uct_ib_iface_set_configured_sls(uct_ib_iface_t *ib_iface,
+                                const uct_ib_iface_config_t *ib_config);
 
 uint16_t uct_ib_iface_resolve_remote_flid(uct_ib_iface_t *iface,
                                           const union ibv_gid *gid);

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -1065,8 +1065,7 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
             goto out;
         }
 
-        uct_ib_iface_set_reverse_sl(iface, ib_config);
-        return status;
+        return uct_ib_iface_set_configured_sls(iface, ib_config);
     }
 
 #if HAVE_DEVX
@@ -1086,7 +1085,7 @@ uct_ib_mlx5_iface_select_sl(uct_ib_iface_t *iface,
         goto out;
     }
 
-    uct_ib_iface_set_reverse_sl(iface, ib_config);
+    uct_ib_iface_set_configured_sls(iface, ib_config);
 
 out:
     return status;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -298,7 +298,11 @@ static UCS_CLASS_INIT_FUNC(uct_rc_verbs_iface_t, uct_md_h tl_md,
     self->super.config.fence_mode        = (uct_rc_fence_mode_t)config->super.super.fence_mode;
     self->super.progress                 = uct_rc_verbs_iface_progress;
     self->super.super.config.sl          = uct_ib_iface_config_select_sl(ib_config);
-    uct_ib_iface_set_reverse_sl(&self->super.super, ib_config);
+
+    status = uct_ib_iface_set_configured_sls(&self->super.super, ib_config);
+    if (status != UCS_OK) {
+        goto err;
+    }
 
     if ((config->super.super.fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         (config->super.super.fence_mode == UCT_RC_FENCE_MODE_AUTO)) {

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -758,7 +758,12 @@ static UCS_CLASS_INIT_FUNC(uct_ud_verbs_iface_t, uct_md_h md, uct_worker_h worke
                               worker, params, config, &init_attr);
 
     self->super.super.config.sl = uct_ib_iface_config_select_sl(&config->super);
-    uct_ib_iface_set_reverse_sl(&self->super.super, &config->super);
+
+    status = uct_ib_iface_set_configured_sls(&self->super.super,
+                                             &config->super);
+    if (status != UCS_OK) {
+        return status;
+    }
 
     memset(&self->tx.wr_inl, 0, sizeof(self->tx.wr_inl));
     self->tx.wr_inl.opcode            = IBV_WR_SEND;


### PR DESCRIPTION
## What
New env configuration - UCX_IB_PRIORITY_SLS - a list separated by comma listing SLS for each priority, priority is indicated by index, meaning first SL to be used as lowest priority (0) and last SL as highest priority.

## Why ?
As part of the upcoming [new feature of setting priority for active messages](https://github.com/openucx/ucx/pull/9504), we would want to map priorities to SLs (service levels) in IB transports