### PR TITLE
UCT/ROCM: adjust rocm/ipc performance parameters - v1.16.x

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -32,18 +32,14 @@ static ucs_config_field_t uct_rocm_copy_iface_config_table[] = {
      ucs_offsetof(uct_rocm_copy_iface_config_t, h2d_thresh),
      UCS_CONFIG_TYPE_MEMUNITS},
 
-    {"ENABLE_ASYNC_ZCOPY", "y",
-     "Enable asynchronous zcopy operations",
+    {"ENABLE_ASYNC_ZCOPY", "y", "Enable asynchronous zcopy operations",
      ucs_offsetof(uct_rocm_copy_iface_config_t, enable_async_zcopy),
      UCS_CONFIG_TYPE_BOOL},
 
-    {"LAT", "2e-7",
-     "Latency",
-     ucs_offsetof(uct_rocm_copy_iface_config_t, latency),
-     UCS_CONFIG_TYPE_TIME},
+    {"LAT", "1e-7", "Latency",
+     ucs_offsetof(uct_rocm_copy_iface_config_t, latency), UCS_CONFIG_TYPE_TIME},
 
-    {"SIGPOOL_MAX_ELEMS", "1024",
-     "Maximum number of elements in signal pool",
+    {"SIGPOOL_MAX_ELEMS", "1024", "Maximum number of elements in signal pool",
      ucs_offsetof(uct_rocm_copy_iface_config_t, sigpool_max_elems),
      UCS_CONFIG_TYPE_UINT},
 

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -17,10 +17,17 @@ typedef struct uct_rocm_ipc_iface {
     uct_base_iface_t super;
     ucs_mpool_t signal_pool;
     ucs_queue_head_t signal_queue;
+    struct {
+        size_t min_zcopy;
+        double latency;
+    } config;
+
 } uct_rocm_ipc_iface_t;
 
 typedef struct uct_rocm_ipc_iface_config {
     uct_iface_config_t super;
+    size_t             min_zcopy;
+    double             latency;
 } uct_rocm_ipc_iface_config_t;
 
 #endif


### PR DESCRIPTION
## What
introduce two new parameters for rocm/ipc that allow to fine tune the protocol selection. 

## Why ?
They help to resolve the issue seen with v2 protocols for short message intra-node collective operations.

Backport #9568 
