### PR TITLE
UCS/ARRAY: Use bit field for array is_fixed flag

### DIFF
--- a/src/ucs/datastruct/callbackq.c
+++ b/src/ucs/datastruct/callbackq.c
@@ -63,7 +63,7 @@ struct ucs_callbackq_priv {
     uint64_t                                          fast_remove_mask;
 
     /* Callback ID to index mapping */
-    ucs_array_s(int, unsigned)                        idxs;
+    ucs_array_s(unsigned, unsigned)                   idxs;
 
     /* Index of first free item in the freelist */
     int                                               free_idx_id;

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -69,9 +69,9 @@ BEGIN_C_DECLS
 
 #define UCS_ENABLE_ASSERT 0
 
-#define ucs_bug(...)
-#define ucs_assert(...)
-#define ucs_assertv(...)
+#define ucs_bug(...)     do {} while(0)
+#define ucs_assert(...)  do {} while(0)
+#define ucs_assertv(...) do {} while(0)
 
 #endif
 

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -177,6 +177,14 @@
     ucs_typeof(((_type*)0)->_field)
 
 /**
+ * @param _type   Integer type.
+ *
+ * @return Whether integer type is unsigned.
+ */
+#define ucs_is_unsigned_type(_type) \
+    ((_type)(-1) > (_type)(0))
+
+/**
  * Prevent compiler from reordering instructions
  */
 #define ucs_compiler_fence()       asm volatile(""::: "memory")

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -9,6 +9,7 @@ extern "C" {
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/datastruct/string_buffer.h>
 #include <ucs/datastruct/string_set.h>
+#include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
 }
 
@@ -257,8 +258,8 @@ void test_string_buffer::test_fixed(ucs_string_buffer_t *strb, size_t capacity)
     ucs_string_buffer_appendf(strb, "%s", "mrmeeseeks");
     ucs_string_buffer_appendf(strb, "%s", "lookatme");
 
-    EXPECT_LE(ucs_string_buffer_length(strb), capacity - 1);
-    EXPECT_EQ(std::string("immrmeeseeksloo"), ucs_string_buffer_cstr(strb));
+    EXPECT_EQ(ucs_string_buffer_length(strb), capacity - 1);
+    EXPECT_EQ(std::string("immrmeeseekslook"), ucs_string_buffer_cstr(strb));
 }
 
 UCS_TEST_F(test_string_buffer, fixed_static) {


### PR DESCRIPTION
## What
2 improvements in this PR:
- Use bit field in ucs_array for storing `is_fixed` flag
- Allow to create array of dynamic (not just compile-time constant) size on stack 

## Why ?
Before this change we used lower bit of ucs_array `capacity` field to store the "fixed" flag.
There are 2 issues with this design choice:
- debugability: while you see certain value in the debugger for array capacity (e.g. say 3), this might not be the REAL capacity of an array, because LSB is simply disregarded when checking capacity. This is ambiguous and error-prone
- can't use full capacity of fixed array in some cases.
The problem here is that despite the REAL capacity is 3, ucs_array_capacity returns 2, because it discards the LSB. For dynamic arrays this is not an issue - it will just grow a bit in advance (still not good). But for fixed array this IS an issue: we cannot use full capacity of an array, and we cannot allocate more by definition.

For the second improvement - previously we were able to create arrays of compile-time-constant size on stack. However this does not allow user to create arrays of runtime size on stack, which is sometimes desirable. The idea here is to use ucs_alloca that imposes array size constraints at runtime.

## How ?
We discussed with Yossi whether we should use LSB or MSB of ucs_array capacity for storing "fixed" flag. I measured performance of both approaches and don't see any difference. However I have a slight preference of placing new bit field `is_fixed` after the `capacity` field (= LSB approach), just to maintain the same order of assignment.
Currently we have `{ buf, size, capacity }` static initializer for array, so I just wanted to keep the order these first three fields the same as before. This is safer option IMO
