### PR TITLE
AZP/RELEASE: Fix dual release - v1.16.x

### DIFF
--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -2,7 +2,9 @@ parameters:
   arch:
   container:  
   demands: []
-
+  temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/tmp-settings.xml
+  gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg
+  
 jobs:
   - job: jucx_build_${{ parameters.arch }}
     displayName: JUCX build ${{ parameters.arch }}


### PR DESCRIPTION
## What
Add missing params to Java build.

## Why ?
Failure to publish Java build.
[Failure log
](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=74066&view=logs&j=2e2740d9-d4aa-5179-08dd-ad68a55c4bdb&t=d0bcc340-d162-529a-87d7-53d53d7ac2c5&l=20)