### PR TITLE
UCT/IB: Auto-detect GID idx with FLID routing

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -651,7 +651,7 @@ const uct_ib_device_spec_t* uct_ib_device_spec(uct_ib_device_t *dev)
 static unsigned long uct_ib_device_get_ib_gid_index(uct_ib_md_t *md)
 {
     if (md->config.gid_index == UCS_ULUNITS_AUTO) {
-        return UCT_IB_MD_DEFAULT_GID_INDEX;
+        return UCT_IB_DEVICE_DEFAULT_GID_INDEX;
     } else {
         return md->config.gid_index;
     }
@@ -907,7 +907,7 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
         }
     }
 
-    gid_info->gid_index             = UCT_IB_MD_DEFAULT_GID_INDEX;
+    gid_info->gid_index             = UCT_IB_DEVICE_DEFAULT_GID_INDEX;
     gid_info->roce_info.ver         = UCT_IB_DEVICE_ROCE_V1;
     gid_info->roce_info.addr_family = AF_INET;
 

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -53,6 +53,10 @@
 #define UCT_IB_SITE_LOCAL_PREFIX          be64toh(0xfec0000000000000ul) /* IBTA 4.1.1 12b */
 #define UCT_IB_SITE_LOCAL_MASK            be64toh(0xffffffffffff0000ul) /* IBTA 4.1.1 12b */
 #define UCT_IB_SITE_LOCAL_FLID_MASK       be64toh(0xffffffff00000000ul) /* site-local + flid */
+#define UCT_IB_GUID_OPENIB_OUI            0x001405 /* An OUI is a 24 bit globally unique assigned
+                                                      number referenced by various standards.
+                                                      IB_OPENIB_OUI is part of the routable alias
+                                                      GUID built by SM. */
 #define UCT_IB_DEFAULT_ROCEV2_DSCP        106  /* Default DSCP for RoCE v2 */
 #define UCT_IB_ROCE_UDP_SRC_PORT_BASE     0xC000
 #define UCT_IB_CQE_SL_PKTYPE_MASK         0x7 /* SL for IB or packet type
@@ -65,6 +69,9 @@
 #define UCT_IB_DEVICE_SYSFS_GID_NDEV_FMT  UCT_IB_DEVICE_SYSFS_GID_ATTR_PFX "/ndevs/%d"
 #define UCT_IB_DEVICE_ECE_DEFAULT         0x0         /* default ECE */
 #define UCT_IB_DEVICE_ECE_MAX             0xffffffffU /* max ECE */
+#define UCT_IB_DEVICE_DEFAULT_GID_INDEX 0   /* The gid index used by default for an IB/RoCE port */
+#define UCT_IB_DEVICE_ROUTABLE_FLID_GID_INDEX 1 /* The gid index used by default
+                                                   with FLID based IB routing */
 
 
 enum {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -18,8 +18,6 @@
 #define UCT_IB_MD_PACKED_RKEY_SIZE   sizeof(uint64_t)
 #define UCT_IB_MD_INVALID_FLUSH_RKEY 0xff
 
-#define UCT_IB_MD_DEFAULT_GID_INDEX 0   /**< The gid index used by default for an IB/RoCE port */
-
 #define UCT_IB_MEM_ACCESS_FLAGS  (IBV_ACCESS_LOCAL_WRITE | \
                                   IBV_ACCESS_REMOTE_WRITE | \
                                   IBV_ACCESS_REMOTE_READ | \

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -485,15 +485,15 @@ static ucs_status_t uct_rdmacm_cm_id_to_dev_addr(uct_rdmacm_cm_t *cm,
         /* For local IB address, assume the remote subnet prefix is the same
          * and pack it to make reachability check pass */
         ret = ibv_query_gid(cm_id->verbs, cm_id->port_num,
-                            UCT_IB_MD_DEFAULT_GID_INDEX, &params.gid);
+                            UCT_IB_DEVICE_DEFAULT_GID_INDEX, &params.gid);
         if (ret) {
             ucs_error("ibv_query_gid(dev=%s port=%d index=%d) failed: %m",
                       ibv_get_device_name(cm_id->verbs->device),
-                      cm_id->port_num, UCT_IB_MD_DEFAULT_GID_INDEX);
+                      cm_id->port_num, UCT_IB_DEVICE_DEFAULT_GID_INDEX);
             return UCS_ERR_IO_ERROR;
         }
 
-        params.gid_index = UCT_IB_MD_DEFAULT_GID_INDEX;
+        params.gid_index = UCT_IB_DEVICE_DEFAULT_GID_INDEX;
         params.flags    |= UCT_IB_ADDRESS_PACK_FLAG_SUBNET_PREFIX |
                            UCT_IB_ADDRESS_PACK_FLAG_GID_INDEX;
     }


### PR DESCRIPTION
## What
Use routable gid when FLID routing is configured and enabled

## Why ?
better use experience, no need to set GID manually for FLID based routing to work properly