### PR TITLE
AZP/RELEASE: Refactor GPG sign and publish of Jar files - 1.16.x

### DIFF
--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -129,12 +129,10 @@ publish-snapshot:
 
 publish-release:
 	@make set-version JUCX_VERSION=${JUCX_VERSION}
-	@make repack-jar
-	@make check-jar
 	@make publish
 
 publish:
-	$(MVNCMD) deploy:deploy-file -Dfile=$(jarfile) -DskipTests ${ARGS}
+	$(MVNCMD) deploy -DskipTests ${ARGS}
 
 test:
 	$(MVNCMD) test -DargLine="-XX:OnError='cat hs_err_pid%p.log'"

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -20,6 +20,7 @@ resources:
       options: $(DOCKER_OPT_VOLUMES)
     - container: centos8_cuda11_x86_64
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/centos8-mofed5-cuda11:3
+      options: $(DOCKER_OPT_VOLUMES)
     - container: ubuntu16_cuda11_x86_64
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu16.04-mofed5-cuda11:3
     - container: ubuntu18_cuda11_x86_64
@@ -112,7 +113,7 @@ stages:
       - template: jucx/jucx-build.yml
         parameters:
           arch: amd64
-          container: centos7_cuda11_x86_64
+          container: centos8_cuda11_x86_64
           demands: ucx_docker
 
       - template: jucx/jucx-build.yml

--- a/buildlib/dockers/centos-release.Dockerfile
+++ b/buildlib/dockers/centos-release.Dockerfile
@@ -5,27 +5,28 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-centos${OS_VERSION}
 RUN yum install -y \
     autoconf \
     automake \
+    environment-modules \
+    ethtool \
     file \
+    fuse-libs \
     gcc-c++ \
     git \
     glibc-devel \
     libtool \
+    libusbx \
+    lsof \
     make \
     maven \
     numactl-devel \
+    pinentry \
+    python36 \
     rdma-core-devel \
     rpm-build \
     tcl \
     tcsh \
     tk \
-    wget \
-    libusbx \
-    fuse-libs \
-    python36 \
-    lsof \
-    ethtool \
-    environment-modules \
     valgrind-devel \
+    wget \
     && yum clean all
 
 # MOFED

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -8,6 +8,9 @@ parameters:
 jobs:
   - job: jucx_build_${{ parameters.arch }}
     displayName: JUCX build ${{ parameters.arch }}
+    variables:
+      ${{ if ne(parameters.arch, 'amd64') }}:
+        SUFFIX: "-${{ parameters.arch }}"
 
     # we need to use lowest version for compatibility
     container: ${{ parameters.container }}    
@@ -43,7 +46,7 @@ jobs:
           MAVEN_VERSION=${TAG:1}
           make -C bindings/java/src/main/native/ package JUCX_VERSION=${MAVEN_VERSION}
         displayName: Build JUCX
-        condition: eq(variables['Build.Reason'], 'PullRequest')
+        condition: eq(variables['Build.Reason'], 'IndividualCI')
 
       - bash: |
           set -eE
@@ -82,12 +85,20 @@ jobs:
           cp $(publicKey.secureFilePath)  ${{ parameters.gpg_dir }}/pubring.gpg
           cp $(privateKey.secureFilePath) ${{ parameters.gpg_dir }}/secring.gpg
           export GNUPGHOME=${{ parameters.gpg_dir }}
+
+          # GPG agent config
+          echo "use-agent" > $GNUPGHOME/gpg.conf
+          echo "pinentry-mode loopback" >> $GNUPGHOME/gpg.conf
+          echo "allow-loopback-pinentry" > $GNUPGHOME/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye || true
+
           TAG=`git describe --tags`
           # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
           # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
           MAVEN_VERSION=${TAG:1}
           make -C bindings/java/src/main/native/ publish-release \
-              ARGS="--settings ${{ parameters.temp_cfg }}" JUCX_VERSION=${MAVEN_VERSION}
+              ARGS="--settings ${{ parameters.temp_cfg }}" \
+              JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
         displayName: Publish JUCX jar to maven central
         condition: eq(variables['Build.Reason'], 'IndividualCI')
         env:


### PR DESCRIPTION
## What
Refactoring the process for releasing Jar files to enable build, sign, and publishing per platform.

## Why ?
Failures in Maven publish otherwise.

## How ?
1. Move forward from CentOS-7 to CentOS-8 due to the outdated GPG agent.
2. Add the 'pinentry' package in Docker.
3. Configure the GPG agent to use pinentry.
4. Add filename suffix for non-x86 platforms.
