### PR TITLE
UCT/ROCM: set parameters dependent on GPU type

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -501,6 +501,54 @@ ucs_status_t uct_rocm_base_get_link_type(hsa_amd_link_info_type_t *link_type)
     return UCS_OK;
 }
 
+uct_rocm_amd_gpu_product_t uct_rocm_base_get_gpu_product(void)
+{
+    uct_rocm_amd_gpu_product_t gpu_product = UCT_ROCM_AMD_GPU_MI200;
+    char product_name[64];
+    char gfx_name[64];
+    hsa_status_t status;
+
+    /* fetching data from GPU 0, assuming all GPUs on a node are
+       identical */
+    status = hsa_agent_get_info(uct_rocm_base_agents.gpu_agents[0],
+                                (hsa_agent_info_t)
+                                        HSA_AMD_AGENT_INFO_PRODUCT_NAME,
+                                (void*)product_name);
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_debug("Error in hsa_agent_info %d", status);
+        return gpu_product;
+    }
+
+    if (NULL != strstr(product_name, "MI300A")) {
+        gpu_product = UCT_ROCM_AMD_GPU_MI300A;
+        ucs_trace("found MI300A GPU");
+    } else if (NULL != strstr(product_name, "MI300X")) {
+        gpu_product = UCT_ROCM_AMD_GPU_MI300X;
+        ucs_trace("found MI300X GPU");
+    } else {
+        /* In case product_name is not set correctly, query the gfx
+           architecture name */
+        status = hsa_agent_get_info(uct_rocm_base_agents.gpu_agents[0],
+                                    (hsa_agent_info_t)HSA_AGENT_INFO_NAME,
+                                    (void*)gfx_name);
+        if (status != HSA_STATUS_SUCCESS) {
+            ucs_debug("error in hsa_agent_info %d", status);
+            return gpu_product;
+        }
+
+        if (NULL != strstr(gfx_name, "gfx94")) {
+            /* This is an MI300 GPU, but cannot say whether its the A or X
+               variant. Assuming A variant for now*/
+            gpu_product = UCT_ROCM_AMD_GPU_MI300A;
+            ucs_trace("found gfx94* GPU, assuming MI300A");
+        } else {
+            ucs_trace("assuming MI100/MI200 GPU");
+        }
+    }
+
+    return gpu_product;
+}
+
 UCS_MODULE_INIT() {
     UCS_MODULE_FRAMEWORK_DECLARE(uct_rocm);
     UCS_MODULE_FRAMEWORK_LOAD(uct_rocm, 0);

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -13,6 +13,13 @@
 #include <hsa.h>
 #include <hsa_ext_amd.h>
 
+/* First one is used as the default value */
+typedef enum uct_rocm_amd_gpu_product {
+    UCT_ROCM_AMD_GPU_UNDEFINED = -1,
+    UCT_ROCM_AMD_GPU_MI200,
+    UCT_ROCM_AMD_GPU_MI300A,
+    UCT_ROCM_AMD_GPU_MI300X
+} uct_rocm_amd_gpu_product_t;
 
 hsa_status_t uct_rocm_base_init(void);
 ucs_status_t uct_rocm_base_query_md_resources(uct_component_h component,
@@ -38,6 +45,7 @@ ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
                                      const size_t length,
                                      uct_md_mem_attr_t *mem_attr_p);
 ucs_status_t uct_rocm_base_get_link_type(hsa_amd_link_info_type_t *type);
+uct_rocm_amd_gpu_product_t uct_rocm_base_get_gpu_product(void);
 int uct_rocm_base_is_dmabuf_supported();
 
 #endif


### PR DESCRIPTION
## What
set the bandwidth values in the rocm/copy performance estimate functions based on the GPU type that we found. We use the same parameters for MI300A and MI300X at the moment, but the infrastructure is in place in case we need to distinguish between them at a later point.

## Why ?
Performance fixes with ucx 1.16 for non MI200 GPUs
