### PR TITLE
AZP/RELEASE: Rework JUCX verification & release processes

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -117,7 +117,33 @@
         </build>
       </profile>
 
+      <profile>
+        <id>local-deploy</id>
+        <properties>
+          <gpg.skip>true</gpg.skip>
+        </properties>
+        <distributionManagement>
+          <repository>
+            <id>local-repo</id>
+            <url>file://tmp</url>
+          </repository>
+        </distributionManagement>
+        <build>
+          <plugins>
+            <!-- Skip nexus staging for local deployment -->
+            <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <configuration>
+                <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
     </profiles>
+
+
 
   <issueManagement>
     <system>Github</system>

--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -119,18 +119,27 @@
 
       <profile>
         <id>local-deploy</id>
-        <properties>
-          <gpg.skip>true</gpg.skip>
-        </properties>
         <distributionManagement>
           <repository>
             <id>local-repo</id>
-            <url>file://tmp</url>
+            <name>Local Repository</name>
+            <url>file://bindings/java/src/main/native/build-java/</url>
           </repository>
         </distributionManagement>
         <build>
           <plugins>
-            <!-- Skip nexus staging for local deployment -->
+            <!-- Disable GPG signing -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>sign-artifacts</id>
+                  <phase>none</phase>
+                </execution>
+              </executions>
+            </plugin>
+            <!-- Skip nexus staging -->
             <plugin>
               <groupId>org.sonatype.plugins</groupId>
               <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -142,8 +151,6 @@
         </build>
       </profile>
     </profiles>
-
-
 
   <issueManagement>
     <system>Github</system>

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -131,7 +131,7 @@ publish-release:
 
 publish-local:
 	@make set-version JUCX_VERSION=${JUCX_VERSION}
-	$(MVNCMD) deploy -DskipTests -Plocal-deploy
+	$(MVNCMD) deploy -DskipTests ${ARGS} -Plocal-deploy
 
 publish:
 	$(MVNCMD) deploy -DskipTests ${ARGS}

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -122,9 +122,7 @@ check-jar:
 
 # Publish JUCX jar to maven central
 publish-snapshot:
-	@make set-version JUCX_VERSION=@VERSION@-SNAPSHOT
-	@make repack-jar
-	@make check-jar
+	@make set-version JUCX_VERSION=${JUCX_VERSION}-SNAPSHOT
 	@make publish
 
 publish-release:

--- a/bindings/java/src/main/native/Makefile.am
+++ b/bindings/java/src/main/native/Makefile.am
@@ -129,6 +129,10 @@ publish-release:
 	@make set-version JUCX_VERSION=${JUCX_VERSION}
 	@make publish
 
+publish-local:
+	@make set-version JUCX_VERSION=${JUCX_VERSION}
+	$(MVNCMD) deploy -DskipTests -Plocal-deploy
+
 publish:
 	$(MVNCMD) deploy -DskipTests ${ARGS}
 

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -115,9 +115,11 @@ stages:
           arch: amd64
           container: centos8_cuda11_x86_64
           demands: ucx_docker
+          target: publish-release
 
       - template: jucx/jucx-build.yml
         parameters:
           arch: aarch64
           container: centos8_cuda11_aarch64
           demands: ucx-arm64
+          target: publish-release

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -44,9 +44,11 @@ stages:
           arch: amd64
           container: centos8_cuda11_x86_64
           demands: ucx_docker
+          target: publish-snapshot
 
       - template: jucx/jucx-build.yml
         parameters:
           arch: aarch64
           container: centos8_cuda11_aarch64
           demands: ucx-arm64
+          target: publish-snapshot

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -1,6 +1,3 @@
-# See https://aka.ms/yaml
-# This pipeline to be run on direct pushes and merges
-
 pr:
   - master
   - v*.*.x
@@ -8,11 +5,18 @@ trigger:
   - master
   - v*.*.x
 
+variables:
+  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local
+
 resources:
   containers:
-    - container: centos7_cuda11
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5-cuda11:2
-
+    - container: centos8_cuda11_x86_64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/centos8-mofed5-cuda11:3
+      options: $(DOCKER_OPT_VOLUMES)
+    - container: centos8_cuda11_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/centos8-mofed5-cuda11:3
+      options: $(DOCKER_OPT_VOLUMES)
+      
 stages:
   - stage: Prepare
     jobs:
@@ -30,13 +34,19 @@ stages:
               set -x
               check_release_build $(Build.Reason) $(Build.SourceVersion) "AZP/SNAPSHOT: "
             name: Result
+            
   - stage: Build
     dependsOn: Prepare
     condition: eq(dependencies.Prepare.outputs['Check.Result.Launch'], 'True')
     jobs:
-      - template: jucx/jucx-publish.yml
+      - template: jucx/jucx-build.yml
         parameters:
-          ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-            target: publish-snapshot
-          ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-            target: package
+          arch: amd64
+          container: centos8_cuda11_x86_64
+          demands: ucx_docker
+
+      - template: jucx/jucx-build.yml
+        parameters:
+          arch: aarch64
+          container: centos8_cuda11_aarch64
+          demands: ucx-arm64

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -47,6 +47,21 @@ jobs:
           make -C bindings/java/src/main/native/ package JUCX_VERSION=${MAVEN_VERSION}
         displayName: Build JUCX
 
+
+      - bash: |
+          set -exE
+          source buildlib/az-helpers.sh
+          az_init_modules
+          az_module_load dev/mvn
+          az_module_load dev/jdk-1.8
+          TAG=`git describe --tags`
+          MAVEN_VERSION=${TAG:1}
+          make -C bindings/java/src/main/native/ publish-local \
+              JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
+        displayName: Local Publish of JUCX jar
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
+
       - bash: |
           set -eE
           {

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -2,6 +2,7 @@ parameters:
   arch:
   container:  
   demands: []
+  target:
 
 jobs:
   - job: jucx_build_${{ parameters.arch }}
@@ -46,21 +47,6 @@ jobs:
           MAVEN_VERSION=${TAG:1}
           make -C bindings/java/src/main/native/ package JUCX_VERSION=${MAVEN_VERSION}
         displayName: Build JUCX
-
-
-      - bash: |
-          set -exE
-          source buildlib/az-helpers.sh
-          az_init_modules
-          az_module_load dev/mvn
-          az_module_load dev/jdk-1.8
-          TAG=`git describe --tags`
-          MAVEN_VERSION=${TAG:1}
-          make -C bindings/java/src/main/native/ publish-local \
-              JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
-        displayName: Local Publish of JUCX jar
-        condition: eq(variables['Build.Reason'], 'PullRequest')
-
 
       - bash: |
           set -eE
@@ -109,10 +95,10 @@ jobs:
           # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
           # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
           MAVEN_VERSION=${TAG:1}
-          make -C bindings/java/src/main/native/ publish-snapshot \
+          make -C bindings/java/src/main/native/ ${{ parameters.target }} \
               ARGS="--settings $(temp_cfg)" \
               JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
-        displayName: Publish JUCX jar to maven central
+        displayName: Publish-Maven
         condition: eq(variables['Build.Reason'], 'IndividualCI')
         env:
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -2,13 +2,13 @@ parameters:
   arch:
   container:  
   demands: []
-  temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/tmp-settings.xml
-  gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg
-  
+
 jobs:
   - job: jucx_build_${{ parameters.arch }}
     displayName: JUCX build ${{ parameters.arch }}
     variables:
+      temp_cfg: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/tmp-settings.xml
+      gpg_dir: $(System.DefaultWorkingDirectory)/bindings/java/src/main/native/build-java/gpg    
       ${{ if ne(parameters.arch, 'amd64') }}:
         SUFFIX: "-${{ parameters.arch }}"
 
@@ -46,7 +46,6 @@ jobs:
           MAVEN_VERSION=${TAG:1}
           make -C bindings/java/src/main/native/ package JUCX_VERSION=${MAVEN_VERSION}
         displayName: Build JUCX
-        condition: eq(variables['Build.Reason'], 'IndividualCI')
 
       - bash: |
           set -eE
@@ -55,9 +54,8 @@ jobs:
             echo -e "<id>ossrh</id><username>\${env.SONATYPE_USERNAME}</username>"
             echo -e "<password>\${env.SONATYPE_PASSWORD}</password>"
             echo -e "</server></servers></settings>"
-          } > ${{ parameters.temp_cfg }}
+          } > $(temp_cfg)
         displayName: Generate temporary config
-        condition: eq(variables['Build.Reason'], 'IndividualCI')
 
       - task: DownloadSecureFile@1
         displayName: Download Secure file
@@ -79,12 +77,12 @@ jobs:
           # use the lowest supported Java version for compatibility:
           az_module_load dev/jdk-1.8
           mvn --version
-          mkdir -p ${{ parameters.gpg_dir }}
+          mkdir -p $(gpg_dir)
           export GPG_TTY=`tty`
-          chmod 700 ${{ parameters.gpg_dir }}
-          cp $(publicKey.secureFilePath)  ${{ parameters.gpg_dir }}/pubring.gpg
-          cp $(privateKey.secureFilePath) ${{ parameters.gpg_dir }}/secring.gpg
-          export GNUPGHOME=${{ parameters.gpg_dir }}
+          chmod 700 $(gpg_dir)
+          cp $(publicKey.secureFilePath)  $(gpg_dir)/pubring.gpg
+          cp $(privateKey.secureFilePath) $(gpg_dir)/secring.gpg
+          export GNUPGHOME=$(gpg_dir)
 
           # GPG agent config
           echo "use-agent" > $GNUPGHOME/gpg.conf
@@ -96,8 +94,8 @@ jobs:
           # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
           # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string
           MAVEN_VERSION=${TAG:1}
-          make -C bindings/java/src/main/native/ publish-release \
-              ARGS="--settings ${{ parameters.temp_cfg }}" \
+          make -C bindings/java/src/main/native/ publish-snapshot \
+              ARGS="--settings $(temp_cfg)" \
               JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
         displayName: Publish JUCX jar to maven central
         condition: eq(variables['Build.Reason'], 'IndividualCI')

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -1,9 +1,10 @@
 parameters:
-  name: java test
+  arch:
   demands: []
 
 jobs:
-  - job: ${{ parameters.name }}
+  - job: jucx_test_${{ parameters.arch }}
+    displayName: JUCX Test ${{ parameters.arch }}
     workspace:
       clean: all
       
@@ -26,7 +27,6 @@ jobs:
       - bash: |
           set -xeE
           source buildlib/az-helpers.sh
-          check_gpu ${{ parameters.name }}
           az_init_modules
           az_module_load dev/mvn
           az_module_load dev/jdk-${JAVA_VERSION}
@@ -37,6 +37,20 @@ jobs:
           make -j`nproc`
           make install
         displayName: Build UCX
+
+      - bash: |
+          set -exE
+          source buildlib/az-helpers.sh
+          az_init_modules
+          az_module_load dev/mvn
+          az_module_load dev/jdk-1.8
+          TAG=`git describe --tags`
+          MAVEN_VERSION=${TAG:1}
+          make -C bindings/java/src/main/native/ publish-local \
+              JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
+        displayName: Publish-Local
+        condition: eq(variables['Build.Reason'], 'PullRequest')
+
 
       - bash: |
           set -xeE

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -324,12 +324,13 @@ stages:
     jobs:
       - template: ../jucx/jucx-test.yml
         parameters:
-          name: new
-          demands: ucx_new -equals yes
+          arch: amd64
+          demands: ucx_gpu
+
       - template: ../jucx/jucx-test.yml
         parameters:
-          name: gpu
-          demands: ucx_gpu -equals yes
+          arch: aarch64
+          demands: ucx-arm64
 
   - stage: go
     dependsOn: [Static_check]


### PR DESCRIPTION
## What
Summary of actions per trigger:

| Trigger                          | Actions                                        |
| -------------------------------- | ---------------------------------------------- |
| **PR request**                   | 1. Ensure that the JAR compiles.                |
|                                  | 2. Publish to local FS.                         |
|                                  | 3. Run benchmark tests using the locally published JAR. |
| **Merge to master or release branches** | Publish Snapshot to Maven Central repo (mutable). |
| **Release (including RCs)**      |  Publish release JAR to Maven Central repo (immutable). |


## Why
The purpose is to detect possible JUCX compilation and publishing issues on the PR level.

## How:
Publish to Maven Central is defined at `jucx-build.yml`:

- The pipeline "UCX release" calls it with the target "publish-release".
- The pipeline "UCX snapshot" calls it with the target "publish-snapshot".

The local publish step is at `jucx-test.yml`, which is only called by the "UCX PR" pipeline.
