### PR TITLE
CI: Move Valgrind check to a separate stage

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -299,13 +299,11 @@ stages:
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: centos7_cuda11
-        valgrind_disable: yes
     - template: tests.yml
       parameters:
         name: new
         demands: ucx_new -equals yes
         test_perf: 1
-        valgrind_disable: yes
     - template: tests.yml
       parameters:
         name: roce
@@ -419,7 +417,35 @@ stages:
         test_perf: 0
         container: ubuntu22_cuda12
         asan_check: yes
-        valgrind_disable: yes
+
+  - stage: Valgrind
+    dependsOn: [Static_check]
+    jobs:
+    - template: tests.yml
+      parameters:
+        name: althca
+        demands: ucx_althca -equals yes
+        test_perf: 0
+        valgrind_check: yes
+    - template: tests.yml
+      parameters:
+        name: roce
+        demands: ucx_roce -equals yes
+        test_perf: 0
+        valgrind_check: yes
+    - template: tests.yml
+      parameters:
+        name: roce_proto_disable
+        demands: ucx_roce -equals yes
+        test_perf: 0
+        proto_enable: no
+        valgrind_check: yes
+    - template: tests.yml
+      parameters:
+        name: BlueField
+        demands: ucx_bf -equals yes
+        test_perf: 0
+        valgrind_check: yes
 
 #  - stage: Cuda_compatible
 #    dependsOn: [Static_check]

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -6,6 +6,7 @@ parameters:
   container:
   proto_enable: yes
   asan_check: no
+  valgrind_check: no
 
 jobs:
   - job: tests_${{ parameters.name }}
@@ -48,5 +49,5 @@ jobs:
           JENKINS_TEST_PERF: ${{ parameters.test_perf }}
           PROTO_ENABLE: ${{ parameters.proto_enable }}
           ASAN_CHECK: ${{ parameters.asan_check }}
-          JENKINS_NO_VALGRIND: ${{ parameters.valgrind_disable }}
+          VALGRIND_CHECK: ${{ parameters.valgrind_check }}
           RUNNING_IN_AZURE: yes


### PR DESCRIPTION
## What
Moves tests execution with enabled Valgrind to the separate stage of CI.

## Why
In that scheme, if valgrind fails but tests without valgrind passed, there is no need to rerun the tests without valgrind.
