### PR TITLE
GTEST/COMMON: check support for hipMallocPitch

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -121,6 +121,24 @@ bool mem_buffer::is_rocm_managed_supported()
 #endif
 }
 
+bool mem_buffer::is_rocm_malloc_pitch_supported()
+{
+#if HAVE_ROCM
+    hipError_t ret;
+    int imageSupport;
+
+    ret = hipDeviceGetAttribute(&imageSupport, hipDeviceAttributeImageSupport,
+                                0);
+    if (ret != hipSuccess) {
+        return false;
+    }
+
+    return (imageSupport == 1);
+#else
+    return false;
+#endif
+}
+
 const std::vector<ucs_memory_type_t>&  mem_buffer::supported_mem_types()
 {
     static std::vector<ucs_memory_type_t> vec;

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -88,6 +88,9 @@ public:
     /* returns whether ROCM device supports managed memory */
     static bool is_rocm_managed_supported();
 
+    /* returns whether ROCM device supports hipMallocPitch */
+    static bool is_rocm_malloc_pitch_supported();
+
     /* Return free memory on the BAR1 / GPU. If GPU is not used
      * SIZE_MAX is returned */
     static size_t get_bar1_free_size();

--- a/test/gtest/ucm/rocm_hooks.cc
+++ b/test/gtest/ucm/rocm_hooks.cc
@@ -141,11 +141,13 @@ UCS_TEST_F(rocm_hooks, test_hipMallocPitch) {
     void * dptr;
     size_t pitch;
 
-    ret = hipMallocPitch(&dptr, &pitch, 4, 8);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_alloc_events((void *)dptr, (pitch * 8));
+    if (mem_buffer::is_rocm_malloc_pitch_supported()) {
+        ret = hipMallocPitch(&dptr, &pitch, 4, 8);
+        ASSERT_EQ(ret, hipSuccess);
+        check_mem_alloc_events((void*)dptr, (pitch * 8));
 
-    ret = hipFree(dptr);
-    ASSERT_EQ(ret, hipSuccess);
-    check_mem_free_events((void *)dptr, 0);
+        ret = hipFree(dptr);
+        ASSERT_EQ(ret, hipSuccess);
+        check_mem_free_events((void*)dptr, 0);
+    }
 }


### PR DESCRIPTION
## What
gfx94* architectures do not support hipMallocPitch, so disable them in gtest. Add a check for image support on the GPU, which is  required for hipMallocPitch.