### PR TITLE
UCS/RCACHE: Fix events synchronization

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1487,7 +1487,6 @@ ucp_mem_rcache_create(ucp_context_h context, const char *name,
     rcache_params->ops                = &ucp_mem_rcache_ops;
 
     if (events) {
-        rcache_params->flags         |= UCS_RCACHE_FLAG_SYNC_EVENTS;
         rcache_params->ucm_events     = UCM_EVENT_VM_UNMAPPED |
                                         UCM_EVENT_MEM_TYPE_FREE;
     }

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -41,6 +41,7 @@ nobase_dist_libucs_la_HEADERS = \
 	datastruct/khash.h \
 	datastruct/linear_func.h \
 	datastruct/list.h \
+	datastruct/lockless_sync_def.h \
 	datastruct/mpool.h \
 	datastruct/mpool_set.h \
 	datastruct/pgtable.h \
@@ -100,7 +101,8 @@ noinst_HEADERS = \
 	datastruct/bitmap.h \
 	datastruct/dynamic_bitmap.h \
 	datastruct/frag_list.h \
-        datastruct/lru.h \
+	datastruct/lockless_sync.h \
+	datastruct/lru.h \
 	datastruct/mpmc.h \
 	datastruct/mpool.inl \
 	datastruct/mpool_set.inl \

--- a/src/ucs/datastruct/list.h
+++ b/src/ucs/datastruct/list.h
@@ -216,9 +216,9 @@ static inline unsigned long ucs_list_length(ucs_list_link_t *head)
  */
 #define ucs_list_extract_head(_head, _type, _member) \
     ({ \
-        ucs_list_link_t *tmp = (_head)->next; \
-        ucs_list_del(tmp); \
-        ucs_container_of(tmp, _type, _member); \
+        ucs_list_link_t *_tmp = (_head)->next; \
+        ucs_list_del(_tmp); \
+        ucs_container_of(_tmp, _type, _member); \
     })
 
 END_C_DECLS

--- a/src/ucs/datastruct/lockless_sync.h
+++ b/src/ucs/datastruct/lockless_sync.h
@@ -1,0 +1,212 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef LOCKLESS_SYNC_H_
+#define LOCKLESS_SYNC_H_
+
+#include "lockless_sync_def.h"
+
+#include <ucs/arch/cpu.h>
+#include <ucs/debug/assert.h>
+
+
+/**
+ * Lock-less synchronization for objects stored in a container. The objects
+ * may be invalidated and released from an asynchronous garbage collecting
+ * thread. The main thread can safely utilize an object acquired with
+ * ucs_lockless_sync_get() before it released with ucs_lockless_sync_put().
+ * The asynchronous thread may:
+ * - Mark regions for invalidation. If ucs_lockless_sync_invalidate() returns true,
+ *   the object should be queued for content release.
+ * - Release its content if ucs_lockless_sync_release() returns true.
+ *
+ * Synchronization restrictions:
+ * - refcount modified from the main thread only.
+ * - flags modified under the container lock only.
+ */
+
+
+enum {
+    UCS_LOCKLESS_SYNC_FLAG_STORED  = UCS_BIT(0), /**< Object held by container */
+    UCS_LOCKLESS_SYNC_FLAG_READY   = UCS_BIT(2), /**< Object ready for use */
+    UCS_LOCKLESS_SYNC_FLAG_INVALID = UCS_BIT(1), /**< Object invalidated */
+};
+
+
+#define UCS_LOCKLESS_SYNC_FMT " %c%c%c ref %u"
+#define UCS_LOCKLESS_SYNC_ARG(_obj) \
+    ((_obj)->flags & UCS_LOCKLESS_SYNC_FLAG_READY)   ? 'r' : '-', \
+    ((_obj)->flags & UCS_LOCKLESS_SYNC_FLAG_INVALID) ? 'i' : '-', \
+    ((_obj)->flags & UCS_LOCKLESS_SYNC_FLAG_STORED)  ? 's' : '-', \
+    (_obj)->refcount
+
+
+/**
+ * Initialize object.
+ * Called from main thread under container lock.
+ *
+ * @param [in]  obj         Pointer to an object.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_lockless_sync_init(ucs_ll_sync_obj_t *obj)
+{
+    obj->refcount = 1;
+    obj->flags    = UCS_LOCKLESS_SYNC_FLAG_STORED;
+}
+
+
+/**
+ * Transit object to ready state.
+ * Called from main thread under container lock.
+ *
+ * @param [in]  obj         Pointer to an object.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucs_lockless_sync_set_ready(ucs_ll_sync_obj_t *obj)
+{
+    obj->refcount++;
+    obj->flags |= UCS_LOCKLESS_SYNC_FLAG_READY;
+}
+
+
+/**
+ * If object is usable acquire it and return true.
+ * Called from main thread.
+ *
+ * @param [in]  obj         Pointer to an object.
+ *
+ * @return true if acquired succefully.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_lockless_sync_get(ucs_ll_sync_obj_t *obj)
+{
+    obj->refcount++;
+    ucs_memory_cpu_store_fence();
+
+    if (ucs_unlikely((obj->flags & (UCS_LOCKLESS_SYNC_FLAG_READY |
+                                    UCS_LOCKLESS_SYNC_FLAG_INVALID)) !=
+                     UCS_LOCKLESS_SYNC_FLAG_READY)) {
+        obj->refcount--;
+        return 0;
+    }
+
+    return 1;
+}
+
+
+/**
+ * Release object.
+ * Called from main thread.
+ *
+ * @param [in]  obj         Pointer to an object.
+ *
+ * @return true if object should be destroyed.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_lockless_sync_put(ucs_ll_sync_obj_t *obj)
+{
+    ucs_assert(obj->refcount > 0);
+    return --obj->refcount == 0;
+}
+
+
+/**
+ * If object is stored in container and has no references return true.
+ * Called from main thread.
+ *
+ * @param [in]  obj         Pointer to an object.
+ *
+ * @return true if object can be evicted.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_lockless_sync_evict(ucs_ll_sync_obj_t *obj)
+{
+    return (obj->flags & UCS_LOCKLESS_SYNC_FLAG_STORED) && (obj->refcount == 1);
+}
+
+
+/**
+ * If object is stored in container mark it as removed and return true.
+ * If object has no references and may be destroyed set destroy to true.
+ * Called from main thread under container lock.
+ *
+ * @param [in]  obj         Pointer to an object.
+ * @param [out] destroy     true if object should be destroyed.
+ *
+ * @return true if object should be removed from container.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_lockless_sync_remove(ucs_ll_sync_obj_t *obj, int *destroy)
+{
+    unsigned flags;
+
+    ucs_memory_cpu_load_fence();
+    flags = obj->flags;
+    if (flags & UCS_LOCKLESS_SYNC_FLAG_STORED) {
+        obj->flags &= ~UCS_LOCKLESS_SYNC_FLAG_STORED;
+        *destroy = (--obj->refcount == 0);
+        return 1;
+    }
+
+    *destroy = (obj->refcount == 0);
+    return 0;
+}
+
+/**
+ * Mark object as invalid. Return true is it wasn't marked invalid before and
+ * should be invalidated.
+ * Called from asynchronous GC thread under container lock.
+ *
+ * @param [in]  obj         Pointer to an object.
+ *
+ * @return true if object should be invalidated.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_lockless_sync_invalidate(ucs_ll_sync_obj_t *obj)
+{
+    unsigned flags;
+
+    ucs_memory_cpu_load_fence();
+    flags = obj->flags;
+    if (flags & UCS_LOCKLESS_SYNC_FLAG_INVALID) {
+        return 0;
+    }
+
+    ucs_assert(flags & UCS_LOCKLESS_SYNC_FLAG_STORED);
+    obj->flags |= UCS_LOCKLESS_SYNC_FLAG_INVALID;
+    ucs_memory_cpu_store_fence();
+    return 1;
+}
+
+/**
+ * If objects content may be released return true and mark object as not usable.
+ * Called from asynchronous GC thread under container lock.
+ *
+ * @param [in]  obj         Pointer to an object.
+ *
+ * @return true if object's content should be released.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucs_lockless_sync_release(ucs_ll_sync_obj_t *obj)
+{
+    unsigned flags;
+
+    ucs_memory_cpu_load_fence();
+    flags = obj->flags;
+    ucs_assert(flags & UCS_LOCKLESS_SYNC_FLAG_INVALID);
+    if (obj->refcount > !!(flags & UCS_LOCKLESS_SYNC_FLAG_STORED)) {
+        return 0;
+    }
+
+    if (flags & UCS_LOCKLESS_SYNC_FLAG_READY) {
+        obj->flags &= ~UCS_LOCKLESS_SYNC_FLAG_READY;
+        return 1;
+    }
+
+    return 0;
+}
+
+#endif

--- a/src/ucs/datastruct/lockless_sync_def.h
+++ b/src/ucs/datastruct/lockless_sync_def.h
@@ -1,0 +1,20 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef LOCKLESS_SYNC_DEF_H_
+#define LOCKLESS_SYNC_DEF_H_
+
+#include <ucs/sys/compiler_def.h>
+
+#include <inttypes.h>
+
+typedef struct {
+    uint32_t refcount;  /**< Reference count, including +1 if object stored
+                             in container */
+    uint8_t  flags;     /**< Status flags */
+} UCS_S_PACKED ucs_ll_sync_obj_t;
+
+#endif

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -19,10 +19,11 @@
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/time/time_def.h>
 #include <ucs/config/parser.h>
+#include <ucs/datastruct/lockless_sync_def.h>
 #include <sys/mman.h>
 
 
-#define UCS_RCACHE_PROT_FMT "%c%c"
+#define UCS_RCACHE_PROT_FMT " %c%c"
 #define UCS_RCACHE_PROT_ARG(_prot) \
     ((_prot) & PROT_READ)  ? 'r' : '-', \
     ((_prot) & PROT_WRITE) ? 'w' : '-'
@@ -38,15 +39,6 @@ typedef struct ucs_rcache_ops     ucs_rcache_ops_t;
 typedef struct ucs_rcache_params  ucs_rcache_params_t;
 typedef struct ucs_rcache_region  ucs_rcache_region_t;
 typedef struct ucs_rcache_config  ucs_rcache_config_t;
-
-/*
- * Memory region flags.
- */
-enum {
-    UCS_RCACHE_REGION_FLAG_PGTABLE    = UCS_BIT(0), /**< In the page table */
-    UCS_RCACHE_REGION_FLAG_REGISTERED = UCS_BIT(2), /**< Memory registered */
-    UCS_RCACHE_REGION_FLAG_RELEASING  = UCS_BIT(1), /**< Memory invalidated */
-};
 
 /*
  * Memory registration flags.
@@ -168,11 +160,9 @@ struct ucs_rcache_region {
     ucs_list_link_t        tmp_list;  /**< Temp list element */
     ucs_list_link_t        comp_list; /**< Completion list element */
     size_t                 alignment;
-    volatile uint32_t      refcount;  /**< Reference count, including +1 if it's
-                                           in the page table */
+    ucs_ll_sync_obj_t      lls;       /**< Lock-less storage state */
     ucs_status_t           status;    /**< Current status code */
     uint8_t                prot;      /**< Protection bits */
-    uint8_t                flags;     /**< Status flags */
     uint8_t                lru_flags; /**< LRU flags */
     union {
         uint64_t           priv;      /**< Used internally */

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -70,7 +70,7 @@ struct ucs_rcache {
     ucs_pgtable_t       pgtable;         /**< page table to hold the regions */
 
 
-    ucs_spinlock_t      lock;            /**< Protects 'mp', 'inv_q' and 'gc_list'.
+    ucs_spinlock_t      lock;            /**< Protects 'mp' and 'inv_q'
                                               This is a separate lock because we
                                               may want to invalidate regions
                                               while the page table lock is held by
@@ -89,7 +89,8 @@ struct ucs_rcache {
 
     unsigned long       num_regions;     /**< Total number of managed regions */
     size_t              total_size;      /**< Total size of registered memory */
-    size_t              unreleased_size; /**< Total size of the regions in gc_list and in inv_q */
+    size_t              inv_q_size;      /**< Size of the regions in inv_q */
+    size_t              gc_size;         /**< Size of the regions in gc_list */
 
     struct {
         ucs_spinlock_t  lock;            /**< Lock for this structure */
@@ -132,8 +133,7 @@ size_t ucs_rcache_distribution_get_num_bins();
 
 
 void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
-                                     ucs_rcache_region_t *region,
-                                     int drop_lock);
+                                     ucs_rcache_region_t *region);
 
 
 void ucs_rcache_region_log(const char *file, int line, const char *function,

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -9,6 +9,7 @@
 
 #include "rcache.h"
 
+#include <ucs/datastruct/lockless_sync.h>
 #include <ucs/datastruct/list.h>
 #include <ucs/stats/stats.h>
 #include <ucs/type/spinlock.h>

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -321,7 +321,7 @@ uct_rocm_copy_mem_rcache_reg(uct_md_h uct_md, void *address, size_t length,
         return status;
     }
 
-    ucs_assert(rregion->refcount > 0);
+    ucs_assert(rregion->lls.refcount > 0);
     memh    = &ucs_derived_of(rregion, uct_rocm_copy_rcache_region_t)->memh;
     *memh_p = memh;
     return UCS_OK;

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -9,6 +9,7 @@ extern "C" {
 #include <ucs/arch/atomic.h>
 #include <ucs/sys/math.h>
 #include <ucs/stats/stats.h>
+#include <ucs/memory/rcache.inl>
 #include <ucs/memory/rcache.h>
 #include <ucs/memory/rcache_int.h>
 #include <ucs/sys/sys.h>
@@ -65,7 +66,8 @@ UCS_TEST_F(test_rcache_basic, create_destroy) {
 }
 
 
-class test_rcache : public ucs::test {
+class test_rcache : public ucs::test_with_param<int> {
+    //base, public ::testing::TestWithParam<int> {
 protected:
 
     struct region {
@@ -76,10 +78,17 @@ protected:
 
     test_rcache() : m_reg_count(0), m_ptr(NULL), m_comp_count(0)
     {
+        pthread_spin_init(&m_lock, 0);
+    }
+
+    ~test_rcache()
+    {
+        pthread_spin_destroy(&m_lock);
+
     }
 
     virtual void init() {
-        ucs::test::init();
+        ucs::test_base::init();
         ucs_rcache_params params = rcache_params();
         UCS_TEST_CREATE_HANDLE_IF_SUPPORTED(ucs_rcache_t*, m_rcache, ucs_rcache_destroy,
                                             ucs_rcache_create, &params, "test", ucs_stats_get_root());
@@ -88,7 +97,7 @@ protected:
     virtual void cleanup() {
         m_rcache.reset();
         EXPECT_EQ(0u, m_reg_count);
-        ucs::test::cleanup();
+        ucs::test_base::cleanup();
     }
 
     virtual ucs_rcache_params_t rcache_params()
@@ -100,13 +109,31 @@ protected:
         return params;
     }
 
+    int safe_api()
+    {
+        return GetParam();
+    }
+
     region *get(void *address, size_t length, int prot = PROT_READ | PROT_WRITE,
                 size_t alignment = UCS_PGT_ADDR_ALIGN)
     {
-        ucs_status_t status;
-        ucs_rcache_region_t *r;
-        status = ucs_rcache_get(m_rcache, address, length, alignment, prot,
-                                NULL, &r);
+        ucs_status_t status = UCS_OK;
+        ucs_rcache_region_t *r = NULL;
+
+        if (safe_api()) {
+             pthread_spin_lock(&m_lock);
+             r = ucs_rcache_lookup_unsafe(m_rcache, address, length, alignment,
+                                          prot);
+             if (r == NULL) {
+                 status = ucs_rcache_get(m_rcache, address, length, alignment,
+                                         prot, NULL, &r);
+             }
+             pthread_spin_unlock(&m_lock);
+        } else {
+             status = ucs_rcache_get(m_rcache, address, length, alignment, prot,
+                                     NULL, &r);
+        }
+
         ASSERT_UCS_OK(status);
         EXPECT_TRUE(r != NULL);
         struct region *region = ucs_derived_of(r, struct region);
@@ -116,7 +143,13 @@ protected:
     }
 
     void put(region *r) {
-        ucs_rcache_region_put(m_rcache, &r->super);
+        if (safe_api()) {
+            pthread_spin_lock(&m_lock);
+            ucs_rcache_region_put_unsafe(m_rcache, &r->super);
+            pthread_spin_unlock(&m_lock);
+        } else {
+            ucs_rcache_region_put(m_rcache, &r->super);
+        }
     }
 
     virtual ucs_status_t mem_reg(region *region)
@@ -190,6 +223,7 @@ protected:
     ucs::handle<ucs_rcache_t*> m_rcache;
     void * volatile m_ptr;
     size_t m_comp_count;
+    pthread_spinlock_t m_lock;
 
 private:
 
@@ -265,7 +299,7 @@ out:
     return pa;
 }
 
-UCS_MT_TEST_F(test_rcache, basic, 10) {
+UCS_MT_TEST_P(test_rcache, basic, 10) {
     static const size_t size = 1 * 1024 * 1024;
     void *ptr = malloc(size);
     region *region = get(ptr, size);
@@ -273,7 +307,7 @@ UCS_MT_TEST_F(test_rcache, basic, 10) {
     free(ptr);
 }
 
-UCS_MT_TEST_F(test_rcache, get_unmapped, 6) {
+UCS_MT_TEST_P(test_rcache, get_unmapped, 6) {
     /*
      *  - allocate, get, put, get again -> should be same id
      *  - release, get again -> should be different id
@@ -312,7 +346,7 @@ UCS_MT_TEST_F(test_rcache, get_unmapped, 6) {
 
 /* This test gets region N times and later puts it N times and invalidates N/2
  * times - mix multiple put and invalidate calls */
-UCS_MT_TEST_F(test_rcache, put_and_invalidate, 1)
+UCS_MT_TEST_P(test_rcache, put_and_invalidate, 1)
 {
     static const size_t size = 1 * UCS_MBYTE;
     std::vector<region*> regions;
@@ -354,7 +388,7 @@ UCS_MT_TEST_F(test_rcache, put_and_invalidate, 1)
     free(ptr);
 }
 
-UCS_MT_TEST_F(test_rcache, merge, 6) {
+UCS_MT_TEST_P(test_rcache, merge, 6) {
     /*
      * +---------+-----+---------+
      * | region1 | pad | region2 |
@@ -402,7 +436,7 @@ UCS_MT_TEST_F(test_rcache, merge, 6) {
     munmap(mem, size1 + pad + size2);
 }
 
-UCS_TEST_F(test_rcache, merge_aligned)
+UCS_TEST_P(test_rcache, merge_aligned)
 {
     /*
      * 0         4     5         9
@@ -462,7 +496,7 @@ UCS_TEST_F(test_rcache, merge_aligned)
     free(mem);
 }
 
-UCS_MT_TEST_F(test_rcache, merge_inv, 6) {
+UCS_MT_TEST_P(test_rcache, merge_inv, 6) {
     /*
      * Merge with another region which causes immediate invalidation of the
      * other region.
@@ -496,7 +530,7 @@ UCS_MT_TEST_F(test_rcache, merge_inv, 6) {
     munmap(mem, pad + size2);
 }
 
-UCS_MT_TEST_F(test_rcache, release_inuse, 6) {
+UCS_MT_TEST_P(test_rcache, release_inuse, 6) {
     static const size_t size = 1 * 1024 * 1024;
 
     void *ptr1 = malloc(size);
@@ -523,7 +557,7 @@ UCS_MT_TEST_F(test_rcache, release_inuse, 6) {
  *
  * don't merge with inaccessible pages
  */
-UCS_MT_TEST_F(test_rcache, merge_with_unwritable, 6) {
+UCS_MT_TEST_P(test_rcache, merge_with_unwritable, 6) {
     static const size_t size1 = 10 * ucs_get_page_size();
     static const size_t size2 =  8 * ucs_get_page_size();
 
@@ -552,7 +586,7 @@ UCS_MT_TEST_F(test_rcache, merge_with_unwritable, 6) {
 }
 
 /* don't expand prot of our region if our pages cant support it */
-UCS_MT_TEST_F(test_rcache, merge_merge_unwritable, 6) {
+UCS_MT_TEST_P(test_rcache, merge_merge_unwritable, 6) {
     static const size_t size1 = 10 * ucs_get_page_size();
     static const size_t size2 =  8 * ucs_get_page_size();
 
@@ -581,7 +615,7 @@ UCS_MT_TEST_F(test_rcache, merge_merge_unwritable, 6) {
 }
 
 /* expand prot of new region to support existing regions */
-UCS_MT_TEST_F(test_rcache, merge_expand_prot, 6) {
+UCS_MT_TEST_P(test_rcache, merge_expand_prot, 6) {
     static const size_t size1 = 10 * ucs_get_page_size();
     static const size_t size2 =  8 * ucs_get_page_size();
 
@@ -621,7 +655,7 @@ UCS_MT_TEST_F(test_rcache, merge_expand_prot, 6) {
  * |     |    region2    |  4. region2 is created. region1 must be invalidated and
  * +-----+---------------+     kicked out of pagetable.
  */
-UCS_MT_TEST_F(test_rcache, merge_invalid_prot, 6)
+UCS_MT_TEST_P(test_rcache, merge_invalid_prot, 6)
 {
     static const size_t size1 = 10 * ucs_get_page_size();
     static const size_t size2 =  8 * ucs_get_page_size();
@@ -651,7 +685,7 @@ UCS_MT_TEST_F(test_rcache, merge_invalid_prot, 6)
     munmap(mem, size1+size2);
 }
 
-UCS_MT_TEST_F(test_rcache, shared_region, 6) {
+UCS_MT_TEST_P(test_rcache, shared_region, 6) {
     static const size_t size = 1 * 1024 * 1024;
 
     void *mem = shared_malloc(size);
@@ -710,7 +744,7 @@ protected:
     }
 };
 
-UCS_MT_TEST_F(test_rcache_no_register, register_failure, 10) {
+UCS_MT_TEST_P(test_rcache_no_register, register_failure, 10) {
     static const size_t size = 1 * 1024 * 1024;
     void *ptr = malloc(size);
 
@@ -741,7 +775,7 @@ UCS_MT_TEST_F(test_rcache_no_register, register_failure, 10) {
  * +-----+---------------+     kicked out of pagetable. Creation of region2
  *                             must fail.
  */
-UCS_MT_TEST_F(test_rcache_no_register, merge_invalid_prot_slow, 5)
+UCS_MT_TEST_P(test_rcache_no_register, merge_invalid_prot_slow, 5)
 {
     static const size_t size1 = 10 * ucs_get_page_size();
     static const size_t size2 =  8 * ucs_get_page_size();
@@ -792,7 +826,7 @@ protected:
     }
 };
 
-UCS_TEST_F(test_rcache_with_limit, by_count) {
+UCS_TEST_P(test_rcache_with_limit, by_count) {
     static const size_t size = 32;
 
     /* First region will be added */
@@ -830,7 +864,7 @@ UCS_TEST_F(test_rcache_with_limit, by_count) {
     free(ptr1);
 }
 
-UCS_TEST_F(test_rcache_with_limit, by_size) {
+UCS_TEST_P(test_rcache_with_limit, by_size) {
     static const size_t size = 600;
 
     /* First region will be added */
@@ -847,7 +881,7 @@ UCS_TEST_F(test_rcache_with_limit, by_size) {
     free(ptr1);
 }
 
-UCS_TEST_F(test_rcache_with_limit, by_size_inuse) {
+UCS_TEST_P(test_rcache_with_limit, by_size_inuse) {
     static const size_t size = 600;
 
     /* First region will be added */
@@ -902,7 +936,7 @@ protected:
     }
 };
 
-UCS_TEST_F(test_rcache_stats, basic) {
+UCS_TEST_P(test_rcache_stats, basic) {
     static const size_t size = 4096;
     void *ptr = malloc(size);
     region *r1, *r2;
@@ -932,7 +966,7 @@ UCS_TEST_F(test_rcache_stats, basic) {
     EXPECT_EQ(0, get_counter(UCS_RCACHE_UNMAPS));
 }
 
-UCS_TEST_F(test_rcache_stats, unmap_dereg) {
+UCS_TEST_P(test_rcache_stats, unmap_dereg) {
     static const size_t size1 = 1024 * 1024;
     void *mem = alloc_pages(size1, PROT_READ|PROT_WRITE);
     region *r1;
@@ -955,7 +989,7 @@ UCS_TEST_F(test_rcache_stats, unmap_dereg) {
     munmap(mem, size1);
 }
 
-UCS_TEST_F(test_rcache_stats, unmap_dereg_with_lock) {
+UCS_TEST_P(test_rcache_stats, unmap_dereg_with_lock) {
     static const size_t size1 = 1024 * 1024;
     void *mem = alloc_pages(size1, PROT_READ|PROT_WRITE);
     region *r1;
@@ -967,7 +1001,7 @@ UCS_TEST_F(test_rcache_stats, unmap_dereg_with_lock) {
      * We can have more unmap events if releasing the region structure triggers
      * releasing memory back to the OS.
      */
-    pthread_rwlock_wrlock(&m_rcache->pgt_lock);
+    pthread_rwlock_rdlock(&m_rcache->pgt_lock);
     munmap(mem, size1);
     pthread_rwlock_unlock(&m_rcache->pgt_lock);
 
@@ -990,7 +1024,7 @@ UCS_TEST_F(test_rcache_stats, unmap_dereg_with_lock) {
     munmap(mem, size1);
 }
 
-UCS_TEST_F(test_rcache_stats, merge) {
+UCS_TEST_P(test_rcache_stats, merge) {
     static const size_t size1 = 1024 * 1024;
     void *mem = alloc_pages(size1, PROT_READ|PROT_WRITE);
     region *r1, *r2;
@@ -1008,7 +1042,7 @@ UCS_TEST_F(test_rcache_stats, merge) {
     munmap(mem, size1);
 }
 
-UCS_TEST_F(test_rcache_stats, hits_slow) {
+UCS_TEST_P(test_rcache_stats, hits_slow) {
     static const size_t size1 = 1024 * 1024;
     region *r1, *r2;
     void *mem1, *mem2;
@@ -1021,7 +1055,7 @@ UCS_TEST_F(test_rcache_stats, hits_slow) {
     r1 = get(mem2, size1);
 
     /* generate unmap event under lock, to roce using invalidation queue */
-    pthread_rwlock_rdlock(&m_rcache->pgt_lock);
+    pthread_rwlock_wrlock(&m_rcache->pgt_lock);
     munmap(mem1, size1);
     pthread_rwlock_unlock(&m_rcache->pgt_lock);
 
@@ -1131,3 +1165,14 @@ UCS_TEST_F(test_rcache_pfn, enum_pfn) {
         munmap(region, len);
     }
 }
+
+#define INSTANTIATE_RCACHE_TEST_CASES(_test_fixture) \
+    INSTANTIATE_TEST_SUITE_P(old_api, _test_fixture, ::testing::Values(0)); \
+    INSTANTIATE_TEST_SUITE_P(safe_api, _test_fixture, ::testing::Values(1))
+
+INSTANTIATE_RCACHE_TEST_CASES(test_rcache);
+INSTANTIATE_RCACHE_TEST_CASES(test_rcache_no_register);
+INSTANTIATE_RCACHE_TEST_CASES(test_rcache_with_limit);
+#ifdef ENABLE_STATS
+INSTANTIATE_RCACHE_TEST_CASES(test_rcache_stats);
+#endif


### PR DESCRIPTION
## What
Regions invalidated by memory event are removed from pgtable only when new regions are added. This may cause memory leaks.

## How ?
Mark invalidated regions in pgtable, remove once pgtable write lock may be acquired, and unregister memory from asynchronous thread. Use region->flags to synchronize with fast path rcache get.