### PR TITLE
BUILD/DEBIAN: Remove libnvidia-compute version dependency

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -99,7 +99,7 @@ jobs:
 
           # Remove superfluous dependency
           dpkg-deb -R "ucx-cuda-${VER}.deb" tmp    # Extract
-          sed -i 's/libnvidia-compute-[0-9]* | libnvidia-ml1, //g' tmp/DEBIAN/control
+          sed -i 's/libnvidia-compute | libnvidia-ml1, //g' tmp/DEBIAN/control
           dpkg-deb -b tmp "ucx-cuda-${VER}.deb"        # Rebuild
           dpkg-deb -I "ucx-cuda-${VER}.deb"
           dpkg-deb -I "ucx-${VER}.deb"

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -33,7 +33,7 @@ override_dh_auto_install:
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 	if [ -e debian/ucx-cuda.substvars ]; then \
-	  sed -i -e 's/libnvidia-compute-\([0-9]\+\)/& | libnvidia-ml1/' \
+	  sed -i -e 's/libnvidia-compute-\([0-9]\+\)/libnvidia-compute | libnvidia-ml1/' \
 	    debian/ucx-cuda.substvars \
 	; fi
 


### PR DESCRIPTION
## Why
Fix upgrading ucx-cuda package, internal issue [3749336](https://redmine.mellanox.com/issues/3749336)