### PR TITLE
GTEST: refactoring of entity storage in UCT

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -737,7 +737,7 @@ UCS_TEST_P(test_ucp_am_nbx, set_invalid_handler)
     EXPECT_UCS_OK(status);
 
     // Check that error is returned if id or callback is not set
-    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
 
     params.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID;
     status            = ucp_worker_set_am_recv_handler(sender().worker(),
@@ -786,7 +786,7 @@ UCS_TEST_P(test_ucp_am_nbx, max_am_header)
 #if ENABLE_PARAMS_CHECK
 UCS_TEST_P(test_ucp_am_nbx, am_header_error)
 {
-    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
 
     ucp_request_param_t param;
     param.op_attr_mask    = 0ul;
@@ -1249,7 +1249,7 @@ protected:
         } else {
             // Send request may complete with error
             // (rndv should complete with EP_TIMEOUT)
-            scoped_log_handler wrap_err(wrap_errors_logger);
+            ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
             request_wait(sreq);
             EXPECT_LT(m_recv_counter, m_send_counter);
         }
@@ -1735,7 +1735,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_rndv, invalid_recv_desc,
 
     wait_receives();
 
-    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
     /* attempt to recv data with invalid 'data_desc' since it was reliased
      * due to am_data_drop_rndv_cb() returned UCS_OK */
     ucs_status_ptr_t rptr = ucp_am_recv_data_nbx(receiver().worker(),
@@ -1760,7 +1760,7 @@ UCS_TEST_P(test_ucp_am_nbx_rndv, reject_rndv)
     param.op_attr_mask      = 0ul;
     ucs_status_t statuses[] = {UCS_OK, UCS_ERR_REJECTED, UCS_ERR_NO_MEMORY};
 
-    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
 
     for (int i = 0; i < ucs_static_array_size(statuses); ++i) {
         reset_counters();

--- a/test/gtest/ucp/test_ucp_atomic.cc
+++ b/test/gtest/ucp/test_ucp_atomic.cc
@@ -290,7 +290,7 @@ UCS_TEST_P(test_ucp_atomic64, fetch) {
 UCS_TEST_P(test_ucp_atomic32, misaligned_post) {
     {
         /* Test that unaligned addresses generate error */
-        scoped_log_handler slh(hide_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::hide_errors_logger);
         test(static_cast<send_func_t>(&test_ucp_atomic32::misaligned_post),
              UCS_BIT(UCP_ATOMIC_OP_ADD), 1);
     }
@@ -299,7 +299,7 @@ UCS_TEST_P(test_ucp_atomic32, misaligned_post) {
 UCS_TEST_P(test_ucp_atomic64, misaligned_post) {
     {
         /* Test that unaligned addresses generate error */
-        scoped_log_handler slh(hide_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::hide_errors_logger);
         test(static_cast<send_func_t>(&test_ucp_atomic64::misaligned_post),
              UCS_BIT(UCP_ATOMIC_OP_ADD), 1);
     }

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -86,15 +86,15 @@ UCS_TEST_P(test_ucp_version, wrong_api_version) {
     ucs_status_t status;
     size_t warn_count;
     {
-        scoped_log_handler slh(hide_warns_logger);
-        warn_count = m_warnings.size();
+        ucs::log::scoped_handler slh(ucs::log::hide_warns_logger);
+        warn_count = ucs::log::warnings().size();
         status = ucp_init_version(99, 99, &get_variant_ctx_params(),
                                   config.get(), &ucph);
     }
     if (status != UCS_OK) {
         ADD_FAILURE() << "Failed to create UCP with wrong version";
     } else {
-        if (m_warnings.size() == warn_count) {
+        if (ucs::log::warnings().size() == warn_count) {
             ADD_FAILURE() << "Missing wrong version warning";
         }
         ucp_cleanup(ucph);

--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -84,7 +84,7 @@ void test_ucp_memheap::test_xfer(send_func_t send_func, size_t size,
                            send_memh,
                            UCS_PTR_BYTE_OFFSET(memheap.ptr(), offset),
                            rkey, arg);
-        if (num_errors() > 0) {
+        if (ucs::log::num_errors() > 0) {
             break;
         }
     }

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -193,7 +193,7 @@ bool test_ucp_mmap::resolve_rma(entity *e, ucp_rkey_h rkey)
     ucs_status_t status;
 
     {
-        scoped_log_handler slh(hide_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::hide_errors_logger);
         status = UCP_RKEY_RESOLVE(rkey, e->ep(), rma);
     }
 
@@ -213,7 +213,7 @@ bool test_ucp_mmap::resolve_amo(entity *e, ucp_rkey_h rkey)
     ucs_status_t status;
 
     {
-        scoped_log_handler slh(hide_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::hide_errors_logger);
         status = UCP_RKEY_RESOLVE(rkey, e->ep(), amo);
     }
 
@@ -575,7 +575,7 @@ test_ucp_mmap::import_no_md_error_handler(const char *file, unsigned line,
 {
     // Ignore errors that no suitable MDs for import as it is expected
     if (level == UCS_LOG_LEVEL_ERROR) {
-        std::string err_str = format_message(message, ap);
+        std::string err_str = ucs::log::format_message(message, ap);
         if (err_str.find("no suitable UCT memory domains to perform importing"
                          " on") != std::string::npos) {
             UCS_TEST_MESSAGE << err_str;
@@ -601,7 +601,7 @@ void test_ucp_mmap::import_memh(void *exported_memh_buf, ucp_mem_h *memh_p)
     params.exported_memh_buffer = exported_memh_buf;
 
     {
-        scoped_log_handler warn_slh(import_no_md_error_handler);
+        ucs::log::scoped_handler warn_slh(import_no_md_error_handler);
         ucs_status_t status = ucp_mem_map(receiver().ucph(), &params, memh_p);
         if (status == UCS_ERR_UNREACHABLE) {
             release_exported_memh_buf(exported_memh_buf);
@@ -992,7 +992,7 @@ UCS_TEST_P(test_ucp_rkey_compare, rkey_compare_errors)
     ucs_status_t status;
     int result;
 
-    scoped_log_handler err_handler(wrap_errors_logger);
+    ucs::log::scoped_handler err_handler(ucs::log::wrap_errors_logger);
 
     status = ucp_rkey_compare(receiver().worker(), rkey, rkey, &params, NULL);
     EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -212,7 +212,7 @@ test_ucp_peer_failure::warn_unreleased_rdesc_handler(const char *file, unsigned 
                                                      const char *message, va_list ap)
 {
     if (level == UCS_LOG_LEVEL_WARN) {
-        std::string err_str = format_message(message, ap);
+        std::string err_str = ucs::log::format_message(message, ap);
 
         if (err_str.find("unexpected tag-receive descriptor") != std::string::npos) {
             return UCS_LOG_FUNC_RC_STOP;
@@ -236,7 +236,7 @@ void test_ucp_peer_failure::fail_receiver() {
         /* transform warning messages about unreleased TM rdescs to test
          * message that are expected here, since we closed receiver w/o
          * reading the messages that were potentially received */
-        scoped_log_handler slh(warn_unreleased_rdesc_handler);
+        ucs::log::scoped_handler slh(warn_unreleased_rdesc_handler);
 
         cleanup_rndv_descs();
         failing_receiver().cleanup();
@@ -393,7 +393,7 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
     double prev_ib_ud_peer_timeout = sender().set_ib_ud_peer_timeout(3.);
 
     {
-        scoped_log_handler slh(wrap_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::wrap_errors_logger);
 
         fail_receiver();
 
@@ -561,8 +561,8 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
            "KEEPALIVE_INTERVAL=0.3", "KEEPALIVE_NUM_EPS=inf") {
     /* TODO: wireup is not tested yet */
 
-    scoped_log_handler err_handler(wrap_errors_logger);
-    scoped_log_handler warn_handler(hide_warns_logger);
+    ucs::log::scoped_handler err_handler(ucs::log::wrap_errors_logger);
+    ucs::log::scoped_handler warn_handler(ucs::log::hide_warns_logger);
 
     /* initiate p2p pairing */
     ucp_ep_resolve_remote_id(failing_sender(), 0);
@@ -599,9 +599,8 @@ UCS_TEST_P(test_ucp_peer_failure_keepalive, kill_receiver,
     wait_for_flag(&m_err_count);
 
     /* dump warnings */
-    int warn_count = m_warnings.size();
-    for (int i = 0; i < warn_count; ++i) {
-        UCS_TEST_MESSAGE << "< " << m_warnings[i] << " >";
+    for (auto &w : ucs::log::warnings()) {
+        UCS_TEST_MESSAGE << "< " << w << " >";
     }
 
     EXPECT_NE(0, m_err_count);
@@ -719,7 +718,7 @@ protected:
             return;
         }
 
-        scoped_log_handler slh(wrap_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::wrap_errors_logger);
         m_peer_to_close->close_all_eps(*self, 0, UCP_EP_CLOSE_FLAG_FORCE);
 
         void *peer_req = (m_peer_to_close == &sender()) ? m_sreq : m_rreq;
@@ -797,7 +796,7 @@ protected:
         protos_replace_progress();
 
         {
-            scoped_log_handler slh(wrap_errors_logger);
+            ucs::log::scoped_handler slh(ucs::log::wrap_errors_logger);
             auto result = smoke_test(true);
             ASSERT_TRUE(UCS_STATUS_IS_ERR(result.first));
             ASSERT_TRUE(UCS_STATUS_IS_ERR(result.second));

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -72,7 +72,7 @@ protected:
                 const char *message, va_list ap) {
         // Ignore errors that transport cannot reach peer
         if (level == UCS_LOG_LEVEL_ERROR) {
-            std::string err_str = format_message(message, ap);
+            std::string err_str = ucs::log::format_message(message, ap);
             if (strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNREACHABLE)) ||
                 strstr(err_str.c_str(), ucs_status_string(UCS_ERR_UNSUPPORTED)) ||
                 strstr(err_str.c_str(), "no peer failure handler")) {

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -174,7 +174,7 @@ protected:
                       target_mem_type, mem_map_flags, is_ep_flush(), user_memh(),
                       mem_types);
 
-            if (HasFailure() || (num_errors() > 0)) {
+            if (HasFailure() || (ucs::log::num_errors() > 0)) {
                 break;
             }
         }

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -683,7 +683,7 @@ public:
             // Should not have warnings if leak check is off
             ucp_test::cleanup();
         } else {
-            scoped_log_handler wrap_warn(wrap_warns_logger);
+            ucs::log::scoped_handler wrap_warn(ucs::log::wrap_warns_logger);
             ucp_test::cleanup();
             check_leak_warnings(); // Leak check is enabled - expect warnings
         }
@@ -692,10 +692,9 @@ public:
 private:
     void check_leak_warnings()
     {
-        EXPECT_EQ(2u, m_warnings.size());
-        for (size_t i = 0; i < m_warnings.size(); ++i) {
-            std::string::size_type pos = m_warnings[i].find(
-                    "not returned to mpool ucp_requests");
+        EXPECT_EQ(2u, ucs::log::warnings().size());
+        for (auto &w : ucs::log::warnings()) {
+            auto pos = w.find("not returned to mpool ucp_requests");
             EXPECT_NE(std::string::npos, pos);
         }
     }

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -583,20 +583,19 @@ UCS_TEST_P(test_async, modify_event) {
 
 UCS_TEST_P(test_async, warn_block) {
     {
-        scoped_log_handler slh(hide_warns_logger);
+        ucs::log::scoped_handler slh(ucs::log::hide_warns_logger);
         {
             local_event le(GetParam());
             le.block();
         }
     }
 
-    int warn_count = m_warnings.size();
-    for (int i = 0; i < warn_count; ++i) {
-        UCS_TEST_MESSAGE << "< " << m_warnings[i] << " >";
+    for (auto &w : ucs::log::warnings()) {
+        UCS_TEST_MESSAGE << "< " << w << " >";
     }
 
     if (GetParam() != UCS_ASYNC_MODE_POLL) {
-        EXPECT_GE(warn_count, 1);
+        EXPECT_GE(ucs::log::warnings().size(), 1u);
     }
 }
 

--- a/test/gtest/ucs/test_config.cc
+++ b/test/gtest/ucs/test_config.cc
@@ -266,7 +266,7 @@ protected:
     {
         // Ignore errors that invalid input parameters as it is expected
         if ((level == UCS_LOG_LEVEL_WARN) || (level == UCS_LOG_LEVEL_ERROR)) {
-            std::string err_str = format_message(message, ap);
+            std::string err_str = ucs::log::format_message(message, ap);
 
             for (size_t i = 0; i < config_err_exp_str.size(); i++) {
                 if (err_str.find(config_err_exp_str[i]) != std::string::npos) {
@@ -288,8 +288,8 @@ protected:
         // Ignore errors that invalid input parameters as it is expected
         if (level == UCS_LOG_LEVEL_ERROR) {
             m_num_errors++;
-            return wrap_errors_logger(file, line, function, level, comp_conf,
-                                      message, ap);
+            return ucs::log::wrap_errors_logger(file, line, function, level,
+                                                comp_conf, message, ap);
         }
 
         return UCS_LOG_FUNC_RC_CONTINUE;
@@ -567,7 +567,7 @@ UCS_TEST_F(test_config, set_get) {
 
     /* try to set incorrect value - color should not be updated */
     {
-        scoped_log_handler log_handler_vars(config_error_suppress);
+        ucs::log::scoped_handler log_handler_vars(config_error_suppress);
         opts.set("COLOR", "magenta");
     }
 
@@ -630,7 +630,7 @@ UCS_TEST_F(test_config, unused) {
 
     {
         config_err_exp_str.push_back(warn_str + ": " + unused_var1);
-        scoped_log_handler log_handler(config_error_handler);
+        ucs::log::scoped_handler log_handler(config_error_handler);
         car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
 
         ucs_config_parser_print_env_vars_once(UCS_DEFAULT_ENV_PREFIX);
@@ -644,7 +644,7 @@ UCS_TEST_F(test_config, unused) {
         ucs::scoped_setenv env2(unused_var2.c_str(), "unused");
 
         config_err_exp_str.push_back(warn_str + ": " + unused_var2);
-        scoped_log_handler log_handler(config_error_handler);
+        ucs::log::scoped_handler log_handler(config_error_handler);
         car_opts opts("TEST_", NULL);
 
         ucs_config_parser_print_env_vars_once("TEST_");
@@ -688,7 +688,7 @@ UCS_TEST_F(test_config, deprecated) {
     config_err_exp_str.push_back(deprecated_var1 + warn_str);
 
     {
-        scoped_log_handler log_handler(config_error_handler);
+        ucs::log::scoped_handler log_handler(config_error_handler);
         car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
     }
 
@@ -698,7 +698,7 @@ UCS_TEST_F(test_config, deprecated) {
         ucs::scoped_setenv env2(deprecated_var2.c_str(), "58");
         config_err_exp_str.push_back(deprecated_var2 + warn_str);
 
-        scoped_log_handler log_handler_vars(config_error_handler);
+        ucs::log::scoped_handler log_handler_vars(config_error_handler);
         car_opts opts(UCS_DEFAULT_ENV_PREFIX, NULL);
         config_err_exp_str.pop_back();
     }
@@ -809,7 +809,7 @@ UCS_TEST_F(test_config, test_key_value_wrong_syntax) {
         config_err_exp_str = {"key 'unknown' is not supported",
                               "Invalid value for TEMP: 'unknown:10'"};
 
-        scoped_log_handler log_handler_vars(config_error_handler);
+        ucs::log::scoped_handler log_handler_vars(config_error_handler);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, opts.set("TEMP", "unknown:10"));
         EXPECT_EQ(17, opts->temp_front);
         EXPECT_EQ(17, opts->temp_rear);
@@ -819,7 +819,7 @@ UCS_TEST_F(test_config, test_key_value_wrong_syntax) {
     {
         config_err_exp_str = {"Invalid value for TEMP: ''"};
 
-        scoped_log_handler log_handler_vars(config_error_handler);
+        ucs::log::scoped_handler log_handler_vars(config_error_handler);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, opts.set("TEMP", ""));
         EXPECT_EQ(17, opts->temp_front);
         EXPECT_EQ(17, opts->temp_rear);
@@ -830,7 +830,7 @@ UCS_TEST_F(test_config, test_key_value_wrong_syntax) {
         config_err_exp_str = {"no value configured for key 'first'",
                               "Invalid value for PASSENGERS: "};
 
-        scoped_log_handler log_handler_vars(config_error_handler);
+        ucs::log::scoped_handler log_handler_vars(config_error_handler);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, opts.set("PASSENGERS", "second:2"));
         EXPECT_STREQ("None", opts->passengers[0]);
         EXPECT_STREQ("None", opts->passengers[1]);

--- a/test/gtest/ucs/test_datatype.cc
+++ b/test/gtest/ucs/test_datatype.cc
@@ -1268,7 +1268,7 @@ UCS_TEST_F(test_array, add_above_max_capacity) {
     EXPECT_EQ(max_capacity, ucs_array_length(&test_array));
 
     {
-        scoped_log_handler slh(hide_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::hide_errors_logger);
         ucs_status_t status = ucs_array_reserve(&test_array, max_capacity + 1);
         EXPECT_EQ(UCS_ERR_EXCEEDS_LIMIT, status);
     }

--- a/test/gtest/ucs/test_memtrack.cc
+++ b/test/gtest/ucs/test_memtrack.cc
@@ -273,7 +273,7 @@ public:
                           const ucs_log_component_config_t *comp_conf,
                           const char *message, va_list ap)
     {
-        std::string log_str = format_message(message, ap);
+        std::string log_str = ucs::log::format_message(message, ap);
         if ((level == UCS_LOG_LEVEL_WARN) &&
             (log_str.find("allocated zero-size block") != std::string::npos)) {
             UCS_TEST_MESSAGE << log_str;
@@ -290,7 +290,7 @@ public:
 size_t test_memtrack_log::log_count = 0;
 
 UCS_TEST_F(test_memtrack_log, zero_size) {
-    scoped_log_handler slh(zero_size_log_handler);
+    ucs::log::scoped_handler slh(zero_size_log_handler);
 
     int count_before = log_count;
     void *ptr        = ucs_calloc(1, 0, "test");

--- a/test/gtest/ucs/test_mpool.cc
+++ b/test/gtest/ucs/test_mpool.cc
@@ -37,7 +37,7 @@ protected:
     {
         // Ignore errors that invalid input parameters as it is expected
         if (level == UCS_LOG_LEVEL_ERROR) {
-            std::string err_str = format_message(message, ap);
+            std::string err_str = ucs::log::format_message(message, ap);
             std::string exp_str = "Invalid memory pool parameter(s)";
 
             if (err_str == exp_str) {
@@ -62,7 +62,7 @@ protected:
                            const char *message, va_list ap)
     {
         if (level == UCS_LOG_LEVEL_WARN) {
-            std::string msg = format_message(message, ap);
+            std::string msg = ucs::log::format_message(message, ap);
             if (is_leak_str(msg)) {
                 UCS_TEST_MESSAGE << "< " << msg << " >";
                 ++leak_count;
@@ -135,7 +135,7 @@ UCS_TEST_F(test_mpool, wrong_ops) {
     ucs_mpool_t mp;
     ucs_status_t status;
     ucs_mpool_ops_t ops = { 0 };
-    scoped_log_handler log_handler(mpool_log_handler);
+    ucs::log::scoped_handler log_handler(mpool_log_handler);
     ucs_mpool_params_t mp_params;
 
     ucs_mpool_params_reset(&mp_params);
@@ -153,7 +153,7 @@ UCS_TEST_F(test_mpool, wrong_ops) {
 UCS_TEST_F(test_mpool, wrong_mpool_chuk_size) {
     ucs_mpool_t mp;
     ucs_mpool_ops_t ops = { 0 };
-    scoped_log_handler log_handler(mpool_log_handler);
+    ucs::log::scoped_handler log_handler(mpool_log_handler);
     ucs_mpool_params_t mp_params;
 
     ucs_mpool_params_reset(&mp_params);
@@ -361,7 +361,7 @@ UCS_TEST_F(test_mpool, leak_check) {
     // Do not release allocated objects
 
     leak_count = 0;
-    scoped_log_handler log_handler(mpool_log_leak_handler);
+    ucs::log::scoped_handler log_handler(mpool_log_leak_handler);
     ucs_mpool_cleanup(&mp, 1);
 
     EXPECT_EQ(5u, leak_count);

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -702,7 +702,7 @@ protected:
     {
         /* Ignore warnings about empty memory pool */
         if ((level == UCS_LOG_LEVEL_WARN) && strstr(message, "failed to register")) {
-            UCS_TEST_MESSAGE << format_message(message, ap);
+            UCS_TEST_MESSAGE << ucs::log::format_message(message, ap);
             return UCS_LOG_FUNC_RC_STOP;
         }
 

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -27,7 +27,7 @@ protected:
     {
         // Ignore errors that invalid input parameters as it is expected
         if (level == UCS_LOG_LEVEL_ERROR) {
-            std::string err_str = format_message(message, ap);
+            std::string err_str = ucs::log::format_message(message, ap);
 
             if (err_str.find(socket_err_exp_str) != std::string::npos) {
                 UCS_TEST_MESSAGE << err_str;
@@ -80,7 +80,7 @@ UCS_TEST_F(test_socket, sockaddr_sizeof) {
     /* Check with wrong address family */
     {
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         size             = 0;
         saddr->sa_family = AF_UNIX;
@@ -114,7 +114,7 @@ UCS_TEST_F(test_socket, sockaddr_inet_addr_sizeof) {
     /* Check with wrong address family */
     {
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         size             = 0;
         saddr->sa_family = AF_UNIX;
@@ -152,7 +152,7 @@ UCS_TEST_F(test_socket, sockaddr_get_port) {
     /* Check with wrong address family */
     {
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         port             = sin_port;
         saddr->sa_family = AF_UNIX;
@@ -197,7 +197,7 @@ UCS_TEST_F(test_socket, sockaddr_get_inet_addr) {
     {
         saddr->sa_family   = AF_UNIX;
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         EXPECT_EQ(NULL, ucs_sockaddr_get_inet_addr(saddr));
     }
@@ -227,7 +227,7 @@ UCS_TEST_F(test_socket, sockaddr_set_port) {
     {
         saddr->sa_family   = AF_UNIX;
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         EXPECT_EQ(UCS_ERR_INVALID_PARAM,
                   ucs_sockaddr_set_port(saddr, sin_port));
@@ -265,7 +265,7 @@ UCS_TEST_F(test_socket, sockaddr_set_inet_addr) {
     {
         saddr->sa_family   = AF_UNIX;
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         EXPECT_EQ(UCS_ERR_INVALID_PARAM,
                   ucs_sockaddr_set_inet_addr(saddr, NULL));
@@ -318,7 +318,7 @@ UCS_TEST_F(test_socket, sockaddr_is_inaddr) {
     {
         saddr->sa_family   = AF_UNIX;
         socket_err_exp_str = "unknown address family:";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         EXPECT_FALSE(ucs_sockaddr_is_inaddr_any(saddr));
     }
@@ -418,7 +418,7 @@ UCS_TEST_F(test_socket, sock_ipportstr_to_sockaddr) {
     /* Check wrong IPv4:port addresses */
     {
         socket_err_exp_str = "invalid address";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         check_ip_port("", 0, UCS_ERR_INVALID_ADDR, "");
         check_ip_port("randomstring", 0, UCS_ERR_INVALID_ADDR, "");
@@ -428,7 +428,7 @@ UCS_TEST_F(test_socket, sock_ipportstr_to_sockaddr) {
     }
     {
         socket_err_exp_str = "invalid port";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         check_ip_port("1.1.1.1:-1", 0, UCS_ERR_INVALID_ADDR, "");
         check_ip_port("1.1.1.1:65536", 0, UCS_ERR_INVALID_ADDR, "");
@@ -452,7 +452,7 @@ UCS_TEST_F(test_socket, sock_ipportstr_to_sockaddr) {
     /* Check wrong IPv6:port addresses */
     {
         socket_err_exp_str = "invalid address";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         check_ip_port("", 0, UCS_ERR_INVALID_ADDR, "");
         check_ip_port(":::", 0, UCS_ERR_INVALID_ADDR, "");
@@ -460,7 +460,7 @@ UCS_TEST_F(test_socket, sock_ipportstr_to_sockaddr) {
     }
     {
         socket_err_exp_str = "invalid port";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         check_ip_port("[::1]:-1", 0, UCS_ERR_INVALID_ADDR, "");
         check_ip_port("[::1]:65536", 0, UCS_ERR_INVALID_ADDR, "");
@@ -481,7 +481,7 @@ UCS_TEST_F(test_socket, port_from_string) {
 
     {
         socket_err_exp_str = "invalid port";
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
 
         EXPECT_EQ(UCS_ERR_INVALID_ADDR, ucs_sock_port_from_string("", &port));
         EXPECT_EQ(UCS_ERR_INVALID_ADDR, ucs_sock_port_from_string("-1", &port));
@@ -523,7 +523,7 @@ UCS_TEST_F(test_socket, socket_setopt) {
         socket_err_exp_str = "failed to set " + ucs::to_string(optname) + " option for " +
                              ucs::to_string(level) + " level on fd " + ucs::to_string(fd) +
                              + ": " + strerror(EINVAL);
-        scoped_log_handler log_handler(socket_error_handler);
+        ucs::log::scoped_handler log_handler(socket_error_handler);
         status = ucs_socket_setopt(fd, level, optname, &optval, optlen);
         EXPECT_EQ(status, UCS_ERR_IO_ERROR);
     }
@@ -662,7 +662,7 @@ UCS_TEST_F(test_socket, sockaddr_cmp_err) {
     sa_in.sin_family = AF_INET;
 
     socket_err_exp_str = "unknown address family: ";
-    scoped_log_handler log_handler(socket_error_handler);
+    ucs::log::scoped_handler log_handler(socket_error_handler);
 
     sockaddr_cmp_err_test((const struct sockaddr*)&sa_un,
                           (const struct sockaddr*)&sa_un);
@@ -709,7 +709,7 @@ UCS_TEST_F(test_socket, sockaddr_get_ipstr) {
 
     /* Check invalid sa_family */
     socket_err_exp_str = "unknown address family:";
-    scoped_log_handler log_handler(socket_error_handler);
+    ucs::log::scoped_handler log_handler(socket_error_handler);
 
     saddr->sa_family = AF_UNIX;
     sockaddr_get_ipstr_check(saddr, UCS_ERR_INVALID_PARAM);

--- a/test/gtest/uct/ib/test_cqe_zipping.cc
+++ b/test/gtest/uct/ib/test_cqe_zipping.cc
@@ -79,8 +79,8 @@ public:
             UCS_TEST_SKIP_R("unsupported");
         }
 
-        uct_iface_set_am_handler(receiver()->iface(), 0, am_cb, &m_recv_cnt, 0);
-        m_send_buf = new mapped_buffer(m_buf_size, 0, *sender());
+        uct_iface_set_am_handler(receiver().iface(), 0, am_cb, &m_recv_cnt, 0);
+        m_send_buf = new mapped_buffer(m_buf_size, 0, sender());
     }
 
     void flush_and_reset()
@@ -104,34 +104,25 @@ public:
     }
 
 private:
-    entity *sender() const
-    {
-        return m_e1;
-    }
-
-    entity *receiver() const
-    {
-        return m_e2;
-    }
-
     virtual void cleanup()
     {
         delete m_send_buf;
-        uct_iface_set_am_handler(receiver()->iface(), 0, NULL, NULL, 0);
+        uct_iface_set_am_handler(receiver().iface(), 0, NULL, NULL, 0);
 
         test_uct_ib::cleanup();
         test_uct_ib_with_specific_port::cleanup();
+        m_entities.clear();
 
         stats_restore();
     }
 
     ucs_status_t am_zcopy()
     {
-        auto size = sender()->iface_attr().cap.am.max_zcopy;
+        auto size = sender().iface_attr().cap.am.max_zcopy;
         size      = ucs_min(size, m_buf_size);
         uct_iov_t iov{m_send_buf->ptr(), size, m_send_buf->memh(), 0, 1};
 
-        return uct_ep_am_zcopy(sender()->ep(0), 0, m_send_buf->ptr(), 0, &iov,
+        return uct_ep_am_zcopy(sender().ep(0), 0, m_send_buf->ptr(), 0, &iov,
                                1, 0, nullptr);
     }
 

--- a/test/gtest/uct/ib/test_devx.cc
+++ b/test/gtest/uct/ib/test_devx.cc
@@ -14,13 +14,9 @@ extern "C" {
 
 class test_devx : public uct_test {
 public:
-    entity* m_e;
-
     void init() {
         uct_test::init();
-
-        m_e = create_entity(0);
-        m_entities.push_back(m_e);
+        create_entity(0);
 
         if (!(md()->super.dev.flags & UCT_IB_DEVICE_FLAG_MLX5_PRM &&
               md()->flags & UCT_IB_MLX5_MD_FLAG_DEVX)) {
@@ -31,11 +27,11 @@ public:
     }
 
     uct_ib_mlx5_md_t *md() {
-        return ucs_derived_of(m_e->md(), uct_ib_mlx5_md_t);
+        return ucs_derived_of(e(0).md(), uct_ib_mlx5_md_t);
     }
 
     uct_priv_worker_t *worker() {
-        return ucs_derived_of(m_e->worker(), uct_priv_worker_t);
+        return ucs_derived_of(e(0).worker(), uct_priv_worker_t);
     }
 };
 

--- a/test/gtest/uct/ib/test_ib.h
+++ b/test/gtest/uct/ib/test_ib.h
@@ -21,7 +21,6 @@ public:
         /* data follows */
     } recv_desc_t;
 
-    test_uct_ib();
     void init();
     virtual void create_connected_entities();
     static ucs_status_t ib_am_handler(void *arg, void *data,
@@ -29,7 +28,6 @@ public:
     virtual void send_recv_short();
 
 protected:
-    entity *m_e1, *m_e2;
     static size_t m_ib_am_handler_counter;
 };
 

--- a/test/gtest/uct/ib/test_ib_event.cc
+++ b/test/gtest/uct/ib/test_ib_event.cc
@@ -186,7 +186,7 @@ public:
                        const ucs_log_component_config_t *comp_conf,
                        const char *message, va_list ap)
     {
-        std::string msg = format_message(message, ap);
+        std::string msg = ucs::log::format_message(message, ap);
 
         UCS_TEST_MESSAGE << msg.c_str();
         sscanf(msg.c_str(),
@@ -305,30 +305,27 @@ public:
 
     virtual void init() {
         uct_test::init();
-        m_e.reset(create_entity(0));
+        create_entity(0);
     }
 
     bool wait_for_last_wqe_event(bool before) {
         ucs_status_t status;
         bool ret;
 
-        init_qp(*m_e);
+        init_qp(e(0));
 
-        status = uct_ib_device_async_event_register(dev(*m_e),
+        status = uct_ib_device_async_event_register(dev(e(0)),
                 IBV_EVENT_QP_LAST_WQE_REACHED, m_qp->qp_num());
         ASSERT_UCS_OK(status);
 
-        ret = uct_test_event_base::wait_for_last_wqe_event(*m_e, before);
+        ret = uct_test_event_base::wait_for_last_wqe_event(e(0), before);
 
-        uct_ib_device_async_event_unregister(dev(*m_e),
+        uct_ib_device_async_event_unregister(dev(e(0)),
                 IBV_EVENT_QP_LAST_WQE_REACHED, m_qp->qp_num());
 
         m_qp.reset();
         return ret;
     }
-
-protected:
-    ucs::auto_ptr<entity> m_e;
 
 private:
 #if HAVE_MLX5_DV

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -14,54 +14,57 @@ void test_rc::init()
 {
     uct_test::init();
 
-    m_e1 = uct_test::create_entity(0);
-    m_entities.push_back(m_e1);
-
+    uct_test::create_entity(0);
     check_skip_test();
-
-    m_e2 = uct_test::create_entity(0);
-    m_entities.push_back(m_e2);
-
+    uct_test::create_entity(0);
     connect();
+}
+
+void test_rc::cleanup()
+{
+    uct_test::cleanup();
+    m_entities.clear();
 }
 
 void test_rc::connect()
 {
-    m_e1->connect(0, *m_e2, 0);
-    m_e2->connect(0, *m_e1, 0);
+    sender().connect(0, receiver(), 0);
+    receiver().connect(0, sender(), 0);
 
-    uct_iface_set_am_handler(m_e1->iface(), 0, am_dummy_handler, NULL, 0);
-    uct_iface_set_am_handler(m_e2->iface(), 0, am_dummy_handler, NULL, 0);
+    uct_iface_set_am_handler(sender().iface(), 0, am_dummy_handler, NULL, 0);
+    uct_iface_set_am_handler(receiver().iface(), 0, am_dummy_handler, NULL, 0);
 }
 
 // Check that iface tx ops buffer and flush comp memory pool are moderated
 // properly when we have communication ops + lots of flushes
 void test_rc::test_iface_ops(int cq_len)
 {
-    entity *e = uct_test::create_entity(0);
-    m_entities.push_back(e);
-    e->connect(0, *m_e2, 0);
+    uct_test::create_entity(0);
+    ASSERT_EQ(3u, m_entities.size());
+    entity &e1 = e(0);
+    entity &e2 = e(1);
+    entity &e3 = e(2);
+    e3.connect(0, e2, 0);
 
-    mapped_buffer sendbuf(1024, 0ul, *e);
-    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, e3);
+    mapped_buffer recvbuf(1024, 0ul, e2);
     uct_completion_t comp;
     comp.count = cq_len * 512; // some big value to avoid func invocation
     comp.func  = NULL;
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
-                            sendbuf.memh(), m_e1->iface_attr().cap.put.max_iov);
+                            sendbuf.memh(), e1.iface_attr().cap.put.max_iov);
     // For _x transports several CQEs can be consumed per WQE, post less put zcopy
     // ops, so that flush would be successful (otherwise flush will return
     // NO_RESOURCES and completion will not be added for it).
     for (int i = 0; i < cq_len / 5; i++) {
-        ASSERT_UCS_OK_OR_INPROGRESS(uct_ep_put_zcopy(e->ep(0), iov, iovcnt,
+        ASSERT_UCS_OK_OR_INPROGRESS(uct_ep_put_zcopy(e3.ep(0), iov, iovcnt,
                                                      recvbuf.addr(),
                                                      recvbuf.rkey(), &comp));
-
         // Create some stress on iface (flush mp):
         // post 10 flushes per every put.
         for (int j = 0; j < 10; j++) {
-            ASSERT_UCS_OK_OR_INPROGRESS(uct_ep_flush(e->ep(0), 0, &comp));
+            ASSERT_UCS_OK_OR_INPROGRESS(uct_ep_flush(e3.ep(0), 0, &comp));
         }
     }
 
@@ -81,30 +84,30 @@ UCS_TEST_SKIP_COND_P(test_rc, stress_iface_ops,
 }
 
 UCS_TEST_P(test_rc, tx_cq_moderation) {
-    unsigned tx_mod   = ucs_min(rc_iface(m_e1)->config.tx_moderation / 4, 8);
-    int16_t init_rsc  = rc_ep(m_e1)->txqp.available;
+    unsigned tx_mod   = ucs_min(rc_iface(sender())->config.tx_moderation / 4, 8);
+    int16_t init_rsc  = rc_ep(sender())->txqp.available;
 
-    send_am_messages(m_e1, tx_mod, UCS_OK);
+    send_am_messages(sender(), tx_mod, UCS_OK);
 
-    int16_t rsc = rc_ep(m_e1)->txqp.available;
+    int16_t rsc = rc_ep(sender())->txqp.available;
 
     EXPECT_LE(rsc, init_rsc);
 
     short_progress_loop(100);
 
-    EXPECT_EQ(rsc, rc_ep(m_e1)->txqp.available);
+    EXPECT_EQ(rsc, rc_ep(sender())->txqp.available);
 
     flush();
 
-    EXPECT_EQ(init_rsc, rc_ep(m_e1)->txqp.available);
+    EXPECT_EQ(init_rsc, rc_ep(sender())->txqp.available);
 }
 
 UCS_TEST_P(test_rc, flush_fc, "FLUSH_MODE?=fc") {
-    send_am_messages(m_e1, 1, UCS_OK);
+    send_am_messages(sender(), 1, UCS_OK);
 
     ucs_status_t status;
     do {
-        status = uct_ep_flush(m_e1->ep(0), 0, NULL);
+        status = uct_ep_flush(sender().ep(0), 0, NULL);
         short_progress_loop();
         if (status != UCS_ERR_NO_RESOURCE) {
             ASSERT_UCS_OK_OR_INPROGRESS(status);
@@ -132,13 +135,13 @@ protected:
 UCS_TEST_P(test_rc_max_wr, send_limit)
 {
     /* first 32 messages should be OK */
-    send_am_messages(m_e1, 32, UCS_OK);
+    send_am_messages(sender(), 32, UCS_OK);
 
     /* next message - should fail */
-    send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
+    send_am_messages(sender(), 1, UCS_ERR_NO_RESOURCE);
 
     progress_loop();
-    send_am_messages(m_e1, 1, UCS_OK);
+    send_am_messages(sender(), 1, UCS_OK);
 }
 
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc_max_wr)
@@ -180,13 +183,10 @@ public:
         uct_test::init();
 
         uct_iface_params_t params = iface_params();
-        m_entity                  = uct_test::create_entity(params);
+        m_entity                  = &uct_test::create_entity(params);
 
         params.features    |= UCT_IFACE_FEATURE_FLUSH_REMOTE;
-        m_entity_flush_rkey = uct_test::create_entity(params);
-
-        m_entities.push_back(m_entity);
-        m_entities.push_back(m_entity_flush_rkey);
+        m_entity_flush_rkey = &uct_test::create_entity(params);
     }
 
     using map_size_t = std::map<std::string, std::pair<size_t, size_t>>;
@@ -261,35 +261,35 @@ public:
     }
 
     void cleanup() {
-        uct_test::cleanup();
+        test_rc::cleanup();
         stats_restore();
     }
 
 #ifdef ENABLE_STATS
-    uint64_t get_no_reads_stat_counter(entity *e) {
-        uct_rc_iface_t *iface = ucs_derived_of(e->iface(), uct_rc_iface_t);
+    uint64_t get_no_reads_stat_counter(entity &e) {
+        uct_rc_iface_t *iface = ucs_derived_of(e.iface(), uct_rc_iface_t);
 
         return UCS_STATS_GET_COUNTER(iface->stats, UCT_RC_IFACE_STAT_NO_READS);
     }
 #endif
 
-    ssize_t reads_available(entity *e) {
+    ssize_t reads_available(entity &e) {
         return rc_iface(e)->tx.reads_available;
     }
 
-    void post_max_reads(entity *e, const mapped_buffer &sendbuf,
+    void post_max_reads(entity &e, const mapped_buffer &sendbuf,
                         const mapped_buffer &recvbuf) {
         UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
-                                sendbuf.memh(), e->iface_attr().cap.get.max_iov);
+                                sendbuf.memh(), e.iface_attr().cap.get.max_iov);
 
         int i = 0;
         ucs_status_t status;
         do {
             if (i++ % 2) {
-                status = uct_ep_get_zcopy(e->ep(0), iov, iovcnt, recvbuf.addr(),
+                status = uct_ep_get_zcopy(e.ep(0), iov, iovcnt, recvbuf.addr(),
                                           recvbuf.rkey(), &m_comp);
             } else {
-                status = uct_ep_get_bcopy(e->ep(0), (uct_unpack_callback_t)memcpy,
+                status = uct_ep_get_bcopy(e.ep(0), (uct_unpack_callback_t)memcpy,
                                           sendbuf.ptr(), sendbuf.length(),
                                           recvbuf.addr(), recvbuf.rkey(), &m_comp);
             }
@@ -302,9 +302,9 @@ public:
     void add_pending_ams(pending_send_request_t *reqs, int num_reqs) {
         for (int i = 0; i < num_reqs; ++i) {
             reqs[i].uct.func = pending_cb_send_am;
-            reqs[i].ep       = m_e1->ep(0);
+            reqs[i].ep       = sender().ep(0);
             reqs[i].cb_count = i;
-            ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &reqs[i].uct, 0));
+            ASSERT_UCS_OK(uct_ep_pending_add(sender().ep(0), &reqs[i].uct, 0));
         }
     }
 
@@ -355,59 +355,59 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_ops_limit,
                      !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
                                  UCT_IFACE_FLAG_GET_BCOPY))
 {
-    mapped_buffer sendbuf(1024, 0ul, *m_e1);
-    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, sender());
+    mapped_buffer recvbuf(1024, 0ul, receiver());
 
-    post_max_reads(m_e1, sendbuf, recvbuf);
+    post_max_reads(sender(), sendbuf, recvbuf);
 
 #ifdef ENABLE_STATS
-    EXPECT_GT(get_no_reads_stat_counter(m_e1), 0ul);
+    EXPECT_GT(get_no_reads_stat_counter(sender()), 0ul);
 #endif
 
     // Check that it is possible to add to pending if get returns NO_RESOURCE
     // due to lack of get credits
     uct_pending_req_t pend_req;
     pend_req.func = NULL; // Make valgrind happy
-    EXPECT_EQ(UCS_OK, uct_ep_pending_add(m_e1->ep(0), &pend_req, 0));
-    uct_ep_pending_purge(m_e1->ep(0), NULL, NULL);
+    EXPECT_EQ(UCS_OK, uct_ep_pending_add(sender().ep(0), &pend_req, 0));
+    uct_ep_pending_purge(sender().ep(0), NULL, NULL);
 
     flush();
-    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(sender()));
 }
 
 // Check that get function fails for messages bigger than MAX_GET_ZCOPY value
 UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_size_limit,
                      !check_caps(UCT_IFACE_FLAG_GET_ZCOPY))
 {
-    EXPECT_EQ(m_max_get_zcopy, m_e1->iface_attr().cap.get.max_zcopy);
+    EXPECT_EQ(m_max_get_zcopy, sender().iface_attr().cap.get.max_zcopy);
 
-    mapped_buffer buf(m_max_get_zcopy + 1, 0ul, *m_e1);
+    mapped_buffer buf(m_max_get_zcopy + 1, 0ul, sender());
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buf.ptr(), buf.length(), buf.memh(),
-                            m_e1->iface_attr().cap.get.max_iov);
+                            sender().iface_attr().cap.get.max_iov);
 
-    scoped_log_handler wrap_err(wrap_errors_logger);
-    ucs_status_t status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt,
+    ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
+    ucs_status_t status = uct_ep_get_zcopy(sender().ep(0), iov, iovcnt,
                                            buf.addr(), buf.rkey(), &m_comp);
     EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
 
     flush();
-    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(sender()));
 }
 
 // Check that get size value is trimmed by the actual maximum IB msg size
 UCS_TEST_SKIP_COND_P(test_rc_get_limit, invalid_get_size,
                      !check_caps(UCT_IFACE_FLAG_GET_ZCOPY))
 {
-    size_t max_ib_msg = uct_ib_iface_port_attr(&rc_iface(m_e1)->super)->max_msg_sz;
+    size_t max_ib_msg = uct_ib_iface_port_attr(
+            &rc_iface(sender())->super)->max_msg_sz;
 
     modify_config("RC_MAX_GET_ZCOPY", ucs::to_string(max_ib_msg + 1).c_str());
 
-    scoped_log_handler wrap_warn(hide_warns_logger);
-    entity *e = uct_test::create_entity(0);
-    m_entities.push_back(e);
+    ucs::log::scoped_handler wrap_warn(ucs::log::hide_warns_logger);
+    uct_test::create_entity(0);
 
-    EXPECT_EQ(m_max_get_zcopy, m_e1->iface_attr().cap.get.max_zcopy);
+    EXPECT_EQ(m_max_get_zcopy, sender().iface_attr().cap.get.max_zcopy);
 }
 
 // Check that gets resource counter is not affected/changed when the get
@@ -416,26 +416,26 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, post_get_no_res,
                      !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
                                  UCT_IFACE_FLAG_AM_BCOPY))
 {
-    unsigned max_get_bytes = reads_available(m_e1);
+    unsigned max_get_bytes = reads_available(sender());
     ucs_status_t status;
 
     do {
-        status = send_am_message(m_e1, 0, 0);
+        status = send_am_message(sender(), 0, 0);
     } while (status == UCS_OK);
 
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
-    EXPECT_EQ(max_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(max_get_bytes, reads_available(sender()));
 
-    mapped_buffer buf(1024, 0ul, *m_e1);
+    mapped_buffer buf(1024, 0ul, sender());
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, buf.ptr(), buf.length(), buf.memh(),
-                            m_e1->iface_attr().cap.get.max_iov);
+                            sender().iface_attr().cap.get.max_iov);
 
-    status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt, buf.addr(), buf.rkey(),
+    status = uct_ep_get_zcopy(sender().ep(0), iov, iovcnt, buf.addr(), buf.rkey(),
                               &m_comp);
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
-    EXPECT_EQ(max_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(max_get_bytes, reads_available(sender()));
 #ifdef ENABLE_STATS
-    EXPECT_EQ(get_no_reads_stat_counter(m_e1), 0ul);
+    EXPECT_EQ(get_no_reads_stat_counter(sender()), 0ul);
 #endif
 
     flush();
@@ -452,13 +452,13 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, check_rma_ops,
                                  UCT_IFACE_FLAG_AM_ZCOPY))
 
 {
-    mapped_buffer sendbuf(1024, 0ul, *m_e1);
-    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, sender());
+    mapped_buffer recvbuf(1024, 0ul, receiver());
 
-    post_max_reads(m_e1, sendbuf, recvbuf);
+    post_max_reads(sender(), sendbuf, recvbuf);
 
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), 1, sendbuf.memh(), 1);
-    uct_ep_h ep = m_e1->ep(0);
+    uct_ep_h ep = sender().ep(0);
 
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, uct_ep_put_short(ep, NULL, 0, 0, 0));
     EXPECT_EQ(UCS_ERR_NO_RESOURCE, uct_ep_put_bcopy(ep, NULL, NULL, 0, 0));
@@ -514,7 +514,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, check_rma_ops,
     }
 
     flush();
-    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(sender()));
 }
 
 // Check that outstanding get ops purged gracefully when ep is closed.
@@ -523,19 +523,19 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_zcopy_purge,
                      !check_caps(UCT_IFACE_FLAG_GET_ZCOPY |
                                  UCT_IFACE_FLAG_GET_BCOPY))
 {
-    mapped_buffer sendbuf(1024, 0ul, *m_e1);
-    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, sender());
+    mapped_buffer recvbuf(1024, 0ul, receiver());
 
-    post_max_reads(m_e1, sendbuf, recvbuf);
+    post_max_reads(sender(), sendbuf, recvbuf);
 
-    scoped_log_handler hide_warn(hide_warns_logger);
+    ucs::log::scoped_handler hide_warn(ucs::log::hide_warns_logger);
 
     unsigned flags      = UCT_FLUSH_FLAG_CANCEL;
     ucs_time_t deadline = ucs::get_deadline();
     ucs_status_t status;
     do {
-        ASSERT_EQ(1ul, m_e1->num_eps());
-        status = uct_ep_flush(m_e1->ep(0), flags, NULL);
+        ASSERT_EQ(1ul, sender().num_eps());
+        status = uct_ep_flush(sender().ep(0), flags, NULL);
         progress();
         if ((flags & UCT_FLUSH_FLAG_CANCEL) && (status != UCS_ERR_NO_RESOURCE)) {
             ASSERT_UCS_OK_OR_INPROGRESS(status);
@@ -545,9 +545,9 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, get_zcopy_purge,
     } while (((status == UCS_ERR_NO_RESOURCE) || (status == UCS_INPROGRESS)) &&
              (ucs_get_time() < deadline));
 
-    m_e1->destroy_eps();
+    sender().destroy_eps();
     flush();
-    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(sender()));
 }
 
 // Check that it is not possible to send while not all pendings are dispatched
@@ -564,16 +564,16 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, ordering_pending,
     volatile uint64_t sn = 0;
     ucs_status_t status;
 
-    uct_iface_set_am_handler(m_e2->iface(), AM_CHECK_ORDER_ID,
+    uct_iface_set_am_handler(receiver().iface(), AM_CHECK_ORDER_ID,
                              am_handler_ordering, (void*)&sn, 0);
 
-    mapped_buffer sendbuf(1024, 0ul, *m_e1);
-    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, sender());
+    mapped_buffer recvbuf(1024, 0ul, receiver());
 
-    post_max_reads(m_e1, sendbuf, recvbuf);
+    post_max_reads(sender(), sendbuf, recvbuf);
 
     EXPECT_EQ(UCS_ERR_NO_RESOURCE,
-              uct_ep_am_short(m_e1->ep(0), AM_CHECK_ORDER_ID, 0, NULL, 0));
+              uct_ep_am_short(sender().ep(0), AM_CHECK_ORDER_ID, 0, NULL, 0));
 
     const uint64_t num_pend = 3;
     pending_send_request_t reqs[num_pend];
@@ -581,7 +581,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, ordering_pending,
 
     do {
         progress();
-        status = uct_ep_am_short(m_e1->ep(0), AM_CHECK_ORDER_ID, num_pend,
+        status = uct_ep_am_short(sender().ep(0), AM_CHECK_ORDER_ID, num_pend,
                                  NULL, 0);
     } while (status != UCS_OK);
 
@@ -589,7 +589,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, ordering_pending,
     EXPECT_EQ(num_pend, sn);
 
     flush();
-    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(sender()));
 }
 
 UCS_TEST_SKIP_COND_P(test_rc_get_limit, ordering_comp_cb,
@@ -601,29 +601,29 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, ordering_comp_cb,
     volatile uint64_t sn    = 0;
     const uint64_t num_pend = 3;
 
-    uct_iface_set_am_handler(m_e2->iface(), AM_CHECK_ORDER_ID,
+    uct_iface_set_am_handler(receiver().iface(), AM_CHECK_ORDER_ID,
                              am_handler_ordering, (void*)&sn, 0);
 
-    mapped_buffer sendbuf(1024, 0ul, *m_e1);
-    mapped_buffer recvbuf(1024, 0ul, *m_e2);
+    mapped_buffer sendbuf(1024, 0ul, sender());
+    mapped_buffer recvbuf(1024, 0ul, receiver());
 
     am_completion_t comp;
     comp.uct.func       = get_comp_cb;
     comp.uct.count      = 1;
     comp.uct.status     = UCS_OK;
-    comp.ep             = m_e1->ep(0);
+    comp.ep             = sender().ep(0);
     comp.cb_count       = num_pend;
-    ucs_status_t status = uct_ep_get_bcopy(m_e1->ep(0),
+    ucs_status_t status = uct_ep_get_bcopy(sender().ep(0),
                                            (uct_unpack_callback_t)memcpy,
                                            sendbuf.ptr(), sendbuf.length(),
                                            recvbuf.addr(), recvbuf.rkey(),
                                            &comp.uct);
     ASSERT_FALSE(UCS_STATUS_IS_ERR(status));
 
-    post_max_reads(m_e1, sendbuf, recvbuf);
+    post_max_reads(sender(), sendbuf, recvbuf);
 
     EXPECT_EQ(UCS_ERR_NO_RESOURCE,
-              uct_ep_am_short(m_e1->ep(0), AM_CHECK_ORDER_ID, 0, NULL, 0));
+              uct_ep_am_short(sender().ep(0), AM_CHECK_ORDER_ID, 0, NULL, 0));
 
     pending_send_request_t reqs[num_pend];
     add_pending_ams(reqs, num_pend);
@@ -632,7 +632,7 @@ UCS_TEST_SKIP_COND_P(test_rc_get_limit, ordering_comp_cb,
     EXPECT_EQ(num_pend - 1, sn);
 
     flush();
-    EXPECT_EQ(m_num_get_bytes, reads_available(m_e1));
+    EXPECT_EQ(m_num_get_bytes, reads_available(sender()));
 }
 
 UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_get_limit)
@@ -661,10 +661,10 @@ public:
         return UCS_OK;
     }
 
-    void send_recv(uct_ep_h ep, entity *ent, size_t length)
+    void send_recv(uct_ep_h ep, entity &ent, size_t length)
     {
         /* set a callback for the uct to invoke for receiving the data */
-        uct_iface_set_am_handler(ent->iface(), 0, recv_handler, &length, 0);
+        uct_iface_set_am_handler(ent.iface(), 0, recv_handler, &length, 0);
 
         /* send the data */
         ssize_t packed_size = uct_ep_am_bcopy(ep, 0, send_pack_cb, &length, 0);
@@ -681,7 +681,7 @@ size_t test_rc_ece_auto::m_recv_count = 0;
 
 UCS_TEST_P(test_rc_ece_auto, send_recv)
 {
-    send_recv(m_e1->ep(0), m_e2, m_e1->iface_attr().cap.am.max_bcopy);
+    send_recv(sender().ep(0), receiver(), sender().iface_attr().cap.am.max_bcopy);
 }
 
 UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_ece_auto)
@@ -696,23 +696,23 @@ void test_rc_flow_control::init()
     }
     test_rc::init();
 
-    ucs_assert(rc_iface(m_e1)->config.fc_enabled);
-    ucs_assert(rc_iface(m_e2)->config.fc_enabled);
+    ucs_assert(rc_iface(sender())->config.fc_enabled);
+    ucs_assert(rc_iface(receiver())->config.fc_enabled);
 
-    uct_iface_set_am_handler(m_e1->iface(), FLUSH_AM_ID, am_handler, NULL, 0);
-    uct_iface_set_am_handler(m_e2->iface(), FLUSH_AM_ID, am_handler, NULL, 0);
+    uct_iface_set_am_handler(sender().iface(), FLUSH_AM_ID, am_handler, NULL, 0);
+    uct_iface_set_am_handler(receiver().iface(), FLUSH_AM_ID, am_handler, NULL, 0);
 
 }
 
 void test_rc_flow_control::cleanup()
 {
     /* Restore FC state to enabled, so iface cleanup will destroy the grant mpool */
-    rc_iface(m_e1)->config.fc_enabled = 1;
-    rc_iface(m_e2)->config.fc_enabled = 1;
+    rc_iface(sender())->config.fc_enabled   = 1;
+    rc_iface(receiver())->config.fc_enabled = 1;
     test_rc::cleanup();
 }
 
-void test_rc_flow_control::send_am_and_flush(entity *e, int num_msg)
+void test_rc_flow_control::send_am_and_flush(entity &e, int num_msg)
 {
     m_am_rx_count = 0;
 
@@ -722,7 +722,7 @@ void test_rc_flow_control::send_am_and_flush(entity *e, int num_msg)
     EXPECT_EQ(m_am_rx_count, 1ul);
 }
 
-void test_rc_flow_control::validate_grant(entity *e)
+void test_rc_flow_control::validate_grant(entity &e)
 {
     wait_for_flag(&get_fc_ptr(e)->fc_wnd);
     EXPECT_GT(get_fc_ptr(e)->fc_wnd, 0);
@@ -734,22 +734,22 @@ void test_rc_flow_control::validate_grant(entity *e)
 void test_rc_flow_control::test_general(int wnd, int soft_thresh,
                                         int hard_thresh, bool is_fc_enabled)
 {
-    set_fc_attributes(m_e1, is_fc_enabled, wnd, soft_thresh, hard_thresh);
+    set_fc_attributes(sender(), is_fc_enabled, wnd, soft_thresh, hard_thresh);
 
-    send_am_messages(m_e1, wnd, UCS_OK);
-    send_am_messages(m_e1, 1, is_fc_enabled ?  UCS_ERR_NO_RESOURCE : UCS_OK);
+    send_am_messages(sender(), wnd, UCS_OK);
+    send_am_messages(sender(), 1, is_fc_enabled ?  UCS_ERR_NO_RESOURCE : UCS_OK);
 
-    validate_grant(m_e1);
-    send_am_messages(m_e1, 1, UCS_OK);
+    validate_grant(sender());
+    send_am_messages(sender(), 1, UCS_OK);
 
     if (!is_fc_enabled) {
         /* Make valgrind happy, need to enable FC for proper cleanup */
-        set_fc_attributes(m_e1, true, wnd, wnd, 1);
+        set_fc_attributes(sender(), true, wnd, wnd, 1);
     }
     flush();
 }
 
-void test_rc_flow_control::wait_fc_hard_resend(entity *e)
+void test_rc_flow_control::wait_fc_hard_resend(entity &e)
 {
 }
 
@@ -757,47 +757,47 @@ void test_rc_flow_control::test_pending_grant(int16_t wnd)
 {
     /* Block send capabilities of m_e2 for fc grant to be
      * added to the pending queue. */
-    disable_entity(m_e2);
-    set_fc_attributes(m_e1, true, wnd, wnd, 1);
+    disable_entity(receiver());
+    set_fc_attributes(sender(), true, wnd, wnd, 1);
 
-    send_am_and_flush(m_e1, wnd);
+    send_am_and_flush(sender(), wnd);
 
     /* Now m_e1 should be blocked by FC window and FC grant
      * should be in pending queue of m_e2. */
-    send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
-    EXPECT_LE(get_fc_ptr(m_e1)->fc_wnd, 0);
+    send_am_messages(sender(), 1, UCS_ERR_NO_RESOURCE);
+    EXPECT_LE(get_fc_ptr(sender())->fc_wnd, 0);
 
-    wait_fc_hard_resend(m_e1);
+    wait_fc_hard_resend(sender());
 
     /* Enable send capabilities of m_e2 and send short put message to force
      * pending queue dispatch. Can't send AM message for that, because it may
      * trigger reordering assert due to disable/enable entity hack. */
-    enable_entity(m_e2);
-    set_tx_moderation(m_e2, 0);
-    EXPECT_EQ(UCS_OK, uct_ep_put_short(m_e2->ep(0), NULL, 0, 0, 0));
+    enable_entity(receiver());
+    set_tx_moderation(receiver(), 0);
+    EXPECT_EQ(UCS_OK, uct_ep_put_short(receiver().ep(0), NULL, 0, 0, 0));
 
     /* Check that m_e1 got grant */
-    validate_grant(m_e1);
-    send_am_messages(m_e1, 1, UCS_OK);
+    validate_grant(sender());
+    send_am_messages(sender(), 1, UCS_OK);
 }
 
 void test_rc_flow_control::test_flush_fc_disabled()
 {
-    set_fc_disabled(m_e1);
+    set_fc_disabled(sender());
     ucs_status_t status;
 
     /* If FC is disabled, wnd=0 should not prevent the flush */
-    get_fc_ptr(m_e1)->fc_wnd = 0;
-    status = uct_ep_flush(m_e1->ep(0), 0, NULL);
+    get_fc_ptr(sender())->fc_wnd = 0;
+    status = uct_ep_flush(sender().ep(0), 0, NULL);
     EXPECT_EQ(UCS_OK, status);
 
     /* send active message should be OK */
-    get_fc_ptr(m_e1)->fc_wnd = 1;
-    send_am_messages(m_e1, 1, UCS_OK);
-    EXPECT_EQ(0, get_fc_ptr(m_e1)->fc_wnd);
+    get_fc_ptr(sender())->fc_wnd = 1;
+    send_am_messages(sender(), 1, UCS_OK);
+    EXPECT_EQ(0, get_fc_ptr(sender())->fc_wnd);
 
     /* flush must have resources */
-    status = uct_ep_flush(m_e1->ep(0), 0, NULL);
+    status = uct_ep_flush(sender().ep(0), 0, NULL);
     EXPECT_FALSE(UCS_STATUS_IS_ERR(status)) << ucs_status_string(status);
 }
 
@@ -805,19 +805,19 @@ void test_rc_flow_control::test_pending_purge(int wnd, int num_pend_sends)
 {
     pending_send_request_t reqs[num_pend_sends];
 
-    disable_entity(m_e2);
-    set_fc_attributes(m_e1, true, wnd, wnd, 1);
+    disable_entity(receiver());
+    set_fc_attributes(sender(), true, wnd, wnd, 1);
 
-    send_am_and_flush(m_e1, wnd);
+    send_am_and_flush(sender(), wnd);
 
     /* Now m2 ep should have FC grant message in the pending queue.
      * Add some user pending requests as well */
     for (int i = 0; i < num_pend_sends; i++) {
         reqs[i].uct.func    = NULL; /* make valgrind happy */
         reqs[i].purge_count = 0;
-        EXPECT_EQ(uct_ep_pending_add(m_e2->ep(0), &reqs[i].uct, 0), UCS_OK);
+        EXPECT_EQ(uct_ep_pending_add(receiver().ep(0), &reqs[i].uct, 0), UCS_OK);
     }
-    uct_ep_pending_purge(m_e2->ep(0), purge_cb, NULL);
+    uct_ep_pending_purge(receiver().ep(0), purge_cb, NULL);
 
     for (int i = 0; i < num_pend_sends; i++) {
         EXPECT_EQ(1, reqs[i].purge_count);
@@ -842,13 +842,13 @@ UCS_TEST_P(test_rc_flow_control, pending_only_fc)
 {
     int wnd = 2;
 
-    disable_entity(m_e2);
-    set_fc_attributes(m_e1, true, wnd, wnd, 1);
+    disable_entity(receiver());
+    set_fc_attributes(sender(), true, wnd, wnd, 1);
 
-    send_am_and_flush(m_e1, wnd);
+    send_am_and_flush(sender(), wnd);
 
-    m_e2->destroy_ep(0);
-    ASSERT_TRUE(ucs_arbiter_is_empty(&rc_iface(m_e2)->tx.arbiter));
+    receiver().destroy_ep(0);
+    ASSERT_TRUE(ucs_arbiter_is_empty(&rc_iface(receiver())->tx.arbiter));
 }
 
 /* Check that user callback passed to uct_ep_pending_purge is not
@@ -878,21 +878,24 @@ void test_rc_flow_control_stats::test_general(int wnd, int soft_thresh,
 {
     uint64_t v;
 
-    set_fc_attributes(m_e1, true, wnd, soft_thresh, hard_thresh);
+    set_fc_attributes(sender(), true, wnd, soft_thresh, hard_thresh);
 
-    send_am_messages(m_e1, wnd, UCS_OK);
-    send_am_messages(m_e1, 1, UCS_ERR_NO_RESOURCE);
+    send_am_messages(sender(), wnd, UCS_OK);
+    send_am_messages(sender(), 1, UCS_ERR_NO_RESOURCE);
 
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e1)->stats, UCT_RC_FC_STAT_NO_CRED);
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(sender())->stats,
+                              UCT_RC_FC_STAT_NO_CRED);
     EXPECT_EQ(1ul, v);
 
-    validate_grant(m_e1);
-    send_am_messages(m_e1, 1, UCS_OK);
+    validate_grant(sender());
+    send_am_messages(sender(), 1, UCS_OK);
 
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e1)->stats, UCT_RC_FC_STAT_TX_HARD_REQ);
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(sender())->stats,
+                              UCT_RC_FC_STAT_TX_HARD_REQ);
     EXPECT_EQ(1ul, v);
 
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e1)->stats, UCT_RC_FC_STAT_RX_PURE_GRANT);
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(sender())->stats,
+                              UCT_RC_FC_STAT_RX_PURE_GRANT);
     EXPECT_EQ(1ul, v);
     flush();
 }
@@ -910,18 +913,22 @@ UCS_TEST_P(test_rc_flow_control_stats, soft_request)
     int s_thresh = 4;
     int h_thresh = 1;
 
-    set_fc_attributes(m_e1, true, wnd, s_thresh, h_thresh);
-    send_am_and_flush(m_e1, wnd - (s_thresh - 1));
+    set_fc_attributes(sender(), true, wnd, s_thresh, h_thresh);
+    send_am_and_flush(sender(), wnd - (s_thresh - 1));
 
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e1)->stats, UCT_RC_FC_STAT_TX_SOFT_REQ);
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(sender())->stats,
+                              UCT_RC_FC_STAT_TX_SOFT_REQ);
     EXPECT_EQ(1ul, v);
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e2)->stats, UCT_RC_FC_STAT_RX_SOFT_REQ);
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(receiver())->stats,
+                              UCT_RC_FC_STAT_RX_SOFT_REQ);
     EXPECT_EQ(1ul, v);
 
-    send_am_and_flush(m_e2, wnd - (s_thresh - 1));
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e1)->stats, UCT_RC_FC_STAT_RX_GRANT);
+    send_am_and_flush(receiver(), wnd - (s_thresh - 1));
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(sender())->stats,
+                              UCT_RC_FC_STAT_RX_GRANT);
     EXPECT_EQ(1ul, v);
-    v = UCS_STATS_GET_COUNTER(get_fc_ptr(m_e2)->stats, UCT_RC_FC_STAT_TX_GRANT);
+    v = UCS_STATS_GET_COUNTER(get_fc_ptr(receiver())->stats,
+                              UCT_RC_FC_STAT_TX_GRANT);
     EXPECT_EQ(1ul, v);
 }
 
@@ -940,8 +947,8 @@ test_uct_iface_attrs::attr_map_t test_rc_iface_attrs::get_num_iov() {
         return get_num_iov_mlx5_common(0ul);
     } else {
         EXPECT_TRUE(has_transport("rc_verbs"));
-        m_e->connect(0, *m_e, 0);
-        uct_rc_verbs_ep_t *ep = ucs_derived_of(m_e->ep(0), uct_rc_verbs_ep_t);
+        e(0).connect(0, e(0), 0);
+        uct_rc_verbs_ep_t *ep = ucs_derived_of(e(0).ep(0), uct_rc_verbs_ep_t);
         uint32_t max_sge = 0; // for gcc 10 -Og
         ASSERT_UCS_OK(uct_ib_qp_max_send_sge(ep->qp, &max_sge));
 
@@ -972,7 +979,7 @@ test_rc_iface_attrs::get_num_iov_mlx5_common(size_t av_size)
     iov_map["am"]  = UCT_IB_MLX5_AM_ZCOPY_MAX_IOV;
 
 #if IBV_HW_TM
-    if (UCT_RC_MLX5_TM_ENABLED(ucs_derived_of(m_e->iface(),
+    if (UCT_RC_MLX5_TM_ENABLED(ucs_derived_of(e(0).iface(),
                                               uct_rc_mlx5_iface_common_t))) {
         // For TAG eager zcopy iovs can use all WQE space, remaining from control
         // segment, TMH header (+ inline data segment) and AV (if relevant)
@@ -1024,7 +1031,7 @@ UCS_TEST_SKIP_COND_P(test_rc_keepalive, pending,
 {
     ucs_status_t status;
 
-    scoped_log_handler slh(wrap_errors_logger);
+    ucs::log::scoped_handler slh(ucs::log::wrap_errors_logger);
     flush();
     /* ensure that everything works as expected */
     EXPECT_EQ(0, m_err_count);
@@ -1072,25 +1079,25 @@ public:
     {
         test_rc::init();
 
-        m_buf8b = new mapped_buffer(8, 0x1, *m_e1);
-        m_buf8k = new mapped_buffer(8 * UCS_KBYTE, 0x2, *m_e1);
+        m_buf8b = new mapped_buffer(8, 0x1, sender());
+        m_buf8k = new mapped_buffer(8 * UCS_KBYTE, 0x2, sender());
     }
 
     void connect()
     {
         test_rc::connect();
 
-        m_e1->connect(0, *m_e2, 0);
-        m_e2->connect(0, *m_e1, 0);
-        m_e1->connect(1, *m_e2, 1);
-        m_e2->connect(1, *m_e1, 1);
+        sender().connect(0, receiver(), 0);
+        receiver().connect(0, sender(), 0);
+        sender().connect(1, receiver(), 1);
+        receiver().connect(1, sender(), 1);
     }
 
     bool send(int ep, void *buf)
     {
         ssize_t status;
 
-        status = uct_ep_am_bcopy(m_e1->ep(ep), 0, mapped_buffer::pack, buf, 0);
+        status = uct_ep_am_bcopy(sender().ep(ep), 0, mapped_buffer::pack, buf, 0);
         if (status == UCS_ERR_NO_RESOURCE) {
             short_progress_loop();
             return false;

--- a/test/gtest/uct/ib/test_rc.h
+++ b/test/gtest/uct/ib/test_rc.h
@@ -26,18 +26,19 @@ public:
         uct_ep_h          ep;
     } pending_send_request_t;
 
-    virtual void init();
+    virtual void init() override;
+    virtual void cleanup() override;
     virtual void connect();
 
-    uct_rc_iface_t* rc_iface(entity *e) {
-        return ucs_derived_of(e->iface(), uct_rc_iface_t);
+    uct_rc_iface_t* rc_iface(entity &e) {
+        return ucs_derived_of(e.iface(), uct_rc_iface_t);
     }
 
-    uct_rc_ep_t* rc_ep(entity *e, int ep_idx = 0) {
-        return ucs_derived_of(e->ep(ep_idx), uct_rc_ep_t);
+    uct_rc_ep_t* rc_ep(entity &e, int ep_idx = 0) {
+        return ucs_derived_of(e.ep(ep_idx), uct_rc_ep_t);
     }
 
-    void send_am_messages(entity *e, int wnd, ucs_status_t expected,
+    void send_am_messages(entity &e, int wnd, ucs_status_t expected,
                           uint8_t am_id = 0, int ep_idx = 0) {
         for (int i = 0; i < wnd; i++) {
             EXPECT_EQ(expected, send_am_message(e, am_id, ep_idx));
@@ -54,10 +55,6 @@ public:
                                          unsigned flags) {
         return UCS_OK;
     }
-
-protected:
-    entity *m_e1, *m_e2;
-
 };
 
 class test_rc_flow_control : public test_rc {
@@ -71,23 +68,24 @@ public:
     void init();
     void cleanup();
 
-    virtual uct_rc_fc_t* get_fc_ptr(entity *e, int ep_idx = 0) {
+    virtual uct_rc_fc_t* get_fc_ptr(entity &e, int ep_idx = 0) {
         return &rc_ep(e, ep_idx)->fc;
     }
 
-    virtual void disable_entity(entity *e) {
+    virtual void disable_entity(entity &e) {
         rc_iface(e)->tx.cq_available = 0;
     }
 
-    virtual void enable_entity(entity *e, unsigned cq_num = 128) {
+    virtual void enable_entity(entity &e, unsigned cq_num = 128) {
         rc_iface(e)->tx.cq_available = cq_num;
     }
 
-    virtual void set_tx_moderation(entity *e, int val) {
+    virtual void set_tx_moderation(entity &e, int val) {
         rc_iface(e)->config.tx_moderation = val;
     }
 
-    void set_fc_attributes(entity *e, bool enabled, int wnd, int s_thresh, int h_thresh) {
+    void set_fc_attributes(entity &e, bool enabled, int wnd, int s_thresh,
+                           int h_thresh) {
         rc_iface(e)->config.fc_enabled     = enabled;
         rc_iface(e)->config.fc_wnd_size    = get_fc_ptr(e)->fc_wnd = wnd;
         rc_iface(e)->config.fc_soft_thresh = s_thresh;
@@ -95,12 +93,12 @@ public:
 
     }
 
-    void set_fc_disabled(entity *e) {
+    void set_fc_disabled(entity &e) {
         /* same as default settings in rc_iface_init */
         set_fc_attributes(e, false, std::numeric_limits<int16_t>::max(), 0, 0);
     }
 
-    void send_am_and_flush(entity *e, int num_msg);
+    void send_am_and_flush(entity &e, int num_msg);
 
     void progress_loop(double delta_ms=10.0) {
         uct_test::short_progress_loop(delta_ms);
@@ -132,11 +130,11 @@ public:
         return UCS_OK;
     }
 
-    void validate_grant(entity *e);
+    void validate_grant(entity &e);
 
     void test_general(int wnd, int s_thresh, int h_thresh, bool is_fc_enabled);
 
-    virtual void wait_fc_hard_resend(entity *e);
+    virtual void wait_fc_hard_resend(entity &e);
 
     virtual void test_pending_grant(int16_t wnd);
 

--- a/test/gtest/uct/ib/ud_base.cc
+++ b/test/gtest/uct/ib/ud_base.cc
@@ -6,13 +6,9 @@ void ud_base_test::init()
 {
     uct_test::init();
 
-    m_e1 = uct_test::create_entity(0, get_err_handler());
-    m_entities.push_back(m_e1);
-
+    uct_test::create_entity(0, get_err_handler());
     check_skip_test();
-
-    m_e2 = uct_test::create_entity(0, get_err_handler());
-    m_entities.push_back(m_e2);
+    uct_test::create_entity(0, get_err_handler());
 }
 
 uct_error_handler_t ud_base_test::get_err_handler() const
@@ -20,19 +16,19 @@ uct_error_handler_t ud_base_test::get_err_handler() const
     return NULL;
 }
 
-uct_ud_ep_t *ud_base_test::ep(entity *e)
+uct_ud_ep_t *ud_base_test::ep(entity &e)
 {
-    return ucs_derived_of(e->ep(0), uct_ud_ep_t);
+    return ep(e, 0);
 }
 
-uct_ud_ep_t *ud_base_test::ep(entity *e, int i)
+uct_ud_ep_t *ud_base_test::ep(entity &e, int i)
 {
-    return ucs_derived_of(e->ep(i), uct_ud_ep_t);
+    return ucs_derived_of(e.ep(i), uct_ud_ep_t);
 }
 
-uct_ud_iface_t *ud_base_test::iface(entity *e)
+uct_ud_iface_t *ud_base_test::iface(entity &e)
 {
-    return ucs_derived_of(e->iface(), uct_ud_iface_t);
+    return ucs_derived_of(e.iface(), uct_ud_iface_t);
 }
 
 void ud_base_test::short_progress_loop(double delta_ms, entity *e) const
@@ -42,8 +38,8 @@ void ud_base_test::short_progress_loop(double delta_ms, entity *e) const
 
 void ud_base_test::connect()
 {
-    m_e1->connect(0, *m_e2, 0);
-    m_e2->connect(0, *m_e1, 0);
+    sender().connect(0, receiver(), 0);
+    receiver().connect(0, sender(), 0);
 }
 
 void ud_base_test::cleanup()
@@ -51,46 +47,45 @@ void ud_base_test::cleanup()
     uct_test::cleanup();
 }
 
-ucs_status_t ud_base_test::tx(entity *e)
+ucs_status_t ud_base_test::tx(entity &e)
 {
-    ucs_status_t err;
-    err = uct_ep_put_short(e->ep(0), &m_dummy, sizeof(m_dummy), (uint64_t)&m_dummy, 0);
-    return err;
+    return uct_ep_put_short(e.ep(0), &m_dummy, sizeof(m_dummy),
+                            (uint64_t)&m_dummy, 0);
 }
 
-ucs_status_t ud_base_test::ep_flush_b(entity *e)
-{
-    ucs_status_t status;
-    
-    do {
-        short_progress_loop();
-        status = uct_ep_flush(e->ep(0), 0, NULL);
-    } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
-
-    return status;
-}
-
-ucs_status_t ud_base_test::iface_flush_b(entity *e)
+ucs_status_t ud_base_test::ep_flush_b(entity &e)
 {
     ucs_status_t status;
     
     do {
         short_progress_loop();
-        status = uct_iface_flush(e->iface(), 0, NULL);
+        status = uct_ep_flush(e.ep(0), 0, NULL);
+    } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
+
+    return status;
+}
+
+ucs_status_t ud_base_test::iface_flush_b(entity &e)
+{
+    ucs_status_t status;
+    
+    do {
+        short_progress_loop();
+        status = uct_iface_flush(e.iface(), 0, NULL);
     } while (status == UCS_INPROGRESS || status == UCS_ERR_NO_RESOURCE);
 
     return status;
 }
 
 
-void ud_base_test::set_tx_win(entity *e, uct_ud_psn_t size)
+void ud_base_test::set_tx_win(entity &e, uct_ud_psn_t size)
 {
     /* force window */
     ep(e)->tx.max_psn = ep(e)->tx.acked_psn + size;
     ep(e)->ca.cwnd = size;
 }
 
-void ud_base_test::disable_async(entity *e)
+void ud_base_test::disable_async(entity &e)
 {
     iface(e)->async.disable = 1;
 }

--- a/test/gtest/uct/ib/ud_base.h
+++ b/test/gtest/uct/ib/ud_base.h
@@ -26,31 +26,30 @@ public:
 
     virtual uct_error_handler_t get_err_handler() const;
 
-    uct_ud_ep_t *ep(entity *e);
+    uct_ud_ep_t *ep(entity &e);
 
-    uct_ud_ep_t *ep(entity *e, int i);
+    uct_ud_ep_t *ep(entity &e, int i);
 
-    uct_ud_iface_t *iface(entity *e);
+    uct_ud_iface_t *iface(entity &e);
 
     void connect();
 
     void cleanup();
 
-    ucs_status_t tx(entity *e);
+    ucs_status_t tx(entity &e);
 
-    ucs_status_t ep_flush_b(entity *e);
+    ucs_status_t ep_flush_b(entity &e);
 
-    ucs_status_t iface_flush_b(entity *e);
+    ucs_status_t iface_flush_b(entity &e);
 
-    void set_tx_win(entity *e, uct_ud_psn_t size);
+    void set_tx_win(entity &e, uct_ud_psn_t size);
 
-    void disable_async(entity *e);
+    void disable_async(entity &e);
 
     virtual void
     short_progress_loop(double delta_ms = 10.0, entity *e = NULL) const;
 
 protected:
-    entity *m_e1, *m_e2;
     uint64_t m_dummy;
 };
 

--- a/test/gtest/uct/test_amo.cc
+++ b/test/gtest/uct/test_amo.cc
@@ -18,16 +18,14 @@ void uct_amo_test::init() {
 
     srand48(ucs::rand());
 
-    entity *receiver = uct_test::create_entity(0);
-    m_entities.push_back(receiver);
+    entity &receiver = uct_test::create_entity(0);
 
     check_skip_test();
 
     for (unsigned i = 0; i < num_senders(); ++i) {
-        entity *sender = uct_test::create_entity(0);
-        m_entities.push_back(sender);
-        sender->connect(0, *receiver, i);
-        receiver->connect(i, *sender, 0);
+        entity &sender = uct_test::create_entity(0);
+        sender.connect(0, receiver, i);
+        receiver.connect(i, sender, 0);
     }
 }
 
@@ -55,11 +53,11 @@ void uct_amo_test::add_reply_safe(uint64_t data) {
     pthread_spin_unlock(&m_replies_lock);
 }
 
-const uct_amo_test::entity& uct_amo_test::receiver() {
+const entity& uct_amo_test::receiver() {
     return m_entities.at(0);
 }
 
-const uct_amo_test::entity& uct_amo_test::sender(unsigned index) {
+const entity& uct_amo_test::sender(unsigned index) {
     return m_entities.at(1 + index);
 }
 

--- a/test/gtest/uct/test_fence.cc
+++ b/test/gtest/uct/test_fence.cc
@@ -30,28 +30,16 @@ public:
     virtual void init() {
         uct_test::init();
 
-        entity *receiver = uct_test::create_entity(0);
-        m_entities.push_back(receiver);
-
+        uct_test::create_entity(0);
         check_skip_test();
+        uct_test::create_entity(0);
 
-        entity *sender = uct_test::create_entity(0);
-        m_entities.push_back(sender);
-
-        sender->connect(0, *receiver, 1);
-        receiver->connect(1, *sender, 0);
+        sender().connect(0, receiver(), 1);
+        receiver().connect(1, sender(), 0);
     }
 
     virtual void cleanup() {
         uct_test::cleanup();
-    }
-
-    const entity& sender() {
-        return m_entities.at(1);
-    }
-
-    const entity& receiver() {
-        return m_entities.at(0);
     }
 
     class worker {

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -30,18 +30,14 @@ public:
     void init() {
         uct_test::init();
 
-        entity *m_sender = uct_test::create_entity(0);
-        m_entities.push_back(m_sender);
-
+        uct_test::create_entity(0);
         check_skip_test();
 
         if (UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) {
-            m_sender->connect(0, *m_sender, 0);
+            sender().connect(0, sender(), 0);
         } else {
-            entity *m_receiver = uct_test::create_entity(0);
-            m_entities.push_back(m_receiver);
-
-            m_sender->connect(0, *m_receiver, 0);
+            uct_test::create_entity(0);
+            sender().connect(0, receiver(), 0);
         }
         am_rx_count   = 0;
         m_flush_flags = 0;
@@ -331,11 +327,11 @@ public:
     void test_flush_am_pending(flush_func_t flush, bool destroy_ep);
 
 protected:
-    uct_test::entity& sender() {
+    entity& sender() {
         return **m_entities.begin();
     }
 
-    uct_test::entity& receiver() {
+    entity& receiver() {
         return **(m_entities.end() - 1);
     }
 
@@ -614,8 +610,8 @@ public:
         peer(uct_cancel_test &test) :
             m_e(NULL), m_buf(NULL), m_buf32(NULL), m_peer(NULL), m_test(test)
         {
-            m_e = m_test.uct_test::create_entity(0, error_handler_cb);
-            m_test.m_entities.push_back(m_e);
+            m_test.uct_test::create_entity(0, error_handler_cb);
+            m_e = m_test.m_entities.front();
 
             m_buf.reset(new mapped_buffer(BUF_SIZE, 0, *m_e));
             m_buf32.reset(new mapped_buffer(32, 0, *m_e));

--- a/test/gtest/uct/test_many2one_am.cc
+++ b/test/gtest/uct/test_many2one_am.cc
@@ -21,7 +21,7 @@ public:
         unsigned length;
     } receive_desc_t;
 
-    test_many2one_am() : m_am_count(0), m_receiver(NULL) {
+    test_many2one_am() : m_am_count(0) {
     }
 
     void init() {
@@ -48,8 +48,11 @@ public:
 
         uct_test::init();
 
-        m_receiver = create_entity(sizeof(receive_desc_t));
-        m_entities.push_back(m_receiver);
+        for (unsigned i = 0; i < NUM_SENDERS; ++i) {
+            create_entity(0);
+        }
+
+        create_entity(sizeof(receive_desc_t));
 
         check_skip_test();
     }
@@ -103,7 +106,6 @@ public:
 protected:
     volatile uint32_t             m_am_count;
     std::vector<receive_desc_t*>  m_backlog;
-    entity                       *m_receiver;
 };
 
 
@@ -116,17 +118,15 @@ UCS_TEST_SKIP_COND_P(test_many2one_am, am_bcopy,
 
     ucs::ptr_vector<mapped_buffer> buffers;
     for (unsigned i = 0; i < NUM_SENDERS; ++i) {
-        entity *sender = create_entity(0);
         mapped_buffer *buffer = new mapped_buffer(
-                            sender->iface_attr().cap.am.max_bcopy, 0, *sender);
-        sender->connect(0, *m_receiver, i);
-        m_entities.push_back(sender);
+                            sender(i).iface_attr().cap.am.max_bcopy, 0, sender(i));
+        sender(i).connect(0, receiver(), i);
         buffers.push_back(buffer);
     }
 
     m_am_count = 0;
 
-    status = uct_iface_set_am_handler(m_receiver->iface(), AM_ID, am_handler,
+    status = uct_iface_set_am_handler(receiver().iface(), AM_ID, am_handler,
                                       (void*)this, 0);
     ASSERT_UCS_OK(status);
 
@@ -138,15 +138,14 @@ UCS_TEST_SKIP_COND_P(test_many2one_am, am_bcopy,
 
         ssize_t packed_len;
         for (;;) {
-            const entity& sender = ent(sender_num + 1);
-            packed_len = uct_ep_am_bcopy(sender.ep(0), AM_ID,
+            packed_len = uct_ep_am_bcopy(sender(sender_num).ep(0), AM_ID,
                                          mapped_buffer::pack,
                                          (void*)&buffer, 0);
             if (packed_len != UCS_ERR_NO_RESOURCE) {
                 break;
             }
-            sender.progress();
-            m_receiver->progress();
+            sender(sender_num).progress();
+            receiver().progress();
         }
         if (packed_len < 0) {
             ASSERT_UCS_OK((ucs_status_t)packed_len);
@@ -157,14 +156,13 @@ UCS_TEST_SKIP_COND_P(test_many2one_am, am_bcopy,
         progress();
     }
 
-    status = uct_iface_set_am_handler(m_receiver->iface(), AM_ID,
-                                      NULL, NULL, 0);
+    status = uct_iface_set_am_handler(receiver().iface(), AM_ID, NULL, NULL, 0);
     ASSERT_UCS_OK(status);
 
     check_backlog();
 
     for (unsigned i = 0; i < NUM_SENDERS; ++i) {
-        ent(i + 1).flush();
+        sender(i).flush();
     }
 
     buffers.clear();

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -524,7 +524,7 @@ public:
             !strcmp(function, UCS_PP_QUOTE(uct_iface_mpool_empty_warn)))
         {
             UCS_TEST_MESSAGE << file << ":" << line << ": "
-                             << format_message(message, ap);
+                             << ucs::log::format_message(message, ap);
             return UCS_LOG_FUNC_RC_STOP;
         }
 
@@ -817,9 +817,8 @@ public:
     void test_invalid_alignment(size_t alignment, size_t align_offset,
                                 uint64_t field_mask)
     {
-        entity *dummy = uct_test::create_entity(0);
-        m_entities.push_back(dummy);
-        uct_iface_params_t params = dummy->iface_params();
+        uct_test::create_entity(0);
+        uct_iface_params_t params = e(0).iface_params();
 
         check_skip_test();
 
@@ -833,9 +832,9 @@ public:
 
         params.field_mask |= field_mask;
 
-        scoped_log_handler wrap_err(wrap_errors_logger);
+        ucs::log::scoped_handler wrap_err(ucs::log::wrap_errors_logger);
         uct_iface_h iface;
-        ucs_status_t status = uct_iface_open(dummy->md(), dummy->worker(),
+        ucs_status_t status = uct_iface_open(e(0).md(), e(0).worker(),
                                              &params, m_iface_config, &iface);
         EXPECT_EQ(UCS_ERR_INVALID_PARAM, status) << "alignment " << alignment;
     }

--- a/test/gtest/uct/test_p2p_err.cc
+++ b/test/gtest/uct/test_p2p_err.cc
@@ -44,7 +44,7 @@ public:
     {
         pack_arg arg;
 
-        scoped_log_handler slh(wrap_errors_logger);
+        ucs::log::scoped_handler slh(ucs::log::wrap_errors_logger);
 
         ucs_status_t status = UCS_OK;
         ssize_t packed_len;
@@ -106,9 +106,8 @@ public:
         /* Count how many error messages match/don't match the given pattern */
         size_t num_matched   = 0;
         size_t num_unmatched = 0;
-        for (std::vector<std::string>::iterator iter = m_errors.begin();
-                        iter != m_errors.end(); ++iter) {
-            if (iter->find(error_pattern) != iter->npos) {
+        for (auto &e : ucs::log::errors()) {
+            if (e.find(error_pattern) != e.npos) {
                 ++num_matched;
             } else {
                 ++num_unmatched;
@@ -139,9 +138,8 @@ private:
     static ucs_status_t
     error_handler(void *arg, uct_ep_h ep, ucs_status_t status) {
         uct_p2p_err_test *self = static_cast<uct_p2p_err_test*>(arg);
-        const p2p_resource *r = dynamic_cast<const p2p_resource*>(self->GetParam());
-        ucs_assert_always(r != NULL);
-        if (r->loopback) {
+
+        if (self->is_loopback()) {
             /* In loop back IB TLs can generate QP flush error before remote
              * access error. */
             ucs_log(UCS_LOG_LEVEL_ERROR, "Error on ep %p with status %s is handled",

--- a/test/gtest/uct/test_progress.cc
+++ b/test/gtest/uct/test_progress.cc
@@ -16,18 +16,18 @@ public:
     virtual void init()
     {
         uct_test::init();
-        m_entities.push_back(create_entity(0));
+        create_entity(0);
     }
 
 protected:
     uct_worker_h worker(unsigned index = 0)
     {
-        return ent(index).worker();
+        return e(index).worker();
     }
 
     uct_iface_h iface(unsigned index = 0)
     {
-        return ent(index).iface();
+        return e(index).iface();
     }
 
     static unsigned count_progress(void *arg)

--- a/test/gtest/uct/test_tag.cc
+++ b/test/gtest/uct/test_tag.cc
@@ -452,11 +452,11 @@ public:
 
 
 protected:
-    uct_test::entity& sender() {
+    entity& sender() {
         return **m_entities.begin();
     }
 
-    uct_test::entity& receiver() {
+    entity& receiver() {
         return **(m_entities.end() - 1);
     }
 
@@ -774,6 +774,7 @@ public:
 
     void cleanup() {
         test_tag::cleanup();
+        m_entities.clear();
         stats_restore();
     }
 
@@ -967,14 +968,6 @@ protected:
     std::vector<void*> m_uct_descs;
     bool               m_hold_uct_desc;
 
-    uct_test::entity& sender() {
-        return **m_entities.begin();
-    }
-
-    uct_test::entity& receiver() {
-        return **(m_entities.end() - 1);
-    }
-
 private:
     ucs_status_t unexp_handler(void *data, unsigned flags, uint64_t imm,
                                void **context);
@@ -1023,23 +1016,21 @@ void test_tag_mp_xrq::init()
 
     uct_test::init();
 
-    entity *sender = uct_test::create_entity(0ul, NULL, unexp_eager, unexp_rndv,
-                                             reinterpret_cast<void*>(this),
-                                             reinterpret_cast<void*>(this));
-    m_entities.push_back(sender);
+    uct_test::create_entity(0ul, NULL, unexp_eager, unexp_rndv,
+                            reinterpret_cast<void*>(this),
+                            reinterpret_cast<void*>(this));
 
-    entity *receiver = uct_test::create_entity(0ul, NULL, unexp_eager, unexp_rndv,
-                                               reinterpret_cast<void*>(this),
-                                               reinterpret_cast<void*>(this));
-    m_entities.push_back(receiver);
+    uct_test::create_entity(0ul, NULL, unexp_eager, unexp_rndv,
+                            reinterpret_cast<void*>(this),
+                            reinterpret_cast<void*>(this));
 
     if (!UCT_RC_MLX5_MP_ENABLED(rc_mlx5_iface(test_tag_mp_xrq::sender()))) {
         UCS_TEST_SKIP_R("No MP XRQ support");
     }
 
-    sender->connect(0, *receiver, 0);
+    sender().connect(0, receiver(), 0);
 
-    uct_iface_set_am_handler(receiver->iface(), AM_ID, am_handler, this, 0);
+    uct_iface_set_am_handler(receiver().iface(), AM_ID, am_handler, this, 0);
 }
 
 void test_tag_mp_xrq::send_eager_bcopy(mapped_buffer *buf)

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -67,19 +67,16 @@ void uct_p2p_test::init() {
     ucs_assert_always(r != NULL);
 
     /* Create 2 connected endpoints */
-    entity *e1 = uct_test::create_entity(m_rx_headroom, m_err_handler);
-    m_entities.push_back(e1);
+    uct_test::create_entity(m_rx_headroom, m_err_handler);
 
     check_skip_test();
 
     if (r->loopback) {
-        e1->connect(0, *e1, 0);
+        sender().connect(0, sender(), 0);
     } else {
-        entity *e2 = uct_test::create_entity(m_rx_headroom, m_err_handler);
-        m_entities.push_back(e2);
-
-        e1->connect(0, *e2, 0);
-        e2->connect(0, *e1, 0);
+        uct_test::create_entity(m_rx_headroom, m_err_handler);
+        sender().connect(0, receiver(), 0);
+        receiver().connect(0, sender(), 0);
     }
 
     /* Allocate completion handle and set the callback */
@@ -92,6 +89,7 @@ void uct_p2p_test::init() {
 void uct_p2p_test::cleanup() {
     flush();
     uct_test::cleanup();
+    m_entities.clear();
 }
 
 void uct_p2p_test::test_xfer(send_func_t send, size_t length, unsigned flags,
@@ -310,16 +308,8 @@ void uct_p2p_test::wait_for_remote() {
     flush();
 }
 
-uct_test::entity& uct_p2p_test::sender() {
-    return **m_entities.begin();
-}
-
 uct_ep_h uct_p2p_test::sender_ep() {
     return sender().ep(0);
-}
-
-uct_test::entity& uct_p2p_test::receiver() {
-    return **(m_entities.end() - 1);
 }
 
 uct_completion_t *uct_p2p_test::comp() {

--- a/test/gtest/uct/uct_p2p_test.h
+++ b/test/gtest/uct/uct_p2p_test.h
@@ -58,9 +58,7 @@ protected:
     void blocking_send(send_func_t send, uct_ep_h ep, const mapped_buffer &sendbuf,
                        const mapped_buffer &recvbuf, bool wait_for_completion);
     void wait_for_remote();
-    entity& sender();
     uct_ep_h sender_ep();
-    entity& receiver();
     uct_completion_t *comp();
     void disable_comp();
 

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -101,11 +101,132 @@ protected:
 };
 
 
+enum atomic_mode {
+    OP32,
+    OP64,
+    FOP32,
+    FOP64
+};
+
+
+class entity {
+public:
+    typedef std::vector< ucs::handle<uct_ep_h> > eps_vec_t;
+
+    entity(const resource& resource, uct_iface_config_t *iface_config,
+           uct_iface_params_t *params, uct_md_config_t *md_config);
+
+    entity(const resource& resource, uct_md_config_t *md_config,
+           uct_cm_config_t *cm_config);
+
+    void mem_alloc_host(size_t length, unsigned mem_flags,
+                        uct_allocated_memory_t *mem) const;
+
+    void mem_free_host(const uct_allocated_memory_t *mem) const;
+
+    void mem_type_reg(uct_allocated_memory_t *mem, unsigned flags) const;
+
+    void mem_type_dereg(uct_allocated_memory_t *mem) const;
+
+    void rkey_unpack(const uct_allocated_memory_t *mem,
+                     uct_rkey_bundle *rkey_bundle) const;
+
+    void rkey_release(const uct_rkey_bundle *rkey_bundle) const;
+
+    unsigned progress() const;
+
+    bool is_caps_supported(uint64_t required_flags) const;
+    bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0) const;
+    bool check_event_caps(uint64_t required_flags,
+                          uint64_t invalid_flags = 0) const;
+    bool check_atomics(uint64_t required_ops, atomic_mode mode) const;
+
+    uct_md_h md() const;
+
+    const uct_md_attr_v2_t& md_attr() const;
+
+    uct_worker_h worker() const;
+
+    uct_cm_h cm() const;
+
+    const uct_cm_attr_t& cm_attr() const;
+
+    uct_listener_h listener() const;
+
+    uct_listener_h revoke_listener() const;
+
+    uct_iface_h iface() const;
+
+    const uct_iface_attr& iface_attr() const;
+
+    const uct_iface_params& iface_params() const;
+
+    uct_ep_h ep(unsigned index) const;
+
+    eps_vec_t& eps();
+    size_t num_eps() const;
+    void reserve_ep(unsigned index);
+
+    void create_ep(unsigned index = 0, unsigned path_index = 0);
+    void destroy_ep(unsigned index);
+    void revoke_ep(unsigned index);
+    void destroy_eps();
+    void connect(unsigned index, entity& other, unsigned other_index);
+    void connect_to_iface(unsigned index, entity& other);
+    void connect_to_ep(unsigned index, entity& other,
+                       unsigned other_index);
+    void connect_to_sockaddr(unsigned index,
+                             const ucs::sock_addr_storage &remote_addr,
+                             const ucs::sock_addr_storage *local_addr,
+                             uct_cm_ep_resolve_callback_t resolve_cb,
+                             uct_cm_ep_client_connect_callback_t connect_cb,
+                             uct_ep_disconnect_cb_t disconnect_cb,
+                             void *user_data);
+
+    ucs_status_t listen(const ucs::sock_addr_storage &listen_addr,
+                        const uct_listener_params_t &params);
+    void disconnect(uct_ep_h ep);
+
+    void flush() const;
+
+    ucs_async_context_t &async() const;
+
+    size_t                   max_conn_priv;
+
+private:
+    class async_wrapper {
+    public:
+        ucs_async_context_t   m_async;
+        async_wrapper();
+        ~async_wrapper();
+        void check_miss();
+    private:
+        async_wrapper(const async_wrapper &);
+    };
+
+
+    void connect_p2p_ep(uct_ep_h from, uct_ep_h to);
+
+    const resource              m_resource;
+    ucs::handle<uct_md_h>       m_md;
+    uct_md_attr_v2_t            m_md_attr;
+    mutable async_wrapper       m_async;
+    ucs::handle<uct_worker_h>   m_worker;
+    ucs::handle<uct_cm_h>       m_cm;
+    uct_cm_attr_t               m_cm_attr;
+    ucs::handle<uct_listener_h> m_listener;
+    ucs::handle<uct_iface_h>    m_iface;
+    eps_vec_t                   m_eps;
+    uct_iface_attr_t            m_iface_attr;
+    uct_iface_params_t          m_iface_params;
+};
+
 /**
  * UCT test, parametrized on a transport/device.
  */
 class uct_test : public testing::TestWithParam<const resource*>,
-                 public uct_test_base {
+                 public uct_test_base,
+                 public ucs::entities_storage<entity> {
 public:
     UCS_TEST_BASE_IMPL;
 
@@ -117,126 +238,7 @@ public:
     uct_test();
     virtual ~uct_test();
 
-    enum atomic_mode {
-        OP32,
-        OP64,
-        FOP32,
-        FOP64
-    };
-
 protected:
-
-    class entity {
-    public:
-        typedef uct_test::atomic_mode atomic_mode;
-        typedef std::vector< ucs::handle<uct_ep_h> > eps_vec_t;
-
-        entity(const resource& resource, uct_iface_config_t *iface_config,
-               uct_iface_params_t *params, uct_md_config_t *md_config);
-
-        entity(const resource& resource, uct_md_config_t *md_config,
-               uct_cm_config_t *cm_config);
-
-        void mem_alloc_host(size_t length, unsigned mem_flags,
-                            uct_allocated_memory_t *mem) const;
-
-        void mem_free_host(const uct_allocated_memory_t *mem) const;
-
-        void mem_type_reg(uct_allocated_memory_t *mem, unsigned flags) const;
-
-        void mem_type_dereg(uct_allocated_memory_t *mem) const;
-
-        void rkey_unpack(const uct_allocated_memory_t *mem,
-                         uct_rkey_bundle *rkey_bundle) const;
-
-        void rkey_release(const uct_rkey_bundle *rkey_bundle) const;
-
-        unsigned progress() const;
-
-        bool is_caps_supported(uint64_t required_flags);
-        bool check_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
-        bool check_event_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
-        bool check_atomics(uint64_t required_ops, atomic_mode mode);
-
-        uct_md_h md() const;
-
-        const uct_md_attr_v2_t& md_attr() const;
-
-        uct_worker_h worker() const;
-
-        uct_cm_h cm() const;
-
-        const uct_cm_attr_t& cm_attr() const;
-
-        uct_listener_h listener() const;
-
-        uct_listener_h revoke_listener() const;
-
-        uct_iface_h iface() const;
-
-        const uct_iface_attr& iface_attr() const;
-
-        const uct_iface_params& iface_params() const;
-
-        uct_ep_h ep(unsigned index) const;
-
-        eps_vec_t& eps();
-        size_t num_eps() const;
-        void reserve_ep(unsigned index);
-
-        void create_ep(unsigned index = 0, unsigned path_index = 0);
-        void destroy_ep(unsigned index);
-        void revoke_ep(unsigned index);
-        void destroy_eps();
-        void connect(unsigned index, entity& other, unsigned other_index);
-        void connect_to_iface(unsigned index, entity& other);
-        void connect_to_ep(unsigned index, entity& other,
-                           unsigned other_index);
-        void connect_to_sockaddr(unsigned index,
-                                 const ucs::sock_addr_storage &remote_addr,
-                                 const ucs::sock_addr_storage *local_addr,
-                                 uct_cm_ep_resolve_callback_t resolve_cb,
-                                 uct_cm_ep_client_connect_callback_t connect_cb,
-                                 uct_ep_disconnect_cb_t disconnect_cb,
-                                 void *user_data);
-
-        ucs_status_t listen(const ucs::sock_addr_storage &listen_addr,
-                            const uct_listener_params_t &params);
-        void disconnect(uct_ep_h ep);
-
-        void flush() const;
-
-        ucs_async_context_t &async() const;
-
-        size_t                   max_conn_priv;
-
-    private:
-        class async_wrapper {
-        public:
-            ucs_async_context_t   m_async;
-            async_wrapper();
-            ~async_wrapper();
-            void check_miss();
-        private:
-            async_wrapper(const async_wrapper &);
-        };
-
-
-        void connect_p2p_ep(uct_ep_h from, uct_ep_h to);
-
-        const resource              m_resource;
-        ucs::handle<uct_md_h>       m_md;
-        uct_md_attr_v2_t            m_md_attr;
-        mutable async_wrapper       m_async;
-        ucs::handle<uct_worker_h>   m_worker;
-        ucs::handle<uct_cm_h>       m_cm;
-        uct_cm_attr_t               m_cm_attr;
-        ucs::handle<uct_listener_h> m_listener;
-        ucs::handle<uct_iface_h>    m_iface;
-        eps_vec_t                   m_eps;
-        uct_iface_attr_t            m_iface_attr;
-        uct_iface_params_t          m_iface_params;
-    };
 
     class mapped_buffer {
     public:
@@ -266,7 +268,7 @@ protected:
     private:
         void reset();
 
-        const uct_test::entity& m_entity;
+        const entity&           m_entity;
 
         void                    *m_buf;
         void                    *m_end;
@@ -396,7 +398,6 @@ protected:
     void check_caps_skip(uint64_t required_flags, uint64_t invalid_flags = 0);
     bool check_event_caps(uint64_t required_flags, uint64_t invalid_flags = 0);
     bool check_atomics(uint64_t required_ops, atomic_mode mode);
-    const entity& ent(unsigned index) const;
     unsigned progress() const;
     unsigned progress_mt() const;
     void flush(ucs_time_t deadline = ULONG_MAX) const;
@@ -418,7 +419,7 @@ protected:
     static void init_sockaddr_rsc(resource *rsc, struct sockaddr *listen_addr,
                                   struct sockaddr *connect_addr, size_t size,
                                   bool init_src);
-    uct_test::entity *
+    entity&
     create_entity(size_t rx_headroom, uct_error_handler_t err_handler = NULL,
                   uct_tag_unexp_eager_cb_t eager_cb = NULL,
                   uct_tag_unexp_rndv_cb_t rndv_cb = NULL,
@@ -436,16 +437,15 @@ protected:
                               void *async_event_arg = NULL,
                               size_t am_alignment = 0ul,
                               size_t am_align_offset = 0ul);
-    uct_test::entity* create_entity(uct_iface_params_t &params);
-    uct_test::entity* create_entity();
+    entity& create_entity(uct_iface_params_t &params);
+    entity& create_entity();
     int max_connections();
     int max_connect_batch();
 
     void reduce_tl_send_queues();
 
-    ucs_status_t send_am_message(entity *e, uint8_t am_id = 0, int ep_idx = 0);
+    ucs_status_t send_am_message(entity &e, uint8_t am_id = 0, int ep_idx = 0);
 
-    ucs::ptr_vector<entity> m_entities;
     uct_iface_config_t      *m_iface_config;
     uct_md_config_t         *m_md_config;
     uct_cm_config_t         *m_cm_config;
@@ -461,9 +461,6 @@ public:
     void init();
     virtual attr_map_t get_num_iov() = 0;
     void basic_iov_test();
-
-protected:
-    entity *m_e;
 };
 
 


### PR DESCRIPTION
## What
 - reuse common entity storage in UCT tests
 - dependent change is move `class entity` and logging functionality to separate classes from `class uct_test`

## Why ?
`entity_storage` was initially designed to be reused in UCT and UCP tests but was implemented only in UCT
This PR unifies usage of entities in UCP and UCT tests

## How ?
 - move `class entity` and logging functionality to separate classes from `class uct_test`
 - del `m_entities` from `class uct_test` and add inheritance from `entities_storage`
 - replace `m_e1` with `sender()`, `m_e2` with `receiver()`, etc