### PR TITLE
TOOLS/PERF: Second batch commit for DPU xgvmi daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ ucx*tar.gz
 src/tools/info/build_config.h
 src/tools/info/ucx_info
 src/tools/perf/ucx_perftest
+src/tools/perf/ucx_perftest_daemon
 src/tools/profile/ucx_read_profile
 test/apps/test_dlopen_cfg_print
 test/apps/test_link_map

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -109,6 +109,7 @@ struct ucx_perf_context {
             unsigned long              remote_addr;
             ucp_mem_h                  send_memh;
             ucp_mem_h                  recv_memh;
+            ucp_perf_daemon_req_t      daemon_req;
             ucp_dt_iov_t               *send_iov;
             ucp_dt_iov_t               *recv_iov;
             void                       *am_hdr;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -196,6 +196,7 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.ucp.send_datatype = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.recv_datatype = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.am_hdr_size   = 0;
+    params->super.ucp.is_daemon_mode  = 0;
     params->super.ucp.dmn_local_addr  = empty_addr;
     params->super.ucp.dmn_remote_addr = empty_addr;
     strcpy(params->super.uct.dev_name, TL_RESOURCE_NAME_NONE);

--- a/src/tools/perf/perftest_daemon.c
+++ b/src/tools/perf/perftest_daemon.c
@@ -11,6 +11,7 @@
 #include "perftest.h"
 
 #include <ucp/api/ucp.h>
+#include <ucp/core/ucp_mm.h>
 #include <ucs/debug/log.h>
 #include <ucs/sys/sock.h>
 #include <ucs/sys/string.h>
@@ -26,21 +27,34 @@ typedef struct ucp_perf_daemon_context_t {
     ucp_context_h                      context;
     ucp_worker_h                       worker;
     ucp_listener_h                     listener;
+    sa_family_t                        ai_family;
     uint16_t                           port;
     ucp_ep_h                           host_ep;
     ucp_ep_h                           peer_ep;
     struct sockaddr_storage            peer_address;
     ucp_mem_h                          send_memh;
     ucp_mem_h                          recv_memh;
-    void                               *rx_address;
 } ucp_perf_daemon_context_t;
 
 static volatile int terminated = 0;
 
+const char *ucp_perf_daemon_am_id_name(ucp_perf_daemon_am_id_t am_id)
+{
+#define UCP_PERF_DAEMON_NAME_CASE(ID, _) \
+    case ID: \
+        return #ID;
+
+    switch (am_id) {
+        UCP_FOREACH_PERF_DAEMON_AM_ID(UCP_PERF_DAEMON_NAME_CASE);
+    default:
+        return "UNKNOWN";
+    }
+}
+
 static void
 ucp_perf_daemon_ep_close(ucp_perf_daemon_context_t *ctx, ucp_ep_h ep)
 {
-    ucp_request_param_t param;
+    ucp_request_param_t param = {};
     ucs_status_ptr_t close_req;
     ucs_status_t status;
 
@@ -81,7 +95,7 @@ ucp_perf_daemon_server_conn_handle_cb(ucp_conn_request_h conn_request,
     ucs_status_t status;
     ucp_ep_h ep;
 
-    ep_params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLER  |
+    ep_params.field_mask      = UCP_EP_PARAM_FIELD_ERR_HANDLER |
                                 UCP_EP_PARAM_FIELD_CONN_REQUEST |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
     ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
@@ -94,6 +108,303 @@ ucp_perf_daemon_server_conn_handle_cb(ucp_conn_request_h conn_request,
         ucs_error("failed to create an endpoint on the daemon: %s",
                   ucs_status_string(status));
     }
+}
+
+static ucs_status_t
+ucp_perf_daemon_set_am_recv_handler(ucp_perf_daemon_context_t *ctx,
+                                    ucp_perf_daemon_am_id_t am_id,
+                                    ucp_am_recv_callback_t cb)
+{
+    ucp_am_handler_param_t param;
+    ucs_status_t status;
+
+    param.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
+                       UCP_AM_HANDLER_PARAM_FIELD_CB |
+                       UCP_AM_HANDLER_PARAM_FIELD_FLAGS |
+                       UCP_AM_HANDLER_PARAM_FIELD_ARG;
+    param.id         = am_id;
+    param.cb         = cb;
+    param.flags      = UCP_AM_FLAG_WHOLE_MSG;
+    param.arg        = ctx;
+
+    status = ucp_worker_set_am_recv_handler(ctx->worker, &param);
+    if (UCS_OK != status) {
+        ucs_error("failed to set am recv handler: %s",
+                  ucs_status_string(status));
+        return status;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_send_am_eager_reply(ucp_ep_h ep, ucp_perf_daemon_am_id_t am_id)
+{
+    ucp_request_param_t param = {};
+    ucs_status_ptr_t sreq;
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.flags        = UCP_AM_SEND_FLAG_REPLY | UCP_AM_SEND_FLAG_EAGER;
+
+    sreq = ucp_am_send_nbx(ep, am_id, NULL, 0ul, NULL, 0ul, &param);
+    if (UCS_PTR_IS_PTR(sreq)) {
+        ucp_request_free(sreq);
+    } else if (UCS_PTR_IS_ERR(sreq)) {
+        ucs_error("failed to send am id %u: %s", am_id,
+                  ucs_status_string(UCS_PTR_STATUS(sreq)));
+        return UCS_PTR_STATUS(sreq);
+    }
+
+    return UCS_OK;
+}
+
+static void
+ucp_perf_daemon_send_cb(void *request, ucs_status_t status, void *user_data)
+{
+    ucp_perf_daemon_context_t *ctx = user_data;
+
+    ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
+                                        UCP_PERF_DAEMON_AM_ID_SEND_CMPL);
+    ucp_request_free(request);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_perf_daemon_handle_request(
+        ucp_perf_daemon_context_t *ctx, ucp_perf_daemon_req_t *req)
+{
+    ucp_request_param_t param = {};
+    ucs_status_ptr_t sptr;
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_MEMH |
+                         UCP_OP_ATTR_FIELD_CALLBACK |
+                         UCP_OP_ATTR_FIELD_USER_DATA |
+                         UCP_OP_ATTR_FIELD_FLAGS |
+                         UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    param.memh         = ctx->send_memh;
+    param.cb.send      = ucp_perf_daemon_send_cb;
+    param.user_data    = ctx;
+    param.flags        = UCP_AM_SEND_FLAG_RNDV;
+
+    sptr = ucp_am_send_nbx(ctx->peer_ep, UCP_PERF_DAEMON_AM_ID_PEER_TX, NULL,
+                           0ul, (void*)req->addr, (size_t)req->length, &param);
+
+    return UCS_PTR_STATUS(sptr);
+}
+
+static void ucp_perf_daemon_recv_cb(void *request, ucs_status_t status,
+                                    size_t length, void *user_data)
+{
+    ucp_perf_daemon_context_t *ctx = user_data;
+
+    ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
+                                        UCP_PERF_DAEMON_AM_ID_RECV_CMPL);
+    ucp_request_free(request);
+}
+
+static ucs_status_t
+ucp_perf_daemon_create_peer_ep(ucp_perf_daemon_context_t *ctx,
+                               const void *address, size_t address_length)
+{
+    ucp_ep_params_t ep_params;
+    ucs_status_t status;
+
+    memcpy(&ctx->peer_address, address, address_length);
+
+    ep_params.field_mask       = UCP_EP_PARAM_FIELD_FLAGS |
+                                 UCP_EP_PARAM_FIELD_SOCK_ADDR |
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLER |
+                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
+    ep_params.err_mode         = UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.err_handler.cb   = ucp_perf_daemon_err_cb;
+    ep_params.err_handler.arg  = ctx;
+    ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
+    ep_params.sockaddr.addr    = (struct sockaddr*)&ctx->peer_address;
+    ep_params.sockaddr.addrlen = sizeof(ctx->peer_address);
+
+    status = ucp_ep_create(ctx->worker, &ep_params, &ctx->peer_ep);
+    if (status != UCS_OK) {
+        ucs_error("daemon failed to create an endpoint: %s",
+                  ucs_status_string(status));
+        return status;
+    }
+
+    return ucp_perf_daemon_send_am_eager_reply(ctx->peer_ep,
+                                               UCP_PERF_DAEMON_AM_ID_PEER_INIT);
+}
+
+static void ucp_perf_daemon_check_am_msg(const ucp_am_recv_param_t *param,
+                                         size_t header_length,
+                                         int check_reply_ep, int check_rndv,
+                                         ucp_perf_daemon_am_id_t am_id)
+{
+    ucs_trace_data("message received: %s", ucp_perf_daemon_am_id_name(am_id));
+
+    ucs_assertv(check_rndv == !!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV),
+                "am message received with unsupported %s protocol",
+                (check_rndv ? "eager" : "rndv"));
+
+    ucs_assertv(header_length == 0, "header_length %zu", header_length);
+
+    ucs_assertv(check_reply_ep ==
+                        !!(param->recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP),
+                "am message received %s reply EP",
+                (check_reply_ep ? "without" : "with"));
+}
+
+static ucp_mem_h
+ucp_perf_daemon_memh_import(ucp_perf_daemon_context_t *ctx, void *packed_memh)
+{
+    ucp_mem_map_params_t params = {};
+    ucs_status_t status;
+    ucp_mem_h memh;
+
+    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_EXPORTED_MEMH_BUFFER;
+    params.exported_memh_buffer = packed_memh;
+
+    status = ucp_mem_map(ctx->context, &params, &memh);
+    if (status != UCS_OK) {
+        ucs_error("failed to import memory (%s)", ucs_status_string(status));
+        return NULL;
+    }
+
+    return memh;
+}
+
+/*
+ * Unpack array length and array contents from a buffer.
+ *
+ * @param [in]  ptr    Pointer to the buffer.
+ * @param [out] length Length of the array.
+ * @param [out] value  Pointer to the array.
+ */
+static void ucp_perf_unpack_array(void **ptr, uint64_t *length, void **value)
+{
+    *length = *ucs_serialize_next(ptr, uint64_t);
+    *value = (length != 0) ? ucs_serialize_next_raw(ptr, void, *length) : NULL;
+}
+
+static ucs_status_t
+ucp_perf_daemon_init_handler(void *arg, const void *header,
+                             size_t header_length, void *data, size_t length,
+                             const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    void *ptr                      = data;
+    void *value;
+    uint64_t value_length;
+    ucs_status_t status;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 1, 0,
+                                 UCP_PERF_DAEMON_AM_ID_INIT);
+
+    /* Peer EP must not be initialized on receiving HOST_INIT message.
+     * Otherwise it means that daemon was already initialized from host. For now
+     * we don't support multiple host processes, or connection reestablishment
+     */
+    if (ctx->peer_ep != NULL) {
+        ucs_error("duplicate daemon init req");
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
+    ctx->host_ep = param->reply_ep;
+
+    ucp_perf_unpack_array(&ptr, &value_length, &value);
+    if (value_length != 0) {
+        status = ucp_perf_daemon_create_peer_ep(ctx, value, value_length);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    ucp_perf_unpack_array(&ptr, &value_length, &value);
+    ctx->send_memh = ucp_perf_daemon_memh_import(ctx, value);
+    ucp_perf_unpack_array(&ptr, &value_length, &value);
+    ctx->recv_memh = ucp_perf_daemon_memh_import(ctx, value);
+
+    ucs_assertv_always(UCS_PTR_BYTE_DIFF(data, ptr) <= length,
+                       "data=%p ptr=%p length=%zu", data, ptr, length);
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_send_handler(void *arg, const void *header,
+                             size_t header_length, void *data, size_t length,
+                             const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    ucp_perf_daemon_req_t *req     = data;
+    ucs_status_t status;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 0, 0,
+                                 UCP_PERF_DAEMON_AM_ID_SEND_REQ);
+    ucs_assertv(length >= sizeof(*req), "length=%lu", length);
+    ucs_assert(ctx->peer_ep != NULL);
+
+    status = ucp_perf_daemon_handle_request(ctx, req);
+    if (ucs_unlikely(UCS_STATUS_IS_ERR(status))) {
+        ucs_error("operation failed: %s", ucs_status_string(status));
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_fin_handler(void *arg, const void *header, size_t header_length,
+                            void *data, size_t length,
+                            const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_check_am_msg(param, header_length, 0, 0,
+                                 UCP_PERF_DAEMON_AM_ID_FIN);
+
+    terminated = 1;
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_peer_init_handler(void *arg, const void *header,
+                                  size_t header_length, void *data,
+                                  size_t length,
+                                  const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 1, 0,
+                                 UCP_PERF_DAEMON_AM_ID_PEER_INIT);
+
+    ctx->peer_ep = param->reply_ep;
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucp_perf_daemon_peer_tx_handler(void *arg, const void *header,
+                                size_t header_length, void *data, size_t length,
+                                const ucp_am_recv_param_t *param)
+{
+    ucp_perf_daemon_context_t *ctx = arg;
+    ucp_request_param_t params;
+    ucs_status_ptr_t sptr;
+
+    ucp_perf_daemon_check_am_msg(param, header_length, 0, 1,
+                                 UCP_PERF_DAEMON_AM_ID_PEER_TX);
+
+    params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                          UCP_OP_ATTR_FIELD_USER_DATA |
+                          UCP_OP_ATTR_FIELD_MEMH |
+                          UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    params.user_data    = ctx;
+    params.cb.recv_am   = ucp_perf_daemon_recv_cb;
+    params.memh         = ctx->recv_memh;
+
+    sptr = ucp_am_recv_data_nbx(ctx->worker, data,
+                                ucp_memh_address(ctx->recv_memh), length,
+                                &params);
+    if (UCS_PTR_IS_ERR(sptr)) {
+        ucs_error("failed to receive data: %s",
+                  ucs_status_string(UCS_PTR_STATUS(sptr)));
+        return UCS_PTR_STATUS(sptr);
+    }
+
+    ucs_assert(UCS_PTR_IS_PTR(sptr));
+    return UCS_INPROGRESS;
 }
 
 static void ucp_perf_daemon_cleanup(ucp_perf_daemon_context_t *ctx)
@@ -115,12 +426,39 @@ static void ucp_perf_daemon_cleanup(ucp_perf_daemon_context_t *ctx)
     ucp_cleanup(ctx->context);
 }
 
+static ucs_status_t
+ucp_perf_daemon_set_am_handlers(ucp_perf_daemon_context_t *ctx)
+{
+    struct {
+        ucp_perf_daemon_am_id_t id;
+        ucp_am_recv_callback_t  cb;
+    } handlers[] = {
+        {UCP_PERF_DAEMON_AM_ID_INIT, ucp_perf_daemon_init_handler},
+        {UCP_PERF_DAEMON_AM_ID_SEND_REQ, ucp_perf_daemon_send_handler},
+        {UCP_PERF_DAEMON_AM_ID_FIN, ucp_perf_daemon_fin_handler},
+        {UCP_PERF_DAEMON_AM_ID_PEER_INIT, ucp_perf_daemon_peer_init_handler},
+        {UCP_PERF_DAEMON_AM_ID_PEER_TX, ucp_perf_daemon_peer_tx_handler},
+    };
+    size_t i;
+    ucs_status_t status;
+
+    for (i = 0; i < ucs_static_array_size(handlers); ++i) {
+        status = ucp_perf_daemon_set_am_recv_handler(ctx, handlers[i].id,
+                                                     handlers[i].cb);
+        if (UCS_OK != status) {
+            return status;
+        }
+    }
+
+    return UCS_OK;
+}
+
 static ucs_status_t ucp_perf_daemon_init(ucp_perf_daemon_context_t *ctx)
 {
     ucp_listener_params_t listen_params = {};
     ucp_worker_params_t worker_params   = {};
+    struct sockaddr_storage listen_addr = {};
     ucp_params_t ucp_params;
-    struct sockaddr_in listen_addr;
     ucp_config_t *config;
     ucs_status_t status;
 
@@ -147,9 +485,14 @@ static ucs_status_t ucp_perf_daemon_init(ucp_perf_daemon_context_t *ctx)
         goto err_free_ctx;
     }
 
-    listen_addr.sin_family      = AF_INET;
-    listen_addr.sin_addr.s_addr = INADDR_ANY;
-    listen_addr.sin_port        = htons(ctx->port);
+    status = ucp_perf_daemon_set_am_handlers(ctx);
+    if (status != UCS_OK) {
+        goto err_free_worker;
+    }
+
+    listen_addr.ss_family = ctx->ai_family;
+    ucs_sockaddr_set_inaddr_any((struct sockaddr*)&listen_addr, ctx->ai_family);
+    ucs_sockaddr_set_port((struct sockaddr*)&listen_addr, ctx->port);
 
     listen_params.field_mask       = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
                                      UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
@@ -197,6 +540,9 @@ static ucs_status_t ucp_perf_daemon_parse_cmd(ucp_perf_daemon_context_t *ctx,
                 return UCS_ERR_INVALID_PARAM;
             }
             break;
+        case '6':
+            ctx->ai_family = AF_INET6;
+            break;
         default:
             return UCS_ERR_INVALID_PARAM;
         }
@@ -214,6 +560,7 @@ static void usage(const ucp_perf_daemon_context_t *ctx, const char *program)
     printf("     -p <port>      TCP port to use for data exchange (%d)\n"
            "                    default value: (%d)\n",
            ctx->port, DEFAULT_DAEMON_PORT);
+    printf("     -6             Use IPv6 address for in data exchange\n");
     printf("\n");
 }
 
@@ -222,7 +569,8 @@ int main(int argc, char *const argv[])
     ucp_perf_daemon_context_t ctx = {};
     struct sigaction new_sigaction;
 
-    ctx.port = DEFAULT_DAEMON_PORT; /* default value */
+    ctx.port      = DEFAULT_DAEMON_PORT; /* default value */
+    ctx.ai_family = AF_INET;
 
     if (ucp_perf_daemon_parse_cmd(&ctx, argc, argv) != UCS_OK) {
         usage(&ctx, ucs_basename(argv[0]));
@@ -238,7 +586,7 @@ int main(int argc, char *const argv[])
     sigaction(SIGTERM, &new_sigaction, NULL);
 
     if (ucp_perf_daemon_init(&ctx) != UCS_OK) {
-        ucs_error("failed to initalize");
+        ucs_error("failed to initialize");
         return EXIT_FAILURE;
     }
 

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -312,6 +312,7 @@ static ucs_status_t verify_daemon_params(ucx_perf_params_t *params)
         return UCS_ERR_UNSUPPORTED;
     }
 
+    params->ucp.is_daemon_mode = 1;
     return UCS_OK;
 }
 

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -242,6 +242,7 @@ void test_perf::test_params_init(const test_spec &test,
     params.ucp.send_datatype    = (ucp_perf_datatype_t)test.data_layout;
     params.ucp.recv_datatype    = (ucp_perf_datatype_t)test.data_layout;
     params.ucp.am_hdr_size      = 0;
+    params.ucp.is_daemon_mode   = 0;
     params.ucp.dmn_local_addr   = {};
     params.ucp.dmn_remote_addr  = {};
 }


### PR DESCRIPTION
## What
Second batch commit for DPU xgvmi daemon
It contains handlers for host-to-peer and peer-to-peer messages no the daemon side.

For reference:
The first batch commit https://github.com/openucx/ucx/pull/9536 is merged.
The original changes: https://github.com/openucx/ucx/pull/8767

## Why ?
The overall goal is to provide initial support for offloading communication to DPU using exported memh feature. We split the original change-set into several parts not exceeding 500 LOC limit, so that it's easier to review.
