### PR TITLE
CONFIG/M4: Disable MAD support to prevent libibmad/libumad dependency leak

### DIFF
--- a/config/m4/mad.m4
+++ b/config/m4/mad.m4
@@ -9,9 +9,9 @@
 #
 AC_ARG_WITH([mad],
             [AS_HELP_STRING([--with-mad=(DIR)],
-                [Enable Infiniband MAD support (default is guess).])],
+                [Enable Infiniband MAD support (default is no).])],
             [],
-            [with_mad=guess])
+            [with_mad=no])
 
 mad_happy=no
 AS_IF([test "x$with_mad" == "xno"],


### PR DESCRIPTION
## What
Fix dependency leak from rpm build machine, when `libibmad-devel` and `libumad-devel` are installed.

## Why ?
RPM users might not have those libs installed. Valid also for non-rpm package builders.

## How ?
Force disable in v1.16, later can be default guess (or rather yes for more predictability), then `dlopen()` at runtime.
