### PR TITLE
TOOLS/PERF: dlopen MAD related libibmad/libibumad

### DIFF
--- a/config/m4/mad.m4
+++ b/config/m4/mad.m4
@@ -1,11 +1,12 @@
 #
-# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2023. ALL RIGHTS RESERVED.
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2024. ALL RIGHTS RESERVED.
 #
 # See file LICENSE for terms.
 #
 
 #
-# Check library support for Infiniband Management Datagrams (MAD)
+# Check library support for Infiniband Management Datagrams (MAD).
+# Libraries are dlopen'ed at runtime.
 #
 AC_ARG_WITH([mad],
             [AS_HELP_STRING([--with-mad=(DIR)],
@@ -22,21 +23,16 @@ AS_IF([test "x$with_mad" == "xno"],
             [
                 AC_MSG_NOTICE([Infiniband MAD Path not specified. Guessing ...])
                 MAD_CFLAGS=""
-                MAD_LDFLAGS=""
             ],
         [x/*],
             [
                 AC_MSG_NOTICE([Infiniband MAD Path is "$with_mad" ...])
                 MAD_CFLAGS="-I$with_mad/include"
-                MAD_LDFLAGS="-L$with_mad/lib -L$with_mad/lib64"
             ],
         [AC_MSG_ERROR([Invalid Infiniband MAD path "$with_mad"])])
 
     save_CFLAGS="$CFLAGS"
-    save_LDFLAGS="$LDFLAGS"
-
     CFLAGS="$CFLAGS $MAD_CFLAGS"
-    LDFLAGS="$LDFLAGS $MAD_LDFLAGS"
 
     mad_happy=yes
 
@@ -44,25 +40,17 @@ AS_IF([test "x$with_mad" == "xno"],
     AC_CHECK_HEADER([infiniband/umad.h],       [:], [mad_happy=no])
     AC_CHECK_HEADER([infiniband/umad_types.h], [:], [mad_happy=no])
 
-    AS_IF([test "x$mad_happy" = "xyes"],
-        [
-            AC_CHECK_LIB([ibmad],  [mad_build_pkt], [:], [mad_happy=no])
-            AC_CHECK_LIB([ibumad], [umad_send],     [:], [mad_happy=no])
-        ])
-
     CFLAGS="$save_CFLAGS"
-    LDFLAGS="$save_LDFLAGS"
 
     AS_IF([test "x$mad_happy" = "xyes"],
         [
             AC_DEFINE([HAVE_MAD], 1, [Enable Infiniband MAD support])
             AC_SUBST([MAD_CFLAGS])
-            AC_SUBST([MAD_LDFLAGS])
-            AC_SUBST([MAD_LIBS], "-libmad -libumad")
+            AC_SUBST([MAD_LIBS], "-ldl")
         ],
         [
             AS_IF([test "x$with_mad" != "xguess"],
-                [AC_MSG_ERROR([Infiniband MAD library or headers not found])],
+                [AC_MSG_ERROR([Infiniband MAD headers not found])],
                 [AC_MSG_WARN([Disabling support for Infiniband MAD])])
         ])
     ]

--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2024. ALL RIGHTS RESERVED.
 # Copyright (C) UT-Battelle, LLC. 2015-2017. ALL RIGHTS RESERVED.
 # Copyright (C) The University of Tennessee and The University
 #               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
@@ -33,7 +33,6 @@ ucx_perftest_CPPFLAGS = $(BASE_CPPFLAGS)
 ucx_perftest_CFLAGS   = $(BASE_CFLAGS) $(OPENMP_CFLAGS) $(MAD_CFLAGS)
 ucx_perftest_LDFLAGS  = \
 	$(LDFLAGS_DYNAMIC_LIST_DATA) \
-	$(MAD_LDFLAGS) \
 	$(MAD_LIBS)
 
 ucx_perftest_LDADD    = \


### PR DESCRIPTION
## What
Build with headers, and dlopen() at runtime.

## Why ?
Not all machines have that libibmad and/or libibumad installed.

## How ?
Use typeof to track function type from header, and keep actual code out of macros.

### Tested
- lid/giud running modes, tested missing lib, tested enabling debug (for extern ibdebug).
- ldd/readelf -a do not show dependency