### PR TITLE
UCS/DATASTRUCT: Fixed FP division by zero.

### DIFF
--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -22,7 +22,7 @@
 /* Format string to display a protocol performance function bandwidth */
 #define UCP_PROTO_PERF_FUNC_BW_FMT "%.2f"
 #define UCP_PROTO_PERF_FUNC_BW_ARG(_perf_func) \
-    (1.0 / ((_perf_func)->m * UCS_MBYTE))
+    ((_perf_func)->m != 0.0) ? (1.0 / ((_perf_func)->m * UCS_MBYTE)) : INFINITY
 
 /* Format string to display a protocol performance function */
 #define UCP_PROTO_PERF_FUNC_FMT(_perf_var) " " #_perf_var ": " \

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -82,7 +82,8 @@ ucp_proto_reconfig_init(const ucp_proto_init_params_t *init_params)
 
     /* Set the performance estimation as worse than any other protocol */
     perf_range->max_length = SIZE_MAX;
-    ucp_proto_perf_set(perf_range->perf, ucs_linear_func_make(INFINITY, 0));
+    ucp_proto_perf_set(perf_range->perf, ucs_linear_func_make(INFINITY,
+                                                              INFINITY));
 
     perf_range->node = ucp_proto_perf_node_new_data("dummy", "");
     return UCS_OK;

--- a/src/ucs/datastruct/linear_func.h
+++ b/src/ucs/datastruct/linear_func.h
@@ -163,6 +163,10 @@ ucs_linear_func_intersect(ucs_linear_func_t func1, ucs_linear_func_t func2,
 {
     double x;
 
+    if (func1.m == func2.m) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     x = (func2.c - func1.c) / (func1.m - func2.m);
     if (isnan(x) || isinf(x)) {
         return UCS_ERR_INVALID_PARAM;


### PR DESCRIPTION
## What
Added checks to avoid division by zero.

## Why ?
To fix https://github.com/openucx/ucx/issues/9631
