### PR TITLE
UCT/CUDA: Don't register memory without active context - v1.16.x

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -214,6 +214,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ai.rapids</groupId>
+      <artifactId>cudf</artifactId>
+      <version>23.10.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -12,6 +12,7 @@ import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 import org.openucx.jucx.ucp.*;
 import org.openucx.jucx.ucs.UcsConstants;
+import ai.rapids.cudf.Cuda;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -118,6 +119,8 @@ public class UcpEndpointTest extends UcxTest {
             .setName("testGetNB").setUcpAddress(worker2.getAddress());
         UcpEndpoint endpoint = worker1.newEndpoint(epParams);
 
+        cudaSetDevice(memType);
+
         // Allocate 2 source and 2 destination buffers, to perform 2 RDMA Read operations
         MemoryBlock src1 = allocateMemory(context2, worker2, memType, UcpMemoryTest.MEM_SIZE);
         MemoryBlock src2 = allocateMemory(context2, worker2, memType, UcpMemoryTest.MEM_SIZE);
@@ -211,6 +214,8 @@ public class UcpEndpointTest extends UcxTest {
         UcpContext context2 = new UcpContext(params);
         UcpWorker worker1 = context1.newWorker(rdmaWorkerParams);
         UcpWorker worker2 = context2.newWorker(rdmaWorkerParams);
+
+        cudaSetDevice(memType);
 
         MemoryBlock src1 = allocateMemory(context1, worker1, memType, UcpMemoryTest.MEM_SIZE);
         MemoryBlock src2 = allocateMemory(context1, worker1, memType, UcpMemoryTest.MEM_SIZE);
@@ -691,6 +696,8 @@ public class UcpEndpointTest extends UcxTest {
 
         header.rewind();
 
+        cudaSetDevice(memType);
+
         MemoryBlock sendData = allocateMemory(context2, worker2, memType, dataSize);
         sendData.setData(dataString);
 
@@ -812,5 +819,12 @@ public class UcpEndpointTest extends UcxTest {
             cachedEp.iterator().next(), sendData, recvData, recvEagerData);
         closeResources();
         cachedEp.clear();
+    }
+
+    private void cudaSetDevice(int memType) {
+        if (memType == UcsConstants.MEMORY_TYPE.UCS_MEMORY_TYPE_CUDA) {
+            Cuda.setDevice(0);
+            Cuda.deviceSynchronize();
+        }
     }
 }

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -158,6 +158,11 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_mem_reg,
     CUresult result;
     ucs_status_t status;
 
+    if (!uct_cuda_base_is_context_active()) {
+        ucs_debug("attempt to register memory without active context");
+        return uct_md_dummy_mem_reg(md, address, length, params, memh_p);
+    }
+
     result = cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                    (CUdeviceptr)(address));
     if ((result == CUDA_SUCCESS) && ((memType == CU_MEMORYTYPE_HOST)    ||


### PR DESCRIPTION
## Why
Fix Cuda host memory registration error (from ucp_mem_map) when there is no active context.
For example, ails with shmem applications, like so:
```
[r-hpc-gpu08:62403:0]    cuda_copy_md.c:173  UCX  ERROR cudaHostRegister() failed: invalid argument
[r-hpc-gpu08:62403:0]          ucp_mm.c:70   UCX  ERROR failed to register address 0xff000000 (host) length 11202985984 on md[3]=cuda_cpy: Input/output error (md supports: host|cuda|cuda-managed)
```

Fixes internal issue [3748762](https://redmine.mellanox.com/issues/3748762)

## Note
The fix is needed only on v1.16.x branch, since on master branch it was already fixed by #8590