### PR TITLE
CI: Remove empty valgrind tests and duplicate function

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -173,22 +173,42 @@ try_load_cuda_env() {
     num_gpus=0
     have_cuda=no
     have_gdrcopy=no
-    if [ -f "/proc/driver/nvidia/version" ]; then
-        have_cuda=yes
-        have_gdrcopy=yes
-        az_module_load dev/cuda12.2.2 || have_cuda=no
-        az_module_load dev/gdrcopy2.3.1-1_cuda12.2.2 || have_gdrcopy=no
-        nvidia-smi -a
-        ls -l /dev/nvidia*
-        num_gpus=$(nvidia-smi -L | wc -l)
-        if [ "$num_gpus" -gt 0 ] && ! [ -f /sys/kernel/mm/memory_peers/nv_mem/version ]
-        then
-            lsmod
-            azure_log_error "GPU direct driver not loaded"
-        fi
+
+    # List relevant modules
+    lsmod | grep -P "^(nvidia|nv_peer_mem|gdrdrv)\W" || true
+
+    # Check nvidia driver
+    [ -f "/proc/driver/nvidia/version" ] || return 0
+
+    # Check peer mem driver
+    [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ] || return 0
+
+    # Check number of available GPUs
+    nvidia-smi -a
+    num_gpus=$(nvidia-smi -L | wc -l)
+    [ "${num_gpus}" -gt 0 ] || return 0
+
+    # Check cuda env module
+    az_module_load dev/cuda12.2.2 || return 0
+    have_cuda=yes
+
+    # Check gdrcopy
+    if [ -w "/dev/gdrdrv" ]
+    then
+        az_module_load dev/gdrcopy2.3.1-1_cuda12.2.2 && have_gdrcopy=yes
+    fi
+
+    # Set CUDA_VISIBLE_DEVICES
+    if [ -n "${worker}" ]
+    then
+        export CUDA_VISIBLE_DEVICES=$((worker % num_gpus))
     fi
 }
 
+load_cuda_env() {
+    try_load_cuda_env
+    [ "${have_cuda}" == "yes" ] || azure_log_error "Cuda device is not available"
+}
 
 check_release_build() {
     build_reason=$1

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -6,7 +6,7 @@ jobs:
   - job: ${{ parameters.name }}
     workspace:
       clean: all
-      
+
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}
@@ -30,7 +30,7 @@ jobs:
           az_init_modules
           az_module_load dev/mvn
           az_module_load dev/jdk-${JAVA_VERSION}
-          try_load_cuda_env
+          load_cuda_env
           ./autogen.sh
           ./contrib/configure-devel --prefix=$(Build.Repository.LocalPath)/install \
             --with-java --enable-gtest=no --with-cuda=$have_cuda
@@ -42,7 +42,7 @@ jobs:
           set -xeE
           source buildlib/az-helpers.sh
           az_init_modules
-          try_load_cuda_env
+          load_cuda_env
           az_module_load dev/mvn
           az_module_load dev/jdk-${JAVA_VERSION}
 

--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -39,7 +39,7 @@ jobs:
         check_gpu ${{ parameters.name }}
         az_init_modules
         az_module_load dev/go-latest
-        try_load_cuda_env
+        load_cuda_env
         ./autogen.sh
         mkdir build
         cd build
@@ -52,7 +52,7 @@ jobs:
         set -xeE
         source buildlib/az-helpers.sh
         az_init_modules
-        try_load_cuda_env
+        load_cuda_env
         az_module_load dev/go-latest
         make -C build/bindings/go test
       displayName: Run go tests
@@ -60,7 +60,7 @@ jobs:
         set -xeE
         source buildlib/az-helpers.sh
         az_init_modules
-        try_load_cuda_env
+        load_cuda_env
         az_module_load dev/go-latest
         go_port=$((30000 + $(AZP_AGENT_ID) * 100))
         args="-p=$go_port"

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -425,15 +425,10 @@ stages:
         container: ubuntu2204
         asan_check: yes
 
+
   - stage: Valgrind
     dependsOn: [Static_check]
     jobs:
-    - template: tests.yml
-      parameters:
-        name: althca
-        demands: ucx_althca -equals yes
-        test_perf: 0
-        valgrind_check: yes
     - template: tests.yml
       parameters:
         name: roce
@@ -446,12 +441,6 @@ stages:
         demands: ucx_roce -equals yes
         test_perf: 0
         proto_enable: no
-        valgrind_check: yes
-    - template: tests.yml
-      parameters:
-        name: BlueField
-        demands: ucx_bf -equals yes
-        test_perf: 0
         valgrind_check: yes
 
 #  - stage: Cuda_compatible

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -137,31 +137,6 @@ module_unload() {
 }
 
 #
-# try load cuda modules if nvidia driver is installed
-#
-try_load_cuda_env() {
-	num_gpus=0
-	have_cuda=no
-	have_gdrcopy=no
-	if [ -f "/proc/driver/nvidia/version" ]; then
-		have_cuda=yes
-		have_gdrcopy=yes
-		module_load $CUDA_MODULE    || have_cuda=no
-		module_load $GDRCOPY_MODULE || have_gdrcopy=no
-		num_gpus=$(nvidia-smi -L | wc -l)
-		export CUDA_VISIBLE_DEVICES=$(($worker%$num_gpus))
-	fi
-}
-
-#
-# Alwasy succeeds
-#
-unload_cuda_env() {
-	module_unload $CUDA_MODULE
-	module_unload $GDRCOPY_MODULE
-}
-
-#
 # Get list IB devices
 #
 get_ib_devices() {

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -24,6 +24,7 @@
 #  - worker   : number of current parallel executor
 #
 
+source $(dirname $0)/../buildlib/az-helpers.sh
 source $(dirname $0)/../buildlib/tools/common.sh
 
 WORKSPACE=${WORKSPACE:=$PWD}
@@ -1082,9 +1083,6 @@ set_ucx_common_test_env() {
 #
 run_tests() {
 	export UCX_PROTO_REQUEST_RESET=y
-
-	# load cuda env only if GPU available for remaining tests
-	try_load_cuda_env
 
 	# all are running mpi tests
 	run_mpi_tests


### PR DESCRIPTION
## Why
* try_load_cuda_env was defined twice, remove the duplication
* valgrind tests do not run on althca or bf machines, so remove the stage