### PR TITLE
AZP/PERF: Change config files path

### DIFF
--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -38,7 +38,7 @@ steps:
       python3 -u perfx.py \
         --before "$SHA_Before" \
         --after "$SHA_After" \
-        --config ucx-rdmz.yml \
+        --config configs/ucx_configs/ucx-rdmz.yml \
         "${perfxParams[@]}" | tee $(WorkDir)/results-${{ parameters.Name }}.txt
       mv $(WorkDir)/PerfX/perfx.log $(WorkDir)/PerfX/${{ parameters.Name }}.log
     displayName: ${{ parameters.Name }}


### PR DESCRIPTION
## What
Change the path to PerfX config file to reflect the recent files structure reorg in PerfX.

## Why ?
UCX Perf pipeline fails.

