### PR TITLE
TEST/APPS: Modify test_fuzzy_match.py and test_ucx_tls.py to use default python version

### DIFF
--- a/test/apps/test_fuzzy_match.py
+++ b/test/apps/test_fuzzy_match.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 #
 # Copyright (C) 2022 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 #
 # Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2017. ALL RIGHTS RESERVED.
 #


### PR DESCRIPTION
## What
Fixed test_fuzzy_match.py and test_ucx_tls.py python version reference.

## Why ?
Default python for RHEL8 is python3.
