### PR TITLE
UCP/CORE: Fixed wiface activation counter.

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -768,6 +768,7 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_ep_config_key_t key;
     uct_ep_h uct_ep;
     ucs_status_t status;
+    ucp_worker_cfg_index_t cfg_index;
 
     ucs_assert(ep_init_flags & UCP_EP_INIT_CM_WIREUP_CLIENT);
     ucs_assert(ucp_worker_num_cm_cmpts(ep->worker) != 0);
@@ -791,11 +792,12 @@ ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
     }
 
     status = ucp_worker_get_ep_config(ep->worker, &key, ep_init_flags,
-                                      &ep->cfg_index);
+                                      &cfg_index);
     if (status != UCS_OK) {
         return status;
     }
 
+    ucp_ep_set_cfg_index(ep, cfg_index);
     ep->am_lane = key.am_lane;
     if (!ucp_ep_has_cm_lane(ep)) {
         ucp_ep_update_flags(ep, UCP_EP_FLAG_CONNECT_REQ_QUEUED, 0);
@@ -1330,21 +1332,22 @@ ucp_ep_set_lanes_failed(ucp_ep_h ep, uct_ep_h *uct_eps, uct_ep_h failed_ep)
 void ucp_ep_unprogress_uct_ep(ucp_ep_h ep, uct_ep_h uct_ep,
                               ucp_rsc_index_t rsc_index)
 {
+    ucp_worker_h worker                 = ep->worker;
+    ucp_context_h context               = worker->context;
+    const ucp_context_config_t *ctx_cfg = &context->config.ext;
     ucp_worker_iface_t *wiface;
 
-    if ((rsc_index == UCP_NULL_RESOURCE) ||
-        !ep->worker->context->config.ext.adaptive_progress ||
+    if ((rsc_index == UCP_NULL_RESOURCE) || !ctx_cfg->adaptive_progress ||
         /* Do not unprogress an already failed lane */
-        ucp_is_uct_ep_failed(uct_ep) ||
-        ucp_wireup_ep_test(uct_ep)) {
+        ucp_is_uct_ep_failed(uct_ep) || ucp_wireup_ep_test(uct_ep) ||
+        ctx_cfg->proto_enable) {
         return;
     }
 
-    wiface = ucp_worker_iface(ep->worker, rsc_index);
-    ucs_debug("ep %p: unprogress iface %p " UCT_TL_RESOURCE_DESC_FMT,
-              ep, wiface->iface,
-              UCT_TL_RESOURCE_DESC_ARG(
-              &(ep->worker->context->tl_rscs[rsc_index].tl_rsc)));
+    wiface = ucp_worker_iface(worker, rsc_index);
+    ucs_debug("ep %p: unprogress iface %p " UCT_TL_RESOURCE_DESC_FMT, ep,
+              wiface->iface,
+              UCT_TL_RESOURCE_DESC_ARG(&(context->tl_rscs[rsc_index].tl_rsc)));
     ucp_worker_iface_unprogress_ep(wiface);
 }
 
@@ -1556,6 +1559,39 @@ void ucp_ep_set_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
     ucp_worker_signal_internal(worker);
 }
 
+static void
+ucp_ep_config_activate_worker_ifaces(ucp_worker_h worker,
+                                     ucp_worker_cfg_index_t cfg_index)
+{
+    ucp_ep_config_t *ep_config = ucp_worker_ep_config(worker, cfg_index);
+
+    ucs_trace("activate wifaces worker %p ep config %u ep count %u", worker,
+              cfg_index, ep_config->ep_count);
+    if (ep_config->ep_count++ == 0) {
+        ucp_wiface_process_for_each_lane(worker, ep_config,
+                                         ep_config->proto_lane_map,
+                                         ucp_worker_iface_progress_ep);
+    }
+}
+
+static void
+ucp_ep_config_deactivate_worker_ifaces(ucp_worker_h worker,
+                                       ucp_worker_cfg_index_t cfg_index)
+{
+    ucp_ep_config_t *ep_config = ucp_worker_ep_config(worker, cfg_index);
+
+    ucs_trace("deactivate wifaces worker %p ep config %u ep count %u", worker,
+              cfg_index, ep_config->ep_count);
+    ucs_assertv(ep_config->ep_count > 0, "worker %p ep config %u", worker,
+                cfg_index);
+
+    if (--ep_config->ep_count == 0) {
+        ucp_wiface_process_for_each_lane(worker, ep_config,
+                                         ep_config->proto_lane_map,
+                                         ucp_worker_iface_unprogress_ep);
+    }
+}
+
 void ucp_ep_cleanup_lanes(ucp_ep_h ep)
 {
     uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
@@ -1578,6 +1614,8 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
         ucp_ep_unprogress_uct_ep(ep, uct_ep, ucp_ep_get_rsc_index(ep, lane));
         uct_ep_destroy(uct_ep);
     }
+
+    ucp_ep_config_deactivate_worker_ifaces(ep->worker, ep->cfg_index);
 }
 
 void ucp_ep_disconnected(ucp_ep_h ep, int force)
@@ -3770,4 +3808,14 @@ ucs_status_t ucp_ep_realloc_lanes(ucp_ep_h ep, unsigned new_num_lanes)
     }
 
     return UCS_OK;
+}
+
+void ucp_ep_set_cfg_index(ucp_ep_h ep, ucp_worker_cfg_index_t cfg_index)
+{
+    if (ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
+        ucp_ep_config_deactivate_worker_ifaces(ep->worker, ep->cfg_index);
+    }
+
+    ep->cfg_index = cfg_index;
+    ucp_ep_config_activate_worker_ifaces(ep->worker, cfg_index);
 }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -473,6 +473,12 @@ struct ucp_ep_config {
 
     /* Bitmap of preregistration for am_bw lanes */
     ucp_md_map_t                  am_bw_prereg_md_map;
+
+    /* Bitmap of lanes selected by the protocols */
+    ucp_lane_map_t                proto_lane_map;
+
+    /* Number of endpoints using this configuration */
+    unsigned                      ep_count;
 };
 
 
@@ -884,5 +890,18 @@ ucs_status_t ucp_ep_query_sockaddr(ucp_ep_h ucp_ep, ucp_ep_attr_t *attr);
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_ep_realloc_lanes(ucp_ep_h ep, unsigned new_num_lanes);
+
+
+/**
+ * @brief Set configuration index to the endpoint.
+ * 
+ * Changing of the configuration index deactivates UCP worker interfaces
+ * corresponding to the previous endpoint configuration and activates interfaces
+ * of the new configurtion.
+ *
+ * @param [in] ep         Endpoint object.
+ * @param [in] cfg_index  Endpoint configuration index.
+ */
+void ucp_ep_set_cfg_index(ucp_ep_h ep, ucp_worker_cfg_index_t cfg_index);
 
 #endif

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -19,8 +19,7 @@
 
 static inline ucp_ep_config_t *ucp_ep_config(ucp_ep_h ep)
 {
-    ucs_assert(ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
-    return &ucs_array_elem(&ep->worker->ep_config, ep->cfg_index);
+    return ucp_worker_ep_config(ep->worker, ep->cfg_index);
 }
 
 static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_fast_lane(ucp_ep_h ep,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -725,14 +725,8 @@ static void ucp_worker_iface_deactivate(ucp_worker_iface_t *wiface, int force)
               worker->num_active_ifaces);
 
     if (!force) {
-        ucs_assertv(worker->context->config.ext.proto_enable ||
-                    (wiface->activate_count > 0), UCP_WIFACE_FMT " acount=%u",
-                    UCP_WIFACE_ARG(wiface), wiface->activate_count);
-
-        if (wiface->activate_count == 0) {
-            /* The interface has not been activated. */
-            return;
-        }
+        ucs_assertv(wiface->activate_count > 0, UCP_WIFACE_FMT,
+                    UCP_WIFACE_ARG(wiface));
 
         if (--wiface->activate_count > 0) {
             /* The interface is not completely deactivated yet. */
@@ -3676,4 +3670,23 @@ static void ucp_am_mpool_obj_str(ucs_mpool_t *mp, void *obj,
 #if ENABLE_DEBUG_DATA
     ucs_string_buffer_appendf(strb, " name:%s", rdesc->name);
 #endif
+}
+
+void
+ucp_wiface_process_for_each_lane(ucp_worker_h worker,
+                                 ucp_ep_config_t *ep_config,
+                                 ucp_lane_map_t lane_map,
+                                 void (*wiface_process)(ucp_worker_iface_t*))
+{
+    ucp_lane_index_t lane;
+    ucp_rsc_index_t rsc_index;
+    ucp_worker_iface_t *wiface;
+
+    ucs_for_each_bit(lane, lane_map) {
+        ucs_assertv(lane < UCP_MAX_LANES,
+                    "lane=%" PRIu8 ", lane_map=0x%" PRIx16, lane, lane_map);
+        rsc_index = ep_config->key.lanes[lane].rsc_index;
+        wiface    = ucp_worker_iface(worker, rsc_index);
+        wiface_process(wiface);
+    }
 }

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -121,10 +121,9 @@ enum {
                                                                of arm_ifaces list, so
                                                                it needs to be armed
                                                                in ucp_worker_arm(). */
-    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2), /**< There is another UCP iface
+    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2)  /**< There is another UCP iface
                                                                with the same caps, but
                                                                with better performance */
-    UCP_WORKER_IFACE_FLAG_KEEP_ACTIVE       = UCS_BIT(3)  /**< Progress should be activated */
 };
 
 
@@ -440,5 +439,20 @@ ucp_worker_flush_ops_count_add(ucp_worker_h worker, int count)
 
     worker->flush_ops_count = flush_ops_count;
 }
+
+
+/**
+ * @brief Process corresponding UCP worker interface for each lane in the map.
+ *
+ * @param [in] worker          Worker object containing interfaces.
+ * @param [in] ep_config       Endpoint configuration containing resources.
+ * @param [in] lane_map        Map of lanes to iterate through.
+ * @param [in] wiface_process  Process method to be invoked for each wiface.
+ */
+void
+ucp_wiface_process_for_each_lane(ucp_worker_h worker,
+                                 ucp_ep_config_t *ep_config,
+                                 ucp_lane_map_t lane_map,
+                                 void (*wiface_process)(ucp_worker_iface_t*));
 
 #endif

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -264,4 +264,15 @@ ucp_worker_default_address_pack_flags(ucp_worker_h worker)
         } \
     }
 
+
+/**
+ * @return endpoint configuration by configuration index
+ */
+static inline ucp_ep_config_t
+*ucp_worker_ep_config(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index)
+{
+    ucs_assert(cfg_index != UCP_WORKER_CFG_INDEX_NULL);
+    return &ucs_array_elem(&worker->ep_config, cfg_index);
+}
+
 #endif

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1017,23 +1017,11 @@ static int ucp_wireup_should_activate_wiface(ucp_worker_iface_t *wiface,
     /* Activate worker iface if: a) new protocol selection logic is disabled; or
      * b) stream support is requested, because stream API does not support new
      * protocol selection logic; or c) lane is used for checking a connection
-     * state; or d) the endpoint is a mem-type ep; or e) iface was activated
-     * before (some ep was created and later destroyed). The last check is
-     * needed to workaround the following problem with proto v2:
-     * 1. ep is created using some ep config
-     * 2. Some protocols are selected for some operations and this enables
-     *    progress for the affected lanes
-     * 3. ep is destroyed and progress is disabled for all corresponding ifaces
-     * 4. New ep is created with the same ep config used during step n1
-     * 5. Progress is not enabled, because protocols selection for these
-     *    parameters (and ep config) was already done on step n2.
-     * TODO: Reconsider this approach when progress enabling scheme changes. */
-
+     * state; or d) the endpoint is a mem-type ep. */
     return !context->config.ext.proto_enable ||
            (context->config.features & UCP_FEATURE_STREAM) ||
            (ucp_ep_config(ep)->key.keepalive_lane == lane) ||
-           (ep->flags & UCP_EP_FLAG_INTERNAL) ||
-           (wiface->flags & UCP_WORKER_IFACE_FLAG_KEEP_ACTIVE);
+           (ep->flags & UCP_EP_FLAG_INTERNAL);
 }
 
 static ucs_status_t
@@ -1619,8 +1607,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         ucs_fatal("endpoint reconfiguration not supported yet");
     }
 
-    ep->cfg_index = new_cfg_index;
-    ep->am_lane   = key.am_lane;
+    ucp_ep_set_cfg_index(ep, new_cfg_index);
+    ep->am_lane = key.am_lane;
 
     snprintf(str, sizeof(str), "ep %p", ep);
     ucp_wireup_print_config(worker, &ucp_ep_config(ep)->key, str,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -454,6 +454,7 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
     ucs_queue_head_t tmp_pending_queue;
     ucs_status_t status;
     ucs_log_level_t fallback_log_level;
+    ucp_worker_cfg_index_t cfg_index;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
@@ -505,11 +506,12 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
         ucp_ep_realloc_lanes(ep, key.num_lanes);
 
         status = ucp_worker_get_ep_config(worker, &key, ep_init_flags,
-                                          &ep->cfg_index);
+                                          &cfg_index);
         if (status != UCS_OK) {
             goto err;
         }
 
+        ucp_ep_set_cfg_index(ep, cfg_index);
         ep->am_lane = key.am_lane;
 
         status = ucp_cm_ep_init_lanes(ep, &tl_bitmap);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -271,16 +271,22 @@ void ucp_wireup_ep_discard_aux_ep(ucp_wireup_ep_t *wireup_ep,
 {
     ucp_ep_h ucp_ep     = wireup_ep->super.ucp_ep;
     uct_ep_h aux_ep     = wireup_ep->aux_ep;
+    ucp_worker_h worker = ucp_ep->worker;
+    ucp_rsc_index_t rsc_index;
 
     if (aux_ep == NULL) {
         return;
     }
 
     ucp_wireup_ep_disown(&wireup_ep->super.super, aux_ep);
-    ucp_worker_discard_uct_ep(ucp_ep, aux_ep, wireup_ep->aux_rsc_index,
-                              ep_flush_flags, purge_cb, purge_arg,
+    rsc_index = wireup_ep->aux_rsc_index;
+    ucp_worker_discard_uct_ep(ucp_ep, aux_ep, rsc_index, ep_flush_flags,
+                              purge_cb, purge_arg,
                               (ucp_send_nbx_callback_t)ucs_empty_function,
                               NULL);
+    if (worker->context->config.ext.proto_enable) {
+        ucp_worker_iface_unprogress_ep(ucp_worker_iface(worker, rsc_index));
+    }
 }
 
 static ucs_status_t ucp_wireup_ep_flush(uct_ep_h uct_ep, unsigned flags,


### PR DESCRIPTION
## What
Added usage counter to ep configuration structure to track the number of endpoints using the configuration.
Reverted https://github.com/openucx/ucx/pull/9104.
Activated UCP worker interfaces when setting endpoint configuration to an endpoint.

## Why ?
The changes are required to properly deactivate worker interface when it is unused.
Currently we may deactivate worker interface even if there are still active endpoints.
