### PR TITLE
UCP/WIREUP: Add rma_bw lanes in smaller chunks for each memtype

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -236,6 +236,10 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "multiple rails. Must be greater than 0.",
    ucs_offsetof(ucp_context_config_t, min_rndv_chunk_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"RMA_BW_LANES_BATCH", UCS_PP_MAKE_STRING(UCP_PROTO_MAX_LANES),
+   "Add RMA bandwidth lanes in batches of this size iteratively over memory types",
+   ucs_offsetof(ucp_context_config_t, rma_bw_lanes_batch), UCS_CONFIG_TYPE_UINT},
+
   {"RMA_ZCOPY_MAX_SEG_SIZE", "auto",
    "Max size of a segment for rma/rndv zcopy.",
    ucs_offsetof(ucp_context_config_t, rma_zcopy_max_seg_size), UCS_CONFIG_TYPE_MEMUNITS},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -110,6 +110,8 @@ typedef struct ucp_context_config {
     unsigned                               max_rndv_lanes;
     /** RMA multi-lane support */
     unsigned                               max_rma_lanes;
+    /** Lane batch size when adding RMA bw lanes iteratively over mem types */
+    unsigned                               rma_bw_lanes_batch;
     /** Minimum allowed chunk size when splitting rndv message over multiple
      *  lanes */
     size_t                                 min_rndv_chunk_size;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1761,11 +1761,11 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
     }
 
     ucp_wireup_dev_usage_count_init(&dev_count);
-    dev_count.excl_lane = am_lane;
-    bw_info.dev_count   = &dev_count;
-    num_am_bw_lanes     = ucp_wireup_add_bw_lanes(select_params, &bw_info,
-                                                  ucp_tl_bitmap_max,
-                                                  select_ctx, 0);
+    dev_count.excl_lane       = am_lane;
+    bw_info.dev_count         = &dev_count;
+    num_am_bw_lanes = ucp_wireup_add_bw_lanes(select_params, &bw_info,
+                                              ucp_tl_bitmap_max,
+                                              select_ctx, 0);
     return ((am_lane != UCP_NULL_LANE) || (num_am_bw_lanes > 0)) ? UCS_OK :
            UCS_ERR_UNREACHABLE;
 }
@@ -1892,7 +1892,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     dev_count = ucs_malloc(UCS_MEMORY_TYPE_LAST * sizeof(*dev_count),
                            "rma_bw_lanes_dev_count");
     if (dev_count == NULL) {
-        ucs_log(UCS_LOG_LEVEL_ERROR, "failed to allocate dev_count");
+        ucs_error("failed to allocate dev_count");
         return UCS_ERR_NO_MEMORY;
     }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1996,9 +1996,9 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         /* Add lanes that can access the memory by short operations */
         added_lanes = 0;
 
-        while (max_lanes > 0) {
+        while (added_lanes < max_lanes) {
             added_lanes_prev  = added_lanes;
-            bw_info.max_lanes = ucs_min(max_lanes, lanes_batch);
+            bw_info.max_lanes = ucs_min(max_lanes - added_lanes, lanes_batch);
             UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
             ucs_memory_type_for_each(mem_type) {
                 UCP_CONTEXT_MEM_CAP_TLS(context, mem_type, reg_mem_types,
@@ -2020,7 +2020,6 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
             if (added_lanes == added_lanes_prev) {
                 break;
             }
-            max_lanes -= bw_info.max_lanes;
         }
 
         if (added_lanes /* There are selected lanes */ ||

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1889,7 +1889,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
          * Allow selecting additional lanes in case the remote memory will not be
          * registered with this memory domain, i.e with GPU memory.
          */
-        memset(&dev_count, 0, sizeof(dev_count));
+        memset(dev_count, 0, sizeof(dev_count));
         bw_info.local_dev_bitmap           = UINT64_MAX;
         bw_info.remote_dev_bitmap          = UINT64_MAX;
         bw_info.criteria.title             = "obtain remote memory pointer";
@@ -1905,7 +1905,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
                                 UCP_NULL_LANE, select_ctx, 0);
     }
 
-    memset(&dev_count, 0, sizeof(dev_count));
+    memset(dev_count, 0, sizeof(dev_count));
     bw_info.local_dev_bitmap          = UINT64_MAX;
     bw_info.remote_dev_bitmap         = UINT64_MAX;
     bw_info.criteria.title            = "high-bw remote memory access";

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1518,7 +1518,8 @@ ucp_wireup_add_fast_lanes(ucp_worker_h worker,
     /* Calculate max BW of existing lanes of the corresponding mem type */
     for (lane_desc = select_ctx->lane_descs;
      lane_desc < select_ctx->lane_descs + select_ctx->num_lanes; ++lane_desc) {
-        if (lane_desc->rsc_index != UCP_NULL_RESOURCE) {
+        if ((lane_desc->rsc_index != UCP_NULL_RESOURCE) &&
+            (lane_desc->lane_types & UCS_BIT(lane_type))) {
             md_index = context->tl_rscs[lane_desc->rsc_index].md_index;
             md_attr  = &context->tl_mds[md_index].attr;
             if (md_attr->reg_mem_types & lane_reg_mem_types) {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1845,7 +1845,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         UCP_RNDV_MODE_GET_ZCOPY,
         UCP_RNDV_MODE_PUT_ZCOPY
     };
-    ucp_wireup_dev_usage_count dev_count[UCS_MEMORY_TYPE_LAST];
+    ucp_wireup_dev_usage_count *dev_count;
     ucp_wireup_select_bw_info_t bw_info;
     ucs_memory_type_t mem_type;
     unsigned max_lanes, lanes_batch;
@@ -1888,6 +1888,13 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     }
 
     bw_info.md_map = 0;
+
+    dev_count = ucs_malloc(UCS_MEMORY_TYPE_LAST * sizeof(*dev_count),
+                           "rma_bw_lanes_dev_count");
+    if (dev_count == NULL) {
+        ucs_log(UCS_LOG_LEVEL_ERROR, "failed to allocate dev_count");
+        return UCS_ERR_NO_MEMORY;
+    }
 
     /* check rkey_ptr */
     if (!(ep_init_flags & UCP_EP_INIT_FLAG_MEM_TYPE) &&
@@ -2030,6 +2037,7 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         }
     }
 
+    ucs_free(dev_count);
     return UCS_OK;
 }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1527,8 +1527,8 @@ ucp_wireup_add_fast_lanes(ucp_worker_h worker,
     const uct_md_attr_v2_t *md_attr;
 
     /* Calculate max BW of existing lanes of the corresponding mem type */
-    for (lane_desc = select_ctx->lane_descs;
-     lane_desc < select_ctx->lane_descs + select_ctx->num_lanes; ++lane_desc) {
+    ucs_carray_for_each(lane_desc, select_ctx->lane_descs,
+                        select_ctx->num_lanes) {
         if ((lane_desc->rsc_index != UCP_NULL_RESOURCE) &&
             (lane_desc->lane_types & UCS_BIT(lane_type))) {
             md_index = context->tl_rscs[lane_desc->rsc_index].md_index;
@@ -1542,7 +1542,7 @@ ucp_wireup_add_fast_lanes(ucp_worker_h worker,
         }
     }
 
-    /* Iterate over all elements and calculate max BW */
+    /* Update max BW based on the BW of new lanes (sinfo elements) */
     ucs_array_for_each(sinfo, sinfo_array) {
         lane_bw = ucp_wireup_get_lane_bw(worker, sinfo->rsc_index,
                                          sinfo->addr_index,


### PR DESCRIPTION
## What
Add rma_bw lanes in smaller chunks for each memtype.

## Why ?
The rma_bw lanes are added for each memtype, starting from host. Thus, the lanes added for host memory can exhaust the limit for the total number of lanes, leading to cuda_ipc lane to be missed. Adding the lanes in smaller chunks iteratively avoids this issue.

## How ?

