### PR TITLE
UCT/CUDA_IPC: Use active-queues to track outstanding work

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -92,6 +92,22 @@ typedef struct uct_cuda_iface {
     int              eventfd;
 } uct_cuda_iface_t;
 
+typedef struct uct_cuda_queue_desc {
+    /* stream on which asynchronous memcpy operations are enqueued */
+    CUstream         stream;
+    /* queue of cuda events */
+    ucs_queue_head_t event_queue;
+    /* needed to allow queue descriptor to be added to iface->active_queue */
+    ucs_queue_elem_t queue;
+} uct_cuda_queue_desc_t;
+
+
+typedef struct uct_cuda_event_desc {
+    CUevent          event;
+    uct_completion_t *comp;
+    ucs_queue_elem_t queue;
+} uct_cuda_event_desc_t;
+
 ucs_status_t
 uct_cuda_base_query_devices_common(
         uct_md_h md, uct_device_type_t dev_type,

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -103,8 +103,8 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src,
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_cuda_copy_iface_t);
     uct_base_iface_t *base_iface = ucs_derived_of(tl_ep->iface, uct_base_iface_t);
-    uct_cuda_copy_event_desc_t *cuda_event;
-    uct_cuda_copy_queue_desc_t *q_desc;
+    uct_cuda_event_desc_t *cuda_event;
+    uct_cuda_queue_desc_t *q_desc;
     ucs_status_t status;
     ucs_memory_type_t src_type;
     ucs_memory_type_t dst_type;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -163,7 +163,7 @@ static ucs_status_t uct_cuda_copy_iface_flush(uct_iface_h tl_iface, unsigned fla
                                               uct_completion_t *comp)
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
-    uct_cuda_copy_queue_desc_t *q_desc;
+    uct_cuda_queue_desc_t *q_desc;
     ucs_queue_iter_t iter;
     ucs_status_t status;
 
@@ -192,14 +192,14 @@ static ucs_status_t uct_cuda_copy_iface_flush(uct_iface_h tl_iface, unsigned fla
 static UCS_F_ALWAYS_INLINE unsigned
 uct_cuda_copy_queue_head_ready(ucs_queue_head_t *queue_head)
 {
-    uct_cuda_copy_event_desc_t *cuda_event;
+    uct_cuda_event_desc_t *cuda_event;
 
     if (ucs_queue_is_empty(queue_head)) {
         return 0;
     }
 
     cuda_event = ucs_queue_head_elem_non_empty(queue_head,
-                                               uct_cuda_copy_event_desc_t,
+                                               uct_cuda_event_desc_t,
                                                queue);
     return (CUDA_SUCCESS == cuEventQuery(cuda_event->event));
 }
@@ -210,7 +210,7 @@ uct_cuda_copy_progress_event_queue(uct_cuda_copy_iface_t *iface,
                                    unsigned max_events)
 {
     unsigned count = 0;
-    uct_cuda_copy_event_desc_t *cuda_event;
+    uct_cuda_event_desc_t *cuda_event;
 
     ucs_queue_for_each_extract(cuda_event, queue_head, queue,
                                cuEventQuery(cuda_event->event) ==
@@ -237,7 +237,7 @@ static unsigned uct_cuda_copy_iface_progress(uct_iface_h tl_iface)
     unsigned max_events = iface->config.max_poll;
     unsigned count      = 0;
     ucs_queue_head_t *event_q;
-    uct_cuda_copy_queue_desc_t *q_desc;
+    uct_cuda_queue_desc_t *q_desc;
     ucs_queue_iter_t iter;
 
     ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
@@ -259,7 +259,7 @@ static ucs_status_t uct_cuda_copy_iface_event_fd_arm(uct_iface_h tl_iface,
     ucs_status_t status;
     CUstream *stream;
     ucs_queue_head_t *event_q;
-    uct_cuda_copy_queue_desc_t *q_desc;
+    uct_cuda_queue_desc_t *q_desc;
     ucs_queue_iter_t iter;
 
     ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
@@ -345,7 +345,7 @@ static uct_iface_ops_t uct_cuda_copy_iface_ops = {
 
 static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
 {
-    uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t *) obj;
+    uct_cuda_event_desc_t *base = (uct_cuda_event_desc_t *) obj;
     ucs_status_t status;
 
     memset(base, 0 , sizeof(*base));
@@ -358,7 +358,7 @@ static void uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chun
 
 static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
-    uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t *) obj;
+    uct_cuda_event_desc_t *base = (uct_cuda_event_desc_t *) obj;
     uct_cuda_copy_iface_t *iface     = ucs_container_of(mp,
                                                         uct_cuda_copy_iface_t,
                                                         cuda_event_desc);
@@ -481,7 +481,7 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
     UCS_BITMAP_CLEAR(&self->streams_to_sync);
 
     ucs_mpool_params_reset(&mp_params);
-    mp_params.elem_size       = sizeof(uct_cuda_copy_event_desc_t);
+    mp_params.elem_size       = sizeof(uct_cuda_event_desc_t);
     mp_params.elems_per_chunk = 128;
     mp_params.max_elems       = self->config.max_cuda_events;
     mp_params.ops             = &uct_cuda_copy_event_desc_mpool_ops;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -39,15 +39,6 @@ typedef uint64_t uct_cuda_copy_iface_addr_t;
 */
 typedef ucs_bitmap_t(UCT_CUDA_MEMORY_TYPES_MAP) uct_cu_stream_bitmap_t;
 
-typedef struct uct_cuda_copy_queue_desc {
-    /* stream on which asynchronous memcpy operations are enqueued */
-    CUstream                    stream;
-    /* queue of cuda events */
-    ucs_queue_head_t            event_queue;
-    /* needed to allow queue descriptor to be added to iface->active_queue */
-    ucs_queue_elem_t            queue;
-} uct_cuda_copy_queue_desc_t;
-
 
 typedef struct uct_cuda_copy_iface {
     uct_cuda_iface_t            super;
@@ -64,7 +55,7 @@ typedef struct uct_cuda_copy_iface {
     /* stream used to issue short operations */
     CUcontext                   cuda_context;
     /* array of queue descriptors for each src/dst memory type combination */
-    uct_cuda_copy_queue_desc_t  queue_desc[UCS_MEMORY_TYPE_LAST][UCS_MEMORY_TYPE_LAST];
+    uct_cuda_queue_desc_t       queue_desc[UCS_MEMORY_TYPE_LAST][UCS_MEMORY_TYPE_LAST];
     /* config parameters to control cuda copy transport */
     struct {
         unsigned                max_poll;
@@ -89,13 +80,6 @@ typedef struct uct_cuda_copy_iface_config {
     unsigned                max_cuda_events;
     double                  bandwidth;
 } uct_cuda_copy_iface_config_t;
-
-
-typedef struct uct_cuda_copy_event_desc {
-    CUevent          event;
-    uct_completion_t *comp;
-    ucs_queue_elem_t queue;
-} uct_cuda_copy_event_desc_t;
 
 
 static UCS_F_ALWAYS_INLINE unsigned

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -63,6 +63,7 @@ int uct_cuda_ipc_ep_is_connected(const uct_ep_h tl_ep,
     return ep->remote_pid == *(pid_t*)params->iface_addr;
 }
 
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
                                   const uct_iov_t *iov, uct_rkey_t rkey,
@@ -73,11 +74,12 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     void *mapped_rem_addr;
     void *mapped_addr;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
-    ucs_queue_head_t *outstanding_queue;
     ucs_status_t status;
     CUdeviceptr dst, src;
-    CUstream stream;
+    CUstream *stream;
     size_t offset;
+    uct_cuda_queue_desc_t *q_desc;
+    ucs_queue_head_t *event_q;
 
     if (0 == iov[0].length) {
         ucs_trace_data("Zero length request: skip it");
@@ -111,8 +113,9 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
 
     key->dev_num %= iface->config.max_streams; /* round-robin */
 
-    stream            = iface->stream_d2d[key->dev_num];
-    outstanding_queue = &iface->outstanding_d2d_event_q;
+    q_desc            = &iface->queue_desc[key->dev_num];
+    event_q           = &q_desc->event_queue;
+    stream            = &iface->queue_desc[key->dev_num].stream;
     cuda_ipc_event    = ucs_mpool_get(&iface->event_desc);
 
     if (ucs_unlikely(cuda_ipc_event == NULL)) {
@@ -126,27 +129,30 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         ((direction == UCT_CUDA_IPC_PUT) ? iov[0].buffer : mapped_rem_addr);
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemcpyDtoDAsync(dst, src, iov[0].length,
-                                                        stream));
+                                                        *stream));
     if (UCS_OK != status) {
         ucs_mpool_put(cuda_ipc_event);
         return status;
     }
-
-    iface->stream_refcount[key->dev_num]++;
-    cuda_ipc_event->stream_id = key->dev_num;
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuEventRecord(cuda_ipc_event->event,
-                                                    stream));
+                                                    *stream));
     if (UCS_OK != status) {
         ucs_mpool_put(cuda_ipc_event);
         return status;
     }
 
-    ucs_queue_push(outstanding_queue, &cuda_ipc_event->queue);
+
+    if (ucs_queue_is_empty(event_q)) {
+        ucs_queue_push(&iface->active_queue, &q_desc->queue);
+    }
+
+    ucs_queue_push(event_q, &cuda_ipc_event->queue);
     cuda_ipc_event->comp        = comp;
     cuda_ipc_event->mapped_addr = mapped_addr;
     cuda_ipc_event->d_bptr      = (uintptr_t)key->d_bptr;
     cuda_ipc_event->pid         = key->pid;
+
     ucs_trace("cuMemcpyDtoDAsync issued :%p dst:%p, src:%p  len:%ld",
              cuda_ipc_event, (void *) dst, (void *) src, iov[0].length);
     return UCS_INPROGRESS;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -22,14 +22,11 @@
 typedef struct uct_cuda_ipc_iface {
     uct_cuda_iface_t super;
     ucs_mpool_t      event_desc;              /* cuda event desc */
-    ucs_queue_head_t outstanding_d2d_event_q; /* stream for outstanding d2d */
     int              eventfd;              /* get event notifications */
     int              streams_initialized;     /* indicates if stream created */
     CUcontext        cuda_context;
-    CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
-                                              /* per-peer stream */
-    unsigned long    stream_refcount[UCT_CUDA_IPC_MAX_PEERS];
-                                              /* per stream outstanding ops */
+    ucs_queue_head_t      active_queue;
+    uct_cuda_queue_desc_t queue_desc[UCT_CUDA_IPC_MAX_PEERS];
     struct {
         unsigned                max_poll;            /* query attempts w.o success */
         unsigned                max_streams;         /* # concurrent streams for || progress*/
@@ -55,7 +52,6 @@ typedef struct uct_cuda_ipc_iface_config {
 typedef struct uct_cuda_ipc_event_desc {
     CUevent           event;
     void              *mapped_addr;
-    unsigned          stream_id;
     uct_completion_t  *comp;
     ucs_queue_elem_t  queue;
     uct_cuda_ipc_ep_t *ep;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_iface.h>
 #include <uct/cuda/base/cuda_iface.h>
+#include <ucs/datastruct/khash.h>
 #include <ucs/arch/cpu.h>
 #include <cuda.h>
 
@@ -16,20 +17,18 @@
 #include "cuda_ipc_cache.h"
 
 
-#define UCT_CUDA_IPC_MAX_PEERS  16
+KHASH_MAP_INIT_INT(cuda_ipc_queue_desc, uct_cuda_queue_desc_t*);
 
 
 typedef struct uct_cuda_ipc_iface {
     uct_cuda_iface_t super;
     ucs_mpool_t      event_desc;              /* cuda event desc */
     int              eventfd;              /* get event notifications */
-    int              streams_initialized;     /* indicates if stream created */
     CUcontext        cuda_context;
     ucs_queue_head_t      active_queue;
-    uct_cuda_queue_desc_t queue_desc[UCT_CUDA_IPC_MAX_PEERS];
+    khash_t(cuda_ipc_queue_desc) queue_desc_map;
     struct {
         unsigned                max_poll;            /* query attempts w.o success */
-        unsigned                max_streams;         /* # concurrent streams for || progress*/
         unsigned                max_cuda_ipc_events; /* max mpool entries */
         int                     enable_cache;        /* enable/disable ipc handle cache */
         ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platorms */
@@ -41,7 +40,6 @@ typedef struct uct_cuda_ipc_iface {
 typedef struct uct_cuda_ipc_iface_config {
     uct_iface_config_t      super;
     unsigned                max_poll;
-    unsigned                max_streams;
     int                     enable_cache;
     ucs_on_off_auto_value_t enable_get_zcopy;
     unsigned                max_cuda_ipc_events;
@@ -61,4 +59,6 @@ typedef struct uct_cuda_ipc_event_desc {
 
 
 ucs_status_t uct_cuda_ipc_iface_init_streams(uct_cuda_ipc_iface_t *iface);
+ucs_status_t uct_cuda_ipc_get_queue_desc(uct_cuda_ipc_iface_t *iface, int index,
+                                         uct_cuda_queue_desc_t **q_desc_p);
 #endif


### PR DESCRIPTION
## What/Why ?
Currently CUDA_IPC transport uses integer stream_count to track outstanding work but in preparation for multi-device support, this PR moves to active_queue usage similar to cuda_copy transport. This will eventually also help unify more common code shared between cuda_ipc and cuda_copy when it comes to stream/event usage. This PR also removes max peer limitations.
