### PR TITLE
UCP/UCT/IB: Don't allocate huge pages by default

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -531,7 +531,7 @@ static ucs_config_field_t ucp_config_table[] = {
    "  [a-z] - matches one character from the range given in the bracket.",
    ucs_offsetof(ucp_config_t, protos), UCS_CONFIG_TYPE_ALLOW_LIST},
 
-  {"ALLOC_PRIO", "md:sysv,md:posix,huge,thp,md:*,mmap,heap",
+  {"ALLOC_PRIO", "md:sysv,md:posix,thp,md:*,mmap,heap",
    "Priority of memory allocation methods. Each item in the list can be either\n"
    "an allocation method (huge, thp, mmap, libc) or md:<NAME> which means to use the\n"
    "specified memory domain for allocation. NAME can be either a UCT component\n"

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -62,7 +62,7 @@ static const char *uct_ib_iface_addr_types[] = {
 };
 
 ucs_config_field_t uct_ib_iface_config_table[] = {
-  {"", "", NULL,
+  {"", "ALLOC=thp,mmap,heap", NULL,
    ucs_offsetof(uct_ib_iface_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
   {"SEG_SIZE", "8192",


### PR DESCRIPTION
## Why
Workaround test failures on `swx-rain02-bf1` with `Ubuntu 22.04.3 LTS`
`MLNX_OFED_LINUX-23.10-0.5.5.0`

## Details
Huge pages are reserved by default:
```
$ cat /proc/meminfo |grep -i hugepage
AnonHugePages:         0 kB
ShmemHugePages:        0 kB
FileHugePages:         0 kB
HugePages_Total:    1024
HugePages_Free:      980
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
```

Test failure is:
```
$ iter env RDMAV_HUGEPAGES_SAFE=1 UCX_LOG_LEVEL_TRIGGER=error ./test/gtest/gtest --gtest_filter=rcx/test_ucp_mmap.alloc_rereg*
...
=========================================
Iteration 10 started at Sun Feb 4 16:00:25 IST 2024
=========================================
env RDMAV_HUGEPAGES_SAFE=1 UCX_LOG_LEVEL_TRIGGER=error ./test/gtest/gtest --gtest_filter=rcx/test_ucp_mmap.alloc_rereg*
[     INFO ] ugni is not available
[     INFO ] ugni,cuda_copy,rocm_copy is not available
[     INFO ] Using random seed of 6266
Note: Google Test filter = rcx/test_ucp_mmap.alloc_rereg*
Note: Randomizing tests' orders with a seed of 29853 .
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from rcx/test_ucp_mmap
[ RUN      ] rcx/test_ucp_mmap.alloc_rereg/0 <rc_x,cuda_copy,rocm_copy>
[       OK ] rcx/test_ucp_mmap.alloc_rereg/0 (611 ms)
[ RUN      ] rcx/test_ucp_mmap.alloc_rereg/1 <rc_x,cuda_copy,rocm_copy/map_nb>
[swx-rain02-bf1:706543:a:706607]       ib_md.c:294  ibv_reg_mr(address=0xffffa4a00000, length=6291456, access=0xf) failed: Invalid argument. Application is using HUGE pages. Please set environment variable RDMAV_HUGEPAGES_SAFE=1
==== backtrace (tid: 706607) ====
 0  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_handle_error+0x2cc) [0xffffae946b9c]
 1  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_fatal_error_message+0xe0) [0xffffae943e50]
 2  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_log_default_handler+0xba8) [0xffffae948bd8]
 3  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_log_dispatch+0xe0) [0xffffae949010]
 4  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(+0x247bc) [0xffffae6247bc]
 5  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(uct_ib_reg_mr+0x4a0) [0xffffae625140]
 6  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(+0x30134) [0xffffae630134]
 7  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(+0x31ef8) [0xffffae631ef8]
 8  /labhome/yosefe/work/ucx/build-aarch64/src/uct/.libs/libuct.so.0(uct_md_mem_reg+0x34) [0xffffae8c4bf4]
 9  /labhome/yosefe/work/ucx/build-aarch64/src/uct/.libs/libuct.so.0(uct_iface_mem_alloc+0x17c) [0xffffae8c5ccc]
10  /labhome/yosefe/work/ucx/build-aarch64/src/uct/.libs/libuct.so.0(uct_iface_mp_chunk_alloc+0x80) [0xffffae8c5dd4]
11  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_mpool_grow+0x80) [0xffffae93a6b4]
12  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_mpool_get_grow+0x1c) [0xffffae93aa4c]
13  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(+0x982b4) [0xffffae6982b4]
14  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(+0x9f020) [0xffffae69f020]
15  /labhome/yosefe/work/ucx/build-aarch64/src/uct/ib/.libs/libuct_ib.so.0(+0x885a8) [0xffffae6885a8]
16  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(+0x1846c) [0xffffae92846c]
17  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(+0x18658) [0xffffae928658]
18  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_async_dispatch_handlers+0x54) [0xffffae929284]
19  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(ucs_async_dispatch_timerq+0x12c) [0xffffae9294cc]
20  /labhome/yosefe/work/ucx/build-aarch64/src/ucs/.libs/libucs.so.0(+0x1da14) [0xffffae92da14]
21  /lib/aarch64-linux-gnu/libc.so.6(+0x7d5c8) [0xffffae13d5c8]
22  /lib/aarch64-linux-gnu/libc.so.6(+0xe5d9c) [0xffffae1a5d9c]
=================================
[swx-rain02-bf1:706543:a:706607] Process frozen, press Enter to attach a debugger...
```
 <br/>

`UCX_IB_FORK_INIT=n` makes the test pass 100 iterations.
Related internal issue: [3768936](https://redmine.mellanox.com/issues/3768936)
