### PR TITLE
UCP/PROTO: Set _FLAG_RESPONSE for rndv/put/zcopy

### DIFF
--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -238,7 +238,8 @@ ucp_proto_rndv_put_common_init(const ucp_proto_init_params_t *init_params,
         .super.send_op       = UCT_EP_OP_PUT_ZCOPY,
         .super.memtype_op    = memtype_op,
         .super.flags         = flags | UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
-                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS,
+                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
+                               UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
         .super.exclude_map   = 0,
         .max_lanes           = context->config.ext.max_rndv_lanes,
         .initial_reg_md_map  = initial_reg_md_map,


### PR DESCRIPTION
## What
Define  UCP_PROTO_COMMON_INIT_FLAG_RESPONSE for `rndv/put/zcopy` protocol

## Why ?
`rndv/get/zcopy` has this flag and if I understand the meaning of this flag correctly, `rndv/put/zcopy` should have it too. The second reason is that absense of this flag in `rndv/put/zcopy` can cause choosing it instead of `rndv/get/zcopy` in case of cheap RTR message since it adds extra overheads during `ucp_proto_common_init_xfer_perf`
