### PR TITLE
CI: Add IB options for Ubuntu 22.04 image

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -47,6 +47,9 @@ resources:
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu2204
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2204_ib
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_IB)
     - container: ubuntu2210
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.10/builder:mofed-5.8-0.2.1.0
@@ -422,7 +425,7 @@ stages:
         name: new
         demands: ucx_new -equals yes
         test_perf: 0
-        container: ubuntu2204
+        container: ubuntu2204_ib
         asan_check: yes
 
   - stage: Valgrind

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -47,7 +47,7 @@ resources:
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu2204
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_IB)
     - container: ubuntu2210
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.10/builder:mofed-5.8-0.2.1.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)


### PR DESCRIPTION
## What
Add docker args for IB testing for Ubuntu 22.04 image initialization

## Why
This image is used for ASAN testing, without these options IB isn't tested.
