### PR TITLE
UCT/IB/DC: dynamic allocation of dci pools by configuration

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -213,6 +213,7 @@ void print_type_info(const char * tl_name)
         PRINT_SIZE(uct_dc_mlx5_ep_t);
         PRINT_SIZE(uct_dc_mlx5_iface_t);
         PRINT_SIZE(uct_dc_mlx5_iface_config_t);
+        PRINT_SIZE(uct_dc_mlx5_dci_pool_t);
         printf("\n");
     }
 #endif

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -24,6 +24,7 @@
 
 
 #define UCT_IB_QPN_ORDER                  24  /* How many bits can be an IB QP number */
+#define UCT_IB_INVALID_QPN                UCS_MASK(UCT_IB_QPN_ORDER)
 #define UCT_IB_UIDX_SHIFT                 8   /* BE uidx shift */
 #define UCT_IB_LRH_LEN                    8   /* IB Local routing header */
 #define UCT_IB_GRH_LEN                    40  /* IB GLobal routing header */

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -146,6 +146,12 @@ ucs_config_field_t uct_dc_mlx5_iface_config_table[] = {
     {NULL}
 };
 
+static uint8_t
+uct_dc_mlx5_max_rd_atomic(const uct_dc_mlx5_iface_addr_t *if_addr)
+{
+    return (if_addr->flags & UCT_DC_MLX5_IFACE_ADDR_MAX_RD_ATOMIC_16) ? 16 : 64;
+}
+
 static ucs_status_t
 uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
 {
@@ -153,11 +159,13 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
                                                 uct_dc_mlx5_iface_t);
     const uct_ib_address_t *ib_addr;
     const uct_dc_mlx5_iface_addr_t *if_addr;
+    uct_dc_mlx5_dci_config_t dci_config;
     ucs_status_t status;
     int is_global;
     uct_ib_mlx5_base_av_t av;
     struct mlx5_grh_av grh_av;
     unsigned path_index;
+    uint8_t max_rd_atomic, if_addr_max_rd_atomic;
 
     ucs_trace_func("");
 
@@ -165,6 +173,12 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
     ib_addr    = (const uct_ib_address_t *)params->dev_addr;
     if_addr    = (const uct_dc_mlx5_iface_addr_t *)params->iface_addr;
     path_index = UCT_EP_PARAMS_GET_PATH_INDEX(params);
+
+    if_addr_max_rd_atomic = uct_dc_mlx5_max_rd_atomic(if_addr);
+    max_rd_atomic         = ucs_min(iface->super.super.config.max_rd_atomic,
+                                    if_addr_max_rd_atomic);
+
+    uct_dc_mlx5_init_dci_config(&dci_config, path_index, max_rd_atomic);
 
     status = uct_ud_mlx5_iface_get_av(&iface->super.super.super,
                                       &iface->ud_common, ib_addr, path_index,
@@ -175,10 +189,10 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
 
     if (is_global) {
         return UCS_CLASS_NEW(uct_dc_mlx5_grh_ep_t, ep_p, iface, if_addr, &av,
-                             path_index, &grh_av);
+                             path_index, &grh_av, &dci_config);
     } else {
         return UCS_CLASS_NEW(uct_dc_mlx5_ep_t, ep_p, iface, if_addr, &av,
-                             path_index);
+                             path_index, &dci_config);
     }
 }
 
@@ -253,6 +267,7 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
     uint8_t dci_index;
     struct mlx5_cqe64 *cqe;
     uint16_t hw_ci;
+    uct_dc_dci_t *dci;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     cqe = uct_ib_mlx5_poll_cq(&iface->super.super.super,
@@ -267,8 +282,10 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
     ucs_memory_cpu_load_fence();
 
     dci_index = uct_dc_mlx5_iface_dci_find(iface, cqe);
-    txqp      = &iface->tx.dcis[dci_index].txqp;
-    txwq      = &iface->tx.dcis[dci_index].txwq;
+    dci       = uct_dc_mlx5_iface_dci(iface, dci_index);
+    ucs_assert_always(uct_dc_mlx5_is_dci_valid(dci));
+    txqp      = &dci->txqp;
+    txwq      = &dci->txwq;
     hw_ci     = ntohs(cqe->wqe_counter);
 
     ucs_trace_poll("dc iface %p tx_cqe: dci[%d] txqp %p hw_ci %d",
@@ -282,8 +299,7 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
      *       to avoid OOO sends when this is the only missing resource.
      */
     uct_dc_mlx5_iface_dci_put(iface, dci_index);
-    uct_dc_mlx5_iface_progress_pending(iface,
-                                       iface->tx.dcis[dci_index].pool_index);
+    uct_dc_mlx5_iface_progress_pending(iface, dci->pool_index);
     uct_dc_mlx5_iface_check_tx(iface);
     uct_ib_mlx5_update_db_cq_ci(&iface->super.cq[UCT_IB_DIR_TX]);
 
@@ -344,18 +360,14 @@ static void uct_ib_mlx5dv_dci_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
     uct_ib_mlx5dv_dc_qp_init_attr(dv_attr, MLX5DV_DCTYPE_DCI);
 }
 
-static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
-                                                 uint8_t pool_index,
-                                                 uint8_t dci_index,
-                                                 uint8_t path_index,
-                                                 int full_handshake)
+ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
+                                          uint8_t dci_index, int connect)
 {
-    uct_ib_iface_t *ib_iface           = &iface->super.super.super;
-    uct_ib_mlx5_qp_attr_t attr         = {};
+    uct_ib_iface_t *ib_iface   = &iface->super.super.super;
+    uct_ib_mlx5_qp_attr_t attr = {};
+    uct_ib_mlx5_md_t *md = ucs_derived_of(ib_iface->super.md, uct_ib_mlx5_md_t);
+    uct_dc_dci_t *dci    = uct_dc_mlx5_iface_dci(iface, dci_index);
     ucs_status_t status;
-    uct_ib_mlx5_md_t *md               = ucs_derived_of(ib_iface->super.md,
-                                                        uct_ib_mlx5_md_t);
-    uct_dc_dci_t *dci                  = &iface->tx.dcis[dci_index];
 #if HAVE_DC_DV
     uct_ib_device_t *dev               = uct_ib_iface_device(ib_iface);
     struct mlx5dv_qp_init_attr dv_attr = {};
@@ -370,7 +382,8 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_DCI) {
         attr.super.max_inl_cqe[UCT_IB_DIR_RX] = 0;
         attr.uidx                        = htonl(dci_index) >> UCT_IB_UIDX_SHIFT;
-        attr.full_handshake              = full_handshake;
+        attr.full_handshake              = iface->flags &
+                                           UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE;
         attr.rdma_wr_disabled            = (iface->flags & UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT) &&
                                            (md->flags & UCT_IB_MLX5_MD_FLAG_NO_RDMA_WR_OPTIMIZED);
         attr.log_num_dci_stream_channels = ucs_ilog2(iface->tx.num_dci_channels);
@@ -434,12 +447,11 @@ init_qp:
         goto err_qp;
     }
 
-    dci->pool_index = pool_index;
-    dci->path_index = path_index;
-
-    status = uct_dc_mlx5_iface_dci_connect(iface, dci);
-    if (status != UCS_OK) {
-        goto err;
+    if (connect) {
+        status = uct_dc_mlx5_iface_dci_connect(iface, dci);
+        if (status != UCS_OK) {
+            goto err;
+        }
     }
 
     if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
@@ -475,19 +487,21 @@ err_put_res_domain:
 }
 
 #if HAVE_DC_DV
-ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                           uct_dc_dci_t *dci)
+ucs_status_t
+uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
                                           uct_ib_mlx5_md_t);
     uct_ib_device_t *dev = uct_ib_iface_device(&iface->super.super.super);
+    uct_dc_mlx5_dci_config_t *config =
+            &iface->tx.dci_pool[dci->pool_index].config;
     struct ibv_qp_attr attr;
     long attr_mask;
     ucs_status_t status;
 
     if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX) {
         return uct_dc_mlx5_iface_devx_dci_connect(iface, &dci->txwq.super,
-                                                  dci->path_index);
+                                                  config);
     }
 
     ucs_assert(dci->txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_VERBS);
@@ -533,7 +547,7 @@ ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
     attr.timeout        = iface->super.super.config.timeout;
     attr.rnr_retry      = iface->super.super.config.rnr_retry;
     attr.retry_cnt      = iface->super.super.config.retry_cnt;
-    attr.max_rd_atomic  = iface->super.super.config.max_rd_atomic;
+    attr.max_rd_atomic  = config->max_rd_atomic;
     attr_mask           = IBV_QP_STATE      |
                           IBV_QP_SQ_PSN     |
                           IBV_QP_TIMEOUT    |
@@ -733,93 +747,159 @@ void uct_dc_mlx5_cleanup_rx(uct_rc_iface_t *rc_iface)
 static void uct_dc_mlx5_iface_dci_pool_destroy(uct_dc_mlx5_dci_pool_t *dci_pool)
 {
     ucs_arbiter_cleanup(&dci_pool->arbiter);
-    ucs_free(dci_pool->stack);
+    ucs_array_cleanup_dynamic(&dci_pool->stack);
 }
 
-static void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface,
-                                           uint8_t num_dci_pools,
-                                           uint8_t num_dcis)
+static void
+uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
                                           uct_ib_mlx5_md_t);
+
+    uct_rc_txqp_cleanup(&iface->super.super, &dci->txqp);
+    uct_ib_mlx5_destroy_qp(md, &dci->txwq.super);
+
+    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+        ucs_arbiter_group_cleanup(&dci->arb_group);
+    }
+    uct_ib_mlx5_qp_mmio_cleanup(&dci->txwq.super, dci->txwq.reg);
+
+    dci->txwq.super.qp_num = UCT_IB_INVALID_QPN;
+}
+
+static void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface)
+{
+    uint8_t num_dcis = ucs_array_length(&iface->tx.dcis);
+    uct_dc_dci_t *dci;
     uint8_t pool_index, dci_index;
 
-    ucs_assert(num_dci_pools <= iface->tx.num_dci_pools);
-    ucs_assert(num_dcis <= uct_dc_mlx5_iface_total_ndci(iface));
-
     for (dci_index = 0; dci_index < num_dcis; dci_index++) {
-        uct_rc_txqp_cleanup(&iface->super.super,
-                            &iface->tx.dcis[dci_index].txqp);
-        uct_ib_mlx5_destroy_qp(md, &iface->tx.dcis[dci_index].txwq.super);
-
-        if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
-            ucs_arbiter_group_cleanup(&iface->tx.dcis[dci_index].arb_group);
+        dci = uct_dc_mlx5_iface_dci(iface, dci_index);
+        if (!uct_dc_mlx5_is_dci_valid(dci)) {
+            continue;
         }
-        uct_ib_mlx5_qp_mmio_cleanup(&iface->tx.dcis[dci_index].txwq.super,
-                                    iface->tx.dcis[dci_index].txwq.reg);
+
+        uct_dc_mlx5_destroy_dci(iface, dci);
     }
 
-    for (pool_index = 0; pool_index < num_dci_pools; pool_index++) {
+    for (pool_index = 0; pool_index < iface->tx.num_dci_pools; pool_index++) {
         uct_dc_mlx5_iface_dci_pool_destroy(&iface->tx.dci_pool[pool_index]);
     }
 
-    ucs_free(iface->tx.dcis);
+    ucs_array_cleanup_dynamic(&iface->tx.dcis);
+}
+
+static void
+uct_dc_mlx5_dump_dci_pool_config(const uct_dc_mlx5_dci_config_t *config)
+{
+    ucs_debug("dci pool config: (path_index=%u, max_rd_atomic=%u)",
+              config->path_index, config->max_rd_atomic);
+}
+
+static void
+uct_dc_mlx5_iface_create_dci_pool(uct_dc_mlx5_iface_t *iface,
+                                  const uct_dc_mlx5_dci_config_t *config,
+                                  uint8_t *pool_index_p)
+{
+    const uint8_t pool_index = iface->tx.num_dci_pools;
+    uint8_t pool_size        = iface->tx.ndci;
+    uct_dc_mlx5_dci_pool_t *dci_pool;
+
+    ucs_assertv_always(iface->tx.num_dci_pools <
+                               UCT_DC_MLX5_IFACE_MAX_DCI_POOLS,
+                       "num_dci_pools=%d, UCT_DC_MLX5_IFACE_MAX_DCI_POOLS=%d",
+                       iface->tx.num_dci_pools,
+                       UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
+    ucs_debug("creating dci pool %u with %u QPs", pool_index, pool_size);
+    uct_dc_mlx5_dump_dci_pool_config(config);
+
+    dci_pool                    = &iface->tx.dci_pool[pool_index];
+    dci_pool->stack_top         = 0;
+    dci_pool->release_stack_top = -1;
+    dci_pool->config            = *config;
+    ucs_arbiter_init(&dci_pool->arbiter);
+    ucs_array_init_dynamic(&dci_pool->stack);
+
+    iface->tx.num_dci_pools++;
+    *pool_index_p = pool_index;
+}
+
+uint32_t uct_dc_mlx5_dci_config_hash(const uct_dc_mlx5_dci_config_t *dci_config)
+{
+    return dci_config->path_index | (dci_config->max_rd_atomic << 8);
+}
+
+ucs_status_t
+uct_dc_mlx5_dci_pool_get_or_create(uct_dc_mlx5_iface_t *iface,
+                                   const uct_dc_mlx5_dci_config_t *dci_config,
+                                   uint8_t *pool_index_p)
+{
+    uint32_t config_hash = uct_dc_mlx5_dci_config_hash(dci_config);
+    khiter_t khit;
+    ucs_kh_put_t kh_put_ret;
+
+    khit = kh_put(uct_dc_mlx5_config_hash, &iface->dc_config_hash, config_hash,
+                  &kh_put_ret);
+    if (kh_put_ret == UCS_KH_PUT_KEY_PRESENT) {
+        *pool_index_p = kh_value(&iface->dc_config_hash, khit);
+        return UCS_OK;
+    }
+
+    if (kh_put_ret == UCS_KH_PUT_FAILED) {
+        ucs_error("failed to kh_put a new dci configuration");
+        return UCS_ERR_EXCEEDS_LIMIT;
+    }
+
+    uct_dc_mlx5_iface_create_dci_pool(iface, dci_config, pool_index_p);
+    kh_value(&iface->dc_config_hash, khit) = *pool_index_p;
+
+    return UCS_OK;
+}
+
+ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
+                                                    uint16_t size)
+{
+    uct_dc_dci_t empty_dci = {{{0}}};
+
+    empty_dci.txwq.super.qp_num = UCT_IB_INVALID_QPN;
+    ucs_array_resize(&iface->tx.dcis, size, empty_dci,
+                     ucs_error("%p: could not resize dcis array to %u", iface,
+                               size);
+                     return UCS_ERR_NO_MEMORY);
+
+    return UCS_OK;
 }
 
 static ucs_status_t
 uct_dc_mlx5_iface_dcis_create(uct_dc_mlx5_iface_t *iface,
                               const uct_dc_mlx5_iface_config_t *config)
 {
-    const uint8_t num_paths = iface->super.super.super.num_paths;
-    uint8_t dci_index       = 0;
-    uct_dc_mlx5_dci_pool_t *dci_pool;
-    uint8_t pool_index, i;
     ucs_status_t status;
+    uct_dc_dci_t *dci;
 
-    iface->tx.dcis = ucs_calloc(uct_dc_mlx5_iface_total_ndci(iface),
-                                sizeof(*iface->tx.dcis), "dcis");
-    if (iface->tx.dcis == NULL) {
-        status = UCS_ERR_NO_MEMORY;
-        goto err;
+    ucs_array_init_dynamic(&iface->tx.dcis);
+    /* Reserving max size as a temporary solution due to pointer-copy issue in ucs_array
+       TODO: fix when ucs_array_t supports complex types 
+    */
+    status = uct_dc_mlx5_iface_resize_and_fill_dcis(
+            iface, UCT_DC_MLX5_IFACE_MAX_DCI_POOLS * iface->tx.ndci);
+    if (status != UCS_OK) {
+        return status;
     }
 
-    for (pool_index = 0; pool_index < iface->tx.num_dci_pools; pool_index++) {
-        ucs_debug("creating dci pool %u with %u QPs", pool_index, iface->tx.ndci);
+    ucs_array_length(&iface->tx.dcis) = 0;
 
-        dci_pool        = &iface->tx.dci_pool[pool_index];
-        dci_pool->stack = ucs_calloc(iface->tx.ndci, sizeof(*dci_pool->stack),
-                                     "dci pool stack");
-        if (dci_pool->stack == NULL) {
-            status = UCS_ERR_NO_MEMORY;
-            goto err_dcis_destroy;
-        }
-
-        ucs_arbiter_init(&dci_pool->arbiter);
-        dci_pool->stack_top         = 0;
-        dci_pool->release_stack_top = -1;
-
-        for (i = 0; i < iface->tx.ndci; ++i) {
-            status = uct_dc_mlx5_iface_create_dci(
-                    iface, pool_index, dci_index, pool_index % num_paths,
-                    iface->flags & UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE);
-            if (status != UCS_OK) {
-                goto err_dci_pool_destroy;
-            }
-
-            dci_pool->stack[i] = dci_index;
-            ++dci_index;
-        }
+    status = uct_dc_mlx5_iface_create_dci(iface, 0, 0);
+    if (status != UCS_OK) {
+        return status;
     }
 
-    iface->tx.bb_max = iface->tx.dcis[0].txwq.bb_max;
+    dci = uct_dc_mlx5_iface_dci(iface, 0);
+
+    iface->tx.bb_max = dci->txwq.bb_max;
+    uct_dc_mlx5_destroy_dci(iface, dci);
+
     return UCS_OK;
-
-err_dci_pool_destroy:
-    uct_dc_mlx5_iface_dci_pool_destroy(dci_pool);
-err_dcis_destroy:
-    uct_dc_mlx5_iface_dcis_destroy(iface, pool_index, dci_index);
-err:
-    return status;
 }
 
 void uct_dc_mlx5_iface_set_quota(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_iface_config_t *config)
@@ -870,7 +950,7 @@ static void uct_dc_mlx5_iface_vfs_refresh(uct_iface_h tl_iface)
         dci_pool = &iface->tx.dci_pool[pool_index];
         ucs_vfs_obj_add_dir(iface, dci_pool, "dci_pool/%d", pool_index);
         for (i = 0; i < iface->tx.ndci; ++i) {
-            dci = &iface->tx.dcis[dci_index];
+            dci = uct_dc_mlx5_iface_dci(iface, dci_index);
             ucs_vfs_obj_add_dir(dci_pool, dci, "%d", dci_index);
             uct_ib_mlx5_txwq_vfs_populate(&dci->txwq, dci);
             uct_rc_txqp_vfs_populate(&dci->txqp, dci);
@@ -958,6 +1038,7 @@ uct_dc_mlx5_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr
 
 static inline ucs_status_t uct_dc_mlx5_iface_flush_dcis(uct_dc_mlx5_iface_t *iface)
 {
+    size_t num_dcis;
     int i;
 
     if (kh_size(&iface->tx.fc_hash) != 0) {
@@ -966,8 +1047,10 @@ static inline ucs_status_t uct_dc_mlx5_iface_flush_dcis(uct_dc_mlx5_iface_t *ifa
         return UCS_INPROGRESS;
     }
 
-    for (i = 0; i < iface->tx.ndci * iface->tx.num_dci_pools; i++) {
-        if (uct_dc_mlx5_iface_flush_dci(iface, i) != UCS_OK) {
+    num_dcis = ucs_array_length(&iface->tx.dcis);
+    for (i = 0; i < num_dcis; i++) {
+        if (uct_dc_mlx5_is_dci_valid(uct_dc_mlx5_iface_dci(iface, i)) &&
+            uct_dc_mlx5_iface_flush_dci(iface, i) != UCS_OK) {
             return UCS_INPROGRESS;
         }
     }
@@ -1001,6 +1084,8 @@ ucs_status_t uct_dc_mlx5_iface_flush(uct_iface_h tl_iface, unsigned flags, uct_c
 
 ucs_status_t uct_dc_mlx5_iface_init_fc_ep(uct_dc_mlx5_iface_t *iface)
 {
+    uint8_t pool_index = 0;
+    uct_dc_mlx5_dci_config_t dci_config;
     ucs_status_t status;
     uct_dc_mlx5_ep_t *ep;
 
@@ -1010,6 +1095,7 @@ ucs_status_t uct_dc_mlx5_iface_init_fc_ep(uct_dc_mlx5_iface_t *iface)
         status =  UCS_ERR_NO_MEMORY;
         goto err;
     }
+
     /* We do not have any peer address at this point, so init basic subclasses
      * only (for statistics, iface, etc) */
     status = UCS_CLASS_INIT(uct_base_ep_t, (void*)(&ep->super),
@@ -1020,8 +1106,17 @@ ucs_status_t uct_dc_mlx5_iface_init_fc_ep(uct_dc_mlx5_iface_t *iface)
         goto err_free;
     }
 
-    ep->flags = 0;
-    status    = uct_dc_mlx5_ep_basic_init(iface, ep);
+    uct_dc_mlx5_init_dci_config(&dci_config, 0,
+                                iface->super.super.config.max_rd_atomic);
+    status = uct_dc_mlx5_dci_pool_get_or_create(iface, &dci_config,
+                                                &pool_index);
+    if (status != UCS_OK) {
+        goto err_cleanup;
+    }
+
+    ep->flags = pool_index & UCT_DC_MLX5_EP_FLAG_POOL_INDEX_MASK;
+
+    status = uct_dc_mlx5_ep_basic_init(iface, ep);
     if (status != UCS_OK) {
         ucs_error("FC ep init failed %s", ucs_status_string(status));
         goto err_cleanup;
@@ -1041,6 +1136,7 @@ err:
 static void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface)
 {
     uct_dc_mlx5_ep_t *fc_ep = iface->tx.fc_ep;
+    uct_dc_dci_t *fc_dci    = uct_dc_mlx5_iface_dci(iface, fc_ep->dci);
     uct_rc_iface_send_op_t *op;
     ucs_queue_iter_t iter;
     uct_rc_txqp_t *txqp;
@@ -1049,8 +1145,13 @@ static void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface)
     ucs_arbiter_group_cleanup(&fc_ep->arb_group);
     uct_rc_fc_cleanup(&fc_ep->fc);
 
+    if ((fc_ep->dci != UCT_DC_MLX5_EP_NO_DCI) &&
+        !uct_dc_mlx5_is_dci_valid(fc_dci)) {
+        goto out;
+    }
+
     if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
-        txqp = &iface->tx.dcis[fc_ep->dci].txqp;
+        txqp = &fc_dci->txqp;
         ucs_queue_for_each_safe(op, iter, &txqp->outstanding, queue) {
             if (op->handler == uct_dc_mlx5_ep_fc_pure_grant_send_completion) {
                 ucs_queue_del_iter(&txqp->outstanding, iter);
@@ -1059,13 +1160,13 @@ static void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface)
         }
     } else if (fc_ep->dci != UCT_DC_MLX5_EP_NO_DCI) {
         /* All outstanding operations on this DCI are FC_PURE_GRANT packets */
-        txqp = &iface->tx.dcis[fc_ep->dci].txqp;
+        txqp = &fc_dci->txqp;
         uct_rc_txqp_purge_outstanding(&iface->super.super, txqp,
                                       /* complete with OK to avoid re-sending */
-                                      UCS_OK,
-                                      iface->tx.dcis[fc_ep->dci].txwq.sw_pi, 0);
+                                      UCS_OK, fc_dci->txwq.sw_pi, 0);
     }
 
+out:
     UCS_CLASS_CLEANUP(uct_base_ep_t, fc_ep);
     ucs_free(fc_ep);
 }
@@ -1235,9 +1336,9 @@ static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
     }
 
     if (ep == NULL) {
-        uct_ib_mlx5_completion_with_err(&iface->super.super.super,
-                                        (uct_ib_mlx5_err_cqe_t*)cqe,
-                                        &iface->tx.dcis[dci_index].txwq, level);
+        uct_ib_mlx5_completion_with_err(
+                &iface->super.super.super, (uct_ib_mlx5_err_cqe_t*)cqe,
+                &uct_dc_mlx5_iface_dci(iface, dci_index)->txwq, level);
         return;
     }
 
@@ -1456,7 +1557,6 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     ucs_status_t status;
     unsigned tx_cq_size;
     unsigned num_dci_channels;
-    int max_dcis;
 
     ucs_trace_func("");
 
@@ -1504,15 +1604,16 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     uct_dc_mlx5_iface_init_version(self, tl_md);
 
-    self->tx.fc_seq                        = 0;
-    self->tx.fc_hard_req_timeout           = config->fc_hard_req_timeout;
-    self->tx.fc_hard_req_resend_time       = ucs_get_time();
-    self->tx.fc_hard_req_progress_cb_id    = UCS_CALLBACKQ_ID_NULL;
-    self->tx.num_dci_pools                 = 1;
-    self->flags                            = 0;
-    self->tx.av_fl_mlid                    = self->super.super.super.path_bits[0] & 0x7f;
+    self->tx.fc_seq                     = 0;
+    self->tx.fc_hard_req_timeout        = config->fc_hard_req_timeout;
+    self->tx.fc_hard_req_resend_time    = ucs_get_time();
+    self->tx.fc_hard_req_progress_cb_id = UCS_CALLBACKQ_ID_NULL;
+    self->tx.num_dci_pools              = 0;
+    self->flags                         = 0;
+    self->tx.av_fl_mlid = self->super.super.super.path_bits[0] & 0x7f;
 
     kh_init_inplace(uct_dc_mlx5_fc_hash, &self->tx.fc_hash);
+    kh_init_inplace(uct_dc_mlx5_config_hash, &self->dc_config_hash);
 
     self->tx.rand_seed = config->rand_seed ? config->rand_seed : time(NULL);
     self->tx.pend_cb   = uct_dc_mlx5_iface_is_dci_shared(self) ?
@@ -1539,19 +1640,11 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     if (ucs_test_all_flags(md->flags, UCT_IB_MLX5_MD_FLAG_DEVX_DCI |
                                       UCT_IB_MLX5_MD_FLAG_CQE_V1)) {
         self->flags           |= UCT_DC_MLX5_IFACE_FLAG_UIDX;
-        self->tx.num_dci_pools = self->super.super.super.num_paths;
     }
 
     if ((params->field_mask & UCT_IFACE_PARAM_FIELD_FEATURES) &&
         !(params->features & UCT_IFACE_FEATURE_PUT)) {
         self->flags |= UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT;
-    }
-
-    max_dcis = ucs_min(INT8_MAX, UINT8_MAX / self->tx.num_dci_pools);
-    if ((self->tx.ndci < 1) || (self->tx.ndci > max_dcis)) {
-        ucs_error("dc interface must have 1..%d dcis (requested: %u)", max_dcis,
-                  self->tx.ndci);
-        return UCS_ERR_INVALID_PARAM;
     }
 
     status = uct_dc_mlx5_iface_init_port_affinity(self, config);
@@ -1594,7 +1687,11 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     }
 
     /* Create fake endpoint which will be used for sending FC grants */
-    uct_dc_mlx5_iface_init_fc_ep(self);
+    status = uct_dc_mlx5_iface_init_fc_ep(self);
+    if (status != UCS_OK) {
+        ucs_error("failed to init fc_ep");
+        goto err_destroy_fc_ep_and_dcis;
+    }
 
     uct_dc_mlx5_iface_set_quota(self, config);
 
@@ -1605,8 +1702,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     return UCS_OK;
 
 err_destroy_fc_ep_and_dcis:
-    uct_dc_mlx5_iface_dcis_destroy(self, self->tx.num_dci_pools,
-                                   uct_dc_mlx5_iface_total_ndci(self));
+    uct_dc_mlx5_iface_dcis_destroy(self);
 err_destroy_dct:
     uct_dc_mlx5_destroy_dct(self);
 err:
@@ -1631,12 +1727,12 @@ static UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_iface_t)
 
     uct_dc_mlx5_destroy_dct(self);
     kh_destroy_inplace(uct_dc_mlx5_fc_hash, &self->tx.fc_hash);
+    kh_destroy_inplace(uct_dc_mlx5_config_hash, &self->dc_config_hash);
     uct_dc_mlx5_iface_cleanup_fc_ep(self);
     ucs_callbackq_remove_oneshot(&worker->progress_q, self,
                                  uct_dc_mlx5_ep_dci_release_remove_filter,
                                  self);
-    uct_dc_mlx5_iface_dcis_destroy(self, self->tx.num_dci_pools,
-                                   uct_dc_mlx5_iface_total_ndci(self));
+    uct_dc_mlx5_iface_dcis_destroy(self);
 }
 
 UCS_CLASS_DEFINE(uct_dc_mlx5_iface_t, uct_rc_mlx5_iface_common_t);
@@ -1671,7 +1767,8 @@ UCT_TL_DEFINE_ENTRY(&uct_ib_component, dc_mlx5, uct_dc_mlx5_query_tl_devices,
 
 void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 {
-    uct_ib_mlx5_txwq_t *txwq = &iface->tx.dcis[dci_index].txwq;
+    uct_dc_dci_t *dci        = uct_dc_mlx5_iface_dci(iface, dci_index);
+    uct_ib_mlx5_txwq_t *txwq = &dci->txwq;
     ucs_status_t status;
 
     ucs_debug("iface %p reset dci[%d] qpn 0x%x", iface, dci_index,
@@ -1693,7 +1790,7 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
                   ucs_status_string(status));
     }
 
-    status = uct_dc_mlx5_iface_dci_connect(iface, &iface->tx.dcis[dci_index]);
+    status = uct_dc_mlx5_iface_dci_connect(iface, dci);
     if (status != UCS_OK) {
         ucs_fatal("iface %p failed to connect dci[%d] qpn 0x%x: %s",
                   iface, dci_index, txwq->super.qp_num,

--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -88,7 +88,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
 
 ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
                                                 uct_ib_mlx5_qp_t *qp,
-                                                uint8_t path_index)
+                                                const uct_dc_mlx5_dci_config_t *dci_config)
 {
     uct_rc_iface_t *rc_iface = &iface->super.super;
     uct_ib_mlx5_md_t *md     = uct_ib_mlx5_iface_md(&rc_iface->super);
@@ -140,8 +140,8 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           rc_iface->super.config.sl);
         if (iface->tx.port_affinity) {
-            uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
-                                                   &opt_param_mask);
+            uct_ib_mlx5_devx_set_qpc_port_affinity(md, dci_config->path_index,
+                                                   qpc, &opt_param_mask);
         }
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl,
@@ -162,7 +162,7 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
     /* cppcheck-suppress internalAstError */
     UCT_IB_MLX5DV_SET(qpc, qpc, log_sra_max,
-                      ucs_ilog2_or0(rc_iface->config.max_rd_atomic));
+                      ucs_ilog2_or0(dci_config->max_rd_atomic));
     UCT_IB_MLX5DV_SET(qpc, qpc, retry_count, rc_iface->config.retry_cnt);
     UCT_IB_MLX5DV_SET(qpc, qpc, rnr_retry, rc_iface->config.rnr_retry);
     UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.ack_timeout,


### PR DESCRIPTION
## What
Instead of creating all dci pools (and dcis) on iface init, dci pools will be created dynamically on demand by configuration

## Why ?
As part of the active messages priority feature - creating different pools with different SLs is required, enabling dedicated dci pools for different lanes with different priorities, as we can't change SL of a dci (qp) after creation / connection.

## How ?
For each new dc ep created - a matching dci pool will be created unless a dci pool with the same exact configuration already exists in the hash table, in which the configuration is the key and the value is pool_index, so eps which share configuration will also share a dci pool.
