### PR TITLE
UCM/PTMALLOC286: added UCS_V_UNUSED attribute to nfences

### DIFF
--- a/src/ucm/ptmalloc286/malloc.c
+++ b/src/ucm/ptmalloc286/malloc.c
@@ -526,6 +526,7 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #endif
 
 #include <ucs/sys/preprocessor.h>
+#include <ucs/sys/compiler_def.h>
 
 /* Version identifier to allow people to support multiple versions */
 #ifndef DLMALLOC_VERSION
@@ -3997,7 +3998,7 @@ static void add_segment(mstate m, char* tbase, size_t tsize, flag_t mmapped) {
   msegmentptr ss = (msegmentptr)(chunk2mem(sp));
   mchunkptr tnext = chunk_plus_offset(sp, ssize);
   mchunkptr p = tnext;
-  int nfences = 0;
+  int UCS_V_UNUSED nfences = 0;
 
   /* reset top to new space */
   init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);


### PR DESCRIPTION
## What
Bugfix for #8898 - added UCS_V_UNUSED attribute to nfences

## Why ?
In non-debug compilation `assert` have empty definition making nfences an unused variable which fails compilation.
