### PR TITLE
UCP/WIREUP: Add capability to separate RMA and AM lanes

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -93,9 +93,22 @@ enum uct_perf_attr_field {
     UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(9),
 
     /** Enable @ref uct_perf_attr_t::max_inflight_eps */
-    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10)
+    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10),
+
+    /** Enable @ref uct_perf_attr_t::flags */
+    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(11)
 };
 
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Flags of supported performance attributes functionalities
+ *
+ * This is used in @ref uct_perf_attr_t::flags.
+ */
+typedef enum {
+    /** TX operations can depend on unrelated RX operation completion */
+    UCT_PERF_ATTR_FLAGS_TX_RX_SHARED = UCS_BIT(0)
+} uct_perf_attr_flags_t;
 
 /**
  * @ingroup UCT_RESOURCE
@@ -187,6 +200,11 @@ typedef struct {
      * This field is set by the UCT layer.
      */
     size_t              max_inflight_eps;
+
+    /**
+     * Performance characteristics of the network interface.
+     */
+    uint64_t            flags;
 } uct_perf_attr_t;
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -548,6 +548,10 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -434,6 +434,10 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -459,6 +459,10 @@ uct_cuda_ipc_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -150,6 +150,10 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1809,6 +1809,10 @@ uct_ib_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -848,6 +848,7 @@ static ucs_status_t uct_dc_mlx5_iface_estimate_perf(uct_iface_h tl_iface,
                                                     uct_perf_attr_t *perf_attr)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
+    uct_ib_iface_t *ib_iface   = &iface->super.super.super;
     ucs_status_t status;
 
     status = uct_ib_iface_estimate_perf(tl_iface, perf_attr);
@@ -857,6 +858,13 @@ static ucs_status_t uct_dc_mlx5_iface_estimate_perf(uct_iface_h tl_iface,
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS) {
         perf_attr->max_inflight_eps = iface->tx.ndci;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        if (uct_ib_iface_port_attr(ib_iface)->active_speed ==
+            UCT_IB_SPEED_NDR) {
+            perf_attr->flags |= UCT_PERF_ATTR_FLAGS_TX_RX_SHARED;
+        }
     }
 
     return UCS_OK;

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -269,6 +269,10 @@ uct_rocm_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -575,6 +575,10 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->max_inflight_eps = SIZE_MAX;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What
Add UCT flag when TX (like AM) depends on RX (like RDMA_READ). Implement AM lane isolation wrt to RMA lane.

## Why ?
To avoid RX throughput dependency that limits overall TX throughput.

## How ?
- Add a TX/RX dependency flag
- Allow skipping AM lane when creating RMA lanes
  - To maintain overall number of lanes, allow overriding dev_num_paths, when a AM lane has been skipped for that reason

### Tested
- Old and new version: each side performs according to its code version
- CX7 sees 1 AM + 2 RMA lanes, CX6 sees 1 lanes AM/RMA

```
ep 0x7f4224a4b000: am_lane 0 wireup_msg_lane <none> cm_lane <none> keepalive_lane <none> reachable_mds 0x7
ep 0x7f4224a4b000: lane[0]:  0:dc_mlx5/mlx5_0:1.0 md[0]      -> addr[0].md[0]/ib/sysdev[1] seg 4294967295 am am_bw#0
ep 0x7f4224a4b000: lane[1]:  4:dc_mlx5/mlx5_2:1.0 md[2]      -> addr[4].md[2]/ib/sysdev[3] seg 4294967295 rma_bw#0
ep 0x7f4224a4b000: lane[2]:  2:dc_mlx5/mlx5_1:1.0 md[1]      -> addr[2].md[1]/ib/sysdev[2] seg 4294967295 rma_bw#1
ep 0x7f4224a4b000: lane[3]:  0:dc_mlx5/mlx5_0:1.1 md[0]      -> addr[0].md[0]/ib/sysdev[1] seg 4294967295 rma_bw#4
ep 0x7f4224a4b000: lane[4]:  4:dc_mlx5/mlx5_2:1.1 md[2]      -> addr[4].md[2]/ib/sysdev[3] seg 4294967295 rma_bw#2
ep 0x7f4224a4b000: lane[5]:  2:dc_mlx5/mlx5_1:1.1 md[1]      -> addr[2].md[1]/ib/sysdev[2] seg 4294967295 rma_bw#3
ep 0x7f4224a4b000: lane[6]:  0:dc_mlx5/mlx5_0:1.2 md[0]      -> addr[0].md[0]/ib/sysdev[1] seg 4294967295 rma_bw#5
   ^---- added lane[6]
```