### PR TITLE
UCT/MM: Replaced error value with debug log message for shm_unlink

### DIFF
--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -516,7 +516,7 @@ uct_posix_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
     /* If using procfs link instead of mmid, remove the original file and update
      * seg->seg_id */
     if (posix_config->use_proc_link) {
-        uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_DEBUG);
+        uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_DIAG);
 
         /* Replace mmid by pid+fd. Keep previous SHM_OPEN flag for mkey_pack() */
         seg->seg_id = uct_posix_mmid_procfs_pack(fd) |
@@ -584,7 +584,7 @@ uct_posix_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
 err_close:
     close(fd);
     if (!(seg->seg_id & UCT_POSIX_SEG_FLAG_PROCFS)) {
-        uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_ERROR);
+        uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_WARN);
     }
 err_free_seg:
     ucs_free(seg);

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -274,7 +274,8 @@ static ucs_status_t uct_posix_procfs_open(int pid, int peer_fd, int* fd_p)
     return uct_posix_open_check_result("open", file_path, 0, ret, fd_p);
 }
 
-static ucs_status_t uct_posix_unlink(uct_mm_md_t *md, uint64_t seg_id)
+static ucs_status_t
+uct_posix_unlink(uct_mm_md_t *md, uint64_t seg_id, ucs_log_level_t err_level)
 {
     uct_posix_md_config_t *posix_config = ucs_derived_of(md->config,
                                                          uct_posix_md_config_t);
@@ -286,7 +287,7 @@ static ucs_status_t uct_posix_unlink(uct_mm_md_t *md, uint64_t seg_id)
                           seg_id & UCT_POSIX_SEG_MMID_MASK);
         ret = shm_unlink(file_path);
         if (ret < 0) {
-            ucs_error("shm_unlink(%s) failed: %m", file_path);
+            ucs_log(err_level, "shm_unlink(%s) failed: %m", file_path);
             return UCS_ERR_SHMEM_SEGMENT;
         }
     } else {
@@ -515,10 +516,7 @@ uct_posix_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
     /* If using procfs link instead of mmid, remove the original file and update
      * seg->seg_id */
     if (posix_config->use_proc_link) {
-        status = uct_posix_unlink(md, seg->seg_id);
-        if (status != UCS_OK) {
-            goto err_close;
-        }
+        uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_DEBUG);
 
         /* Replace mmid by pid+fd. Keep previous SHM_OPEN flag for mkey_pack() */
         seg->seg_id = uct_posix_mmid_procfs_pack(fd) |
@@ -586,7 +584,7 @@ uct_posix_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
 err_close:
     close(fd);
     if (!(seg->seg_id & UCT_POSIX_SEG_FLAG_PROCFS)) {
-        uct_posix_unlink(md, seg->seg_id);
+        uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_ERROR);
     }
 err_free_seg:
     ucs_free(seg);
@@ -612,7 +610,7 @@ static ucs_status_t uct_posix_mem_free(uct_md_h tl_md, uct_mem_h memh)
         ucs_assert(dummy_pid == getpid());
         close(fd);
     } else {
-        status = uct_posix_unlink(md, seg->seg_id);
+        status = uct_posix_unlink(md, seg->seg_id, UCS_LOG_LEVEL_ERROR);
         if (status != UCS_OK) {
             return status;
         }


### PR DESCRIPTION
## What
Display log message instead of returning an error when failing on `uct_posix_unlink` in `uct_posix_mem_alloc`

## Why ?
Prevent UCX init from failing over sporadic "No Such file or directory" error when trying to delete a SHM file.

This PR fix this issue:
https://redmine.mellanox.com/issues/3602767

Also the same error was seen in:
https://redmine.mellanox.com/issues/3730544
