### PR TITLE
UCP/PROTO: Fix unitialized structs

### DIFF
--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -224,6 +224,9 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     ucs_status_t status;
     size_t priv_size;
 
+    memset(0, &init_params, sizeof(init_params));
+    memset(0, &proto_caps, sizeof(proto_caps));
+
     ucs_assert(ep_cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 
     init_params.worker         = worker;

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -224,8 +224,8 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     ucs_status_t status;
     size_t priv_size;
 
-    memset(0, &init_params, sizeof(init_params));
-    memset(0, &proto_caps, sizeof(proto_caps));
+    memset(&init_params, 0, sizeof(init_params));
+    memset(&proto_caps, 0, sizeof(proto_caps));
 
     ucs_assert(ep_cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 


### PR DESCRIPTION
Issue introduced with 4878f49b38 and reproduced when using UCX_LOG_LEVEL=data variable

## What
Initialize structs otherwise its contains is a garbage

## Why ?
Unable obtain real issue data when collecting logs
