### PR TITLE
UCT/ROCM: increase max. no. of agents

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -14,7 +14,7 @@
 #include <sys/utsname.h>
 #include <pthread.h>
 
-#define MAX_AGENTS 63
+#define MAX_AGENTS 127
 static struct agents {
     int num;
     hsa_agent_t agents[MAX_AGENTS];


### PR DESCRIPTION
## What
we need to increase the max. no. of HSA agents to accommodate some of the potential system configurations.
