### PR TITLE
UCP/PROTO: Fix unitialized structs

### DIFF
--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -224,6 +224,9 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     ucs_status_t status;
     size_t priv_size;
 
+    memset(&init_params, 0, sizeof(init_params));
+    memset(&proto_caps, 0, sizeof(proto_caps));
+
     ucs_assert(ep_cfg_index != UCP_WORKER_CFG_INDEX_NULL);
 
     init_params.worker         = worker;


### PR DESCRIPTION
Issue introduced with 4878f49b38 and reproduced when using UCX_LOG_LEVEL=data variable
