### PR TITLE
UCT/IB/BASE: Fix error message for QP create

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1094,7 +1094,7 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
         uct_ib_check_memlock_limit_msg(
                 UCS_LOG_LEVEL_ERROR,
                 "iface=%p: failed to create %s QP "
-                "TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d: %m",
+                "TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d",
                 iface, uct_ib_qp_type_str(attr->qp_type), attr->cap.max_send_wr,
                 attr->cap.max_send_sge, attr->cap.max_inline_data,
                 attr->max_inl_cqe[UCT_IB_DIR_TX], attr->cap.max_recv_wr,


### PR DESCRIPTION
## What

This PR fixes minor issue for printed error trace when `ibv_create_qp()` function failed
 in UCT/IB base code.

## Why ?

When debugging some issue noticed that string representation of `errno` is printed twice:
```
[1707374670.430287] [***:1409 :0]        ib_iface.c:1031 UCX  ERROR   iface=0x55555564cfa0: failed to create RC QP TX wr:256 sge:5 inl:64 resp:64 RX wr:0 sge:1 resp:64: File exists failed: File exists
```

## How ?

Remove extra `%m` passed to `uct_ib_check_memlock_limit_msg()` macro, because it prints an error string taken as `%s` from `strerror()`.