### PR TITLE
AZP/STATIC_CHECKS: Separate shell part of yaml file

### DIFF
--- a/buildlib/pr/static_checks.yml
+++ b/buildlib/pr/static_checks.yml
@@ -12,40 +12,9 @@ jobs:
         fetchDepth: 100
 
       - bash: |
-          set -eEx
-          . buildlib/tools/common.sh
-          prepare_build
-          clang --version
-          gcc --version
-          cppcheck --version
-          ${WORKSPACE}/contrib/configure-release
-
-          report_dir=$(readlink -f $(System.DefaultWorkingDirectory)/static_check)
-          mkdir -p $report_dir
-          echo "##vso[task.setvariable variable=reportExists]True"
-          echo "##vso[task.setvariable variable=report_dir]$report_dir"
-
-          export PATH="`csclng --print-path-to-wrap`:`cscppc --print-path-to-wrap`:`cswrap --print-path-to-wrap`:$PATH"
-          export CSCLNG_ADD_OPTS="-Xanalyzer:-analyzer-output=html:-o:$report_dir"
-          set -o pipefail
-          make -j`nproc` |& tee $report_dir/compile.log
-          set +o pipefail
-
-          cs_errors="cs.err"
-          cslinker --quiet $report_dir/compile.log \
-            | csgrep --mode=json --path ${WORKSPACE} --strip-path-prefix ${WORKSPACE} \
-            | csgrep --mode=json --invert-match --path 'conftest.c' \
-            | csgrep --mode=grep --invert-match --event "internal warning" --prune-events=1 \
-            > $cs_errors
-
-          if [ -s $cs_errors ]; then
-            echo "static checkers found errors:"
-            cat $cs_errors
-            echo "##vso[task.logissue type=error]static checkers found errors"
-            echo "##vso[task.complete result=Failed;]"
-          else
-            echo "No errors reported by static checkers"
-          fi
+          export WORKDIR=$(System.DefaultWorkingDirectory)
+          export WORKSPACE
+          buildlib/tools/static_checks.sh
         displayName: cstools reports
         env:
           BUILD_ID: "$(Build.BuildId)-$(Build.BuildNumber)"

--- a/buildlib/tools/static_checks.sh
+++ b/buildlib/tools/static_checks.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eEx
+
+source buildlib/tools/common.sh
+
+prepare_build
+clang --version
+gcc --version
+cppcheck --version
+${WORKSPACE}/contrib/configure-release
+
+report_dir=$(readlink -f ${WORKDIR}/static_check)
+mkdir -p $report_dir
+echo "##vso[task.setvariable variable=reportExists]True"
+echo "##vso[task.setvariable variable=report_dir]$report_dir"
+
+export PATH="`csclng --print-path-to-wrap`:`cscppc --print-path-to-wrap`:`cswrap --print-path-to-wrap`:$PATH"
+export CSCLNG_ADD_OPTS="-Xanalyzer:-analyzer-output=html:-o:$report_dir"
+set -o pipefail
+make -j`nproc` |& tee $report_dir/compile.log
+set +o pipefail
+
+cs_errors="cs.err"
+cslinker --quiet $report_dir/compile.log \
+    | csgrep --mode=json --path ${WORKSPACE} --strip-path-prefix ${WORKSPACE} \
+    | csgrep --mode=json --invert-match --path 'conftest.c' \
+    | csgrep --mode=grep --invert-match --event "internal warning" --prune-events=1 \
+    > $cs_errors
+
+if [ -s $cs_errors ]; then
+    echo "static checkers found errors:"
+    cat $cs_errors
+    echo "##vso[task.logissue type=error]static checkers found errors"
+    echo "##vso[task.complete result=Failed;]"
+else
+    echo "No errors reported by static checkers"
+fi
+


### PR DESCRIPTION
## What
Move bash part of yaml file in its own shell script.

## Why ?
Easier to run on local machine to repro various failures.

## How ?
Add new shell script. Use with or without same docker image.

```
docker run -it --rm -v $(pwd):/mnt rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:1 /bin/bash
WORKDIR=$(pwd) EXECUTOR_NUMBER=0 BUILD_ID=0 ./buildlib/tools/static_checks.sh
```