### PR TITLE
UCT/IB/DC: bugfix - dci_pool_index have only 3 bits in ep->flags (it's max value is 15)

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -1580,6 +1580,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dct, DCT, status, err);
 
     ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
+    UCS_STATIC_ASSERT((UCT_DC_MLX5_IFACE_MAX_DCI_POOLS - 1) <=
+                      UCT_DC_MLX5_EP_FLAG_POOL_INDEX_MASK);
 
     /* create DC target */
     status = uct_dc_mlx5_iface_create_dct(self, config);

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -27,35 +27,35 @@
 
 enum uct_dc_mlx5_ep_flags {
     /* DCI pool EP assigned to according to it's lag port */
-    UCT_DC_MLX5_EP_FLAG_POOL_INDEX_MASK     = UCS_MASK(3),
+    UCT_DC_MLX5_EP_FLAG_POOL_INDEX_MASK     = UCS_MASK(5),
 
     /* EP is in the tx_wait state. See description of the dcs+quota dci
        selection policy above */
-    UCT_DC_MLX5_EP_FLAG_TX_WAIT             = UCS_BIT(3),
+    UCT_DC_MLX5_EP_FLAG_TX_WAIT             = UCS_BIT(5),
 
     /* EP has GRH address. Used by dc_mlx5 endpoint */
-    UCT_DC_MLX5_EP_FLAG_GRH                 = UCS_BIT(4),
+    UCT_DC_MLX5_EP_FLAG_GRH                 = UCS_BIT(6),
 
     /* Keepalive Request scheduled: indicates that keepalive request
      * is scheduled in outstanding queue and no more keepalive actions
      * are needed */
-    UCT_DC_MLX5_EP_FLAG_KEEPALIVE_POSTED    = UCS_BIT(5),
+    UCT_DC_MLX5_EP_FLAG_KEEPALIVE_POSTED    = UCS_BIT(7),
 
     /* Flush cancel was executed on EP */
-    UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL        = UCS_BIT(6),
+    UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL        = UCS_BIT(8),
 
     /* Error handler already called or flush(CANCEL) disabled it */
-    UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED = UCS_BIT(7),
+    UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED = UCS_BIT(9),
 
     /* EP supports flush remote operation */
-    UCT_DC_MLX5_EP_FLAG_FLUSH_RKEY          = UCS_BIT(8),
+    UCT_DC_MLX5_EP_FLAG_FLUSH_RKEY          = UCS_BIT(10),
 
     /* Flush remote operation should be invoked */
-    UCT_DC_MLX5_EP_FLAG_FLUSH_REMOTE        = UCS_BIT(9),
+    UCT_DC_MLX5_EP_FLAG_FLUSH_REMOTE        = UCS_BIT(11),
 
 #if UCS_ENABLE_ASSERT
     /* EP was invalidated without DCI */
-    UCT_DC_MLX5_EP_FLAG_INVALIDATED         = UCS_BIT(10)
+    UCT_DC_MLX5_EP_FLAG_INVALIDATED         = UCS_BIT(12)
 #else
     UCT_DC_MLX5_EP_FLAG_INVALIDATED         = 0
 #endif

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1258,8 +1258,8 @@ uct_test::entity::connect_to_sockaddr(unsigned index,
     m_eps[index].reset(ep, uct_ep_destroy);
 }
 
-void uct_test::entity::connect_to_ep(unsigned index, entity& other,
-                                     unsigned other_index)
+void uct_test::entity::connect_to_ep(unsigned index, entity &other,
+                                     unsigned other_index, unsigned path_index)
 {
     ucs_status_t status;
     uct_ep_h ep, remote_ep;
@@ -1271,8 +1271,10 @@ void uct_test::entity::connect_to_ep(unsigned index, entity& other,
     }
 
     other.reserve_ep(other_index);
-    ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE;
+    ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
+                           UCT_EP_PARAM_FIELD_PATH_INDEX;
     ep_params.iface      = other.m_iface;
+    ep_params.path_index = path_index;
     status               = uct_ep_create(&ep_params, &remote_ep);
     ASSERT_UCS_OK(status);
     other.m_eps[other_index].reset(remote_ep, uct_ep_destroy);
@@ -1291,7 +1293,9 @@ void uct_test::entity::connect_to_ep(unsigned index, entity& other,
     }
 }
 
-void uct_test::entity::connect_to_iface(unsigned index, entity& other) {
+void uct_test::entity::connect_to_iface(unsigned index, entity &other,
+                                        unsigned path_index)
+{
     uct_device_addr_t *dev_addr;
     uct_iface_addr_t *iface_addr;
     uct_ep_params_t ep_params;
@@ -1312,12 +1316,14 @@ void uct_test::entity::connect_to_iface(unsigned index, entity& other) {
     status = uct_iface_get_address(other.iface(), iface_addr);
     ASSERT_UCS_OK(status);
 
-    ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE    |
+    ep_params.field_mask = UCT_EP_PARAM_FIELD_IFACE |
                            UCT_EP_PARAM_FIELD_DEV_ADDR |
-                           UCT_EP_PARAM_FIELD_IFACE_ADDR;
+                           UCT_EP_PARAM_FIELD_IFACE_ADDR |
+                           UCT_EP_PARAM_FIELD_PATH_INDEX;
     ep_params.iface      = iface();
     ep_params.dev_addr   = dev_addr;
     ep_params.iface_addr = iface_addr;
+    ep_params.path_index = path_index;
 
     status = uct_ep_create(&ep_params, &ep);
     ASSERT_UCS_OK(status);

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -189,9 +189,10 @@ protected:
         void revoke_ep(unsigned index);
         void destroy_eps();
         void connect(unsigned index, entity& other, unsigned other_index);
-        void connect_to_iface(unsigned index, entity& other);
-        void connect_to_ep(unsigned index, entity& other,
-                           unsigned other_index);
+        void connect_to_iface(unsigned index, entity &other,
+                              unsigned path_index = 0);
+        void connect_to_ep(unsigned index, entity &other, unsigned other_index,
+                           unsigned path_index = 0);
         void connect_to_sockaddr(unsigned index,
                                  const ucs::sock_addr_storage &remote_addr,
                                  const ucs::sock_addr_storage *local_addr,


### PR DESCRIPTION
## What
Adding dci_pool_index attribute to `uct_dc_mlx5_ep_t` instead of using the first 3 bits of `ep->flags`.

## Why ?
`UCT_DC_MLX5_IFACE_MAX_DCI_POOLS` is defined to be 16, meaning 3 bits aren't enough, this patch fixes the issue by adding a separate field for dci_pool_index.