### PR TITLE
UCT/IB/MLX5: Prevent compiler to use memmove

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -508,8 +508,15 @@ static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
     UCS_WORD_COPY(__m128i, dst, __m128i, src, MLX5_SEND_WQE_BB);
 #elif defined(__ARM_NEON)
     vst4q_u64(dst, vld4q_u64(src));
-#else /* NO SIMD support */
-    UCS_WORD_COPY(uint64_t, dst, uint64_t, src, MLX5_SEND_WQE_BB);
+#else
+    typedef struct {
+        uint8_t data[MLX5_SEND_WQE_BB];
+    } UCS_S_PACKED uct_ib_mlx5_send_wqe_bb_t;
+
+    /* Prevent the compiler to replace by memmove() */
+    UCS_WORD_COPY(uct_ib_mlx5_send_wqe_bb_t, dst,
+                  uct_ib_mlx5_send_wqe_bb_t, src,
+                  MLX5_SEND_WQE_BB);
 #endif
 }
 


### PR DESCRIPTION
## What
Help compiler to optimize without introducting any function call, using instead `movl`, `movq` or `xmm` registers, depending on the optimization level selected.
## Why ?
With `-O2` only, the compiler replaces `UCS_WORD_COPY(uint64_t, dst, uint64_t, src, MLX5_SEND_WQE_BB);` by `memmove()`. This is causing crash below:
```
ib_mlx5_log.c:179  Local length error on mlx5_0:1/IB (synd 0x1 vend 0x68 hw_synd 0/141)
ib_mlx5_log.c:179  UD QP 0x15a6 wqe[18856]: SEND --- [rqpn 0x15a7 rlid 5] [inl len 24] [va 0x7f2e11f79fe0 len 4072 lkey 0x203400]
```

It is not entirely clear why, but this could be related to introduced out-of-order/block copy, added prefetch intel instruction...

Internal: [3774158](https://redmine.mellanox.com/issues/3774158)

## How ?
Adding compiler fence inside `UCS_WORD_COPY()` disables usage of `xmm` registers at `-O3` so it is not an option.
### Repro
- AMD EPYC 9654 96-Core Processor
- gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)
- GNU C Library (Ubuntu GLIBC 2.35-0ubuntu3.6) stable release version 2.35.
- IB Firmware version: 20.39.1002
