### PR TITLE
UCP/PROTO: Move non-rndv protocols to use probe() instead of init()

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -15,8 +15,8 @@
 #include <ucp/proto/proto_multi.inl>
 
 
-static ucs_status_t
-ucp_am_eager_multi_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_multi_bcopy_proto_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -47,11 +47,10 @@ ucp_am_eager_multi_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
 
     if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, params.super.super.priv,
-                                params.super.super.priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -167,15 +166,15 @@ ucp_proto_t ucp_am_eager_multi_bcopy_proto = {
     .name     = "am/egr/multi/bcopy",
     .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
-    .init     = ucp_am_eager_multi_bcopy_proto_init,
+    .probe    = ucp_am_eager_multi_bcopy_proto_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_bcopy_proto_progress},
     .abort    = ucp_proto_am_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
 };
 
-static ucs_status_t
-ucp_am_eager_multi_zcopy_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_multi_zcopy_proto_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -208,11 +207,10 @@ ucp_am_eager_multi_zcopy_proto_init(const ucp_proto_init_params_t *init_params)
 
     if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, params.super.super.priv,
-                                params.super.super.priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 static UCS_F_ALWAYS_INLINE size_t ucp_am_eager_multi_zcopy_add_payload(
@@ -303,7 +301,7 @@ ucp_proto_t ucp_am_eager_multi_zcopy_proto = {
     .name     = "am/egr/multi/zcopy",
     .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_am_eager_multi_zcopy_proto_init,
+    .probe    = ucp_am_eager_multi_zcopy_proto_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_am_eager_multi_zcopy_proto_progress},
     .abort    = ucp_proto_am_request_zcopy_abort,

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -87,9 +87,9 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
     return UCS_OK;
 }
 
-static ucs_status_t
-ucp_am_eager_short_proto_init_common(const ucp_proto_init_params_t *init_params,
-                                     ucp_operation_id_t op_id)
+static void
+ucp_am_eager_short_probe_common(const ucp_proto_init_params_t *init_params,
+                                ucp_operation_id_t op_id)
 {
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     ucp_proto_single_init_params_t params        = {
@@ -118,16 +118,15 @@ ucp_am_eager_short_proto_init_common(const ucp_proto_init_params_t *init_params,
     if (!ucp_am_check_init_params(init_params, UCS_BIT(op_id),
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV) ||
         !ucp_proto_is_short_supported(select_param)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
-static ucs_status_t
-ucp_am_eager_short_proto_init(const ucp_proto_init_params_t *init_params)
+static void ucp_am_eager_short_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_am_eager_short_proto_init_common(init_params, UCP_OP_ID_AM_SEND);
+    ucp_am_eager_short_probe_common(init_params, UCP_OP_ID_AM_SEND);
 }
 
 static ucs_status_t ucp_am_eager_short_proto_progress(uct_pending_req_t *self)
@@ -139,18 +138,17 @@ ucp_proto_t ucp_am_eager_short_proto = {
     .name     = "am/egr/short",
     .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_AM_SHORT,
-    .init     = ucp_am_eager_short_proto_init,
+    .probe    = ucp_am_eager_short_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_proto_progress},
     .abort    = ucp_proto_am_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
 };
 
-static ucs_status_t
-ucp_am_eager_short_reply_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_short_reply_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_am_eager_short_proto_init_common(init_params,
-                                                UCP_OP_ID_AM_SEND_REPLY);
+    ucp_am_eager_short_probe_common(init_params, UCP_OP_ID_AM_SEND_REPLY);
 }
 
 static ucs_status_t
@@ -163,7 +161,7 @@ ucp_proto_t ucp_am_eager_short_reply_proto = {
     .name     = "am/egr/short/reply",
     .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_AM_SHORT,
-    .init     = ucp_am_eager_short_reply_proto_init,
+    .probe    = ucp_am_eager_short_reply_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_short_reply_proto_progress},
     .abort    = ucp_proto_am_request_bcopy_abort,
@@ -219,7 +217,7 @@ ucp_am_eager_single_bcopy_proto_progress(uct_pending_req_t *self)
     return ucp_proto_am_handle_user_header_send_status(req, status);
 }
 
-static ucs_status_t ucp_am_eager_single_bcopy_proto_init_common(
+static void ucp_am_eager_single_bcopy_probe_common(
         const ucp_proto_init_params_t *init_params, ucp_operation_id_t op_id)
 {
     ucp_context_t *context                = init_params->worker->context;
@@ -248,35 +246,34 @@ static ucs_status_t ucp_am_eager_single_bcopy_proto_init_common(
 
     if (!ucp_am_check_init_params(init_params, UCS_BIT(op_id),
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
-static ucs_status_t
-ucp_am_eager_single_bcopy_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_single_bcopy_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_am_eager_single_bcopy_proto_init_common(init_params,
-                                                       UCP_OP_ID_AM_SEND);
+    ucp_am_eager_single_bcopy_probe_common(init_params, UCP_OP_ID_AM_SEND);
 }
 
 ucp_proto_t ucp_am_eager_single_bcopy_proto = {
     .name     = "am/egr/single/bcopy",
     .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
-    .init     = ucp_am_eager_single_bcopy_proto_init,
+    .probe    = ucp_am_eager_single_bcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_proto_progress},
     .abort    = ucp_proto_am_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
 };
 
-static ucs_status_t ucp_am_eager_single_bcopy_reply_proto_init(
-        const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_single_bcopy_reply_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_am_eager_single_bcopy_proto_init_common(init_params,
-                                                       UCP_OP_ID_AM_SEND_REPLY);
+    ucp_am_eager_single_bcopy_probe_common(init_params,
+                                           UCP_OP_ID_AM_SEND_REPLY);
 }
 
 static size_t ucp_am_eager_single_bcopy_reply_pack(void *dest, void *arg)
@@ -302,14 +299,14 @@ ucp_proto_t ucp_am_eager_single_bcopy_reply_proto = {
     .name     = "am/egr/single/bcopy/reply",
     .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
-    .init     = ucp_am_eager_single_bcopy_reply_proto_init,
+    .probe    = ucp_am_eager_single_bcopy_reply_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_bcopy_reply_proto_progress},
     .abort    = ucp_proto_am_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
 };
 
-static ucs_status_t ucp_am_eager_single_zcopy_proto_init_common(
+static void ucp_am_eager_single_zcopy_probe_common(
         const ucp_proto_init_params_t *init_params, ucp_operation_id_t op_id)
 {
     ucp_context_t *context                = init_params->worker->context;
@@ -340,17 +337,16 @@ static ucs_status_t ucp_am_eager_single_zcopy_proto_init_common(
     if (!ucp_am_check_init_params(init_params, UCS_BIT(op_id),
                                   UCP_PROTO_SELECT_OP_FLAG_AM_RNDV) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
-static ucs_status_t
-ucp_am_eager_single_zcopy_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_single_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_am_eager_single_zcopy_proto_init_common(init_params,
-                                                       UCP_OP_ID_AM_SEND);
+    ucp_am_eager_single_zcopy_probe_common(init_params, UCP_OP_ID_AM_SEND);
 }
 
 static ucs_status_t
@@ -402,18 +398,18 @@ ucp_proto_t ucp_am_eager_single_zcopy_proto = {
     .name     = "am/egr/single/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_am_eager_single_zcopy_proto_init,
+    .probe    = ucp_am_eager_single_zcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_proto_progress},
     .abort    = ucp_proto_am_request_zcopy_abort,
     .reset    = ucp_am_proto_request_zcopy_reset
 };
 
-static ucs_status_t ucp_am_eager_single_zcopy_reply_proto_init(
-        const ucp_proto_init_params_t *init_params)
+static void
+ucp_am_eager_single_zcopy_reply_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_am_eager_single_zcopy_proto_init_common(init_params,
-                                                       UCP_OP_ID_AM_SEND_REPLY);
+    ucp_am_eager_single_zcopy_probe_common(init_params,
+                                           UCP_OP_ID_AM_SEND_REPLY);
 }
 
 static ucs_status_t
@@ -458,7 +454,7 @@ ucp_proto_t ucp_am_eager_single_zcopy_reply_proto = {
     .name     = "am/egr/single/zcopy/reply",
     .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_am_eager_single_zcopy_reply_proto_init,
+    .probe    = ucp_am_eager_single_zcopy_reply_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_am_eager_single_zcopy_reply_proto_progress},
     .abort    = ucp_proto_am_request_zcopy_abort,

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -647,6 +647,15 @@ ucp_proto_common_find_am_bcopy_hdr_lane(const ucp_proto_init_params_t *params)
     return lane;
 }
 
+void ucp_proto_common_add_proto(const ucp_proto_common_init_params_t *params,
+                                const ucp_proto_caps_t *proto_caps,
+                                const void *priv, size_t priv_size)
+{
+    ucp_proto_select_add_proto(&params->super, params->cfg_thresh,
+                               params->cfg_priority, proto_caps, priv,
+                               priv_size);
+}
+
 void ucp_proto_request_zcopy_completion(uct_completion_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t,

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -259,6 +259,11 @@ ucp_lane_index_t
 ucp_proto_common_find_am_bcopy_hdr_lane(const ucp_proto_init_params_t *params);
 
 
+void ucp_proto_common_add_proto(const ucp_proto_common_init_params_t *params,
+                                const ucp_proto_caps_t *proto_caps,
+                                const void *priv, size_t priv_size);
+
+
 void ucp_proto_request_zcopy_completion(uct_completion_t *self);
 
 

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -60,7 +60,7 @@ void ucp_proto_select_perf_str(const ucs_linear_func_t *perf, char *time_str,
 
 
 void ucp_proto_select_init_trace_caps(
-        ucp_proto_id_t proto_id, const ucp_proto_init_params_t *init_params);
+        const ucp_proto_init_params_t *init_params);
 
 
 void ucp_proto_select_info(ucp_worker_h worker,

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -31,13 +31,14 @@ UCS_ARRAY_DECLARE_TYPE(ucp_proto_perf_ranges_t, unsigned,
  * Add a "pipelined performance" range, which represents the send time of
  * multiples fragments. 'frag_range' is the time to send a single fragment.
  */
-void ucp_proto_common_add_ppln_range(const ucp_proto_init_params_t *init_params,
+void ucp_proto_common_add_ppln_range(ucp_proto_caps_t *caps,
                                      const ucp_proto_perf_range_t *frag_range,
                                      size_t max_length);
 
 
 void ucp_proto_common_init_base_caps(
-        const ucp_proto_common_init_params_t *params, size_t min_length);
+        const ucp_proto_common_init_params_t *params, ucp_proto_caps_t *caps,
+        size_t min_length);
 
 
 void ucp_proto_perf_range_add_data(const ucp_proto_perf_range_t *range);
@@ -66,20 +67,20 @@ ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
  * Initialize the performance of a protocol that consists of several parallel
  * stages. The performance estimations are added to params->caps.
  *
- * @param [in] params        Protocol initialization parameters.
- * @param [in] range_start   Range interval start.
- * @param [in] range_end     Range interval end.
- * @param [in] frag_size     Size of protocol's fragments.
- * @param [in] bias          Performance bias (0 - no bias).
- * @param [in] stages        Array of parallel stages performance ranges.
- * @param [in] num_stages    Number of parallel stages in the protocol.
+ * @param [in]    proto_name    Protocol name, for debugging.
+ * @param [in]    range_start   Range interval start.
+ * @param [in]    range_end     Range interval end.
+ * @param [in]    frag_size     Size of protocol's fragments.
+ * @param [in]    bias          Performance bias (0 - no bias).
+ * @param [in]    stages        Array of parallel stages performance ranges.
+ * @param [in]    num_stages    Number of parallel stages in the protocol.
+ * @param [inout] caps          Filled with protocol performance data.
  */
 ucs_status_t
-ucp_proto_init_parallel_stages(const ucp_proto_init_params_t *params,
-                               size_t range_start, size_t range_end,
-                               size_t frag_size, double bias,
+ucp_proto_init_parallel_stages(const char *proto_name, size_t range_start,
+                               size_t range_end, size_t frag_size, double bias,
                                const ucp_proto_perf_range_t **stages,
-                               unsigned num_stages);
+                               unsigned num_stages, ucp_proto_caps_t *caps);
 
 
 void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,
@@ -100,7 +101,7 @@ ucs_status_t
 ucp_proto_common_init_caps(const ucp_proto_common_init_params_t *params,
                            const ucp_proto_common_tl_perf_t *tl_perf,
                            ucp_proto_perf_node_t *const tl_perf_node,
-                           ucp_md_map_t reg_md_map);
+                           ucp_md_map_t reg_md_map, ucp_proto_caps_t *caps);
 
 
 /**

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -19,6 +19,33 @@
 
 
 /**
+ * Helper macro to calculate the size of a protocol private data structure that
+ * extends ucp_proto_multi_priv_t, according to the actual number of lanes.
+ *
+ * @param _priv   Pointer to the private data structure.
+ * @param _mpriv  Name of the ucp_proto_multi_priv_t field in _priv.
+ *
+ * Example usage:
+ *  typedef struct { int abc; ucp_proto_multi_priv_t mpriv; } my_priv_t;
+ *       my_priv_t priv;
+ *       ...
+ *       UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(&priv, mpriv);
+ */
+#define UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(_priv, _mpriv) \
+    ({ \
+        typedef ucs_typeof(*(_priv)) _type; \
+        \
+        /* Make sure _mpriv is the last field in _type */ \
+        UCS_STATIC_ASSERT((ucs_offsetof(_type, _mpriv) + \
+                           sizeof(ucp_proto_multi_priv_t)) == sizeof(_type)); \
+        \
+        /* Add actual priv size to the offset it starts at */ \
+        ucs_offsetof(_type, _mpriv) + \
+                ucp_proto_multi_priv_size(&(_priv)->_mpriv); \
+    })
+
+
+/**
  * UCP base protocol definition for multi-fragment protocols
  */
 typedef struct ucp_proto_send_multi {
@@ -56,6 +83,9 @@ typedef struct {
 
 /*
  * Base class for protocols with fragmentation
+ * When part of a larger struct, must be the last field to allow a smaller size
+ * according to the actual number of lanes. The structure size can be obtained
+ * by @ref ucp_proto_multi_priv_size.
  */
 typedef struct {
     ucp_md_map_t                reg_md_map;   /* Memory domains to register on */
@@ -65,7 +95,7 @@ typedef struct {
     ucp_lane_index_t            num_lanes;    /* Number of lanes to use */
     size_t                      align_thresh; /* Cached value of threshold for
                                                  enabling data split alignment */
-    ucp_proto_multi_lane_priv_t lanes[0];     /* Array of lanes */
+    ucp_proto_multi_lane_priv_t lanes[UCP_MAX_LANES]; /* Array of lanes */
 } ucp_proto_multi_priv_t;
 
 
@@ -126,8 +156,14 @@ typedef ucs_status_t (*ucp_proto_multi_lane_send_func_t)(ucp_request_t *req,
 
 
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
-                                  ucp_proto_multi_priv_t *mpriv,
-                                  size_t *priv_size_p);
+                                  ucp_proto_caps_t *caps,
+                                  ucp_proto_multi_priv_t *mpriv);
+
+
+size_t ucp_proto_multi_priv_size(const ucp_proto_multi_priv_t *mpriv);
+
+
+void ucp_proto_multi_probe(const ucp_proto_multi_init_params_t *params);
 
 
 void ucp_proto_multi_query_config(const ucp_proto_query_params_t *params,

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -716,6 +716,8 @@ void ucp_proto_select_add_proto(const ucp_proto_init_params_t *init_params,
     ucp_proto_id_t proto_id                       = init_params->proto_id;
     ucp_proto_init_elem_t *init_elem;
     const char *proto_name;
+    char min_length_str[64];
+    char thresh_str[64];
     size_t priv_offset;
 
     proto_name = ucp_proto_id_field(proto_id, name);
@@ -731,7 +733,17 @@ void ucp_proto_select_add_proto(const ucp_proto_init_params_t *init_params,
                     proto_name);
     }
 
-    ucp_proto_select_init_trace_caps(proto_id, init_params);
+    ucs_trace("added protocol %s min_length %s cfg_thresh %s cfg_priority %d "
+              "priv_size %zu",
+              init_params->proto_name,
+              ucs_memunits_to_str(proto_caps->min_length, min_length_str,
+                                  sizeof(min_length_str)),
+              ucs_memunits_to_str(cfg_thresh, thresh_str, sizeof(thresh_str)),
+              cfg_priority, priv_size);
+
+    ucs_log_indent(1);
+    ucp_proto_select_init_trace_caps(init_params);
+    ucs_log_indent(-1);
 
     /* Copy private data */
     priv_offset = ucs_array_length(&proto_init->priv_buf);

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -18,9 +18,9 @@
 #include <ucs/sys/math.h>
 
 
-ucs_status_t
-ucp_proto_single_init_priv(const ucp_proto_single_init_params_t *params,
-                           ucp_proto_single_priv_t *spriv)
+ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
+                                   ucp_proto_caps_t *caps,
+                                   ucp_proto_single_priv_t *spriv)
 {
     ucp_proto_perf_node_t *tl_perf_node;
     ucp_proto_common_tl_perf_t tl_perf;
@@ -56,27 +56,28 @@ ucp_proto_single_init_priv(const ucp_proto_single_init_params_t *params,
     }
 
     status = ucp_proto_common_init_caps(&params->super, &tl_perf, tl_perf_node,
-                                        reg_md_map);
+                                        reg_md_map, caps);
     ucp_proto_perf_node_deref(&tl_perf_node);
 
     return status;
 }
 
-ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params)
+void ucp_proto_single_probe(const ucp_proto_single_init_params_t *params)
 {
+    ucp_proto_single_priv_t spriv;
+    ucp_proto_caps_t caps;
     ucs_status_t status;
 
     if (!ucp_proto_common_init_check_err_handling(&params->super)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    status = ucp_proto_single_init_priv(params, params->super.super.priv);
+    status = ucp_proto_single_init(params, &caps, &spriv);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
-    *params->super.super.priv_size = sizeof(ucp_proto_single_priv_t);
-    return UCS_OK;
+    ucp_proto_common_add_proto(&params->super, &caps, &spriv, sizeof(spriv));
 }
 
 void ucp_proto_single_query(const ucp_proto_query_params_t *params,

--- a/src/ucp/proto/proto_single.h
+++ b/src/ucp/proto/proto_single.h
@@ -24,12 +24,12 @@ typedef struct {
 } ucp_proto_single_init_params_t;
 
 
-ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params);
+ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
+                                   ucp_proto_caps_t *caps,
+                                   ucp_proto_single_priv_t *spriv);
 
 
-ucs_status_t
-ucp_proto_single_init_priv(const ucp_proto_single_init_params_t *params,
-                           ucp_proto_single_priv_t *spriv);
+void ucp_proto_single_probe(const ucp_proto_single_init_params_t *params);
 
 
 void ucp_proto_single_query(const ucp_proto_query_params_t *params,

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -399,8 +399,8 @@ ucp_proto_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
     return ucp_amo_sw_progress(self, pack_cb, fetch);
 }
 
-static ucs_status_t
-ucp_proto_amo_sw_init(const ucp_proto_init_params_t *init_params, unsigned flags)
+static void ucp_proto_amo_sw_probe(const ucp_proto_init_params_t *init_params,
+                                   unsigned flags)
 {
     const ucp_ep_config_key_t *ep_config_key = init_params->ep_config_key;
     ucp_worker_h worker                      = init_params->worker;
@@ -437,11 +437,11 @@ ucp_proto_amo_sw_init(const ucp_proto_init_params_t *init_params, unsigned flags
             (iface_attr->cap.flags & UCT_IFACE_FLAG_ATOMIC_DEVICE)) {
             ucs_trace("software atomics not supported because device atomics "
                       "are selected");
-            return UCS_ERR_UNSUPPORTED;
+            return;
         }
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 static ucs_status_t ucp_proto_amo_sw_progress_post(uct_pending_req_t *self)
@@ -449,22 +449,22 @@ static ucs_status_t ucp_proto_amo_sw_progress_post(uct_pending_req_t *self)
     return ucp_proto_amo_sw_progress(self, ucp_proto_amo_sw_post_pack_cb, 0);
 }
 
-static ucs_status_t
-ucp_proto_amo_sw_init_post(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_amo_sw_post_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_AMO_POST)) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_amo_sw_init(init_params, 0);
+    ucp_proto_amo_sw_probe(init_params, 0);
 }
 
 ucp_proto_t ucp_get_amo_post_proto = {
     .name     = "amo/post/sw",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
-    .init     = ucp_proto_amo_sw_init_post,
+    .probe    = ucp_proto_amo_sw_post_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_amo_sw_progress_post},
     .abort    = ucp_proto_abort_fatal_not_implemented,
@@ -476,25 +476,24 @@ static ucs_status_t ucp_proto_amo_sw_progress_fetch(uct_pending_req_t *self)
     return ucp_proto_amo_sw_progress(self, ucp_proto_amo_sw_fetch_pack_cb, 1);
 }
 
-static ucs_status_t
-ucp_proto_amo_sw_init_fetch(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_amo_sw_fetch_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_proto_init_check_op(init_params,
                                  UCS_BIT(UCP_OP_ID_AMO_FETCH) |
                                  UCS_BIT(UCP_OP_ID_AMO_CSWAP)) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_amo_sw_init(init_params,
-                                 UCP_PROTO_COMMON_INIT_FLAG_RESPONSE);
+    ucp_proto_amo_sw_probe(init_params, UCP_PROTO_COMMON_INIT_FLAG_RESPONSE);
 }
 
 ucp_proto_t ucp_get_amo_fetch_proto = {
     .name     = "amo/fetch/sw",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
-    .init     = ucp_proto_amo_sw_init_fetch,
+    .probe    = ucp_proto_amo_sw_fetch_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_amo_sw_progress_fetch},
     .abort    = ucp_proto_abort_fatal_not_implemented,

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -71,8 +71,8 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
     return status;
 }
 
-static ucs_status_t
-ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_get_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_h context                 = init_params->worker->context;
     ucp_proto_single_init_params_t params = {
@@ -100,17 +100,17 @@ ucp_proto_get_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 ucp_proto_t ucp_get_am_bcopy_proto = {
     .name     = "get/am/bcopy",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
-    .init     = ucp_proto_get_am_bcopy_init,
+    .probe    = ucp_proto_get_am_bcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_get_am_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_id_abort,

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -71,8 +71,8 @@ static ucs_status_t ucp_proto_get_offload_bcopy_progress(uct_pending_req_t *self
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
 
-static ucs_status_t
-ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_get_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -106,18 +106,17 @@ ucp_proto_get_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         !ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, init_params->priv,
-                                init_params->priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 ucp_proto_t ucp_get_offload_bcopy_proto = {
     .name     = "get/bcopy",
     .desc     = UCP_PROTO_COPY_OUT_DESC,
     .flags    = 0,
-    .init     = ucp_proto_get_offload_bcopy_init,
+    .probe    = ucp_proto_get_offload_bcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_bcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
@@ -162,8 +161,8 @@ static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self
             ucp_proto_request_zcopy_completion);
 }
 
-static ucs_status_t
-ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -199,18 +198,17 @@ ucp_proto_get_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, init_params->priv,
-                                init_params->priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 ucp_proto_t ucp_get_offload_zcopy_proto = {
     .name     = "get/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_proto_get_offload_zcopy_init,
+    .probe    = ucp_proto_get_offload_zcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_get_offload_zcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -73,8 +73,8 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
                                     UCP_DT_MASK_CONTIG_IOV);
 }
 
-static ucs_status_t
-ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_put_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_h context                = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -106,18 +106,17 @@ ucp_proto_put_am_bcopy_init(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, init_params->priv,
-                                init_params->priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 ucp_proto_t ucp_put_am_bcopy_proto = {
     .name     = "put/am/bcopy",
     .desc     = UCP_PROTO_RMA_EMULATION_DESC,
     .flags    = 0,
-    .init     = ucp_proto_put_am_bcopy_init,
+    .probe    = ucp_proto_put_am_bcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_am_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -46,8 +46,8 @@ static ucs_status_t ucp_proto_put_offload_short_progress(uct_pending_req_t *self
     return UCS_OK;
 }
 
-static ucs_status_t
-ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_put_offload_short_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_proto_single_init_params_t params = {
         .super.super         = *init_params,
@@ -76,17 +76,17 @@ ucp_proto_put_offload_short_init(const ucp_proto_init_params_t *init_params)
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT)) ||
         !ucp_proto_is_short_supported(init_params->select_param)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 ucp_proto_t ucp_put_offload_short_proto = {
     .name     = "put/offload/short",
     .desc     = UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_PUT_SHORT,
-    .init     = ucp_proto_put_offload_short_init,
+    .probe    = ucp_proto_put_offload_short_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_put_offload_short_progress},
     .abort    = ucp_proto_request_bcopy_abort,
@@ -142,8 +142,8 @@ static ucs_status_t ucp_proto_put_offload_bcopy_progress(uct_pending_req_t *self
                                     UCP_DT_MASK_ALL);
 }
 
-static ucs_status_t
-ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_put_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -176,18 +176,17 @@ ucp_proto_put_offload_bcopy_init(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, init_params->priv,
-                                init_params->priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 ucp_proto_t ucp_put_offload_bcopy_proto = {
     .name     = "put/offload/bcopy",
     .desc     = UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
-    .init     = ucp_proto_put_offload_bcopy_init,
+    .probe    = ucp_proto_put_offload_bcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort,
@@ -229,8 +228,8 @@ ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
             ucp_proto_request_zcopy_completion);
 }
 
-static ucs_status_t
-ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -265,18 +264,17 @@ ucp_proto_put_offload_zcopy_init(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(&params, init_params->priv,
-                                init_params->priv_size);
+    ucp_proto_multi_probe(&params);
 }
 
 ucp_proto_t ucp_put_offload_zcopy_proto = {
     .name     = "put/offload/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_proto_put_offload_zcopy_init,
+    .probe    = ucp_proto_put_offload_zcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_proto_put_offload_zcopy_progress},
     .abort    = ucp_proto_request_zcopy_abort,

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -29,7 +29,9 @@ ucp_rndv_am_cfg_thresh(ucp_context_t *context, size_t am_thresh)
 static ucs_status_t
 ucp_proto_rndv_am_init_common(ucp_proto_multi_init_params_t *params)
 {
-    ucp_context_h context = params->super.super.worker->context;
+    ucp_context_h context         = params->super.super.worker->context;
+    ucp_proto_multi_priv_t *mpriv = params->super.super.priv;
+    ucs_status_t status;
 
     if (!ucp_proto_rndv_op_check(&params->super.super, UCP_OP_ID_RNDV_SEND,
                                  0)) {
@@ -46,8 +48,13 @@ ucp_proto_rndv_am_init_common(ucp_proto_multi_init_params_t *params)
     params->max_lanes        = context->config.ext.max_rndv_lanes;
     params->opt_align_offs   = UCP_PROTO_COMMON_OFFSET_INVALID;
 
-    return ucp_proto_multi_init(params, params->super.super.priv,
-                                params->super.super.priv_size);
+    status = ucp_proto_multi_init(params, params->super.super.caps, mpriv);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *params->super.super.priv_size = ucp_proto_multi_priv_size(mpriv);
+    return UCS_OK;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -48,7 +48,6 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
     const ucp_proto_perf_range_t *frag_range;
     size_t frag_min_length, frag_max_length;
     ucp_worker_cfg_index_t rkey_cfg_index;
-    ucp_proto_init_params_t ppln_params;
     ucp_proto_select_param_t sel_param;
     ucp_proto_select_t *proto_select;
     ucs_linear_func_t ppln_overhead;
@@ -101,13 +100,11 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
               UCP_PROTO_PERF_FUNC_TYPES_ARG(frag_range->perf));
 
     /* Add the single range of the pipeline protocol to ppln_caps */
-    ppln_params            = *init_params;
-    ppln_params.caps       = &ppln_caps;
     ppln_caps.cfg_thresh   = thresh_elem->proto_config.cfg_thresh;
     ppln_caps.cfg_priority = 0;
     ppln_caps.min_length   = frag_max_length + 1;
     ppln_caps.num_ranges   = 0;
-    ucp_proto_common_add_ppln_range(&ppln_params, frag_range, SIZE_MAX);
+    ucp_proto_common_add_ppln_range(&ppln_caps, frag_range, SIZE_MAX);
 
     /* Initialize private data */
     *init_params->priv_size = sizeof(*rpriv);

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -79,8 +79,7 @@ ucp_proto_rndv_rkey_ptr_init(const ucp_proto_init_params_t *init_params)
         return UCS_ERR_UNSUPPORTED;
     }
 
-    params.super.super.caps = &rkey_ptr_caps;
-    status = ucp_proto_single_init_priv(&params, &rpriv->spriv);
+    status = ucp_proto_single_init(&params, &rkey_ptr_caps, &rpriv->spriv);
     if (status != UCS_OK) {
         return status;
     }
@@ -250,9 +249,8 @@ ucp_proto_rndv_rkey_ptr_mtype_init(const ucp_proto_init_params_t *init_params)
         return status;
     }
 
-    params.super.super.caps = &rkey_ptr_caps;
-
-    status = ucp_proto_single_init_priv(&params, &rpriv->super.spriv);
+    status = ucp_proto_single_init(&params, &rkey_ptr_caps,
+                                   &rpriv->super.spriv);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/ucp/stream/stream_multi.c
+++ b/src/ucp/stream/stream_multi.c
@@ -22,16 +22,15 @@
 #define UCP_PROTO_STREAM_ZCOPY_DESC \
     UCP_PROTO_STREAM_DESC " " UCP_PROTO_ZCOPY_DESC " " UCP_PROTO_COPY_OUT_DESC
 
-static ucs_status_t
-ucp_stream_multi_common_init(const ucp_proto_multi_init_params_t *params)
+static void
+ucp_stream_multi_common_probe(const ucp_proto_multi_init_params_t *params)
 {
     if (!ucp_proto_init_check_op(&params->super.super,
                                  UCS_BIT(UCP_OP_ID_STREAM_SEND))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_multi_init(params, params->super.super.priv,
-                                params->super.super.priv_size);
+    ucp_proto_multi_probe(params);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -70,8 +69,8 @@ static ucs_status_t ucp_stream_multi_bcopy_progress(uct_pending_req_t *uct_req)
             ucp_proto_request_bcopy_complete_success);
 }
 
-static ucs_status_t
-ucp_stream_multi_bcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_stream_multi_bcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -101,14 +100,14 @@ ucp_stream_multi_bcopy_init(const ucp_proto_init_params_t *init_params)
         .middle.lane_type    = UCP_LANE_TYPE_AM
     };
 
-    return ucp_stream_multi_common_init(&params);
+    ucp_stream_multi_common_probe(&params);
 }
 
 ucp_proto_t ucp_stream_multi_bcopy_proto = {
     .name     = "stream/multi/bcopy",
     .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_STREAM_BCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_stream_multi_bcopy_init,
+    .probe    = ucp_stream_multi_bcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_stream_multi_bcopy_progress},
     .abort    = ucp_proto_request_bcopy_abort,
@@ -142,8 +141,8 @@ static ucs_status_t ucp_stream_multi_zcopy_progress(uct_pending_req_t *uct_req)
             ucp_proto_request_zcopy_completion);
 }
 
-static ucs_status_t
-ucp_stream_multi_zcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_stream_multi_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -174,14 +173,14 @@ ucp_stream_multi_zcopy_init(const ucp_proto_init_params_t *init_params)
         .middle.lane_type    = UCP_LANE_TYPE_AM
     };
 
-    return ucp_stream_multi_common_init(&params);
+    ucp_stream_multi_common_probe(&params);
 }
 
 ucp_proto_t ucp_stream_multi_zcopy_proto = {
     .name     = "stream/multi/zcopy",
     .desc     = UCP_PROTO_MULTI_FRAG_DESC " " UCP_PROTO_STREAM_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_stream_multi_zcopy_init,
+    .probe    = ucp_stream_multi_zcopy_probe,
     .query    = ucp_proto_multi_query,
     .progress = {ucp_stream_multi_zcopy_progress},
     .abort    = ucp_proto_request_zcopy_abort,

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -44,8 +44,8 @@ static ucs_status_t ucp_eager_short_progress(uct_pending_req_t *self)
     return UCS_OK;
 }
 
-static ucs_status_t
-ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_eager_short_probe(const ucp_proto_init_params_t *init_params)
 {
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     ucp_proto_single_init_params_t params        = {
@@ -74,17 +74,17 @@ ucp_proto_eager_short_init(const ucp_proto_init_params_t *init_params)
     /* AM based proto can not be used if tag offload lane configured */
     if (!ucp_tag_eager_check_op_id(init_params, UCP_OP_ID_TAG_SEND, 0) ||
         !ucp_proto_is_short_supported(select_param)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 ucp_proto_t ucp_eager_short_proto = {
     .name     = "egr/short",
     .desc     = "eager " UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_AM_SHORT,
-    .init     = ucp_proto_eager_short_init,
+    .probe    = ucp_proto_eager_short_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_short_progress},
     .abort    = ucp_proto_request_bcopy_abort,
@@ -117,8 +117,8 @@ static ucs_status_t ucp_eager_bcopy_single_progress(uct_pending_req_t *self)
             req, SIZE_MAX, ucp_proto_request_bcopy_complete_success, 1);
 }
 
-static ucs_status_t
-ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_eager_bcopy_single_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context                = init_params->worker->context;
     ucp_proto_single_init_params_t params = {
@@ -145,25 +145,25 @@ ucp_proto_eager_bcopy_single_init(const ucp_proto_init_params_t *init_params)
 
     /* AM based proto can not be used if tag offload lane configured */
     if (!ucp_tag_eager_check_op_id(init_params, UCP_OP_ID_TAG_SEND, 0)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 ucp_proto_t ucp_eager_bcopy_single_proto = {
     .name     = "egr/single/bcopy",
     .desc     = UCP_PROTO_EAGER_BCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_proto_eager_bcopy_single_init,
+    .probe    = ucp_proto_eager_bcopy_single_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_eager_bcopy_single_progress},
     .abort    = ucp_proto_request_bcopy_abort,
     .reset    = ucp_proto_request_bcopy_reset
 };
 
-static ucs_status_t
-ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_eager_zcopy_single_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context                = init_params->worker->context;
     ucp_proto_single_init_params_t params = {
@@ -193,10 +193,10 @@ ucp_proto_eager_zcopy_single_init(const ucp_proto_init_params_t *init_params)
     /* AM based proto can not be used if tag offload lane configured */
     if (!ucp_tag_eager_check_op_id(init_params, UCP_OP_ID_TAG_SEND, 0) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 static ucs_status_t
@@ -229,7 +229,7 @@ ucp_proto_t ucp_eager_zcopy_single_proto = {
     .name     = "egr/single/zcopy",
     .desc     = UCP_PROTO_EAGER_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_proto_eager_zcopy_single_init,
+    .probe    = ucp_proto_eager_zcopy_single_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_zcopy_single_progress},
     .abort    = ucp_proto_request_zcopy_abort,

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -41,7 +41,7 @@ ucp_proto_eager_tag_offload_short_progress(uct_pending_req_t *self)
     return UCS_OK;
 }
 
-static ucs_status_t ucp_proto_eager_tag_offload_short_init(
+static void ucp_proto_eager_tag_offload_short_probe(
         const ucp_proto_init_params_t *init_params)
 {
     const ucp_proto_select_param_t *select_param = init_params->select_param;
@@ -71,17 +71,17 @@ static ucs_status_t ucp_proto_eager_tag_offload_short_init(
 
     if (!ucp_tag_eager_check_op_id(init_params, UCP_OP_ID_TAG_SEND, 1) ||
         !ucp_proto_is_short_supported(select_param)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
 ucp_proto_t ucp_eager_tag_offload_short_proto = {
     .name     = "egr/offload/short",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_SHORT_DESC,
     .flags    = UCP_PROTO_FLAG_TAG_SHORT,
-    .init     = ucp_proto_eager_tag_offload_short_init,
+    .probe    = ucp_proto_eager_tag_offload_short_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_short_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
@@ -115,7 +115,7 @@ ucp_proto_eager_tag_offload_bcopy_common(ucp_request_t *req,
     return ucs_likely(packed_len >= 0) ? UCS_OK : packed_len;
 }
 
-static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init_common(
+static void ucp_proto_eager_tag_offload_bcopy_probe_common(
         const ucp_proto_init_params_t *init_params, ucp_proto_id_t op_id)
 {
     ucp_context_t *context                = init_params->worker->context;
@@ -145,12 +145,11 @@ static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init_common(
 
     /* offload proto can not be used if no tag offload lane configured */
     if (!ucp_tag_eager_check_op_id(init_params, op_id, 1)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
-
 
 static ucs_status_t
 ucp_proto_eager_tag_offload_bcopy_progress(uct_pending_req_t *self)
@@ -166,18 +165,18 @@ ucp_proto_eager_tag_offload_bcopy_progress(uct_pending_req_t *self)
             status);
 }
 
-static ucs_status_t ucp_proto_eager_tag_offload_bcopy_init(
+static void ucp_proto_eager_tag_offload_bcopy_probe(
         const ucp_proto_init_params_t *init_params)
 {
-    return ucp_proto_eager_tag_offload_bcopy_init_common(init_params,
-                                                         UCP_OP_ID_TAG_SEND);
+    ucp_proto_eager_tag_offload_bcopy_probe_common(init_params,
+                                                   UCP_OP_ID_TAG_SEND);
 }
 
 ucp_proto_t ucp_tag_offload_eager_bcopy_single_proto = {
     .name     = "egr/offload/bcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
-    .init     = ucp_proto_eager_tag_offload_bcopy_init,
+    .probe    = ucp_proto_eager_tag_offload_bcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_bcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
@@ -206,25 +205,25 @@ ucp_proto_eager_sync_tag_offload_bcopy_progress(uct_pending_req_t *self)
             spriv->super.lane, status);
 }
 
-static ucs_status_t ucp_proto_eager_sync_tag_offload_bcopy_init(
+static void ucp_proto_eager_sync_tag_offload_bcopy_probe(
         const ucp_proto_init_params_t *init_params)
 {
-    return ucp_proto_eager_tag_offload_bcopy_init_common(
-            init_params, UCP_OP_ID_TAG_SEND_SYNC);
+    ucp_proto_eager_tag_offload_bcopy_probe_common(init_params,
+                                                   UCP_OP_ID_TAG_SEND_SYNC);
 }
 
 ucp_proto_t ucp_eager_sync_bcopy_single_proto = {
     .name     = "egrsnc/offload/bcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_COPY_IN_DESC,
     .flags    = 0,
-    .init     = ucp_proto_eager_sync_tag_offload_bcopy_init,
+    .probe    = ucp_proto_eager_sync_tag_offload_bcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_sync_tag_offload_bcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
     .reset    = ucp_proto_request_bcopy_id_reset
 };
 
-static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init_common(
+static void ucp_proto_eager_tag_offload_zcopy_probe_common(
         const ucp_proto_init_params_t *init_params, ucp_proto_id_t op_id)
 {
     ucp_context_t *context                = init_params->worker->context;
@@ -257,17 +256,17 @@ static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init_common(
     /* offload proto can not be used if no tag offload lane configured */
     if (!ucp_tag_eager_check_op_id(init_params, op_id, 1) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_single_init(&params);
+    ucp_proto_single_probe(&params);
 }
 
-static ucs_status_t ucp_proto_eager_tag_offload_zcopy_init(
+static void ucp_proto_eager_tag_offload_zcopy_probe(
         const ucp_proto_init_params_t *init_params)
 {
-    return ucp_proto_eager_tag_offload_zcopy_init_common(init_params,
-                                                         UCP_OP_ID_TAG_SEND);
+    ucp_proto_eager_tag_offload_zcopy_probe_common(init_params,
+                                                   UCP_OP_ID_TAG_SEND);
 }
 
 static ucs_status_t
@@ -297,18 +296,18 @@ ucp_proto_t ucp_tag_offload_eager_zcopy_single_proto = {
     .name     = "egr/offload/zcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_proto_eager_tag_offload_zcopy_init,
+    .probe    = ucp_proto_eager_tag_offload_zcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_tag_offload_zcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,
     .reset    = ucp_proto_request_zcopy_reset
 };
 
-static ucs_status_t ucp_proto_eager_sync_tag_offload_zcopy_init(
+static void ucp_proto_eager_sync_tag_offload_zcopy_probe(
         const ucp_proto_init_params_t *init_params)
 {
-    return ucp_proto_eager_tag_offload_zcopy_init_common(
-            init_params, UCP_OP_ID_TAG_SEND_SYNC);
+    ucp_proto_eager_tag_offload_zcopy_probe_common(init_params,
+                                                   UCP_OP_ID_TAG_SEND_SYNC);
 }
 
 static ucs_status_t
@@ -358,7 +357,7 @@ ucp_proto_t ucp_eager_sync_zcopy_single_proto = {
     .name     = "egrsnc/offload/zcopy",
     .desc     = UCP_PROTO_EAGER_OFFLOAD_DESC " " UCP_PROTO_ZCOPY_DESC,
     .flags    = 0,
-    .init     = ucp_proto_eager_sync_tag_offload_zcopy_init,
+    .probe    = ucp_proto_eager_sync_tag_offload_zcopy_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_proto_eager_sync_tag_offload_zcopy_progress},
     .abort    = ucp_proto_abort_fatal_not_implemented,

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -48,13 +48,21 @@ ucp_tag_rndv_offload_proto_init(const ucp_proto_init_params_t *init_params)
        .lane_type           = UCP_LANE_TYPE_TAG,
        .tl_cap_flags        = UCT_IFACE_FLAG_TAG_RNDV_ZCOPY
     };
+    ucs_status_t status;
 
     if (!ucp_tag_rndv_check_op_id(init_params) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    return ucp_proto_single_init(&params);
+    status = ucp_proto_single_init(&params, params.super.super.caps,
+                                   params.super.super.priv);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *init_params->priv_size = sizeof(ucp_proto_single_priv_t);
+    return UCS_OK;
 }
 
 static void


### PR DESCRIPTION
## Why
Next phase of adding protocol variants, moving from init() to probe()