### PR TITLE
UCP/RNDV: Fixed rkey pack crash when mem reg failed - v1.16.x 

### DIFF
--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -353,6 +353,7 @@ ucp_proto_request_pack_rkey(ucp_request_t *req, ucp_md_map_t md_map,
                             void *rkey_buffer)
 {
     const ucp_datatype_iter_t *dt_iter = &req->send.state.dt_iter;
+    ucp_mem_h memh;
     ssize_t packed_rkey_size;
 
     /* For contiguous buffer, pack one rkey
@@ -360,12 +361,15 @@ ucp_proto_request_pack_rkey(ucp_request_t *req, ucp_md_map_t md_map,
      */
     ucs_assertv(dt_iter->dt_class == UCP_DATATYPE_CONTIG, "dt_class=%s",
                 ucp_datatype_class_names[dt_iter->dt_class]);
-    ucs_assertv(ucs_test_all_flags(dt_iter->type.contig.memh->md_map, md_map),
-                "dt_iter_md_map=0x%"PRIx64" md_map=0x%"PRIx64,
-                dt_iter->type.contig.memh->md_map, md_map);
+
+    memh = dt_iter->type.contig.memh;
+    if (!ucs_test_all_flags(memh->md_map, md_map)) {
+        ucs_trace("dt_iter_md_map=0x%"PRIx64" md_map=0x%"PRIx64, memh->md_map,
+                  md_map);
+    }
 
     packed_rkey_size = ucp_rkey_pack_memh(
-            req->send.ep->worker->context, md_map, dt_iter->type.contig.memh,
+            req->send.ep->worker->context, md_map & memh->md_map, memh,
             dt_iter->type.contig.buffer, dt_iter->length, &dt_iter->mem_info,
             distance_dev_map, dev_distance,
             ucp_ep_config(req->send.ep)->uct_rkey_pack_flags, rkey_buffer);

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -181,7 +181,8 @@ static ucs_status_t ucp_proto_rndv_rtr_progress(uct_pending_req_t *self)
         status = ucp_datatype_iter_mem_reg(req->send.ep->worker->context,
                                            &req->send.state.dt_iter,
                                            rpriv->super.md_map,
-                                           UCT_MD_MEM_ACCESS_REMOTE_PUT,
+                                           UCT_MD_MEM_ACCESS_REMOTE_PUT |
+                                           UCT_MD_MEM_FLAG_HIDE_ERRORS,
                                            UCP_DT_MASK_ALL);
         if (status != UCS_OK) {
             ucp_proto_request_abort(req, status);


### PR DESCRIPTION
## What
Excluded memory domains from the list where memory registration failed.

## Why ?
Scenario:
```C
ucp_tag_rndv_rts_progress
    ucp_proto_rndv_rts_request_init
        ucp_datatype_iter_mem_reg(rpriv->md_map)
            ucp_datatype_iter_mem_reg_single
                ucp_memh_register
                    ucp_memh_register_internal
                        /* uct_md_mem_reg_v2 fails for md_x */
    ucp_proto_am_bcopy_single_progress
        ucp_proto_am_bcopy_single_send
	    ucp_tag_rndv_proto_rts_pack
                ucp_proto_rndv_rts_pack
                    ucp_proto_request_pack_rkey(rpriv->md_map)
                        ucp_rkey_pack_memh
                            /* uct_md_mkey_pack_v2 crashes for md_x */
```

## How ?
Cherry-picked https://github.com/openucx/ucx/pull/9676