### PR TITLE
UCP/PROTOV2: Return error with immediate completion when put short fails

### DIFF
--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -266,7 +266,8 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
 
     if (worker->context->config.ext.proto_enable) {
         status = ucp_put_send_short(ep, buffer, count, remote_addr, rkey, param);
-        if (ucs_likely(status != UCS_ERR_NO_RESOURCE)) {
+        if (ucs_likely(status != UCS_ERR_NO_RESOURCE) ||
+            ucs_unlikely(param->op_attr_mask & UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)) {
             ret = UCS_STATUS_PTR(status);
             goto out_unlock;
         }


### PR DESCRIPTION
## What
Return no resource if we risk not being able to complete put immediately.

## Why ?
Reported as #9691.