### PR TITLE
UCT/IB/GGA: fix compilation

### DIFF
--- a/src/uct/ib/Makefile.am
+++ b/src/uct/ib/Makefile.am
@@ -73,13 +73,13 @@ noinst_HEADERS += \
 libuct_ib_la_SOURCES += \
 	rc/accel/rc_mlx5_ep.c \
 	rc/accel/rc_mlx5_iface.c \
-	rc/accel/rc_mlx5_common.c \
-	rc/accel/gga_mlx5.c
+	rc/accel/rc_mlx5_common.c
 endif # HAVE_MLX5_DV
 
 if HAVE_DEVX
 libuct_ib_la_SOURCES += \
-	rc/accel/rc_mlx5_devx.c
+	rc/accel/rc_mlx5_devx.c \
+	rc/accel/gga_mlx5.c
 endif # HAVE_DEVX
 
 endif # HAVE_TL_RC

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -198,7 +198,9 @@ static uct_tl_t *uct_ib_tls[] = {
 #endif
 #if defined (HAVE_TL_RC) && defined (HAVE_MLX5_DV)
     &UCT_TL_NAME(rc_mlx5),
+#ifdef HAVE_DEVX
     &UCT_TL_NAME(gga_mlx5),
+#endif
 #endif
 #ifdef HAVE_TL_UD
     &UCT_TL_NAME(ud_verbs),


### PR DESCRIPTION
## What
fix compilation without devx

## Why ?
gga_mlx5.c file was wrongly added under `HAVE_MLX5_DV` condition instead of `HAVE_DEVX`
