### PR TITLE
UCT: Added configuration variables to set overheads for IB and MM interfaces.

### DIFF
--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -153,6 +153,21 @@ static inline void ucs_sec_to_timespec(double seconds, struct timespec *ts)
     ts->tv_nsec = nsec % UCS_NSEC_PER_SEC;
 }
 
+
+/**
+ * Convert UCS time units, including auto and inf values, to seconds
+ */
+static inline double ucs_time_units_to_sec(ucs_time_t t, double auto_val)
+{
+    if (t == UCS_TIME_AUTO) {
+        return auto_val;
+    } else if (t == UCS_TIME_INFINITY) {
+        return INFINITY;
+    }
+
+    return ucs_time_to_sec(t);
+}
+
 END_C_DECLS
 
 #endif

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -127,6 +127,22 @@ typedef struct uct_ib_address_pack_params {
 } uct_ib_address_pack_params_t;
 
 
+
+/** Overhead of send operation of ib interface */
+typedef struct uct_ib_iface_send_overhead {
+    /** Overhead of allocating a tx buffer */
+    ucs_time_t bcopy;
+    /** Overhead of processing a work request completion */
+    ucs_time_t cqe;
+    /** Overhead of writing a doorbell to PCI */
+    ucs_time_t db;
+    /** Overhead of fetching a wqe */
+    ucs_time_t wqe_fetch;
+    /** Overhead of posting a wqe */
+    ucs_time_t wqe_post;
+} uct_ib_iface_send_overhead_t;
+
+
 struct uct_ib_iface_config {
     uct_iface_config_t      super;
 
@@ -185,16 +201,21 @@ struct uct_ib_iface_config {
     UCS_CONFIG_ARRAY_FIELD(ucs_range_spec_t, ranges) lid_path_bits;
 
     /* IB PKEY to use */
-    unsigned                pkey;
+    unsigned                     pkey;
 
     /* Path MTU size */
-    uct_ib_mtu_t            path_mtu;
+    uct_ib_mtu_t                 path_mtu;
 
     /* QP counter set ID */
-    unsigned long           counter_set_id;
+    unsigned long                counter_set_id;
 
     /* IB reverse SL (default: AUTO - same value as sl) */
-    unsigned long           reverse_sl;
+    unsigned long                reverse_sl;
+
+    /**
+     * Estimated overhead of preparing a work request and posting it to the NIC
+     */
+    uct_ib_iface_send_overhead_t send_overhead;
 };
 
 
@@ -287,25 +308,29 @@ struct uct_ib_iface {
     uct_ib_device_gid_info_t  gid_info;
 
     struct {
-        unsigned              rx_payload_offset;   /* offset from desc to payload */
-        unsigned              rx_hdr_offset;       /* offset from desc to network header */
-        unsigned              rx_headroom_offset;  /* offset from desc to user headroom */
-        unsigned              rx_max_batch;
-        unsigned              rx_max_poll;
-        unsigned              tx_max_poll;
-        unsigned              seg_size;
-        unsigned              roce_path_factor;
-        uint8_t               max_inl_cqe[UCT_IB_DIR_LAST];
-        uint8_t               port_num;
-        uint8_t               sl;
-        uint8_t               reverse_sl;
-        uint8_t               traffic_class;
-        uint8_t               hop_limit;
-        uint8_t               qp_type;
-        uint8_t               force_global_addr;
-        uint8_t               flid_enabled;
-        enum ibv_mtu          path_mtu;
-        uint8_t               counter_set_id;
+        /* offset from desc to payload */
+        unsigned                     rx_payload_offset;
+        /* offset from desc to network header */
+        unsigned                     rx_hdr_offset;
+        /* offset from desc to user headroom */
+        unsigned                     rx_headroom_offset;
+        unsigned                     rx_max_batch;
+        unsigned                     rx_max_poll;
+        unsigned                     tx_max_poll;
+        unsigned                     seg_size;
+        unsigned                     roce_path_factor;
+        uint8_t                      max_inl_cqe[UCT_IB_DIR_LAST];
+        uint8_t                      port_num;
+        uint8_t                      sl;
+        uint8_t                      reverse_sl;
+        uint8_t                      traffic_class;
+        uint8_t                      hop_limit;
+        uint8_t                      qp_type;
+        uint8_t                      force_global_addr;
+        uint8_t                      flid_enabled;
+        enum ibv_mtu                 path_mtu;
+        uint8_t                      counter_set_id;
+        uct_ib_iface_send_overhead_t send_overhead;
     } config;
 
     uct_ib_iface_ops_t        *ops;

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -67,6 +67,26 @@ ucs_config_field_t uct_mm_iface_config_table[] = {
     {"ERROR_HANDLING", "n", "Expose error handling support capability",
      ucs_offsetof(uct_mm_iface_config_t, error_handling), UCS_CONFIG_TYPE_BOOL},
 
+    {"SEND_OVERHEAD", UCS_VALUE_AUTO_STR,
+     "Time spent after the message request has been passed to the hardware or\n"
+     "system software layers and before operation has been finalized", 0,
+     UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_TIME_UNITS,
+        {"am_short", "send overhead for short Active Message operation type",
+         ucs_offsetof(uct_mm_iface_config_t, overhead.send.am_short)},
+        {"am_bcopy", "send overhead for buffered Active Message operation type",
+         ucs_offsetof(uct_mm_iface_config_t, overhead.send.am_bcopy)},
+        {NULL})},
+
+    {"RECV_OVERHEAD", UCS_VALUE_AUTO_STR,
+     "Message receive overhead time", 0,
+     UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_TIME_UNITS,
+        {"am_short", "receive overhead for short Active Message operation type",
+         ucs_offsetof(uct_mm_iface_config_t, overhead.recv.am_short)},
+        {"am_bcopy", "receive overhead for buffered Active Message operation "
+                     "type",
+         ucs_offsetof(uct_mm_iface_config_t, overhead.recv.am_bcopy)},
+        {NULL})},
+
     {NULL}
 };
 
@@ -518,6 +538,7 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     uct_ep_operation_t op = UCT_ATTR_VALUE(PERF, perf_attr, operation,
                                            OPERATION, UCT_EP_OP_LAST);
     double short_overhead, am_overhead;
+    uct_mm_iface_op_overhead_t *overhead;
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         perf_attr->bandwidth.shared = 0;
@@ -534,14 +555,16 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         am_overhead    = UCT_MM_IFACE_OVERHEAD;
     }
 
-
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {
+        overhead = &iface->config.overhead.send;
         switch (op) {
         case UCT_EP_OP_AM_SHORT:
-            perf_attr->send_pre_overhead = short_overhead;
+            perf_attr->send_pre_overhead =
+                    ucs_time_units_to_sec(overhead->am_short, short_overhead);
             break;
         case UCT_EP_OP_AM_BCOPY:
-            perf_attr->send_pre_overhead = am_overhead;
+            perf_attr->send_pre_overhead =
+                    ucs_time_units_to_sec(overhead->am_bcopy, am_overhead);
             break;
         default:
             perf_attr->send_pre_overhead = UCT_MM_IFACE_OVERHEAD;
@@ -550,12 +573,15 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     }
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_RECV_OVERHEAD) {
+        overhead = &iface->config.overhead.recv;
         switch (op) {
         case UCT_EP_OP_AM_SHORT:
-            perf_attr->recv_overhead = short_overhead;
+            perf_attr->recv_overhead = ucs_time_units_to_sec(overhead->am_short,
+                                                             short_overhead);
             break;
         case UCT_EP_OP_AM_BCOPY:
-            perf_attr->recv_overhead = am_overhead;
+            perf_attr->recv_overhead = ucs_time_units_to_sec(overhead->am_bcopy,
+                                                             am_overhead);
             break;
         default:
             perf_attr->recv_overhead = UCT_MM_IFACE_OVERHEAD;
@@ -757,6 +783,7 @@ static UCS_CLASS_INIT_FUNC(uct_mm_iface_t, uct_md_h md, uct_worker_h worker,
         goto err;
     }
 
+    self->config.overhead          = mm_config->overhead;
     self->config.fifo_size         = mm_config->fifo_size;
     self->config.fifo_elem_size    = mm_config->fifo_elem_size;
     self->config.seg_size          = mm_config->seg_size;

--- a/src/uct/sm/mm/base/mm_iface.h
+++ b/src/uct/sm/mm/base/mm_iface.h
@@ -87,6 +87,18 @@ enum {
 #define UCT_MM_IFACE_FIFO_HEAD_EVENT_ARMED      UCS_BIT(63)
 
 
+typedef struct uct_mm_iface_op_overhead {
+    ucs_time_t am_short;
+    ucs_time_t am_bcopy;
+} uct_mm_iface_op_overhead_t;
+
+
+typedef struct uct_mm_iface_overhead {
+    uct_mm_iface_op_overhead_t send;
+    uct_mm_iface_op_overhead_t recv;
+} uct_mm_iface_overhead_t;
+
+
 /**
  * MM interface configuration
  */
@@ -103,6 +115,7 @@ typedef struct uct_mm_iface_config {
     unsigned                 fifo_elem_size;      /* Size of the FIFO element size */
     int                      error_handling; /* Exposing of error handling cap */
     uct_iface_mpool_config_t mp;
+    uct_mm_iface_overhead_t  overhead;
 } uct_mm_iface_config_t;
 
 
@@ -215,11 +228,13 @@ typedef struct uct_mm_iface {
     uct_recv_desc_t         release_desc;
 
     struct {
-        unsigned            fifo_size;
-        unsigned            fifo_elem_size;
-        unsigned            seg_size;         /* size of the receive descriptor (for payload)*/
-        unsigned            fifo_max_poll;
-        uint64_t            extra_cap_flags;
+        unsigned                fifo_size;
+        unsigned                fifo_elem_size;
+        /* size of the receive descriptor (for payload) */
+        unsigned                seg_size;
+        unsigned                fifo_max_poll;
+        uint64_t                extra_cap_flags;
+        uct_mm_iface_overhead_t overhead;
     } config;
 } uct_mm_iface_t;
 


### PR DESCRIPTION
## What
Added IB_SEND_OVERHEAD configuration variables.
Added MM_[SEND|RECV]_OVERHEAD configuration variables.
Added helper method to time units, including special values, to seconds.