### PR TITLE
TEST/UCP: Fix double munmap in ucp mmap tests

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -641,7 +641,9 @@ mmap_fixed_address::mmap_fixed_address(size_t length) : m_length(length) {
 }
 
 mmap_fixed_address::~mmap_fixed_address() {
-    munmap(m_ptr, m_length);
+    if (m_ptr != NULL) {
+        munmap(m_ptr, m_length);
+    }
 }
 
 std::string compact_string(const std::string &str, size_t length)

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -352,6 +352,8 @@ public:
     mmap_fixed_address(size_t length);
     ~mmap_fixed_address();
     void* operator*() const { return m_ptr; }
+    void detach() { m_ptr = NULL; }
+
 private:
     void *m_ptr;
     size_t m_length;

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -897,6 +897,7 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
         is_dummy = (size == 0);
         test_rkey_management(memh, is_dummy, is_tl_rdma());
 
+        ptr.detach();
         status = ucp_mem_unmap(sender().ucph(), memh);
         ASSERT_UCS_OK(status);
     }


### PR DESCRIPTION
## What
Fix potential double `munmap()` causing unrelated memory to disappear altogether.

## Why ?
Triggered with #9668 at commit 9e98b04 with `UCX_LOG_LEVEL=debug.. >/dev/null` to help repro:
```
[ RUN      ] tcp/test_ucp_mmap.fixed/0 <tcp,cuda_copy,rocm_copy>
[swx-rdmz-ucx-new-02:29082:0:29082] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x7f8142912ec0)
/scrap/azure/agent-04/AZP_WORKSPACE/2/s/contrib/../test/gtest/common/test_helpers.cc:55: Failure
Failed
```

## How ?
Instantiating `ucs::mmap_fixed_address` creates a new mapping in an available range. `ucp_mem_map(ALLOCATE|FIXED)` is then invoked and eventually `mmap(FIXED)` replaces that already owned mapping. In the test, `ucp_mem_unmap()` releases it, but `ucs::~mmap_fixed_address` is also calling `munmap()`. Issue arise when an unrelated `mmap()` has taken place in between.