### PR TITLE
UCP/PROTO: Add RNDV performance variants

### DIFF
--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -59,21 +59,22 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
     return ucp_proto_am_handle_user_header_send_status(req, status);
 }
 
-ucs_status_t ucp_am_rndv_rts_init(const ucp_proto_init_params_t *init_params)
+void ucp_am_rndv_rts_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_rts_init(init_params);
+    ucp_proto_rndv_rts_probe(init_params);
 }
+
 
 ucp_proto_t ucp_am_rndv_proto = {
     .name     = "am/rndv",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_am_rndv_rts_init,
+    .probe    = ucp_am_rndv_rts_probe,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_am_rndv_proto_progress},
     .abort    = ucp_proto_rndv_rts_abort,

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -23,7 +23,7 @@
 
 
 /* Maximal size of protocol private data */
-#define UCP_PROTO_PRIV_MAX          1024
+#define UCP_PROTO_PRIV_MAX          2048
 
 
 /* Maximal number of protocols in total */
@@ -60,10 +60,6 @@ typedef struct ucp_proto_perf_node ucp_proto_perf_node_t;
 
 /* Key for selecting a protocol */
 typedef struct ucp_proto_select_param ucp_proto_select_param_t;
-
-
-/* Context for probing a protocol for a specific selection key */
-typedef struct ucp_proto_probe_ctx ucp_proto_probe_ctx_t;
 
 
 /* Protocol stage ID */
@@ -170,6 +166,26 @@ typedef struct {
     ucp_proto_perf_range_t  ranges[UCP_PROTO_MAX_PERF_RANGES];
 
 } ucp_proto_caps_t;
+
+
+typedef struct {
+    ucp_proto_id_t   proto_id;
+    size_t           priv_offset;
+    size_t           priv_size;
+    size_t           cfg_thresh; /* Configured protocol threshold */
+    unsigned         cfg_priority; /* Priority of configuration */
+    ucp_proto_caps_t caps;
+} ucp_proto_init_elem_t;
+
+
+/* Parameters structure for initializing protocols for a selection parameter */
+typedef struct {
+    ucs_array_s(size_t, uint8_t)                 priv_buf;
+    ucs_array_s(unsigned, ucp_proto_init_elem_t) protocols;
+} ucp_proto_probe_ctx_t;
+
+
+typedef ucp_proto_probe_ctx_t ucp_proto_select_init_protocols_t;
 
 
 /**

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -20,23 +20,6 @@
 
 #include <ucp/core/ucp_worker.inl>
 
-
-typedef struct {
-    ucp_proto_id_t   proto_id;
-    size_t           priv_offset;
-    size_t           cfg_thresh; /* Configured protocol threshold */
-    unsigned         cfg_priority; /* Priority of configuration */
-    ucp_proto_caps_t caps;
-} ucp_proto_init_elem_t;
-
-/* Parameters structure for initializing protocols for a selection parameter */
-struct ucp_proto_probe_ctx {
-    ucs_array_s(size_t, uint8_t)                 priv_buf;
-    ucs_array_s(unsigned, ucp_proto_init_elem_t) protocols;
-};
-
-typedef ucp_proto_probe_ctx_t ucp_proto_select_init_protocols_t;
-
 UCS_ARRAY_DECLARE_TYPE(ucp_proto_ranges_t, unsigned, ucp_proto_perf_range_t);
 UCS_ARRAY_DECLARE_TYPE(ucp_proto_thresh_t, unsigned,
                        ucp_proto_threshold_elem_t);
@@ -210,7 +193,7 @@ out:
     return status;
 }
 
-static ucs_status_t
+ucs_status_t
 ucp_proto_select_init_protocols(ucp_worker_h worker,
                                 ucp_worker_cfg_index_t ep_cfg_index,
                                 ucp_worker_cfg_index_t rkey_cfg_index,
@@ -219,7 +202,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
 {
     ucp_proto_caps_t proto_caps = {};
     UCS_STRING_BUFFER_ONSTACK(strb, UCP_PROTO_CONFIG_STR_MAX);
-    void *proto_priv = ucs_alloca(UCP_PROTO_PRIV_MAX);
+    uint8_t proto_priv[UCP_PROTO_PRIV_MAX];
     ucp_proto_init_params_t init_params;
     ucs_status_t status;
     size_t priv_size;
@@ -314,7 +297,7 @@ void ucp_proto_select_caps_cleanup(ucp_proto_caps_t *caps)
     ucp_proto_select_caps_reset(caps);
 }
 
-static void
+void
 ucp_proto_select_cleanup_protocols(ucp_proto_select_init_protocols_t *proto_init)
 {
     ucp_proto_init_elem_t *init_elem;
@@ -754,6 +737,7 @@ void ucp_proto_select_add_proto(const ucp_proto_init_params_t *init_params,
     memset(init_elem, 0, sizeof(*init_elem));
     init_elem->proto_id        = proto_id;
     init_elem->priv_offset     = priv_offset;
+    init_elem->priv_size       = priv_size;
     init_elem->cfg_thresh      = cfg_thresh;
     init_elem->cfg_priority    = cfg_priority;
     init_elem->caps.min_length = proto_caps->min_length;

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -177,6 +177,18 @@ ucp_proto_select_lookup_slow(ucp_worker_h worker,
                              const ucp_proto_select_param_t *select_param);
 
 
+ucs_status_t
+ucp_proto_select_init_protocols(ucp_worker_h worker,
+                                ucp_worker_cfg_index_t ep_cfg_index,
+                                ucp_worker_cfg_index_t rkey_cfg_index,
+                                const ucp_proto_select_param_t *select_param,
+                                ucp_proto_select_init_protocols_t *proto_init);
+
+
+void ucp_proto_select_cleanup_protocols(
+        ucp_proto_select_init_protocols_t *proto_init);
+
+
 const ucp_proto_threshold_elem_t*
 ucp_proto_thresholds_search_slow(const ucp_proto_threshold_elem_t *thresholds,
                                  size_t msg_length);

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -23,6 +23,9 @@
 #define UCP_PROTO_RNDV_OP_ID_MASK \
     (UCS_BIT(UCP_OP_ID_RNDV_SEND) | UCS_BIT(UCP_OP_ID_RNDV_RECV))
 
+/* Varinants priv buffer are located right after the proto priv structure */
+#define UCP_PROTO_RNDV_GET_VARIANT_PRIV(_priv) \
+        UCS_PTR_BYTE_OFFSET(_priv, sizeof(*_priv))
 
 /**
  * Rendezvous protocol which sends a control message to the remote peer, and not
@@ -47,9 +50,9 @@ typedef struct {
     /* Lane for sending the "remote_op" message */
     ucp_lane_index_t        lane;
 
-    /* Which protocol the remote side is expected to use, for performance
-       estimation and reporting purpose */
-    ucp_proto_select_elem_t remote_proto;
+    /* Config of the remote protocol, which is expected to be selected by peer.
+       Used for performance estimation and reporting purpose */
+    ucp_proto_config_t      remote_proto_config;
 } ucp_proto_rndv_ctrl_priv_t;
 
 
@@ -117,18 +120,24 @@ size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params);
 ucs_status_t
 ucp_proto_rndv_ctrl_am_init(const ucp_proto_rndv_ctrl_init_params_t *params);
 
+void
+ucp_proto_rndv_ctrl_am_probe(const ucp_proto_rndv_ctrl_init_params_t *params);
 
-/* Initializes protocol which sends rendezvous control message using specified
- * lane. Can be used by tag matching offload rendezvous protocols, which use
- * tag lane for sending control messages. */
-ucs_status_t
-ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
-                         ucp_lane_index_t lane);
+void ucp_proto_rndv_rts_probe(const ucp_proto_init_params_t *init_params);
 
+void
+ucp_proto_rndv_set_variant_config(const ucp_proto_init_params_t *init_params,
+                                  const ucp_proto_init_elem_t *proto,
+                                  const ucp_proto_select_param_t *select_param,
+                                  ucp_proto_config_t *cfg);
 
-ucs_status_t
-ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params);
+void ucp_proto_rndv_ctrl_probe(const ucp_proto_rndv_ctrl_init_params_t *params,
+                               ucp_lane_index_t lane);
 
+void ucp_proto_rndv_variant_query(ucp_worker_h worker,
+                                  ucp_proto_config_t variant_config,
+                                  const void *variant_priv, size_t msg_length,
+                                  ucp_proto_query_attr_t *proto_attr);
 
 void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
                               ucp_proto_query_attr_t *attr);

--- a/src/ucp/rndv/rndv_ats.c
+++ b/src/ucp/rndv/rndv_ats.c
@@ -24,7 +24,7 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *init_params)
 
     *init_params->priv_size = sizeof(ucp_proto_rndv_ack_priv_t);
 
-    caps.cfg_thresh   = 0;
+    caps.cfg_thresh   = UCS_MEMUNITS_AUTO;
     caps.cfg_priority = 1;
     caps.min_length   = 0;
     caps.num_ranges   = 1;

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -149,8 +149,8 @@ ucp_proto_t ucp_tag_rndv_offload_proto = {
  * It can be used when real rndv offload is not supported (e.g. for non-contig
  * or very large messages) or when it is enabled by protocol selection.
  */
-static ucs_status_t
-ucp_tag_rndv_offload_sw_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_tag_rndv_offload_sw_proto_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_worker_h worker                      = init_params->worker;
     ucp_context_h context                    = worker->context;
@@ -190,11 +190,12 @@ ucp_tag_rndv_offload_sw_proto_init(const ucp_proto_init_params_t *init_params)
 
     if (!ucp_tag_rndv_check_op_id(init_params) ||
         !ucp_ep_config_key_has_tag_lane(init_params->ep_config_key)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_ctrl_init(&params,
-                                    init_params->ep_config_key->tag_lane);
+    *init_params->priv_size = sizeof(ucp_proto_rndv_ctrl_priv_t);
+
+    ucp_proto_rndv_ctrl_probe(&params, init_params->ep_config_key->tag_lane);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_offload_sw_proto_progress, (self),
@@ -229,7 +230,7 @@ ucp_proto_t ucp_tag_rndv_offload_sw_proto = {
     .name     = "tag/rndv/offload_sw",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_tag_rndv_offload_sw_proto_init,
+    .probe    = ucp_tag_rndv_offload_sw_proto_probe,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_tag_rndv_offload_sw_proto_progress},
     .abort    = ucp_proto_rndv_rts_abort,

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -153,21 +153,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
     return status;
 }
 
-ucs_status_t ucp_tag_rndv_rts_init(const ucp_proto_init_params_t *init_params)
+void ucp_tag_rndv_rts_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_tag_rndv_check_op_id(init_params) ||
         ucp_ep_config_key_has_tag_lane(init_params->ep_config_key)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_rts_init(init_params);
+    ucp_proto_rndv_rts_probe(init_params);
 }
 
 ucp_proto_t ucp_tag_rndv_proto = {
     .name     = "tag/rndv",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_tag_rndv_rts_init,
+    .probe    = ucp_tag_rndv_rts_probe,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_tag_rndv_rts_progress},
     .abort    = ucp_proto_rndv_rts_abort,

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -427,7 +427,7 @@ public:
         if (m_test_offload) {
             m_env.push_back(new ucs::scoped_setenv("UCX_RC_TM_ENABLE", "y"));
         }
-        m_min_rndv = 0;
+        m_tag_min_rndv = 0;
     }
 
     void init() {
@@ -439,8 +439,8 @@ public:
 
         if (m_test_offload) {
             ucp_ep_config_t *cfg = ucp_ep_config(sender().ep());
-            m_min_rndv = ucp_ep_tag_offload_min_rndv_thresh(sender().ucph(),
-                                                            &cfg->key);
+            m_tag_min_rndv = ucp_ep_tag_offload_min_rndv_thresh(sender().ucph(),
+                                                                &cfg->key);
         }
     }
 
@@ -454,7 +454,7 @@ public:
 
 protected:
     bool    m_test_offload;
-    size_t  m_min_rndv;
+    size_t  m_tag_min_rndv;
 
     static void check_short_thresh(const ucp_memtype_thresh_t &thresh,
                                    size_t cfg_thresh, bool strict = false)
@@ -484,8 +484,8 @@ protected:
         if (m_test_offload) {
             /* If configured threshold is less than min_rndv, then expect exact
              * min_rndv limit for short messages */
-            if (cfg_thresh < m_min_rndv) {
-                check_short_thresh(cfg->tag.offload.max_eager_short, m_min_rndv,
+            if (cfg_thresh < m_tag_min_rndv) {
+                check_short_thresh(cfg->tag.offload.max_eager_short, m_tag_min_rndv,
                                    true);
             } else {
                 check_short_thresh(cfg->tag.offload.max_eager_short, cfg_thresh);
@@ -503,26 +503,53 @@ protected:
         check_short_thresh(cfg->am_u.max_reply_eager_short, cfg_thresh);
     }
 
+
+    size_t get_initial_msg_length(ucp_proto_select_param_t select_param,
+                                  size_t cfg_thresh)
+    {
+        uint64_t tag_op_id_mask = UCS_BIT(UCP_OP_ID_TAG_SEND) |
+                                  UCS_BIT(UCP_OP_ID_TAG_SEND_SYNC);
+
+        if (ucp_proto_select_check_op(&select_param, tag_op_id_mask)) {
+            /* There is a lower bound for rndv threshold with tag offload.
+             * We should not send messages smaller than this limit */
+            return std::max(m_tag_min_rndv, cfg_thresh);
+        }
+        return cfg_thresh;
+    }
+
     void check_ep_proto_rndv_v2(size_t cfg_thresh, bool expect_rndv)
     {
         ucp_ep_config_t *cfg             = ucp_ep_config(sender().ep());
         ucp_proto_select_t *proto_select = &cfg->proto_select;
-        size_t msg_length                = cfg_thresh;
+        size_t msg_length;
+        ucp_proto_select_key_t select_key;
         ucp_proto_select_elem_t value;
 
-        if (m_test_offload) {
-            /* There is a lower bound for rndv threshold with tag offload.
-             * We should not send messages smaller than this limit */
-            msg_length = ucs_max(m_min_rndv, msg_length);
-        }
+        khint_t i = kh_begin(proto_select->hash);
+        for (; i != kh_end(proto_select->hash); ++i) {
+            if (!kh_exist(proto_select->hash, i)) {
+                continue;
+            }
 
-        kh_foreach_value(proto_select->hash, value, {
             /* Find index of the corresponding ucp_proto_threshold_elem_t
              * to handle the given message size */
-            unsigned idx = 0;
+            unsigned idx   = 0;
+            value          = kh_val(proto_select->hash,i);
+            select_key.u64 = kh_key(proto_select->hash, i);
+            msg_length     = get_initial_msg_length(select_key.param,
+                                                    cfg_thresh);
             const ucp_proto_config_t *proto_config;
+
             for (; msg_length > value.thresholds[idx].max_msg_length; ++idx) {
                 proto_config = &value.thresholds[idx].proto_config;
+                /* Skip check that rndv is disabled for tag offload use case.
+                 * With tag offload rndv protocol might still be used for large
+                 * messages, because of HWTM limitation for eager transfers. */
+                if((m_test_offload) &&
+                   (value.thresholds[idx].max_msg_length >= m_tag_min_rndv)) {
+                    continue;
+                }
                 /* Assert no rndv before expected limit */
                 EXPECT_EQ(nullptr, strstr(proto_config->proto->name, "rndv"));
             }
@@ -532,13 +559,11 @@ protected:
                 EXPECT_EQ(proto_config->cfg_thresh, cfg_thresh);
                 EXPECT_NE(nullptr, strstr(proto_config->proto->name, "rndv"));
             } else if (!m_test_offload) {
-                /* Skip check that rndv is disabled for tag offload use case.
-                 * With tag offload rndv protocol might still be used for large
-                 * messages, because of HWTM limitation for eager transfers. */
+                /*Skip offload because of HWTM limitation for eager transfers.*/
                 EXPECT_NE(proto_config->cfg_thresh, cfg_thresh);
                 EXPECT_EQ(nullptr, strstr(proto_config->proto->name, "rndv"));
             }
-        });
+        }
     }
 
     void check_rndv_threshold(size_t cfg_thresh)


### PR DESCRIPTION
## What
Represent each possible RNDV proto that can be chosen after CTRL message as a separate variant.

## Why ?
That's the first step of MULTI performance estimation rework. The main reason of that patch is that we need to add CTRL msg perf to remote proto perf before selection the best one.

## How ?
The implementation part that worth noting is that remote variant `priv` which is required for `query` and `progress` calls is copied after the CTRL message priv buffer. `remote_proto_config::priv` cannot be filled during initialization, since both CTRL and remote variant `priv` buffers will be copied out during `ucp_proto_select_add_proto`.

There is another patch (https://github.com/openucx/ucx/pull/9728) that does the same change, but store all the initialization proto info inside `ucp_proto_select_elem_t` so it make it possible to assign variant config priv pointers during initialization. I created both of them to show difference between two approaches.