### PR TITLE
UCT/CUDA: Return unreachable from rkey unpack in case of error - v1.16.x

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -209,8 +209,12 @@ static ucs_status_t uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *md
      * stream sequentialization */
     rkey->dev_num = peer_idx;
 
-    UCT_CUDA_IPC_GET_DEVICE(this_device);
     UCT_CUDA_IPC_DEVICE_GET_COUNT(num_devices);
+    if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&this_device)) != UCS_OK) {
+        status = UCS_ERR_UNREACHABLE;
+        goto err;
+    }
+
 
     accessible = &mdc->md->peer_accessible_cache[peer_idx * num_devices + this_device];
     if (*accessible == UCS_TRY) { /* unchecked, add to cache */


### PR DESCRIPTION
## What
Always return unreachable from `uct_cuda_ipc_rkey_unpack` to ignore cuda IPC key when it can't be used (e.g. cuda device is not set for this process)
