### PR TITLE
UCP: Fix rndv ppln protocols selection - v1.16.x

### DIFF
--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -59,7 +59,8 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
     if ((select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         !ucp_proto_init_check_op(init_params, UCP_PROTO_RNDV_OP_ID_MASK) ||
         !ucp_proto_common_init_check_err_handling(&err_params) ||
-        ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
+        ucp_proto_rndv_init_params_is_ppln_frag(init_params) ||
+        (init_params->rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL)) {
         return UCS_ERR_UNSUPPORTED;
     }
 


### PR DESCRIPTION
## What
Do not select pipeline rndv protocols when sender buffer is not contig (in this case address is zero in RTS header)
