### PR TITLE
UCM/BISTRO: Add empty locking step while patching on PPC64 - v1.16.x

### DIFF
--- a/src/ucm/bistro/bistro.c
+++ b/src/ucm/bistro/bistro.c
@@ -55,12 +55,13 @@ void ucm_bistro_modify_code(void *dst, const ucm_bistro_lock_t *bytes)
     uint32_t value32;
 
     UCS_STATIC_ASSERT((sizeof(*bytes) == sizeof(value16)) ||
-                      (sizeof(*bytes) == sizeof(value32)));
+                      (sizeof(*bytes) == sizeof(value32)) ||
+                      (sizeof(*bytes) == 0));
 
     if (sizeof(*bytes) == sizeof(value16)) {
         memcpy(&value16, bytes, sizeof(value16));
         (void)ucs_atomic_swap16(dst, value16);
-    } else {
+    } else if (sizeof(*bytes) == sizeof(value32)) {
         memcpy(&value32, bytes, sizeof(value32));
         (void)ucs_atomic_swap32(dst, value32);
     }

--- a/src/ucm/bistro/bistro_ppc64.h
+++ b/src/ucm/bistro/bistro_ppc64.h
@@ -41,6 +41,14 @@ ucs_status_t ucm_bistro_patch_toc(void *func_ptr, void *hook,
                                   ucm_bistro_restore_point_t **rp,
                                   uint64_t toc);
 
+/* Empty lock implementation */
+typedef struct {
+} UCS_S_PACKED ucm_bistro_lock_t;
+
+static inline void ucm_bistro_patch_lock(void * UCS_V_UNUSED dst)
+{
+}
+
 static inline ucs_status_t
 ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
                  void **orig_func_p, ucm_bistro_restore_point_t **rp)


### PR DESCRIPTION
## What
Backport #9726.