### PR TITLE
UCP/PROTO: Select RNDV lanes according to rma_bw_lanes order

### DIFF
--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -246,6 +246,7 @@ ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
                             ucp_lane_type_t lane_type, uint64_t tl_cap_flags,
                             ucp_lane_index_t max_lanes,
+                            const ucp_lane_index_t *lanes_order,
                             ucp_lane_map_t exclude_map,
                             ucp_lane_index_t *lanes);
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -30,7 +30,7 @@ ucp_proto_single_init_priv(const ucp_proto_single_init_params_t *params,
     ucs_status_t status;
 
     num_lanes = ucp_proto_common_find_lanes(&params->super, params->lane_type,
-                                            params->tl_cap_flags, 1,
+                                            params->tl_cap_flags, 1, NULL,
                                             params->super.exclude_map, &lane);
     if (num_lanes == 0) {
         ucs_trace("no lanes for %s", params->super.super.proto_name);


### PR DESCRIPTION
## What
Protov2 RNDV operations start to choose the lanes according to `rma_bw_lanes` order.

## Why ?
`ep_config_key->lanes` aren't ordered by bandwidth so RNDV protocols can choose suboptimal lanes for RDMA operations. protov1 respects the rma-bw scoring during lanes selection, so this inconsistency can cause performance degradation in comparison with protov1.