### PR TITLE
Fixes for CI failures on BF3 test nodes

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -41,7 +41,7 @@ else
 	echo "Running under jenkins"
 	WS_URL=$JOB_URL/ws
 	if [[ "$VALGRIND_CHECK" == "yes" ]]; then
-		TIMEOUT="timeout 240m"
+		TIMEOUT="timeout 300m"
 	else
 		TIMEOUT="timeout 200m"
 	fi

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -743,6 +743,14 @@ static const ucs_topo_pci_info_t ucs_topo_pci_info[] = {
      .ctrl_overhead = 16,
      .encoding      = 128,
      .decoding      = 130},
+    {.name          = "gen5",
+     .bw_gbps       = 32,
+     .payload       = 256,
+     .tlp_overhead  = 26,
+     .ctrl_ratio    = 4,
+     .ctrl_overhead = 16,
+     .encoding      = 128,
+     .decoding      = 130},
 };
 
 double ucs_topo_get_pci_bw(const char *dev_name, const char *sysfs_path)

--- a/src/uct/ib/rc/accel/gga_mlx5.c
+++ b/src/uct/ib/rc/accel/gga_mlx5.c
@@ -65,6 +65,8 @@ uct_gga_mlx5_query_tl_devices(uct_md_h md,
                               unsigned *num_tl_devices_p)
 {
     uct_ib_mlx5_md_t *mlx5_md = ucs_derived_of(md, uct_ib_mlx5_md_t);
+    uct_tl_device_resource_t *tl_devices;
+    unsigned num_tl_devices;
     ucs_status_t status;
 
     if (strcmp(mlx5_md->super.name, UCT_IB_MD_NAME(mlx5)) ||
@@ -75,13 +77,14 @@ uct_gga_mlx5_query_tl_devices(uct_md_h md,
     }
 
     status = uct_ib_device_query_ports(&mlx5_md->super.dev,
-                                       UCT_IB_DEVICE_FLAG_MLX5_PRM, tl_devices_p,
-                                       num_tl_devices_p);
+                                       UCT_IB_DEVICE_FLAG_MLX5_PRM, &tl_devices,
+                                       &num_tl_devices);
     if (status != UCS_OK) {
         return status;
     }
 
     /* TODO: del to enable GGA in UCP */
+    ucs_free(tl_devices);
     return UCS_ERR_NO_DEVICE;
 }
 


### PR DESCRIPTION
## Why
Fix the following failures on BF3 machines:
1.
```
[ RUN      ] all/test_pci_bw.get_pci_bw/0 <all/tag>
/.autodirect/rdmzsysgwork/yosefe/ucx/contrib/../test/gtest/ucp/test_ucp_worker.cc:923: Failure
Expected: (pci_bw) < (std::numeric_limits<double>::max()), actual: 1.79769e+308 vs 1.79769e+308
[  FAILED  ] all/test_pci_bw.get_pci_bw/0, where GetParam() = all/tag (348 ms)
[----------] 1 test from all/test_pci_bw (348 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (349 ms total)
[  PASSED  ] 0 tests.
```

2. (Valgrind) memory leak in GGA transport