### PR TITLE
UCP/PROTO: Local lanes distance FP8 pack/unpack

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -124,6 +124,14 @@ ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
     return params->worker->context->tl_rscs[rsc_index].tl_rsc.sys_device;
 }
 
+/* Pack/unpack local distance to make it equal to the remote one */
+static void
+ucp_proto_common_fp8_pack_unpack_distance(ucs_sys_dev_distance_t *distance)
+{
+    distance->latency   = UCS_FP8_PACK_UNPACK(LATENCY, distance->latency);
+    distance->bandwidth = UCS_FP8_PACK_UNPACK(BANDWIDTH, distance->bandwidth);
+}
+
 void ucp_proto_common_get_lane_distance(const ucp_proto_init_params_t *params,
                                         ucp_lane_index_t lane,
                                         ucs_sys_device_t sys_dev,
@@ -143,6 +151,8 @@ void ucp_proto_common_get_lane_distance(const ucp_proto_init_params_t *params,
     status     = ucs_topo_get_distance(sys_dev, tl_sys_dev, distance);
     ucs_assertv_always(status == UCS_OK, "sys_dev=%d tl_sys_dev=%d", sys_dev,
                        tl_sys_dev);
+
+    ucp_proto_common_fp8_pack_unpack_distance(distance);
 }
 
 const uct_iface_attr_t *

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -649,18 +649,6 @@ out:
     return UCS_OK;
 }
 
-static double ucp_wireup_fp8_pack_unpack_latency(double latency)
-{
-    ucs_fp8_t packed_lat = UCS_FP8_PACK(LATENCY, latency * UCS_NSEC_PER_SEC);
-    return UCS_FP8_UNPACK(LATENCY, packed_lat) / UCS_NSEC_PER_SEC;
-}
-
-static double ucp_wireup_fp8_pack_unpack_bw(double bandwidth)
-{
-    ucs_fp8_t packed_bw = UCS_FP8_PACK(BANDWIDTH, bandwidth);
-    return UCS_FP8_UNPACK(BANDWIDTH, packed_bw);
-}
-
 static inline double
 ucp_wireup_tl_iface_latency(const ucp_worker_iface_t *wiface,
                             const ucp_unpacked_address_t *unpacked_addr,
@@ -678,7 +666,7 @@ ucp_wireup_tl_iface_latency(const ucp_worker_iface_t *wiface,
         local_lat = ucp_wireup_iface_lat_distance_v2(wiface);
         /* FP8 is a lossy compression method, so in order to create a symmetric
          * calculation we pack/unpack the local latency as well */
-        lat_lossy = ucp_wireup_fp8_pack_unpack_latency(local_lat);
+        lat_lossy = UCS_FP8_PACK_UNPACK(LATENCY, local_lat) / UCS_NSEC_PER_SEC;
 
         return (remote_iface_attr->lat_ovh + lat_lossy) / 2;
     }
@@ -1264,7 +1252,7 @@ ucp_wireup_iface_avail_bandwidth(const ucp_worker_iface_t *wiface,
     if (unpacked_addr->addr_version == UCP_OBJECT_VERSION_V2) {
         /* FP8 is a lossy compression method, so in order to create a symmetric
          * calculation we pack/unpack the local bandwidth as well */
-        local_bw = ucp_wireup_fp8_pack_unpack_bw(local_bw);
+        local_bw = UCS_FP8_PACK_UNPACK(BANDWIDTH, local_bw);
     }
 
     /* Apply dev num paths ratio after fp8 pack/unpack to make sure it is not
@@ -1488,7 +1476,7 @@ static double ucp_wireup_get_lane_bw(ucp_worker_h worker,
     if (address->addr_version == UCP_OBJECT_VERSION_V2) {
         /* FP8 is a lossy compression method, so in order to create a symmetric
          * calculation we pack/unpack the local bandwidth as well */
-        bw_local = ucp_wireup_fp8_pack_unpack_bw(bw_local);
+        bw_local = UCS_FP8_PACK_UNPACK(BANDWIDTH, bw_local);
     }
 
     return ucs_min(bw_local, bw_remote);

--- a/src/ucs/type/float8.h
+++ b/src/ucs/type/float8.h
@@ -236,6 +236,21 @@ ucs_fp8_unpack(ucs_fp8_t value, uint64_t min, uint64_t max)
     _UCS_FP8_IDENTIFIER(_name, _unpack)(_value)
 
 
+/**
+ * Pack a double-precision floating-point number of a given type to a single
+ * byte and then unpack it. Can be useful for simulating the loss of precision
+ * when comparing with an unpacked value.
+ *
+ * @param _name  Packed type name
+ * @param _value Convert this number
+ *
+ * @return A double-precision floating-point number which approximates the
+ *         original value
+ */
+#define UCS_FP8_PACK_UNPACK(_name, _value) \
+    UCS_FP8_UNPACK(_name, UCS_FP8_PACK(_name, _value))
+
+
 END_C_DECLS
 
 #endif

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -110,35 +110,32 @@ UCS_TEST_F(test_type, pack_float) {
     float unpacked;
 
     /* 0 -> 0 */
-    unpacked = UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, 0));
+    unpacked = UCS_FP8_PACK_UNPACK(TEST_LATENCY, 0);
     EXPECT_EQ(unpacked, 0);
 
     /* NaN -> NaN */
-    unpacked = UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, NAN));
+    unpacked = UCS_FP8_PACK_UNPACK(TEST_LATENCY, NAN);
     EXPECT_TRUE(isnan(unpacked));
 
     /* Below min -> min */
     for (uint64_t min_val = UCS_BIT(0); min_val <= UCS_BIT(7); min_val <<= 1) {
         UCS_TEST_MESSAGE << " Pack/unpack " << min_val;
         EXPECT_EQ(
-         UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, UCS_BIT(7))),
-         UCS_FP8_UNPACK(TEST_LATENCY, UCS_FP8_PACK(TEST_LATENCY, min_val)));
+         UCS_FP8_PACK_UNPACK(TEST_LATENCY, UCS_BIT(7)),
+         UCS_FP8_PACK_UNPACK(TEST_LATENCY, min_val));
     }
 
     /* Precision test throughout the whole range */
     for (std::vector<double>::const_iterator it = values.begin();
          it < values.end(); it++) {
-        unpacked = UCS_FP8_UNPACK(TEST_LATENCY,
-                                  UCS_FP8_PACK(TEST_LATENCY, *it));
+        unpacked = UCS_FP8_PACK_UNPACK(TEST_LATENCY, *it);
         ucs_assert((UCS_FP8_PRECISION < unpacked / *it) &&
                    (unpacked / *it <= 1));
     }
 
     /* Above max -> max */
-    EXPECT_EQ(UCS_FP8_UNPACK(TEST_LATENCY,
-                             UCS_FP8_PACK(TEST_LATENCY, UCS_BIT(20))),
-              UCS_FP8_UNPACK(TEST_LATENCY,
-                             UCS_FP8_PACK(TEST_LATENCY, 200000000)));
+    EXPECT_EQ(UCS_FP8_PACK_UNPACK(TEST_LATENCY, UCS_BIT(20)),
+              UCS_FP8_PACK_UNPACK(TEST_LATENCY, 200000000));
 }
 
 class test_init_once: public test_type {


### PR DESCRIPTION
## What
Do FP8 pack/unpack operations for local lane distance

## Why ?
To remove inconsistency with remote distance which always came to comparison after packing/unpacking.
