### PR TITLE
UCS/CONFIG: Filtered out sections from config by platform info.

### DIFF
--- a/src/tools/info/sys_info.c
+++ b/src/tools/info/sys_info.c
@@ -22,42 +22,6 @@
 #include <string.h>
 
 
-static const char *cpu_model_names[] = {
-    [UCS_CPU_MODEL_UNKNOWN]            = "unknown",
-    [UCS_CPU_MODEL_INTEL_IVYBRIDGE]    = "IvyBridge",
-    [UCS_CPU_MODEL_INTEL_SANDYBRIDGE]  = "SandyBridge",
-    [UCS_CPU_MODEL_INTEL_NEHALEM]      = "Nehalem",
-    [UCS_CPU_MODEL_INTEL_WESTMERE]     = "Westmere",
-    [UCS_CPU_MODEL_INTEL_HASWELL]      = "Haswell",
-    [UCS_CPU_MODEL_INTEL_BROADWELL]    = "Broadwell",
-    [UCS_CPU_MODEL_INTEL_SKYLAKE]      = "Skylake",
-    [UCS_CPU_MODEL_INTEL_ICELAKE]      = "Icelake",
-    [UCS_CPU_MODEL_ARM_AARCH64]        = "ARM 64-bit",
-    [UCS_CPU_MODEL_AMD_NAPLES]         = "Naples",
-    [UCS_CPU_MODEL_AMD_ROME]           = "Rome",
-    [UCS_CPU_MODEL_AMD_MILAN]          = "Milan",
-    [UCS_CPU_MODEL_AMD_GENOA]          = "Genoa",
-    [UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG] = "Zhangjiang",
-    [UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU]   = "Wudaokou",
-    [UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI]   = "Lujiazui",
-    [UCS_CPU_MODEL_RV64G]              = "RV64G",
-    [UCS_CPU_MODEL_NVIDIA_GRACE]       = "Grace"
-};
-
-
-
-static const char* cpu_vendor_names[] = {
-    [UCS_CPU_VENDOR_UNKNOWN]          = "unknown",
-    [UCS_CPU_VENDOR_INTEL]            = "Intel",
-    [UCS_CPU_VENDOR_AMD]              = "AMD",
-    [UCS_CPU_VENDOR_GENERIC_ARM]      = "Generic ARM",
-    [UCS_CPU_VENDOR_GENERIC_PPC]      = "Generic PPC",
-    [UCS_CPU_VENDOR_GENERIC_RV64G]    = "Generic RV64G",
-    [UCS_CPU_VENDOR_FUJITSU_ARM]      = "Fujitsu ARM",
-    [UCS_CPU_VENDOR_ZHAOXIN]          = "Zhaoxin",
-    [UCS_CPU_VENDOR_NVIDIA]           = "Nvidia"
-};
-
 static double measure_memcpy_bandwidth(size_t size)
 {
     ucs_time_t start_time, end_time;
@@ -248,9 +212,10 @@ void print_sys_info(int print_opts)
         printf("# Timer frequency: %.3f MHz\n",
                ucs_get_cpu_clocks_per_sec() / 1e6);
         printf("# Timer accuracy: %.3f %%\n", measure_timer_accuracy() * 100);
-        printf("# CPU vendor: %s\n",
-               cpu_vendor_names[ucs_arch_get_cpu_vendor()]);
-        printf("# CPU model: %s\n", cpu_model_names[ucs_arch_get_cpu_model()]);
+        printf("# %s: %s\n", UCS_CPU_VENDOR_LABEL, ucs_cpu_vendor_name());
+        printf("# %s: %s\n", UCS_CPU_MODEL_LABEL, ucs_cpu_model_name());
+        printf("# %s: %s\n", UCS_SYS_DMI_PRODUCT_NAME_LABEL,
+               ucs_sys_dmi_product_name());
     }
 
     if (print_opts & PRINT_SYS_TOPO) {

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -173,3 +173,47 @@ double ucs_cpu_get_memcpy_bw()
 {
     return ucs_cpu_est_bcopy_bw[ucs_arch_get_cpu_vendor()];
 }
+
+const char *ucs_cpu_vendor_name()
+{
+    static const char *cpu_vendor_names[] = {
+        [UCS_CPU_VENDOR_UNKNOWN]       = UCS_VALUE_UNKNOWN_STR,
+        [UCS_CPU_VENDOR_INTEL]         = "Intel",
+        [UCS_CPU_VENDOR_AMD]           = "AMD",
+        [UCS_CPU_VENDOR_GENERIC_ARM]   = "Generic ARM",
+        [UCS_CPU_VENDOR_GENERIC_PPC]   = "Generic PPC",
+        [UCS_CPU_VENDOR_GENERIC_RV64G] = "Generic RV64G",
+        [UCS_CPU_VENDOR_FUJITSU_ARM]   = "Fujitsu ARM",
+        [UCS_CPU_VENDOR_ZHAOXIN]       = "Zhaoxin",
+        [UCS_CPU_VENDOR_NVIDIA]        = "Nvidia"
+    };
+
+    return cpu_vendor_names[ucs_arch_get_cpu_vendor()];
+}
+
+const char *ucs_cpu_model_name()
+{
+    static const char *cpu_model_names[] = {
+        [UCS_CPU_MODEL_UNKNOWN]            = UCS_VALUE_UNKNOWN_STR,
+        [UCS_CPU_MODEL_INTEL_IVYBRIDGE]    = "IvyBridge",
+        [UCS_CPU_MODEL_INTEL_SANDYBRIDGE]  = "SandyBridge",
+        [UCS_CPU_MODEL_INTEL_NEHALEM]      = "Nehalem",
+        [UCS_CPU_MODEL_INTEL_WESTMERE]     = "Westmere",
+        [UCS_CPU_MODEL_INTEL_HASWELL]      = "Haswell",
+        [UCS_CPU_MODEL_INTEL_BROADWELL]    = "Broadwell",
+        [UCS_CPU_MODEL_INTEL_SKYLAKE]      = "Skylake",
+        [UCS_CPU_MODEL_INTEL_ICELAKE]      = "Icelake",
+        [UCS_CPU_MODEL_ARM_AARCH64]        = "ARM 64-bit",
+        [UCS_CPU_MODEL_AMD_NAPLES]         = "Naples",
+        [UCS_CPU_MODEL_AMD_ROME]           = "Rome",
+        [UCS_CPU_MODEL_AMD_MILAN]          = "Milan",
+        [UCS_CPU_MODEL_AMD_GENOA]          = "Genoa",
+        [UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG] = "Zhangjiang",
+        [UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU]   = "Wudaokou",
+        [UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI]   = "Lujiazui",
+        [UCS_CPU_MODEL_RV64G]              = "RV64G",
+        [UCS_CPU_MODEL_NVIDIA_GRACE]       = "Grace"
+    };
+
+    return cpu_model_names[ucs_arch_get_cpu_model()];
+}

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -178,6 +178,13 @@ static inline int ucs_cpu_prefer_relaxed_order()
 #define UCS_CPU_EST_BCOPY_BW_FUJITSU_ARM (12000 * UCS_MBYTE)
 
 
+#define UCS_CPU_VENDOR_LABEL "CPU vendor"
+#define UCS_CPU_MODEL_LABEL  "CPU model"
+
+
+const char *ucs_cpu_vendor_name();
+const char *ucs_cpu_model_name();
+
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -37,6 +37,9 @@ BEGIN_C_DECLS
 #define UCS_HEXUNITS_AUTO   ((uint16_t)-2)
 
 
+#define UCS_VALUE_UNKNOWN_STR "unknown"
+
+
 /**
  * Expand a partial path to full path.
  *

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -48,6 +48,7 @@
 #define UCS_PROCCESS_STAT_FMT      "/proc/%d/stat"
 #define UCS_PROCESS_NS_FIRST       0xF0000000U
 #define UCS_PROCESS_NS_NET_DFLT    0xF0000080U
+#define UCS_DMI_PRODUCT_NAME_FILE  "/sys/devices/virtual/dmi/id/product_name"
 
 #define UCS_NS_INFO_ITEM(_id, _name, _dflt) \
     [_id] = {.name = (_name), .dflt = (_dflt), .value = (_dflt), \
@@ -1647,4 +1648,24 @@ ucs_status_t ucs_sys_read_sysfs_file(const char *dev_name,
     }
 
     return UCS_OK;
+}
+
+const char *ucs_sys_dmi_product_name()
+{
+    static ucs_init_once_t init_once = UCS_INIT_ONCE_INITIALIZER;
+    static char product_name[128];
+    ssize_t nread;
+
+    UCS_INIT_ONCE(&init_once) {
+        nread = ucs_read_file_str(product_name, sizeof(product_name), 1,
+                                  UCS_DMI_PRODUCT_NAME_FILE);
+        if (nread >= 0) {
+            ucs_strtrim(product_name);
+        } else {
+            ucs_strncpy_zero(product_name, UCS_VALUE_UNKNOWN_STR,
+                             sizeof(product_name));
+        }
+    }
+
+    return product_name;
 }

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -67,6 +67,9 @@ typedef cpuset_t ucs_sys_cpuset_t;
 #define UCS_SYS_FS_CPUS_PATH   UCS_SYS_FS_SYSTEM_PATH "/cpu"
 
 
+#define UCS_SYS_DMI_PRODUCT_NAME_LABEL "Product name"
+
+
 BEGIN_C_DECLS
 
 /** @file sys.h */
@@ -689,6 +692,12 @@ ucs_status_t ucs_sys_get_effective_memlock_rlimit(size_t *rlimit_value);
  * @return 1 if built dynamically, 0 if statically.
  */
 int ucs_sys_is_dynamic_lib(void);
+
+
+/**
+ * @return Product name from DMI table.
+ */
+const char *ucs_sys_dmi_product_name();
 
 END_C_DECLS
 

--- a/test/gtest/ucs/ucx_test.conf
+++ b/test/gtest/ucs/ucx_test.conf
@@ -1,3 +1,23 @@
 UCX_PRICE=200
 UCX_BRAND=Mazda
+
+[section to use]
 UCX_TEMP=10,front:15
+
+[section to skip 1]
+CPU vendor=Invalid CPU vendor name
+CPU model=*
+Product name=*
+UCX_PRICE=300
+
+[section to skip 2]
+CPU vendor=*
+CPU model=Invalid CPU model name
+Product name=*
+UCX_BRAND=Ford
+
+[section to skip 3]
+CPU vendor=*
+CPU model=*
+Product name=Invalid Product name
+UCX_TEMP=100


### PR DESCRIPTION
## What
Added "Product name" to the output of `ucx_info -s`.
Added ability to skip sections of config file, if it is filtered out by "CPU vendor", "CPU model", or "Product name".