### PR TITLE
UCT/UCP: UMR approach for XGVMI

### DIFF
--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -478,6 +478,14 @@ static inline ucs_status_t uct_ib_poll_cq(struct ibv_cq *cq, unsigned *count, st
     return UCS_OK;
 }
 
+static inline void uct_ib_destroy_cq(struct ibv_cq *cq, const char *desc)
+{
+    int ret = ibv_destroy_cq(cq);
+    if (ret != 0) {
+        ucs_warn("ibv_destroy_cq(%s) failed with error %d: %m", desc, ret);
+    }
+}
+
 void uct_ib_handle_async_event(uct_ib_device_t *dev, uct_ib_async_event_t *event);
 
 #endif

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1167,11 +1167,7 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
 
 void uct_ib_verbs_destroy_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir)
 {
-    int ret = ibv_destroy_cq(iface->cq[dir]);
-    if (ret != 0) {
-        ucs_warn("ibv_destroy_cq(%s) returned %d: %m",
-                 (dir == UCT_IB_DIR_RX) ? "RX" : "TX", ret);
-    }
+    uct_ib_destroy_cq(iface->cq[dir], (dir == UCT_IB_DIR_RX) ? "RX" : "TX");
 }
 
 static unsigned uct_ib_iface_roce_lag_level(uct_ib_iface_t *iface)

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -395,8 +395,8 @@ uct_ib_md_mlx5_devx_mr_lru_push(uct_ib_mlx5_md_t *md, uint32_t rkey, void *mr)
               kh_size(&md->lru_rkeys.hash), rkey, mr);
 
     if ((++md->lru_rkeys.count % md->super.config.max_idle_rkey_count) == 0) {
-        /* modulo prime number to avoid resonance with mkey */
-        md->mkey_tag = (md->mkey_tag + 1) % 251;
+        /* Increment mkey tag in order to mitigate the rkey collision risk */
+        md->mkey_tag = (md->mkey_tag + 1) % UCT_IB_MLX5_MKEY_TAG_MAX;
     }
 
     return UCS_OK;
@@ -895,6 +895,508 @@ uct_ib_mlx5_devx_dereg_keys(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh)
     return UCS_OK;
 }
 
+static ucs_status_t uct_ib_mlx5_devx_umr_create_cq(uct_ib_mlx5_md_t *md)
+{
+    md->umr.cq = ibv_create_cq(md->super.dev.ibv_context, 1, NULL, NULL, 0);
+    if (NULL == md->umr.cq) {
+        ucs_error("%s: ibv_create_cq() failed to create UMR CQ: %m",
+                  uct_ib_mlx5_dev_name(md));
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ucs_trace("%s: created UMR CQ %p", uct_ib_mlx5_dev_name(md), md->umr.cq);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_ib_mlx5_devx_umr_create_qp(uct_ib_mlx5_md_t *md)
+{
+    struct mlx5dv_qp_init_attr mlx5_qp_attr = {};
+    struct ibv_qp_init_attr_ex qp_attr_ex   = {};
+
+    qp_attr_ex.send_cq             = md->umr.cq;
+    qp_attr_ex.recv_cq             = md->umr.cq;
+    qp_attr_ex.srq                 = NULL;
+    qp_attr_ex.cap.max_send_wr     = 1;
+    qp_attr_ex.cap.max_recv_wr     = 1;
+    qp_attr_ex.cap.max_send_sge    = 1;
+    qp_attr_ex.cap.max_recv_sge    = 1;
+    qp_attr_ex.cap.max_inline_data = sizeof(struct mlx5_wqe_umr_klm_seg);
+    qp_attr_ex.qp_type             = IBV_QPT_RC;
+    qp_attr_ex.comp_mask           = IBV_QP_INIT_ATTR_SEND_OPS_FLAGS |
+                                     IBV_QP_INIT_ATTR_PD;
+    qp_attr_ex.pd                  = md->super.pd;
+    qp_attr_ex.send_ops_flags      = IBV_QP_EX_WITH_SEND;
+
+    mlx5_qp_attr.comp_mask         = MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS;
+    mlx5_qp_attr.send_ops_flags    = MLX5DV_QP_EX_WITH_MR_LIST |
+                                     MLX5DV_QP_EX_WITH_MR_INTERLEAVED;
+
+    md->umr.qp = mlx5dv_create_qp(md->super.dev.ibv_context, &qp_attr_ex,
+                                  &mlx5_qp_attr);
+    if (NULL == md->umr.qp) {
+        ucs_error("%s: mlx5dv_create_qp() failed to create UMR QP: %m",
+                  uct_ib_mlx5_dev_name(md));
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ucs_trace("%s: created UMR QP QPN 0x%x", uct_ib_mlx5_dev_name(md),
+              md->umr.qp->qp_num);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_ib_mlx5_devx_umr_modify_qp(uct_ib_mlx5_md_t *md)
+{
+    uct_ib_device_t *ibdev     = &md->super.dev;
+    struct ibv_qp_attr qp_attr = {};
+    uint8_t port_num;
+    struct ibv_port_attr *port_attr;
+    int attr_mask;
+    int ret;
+
+    port_num  = ibdev->first_port;
+    port_attr = uct_ib_device_port_attr(ibdev, port_num);
+
+    /* Modify QP to INIT state */
+    attr_mask               = IBV_QP_STATE |
+                              IBV_QP_PKEY_INDEX |
+                              IBV_QP_PORT |
+                              IBV_QP_ACCESS_FLAGS;
+    qp_attr.qp_state        = IBV_QPS_INIT;
+    qp_attr.pkey_index      = 0;
+    qp_attr.port_num        = port_num;
+    qp_attr.qp_access_flags = UCT_IB_MEM_ACCESS_FLAGS;
+
+    ret = ibv_modify_qp(md->umr.qp, &qp_attr, attr_mask);
+    if (ret) {
+        ucs_error("%s: ibv_modify_qp(UMR QP 0x%x) failed to modify to INIT: %m",
+                  uct_ib_device_name(ibdev), md->umr.qp->qp_num);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    /* Modify to RTR */
+    attr_mask                  = IBV_QP_STATE |
+                                 IBV_QP_DEST_QPN |
+                                 IBV_QP_PATH_MTU |
+                                 IBV_QP_RQ_PSN |
+                                 IBV_QP_MIN_RNR_TIMER |
+                                 IBV_QP_MAX_DEST_RD_ATOMIC |
+                                 IBV_QP_AV;
+    qp_attr.qp_state           = IBV_QPS_RTR;
+    qp_attr.dest_qp_num        = md->umr.qp->qp_num;
+    qp_attr.path_mtu           = IBV_MTU_512;
+    qp_attr.rq_psn             = 0;
+    qp_attr.min_rnr_timer      = 7;
+    qp_attr.max_dest_rd_atomic = 1;
+    qp_attr.ah_attr.port_num   = port_num;
+    qp_attr.ah_attr.dlid       = port_attr->lid;
+    qp_attr.ah_attr.is_global  = 1;
+
+    if (UCS_OK != uct_ib_device_query_gid(ibdev, port_num,
+                                          UCT_IB_DEVICE_DEFAULT_GID_INDEX,
+                                          &qp_attr.ah_attr.grh.dgid,
+                                          UCS_LOG_LEVEL_ERROR)) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ret = ibv_modify_qp(md->umr.qp, &qp_attr, attr_mask);
+    if (ret) {
+        ucs_error("%s: ibv_modify_qp(UMR QP 0x%x) failed to modify to RTR: %m",
+                  uct_ib_device_name(ibdev), md->umr.qp->qp_num);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    /* Modify to RTS */
+    attr_mask             = IBV_QP_STATE |
+                            IBV_QP_SQ_PSN |
+                            IBV_QP_TIMEOUT |
+                            IBV_QP_RNR_RETRY |
+                            IBV_QP_RETRY_CNT |
+                            IBV_QP_MAX_QP_RD_ATOMIC;
+    qp_attr.qp_state      = IBV_QPS_RTS;
+    qp_attr.sq_psn        = 0;
+    qp_attr.timeout       = 7;
+    qp_attr.rnr_retry     = 7;
+    qp_attr.retry_cnt     = 7;
+    qp_attr.max_rd_atomic = 1;
+
+    ret = ibv_modify_qp(md->umr.qp, &qp_attr, attr_mask);
+    if (ret) {
+        ucs_error("%s: ibv_modify_qp(UMR QP 0x%x) failed to modify to RTS: %m",
+                  uct_ib_device_name(ibdev), md->umr.qp->qp_num);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ucs_trace("%s: initialized UMR QP 0x%x", uct_ib_device_name(ibdev),
+              md->umr.qp->qp_num);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_ib_mlx5_devx_umr_init_export(uct_ib_mlx5_md_t *md)
+{
+    ucs_status_t status;
+
+    status = uct_ib_mlx5_devx_umr_create_cq(md);
+    if (UCS_OK != status) {
+        goto err;
+    }
+
+    status = uct_ib_mlx5_devx_umr_create_qp(md);
+    if (UCS_OK != status) {
+        goto err_destroy_cq;
+    }
+
+    status = uct_ib_mlx5_devx_umr_modify_qp(md);
+    if (UCS_OK != status) {
+        goto err_destroy_qp;
+    }
+
+    /* Initialize indirect UMR mkey pool */
+    ucs_list_head_init(&md->umr.mkey_pool);
+
+    return UCS_OK;
+
+err_destroy_qp:
+    uct_ib_destroy_qp(md->umr.qp);
+err_destroy_cq:
+    ibv_destroy_cq(md->umr.cq);
+err:
+    return status;
+}
+
+static void
+uct_ib_mlx5_devx_umr_mkey_alias_destroy(uct_ib_mlx5_md_t *md,
+                                        uct_ib_mlx5_devx_umr_alias_t *umr_alias)
+{
+    ucs_status_t status;
+
+    ucs_trace("%s: destroy " UCT_IB_MLX5_UMR_ALIAS_FMT,
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias));
+
+    status = uct_ib_mlx5_devx_obj_destroy(umr_alias->cross_mr, "MKEY_ALIAS");
+    if (UCS_OK != status) {
+        ucs_warn("%s: uct_ib_mlx5_devx_obj_destroy(" UCT_IB_MLX5_UMR_ALIAS_FMT
+                 ") failed with error '%s': %m", uct_ib_mlx5_dev_name(md),
+                 UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias),
+                 ucs_status_string(status));
+    }
+}
+
+static void
+uct_ib_mlx5_devx_umr_mkey_destroy(uct_ib_mlx5_md_t *md,
+                                  uct_ib_mlx5_devx_umr_mkey_t *umr_mkey)
+{
+    int ret;
+
+    ucs_trace("%s: destroy " UCT_IB_MLX5_UMR_MKEY_FMT, uct_ib_mlx5_dev_name(md),
+              UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey));
+
+    ret = mlx5dv_destroy_mkey(umr_mkey->mkey);
+    if (0 != ret) {
+        ucs_warn("%s: mlx5dv_destroy_mkey("UCT_IB_MLX5_UMR_MKEY_FMT") returned "
+                 "%d: %m", uct_ib_mlx5_dev_name(md),
+                 UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey), ret);
+    }
+
+    ucs_free(umr_mkey);
+}
+
+static uct_ib_mlx5_devx_umr_mkey_t *
+uct_ib_mlx5_devx_umr_mkey_create(uct_ib_mlx5_md_t *md)
+{
+    struct mlx5dv_mkey_init_attr mkey_init_attr = {
+        .pd           = md->super.pd,
+        .create_flags = MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT,
+        .max_entries  = 1
+    };
+    uct_ib_mlx5_devx_umr_mkey_t *umr_mkey;
+    ucs_status_t status;
+
+    /* Lazy init UMR related objects for exporter */
+    if (NULL == md->umr.qp) {
+        status = uct_ib_mlx5_devx_umr_init_export(md);
+        if (UCS_OK != status) {
+            return NULL;
+        }
+    }
+
+    umr_mkey = ucs_malloc(sizeof(*umr_mkey), "uct_ib_mlx5_devx_umr_mkey_t");
+    if (NULL == umr_mkey) {
+        ucs_error("%s: failed to allocate UMR mkey", uct_ib_mlx5_dev_name(md));
+        return NULL;
+    }
+
+    umr_mkey->mkey = mlx5dv_create_mkey(&mkey_init_attr);
+    if (NULL == umr_mkey->mkey) {
+        ucs_error("%s: mlx5dv_create_mkey() failed to create UMR mkey: %m",
+                  uct_ib_mlx5_dev_name(md));
+        ucs_free(umr_mkey);
+        return NULL;
+    }
+
+    /* Mark mkey as UMR to distinguish it on the importer side */
+    umr_mkey->mkey->lkey |= UCT_IB_MLX5_MKEY_TAG_UMR;
+    umr_mkey->mkey->rkey |= UCT_IB_MLX5_MKEY_TAG_UMR;
+
+    status = uct_ib_mlx5_devx_allow_xgvmi_access(md, umr_mkey->mkey->lkey, 1);
+    if (status != UCS_OK) {
+        /* Reset XGVMI capability flag */
+        md->flags &= ~UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
+        uct_ib_mlx5_devx_umr_mkey_destroy(md, umr_mkey);
+        return NULL;
+    }
+
+    ucs_trace("%s: created " UCT_IB_MLX5_UMR_MKEY_FMT,
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey));
+    return umr_mkey;
+}
+
+static void uct_ib_mlx5_devx_umr_cleanup(uct_ib_mlx5_md_t *md)
+{
+    uct_ib_mlx5_devx_umr_alias_t mkey_alias;
+    uct_ib_mlx5_devx_umr_mkey_t *item, *tmp;
+    int ret;
+
+    /* Destroy UMR mkey hash if present */
+    if (NULL != md->umr.mkey_hash) {
+        ucs_trace("%s: destroy UMR mkey hash with %d elements",
+                  uct_ib_mlx5_dev_name(md), kh_size(md->umr.mkey_hash));
+
+        kh_foreach_value(md->umr.mkey_hash, mkey_alias, {
+            uct_ib_mlx5_devx_umr_mkey_alias_destroy(md, &mkey_alias);
+        });
+
+        kh_destroy(umr_mkey_map, md->umr.mkey_hash);
+    }
+
+    /* Destroy UMR mkey pool if not empty */
+    if (!ucs_list_is_empty(&md->umr.mkey_pool)) {
+        ucs_trace("%s: destroy UMR mkey pool with %lu elements",
+                  uct_ib_mlx5_dev_name(md),
+                  ucs_list_length(&md->umr.mkey_pool));
+
+        ucs_list_for_each_safe(item, tmp, &md->umr.mkey_pool, super) {
+            ucs_list_del(&item->super);
+            uct_ib_mlx5_devx_umr_mkey_destroy(md, item);
+        }
+    }
+
+    if (NULL != md->umr.qp) {
+        ret = ibv_destroy_qp(md->umr.qp);
+        if (ret != 0) {
+            ucs_warn("%s: ibv_destroy_qp(UMR QP) returned %d: %m",
+                     uct_ib_mlx5_dev_name(md), ret);
+        }
+    }
+
+    if (NULL != md->umr.cq) {
+        uct_ib_destroy_cq(md->umr.cq, uct_ib_mlx5_dev_name(md));
+    }
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_umr_post_sync(uct_ib_mlx5_md_t *md, struct ibv_send_wr *wr,
+                               uct_ib_mlx5_devx_umr_mkey_t *umr_mkey,
+                               const char *desc)
+{
+    ucs_time_t start_time = ucs_get_time();
+    struct ibv_wc wc;
+    struct ibv_send_wr *bad_wr;
+    int ret;
+
+    ret = ibv_post_send(md->umr.qp, wr, &bad_wr);
+    if (ret != 0) {
+        ucs_error("%s: ibv_post_send(UMR QP, %s, "UCT_IB_MLX5_UMR_MKEY_FMT") "
+                  "returned %d: %m", uct_ib_mlx5_dev_name(md), desc,
+                  UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey), ret);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    /* Poll for completion with timeout */
+    while ((ret = ibv_poll_cq(md->umr.cq, 1, &wc)) == 0) {
+        if ((ucs_get_time() - start_time) > ucs_time_from_sec(30)) {
+            ucs_error("%s: ibv_poll_cq(UMR CQ, %s, "UCT_IB_MLX5_UMR_MKEY_FMT") "
+                      "timed out", uct_ib_mlx5_dev_name(md), desc,
+                      UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey));
+            return UCS_ERR_TIMED_OUT;
+        }
+    }
+
+    if ((ret < 0) || (wc.status != IBV_WC_SUCCESS)) {
+        ucs_error("%s: ibv_poll_cq(UMR CQ, %s, "UCT_IB_MLX5_UMR_MKEY_FMT") "
+                  "returned %d, status: %s", uct_ib_mlx5_dev_name(md), desc,
+                  UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey), ret,
+                  uct_ib_wc_status_str(wc.status));
+        return UCS_ERR_IO_ERROR;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_umr_mkey_invalidate(uct_ib_mlx5_md_t *md,
+                                     uct_ib_mlx5_devx_umr_mkey_t *umr_mkey)
+{
+    struct ibv_send_wr wr = {
+        .wr_id           = 0,
+        .next            = NULL,
+        .num_sge         = 0,
+        .opcode          = IBV_WR_LOCAL_INV,
+        .send_flags      = IBV_SEND_INLINE | IBV_SEND_SIGNALED,
+        .invalidate_rkey = umr_mkey->mkey->lkey
+    };
+    ucs_status_t status;
+
+    status = uct_ib_mlx5_devx_umr_post_sync(md, &wr, umr_mkey, "invalidation");
+    if (status != UCS_OK) {
+        uct_ib_mlx5_devx_umr_mkey_destroy(md, umr_mkey);
+        return status;
+    }
+
+    /* Add UMR mkey to mkey pool for reuse & cleanup */
+    ucs_list_add_head(&md->umr.mkey_pool, &umr_mkey->super);
+    ucs_trace("%s: put " UCT_IB_MLX5_UMR_MKEY_FMT " into pool (%ld)",
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey),
+              ucs_list_length(&md->umr.mkey_pool));
+    return UCS_OK;
+}
+
+static uct_ib_mlx5_devx_umr_mkey_t *
+uct_ib_mlx5_devx_umr_mkey_pool_get(uct_ib_mlx5_md_t *md)
+{
+    uct_ib_mlx5_devx_umr_mkey_t *umr_mkey;
+
+    if (ucs_list_is_empty(&md->umr.mkey_pool)) {
+        umr_mkey = uct_ib_mlx5_devx_umr_mkey_create(md);
+    } else {
+        umr_mkey = ucs_list_extract_head(&md->umr.mkey_pool,
+                                         uct_ib_mlx5_devx_umr_mkey_t, super);
+        ucs_trace("%s: extracted from pool " UCT_IB_MLX5_UMR_MKEY_FMT,
+                  uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey));
+    }
+
+    return umr_mkey;
+}
+
+static uct_ib_mlx5_devx_umr_mkey_t *
+uct_ib_mlx5_devx_umr_mkey_bind(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mr_t *mr)
+{
+    struct ibv_mr *ib_mr  = mr->super.ib;
+    struct ibv_mw mw      = {
+        .rkey = 0,
+        .type = IBV_MW_TYPE_1
+    };
+    struct ibv_send_wr wr = {
+        .wr_id      = 0,
+        .next       = NULL,
+        .opcode     = IBV_WR_BIND_MW,
+        .send_flags = IBV_SEND_INLINE | IBV_SEND_SIGNALED,
+        .bind_mw    = {
+            .mw        = &mw,
+            .rkey      = 0,
+            .bind_info = {
+                .mr              = ib_mr,
+                .length          = ib_mr->length,
+                .addr            = (uint64_t)ib_mr->addr,
+                .mw_access_flags = UCT_IB_MLX5_MD_UMEM_ACCESS
+            }
+        }
+    };
+    ucs_status_t status;
+    uct_ib_mlx5_devx_umr_mkey_t *umr_mkey;
+
+    umr_mkey = uct_ib_mlx5_devx_umr_mkey_pool_get(md);
+    if (NULL == umr_mkey) {
+        return NULL;
+    }
+
+    /* Set UMR lkey to be registered with given MR */
+    mw.rkey         = umr_mkey->mkey->lkey;
+    wr.bind_mw.rkey = umr_mkey->mkey->lkey;
+
+    status = uct_ib_mlx5_devx_umr_post_sync(md, &wr, umr_mkey, "registration");
+    if (status != UCS_OK) {
+        uct_ib_mlx5_devx_umr_mkey_invalidate(md, umr_mkey);
+        return NULL;
+    }
+
+    ucs_trace("%s: registered addr %p length %zu lkey 0x%x to "
+              UCT_IB_MLX5_UMR_MKEY_FMT, uct_ib_mlx5_dev_name(md), ib_mr->addr,
+              ib_mr->length, ib_mr->lkey, UCT_IB_MLX5_UMR_MKEY_ARG(umr_mkey));
+    return umr_mkey;
+}
+
+static UCS_F_ALWAYS_INLINE uint64_t
+uct_ib_mlx5_devx_umr_mkey_hash_code(const uct_ib_md_packed_mkey_t *packed_mkey)
+{
+    return ((uint64_t)packed_mkey->vhca_id << 32) | packed_mkey->lkey;
+}
+
+/*
+ * Indicate that given mkey is an UMR mkey.
+ */
+static UCS_F_ALWAYS_INLINE int uct_ib_mlx5_devx_mkey_is_umr(uint32_t lkey)
+{
+    return UCT_IB_MLX5_MKEY_TAG_UMR == (lkey & 0xff);
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_umr_mkey_hash_find(uct_ib_mlx5_md_t *md,
+                                    const uct_ib_md_packed_mkey_t *packed_mkey,
+                                    uct_ib_mlx5_devx_umr_alias_t *umr_alias)
+{
+    uint64_t input_key;
+    khiter_t khiter;
+
+    if (NULL == md->umr.mkey_hash) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    input_key = uct_ib_mlx5_devx_umr_mkey_hash_code(packed_mkey);
+    khiter    = kh_get(umr_mkey_map, md->umr.mkey_hash, input_key);
+
+    if (khiter == kh_end(md->umr.mkey_hash)) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    *umr_alias = kh_val(md->umr.mkey_hash, khiter);
+    ucs_trace("%s: found " UCT_IB_MLX5_UMR_ALIAS_FMT " for index 0x%x in hash",
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias),
+              uct_ib_mlx5_mkey_index(packed_mkey->lkey));
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_umr_mkey_hash_put(uct_ib_mlx5_md_t *md,
+                                   const uct_ib_md_packed_mkey_t *packed_mkey,
+                                   const uct_ib_mlx5_devx_umr_alias_t *umr_alias)
+{
+    uint64_t input_key = uct_ib_mlx5_devx_umr_mkey_hash_code(packed_mkey);
+    int ret;
+    khiter_t khiter;
+
+    /* Lazy init UMR mkey alias hash map */
+    if (NULL == md->umr.mkey_hash) {
+        md->umr.mkey_hash = kh_init(umr_mkey_map);
+        if (NULL == md->umr.mkey_hash) {
+            return UCS_ERR_NO_MEMORY;
+        }
+    }
+
+    khiter = kh_put(umr_mkey_map, md->umr.mkey_hash, input_key, &ret);
+    if (ret == UCS_KH_PUT_FAILED) {
+        ucs_error("%s: failed to add " UCT_IB_MLX5_UMR_ALIAS_FMT " to hash map",
+                  uct_ib_mlx5_dev_name(md),
+                  UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias));
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    kh_val(md->umr.mkey_hash, khiter) = *umr_alias;
+    ucs_trace("%s: added " UCT_IB_MLX5_UMR_ALIAS_FMT " for index 0x%x to hash",
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias),
+              uct_ib_mlx5_mkey_index(packed_mkey->lkey));
+    return UCS_OK;
+}
+
 ucs_status_t
 uct_ib_mlx5_devx_mem_dereg(uct_md_h uct_md,
                            const uct_md_mem_dereg_params_t *params)
@@ -934,6 +1436,14 @@ uct_ib_mlx5_devx_mem_dereg(uct_md_h uct_md,
                   uct_ib_device_name(&md->super.dev), memh->cross_mr,
                   memh->exported_lkey);
         status = uct_ib_mlx5_devx_obj_destroy(memh->cross_mr, "CROSS_MR");
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    if (memh->exported_umr_mkey != NULL) {
+        status = uct_ib_mlx5_devx_umr_mkey_invalidate(md,
+                                                      memh->exported_umr_mkey);
         if (status != UCS_OK) {
             return status;
         }
@@ -1793,6 +2303,12 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     md->super.name       = UCT_IB_MD_NAME(mlx5);
     md->super.vhca_id    = vhca_id;
 
+    /* Zero init UMR related fields, will lazy init on first use */
+    md->umr.cq        = NULL;
+    md->umr.qp        = NULL;
+    md->umr.mkey_hash = NULL;
+    ucs_list_head_init(&md->umr.mkey_pool);
+
     ksm_atomic = 0;
     if (md->flags & UCT_IB_MLX5_MD_FLAG_KSM) {
         md->super.cap_flags |= UCT_MD_FLAG_INVALIDATE_RMA;
@@ -1868,6 +2384,7 @@ void uct_ib_mlx5_devx_md_close(uct_md_h tl_md)
     uct_ib_mlx5_md_buf_free(md, md->zero_buf, &md->zero_mem);
     ucs_mpool_cleanup(&md->dbrec_pool, 1);
     ucs_recursive_spinlock_destroy(&md->dbrec_lock);
+    uct_ib_mlx5_devx_umr_cleanup(md);
     uct_ib_md_close_common(&md->super);
     uct_ib_mlx5_devx_mr_lru_cleanup(md);
     uct_ib_md_free(&md->super);
@@ -1977,9 +2494,8 @@ err:
     return 0;
 }
 
-static ucs_status_t
+ucs_status_t
 uct_ib_mlx5_devx_allow_xgvmi_access(uct_ib_mlx5_md_t *md,
-                                    uct_ib_mlx5_devx_mem_t *memh,
                                     uint32_t exported_lkey, int silent)
 {
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(allow_other_vhca_access_in)]   = {0};
@@ -2072,7 +2588,7 @@ static ucs_status_t uct_ib_mlx5_devx_xgvmi_umem_mr(uct_ib_mlx5_md_t *md,
     exported_lkey = (UCT_IB_MLX5DV_GET(create_mkey_out, out, mkey_index) << 8) |
                     md->mkey_tag;
 
-    status = uct_ib_mlx5_devx_allow_xgvmi_access(md, memh, exported_lkey, 0);
+    status = uct_ib_mlx5_devx_allow_xgvmi_access(md, exported_lkey, 0);
     if (status != UCS_OK) {
         goto err_cross_mr_destroy;
     }
@@ -2093,52 +2609,89 @@ err_out:
 #endif
 }
 
+static ucs_status_t
+uct_ib_mlx5_devx_reg_xgvmi_ksm_mr(uct_ib_mlx5_md_t *md,
+                                  uct_ib_mlx5_devx_mem_t *memh)
+{
+    struct mlx5dv_devx_obj *cross_mr = NULL;
+    uint32_t exported_lkey;
+    ucs_status_t status;
+
+    status = uct_ib_mlx5_devx_reg_ksm_data(md, memh, UCT_IB_MR_DEFAULT, 0, 0, 0,
+                                           "exported-key", &cross_mr,
+                                           &exported_lkey);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_mlx5_devx_allow_xgvmi_access(md, exported_lkey, 1);
+    if (status != UCS_OK) {
+        /* Reset XGVMI capability flag */
+        md->flags &= ~UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
+        mlx5dv_devx_obj_destroy(cross_mr);
+        return status;
+    }
+
+    memh->cross_mr      = cross_mr;
+    memh->exported_lkey = exported_lkey;
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_reg_xgvmi_umr_mr(uct_ib_mlx5_md_t *md,
+                                  uct_ib_mlx5_devx_mem_t *memh)
+{
+    uct_ib_mlx5_devx_umr_mkey_t *umr_mkey =
+        uct_ib_mlx5_devx_umr_mkey_bind(md, &memh->mrs[UCT_IB_MR_DEFAULT]);
+    if (NULL == umr_mkey) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    memh->exported_umr_mkey = umr_mkey;
+    memh->exported_lkey     = umr_mkey->mkey->lkey;
+    return UCS_OK;
+}
+
 UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_exported_key,
                         (md, memh), uct_ib_mlx5_md_t *md,
                         uct_ib_mlx5_devx_mem_t *memh)
 {
-    struct mlx5dv_devx_obj *cross_mr;
-    uint32_t exported_lkey;
+    size_t length = memh->mrs[UCT_IB_MR_DEFAULT].super.ib->length;
     ucs_status_t status;
 
     if (memh->dm != NULL) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    ucs_assertv(memh->cross_mr == NULL,
-                "memh=%p cross_mr=%p exported_lkey=0x%x", memh, memh->cross_mr,
+    ucs_assertv((memh->exported_umr_mkey == NULL) && (memh->cross_mr == NULL),
+                "memh=%p exported_umr_mkey=%p cross_mr=%p exported_lkey=0x%x",
+                memh, memh->exported_umr_mkey, memh->cross_mr,
                 memh->exported_lkey);
-    if (!(md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI)) {
-        goto out_umem_mr;
+
+    if (md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI) {
+        /* UMR bind impl (IBV_WR_BIND_MW) attaches a single KLM segment, so:
+        * - IBV_WR_BIND_MW supports the maximum region length of 2GB
+        * - IBV_WR_BIND_MW does not support multi-segment (multi-threaded) MRs
+        * For these use cases we fallback to KSM */
+        if ((length > UCT_IB_MD_MAX_MR_SIZE) ||
+            (memh->super.flags & UCT_IB_MEM_MULTITHREADED)) {
+            status = uct_ib_mlx5_devx_reg_xgvmi_ksm_mr(md, memh);
+        } else {
+            status = uct_ib_mlx5_devx_reg_xgvmi_umr_mr(md, memh);
+        }
+
+        /* If KSM or UMR implementation fail to enable XGVMI, this capability
+         * flag is removed by impl, and then we fallback to UMEM impl */
+        if (md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI) {
+            /* No XGVMI error, return impl status as is */
+            return status;
+        }
+
+        ucs_debug("%s: indirect xgvmi not supported, fallback to DEVX UMEM",
+                  uct_ib_mlx5_dev_name(md));
     }
 
-    ucs_assert(!(memh->super.flags & UCT_IB_MEM_MULTITHREADED));
-    status = uct_ib_mlx5_devx_reg_ksm_data_contig(md, memh->address,
-                                                  (uint64_t)memh->address, 0, 0,
-                                                  "exported-key",
-                                                  &memh->mrs[UCT_IB_MR_DEFAULT],
-                                                  &cross_mr, &exported_lkey);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = uct_ib_mlx5_devx_allow_xgvmi_access(md, memh, exported_lkey, 1);
-    if (status == UCS_OK) {
-        goto out;
-    }
-
-    ucs_debug("%s: indirect cross gvmi not supported, fallback to DEVX UMEM",
-              uct_ib_device_name(&md->super.dev));
-    mlx5dv_devx_obj_destroy(cross_mr);
-    md->flags &= ~UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
-
-out_umem_mr:
     return uct_ib_mlx5_devx_xgvmi_umem_mr(md, memh);
-
-out:
-    memh->cross_mr      = cross_mr;
-    memh->exported_lkey = exported_lkey;
-    return UCS_OK;
 }
 
 static UCS_F_ALWAYS_INLINE int
@@ -2183,7 +2736,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
             return UCS_ERR_INVALID_PARAM;
         }
 
-        if (memh->cross_mr == NULL) {
+        if ((memh->cross_mr == NULL) && (memh->exported_umr_mkey == NULL)) {
             status = uct_ib_mlx5_devx_reg_exported_key(md, memh);
             if (status != UCS_OK) {
                 return status;
@@ -2256,6 +2809,7 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     const uint64_t flags = UCT_MD_MEM_ATTACH_FIELD_VALUE(params, flags,
                                                          FIELD_FLAGS, 0);
     const uct_ib_md_packed_mkey_t *packed_mkey = mkey_buffer;
+    uct_ib_mlx5_devx_umr_alias_t umr_alias     = {};
     uct_ib_mlx5_devx_mem_t *memh;
     void *hdr, *alias_ctx;
     ucs_status_t status;
@@ -2269,6 +2823,13 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
 
     hdr       = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, hdr);
     alias_ctx = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, alias_ctx);
+
+    /* Try to find alias in the UMR hash map */
+    status = uct_ib_mlx5_devx_umr_mkey_hash_find(md, packed_mkey, &umr_alias);
+    if (UCS_OK == status) {
+        memh->super.lkey = umr_alias.lkey;
+        goto out;
+    }
 
     /* create alias */
     UCT_IB_MLX5DV_SET(general_obj_in_cmd_hdr, hdr, opcode,
@@ -2287,11 +2848,11 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     ucs_strncpy_zero(access_key, uct_ib_mkey_token,
                      UCT_IB_MLX5DV_FLD_SZ_BYTES(alias_context, access_key));
 
-    memh->cross_mr = uct_ib_mlx5_devx_obj_create(md->super.dev.ibv_context, in,
-                                                 sizeof(in), out, sizeof(out),
-                                                 "MKEY_ALIAS",
-                                                 uct_md_attach_log_lvl(flags));
-    if (memh->cross_mr == NULL) {
+    umr_alias.cross_mr = uct_ib_mlx5_devx_obj_create(md->super.dev.ibv_context,
+                                                     in, sizeof(in), out,
+                                                     sizeof(out), "MKEY_ALIAS",
+                                                     uct_md_attach_log_lvl(flags));
+    if (umr_alias.cross_mr == NULL) {
         status = UCS_ERR_IO_ERROR;
         goto err_memh_free;
     }
@@ -2304,16 +2865,31 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
         goto err_cross_mr_destroy;
     }
 
-    memh->super.lkey   = (UCT_IB_MLX5DV_GET(create_alias_obj_out, out,
-                                            hdr.obj_id) << 8) |
-                         md->mkey_tag;
+    memh->super.lkey = (UCT_IB_MLX5DV_GET(create_alias_obj_out, out,
+                                          hdr.obj_id) << 8) |
+                       md->mkey_tag;
+
+    /* If received mkey is UMR key, store alias in the UMR hash map */
+    if (uct_ib_mlx5_devx_mkey_is_umr(packed_mkey->lkey)) {
+        umr_alias.lkey = memh->super.lkey;
+
+        status = uct_ib_mlx5_devx_umr_mkey_hash_put(md, packed_mkey, &umr_alias);
+        if (UCS_OK != status) {
+            goto err_cross_mr_destroy;
+        }
+    } else {
+        /* Not UMR mkey: move cross_mr ownership to memh */
+        memh->cross_mr = umr_alias.cross_mr;
+    }
+
+out:
     memh->super.rkey   = memh->super.lkey;
     memh->super.flags |= UCT_IB_MEM_IMPORTED;
     *memh_p            = memh;
     return UCS_OK;
 
 err_cross_mr_destroy:
-    mlx5dv_devx_obj_destroy(memh->cross_mr);
+    uct_ib_mlx5_devx_umr_mkey_alias_destroy(md, &umr_alias);
 err_memh_free:
     ucs_free(memh);
 err:


### PR DESCRIPTION
## What
UMR approach for XGVMI.
This part contains all the core components of the UMR approach:
 - UMR primitives: CQ, QP, init, destroy
 - UMR mkey pool for the exporter part
 - UMR hash map for the importer side

This changeset triggers UMR workflow:
In the exporter (host process), in `uct_ib_mlx5_devx_reg_exported_key`:
 - Find existing UMR mkey in the pool, or create a new one
 - Bind passed UMR with given MR (if MR length is below 2GB and not MT)
 - Otherwise (large or MT MR) fallback to KSM registration
 - Mark UMR mkey tag (8 LBS) so that we distinguish it on the importer side

On the importer side (DPU process), when receiving new rkey (`uct_ib_mlx5_devx_mem_attach`):
 - If passed mkey is UMR key, then lookup alias in the UMR hash map
 - If alias is found, just use it and don't create a new one
 - Otherwise create a new alias, and save it into the UMR hash map (if passed mkey is UMR one)