### PR TITLE
UCT/DC: Print error when max_rd_atomic is different on peers

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -957,6 +957,10 @@ uct_dc_mlx5_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr
         addr->super.flags  |= UCT_DC_MLX5_IFACE_ADDR_FLUSH_RKEY;
     }
 
+    if (iface->super.super.config.max_rd_atomic == 16) {
+        addr->super.flags |= UCT_DC_MLX5_IFACE_ADDR_MAX_RD_ATOMIC_16;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/ib/dc/dc_mlx5.h
+++ b/src/uct/ib/dc/dc_mlx5.h
@@ -67,12 +67,13 @@ typedef struct uct_dc_mlx5_iface  uct_dc_mlx5_iface_t;
 
 
 typedef enum {
-    UCT_DC_MLX5_IFACE_ADDR_HW_TM      = UCS_BIT(0),
-    UCT_DC_MLX5_IFACE_ADDR_DC_V1      = UCS_BIT(1),
-    UCT_DC_MLX5_IFACE_ADDR_DC_V2      = UCS_BIT(2),
-    UCT_DC_MLX5_IFACE_ADDR_FLUSH_RKEY = UCS_BIT(3),
-    UCT_DC_MLX5_IFACE_ADDR_DC_VERS    = UCT_DC_MLX5_IFACE_ADDR_DC_V1 |
-                                        UCT_DC_MLX5_IFACE_ADDR_DC_V2
+    UCT_DC_MLX5_IFACE_ADDR_HW_TM            = UCS_BIT(0),
+    UCT_DC_MLX5_IFACE_ADDR_DC_V1            = UCS_BIT(1),
+    UCT_DC_MLX5_IFACE_ADDR_DC_V2            = UCS_BIT(2),
+    UCT_DC_MLX5_IFACE_ADDR_FLUSH_RKEY       = UCS_BIT(3),
+    UCT_DC_MLX5_IFACE_ADDR_MAX_RD_ATOMIC_16 = UCS_BIT(4),
+    UCT_DC_MLX5_IFACE_ADDR_DC_VERS          = UCT_DC_MLX5_IFACE_ADDR_DC_V1 |
+                                              UCT_DC_MLX5_IFACE_ADDR_DC_V2
 } uct_dc_mlx5_iface_addr_flags_t;
 
 

--- a/src/uct/ib/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/dc/dc_mlx5_ep.c
@@ -1268,6 +1268,13 @@ UCS_CLASS_INIT_FUNC(uct_dc_mlx5_ep_t, uct_dc_mlx5_iface_t *iface,
         self->flush_rkey_hi = 0;
     }
 
+    if ((iface->super.super.config.max_rd_atomic == 16) !=
+        !!(if_addr->flags & UCT_DC_MLX5_IFACE_ADDR_MAX_RD_ATOMIC_16)) {
+        ucs_error("max_rd_attomic values do not match on peers (local is %u), "
+                  "set UCX_RC_MAX_RD_ATOMIC=16 to resolve this issue.",
+                  iface->super.super.config.max_rd_atomic);
+    }
+
     return uct_dc_mlx5_ep_basic_init(iface, self);
 }
 


### PR DESCRIPTION
## What
RDMA_READ or/and atomic operations may fail if peers are using dcis configured with different values of max_rd_atomic. Since certain FW in CX-7 this value was increased from 16 up to 64. This PR checks whether just one of the peers is using old value (16) of max_rd_atomics and prints an error if it is different from the local value.
Later, when dynamic dci allocation is introduced, ep will create a new dci pool matching peers config rather than just printing an error.
