### PR TITLE
UCP/PROTO: Attach unpack time perf node for mtype RTR

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -317,6 +317,7 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
 
     max_length     = ucs_min(params->super.max_length, max_length);
     ctrl_perf.node = ucp_proto_perf_node_new_data(params->ctrl_msg_name, "");
+    ucp_proto_perf_node_add_child(ctrl_perf.node, params->unpack_perf_node);
 
     /* Set send_overheads to the time to send and receive RTS message */
     status = ucp_proto_rndv_ctrl_perf(&params->super.super, rpriv->lane,


### PR DESCRIPTION
## What
Make RTR unpack time node visible on the perf graph.

## Why ?
Now mtype RTR contain BW but the only child node is rcache lookup.

| Before| After|
|--------|--------|
| ![image](https://github.com/openucx/ucx/assets/22097249/4a50874a-bfd6-4c93-a9e6-5fafb47e757e) | ![image](https://github.com/openucx/ucx/assets/22097249/18b9009f-4dbc-4ab5-80d3-2adc72ffbad6) |