### PR TITLE
UCT/CUDA: Removed uct_ep_check support from CUDA_IPC

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -31,12 +31,6 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_ep_t, const uct_ep_params_t *params)
     UCS_CLASS_CALL_SUPER_INIT(uct_base_ep_t, &iface->super.super);
 
     self->remote_pid = *(const pid_t*)params->iface_addr;
-
-    /* Ignore return status, because error handling may not be needed
-     * (it will fail during first check anyway)
-     */
-    uct_ep_keepalive_init(&self->keepalive, self->remote_pid);
-
     return UCS_OK;
 }
 
@@ -192,14 +186,4 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_zcopy,
     uct_cuda_ipc_trace_data(remote_addr, rkey, "PUT_ZCOPY [length %zu]",
                                 uct_iov_total_length(iov, iovcnt));
     return status;
-}
-
-ucs_status_t uct_cuda_ipc_ep_check(const uct_ep_h tl_ep, unsigned flags,
-                                   uct_completion_t *comp)
-{
-    uct_cuda_ipc_ep_t *ep = ucs_derived_of(tl_ep, uct_cuda_ipc_ep_t);
-
-    UCT_EP_KEEPALIVE_CHECK_PARAM(flags, comp);
-    uct_ep_keepalive_check(tl_ep, &ep->keepalive, ep->remote_pid, flags, comp);
-    return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -14,7 +14,6 @@
 typedef struct uct_cuda_ipc_ep {
     uct_base_ep_t        super;
     pid_t                remote_pid;
-    uct_keepalive_info_t keepalive; /* keepalive metadata */
 } uct_cuda_ipc_ep_t;
 
 
@@ -30,9 +29,6 @@ ucs_status_t uct_cuda_ipc_ep_put_zcopy(uct_ep_h tl_ep,
                                        const uct_iov_t *iov, size_t iovcnt,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
-
-ucs_status_t uct_cuda_ipc_ep_check(const uct_ep_h tl_ep, unsigned flags,
-                                   uct_completion_t *comp);
 
 int uct_cuda_ipc_ep_is_connected(const uct_ep_h tl_ep,
                                  const uct_ep_is_connected_params_t *params);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -201,10 +201,9 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
     iface_attr->ep_addr_len             = 0;
     iface_attr->max_conn_priv           = 0;
     iface_attr->cap.flags               = UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
-                                          UCT_IFACE_FLAG_EP_CHECK               |
-                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE       |
-                                          UCT_IFACE_FLAG_PENDING                |
-                                          UCT_IFACE_FLAG_GET_ZCOPY              |
+                                          UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                          UCT_IFACE_FLAG_PENDING          |
+                                          UCT_IFACE_FLAG_GET_ZCOPY        |
                                           UCT_IFACE_FLAG_PUT_ZCOPY;
     iface_attr->cap.event_flags         = UCT_IFACE_FLAG_EVENT_SEND_COMP |
                                           UCT_IFACE_FLAG_EVENT_RECV      |
@@ -353,7 +352,7 @@ static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
     .ep_pending_purge         = ucs_empty_function,
     .ep_flush                 = uct_base_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
-    .ep_check                 = uct_cuda_ipc_ep_check,
+    .ep_check                 = ucs_empty_function_return_unsupported,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cuda_ipc_ep_t),
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_ep_t),
     .iface_flush              = uct_cuda_ipc_iface_flush,

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -77,7 +77,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(uct_ud_verbs_ep_t, 264);
 #  endif
 #  if HAVE_CUDA
-    EXPECTED_SIZE(uct_cuda_ipc_ep_t, 24);
+    EXPECTED_SIZE(uct_cuda_ipc_ep_t, 16);
 #  endif
 #endif
 }

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -8,13 +8,6 @@
 
 #include "test_peer_failure.h"
 
-#if HAVE_CUDA
-extern "C" {
-#include <uct/cuda/cuda_ipc/cuda_ipc_ep.h>
-}
-#endif
-
-
 const uint64_t test_uct_peer_failure::m_required_caps = UCT_IFACE_FLAG_AM_SHORT  |
                                                         UCT_IFACE_FLAG_PENDING   |
                                                         UCT_IFACE_FLAG_CB_SYNC   |
@@ -553,11 +546,6 @@ protected:
         if (has_mm()) {
             uct_mm_ep_t *ep = ucs_derived_of(ep0(), uct_mm_ep_t);
             ep->keepalive.start_time--;
-        } else if (has_cuda_ipc()) {
-#if HAVE_CUDA
-            uct_cuda_ipc_ep_t *ep = ucs_derived_of(ep0(), uct_cuda_ipc_ep_t);
-            ep->keepalive.start_time--;
-#endif
         } else if (has_cma()) {
             uct_cma_ep_t *ep = ucs_derived_of(ep0(), uct_cma_ep_t);
             ep->keepalive.start_time--;
@@ -626,8 +614,6 @@ UCS_TEST_SKIP_COND_P(test_uct_peer_failure_keepalive, killed_post_am,
 }
 
 UCT_INSTANTIATE_NO_SELF_TEST_CASE(test_uct_peer_failure_keepalive)
-_UCT_INSTANTIATE_TEST_CASE(test_uct_peer_failure_keepalive, cuda_ipc);
-
 
 class test_uct_peer_failure_rma_zcopy : public test_uct_peer_failure
 {


### PR DESCRIPTION
## What
uct_ep_check implementations were removed from CUDA_IPC.

## Why ?
uct_ep_check API is used for error handling mechanism.
As part of the lane selection process, we select a single keepalive lane, which is used to check remote EP connection status.
Only transports with one of the following caps can be used as keepalive lane:
1) CONNECT_TO_EP + EP_CHECK flag.
2) CONNECT_TO_IFACE + AM_BCOPY flags.
3)  CONNECT_TO_EP + EP_KEEPALIVE flags.
CUDA_IPC doesn't fulfill those conditions, so cannot be used as keepalive lane.
