### PR TITLE
TOOLS/PERF: CI test for perftest daemon

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ dist_perftest__DATA = \
 	contrib/ucx_perftest_config/test_types_ucp \
 	contrib/ucx_perftest_config/test_types_ucp_rma \
 	contrib/ucx_perftest_config/test_types_ucp_amo \
+	contrib/ucx_perftest_config/test_types_ucp_daemon \
 	contrib/ucx_perftest_config/transports
 
 SUBDIRS = \
@@ -74,6 +75,7 @@ EXTRA_DIST += contrib/ucx_perftest_config/msg_pow2
 EXTRA_DIST += contrib/ucx_perftest_config/README
 EXTRA_DIST += contrib/ucx_perftest_config/test_types_uct
 EXTRA_DIST += contrib/ucx_perftest_config/test_types_ucp
+EXTRA_DIST += contrib/ucx_perftest_config/test_types_ucp_daemon
 EXTRA_DIST += contrib/ucx_perftest_config/transports
 EXTRA_DIST += debian/changelog
 EXTRA_DIST += debian/compat

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -561,6 +561,79 @@ run_ucx_perftest() {
 	fi
 }
 
+start_perftest_daemon() {
+	daemon_exe="$1"
+
+	# Find daemon port
+	dmn_port="$server_port"
+	step_server_port
+
+	# We explicitly disable cuda transport, because it's not p2p and therefore
+	# imposes INVALIDATE_RMA flag for all lanes (@see ucp_ep_config_init).
+	# However invalidating of imported rkeys is not supported by the daemon.
+	# TODO: Should we support invalidation of imported keys?
+	# Normally cuda_ipc cannot be used to communicate between host and DPU,
+	# unless we run both processes on host for testing purposes.
+
+	# Mandatory options to run the daemon
+	# - UCX_RNDV_THRESH=0 is needed to enforce RNDV protocol usage, as it's the
+	# only supported protocol between host and DPU
+	# - UCX_RNDV_SCHEME=put_zcopy. On low buffer dimensions (below ~8KB) UCX
+	# prefers bcopy over zero-copy, but bcopy workflow is not supported by DPU
+	# daemon. The workaround is to force rendezvous scheme to use zero-copy.
+	# get_zcopy option is not good enough, because bcopy is still selected for
+	# tiny messages (below 64 bytes)
+	dmn_env="UCX_TLS=^cuda UCX_TCP_CM_REUSEADDR=y UCX_RNDV_THRESH=0 UCX_RNDV_SCHEME=put_zcopy"
+
+	# Run the daemon
+	env $dmn_env $daemon_exe -p $dmn_port &
+
+	# Return the daemon pid and port
+	eval "$2=$!"
+	eval "$3=$dmn_port"
+}
+
+#
+# Run UCX performance daemon test
+#
+run_ucx_perftest_with_daemon() {
+	ucx_inst_ptest=$ucx_inst/share/ucx/perftest
+
+	ucx_perftest="$ucx_inst/bin/ucx_perftest"
+	ucx_perftest_daemon="$ucx_inst/bin/ucx_perftest_daemon"
+	ucp_test_args="-b $ucx_inst_ptest/test_types_ucp_daemon"
+
+	devices="$(get_ib_bf_devices $(get_active_ib_devices))"
+	for ucx_dev in $devices
+	do
+		echo "==== Running ucx_perftest over a daemon on $ucx_dev ===="
+		ip_addr=$(get_rdma_device_ip_addr $ucx_dev)
+		if [ -z "$ip_addr" ]
+		then
+			echo "Cannot find IPv4 address for device $ucx_dev"
+			continue
+		fi
+
+		export UCX_NET_DEVICES=$ucx_dev
+
+		# Start client and server daemons
+		start_perftest_daemon $ucx_perftest_daemon server_dmn_pid server_dmn_port
+		start_perftest_daemon $ucx_perftest_daemon client_dmn_pid client_dmn_port
+
+		ucp_client_args="-g $ip_addr:$client_dmn_port -G $ip_addr:$server_dmn_port $(hostname)"
+
+		run_client_server_app "$ucx_perftest" "$ucp_test_args" "$ucp_client_args" 0 0
+
+		kill ${client_dmn_pid} || true # ignore failure
+		kill ${server_dmn_pid} || true # ignore failure
+		wait $client_dmn_pid || true
+		wait $server_dmn_pid || true
+
+		unset UCX_TLS
+		unset UCX_NET_DEVICES
+	done
+}
+
 #
 # Test malloc hooks with mpi
 #
@@ -1099,6 +1172,7 @@ run_tests() {
 	do_distributed_task 2 4 test_init_mt
 	do_distributed_task 3 4 run_ucp_client_server
 	do_distributed_task 0 4 test_no_cuda_context
+	do_distributed_task 1 4 run_ucx_perftest_with_daemon
 
 	# long devel tests
 	do_distributed_task 0 4 run_ucp_hello

--- a/contrib/ucx_perftest_config/test_types_ucp_daemon
+++ b/contrib/ucx_perftest_config/test_types_ucp_daemon
@@ -1,0 +1,5 @@
+#
+# UCP daemon basic
+#
+ucp_daemon_bw_1                        -t ucp_am_bw -w 0 -n 10000 -s 1
+ucp_daemon_bw_8k                       -t ucp_am_bw -w 0 -n 10000 -s 8192

--- a/src/tools/perf/Makefile.am
+++ b/src/tools/perf/Makefile.am
@@ -42,6 +42,7 @@ dist_perftest_DATA = \
 	$(top_srcdir)/contrib/ucx_perftest_config/README \
 	$(top_srcdir)/contrib/ucx_perftest_config/test_types_uct \
 	$(top_srcdir)/contrib/ucx_perftest_config/test_types_ucp \
+	$(top_srcdir)/contrib/ucx_perftest_config/test_types_ucp_daemon \
 	$(top_srcdir)/contrib/ucx_perftest_config/transports
 
 

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -118,8 +118,6 @@ enum {
  *      |                 |---------PEER_TX(AM)------->|                 |
  *      |                 |----------(TM msg)--------->|                 |
  *      |<---SEND_CMPL----|                            |---RECV_CMPL---->|
- *      |                 |                            |                 |
- *      |-------FIN------>|                            |<------FIN-------|
  *
  * (AM) used only when AM communication is configured
  * (TM) used only when tag matching communication is configured
@@ -144,11 +142,9 @@ enum {
      * unsolicited in case of AM communication. For tag matching transport it \
      * confirms the completion of RECV_REQ request */ \
     _macro(UCP_PERF_DAEMON_AM_ID_RECV_CMPL, UCP_PERF_AM_ID + 5) \
-    /* Host->DPU daemon finalize message */ \
-    _macro(UCP_PERF_DAEMON_AM_ID_FIN,       UCP_PERF_AM_ID + 6) \
     /* Sender DPU->Receiver DPU, message to establish communication between \
      * DPU peers */ \
-    _macro(UCP_PERF_DAEMON_AM_ID_PEER_INIT, UCP_PERF_AM_ID + 7)
+    _macro(UCP_PERF_DAEMON_AM_ID_PEER_INIT, UCP_PERF_AM_ID + 6)
 
 
 #define UCP_PERF_DAEMON_ENUMIFY(ID, VALUE) ID = VALUE,

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -344,8 +344,10 @@ public:
     {
         ucp_perf_test_runner *test = (ucp_perf_test_runner*)arg;
 
-        ucs_assertv(length == 0ul, "length=%zu", length);
+        ucs_assertv(length == sizeof(ucs_status_t), "length=%zu", length);
         ucs_assert(!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV));
+        ucs_status_t status = *(ucs_status_t*)data;
+        ucs_assert_always(status == UCS_OK);
 
         test->send_completed();
 
@@ -359,8 +361,10 @@ public:
     {
         ucp_perf_test_runner *test = (ucp_perf_test_runner*)arg;
 
-        ucs_assertv(length == 0ul, "length=%zu", length);
+        ucs_assertv(length == sizeof(ucs_status_t), "length=%zu", length);
         ucs_assert(!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV));
+        ucs_status_t status = *(ucs_status_t*)data;
+        ucs_assert_always(status == UCS_OK);
 
         test->recv_completed();
 

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -19,7 +19,7 @@
 #endif
 
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lyzg:G:"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lyz"
 #define TEST_ID_UNDEFINED       -1
 
 #define DEFAULT_DAEMON_PORT     1338

--- a/src/tools/perf/perftest_daemon.c
+++ b/src/tools/perf/perftest_daemon.c
@@ -62,10 +62,10 @@ ucp_perf_daemon_ep_close(ucp_perf_daemon_context_t *ctx, ucp_ep_h ep)
         return;
     }
 
+    ucs_debug("closing ep %p", ep);
     param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
     param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
     close_req          = ucp_ep_close_nbx(ep, &param);
-
     if (UCS_PTR_IS_PTR(close_req)) {
         do {
             ucp_worker_progress(ctx->worker);
@@ -81,9 +81,39 @@ ucp_perf_daemon_ep_close(ucp_perf_daemon_context_t *ctx, ucp_ep_h ep)
     }
 }
 
+static void ucp_perf_daemon_cleanup_connections(ucp_perf_daemon_context_t *ctx)
+{
+    ucs_trace("cleaning up daemon connections");
+
+    if (NULL != ctx->send_memh) {
+        /* coverity[check_return] */
+        ucp_mem_unmap(ctx->context, ctx->send_memh);
+        ctx->send_memh = NULL;
+    }
+
+    if (NULL != ctx->recv_memh) {
+        /* coverity[check_return] */
+        ucp_mem_unmap(ctx->context, ctx->recv_memh);
+        ctx->recv_memh = NULL;
+    }
+
+    ucp_perf_daemon_ep_close(ctx, ctx->host_ep);
+    ctx->host_ep = NULL;
+}
+
 static void ucp_perf_daemon_err_cb(void *arg, ucp_ep_h ep, ucs_status_t status)
 {
-    terminated = 1;
+    ucp_perf_daemon_context_t *ctx = arg;
+
+    if (ep == ctx->host_ep) {
+        ucs_debug("ep %p: host error handler called with status %s", ep,
+                  ucs_status_string(status));
+        ucp_perf_daemon_cleanup_connections(arg);
+    } else {
+        ucs_error("ep %p: peer error handler called with status %s", ep,
+                  ucs_status_string(status));
+        terminated = 1;
+    }
 }
 
 static void
@@ -107,6 +137,8 @@ ucp_perf_daemon_server_conn_handle_cb(ucp_conn_request_h conn_request,
     if (status != UCS_OK) {
         ucs_error("failed to create an endpoint on the daemon: %s",
                   ucs_status_string(status));
+    } else {
+        ucs_debug("new ep %p accepted", ep);
     }
 }
 
@@ -129,7 +161,7 @@ ucp_perf_daemon_set_am_recv_handler(ucp_perf_daemon_context_t *ctx,
 
     status = ucp_worker_set_am_recv_handler(ctx->worker, &param);
     if (UCS_OK != status) {
-        ucs_error("failed to set am recv handler: %s",
+        ucs_error("ucp_worker_set_am_recv_handler() failed with error: %s",
                   ucs_status_string(status));
         return status;
     }
@@ -138,7 +170,8 @@ ucp_perf_daemon_set_am_recv_handler(ucp_perf_daemon_context_t *ctx,
 }
 
 static ucs_status_t
-ucp_perf_daemon_send_am_eager_reply(ucp_ep_h ep, ucp_perf_daemon_am_id_t am_id)
+ucp_perf_daemon_send_am_eager_reply(ucp_ep_h ep, ucp_perf_daemon_am_id_t am_id,
+                                    ucs_status_t status)
 {
     ucp_request_param_t param = {};
     ucs_status_ptr_t sreq;
@@ -146,11 +179,12 @@ ucp_perf_daemon_send_am_eager_reply(ucp_ep_h ep, ucp_perf_daemon_am_id_t am_id)
     param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
     param.flags        = UCP_AM_SEND_FLAG_REPLY | UCP_AM_SEND_FLAG_EAGER;
 
-    sreq = ucp_am_send_nbx(ep, am_id, NULL, 0ul, NULL, 0ul, &param);
+    sreq = ucp_am_send_nbx(ep, am_id, NULL, 0ul, &status, sizeof(status),
+                           &param);
     if (UCS_PTR_IS_PTR(sreq)) {
         ucp_request_free(sreq);
     } else if (UCS_PTR_IS_ERR(sreq)) {
-        ucs_error("failed to send am id %u: %s", am_id,
+        ucs_error("ucp_am_send_nbx(AM_ID=%u) failed with: %s", am_id,
                   ucs_status_string(UCS_PTR_STATUS(sreq)));
         return UCS_PTR_STATUS(sreq);
     }
@@ -163,11 +197,15 @@ ucp_perf_daemon_send_cb(void *request, ucs_status_t status, void *user_data)
 {
     ucp_perf_daemon_context_t *ctx = user_data;
 
-    if (ucs_likely(status == UCS_OK)) {
-        ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
-                                            UCP_PERF_DAEMON_AM_ID_SEND_CMPL);
+    if (status != UCS_OK) {
+        ucs_error("SEND operation failed: %s", ucs_status_string(status));
+    } else {
+        ucs_trace_data("SEND completed");
     }
 
+    ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
+                                        UCP_PERF_DAEMON_AM_ID_SEND_CMPL,
+                                        status);
     ucp_request_free(request);
 }
 
@@ -198,11 +236,15 @@ static void ucp_perf_daemon_recv_cb(void *request, ucs_status_t status,
 {
     ucp_perf_daemon_context_t *ctx = user_data;
 
-    if (ucs_likely(status == UCS_OK)) {
-        ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
-                                            UCP_PERF_DAEMON_AM_ID_RECV_CMPL);
+    if (status != UCS_OK) {
+        ucs_error("RECV operation failed: %s", ucs_status_string(status));
+    } else {
+        ucs_trace_data("RECV completed");
     }
 
+    ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
+                                        UCP_PERF_DAEMON_AM_ID_RECV_CMPL,
+                                        status);
     ucp_request_free(request);
 }
 
@@ -228,13 +270,15 @@ ucp_perf_daemon_create_peer_ep(ucp_perf_daemon_context_t *ctx,
 
     status = ucp_ep_create(ctx->worker, &ep_params, &ctx->peer_ep);
     if (status != UCS_OK) {
-        ucs_error("daemon failed to create an endpoint: %s",
-                  ucs_status_string(status));
+        ucs_error("ucp_ep_create() failed with: %s", ucs_status_string(status));
         return status;
+    } else {
+        ucs_debug("peer ep %p created", ctx->peer_ep);
     }
 
     return ucp_perf_daemon_send_am_eager_reply(ctx->peer_ep,
-                                               UCP_PERF_DAEMON_AM_ID_PEER_INIT);
+                                               UCP_PERF_DAEMON_AM_ID_PEER_INIT,
+                                               UCS_OK);
 }
 
 static void ucp_perf_daemon_check_am_msg(const ucp_am_recv_param_t *param,
@@ -302,11 +346,10 @@ ucp_perf_daemon_init_handler(void *arg, const void *header,
     ucp_perf_daemon_check_am_msg(param, header_length, 1, 0,
                                  UCP_PERF_DAEMON_AM_ID_INIT);
 
-    /* Peer EP must not be initialized on receiving HOST_INIT message.
+    /* Host EP must not be initialized on receiving HOST_INIT message.
      * Otherwise it means that daemon was already initialized from host. For now
-     * we don't support multiple host processes, or connection reestablishment
-     */
-    if (ctx->peer_ep != NULL) {
+     * we don't support multiple host processes */
+    if (ctx->host_ep != NULL) {
         ucs_error("duplicate daemon init req");
         return UCS_ERR_ALREADY_EXISTS;
     }
@@ -314,7 +357,9 @@ ucp_perf_daemon_init_handler(void *arg, const void *header,
     ctx->host_ep = param->reply_ep;
 
     ucp_perf_unpack_array(&ptr, &value_length, &value);
-    if (value_length != 0) {
+    /* Peer EP is persistent during daemon lifetime, create it only if it does
+     * not exist yet */
+    if ((value_length != 0) && (ctx->peer_ep == NULL)) {
         status = ucp_perf_daemon_create_peer_ep(ctx, value, value_length);
         if (status != UCS_OK) {
             return status;
@@ -354,18 +399,6 @@ ucp_perf_daemon_send_handler(void *arg, const void *header,
 }
 
 static ucs_status_t
-ucp_perf_daemon_fin_handler(void *arg, const void *header, size_t header_length,
-                            void *data, size_t length,
-                            const ucp_am_recv_param_t *param)
-{
-    ucp_perf_daemon_check_am_msg(param, header_length, 0, 0,
-                                 UCP_PERF_DAEMON_AM_ID_FIN);
-
-    terminated = 1;
-    return UCS_OK;
-}
-
-static ucs_status_t
 ucp_perf_daemon_peer_init_handler(void *arg, const void *header,
                                   size_t header_length, void *data,
                                   size_t length,
@@ -376,7 +409,13 @@ ucp_perf_daemon_peer_init_handler(void *arg, const void *header,
     ucp_perf_daemon_check_am_msg(param, header_length, 1, 0,
                                  UCP_PERF_DAEMON_AM_ID_PEER_INIT);
 
+    if (ctx->peer_ep != NULL) {
+        ucs_error("duplicate peer init req");
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
     ctx->peer_ep = param->reply_ep;
+    ucs_debug("peer ep %p received", ctx->peer_ep);
     return UCS_OK;
 }
 
@@ -415,18 +454,11 @@ ucp_perf_daemon_peer_tx_handler(void *arg, const void *header,
 
 static void ucp_perf_daemon_cleanup(ucp_perf_daemon_context_t *ctx)
 {
-    if (NULL != ctx->send_memh) {
-        /* coverity[check_return] */
-        ucp_mem_unmap(ctx->context, ctx->send_memh);
-    }
+    ucs_trace("cleaning up daemon");
 
-    if (NULL != ctx->recv_memh) {
-        /* coverity[check_return] */
-        ucp_mem_unmap(ctx->context, ctx->recv_memh);
-    }
+    ucp_perf_daemon_cleanup_connections(ctx);
 
     ucp_perf_daemon_ep_close(ctx, ctx->peer_ep);
-    ucp_perf_daemon_ep_close(ctx, ctx->host_ep);
     ucp_listener_destroy(ctx->listener);
     ucp_worker_destroy(ctx->worker);
     ucp_cleanup(ctx->context);
@@ -441,7 +473,6 @@ ucp_perf_daemon_set_am_handlers(ucp_perf_daemon_context_t *ctx)
     } handlers[] = {
         {UCP_PERF_DAEMON_AM_ID_INIT, ucp_perf_daemon_init_handler},
         {UCP_PERF_DAEMON_AM_ID_SEND_REQ, ucp_perf_daemon_send_handler},
-        {UCP_PERF_DAEMON_AM_ID_FIN, ucp_perf_daemon_fin_handler},
         {UCP_PERF_DAEMON_AM_ID_PEER_INIT, ucp_perf_daemon_peer_init_handler},
         {UCP_PERF_DAEMON_AM_ID_PEER_TX, ucp_perf_daemon_peer_tx_handler},
     };

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1768,13 +1768,15 @@ ucp_memh_import_attach(ucp_context_h context, ucp_mem_h memh,
     ucp_md_index_t md_index;
     unsigned tl_mkey_index;
     const void *tl_mkey_buf;
+    uint8_t tl_mkey_size;
     uct_md_mem_attach_params_t attach_params;
     uct_md_attr_v2_t *md_attr;
     ucs_status_t status;
     uct_mem_h uct_memh;
 
     for (tl_mkey_index = 0; tl_mkey_index < num_tl_mkeys; ++tl_mkey_index) {
-        tl_mkey_buf = tl_mkeys[tl_mkey_index].tl_mkey_buf;
+        tl_mkey_buf  = tl_mkeys[tl_mkey_index].tl_mkey_buf;
+        tl_mkey_size = tl_mkeys[tl_mkey_index].tl_mkey_size;
         ucs_for_each_bit(md_index, tl_mkeys[tl_mkey_index].local_md_map) {
             md_attr = &context->tl_mds[md_index].attr;
             ucs_assert_always(md_attr->flags & UCT_MD_FLAG_EXPORTED_MKEY);
@@ -1783,8 +1785,10 @@ ucp_memh_import_attach(ucp_context_h context, ucp_mem_h memh,
                 continue;
             }
 
-            attach_params.field_mask = UCT_MD_MEM_ATTACH_FIELD_FLAGS;
+            attach_params.field_mask = UCT_MD_MEM_ATTACH_FIELD_FLAGS |
+                                       UCT_MD_MEM_ATTACH_FIELD_MKEY_SIZE;
             attach_params.flags      = UCT_MD_MEM_ATTACH_FLAG_HIDE_ERRORS;
+            attach_params.mkey_size  = tl_mkey_size;
 
             status = uct_md_mem_attach(context->tl_mds[md_index].md, tl_mkey_buf,
                                        &attach_params, &uct_memh);

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -474,13 +474,12 @@ static ucp_md_map_t ucp_rkey_find_global_id_md_map(ucp_context_h context,
 static void
 ucp_memh_exported_tl_mkey_data_unpack(ucp_context_h context, 
                                       const void **start_p,
-                                      const void **tl_mkey_buf_p,
-                                      ucp_md_map_t *md_map_p)
+                                      ucp_unpacked_exported_tl_mkey_t *tl_mkey)
 {
     const void *p = *start_p;
     const void *next_tl_md_p;
     size_t tl_mkey_data_size;
-    size_t tl_mkey_size, global_id_size;
+    uint8_t tl_mkey_size, global_id_size;
     const void *tl_mkey_buf;
     ucp_md_map_t md_map;
 
@@ -505,9 +504,10 @@ ucp_memh_exported_tl_mkey_data_unpack(ucp_context_h context,
     next_tl_md_p = UCS_PTR_BYTE_OFFSET(*start_p, tl_mkey_data_size);
     ucs_assertv(p <= next_tl_md_p, "p=%p, next_tl_md_p=%p", p, next_tl_md_p);
 
-    *start_p       = next_tl_md_p;
-    *tl_mkey_buf_p = tl_mkey_buf;
-    *md_map_p      = md_map;
+    *start_p              = next_tl_md_p;
+    tl_mkey->tl_mkey_buf  = tl_mkey_buf;
+    tl_mkey->tl_mkey_size = tl_mkey_size;
+    tl_mkey->local_md_map = md_map;
 }
 
 ucs_status_t
@@ -555,8 +555,7 @@ ucp_memh_exported_unpack(ucp_context_h context, const void *export_mkey_buffer,
         ucs_assertv(unpacked->num_tl_mkeys < UCP_MAX_MDS, "num_tl_mkeys=%u"
                     " UCP_MAX_MDS=%u", unpacked->num_tl_mkeys, UCP_MAX_MDS);
         tl_mkey = &unpacked->tl_mkeys[unpacked->num_tl_mkeys++];
-        ucp_memh_exported_tl_mkey_data_unpack(context, &p, &tl_mkey->tl_mkey_buf,
-                                              &tl_mkey->local_md_map);
+        ucp_memh_exported_tl_mkey_data_unpack(context, &p, tl_mkey);
     }
 
     if (unpacked->num_tl_mkeys == 0) {

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -123,6 +123,7 @@ typedef struct ucp_rkey {
 
 typedef struct ucp_unpacked_exported_tl_mkey {
     ucp_md_map_t   local_md_map; /* Local MD map of packed TL mkeys */
+    uint8_t        tl_mkey_size; /* Size of the mkey buffer */
     const void     *tl_mkey_buf; /* Packed TL mkey buffer */
 } ucp_unpacked_exported_tl_mkey_t;
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -245,7 +245,9 @@ typedef enum {
  */
 typedef enum {
     /** Enables @ref uct_md_mem_attach_params_t.flags field */
-    UCT_MD_MEM_ATTACH_FIELD_FLAGS = UCS_BIT(0)
+    UCT_MD_MEM_ATTACH_FIELD_FLAGS     = UCS_BIT(0),
+    /** Enables @ref uct_md_mem_attach_params_t.mkey_size field */
+    UCT_MD_MEM_ATTACH_FIELD_MKEY_SIZE = UCS_BIT(1)
 } uct_md_mem_attach_field_mask_t;
 
 
@@ -544,6 +546,11 @@ typedef struct uct_md_mem_attach_params {
      * @ref uct_md_mem_attach_flags_t.
      */
     uint64_t                     flags;
+
+    /**
+     * Size of the memory key.
+     */
+    size_t                       mkey_size;
 } uct_md_mem_attach_params_t;
 
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -156,6 +156,7 @@ typedef struct uct_ib_md {
      * be initiated.  */
     uint32_t                 flush_rkey;
     uint16_t                 vhca_id;
+    uint64_t                 uuid;
     struct {
         uint32_t             base;
         uint32_t             size;
@@ -163,9 +164,10 @@ typedef struct uct_ib_md {
 } uct_ib_md_t;
 
 
-typedef struct uct_ib_md_packed_mkey {
+typedef struct {
     uint32_t lkey;
     uint16_t vhca_id;
+    uint64_t md_uuid;
 } UCS_S_PACKED uct_ib_md_packed_mkey_t;
 
 
@@ -273,6 +275,7 @@ uct_ib_md_pack_exported_mkey(uct_ib_md_t *md, uint32_t lkey, void *buffer)
 
     mkey->lkey    = lkey;
     mkey->vhca_id = md->vhca_id;
+    mkey->md_uuid = md->uuid;
 
     ucs_trace("packed exported mkey on %s: lkey 0x%x",
               uct_ib_device_name(&md->dev), lkey);

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -14,6 +14,7 @@
 #include <ucs/profile/profile.h>
 #include <ucs/sys/ptr_arith.h>
 #include <ucs/time/time.h>
+#include <ucs/type/serialize.h>
 
 /* max log value to store in uint8_t */
 #define UCT_IB_MLX5_MD_MAX_DCI_CHANNELS 8
@@ -1434,9 +1435,21 @@ uct_ib_mlx5_devx_umr_mkey_hash_find(uct_ib_mlx5_md_t *md,
     }
 
     *umr_alias = kh_val(md->umr.mkey_hash, khiter);
-    ucs_trace("%s: found " UCT_IB_MLX5_UMR_ALIAS_FMT " for index 0x%x in hash",
-              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias),
-              uct_ib_mlx5_mkey_index(packed_mkey->lkey));
+
+    /* Check if alias is from the same MD as packed_mkey */
+    if (packed_mkey->md_uuid != umr_alias->md_uuid) {
+        ucs_debug("%s: found " UCT_IB_MLX5_UMR_ALIAS_FMT " in hash, but uuid %"
+                  PRIu64 " doesn't match, removing stale alias",
+                  uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias),
+                  packed_mkey->md_uuid);
+        /* Remove stale entry from hash, and destroy */
+        kh_del(umr_mkey_map, md->umr.mkey_hash, khiter);
+        uct_ib_mlx5_devx_umr_mkey_alias_destroy(md, umr_alias);
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    ucs_trace("%s: found " UCT_IB_MLX5_UMR_ALIAS_FMT " in hash",
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias));
     return UCS_OK;
 }
 
@@ -1466,9 +1479,8 @@ uct_ib_mlx5_devx_umr_mkey_hash_put(uct_ib_mlx5_md_t *md,
     }
 
     kh_val(md->umr.mkey_hash, khiter) = *umr_alias;
-    ucs_trace("%s: added " UCT_IB_MLX5_UMR_ALIAS_FMT " for index 0x%x to hash",
-              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias),
-              uct_ib_mlx5_mkey_index(packed_mkey->lkey));
+    ucs_trace("%s: added " UCT_IB_MLX5_UMR_ALIAS_FMT " to hash",
+              uct_ib_mlx5_dev_name(md), UCT_IB_MLX5_UMR_ALIAS_ARG(umr_alias));
     return UCS_OK;
 }
 
@@ -2420,6 +2432,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     md->flags           |= UCT_IB_MLX5_MD_FLAGS_DEVX_OBJS(md_config->devx_objs);
     md->super.name       = UCT_IB_MD_NAME(mlx5);
     md->super.vhca_id    = vhca_id;
+    md->super.uuid       = ucs_generate_uuid((uintptr_t)md);
 
     if ((md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI) &&
         (md_config->xgvmi_umr_enable == UCS_YES)) {
@@ -2925,6 +2938,25 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE uct_ib_md_packed_mkey_t
+uct_ib_mlx5_devx_get_packed_mkey(const void *mkey_buffer, size_t mkey_size)
+{
+    const void *p = mkey_buffer;
+    uct_ib_md_packed_mkey_t packed_mkey;
+
+    packed_mkey.lkey    = *ucs_serialize_next(&p, uint32_t);
+    packed_mkey.vhca_id = *ucs_serialize_next(&p, uint16_t);
+    packed_mkey.md_uuid = 0;
+
+    /* Backward compatibility: extract MD UUID from mkey buffer only if it's
+     * present there */
+    if (mkey_size > ucs_offsetof(uct_ib_md_packed_mkey_t, md_uuid)) {
+        packed_mkey.md_uuid = *ucs_serialize_next(&p, uint64_t);
+    }
+
+    return packed_mkey;
+}
+
 ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
                                          const void *mkey_buffer,
                                          uct_md_mem_attach_params_t *params,
@@ -2935,7 +2967,9 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     uct_ib_mlx5_md_t *md = ucs_derived_of(uct_md, uct_ib_mlx5_md_t);
     const uint64_t flags = UCT_MD_MEM_ATTACH_FIELD_VALUE(params, flags,
                                                          FIELD_FLAGS, 0);
-    const uct_ib_md_packed_mkey_t *packed_mkey = mkey_buffer;
+    size_t mkey_size     = UCT_MD_MEM_ATTACH_FIELD_VALUE(params, mkey_size,
+                                                         FIELD_MKEY_SIZE, 0);
+    uct_ib_md_packed_mkey_t packed_mkey;
     uct_ib_mlx5_devx_umr_alias_t umr_alias     = {};
     uct_ib_mlx5_devx_mem_t *memh;
     void *hdr, *alias_ctx;
@@ -2948,11 +2982,12 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
         goto err;
     }
 
-    hdr       = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, hdr);
-    alias_ctx = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, alias_ctx);
+    hdr         = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, hdr);
+    alias_ctx   = UCT_IB_MLX5DV_ADDR_OF(create_alias_obj_in, in, alias_ctx);
+    packed_mkey = uct_ib_mlx5_devx_get_packed_mkey(mkey_buffer, mkey_size);
 
     /* Try to find alias in the UMR hash map */
-    status = uct_ib_mlx5_devx_umr_mkey_hash_find(md, packed_mkey, &umr_alias);
+    status = uct_ib_mlx5_devx_umr_mkey_hash_find(md, &packed_mkey, &umr_alias);
     if (UCS_OK == status) {
         memh->super.lkey = umr_alias.lkey;
         goto out;
@@ -2966,15 +3001,16 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     UCT_IB_MLX5DV_SET(general_obj_in_cmd_hdr, hdr, alias_object, 1);
 
     UCT_IB_MLX5DV_SET(alias_context, alias_ctx, vhca_id_to_be_accessed,
-                      packed_mkey->vhca_id);
+                      packed_mkey.vhca_id);
     UCT_IB_MLX5DV_SET(alias_context, alias_ctx, object_id_to_be_accessed,
-                      uct_ib_mlx5_mkey_index(packed_mkey->lkey));
+                      uct_ib_mlx5_mkey_index(packed_mkey.lkey));
     UCT_IB_MLX5DV_SET(alias_context, alias_ctx, metadata_1,
                       uct_ib_mlx5_devx_md_get_pdn(md));
     access_key = UCT_IB_MLX5DV_ADDR_OF(alias_context, alias_ctx, access_key);
     ucs_strncpy_zero(access_key, uct_ib_mkey_token,
                      UCT_IB_MLX5DV_FLD_SZ_BYTES(alias_context, access_key));
 
+    umr_alias.md_uuid  = packed_mkey.md_uuid;
     umr_alias.cross_mr = uct_ib_mlx5_devx_obj_create(md->super.dev.ibv_context,
                                                      in, sizeof(in), out,
                                                      sizeof(out), "MKEY_ALIAS",
@@ -2997,10 +3033,10 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
                        md->mkey_tag;
 
     /* If received mkey is UMR key, store alias in the UMR hash map */
-    if (uct_ib_mlx5_devx_mkey_is_umr(packed_mkey->lkey)) {
+    if (uct_ib_mlx5_devx_mkey_is_umr(packed_mkey.lkey)) {
         umr_alias.lkey = memh->super.lkey;
 
-        status = uct_ib_mlx5_devx_umr_mkey_hash_put(md, packed_mkey, &umr_alias);
+        status = uct_ib_mlx5_devx_umr_mkey_hash_put(md, &packed_mkey, &umr_alias);
         if (UCS_OK != status) {
             goto err_cross_mr_destroy;
         }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -307,13 +307,14 @@ typedef struct {
 typedef struct {
     struct mlx5dv_devx_obj *cross_mr;
     uint32_t               lkey;
+    uint64_t               md_uuid;
 } uct_ib_mlx5_devx_umr_alias_t;
 
 
-#define UCT_IB_MLX5_UMR_ALIAS_FMT "UMR mkey alias %p index 0x%x"
+#define UCT_IB_MLX5_UMR_ALIAS_FMT "UMR mkey alias %p index 0x%x uuid %" PRIu64
 #define UCT_IB_MLX5_UMR_ALIAS_ARG(_umr_alias) \
-    (_umr_alias)->cross_mr, uct_ib_mlx5_mkey_index((_umr_alias)->lkey)
-
+    (_umr_alias)->cross_mr, uct_ib_mlx5_mkey_index((_umr_alias)->lkey), \
+    (_umr_alias)->md_uuid
 
 /* Hash map of indirect mkey (from the host) to mkey alias (on the DPU) */
 /* Note the hash key here is: gvmi_id << 32 | mkey (both uint32_t) */


### PR DESCRIPTION
## What
First CI test for perftest_daemon.

## Why ?
XGVMI functionality must be covered by CI tests to prevent regressions.

## How ?
Some refactoring was needed to allow daemon to support perftest batch mode:
- Moved command line arguments from `TEST_PARAMS_ARGS` (i.e. per-test options) to global options. Reason: these daemon offloading options are immutable during the process lifetime, and should not be changed on per-test basis. It's pretty much like existing options for receiver IP and port.
- Moved daemon-related config params into a separate struct
- Added `daemon-keep-alive` option, to keep daemon alive across multiple test runs
- Support "reconnection" for daemon clients. That means that TCP connection between host and daemon is not reestablished, but it's possible to reconnect to daemon from another EP (INIT and FIN are reentrant)
- Support for batch mode: unless `daemon-keep-alive` option is specified - kill daemon at the end of the batch run  