### PR TITLE
Update running.md

### DIFF
--- a/docs/source/running.md
+++ b/docs/source/running.md
@@ -67,6 +67,8 @@ improvements.
 1. Get latest-and-greatest OpenMPI version:
   ```
   $ git clone https://github.com/open-mpi/ompi.git
+  $ git submodule sync
+  $ git submodule update --init --recursive
   $ cd ompi
   $ ./autogen.pl
   ```


### PR DESCRIPTION
**Commit Summary:** Fix Missing Submodule Error in OMPI Repository Cloning

**Detailed Description:**

When cloning the Open MPI (OMPI) repository, it's essential to ensure that all required submodules are correctly synchronized and retrieved. Failing to do so results in an error during the execution of `autogen.pl`. This error is indicative of missing submodules, which are crucial for the successful setup of the OMPI environment.

**Error Message:** `ERROR: Missing submodule`

**Missing Submodule:** The specific submodule identified as missing is `config/oac`.

**Steps to Reproduce:**
1. Clone the OMPI repository using the following command: 
2. Navigate to the cloned repository directory:
3. Run the `autogen.pl` script: Following these steps without the necessary submodule synchronization leads to the mentioned error, indicating a missing `config/oac` submodule.

## What
_Describe what this PR is doing._ 
This PR modifies running UCX documentation and add two more git commands to sync and retrieve ucx submodules user must run before running the autogen.pl script so that it would not face any errors.
## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._
Running the mentioned commands in running documentation in sequential resulted in the ERROR: Missing submodule.
## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
