### PR TITLE
UCP/PROTO: Implement protocol probe for rendezvous, to support variants

### DIFF
--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -59,21 +59,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
     return ucp_proto_am_handle_user_header_send_status(req, status);
 }
 
-ucs_status_t ucp_am_rndv_rts_init(const ucp_proto_init_params_t *init_params)
+static void ucp_am_rndv_rts_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_am_check_init_params(init_params, UCP_PROTO_AM_OP_ID_MASK,
                                   UCP_PROTO_SELECT_OP_FLAG_AM_EAGER)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_rts_init(init_params);
+    ucp_proto_rndv_rts_probe(init_params);
 }
 
 ucp_proto_t ucp_am_rndv_proto = {
     .name     = "am/rndv",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_am_rndv_rts_init,
+    .probe    = ucp_am_rndv_rts_probe,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_am_rndv_proto_progress},
     .abort    = ucp_proto_rndv_rts_abort,

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -150,25 +150,17 @@ typedef struct {
 
 /**
  * UCP protocol capabilities (per operation parameters)
+ * TODO rename to ucp_proto_perf_t ??
  */
 typedef struct {
-    /* Configured protocol threshold
-       NOTE will be removed when all protocols implement probe() instead of init() */
-    size_t                  cfg_thresh;
-
-    /* Priority of configuration
-       NOTE will be removed when all protocols implement probe() instead of init() */
-    unsigned                cfg_priority;
-
     /* Minimal message size */
-    size_t                  min_length;
+    size_t                 min_length;
 
     /* Number of entries in 'ranges' */
-    unsigned                num_ranges;
+    unsigned               num_ranges;
 
     /* Performance estimation function for different message sizes */
-    ucp_proto_perf_range_t  ranges[UCP_PROTO_MAX_PERF_RANGES];
-
+    ucp_proto_perf_range_t ranges[UCP_PROTO_MAX_PERF_RANGES];
 } ucp_proto_caps_t;
 
 
@@ -186,38 +178,8 @@ typedef struct {
     const ucp_rkey_config_key_t    *rkey_config_key; /* Remote key configuration,
                                                         may be NULL */
     ucp_proto_id_t                 proto_id;         /* Initial protocol ID */
-    const char                     *proto_name;      /* Name of the initialized
-                                                        protocol, for debugging */
-    ucp_proto_probe_ctx_t          *ctx;             /* Selection context for
-                                                        adding a protocol instance */
-
-    /* Output parameters */
-    void                           *priv;       /* Pointer to priv buffer */
-    size_t                         *priv_size;  /* Occupied size in priv buffer */
-    ucp_proto_caps_t               *caps;       /* Protocol capabilities */
+    ucp_proto_probe_ctx_t          *ctx;             /* Context for adding caps */
 } ucp_proto_init_params_t;
-
-
-/**
- * Initialize protocol-specific configuration and estimate protocol performance
- * as function of message size.
- *
- * @param [in]  params   Protocol initialization parameters.
- */
-typedef void (*ucp_proto_probe_func_t)(const ucp_proto_init_params_t *params);
-
-
-/**
- * Initialize protocol-specific configuration and estimate protocol performance
- * as function of message size.
- *
- * @param [in]  params   Protocol initialization parameters.
- *
- * @return UCS_OK              - if successful.
- *         UCS_ERR_UNSUPPORTED - if the protocol is not supported on the key.
- */
-typedef ucs_status_t
-(*ucp_proto_init_func_t)(const ucp_proto_init_params_t *params);
 
 
 typedef struct {
@@ -260,6 +222,15 @@ typedef struct {
     /* Map of used lanes */
     ucp_lane_map_t lane_map;
 } ucp_proto_query_attr_t;
+
+
+/**
+ * Initialize protocol-specific configuration and estimate protocol performance
+ * as function of message size.
+ *
+ * @param [in]  params  Protocol initialization parameters.
+ */
+typedef void (*ucp_proto_probe_func_t)(const ucp_proto_init_params_t *params);
 
 
 /**
@@ -309,12 +280,6 @@ struct ucp_proto {
 
     /* Probe and add protocol instances */
     ucp_proto_probe_func_t   probe;
-
-    /*
-     * Initialization function
-     * TODO remove after all protocols are using probe
-     */
-    ucp_proto_init_func_t    init;
 
     /* Query protocol information */
     ucp_proto_query_func_t   query;

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -245,8 +245,16 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
 
 
 /* @return number of lanes found */
+ucp_lane_index_t ucp_proto_common_find_lanes_with_min_frag(
+        const ucp_proto_common_init_params_t *params, ucp_lane_type_t lane_type,
+        uint64_t tl_cap_flags, ucp_lane_index_t max_lanes,
+        ucp_lane_map_t exclude_map, ucp_lane_index_t *lanes);
+
+
 ucp_lane_index_t
-ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
+ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
+                            uct_ep_operation_t memtype_op, unsigned flags,
+                            ptrdiff_t max_iov_offs, size_t min_iov,
                             ucp_lane_type_t lane_type, uint64_t tl_cap_flags,
                             ucp_lane_index_t max_lanes,
                             ucp_lane_map_t exclude_map,
@@ -256,10 +264,6 @@ ucp_proto_common_find_lanes(const ucp_proto_common_init_params_t *params,
 ucp_md_map_t
 ucp_proto_common_reg_md_map(const ucp_proto_common_init_params_t *params,
                             ucp_lane_map_t lane_map);
-
-
-ucp_lane_index_t
-ucp_proto_common_find_am_bcopy_hdr_lane(const ucp_proto_init_params_t *params);
 
 
 void ucp_proto_common_add_proto(const ucp_proto_common_init_params_t *params,

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -81,12 +81,13 @@ void ucp_proto_select_perf_str(const ucs_linear_func_t *perf, char *time_str,
                       UCP_PROTO_PERF_FUNC_BW_ARG(perf));
 }
 
-void ucp_proto_select_init_trace_caps(const ucp_proto_init_params_t *init_params)
+void ucp_proto_select_init_trace_caps(const ucp_proto_init_params_t *init_params,
+                                      const ucp_proto_caps_t *proto_caps,
+                                      const void *priv)
 {
-    ucp_proto_caps_t *proto_caps          = init_params->caps;
     ucp_proto_query_params_t query_params = {
         .proto         = ucp_protocols[init_params->proto_id],
-        .priv          = init_params->priv,
+        .priv          = priv,
         .worker        = init_params->worker,
         .select_param  = init_params->select_param,
         .ep_config_key = init_params->ep_config_key,

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -59,8 +59,9 @@ void ucp_proto_select_perf_str(const ucs_linear_func_t *perf, char *time_str,
                                size_t bw_str_max);
 
 
-void ucp_proto_select_init_trace_caps(
-        const ucp_proto_init_params_t *init_params);
+void ucp_proto_select_init_trace_caps(const ucp_proto_init_params_t *init_params,
+                                      const ucp_proto_caps_t *proto_caps,
+                                      const void *priv);
 
 
 void ucp_proto_select_info(ucp_worker_h worker,

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -78,10 +78,8 @@ void ucp_proto_common_init_base_caps(
         const ucp_proto_common_init_params_t *params, ucp_proto_caps_t *caps,
         size_t min_length)
 {
-    caps->cfg_thresh   = params->cfg_thresh;
-    caps->cfg_priority = params->cfg_priority;
-    caps->min_length   = ucs_max(params->min_length, min_length);
-    caps->num_ranges   = 0;
+    caps->min_length = ucs_max(params->min_length, min_length);
+    caps->num_ranges = 0;
 }
 
 static int ucp_proto_perf_range_is_zero(const ucp_proto_perf_range_t *range)

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -54,21 +54,20 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     }
 
     /* Find first lane */
-    num_lanes = ucp_proto_common_find_lanes(&params->super,
-                                            params->first.lane_type,
-                                            params->first.tl_cap_flags, 1, 0,
-                                            lanes);
+    num_lanes = ucp_proto_common_find_lanes_with_min_frag(
+            &params->super, params->first.lane_type, params->first.tl_cap_flags,
+            1, 0, lanes);
     if (num_lanes == 0) {
-        ucs_trace("no lanes for %s", params->super.super.proto_name);
+        ucs_trace("no lanes for %s",
+                  ucp_proto_id_field(params->super.super.proto_id, name));
         return UCS_ERR_NO_ELEM;
     }
 
     /* Find rest of the lanes */
-    num_lanes += ucp_proto_common_find_lanes(&params->super,
-                                             params->middle.lane_type,
-                                             params->middle.tl_cap_flags,
-                                             UCP_PROTO_MAX_LANES - 1,
-                                             UCS_BIT(lanes[0]), lanes + 1);
+    num_lanes += ucp_proto_common_find_lanes_with_min_frag(
+            &params->super, params->middle.lane_type,
+            params->middle.tl_cap_flags, UCP_PROTO_MAX_LANES - 1,
+            UCS_BIT(lanes[0]), lanes + 1);
 
     /* Get bandwidth of all lanes and max_bandwidth */
     max_bandwidth = 0;

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -165,9 +165,6 @@ void ucp_proto_select_add_proto(const ucp_proto_init_params_t *init_params,
                                 const void *priv, size_t priv_size);
 
 
-void ucp_proto_select_caps_reset(ucp_proto_caps_t *caps);
-
-
 void ucp_proto_select_caps_cleanup(ucp_proto_caps_t *caps);
 
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -29,11 +29,12 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
     ucp_lane_index_t lane;
     ucs_status_t status;
 
-    num_lanes = ucp_proto_common_find_lanes(&params->super, params->lane_type,
-                                            params->tl_cap_flags, 1,
-                                            params->super.exclude_map, &lane);
+    num_lanes = ucp_proto_common_find_lanes_with_min_frag(
+            &params->super, params->lane_type, params->tl_cap_flags, 1,
+            params->super.exclude_map, &lane);
     if (num_lanes == 0) {
-        ucs_trace("no lanes for %s", params->super.super.proto_name);
+        ucs_trace("no lanes for %s",
+                  ucp_proto_id_field(params->super.super.proto_id, name));
         return UCS_ERR_NO_ELEM;
     }
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -179,7 +179,7 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
                                                remote_select_param);
     if (select_elem == NULL) {
         ucs_debug("%s: did not find protocol for %s",
-                  params->super.super.proto_name,
+                  ucp_proto_id_field(params->super.super.proto_id, name),
                   ucp_operation_names[params->remote_op_id]);
         return UCS_ERR_UNSUPPORTED;
     }
@@ -227,19 +227,17 @@ ucp_proto_rndv_ctrl_perf(const ucp_proto_init_params_t *params,
 
 static ucs_status_t
 ucp_proto_rndv_ctrl_init_priv(const ucp_proto_rndv_ctrl_init_params_t *params,
-                              ucp_lane_index_t lane)
+                              ucp_proto_rndv_ctrl_priv_t *rpriv)
 {
     const ucp_proto_init_params_t *init_params = &params->super.super;
     ucp_context_h context                      = init_params->worker->context;
-    ucp_proto_rndv_ctrl_priv_t *rpriv          = init_params->priv;
     const ucp_proto_select_param_t *select_param;
     ucp_proto_select_param_t remote_select_param;
     ucp_memory_info_t mem_info;
     uint32_t op_attr_mask;
 
-    select_param            = init_params->select_param;
-    *init_params->priv_size = sizeof(ucp_proto_rndv_ctrl_priv_t);
-    rpriv->lane             = lane;
+    select_param = init_params->select_param;
+    rpriv->lane  = params->lane;
 
     op_attr_mask = ucp_proto_select_op_attr_unpack(select_param->op_attr) &
                    UCP_OP_ATTR_FLAG_MULTI_SEND;
@@ -282,11 +280,10 @@ ucp_proto_rndv_ctrl_init_priv(const ucp_proto_rndv_ctrl_init_params_t *params,
 
 ucs_status_t
 ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
-                         ucp_lane_index_t lane)
+                         ucp_proto_caps_t *proto_caps,
+                         ucp_proto_rndv_ctrl_priv_t *priv)
 {
-    ucp_proto_rndv_ctrl_priv_t *rpriv = params->super.super.priv;
-    const char *rndv_op_name          = ucp_operation_names[params->remote_op_id];
-    ucp_proto_caps_t *caps            = params->super.super.caps;
+    const char *rndv_op_name = ucp_operation_names[params->remote_op_id];
     const ucp_proto_perf_range_t *parallel_stages[2];
     size_t min_length, max_length, range_max_length;
     ucp_proto_perf_range_t ctrl_perf, remote_perf;
@@ -300,17 +297,19 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
     ucs_assert(params->super.flags & UCP_PROTO_COMMON_INIT_FLAG_RESPONSE);
     ucs_assert(!(params->super.flags & UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG));
 
-    if (!ucp_proto_common_init_check_err_handling(&params->super)) {
-        return UCS_ERR_UNSUPPORTED;
+    if ((params->lane == UCP_NULL_LANE) ||
+        !ucp_proto_common_init_check_err_handling(&params->super)) {
+        status = UCS_ERR_UNSUPPORTED;
+        goto out;
     }
 
     /* Initialize 'rpriv' structure */
-    status = ucp_proto_rndv_ctrl_init_priv(params, lane);
+    status = ucp_proto_rndv_ctrl_init_priv(params, priv);
     if (status != UCS_OK) {
         goto out;
     }
 
-    if (!ucp_proto_select_get_valid_range(rpriv->remote_proto.thresholds,
+    if (!ucp_proto_select_get_valid_range(priv->remote_proto.thresholds,
                                           &min_length, &max_length)) {
         status = UCS_ERR_UNSUPPORTED;
         goto out;
@@ -321,13 +320,13 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
     ucp_proto_perf_node_add_child(ctrl_perf.node, params->unpack_perf_node);
 
     /* Set send_overheads to the time to send and receive RTS message */
-    status = ucp_proto_rndv_ctrl_perf(&params->super.super, rpriv->lane,
+    status = ucp_proto_rndv_ctrl_perf(&params->super.super, priv->lane,
                                       &send_time, &receive_time);
     if (status != UCS_OK) {
-        return status;
+        goto out;
     }
 
-    ucp_proto_init_memreg_time(&params->super, rpriv->md_map, &memreg_time,
+    ucp_proto_init_memreg_time(&params->super, priv->md_map, &memreg_time,
                                &memreg_perf_node);
     ucp_proto_perf_node_own_child(ctrl_perf.node, &memreg_perf_node);
 
@@ -342,18 +341,19 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
     ucp_proto_perf_range_add_data(&ctrl_perf);
 
     /* Set rendezvous protocol properties */
-    ucp_proto_common_init_base_caps(&params->super, caps, min_length);
+    ucp_proto_common_init_base_caps(&params->super, proto_caps, min_length);
 
     /* Copy performance ranges from the remote protocol, and add overheads */
-    remote_range = rpriv->remote_proto.perf_ranges;
+    remote_range = priv->remote_proto.perf_ranges;
     do {
         range_max_length = ucs_min(remote_range->max_length, max_length);
-        if (range_max_length < caps->min_length) {
+        if (range_max_length < proto_caps->min_length) {
             continue;
         }
 
         ucs_trace("%s: max %zu remote-op %s %s" UCP_PROTO_PERF_FUNC_TYPES_FMT,
-                  params->super.super.proto_name, remote_range->max_length,
+                  ucp_proto_id_field(params->super.super.proto_id, name),
+                  remote_range->max_length,
                   ucp_operation_names[params->remote_op_id],
                   ucp_proto_perf_node_name(remote_range->node),
                   UCP_PROTO_PERF_FUNC_TYPES_ARG(remote_range->perf));
@@ -367,10 +367,10 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
 
         parallel_stages[0] = &ctrl_perf;
         parallel_stages[1] = &remote_perf;
-        status = ucp_proto_init_parallel_stages(params->super.super.proto_name,
+        status = ucp_proto_init_parallel_stages(params->ctrl_msg_name,
                                                 min_length, range_max_length,
                                                 params->perf_bias,
-                                                parallel_stages, 2, caps);
+                                                parallel_stages, 2, proto_caps);
         if (status != UCS_OK) {
             goto out_deref_perf_node;
         }
@@ -386,6 +386,20 @@ out_deref_perf_node:
     ucp_proto_perf_node_deref(&ctrl_perf.node);
 out:
     return status;
+}
+
+void ucp_proto_rndv_ctrl_probe(const ucp_proto_rndv_ctrl_init_params_t *params)
+{
+    ucp_proto_rndv_ctrl_priv_t priv;
+    ucp_proto_caps_t caps;
+    ucs_status_t status;
+
+    status = ucp_proto_rndv_ctrl_init(params, &caps, &priv);
+    if (status != UCS_OK) {
+        return;
+    }
+
+    ucp_proto_common_add_proto(&params->super, &caps, &priv, sizeof(priv));
 }
 
 size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params)
@@ -413,23 +427,29 @@ size_t ucp_proto_rndv_thresh(const ucp_proto_init_params_t *init_params)
     return rndv_thresh;
 }
 
-ucs_status_t
-ucp_proto_rndv_ctrl_am_init(const ucp_proto_rndv_ctrl_init_params_t *params)
+ucp_lane_index_t
+ucp_proto_rndv_find_ctrl_lane(const ucp_proto_init_params_t *params)
 {
-    ucp_lane_index_t lane;
+    ucp_lane_index_t lane, num_lanes;
 
-    /* Find lane to send the initial message */
-    lane = ucp_proto_common_find_am_bcopy_hdr_lane(&params->super.super);
-    if (lane == UCP_NULL_LANE) {
-        return UCS_ERR_NO_ELEM;
+    num_lanes = ucp_proto_common_find_lanes(params, UCT_EP_OP_LAST,
+                                            UCP_PROTO_COMMON_INIT_FLAG_HDR_ONLY,
+                                            UCP_PROTO_COMMON_OFFSET_INVALID, 1,
+                                            UCP_LANE_TYPE_AM,
+                                            UCT_IFACE_FLAG_AM_BCOPY, 1, 0,
+                                            &lane);
+    if (num_lanes == 0) {
+        ucs_debug("no active message lane for %s",
+                  ucp_proto_id_field(params->proto_id, name));
+        return UCP_NULL_LANE;
     }
 
-    ucs_assert(params->super.send_op == UCT_EP_OP_AM_BCOPY);
-
-    return ucp_proto_rndv_ctrl_init(params, lane);
+    ucs_assertv(num_lanes == 1, "proto=%s num_lanes=%u",
+                ucp_proto_id_field(params->proto_id, name), num_lanes);
+    return lane;
 }
 
-ucs_status_t ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params)
+void ucp_proto_rndv_rts_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_h context                    = init_params->worker->context;
     ucp_proto_rndv_ctrl_init_params_t params = {
@@ -451,6 +471,7 @@ ucs_status_t ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
         .remote_op_id        = UCP_OP_ID_RNDV_RECV,
+        .lane                = ucp_proto_rndv_find_ctrl_lane(init_params),
         .unpack_time         = UCS_LINEAR_FUNC_ZERO,
         .perf_bias           = context->config.ext.rndv_perf_diff / 100.0,
         .mem_info.type       = init_params->select_param->mem_type,
@@ -459,7 +480,7 @@ ucs_status_t ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params)
         .md_map              = 0
     };
 
-    return ucp_proto_rndv_ctrl_am_init(&params);
+    ucp_proto_rndv_ctrl_probe(&params);
 }
 
 void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
@@ -535,7 +556,7 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
                                      const ucp_proto_caps_t *input_caps,
                                      ucs_linear_func_t overhead,
                                      ucp_proto_rndv_ack_priv_t *apriv,
-                                     unsigned flags)
+                                     ucp_proto_caps_t *caps)
 {
     const ucp_proto_perf_range_t *parallel_stages[2];
     ucp_proto_perf_range_t ack_range;
@@ -547,7 +568,7 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
         /* Not sending ACK */
         apriv->lane = UCP_NULL_LANE;
     } else {
-        apriv->lane = ucp_proto_common_find_am_bcopy_hdr_lane(init_params);
+        apriv->lane = ucp_proto_rndv_find_ctrl_lane(init_params);
         if (apriv->lane == UCP_NULL_LANE) {
             return UCS_ERR_NO_ELEM;
         }
@@ -564,10 +585,8 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
     ucp_proto_perf_range_add_data(&ack_range);
 
     /* Copy basic capabilities from bulk protocol */
-    init_params->caps->cfg_thresh   = input_caps->cfg_thresh;
-    init_params->caps->cfg_priority = input_caps->cfg_priority;
-    init_params->caps->min_length   = input_caps->min_length;
-    init_params->caps->num_ranges   = 0;
+    caps->min_length = input_caps->min_length;
+    caps->num_ranges = 0;
 
     min_length = input_caps->min_length;
 
@@ -578,11 +597,9 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
         parallel_stages[0] = &ack_range;
         parallel_stages[1] = &input_caps->ranges[i];
 
-        status = ucp_proto_init_parallel_stages(init_params->proto_name,
-                                                min_length,
-                                                ack_range.max_length,
-                                                0, parallel_stages, 2,
-                                                init_params->caps);
+        status = ucp_proto_init_parallel_stages(
+                ucp_proto_id_field(init_params->proto_id, name), min_length,
+                ack_range.max_length, 0, parallel_stages, 2, caps);
         if (status != UCS_OK) {
             break;
         }
@@ -597,8 +614,9 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
 
 ucs_status_t
 ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
-                         ucp_proto_rndv_bulk_priv_t *rpriv, const char *name,
-                         const char *ack_name, size_t *priv_size_p)
+                         const char *name, const char *ack_name,
+                         ucp_proto_rndv_bulk_priv_t *rpriv,
+                         ucp_proto_caps_t *caps)
 {
     ucp_context_t *context        = init_params->super.super.worker->context;
     size_t rndv_align_thresh      = context->config.ext.rndv_align_thresh;
@@ -606,7 +624,7 @@ ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
     ucp_proto_caps_t multi_caps;
     ucs_status_t status;
 
-    status = ucp_proto_multi_init(init_params, &multi_caps, &rpriv->mpriv);
+    status = ucp_proto_multi_init(init_params, &multi_caps, mpriv);
     if (status != UCS_OK) {
         return status;
     }
@@ -615,15 +633,11 @@ ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
     mpriv->align_thresh = ucs_max(rndv_align_thresh,
                                   mpriv->align_thresh + mpriv->min_frag);
 
-    /* Update private data size based of ucp_proto_multi_priv_t variable size */
-    *priv_size_p = UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(rpriv, mpriv);
-
     /* Add ack latency */
     status = ucp_proto_rndv_ack_init(&init_params->super.super, ack_name,
                                      &multi_caps,
                                      ucs_linear_func_make(150e-9, 0),
-                                     &rpriv->super, init_params->super.flags);
-
+                                     &rpriv->super, caps);
     ucp_proto_select_caps_cleanup(&multi_caps);
 
     return status;

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -69,12 +69,9 @@ typedef struct {
 typedef struct {
     ucp_proto_rndv_ack_priv_t super;
 
-    /*
-     * Multi-lane common part.
-     * Must be the last element in this struct, since it's variable-size and
-     * ends with a zero-size array.
-     */
-    ucp_proto_multi_priv_t mpriv;
+    /* Multi-lane common part. Must be the last field, see
+       @ref ucp_proto_multi_priv_t */
+    ucp_proto_multi_priv_t    mpriv;
 } ucp_proto_rndv_bulk_priv_t;
 
 
@@ -86,6 +83,9 @@ typedef struct {
 
     /* Which operation the remote peer is expected to perform */
     ucp_operation_id_t             remote_op_id;
+
+    /* Lane to send control message */
+    ucp_lane_index_t               lane;
 
     /* Time to unpack the received data */
     ucs_linear_func_t              unpack_time;
@@ -106,7 +106,6 @@ typedef struct {
 
     /* Map of mandatory mds which keys should be packed to the rkey */
     ucp_md_map_t                   md_map;
-
 } ucp_proto_rndv_ctrl_init_params_t;
 
 /* Return rendezvous threshold for the provided configuration */
@@ -137,19 +136,19 @@ enum {
 /* Initializes protocol which sends rendezvous control message using AM lane
  * (e.g. RTS and ATS). */
 ucs_status_t
-ucp_proto_rndv_ctrl_am_init(const ucp_proto_rndv_ctrl_init_params_t *params);
-
-
-/* Initializes protocol which sends rendezvous control message using specified
- * lane. Can be used by tag matching offload rendezvous protocols, which use
- * tag lane for sending control messages. */
-ucs_status_t
 ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
-                         ucp_lane_index_t lane);
+                         ucp_proto_caps_t *proto_caps,
+                         ucp_proto_rndv_ctrl_priv_t *priv);
 
 
-ucs_status_t
-ucp_proto_rndv_rts_init(const ucp_proto_init_params_t *init_params);
+void ucp_proto_rndv_ctrl_probe(const ucp_proto_rndv_ctrl_init_params_t *params);
+
+
+ucp_lane_index_t
+ucp_proto_rndv_find_ctrl_lane(const ucp_proto_init_params_t *params);
+
+
+void ucp_proto_rndv_rts_probe(const ucp_proto_init_params_t *init_params);
 
 
 void ucp_proto_rndv_rts_query(const ucp_proto_query_params_t *params,
@@ -160,18 +159,20 @@ void ucp_proto_rndv_rts_abort(ucp_request_t *req, ucs_status_t status);
 
 ucs_status_t ucp_proto_rndv_rts_reset(ucp_request_t *req);
 
-ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *params,
+
+ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
                                      const char *name,
-                                     const ucp_proto_caps_t *bulk_caps,
+                                     const ucp_proto_caps_t *input_caps,
                                      ucs_linear_func_t overhead,
                                      ucp_proto_rndv_ack_priv_t *apriv,
-                                     unsigned flags);
+                                     ucp_proto_caps_t *caps);
 
 
 ucs_status_t
 ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
-                         ucp_proto_rndv_bulk_priv_t *rpriv, const char *name,
-                         const char *ack_name, size_t *priv_size_p);
+                         const char *name, const char *ack_name,
+                         ucp_proto_rndv_bulk_priv_t *rpriv,
+                         ucp_proto_caps_t *caps);
 
 
 ucs_status_t ucp_proto_rndv_ats_progress(uct_pending_req_t *uct_req);

--- a/src/ucp/rndv/rndv_ats.c
+++ b/src/ucp/rndv/rndv_ats.c
@@ -11,25 +11,21 @@
 #include "proto_rndv.inl"
 
 
-static ucs_status_t
-ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *init_params)
+static void ucp_proto_rndv_ats_probe(const ucp_proto_init_params_t *init_params)
 {
+    ucp_proto_caps_t caps, input_caps;
+    ucp_proto_rndv_ack_priv_t priv;
     ucp_proto_perf_range_t *range0;
-    ucp_proto_caps_t caps;
     ucs_status_t status;
 
     if (ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    *init_params->priv_size = sizeof(ucp_proto_rndv_ack_priv_t);
-
-    caps.cfg_thresh   = 0;
-    caps.cfg_priority = 1;
-    caps.min_length   = 0;
-    caps.num_ranges   = 1;
-    range0            = &caps.ranges[0];
-    range0->node      = NULL;
+    input_caps.min_length = 0;
+    input_caps.num_ranges = 1;
+    range0                = &input_caps.ranges[0];
+    range0->node          = NULL;
     ucp_proto_perf_set(range0->perf, UCS_LINEAR_FUNC_ZERO);
 
     /* This protocols supports either a regular rendezvous receive but without
@@ -42,15 +38,19 @@ ucp_proto_rndv_ats_init(const ucp_proto_init_params_t *init_params)
                                        UCS_BIT(UCP_OP_ID_RNDV_RECV_DROP))) {
         range0->max_length = SIZE_MAX;
     } else {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
     status = ucp_proto_rndv_ack_init(init_params, UCP_PROTO_RNDV_ATS_NAME,
-                                     &caps, UCS_LINEAR_FUNC_ZERO,
-                                     init_params->priv, 0);
-    ucp_proto_select_caps_cleanup(&caps);
+                                     &input_caps, UCS_LINEAR_FUNC_ZERO, &priv,
+                                     &caps);
+    ucp_proto_select_caps_cleanup(&input_caps);
 
-    return status;
+    if (status != UCS_OK) {
+        return;
+    }
+
+    ucp_proto_select_add_proto(init_params, 0, 1, &caps, &priv, sizeof(priv));
 }
 
 static void
@@ -73,7 +73,7 @@ ucp_proto_t ucp_rndv_ats_proto = {
     .name     = "rndv/ats",
     .desc     = "no data fetch",
     .flags    = 0,
-    .init     = ucp_proto_rndv_ats_init,
+    .probe    = ucp_proto_rndv_ats_probe,
     .query    = ucp_proto_rndv_ats_query,
     .progress = {ucp_proto_rndv_ats_progress},
     .abort    = ucp_proto_rndv_ats_abort,

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -20,12 +20,12 @@ enum {
     UCP_PROTO_RNDV_GET_STAGE_ATS
 };
 
-static ucs_status_t
-ucp_proto_rndv_get_common_init(const ucp_proto_init_params_t *init_params,
-                               uint64_t rndv_modes, size_t max_length,
-                               uct_ep_operation_t memtype_op, unsigned flags,
-                               ucp_md_map_t initial_reg_md_map,
-                               int support_ppln)
+static void
+ucp_proto_rndv_get_common_probe(const ucp_proto_init_params_t *init_params,
+                                uint64_t rndv_modes, size_t max_length,
+                                uct_ep_operation_t memtype_op, unsigned flags,
+                                ucp_md_map_t initial_reg_md_map,
+                                int support_ppln)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
@@ -59,17 +59,25 @@ ucp_proto_rndv_get_common_init(const ucp_proto_init_params_t *init_params,
         .opt_align_offs      = ucs_offsetof(uct_iface_attr_t,
                                             cap.get.opt_zcopy_align),
     };
+    ucp_proto_rndv_bulk_priv_t rpriv;
+    ucp_proto_caps_t caps;
+    ucs_status_t status;
+    size_t priv_size;
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         !ucp_proto_rndv_op_check(init_params, UCP_OP_ID_RNDV_RECV,
                                  support_ppln)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_bulk_init(&params, init_params->priv,
-                                    UCP_PROTO_RNDV_GET_DESC,
-                                    UCP_PROTO_RNDV_ATS_NAME,
-                                    init_params->priv_size);
+    status = ucp_proto_rndv_bulk_init(&params, UCP_PROTO_RNDV_GET_DESC,
+                                      UCP_PROTO_RNDV_ATS_NAME, &rpriv, &caps);
+    if (status != UCS_OK) {
+        return;
+    }
+
+    priv_size = UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(&rpriv, mpriv);
+    ucp_proto_common_add_proto(&params.super, &caps, &rpriv, priv_size);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -109,15 +117,15 @@ ucp_proto_rndv_get_zcopy_fetch_completion(uct_completion_t *uct_comp)
     ucp_proto_rndv_recv_complete_with_ats(req, UCP_PROTO_RNDV_GET_STAGE_ATS);
 }
 
-static ucs_status_t
-ucp_proto_rndv_get_zcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_get_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
-    return ucp_proto_rndv_get_common_init(init_params,
-                                          UCS_BIT(UCP_RNDV_MODE_GET_ZCOPY),
-                                          SIZE_MAX, UCT_EP_OP_LAST,
-                                          UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
-                                          UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
-                                          0, 0);
+    ucp_proto_rndv_get_common_probe(
+            init_params, UCS_BIT(UCP_RNDV_MODE_GET_ZCOPY), SIZE_MAX,
+            UCT_EP_OP_LAST,
+            UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
+            UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+            0, 0);
 }
 
 static void
@@ -216,7 +224,7 @@ ucp_proto_t ucp_rndv_get_zcopy_proto = {
     .name     = "rndv/get/zcopy",
     .desc     = UCP_PROTO_ZCOPY_DESC " " UCP_PROTO_RNDV_GET_DESC,
     .flags    = 0,
-    .init     = ucp_proto_rndv_get_zcopy_init,
+    .probe    = ucp_proto_rndv_get_zcopy_probe,
     .query    = ucp_proto_rndv_get_zcopy_query,
     .progress = {
          [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_zcopy_fetch_progress,
@@ -300,8 +308,8 @@ ucp_proto_rndv_get_mtype_fetch_progress(uct_pending_req_t *uct_req)
                                     UCS_BIT(UCP_DATATYPE_CONTIG));
 }
 
-static ucs_status_t
-ucp_proto_rndv_get_mtype_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_md_map_t mdesc_md_map;
     ucs_status_t status;
@@ -309,13 +317,13 @@ ucp_proto_rndv_get_mtype_init(const ucp_proto_init_params_t *init_params)
 
     status = ucp_proto_rndv_mtype_init(init_params, &mdesc_md_map, &frag_size);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
-    return ucp_proto_rndv_get_common_init(init_params,
-                                          UCS_BIT(UCP_RNDV_MODE_GET_PIPELINE),
-                                          frag_size, UCT_EP_OP_PUT_ZCOPY, 0,
-                                          mdesc_md_map, 1);
+    ucp_proto_rndv_get_common_probe(init_params,
+                                    UCS_BIT(UCP_RNDV_MODE_GET_PIPELINE),
+                                    frag_size, UCT_EP_OP_PUT_ZCOPY, 0,
+                                    mdesc_md_map, 1);
 }
 
 static void
@@ -348,7 +356,7 @@ ucp_proto_t ucp_rndv_get_mtype_proto = {
     .name     = "rndv/get/mtype",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_proto_rndv_get_mtype_init,
+    .probe    = ucp_proto_rndv_get_mtype_probe,
     .query    = ucp_proto_rndv_get_mtype_query,
     .progress = {
         [UCP_PROTO_RNDV_GET_STAGE_FETCH] = ucp_proto_rndv_get_mtype_fetch_progress,

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -32,12 +32,11 @@ typedef struct {
 } ucp_proto_rndv_ppln_priv_t;
 
 
-static ucs_status_t
-ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_ppln_probe(const ucp_proto_init_params_t *init_params)
 {
     static const double frag_overhead            = 30e-9;
     ucp_worker_h worker                          = init_params->worker;
-    ucp_proto_rndv_ppln_priv_t *rpriv            = init_params->priv;
     const ucp_proto_select_param_t *select_param = init_params->select_param;
     ucp_proto_common_init_params_t err_params    = {
         .super = *init_params,
@@ -49,9 +48,10 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
     size_t frag_min_length, frag_max_length;
     ucp_worker_cfg_index_t rkey_cfg_index;
     ucp_proto_select_param_t sel_param;
+    ucp_proto_rndv_ppln_priv_t rpriv;
     ucp_proto_select_t *proto_select;
+    ucp_proto_caps_t caps, ppln_caps;
     ucs_linear_func_t ppln_overhead;
-    ucp_proto_caps_t ppln_caps;
     char frag_size_str[32];
     ucs_status_t status;
 
@@ -59,7 +59,7 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
         !ucp_proto_init_check_op(init_params, UCP_PROTO_RNDV_OP_ID_MASK) ||
         !ucp_proto_common_init_check_err_handling(&err_params) ||
         ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
     /* Select a protocol for rndv recv */
@@ -73,7 +73,7 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
                                         init_params->rkey_cfg_index,
                                         &rkey_cfg_index);
     if (proto_select == NULL) {
-        return UCS_OK;
+        return;
     }
 
     select_elem = ucp_proto_select_lookup_slow(worker, proto_select, 1,
@@ -81,45 +81,46 @@ ucp_proto_rndv_ppln_init(const ucp_proto_init_params_t *init_params)
                                                init_params->rkey_cfg_index,
                                                &sel_param);
     if (select_elem == NULL) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
     /* Find the performance range of sending one fragment */
     if (!ucp_proto_select_get_valid_range(select_elem->thresholds,
                                           &frag_min_length, &frag_max_length)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
+
+    /* Initialize private data */
+    rpriv.frag_proto = *select_elem;
+    rpriv.frag_size  = frag_max_length;
 
     frag_range  = ucp_proto_perf_range_search(select_elem, frag_max_length);
     thresh_elem = ucp_proto_select_thresholds_search(select_elem,
                                                      frag_max_length);
 
     ucs_trace("rndv_ppln frag %s" UCP_PROTO_PERF_FUNC_TYPES_FMT,
-              ucs_memunits_to_str(rpriv->frag_size, frag_size_str,
+              ucs_memunits_to_str(rpriv.frag_size, frag_size_str,
                                   sizeof(frag_size_str)),
               UCP_PROTO_PERF_FUNC_TYPES_ARG(frag_range->perf));
 
     /* Add the single range of the pipeline protocol to ppln_caps */
-    ppln_caps.cfg_thresh   = thresh_elem->proto_config.cfg_thresh;
-    ppln_caps.cfg_priority = 0;
-    ppln_caps.min_length   = frag_max_length + 1;
-    ppln_caps.num_ranges   = 0;
+    ppln_caps.min_length = frag_max_length + 1;
+    ppln_caps.num_ranges = 0;
     ucp_proto_common_add_ppln_range(&ppln_caps, frag_range, SIZE_MAX);
-
-    /* Initialize private data */
-    *init_params->priv_size = sizeof(*rpriv);
-    rpriv->frag_proto       = *select_elem;
-    rpriv->frag_size        = frag_max_length;
 
     /* Add ATS overhead */
     ppln_overhead = ucs_linear_func_make(frag_overhead,
                                          frag_overhead / frag_max_length);
     status = ucp_proto_rndv_ack_init(init_params, UCP_PROTO_RNDV_ATS_NAME,
-                                     &ppln_caps, ppln_overhead, &rpriv->ack, 0);
+                                     &ppln_caps, ppln_overhead, &rpriv.ack,
+                                     &caps);
+    if (status == UCS_OK) {
+        ucp_proto_select_add_proto(init_params,
+                                   thresh_elem->proto_config.cfg_thresh, 0,
+                                   &caps, &rpriv, sizeof(rpriv));
+    }
 
     ucp_proto_select_caps_cleanup(&ppln_caps);
-
-    return status;
 }
 
 static void ucp_proto_rndv_ppln_query(const ucp_proto_query_params_t *params,
@@ -282,14 +283,14 @@ static size_t ucp_proto_rndv_ppln_pack_ack(void *dest, void *arg)
                                    req->send.rndv.ppln.ack_data_size);
 }
 
-static ucs_status_t
-ucp_proto_rndv_send_ppln_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_send_ppln_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_RNDV_SEND))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_ppln_init(init_params);
+    ucp_proto_rndv_ppln_probe(init_params);
 }
 
 static ucs_status_t
@@ -307,7 +308,7 @@ ucp_proto_t ucp_rndv_send_ppln_proto = {
     .name     = "rndv/send/ppln",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_proto_rndv_send_ppln_init,
+    .probe    = ucp_proto_rndv_send_ppln_probe,
     .query    = ucp_proto_rndv_ppln_query,
     .progress = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,
@@ -317,14 +318,14 @@ ucp_proto_t ucp_rndv_send_ppln_proto = {
     .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };
 
-static ucs_status_t
-ucp_proto_rndv_recv_ppln_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_recv_ppln_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_RNDV_RECV))) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_ppln_init(init_params);
+    ucp_proto_rndv_ppln_probe(init_params);
 }
 
 static ucs_status_t
@@ -360,7 +361,7 @@ ucp_proto_t ucp_rndv_recv_ppln_proto = {
     .name     = "rndv/recv/ppln",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_proto_rndv_recv_ppln_init,
+    .probe    = ucp_proto_rndv_recv_ppln_probe,
     .query    = ucp_proto_rndv_ppln_query,
     .progress = {
         [UCP_PROTO_RNDV_PPLN_STAGE_SEND] = ucp_proto_rndv_ppln_progress,

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -189,17 +189,16 @@ ucp_proto_rndv_put_common_request_init(ucp_request_t *req)
     ucp_proto_rndv_bulk_request_init(req, &rpriv->bulk);
 }
 
-static ucs_status_t
-ucp_proto_rndv_put_common_init(const ucp_proto_init_params_t *init_params,
-                               uint64_t rndv_modes, size_t max_length,
-                               uct_ep_operation_t memtype_op, unsigned flags,
-                               ucp_md_map_t initial_reg_md_map,
-                               uct_completion_callback_t comp_cb,
-                               int support_ppln)
+static void
+ucp_proto_rndv_put_common_probe(const ucp_proto_init_params_t *init_params,
+                                uint64_t rndv_modes, size_t max_length,
+                                uct_ep_operation_t memtype_op, unsigned flags,
+                                ucp_md_map_t initial_reg_md_map,
+                                uct_completion_callback_t comp_cb,
+                                int support_ppln)
 {
     const size_t atp_size                = sizeof(ucp_rndv_ack_hdr_t);
     ucp_context_t *context               = init_params->worker->context;
-    ucp_proto_rndv_put_priv_t *rpriv     = init_params->priv;
     ucp_proto_multi_init_params_t params = {
         .super.super         = *init_params,
         .super.overhead      = 0,
@@ -232,35 +231,33 @@ ucp_proto_rndv_put_common_init(const ucp_proto_init_params_t *init_params,
     };
     const uct_iface_attr_t *iface_attr;
     ucp_lane_index_t lane_idx, lane;
+    ucp_proto_rndv_put_priv_t rpriv;
     int send_atp, use_fence;
-    size_t bulk_priv_size;
-    unsigned atp_map;
+    ucp_proto_caps_t caps;
     ucs_status_t status;
+    unsigned atp_map;
+    size_t priv_size;
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         !ucp_proto_rndv_op_check(init_params, UCP_OP_ID_RNDV_SEND,
                                  support_ppln) ||
         !ucp_proto_common_init_check_err_handling(&params.super)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    status = ucp_proto_rndv_bulk_init(&params, &rpriv->bulk,
-                                      UCP_PROTO_RNDV_PUT_DESC,
-                                      UCP_PROTO_RNDV_ATP_NAME, &bulk_priv_size);
+    status = ucp_proto_rndv_bulk_init(&params, UCP_PROTO_RNDV_PUT_DESC,
+                                      UCP_PROTO_RNDV_ATP_NAME, &rpriv.bulk,
+                                      &caps);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
-    *init_params->priv_size = ucs_offsetof(ucp_proto_rndv_put_priv_t, bulk) +
-                              bulk_priv_size;
-
-    rpriv    = params.super.super.priv;
     send_atp = !ucp_proto_rndv_init_params_is_ppln_frag(init_params);
 
     /* Check which lanes support sending ATP */
     atp_map = 0;
-    for (lane_idx = 0; lane_idx < rpriv->bulk.mpriv.num_lanes; ++lane_idx) {
-        lane       = rpriv->bulk.mpriv.lanes[lane_idx].super.lane;
+    for (lane_idx = 0; lane_idx < rpriv.bulk.mpriv.num_lanes; ++lane_idx) {
+        lane       = rpriv.bulk.mpriv.lanes[lane_idx].super.lane;
         iface_attr = ucp_proto_common_get_iface_attr(init_params, lane);
         if (((iface_attr->cap.flags & UCT_IFACE_FLAG_AM_SHORT) &&
              (iface_attr->cap.am.max_short >= atp_size)) ||
@@ -273,7 +270,7 @@ ucp_proto_rndv_put_common_init(const ucp_proto_init_params_t *init_params,
     /* Use fence only if all lanes support sending ATP and flush is not forced
      */
     use_fence = send_atp && !context->config.ext.rndv_put_force_flush &&
-                (rpriv->bulk.mpriv.lane_map == atp_map);
+                (rpriv.bulk.mpriv.lane_map == atp_map);
 
     /* All lanes can send ATP - invalidate am_lane, to use mpriv->lanes.
      * Otherwise, would need to flush all lanes and send ATP on:
@@ -288,37 +285,38 @@ ucp_proto_rndv_put_common_init(const ucp_proto_init_params_t *init_params,
      */
     if (use_fence) {
         /* Send fence followed by ATP on all lanes */
-        rpriv->bulk.super.lane = UCP_NULL_LANE;
-        rpriv->put_comp_cb     = comp_cb;
-        rpriv->atp_comp_cb     = NULL;
-        rpriv->stage_after_put = UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP;
-        rpriv->flush_map       = 0;
-        rpriv->atp_map         = rpriv->bulk.mpriv.lane_map;
+        rpriv.bulk.super.lane = UCP_NULL_LANE;
+        rpriv.put_comp_cb     = comp_cb;
+        rpriv.atp_comp_cb     = NULL;
+        rpriv.stage_after_put = UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP;
+        rpriv.flush_map       = 0;
+        rpriv.atp_map         = rpriv.bulk.mpriv.lane_map;
     } else {
         /* Flush all lanes and send ATP on all supporting lanes (or control lane
          * otherwise) */
         if (send_atp) {
-            rpriv->put_comp_cb =
+            rpriv.put_comp_cb =
                     ucp_proto_rndv_put_common_flush_completion_send_atp;
-            rpriv->atp_comp_cb = comp_cb;
-            rpriv->atp_map     = (atp_map == 0) ?
-                                 UCS_BIT(rpriv->bulk.super.lane) : atp_map;
+            rpriv.atp_comp_cb = comp_cb;
+            rpriv.atp_map     = (atp_map == 0) ?
+                                UCS_BIT(rpriv.bulk.super.lane) : atp_map;
         } else {
-            rpriv->put_comp_cb = comp_cb;
-            rpriv->atp_comp_cb = NULL;
-            rpriv->atp_map     = 0;
+            rpriv.put_comp_cb = comp_cb;
+            rpriv.atp_comp_cb = NULL;
+            rpriv.atp_map     = 0;
         }
-        rpriv->stage_after_put = UCP_PROTO_RNDV_PUT_STAGE_FLUSH;
-        rpriv->flush_map       = rpriv->bulk.mpriv.lane_map;
-        ucs_assert(rpriv->flush_map != 0);
+        rpriv.stage_after_put = UCP_PROTO_RNDV_PUT_STAGE_FLUSH;
+        rpriv.flush_map       = rpriv.bulk.mpriv.lane_map;
+        ucs_assert(rpriv.flush_map != 0);
     }
 
     if (send_atp) {
-        ucs_assert(rpriv->atp_map != 0);
+        ucs_assert(rpriv.atp_map != 0);
     }
-    rpriv->atp_num_lanes = ucs_popcount(rpriv->atp_map);
+    rpriv.atp_num_lanes = ucs_popcount(rpriv.atp_map);
 
-    return UCS_OK;
+    priv_size = UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(&rpriv, bulk.mpriv);
+    ucp_proto_common_add_proto(&params.super, &caps, &rpriv, priv_size);
 }
 
 static const char *
@@ -384,17 +382,15 @@ static void ucp_proto_rndv_put_zcopy_completion(uct_completion_t *uct_comp)
     ucp_proto_rndv_put_common_complete(req);
 }
 
-static ucs_status_t
-ucp_proto_rndv_put_zcopy_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_put_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
-    unsigned flags = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
-                     UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING;
-
-    return ucp_proto_rndv_put_common_init(init_params,
-                                          UCS_BIT(UCP_RNDV_MODE_PUT_ZCOPY),
-                                          SIZE_MAX, UCT_EP_OP_LAST, flags, 0,
-                                          ucp_proto_rndv_put_zcopy_completion,
-                                          0);
+    ucp_proto_rndv_put_common_probe(
+            init_params, UCS_BIT(UCP_RNDV_MODE_PUT_ZCOPY), SIZE_MAX,
+            UCT_EP_OP_LAST,
+            UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
+            UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+            0, ucp_proto_rndv_put_zcopy_completion, 0);
 }
 
 static void
@@ -429,7 +425,7 @@ ucp_proto_t ucp_rndv_put_zcopy_proto = {
     .name     = "rndv/put/zcopy",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_proto_rndv_put_zcopy_init,
+    .probe    = ucp_proto_rndv_put_zcopy_probe,
     .query    = ucp_proto_rndv_put_zcopy_query,
     .progress = {
         [UCP_PROTO_RNDV_PUT_ZCOPY_STAGE_SEND] = ucp_proto_rndv_put_zcopy_send_progress,
@@ -528,8 +524,8 @@ static void ucp_proto_rndv_put_mtype_frag_completion(uct_completion_t *uct_comp)
     ucp_proto_rndv_ppln_send_frag_complete(req, 1);
 }
 
-static ucs_status_t
-ucp_proto_rndv_put_mtype_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
     uct_completion_callback_t comp_cb;
     ucp_md_map_t mdesc_md_map;
@@ -538,7 +534,7 @@ ucp_proto_rndv_put_mtype_init(const ucp_proto_init_params_t *init_params)
 
     status = ucp_proto_rndv_mtype_init(init_params, &mdesc_md_map, &frag_size);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
     if (ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
@@ -547,10 +543,10 @@ ucp_proto_rndv_put_mtype_init(const ucp_proto_init_params_t *init_params)
         comp_cb = ucp_proto_rndv_put_mtype_completion;
     }
 
-    return ucp_proto_rndv_put_common_init(init_params,
-                                          UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
-                                          frag_size, UCT_EP_OP_GET_ZCOPY, 0,
-                                          mdesc_md_map, comp_cb, 1);
+    ucp_proto_rndv_put_common_probe(init_params,
+                                    UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
+                                    frag_size, UCT_EP_OP_GET_ZCOPY, 0,
+                                    mdesc_md_map, comp_cb, 1);
 }
 
 static void
@@ -567,7 +563,7 @@ ucp_proto_t ucp_rndv_put_mtype_proto = {
     .name     = "rndv/put/mtype",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_proto_rndv_put_mtype_init,
+    .probe    = ucp_proto_rndv_put_mtype_probe,
     .query    = ucp_proto_rndv_put_mtype_query,
     .progress = {
         [UCP_PROTO_RNDV_PUT_MTYPE_STAGE_COPY] = ucp_proto_rndv_put_mtype_copy_progress,

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -42,10 +42,9 @@ static double ucp_proto_rndv_rkey_ptr_overhead()
     }
 }
 
-static ucs_status_t
-ucp_proto_rndv_rkey_ptr_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_rkey_ptr_probe(const ucp_proto_init_params_t *init_params)
 {
-    ucp_proto_rndv_rkey_ptr_priv_t *rpriv = init_params->priv;
     ucp_context_t *context                = init_params->worker->context;
     uint64_t rndv_modes                   = UCS_BIT(UCP_RNDV_MODE_RKEY_PTR);
     ucp_proto_single_init_params_t params = {
@@ -71,26 +70,30 @@ ucp_proto_rndv_rkey_ptr_init(const ucp_proto_init_params_t *init_params)
         .lane_type           = UCP_LANE_TYPE_RKEY_PTR,
         .tl_cap_flags        = 0,
     };
-    ucp_proto_caps_t rkey_ptr_caps;
+    ucp_proto_rndv_rkey_ptr_priv_t rpriv;
+    ucp_proto_caps_t caps, rkey_ptr_caps;
     ucs_status_t status;
 
     if (!ucp_proto_rndv_op_check(init_params, UCP_OP_ID_RNDV_RECV, 0) ||
         !ucp_proto_common_init_check_err_handling(&params.super)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    status = ucp_proto_single_init(&params, &rkey_ptr_caps, &rpriv->spriv);
+    status = ucp_proto_single_init(&params, &rkey_ptr_caps, &rpriv.spriv);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
-    *init_params->priv_size = sizeof(*rpriv);
     status = ucp_proto_rndv_ack_init(init_params, UCP_PROTO_RNDV_ATS_NAME,
                                      &rkey_ptr_caps, UCS_LINEAR_FUNC_ZERO,
-                                     &rpriv->ack, 0);
+                                     &rpriv.ack, &caps);
     ucp_proto_select_caps_cleanup(&rkey_ptr_caps);
 
-    return status;
+    if (status != UCS_OK) {
+        return;
+    }
+
+    ucp_proto_common_add_proto(&params.super, &caps, &rpriv, sizeof(rpriv));
 }
 
 static void
@@ -193,7 +196,7 @@ ucp_proto_t ucp_rndv_rkey_ptr_proto = {
     .name     = "rndv/rkey_ptr",
     .desc     = "copy from mapped remote memory",
     .flags    = 0,
-    .init     = ucp_proto_rndv_rkey_ptr_init,
+    .probe    = ucp_proto_rndv_rkey_ptr_probe,
     .query    = ucp_proto_rndv_rkey_ptr_query,
     .progress = {
          [UCP_PROTO_RNDV_RKEY_PTR_STAGE_COPY] = ucp_proto_rndv_rkey_ptr_fetch_progress,
@@ -203,10 +206,9 @@ ucp_proto_t ucp_rndv_rkey_ptr_proto = {
     .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };
 
-static ucs_status_t
-ucp_proto_rndv_rkey_ptr_mtype_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_proto_rndv_rkey_ptr_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
-    ucp_proto_rndv_rkey_ptr_mtype_priv_t *rpriv = init_params->priv;
     ucp_context_t *context                = init_params->worker->context;
     uint64_t rndv_modes                   = UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE);
     ucp_lane_index_t rkey_ptr_lane        = init_params->ep_config_key->rkey_ptr_lane;
@@ -232,7 +234,8 @@ ucp_proto_rndv_rkey_ptr_mtype_init(const ucp_proto_init_params_t *init_params)
         .lane_type           = UCP_LANE_TYPE_LAST,
         .tl_cap_flags        = 0
     };
-    ucp_proto_caps_t rkey_ptr_caps;
+    ucp_proto_rndv_rkey_ptr_mtype_priv_t rpriv;
+    ucp_proto_caps_t caps, rkey_ptr_caps;
     ucp_lane_index_t lane;
     ucp_md_map_t mdesc_md_map;
     ucs_status_t status;
@@ -240,37 +243,38 @@ ucp_proto_rndv_rkey_ptr_mtype_init(const ucp_proto_init_params_t *init_params)
     if (!context->config.ext.rndv_shm_ppln_enable ||
         !ucp_proto_rndv_op_check(init_params, UCP_OP_ID_RNDV_SEND, 1) ||
         !ucp_proto_common_init_check_err_handling(&params.super)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
     status = ucp_proto_rndv_mtype_init(init_params, &mdesc_md_map,
                                        &params.super.max_length);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
-    status = ucp_proto_single_init(&params, &rkey_ptr_caps,
-                                   &rpriv->super.spriv);
+    status = ucp_proto_single_init(&params, &rkey_ptr_caps, &rpriv.super.spriv);
     if (status != UCS_OK) {
-        return status;
+        return;
     }
 
-    lane                = rpriv->super.spriv.super.lane;
-    rpriv->dst_md_index = init_params->ep_config_key->lanes[lane].dst_md_index;
+    lane               = rpriv.super.spriv.super.lane;
+    rpriv.dst_md_index = init_params->ep_config_key->lanes[lane].dst_md_index;
 
-    ucs_assertv(UCS_BIT(rpriv->dst_md_index) &
+    ucs_assertv(UCS_BIT(rpriv.dst_md_index) &
                 init_params->rkey_config_key->md_map,
-                "dst_md_index %u rkey->md_map 0x%lx", rpriv->dst_md_index,
+                "dst_md_index %u rkey->md_map 0x%lx", rpriv.dst_md_index,
                 init_params->rkey_config_key->md_map);
 
-    *init_params->priv_size = sizeof(*rpriv);
     status = ucp_proto_rndv_ack_init(init_params, UCP_PROTO_RNDV_RKEY_PTR_DESC,
                                      &rkey_ptr_caps, UCS_LINEAR_FUNC_ZERO,
-                                     &rpriv->super.ack, 0);
-
+                                     &rpriv.super.ack, &caps);
     ucp_proto_select_caps_cleanup(&rkey_ptr_caps);
 
-    return status;
+    if (status != UCS_OK) {
+        return;
+    }
+
+    ucp_proto_common_add_proto(&params.super, &caps, &rpriv, sizeof(rpriv));
 }
 
 static ucs_status_t ucp_proto_rndv_rkey_ptr_mtype_completion(ucp_request_t *req)
@@ -357,7 +361,7 @@ ucp_proto_t ucp_rndv_rkey_ptr_mtype_proto = {
     .name     = "rndv/rkey_ptr/mtype",
     .desc     = "copy to mapped remote memory",
     .flags    = 0,
-    .init     = ucp_proto_rndv_rkey_ptr_mtype_init,
+    .probe     = ucp_proto_rndv_rkey_ptr_mtype_probe,
     .query    = ucp_proto_rndv_rkey_ptr_mtype_query,
     .progress = {
         [UCP_PROTO_RNDV_RKEY_PTR_STAGE_COPY] = ucp_proto_rndv_rkey_ptr_mtype_copy_progress,

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -18,8 +18,8 @@
  * remote side (which is the case when tag is matched - everyting is done by the
  * HW/FW).
  */
-static ucs_status_t
-ucp_tag_rndv_offload_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_tag_rndv_offload_proto_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_worker_h worker                   = init_params->worker;
     ucp_context_h context                 = worker->context;
@@ -48,21 +48,13 @@ ucp_tag_rndv_offload_proto_init(const ucp_proto_init_params_t *init_params)
        .lane_type           = UCP_LANE_TYPE_TAG,
        .tl_cap_flags        = UCT_IFACE_FLAG_TAG_RNDV_ZCOPY
     };
-    ucs_status_t status;
 
     if (!ucp_tag_rndv_check_op_id(init_params) ||
         (init_params->select_param->dt_class != UCP_DATATYPE_CONTIG)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    status = ucp_proto_single_init(&params, params.super.super.caps,
-                                   params.super.super.priv);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    *init_params->priv_size = sizeof(ucp_proto_single_priv_t);
-    return UCS_OK;
+    ucp_proto_single_probe(&params);
 }
 
 static void
@@ -145,7 +137,7 @@ ucp_proto_t ucp_tag_rndv_offload_proto = {
     .name     = "tag/rndv/offload",
     .desc     = "rendezvous tag offload",
     .flags    = 0,
-    .init     = ucp_tag_rndv_offload_proto_init,
+    .probe    = ucp_tag_rndv_offload_proto_probe,
     .query    = ucp_proto_single_query,
     .progress = {ucp_tag_rndv_offload_proto_progress},
     .abort    = ucp_proto_request_zcopy_abort,
@@ -157,8 +149,8 @@ ucp_proto_t ucp_tag_rndv_offload_proto = {
  * It can be used when real rndv offload is not supported (e.g. for non-contig
  * or very large messages) or when it is enabled by protocol selection.
  */
-static ucs_status_t
-ucp_tag_rndv_offload_sw_proto_init(const ucp_proto_init_params_t *init_params)
+static void
+ucp_tag_rndv_offload_sw_proto_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_worker_h worker                      = init_params->worker;
     ucp_context_h context                    = worker->context;
@@ -188,6 +180,7 @@ ucp_tag_rndv_offload_sw_proto_init(const ucp_proto_init_params_t *init_params)
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
         .super.exclude_map   = 0,
         .remote_op_id        = UCP_OP_ID_RNDV_RECV,
+        .lane                = init_params->ep_config_key->tag_lane,
         .unpack_time         = UCS_LINEAR_FUNC_ZERO,
         .perf_bias           = context->config.ext.rndv_perf_diff / 100.0,
         .mem_info.type       = init_params->select_param->mem_type,
@@ -198,11 +191,10 @@ ucp_tag_rndv_offload_sw_proto_init(const ucp_proto_init_params_t *init_params)
 
     if (!ucp_tag_rndv_check_op_id(init_params) ||
         !ucp_ep_config_key_has_tag_lane(init_params->ep_config_key)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_ctrl_init(&params,
-                                    init_params->ep_config_key->tag_lane);
+    ucp_proto_rndv_ctrl_probe(&params);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_offload_sw_proto_progress, (self),
@@ -237,7 +229,7 @@ ucp_proto_t ucp_tag_rndv_offload_sw_proto = {
     .name     = "tag/rndv/offload_sw",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_tag_rndv_offload_sw_proto_init,
+    .probe    = ucp_tag_rndv_offload_sw_proto_probe,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_tag_rndv_offload_sw_proto_progress},
     .abort    = ucp_proto_rndv_rts_abort,

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -153,21 +153,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
     return status;
 }
 
-ucs_status_t ucp_tag_rndv_rts_init(const ucp_proto_init_params_t *init_params)
+static void ucp_tag_rndv_rts_probe(const ucp_proto_init_params_t *init_params)
 {
     if (!ucp_tag_rndv_check_op_id(init_params) ||
         ucp_ep_config_key_has_tag_lane(init_params->ep_config_key)) {
-        return UCS_ERR_UNSUPPORTED;
+        return;
     }
 
-    return ucp_proto_rndv_rts_init(init_params);
+    ucp_proto_rndv_rts_probe(init_params);
 }
 
 ucp_proto_t ucp_tag_rndv_proto = {
     .name     = "tag/rndv",
     .desc     = NULL,
     .flags    = 0,
-    .init     = ucp_tag_rndv_rts_init,
+    .probe    = ucp_tag_rndv_rts_probe,
     .query    = ucp_proto_rndv_rts_query,
     .progress = {ucp_tag_rndv_rts_progress},
     .abort    = ucp_proto_rndv_rts_abort,


### PR DESCRIPTION
## Why
- Support adding protocol variants to rendezvous protocols
- Cleanup protocols initialization code needed for to init() callback, after all protocols are switched to probe()