### PR TITLE
UCT/IB: Print device name when failed to create a QP

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1093,9 +1093,10 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
     if (qp == NULL) {
         uct_ib_check_memlock_limit_msg(
                 UCS_LOG_LEVEL_ERROR,
-                "iface=%p: failed to create %s QP "
+                "%s: iface %p failed to create %s QP "
                 "TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d",
-                iface, uct_ib_qp_type_str(attr->qp_type), attr->cap.max_send_wr,
+                uct_ib_device_name(dev), iface,
+                uct_ib_qp_type_str(attr->qp_type), attr->cap.max_send_wr,
                 attr->cap.max_send_sge, attr->cap.max_inline_data,
                 attr->max_inl_cqe[UCT_IB_DIR_TX], attr->cap.max_recv_wr,
                 attr->cap.max_recv_sge, attr->max_inl_cqe[UCT_IB_DIR_RX]);
@@ -1105,10 +1106,10 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
     attr->cap  = attr->ibv.cap;
     *qp_p      = qp;
 
-    ucs_debug("iface=%p: created %s QP 0x%x on %s:%d "
+    ucs_debug("%s: iface %p created %s QP 0x%x on %s:%d "
               "TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d",
-              iface, uct_ib_qp_type_str(attr->qp_type), qp->qp_num,
-              uct_ib_device_name(dev), iface->config.port_num,
+              uct_ib_device_name(dev), iface, uct_ib_qp_type_str(attr->qp_type),
+              qp->qp_num, uct_ib_device_name(dev), iface->config.port_num,
               attr->cap.max_send_wr, attr->cap.max_send_sge,
               attr->cap.max_inline_data, attr->max_inl_cqe[UCT_IB_DIR_TX],
               attr->cap.max_recv_wr, attr->cap.max_recv_sge,

--- a/src/uct/ib/ud/accel/ud_mlx5.c
+++ b/src/uct/ib/ud/accel/ud_mlx5.c
@@ -932,9 +932,10 @@ static ucs_status_t uct_ud_mlx5dv_calc_tx_wqe_ratio(uct_ib_mlx5_md_t *md)
     qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, pd, &qp_init_attr);
 #endif
     if (qp == NULL) {
-        ucs_error("md=%p: failed to create %s QP "
+        ucs_error("%s: md %p failed to create %s QP "
                   "TX wr:%d sge:%d inl:%d RX wr:%d sge:%d: %m",
-                  md, uct_ib_qp_type_str(qp_init_attr.qp_type),
+                  uct_ib_device_name(dev), md,
+                  uct_ib_qp_type_str(qp_init_attr.qp_type),
                   qp_init_attr.cap.max_send_wr, qp_init_attr.cap.max_send_sge,
                   qp_init_attr.cap.max_inline_data,
                   qp_init_attr.cap.max_recv_wr, qp_init_attr.cap.max_recv_sge);


### PR DESCRIPTION
## Why
More verbose error messages