### PR TITLE
UCP/PROTO: add MIN_FRAG flag for put_zcopy proto - v1.16.x

### DIFF
--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -238,7 +238,8 @@ ucp_proto_rndv_put_common_init(const ucp_proto_init_params_t *init_params,
         .super.send_op       = UCT_EP_OP_PUT_ZCOPY,
         .super.memtype_op    = memtype_op,
         .super.flags         = flags | UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
-                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS,
+                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
+                               UCP_PROTO_COMMON_INIT_FLAG_MIN_FRAG,
         .super.exclude_map   = 0,
         .max_lanes           = context->config.ext.max_rndv_lanes,
         .initial_reg_md_map  = initial_reg_md_map,


### PR DESCRIPTION
## What
Backport PR #https://github.com/openucx/ucx/pull/9730

set the UCP_PROTO_COMMON_INIT_FLAG_MIN_FRAG when initialing put_zcopy protocol. Without it, the rocm/ipc transport is not selected for D2D transfer when using RNDV_SCHEME put_zcopy, since rocm/ipc sets a non-zero min_zcopy.

Note, that this flag is also set in the corresponding get_zcopy routine