### PR TITLE
UCS/TOPO: Add support for PCIe gen5 bandwidth detection - v1.16.x

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -677,6 +677,14 @@ static const ucs_topo_pci_info_t ucs_topo_pci_info[] = {
      .ctrl_overhead = 16,
      .encoding      = 128,
      .decoding      = 130},
+    {.name          = "gen5",
+     .bw_gbps       = 32,
+     .payload       = 256,
+     .tlp_overhead  = 26,
+     .ctrl_ratio    = 4,
+     .ctrl_overhead = 16,
+     .encoding      = 128,
+     .decoding      = 130},
 };
 
 double ucs_topo_get_pci_bw(const char *dev_name, const char *sysfs_path)


### PR DESCRIPTION
## Why
Fix CI failures on v1.16.x branch
Cherry-picked from 943c64fb71