### PR TITLE
TOOLS/PERF/LIB: bugfixes for multithreading in UCP perftest

### DIFF
--- a/contrib/ucx_perftest_config/test_types_ucp
+++ b/contrib/ucx_perftest_config/test_types_ucp
@@ -4,6 +4,12 @@
 ucp_iov_contig_tag_lat               -t tag_lat -D iov,contig
 ucp_iov_iov_tag_lat                  -t tag_lat -D iov,iov
 ucp_contig_tag_lat                   -t tag_lat -D contig,contig
+#
+# UCP with Multithreading
+#
+ucp_iov_contig_tag_lat               -t tag_lat -D iov,contig    -T 2
+ucp_iov_iov_tag_lat                  -t tag_lat -D iov,iov       -T 2
+ucp_contig_tag_lat                   -t tag_lat -D contig,contig -T 2
 #IOV with RNDV is not yet supported
 #ucp_contig_iov_tag_lat              -t tag_lat -D contig,iov
 ucp_iov_contig_tag_bw                -t tag_bw  -D iov,contig
@@ -47,3 +53,9 @@ ucp_contig_host_cuda_tag_lat_sleep   -I -E sleep  -t tag_lat -D contig,contig -m
 ucp_contig_cuda_tag_bw_sleep         -I -E sleep  -t tag_bw  -D contig,contig -m cuda,cuda
 ucp_contig_cuda_host_tag_bw_sleep    -I -E sleep  -t tag_bw  -D contig,contig -m cuda,host
 ucp_contig_host_cuda_tag_bw_sleep    -I -E sleep  -t tag_bw  -D contig,contig -m host,cuda
+#
+# CUDA with multithreading
+#
+ucp_contig_cuda_tag_lat              -t tag_lat -D contig,contig -m cuda,cuda -T 2
+ucp_contig_cuda_host_tag_lat         -t tag_lat -D contig,contig -m cuda,host -T 2 
+ucp_contig_host_cuda_tag_lat         -t tag_lat -D contig,contig -m host,cuda -T 2

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -43,17 +43,30 @@ typedef struct ucp_perf_request        ucp_perf_request_t;
 typedef struct ucx_perf_thread_context ucx_perf_thread_context_t;
 
 
+typedef ucs_status_t (*ucx_perf_init_func_t)(ucx_perf_context_t *perf);
+
+typedef ucs_status_t (*ucx_perf_uct_alloc_func_t)(
+        const ucx_perf_context_t *perf, size_t length, unsigned flags,
+        uct_allocated_memory_t *alloc_mem);
+
+typedef void (*ucx_perf_uct_free_func_t)(const ucx_perf_context_t *perf,
+                                         uct_allocated_memory_t *alloc_mem);
+
+typedef void (*ucx_perf_memcpy_func_t)(void *dst,
+                                       ucs_memory_type_t dst_mem_type,
+                                       const void *src,
+                                       ucs_memory_type_t src_mem_type,
+                                       size_t count);
+
+typedef void *(*ucx_perf_memset_func_t)(void *dst, int value, size_t count);
+
 struct ucx_perf_allocator {
-    ucs_memory_type_t mem_type;
-    ucs_status_t (*init)(ucx_perf_context_t *perf);
-    ucs_status_t (*uct_alloc)(const ucx_perf_context_t *perf, size_t length,
-                              unsigned flags, uct_allocated_memory_t *alloc_mem);
-    void         (*uct_free)(const ucx_perf_context_t *perf,
-                             uct_allocated_memory_t *alloc_mem);
-    void         (*memcpy)(void *dst, ucs_memory_type_t dst_mem_type,
-                           const void *src, ucs_memory_type_t src_mem_type,
-                           size_t count);
-    void*        (*memset)(void *dst, int value, size_t count);
+    ucs_memory_type_t         mem_type;
+    ucx_perf_init_func_t      init;
+    ucx_perf_uct_alloc_func_t uct_alloc;
+    ucx_perf_uct_free_func_t  uct_free;
+    ucx_perf_memcpy_func_t    memcpy;
+    ucx_perf_memset_func_t    memset;
 };
 
 typedef struct {

--- a/src/tools/perf/lib/libperf_memory.c
+++ b/src/tools/perf/lib/libperf_memory.c
@@ -346,9 +346,19 @@ void ucx_perf_global_init()
         .memcpy    = ucx_perf_test_memcpy_host,
         .memset    = memset
     };
+    static ucx_perf_allocator_t rdma_allocator = {
+        .mem_type  = UCS_MEMORY_TYPE_RDMA,
+        .init      = ucs_empty_function_return_success,
+        .uct_alloc = (ucx_perf_uct_alloc_func_t)ucs_empty_function_do_assert,
+        .uct_free  = (ucx_perf_uct_free_func_t)ucs_empty_function_do_assert,
+        .memcpy    = (ucx_perf_memcpy_func_t)ucs_empty_function_do_assert,
+        .memset    = (ucx_perf_memset_func_t)ucs_empty_function_do_assert
+    };
+
     UCS_MODULE_FRAMEWORK_DECLARE(ucx_perftest);
 
     ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_HOST] = &host_allocator;
+    ucx_perf_mem_type_allocators[UCS_MEMORY_TYPE_RDMA] = &rdma_allocator;
 
     /* FIXME Memtype allocator modules must be loaded to global scope, otherwise
      * alloc hooks, which are using dlsym() to get pointer to original function,

--- a/src/tools/perf/lib/libperf_thread.c
+++ b/src/tools/perf/lib/libperf_thread.c
@@ -148,8 +148,10 @@ ucs_status_t ucx_perf_thread_spawn(ucx_perf_context_t *perf,
 
 ucs_status_t ucx_perf_allocators_init_thread(ucx_perf_context_t *perf)
 {
+    ucs_status_t status;
+
     /* New threads need explicit device association */
-    ucs_status_t status = perf->send_allocator->init(perf);
+    status = perf->send_allocator->init(perf);
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
## What
1. Fixes for bugs in UCP perftests when combining usage of memory types and multithreading, segfault in allocators initialization and using the wrong worker / worker addresses for the self_eps.
2. Adding multithreading perftests to CI

## Why ?
Those bugs were not discovered until now because the CI did not contain any perftest with multithreading tests.