### PR TITLE
UCP/MM: Check registration flags after taking memh from rcache

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -362,6 +362,7 @@ static void ucp_memh_dereg(ucp_context_h context, ucp_mem_h memh,
 
         memh->uct[md_index] = NULL;
     }
+    memh->md_map &= ~md_map;
 
     ucs_assert(comp.count == 1);
 }
@@ -473,7 +474,8 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
         uct_flags |= UCT_MD_MEM_FLAG_NONBLOCK;
     }
 
-    reg_params.flags         = uct_flags;
+    /* When adding registrations, existing access flags must be supported */
+    reg_params.flags         = uct_flags | memh->uct_flags;
     reg_params.dmabuf_fd     = UCT_DMABUF_FD_INVALID;
     reg_params.dmabuf_offset = 0;
 
@@ -576,27 +578,38 @@ static size_t ucp_memh_size(ucp_context_h context)
     return sizeof(ucp_mem_t) + (sizeof(uct_mem_h) * context->num_mds);
 }
 
-static void ucp_memh_set(ucp_mem_h memh, ucp_context_h context, void* address,
-                         size_t length, ucs_memory_type_t mem_type,
-                         uint8_t memh_flags, uct_alloc_method_t method)
+static void ucp_memh_set_uct_flags(ucp_mem_h memh, unsigned uct_flags)
+{
+    /* When changing memh->uct_flags, must not have any existing registrations,
+       since those may not support the new flags */
+    ucs_assertv(memh->md_map == 0,
+                "memh=%p memh->md_map=0x%" PRIx64
+                " memh->uct_flags=0x%x uct_flags=0x%x",
+                memh, memh->md_map, memh->uct_flags, uct_flags);
+    memh->uct_flags = uct_flags & UCP_MM_UCT_ACCESS_MASK;
+}
+
+static void ucp_memh_init(ucp_mem_h memh, ucp_context_h context,
+                          uint8_t memh_flags, unsigned uct_flags,
+                          uct_alloc_method_t method, ucs_memory_type_t mem_type)
 {
     ucp_memory_info_t info;
 
-    ucp_memory_detect(context, address, length, &info);
-    memh->super.super.start = (uintptr_t)address;
-    memh->super.super.end   = (uintptr_t)address + length;
-    memh->flags             = memh_flags;
+    ucp_memory_detect(context, ucp_memh_address(memh), ucp_memh_length(memh),
+                      &info);
+    ucp_memh_set_uct_flags(memh, uct_flags);
     memh->context           = context;
+    memh->flags             = memh_flags;
+    memh->alloc_md_index    = UCP_NULL_RESOURCE;
+    memh->alloc_method      = method;
     memh->mem_type          = mem_type;
     memh->sys_dev           = info.sys_dev;
-    memh->alloc_method      = method;
-    memh->alloc_md_index    = UCP_NULL_RESOURCE;
 }
 
 static ucs_status_t
 ucp_memh_create(ucp_context_h context, void *address, size_t length,
                 ucs_memory_type_t mem_type, uct_alloc_method_t method,
-                uint8_t memh_flags, ucp_mem_h *memh_p)
+                uint8_t memh_flags, unsigned uct_flags, ucp_mem_h *memh_p)
 {
     ucp_mem_h memh;
 
@@ -605,7 +618,9 @@ ucp_memh_create(ucp_context_h context, void *address, size_t length,
         return UCS_ERR_NO_MEMORY;
     }
 
-    ucp_memh_set(memh, context, address, length, mem_type, memh_flags, method);
+    memh->super.super.start = (uintptr_t)address;
+    memh->super.super.end   = (uintptr_t)address + length;
+    ucp_memh_init(memh, context, memh_flags, uct_flags, method, mem_type);
 
     *memh_p = memh;
     return UCS_OK;
@@ -658,13 +673,14 @@ static ucp_md_index_t ucp_mem_get_md_index(ucp_context_h context,
 
 static ucs_status_t ucp_memh_create_from_mem(ucp_context_h context,
                                              const uct_allocated_memory_t *mem,
+                                             unsigned uct_flags,
                                              ucp_mem_h *memh_p)
 {
     ucs_status_t status;
     ucp_mem_h memh;
 
     status = ucp_memh_create(context, mem->address, mem->length, mem->mem_type,
-                             mem->method, 0, &memh);
+                             mem->method, 0, uct_flags, &memh);
     if (status != UCS_OK) {
         return status;
     }
@@ -787,19 +803,28 @@ ucs_status_t ucp_memh_get_slow(ucp_context_h context, void *address,
     UCP_THREAD_CS_ENTER(&context->mt_lock);
     if (context->rcache == NULL) {
         status = ucp_memh_create(context, reg_address, reg_length, mem_type,
-                                 UCT_ALLOC_METHOD_LAST, 0, &memh);
+                                 UCT_ALLOC_METHOD_LAST, 0, uct_flags, &memh);
+        if (status != UCS_OK) {
+            goto out;
+        }
     } else {
         status = ucp_memh_rcache_get(context->rcache, reg_address, reg_length,
                                      reg_align, mem_type, reg_md_map, uct_flags,
                                      alloc_name, &memh);
+        if (status != UCS_OK) {
+            goto out;
+        }
+
+        if (!ucs_test_all_flags(memh->uct_flags,
+                                uct_flags & UCP_MM_UCT_ACCESS_MASK)) {
+            reg_md_map |= memh->md_map; /* Re-register previous MDs */
+            ucp_memh_dereg(context, memh, memh->md_map);
+            ucp_memh_set_uct_flags(memh, uct_flags);
+        }
 
         ucs_assert(memh->mem_type == mem_type);
         ucs_assert(ucs_padding((intptr_t)ucp_memh_address(memh), reg_align) == 0);
         ucs_assert(ucs_padding(ucp_memh_length(memh), reg_align) == 0);
-    }
-
-    if (status != UCS_OK) {
-        goto out;
     }
 
     ucs_trace(
@@ -847,7 +872,7 @@ ucp_memh_alloc(ucp_context_h context, void *address, size_t length,
         goto out;
     }
 
-    status = ucp_memh_create_from_mem(context, &mem, &memh);
+    status = ucp_memh_create_from_mem(context, &mem, uct_flags, &memh);
     if (status != UCS_OK) {
         goto err_dealloc;
     }
@@ -974,7 +999,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
                                 alloc_name, &memh);
     } else {
         status = ucp_memh_create(context, address, length, mem_type,
-                                 UCT_ALLOC_METHOD_LAST, 0, &memh);
+                                 UCT_ALLOC_METHOD_LAST, 0, uct_flags, &memh);
         if (status != UCS_OK) {
             goto out;
         }
@@ -1412,15 +1437,9 @@ ucp_mem_rcache_mem_reg_cb(void *ctx, ucs_rcache_t *rcache, void *arg,
     ucp_context_h context             = (ucp_context_h)ctx;
     ucp_mem_rcache_reg_ctx_t *reg_ctx = arg;
     ucp_mem_h memh                    = ucs_derived_of(rregion, ucp_mem_t);
-    ucp_memory_info_t info;
 
-    ucp_memory_detect(context, (void*)memh->super.super.start,
-                      memh->super.super.end - memh->super.super.start, &info);
-    memh->context        = context;
-    memh->alloc_md_index = UCP_NULL_RESOURCE;
-    memh->alloc_method   = UCT_ALLOC_METHOD_LAST;
-    memh->mem_type       = reg_ctx->mem_type;
-    memh->sys_dev        = info.sys_dev;
+    ucp_memh_init(memh, context, 0, reg_ctx->uct_flags, UCT_ALLOC_METHOD_LAST,
+                  reg_ctx->mem_type);
 
     if (rcache_mem_reg_flags & UCS_RCACHE_MEM_REG_HIDE_ERRORS) {
         /* Hide errors during registration but fail if any memory domain failed
@@ -1730,7 +1749,7 @@ ucp_memh_import(ucp_context_h context, const void *export_mkey_buffer,
 
     status = ucp_memh_create(context, unpacked_memh.address,
                              unpacked_memh.length, unpacked_memh.mem_type,
-                             UCT_ALLOC_METHOD_LAST, 0, &memh);
+                             UCT_ALLOC_METHOD_LAST, 0, 0, &memh);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -22,6 +22,11 @@
 #define UCP_RCACHE_LOOKUP_FUNC ucs_linear_func_make(50.0e-9, 0)
 
 
+/* Mask of UCT memory flags that need make sure are present when reusing an
+   existing region */
+#define UCP_MM_UCT_ACCESS_MASK UCT_MD_MEM_ACCESS_ALL
+
+
 /**
  * Memory handle flags.
  */
@@ -50,6 +55,7 @@ enum {
 typedef struct ucp_mem {
     ucs_rcache_region_t super;
     uint8_t             flags;          /* Memory handle flags */
+    unsigned            uct_flags;      /* UCT memory registration flags */
     ucp_context_h       context;        /* UCP context that owns a memory handle */
     uct_alloc_method_t  alloc_method;   /* Method used to allocate the memory */
     ucs_sys_device_t    sys_dev;        /* System device index */

--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -57,7 +57,10 @@ ucp_memh_get(ucp_context_h context, void *address, size_t length,
         }
 
         memh = ucs_derived_of(rregion, ucp_mem_t);
-        if (ucs_likely(ucs_test_all_flags(memh->md_map, reg_md_map))) {
+        if (ucs_likely(ucs_test_all_flags(memh->md_map, reg_md_map)) &&
+            ucs_likely(ucs_test_all_flags(
+                    memh->uct_flags,
+                    uct_flags & UCP_MM_UCT_ACCESS_MASK))) {
             ucp_memh_rcache_print(memh, address, length);
             *memh_p = memh;
             UCP_THREAD_CS_EXIT(&context->mt_lock);

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -905,6 +905,80 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
 
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_mmap)
 
+class test_ucp_mmap_atomic : public test_ucp_mmap {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        test_ucp_mmap::get_test_variants(variants,
+                                         UCP_FEATURE_TAG | UCP_FEATURE_AMO64);
+    }
+};
+
+/* Use a buffer for send/recv, and then reuse it for atomic operations */
+UCS_TEST_P(test_ucp_mmap_atomic, reuse_buffer)
+{
+    mem_buffer sbuf(UCS_MBYTE, UCS_MEMORY_TYPE_HOST, 1);
+    mem_buffer rbuf(UCS_MBYTE, UCS_MEMORY_TYPE_HOST);
+
+    /* Send/receive from buffers to trigger adding them to registration cache */
+    {
+        static constexpr uint64_t TAG = 0xdeadbeef;
+        ucp_request_param_t param;
+
+        param.op_attr_mask = 0;
+        auto sreq = ucp_tag_send_nbx(sender().ep(), sbuf.ptr(), sbuf.size(),
+                                     TAG, &param);
+        auto rreq = ucp_tag_recv_nbx(receiver().worker(), rbuf.ptr(),
+                                     rbuf.size(), TAG, 0, &param);
+
+        ASSERT_UCS_OK(requests_wait({sreq, rreq}));
+    }
+
+    /* Map the receive buffer for atomic operations */
+    ucp_mem_h memh;
+    ucp_rkey_h rkey;
+    {
+        ucp_mem_map_params_t params;
+        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                            UCP_MEM_MAP_PARAM_FIELD_LENGTH |
+                            UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+        params.address    = rbuf.ptr();
+        params.length     = rbuf.size();
+        params.flags      = mem_map_flags();
+
+        ASSERT_UCS_OK(ucp_mem_map(receiver().ucph(), &params, &memh));
+
+        void *rkey_buffer;
+        size_t rkey_size;
+        ASSERT_UCS_OK(ucp_rkey_pack(receiver().ucph(), memh, &rkey_buffer,
+                                    &rkey_size));
+        ASSERT_UCS_OK(ucp_ep_rkey_unpack(sender().ep(), rkey_buffer, &rkey));
+
+        ucp_rkey_buffer_release(rkey_buffer);
+    }
+
+    /* Perform atomic operation */
+    {
+        uint64_t value = 1;
+        ucp_request_param_t param;
+
+        param.op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE;
+        param.datatype     = ucp_dt_make_contig(sizeof(value));
+        auto sreq = ucp_atomic_op_nbx(sender().ep(), UCP_ATOMIC_OP_ADD, &value,
+                                      1, (uintptr_t)rbuf.ptr(), rkey, &param);
+
+        param.op_attr_mask = 0;
+        auto freq          = ucp_ep_flush_nbx(sender().ep(), &param);
+
+        ASSERT_UCS_OK(requests_wait({sreq, freq}));
+    }
+
+    /* Unmap the buffer */
+    ucp_rkey_destroy(rkey);
+    ASSERT_UCS_OK(ucp_mem_unmap(receiver().ucph(), memh));
+}
+
+UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_mmap_atomic)
 
 class test_ucp_rkey_compare : public test_ucp_mmap {
 public:


### PR DESCRIPTION
## Why
Fix a remote access error when a memory region obtained from rcache is not registered with atomic access as needed
Fixes internal issue [3784182](https://redmine.mellanox.com/issues/3784182)