### PR TITLE
UCP/PROTO: Improve logging of unimplemented abort/reset

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -845,8 +845,8 @@ ucs_status_t ucp_proto_request_zcopy_id_reset(ucp_request_t *req)
 static void ucp_proto_stub_fatal_not_implemented(const char *func_name,
                                                  ucp_request_t *req)
 {
-    ucs_fatal("%s request %p proto %s, not implemented", func_name, req,
-              req->send.proto_config->proto->name);
+    ucs_fatal("'%s' is not implemented for protocol %s (req: %p)", func_name,
+              req->send.proto_config->proto->name, req);
 }
 
 void ucp_proto_abort_fatal_not_implemented(ucp_request_t *req,


### PR DESCRIPTION
## Why
Change error message from
` Fatal: abort request 0x123456 proto rndv/rts, not implemented`
to
`Fatal: 'abort' is not implemented for protocol rndv/rts (req: 0x123456)`