### PR TITLE
UCP/PROTOV2: Enable using device staging buffers for ppln protos

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1686,13 +1686,12 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->export_md_map            = 0;
 
     ucs_memory_type_for_each(mem_type) {
-        context->reg_md_map[mem_type]     = 0;
-        context->cache_md_map[mem_type]   = 0;
-        context->dmabuf_mds[mem_type]     = UCP_NULL_RESOURCE;
-        context->alloc_md_index[mem_type] = UCP_NULL_RESOURCE;
+        context->reg_md_map[mem_type]           = 0;
+        context->cache_md_map[mem_type]         = 0;
+        context->dmabuf_mds[mem_type]           = UCP_NULL_RESOURCE;
+        context->alloc_md[mem_type].md_index    = UCP_NULL_RESOURCE;
+        context->alloc_md[mem_type].initialized = 0;
     }
-
-    context->alloc_md_index_initialized = 0;
 
     ucs_string_set_init(&avail_tls);
     UCS_STATIC_ASSERT(UCT_DEVICE_TYPE_NET == 0);

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -278,6 +278,14 @@ typedef struct ucp_tl_md {
 } ucp_tl_md_t;
 
 
+typedef struct ucp_context_alloc_md_index {
+    int            initialized;
+    /* Index of memory domain that is used to allocate memory of the given type
+     * using ucp_memh_alloc(). */
+    ucp_md_index_t md_index;
+} ucp_context_alloc_md_index_t;
+
+
 /**
  * UCP context
  */
@@ -288,10 +296,7 @@ typedef struct ucp_context {
     ucp_tl_md_t                   *tl_mds;    /* Memory domain resources */
     ucp_md_index_t                num_mds;    /* Number of memory domains */
 
-    /* Index of memory domain that is used to allocate memory of the given type
-     * using ucp_memh_alloc(). */
-    int                           alloc_md_index_initialized;
-    ucp_md_index_t                alloc_md_index[UCS_MEMORY_TYPE_LAST];
+    ucp_context_alloc_md_index_t  alloc_md[UCS_MEMORY_TYPE_LAST];
 
     /* Map of MDs that provide registration for given memory type,
        ucp_mem_map() will register memory for all those domains. */

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1543,13 +1543,13 @@ void ucp_mem_rcache_cleanup(ucp_context_h context)
 }
 
 ucs_status_t
-ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idx)
+ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idx,
+                          ucs_memory_type_t alloc_mem_type)
 {
-    const ucs_memory_type_t alloc_mem_type = UCS_MEMORY_TYPE_HOST;
     ucs_status_t status;
     uct_allocated_memory_t mem;
 
-    if (!context->alloc_md_index_initialized) {
+    if (!context->alloc_md[alloc_mem_type].initialized) {
         status = ucp_mem_do_alloc(context, NULL, 1,
                                   UCT_MD_MEM_ACCESS_RMA |
                                           UCT_MD_MEM_FLAG_HIDE_ERRORS,
@@ -1559,13 +1559,13 @@ ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idx)
             return status;
         }
 
-        context->alloc_md_index_initialized     = 1;
-        context->alloc_md_index[alloc_mem_type] =
+        context->alloc_md[alloc_mem_type].initialized = 1;
+        context->alloc_md[alloc_mem_type].md_index    =
                 ucp_mem_get_md_index(context, mem.md, mem.method);
         uct_mem_free(&mem);
     }
 
-    *md_idx = context->alloc_md_index[alloc_mem_type];
+    *md_idx = context->alloc_md[alloc_mem_type].md_index;
     return UCS_OK;
 }
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -177,7 +177,7 @@ ucs_status_t ucp_mem_rcache_init(ucp_context_h context,
 void ucp_mem_rcache_cleanup(ucp_context_h context);
 
 /**
- * Get memory domain index that is used to allocate host memory type.
+ * Get memory domain index that is used to allocate certain memory type.
  *
  * @param [in]  context UCP context containing memory domain indexes to use for
  *                      the memory allocation.
@@ -187,7 +187,8 @@ void ucp_mem_rcache_cleanup(ucp_context_h context);
  * @return Error code as defined by @ref ucs_status_t.
  */
 ucs_status_t
-ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idx);
+ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idxi,
+                          ucs_memory_type_t alloc_mem_type);
 
 static UCS_F_ALWAYS_INLINE ucp_md_map_t
 ucp_rkey_packed_md_map(const void *rkey_buffer)

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -393,6 +393,7 @@ ucp_proto_rndv_rtr_mtype_init(const ucp_proto_init_params_t *init_params)
     ucp_proto_rndv_rtr_priv_t *rpriv = init_params->priv;
     const uint64_t rndv_modes        = UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE);
     ucp_context_h context            = init_params->worker->context;
+    ucs_memory_type_t frag_mem_type  = context->config.ext.rndv_frag_mem_type;
     ucp_proto_perf_node_t *unpack_perf_node;
     ucs_linear_func_t unpack_time;
     ucp_md_map_t md_map, dummy_md_map;
@@ -410,25 +411,23 @@ ucp_proto_rndv_rtr_mtype_init(const ucp_proto_init_params_t *init_params)
     }
 
     status = ucp_proto_init_buffer_copy_time(
-            init_params->worker, "rtr/mtype unpack", UCS_MEMORY_TYPE_HOST,
+            init_params->worker, "rtr/mtype unpack", frag_mem_type,
             init_params->select_param->mem_type, UCT_EP_OP_PUT_ZCOPY,
             &unpack_time, &unpack_perf_node);
     if (status != UCS_OK) {
         return status;
     }
 
-    /* Make sure that key of the md used to allocate a bounce buffer will be
-     * packed to the RTR rkey
-     */
-    status = ucp_mm_get_alloc_md_index(context, &md_index);
-    if (status != UCS_OK) {
-        return status;
+    status = ucp_mm_get_alloc_md_index(context, &md_index, frag_mem_type);
+    if ((status != UCS_OK) || (md_index == UCP_NULL_RESOURCE)) {
+        md_map = 0;
+    } else {
+        md_map = UCS_BIT(md_index);
     }
 
-    md_map = UCS_BIT(md_index);
     status = ucp_proto_rndv_rtr_common_init(init_params, rndv_modes, frag_size,
                                             unpack_time, unpack_perf_node,
-                                            md_map, UCS_MEMORY_TYPE_HOST,
+                                            md_map, frag_mem_type,
                                             UCS_SYS_DEVICE_ID_UNKNOWN);
     ucp_proto_perf_node_deref(&unpack_perf_node);
 


### PR DESCRIPTION
## What
Allocate staging buffers for ppln protocols according to UCX_RNDV_FRAG_MEM_TYPE. (currently it is parsed by v1 protos only)
