### PR TITLE
GTEST: Use more than 1 fragment in rndv ppln test

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -610,14 +610,11 @@ void ucp_proto_rndv_rts_abort(ucp_request_t *req, ucs_status_t status)
 
 ucs_status_t ucp_proto_rndv_rts_reset(ucp_request_t *req)
 {
-    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        return UCS_OK;
+    if (req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) {
+        ucs_assert(req->send.state.completed_size == 0);
     }
 
-    ucs_assert(req->send.state.completed_size == 0);
-    ucp_send_request_id_release(req);
-    ucp_proto_request_zcopy_clean(req, UCP_DT_MASK_ALL);
-    return UCS_OK;
+    return ucp_proto_request_zcopy_id_reset(req);
 }
 
 static ucs_status_t

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -219,8 +219,6 @@ void ucp_proto_rndv_bulk_request_init_lane_idx(
 void ucp_proto_rndv_ppln_send_frag_complete(ucp_request_t *freq, int send_ack);
 
 
-void ucp_proto_rndv_ppln_recv_frag_clean(ucp_request_t *freq);
-
 void ucp_proto_rndv_ppln_recv_frag_complete(ucp_request_t *freq, int send_ack,
                                             int abort);
 

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -197,32 +197,6 @@ void ucp_proto_rndv_ppln_send_frag_complete(ucp_request_t *freq, int send_ack)
                                       "ppln_send");
 }
 
-static ucs_status_t ucp_proto_rndv_recv_ppln_reset(ucp_request_t *req)
-{
-    ucs_assertv(req->send.rndv.ppln.ack_data_size <= 0,
-                "req->send.rndv.ppln.ack_data_size=%zd",
-                req->send.rndv.ppln.ack_data_size);
-
-    if (!ucp_proto_common_multi_frag_is_completed(req)) {
-        return UCS_OK;
-    }
-
-    req->status                    = UCS_OK;
-    req->send.state.dt_iter.offset = 0;
-    ucp_proto_request_restart(req);
-    return UCS_OK;
-}
-
-void ucp_proto_rndv_ppln_recv_frag_clean(ucp_request_t *freq)
-{
-    ucp_send_request_id_release(freq);
-
-    /* abort freq since super request may change protocol */
-    ucp_proto_rndv_ppln_frag_complete(freq, 0, 1,
-                                      ucp_proto_rndv_recv_ppln_reset,
-                                      "ppln_recv_clean");
-}
-
 void ucp_proto_rndv_ppln_recv_frag_complete(ucp_request_t *freq, int send_ack,
                                             int abort)
 {

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -301,11 +301,9 @@ ucp_proto_rndv_rtr_mtype_abort(ucp_request_t *req, ucs_status_t status)
 
 static ucs_status_t ucp_proto_rndv_rtr_mtype_reset(ucp_request_t *req)
 {
-    ucs_mpool_put_inline(req->send.rndv.mdesc);
-    if (ucp_proto_rndv_request_is_ppln_frag(req)) {
-        req->status = UCS_ERR_CANCELED;
-        ucp_proto_rndv_ppln_recv_frag_clean(req);
-        return UCS_ERR_CANCELED;
+    if (req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) {
+        ucs_mpool_put_inline(req->send.rndv.mdesc);
+        req->send.rndv.mdesc = NULL;
     }
 
     return ucp_proto_request_zcopy_id_reset(req);

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -17,6 +17,7 @@
 #include "ucp_test.h"
 
 extern "C" {
+#include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_am.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucs/datastruct/mpool.inl>
@@ -1848,7 +1849,14 @@ private:
 
 UCS_TEST_P(test_ucp_am_nbx_rndv_memtype, rndv)
 {
-    test_am_send_recv_memtype(64 * UCS_KBYTE);
+    const auto *cfg                 = &sender().worker()->context->config.ext;
+    const size_t rndv_frag_size     = cfg->rndv_frag_size[UCS_MEMORY_TYPE_HOST];
+    const std::vector<size_t> sizes = {64 * UCS_KBYTE, rndv_frag_size - 1,
+                                       rndv_frag_size  + 1};
+
+    for (size_t size : sizes) {
+        test_am_send_recv_memtype(size);
+    }
 }
 
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_am_nbx_rndv_memtype);


### PR DESCRIPTION
## What
This test provokes a data validation failure in CI
To be extended with the fix for that failure