### PR TITLE
UCT/IB/MD: Disable MR multithreading registration - м1.16.x

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -135,7 +135,7 @@ static ucs_config_field_t uct_ib_md_config_table[] = {
      ucs_offsetof(uct_ib_md_config_t, devx_objs),
      UCS_CONFIG_TYPE_BITMAP(uct_ib_devx_objs)},
 
-    {"REG_MT_THRESH", "4G",
+    {"REG_MT_THRESH", "inf",
      "Minimal MR size to be register using multiple parallel threads.\n"
      "Number of threads used will be determined by number of CPUs which "
      "registering thread is bound to by hard affinity.",


### PR DESCRIPTION
## What
Disabling MR MT registration.

## Why
The implementation of multithreading MR registration contains many errors that are already fixed in master.