### PR TITLE
UCP/WIREUP: Consider local distance during slow lanes dropping - v1.16.x - revert

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1461,18 +1461,12 @@ static double ucp_wireup_get_lane_bw(ucp_worker_h worker,
                                      const ucp_wireup_select_info_t *sinfo,
                                      const ucp_unpacked_address_t *address)
 {
-    ucp_worker_iface_t *wiface = ucp_worker_iface(worker, sinfo->rsc_index);
+    ucp_context_h context = worker->context;
+    const uct_iface_attr_t *iface_attr;
     double bw_local, bw_remote;
 
-    if (address->dst_version < 17) {
-        bw_local = ucp_tl_iface_bandwidth(worker->context,
-                                          &wiface->attr.bandwidth);
-    } else {
-        /* Compare BW including local distance to prevent EP reconfiguration
-         * since remote distance is included to remote_addr*/
-        bw_local = ucp_wireup_iface_bw_distance(wiface);
-    }
-
+    iface_attr = ucp_worker_iface_get_attr(worker, sinfo->rsc_index);
+    bw_local   = ucp_tl_iface_bandwidth(context, &iface_attr->bandwidth);
     bw_remote  = address->address_list[sinfo->addr_index].iface_attr.bandwidth;
 
     if (address->addr_version == UCP_OBJECT_VERSION_V2) {


### PR DESCRIPTION
## What
Reverting the backport of https://github.com/openucx/ucx/pull/9512 since it breaks wire compatibility.