### PR TITLE
UCP/PROTO: Add latency conversion to nsec before FP8 pack/unpack

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -128,7 +128,8 @@ ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
 static void
 ucp_proto_common_fp8_pack_unpack_distance(ucs_sys_dev_distance_t *distance)
 {
-    distance->latency   = UCS_FP8_PACK_UNPACK(LATENCY, distance->latency);
+    double nsec         = distance->latency * UCS_NSEC_PER_SEC;
+    distance->latency   = UCS_FP8_PACK_UNPACK(LATENCY, nsec) / UCS_NSEC_PER_SEC;
     distance->bandwidth = UCS_FP8_PACK_UNPACK(BANDWIDTH, distance->bandwidth);
 }
 


### PR DESCRIPTION
## What
Add conversion of latency to nanoseconds to make FP8 pack/unpack correctly

## Why ?
Latency FP8 pack/unpack supports value represented in nanoseconds

Latency value without this patch after FP8 pack 😄 :
![image](https://github.com/openucx/ucx/assets/22097249/87ed9ef9-46bb-4af8-b1f2-5b6b07b85d93)
