### PR TITLE
UCP/WORKER: Fix atomic device selection

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -1450,7 +1450,8 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
                               UCT_TL_RESOURCE_DESC_ARG(
                                       &context->tl_rscs[rsc_index].tl_rsc),
                               dev->sys_dev, dev->num_paths, num_ep_addrs,
-                              md_flags, iface_attr->cap.flags,
+                              md_flags,
+                              iface_attr->cap.flags & UCP_ADDRESS_IFACE_FLAGS,
                               iface_attr->bandwidth.dedicated / UCS_MBYTE,
                               iface_attr->bandwidth.shared / UCS_MBYTE,
                               iface_attr->overhead * 1e9,
@@ -1813,7 +1814,7 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
 
             ucp_address_trace(unpack_flags,
                               "unpack addr[%d] : sysdev %d paths %d eps %u"
-                              " tl_iface_flags 0x%" PRIx64 " bw %.2f/nMBs"
+                              " tl_flags 0x%" PRIx64 " bw %.2f/nMBs"
                               " ovh %.0fns lat_ovh %.0fns dev_priority %d"
                               " a32 0x%" PRIx64 "/0x%" PRIx64 " a64 0x%" PRIx64
                               "/0x%" PRIx64,


### PR DESCRIPTION
## Why
Fix gtest failure on rock cluster:
```
[ RUN      ] dcx/test_ucp_mmap_atomic.reuse_buffer/0 <dc_x,cuda_copy,rocm_copy>
[1711951084.768635] [rock12:15343:0]          wireup.c:1239 UCX  ERROR   old: am_lane 0 wireup_msg_lane <none> cm_lane <none> keepalive_lane <none> reachable_mds 0xe
[1711951084.768666] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   old: lane[0]:  5:dc_mlx5/mlx5_2:1.0 md[3]      -> md[3]/ib/sysdev[4] seg 4294967295 am am_bw#0
[1711951084.768674] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   old: lane[1]:  5:dc_mlx5/mlx5_2:1.0 md[3]      -> md[2]/ib/sysdev[2] seg 4294967295 amo#0
[1711951084.768679] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   old: lane[2]:  1:dc_mlx5/mlx5_1:1.0 md[1]      -> md[1]/ib/sysdev[3] seg 4294967295 rma_bw#0
[1711951084.768685] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   old: lane[3]:  5:dc_mlx5/mlx5_2:1.1 md[3]      -> md[3]/ib/sysdev[4] seg 4294967295 rma_bw#1
[1711951084.768688] [rock12:15343:0]          wireup.c:1253 UCX  ERROR   old: err mode 0, flags 0x2
[1711951084.768691] [rock12:15343:0]          wireup.c:1239 UCX  ERROR   new: am_lane 0 wireup_msg_lane <none> cm_lane <none> keepalive_lane <none> reachable_mds 0xe
[1711951084.768694] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   new: lane[0]:  5:dc_mlx5/mlx5_2:1.0 md[3]      -> md[3]/ib/sysdev[4] seg 4294967295 am am_bw#0
[1711951084.768698] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   new: lane[1]:  1:dc_mlx5/mlx5_1:1.0 md[1]      -> md[1]/ib/sysdev[3] seg 4294967295 rma_bw#0
[1711951084.768701] [rock12:15343:0]          wireup.c:1249 UCX  ERROR   new: lane[2]:  5:dc_mlx5/mlx5_2:1.1 md[3]      -> md[3]/ib/sysdev[4] seg 4294967295 rma_bw#1
[1711951084.768704] [rock12:15343:0]          wireup.c:1253 UCX  ERROR   new: err mode 0, flags 0x2
[rock12:15343:0:15343]      wireup.c:1619 Fatal: endpoint reconfiguration not supported yet
[rock12:15343:0:15343] Process frozen, press Enter to attach a debugger...
```

## How
Make sure the best-score device is selected for atomic operations. Otherwise, the lane selection process on an endpoint may select a different device, and atomic operations will be disabled during wireup message exchange.