### PR TITLE
UCP/WIREUP: Add missed conversion to nanoseconds before FP8 pack/unpack

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -12,6 +12,7 @@
 #include "proto_common.inl"
 
 #include <ucp/am/ucp_am.inl>
+#include <ucp/wireup/wireup.h>
 #include <uct/api/v2/uct_v2.h>
 
 
@@ -128,8 +129,7 @@ ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
 static void
 ucp_proto_common_fp8_pack_unpack_distance(ucs_sys_dev_distance_t *distance)
 {
-    double nsec         = distance->latency * UCS_NSEC_PER_SEC;
-    distance->latency   = UCS_FP8_PACK_UNPACK(LATENCY, nsec) / UCS_NSEC_PER_SEC;
+    distance->latency   = ucp_wireup_fp8_pack_unpack_latency(distance->latency);
     distance->bandwidth = UCS_FP8_PACK_UNPACK(BANDWIDTH, distance->bandwidth);
 }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -666,7 +666,7 @@ ucp_wireup_tl_iface_latency(const ucp_worker_iface_t *wiface,
         local_lat = ucp_wireup_iface_lat_distance_v2(wiface);
         /* FP8 is a lossy compression method, so in order to create a symmetric
          * calculation we pack/unpack the local latency as well */
-        lat_lossy = UCS_FP8_PACK_UNPACK(LATENCY, local_lat) / UCS_NSEC_PER_SEC;
+        lat_lossy = ucp_wireup_fp8_pack_unpack_latency(local_lat);
 
         return (remote_iface_attr->lat_ovh + lat_lossy) / 2;
     }

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -235,4 +235,10 @@ static inline int ucp_wireup_lane_type_is_fast_path(ucp_lane_type_t lane_type)
     return ucp_wireup_lane_types_has_fast_path(UCS_BIT(lane_type));
 }
 
+static inline double ucp_wireup_fp8_pack_unpack_latency(double latency)
+{
+    return UCS_FP8_PACK_UNPACK(LATENCY, latency * UCS_NSEC_PER_SEC) /
+           UCS_NSEC_PER_SEC;
+}
+
 #endif


### PR DESCRIPTION
## What
Add latency conversion to nanoseconds before FP8 pack/unpack

## Why ?
https://github.com/openucx/ucx/pull/9738 misses conversion to nanoseconds during the wirep ([link to line](https://github.com/openucx/ucx/pull/9738/files#diff-ff110fb0f2e163038a3eb15545d3b81d9d32c121b79e7a764b72fbb1fa643470L654))
