### PR TITLE
UCP/PROTO: Remove redundant frag_size argument from parallel_stages()

### DIFF
--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -70,7 +70,6 @@ ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
  * @param [in]    proto_name    Protocol name, for debugging.
  * @param [in]    range_start   Range interval start.
  * @param [in]    range_end     Range interval end.
- * @param [in]    frag_size     Size of protocol's fragments.
  * @param [in]    bias          Performance bias (0 - no bias).
  * @param [in]    stages        Array of parallel stages performance ranges.
  * @param [in]    num_stages    Number of parallel stages in the protocol.
@@ -78,7 +77,7 @@ ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
  */
 ucs_status_t
 ucp_proto_init_parallel_stages(const char *proto_name, size_t range_start,
-                               size_t range_end, size_t frag_size, double bias,
+                               size_t range_end, double bias,
                                const ucp_proto_perf_range_t **stages,
                                unsigned num_stages, ucp_proto_caps_t *caps);
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -369,7 +369,7 @@ ucp_proto_rndv_ctrl_init(const ucp_proto_rndv_ctrl_init_params_t *params,
         parallel_stages[1] = &remote_perf;
         status = ucp_proto_init_parallel_stages(params->super.super.proto_name,
                                                 min_length, range_max_length,
-                                                SIZE_MAX, params->perf_bias,
+                                                params->perf_bias,
                                                 parallel_stages, 2, caps);
         if (status != UCS_OK) {
             goto out_deref_perf_node;
@@ -580,7 +580,7 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
 
         status = ucp_proto_init_parallel_stages(init_params->proto_name,
                                                 min_length,
-                                                ack_range.max_length, SIZE_MAX,
+                                                ack_range.max_length,
                                                 0, parallel_stages, 2,
                                                 init_params->caps);
         if (status != UCS_OK) {


### PR DESCRIPTION
## What
Remove `frag_size` argument from `ucp_proto_init_parallel_stages` API.

## Why?
Since this argument participates only in logs and perf tree information. Can be removed since `ucp_proto_common_add_ppln_range` already prints info about fragment size.
