### PR TITLE
UCP/PROTO: Report right proto name during ACK perf adding

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -578,7 +578,8 @@ ucs_status_t ucp_proto_rndv_ack_init(const ucp_proto_init_params_t *init_params,
         parallel_stages[0] = &ack_range;
         parallel_stages[1] = &input_caps->ranges[i];
 
-        status = ucp_proto_init_parallel_stages(name, min_length,
+        status = ucp_proto_init_parallel_stages(init_params->proto_name,
+                                                min_length,
                                                 ack_range.max_length, SIZE_MAX,
                                                 0, parallel_stages, 2,
                                                 init_params->caps);


### PR DESCRIPTION
## What
Report protocol name to the perf tree instead of ACK name.

## Why?
| Before| After|
|--------|--------|
| ![image](https://github.com/ivankochin/ucx/assets/22097249/81ab87d0-6e1c-4bc5-bf1e-d824459e22a5) | ![image](https://github.com/ivankochin/ucx/assets/22097249/02a086c2-a41b-4079-9df7-ef2ea5dca3ec)|
