### PR TITLE
UCP/CONTEXT: Add host,cuda_managed to ODP memtypes if Grace CPU is detected

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -165,6 +165,8 @@ typedef struct ucp_context_config {
     char                                   *proto_info_dir;
     /** Memory types that perform non-blocking registration by default */
     uint64_t                               reg_nb_mem_types;
+    /** Toggle population of nonblocking registration memory types */
+    ucs_ternary_auto_value_t               populate_nb_mem_types;
     /** Prefer native RMA transports for RMA/AMO protocols */
     int                                    prefer_offload;
     /** RMA zcopy segment size */


### PR DESCRIPTION
## What
Simpler PR to enable ODP for host/cuda_managed memory on Grace compared to https://github.com/openucx/ucx/pull/9370

## Out-of-scope and deferred to sysadmins:
1. Detecting if ODPv2 is enabled on the system
2. Detecting if Hopper(+) is present
3. Other checks to ensure host and cuda_managed memory actually works correctly with ODPv2
