### PR TITLE
Add UCP_MEM_MAP_BLOCK flag

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -567,7 +567,13 @@ enum {
      * received from different peers are compared equal, they can be used
      * interchangeably, avoiding the need to keep all of them in memory.
      */
-    UCP_MEM_MAP_SYMMETRIC_RKEY = UCS_BIT(3)
+    UCP_MEM_MAP_SYMMETRIC_RKEY = UCS_BIT(3),
+
+    /**
+     * Enforce pinning of the memory pages in the mapping and populate them up-front.
+     * This flag is mutually exclusive with UCP_MEM_MAP_NONBLOCK.
+     */
+    UCP_MEM_MAP_LOCK           = UCS_BIT(4)
 };
 
 


### PR DESCRIPTION
## What
Add UCP_MEM_MAP_BLOCK so the user can enforce blocking memory mapping (e.g., non-ODP registration).

## Why ?
On GH systems, UCX will automatically enable nonblocking mapping (ODP) for all system-allocated memory. In certain cases, however, the user may want to explicitly disable ODP for particular ucp_mem_map calls. This flags allows the user to achieve that.
