### PR TITLE
UCP/CORE: increate max no. of lanes

### DIFF
--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -40,7 +40,7 @@ UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 
 /* Lanes */
-#define UCP_MAX_LANES                16
+#define UCP_MAX_LANES                32
 #define UCP_MAX_FAST_PATH_LANES      5
 #define UCP_MAX_SLOW_PATH_LANES      (UCP_MAX_LANES - UCP_MAX_FAST_PATH_LANES)
 


### PR DESCRIPTION

## What
increase UCP_MAX_LANES from 16 to 32

## Why ?
on some platforms with a large number of RDMA capable interfaces having a max. nunber of 16 lanes is not sufficient. GPU ipc protocols might not be able to enlist when constructing rma_bw_lanes.
