### PR TITLE
UCP/WIREUP: Increase UCP_MAX_LANES to 64

### DIFF
--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -139,7 +139,7 @@ static inline ucp_lane_index_t ucp_ep_num_lanes(ucp_ep_h ep)
 
 static inline int ucp_ep_is_lane_p2p(ucp_ep_h ep, ucp_lane_index_t lane)
 {
-    return ucp_ep_config(ep)->p2p_lanes & UCS_BIT(lane);
+    return !!(ucp_ep_config(ep)->p2p_lanes & UCS_BIT(lane));
 }
 
 static inline ucp_md_index_t ucp_ep_md_index(ucp_ep_h ep, ucp_lane_index_t lane)
@@ -239,7 +239,7 @@ static inline ucp_rsc_index_t
 ucp_ep_config_get_dst_md_cmpt(const ucp_ep_config_key_t *key,
                               ucp_md_index_t dst_md_index)
 {
-    unsigned idx = ucs_popcount(key->reachable_md_map & UCS_MASK(dst_md_index));
+    unsigned idx = ucs_bitmap2idx(key->reachable_md_map, dst_md_index);
 
     return key->dst_md_cmpts[idx];
 }

--- a/src/ucp/core/ucp_types.h
+++ b/src/ucp/core/ucp_types.h
@@ -40,9 +40,9 @@ UCP_UINT_TYPE(UCP_MD_INDEX_BITS)     ucp_md_map_t;
 
 
 /* Lanes */
-#define UCP_MAX_LANES                16
+#define UCP_MAX_LANES_LEGACY         16
+#define UCP_MAX_LANES                64
 #define UCP_MAX_FAST_PATH_LANES      5
-#define UCP_MAX_SLOW_PATH_LANES      (UCP_MAX_LANES - UCP_MAX_FAST_PATH_LANES)
 
 #define UCP_NULL_LANE                ((ucp_lane_index_t)-1)
 typedef uint8_t                      ucp_lane_index_t;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3470,8 +3470,7 @@ static int ucp_worker_do_ep_keepalive(ucp_worker_h worker, ucs_time_t now)
     ucs_trace("ep %p: do keepalive on lane[%d]=%p ep->flags=0x%x", ep, lane,
               uct_ep, ep->flags);
 
-    if (ucp_ep_is_am_keepalive(ep, rsc_index,
-                               ucp_ep_config(ep)->p2p_lanes & UCS_BIT(lane))) {
+    if (ucp_ep_is_am_keepalive(ep, rsc_index, ucp_ep_is_lane_p2p(ep, lane))) {
         status = ucp_ep_do_uct_ep_am_keepalive(ep, uct_ep, rsc_index);
     } else {
         status = uct_ep_check(uct_ep, 0, NULL);
@@ -3773,7 +3772,7 @@ ucp_wiface_process_for_each_lane(ucp_worker_h worker,
 
     ucs_for_each_bit(lane, lane_map) {
         ucs_assertv(lane < UCP_MAX_LANES,
-                    "lane=%" PRIu8 ", lane_map=0x%" PRIx16, lane, lane_map);
+                    "lane=%" PRIu8 ", lane_map=0x%" PRIx64, lane, lane_map);
         rsc_index = ep_config->key.lanes[lane].rsc_index;
         wiface    = ucp_worker_iface(worker, rsc_index);
         wiface_process(wiface);

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -55,10 +55,16 @@ void ucp_proto_common_add_ppln_range(ucp_proto_caps_t *caps,
     frag_overhead =
             ucs_linear_func_apply(ppln_perf[UCP_PROTO_PERF_TYPE_SINGLE], frag_size) -
             ucs_linear_func_apply(ppln_perf[UCP_PROTO_PERF_TYPE_MULTI], frag_size);
-    ucs_assert(frag_overhead >= 0);
 
     ucs_trace("frag-size: %zd" UCP_PROTO_TIME_FMT(frag_overhead), frag_size,
               UCP_PROTO_TIME_ARG(frag_overhead));
+
+    /* In certain cases multi perf can be bigger than single (e.g. FAST_CMPL
+     * with huge send_post_overhead) so the fragment overhead can be negative
+     * according to the logic above. The simplest estimation is to ignore
+     * fragment overhead in that particular case.
+     */
+    frag_overhead = ucs_max(frag_overhead, 0);
 
     /* Apply the pipelining effect when sending multiple fragments */
     ppln_perf[UCP_PROTO_PERF_TYPE_SINGLE] =

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -255,9 +255,10 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_lane_map_progress(
     ucp_lane_index_t lane;
     ucs_status_t status;
 
-    ucs_assertv(remaining_lane_map != 0, "req=%p *lane_p=%d lane_map=0x%x", req,
-                *lane_p, lane_map);
-    lane = ucs_ffs32(remaining_lane_map);
+    ucs_assertv(remaining_lane_map != 0,
+                "req=%p *lane_p=%d lane_map=0x%" PRIx64, req, *lane_p,
+                lane_map);
+    lane = ucs_ffs64(remaining_lane_map);
 
     status = send_func(req, lane);
     if (ucs_likely(status == UCS_OK)) {

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -25,12 +25,13 @@ ucp_ep_flush_request_update_uct_comp(ucp_request_t *req, int diff,
                 &req->send.state.uct_comp, req->send.state.uct_comp.count,
                 diff);
     ucs_assertv(!(req->send.flush.started_lanes & new_started_lanes),
-                "req=%p started_lanes=0x%x new_started_lanes=0x%x", req,
-                req->send.flush.started_lanes, new_started_lanes);
+                "req=%p started_lanes=0x%" PRIx64
+                " new_started_lanes=0x%" PRIx64,
+                req, req->send.flush.started_lanes, new_started_lanes);
 
     ucp_trace_req(req,
                   "flush update ep %p comp_count %d->%d num_lanes %d->%d "
-                  "started_lanes 0x%x->0x%x",
+                  "started_lanes 0x%" PRIx64 "->0x%" PRIx64,
                   req->send.ep, req->send.state.uct_comp.count,
                   req->send.state.uct_comp.count + diff,
                   req->send.flush.num_lanes, ucp_ep_num_lanes(req->send.ep),
@@ -99,7 +100,8 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
     }
 
     ucp_trace_req(req,
-                  "progress ep=%p flush flags=0x%x started_lanes=0x%x count=%d",
+                  "progress ep=%p flush flags=0x%x started_lanes=0x%" PRIx64
+                  " count=%d",
                   ep, ep->flags, req->send.flush.started_lanes,
                   req->send.state.uct_comp.count);
 
@@ -229,20 +231,22 @@ static void ucp_ep_flush_request_resched(ucp_ep_h ep, ucp_request_t *req)
             (ucp_ep_config(ep)->p2p_lanes &&
              ep->worker->context->config.ext.proto_request_reset)) {
             ucs_assertv(!req->send.flush.started_lanes,
-                        "req=%p flush started_lanes=0x%x", req,
+                        "req=%p flush started_lanes=0x%" PRIx64, req,
                         req->send.flush.started_lanes);
         } else {
-            ucs_assertv(!(UCS_BIT(req->send.lane) & req->send.flush.started_lanes),
-                        "req=%p lane=%d started_lanes=0x%x", req, req->send.lane,
-                        req->send.flush.started_lanes);
+            ucs_assertv(!(UCS_BIT(req->send.lane) &
+                          req->send.flush.started_lanes),
+                        "req=%p lane=%d started_lanes=0x%" PRIx64, req,
+                        req->send.lane, req->send.flush.started_lanes);
 
             /* Only lanes connected to iface can be started/flushed before
              * wireup is done because connect2iface does not create wireup_ep
              * without cm mode */
             ucs_assertv(!(req->send.flush.started_lanes &
                           ucp_ep_config(ep)->p2p_lanes),
-                        "req=%p flush started_lanes=0x%x p2p_lanes=0x%x", req,
-                        req->send.flush.started_lanes,
+                        "req=%p flush started_lanes=0x%" PRIx64
+                        " p2p_lanes=0x%" PRIx64,
+                        req, req->send.flush.started_lanes,
                         ucp_ep_config(ep)->p2p_lanes);
         }
 
@@ -348,9 +352,10 @@ void ucp_ep_flush_request_ff(ucp_request_t *req, ucs_status_t status)
     int num_comps = req->send.flush.num_lanes -
                     ucs_popcount(req->send.flush.started_lanes);
 
-    ucp_trace_req(req, "fast-forward flush, comp-=%d num_lanes %d started 0x%x",
-                  num_comps, req->send.flush.num_lanes,
-                  req->send.flush.started_lanes);
+    ucp_trace_req(
+            req, "fast-forward flush, comp-=%d num_lanes %d started 0x%" PRIx64,
+            num_comps, req->send.flush.num_lanes,
+            req->send.flush.started_lanes);
 
     ucp_ep_flush_request_update_uct_comp(req, -num_comps,
                                          UCS_MASK(req->send.flush.num_lanes) &

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -519,7 +519,7 @@ static void ucp_rndv_zcopy_next_lane(ucp_request_t *rndv_req)
     ucp_lane_map_t lane_map;
     lane_map = lanes_map_all & ~UCS_MASK(rndv_req->send.multi_lane_idx + 1);
 
-    rndv_req->send.multi_lane_idx = ucs_ffs32((lane_map > 0) ? lane_map :
+    rndv_req->send.multi_lane_idx = ucs_ffs64((lane_map > 0) ? lane_map :
                                                                lanes_map_all);
 }
 
@@ -694,7 +694,7 @@ static void ucp_rndv_req_init_lanes(ucp_request_t *req,
                                     ucp_lane_map_t lanes_map)
 {
     req->send.rndv.zcopy.lanes_map_all = lanes_map;
-    req->send.multi_lane_idx           = ucs_ffs32(lanes_map);
+    req->send.multi_lane_idx           = ucs_ffs64(lanes_map);
 }
 
 static void ucp_rndv_req_init_zcopy_lane_map(ucp_request_t *rndv_req,

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -93,8 +93,12 @@ ucp_rndv_rkey_ptr_query_common(const ucp_proto_query_params_t *params,
     const ucp_proto_rndv_rkey_ptr_priv_t *rpriv = params->priv;
 
     ucp_proto_default_query(params, attr);
-    attr->lane_map = UCS_BIT(rpriv->spriv.super.lane) |
-                     UCS_BIT(rpriv->ack.lane);
+
+    ucs_assert(rpriv->spriv.super.lane != UCP_NULL_LANE);
+    attr->lane_map = UCS_BIT(rpriv->spriv.super.lane);
+    if (rpriv->ack.lane != UCP_NULL_LANE) {
+        attr->lane_map |= UCS_BIT(rpriv->ack.lane);
+    }
 }
 
 static void

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -362,11 +362,20 @@ ucp_wireup_init_select_info(double score, unsigned addr_index,
     select_info->priority   = priority;
 }
 
-static size_t ucp_wireup_max_lanes(ucp_lane_type_t lane_type)
+static size_t
+ucp_wireup_bw_max_lanes(const ucp_wireup_select_params_t *select_params)
+{
+    return (select_params->address->dst_version < 18) ? UCP_MAX_LANES_LEGACY :
+                                                        UCP_MAX_LANES;
+}
+
+static size_t
+ucp_wireup_max_lanes(const ucp_wireup_select_params_t *select_params,
+                     ucp_lane_type_t lane_type)
 {
     return ucp_wireup_lane_type_is_fast_path(lane_type) ?
                    UCP_MAX_FAST_PATH_LANES :
-                   UCP_MAX_LANES;
+                   ucp_wireup_bw_max_lanes(select_params);
 }
 
 /**
@@ -563,7 +572,8 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             continue;
         }
 
-        if (select_ctx->num_lanes < ucp_wireup_max_lanes(criteria->lane_type)) {
+        if (select_ctx->num_lanes <
+            ucp_wireup_max_lanes(select_params, criteria->lane_type)) {
             /* If we have not reached the lanes limit, we can select any
                combination of rsc_index/addr_index */
             rsc_addr_index_map = addr_index_map;
@@ -697,6 +707,7 @@ ucp_wireup_path_index_is_equal(unsigned path_index1, unsigned path_index2)
 }
 
 static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_lane_desc(
+        const ucp_wireup_select_params_t *select_params,
         const ucp_wireup_select_info_t *select_info,
         ucp_md_index_t dst_md_index, ucs_sys_device_t dst_sys_dev,
         ucp_lane_type_t lane_type, unsigned seg_size,
@@ -749,7 +760,8 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_lane_desc(
         ucs_assert_always(!ucp_wireup_has_slow_lanes(select_ctx));
     }
 
-    if (select_ctx->num_lanes >= ucp_wireup_max_lanes(lane_type)) {
+    if (select_ctx->num_lanes >=
+        ucp_wireup_max_lanes(select_params, lane_type)) {
         log_level = show_error ? UCS_LOG_LEVEL_ERROR : UCS_LOG_LEVEL_DEBUG;
         ucs_log(log_level, "cannot add %s lane - reached limit (%d)",
                 ucp_lane_type_info[lane_type].short_name,
@@ -797,7 +809,8 @@ ucp_wireup_add_lane(const ucp_wireup_select_params_t *select_params,
     ucp_address_entry_t *addr_list = select_params->address->address_list;
     unsigned addr_index            = select_info->addr_index;
 
-    return ucp_wireup_add_lane_desc(select_info, addr_list[addr_index].md_index,
+    return ucp_wireup_add_lane_desc(select_params, select_info,
+                                    addr_list[addr_index].md_index,
                                     addr_list[addr_index].sys_dev, lane_type,
                                     addr_list[addr_index].iface_attr.seg_size,
                                     select_ctx,
@@ -1095,7 +1108,8 @@ ucp_wireup_add_cm_lane(const ucp_wireup_select_params_t *select_params,
                                 &select_info);
 
     /* server is not a proxy because it can create all lanes connected */
-    return ucp_wireup_add_lane_desc(&select_info, UCP_NULL_RESOURCE,
+    return ucp_wireup_add_lane_desc(select_params, &select_info,
+                                    UCP_NULL_RESOURCE,
                                     UCS_SYS_DEVICE_ID_UNKNOWN, UCP_LANE_TYPE_CM,
                                     UINT_MAX, select_ctx, 1);
 }
@@ -1541,9 +1555,10 @@ ucp_wireup_add_fast_lanes(ucp_worker_h worker,
     return num_lanes;
 }
 
-static unsigned
-ucp_wireup_get_current_num_lanes(ucp_ep_h ep, ucp_lane_type_t type)
+static unsigned ucp_wireup_get_current_num_lanes(
+        const ucp_wireup_select_params_t *select_params, ucp_lane_type_t type)
 {
+    ucp_ep_h ep                = select_params->ep;
     unsigned current_num_lanes = 0;
     ucp_lane_index_t lane;
 
@@ -1552,7 +1567,7 @@ ucp_wireup_get_current_num_lanes(ucp_ep_h ep, ucp_lane_type_t type)
      */
     if ((ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) ||
         ucp_ep_has_cm_lane(ep)) {
-        return UCP_PROTO_MAX_LANES;
+        return ucp_wireup_bw_max_lanes(select_params);
     }
 
     for (lane = 0; lane < ucp_ep_config(ep)->key.num_lanes; ++lane) {
@@ -1570,12 +1585,11 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
                         ucp_wireup_select_context_t *select_ctx,
                         unsigned allow_extra_path)
 {
-    ucp_rsc_index_t skip_dev_index       = UCP_NULL_RESOURCE;
-    ucp_ep_h ep                          = select_params->ep;
-    ucp_context_h context                = ep->worker->context;
-    ucp_wireup_dev_usage_count dev_count = {};
-    UCS_ARRAY_DEFINE_ONSTACK(ucp_proto_select_info_array_t, sinfo_array,
-                             UCP_MAX_LANES);
+    ucp_proto_select_info_array_t sinfo_array = UCS_ARRAY_DYNAMIC_INITIALIZER;
+    ucp_rsc_index_t skip_dev_index            = UCP_NULL_RESOURCE;
+    ucp_ep_h ep                               = select_params->ep;
+    ucp_context_h context                     = ep->worker->context;
+    ucp_wireup_dev_usage_count dev_count      = {};
     const uct_iface_attr_t *iface_attr;
     const ucp_address_entry_t *ae;
     ucs_status_t status;
@@ -1585,7 +1599,7 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_rsc_index_t rsc_index;
     unsigned addr_index;
     ucp_wireup_select_info_t *sinfo;
-    unsigned max_lanes;
+    unsigned max_lanes, num_lanes;
     unsigned local_num_paths, remote_num_paths;
 
     local_dev_bitmap      = bw_info->local_dev_bitmap;
@@ -1596,7 +1610,7 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
      * to prevent EP reconfiguration in case of dropping lanes due to low BW.
      * TODO: Remove when endpoint reconfiguration is supported.
      */
-    max_lanes = ucp_wireup_get_current_num_lanes(select_params->ep,
+    max_lanes = ucp_wireup_get_current_num_lanes(select_params,
                                                  bw_info->criteria.lane_type);
     max_lanes = ucs_min(max_lanes, bw_info->max_lanes);
 
@@ -1605,7 +1619,7 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
      * memory registration) */
     while (ucs_array_length(&sinfo_array) < max_lanes) {
         if (excl_lane == UCP_NULL_LANE) {
-            sinfo  = ucs_array_append_fixed(&sinfo_array);
+            sinfo  = ucs_array_append(&sinfo_array, break);
             status = ucp_wireup_select_transport(select_ctx, select_params,
                                                  &bw_info->criteria, tl_bitmap,
                                                  UINT64_MAX, local_dev_bitmap,
@@ -1665,9 +1679,13 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
     }
 
     bw_info->criteria.arg = NULL; /* To suppress compiler warning */
+    num_lanes = ucp_wireup_add_fast_lanes(ep->worker, select_params,
+                                          &sinfo_array,
+                                          bw_info->criteria.lane_type,
+                                          select_ctx);
 
-    return ucp_wireup_add_fast_lanes(ep->worker, select_params, &sinfo_array,
-                                     bw_info->criteria.lane_type, select_ctx);
+    ucs_array_cleanup_dynamic(&sinfo_array);
+    return num_lanes;
 }
 
 static ucs_status_t
@@ -1687,6 +1705,7 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
           (UCP_FEATURE_TAG | UCP_FEATURE_AM)) ||
         (ep_init_flags & (UCP_EP_INIT_FLAG_MEM_TYPE |
                           UCP_EP_INIT_CREATE_AM_LANE_ONLY)) ||
+        /* TODO: Check MAX_RNDV_LANES here for rndv/am case */
         (context->config.ext.max_eager_lanes < 2)) {
         return UCS_OK;
     }
@@ -1882,7 +1901,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
 
     if (context->config.ext.proto_enable &&
         (select_params->address->dst_version > UCP_RELEASE_LEGACY)) {
-        bw_info.max_lanes = UCP_PROTO_MAX_LANES;
+        bw_info.max_lanes = ucp_wireup_max_lanes(select_params,
+                                                 bw_info.criteria.lane_type);
     } else {
         bw_info.max_lanes = context->config.ext.max_rndv_lanes;
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1169,7 +1169,7 @@ ucp_wireup_connect_lane(ucp_ep_h ep, unsigned ep_init_flags,
      * create a wireup endpoint which will start connection establishment
      * protocol using an auxiliary transport.
      */
-    if (ucp_ep_config(ep)->p2p_lanes & UCS_BIT(lane)) {
+    if (ucp_ep_is_lane_p2p(ep, lane)) {
         return ucp_wireup_connect_lane_to_ep(ep, ep_init_flags, lane,
                                              path_index, rsc_index, wiface,
                                              remote_address);
@@ -1447,8 +1447,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
         ucp_wireup_ep_set_aux(cm_wireup_ep,
                               ucp_wireup_ep_extract_next_ep(uct_ep),
                               old_key->lanes[reuse_lane].rsc_index,
-                              ucp_ep_config(ep)->p2p_lanes &
-                                      UCS_BIT(reuse_lane));
+                              ucp_ep_is_lane_p2p(ep, reuse_lane));
 
         /* reset the UCT EP from the previous WIREUP lane and destroy its WIREUP EP,
          * since it's not needed anymore in the new configuration, UCT EP will be

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -417,7 +417,7 @@ static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep,
         ucp_ep_set_lane(ep, lane_idx, uct_ep);
 
         UCS_STATIC_BITMAP_SET(tl_bitmap, rsc_idx);
-        if (ucp_ep_config(ep)->p2p_lanes & UCS_BIT(lane_idx)) {
+        if (ucp_ep_is_lane_p2p(ep, lane_idx)) {
             path_index = ucp_ep_get_path_index(ep, lane_idx);
             status     = ucp_wireup_ep_connect(ucp_ep_get_lane(ep, lane_idx), 0,
                                                rsc_idx, path_index, 0, NULL);

--- a/src/ucs/arch/bitops.h
+++ b/src/ucs/arch/bitops.h
@@ -127,7 +127,7 @@ BEGIN_C_DECLS
     ((sizeof(_n) <= 4) ? __builtin_clz((uint32_t)(_n)) : __builtin_clzl(_n))
 
 /* Returns the number of bits lower than 'bit_index' that are set in 'mask'
- * For example: ucs_idx2bitmap(mask=0xF0, idx=6) returns 2
+ * For example: ucs_bitmap2idx(mask=0xF0, idx=6) returns 2
  */
 static inline unsigned ucs_bitmap2idx(uint64_t mask, unsigned bit_index)
 {

--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -326,7 +326,7 @@ ucs_array_old_buffer_set_null(void **old_buffer_p)
  * fixed-size or not, the maximum capacity range is reduced by 1 bit.
  */
 #define ucs_array_max_capacity(_array) \
-    UCS_MASK_SAFE((CHAR_BIT * sizeof((_array)->length)) - 1)
+    UCS_MASK((CHAR_BIT * sizeof((_array)->length)) - 1)
 
 
 /**

--- a/src/ucs/datastruct/pgtable.c
+++ b/src/ucs/datastruct/pgtable.c
@@ -531,11 +531,11 @@ static void ucs_pgtable_search_recurs(const ucs_pgtable_t *pgtable,
         *last_p = region;
 
         /* Assert that the region actually overlaps the address */
-        ucs_assertv(ucs_max(region->start,   address) <=
-                    ucs_min(region->end - 1, address + UCS_MASK_SAFE(order)),
+        ucs_assertv(ucs_max(region->start, address) <=
+                            ucs_min(region->end - 1, address + UCS_MASK(order)),
                     UCS_PGT_REGION_FMT " address=0x%lx order=%d mask 0x%lx",
                     UCS_PGT_REGION_ARG(region), address, order,
-                    (ucs_pgt_addr_t)UCS_MASK_SAFE(order));
+                    (ucs_pgt_addr_t)UCS_MASK(order));
 
         /* Call the callback */
         cb(pgtable, region, arg);

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -78,7 +78,7 @@
 #define UCS_BIT(i)               (1ul << (i))
 
 /* Mask of bits 0..i-1 */
-#define UCS_MASK(i)              (UCS_BIT(i) - 1)
+#define UCS_MASK(_i)             (((_i) >= 64) ? ~0 : (UCS_BIT(_i) - 1))
 
 /*
  * Enable compiler checks for printf-like formatting.

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -50,9 +50,6 @@ BEGIN_C_DECLS
 #define ucs_signum(_n) \
     (((_n) > (ucs_typeof(_n))0) - ((_n) < (ucs_typeof(_n))0))
 
-#define UCS_MASK_SAFE(_i) \
-    (((_i) >= 64) ? ((uint64_t)(-1)) : UCS_MASK(_i))
-
 #define ucs_div_round_up(_n, _d) \
     (((_n) + (_d) - 1) / (_d))
 

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -129,7 +129,7 @@ private:
                                      size_t length, size_t offset,
                                      const void *buffer, const void *orig_ptr)
     {
-        const uint64_t mask = UCS_MASK_SAFE(length * 8 * sizeof(char));
+        const uint64_t mask = UCS_MASK(length * 8 * sizeof(char));
 
         if (ucs_unlikely(actual != (expected & mask))) {
             pattern_check_failed(expected, actual, length, mask, offset,

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -143,7 +143,7 @@ protected:
                          bool expected, bool sync);
 
     void test_xfer_len_offset();
-    size_t get_msg_size();
+    virtual size_t get_msg_size();
 
     /* Init number of lanes which will be used */
     virtual unsigned num_lanes()
@@ -1211,6 +1211,11 @@ public:
         test_ucp_tag_xfer::init();
     }
 
+    size_t get_msg_size() override
+    {
+        return ucs_align_up(10 * UCS_MBYTE, ucs_get_page_size() * num_lanes());
+    }
+
     void cleanup() override
     {
         test_ucp_tag_xfer::cleanup();
@@ -1229,44 +1234,34 @@ public:
 
     unsigned num_lanes() override
     {
-        return max_lanes;
+        return UCP_MAX_LANES;
     }
 
-    const uint32_t max_lanes = 16;
 };
 
-UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=16", "TM_SW_RNDV=y",
+UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=64", "TM_SW_RNDV=y",
            "RNDV_THRESH=1", "MIN_RNDV_CHUNK_SIZE=1", "MULTI_PATH_RATIO=0.0001")
 {
-    if (is_proto_enabled()) {
-        UCS_TEST_SKIP_R("TM_SW_RNDV has no effect with proto v2");
-    }
-
     receiver().connect(&sender(), get_ep_params());
     test_run_xfer(true, true, true, true, false);
 
-    ucp_lane_index_t num_lanes = ucp_ep_num_lanes(sender().ep());
-    ASSERT_EQ(ucp_ep_num_lanes(receiver().ep()), num_lanes);
-    ASSERT_EQ(num_lanes, max_lanes);
+    EXPECT_EQ(num_lanes(), ucp_ep_num_lanes(sender().ep()));
+    EXPECT_EQ(num_lanes(), ucp_ep_num_lanes(receiver().ep()));
 
-    size_t chunk_size = get_msg_size() / num_lanes;
-
-    for (ucp_lane_index_t lane = 0; lane < num_lanes; ++lane) {
+    size_t bytes_sent = 0;
+    for (ucp_lane_index_t lane = 0; lane < num_lanes(); ++lane) {
         size_t sender_tx   = get_bytes_sent(sender().ep(), lane);
         size_t receiver_tx = get_bytes_sent(receiver().ep(), lane);
         UCS_TEST_MESSAGE << "lane[" << static_cast<int>(lane) << "] : "
                          << "sender " << sender_tx << " receiver " << receiver_tx;
 
-        /* Verify that each lane sent something, except the active message lane
-           that could be used only for control messages */
-        if (lane == num_lanes - 1) {
-            EXPECT_GT(sender_tx + receiver_tx, 0); // last lane sends the rest
-        } else if (lane != ucp_ep_get_am_lane(sender().ep())) {
-            EXPECT_GE(sender_tx + receiver_tx, chunk_size);
-        }
+        EXPECT_GT(sender_tx + receiver_tx, 0);
+        bytes_sent += sender_tx + receiver_tx;
     }
+
+    EXPECT_GE(bytes_sent, get_msg_size());
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(multi_rail_max, ib, "ib")
+UCP_INSTANTIATE_TEST_CASE_TLS(multi_rail_max, rc, "rc")
 
 #endif

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -197,3 +197,28 @@ UCS_TEST_F(test_bitops, is_equal) {
     ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
     ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
 }
+
+template<typename Type> void test_mask()
+{
+    Type expected = 0;
+    /* Test extra bit (should return full mask) */
+    for (size_t bit_num = 0; bit_num <= (sizeof(Type) * 8 + 1); ++bit_num) {
+        Type mask = UCS_MASK(bit_num);
+        if ((bit_num > 0) && (bit_num <= 64)) {
+            expected |= UCS_BIT(bit_num - 1);
+        }
+
+        EXPECT_EQ(expected, mask) << "bit_num=" << bit_num;
+    }
+}
+
+UCS_TEST_F(test_bitops, mask) {
+    test_mask<int8_t>();
+    test_mask<uint8_t>();
+    test_mask<int16_t>();
+    test_mask<uint16_t>();
+    test_mask<int32_t>();
+    test_mask<uint32_t>();
+    test_mask<int64_t>();
+    test_mask<uint64_t>();
+}


### PR DESCRIPTION
## What
Increase number of maximal lanes per EP to 64.

## Why ?
To allow collecting information about all lanes on systems with many transports/devices.
