### PR TITLE
BINDINGS/GO: Fixed go build failure.

### DIFF
--- a/bindings/go/src/ucx/endpoint.go
+++ b/bindings/go/src/ucx/endpoint.go
@@ -29,7 +29,7 @@ func setSendParams(goRequestParams *UcpRequestParams, cRequestParams *C.ucp_requ
 			cRequestParams.user_data = unsafe.Pointer(uintptr(cbId))
 		}
 
-		cRequestParams.SetMemType(goRequestParams)
+		setMemType(goRequestParams, cRequestParams)
 	}
 
 	return cbId

--- a/bindings/go/src/ucx/request.go
+++ b/bindings/go/src/ucx/request.go
@@ -29,7 +29,7 @@ func (p *UcpRequestParams) SetMemType(memType UcsMemoryType) *UcpRequestParams {
 	return p
 }
 
-func (p *C.ucp_request_param_t) SetMemType(params *UcpRequestParams) {
+func setMemType(params *UcpRequestParams, p *C.ucp_request_param_t) {
 	if (params != nil) && params.memTypeSet {
 		p.op_attr_mask = C.UCP_OP_ATTR_FIELD_MEMORY_TYPE
 		p.memory_type = C.ucs_memory_type_t(params.memType)

--- a/bindings/go/src/ucx/worker.go
+++ b/bindings/go/src/ucx/worker.go
@@ -234,7 +234,7 @@ func (w *UcpWorker) RecvTagNonBlocking(address unsafe.Pointer, size uint64,
 	*recvInfoPtr = recvInfo
 
 	if params != nil {
-		(&requestParams).SetMemType(params)
+		setMemType(params, &requestParams)
 
 		if params.Cb != nil {
 			cbId = register(params.Cb)
@@ -306,7 +306,7 @@ func (w *UcpWorker) RecvAmDataNonBlocking(dataDesc *UcpAmData, recvBuffer unsafe
 	*recvInfoPtr = &length
 
 	if params != nil {
-		(&requestParams).SetMemType(params)
+		setMemType(params, &requestParams)
 
 		if params.Cb != nil {
 			cbId = register(params.Cb)


### PR DESCRIPTION
## What
Fixed failure:
```
request.go:32:10: cannot define new methods on non-local type *C.ucp_request_param_t
```

Checked with go1.22.2.

## Why?
https://github.com/openucx/ucx/issues/9482