### PR TITLE
UCT/IB/DC: removed dc keepalive

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -106,11 +106,6 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      ucs_offsetof(uct_dc_mlx5_iface_config_t, dct_affinity),
      UCS_CONFIG_TYPE_UINT_ENUM(uct_dct_affinity_policy_names)},
 
-    {"DCI_KA_FULL_HANDSHAKE", "no",
-     "Force full-handshake protocol for DC keepalive initiator.",
-     ucs_offsetof(uct_dc_mlx5_iface_config_t, dci_ka_full_handshake),
-     UCS_CONFIG_TYPE_TERNARY},
-
     {"DCT_FULL_HANDSHAKE", "no", "Force full-handshake protocol for DC target.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, dct_full_handshake),
      UCS_CONFIG_TYPE_TERNARY},
@@ -149,13 +144,6 @@ ucs_config_field_t uct_dc_mlx5_iface_config_table[] = {
 
     {NULL}
 };
-
-static void
-uct_dc_mlx5_dci_keepalive_handle_failure(uct_dc_mlx5_iface_t *iface,
-                                         struct mlx5_cqe64 *cqe,
-                                         uint8_t dci_index,
-                                         ucs_status_t ep_status);
-
 
 static ucs_status_t
 uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
@@ -246,8 +234,6 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
         iface_attr->cap.flags &= ~(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
                                    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF    |
                                    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM);
-    } else {
-        iface_attr->cap.flags |= UCT_IFACE_FLAG_EP_CHECK;
     }
 
     return UCS_OK;
@@ -790,10 +776,8 @@ uct_dc_mlx5_iface_dcis_create(uct_dc_mlx5_iface_t *iface,
     uint8_t pool_index, i;
     ucs_status_t status;
 
-    iface->tx.dcis = ucs_calloc((iface->tx.ndci * iface->tx.num_dci_pools) +
-                                UCT_DC_MLX5_KEEPALIVE_NUM_DCIS,
-                                sizeof(*iface->tx.dcis),
-                                "dcis");
+    iface->tx.dcis = ucs_calloc(uct_dc_mlx5_iface_total_ndci(iface),
+                                sizeof(*iface->tx.dcis), "dcis");
     if (iface->tx.dcis == NULL) {
         status = UCS_ERR_NO_MEMORY;
         goto err;
@@ -1271,11 +1255,7 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
     UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
     uct_ib_mlx5_txwq_update_flags(txwq, UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
 
-    if (uct_dc_mlx5_iface_is_dci_keepalive(iface, dci_index)) {
-        uct_dc_mlx5_dci_keepalive_handle_failure(iface, cqe, dci_index, status);
-    } else {
-        uct_dc_mlx5_dci_handle_failure(iface, cqe, dci_index, status);
-    }
+    uct_dc_mlx5_dci_handle_failure(iface, cqe, dci_index, status);
 }
 
 static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
@@ -1320,7 +1300,7 @@ static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .ep_pending_purge         = uct_dc_mlx5_ep_pending_purge,
     .ep_flush                 = uct_dc_mlx5_ep_flush,
     .ep_fence                 = uct_dc_mlx5_ep_fence,
-    .ep_check                 = uct_dc_mlx5_ep_check,
+    .ep_check                 = (uct_ep_check_func_t)ucs_empty_function_return_unsupported,
 #if IBV_HW_TM
     .ep_tag_eager_short       = uct_dc_mlx5_ep_tag_eager_short,
     .ep_tag_eager_bcopy       = uct_dc_mlx5_ep_tag_eager_bcopy,
@@ -1478,7 +1458,6 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     unsigned tx_cq_size;
     unsigned num_dci_channels;
     int max_dcis;
-    uint8_t num_cq_dcis;
 
     ucs_trace_func("");
 
@@ -1500,8 +1479,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         return status;
     }
 
-    num_cq_dcis = self->tx.ndci + UCT_DC_MLX5_KEEPALIVE_NUM_DCIS;
-    init_attr.cq_len[UCT_IB_DIR_TX] = sq_length * num_cq_dcis;
+    init_attr.cq_len[UCT_IB_DIR_TX] = sq_length * self->tx.ndci;
     uct_ib_mlx5_parse_cqe_zipping(md, &config->rc_mlx5_common.super,
                                   &init_attr);
 
@@ -1533,7 +1511,6 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     self->tx.fc_hard_req_timeout           = config->fc_hard_req_timeout;
     self->tx.fc_hard_req_resend_time       = ucs_get_time();
     self->tx.fc_hard_req_progress_cb_id    = UCS_CALLBACKQ_ID_NULL;
-    self->keepalive_dci                    = -1;
     self->tx.num_dci_pools                 = 1;
     self->super.super.config.tx_moderation = 0; /* disable tx moderation for dcs */
     self->flags                            = 0;
@@ -1587,8 +1564,6 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     };
 
     UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dci, DCI, status, err);
-    UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dci_ka, KEEPALIVE,
-                                           status, err);
     UCT_DC_MLX5_CHECK_FORCE_FULL_HANDSHAKE(self, config, dct, DCT, status, err);
 
     ucs_assert(self->tx.num_dci_pools <= UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
@@ -1696,68 +1671,6 @@ uct_dc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
 UCT_TL_DEFINE_ENTRY(&uct_ib_component, dc_mlx5, uct_dc_mlx5_query_tl_devices,
                     uct_dc_mlx5_iface_t, "DC_MLX5_",
                     uct_dc_mlx5_iface_config_table, uct_dc_mlx5_iface_config_t);
-
-static void
-uct_dc_mlx5_dci_keepalive_handle_failure(uct_dc_mlx5_iface_t *iface,
-                                         struct mlx5_cqe64 *cqe,
-                                         uint8_t dci_index,
-                                         ucs_status_t ep_status)
-{
-    uint16_t hw_ci = ntohs(cqe->wqe_counter);
-    uct_dc_mlx5_ep_t *ep;
-    uct_rc_iface_send_op_t *op;
-    ucs_queue_elem_t *elem;
-    UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
-
-    ucs_assert(dci_index == iface->keepalive_dci);
-    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
-
-    elem = ucs_queue_pull(&txqp->outstanding);
-    if (elem == NULL) {
-        /* Outstanding list is empty, just exit */
-        goto reset_dci;
-    }
-
-    op = ucs_container_of(elem, uct_rc_iface_send_op_t, queue);
-    if (hw_ci != op->sn) {
-        goto put_op;
-    }
-
-    ep = ucs_derived_of(op->ep, uct_dc_mlx5_ep_t);
-    uct_dc_mlx5_iface_set_ep_failed(iface, ep, cqe, txwq, ep_status);
-
-put_op:
-    ucs_mpool_put(op);
-
-reset_dci:
-    uct_rc_txqp_available_set(txqp, iface->tx.bb_max);
-    uct_rc_txqp_purge_outstanding(&iface->super.super, txqp, ep_status,
-                                  txwq->sw_pi, 0);
-    uct_dc_mlx5_iface_reset_dci(iface, dci_index);
-}
-
-ucs_status_t uct_dc_mlx5_iface_keepalive_init(uct_dc_mlx5_iface_t *iface)
-{
-    int full_handshake = iface->flags &
-                         UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE_FULL_HANDSHAKE;
-    ucs_status_t status;
-    uint8_t dci_index;
-
-    if (ucs_likely(iface->flags & UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE)) {
-        return UCS_OK;
-    }
-
-    dci_index = uct_dc_mlx5_iface_total_ndci(iface);
-    status    = uct_dc_mlx5_iface_create_dci(iface, 0, dci_index, 0,
-                                             full_handshake);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    iface->flags        |= UCT_DC_MLX5_IFACE_FLAG_KEEPALIVE;
-    iface->keepalive_dci = dci_index;
-    return UCS_OK;
-}
 
 void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 {

--- a/src/uct/ib/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/dc/dc_mlx5_ep.h
@@ -36,26 +36,21 @@ enum uct_dc_mlx5_ep_flags {
     /* EP has GRH address. Used by dc_mlx5 endpoint */
     UCT_DC_MLX5_EP_FLAG_GRH                 = UCS_BIT(6),
 
-    /* Keepalive Request scheduled: indicates that keepalive request
-     * is scheduled in outstanding queue and no more keepalive actions
-     * are needed */
-    UCT_DC_MLX5_EP_FLAG_KEEPALIVE_POSTED    = UCS_BIT(7),
-
     /* Flush cancel was executed on EP */
-    UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL        = UCS_BIT(8),
+    UCT_DC_MLX5_EP_FLAG_FLUSH_CANCEL        = UCS_BIT(7),
 
     /* Error handler already called or flush(CANCEL) disabled it */
-    UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED = UCS_BIT(9),
+    UCT_DC_MLX5_EP_FLAG_ERR_HANDLER_INVOKED = UCS_BIT(8),
 
     /* EP supports flush remote operation */
-    UCT_DC_MLX5_EP_FLAG_FLUSH_RKEY          = UCS_BIT(10),
+    UCT_DC_MLX5_EP_FLAG_FLUSH_RKEY          = UCS_BIT(9),
 
     /* Flush remote operation should be invoked */
-    UCT_DC_MLX5_EP_FLAG_FLUSH_REMOTE        = UCS_BIT(11),
+    UCT_DC_MLX5_EP_FLAG_FLUSH_REMOTE        = UCS_BIT(10),
 
 #if UCS_ENABLE_ASSERT
     /* EP was invalidated without DCI */
-    UCT_DC_MLX5_EP_FLAG_INVALIDATED         = UCS_BIT(12)
+    UCT_DC_MLX5_EP_FLAG_INVALIDATED         = UCS_BIT(11)
 #else
     UCT_DC_MLX5_EP_FLAG_INVALIDATED         = 0
 #endif
@@ -239,9 +234,6 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep, uct_pending_purge_callback_t c
 
 void uct_dc_mlx5_ep_do_pending_fc(uct_dc_mlx5_ep_t *fc_ep,
                                   uct_dc_fc_request_t *fc_req);
-
-ucs_status_t
-uct_dc_mlx5_ep_check(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp);
 
 static UCS_F_ALWAYS_INLINE uint8_t
 uct_dc_mlx5_ep_pool_index(uct_dc_mlx5_ep_t *ep)
@@ -449,8 +441,7 @@ uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 
     ucs_assert(dci_index != UCT_DC_MLX5_EP_NO_DCI);
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface) ||
-        uct_dc_mlx5_iface_is_dci_keepalive(iface, dci_index)) {
+    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
         return;
     }
 


### PR DESCRIPTION
## What
Removing keepalive feature from DC transport

## Why ?
It's unused / not needed anymore.
