### PR TITLE
CI: Remove RoCE Valgrind testing

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -450,16 +450,6 @@ stages:
         asan_check: yes
 
 
-  - stage: Valgrind
-    dependsOn: [Static_check]
-    jobs:
-    - template: tests.yml
-      parameters:
-        name: roce
-        demands: ucx_roce -equals yes
-        test_perf: 0
-        valgrind_check: yes
-
 #  - stage: Cuda_compatible
 #    dependsOn: [Static_check]
 #    jobs:


### PR DESCRIPTION
## What
Remove Valgrind testing on RoCE

## Why ?
It's already covered by ASAN and fails due to timeout sometimes.
