### PR TITLE
UCS/CONFIG: Fixed relative path to load the configuration file.

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1759,7 +1759,8 @@ void ucs_config_parse_config_files()
     path_p = ucs_sys_get_lib_path();
     if (path_p != NULL) {
         ucs_strncpy_safe(path, path_p, PATH_MAX);
-        ucs_config_parse_config_file(dirname(path), "../etc/" UCX_CONFIG_FILE_NAME, 1);
+        ucs_config_parse_config_file(dirname(path),
+                                     "../etc/ucx/" UCX_CONFIG_FILE_NAME, 1);
     }
 
     /* User home dir */


### PR DESCRIPTION
## What
Fixed the relative path to load the configuration file.

## Why ?
`./configure --prefix=<install_path> && make install` installs `ucx.conf` configuration file to `<install_path>/etc/ucx`.
