### PR TITLE
UCT/BASE: Also distribute UCT v2 header

### DIFF
--- a/src/uct/Makefile.am
+++ b/src/uct/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_libuct_la_HEADERS = \
 	api/tl.h \
 	api/uct_def.h \
 	api/uct.h \
+	api/v2/uct_v2.h \
 	api/version.h
 
 noinst_HEADERS = \


### PR DESCRIPTION
## What
Make UCT v2 header available for applications to include it.