### PR TITLE
CONFIG: Fixed UCX_IB_MLX5_DEVX_OBJECTS value.

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -1,4 +1,4 @@
 [Grace Hopper]
 Product name=*Grace*Hopper*
 UCX_REG_NONBLOCK_MEM_TYPES=host
-UCX_IB_MLX5_DEVX_OBJECTS=""
+UCX_IB_MLX5_DEVX_OBJECTS=


### PR DESCRIPTION
## What
Fixed [Grave Hopper].UCX_IB_MLX5_DEVX_OBJECTS value.

## Why ?
```
$ ucx_info -c | grep -A 1 MLX5_DEVX_OBJECTS
[1713436665.803947] [sj-cg4-01:1413613:0]          parser.c:1339 UCX  ERROR Invalid value for MLX5_DEVX_OBJECTS: '""'. Expected: comma-separated list of: [rcqp|rcsrq|dct|dcsrq|dci|cq]
[1713436665.803963] [sj-cg4-01:1413613:0]          uct_md.c:271  UCX  ERROR Failed to read MD config
[1713436665.803969] [sj-cg4-01:1413613:0]          parser.c:1339 UCX  ERROR Invalid value for MLX5_DEVX_OBJECTS: '""'. Expected: comma-separated list of: [rcqp|rcsrq|dct|dcsrq|dci|cq]
[1713436665.803973] [sj-cg4-01:1413613:0]          uct_md.c:271  UCX  ERROR Failed to read MD config
[1713436665.803978] [sj-cg4-01:1413613:0]          parser.c:1339 UCX  ERROR Invalid value for MLX5_DEVX_OBJECTS: '""'. Expected: comma-separated list of: [rcqp|rcsrq|dct|dcsrq|dci|cq]
[1713436665.803979] [sj-cg4-01:1413613:0]          uct_md.c:271  UCX  ERROR Failed to read MD config
[1713436665.803983] [sj-cg4-01:1413613:0]          parser.c:1339 UCX  ERROR Invalid value for MLX5_DEVX_OBJECTS: '""'. Expected: comma-separated list of: [rcqp|rcsrq|dct|dcsrq|dci|cq]
[1713436665.803984] [sj-cg4-01:1413613:0]          uct_md.c:271  UCX  ERROR Failed to read MD config
```
