### PR TITLE
AZP/TEST: Add server-side log prints

### DIFF
--- a/buildlib/pr/mad_tests.yml
+++ b/buildlib/pr/mad_tests.yml
@@ -22,7 +22,7 @@ jobs:
       - bash: |
           source ./buildlib/tools/test_mad.sh
           build_ucx_in_docker
-          docker_run_srv
+          docker_run_srv LID
         displayName: Setup Server
 
   - job: SetupClient
@@ -63,9 +63,9 @@ jobs:
           HCA: $(HCA)
         displayName: Test LID
 
-  - job: ServerRestart
+  - job: ServerRestartAndPrintLogs
     dependsOn: TestLid
-    displayName: Server Restart
+    displayName: Server Restart And Print Logs
     pool:
       name: MLNX
       demands: mad_server
@@ -73,13 +73,14 @@ jobs:
       - checkout: none
       - bash: |
           source ./buildlib/tools/test_mad.sh
-          docker_run_srv
+          docker_stop_srv LID
+          docker_run_srv GUID
         displayName: Server Restart
 
   - job: TestGuid
     dependsOn:
       - SetupServer
-      - ServerRestart
+      - ServerRestartAndPrintLogs
     displayName: Test Guid
     timeoutInMinutes: 10
     pool:
@@ -97,9 +98,9 @@ jobs:
           HCA: $(HCA)
         displayName: Test GUID
 
-  - job: ServerStop
+  - job: ServerStopAndPrintLogs
     dependsOn: TestGuid
-    displayName: Server Stop
+    displayName: Server Stop And Print Logs
     condition: always()
     pool:
       name: MLNX
@@ -108,5 +109,5 @@ jobs:
       - checkout: none
       - bash: |
           source ./buildlib/tools/test_mad.sh
-          docker_stop_srv
+          docker_stop_srv GUID
         displayName: Server Stop

--- a/buildlib/tools/test_mad.sh
+++ b/buildlib/tools/test_mad.sh
@@ -34,9 +34,10 @@ build_ucx_in_docker() {
 }
 
 docker_run_srv() {
+    local test_name="$1"
     HCA=$(detect_hca)
-    docker_stop_srv
-    docker run --rm \
+    docker run \
+        --rm \
         --detach \
         --net=host \
         --name ucx_perftest_"$BUILD_BUILDID" \
@@ -45,10 +46,13 @@ docker_run_srv() {
         -v /hpc/local:/hpc/local \
         --ulimit memlock=-1:-1 --device=/dev/infiniband/ \
         $IMAGE \
-        bash -c "${PWD}/install/bin/ucx_perftest -K ${HCA}"
+        bash -c "${PWD}/install/bin/ucx_perftest -K ${HCA} > \
+            ${PWD}/ucx_perf_srv_${test_name}_${BUILD_BUILDID}.log 2>&1"
 }
 
 docker_stop_srv() {
+    local test_name="$1"
+    cat "${PWD}/ucx_perf_srv_${test_name}_${BUILD_BUILDID}.log"
     docker stop ucx_perftest_"$BUILD_BUILDID" || true
 }
 


### PR DESCRIPTION
## What
Get server logs from ephemeral Docker containers.

## Why ?
Currently, there is no way to see stdout+stderr of the server container.

## How ?
Redirect server output to a file on the workspace volume.
