### PR TITLE
UCT/TCP: bind EP fd to iface

### DIFF
--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -400,6 +400,7 @@ typedef struct uct_tcp_iface {
         struct sockaddr_storage   ifaddr;            /* Network address */
         struct sockaddr_storage   netmask;           /* Network address mask */
         size_t                    sockaddr_len;      /* Network address length */
+        ucs_ternary_auto_value_t  ep_bind_src_addr;  /* Bind EP's FD to ifaddr */
         int                       prefer_default;    /* Prefer default gateway */
         int                       put_enable;        /* Enable PUT Zcopy operation support */
         int                       conn_nb;           /* Use non-blocking connect() */
@@ -457,6 +458,7 @@ typedef struct uct_tcp_iface_config {
         unsigned long              cnt;
         ucs_time_t                 intvl;
     } keepalive;
+    ucs_ternary_auto_value_t       ep_bind_src_addr;
 } uct_tcp_iface_config_t;
 
 

--- a/src/uct/tcp/tcp_cm.c
+++ b/src/uct/tcp/tcp_cm.c
@@ -532,6 +532,8 @@ static unsigned uct_tcp_cm_handle_simult_conn(uct_tcp_iface_t *iface,
         if (connect_ep->conn_state != UCT_TCP_EP_CONN_STATE_CONNECTED) {
             uct_tcp_ep_mod_events(accept_ep, 0, UCS_EVENT_SET_EVREAD);
             ucs_assert(connect_ep->stale_fd == -1);
+            ucs_debug("tcp_ep %p: move accept_ep %p fd=%d to stale",
+                      connect_ep, accept_ep, accept_ep->fd);
             connect_ep->stale_fd = accept_ep->fd;
             accept_ep->fd        = -1;
         }

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -111,6 +111,12 @@ static ucs_config_field_t uct_tcp_iface_config_table[] = {
                 UCS_CONFIG_TYPE_TIME_UNITS},
 #endif /* UCT_TCP_EP_KEEPALIVE */
 
+  {"EP_BIND_SRC_ADDR", "try",
+   "Bind client socket to the local network interface before connecting to the "
+   "remote peer",
+   ucs_offsetof(uct_tcp_iface_config_t, ep_bind_src_addr),
+                UCS_CONFIG_TYPE_TERNARY},
+
   {NULL}
 };
 
@@ -690,6 +696,7 @@ static UCS_CLASS_INIT_FUNC(uct_tcp_iface_t, uct_md_h md, uct_worker_h worker,
     self->sockopt.rcvbuf           = config->sockopt.rcvbuf;
     self->config.keepalive.cnt     = config->keepalive.cnt;
     self->config.keepalive.intvl   = config->keepalive.intvl;
+    self->config.ep_bind_src_addr  = config->ep_bind_src_addr;
     self->port_range.first         = config->port_range.first;
     self->port_range.last          = config->port_range.last;
 


### PR DESCRIPTION
## What
bind internal fd of TCP/EP to iface address

## Why ?
fixes https://github.com/openucx/ucx/issues/9763 miltirail case with multiple network interfaces ~~in the same subnet~~.
update: @huzhijiang [mentioned ](https://github.com/openucx/ucx/pull/9839#discussion_r1576554596) that the issue can be reproduced in different subnets too.

## How ?
Add a configurable parameter `UCX_TCP_EP_BIND_SRC_ADDR=y`