### PR TITLE
UCT/GTEST: Fixed multiple tests for gdr_copy transport

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -472,7 +472,7 @@ static void print_md_info(uct_component_h component,
             printf("#           memory invalidation is supported\n");
         }
 
-        if (md_attr.reg_alignment != 0) {
+        if (md_attr.reg_alignment != 1) {
             printf("#            alignment: %zx\n", md_attr.reg_alignment);
         }
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -522,7 +522,7 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
         reg_length  = length;
 
         if (context->rcache == NULL) {
-            reg_align = ucs_max(context->tl_mds[md_index].attr.reg_alignment, 1);
+            reg_align = context->tl_mds[md_index].attr.reg_alignment;
             ucs_align_ptr_range(&reg_address, &reg_length, reg_align);
         }
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -486,6 +486,24 @@ ucs_status_t uct_md_query_v2(uct_md_h md, uct_md_attr_v2_t *md_attr)
     return UCS_OK;
 }
 
+void uct_md_base_md_query(uct_md_attr_v2_t *md_attr)
+{
+    md_attr->reg_mem_types             = 0;
+    md_attr->reg_nonblock_mem_types    = 0;
+    md_attr->cache_mem_types           = 0;
+    md_attr->detect_mem_types          = 0;
+    md_attr->alloc_mem_types           = 0;
+    md_attr->access_mem_types          = 0;
+    md_attr->dmabuf_mem_types          = 0;
+    md_attr->max_alloc                 = 0;
+    md_attr->max_reg                   = ULONG_MAX;
+    md_attr->reg_cost                  = UCS_LINEAR_FUNC_ZERO;
+    md_attr->rkey_packed_size          = 0;
+    md_attr->exported_mkey_packed_size = 0;
+    md_attr->reg_alignment             = 1;
+    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+}
+
 ucs_status_t uct_mem_alloc_check_params(size_t length,
                                         const uct_alloc_method_t *methods,
                                         unsigned num_methods,

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -258,4 +258,6 @@ static UCS_F_ALWAYS_INLINE ucs_log_level_t uct_md_attach_log_lvl(uint64_t flags)
 void uct_md_vfs_init(uct_component_h component, uct_md_h md,
                      const char *md_name);
 
+void uct_md_base_md_query(uct_md_attr_v2_t *md_attr);
+
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -100,25 +100,21 @@ uct_cuda_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
 
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
-    md_attr->dmabuf_mem_types       = md->config.dmabuf_supported ?
-                                      UCS_BIT(UCS_MEMORY_TYPE_CUDA) : 0;
+    uct_md_base_md_query(md_attr);
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    md_attr->dmabuf_mem_types = md->config.dmabuf_supported ?
+                                UCS_BIT(UCS_MEMORY_TYPE_CUDA) : 0;
     md_attr->max_alloc        = SIZE_MAX;
-    md_attr->max_reg          = ULONG_MAX;
-    md_attr->rkey_packed_size = 0;
-    md_attr->reg_cost         = UCS_LINEAR_FUNC_ZERO;
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -31,23 +31,16 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
 static ucs_status_t
 uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags                  = UCT_MD_FLAG_REG |
-                                      UCT_MD_FLAG_NEED_RKEY |
-                                      UCT_MD_FLAG_INVALIDATE |
-                                      UCT_MD_FLAG_INVALIDATE_RMA |
-                                      UCT_MD_FLAG_INVALIDATE_AMO;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->alloc_mem_types        = 0;
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->detect_mem_types       = 0;
-    md_attr->dmabuf_mem_types       = 0;
-    md_attr->max_alloc              = 0;
-    md_attr->max_reg                = ULONG_MAX;
-    md_attr->rkey_packed_size       = sizeof(uct_cuda_ipc_rkey_t);
-    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    uct_md_base_md_query(md_attr);
+    md_attr->flags            = UCT_MD_FLAG_REG |
+                                UCT_MD_FLAG_NEED_RKEY |
+                                UCT_MD_FLAG_INVALIDATE |
+                                UCT_MD_FLAG_INVALIDATE_RMA |
+                                UCT_MD_FLAG_INVALIDATE_AMO;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->rkey_packed_size = sizeof(uct_cuda_ipc_rkey_t);
     return UCS_OK;
 }
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -37,20 +37,13 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
 static ucs_status_t
 uct_gdr_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->alloc_mem_types        = 0;
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->detect_mem_types       = 0;
-    md_attr->dmabuf_mem_types       = 0;
-    md_attr->max_alloc              = 0;
-    md_attr->max_reg                = ULONG_MAX;
-    md_attr->rkey_packed_size       = sizeof(uct_gdr_copy_key_t);
-    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
-    md_attr->reg_alignment          = GPU_PAGE_SIZE;
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    uct_md_base_md_query(md_attr);
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->rkey_packed_size = sizeof(uct_gdr_copy_key_t);
+    md_attr->reg_alignment    = GPU_PAGE_SIZE;
     return UCS_OK;
 }
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -242,13 +242,11 @@ ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     size_t component_name_length = strlen(md->super.component->name);
     uint64_t guid                = IBV_DEV_ATTR(&md->dev, sys_image_guid);
 
+    uct_md_base_md_query(md_attr);
     md_attr->max_alloc                 = ULONG_MAX; /* TODO query device */
     md_attr->max_reg                   = ULONG_MAX; /* TODO query device */
     md_attr->flags                     = md->cap_flags;
-    md_attr->alloc_mem_types           = 0;
     md_attr->access_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types          = 0;
-    md_attr->dmabuf_mem_types          = 0;
     md_attr->reg_mem_types             = md->reg_mem_types;
     md_attr->reg_nonblock_mem_types    = md->reg_nonblock_mem_types;
     md_attr->cache_mem_types           = UCS_MASK(UCS_MEMORY_TYPE_LAST);

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -49,25 +49,21 @@ uct_rocm_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_rocm_copy_md_t *md = ucs_derived_of(uct_md, uct_rocm_copy_md_t);
 
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY |
-                                      UCT_MD_FLAG_ALLOC;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->dmabuf_mem_types       = 0;
+    uct_md_base_md_query(md_attr);
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY |
+                                UCT_MD_FLAG_ALLOC;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     if (md->have_dmabuf) {
         md_attr->dmabuf_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     }
-    md_attr->max_alloc              = SIZE_MAX;
-    md_attr->max_reg                = ULONG_MAX;
-    md_attr->rkey_packed_size       = sizeof(uct_rocm_copy_key_t);
-    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    md_attr->max_alloc        = SIZE_MAX;
+    md_attr->rkey_packed_size = sizeof(uct_rocm_copy_key_t);
 
     return UCS_OK;
 }

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -24,22 +24,15 @@ static ucs_config_field_t uct_rocm_ipc_md_config_table[] = {
 
 static ucs_status_t uct_rocm_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->rkey_packed_size       = sizeof(uct_rocm_ipc_key_t);
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->alloc_mem_types        = 0;
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->detect_mem_types       = 0;
-    md_attr->dmabuf_mem_types       = 0;
-    md_attr->max_alloc              = 0;
-    md_attr->max_reg                = ULONG_MAX;
+    uct_md_base_md_query(md_attr);
+    md_attr->rkey_packed_size = sizeof(uct_rocm_ipc_key_t);
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
 
     /* TODO: get accurate number */
-    md_attr->reg_cost             = ucs_linear_func_make(9e-9, 0);
-
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    md_attr->reg_cost         = ucs_linear_func_make(9e-9, 0);
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/base/mm_md.c
+++ b/src/uct/sm/mm/base/mm_md.c
@@ -69,21 +69,17 @@ ucs_status_t uct_mm_seg_new(void *address, size_t length, uct_mm_seg_t **seg_p)
 
 void uct_mm_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr, uint64_t max_alloc)
 {
+    uct_md_base_md_query(md_attr);
     md_attr->flags            = UCT_MD_FLAG_RKEY_PTR | UCT_MD_FLAG_NEED_RKEY;
     md_attr->max_reg          = 0;
-    md_attr->max_alloc        = 0;
     md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
 
     if (max_alloc > 0) {
         md_attr->flags    |= UCT_MD_FLAG_ALLOC | UCT_MD_FLAG_FIXED;
         md_attr->max_alloc = max_alloc;
     }
-
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
 }
 
 ucs_status_t uct_mm_md_open(uct_component_t *component, const char *md_name,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -195,20 +195,13 @@ ucs_status_t uct_cma_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_cma_md_t *md = ucs_derived_of(uct_md, uct_cma_md_t);
 
-    md_attr->rkey_packed_size       = 0;
+    uct_md_base_md_query(md_attr);
     md_attr->flags                  = UCT_MD_FLAG_REG | md->extra_caps;
     md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->alloc_mem_types        = 0;
     md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types       = 0;
-    md_attr->dmabuf_mem_types       = 0;
-    md_attr->max_alloc              = 0;
-    md_attr->max_reg                = ULONG_MAX;
     md_attr->reg_cost               = ucs_linear_func_make(9e-9, 0);
-
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -185,9 +185,8 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
     uct_knem_md_t *md = ucs_derived_of(uct_md, uct_knem_md_t);
 
+    uct_md_base_md_query(md_attr);
     md_attr->flags                  = UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types          = 0;
-    md_attr->reg_nonblock_mem_types = 0;
     if (uct_knem_md_check_mem_reg(uct_md)) {
         md_attr->flags         |= UCT_MD_FLAG_REG;
         md_attr->reg_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_HOST);
@@ -195,14 +194,8 @@ ucs_status_t uct_knem_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 
     md_attr->rkey_packed_size = sizeof(uct_knem_key_t);
     md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->alloc_mem_types  = 0;
     md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types = 0;
-    md_attr->dmabuf_mem_types = 0;
-    md_attr->max_alloc        = 0;
-    md_attr->max_reg          = ULONG_MAX;
     md_attr->reg_cost         = md->reg_cost;
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
     return UCS_OK;
 }
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -409,21 +409,14 @@ static uct_iface_ops_t uct_self_iface_ops = {
 
 static ucs_status_t uct_self_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
+    uct_md_base_md_query(attr);
     /* Dummy memory registration provided. No real memory handling exists */
     attr->flags                  = UCT_MD_FLAG_REG |
                                    UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
     attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->alloc_mem_types        = 0;
-    attr->detect_mem_types       = 0;
     attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->dmabuf_mem_types       = 0;
-    attr->max_alloc              = 0;
-    attr->max_reg                = ULONG_MAX;
-    attr->rkey_packed_size       = 0;
-    attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
-    memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }
 

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -29,21 +29,14 @@ static ucs_config_field_t uct_tcp_md_config_table[] = {
 
 static ucs_status_t uct_tcp_md_query(uct_md_h md, uct_md_attr_v2_t *attr)
 {
+    uct_md_base_md_query(attr);
     /* Dummy memory registration provided. No real memory handling exists */
     attr->flags                  = UCT_MD_FLAG_REG |
                                    UCT_MD_FLAG_NEED_RKEY; /* TODO ignore rkey in rma/amo ops */
-    attr->max_alloc              = 0;
     attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->alloc_mem_types        = 0;
     attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    attr->detect_mem_types       = 0;
-    attr->dmabuf_mem_types       = 0;
-    attr->max_reg                = ULONG_MAX;
-    attr->rkey_packed_size       = 0;
-    attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
-    memset(&attr->local_cpus, 0xff, sizeof(attr->local_cpus));
     return UCS_OK;
 }
 

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -36,20 +36,14 @@ uct_ugni_query_md_resources(uct_component_h component,
 
 static ucs_status_t uct_ugni_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->rkey_packed_size       = 3 * sizeof(uint64_t);
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_MEMH |
-                                      UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->alloc_mem_types        = 0;
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md_attr->detect_mem_types       = 0;
-    md_attr->dmabuf_mem_types       = 0;
-    md_attr->max_alloc              = 0;
-    md_attr->max_reg                = ULONG_MAX;
-    md_attr->reg_cost               = ucs_linear_func_make(1000.0e-9, 0.007e-9);
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    uct_md_base_md_query(md_attr);
+    md_attr->rkey_packed_size = 3 * sizeof(uint64_t);
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_MEMH |
+                                UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md_attr->reg_cost         = ucs_linear_func_make(1000.0e-9, 0.007e-9);
     return UCS_OK;
 }
 

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -36,31 +36,27 @@ static ucs_config_field_t uct_ze_copy_md_config_table[] = {
 
 static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
-    md_attr->flags                  = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
-    md_attr->reg_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->reg_nonblock_mem_types = 0;
-    md_attr->cache_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->alloc_mem_types        = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->access_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->detect_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->dmabuf_mem_types       = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                      UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE);
-    md_attr->max_alloc              = SIZE_MAX;
-    md_attr->max_reg                = ULONG_MAX;
-    md_attr->rkey_packed_size       = 0;
-    md_attr->reg_cost               = UCS_LINEAR_FUNC_ZERO;
-    memset(&md_attr->local_cpus, 0xff, sizeof(md_attr->local_cpus));
+    uct_md_base_md_query(md_attr);
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
+    md_attr->dmabuf_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE);
+    md_attr->max_alloc        = SIZE_MAX;
     return UCS_OK;
 }
 

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -75,8 +75,6 @@ protected:
 
     static void dereg_cb(uct_completion_t *comp);
 
-    bool is_gpu_ipc() const;
-
     const unsigned md_flags_remote_rma = UCT_MD_MEM_ACCESS_REMOTE_PUT |
                                          UCT_MD_MEM_ACCESS_REMOTE_GET;
 


### PR DESCRIPTION
## What
This is the fix for [RM#3873368](https://redmine.mellanox.com/issues/3873368).
The issue is always reproducible on rock, when building and running UCX with the following modules:
```
module load hpcx-env
module load hpcx-env/cuda
module load hpcx-env/gdrcopy
```
With `gdr_copy` MD configured, memory registration fails in several test suites:
- 3 tests in test_md
- 2 tests in uct_test
- test_uct_loopback_cuda

The root cause was always the same: CUDA memory of arbitrary size was allocated, and then this memory is registered with `uct_md_mem_reg` without any alignment. However this does not work for gdr_copy transport, because it's required to register memory aligned by GPU_PAGE_SIZE (64k in this case).

I fixed the memory registration in all those places the same way it's done in ucp_mm module: by alignment using `ucs_align_ptr_range` API