### PR TITLE
GTEST/UCT: add caps check for AM where it's used

### DIFF
--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -329,7 +329,8 @@ private:
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_test, am_sync,
                      ((UCT_DEVICE_TYPE_SELF == GetParam()->dev_type) ||
-                      !check_caps(UCT_IFACE_FLAG_CB_SYNC,
+                      !check_caps(UCT_IFACE_FLAG_CB_SYNC |
+                                  UCT_IFACE_FLAG_AM_BCOPY,
                                   UCT_IFACE_FLAG_AM_DUP))) {
 
     ucs_status_t status;
@@ -868,13 +869,15 @@ private:
 };
 
 
-UCS_TEST_P(uct_p2p_am_alignment, invalid_align)
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, invalid_align,
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     test_invalid_alignment(0, 0, UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT);
     test_invalid_alignment(3, 1, UCT_IFACE_PARAM_FIELD_AM_ALIGNMENT);
 }
 
-UCS_TEST_P(uct_p2p_am_alignment, invalid_offset)
+UCS_TEST_SKIP_COND_P(uct_p2p_am_alignment, invalid_offset,
+                     !check_caps(UCT_IFACE_FLAG_AM_BCOPY))
 {
     // Align ofsset has no meaning if alignment is not requested
     test_invalid_alignment(0, 11, UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -837,9 +837,9 @@ uct_test::entity::entity(const resource& resource, uct_iface_config_t *iface_con
                            uct_worker_create, &m_async.m_async,
                            UCS_THREAD_MODE_SINGLE);
 
-    UCS_TEST_CREATE_HANDLE(uct_md_h, m_md, uct_md_close, uct_md_open,
-                           resource.component, resource.md_name.c_str(),
-                           md_config);
+    UCS_TEST_CREATE_HANDLE_IF_SUPPORTED(uct_md_h, m_md, uct_md_close,
+                                        uct_md_open, resource.component,
+                                        resource.md_name.c_str(), md_config);
 
     m_md_attr.field_mask = UINT64_MAX;
     status               = uct_md_query_v2(m_md, &m_md_attr);


### PR DESCRIPTION
## What
add caps check for AM where it's used in UCT gtests

## Why ?
Transport with unsupported capabilities will fail 

