### PR TITLE
UCP/CORE: Use rcache overhead env for protocol perf estimation.

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -11,3 +11,4 @@ UCX_IB_PCI_RELAXED_ORDERING=try
 UCX_IB_SEND_OVERHEAD=bcopy:5ns,cqe:50ns,db:400ns,wqe_fetch:350ns,wqe_post:100ns
 UCX_MM_SEND_OVERHEAD=am_short:40ns,am_bcopy:220ns
 UCX_MM_RECV_OVERHEAD=am_short:40ns,am_bcopy:220ns
+UCX_RCACHE_OVERHEAD=360ns

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -181,6 +181,8 @@ typedef struct ucp_context_config {
     double                                 proto_overhead_rndv_rtr;
     double                                 proto_overhead_sw;
     double                                 proto_overhead_rkey_ptr;
+    /** Registration cache lookup overhead estimation */
+    double                                 rcache_overhead;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1568,6 +1568,9 @@ ucs_status_t ucp_mem_rcache_init(ucp_context_h context,
         }
     }
 
+    context->config.ext.rcache_overhead = ucs_time_units_to_sec(
+            rcache_config->overhead, UCP_RCACHE_OVERHEAD_DEFAULT);
+
     return UCS_OK;
 
 err_rcache_destroy:

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -20,7 +20,7 @@
 #include <inttypes.h>
 
 
-#define UCP_RCACHE_LOOKUP_FUNC ucs_linear_func_make(50.0e-9, 0)
+#define UCP_RCACHE_OVERHEAD_DEFAULT 50.0e-9
 
 
 /* Mask of UCT memory flags that need make sure are present when reusing an

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -315,7 +315,8 @@ void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,
     if (context->rcache != NULL) {
         perf_node = ucp_proto_perf_node_new_data("rcache lookup", "");
 
-        *memreg_time = UCP_RCACHE_LOOKUP_FUNC;
+        *memreg_time = ucs_linear_func_make(context->config.ext.rcache_overhead,
+                                            0);
 
         ucp_proto_perf_node_add_data(perf_node, "lookup", *memreg_time);
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1295,7 +1295,7 @@ ucp_wireup_mem_reg_cost(ucp_context_t *context,
     }
 
     if (remote_addr->dst_version > UCP_RELEASE_LEGACY) {
-        return UCP_RCACHE_LOOKUP_FUNC;
+        return ucs_linear_func_make(UCP_RCACHE_OVERHEAD_DEFAULT, 0);
     }
 
     /* This is needed to preserve wire-compatibility support with

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -637,16 +637,3 @@ ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
 
     return UCS_OK;
 }
-
-double uct_md_rcache_overhead(const ucs_rcache_config_t *rcache_config)
-{
-    if (rcache_config->overhead == UCS_TIME_AUTO) {
-        if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_FUJITSU_ARM) {
-            return 360e-9;
-        } else {
-            return 180e-9;
-        }
-    } else {
-        return ucs_time_to_sec(rcache_config->overhead);
-    }
-}

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -238,8 +238,6 @@ ucs_status_t uct_md_dummy_mem_reg(uct_md_h md, void *address, size_t length,
 ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
                                     const uct_md_mem_dereg_params_t *params);
 
-double uct_md_rcache_overhead(const ucs_rcache_config_t *rcache_config);
-
 extern ucs_config_field_t uct_md_config_table[];
 
 static inline ucs_log_level_t uct_md_reg_log_lvl(uint64_t flags)


### PR DESCRIPTION
## What
Removed `uct_md_rcache_overhead`. The method became unused after merging https://github.com/openucx/ucx/pull/8225.
Added logic to use previously unused `UCX_RCACHE_OVERHEAD` environment variable. The variable can be used to configure the `rcache lookup` node (applied suggestion https://github.com/openucx/ucx/pull/8995#discussion_r1160421878).
Added `UCX_RCACHE_OVERHEAD` to `[Fujitsu ARM]` section to restore adjustments made by https://github.com/openucx/ucx/pull/7583.
