### PR TITLE
CONFIG: Guess perftest MAD support by default

### DIFF
--- a/config/m4/mad.m4
+++ b/config/m4/mad.m4
@@ -11,7 +11,7 @@ AC_ARG_WITH([mad],
             [AS_HELP_STRING([--with-mad=(DIR)],
                 [Enable Infiniband MAD support (default is no).])],
             [],
-            [with_mad=no])
+            [with_mad=guess])
 
 mad_happy=no
 AS_IF([test "x$with_mad" == "xno"],


### PR DESCRIPTION
## What
Enable perftest MAD by default.

## Why ?
Runtime dependency is properly handled by dlopen() (#9637 )