### PR TITLE
UCP/PROTO: Remove UCP_PROTO_PRIV_MAX

### DIFF
--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -22,10 +22,6 @@
 #define UCP_PROTO_MAX_PERF_RANGES 24
 
 
-/* Maximal size of protocol private data */
-#define UCP_PROTO_PRIV_MAX          1024
-
-
 /* Maximal number of protocols in total */
 #define UCP_PROTO_MAX_COUNT         64
 


### PR DESCRIPTION
## What
Remove redundant UCP_PROTO_PRIV_MAX macro.

## Why ?
It became unused after this commit: https://github.com/ivankochin/ucx/commit/ac9814b7231cb2857ac395d93a93c999af47a3ff#diff-b729ff9730727dbf69aa2e2f32eab876f0d1f68803a2b7714a911fe056909004
