### PR TITLE
UCP/RCACHE: Preserve uct_flags from memory regions we merge with

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -822,6 +822,10 @@ ucp_memh_find_slow(ucp_context_h context, void *address, size_t length,
             return UCS_OK;
         }
 
+        ucs_trace("memh %p uct_flags mismatch, expected 0x%x got 0x%x", memh,
+                  uct_flags & UCP_MM_UCT_ACCESS_MASK,
+                  memh->uct_flags & UCP_MM_UCT_ACCESS_MASK);
+
         /* Invalidate the mismatching region and get a new one */
         ucs_rcache_region_invalidate(context->rcache, &memh->super,
                                      ucs_empty_function, NULL);
@@ -1495,13 +1499,25 @@ static void ucp_mem_rcache_mem_dereg_cb(void *ctx, ucs_rcache_t *rcache,
     ucp_memh_dereg(context, memh, memh->md_map);
 }
 
-static void ucp_mem_rcache_dump_region_cb(void *rcontext, ucs_rcache_t *rcache,
-                                         ucs_rcache_region_t *rregion, char *buf,
-                                         size_t max)
+static void ucp_mem_rcache_merge_cb(void *ctx, ucs_rcache_t *rcache, void *arg,
+                                    ucs_rcache_region_t *rregion)
+{
+    ucp_mem_rcache_reg_ctx_t *reg_ctx = arg;
+    ucp_mem_h memh                    = ucs_derived_of(rregion, ucp_mem_t);
+
+    ucs_log_indent(+1);
+    ucs_trace("merge with memh %p uct_flags 0x%x", memh, memh->uct_flags);
+    reg_ctx->uct_flags |= memh->uct_flags;
+    ucs_log_indent(-1);
+}
+
+static void ucp_mem_rcache_dump_region_cb(void *ctx, ucs_rcache_t *rcache,
+                                          ucs_rcache_region_t *rregion,
+                                          char *buf, size_t max)
 {
     UCS_STRING_BUFFER_FIXED(strb, buf, max);
     ucp_mem_h memh        = ucs_derived_of(rregion, ucp_mem_t);
-    ucp_context_h context = rcontext;
+    ucp_context_h context = ctx;
     unsigned md_index;
 
     if (memh->md_map == 0) {
@@ -1524,6 +1540,7 @@ static void ucp_mem_rcache_dump_region_cb(void *rcontext, ucs_rcache_t *rcache,
 static ucs_rcache_ops_t ucp_mem_rcache_ops = {
     .mem_reg     = ucp_mem_rcache_mem_reg_cb,
     .mem_dereg   = ucp_mem_rcache_mem_dereg_cb,
+    .merge       = ucp_mem_rcache_merge_cb,
     .dump_region = ucp_mem_rcache_dump_region_cb
 };
 

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -761,7 +761,7 @@ static void ucs_rcache_lru_evict(ucs_rcache_t *rcache)
 static ucs_status_t
 ucs_rcache_check_overlap_one(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
                              ucs_pgt_addr_t *end, size_t *alignment, int *prot,
-                             ucs_rcache_region_t *region)
+                             void *arg, ucs_rcache_region_t *region)
 {
     int mem_prot;
 
@@ -815,6 +815,9 @@ ucs_rcache_check_overlap_one(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
     ucs_rcache_region_trace(rcache, region,
                             "merge 0x%lx..0x%lx "UCS_RCACHE_PROT_FMT" with",
                             *start, *end, UCS_RCACHE_PROT_ARG(*prot));
+
+    rcache->params.ops->merge(rcache->params.context, rcache, arg, region);
+
     *alignment = ucs_max(*alignment, region->alignment);
     *start     = ucs_min(*start, region->super.start);
     *end       = ucs_max(*end, region->super.end);
@@ -833,7 +836,7 @@ ucs_rcache_check_overlap_one(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
  * report this issue (e.g. standard ASAN on Ubuntu 22.04).
  */
 static ucs_status_t UCS_F_NO_SANITIZE_ADDRESS
-ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
+ucs_rcache_check_overlap(ucs_rcache_t *rcache, void *arg, ucs_pgt_addr_t *start,
                          ucs_pgt_addr_t *end, size_t *alignment, int *prot,
                          int *merged, ucs_rcache_region_t **region_p)
 {
@@ -869,7 +872,7 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
 
         ucs_list_for_each_safe(region, tmp, &region_list, tmp_list) {
             status = ucs_rcache_check_overlap_one(rcache, start, end, alignment,
-                                                  prot, region);
+                                                  prot, arg, region);
             if (status == UCS_OK) {
                 *merged = 1;
             }
@@ -946,8 +949,8 @@ retry:
 
     /* Check overlap with existing regions */
     /* coverity[double_lock] */
-    status = UCS_PROFILE_CALL(ucs_rcache_check_overlap, rcache, &start, &end,
-                              &alignment, &prot, &merged, &region);
+    status = UCS_PROFILE_CALL(ucs_rcache_check_overlap, rcache, arg, &start,
+                              &end, &alignment, &prot, &merged, &region);
     if (status == UCS_ERR_ALREADY_EXISTS) {
         /* Found a matching region (it could have been added after we released
          * the lock)

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -82,7 +82,7 @@ struct ucs_rcache_ops {
     /**
      * Register a memory region.
      *
-     * @param [in]  context    User context, as passed to @ref ucs_rcache_create
+     * @param [in]  context    User context, as passed to @ref ucs_rcache_create().
      * @param [in]  rcache     Pointer to the registration cache.
      * @param [in]  arg        Custom argument passed to @ref ucs_rcache_get().
      * @param [in]  region     Memory region to register. This may point to a larger
@@ -101,25 +101,37 @@ struct ucs_rcache_ops {
     ucs_status_t           (*mem_reg)(void *context, ucs_rcache_t *rcache,
                                       void *arg, ucs_rcache_region_t *region,
                                       uint16_t flags);
-   /**
-    * Deregister a memory region.
-    *
-    * @param [in]  context    User context, as passed to @ref ucs_rcache_create
-    * @param [in]  rcache     Pointer to the registration cache.
-    * @param [in]  region     Memory region to deregister.
-    */
+    /**
+     * Deregister a memory region.
+     *
+     * @param [in]  context  User context, as passed to @ref ucs_rcache_create().
+     * @param [in]  rcache   Pointer to the registration cache.
+     * @param [in]  region   Memory region to deregister.
+     */
     void                   (*mem_dereg)(void *context, ucs_rcache_t *rcache,
                                         ucs_rcache_region_t *region);
+
+    /**
+     * Called in the context of region lookup, for every existing region that
+     * we are potentially merging with.
+     *
+     * @param [in]  context  User context, as passed to @ref ucs_rcache_create().
+     * @param [in]  rcache   Pointer to the registration cache.
+     * @param [in]  arg      Custom argument passed to @ref ucs_rcache_get().
+     * @param [in]  region   Memory region we are merging with.
+     */
+    void                   (*merge)(void *context, ucs_rcache_t *rcache,
+                                    void *arg, ucs_rcache_region_t *region);
 
     /**
      * Dump memory region information to a string buffer.
      * (Only the user-defined part of the memory region should be dumped)
      *
-     * @param [in]  context    User context, as passed to @ref ucs_rcache_create
-     * @param [in]  rcache     Pointer to the registration cache.
-     * @param [in]  region    Memory region to dump.
-     * @param [in]  buf       String buffer to dump to.
-     * @param [in]  max       Maximal length of the string buffer.
+     * @param [in]  context  User context, as passed to @ref ucs_rcache_create().
+     * @param [in]  rcache   Pointer to the registration cache.
+     * @param [in]  region   Memory region to dump.
+     * @param [in]  buf      String buffer to dump to.
+     * @param [in]  max      Maximal length of the string buffer.
      */
     void                   (*dump_region)(void *context, ucs_rcache_t *rcache,
                                           ucs_rcache_region_t *region,

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -389,6 +389,7 @@ static void uct_rocm_copy_rcache_dump_region_cb(void *context, ucs_rcache_t *rca
 static ucs_rcache_ops_t uct_rocm_copy_rcache_ops = {
     .mem_reg     = uct_rocm_copy_rcache_mem_reg_cb,
     .mem_dereg   = uct_rocm_copy_rcache_mem_dereg_cb,
+    .merge       = (void*)ucs_empty_function,
     .dump_region = uct_rocm_copy_rcache_dump_region_cb
 };
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -181,6 +181,7 @@ static void uct_xpmem_rcache_dump_region(void *context, ucs_rcache_t *rcache,
 static ucs_rcache_ops_t uct_xpmem_rcache_ops = {
     .mem_reg     = uct_xpmem_rcache_mem_reg,
     .mem_dereg   = uct_xpmem_rcache_mem_dereg,
+    .merge       = (void*)ucs_empty_function,
     .dump_region = uct_xpmem_rcache_dump_region
 };
 

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -93,7 +93,7 @@ protected:
 
     virtual ucs_rcache_params_t rcache_params()
     {
-        static const ucs_rcache_ops_t ops = {mem_reg_cb, mem_dereg_cb,
+        static const ucs_rcache_ops_t ops = {mem_reg_cb, mem_dereg_cb, merge_cb,
                                              dump_region_cb};
         ucs_rcache_params_t params        = get_default_rcache_params(this, &ops);
         params.region_struct_size         = sizeof(region);
@@ -206,6 +206,11 @@ private:
     {
         reinterpret_cast<test_rcache*>(context)->mem_dereg(
                         ucs_derived_of(r, struct region));
+    }
+
+    static void merge_cb(void *context, ucs_rcache_t *rcache, void *arg,
+                         ucs_rcache_region_t *r)
+    {
     }
 
     static void dump_region_cb(void *context, ucs_rcache_t *rcache,


### PR DESCRIPTION
## Why
Fix a performance degradation with #9794 due to not excessive memory re-registration when merging rcache regions
cc @Sergei-Lebedev 
Internal issue [3884209](https://redmine.mellanox.com/issues/3884209)