### PR TITLE
UCP/RNDV/PUT: Replace request ATP/flush lane map with lane indexes

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -283,11 +283,13 @@ struct ucp_request {
                             union {
                                 /* Used by rndv/put and rndv/put/frag */
                                 struct {
-                                    /* Which lanes need to flush (0 in fence mode) */
-                                    ucp_lane_map_t flush_map;
+                                    /* Next lane to flush is the first set bit
+                                       in rpriv->flush_map that's >= flush_lane */
+                                    ucp_lane_index_t flush_lane;
 
-                                    /* Which lanes need to send atp */
-                                    ucp_lane_map_t atp_map;
+                                    /* Next lane to send ATP is the first set bit
+                                       in rpriv->atp_map that's >= atp_lane */
+                                    ucp_lane_index_t atp_lane;
                                 } put;
 
                                 /* Used by rndv/send/ppln and rndv/recv/ppln */

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -247,14 +247,17 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_zcopy_progress(
                                     dt_mask);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_multi_lane_map_progress(ucp_request_t *req, ucp_lane_map_t *lane_map,
-                                   ucp_proto_multi_lane_send_func_t send_func)
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_lane_map_progress(
+        ucp_request_t *req, ucp_lane_index_t *lane_p, ucp_lane_map_t lane_map,
+        ucp_proto_multi_lane_send_func_t send_func)
 {
-    ucp_lane_index_t lane = ucs_ffs32(*lane_map);
+    ucp_lane_map_t remaining_lane_map = lane_map & ~UCS_MASK(*lane_p);
+    ucp_lane_index_t lane;
     ucs_status_t status;
 
-    ucs_assert(*lane_map != 0);
+    ucs_assertv(remaining_lane_map != 0, "req=%p *lane_p=%d lane_map=0x%x", req,
+                *lane_p, lane_map);
+    lane = ucs_ffs32(remaining_lane_map);
 
     status = send_func(req, lane);
     if (ucs_likely(status == UCS_OK)) {
@@ -265,13 +268,15 @@ ucp_proto_multi_lane_map_progress(ucp_request_t *req, ucp_lane_map_t *lane_map,
         return ucp_proto_multi_handle_send_error(req, lane, status);
     }
 
-    *lane_map &= ~UCS_BIT(lane);
-    if (*lane_map != 0) {
-        return UCS_INPROGRESS; /* Not finished all lanes yet */
+    if (ucs_is_pow2_or_zero(remaining_lane_map)) {
+        /* This lane was the last one */
+        ucp_request_invoke_uct_completion_success(req);
+        return UCS_OK;
     }
 
-    ucp_request_invoke_uct_completion_success(req);
-    return UCS_OK;
+    /* Not finished yet, so continue from next lane */
+    *lane_p = lane + 1;
+    return UCS_INPROGRESS;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t


### PR DESCRIPTION
## Why
Allow keeping same request size if increasing max lanes