### PR TITLE
UCP/CORE: Fix for activate count

### DIFF
--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -370,6 +370,12 @@ typedef struct {
 KHASH_DECLARE(ucp_ep_peer_mem_hash, uint64_t, ucp_ep_peer_mem_data_t);
 
 
+typedef enum {
+    /* Protocol initialization was done */
+    UCP_EP_PROTO_INITIALIZED = UCS_BIT(0),
+} ucp_ep_init_flags_t;
+
+
 struct ucp_ep_config {
 
     /* A key which uniquely defines the configuration, and all other fields of
@@ -476,6 +482,9 @@ struct ucp_ep_config {
 
     /* Bitmap of lanes selected by the protocols */
     ucp_lane_map_t                proto_lane_map;
+
+    /* EP initialization flags from @ref ucp_ep_init_flags_t */
+    unsigned                      proto_init_flags;
 
     /* Number of endpoints using this configuration */
     unsigned                      ep_count;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1822,7 +1822,10 @@ ucp_memh_import(ucp_context_h context, const void *export_mkey_buffer,
                  * given address, but an imported memory handle hasn't been
                  * removed from the RCACHE yet. So, it had refcount == 1 and
                  * now it should be 2. */
-                ucs_assertv(rregion->refcount == 2, "%u", rregion->refcount);
+                ucs_assertv(rregion->refcount == 2, "Unexpected refcount: %u. "
+                            "This may indicate that exported memory handle was "
+                            "destroyed, but imported memory handle was not",
+                            rregion->refcount);
                 ucs_rcache_region_invalidate(rcache, rregion,
                                              ucs_empty_function, NULL);
                 ucs_rcache_region_put_unsafe(rcache, rregion);

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -406,6 +406,8 @@ void ucp_worker_signal_internal(ucp_worker_h worker);
 
 void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags);
 
+int ucp_worker_iface_is_activated(const ucp_worker_iface_t *wiface);
+
 void ucp_worker_keepalive_add_ep(ucp_ep_h );
 
 /* EP should be removed from worker all_eps prior to call this function */

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -204,6 +204,9 @@ UCS_CLASS_DEFINE_NAMED_NEW_FUNC(ucp_wireup_ep_create, ucp_wireup_ep_t, uct_ep_t,
 void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
                            ucp_rsc_index_t rsc_index, int is_p2p)
 {
+    ucp_worker_iface_t *wiface =
+        ucp_worker_iface(wireup_ep->super.ucp_ep->worker, rsc_index);
+
     ucs_assert(!ucp_wireup_ep_test(uct_ep));
     wireup_ep->aux_ep        = uct_ep;
     wireup_ep->aux_rsc_index = rsc_index;
@@ -211,6 +214,8 @@ void ucp_wireup_ep_set_aux(ucp_wireup_ep_t *wireup_ep, uct_ep_h uct_ep,
     if (is_p2p) {
         wireup_ep->flags |= UCP_WIREUP_EP_FLAG_AUX_P2P;
     }
+
+    ucp_worker_iface_progress_ep(wiface);
 }
 
 static ucs_status_t
@@ -253,8 +258,6 @@ ucp_wireup_ep_connect_aux(ucp_wireup_ep_t *wireup_ep, unsigned ep_init_flags,
     }
 
     ucp_wireup_ep_set_aux(wireup_ep, uct_ep, select_info.rsc_index, 0);
-
-    ucp_worker_iface_progress_ep(wiface);
 
     ucs_debug("ep %p: wireup_ep %p created aux_ep %p to %s using "
               UCT_TL_RESOURCE_DESC_FMT, ucp_ep, wireup_ep, wireup_ep->aux_ep,

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -155,7 +155,7 @@ public:
         return UCS_LOG_FUNC_RC_CONTINUE;
     }
 
-    int is_skip_interface(struct ifaddrs *ifa) {
+    virtual int is_skip_interface(const struct ifaddrs *ifa) const {
         int skip = 0;
 
         if (!has_transport("tcp") && !has_transport("all") &&
@@ -618,6 +618,17 @@ public:
         EXPECT_EQ(1ul, e.get_err_num_rejected());
     }
 
+    template <typename Func>
+    void wait_progress(Func func)
+    {
+        ucs_time_t deadline = ucs::get_deadline();
+        while (!func() && (ucs_get_time() < deadline)) {
+            progress();
+        };
+
+        EXPECT_GT(deadline, ucs_get_time());
+    }
+
     virtual ucp_ep_params_t get_ep_params()
     {
         ucp_ep_params_t ep_params = ucp_test::get_ep_params();
@@ -750,9 +761,9 @@ public:
         EXPECT_EQ(m_test_addr, attr.local_sockaddr);
     }
 
-    void one_sided_disconnect(entity &e, uint32_t flags = 0)
+    void one_sided_disconnect(entity &e, uint32_t flags = 0, int ep_index = 0)
     {
-        void *req           = e.disconnect_nb(0, 0, flags);
+        void *req           = e.disconnect_nb(0, ep_index, flags);
         ucs_time_t deadline = ucs::get_deadline();
         scoped_log_handler slh(detect_error_logger);
         while (!is_request_completed(req) && (ucs_get_time() < deadline)) {
@@ -3232,3 +3243,70 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err_sender)
 UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_sockaddr_protocols_err_sender,
                                         rc_no_ud, "rc_mlx5,rc_verbs")
+
+
+class test_ucp_sockaddr_iface_activate : public test_ucp_sockaddr {
+public:
+    static void
+    get_test_variants(std::vector<ucp_test_variant>& variants)
+    {
+        get_test_variants_mt(variants, UCP_FEATURE_TAG,
+                             CONN_REQ_TAG | TEST_MODIFIER_CM_USE_ALL_DEVICES,
+                             "tag");
+    }
+
+    virtual int is_skip_interface(const struct ifaddrs *ifa) const
+    {
+        return test_ucp_sockaddr::is_skip_interface(ifa) ||
+               ucs::is_rdmacm_netdev(ifa->ifa_name);
+    }
+
+    bool is_any_interface_activated(entity &e) const
+    {
+        ucp_worker_h worker = e.worker();
+        for (unsigned i = 0; i < worker->num_ifaces; ++i) {
+            if (ucp_worker_iface_is_activated(worker->ifaces[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void client_connect_disconnect()
+    {
+        /* Check state before connection establishment */
+        EXPECT_FALSE(is_any_interface_activated(receiver()));
+        int receiver_ep_count = receiver().get_num_eps();
+
+        /* Connect sender and receiver */
+        client_ep_connect_basic(get_ep_params(), 0, false);
+        wait_progress([&] {
+            return receiver().get_num_eps() == (receiver_ep_count + 1);
+        });
+
+        /* Check state after connection establishment */
+        EXPECT_EQ(0, sender().get_err_num());
+        EXPECT_TRUE(is_any_interface_activated(sender()));
+        EXPECT_TRUE(is_any_interface_activated(receiver()));
+
+        one_sided_disconnect(sender());
+        one_sided_disconnect(receiver(), 0, receiver_ep_count);
+
+        EXPECT_FALSE(is_any_interface_activated(receiver()));
+        receiver().reset_err_num();
+
+        /* TODO: check why receiver interfaces are not deactivated on one-sided
+         * client disconnect */
+    }
+};
+
+UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_iface_activate, iface_activate_count,
+                     !is_proto_enabled())
+{
+    listen(cb_type());
+    client_connect_disconnect();
+    client_connect_disconnect();
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_sockaddr_iface_activate, tcp, "tcp")

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1094,6 +1094,11 @@ const size_t &ucp_test_base::entity::get_err_num() const {
     return m_err_cntr;
 }
 
+void ucp_test_base::entity::reset_err_num() {
+    m_err_cntr = 0;
+    m_rejected_cntr = 0;
+}
+
 const size_t &ucp_test_base::entity::get_accept_err_num() const {
     return m_accept_err_cntr;
 }

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -141,6 +141,8 @@ public:
 
         const size_t &get_err_num() const;
 
+        void reset_err_num();
+
         const size_t &get_accept_err_num() const;
 
         void warn_existing_eps() const;


### PR DESCRIPTION
There is a bug introduced in recent commit https://github.com/openucx/ucx/pull/9650, which is exposed in 2 ways:
- assertion failure in debug build in function `ucp_worker_iface_deactivate : wiface->activate_count > 0`
- in release mode process hangs
Revert of that commit solves the connectivity issue both for daemon CI use case and RFI.

The issue happens on the receiver side, only when there are multiple connections from the same sender. In this case there are multiple wireup_eps created and they reuse the same ep_config. However, increments and decrements of interface reference counter are not consistent:
```
First sender connect:
  ucp_worker_get_ep_config -> Load new config
    ucp_worker_ep_config_short_init -> Select protocols
      ucp_wiface_process_for_each_lane -> activate_count ++
  ucp_ep_set_cfg_index -> Set config to EP
    ucp_ep_config_activate_worker_ifaces
      ucp_wiface_process_for_each_lane -> activate_count ++
First sender disconnect
  ucp_wireup_process_request -> Handle disconnect event
    ucp_ep_set_cfg_index -> Update config, remove active interfaces
      ucp_wiface_process_for_each_lane -> activate_count --
  ucp_wireup_eps_progress -> Wireup EP gets deleted
    ucp_proxy_ep_replace
      ucp_wireup_ep_t_cleanup
        ucp_wireup_ep_discard_aux_ep
          ucp_worker_iface_unprogress_ep -> activate_count --  

Now the second client connects and reuses the same ep_config:
  ucp_worker_get_ep_config -> Reuse existing config
    No increment happens here, just return <<< Fix here?
  ucp_ep_set_cfg_index -> Set config to EP
    ucp_ep_config_activate_worker_ifaces
      ucp_wiface_process_for_each_lane -> activate_count ++
Second sender disconnect
  ucp_wireup_process_request -> Handle disconnect event
    ucp_ep_set_cfg_index -> Update config, remove active interfaces
      ucp_wiface_process_for_each_lane -> activate_count -- (HERE refcount reaches 0, interface gets deactivated)
  ucp_wireup_eps_progress -> Wireup EP gets deleted
    ucp_proxy_ep_replace
      ucp_wireup_ep_t_cleanup
        ucp_wireup_ep_discard_aux_ep
          ucp_worker_iface_unprogress_ep -> activate_count -- (Failure: activate_count == 0)
```
As we agreed after internal discussion, the idea is to avoid iface activation during config creation. Instead, we do iface activation on `ucp_ep_set_cfg_index`. Also add missing iface activation for AUX EP