### PR TITLE
CI: Fix gdrcopy check by allowing the dev access from Docker

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -1,7 +1,7 @@
 variables:
   DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
   DOCKER_OPT_IB: --ulimit memlock=-1:-1 --device=/dev/infiniband/ --net=host
-  DOCKER_OPT_GPU: --gpus all $(DOCKER_OPT_IB)
+  DOCKER_OPT_GPU: --gpus all --device=/dev/gdrdrv $(DOCKER_OPT_IB)
   DOCKER_OPT_ARGS: --cap-add=SYS_PTRACE
 
 resources:


### PR DESCRIPTION
## What
Allow access to /dev/gdrdrv inode for GPU-enabled Docker containers.

## Why ?
[HPCINFRA-2031](https://jirasw.nvidia.com/browse/HPCINFRA-2031) (Internal link).

