### PR TITLE
UCT/CUDA: Detect fabric vmm memory

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -74,6 +74,10 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                               have_cuda_static="yes"],
                              [], [-ldl -lrt -lpthread])])
 
+         AC_CHECK_DECLS([CU_MEM_HANDLE_TYPE_FABRIC],
+                        [AC_DEFINE([HAVE_CUDA_FABRIC], 1, [Enable CUDA fabric handle support])],
+                        [], [[#include <cuda.h>]])
+
          CPPFLAGS="$save_CPPFLAGS"
          LDFLAGS="$save_LDFLAGS"
          LIBS="$save_LIBS"

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -189,11 +189,11 @@ UCM_CUDA_ALLOC_FUNC(cuMemMap, UCS_MEMORY_TYPE_UNKNOWN, CUresult, CUDA_SUCCESS,
                     "size=%zu offset=%zu handle=0x%llx flags=0x%llx", size_t,
                     size_t, CUmemGenericAllocationHandle, unsigned long long)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_ALLOC_FUNC(cuMemAllocAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, CUresult,
+UCM_CUDA_ALLOC_FUNC(cuMemAllocAsync, UCS_MEMORY_TYPE_CUDA, CUresult,
                     CUDA_SUCCESS, arg0, CUdeviceptr, *, "size=%zu stream=%p",
                     size_t, CUstream)
-UCM_CUDA_ALLOC_FUNC(cuMemAllocFromPoolAsync, UCS_MEMORY_TYPE_CUDA_MANAGED,
-                    CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, *,
+UCM_CUDA_ALLOC_FUNC(cuMemAllocFromPoolAsync, UCS_MEMORY_TYPE_CUDA, CUresult,
+                    CUDA_SUCCESS, arg0, CUdeviceptr, *,
                     "size=%zu pool=%p stream=%p", size_t, CUmemoryPool,
                     CUstream)
 #endif
@@ -208,8 +208,8 @@ UCM_CUDA_FREE_FUNC(cuMemFreeHost_v2, UCS_MEMORY_TYPE_HOST, CUresult, arg0, 0,
 UCM_CUDA_FREE_FUNC(cuMemUnmap, UCS_MEMORY_TYPE_UNKNOWN, CUresult, arg0, arg1,
                    "ptr=%llx size=%zu", CUdeviceptr, size_t)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_FREE_FUNC(cuMemFreeAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, CUresult, arg0,
-                   0, "ptr=0x%llx, stream=%p", CUdeviceptr, CUstream)
+UCM_CUDA_FREE_FUNC(cuMemFreeAsync, UCS_MEMORY_TYPE_CUDA, CUresult, arg0, 0,
+                   "ptr=0x%llx, stream=%p", CUdeviceptr, CUstream)
 #endif
 
 static ucm_cuda_func_t ucm_cuda_driver_funcs[] = {
@@ -244,21 +244,20 @@ UCM_CUDA_ALLOC_FUNC(cudaMallocPitch, UCS_MEMORY_TYPE_CUDA, cudaError_t,
                     cudaSuccess, ((size_t)arg1) * (arg2), void*, *,
                     "pitch=%p width=%zu height=%zu", size_t*, size_t, size_t)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, cudaError_t,
+UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t,
                     cudaSuccess, arg0, void*, *, "size=%zu stream=%p", size_t,
                     cudaStream_t)
-UCM_CUDA_ALLOC_FUNC(cudaMallocFromPoolAsync, UCS_MEMORY_TYPE_CUDA_MANAGED,
-                    cudaError_t, cudaSuccess, arg0, void*, *,
-                    "size=%zu pool=%p stream=%p", size_t, cudaMemPool_t,
-                    cudaStream_t)
+UCM_CUDA_ALLOC_FUNC(cudaMallocFromPoolAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t,
+                    cudaSuccess, arg0, void*, *, "size=%zu pool=%p stream=%p",
+                    size_t, cudaMemPool_t, cudaStream_t)
 #endif
 UCM_CUDA_FREE_FUNC(cudaFree, UCS_MEMORY_TYPE_CUDA, cudaError_t, arg0, 0,
                    "devPtr=%p", void*)
 UCM_CUDA_FREE_FUNC(cudaFreeHost, UCS_MEMORY_TYPE_HOST, cudaError_t, arg0, 0,
                    "ptr=%p", void*)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_FREE_FUNC(cudaFreeAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, cudaError_t,
-                   arg0, 0, "devPtr=%p, stream=%p", void*, cudaStream_t)
+UCM_CUDA_FREE_FUNC(cudaFreeAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t, arg0, 0,
+                   "devPtr=%p, stream=%p", void*, cudaStream_t)
 #endif
 
 static ucm_cuda_func_t ucm_cuda_runtime_funcs[] = {

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -60,6 +60,10 @@ const char *uct_cuda_base_cu_get_error_string(CUresult result);
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
+#define UCT_CUDADRV_FUNC_LOG_WARN(_func) \
+    UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_WARN)
+
+
 #define UCT_CUDADRV_FUNC_LOG_DEBUG(_func) \
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_DEBUG)
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 #include <uct/cuda/base/cuda_md.h>
+#include <cuda.h>
 
 
 extern uct_component_t uct_cuda_copy_component;
@@ -23,27 +24,43 @@ typedef enum {
  * @brief cuda_copy MD descriptor
  */
 typedef struct uct_cuda_copy_md {
-    struct uct_md               super;           /* Domain info */
+    struct uct_md                super;           /* Domain info */
+    int                          sync_memops_set;
+    size_t                       granularity;     /* allocation granularity */
     struct {
-        ucs_on_off_auto_value_t alloc_whole_reg; /* force return of allocation
-                                                    range even for small bar
-                                                    GPUs*/
-        double                  max_reg_ratio;
-        int                     dmabuf_supported;
-        uct_cuda_pref_loc_t     pref_loc;
+        ucs_on_off_auto_value_t  alloc_whole_reg; /* force return of allocation
+                                                     range even for small bar
+                                                     GPUs*/
+        double                   max_reg_ratio;
+        int                      dmabuf_supported;
+        ucs_ternary_auto_value_t enable_fabric;
+        uct_cuda_pref_loc_t      pref_loc;
     } config;
 } uct_cuda_copy_md_t;
 
 /**
- * gdr copy domain configuration.
+ * cuda_copy MD configuration.
  */
 typedef struct uct_cuda_copy_md_config {
     uct_md_config_t             super;
     ucs_on_off_auto_value_t     alloc_whole_reg;
     double                      max_reg_ratio;
     ucs_ternary_auto_value_t    enable_dmabuf;
+    ucs_ternary_auto_value_t    enable_fabric;
     uct_cuda_pref_loc_t         pref_loc;
 } uct_cuda_copy_md_config_t;
+
+/**
+ * copy alloc handle.
+ */
+typedef struct uct_cuda_copy_alloc_handle {
+    CUdeviceptr                 ptr;
+    size_t                      length;
+    uint8_t                     is_vmm;
+#if HAVE_CUDA_FABRIC
+    CUmemGenericAllocationHandle generic_handle;
+#endif
+} uct_cuda_copy_alloc_handle_t;
 
 
 ucs_status_t uct_cuda_copy_md_detect_memory_type(uct_md_h md,

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -308,7 +308,7 @@ UCS_TEST_F(cuda_hooks, test_cuMemAllocAsync) {
     /* release with cuMemFree */
     ret = cuMemAllocAsync(&dptr, 64, 0);
     ASSERT_EQ(ret, CUDA_SUCCESS);
-    check_mem_alloc_events((void*)dptr, 64, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    check_mem_alloc_events((void*)dptr, 64, UCS_MEMORY_TYPE_CUDA);
 
     ret = cuMemFree(dptr);
     ASSERT_EQ(ret, CUDA_SUCCESS);
@@ -324,6 +324,7 @@ UCS_TEST_F(cuda_hooks, test_cuMemAllocAsync) {
     check_mem_free_events((void*)dptr, 64);
 }
 #endif
+
 
 UCS_TEST_F(cuda_hooks, test_cuda_Malloc_Free) {
     cudaError_t ret;
@@ -404,7 +405,7 @@ UCS_TEST_F(cuda_hooks, test_cudaMallocAsync) {
     /* release with cudaFree */
     ret = cudaMallocAsync(&ptr, 64, 0);
     ASSERT_EQ(ret, cudaSuccess);
-    check_mem_alloc_events(ptr, 64, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    check_mem_alloc_events(ptr, 64, UCS_MEMORY_TYPE_CUDA);
 
     ret = cudaFree(ptr);
     ASSERT_EQ(ret, cudaSuccess);


### PR DESCRIPTION
## What/Why?
Breaking https://github.com/openucx/ucx/pull/9787 into parts. This part isolates:
1. Fabric memory detection in cuda_copy transport
2. Change UCM cuda hooks to treat mallocasync memory as CUDA memory and not CUDA managed memory.
3. Add ability to allocate fabric pinned memory for rendezvous fragments

## Notes
1. This will break existing mallocasync support which applies managed memory pipeline protocols
2. Currently EGM fabric VMM allocations are treated as device memory for subsequent PRs to leverage NVLINKs for EGM transfers. In a subsequent PR, this change will be reverted once it is confirmed that cuda_ipc supporting host memory doesn't break UCP protocolsV2.
