### PR TITLE
CI/MAD: Run Docker as a user to avoid creating files as root 

### DIFF
--- a/buildlib/tools/test_mad.sh
+++ b/buildlib/tools/test_mad.sh
@@ -23,23 +23,24 @@ build_ucx() {
 
 build_ucx_in_docker() {
     docker run --rm \
+        --user "$(id -u)":"$(id -g)" \
         --name ucx_build_"$BUILD_BUILDID" \
         -e BUILD_SOURCESDIRECTORY="$BUILD_SOURCESDIRECTORY" \
         -v "$PWD":"$PWD" -w "$PWD" \
         -v /hpc/local:/hpc/local \
         $IMAGE \
         bash -c "source ./buildlib/tools/test_mad.sh && build_ucx"
-
-    sudo chown -R swx-azure-svc:ecryptfs "$PWD"
 }
 
 docker_run_srv() {
     local test_name="$1"
     HCA=$(detect_hca)
+    sudo chmod 777 /dev/infiniband/umad*
     docker run \
         --rm \
         --detach \
         --net=host \
+        --user "$(id -u)":"$(id -g)" \
         --name ucx_perftest_"$BUILD_BUILDID" \
         -e BUILD_SOURCESDIRECTORY="$BUILD_SOURCESDIRECTORY" \
         -v "$PWD":"$PWD" -w "$PWD" \


### PR DESCRIPTION
## What
Regain ownership of files in the working directory after running custom "docker run" commands.

## Why ?
CI fails, as it's unable to clean up root files left on hosts by the Docker container.

Findings:
```
[swx-azure-svc@vulcan03 11:00:53 azure]$ find . -user root
./agent-02/AZP_WORKSPACE/3/s/ucx_perf_srv_LID_80635.log
./agent-02/AZP_WORKSPACE/3/s/ucx_perf_srv_GUID_80635.log
```