### PR TITLE
UCP/WIREUP: Fix AM BW multi-lanes selection

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1733,7 +1733,7 @@ ucp_wireup_add_am_bw_lanes(const ucp_wireup_select_params_t *select_params,
 
     num_am_bw_lanes = ucp_wireup_add_bw_lanes(select_params, &bw_info,
                                               ucp_tl_bitmap_max, am_lane,
-                                              select_ctx, 1);
+                                              select_ctx, 0);
     return ((am_lane != UCP_NULL_LANE) || (num_am_bw_lanes > 0)) ? UCS_OK :
            UCS_ERR_UNREACHABLE;
 }

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -1464,7 +1464,8 @@ UCS_TEST_SKIP_COND_P(test_max_lanes, 16_lanes_reconf, !cm_use_all_devices(),
     ASSERT_EQ(16, (int)ucp_ep_num_lanes(receiver().ep()));
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_max_lanes, ib, "ib")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_max_lanes, rc, "rc")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_max_lanes, ud, "ud")
 
 class test_ucp_sockaddr_wireup_fail : public test_ucp_sockaddr_wireup {
 protected:

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1237,7 +1237,8 @@ public:
         return max_lanes;
     }
 
-    void test_max_lanes(bool is_eager) {
+    void test_max_lanes(bool is_eager)
+    {
         receiver().connect(&sender(), get_ep_params());
         test_run_xfer(true, true, true, true, false);
 


### PR DESCRIPTION
## What
- Fixes lanes selection process for multi-lane AM BW case
- Extend testing for max lanes case

## Why ?
- Currently, UCX chooses `MAX_LANES - 1` number of lanes since `am_lane` is passed to `ucp_wireup_add_bw_lanes` as `excl_lane` parameter, so UCX shouldn't subtract extra one lane.
-  During `ucp_wireup_construct_lanes` execution UCX places all the `am_bw_lanes` to one position further to set `am_lane` to `am_bw_lanes[0]` later, but `am_lane` is already part of `am_bw_lanes`, so we should place it as usual, but doesn't include to sorted range.