### PR TITLE
TEST/GTEST/UCT: Fix heap-buffer overflow in AMO test

### DIFF
--- a/test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc
+++ b/test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc
@@ -30,7 +30,7 @@ UCS_TEST_SKIP_COND_P(uct_atomic_key_reg_rdma_mem_type, fadd64,
 
     run_workers(static_cast<send_func_t>(
                         &uct_amo_test::atomic_fop<uint64_t, UCT_ATOMIC_OP_ADD>),
-                recvbuf, std::vector<uint64_t>(1, add), false);
+                recvbuf, std::vector<uint64_t>(num_senders(), add), false);
     wait_for_remote();
 }
 


### PR DESCRIPTION
## What
Fix heap-buffer overflow in test code.

## Why ?
Reported by ASAN in CI on many PRs.

## How ?
```
==25238==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200009d3b8 at pc 0x55d822608015 bp 0x7ffe8ac96730 sp 0x7ffe8ac96720
READ of size 8 at 0x60200009d3b8 thread T0
    #0 0x55d822608014 in uct_amo_test::run_workers(ucs_status_t (uct_amo_test::*)(uct_ep*, uct_amo_test::worker&, uct_test::mapped_buffer const&, unsigned long*, uct_amo_test::completion*), uct_test::mapped_buffer const&, std::vector<unsigned long, std::allocator<unsigned long> >, bool) /__w/6/s/contrib/../test/gtest/uct/test_amo.cc:130
    #1 0x55d82261404a in uct_atomic_key_reg_rdma_mem_type_fadd64_Test::test_body() /__w/6/s/contrib/../test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc:31
```
