### PR TITLE
GTEST/COMMON: Cache CUDA device BAR1 available size - v1.17.x

### DIFF
--- a/contrib/lsan.supp
+++ b/contrib/lsan.supp
@@ -1,1 +1,2 @@
 leak:libcuda
+leak:nvmlInitWithFlags

--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -100,6 +100,7 @@ int main(int argc, char **argv) {
 
     /* set gpu context for tests that need it */
     mem_buffer::set_device_context();
+    mem_buffer::get_bar1_free_size_nvml();
 
     int ret;
     ret = ucs::watchdog_start();

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -93,9 +93,15 @@ public:
     /* returns whether ROCM device supports hipMallocPitch */
     static bool is_rocm_malloc_pitch_supported();
 
+    /* Get from NVML BAR1 free size */
+    static void get_bar1_free_size_nvml();
+
     /* Return free memory on the BAR1 / GPU. If GPU is not used
      * SIZE_MAX is returned */
-    static size_t get_bar1_free_size();
+    static size_t get_bar1_free_size()
+    {
+        return m_bar1_free_size;
+    }
 
     mem_buffer(size_t size, ucs_memory_type_t mem_type);
     mem_buffer(size_t size, ucs_memory_type_t mem_type, uint64_t seed);
@@ -143,6 +149,8 @@ private:
     static bool check_mem_types(ucs_memory_type_t dst_mem_type,
                                 ucs_memory_type_t src_mem_type,
                                 const uint64_t mem_types);
+
+    static size_t           m_bar1_free_size;
 
     const ucs_memory_type_t m_mem_type;
     void * const            m_ptr;


### PR DESCRIPTION
## What
Backport #9877.

## Why ?
Branch v1.17.x also needs to build and test cleanly.