### PR TITLE
UCT/IB/DEVX: Set atomic_mode basing on device capabilities

### DIFF
--- a/src/uct/ib/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/dc/dc_mlx5_devx.c
@@ -12,6 +12,7 @@
 
 #include <uct/api/uct.h>
 #include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
+#include <uct/ib/mlx5/ib_mlx5.inl>
 #include <ucs/arch/bitops.h>
 
 
@@ -46,7 +47,8 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
     UCT_IB_MLX5DV_SET(dctc, dctc, cs_res,
                       uct_ib_mlx5_qpc_cs_res(
                               ib_iface->config.max_inl_cqe[UCT_IB_DIR_RX], 1));
-    UCT_IB_MLX5DV_SET(dctc, dctc, atomic_mode, UCT_IB_MLX5_ATOMIC_MODE);
+    UCT_IB_MLX5DV_SET(dctc, dctc, atomic_mode,
+                      uct_ib_mlx5_get_atomic_mode(ib_iface));
     if (!uct_ib_iface_is_roce(&iface->super.super.super)) {
         UCT_IB_MLX5DV_SET(dctc, dctc, pkey_index, ib_iface->pkey_index);
     }
@@ -131,7 +133,8 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
     UCT_IB_MLX5DV_SET(qpc, qpc, mtu, rc_iface->super.config.path_mtu);
     UCT_IB_MLX5DV_SET(qpc, qpc, log_msg_max, UCT_IB_MLX5_LOG_MAX_MSG_SIZE);
-    UCT_IB_MLX5DV_SET(qpc, qpc, atomic_mode, UCT_IB_MLX5_ATOMIC_MODE);
+    UCT_IB_MLX5DV_SET(qpc, qpc, atomic_mode,
+                      uct_ib_mlx5_get_atomic_mode(&rc_iface->super));
     UCT_IB_MLX5DV_SET(qpc, qpc, rae, true);
     if (uct_ib_iface_is_roce(&rc_iface->super)) {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -61,7 +61,8 @@
 #define UCT_IB_MLX5_CQ_SET_CI            0
 #define UCT_IB_MLX5_CQ_ARM_DB            1
 #define UCT_IB_MLX5_LOG_MAX_MSG_SIZE     30
-#define UCT_IB_MLX5_ATOMIC_MODE          3
+#define UCT_IB_MLX5_ATOMIC_MODE_COMP     1
+#define UCT_IB_MLX5_ATOMIC_MODE_EXT      3
 #define UCT_IB_MLX5_CQE_FLAG_L3_IN_DATA  UCS_BIT(28) /* GRH/IP in the receive buffer */
 #define UCT_IB_MLX5_CQE_FLAG_L3_IN_CQE   UCS_BIT(29) /* GRH/IP in the CQE */
 #define UCT_IB_MLX5_CQE_FORMAT_MASK      0xc

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -651,3 +651,11 @@ uct_ib_mlx5_update_cqe_zipping_stats(uct_ib_iface_t *iface,
                                  UCT_IB_IFACE_STAT_RX_COMPLETION_ZIPPED, 1);
     }
 }
+
+
+static int UCS_F_ALWAYS_INLINE
+uct_ib_mlx5_get_atomic_mode(uct_ib_iface_t *iface)
+{
+    return uct_ib_iface_device(iface)->ext_atomic_arg_sizes ?
+        UCT_IB_MLX5_ATOMIC_MODE_EXT : UCT_IB_MLX5_ATOMIC_MODE_COMP;
+}

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -460,7 +460,8 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
 
     UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.vhca_port_num, ah_attr->port_num);
     UCT_IB_MLX5DV_SET(qpc, qpc, log_rra_max, ucs_ilog2_or0(max_rd_atomic));
-    UCT_IB_MLX5DV_SET(qpc, qpc, atomic_mode, UCT_IB_MLX5_ATOMIC_MODE);
+    UCT_IB_MLX5DV_SET(qpc, qpc, atomic_mode,
+                      uct_ib_mlx5_get_atomic_mode(&iface->super.super));
     UCT_IB_MLX5DV_SET(qpc, qpc, rre, true);
     UCT_IB_MLX5DV_SET(qpc, qpc, rwe, true);
     UCT_IB_MLX5DV_SET(qpc, qpc, rae, true);


### PR DESCRIPTION
## What
Set atomic_mode during DEVX device creation basing on the device capabilities.

## Why ?
Currently atomic_mode always set to one hardcoded value, but if extended atomics are not supported or disabled by PCI it should be set to another one.

## Notes
Tested manually with PCI_ATOMICS_ENABLED_EXT_ATOMICS_DISABLED setting.
