### PR TITLE
Add support for loongarch64

### DIFF
--- a/src/ucm/Makefile.am
+++ b/src/ucm/Makefile.am
@@ -33,7 +33,8 @@ noinst_HEADERS = \
 	bistro/bistro_x86_64.h \
 	bistro/bistro_aarch64.h \
 	bistro/bistro_ppc64.h \
-	bistro/bistro_rv64.h
+	bistro/bistro_rv64.h \
+	bistro/bistro_loongarch64.h
 
 libucm_la_SOURCES = \
 	event/event.c \
@@ -47,7 +48,8 @@ libucm_la_SOURCES = \
 	bistro/bistro_x86_64.c \
 	bistro/bistro_aarch64.c \
 	bistro/bistro_ppc64.c \
-	bistro/bistro_rv64.c
+	bistro/bistro_rv64.c \
+	bistro/bistro_loongarch64.c
 
 if HAVE_UCM_PTMALLOC286
 libucm_la_CPPFLAGS += \

--- a/src/ucm/bistro/bistro.c
+++ b/src/ucm/bistro/bistro.c
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2018. ALL RIGHTS RESERVED.
  * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+ * Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -121,7 +122,7 @@ ucs_status_t ucm_bistro_apply_patch(void *dst, void *patch, size_t len)
     return status;
 }
 
-#if defined(__x86_64__) || defined (__aarch64__) || defined (__riscv)
+#if defined(__x86_64__) || defined (__aarch64__) || defined (__riscv) || defined(__loongarch64)
 struct ucm_bistro_restore_point {
     void               *addr;     /* address of function to restore */
     size_t             patch_len; /* patch length */

--- a/src/ucm/bistro/bistro.h
+++ b/src/ucm/bistro/bistro.h
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2018. ALL RIGHTS RESERVED.
  * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+ * Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -23,6 +24,8 @@ typedef struct ucm_bistro_restore_point ucm_bistro_restore_point_t;
 #  include "bistro_x86_64.h"
 #elif defined(__riscv)
 #  include "bistro_rv64.h"
+#elif defined(__loongarch64)
+#  include "bistro_loongarch64.h"
 #else
 #  error "Unsupported architecture"
 #endif

--- a/src/ucm/bistro/bistro_loongarch64.c
+++ b/src/ucm/bistro/bistro_loongarch64.c
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) Xing Li, Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#if defined(__loongarch64)
+
+#include <ucs/arch/cpu.h>
+#include <ucm/bistro/bistro.h>
+#include <ucm/bistro/bistro_int.h>
+#include <ucs/debug/assert.h>
+#include <ucs/sys/math.h>
+#include <ucm/util/sys.h>
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#define T0 12
+#define T2 14
+#define RA  1
+#define ZERO  0
+
+/**
+  * @brief JIRL - Add 16 bit immediate to source register, save to destination
+  * register, jump and link from destination register
+  *
+  * @param[in] _regd source register number (0-31)
+  * @param[in] _regj destination register number (0-31)
+  * @param[in] _imm 16 bit immmediate value
+  */
+#define JIRL(_regd, _regj, _imm) \
+    (((0x13) << 26 ) | ((_imm) << 10) | ((_regj) << 5) | (_regd))
+/**
+  * @brief B - Indirect jump
+  *
+  * @param[in] _imm 26 bit immmediate value
+  */
+#define B(_imm) \
+	((0x14) << 26) | (((_imm) & 0xffff) << 10) | ((_imm) >>16)
+
+/**
+  * @brief PCADDU12I - Add upper intermediate to PC
+  *
+  * @param[in] _regd register number (0-31)
+  * @param[in] _imm 20 bit immmediate value
+  */
+#define PCADDU12I(_regd, _imm) (((0xe) << 25) | ((_imm) << 5) | (_regd))
+
+/**
+  * @brief LD - Load from memory with address from register plus immediate
+  *
+  * @param[in] _regs source register number (0-31)
+  * @param[in] _regd destination register number (0-31)
+  * @param[in] _imm 12 bit immmediate value
+  */
+#define LD(_regd, _regj, _imm) \
+    (((0xa3) << 22) | ((_imm) << 10) | ((_regj) << 5) | (_regd))
+
+void ucm_bistro_patch_lock(void *dst)
+{
+    static const ucm_bistro_lock_t self_jmp = {
+        .j = B(0)
+    };
+
+    ucm_bistro_modify_code(dst, &self_jmp);
+}
+
+ucs_status_t ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
+                              void **orig_func_p,
+                              ucm_bistro_restore_point_t **rp)
+{
+    ucs_status_t status;
+    ucm_bistro_patch_t patch;
+
+    patch = (ucm_bistro_patch_t) {
+        .pcaddu12i = PCADDU12I(T0, 0),
+        .ld        = LD(T2, T0, 0x10),
+        .jirl      = JIRL(0, T2, 0),
+        .spare     = 0,
+        .address   = (uintptr_t)hook
+    };
+
+    if (orig_func_p != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = ucm_bistro_create_restore_point(func_ptr, sizeof(patch), rp);
+    if (UCS_STATUS_IS_ERR(status)) {
+        return status;
+    }
+
+    return ucm_bistro_apply_patch_atomic(func_ptr, &patch, sizeof(patch));
+}
+
+ucs_status_t ucm_bistro_relocate_one(ucm_bistro_relocate_context_t *ctx)
+{
+    return UCS_ERR_UNSUPPORTED;
+}
+
+#endif

--- a/src/ucm/bistro/bistro_loongarch64.h
+++ b/src/ucm/bistro/bistro_loongarch64.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+ * Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+
+#ifndef UCM_BISTRO_BISTRO_LOONGARCH64_H_
+#define UCM_BISTRO_BISTRO_LOONGARCH64_H_
+
+#include <ucs/type/status.h>
+#include <ucs/sys/compiler_def.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define UCM_BISTRO_PROLOGUE
+#define UCM_BISTRO_EPILOGUE
+
+typedef struct ucm_bistro_patch {
+    uint32_t pcaddu12i;
+    uint32_t ld;
+    uint32_t jirl;
+    uint32_t spare;
+    uint64_t address;
+} UCS_S_PACKED ucm_bistro_patch_t;
+
+
+/**
+ * Set library function call hook using Binary Instrumentation
+ * method (BISTRO): replace function body by user defined call
+ *
+ * @param func_ptr     Pointer to function to patch.
+ * @param hook         User-defined replacement function.
+ * @param symbol       Function name to replace.
+ * @param orig_func_p  Unsupported on this architecture and must be NULL.
+ *                     If set to a non-NULL value, this function returns
+ *                     @ref UCS_ERR_UNSUPPORTED.
+ * @param rp           Restore point used to restore original function.
+ *                     Optional, may be NULL.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucm_bistro_patch(void *func_ptr, void *hook, const char *symbol,
+                              void **orig_func_p,
+                              ucm_bistro_restore_point_t **rp);
+
+/* Lock implementation */
+typedef struct {
+    uint32_t j; /* jump to self */
+} UCS_S_PACKED ucm_bistro_lock_t;
+
+/**
+ * Helper functions to improve atomicity of function patching
+ */
+void ucm_bistro_patch_lock(void *dst);
+
+#endif

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (C) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
 # Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+# Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -24,6 +25,7 @@ nobase_dist_libucs_la_HEADERS = \
 	arch/aarch64/bitops.h \
 	arch/ppc64/bitops.h \
 	arch/rv64/bitops.h \
+	arch/loongarch64/bitops.h \
 	arch/x86_64/bitops.h \
 	arch/bitops.h \
 	algorithm/crc.h \
@@ -85,6 +87,7 @@ nobase_dist_libucs_la_HEADERS = \
 	arch/x86_64/atomic.h \
 	arch/aarch64/global_opts.h \
 	arch/generic/atomic.h \
+	arch/loongarch64/global_opts.h \
 	arch/ppc64/global_opts.h \
 	arch/rv64/global_opts.h \
 	arch/global_opts.h
@@ -92,6 +95,7 @@ nobase_dist_libucs_la_HEADERS = \
 noinst_HEADERS = \
 	arch/aarch64/cpu.h \
 	arch/generic/cpu.h \
+	arch/loongarch64/cpu.h \
 	arch/ppc64/cpu.h \
 	arch/rv64/cpu.h \
 	arch/x86_64/cpu.h \
@@ -149,6 +153,8 @@ libucs_la_SOURCES = \
 	algorithm/string_distance.c \
 	arch/aarch64/cpu.c \
 	arch/aarch64/global_opts.c \
+	arch/loongarch64/cpu.c \
+	arch/loongarch64/global_opts.c \
 	arch/ppc64/timebase.c \
 	arch/ppc64/global_opts.c \
 	arch/rv64/cpu.c \

--- a/src/ucs/arch/atomic.h
+++ b/src/ucs/arch/atomic.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -17,6 +18,8 @@
 #elif defined(__aarch64__)
 #  include "generic/atomic.h"
 #elif defined(__riscv)
+#  include "generic/atomic.h"
+#elif defined(__loongarch64)
 #  include "generic/atomic.h"
 #else
 #  error "Unsupported architecture"

--- a/src/ucs/arch/bitops.h
+++ b/src/ucs/arch/bitops.h
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
 * Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -23,6 +24,8 @@ BEGIN_C_DECLS
 #  include "aarch64/bitops.h"
 #elif defined(__riscv)
 #  include "rv64/bitops.h"
+#elif defined(__loongarch64)
+#  include "loongarch64/bitops.h"
 #else
 #  error "Unsupported architecture"
 #endif

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -56,6 +57,10 @@ const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST] = {
         .max = UCS_MEMUNITS_INF
     },
     [UCS_CPU_VENDOR_GENERIC_ARM] = {
+        .min = UCS_MEMUNITS_INF,
+        .max = UCS_MEMUNITS_INF
+    },
+    [UCS_CPU_VENDOR_GENERIC_LOONGARCH64] = {
         .min = UCS_MEMUNITS_INF,
         .max = UCS_MEMUNITS_INF
     },
@@ -164,6 +169,7 @@ const char *ucs_cpu_vendor_name()
         [UCS_CPU_VENDOR_INTEL]         = "Intel",
         [UCS_CPU_VENDOR_AMD]           = "AMD",
         [UCS_CPU_VENDOR_GENERIC_ARM]   = "Generic ARM",
+        [UCS_CPU_VENDOR_GENERIC_LOONGARCH64] = "Generic LoongArch64",
         [UCS_CPU_VENDOR_GENERIC_PPC]   = "Generic PPC",
         [UCS_CPU_VENDOR_GENERIC_RV64G] = "Generic RV64G",
         [UCS_CPU_VENDOR_FUJITSU_ARM]   = "Fujitsu ARM",
@@ -189,6 +195,7 @@ const char *ucs_cpu_model_name()
         [UCS_CPU_MODEL_ARM_AARCH64]        = "ARM 64-bit",
         [UCS_CPU_MODEL_AMD_NAPLES]         = "Naples",
         [UCS_CPU_MODEL_AMD_ROME]           = "Rome",
+        [UCS_CPU_MODEL_LOONGARCH64]        = "LoongArch 64-bit",
         [UCS_CPU_MODEL_AMD_MILAN]          = "Milan",
         [UCS_CPU_MODEL_AMD_GENOA]          = "Genoa",
         [UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG] = "Zhangjiang",

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -3,6 +3,7 @@
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -35,6 +36,7 @@ typedef enum ucs_cpu_model {
     UCS_CPU_MODEL_AMD_ROME,
     UCS_CPU_MODEL_AMD_MILAN,
     UCS_CPU_MODEL_AMD_GENOA,
+    UCS_CPU_MODEL_LOONGARCH64,
     UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG,
     UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU,
     UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI,
@@ -67,6 +69,7 @@ typedef enum ucs_cpu_vendor {
     UCS_CPU_VENDOR_INTEL,
     UCS_CPU_VENDOR_AMD,
     UCS_CPU_VENDOR_GENERIC_ARM,
+    UCS_CPU_VENDOR_GENERIC_LOONGARCH64,
     UCS_CPU_VENDOR_GENERIC_PPC,
     UCS_CPU_VENDOR_FUJITSU_ARM,
     UCS_CPU_VENDOR_ZHAOXIN,
@@ -107,6 +110,8 @@ typedef struct ucs_cpu_builtin_memcpy {
 #  include "aarch64/cpu.h"
 #elif defined(__riscv)
 #  include "rv64/cpu.h"
+#elif defined(__loongarch64)
+#  include "loongarch64/cpu.h"
 #else
 #  error "Unsupported architecture"
 #endif

--- a/src/ucs/arch/global_opts.h
+++ b/src/ucs/arch/global_opts.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -18,6 +19,8 @@
 #  include "aarch64/global_opts.h"
 #elif defined(__riscv)
 #  include "rv64/global_opts.h"
+#elif defined(__loongarch64)
+#  include "loongarch64/global_opts.h"
 #else
 #  error "Unsupported architecture"
 #endif

--- a/src/ucs/arch/loongarch64/bitops.h
+++ b/src/ucs/arch/loongarch64/bitops.h
@@ -1,0 +1,34 @@
+/**
+* Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_ARCH_LOONGARCH64_BITOPS_H_
+#define UCS_ARCH_LOONGARCH64_BITOPS_H_
+
+#include <ucs/sys/compiler_def.h>
+#include <stdint.h>
+
+static UCS_F_ALWAYS_INLINE unsigned __ucs_ilog2_u32(uint32_t n)
+{
+    return 31 - __builtin_clz(n);
+}
+
+static UCS_F_ALWAYS_INLINE unsigned __ucs_ilog2_u64(uint64_t n)
+{
+    return 63 - __builtin_clzll(n);
+}
+
+static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
+{
+    return __ucs_ilog2_u32(n & -n);
+}
+
+static UCS_F_ALWAYS_INLINE unsigned ucs_ffs64(uint64_t n)
+{
+    return __ucs_ilog2_u64(n & -n);
+}
+
+#endif

--- a/src/ucs/arch/loongarch64/cpu.c
+++ b/src/ucs/arch/loongarch64/cpu.c
@@ -1,0 +1,22 @@
+/**
+* Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#if defined(__loongarch64)
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <ucs/arch/cpu.h>
+
+ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
+{
+    return UCS_CPU_VENDOR_GENERIC_LOONGARCH64;
+}
+
+#endif
+

--- a/src/ucs/arch/loongarch64/cpu.h
+++ b/src/ucs/arch/loongarch64/cpu.h
@@ -1,0 +1,116 @@
+/**
+* Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Rivos Inc. 2023
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_ARCH_LOONGARCH64_CPU_H_
+#define UCS_ARCH_LOONGARCH64_CPU_H_
+
+#include <ucs/arch/generic/cpu.h>
+#include <ucs/config/global_opts.h>
+#include <ucs/config/types.h>
+#include <ucs/sys/compiler.h>
+#include <ucs/sys/compiler_def.h>
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+BEGIN_C_DECLS
+
+/** @file cpu.h */
+
+#define UCS_ARCH_CACHE_LINE_SIZE 64
+
+#define ucs_loongarch64_dbar(hint)   asm volatile ("dbar %0 " : : "I"(hint) : "memory")
+
+#define crwrw           0b00000
+#define cr_r_           0b00101
+#define c_w_w           0b01010
+
+#define orwrw           0b10000
+#define or_r_           0b10101
+#define o_w_w           0b11010
+
+#define orw_w           0b10010
+#define or_rw           0b10100
+
+#define ucs_memory_bus_store_fence() ucs_loongarch64_dbar(c_w_w) 
+#define ucs_memory_bus_load_fence()  ucs_loongarch64_dbar(cr_r_) 
+
+
+#define ucs_memory_cpu_fence()               ucs_loongarch64_dbar(orwrw)     
+#define ucs_memory_bus_cacheline_wc_flush()  ucs_memory_cpu_fence()
+#define ucs_memory_cpu_store_fence()         ucs_loongarch64_dbar(o_w_w)      
+#define ucs_memory_cpu_load_fence()          ucs_loongarch64_dbar(or_r_)     
+#define ucs_memory_cpu_wc_fence()            ucs_memory_cpu_fence()
+
+static inline double ucs_arch_get_clocks_per_sec()
+{
+    return ucs_arch_generic_get_clocks_per_sec();
+}
+
+static inline ucs_cpu_model_t ucs_arch_get_cpu_model()
+{
+    return UCS_CPU_MODEL_LOONGARCH64;
+}
+
+static inline int ucs_arch_get_cpu_flag()
+{
+    return UCS_CPU_FLAG_UNKNOWN;
+}
+
+static inline void ucs_cpu_init()
+{
+}
+
+ucs_cpu_vendor_t ucs_arch_get_cpu_vendor();
+
+static inline ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
+{
+    return UCS_ERR_UNSUPPORTED;
+}
+
+static inline uint64_t ucs_arch_read_hres_clock()
+{
+    uint64_t cnt_id, time;
+    __asm__ __volatile__ (
+	"rdtime.d %0, %1\n\t"
+	:"=&r"(time), "=&r"(cnt_id)
+    );
+    return time;
+}
+
+#define ucs_arch_wait_mem ucs_arch_generic_wait_mem
+
+#if !HAVE___CLEAR_CACHE
+static inline void ucs_arch_clear_cache(void *start, void *end)
+{
+      usc_memory_cpu_fence();
+}
+#endif
+
+static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
+                                       ucs_arch_memcpy_hint_t hint,
+                                       size_t total_len)
+{
+    return memcpy(dst, src, len);
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_memcpy_nontemporal(void *dst, const void *src, size_t len)
+{
+    memcpy(dst, src, len);
+}
+
+END_C_DECLS
+
+#endif
+

--- a/src/ucs/arch/loongarch64/global_opts.c
+++ b/src/ucs/arch/loongarch64/global_opts.c
@@ -1,0 +1,25 @@
+/**
+* Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#if defined(__loongarch64)
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <ucs/arch/global_opts.h>
+#include <ucs/config/parser.h>
+
+ucs_config_field_t ucs_arch_global_opts_table[] = {
+    {NULL}
+};
+
+void ucs_arch_print_memcpy_limits(ucs_arch_global_opts_t *config)
+{
+}
+
+#endif

--- a/src/ucs/arch/loongarch64/global_opts.h
+++ b/src/ucs/arch/loongarch64/global_opts.h
@@ -1,0 +1,26 @@
+/**
+* Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_LOONGARCH64_GLOBAL_OPTS_H_
+#define UCS_LOONGARCH64_GLOBAL_OPTS_H_
+
+#include <stddef.h>
+
+#include <ucs/sys/compiler_def.h>
+
+BEGIN_C_DECLS
+
+#define UCS_ARCH_GLOBAL_OPTS_INITALIZER {}
+
+/* built-in memcpy config */
+typedef struct ucs_arch_global_opts {
+    char dummy;
+} ucs_arch_global_opts_t;
+
+END_C_DECLS
+
+#endif

--- a/src/ucs/configure.m4
+++ b/src/ucs/configure.m4
@@ -3,6 +3,7 @@
 # Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 # Copyright (C) ARM, Ltd. 2016. ALL RIGHTS RESERVED.
 # Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+# Copyright (C) Dandan Zhang, 2024. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -239,7 +240,7 @@ AC_ARG_WITH([cache-line-size],
         [AS_HELP_STRING([--with-cache-line-size=SIZE],
             [Build UCX with cache line size defined by user. This parameter
              overwrites default cache line sizes defines in
-             UCX (x86-64: 64, Power: 128, ARMv8: 64/128, RISCV: 64). The supported values are: 64, 128])],
+             UCX (x86-64: 64, Power: 128, ARMv8: 64/128, RISCV: 64, LoongArch: 64). The supported values are: 64, 128])],
         [],
         [with_cache_line_size=no])
 


### PR DESCRIPTION
Add support for loongarch64.
Signed-Off-By: lixing@loongson.cn, zhangdandan@loongson.cn

## What
Compiling the ucx failed for loongarch64 in my local ENV.
I filed an issue requesting support for the loongarch architecture.
The issue can be found at https://github.com/openucx/ucx/issues/9873.

## Why ?
Lack of LoongArch architecture support in ucx source.
```
In file included from /home/ucx/src/ucs/time/time.h:10,
                 from /home/ucx/src/ucm/util/sys.h:13,
                 from mmap/mmap.h:11,
                 from mmap/install.c:12:
/home/ucx/src/ucs/arch/cpu.h:111:4: error: #error "Unsupported architecture"
  111 | #  error "Unsupported architecture"
      |    ^~~~~
/home/ucx/src/ucs/arch/cpu.h: In function 'ucs_cpu_prefer_relaxed_order':
/home/ucx/src/ucs/arch/cpu.h:158:35: error: implicit declaration of function 'ucs_arch_get_cpu_vendor' [-Werror=implicit-function-declaration]
  158 |     ucs_cpu_vendor_t cpu_vendor = ucs_arch_get_cpu_vendor();
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~
/home/ucx/src/ucs/arch/cpu.h:158:35: error: nested extern declaration of 'ucs_arch_get_cpu_vendor' [-Werror=nested-externs]
```
And we need to add loongarch64 support in Debian ucx source package.
Please see https://buildd.debian.org/status/package.php?p=ucx&suite=sid

## How ?
Debootstrap a loong64 rootfs from debian ports.
According to README, I have built ucx successfully and test binaries are normal.
```
root@localhost:/home/gitclone/ucx# ./autogen.sh 
root@localhost:/home/gitclone/ucx# ./contrib/configure-release --prefix=/usr/local/
root@localhost:/home/gitclone/ucx# make -j8
root@localhost:/home/gitclone/ucx# make install
root@localhost:/usr/local/bin# ls
io_demo  ucx_info  ucx_perftest  ucx_perftest_daemon  ucx_read_profile
root@localhost:/usr/local/bin# ldd ucx_info 
	linux-vdso.so.1 (0x000000fffff18000)
	libucp.so.0 => /usr/local/lib/libucp.so.0 (0x000000fff1034000)
	libuct.so.0 => /usr/local/lib/libuct.so.0 (0x000000fff0ff0000)
	libucs.so.0 => /usr/local/lib/libucs.so.0 (0x000000fff0f88000)
	libc.so.6 => /lib/loongarch64-linux-gnu/libc.so.6 (0x000000fff0dfc000)
	libm.so.6 => /lib/loongarch64-linux-gnu/libm.so.6 (0x000000fff0d70000)
	libucm.so.0 => /usr/local/lib/libucm.so.0 (0x000000fff0d50000)
	/lib64/ld-linux-loongarch-lp64d.so.1 (0x000000fff112c000)
root@localhost:/usr/local/bin# ./ucx_info -v
# Library version: 1.18.0
# Library path: /usr/local/lib/libucs.so.0
# API headers version: 1.18.0
# Git branch 'master', revision e4c7481
# Configured with: --disable-logging --disable-debug --disable-assertions --disable-params-check --prefix=/usr/local/
```