### PR TITLE
AZP/SNAPSHOT: Add JUCX tests on ARM

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -362,6 +362,11 @@ stages:
           name: gpu
           demands: ucx_gpu
 
+      - template: ../jucx/jucx-test.yml
+        parameters:
+          arch: aarch64
+          demands: ucx-arm64
+
   - stage: go
     dependsOn: [Static_check]
     jobs:


### PR DESCRIPTION
## What
Add JUCX tests on ARM

## Why ?
Following https://github.com/openucx/ucx/pull/9593, some of the newly added tests on ARM failed.
This PR is to troubleshoot failures and complete the ARM-based testing cycle.

