### PR TITLE
UCS/SOCK: Added subnet match support

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -15,6 +15,7 @@
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/math.h>
+#include <ucs/sys/sock.h>
 #include <string.h>
 #include <ctype.h>
 
@@ -144,6 +145,15 @@ void ucs_string_buffer_append_iovec(ucs_string_buffer_t *strb,
                                   iov[iov_index].iov_len);
     }
     ucs_string_buffer_rtrim(strb, "|");
+}
+
+void ucs_string_buffer_append_saddr(ucs_string_buffer_t *strb,
+                                    const struct sockaddr *sa)
+{
+    char sockstr[UCS_SOCKADDR_STRING_LEN];
+
+    ucs_sockaddr_str(sa, sockstr, UCS_SOCKADDR_STRING_LEN);
+    ucs_string_buffer_appendf(strb, "%s", sockstr);
 }
 
 static int ucs_string_buffer_match_charset(char ch, const char *charset)

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -10,6 +10,7 @@
 #include <ucs/sys/compiler_def.h>
 #include <ucs/type/status.h>
 #include <ucs/datastruct/array.h>
+#include <sys/socket.h>
 #include <sys/uio.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -187,6 +188,16 @@ void ucs_string_buffer_append_flags(ucs_string_buffer_t *strb, uint64_t mask,
  */
 void ucs_string_buffer_append_iovec(ucs_string_buffer_t *strb,
                                     const struct iovec *iov, size_t iovcnt);
+
+
+/**
+ * Append a sockaddr representation to the string buffer.
+ *
+ * @param [inout] strb  String buffer to append to.
+ * @param [in]    sa    Pointer to a sockaddr object.
+ */
+void ucs_string_buffer_append_saddr(ucs_string_buffer_t *strb,
+                                    const struct sockaddr *sa);
 
 
 /**

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -540,6 +540,21 @@ int ucs_sockaddr_ip_cmp(const struct sockaddr *sa1, const struct sockaddr *sa2);
 
 
 /**
+ * Checks if two IP addresses are in the same subnet
+ *
+ * @param [in]  sa1         Pointer to sockaddr structure #1.
+ * @param [in]  sa2         Pointer to sockaddr structure #2.
+ * @param [in]  prefix_len  Subnet prefix length in bits.
+ *
+ * @return 1 if both addresses are in the same subnet.
+ *         0 if not
+ */
+int ucs_sockaddr_is_same_subnet(const struct sockaddr *sa1,
+                                const struct sockaddr *sa2,
+                                unsigned prefix_len);
+
+
+/**
  * Indicate if given IP address is INADDR_ANY (IPV4) or in6addr_any (IPV6)
  *
  * @param [in]   addr       Pointer to sockaddr structure.


### PR DESCRIPTION
## What
Added new API for subnet match support.

## Why ?
To allow subnet matching from all parts of code.
Before this PR, subnet matching was done only in ib_iface_roce_is_reachable, but there is a demand to support it also for
matching with user configured subnets (ie. for GID selection).

This is the first PR of the GID subnet filter feature.


