### PR TITLE
UCS/CPU: Make headers C89 compliant

### DIFF
--- a/src/ucs/memory/numa.h
+++ b/src/ucs/memory/numa.h
@@ -21,22 +21,22 @@ typedef int16_t ucs_numa_node_t;
 extern const char *ucs_numa_policy_names[];
 
 
-void ucs_numa_init();
+void ucs_numa_init(void);
 
 
-void ucs_numa_cleanup();
+void ucs_numa_cleanup(void);
 
 
 /**
  * @return The number of CPU cores in the system.
  */
-unsigned ucs_numa_num_configured_cpus();
+unsigned ucs_numa_num_configured_cpus(void);
 
 
 /**
  * @return The number of memory nodes in the system.
  */
-unsigned ucs_numa_num_configured_nodes();
+unsigned ucs_numa_num_configured_nodes(void);
 
 
 /**

--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -78,7 +78,7 @@
 #define UCS_BIT(i)               (1ul << (i))
 
 /* Mask of bits 0..i-1 */
-#define UCS_MASK(_i)             (((_i) >= 64) ? ~0 : (UCS_BIT(_i) - 1))
+#define UCS_MASK(_i)             (((_i) >= 64) ? ~0u : (UCS_BIT(_i) - 1))
 
 /*
  * Enable compiler checks for printf-like formatting.

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -239,7 +239,7 @@ ucs_numa_node_t ucs_topo_sys_device_get_numa_node(ucs_sys_device_t sys_dev);
  *
  * @return Number of system devices.
  */
-unsigned ucs_topo_num_devices();
+unsigned ucs_topo_num_devices(void);
 
 
 /**
@@ -252,13 +252,13 @@ void ucs_topo_print_info(FILE *stream);
 /**
  * Initialize UCS topology subsystem.
  */
-void ucs_topo_init();
+void ucs_topo_init(void);
 
 
 /**
  * Cleanup UCS topology subsystem.
  */
-void ucs_topo_cleanup();
+void ucs_topo_cleanup(void);
 
 END_C_DECLS
 


### PR DESCRIPTION
This is not a correctness issue but a user friendliness issue. Including some UCX headers while compiling OMPI with picky compiler options generate a ton of warnings.

The warning in compiler_def.h is about the two branches of the conditional returning different integer types (one int and the other unsigned long).

The other warnings are about declaration of functions with no arguments. The solution here is either adding void to signal there are no arguments or making the declaration a prototype.

Fixes #9910