### PR TITLE
GTEST/UD: Increase UD EP timeout when running under valgrind - v1.17.x

### DIFF
--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
         modify_config_for_valgrind("IB_TX_BUFS_GROW", "64");
         modify_config_for_valgrind("UD_RX_QUEUE_LEN", "256");
         modify_config_for_valgrind("UD_RX_QUEUE_LEN_INIT", "32");
+        modify_config_for_valgrind("UD_TIMEOUT", "300s");
         modify_config_for_valgrind("RC_TX_CQ_LEN", "128");
         modify_config_for_valgrind("RC_RX_QUEUE_LEN", "128");
         modify_config_for_valgrind("DC_TX_QUEUE_LEN", "16");


### PR DESCRIPTION
This is double commit of https://github.com/openucx/ucx/pull/9880, into v1.17.x branch

Fix for [RM#3918537](https://redmine.mellanox.com/issues/3918537)

I managed to reproduce this issue on rock machines in 100% of the cases, but only when running this test under high CPU load. This CPU load I generate using dummy 64 processes (yes > /dev/null).
I checked ud_ep timeout logic, and it seems to work correctly. So the reasonable fix would be to increase UCX_UD_TIMEOUT (from 30s to 300s) when running under valgrind. With increased timeout the issue is not reproducible anymore, even with artificial CPU load