### PR TITLE
TOOLS/PERF: fix batch documentation

### DIFF
--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -87,8 +87,11 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("     -o             do not progress the responder in one-sided tests\n");
     printf("     -B             register memory with NONBLOCK flag\n");
     printf("     -b <file>      read and execute tests from a batch file: every line in the\n");
-    printf("                    file is a test to run, first word is test name, the rest of\n");
-    printf("                    the line is command-line arguments for the test.\n");
+    printf("                    file is a test to run. The first word is a user-defined\n");
+    printf("                    test name, followed by command-line arguments, for example:\n");
+    printf("\n");
+    printf("                        test_tag_bandwidth_64k -t tag_bw -s 65536 -n 10000\n");
+    printf("\n");
     printf("     -R <rank>      percentile rank of the percentile data in latency tests (%.1f)\n",
                                 ctx->params.super.percentile_rank);
     printf("     -p <port>      TCP port to use for data exchange (%d)\n", ctx->port);


### PR DESCRIPTION
## What
Add explanation for the "-b" flag of `ucx_perftest` help message.

## Why ?
Following https://github.com/openucx/ucx/discussions/9868:
The current help message of  "-b" flag of `ucx_perftest` doesn't specify that the first element of each line is supposed to be a user defined test name.

before:
![image](https://github.com/openucx/ucx/assets/80859800/bb501444-8b2c-4f1f-9a32-d0ace07009c9)

after:
![image](https://github.com/openucx/ucx/assets/80859800/f06154b8-6a5c-4849-b868-b788981ded8c)
