### PR TITLE
UCP/PROTO: Accumulate max frag across all lanes

### DIFF
--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -144,7 +144,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     mpriv->min_frag     = 0;
     mpriv->max_frag_sum = 0;
     mpriv->align_thresh = 1;
-    perf.max_frag       = SIZE_MAX;
+    perf.max_frag       = 0;
     perf.min_length     = 0;
     weight_sum          = 0;
     min_end_offset      = 0;
@@ -167,8 +167,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         ucs_assert(max_frag > 0);
 
         lpriv->max_frag = max_frag;
-        perf.max_frag   = ucs_min(perf.max_frag, lpriv->max_frag);
-
+        perf.max_frag  += max_frag;
 
         /* Calculate lane weight as a fixed-point fraction */
         lpriv->weight = ucs_proto_multi_calc_weight(lane_perf->bandwidth,


### PR DESCRIPTION
## What
Calculate `perf::max_frag` as a sum across all the chosen lanes instead of choosing minimal `max_frag`.

## Why ?

Fix errors like [that one](https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/81603/logs/449):

```
2024-05-30T17:31:50.2347606Z [ RUN      ] rcx/test_proto_reset.put_offload_zcopy/0 <rc_x>
2024-05-30T17:31:50.5009110Z [swx-rain01-bf1:712800:4:712800]  proto_init.c:730  Assertion `range_end >= caps->min_length' failed: range_end=256 caps->min_length=324
2024-05-30T17:31:50.5033953Z ==== backtrace (tid: 712800) ====
2024-05-30T17:31:50.5035454Z  0  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucs/.libs/libucs.so.0(ucs_debug_print_backtrace+0x9c) [0xffffb89a6020]
2024-05-30T17:31:50.5036470Z  1  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucs/.libs/libucs.so.0(ucs_handle_error+0x478) [0xffffb89a9f18]
2024-05-30T17:31:50.5038371Z  2  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucs/.libs/libucs.so.0(ucs_fatal_error_message+0x148) [0xffffb89a4fa8]
2024-05-30T17:31:50.5039079Z  3  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucs/.libs/libucs.so.0(ucs_fatal_error_format+0x1b0) [0xffffb89a5180]
2024-05-30T17:31:50.5039692Z  4  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucp/.libs/libucp.so.0(ucp_proto_common_init_caps+0x3e0) [0xffffb84b4940]
2024-05-30T17:31:50.5040334Z  5  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucp/.libs/libucp.so.0(ucp_proto_multi_init+0xea8) [0xffffb84c7b98]
2024-05-30T17:31:50.5040952Z  6  /scrap/azure/agent-04/AZP_WORKSPACE/2/s/build-test/src/ucp/.libs/libucp.so.0(ucp_proto_rndv_bulk_init+0xf4) [0xffffb852a004]
```

## How ?
That particular test sets `RMA_ZCOPY_MAX_SEG_SIZE=1024`. And there are two lanes that are chosen for rndv_get proto initialization. Since one lanes has approximately 4 times higher BW this lane sends 80% of msg and another sends 20% only. Since `max_seg_size=1024`, fast lane send `lane_perf->max_frag=1024` and slow lane `lane_perf->max_frag=256` only. And since slow lane sends only 20%, it’s `min_len=64*5 = 324`.

Since `ucp_proto_multi_init` chooses maximal `min_length` and minimal `max_frag` across all lanes for common `tl_perf` structure and `caps`, it's `max_frag` becomes equal to `256` and it's `min_length` becomes `324`. These two values can be used as `range_start` and `range_end` for `ucp_proto_init_single_frag_ranges`. That's why this assert exists and fails.

The case described above shows that `tl_perf->min_length` represents the minimal size of the message that can be send to respect the slowest lane minimal allowed frag and `tl_perf->max_length` is message length that can be sent by one lane. But RNDV protocols always split even small messages to several parts if there are several lanes.

Thus said the `max_frag` should also be calculated as maximal message size that can be processed without using any lane twice.

Another way of fixing that is assuming that protocols like `rndv/get/zcopy` with several lanes doesn't have "single fragment" range at all, but it would require significant logic changes.

