### PR TITLE
UCP/PROTO: Make perf nodes names more informative

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -245,6 +245,11 @@ void ucp_proto_common_lane_perf_node(ucp_context_h context,
     const uct_tl_resource_desc_t *tl_rsc = &context->tl_rscs[rsc_index].tl_rsc;
     ucp_proto_perf_node_t *perf_node;
 
+    if (perf_attr->operation == UCT_EP_OP_LAST) {
+        *perf_node_p = NULL;
+        return;
+    }
+
     perf_node = ucp_proto_perf_node_new_data(
             uct_ep_operation_names[perf_attr->operation],
             UCT_TL_RESOURCE_DESC_FMT, UCT_TL_RESOURCE_DESC_ARG(tl_rsc));

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -33,7 +33,7 @@ struct ucp_proto_perf_node {
     ucp_proto_perf_node_type_t                    type;
 
     /* Name of the range */
-    const char                                    *name;
+    char                                          name[UCP_PROTO_DESC_STR_MAX];
 
     /* Description of the range */
     char                                          desc[UCP_PROTO_DESC_STR_MAX];
@@ -512,9 +512,11 @@ ucp_proto_perf_node_new(ucp_proto_perf_node_type_t type, const char *name,
     }
 
     perf_node->type     = type;
-    perf_node->name     = name;
     perf_node->refcount = 1;
     ucs_array_init_dynamic(&perf_node->children);
+
+    ucs_assert(name != NULL);
+    ucs_strncpy_safe(perf_node->name, name, sizeof(perf_node->name));
     ucs_vsnprintf_safe(perf_node->desc, sizeof(perf_node->desc), desc_fmt, ap);
 
     return perf_node;
@@ -899,7 +901,8 @@ ucp_proto_perf_graph_dump_recurs(ucp_proto_perf_node_t *perf_node,
     /* Description */
     if (!ucs_string_is_empty(perf_node->desc)) {
         ucs_string_buffer_appendf(
-                strb, "<font face=\"calibri\" point-size=\"11\">%s<br/></font>",
+                strb, "<font face=\"calibri\" point-size=\"11\">%s"
+                UCP_PROTO_PERF_NODE_NEW_LINE"</font>",
                 perf_node->desc);
     }
 

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -10,6 +10,9 @@
 #include "proto_select.h"
 
 
+/* String to place new line inside performance graph */
+#define UCP_PROTO_PERF_NODE_NEW_LINE "<br/>"
+
 /* Format string to display a protocol time */
 #define UCP_PROTO_TIME_FMT(_time_var) " " #_time_var ": %.2f ns"
 #define UCP_PROTO_TIME_ARG(_time_val) ((_time_val) * 1e9)


### PR DESCRIPTION
## What
Place full protocol chain to the perf nodes' names.

## Why ?
Makes protocol graph debugging more convenient.

| Before| After|
|--------|--------|
| ![image](https://github.com/openucx/ucx/assets/22097249/f52ea648-1caf-4561-8f2c-91a38e0e8ec2)| ![image](https://github.com/openucx/ucx/assets/22097249/0d5cd410-4f7f-4f82-aff2-4be127925bc1)|
