### PR TITLE
GTEST/UCT: Do not check gdr_copy perf in test_uct_loopback

### DIFF
--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -50,7 +50,8 @@ void test_uct_perf::test_execute(unsigned flags = 0,
         }
     }
 
-    if (has_transport("tcp") || has_transport("cuda_copy")) {
+    if (has_transport("tcp") || has_transport("cuda_copy") ||
+        has_transport("gdr_copy")) {
         check_perf = false; /* TODO calibrate expected performance based on transport */
         max_iter   = 1000lu;
     }


### PR DESCRIPTION
## What
 Do not check gdr_copy performance in test_uct_loopback

## Why ?
To avoid CI failures like:
```
2024-06-03T14:20:53.8553317Z [ RUN      ] gdr_copy/test_uct_loopback_cuda.envelope/0 <gdr_copy/cuda>
2024-06-03T14:20:53.8575555Z [     INFO ] send mem type: host / recv mem type: cuda
2024-06-03T14:20:55.8972802Z [     INFO ] cuda               put latency : 8.168 usec
2024-06-03T14:20:59.5822542Z [     INFO ] cuda               put latency : 8.150 usec (attempt 1)
2024-06-03T14:21:03.2452147Z [     INFO ] cuda               put latency : 8.042 usec (attempt 2)
2024-06-03T14:21:07.0235042Z [     INFO ] cuda               put latency : 8.586 usec (attempt 3)
2024-06-03T14:21:10.7139065Z [     INFO ] cuda               put latency : 8.124 usec (attempt 4)
2024-06-03T14:21:14.4211134Z [     INFO ] cuda               put latency : 8.192 usec (attempt 5)
2024-06-03T14:21:18.1102324Z [     INFO ] cuda               put latency : 8.127 usec (attempt 6)
2024-06-03T14:21:21.9205770Z [     INFO ] cuda               put latency : 8.112 usec (attempt 7)
2024-06-03T14:21:25.4971873Z [     INFO ] cuda               put latency : 8.066 usec (attempt 8)
2024-06-03T14:21:29.4216340Z [     INFO ] cuda               put latency : 8.116 usec (attempt 9)
2024-06-03T14:21:32.8855470Z [     INFO ] cuda               put latency : 8.123 usec (attempt 10)
2024-06-03T14:21:34.8858390Z /__w/1/s/contrib/../test/gtest/common/test_perf.cc:379: Failure
2024-06-03T14:21:34.8859636Z Failed
2024-06-03T14:21:34.8860211Z Invalid put latency performance, expected: 0.002..7.5
2024-06-03T14:21:35.2110651Z [     INFO ] cuda                  put rate : 7.686 Mpps
2024-06-03T14:21:35.7062583Z [  FAILED  ] gdr_copy/test_uct_loopback_cuda.envelope/0, where GetParam() = gdr_copy/cuda (41851 ms)

```
