### PR TITLE
UCS/GTEST: fixed uninitialized value access

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -827,12 +827,8 @@ ucs_rcache_check_overlap_one(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
     return UCS_OK;
 }
 
-/* Lock must be held
- * Old ASAN versions reports buffer underflow false-positive during access to
- * `region` through `ucs_list_link_t` entry. Newer ASAN versions don't
- * report this issue (e.g. standard ASAN on Ubuntu 22.04).
- */
-static ucs_status_t UCS_F_NO_SANITIZE_ADDRESS
+/* Lock must be held */
+static ucs_status_t
 ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
                          ucs_pgt_addr_t *end, size_t *alignment, int *prot,
                          int *merged, ucs_rcache_region_t **region_p)
@@ -852,14 +848,16 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
     ucs_list_head_init(&region_list);
     ucs_rcache_find_regions(rcache, *start, *end - 1, &region_list);
 
-    region = ucs_list_next(&region_list, ucs_rcache_region_t, tmp_list);
-    if (ucs_list_is_only(&region_list, &region->tmp_list) &&
-        (*start >= region->super.start) && (*end <= region->super.end) &&
-        ucs_rcache_region_test(region, *prot, *alignment)) {
-        /* Found a region which contains the given address range */
-        ucs_rcache_region_hold(rcache, region);
-        *region_p = region;
-        return UCS_ERR_ALREADY_EXISTS;
+    if (!ucs_list_is_empty(&region_list)) {
+        region = ucs_list_next(&region_list, ucs_rcache_region_t, tmp_list);
+        if (ucs_list_is_only(&region_list, &region->tmp_list) &&
+            (*start >= region->super.start) && (*end <= region->super.end) &&
+            ucs_rcache_region_test(region, *prot, *alignment)) {
+            /* Found a region which contains the given address range */
+            ucs_rcache_region_hold(rcache, region);
+            *region_p = region;
+            return UCS_ERR_ALREADY_EXISTS;
+        }
     }
 
     /* TODO check if any of the regions is locked */


### PR DESCRIPTION
## What
This is fix for [RM#3919044](https://redmine.mellanox.com/issues/3919044), double commit into v.1.17.x, master PR is https://github.com/openucx/ucx/pull/9917
There are multiple test failures reported as:
```
==54391== Conditional jump or move depends on uninitialised value(s)
==54391==    at 0x50AE1A2: ucs_rcache_check_overlap (rcache.c:860)
==54391==    by 0x50AE1A2: ucs_rcache_create_region (rcache.c:952)
==54391==    by 0x50AE9AB: ucs_rcache_get (rcache.c:1108)
==54391==    by 0xBE26F4: test_rcache::get(void*, unsigned long, int, unsigned long) (test_rcache.cc:109)
==54391==    by 0xBD33E1: test_rcache_basic_Test::test_body() (test_rcache.cc:276)
==54391==    by 0x637499: ucs::test_base::thread_func(void*) (test.cc:397)
==54391==    by 0x995ADD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==54391==  Uninitialised value was created by a stack allocation
```

## Why ?
Function `ucs_rcache_check_overlap` was modified in https://github.com/openucx/ucx/pull/9441, with additional check whether found region is the only element in the list. The issue reported by ASAN and valgrind happens when returned region list is empty. In this case we access some uninitialized data on the stack:
```
    ucs_list_link_t region_list;
    ucs_list_head_init(&region_list);
    ucs_rcache_find_regions(rcache, *start, *end - 1, &region_list); << returns empty list

    region = ucs_list_next(&region_list, ucs_rcache_region_t, tmp_list); << access non-existing region by offset on the stack
```

## How ?
Added check that returned list is not empty
