### PR TITLE
UCP/WIREUP: Only skip AM lanes for RMA with supported remote addresses - v1.17.x

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1898,7 +1898,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
      * use of fence operations usually don't request the TAG feature, hence the
      * check.
      */
-    if (context->config.features & (UCP_FEATURE_TAG | UCP_FEATURE_AM)) {
+    if ((select_params->address->dst_version >= 17) &&
+        (context->config.features & (UCP_FEATURE_TAG | UCP_FEATURE_AM))) {
         ucs_carray_for_each(lane_desc, select_ctx->lane_descs,
                             select_ctx->num_lanes) {
             if (!(lane_desc->lane_types & UCS_BIT(UCP_LANE_TYPE_AM))) {


### PR DESCRIPTION
## What
backport #9915

Only skip AM lanes with appropriate with peers >= v1.17.