### PR TITLE
BINDINGS/GO: Fixed make distcheck.

### DIFF
--- a/bindings/go/Makefile.am
+++ b/bindings/go/Makefile.am
@@ -5,6 +5,10 @@
 
 if HAVE_GO
 
+EXTRA_DIST = \
+	src \
+	tests
+
 GOOBJDIR=$(abs_top_builddir)/bindings/go/$(objdir)
 GOPATH=$(abs_top_srcdir)/bindings/go/
 CGOCFLAGS=-I$(abs_top_builddir)/src -I$(abs_top_srcdir)/src
@@ -58,6 +62,9 @@ run-perftest:
 
 install-exec-hook: goperftest
 	$(INSTALL) ${GOTMPDIR}/goperftest $(DESTDIR)$(bindir)
+
+uninstall-hook:
+	$(RM) $(DESTDIR)$(bindir)/goperftest
 
 all: goperftest build
 


### PR DESCRIPTION
## What
Fixed `make distcheck` command when go bindings are enabled.

An example of the error in the output of the command:
```
make[3]: Entering directory `/ucx/build/ucx-1.18.0/_build/sub/bindings/go'
go env -w GO111MODULE=off ; \
cd /ucx/build/ucx-1.18.0/_build/sub/../../bindings/go/src/examples/perftest ;\
go build --tags= -o /ucx/build/ucx-1.18.0/_build/sub/bindings/go/.libs/tmp/goperftest
/bin/sh: line 1: cd: /ucx/build/ucx-1.18.0/_build/sub/../../bindings/go/src/examples/perftest: No such file or directory
package .: no Go files in /ucx/build/ucx-1.18.0/_build/sub/bindings/go
```
The error was mentioned https://github.com/openucx/ucx/issues/9798.

Fixed uninstalling of the go performance benchmark. The binary should be manually removed since it is installed using install-exec-hook.