### PR TITLE
BUILD/ASAN: Preload a single ASAN version

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -33,7 +33,7 @@ export ASAN_OPTIONS=protect_shadow_gap=0
 
 # LD_PRELOAD puts ASAN first in initial library list which is required for
 # correct ASAN work.
-ASAN_LD_PRELOAD=$(shell ldconfig -p | grep libasan.so | tr ' ' '\n' | grep /)
+ASAN_LD_PRELOAD=$(shell ldconfig -p | grep libasan.so | tr ' ' '\n' | grep / | head -1)
 TEST_ENV=LD_PRELOAD=$(ASAN_LD_PRELOAD):$(LD_PRELOAD)
 endif
 


### PR DESCRIPTION
## What
Only use a single ASAN version with LD_PRELOAD.

## Why ?
Some machines had both libasan6 and libasan8 installed, so LD_PRELOAD tried to load them both:
`env LD_PRELOAD=/lib/aarch64-linux-gnu/libasan.so.8 /lib/aarch64-linux-gnu/libasan.so.6:  ...`

Even though libasan.so.6 was present, the linker stopped after finding libasan.so.8 and never reached the path to libasan.so.6. This resulted in error:
`env: ‘/lib/aarch64-linux-gnu/libasan.so.6:’ No such file or directory`