### PR TITLE
AZP: Remove git unshallow - v1.17.x

### DIFF
--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -42,7 +42,6 @@ jobs:
           az_module_load dev/mvn
           # use the lowest supported Java version for compatibility:
           az_module_load dev/jdk-1.8
-          git fetch --unshallow
           TAG=`git describe --tags`
           # Maven requires version to be of form MAJOR_VERSION.MINOR_VERSIOn,...
           # ucx tags are of form v1.x.x - need to remove 'v' from the beginning of string

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -47,7 +47,6 @@ jobs:
           az_init_modules
           az_module_load dev/mvn
           az_module_load dev/jdk-1.8
-          git fetch --unshallow
           TAG=`git describe --tags`
           MAVEN_VERSION=${TAG:1}
           make -C bindings/java/src/main/native/ publish-local \


### PR DESCRIPTION
## What
Remove git unshallow.

## Why ?
No longer needed and causes failure sometimes.

