### PR TITLE
CLANG-FORMAT:UCP/TAG: Minor fixes.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -128,7 +128,6 @@ FixNamespaceComments: true
 NamespaceIndentation: None
 UseTab: Never
 ReflowComments: false
-SortIncludes: false
 IncludeCategories:
  - Regex: '^"'
    Priority: 1

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -128,7 +128,7 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
         status = ucp_recv_desc_init(worker, data, length, 0, am_flags, hdr_len,
                                     flags, priv_length, 1, name, &rdesc);
         if (!UCS_STATUS_IS_ERR(status)) {
-            ucp_tag_unexp_recv(&worker->tm, rdesc, eager_hdr->super.tag);
+            ucp_tag_unexp_recv(&worker->tm, rdesc, recv_tag);
         }
     }
 


### PR DESCRIPTION
## What
Removed duplicated field from `.clang-format` file.
Used local variable assigned to the value of the structure's filed.