### PR TITLE
UCS/ASYNC: Skip released handler in poll missed process

### DIFF
--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -104,11 +104,27 @@ static inline uint64_t ucs_async_missed_event_pack(int id,
     return ((uint64_t)id << UCS_ASYNC_MISSED_QUEUE_SHIFT) | (uint32_t)events;
 }
 
+static inline int ucs_async_missed_event_unpack_id(uint64_t value)
+{
+    return value >> UCS_ASYNC_MISSED_QUEUE_SHIFT;
+}
+
+static inline int ucs_async_missed_event_unpack_events(uint64_t value)
+{
+    return value & UCS_ASYNC_MISSED_QUEUE_MASK;
+}
+
 static inline void ucs_async_missed_event_unpack(uint64_t value, int *id_p,
                                                  int *events_p)
 {
-    *id_p     = value >> UCS_ASYNC_MISSED_QUEUE_SHIFT;
-    *events_p = value & UCS_ASYNC_MISSED_QUEUE_MASK;
+    *id_p     = ucs_async_missed_event_unpack_id(value);
+    *events_p = ucs_async_missed_event_unpack_events(value);
+}
+
+static int ucs_async_missed_event_is_same(uint64_t value, void *arg)
+{
+    return ucs_async_missed_event_unpack_id(value) ==
+           ((ucs_async_handler_t *)arg)->id;
 }
 
 static void ucs_async_handler_hold(ucs_async_handler_t *handler)
@@ -530,6 +546,7 @@ err:
 ucs_status_t ucs_async_remove_handler(int id, int is_sync)
 {
     ucs_async_handler_t *handler;
+    ucs_async_context_t *async;
     ucs_status_t status;
 
     /* We can't find the async handle mode without taking a read lock, which in
@@ -566,6 +583,12 @@ ucs_status_t ucs_async_remove_handler(int id, int is_sync)
              * for the async handler to complete */
             sched_yield();
         }
+    }
+
+    async = handler->async;
+    if (async != NULL) {
+        ucs_mpmc_queue_remove_if(&async->missed, ucs_async_missed_event_is_same,
+                                 handler);
     }
 
     ucs_async_handler_put(handler);

--- a/src/ucs/datastruct/mpmc.h
+++ b/src/ucs/datastruct/mpmc.h
@@ -32,6 +32,17 @@ typedef struct ucs_mpmc_elem {
 
 
 /**
+ * MPMC queue element value predicate.
+ *
+ * @param [in] value MPMC queue element value to check.
+ * @param [in] arg   User-defined argument.
+ *
+ * @return Predicate result value - nonzero means "true", zero means "false".
+ */
+typedef int (*ucs_mpmc_queue_predicate_t)(uint64_t value, void *arg);
+
+
+/**
  * Initialize MPMC queue.
  *
  * @param length   Queue length.
@@ -62,6 +73,19 @@ ucs_status_t ucs_mpmc_queue_push(ucs_mpmc_queue_t *mpmc, uint64_t value);
  *                            or another thread removed the current item.
  */
 ucs_status_t ucs_mpmc_queue_pull(ucs_mpmc_queue_t *mpmc, uint64_t *value_p);
+
+
+/**
+ * Remove all elements from the MPMC queue with the given value for which the
+ * given predicate returns "true" (nonzero) value.
+ * This can be used from any context and any thread.
+ *
+ * @param  [in] mpmc      MPMC queue.
+ * @param  [in] predicate Predicate to check candidates for removal.
+ * @param  [in] arg       User-defined argument for the predicate.
+ */
+void ucs_mpmc_queue_remove_if(ucs_mpmc_queue_t *mpmc,
+                              ucs_mpmc_queue_predicate_t predicate, void *arg);
 
 
 /**

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -69,13 +69,12 @@ protected:
 
 class base_event : public base_async {
 public:
-    base_event(ucs_async_mode_t mode) : base_async(mode) {
-        ucs_status_t status = ucs_async_pipe_create(&m_event_pipe);
-        ASSERT_UCS_OK(status);
+    base_event(ucs_async_mode_t mode) : base_async(mode), m_event_valid(0) {
+        create_event();
     }
 
     virtual ~base_event() {
-        ucs_async_pipe_destroy(&m_event_pipe);
+        destroy_event();
     }
 
     void set_handler(ucs_async_context_t *async) {
@@ -95,8 +94,25 @@ public:
         ucs_async_pipe_push(&m_event_pipe);
     }
 
+    void push_event_if_valid() {
+        if (m_event_valid) {
+            push_event();
+        }
+    }
+
     void reset() {
         ucs_async_pipe_drain(&m_event_pipe);
+    }
+
+    void create_event() {
+        ucs_status_t status = ucs_async_pipe_create(&m_event_pipe);
+        ASSERT_UCS_OK(status);
+        EXPECT_EQ(0, ucs_atomic_cswap32(&m_event_valid, 0, 1));
+    }
+
+    void destroy_event() {
+        EXPECT_EQ(1, ucs_atomic_cswap32(&m_event_valid, 1, 0));
+        ucs_async_pipe_destroy(&m_event_pipe);
     }
 
 protected:
@@ -110,6 +126,7 @@ private:
     }
 
     ucs_async_pipe_t m_event_pipe;
+    volatile uint32_t m_event_valid;
 };
 
 class base_timer : public base_async {
@@ -222,11 +239,19 @@ class local_event : public local,
 {
 public:
     local_event(ucs_async_mode_t mode) : local(mode), base_event(mode) {
+        set_event();
+    }
+
+    void set_event() {
         set_handler(&m_async);
     }
 
-    ~local_event() {
+    void unset_event() {
         unset_handler();
+    }
+
+    ~local_event() {
+        unset_event();
     }
 };
 
@@ -349,10 +374,44 @@ protected:
         return result;
     }
 
-    void spawn() {
+    int repeat_create_destroy_run(unsigned index) {
+        static_assert(std::is_base_of<local_event, LOCAL>::value, "");
+        LOCAL le(GetParam());
+        m_ev[index] = &le;
+
+        check_is_blocked(&le, false);
+
+        barrier();
+
+        while (!m_stop[index]) {
+            le.block();
+            check_is_blocked(&le, true);
+            unsigned before = le.count();
+            suspend_and_poll(&le, 10);
+            unsigned after = le.count();
+            le.unblock();
+            EXPECT_EQ(before, after); /* Should not handle while blocked */
+
+            auto wait = ucs::rand() % 20;
+            le.unset_event();
+            le.destroy_event();
+            suspend(wait);
+            le.create_event(); /* same memory could be used by other thread */
+            le.set_event();
+            suspend(20 - wait);
+            le.check_miss();
+        }
+
+        check_is_blocked(&le, false);
+
+        m_ev[index] = NULL;
+        return le.count();
+    }
+
+    void spawn(void *(*f)(void*) = thread_func) {
         for (unsigned i = 0; i < NUM_THREADS; ++i) {
             m_stop[i] = false;
-            pthread_create(&m_threads[i], NULL, thread_func, (void*)this);
+            pthread_create(&m_threads[i], NULL, f, (void*)this);
         }
         barrier();
     }
@@ -399,6 +458,7 @@ private:
         pthread_barrier_wait(&m_barrier);
     }
 
+public:
     static void *thread_func(void *arg)
     {
         test_async_mt *self = reinterpret_cast<test_async_mt*>(arg);
@@ -413,6 +473,21 @@ private:
         return (void*)-1;
     }
 
+    static void *repeat_create_destroy_func(void *arg)
+    {
+        test_async_mt *self = reinterpret_cast<test_async_mt*>(arg);
+
+        for (unsigned index = 0; index < NUM_THREADS; ++index) {
+            if (self->m_threads[index] == pthread_self()) {
+                return (void*)(uintptr_t)self->repeat_create_destroy_run(index);
+            }
+        }
+
+        /* Not found */
+        return (void*)-1;
+    }
+
+private:
     pthread_t                      m_threads[NUM_THREADS];
     pthread_barrier_t              m_barrier;
     int                            m_thread_counts[NUM_THREADS];
@@ -809,6 +884,19 @@ UCS_TEST_SKIP_COND_P(test_async_event_mt, multithread,
         UCS_TEST_MESSAGE << "retry " << (retry + 1);
     }
     EXPECT_GE(min_count, exp_min_count);
+}
+
+UCS_TEST_SKIP_COND_P(test_async_event_mt, multithread_create_destroy,
+                     !(HAVE_DECL_F_SETOWN_EX)) {
+    spawn(repeat_create_destroy_func);
+    for (int j = 0; j < 4; ++j) {
+        for (unsigned i = 0; i < NUM_THREADS; ++i) {
+            event(i)->push_event_if_valid();
+        }
+        suspend(30);
+    }
+    suspend();
+    stop();
 }
 
 UCS_TEST_SKIP_COND_P(test_async_event_mt, check_blocks_multithread,


### PR DESCRIPTION
## What
Skip events in poll missed process if its handler has already been removed.

## Why ?
Async handler might be removed while events missed.
When the handler be called in poll missed process and same memory is reused by the other worker, the handler will try to access wrong resources.

## How ?
Set MPMC queue element's value to -1 if handler removed, then skip the events in poll missed process.
