### PR TITLE
UCS/SYS/TOPO: Added options to set distance between devices.

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -2,6 +2,7 @@
 CPU model=Grace
 UCX_REG_NONBLOCK_MEM_TYPES=host
 UCX_IB_MLX5_DEVX_OBJECTS=
+UCX_DISTANCE_BW=auto,sys:16500MBs
 
 [Fujitsu ARM]
 CPU vendor=Fujitsu ARM
@@ -12,3 +13,15 @@ UCX_IB_SEND_OVERHEAD=bcopy:5ns,cqe:50ns,db:400ns,wqe_fetch:350ns,wqe_post:100ns
 UCX_MM_SEND_OVERHEAD=am_short:40ns,am_bcopy:220ns
 UCX_MM_RECV_OVERHEAD=am_short:40ns,am_bcopy:220ns
 UCX_RCACHE_OVERHEAD=360ns
+
+[AMD Rome]
+CPU model=Rome
+UCX_DISTANCE_BW=auto,sys:5100MBs
+
+[AMD Milan]
+CPU model=Milan
+UCX_DISTANCE_BW=auto,sys:5100MBs
+
+[AMD Genoa]
+CPU model=Genoa
+UCX_DISTANCE_BW=auto,sys:5100MBs

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -74,6 +74,22 @@ static UCS_CONFIG_DEFINE_ARRAY(signo,
                                UCS_CONFIG_TYPE_SIGNO);
 
 
+#define UCS_DISTANCE_KEYS_DESCRIPTION(_field) \
+    {"phb", \
+     "connection traversing PCIe as well as a PCIe Host Bridge (typically " \
+     "the CPU)", \
+     ucs_offsetof(ucs_global_opts_t, dist.phb._field)}, \
+    {"node", \
+     "connection traversing PCIe as well as the interconnect between PCIe " \
+     "Host Bridges within a NUMA node", \
+     ucs_offsetof(ucs_global_opts_t, dist.node._field)}, \
+    {"sys", \
+     "connection traversing PCIe as well as the SMP interconnect between " \
+     "NUMA nodes", \
+     ucs_offsetof(ucs_global_opts_t, dist.sys._field)}, \
+    {NULL}
+
+
 static ucs_config_field_t ucs_global_opts_table[] = {
  {"LOG_LEVEL", "warn",
   "UCS logging level. Messages with a level higher or equal to the selected "
@@ -190,6 +206,16 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "Comma-separated list of providers for detecting system topology.\n"
   "The list order decides the priority of the providers.",
   ucs_offsetof(ucs_global_opts_t, topo_prio), UCS_CONFIG_TYPE_STRING_ARRAY},
+
+ {"DISTANCE_LAT", "phb:300ns,node:300ns,sys:500ns",
+  "Estimated latency between system devices", 0,
+  UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_TIME,
+                            UCS_DISTANCE_KEYS_DESCRIPTION(latency))},
+
+ {"DISTANCE_BW", "auto",
+  "Estimated bandwidth between system devices", 0,
+  UCS_CONFIG_TYPE_KEY_VALUE(UCS_CONFIG_TYPE_BW,
+                            UCS_DISTANCE_KEYS_DESCRIPTION(bandwidth))},
 
  {NULL}
 };

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -12,6 +12,7 @@
 #include <ucs/stats/stats_fwd.h>
 #include <ucs/type/status.h>
 #include <ucs/sys/compiler_def.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <ucs/arch/global_opts.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -147,6 +148,19 @@ typedef struct {
        values. */
     size_t                     rcache_stat_min;
     size_t                     rcache_stat_max;
+
+    /* Estimated latency and bandwidth between devices according to distance
+       within the sysfs device tree */
+    struct {
+        /* Connection traversing PCIe as well as a PCIe Host Bridge */
+        ucs_sys_dev_distance_t phb;
+        /* Connection traversing PCIe as well as the interconnect between PCIe
+           Host Bridges within a NUMA node */
+        ucs_sys_dev_distance_t node;
+        /* Connection traversing PCIe as well as the SMP interconnect between
+           NUMA nodes */
+        ucs_sys_dev_distance_t sys;
+    } dist;
 } ucs_global_opts_t;
 
 

--- a/src/ucs/memory/numa.h
+++ b/src/ucs/memory/numa.h
@@ -7,7 +7,10 @@
 #ifndef UCS_NUMA_H_
 #define UCS_NUMA_H_
 
+#include <ucs/sys/compiler_def.h>
 #include <stdint.h>
+
+BEGIN_C_DECLS
 
 #define UCS_NUMA_NODE_DEFAULT    0
 #define UCS_NUMA_NODE_UNDEFINED -1
@@ -65,5 +68,7 @@ ucs_numa_node_t ucs_numa_node_of_device(const char *dev_path);
  */
 ucs_numa_distance_t
 ucs_numa_distance(ucs_numa_node_t node1, ucs_numa_node_t node2);
+
+END_C_DECLS
 
 #endif


### PR DESCRIPTION
## What
Added options to set estimated latency and bandwidth values according to the distance within the sysfs device tree.
Moved platform specific values to `ucx.conf` file.
