### PR TITLE
GTEST: Do not run memtype RMA tests with protov1

### DIFF
--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -371,7 +371,8 @@ protected:
     }
 
     bool host_only() {
-        return get_variant_value() & NON_BLOCK;
+        // RMA does not support non-host memory with proto v1
+        return (get_variant_value() & NON_BLOCK) || !is_proto_enabled();
     }
 
 private:


### PR DESCRIPTION
## What
Do not run RMA tests using non-host memory with proto v1, because it is supported with new protocols only

## Why
Fixes CI issues, like:
```
[ RUN      ] rc/test_ucp_rma_reg.get_nonblocking/3 <rc_v,cuda_copy,rocm_copy/no_rcache>
[     INFO ] host->host 5x128 5x1002 5x17880 5x50841 5x2538190 
[swx-rain03:66984:0:66984] Caught signal 11 (Segmentation fault: invalid permissions for mapped object at address 0x7f3a78e00400)
==== backtrace (tid:  66984) ====
 0 0x0000000000155875 __memcpy_ssse3_back()  :0
 1 0x000000000003a345 uct_rc_ep_get_bcopy_handler()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/base/rc_ep.c:293
 2 0x000000000003a345 ucs_mpool_obj_owner()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/mpool.inl:69
 3 0x000000000003a345 uct_rc_op_release_get_bcopy()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/base/rc_ep.c:269
 4 0x000000000003a345 uct_rc_ep_get_bcopy_handler()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/base/rc_ep.c:295
 5 0x0000000000046aad uct_rc_txqp_completion_op()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/base/rc_ep.h:441
 6 0x0000000000046aad uct_rc_txqp_completion_desc()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/base/rc_ep.h:450
 7 0x0000000000046aad uct_rc_verbs_iface_poll_tx()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/verbs/rc_verbs_iface.c:178
 8 0x0000000000046aad uct_rc_verbs_iface_progress()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/rc/verbs/rc_verbs_iface.c:199
 9 0x00000000000752e2 ucs_callbackq_dispatch()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/callbackq.h:215
10 0x00000000000752e2 uct_worker_progress()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/uct/api/uct.h:2787
11 0x00000000000752e2 ucp_worker_progress()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_worker.c:3027
12 0x0000000000b0b3ac ucp_test_base::entity::progress()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/ucp_test.cc:1043
13 0x0000000000b0c9ff ucp_test::progress()  /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/ucp_test.cc:167
```
