### PR TITLE
GTEST/UCP/TAG: Avoid transfer timeouts on CI for BF

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_match.cc
+++ b/test/gtest/ucp/test_ucp_tag_match.cc
@@ -856,7 +856,7 @@ UCS_TEST_P(test_ucp_tag_match_rndv, req_exp_auto_thresh, "RNDV_THRESH=auto") {
 
 UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
     const std::vector<size_t> sizes = {1000, 2000, 8000,
-                                       ucs::limit_buffer_size(2500ul *
+                                       ucs::limit_buffer_size(250ul *
                                                               UCS_MBYTE),
                                        ucs::limit_buffer_size(UCS_GBYTE + 32)};
 
@@ -865,6 +865,8 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
         const size_t size = c_size / ucs::test_time_multiplier() /
                             ucs::test_time_multiplier();
         request *my_send_req, *my_recv_req;
+
+        UCS_TEST_MESSAGE << size << " bytes (c_size=" << c_size << ")";
 
         std::vector<char> sendbuf(size, 0);
         std::vector<char> recvbuf(size, 0);
@@ -881,6 +883,7 @@ UCS_TEST_P(test_ucp_tag_match_rndv, exp_huge_mix) {
 
         wait(my_recv_req);
 
+        EXPECT_EQ(UCS_OK,              my_recv_req->status);
         EXPECT_EQ(sendbuf.size(),      my_recv_req->info.length);
         EXPECT_EQ((ucp_tag_t)0x111337, my_recv_req->info.sender_tag);
         EXPECT_TRUE(my_recv_req->completed);


### PR DESCRIPTION
## What
Improve asserts and remove 2.5GB transfer from test, which is causing issue on BF likely with many tests in parallel.

## How ?
Expectation failure is actually due to a transport retry count failure. Also with the provided `param->recv.cb`, `req->info` content is only valid when `status == UCS_OK`.

### Symptom
```
[ RUN      ] dcx/test_ucp_tag_match_rndv.exp_huge_mix/0 <dc_x/rndv_auto>
...
Expected equality of these values:
  sendbuf.size()
    Which is: 2064117248
  my_recv_req->info.length
    Which is: 8000
...
Expected equality of these values:
  sendbuf
    Which is: { 'B' (66, 0x42), 'k' (107, 0x6B), '\x12' (18), '\x6' (6), '\0', '\0', '\0', '\0', '\xA5' (165), '0' (48, 0x30), '\xB8' (184), '<' (60, 0x3C), '\0', '\0', '\0', '\0', '\x83' (131), '\xE6' (230), '1' (49, 0x31), '_' (95, 0x5F), '\x2' (2), '\0', '\0', '\0', '/' (47, 0x2F), '\x1' (1), '\xF3' (243), '\xB7' (183), '\x17' (23), '\0', '\0', '\0', ... }
  recvbuf
    Which is: { 'B' (66, 0x42), 'k' (107, 0x6B), '\x12' (18), '\x6' (6), '\0', '\0', '\0', '\0', '\xA5' (165), '0' (48, 0x30), '\xB8' (184), '<' (60, 0x3C), '\0', '\0', '\0', '\0', '\x83' (131), '\xE6' (230), '1' (49, 0x31), '_' (95, 0x5F), '\x2' (2), '\0', '\0', '\0', '/' (47, 0x2F), '\x1' (1), '\xF3' (243), '\xB7' (183), '\x17' (23), '\0', '\0', '\0', ... }

```
### With debugs
```
UCX  DIAG  Transport retry count exceeded on mlx5_0:1/RoCE (synd 0x15 vend 0x81 hw_synd 0/0)
UCX  DIAG  DCI QP 0x9485 wqe[17]: RDMA_READ s-- [rqpn 0x9517 rmac 58:a2:e1:84:b0:46 sgix 3 dgid ::ffff:1.11.11.2 tc 106] [rva 0xffff4dd39200 rkey 0x61600] [va 0xfffed2cba200 len 721939472 lkey 0x67e00]
```