### PR TITLE
UCP/AM: Limit active message id to uint16_t

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1881,6 +1881,7 @@ typedef struct ucp_am_handler_param {
 
     /**
      * Active Message id.
+     * @warning Value must be between 0 and UINT16_MAX.
      */
     unsigned                 id;
 


### PR DESCRIPTION
## What
When registering an AM handler, ensure the id fits within the `uint16_t` range.

## Why ?
The AM API accepts the AM handler id as an `unsigned int`, but internally the id is constrained to `uint16_t`. This difference can cause multiple ids (up to 2^16) to map to the same internal id, ultimately referring to the same AM handler (the last one registered).

## How ?
When registering AM handler, ensure `param->id`'s 16 msb are not set. If any of them are non-zero, the function returns an error.
