### PR TITLE
UCS/PARSER: Fix time units description

### DIFF
--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -389,12 +389,12 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_TIME       {ucs_config_sscanf_time,      ucs_config_sprintf_time, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \
                                     ucs_config_help_generic,     ucs_config_doc_nop, \
-                                    "time value: <number>[s|us|ms|ns]"}
+                                    "time value: <number>[m|s|ms|us|ns]"}
 
 #define UCS_CONFIG_TYPE_TIME_UNITS {ucs_config_sscanf_time_units, ucs_config_sprintf_time_units, \
                                     ucs_config_clone_ulong,       ucs_config_release_nop, \
                                     ucs_config_help_generic,      ucs_config_doc_nop, \
-                                    "time value: <number>[s|us|ms|ns], \"inf\", or \"auto\""}
+                                    "time value: <number>[m|s|ms|us|ns], \"inf\", or \"auto\""}
 
 #define UCS_CONFIG_TYPE_BW         {ucs_config_sscanf_bw,        ucs_config_sprintf_bw, \
                                     ucs_config_clone_double,     ucs_config_release_nop, \


### PR DESCRIPTION
## What
Add minutes as possible  value to the time units description in parser.
Also change order of time units from largest to smallest (change positions of `us` and `ms`)

**Before**
```
[mikhailb@rock18 ucx-tmp]$ ucx_info -f | grep -B 5 KEEPALIVE_INTERVAL
# Time interval between keepalive rounds. Must be non-zero value.
#
#
# syntax:    time value: <number>[s|us|ms|ns], "inf", or "auto"
#
UCX_KEEPALIVE_INTERVAL=20000000.00us
[mikhailb@rock18 ucx-tmp]$ ucx_info -f | grep -B 5 UCX_RDMA_CM_TIMEOUT
# Timeout for RDMA address and route resolve operations
#
#
# syntax:    time value: <number>[s|us|ms|ns]
#
UCX_RDMA_CM_TIMEOUT=10000000.00us
```
**After**
```
[mikhailb@rock18 ucx-tmp]$ ./src/tools/info/ucx_info -f | grep -B 5 KEEPALIVE_INTERVAL
# Time interval between keepalive rounds. Must be non-zero value.
#
#
# syntax:    time value: <number>[m|s|ms|us|ns], "inf", or "auto"
#
UCX_KEEPALIVE_INTERVAL=20000000.00us
[mikhailb@rock18 ucx-tmp]$ ./src/tools/info/ucx_info -f | grep -B 5 UCX_RDMA_CM_TIMEOUT
# Timeout for RDMA address and route resolve operations
#
#
# syntax:    time value: <number>[m|s|ms|us|ns]
#
UCX_RDMA_CM_TIMEOUT=10000000.00us

```