### PR TITLE
AZP: Disable wire-compat tests on rain machines

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -290,10 +290,11 @@ stages:
       parameters:
         name: new
         demands: ucx_new -equals yes
-    - template: wire_compat.yml
-      parameters:
-        name: bond
-        demands: ucx_iodemo -equals yes
+    # Temporaly disable wire-compat tests on rain machines
+    #- template: wire_compat.yml
+    #  parameters:
+    #    name: bond
+    #    demands: ucx_iodemo -equals yes
 
   - stage: Coverity
     dependsOn: [Static_check]


### PR DESCRIPTION
## What
Temporarily disable wirecompatibility tests on rain machines. The test fails due to long standing issue when RMA BW lanes performance is estimated differently in selection score function and during lanes creation in `ucp_wireup_add_rma_bw_lanes`.


## Why ?
To unblock CI