### PR TITLE
BUILD/CONFIGURE: enforce 8KB stack threshold on compilation

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -451,6 +451,23 @@ AS_IF([test "x$enable_gcov" = xyes],
 
 
 #
+# Enable stack usage check
+#
+AC_ARG_ENABLE([stack-usage-check],
+        AS_HELP_STRING([--enable-stack-usage-check], [Enable stack usage check with -Wframe-larger-than=8192]),
+        [],
+        [enable_stack_usage_check=yes])
+
+AS_IF([test "x$enable_stack_usage_check" = xyes],
+      [AS_IF([test "x$enable_asan" = xyes],
+             [AC_MSG_NOTICE([Stack usage check was not added because ASAN is enabled])],
+             [ADD_COMPILER_FLAG_IF_SUPPORTED([stack_usage_check],
+                                             [-Wframe-larger-than=8192],
+                                             [AC_LANG_SOURCE([[int main(int argc, char** argv) { return 0; }]])])])],
+      [AC_MSG_NOTICE([Stack usage check is disabled])])
+
+
+#
 # Check for C++ support
 #
 CHECK_CXX_COMP()


### PR DESCRIPTION
## What?
Improves stack memory usage by introducing an 8KB threshold for stack frames using the GCC flag `-Wframe-larger-than=8192`. The fixes for functions that exceed this limit were merged:
- [x] https://github.com/openucx/ucx/pull/10128
- [x] https://github.com/openucx/ucx/pull/10157
- [x] https://github.com/openucx/ucx/pull/10130
- [x] https://github.com/openucx/ucx/pull/10131
- [x] https://github.com/openucx/ucx/pull/10127
- [x] https://github.com/openucx/ucx/pull/10274

## Why?
Customers with limited stack sizes have recently experienced stack overflow issues when running UCX.
The goal is to ensure that the entire UCX runs within a defined stack size threshold.
Mitigates the risk of stack overflow, particularly in environments with limited stack sizes.

## How?
- [x] Include -Wframe-larger-than=8192 in the build configuration to trigger warnings for large stack frames.
- [x] Review and refactor functions with large stack frames or move large variables to the heap.