### PR TITLE
UCT/IB: Retry ODP registration unlimitedly

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -158,9 +158,9 @@ ucs_config_field_t uct_ib_md_config_table[] = {
      "Maximal number of invalidated memory keys that are kept idle before reuse.",
      ucs_offsetof(uct_ib_md_config_t, ext.max_idle_rkey_count), UCS_CONFIG_TYPE_UINT},
 
-    {"REG_RETRY_CNT", "7",
+    {"REG_RETRY_CNT", "inf",
      "Number of memory registration attempts.",
-     ucs_offsetof(uct_ib_md_config_t, ext.reg_retry_cnt), UCS_CONFIG_TYPE_UINT},
+     ucs_offsetof(uct_ib_md_config_t, ext.reg_retry_cnt), UCS_CONFIG_TYPE_ULUNITS},
 
     {"SMKEY_BLOCK_SIZE", "8",
      "Number of indexes in a symmetric block. More can lead to less contention.",
@@ -462,7 +462,7 @@ ucs_status_t uct_ib_reg_mr(uct_ib_md_t *md, void *address, size_t length,
                            struct ibv_mr **mr_p)
 {
     ucs_time_t UCS_V_UNUSED start_time = ucs_get_time();
-    unsigned retry                     = 0;
+    unsigned long retry                = 0;
     size_t UCS_V_UNUSED dmabuf_offset;
     const char *title;
     struct ibv_mr *mr;
@@ -511,7 +511,7 @@ ucs_status_t uct_ib_reg_mr(uct_ib_md_t *md, void *address, size_t length,
     }
 
     ucs_trace("%s(pd=%p addr=%p len=%zu fd=%d offset=%zu access=0x%" PRIx64 "):"
-              " mr=%p lkey=0x%x retry=%d took %.3f ms",
+              " mr=%p lkey=0x%x retry=%lu took %.3f ms",
               title, md->pd, address, length, dmabuf_fd, dmabuf_offset,
               access_flags, mr, mr->lkey, retry,
               ucs_time_to_msec(ucs_get_time() - start_time));
@@ -541,7 +541,7 @@ ucs_status_t uct_ib_mem_prefetch(uct_ib_md_t *md, uct_ib_mem_t *ib_memh,
                                  void *addr, size_t length)
 {
 #if HAVE_DECL_IBV_ADVISE_MR
-    unsigned retry = 0;
+    unsigned long retry = 0;
     struct ibv_sge sg_list;
     int ret;
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -94,7 +94,7 @@ typedef struct uct_ib_md_ext_config {
                                                        invalidated memory keys
                                                        that are kept idle before
                                                        reuse*/
-    unsigned                 reg_retry_cnt; /**< Memory registration retry count */
+    unsigned long            reg_retry_cnt; /**< Memory registration retry count */
     unsigned                 smkey_block_size; /**< Mkey indexes in a symmetric block */
 } uct_ib_md_ext_config_t;
 


### PR DESCRIPTION
## What
Keep trying to register memory. If it return EAGAIN it means following registration should succeed.

