### PR TITLE
UCS/TIME: Fix undeclared INFINITY error in ucs_time_units_to_sec()

### DIFF
--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -11,6 +11,7 @@
 #include <ucs/time/time_def.h>
 #include <sys/time.h>
 #include <limits.h>
+#include <math.h>
 
 BEGIN_C_DECLS
 


### PR DESCRIPTION
Included <math.h> in ucs_time_units_to_sec() to resolve compilation errors due to missing INFINITY constant.

Fixes the following build issue:

```
 /ompi-mtt/ucx/src/ucs/time/time.h: In function ‘ucs_time_units_to_sec’:
 /ompi-mtt/ucx/src/ucs/time/time.h:165:16: error: ‘INFINITY’ undeclared (first use in this function); did you mean ‘NFDBITS’?
         return INFINITY;
                ^~~~~~~~
                NFDBITS
 /ompi-mtt/ucx/src/ucs/time/time.h:165:16: note: each undeclared identifier is reported only once for each function it appears in
In file included from  /ompi-mtt/ucx/src/ucm/util/sys.h:13,
                 from  /ompi-mtt/ucx/src/ucm/bistro/bistro_int.h:16,
                 from bistro/bistro.c:18:
 /ompi-mtt/ucx/src/ucs/time/time.h: In function ‘ucs_time_units_to_sec’:
 /ompi-mtt/ucx/src/ucs/time/time.h:165:16: error: ‘INFINITY’ undeclared (first use in this function); did you mean ‘NFDBITS’?
         return INFINITY;
                ^~~~~~~~
                NFDBITS
 /ompi-mtt/ucx/src/ucs/time/time.h:165:16: note: each undeclared identifier is reported only once for each function it appears in
In file included from  /ompi-mtt/ucx/src/ucm/util/sys.h:13,
                 from util/replace.c:20:
 /ompi-mtt/ucx/src/ucs/time/time.h: In function ‘ucs_time_units_to_sec’:
 /ompi-mtt/ucx/src/ucs/time/time.h:165:16: error: ‘INFINITY’ undeclared (first use in this function); did you mean ‘NFDBITS’?
         return INFINITY;
                ^~~~~~~~
                NFDBITS
```
