### PR TITLE
UCP/PROTO: Extend ucp_proto_perf structure interfaces

### DIFF
--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -28,7 +28,7 @@
     ((_perf_func)->m != 0.0) ? (1.0 / ((_perf_func)->m * UCS_MBYTE)) : INFINITY
 
 /* Format string to display a protocol performance function */
-#define UCP_PROTO_PERF_FUNC_FMT(_perf_var) " " #_perf_var ": " \
+#define UCP_PROTO_PERF_FUNC_FMT \
     UCP_PROTO_PERF_FUNC_TIME_FMT " ns/KB, " \
     UCP_PROTO_PERF_FUNC_BW_FMT " MB/s"
 #define UCP_PROTO_PERF_FUNC_ARG(_perf_func) \
@@ -38,9 +38,9 @@
 /* Format string to display a protocol performance estimations
  * of different types. See ucp_proto_perf_type_t */
 #define UCP_PROTO_PERF_FUNC_TYPES_FMT \
-    UCP_PROTO_PERF_FUNC_FMT(single) \
-    UCP_PROTO_PERF_FUNC_FMT(multi) \
-    UCP_PROTO_PERF_FUNC_FMT(cpu)
+    "single: " UCP_PROTO_PERF_FUNC_FMT \
+    "multi: " UCP_PROTO_PERF_FUNC_FMT \
+    "cpu: " UCP_PROTO_PERF_FUNC_FMT
 #define UCP_PROTO_PERF_FUNC_TYPES_ARG(_perf_func) \
     UCP_PROTO_PERF_FUNC_ARG((&(_perf_func)[UCP_PROTO_PERF_TYPE_SINGLE])), \
     UCP_PROTO_PERF_FUNC_ARG((&(_perf_func)[UCP_PROTO_PERF_TYPE_MULTI])), \
@@ -95,6 +95,10 @@ void ucp_proto_config_info_str(ucp_worker_h worker,
                                const ucp_proto_config_t *proto_config,
                                size_t msg_length, ucs_string_buffer_t *strb);
 
+ucp_proto_perf_node_t *
+ucp_proto_perf_node_new(ucp_proto_perf_node_type_t type,
+                        unsigned selected_child, const char *name,
+                        const char *desc_fmt, va_list ap);
 
 ucp_proto_perf_node_t *
 ucp_proto_perf_node_new_data(const char *name, const char *desc_fmt, ...);

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -25,6 +25,9 @@
  */
 #define UCP_PROTO_MSGLEN_EPSILON   0.5
 
+const char *ucp_envelope_convex_names[] = {"concave envelope",
+                                           "convex envelope"};
+
 void ucp_proto_common_add_ppln_range(ucp_proto_caps_t *caps,
                                      const ucp_proto_perf_range_t *frag_range,
                                      size_t max_length)
@@ -107,13 +110,11 @@ void ucp_proto_perf_range_add_data(const ucp_proto_perf_range_t *range)
 }
 
 ucs_status_t
-ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
+ucp_proto_perf_envelope_make(const ucs_linear_func_t *funcs, uint64_t funcs_num,
                              size_t range_start, size_t range_end, int convex,
                              ucp_proto_perf_envelope_t *envelope_list)
 {
-    const ucs_linear_func_t *perf_list_ptr = ucs_array_begin(perf_list);
-    const unsigned perf_list_length        = ucs_array_length(perf_list);
-    size_t start                           = range_start;
+    size_t start = range_start;
     char num_str[64];
     struct {
         unsigned index;
@@ -125,20 +126,25 @@ ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
     double x_sample, x_intersect;
     uint64_t mask;
 
-    ucs_assert_always(perf_list_length < 64);
-    mask = UCS_MASK(perf_list_length);
+    ucs_assertv_always((funcs_num > 0) && (funcs_num < 64),
+                       "funcs_num=%zu", funcs_num);
+    mask = UCS_MASK(funcs_num);
 
     do {
-        ucs_assert(mask != 0);
-
         /* Find best trend at the 'start' point */
         best.index  = UINT_MAX;
         best.result = DBL_MAX;
+        x_sample    = start;
+        if (x_sample < range_end) {
+            x_sample += UCP_PROTO_MSGLEN_EPSILON;
+        }
         ucs_for_each_bit(curr.index, mask) {
-            x_sample    = start + UCP_PROTO_MSGLEN_EPSILON;
-            curr.result = ucs_linear_func_apply(perf_list_ptr[curr.index],
-                                                x_sample);
-            ucs_assert(curr.result != DBL_MAX);
+            curr.result = ucs_linear_func_apply(funcs[curr.index], x_sample);
+            ucs_assertv((curr.result != DBL_MAX) && !isnan(curr.result),
+                        "curr.index=%u curr.result=%f x_sample=%f "
+                        "funcs[curr.index]="UCP_PROTO_PERF_FUNC_FMT,
+                        curr.index, curr.result, x_sample,
+                        UCP_PROTO_PERF_FUNC_ARG(&funcs[curr.index]));
             if ((best.index == UINT_MAX) ||
                 ((curr.result < best.result) == convex)) {
                 best = curr;
@@ -159,13 +165,14 @@ ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
         midpoint = range_end;
         mask    &= ~UCS_BIT(best.index);
         ucs_for_each_bit(curr.index, mask) {
-            status = ucs_linear_func_intersect(perf_list_ptr[curr.index],
-                                               perf_list_ptr[best.index],
-                                               &x_intersect);
-            if ((status == UCS_OK) && (x_intersect > start)) {
-                /* We care only if the intersection is after 'start', since
-                 * otherwise 'best' is better than 'curr' at
-                 * 'end' as well as at 'start'.
+            status = ucs_linear_func_intersect(funcs[curr.index],
+                                               funcs[best.index], &x_intersect);
+            if ((status == UCS_OK) && (x_intersect > x_sample)) {
+                /* We care only if the intersection is after 'x_sample', since
+                 * otherwise 'best' is better than 'curr' at 'end' as well as
+                 * at 'x_sample'. Since 'x_sample' differs from start only
+                 * for 0.5 we make an estimation and set it as 'best' for
+                 * 'start' as well.
                  */
                 midpoint = ucs_min(ucs_double_to_sizet(x_intersect, SIZE_MAX),
                                    midpoint);
@@ -227,7 +234,7 @@ ucp_proto_init_parallel_stages(const char *proto_name, size_t range_start,
         *perf_elem = (*stage_elem)->perf[UCP_PROTO_PERF_TYPE_MULTI];
 
         ucs_trace("stage[%zu] %s " UCP_PROTO_PERF_FUNC_TYPES_FMT
-                  UCP_PROTO_PERF_FUNC_FMT(perf_elem),
+                  UCP_PROTO_PERF_FUNC_FMT,
                   stage_elem - stages,
                   ucp_proto_perf_node_name((*stage_elem)->node),
                   UCP_PROTO_PERF_FUNC_TYPES_ARG((*stage_elem)->perf),
@@ -240,8 +247,9 @@ ucp_proto_init_parallel_stages(const char *proto_name, size_t range_start,
     *perf_elem = sum_cpu_perf;
 
     /* Multi-fragment is pipelining overheads and network transfer */
-    status = ucp_proto_perf_envelope_make(&stage_list, range_start, range_end,
-                                          0, &concave);
+    status = ucp_proto_perf_envelope_make(ucs_array_begin(&stage_list),
+                                          ucs_array_length(&stage_list),
+                                          range_start, range_end, 0, &concave);
     if (status != UCS_OK) {
         goto out;
     }
@@ -336,7 +344,7 @@ void ucp_proto_init_memreg_time(const ucp_proto_common_init_params_t *params,
         md_attr = &context->tl_mds[md_index].attr;
         md_name = context->tl_mds[md_index].rsc.md_name;
         ucs_linear_func_add_inplace(memreg_time, md_attr->reg_cost);
-        ucs_trace("md %s" UCP_PROTO_PERF_FUNC_FMT(reg_cost), md_name,
+        ucs_trace("md %s reg_cost: " UCP_PROTO_PERF_FUNC_FMT, md_name,
                   UCP_PROTO_PERF_FUNC_ARG(&md_attr->reg_cost));
 
         ucp_proto_perf_node_add_data(perf_node, md_name, md_attr->reg_cost);

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -27,6 +27,10 @@ UCS_ARRAY_DECLARE_TYPE(ucp_proto_perf_list_t, unsigned, ucs_linear_func_t);
 UCS_ARRAY_DECLARE_TYPE(ucp_proto_perf_ranges_t, unsigned,
                        ucp_proto_perf_range_t);
 
+
+extern const char *ucp_envelope_convex_names[];
+
+
 /**
  * Add a "pipelined performance" range, which represents the send time of
  * multiples fragments. 'frag_range' is the time to send a single fragment.
@@ -48,8 +52,9 @@ void ucp_proto_perf_range_add_data(const ucp_proto_perf_range_t *range);
  * Accepts a list of performance functions for a given range and appends the
  * convex or concave envelope of these functions to an output list.
  *
- * @param [in] perf_list       List of performance functions.
- * @param [in] range_start     Range interval start.
+ * @param [in] funcs           Array of performance functions.
+ * @param [in] funcs_num       Number of functions in list.
+ *                             should be considered during envelope calculation.
  * @param [in] range_end       Range interval end.
  * @param [in] convex          Whether to select convex (maximal) or concave
  *                             (minimal) function from 'perf_list'.
@@ -58,7 +63,7 @@ void ucp_proto_perf_range_add_data(const ucp_proto_perf_range_t *range);
  *                             which it corresponds.
  */
 ucs_status_t
-ucp_proto_perf_envelope_make(const ucp_proto_perf_list_t *perf_list,
+ucp_proto_perf_envelope_make(const ucs_linear_func_t *funcs, uint64_t funcs_num,
                              size_t range_start, size_t range_end, int convex,
                              ucp_proto_perf_envelope_t *envelope_list);
 

--- a/src/ucp/proto/proto_perf.c
+++ b/src/ucp/proto/proto_perf.c
@@ -10,6 +10,7 @@
 
 #include "proto_perf.h"
 #include "proto_debug.h"
+#include "proto_init.h"
 
 #include <ucs/datastruct/list.h>
 #include <ucs/debug/log.h>
@@ -20,19 +21,19 @@
 
 struct ucp_proto_perf_segment {
     /* List element */
-    ucs_list_link_t       list;
+    ucs_list_link_t          list;
 
     /* Start value of this segment (inclusive) */
-    size_t                start;
+    size_t                   start;
 
     /* End value of this segment (inclusive) */
-    size_t                end;
+    size_t                   end;
 
     /* Associacted performance node */
-    ucp_proto_perf_node_t *node;
+    ucp_proto_perf_node_t    *node;
 
     /* Linear function representing value of each contributing factor */
-    ucs_linear_func_t     factors[UCP_PROTO_PERF_FACTOR_LAST];
+    ucp_proto_perf_factors_t perf_factors;
 };
 
 /*
@@ -53,34 +54,50 @@ struct ucp_proto_perf {
     ucs_list_for_each((_seg), &(_perf)->segments, list)
 
 static const char *ucp_proto_perf_factor_names[] = {
-    [UCP_PROTO_PERF_FACTOR_LOCAL_CPU]  = "cpu",
-    [UCP_PROTO_PERF_FACTOR_REMOTE_CPU] = "rem_cpu",
-    [UCP_PROTO_PERF_FACTOR_LOCAL_TL]   = "tl",
-    [UCP_PROTO_PERF_FACTOR_REMOTE_TL]  = "rem_tl",
-    [UCP_PROTO_PERF_FACTOR_LATENCY]    = "lat",
-    [UCP_PROTO_PERF_FACTOR_SINGLE]     = "sngl",
-    [UCP_PROTO_PERF_FACTOR_MULTI]      = "mult",
-    [UCP_PROTO_PERF_FACTOR_LAST]       = NULL
+    [UCP_PROTO_PERF_FACTOR_LOCAL_CPU]         = "cpu",
+    [UCP_PROTO_PERF_FACTOR_REMOTE_CPU]        = "cpu-remote",
+    [UCP_PROTO_PERF_FACTOR_LOCAL_TL]          = "tl",
+    [UCP_PROTO_PERF_FACTOR_REMOTE_TL]         = "tl-remote",
+    [UCP_PROTO_PERF_FACTOR_LOCAL_MTYPE_COPY]  = "mtcopy",
+    [UCP_PROTO_PERF_FACTOR_REMOTE_MTYPE_COPY] = "mtcopy-remote",
+    [UCP_PROTO_PERF_FACTOR_LATENCY]           = "lat",
+    [UCP_PROTO_PERF_FACTOR_LAST]              = NULL
 };
 
 static void ucp_proto_perf_check(const ucp_proto_perf_t *perf)
 {
 #if ENABLE_ASSERT
+    ucs_string_buffer_t funcb = UCS_STRING_BUFFER_INITIALIZER;
+    const char *reason        = NULL;
     const ucp_proto_perf_segment_t *seg;
     size_t min_start;
 
+    ucs_assert(perf != NULL);
+
     min_start = 0;
     ucp_proto_perf_segment_foreach(seg, perf) {
-        ucs_assertv((seg->start >= min_start) && (seg->start <= seg->end),
-                    "perf=%p seg->start=%zu seg->end=%zu min_start=%zu", perf,
-                    seg->start, seg->end, min_start);
-        if (seg->end == SIZE_MAX) {
-            ucs_assertv(ucs_list_is_last(&perf->segments, &seg->list),
-                        "perf=%p seg->start=%zu seg->end=%zu", perf, seg->start,
-                        seg->end);
-        } else {
-            min_start = seg->end + 1;
+        if (seg->start < min_start) {
+            reason = "seg->start < min_start";
+            break;
         }
+        if (seg->start > seg->end) {
+            reason = "seg->start > seg->end";
+            break;
+        }
+        if (seg->end < SIZE_MAX) {
+            min_start = seg->end + 1;
+        } else if (!ucs_list_is_last(&perf->segments, &seg->list)) {
+            reason = "!ucs_list_is_last(&perf->segments, &seg->list)";
+            break;
+        }
+    }
+
+    if (reason != NULL) {
+        ucp_proto_perf_str(perf, &funcb);
+        ucs_fatal("%s seg=[%zu, %zu] min_start=%zu\nperf=%p name=%s %s",
+                  reason, seg->start, seg->end, min_start, perf, perf->name,
+                  ucs_string_buffer_cstr(&funcb));
+        ucs_string_buffer_cleanup(&funcb);
     }
 #endif
 }
@@ -99,12 +116,13 @@ static ucs_status_t ucp_proto_perf_segment_new(const ucp_proto_perf_t *perf,
         return UCS_ERR_NO_MEMORY;
     }
 
+    for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST; factor_id++) {
+        seg->perf_factors[factor_id] = UCS_LINEAR_FUNC_ZERO;
+    }
+
     seg->start = start;
     seg->end   = end;
     seg->node  = NULL;
-    for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST; factor_id++) {
-        seg->factors[factor_id] = UCS_LINEAR_FUNC_ZERO;
-    }
 
     *seg_p = seg;
     return UCS_OK;
@@ -127,7 +145,7 @@ static ucs_status_t ucp_proto_perf_segment_split(const ucp_proto_perf_t *perf,
     }
 
     for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST; factor_id++) {
-        new_seg->factors[factor_id] = seg->factors[factor_id];
+        new_seg->perf_factors[factor_id] = seg->perf_factors[factor_id];
     }
     new_seg->node = ucp_proto_perf_node_dup(seg->node);
 
@@ -137,28 +155,45 @@ static ucs_status_t ucp_proto_perf_segment_split(const ucp_proto_perf_t *perf,
     return UCS_OK;
 }
 
-static void ucp_proto_perf_segment_add_funcs(
-        ucp_proto_perf_t *perf, ucp_proto_perf_segment_t *seg,
-        const ucs_linear_func_t funcs[UCP_PROTO_PERF_FACTOR_LAST],
-        uint64_t factors_bitmap, ucp_proto_perf_node_t *perf_node)
+static void
+ucp_proto_perf_node_update_factors(ucp_proto_perf_node_t *perf_node,
+                                   const ucp_proto_perf_factors_t perf_factors)
 {
-    unsigned factor_id;
+    ucp_proto_perf_factor_id_t factor_id;
+    ucs_linear_func_t perf_factor;
 
-    /* Create a performance node for this segment if it does not exist yet */
+    /* Add the functions to the segment and the performance node */
+    for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST; ++factor_id) {
+        perf_factor = perf_factors[factor_id];
+        if (ucs_linear_func_is_zero(perf_factor, UCP_PROTO_PERF_EPSILON)) {
+            continue;
+        }
+
+        ucp_proto_perf_node_update_data(perf_node,
+                                        ucp_proto_perf_factor_names[factor_id],
+                                        perf_factors[factor_id]);
+    }
+}
+
+static void
+ucp_proto_perf_segment_add_funcs(ucp_proto_perf_t *perf,
+                                 ucp_proto_perf_segment_t *seg,
+                                 const ucp_proto_perf_factors_t perf_factors,
+                                 ucp_proto_perf_node_t *perf_node)
+{
+    ucp_proto_perf_factor_id_t factor_id;
+
     if (seg->node == NULL) {
         seg->node = ucp_proto_perf_node_new_data(perf->name, "");
     }
 
     /* Add the functions to the segment and the performance node */
-    ucs_for_each_bit(factor_id, factors_bitmap) {
-        ucs_assert(factor_id < UCP_PROTO_PERF_FACTOR_LAST); /* For Coverity */
-        ucs_linear_func_add_inplace(&seg->factors[factor_id], funcs[factor_id]);
-        ucp_proto_perf_node_update_data(seg->node,
-                                        ucp_proto_perf_factor_names[factor_id],
-                                        seg->factors[factor_id]);
+    for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST; ++factor_id) {
+        ucs_linear_func_add_inplace(&seg->perf_factors[factor_id],
+                                    perf_factors[factor_id]);
     }
 
-    /* Add the child performance node to the segment performance node */
+    ucp_proto_perf_node_update_factors(seg->node, seg->perf_factors);
     ucp_proto_perf_node_add_child(seg->node, perf_node);
 }
 
@@ -188,82 +223,39 @@ void ucp_proto_perf_destroy(ucp_proto_perf_t *perf)
     ucs_free(perf);
 }
 
-ucs_status_t ucp_proto_perf_from_caps(const char *name,
-                                      const ucp_proto_caps_t *proto_caps,
-                                      ucp_proto_perf_t **perf_p)
+int ucp_proto_perf_is_empty(const ucp_proto_perf_t *perf)
 {
-    ucs_linear_func_t funcs[UCP_PROTO_PERF_FACTOR_LAST];
-    const ucp_proto_perf_range_t *range;
-    ucp_proto_perf_segment_t *seg;
-    ucp_proto_perf_t *perf;
-    ucs_status_t status;
-    size_t range_start;
-
-    status = ucp_proto_perf_create(name, &perf);
-    if (status != UCS_OK) {
-        goto err;
-    }
-
-    range_start = proto_caps->min_length;
-    ucs_carray_for_each(range, proto_caps->ranges, proto_caps->num_ranges) {
-        if (range->max_length < range_start) {
-            /* Skip empty ranges */
-            continue;
-        }
-
-        status = ucp_proto_perf_segment_new(perf, range_start,
-                                            range->max_length, &seg);
-        if (status != UCS_OK) {
-            goto err_destroy;
-        }
-
-        seg->node = range->node;
-        ucp_proto_perf_node_ref(seg->node);
-        ucs_list_add_tail(&perf->segments, &seg->list);
-
-        funcs[UCP_PROTO_PERF_FACTOR_LOCAL_CPU] =
-                range->perf[UCP_PROTO_PERF_TYPE_CPU];
-        funcs[UCP_PROTO_PERF_FACTOR_SINGLE] =
-                range->perf[UCP_PROTO_PERF_TYPE_SINGLE];
-        funcs[UCP_PROTO_PERF_FACTOR_MULTI] =
-                range->perf[UCP_PROTO_PERF_TYPE_MULTI];
-        ucp_proto_perf_segment_add_funcs(
-                perf, seg, funcs,
-                UCS_BIT(UCP_PROTO_PERF_FACTOR_LOCAL_CPU) |
-                UCS_BIT(UCP_PROTO_PERF_FACTOR_SINGLE) |
-                UCS_BIT(UCP_PROTO_PERF_FACTOR_MULTI),
-                NULL);
-
-        range_start = range->max_length + 1;
-    }
-
-    ucp_proto_perf_check(perf);
-    *perf_p = perf;
-    return UCS_OK;
-
-err_destroy:
-    ucp_proto_perf_destroy(perf);
-err:
-    return status;
+    return ucs_list_is_empty(&perf->segments);
 }
 
-ucs_status_t ucp_proto_perf_add_funcs(
-        ucp_proto_perf_t *perf, size_t start, size_t end,
-        const ucs_linear_func_t funcs[UCP_PROTO_PERF_FACTOR_LAST],
-        uint64_t factors_bitmap, ucp_proto_perf_node_t *perf_node)
+ucs_status_t
+ucp_proto_perf_add_funcs(ucp_proto_perf_t *perf, size_t start, size_t end,
+                         const ucp_proto_perf_factors_t perf_factors,
+                         ucp_proto_perf_node_t *child_perf_node,
+                         const char *title, const char *desc_fmt, ...)
 {
     ucp_proto_perf_segment_t *seg, *new_seg;
+    ucp_proto_perf_node_t *perf_node;
     ucs_status_t status;
     size_t seg_end;
+    va_list ap;
 
     ucp_proto_perf_check(perf);
+
+    va_start(ap, desc_fmt);
+    perf_node = ucp_proto_perf_node_new(UCP_PROTO_PERF_NODE_TYPE_DATA, 0, title,
+                                        desc_fmt, ap);
+    va_end(ap);
+
+    ucp_proto_perf_node_update_factors(perf_node, perf_factors);
+    ucp_proto_perf_node_add_child(perf_node, child_perf_node);
 
     /*                   __________         _________________
      * perf before:     |__________|       |_________________|
      *                __________________
      * range to add: |__________________|
      *                __________________    _________________
-     * perf after:   |__|__________|____|  |_____|__________|
+     * perf after:   |__|__________|____|  |_________________|
      */
     seg = ucs_list_head(&perf->segments, ucp_proto_perf_segment_t, list);
     while ((&seg->list != &perf->segments) && (start <= end)) {
@@ -308,8 +300,11 @@ ucs_status_t ucp_proto_perf_add_funcs(
                     seg->start);
         ucs_assertv(end >= seg->end, "end=%zu seg->end=%zu", end, seg->end);
 
-        ucp_proto_perf_segment_add_funcs(perf, seg, funcs, factors_bitmap,
-                                         perf_node);
+        ucp_proto_perf_segment_add_funcs(perf, seg, perf_factors, perf_node);
+        if (seg->end == SIZE_MAX) {
+            goto out_ok; /* Avoid wraparound */
+        }
+
         start = seg->end + 1;
         seg   = ucs_list_next(&seg->list, ucp_proto_perf_segment_t, list);
     }
@@ -322,13 +317,13 @@ ucs_status_t ucp_proto_perf_add_funcs(
         }
 
         ucs_list_add_tail(&perf->segments, &seg->list);
-        ucp_proto_perf_segment_add_funcs(perf, seg, funcs, factors_bitmap,
-                                         perf_node);
+        ucp_proto_perf_segment_add_funcs(perf, seg, perf_factors, perf_node);
     }
 
+out_ok:
     status = UCS_OK;
-
 out:
+    ucp_proto_perf_node_deref(&perf_node);
     ucp_proto_perf_check(perf);
     return status;
 }
@@ -393,9 +388,8 @@ ucs_status_t ucp_proto_perf_aggregate(const char *name,
             ucs_list_add_tail(&perf->segments, &new_seg->list);
             for (i = 0; i < num_elems; ++i) {
                 seg = ucs_container_of(pos[i], ucp_proto_perf_segment_t, list);
-                ucp_proto_perf_segment_add_funcs(
-                        perf, new_seg, seg->factors,
-                        UCS_MASK(UCP_PROTO_PERF_FACTOR_LAST), seg->node);
+                ucp_proto_perf_segment_add_funcs(perf, new_seg,
+                                                 seg->perf_factors, seg->node);
             }
 
             if (end == SIZE_MAX) {
@@ -420,6 +414,117 @@ err:
     return status;
 }
 
+static ucs_status_t
+ucp_proto_flat_perf_alloc(ucp_proto_flat_perf_t **flat_perf_p)
+{
+    ucp_proto_flat_perf_t *flat_perf;
+
+    flat_perf = ucs_malloc(sizeof(*flat_perf), "flat_perf");
+    if (flat_perf == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    *flat_perf_p = flat_perf;
+    return UCS_OK;
+}
+
+ucs_status_t ucp_proto_perf_envelope(const ucp_proto_perf_t *perf, int convex,
+                                     ucp_proto_flat_perf_t **flat_perf_ptr)
+{
+    ucp_proto_perf_envelope_elem_t *envelope_elem;
+    const ucp_proto_perf_segment_t *seg;
+    ucp_proto_flat_perf_range_t *range;
+    ucp_proto_perf_envelope_t envelope;
+    ucp_proto_flat_perf_t *flat_perf;
+    ucs_status_t status;
+    size_t range_start;
+
+    status = ucp_proto_flat_perf_alloc(&flat_perf);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucp_proto_perf_check(perf);
+
+    ucs_array_init_dynamic(flat_perf);
+    ucs_array_init_dynamic(&envelope);
+    ucp_proto_perf_segment_foreach(seg, perf) {
+        ucs_array_clear(&envelope);
+        status = ucp_proto_perf_envelope_make(
+                seg->perf_factors, UCP_PROTO_PERF_FACTOR_LAST_WO_LATENCY,
+                seg->start, seg->end, convex, &envelope);
+        if (status != UCS_OK) {
+            goto err_cleanup;
+        }
+
+        range_start = seg->start;
+        ucs_array_for_each(envelope_elem, &envelope) {
+            range        = ucs_array_append(flat_perf,
+                                            status = UCS_ERR_NO_MEMORY;
+                                            goto err_cleanup);
+            range->start = range_start;
+            range->end   = envelope_elem->max_length;
+            range->value = seg->perf_factors[envelope_elem->index];
+            range->node  = ucp_proto_perf_node_new_data(
+                    perf->name, ucp_envelope_convex_names[convex]);
+            ucp_proto_perf_node_add_child(range->node, seg->node);
+            ucp_proto_perf_node_add_data(range->node, "total", range->value);
+
+            range_start = envelope_elem->max_length + 1;
+        }
+    }
+
+    *flat_perf_ptr = flat_perf;
+    ucs_array_cleanup_dynamic(&envelope);
+    return UCS_OK;
+
+err_cleanup:
+    ucp_proto_flat_perf_destroy(flat_perf);
+    ucs_array_cleanup_dynamic(&envelope);
+    return status;
+}
+
+ucs_status_t ucp_proto_perf_sum(const ucp_proto_perf_t *perf,
+                                ucp_proto_flat_perf_t **flat_perf_ptr)
+{
+    const ucp_proto_perf_segment_t *seg;
+    ucp_proto_flat_perf_range_t *range;
+    ucp_proto_perf_factor_id_t factor_id;
+    ucp_proto_flat_perf_t *flat_perf;
+    ucs_status_t status;
+
+    status = ucp_proto_flat_perf_alloc(&flat_perf);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_array_init_dynamic(flat_perf);
+    ucp_proto_perf_segment_foreach(seg, perf) {
+        range        = ucs_array_append(flat_perf, status = UCS_ERR_NO_MEMORY;
+                                        goto err_cleanup);
+        range->start = seg->start;
+        range->end   = seg->end;
+        range->value = UCS_LINEAR_FUNC_ZERO;
+        range->node  = ucp_proto_perf_node_new_data(perf->name, "flat perf");
+
+        for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST;
+             factor_id++) {
+            ucs_linear_func_add_inplace(&range->value,
+                                        seg->perf_factors[factor_id]);
+        }
+
+        ucp_proto_perf_node_add_child(range->node, seg->node);
+        ucp_proto_perf_node_add_data(range->node, "sum", range->value);
+    }
+
+    *flat_perf_ptr = flat_perf;
+    return UCS_OK;
+
+err_cleanup:
+    ucp_proto_flat_perf_destroy(flat_perf);
+    return status;
+}
+
 ucp_proto_perf_segment_t *
 ucp_proto_perf_find_segment_lb(const ucp_proto_perf_t *perf, size_t lb)
 
@@ -439,7 +544,7 @@ ucs_linear_func_t
 ucp_proto_perf_segment_func(const ucp_proto_perf_segment_t *seg,
                             ucp_proto_perf_factor_id_t factor_id)
 {
-    return seg->factors[factor_id];
+    return seg->perf_factors[factor_id];
 }
 
 size_t ucp_proto_perf_segment_start(const ucp_proto_perf_segment_t *seg)
@@ -458,35 +563,99 @@ ucp_proto_perf_segment_node(const ucp_proto_perf_segment_t *seg)
     return seg->node;
 }
 
-static void ucp_proto_perf_segment_dump(const ucp_proto_perf_segment_t *seg,
-                                        ucs_string_buffer_t *strb)
+const ucp_proto_perf_segment_t *
+ucp_proto_perf_segment_next(const ucp_proto_perf_t *perf,
+                            const ucp_proto_perf_segment_t *seg)
+{
+    if (ucs_list_is_last(&perf->segments, &seg->list)) {
+        return NULL;
+    }
+
+    return ucs_list_next(&seg->list, ucp_proto_perf_segment_t, list);
+}
+
+const ucp_proto_perf_segment_t *
+ucp_proto_perf_segment_last(const ucp_proto_perf_t *perf)
+{
+    if (ucs_list_is_empty(&perf->segments)) {
+        return NULL;
+    }
+
+    return ucs_list_tail(&perf->segments, ucp_proto_perf_segment_t, list);
+}
+
+void ucp_proto_perf_segment_str(const ucp_proto_perf_segment_t *seg,
+                                ucs_string_buffer_t *strb)
 {
     ucp_proto_perf_factor_id_t factor_id;
-    ucs_linear_func_t func;
-
-    ucs_string_buffer_appendf(strb, "{%zu..%zu", seg->start, seg->end);
+    ucs_linear_func_t perf_factor;
 
     for (factor_id = 0; factor_id < UCP_PROTO_PERF_FACTOR_LAST; factor_id++) {
-        func = seg->factors[factor_id];
-        if (ucs_linear_func_is_zero(func, UCP_PROTO_PERF_EPSILON)) {
+        perf_factor = ucp_proto_perf_segment_func(seg, factor_id);
+        if (ucs_linear_func_is_zero(perf_factor, UCP_PROTO_PERF_EPSILON)) {
             continue;
         }
 
-        ucs_string_buffer_appendf(strb, " %s:%.2f+%.2fx",
+        ucs_string_buffer_appendf(strb, "%s: " UCP_PROTO_PERF_FUNC_FMT " ",
                                   ucp_proto_perf_factor_names[factor_id],
-                                  func.c, func.m);
-    }
-
-    ucs_string_buffer_appendf(strb, "} ");
-}
-
-void ucp_proto_perf_dump(const ucp_proto_perf_t *perf,
-                         ucs_string_buffer_t *strb)
-{
-    ucp_proto_perf_segment_t *seg;
-
-    ucp_proto_perf_segment_foreach(seg, perf) {
-        ucp_proto_perf_segment_dump(seg, strb);
+                                  UCP_PROTO_PERF_FUNC_ARG(&perf_factor));
     }
     ucs_string_buffer_rtrim(strb, NULL);
+}
+
+void ucp_proto_perf_str(const ucp_proto_perf_t *perf, ucs_string_buffer_t *strb)
+{
+    ucp_proto_perf_segment_t *seg;
+    char range_str[64];
+
+    ucp_proto_perf_segment_foreach(seg, perf) {
+        ucs_memunits_range_str(seg->start, seg->end, range_str,
+                               sizeof(range_str));
+        ucs_string_buffer_appendf(strb, "%s {", range_str);
+        ucp_proto_perf_segment_str(seg, strb);
+        ucs_string_buffer_appendf(strb, "} ");
+    }
+    ucs_string_buffer_rtrim(strb, NULL);
+}
+
+void ucp_proto_flat_perf_str(const ucp_proto_flat_perf_t *flat_perf,
+                             ucs_string_buffer_t *strb)
+{
+    ucp_proto_flat_perf_range_t *range;
+    char range_str[64];
+
+    ucs_array_for_each(range, flat_perf) {
+        ucs_memunits_range_str(range->start, range->end, range_str,
+                               sizeof(range_str));
+        ucs_string_buffer_appendf(strb, "%s {", range_str);
+        ucs_string_buffer_appendf(strb, UCP_PROTO_PERF_FUNC_FMT,
+                                  UCP_PROTO_PERF_FUNC_ARG(&range->value));
+        ucs_string_buffer_appendf(strb, "} ");
+    }
+    ucs_string_buffer_rtrim(strb, NULL);
+}
+
+const ucp_proto_flat_perf_range_t *
+ucp_proto_flat_perf_find_lb(const ucp_proto_flat_perf_t *flat_perf, size_t lb)
+{
+    ucp_proto_flat_perf_range_t *range;
+
+    ucs_array_for_each(range, flat_perf) {
+        if (lb <= range->end) {
+            return range;
+        }
+    }
+    return NULL;
+}
+
+void ucp_proto_flat_perf_destroy(ucp_proto_flat_perf_t *flat_perf)
+{
+    ucp_proto_flat_perf_range_t *range;
+
+    ucs_array_for_each(range, flat_perf) {
+        ucp_proto_perf_node_deref(&range->node);
+    }
+
+    ucs_array_cleanup_dynamic(flat_perf);
+    ucs_free(flat_perf);
 }

--- a/src/ucp/proto/proto_perf.h
+++ b/src/ucp/proto/proto_perf.h
@@ -28,11 +28,45 @@ typedef enum {
     UCP_PROTO_PERF_FACTOR_REMOTE_CPU,
     UCP_PROTO_PERF_FACTOR_LOCAL_TL,
     UCP_PROTO_PERF_FACTOR_REMOTE_TL,
-    UCP_PROTO_PERF_FACTOR_LATENCY,
-    UCP_PROTO_PERF_FACTOR_SINGLE, /* For compatibility; to remove */
-    UCP_PROTO_PERF_FACTOR_MULTI,  /* For compatibility; to remove */
+    UCP_PROTO_PERF_FACTOR_LOCAL_MTYPE_COPY,
+    UCP_PROTO_PERF_FACTOR_REMOTE_MTYPE_COPY,
+    UCP_PROTO_PERF_FACTOR_LAST_WO_LATENCY,
+    UCP_PROTO_PERF_FACTOR_LATENCY = UCP_PROTO_PERF_FACTOR_LAST_WO_LATENCY,
     UCP_PROTO_PERF_FACTOR_LAST
 } ucp_proto_perf_factor_id_t;
+
+
+/* Final protocol perfomance segment, represents estimated protocol performance
+ * in a single range */
+typedef struct {
+    size_t                start;
+    size_t                end;
+    ucs_linear_func_t     value;
+    ucp_proto_perf_node_t *node;
+} ucp_proto_flat_perf_range_t;
+
+/* Structure that stores final protocols performance for comparison */
+UCS_ARRAY_DECLARE_TYPE(ucp_proto_flat_perf_t, unsigned,
+                       ucp_proto_flat_perf_range_t);
+
+
+/* Array of all performance factors */
+typedef ucs_linear_func_t ucp_proto_perf_factors_t[UCP_PROTO_PERF_FACTOR_LAST];
+
+
+#define UCP_PROTO_PERF_FACTORS_INITIALIZER {}
+
+
+/* Iterate on all segments within a given range */
+#define ucp_proto_perf_segment_foreach_range(_seg, _seg_start, _seg_end, \
+                                             _perf, _range_start, _range_end) \
+    for (_seg = ucp_proto_perf_find_segment_lb(_perf, _range_start); \
+         (_seg != NULL) && \
+         (_seg_start = \
+                  ucs_max(_range_start, ucp_proto_perf_segment_start(seg)), \
+         _seg_end = ucs_min(_range_end, ucp_proto_perf_segment_end(seg)), \
+         _seg_start <= seg_end); \
+         _seg = ucp_proto_perf_segment_next(_perf, _seg))
 
 
 /**
@@ -55,24 +89,16 @@ void ucp_proto_perf_destroy(ucp_proto_perf_t *perf);
 
 
 /**
- * Create proto perf structure from proto caps.
- *
- * @param [in]  name        Name of the performance data structure.
- * @param [in]  proto_caps  Proto caps to create perf from.
- * @param [out] perf_p      Filled with the new performance data structure.
-*/
-ucs_status_t ucp_proto_perf_from_caps(const char *name,
-                                      const ucp_proto_caps_t *proto_caps,
-                                      ucp_proto_perf_t **perf_p);
+ * @return Whether the perf is empty.
+ */
+int ucp_proto_perf_is_empty(const ucp_proto_perf_t *perf);
 
 
 /**
  * Add linear functions to several performance factors at the range
  * [ @a start, @a end ]. The performance functions to add are provided in the
  * array @a funcs, each entry corresponding to a factor id defined in
- * @ref ucp_proto_perf_factor_id_t. The bitmap @a factors_bitmap specifies the
- * valid elements in that array; any elements not specified in the bitmap are
- * ignored.
+ * @ref ucp_proto_perf_factor_id_t.
  *
  * Initially, all ranges are uninitialized; repeated calls to this function
  * should be used to populate the @a perf data structure.
@@ -80,18 +106,22 @@ ucs_status_t ucp_proto_perf_from_caps(const char *name,
  * @param [in] perf            Performance data structure to update.
  * @param [in] start           Add the performance function to this range start (inclusive).
  * @param [in] end             Add the performance function to this range end (inclusive).
- * @param [in] funcs           Array of performance functions to add.
- * @param [in] factors_bitmap  Bitmap of performance factors to add, using bit
- *                             indexes defined in @ref ucp_proto_perf_factor_id_t.
- * @param [in] perf_node       Performance node that represents the added function.
- *                             Can be NULL.
+ * @param [in] perf_factors    Array of performance functions to add.
+ * @param [in] child_perf_node Performance node that would be considered as
+ *                             child node for all segment nodes on [start, end]
+ *                             interval.
+ * @param [in] title           Title for performance node that would be created
+ *                             to represent @a perf_factors data.
+ * @param [in] desc_fmt        Formatted description for performance node that
+ *                             would be created to represent @a perf_factors data.
  *
  * @note This function may adjust the reference count of @a perf_node as needed.
  */
-ucs_status_t ucp_proto_perf_add_funcs(
-        ucp_proto_perf_t *perf, size_t start, size_t end,
-        const ucs_linear_func_t funcs[UCP_PROTO_PERF_FACTOR_LAST],
-        uint64_t factors_bitmap, ucp_proto_perf_node_t *perf_node);
+ucs_status_t
+ucp_proto_perf_add_funcs(ucp_proto_perf_t *perf, size_t start, size_t end,
+                         const ucp_proto_perf_factors_t perf_factors,
+                         ucp_proto_perf_node_t *child_perf_node,
+                         const char *title, const char *desc_fmt, ...);
 
 
 /**
@@ -108,11 +138,35 @@ ucs_status_t ucp_proto_perf_add_funcs(
  *                          that should be aggregated.
  * @param [in]  num_elems   Number of elements in @a perf_elems array.
  * @param [out] perf_p      Filled with the new performance data structure.
-*/
+ */
 ucs_status_t ucp_proto_perf_aggregate(const char *name,
                                       const ucp_proto_perf_t *const *perf_elems,
                                       unsigned num_elems,
                                       ucp_proto_perf_t **perf_p);
+
+
+/**
+ * Convert given @a perf to @a flat_perf structure that contains convex or
+ * concave envelope across all factors for each segment. Used for async scheme
+ * performance estimations.
+ *
+ * @param [in]  perf          Performance data structure to convert.
+ * @param [in]  convex        If 1 calculate convex, if 0 concave.
+ * @param [out] flat_perf_ptr Filled with convex or concave envelope.
+ */
+ucs_status_t ucp_proto_perf_envelope(const ucp_proto_perf_t *perf, int convex,
+                                     ucp_proto_flat_perf_t **flat_perf_ptr);
+
+
+/**
+ * Convert given @a perf to @a flat_perf structure that contains sum of all
+ * factors for each segment. Used for blocking scheme performance estimations.
+ *
+ * @param [in]  perf          Performance data structure to convert.
+ * @param [out] flat_perf_ptr Filled with sum of all factors.
+ */
+ucs_status_t ucp_proto_perf_sum(const ucp_proto_perf_t *perf,
+                                ucp_proto_flat_perf_t **flat_perf_ptr);
 
 
 /**
@@ -174,12 +228,72 @@ ucp_proto_perf_segment_node(const ucp_proto_perf_segment_t *seg);
 
 
 /**
+ * Get next segment, or NULL if none.
+ */
+const ucp_proto_perf_segment_t *
+ucp_proto_perf_segment_next(const ucp_proto_perf_t *perf,
+                            const ucp_proto_perf_segment_t *seg);
+
+
+/**
+ * Get last segment, or NULL if none.
+ */
+const ucp_proto_perf_segment_t *
+ucp_proto_perf_segment_last(const ucp_proto_perf_t *perf);
+
+
+/**
+ * Dump the performance data of the segment to a string buffer.
+ *
+ * @param [in]  seg         Segment to dump.
+ * @param [out] strb        String buffer to dump the performance data to.
+ */
+void ucp_proto_perf_segment_str(const ucp_proto_perf_segment_t *seg,
+                                ucs_string_buffer_t *strb);
+
+
+/**
+ * Dump the final performance data structure to a string buffer.
+ *
+ * @param [in]  flat_perf   Final performance data structure to dump.
+ * @param [out] strb        String buffer to dump the performance data to.
+ */
+void ucp_proto_flat_perf_str(const ucp_proto_flat_perf_t *flat_perf,
+                             ucs_string_buffer_t *strb);
+
+
+/**
  * Dump the performance data structure to a string buffer.
  *
  * @param [in]  perf        Performance data structure to dump.
  * @param [out] strb        String buffer to dump the performance data to.
  */
-void ucp_proto_perf_dump(const ucp_proto_perf_t *perf,
-                         ucs_string_buffer_t *strb);
+void ucp_proto_perf_str(const ucp_proto_perf_t *perf,
+                        ucs_string_buffer_t *strb);
+
+
+/**
+ * Find the first range that contains a point greater than or equal to a given
+ * lower bound value.
+ *
+ * @param [in] flat_perf     Flat performance data structure.
+ * @param [in] lb            Lower bound of the segment to find.
+ *
+ * @return Pointer to the first range that contains a point greater than or
+ *         equal to @a lb, or NULL if all ranges end before @a lb.
+ */
+const ucp_proto_flat_perf_range_t *
+ucp_proto_flat_perf_find_lb(const ucp_proto_flat_perf_t *flat_perf, size_t lb);
+
+
+/**
+ * Destroy a flat performance data structure and free associated memory.
+ * The reference counts of any perf_node objects passed to
+ * @ref ucp_proto_perf_add_func() will be adjusted accordingly.
+ *
+ * @param [in]  flat_perf   Performance data structure to destroy.
+*/
+void ucp_proto_flat_perf_destroy(ucp_proto_flat_perf_t *flat_perf);
+
 
 #endif

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -78,8 +78,7 @@ static void ucp_proto_reconfig_probe(const ucp_proto_init_params_t *init_params)
     caps.num_ranges           = 1;
     caps.ranges[0].max_length = SIZE_MAX;
     caps.ranges[0].node       = ucp_proto_perf_node_new_data("dummy", "");
-    ucp_proto_perf_set(caps.ranges[0].perf,
-                       ucs_linear_func_make(INFINITY, INFINITY));
+    ucp_proto_perf_set(caps.ranges[0].perf, ucs_linear_func_make(INFINITY, 0));
 
     ucp_proto_select_add_proto(init_params, UCS_MEMUNITS_INF, 0, &caps, NULL,
                                0);

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -421,9 +421,12 @@ ucp_proto_select_elem_init_thresh(ucp_worker_h worker,
         }
 
         ucs_assert_always(!ucs_array_is_empty(&perf_list));
+        ucs_assert_always(ucs_array_length(&perf_list) < 64);
 
-        status = ucp_proto_perf_envelope_make(&perf_list, msg_length,
-                                              max_length, 1, &envelope);
+        status = ucp_proto_perf_envelope_make(ucs_array_begin(&perf_list),
+                                              ucs_array_length(&perf_list),
+                                              msg_length, max_length, 1,
+                                              &envelope);
         if (status != UCS_OK) {
             goto err_cleanup_perf_list;
         }

--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -401,6 +401,16 @@ ucs_array_old_buffer_set_null(void **old_buffer_p)
         ucs_array_length(_array) = (_new_length); \
     }
 
+/**
+ * Remove all elements from array
+ *
+ * @param _array        Array to clean
+ */
+#define ucs_array_clear(_array) \
+    { \
+        ucs_array_length(_array) = 0; \
+    }
+
 
 /**
  * Remove the last element in the array (decrease length by 1)

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -43,7 +43,7 @@ void ucs_string_buffer_cleanup(ucs_string_buffer_t *strb)
 
 void ucs_string_buffer_reset(ucs_string_buffer_t *strb)
 {
-    ucs_array_length(strb) = 0;
+    ucs_array_clear(strb);
 }
 
 size_t ucs_string_buffer_length(ucs_string_buffer_t *strb)

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -17,6 +17,7 @@ extern "C" {
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_perf.h>
+#include <ucp/proto/proto_init.h>
 #include <ucs/datastruct/linear_func.h>
 #include <ucp/proto/proto_select.inl>
 #include <ucp/core/ucp_worker.inl>
@@ -350,7 +351,17 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_perf_node, all, "all")
 static std::ostream &operator<<(std::ostream &os, const ucp_proto_perf_t *perf)
 {
     ucs_string_buffer_t strb = UCS_STRING_BUFFER_INITIALIZER;
-    ucp_proto_perf_dump(perf, &strb);
+    ucp_proto_perf_str(perf, &strb);
+    auto &ret = os << ucs_string_buffer_cstr(&strb);
+    ucs_string_buffer_cleanup(&strb);
+    return ret;
+}
+
+static std::ostream &
+operator<<(std::ostream &os, const ucp_proto_flat_perf_t *flat_perf)
+{
+    ucs_string_buffer_t strb = UCS_STRING_BUFFER_INITIALIZER;
+    ucp_proto_flat_perf_str(flat_perf, &strb);
     auto &ret = os << ucs_string_buffer_cstr(&strb);
     ucs_string_buffer_cleanup(&strb);
     return ret;
@@ -358,17 +369,23 @@ static std::ostream &operator<<(std::ostream &os, const ucp_proto_perf_t *perf)
 
 static std::ostream &operator<<(std::ostream &os, const ucs_linear_func_t &func)
 {
-    return os << func.c << "+" << func.m << "x";
+    char buffer[128];
+
+    ucs_snprintf_safe(buffer, sizeof(buffer), UCP_PROTO_PERF_FUNC_FMT,
+                      UCP_PROTO_PERF_FUNC_ARG(&func));
+    return os << buffer;
 }
 
 class test_proto_perf : public ucs::test {
 public:
     using perf_ptr_t         = std::shared_ptr<ucp_proto_perf_t>;
+    using flat_perf_ptr_t    = std::shared_ptr<ucp_proto_flat_perf_t>;
     using perf_factors_map_t = std::unordered_map<int, ucs_linear_func_t>;
-
 protected:
     virtual void cleanup() override
     {
+        m_envelope_flat_perf.reset();
+        m_sum_flat_perf.reset();
         m_perf.reset();
     }
 
@@ -376,14 +393,7 @@ protected:
     {
         ucp_proto_perf_t *perf;
         ASSERT_UCS_OK(ucp_proto_perf_create("test", &perf));
-        return make_perf_shared_ptr(perf);
-    }
-
-    static perf_ptr_t from_caps(const ucp_proto_caps_t &caps)
-    {
-        ucp_proto_perf_t *perf;
-        ASSERT_UCS_OK(ucp_proto_perf_from_caps("test", &caps, &perf));
-        return make_perf_shared_ptr(perf);
+        return make_perf_ptr(perf);
     }
 
     perf_ptr_t aggregate(const std::vector<perf_ptr_t> &perfs)
@@ -397,20 +407,20 @@ protected:
         ASSERT_UCS_OK(ucp_proto_perf_aggregate("aggregate",
                                                perfs_ptr_vec.data(),
                                                perfs_ptr_vec.size(), &perf));
-        return make_perf_shared_ptr(perf);
+        return make_perf_ptr(perf);
     }
 
     static void add_funcs(perf_ptr_t perf, size_t start, size_t end,
                           const perf_factors_map_t &factors)
     {
-        ucs_linear_func_t funcs[UCP_PROTO_PERF_FACTOR_LAST];
-        uint64_t factors_map = 0;
+        ucp_proto_perf_factors_t perf_factors =
+                UCP_PROTO_PERF_FACTORS_INITIALIZER;
+
         for (auto &f : factors) {
-            funcs[f.first] = f.second;
-            factors_map   |= UCS_BIT(f.first);
+            perf_factors[f.first] = f.second;
         }
-        ASSERT_UCS_OK(ucp_proto_perf_add_funcs(perf.get(), start, end, funcs,
-                                               factors_map, NULL));
+        ASSERT_UCS_OK(ucp_proto_perf_add_funcs(perf.get(), start, end,
+                                               perf_factors, NULL, "test", ""));
     }
 
     static void add_func(perf_ptr_t perf, size_t start, size_t end,
@@ -431,19 +441,24 @@ protected:
         return ucp_proto_perf_find_segment_lb(perf.get(), start);
     }
 
-    void expect_empty_range(size_t start, size_t end)
+    static const ucp_proto_flat_perf_range_t *
+    find_lb(flat_perf_ptr_t flat_perf, size_t start)
     {
-        ucp_proto_perf_segment_t *seg = find_lb(m_perf, start);
-
-        EXPECT_TRUE((seg == nullptr) ||
-                    (end < ucp_proto_perf_segment_start(seg)))
-                << "perf=" << m_perf.get() << " start=" << start
-                << " end=" << end;
+        return ucp_proto_flat_perf_find_lb(flat_perf.get(), start);
     }
 
-    void
-    expect_perf(size_t start, size_t end, const perf_factors_map_t &factors)
+    void expect_empty_range(size_t start, size_t end) const
     {
+        expect_perf_empty_range(m_perf, start, end);
+        expect_perf_empty_range(m_sum_flat_perf, start, end);
+        expect_perf_empty_range(m_envelope_flat_perf, start, end);
+    }
+
+    void expect_perf(size_t start, size_t end,
+                     const perf_factors_map_t &factors) const
+    {
+        ASSERT_FALSE(ucp_proto_perf_is_empty(m_perf.get()));
+
         const ucp_proto_perf_segment_t *seg = find_lb(m_perf, start);
         ASSERT_NE(nullptr, seg) << "start=" << start;
 
@@ -462,72 +477,214 @@ protected:
                     seg, (ucp_proto_perf_factor_id_t)factor_id);
             EXPECT_TRUE(
                     ucs_linear_func_is_equal(expected_func, segment_func, 1e-9))
-                    << "factor_id=" << factor_id << " expected_func"
-                    << expected_func << " segment_func=" << segment_func;
+                    << "start=" << start << " end=" << end
+                    << " factor_id=" << factor_id
+                    << " expected_func=" << expected_func
+                    << " segment_func=" << segment_func;
         }
+
+        expect_flat_perf(start, end, factors);
+    }
+
+    void make_flat_perf()
+    {
+        ucp_proto_flat_perf_t *envelope_perf, *sum_perf;
+
+        ASSERT_NE(m_perf.get(), nullptr) << "Perf should be initialized";
+        ASSERT_UCS_OK(ucp_proto_perf_envelope(m_perf.get(), 0, &envelope_perf));
+        ASSERT_UCS_OK(ucp_proto_perf_sum(m_perf.get(), &sum_perf));
+
+        m_envelope_flat_perf = make_flat_perf_ptr(envelope_perf);
+        m_sum_flat_perf      = make_flat_perf_ptr(sum_perf);
+    }
+
+    static ucs_linear_func_t perf_func(double overhead_nsec, double bw_mbs)
+    {
+        return {overhead_nsec * 1e-9, 1.0 / (bw_mbs * UCS_MBYTE)};
+    }
+
+    void print_perf() const
+    {
+        UCS_TEST_MESSAGE << "perf:     " << m_perf.get();
+        UCS_TEST_MESSAGE << "envelope: " << m_envelope_flat_perf.get();
+        UCS_TEST_MESSAGE << "sum:      " << m_sum_flat_perf.get();
     }
 
 private:
-    static perf_ptr_t make_perf_shared_ptr(ucp_proto_perf_t *perf)
+    static size_t get_start(ucp_proto_perf_segment_t *seg)
+    {
+        return ucp_proto_perf_segment_start(seg);
+    }
+
+    static size_t get_start(const ucp_proto_flat_perf_range_t *range)
+    {
+        return range->start;
+    }
+
+    template<typename PerfPtrType>
+    void
+    expect_perf_empty_range(PerfPtrType perf, size_t start, size_t end) const
+    {
+        ASSERT_NE(perf.get(), nullptr);
+        auto *seg = find_lb(perf, start);
+
+        EXPECT_TRUE((seg == nullptr) || (end < get_start(seg)))
+                << "perf=" << perf.get() << " start=" << start
+                << " end=" << end;
+    }
+
+    void expect_flat_range(flat_perf_ptr_t flat_perf, size_t start, size_t end,
+                           ucs_linear_func_t exp_func) const
+    {
+        auto *range     = find_lb(flat_perf, start);
+        size_t midpoint = start + (end - start) / 2;
+
+        std::stringstream info;
+        info << "expected=[" << start << ", " << end << ", " << exp_func
+             << "] actual=[" << range->start << ", " << range->end << ", "
+             << range->value << "]";
+
+        EXPECT_NE(range, nullptr) << info.str();
+        EXPECT_GE(start, range->start) << info.str();
+        EXPECT_LE(end, range->end) << info.str();
+
+        // Cannot compare functions directly since on big sizes (e.g. SIZE_MAX)
+        // small latency difference can be overhelmed by floating point math
+        // innacurracy after addition with huge BW*SIZE_MAX.
+        for (size_t point : {start, midpoint, end}) {
+            double expected_result = ucs_linear_func_apply(exp_func, point);
+            double range_result = ucs_linear_func_apply(range->value, point);
+            EXPECT_NEAR(expected_result, range_result, 10e-9) << info.str();
+        }
+    }
+
+    void expect_envelope_flat_perf(size_t start, size_t end,
+                                   const perf_factors_map_t &factors) const
+    {
+        ucp_proto_perf_envelope_t envelope = UCS_ARRAY_DYNAMIC_INITIALIZER;
+        ucp_proto_perf_envelope_elem_t *envelope_elem;
+        std::vector<ucs_linear_func_t> factors_vec;
+
+        for (const auto &factor : factors) {
+            if (factor.first == UCP_PROTO_PERF_FACTOR_LATENCY) {
+                // Latency shouldn't be considered during envelope building
+                factors_vec.emplace_back(UCS_LINEAR_FUNC_ZERO);
+            } else {
+                factors_vec.emplace_back(factor.second);
+            }
+        }
+        ASSERT_FALSE(factors_vec.empty());
+
+        ASSERT_UCS_OK(ucp_proto_perf_envelope_make(&factors_vec.front(),
+                                                   factors_vec.size(), start,
+                                                   end, 0, &envelope));
+
+        ucs_array_for_each(envelope_elem, &envelope) {
+            ucs_assert(envelope_elem != NULL); /* For coverity */
+            expect_flat_range(m_envelope_flat_perf, start,
+                              envelope_elem->max_length,
+                              factors_vec[envelope_elem->index]);
+            start = envelope_elem->max_length + 1;
+        }
+
+        ucs_array_cleanup_dynamic(&envelope);
+    }
+
+    void expect_sum_flat_perf(size_t start, size_t end,
+                              const perf_factors_map_t &factors) const
+    {
+        ucs_linear_func_t expected_func = UCS_LINEAR_FUNC_ZERO;
+        for (const auto &factor : factors) {
+            ucs_linear_func_add_inplace(&expected_func, factor.second);
+        }
+
+        expect_flat_range(m_sum_flat_perf, start, end, expected_func);
+    }
+
+    void expect_flat_perf(size_t start, size_t end,
+                          const perf_factors_map_t &factors) const
+    {
+        // Reduce testing range to `max_envelope_check_size` since precise
+        // testing of big sizes is impossible due to floating point loss
+        if (start > max_envelope_check_size) {
+            return;
+        }
+        end = std::min(end, max_envelope_check_size);
+
+        expect_envelope_flat_perf(start, end, factors);
+        expect_sum_flat_perf(start, end, factors);
+    }
+
+    static perf_ptr_t make_perf_ptr(ucp_proto_perf_t *perf)
     {
         return {perf, ucp_proto_perf_destroy};
     }
 
+    static flat_perf_ptr_t make_flat_perf_ptr(ucp_proto_flat_perf_t *flat_perf)
+    {
+        return {flat_perf, ucp_proto_flat_perf_destroy};
+    }
+
 protected:
+    static const size_t            max_envelope_check_size;
     static const ucs_linear_func_t local_tl_func;
     static const ucs_linear_func_t remote_tl_func;
     static const ucs_linear_func_t local_cpu_func;
-    perf_ptr_t m_perf;
+    flat_perf_ptr_t                m_envelope_flat_perf;
+    flat_perf_ptr_t                m_sum_flat_perf;
+    perf_ptr_t                     m_perf;
 };
 
-const ucs_linear_func_t test_proto_perf::local_tl_func  = {10, 1};
-const ucs_linear_func_t test_proto_perf::remote_tl_func = {20, 2};
-const ucs_linear_func_t test_proto_perf::local_cpu_func = {30, 3};
+const ucs_linear_func_t test_proto_perf::local_tl_func  = perf_func(10, 1000);
+const ucs_linear_func_t test_proto_perf::remote_tl_func = perf_func(20, 2000);
+const ucs_linear_func_t test_proto_perf::local_cpu_func = perf_func(30, 3000);
+const size_t test_proto_perf::max_envelope_check_size   = UCS_GBYTE;
 
 UCS_TEST_F(test_proto_perf, empty)
 {
     m_perf = create();
+
+    make_flat_perf();
+    print_perf();
+
     expect_empty_range(0, SIZE_MAX);
-}
 
-UCS_TEST_F(test_proto_perf, from_caps)
-{
-    ucp_proto_caps_t caps;
-
-    caps.min_length = 1000;
-    caps.num_ranges = 2;
-
-    caps.ranges[0].max_length                       = 1999;
-    caps.ranges[0].perf[UCP_PROTO_PERF_TYPE_SINGLE] = local_tl_func;
-    caps.ranges[0].perf[UCP_PROTO_PERF_TYPE_MULTI]  = UCS_LINEAR_FUNC_ZERO;
-    caps.ranges[0].perf[UCP_PROTO_PERF_TYPE_CPU]    = UCS_LINEAR_FUNC_ZERO;
-    caps.ranges[0].node                             = NULL;
-
-    caps.ranges[1].max_length                       = 2999;
-    caps.ranges[1].perf[UCP_PROTO_PERF_TYPE_SINGLE] = UCS_LINEAR_FUNC_ZERO;
-    caps.ranges[1].perf[UCP_PROTO_PERF_TYPE_MULTI]  = UCS_LINEAR_FUNC_ZERO;
-    caps.ranges[1].perf[UCP_PROTO_PERF_TYPE_CPU]    = local_cpu_func;
-    caps.ranges[1].node                             = NULL;
-
-    m_perf = from_caps(caps);
-    UCS_TEST_MESSAGE << m_perf.get();
-
-    expect_empty_range(0, 999);
-    expect_perf(1000, 1999, {{UCP_PROTO_PERF_FACTOR_SINGLE, local_tl_func}});
-    expect_perf(2000, 2999,
-                {{UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func}});
-    expect_empty_range(3000, SIZE_MAX);
+    ASSERT_TRUE(ucp_proto_perf_is_empty(m_perf.get()));
 }
 
 UCS_TEST_F(test_proto_perf, single_func)
 {
     m_perf = create();
     add_func(1000, 1999, UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func);
-    UCS_TEST_MESSAGE << m_perf.get();
+
+    make_flat_perf();
+    print_perf();
 
     expect_empty_range(0, 999);
     expect_perf(1000, 1999, {{UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func}});
     expect_empty_range(2000, SIZE_MAX);
+}
+
+UCS_TEST_F(test_proto_perf, to_inf) {
+    /*
+     *  0    172                   SIZE_MAX
+     *  |     |                       |
+     *  |     +------ local_tl -------+
+     *  |                             |
+     *  |                             |
+     *  +----------- local_cpu -------+
+     */
+    m_perf = create();
+    add_func(172, SIZE_MAX, UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func);
+    add_func(0, SIZE_MAX, UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func);
+
+    make_flat_perf();
+    print_perf();
+
+    expect_perf(0, 171, {{UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func}});
+    expect_perf(172, SIZE_MAX,
+                {{UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func},
+                 {UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func}});
 }
 
 UCS_TEST_F(test_proto_perf, intersect_first)
@@ -544,7 +701,9 @@ UCS_TEST_F(test_proto_perf, intersect_first)
     add_func(500, 1999, UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func);
     add_func(3000, 3999, UCP_PROTO_PERF_FACTOR_REMOTE_TL, remote_tl_func);
     add_func(1000, 4999, UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func);
-    UCS_TEST_MESSAGE << m_perf.get();
+
+    make_flat_perf();
+    print_perf();
 
     expect_empty_range(0, 499);
     expect_perf(500, 999, {{UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func}});
@@ -575,7 +734,9 @@ UCS_TEST_F(test_proto_perf, intersect_last)
     add_func(1000, 1999, UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func);
     add_func(3000, 3999, UCP_PROTO_PERF_FACTOR_REMOTE_TL, remote_tl_func);
     add_func(500, 3499, UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func);
-    UCS_TEST_MESSAGE << m_perf.get();
+
+    make_flat_perf();
+    print_perf();
 
     expect_empty_range(0, 499);
     expect_perf(500, 999, {{UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func}});
@@ -605,7 +766,9 @@ UCS_TEST_F(test_proto_perf, intersect_middle)
     m_perf = create();
     add_func(500, 2999, UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func);
     add_func(1000, 1999, UCP_PROTO_PERF_FACTOR_LOCAL_CPU, local_cpu_func);
-    UCS_TEST_MESSAGE << m_perf.get();
+
+    make_flat_perf();
+    print_perf();
 
     expect_empty_range(0, 499);
     expect_perf(500, 999, {{UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func}});
@@ -636,7 +799,9 @@ UCS_TEST_F(test_proto_perf, agg2)
     UCS_TEST_MESSAGE << perf2.get();
 
     m_perf = aggregate({perf1, perf2});
-    UCS_TEST_MESSAGE << m_perf.get();
+
+    make_flat_perf();
+    print_perf();
 
     expect_empty_range(0, 999);
     expect_perf(1000, 1999,
@@ -674,7 +839,9 @@ UCS_TEST_F(test_proto_perf, agg3)
     UCS_TEST_MESSAGE << perf3.get();
 
     m_perf = aggregate({perf1, perf2, perf3});
-    UCS_TEST_MESSAGE << m_perf.get();
+
+    make_flat_perf();
+    print_perf();
 
     expect_empty_range(0, 1199);
     expect_perf(1200, 1999,
@@ -682,6 +849,51 @@ UCS_TEST_F(test_proto_perf, agg3)
                   ucs_linear_func_add(local_cpu_func, local_cpu_func)},
                  {UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_func}});
     expect_empty_range(2000, SIZE_MAX);
+}
+
+UCS_TEST_F(test_proto_perf, envelope_intersect) {
+    size_t overhead_per_byte = 10;
+    size_t fixed_overhead    = 1000;
+    auto local_tl_factor     = ucs_linear_func_make(0, overhead_per_byte);
+    auto remote_tl_factor    = ucs_linear_func_make(fixed_overhead, 0);
+
+    /*
+     * Case for testing intersection of two factors:
+     *           //
+     * envelope //
+     *         //
+     * _______//
+     * -------+-----------------------------
+     *       /                   REMOTE_TL
+     *      /
+     *     / LOCAL_TL
+     */
+    m_perf = create();
+    add_func(0, SIZE_MAX, UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_factor);
+    add_func(0, SIZE_MAX, UCP_PROTO_PERF_FACTOR_REMOTE_TL, remote_tl_factor);
+
+    make_flat_perf();
+    print_perf();
+
+    expect_perf(0, SIZE_MAX,
+                {{UCP_PROTO_PERF_FACTOR_LOCAL_TL, local_tl_factor},
+                 {UCP_PROTO_PERF_FACTOR_REMOTE_TL, remote_tl_factor}});
+
+    // `fixed_overhead` should be divisible by `overhead_per_byte` to have
+    // accurate intersection point
+    ASSERT_GE(fixed_overhead, overhead_per_byte);
+    ASSERT_EQ(fixed_overhead % overhead_per_byte, 0);
+    auto intersection     = fixed_overhead / overhead_per_byte;
+    auto *remote_tl_range = find_lb(m_envelope_flat_perf, intersection);
+    auto *local_tl_range  = find_lb(m_envelope_flat_perf, intersection + 1);
+
+    ASSERT_NE(remote_tl_range, nullptr);
+    ASSERT_NE(local_tl_range, nullptr);
+
+    ASSERT_TRUE(ucs_linear_func_is_equal(remote_tl_factor,
+                                         remote_tl_range->value, 1e-9));
+    ASSERT_TRUE(ucs_linear_func_is_equal(local_tl_factor,
+                                         local_tl_range->value, 1e-9));
 }
 
 class test_proto_perf_aggregate : public test_proto_perf {
@@ -730,13 +942,16 @@ test_proto_perf_aggregate::generate_random_perf(unsigned max_segments)
     auto points     = generate_random_sequence(max_segments);
     for (auto point : points) {
         if (ucs::rand_range(4) > 0) {
-            ucs_linear_func_t tl_func  = {1.0 * ucs::rand_range(4),
-                                          1.0 * ucs::rand_range(4)};
-            ucs_linear_func_t cpu_func = {2.0 * ucs::rand_range(4),
-                                          2.0 * ucs::rand_range(4)};
-            add_funcs(perf, start, point,
-                      {{UCP_PROTO_PERF_FACTOR_LOCAL_TL, tl_func},
-                       {UCP_PROTO_PERF_FACTOR_LOCAL_CPU, cpu_func}});
+            size_t num_factors = ucs::rand_range(UCP_PROTO_PERF_FACTOR_LAST);
+            perf_factors_map_t factors_map;
+            for (int i = 0; i < num_factors; ++i) {
+                auto factor_id   = ucs::rand_range(UCP_PROTO_PERF_FACTOR_LAST);
+                /* Avoid setting 0 BW since it can cause INF estimated time */
+                auto factor_func = perf_func(1.0 * ucs::rand_range(4),
+                                             1000.0 * (ucs::rand_range(4) + 1));
+                factors_map.emplace(factor_id, factor_func);
+            }
+            add_funcs(perf, start, point, factors_map);
         }
         start = point + 1;
     }
@@ -815,6 +1030,8 @@ void test_proto_perf_aggregate::test_random_funcs(unsigned num_perfs,
 
     m_perf = aggregate(perfs);
 
+    make_flat_perf();
+
     for (auto point : sample_points) {
         auto expected_result = expected_aggregate_result(perfs, point);
         if (expected_result) {
@@ -828,7 +1045,8 @@ void test_proto_perf_aggregate::test_random_funcs(unsigned num_perfs,
         for (size_t i = 0; i < perfs.size(); ++i) {
             UCS_TEST_MESSAGE << "perf " << i << ": " << perfs[i].get();
         }
-        UCS_TEST_MESSAGE << "result: " << m_perf.get();
+        UCS_TEST_MESSAGE << "result:";
+        print_perf();
     }
 
     m_perf.reset();


### PR DESCRIPTION
## What
The first part of #9954 which includes changes related to `ucp_proto_perf_t`  structure. The main changes is introduction of 
`ucp_proto_flat_perf_t` structure which stores result of sum or envelope across all the factors for all ranges. It required to calculate final performance estimation for SINGLE or MULTI mode.

## Why ?
Origin PR is too big to merge it without separation.
