### PR TITLE
UCT/CUDA_IPC: Redesign peer accessible cache

### DIFF
--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -103,6 +103,7 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
 
 UCS_STATIC_INIT
 {
+    /* coverity[check_return] */
     cuInit(0);
 }
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -246,7 +246,8 @@ endif # HAVE_IB
 
 if HAVE_CUDA
 gtest_SOURCES += \
-	ucm/cuda_hooks.cc
+	ucm/cuda_hooks.cc \
+	uct/cuda/test_cuda_ipc_md.cc
 gtest_CPPFLAGS += \
 	$(CUDA_CPPFLAGS)
 gtest_LDFLAGS += \

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2024. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <uct/test_md.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+extern "C" {
+#include <uct/cuda/cuda_ipc/cuda_ipc_md.h>
+}
+
+class test_cuda_ipc_md : public test_md {
+protected:
+    static uct_cuda_ipc_rkey_t unpack(uct_md_h md, int64_t uuid)
+    {
+        CUdeviceptr ptr;
+        EXPECT_EQ(CUDA_SUCCESS, cuMemAlloc(&ptr, 64));
+        uct_mem_h memh;
+        EXPECT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, 64, NULL, &memh));
+        uct_cuda_ipc_rkey_t rkey;
+        EXPECT_UCS_OK(md->ops->mkey_pack(md, memh, (void *)ptr, 64, NULL,
+                                         &rkey));
+
+        int64_t *uuid64 = (int64_t *)rkey.uuid.bytes;
+        uuid64[0]       = uuid;
+        uuid64[1]       = uuid;
+
+        /* cuIpcOpenMemHandle used by cuda_ipc_cache does not allow to open
+         * handle that was created by the same process */
+        EXPECT_EQ(UCS_ERR_UNREACHABLE,
+                  md->component->rkey_unpack(md->component, &rkey, NULL, NULL));
+
+        uct_md_mem_dereg_params_t params;
+        params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+        params.memh       = memh;
+        EXPECT_UCS_OK(md->ops->mem_dereg(md, &params));
+
+        EXPECT_EQ(CUDA_SUCCESS, cuMemFree(ptr));
+        return rkey;
+    }
+};
+
+class cuda_context {
+public:
+    cuda_context()
+    {
+        if (cudaSetDevice(0) != cudaSuccess) {
+            UCS_TEST_SKIP_R("can't set cuda device");
+        }
+
+        if (cuInit(0) != CUDA_SUCCESS) {
+            UCS_TEST_SKIP_R("can't init cuda device");
+        }
+
+        if (cuDeviceGet(&m_device, 0) != CUDA_SUCCESS) {
+            UCS_TEST_SKIP_R("can't get cuda device");
+        }
+
+        if (cuCtxCreate(&m_context, 0, m_device) != CUDA_SUCCESS) {
+            UCS_TEST_SKIP_R("can't create cuda context");
+        }
+    }
+
+    ~cuda_context()
+    {
+        EXPECT_EQ(CUDA_SUCCESS, cuCtxDestroy(m_context));
+    }
+
+protected:
+    CUdevice  m_device{CU_DEVICE_INVALID};
+    CUcontext m_context{NULL};
+};
+
+UCS_MT_TEST_P(test_cuda_ipc_md, multiple_mds, 8)
+{
+    cuda_context cuda_ctx;
+    ucs::handle<uct_md_h> md;
+    UCS_TEST_CREATE_HANDLE(uct_md_h, md, uct_md_close, uct_md_open,
+                           GetParam().component, GetParam().md_name.c_str(),
+                           m_md_config);
+
+    {
+        /* Create and destroy temporary MD */
+        ucs::handle<uct_md_h> tmp_md;
+        UCS_TEST_CREATE_HANDLE(uct_md_h, tmp_md, uct_md_close, uct_md_open,
+                               GetParam().component, GetParam().md_name.c_str(),
+                               m_md_config);
+    }
+
+    for (int64_t i = 0; i < 64; ++i) {
+        /* We get unique dev_num on new UUID */
+        uct_cuda_ipc_rkey_t rkey = unpack(md, i + 1);
+        EXPECT_EQ(i, rkey.dev_num);
+        /* Subsequent call with the same UUID returns value from cache */
+        rkey = unpack(md, i + 1);
+        EXPECT_EQ(i, rkey.dev_num);
+    }
+}
+
+_UCT_MD_INSTANTIATE_TEST_CASE(test_cuda_ipc_md, cuda_ipc);


### PR DESCRIPTION
## What
Redesigned peer accessible cache in uct_cuda_ipc component.
There were several design flaws in existing implementation:
- uct_cuda_ipc_component stores a reference to the last created MD. However if last MD is closed this leads to the dangling pointer (root cause of VASP application segfault)
- peer accessible cache is not thread safe, fails in case of multiple contexts
- cache is stored per each cuda_ipc MD, but in fact only the last created MD is used for caching
- minor: improved lookup to use hash map instead of an array based search

Consideration: locking
- global cache, single lock (current impl)
- cache in TLS
- cache per UCT worker

UPD:
I tested lock overhead with ucx_perftest on 4-16 threads with different message sizes (64-4096).
There is **no visible performance drop** when using global lock for peer accessibility cache.

## Why ?
Fix for https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=4705183
([RM#3955117](https://redmine.mellanox.com/issues/3955117))
