### PR TITLE
UCT/CUDA_IPC: Fabric memory IPC support

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -74,6 +74,10 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                               have_cuda_static="yes"],
                              [], [-ldl -lrt -lpthread])])
 
+         AC_CHECK_DECLS([CU_MEM_HANDLE_TYPE_FABRIC],
+                        [AC_DEFINE([HAVE_CUDA_FABRIC], 1, [Enable CUDA fabric handle support])],
+                        [], [[#include <cuda.h>]])
+
          CPPFLAGS="$save_CPPFLAGS"
          LDFLAGS="$save_LDFLAGS"
          LIBS="$save_LIBS"

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -189,11 +189,11 @@ UCM_CUDA_ALLOC_FUNC(cuMemMap, UCS_MEMORY_TYPE_UNKNOWN, CUresult, CUDA_SUCCESS,
                     "size=%zu offset=%zu handle=0x%llx flags=0x%llx", size_t,
                     size_t, CUmemGenericAllocationHandle, unsigned long long)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_ALLOC_FUNC(cuMemAllocAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, CUresult,
+UCM_CUDA_ALLOC_FUNC(cuMemAllocAsync, UCS_MEMORY_TYPE_CUDA, CUresult,
                     CUDA_SUCCESS, arg0, CUdeviceptr, *, "size=%zu stream=%p",
                     size_t, CUstream)
-UCM_CUDA_ALLOC_FUNC(cuMemAllocFromPoolAsync, UCS_MEMORY_TYPE_CUDA_MANAGED,
-                    CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, *,
+UCM_CUDA_ALLOC_FUNC(cuMemAllocFromPoolAsync, UCS_MEMORY_TYPE_CUDA, CUresult,
+                    CUDA_SUCCESS, arg0, CUdeviceptr, *,
                     "size=%zu pool=%p stream=%p", size_t, CUmemoryPool,
                     CUstream)
 #endif
@@ -208,8 +208,8 @@ UCM_CUDA_FREE_FUNC(cuMemFreeHost_v2, UCS_MEMORY_TYPE_HOST, CUresult, arg0, 0,
 UCM_CUDA_FREE_FUNC(cuMemUnmap, UCS_MEMORY_TYPE_UNKNOWN, CUresult, arg0, arg1,
                    "ptr=%llx size=%zu", CUdeviceptr, size_t)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_FREE_FUNC(cuMemFreeAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, CUresult, arg0,
-                   0, "ptr=0x%llx, stream=%p", CUdeviceptr, CUstream)
+UCM_CUDA_FREE_FUNC(cuMemFreeAsync, UCS_MEMORY_TYPE_CUDA, CUresult, arg0, 0,
+                   "ptr=0x%llx, stream=%p", CUdeviceptr, CUstream)
 #endif
 
 static ucm_cuda_func_t ucm_cuda_driver_funcs[] = {
@@ -244,21 +244,20 @@ UCM_CUDA_ALLOC_FUNC(cudaMallocPitch, UCS_MEMORY_TYPE_CUDA, cudaError_t,
                     cudaSuccess, ((size_t)arg1) * (arg2), void*, *,
                     "pitch=%p width=%zu height=%zu", size_t*, size_t, size_t)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, cudaError_t,
+UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t,
                     cudaSuccess, arg0, void*, *, "size=%zu stream=%p", size_t,
                     cudaStream_t)
-UCM_CUDA_ALLOC_FUNC(cudaMallocFromPoolAsync, UCS_MEMORY_TYPE_CUDA_MANAGED,
-                    cudaError_t, cudaSuccess, arg0, void*, *,
-                    "size=%zu pool=%p stream=%p", size_t, cudaMemPool_t,
-                    cudaStream_t)
+UCM_CUDA_ALLOC_FUNC(cudaMallocFromPoolAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t,
+                    cudaSuccess, arg0, void*, *, "size=%zu pool=%p stream=%p",
+                    size_t, cudaMemPool_t, cudaStream_t)
 #endif
 UCM_CUDA_FREE_FUNC(cudaFree, UCS_MEMORY_TYPE_CUDA, cudaError_t, arg0, 0,
                    "devPtr=%p", void*)
 UCM_CUDA_FREE_FUNC(cudaFreeHost, UCS_MEMORY_TYPE_HOST, cudaError_t, arg0, 0,
                    "ptr=%p", void*)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_FREE_FUNC(cudaFreeAsync, UCS_MEMORY_TYPE_CUDA_MANAGED, cudaError_t,
-                   arg0, 0, "devPtr=%p, stream=%p", void*, cudaStream_t)
+UCM_CUDA_FREE_FUNC(cudaFreeAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t, arg0, 0,
+                   "devPtr=%p, stream=%p", void*, cudaStream_t)
 #endif
 
 static ucm_cuda_func_t ucm_cuda_runtime_funcs[] = {

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -60,6 +60,10 @@ const char *uct_cuda_base_cu_get_error_string(CUresult result);
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_ERROR)
 
 
+#define UCT_CUDADRV_FUNC_LOG_WARN(_func) \
+    UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_WARN)
+
+
 #define UCT_CUDADRV_FUNC_LOG_DEBUG(_func) \
     UCT_CUDADRV_FUNC(_func, UCS_LOG_LEVEL_DEBUG)
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -8,6 +8,7 @@
 
 #include <uct/base/uct_md.h>
 #include <uct/cuda/base/cuda_md.h>
+#include <cuda.h>
 
 
 extern uct_component_t uct_cuda_copy_component;
@@ -23,27 +24,43 @@ typedef enum {
  * @brief cuda_copy MD descriptor
  */
 typedef struct uct_cuda_copy_md {
-    struct uct_md               super;           /* Domain info */
+    struct uct_md                super;           /* Domain info */
+    int                          sync_memops_set;
+    size_t                       granularity;     /* allocation granularity */
     struct {
-        ucs_on_off_auto_value_t alloc_whole_reg; /* force return of allocation
-                                                    range even for small bar
-                                                    GPUs*/
-        double                  max_reg_ratio;
-        int                     dmabuf_supported;
-        uct_cuda_pref_loc_t     pref_loc;
+        ucs_on_off_auto_value_t  alloc_whole_reg; /* force return of allocation
+                                                     range even for small bar
+                                                     GPUs*/
+        double                   max_reg_ratio;
+        int                      dmabuf_supported;
+        ucs_ternary_auto_value_t enable_fabric;
+        uct_cuda_pref_loc_t      pref_loc;
     } config;
 } uct_cuda_copy_md_t;
 
 /**
- * gdr copy domain configuration.
+ * cuda_copy MD configuration.
  */
 typedef struct uct_cuda_copy_md_config {
     uct_md_config_t             super;
     ucs_on_off_auto_value_t     alloc_whole_reg;
     double                      max_reg_ratio;
     ucs_ternary_auto_value_t    enable_dmabuf;
+    ucs_ternary_auto_value_t    enable_fabric;
     uct_cuda_pref_loc_t         pref_loc;
 } uct_cuda_copy_md_config_t;
+
+/**
+ * copy alloc handle.
+ */
+typedef struct uct_cuda_copy_alloc_handle {
+    CUdeviceptr                 ptr;
+    size_t                      length;
+    uint8_t                     is_vmm;
+#if HAVE_CUDA_FABRIC
+    CUmemGenericAllocationHandle generic_handle;
+#endif
+} uct_cuda_copy_alloc_handle_t;
 
 
 ucs_status_t uct_cuda_copy_md_detect_memory_type(uct_md_h md,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -79,8 +79,10 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                    const uct_iface_is_reachable_params_t *params)
 {
     return uct_iface_is_reachable_params_addrs_valid(params) &&
+#if !HAVE_CUDA_FABRIC
            (ucs_get_system_id() == *((const uint64_t*)params->device_addr)) &&
            (getpid() != *(pid_t*)params->iface_addr) &&
+#endif
            uct_iface_scope_is_reachable(tl_iface, params);
 }
 
@@ -559,7 +561,12 @@ uct_cuda_ipc_query_devices(
         uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
         unsigned *num_tl_devices_p)
 {
-    return uct_cuda_base_query_devices_common(md, UCT_DEVICE_TYPE_SHM,
+#if HAVE_CUDA_FABRIC
+    uct_device_type_t dev_type = UCT_DEVICE_TYPE_NET;
+#else
+    uct_device_type_t dev_type = UCT_DEVICE_TYPE_SHM;
+#endif
+    return uct_cuda_base_query_devices_common(md, dev_type,
                                               tl_devices_p, num_tl_devices_p);
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -52,11 +52,34 @@ typedef struct {
 } uct_cuda_ipc_memh_t;
 
 
+#if HAVE_CUDA_FABRIC
+typedef enum uct_cuda_ipc_key_handle {
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_ERROR = 0,
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY,
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM,
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL
+} uct_cuda_ipc_key_handle_t;
+
+
+typedef struct uct_cuda_ipc_md_handle {
+    union {
+        CUipcMemHandle    legacy; /* Legacy IPC handle */
+        CUmemFabricHandle vmm;    /* VMM export handle */
+        CUmemFabricHandle mempool;/* MallocAsync handle */
+    } handle;
+    CUmemPoolPtrExportData ptr;
+    uct_cuda_ipc_key_handle_t handle_type;
+} uct_cuda_ipc_md_handle_t;
+#else
+typedef CUipcMemHandle uct_cuda_ipc_md_handle_t;
+#endif
+
+
 /**
  * @brief cudar ipc region registered for exposure
  */
 typedef struct {
-    CUipcMemHandle  ph;      /* Memory handle of GPU memory */
+    uct_cuda_ipc_md_handle_t  ph;      /* Memory handle of GPU memory */
     CUdeviceptr     d_bptr;  /* Allocation base address */
     size_t          b_len;   /* Allocation size */
     ucs_list_link_t link;
@@ -67,7 +90,7 @@ typedef struct {
  * @brief cuda ipc remote key for put/get
  */
 typedef struct {
-    CUipcMemHandle  ph;      /* Memory handle of GPU memory */
+    uct_cuda_ipc_md_handle_t  ph;      /* Memory handle of GPU memory */
     pid_t           pid;     /* PID as key to resolve peer_map hash */
     CUdeviceptr     d_bptr;  /* Allocation base address */
     size_t          b_len;   /* Allocation size */

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -308,7 +308,7 @@ UCS_TEST_F(cuda_hooks, test_cuMemAllocAsync) {
     /* release with cuMemFree */
     ret = cuMemAllocAsync(&dptr, 64, 0);
     ASSERT_EQ(ret, CUDA_SUCCESS);
-    check_mem_alloc_events((void*)dptr, 64, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    check_mem_alloc_events((void*)dptr, 64, UCS_MEMORY_TYPE_CUDA);
 
     ret = cuMemFree(dptr);
     ASSERT_EQ(ret, CUDA_SUCCESS);
@@ -324,6 +324,7 @@ UCS_TEST_F(cuda_hooks, test_cuMemAllocAsync) {
     check_mem_free_events((void*)dptr, 64);
 }
 #endif
+
 
 UCS_TEST_F(cuda_hooks, test_cuda_Malloc_Free) {
     cudaError_t ret;
@@ -404,7 +405,7 @@ UCS_TEST_F(cuda_hooks, test_cudaMallocAsync) {
     /* release with cudaFree */
     ret = cudaMallocAsync(&ptr, 64, 0);
     ASSERT_EQ(ret, cudaSuccess);
-    check_mem_alloc_events(ptr, 64, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    check_mem_alloc_events(ptr, 64, UCS_MEMORY_TYPE_CUDA);
 
     ret = cudaFree(ptr);
     ASSERT_EQ(ret, cudaSuccess);


### PR DESCRIPTION
## What/Why?
Second part of https://github.com/openucx/ucx/pull/9787 and follow up to https://github.com/openucx/ucx/pull/9867. This implements IPC-support for fabric handle associated memory using the newer import/export API and caches import operations similar to legacy IPC handles.