### PR TITLE
GTEST: disable-new-dtags

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -82,6 +82,11 @@ gtest_CPPFLAGS = \
 	$(OPENMP_CFLAGS)
 
 gtest_LDFLAGS  = $(GTEST_LDFLAGS) -no-install $(LDFLAGS_DYNAMIC_LIST_DATA)
+
+# disable-new-dtags to force using RPATH instead of RUNPATH to avoid loading of
+# wrong shared libraries accessible by LD_LIBRARY_PATH
+gtest_LDFLAGS += -Wl,--disable-new-dtags
+
 gtest_CFLAGS   = $(BASE_CFLAGS)
 gtest_CXXFLAGS = \
 	$(BASE_CXXFLAGS) $(GTEST_CXXFLAGS) -std=c++11 \


### PR DESCRIPTION
## What
disable-new-dtags to use RPATH instead of RUN_PATH to avoid loading of wrong libucp.so if it's accessible by LD_LIBRARY_PATH

## Why ?
fixes https://github.com/openucx/ucx/issues/9890

## How ?
add the parameter to the linker command
