### PR TITLE
UCT/IB/MLX5: suggest user to increase PF_LOG_BAR_SIZE when UAR allocation fails

### DIFF
--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -170,7 +170,7 @@ AS_IF([test "x$with_ib" = "xyes"],
                            MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE,
                            MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE,
                            MLX5DV_UAR_ALLOC_TYPE_BF,
-                           MLX5DV_UAR_ALLOC_TYPE_NC,
+                           MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED,
                            mlx5dv_devx_umem_reg_ex],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])
                        AC_CHECK_MEMBERS([struct mlx5dv_cq.cq_uar],

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1883,20 +1883,6 @@ static void uct_ib_mlx5_md_port_counter_set_id_init(uct_ib_mlx5_md_t *md)
     }
 }
 
-static int uct_ib_mlx5_check_uar(uct_ib_mlx5_md_t *md)
-{
-    uct_ib_mlx5_devx_uar_t uar;
-    ucs_status_t status;
-
-    status = uct_ib_mlx5_devx_uar_init(&uar, md, 0);
-    if (status != UCS_OK) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    uct_ib_mlx5_devx_uar_cleanup(&uar);
-    return UCS_OK;
-}
-
 ucs_status_t
 uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
                                   void **address_p, ucs_memory_type_t mem_type,
@@ -2127,7 +2113,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         goto err_free_context;
     }
 
-    status = uct_ib_mlx5_check_uar(md);
+    status = uct_ib_mlx5_devx_check_uar(md);
     if (status != UCS_OK) {
         goto err_free_md;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -78,10 +78,10 @@
 #  define UCT_IB_MLX5_UAR_ALLOC_TYPE_WC 0x0
 #endif
 
-#if HAVE_DECL_MLX5DV_UAR_ALLOC_TYPE_NC
-#  define UCT_IB_MLX5_UAR_ALLOC_TYPE_NC MLX5DV_UAR_ALLOC_TYPE_NC
+#if HAVE_DECL_MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED
+#  define UCT_IB_MLX5_UAR_ALLOC_TYPE_NC MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED
 #else
-#  define UCT_IB_MLX5_UAR_ALLOC_TYPE_NC 0x1
+#  define UCT_IB_MLX5_UAR_ALLOC_TYPE_NC (1U << 31)
 #endif
 
 #define UCT_IB_MLX5_OPMOD_EXT_ATOMIC(_log_arg_size) \
@@ -197,9 +197,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_MMO_DMA              = UCS_BIT(15),
     /* Device supports XGVMI UMR workflow */
     UCT_IB_MLX5_MD_FLAG_XGVMI_UMR            = UCS_BIT(16),
+    /* Device supports UAR WC allocation type */
+    UCT_IB_MLX5_MD_FLAG_UAR_USE_WC           = UCS_BIT(17),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 17,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 18,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),
@@ -857,6 +859,8 @@ void uct_ib_mlx5_verbs_srq_cleanup(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs
 int uct_ib_mlx5_devx_uar_cmp(uct_ib_mlx5_devx_uar_t *uar,
                              uct_ib_mlx5_md_t *md,
                              uct_ib_mlx5_mmio_mode_t mmio_mode);
+
+ucs_status_t uct_ib_mlx5_devx_check_uar(uct_ib_mlx5_md_t *md);
 
 ucs_status_t uct_ib_mlx5_devx_uar_init(uct_ib_mlx5_devx_uar_t *uar,
                                        uct_ib_mlx5_md_t *md,


### PR DESCRIPTION
## What ?
Improve error logging for UAR allocation failure in `uct_ib_mlx5_devx_alloc_uar`.

## Why ?
To inform users to increase `PF_LOG_BAR_SIZE` and reboot when UAR allocation fails due to insufficient memory.
see also: https://github.com/open-mpi/ompi/issues/6854

## How ?
Update the error message in `uct_ib_mlx5_devx_alloc_uar` to suggest increasing `PF_LOG_BAR_SIZE` and mention the reboot requirement.