### PR TITLE
UCS/TOPO: Set higher bandwidth for different NUMA nodes on Grace

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -341,6 +341,9 @@ static void ucs_topo_sys_root_distance(ucs_sys_dev_distance_t *distance)
     case UCS_CPU_MODEL_AMD_GENOA:
         distance->bandwidth = 5100 * UCS_MBYTE;
         break;
+    case UCS_CPU_MODEL_NVIDIA_GRACE:
+        distance->bandwidth = 16500 * UCS_MBYTE;
+        break;
     default:
         distance->bandwidth = 220 * UCS_MBYTE;
         break;


### PR DESCRIPTION
## What
Bandwidth on different NUMA nodes is almost identical to the ones on same NUMA nodes on Grace.

Issue: [3972096](https://redmine.mellanox.com/issues/3972096)

## Why ?
With GPU0 on NUMA 0, mlx5_0/mlx5_3/mlx5_7/mlx5_9 on NUMA 0/1/2/3. Without that patch, mlx5_0 is seen so fast that other interfaces are not used for D2H transfers (RNDV get), and bandwidth is capped at <50GBs (400Gbps CX7).

Adding huge `UCX_MULTI_LANE_MAX_RATIO` leads to using many interfaces but with traffic still going through mlx5_0:1 for >90% of it.