### PR TITLE
UCP/WIREUP/IB: provide a reason when a resource's lane is unreachable

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1243,7 +1243,8 @@ static void ucp_wireup_print_config(ucp_worker_h worker,
 
 int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             ucp_rsc_index_t rsc_index,
-                            const ucp_address_entry_t *ae)
+                            const ucp_address_entry_t *ae,
+                            char *info_str, size_t info_str_size)
 {
     ucp_context_h context      = ep->worker->context;
     ucp_worker_iface_t *wiface = ucp_worker_iface(ep->worker, rsc_index);
@@ -1254,11 +1255,22 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
         .iface_addr  = ae->iface_addr,
     };
 
-    return (context->tl_rscs[rsc_index].tl_name_csum == ae->tl_name_csum) &&
-           (/* assume reachability is checked by CM, if EP selects lanes
-             * during CM phase */
-            (ep_init_flags & UCP_EP_INIT_CM_PHASE) ||
-            uct_iface_is_reachable_v2(wiface->iface, &params));
+    if (info_str != NULL) {
+        params.field_mask        |=
+                                UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING |
+                                UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING_LENGTH;
+        params.info_string        = info_str;
+        params.info_string_length = info_str_size;
+    }
+
+    if (context->tl_rscs[rsc_index].tl_name_csum != ae->tl_name_csum) {
+        return 0;
+    }
+
+    /* assume reachability is checked by CM, if EP selects lanes
+     * during CM phase */
+    return (ep_init_flags & UCP_EP_INIT_CM_PHASE) ||
+           uct_iface_is_reachable_v2(wiface->iface, &params);
 }
 
 static void
@@ -1280,7 +1292,7 @@ ucp_wireup_get_reachable_mds(ucp_ep_h ep, unsigned ep_init_flags,
     ae_dst_md_map = 0;
     UCS_STATIC_BITMAP_FOR_EACH_BIT(rsc_index, &context->tl_bitmap) {
         ucp_unpacked_address_for_each(ae, remote_address) {
-            if (ucp_wireup_is_reachable(ep, ep_init_flags, rsc_index, ae)) {
+            if (ucp_wireup_is_reachable(ep, ep_init_flags, rsc_index, ae, NULL, 0)) {
                 ae_dst_md_map         |= UCS_BIT(ae->md_index);
                 dst_md_index           = context->tl_rscs[rsc_index].md_index;
                 ae_cmpts[ae->md_index] = context->tl_mds[dst_md_index].cmpt_index;

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -174,7 +174,8 @@ int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 
 int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             ucp_rsc_index_t rsc_index,
-                            const ucp_address_entry_t *ae);
+                            const ucp_address_entry_t *ae,
+                            char *info_str, size_t info_str_size);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    const ucp_tl_bitmap_t *local_tl_bitmap,

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -242,6 +242,26 @@ static int uct_iface_is_same_device(const uct_iface_h iface,
     return !memcmp(device_addr, dev_addr, attr.device_addr_len);
 }
 
+void uct_iface_fill_info_str_buf(const uct_iface_is_reachable_params_t *params,
+                                 const char *fmt, ...)
+{
+    char *info_str_buf      = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD,
+                                              params, info_string, INFO_STRING,
+                                              NULL);
+    size_t info_str_buf_len = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD,
+                                              params, info_string_length,
+                                              INFO_STRING_LENGTH, 0);
+    va_list ap;
+
+    if (info_str_buf == NULL) {
+        return;
+    }
+
+    va_start(ap, fmt);
+    ucs_vsnprintf_safe(info_str_buf, info_str_buf_len, fmt, ap);
+    va_end(ap);
+}
+
 int uct_iface_is_reachable_params_valid(
         const uct_iface_is_reachable_params_t *params, uint64_t flags)
 {
@@ -289,6 +309,17 @@ int uct_iface_is_reachable_v2(const uct_iface_h tl_iface,
                               const uct_iface_is_reachable_params_t *params)
 {
     const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+    char *info_str_buf            = UCS_PARAM_VALUE(
+                                          UCT_IFACE_IS_REACHABLE_FIELD, params,
+                                          info_string, INFO_STRING, NULL);
+    size_t info_str_buf_len       = UCS_PARAM_VALUE(
+                                          UCT_IFACE_IS_REACHABLE_FIELD, params,
+                                          info_string_length,
+                                          INFO_STRING_LENGTH, 0);
+
+    if ((info_str_buf != NULL) && (info_str_buf_len > 0)) {
+        info_str_buf[0] = '\0';
+    }
 
     return iface->internal_ops->iface_is_reachable_v2(tl_iface, params);
 }

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -912,6 +912,9 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
 int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
                                  ucs_sys_namespace_type_t sys_ns_type);
 
+void uct_iface_fill_info_str_buf(const uct_iface_is_reachable_params_t *params,
+                                 const char *fmt, ...);
+
 int uct_iface_is_reachable_params_valid(
         const uct_iface_is_reachable_params_t *params, uint64_t flags);
 

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1006,7 +1006,21 @@ uct_dc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
                         UCT_RC_MLX5_TM_ENABLED(&iface->super));
         same_version = ((addr->flags & UCT_DC_MLX5_IFACE_ADDR_DC_VERS) ==
                         iface->version_flag);
-        if (!same_version || !same_tm) {
+        if (!same_version) {
+            uct_iface_fill_info_str_buf(
+                        params,
+                        "incompatible dc version, %u (local) vs. %u (remote)",
+                        iface->version_flag,
+                        addr->flags & UCT_DC_MLX5_IFACE_ADDR_DC_VERS);
+            return 0;
+        }
+
+        if (!same_tm) {
+            uct_iface_fill_info_str_buf(
+                params,
+                "different support for HW tag matching, local: %s, remote: %s",
+                UCT_RC_MLX5_TM_ENABLED(&iface->super)? "enabled" : "disabled",
+                UCT_DC_MLX5_IFACE_ADDR_TM_ENABLED(addr) ? "enabled" : "disabled");
             return 0;
         }
     }

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -643,13 +643,21 @@ static int
 uct_rc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                   const uct_iface_is_reachable_params_t *params)
 {
+    static const char *tm_type_to_str[] = {"basic", "tag matching"};
     uint8_t my_type = uct_rc_mlx5_iface_get_address_type(tl_iface);
+    uint8_t remote_type;
     const uct_iface_addr_t *iface_addr;
 
     iface_addr = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
                                  iface_addr, IFACE_ADDR, NULL);
+
     /* Check hardware tag matching compatibility */
-    if ((iface_addr != NULL) && (my_type != *(uint8_t*)iface_addr)) {
+    if ((iface_addr != NULL) &&
+        ((remote_type = *(uint8_t*)iface_addr) != my_type)) {
+        uct_iface_fill_info_str_buf(
+                    params, "incompatible hardware tag matching. "
+                    "%s (local) vs %s (remote)",
+                    tm_type_to_str[my_type], tm_type_to_str[remote_type]);
         return 0;
     }
 


### PR DESCRIPTION
## What
During the wireup process, provide a reason when a resource's lane is unreachable.

## Why
Users need more information about why a device is not reachable after an unsuccessful connection establishment. This information should be passed from UCT to UCP. 

## How ?
Pass a string to select/search_lane functions so in case the wireup process fails, the reason will be printed out in an upper layer.