### PR TITLE
UCT/IB/DC: in poll_tx change is_valid_dci ucs_assert_always to ucs_as…

### DIFF
--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -283,7 +283,7 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
 
     dci_index = uct_dc_mlx5_iface_dci_find(iface, cqe);
     dci       = uct_dc_mlx5_iface_dci(iface, dci_index);
-    ucs_assert_always(uct_dc_mlx5_is_dci_valid(dci));
+    ucs_assert(uct_dc_mlx5_is_dci_valid(dci));
     txqp      = &dci->txqp;
     txwq      = &dci->txwq;
     hw_ci     = ntohs(cqe->wqe_counter);


### PR DESCRIPTION
## What
In `uct_dc_mlx5_poll_tx` - use `ucs_assert` instead of `ucs_assert_always`.

## Why ?
It's a fast path function so we would like to assert only in `devel` build.

Noticed by @brminich at:
https://github.com/openucx/ucx/pull/9665#discussion_r1668834276 