### PR TITLE
UCP/GTEST: Fix rtr_mtype abort()

### DIFF
--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -277,11 +277,11 @@ static size_t ucp_proto_rndv_rtr_mtype_pack(void *dest, void *arg)
     return sizeof(*rtr) + packed_rkey_size;
 }
 
-static void ucp_proto_rndv_rtr_mtype_complete(ucp_request_t *req)
+static void ucp_proto_rndv_rtr_mtype_complete(ucp_request_t *req, int abort)
 {
     ucs_mpool_put_inline(req->send.rndv.mdesc);
     if (ucp_proto_rndv_request_is_ppln_frag(req)) {
-        ucp_proto_rndv_ppln_recv_frag_complete(req, 0, 0);
+        ucp_proto_rndv_ppln_recv_frag_complete(req, 0, abort);
     } else {
         ucp_proto_rndv_rtr_common_complete(req, UCS_BIT(UCP_DATATYPE_CONTIG));
     }
@@ -290,15 +290,13 @@ static void ucp_proto_rndv_rtr_mtype_complete(ucp_request_t *req)
 static void
 ucp_proto_rndv_rtr_mtype_abort(ucp_request_t *req, ucs_status_t status)
 {
-    req->status = status;
-    ucp_send_request_id_release(req);
-    ucs_mpool_put_inline(req->send.rndv.mdesc);
+    ucp_request_t *super_req = ucp_request_get_super(req);
 
-    if (ucp_proto_rndv_request_is_ppln_frag(req)) {
-        ucp_proto_rndv_ppln_recv_frag_complete(req, 0, 1);
-    } else {
-        ucp_proto_rndv_rtr_common_complete(req, UCS_BIT(UCP_DATATYPE_CONTIG));
-    }
+    super_req->status = status;
+
+    /*TODO: Invalidate memh */
+    ucp_send_request_id_release(req);
+    ucp_proto_rndv_rtr_mtype_complete(req, 1);
 }
 
 static ucs_status_t ucp_proto_rndv_rtr_mtype_reset(ucp_request_t *req)
@@ -315,7 +313,7 @@ static void ucp_proto_rndv_rtr_mtype_copy_completion(uct_completion_t *uct_comp)
 {
     ucp_request_t *req = ucs_container_of(uct_comp, ucp_request_t,
                                           send.state.uct_comp);
-    ucp_proto_rndv_rtr_mtype_complete(req);
+    ucp_proto_rndv_rtr_mtype_complete(req, 0);
 }
 
 static void
@@ -325,7 +323,7 @@ ucp_proto_rndv_rtr_mtype_data_received(ucp_request_t *req, int in_buffer)
     if (in_buffer) {
         /* Data was already placed in user buffer because the sender responded
            with RNDV_DATA packets */
-        ucp_proto_rndv_rtr_mtype_complete(req);
+        ucp_proto_rndv_rtr_mtype_complete(req, 0);
     } else {
         /* Data was not placed in user buffer, which means it was placed to
            the remote address we published - the rendezvous fragment */

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -2009,8 +2009,8 @@ protected:
                         uint64_t sender_cntr, uint64_t sender_cntr_value,
                         uint64_t receiver_cntr, uint64_t receiver_cntr_value)
     {
-        if (!is_ppln_supported(mem_type)) {
-            UCS_TEST_SKIP_R("No RMA support");
+        if (!sender().is_rndv_ppln_supported()) {
+            UCS_TEST_SKIP_R("RNDV pipeline is not supported");
         }
 
         const size_t rndv_frag_size = get_rndv_frag_size(mem_type);
@@ -2028,29 +2028,6 @@ private:
 
         EXPECT_EQ(exp_value, value) << "counter is "
                                     << stats_node->cls->counter_names[cntr];
-    }
-
-    bool is_ppln_supported(ucs_memory_type_t mem_type)
-    {
-        const auto ep     = sender().ep();
-        const auto config = ucp_ep_config(ep);
-
-        for (auto i = 0; i < config->key.num_lanes; ++i) {
-            const auto lane = config->key.rma_bw_lanes[i];
-            if (lane == UCP_NULL_LANE) {
-                break;
-            }
-            if (ucp_ep_md_attr(ep, lane)->reg_mem_types & UCS_BIT(mem_type)) {
-                const auto iface_attr =
-                    ucp_worker_iface_get_attr(sender().worker(),
-                                              ucp_ep_get_rsc_index(ep, lane));
-                if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_ZCOPY) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 };
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -27,7 +27,9 @@ public:
     ucp_ep_params_t get_ep_params();
 
 protected:
-    static const int AM_ID = 0;
+    static const int AM_ID        = 0;
+    static const uint64_t TX_SEED = 0x1111111111111111lu;
+    static const uint64_t RX_SEED = 0x2222222222222222lu;
 
     enum {
         TEST_AM  = UCS_BIT(0),
@@ -75,14 +77,17 @@ protected:
 
     void cleanup_rndv_descs();
 
-    void                    *m_sreq, *m_rreq;
-    std::queue<void *>      m_am_rndv_descs;
-    size_t                  m_am_rx_count;
-    size_t                  m_err_count;
-    ucs_status_t            m_err_status;
-    std::string             m_sbuf, m_rbuf;
-    mem_handle_t            m_stable_memh, m_failing_memh;
-    ucs::handle<ucp_rkey_h> m_stable_rkey, m_failing_rkey;
+    void init_buffers(size_t msg_size);
+
+    void                        *m_sreq, *m_rreq;
+    std::queue<void *>          m_am_rndv_descs;
+    size_t                      m_am_rx_count;
+    size_t                      m_err_count;
+    ucs_memory_type_t           m_mem_type;
+    ucs_status_t                m_err_status;
+    std::unique_ptr<mem_buffer> m_sbuf, m_rbuf;
+    mem_handle_t                m_stable_memh, m_failing_memh;
+    ucs::handle<ucp_rkey_h>     m_stable_rkey, m_failing_rkey;
 };
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_peer_failure)
@@ -95,9 +100,11 @@ test_ucp_peer_failure::test_ucp_peer_failure() :
     m_rreq(nullptr),
     m_am_rx_count(0),
     m_err_count(0),
+    m_mem_type(UCS_MEMORY_TYPE_HOST),
     m_err_status(UCS_OK)
 {
-    ucs::fill_random(m_sbuf);
+    m_sbuf.reset();
+    m_rbuf.reset();
     configure_peer_failure_settings();
 }
 
@@ -192,13 +199,13 @@ void *test_ucp_peer_failure::send_nb(ucp_ep_h ep, ucp_rkey_h rkey)
     param.datatype     = DATATYPE;
     param.cb.send      = send_cb;
     if (get_variant_value() & TEST_AM) {
-        return ucp_am_send_nbx(ep, AM_ID, NULL, 0, &m_sbuf[0], m_sbuf.size(),
+        return ucp_am_send_nbx(ep, AM_ID, NULL, 0, m_sbuf->ptr(), m_sbuf->size(),
                                &param);
     } else if (get_variant_value() & TEST_TAG) {
-        return ucp_tag_send_nbx(ep, &m_sbuf[0], m_sbuf.size(), 0, &param);
+        return ucp_tag_send_nbx(ep, m_sbuf->ptr(), m_sbuf->size(), 0, &param);
     } else if (get_variant_value() & TEST_RMA) {
-        return ucp_put_nbx(ep, &m_sbuf[0], m_sbuf.size(), (uintptr_t)&m_rbuf[0],
-                           rkey, &param);
+        return ucp_put_nbx(ep, m_sbuf->ptr(), m_sbuf->size(),
+                           (uintptr_t)m_rbuf->ptr(), rkey, &param);
     } else {
         ucs_fatal("invalid test case");
     }
@@ -265,21 +272,21 @@ test_ucp_peer_failure::smoke_test(bool stable_pair)
         while (!m_am_rndv_descs.empty()) {
             m_rreq        = ucp_am_recv_data_nbx(recv_entity.worker(),
                                                  m_am_rndv_descs.front(),
-                                                 &m_rbuf[0], m_rbuf.size(),
+                                                 m_rbuf->ptr(), m_rbuf->size(),
                                                  &req_param);
             result.second = request_wait(m_rreq);
             m_am_rndv_descs.pop();
         }
     } else if (get_variant_value() & TEST_TAG) {
-        m_rreq        = ucp_tag_recv_nbx(recv_entity.worker(), &m_rbuf[0],
-                                         m_rbuf.size(), 0, 0, &req_param);
+        m_rreq        = ucp_tag_recv_nbx(recv_entity.worker(), m_rbuf->ptr(),
+                                         m_rbuf->size(), 0, 0, &req_param);
         result.second = request_wait(m_rreq);
     } else if (get_variant_value() & TEST_RMA) {
         // Flush the sender and expect data to arrive on receiver
         void *freq = ucp_ep_flush_nb(send_ep, 0,
                                      (ucp_send_callback_t)ucs_empty_function);
         request_wait(freq);
-        EXPECT_EQ(m_sbuf, m_rbuf);
+        m_rbuf->pattern_check(TX_SEED);
         result.second = UCS_OK;
     }
 
@@ -302,8 +309,8 @@ void test_ucp_peer_failure::get_rkey(ucp_ep_h ep, entity& dst, mem_handle_t& mem
     memset(&params, 0, sizeof(params));
     params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                         UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    params.address    = &m_rbuf[0];
-    params.length     = m_rbuf.size();
+    params.address    = m_rbuf->ptr();
+    params.length     = m_rbuf->size();
 
     ucp_mem_h ucp_memh;
     ucs_status_t status = ucp_mem_map(dst.ucph(), &params, &ucp_memh);
@@ -351,8 +358,7 @@ void test_ucp_peer_failure::do_test(size_t msg_size, int pre_msg_count,
 {
     skip_loopback();
 
-    m_sbuf.resize(msg_size);
-    m_rbuf.resize(msg_size);
+    init_buffers(msg_size);
 
     /* connect 2 ep's from sender() to 2 receiver entities */
     create_entity();
@@ -477,6 +483,11 @@ void test_ucp_peer_failure::cleanup_rndv_descs() {
     }
 }
 
+void test_ucp_peer_failure::init_buffers(size_t msg_size) {
+    m_sbuf.reset(new mem_buffer(msg_size, m_mem_type, TX_SEED));
+    m_rbuf.reset(new mem_buffer(msg_size, m_mem_type, RX_SEED));
+}
+
 UCS_TEST_P(test_ucp_peer_failure, basic) {
     do_test(UCS_KBYTE, /* msg_size */
             0, /* pre_msg_cnt */
@@ -517,9 +528,6 @@ class test_ucp_peer_failure_keepalive : public test_ucp_peer_failure
 {
 public:
     test_ucp_peer_failure_keepalive() {
-        m_sbuf.resize(1 * UCS_MBYTE);
-        m_rbuf.resize(1 * UCS_MBYTE);
-
         m_env.push_back(new ucs::scoped_setenv("UCX_TCP_KEEPIDLE", "inf"));
         m_env.push_back(new ucs::scoped_setenv("UCX_UD_TIMEOUT", "3s"));
     }
@@ -533,6 +541,7 @@ public:
         failing_receiver().connect(&sender(), get_ep_params());
         set_am_handler(failing_receiver());
         set_am_handler(stable_receiver());
+        init_buffers(UCS_MBYTE);
     }
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
@@ -641,16 +650,18 @@ protected:
 
     void init()
     {
+        if (!is_proto_enabled()) {
+            UCS_TEST_SKIP_R("proto v1");
+        }
+
         self = this;
+        modify_config("RNDV_THRESH", "0");
 
         test_ucp_peer_failure::init();
 
         receiver().connect(&sender(), get_ep_params());
         sender().connect(&receiver(), get_ep_params());
         set_am_handler(receiver());
-
-        m_sbuf.resize(UCS_KBYTE);
-        m_rbuf.resize(UCS_KBYTE);
     }
 
     template<typename Func>
@@ -787,6 +798,8 @@ protected:
             UCS_TEST_SKIP_R("transport has no rma_bw lanes");
         }
 
+        init_buffers(16 * UCS_KBYTE);
+
         define_test_settings(mode, replace_ops);
 
         smoke_test(true);
@@ -830,40 +843,68 @@ protected:
 
 test_ucp_peer_failure_rndv_abort *test_ucp_peer_failure_rndv_abort::self = nullptr;
 
-UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort, get_zcopy,
-                     !is_proto_enabled(), "RNDV_THRESH=0",
-                     "RNDV_SCHEME=get_zcopy")
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort, get_zcopy, "RNDV_SCHEME=get_zcopy")
 {
     rndv_progress_failure_test(rndv_mode::rndv_get, true);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort, put_zcopy_force_flush,
-                     !is_proto_enabled(), "RNDV_THRESH=0",
-                     "RNDV_SCHEME=put_zcopy", "RNDV_PUT_FORCE_FLUSH=y")
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort, put_zcopy_force_flush,
+           "RNDV_SCHEME=put_zcopy", "RNDV_PUT_FORCE_FLUSH=y")
 {
     rndv_progress_failure_test(rndv_mode::rndv_put, true);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort,
-                     get_zcopy_memory_invalidation, !is_proto_enabled(),
-                     "RNDV_THRESH=0", "RNDV_SCHEME=get_zcopy")
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort, get_zcopy_memory_invalidation,
+           "RNDV_SCHEME=get_zcopy")
 {
     rndv_progress_failure_test(rndv_mode::rndv_get, false);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort,
-                     put_zcopy_memory_invalidation, !is_proto_enabled(),
-                     "RNDV_THRESH=0", "RNDV_SCHEME=put_zcopy")
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort, put_zcopy_memory_invalidation,
+           "RNDV_SCHEME=put_zcopy")
 {
     rndv_progress_failure_test(rndv_mode::rndv_put, false);
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_peer_failure_rndv_abort,
-                     put_zcopy_force_flush_memory_invalidation,
-                     !is_proto_enabled(), "RNDV_THRESH=0",
-                     "RNDV_SCHEME=put_zcopy", "RNDV_PUT_FORCE_FLUSH=y")
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort,
+           put_zcopy_force_flush_memory_invalidation, "RNDV_SCHEME=put_zcopy",
+           "RNDV_PUT_FORCE_FLUSH=y")
 {
     rndv_progress_failure_test(rndv_mode::rndv_put, false);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_peer_failure_rndv_abort)
+
+
+class test_ucp_peer_failure_rndv_ppln_abort :
+      public test_ucp_peer_failure_rndv_abort {
+public:
+    static void get_test_variants(variant_vec_t &variants)
+    {
+        if (!mem_buffer::is_gpu_supported()) {
+            return;
+        }
+
+        test_ucp_peer_failure_rndv_abort::get_test_variants(variants);
+    }
+
+    void init() override
+    {
+        modify_config("RNDV_SCHEME", "put_ppln");
+        modify_config("RNDV_PIPELINE_SHM_ENABLE", "n");
+        m_mem_type = UCS_MEMORY_TYPE_CUDA;
+        test_ucp_peer_failure_rndv_abort::init();
+    }
+};
+
+UCS_TEST_P(test_ucp_peer_failure_rndv_ppln_abort, rtr_mtype)
+{
+    if (!sender().is_rndv_ppln_supported()) {
+        UCS_TEST_SKIP_R("RNDV pipeline is not supported");
+    }
+    // Sender is supposed to use put_zcopy, because put_mtype is not supported
+    // with error handling yet
+    rndv_progress_failure_test(rndv_mode::rndv_put, true);
+}
+
+UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_peer_failure_rndv_ppln_abort);

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1182,6 +1182,30 @@ bool ucp_test_base::entity::has_lane_with_caps(uint64_t caps) const
     return false;
 }
 
+bool ucp_test_base::entity::is_rndv_ppln_supported() const
+{
+    const auto ep              = this->ep();
+    const auto config          = ucp_ep_config(ep);
+    ucs_memory_type_t mem_type = this->ucph()->config.ext.rndv_frag_mem_type;
+
+    for (auto i = 0; i < config->key.num_lanes; ++i) {
+        const auto lane = config->key.rma_bw_lanes[i];
+        if (lane == UCP_NULL_LANE) {
+            break;
+        }
+        if (ucp_ep_md_attr(ep, lane)->reg_mem_types & UCS_BIT(mem_type)) {
+            const auto iface_attr =
+                ucp_worker_iface_get_attr(this->worker(),
+                        ucp_ep_get_rsc_index(ep, lane));
+            if (iface_attr->cap.flags & UCT_IFACE_FLAG_PUT_ZCOPY) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 bool ucp_test_base::entity::is_conn_reqs_queue_empty() const
 {
     return m_conn_reqs.empty();

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -155,6 +155,8 @@ public:
 
         bool has_lane_with_caps(uint64_t caps) const;
 
+        bool is_rndv_ppln_supported() const;
+
         bool is_conn_reqs_queue_empty() const;
 
     protected:


### PR DESCRIPTION
## What
- Fix abort() function for rtr_mtype (need to set status in the super request, so it is propogated to receive request)
- Add gtest for testing error handling with ppln protocol

