### PR TITLE
AZP: Multiple wire-compat test fixes

### DIFF
--- a/buildlib/pr/wire_compat.yml
+++ b/buildlib/pr/wire_compat.yml
@@ -90,12 +90,13 @@ jobs:
           UCX_LEGACY_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)
         displayName: compare tls performance characteristics
         condition: ne(variables.ucx_tag, 'v1.14.0')
-      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a
+      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a "-c tag"
         env:
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib
           UCX_LEGACY_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/lib
           AZP_AGENT_ID: $(AZP_AGENT_ID)
         displayName: ucp_client_server with UCX $(ucx_tag)
+        condition: ne(variables.ucx_tag, 'v1.14.0')
         timeoutInMinutes: 2
       - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/ucp_hworld -n
         env:
@@ -104,13 +105,14 @@ jobs:
           AZP_AGENT_ID: $(AZP_AGENT_ID)
         displayName: ucp_hello_world with UCX $(ucx_tag)
         timeoutInMinutes: 2
-      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a
+      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a "-c tag"
         env:
           UCX_TLS: ^sm
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib
           UCX_LEGACY_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/lib
           AZP_AGENT_ID: $(AZP_AGENT_ID)
         displayName: ucp_client_server (no sm) with UCX $(ucx_tag)
+        condition: ne(variables.ucx_tag, 'v1.14.0')
         timeoutInMinutes: 2
       - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/ucp_hworld -n
         env:

--- a/buildlib/tools/check_tls_perf_caps.sh
+++ b/buildlib/tools/check_tls_perf_caps.sh
@@ -15,6 +15,8 @@ LD_LIBRARY_PATH=${UCX_PR_PATH}/lib "${UCX_PR_PATH}"/bin/ucx_info -v
 LD_LIBRARY_PATH=${UCX_LEGACY_PATH}/lib old_out=$("${UCX_LEGACY_PATH}"/bin/ucx_info -d)
 LD_LIBRARY_PATH=${UCX_PR_PATH}/lib new_out=$("${UCX_PR_PATH}"/bin/ucx_info -d)
 
+export UCX_TCP_BRIDGE_ENABLE=y #bridge devices are not shown by default since v1.16
+
 res=true
 for tl_name in $(echo "${old_out}" | grep Transport | awk '{print $3}')
 do

--- a/buildlib/tools/test_wire_compat.sh
+++ b/buildlib/tools/test_wire_compat.sh
@@ -7,21 +7,23 @@
 
 exe_name=$1
 client_opt=$2
+common_opt=$3
 port=$((10000 + 1000 * ${AZP_AGENT_ID}))
 
 export UCX_CM_REUSEADDR=y UCX_LOG_LEVEL=info UCX_WARN_UNUSED_ENV_VARS=n
+export UCX_IB_ROCE_LOCAL_SUBNET=y
 exe_cmd="stdbuf -oL ${exe_name} -p ${port}"
 
 # Test server is legacy, client is master
-LD_LIBRARY_PATH=${UCX_LEGACY_LIB_PATH} ${exe_cmd} &
+LD_LIBRARY_PATH=${UCX_LEGACY_LIB_PATH} ${exe_cmd} ${common_opt} &
 server_pid=$!
 sleep 5
-LD_LIBRARY_PATH=${UCX_PR_LIB_PATH} ${exe_cmd} ${client_opt} 127.0.0.1
+LD_LIBRARY_PATH=${UCX_PR_LIB_PATH} ${exe_cmd} ${common_opt} ${client_opt} 127.0.0.1
 if ! kill -9 ${server_pid}; then echo "server already terminated"; fi
 
 # Test server is master, client is legacy
-LD_LIBRARY_PATH=${UCX_PR_LIB_PATH} ${exe_cmd} &
+LD_LIBRARY_PATH=${UCX_PR_LIB_PATH} ${exe_cmd} ${common_opt} &
 server_pid=$!
 sleep 5
-LD_LIBRARY_PATH=${UCX_LEGACY_LIB_PATH} ${exe_cmd} ${client_opt} 127.0.0.1
+LD_LIBRARY_PATH=${UCX_LEGACY_LIB_PATH} ${exe_cmd} ${common_opt} ${client_opt} 127.0.0.1
 if ! kill -9 ${server_pid}; then echo "server already terminated"; fi


### PR DESCRIPTION
## What
Some fixes in wire-compat testing:
- Use tag API in client-server example to make sure that RMA BW lanes are established
- Use `UCX_TCP_BRIDGE_ENABLE=y` to not fail `check_tls_perf_caps.sh`, because bridge devices are not shown in `ucx_info -d` since #9487
- Do not try to connect to different subnet addresses with RoCE
