### PR TITLE
UCT: Fix descriprion of uct_md_flags_v2_t

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -938,7 +938,7 @@ typedef enum {
      * Memory domain supports invalidation of memory handle registered by
      * @ref uct_md_mem_reg_v2 with @ref UCT_MD_MEM_ACCESS_RMA flag and packed
      * key by @ref uct_md_mkey_pack_v2 with
-     * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag.
+     * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA flag.
      */
     UCT_MD_FLAG_INVALIDATE_RMA = UCT_MD_FLAG_V2_FIRST,
 
@@ -946,7 +946,7 @@ typedef enum {
      * Memory domain supports invalidation of memory handle registered by
      * @ref uct_md_mem_reg_v2 with @ref UCT_MD_MEM_ACCESS_REMOTE_ATOMIC flag and
      * packed key by @ref uct_md_mkey_pack_v2 with
-     * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE flag.
+     * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE_AMO flag.
      */
     UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12)
 } uct_md_flags_v2_t;


### PR DESCRIPTION
## What
Fix doc (flag `UCT_MD_MKEY_PACK_FLAG_INVALIDATE` does not exist)
