### PR TITLE
UCT/IB/DC: apply append_safe mechanism to dcis array, added ucs_array_resize_safe for similar reasons

### DIFF
--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -278,13 +278,20 @@ ucs_array_old_buffer_set_null(void **old_buffer_p)
  * @param _new_length      New size for the array.
  * @param _init_value      Initialize new elements to this value.
  * @param _failed_actions  Actions to perform if the append operation failed.
+ * @param _old_buffer_p    If the array was reallocated, and this parameter is
+ *                         non-NULL, the previous buffer will not be released,
+ *                         instead it will be returned in *_old_buffer_p,
+ *                         and the caller should copy the contents of the previous buffer 
+ *                         to the new array buffer.
  */
-#define ucs_array_resize(_array, _new_length, _init_value, _failed_actions) \
+#define ucs_array_resize_safe(_array, _new_length, _init_value, \
+                              _failed_actions, _old_buffer_p) \
     { \
         ucs_typeof((_array)->length) _extend_index; \
         ucs_status_t _extend_status; \
         \
-        _extend_status = ucs_array_reserve(_array, _new_length); \
+        _extend_status = ucs_array_reserve_safe(_array, _new_length, \
+                                                _old_buffer_p); \
         if (_extend_status == UCS_OK) { \
             for (_extend_index = (_array)->length; \
                  _extend_index < (_new_length); ++_extend_index) { \
@@ -295,6 +302,19 @@ ucs_array_old_buffer_set_null(void **old_buffer_p)
             _failed_actions; \
         } \
     }
+
+
+/*
+ * Change the size of the array and initialize new elements.
+ *
+ * @param _array           Array to resize.
+ * @param _new_length      New size for the array.
+ * @param _init_value      Initialize new elements to this value.
+ * @param _failed_actions  Actions to perform if the append operation failed.
+ */
+#define ucs_array_resize(_array, _new_length, _init_value, _failed_actions) \
+    ucs_array_resize_safe(_array, _new_length, _init_value, _failed_actions, \
+                          NULL)
 
 
 /**

--- a/src/ucs/datastruct/list.h
+++ b/src/ucs/datastruct/list.h
@@ -7,6 +7,7 @@
 #ifndef UCS_LIST_H_
 #define UCS_LIST_H_
 
+#include <ucs/debug/debug.h>
 #include <ucs/sys/compiler_def.h>
 
 
@@ -15,6 +16,8 @@ BEGIN_C_DECLS
 #define UCS_LIST_INITIALIZER(_prev, _next) \
     { (_prev), (_next) }
 
+#define UCS_LIST_CHECK_ELEM_IS_VALID(_elem) \
+    UCS_ASAN_ADDRESS_IS_VALID(_elem, sizeof(ucs_list_link_t));
 
 /**
  * Declare an empty list
@@ -111,6 +114,7 @@ static inline void ucs_list_del(ucs_list_link_t *elem)
  */
 static inline int ucs_list_is_empty(const ucs_list_link_t *head)
 {
+    UCS_LIST_CHECK_ELEM_IS_VALID(head->next);
     return head->next == head;
 }
 
@@ -120,6 +124,8 @@ static inline int ucs_list_is_empty(const ucs_list_link_t *head)
 static inline int
 ucs_list_is_first(const ucs_list_link_t *head, const ucs_list_link_t *elem)
 {
+    UCS_LIST_CHECK_ELEM_IS_VALID(head);
+    UCS_LIST_CHECK_ELEM_IS_VALID(elem->prev);
     return elem->prev == head;
 }
 
@@ -129,6 +135,8 @@ ucs_list_is_first(const ucs_list_link_t *head, const ucs_list_link_t *elem)
 static inline int
 ucs_list_is_last(const ucs_list_link_t *head, const ucs_list_link_t *elem)
 {
+    UCS_LIST_CHECK_ELEM_IS_VALID(head);
+    UCS_LIST_CHECK_ELEM_IS_VALID(elem->next);
     return elem->next == head;
 }
 
@@ -177,7 +185,9 @@ static inline unsigned long ucs_list_length(ucs_list_link_t *head)
     unsigned long length;
     ucs_list_link_t *ptr;
 
+    UCS_LIST_CHECK_ELEM_IS_VALID(head->next);
     for (ptr = head->next, length = 0; ptr != head; ptr = ptr->next, ++length);
+
     return length;
 }
 
@@ -215,6 +225,7 @@ static inline unsigned long ucs_list_length(ucs_list_link_t *head)
  * Iterate over members of the list.
  */
 #define ucs_list_for_each(_elem, _head, _member) \
+    UCS_LIST_CHECK_ELEM_IS_VALID(_head); \
     for (_elem = ucs_container_of((_head)->next, ucs_typeof(*_elem), _member); \
         &(_elem)->_member != (_head); \
         _elem = ucs_container_of((_elem)->_member.next, ucs_typeof(*_elem), _member))
@@ -223,6 +234,7 @@ static inline unsigned long ucs_list_length(ucs_list_link_t *head)
  * Iterate over members of the list, the user may invalidate the current entry.
  */
 #define ucs_list_for_each_safe(_elem, _telem, _head, _member) \
+    UCS_LIST_CHECK_ELEM_IS_VALID(_head); \
     for (_elem = ucs_container_of((_head)->next, ucs_typeof(*_elem), _member), \
         _telem = ucs_container_of(_elem->_member.next, ucs_typeof(*_elem), _member); \
         &_elem->_member != (_head); \

--- a/src/ucs/debug/debug.h
+++ b/src/ucs/debug/debug.h
@@ -9,6 +9,12 @@
 
 #include <ucs/sys/compiler_def.h>
 
+#ifdef __SANITIZE_ADDRESS__
+#include <sanitizer/asan_interface.h>
+#include <ucs/debug/assert.h>
+#endif
+
+
 BEGIN_C_DECLS
 
 /**
@@ -17,6 +23,15 @@ BEGIN_C_DECLS
  * @param signum   Signal number to disable handling.
  */
 void ucs_debug_disable_signal(int signum);
+
+
+#ifdef __SANITIZE_ADDRESS__
+#define UCS_ASAN_ADDRESS_IS_VALID(_ptr, _size) \
+    ucs_assertv(!__asan_region_is_poisoned((void*)(_ptr), _size), "%s: %p", \
+                #_ptr, (void*)(_ptr))
+#else
+#define UCS_ASAN_ADDRESS_IS_VALID(_ptr, _size)
+#endif
 
 END_C_DECLS
 

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -861,12 +861,19 @@ ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
                                                     uint16_t size)
 {
     uct_dc_dci_t empty_dci = {{{0}}};
+    size_t old_length      = ucs_array_length(&iface->tx.dcis);
+    void *old_buffer_p;
 
     empty_dci.txwq.super.qp_num = UCT_IB_INVALID_QPN;
-    ucs_array_resize(&iface->tx.dcis, size, empty_dci,
-                     ucs_error("%p: could not resize dcis array to %u", iface,
-                               size);
-                     return UCS_ERR_NO_MEMORY);
+    ucs_array_resize_safe(&iface->tx.dcis, size, empty_dci,
+                          ucs_error("%p: could not resize dcis array to %u",
+                                    iface, size);
+                          return UCS_ERR_NO_MEMORY, &old_buffer_p);
+    if (old_buffer_p) {
+        uct_dc_mlx5_iface_dcis_array_copy(iface->tx.dcis.buffer, old_buffer_p,
+                                          old_length);
+        ucs_array_buffer_free(old_buffer_p);
+    }
 
     return UCS_OK;
 }
@@ -879,11 +886,7 @@ uct_dc_mlx5_iface_dcis_create(uct_dc_mlx5_iface_t *iface,
     uct_dc_dci_t *dci;
 
     ucs_array_init_dynamic(&iface->tx.dcis);
-    /* Reserving max size as a temporary solution due to pointer-copy issue in ucs_array
-       TODO: fix when ucs_array_t supports complex types 
-    */
-    status = uct_dc_mlx5_iface_resize_and_fill_dcis(
-            iface, UCT_DC_MLX5_IFACE_MAX_DCI_POOLS * iface->tx.ndci);
+    status = uct_dc_mlx5_iface_resize_and_fill_dcis(iface, 1);
     if (status != UCS_OK) {
         return status;
     }
@@ -899,6 +902,8 @@ uct_dc_mlx5_iface_dcis_create(uct_dc_mlx5_iface_t *iface,
 
     iface->tx.bb_max = dci->txwq.bb_max;
     uct_dc_mlx5_destroy_dci(iface, dci);
+
+    ucs_array_length(&iface->tx.dcis) = 0;
 
     return UCS_OK;
 }

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -500,10 +500,10 @@ public:
         uct_dc_mlx5_iface_t *iface      = ucs_derived_of(e->iface(),
                                                          uct_dc_mlx5_iface_t);
         uct_dc_mlx5_pool_stack_t *stack = &iface->tx.dci_pool[0].stack;
+        uct_dc_dci_t *dci;
 
-        for (int i = 0; i < iface->tx.ndci; ++i) {
-            uct_rc_txqp_available_set(&ucs_array_elem(&iface->tx.dcis, i).txqp,
-                                      0);
+        ucs_array_for_each(dci, &iface->tx.dcis) {
+            uct_rc_txqp_available_set(&dci->txqp, 0);
         }
 
         for (int i = ucs_array_length(stack); i < iface->tx.ndci; i++) {
@@ -515,9 +515,9 @@ public:
     virtual void enable_entity(entity *e, unsigned cq_num = 128) {
         uct_dc_mlx5_iface_t *iface = ucs_derived_of(e->iface(),
                                                     uct_dc_mlx5_iface_t);
+        uct_dc_dci_t *dci;
 
-        for (int i = 0; i < iface->tx.ndci; ++i) {
-            uct_dc_dci_t *dci = &ucs_array_elem(&iface->tx.dcis, i);
+        ucs_array_for_each(dci, &iface->tx.dcis) {
             uct_rc_txqp_available_set(&dci->txqp, dci->txwq.bb_max);
         }
 


### PR DESCRIPTION
## What
Used `ucs_array_append_safe` when adding a new DCI, and `ucs_array_resize_safe` in random policy

## Why ?
Applying changes from #9930 to `dcis` array and avoiding the reservation of the entire array (a fix that was used as a workaround to `ucs_array_t` copy issue)