### PR TITLE
UCT/IB/DC: minor fix - hw_dcs assumes 1 dci was created

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -28,12 +28,12 @@
 #define UCT_DC_MLX5_MAX_TX_CQ_LEN (16 * UCS_MBYTE)
 
 
-static const char *uct_dc_tx_policy_names[] = {
-    [UCT_DC_TX_POLICY_DCS]           = "dcs",
-    [UCT_DC_TX_POLICY_DCS_QUOTA]     = "dcs_quota",
-    [UCT_DC_TX_POLICY_RAND]          = "rand",
-    [UCT_DC_TX_POLICY_HW_DCS]        = "hw_dcs",
-    [UCT_DC_TX_POLICY_LAST]          = NULL
+const char *uct_dc_tx_policy_names[] = {
+    [UCT_DC_TX_POLICY_DCS]       = "dcs",
+    [UCT_DC_TX_POLICY_DCS_QUOTA] = "dcs_quota",
+    [UCT_DC_TX_POLICY_RAND]      = "rand",
+    [UCT_DC_TX_POLICY_HW_DCS]    = "hw_dcs",
+    [UCT_DC_TX_POLICY_LAST]      = NULL
 };
 
 static const char *uct_dct_affinity_policy_names[] = {

--- a/src/uct/ib/mlx5/dc/dc_mlx5.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.h
@@ -351,6 +351,9 @@ struct uct_dc_mlx5_iface {
 
 extern ucs_config_field_t uct_dc_mlx5_iface_config_table[];
 
+extern const char *uct_dc_tx_policy_names[];
+
+
 ucs_status_t
 uct_dc_mlx5_iface_create_dct(uct_dc_mlx5_iface_t *iface,
                              const uct_dc_mlx5_iface_config_t *config);

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
@@ -361,8 +361,13 @@ uct_dc_mlx5_ep_basic_init(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
         }
     } else if (uct_dc_mlx5_iface_is_hw_dcs(iface)) {
         ucs_assertv(iface->tx.ndci == 1, "ndci=%u", iface->tx.ndci);
-        dci                   = uct_dc_mlx5_iface_dci(iface, ep->dci);
+        if (ucs_array_is_empty(&iface->tx.dcis)) {
+            uct_dc_mlx5_iface_resize_and_fill_dcis(iface, 1);
+            uct_dc_mlx5_dci_pool_init_dci(iface, uct_dc_mlx5_ep_pool_index(ep),
+                                          0);
+        }
         ep->dci               = 0;
+        dci                   = uct_dc_mlx5_iface_dci(iface, ep->dci);
         ep->dci_channel_index = dci->next_channel_index++ %
                                 iface->tx.num_dci_channels;
     } else {

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -477,7 +477,53 @@ UCT_DC_INSTANTIATE_TEST_CASE(test_dc)
 
 
 class test_dc_flow_control : public test_rc_flow_control {
+protected:
+    virtual void init()
+    {
+        modify_config("DC_MLX5_TX_POLICY", get_tx_policy_name());
+        test_rc_flow_control::init();
+    }
+
 public:
+    static std::vector<const struct resource*>
+    enum_resources(const std::string &tl_name)
+    {
+        static std::vector<struct resource> all_resources;
+        auto resources = uct_test::enum_resources(tl_name);
+
+        if (resources.empty()) {
+            return resources;
+        }
+
+        ucs_assert(tl_name == "dc_mlx5");
+
+        if (all_resources.empty()) {
+            std::vector<uct_dc_tx_policy_t> policies =
+                    {UCT_DC_TX_POLICY_DCS_QUOTA, UCT_DC_TX_POLICY_RAND,
+                     UCT_DC_TX_POLICY_HW_DCS};
+            for (auto policy : policies) {
+                for (const auto &elem : resources) {
+                    struct resource rsc = *elem;
+                    rsc.variant         = policy;
+                    rsc.variant_name    = uct_dc_tx_policy_names[policy];
+                    all_resources.push_back(rsc);
+                }
+            }
+        }
+
+        return filter_resources(all_resources,
+                                resource::is_equal_component_name, "");
+    }
+
+    int get_tx_policy() const
+    {
+        return GetParam()->variant;
+    }
+
+    std::string get_tx_policy_name() const
+    {
+        return GetParam()->variant_name;
+    }
 
     /* virtual */
     uct_rc_fc_t* get_fc_ptr(entity *e, int ep_idx = 0) {
@@ -614,8 +660,14 @@ UCS_TEST_P(test_dc_flow_control, soft_request)
  * 2) No crash when grant for destroyed ep arrives */
 UCS_TEST_P(test_dc_flow_control, flush_destroy)
 {
-    int wnd = 5;
+    int wnd                    = 5;
+    uct_dc_mlx5_iface_t *iface = ucs_derived_of(m_e1->iface(),
+                                                uct_dc_mlx5_iface_t);
     ucs_status_t status;
+
+    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+        UCS_TEST_SKIP_R("shared dcis are not supported - no pending wait");
+    }
 
     disable_entity(m_e2);
 


### PR DESCRIPTION
## What
HW_DCS policy assumes a dci was already created, leading to infinite polling if not creating it in ep_basic_init

* Added a few simple hw_dcs tests as that policy is not tested in CI at all.

## Why ?
This is a bug that started in one of the recent features: dynamic creation of dcis (#9665)

