### PR TITLE
UCT/KNEM/CUDA_IPC/SELF: Fixed uct_ep_is_connected

### DIFF
--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -310,9 +310,21 @@ int uct_base_iface_is_reachable(const uct_iface_h tl_iface,
 int uct_base_ep_is_connected(const uct_ep_h tl_ep,
                              const uct_ep_is_connected_params_t *params)
 {
-    UCT_EP_IS_CONNECTED_CHECK_DEV_IFACE_ADDRS(params);
-    return uct_base_iface_is_reachable(tl_ep->iface, params->device_addr,
-                                       params->iface_addr);
+    uct_iface_is_reachable_params_t is_reachable_params = {0};
+
+    if (params->field_mask & UCT_EP_IS_CONNECTED_FIELD_DEVICE_ADDR) {
+        is_reachable_params.field_mask |=
+                UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR;
+        is_reachable_params.device_addr = params->device_addr;
+    }
+
+    if (params->field_mask & UCT_EP_IS_CONNECTED_FIELD_IFACE_ADDR) {
+        is_reachable_params.field_mask |=
+                UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR;
+        is_reachable_params.iface_addr  = params->iface_addr;
+    }
+
+    return uct_iface_is_reachable_v2(tl_ep->iface, &is_reachable_params);
 }
 
 int uct_ep_is_connected(uct_ep_h ep, const uct_ep_is_connected_params_t *params)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -480,7 +480,7 @@ static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_cuda_ipc_iface_is_reachable_v2,
-    .ep_is_connected       = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int
+    .ep_is_connected       = uct_cuda_ipc_ep_is_connected
 };
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -79,7 +79,8 @@ uct_cma_iface_is_reachable_v2(const uct_iface_h tl_iface,
     ucs_cma_iface_ext_device_addr_t *iface_addr;
     pid_t peer_pid;
 
-    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
+    if (!uct_iface_is_reachable_params_addrs_valid(params) ||
+        (params->device_addr == NULL) || (params->iface_addr == NULL)) {
         return 0;
     }
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -374,7 +374,8 @@ static uct_iface_internal_ops_t uct_self_iface_internal_ops = {
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
     .ep_invalidate         = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
     .ep_connect_to_ep_v2   = ucs_empty_function_return_unsupported,
-    .iface_is_reachable_v2 = uct_self_iface_is_reachable_v2
+    .iface_is_reachable_v2 = uct_self_iface_is_reachable_v2,
+    .ep_is_connected       = uct_base_ep_is_connected
 };
 
 static uct_iface_ops_t uct_self_iface_ops = {

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -599,6 +599,16 @@ protected:
     UCT_INSTANTIATE_RC_TEST_CASE(_test_case) \
     _UCT_INSTANTIATE_TEST_CASE(_test_case, dc_mlx5)
 
+
+/**
+ * Instantiate the parametrized test case for CUDA_IPC.
+ * TODO: add cuda_ipc to UCT_INSTANTIATE_TEST_CASE.
+ *
+ * @param _test_case  Test case class, derived from uct_test.
+ */
+#define UCT_INSTANTIATE_CUDA_IPC_TEST_CASE(_test_case) \
+    _UCT_INSTANTIATE_TEST_CASE(_test_case, cuda_ipc)
+
 std::ostream& operator<<(std::ostream& os, const uct_tl_resource_desc_t& resource);
 
 #endif


### PR DESCRIPTION
## What
Fixed uct_ep_is_connected API for 3 transports: knem, self, cuda_ipc.

## Why ?
These transports should support is_connected API in order for EP reconfiguration to work properly.

## How
1) The macro `UCT_EP_IS_CONNECTED_CHECK_DEV_IFACE_ADDRS` is removed from `uct_base_ep_is_connected`, in order to allow transports without dev_addr to use it (eg. knem).
2) In cuda_ipc/self -> updated `ep_is_connected` callback.
