### PR TITLE
UCT/IB/MLX5: Add multi_path config to enable Adaptive Routing

### DIFF
--- a/src/ucs/config/types.h
+++ b/src/ucs/config/types.h
@@ -94,6 +94,20 @@ typedef enum {
 } ucs_config_print_flags_t;
 
 
+static inline int
+ucs_ternary_auto_value_is_yes_or_try(ucs_ternary_auto_value_t value)
+{
+    return (value == UCS_YES) || (value == UCS_TRY);
+}
+
+
+static inline int
+ucs_ternary_auto_value_is_yes_or_no(ucs_ternary_auto_value_t value)
+{
+    return (value == UCS_YES) || (value == UCS_NO);
+}
+
+
 /**
  * Structure type for array configuration. Should be used inside the configuration
  * structure declaration.

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -345,6 +345,7 @@ struct uct_ib_iface {
         enum ibv_mtu                 path_mtu;
         uint8_t                      counter_set_id;
         uct_ib_iface_send_overhead_t send_overhead;
+        ucs_ternary_auto_value_t     dp_ordering_ooo; /* Activate RW OOO */
     } config;
 
     uct_ib_iface_ops_t        *ops;

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1606,6 +1606,13 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
                               tl_md, worker, params, &config->super,
                               &config->rc_mlx5_common, &init_attr);
 
+    status = uct_rc_mlx5_dp_ordering_ooo_init(
+            &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC,
+            &config->rc_mlx5_common, "dc");
+    if (status != UCS_OK) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     tx_cq_size = uct_ib_cq_size(&self->super.super.super, &init_attr,
                                 UCT_IB_DIR_TX);
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -462,6 +462,16 @@ ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
     return UCS_OK;
 }
 
+void uct_ib_mlx5_devx_set_qpc_dp_ordering(
+        void *qpc, ucs_ternary_auto_value_t dp_ordering_ooo)
+{
+    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_0,
+                      ucs_ternary_auto_value_is_yes_or_try(dp_ordering_ooo));
+    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_1, 0);
+    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_force,
+                      ucs_ternary_auto_value_is_yes_or_no(dp_ordering_ooo));
+}
+
 void uct_ib_mlx5_devx_set_qpc_port_affinity(uct_ib_mlx5_md_t *md,
                                             uint8_t path_index, void *qpc,
                                             uint32_t *opt_param_mask)

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -202,7 +202,10 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    pps[0x1];
     uint8_t    pps_modify[0x1];
     uint8_t    log_max_msg[0x5];
-    uint8_t    reserved_at_1c8[0x4];
+    uint8_t    dp_ordering_ooo_rw_xrc[0x1];
+    uint8_t    dp_ordering_ooo_rw_dc[0x1];
+    uint8_t    dp_ordering_ooo_rw_rc[0x1];
+    uint8_t    reserved_at_1cb[0x1];
     uint8_t    max_tc[0x4];
     uint8_t    reserved_at_1d0[0x1];
     uint8_t    dcbx[0x1];
@@ -500,7 +503,8 @@ struct uct_ib_mlx5_cmd_hca_cap_2_bits {
 
     uint8_t    reserved_at_80[0x3];
     uint8_t    max_num_prog_sample_field[0x5];
-    uint8_t    reserved_at_88[0x3];
+    uint8_t    dp_ordering_force[0x1];
+    uint8_t    reserved_at_89[0x2];
     uint8_t    log_max_num_reserved_qpn[0x5];
     uint8_t    atomic_rate_pa[0x1];
     uint8_t    introspection_mkey_access_allowed[0x1];
@@ -870,7 +874,7 @@ struct uct_ib_mlx5_set_xrq_dc_params_entry_in_bits {
     uint8_t         reserved_at_80[0x3];
     uint8_t         ack_timeout[0x5];
     uint8_t         reserved_at_88[0x4];
-    uint8_t         multi_path[0x1];
+    uint8_t         dp_ordering[0x1];
     uint8_t         mtu[0x3];
     uint8_t         pkey_table_index[0x10];
 
@@ -913,7 +917,8 @@ struct uct_ib_mlx5_dctc_bits {
     uint8_t         offload_type[0x4];
     uint8_t         reserved_at_1c[0x4];
 
-    uint8_t         reserved_at_20[0x8];
+    uint8_t         reserved_at_20[0x7];
+    uint8_t         dp_ordering_force[0x1];
     uint8_t         user_index[0x18];
 
     uint8_t         reserved_at_40[0x8];
@@ -928,8 +933,9 @@ struct uct_ib_mlx5_dctc_bits {
     uint8_t         latency_sensitive[0x1];
     uint8_t         rlky[0x1];
     uint8_t         force_full_handshake[0x1];
-    uint8_t         multi_path[0x1];
-    uint8_t         reserved_at_74[0xc];
+    uint8_t         dp_ordering_0[0x1];
+    uint8_t         dp_ordering_1[0x1];
+    uint8_t         reserved_at_75[0xb];
 
     uint8_t         reserved_at_80[0x8];
     uint8_t         cs_res[0x8];
@@ -1384,7 +1390,8 @@ struct uct_ib_mlx5_qpc_bits {
     uint8_t         latency_sensitive[0x1];
     uint8_t         reserved_at_24[0x1];
     uint8_t         drain_sigerr[0x1];
-    uint8_t         reserved_at_26[0x2];
+    uint8_t         dp_ordering_0[0x1];
+    uint8_t         dp_ordering_force[0x1];
     uint8_t         pd[0x18];
 
     uint8_t         mtu[0x3];
@@ -1458,7 +1465,8 @@ struct uct_ib_mlx5_qpc_bits {
     uint8_t         rae[0x1];
     uint8_t         reserved_at_493[0x1];
     uint8_t         page_offset[0x6];
-    uint8_t         reserved_at_49a[0x3];
+    uint8_t         reserved_at_49a[0x2];
+    uint8_t         dp_ordering_1[0x1];
     uint8_t         cd_slave_receive[0x1];
     uint8_t         cd_slave_send[0x1];
     uint8_t         cd_master[0x1];

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -201,9 +201,15 @@ enum {
     UCT_IB_MLX5_MD_FLAG_UAR_USE_WC           = UCS_BIT(17),
     /* Device supports implicit ODP with PCI relaxed order */
     UCT_IB_MLX5_MD_FLAG_GVA_RO               = UCS_BIT(18),
+    /* RoCE supports out-of-order RDMA for RC */
+    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC = UCS_BIT(19),
+    /* RoCE supports out-of-order RDMA for DC */
+    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC = UCS_BIT(20),
+    /* RoCE supports forcing ordering configuration */
+    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE     = UCS_BIT(21),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 19,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 22,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),
@@ -954,6 +960,9 @@ uct_ib_mlx5_devx_general_cmd(struct ibv_context *context,
 ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
                                                 uint8_t port_num,
                                                 uint16_t *ooo_sl_mask_p);
+
+void uct_ib_mlx5_devx_set_qpc_dp_ordering(
+        void *qpc, ucs_ternary_auto_value_t dp_ordering_ooo);
 
 void uct_ib_mlx5_devx_set_qpc_port_affinity(uct_ib_mlx5_md_t *md,
                                             uint8_t path_index, void *qpc,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -475,6 +475,13 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_iface_ops_t*,
 #define UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ 8
 
 
+ucs_status_t
+uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
+                                 uint64_t tl_flag,
+                                 uct_rc_mlx5_iface_common_config_t *config,
+                                 const char *tl_name);
+
+
 #if IBV_HW_TM
 void uct_rc_mlx5_handle_unexp_rndv(uct_rc_mlx5_iface_common_t *iface,
                                    struct ibv_tmh *tmh, uct_tag_t tag,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -434,6 +434,8 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
                               uct_ib_iface_roce_dscp(&iface->super.super));
         }
 
+        uct_ib_mlx5_devx_set_qpc_dp_ordering(
+                qpc, iface->super.super.config.dp_ordering_ooo);
         uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
                                                &opt_param_mask);
     } else {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -923,6 +923,13 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
                               tl_md, worker, params, &config->super.super,
                               &config->rc_mlx5_common, &init_attr);
 
+    status = uct_rc_mlx5_dp_ordering_ooo_init(
+            &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC,
+            &config->rc_mlx5_common, "rc_mlx5");
+    if (status != UCS_OK) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);
     if (status != UCS_OK) {
         return status;


### PR DESCRIPTION
## What
Add adaptive routing support for `rc_x` and `dc` transports on RoCE by the use of `multi_path` and `multi_path_force` parameters.

## Why ?
Need to implement `UCX_IB_AR_ENABLE=auto/no/yes` for RoCE.

## How ?
Use PRM to add:
- HCA Cap/Cap2 multi_path force/rc/rcx/dc handling
  - force option allows overriding nvconfig/sm..
- skip setting multipath parameters upon QP creation
- on RoCE: dc: set both for DCT context and DC QP INIT2RTR transition as specified in PRM
- on RoCE: rc_x: set multipath parameters on QP INIT2RTR transition as specified in PRM

### Tested
On RoCE cluster tested UCX_IB_AR_ENABLE=auto/no/yes for rc_x and dc. Could not confirm actual throughput improvement.
