### PR TITLE
UCM: Use mmap instead of mremap while parsing /proc/self/maps - v1.17.x

### DIFF
--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -156,7 +156,7 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
     char prot_c[4];
     int line_num;
     int prot;
-    char *ptr, *newline;
+    char *ptr, *newline, *orig_buffer;
     int maps_fd;
     int ret;
     int n;
@@ -188,11 +188,24 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
             }
         } else if (read_size == buffer_size - offset) {
             /* enlarge buffer */
-            buffer = ucm_orig_mremap(buffer, buffer_size, buffer_size * 2,
-                                     MREMAP_MAYMOVE, NULL);
+            orig_buffer = buffer;
+            buffer      = ucm_orig_mmap(NULL, buffer_size * 2,
+                                        PROT_READ|PROT_WRITE,
+                                        MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
             if (buffer == MAP_FAILED) {
-                ucm_fatal("failed to allocate maps buffer(size=%zu)", buffer_size);
+                ucm_fatal("failed to reallocate buffer for reading "
+                          "/proc/self/maps from %p/%zu to size %zu: %m",
+                          orig_buffer, buffer_size, buffer_size * 2);
             }
+
+            memcpy(buffer, orig_buffer, buffer_size);
+
+            ret = ucm_orig_munmap(orig_buffer, buffer_size);
+            if (ret != 0) {
+                ucm_warn("munmap(%p, %zu) failed: %m", orig_buffer,
+                         buffer_size);
+            }
+
             buffer_size *= 2;
 
             /* read again from the beginning of the file */


### PR DESCRIPTION
## What
Backport the related #9901 and #9876 to keep the code in sync with master.