### PR TITLE
UCS/SYS/COMPILER_DEF: use __func__ instead of __FUNCTION__ to meet standard

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -36,7 +36,7 @@
         ret = ucm_orig_##_name(ptr_arg, UCM_FUNC_PASS_ARGS(__VA_ARGS__)); \
         if (ret == (_success)) { \
             ptr = _ref ptr_arg; \
-            ucm_trace("%s(" _args_fmt ") allocated %p", __FUNCTION__, \
+            ucm_trace("%s(" _args_fmt ") allocated %p", __func__, \
                       UCM_FUNC_PASS_ARGS(__VA_ARGS__), (void*)ptr); \
             ucm_cuda_dispatch_mem_alloc((CUdeviceptr)ptr, (_size), \
                                         (_mem_type)); \
@@ -53,7 +53,7 @@
         _retval ret; \
         \
         ucm_event_enter(); \
-        ucm_trace("%s(" _args_fmt ")", __FUNCTION__, \
+        ucm_trace("%s(" _args_fmt ")", __func__, \
                   UCM_FUNC_PASS_ARGS(__VA_ARGS__)); \
         ucm_cuda_dispatch_mem_free((CUdeviceptr)(_ptr_arg), _size, _mem_type, \
                                    #_name); \

--- a/src/ucm/util/log.h
+++ b/src/ucm/util/log.h
@@ -18,7 +18,7 @@
 #define ucm_log(_level, _message, ...) \
     if (((_level) <= UCS_MAX_LOG_LEVEL) && \
         ((_level) <= (int)ucm_global_opts.log_level)) { \
-        __ucm_log(__FILE__, __LINE__, __FUNCTION__, (_level), _message, \
+        __ucm_log(__FILE__, __LINE__, __func__, (_level), _message, \
                   ## __VA_ARGS__); \
     }
 

--- a/src/ucm/util/replace.h
+++ b/src/ucm/util/replace.h
@@ -34,7 +34,7 @@ extern pthread_t volatile ucm_reloc_get_orig_thread;
     { \
         _rettype res; \
         UCM_BISTRO_PROLOGUE; \
-        ucm_trace("%s()", __FUNCTION__); \
+        ucm_trace("%s()", __func__); \
         \
         if (ucs_unlikely(ucm_reloc_get_orig_thread == pthread_self())) { \
             return (_rettype)_fail_val; \
@@ -60,7 +60,7 @@ extern pthread_t volatile ucm_reloc_get_orig_thread;
         typedef _rettype (*func_ptr_t) (__VA_ARGS__); \
         static func_ptr_t orig_func_ptr = NULL; \
         \
-        ucm_trace("%s()", __FUNCTION__); \
+        ucm_trace("%s()", __func__); \
         \
         if (ucs_unlikely(orig_func_ptr == NULL)) { \
             pthread_mutex_lock(&ucm_reloc_get_orig_lock); \

--- a/src/ucs/debug/assert.h
+++ b/src/ucs/debug/assert.h
@@ -24,7 +24,7 @@ BEGIN_C_DECLS
 #define ucs_assert_always(_expression) \
     do { \
         if (!ucs_likely(_expression)) { \
-            ucs_fatal_error_format(__FILE__, __LINE__, __FUNCTION__, \
+            ucs_fatal_error_format(__FILE__, __LINE__, __func__, \
                                    "Assertion `%s' failed", #_expression); \
         } \
     } while (0)
@@ -36,7 +36,7 @@ BEGIN_C_DECLS
 #define ucs_assertv_always(_expression, _fmt, ...) \
     do { \
         if (!ucs_likely(_expression)) { \
-            ucs_fatal_error_format(__FILE__, __LINE__, __FUNCTION__, \
+            ucs_fatal_error_format(__FILE__, __LINE__, __func__, \
                                    "Assertion `%s' failed: " _fmt, \
                                    #_expression, ## __VA_ARGS__); \
         } \
@@ -47,7 +47,7 @@ BEGIN_C_DECLS
  * Generate a fatal error
  */
 #define ucs_fatal(_fmt, ...) \
-    ucs_fatal_error_format(__FILE__, __LINE__, __FUNCTION__, \
+    ucs_fatal_error_format(__FILE__, __LINE__, __func__, \
                            "Fatal: " _fmt, ## __VA_ARGS__)
 
 
@@ -59,7 +59,7 @@ BEGIN_C_DECLS
  * Generate a program bug report if assertions are enabled
  */
 #define ucs_bug(_fmt, ...) \
-    ucs_fatal_error_format(__FILE__, __LINE__, __FUNCTION__, \
+    ucs_fatal_error_format(__FILE__, __LINE__, __func__, \
                            "Bug: " _fmt, ## __VA_ARGS__)
 
 #define ucs_assert  ucs_assert_always

--- a/src/ucs/debug/log_def.h
+++ b/src/ucs/debug/log_def.h
@@ -50,7 +50,7 @@ BEGIN_C_DECLS
 #define ucs_trace_req(_fmt, ...)    ucs_log(UCS_LOG_LEVEL_TRACE_REQ, _fmt, ## __VA_ARGS__)
 #define ucs_trace_data(_fmt, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_DATA, _fmt, ## __VA_ARGS__)
 #define ucs_trace_async(_fmt, ...)  ucs_log(UCS_LOG_LEVEL_TRACE_ASYNC, _fmt, ## __VA_ARGS__)
-#define ucs_trace_func(_fmt, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _fmt ")", __FUNCTION__, ## __VA_ARGS__)
+#define ucs_trace_func(_fmt, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_FUNC, "%s(" _fmt ")", __func__, ## __VA_ARGS__)
 #define ucs_trace_poll(_fmt, ...)   ucs_log(UCS_LOG_LEVEL_TRACE_POLL, _fmt, ## __VA_ARGS__)
 
 #define ucs_log_indent_level(_level, _delta) \
@@ -78,7 +78,7 @@ BEGIN_C_DECLS
 #define ucs_print(_fmt, ...) \
     do { \
         if (ucs_global_opts.log_print_enable) { \
-            ucs_log_dispatch(__FILE__, __LINE__, __FUNCTION__, \
+            ucs_log_dispatch(__FILE__, __LINE__, __func__, \
                              UCS_LOG_LEVEL_PRINT, &ucs_global_opts.log_component, _fmt, ## __VA_ARGS__); \
         } \
     } while(0)

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -18,7 +18,7 @@
 #define ucs_rcache_region_log_lvl(_level, _message, ...) \
     do { \
         if (ucs_log_is_enabled(_level)) { \
-            ucs_rcache_region_log(__FILE__, __LINE__, __FUNCTION__, (_level), \
+            ucs_rcache_region_log(__FILE__, __LINE__, __func__, (_level), \
                                   _message, ## __VA_ARGS__); \
         } \
     } while (0)

--- a/src/ucs/profile/profile_defs.h
+++ b/src/ucs/profile/profile_defs.h
@@ -216,7 +216,7 @@ unsigned ucs_profile_calc_num_threads(size_t total_num_records,
         static ucs_profile_loc_id_t loc_id = UCS_PROFILE_LOC_ID_UNKNOWN; \
         if (loc_id != UCS_PROFILE_LOC_ID_DISABLED) { \
             ucs_profile_record(_ctx, _type, _name, _param32, _param64, \
-                               __FILE__, __LINE__, __FUNCTION__, &loc_id); \
+                               __FILE__, __LINE__, __func__, &loc_id); \
         } \
     }
 

--- a/src/uct/ib/base/ib_log.h
+++ b/src/uct/ib/base/ib_log.h
@@ -89,14 +89,14 @@ void __uct_ib_log_recv_completion(const char *file, int line, const char *functi
 
 #define uct_ib_log_post_send(_iface, _qp, _wr, _max_sge, _dump_cb) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
-        __uct_ib_log_post_send(__FILE__, __LINE__, __FUNCTION__, \
+        __uct_ib_log_post_send(__FILE__, __LINE__, __func__, \
                                 _iface, _qp, _wr, _max_sge, _dump_cb); \
     }
 
 /* Suitable for both: regular and exp wcs */
 #define uct_ib_log_recv_completion(_iface, _wc, _data, _length, _dump_cb, ...) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
-        __uct_ib_log_recv_completion(__FILE__, __LINE__, __FUNCTION__, \
+        __uct_ib_log_recv_completion(__FILE__, __LINE__, __func__, \
                                      _iface, (_wc)->qp_num, (_wc)->src_qp, (_wc)->slid, \
                                      _data, _length, _dump_cb, ## __VA_ARGS__); \
     }

--- a/src/uct/ib/mlx5/ib_mlx5_log.h
+++ b/src/uct/ib/mlx5/ib_mlx5_log.h
@@ -42,19 +42,19 @@ void uct_ib_mlx5_av_dump(char *buf, size_t max,
 
 #define uct_ib_mlx5_log_tx(_iface, _wqe, _qstart, _qend, _max_sge, _log_sge, _dump_cb) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
-        __uct_ib_mlx5_log_tx(__FILE__, __LINE__, __FUNCTION__, \
+        __uct_ib_mlx5_log_tx(__FILE__, __LINE__, __func__, \
                              _iface, _wqe, _qstart, _qend, _max_sge, _log_sge, _dump_cb); \
     }
 
 #define uct_ib_mlx5_log_rx(_iface, _cqe, _data, _dump_cb) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
-        __uct_ib_mlx5_log_rx(__FILE__, __LINE__, __FUNCTION__, \
+        __uct_ib_mlx5_log_rx(__FILE__, __LINE__, __func__, \
                              _iface, _cqe, _data, _dump_cb); \
     }
 
 #define uct_ib_mlx5_log_cqe(_cqe) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
-        uct_ib_mlx5_cqe_dump(__FILE__, __LINE__, __FUNCTION__, \
+        uct_ib_mlx5_cqe_dump(__FILE__, __LINE__, __func__, \
                              cqe); \
     }
 


### PR DESCRIPTION
## What
Use `__func__` instead of `__FUNCTION__` on supported C versions

## Why ?
To meet [C standard](https://gcc.gnu.org/onlinedocs/gcc/Function-Names.html) 

