### PR TITLE
AZP/RELEASE: Scheduled DRP testing

### DIFF
--- a/buildlib/azure-pipelines-release-drp.yml
+++ b/buildlib/azure-pipelines-release-drp.yml
@@ -6,6 +6,14 @@ pr:
   - master
   - v*.*.x
 
+schedules:
+- cron: '0 0 * * 6'
+  displayName: Saturday night test
+  always: true
+  branches:
+    include:
+    - master
+
 variables:
   DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local
   REPO_MIRROR: harbor-pdc.nvidia.com
@@ -73,6 +81,8 @@ stages:
               check_release_build $(Build.Reason) $(Build.SourceVersion) "AZP/DRP-RELEASE: "
             name: Result
             displayName: Check build condition
+            env:
+              AZURE_DEVOPS_EXT_PAT: $(AZURE_DEVOPS_EXT_PAT)
 
   - stage: GitHubDraft
     condition: eq(dependencies.Prepare.outputs['CheckRelease.Result.Launch'], 'True')


### PR DESCRIPTION
## What
Add scheduled testing for the DRP release environment.

## Why ?
https://jirasw.nvidia.com/browse/HPCINFRA-2291 (internal link)

## How ?
Scheduled builds to create artifacts but not publish them.

Emergency release procedure:
1. Disable the main release pipeline.
2. Proceed as usual.

The DRP release pipeline will check the status of the main release pipeline.
Only if main is disabled will it run the full release cycle including the artifact's publishing.
