### PR TITLE
GTEST: ASAN suppression for memory leak in binutils/bfd

### DIFF
--- a/contrib/lsan.supp
+++ b/contrib/lsan.supp
@@ -1,3 +1,4 @@
 leak:libcuda
 leak:dlsym
 leak:nvmlInitWithFlags
+leak:bfd_map_over_sections

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -339,3 +339,9 @@
    obj:*/libmlx5*.so*
    fun:uct_rdmacm_cm_create_dummy_qp
 }
+{
+   bfd_map_over_sections_leak
+   Memcheck:Leak
+   ...
+   fun:bfd_map_over_sections
+}


### PR DESCRIPTION
## What
When binutils-dev package is installed on CI machines, it triggers ASAN/valgrind errors:
```
   #0 0xffff8d49a2f4 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0xffff8cb9c3f8  (/lib/aarch64-linux-gnu/libbfd-2.38-system.so+0xac3f8)
    #2 0xffff8cb9e0f0  (/lib/aarch64-linux-gnu/libbfd-2.38-system.so+0xae0f0)
    #3 0xffff8cb9f94c  (/lib/aarch64-linux-gnu/libbfd-2.38-system.so+0xaf94c)
    #4 0xffff8cba3928  (/lib/aarch64-linux-gnu/libbfd-2.38-system.so+0xb3928)
    #5 0xffff8cb73294 in _bfd_elf_find_nearest_line (/lib/aarch64-linux-gnu/libbfd-2.38-system.so+0x83294)
    #6 0xffff8d306cfc in find_address_in_section /scrap/azure/agent-02/AZP_WORKSPACE/3/s/contrib/../src/ucs/debug/debug.c:335
    #7 0xffff8cb3f99c in bfd_map_over_sections (/lib/aarch64-linux-gnu/libbfd-2.38-system.so+0x4f99c)
    #8 0xffff8d307cec in get_line_info /scrap/azure/agent-02/AZP_WORKSPACE/3/s/contrib/../src/ucs/debug/debug.c:367
```

## Why ?
There is a memory leak in binutils libbfd, described in their mailing list: https://lists.gnu.org/archive/html/bug-binutils/2023-12/msg00089.html
This memory leak is fixed 7 months ago and fix is present in libbfd-2.42, while we use version 2.38.
So for now we can only suppress this leak in ASAN and valgrind

## How ?
Added suppressions for this memory leak in ASAN and valgrind