### PR TITLE
TEST/CALLBACKQ: Fix test_callbackq.test_callbackq test failures

### DIFF
--- a/test/gtest/configure.m4
+++ b/test/gtest/configure.m4
@@ -16,11 +16,17 @@ CHECK_COMPILER_FLAG([--diag_suppress 186], [--diag_suppress 186],
                     [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [GTEST_CXXFLAGS="$GTEST_CXXFLAGS --diag_suppress 186"],
                     [])
-                    
+
 # error #236: controlling expression is constant
 CHECK_COMPILER_FLAG([--diag_suppress 236], [--diag_suppress 236],
                     [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
                     [GTEST_CXXFLAGS="$GTEST_CXXFLAGS --diag_suppress 236"],
+                    [])
+
+# Avoid warnings about C++17 mangling compatibility
+CHECK_COMPILER_FLAG([-Wno-noexcept-type], [-Wno-noexcept-type],
+                    [AC_LANG_SOURCE([[int main(int argc, char** argv){return 0;}]])],
+                    [GTEST_CXXFLAGS="$GTEST_CXXFLAGS -Wno-noexcept-type "],
                     [])
 
 AC_LANG_POP([C++])

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -352,14 +352,12 @@ protected:
         }
     }
 
-    template <typename T>
-    void wait_for_value(volatile T *var, T value, double timeout = 10.0) const
+    template<typename T>
+    void wait_for_value(const volatile T *var, T value,
+                        double timeout = DEFAULT_TIMEOUT_SEC) const
     {
-        ucs_time_t deadline = ucs_get_time() +
-                              ucs_time_from_sec(timeout) * ucs::test_time_multiplier();
-        while ((ucs_get_time() < deadline) && (*var != value)) {
-            short_progress_loop();
-        }
+        test_base::wait_for_value(
+                var, value, [this]() { short_progress_loop(); }, timeout);
     }
 
     static const ucp_datatype_t DATATYPE;

--- a/test/gtest/ucs/test_callbackq.cc
+++ b/test/gtest/ucs/test_callbackq.cc
@@ -357,6 +357,7 @@ UCS_MT_TEST_F(test_callbackq, oneshot_mt, 10) {
 
     add_oneshot(&ctx);
     dispatch(100);
+    wait_for_value(&ctx.count, 1u);
     EXPECT_EQ(1u, ctx.count);
 }
 


### PR DESCRIPTION
## Why
Fix test failures like:
```
2024-07-10T10:31:07.4474989Z [ RUN      ] test_callbackq.oneshot_mt/mt_10 <> <>
2024-07-10T10:31:07.4478332Z /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucs/test_callbackq.cc:360: Failure
2024-07-10T10:31:07.4478820Z Expected equality of these values:
2024-07-10T10:31:07.4479038Z   1u
2024-07-10T10:31:07.4479254Z     Which is: 1
2024-07-10T10:31:07.4479513Z   ctx.count
2024-07-10T10:31:07.4479810Z     Which is: 1
2024-07-10T10:31:07.4481242Z [  FAILED  ] test_callbackq.oneshot_mt/mt_10, where TypeParam =  and GetParam() =  (1 ms)
2024-07-10T10:31:07.4481612Z [ RUN      ] test_callbackq.remove_self_safe <> <>
```