### PR TITLE
UCT/IB: Support subnet filter list for RoCE GID

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -30,8 +30,6 @@
 /* width of titles in docstring */
 #define UCS_CONFIG_PARSER_DOCSTR_WIDTH         10
 
-/* String literal for allow-list */
-#define UCS_CONFIG_PARSER_ALL "all"
 
 /* list of prefixes for a configuration variable, used to dump all possible
  * aliases.

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -21,6 +21,9 @@
 #define UCS_CONFIG_ARRAY_MAX   128
 #define UCX_CONFIG_FILE_NAME   "ucx.conf"
 
+/* String literal for allow-list */
+#define UCS_CONFIG_PARSER_ALL "all"
+
 BEGIN_C_DECLS
 
 /** @file parser.h */

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -72,6 +72,14 @@ uct_ib_async_event_hash_equal(uct_ib_async_event_t event1,
 KHASH_IMPL(uct_ib_async_event, uct_ib_async_event_t, uct_ib_async_event_val_t, 1,
            uct_ib_async_event_hash_func, uct_ib_async_event_hash_equal)
 
+typedef struct uct_ib_device_subnet {
+    struct sockaddr_storage address;
+    unsigned                prefix_length;
+} uct_ib_device_subnet_t;
+
+UCS_ARRAY_DECLARE_TYPE(uct_ib_device_subnet_array_t, unsigned,
+                       uct_ib_device_subnet_t);
+
 #ifdef ENABLE_STATS
 static ucs_stats_class_t uct_ib_device_stats_class = {
     .name          = "",
@@ -875,9 +883,141 @@ int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
     return 1;
 }
 
-ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
-                                      uct_ib_device_gid_info_t *gid_info)
+ucs_status_t
+uct_ib_device_roce_gid_to_sockaddr(sa_family_t af, const void *gid,
+                                   struct sockaddr_storage *sock_storage)
 {
+    struct sockaddr *sa = (struct sockaddr*)sock_storage;
+    const uint8_t *inet_addr;
+    size_t addr_size;
+    ucs_status_t status;
+
+    /* Set address family */
+    sa->sa_family = af;
+
+    /* Set port to 0 as it's not relevant for RoCE */
+    status = ucs_sockaddr_set_port(sa, 0);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* Get address size */
+    status = ucs_sockaddr_inet_addr_size(af, &addr_size);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* Set IP address */
+    inet_addr = UCS_PTR_BYTE_OFFSET(gid, sizeof(union ibv_gid) - addr_size);
+    return ucs_sockaddr_set_inet_addr(sa, inet_addr);
+}
+
+static ucs_status_t
+uct_ib_device_parse_subnet_filter(const ucs_config_allow_list_t *subnet_strs,
+                                  uct_ib_device_subnet_array_t *subnets)
+{
+    char *address_str, *mask_str;
+    char **subnet_str;
+    char subnet_str_dup[UCS_SOCKADDR_STRING_LEN];
+    uct_ib_device_subnet_t *subnet;
+    ucs_status_t status;
+
+    if (subnet_strs->mode == UCS_CONFIG_ALLOW_LIST_ALLOW_ALL) {
+        return UCS_OK;
+    }
+
+    ucs_carray_for_each(subnet_str, subnet_strs->array.names,
+                        subnet_strs->array.count) {
+        ucs_strncpy_safe(subnet_str_dup, *subnet_str, sizeof(subnet_str_dup));
+
+        /* Expect a string of the following pattern: x.x.x.x/y */
+        ucs_string_split(subnet_str_dup, "/", 2, &address_str, &mask_str);
+        if (mask_str == NULL) {
+            status = UCS_ERR_INVALID_PARAM;
+            goto err;
+        }
+
+        subnet = ucs_array_append_fixed(subnets);
+
+        /* Parse subnet address */
+        status = ucs_sock_ipstr_to_sockaddr(address_str, &subnet->address);
+        if (status != UCS_OK) {
+            goto err;
+        }
+
+        /* Parse subnet mask */
+        if (sscanf(mask_str, "%u", &subnet->prefix_length) != 1) {
+            status = UCS_ERR_INVALID_PARAM;
+            goto err;
+        }
+    }
+
+    return UCS_OK;
+
+err:
+    ucs_error("failed to parse RoCE subnet: %s", *subnet_str);
+    return status;
+}
+
+static int
+uct_ib_device_match_roce_subnet(const uct_ib_device_gid_info_t *gid_info,
+                                const uct_ib_device_subnet_array_t *subnets,
+                                ucs_config_allow_list_mode_t mode)
+{
+    const int is_allow_mode = (mode == UCS_CONFIG_ALLOW_LIST_ALLOW);
+    static const char UCS_V_UNUSED *allow_mode_str[] = {"accepted",
+                                                        "restricted"};
+    const uct_ib_device_subnet_t *subnet;
+    struct sockaddr_storage gid_sockaddr;
+    char gid_str[UCS_SOCKADDR_STRING_LEN];
+    char subnet_str[UCS_SOCKADDR_STRING_LEN];
+
+    if (mode == UCS_CONFIG_ALLOW_LIST_ALLOW_ALL) {
+        return 1;
+    }
+
+    /* Convert GID to sockaddr structure */
+    if (uct_ib_device_roce_gid_to_sockaddr(gid_info->roce_info.addr_family,
+                                           &gid_info->gid,
+                                           &gid_sockaddr) != UCS_OK) {
+        ucs_error("failed to convert GID %u to sockaddr", gid_info->gid_index);
+        return 0;
+    }
+
+    /* Iterate over all subnets and compare them with GID */
+    ucs_array_for_each(subnet, subnets) {
+        if (!ucs_sockaddr_is_same_subnet(
+                    (const struct sockaddr*)&gid_sockaddr,
+                    (const struct sockaddr*)&subnet->address,
+                    subnet->prefix_length)) {
+            continue;
+        }
+
+        ucs_sockaddr_str((const struct sockaddr*)&gid_sockaddr, gid_str,
+                         UCS_SOCKADDR_STRING_LEN);
+        ucs_sockaddr_str((const struct sockaddr*)&subnet->address, subnet_str,
+                         UCS_SOCKADDR_STRING_LEN);
+        ucs_trace("address %s at gid[%u] was %s by subnet filter %s/%u",
+                  gid_str, gid_info->gid_index, allow_mode_str[!is_allow_mode],
+                  subnet_str, subnet->prefix_length);
+
+        /* Accept/Restrict GID according to required policy */
+        return is_allow_mode;
+    }
+
+    ucs_trace("gid index %u was %s due to no matching subnets",
+              gid_info->gid_index, allow_mode_str[!is_allow_mode]);
+
+    /* Handle non-matched GID according to policy */
+    return !is_allow_mode;
+}
+
+ucs_status_t
+uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
+                         const ucs_config_allow_list_t *subnet_strs,
+                         uct_ib_device_gid_info_t *gid_info)
+{
+    static const size_t max_str_len                     = 200;
     static const uct_ib_roce_version_info_t roce_prio[] = {
         {UCT_IB_DEVICE_ROCE_V2, AF_INET},
         {UCT_IB_DEVICE_ROCE_V2, AF_INET6},
@@ -887,10 +1027,18 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
     int gid_tbl_len         = uct_ib_device_port_attr(dev, port_num)->gid_tbl_len;
     ucs_status_t status     = UCS_OK;
     int priorities_arr_len  = ucs_static_array_size(roce_prio);
+    UCS_ARRAY_DEFINE_ONSTACK(uct_ib_device_subnet_array_t, subnets,
+                             subnet_strs->array.count);
     uct_ib_device_gid_info_t gid_info_tmp;
-    int i, prio_idx;
+    int i, prio_idx, res;
+    char subnet_list_str[max_str_len];
 
     ucs_assert(uct_ib_device_is_port_roce(dev, port_num));
+
+    status = uct_ib_device_parse_subnet_filter(subnet_strs, &subnets);
+    if (status != UCS_OK) {
+        return status;
+    }
 
     /* search for matching GID table entries, according to the order defined
      * in priorities array
@@ -906,13 +1054,23 @@ ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
 
             if ((roce_prio[prio_idx].ver         == gid_info_tmp.roce_info.ver) &&
                 (roce_prio[prio_idx].addr_family == gid_info_tmp.roce_info.addr_family) &&
-                uct_ib_device_test_roce_gid_index(dev, port_num, &gid_info_tmp.gid, i)) {
-
+                uct_ib_device_test_roce_gid_index(dev, port_num, &gid_info_tmp.gid, i) &&
+                uct_ib_device_match_roce_subnet(&gid_info_tmp, &subnets,
+                                                subnet_strs->mode)) {
                 gid_info->gid_index = i;
                 gid_info->roce_info = gid_info_tmp.roce_info;
                 goto out_print;
             }
         }
+    }
+
+    if (subnet_strs->mode != UCS_CONFIG_ALLOW_LIST_ALLOW_ALL) {
+        res = ucs_config_sprintf_allow_list(subnet_list_str, max_str_len,
+                                            subnet_strs,
+                                            &ucs_config_array_string);
+        ucs_error("failed to find a gid which matches/unmatches the following "
+                  "subnet list: %s", res ? subnet_list_str : "<none>");
+        return UCS_ERR_INVALID_PARAM;
     }
 
     gid_info->gid_index             = UCT_IB_DEVICE_DEFAULT_GID_INDEX;

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -322,12 +322,15 @@ const uct_ib_device_spec_t* uct_ib_device_spec(uct_ib_device_t *dev);
  *
  * @param [in]  dev             IB device.
  * @param [in]  port_num        Port number.
+ * @param [in]  subnet_strs     List of allowed/restricted subnets to select
+ *                              from.
  * @param [out] gid_info        Filled with the selected gid index and the
  *                              port's RoCE version and address family.
  */
-ucs_status_t uct_ib_device_select_gid(uct_ib_device_t *dev,
-                                      uint8_t port_num,
-                                      uct_ib_device_gid_info_t *gid_info);
+ucs_status_t
+uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
+                         const ucs_config_allow_list_t *subnets_array,
+                         uct_ib_device_gid_info_t *gid_info);
 
 
 /**
@@ -462,6 +465,10 @@ int uct_ib_get_cqe_size(int cqe_size_min);
 
 const char* uct_ib_ah_attr_str(char *buf, size_t max,
                                const struct ibv_ah_attr *ah_attr);
+
+ucs_status_t
+uct_ib_device_roce_gid_to_sockaddr(sa_family_t af, const void *gid,
+                                   struct sockaddr_storage *sock_storage);
 
 static inline ucs_status_t uct_ib_poll_cq(struct ibv_cq *cq, unsigned *count, struct ibv_wc *wcs)
 {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -204,6 +204,9 @@ struct uct_ib_iface_config {
     /* Length of subnet prefix for reachability check */
     unsigned long           rocev2_subnet_pfx_len;
 
+    /* List of included/excluded subnets to filter RoCE GID entries by */
+    ucs_config_allow_list_t rocev2_subnet_filter;
+
     /* Multiplier for RoCE LAG UDP source port calculation */
     unsigned                roce_path_factor;
 
@@ -543,9 +546,12 @@ int uct_ib_iface_is_roce_v2(uct_ib_iface_t *iface);
  *
  * @param iface                 IB interface
  * @param md_config_index       Gid index from the md configuration.
+ * @param subnets_list          Subnets list to filter GIDs by.
  */
-ucs_status_t uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
-                                             unsigned long cfg_gid_index);
+ucs_status_t
+uct_ib_iface_init_roce_gid_info(uct_ib_iface_t *iface,
+                                unsigned long cfg_gid_index,
+                                const ucs_config_allow_list_t *subnets_list);
 
 
 static inline uct_ib_md_t* uct_ib_iface_md(uct_ib_iface_t *iface)

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -359,6 +359,7 @@ public:
         union ibv_gid gid;
         uct_ib_md_config_t *md_config =
             ucs_derived_of(m_md_config, uct_ib_md_config_t);
+        ucs_config_allow_list_t dummy_subnet_list;
         ucs::handle<uct_md_h> uct_md;
         uct_ib_iface_t dummy_ib_iface;
         uct_ib_md_t *ib_md;
@@ -376,11 +377,14 @@ public:
 
         ASSERT_EQ(&ib_md->dev, uct_ib_iface_device(&dummy_ib_iface));
 
+        dummy_subnet_list.mode = UCS_CONFIG_ALLOW_LIST_ALLOW_ALL;
+
         /* uct_ib_iface_init_roce_gid_info() requires only the port from the
          * ib_iface so we can use a dummy one here.
          * this function will set the gid_index in the dummy ib_iface. */
         status = uct_ib_iface_init_roce_gid_info(&dummy_ib_iface,
-                                                 md_config->ext.gid_index);
+                                                 md_config->ext.gid_index,
+                                                 &dummy_subnet_list);
         ASSERT_UCS_OK(status);
 
         gid_index = dummy_ib_iface.gid_info.gid_index;


### PR DESCRIPTION
## What
Allow to specify a list of allowed/restricted subnets, of which a GID would be selected from.

## Why ?
To support setups with asymmetric GID table configuration.
Request came from following ticket:
https://nvbugspro.nvidia.com/bug/4214093

## How ?
1) Add a new config var: UCX_ROCE_SUBNET_FILTER_LIST, which will be of the following pattern: 
    1.1.1.1/24,2.2.2.2/16,3.3.3.3/8
2) Move `uct_ib_iface_roce_to_sockaddr` from `ib_iface.c` to `ib_device.c`, and rename it to `uct_ib_device_roce_gid_to_sockaddr`.
3) In RoCE GID initialization:
    - Parse the given subnets and report any issues.
    - Iterate through all gid entries and check if match to any subnet.

## Tests
For now, checked manually.
When CI setup is ready, will add gtests as well.
ticket for CI setup:
https://jirasw.nvidia.com/browse/HPCINFRA-2389