### PR TITLE
UCS/VFS: Use shmem to detect server alive instead of inotify

### DIFF
--- a/src/tools/vfs/Makefile.am
+++ b/src/tools/vfs/Makefile.am
@@ -13,6 +13,7 @@ ucx_vfs_CFLAGS   = $(BASE_CFLAGS)
 ucx_vfs_SOURCES  = vfs_main.c vfs_server.c
 noinst_HEADERS   = vfs_daemon.h
 ucx_vfs_LDADD    = $(FUSE3_LIBS) \
-                   $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la
+                   $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la \
+                   $(top_builddir)/src/ucs/libucs.la
 
 endif

--- a/src/ucs/vfs/fuse/configure.m4
+++ b/src/ucs/vfs/fuse/configure.m4
@@ -3,11 +3,6 @@
 #
 
 
-AC_CHECK_DECLS([inotify_init, inotify_add_watch, IN_ATTRIB],
-               [AC_DEFINE([HAVE_INOTIFY], 1, [Enable inotify support])],
-               [],
-               [[#include <sys/inotify.h>]])
-
 AS_IF([test "x$fuse3_happy" = "xyes"], [ucs_modules="${ucs_modules}:fuse"])
 AC_CONFIG_FILES([src/ucs/vfs/fuse/Makefile
                  src/ucs/vfs/fuse/ucx-fuse.pc])

--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -255,8 +255,8 @@ static void ucs_vfs_fuse_thread_reset_affinity()
 
 static void ucs_vfs_fuse_log_info(const ucs_vfs_info_t *info, const char *msg)
 {
-    ucs_debug("%s: pid %d, sequence %" PRIu64 ", start time %" PRIu64,
-              msg, info->pid, info->sequence, info->start_time);
+    ucs_debug("%s: pid %d, sequence %" PRIu64 ", start time %" PRIu64, msg,
+              info->pid, info->sequence, info->start_time);
 }
 
 static void *ucs_vfs_fuse_thread_func(void *arg)

--- a/src/ucs/vfs/sock/vfs_sock.c
+++ b/src/ucs/vfs/sock/vfs_sock.c
@@ -296,6 +296,7 @@ ucs_status_t ucs_vfs_data_init(ucs_vfs_data_t *data)
     ucs_status_t status;
     int ret;
 
+    /* coverity[missing_lock] */
     data->stop = 0;
 
     /* File lock to avoid data races during shared memory creation phase:

--- a/src/ucs/vfs/sock/vfs_sock.c
+++ b/src/ucs/vfs/sock/vfs_sock.c
@@ -10,6 +10,7 @@
 
 #include "vfs_sock.h"
 
+#include <ucs/debug/log_def.h>
 #include <ucs/sys/compiler_def.h>
 #include <sys/socket.h>
 #include <string.h>
@@ -17,7 +18,24 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
+#include <pthread.h>
 #include <pwd.h>
+#include <sys/file.h>
+#include <sys/shm.h>
+
+
+#define UCS_VFS_SHM_KEY   13579
+#define UCS_VFS_FILE_LOCK "/tmp/ucx-vfs.lock"
+
+
+/**
+ * VFS shared data structure
+ */
+typedef struct ucs_vfs_shared_data {
+    pthread_mutex_t mutex;
+    pthread_cond_t  cond;
+    ucs_vfs_info_t  info;
+} ucs_vfs_shared_data_t;
 
 
 typedef struct {
@@ -169,4 +187,175 @@ int ucs_vfs_sock_recv(int sockfd, ucs_vfs_sock_message_t *vfs_msg)
     }
 
     return 0;
+}
+
+void ucs_vfs_data_destroy_shared(ucs_vfs_data_t *data)
+{
+    struct shmid_ds stat;
+    int ret;
+
+    ucs_debug("destroy VFS shared data %p", data);
+    if (data->shared != UCS_VFS_UNDEFINED) {
+        ret = shmdt(data->shared);
+        if (ret != 0) {
+            ucs_warn("shmdt(%p) failed: %m", data->shared);
+        }
+    }
+
+    if (data->shmid != -1) {
+        /* Check how many existing attachments exist from other processes */
+        ret = shmctl(data->shmid, IPC_STAT, &stat);
+        if (ret != 0) {
+            ucs_warn("shmctl(%d, IPC_STAT) failed: %m", data->shmid);
+        } else if (stat.shm_nattch == 0) {
+            /* Last attachment, remove shared memory */
+            ucs_debug("destroy VFS shared memory %p", data);
+            ret = shmctl(data->shmid, IPC_RMID, NULL);
+            if (ret != 0) {
+                ucs_warn("shmctl(%d, IPC_RMID) failed: %m", data->shmid);
+            }
+        }
+    }
+}
+
+static ucs_status_t ucs_vfs_data_init_shared(ucs_vfs_data_t *data)
+{
+    int init_needed = 0;
+    pthread_mutexattr_t mutex_attr;
+    pthread_condattr_t cond_attr;
+    ucs_status_t status;
+    int ret;
+
+    /* Try to create shared memory, succeed only if it's not created yet by
+     * another process */
+    data->shmid = shmget(UCS_VFS_SHM_KEY, sizeof(ucs_vfs_shared_data_t),
+                         IPC_CREAT | IPC_EXCL | 0666);
+    if (data->shmid == -1) {
+        /* Already exists, try to open it */
+        if (errno == EEXIST) {
+            data->shmid = shmget(UCS_VFS_SHM_KEY, sizeof(ucs_vfs_shared_data_t),
+                                 0666);
+        }
+
+        if (data->shmid == -1) {
+            ucs_error("shmget() failed: %m");
+            return UCS_ERR_NO_MEMORY;
+        }
+    } else {
+        init_needed = 1;
+    }
+
+    /* Attach shared memory */
+    data->shared = (ucs_vfs_shared_data_t*)shmat(data->shmid, NULL, 0);
+    if (data->shared == UCS_VFS_UNDEFINED) {
+        ucs_error("shmat(data=%d) failed: %m", data->shmid);
+        status = UCS_ERR_IO_ERROR;
+        goto err;
+    }
+
+#define CHECK_INIT(_init) \
+    ret = _init; \
+    if (ret != 0) { \
+        ucs_error(#_init " failed: %m"); \
+        status = UCS_ERR_INVALID_PARAM; \
+        goto err; \
+    }
+
+    if (init_needed) {
+        /* This block is executed by the first process that created shared
+         * memory region, either client or daemon */
+        CHECK_INIT(pthread_mutexattr_init(&mutex_attr));
+        CHECK_INIT(pthread_mutexattr_setpshared(&mutex_attr,
+                                                PTHREAD_PROCESS_SHARED));
+        CHECK_INIT(pthread_mutex_init(&data->shared->mutex, &mutex_attr));
+
+        CHECK_INIT(pthread_condattr_init(&cond_attr));
+        CHECK_INIT(pthread_condattr_setpshared(&cond_attr,
+                                               PTHREAD_PROCESS_SHARED));
+        CHECK_INIT(pthread_cond_init(&data->shared->cond, &cond_attr));
+
+        ucs_debug("created VFS shared data %p", data);
+    } else {
+        ucs_debug("loaded VFS shared data %p", data);
+    }
+
+    return UCS_OK;
+
+err:
+    ucs_vfs_data_destroy_shared(data);
+    return status;
+}
+
+ucs_status_t ucs_vfs_data_init(ucs_vfs_data_t *data)
+{
+    ucs_status_t status;
+    int ret;
+
+    /* File lock to avoid data races during shared memory creation phase:
+     * It might happen that one process creates shared memory, and the second
+     * one attaches to it, and we must guarantee that all initialization is done
+     * by the time second process starts using it */
+    data->flock = open(UCS_VFS_FILE_LOCK, O_RDWR | O_CREAT | O_CLOEXEC, 0777);
+    if (data->flock == -1) {
+        ucs_error("open(%s) failed: %m", UCS_VFS_FILE_LOCK);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    ret = flock(data->flock, LOCK_EX);
+    if (ret != 0) {
+        ucs_error("flock(%d, LOCK_EX) failed: %m", data->flock);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    status = ucs_vfs_data_init_shared(data);
+
+    flock(data->flock, LOCK_UN);
+    return status;
+}
+
+void ucs_vfs_data_destroy(ucs_vfs_data_t *data)
+{
+    flock(data->flock, LOCK_EX);
+    ucs_vfs_data_destroy_shared(data);
+    flock(data->flock, LOCK_UN);
+    close(data->flock);
+}
+
+void ucs_vfs_data_get(ucs_vfs_data_t *data, ucs_vfs_info_t *info)
+{
+    pthread_mutex_lock(&data->shared->mutex);
+    *info = data->shared->info;
+    pthread_mutex_unlock(&data->shared->mutex);
+}
+
+void ucs_vfs_data_notify(ucs_vfs_data_t *data, const ucs_vfs_info_t *info)
+{
+    ucs_debug("notify VFS shared data %p", data);
+    pthread_mutex_lock(&data->shared->mutex);
+    data->shared->info = *info;
+    pthread_cond_broadcast(&data->shared->cond);
+    pthread_mutex_unlock(&data->shared->mutex);
+}
+
+ucs_status_t ucs_vfs_data_wait(ucs_vfs_data_t *data, ucs_vfs_info_t *info)
+{
+    ucs_debug("wait on VFS shared data %p", data);
+    pthread_mutex_lock(&data->shared->mutex);
+    /* Wait until interrupted or info sequence is greater than the old value */
+    while ((!data->stop) && (data->shared->info.sequence <= info->sequence)) {
+        pthread_cond_wait(&data->shared->cond, &data->shared->mutex);
+    }
+
+    *info = data->shared->info;
+    pthread_mutex_unlock(&data->shared->mutex);
+    return data->stop ? UCS_ERR_CANCELED : UCS_OK;
+}
+
+void ucs_vfs_data_interrupt(ucs_vfs_data_t *data)
+{
+    ucs_debug("interrupt VFS shared data %p", data);
+    pthread_mutex_lock(&data->shared->mutex);
+    data->stop = 1;
+    pthread_cond_broadcast(&data->shared->cond);
+    pthread_mutex_unlock(&data->shared->mutex);
 }

--- a/src/ucs/vfs/sock/vfs_sock.h
+++ b/src/ucs/vfs/sock/vfs_sock.h
@@ -103,7 +103,7 @@ typedef struct {
 } ucs_vfs_data_t;
 
 
-#define UCS_VFS_UNDEFINED ((void *)-1)
+#define UCS_VFS_UNDEFINED ((struct ucs_vfs_shared_data*)-1)
 #define UCS_VFS_DATA_INIT {UCS_VFS_UNDEFINED, -1, -1, 0}
 
 
@@ -118,8 +118,9 @@ ucs_status_t ucs_vfs_data_init(ucs_vfs_data_t *data);
 /**
  * Destroy VFS shared memory handler.
  * @param [in] data  VFS shared memory handler.
+ * @return 1 if the shared memory was destroyed, 0 if it was just detached
  */
-void ucs_vfs_data_destroy(ucs_vfs_data_t *data);
+int ucs_vfs_data_destroy(ucs_vfs_data_t *data);
 
 
 /**

--- a/src/ucs/vfs/sock/vfs_sock.h
+++ b/src/ucs/vfs/sock/vfs_sock.h
@@ -7,6 +7,7 @@
 #ifndef UCS_VFS_SOCK_H_
 #define UCS_VFS_SOCK_H_
 
+#include <ucs/time/time.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <stdint.h>
@@ -83,5 +84,76 @@ int ucs_vfs_sock_send(int sockfd, const ucs_vfs_sock_message_t *vfs_msg);
  * @return 0 on success, or the negative value of errno in case of failure.
  */
 int ucs_vfs_sock_recv(int sockfd, ucs_vfs_sock_message_t *vfs_msg);
+
+
+/* VFS daemon information stored in the shared memory */
+typedef struct {
+    pid_t      pid;
+    uint64_t   sequence;
+    ucs_time_t start_time;
+} ucs_vfs_info_t;
+
+
+/* Handler structure to operate VFS shared memory */
+typedef struct {
+    struct ucs_vfs_shared_data *shared;
+    int                        flock;
+    int                        shmid;
+    int                        stop;
+} ucs_vfs_data_t;
+
+
+#define UCS_VFS_UNDEFINED ((void *)-1)
+#define UCS_VFS_DATA_INIT {UCS_VFS_UNDEFINED, -1, -1, 0}
+
+
+/**
+ * Initialize VFS shared memory handler.
+ * @param [in] data  VFS shared memory handler.
+ * @return UCS_OK on success, or an error code on failure.
+ */
+ucs_status_t ucs_vfs_data_init(ucs_vfs_data_t *data);
+
+
+/**
+ * Destroy VFS shared memory handler.
+ * @param [in] data  VFS shared memory handler.
+ */
+void ucs_vfs_data_destroy(ucs_vfs_data_t *data);
+
+
+/**
+ * Get VFS daemon information.
+ * @param [in]  data  VFS shared memory handler.
+ * @param [out] info  Filled with VFS daemon information.
+ */
+void ucs_vfs_data_get(ucs_vfs_data_t *data, ucs_vfs_info_t *info);
+
+
+/**
+ * Update VFS daemon information and notify all the waiting processes.
+ * @param [in] data  VFS shared memory handler.
+ * @param [in] info  New VFS daemon information.
+ */
+void ucs_vfs_data_notify(ucs_vfs_data_t *data, const ucs_vfs_info_t *info);
+
+
+/**
+ * Wait for update of VFS daemon information to change.
+ * This operation is blocking and may be interrupted by ucs_vfs_data_interrupt.
+ * @param [in]     data  VFS shared memory handler.
+ * @param [in/out] info  Input with the current VFS daemon information,
+ *                       output with the new information.
+ * @return UCS_OK on success,
+ *         UCS_ERR_CANCELED on interrupt from ucs_vfs_data_interrupt
+ */
+ucs_status_t ucs_vfs_data_wait(ucs_vfs_data_t *data, ucs_vfs_info_t *info);
+
+
+/**
+ * Interrupt the blocking ucs_vfs_data_wait operation.
+ * @param [in] data  VFS shared memory handler.
+ */
+void ucs_vfs_data_interrupt(ucs_vfs_data_t *data);
 
 #endif

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -374,13 +374,16 @@ protected:
 
     virtual void cleanup()
     {
+        /* When VFS is enabled, the "fuse" thread is created that owns the copy
+         * of ucs_vfs_data_t, and therefore prevents this shared memory from
+         * being unlinked immediately */
         EXPECT_EQ(!ucs_global_opts.vfs_enable, ucs_vfs_data_destroy(&m_data));
     }
 
     ucs_vfs_data_t m_data;
 };
 
-UCS_TEST_F(test_vfs_data, shared_data_wait)
+UCS_TEST_F(test_vfs_data, wait)
 {
     std::vector<pid_t> pids;
     for (int i = 0; i < 10; ++i) {
@@ -397,13 +400,13 @@ UCS_TEST_F(test_vfs_data, shared_data_wait)
             exit(HasFailure() ? EXIT_FAILURE : EXIT_SUCCESS);
         }
 
-        /* Simulate server workflow */
-        EXPECT_UCS_OK(ucs_vfs_data_init(&m_data));
-        ucs_vfs_info_t info = { 0, 100, 0 };
-        ucs_vfs_data_notify(&m_data, &info);
-
         pids.push_back(pid);
     }
+
+    /* Simulate server workflow */
+    EXPECT_UCS_OK(ucs_vfs_data_init(&m_data));
+    ucs_vfs_info_t info = { 0, 100, 0 };
+    ucs_vfs_data_notify(&m_data, &info);
 
     for (pid_t pid : pids) {
         int status;
@@ -412,7 +415,7 @@ UCS_TEST_F(test_vfs_data, shared_data_wait)
     }
 }
 
-UCS_TEST_F(test_vfs_data, shared_data_interrupt)
+UCS_TEST_F(test_vfs_data, interrupt)
 {
     EXPECT_UCS_OK(ucs_vfs_data_init(&m_data));
 

--- a/test/gtest/ucs/test_vfs.cc
+++ b/test/gtest/ucs/test_vfs.cc
@@ -360,8 +360,7 @@ UCS_MT_TEST_F(test_vfs_obj, rw_file, 4)
     ucs_vfs_obj_remove(&obj);
 }
 
-class test_vfs_data : public ucs::test
-{
+class test_vfs_data : public ucs::test {
 protected:
     virtual void init()
     {
@@ -377,7 +376,13 @@ protected:
         /* When VFS is enabled, the "fuse" thread is created that owns the copy
          * of ucs_vfs_data_t, and therefore prevents this shared memory from
          * being unlinked immediately */
-        EXPECT_EQ(!ucs_global_opts.vfs_enable, ucs_vfs_data_destroy(&m_data));
+        EXPECT_EQ(!is_vfs_enabled(), ucs_vfs_data_destroy(&m_data));
+    }
+
+    static bool is_vfs_enabled()
+    {
+        return ucs_global_opts.vfs_enable &&
+               (std::string(ucs_MODULES).find("fuse") != std::string::npos);
     }
 
     ucs_vfs_data_t m_data;
@@ -405,7 +410,7 @@ UCS_TEST_F(test_vfs_data, wait)
 
     /* Simulate server workflow */
     EXPECT_UCS_OK(ucs_vfs_data_init(&m_data));
-    ucs_vfs_info_t info = { 0, 100, 0 };
+    ucs_vfs_info_t info = {0, 100, 0};
     ucs_vfs_data_notify(&m_data, &info);
 
     for (pid_t pid : pids) {


### PR DESCRIPTION
## What
Use shared memory mechanisms to detect VFS server aliveness instead of inotify approach.

## Why
1. We have an evidence (NVHPC setup) that inotify_add_watch may be blocking and time consuming. Despite it's executed from the separate thread it still significantly delays the main thread (to be understood why).
2. On system with frequent changes in /tmp folder the waiting is not just idle wait, because actually we wake up the thread to check all the events from inotify, even those which are irrelevant to us.
Those operations are: read, mutex_unlock, string comparison, mutex_lock.
3. inotify is not super reliable way of event processing - in case of massive events they are just dropped, so we can lose an update.
4. Inotify approach comes with some associated memory overhead and complexity

## How
The idea is to replace inotify approach with waiting on shared condition variable. In order to do so, we create a shared memory that is attached by the VFS client and daemon, where daemon updates the shared memory, and clients monitor the updates.