### PR TITLE
Fix failing test for MAD that breaks build

### DIFF
--- a/config/m4/mad.m4
+++ b/config/m4/mad.m4
@@ -14,7 +14,7 @@ AC_ARG_WITH([mad],
             [with_mad=guess])
 
 mad_happy=no
-AS_IF([test "x$with_mad" == "xno"],
+AS_IF([test "x$with_mad" = "xno"],
     [AC_MSG_WARN([Infiniband MAD support explicitly disabled])],
 
     [AS_CASE(["x$with_mad"],


### PR DESCRIPTION
On at least one distro I've tested (Void, in case it matters) the shell chokes on using the Bash-specific `==` syntax rather than POSIX Bourne `=`. This happens whether or not `--with-mad` is specified.
