### PR TITLE
UCT/IB: fix invalid GIDs filter

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1125,9 +1125,9 @@ ucs_status_t uct_ib_device_mtu(const char *dev_name, uct_md_h md, int *p_mtu)
     return UCS_OK;
 }
 
-int uct_ib_device_is_gid_raw_empty(uint8_t *gid_raw)
+int uct_ib_device_is_gid_valid(const union ibv_gid *gid)
 {
-    return (*(uint64_t *)gid_raw == 0) && (*(uint64_t *)(gid_raw + 8) == 0);
+    return gid->global.interface_id != 0;
 }
 
 ucs_status_t uct_ib_device_query_gid(uct_ib_device_t *dev, uint8_t port_num,
@@ -1143,7 +1143,7 @@ ucs_status_t uct_ib_device_query_gid(uct_ib_device_t *dev, uint8_t port_num,
         return status;
     }
 
-    if (uct_ib_device_is_gid_raw_empty(gid_info.gid.raw)) {
+    if (!uct_ib_device_is_gid_valid(&gid_info.gid)) {
         ucs_log(error_level, "invalid gid[%d] on %s:%d", gid_index,
                 uct_ib_device_name(dev), port_num);
         return UCS_ERR_INVALID_ADDR;

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -349,9 +349,9 @@ int uct_ib_device_is_port_roce(uct_ib_device_t *dev, uint8_t port_num);
 
 
 /**
- * @return 1 if the gid_raw is 0, 0 otherwise.
+ * @return whether the gid is valid
  */
-int uct_ib_device_is_gid_raw_empty(uint8_t *gid_raw);
+int uct_ib_device_is_gid_valid(const union ibv_gid *gid);
 
 
 /**

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -392,7 +392,7 @@ public:
         }
 
         /* check if the gid is valid to use */
-        if (uct_ib_device_is_gid_raw_empty(gid.raw)) {
+        if (!uct_ib_device_is_gid_valid(&gid)) {
             UCS_TEST_SKIP_R(device_str.str() + " is empty");
         }
 


### PR DESCRIPTION
## What?
Modified the function `uct_ib_device_is_gid_raw_empty` to check if the lower 64 bits of the GID are all zeros, indicating an invalid GID, and renamed it to `uct_ib_device_is_invalid_gid`.

## Why ?
The previous implementation checked all 128 bits of the GID to determine if it was invalid. As a result, GIDs like "fe80:0000:0000:0000:0000:0000:0000:0000" weren't filtered out, even though they are considered invalid. The new implementation aligns with the filter used in `ibv_devinfo`: https://github.com/linux-rdma/rdma-core/blob/a7528e06cf108954ea1fddb96d4aab240ae6c5a0/libibverbs/examples/devinfo.c#L225, ensuring consistency and accuracy in identifying invalid GIDs.

## How ?
Renamed and modified the function to check the lower 64 bits.
