### PR TITLE
CONFIG/M4: Use POSIX bourne syntax to check equality

### DIFF
--- a/config/m4/mad.m4
+++ b/config/m4/mad.m4
@@ -14,7 +14,7 @@ AC_ARG_WITH([mad],
             [with_mad=guess])
 
 mad_happy=no
-AS_IF([test "x$with_mad" == "xno"],
+AS_IF([test "x$with_mad" = "xno"],
     [AC_MSG_WARN([Infiniband MAD support explicitly disabled])],
 
     [AS_CASE(["x$with_mad"],


### PR DESCRIPTION
## What
Make m4 shell test POSIX bourne compliant as per report in #10041.

## Why ?
Configuration step always fails on some distributions.