### PR TITLE
COVERITY: Allow iterative runs for faster turnaround time

### DIFF
--- a/buildlib/pr/coverity.yml
+++ b/buildlib/pr/coverity.yml
@@ -20,7 +20,7 @@ jobs:
           fetchDepth: 100
           retryCountOnTaskFailure: 5
         - bash: |
-            ./buildlib/tools/coverity.sh ${{ mode }}
+            ./buildlib/tools/coverity.sh ${{ mode }} --clean --with-cuda --with-gdrcopy --with-java
             res=$?
             reportExists=False
             set -x

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -21,7 +21,7 @@ FUSE3_MODULE="dev/fuse-3.10.5"
 #
 num_cpus=$(lscpu -p | grep -v '^#' | wc -l)
 [ -z $num_cpus ] && num_cpus=1
-parallel_jobs=4
+parallel_jobs=${parallel_jobs:-4}
 [ $parallel_jobs -gt $num_cpus ] && parallel_jobs=$num_cpus
 num_pinned_threads=$(nproc)
 [ $parallel_jobs -gt $num_pinned_threads ] && parallel_jobs=$num_pinned_threads


### PR DESCRIPTION
## What
Allow iterative runs for coverity script.

## Why ?
A full run takes more than 30 minutes. Using the added `INCREMENTAL=yes` allows rebuild with html generation within 6 minutes.

## How ?
Split configure and cleanup part.
### Tested
```
# First run
$ parallel_jobs=32 ENABLE_JAVA=no BUILD_ID=scrap/build ./buildlib/tools/coverity.sh devel

# Following runs
$ INCREMENTAL=yes parallel_jobs=32 ENABLE_JAVA=no BUILD_ID=scrap/build ./buildlib/tools/coverity.sh devel
```