### PR TITLE
UCT/GDR: Fix md_close when no rcache

### DIFF
--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -430,6 +430,7 @@ uct_gdr_copy_md_create(uct_component_t *component,
     md->super.component = &uct_gdr_copy_component;
     md->reg_cost        = md_config->uc_reg_cost;
     md->super.ops       = &uct_gdr_copy_md_ops;
+    md->rcache          = NULL;
 
     md->gdrcpy_ctx = gdr_open();
     if (md->gdrcpy_ctx == NULL) {


### PR DESCRIPTION
## What
Fix crash in `uct_gdr_copy_md_close` when GDR_COPY rcache is disabled

```
0x00007f3ef989542f in __GI___wait4 (pid=pid@entry=3071342, stat_loc=stat_loc@entry=0x7f3efac6ceac, options=options@entry=0, usage=usage@entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
30      ../sysdeps/unix/sysv/linux/wait4.c: No such file or directory.
#0  0x00007f3ef989542f in __GI___wait4 (pid=pid@entry=3071342, stat_loc=stat_loc@entry=0x7f3efac6ceac, options=options@entry=0, usage=usage@entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#1  0x00007f3ef98953ab in __GI___waitpid (pid=pid@entry=3071342, stat_loc=stat_loc@entry=0x7f3efac6ceac, options=options@entry=0) at ./posix/waitpid.c:38
#2  0x00007f3efd01bbbf in ucs_debugger_attach () at debug/debug.c:819
#3  0x00007f3efd01eef9 in ucs_error_freeze (message=0x7f3efd04d8a7 "address not mapped to object") at debug/debug.c:922
#4  ucs_handle_error (message=0x7f3efd04d8a7 "address not mapped to object") at debug/debug.c:1092
#5  ucs_handle_error (message=0x7f3efd04d8a7 "address not mapped to object") at debug/debug.c:1080
#6  0x00007f3efd01f06d in ucs_debug_handle_error_signal (signo=signo@entry=11, cause=0x7f3efd04d8a7 "address not mapped to object", fmt=fmt@entry=0x7f3efd04d949 " at address %p") at debug/debug.c:1041
#7  0x00007f3efd01f356 in ucs_error_signal_handler (signo=11, info=0x7f3efac6d5f0, context=<optimized out>) at debug/debug.c:1063
#8  <signal handler called>
#9  0x00007f3efd028a16 in ucs_rcache_t_cleanup (self=0x100000000) at memory/rcache.c:1386
#10 0x00007f3efd03b05e in ucs_class_call_cleanup_chain (cls=cls@entry=0x7f3efd063e80 <ucs_rcache_t_class>, obj=obj@entry=0x100000000, limit=limit@entry=-1) at type/class.c:56
#11 0x00007f3efd02a8c5 in ucs_rcache_destroy (self=0x100000000) at memory/rcache.c:1416
#12 0x00007f3efcda4886 in uct_gdr_copy_md_close (uct_md=0x558b3e1c7f60) at gdr_copy_md.c:285
#13 0x0000558b3ce4c9a1 in uct_test::enum_resources (tl_name="rc_verbs") at uct/uct_test.cc:457
#14 0x0000558b3cce4450 in gtest_rc_verbsuct_atomic_key_reg_rdma_mem_type_EvalGenerator_ () at uct/test_atomic_key_reg_rdma_mem_type.cc:43
#15 0x0000558b3cce6f69 in testing::internal::ParameterizedTestSuiteInfo<uct_atomic_key_reg_rdma_mem_type>::RegisterTests (this=0x558b3e0d0420) at ./common/googletest/internal/gtest-param-util.h:537
#16 0x0000558b3d5e56ed in testing::internal::ParameterizedTestSuiteRegistry::RegisterTests (this=0x558b3e0cbdb8) at internal/gtest-param-util.h:699
#17 testing::internal::UnitTestImpl::RegisterParameterizedTests (this=0x558b3e0cbcd0) at gtest.cc:2651
#18 testing::internal::UnitTestImpl::RegisterParameterizedTests (this=0x558b3e0cbcd0) at gtest.cc:2649
#19 0x0000558b3d5f6293 in testing::internal::UnitTestImpl::PostFlagParsingInit (this=0x558b3e0cbcd0) at gtest.cc:5138
#20 testing::internal::UnitTestImpl::PostFlagParsingInit (this=0x558b3e0cbcd0) at gtest.cc:5120
#21 0x0000558b3cc024b9 in main (argc=<optimized out>, argv=0x7ffc4bd4fa88) at common/main.cc:68
25      in ../sysdeps/unix/sysv/linux/wait4.c

```