### PR TITLE
UCS/VFS: inotify watch from private user folder

### DIFF
--- a/src/tools/vfs/Makefile.am
+++ b/src/tools/vfs/Makefile.am
@@ -13,6 +13,7 @@ ucx_vfs_CFLAGS   = $(BASE_CFLAGS)
 ucx_vfs_SOURCES  = vfs_main.c vfs_server.c
 noinst_HEADERS   = vfs_daemon.h
 ucx_vfs_LDADD    = $(FUSE3_LIBS) \
-                   $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la
+                   $(top_builddir)/src/ucs/vfs/sock/libucs_vfs_sock.la \
+                   $(top_builddir)/src/ucs/libucs.la
 
 endif

--- a/src/tools/vfs/vfs_daemon.h
+++ b/src/tools/vfs/vfs_daemon.h
@@ -25,18 +25,8 @@ enum {
 };
 
 
-#define vfs_error(_fmt, ...) \
-    { \
-        fprintf(stderr, "Error: " _fmt "\n", ##__VA_ARGS__); \
-    }
-
-
-#define vfs_log(_fmt, ...) \
-    { \
-        if (g_opts.verbose) { \
-            fprintf(stderr, "Debug: " _fmt "\n", ##__VA_ARGS__); \
-        } \
-    }
+#define vfs_error ucs_error
+#define vfs_log   ucs_debug
 
 
 typedef struct {
@@ -45,7 +35,6 @@ typedef struct {
     int        verbose;
     const char *mountpoint_dir;
     const char *mount_opts;
-    const char *sock_path;
 } vfs_opts_t;
 
 

--- a/src/tools/vfs/vfs_server.c
+++ b/src/tools/vfs/vfs_server.c
@@ -11,6 +11,7 @@
 #include "vfs_daemon.h"
 
 #include <ucs/datastruct/khash.h>
+#include <ucs/debug/log_def.h>
 #include <sys/poll.h>
 #include <signal.h>
 
@@ -93,7 +94,7 @@ static int vfs_server_poll_events()
     if (ret < 0) {
         ret = -errno;
         if (errno != EINTR) {
-            vfs_error("poll(nfds=%d) failed: %m", vfs_server_context.nfds)
+            vfs_error("poll(nfds=%d) failed: %m", vfs_server_context.nfds);
         }
         return ret;
     }

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -17,6 +17,7 @@
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
 #include <ucs/vfs/base/vfs_obj.h>
+#include <ucs/vfs/sock/vfs_sock.h>
 #include <sys/signal.h>
 
 
@@ -224,6 +225,10 @@ static ucs_config_field_t ucs_global_opts_read_only_table[] = {
  {"VFS_ENABLE", "y",
   "Enable virtual monitoring filesystem",
   ucs_offsetof(ucs_global_opts_t, vfs_enable), UCS_CONFIG_TYPE_BOOL},
+
+  {"VFS_SOCK_PATH", UCX_VFS_SOCK_DEFAULT_PATH,
+   "Listening UNIX socket path of the VFS daemon.",
+   ucs_offsetof(ucs_global_opts_t, vfs_sock_path), UCS_CONFIG_TYPE_STRING},
 
  {"VFS_THREAD_AFFINITY", "n",
   "Enable inheriting main process affinity for virtual monitoring filesystem\n"

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -124,6 +124,9 @@ typedef struct {
     /* Enable VFS monitoring */
     int                        vfs_enable;
 
+    /* Listening UNIX socket path of the VFS daemon */
+    char                       *vfs_sock_path;
+
     /* registration cache checks if physical pages are not moved */
     unsigned                   rcache_check_pfn;
 

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -48,45 +48,39 @@ void ucs_fill_filename_template(const char *tmpl, char *buf, size_t max)
         length = ucs_min(pp - pf, end - p);
         strncpy(p, pf, length);
         p += length;
+        /* default length of the modifier (e.g. %p) */
+        length = 2;
 
         switch (*(pp + 1)) {
         case 'p':
             snprintf(p, end - p, "%d", getpid());
-            pf = pp + 2;
-            p += strlen(p);
             break;
         case 'h':
             snprintf(p, end - p, "%s", ucs_get_host_name());
-            pf = pp + 2;
-            p += strlen(p);
             break;
         case 'c':
             snprintf(p, end - p, "%02d", ucs_get_first_cpu());
-            pf = pp + 2;
-            p += strlen(p);
             break;
         case 't':
             t = time(NULL);
             strftime(p, end - p, "%Y-%m-%d-%H-%M-%S", localtime(&t));
-            pf = pp + 2;
-            p += strlen(p);
             break;
         case 'u':
             snprintf(p, end - p, "%s", ucs_basename(ucs_get_user_name()));
-            pf = pp + 2;
-            p += strlen(p);
             break;
         case 'e':
             snprintf(p, end - p, "%s", ucs_basename(ucs_get_exe()));
-            pf = pp + 2;
-            p += strlen(p);
+            break;
+        case 'i':
+            snprintf(p, end - p, "%u", geteuid());
             break;
         default:
             *(p++) = *pp;
-            pf = pp + 1;
+            length = 1;
             break;
         }
 
+        pf = pp + length;
         p += strlen(p);
     }
     *p = 0;

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -54,6 +54,11 @@ void ucs_expand_path(const char *path, char *fullpath, size_t max);
  * Fill a filename template. The following values in the string are replaced:
  *  %p - replaced by process id
  *  %h - replaced by host name
+ *  %c - replaced by the first CPU we are bound to
+ *  %t - replaced by local time
+ *  %u - replaced by user name
+ *  %e - replaced by executable basename
+ *  %i - replaced by user id
  *
  * @param tmpl   File name template (possibly containing formatting sequences)
  * @param buf    Filled with resulting file name

--- a/src/ucs/vfs/sock/vfs_sock.h
+++ b/src/ucs/vfs/sock/vfs_sock.h
@@ -7,12 +7,16 @@
 #ifndef UCS_VFS_SOCK_H_
 #define UCS_VFS_SOCK_H_
 
+#include <ucs/config/types.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <stdint.h>
 
 /* This header file defines socket operations for communicating between UCS
  * library and VFS daemon */
+
+#define UCX_VFS_SOCK_DEFAULT_PATH "/run/user/%i/ucx/vfs.sock"
+
 
 /**
  * VFS socket message type
@@ -50,6 +54,16 @@ typedef struct {
  * @param [out] un_addr  Filled with socket address.
  */
 void ucs_vfs_sock_get_address(struct sockaddr_un *un_addr);
+
+
+/**
+ * Find directory in the given path, and create it if it does not exist.
+ *
+ * @param [in]   sock_path Path to the socket file.
+ * @param [in]   log_level Log level to use in case of failure.
+ * @return 0 on success, or the negative value of errno in case of failure.
+ */
+int ucs_vfs_sock_mkdir(const char *sock_path, ucs_log_level_t log_level);
 
 
 /**


### PR DESCRIPTION
## What
Make VFS unix socket path configurable with UCX_VFS_SOCK_PATH option
By default put listening socket in dedicated folder: `/run/user/<user_id>/ucx/vfs.sock`

## Why ?
We use inotify watch from the client side to detect VFS server presence. When we run inotify watch in a public folder (/tmp) with many files, then we experience the following issues:
- inotify_add_watch can take more than a second to start (in NVHPC cluster), and the main thread is delayed
- we wake VFS fuse thread on all the file create events, even unrelated to us

## How ?
Added option UCX_VFS_SOCK_PATH to configure socket path on the client side. Before it was only configurable on VFS daemon side with -l option.
Use %i wildcard that represents user_id. Ideally we should use `ucs_fill_filename_template` here, but ucs library is not linked by vfs_sock, and it's not desirable to add this dependency. 
By default the folder for VFS socket is `/run/user/<user_id>/ucx`, and both client and server creates this folder - this way we guarantee that no interference happens with other processes, and no wakeups on irrelevant files created