### PR TITLE
UCP/WIREUP: specify a reason for wireup failure - part 2

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -910,7 +910,8 @@ void uct_iface_get_local_address(uct_iface_local_addr_ns_t *addr_ns,
                                  ucs_sys_namespace_type_t sys_ns_type);
 
 int uct_iface_local_is_reachable(uct_iface_local_addr_ns_t *addr_ns,
-                                 ucs_sys_namespace_type_t sys_ns_type);
+                                 ucs_sys_namespace_type_t sys_ns_type,
+                                 const uct_iface_is_reachable_params_t *params);
 
 void uct_iface_fill_info_str_buf(const uct_iface_is_reachable_params_t *params,
                                  const char *fmt, ...);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -71,9 +71,19 @@ static int uct_cuda_copy_iface_is_reachable_v2(
     }
 
     addr = (uct_cuda_copy_iface_addr_t*)params->iface_addr;
+    if (addr == NULL) {
+        uct_iface_fill_info_str_buf(params, "device address is empty");
+        return 0;
+    }
 
-    return (addr != NULL) && (iface->id == *addr) &&
-           uct_iface_scope_is_reachable(tl_iface, params);
+    if (iface->id != *addr) {
+        uct_iface_fill_info_str_buf(
+                params, "different iface id %"PRIx64" vs %"PRIx64"",
+                iface->id, *addr);
+        return 0;
+    }
+
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -55,9 +55,19 @@ uct_gdr_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
     }
 
     addr = (uct_gdr_copy_iface_addr_t*)params->iface_addr;
+    if (addr == NULL) {
+        uct_iface_fill_info_str_buf(params, "device address is empty");
+        return 0;
+    }
 
-    return (addr != NULL) && (iface->id == *addr) &&
-           uct_iface_scope_is_reachable(tl_iface, params);
+    if (iface->id != *addr) {
+        uct_iface_fill_info_str_buf(params,
+                                    "different iface id %"PRIx64" vs %"PRIx64"",
+                                    iface->id, *addr);
+        return 0;
+    }
+
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -72,9 +72,18 @@ static int uct_rocm_copy_iface_is_reachable_v2(
     }
 
     addr = (uct_rocm_copy_iface_addr_t*)params->iface_addr;
+    if (addr == NULL) {
+        uct_iface_fill_info_str_buf(params, "device address is empty");
+        return 0;
+    }
 
-    return (addr != NULL) && (iface->id == *addr) &&
-           uct_iface_scope_is_reachable(tl_iface, params);
+    if (iface->id != *addr) {
+        uct_iface_fill_info_str_buf(
+                params, "different iface id %"PRIx64" vs %"PRIx64"", iface->id, *addr);
+        return 0;
+    }
+
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,

--- a/src/uct/sm/base/sm_iface.c
+++ b/src/uct/sm/base/sm_iface.c
@@ -49,10 +49,11 @@ uct_sm_iface_get_device_address(uct_iface_t *tl_iface, uct_device_addr_t *addr)
 }
 
 int uct_sm_iface_is_reachable(const uct_iface_h tl_iface,
-                              const uct_device_addr_t *dev_addr)
+                              const uct_iface_is_reachable_params_t *params)
 {
-    return uct_iface_local_is_reachable((uct_iface_local_addr_ns_t*)dev_addr,
-                                        UCS_SYS_NS_TYPE_IPC);
+    return uct_iface_local_is_reachable(
+            (uct_iface_local_addr_ns_t*)params->device_addr,
+            UCS_SYS_NS_TYPE_IPC, params);
 }
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags)

--- a/src/uct/sm/base/sm_iface.h
+++ b/src/uct/sm/base/sm_iface.h
@@ -40,7 +40,7 @@ ucs_status_t uct_sm_iface_get_device_address(uct_iface_t *tl_iface,
                                              uct_device_addr_t *addr);
 
 int uct_sm_iface_is_reachable(const uct_iface_h tl_iface,
-                              const uct_device_addr_t *dev_addr);
+                              const uct_iface_is_reachable_params_t *params);
 
 ucs_status_t uct_sm_iface_fence(uct_iface_t *tl_iface, unsigned flags);
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -138,8 +138,12 @@ uct_mm_iface_is_reachable_v2(const uct_iface_h tl_iface,
     }
 
     iface_addr = (void*)params->iface_addr;
+    if (iface_addr == NULL) {
+        uct_iface_fill_info_str_buf(params, "iface address is empty");
+        return 0;
+    }
 
-    return uct_sm_iface_is_reachable(tl_iface, params->device_addr) &&
+    return uct_sm_iface_is_reachable(tl_iface, params) &&
            uct_mm_md_mapper_ops(md)->is_reachable(md, iface_addr->fifo_seg_id,
                                                   iface_addr + 1) &&
            uct_iface_scope_is_reachable(tl_iface, params);

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -44,7 +44,7 @@ uct_knem_iface_is_reachable_v2(const uct_iface_h tl_iface,
 {
     return uct_iface_is_reachable_params_valid(
                    params, UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR) &&
-           uct_sm_iface_is_reachable(tl_iface, params->device_addr) &&
+           uct_sm_iface_is_reachable(tl_iface, params) &&
            uct_iface_scope_is_reachable(tl_iface, params);
 }
 

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -153,9 +153,18 @@ uct_self_iface_is_reachable_v2(const uct_iface_h tl_iface,
     }
 
     addr = (const uct_self_iface_addr_t*)params->iface_addr;
+    if (addr == NULL) {
+        uct_iface_fill_info_str_buf(params, "iface address is empty");
+        return 0;
+    }
 
-    return (addr != NULL) && (iface->id == *addr) &&
-           uct_iface_scope_is_reachable(tl_iface, params);
+    if (iface->id != *addr) {
+        uct_iface_fill_info_str_buf(
+                params, "iface id and iface address differ (%lu vs %lu)",
+                iface->id, *addr);
+        return 0;
+    }
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static void uct_self_iface_sendrecv_am(uct_self_iface_t *iface, uint8_t am_id,

--- a/src/uct/ze/copy/ze_copy_iface.c
+++ b/src/uct/ze/copy/ze_copy_iface.c
@@ -41,8 +41,19 @@ uct_ze_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
     }
 
     addr = (uct_ze_copy_iface_addr_t*)params->iface_addr;
-    return (addr != NULL) && (iface->id == *addr) &&
-           uct_iface_scope_is_reachable(tl_iface, params);
+    if (addr == NULL) {
+        uct_iface_fill_info_str_buf(params, "device address is empty");
+        return 0;
+    }
+
+    if (iface->id != *addr) {
+        uct_iface_fill_info_str_buf(params,
+                                    "different iface id %"PRIx64" vs %"PRIx64"",
+                                    iface->id, *addr);
+        return 0;
+    }
+
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static ucs_status_t


### PR DESCRIPTION
## What
During the wireup process, provide a reason when a resource's lane is unreachable (second part after https://github.com/openucx/ucx/pull/9995. Includes all the transports other than IB).

## Why ?
Users need more information about why a device is not reachable after an unsuccessful connection establishment. This information should be passed from UCT to UCP.

## How ?
Pass a string to select/search_lane functions so in case the wireup process fails, the reason will be printed out in an upper layer.
