### PR TITLE
UCT/MD/IB: Add ODP support for verbs and mlx5dv

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1203,6 +1203,35 @@ static void uct_ib_md_check_dmabuf(uct_ib_md_t *md)
 #endif
 }
 
+int uct_ib_md_check_odp_common(uct_ib_md_t *md, const char **reason_ptr)
+{
+    if (IBV_ACCESS_ON_DEMAND == 0) {
+        *reason_ptr = "IBV_ACCESS_ON_DEMAND is not supported";
+        return 0;
+    }
+
+    if (!IBV_DEVICE_HAS_ODP(&md->dev)) {
+        *reason_ptr = "device does not support IBV_ACCESS_ON_DEMAND";
+        return 0;
+    }
+
+    return 1;
+}
+
+void uct_ib_md_check_odp(uct_ib_md_t *md)
+{
+    const char *device_name = uct_ib_device_name(&md->dev);
+    const char *reason;
+
+    if (!uct_ib_md_check_odp_common(md, &reason)) {
+        ucs_debug("%s: ODP is disabled because %s", device_name, reason);
+        return;
+    }
+
+    md->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    ucs_debug("%s: ODP is supported, version 1", device_name);
+}
+
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                    struct ibv_device *ib_device,
                                    const uct_ib_md_config_t *md_config)
@@ -1463,6 +1492,7 @@ static ucs_status_t uct_ib_verbs_md_open(struct ibv_device *ibv_device,
 
     uct_ib_md_ece_check(md);
     uct_ib_md_parse_relaxed_order(md, md_config, 0);
+    uct_ib_md_check_odp(md);
 
     *p_md = md;
     return UCS_OK;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -372,6 +372,11 @@ ucs_status_t uct_ib_mem_prefetch(uct_ib_md_t *md, uct_ib_mem_t *ib_memh,
  */
 void uct_ib_md_ece_check(uct_ib_md_t *md);
 
+/* Check if IB MD supports nonblocking registration */
+void uct_ib_md_check_odp(uct_ib_md_t *md);
+
+int uct_ib_md_check_odp_common(uct_ib_md_t *md, const char **reason_ptr);
+
 ucs_status_t
 uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
                             const uct_md_mem_reg_params_t *params,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1609,13 +1609,7 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
     struct ibv_mr *mr;
     uint8_t version;
 
-    if (IBV_ACCESS_ON_DEMAND == 0) {
-        reason = "IBV_ACCESS_ON_DEMAND is not supported";
-        goto no_odp;
-    }
-
-    if (!IBV_DEVICE_HAS_ODP(&md->super.dev)) {
-        reason = "device does not support ODP";
+    if (!uct_ib_md_check_odp_common(&md->super, &reason)) {
         goto no_odp;
     }
 
@@ -3199,6 +3193,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
 
     uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
     uct_ib_md_ece_check(&md->super);
+    uct_ib_md_check_odp(&md->super);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -106,6 +106,11 @@ public:
             modify_config("PROTO_ENABLE", "n");
         }
 
+        if (get_variant_value() == VARIANT_MAP_NONBLOCK) {
+            // ODPv1 cannot interact with DEVX objects
+            modify_config("IB_MLX5_DEVX_OBJECTS", "", SETENV_IF_NOT_EXIST);
+        }
+
         if (get_variant_value() == VARIANT_NO_RCACHE) {
             modify_config("RCACHE_ENABLE", "n");
             ucp_test::init(); // Init UCP with rcache disabled
@@ -547,7 +552,11 @@ UCS_TEST_P(test_ucp_mmap, reg_mem_type) {
 
     for (int i = 0; i < 1000 / ucs::test_time_multiplier(); ++i) {
         size_t size    = ucs::rand() % UCS_MBYTE;
-        alloc_mem_type = mem_types.at(ucs::rand() % mem_types.size());
+        auto flags     = mem_map_flags();
+        /* Test ODP registration with host buffer only */
+        alloc_mem_type = (flags & VARIANT_MAP_NONBLOCK) ?
+                UCS_MEMORY_TYPE_HOST :
+                mem_types.at(ucs::rand() % mem_types.size());
         mem_buffer buf(size, alloc_mem_type);
         mem_buffer::pattern_fill(buf.ptr(), size, 0, alloc_mem_type);
 
@@ -561,7 +570,7 @@ UCS_TEST_P(test_ucp_mmap, reg_mem_type) {
         params.address     = buf.ptr();
         params.length      = size;
         params.memory_type = alloc_mem_type;
-        params.flags       = mem_map_flags();
+        params.flags       = flags;
 
         status = ucp_mem_map(sender().ucph(), &params, &memh);
         ASSERT_UCS_OK(status);
@@ -943,8 +952,7 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
     }
 }
 
-UCS_TEST_P(test_ucp_mmap, gva_allocate, "GVA_ENABLE=y",
-           "IB_MLX5_DEVX_OBJECTS?=")
+UCS_TEST_P(test_ucp_mmap, gva_allocate, "GVA_ENABLE=y")
 {
     for (auto mem_type : mem_buffer::supported_mem_types()) {
         ucp_md_map_t md_map = sender().ucph()->gva_md_map[mem_type];
@@ -969,7 +977,7 @@ UCS_TEST_P(test_ucp_mmap, gva_allocate, "GVA_ENABLE=y",
     }
 }
 
-UCS_TEST_P(test_ucp_mmap, gva, "GVA_ENABLE=y", "IB_MLX5_DEVX_OBJECTS?=")
+UCS_TEST_P(test_ucp_mmap, gva, "GVA_ENABLE=y")
 {
     std::list<void*> bufs;
     ucp_mem_h first     = NULL;

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -311,3 +311,18 @@ UCS_TEST_P(test_ib_md, smkey_reg_atomic_mt, "IB_REG_MT_THRESH=1k",
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)
+
+class test_ib_md_non_blocking : public test_md_non_blocking {
+};
+
+UCS_TEST_P(test_ib_md_non_blocking, reg_advise_odp_no_devx, "IB_MLX5_DEVX=no")
+{
+    test_nb_reg_advise();
+}
+
+UCS_TEST_P(test_ib_md_non_blocking, reg_odp_no_devx, "IB_MLX5_DEVX=no")
+{
+    test_nb_reg();
+}
+
+_UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md_non_blocking, ib)

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -1137,44 +1137,16 @@ UCS_TEST_P(test_md_memlock_limit, md_open)
 
 UCT_MD_INSTANTIATE_TEST_CASE(test_md_memlock_limit)
 
-class test_md_non_blocking : public test_md
-{
-protected:
-    void init() override {
-        /* ODPv1 IB feature can work only for certain DEVX configuration */
-        modify_config("IB_MLX5_DEVX_OBJECTS", "dct,dcsrq", IGNORE_IF_NOT_EXIST);
-        test_md::init();
-    }
-};
-
 UCS_TEST_SKIP_COND_P(test_md_non_blocking, reg_advise,
                      !check_caps(UCT_MD_FLAG_REG | UCT_MD_FLAG_ADVISE))
 {
-    test_reg_advise(UCS_KBYTE, UCS_KBYTE, 0, true);
-    test_reg_advise(UCS_KBYTE, UCS_KBYTE / 2, 0, true);
-    test_reg_advise(UCS_KBYTE, UCS_KBYTE / 2, UCS_KBYTE / 4, true);
-
-    /*
-     * TODO: These tests should be enabled
-     * when https://redmine.mellanox.com/issues/336376 fixed
-
-     * test_reg_advise(UCS_MBYTE, UCS_MBYTE, 0, true);
-     * test_reg_advise(UCS_MBYTE, UCS_MBYTE / 2, 0, true);
-     * test_reg_advise(UCS_MBYTE, UCS_MBYTE / 2, UCS_MBYTE / 4, true);
-     */
+    test_nb_reg_advise();
 }
 
 UCS_TEST_SKIP_COND_P(test_md_non_blocking, reg,
                      !check_caps(UCT_MD_FLAG_REG))
 {
-    test_reg_advise(UCS_KBYTE, 0, 0, true);
-
-    /*
-     * TODO: This test should be enabled
-     * when https://redmine.mellanox.com/issues/336376 fixed
-
-     * test_reg_advise(UCS_MBYTE, 0, 0, true);
-     */
+    test_nb_reg();
 }
 
 UCT_MD_INSTANTIATE_TEST_CASE(test_md_non_blocking)

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -87,6 +87,33 @@ protected:
 };
 
 
+class test_md_non_blocking : public test_md {
+protected:
+    void init() override
+    {
+        /* ODPv1 IB feature can work only for certain DEVX configuration */
+        modify_config("IB_MLX5_DEVX_OBJECTS", "dct,dcsrq", IGNORE_IF_NOT_EXIST);
+        test_md::init();
+    }
+
+    void test_nb_reg_advise()
+    {
+        for (auto size : {UCS_KBYTE, UCS_MBYTE}) {
+            test_reg_advise(size, size, 0, true);
+            test_reg_advise(size, size / 2, 0, true);
+            test_reg_advise(size, size / 2, size / 4, true);
+        }
+    }
+
+    void test_nb_reg()
+    {
+        for (auto size : {UCS_KBYTE, UCS_MBYTE}) {
+            test_reg_advise(size, 0, 0, true);
+        }
+    }
+};
+
+
 #define _UCT_MD_INSTANTIATE_TEST_CASE(_test_case, _cmpt_name) \
     INSTANTIATE_TEST_SUITE_P(_cmpt_name, _test_case, \
                             testing::ValuesIn(_test_case::enum_mds(#_cmpt_name)));


### PR DESCRIPTION
## What
Support ODPv1 for verbs and mlx5dv MDs.

## Why ?
To provide workaround in case of issues with DEVX ODP support.
