### PR TITLE
UCP/CORE: Fix wrong flag being used for checking BCOPY capability

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3527,7 +3527,7 @@ int ucp_ep_is_am_keepalive(ucp_ep_h ep, ucp_rsc_index_t rsc_index, int is_p2p)
             /* Transport is not connected as point-to-point */
             !is_p2p &&
             /* Transport supports active messages */
-            (ucp_worker_iface(ep->worker, rsc_index)->flags &
+            (ucp_worker_iface(ep->worker, rsc_index)->attr.cap.flags &
              UCT_IFACE_FLAG_AM_BCOPY);
 }
 


### PR DESCRIPTION
## What
Use proper flags for checking bcopy capability before sending keepalives.

## Why ?
Was previously ending-up using `UCP_WORKER_IFACE_FLAG_ON_ARM_LIST` potentially causing transcient errors.

## How ?
Exercise code path with `./test/gtest/gtest --gtest_filter=ud/test_ucp_peer_failure_keepalive.kill_receiver/0` where we should see wireup check AM being sent instead of zero size PUT.