### PR TITLE
GTEST: Fix tcp_device name detection in pci_bw test

### DIFF
--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -859,7 +859,8 @@ public:
         }
 
         for (const auto &file : sysfs_files) {
-            if (file.find("slave_") != std::string::npos) {
+            if ((file.find("slave_") != std::string::npos) ||
+                (file.find("lower_") != std::string::npos)) {
                 dev_path += "/" + file;
                 break;
             }


### PR DESCRIPTION
## What
Fix tcp device name detection in pci bw test

## Why ?
```
2024-08-14T21:20:05.1331101Z [----------] 1 test from all/test_pci_bw
2024-08-14T21:20:05.1332298Z [ RUN      ] all/test_pci_bw.get_pci_bw/0 <all/tag>
2024-08-14T21:20:05.5218597Z /scrap/azure/agent-08/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/test_ucp_worker.cc:923: Failure
2024-08-14T21:20:05.5220864Z Expected: (pci_bw) < (std::numeric_limits<double>::max()), actual: 1.79769e+308 vs 1.79769e+308
2024-08-14T21:20:05.6323040Z [  FAILED  ] all/test_pci_bw.get_pci_bw/0, where GetParam() = all/tag (499 ms)
2024-08-14T21:20:05.6325843Z [----------] 1 test from all/test_pci_bw (499 ms total)
```

## How ?

```
mikhailb@swx-rain03:~/work/ucx$ ls /sys/class/net/bond0/slave_*
ls: cannot access '/sys/class/net/bond0/slave_*': No such file or directory

mikhailb@swx-rain03:~/work/ucx$ ls /sys/class/net/bond0/lower_*
/sys/class/net/bond0/lower_enp217s0f0np0:
addr_assign_type  bonding_slave  carrier_changes     compat  dev_id    duplex  gro_flush_timeout  hp_pp_burst_size  iflink     mtu                   netdev_group  phys_port_id    phy_stats   qos            settings    subsystem  tx_queue_len  upper_bond0
address           broadcast      carrier_down_count  debug   dev_port  ecn     hp_oob_cnt         ifalias           link_mode  name_assign_type      num_prio_hp   phys_port_name  power       queues         speed       testing    type
addr_len          carrier        carrier_up_count    device  dormant   flags   hp_oob_cnt_mode    ifindex           master     napi_defer_hard_irqs  operstate     phys_switch_id  proto_down  rx_page_cache  statistics  threaded   uevent

/sys/class/net/bond0/lower_enp217s0f1np1:
addr_assign_type  bonding_slave  carrier_changes     compat  dev_id    duplex  gro_flush_timeout  hp_pp_burst_size  iflink     mtu                   netdev_group  phys_port_id    phy_stats   qos            settings    subsystem  tx_queue_len  upper_bond0
address           broadcast      carrier_down_count  debug   dev_port  ecn     hp_oob_cnt         ifalias           link_mode  name_assign_type      num_prio_hp   phys_port_name  power       queues         speed       testing    type
addr_len          carrier        carrier_up_count    device  dormant   flags   hp_oob_cnt_mode    ifindex           master     napi_defer_hard_irqs  operstate     phys_switch_id  proto_down  rx_page_cache  statistics  threaded   uevent

```