### PR TITLE
UCT/CUDA: Detect async allocations as managed (plus env var)

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -24,8 +24,8 @@
 
 
 /* Create a body of CUDA memory allocation replacement function */
-#define UCM_CUDA_ALLOC_FUNC(_name, _mem_type, _retval, _success, _size, \
-                            _ptr_type, _ref, _args_fmt, ...) \
+#define UCM_CUDA_ALLOC_FUNC(_name, _retval, _success, _size, _ptr_type, _ref, \
+                            _args_fmt, ...) \
     _retval ucm_##_name(_ptr_type _ref ptr_arg, \
                         UCM_FUNC_DEFINE_ARGS(__VA_ARGS__)) \
     { \
@@ -38,8 +38,7 @@
             ptr = _ref ptr_arg; \
             ucm_trace("%s(" _args_fmt ") allocated %p", __func__, \
                       UCM_FUNC_PASS_ARGS(__VA_ARGS__), (void*)ptr); \
-            ucm_cuda_dispatch_mem_alloc((CUdeviceptr)ptr, (_size), \
-                                        (_mem_type)); \
+            ucm_cuda_dispatch_mem_alloc((CUdeviceptr)ptr, (_size)); \
         } \
         ucm_event_leave(); \
         return ret; \
@@ -123,8 +122,7 @@ UCM_DEFINE_REPLACE_DLSYM_PTR_FUNC(cudaMallocManaged, cudaError_t, -1, void**,
 UCM_DEFINE_REPLACE_DLSYM_PTR_FUNC(cudaMallocPitch, cudaError_t, -1, void**,
                                   size_t*, size_t, size_t)
 
-static void ucm_cuda_dispatch_mem_alloc(CUdeviceptr ptr, size_t length,
-                                        ucs_memory_type_t mem_type)
+static void ucm_cuda_dispatch_mem_alloc(CUdeviceptr ptr, size_t length)
 {
     ucm_event_t event;
 
@@ -169,33 +167,29 @@ static void ucm_cuda_dispatch_mem_free(CUdeviceptr ptr, size_t length,
 }
 
 /* Driver API replacements */
-UCM_CUDA_ALLOC_FUNC(cuMemAlloc, UCS_MEMORY_TYPE_CUDA, CUresult, CUDA_SUCCESS,
-                    arg0, CUdeviceptr, *, "size=%zu", size_t)
-UCM_CUDA_ALLOC_FUNC(cuMemAlloc_v2, UCS_MEMORY_TYPE_CUDA, CUresult, CUDA_SUCCESS,
-                    arg0, CUdeviceptr, *, "size=%zu", size_t)
-UCM_CUDA_ALLOC_FUNC(cuMemAllocManaged, UCS_MEMORY_TYPE_CUDA_MANAGED, CUresult,
-                    CUDA_SUCCESS, arg0, CUdeviceptr, *, "size=%zu flags=0x%x",
-                    size_t, unsigned)
-UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch, UCS_MEMORY_TYPE_CUDA, CUresult,
-                    CUDA_SUCCESS, ((size_t)arg1) * (arg2), CUdeviceptr, *,
+UCM_CUDA_ALLOC_FUNC(cuMemAlloc, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, *,
+                    "size=%zu", size_t)
+UCM_CUDA_ALLOC_FUNC(cuMemAlloc_v2, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, *,
+                    "size=%zu", size_t)
+UCM_CUDA_ALLOC_FUNC(cuMemAllocManaged, CUresult, CUDA_SUCCESS, arg0,
+                    CUdeviceptr, *, "size=%zu flags=0x%x", size_t, unsigned)
+UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch, CUresult, CUDA_SUCCESS,
+                    ((size_t)arg1) * (arg2), CUdeviceptr, *,
                     "pitch=%p width=%zu height=%zu elem=%u", size_t*, size_t,
                     size_t, unsigned)
-UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch_v2, UCS_MEMORY_TYPE_CUDA, CUresult,
-                    CUDA_SUCCESS, ((size_t)arg1) * (arg2), CUdeviceptr, *,
+UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch_v2, CUresult, CUDA_SUCCESS,
+                    ((size_t)arg1) * (arg2), CUdeviceptr, *,
                     "pitch=%p width=%zu height=%zu elem=%u", size_t*, size_t,
                     size_t, unsigned)
-UCM_CUDA_ALLOC_FUNC(cuMemMap, UCS_MEMORY_TYPE_UNKNOWN, CUresult, CUDA_SUCCESS,
-                    arg0, CUdeviceptr, ,
+UCM_CUDA_ALLOC_FUNC(cuMemMap, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, ,
                     "size=%zu offset=%zu handle=0x%llx flags=0x%llx", size_t,
                     size_t, CUmemGenericAllocationHandle, unsigned long long)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_ALLOC_FUNC(cuMemAllocAsync, UCS_MEMORY_TYPE_CUDA, CUresult,
-                    CUDA_SUCCESS, arg0, CUdeviceptr, *, "size=%zu stream=%p",
-                    size_t, CUstream)
-UCM_CUDA_ALLOC_FUNC(cuMemAllocFromPoolAsync, UCS_MEMORY_TYPE_CUDA, CUresult,
-                    CUDA_SUCCESS, arg0, CUdeviceptr, *,
-                    "size=%zu pool=%p stream=%p", size_t, CUmemoryPool,
-                    CUstream)
+UCM_CUDA_ALLOC_FUNC(cuMemAllocAsync, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr,
+                    *, "size=%zu stream=%p", size_t, CUstream)
+UCM_CUDA_ALLOC_FUNC(cuMemAllocFromPoolAsync, CUresult, CUDA_SUCCESS, arg0,
+                    CUdeviceptr, *, "size=%zu pool=%p stream=%p", size_t,
+                    CUmemoryPool, CUstream)
 #endif
 UCM_CUDA_FREE_FUNC(cuMemFree, UCS_MEMORY_TYPE_CUDA, CUresult, arg0, 0,
                    "ptr=0x%llx", CUdeviceptr)
@@ -235,21 +229,19 @@ static ucm_cuda_func_t ucm_cuda_driver_funcs[] = {
 };
 
 /* Runtime API replacements */
-UCM_CUDA_ALLOC_FUNC(cudaMalloc, UCS_MEMORY_TYPE_CUDA, cudaError_t, cudaSuccess,
-                    arg0, void*, *, "size=%zu", size_t)
-UCM_CUDA_ALLOC_FUNC(cudaMallocManaged, UCS_MEMORY_TYPE_CUDA_MANAGED,
-                    cudaError_t, cudaSuccess, arg0, void*, *,
+UCM_CUDA_ALLOC_FUNC(cudaMalloc, cudaError_t, cudaSuccess, arg0, void*, *,
+                    "size=%zu", size_t)
+UCM_CUDA_ALLOC_FUNC(cudaMallocManaged, cudaError_t, cudaSuccess, arg0, void*, *,
                     "size=%zu flags=0x%x", size_t, unsigned)
-UCM_CUDA_ALLOC_FUNC(cudaMallocPitch, UCS_MEMORY_TYPE_CUDA, cudaError_t,
-                    cudaSuccess, ((size_t)arg1) * (arg2), void*, *,
+UCM_CUDA_ALLOC_FUNC(cudaMallocPitch, cudaError_t, cudaSuccess,
+                    ((size_t)arg1) * (arg2), void*, *,
                     "pitch=%p width=%zu height=%zu", size_t*, size_t, size_t)
 #if CUDA_VERSION >= 11020
-UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t,
-                    cudaSuccess, arg0, void*, *, "size=%zu stream=%p", size_t,
-                    cudaStream_t)
-UCM_CUDA_ALLOC_FUNC(cudaMallocFromPoolAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t,
-                    cudaSuccess, arg0, void*, *, "size=%zu pool=%p stream=%p",
-                    size_t, cudaMemPool_t, cudaStream_t)
+UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, cudaError_t, cudaSuccess, arg0, void*, *,
+                    "size=%zu stream=%p", size_t, cudaStream_t)
+UCM_CUDA_ALLOC_FUNC(cudaMallocFromPoolAsync, cudaError_t, cudaSuccess, arg0,
+                    void*, *, "size=%zu pool=%p stream=%p", size_t,
+                    cudaMemPool_t, cudaStream_t)
 #endif
 UCM_CUDA_FREE_FUNC(cudaFree, UCS_MEMORY_TYPE_CUDA, cudaError_t, arg0, 0,
                    "devPtr=%p", void*)

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -72,6 +72,12 @@ static ucs_config_field_t uct_cuda_copy_md_config_table[] = {
      ucs_offsetof(uct_cuda_copy_md_config_t, enable_fabric),
      UCS_CONFIG_TYPE_TERNARY},
 
+    {"ASYNC_MEM_TYPE", "cuda-managed",
+     "Memory type which is detected for asynchronously allocated cuda memory.\n"
+     "Allowed memory type is one of: cuda, cuda-managed",
+     ucs_offsetof(uct_cuda_copy_md_config_t, cuda_async_mem_type),
+     UCS_CONFIG_TYPE_ENUM(ucs_memory_type_names)},
+
     {NULL}
 };
 
@@ -515,10 +521,11 @@ static ucs_status_t
 uct_cuda_copy_md_query_attributes(uct_cuda_copy_md_t *md, const void *address,
                                   size_t length, ucs_memory_info_t *mem_info)
 {
-#define UCT_CUDA_MEM_QUERY_NUM_ATTRS 3
+#define UCT_CUDA_MEM_QUERY_NUM_ATTRS 4
     CUmemorytype cuda_mem_type = CU_MEMORYTYPE_HOST;
     uint32_t is_managed        = 0;
     CUdevice cuda_device       = -1;
+    CUcontext cuda_mem_ctx     = NULL;
     CUpointer_attribute attr_type[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
     void *attr_data[UCT_CUDA_MEM_QUERY_NUM_ATTRS];
     CUdeviceptr base_address;
@@ -542,6 +549,8 @@ uct_cuda_copy_md_query_attributes(uct_cuda_copy_md_t *md, const void *address,
         attr_data[1] = &is_managed;
         attr_type[2] = CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
         attr_data[2] = &cuda_device;
+        attr_type[3] = CU_POINTER_ATTRIBUTE_CONTEXT;
+        attr_data[3] = &cuda_mem_ctx;
 
         status = UCT_CUDADRV_FUNC_LOG_ERR(
                 cuPointerGetAttributes(ucs_static_array_size(attr_data),
@@ -557,10 +566,21 @@ uct_cuda_copy_md_query_attributes(uct_cuda_copy_md_t *md, const void *address,
             return UCS_ERR_INVALID_ADDR;
         }
 
-        if (is_managed) {
+        if (is_managed ||
+            ((cuda_mem_ctx == NULL) && md->config.cuda_async_managed)) {
             /* is_managed: cuMemGetAddress range does not support managed memory
              * so use provided address and length as base address and alloc
-             * length respectively */
+             * length respectively
+             *
+             * cuda_async_managed: currently virtual/stream-ordered CUDA
+             * allocations are typed as `UCS_MEMORY_TYPE_CUDA_MANAGED`. This may
+             * be changed using UCX_CUDA_COPY_ASYNC_MEM_TYPE env var.
+             * Ideally checking for
+             * `CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE` would be better
+             * here, but due to a bug in the driver `cudaMalloc` also returns false
+             * in that case. Therefore, checking whether the allocation was not
+             * allocated in a context should also allows us to identify
+             * virtual/stream-ordered CUDA allocations. */
             mem_info->type = UCS_MEMORY_TYPE_CUDA_MANAGED;
 
             cu_err = cuMemRangeGetAttribute(
@@ -813,6 +833,16 @@ uct_cuda_copy_md_open(uct_component_t *component, const char *md_name,
     md->config.dmabuf_supported = 0;
     md->sync_memops_set         = 0;
     md->granularity             = SIZE_MAX;
+
+    if ((config->cuda_async_mem_type != UCS_MEMORY_TYPE_CUDA) &&
+        (config->cuda_async_mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED)) {
+        ucs_warn("wrong memory type for async memory allocations: \"%s\";"
+                " cuda-managed will be used instead",
+                ucs_memory_type_names[config->cuda_async_mem_type]);
+    }
+
+    md->config.cuda_async_managed =
+                          (config->cuda_async_mem_type != UCS_MEMORY_TYPE_CUDA);
 
     dmabuf_supported = uct_cuda_copy_md_is_dmabuf_supported();
     if ((config->enable_dmabuf == UCS_YES) && !dmabuf_supported) {

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -35,6 +35,7 @@ typedef struct uct_cuda_copy_md {
         int                      dmabuf_supported;
         ucs_ternary_auto_value_t enable_fabric;
         uct_cuda_pref_loc_t      pref_loc;
+        int                      cuda_async_managed;
     } config;
 } uct_cuda_copy_md_t;
 
@@ -48,6 +49,7 @@ typedef struct uct_cuda_copy_md_config {
     ucs_ternary_auto_value_t    enable_dmabuf;
     ucs_ternary_auto_value_t    enable_fabric;
     uct_cuda_pref_loc_t         pref_loc;
+    ucs_memory_type_t           cuda_async_mem_type;
 } uct_cuda_copy_md_config_t;
 
 /**


### PR DESCRIPTION
## What
Detect async memory allocations as cuda-managed memory to avoid cuda-ipc transport being selected.

## Why ?
Fixes a regression from #9867 

```
Allocate async cuda memory
Allocate async cuda memory
cuda_ipc_md.c:112  UCX  ERROR cuIpcGetMemHandle(&key->ph, (CUdeviceptr)addr) failed: invalid argument
proto_common.inl:373  UCX  ERROR failed to pack remote key: Input/output error
cuda_ipc_md.c:112  UCX  ERROR cuIpcGetMemHandle(&key->ph, (CUdeviceptr)addr) failed: invalid argument
proto_common.inl:373  UCX  ERROR failed to pack remote key: Input/output error
proto_rndv.c:850  Assertion `(address != 0) == (rkey_length > 0)' failed: rts rts->address=0x320000000 rkey_length=0

```