### PR TITLE
CONTRIB/IBMOCK: Inital add with EFA support

### DIFF
--- a/buildlib/pr/efa.yml
+++ b/buildlib/pr/efa.yml
@@ -1,0 +1,31 @@
+parameters:
+  demands: []
+  container: rhel90_ib
+
+jobs:
+  - job: tests_${{ parameters.name }}
+    pool:
+      name: MLNX
+      demands: ${{ parameters.demands }}
+    displayName: ${{ parameters.name }} on ${{ parameters.container }}
+    container: ${{ parameters.container }}
+    timeoutInMinutes: 90
+    workspace:
+      clean: outputs
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        retryCountOnTaskFailure: 5
+      - bash: |
+          ./contrib/test_efa.sh build_efa
+        displayName: Build rdma-core and ibmock
+      - bash: |
+          ./contrib/test_efa.sh gtest_efa
+        displayName: Run gtests
+      - bash: |
+          ./contrib/test_efa.sh install_rdma_core_efa
+        displayName: Setup rmda-core
+      - bash: |
+          ./contrib/test_efa.sh test_rpm_efa
+        displayName: RPM test

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -33,6 +33,9 @@ resources:
     - container: rhel90
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel9.0/builder:mofed-5.6-0.5.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: rhel90_ib
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel9.0/builder:mofed-5.6-0.5.0.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_IB)
     - container: ubuntu2004
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu20.04/builder:mofed-5.0-1.0.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
@@ -342,6 +345,14 @@ stages:
         demands: ucx_bf -equals yes
         run_tests: yes
         test_perf: 0
+
+  - stage: EFA_Tests
+    dependsOn: [Static_check]
+    jobs:
+    - template: efa.yml
+      parameters:
+        name: EFA
+        demands: ucx_new -equals yes
 
   - stage: Namespace_Tests
     dependsOn: [Static_check]

--- a/contrib/ibmock/Makefile
+++ b/contrib/ibmock/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+CC ?= gcc
+CFLAGS = -ggdb3 -fPIC -Wall -Wextra -Werror
+
+INCLUDES ?=
+BUILD ?= ./build
+
+MAJOR = 1
+MINOR = 1
+VERSION = $(MAJOR).$(MINOR)
+
+OBJS_IBVERBS = $(addprefix $(BUILD)/, verbs.o config.o stubs.o)
+OBJS_EFA = $(addprefix $(BUILD)/, efa.o config.o)
+
+.PHONY: all clean make_dir
+
+all: make_dir $(BUILD)/libibverbs.so.1 $(BUILD)/libefa.so.1
+
+make_dir: $(BUILD)/
+$(BUILD)/:
+	mkdir -p $(BUILD)
+
+$(OBJS_EFA) $(OBJS_IBVERBS): *.h
+
+$(BUILD)/libibverbs.so: $(OBJS_IBVERBS)
+$(BUILD)/libefa.so: $(OBJS_EFA)
+$(BUILD)/%.so.$(MAJOR): $(BUILD)/%.so
+
+$(BUILD)/%.o: %.c
+	$(CC) -c $(INCLUDES) $(CFLAGS) -o $@ $<
+
+$(BUILD)/%.so:
+	$(CC) -shared -o $@ -Wl,--soname='$@.$(VERSION)' $^
+
+$(BUILD)/%.so.$(MAJOR): $(BUILD)/%.so
+	ln -sf $(shell basename $<) $@
+
+clean:
+	rm -f $(addprefix $(BUILD)/, *.o *.so.* *.so)

--- a/contrib/ibmock/README.md
+++ b/contrib/ibmock/README.md
@@ -1,0 +1,33 @@
+## What
+IB devices mock implementation. Only EFA devices from same process are supported for now, UD and SRD.
+
+## How
+
+### Build
+rdma-core (optional)
+```
+cd rdma-core
+./build.sh
+```
+
+UCX
+```
+cd ucx
+./autogen.sh
+./contrib/configure-devel --with-verbs=$(pwd)/../rdma-core/build --with-efa
+make -j && make install
+```
+
+IB mock
+```
+cd ibmock
+make INCLUDES=-I$(pwd)/../rdma-core/build/include
+```
+
+### Run
+```
+export LD_LIBRARY_PATH=$(pwd)/../efa_mock/build:$LD_LIBRARY_PATH
+UCX_TLS=srd ucx_perftest -t tag_bw -l
+UCX_TLS=ud ucx_perftest -t tag_bw -l
+ucx_info -d
+```

--- a/contrib/ibmock/config.c
+++ b/contrib/ibmock/config.c
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+
+struct efadv_device_attr efa_dev_attr = {
+    .comp_mask       = 0,
+    .max_sq_wr       = 4096,
+    .max_rq_wr       = 32768,
+    .max_sq_sge      = 2,
+    .max_rq_sge      = 3,
+    .inline_buf_size = 32,
+    .device_caps     = 15,
+    .max_rdma_size   = 1073741824
+};
+
+struct ibv_device_attr efa_ibv_dev_attr = {
+    .fw_ver                    = "0.0.0.0",
+    .node_guid                 = 0,
+    .sys_image_guid            = 0,
+    .max_mr_size               = 103079215104,
+    .page_size_cap             = 4294963200,
+    .vendor_id                 = 7439,
+    .vendor_part_id            = 61345,
+    .hw_ver                    = 61345,
+    .max_qp                    = 256,
+    .max_qp_wr                 = 4096,
+    .device_cap_flags          = 0,
+    .max_sge                   = 2,
+    .max_sge_rd                = 1,
+    .max_cq                    = 512,
+    .max_cqe                   = 32768,
+    .max_mr                    = 262144,
+    .max_pd                    = 256,
+    .max_qp_rd_atom            = 0,
+    .max_ee_rd_atom            = 0,
+    .max_res_rd_atom           = 0,
+    .max_qp_init_rd_atom       = 0,
+    .max_ee_init_rd_atom       = 0,
+    .atomic_cap                = IBV_ATOMIC_NONE,
+    .max_ee                    = 0,
+    .max_rdd                   = 0,
+    .max_mw                    = 0,
+    .max_raw_ipv6_qp           = 0,
+    .max_raw_ethy_qp           = 0,
+    .max_mcast_grp             = 0,
+    .max_mcast_qp_attach       = 0,
+    .max_total_mcast_qp_attach = 0,
+    .max_ah                    = 1024,
+    .max_fmr                   = 0,
+    .max_map_per_fmr           = 0,
+    .max_srq                   = 0,
+    .max_srq_wr                = 0,
+    .max_srq_sge               = 0,
+    .max_pkeys                 = 1,
+    .local_ca_ack_delay        = 0,
+    .phys_port_cnt             = 1
+};
+
+struct ibv_port_attr efa_ib_port_attr = {
+    .state           = IBV_PORT_ACTIVE,
+    .max_mtu         = IBV_MTU_4096,
+    .active_mtu      = IBV_MTU_4096,
+    .gid_tbl_len     = 1,
+    .port_cap_flags  = 0,
+    .max_msg_sz      = 8928,
+    .bad_pkey_cntr   = 0,
+    .qkey_viol_cntr  = 0,
+    .pkey_tbl_len    = 1,
+    .lid             = 0,
+    .sm_lid          = 0,
+    .lmc             = 1,
+    .max_vl_num      = 1,
+    .sm_sl           = 0,
+    .subnet_timeout  = 0,
+    .init_type_reply = 0,
+    .active_width    = 2,
+    .active_speed    = 32,
+    .phys_state      = 5,
+    .link_layer      = 0,
+    .flags           = 0,
+    .port_cap_flags2 = 0,
+    /* .active_speed_ex = 0 */
+};
+
+struct ibv_qp_attr efa_ib_qp_attr = {
+    .cap = {
+        .max_send_wr     = 256,
+        .max_recv_wr     = 4096,
+        .max_send_sge    = 2,
+        .max_recv_sge    = 1,
+        .max_inline_data = 32
+    }
+};
+
+struct ibv_qp_init_attr efa_ib_qp_init_attr = {
+    .srq        = 0x0,
+    .cap        = {
+        .max_send_wr     = 256,
+        .max_recv_wr     = 4096,
+        .max_send_sge    = 2,
+        .max_recv_sge    = 1,
+        .max_inline_data = 32
+    },
+    .sq_sig_all = 1
+};

--- a/contrib/ibmock/config.h
+++ b/contrib/ibmock/config.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef __CONFIG_H
+#define __CONFIG_H
+
+#include <infiniband/efadv.h>
+#include <infiniband/verbs.h>
+
+
+extern struct efadv_device_attr efa_dev_attr;
+extern struct ibv_device_attr efa_ibv_dev_attr;
+extern struct ibv_port_attr efa_ib_port_attr;
+extern struct ibv_qp_attr efa_ib_qp_attr;
+extern struct ibv_qp_init_attr efa_ib_qp_init_attr;
+
+#endif

--- a/contrib/ibmock/efa.c
+++ b/contrib/ibmock/efa.c
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <infiniband/efadv.h>
+#include <infiniband/verbs.h>
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "fake.h"
+#include "verbs.h"
+#include "config.h"
+
+int efadv_query_device(struct ibv_context *context,
+                       struct efadv_device_attr *attr, uint32_t inlen)
+{
+    if ((context == NULL) || (inlen != sizeof(efa_dev_attr))) {
+        return EINVAL;
+    }
+
+    if ((context->device->node_type != IBV_NODE_UNSPECIFIED) ||
+        (context->device->transport_type != IBV_TRANSPORT_UNSPECIFIED)) {
+        return ENOTSUP;
+    }
+
+    memcpy(attr, &efa_dev_attr, sizeof(efa_dev_attr));
+    return 0;
+}
+
+struct ibv_qp *efadv_create_driver_qp_impl(struct ibv_pd           *pd,
+                                           struct ibv_qp_init_attr *attr,
+                                           uint32_t driver_qp_type)
+{
+    struct fake_qp *fqp;
+    struct ibv_qp *qp;
+
+
+    fqp = calloc(1, sizeof(*fqp));
+    if (fqp == NULL) {
+        return NULL;
+    }
+
+    fqp->fpd = (struct fake_pd*)pd;
+
+    fqp->qp_ex.wr_start        = dev_qp_wr_start;
+    fqp->qp_ex.wr_rdma_read    = dev_qp_wr_rdma_read;
+    fqp->qp_ex.wr_set_sge_list = dev_qp_wr_set_sge_list;
+    fqp->qp_ex.wr_set_ud_addr  = dev_qp_wr_set_ud_addr;
+    fqp->qp_ex.wr_complete     = dev_qp_wr_complete;
+
+    list_init(&fqp->recv_reqs);
+
+    qp             = &fqp->qp_ex.qp_base;
+    qp->qp_context = pd->context;
+    qp->context    = pd->context;
+    qp->qp_type    = driver_qp_type;
+    qp->send_cq    = attr->send_cq;
+    qp->recv_cq    = attr->recv_cq;
+    qp->pd         = pd;
+    qp->state      = IBV_QPS_RESET;
+
+    lock();
+    qp->qp_num = ++fake_qpn;
+    array_append(&fake_qps, &fqp, sizeof(fqp));
+    unlock();
+    return qp;
+}
+
+struct ibv_qp *efadv_create_driver_qp(struct ibv_pd           *pd,
+                                      struct ibv_qp_init_attr *attr,
+                                      uint32_t                driver_qp_type)
+{
+    if ((attr->qp_type != IBV_QPT_DRIVER) ||
+        (driver_qp_type != EFADV_QP_DRIVER_TYPE_SRD)) {
+        return NULL;
+    }
+
+    return efadv_create_driver_qp_impl(pd, attr, driver_qp_type);
+}
+
+struct ibv_qp *efadv_create_qp_ex(struct ibv_context         *context,
+                                  struct ibv_qp_init_attr_ex *attr_ex,
+                                  struct efadv_qp_init_attr  *efa_attr,
+                                  uint32_t                   inlen)
+{
+    struct ibv_qp_init_attr attr = {
+        .qp_type = efa_attr->driver_qp_type,
+        .send_cq = attr_ex->send_cq,
+        .recv_cq = attr_ex->recv_cq
+    };
+    (void)context;
+
+    if (inlen != sizeof(*efa_attr)) {
+        return NULL;
+    }
+
+    return efadv_create_driver_qp_impl(attr_ex->pd, &attr,
+                                       efa_attr->driver_qp_type);
+}

--- a/contrib/ibmock/fake.h
+++ b/contrib/ibmock/fake.h
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef __FAKE_H
+#define __FAKE_H
+
+#include <infiniband/verbs.h>
+
+#include <stdint.h>
+
+#include "lib.h"
+
+struct fake_device {
+    struct ibv_device dev;
+    int               id;
+};
+
+struct fake_ah {
+    struct ibv_ah      ah;
+    struct ibv_ah_attr attr;
+};
+
+struct fake_pd {
+    struct ibv_pd pd;
+    uint32_t      lkey;
+    array_t       mrs; /* memory registrations */
+    array_t       qps; /* queue pairs created */
+};
+
+struct fake_mr {
+    struct ibv_mr  mr;
+    struct fake_pd *fpd;
+};
+
+struct fake_qp {
+    struct ibv_qp_ex   qp_ex;
+    struct fake_pd     *fpd;
+
+    /* Write in preparation */
+    struct ibv_send_wr sr;
+    struct ibv_ah      *ah;
+    uint32_t           remote_qpn;
+
+    /* Posted receives */
+    struct list        recv_reqs;
+};
+
+struct fake_cq {
+    struct ibv_cq cq;
+    struct list   wcs;
+};
+
+struct fake_cqe {
+    struct list    list;
+    struct ibv_wc  wc;
+    struct fake_cq *fcq; /* owner CQ */
+    void (*free)(void*);
+};
+
+/* Header for serialized payloads */
+struct fake_hdr {
+    union ibv_gid gid;
+    unsigned      opcode;
+    unsigned      src_qp;
+    unsigned      qpn;
+    struct {
+        union ibv_gid src_gid;
+        uint32_t      rkey;
+        uint64_t      addr;
+        int           count;
+        size_t        len;
+    } rdma;
+};
+
+struct fake_recv_wr {
+    struct list        list;
+    struct ibv_recv_wr wr;
+    struct fake_cqe    fcqe;
+    struct ibv_sge     sge[];
+};
+
+extern int fake_qpn;
+extern array_t fake_qps;
+
+#endif /* __FAKE_H */

--- a/contrib/ibmock/lib.h
+++ b/contrib/ibmock/lib.h
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef __LIB_H
+#define __LIB_H
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <sys/uio.h>
+
+
+typedef struct {
+    void   *data;
+    size_t elem_size;
+    size_t count;
+    size_t total;
+} array_t;
+
+void lock(void);
+void unlock(void);
+
+#define min(_a, _b) ((_a) < (_b) ? (_a) : (_b))
+
+#define container_of(_ptr, _type, _member) \
+    ((_type*)((char*)(_ptr) - (char*)&((_type*)0)->_member))
+
+static inline void array_init(array_t *a, size_t elem_size)
+{
+    memset(a, 0, sizeof(*a));
+    a->elem_size = elem_size;
+}
+
+static inline void array_cleanup(array_t *a)
+{
+    if (a->data) {
+        free(a->data);
+    }
+
+    if (a->count) {
+        fprintf(stderr, "ibmock: non-empty array (count=%zu)\n", a->count);
+    }
+}
+
+static inline void *array_append(array_t *a, const void *data, size_t len)
+{
+    void *tmp, *ptr;
+    size_t total;
+
+    assert(len == a->elem_size);
+
+    if (a->count >= a->total) {
+        total = (a->total * 2)? : 8;
+        tmp   = realloc(a->data, total * a->elem_size);
+        if (tmp == NULL) {
+            fprintf(stderr, "ibmock: OOM\n");
+            exit(1);
+        }
+
+        a->data  = tmp;
+        a->total = total;
+    }
+
+    ptr = a->data + (a->count * a->elem_size);
+    memcpy(ptr, data, len);
+    a->count++;
+    return ptr;
+}
+
+static inline void *array_end(const array_t *a)
+{
+    return a->data + a->elem_size * a->count;
+}
+
+static inline void array_remove(array_t *a, void *data)
+{
+    assert(data >= a->data &&
+           data + a->elem_size <= array_end(a));
+    a->count--;
+
+    if (data < array_end(a)) {
+        memmove(data, data + a->elem_size, array_end(a) - data);
+    }
+}
+
+#define array_foreach(_entry, _arr) \
+    for (_entry = (_arr)->data; \
+         (void*)(_entry + 1) <= \
+         (_arr)->data + (_arr)->elem_size * (_arr)->count; \
+         _entry++)
+
+
+struct list {
+    struct list *next, *prev;
+};
+
+static inline void list_init(struct list *head)
+{
+    head->next = head->prev = head;
+}
+
+static inline void list_add_tail(struct list *head, struct list *entry)
+{
+    head->prev->next = entry;
+    entry->prev      = head->prev;
+    entry->next      = head;
+    head->prev       = entry;
+}
+
+static inline void list_del(struct list *entry)
+{
+    entry->next->prev = entry->prev;
+    entry->prev->next = entry->next;
+    entry->next = entry->prev = entry;
+}
+
+static inline int list_is_empty(struct list *head)
+{
+    return head->next == head;
+}
+
+static inline void *list_first(struct list *head)
+{
+    return head->next;
+}
+
+#endif /* __LIB_H */

--- a/contrib/ibmock/stubs.c
+++ b/contrib/ibmock/stubs.c
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "verbs.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+int ibv_cmd_destroy_srq(struct ibv_srq *srq)
+{
+    (void)srq;
+    return ENOTSUP;
+}
+
+int ibv_cmd_destroy_wq(struct ibv_wq *wq)
+{
+    (void)wq;
+    return ENOTSUP;
+}
+
+int ibv_cmd_destroy_cq(struct ibv_cq *cq)
+{
+    (void)cq;
+    return ENOTSUP;
+}
+
+struct ibv_open_xrcd_resp;
+struct ibv_open_xrcd;
+struct verbs_xrcd;
+
+int ibv_cmd_open_xrcd(struct ibv_context *context, struct verbs_xrcd *xrcd,
+                      int vxrcd_size, struct ibv_xrcd_init_attr *attr,
+                      struct ibv_open_xrcd *cmd, size_t cmd_size,
+                      struct ibv_open_xrcd_resp *resp, size_t resp_size)
+{
+    (void)context;
+    (void)xrcd;
+    (void)vxrcd_size;
+    (void)attr;
+    (void)cmd;
+    (void)cmd_size;
+    (void)resp;
+    (void)resp_size;
+    return ENOTSUP;
+}
+
+int ibv_cmd_close_xrcd(struct verbs_xrcd *xrcd)
+{
+    (void)xrcd;
+    return ENOTSUP;
+}
+
+int ibv_cmd_attach_mcast(struct ibv_qp *qp, const union ibv_gid *gid,
+                         uint16_t lid)
+{
+    (void)qp;
+    (void)gid;
+    (void)lid;
+    return ENOTSUP;
+}
+
+int ibv_cmd_detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid,
+                         uint16_t lid)
+{
+    (void)qp;
+    (void)gid;
+    (void)lid;
+    return ENOTSUP;
+}
+
+struct ibv_create_qp_resp_ex;
+struct ibv_create_qp_ex;
+struct verbs_qp *qp;
+
+int ibv_cmd_create_qp_ex2(struct ibv_context *context, struct verbs_qp *qp,
+                          int vqp_sz, struct ibv_qp_init_attr_ex *qp_attr,
+                          struct ibv_create_qp_ex *cmd, size_t cmd_core_size,
+                          size_t cmd_size, struct ibv_create_qp_resp_ex *resp,
+                          size_t resp_core_size, size_t resp_size)
+{
+    (void)context;
+    (void)qp;
+    (void)vqp_sz;
+    (void)qp_attr;
+    (void)cmd;
+    (void)cmd_core_size;
+    (void)cmd_size;
+    (void)resp;
+    (void)resp_core_size;
+    (void)resp_size;
+
+    return ENOTSUP;
+}
+
+struct verbs_mr;
+
+int ibv_cmd_query_mr(struct ibv_pd *pd, struct verbs_mr *vmr,
+                     uint32_t mr_handle)
+{
+    (void)pd;
+    (void)vmr;
+    (void)mr_handle;
+
+    return ENOTSUP;
+}
+
+int ibv_cmd_create_flow(struct ibv_qp *qp, struct ibv_flow *flow_id,
+                        struct ibv_flow_attr *flow_attr, void *ucmd,
+                        size_t ucmd_size)
+{
+    (void)qp;
+    (void)flow_id;
+    (void)flow_attr;
+    (void)ucmd;
+    (void)ucmd_size;
+
+    return ENOTSUP;
+}
+
+struct verbs_cq;
+struct ibv_create_cq_ex;
+
+int ibv_cmd_create_cq_ex(struct ibv_context *context,
+                         const struct ibv_cq_init_attr_ex *cq_attr,
+                         struct verbs_cq *cq, struct ibv_create_cq_ex *cmd,
+                         size_t cmd_size,
+                         struct ib_uverbs_ex_create_cq_resp *resp,
+                         size_t resp_size, uint32_t cmd_flags)
+{
+    (void)context;
+    (void)cq_attr;
+    (void)cq;
+    (void)cmd;
+    (void)cmd_size;
+    (void)resp;
+    (void)resp_size;
+    (void)cmd_flags;
+
+    return ENOTSUP;
+}
+
+int ibv_cmd_dealloc_mw(struct ibv_mw *mw)
+{
+    (void)mw;
+
+    return ENOTSUP;
+}
+
+int ibv_cmd_dealloc_pd(struct ibv_pd *pd)
+{
+    (void)pd;
+
+    return ENOTSUP;
+}
+
+struct ibv_command_buffer;
+
+struct ibv_mr *ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+                                 size_t length, uint64_t iova, int fd,
+                                 int access)
+{
+    (void)pd;
+    (void)offset;
+    (void)length;
+    (void)iova;
+    (void)fd;
+    (void)access;
+    return NULL; /* not supported */
+}
+
+int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
+                          uint64_t iova, int fd, int access,
+                          struct verbs_mr *vmr,
+                          struct ibv_command_buffer *driver)
+{
+    (void)pd;
+    (void)offset;
+    (void)length;
+    (void)iova;
+    (void)fd;
+    (void)access;
+    (void)vmr;
+    (void)driver;
+
+    return ENOTSUP;
+}
+
+struct ibv_query_port;
+
+int ibv_cmd_query_port(struct ibv_context *context, uint8_t port_num,
+                       struct ibv_port_attr *port_attr,
+                       struct ibv_query_port *cmd, size_t cmd_size)
+{
+    (void)context;
+    (void)port_num;
+    (void)port_attr;
+    (void)cmd;
+    (void)cmd_size;
+
+    return ENOTSUP;
+}
+
+struct ibv_modify_qp;
+
+int ibv_cmd_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+                      int attr_mask, struct ibv_modify_qp *cmd, size_t cmd_size)
+{
+    (void)qp;
+    (void)attr;
+    (void)attr_mask;
+    (void)cmd;
+    (void)cmd_size;
+
+    return ENOTSUP;
+}
+
+struct ibv_srq *ibv_create_srq(struct ibv_pd *pd,
+                               struct ibv_srq_init_attr *srq_init_attr)
+{
+    (void)pd;
+    (void)srq_init_attr;
+    return NULL;
+}

--- a/contrib/ibmock/verbs.c
+++ b/contrib/ibmock/verbs.c
@@ -1,0 +1,1074 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "config.h"
+#include "verbs.h"
+#include "lib.h"
+#include "fake.h"
+
+#include <sys/uio.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#define NUM_DEVS   2
+#define SYS_PATH   "/tmp/ibmock"
+#define DUMMY_PKEY 65535 /* Dummy pkey with full membership for now */
+
+static pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void lock(void)
+{
+    pthread_mutex_lock(&global_lock);
+}
+
+void unlock(void)
+{
+    pthread_mutex_unlock(&global_lock);
+}
+
+bool verbs_allow_disassociate_destroy = 0;
+
+enum be_mode {
+    BE_NOTSET,
+    BE_LOOPBACK
+};
+
+static enum be_mode be_mode_get(void)
+{
+    return BE_LOOPBACK;
+}
+
+struct ibv_device **ibv_get_device_list(int *num_devices)
+{
+    struct fake_device *fake;
+    struct ibv_device **devs;
+    int i;
+
+    *num_devices = NUM_DEVS;
+    devs         = calloc(*num_devices + 1, sizeof(*devs));
+    if (devs == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < *num_devices; i++) {
+        fake = calloc(1, sizeof(*fake));
+        if (fake == NULL) {
+            goto failure;
+        }
+
+        fake->id = i;
+
+        devs[i]                 = &fake->dev;
+        devs[i]->node_type      = IBV_NODE_UNSPECIFIED;
+        devs[i]->transport_type = IBV_TRANSPORT_UNSPECIFIED;
+
+        sprintf(devs[i]->name, "rdmap%d", i);
+        sprintf(devs[i]->dev_name, "uverbs%d", i);
+        sprintf(devs[i]->dev_path, "%s/sys/class/infiniband/rdmap%d",
+                SYS_PATH, i);
+        sprintf(devs[i]->ibdev_path, "%s/sys/class/infiniband/uverbs%d",
+                SYS_PATH, i);
+    }
+
+    devs[i] = NULL;
+    return devs;
+
+failure:
+    while (i-- > 0) {
+        free(devs[i]);
+    }
+
+    free(devs);
+    return NULL;
+}
+
+void ibv_free_device_list(struct ibv_device **list)
+{
+    int i;
+
+    for (i = 0; i < NUM_DEVS; i++) {
+        free(list[i]);
+    }
+
+    free(list);
+}
+
+const char *ibv_get_sysfs_path(void)
+{
+    return SYS_PATH;
+}
+
+const char *ibv_get_device_name(struct ibv_device *device)
+{
+    return device->name;
+}
+
+int ibv_fork_init(void)
+{
+    return 0;
+}
+
+static int vctx_query_port(struct ibv_context *context, uint8_t port_num,
+                           struct ibv_port_attr *port_attr,
+                           size_t port_attr_len)
+{
+    (void)context;
+
+    if ((port_num != 1) || (port_attr_len != sizeof(*port_attr))) {
+        return EINVAL;
+    }
+
+    memcpy(port_attr, &efa_ib_port_attr, sizeof(*port_attr));
+    return 0;
+}
+
+#undef ibv_query_port
+int ibv_query_port(struct ibv_context *context, uint8_t port_num,
+                   struct _compat_ibv_port_attr *port_attr)
+{
+    return vctx_query_port(context, port_num, (struct ibv_port_attr*)port_attr,
+                           sizeof(struct ibv_port_attr));
+}
+
+struct fake_recv_wr *fake_recv_wr_create(struct ibv_recv_wr *wr)
+{
+    (void)wr;
+    return NULL;
+}
+
+static int dev_post_recv(struct ibv_qp *qp, struct ibv_recv_wr *wr,
+                         struct ibv_recv_wr **bad_wr)
+{
+    struct fake_qp *fqp = (struct fake_qp*)qp;
+    struct fake_recv_wr *recv_wr;
+
+    lock();
+    for (; wr; wr = wr->next) {
+        recv_wr = calloc(1, sizeof(*recv_wr) +
+                         ( wr->num_sge * sizeof(*recv_wr->sge)));
+        if (recv_wr == NULL) {
+            if (bad_wr) {
+                *bad_wr = wr;
+            }
+            unlock();
+            return -1;
+        }
+
+        memcpy(&recv_wr->wr, wr, sizeof(*wr));
+        memcpy(recv_wr->sge, wr->sg_list, sizeof(*recv_wr->sge) * wr->num_sge);
+        list_add_tail(&fqp->recv_reqs, &recv_wr->list);
+    }
+
+    unlock();
+    return 0;
+}
+
+#define MAX_SGE  64
+#define GRH_SIZE 40
+
+static void fake_recv_wr_free(void *ptr)
+{
+    struct fake_recv_wr *recv = container_of(ptr, struct fake_recv_wr, fcqe);
+    free(recv);
+}
+
+static enum ibv_wc_opcode dev_wc_opcode(enum ibv_wr_opcode opcode)
+{
+    if (opcode == IBV_WR_SEND) {
+        return IBV_WC_SEND;
+    } else if (opcode == IBV_WR_RDMA_READ) {
+        return IBV_WC_RDMA_READ;
+    }
+
+    return IBV_WC_RDMA_READ;
+}
+
+static int
+rx_send(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
+{
+    struct fake_recv_wr *recv;
+    struct fake_cq *fcq;
+    struct ibv_sge *sge;
+    struct ibv_recv_wr *wr;
+    int i, j, src_len, dst_len, len;
+    size_t src_off, dst_off, total = 0;
+
+    if (list_is_empty(&fqp->recv_reqs)) {
+        return 1;
+    }
+
+    src_off = sizeof(*hdr);
+    dst_off = 0;
+
+    recv = list_first(&fqp->recv_reqs);
+    list_del(&recv->list);
+
+    wr  = &recv->wr;
+    sge = recv->sge;
+
+    for (i = 0, j = 0; i < count; i++, src_off = 0) {
+        while (src_off < iov[i].iov_len) {
+            src_len = iov[i].iov_len - src_off;
+            dst_len = sge[j].length - dst_off;
+            if (!dst_len) {
+                j++;
+                dst_off = 0;
+                if (j >= wr->num_sge) {
+                    fprintf(stderr, "ibmock: error: posted RX too short\n");
+                    return -1;
+                }
+            }
+
+            len = min(src_len, dst_len);
+            memcpy((void*)sge[j].addr + dst_off, iov[i].iov_base + src_off,
+                   len);
+            src_off += len;
+            dst_off += len;
+            total   += len;
+        }
+    }
+
+    recv->fcqe.wc.status   = IBV_WC_SUCCESS;
+    recv->fcqe.wc.wr_id    = wr->wr_id;
+    recv->fcqe.wc.src_qp   = hdr->src_qp;
+    recv->fcqe.wc.qp_num   = fqp->qp_ex.qp_base.qp_num;
+    recv->fcqe.wc.byte_len = total;
+    recv->fcqe.free        = fake_recv_wr_free;
+
+    fcq = (struct fake_cq*)fqp->qp_ex.qp_base.recv_cq;
+    list_add_tail(&fcq->wcs, &recv->fcqe.list);
+    return 1;
+}
+
+static int
+rx_rdma(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
+{
+    int found = 0;
+    struct fake_mr **mr;
+    struct {
+        void     *addr;
+        uint32_t len;
+    } __attribute__((packed)) dest[hdr->rdma.count];
+    int i;
+    size_t src_off, dst_off, total, len;
+
+    array_foreach(mr, &fqp->fpd->mrs) {
+        if ((*mr)->mr.lkey == hdr->rdma.rkey) {
+            /* TODO check addr ranges, deduplicate mr key lookup */
+            found = 1;
+        }
+    }
+
+    if (!found) {
+        fprintf(stderr, "ibmock: rx rdma rkey not found PD of QP#%d\n",
+               fqp->qp_ex.qp_base.qp_num);
+        return 0;
+    }
+
+    i       = 0;
+    src_off = sizeof(*hdr);
+    dst_off = 0;
+    for (dst_off = 0; dst_off < sizeof(dest);) {
+        while (i < count && src_off >= iov[i].iov_len) {
+            src_off = 0;
+            i++;
+        }
+
+        if (i >= count) {
+            fprintf(stderr, "ibmock: IO error\n");
+            return 0;
+        }
+
+        len = min(sizeof(dest) - dst_off, iov[i].iov_len - src_off);
+        memcpy((void*)dest + dst_off, iov[i].iov_base + src_off, len);
+        dst_off += len;
+        src_off += len;
+    }
+
+    total = 0;
+    for (i = 0; i < hdr->rdma.count; i++) {
+        memcpy(dest[i].addr, (void*)hdr->rdma.addr + total, dest[i].len);
+        total += dest[i].len;
+    }
+
+    assert(total == hdr->rdma.len);
+    return 1;
+}
+
+static int dev_rx_cb(struct iovec *iov, int count)
+{
+    struct fake_hdr *hdr = iov[0].iov_base;
+    uint8_t *gid         = hdr->gid.raw;
+    struct fake_qp *fqp  = NULL;
+    struct fake_qp **entry;
+    int ret;
+
+    if (gid[13] != be_mode_get()) {
+        return 0; /* not ours */
+    }
+
+    /* Lookup QP */
+    array_foreach(entry, &fake_qps) {
+        if ((*entry)->qp_ex.qp_base.qp_num == hdr->qpn) {
+            fqp = *entry;
+            break;
+        }
+    }
+
+    if (fqp == NULL) {
+        return 1;
+    }
+
+    if (hdr->opcode == IBV_WR_SEND) {
+        ret = rx_send(fqp, hdr, iov, count);
+    } else if (hdr->opcode == IBV_WR_RDMA_READ) {
+        ret = rx_rdma(fqp, hdr, iov, count);
+    }
+
+    return ret;
+}
+
+static void dev_send_comp(void *arg, int ret)
+{
+    struct fake_cqe *fcqe = arg;
+
+    if (ret < 0) {
+        fcqe->wc.status = IBV_WC_GENERAL_ERR;
+    }
+
+    list_add_tail(&fcqe->fcq->wcs, &fcqe->list);
+}
+
+static int dev_wr_send_serialize(struct ibv_qp *qp, struct ibv_send_wr *wr,
+                                 struct ibv_ah *ah, uint32_t remote_qpn)
+{
+    union {
+        struct fake_hdr hdr;
+        char            _padding[sizeof(struct fake_hdr) + GRH_SIZE];
+    } u;
+    struct fake_hdr *hdr = &u.hdr;
+    size_t total         = 0;
+    struct iovec iov[2 * MAX_SGE + 1];
+    struct fake_ah *fah;
+    struct fake_cqe *fcqe;
+    struct ibv_wc *wc;
+    int i, ret, count;
+
+    if ((wr->opcode != IBV_WR_SEND) && (wr->opcode != IBV_WR_RDMA_READ)) {
+        return -1;
+    }
+
+    fah = (struct fake_ah*)ah;
+
+    memcpy(&hdr->gid, &fah->attr.grh.dgid, sizeof(hdr->gid));
+    hdr->opcode = wr->opcode;
+    hdr->src_qp = qp->qp_num;
+    hdr->qpn    = remote_qpn;
+
+    iov[0].iov_base = hdr;
+    iov[0].iov_len  = sizeof(*hdr);
+
+    if (qp->qp_type == IBV_QPT_UD) {
+        iov[0].iov_len += GRH_SIZE;
+    }
+
+    for (i = 0; i < wr->num_sge; i++) {
+        if (wr->opcode == IBV_WR_SEND) {
+            iov[1 + i].iov_base = (void*)wr->sg_list[i].addr;
+            iov[1 + i].iov_len  = wr->sg_list[i].length;
+
+            total += iov[1 + i].iov_len;
+        } else if (wr->opcode == IBV_WR_RDMA_READ) {
+            iov[1 + (2 * i)].iov_base = &wr->sg_list[i].addr;
+            iov[1 + (2 * i)].iov_len  = sizeof(wr->sg_list[i].addr);
+            iov[2 + (2 * i)].iov_base = &wr->sg_list[i].length;
+            iov[2 + (2 * i)].iov_len  = sizeof(wr->sg_list[i].length);
+
+            total += wr->sg_list[i].length;
+        }
+    }
+
+    count = wr->num_sge + 1;
+    if (wr->opcode == IBV_WR_RDMA_READ) {
+        hdr->rdma.rkey  = wr->wr.rdma.rkey;
+        hdr->rdma.addr  = wr->wr.rdma.remote_addr;
+        hdr->rdma.len   = total;
+        hdr->rdma.count = wr->num_sge;
+
+        count += wr->num_sge;
+    }
+
+    /* Pre-generate completion queue entry */
+    fcqe = malloc(sizeof(*fcqe));
+    if (fcqe == NULL) {
+        return -1;
+    }
+
+    fcqe->fcq  = (struct fake_cq*)qp->send_cq;
+    fcqe->free = free;
+
+    wc           = &fcqe->wc;
+    wc->status   = IBV_WC_SUCCESS;
+    wc->wr_id    = wr->wr_id;
+    wc->opcode   = dev_wc_opcode(wr->opcode);
+    wc->qp_num   = remote_qpn;
+    wc->src_qp   = qp->qp_num;
+    wc->byte_len = total;
+
+    /* TODO: Use actual backend for multi process/nodes */
+    ret = dev_rx_cb(iov, count);
+    if (ret == 0) {
+        free(fcqe);
+        return -1;
+    }
+
+    dev_send_comp(fcqe, ret);
+    return 0;
+}
+
+static int dev_post_send(struct ibv_qp *qp, struct ibv_send_wr *wr,
+                         struct ibv_send_wr **bad_wr)
+{
+    int found[MAX_SGE];
+    struct fake_qp *fqp = (struct fake_qp*)qp;
+    struct fake_mr **mr;
+    int i, ret, total;
+
+    lock();
+    for (; wr; wr = wr->next) {
+        if (wr->opcode != IBV_WR_SEND) {
+            *bad_wr = wr;
+            ret     = -EINVAL;
+            goto fail;
+        }
+
+        if (wr->num_sge > MAX_SGE) {
+            ret = -EINVAL;
+            goto fail;
+        }
+
+        if (!(wr->send_flags & IBV_SEND_INLINE)) {
+            total = 0;
+            memset(found, 0, sizeof(found));
+            array_foreach(mr, &fqp->fpd->mrs) {
+                for (i = 0; i < wr->num_sge; i++) {
+                    if ((*mr)->mr.lkey == wr->sg_list[i].lkey) {
+                        total   += !found[i];
+                        found[i] = 1;
+                    }
+                }
+
+                if (total == wr->num_sge) {
+                    break;
+                }
+            }
+
+            if (total != wr->num_sge) {
+                ret = -EINVAL;
+                goto fail;
+            }
+        }
+
+
+        if (dev_wr_send_serialize(qp, wr, wr->wr.ud.ah, wr->wr.ud.remote_qpn)) {
+            ret = -ENOMEM;
+            goto fail;
+        }
+    }
+
+    unlock();
+    return 0;
+
+fail:
+    unlock();
+    return ret;
+}
+
+static int dev_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc)
+{
+    struct fake_cq *fcq = (struct fake_cq*)cq;
+    struct fake_cqe *fcqe;
+    int i;
+
+    lock();
+    for (i = 0; i < num_entries; i++) {
+        if (list_is_empty(&fcq->wcs)) {
+            break;
+        }
+
+        fcqe = (struct fake_cqe*)list_first(&fcq->wcs);
+        list_del(&fcqe->list);
+        wc[i] = fcqe->wc;
+        fcqe->free(fcqe);
+    }
+
+    unlock();
+    return i;
+}
+
+struct ibv_context *ibv_open_device(struct ibv_device *device)
+{
+    struct verbs_context *vctx;
+    int fds[2];
+
+    vctx = calloc(1, sizeof(*vctx));
+    if (vctx == NULL) {
+        return NULL;
+    }
+
+    vctx->context.device = malloc(sizeof(struct fake_device));
+    if (vctx->context.device == NULL) {
+        free(vctx);
+        return NULL;
+    }
+    vctx->context.ops.post_send = dev_post_send;
+    vctx->context.ops.post_recv = dev_post_recv;
+    vctx->context.ops.poll_cq   = dev_poll_cq;
+
+    if (pipe(fds)) {
+        free(vctx);
+        return NULL;
+    }
+
+    vctx->context.cmd_fd           = fds[0];
+    vctx->context.async_fd         = fds[1];
+    vctx->context.num_comp_vectors = 8,
+
+    memcpy(vctx->context.device, device, sizeof(struct fake_device));
+    vctx->context.abi_compat = __VERBS_ABI_IS_EXTENDED;
+    vctx->query_port         = vctx_query_port;
+
+    return &vctx->context;
+}
+
+int ibv_close_device(struct ibv_context *context)
+{
+    close(context->async_fd);
+    close(context->cmd_fd);
+    free(context->device);
+    free(verbs_get_ctx(context));
+    return 0;
+}
+
+struct ibv_pd *ibv_alloc_pd(struct ibv_context *context)
+{
+    struct fake_pd *fpd = calloc(1, sizeof(*fpd));
+    struct ibv_pd *pd;
+
+    if (fpd == NULL) {
+        return NULL;
+    }
+
+    array_init(&fpd->mrs, sizeof(struct fake_mr*));
+    array_init(&fpd->qps, sizeof(struct fake_qp*));
+
+    pd          = &fpd->pd;
+    pd->context = context;
+    return pd;
+}
+
+int ibv_dealloc_pd(struct ibv_pd *pd)
+{
+    struct fake_pd *fpd = (struct fake_pd*)pd;
+
+    array_cleanup(&fpd->mrs);
+    array_cleanup(&fpd->qps);
+    free(fpd);
+    return 0;
+}
+
+struct ibv_cq *ibv_create_cq(struct ibv_context *context, int cqe,
+                             void *cq_context, struct ibv_comp_channel *channel,
+                             int comp_vector)
+{
+    struct fake_cq *fcq;
+    struct ibv_cq *cq;
+
+    (void)comp_vector;
+
+    fcq = calloc(1, sizeof(*fcq));
+    if (fcq == NULL) {
+        return NULL;
+    }
+
+    cq             = &fcq->cq;
+    cq->context    = context;
+    cq->channel    = channel;
+    cq->cqe        = cqe;
+    cq->cq_context = cq_context;
+
+    list_init(&fcq->wcs);
+    return cq;
+}
+
+int ibv_destroy_cq(struct ibv_cq *cq)
+{
+    struct fake_cq *fcq = (struct fake_cq*)cq;
+    struct fake_cqe *fcqe;
+
+    while (!list_is_empty(&fcq->wcs)) {
+        fcqe = (struct fake_cqe*)list_first(&fcq->wcs);
+        list_del(&fcqe->list);
+        fcqe->free(fcqe);
+    }
+
+    free(fcq);
+    return 0;
+}
+
+int fake_qpn = 0;
+array_t fake_qps;
+
+struct ibv_qp *ibv_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
+{
+    struct fake_qp *fqp;
+    struct ibv_qp *qp;
+
+    if ((attr->qp_type != IBV_QPT_DRIVER) && (attr->qp_type != IBV_QPT_UD)) {
+        return NULL; /* RC is not supported */
+    }
+
+    if ((attr->cap.max_inline_data > efa_dev_attr.inline_buf_size) ||
+        (attr->cap.max_send_sge > efa_dev_attr.max_sq_sge)) {
+        return NULL;
+    }
+
+    fqp = calloc(1, sizeof(*fqp));
+    if (fqp == NULL) {
+        return NULL;
+    }
+
+    lock();
+    fqp->fpd = (struct fake_pd*)pd;
+    list_init(&fqp->recv_reqs);
+
+    qp          = &fqp->qp_ex.qp_base;
+    qp->context = pd->context;
+    qp->qp_type = attr->qp_type;
+    qp->send_cq = attr->send_cq;
+    qp->recv_cq = attr->recv_cq;
+    qp->pd      = pd;
+    qp->srq     = attr->srq;
+    qp->state   = IBV_QPS_RESET;
+    qp->qp_num  = ++fake_qpn;
+
+    array_append(&fake_qps, &fqp, sizeof(fqp));
+    unlock();
+    return qp;
+}
+
+
+int ibv_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask)
+{
+    (void)attr_mask;
+
+    lock();
+
+    switch (attr->qp_state) {
+    case IBV_QPS_INIT:
+        if (qp->state != IBV_QPS_RESET) {
+            goto fail;
+        }
+        break;
+    case IBV_QPS_RTR:
+        if (qp->state != IBV_QPS_INIT) {
+            goto fail;
+        }
+
+        break;
+    case IBV_QPS_RTS:
+        if (qp->state != IBV_QPS_RTR) {
+            goto fail;
+        }
+
+        break;
+    default:
+        unlock();
+        return ENOTSUP;
+    }
+
+    qp->state = attr->qp_state;
+    unlock();
+    return 0;
+
+fail:
+    unlock();
+    return EINVAL;
+}
+
+int ibv_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask,
+                 struct ibv_qp_init_attr *init_attr)
+{
+    struct ibv_qp_init_attr qp_init_attr = efa_ib_qp_init_attr;
+    (void)attr_mask;
+
+    lock();
+    qp_init_attr.qp_context = qp->context;
+    qp_init_attr.send_cq    = qp->send_cq;
+    qp_init_attr.recv_cq    = qp->recv_cq;
+    qp_init_attr.qp_type    = qp->qp_type;
+
+    memcpy(attr, &efa_ib_qp_attr, sizeof(efa_ib_qp_attr));
+    memcpy(init_attr, &qp_init_attr, sizeof(qp_init_attr));
+    unlock();
+    return 0;
+}
+
+int ibv_destroy_qp(struct ibv_qp *qp)
+{
+    struct fake_qp **entry, *fqp = (struct fake_qp*)qp;
+    struct fake_recv_wr *fake_wr;
+
+    lock();
+    array_foreach(entry, &fake_qps) {
+        if (fqp == *entry) {
+            array_remove(&fake_qps, entry);
+
+            while (!list_is_empty(&fqp->recv_reqs)) {
+                fake_wr = list_first(&fqp->recv_reqs);
+                list_del(&fake_wr->list);
+                free(fake_wr);
+            }
+
+            free(fqp);
+            unlock();
+            return 0;
+        }
+    }
+
+    fprintf(stderr, "ibmock: failed to destroy QP#%d\n", qp->qp_num);
+    unlock();
+    return -1;
+}
+
+/* verbs.h header re/post defines ibv_reg_mr() */
+#undef ibv_reg_mr
+
+struct ibv_mr *ibv_reg_mr_iova2(struct ibv_pd *pd, void *addr, size_t length,
+                                uint64_t iova, unsigned int access)
+{
+    struct fake_pd *fpd = (struct fake_pd*)pd;
+    struct fake_mr *fmr;
+    struct ibv_mr *mr;
+    (void)iova;
+
+    fmr = calloc(1, sizeof(*fmr));
+    if (fmr == NULL) {
+        return NULL;
+    }
+
+    lock();
+    mr          = &fmr->mr;
+    mr->context = pd->context;
+    mr->pd      = pd;
+    mr->addr    = addr;
+    mr->length  = length;
+    mr->handle  = access;
+    mr->rkey    = mr->lkey = ++fpd->lkey;
+
+    fmr->fpd = fpd;
+    array_append(&fpd->mrs, &fmr, sizeof(fmr));
+    unlock();
+
+    return mr;
+}
+
+struct ibv_mr *
+ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length, int access)
+{
+    return ibv_reg_mr_iova2(pd, addr, length, (uint64_t)addr, access);
+}
+
+int ibv_dereg_mr(struct ibv_mr *mr)
+{
+    struct fake_mr **entry, *fmr = (struct fake_mr*)mr;
+
+    lock();
+    array_foreach(entry, &fmr->fpd->mrs) {
+        if (fmr == *entry) {
+            array_remove(&fmr->fpd->mrs, entry);
+            free(fmr);
+            unlock();
+            return 0;
+        }
+    }
+
+    free(fmr);
+    fprintf(stderr, "ibmock: failed to deregister MR lkey=%x\n", mr->lkey);
+    unlock();
+    return -1;
+}
+
+int ibv_query_pkey(struct ibv_context *context, uint8_t port_num, int index,
+                   uint16_t *pkey)
+{
+    (void)context;
+    (void)port_num;
+    (void)index;
+
+    if ((port_num != 1) || (index != 0)) {
+        return EINVAL;
+    }
+
+    *pkey = DUMMY_PKEY;
+    return 0;
+}
+
+int ibv_query_gid(struct ibv_context *context, uint8_t port_num, int index,
+                  union ibv_gid *gid)
+{
+    struct fake_device *fdevice = (struct fake_device*)context->device;
+    /* Construct an arbitrary GID based on default GID prefix */
+    uint8_t addr[16] = {0xfe,        0x80,          0x00,     0x00, 0x00, 0x00,
+                        0x00,        0x00,          0x04,     0x07, 0x64, 0xff,
+                        fdevice->id, be_mode_get(), port_num, index};
+
+    (void)context;
+    memcpy(gid->raw, addr, sizeof(gid->raw));
+    return 0;
+}
+
+int ibv_query_device(struct ibv_context *context,
+                     struct ibv_device_attr *device_attr)
+{
+    (void)context;
+    memcpy(device_attr, &efa_ibv_dev_attr, sizeof(*device_attr));
+    return 0;
+}
+
+__be64 ibv_get_device_guid(struct ibv_device *device)
+{
+    (void)device;
+    errno = ENOTSUP;
+    return 0;
+}
+
+int ibv_get_device_index(struct ibv_device *device)
+{
+    struct fake_device *fake = (struct fake_device*)device;
+
+    return fake->id;
+}
+
+struct ibv_ah *ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
+{
+    struct fake_ah *fah = calloc(1, sizeof(*fah));
+    static int ah_handle;
+
+    if (fah == NULL) {
+        return NULL;
+    }
+
+    lock();
+    fah->ah.context = pd->context;
+    fah->ah.pd      = pd;
+    fah->ah.handle  = ++ah_handle;
+    unlock();
+
+    memcpy(&fah->attr, attr, sizeof(*attr));
+    return &fah->ah;
+}
+
+int ibv_destroy_ah(struct ibv_ah *ah)
+{
+    free(ah);
+    return 0;
+}
+
+struct ibv_qp_ex *ibv_qp_to_qp_ex(struct ibv_qp *qp)
+{
+    return (struct ibv_qp_ex*)qp;
+}
+
+void dev_qp_wr_start(struct ibv_qp_ex *qp_ex)
+{
+    struct fake_qp *fqp = (struct fake_qp*)qp_ex;
+
+    memset(&fqp->sr, 0, sizeof(fqp->sr));
+}
+
+void dev_qp_wr_rdma_read(struct ibv_qp_ex *qp_ex, uint32_t rkey,
+                         uint64_t remote_addr)
+{
+    struct fake_qp *fqp = (struct fake_qp*)qp_ex;
+
+    fqp->sr.opcode              = IBV_WR_RDMA_READ;
+    fqp->sr.wr.rdma.rkey        = rkey;
+    fqp->sr.wr.rdma.remote_addr = remote_addr;
+}
+
+void dev_qp_wr_set_sge_list(struct ibv_qp_ex *qp_ex, size_t num_sge,
+                            const struct ibv_sge *sg_list)
+{
+    struct fake_qp *fqp = (struct fake_qp*)qp_ex;
+
+    fqp->sr.sg_list = (struct ibv_sge*)sg_list;
+    fqp->sr.num_sge = num_sge;
+}
+
+void dev_qp_wr_set_ud_addr(struct ibv_qp_ex *qp_ex, struct ibv_ah *ah,
+                           uint32_t remote_qpn, uint32_t remote_qkey)
+{
+    struct fake_qp *fqp = (struct fake_qp*)qp_ex;
+
+    (void)remote_qkey;
+
+    fqp->ah         = ah;
+    fqp->remote_qpn = remote_qpn;
+}
+
+int dev_qp_wr_complete(struct ibv_qp_ex *qp_ex)
+{
+    struct fake_qp *fqp = (struct fake_qp*)qp_ex;
+    int ret;
+
+    lock();
+    fqp->sr.wr_id = qp_ex->wr_id;
+
+    ret = dev_wr_send_serialize(&qp_ex->qp_base, &fqp->sr, fqp->ah,
+                                fqp->remote_qpn);
+    unlock();
+    return ret;
+}
+
+__attribute__((constructor)) void verbs_ctor(void)
+{
+    array_init(&fake_qps, sizeof(struct fake_qp*));
+}
+
+__attribute__((destructor)) void verbs_dtor(void)
+{
+    array_cleanup(&fake_qps);
+}
+
+/* rdma-core copy/paste */
+void ibv_copy_ah_attr_from_kern(struct ibv_ah_attr *dst,
+                                struct ib_uverbs_ah_attr *src)
+{
+    memcpy(dst->grh.dgid.raw, src->grh.dgid, sizeof dst->grh.dgid);
+    dst->grh.flow_label    = src->grh.flow_label;
+    dst->grh.sgid_index    = src->grh.sgid_index;
+    dst->grh.hop_limit     = src->grh.hop_limit;
+    dst->grh.traffic_class = src->grh.traffic_class;
+
+    dst->dlid          = src->dlid;
+    dst->sl            = src->sl;
+    dst->src_path_bits = src->src_path_bits;
+    dst->static_rate   = src->static_rate;
+    dst->is_global     = src->is_global;
+    dst->port_num      = src->port_num;
+}
+
+/* rdma-core copy/paste */
+const char *ibv_node_type_str(enum ibv_node_type node_type)
+{
+    static const char *const node_type_str[] = {
+        [IBV_NODE_CA]          = "InfiniBand channel adapter",
+        [IBV_NODE_SWITCH]      = "InfiniBand switch",
+        [IBV_NODE_ROUTER]      = "InfiniBand router",
+        [IBV_NODE_RNIC]        = "iWARP NIC",
+        [IBV_NODE_USNIC]       = "usNIC",
+        [IBV_NODE_USNIC_UDP]   = "usNIC UDP",
+        [IBV_NODE_UNSPECIFIED] = "unspecified",
+    };
+
+    if ((node_type < IBV_NODE_CA) || (node_type > IBV_NODE_UNSPECIFIED)) {
+        return "unknown";
+    }
+
+    return node_type_str[node_type];
+}
+
+/* rdma-core copy/paste */
+const char *ibv_port_state_str(enum ibv_port_state port_state)
+{
+    static const char *const port_state_str[] = {
+        [IBV_PORT_NOP]          = "no state change (NOP)",
+        [IBV_PORT_DOWN]         = "down",
+        [IBV_PORT_INIT]         = "init",
+        [IBV_PORT_ARMED]        = "armed",
+        [IBV_PORT_ACTIVE]       = "active",
+        [IBV_PORT_ACTIVE_DEFER] = "active defer"
+    };
+
+    if ((port_state < IBV_PORT_NOP) || (port_state > IBV_PORT_ACTIVE_DEFER)) {
+        return "unknown";
+    }
+
+    return port_state_str[port_state];
+}
+
+/* rdma-core copy/paste */
+const char *ibv_event_type_str(enum ibv_event_type event)
+{
+    static const char *const event_type_str[] = {
+        [IBV_EVENT_CQ_ERR]        = "CQ error",
+        [IBV_EVENT_QP_FATAL]      = "local work queue catastrophic error",
+        [IBV_EVENT_QP_REQ_ERR]    = "invalid request local work queue error",
+        [IBV_EVENT_QP_ACCESS_ERR] = "local access violation work queue error",
+        [IBV_EVENT_COMM_EST]      = "communication established",
+        [IBV_EVENT_SQ_DRAINED]    = "send queue drained",
+        [IBV_EVENT_PATH_MIG]      = "path migrated",
+        [IBV_EVENT_PATH_MIG_ERR]  = "path migration request error",
+        [IBV_EVENT_DEVICE_FATAL]  = "local catastrophic error",
+        [IBV_EVENT_PORT_ACTIVE]   = "port active",
+        [IBV_EVENT_PORT_ERR]      = "port error",
+        [IBV_EVENT_LID_CHANGE]    = "LID change",
+        [IBV_EVENT_PKEY_CHANGE]   = "P_Key change",
+        [IBV_EVENT_SM_CHANGE]     = "SM change",
+        [IBV_EVENT_SRQ_ERR]       = "SRQ catastrophic error",
+        [IBV_EVENT_SRQ_LIMIT_REACHED]   = "SRQ limit reached",
+        [IBV_EVENT_QP_LAST_WQE_REACHED] = "last WQE reached",
+        [IBV_EVENT_CLIENT_REREGISTER]   = "client reregistration",
+        [IBV_EVENT_GID_CHANGE]          = "GID table change",
+        [IBV_EVENT_WQ_FATAL]            = "WQ fatal"
+    };
+
+    if ((event < IBV_EVENT_CQ_ERR) || (event > IBV_EVENT_WQ_FATAL)) {
+        return "unknown";
+    }
+
+    return event_type_str[event];
+}
+
+/* rdma-core copy/paste */
+const char *ibv_wc_status_str(enum ibv_wc_status status)
+{
+    static const char *const wc_status_str[] = {
+        [IBV_WC_SUCCESS]            = "success",
+        [IBV_WC_LOC_LEN_ERR]        = "local length error",
+        [IBV_WC_LOC_QP_OP_ERR]      = "local QP operation error",
+        [IBV_WC_LOC_EEC_OP_ERR]     = "local EE context operation error",
+        [IBV_WC_LOC_PROT_ERR]       = "local protection error",
+        [IBV_WC_WR_FLUSH_ERR]       = "Work Request Flushed Error",
+        [IBV_WC_MW_BIND_ERR]        = "memory management operation error",
+        [IBV_WC_BAD_RESP_ERR]       = "bad response error",
+        [IBV_WC_LOC_ACCESS_ERR]     = "local access error",
+        [IBV_WC_REM_INV_REQ_ERR]    = "remote invalid request error",
+        [IBV_WC_REM_ACCESS_ERR]     = "remote access error",
+        [IBV_WC_REM_OP_ERR]         = "remote operation error",
+        [IBV_WC_RETRY_EXC_ERR]      = "transport retry counter exceeded",
+        [IBV_WC_RNR_RETRY_EXC_ERR]  = "RNR retry counter exceeded",
+        [IBV_WC_LOC_RDD_VIOL_ERR]   = "local RDD violation error",
+        [IBV_WC_REM_INV_RD_REQ_ERR] = "remote invalid RD request",
+        [IBV_WC_REM_ABORT_ERR]      = "aborted error",
+        [IBV_WC_INV_EECN_ERR]       = "invalid EE context number",
+        [IBV_WC_INV_EEC_STATE_ERR]  = "invalid EE context state",
+        [IBV_WC_FATAL_ERR]          = "fatal error",
+        [IBV_WC_RESP_TIMEOUT_ERR]   = "response timeout error",
+        [IBV_WC_GENERAL_ERR]        = "general error",
+        [IBV_WC_TM_ERR]             = "TM error",
+        [IBV_WC_TM_RNDV_INCOMPLETE] = "TM software rendezvous",
+    };
+
+    if ((status < IBV_WC_SUCCESS) || (status > IBV_WC_TM_RNDV_INCOMPLETE)) {
+        return "unknown";
+    }
+
+    return wc_status_str[status];
+}

--- a/contrib/ibmock/verbs.h
+++ b/contrib/ibmock/verbs.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef __VERBS_H
+#define __VERBS_H
+
+#include <infiniband/verbs.h>
+
+/* QP related callback */
+void dev_qp_wr_start(struct ibv_qp_ex *qp_ex);
+void dev_qp_wr_rdma_read(struct ibv_qp_ex *qp_ex, uint32_t rkey,
+                         uint64_t remote_addr);
+void dev_qp_wr_set_sge_list(struct ibv_qp_ex *qp, size_t num_sge,
+                            const struct ibv_sge *sg_list);
+void(dev_qp_wr_set_ud_addr)(struct ibv_qp_ex *qp, struct ibv_ah *ah,
+                            uint32_t remote_qpn, uint32_t remote_qkey);
+int dev_qp_wr_complete(struct ibv_qp_ex *qp);
+#endif /* __VERBS_H */

--- a/contrib/test_efa.sh
+++ b/contrib/test_efa.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/bash -eEx
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+source $(dirname $0)/../buildlib/az-helpers.sh
+source $(dirname $0)/../buildlib/tools/common.sh
+
+WORKSPACE=${WORKSPACE:=$PWD}
+ucx_inst=${WORKSPACE}/install
+
+if [ ! -f ./autogen.sh ]
+then
+    echo "error: run from UCX root"
+    exit 1
+fi
+
+rdma_core_version=55
+rdma_core_tarball=v$rdma_core_version.0.tar.gz
+rdma_core=../rdma-core-$rdma_core_version.0
+rdma_core_tarball_sha=a02d128974055ffa92577e4d3889213ac180a79f05b077aeb884bafb6b46e957
+
+build_rdma_core_efa() {
+    # Fetch rdma-core
+    if [ ! -d $rdma_core ]
+    then
+        wget -O ../$rdma_core_tarball \
+            https://github.com/linux-rdma/rdma-core/archive/refs/tags/$rdma_core_tarball
+        echo "$rdma_core_tarball_sha ../$rdma_core_tarball" | sha256sum --check
+        tar zxvf ../$rdma_core_tarball -C ../
+    fi
+
+    # Build rdma-core
+    cd $rdma_core
+    ./build.sh
+    ls -alrt ./build/include/infiniband/
+    cd -
+
+    # Build IBMOCK
+    cd contrib/ibmock
+    make INCLUDES=-I"$(pwd)/../../$rdma_core/build/include"
+    cd -
+}
+
+build_ucx_efa() {
+    # Build UCX with EFA
+    [ -f Makefile ] && make distclean
+    ./autogen.sh
+    cd contrib
+    build devel --enable-gtest \
+        --with-verbs="$(pwd)/../$rdma_core/build" --with-efa --without-mlx5 \
+        --without-knem --without-gdrcopy --without-cuda
+    cd -
+}
+
+build_rdma_core_rpm() {
+    sudo yum -y install ninja-build pandoc perl-generators python3-Cython python3-docutils
+    cd $rdma_core
+    rm -rf SOURCES tmp || :
+    mkdir SOURCES tmp
+    tar --wildcards -xzf ../$rdma_core_tarball $(basename $rdma_core)/redhat/rdma-core.spec --strip-components=2
+    RPM_SRC=$((rpmspec -P *.spec || grep ^Source: *.spec) | awk '/^Source:/{split($0,a,"[ \t]+");print(a[2])}')
+    (cd SOURCES && ln -sf ../../$rdma_core_tarball "$RPM_SRC")
+    rpmbuild --define '_tmppath '$(pwd)'/tmp' --define '_topdir '$(pwd) -bb *.spec
+    cd -
+}
+
+install_rdma_core_rpm() {
+    local pkgs="libibumad infiniband-diags libibverbs librdmacm rdma-core rdma-core-devel"
+    for pkg in $pkgs; do
+        sudo yum -y remove $pkg || :
+    done
+
+    for pkg in $pkgs; do
+        sudo rpm -i $rdma_core/RPMS/x86_64/$pkg-$rdma_core_version*.rpm
+    done
+}
+
+install_rdma_core() {
+    cd $rdma_core/build
+    sudo /bin/cp -r -f lib/lib*efa*.so* /usr/lib64/
+    sudo /bin/cp -r -f include/infiniband/*efa*h /usr/include/infiniband/
+    cd -
+}
+
+run_gtests() {
+    if [ ! -d /dev/infiniband ]
+    then
+        mkdir /dev/infiniband
+        mknod /dev/infiniband/uverbs0 c 1 3
+        mknod /dev/infiniband/uverbs1 c 1 3
+        chmod ugo+rw /dev/infiniband/uver*
+    fi
+
+    # Setup ibmock library
+    export LD_LIBRARY_PATH=$(pwd)/contrib/ibmock/build:$(pwd)/$rdma_core/build/lib:$LD_LIBRARY_PATH
+    export CLOUD_TYPE=aws
+
+    # Check basic ibmock functionality, error if mocked interface is not found
+    UCX_LOG_LEVEL=trace \
+    UCX_PROTO_INFO=y UCX_TLS=ud UCX_NET_DEVICES=rdmap0:1 \
+        ./install/bin/ucx_perftest -l -t tag_bw
+    ./install/bin/ucx_info -d
+
+    # Try the faster approach before valgrind
+    ./contrib/test/gtest/gtest --gtest_filter=*ud*
+    make -C contrib/test/gtest test_valgrind GTEST_FILTER=*ud*:-*test_uct_perf.envelope*
+}
+
+test_ucx_rpm() {
+    cd contrib
+    ./buildrpm.sh -s -t -b
+    rpm -qplvi rpm-dist/*/ucx-ib-efa-[1-9]*rpm | grep libuct_ib_efa.so
+    rpm -qplvi rpm-dist/*/ucx-ib-efa-[1-9]*rpm
+    cd -
+}
+
+case "${1-:}" in
+    install_rdma_core_efa)
+        install_rdma_core
+        ;;
+    test_rpm_efa)
+        build_ucx_efa
+        test_ucx_rpm
+        ;;
+    build_efa)
+        build_rdma_core_efa
+        build_ucx_efa
+        ;;
+    gtest_efa)
+        run_gtests
+        ;;
+    *)
+        echo "error: invalid argument"
+        exit 1
+esac

--- a/src/uct/ib/efa/srd/srd_iface.c
+++ b/src/uct/ib/efa/srd/srd_iface.c
@@ -357,8 +357,7 @@ static uct_iface_ops_t uct_srd_iface_tl_ops = {
         ucs_empty_function_return_unsupported,
     .ep_pending_purge         = (uct_ep_pending_purge_func_t)
         ucs_empty_function_return_unsupported,
-    .iface_flush              = (uct_iface_flush_func_t)
-        ucs_empty_function_return_unsupported,
+    .iface_flush              = uct_base_iface_flush,
     .iface_fence              = (uct_iface_fence_func_t)
         ucs_empty_function_return_unsupported,
     .iface_progress_enable    = (uct_iface_progress_enable_func_t)

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -530,6 +530,10 @@ static std::map<std::string, std::string> get_all_rdmacm_net_devices()
     ssize_t nread;
     int port_num;
 
+    if (ucs::is_aws()) {
+        return devices;
+    }
+
     std::vector<std::string> ndevs = read_dir(sysfs_net_dir);
 
     /* Enumerate IPoIB and RoCE devices which have direct mapping to an RDMA

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -327,6 +327,12 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
     size_t max_iter = std::numeric_limits<size_t>::max();
     test_spec test  = tests[get_variant_value(VARIANT_TEST_TYPE)];
 
+    if (ucs::is_aws() && (test.wait_mode == UCX_PERF_WAIT_MODE_SLEEP) &&
+        has_transport("ud_v")) {
+        // TODO support wakeup in UD transport without requiring IBV_SEND_SOLICITED
+        UCS_TEST_SKIP_R("wait mode sleep on EFA not available on UD");
+    }
+
     if (has_transport("tcp")) {
         max_iter   = 1000lu;
     }
@@ -361,6 +367,10 @@ class test_ucp_loopback : public test_ucp_perf {};
 UCS_TEST_P(test_ucp_loopback, envelope)
 {
     test_spec test = tests[get_variant_value(VARIANT_TEST_TYPE)];
+
+    if (ucs::is_aws() && (test.wait_mode == UCX_PERF_WAIT_MODE_SLEEP)) {
+        UCS_TEST_SKIP_R("wait mode sleep on EFA not available");
+    }
 
     test.send_mem_type = UCS_MEMORY_TYPE_HOST;
     test.recv_mem_type = UCS_MEMORY_TYPE_HOST;


### PR DESCRIPTION
## What
Add IB mocking (EFA support) capability.

## Why ?
Need to run gtest without the need for EFA interface.

## How ?
Implement loopback libibverbs/libefa. Keep build/code independent from UCX libraries.
### Perftest/Info
```
vdi$ export LD_LIBRARY_PATH=$(pwd)/../efa_mock/build:$LD_LIBRARY_PATH
vdi$ UCX_TLS=srd ucx_perftest -t tag_bw -l
vdi$ UCX_TLS=ud ucx_perftest -t tag_bw -l
vdi$ ucx_info -d
```
### Gtest:
```
vdi$ export LD_LIBRARY_PATH=$(pwd)/../hpc-poc/ibmock/build
vdi$  ./test/gtest/gtest --gtest_filter=*ud*
...
[----------] Global test environment tear-down
[==========] 2300 tests from 119 test suites ran. (642250 ms total)
[  PASSED  ] 2300 tests.

vdi$ valgrind --leak-check=full  ./test/gtest/gtest --gtest_filter=\
*ud*-*perf.enveloppe*
```