### PR TITLE
AZP: Use different ports in one wire-compat job

### DIFF
--- a/buildlib/pr/wire_compat.yml
+++ b/buildlib/pr/wire_compat.yml
@@ -90,7 +90,9 @@ jobs:
           UCX_LEGACY_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)
         displayName: compare tls performance characteristics
         condition: ne(variables.ucx_tag, 'v1.14.0')
-      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a "-c tag"
+      - bash: |
+          export WIRE_COMPAT_STAGE_ID=1
+          buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a "-c tag"
         env:
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib
           UCX_LEGACY_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/lib
@@ -98,14 +100,18 @@ jobs:
         displayName: ucp_client_server with UCX $(ucx_tag)
         condition: ne(variables.ucx_tag, 'v1.14.0')
         timeoutInMinutes: 2
-      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/ucp_hworld -n
+      - bash: |
+          export WIRE_COMPAT_STAGE_ID=2
+          buildlib/tools/test_wire_compat.sh $(test_dir)/ucp_hworld -n
         env:
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib
           UCX_LEGACY_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/lib
           AZP_AGENT_ID: $(AZP_AGENT_ID)
         displayName: ucp_hello_world with UCX $(ucx_tag)
         timeoutInMinutes: 2
-      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a "-c tag"
+      - bash: |
+          export WIRE_COMPAT_STAGE_ID=3
+          buildlib/tools/test_wire_compat.sh $(test_dir)/client_server -a "-c tag"
         env:
           UCX_TLS: ^sm
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib
@@ -114,7 +120,9 @@ jobs:
         displayName: ucp_client_server (no sm) with UCX $(ucx_tag)
         condition: ne(variables.ucx_tag, 'v1.14.0')
         timeoutInMinutes: 2
-      - bash: buildlib/tools/test_wire_compat.sh $(test_dir)/ucp_hworld -n
+      - bash: |
+          export WIRE_COMPAT_STAGE_ID=4
+          buildlib/tools/test_wire_compat.sh $(test_dir)/ucp_hworld -n
         env:
           UCX_TLS: ^sm
           UCX_PR_LIB_PATH: $(System.DefaultWorkingDirectory)/$(ucx_current)/lib

--- a/buildlib/tools/test_wire_compat.sh
+++ b/buildlib/tools/test_wire_compat.sh
@@ -8,10 +8,11 @@
 exe_name=$1
 client_opt=$2
 common_opt=$3
-port=$((10000 + 1000 * ${AZP_AGENT_ID}))
+port=$((10000 + 1000 * ${AZP_AGENT_ID} + 100 * ${WIRE_COMPAT_STAGE_ID}))
 
 export UCX_CM_REUSEADDR=y UCX_LOG_LEVEL=info UCX_WARN_UNUSED_ENV_VARS=n
 export UCX_IB_ROCE_LOCAL_SUBNET=y
+
 exe_cmd="stdbuf -oL ${exe_name} -p ${port}"
 
 # Test server is legacy, client is master
@@ -20,6 +21,8 @@ server_pid=$!
 sleep 5
 LD_LIBRARY_PATH=${UCX_PR_LIB_PATH} ${exe_cmd} ${common_opt} ${client_opt} 127.0.0.1
 if ! kill -9 ${server_pid}; then echo "server already terminated"; fi
+
+exe_cmd="stdbuf -oL ${exe_name} -p $((port + 10))"
 
 # Test server is master, client is legacy
 LD_LIBRARY_PATH=${UCX_PR_LIB_PATH} ${exe_cmd} ${common_opt} &


### PR DESCRIPTION
## What
Use different ports in one wire-compat job to avoid CI failures like
```
[1724129739.884304] [swx-rdmz-ucx-new-02:17268:0]          parser.c:2307 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1724129739.884905] [swx-rdmz-ucx-new-02:17268:0]          parser.c:2314 UCX  INFO  UCX_* env variables: UCX_WARN_UNUSED_ENV_VARS=n UCX_TLS=^sm UCX_CM_REUSEADDR=y UCX_IB_ROCE_LOCAL_SUBNET=y UCX_LOG_LEVEL=info
[1724129740.029045] [swx-rdmz-ucx-new-02:17268:0] rdmacm_listener.c:83   UCX  DIAG  rdma_bind_addr(addr=0.0.0.0:22000) failed: Cannot assign requested address
[1724129740.029084] [swx-rdmz-ucx-new-02:17268:0]    ucp_listener.c:242  UCX  DIAG  failed to create UCT listener on CM 0x10e1830 (component rdmacm) with address 0.0.0.0:22000 status Device is busy
failed to listen (Device is busy)
```


