### PR TITLE
UCS/LOG: add log level check to UCS backtrace log

### DIFF
--- a/src/ucs/debug/log.c
+++ b/src/ucs/debug/log.c
@@ -584,6 +584,10 @@ void ucs_log_print_backtrace(ucs_log_level_t level)
     char buf[1024];
     ucs_status_t status;
 
+    if (!ucs_log_is_enabled(level)) {
+        return;
+    }
+
     status = ucs_debug_backtrace_create(&bckt, 1);
     if (status != UCS_OK) {
         return;


### PR DESCRIPTION
## What ?
Add log level check to `ucs_log_print_backtrace`

## Why ?
Currently `ucs_log_print_backtrace` doesn't check if the given log level is enabled in UCX

## How ?
Used `ucs_log_is_enabled` to check the given log level