### PR TITLE
UCP/CONFIG: limit transport availability check to ALLOW mode configuration lists only

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1838,8 +1838,11 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
         }
 
         ucp_get_aliases_set(&avail_tls);
-        ucp_report_unavailable(&config->tls.array, tl_cfg_mask, "", "transport",
-                               &avail_tls);
+
+        if (config->tls.mode == UCS_CONFIG_ALLOW_LIST_ALLOW) {
+            ucp_report_unavailable(&config->tls.array, tl_cfg_mask, "", "transport",
+                                   &avail_tls);
+        }
     }
 
     /* Validate context resources */


### PR DESCRIPTION
## What
Limit the transport availability check to configuration lists set to ALLOW mode only.

## Why ?
Currently ucp_context checks the availability of a user configured transport even when the configuration list is set to NEGATE (i.e. all the transports in this list must NOT be used). This creates a problem when the user excludes an already unavailable transport, for instance `UCX_TLS=^gdr_copy`.
