### PR TITLE
UCP/RNDV/PPLN: Advertise error handling capability for put_mtype/ppln protocols

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -354,6 +354,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Use two stage pipeline rendezvous protocol for intra-node GPU to GPU transfers",
    ucs_offsetof(ucp_context_config_t, rndv_shm_ppln_enable), UCS_CONFIG_TYPE_BOOL},
 
+  {"RNDV_PIPELINE_ERROR_HANDLING", "n",
+   "Allow using error handling protocol in the rendezvous pipeline protocol\n"
+   "even if invalidation workflow isn't supported",
+   ucs_offsetof(ucp_context_config_t, rndv_errh_ppln_enable), UCS_CONFIG_TYPE_BOOL},
+
   {"FLUSH_WORKER_EPS", "y",
    "Enable flushing the worker by flushing its endpoints. Allows completing\n"
    "the flush operation in a bounded time even if there are new requests on\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -84,6 +84,8 @@ typedef struct ucp_context_config {
     size_t                                 rndv_pipeline_send_thresh;
     /** Enabling 2-stage pipeline rndv protocol */
     int                                    rndv_shm_ppln_enable;
+    /** Enable error handling for rndv pipeline protocol */
+    int                                    rndv_errh_ppln_enable;
     /** Threshold for using tag matching offload capabilities. Smaller buffers
      *  will not be posted to the transport. */
     size_t                                 tm_thresh;

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -1002,3 +1002,14 @@ void ucp_proto_rndv_bulk_request_init_lane_idx(
 
     req->send.multi_lane_idx = lane_idx - 1;
 }
+
+void ucp_proto_rndv_stub_abort(ucp_request_t *req, ucs_status_t status)
+{
+    /* FIXME: Proper abort functionality is not implemented yet.
+     * This stub function is used to advertise error-handling capability for
+     * pipeline protocols, but proper implementation is to be done */
+    ucs_diag("aborting rendezvous request %p with status %s. This may lead to "
+             "data corruption, since invalidation workflow isn't implemented",
+             req, ucs_status_string(status));
+    ucp_invoke_uct_completion(&req->send.state.uct_comp, status);
+}

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -130,6 +130,13 @@ enum {
 };
 
 
+/* rndv_get stages */
+enum {
+    UCP_PROTO_RNDV_GET_STAGE_FETCH = UCP_PROTO_STAGE_START,
+    UCP_PROTO_RNDV_GET_STAGE_ATS
+};
+
+
 /* Initializes protocol which sends rendezvous control message using AM lane
  * (e.g. RTS and ATS). */
 void ucp_proto_rndv_ctrl_probe(const ucp_proto_rndv_ctrl_init_params_t *params,
@@ -211,5 +218,8 @@ void ucp_proto_rndv_ppln_send_frag_complete(ucp_request_t *freq, int send_ack);
 
 void ucp_proto_rndv_ppln_recv_frag_complete(ucp_request_t *freq, int send_ack,
                                             int abort);
+
+
+void ucp_proto_rndv_stub_abort(ucp_request_t *req, ucs_status_t status);
 
 #endif

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -15,11 +15,6 @@
 
 #define UCP_PROTO_RNDV_GET_DESC "read from remote"
 
-enum {
-    UCP_PROTO_RNDV_GET_STAGE_FETCH = UCP_PROTO_STAGE_START,
-    UCP_PROTO_RNDV_GET_STAGE_ATS
-};
-
 static void
 ucp_proto_rndv_get_common_probe(const ucp_proto_init_params_t *init_params,
                                 uint64_t rndv_modes, size_t max_length,

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -564,11 +564,15 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
     ucp_md_map_t mdesc_md_map;
     ucs_status_t status;
     size_t frag_size;
+    unsigned flags;
 
     status = ucp_proto_rndv_mtype_init(init_params, &mdesc_md_map, &frag_size);
     if (status != UCS_OK) {
         return;
     }
+
+    flags = init_params->worker->context->config.ext.rndv_errh_ppln_enable ?
+                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING : 0;
 
     if (ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
         comp_cb = ucp_proto_rndv_put_mtype_frag_completion;
@@ -578,7 +582,7 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
 
     ucp_proto_rndv_put_common_probe(init_params,
                                     UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
-                                    frag_size, UCT_EP_OP_GET_ZCOPY, 0,
+                                    frag_size, UCT_EP_OP_GET_ZCOPY, flags,
                                     mdesc_md_map, comp_cb, 1,
                                     UCP_WORKER_STAT_RNDV_PUT_MTYPE_ZCOPY);
 }
@@ -606,6 +610,6 @@ ucp_proto_t ucp_rndv_put_mtype_proto = {
         [UCP_PROTO_RNDV_PUT_STAGE_ATP]        = ucp_proto_rndv_put_common_atp_progress,
         [UCP_PROTO_RNDV_PUT_STAGE_FENCED_ATP] = ucp_proto_rndv_put_common_fenced_atp_progress,
     },
-    .abort    = ucp_proto_abort_fatal_not_implemented,
+    .abort    = ucp_proto_rndv_stub_abort,
     .reset    = (ucp_request_reset_func_t)ucp_proto_reset_fatal_not_implemented
 };

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -295,6 +295,12 @@ ucp_proto_rndv_rtr_mtype_abort(ucp_request_t *req, ucs_status_t status)
 
     super_req->status = status;
 
+    /* When pipeline is used, there is a top-level 'recv' request that we also
+     * need to abort */
+    if (ucp_proto_rndv_request_is_ppln_frag(req)) {
+        ucp_request_get_super(super_req)->status = status;
+    }
+
     /*TODO: Invalidate memh */
     ucp_send_request_id_release(req);
     ucp_proto_rndv_rtr_mtype_complete(req, 1);


### PR DESCRIPTION
## What
Using UCX in this combination: 1.18+proto_v2+CUDA async+error handling, causes memory transfer via host instead of bounce buffers, making transfers prohibitively slow. Unlike with proto_v1, pipeline protocol (rndv_ppln over rnvd_(put/rtr)_mtype) is not being selected, because it doesn't support error handling.
As a result, memory copy is done through host staging buffers which drastically affect performance. The proper solution would be to enable error handling for aforementioned protocols with rkey invalidation.

This PR is the first step towards the real solution: here we just advertise support for error handling without providing invalidation flow. Subsequent PR will provide the invalidation functionality.

Related PRs: https://github.com/openucx/ucx/pull/8666, https://github.com/openucx/ucx/pull/9999
