### PR TITLE
BUILD: print test name on failure in builds.sh

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -461,5 +461,5 @@ do
 	[ -d "${ucx_build_dir}" ] && rm -rf ${ucx_build_dir}/*
 
 	# run the test
-	${test_name}
+	$test_name || { azure_log_error "Test failed: $test_name"; exit 1; }
 done


### PR DESCRIPTION
## What
Added logic to `builds.sh` to print the test name if a test fails.

## Why ?
To quickly identify which test failed, improving debugging efficiency.

## How ?
Inserted a conditional check after each test in builds.sh to print the test name and exit on failure.
