### PR TITLE
UCP/MMAP: Avoid noblocking registration for MDs which do not support it

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1605,6 +1605,11 @@ ucp_add_component_resources(ucp_context_h context, ucp_rsc_index_t cmpt_index,
                         context->reg_md_map[mem_type] |= UCS_BIT(md_index);
                     }
 
+                    if (md_attr->reg_nonblock_mem_types & UCS_BIT(mem_type)) {
+                        context->reg_nonblock_md_map[mem_type] |=
+                                UCS_BIT(md_index);
+                    }
+
                     if (md_attr->cache_mem_types & UCS_BIT(mem_type)) {
                         context->cache_md_map[mem_type] |= UCS_BIT(md_index);
                     }
@@ -1732,6 +1737,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     ucs_memory_type_for_each(mem_type) {
         context->reg_md_map[mem_type]           = 0;
         context->reg_block_md_map[mem_type]     = 0;
+        context->reg_nonblock_md_map[mem_type]  = 0;
         context->cache_md_map[mem_type]         = 0;
         context->gva_md_map[mem_type]           = 0;
         context->dmabuf_mds[mem_type]           = UCP_NULL_RESOURCE;

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -320,6 +320,10 @@ typedef struct ucp_context {
        ucp_mem_map() will register memory for all those domains. */
     ucp_md_map_t                  reg_md_map[UCS_MEMORY_TYPE_LAST];
 
+    /* Map of MDs that provide nonblocking registration for given memory type,
+       ucp_mem_map() will register memory for all those domains. */
+    ucp_md_map_t                  reg_nonblock_md_map[UCS_MEMORY_TYPE_LAST];
+
     /* Map of MDs that provide blocking registration for given memory type.
      * This map is initialized if non-blocking registration is requested for
      * the memory type (thus reg_md_map contains only MDs supporting

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -583,11 +583,11 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                     context->reg_md_map[mem_type],
                     context->reg_block_md_map[mem_type]);
 
-        reg_params.flags      = uct_flags | memh->uct_flags;
         reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+        reg_params.flags      = uct_flags | memh->uct_flags;
         if (!(context->reg_nonblock_md_map[mem_type] & md_index)) {
-            /* Ignore nonblcok flag if MD doesn't support it */
-            reg_params.flags &= !UCT_MD_MEM_FLAG_NONBLOCK;
+            /* Ignore nonblock flag if MD doesn't support it */
+            reg_params.flags &= ~UCT_MD_MEM_FLAG_NONBLOCK;
         }
 
         if (dmabuf_md_map & UCS_BIT(md_index)) {

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -106,6 +106,11 @@ public:
             modify_config("PROTO_ENABLE", "n");
         }
 
+        if (get_variant_value() == VARIANT_MAP_NONBLOCK) {
+            // ODPv1 cannot interact with DEVX objects
+            modify_config("IB_MLX5_DEVX_OBJECTS", "", SETENV_IF_NOT_EXIST);
+        }
+
         if (get_variant_value() == VARIANT_NO_RCACHE) {
             modify_config("RCACHE_ENABLE", "n");
             ucp_test::init(); // Init UCP with rcache disabled
@@ -944,7 +949,7 @@ UCS_TEST_P(test_ucp_mmap, fixed) {
     }
 }
 
-UCS_TEST_P(test_ucp_mmap, gva, "GVA_ENABLE=y", "IB_MLX5_DEVX_OBJECTS?=")
+UCS_TEST_P(test_ucp_mmap, gva, "GVA_ENABLE=y")
 {
     std::list<void*> bufs;
     ucp_mem_h first     = NULL;


### PR DESCRIPTION
## What
Currently `ucp_mem_map` registers MDs according to `reg_md_map` only. But if CUDA buffer was provided with nonblocking registration flag, `ucp_mem_map` will call UCT registration with this flag for all MDs in `reg_md_map`.

This patch reworks this logic by the following way:
- If `mem_type` was specified in `UCX_REG_NONBLOCK_MEM_TYPES`, then register only MDs that support nonblocking registration
- Else do not pass nonblocking flag for MDs that don't support it (since this flag documented as a hint)

## Why ?
To avoid weird  CUDA memory ODP registration case.
