### PR TITLE
UCT/IB: Support cuda-managed memory when ODP is available

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -1,6 +1,7 @@
 [Grace Hopper]
 CPU model=Grace
-UCX_REG_NONBLOCK_MEM_TYPES=host
+UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed
+UCX_IB_ODP_MEM_TYPES=host,cuda-managed
 UCX_IB_MLX5_DEVX_OBJECTS=
 
 [Fujitsu ARM]

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -170,6 +170,12 @@ ucs_config_field_t uct_ib_md_config_table[] = {
      "Enable UMR optimization for XGVMI mkeys export/import.",
      ucs_offsetof(uct_ib_md_config_t, xgvmi_umr_enable), UCS_CONFIG_TYPE_BOOL},
 
+    {"ODP_MEM_TYPES", "host",
+     "Advertise non-blocking registration for these memory types, when ODP is "
+     "enabled.\n",
+     ucs_offsetof(uct_ib_md_config_t, ext.odp.mem_types),
+     UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
+
     {NULL}
 };
 
@@ -581,7 +587,8 @@ ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
     memh->rkey = UCT_IB_INVALID_MKEY;
 
     if ((mem_flags & UCT_MD_MEM_FLAG_NONBLOCK) && (length > 0) &&
-        (md->reg_nonblock_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+        (md->reg_nonblock_mem_types != 0)) {
+        /* Registration will fail if memory does not actually support it */
         memh->flags |= UCT_IB_MEM_FLAG_ODP;
     }
 
@@ -1232,8 +1239,10 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         md->check_subnet_filter = 1;
     }
 
+    md->reg_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                        md->reg_nonblock_mem_types;
+
     /* Check for GPU-direct support */
-    md->reg_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     if (md_config->enable_gpudirect_rdma != UCS_NO) {
         /* check if GDR driver is loaded */
         uct_ib_check_gpudirect_driver(

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -83,6 +83,7 @@ typedef struct uct_ib_md_ext_config {
     struct {
         int                  prefetch;     /**< Auto-prefetch non-blocking memory
                                                 registrations / allocations */
+        uint64_t             mem_types;    /**< Supported mem types for ODP */
     } odp;
 
     unsigned long            gid_index;    /**< IB GID index to use */

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1581,6 +1581,7 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
 {
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out)] = {};
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)]   = {};
+    ucs_string_buffer_t strb = UCS_STRING_BUFFER_INITIALIZER;
     ucs_status_t status;
     const void *odp_cap;
     const char *reason;
@@ -1651,10 +1652,17 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
         goto no_odp;
     }
 
-    ucs_debug("%s: ODP is supported, version %d",
-              uct_ib_device_name(&md->super.dev), version);
-    md->super.reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    md->super.gva_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    md->super.gva_mem_types          = md_config->ext.odp.mem_types;
+    md->super.reg_nonblock_mem_types = md_config->ext.odp.mem_types;
+
+    if (ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
+        ucs_string_buffer_append_flags(&strb, md->super.reg_nonblock_mem_types,
+                                       ucs_memory_type_names);
+        ucs_debug("%s: ODP is supported, version %d: memory=%s",
+                  uct_ib_device_name(&md->super.dev), version,
+                  ucs_string_buffer_cstr(&strb));
+        ucs_string_buffer_cleanup(&strb);
+    }
 
     return;
 


### PR DESCRIPTION
## What
Allow memory registration for cuda-managed memory when ODP is enabled on machines with coherent memory.

## Why ?
Needed to enable rdma, avoiding long-term page pinning.

## How ?
Advertise support, and make sure non-blocking registration is always requested for cuda-managed, since it currently fails otherwise.

### Test
```
mpirun -mca coll ^hcoll -mca pml ucx -np 2 osu_bw -d managed MD MD
./bin/ucx_perftest -m cuda-managed -t <tag_bw|ucp_put_bw|ucp_get>
```

- Confirmed actual RDMA operation against cuda-managed memory with ODPv1
- enable rdma assertion on gtest
- tested on GH200 / A100 without coherent.
- tested with `UCX_IB_ODP_PREFETCH=y`