### PR TITLE
UCP/CONTEXT/CONFIG: create env vars to force MULTI_SEND and FAST_CMPL

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -204,7 +204,8 @@ public:
         params.cb.send      = cb;
         params.user_data    = this;
 
-        if (TYPE == UCX_PERF_TEST_TYPE_STREAM_UNI) {
+        if ((TYPE == UCX_PERF_TEST_TYPE_STREAM_UNI) ||
+            (m_perf.ucp.worker->context->config.ext.force_multi_send)) {
             params.op_attr_mask |= UCP_OP_ATTR_FLAG_MULTI_SEND;
         }
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -522,6 +522,14 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Prefetch memory when using global VA MR",
    ucs_offsetof(ucp_context_config_t, gva_prefetch), UCS_CONFIG_TYPE_BOOL},
 
+  {"FORCE_FAST_CMPL", "n",
+   "Enable or disable forced FAST_CMPL flag for all operations.",
+   ucs_offsetof(ucp_context_config_t, force_fast_cmpl), UCS_CONFIG_TYPE_BOOL},
+
+  {"FORCE_MULTI_SEND", "n",
+   "Enable or disable forced MULTI_SEND flag for all operations.",
+   ucs_offsetof(ucp_context_config_t, force_multi_send), UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -189,6 +189,10 @@ typedef struct ucp_context_config {
     double                                 proto_overhead_rkey_ptr;
     /** Registration cache lookup overhead estimation */
     double                                 rcache_overhead;
+    /** Enable forced FAST_CMPL flag for all operations */
+    int                                    force_fast_cmpl;
+    /** Enable forced MULTI_SEND flag for all operations */
+    int                                    force_multi_send;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -958,8 +958,9 @@ ucp_request_param_rndv_thresh(ucp_request_t *req,
                               ucp_rndv_thresh_t *am_thresh_config,
                               size_t *rndv_rma_thresh, size_t *rndv_am_thresh)
 {
-    if ((param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) &&
-        ucs_likely(UCP_MEM_IS_HOST(req->send.mem_type))) {
+    if (((param->op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) ||
+        (req->send.ep->worker->context->config.ext.force_fast_cmpl)) &&
+        (ucs_likely(UCP_MEM_IS_HOST(req->send.mem_type)))) {
         *rndv_rma_thresh = rma_thresh_config->local;
         *rndv_am_thresh  = am_thresh_config->local;
     } else {

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -736,8 +736,7 @@ void ucp_proto_select_short_init(ucp_worker_h worker,
                                  ucp_operation_id_t op_id, unsigned proto_flags,
                                  ucp_proto_select_short_t *proto_short)
 {
-    static const uint32_t op_attributes[] = {0, UCP_OP_ATTR_FLAG_FAST_CMPL,
-                                             UCP_OP_ATTR_FLAG_MULTI_SEND};
+    uint32_t op_attributes[3]             = {0};
     ucp_context_h context                 = worker->context;
     const ucp_proto_t *proto              = NULL;
     const ucp_proto_threshold_elem_t *thresh;
@@ -746,6 +745,16 @@ void ucp_proto_select_short_init(ucp_worker_h worker,
     ucp_memory_info_t mem_info;
     ssize_t max_short_signed;
     const uint32_t *op_attribute;
+
+    if ((UCP_OP_ATTR_FLAG_FAST_CMPL) ||
+        (worker->context->config.ext.force_fast_cmpl)) {
+        op_attributes[1] = UCP_OP_ATTR_FLAG_FAST_CMPL;
+    }
+
+    if ((UCP_OP_ATTR_FLAG_MULTI_SEND) ||
+        (worker->context->config.ext.force_multi_send)) {
+        op_attributes[2] = UCP_OP_ATTR_FLAG_MULTI_SEND;
+    }
 
     if (worker->context->config.progress_wrapper_enabled) {
         ucp_proto_select_short_disable(proto_short);


### PR DESCRIPTION
## What ?
Create environment variables (`UCX_FORCE_FAST_CMPL` and `UCX_FORCE_MULTI_SEND`) to automatically enforce the `UCP_OP_ATTR_FLAG_FAST_CMPL` and `UCP_OP_ATTR_FLAG_MULTI_SEND` flags for all UCX operations.

## Why ?
These variables provide a way to globally enforce specific behaviors (FAST_CMPL and MULTI_SEND) across all UCX operations, optimizing performance without needing to modify each operation individually.

## How ?
Added `FORCE_FAST_CMPL` and `FORCE_MULTI_SEND` in `ucp_context_config_t` and updated environment parsing logic.
Updated functions to check these new settings and apply the flags accordingly.