### PR TITLE
UCT/IB/BASE: added ConnectX-8 to uct_ib_builtin_device_specs[]

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -144,6 +144,9 @@ static uct_ib_device_spec_t uct_ib_builtin_device_specs[] = {
   {"ConnectX-7", {0x15b3, 4129},
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V2, 70},
+  {"ConnectX-8", {0x15b3, 4131},
+   UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
+   UCT_IB_DEVICE_FLAG_DC_V2, 80},
   {"BlueField", {0x15b3, 0xa2d2},
    UCT_IB_DEVICE_FLAG_MELLANOX | UCT_IB_DEVICE_FLAG_MLX5_PRM |
    UCT_IB_DEVICE_FLAG_DC_V2, 41},
@@ -1501,3 +1504,4 @@ const char* uct_ib_ah_attr_str(char *buf, size_t max,
 
     return buf;
 }
+


### PR DESCRIPTION
## What
Adding ConnectX-8 device spec

## Why ?
So UCX will be able to identify ConnectX-8 devices and use them
