### PR TITLE
UCP/MM: Augment registered access flags to avoid repeated invalidations

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -25,7 +25,7 @@
 
 /* Mask of UCT memory flags that need make sure are present when reusing an
    existing region */
-#define UCP_MM_UCT_ACCESS_MASK UCT_MD_MEM_ACCESS_ALL
+#define UCP_MM_UCT_ACCESS_FLAGS(_flags) ((_flags) & UCT_MD_MEM_ACCESS_ALL)
 
 
 /**

--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -58,9 +58,9 @@ ucp_memh_get(ucp_context_h context, void *address, size_t length,
 
         memh = ucs_derived_of(rregion, ucp_mem_t);
         if (ucs_likely(ucs_test_all_flags(memh->md_map, reg_md_map)) &&
-            ucs_likely(ucs_test_all_flags(
-                    memh->uct_flags,
-                    uct_flags & UCP_MM_UCT_ACCESS_MASK))) {
+            ucs_likely(
+                    ucs_test_all_flags(memh->uct_flags,
+                                       UCP_MM_UCT_ACCESS_FLAGS(uct_flags)))) {
             ucp_memh_rcache_print(memh, address, length);
             *memh_p = memh;
             UCP_THREAD_CS_EXIT(&context->mt_lock);


### PR DESCRIPTION
## What
Fix performance gap when requesting registered memory with alternating access flags.

Internal issue: [4007343](https://redmine.mellanox.com/issues/4007343)
## Why ?
It is possible to observe 10x performance reduction depending on the use-case due to this invalidation bouncing, between:
- `UCT_MD_MEM_ACCESS_LOCAL_WRITE` / `UCT_MD_MEM_ACCESS_REMOTE_PUT`

## How ?
Augment registration flags.
