### PR TITLE
UCS/VFS: Detect deletion of the monitored folder

### DIFF
--- a/src/ucs/vfs/fuse/vfs_fuse.c
+++ b/src/ucs/vfs/fuse/vfs_fuse.c
@@ -254,6 +254,16 @@ static ucs_status_t ucs_vfs_fuse_wait_for_path(const char *path)
 
     pthread_mutex_lock(&ucs_vfs_fuse_context.mutex);
 
+    /* Check 'stop' flag before entering the loop. If the main thread sets
+     * 'stop' flag before this thread created 'inotify_fd' fd, the execution
+     * of the thread has to be stopped, otherwise - the thread hangs waiting
+     * for the data on 'inotify_fd' fd.
+     */
+    if (ucs_vfs_fuse_context.stop) {
+        status = UCS_ERR_CANCELED;
+        goto out;
+    }
+
     /* Create directory path */
     ret = ucs_vfs_sock_mkdir(path, UCS_LOG_LEVEL_DIAG);
     if (ret != 0) {
@@ -282,23 +292,15 @@ static ucs_status_t ucs_vfs_fuse_wait_for_path(const char *path)
                      sizeof(watch_filename));
     watch_dirname = dirname(dir_buf);
 
-    /* Watch for new files in 'watch_dirname' */
+    /* Watch for new files in 'watch_dirname' and monitor if this watch gets
+     * deleted explicitly or implicitly */
     ucs_vfs_fuse_context.watch_desc = inotify_add_watch(
-            ucs_vfs_fuse_context.inotify_fd, watch_dirname, IN_CREATE);
+            ucs_vfs_fuse_context.inotify_fd, watch_dirname,
+            IN_CREATE | IN_IGNORED);
     if (ucs_vfs_fuse_context.watch_desc < 0) {
         ucs_error("inotify_add_watch(%s) failed: %m", watch_dirname);
         status = UCS_ERR_IO_ERROR;
         goto out_close_inotify_fd;
-    }
-
-    /* Check 'stop' flag before entering the loop. If the main thread sets
-     * 'stop' flag before this thread created 'inotify_fd' fd, the execution
-     * of the thread has to be stopped, otherwise - the thread hangs waiting
-     * for the data on 'inotify_fd' fd.
-     */
-    if (ucs_vfs_fuse_context.stop) {
-        status = UCS_ERR_CANCELED;
-        goto out_close_watch_id;
     }
 
     /* Read events from inotify channel and exit when either the main thread set
@@ -330,6 +332,15 @@ static ucs_status_t ucs_vfs_fuse_wait_for_path(const char *path)
         for (offset  = 0; offset < nread;
              offset += (sizeof(*event) + event->len)) {
             event = UCS_PTR_BYTE_OFFSET(event_buf, offset);
+
+            /* Watch was removed explicitly (inotify_rm_watch) or automatically
+             * (file was deleted, or file system was unmounted). */
+            if (event->mask & IN_IGNORED) {
+                ucs_debug("inotify watch on '%s' was removed", watch_dirname);
+                status = UCS_ERR_IO_ERROR;
+                goto out_close_watch_id;
+            }
+
             if (!(event->mask & IN_CREATE)) {
                 ucs_trace("ignoring inotify event with mask 0x%x", event->mask);
                 continue;


### PR DESCRIPTION
## What
Fix for https://redmine.mellanox.com/issues/4044773
We see that fuse thread is not interrupted from the main thread dtor, and remains waiting for data in the read:
```
Thread 2 (Thread 0x7fb4cffff700 (LWP 420349)):
#0  0x00007fb4de0abaa4 in read () from /lib64/libpthread.so.0
#1  0x00007fb4de6448f6 in ucs_vfs_fuse_wait_for_path (path=path@entry=0x7fb4cfffecd2 "/run/user/90540/ucx/vfs.sock") at vfs_fuse.c:311
#2  0x00007fb4de644c2d in ucs_vfs_fuse_thread_func (arg=<optimized out>) at vfs_fuse.c:418
Thread 1 (Thread 0x7fb4de7fb8c0 (LWP 420284)):
#0  0x00007fb4de0a36bd in __pthread_timedjoin_ex () from /lib64/libpthread.so.0
#1  0x00007fb4de6443d5 in ucs_fuse_thread_stop () at vfs_fuse.c:510
```
The only reason it can happen is that folder that we monitor (`/run/user/<user_id>/ucx`) gets deleted/recreated in the meantime. Currently we see this happening when tests are executed under `mtt` account.

## Why ?
We must get notified when `/run/user/<user_id>/ucx` folder gets deleted, so we must also handle **IN_IGNORED** event in addition to IN_CREATE

## How ?
On receiving this event we can either:
1. return error, so that VFS becomes efficiently disabled
2. return UCS_OK, so that we try again to create and monitor that folder
For now option 1 is implemented
