### PR TITLE
ARCH/X86: Add CPU Model for MI300A - v1.17.x

### DIFF
--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -472,7 +472,7 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
                 break;
             }
             break;
-        /* AMD Zen3 */
+        /* AMD Zen3/Zen4 */
         case 0x19:
             switch (model) {
             case 0x00:
@@ -480,6 +480,7 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
                 cpu_model = UCS_CPU_MODEL_AMD_MILAN;
                 break;
             case 0x11:
+            case 0x90:
                 cpu_model = UCS_CPU_MODEL_AMD_GENOA;
                 break;
             }


### PR DESCRIPTION
## What
The MI300A has 24 Zen4 cores, which are architecturally (mostly) identical to the Genoa processors. They have however a different CPU id. Add the CPU ID to recognize CPU on this architecture.

## How ?
(cherry picked from commit 8b2113067bc5d158561c9564282d52c5e79d3bfe)