### PR TITLE
BUILD: enable single test run in builds.sh

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -448,6 +448,25 @@ then
 			'build_armclang')
 fi
 
+# Handle specific test execution
+if [ "$1" ]; then
+	test_name="$1"
+	if [[ " ${tests[@]} " =~ " ${test_name} " ]]; then
+		[ -d "${ucx_build_dir}" ] && rm -rf ${ucx_build_dir}/*
+
+		if [ $test_name ]; then
+			echo "Test succeeded: ${test_name}"
+			exit 0
+		else
+			echo "Test failed: ${test_name}"
+			exit 1
+		fi
+	else
+		echo "Error: Test '${test_name}' not found"
+		exit 1
+	fi
+fi
+
 num_tests=${#tests[@]}
 for ((i=0;i<${num_tests};++i))
 do
@@ -460,6 +479,9 @@ do
 	# cleanup build dir before the task
 	[ -d "${ucx_build_dir}" ] && rm -rf ${ucx_build_dir}/*
 
-	# run the test
-	$test_name || { azure_log_error "Test failed: $test_name"; exit 1; }
+	if ! $test_name; then
+		azure_log_error "Test failed: $test_name"
+		azure_log_error	"To debug, rerun the test with: $0 $test_name"
+		exit 1
+	fi
 done


### PR DESCRIPTION
## What?
Updated ucx/buildlib/tools/builds.sh to allow running a specific test by passing its name as an argument.

## Why?
To make debugging more efficient by allowing developers to run only the necessary test.

## How?
Added logic to check for a test name argument and run only that test if provided, with error handling for invalid names.
