### PR TITLE
UCT/IB: Check implicit ODP with relaxed ordering

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -598,7 +598,7 @@ ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
     return UCS_OK;
 }
 
-uint64_t uct_ib_memh_access_flags(uct_ib_md_t *md, uct_ib_mem_t *memh)
+uint64_t uct_ib_memh_access_flags(uct_ib_mem_t *memh, int relaxed_order)
 {
     uint64_t access_flags = UCT_IB_MEM_ACCESS_FLAGS;
 
@@ -606,7 +606,7 @@ uint64_t uct_ib_memh_access_flags(uct_ib_md_t *md, uct_ib_mem_t *memh)
         access_flags |= IBV_ACCESS_ON_DEMAND;
     }
 
-    if (md->relaxed_order) {
+    if (relaxed_order) {
         access_flags |= IBV_ACCESS_RELAXED_ORDERING;
     }
 
@@ -633,7 +633,7 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
     }
 
     memh         = ucs_derived_of(ib_memh, uct_ib_verbs_mem_t);
-    access_flags = uct_ib_memh_access_flags(md, &memh->super);
+    access_flags = uct_ib_memh_access_flags(&memh->super, md->relaxed_order);
 
     status = uct_ib_reg_mr(md, address, length, params, access_flags, NULL,
                            &mr_default);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -377,7 +377,7 @@ uct_ib_md_handle_mr_list_mt(uct_ib_md_t *md, void *address, size_t length,
                             uint64_t access_flags, size_t mr_num,
                             struct ibv_mr **mrs);
 
-uint64_t uct_ib_memh_access_flags(uct_ib_md_t *md, uct_ib_mem_t *memh);
+uint64_t uct_ib_memh_access_flags(uct_ib_mem_t *memh, int relaxed_order);
 
 ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
                                   const uct_md_mem_reg_params_t *params,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -690,7 +690,8 @@ uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
                         uct_ib_mr_type_t mr_type, uint64_t access_mask,
                         uint32_t *lkey_p, uint32_t *rkey_p)
 {
-    uint64_t access_flags = uct_ib_memh_access_flags(&md->super, &memh->super) &
+    uint64_t access_flags = uct_ib_memh_access_flags(&memh->super,
+                                                     md->super.relaxed_order) &
                             access_mask;
     unsigned flags        = UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
                                                        FIELD_FLAGS, 0);
@@ -763,6 +764,16 @@ uct_ib_mlx5_devx_memh_alloc(uct_ib_mlx5_md_t *md, size_t length,
     return UCS_OK;
 }
 
+static int
+uct_ib_mlx5_devx_memh_has_ro(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh)
+{
+    if (memh->mrs[UCT_IB_MR_DEFAULT].super.ib->length == SIZE_MAX) {
+        return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
+    }
+
+    return md->super.relaxed_order;
+}
+
 static ucs_status_t
 uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, uct_mem_h *memh_p)
 {
@@ -771,6 +782,7 @@ uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, uct_mem_h *memh_p)
     uct_ib_mlx5_devx_mem_t *memh;
     uint64_t access_flags;
     ucs_status_t status;
+    int relaxed_order;
 
     status = uct_ib_mlx5_devx_memh_alloc(md, SIZE_MAX, UCT_MD_MEM_FLAG_NONBLOCK,
                                          sizeof(memh->mrs[0]), &memh);
@@ -778,14 +790,15 @@ uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, uct_mem_h *memh_p)
         goto err;
     }
 
-    access_flags = uct_ib_memh_access_flags(&md->super, &memh->super);
+    relaxed_order = md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
+    access_flags  = uct_ib_memh_access_flags(&memh->super, relaxed_order);
     status = uct_ib_reg_mr(&md->super, NULL, SIZE_MAX, &params, access_flags,
                            NULL, &memh->mrs[UCT_IB_MR_DEFAULT].super.ib);
     if (status != UCS_OK) {
         goto err_reg;
     }
 
-    if (md->super.relaxed_order) {
+    if (relaxed_order) {
         status = uct_ib_reg_mr(&md->super, NULL, SIZE_MAX, &params,
                                access_flags & ~IBV_ACCESS_RELAXED_ORDERING,
                                NULL,
@@ -1507,7 +1520,7 @@ uct_ib_mlx5_devx_mem_dereg(uct_md_h uct_md,
     }
 
     if (!(memh->super.flags & UCT_IB_MEM_IMPORTED)) {
-        if (md->super.relaxed_order) {
+        if (uct_ib_mlx5_devx_memh_has_ro(md, memh)) {
             status = uct_ib_mlx5_devx_dereg_mr(md, memh,
                                                UCT_IB_MR_STRICT_ORDER);
             if (status != UCS_OK) {
@@ -1584,6 +1597,7 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
     ucs_status_t status;
     const void *odp_cap;
     const char *reason;
+    struct ibv_mr *mr;
     uint8_t version;
 
     if (IBV_ACCESS_ON_DEMAND == 0) {
@@ -1656,6 +1670,19 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
     md->super.reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     md->super.gva_mem_types          = UCS_BIT(UCS_MEMORY_TYPE_HOST);
 
+    if (!md->super.relaxed_order) {
+        return;
+    }
+
+    mr = ibv_reg_mr(md->super.pd, NULL, SIZE_MAX,
+                    UCT_IB_MEM_ACCESS_FLAGS | IBV_ACCESS_RELAXED_ORDERING |
+                    IBV_ACCESS_ON_DEMAND);
+    if (mr == NULL) {
+        return;
+    }
+
+    ibv_dereg_mr(mr);
+    md->flags |= UCT_IB_MLX5_MD_FLAG_GVA_RO;
     return;
 
 no_odp:
@@ -2802,7 +2829,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
      */
     if (ucs_unlikely(memh->atomic_dvmr == NULL) &&
         ((memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) ||
-         md->super.relaxed_order) &&
+         uct_ib_mlx5_devx_memh_has_ro(md, memh)) &&
         !(memh->super.flags & UCT_IB_MEM_IMPORTED) &&
         ucs_test_all_flags(md->flags,
                            UCT_IB_MLX5_MD_FLAG_KSM |

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -199,9 +199,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_XGVMI_UMR            = UCS_BIT(16),
     /* Device supports UAR WC allocation type */
     UCT_IB_MLX5_MD_FLAG_UAR_USE_WC           = UCS_BIT(17),
+    /* Device supports implicit ODP with PCI relaxed order */
+    UCT_IB_MLX5_MD_FLAG_GVA_RO               = UCS_BIT(18),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 18,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 19,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),


### PR DESCRIPTION
## What
Check whether implicit ODP with PCI relaxed order flag is supported by driver

## Why ?
Internal issue [4042329](https://redmine.mellanox.com/issues/4042329)
