### PR TITLE
UCT/IB/MLX5/DC: dci_channel_index is not limited by num_dci_channels

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
@@ -368,8 +368,7 @@ uct_dc_mlx5_ep_basic_init(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
         }
         ep->dci               = 0;
         dci                   = uct_dc_mlx5_iface_dci(iface, ep->dci);
-        ep->dci_channel_index = dci->next_channel_index++ %
-                                iface->tx.num_dci_channels;
+        ep->dci_channel_index = dci->next_channel_index++;
     } else {
         ep->dci               = UCT_DC_MLX5_EP_NO_DCI;
         ep->dci_channel_index = 0;


### PR DESCRIPTION
## What
Removed limitation of `dci_channel_index` by `num_dci_channels`

## Why ?
Improvement in performance, utilization of all 256 DCI channels