### PR TITLE
GPU/DOCKER: Add --ipc=host docker option for GPU - v1.17.x

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -1,7 +1,7 @@
 variables:
   DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
   DOCKER_OPT_IB: --ulimit memlock=-1:-1 --device=/dev/infiniband/ --net=host
-  DOCKER_OPT_GPU: --gpus all $(DOCKER_OPT_IB)
+  DOCKER_OPT_GPU: --gpus all --device=/dev/gdrdrv --ipc=host $(DOCKER_OPT_IB)
   DOCKER_OPT_ARGS: --cap-add=SYS_PTRACE
 
 resources:


### PR DESCRIPTION
What
Add '--ipc=host' docker option for GPU nodes.

Why ?
Fix CUDA segfaults during tests.
https://github.com/NVIDIA/nvidia-docker/issues/1396