### PR TITLE
UCP: Enable ppln protos with cuda buffers by default

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -37,6 +37,7 @@ ucp_am_eager_multi_bcopy_proto_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .max_lanes           = context->config.ext.max_eager_lanes,
         .initial_reg_md_map  = 0,
         .first.lane_type     = UCP_LANE_TYPE_AM,
@@ -197,6 +198,7 @@ ucp_am_eager_multi_zcopy_proto_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .max_lanes           = context->config.ext.max_eager_lanes,
         .initial_reg_md_map  = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -111,6 +111,7 @@ ucp_am_eager_short_probe_common(const ucp_proto_init_params_t *init_params,
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_SHORT
     };
@@ -240,6 +241,7 @@ static void ucp_am_eager_single_bcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -330,6 +332,7 @@ static void ucp_am_eager_single_zcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_ZCOPY
     };

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -340,11 +340,15 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "and the resulting performance.",
    ucs_offsetof(ucp_context_config_t, estimated_num_ppn), UCS_CONFIG_TYPE_ULUNITS},
 
-  {"RNDV_FRAG_MEM_TYPE", "host",
-   "Memory type of fragments used for RNDV pipeline protocol.\n"
-   "Allowed memory types is one of: host, cuda, rocm, ze-host, ze-device",
-   ucs_offsetof(ucp_context_config_t, rndv_frag_mem_type),
-   UCS_CONFIG_TYPE_ENUM(ucs_memory_type_names)},
+  {"RNDV_FRAG_MEM_TYPE", NULL, "",
+   ucs_offsetof(ucp_context_config_t, rndv_frag_mem_types),
+   UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
+
+  {"RNDV_FRAG_MEM_TYPES", "host,cuda",
+   "Memory types of fragments used for RNDV pipeline protocol.\n"
+   "Allowed memory types are: host, cuda, rocm, ze-host, ze-device",
+   ucs_offsetof(ucp_context_config_t, rndv_frag_mem_types),
+   UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
 
   {"RNDV_PIPELINE_SEND_THRESH", "inf",
    "RNDV size threshold to enable sender side pipeline for mem type",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -78,8 +78,8 @@ typedef struct ucp_context_config {
     size_t                                 rndv_frag_size[UCS_MEMORY_TYPE_LAST];
     /** Number of RNDV pipeline fragments per allocation */
     size_t                                 rndv_num_frags[UCS_MEMORY_TYPE_LAST];
-    /** Memory type of fragments used for RNDV pipeline protocol */
-    ucs_memory_type_t                      rndv_frag_mem_type;
+    /** Memory types of fragments used for RNDV pipeline protocol */
+    uint64_t                               rndv_frag_mem_types;
     /** RNDV pipeline send threshold */
     size_t                                 rndv_pipeline_send_thresh;
     /** Enabling 2-stage pipeline rndv protocol */

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -61,6 +61,7 @@ typedef enum {
 
     /* Supports starting the request when its datatype iterator offset is > 0 */
     UCP_PROTO_COMMON_INIT_FLAG_RESUME        = UCS_BIT(10),
+    UCP_PROTO_COMMON_KEEP_MD_MAP             = UCS_BIT(11)
 } ucp_proto_common_init_flags_t;
 
 
@@ -120,6 +121,13 @@ typedef struct {
 
     /* Map of unsuitable lanes */
     ucp_lane_map_t          exclude_map;
+
+    /* Memory type of the buffer used for data transfer on the transport level.
+     * If UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY flag is set, it is expected to
+     * be the user buffer memory type. Alternatively, it refers to the type of
+     * memory used for bounce buffers (either in the UCP or UCT layer) where
+     * data needs to be copied as part of the protocol. */
+    ucs_memory_type_t       reg_mem_type;
 } ucp_proto_common_init_params_t;
 
 
@@ -259,8 +267,9 @@ ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
                             uct_ep_operation_t memtype_op, unsigned flags,
                             ptrdiff_t max_iov_offs, size_t min_iov,
-                            ucp_lane_type_t lane_type, uint64_t tl_cap_flags,
-                            ucp_lane_index_t max_lanes,
+                            ucp_lane_type_t lane_type,
+                            ucs_memory_type_t reg_mem_type,
+                            uint64_t tl_cap_flags, ucp_lane_index_t max_lanes,
                             ucp_lane_map_t exclude_map,
                             ucp_lane_index_t *lanes);
 

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -171,6 +171,7 @@ static void ucp_proto_amo_probe(const ucp_proto_init_params_t *init_params,
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AMO,
         .tl_cap_flags        = 0
     };

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -424,6 +424,7 @@ static void ucp_proto_amo_sw_probe(const ucp_proto_init_params_t *init_params,
         .super.flags         = flags | UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = 0
     };

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -95,6 +95,7 @@ ucp_proto_get_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -96,6 +96,7 @@ ucp_proto_get_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .max_lanes           = UCP_PROTO_RMA_MAX_BCOPY_LANES,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_BCOPY,
@@ -202,6 +203,7 @@ ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_RESPONSE |
                                UCP_PROTO_COMMON_INIT_FLAG_MIN_FRAG,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .max_lanes           = context->config.ext.max_rma_lanes,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -97,6 +97,7 @@ ucp_proto_put_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -70,6 +70,7 @@ ucp_proto_put_offload_short_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG   |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_RMA,
         .tl_cap_flags        = UCT_IFACE_FLAG_PUT_SHORT
     };
@@ -166,6 +167,7 @@ ucp_proto_put_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .max_lanes           = UCP_PROTO_RMA_MAX_BCOPY_LANES,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_BCOPY,
@@ -254,6 +256,7 @@ ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .max_lanes           = context->config.ext.max_rma_lanes,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_ZCOPY,

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -69,6 +69,11 @@ typedef struct {
 typedef struct {
     ucp_proto_rndv_ack_priv_t super;
 
+    /* Memory type of fragment buffers which are used by get/mtype and put/mtype
+     * protocols.
+     * TODO: Create a separate struct for mtype protocols and move it there. */
+    ucs_memory_type_t         frag_mem_type;
+
     /* Multi-lane common part. Must be the last field, see
        @ref ucp_proto_multi_priv_t */
     ucp_proto_multi_priv_t    mpriv;

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -114,6 +114,8 @@ static void ucp_rndv_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
+        .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -186,6 +188,8 @@ static void ucp_rndv_am_zcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY   |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+        .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY
     };

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -13,11 +13,9 @@
 
 
 static ucp_ep_h ucp_proto_rndv_mtype_ep(ucp_worker_t *worker,
+                                        ucs_memory_type_t frag_mem_type,
                                         ucs_memory_type_t buf_mem_type)
 {
-    ucs_memory_type_t frag_mem_type =
-                                 worker->context->config.ext.rndv_frag_mem_type;
-
     if (worker->mem_type_ep[buf_mem_type] != NULL) {
         return worker->mem_type_ep[buf_mem_type];
     }
@@ -27,15 +25,15 @@ static ucp_ep_h ucp_proto_rndv_mtype_ep(ucp_worker_t *worker,
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
+                          ucs_memory_type_t frag_mem_type,
                           ucp_md_map_t *mdesc_md_map_p, size_t *frag_size_p)
 {
-    ucp_worker_h worker             = init_params->worker;
-    ucp_context_h context           = worker->context;
-    ucs_memory_type_t mem_type      = init_params->select_param->mem_type;
-    ucs_memory_type_t frag_mem_type = context->config.ext.rndv_frag_mem_type;
+    ucp_worker_h worker        = init_params->worker;
+    ucp_context_h context      = worker->context;
+    ucs_memory_type_t mem_type = init_params->select_param->mem_type;
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
-        (ucp_proto_rndv_mtype_ep(worker, mem_type) == NULL) ||
+        (ucp_proto_rndv_mtype_ep(worker, frag_mem_type, mem_type) == NULL) ||
         !ucp_proto_init_check_op(init_params, UCP_PROTO_RNDV_OP_ID_MASK)) {
         return UCS_ERR_UNSUPPORTED;
     }
@@ -47,11 +45,10 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_proto_rndv_mtype_request_init(ucp_request_t *req)
+ucp_proto_rndv_mtype_request_init(ucp_request_t *req,
+                                  ucs_memory_type_t frag_mem_type)
 {
-    ucp_worker_h worker             = req->send.ep->worker;
-    ucs_memory_type_t frag_mem_type =
-                                 worker->context->config.ext.rndv_frag_mem_type;
+    ucp_worker_h worker = req->send.ep->worker;
 
     req->send.rndv.mdesc = ucp_rndv_mpool_get(worker, frag_mem_type,
                                               UCS_SYS_DEVICE_ID_UNKNOWN);
@@ -82,6 +79,7 @@ static ucp_ep_h ucp_proto_rndv_req_mtype_ep(ucp_request_t *req)
     ucp_ep_h mem_type_ep;
 
     mem_type_ep = ucp_proto_rndv_mtype_ep(req->send.ep->worker,
+                                          req->send.rndv.mdesc->memh->mem_type,
                                           req->send.state.dt_iter.mem_info.type);
     ucs_assert(mem_type_ep != NULL);
 
@@ -130,10 +128,12 @@ ucp_proto_rndv_mtype_next_iov(ucp_request_t *req,
 
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_mtype_copy(
         ucp_request_t *req, void *buffer, uct_mem_h memh,
-        uct_ep_put_zcopy_func_t copy_func, uct_completion_callback_t comp_func,
-        const char *mode)
+        ucs_memory_type_t frag_mem_type, uct_ep_put_zcopy_func_t copy_func,
+        uct_completion_callback_t comp_func, const char *mode)
 {
-    ucp_ep_h mtype_ep     = ucp_proto_rndv_req_mtype_ep(req);
+    ucp_ep_h mtype_ep     = ucp_proto_rndv_mtype_ep(
+                              req->send.ep->worker, frag_mem_type,
+                              req->send.state.dt_iter.mem_info.type);
     ucp_lane_index_t lane = ucp_ep_config(mtype_ep)->key.rma_bw_lanes[0];
     ucp_context_t UCS_V_UNUSED *context = req->send.ep->worker->context;
     ucs_status_t status;
@@ -142,7 +142,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_mtype_copy(
     ucp_trace_req(req, "buffer %p copy-%s %p %s-%s using memtype-ep %p lane[%d]",
                   buffer, mode, req->send.state.dt_iter.type.contig.buffer,
                   ucs_memory_type_names[req->send.state.dt_iter.mem_info.type],
-                  ucs_memory_type_names[context->config.ext.rndv_frag_mem_type],
+                  ucs_memory_type_names[frag_mem_type],
                   mtype_ep, lane);
 
     ucp_proto_completion_init(&req->send.state.uct_comp, comp_func);
@@ -167,20 +167,39 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_mtype_copy(
     return status;
 }
 
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_rndv_mdesc_mtype_copy(ucp_request_t *req,
+                                uct_ep_put_zcopy_func_t copy_func,
+                                uct_completion_callback_t comp_func,
+                                const char *mode)
+{
+    ucp_mem_desc_t *mdesc = req->send.rndv.mdesc;
+
+    return ucp_proto_rndv_mtype_copy(
+                 req, mdesc->ptr, ucp_proto_rndv_mtype_get_req_memh(req),
+                 mdesc->memh->mem_type, copy_func, comp_func, mode);
+}
+
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_rndv_mtype_query_desc(const ucp_proto_query_params_t *params,
+                                ucs_memory_type_t frag_mem_type,
                                 ucp_proto_query_attr_t *attr,
                                 const char *xfer_desc)
 {
     UCS_STRING_BUFFER_FIXED(strb, attr->desc, sizeof(attr->desc));
     ucp_context_h context      = params->worker->context;
     ucs_memory_type_t mem_type = params->select_param->mem_type;
-    ucp_ep_h mtype_ep          = ucp_proto_rndv_mtype_ep(params->worker,
-                                                         mem_type);
+    ucp_ep_h mtype_ep;
     ucp_lane_index_t lane;
     ucp_rsc_index_t rsc_index;
     const char *tl_name;
 
+    /* Make coverity happy */
+    ucs_assertv(frag_mem_type < UCS_MEMORY_TYPE_UNKNOWN, "frag_mem_type = %u",
+                frag_mem_type);
+
+    mtype_ep  = ucp_proto_rndv_mtype_ep(params->worker, frag_mem_type,
+                                        mem_type);
     ucs_assert(mtype_ep != NULL);
 
     lane      = ucp_ep_config(mtype_ep)->key.rma_bw_lanes[0];
@@ -196,6 +215,9 @@ ucp_proto_rndv_mtype_query_desc(const ucp_proto_query_params_t *params,
     if (ucp_proto_select_op_id(params->select_param) == UCP_OP_ID_RNDV_RECV) {
         ucs_string_buffer_appendf(&strb, ", %s", tl_name);
     }
+
+    ucs_string_buffer_appendf(&strb, ", frag %s",
+                              ucs_memory_type_names[frag_mem_type]);
 }
 
 #endif

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -93,6 +93,7 @@ ucp_proto_rndv_rkey_ptr_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_RKEY_PTR,
         .tl_cap_flags        = 0,
     };
@@ -253,6 +254,7 @@ ucp_proto_rndv_rkey_ptr_mtype_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS,
         .super.exclude_map   = (rkey_ptr_lane == UCP_NULL_LANE) ?
                                0 : UCS_BIT(rkey_ptr_lane),
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_LAST,
         .tl_cap_flags        = 0
     };
@@ -268,8 +270,9 @@ ucp_proto_rndv_rkey_ptr_mtype_probe(const ucp_proto_init_params_t *init_params)
         return;
     }
 
-    status = ucp_proto_rndv_mtype_init(init_params, &mdesc_md_map,
-                                       &params.super.max_length);
+    /* 2-stage ppln protocols work with host staging buffers only */
+    status = ucp_proto_rndv_mtype_init(init_params, UCS_MEMORY_TYPE_HOST,
+                                       &mdesc_md_map, &params.super.max_length);
     if (status != UCS_OK) {
         return;
     }
@@ -342,7 +345,7 @@ ucp_proto_rndv_rkey_ptr_mtype_copy_progress(uct_pending_req_t *uct_req)
 
     req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     ucp_proto_rndv_mtype_copy(req, ppln_data->local_ptr, ppln_data->uct_memh,
-                              uct_ep_get_zcopy,
+                              UCS_MEMORY_TYPE_HOST, uct_ep_get_zcopy,
                               ucp_proto_rndv_rkey_ptr_mtype_copy_completion,
                               "in from");
 
@@ -368,7 +371,7 @@ ucp_proto_rndv_rkey_ptr_mtype_query(const ucp_proto_query_params_t *params,
     const char *desc = UCP_PROTO_RNDV_RKEY_PTR_DESC;
 
     ucp_rndv_rkey_ptr_query_common(params, attr);
-    ucp_proto_rndv_mtype_query_desc(params, attr, desc);
+    ucp_proto_rndv_mtype_query_desc(params, UCS_MEMORY_TYPE_HOST, attr, desc);
 }
 
 ucp_proto_t ucp_rndv_rkey_ptr_mtype_proto = {

--- a/src/ucp/stream/stream_multi.c
+++ b/src/ucp/stream/stream_multi.c
@@ -92,6 +92,7 @@ ucp_stream_multi_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
@@ -165,6 +166,7 @@ ucp_stream_multi_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -70,6 +70,7 @@ static void ucp_proto_eager_bcopy_multi_common_probe(
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
@@ -241,6 +242,7 @@ ucp_proto_eager_zcopy_multi_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -67,6 +67,7 @@ ucp_proto_eager_short_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_SHORT
     };
@@ -139,6 +140,8 @@ ucp_proto_eager_bcopy_single_probe(const ucp_proto_init_params_t *init_params)
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+        .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -186,6 +189,7 @@ ucp_proto_eager_zcopy_single_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_ZCOPY
     };

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -65,6 +65,7 @@ static void ucp_proto_eager_tag_offload_short_probe(
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_TAG,
         .tl_cap_flags        = UCT_IFACE_FLAG_TAG_EAGER_SHORT
     };
@@ -139,6 +140,7 @@ static void ucp_proto_eager_tag_offload_bcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .lane_type           = UCP_LANE_TYPE_TAG,
         .tl_cap_flags        = UCT_IFACE_FLAG_TAG_EAGER_BCOPY
     };
@@ -249,6 +251,7 @@ static void ucp_proto_eager_tag_offload_zcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = init_params->select_param->mem_type,
         .lane_type           = UCP_LANE_TYPE_TAG,
         .tl_cap_flags        = UCT_IFACE_FLAG_TAG_EAGER_ZCOPY
     };

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -45,6 +45,7 @@ ucp_tag_rndv_offload_proto_probe(const ucp_proto_init_params_t *init_params)
                               UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                               UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
        .super.exclude_map   = 0,
+       .super.reg_mem_type  = init_params->select_param->mem_type,
        .lane_type           = UCP_LANE_TYPE_TAG,
        .tl_cap_flags        = UCT_IFACE_FLAG_TAG_RNDV_ZCOPY
     };
@@ -179,6 +180,7 @@ ucp_tag_rndv_offload_sw_proto_probe(const ucp_proto_init_params_t *init_params)
         .super.memtype_op    = UCT_EP_OP_LAST,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
         .super.exclude_map   = 0,
+        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .remote_op_id        = UCP_OP_ID_RNDV_RECV,
         .lane                = init_params->ep_config_key->tag_lane,
         .perf_bias           = context->config.ext.rndv_perf_diff / 100.0,

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -69,6 +69,7 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
 {
     const char *alloc_name;
     const uct_alloc_method_t *method;
+    ucs_log_level_t log_level;
     ucs_memory_type_t mem_type;
     uct_md_attr_t md_attr;
     ucs_status_t status;
@@ -101,6 +102,8 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
     mem_type     = (params->field_mask & UCT_MEM_ALLOC_PARAM_FIELD_MEM_TYPE) ?
                    params->mem_type : UCS_MEMORY_TYPE_HOST;
     alloc_length = length;
+    log_level    = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
+                   UCS_LOG_LEVEL_ERROR;
 
     ucs_trace("allocating %s: %s memory length %zu flags 0x%x", alloc_name,
               ucs_memory_type_names[mem_type], alloc_length, flags);
@@ -122,7 +125,7 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
                 md           = params->mds.mds[md_index];
                 status = uct_md_query(md, &md_attr);
                 if (status != UCS_OK) {
-                    ucs_error("Failed to query MD");
+                    ucs_log(log_level, "Failed to query MD");
                     goto out;
                 }
 
@@ -152,9 +155,10 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
                                           mem_type, flags, alloc_name,
                                           &memh);
                 if (status != UCS_OK) {
-                    ucs_error("failed to allocate %zu bytes using md %s for %s: %s",
-                              alloc_length, md->component->name,
-                              alloc_name, ucs_status_string(status));
+                    ucs_log(log_level,
+                            "failed to allocate %zu bytes using md %s for %s: %s",
+                            alloc_length, md->component->name, alloc_name,
+                            ucs_status_string(status));
                     goto out;
                 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -13,6 +13,30 @@
 #include <ucs/type/spinlock.h>
 #include <ucs/config/types.h>
 
+
+#if HAVE_CUDA_FABRIC
+typedef enum uct_cuda_ipc_key_handle {
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_ERROR = 0,
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, /* cudaMalloc memory */
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM, /* cuMemCreate memory */
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL /* cudaMallocAsync memory */
+} uct_cuda_ipc_key_handle_t;
+
+
+typedef struct uct_cuda_ipc_md_handle {
+    uct_cuda_ipc_key_handle_t handle_type;
+    union {
+        CUipcMemHandle        legacy;        /* Legacy IPC handle */
+        CUmemFabricHandle     fabric_handle; /* VMM/Mallocasync export handle */
+    } handle;
+    CUmemPoolPtrExportData    ptr;
+    CUmemoryPool              pool;
+} uct_cuda_ipc_md_handle_t;
+#else
+typedef CUipcMemHandle uct_cuda_ipc_md_handle_t;
+#endif
+
+
 /**
  * @brief cuda ipc MD descriptor
  */
@@ -21,6 +45,13 @@ typedef struct uct_cuda_ipc_md {
     ucs_ternary_auto_value_t enable_mnnvl;
 } uct_cuda_ipc_md_t;
 
+
+typedef struct uct_cuda_ipc_uuid_hash_key {
+    int     type;
+    CUuuid  uuid;
+} uct_cuda_ipc_uuid_hash_key_t;
+
+
 typedef struct {
     /* GPU Device number */
     int     dev_num;
@@ -28,21 +59,30 @@ typedef struct {
     uint8_t accessible[0];
 } uct_cuda_ipc_dev_cache_t;
 
-static UCS_F_ALWAYS_INLINE int uct_cuda_ipc_uuid_equals(CUuuid a, CUuuid b)
+
+static UCS_F_ALWAYS_INLINE int
+uct_cuda_ipc_uuid_equals(uct_cuda_ipc_uuid_hash_key_t key1,
+                         uct_cuda_ipc_uuid_hash_key_t key2)
 {
-    int64_t *a64 = (int64_t *)a.bytes;
-    int64_t *b64 = (int64_t *)b.bytes;
-    return (a64[0] == b64[0]) && (a64[1] == b64[1]);
+    int64_t *a64 = (int64_t *)key1.uuid.bytes;
+    int64_t *b64 = (int64_t *)key2.uuid.bytes;
+
+    return (key1.type == key2.type) && (a64[0] == b64[0]) && (a64[1] == b64[1]);
 }
 
-static UCS_F_ALWAYS_INLINE khint32_t uct_cuda_ipc_uuid_hash_func(CUuuid key)
+
+static UCS_F_ALWAYS_INLINE khint32_t
+uct_cuda_ipc_uuid_hash_func(uct_cuda_ipc_uuid_hash_key_t key)
 {
-    int64_t *i64 = (int64_t *)key.bytes;
-    return kh_int64_hash_func(i64[0] ^ i64[1]);
+    int64_t *i64 = (int64_t *)key.uuid.bytes;
+    return kh_int64_hash_func(i64[0] ^ i64[1] ^ key.type);
 }
 
-KHASH_INIT(cuda_ipc_uuid_hash, CUuuid, uct_cuda_ipc_dev_cache_t*, 1,
-           uct_cuda_ipc_uuid_hash_func, uct_cuda_ipc_uuid_equals);
+
+KHASH_INIT(cuda_ipc_uuid_hash, uct_cuda_ipc_uuid_hash_key_t,
+           uct_cuda_ipc_dev_cache_t*, 1, uct_cuda_ipc_uuid_hash_func,
+           uct_cuda_ipc_uuid_equals);
+
 
 /**
  * @brief cuda ipc component extension
@@ -72,29 +112,6 @@ typedef struct {
     int             dev_num; /* GPU Device number */
     ucs_list_link_t list;
 } uct_cuda_ipc_memh_t;
-
-
-#if HAVE_CUDA_FABRIC
-typedef enum uct_cuda_ipc_key_handle {
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_ERROR = 0,
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, /* cudaMalloc memory */
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM, /* cuMemCreate memory */
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL /* cudaMallocAsync memory */
-} uct_cuda_ipc_key_handle_t;
-
-
-typedef struct uct_cuda_ipc_md_handle {
-    uct_cuda_ipc_key_handle_t handle_type;
-    union {
-        CUipcMemHandle        legacy;        /* Legacy IPC handle */
-        CUmemFabricHandle     fabric_handle; /* VMM/Mallocasync export handle */
-    } handle;
-    CUmemPoolPtrExportData    ptr;
-    CUmemoryPool              pool;
-} uct_cuda_ipc_md_handle_t;
-#else
-typedef CUipcMemHandle uct_cuda_ipc_md_handle_t;
-#endif
 
 
 /**

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1184,8 +1184,11 @@ bool ucp_test_base::entity::has_lane_with_caps(uint64_t caps) const
 
 bool ucp_test_base::entity::is_rndv_put_ppln_supported() const
 {
-    const auto config          = ucp_ep_config(ep());
-    ucs_memory_type_t mem_type = ucph()->config.ext.rndv_frag_mem_type;
+    const auto config = ucp_ep_config(ep());
+    ucs_memory_type_t mem_type;
+
+    mem_type = (ucs_memory_type_t)ucs_ffs64(
+                                        ucph()->config.ext.rndv_frag_mem_types);
 
     for (auto i = 0; i < config->key.num_lanes; ++i) {
         const auto lane = config->key.rma_bw_lanes[i];


### PR DESCRIPTION
## What
Enable using cuda staging buffers for pipeline protocols by default.

## Why ?
Using ppln protocols with cuda staging buffers provides better performance for the following cases:
- sending data from cuda-managed memory to cuda memory
- sending data between different nodes where MNNVLK is available
- etc

## How ?
Rename `RNDV_FRAG_MEM_TYPE` to `RNDV_FRAG_MEM_TYPES` and allow to specify a list of memory types. Then initialize RNDV_RECEIVE protocol variants (rtr_mtype and get_mtype) with these memory types. RNDV_SEND protocol has to use the mem type which corresponds to the rkey from received RTR, because:
- We use different fragment sizes for different mem_types, so rtr_mtype and put_mtype sizes will be different which breaks the protocol
- Currently there is no strong use-case to support ppln protocols with different mem_type fragments being used by peers