### PR TITLE
DNR/AZP: Use ARM nodes whenever possible

### DIFF
--- a/buildlib/pr/codestyle.yml
+++ b/buildlib/pr/codestyle.yml
@@ -4,8 +4,7 @@ jobs:
     displayName: commit title
     pool:
       name: MLNX
-      demands:
-      - ucx_docker -equals yes
+      demands: ucx-arm64
     steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
## What
Offload certain jobs to ARM machines.

## Why ?
Improve resource utilization.
