### PR TITLE
GTEST: disable gdrcopy to avoid dmabuf failures - v1.17.x

### DIFF
--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -470,7 +470,7 @@ std::vector<ucp_test_param> enum_test_params(const std::string& tls)
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, rcx, \
                                             "rc_x") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib, \
-                                            "shm,ib,gdr_copy") \
+                                            "shm,ib") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, shm_ib_ipc, \
                                             "shm,ib,cuda_ipc,rocm_ipc") \
     UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(_test_case, ugni, \

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -493,8 +493,7 @@ protected:
     knem
 
 #define UCT_TEST_CUDA_MEM_TYPE_TLS \
-    cuda_copy,              \
-    gdr_copy
+    cuda_copy
 
 #define UCT_TEST_ROCM_MEM_TYPE_TLS \
     rocm_copy


### PR DESCRIPTION
## What
disable gdrcopy to avoid dmabuf failures, like:
```
[ RUN      ] shm_ib/test_ucp_am_nbx_eager_memtype.basic/19 <shm,ib,gdr_copy,cuda_copy,rocm_copy/proto_v1/prereg/cuda/cuda>
[1724858288.255042] [swx-rdmz-ucx-gpu-02:70262:0]           ib_md.c:293  UCX  ERROR ibv_reg_dmabuf_mr(address=0x7f3245200000, length=65536, access=0xf) failed: Invalid argument
[1724858288.255086] [swx-rdmz-ucx-gpu-02:70262:0]          ucp_mm.c:70   UCX  ERROR failed to register address 0x7f3245200000 (cuda) length 65536 dmabuf_fd 103 on md[3]=mlx5_0: Input/output error (md supports: host|cuda)
/__w/2/s/contrib/../test/gtest/ucp/ucp_test.cc:1057: Failure
Error: Input/output error
/__w/2/s/contrib/../test/gtest/common/test.cc:366: Failure
Failed
 ```