### PR TITLE
UCP/RCACHE: Preserve uct_flags from memory regions we merge with - v1.17.x

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -25,7 +25,7 @@
 
 /* Mask of UCT memory flags that need make sure are present when reusing an
    existing region */
-#define UCP_MM_UCT_ACCESS_MASK UCT_MD_MEM_ACCESS_ALL
+#define UCP_MM_UCT_ACCESS_FLAGS(_flags) ((_flags) & UCT_MD_MEM_ACCESS_ALL)
 
 
 /**

--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -58,9 +58,9 @@ ucp_memh_get(ucp_context_h context, void *address, size_t length,
 
         memh = ucs_derived_of(rregion, ucp_mem_t);
         if (ucs_likely(ucs_test_all_flags(memh->md_map, reg_md_map)) &&
-            ucs_likely(ucs_test_all_flags(
-                    memh->uct_flags,
-                    uct_flags & UCP_MM_UCT_ACCESS_MASK))) {
+            ucs_likely(
+                    ucs_test_all_flags(memh->uct_flags,
+                                       UCP_MM_UCT_ACCESS_FLAGS(uct_flags)))) {
             ucp_memh_rcache_print(memh, address, length);
             *memh_p = memh;
             UCP_THREAD_CS_EXIT(&context->mt_lock);

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -82,7 +82,7 @@ struct ucs_rcache_ops {
     /**
      * Register a memory region.
      *
-     * @param [in]  context    User context, as passed to @ref ucs_rcache_create
+     * @param [in]  context    User context, as passed to @ref ucs_rcache_create().
      * @param [in]  rcache     Pointer to the registration cache.
      * @param [in]  arg        Custom argument passed to @ref ucs_rcache_get().
      * @param [in]  region     Memory region to register. This may point to a larger
@@ -101,25 +101,37 @@ struct ucs_rcache_ops {
     ucs_status_t           (*mem_reg)(void *context, ucs_rcache_t *rcache,
                                       void *arg, ucs_rcache_region_t *region,
                                       uint16_t flags);
-   /**
-    * Deregister a memory region.
-    *
-    * @param [in]  context    User context, as passed to @ref ucs_rcache_create
-    * @param [in]  rcache     Pointer to the registration cache.
-    * @param [in]  region     Memory region to deregister.
-    */
+    /**
+     * Deregister a memory region.
+     *
+     * @param [in]  context  User context, as passed to @ref ucs_rcache_create().
+     * @param [in]  rcache   Pointer to the registration cache.
+     * @param [in]  region   Memory region to deregister.
+     */
     void                   (*mem_dereg)(void *context, ucs_rcache_t *rcache,
                                         ucs_rcache_region_t *region);
+
+    /**
+     * Called in the context of region lookup, for every existing region that
+     * we are potentially merging with.
+     *
+     * @param [in]  context  User context, as passed to @ref ucs_rcache_create().
+     * @param [in]  rcache   Pointer to the registration cache.
+     * @param [in]  arg      Custom argument passed to @ref ucs_rcache_get().
+     * @param [in]  region   Memory region we are merging with.
+     */
+    void                   (*merge)(void *context, ucs_rcache_t *rcache,
+                                    void *arg, ucs_rcache_region_t *region);
 
     /**
      * Dump memory region information to a string buffer.
      * (Only the user-defined part of the memory region should be dumped)
      *
-     * @param [in]  context    User context, as passed to @ref ucs_rcache_create
-     * @param [in]  rcache     Pointer to the registration cache.
-     * @param [in]  region    Memory region to dump.
-     * @param [in]  buf       String buffer to dump to.
-     * @param [in]  max       Maximal length of the string buffer.
+     * @param [in]  context  User context, as passed to @ref ucs_rcache_create().
+     * @param [in]  rcache   Pointer to the registration cache.
+     * @param [in]  region   Memory region to dump.
+     * @param [in]  buf      String buffer to dump to.
+     * @param [in]  max      Maximal length of the string buffer.
      */
     void                   (*dump_region)(void *context, ucs_rcache_t *rcache,
                                           ucs_rcache_region_t *region,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -408,6 +408,7 @@ static void uct_gdr_copy_rcache_dump_region_cb(void *context,
 static ucs_rcache_ops_t uct_gdr_copy_rcache_ops = {
     .mem_reg     = uct_gdr_copy_rcache_mem_reg_cb,
     .mem_dereg   = uct_gdr_copy_rcache_mem_dereg_cb,
+    .merge       = (void*)ucs_empty_function,
     .dump_region = uct_gdr_copy_rcache_dump_region_cb
 };
 

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -389,6 +389,7 @@ static void uct_rocm_copy_rcache_dump_region_cb(void *context, ucs_rcache_t *rca
 static ucs_rcache_ops_t uct_rocm_copy_rcache_ops = {
     .mem_reg     = uct_rocm_copy_rcache_mem_reg_cb,
     .mem_dereg   = uct_rocm_copy_rcache_mem_dereg_cb,
+    .merge       = (void*)ucs_empty_function,
     .dump_region = uct_rocm_copy_rcache_dump_region_cb
 };
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -181,6 +181,7 @@ static void uct_xpmem_rcache_dump_region(void *context, ucs_rcache_t *rcache,
 static ucs_rcache_ops_t uct_xpmem_rcache_ops = {
     .mem_reg     = uct_xpmem_rcache_mem_reg,
     .mem_dereg   = uct_xpmem_rcache_mem_dereg,
+    .merge       = (void*)ucs_empty_function,
     .dump_region = uct_xpmem_rcache_dump_region
 };
 

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -93,7 +93,7 @@ protected:
 
     virtual ucs_rcache_params_t rcache_params()
     {
-        static const ucs_rcache_ops_t ops = {mem_reg_cb, mem_dereg_cb,
+        static const ucs_rcache_ops_t ops = {mem_reg_cb, mem_dereg_cb, merge_cb,
                                              dump_region_cb};
         ucs_rcache_params_t params        = get_default_rcache_params(this, &ops);
         params.region_struct_size         = sizeof(region);
@@ -206,6 +206,11 @@ private:
     {
         reinterpret_cast<test_rcache*>(context)->mem_dereg(
                         ucs_derived_of(r, struct region));
+    }
+
+    static void merge_cb(void *context, ucs_rcache_t *rcache, void *arg,
+                         ucs_rcache_region_t *r)
+    {
     }
 
     static void dump_region_cb(void *context, ucs_rcache_t *rcache,


### PR DESCRIPTION
## What
backport #9859, cherry-picked, minor function prototype conflict
