### PR TITLE
Update cuda_copy and gdr_copy perf estimates for coherent platforms

### DIFF
--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -61,6 +61,34 @@ err:
     *sys_dev_p = UCS_SYS_DEVICE_ID_UNKNOWN;
 }
 
+int uct_cuda_base_is_coherent()
+{
+    CUdevice cu_device;
+    int coherent;
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cu_device, 0));
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuDeviceGetAttribute(&coherent,
+                                 CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
+                                 cu_device));
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return coherent;
+}
+
+int uct_cuda_base_have_c2c()
+{
+    /* TODO: not all coherent platforms have C2C; use nvml to check for it */
+    return uct_cuda_base_is_coherent();
+}
+
 ucs_status_t
 uct_cuda_base_query_md_resources(uct_component_t *component,
                                  uct_md_resource_desc_t **resources_p,

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -42,4 +42,20 @@ uct_cuda_base_query_devices(uct_md_h md,
  */
 ucs_status_t uct_cuda_base_check_device_name(const uct_iface_params_t *params);
 
+
+/**
+ * Check whether the platform is coherent.
+ *
+ * @return 1 if coherent, or 0 otherwise.
+ */
+int uct_cuda_base_is_coherent();
+
+
+/**
+ * Check for the existence of C2C links between CPU and GPU.
+ *
+ * @return 1 if have C2C links, or 0 otherwise.
+ */
+int uct_cuda_base_have_c2c();
+
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -44,7 +44,6 @@ static ucs_config_field_t uct_cuda_copy_iface_config_table[] = {
     {NULL}
 };
 
-
 /* Forward declaration for the delete function */
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_iface_t)(uct_iface_t*);
 
@@ -397,14 +396,15 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->bandwidth.dedicated = 0;
         if ((src_mem_type == UCS_MEMORY_TYPE_HOST) &&
             (dst_mem_type == UCS_MEMORY_TYPE_CUDA)) {
-            perf_attr->bandwidth.shared = (zcopy ? 8300.0 : 7900.0) * UCS_MBYTE;
+            perf_attr->bandwidth.shared = zcopy ? iface->bw.h2d_zcopy :
+                                          iface->bw.h2d;
         } else if ((src_mem_type == UCS_MEMORY_TYPE_CUDA) &&
                    (dst_mem_type == UCS_MEMORY_TYPE_HOST)) {
-            perf_attr->bandwidth.shared = (zcopy ? 11660.0 : 9320.0) *
-                                          UCS_MBYTE;
+            perf_attr->bandwidth.shared = zcopy ? iface->bw.d2h_zcopy :
+                                          iface->bw.d2h;
         } else if ((src_mem_type == UCS_MEMORY_TYPE_CUDA) &&
                    (dst_mem_type == UCS_MEMORY_TYPE_CUDA)) {
-            perf_attr->bandwidth.shared = 320.0 * UCS_GBYTE;
+            perf_attr->bandwidth.shared = iface->bw.d2d;
         } else {
             perf_attr->bandwidth.shared = iface->config.bandwidth;
         }
@@ -439,6 +439,20 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     }
 
     return UCS_OK;
+}
+
+static void uct_cuda_copy_iface_set_bw_vals(uct_cuda_copy_iface_t *iface)
+{
+   const uct_cuda_copy_md_t *md = ucs_derived_of(iface->super.super.md,
+                                                 uct_cuda_copy_md_t);
+    iface->bw.d2d       = 320.0 * UCS_GBYTE;
+    iface->bw.h2d_zcopy = (md->have_c2c ? 400000.0 : 8300.0)  * UCS_MBYTE;
+    iface->bw.d2h_zcopy = (md->have_c2c ? 400000.0 : 11660.0) * UCS_MBYTE;
+    /* non-zcopy operations invoke stream synchronizaion every time. Therefore,
+     * we set a lower bandwidth for them compared to the zcopy versions.
+     */
+    iface->bw.h2d       = iface->bw.h2d_zcopy * 0.95;
+    iface->bw.d2h       = iface->bw.d2h_zcopy * 0.95;
 }
 
 static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
@@ -507,6 +521,7 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
 
     self->short_stream = 0;
     self->cuda_context = 0;
+    uct_cuda_copy_iface_set_bw_vals(self);
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -76,6 +76,14 @@ typedef struct uct_cuda_copy_iface {
         void                    *event_arg;
         uct_async_event_cb_t    event_cb;
     } async;
+    /* bandwidth values used for perf estimate */
+    struct {
+        double d2d;
+        double h2d;
+        double d2h;
+        double h2d_zcopy;
+        double d2h_zcopy;
+    } bw;
 
     /* 2D bitmap representing which streams in queue_desc matrix 
        should sync during flush */

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -833,6 +833,7 @@ uct_cuda_copy_md_open(uct_component_t *component, const char *md_name,
     md->config.dmabuf_supported = 0;
     md->sync_memops_set         = 0;
     md->granularity             = SIZE_MAX;
+    md->have_c2c                = uct_cuda_base_have_c2c();
 
     if ((config->cuda_async_mem_type != UCS_MEMORY_TYPE_CUDA) &&
         (config->cuda_async_mem_type != UCS_MEMORY_TYPE_CUDA_MANAGED)) {

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -27,6 +27,7 @@ typedef struct uct_cuda_copy_md {
     struct uct_md                super;           /* Domain info */
     int                          sync_memops_set;
     size_t                       granularity;     /* allocation granularity */
+    int                          have_c2c;
     struct {
         ucs_on_off_auto_value_t  alloc_whole_reg; /* force return of allocation
                                                      range even for small bar

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -77,24 +77,7 @@ static ucs_status_t uct_cuda_ipc_iface_get_address(uct_iface_h tl_iface,
 #if HAVE_CUDA_FABRIC
 static int uct_cuda_ipc_iface_is_mnnvl_supported(uct_cuda_ipc_md_t *md)
 {
-    CUdevice cu_device;
-    int coherent;
-    ucs_status_t status;
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cu_device, 0));
-    if (status != UCS_OK) {
-        return 0;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(
-            cuDeviceGetAttribute(&coherent,
-                                 CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
-                                 cu_device));
-    if (status != UCS_OK) {
-        return 0;
-    }
-
-    return coherent && (md->enable_mnnvl != UCS_NO);
+    return uct_cuda_base_is_coherent() && (md->enable_mnnvl != UCS_NO);
 }
 #endif
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -16,10 +16,7 @@
 #include <ucs/sys/string.h>
 
 
-#define UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH (6911.0 * UCS_MBYTE)
 #define UCT_GDR_COPY_IFACE_OVERHEAD          0
-#define UCT_GDR_COPY_IFACE_GET_LATENCY       ucs_linear_func_make(1.4e-6, 0)
-#define UCT_GDR_COPY_IFACE_PUT_LATENCY       ucs_linear_func_make(0.4e-6, 0)
 
 static ucs_config_field_t uct_gdr_copy_iface_config_table[] = {
 
@@ -100,9 +97,9 @@ uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.am.max_iov          = 1;
 
     /* Report GET latency by default as worst case */
-    iface_attr->latency                 = UCT_GDR_COPY_IFACE_GET_LATENCY;
+    iface_attr->latency                 = iface->bw_lat.get_lat;
     iface_attr->bandwidth.dedicated     = 0;
-    iface_attr->bandwidth.shared        = UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
+    iface_attr->bandwidth.shared        = iface->bw_lat.put_bw;
     iface_attr->overhead                = UCT_GDR_COPY_IFACE_OVERHEAD;
     iface_attr->priority                = 0;
 
@@ -110,19 +107,21 @@ uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 }
 
 static ucs_status_t
-uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
+uct_gdr_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 {
-    uct_ep_operation_t op = UCT_ATTR_VALUE(PERF, perf_attr, operation,
-                                           OPERATION, UCT_EP_OP_LAST);
+    uct_ep_operation_t op             = UCT_ATTR_VALUE(PERF, perf_attr,
+                                                       operation, OPERATION,
+                                                       UCT_EP_OP_LAST);
+    const uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface,
+                                                       uct_gdr_copy_iface_t);
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
         if ((op == UCT_EP_OP_GET_SHORT) || (op == UCT_EP_OP_GET_ZCOPY)) {
-            perf_attr->bandwidth.dedicated = 250.0 * UCS_MBYTE;
+            perf_attr->bandwidth.dedicated = iface->bw_lat.get_bw;
             perf_attr->bandwidth.shared    = 0;
         } else {
             perf_attr->bandwidth.dedicated = 0;
-            perf_attr->bandwidth.shared    =
-                    UCT_GDR_COPY_IFACE_DEFAULT_BANDWIDTH;
+            perf_attr->bandwidth.shared    = iface->bw_lat.put_bw;
         }
     }
 
@@ -140,9 +139,9 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
         if (op == UCT_EP_OP_PUT_SHORT) {
-            perf_attr->latency = UCT_GDR_COPY_IFACE_PUT_LATENCY;
+            perf_attr->latency = iface->bw_lat.put_lat;
         } else {
-            perf_attr->latency = UCT_GDR_COPY_IFACE_GET_LATENCY;
+            perf_attr->latency = iface->bw_lat.get_lat;
         }
     }
 
@@ -155,6 +154,24 @@ uct_gdr_copy_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
     }
 
     return UCS_OK;
+}
+
+static void uct_gdr_copy_iface_set_bw_lat_vals(uct_gdr_copy_iface_t *iface)
+{
+    const uct_gdr_copy_md_t *md = ucs_derived_of(iface->super.md,
+                                                 uct_gdr_copy_md_t);
+
+    if (md->have_c2c) {
+        iface->bw_lat.get_bw  = 8170.0  * UCS_MBYTE;
+        iface->bw_lat.put_bw  = 13930.0 * UCS_MBYTE;
+        iface->bw_lat.get_lat = ucs_linear_func_make(0.003e-6, 0);
+        iface->bw_lat.put_lat = iface->bw_lat.get_lat;
+    } else {
+        iface->bw_lat.get_bw  = 250.0  * UCS_MBYTE;
+        iface->bw_lat.put_bw  = 6911.0 * UCS_MBYTE;
+        iface->bw_lat.get_lat = ucs_linear_func_make(1.4e-6, 0);
+        iface->bw_lat.put_lat = ucs_linear_func_make(0.4e-6, 0);
+    }
 }
 
 static uct_iface_ops_t uct_gdr_copy_iface_ops = {
@@ -206,6 +223,7 @@ static UCS_CLASS_INIT_FUNC(uct_gdr_copy_iface_t, uct_md_h md, uct_worker_h worke
     }
 
     self->id = ucs_generate_uuid((uintptr_t)self);
+    uct_gdr_copy_iface_set_bw_lat_vals(self);
 
     return UCS_OK;
 }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.h
@@ -15,6 +15,14 @@ typedef uint64_t uct_gdr_copy_iface_addr_t;
 typedef struct uct_gdr_copy_iface {
     uct_base_iface_t            super;
     uct_gdr_copy_iface_addr_t   id;
+    /* bandwidth and latency values used for perf estimate */
+    struct {
+        double            get_bw;
+        double            put_bw;
+        ucs_linear_func_t get_lat;
+        ucs_linear_func_t put_lat;
+    } bw_lat;
+
 } uct_gdr_copy_iface_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -460,6 +460,7 @@ uct_gdr_copy_md_create(uct_component_t *component,
 
     md->super.ops = &uct_gdr_copy_md_rcache_ops;
     md->reg_cost  = UCS_LINEAR_FUNC_ZERO;
+    md->have_c2c  = uct_cuda_base_have_c2c();
 
 out:
     *md_p = md;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -22,6 +22,7 @@ typedef struct {
     gdr_t               gdrcpy_ctx; /**< gdr copy context */
     ucs_linear_func_t   reg_cost;   /**< Memory registration cost */
     ucs_rcache_t        *rcache;    /**< Registration cache */
+    int                 have_c2c;
 } uct_gdr_copy_md_t;
 
 


### PR DESCRIPTION
## What
Update cuda_copy and gdr_copy perf estimates for coherent platforms 

## Why ?
The bandwidth and latency values will be different for PCIe versus C2C links that connect CPU and GPU. 

## How ?
Check for the existence of C2C links and update the values accordingly.
