### PR TITLE
DEBIAN: Add libuct_ib_mlx5.so to package

### DIFF
--- a/debian/ucx.install
+++ b/debian/ucx.install
@@ -5,6 +5,7 @@ usr/lib/cmake
 usr/lib/pkgconfig
 usr/lib/ucx/libuct_cma.*
 usr/lib/ucx/libuct_ib.*
+usr/lib/ucx/libuct_ib_mlx5.*
 usr/lib/ucx/libuct_rdmacm.*
 # FIXME: this really should go under docs or examples:
 usr/share/*


### PR DESCRIPTION
## What
Also package UCT mlx5 library for Debian.

Internal issue: [4054962](https://redmine.mellanox.com/issues/4054962)
## How ?
Tested:
```
dpkg-buildpackage -us -uc
dpkg --contents ucx_1.18.1f91c55_amd64.deb | grep uct_mlx5
```