### PR TITLE
UCS/CONFIG: Use uint64_t to parse configuration bitmaps

### DIFF
--- a/src/ucm/api/ucm.h
+++ b/src/ucm/api/ucm.h
@@ -213,7 +213,7 @@ typedef struct ucm_global_config {
     ucm_mmap_hook_mode_t mmap_hook_mode;              /* MMAP hook mode */
     int                  enable_malloc_hooks;         /* Enable installing malloc hooks */
     int                  enable_malloc_reloc;         /* Enable installing malloc relocations */
-    int                  cuda_hook_modes;             /* Bitmap of allowed cuda hooks modes */
+    uint64_t             cuda_hook_modes;             /* Bitmap of allowed cuda hooks modes */
     int                  enable_dynamic_mmap_thresh;  /* Enable adaptive mmap threshold */
     size_t               alloc_alignment;             /* Alignment for memory allocations */
     int                  dlopen_process_rpath;        /* Process RPATH section in dlopen hook */

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -147,7 +147,7 @@ typedef struct ucp_context_config {
     /** Enable indirect IDs to object pointers in wire protocols */
     ucs_on_off_auto_value_t                proto_indirect_id;
     /** Bitmap of memory types whose allocations are registered fully */
-    unsigned                               reg_whole_alloc_bitmap;
+    uint64_t                               reg_whole_alloc_bitmap;
     /** Always use flush operation in rendezvous put */
     int                                    rndv_put_force_flush;
     /** Maximum size of mem type direct rndv*/

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -54,7 +54,7 @@ typedef struct {
     int                        mpool_fifo;
 
     /* Handle errors mode */
-    unsigned                   handle_errors;
+    uint64_t                   handle_errors;
 
     /* Error signals */
     UCS_CONFIG_ARRAY_FIELD(int, signals) error_signals;
@@ -105,7 +105,7 @@ typedef struct {
     size_t                     memtrack_limit;
 
     /* Profiling mode */
-    unsigned                   profile_mode;
+    uint64_t                   profile_mode;
 
     /* Profiling output file name */
     char                       *profile_file;

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -443,7 +443,7 @@ int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg)
     }
 
     ret = 1;
-    *((unsigned*)dest) = 0;
+    *((uint64_t*)dest) = 0;
     p = strtok_r(str, ",", &saveptr);
     while (p != NULL) {
         i = ucs_string_find_in_list(p, (const char**)arg, 0);
@@ -451,7 +451,10 @@ int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg)
             ret = 0;
             break;
         }
-        *((unsigned*)dest) |= UCS_BIT(i);
+
+        ucs_assertv(i < (sizeof(uint64_t) * 8), "bit %d overflows for '%s'", i,
+                    p);
+        *((uint64_t*)dest) |= UCS_BIT(i);
         p = strtok_r(NULL, ",", &saveptr);
     }
 
@@ -462,7 +465,7 @@ int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg)
 int ucs_config_sprintf_bitmap(char *buf, size_t max,
                               const void *src, const void *arg)
 {
-    ucs_flags_str(buf, max, *((unsigned*)src), (const char**)arg);
+    ucs_flags_str(buf, max, *((uint64_t*)src), (const char**)arg);
     return 1;
 }
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -186,7 +186,7 @@ typedef struct uct_ib_md_config {
 
     int                      mlx5dv; /**< mlx5 support */
     int                      devx; /**< DEVX support */
-    unsigned                 devx_objs;    /**< Objects to be created by DevX */
+    uint64_t                 devx_objs;    /**< Objects to be created by DevX */
     ucs_ternary_auto_value_t mr_relaxed_order; /**< Allow reorder memory accesses */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
     int                      xgvmi_umr_enable; /**< Enable UMR workflow for XGVMI */


### PR DESCRIPTION
## What
Align all users to `uint64_t` and validate bit ranges.

We were previously using `uint64_t` for one configuration instead of the then expected `unsigned`.