### PR TITLE
AZP: Temporarily disable althca tests for OS upgrade (v1.17.x)

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -270,10 +270,10 @@ stages:
   - stage: WireCompat
     dependsOn: [Static_check]
     jobs:
-    - template: wire_compat.yml
-      parameters:
-        name: althca
-        demands: ucx_althca -equals yes
+    # - template: wire_compat.yml
+    #   parameters:
+    #     name: althca
+    #     demands: ucx_althca -equals yes
     - template: wire_compat.yml
       parameters:
         name: gpu
@@ -305,11 +305,11 @@ stages:
   - stage: Tests
     dependsOn: [Static_check]
     jobs:
-    - template: tests.yml
-      parameters:
-        name: althca
-        demands: ucx_althca -equals yes
-        test_perf: 0
+    # - template: tests.yml
+    #   parameters:
+    #     name: althca
+    #     demands: ucx_althca -equals yes
+    #     test_perf: 0
     - template: tests.yml
       parameters:
         name: gpu


### PR DESCRIPTION
## What
Temporarily disable althca tests.

## Why ?
We have a single node for althca tests. Taking it offline for OS upgrade will cause all PRs to hang indefinitely.