### PR TITLE
UCP/EP/WIREUP: minor code cleanup

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -764,8 +764,9 @@ void ucp_worker_mem_type_eps_destroy(ucp_worker_h worker)
     UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
-ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
-                                       ucp_wireup_ep_t **wireup_ep)
+static ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep,
+                                              unsigned ep_init_flags,
+                                              ucp_wireup_ep_t **wireup_ep)
 {
     ucp_ep_config_key_t key;
     uct_ep_h uct_ep;

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -697,9 +697,6 @@ ucs_status_t
 ucp_ep_config_err_mode_check_mismatch(ucp_ep_h ep,
                                       ucp_err_handling_mode_t err_mode);
 
-ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep, unsigned ep_init_flags,
-                                       ucp_wireup_ep_t **wireup_ep);
-
 ucs_status_t
 ucp_ep_create_to_worker_addr(ucp_worker_h worker,
                              const ucp_tl_bitmap_t *local_tl_bitmap,


### PR DESCRIPTION
## What
define `ucp_ep_init_create_wireup` as static

## Why?
code cleanup, I noticed that `ucp_ep_init_create_wireup ` function is used only once
