### PR TITLE
STACK: Change PATH_MAX stack allocation to heap

### DIFF
--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1614,15 +1614,21 @@ void ucs_config_parse_config_file(const char *dir_path, const char *file_name,
         .section_info = {.name = "",
                          .skip = 0}
     };
-    char file_path[MAXPATHLEN];
+    char *file_path;
     int parse_result;
     FILE* file;
+    ucs_status_t status;
 
-    ucs_snprintf_safe(file_path, MAXPATHLEN, "%s/%s", dir_path, file_name);
+    status = ucs_string_alloc_formatted_path(&file_path, "file_path", "%s/%s",
+                                             dir_path, file_name);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
     file = fopen(file_path, "r");
     if (file == NULL) {
         ucs_debug("failed to open config file %s: %m", file_path);
-        return;
+        goto out_free_file_path;
     }
 
     parse_result = ini_parse_file(file, ucs_config_parse_config_file_line,
@@ -1633,6 +1639,11 @@ void ucs_config_parse_config_file(const char *dir_path, const char *file_name,
 
     ucs_debug("parsed config file %s", file_path);
     fclose(file);
+
+out_free_file_path:
+    ucs_free(file_path);
+out:
+    return;
 }
 
 static ucs_status_t
@@ -1750,18 +1761,26 @@ static ucs_status_t ucs_config_parser_get_sub_prefix(const char *env_prefix,
 
 void ucs_config_parse_config_files()
 {
-    const char *path_p;
-    char path[PATH_MAX];
+    char *path;
+    const char *path_p, *dirname;
+    ucs_status_t status;
 
     /* System-wide configuration file */
     ucs_config_parse_config_file(UCX_CONFIG_DIR, UCX_CONFIG_FILE_NAME, 1);
 
     /* Library dir */
     path_p = ucs_sys_get_lib_path();
+
     if (path_p != NULL) {
-        ucs_strncpy_safe(path, path_p, PATH_MAX);
-        ucs_config_parse_config_file(dirname(path),
+        status = ucs_string_alloc_path_buffer_and_get_dirname(&path, "path",
+                                                              path_p, &dirname);
+        if (status != UCS_OK) {
+            return;
+        }
+
+        ucs_config_parse_config_file(dirname,
                                      "../etc/ucx/" UCX_CONFIG_FILE_NAME, 1);
+        ucs_free(path);
     }
 
     /* User home dir */

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -433,10 +433,10 @@ void ucs_memtrack_init()
         return;
     }
 
+    ucs_memtrack_vfs_init();
+
     ucs_debug("memtrack enabled");
     ucs_memtrack_context.enabled = 1;
-
-    ucs_memtrack_vfs_init();
 }
 
 void ucs_memtrack_cleanup()
@@ -447,12 +447,11 @@ void ucs_memtrack_cleanup()
         return;
     }
 
-    ucs_vfs_obj_remove(&ucs_memtrack_context);
-
     ucs_memtrack_generate_report();
 
-    /* disable before releasing the stats node */
+    /* disable before releasing the vfs object and the stats node */
     ucs_memtrack_context.enabled = 0;
+    ucs_vfs_obj_remove(&ucs_memtrack_context);
     UCS_STATS_NODE_FREE(ucs_memtrack_context.stats);
 
     /* cleanup entries */

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -464,3 +464,42 @@ ucs_status_t ucs_string_alloc_path_buffer(char **buffer_p, const char *name)
     *buffer_p = temp_buffer;
     return UCS_OK;
 }
+
+ucs_status_t ucs_string_alloc_formatted_path(char **buffer_p, const char *name,
+                                             const char *fmt, ...)
+{
+    char *temp_buffer = NULL;
+    va_list ap;
+    ucs_status_t status;
+
+    status = ucs_string_alloc_path_buffer(&temp_buffer, name);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    va_start(ap, fmt);
+    ucs_vsnprintf_safe(temp_buffer, PATH_MAX, fmt, ap);
+    va_end(ap);
+
+    *buffer_p = temp_buffer;
+    return UCS_OK;
+}
+
+ucs_status_t ucs_string_alloc_path_buffer_and_get_dirname(char **buffer_p,
+                                                          const char *name,
+                                                          const char *path,
+                                                          const char **dir_p)
+{
+    ucs_status_t status;
+    char *buffer;
+
+    status = ucs_string_alloc_path_buffer(buffer_p, name);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    buffer = *buffer_p;
+    ucs_strncpy_safe(buffer, path, PATH_MAX);
+    *dir_p = dirname(buffer);
+    return UCS_OK;
+}

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -363,10 +363,43 @@ static inline int ucs_string_is_empty(const char *str)
  * Allocates a path buffer of size PATH_MAX.
  *
  * @param buffer_p Pointer to the buffer.
+ *                 The buffer is allocated and should be released by the caller.
  * @param name     Name of the buffer for logging.
- * @return         UCS_OK on success, UCS_ERR_NO_MEMORY on failure.
+ *
+ * @return UCS_OK on success, UCS_ERR_NO_MEMORY on failure.
  */
 ucs_status_t ucs_string_alloc_path_buffer(char **buffer_p, const char *name);
+
+/**
+ * Allocates a path buffer of size PATH_MAX and format a path string into it.
+ *
+ * @param buffer_p Pointer to the buffer.
+ *                 The buffer is allocated and should be released by the caller.
+ * @param name     Name of the buffer for logging.
+ * @param fmt      Format string for the path.
+ * @param ...      Arguments for the format string.
+ *
+ * @return UCS_OK on success, UCS_ERR_NO_MEMORY on failure.
+ */
+ucs_status_t ucs_string_alloc_formatted_path(char **buffer_p, const char *name,
+                                             const char *fmt, ...);
+
+/**
+ * Allocates a path buffer of size PATH_MAX and gets the directory name of a
+ * given path.
+ *
+ * @param buffer_p Pointer to the buffer.
+ *                The buffer is allocated and should be released by the caller.
+ * @param name     Name of the buffer for logging.
+ * @param path     Path to get the directory name from.
+ * @param dir_p    Pointer to the directory name.
+ *
+ * @return UCS_OK on success, UCS_ERR_NO_MEMORY on failure.
+ */
+ucs_status_t ucs_string_alloc_path_buffer_and_get_dirname(char **buffer_p,
+                                                          const char *name,
+                                                          const char *path,
+                                                          const char **dir_p);
 
 END_C_DECLS
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -244,9 +244,14 @@ uct_tcp_iface_is_reachable_v2(const uct_iface_h tl_iface,
 static const char *
 uct_tcp_iface_get_sysfs_path(const char *dev_name, char *path_buffer)
 {
+    const char *sysfs_path = NULL;
     ucs_status_t status;
-    const char *sysfs_path;
-    char lowest_path_buf[PATH_MAX];
+    char *lowest_path_buf;
+
+    status = ucs_string_alloc_path_buffer(&lowest_path_buf, "lowest_path_buf");
+    if (status != UCS_OK) {
+        goto out;
+    }
 
     /* Deep search to find the lowest device sysfs path:
      * 1) For regular device, use regular sysfs form.
@@ -255,11 +260,15 @@ uct_tcp_iface_get_sysfs_path(const char *dev_name, char *path_buffer)
     status = ucs_netif_get_lowest_device_path(dev_name, lowest_path_buf,
                                               PATH_MAX);
     if (status != UCS_OK) {
-        return NULL;
+        goto out_free_lowest_path_buf;
     }
 
     /* 'path_buffer' size is PATH_MAX */
     sysfs_path = ucs_topo_resolve_sysfs_path(lowest_path_buf, path_buffer);
+
+out_free_lowest_path_buf:
+    ucs_free(lowest_path_buf);
+out:
     return sysfs_path;
 }
 
@@ -272,14 +281,19 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
     ucs_status_t status;
     int is_default;
     double pci_bw, network_bw, calculated_bw;
-    char path_buffer[PATH_MAX];
+    char *path_buffer;
     const char *sysfs_path;
 
     uct_base_iface_query(&iface->super, attr);
 
     status = uct_tcp_netif_caps(iface->if_name, &attr->latency.c, &network_bw);
     if (status != UCS_OK) {
-        return status;
+        goto out;
+    }
+
+    status = ucs_string_alloc_path_buffer(&path_buffer, "path_buffer");
+    if (status != UCS_OK) {
+        goto out;
     }
 
     sysfs_path             = uct_tcp_iface_get_sysfs_path(iface->if_name, path_buffer);
@@ -339,7 +353,7 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
     if (iface->config.prefer_default) {
         status = uct_tcp_netif_is_default(iface->if_name, &is_default);
         if (status != UCS_OK) {
-             return status;
+            goto out_free_path_buffer;
         }
 
         attr->priority    = is_default ? 0 : 1;
@@ -347,7 +361,10 @@ static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
         attr->priority    = 0;
     }
 
-    return UCS_OK;
+out_free_path_buffer:
+    ucs_free(path_buffer);
+out:
+    return status;
 }
 
 static ucs_status_t uct_tcp_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p)
@@ -882,13 +899,25 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_tcp_iface_t, uct_iface_t, uct_md_h,
 
 static int uct_tcp_is_bridge(const char *if_name)
 {
-    char path[PATH_MAX];
+    char *path;
+    int ret;
     struct stat st;
+    ucs_status_t status;
 
-    ucs_snprintf_safe(path, PATH_MAX, UCT_TCP_IFACE_NETDEV_DIR "/%s/bridge",
-                      if_name);
+    status = ucs_string_alloc_formatted_path(&path, "path",
+                                             UCT_TCP_IFACE_NETDEV_DIR
+                                             "/%s/bridge",
+                                             if_name);
+    if (status != UCS_OK) {
+        ret = 0;
+        goto out;
+    }
 
-    return (stat(path, &st) == 0) && S_ISDIR(st.st_mode);
+    ret = (stat(path, &st) == 0) && S_ISDIR(st.st_mode);
+
+    ucs_free(path);
+out:
+    return ret;
 }
 
 ucs_status_t uct_tcp_query_devices(uct_md_h md,
@@ -903,7 +932,7 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
     int is_active, i, n;
     ucs_status_t status;
     const char *sysfs_path;
-    char path_buffer[PATH_MAX];
+    char *path_buffer;
     ucs_sys_device_t sys_dev;
 
     n = scandir(UCT_TCP_IFACE_NETDEV_DIR, &entries, NULL, alphasort);
@@ -915,6 +944,12 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
 
     devices     = NULL;
     num_devices = 0;
+
+    status = ucs_string_alloc_path_buffer(&path_buffer, "path_buffer");
+    if (status != UCS_OK) {
+        goto out;
+    }
+
     ucs_carray_for_each(entry, entries, n) {
         /* According to the sysfs(5) manual page, all of entries
          * has to be a symbolic link representing one of the real
@@ -977,6 +1012,7 @@ out_release:
     }
 
     free(entries);
+    ucs_free(path_buffer);
 out:
     return status;
 }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -456,12 +456,13 @@ bool is_inet_addr(const struct sockaddr* ifa_addr) {
 
 static bool netif_has_sysfs_file(const char *ifa_name, const char *file_name)
 {
-    char path[PATH_MAX];
-    ucs_snprintf_safe(path, sizeof(path), "/sys/class/net/%s/%s", ifa_name,
+    std::string path(PATH_MAX, '\0');
+
+    ucs_snprintf_safe(&path[0], path.size(), "/sys/class/net/%s/%s", ifa_name,
                       file_name);
 
     struct stat st;
-    return stat(path, &st) >= 0;
+    return stat(path.c_str(), &st) >= 0;
 }
 
 bool is_interface_usable(struct ifaddrs *ifa)

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -903,17 +903,18 @@ UCS_TEST_P(test_pci_bw, get_pci_bw)
 {
     ucp_worker_h worker = sender().worker();
     ucp_context_h ctx   = worker->context;
-    char path_buffer[PATH_MAX];
+    std::string path_buffer(PATH_MAX, '\0');
     const ucp_worker_iface_t *wiface;
 
     for (auto i = 0; i < worker->num_ifaces; ++i) {
-        wiface                 = worker->ifaces[i];
-        const auto dev_name    = ctx->tl_rscs[wiface->rsc_index].tl_rsc.dev_name;
-        const auto tcp_device  = get_tcp_device(dev_name);
-        const auto dev_path    = !tcp_device.empty() ? tcp_device :
-                                                          get_ib_device(dev_name);
+        wiface              = worker->ifaces[i];
+        const auto dev_name = ctx->tl_rscs[wiface->rsc_index].tl_rsc.dev_name;
+        const auto tcp_device = get_tcp_device(dev_name);
+        const auto dev_path   = !tcp_device.empty() ? tcp_device :
+                                                        get_ib_device(dev_name);
+
         const char *sysfs_path = ucs_topo_resolve_sysfs_path(dev_path.c_str(),
-                                                             path_buffer);
+                                                             &path_buffer[0]);
         const double pci_bw    = ucs_topo_get_pci_bw(dev_name, sysfs_path);
 
         uct_iface_attr_t attr;

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -64,9 +64,10 @@ UCS_TEST_F(test_string, common_prefix_len) {
 }
 
 UCS_TEST_F(test_string, path) {
-    char path[PATH_MAX];
-    ucs_path_get_common_parent("/sys/dev/one", "/sys/dev/two", path);
-    EXPECT_STREQ("/sys/dev", path);
+    std::string path(PATH_MAX, '\0');
+
+    ucs_path_get_common_parent("/sys/dev/one", "/sys/dev/two", &path[0]);
+    EXPECT_STREQ("/sys/dev", path.c_str());
 
     EXPECT_EQ(4, ucs_path_calc_distance("/root/foo/bar", "/root/charlie/fox"));
     EXPECT_EQ(2, ucs_path_calc_distance("/a/b/c/d", "/a/b/c/e"));


### PR DESCRIPTION
## What?
This PR changes all stack allocations of char arrays sized `PATH_MAX` to heap allocations.

## Why?
Customers with limited stack sizes have recently experienced stack overflow issues when running UCX. Moving these allocations to the heap prevents such overflows.

## How?
Heap allocations replace stack allocations for char arrays of size `PATH_MAX`.
