### PR TITLE
UCS/TOPO: change topo.c stack allocation to heap

### DIFF
--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -451,3 +451,16 @@ char* ucs_string_split(char *str, const char *delim, int count, ...)
 
     return p;
 }
+
+ucs_status_t ucs_string_alloc_path_buffer(char **buffer_p, const char *name)
+{
+    char *temp_buffer = ucs_malloc(PATH_MAX, name);
+
+    if (temp_buffer == NULL) {
+        ucs_error("failed to allocate memory for %s", name);
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    *buffer_p = temp_buffer;
+    return UCS_OK;
+}

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -359,6 +359,15 @@ static inline int ucs_string_is_empty(const char *str)
     return *str == '\0';
 }
 
+/**
+ * Allocates a path buffer of size PATH_MAX.
+ *
+ * @param buffer_p Pointer to the buffer.
+ * @param name     Name of the buffer for logging.
+ * @return         UCS_OK on success, UCS_ERR_NO_MEMORY on failure.
+ */
+ucs_status_t ucs_string_alloc_path_buffer(char **buffer_p, const char *name);
+
 END_C_DECLS
 
 #endif

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -207,34 +207,55 @@ ucs_topo_bus_id_to_sysfs_path(const ucs_sys_bus_id_t *bus_id, char *path,
                               size_t max)
 {
     const size_t prefix_length = strlen(UCS_TOPO_SYSFS_PCI_PREFIX);
-    char link_path[PATH_MAX];
+    ucs_status_t status;
+    char *link_path;
 
-    if (max < PATH_MAX) {
-        return UCS_ERR_BUFFER_TOO_SMALL;
+    status = ucs_string_alloc_path_buffer(&link_path, "link_path");
+    if (status != UCS_OK) {
+        goto out;
     }
 
-    ucs_strncpy_safe(link_path, UCS_TOPO_SYSFS_PCI_PREFIX, sizeof(link_path));
+    if (max < PATH_MAX) {
+        status = UCS_ERR_BUFFER_TOO_SMALL;
+        goto out_free_link_path;
+    }
+
+    ucs_strncpy_safe(link_path, UCS_TOPO_SYSFS_PCI_PREFIX, PATH_MAX);
     ucs_topo_bus_id_str(bus_id, 0, link_path + prefix_length,
                         PATH_MAX - prefix_length);
     if (realpath(link_path, path) == NULL) {
-        return UCS_ERR_IO_ERROR;
+        status = UCS_ERR_IO_ERROR;
     }
 
-    return UCS_OK;
+out_free_link_path:
+    ucs_free(link_path);
+out:
+    return status;
 }
 
 static int
 ucs_topo_read_device_numa_node(const ucs_sys_bus_id_t *bus_id)
 {
-    char path[PATH_MAX];
+    int numa_node = UCS_NUMA_NODE_UNDEFINED;
+    char *path;
     ucs_status_t status;
 
-    status = ucs_topo_bus_id_to_sysfs_path(bus_id, path, sizeof(path));
+    status = ucs_string_alloc_path_buffer(&path, "sysfs_path");
     if (status != UCS_OK) {
-        return UCS_NUMA_NODE_UNDEFINED;
+        goto out;
     }
 
-    return ucs_numa_node_of_device(path);
+    status = ucs_topo_bus_id_to_sysfs_path(bus_id, path, PATH_MAX);
+    if (status != UCS_OK) {
+        goto out_free_path;
+    }
+
+    numa_node = ucs_numa_node_of_device(path);
+
+out_free_path:
+    ucs_free(path);
+out:
+    return numa_node;
 }
 
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
@@ -367,8 +388,23 @@ ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
                             ucs_sys_device_t device2,
                             ucs_sys_dev_distance_t *distance)
 {
-    char path1[PATH_MAX], path2[PATH_MAX], common_path[PATH_MAX];
     ucs_status_t status;
+    char *path1, *path2, *common_path;
+
+    status = ucs_string_alloc_path_buffer(&path1, "path1");
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    status = ucs_string_alloc_path_buffer(&path2, "path2");
+    if (status != UCS_OK) {
+        goto out_free_path1;
+    }
+
+    status = ucs_string_alloc_path_buffer(&common_path, "common_path");
+    if (status != UCS_OK) {
+        goto out_free_path2;
+    }
 
     /* If one of the devices is unknown, we assume near topology */
     if ((device1 == UCS_SYS_DEVICE_ID_UNKNOWN) ||
@@ -376,14 +412,14 @@ ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
         goto default_distance;
     }
 
-    status = ucs_topo_sys_dev_to_sysfs_path(device1, path1, sizeof(path1));
+    status = ucs_topo_sys_dev_to_sysfs_path(device1, path1, PATH_MAX);
     if (status != UCS_OK) {
         ucs_debug("failed to get sysfs path for %s",
                   ucs_topo_sys_device_get_name(device1));
         goto default_distance;
     }
 
-    status = ucs_topo_sys_dev_to_sysfs_path(device2, path2, sizeof(path2));
+    status = ucs_topo_sys_dev_to_sysfs_path(device2, path2, PATH_MAX);
     if (status != UCS_OK) {
         ucs_debug("failed to get sysfs path for %s",
                   ucs_topo_sys_device_get_name(device2));
@@ -394,22 +430,30 @@ ucs_topo_get_distance_sysfs(ucs_sys_device_t device1,
     if (ucs_topo_is_pci_root(common_path)) {
         ucs_topo_set_distance(&ucs_global_opts.dist.phb,
                               ucs_topo_pci_root_bw(path1, path2), distance);
-        return UCS_OK;
+        goto out_free_common_path;
     } else if (ucs_topo_is_sys_root(common_path)) {
         if (ucs_topo_is_same_numa_node(device1, device2)) {
             ucs_topo_set_distance(&ucs_global_opts.dist.node, 17000 * UCS_MBYTE,
                                   distance);
-            return UCS_OK;
+            goto out_free_common_path;
         }
 
         ucs_topo_set_distance(&ucs_global_opts.dist.sys, 220 * UCS_MBYTE,
                               distance);
-        return UCS_OK;
+        goto out_free_common_path;
     }
 
     /* Report best perf for common PCI bridge or sysfs parsing error */
 default_distance:
-    return ucs_topo_get_distance_default(device1, device2, distance);
+    status = ucs_topo_get_distance_default(device1, device2, distance);
+out_free_common_path:
+    ucs_free(common_path);
+out_free_path2:
+    ucs_free(path2);
+out_free_path1:
+    ucs_free(path1);
+out:
+    return status;
 }
 
 static void ucs_topo_get_memory_distance_sysfs(ucs_sys_device_t device,
@@ -809,10 +853,14 @@ out_max_bw:
 const char *ucs_topo_resolve_sysfs_path(const char *dev_path, char *path_buffer)
 {
     const char *detected_type = NULL;
-    char device_file_path[PATH_MAX];
-    char *sysfs_realpath;
+    char *device_file_path, *sysfs_realpath, *sysfs_path;
     struct stat st_buf;
-    char *sysfs_path;
+    ucs_status_t status;
+
+    status = ucs_string_alloc_path_buffer(&device_file_path, "device_file_path");
+    if (status != UCS_OK) {
+        goto out_undetected;
+    }
 
     /* realpath name is expected to be like below:
      * PF: /sys/devices/.../0000:03:00.0/<interface_type>/<dev_name>
@@ -821,13 +869,12 @@ const char *ucs_topo_resolve_sysfs_path(const char *dev_path, char *path_buffer)
 
     sysfs_realpath = realpath(dev_path, path_buffer);
     if (sysfs_realpath == NULL) {
-        goto out_undetected;
+        goto out_free_device_file_path;
     }
 
     /* Try PF: strip 2 components */
     sysfs_path = ucs_dirname(sysfs_realpath, 2);
-    ucs_snprintf_safe(device_file_path, sizeof(device_file_path), "%s/device",
-                      sysfs_path);
+    ucs_snprintf_safe(device_file_path, PATH_MAX, "%s/device", sysfs_path);
 
     if (!stat(device_file_path, &st_buf)) {
         detected_type = "PF";
@@ -836,20 +883,21 @@ const char *ucs_topo_resolve_sysfs_path(const char *dev_path, char *path_buffer)
 
     /* Try SF: strip 3 components (one more) */
     sysfs_path = ucs_dirname(sysfs_path, 1);
-    ucs_snprintf_safe(device_file_path, sizeof(device_file_path), "%s/device",
-                      sysfs_path);
+    ucs_snprintf_safe(device_file_path, PATH_MAX, "%s/device", sysfs_path);
 
     if (!stat(device_file_path, &st_buf)) {
         detected_type = "SF";
         goto out_detected;
     }
 
+out_free_device_file_path:
+    ucs_free(device_file_path);
 out_undetected:
     ucs_debug("%s: sysfs path undetected", dev_path);
     return NULL;
-
 out_detected:
     ucs_debug("%s: %s sysfs path is '%s'\n", dev_path, detected_type,
               sysfs_path);
+    ucs_free(device_file_path);
     return sysfs_path;
 }


### PR DESCRIPTION
## What?
This PR changes all stack allocations of char arrays sized `PATH_MAX` to heap allocations in `topo.c`.

## Why?
Customers with limited stack sizes have recently experienced stack overflow issues when running UCX, where functions like `ucs_topo_get_distance_sysfs()` were using more than 12kB of stack space due to multiple PATH_MAX-sized stack allocations. 
They have temporarily increased their stack size to mitigate this, but a code change in UCX is needed to reduce stack space usage and avoid such workarounds.

## How?
Changed PATH_MAX-sized buffers in `topo.c` use heap allocation, reducing stack usage.
