### PR TITLE
GTEST: reduce stack frame size in gtest macros

### DIFF
--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -287,11 +287,8 @@ class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public test_case_name 
   static ::testing::TestInfo* const test_info_;\
   GTEST_DISALLOW_COPY_AND_ASSIGN_(\
       GTEST_TEST_CLASS_NAME_(test_case_name, test_name));\
-}; \
-\
-::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(test_case_name, test_name)\
-  ::test_info_ = \
-    ::testing::internal::MakeAndRegisterTestInfo( \
+  static ::testing::TestInfo* GTEST_NO_INLINE_ create_test_info() { \
+    return ::testing::internal::MakeAndRegisterTestInfo( \
         #test_case_name, \
         (num_threads == 1) ? #test_name : #test_name "/mt_" #num_threads, \
         "", "", \
@@ -301,6 +298,11 @@ class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public test_case_name 
 		test_case_name::TearDownTestCase, \
         new ::testing::internal::TestFactoryImpl< \
             GTEST_TEST_CLASS_NAME_(test_case_name, test_name)>); \
+  } \
+}; \
+\
+::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(test_case_name, test_name) \
+    ::test_info_ = create_test_info(); \
 void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::test_body()
 
 


### PR DESCRIPTION
## What?
This PR refactors test suite registration macros to reduce stack frame size and defer complex initialization logic.

## Why?
Customers with limited stack sizes have recently experienced stack overflow issues when running UCX. 
The goal is to ensure that the entire UCX runs within a defined stack size threshold. By reducing the stack frame size in test macros, this change helps in testing the runtime stack usage, ensuring that it starts within the threshold.

## How?
The registration logic has been moved to separate functions and marked as noinline, deferring execution and reducing the complexity of static initialization.
