### PR TITLE
STACK: reduce stack usage in tests

### DIFF
--- a/test/gtest/common/googletest/gtest.h
+++ b/test/gtest/common/googletest/gtest.h
@@ -1520,10 +1520,10 @@ inline bool operator!=(faketype, faketype) { return false; }
 
 // The helper function for {ASSERT|EXPECT}_EQ.
 template <typename T1, typename T2>
-AssertionResult CmpHelperEQ(const char* lhs_expression,
-                            const char* rhs_expression,
-                            const T1& lhs,
-                            const T2& rhs) {
+GTEST_NO_INLINE_ AssertionResult CmpHelperEQ(const char* lhs_expression,
+                                             const char* rhs_expression,
+                                             const T1& lhs,
+                                             const T2& rhs) {
   if (lhs == rhs) {
     return AssertionSuccess();
   }

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -9,6 +9,19 @@ extern "C" {
 }
 
 class test_bitops : public ucs::test {
+protected:
+    static void
+    check_bitwise_equality(const uint8_t *buffer1, const uint8_t *buffer2,
+                           const std::vector<int> &indices, int max_equal_index)
+    {
+        for (int i : indices) {
+            if (i <= max_equal_index) {
+                ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, i));
+            } else {
+                ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, i));
+            }
+        }
+    }
 };
 
 UCS_TEST_F(test_bitops, ffs32) {
@@ -91,111 +104,38 @@ UCS_TEST_F(test_bitops, ptr_ctz) {
 }
 
 UCS_TEST_F(test_bitops, is_equal) {
-    uint8_t buffer1[20] = {0};
-    uint8_t buffer2[20] = {0};
+    uint8_t buffer1[20]            = {0};
+    uint8_t buffer2[20]            = {0};
+    const std::vector<int> indices = {0, 1, 8, 64, 65, 128, 130, 159, 160};
 
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 160);
 
     buffer1[19] = 0x1; /* 00000001 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 159);
 
     buffer1[19] = 0x10; /* 00010000 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 130);
 
     buffer1[16] = 0xff; /* 11111111 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 128);
 
     buffer1[9] = 0xff; /* 11111111 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 65);
 
     buffer1[7] = 0xff; /* 11111111 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 8);
 
     buffer1[1] = 0xff; /* 11111111 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 65));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 128));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 130));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 159));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 160));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 8);
 
     buffer1[0] = 0x1; /* 00000001 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 1);
 
     buffer2[0] = 0x1; /* 00000001 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 8);
 
     buffer2[0] = 0xff; /* 11111111 */
-
-    ASSERT_TRUE(ucs_bitwise_is_equal(buffer1, buffer2, 0));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 1));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 8));
-    ASSERT_FALSE(ucs_bitwise_is_equal(buffer1, buffer2, 64));
+    test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 0);
 }
 
 template<typename Type> void test_mask()

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -8,6 +8,8 @@
 
 #include <uct/uct_test.h>
 
+#include <vector>
+
 extern "C" {
 #include <ucs/time/time.h>
 #include <ucs/datastruct/queue.h>
@@ -757,10 +759,9 @@ UCS_TEST_P(test_ud, connect_iface_sim2v2) {
  * - flush() will also progress pending CREQs
  */
 UCS_TEST_P(test_ud, connect_iface_2k) {
-
     unsigned i;
-    unsigned cids[2000];
     unsigned count = 2000 / ucs::test_time_multiplier();
+    std::vector<unsigned> cids(count, 0);
 
     /* create 2k connections */
     for (i = 0; i < count; i++) {


### PR DESCRIPTION
## What?
This PR reduces stack memory usage by converting stack allocations to heap in various UCX tests.

## Why?
Customers with limited stack sizes have recently experienced stack overflow issues when running UCX.
The goal is to ensure that the entire UCX runs within a defined stack size threshold. By reducing the stack frame size in tests, this change helps in testing the runtime stack usage, ensuring that it starts within the threshold.

![image](https://github.com/user-attachments/assets/1c018bb1-dcef-453e-a849-67598931b14e)
![image](https://github.com/user-attachments/assets/bfcd601f-133c-4c7d-8d27-5a4fad8149f0)
![image](https://github.com/user-attachments/assets/d119b8cf-6b83-419c-8a37-8538e7248785)

## How?
This PR reduces stack usage by creating separate helper functions for excessive inline functions calls.


