### PR TITLE
UCT/IB/MLX5/DV: added missing conditional compilation checks for dm

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -269,15 +269,24 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm_data_contig(
                                               list_size, mr_p, mkey);
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_mlx5_devx_has_dm(const uct_ib_mlx5_devx_mem_t *memh)
+{
+    #if HAVE_IBV_DM
+        return memh->dm != NULL;
+    #else
+        return 0;
+    #endif
+}
+
 static void *
 uct_ib_mlx5_devx_memh_base_address(const uct_ib_mlx5_devx_mem_t *memh)
 {
-#if HAVE_IBV_DM
-    if (memh->dm != NULL) {
+    if (uct_ib_mlx5_devx_has_dm(memh)) {
         /* Device memory memory key is zero based */
         return NULL;
     }
-#endif
+
     return memh->address;
 }
 
@@ -493,12 +502,11 @@ static UCS_F_ALWAYS_INLINE uint32_t uct_ib_mlx5_mkey_index(uint32_t mkey)
 static UCS_F_ALWAYS_INLINE uct_ib_mr_type_t uct_ib_devx_get_atomic_mr_type(
         uct_ib_md_t *md, const uct_ib_mlx5_devx_mem_t *memh)
 {
-#if HAVE_IBV_DM
     /* Device memory only supports default mr */
-    if (memh->dm != NULL) {
+    if (uct_ib_mlx5_devx_has_dm(memh)) {
         return UCT_IB_MR_DEFAULT;
     }
-#endif
+
     return uct_ib_md_get_atomic_mr_type(md);
 }
 
@@ -2575,7 +2583,7 @@ static ucs_status_t uct_ib_mlx5_devx_xgvmi_umem_mr(uct_ib_mlx5_md_t *md,
     size_t length;
     void *mkc;
 
-    if (memh->dm != NULL) {
+    if (uct_ib_mlx5_devx_has_dm(memh)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
@@ -2701,7 +2709,7 @@ UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_exported_key,
     size_t length = memh->mrs[UCT_IB_MR_DEFAULT].super.ib->length;
     ucs_status_t status;
 
-    if (memh->dm != NULL) {
+    if (uct_ib_mlx5_devx_has_dm(memh)) {
         return UCS_ERR_UNSUPPORTED;
     }
 
@@ -2759,15 +2767,14 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
 
     flags = UCS_PARAM_VALUE(UCT_MD_MKEY_PACK_FIELD, params, flags, FLAGS, 0);
     if (flags & UCT_MD_MKEY_PACK_FLAG_EXPORT) {
-#if HAVE_IBV_DM
-        if (memh->dm != NULL) {
+        if (uct_ib_mlx5_devx_has_dm(memh)) {
             ucs_error("%s: cannot export memory allocated on the device "
                       "(address %p length %zu)",
                       uct_ib_device_name(&md->super.dev), memh->address,
                       memh->mrs[UCT_IB_MR_DEFAULT].super.ib->length);
             return UCS_ERR_INVALID_PARAM;
         }
-#endif
+
         if (uct_ib_mlx5_devx_mkey_pack_invalidate_param_check(flags)) {
             ucs_error("packing a memory key that supports invalidation "
                       "and exporting is unsupported");
@@ -2824,7 +2831,8 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    if ((flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA) || (memh->dm != NULL)) {
+    if ((flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA) ||
+        uct_ib_mlx5_devx_has_dm(memh)) {
         if (ucs_unlikely(memh->indirect_dvmr == NULL)) {
             status = uct_ib_mlx5_devx_reg_indirect_key(md, memh);
             if (status != UCS_OK) {
@@ -2942,7 +2950,7 @@ err:
 ucs_status_t
 uct_ib_mlx5_devx_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
 {
-    uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    uct_ib_md_t UCS_V_UNUSED *md = ucs_derived_of(uct_md, uct_ib_md_t);
     ucs_status_t status;
 
     status = uct_ib_md_query(uct_md, md_attr);
@@ -2955,8 +2963,8 @@ uct_ib_mlx5_devx_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
         md_attr->alloc_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_RDMA);
         md_attr->max_alloc        = md->dev.dev_attr.max_dm_size;
     }
-
 #endif
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What
Added missing compilation checks for `HAVE_IBV_DM` reported by #10129

## Why ?
To avoid compilation issues when dm is not supported / ucx is configured with `--without-dm` flag
