### PR TITLE
UCT/GGA: fix component loading

### DIFF
--- a/src/uct/base/uct_component.c
+++ b/src/uct/base/uct_component.c
@@ -172,6 +172,9 @@ err:
 
 void uct_component_register(uct_component_t *component)
 {
+    ucs_trace("component_list %p: register %p %s", &uct_components_list,
+              component, component->name);
+
     ucs_list_add_tail(&uct_components_list, &component->list);
     ucs_list_add_tail(&ucs_config_global_list, &component->md_config.list);
     ucs_list_add_tail(&ucs_config_global_list, &component->cm_config.list);
@@ -179,6 +182,9 @@ void uct_component_register(uct_component_t *component)
 
 void uct_component_unregister(uct_component_t *component)
 {
+    ucs_trace("component_list %p: unregister %p %s", &uct_components_list,
+              component, component->name);
+
     /* TODO: add ucs_list_del(uct_components_list) */
     ucs_list_del(&component->md_config.list);
     ucs_list_del(&component->cm_config.list);

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -793,14 +793,11 @@ ucs_status_t uct_ib_query_md_resources(uct_component_t *component,
                                        uct_md_resource_desc_t **resources_p,
                                        unsigned *num_resources_p)
 {
-    UCS_MODULE_FRAMEWORK_DECLARE(uct_ib);
     int num_resources = 0;
     uct_md_resource_desc_t *resources;
     struct ibv_device **device_list;
     ucs_status_t status;
     int i, num_devices;
-
-    UCS_MODULE_FRAMEWORK_LOAD(uct_ib, 0);
 
     /* Get device list from driver */
     device_list = ibv_get_device_list(&num_devices);
@@ -1517,6 +1514,7 @@ uct_component_t uct_ib_component = {
 
 void UCS_F_CTOR uct_ib_init()
 {
+    UCS_MODULE_FRAMEWORK_DECLARE(uct_ib);
     ssize_t i;
 
     ucs_list_add_head(&uct_ib_ops, &UCT_IB_MD_OPS_NAME(verbs).list);
@@ -1525,6 +1523,8 @@ void UCS_F_CTOR uct_ib_init()
     for (i = 0; i < ucs_static_array_size(uct_ib_tls); i++) {
         uct_tl_register(&uct_ib_component, uct_ib_tls[i]);
     }
+
+    UCS_MODULE_FRAMEWORK_LOAD(uct_ib, 0);
 }
 
 void UCS_F_DTOR uct_ib_cleanup()


### PR DESCRIPTION
## What
fix GGA component loading

## Why ?
too late GGA component registration (found with `ucx_perftest`)

## How ?
move IB load from query_md_resources to `so` ctor 