### PR TITLE
UCT: check reachability using the routing table

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Alex Margolin <alex.margolin@huawei.com>
 Alex Mikheev <alexm@mellanox.com>
 Alexey Rivkin <arivkin@nvidia.com>
 Alina Sklarevich <alinas@mellanox.com>
+Alma Mastbaum <amastbaum@nvidia.com>
 Anatoly Vildemanov <anatolyv@nvidia.com>
 Andrey Maslennikov <andreyma@mellanox.com>
 Artem Polyakov <artemp@nvidia.com>

--- a/buildlib/tools/build_static.sh
+++ b/buildlib/tools/build_static.sh
@@ -64,7 +64,6 @@ az_init_modules
 prepare_build
 
 # Don't cross-connect RoCE devices
-export UCX_IB_ROCE_LOCAL_SUBNET=y
 export UCX_IB_ROCE_SUBNET_PREFIX_LEN=inf
 build_static
 

--- a/buildlib/tools/test_wire_compat.sh
+++ b/buildlib/tools/test_wire_compat.sh
@@ -11,7 +11,6 @@ common_opt=$3
 port=$((10000 + 1000 * ${AZP_AGENT_ID} + 100 * ${WIRE_COMPAT_STAGE_ID}))
 
 export UCX_CM_REUSEADDR=y UCX_LOG_LEVEL=info UCX_WARN_UNUSED_ENV_VARS=n
-export UCX_IB_ROCE_LOCAL_SUBNET=y
 
 exe_cmd="stdbuf -oL ${exe_name} -p ${port}"
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1143,7 +1143,6 @@ set_ucx_common_test_env() {
 	export UCX_TCP_CM_REUSEADDR=y
 
 	# Don't cross-connect RoCE devices
-	export UCX_IB_ROCE_LOCAL_SUBNET=y
 	export UCX_IB_ROCE_SUBNET_PREFIX_LEN=inf
 
 	export LSAN_OPTIONS=suppressions=${WORKSPACE}/contrib/lsan.supp

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -131,6 +131,7 @@ noinst_HEADERS = \
 	sys/iovec.h \
 	sys/iovec.inl \
 	sys/ptr_arith.h \
+	sys/netlink.h \
 	time/time.h \
 	time/timerq.h \
 	time/timer_wheel.h \
@@ -205,6 +206,7 @@ libucs_la_SOURCES = \
 	sys/sock.c \
 	sys/topo/base/topo.c \
 	sys/stubs.c \
+	sys/netlink.c \
 	sys/uid.c \
 	time/time.c \
 	time/timer_wheel.c \

--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -1,0 +1,237 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "netlink.h"
+
+#include <ucs/debug/log.h>
+#include <ucs/sys/compiler.h>
+#include <ucs/sys/sock.h>
+#include <ucs/type/status.h>
+#include <ucs/debug/memtrack_int.h>
+
+#include <errno.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+
+typedef struct {
+    const struct sockaddr *sa_remote;
+    int                    if_index;
+    int                    found;
+} ucs_netlink_route_info_t;
+
+
+/**
+ * Callback function for parsing individual netlink messages.
+ *
+ * @param [in] nlh    Pointer to the netlink message header.
+ * @param [in] nl_msg Pointer to the netlink message payload.
+ * @param [in] arg    User-provided argument passed through from the caller.
+ *
+ * @return UCS_OK if parsing is complete, UCS_INPROGRESS if there are more
+ *         messages to be parsed, or error code otherwise.
+ */
+typedef ucs_status_t (*ucs_netlink_parse_cb_t)(const struct nlmsghdr *nlh,
+                                               const void *nl_msg, void *arg);
+
+static ucs_status_t ucs_netlink_socket_init(int *fd_p, int protocol)
+{
+    struct sockaddr_nl sa = {.nl_family = AF_NETLINK};
+    ucs_status_t status;
+
+    status = ucs_socket_create(AF_NETLINK, SOCK_RAW, protocol, fd_p);
+    if (status != UCS_OK) {
+        ucs_error("failed to create netlink socket: %s",
+                  ucs_status_string(status));
+        goto err;
+    }
+
+    if (bind(*fd_p, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        ucs_error("failed to bind netlink socket %d: %m", *fd_p);
+        status = UCS_ERR_IO_ERROR;
+        goto err_close_socket;
+    }
+
+    return UCS_OK;
+
+err_close_socket:
+    ucs_close_fd(fd_p);
+err:
+    return status;
+}
+
+static ucs_status_t
+ucs_netlink_parse_msg(const void *msg, size_t msg_len,
+                      ucs_netlink_parse_cb_t parse_cb, void *arg)
+{
+    ucs_status_t status        = UCS_INPROGRESS;
+    const struct nlmsghdr *nlh = (const struct nlmsghdr *)msg;
+
+    while ((status == UCS_INPROGRESS) && NLMSG_OK(nlh, msg_len) &&
+           (nlh->nlmsg_type != NLMSG_DONE)) {
+        if (nlh->nlmsg_type == NLMSG_ERROR) {
+            struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+            ucs_error("received error response from netlink err=%d: %s\n",
+                      err->error, strerror(-err->error));
+            return UCS_ERR_IO_ERROR;
+        }
+
+        status = parse_cb(nlh, NLMSG_DATA(nlh), arg);
+        nlh    = NLMSG_NEXT(nlh, msg_len);
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucs_netlink_send_request(int protocol, unsigned short nlmsg_type,
+                         const void *protocol_header, size_t header_length,
+                         ucs_netlink_parse_cb_t parse_cb, void *arg)
+{
+    struct nlmsghdr nlh = {0};
+    char *recv_msg      = NULL;
+    size_t recv_msg_len = 0;
+    int netlink_fd      = -1;
+    ucs_status_t status;
+    struct iovec iov[2];
+    size_t bytes_sent;
+
+    status = ucs_netlink_socket_init(&netlink_fd, protocol);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    nlh.nlmsg_len   = NLMSG_LENGTH(header_length);
+    nlh.nlmsg_type  = nlmsg_type;
+    nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    iov[0].iov_base = &nlh;
+    iov[0].iov_len  = sizeof(nlh);
+    iov[1].iov_base = (void *)protocol_header;
+    iov[1].iov_len  = header_length;
+
+    do {
+        status = ucs_socket_sendv_nb(netlink_fd, iov, 2, &bytes_sent);
+    } while (status == UCS_ERR_NO_PROGRESS);
+
+    if (status != UCS_OK) {
+        ucs_error("failed to send netlink message on fd=%d: %s",
+                  netlink_fd, ucs_status_string(status));
+        goto out;
+    }
+
+    /* get message size */
+    status = ucs_socket_recv_nb(netlink_fd, NULL, MSG_PEEK | MSG_TRUNC,
+                                &recv_msg_len);
+    if (status != UCS_OK) {
+        ucs_error("failed to get netlink message size %d (%s)",
+                  status, ucs_status_string(status));
+        goto out;
+    }
+
+    recv_msg = ucs_malloc(recv_msg_len, "netlink recv message");
+    if (recv_msg == NULL) {
+        ucs_error("failed to allocate a buffer for netlink receive message of"
+                  " size %zu", recv_msg_len);
+        goto out;
+    }
+
+    status = ucs_socket_recv(netlink_fd, recv_msg, recv_msg_len);
+    if (status != UCS_OK) {
+        ucs_error("failed to receive netlink message on fd=%d: %s",
+                  netlink_fd, ucs_status_string(status));
+        goto out;
+    }
+
+    status = ucs_netlink_parse_msg(recv_msg, recv_msg_len, parse_cb, arg);
+
+out:
+    ucs_close_fd(&netlink_fd);
+    ucs_free(recv_msg);
+    return status;
+}
+
+static ucs_status_t
+ucs_netlink_get_route_info(const struct rtattr *rta, int len, int *if_index_p,
+                           const void **dst_in_addr)
+{
+    *if_index_p  = -1;
+    *dst_in_addr = NULL;
+
+    for (; RTA_OK(rta, len); rta = RTA_NEXT(rta, len)) {
+        if (rta->rta_type == RTA_OIF) {
+            *if_index_p = *((const int *)RTA_DATA(rta));
+        } else if (rta->rta_type == RTA_DST) {
+            *dst_in_addr = RTA_DATA(rta);
+        }
+    }
+
+    if ((*if_index_p == -1) || (*dst_in_addr == NULL)) {
+        ucs_diag("invalid routing table entry");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+ucs_netlink_parse_rt_entry_cb(const struct nlmsghdr *nlh, const void *nl_msg,
+                              void *arg)
+{
+    ucs_netlink_route_info_t *info = (ucs_netlink_route_info_t *)arg;
+    int rule_iface;
+    const void *dst_in_addr;
+
+    if (ucs_netlink_get_route_info(RTM_RTA((const struct rtmsg *)nl_msg),
+                                   RTM_PAYLOAD(nlh), &rule_iface,
+                                   &dst_in_addr) != UCS_OK) {
+        return UCS_INPROGRESS;
+    }
+
+    if (rule_iface != info->if_index) {
+        return UCS_INPROGRESS;
+    }
+
+    if (ucs_bitwise_is_equal(ucs_sockaddr_get_inet_addr(info->sa_remote),
+                             dst_in_addr,
+                             ((const struct rtmsg *)nl_msg)->rtm_dst_len)) {
+        info->found = 1;
+        return UCS_OK;
+    }
+
+    return UCS_INPROGRESS;
+}
+
+int ucs_netlink_route_exists(const char *if_name,
+                             const struct sockaddr *sa_remote)
+{
+    ucs_netlink_route_info_t info = {0};
+    struct rtmsg rtm              = {0};
+    int iface_index;
+
+    iface_index = if_nametoindex(if_name);
+    if (iface_index == 0) {
+        ucs_error("failed to get interface index (errno %d)", errno);
+        goto out;
+    }
+
+    rtm.rtm_family = sa_remote->sa_family;
+    rtm.rtm_table  = RT_TABLE_MAIN;
+
+    info.if_index  = iface_index;
+    info.sa_remote = sa_remote;
+
+    ucs_netlink_send_request(NETLINK_ROUTE, RTM_GETROUTE, &rtm, sizeof(rtm),
+                             ucs_netlink_parse_rt_entry_cb, &info);
+
+out:
+    return info.found;
+}

--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -1,0 +1,31 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_NETLINK_H
+#define UCS_NETLINK_H
+
+#include <ucs/type/status.h>
+
+#include <netinet/in.h>
+
+BEGIN_C_DECLS
+
+
+/**
+ * Check whether a routing table rule exists for a given network
+ * interface name and a destination address.
+ *
+ * @param [in]  if_name    Pointer to the name of the interface.
+ * @param [in]  sa_remote  Pointer to the destination address.
+ *
+ * @return 1 if rule exists, or 0 otherwise.
+ */
+int ucs_netlink_route_exists(const char *if_name,
+                             const struct sockaddr *sa_remote);
+
+END_C_DECLS
+
+#endif /* UCS_NETLINK_H */

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -111,11 +111,12 @@ unsigned ucs_netif_bond_ad_num_ports(const char *if_name);
  *
  * @param [in]   domain     Communication domain (AF_INET/AF_INET6/etc).
  * @param [in]   type       Communication semantics (SOCK_STREAM/SOCK_DGRAM/etc).
+ * @param [in]   protocol   Communication protocol (IPPROTO_TCP/NETLINK_ROUTE/etc).
  * @param [out]  fd_p       Pointer to created fd.
  *
  * @return UCS_OK on success or UCS_ERR_IO_ERROR on failure.
  */
-ucs_status_t ucs_socket_create(int domain, int type, int *fd_p);
+ucs_status_t ucs_socket_create(int domain, int type, int protocol, int *fd_p);
 
 
 /**
@@ -279,13 +280,14 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
  * @param [in]      fd              Socket fd.
  * @param [in]      data            A pointer to a buffer to receive the incoming
  *                                  data.
+ * @param [in]      flags           recv flags.
  * @param [in/out]  length_p        The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter. The amount of
  *                                  data received is written to this argument.
  *
  * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
+ucs_status_t ucs_socket_recv_nb(int fd, void *data, int flags, size_t *length_p);
 
 
 /**

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -23,6 +23,7 @@
 #include <ucs/type/serialize.h>
 #include <ucs/debug/log.h>
 #include <ucs/time/time.h>
+#include <ucs/sys/netlink.h>
 #include <ucs/sys/sock.h>
 #include <string.h>
 #include <stdlib.h>
@@ -40,6 +41,13 @@ const char *uct_ib_mtu_values[] = {
     [UCT_IB_MTU_2048]       = "2048",
     [UCT_IB_MTU_4096]       = "4096",
     [UCT_IB_MTU_LAST]       = NULL
+};
+
+const char *uct_ib_reachability_modes[] = {
+    [UCT_IB_REACHABILITY_MODE_ROUTE]        = "route",
+    [UCT_IB_REACHABILITY_MODE_LOCAL_SUBNET] = "local_subnet",
+    [UCT_IB_REACHABILITY_MODE_ALL]          = "all",
+    [UCT_IB_REACHABILITY_MODE_LAST]         = NULL
 };
 
 enum {
@@ -180,6 +188,13 @@ ucs_config_field_t uct_ib_iface_config_table[] = {
    "address and a netmask in the form x.x.x.x/y.\n"
    "It must not be used together with UCX_IB_GID_INDEX.",
    ucs_offsetof(uct_ib_iface_config_t, rocev2_subnet_filter), UCS_CONFIG_TYPE_ALLOW_LIST},
+
+  {"ROCE_REACHABILITY_MODE", "route",
+   "The mode used for performing the reachability check\n"
+   " - route        - all routable addresses are assumed as reachable\n"
+   " - local_subnet - only addresses within the interface's subnet are assumed as reachable.\n"
+   " - all          - all addresses are assumed as reachable, without any check",
+   ucs_offsetof(uct_ib_iface_config_t, reachability_mode), UCS_CONFIG_TYPE_ENUM(uct_ib_reachability_modes)},
 
   {"ROCE_PATH_FACTOR", "1",
    "Multiplier for RoCE LAG UDP source port calculation. The UDP source port\n"
@@ -620,8 +635,8 @@ ucs_status_t uct_ib_iface_get_device_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static void uct_ib_iface_log_subnet_info(const struct sockaddr_storage *sa1,
-                                         const struct sockaddr_storage *sa2,
+static void uct_ib_iface_log_subnet_info(const struct sockaddr *sa1,
+                                         const struct sockaddr *sa2,
                                          unsigned prefix_len, int matched)
 {
     UCS_STRING_BUFFER_ONSTACK(info, UCS_SOCKADDR_STRING_LEN * 2 + 60);
@@ -635,84 +650,58 @@ static void uct_ib_iface_log_subnet_info(const struct sockaddr_storage *sa1,
                               " match with a %u-bit prefix, addresses: ",
                               prefix_len);
 
-    ucs_string_buffer_append_saddr(&info, (struct sockaddr*)sa1);
+    ucs_string_buffer_append_saddr(&info, sa1);
     ucs_string_buffer_appendf(&info, " ");
-    ucs_string_buffer_append_saddr(&info, (struct sockaddr*)sa2);
+    ucs_string_buffer_append_saddr(&info, sa2);
     ucs_debug("%s", ucs_string_buffer_cstr(&info));
 }
 
 static int
-uct_ib_iface_roce_is_reachable(const uct_ib_device_gid_info_t *local_gid_info,
-                               const uct_ib_address_t *remote_ib_addr,
-                               unsigned prefix_bits,
-                               const uct_iface_is_reachable_params_t *params)
+uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, int gid_index,
+                              struct sockaddr *sa_remote,
+                              const uct_iface_is_reachable_params_t *params)
 {
-    sa_family_t local_ib_addr_af         = local_gid_info->roce_info.addr_family;
-    uct_ib_roce_version_t local_roce_ver = local_gid_info->roce_info.ver;
-    uint8_t remote_ib_addr_flags         = remote_ib_addr->flags;
-    struct sockaddr_storage sa_local, sa_remote;
-    uct_ib_roce_version_t remote_roce_ver;
-    sa_family_t remote_ib_addr_af;
-    char local_str[128], remote_str[128];
-    int matched;
+    uct_ib_device_t *dev = uct_ib_iface_device(iface);
+    uint8_t port_num     = iface->config.port_num;
+    char ndev_name[IFNAMSIZ];
+    char remote_str[128];
+    ucs_status_t status;
 
-    /* check for wildcards in the RoCE version (RDMACM or non-RoCE cases) */
-    if ((uct_ib_address_flags_get_roce_version(remote_ib_addr_flags)) ==
-         UCT_IB_DEVICE_ROCE_ANY) {
-        return 1;
+    status = uct_ib_device_get_roce_ndev_name(dev, port_num, gid_index,
+                                              ndev_name, sizeof(ndev_name));
+    if (status != UCS_OK) {
+        uct_iface_fill_info_str_buf(params,
+                                    "couldn't get network interface name");
+        return 0;
     }
 
-    /* check for zero-sized netmask */
+    if (!ucs_netlink_route_exists(ndev_name, sa_remote)) {
+        uct_iface_fill_info_str_buf(params, "remote address %s is not routable",
+                                    ucs_sockaddr_str(sa_remote, remote_str, 128));
+        return 0;
+    }
+
+    return 1;
+}
+
+static int
+uct_ib_iface_roce_is_local_subnet(int prefix_bits,
+                                  const struct sockaddr *sa_local,
+                                  const struct sockaddr *sa_remote,
+                                  const uct_iface_is_reachable_params_t *params)
+{
+    int matched;
+    char local_str[128], remote_str[128];
+
+    /* A 0-bit netmask implies any address is reachable */
     if (prefix_bits == 0) {
         return 1;
     }
 
-    /* check the RoCE version */
-    ucs_assert(local_roce_ver != UCT_IB_DEVICE_ROCE_ANY);
-
-    remote_roce_ver = uct_ib_address_flags_get_roce_version(remote_ib_addr_flags);
-
-    if (local_roce_ver != remote_roce_ver) {
-        uct_iface_fill_info_str_buf(
-                        params,
-                        "different RoCE versions detected. local %s (gid=%s)"
-                        "remote %s (gid=%s)",
-                        uct_ib_roce_version_str(local_roce_ver),
-                        uct_ib_gid_str(&local_gid_info->gid, local_str,
-                                       sizeof(local_str)),
-                        uct_ib_roce_version_str(remote_roce_ver),
-                        uct_ib_gid_str((union ibv_gid*)(remote_ib_addr + 1),
-                                       remote_str, sizeof(remote_str)));
-        return 0;
-    }
-
-    if (local_gid_info->roce_info.ver != UCT_IB_DEVICE_ROCE_V2) {
-        return 1; /* We assume it is, but actually there's no good test */
-    }
-
-    remote_ib_addr_af = uct_ib_address_flags_get_roce_af(remote_ib_addr_flags);
-    if ((uct_ib_device_roce_gid_to_sockaddr(local_ib_addr_af,
-                                            &local_gid_info->gid,
-                                            &sa_local) != UCS_OK)) {
-        uct_iface_fill_info_str_buf(
-               params, "Couldn't convert local RoCE address to socket address");
-        return 0;
-    }
-
-    if (uct_ib_device_roce_gid_to_sockaddr(remote_ib_addr_af,
-                                           remote_ib_addr + 1,
-                                           &sa_remote) != UCS_OK) {
-        uct_iface_fill_info_str_buf(
-               params, "Couldn't convert remote RoCE address to socket address");
-        return 0;
-    }
-
-    matched = ucs_sockaddr_is_same_subnet((struct sockaddr*)&sa_local,
-                                          (struct sockaddr*)&sa_remote,
-                                          prefix_bits);
+    matched = ucs_sockaddr_is_same_subnet(sa_local, sa_remote, prefix_bits);
 
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
-        uct_ib_iface_log_subnet_info(&sa_local, &sa_remote, prefix_bits, matched);
+        uct_ib_iface_log_subnet_info(sa_local, sa_remote, prefix_bits, matched);
     }
 
     if (!matched) {
@@ -720,14 +709,94 @@ uct_ib_iface_roce_is_reachable(const uct_ib_device_gid_info_t *local_gid_info,
                     params,
                     "IP addresses do not match with a %u-bit prefix. local IP"
                     " is %s, remote IP is %s",
-                    prefix_bits,
-                    ucs_sockaddr_str((struct sockaddr *)&sa_local,
-                                     local_str, 128),
-                    ucs_sockaddr_str((struct sockaddr *)&sa_remote,
-                                     remote_str, 128));
+                    prefix_bits, ucs_sockaddr_str(sa_local, local_str, 128),
+                    ucs_sockaddr_str(sa_remote, remote_str, 128));
     }
 
     return matched;
+}
+
+static int
+uct_ib_iface_roce_is_reachable(uct_ib_iface_t *iface,
+                               const uct_ib_address_t *remote_ib_addr,
+                               const uct_iface_is_reachable_params_t *params)
+{
+    uct_ib_device_gid_info_t local_gid_info = iface->gid_info;
+    sa_family_t local_ib_addr_af            = local_gid_info.roce_info.addr_family;
+    uct_ib_roce_version_t local_roce_ver    = local_gid_info.roce_info.ver;
+    uint8_t remote_ib_addr_flags            = remote_ib_addr->flags;
+    struct sockaddr_storage sa_local, sa_remote;
+    uct_ib_roce_version_t remote_roce_ver;
+    sa_family_t remote_ib_addr_af;
+    char local_str[128], remote_str[128];
+
+    remote_roce_ver = uct_ib_address_flags_get_roce_version(remote_ib_addr_flags);
+
+    /* check for wildcards in the RoCE version (RDMACM or non-RoCE cases)
+       or for reachability mode 'all' (no reachibility check is needed) */
+    if ((remote_roce_ver == UCT_IB_DEVICE_ROCE_ANY) ||
+        (iface->config.reachability_mode == UCT_IB_REACHABILITY_MODE_ALL)) {
+        return 1;
+    }
+
+    /* check the RoCE version */
+    ucs_assert(local_roce_ver != UCT_IB_DEVICE_ROCE_ANY);
+
+    if (local_roce_ver != remote_roce_ver) {
+        uct_iface_fill_info_str_buf(
+                        params,
+                        "different RoCE versions detected. local %s (gid=%s)"
+                        "remote %s (gid=%s)",
+                        uct_ib_roce_version_str(local_roce_ver),
+                        uct_ib_gid_str(&local_gid_info.gid, local_str,
+                                       sizeof(local_str)),
+                        uct_ib_roce_version_str(remote_roce_ver),
+                        uct_ib_gid_str((union ibv_gid*)(remote_ib_addr + 1),
+                                       remote_str, sizeof(remote_str)));
+        return 0;
+    }
+
+    if (local_roce_ver != UCT_IB_DEVICE_ROCE_V2) {
+        return 1; /* We assume it is, but actually there's no good test */
+    }
+
+    remote_ib_addr_af = uct_ib_address_flags_get_roce_af(remote_ib_addr_flags);
+    if (local_ib_addr_af != remote_ib_addr_af) {
+        uct_iface_fill_info_str_buf(
+                    params, "different IP versions, local %s vs remote %s\n",
+                    local_ib_addr_af == AF_INET ? "IPv4": "IPv6",
+                    remote_ib_addr_af == AF_INET ? "IPv4": "IPv6");
+        return 0;
+    }
+
+    if ((uct_ib_device_roce_gid_to_sockaddr(local_ib_addr_af,
+                                            &local_gid_info.gid,
+                                            &sa_local) != UCS_OK)) {
+        uct_iface_fill_info_str_buf(
+               params, "couldn't convert local RoCE address to socket address");
+        return 0;
+    }
+
+    if (uct_ib_device_roce_gid_to_sockaddr(remote_ib_addr_af,
+                                           remote_ib_addr + 1,
+                                           &sa_remote) != UCS_OK) {
+        uct_iface_fill_info_str_buf(
+               params, "couldn't convert remote RoCE address to socket address");
+        return 0;
+    }
+
+    if (iface->config.reachability_mode == UCT_IB_REACHABILITY_MODE_ROUTE) {
+        return uct_ib_iface_roce_is_routable(iface, local_gid_info.gid_index,
+                                             (struct sockaddr *)&sa_remote,
+                                             params);
+    }
+
+    ucs_assert(iface->config.reachability_mode ==
+               UCT_IB_REACHABILITY_MODE_LOCAL_SUBNET);
+    return uct_ib_iface_roce_is_local_subnet(iface->addr_prefix_bits,
+                                             (const struct sockaddr *)&sa_local,
+                                             (const struct sockaddr *)&sa_remote,
+                                             params);
 }
 
 int uct_ib_iface_is_same_device(const uct_ib_address_t *ib_addr, uint16_t dlid,
@@ -827,8 +896,7 @@ static int uct_ib_iface_dev_addr_is_reachable(
         /* there shouldn't be a lid and the UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH
          * flag should be on. If reachable, the remote and local RoCE versions
          * and address families have to be the same */
-        return uct_ib_iface_roce_is_reachable(&iface->gid_info, ib_addr,
-                                              iface->addr_prefix_bits,
+        return uct_ib_iface_roce_is_reachable(iface, ib_addr,
                                               is_reachable_params);
     } else {
         /* local and remote have different link layers and therefore are unreachable */
@@ -1321,8 +1389,14 @@ uct_ib_iface_init_roce_addr_prefix(uct_ib_iface_t *iface,
 
     ucs_assert(uct_ib_iface_is_roce(iface));
 
+    /* Override the original value of reachability_mode if
+       rocev2_local_subnet is enabled to maintain backward compatibility */
+    iface->config.reachability_mode = config->rocev2_local_subnet ?
+                                      UCT_IB_REACHABILITY_MODE_LOCAL_SUBNET :
+                                      config->reachability_mode;
+
     if ((gid_info->roce_info.ver != UCT_IB_DEVICE_ROCE_V2) ||
-        !config->rocev2_local_subnet) {
+        (iface->config.reachability_mode != UCT_IB_REACHABILITY_MODE_LOCAL_SUBNET)) {
         iface->addr_prefix_bits = 0;
         return UCS_OK;
     }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -107,6 +107,18 @@ enum {
     UCT_IB_ADDRESS_PACK_FLAG_PKEY          = UCS_BIT(5)
 };
 
+
+/**
+ * Reachability mode.
+ */
+typedef enum {
+    UCT_IB_REACHABILITY_MODE_ROUTE        = 0,
+    UCT_IB_REACHABILITY_MODE_LOCAL_SUBNET = 1,
+    UCT_IB_REACHABILITY_MODE_ALL          = 2,
+    UCT_IB_REACHABILITY_MODE_LAST
+} uct_ib_iface_reachability_mode_t;
+
+
 enum {
     UCT_IB_IFACE_STAT_RX_COMPLETION,
     UCT_IB_IFACE_STAT_TX_COMPLETION,
@@ -175,60 +187,63 @@ struct uct_ib_iface_config {
     } rx;
 
     /* Inline space to reserve in CQ */
-    size_t                  inl[UCT_IB_DIR_LAST];
+    size_t                           inl[UCT_IB_DIR_LAST];
 
     /* Change the address type */
-    int                     addr_type;
+    int                              addr_type;
 
     /* Force global routing */
-    int                     is_global;
+    int                              is_global;
 
     /* Use FLID based routing */
-    int                     flid_enabled;
+    int                              flid_enabled;
 
     /* IB SL to use (default: AUTO) */
-    unsigned long           sl;
+    unsigned long                    sl;
 
     /* IB Traffic Class to use */
-    unsigned long           traffic_class;
+    unsigned long                    traffic_class;
 
     /* IB hop limit / TTL */
-    unsigned                hop_limit;
+    unsigned                         hop_limit;
 
     /* Number of paths to expose for the interface  */
-    unsigned long           num_paths;
+    unsigned long                    num_paths;
 
     /* Whether to check RoCEv2 reachability by IP address and local subnet */
-    int                     rocev2_local_subnet;
+    int                              rocev2_local_subnet;
 
     /* Length of subnet prefix for reachability check */
-    unsigned long           rocev2_subnet_pfx_len;
+    unsigned long                    rocev2_subnet_pfx_len;
+
+    /* Mode used for performing reachability check */
+    uct_ib_iface_reachability_mode_t reachability_mode;
 
     /* List of included/excluded subnets to filter RoCE GID entries by */
-    ucs_config_allow_list_t rocev2_subnet_filter;
+    ucs_config_allow_list_t          rocev2_subnet_filter;
 
     /* Multiplier for RoCE LAG UDP source port calculation */
-    unsigned                roce_path_factor;
+    unsigned                         roce_path_factor;
 
     /* Ranges of path bits */
     UCS_CONFIG_ARRAY_FIELD(ucs_range_spec_t, ranges) lid_path_bits;
 
     /* IB PKEY to use */
-    unsigned                     pkey;
+    unsigned                         pkey;
 
     /* Path MTU size */
-    uct_ib_mtu_t                 path_mtu;
+    uct_ib_mtu_t                     path_mtu;
 
     /* QP counter set ID */
-    unsigned long                counter_set_id;
+    unsigned long                    counter_set_id;
 
     /* IB reverse SL (default: AUTO - same value as sl) */
-    unsigned long                reverse_sl;
+    unsigned long                    reverse_sl;
 
     /**
      * Estimated overhead of preparing a work request and posting it to the NIC
      */
-    uct_ib_iface_send_overhead_t send_overhead;
+    uct_ib_iface_send_overhead_t     send_overhead;
 };
 
 
@@ -325,28 +340,29 @@ struct uct_ib_iface {
 
     struct {
         /* offset from desc to payload */
-        unsigned                     rx_payload_offset;
+        unsigned                         rx_payload_offset;
         /* offset from desc to network header */
-        unsigned                     rx_hdr_offset;
+        unsigned                         rx_hdr_offset;
         /* offset from desc to user headroom */
-        unsigned                     rx_headroom_offset;
-        unsigned                     rx_max_batch;
-        unsigned                     rx_max_poll;
-        unsigned                     tx_max_poll;
-        unsigned                     seg_size;
-        unsigned                     roce_path_factor;
-        uint8_t                      max_inl_cqe[UCT_IB_DIR_LAST];
-        uint8_t                      port_num;
-        uint8_t                      sl;
-        uint8_t                      reverse_sl;
-        uint8_t                      traffic_class;
-        uint8_t                      hop_limit;
-        uint8_t                      qp_type;
-        uint8_t                      force_global_addr;
-        uint8_t                      flid_enabled;
-        enum ibv_mtu                 path_mtu;
-        uint8_t                      counter_set_id;
-        uct_ib_iface_send_overhead_t send_overhead;
+        unsigned                         rx_headroom_offset;
+        unsigned                         rx_max_batch;
+        unsigned                         rx_max_poll;
+        unsigned                         tx_max_poll;
+        unsigned                         seg_size;
+        unsigned                         roce_path_factor;
+        uint8_t                          max_inl_cqe[UCT_IB_DIR_LAST];
+        uint8_t                          port_num;
+        uint8_t                          sl;
+        uint8_t                          reverse_sl;
+        uint8_t                          traffic_class;
+        uint8_t                          hop_limit;
+        uint8_t                          qp_type;
+        uint8_t                          force_global_addr;
+        uint8_t                          flid_enabled;
+        enum ibv_mtu                     path_mtu;
+        uint8_t                          counter_set_id;
+        uct_ib_iface_send_overhead_t     send_overhead;
+        uct_ib_iface_reachability_mode_t reachability_mode;
     } config;
 
     uct_ib_iface_ops_t        *ops;

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -677,7 +677,7 @@ static ucs_status_t uct_tcp_ep_create_socket_and_connect(uct_tcp_ep_t *ep)
     struct sockaddr *saddr = (struct sockaddr*)ep->peer_addr;
     ucs_status_t status;
 
-    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, &ep->fd);
+    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, 0, &ep->fd);
     if (status != UCS_OK) {
         goto err;
     }
@@ -1289,7 +1289,7 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t recv_length)
     }
 
     status = ucs_socket_recv_nb(ep->fd, UCS_PTR_BYTE_OFFSET(ep->rx.buf,
-                                                            ep->rx.length),
+                                                            ep->rx.length), 0,
                                 &recv_length);
     if (ucs_unlikely(status != UCS_OK)) {
         uct_tcp_ep_handle_recv_err(ep, status);
@@ -1585,7 +1585,7 @@ static unsigned uct_tcp_ep_progress_put_rx(uct_tcp_ep_t *ep)
     put_req     = (uct_tcp_ep_put_req_hdr_t*)ep->rx.buf;
     recv_length = put_req->length;
     status      = ucs_socket_recv_nb(ep->fd, (void*)(uintptr_t)put_req->addr,
-                                     &recv_length);
+                                     0, &recv_length);
     if (ucs_unlikely(status != UCS_OK)) {
         uct_tcp_ep_handle_recv_err(ep, status);
         return 0;

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -771,7 +771,7 @@ static ucs_status_t uct_tcp_sockcm_ep_recv_nb(uct_tcp_sockcm_ep_t *cep)
     status = ucs_socket_recv_nb(cep->fd,
                                 UCS_PTR_BYTE_OFFSET(cep->comm_ctx.buf,
                                                     cep->comm_ctx.offset),
-                                &recv_length);
+                                0, &recv_length);
     if ((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS)) {
         if (status != UCS_ERR_NOT_CONNECTED) {  /* ECONNRESET cannot return from recv() */
             uct_cm_ep_peer_error(&cep->super,
@@ -874,7 +874,7 @@ static ucs_status_t uct_tcp_sockcm_ep_client_init(uct_tcp_sockcm_ep_t *cep,
     }
 
     server_addr = params->sockaddr->addr;
-    status = ucs_socket_create(server_addr->sa_family, SOCK_STREAM, &cep->fd);
+    status = ucs_socket_create(server_addr->sa_family, SOCK_STREAM, 0, &cep->fd);
     if (status != UCS_OK) {
         goto err;
     }

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -609,7 +609,7 @@ uint16_t get_port() {
     socklen_t len = sizeof(ret_addr);
     uint16_t port;
 
-    status = ucs_socket_create(AF_INET, SOCK_STREAM, &sock_fd);
+    status = ucs_socket_create(AF_INET, SOCK_STREAM, 0, &sock_fd);
     EXPECT_EQ(status, UCS_OK);
 
     memset(&addr_in, 0, sizeof(struct sockaddr_in));

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -542,7 +542,7 @@ UCS_TEST_F(test_socket, socket_setopt) {
 
     optlen = sizeof(optval);
 
-    status = ucs_socket_create(AF_INET, SOCK_STREAM, &fd);
+    status = ucs_socket_create(AF_INET, SOCK_STREAM, 0, &fd);
     EXPECT_UCS_OK(status);
     EXPECT_GE(fd, 0);
 

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -304,7 +304,8 @@ void test_uct_ib_with_specific_port::cleanup() {
 class test_uct_ib_roce : public test_uct_ib {
 };
 
-UCS_TEST_P(test_uct_ib_roce, local_subnet_only, "IB_ROCE_LOCAL_SUBNET=y")
+UCS_TEST_P(test_uct_ib_roce, local_subnet_only,
+           "IB_ROCE_REACHABILITY_MODE=local_subnet")
 {
     send_recv_short();
 }

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -48,7 +48,7 @@ public:
 
         scoped_log_handler slh(wrap_errors_logger);
         if (nb) {
-            status = ucs_socket_recv_nb(fd, &msg, &msg_size);
+            status = ucs_socket_recv_nb(fd, &msg, 0, &msg_size);
         } else {
             status = ucs_socket_recv(fd, &msg, msg_size);
         }
@@ -186,7 +186,7 @@ private:
         int fd;
         EXPECT_TRUE((dest_addr.ss_family == AF_INET) ||
                     (dest_addr.ss_family == AF_INET6));
-        status = ucs_socket_create(dest_addr.ss_family, SOCK_STREAM, &fd);
+        status = ucs_socket_create(dest_addr.ss_family, SOCK_STREAM, 0, &fd);
         ASSERT_UCS_OK(status);
 
         status = ucs_socket_connect(fd, (struct sockaddr*)&dest_addr);


### PR DESCRIPTION
## What
Add a new reachability check mode for IP-based lanes.

## Why ?
Currently, the reachability of IP-based lanes is only verified by checking if the local and remote addresses share the same subnet. If they do, the remote address is considered reachable.
However, we want to introduce an additional reachability check (and mode) that considers non-local addresses. This will allow us to determine if the remote address is reachable based on routing information, not just subnet matching.

## How ?
When the reachability mode is set to "route," the routing table will be consulted to verify reachability based on the specified interface and destination address.