### PR TITLE
UCT/IB/MLX5/DC: introducing dcs_hybrid policy

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -29,11 +29,12 @@
 
 
 const char *uct_dc_tx_policy_names[] = {
-    [UCT_DC_TX_POLICY_DCS]       = "dcs",
-    [UCT_DC_TX_POLICY_DCS_QUOTA] = "dcs_quota",
-    [UCT_DC_TX_POLICY_RAND]      = "rand",
-    [UCT_DC_TX_POLICY_HW_DCS]    = "hw_dcs",
-    [UCT_DC_TX_POLICY_LAST]      = NULL
+    [UCT_DC_TX_POLICY_DCS]        = "dcs",
+    [UCT_DC_TX_POLICY_DCS_QUOTA]  = "dcs_quota",
+    [UCT_DC_TX_POLICY_DCS_HYBRID] = "dcs_hybrid",
+    [UCT_DC_TX_POLICY_RAND]       = "rand",
+    [UCT_DC_TX_POLICY_HW_DCS]     = "hw_dcs",
+    [UCT_DC_TX_POLICY_LAST]       = NULL
 };
 
 static const char *uct_dct_affinity_policy_names[] = {
@@ -250,7 +251,7 @@ static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
 
     /* Error handling is not supported with random dci policy
      * TODO: Fix */
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         iface_attr->cap.flags &= ~(UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
                                    UCT_IFACE_FLAG_ERRHANDLE_ZCOPY_BUF    |
                                    UCT_IFACE_FLAG_ERRHANDLE_REMOTE_MEM);
@@ -366,7 +367,8 @@ static void uct_ib_mlx5dv_dci_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
 }
 
 ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
-                                          uint8_t dci_index, int connect)
+                                          uint8_t dci_index, int connect,
+                                          uint8_t num_dci_channels)
 {
     uct_ib_iface_t *ib_iface   = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr = {};
@@ -391,7 +393,7 @@ ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
                                            UCT_DC_MLX5_IFACE_FLAG_DCI_FULL_HANDSHAKE;
         attr.rdma_wr_disabled            = (iface->flags & UCT_DC_MLX5_IFACE_FLAG_DISABLE_PUT) &&
                                            (md->flags & UCT_IB_MLX5_MD_FLAG_NO_RDMA_WR_OPTIMIZED);
-        attr.log_num_dci_stream_channels = ucs_ilog2(iface->tx.num_dci_channels);
+        attr.log_num_dci_stream_channels = ucs_ilog2(num_dci_channels);
         status = uct_ib_mlx5_devx_create_qp(ib_iface,
                                             &iface->super.cq[UCT_IB_DIR_TX],
                                             &iface->super.cq[UCT_IB_DIR_RX],
@@ -459,7 +461,7 @@ init_qp:
         }
     }
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         ucs_arbiter_group_init(&dci->arb_group);
     } else {
         dci->ep = NULL;
@@ -765,7 +767,7 @@ uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci)
     uct_rc_txqp_cleanup(&iface->super.super, &dci->txqp);
     uct_ib_mlx5_destroy_qp(md, &dci->txwq.super);
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         ucs_arbiter_group_cleanup(&dci->arb_group);
     }
     uct_ib_mlx5_qp_mmio_cleanup(&dci->txwq.super, dci->txwq.reg);
@@ -886,8 +888,8 @@ ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
 }
 
 static ucs_status_t
-uct_dc_mlx5_iface_dcis_create(uct_dc_mlx5_iface_t *iface,
-                              const uct_dc_mlx5_iface_config_t *config)
+uct_dc_mlx5_iface_init_dcis_array(uct_dc_mlx5_iface_t *iface,
+                                  const uct_dc_mlx5_iface_config_t *config)
 {
     ucs_status_t status;
     uct_dc_dci_t *dci;
@@ -901,7 +903,7 @@ uct_dc_mlx5_iface_dcis_create(uct_dc_mlx5_iface_t *iface,
 
     ucs_array_length(&iface->tx.dcis) = 0;
 
-    status = uct_dc_mlx5_iface_create_dci(iface, 0, 0);
+    status = uct_dc_mlx5_iface_create_dci(iface, 0, 0, 1);
     if (status != UCS_OK) {
         return status;
     }
@@ -1178,7 +1180,7 @@ static void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface)
         goto out;
     }
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         txqp = &fc_dci->txqp;
         ucs_queue_for_each_safe(op, iter, &txqp->outstanding, queue) {
             if (op->handler == uct_dc_mlx5_ep_fc_pure_grant_send_completion) {
@@ -1355,7 +1357,7 @@ static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
     uct_dc_mlx5_ep_t *ep;
     ucs_log_level_t  level;
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_is_dci_shared(iface, dci_index)) {
         ep    = NULL;
         level = UCS_LOG_LEVEL_FATAL; /* error handling is not supported with rand dci */
     } else {
@@ -1593,6 +1595,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     self->tx.dcis_initial_capacity =
             ucs_min(config->dcis_initial_capacity,
                     self->tx.ndci * UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
+    self->tx.hybrid_hw_dci = uct_dc_mlx5_iface_is_hybrid(self) ?
+                                     UCT_DC_MLX5_HW_DCI_INDEX :
+                                     -1;
 
     init_attr.qp_type       = UCT_IB_QPT_DCI;
     init_attr.flags         = UCT_IB_TX_OPS_PER_PATH;
@@ -1654,16 +1659,17 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     kh_init_inplace(uct_dc_mlx5_config_hash, &self->dc_config_hash);
 
     self->tx.rand_seed = config->rand_seed ? config->rand_seed : time(NULL);
-    self->tx.pend_cb   = uct_dc_mlx5_iface_is_dci_shared(self) ?
-                         uct_dc_mlx5_iface_dci_do_rand_pending_tx :
-                         uct_dc_mlx5_iface_dci_do_dcs_pending_tx;
+    self->tx.pend_cb   = uct_dc_mlx5_iface_is_policy_shared(self) ?
+                                   uct_dc_mlx5_iface_dci_do_rand_pending_tx :
+                                   uct_dc_mlx5_iface_dci_do_dcs_pending_tx;
 
     if (config->num_dci_channels == 0) {
         ucs_error("num_dci_channels must be larger than 0");
         return UCS_ERR_INVALID_PARAM;
     }
 
-    if (uct_dc_mlx5_iface_is_hw_dcs(self)) {
+    if (uct_dc_mlx5_iface_is_hw_dcs(self) ||
+        uct_dc_mlx5_iface_is_hybrid(self)) {
         /* Calculate num_dci_channels: select minimum from requested by runtime
          * and supported by HCA, must be power of two */
         num_dci_channels          = ucs_roundup_pow2(config->num_dci_channels);
@@ -1704,7 +1710,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     }
 
     /* create DC initiators */
-    status = uct_dc_mlx5_iface_dcis_create(self, config);
+    status = uct_dc_mlx5_iface_init_dcis_array(self, config);
     if (status != UCS_OK) {
         goto err_destroy_dct;
     }

--- a/src/uct/ib/mlx5/dc/dc_mlx5.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.h
@@ -147,6 +147,7 @@ typedef enum {
     /* Policies with dedicated DCI per active connection */
     UCT_DC_TX_POLICY_DCS,
     UCT_DC_TX_POLICY_DCS_QUOTA,
+    UCT_DC_TX_POLICY_DCS_HYBRID,
     /* Policies with shared DCI */
     UCT_DC_TX_POLICY_SHARED_FIRST,
     UCT_DC_TX_POLICY_RAND = UCT_DC_TX_POLICY_SHARED_FIRST,
@@ -194,6 +195,12 @@ typedef void (*uct_dc_dci_handle_failure_func_t)(uct_dc_mlx5_iface_t *iface,
                                                  ucs_status_t status);
 
 
+typedef enum {
+    /* Indicates that this specific dci is shared, regardless of policy */
+    UCT_DC_DCI_FLAG_SHARED = UCS_BIT(0),
+} uct_dc_dci_flags_t;
+
+
 typedef struct uct_dc_dci {
     uct_rc_txqp_t                 txqp; /* DCI qp */
     uct_ib_mlx5_txwq_t            txwq; /* DCI mlx5 wq */
@@ -211,6 +218,7 @@ typedef struct uct_dc_dci {
     uint8_t                       path_index; /* Path index */
     uint8_t                       next_channel_index; /* next DCI channel index
                                                          to be used by EP */
+    uint8_t                       flags; /* See uct_dc_dci_flags_t */
 } uct_dc_dci_t;
 
 
@@ -333,6 +341,9 @@ struct uct_dc_mlx5_iface {
         uint8_t                      num_dci_channels;
 
         uint16_t                     dcis_initial_capacity;
+
+        /* used in hybrid dcs policy otherwise -1 */
+        uint16_t                     hybrid_hw_dci;
     } tx;
 
     struct {
@@ -392,7 +403,8 @@ void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,
 void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index);
 
 ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
-                                          uint8_t dci_index, int connect);
+                                          uint8_t dci_index, int connect,
+                                          uint8_t num_dci_channels);
 
 ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
                                                     uint16_t size);

--- a/src/uct/ib/mlx5/dc/dc_mlx5.inl
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.inl
@@ -65,7 +65,7 @@ uct_dc_mlx5_ep_pending_common(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
     UCS_STATIC_ASSERT(sizeof(uct_dc_mlx5_pending_req_priv) <=
                       UCT_PENDING_REQ_PRIV_LEN);
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         uct_dc_mlx5_pending_req_priv(r)->ep = ep;
         group = uct_dc_mlx5_ep_rand_arb_group(iface, ep);
     } else {

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -654,7 +654,7 @@ uct_dc_mlx5_ep_flush_cancel(uct_dc_mlx5_ep_t *ep)
     ucs_status_t status;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         /* flush(cancel) is supported only with error handling, which is not
          * supported by random policy */
         return UCS_ERR_UNSUPPORTED;
@@ -1283,7 +1283,7 @@ UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_ep_t)
     uct_dc_mlx5_ep_fc_cleanup(self);
 
     if ((self->dci == UCT_DC_MLX5_EP_NO_DCI) ||
-        uct_dc_mlx5_iface_is_dci_shared(iface)) {
+        uct_dc_mlx5_is_dci_shared(iface, self->dci)) {
         return;
     }
 
@@ -1387,18 +1387,18 @@ uct_dc_mlx5_iface_dci_do_pending_wait(ucs_arbiter_t *arbiter,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface, uct_dc_mlx5_iface_t);
     uint8_t pool_index = uct_dc_mlx5_ep_pool_index(ep);
 
-    ucs_assert(!uct_dc_mlx5_iface_is_dci_shared(iface));
+    ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
     ucs_assertv(ep->dci == UCT_DC_MLX5_EP_NO_DCI,
                 "ep %p (iface=%p) has DCI=%d (pool %d) while it is scheduled "
                 "in DCI wait queue",
                 ep, iface, ep->dci,
                 uct_dc_mlx5_iface_dci(iface, ep->dci)->pool_index);
 
-    if (!uct_dc_mlx5_iface_dci_can_alloc_or_create(iface, pool_index)) {
+    if (uct_dc_mlx5_iface_dci_can_alloc_or_create(iface, pool_index)) {
+        uct_dc_mlx5_iface_dci_alloc(iface, ep);
+    } else if (uct_dc_mlx5_set_ep_to_hw_dcs(iface, ep) != UCS_OK) {
         return UCS_ARBITER_CB_RESULT_STOP;
     }
-
-    uct_dc_mlx5_iface_dci_alloc(iface, ep);
 
     ucs_assert_always(ep->dci != UCT_DC_MLX5_EP_NO_DCI);
     uct_dc_mlx5_iface_dci_sched_tx(iface, ep);
@@ -1442,7 +1442,7 @@ unsigned uct_dc_mlx5_ep_dci_release_progress(void *arg)
     uint8_t dci;
     uct_dc_mlx5_dci_pool_t *dci_pool;
 
-    ucs_assert(!uct_dc_mlx5_iface_is_dci_shared(iface));
+    ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
     UCS_STATIC_ASSERT((sizeof(iface->tx.dci_pool_release_bitmap) * 8) <=
                        UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
 
@@ -1545,7 +1545,7 @@ uct_dc_mlx5_ep_arbiter_purge_cb(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *gro
                                                     priv);
     uct_rc_pending_req_t *freq;
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface) &&
+    if (uct_dc_mlx5_iface_is_policy_shared(iface) &&
         (uct_dc_mlx5_pending_req_priv(req)->ep != ep)) {
         /* Element belongs to another ep - do not remove it */
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
@@ -1585,7 +1585,7 @@ void uct_dc_mlx5_ep_pending_purge(uct_ep_h tl_ep,
                             &args);
 
     if ((ep->dci != UCT_DC_MLX5_EP_NO_DCI) &&
-        !uct_dc_mlx5_iface_is_dci_shared(iface)) {
+        !uct_dc_mlx5_iface_is_policy_shared(iface)) {
         uct_dc_mlx5_iface_dci_detach(iface, ep);
     }
 }
@@ -1719,7 +1719,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
               iface, ep, dci_index, txwq->super.qp_num,
               ucs_status_string(ep_status));
 
-    ucs_assert(!uct_dc_mlx5_iface_is_dci_shared(iface));
+    ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
 
     uct_dc_mlx5_update_tx_res(iface, txwq, txqp, pi);
     uct_rc_txqp_purge_outstanding(&iface->super.super, txqp, ep_status, pi, 0);

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -665,7 +665,7 @@ UCS_TEST_P(test_dc_flow_control, flush_destroy)
                                                 uct_dc_mlx5_iface_t);
     ucs_status_t status;
 
-    if (uct_dc_mlx5_iface_is_dci_shared(iface)) {
+    if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         UCS_TEST_SKIP_R("shared dcis are not supported - no pending wait");
     }
 


### PR DESCRIPTION
## What
Introducing a new dci allocation policy - dcs_hybrid which will behave the same as dcs_quota except using a dedicated HW dci when available instead of waiting for a dci from the pool to be available

## Why ?
Utilizing hw resources instead of waiting for another dci, improves latency for certain message sizes

## How ?
In case `dci_alloc_or_create` returned 0 - use the dedicated HW dci with a new dci channel.
