### PR TITLE
UCT/CUDA: Advertise MNNVL inter-node capability with shm device type

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2961,7 +2961,10 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
     if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
         UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &worker->context->tl_bitmap) {
-            if (context->tl_rscs[tl_id].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
+            if ((context->tl_rscs[tl_id].tl_rsc.dev_type ==
+                 UCT_DEVICE_TYPE_NET) ||
+                (context->tl_rscs[tl_id].tl_rsc.flags &
+                 UCT_TL_RESOURCE_FLAG_INTER_NODE)) {
                 UCS_STATIC_BITMAP_SET(&tl_bitmap, tl_id);
             }
         }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -332,7 +332,10 @@ typedef struct uct_tl_resource_desc {
                                                 (e.g. UCT_DEVICE_TYPE_NET for a network interface) */
     ucs_sys_device_t         sys_device;   /**< The identifier associated with the device
                                                 bus_id as captured in ucs_sys_bus_id_t struct */
+    uint8_t                  flags;        /**< Associated flags to the resource */
 } uct_tl_resource_desc_t;
+
+#define UCT_TL_RESOURCE_FLAG_INTER_NODE UCS_BIT(0) /**< Inter-node capability */
 
 #define UCT_TL_RESOURCE_DESC_FMT              "%s/%s"
 #define UCT_TL_RESOURCE_DESC_ARG(_resource)   (_resource)->tl_name, (_resource)->dev_name

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -385,6 +385,7 @@ typedef struct uct_tl_device_resource {
                                               (e.g. UCT_DEVICE_TYPE_NET for a network interface) */
     ucs_sys_device_t         sys_device; /**< The identifier associated with the device
                                               bus_id as captured in ucs_sys_bus_id_t struct */
+    uint8_t                  flags;      /**< Associated flags to the resource */
 } uct_tl_device_resource_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -120,6 +120,7 @@ ucs_status_t uct_md_query_tl_resources(uct_md_h md,
                              sizeof(tmp[num_resources + i].dev_name));
             tmp[num_resources + i].dev_type   = tl_devices[i].type;
             tmp[num_resources + i].sys_device = tl_devices[i].sys_device;
+            tmp[num_resources + i].flags      = tl_devices[i].flags;
         }
 
         resources      = tmp;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -611,16 +611,25 @@ uct_cuda_ipc_query_devices(
         uct_md_h uct_md, uct_tl_device_resource_t **tl_devices_p,
         unsigned *num_tl_devices_p)
 {
+    uint8_t flags              = 0;
     uct_device_type_t dev_type = UCT_DEVICE_TYPE_SHM;
+    ucs_status_t status;
+
 #if HAVE_CUDA_FABRIC
     uct_cuda_ipc_md_t *md      = ucs_derived_of(uct_md, uct_cuda_ipc_md_t);
 
     if (uct_cuda_ipc_iface_is_mnnvl_supported(md)) {
-        dev_type = UCT_DEVICE_TYPE_NET;
+        flags = UCT_TL_RESOURCE_FLAG_INTER_NODE;
     }
 #endif
-    return uct_cuda_base_query_devices_common(uct_md, dev_type,
-                                              tl_devices_p, num_tl_devices_p);
+    status = uct_cuda_base_query_devices_common(uct_md, dev_type, tl_devices_p,
+                                                num_tl_devices_p);
+    if (status == UCS_OK) {
+        ucs_assert(*num_tl_devices_p == 1);
+        (*tl_devices_p)->flags = flags;
+    }
+
+    return status;
 }
 
 UCS_CLASS_DEFINE(uct_cuda_ipc_iface_t, uct_cuda_iface_t);


### PR DESCRIPTION
## What
Keep cuda device type as SHM and advertise MNNVL as SHM with inter-node capability to avoid `cuda_ipc` transport deactivation when specifying `UCX_NET_DEVICES`.

## Why ?
We do not need to be able to list/exclude MNNVL from/with `UCX_NET_DEVICES=^cuda` as there is already the specific configuration `ENABLE_MNNVL` to control that.

## How ?
Sanity tested, but not end-to-end tested.
