### PR TITLE
UCT/CUDA: Avoid crash in MPI_Finalize when CUDA context is destroyed

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -76,10 +76,22 @@ static UCS_F_ALWAYS_INLINE int uct_cuda_base_is_context_active()
 }
 
 
+static UCS_F_ALWAYS_INLINE int uct_cuda_base_is_context_valid(CUcontext ctx)
+{
+    unsigned version;
+    ucs_status_t status;
+
+    /* Check if CUDA context is valid by running a dummy operation on it */
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetApiVersion(ctx, &version));
+    return (status == UCS_OK);
+}
+
+
 static UCS_F_ALWAYS_INLINE int uct_cuda_base_context_match(CUcontext ctx1,
                                                            CUcontext ctx2)
 {
-    return ((ctx1 != NULL) && (ctx1 == ctx2));
+    return ((ctx1 != NULL) && (ctx1 == ctx2) &&
+            uct_cuda_base_is_context_valid(ctx1));
 }
 
 


### PR DESCRIPTION
## What
There is a crash in UCX when we destroy CUDA interfaces (cuda_ipc_iface and cuda_copy_iface) with CUDA context already closed by an application.
The goal of this fix is to avoid crash of UCX, while still printing the errors and release non-CUDA related objects

## Why ?
There is such a use case in Fortran client app:
1. CALL ACC_SHUTDOWN(ACC_DEVICE_NVIDIA)  << This essentially closes CUDA context
2. call MPI_Finalize(ierr)  << Here CUDA context is closed and we cannot release the resources
If we reverse the order of these operations then the issue disappears.

## How ?
Now we check CUDA context for validity using some dummy operation on it: `cuCtxGetApiVersion`