### PR TITLE
UCT/IB/MLX5: enable ddp support when available

### DIFF
--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -278,6 +278,12 @@ AS_IF([test "x$with_ib" = "xyes"],
            AC_CHECK_DECLS([ibv_alloc_dm],
                [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support])],
                [], [[#include <infiniband/verbs.h>]])])
+        
+        # DDP support
+        AS_IF([test "x$have_mlx5" = xyes], [
+           AC_CHECK_DECLS([MLX5DV_CONTEXT_MASK_OOO_RECV_WRS],
+               [AC_DEFINE([HAVE_OOO_RECV_WRS], 1, [Have DDP support])],
+               [], [[#include <infiniband/mlx5dv.h>]])])
 
        mlnx_valg_libdir=$with_verbs/lib${libsuff}/mlnx_ofed/valgrind
        AC_MSG_NOTICE([Checking OFED valgrind libs $mlnx_valg_libdir])

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -207,9 +207,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC = UCS_BIT(20),
     /* RoCE supports forcing ordering configuration */
     UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE     = UCS_BIT(21),
+    /* Device supports DDP (OOO data placement)*/
+    UCT_IB_MLX5_MD_FLAG_DDP                   = UCS_BIT(22),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 22,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 23,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -1055,6 +1055,9 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
                                         struct mlx5dv_qp_init_attr *dv_attr,
                                         unsigned scat2cqe_dir_mask)
 {
+    uct_ib_mlx5_md_t UCS_V_UNUSED *md = uct_ib_mlx5_iface_md(
+            &iface->super.super);
+
 #if HAVE_DECL_MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE
     if ((scat2cqe_dir_mask & UCS_BIT(UCT_IB_DIR_RX)) &&
         (iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] == 0)) {
@@ -1083,6 +1086,13 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
         }
 #endif
     }
+
+#ifdef HAVE_OOO_RECV_WRS
+    if (md->flags & UCT_IB_MLX5_MD_FLAG_DDP) {
+        dv_attr->create_flags |= MLX5DV_QP_CREATE_OOO_DP;
+        dv_attr->comp_mask    |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
+    }
+#endif
 }
 #endif
 


### PR DESCRIPTION
## What
Enable ddp support for mlx5dv flow, in order to use it need to disable devx: `UCX_IB_MLX5_DEVX=no`

## Why ?
DDP is a new feature in CX8 
