### PR TITLE
UCT/GGA: Initialize RoCE multipath configuration when creating interface

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1610,7 +1610,7 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
             &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC,
             &config->rc_mlx5_common, "dc");
     if (status != UCS_OK) {
-        return UCS_ERR_INVALID_PARAM;
+        return status;
     }
 
     tx_cq_size = uct_ib_cq_size(&self->super.super.super, &init_attr,

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -496,6 +496,7 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
             ucs_derived_of(tl_config, uct_gga_mlx5_iface_config_t);
     uct_ib_mlx5_md_t *md                = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
     uct_ib_iface_init_attr_t init_attr  = {};
+    ucs_status_t status;
 
     init_attr.qp_type               = IBV_QPT_RC;
     init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx_cq_len;
@@ -508,6 +509,13 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
                               &uct_gga_mlx5_iface_ops, tl_md, worker, params,
                               &config->super.super, &config->rc_mlx5_common,
                               &init_attr);
+
+    status = uct_rc_mlx5_dp_ordering_ooo_init(
+            &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC,
+            &config->rc_mlx5_common, "gga");
+    if (status != UCS_OK) {
+        return status;
+    }
 
     uct_gga_mlx5_iface_disable_rx(&self->super);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -654,7 +654,7 @@ failure:
     ucs_error("%s: cannot set ar_enable=%d for RoCE on %s",
               uct_ib_device_name(&md->super.dev), config->super.ar_enable,
               tl_name);
-    return UCS_ERR_UNSUPPORTED;
+    return UCS_ERR_INVALID_PARAM;
 }
 
 #if IBV_HW_TM

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -927,7 +927,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
             &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC,
             &config->rc_mlx5_common, "rc_mlx5");
     if (status != UCS_OK) {
-        return UCS_ERR_INVALID_PARAM;
+        return status;
     }
 
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);


### PR DESCRIPTION
## What
Initialize adaptive routing configuration when creating GGA interface. Relates to #10013.

## Why?
Avoid random QP modify failures on CI.