### PR TITLE
UCT/API: Add new MD resource query API

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1052,43 +1052,8 @@ int uct_iface_is_reachable_v2(uct_iface_h iface,
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Capability flags of @ref uct_tl_resource_desc_t.
- *
- * The enumeration defines bit mask of capabilities in @ref
- * uct_tl_resource_desc_v2_t::flags, set by @ref uct_md_query_tl_resources_v2.
- */
-typedef enum {
-    /**
-     * If set, the resource supports inter-node communications.
-     */
-    UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
-} uct_md_query_tl_resources_flags_t;
-
-
-/**
- * @ingroup UCT_RESOURCE
- * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
- */
-typedef struct {
-    /**
-     * Mask of valid fields which must currently be set to zero.
-     * Future fields not specified in this mask will be ignored.
-     * Provides ABI compatibility with respect to adding new fields.
-     */
-    uint64_t field_mask;
-} uct_md_query_tl_resources_params_t;
-
-
-/**
- * @ingroup UCT_RESOURCE
  * @brief Communication resource descriptor.
  *
- * Resource descriptor is an object representing the network resource.
- * Resource descriptor could represent a stand-alone communication resource
- * such as an HCA port, network interface, or multiple resources such as
- * multiple network interfaces or communication ports. It could also represent
- * virtual communication resources that are defined over a single physical
- * network interface.
  */
 typedef struct uct_tl_resource_desc_v2 {
     /**
@@ -1123,6 +1088,72 @@ typedef struct uct_tl_resource_desc_v2 {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Capability flags in @ref uct_tl_resource_desc_v2_t.
+ *
+ * The enumeration defines bit mask of capabilities in @ref
+ * uct_tl_resource_desc_v2_t::flags.
+ */
+typedef enum {
+    /**
+     * If set, the resource supports inter-node communications.
+     */
+    UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
+} uct_md_query_tl_resources_flags_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Describe valid input/output fields set in @ref
+ * uct_md_query_tl_resources_params_t::field_mask
+ */
+typedef enum {
+    /*
+     * The function @ref uct_md_query_tl_resources_v2 will return a populated
+     * resource array.
+     */
+    UCT_MD_QUERY_TL_RESOURCES_PARAM_FIELD_RESOURCES = UCS_BIT(0)
+} uct_md_query_tl_resources_params_flags_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
+ */
+typedef struct {
+    /**
+     * Mask of valid or requested fields in this structure.
+     * Fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t field_mask;
+
+    /*
+     * Number of resources returned in the resource descriptor. It is an output
+     * parameter populated when @ref
+     * UCT_MD_QUERY_TL_RESOURCES_PARAM_FIELD_RESOURCES is set in @ref
+     * uct_md_query_tl_resources_params_t::field_mask.
+     */
+    unsigned num_resources;
+
+    /**
+     * Resource descriptor is an object representing the network resource.
+     * Resource descriptor could represent a stand-alone communication resource
+     * such as an HCA port, network interface, or multiple resources such as
+     * multiple network interfaces or communication ports. It could also represent
+     * virtual communication resources that are defined over a single physical
+     * network interface.
+     *
+     * It is an output parameter populated when @ref
+     * UCT_MD_QUERY_TL_RESOURCES_PARAM_FIELD_RESOURCES is set in @ref
+     * uct_md_query_tl_resources_params_t::field_mask, which must be released
+     * by @ref uct_release_tl_resource_list_v2.
+     */
+    uct_tl_resource_desc_v2_t *resources;
+} uct_md_query_tl_resources_params_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Query for transport resources.
  *
  * This routine queries the @ref uct_md_h "memory domain" for communication
@@ -1131,17 +1162,12 @@ typedef struct uct_tl_resource_desc_v2 {
  * @param [in]    md              Handle to memory domain.
  * @param [inout] params          Parameters as defined in @ref
  *                                uct_md_query_tl_resources_params_t.
- * @param [out]   resources_p     Filled with a pointer to an array of resource
- *                                descriptors.
- * @param [out]   num_resources_p Filled with the number of resources in the array.
  *
  * @return Error code.
  */
 ucs_status_t
 uct_md_query_tl_resources_v2(uct_md_h md,
-                             uct_md_query_tl_resources_params_t *params,
-                             uct_tl_resource_desc_v2_t **resources_p,
-                             unsigned *num_resources_p);
+                             uct_md_query_tl_resources_params_t *params);
 
 
 /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1052,6 +1052,83 @@ int uct_iface_is_reachable_v2(uct_iface_h iface,
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
+ */
+typedef struct uct_md_query_tl_resources_params {
+    /**
+     * Mask of valid fields which must currently be set to zero.
+     * Future fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t                       field_mask;
+} uct_md_query_tl_resources_params_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Capability flags of @ref uct_tl_resource_desc_t.
+ *
+ * The enumeration defines bit mask of capabilities in @ref
+ * uct_tl_resource_desc_v2_t::flags, set by @ref uct_md_query_tl_resources_v2.
+ */
+enum {
+    /**
+     * If set, the resource supports inter-node communications.
+     */
+    UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Communication resource descriptor.
+ *
+ * Resource descriptor of a standalone communication resource with extraneous
+ * flags.
+ */
+typedef struct uct_tl_resource_desc_v2 {
+    uct_tl_resource_desc_t desc;  /**< Main resource descriptor */
+    uint64_t               flags; /**< Associated resource flags */
+} uct_tl_resource_desc_v2_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Query for transport resources.
+ *
+ * This routine queries the @ref uct_md_h "memory domain" for communication
+ * resources that are available for it.
+ *
+ * @param [in]  md              Handle to memory domain.
+ * @param [out] resources_p     Filled with a pointer to an array of resource
+ *                              descriptors.
+ * @param [out] num_resources_p Filled with the number of resources in the array.
+ * @param [in]  params          Parameters as defined in @ref
+ *                              uct_md_query_tl_resources_params_t.
+ *
+ * @return Error code.
+ */
+ucs_status_t
+uct_md_query_tl_resources_v2(uct_md_h md,
+                             uct_tl_resource_desc_v2_t **resources_p,
+                             unsigned *num_resources_p,
+                             uct_md_query_tl_resources_params_t *params);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Release the list of resources returned from @ref uct_md_query_tl_resources_v2.
+ *
+ * This routine releases the memory associated with the list of resources
+ * allocated by @ref uct_md_query_tl_resources_v2.
+ *
+ * @param [in] resources  Array of resource descriptors to release.
+ */
+void uct_release_tl_resource_list_v2(uct_tl_resource_desc_v2_t *resources);
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Connect endpoint to a remote endpoint.
  *
  * requires @ref UCT_IFACE_FLAG_CONNECT_TO_EP capability.

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1099,20 +1099,20 @@ typedef struct uct_tl_resource_desc_v2 {
  * This routine queries the @ref uct_md_h "memory domain" for communication
  * resources that are available for it.
  *
- * @param [in]  md              Handle to memory domain.
- * @param [out] resources_p     Filled with a pointer to an array of resource
- *                              descriptors.
- * @param [out] num_resources_p Filled with the number of resources in the array.
- * @param [in]  params          Parameters as defined in @ref
- *                              uct_md_query_tl_resources_params_t.
+ * @param [in]    md              Handle to memory domain.
+ * @param [inout] params          Parameters as defined in @ref
+ *                                uct_md_query_tl_resources_params_t.
+ * @param [out]   resources_p     Filled with a pointer to an array of resource
+ *                                descriptors.
+ * @param [out]   num_resources_p Filled with the number of resources in the array.
  *
  * @return Error code.
  */
 ucs_status_t
 uct_md_query_tl_resources_v2(uct_md_h md,
+                             uct_md_query_tl_resources_params_t *params,
                              uct_tl_resource_desc_v2_t **resources_p,
-                             unsigned *num_resources_p,
-                             uct_md_query_tl_resources_params_t *params);
+                             unsigned *num_resources_p);
 
 
 /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1052,31 +1052,31 @@ int uct_iface_is_reachable_v2(uct_iface_h iface,
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
- */
-typedef struct uct_md_query_tl_resources_params {
-    /**
-     * Mask of valid fields which must currently be set to zero.
-     * Future fields not specified in this mask will be ignored.
-     * Provides ABI compatibility with respect to adding new fields.
-     */
-    uint64_t                       field_mask;
-} uct_md_query_tl_resources_params_t;
-
-
-/**
- * @ingroup UCT_RESOURCE
  * @brief Capability flags of @ref uct_tl_resource_desc_t.
  *
  * The enumeration defines bit mask of capabilities in @ref
  * uct_tl_resource_desc_v2_t::flags, set by @ref uct_md_query_tl_resources_v2.
  */
-enum {
+typedef enum {
     /**
      * If set, the resource supports inter-node communications.
      */
     UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
-};
+} uct_md_query_tl_esources_flags_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
+ */
+typedef struct {
+    /**
+     * Mask of valid fields which must currently be set to zero.
+     * Future fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t field_mask;
+} uct_md_query_tl_resources_params_t;
 
 
 /**
@@ -1087,8 +1087,16 @@ enum {
  * flags.
  */
 typedef struct uct_tl_resource_desc_v2 {
-    uct_tl_resource_desc_t desc;  /**< Main resource descriptor */
-    uint64_t               flags; /**< Associated resource flags */
+    /**
+     * Main resource descriptor
+     */
+    uct_tl_resource_desc_t desc;
+
+    /**
+     * Associated resource flags using bits from @ref
+     * uct_md_query_tl_resources_flags_t.
+     */
+    uint64_t               flags;
 } uct_tl_resource_desc_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1062,7 +1062,7 @@ typedef enum {
      * If set, the resource supports inter-node communications.
      */
     UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
-} uct_md_query_tl_esources_flags_t;
+} uct_md_query_tl_resources_flags_t;
 
 
 /**
@@ -1083,20 +1083,41 @@ typedef struct {
  * @ingroup UCT_RESOURCE
  * @brief Communication resource descriptor.
  *
- * Resource descriptor of a standalone communication resource with extraneous
- * flags.
+ * Resource descriptor is an object representing the network resource.
+ * Resource descriptor could represent a stand-alone communication resource
+ * such as an HCA port, network interface, or multiple resources such as
+ * multiple network interfaces or communication ports. It could also represent
+ * virtual communication resources that are defined over a single physical
+ * network interface.
  */
 typedef struct uct_tl_resource_desc_v2 {
     /**
-     * Main resource descriptor
+     * Transport name
      */
-    uct_tl_resource_desc_t desc;
+    char              tl_name[UCT_TL_NAME_MAX];
+
+    /**
+     * Hardware device name
+     */
+    char              dev_name[UCT_DEVICE_NAME_MAX];
+
+    /**
+     * Device represented by this resource
+     * (e.g. UCT_DEVICE_TYPE_NET for a network interface)
+     */
+    uct_device_type_t dev_type;
+
+    /**
+     * The identifier associated with the device bus_id as captured in
+     * @ref ucs_sys_bus_id_t
+     */
+    ucs_sys_device_t  sys_device;
 
     /**
      * Associated resource flags using bits from @ref
      * uct_md_query_tl_resources_flags_t.
      */
-    uint64_t               flags;
+    uint64_t          flags;
 } uct_tl_resource_desc_v2_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -172,9 +172,9 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
 
 ucs_status_t uct_md_query_tl_resources_v2(
         uct_md_h UCS_V_UNUSED md,
+        uct_md_query_tl_resources_params_t *UCS_V_UNUSED params,
         uct_tl_resource_desc_v2_t **UCS_V_UNUSED resources_p,
-        unsigned *UCS_V_UNUSED num_resources_p,
-        uct_md_query_tl_resources_params_t *UCS_V_UNUSED params)
+        unsigned *UCS_V_UNUSED num_resources_p)
 {
     return UCS_ERR_NOT_IMPLEMENTED;
 }

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -170,6 +170,20 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
     return UCS_OK;
 }
 
+ucs_status_t uct_md_query_tl_resources_v2(
+        uct_md_h UCS_V_UNUSED md,
+        uct_tl_resource_desc_v2_t **UCS_V_UNUSED resources_p,
+        unsigned *UCS_V_UNUSED num_resources_p,
+        uct_md_query_tl_resources_params_t *UCS_V_UNUSED params)
+{
+    return UCS_ERR_NOT_IMPLEMENTED;
+}
+
+void uct_release_tl_resource_list_v2(
+        uct_tl_resource_desc_v2_t *UCS_V_UNUSED resources)
+{
+}
+
 ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
                                      const void *rkey_buffer, uct_rkey_t *rkey_p,
                                      void **handle_p)

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -172,9 +172,7 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
 
 ucs_status_t uct_md_query_tl_resources_v2(
         uct_md_h UCS_V_UNUSED md,
-        uct_md_query_tl_resources_params_t *UCS_V_UNUSED params,
-        uct_tl_resource_desc_v2_t **UCS_V_UNUSED resources_p,
-        unsigned *UCS_V_UNUSED num_resources_p)
+        uct_md_query_tl_resources_params_t *UCS_V_UNUSED params)
 {
     return UCS_ERR_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
## What
Introduce UCT MD transport resource descriptor query v2. Relates to #10141.

## Why ?
More parameters need to be queried and UCT ABI cannot change.

## How ?
Add all mandatory fields as parameters, use new `params` for future parameter (in and out).