### PR TITLE
AZP: Retry git clone

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -247,3 +247,23 @@ get_arch() {
         echo "$arch"
     fi
 }
+
+git_clone_with_retry() {
+    local branch="$1"
+    local target_dir="$2"
+    local depth="$3"
+    local max_attempts=5
+
+    for attempt in $(seq 1 $max_attempts); do
+        echo "Attempt $attempt of $max_attempts: Cloning UCX (branch: $branch)"
+        if git clone --depth "$depth" -b "$branch" "$BUILD_REPOSITORY_URI" "$target_dir"; then
+            echo "Clone successful"
+            return 0
+        fi
+        echo "Clone failed. Retrying in 5 seconds..."
+        sleep 5
+    done
+
+    echo "Failed to clone UCX after $max_attempts attempts"
+    return 1
+}

--- a/buildlib/pr/wire_compat.yml
+++ b/buildlib/pr/wire_compat.yml
@@ -72,8 +72,10 @@ jobs:
       - bash: chmod u+rwx $(System.DefaultWorkingDirectory)/$(ucx_current)/bin/ucx_info
       - bash: |
           set -eEx
+          source buildlib/az-helpers.sh
           ucx_dir=$(System.DefaultWorkingDirectory)/$(ucx_legacy)
-          git clone --depth 1 -b $(ucx_tag) https://github.com/openucx/ucx.git ${ucx_dir}
+          depth=1
+          git_clone_with_retry "$(ucx_tag)" "${ucx_dir}" "${depth}"
           cd ${ucx_dir}
           ./autogen.sh
           ./contrib/configure-release --enable-assertions --prefix=${PWD} --without-java --without-go


### PR DESCRIPTION
## What
Retry 'git clone' command in case of a failure.

## Why ?
Sometimes we get a git clone error:
```
git clone --depth 1 -b v1.16.x https://github.com/openucx/ucx.git /__w/2/s/ucx_v1.16.x_88170_gpu
Cloning into '/__w/2/s/ucx_v1.16.x_88170_gpu'...
error: RPC failed; result=18, HTTP code = 200
fatal: The remote end hung up unexpectedly 
```
Switching to the built-in Azure function will prevent such failures using the retry logic.

