### PR TITLE
UCT/VERBS/RC: Fix the macro that is supposed fill desc within uct rc.

### DIFF
--- a/src/uct/ib/rc/verbs/rc_verbs_impl.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_impl.h
@@ -195,7 +195,7 @@ uct_rc_verbs_iface_fill_inl_am_sge_iov(uct_rc_verbs_iface_t *iface, uint8_t id,
         struct ibv_sge *sge; \
         (_wr)->next    = NULL; \
         sge            = (_wr)->sg_list; \
-        sge->addr      = (uintptr_t)(desc + 1); \
+        sge->addr      = (uintptr_t)((_desc) + 1); \
         sge->lkey      = (_desc)->lkey; \
     }
 


### PR DESCRIPTION
Fix the macro that is supposed fill desc withing uct rc.

## What
This change fixes a typo in the implementation of `UCT_RC_VERBS_FILL_DESC_WR`.

## Why
The assignment to `sge->addr` incorrectly uses `desc` instead of `_desc`. While this won't cause a compilation error if the actual variable passed to the macro is named `desc`, the macro should consistently use `_desc` throughout its implementation.

## How
Since this is just a typo, the only change required was adding an underscore (`_`)!

