### PR TITLE
UCT/API: Add new MD resource query API implementation

### DIFF
--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -131,8 +131,8 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
                                  UCT_IFACE_PARAM_FIELD_STATS_ROOT  |
                                  UCT_IFACE_PARAM_FIELD_RX_HEADROOM,
         .open_mode             = UCT_IFACE_OPEN_MODE_DEVICE,
-        .mode.device.tl_name   = resource->desc.tl_name,
-        .mode.device.dev_name  = resource->desc.dev_name,
+        .mode.device.tl_name   = resource->tl_name,
+        .mode.device.dev_name  = resource->dev_name,
         .stats_root            = ucs_stats_get_root(),
         .rx_headroom           = 0
     };
@@ -142,19 +142,19 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
     ucs_status_t status;
     uct_iface_h iface;
 
-    status = uct_md_iface_config_read(md, resource->desc.tl_name, NULL, NULL, &iface_config);
+    status = uct_md_iface_config_read(md, resource->tl_name, NULL, NULL, &iface_config);
     if (status != UCS_OK) {
         return;
     }
 
-    printf("#      Transport: %s\n", resource->desc.tl_name);
-    printf("#         Device: %s\n", resource->desc.dev_name);
-    printf("#           Type: %s\n", uct_device_type_names[resource->desc.dev_type]);
+    printf("#      Transport: %s\n", resource->tl_name);
+    printf("#         Device: %s\n", resource->dev_name);
+    printf("#           Type: %s\n", uct_device_type_names[resource->dev_type]);
     printf("#          Flags: 0x%zx\n", resource->flags);
     printf("#  System device: %s",
-           ucs_topo_sys_device_get_name(resource->desc.sys_device));
-    if (resource->desc.sys_device != UCS_SYS_DEVICE_ID_UNKNOWN) {
-        printf(" (%d)", resource->desc.sys_device);
+           ucs_topo_sys_device_get_name(resource->sys_device));
+    if (resource->sys_device != UCS_SYS_DEVICE_ID_UNKNOWN) {
+        printf(" (%d)", resource->sys_device);
     }
     printf("\n");
 
@@ -350,8 +350,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
 
 static ucs_status_t print_tl_info(uct_md_h md, const char *tl_name,
                                   const uct_tl_resource_desc_v2_t *resources,
-                                  unsigned num_resources,
-                                  int print_opts,
+                                  unsigned num_resources, int print_opts,
                                   ucs_config_print_flags_t print_flags)
 {
     ucs_async_context_t async;
@@ -376,7 +375,7 @@ static ucs_status_t print_tl_info(uct_md_h md, const char *tl_name,
         printf("# (No supported devices found)\n");
     }
     for (i = 0; i < num_resources; ++i) {
-        ucs_assert(!strcmp(tl_name, resources[i].desc.tl_name));
+        ucs_assert(!strcmp(tl_name, resources[i].tl_name));
         print_iface_info(worker, md, &resources[i]);
     }
 
@@ -416,8 +415,8 @@ static void print_md_info(uct_component_h component,
     }
 
     params.field_mask = 0;
-    status = uct_md_query_tl_resources_v2(md, &resources, &num_resources,
-                                          &params);
+    status            = uct_md_query_tl_resources_v2(md, &params, &resources,
+                                                     &num_resources);
     if (status != UCS_OK) {
         printf("#   < failed to query memory domain resources >\n");
         goto out_close_md;
@@ -430,7 +429,7 @@ static void print_md_info(uct_component_h component,
     if (req_tl_name != NULL) {
         resource_index = 0;
         while (resource_index < num_resources) {
-            if (!strcmp(resources[resource_index].desc.tl_name, req_tl_name)) {
+            if (!strcmp(resources[resource_index].tl_name, req_tl_name)) {
                 break;
             }
             ++resource_index;
@@ -523,10 +522,10 @@ static void print_md_info(uct_component_h component,
     resource_index = 0;
     while (resource_index < num_resources) {
         /* Gather all resources for this transport */
-        tl_name = resources[resource_index].desc.tl_name;
+        tl_name = resources[resource_index].tl_name;
         count = 1;
         for (j = resource_index + 1; j < num_resources; ++j) {
-            if (!strcmp(tl_name, resources[j].desc.tl_name)) {
+            if (!strcmp(tl_name, resources[j].tl_name)) {
                 tmp = resources[count + resource_index];
                 resources[count + resource_index] = resources[j];
                 resources[j] = tmp;

--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -122,7 +122,7 @@ static const char *size_limit_to_str(size_t min_size, size_t max_size)
 }
 
 static void print_iface_info(uct_worker_h worker, uct_md_h md,
-                             uct_tl_resource_desc_v2_t *resource)
+                             const uct_tl_resource_desc_v2_t *resource)
 {
     char buf[256]                   = {0};
     uct_iface_params_t iface_params = {
@@ -349,7 +349,7 @@ static void print_iface_info(uct_worker_h worker, uct_md_h md,
 }
 
 static ucs_status_t print_tl_info(uct_md_h md, const char *tl_name,
-                                  uct_tl_resource_desc_v2_t *resources,
+                                  const uct_tl_resource_desc_v2_t *resources,
                                   unsigned num_resources,
                                   int print_opts,
                                   ucs_config_print_flags_t print_flags)

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -39,7 +39,7 @@ KHASH_IMPL(ucp_context_imported_mem_hash, uint64_t, ucs_rcache_t*, 1,
 enum {
     /* The flag indicates that the resource may be used for auxiliary
      * wireup communications only */
-    UCP_TL_RSC_FLAG_AUX        = UCS_BIT(0)
+    UCP_TL_RSC_FLAG_AUX = UCS_BIT(0)
 };
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -39,7 +39,10 @@ KHASH_IMPL(ucp_context_imported_mem_hash, uint64_t, ucs_rcache_t*, 1,
 enum {
     /* The flag indicates that the resource may be used for auxiliary
      * wireup communications only */
-    UCP_TL_RSC_FLAG_AUX = UCS_BIT(0)
+    UCP_TL_RSC_FLAG_AUX        = UCS_BIT(0),
+    /* The flag indicates that the resource may be used as inter-node
+     * communication */
+    UCP_TL_RSC_FLAG_INTER_NODE = UCS_BIT(1)
 };
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -39,10 +39,7 @@ KHASH_IMPL(ucp_context_imported_mem_hash, uint64_t, ucs_rcache_t*, 1,
 enum {
     /* The flag indicates that the resource may be used for auxiliary
      * wireup communications only */
-    UCP_TL_RSC_FLAG_AUX        = UCS_BIT(0),
-    /* The flag indicates that the resource may be used as inter-node
-     * communication */
-    UCP_TL_RSC_FLAG_INTER_NODE = UCS_BIT(1)
+    UCP_TL_RSC_FLAG_AUX        = UCS_BIT(0)
 };
 
 
@@ -236,7 +233,7 @@ struct ucp_config {
  * UCP communication resource descriptor
  */
 typedef struct ucp_tl_resource_desc {
-    uct_tl_resource_desc_t        tl_rsc;       /* UCT resource descriptor */
+    uct_tl_resource_desc_v2_t     tl_rsc;       /* UCT resource descriptor */
     uint16_t                      tl_name_csum; /* Checksum of transport name */
     ucp_md_index_t                md_index;     /* Memory domain index (within the context) */
     ucp_rsc_index_t               dev_index;    /* Arbitrary device index. Resources

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3144,7 +3144,7 @@ void ucp_ep_config_lane_info_str(ucp_worker_h worker,
                                  ucs_string_buffer_t *strbuf)
 {
     ucp_context_h context = worker->context;
-    uct_tl_resource_desc_t *rsc;
+    uct_tl_resource_desc_v2_t *rsc;
     ucp_rsc_index_t rsc_index;
     ucp_md_index_t dst_md_index;
     ucp_md_index_t md_index;
@@ -3485,7 +3485,7 @@ void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
                               ucs_string_buffer_t *lane_info_strb)
 {
     ucp_rsc_index_t rsc_index;
-    uct_tl_resource_desc_t *tl_rsc;
+    uct_tl_resource_desc_v2_t *tl_rsc;
 
     if (lane == UCP_NULL_LANE) {
         ucs_string_buffer_appendf(lane_info_strb, "NULL lane");
@@ -3691,7 +3691,7 @@ static ucs_status_t ucp_ep_query_transport(ucp_ep_h ep, ucp_ep_attr_t *attr)
 {
     ucp_worker_h worker     = ep->worker;
     ucp_ep_config_t *config = ucp_ep_config(ep);
-    const uct_tl_resource_desc_t *rsc;
+    const uct_tl_resource_desc_v2_t *rsc;
     ucp_transport_entry_t *transport_entry;
     size_t device_limit;
     size_t transport_limit;

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -97,7 +97,7 @@ static inline ucp_rsc_index_t ucp_ep_get_rsc_index(ucp_ep_h ep, ucp_lane_index_t
     return ucp_ep_config(ep)->key.lanes[lane].rsc_index;
 }
 
-static inline const uct_tl_resource_desc_t *
+static inline const uct_tl_resource_desc_v2_t *
 ucp_ep_get_tl_rsc(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     return &ep->worker->context->tl_rscs[ucp_ep_get_rsc_index(ep, lane)].tl_rsc;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2961,7 +2961,9 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
     if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
         UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &worker->context->tl_bitmap) {
-            if (context->tl_rscs[tl_id].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
+            if ((context->tl_rscs[tl_id].tl_rsc.dev_type ==
+                 UCT_DEVICE_TYPE_NET) ||
+                (context->tl_rscs[tl_id].flags & UCP_TL_RSC_FLAG_INTER_NODE)) {
                 UCS_STATIC_BITMAP_SET(&tl_bitmap, tl_id);
             }
         }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2963,7 +2963,8 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &worker->context->tl_bitmap) {
             if ((context->tl_rscs[tl_id].tl_rsc.dev_type ==
                  UCT_DEVICE_TYPE_NET) ||
-                (context->tl_rscs[tl_id].flags & UCP_TL_RSC_FLAG_INTER_NODE)) {
+                (context->tl_rscs[tl_id].tl_rsc.flags &
+                 UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE)) {
                 UCS_STATIC_BITMAP_SET(&tl_bitmap, tl_id);
             }
         }

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -242,7 +242,8 @@ void ucp_proto_common_lane_perf_node(ucp_context_h context,
                                      const uct_perf_attr_t *perf_attr,
                                      ucp_proto_perf_node_t **perf_node_p)
 {
-    const uct_tl_resource_desc_t *tl_rsc = &context->tl_rscs[rsc_index].tl_rsc;
+    const uct_tl_resource_desc_v2_t *tl_rsc =
+            &context->tl_rscs[rsc_index].tl_rsc;
     ucp_proto_perf_node_t *perf_node;
 
     if (perf_attr->operation == UCT_EP_OP_LAST) {

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -239,7 +239,7 @@ ucp_wireup_test_select_flags(const ucp_wireup_select_flags_t *select_flags,
 }
 
 static int
-ucp_wireup_check_select_flags(const uct_tl_resource_desc_t *resource,
+ucp_wireup_check_select_flags(const uct_tl_resource_desc_v2_t *resource,
                               uint64_t flags,
                               const ucp_wireup_select_flags_t *select_flags,
                               const char *title, const char **flag_descs,
@@ -263,7 +263,7 @@ ucp_wireup_check_select_flags(const uct_tl_resource_desc_t *resource,
     return 1;
 }
 
-static int ucp_wireup_check_flags(const uct_tl_resource_desc_t *resource,
+static int ucp_wireup_check_flags(const uct_tl_resource_desc_v2_t *resource,
                                   uint64_t flags, uint64_t select_flags,
                                   const char *title, const char **flag_descs,
                                   char *reason, size_t max)
@@ -275,7 +275,7 @@ static int ucp_wireup_check_flags(const uct_tl_resource_desc_t *resource,
                                          flag_descs, reason, max);
 }
 
-static int ucp_wireup_check_amo_flags(const uct_tl_resource_desc_t *resource,
+static int ucp_wireup_check_amo_flags(const uct_tl_resource_desc_v2_t *resource,
                                       uint64_t flags, uint64_t required_flags,
                                       int op_size, int fetch,
                                       const char *title, char *reason,
@@ -306,9 +306,10 @@ ucp_wireup_check_keepalive(const ucp_wireup_select_params_t *select_params,
                            const char *title, int is_keepalive,
                            const char **flag_descs, char *reason, size_t max)
 {
-    ucp_worker_h worker                    = select_params->ep->worker;
-    ucp_context_h context                  = worker->context;
-    const uct_tl_resource_desc_t *resource = &context->tl_rscs[rsc_index].tl_rsc;
+    ucp_worker_h worker   = select_params->ep->worker;
+    ucp_context_h context = worker->context;
+    const uct_tl_resource_desc_v2_t *resource =
+            &context->tl_rscs[rsc_index].tl_rsc;
     char title_keepalive[128];
     char title_ep_check[128];
     char title_am_based[128];
@@ -404,7 +405,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     ucp_tl_addr_bitmap_t addr_index_map, rsc_addr_index_map;
     const ucp_wireup_lane_desc_t *lane_desc;
     unsigned addr_index;
-    uct_tl_resource_desc_t *resource;
+    uct_tl_resource_desc_v2_t *resource;
     const ucp_address_entry_t *ae;
     ucp_worker_iface_t *wiface;
     ucp_rsc_index_t rsc_index;
@@ -2072,7 +2073,7 @@ ucp_wireup_select_wireup_msg_lane(ucp_worker_h worker,
     ucp_context_h context          = worker->context;
     ucp_lane_index_t p2p_lane      = UCP_NULL_LANE;
     ucp_wireup_criteria_t criteria = {0};
-    uct_tl_resource_desc_t *resource;
+    uct_tl_resource_desc_v2_t *resource;
     ucp_rsc_index_t rsc_index;
     uct_iface_attr_t *attrs;
     ucp_lane_index_t lane;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1052,9 +1052,24 @@ int uct_iface_is_reachable_v2(uct_iface_h iface,
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Capability flags of @ref uct_tl_resource_desc_t.
+ *
+ * The enumeration defines bit mask of capabilities in @ref
+ * uct_tl_resource_desc_v2_t::flags, set by @ref uct_md_query_tl_resources_v2.
+ */
+typedef enum {
+    /**
+     * If set, the resource supports inter-node communications.
+     */
+    UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
+} uct_md_query_tl_esources_flags_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
  */
-typedef struct uct_md_query_tl_resources_params {
+typedef struct {
     /**
      * Mask of valid fields which must currently be set to zero.
      * Future fields not specified in this mask will be ignored.
@@ -1066,29 +1081,22 @@ typedef struct uct_md_query_tl_resources_params {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Capability flags of @ref uct_tl_resource_desc_t.
- *
- * The enumeration defines bit mask of capabilities in @ref
- * uct_tl_resource_desc_v2_t::flags, set by @ref uct_md_query_tl_resources_v2.
- */
-enum {
-    /**
-     * If set, the resource supports inter-node communications.
-     */
-    UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
-};
-
-
-/**
- * @ingroup UCT_RESOURCE
  * @brief Communication resource descriptor.
  *
  * Resource descriptor of a standalone communication resource with extraneous
  * flags.
  */
 typedef struct uct_tl_resource_desc_v2 {
-    uct_tl_resource_desc_t desc;  /**< Main resource descriptor */
-    uint64_t               flags; /**< Associated resource flags */
+    /**
+     * Main resource descriptor
+     */
+    uct_tl_resource_desc_t desc;
+
+    /**
+     * Associated resource flags using bits from @ref
+     * uct_md_query_tl_resources_flags_t.
+     */
+    uint64_t               flags;
 } uct_tl_resource_desc_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1062,7 +1062,7 @@ typedef enum {
      * If set, the resource supports inter-node communications.
      */
     UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
-} uct_md_query_tl_esources_flags_t;
+} uct_md_query_tl_resources_flags_t;
 
 
 /**
@@ -1075,7 +1075,7 @@ typedef struct {
      * Future fields not specified in this mask will be ignored.
      * Provides ABI compatibility with respect to adding new fields.
      */
-    uint64_t                       field_mask;
+    uint64_t field_mask;
 } uct_md_query_tl_resources_params_t;
 
 
@@ -1083,20 +1083,41 @@ typedef struct {
  * @ingroup UCT_RESOURCE
  * @brief Communication resource descriptor.
  *
- * Resource descriptor of a standalone communication resource with extraneous
- * flags.
+ * Resource descriptor is an object representing the network resource.
+ * Resource descriptor could represent a stand-alone communication resource
+ * such as an HCA port, network interface, or multiple resources such as
+ * multiple network interfaces or communication ports. It could also represent
+ * virtual communication resources that are defined over a single physical
+ * network interface.
  */
 typedef struct uct_tl_resource_desc_v2 {
     /**
-     * Main resource descriptor
+     * Transport name
      */
-    uct_tl_resource_desc_t desc;
+    char              tl_name[UCT_TL_NAME_MAX];
+
+    /**
+     * Hardware device name
+     */
+    char              dev_name[UCT_DEVICE_NAME_MAX];
+
+    /**
+     * Device represented by this resource
+     * (e.g. UCT_DEVICE_TYPE_NET for a network interface)
+     */
+    uct_device_type_t dev_type;
+
+    /**
+     * The identifier associated with the device bus_id as captured in
+     * @ref ucs_sys_bus_id_t
+     */
+    ucs_sys_device_t  sys_device;
 
     /**
      * Associated resource flags using bits from @ref
      * uct_md_query_tl_resources_flags_t.
      */
-    uint64_t               flags;
+    uint64_t          flags;
 } uct_tl_resource_desc_v2_t;
 
 
@@ -1107,20 +1128,20 @@ typedef struct uct_tl_resource_desc_v2 {
  * This routine queries the @ref uct_md_h "memory domain" for communication
  * resources that are available for it.
  *
- * @param [in]  md              Handle to memory domain.
- * @param [out] resources_p     Filled with a pointer to an array of resource
- *                              descriptors.
- * @param [out] num_resources_p Filled with the number of resources in the array.
- * @param [in]  params          Parameters as defined in @ref
- *                              uct_md_query_tl_resources_params_t.
+ * @param [in]    md              Handle to memory domain.
+ * @param [inout] params          Parameters as defined in @ref
+ *                                uct_md_query_tl_resources_params_t.
+ * @param [out]   resources_p     Filled with a pointer to an array of resource
+ *                                descriptors.
+ * @param [out]   num_resources_p Filled with the number of resources in the array.
  *
  * @return Error code.
  */
 ucs_status_t
 uct_md_query_tl_resources_v2(uct_md_h md,
+                             uct_md_query_tl_resources_params_t *params,
                              uct_tl_resource_desc_v2_t **resources_p,
-                             unsigned *num_resources_p,
-                             uct_md_query_tl_resources_params_t *params);
+                             unsigned *num_resources_p);
 
 
 /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1052,6 +1052,83 @@ int uct_iface_is_reachable_v2(uct_iface_h iface,
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief Parameters passed to @ref uct_md_query_tl_resources_v2.
+ */
+typedef struct uct_md_query_tl_resources_params {
+    /**
+     * Mask of valid fields which must currently be set to zero.
+     * Future fields not specified in this mask will be ignored.
+     * Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t                       field_mask;
+} uct_md_query_tl_resources_params_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Capability flags of @ref uct_tl_resource_desc_t.
+ *
+ * The enumeration defines bit mask of capabilities in @ref
+ * uct_tl_resource_desc_v2_t::flags, set by @ref uct_md_query_tl_resources_v2.
+ */
+enum {
+    /**
+     * If set, the resource supports inter-node communications.
+     */
+    UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE = UCS_BIT(0)
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Communication resource descriptor.
+ *
+ * Resource descriptor of a standalone communication resource with extraneous
+ * flags.
+ */
+typedef struct uct_tl_resource_desc_v2 {
+    uct_tl_resource_desc_t desc;  /**< Main resource descriptor */
+    uint64_t               flags; /**< Associated resource flags */
+} uct_tl_resource_desc_v2_t;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Query for transport resources.
+ *
+ * This routine queries the @ref uct_md_h "memory domain" for communication
+ * resources that are available for it.
+ *
+ * @param [in]  md              Handle to memory domain.
+ * @param [out] resources_p     Filled with a pointer to an array of resource
+ *                              descriptors.
+ * @param [out] num_resources_p Filled with the number of resources in the array.
+ * @param [in]  params          Parameters as defined in @ref
+ *                              uct_md_query_tl_resources_params_t.
+ *
+ * @return Error code.
+ */
+ucs_status_t
+uct_md_query_tl_resources_v2(uct_md_h md,
+                             uct_tl_resource_desc_v2_t **resources_p,
+                             unsigned *num_resources_p,
+                             uct_md_query_tl_resources_params_t *params);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Release the list of resources returned from @ref uct_md_query_tl_resources_v2.
+ *
+ * This routine releases the memory associated with the list of resources
+ * allocated by @ref uct_md_query_tl_resources_v2.
+ *
+ * @param [in] resources  Array of resource descriptors to release.
+ */
+void uct_release_tl_resource_list_v2(uct_tl_resource_desc_v2_t *resources);
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Connect endpoint to a remote endpoint.
  *
  * requires @ref UCT_IFACE_FLAG_CONNECT_TO_EP capability.

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -385,6 +385,7 @@ typedef struct uct_tl_device_resource {
                                               (e.g. UCT_DEVICE_TYPE_NET for a network interface) */
     ucs_sys_device_t         sys_device; /**< The identifier associated with the device
                                               bus_id as captured in ucs_sys_bus_id_t struct */
+    uint64_t                 flags;      /**< Associated flags to the resource */
 } uct_tl_device_resource_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -78,9 +78,9 @@ void uct_md_close(uct_md_h md)
 
 ucs_status_t
 uct_md_query_tl_resources_v2(uct_md_h md,
+                             uct_md_query_tl_resources_params_t *params,
                              uct_tl_resource_desc_v2_t **resources_p,
-                             unsigned *num_resources_p,
-                             uct_md_query_tl_resources_params_t *params)
+                             unsigned *num_resources_p)
 {
     uct_component_t *component = md->component;
     uct_tl_resource_desc_v2_t *resources, *tmp;
@@ -122,14 +122,14 @@ uct_md_query_tl_resources_v2(uct_md_h md,
 
         /* add tl devices to overall list of resources */
         for (i = 0; i < num_tl_devices; ++i) {
-            ucs_strncpy_zero(tmp[num_resources + i].desc.tl_name, tl->name,
-                             sizeof(tmp[num_resources + i].desc.tl_name));
-            ucs_strncpy_zero(tmp[num_resources + i].desc.dev_name,
+            ucs_strncpy_zero(tmp[num_resources + i].tl_name, tl->name,
+                             sizeof(tmp[num_resources + i].tl_name));
+            ucs_strncpy_zero(tmp[num_resources + i].dev_name,
                              tl_devices[i].name,
-                             sizeof(tmp[num_resources + i].desc.dev_name));
-            tmp[num_resources + i].desc.dev_type   = tl_devices[i].type;
-            tmp[num_resources + i].desc.sys_device = tl_devices[i].sys_device;
-            tmp[num_resources + i].flags           = tl_devices[i].flags;
+                             sizeof(tmp[num_resources + i].dev_name));
+            tmp[num_resources + i].dev_type   = tl_devices[i].type;
+            tmp[num_resources + i].sys_device = tl_devices[i].sys_device;
+            tmp[num_resources + i].flags      = tl_devices[i].flags;
         }
 
         resources      = tmp;
@@ -161,8 +161,8 @@ ucs_status_t uct_md_query_tl_resources(uct_md_h md,
     unsigned i;
 
     params.field_mask = 0;
-    status            = uct_md_query_tl_resources_v2(md, &resources_v2,
-                                                     num_resources_p, &params);
+    status            = uct_md_query_tl_resources_v2(md, &params, &resources_v2,
+                                                     num_resources_p);
     if (status != UCS_OK) {
         return status;
     }
@@ -176,7 +176,13 @@ ucs_status_t uct_md_query_tl_resources(uct_md_h md,
     }
 
     for (i = 0; i < *num_resources_p; ++i) {
-        (*resources_p)[i] = resources_v2[i].desc;
+        memcpy((*resources_p)[i].tl_name, resources_v2[i].tl_name,
+               sizeof(resources_v2[i].tl_name));
+        memcpy((*resources_p)[i].dev_name, resources_v2[i].dev_name,
+               sizeof(resources_v2[i].dev_name));
+
+        (*resources_p)[i].dev_type   = resources_v2[i].dev_type;
+        (*resources_p)[i].sys_device = resources_v2[i].sys_device;
     }
 
     uct_release_tl_resource_list_v2(resources_v2);

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -170,6 +170,20 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
     return UCS_OK;
 }
 
+ucs_status_t uct_md_query_tl_resources_v2(
+        uct_md_h UCS_V_UNUSED md,
+        uct_tl_resource_desc_v2_t **UCS_V_UNUSED resources_p,
+        unsigned *UCS_V_UNUSED num_resources_p,
+        uct_md_query_tl_resources_params_t *UCS_V_UNUSED params)
+{
+    return UCS_ERR_NOT_IMPLEMENTED;
+}
+
+void uct_release_tl_resource_list_v2(
+        uct_tl_resource_desc_v2_t *UCS_V_UNUSED resources)
+{
+}
+
 ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
                                      const void *rkey_buffer, uct_rkey_t *rkey_p,
                                      void **handle_p)

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -90,6 +90,8 @@ uct_md_query_tl_resources_v2(uct_md_h md,
     uct_tl_t *tl;
 
     if (params->field_mask != 0) {
+        ucs_error("invalid field_mask 0x%" PRIu64 " passed",
+                  params->field_mask);
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -165,8 +167,10 @@ ucs_status_t uct_md_query_tl_resources(uct_md_h md,
         return status;
     }
 
-    *resources_p = malloc(*num_resources_p * sizeof(**resources_p));
+    *resources_p = ucs_malloc(*num_resources_p * sizeof(**resources_p),
+                              "tl resource");
     if (*resources_p == NULL) {
+        ucs_error("failed to allocate tl resources descriptor");
         uct_release_tl_resource_list_v2(resources_v2);
         return UCS_ERR_NO_MEMORY;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -611,7 +611,7 @@ uct_cuda_ipc_query_devices(
         uct_md_h uct_md, uct_tl_device_resource_t **tl_devices_p,
         unsigned *num_tl_devices_p)
 {
-    uint64_t flags             = 0;
+    uint64_t flags = 0;
     ucs_status_t status;
 #if HAVE_CUDA_FABRIC
     uct_cuda_ipc_md_t *md      = ucs_derived_of(uct_md, uct_cuda_ipc_md_t);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -612,15 +612,23 @@ uct_cuda_ipc_query_devices(
         unsigned *num_tl_devices_p)
 {
     uct_device_type_t dev_type = UCT_DEVICE_TYPE_SHM;
+    uint64_t flags             = 0;
+    ucs_status_t status;
 #if HAVE_CUDA_FABRIC
     uct_cuda_ipc_md_t *md      = ucs_derived_of(uct_md, uct_cuda_ipc_md_t);
 
     if (uct_cuda_ipc_iface_is_mnnvl_supported(md)) {
-        dev_type = UCT_DEVICE_TYPE_NET;
+        flags = UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE;
     }
 #endif
-    return uct_cuda_base_query_devices_common(uct_md, dev_type,
-                                              tl_devices_p, num_tl_devices_p);
+    status = uct_cuda_base_query_devices_common(uct_md, dev_type,
+                                                tl_devices_p, num_tl_devices_p);
+    if (status == UCS_OK) {
+        ucs_assert(*num_tl_devices_p == 1);
+        (*tl_devices_p)->flags = flags;
+    }
+
+    return status;
 }
 
 UCS_CLASS_DEFINE(uct_cuda_ipc_iface_t, uct_cuda_iface_t);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -611,7 +611,6 @@ uct_cuda_ipc_query_devices(
         uct_md_h uct_md, uct_tl_device_resource_t **tl_devices_p,
         unsigned *num_tl_devices_p)
 {
-    uct_device_type_t dev_type = UCT_DEVICE_TYPE_SHM;
     uint64_t flags             = 0;
     ucs_status_t status;
 #if HAVE_CUDA_FABRIC
@@ -621,7 +620,7 @@ uct_cuda_ipc_query_devices(
         flags = UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE;
     }
 #endif
-    status = uct_cuda_base_query_devices_common(uct_md, dev_type,
+    status = uct_cuda_base_query_devices_common(uct_md, UCT_DEVICE_TYPE_SHM,
                                                 tl_devices_p, num_tl_devices_p);
     if (status == UCS_OK) {
         ucs_assert(*num_tl_devices_p == 1);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -964,6 +964,7 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
                           (*entry)->d_name);
         devices[num_devices].type       = UCT_DEVICE_TYPE_NET;
         devices[num_devices].sys_device = sys_dev;
+        devices[num_devices].flags      = 0;
         ++num_devices;
     }
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -558,6 +558,30 @@ UCS_TEST_P(test_md, mem_query) {
     }
 }
 
+UCS_TEST_P(test_md, tl_resource_desc_v1_v2) {
+    uct_md_query_tl_resources_params_t params = {};
+    uct_tl_resource_desc_t *v1;
+    uct_tl_resource_desc_v2_t *v2;
+    unsigned num_v1, num_v2;
+
+    ASSERT_UCS_OK(uct_md_query_tl_resources(md(), &v1, &num_v1));
+    ASSERT_UCS_OK(uct_md_query_tl_resources_v2(md(), &v2, &num_v2, &params));
+    ASSERT_TRUE(num_v2 > 0);
+    ASSERT_EQ(num_v2, num_v1);
+
+    for (auto i = 0; i < num_v1; ++i) {
+        EXPECT_TRUE(!strcmp(v1[i].tl_name, v2[i].desc.tl_name));
+        EXPECT_TRUE(!strcmp(v1[i].dev_name, v2[i].desc.dev_name));
+        EXPECT_EQ(v1[i].dev_type, v2[i].desc.dev_type);
+        EXPECT_EQ(v1[i].sys_device, v2[i].desc.sys_device);
+        EXPECT_TRUE((v2[i].flags == 0) ||
+                    (v2[i].flags == UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE));
+    }
+
+    uct_release_tl_resource_list(v1);
+    uct_release_tl_resource_list_v2(v2);
+}
+
 UCS_TEST_P(test_md, sys_device) {
     uct_tl_resource_desc_t *tl_resources;
     unsigned num_tl_resources;

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -573,13 +573,16 @@ UCS_TEST_P(test_md, tl_resource_desc_v1_v2) {
     EXPECT_GT(num_v2, 0);
     EXPECT_EQ(num_v2, num_v1);
 
-    for (auto i = 0; (i < num_v1) && (num_v1 == num_v2) ; ++i) {
-        EXPECT_TRUE(!strcmp(v1[i].tl_name, v2[i].desc.tl_name));
-        EXPECT_TRUE(!strcmp(v1[i].dev_name, v2[i].desc.dev_name));
-        EXPECT_EQ(v1[i].dev_type, v2[i].desc.dev_type);
-        EXPECT_EQ(v1[i].sys_device, v2[i].desc.sys_device);
-        EXPECT_TRUE((v2[i].flags == 0) ||
-                    (v2[i].flags == UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE));
+    if ((status_v1 == UCS_OK) && (status_v2 == UCS_OK) &&
+        (num_v1 == num_v2)) {
+        for (auto i = 0; i < num_v1; ++i) {
+            EXPECT_TRUE(!strcmp(v1[i].tl_name, v2[i].desc.tl_name));
+            EXPECT_TRUE(!strcmp(v1[i].dev_name, v2[i].desc.dev_name));
+            EXPECT_EQ(v1[i].dev_type, v2[i].desc.dev_type);
+            EXPECT_EQ(v1[i].sys_device, v2[i].desc.sys_device);
+            EXPECT_TRUE((v2[i].flags == 0) ||
+                        (v2[i].flags == UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE));
+        }
     }
 
     if (status_v1 == UCS_OK) {

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -563,13 +563,17 @@ UCS_TEST_P(test_md, tl_resource_desc_v1_v2) {
     uct_tl_resource_desc_t *v1;
     uct_tl_resource_desc_v2_t *v2;
     unsigned num_v1, num_v2;
+    ucs_status_t status_v1, status_v2;
 
-    ASSERT_UCS_OK(uct_md_query_tl_resources(md(), &v1, &num_v1));
-    ASSERT_UCS_OK(uct_md_query_tl_resources_v2(md(), &v2, &num_v2, &params));
-    ASSERT_TRUE(num_v2 > 0);
-    ASSERT_EQ(num_v2, num_v1);
+    status_v1 = uct_md_query_tl_resources(md(), &v1, &num_v1);
+    status_v2 = uct_md_query_tl_resources_v2(md(), &v2, &num_v2, &params);
 
-    for (auto i = 0; i < num_v1; ++i) {
+    EXPECT_UCS_OK(status_v1);
+    EXPECT_UCS_OK(status_v2);
+    EXPECT_GT(num_v2, 0);
+    EXPECT_EQ(num_v2, num_v1);
+
+    for (auto i = 0; (i < num_v1) && (num_v1 == num_v2) ; ++i) {
         EXPECT_TRUE(!strcmp(v1[i].tl_name, v2[i].desc.tl_name));
         EXPECT_TRUE(!strcmp(v1[i].dev_name, v2[i].desc.dev_name));
         EXPECT_EQ(v1[i].dev_type, v2[i].desc.dev_type);
@@ -578,8 +582,13 @@ UCS_TEST_P(test_md, tl_resource_desc_v1_v2) {
                     (v2[i].flags == UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE));
     }
 
-    uct_release_tl_resource_list(v1);
-    uct_release_tl_resource_list_v2(v2);
+    if (status_v1 == UCS_OK) {
+        uct_release_tl_resource_list(v1);
+    }
+
+    if (status_v2 == UCS_OK) {
+        uct_release_tl_resource_list_v2(v2);
+    }
 }
 
 UCS_TEST_P(test_md, sys_device) {

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -558,7 +558,8 @@ UCS_TEST_P(test_md, mem_query) {
     }
 }
 
-UCS_TEST_P(test_md, tl_resource_desc_v1_v2) {
+UCS_TEST_P(test_md, tl_resource_desc_v1_v2)
+{
     uct_md_query_tl_resources_params_t params = {};
     uct_tl_resource_desc_t *v1;
     uct_tl_resource_desc_v2_t *v2;
@@ -566,20 +567,19 @@ UCS_TEST_P(test_md, tl_resource_desc_v1_v2) {
     ucs_status_t status_v1, status_v2;
 
     status_v1 = uct_md_query_tl_resources(md(), &v1, &num_v1);
-    status_v2 = uct_md_query_tl_resources_v2(md(), &v2, &num_v2, &params);
+    status_v2 = uct_md_query_tl_resources_v2(md(), &params, &v2, &num_v2);
 
     EXPECT_UCS_OK(status_v1);
     EXPECT_UCS_OK(status_v2);
     EXPECT_GT(num_v2, 0);
     EXPECT_EQ(num_v2, num_v1);
 
-    if ((status_v1 == UCS_OK) && (status_v2 == UCS_OK) &&
-        (num_v1 == num_v2)) {
+    if ((status_v1 == UCS_OK) && (status_v2 == UCS_OK) && (num_v1 == num_v2)) {
         for (auto i = 0; i < num_v1; ++i) {
-            EXPECT_TRUE(!strcmp(v1[i].tl_name, v2[i].desc.tl_name));
-            EXPECT_TRUE(!strcmp(v1[i].dev_name, v2[i].desc.dev_name));
-            EXPECT_EQ(v1[i].dev_type, v2[i].desc.dev_type);
-            EXPECT_EQ(v1[i].sys_device, v2[i].desc.sys_device);
+            EXPECT_TRUE(!strcmp(v1[i].tl_name, v2[i].tl_name));
+            EXPECT_TRUE(!strcmp(v1[i].dev_name, v2[i].dev_name));
+            EXPECT_EQ(v1[i].dev_type, v2[i].dev_type);
+            EXPECT_EQ(v1[i].sys_device, v2[i].sys_device);
             EXPECT_TRUE((v2[i].flags == 0) ||
                         (v2[i].flags == UCT_TL_RESOURCE_DESC_FLAG_INTER_NODE));
         }


### PR DESCRIPTION
## What
Implement UCT MD transport resource descriptor query v2.

Relates to #10141 and #10154.

## Why ?
We need to introduce a new flag to allow sending address of some device of type SHM, even with net address only restriction.

## How ?
Add to `ucx_info -d` and add UT. All users initialize the uct resource descriptor to zero except TCP.