### PR TITLE
TEST/GTEST: Removed extra whitespace.

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -151,7 +151,7 @@ gtest_SOURCES = \
 	ucp/test_ucp_mem_type.cc \
 	ucp/test_ucp_perf.cc \
 	ucp/test_ucp_proto.cc \
-	ucp/test_ucp_ep_reconfig.cc \	
+	ucp/test_ucp_ep_reconfig.cc \
 	ucp/test_ucp_rma.cc \
 	ucp/test_ucp_rma_mt.cc \
 	ucp/test_ucp_tag_cancel.cc \


### PR DESCRIPTION
## What
Removed extra whitespace.

## Why ?
Fixed `test/gtest/Makefile.am:154: warning: whitespace following trailing backslash`.
