### PR TITLE
CI: add AddressSanitizer load check in test_jenkins

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1131,6 +1131,13 @@ run_test_proto_disable() {
 
 run_asan_check() {
 	build devel --enable-gtest --enable-asan --without-valgrind
+
+	if ! ldd ${WORKSPACE}/build-test/test/gtest/gtest | grep -q "libasan.so"
+	then
+		azure_log_error "Error: ASan is not loaded."
+		exit 1
+	fi
+
 	run_gtest "default"
 }
 


### PR DESCRIPTION
## What?
Added a check to ensure AddressSanitizer is loaded before running tests in `run_asan_check()` in `test_jenkins.sh`. 

## Why?
To prevent tests from running without AddressSanitizer enabled in `run_asan_check()`, ensuring memory issues are caught during CI.

## How?
Added a check for `libasan.so` in the `run_asan_check()` function. If AddressSanitizer is not loaded, the script logs an error and exits.
