### PR TITLE
UCT/IB/MLX5: correct array address grammar semantic

### DIFF
--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -417,9 +417,9 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
 
         uct_ib_mlx5_get_av(ah, &mlx5_av);
         memcpy(UCT_IB_MLX5DV_ADDR_OF(qpc, qpc, primary_address_path.rmac_47_32),
-               &mlx5_av.rmac, sizeof(mlx5_av.rmac));
+               mlx5_av.rmac, sizeof(mlx5_av.rmac));
         memcpy(UCT_IB_MLX5DV_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
-               &mlx5_av.rgid, sizeof(mlx5_av.rgid));
+               mlx5_av.rgid, sizeof(mlx5_av.rgid));
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.hop_limit,
                           mlx5_av.hop_limit);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.src_addr_index,


### PR DESCRIPTION
1. There's no need to get one dim array address as array member start address.
2. unify rmac & rgid start address with the access method in function uct_ib_mlx5_set_dgram_seg_grh

## What
```correct one dim array address grammar semantic usage```.
There's no function error in the original code implementation.

## Why ?
```align the rmac & rgid start address with the access method in``` [uct_ib_mlx5_set_dgram_seg_grh](https://github.com/openucx/ucx/blob/v1.17.0/src/uct/ib/mlx5/ib_mlx5.inl#L340)