### PR TITLE
TOOLS/INFO: fix memory leak in print_ucp_ep_info()

### DIFF
--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -322,7 +322,7 @@ out:
         ucp_listener_destroy(listener);
     }
 
-    if (worker_attrs.address == NULL) {
+    if (worker_attrs.address != NULL) {
         ucp_worker_release_address(peer_worker, worker_attrs.address);
     }
 


### PR DESCRIPTION
## What?
Fix memory leak in print_ucp_ep_info()

## Why?
Backtrace:

Error executing /__w/1/s/install/bin/ucx_info -u a r t s -e:
 
=================================================================
==45079==ERROR: LeakSanitizer: detected memory leaks
 
Direct leak of 600 byte(s) in 1 object(s) allocated from:
#0 0x7f408f721ba8 in __interceptor_malloc (/usr/lib64/libasan.so.5+0xefba8)
#1 0x7f408e6e52a7 in ucs_malloc /__w/1/s/contrib/../src/ucs/debug/memtrack.c:320
#2 0x7f408f053e70 in ucp_address_pack /__w/1/s/contrib/../src/ucp/wireup/address.c:1562
#3 0x7f408ee35e8a in ucp_worker_address_pack /__w/1/s/contrib/../src/ucp/core/ucp_worker.c:2972
#4 0x7f408ee360ef in ucp_worker_query /__w/1/s/contrib/../src/ucp/core/ucp_worker.c:2990
#5 0x405988 in print_ucp_ep_info /__w/1/s/contrib/../src/tools/info/proto_info.c:280
#6 0x406146 in print_ucp_info /__w/1/s/contrib/../src/tools/info/proto_info.c:421
#7 0x4038f8 in main /__w/1/s/contrib/../src/tools/info/ucx_info.c:318
#8 0x7f408d8c6492 in __libc_start_main (/usr/lib64/libc.so.6+0x23492)
 
SUMMARY: AddressSanitizer: 600 byte(s) leaked in 1 allocation(s).

## How?
Fix check 
