### PR TITLE
UCP/CONTEXT/CONFIG: create env vars to force MULTI_SEND and FAST_CMPL

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -140,6 +140,13 @@ const char *ucp_object_versions[] = {
     [UCP_OBJECT_VERSION_LAST] = NULL
 };
 
+const char *ucp_extra_op_attr_flags_names[] = {
+    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_NO_IMM_CMPL)]    = "no_imm_cmpl",
+    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_FAST_CMPL)]      = "fast_cmpl",
+    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)] = "force_imm_cmpl",
+    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_MULTI_SEND)]     = "multi_send",
+    NULL
+};
 
 static UCS_CONFIG_DEFINE_ARRAY(memunit_sizes, sizeof(size_t),
                                UCS_CONFIG_TYPE_MEMUNITS);
@@ -530,6 +537,13 @@ static ucs_config_field_t ucp_context_config_table[] = {
   {"GVA_PREFETCH", "y",
    "Prefetch memory when using global VA MR",
    ucs_offsetof(ucp_context_config_t, gva_prefetch), UCS_CONFIG_TYPE_BOOL},
+
+  {"EXTRA_OP_ATTR_FLAGS", "",
+   "Additional send/receive operation flags that are added for each request"
+   "in addition to what is set explicitly by the user. \n"
+   "Possible values are: no_imm_cmpl, fast_cmpl, force_imm_cmpl, multi_send.",
+   ucs_offsetof(ucp_context_config_t, extra_op_attr_flags),
+   UCS_CONFIG_TYPE_BITMAP(ucp_extra_op_attr_flags_names)},
 
   {NULL}
 };

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -42,6 +42,15 @@ enum {
     UCP_TL_RSC_FLAG_AUX = UCS_BIT(0)
 };
 
+#define UCP_OP_ATTR_INDEX_MASK (UCP_OP_ATTR_FLAG_NO_IMM_CMPL    | \
+                                UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL | \
+                                UCP_OP_ATTR_FLAG_FAST_CMPL      | \
+                                UCP_OP_ATTR_FLAG_MULTI_SEND)
+
+#define UCP_OP_ATTR_INDEX(_op_attr_flag) \
+    (ucs_ilog2(ucp_proto_select_op_attr_pack((_op_attr_flag), \
+                                             UCP_OP_ATTR_INDEX_MASK)))
+
 
 typedef struct ucp_context_config {
     /** Threshold for switching UCP to buffered copy(bcopy) protocol */
@@ -191,6 +200,8 @@ typedef struct ucp_context_config {
     double                                 proto_overhead_rkey_ptr;
     /** Registration cache lookup overhead estimation */
     double                                 rcache_overhead;
+    /** UCP extra operation attributes flags */
+    uint64_t                               extra_op_attr_flags;
 } ucp_context_config_t;
 
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -456,12 +456,15 @@ ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
                            const ucp_proto_select_param_t *select_param,
                            ucp_proto_select_elem_t *select_elem)
 {
+    ucp_proto_select_param_t select_param_copy = *select_param;
     UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
     UCS_STRING_BUFFER_ONSTACK(config_name_strb, UCP_PROTO_SELECT_PARAM_STR_MAX);
     ucp_proto_select_init_protocols_t proto_init;
     ucs_status_t status;
 
-    ucp_proto_select_info_str(worker, rkey_cfg_index, select_param,
+    select_param_copy.op_attr |= worker->context->config.ext.extra_op_attr_flags;
+
+    ucp_proto_select_info_str(worker, rkey_cfg_index, &select_param_copy,
                               ucp_operation_names, &sel_param_strb);
     ucp_ep_config_name(worker, ep_cfg_index, &config_name_strb);
 
@@ -472,7 +475,7 @@ ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
     ucs_log_indent(1);
 
     status = ucp_proto_select_init_protocols(worker, ep_cfg_index,
-                                             rkey_cfg_index, select_param,
+                                             rkey_cfg_index, &select_param_copy,
                                              &proto_init);
     if (status != UCS_OK) {
         goto out;
@@ -480,7 +483,7 @@ ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
 
     status = ucp_proto_select_elem_init_thresh(worker, select_elem, &proto_init,
                                                ep_cfg_index, rkey_cfg_index,
-                                               select_param, internal);
+                                               &select_param_copy, internal);
     if (status != UCS_OK) {
         goto out_cleanup_proto_init;
     }
@@ -489,7 +492,7 @@ ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
 
     if (!internal) {
         ucp_proto_select_elem_trace(worker, ep_cfg_index, rkey_cfg_index,
-                                    select_param, select_elem);
+                                    &select_param_copy, select_elem);
     }
 
     status = UCS_OK;

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -43,6 +43,11 @@
 #define UCP_PROTO_SELECT_PARAM_STR_MAX 128
 
 
+/* Pack operation attributes from uint32_t to a uint8_t */
+#define ucp_proto_select_op_attr_pack(_op_attr, _mask) \
+    (((_op_attr) & (_mask)) / UCP_PROTO_SELECT_OP_ATTR_BASE)
+
+
 typedef struct {
     ucp_proto_id_t        proto_id;
     size_t                priv_offset;

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -44,19 +44,12 @@ ucp_proto_select_thresholds_search(const ucp_proto_select_elem_t *select_elem,
     return ucp_proto_thresholds_search_slow(thresholds + 4, msg_length);
 }
 
-static UCS_F_ALWAYS_INLINE uint8_t
-ucp_proto_select_op_attr_pack(uint32_t op_attr_mask)
+static UCS_F_ALWAYS_INLINE uint32_t
+ucp_proto_select_op_attr_unpack(uint8_t op_attr)
 {
     UCS_STATIC_ASSERT(
             (UCP_PROTO_SELECT_OP_ATTR_MASK / UCP_PROTO_SELECT_OP_ATTR_BASE) <
             UCP_PROTO_SELECT_OP_FLAGS_BASE);
-    return (op_attr_mask & UCP_PROTO_SELECT_OP_ATTR_MASK) /
-           UCP_PROTO_SELECT_OP_ATTR_BASE;
-}
-
-static UCS_F_ALWAYS_INLINE uint32_t
-ucp_proto_select_op_attr_unpack(uint8_t op_attr)
-{
     return op_attr * UCP_PROTO_SELECT_OP_ATTR_BASE;
 }
 
@@ -141,7 +134,8 @@ static UCS_F_ALWAYS_INLINE void ucp_proto_select_param_init_common(
      * op_flags are modifiers for the operation, for now only FAST_CMPL is
      * supported */
     select_param->op_id_flags   = op_id | op_flags;
-    select_param->op_attr       = ucp_proto_select_op_attr_pack(op_attr_mask);
+    select_param->op_attr       = ucp_proto_select_op_attr_pack(
+        op_attr_mask, UCP_PROTO_SELECT_OP_ATTR_MASK);
     select_param->dt_class      = dt_class;
     select_param->mem_type      = mem_info->type;
     select_param->sys_dev       = mem_info->sys_dev;

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -84,7 +84,7 @@ ucp_proto_rndv_ppln_probe(const ucp_proto_init_params_t *init_params)
     sel_param.op_id_flags = ucp_proto_select_op_id(select_param) |
                             UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
     sel_param.op_attr     = ucp_proto_select_op_attr_pack(
-            UCP_OP_ATTR_FLAG_MULTI_SEND);
+        UCP_OP_ATTR_FLAG_MULTI_SEND, UCP_PROTO_SELECT_OP_ATTR_MASK);
 
     proto_select = ucp_proto_select_get(worker, init_params->ep_cfg_index,
                                         init_params->rkey_cfg_index,


### PR DESCRIPTION
## What?
Added environment variables (`UCX_FORCE_FAST_CMPL` and `UCX_FORCE_MULTI_SEND`) to enforce the `UCP_OP_ATTR_FLAG_FAST_CMPL` and `UCP_OP_ATTR_FLAG_MULTI_SEND` flags globally for all UCX operations.

## Why?
To simplify configuration and improve performance by enabling these optimizations globally without needing to modify each operation individually.

## How?
Added `FORCE_FAST_CMPL` and `FORCE_MULTI_SEND` to `ucp_context_config_t` and updated the environment parsing logic to apply these flags automatically during protocol initialization.
