### PR TITLE
UCT/API: Change HIDE_ERRORS flag description

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -795,8 +795,8 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_FLAG_LOCK            = UCS_BIT(2),
 
     /**
-     * Hide errors on memory registration. In some cases registration failure
-     * is not an error (e. g. for merged memory regions).
+     * Hide errors on memory registration and allocation. If this flag is set,
+     * no error messages will be printed.
      */
     UCT_MD_MEM_FLAG_HIDE_ERRORS     = UCS_BIT(3),
 


### PR DESCRIPTION
## What
Update description of `UCT_MD_MEM_FLAG_HIDE_ERRORS`

## Why ?
- Statemenet about merged memory regions is no longer valid
- Allow users using this flag for allocations 