### PR TITLE
UCT/IB/MLX5: reduce log level of both WC and NC unsupported

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -608,8 +608,8 @@ ucs_status_t uct_ib_mlx5_devx_check_uar(uct_ib_mlx5_md_t *md)
                                             UCT_IB_MLX5_UAR_ALLOC_TYPE_NC,
                                             &uar.uar);
         if (status == UCS_ERR_UNSUPPORTED) {
-            ucs_error("%s: both WC and NC_DEDICATED UAR allocation types "
-                      " are not supported", uct_ib_device_name(&md->super.dev));
+            ucs_diag("%s: both WC and NC_DEDICATED UAR allocation types "
+                     "are not supported", uct_ib_device_name(&md->super.dev));
             return status;
         } else if (status != UCS_OK) {
             return status;


### PR DESCRIPTION
## What?
Reduce log level of both `WC` and `NC_DEDICATED` unsupported in `uct_ib_mlx5_devx_check_uar()`.

## Why?
Following https://github.com/openucx/ucx/issues/10180.

## How?
Reduce the log level of "both WC and NC_DEDICATED UAR allocation types are not supported" from ERROR to DIAG, and let UCX disable DevX automatically in this case.