### PR TITLE
UCP: Send ATP on a correct lane to fix CI failures

### DIFF
--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -138,6 +138,14 @@ ucp_proto_rndv_put_common_atp_send(ucp_request_t *req, ucp_lane_index_t lane)
         return UCS_OK;
     }
 
+    /* Ensure ATP is sent on the same lane as the data to prevent ATP from
+     * arriving before the data. If data transmission starts from a non-zero
+     * lane, ATP may never be sent on the data lane. */
+    if (ucs_unlikely((req->send.state.dt_iter.length < rpriv->atp_num_lanes) &&
+                     (lane < req->send.multi_lane_idx))) {
+        return UCS_OK;
+    }
+
     pack_ctx.req = req;
 
     /* When we need to send multiple ATP messages: each will acknowledge 1 byte,


### PR DESCRIPTION
## What
Fixes the following bug in CI
```
[ RUN      ] dcx/test_ucp_am_nbx_rndv_memtype.rndv/32 <dc_x,cuda_copy,rocm_copy/cuda-managed/cuda-managed>
common/mem_buffer.cc:321: Failure
Pattern check failed at 0x7fab92100200 offset 524288 (length 1 mask: 0xff): Expected: 0xb4 Actual: 0x0
Trace/breakpoint trap (core dumped)
```

The issue occurs when using the rndv put pipeline protocol, and data is split into two fragments: the first being 512KB and the second only 1 byte. For the second fragment, UCP sends the 1 byte starting from lane 1, transmitting all of it on that lane. However, ATP is sent starting from lane 0. Each ATP, except the last one, confirms just 1 byte to prevent premature receive completion on the peer side.

The problem arises because the data size is only 1 byte. The first ATP (on lane 0) informs the receiver that the data is ready, but since it is sent on a different lane than the data, it arrives before the data itself. As a result, the receiver completes the request even though the actual data hasn't arrived yet.

