### PR TITLE
UCP: Fix perf estimation for rndv ppln protos

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -37,7 +37,7 @@ ucp_am_eager_multi_bcopy_proto_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = context->config.ext.max_eager_lanes,
         .initial_reg_md_map  = 0,
         .first.lane_type     = UCP_LANE_TYPE_AM,
@@ -198,7 +198,8 @@ ucp_am_eager_multi_zcopy_proto_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .max_lanes           = context->config.ext.max_eager_lanes,
         .initial_reg_md_map  = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -111,7 +111,7 @@ ucp_am_eager_short_probe_common(const ucp_proto_init_params_t *init_params,
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_SHORT
     };
@@ -241,7 +241,7 @@ static void ucp_am_eager_single_bcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -332,7 +332,8 @@ static void ucp_am_eager_single_zcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_ZCOPY
     };

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1745,6 +1745,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
         context->gva_md_map[mem_type]           = 0;
         context->dmabuf_mds[mem_type]           = UCP_NULL_RESOURCE;
         context->alloc_md[mem_type].md_index    = UCP_NULL_RESOURCE;
+        context->alloc_md[mem_type].sys_dev     = UCS_SYS_DEVICE_ID_UNKNOWN;
         context->alloc_md[mem_type].initialized = 0;
     }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -23,6 +23,7 @@
 #include <ucs/datastruct/conn_match.h>
 #include <ucs/memory/memtype_cache.h>
 #include <ucs/memory/memory_type.h>
+#include <ucs/memory/rcache.h>
 #include <ucs/type/spinlock.h>
 #include <ucs/sys/string.h>
 #include <ucs/type/param.h>
@@ -302,7 +303,8 @@ typedef struct ucp_context_alloc_md_index {
     int            initialized;
     /* Index of memory domain that is used to allocate memory of the given type
      * using ucp_memh_alloc(). */
-    ucp_md_index_t md_index;
+    ucp_md_index_t   md_index;
+    ucs_sys_device_t sys_dev;
 } ucp_context_alloc_md_index_t;
 
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -11,6 +11,7 @@
 
 #include <ucp/api/ucp_def.h>
 #include <ucp/core/ucp_ep.h>
+#include <ucp/dt/dt.h>
 #include <uct/api/uct.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/debug/log.h>
@@ -112,6 +113,8 @@ typedef struct {
 
 extern ucp_mem_dummy_handle_t ucp_mem_dummy_handle;
 
+extern const ucp_memory_info_t ucp_mem_info_unknown;
+
 
 ucs_status_t ucp_reg_mpool_malloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p);
 
@@ -187,16 +190,21 @@ void ucp_mem_rcache_cleanup(ucp_context_h context);
 /**
  * Get memory domain index that is used to allocate certain memory type.
  *
- * @param [in]  context UCP context containing memory domain indexes to use for
- *                      the memory allocation.
- * @param [out] md_idx  Index of the memory domain that is used to allocate host
- *                      memory.
+ * @param [in]  context        UCP context containing memory domain indexes to
+ *                             use for the memory allocation.
+ * @param [in]  alloc_mem_type Memory type to get allocation index and sys
+ *                             device for.
+ * @param [out] md_idx         Index of the memory domain that is used to
+ *                             allocate memory.
+ * @param [out] sys_dev        Device id on which the memory was allocated.
  *
  * @return Error code as defined by @ref ucs_status_t.
  */
 ucs_status_t
-ucp_mm_get_alloc_md_index(ucp_context_h context, ucp_md_index_t *md_idxi,
-                          ucs_memory_type_t alloc_mem_type);
+ucp_mm_get_alloc_md_index(ucp_context_h context,
+                          ucs_memory_type_t alloc_mem_type,
+                          ucp_md_index_t *md_idx,
+                          ucs_sys_device_t *sys_dev);
 
 static UCS_F_ALWAYS_INLINE ucp_md_map_t
 ucp_rkey_packed_md_map(const void *rkey_buffer)

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -10,6 +10,7 @@
 #include "ucp_types.h"
 
 #include <ucp/core/ucp_context.h>
+#include <ucp/proto/proto_select.h>
 
 
 /**

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -26,6 +26,7 @@ const char * ucp_datatype_class_names[] = {
     [UCP_DATATYPE_GENERIC]  = "generic"
 };
 
+
 UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
                       (worker, buffer, recv_data, recv_length, mem_type),
                       ucp_worker_h worker, void *buffer, const void *recv_data,

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -10,7 +10,6 @@
 #define UCP_DT_H_
 
 #include <ucp/api/ucp.h>
-#include <ucp/core/ucp_mm.h>
 #include <ucp/core/ucp_types.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/profile/profile.h>

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -9,6 +9,7 @@
 
 #include "proto.h"
 #include "proto_select.h"
+#include <ucp/dt/dt.h>
 
 #include <uct/api/v2/uct_v2.h>
 
@@ -122,12 +123,12 @@ typedef struct {
     /* Map of unsuitable lanes */
     ucp_lane_map_t          exclude_map;
 
-    /* Memory type of the buffer used for data transfer on the transport level.
+    /* Memory info of the buffer used for data transfer on the transport level.
      * If UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY flag is set, it is expected to
-     * be the user buffer memory type. Alternatively, it refers to the type of
+     * be the user buffer memory info. Alternatively, it refers to the type of
      * memory used for bounce buffers (either in the UCP or UCT layer) where
      * data needs to be copied as part of the protocol. */
-    ucs_memory_type_t       reg_mem_type;
+    ucp_memory_info_t       reg_mem_info;
 } ucp_proto_common_init_params_t;
 
 
@@ -192,6 +193,10 @@ typedef ucs_status_t (*ucp_proto_complete_cb_t)(ucp_request_t *req);
 
 ucp_proto_common_init_params_t
 ucp_proto_common_init_params(const ucp_proto_init_params_t *init_params);
+
+
+ucp_memory_info_t ucp_proto_common_select_param_mem_info(
+                                  const ucp_proto_select_param_t *select_param);
 
 
 /**

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -395,8 +395,8 @@ ucp_proto_init_add_buffer_perf(const ucp_proto_common_init_params_t *params,
         /* TODO: This mem_type initialization is specific to put and get mtype
          * protocols. Consider moving it to the corresponding probe functions.
          */
-        if (params->reg_mem_type != UCS_MEMORY_TYPE_UNKNOWN) {
-            buffer_mem_type = params->reg_mem_type;
+        if (params->reg_mem_info.type != UCS_MEMORY_TYPE_UNKNOWN) {
+            buffer_mem_type = params->reg_mem_info.type;
         } else {
             buffer_mem_type = UCS_MEMORY_TYPE_HOST;
         }

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -171,7 +171,7 @@ static void ucp_proto_amo_probe(const ucp_proto_init_params_t *init_params,
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AMO,
         .tl_cap_flags        = 0
     };

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -424,7 +424,7 @@ static void ucp_proto_amo_sw_probe(const ucp_proto_init_params_t *init_params,
         .super.flags         = flags | UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = 0
     };

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -95,7 +95,7 @@ ucp_proto_get_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -96,7 +96,7 @@ ucp_proto_get_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = UCP_PROTO_RMA_MAX_BCOPY_LANES,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_BCOPY,
@@ -203,7 +203,8 @@ ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_RESPONSE |
                                UCP_PROTO_COMMON_INIT_FLAG_MIN_FRAG,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .max_lanes           = context->config.ext.max_rma_lanes,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -97,7 +97,7 @@ ucp_proto_put_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -70,7 +70,7 @@ ucp_proto_put_offload_short_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG   |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_RMA,
         .tl_cap_flags        = UCT_IFACE_FLAG_PUT_SHORT
     };
@@ -167,7 +167,7 @@ ucp_proto_put_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = UCP_PROTO_RMA_MAX_BCOPY_LANES,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_BCOPY,
@@ -256,7 +256,8 @@ ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .max_lanes           = context->config.ext.max_rma_lanes,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_ZCOPY,

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -99,10 +99,6 @@ typedef struct {
        a 3% better time) */
     double                         perf_bias;
 
-    /* Memory type of the transfer. Used as rkey memory information when
-       selecting the remote protocol. */
-    ucp_memory_info_t              mem_info;
-
     /* Name of the control message, e.g "RTS" */
     const char                     *ctrl_msg_name;
 

--- a/src/ucp/rndv/rndv_am.c
+++ b/src/ucp/rndv/rndv_am.c
@@ -115,7 +115,7 @@ static void ucp_rndv_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -189,7 +189,8 @@ static void ucp_rndv_am_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY
     };

--- a/src/ucp/rndv/rndv_rkey_ptr.c
+++ b/src/ucp/rndv/rndv_rkey_ptr.c
@@ -93,7 +93,7 @@ ucp_proto_rndv_rkey_ptr_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_RKEY_PTR,
         .tl_cap_flags        = 0,
     };
@@ -254,7 +254,7 @@ ucp_proto_rndv_rkey_ptr_mtype_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS,
         .super.exclude_map   = (rkey_ptr_lane == UCP_NULL_LANE) ?
                                0 : UCS_BIT(rkey_ptr_lane),
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_LAST,
         .tl_cap_flags        = 0
     };

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -177,12 +177,11 @@ static void ucp_proto_rndv_rtr_probe(const ucp_proto_init_params_t *init_params)
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RESPONSE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .remote_op_id        = UCP_OP_ID_RNDV_SEND,
         .lane                = ucp_proto_rndv_find_ctrl_lane(init_params),
         .perf_bias           = 0.0,
-        .mem_info.type       = init_params->select_param->mem_type,
-        .mem_info.sys_dev    = init_params->select_param->sys_dev,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTR_NAME,
         .md_map              = 0
     };
@@ -393,11 +392,9 @@ ucp_proto_rndv_rtr_mtype_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_KEEP_MD_MAP,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
         .remote_op_id        = UCP_OP_ID_RNDV_SEND,
         .lane                = ucp_proto_rndv_find_ctrl_lane(init_params),
         .perf_bias           = 0.0,
-        .mem_info.sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTR_NAME,
     };
     ucs_memory_type_t frag_mem_type;
@@ -419,9 +416,10 @@ ucp_proto_rndv_rtr_mtype_probe(const ucp_proto_init_params_t *init_params)
             continue;
         }
 
-        params.mem_info.type = frag_mem_type;
+        params.super.reg_mem_info.type = frag_mem_type;
 
-        status = ucp_mm_get_alloc_md_index(context, &md_index, frag_mem_type);
+        status = ucp_mm_get_alloc_md_index(context, frag_mem_type, &md_index,
+                                           &params.super.reg_mem_info.sys_dev);
         if ((status == UCS_OK) && (md_index != UCP_NULL_RESOURCE)) {
             params.md_map = UCS_BIT(md_index);
         } else if (frag_mem_type == UCS_MEMORY_TYPE_HOST) {

--- a/src/ucp/stream/stream_multi.c
+++ b/src/ucp/stream/stream_multi.c
@@ -92,7 +92,7 @@ ucp_stream_multi_bcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
@@ -166,7 +166,8 @@ ucp_stream_multi_zcopy_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .max_lanes           = 1,
         .initial_reg_md_map  = 0,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -70,7 +70,7 @@ static void ucp_proto_eager_bcopy_multi_common_probe(
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING |
                                UCP_PROTO_COMMON_INIT_FLAG_RESUME,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_BCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_BCOPY
@@ -242,7 +242,8 @@ ucp_proto_eager_zcopy_multi_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_AM_ZCOPY,
         .middle.tl_cap_flags = UCT_IFACE_FLAG_AM_ZCOPY

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -67,7 +67,7 @@ ucp_proto_eager_short_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_SHORT
     };
@@ -141,7 +141,7 @@ ucp_proto_eager_bcopy_single_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_BCOPY
     };
@@ -189,7 +189,8 @@ ucp_proto_eager_zcopy_single_probe(const ucp_proto_init_params_t *init_params)
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE |
                                UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .lane_type           = UCP_LANE_TYPE_AM,
         .tl_cap_flags        = UCT_IFACE_FLAG_AM_ZCOPY
     };

--- a/src/ucp/tag/offload/eager.c
+++ b/src/ucp/tag/offload/eager.c
@@ -65,7 +65,7 @@ static void ucp_proto_eager_tag_offload_short_probe(
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_TAG,
         .tl_cap_flags        = UCT_IFACE_FLAG_TAG_EAGER_SHORT
     };
@@ -140,7 +140,7 @@ static void ucp_proto_eager_tag_offload_bcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_mem_info_unknown,
         .lane_type           = UCP_LANE_TYPE_TAG,
         .tl_cap_flags        = UCT_IFACE_FLAG_TAG_EAGER_BCOPY
     };
@@ -251,7 +251,8 @@ static void ucp_proto_eager_tag_offload_zcopy_probe_common(
                                UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG |
                                UCP_PROTO_COMMON_INIT_FLAG_CAP_SEG_SIZE,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = init_params->select_param->mem_type,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .lane_type           = UCP_LANE_TYPE_TAG,
         .tl_cap_flags        = UCT_IFACE_FLAG_TAG_EAGER_ZCOPY
     };

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -45,7 +45,8 @@ ucp_tag_rndv_offload_proto_probe(const ucp_proto_init_params_t *init_params)
                               UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY |
                               UCP_PROTO_COMMON_INIT_FLAG_SINGLE_FRAG,
        .super.exclude_map   = 0,
-       .super.reg_mem_type  = init_params->select_param->mem_type,
+       .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
        .lane_type           = UCP_LANE_TYPE_TAG,
        .tl_cap_flags        = UCT_IFACE_FLAG_TAG_RNDV_ZCOPY
     };
@@ -180,12 +181,11 @@ ucp_tag_rndv_offload_sw_proto_probe(const ucp_proto_init_params_t *init_params)
         .super.memtype_op    = UCT_EP_OP_LAST,
         .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_RESPONSE,
         .super.exclude_map   = 0,
-        .super.reg_mem_type  = UCS_MEMORY_TYPE_UNKNOWN,
+        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
         .remote_op_id        = UCP_OP_ID_RNDV_RECV,
         .lane                = init_params->ep_config_key->tag_lane,
         .perf_bias           = context->config.ext.rndv_perf_diff / 100.0,
-        .mem_info.type       = init_params->select_param->mem_type,
-        .mem_info.sys_dev    = init_params->select_param->sys_dev,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTS_NAME,
         .md_map              = 0
     };


### PR DESCRIPTION
## What
Need to take into account device distances for rndv ppln protocols (taking mtype and sys_dev for the corresponding fragment type)

## Why ?
PPLN protocols should not be selected over get/put based when GPU direct RDMA is enabled

**Before**
```
[1727631616.028245] [rock24:3137233:0]   +--------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
[1727631616.028250] [rock24:3137233:0]   | ucp_context_0 inter-node cfg#3 | rendezvous data fetch(multi) into cuda/GPU0 from cuda/dev[0]                                                                      |
[1727631616.028253] [rock24:3137233:0]   +--------------------------------+-----------------------------------------------------------------+-----------------------------------------------------------------+
[1727631616.028255] [rock24:3137233:0]   |                              0 | no data fetch                                                   |                                                                 |
[1727631616.028257] [rock24:3137233:0]   |                         1..282 | (?) zero-copy fenced write to remote                            | 23% on rc_mlx5/mlx5_0:1/path0 and 77% on rc_mlx5/mlx5_2:1/path0 |
[1727631616.028258] [rock24:3137233:0]   |                     283..98367 | zero-copy read from remote                                      | 23% on rc_mlx5/mlx5_0:1/path0 and 77% on rc_mlx5/mlx5_2:1/path0 |
[1727631616.028260] [rock24:3137233:0]   |                      98368..4M | (?) cuda_copy, fenced write to remote, frag cuda, cuda_copy, fr | 50% on rc_mlx5/mlx5_0:1/path0 and 50% on rc_mlx5/mlx5_2:1/path0 |
[1727631616.028262] [rock24:3137233:0]   |                   4194305..inf | pipeline cuda_copy, fenced write to remote, frag cuda, cuda_cop | 50% on rc_mlx5/mlx5_0:1/path0 and 50% on rc_mlx5/mlx5_2:1/path0 |
[1727631616.028263] [rock24:3137233:0]   +--------------------------------+-----------------------------------------------------------------+-----------------------------------------------------------------+

```

**After:**
```
[1727631560.456379] [rock24:3136926:0]   +--------------------------------+--------------------------------------------------------------------------------------------------------+
[1727631560.456384] [rock24:3136926:0]   | ucp_context_0 inter-node cfg#3 | rendezvous data fetch(multi) into cuda/GPU0 from cuda/dev[0]                                           |
[1727631560.456386] [rock24:3136926:0]   +--------------------------------+--------------------------------------+-----------------------------------------------------------------+
[1727631560.456389] [rock24:3136926:0]   |                              0 | no data fetch                        |                                                                 |
[1727631560.456392] [rock24:3136926:0]   |                         1..282 | (?) zero-copy fenced write to remote | 23% on rc_mlx5/mlx5_0:1/path0 and 77% on rc_mlx5/mlx5_2:1/path0 |
[1727631560.456393] [rock24:3136926:0]   |                       283..inf | zero-copy read from remote           | 23% on rc_mlx5/mlx5_0:1/path0 and 77% on rc_mlx5/mlx5_2:1/path0 |
[1727631560.456395] [rock24:3136926:0]   +--------------------------------+--------------------------------------+-----------------------------------------------------------------+

```