### PR TITLE
UCT/GDRCOPY: Set LAT/BW for iface_query as best between put and get operations

### DIFF
--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -128,11 +128,17 @@ uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.am.max_hdr          = 0;
     iface_attr->cap.am.max_iov          = 1;
 
-    /* Report GET latency by default as worst case */
-    iface_attr->latency                 = iface->config.get_latency;
-    iface_attr->bandwidth               = iface->config.get_bw;
-    iface_attr->overhead                = UCT_GDR_COPY_IFACE_OVERHEAD;
-    iface_attr->priority                = 0;
+    /* Report best performance by default */
+    iface_attr->latency.c           = ucs_min(iface->config.get_latency.c,
+                                              iface->config.put_latency.c);
+    iface_attr->latency.m           = ucs_min(iface->config.get_latency.m,
+                                              iface->config.put_latency.m);
+    iface_attr->bandwidth.dedicated = ucs_max(iface->config.get_bw.dedicated,
+                                              iface->config.put_bw.dedicated);
+    iface_attr->bandwidth.shared    = ucs_max(iface->config.get_bw.shared,
+                                              iface->config.put_bw.shared);
+    iface_attr->overhead            = UCT_GDR_COPY_IFACE_OVERHEAD;
+    iface_attr->priority            = 0;
 
     return UCS_OK;
 }


### PR DESCRIPTION
## What
Report GDR copy BW and LAT for `iface_query` as mean between GET and PUT operations.

## Why ?
That PR is a fix for performance regression on rock setup that was introduced here https://github.com/openucx/ucx/pull/10112

Before introducing env variables for setting GDR copy perf `iface_query` reported put BW but get LAT (since get LAT is the worse case). After  https://github.com/openucx/ucx/pull/10112 it started to report get BW and LAT (because get BW is worst case too), but that lead to significant performance degradation on rock because cuda_copy started to be chosen as memcopy EP instead of gdr_copy.

Since reporting GET LAT and PUT BW for `iface_query` seems weird FMPOV I decided that solution may be reporting mean of GET and PUT operations performance  for `iface_query`. Initial experiment shown that degradation is fixed with that approach. Still need to perform extended performance testing to prove absense of regressions in other places.

