### PR TITLE
GTEST/IB: Don't fatal if an SL is blocked

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -290,6 +290,16 @@ test_base::wrap_errors_logger(const char *file, unsigned line,
 }
 
 ucs_log_func_rc_t
+test_base::wrap_fatal_logger(const char *file, unsigned line,
+                             const char *function, ucs_log_level_t level,
+                             const ucs_log_component_config_t *comp_conf,
+                             const char *message, va_list ap)
+{
+    return common_logger(UCS_LOG_LEVEL_FATAL, true, m_errors, 1000, file, line,
+                         function, level, comp_conf, message, ap);
+}
+
+ucs_log_func_rc_t
 test_base::wrap_warns_logger(const char *file, unsigned line,
                              const char *function, ucs_log_level_t level,
                              const ucs_log_component_config_t *comp_conf,

--- a/test/gtest/common/test.h
+++ b/test/gtest/common/test.h
@@ -147,6 +147,12 @@ protected:
                        const char *message, va_list ap);
 
     static ucs_log_func_rc_t
+    wrap_fatal_logger(const char *file, unsigned line, const char *function,
+                      ucs_log_level_t level,
+                      const ucs_log_component_config_t *comp_conf,
+                      const char *message, va_list ap);
+
+    static ucs_log_func_rc_t
     wrap_warns_logger(const char *file, unsigned line, const char *function,
                       ucs_log_level_t level,
                       const ucs_log_component_config_t *comp_conf,

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -68,8 +68,8 @@ void test_uct_ib::send_recv_short() {
     EXPECT_TRUE((status == UCS_OK) || (status == UCS_INPROGRESS));
 
     flush();
-    wait_for_value(&test_uct_ib::m_ib_am_handler_counter,
-                   start_am_counter + 1, true);
+    wait_for_value(&test_uct_ib::m_ib_am_handler_counter, start_am_counter + 1,
+                   true, 2);
 
     ASSERT_EQ(sizeof(send_data), recv_buffer->length);
     EXPECT_EQ(send_data, *(uint64_t*)(recv_buffer+1));
@@ -446,6 +446,7 @@ protected:
 UCS_TEST_P(test_uct_ib_sl, check_ib_sl_config) {
     // go over all SLs, check UCTs could be initialized on a specific SL
     // and able to send/recv traffic
+    scoped_log_handler log_handler(wrap_fatal_logger);
     for (uint8_t sl = 0; sl < UCT_IB_SL_NUM; ++sl)  {
         if (!has_transport("rc_verbs") && !has_transport("ud_verbs")) {
             // if AR is configured on the given SL, set AR_ENABLE to "y",


### PR DESCRIPTION
## What
Proposal to keep running gtests when TB does not support some SL.

## Why ?
We have test bed that does not let traffic through for SL > 7, and it is causing gtest crash. In this specific traffic test, we can keep going, signaling failure anyways.

## How ?
Ignore fatal.