### PR TITLE
CONTRIB: Add checking script before push

### DIFF
--- a/buildlib/pr/codestyle.yml
+++ b/buildlib/pr/codestyle.yml
@@ -14,21 +14,13 @@ jobs:
 
       - bash: |
           set -eE
+          source ./buildlib/tools/codestyle.sh
+
           BASE_SOURCEVERSION=$(git rev-parse HEAD^)
           range="$BASE_SOURCEVERSION..$(Build.SourceVersion)"
-          ok=1
-          for sha1 in `git log $range --format="%h"`
-          do
-              title=`git log -1 --format="%s" $sha1`
-              if echo $title | grep -qP '^Merge |^[0-9A-Z/_\-]*: \w'
-              then
-                  echo "Good commit title: '$title'"
-              else
-                  echo "Bad commit title: '$title'"
-                  ok=0
-              fi
-          done
-          if [ $ok -ne 1 ]
+
+          codestyle_check_commit_title "$range"
+          if [[ $? -ne 0 ]]
           then
               url="https://github.com/openucx/ucx/wiki/Guidance-for-contributors#general-guidelines"
               echo "##vso[task.logissue type=error]Bad commit title(s), see $url for more info."
@@ -85,8 +77,7 @@ jobs:
         retryCountOnTaskFailure: 5
 
       - bash: |
-          python3 -m venv /tmp/codespell_env
-          source /tmp/codespell_env/bin/activate
-          pip3 install codespell
-          codespell
+          set -eE
+          source ./buildlib/tools/codestyle.sh
+          codestyle_check_spell
         displayName: codespell test

--- a/buildlib/tools/codestyle.sh
+++ b/buildlib/tools/codestyle.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+codestyle_check_commit_title() {
+    local range="$1"
+    local err=0
+
+    for sha1 in `git log "$range" --format="%h"`
+    do
+        title=`git log -1 --format="%s" $sha1`
+        if echo $title | grep -qP '^Merge |^[0-9A-Z/_\-]*: \w'
+        then
+            echo "Good commit title: '$title'"
+        else
+            echo "Bad commit title: '$title'"
+            err=1
+        fi
+    done
+
+    return $err
+}
+
+codestyle_check_spell() {
+    python3 -m venv /tmp/codespell_env
+    source /tmp/codespell_env/bin/activate
+    pip3 install codespell
+    codespell "$@"
+}

--- a/buildlib/tools/git_ready.sh
+++ b/buildlib/tools/git_ready.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+source ./buildlib/tools/codestyle.sh
+
+ucx=://github.com/openucx/ucx
+upstream=$(git remote -v  | grep -P "[\t ].*${ucx}.*[\t ].*fetch" | cut -f 1 | head -n 1)
+base=$(git merge-base "$upstream"/master HEAD)
+
+if ! git diff-index --quiet HEAD; then
+    echo "error: tree not clean"
+    exit 1
+fi
+
+codestyle_check_commit_title "$base"..HEAD
+if [[ $? -ne 0 ]]
+then
+    echo "error: fix commit title"
+    exit 1
+fi
+
+# Code format
+module load dev/llvm-ucx || :
+git clang-format --diff "$base" HEAD | patch -p1
+module unload dev/llvm-ucx || :
+
+# Codespell
+codestyle_check_spell --write-changes || :
+
+# Create commit for pre-push fixes
+if ! git diff-index --quiet HEAD; then
+    git add -p
+    # returns 1 if cached index is not empty
+    git diff --cached --exit-code || git commit -m "$title"
+fi
+
+# Pushing
+if [ "${1-}" = "--push" ]
+then
+
+    opt="${2-}"
+    remote="${opt%%/*}"
+    branch="${opt#*/}"
+
+    if [ "$remote" = "$opt" ] || [ -z "$remote" ] || [ -z "$branch" ]
+    then
+        echo "error: specify push location with '--push <remote>/<branch_name>'"
+        exit 1
+    fi
+
+    cmd="git push $remote HEAD:refs/heads/$branch"
+    echo "$cmd"
+    echo "<enter> or <ctrl-c> to abort"
+    read -r
+    $cmd
+fi


### PR DESCRIPTION
## What
Shell script to perform simple preliminary checks before pushing.

## Why ?
Avoid spending CI cycles with repeated pushing.

## How ?
Implement commit title, code format and spell checks locally. Ran `shellcheck` on it.
```
$ ./contrib/gitready.sh
$ ./contrib/gitready.sh --push origin/my_branch
```