### PR TITLE
UCT/CUDA_IPC: disable mnnvl by default

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -25,7 +25,7 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_cuda_ipc_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
 
-    {"ENABLE_MNNVL", "try",
+    {"ENABLE_MNNVL", "no",
      "Enable multi-node NVLINK capabilities.",
      ucs_offsetof(uct_cuda_ipc_md_config_t, enable_mnnvl), UCS_CONFIG_TYPE_TERNARY},
 


### PR DESCRIPTION
## Why
Enabling MNNVL by default causes pipeline protocols to be used for inter-node transfers on systems without MNNVL capabilities. This PR disables MNNVL capability by default and users are expected to manually enable using `UCX_CUDA_IPC_ENABLE_MNNVL=try` or `UCX_CUDA_IPC_ENABLE_MNNVL=yes` on MNNVL systems
