### PR TITLE
 UCT/IB/UD: Use interface address family when checking RoCE GRH

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1,6 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
+* Copyright (c) Google, LLC, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -66,6 +67,9 @@
 #define UCT_IB_MLX5_ATOMIC_MODE_EXT      3
 #define UCT_IB_MLX5_CQE_FLAG_L3_IN_DATA  UCS_BIT(28) /* GRH/IP in the receive buffer */
 #define UCT_IB_MLX5_CQE_FLAG_L3_IN_CQE   UCS_BIT(29) /* GRH/IP in the CQE */
+/* Bits 24-26 of flags_rqpn indicate the packet type */
+#define UCT_IB_MLX5_RQPN_ROCE_FLAG_IPV6  UCS_BIT(24)
+#define UCT_IB_MLX5_RQPN_ROCE_FLAG_IPV4  UCS_BIT(25)
 #define UCT_IB_MLX5_CQE_FORMAT_MASK      0xc
 #define UCT_IB_MLX5_MINICQE_ARR_MAX_SIZE 7
 #define UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK  0x0000FFFF  /* Byte count mask for multi-packet RQs */

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2017.  ALL RIGHTS RESERVED.
 * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
+* Copyright (c) Google, LLC, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -521,7 +522,7 @@ uct_ud_mlx5_iface_poll_rx(uct_ud_mlx5_iface_t *iface, int is_async)
 
     if (!uct_ud_iface_check_grh(&iface->super, packet,
                                 uct_ib_mlx5_cqe_is_grh_present(cqe),
-                                cqe->flags_rqpn & 0xFF)) {
+                                uct_ib_mlx5_cqe_roce_gid_len(cqe))) {
         ucs_mpool_put_inline(desc);
         goto out_polled;
     }

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2020. ALL RIGHTS RESERVED.
+* Copyright (c) Google, LLC, 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -395,10 +396,9 @@ static UCS_F_ALWAYS_INLINE void uct_ud_leave(uct_ud_iface_t *iface)
 
 static UCS_F_ALWAYS_INLINE int
 uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present,
-                       uint8_t roce_pkt_type)
+                       size_t gid_len)
 {
     struct ibv_grh *grh = (struct ibv_grh *)packet;
-    size_t gid_len;
     union ibv_gid *gid;
     khiter_t khiter;
     char gid_str[128] UCS_V_UNUSED;
@@ -411,25 +411,6 @@ uct_ud_iface_check_grh(uct_ud_iface_t *iface, void *packet, int is_grh_present,
         ucs_warn("RoCE packet does not contain GRH");
         return 1;
     }
-
-    /*
-     * Take the packet type from CQE, because:
-     * 1. According to Annex17_RoCEv2 (A17.4.5.1):
-     * For UD, the Completion Queue Entry (CQE) includes remote address
-     * information (InfiniBand Specification Vol. 1 Rev 1.2.1 Section 11.4.2.1).
-     * For RoCEv2, the remote address information comprises the source L2
-     * Address and a flag that indicates if the received frame is an IPv4,
-     * IPv6 or RoCE packet.
-     * 2. According to PRM, for responder UD/DC over RoCE sl represents RoCE
-     * packet type as:
-     * bit 3    : when set R-RoCE frame contains an UDP header otherwise not
-     * Bits[2:0]: L3_Header_Type, as defined below
-     *     - 0x0 : GRH - (RoCE v1.0)
-     *     - 0x1 : IPv6 - (RoCE v1.5/v2.0)
-     *     - 0x2 : IPv4 - (RoCE v1.5/v2.0)
-     */
-    gid_len = ((roce_pkt_type & UCT_IB_CQE_SL_PKTYPE_MASK) == 0x2) ?
-              UCS_IPV4_ADDR_LEN : UCS_IPV6_ADDR_LEN;
 
     if (ucs_likely((gid_len == iface->gid_table.last_len) &&
                     uct_ud_gid_equal(&grh->dgid, &iface->gid_table.last,


### PR DESCRIPTION
Some RoCE device drivers fail to set the service level in the work completion for UD completions. This leads to silently dropping all (or almost all) UD packets on these networks. This commit updates the GRH check logic to use the GRH to detect IPv4  vs IPv6.

## What

Update the GID length calculation to use the GRH instead of the service level in the work completion.

## Why ?

We have a system using Intel iRDMA which is not setting the service level for any UD work completion. This makes UCT silently drop all UD packets. This PR changes the code for non-mlx hardware to detect the address family (IPv4 vs IPv6) based on the data in the GRH. For IPv6 the first byte will contain 0x6X where X is any value whereas this byte will be untouched in IPv4. To ensure that a mix of IPv6 and IPv4 packets does not confuse the logic all posted UD receive buffers will have the first byte set to a known value (0xff).

For mlx hardware the gid length will be calculated based on the RoCE packet type in flags_rqpn as was done before.