### PR TITLE
CI: Fix spellcheck on generated files

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./test/gtest/common,./src/ucs/datastruct/sglib.h,./docs/doxygen/Architecture*,./docs/doxygen/header.tex.in,./src/ucm/ptmalloc286,./config/m4/ax_prog_doxygen.m4,./VENV/*
+skip = ./test/gtest/common,./src/ucs/datastruct/sglib.h,./docs/doxygen/Architecture*,./docs/doxygen/header.tex.in,./src/ucm/ptmalloc286,./config/m4/ax_prog_doxygen.m4,./VENV/*,./ltmain.sh,./configure,./config.guess,./config.sub,./.git,./depcomp,./libtool,./config/m4/libtool.m4
 ignore-words-list = hsa,inout,scoll,warmup,pullrequest,shft


### PR DESCRIPTION
## What
Don't write to inapropriate files when running `codespell --write-changes`.