### PR TITLE
GTEST/COMMON/MAIN: fix core dump issue on exception in gtest initialization

### DIFF
--- a/test/gtest/common/main.cc
+++ b/test/gtest/common/main.cc
@@ -64,8 +64,15 @@ static void set_log_level()
 }
 
 int main(int argc, char **argv) {
-    // coverity[fun_call_w_exception]: uncaught exceptions cause nonzero exit anyway, so don't warn.
-    ::testing::InitGoogleTest(&argc, argv);
+    try {
+        ::testing::InitGoogleTest(&argc, argv);
+    } catch (const std::exception& e) {
+        UCS_TEST_MESSAGE << "Failed to initialize gtest: " << e.what();
+        return -1;
+    } catch (...) {
+        UCS_TEST_MESSAGE << "Unknown exception during gtest initialization";
+        return -1;
+    }
 
     parse_test_opts(argc, argv);
 


### PR DESCRIPTION
## What?
Fixes the issue where gtest fails to catch exceptions during test initialization, which causes a core dump.

## Why?
When an exception is thrown during the test creation phase, gtest does not handle it properly, resulting in a crash. This change ensures exceptions are caught, preventing the core dump.

## How?
Added try-catch blocks around gtest initialization to catch and handle exceptions, logging the errors without crashing the application.

## Backtrace
```
#0  0x00007ffff5105a4f in raise () from /lib64/libc.so.6
#1  0x00007ffff50d8db5 in abort () from /lib64/libc.so.6
#2  0x00007ffff5cde09b in __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] () from /lib64/libstdc++.so.6
#3  0x00007ffff5ce453c in __cxxabiv1::__terminate(void (*)()) () from /lib64/libstdc++.so.6
#4  0x00007ffff5ce4597 in std::terminate() () from /lib64/libstdc++.so.6
#5  0x00007ffff5ce47f8 in __cxa_throw () from /lib64/libstdc++.so.6
#6  0x0000000000b85a2d in ucp_test::check_tls (tls=...) at /usr/include/c++/8/bits/exception.h:63
#7  0x0000000000b84be7 in ucp_test::enum_test_params (variants=std::vector of length 2, capacity 2 = {...}, tls="dc_x")
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/ucp/ucp_test.cc:528
#8  0x000000000086a8d1 in enum_test_params<test_ucp_am> (tls="dc_x") at /usr/include/c++/8/ext/new_allocator.h:79
#9  0x000000000084a097 in gtest_dcxtest_ucp_am_EvalGenerator_ () at /usr/include/c++/8/ext/new_allocator.h:79
#10 0x00000000008984a9 in testing::internal::ParameterizedTestSuiteInfo<test_ucp_am>::RegisterTests (this=0x1431b10)
    at /usr/include/c++/8/bits/stl_iterator.h:783
#11 0x0000000000e5e71d in testing::internal::ParameterizedTestSuiteRegistry::RegisterTests (this=0x140b858)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/internal/gtest-param-util.h:699
#12 testing::internal::UnitTestImpl::RegisterParameterizedTests (this=0x140b770)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/gtest.cc:2651
#13 testing::internal::UnitTestImpl::RegisterParameterizedTests (this=0x140b770)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/gtest.cc:2649
#14 0x0000000000e6b0d2 in testing::internal::UnitTestImpl::PostFlagParsingInit (this=0x140b770)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/gtest.cc:5138
#15 testing::internal::UnitTestImpl::PostFlagParsingInit (this=0x140b770)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/gtest.cc:5120
#16 0x0000000000e75d8b in testing::internal::InitGoogleTestImpl<char> (argc=argc@entry=0x7fffffffbffc,
    argv=argv@entry=0x7fffffffc2a8)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/gtest.h:1412
#17 0x0000000000e6bb35 in testing::InitGoogleTest (argc=argc@entry=0x7fffffffbffc, argv=argv@entry=0x7fffffffc2a8)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/googletest/gtest.cc:6118
#18 0x0000000000636633 in main (argc=<optimized out>, argv=0x7fffffffc2a8)
    at /labhome/mshalev/workspace/ucx/contrib/../test/gtest/common/main.cc:68 

 ```

## Before
![image](https://github.com/user-attachments/assets/451bd4f6-294b-4a14-bb52-3254cd639374)

## After
![image](https://github.com/user-attachments/assets/12130f8c-28bb-435d-b533-f4d25cd8e4ba)
