### PR TITLE
UCP/ASAN: Fixed ASAN detected buffer overflow

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -174,7 +174,8 @@ UCS_PROFILE_FUNC(ssize_t, ucp_rkey_pack_memh,
         }
 
         ucs_trace("rkey %s for md[%d]=%s",
-                  ucs_str_dump_hex(p, tl_rkey_size, buf, sizeof(buf), SIZE_MAX),
+                  ucs_str_dump_hex(tl_rkey_buf, tl_rkey_size, buf, sizeof(buf),
+                                   SIZE_MAX),
                   md_index, context->tl_mds[md_index].rsc.md_name);
     }
 
@@ -395,6 +396,7 @@ ucp_memh_exported_pack(const ucp_mem_h memh, void *buffer)
     ucp_md_index_t md_index;
     size_t tl_mkey_size, global_id_size;
     size_t tl_mkey_data_size;
+    void *tl_mkey_buf;
 
     ucs_log_indent(1);
 
@@ -423,9 +425,10 @@ ucp_memh_exported_pack(const ucp_mem_h memh, void *buffer)
                     "tl_mkey_size %zu", tl_mkey_size);
         *ucs_serialize_next(&p, uint8_t) = tl_mkey_size;
 
-        status = uct_md_mkey_pack_v2(
-                tl_mds[md_index].md, memh->uct[md_index], address, length,
-                &params, ucs_serialize_next_raw(&p, void, tl_mkey_size));
+        tl_mkey_buf = ucs_serialize_next_raw(&p, void, tl_mkey_size);
+        status      = uct_md_mkey_pack_v2(tl_mds[md_index].md,
+                                          memh->uct[md_index], address, length,
+                                          &params, tl_mkey_buf);
         if (status != UCS_OK) {
             result = status;
             goto out;
@@ -437,7 +440,7 @@ ucp_memh_exported_pack(const ucp_mem_h memh, void *buffer)
 
         ucs_trace("exported mkey[%d]=%s for md[%d]=%s",
                   ucs_bitmap2idx(export_md_map, md_index),
-                  ucs_str_dump_hex(p, tl_mkey_size, buf, sizeof(buf),
+                  ucs_str_dump_hex(tl_mkey_buf, tl_mkey_size, buf, sizeof(buf),
                                    SIZE_MAX),
                   md_index, tl_mds[md_index].rsc.md_name);
     }


### PR DESCRIPTION
## What
When running ucp_perftest_daemon with ASAN and trace logs, 2 buffer overflows are detected, both related to HEX dump of mkey/rkey. The regression was introduced in PR: https://github.com/openucx/ucx/pull/6745

The original hex dump was correct: https://github.com/openucx/ucx/pull/4153/files#diff-81ab501a3a76470dfbfe72e890118aa3083efe0434532272d12f2d5614047ec7R92
Then the impl was refactored to use common serialization API. And the issue is that `ucs_serialize_next_raw` already advances the pointer, so we dump the garbage value behind the key bytes