### PR TITLE
UCT/MEM: Improve logs on allocation failure

### DIFF
--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -293,7 +293,10 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
         }
     }
 
-    ucs_debug("could not allocate memory with any of the provided methods");
+    ucs_debug("could not allocate %s: %s memory length=%zu flags=0x%x "
+              "num_methods=%u",
+              alloc_name, ucs_memory_type_names[mem_type], alloc_length, flags,
+              num_methods);
     status = UCS_ERR_NO_MEMORY;
     goto out;
 


### PR DESCRIPTION
## What
Detail logging.

`uct_mem.c:298  UCX  DEBUG   could not allocate user memory: host memory length=4096 flags=0x0 num_methods=1`