### PR TITLE
CONFIG/SPEC: Bump version to 1.19.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)  # Major version. Usually does not change.
-define([ucx_ver_minor], 18) # Minor version. Increased for each release.
+define([ucx_ver_minor], 19) # Minor version. Increased for each release.
 define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -405,6 +405,8 @@ Provides oneAPI Level Zero (ZE) Runtime support for UCX.
 %endif
 
 %changelog
+* Sat Oct 12 2024 Yossi Itigin <yosefe@nvidia.com> 1.19.0-1
+- Bump version to 1.19.0
 * Fri Apr 19 2024 Yossi Itigin <yosefe@nvidia.com> 1.18.0-1
 - Bump version to 1.18.0
 * Tue Oct 31 2023 Yossi Itigin <yosefe@nvidia.com> 1.17.0-1


### PR DESCRIPTION
## Why
Bump version to 1.19.0 after branching v1.18.x