### PR TITLE
UCS/MPMC: Don't assume pointer validity without lock

### DIFF
--- a/src/ucs/datastruct/mpmc.c
+++ b/src/ucs/datastruct/mpmc.c
@@ -59,7 +59,7 @@ ucs_status_t ucs_mpmc_queue_pull(ucs_mpmc_queue_t *mpmc, uint64_t *value_p)
     ucs_status_t status = UCS_ERR_NO_PROGRESS;
     ucs_mpmc_elem_t *elem;
 
-    if (ucs_queue_is_empty(&mpmc->queue)) {
+    if (ucs_mpmc_queue_is_empty(mpmc)) {
         return status;
     }
 

--- a/src/ucs/datastruct/mpmc.h
+++ b/src/ucs/datastruct/mpmc.h
@@ -93,7 +93,7 @@ void ucs_mpmc_queue_remove_if(ucs_mpmc_queue_t *mpmc,
  */
 static inline int ucs_mpmc_queue_is_empty(ucs_mpmc_queue_t *mpmc)
 {
-    return ucs_queue_is_empty(&mpmc->queue);
+    return ucs_queue_is_empty_no_deref(&mpmc->queue);
 }
 
 #endif

--- a/src/ucs/datastruct/queue.h
+++ b/src/ucs/datastruct/queue.h
@@ -58,12 +58,20 @@ ucs_queue_is_tail(ucs_queue_head_t *queue, ucs_queue_elem_t *elem)
 }
 
 /**
+ * @return Whether the queue is empty without assumption on pointer validity
+ */
+static inline int ucs_queue_is_empty_no_deref(const ucs_queue_head_t *queue)
+{
+    return queue->ptail == &queue->head;
+}
+
+/**
  * @return Whether the queue is empty.
  */
 static inline int ucs_queue_is_empty(const ucs_queue_head_t *queue)
 {
     UCS_QUEUE_CHECK_HEAD_IS_VALID(queue);
-    return queue->ptail == &queue->head;
+    return ucs_queue_is_empty_no_deref(queue);
 }
 
 /**

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -1336,7 +1336,8 @@ void ucs_debug_asan_validate_address(const char *ptr_name, void *address,
 {
 #ifdef __SANITIZE_ADDRESS__
     if (__asan_region_is_poisoned(address, size)) {
-        ucs_fatal("%s at: %p is poisoned", ptr_name, address);
+        ucs_fatal("%s: address=%p size=%zu is poisoned", ptr_name, address,
+                  size);
     }
 #endif
 }


### PR DESCRIPTION
## What
Don't check for pointer validity when accessing without lock.

## Why ?
We cannot assume stable memory content outside of lock.

## How ?
Add and use specific function for unlocked accesses as it's racing with either free or alloc path.

### Original failure
```
[ RUN      ] test_mpmc.multi_threaded <> <>
[swx-rdmz-ucx-gpu-01:31308:4:35972]       debug.c:1339 Fatal: (queue)->ptail at: 0x6020002503b0 is poisoned
```

### New log
```
queue.h:73   Assertion `!__asan_region_is_poisoned((void*)((queue)->ptail), sizeof(*(queue)->ptail))' failed: (queue)->ptail: address=0x602000055ed0 size=8
```