### PR TITLE
CONTRIB/CTAGS: Add ctags script trying to also generate profile functions

### DIFF
--- a/buildlib/dockers/fedora.Dockerfile
+++ b/buildlib/dockers/fedora.Dockerfile
@@ -1,4 +1,5 @@
-# docker build -t ucfconsort.azurecr.io/ucx/fedora:5 -f buildlib/fedora.Dockerfile buildlib/
+# docker build -t harbor.mellanox.com/ucx/fedora33:2 -f buildlib/dockers/fedora.Dockerfile buildlib/
+# docker push harbor.mellanox.com/ucx/fedora33:2
 FROM fedora:33
 
 RUN dnf install -y \
@@ -23,6 +24,8 @@ RUN dnf install -y \
     python \
     rdma-core-devel \
     rpm-build \
+    vim \
+    ctags \
     && dnf clean dbcache packages
 RUN export BUILD_ROOT=/tmp/llvm-project && \
     git clone https://github.com/openucx/llvm-project.git --depth=1 -b ucx-clang-format --single-branch ${BUILD_ROOT} && \

--- a/buildlib/pr/codestyle.yml
+++ b/buildlib/pr/codestyle.yml
@@ -90,3 +90,20 @@ jobs:
           pip3 install codespell
           codespell
         displayName: codespell test
+
+  - job: ctags_generation
+    displayName: ctags check
+    pool:
+      name: MLNX
+      demands:
+      - ucx_docker -equals yes
+    container: fedora
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        retryCountOnTaskFailure: 5
+
+      - bash: |
+          ./buildlib/tools/test_ctags.sh
+        displayName: ctags generation test

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -16,7 +16,7 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos7-mofed5.4-cuda11:1
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: fedora
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:1
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:2
       options: $(DOCKER_OPT_ARGS)
     - container: fedora34
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora34:2

--- a/buildlib/tools/test_ctags.sh
+++ b/buildlib/tools/test_ctags.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+realdir=$(realpath $(dirname $0))
+source ${realdir}/../az-helpers.sh
+
+set -eu
+
+./contrib/ctags.sh
+
+[[ -f tags ]] || { echo "TAG file not found"; exit 1; }
+
+set +e
+set -x
+
+failures=
+
+for tag in \
+    tag_not_found \
+    ucp_tag_send_nbx \
+    ucs_error \
+    ucp_request_free \
+    test_ucp_am;
+do
+    echo checking tag=$tag
+    vim -u NONE -c "set tags=./tags" -c "tag $tag" -c 'if v:errmsg != "" | cquit | else | quit | endif'
+    if [[ $? -ne 0 ]]; then
+        failures="$failures|$tag"
+    fi
+done
+
+if [[ "$failures" = "|tag_not_found" ]]
+then
+    echo "SUCCESS"
+    exit 0
+else
+    azure_log_error "Failed to find generated ctags: $failures"
+    exit 1
+fi

--- a/contrib/ctags.sh
+++ b/contrib/ctags.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+cd $(dirname $0)/..
+
+echo "Using $PWD"
+
+rm -f tags || :
+ctags -R -f tags .
+
+find . -name "*.inl" -type f -exec \
+    ctags -R -f tags \
+    --append=yes \
+    --language-force=C \
+    {} \;
+
+find . -type f -and \( -name '*.inl' -or -name '*.c' \) \
+    -exec awk -f ./contrib/ctags_ucx.awk {} \; >>tags
+
+LC_COLLATE=C sort -o tags{,}

--- a/contrib/ctags_ucx.awk
+++ b/contrib/ctags_ucx.awk
@@ -1,0 +1,39 @@
+#!/usr/bin/env awk -f
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+BEGIN {
+    OFS="\t"
+}
+
+function emit(type, name) {
+    print name, FILENAME, "/^" $0 "$/;\"", "f", "typeref:typename:"type, "file:"
+}
+
+function fail(line) {
+    print "Failed to get function name for:" | "cat >&2"
+    print line | "cat >&2"
+}
+
+/UCS_PROFILE_FUNC_VOID[\t ]*\(/ {
+    match($0, /UCS_PROFILE_FUNC_VOID\([\t ]*([^, \t]+)/, name)
+    if (name[1] == "") {
+        fail($0)
+        next
+    }
+
+    emit("void", name[1]);
+}
+
+/UCS_PROFILE_FUNC[\t ]*\(/ {
+    match($0, /UCS_PROFILE_FUNC\([\t ]*([^, \t]+)/, type)
+    match($0, /UCS_PROFILE_FUNC\([^,]+,[\t ]*([^, \t]+)/, name)
+    if (type[1] == "" || name[1] == "") {
+        fail($0)
+        next
+    }
+
+    emit(type[1], name[1]);
+}


### PR DESCRIPTION
## What
Generate tag including profiled functions.

## Why ?
Need to be able to follow those functions.

## How ?
```shell
$ ./contrib/ctags.sh
$ grep 'cuda_ocpy_ep_get.*PROFILE_FUNC' tags
uct_cuda_copy_ep_get_short      ./src/uct/cuda/cuda_copy/cuda_copy_ep.c /^UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_get_short,$/;"        f       typeref:typename:ucs_status_t   file:
uct_gdr_copy_ep_get_short       ./src/uct/cuda/gdr_copy/gdr_copy_ep.c   /^UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_ep_get_short,$/;" f       typeref:typename:ucs_status_t   file:
```
