### PR TITLE
UCP/PROTO: Fix RNDV_SCHEME logic

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -395,24 +395,14 @@ static void ucp_proto_rndv_ctrl_variant_probe(
     /* Set priority and threshold for this variant */
     cfg_thresh   = params->super.cfg_thresh;
     cfg_priority = params->super.cfg_priority;
-    if ((remote_proto->cfg_thresh != UCS_MEMUNITS_INF) &&
-        (remote_proto->cfg_thresh != UCS_MEMUNITS_AUTO)) {
-        /* Consider remote priority and threshold only if RNDV_SCHEME or
-            * BCOPY/ZCOPY thresh are set to force these settings */
-        cfg_priority = remote_proto->cfg_priority;
-        cfg_thresh   = (cfg_thresh == UCS_MEMUNITS_AUTO) ?
-                                 remote_proto->cfg_thresh :
-                                 ucs_max(cfg_thresh, remote_proto->cfg_thresh);
+    if (remote_proto->cfg_thresh != UCS_MEMUNITS_AUTO) {
+        /* If RNDV_SCHEME is set, all protocols except forced one report INF */
+        ucs_assertv(remote_proto->cfg_thresh == UCS_MEMUNITS_INF,
+                    "variant_name=%s remote_proto->cfg_thresh=%zu",
+                    variant_name, remote_proto->cfg_thresh);
+        cfg_thresh = remote_proto->cfg_thresh;
     }
 
-    /* Remote variants priorities are used to respect RNDV_SCHEME setting
-     * so they should contain value greater than CTRL message `cfg_thresh`.
-     * Equality is allowed for RTR remote variants.
-     */
-    ucs_assertv(params->super.cfg_priority <= remote_proto->cfg_priority,
-                "remote_proto=%s params->super.cfg_priority=%u "
-                "remote_proto->cfg_priority=%u", variant_name,
-                params->super.cfg_priority, remote_proto->cfg_priority);
     ucp_proto_select_add_proto(&params->super.super, cfg_thresh, cfg_priority,
                                perf, rpriv, priv_size);
 

--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -20,15 +20,14 @@
 static UCS_F_ALWAYS_INLINE size_t
 ucp_proto_rndv_cfg_thresh(ucp_context_h context, uint64_t rndv_modes)
 {
+    ucp_rndv_mode_t mode = context->config.ext.rndv_mode;
     ucs_assert(!(rndv_modes & UCS_BIT(UCP_RNDV_MODE_AUTO)));
 
-    if (context->config.ext.rndv_mode == UCP_RNDV_MODE_AUTO) {
-        return UCS_MEMUNITS_AUTO; /* automatic threshold */
-    } else if (rndv_modes & UCS_BIT(context->config.ext.rndv_mode)) {
-        return 0; /* enabled by default */
-    } else {
-        return UCS_MEMUNITS_INF; /* used only as last resort */
+    if ((mode == UCP_RNDV_MODE_AUTO) || (rndv_modes & UCS_BIT(mode))) {
+        return UCS_MEMUNITS_AUTO;
     }
+
+    return UCS_MEMUNITS_INF; /* used only as last resort */
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1627,14 +1627,18 @@ public:
                                  void *data, size_t length,
                                  const ucp_am_recv_param_t *rx_param)
     {
-        EXPECT_TRUE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV);
-        EXPECT_FALSE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA);
-
         ucs_status_t status = test_ucp_am_nbx::am_data_handler(header,
                                                                header_length,
                                                                data, length,
                                                                rx_param);
         EXPECT_FALSE(UCS_STATUS_IS_ERR(status));
+
+        if (!m_check_recv_rndv_flags) {
+            return status;
+        }
+
+        EXPECT_TRUE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV);
+        EXPECT_FALSE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA);
 
         return UCS_INPROGRESS;
     }
@@ -1732,8 +1736,16 @@ public:
         return cfg->rndv_frag_size[mem_type];
     }
 
+    void check_rma_support()
+    {
+        if (!sender().is_rndv_supported()) {
+            UCS_TEST_SKIP_R("RNDV is not supported");
+        }
+    }
+
 protected:
     static constexpr unsigned RNDV_THRESH = 128;
+    bool m_check_recv_rndv_flags          = true;
     ucs_status_t m_status;
     bool m_am_recv_cb_invoked;
 };
@@ -1745,11 +1757,13 @@ UCS_TEST_P(test_ucp_am_nbx_rndv, rndv_auto, "RNDV_SCHEME=auto")
 
 UCS_TEST_P(test_ucp_am_nbx_rndv, rndv_get, "RNDV_SCHEME=get_zcopy")
 {
+    check_rma_support();
     test_am_send_recv(64 * UCS_KBYTE);
 }
 
 UCS_TEST_P(test_ucp_am_nbx_rndv, rndv_put, "RNDV_SCHEME=put_zcopy")
 {
+    check_rma_support();
     test_am_send_recv(64 * UCS_KBYTE);
 }
 
@@ -2084,6 +2098,8 @@ UCS_TEST_P(test_ucp_am_nbx_rndv_ppln, host_buff_host_frag,
            "RNDV_FRAG_MEM_TYPE=host")
 {
     // Host memory should not be pipelined thru host staging buffers
+    m_check_recv_rndv_flags = false;
+
     test_ppln_send(UCS_MEMORY_TYPE_HOST, 2, 0);
 }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -899,13 +899,18 @@ protected:
         return get_variant_value() & TEST_MODIFIER_SA_DATA_V1;
     }
 
-    bool has_rndv_lanes(ucp_ep_h ep)
+    bool has_rndv_lanes(const entity &entity)
     {
+        const auto *config   = &entity.worker()->context->config.ext;
+        const auto &ep       = entity.ep();
+        uint64_t iface_flags = (config->rndv_mode == UCP_RNDV_MODE_GET_ZCOPY) ?
+                                       UCT_IFACE_FLAG_GET_ZCOPY :
+                                       UCT_IFACE_FLAG_PUT_ZCOPY;
+
         for (ucp_lane_index_t lane_idx = 0;
              lane_idx < ucp_ep_num_lanes(ep); ++lane_idx) {
             if ((lane_idx != ucp_ep_get_cm_lane(ep)) &&
-                (ucp_ep_get_iface_attr(ep, lane_idx)->cap.flags &
-                 (UCT_IFACE_FLAG_GET_ZCOPY | UCT_IFACE_FLAG_PUT_ZCOPY)) &&
+                (ucp_ep_get_iface_attr(ep, lane_idx)->cap.flags & iface_flags) &&
                 /* RNDV lanes should be selected if transport supports GET/PUT
                  * Zcopy and: */
                 (/* - either memory invalidation can be done on its MD */
@@ -938,6 +943,10 @@ protected:
         constexpr size_t length = 4 * UCS_KBYTE;
 
         listen_and_communicate(false, SEND_DIRECTION_BIDI);
+
+        if (!has_rndv_lanes(sender())) {
+            UCS_TEST_SKIP_R("no RNDV lanes");
+        }
 
         mem_buffer send_buffer(length, UCS_MEMORY_TYPE_HOST);
         send_buffer.pattern_fill(1, length);
@@ -1386,7 +1395,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_wireup, compare_cm_and_wireup_configs,
     cm_ep_cfg_key           = &ucp_ep_config(sender().ep())->key;
     /* Don't check RNDV lanes, because CM prefers p2p connection mode for RNDV
      * lanes and they don't support memory invalidation on MD */
-    should_check_rndv_lanes = !has_rndv_lanes(sender().ep());
+    should_check_rndv_lanes = !has_rndv_lanes(sender());
     EXPECT_NE(UCP_NULL_LANE, ucp_ep_get_cm_lane(sender().ep()));
     disconnect(sender());
     disconnect(receiver());
@@ -1996,8 +2005,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_sockaddr_check_lanes, check_rndv_lanes,
 {
     listen_and_communicate(false, SEND_DIRECTION_BIDI);
 
-    EXPECT_EQ(has_rndv_lanes(sender().ep()),
-              has_rndv_lanes(receiver().ep()));
+    EXPECT_EQ(has_rndv_lanes(sender()), has_rndv_lanes(receiver()));
 
     concurrent_disconnect();
 }
@@ -3169,6 +3177,10 @@ protected:
             send_recv(sender(), receiver(), send_recv_type(), false, cb_type(),
                       sender_idx);
 
+            if (!has_rndv_lanes(sender())) {
+                UCS_TEST_SKIP_R("no RNDV lanes");
+            }
+
             for (size_t i = 0; i < num_sends; ++i) {
                 void *sreq = send(sender(), send_buf.ptr(), size,
                                   SEND_RECV_TAG, send_cb, NULL, sender_idx);
@@ -3248,7 +3260,7 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
 {
     size_t num_sends = ucs_max(100, 100000 / ucs::test_time_multiplier() /
                                     ucs::test_time_multiplier());
-    do_tag_rndv_killed_sender_test(1, 128, num_sends);
+    do_tag_rndv_killed_sender_test(1, 1024, num_sends);
 }
 
 UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
@@ -3257,7 +3269,7 @@ UCS_TEST_P(test_ucp_sockaddr_protocols_err_sender,
 {
     size_t num_sends = ucs_max(100, 100000 / ucs::test_time_multiplier() /
                                     ucs::test_time_multiplier());
-    do_tag_rndv_killed_sender_test(4, 128, num_sends);
+    do_tag_rndv_killed_sender_test(4, 1024, num_sends);
 }
 
 UCP_INSTANTIATE_CM_TEST_CASE(test_ucp_sockaddr_protocols_err_sender)

--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1208,6 +1208,12 @@ bool ucp_test_base::entity::is_rndv_put_ppln_supported() const
     return false;
 }
 
+bool ucp_test_base::entity::is_rndv_supported() const
+{
+    const auto config = ucp_ep_config(ep());
+    return config->key.rma_bw_lanes[0] != UCP_NULL_LANE;
+}
+
 bool ucp_test_base::entity::is_conn_reqs_queue_empty() const
 {
     return m_conn_reqs.empty();

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -158,6 +158,8 @@ public:
 
         bool is_rndv_put_ppln_supported() const;
 
+        bool is_rndv_supported() const;
+
         bool is_conn_reqs_queue_empty() const;
 
     protected:


### PR DESCRIPTION
## What
Change `RNDV_SCHEME` and `RNDV_THRESH` logic to work properly.

## Why ?
Currently if user set certain `RNDV_SCHEME` without setting `RNDV_THRESH` this scheme would be forced on all sizes since `cfg_thresh` for this protocol would be `0`. This change fixes that.

## How ?
With this change remote variant can report only 2 values as `cfg_thresh`: `AUTO` and `INF`. `AUTO` reported for:
- all protocols if `RNDV_SCHEME=auto`
- protocol that is set in `RNDV_SCHEME`

`INF` is reported for all protocols that are not set in `RNDV_SCHEME` if `RNDV_SCHEME` is set to some certain protocol.


## Manual testing cases:
| RNDV_THRESH| RNDV_SCHEME| RESULT|
|--------|--------|--------|
| AUTO| AUTO| All protocols are selected basing on perf comparison|
| AUTO| GET_ZCOPY| No hard thresh, but only GET_ZCOPY protocol participates in proto selection |
| AUTO| PUT_ZCOPY| No hard thresh, but only GET_ZCOPY protocol participates in proto selection |
| 1024| AUTO| Starting from 1024 RNDV is forced but which RNDV protocol would be used decided by proto selection |
| 1024| GET_ZCOPY| RNDV_GET used starting from 1024 |
| 1024| PUT_ZCOPY| RNDV_PUT used starting from 1024 |
| INF| AUTO| RNDV is not used |
| INF| GET_ZCOPY| RNDV is not used  |
| INF| PUT_ZCOPY| RNDV is not used |
 