### PR TITLE
UCT/GGA: fix compilation --with-mlx5-dv=no --with-devx=no

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -461,5 +461,5 @@ do
 	[ -d "${ucx_build_dir}" ] && rm -rf ${ucx_build_dir}/*
 
 	# run the test
-	$test_name || { azure_log_error "Test failed: $test_name"; exit 1; }
+	$test_name
 done

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -256,7 +256,7 @@ typedef struct uct_ib_mlx5_dma_opaque_mr {
 } uct_ib_mlx5_dma_opaque_mr_t;
 
 
-#if HAVE_DEVX
+#if HAVE_MLX5_MMO
 /**
  * full WQE format:
  * struct mlx5_wqe_ctrl_seg;
@@ -269,8 +269,10 @@ typedef struct uct_ib_mlx5_dma_seg {
     uint32_t be_opaque_lkey;
     uint64_t be_opaque_vaddr;
 } UCS_S_PACKED uct_ib_mlx5_dma_seg_t;
+#endif
 
 
+#if HAVE_DEVX
 typedef struct {
     struct mlx5dv_devx_obj *dvmr;
     int                    mr_num;

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -239,13 +239,18 @@ static unsigned uct_ib_mlx5_parse_dseg(void **dseg_p, unsigned op_flags,
     return ds;
 }
 
-static void* uct_ib_mlx5_dump_dma_seg(uct_ib_mlx5_dma_seg_t *dma_seg,
-                                      char *buf, size_t max)
+static void* uct_ib_mlx5_dump_dma_seg(void *seg, char *buf, size_t max)
 {
+#if HAVE_MLX5_MMO
+    uct_ib_mlx5_dma_seg_t *dma_seg = seg;
+
     snprintf(buf, max, " DMA[lkey 0x%x va 0x%"PRIx64"]",
              be32toh(dma_seg->be_opaque_lkey),
              be64toh(dma_seg->be_opaque_vaddr));
     return dma_seg + 1;
+#else
+    ucs_fatal("WQE dump: unexpected DMA segment at %p", seg);
+#endif
 }
 
 static uint64_t network_to_host(void *ptr, int size)


### PR DESCRIPTION
## What
fix build `--with-mlx5-dv=no --with-devx=no`

## Why ?
to fix non-default build configuration
