### PR TITLE
GTEST/UCP: Disabled performance checking for UD transports.

### DIFF
--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -330,7 +330,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
     size_t max_iter = std::numeric_limits<size_t>::max();
     test_spec test  = tests[get_variant_value(VARIANT_TEST_TYPE)];
 
-    if (has_transport("tcp")) {
+    if (has_any_transport({"tcp", "ud_v", "ud_x"})) {
         check_perf = false;
         max_iter   = 1000lu;
     }


### PR DESCRIPTION
## What
Disabled performance checking for UD transports in `test_ucp_perf.envelope`.

## Why ?
To avoid such failures:
```
[ RUN      ] udx/test_ucp_perf.envelope/37 <ud_x/am_bw_b>
[     INFO ]                    am_bw_b : 1.025 MB/sec
[     INFO ]                    am_bw_b : 2.523 MB/sec (attempt 1)
[     INFO ]                    am_bw_b : 2.535 MB/sec (attempt 2)
[     INFO ]                    am_bw_b : 1.774 MB/sec (attempt 3)
[     INFO ]                    am_bw_b : 1.777 MB/sec (attempt 4)
[     INFO ]                    am_bw_b : 1.573 MB/sec (attempt 5)
[     INFO ]                    am_bw_b : 1.409 MB/sec (attempt 6)
/__w/1/s/contrib/../test/gtest/common/test_helpers.cc:55: Failure
Failed
Connection timed out - abort testing
```
, or
```
[ RUN      ] ud/test_ucp_perf.envelope/37 <ud_v/am_bw_b>
[     INFO ]                    am_bw_b : 2.142 MB/sec
[     INFO ]                    am_bw_b : 3.814 MB/sec (attempt 1)
[     INFO ]                    am_bw_b : 17.229 MB/sec (attempt 2)
[     INFO ]                    am_bw_b : 4.329 MB/sec (attempt 3)
[     INFO ]                    am_bw_b : 11.041 MB/sec (attempt 4)
[     INFO ]                    am_bw_b : 11.873 MB/sec (attempt 5)
[     INFO ]                    am_bw_b : 15.773 MB/sec (attempt 6)
[     INFO ]                    am_bw_b : 15.996 MB/sec (attempt 7)
[     INFO ]                    am_bw_b : 7.908 MB/sec (attempt 8)
[     INFO ]                    am_bw_b : 18.133 MB/sec (attempt 9)
[     INFO ]                    am_bw_b : 14.656 MB/sec (attempt 10)
/__w/1/s/contrib/../test/gtest/common/test_perf.cc:379: Failure
Failed
Invalid am_bw_b performance, expected: 20..5e+05
[  FAILED  ] ud/test_ucp_perf.envelope/37, where GetParam() = ud_v/am_bw_b (331765 ms)
```