### PR TITLE
UCP: Fixed stack overflow in exported rkey unpack

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1774,37 +1774,38 @@ ucp_memh_import_attach(ucp_context_h context, ucp_mem_h memh,
     uct_mem_h uct_memh;
 
     for (tl_mkey_index = 0; tl_mkey_index < num_tl_mkeys; ++tl_mkey_index) {
-        md_index    = tl_mkeys[tl_mkey_index].md_index;
         tl_mkey_buf = tl_mkeys[tl_mkey_index].tl_mkey_buf;
-        md_attr     = &context->tl_mds[md_index].attr;
-        ucs_assert_always(md_attr->flags & UCT_MD_FLAG_EXPORTED_MKEY);
+        ucs_for_each_bit(md_index, tl_mkeys[tl_mkey_index].local_md_map) {
+            md_attr = &context->tl_mds[md_index].attr;
+            ucs_assert_always(md_attr->flags & UCT_MD_FLAG_EXPORTED_MKEY);
 
-        if (memh->uct[md_index] != NULL) {
-            continue;
-        }
+            if (memh->uct[md_index] != NULL) {
+                continue;
+            }
 
-        attach_params.field_mask = UCT_MD_MEM_ATTACH_FIELD_FLAGS;
-        attach_params.flags      = UCT_MD_MEM_ATTACH_FLAG_HIDE_ERRORS;
+            attach_params.field_mask = UCT_MD_MEM_ATTACH_FIELD_FLAGS;
+            attach_params.flags      = UCT_MD_MEM_ATTACH_FLAG_HIDE_ERRORS;
 
-        status = uct_md_mem_attach(context->tl_mds[md_index].md, tl_mkey_buf,
-                                   &attach_params, &uct_memh);
-        if (ucs_unlikely(status != UCS_OK)) {
-            /* Don't print an error, because two MDs can have similar global
-             * identifiers, but a memory key was exported on another MD */
-            ucs_trace("failed to attach memory on '%s/%s': %s",
-                      md_attr->component_name,
+            status = uct_md_mem_attach(context->tl_mds[md_index].md, tl_mkey_buf,
+                                       &attach_params, &uct_memh);
+            if (ucs_unlikely(status != UCS_OK)) {
+                /* Don't print an error, because two MDs can have similar global
+                 * identifiers, but a memory key was exported on another MD */
+                ucs_trace("failed to attach memory on '%s/%s': %s",
+                          md_attr->component_name,
+                          context->tl_mds[md_index].rsc.md_name,
+                          ucs_status_string(status));
+                continue;
+            }
+
+            memh->uct[md_index] = uct_memh;
+            memh->md_map       |= UCS_BIT(md_index);
+
+            ucs_trace("imported address %p length %zu on md[%d]=%s: uct_memh %p",
+                      ucp_memh_address(memh), ucp_memh_length(memh), md_index,
                       context->tl_mds[md_index].rsc.md_name,
-                      ucs_status_string(status));
-            continue;
+                      memh->uct[md_index]);
         }
-
-        memh->uct[md_index] = uct_memh;
-        memh->md_map       |= UCS_BIT(md_index);
-
-        ucs_trace("imported address %p length %zu on md[%d]=%s: uct_memh %p",
-                  ucp_memh_address(memh), ucp_memh_length(memh), md_index,
-                  context->tl_mds[md_index].rsc.md_name,
-                  memh->uct[md_index]);
     }
 
     if (memh->md_map == 0) {

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -122,7 +122,7 @@ typedef struct ucp_rkey {
 
 
 typedef struct ucp_unpacked_exported_tl_mkey {
-    ucp_md_index_t md_index;     /* Index of MD which owns TL mkey */
+    ucp_md_map_t   local_md_map; /* Local MD map of packed TL mkeys */
     const void     *tl_mkey_buf; /* Packed TL mkey buffer */
 } ucp_unpacked_exported_tl_mkey_t;
 


### PR DESCRIPTION
## What
Fix for the segfault described in [RM#4105410](https://redmine.mellanox.com/issues/4105410)
The root cause is that export unpack logic stores all **combinations** of remote_md-local_md in 
`tl_mkeys[UCP_MAX_MDS]` array, which is not sufficient to store all of them. WIth large number of IB devices (like on nemo01) this overrides memory on stack and leads to stack corruption, therefore we don't see the backtrace.
This is initial behaviour introduced in https://github.com/openucx/ucx/pull/8584

## How ?
- Changed `ucp_unpacked_exported_tl_mkey_t` structure to store MD map instead of an individual index, to avoid storing combinations.
- Changed impl of key export to deal with `local_md_map`
- Added assertion to avoid stack overflow in the future
