### PR TITLE
UCP: Fix for assertion on rkey destroy

### DIFF
--- a/src/ucp/rndv/proto_rndv.inl
+++ b/src/ucp/rndv/proto_rndv.inl
@@ -154,14 +154,16 @@ ucp_proto_rndv_rkey_destroy(ucp_request_t *req)
 {
     ucs_assert(req->send.rndv.rkey != NULL);
     ucp_rkey_destroy(req->send.rndv.rkey);
-#if UCS_ENABLE_ASSERT
     req->send.rndv.rkey = NULL;
-#endif
 }
 
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_rndv_recv_complete_with_ats(ucp_request_t *req, uint8_t ats_stage)
 {
+    if (req->send.rndv.rkey != NULL) {
+        ucp_proto_rndv_rkey_destroy(req);
+    }
+
     ucp_proto_request_set_stage(req, ats_stage);
     ucp_request_send(req);
 }


### PR DESCRIPTION
## What
Many unit tests in `force_close_during_rndv` in master are failing with assertion:
```
[ RUN      ] dc_no_ud_ud_x/test_ucp_sockaddr.force_close_during_rndv/1 <dc_mlx5,mm/tag,mt>
      369 ucp_proto_rndv_recv_complete_status(ucp_request_t *req, ucs_status_t status)
      370 {
      371     /* Remote key should already be released */
==>   372     ucs_assert(req->send.rndv.rkey == NULL);
```
The bug was introduced in https://github.com/openucx/ucx/pull/10038
