### PR TITLE
UCM: Fixed race condition in parsing proc maps

### DIFF
--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -368,15 +368,15 @@ out:
 static int ucm_cudamem_scan_regions_cb(void *arg, void *addr, size_t length,
                                        int prot, const char *path)
 {
-    static const char *cuda_path_pattern = "/dev/nvidia";
-    ucm_event_handler_t *handler         = arg;
+    static const char cuda_path_pattern[] = "/dev/nvidia";
+    ucm_event_handler_t *handler          = arg;
     ucm_event_t event;
 
     /* we are interested in blocks which don't have any access permissions, or
      * mapped to nvidia device.
      */
     if ((prot & (PROT_READ | PROT_WRITE | PROT_EXEC)) &&
-        strncmp(path, cuda_path_pattern, strlen(cuda_path_pattern))) {
+        strncmp(path, cuda_path_pattern, sizeof(cuda_path_pattern) - 1)) {
         return 0;
     }
 

--- a/src/ucm/rocm/rocmmem.c
+++ b/src/ucm/rocm/rocmmem.c
@@ -172,12 +172,12 @@ out:
 static int ucm_rocm_scan_regions_cb(void *arg, void *addr, size_t length,
                                     int prot, const char *path)
 {
-    static const char *rocm_path_pattern = "/dev/dri";
-    ucm_event_handler_t *handler = arg;
+    static const char rocm_path_pattern[] = "/dev/dri";
+    ucm_event_handler_t *handler          = arg;
     ucm_event_t event;
 
     if ((prot & (PROT_READ | PROT_WRITE | PROT_EXEC)) &&
-        strncmp(path, rocm_path_pattern, strlen(rocm_path_pattern))) {
+        strncmp(path, rocm_path_pattern, sizeof(rocm_path_pattern) - 1)) {
         return 0;
     }
     ucm_debug("dispatching initial memtype allocation for %p..%p %s", addr,

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -150,7 +150,7 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
 {
     static char  *buffer         = MAP_FAILED;
     static size_t buffer_size    = 32768;
-    static pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
+    static pthread_mutex_t lock  = PTHREAD_MUTEX_INITIALIZER;
     ssize_t read_size, offset;
     unsigned long start, end;
     char prot_c[4];
@@ -168,7 +168,7 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
     }
 
     /* read /proc/self/maps fully into the buffer */
-    pthread_rwlock_wrlock(&lock);
+    pthread_mutex_lock(&lock);
 
     if (buffer == MAP_FAILED) {
         buffer = ucm_orig_mmap(NULL, buffer_size, PROT_READ|PROT_WRITE,
@@ -223,11 +223,8 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
             offset += read_size;
         }
     }
-    pthread_rwlock_unlock(&lock);
 
     close(maps_fd);
-
-    pthread_rwlock_rdlock(&lock);
 
     ptr      = buffer;
     line_num = 1;
@@ -265,7 +262,7 @@ void ucm_parse_proc_self_maps(ucm_proc_maps_cb_t cb, void *arg)
     }
 
 out:
-    pthread_rwlock_unlock(&lock);
+    pthread_mutex_unlock(&lock);
 }
 
 typedef struct {

--- a/src/ucm/ze/zemem.c
+++ b/src/ucm/ze/zemem.c
@@ -222,12 +222,12 @@ out:
 static int ucm_zemem_scan_regions_cb(void *arg, void *addr, size_t length,
                                      int prot, const char *path)
 {
-    static const char *ze_path_pattern = "/dev/dri";
-    ucm_event_handler_t *handler       = arg;
+    static const char ze_path_pattern[] = "/dev/dri";
+    ucm_event_handler_t *handler        = arg;
     ucm_event_t event;
 
     if ((prot & (PROT_READ | PROT_WRITE | PROT_EXEC)) &&
-        strncmp(path, ze_path_pattern, strlen(ze_path_pattern))) {
+        strncmp(path, ze_path_pattern, sizeof(ze_path_pattern) - 1)) {
         return 0;
     }
 

--- a/src/ucs/memory/memtype_cache.c
+++ b/src/ucs/memory/memtype_cache.c
@@ -429,5 +429,6 @@ void ucs_memtype_cache_cleanup()
 
     if (ucs_memtype_cache_global_instance) {
         UCS_CLASS_DELETE(ucs_memtype_cache_t, ucs_memtype_cache_global_instance);
+        ucs_memtype_cache_global_instance = NULL;
     }
 }

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -436,7 +436,9 @@ INSTANTIATE_TEST_SUITE_P(mem_type, test_memtype_cache,
 class test_memtype_cache_deferred_create : public test_memtype_cache {
 protected:
     virtual void init() {
-        /* do nothing */
+        /* Clean the global memtype cache */
+        ucs_memtype_cache_cleanup();
+        ucs_memtype_cache_global_init();
     }
 
     void test_unknown_region_found(const mem_buffer &b) const {
@@ -492,6 +494,10 @@ UCS_TEST_P(test_memtype_cache_deferred_create, lookup_adjacent_regions) {
 
 UCS_TEST_P(test_memtype_cache_deferred_create, lookup_overlapped_regions) {
     test_alloc_before_init(1000000, false, 1);
+}
+
+UCS_MT_TEST_P(test_memtype_cache_deferred_create, mt_cache_init, 8) {
+    test_alloc_before_init(1000000, false, 0);
 }
 
 INSTANTIATE_TEST_SUITE_P(mem_type, test_memtype_cache_deferred_create,


### PR DESCRIPTION
## What
Segfault in MT applications using CUDA memory allocated before UCX is initialised.

## Why ?
Segfault happens because UCX treats passed memory buffer as HOST memory instead of CUDA
Because `memtype_cache` does not contain all maps allocated before UCX init
Because `ucs_memtype_cache_get_global` creates multiple instances of `memtype_cache`, but concurrent init is buggy
```
ucp_datatype_iter_detect_mem_info
  ucp_memory_detect
    ucp_memory_detect_internal
      ucs_memtype_cache_lookup
        ucs_memtype_cache_get_global
          **create ucs_memtype_cache_t per each concurrent thread**
            ucm_set_event_handler
              get_existing_alloc
                ucm_cudamem_get_existing_alloc
                  ucm_parse_proc_self_maps  << parallel reads, but read is **destructive**
```

## How ?
- Fixed destructive read in ucm_parse_proc_self_maps
- Added unit test that reproduces the issue
- Micro optimisations for constant string comparison