### PR TITLE
AZP: Improve reporting of CUDA device status during tests

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -207,7 +207,13 @@ try_load_cuda_env() {
 
 load_cuda_env() {
     try_load_cuda_env
-    [ "${have_cuda}" == "yes" ] || azure_log_error "Cuda device is not available"
+    if [ "${have_cuda}" != "yes" ] ; then
+        if [ "${ucx_gpu}" = "yes" ] ; then
+            azure_log_error "CUDA load failed on GPU node $(hostname -s)"
+            exit 1
+        fi
+        azure_log_warning "Cuda device is not available"
+    fi
 }
 
 check_release_build() {


### PR DESCRIPTION
## What
Trigger warning if CUDA device is unavailable on non-GPU nodes.
Trigger error if CUDA device is unavailable on GPU nodes.

## Why ?
If CUDA device was not found, UCX is configured with no CUDA:
https://github.com/openucx/ucx/blob/master/buildlib/jucx/jucx-test.yml#L39
It's expected in some cases, as we currently do not have ARM machines with GPU.