### PR TITLE
PERF: handle error status in send/recv callbacks

### DIFF
--- a/src/tools/perf/perftest_daemon.c
+++ b/src/tools/perf/perftest_daemon.c
@@ -163,8 +163,11 @@ ucp_perf_daemon_send_cb(void *request, ucs_status_t status, void *user_data)
 {
     ucp_perf_daemon_context_t *ctx = user_data;
 
-    ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
-                                        UCP_PERF_DAEMON_AM_ID_SEND_CMPL);
+    if (ucs_likely(status == UCS_OK)) {
+        ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
+                                            UCP_PERF_DAEMON_AM_ID_SEND_CMPL);
+    }
+
     ucp_request_free(request);
 }
 
@@ -195,8 +198,11 @@ static void ucp_perf_daemon_recv_cb(void *request, ucs_status_t status,
 {
     ucp_perf_daemon_context_t *ctx = user_data;
 
-    ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
-                                        UCP_PERF_DAEMON_AM_ID_RECV_CMPL);
+    if (ucs_likely(status == UCS_OK)) {
+        ucp_perf_daemon_send_am_eager_reply(ctx->host_ep,
+                                            UCP_PERF_DAEMON_AM_ID_RECV_CMPL);
+    }
+
     ucp_request_free(request);
 }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2531,10 +2531,11 @@ protected:
             rx_am_msg_arg arg(receiver(), &rhdr[0], &rb[0], rmemh);
             set_am_data_handler(receiver(), 0, rx_am_msg_cb, &arg);
 
-            ucp_request_param_t param = {};
+            ucp_request_param_t param;
+            param.op_attr_mask = 0;
             if (smemh != NULL) {
-                param.op_attr_mask = UCP_OP_ATTR_FIELD_MEMH;
-                param.memh         = smemh;
+                param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+                param.memh          = smemh;
             }
 
             param.op_attr_mask |= UCP_OP_ATTR_FIELD_FLAGS;


### PR DESCRIPTION
## What
handle error status in send/recv callbacks of ucx_perftest_daemon

## Why ?
to avoid segfault on cleanup
