### PR TITLE
CONF/GRACE: Disable ODP for cuda-managed - v1.18.x

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -1,7 +1,6 @@
 [Grace Hopper]
 CPU model=Grace
-UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed
-UCX_IB_ODP_MEM_TYPES=host,cuda-managed
+UCX_REG_NONBLOCK_MEM_TYPES=host
 UCX_IB_MLX5_DEVX_OBJECTS=
 UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBs
 # Real latency is around 30ns, rest is gdrcopy rcache overhead


### PR DESCRIPTION
## What
Disable ODP for cuda-managed by default, because currently async memory is detected as cuda-managed and it does not seem support ODP
