### PR TITLE
BUILDLIB/PR/CUDA: Test memory hooks w/o forcing far jump in bistro mode.

### DIFF
--- a/buildlib/pr/cuda/test_malloc_hook.sh
+++ b/buildlib/pr/cuda/test_malloc_hook.sh
@@ -32,46 +32,54 @@ build() {
 	make -j$(nproc)
 }
 
-test_malloc_hook() {
-	echo "==== Running malloc hooks test ===="
-
+test_malloc_hook_mode() {
+	mode=$1
 	cuda_dynamic_exe=./test/apps/test_cuda_hook_dynamic
 	cuda_static_exe=./test/apps/test_cuda_hook_static
 
-	for mode in reloc bistro
-	do
-		export UCX_MEM_CUDA_HOOK_MODE=${mode}
+	export UCX_MEM_CUDA_HOOK_MODE=${mode}
 
-		# Run cuda memory hooks with dynamic link
-		${cuda_dynamic_exe}
+	# Run cuda memory hooks with dynamic link
+	${cuda_dynamic_exe}
 
-		# Run cuda memory hooks with static link, if exists. If the static
-		# library 'libcudart_static.a' is not present, static test will not
-		# be built.
-		if [ -x ${cuda_static_exe} ]
+	# Run cuda memory hooks with static link, if exists. If the static
+	# library 'libcudart_static.a' is not present, static test will not
+	# be built.
+	if [ -x ${cuda_static_exe} ]
+	then
+		${cuda_static_exe} && status="pass" || status="fail"
+		[ ${mode} == "bistro" ] && exp_status="pass" || exp_status="fail"
+		if [ ${status} == ${exp_status} ]
 		then
-			${cuda_static_exe} && status="pass" || status="fail"
-			[ ${mode} == "bistro" ] && exp_status="pass" || exp_status="fail"
-			if [ ${status} == ${exp_status} ]
-			then
-				echo "Static link with cuda ${status}, as expected"
-			else
-				echo "Static link with cuda is expected to ${exp_status}, actual: ${status}"
-				exit 1
-			fi
+			echo "Static link with cuda ${status}, as expected"
+		else
+			echo "Static link with cuda is expected to ${exp_status}, actual: ${status}"
+			exit 1
 		fi
+	fi
 
-		# Test that driver API hooks work in both reloc and bistro modes,
-		# since we call them directly from the test
-		${cuda_dynamic_exe} -d
-		[ -x ${cuda_static_exe} ] && ${cuda_static_exe} -d
+	# Test that driver API hooks work in both reloc and bistro modes,
+	# since we call them directly from the test
+	${cuda_dynamic_exe} -d
+	[ -x ${cuda_static_exe} ] && ${cuda_static_exe} -d
 
-		# Test hooks in gtest
-		UCX_MEM_LOG_LEVEL=diag \
-			./test/gtest/gtest --gtest_filter='cuda_hooks.*'
+	# Test hooks in gtest
+	UCX_MEM_LOG_LEVEL=diag ./test/gtest/gtest --gtest_filter='cuda_hooks.*'
 
-		unset UCX_MEM_CUDA_HOOK_MODE
-	done
+	unset UCX_MEM_CUDA_HOOK_MODE
+}
+
+test_malloc_hook() {
+	echo "==== Running malloc hooks test, using ELF relocation table ===="
+	test_malloc_hook_mode 'reloc'
+
+	echo "==== Running malloc hooks test, using binary instrumentation ===="
+	test_malloc_hook_mode 'bistro'
+
+	echo "==== Running malloc hooks test with far jump, using binary instrumentation ===="
+	export UCX_MEM_BISTRO_FORCE_FAR_JUMP=y
+	test_malloc_hook_mode 'bistro'
+	unset UCX_MEM_BISTRO_FORCE_FAR_JUMP
 }
 
 check_gpu 'gpu'

--- a/test/apps/test_cuda_hook.c
+++ b/test/apps/test_cuda_hook.c
@@ -11,7 +11,6 @@
 #include <ucp/api/ucp.h>
 #include <ucm/api/ucm.h>
 #include <cuda_runtime.h>
-#include <sys/mman.h>
 #include <getopt.h>
 #include <cuda.h>
 
@@ -65,7 +64,7 @@ static void alloc_driver_api()
     printf("cuMemAlloc() returned 0x%lx result %d\n", (uintptr_t)dptr, res);
     cuMemFree(dptr);
 
-    cuCtxDetach(context);
+    cuCtxDestroy(context);
 }
 
 static void alloc_runtime_api()
@@ -82,13 +81,11 @@ int main(int argc, char **argv)
 {
     static const ucm_event_type_t memtype_events = UCM_EVENT_MEM_TYPE_ALLOC |
                                                    UCM_EVENT_MEM_TYPE_FREE;
-    static const size_t dummy_va_size            = 4 * (1ul << 30); /* 4 GB */
     static const int num_expected_events         = 2;
     ucp_context_h context;
     ucs_status_t status;
     ucp_params_t params;
     int use_driver_api;
-    void *dummy_ptr;
     int num_events;
     int c;
 
@@ -106,18 +103,6 @@ int main(int argc, char **argv)
             return -1;
         }
     }
-
-    /* In order to test long jumps in bistro hooks code, increase address space
-     * separation by allocating a large VA space segment.
-     */
-    dummy_ptr = mmap(NULL, dummy_va_size, PROT_READ | PROT_WRITE,
-                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (dummy_ptr == MAP_FAILED) {
-        printf("failed to allocate dummy VA space: %m\n");
-        return -1;
-    }
-
-    printf("allocated dummy VA space at %p\n", dummy_ptr);
 
     params.field_mask = UCP_PARAM_FIELD_FEATURES;
     params.features   = UCP_FEATURE_TAG | UCP_FEATURE_STREAM;
@@ -141,6 +126,5 @@ int main(int argc, char **argv)
 
     ucp_cleanup(context);
 
-    munmap(dummy_ptr, dummy_va_size);
     return (num_events >= num_expected_events) ? 0 : -1;
 }


### PR DESCRIPTION
## What
Testing of CUDA memory hooks with and without forcing of far jumps in binary instrumentation mode.

`test_cuda_hook` is executed with and without forcing far jump when applying bistro patches. Thus, the allocation of a large VA space segment was removed from the test code.

(+ replaced deprecated `cuCtxDetach` by `cuCtxDestroy`)