### PR TITLE
UCT/CUDA_IPC: Patch latency and overhead

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -9,6 +9,9 @@ UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBs
 UCX_GDR_COPY_LAT=200ns
 UCX_DISTANCE_BW=auto,sys:16500MBs
 
+UCX_CUDA_IPC_LAT=2.5us
+UCX_CUDA_IPC_OVERHEAD=3.3us
+
 [Fujitsu ARM]
 CPU vendor=Fujitsu ARM
 UCX_BCOPY_BW=12000MBs

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -19,36 +19,35 @@
 #define UCT_CUDA_IPC_MAX_PEERS  16
 
 
+typedef struct uct_cuda_ipc_iface_config_params {
+    unsigned                max_poll;            /* query attempts w.o success */
+    unsigned                max_streams;         /* # concurrent streams for || progress*/
+    unsigned                max_cuda_ipc_events; /* max mpool entries */
+    int                     enable_cache;        /* enable/disable ipc handle cache */
+    ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platforms */
+    double                  bandwidth;           /* estimated bandwidth */
+    double                  latency;             /* estimated latency */
+    double                  overhead;            /* estimated CPU overhead */
+} uct_cuda_ipc_iface_config_params_t;
+
 typedef struct uct_cuda_ipc_iface {
-    uct_cuda_iface_t super;
-    ucs_mpool_t      event_desc;              /* cuda event desc */
-    ucs_queue_head_t outstanding_d2d_event_q; /* stream for outstanding d2d */
-    int              eventfd;              /* get event notifications */
-    int              streams_initialized;     /* indicates if stream created */
-    CUcontext        cuda_context;
-    CUstream         stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
-                                              /* per-peer stream */
-    unsigned long    stream_refcount[UCT_CUDA_IPC_MAX_PEERS];
-                                              /* per stream outstanding ops */
-    struct {
-        unsigned                max_poll;            /* query attempts w.o success */
-        unsigned                max_streams;         /* # concurrent streams for || progress*/
-        unsigned                max_cuda_ipc_events; /* max mpool entries */
-        int                     enable_cache;        /* enable/disable ipc handle cache */
-        ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platforms */
-        double                  bandwidth;
-    } config;
+    uct_cuda_iface_t                   super;
+    ucs_mpool_t                        event_desc;              /* cuda event desc */
+    ucs_queue_head_t                   outstanding_d2d_event_q; /* stream for outstanding d2d */
+    int                                eventfd;                 /* get event notifications */
+    int                                streams_initialized;     /* indicates if stream created */
+    CUcontext                          cuda_context;
+    CUstream                           stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
+                                                                /* per-peer stream */
+    unsigned long                      stream_refcount[UCT_CUDA_IPC_MAX_PEERS];
+                                                                /* per stream outstanding ops */
+    uct_cuda_ipc_iface_config_params_t config;                  /* configurable iface parameters */
 } uct_cuda_ipc_iface_t;
 
 
 typedef struct uct_cuda_ipc_iface_config {
-    uct_iface_config_t      super;
-    unsigned                max_poll;
-    unsigned                max_streams;
-    int                     enable_cache;
-    ucs_on_off_auto_value_t enable_get_zcopy;
-    unsigned                max_cuda_ipc_events;
-    double                  bandwidth;
+    uct_iface_config_t                 super;
+    uct_cuda_ipc_iface_config_params_t params;
 } uct_cuda_ipc_iface_config_t;
 
 


### PR DESCRIPTION
## What
Add ability to set platform specific cuda_ipc latency and overhead

## Why ?
To improve protocols performance prediction accuracy
