### PR TITLE
UCT/CUDA_IPC: Increase MAX_PEERS and MAX_STREAMS

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -42,7 +42,7 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
      "Max number of event completions to pick during cuda events polling",
       ucs_offsetof(uct_cuda_ipc_iface_config_t, params.max_poll), UCS_CONFIG_TYPE_UINT},
 
-    {"MAX_STREAMS", "16",
+    {"MAX_STREAMS", UCS_PP_MAKE_STRING(UCT_CUDA_IPC_MAX_PEERS),
      "Max number of CUDA streams to make concurrent progress on",
       ucs_offsetof(uct_cuda_ipc_iface_config_t, params.max_streams), UCS_CONFIG_TYPE_UINT},
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -16,7 +16,7 @@
 #include "cuda_ipc_cache.h"
 
 
-#define UCT_CUDA_IPC_MAX_PEERS  16
+#define UCT_CUDA_IPC_MAX_PEERS 128
 
 
 typedef struct uct_cuda_ipc_iface_config_params {


### PR DESCRIPTION
## Why ?
Need this ensure greater concurrency for a larger count of peers reachable by cuda_ipc.