### PR TITLE
UCT/CUDA: Detect async mem as cuda on Grace

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -6,6 +6,7 @@ UCX_IB_MLX5_DEVX_OBJECTS=
 UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBs
 UCX_GDR_COPY_LAT=30e-9
 UCX_DISTANCE_BW=auto,sys:16500MBs
+UCX_CUDA_COPY_ASYNC_MEM_TYPE=cuda
 
 [Fujitsu ARM]
 CPU vendor=Fujitsu ARM


### PR DESCRIPTION
## What
Detect  async allocated memory as cuda on Grace platform

## Why ?
Fixes internal issue [RM4125745](https://redmine.mellanox.com/issues/4125745)


(fixed in v1.18.x by #10254)