### PR TITLE
UCM: Minor mem hooks fixes

### DIFF
--- a/src/ucm/util/replace.h
+++ b/src/ucm/util/replace.h
@@ -44,9 +44,6 @@ extern pthread_t volatile ucm_reloc_get_orig_thread;
         return res; \
     }
 
-#define UCM_OVERRIDE_FUNC(_name, _rettype) \
-    _rettype _name() __attribute__ ((alias (UCS_PP_QUOTE(ucm_override_##_name)))); \
-
 #define UCM_DEFINE_DLSYM_FUNC(_name, _rettype, _fail_val, ...) \
     _UCM_DEFINE_DLSYM_FUNC(_name, ucm_orig_##_name, ucm_override_##_name, \
                           _rettype, _fail_val, __VA_ARGS__)

--- a/src/ucs/config/ucm_opts.c
+++ b/src/ucs/config/ucm_opts.c
@@ -42,9 +42,9 @@ static ucs_config_field_t ucm_global_config_table[] = {
   {"MMAP_HOOK_MODE", UCM_DEFAULT_HOOK_MODE_STR,
    "MMAP hook mode\n"
    " none   - Don't set mmap hooks.\n"
-   " reloc  - Use ELF relocation table to set hooks.\n"
+   " reloc  - Use ELF relocation table to set hooks."
 #if UCM_BISTRO_HOOKS
-   " bistro - Use binary instrumentation to set hooks.\n"
+   "\n bistro - Use binary instrumentation to set hooks."
 #endif
    ,ucs_offsetof(ucm_global_config_t, mmap_hook_mode),
                  UCS_CONFIG_TYPE_ENUM(ucm_mmap_hook_modes)},
@@ -73,7 +73,7 @@ static ucs_config_field_t ucm_global_config_table[] = {
    "          part of the application is linked with Cuda runtime statically,\n"
    "          some memory events may be missed and not reported."
 #if UCM_BISTRO_HOOKS
-   " bistro - Use binary instrumentation to set hooks. In this mode, it's\n"
+   "\n bistro - Use binary instrumentation to set hooks. In this mode, it's\n"
    "          possible to intercept calls from the Cuda runtime library to\n"
    "          Cuda driver APIs, so memory events are reported properly even\n"
    "          for statically-linked applications."


### PR DESCRIPTION
## What
- Minor fixes in hooks env var descriptions
- Removing unsed UCM_OVERRIDE_FUNC

## Why ?
**Before**
```
[mikhailb@rock06 ucx-tmp]$ ucx_info -f | grep -B 12 UCX_MEM_CUDA_HOOK_MODE
# Cuda memory hook modes. A combination of:
#  none   - Don't set Cuda hooks.
#  reloc  - Use ELF relocation table to set hooks. In this mode, if any
#           part of the application is linked with Cuda runtime statically,
#           some memory events may be missed and not reported. bistro - Use binary instrumentation to set hooks. In this mode, it's
#           possible to intercept calls from the Cuda runtime library to
#           Cuda driver APIs, so memory events are reported properly even
#           for statically-linked applications.
#
#
# syntax:    comma-separated list of: [none|reloc|bistro]
#
UCX_MEM_CUDA_HOOK_MODE=bistro
```

**After**
```
[mikhailb@rock06 ucx-tmp]$ ./src/tools/info/ucx_info -f | grep -B 12 UCX_MEM_CUDA_HOOK_MODE
#  none   - Don't set Cuda hooks.
#  reloc  - Use ELF relocation table to set hooks. In this mode, if any
#           part of the application is linked with Cuda runtime statically,
#           some memory events may be missed and not reported.
#  bistro - Use binary instrumentation to set hooks. In this mode, it's
#           possible to intercept calls from the Cuda runtime library to
#           Cuda driver APIs, so memory events are reported properly even
#           for statically-linked applications.
#
#
# syntax:    comma-separated list of: [none|reloc|bistro]
```