### PR TITLE
CONFIG/SPEC: Enable IB mlx5 build by default

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -11,7 +11,7 @@
 %bcond_with    vfs
 %bcond_with    mad
 %bcond_with    ze
-%bcond_with    mlx5
+%bcond_without mlx5
 
 Name: ucx
 Version: @VERSION@


### PR DESCRIPTION
## What
Enable ib mlx5 UCX submodule by default. When using `rpmbuild.sh`, issue is not visible as it explicitly passes the `--with-mlx5`.

## Testing
With script below, uct mlx5 rpm is not built, with patch mlx5 is built:
```
sed -i '/with.*mlx5/d' contrib/buildrpm.sh
./autogen.sh
./configure
./contrib/buildrpm.sh -t
./contrib/buildrpm.sh --binrpm
```