### PR TITLE
CONFIG/SPEC: Enable IB mlx5 build by default - v1.18.x

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -11,7 +11,7 @@
 %bcond_with    vfs
 %bcond_with    mad
 %bcond_with    ze
-%bcond_with    mlx5
+%bcond_without mlx5
 
 Name: ucx
 Version: @VERSION@


### PR DESCRIPTION
## What
backport #10268, re-tested on v1.18.x.