### PR TITLE
UCT/IB/MLX5/DC: Change DCIs array to pointers - dynamic array grow

### DIFF
--- a/src/ucs/datastruct/array.h
+++ b/src/ucs/datastruct/array.h
@@ -278,20 +278,13 @@ ucs_array_old_buffer_set_null(void **old_buffer_p)
  * @param _new_length      New size for the array.
  * @param _init_value      Initialize new elements to this value.
  * @param _failed_actions  Actions to perform if the append operation failed.
- * @param _old_buffer_p    If the array was reallocated, and this parameter is
- *                         non-NULL, the previous buffer will not be released,
- *                         instead it will be returned in *_old_buffer_p,
- *                         and the caller should copy the contents of the previous buffer 
- *                         to the new array buffer.
  */
-#define ucs_array_resize_safe(_array, _new_length, _init_value, \
-                              _failed_actions, _old_buffer_p) \
+#define ucs_array_resize(_array, _new_length, _init_value, _failed_actions) \
     { \
         ucs_typeof((_array)->length) _extend_index; \
         ucs_status_t _extend_status; \
         \
-        _extend_status = ucs_array_reserve_safe(_array, _new_length, \
-                                                _old_buffer_p); \
+        _extend_status = ucs_array_reserve(_array, _new_length); \
         if (_extend_status == UCS_OK) { \
             for (_extend_index = (_array)->length; \
                  _extend_index < (_new_length); ++_extend_index) { \
@@ -302,19 +295,6 @@ ucs_array_old_buffer_set_null(void **old_buffer_p)
             _failed_actions; \
         } \
     }
-
-
-/*
- * Change the size of the array and initialize new elements.
- *
- * @param _array           Array to resize.
- * @param _new_length      New size for the array.
- * @param _init_value      Initialize new elements to this value.
- * @param _failed_actions  Actions to perform if the append operation failed.
- */
-#define ucs_array_resize(_array, _new_length, _init_value, _failed_actions) \
-    ucs_array_resize_safe(_array, _new_length, _init_value, _failed_actions, \
-                          NULL)
 
 
 /**

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -24,7 +24,6 @@
 
 
 #define UCT_IB_QPN_ORDER                  24  /* How many bits can be an IB QP number */
-#define UCT_IB_INVALID_QPN                UCS_MASK(UCT_IB_QPN_ORDER)
 #define UCT_IB_UIDX_SHIFT                 8   /* BE uidx shift */
 #define UCT_IB_LRH_LEN                    8   /* IB Local routing header */
 #define UCT_IB_GRH_LEN                    40  /* IB GLobal routing header */

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -135,10 +135,10 @@ ucs_config_field_t uct_dc_mlx5_iface_config_sub_table[] = {
      ucs_offsetof(uct_dc_mlx5_iface_config_t, num_dci_channels),
      UCS_CONFIG_TYPE_UINT},
 
-    {"DCIS_INITIAL_CAPACITY", "inf",
+    {"DCIS_INITIAL_CAPACITY", "auto",
      "Initial capacity of DCIs array.",
      ucs_offsetof(uct_dc_mlx5_iface_config_t, dcis_initial_capacity),
-     UCS_CONFIG_TYPE_UINT},
+     UCS_CONFIG_TYPE_ULUNITS},
 
     {NULL}
 };
@@ -278,7 +278,6 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
     struct mlx5_cqe64 *cqe;
     uint16_t hw_ci;
     uct_dc_dci_t *dci;
-    UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     cqe = uct_ib_mlx5_poll_cq(&iface->super.super.super,
                               &iface->super.cq[UCT_IB_DIR_TX], poll_flags,
@@ -293,16 +292,13 @@ uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
 
     dci_index = uct_dc_mlx5_iface_dci_find(iface, cqe);
     dci       = uct_dc_mlx5_iface_dci(iface, dci_index);
-    ucs_assert(uct_dc_mlx5_is_dci_valid(dci));
-    txqp      = &dci->txqp;
-    txwq      = &dci->txwq;
     hw_ci     = ntohs(cqe->wqe_counter);
 
-    ucs_trace_poll("dc iface %p tx_cqe: dci[%d] txqp %p hw_ci %d",
-                   iface, dci_index, txqp, hw_ci);
+    ucs_trace_poll("dc iface %p tx_cqe: dci[%d] txqp %p hw_ci %d", iface,
+                   dci_index, &dci->txqp, hw_ci);
 
-    uct_rc_mlx5_txqp_process_tx_cqe(txqp, cqe, hw_ci);
-    uct_dc_mlx5_update_tx_res(iface, txwq, txqp, hw_ci);
+    uct_rc_mlx5_txqp_process_tx_cqe(&dci->txqp, cqe, hw_ci);
+    uct_dc_mlx5_update_tx_res(iface, dci_index, hw_ci);
 
     /**
      * Note: DCI is released after handling completion callbacks,
@@ -377,8 +373,9 @@ ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     uct_ib_iface_t *ib_iface   = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr = {};
     uct_ib_mlx5_md_t *md = ucs_derived_of(ib_iface->super.md, uct_ib_mlx5_md_t);
-    uct_dc_dci_t *dci    = uct_dc_mlx5_iface_dci(iface, dci_index);
+    uct_dc_dci_t *dci    = ucs_calloc(1, sizeof(uct_dc_dci_t), "dci");
     ucs_status_t status;
+
 #if HAVE_DC_DV
     uct_ib_device_t *dev               = uct_ib_iface_device(ib_iface);
     struct mlx5dv_qp_init_attr dv_attr = {};
@@ -404,7 +401,7 @@ ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
                                             &dci->txwq.super, &dci->txwq,
                                             &attr);
         if (status != UCS_OK) {
-            return status;
+            goto err_free_dci;
         }
 
         ucs_debug("created DevX DCI 0x%x, rdma_wr_disabled=%d", dci->txwq.super.qp_num,
@@ -414,12 +411,13 @@ ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
 
     if (iface->super.cq[UCT_IB_DIR_TX].type != UCT_IB_MLX5_OBJ_TYPE_VERBS) {
         ucs_error("cannot create verbs DCI with DEVX CQ");
-        return UCS_ERR_INVALID_PARAM;
+        status = UCS_ERR_INVALID_PARAM;
+        goto err_free_dci;
     }
 
     status = uct_ib_mlx5_iface_get_res_domain(ib_iface, &dci->txwq.super);
     if (status != UCS_OK) {
-        return status;
+        goto err_free_dci;
     }
 
     uct_ib_mlx5_iface_fill_attr(ib_iface, &dci->txwq.super, &attr);
@@ -439,8 +437,7 @@ ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     }
 
     dci->txwq.super.verbs.qp = qp;
-    dci->txwq.super.qp_num = dci->txwq.super.verbs.qp->qp_num;
-
+    dci->txwq.super.qp_num   = dci->txwq.super.verbs.qp->qp_num;
 init_qp:
 #else
     uct_rc_mlx5_iface_fill_attr(&iface->super, &attr,
@@ -448,7 +445,7 @@ init_qp:
                                 &iface->super.rx.srq);
     status = uct_ib_mlx5_iface_create_qp(ib_iface, &dci->txwq.super, &attr);
     if (status != UCS_OK) {
-        return status;
+        goto err_free_dci;
     }
 #endif
     status = uct_rc_txqp_init(&dci->txqp, &iface->super.super,
@@ -457,6 +454,11 @@ init_qp:
     if (status != UCS_OK) {
         goto err_qp;
     }
+
+    ucs_assertv_always(!uct_dc_mlx5_is_dci_valid(
+                               uct_dc_mlx5_iface_dci(iface, dci_index)),
+                       "iface=%p dci_index=%d", iface, dci_index);
+    ucs_array_elem(&iface->tx.dcis, dci_index) = dci;
 
     if (connect) {
         status = uct_dc_mlx5_iface_dci_connect(iface, dci);
@@ -494,6 +496,8 @@ err_put_res_domain:
         uct_ib_mlx5_iface_put_res_domain(&dci->txwq.super);
     }
 #endif
+err_free_dci:
+    ucs_free(dci);
     return status;
 }
 
@@ -763,10 +767,11 @@ static void uct_dc_mlx5_iface_dci_pool_destroy(uct_dc_mlx5_dci_pool_t *dci_pool)
 }
 
 static void
-uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci)
+uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uint16_t dci_index)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
                                           uct_ib_mlx5_md_t);
+    uct_dc_dci_t *dci    = uct_dc_mlx5_iface_dci(iface, dci_index);
 
     uct_rc_txqp_cleanup(&iface->super.super, &dci->txqp);
     uct_ib_mlx5_destroy_qp(md, &dci->txwq.super);
@@ -776,7 +781,8 @@ uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci)
     }
     uct_ib_mlx5_qp_mmio_cleanup(&dci->txwq.super, dci->txwq.reg);
 
-    dci->txwq.super.qp_num = UCT_IB_INVALID_QPN;
+    ucs_free(dci);
+    ucs_array_elem(&iface->tx.dcis, dci_index) = NULL;
 }
 
 static void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface)
@@ -792,7 +798,7 @@ static void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface)
             continue;
         }
 
-        uct_dc_mlx5_destroy_dci(iface, dci);
+        uct_dc_mlx5_destroy_dci(iface, dci_index);
     }
 
     for (pool_index = 0; pool_index < iface->tx.num_dci_pools; pool_index++) {
@@ -872,23 +878,10 @@ uct_dc_mlx5_dci_pool_get_or_create(uct_dc_mlx5_iface_t *iface,
 ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
                                                     uint16_t size)
 {
-    uct_dc_dci_t empty_dci = {{{0}}};
-    size_t old_length      = ucs_array_length(&iface->tx.dcis);
-    void *old_buffer_p;
-
-    empty_dci.txwq.super.qp_num = UCT_IB_INVALID_QPN;
-    ucs_array_resize_safe(&iface->tx.dcis, size, empty_dci,
-                          ucs_error("%p: could not resize dcis array to %u",
-                                    iface, size);
-                          return UCS_ERR_NO_MEMORY, &old_buffer_p);
-    if (old_buffer_p) {
-        /* FIXME: resizing the array can cause use-after-free in certain scenarios */
-        ucs_diag("currently DCI array reallocation is unsafe");
-        uct_dc_mlx5_iface_dcis_array_copy(iface->tx.dcis.buffer, old_buffer_p,
-                                          old_length);
-        ucs_array_buffer_free(old_buffer_p);
-    }
-
+    ucs_array_resize(&iface->tx.dcis, size, NULL,
+                     ucs_error("%p: could not resize dcis array to %u", iface,
+                               size);
+                     return UCS_ERR_NO_MEMORY);
     return UCS_OK;
 }
 
@@ -916,7 +909,7 @@ uct_dc_mlx5_iface_init_dcis_array(uct_dc_mlx5_iface_t *iface,
     dci = uct_dc_mlx5_iface_dci(iface, 0);
 
     iface->tx.bb_max = dci->txwq.bb_max;
-    uct_dc_mlx5_destroy_dci(iface, dci);
+    uct_dc_mlx5_destroy_dci(iface, 0);
 
     ucs_array_length(&iface->tx.dcis) = 0;
 
@@ -1171,7 +1164,7 @@ err:
 static void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface)
 {
     uct_dc_mlx5_ep_t *fc_ep = iface->tx.fc_ep;
-    uct_dc_dci_t *fc_dci    = uct_dc_mlx5_iface_dci(iface, fc_ep->dci);
+    uct_dc_dci_t *fc_dci;
     uct_rc_iface_send_op_t *op;
     ucs_queue_iter_t iter;
     uct_rc_txqp_t *txqp;
@@ -1180,8 +1173,12 @@ static void uct_dc_mlx5_iface_cleanup_fc_ep(uct_dc_mlx5_iface_t *iface)
     ucs_arbiter_group_cleanup(&fc_ep->arb_group);
     uct_rc_fc_cleanup(&fc_ep->fc);
 
-    if ((fc_ep->dci == UCT_DC_MLX5_EP_NO_DCI) ||
-        !uct_dc_mlx5_is_dci_valid(fc_dci)) {
+    if (fc_ep->dci == UCT_DC_MLX5_EP_NO_DCI) {
+        goto out;
+    }
+
+    fc_dci = uct_dc_mlx5_iface_dci(iface, fc_ep->dci);
+    if (!uct_dc_mlx5_is_dci_valid(fc_dci)) {
         goto out;
     }
 
@@ -1386,10 +1383,9 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_dc_mlx5_iface_t);
     struct mlx5_cqe64 *cqe     = arg;
     uct_dci_index_t dci_index  = uct_dc_mlx5_iface_dci_find(iface, cqe);
-    UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
-    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
-    uct_ib_mlx5_txwq_update_flags(txwq, UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
+    uct_ib_mlx5_txwq_update_flags(&uct_dc_mlx5_iface_dci(iface, dci_index)->txwq,
+                                  UCT_IB_MLX5_TXWQ_FLAG_FAILED, 0);
 
     uct_dc_mlx5_dci_handle_failure(iface, cqe, dci_index, status);
 }
@@ -1592,14 +1588,21 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     ucs_status_t status;
     unsigned tx_cq_size;
     unsigned num_dci_channels;
+    size_t max_capacity;
 
     ucs_trace_func("");
 
     self->tx.policy = config->tx_policy;
     self->tx.ndci   = uct_dc_mlx5_iface_is_hw_dcs(self) ? 1 : config->ndci;
-    self->tx.dcis_initial_capacity =
-            ucs_min(config->dcis_initial_capacity,
-                    self->tx.ndci * UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
+
+    if (config->dcis_initial_capacity == UCS_ULUNITS_AUTO) {
+        max_capacity = uct_dc_mlx5_iface_is_dci_rand(self) ? SIZE_MAX : 1;
+    } else {
+        max_capacity = config->dcis_initial_capacity;
+    }
+    self->tx.dcis_initial_capacity = ucs_min(
+            max_capacity, self->tx.ndci * UCT_DC_MLX5_IFACE_MAX_DCI_POOLS);
+
     self->tx.hybrid_hw_dci = uct_dc_mlx5_iface_is_hybrid(self) ?
                                      UCT_DC_MLX5_HW_DCI_INDEX :
                                      -1;

--- a/src/uct/ib/mlx5/dc/dc_mlx5.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.h
@@ -38,12 +38,6 @@ struct ibv_ravh {
 #define UCT_DC_MLX5_IFACE_ADDR_TM_ENABLED(_addr) \
     (!!((_addr)->flags & UCT_DC_MLX5_IFACE_ADDR_HW_TM))
 
-#define UCT_DC_MLX5_IFACE_TXQP_DCI_GET(_iface, _dci, _txqp, _txwq) \
-    { \
-        ucs_assert(_dci != UCT_DC_MLX5_EP_NO_DCI); \
-        _txqp = &uct_dc_mlx5_iface_dci(_iface, _dci)->txqp; \
-        _txwq = &uct_dc_mlx5_iface_dci(_iface, _dci)->txwq; \
-    }
 
 /**
  * Set iface config flag for enabling full handshake on DCI/DCT,
@@ -186,7 +180,7 @@ typedef struct uct_dc_mlx5_iface_config {
     ucs_time_t                          fc_hard_req_timeout;
     uct_ud_mlx5_iface_common_config_t   mlx5_ud;
     unsigned                            num_dci_channels;
-    unsigned                            dcis_initial_capacity;
+    size_t                              dcis_initial_capacity;
 } uct_dc_mlx5_iface_config_t;
 
 
@@ -285,7 +279,7 @@ typedef struct {
 } uct_dc_mlx5_dci_pool_t;
 
 
-UCS_ARRAY_DECLARE_TYPE(uct_dc_dci_array_t, uct_dci_index_t, uct_dc_dci_t);
+UCS_ARRAY_DECLARE_TYPE(uct_dc_dci_array_t, uct_dci_index_t, uct_dc_dci_t*);
 
 struct uct_dc_mlx5_iface {
     uct_rc_mlx5_iface_common_t       super;
@@ -426,13 +420,13 @@ uct_dc_mlx5_dci_config_hash(const uct_dc_mlx5_dci_config_t *dci_config);
 
 static UCS_F_ALWAYS_INLINE uint8_t uct_dc_mlx5_is_dci_valid(const uct_dc_dci_t *dci)
 {
-    return dci->txwq.super.qp_num != UCT_IB_INVALID_QPN;
+    return dci != NULL;
 }
 
 static UCS_F_ALWAYS_INLINE uct_dc_dci_t *
 uct_dc_mlx5_iface_dci(uct_dc_mlx5_iface_t *iface, uct_dci_index_t dci_index)
 {
-    return &ucs_array_elem(&iface->tx.dcis, dci_index);
+    return ucs_array_elem(&iface->tx.dcis, dci_index);
 }
 
 #if HAVE_DEVX
@@ -489,17 +483,26 @@ static UCS_F_ALWAYS_INLINE uct_dci_index_t
 uct_dc_mlx5_iface_dci_find(uct_dc_mlx5_iface_t *iface, struct mlx5_cqe64 *cqe)
 {
     uint32_t qp_num;
-    int i, ndci;
+    int ndci;
+    uct_dci_index_t dci_index;
 
     if (ucs_likely(iface->flags & UCT_DC_MLX5_IFACE_FLAG_UIDX)) {
-        return cqe->srqn_uidx >> UCT_IB_UIDX_SHIFT;
+        dci_index = cqe->srqn_uidx >> UCT_IB_UIDX_SHIFT;
+        ucs_assertv(uct_dc_mlx5_is_dci_valid(
+                            uct_dc_mlx5_iface_dci(iface, dci_index)),
+                    "iface=%p, dci=%d", iface, dci_index);
+        return dci_index;
     }
 
     qp_num = ntohl(cqe->sop_drop_qpn) & UCS_MASK(UCT_IB_QPN_ORDER);
     ndci   = ucs_array_length(&iface->tx.dcis);
-    for (i = 0; i < ndci; i++) {
-        if (uct_dc_mlx5_iface_dci(iface, i)->txwq.super.qp_num == qp_num) {
-            return i;
+    for (dci_index = 0; dci_index < ndci; dci_index++) {
+        if (uct_dc_mlx5_iface_dci(iface, dci_index)->txwq.super.qp_num ==
+            qp_num) {
+            ucs_assertv(uct_dc_mlx5_is_dci_valid(
+                                uct_dc_mlx5_iface_dci(iface, dci_index)),
+                        "iface=%p, dci=%d", iface, dci_index);
+            return dci_index;
         }
     }
 

--- a/src/uct/ib/mlx5/dc/dc_mlx5.inl
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.inl
@@ -14,11 +14,12 @@
 
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_update_tx_res(uct_dc_mlx5_iface_t *iface, uct_ib_mlx5_txwq_t *txwq,
-                          uct_rc_txqp_t *txqp, uint16_t hw_ci)
+uct_dc_mlx5_update_tx_res(uct_dc_mlx5_iface_t *iface, uint16_t dci_index, uint16_t hw_ci)
 {
-    uct_rc_txqp_available_set(txqp, uct_ib_mlx5_txwq_update_bb(txwq, hw_ci));
-    ucs_assert(uct_rc_txqp_available(txqp) <= txwq->bb_max);
+    uct_dc_dci_t *dci = uct_dc_mlx5_iface_dci(iface, dci_index);
+
+    uct_rc_txqp_available_set(&dci->txqp, uct_ib_mlx5_txwq_update_bb(&dci->txwq, hw_ci));
+    ucs_assert(uct_rc_txqp_available(&dci->txqp) <= dci->txwq.bb_max);
 
     uct_rc_iface_update_reads(&iface->super.super);
 }

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -1276,7 +1276,7 @@ UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_ep_t)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(self->super.super.iface,
                                                 uct_dc_mlx5_iface_t);
-    uct_dc_dci_t *dci          = uct_dc_mlx5_iface_dci(iface, self->dci);
+    uct_dc_dci_t *dci;
 
     uct_dc_mlx5_ep_pending_purge(&self->super.super,
                                  uct_rc_ep_pending_purge_warn_cb, self);
@@ -1294,7 +1294,7 @@ UCS_CLASS_CLEANUP_FUNC(uct_dc_mlx5_ep_t)
     ucs_assertv_always(uct_dc_mlx5_iface_dci_has_outstanding(iface, self->dci),
                        "iface (%p) ep (%p) dci leak detected: dci=%d", iface,
                        self, self->dci);
-
+    dci = uct_dc_mlx5_iface_dci(iface, self->dci);
     if (!uct_dc_mlx5_is_dci_valid(dci)) {
         return;
     }
@@ -1732,23 +1732,22 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
                                                 uct_dc_mlx5_iface_t);
     uct_dci_index_t dci_index  = ep->dci;
     uint16_t pi                = ntohs(cqe->wqe_counter);
+    uct_dc_dci_t *dci          = uct_dc_mlx5_iface_dci(iface, dci_index);
     uint8_t pool_index;
-    UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
-
-    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
 
     ucs_debug("handle failure iface %p, ep %p, dci[%d] qpn 0x%x, status: %s",
-              iface, ep, dci_index, txwq->super.qp_num,
+              iface, ep, dci_index, dci->txwq.super.qp_num,
               ucs_status_string(ep_status));
 
     ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
 
-    uct_dc_mlx5_update_tx_res(iface, txwq, txqp, pi);
-    uct_rc_txqp_purge_outstanding(&iface->super.super, txqp, ep_status, pi, 0);
+    uct_dc_mlx5_update_tx_res(iface, dci_index, pi);
+    uct_rc_txqp_purge_outstanding(&iface->super.super, &dci->txqp, ep_status,
+                                  pi, 0);
 
     /* Invoke a user's error callback and release TX/FC resources before
      * releasing DCI, to have DCI for doing possible flush(CANCEL) */
-    uct_dc_mlx5_iface_set_ep_failed(iface, ep, cqe, txwq, ep_status);
+    uct_dc_mlx5_iface_set_ep_failed(iface, ep, cqe, &dci->txwq, ep_status);
 
     ucs_assertv(ep->fc.fc_wnd == iface->super.super.config.fc_wnd_size,
                 "ep %p: fc_wnd=%d config_fc_wnd=%u", ep, ep->fc.fc_wnd,

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
@@ -23,7 +23,11 @@
 
 
 #define UCT_DC_MLX5_IFACE_TXQP_GET(_iface, _ep, _txqp, _txwq) \
-    UCT_DC_MLX5_IFACE_TXQP_DCI_GET(_iface, (_ep)->dci, _txqp, _txwq)
+    { \
+        ucs_assert((_ep)->dci != UCT_DC_MLX5_EP_NO_DCI); \
+        _txqp = &uct_dc_mlx5_iface_dci(_iface, (_ep)->dci)->txqp; \
+        _txwq = &uct_dc_mlx5_iface_dci(_iface, (_ep)->dci)->txwq; \
+    }
 
 
 enum uct_dc_mlx5_ep_flags {
@@ -346,8 +350,8 @@ uct_dc_mlx5_dci_pool_init_dci(uct_dc_mlx5_iface_t *iface, uint8_t pool_index,
                               uct_dci_index_t dci_index)
 {
     uct_dc_mlx5_dci_pool_t *pool = &iface->tx.dci_pool[pool_index];
-    uct_dc_dci_t *dci            = uct_dc_mlx5_iface_dci(iface, dci_index);
     uint8_t num_channels         = 1;
+    uct_dc_dci_t *dci;
     ucs_status_t status;
 
     ucs_assertv(ucs_array_length(&pool->stack) < iface->tx.ndci,
@@ -365,6 +369,7 @@ uct_dc_mlx5_dci_pool_init_dci(uct_dc_mlx5_iface_t *iface, uint8_t pool_index,
         return status;
     }
 
+    dci             = uct_dc_mlx5_iface_dci(iface, dci_index);
     dci->path_index = pool->config.path_index;
     dci->pool_index = pool_index;
 


### PR DESCRIPTION
## What
- Access DCIs by index instead of by pointer
- in poll_tx: relocate dcis array so asan would catch if memory violation is done
- Set default dcis array capacity to 1.

## Why ?
Suggesting a future proof fix for the issues caused by dynamic resizing of dcis array (use after free caused by using an old pointer after resize).