### PR TITLE
ARCH/X86: Add Turin support

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -23,18 +23,15 @@ UCX_MM_SEND_OVERHEAD=am_short:40ns,am_bcopy:220ns
 UCX_MM_RECV_OVERHEAD=am_short:40ns,am_bcopy:220ns
 UCX_RCACHE_OVERHEAD=360ns
 
-[AMD Rome]
-CPU model=Rome
+[AMD]
+CPU vendor=AMD
+# UCX_DISTANCE_BW may affect GPU communication methods.
+# Tune it based on the actual PCIE bandwidth between the devices in your system
 UCX_DISTANCE_BW=auto,sys:5100MBs
 
 [AMD Milan]
 CPU model=Milan
-UCX_DISTANCE_BW=auto,sys:5100MBs
 # Real latencies are around 1.4 and 0.4, rest is gdrcopy rcache overhead
 # TODO: Add gdrcopy rcache overhead as separate performance graph node
 # TODO: Add rcache overhead not only for Milan and GH systems
 UCX_GDR_COPY_LAT=get:1.65e-6,put:0.65e-6
-
-[AMD Genoa]
-CPU model=Genoa
-UCX_DISTANCE_BW=auto,sys:5100MBs

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -191,6 +192,7 @@ const char *ucs_cpu_model_name()
         [UCS_CPU_MODEL_AMD_ROME]           = "Rome",
         [UCS_CPU_MODEL_AMD_MILAN]          = "Milan",
         [UCS_CPU_MODEL_AMD_GENOA]          = "Genoa",
+        [UCS_CPU_MODEL_AMD_TURIN]          = "Turin",
         [UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG] = "Zhangjiang",
         [UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU]   = "Wudaokou",
         [UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI]   = "Lujiazui",

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -3,6 +3,7 @@
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -35,6 +36,7 @@ typedef enum ucs_cpu_model {
     UCS_CPU_MODEL_AMD_ROME,
     UCS_CPU_MODEL_AMD_MILAN,
     UCS_CPU_MODEL_AMD_GENOA,
+    UCS_CPU_MODEL_AMD_TURIN,
     UCS_CPU_MODEL_ZHAOXIN_ZHANGJIANG,
     UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU,
     UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI,
@@ -162,7 +164,8 @@ static inline int ucs_cpu_prefer_relaxed_order()
             ((cpu_model == UCS_CPU_MODEL_AMD_NAPLES) ||
              (cpu_model == UCS_CPU_MODEL_AMD_ROME) ||
              (cpu_model == UCS_CPU_MODEL_AMD_MILAN) ||
-             (cpu_model == UCS_CPU_MODEL_AMD_GENOA)));
+             (cpu_model == UCS_CPU_MODEL_AMD_GENOA) ||
+             (cpu_model == UCS_CPU_MODEL_AMD_TURIN)));
 }
 
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -485,6 +485,13 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
                 break;
             }
             break;
+        /* AMD Zen5 */
+        case 0x1a:
+            if ((model <= 0x2f) || (model >= 0x40 && model <= 0x4f) ||
+                (model >= 0x60 && model <= 0x7f)) {
+                cpu_model = UCS_CPU_MODEL_AMD_TURIN;
+            }
+            break;
         }
     }
 


### PR DESCRIPTION
Acked-by: Edgar Gabriel <edgar.gabriel@amd.com>

## What?
Adding support for AMD's Turin processors.

Ref: https://www.amd.com/en/products/processors/server/epyc/9005-series.html