### PR TITLE
UCP/RNDV: Remove RNDV_PERF_DIFF setting

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -191,11 +191,6 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "is zero or negative",
    ucs_offsetof(ucp_context_config_t, rndv_thresh_fallback), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"RNDV_PERF_DIFF", "1",
-   "The percentage allowed for performance difference between rendezvous and "
-   "the eager_zcopy protocol",
-   ucs_offsetof(ucp_context_config_t, rndv_perf_diff), UCS_CONFIG_TYPE_DOUBLE},
-
   {"MULTI_LANE_MAX_RATIO", "4",
    "Maximal allowed ratio between slowest and fastest lane in a multi-lane\n"
    "protocol. Lanes slower than the specified ratio will not be used.",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -66,9 +66,6 @@ typedef struct ucp_context_config {
     /** Threshold for switching UCP to rendezvous protocol in case the calculated
      *  threshold is zero or negative */
     size_t                                 rndv_thresh_fallback;
-    /** The percentage allowed for performance difference between rendezvous
-     *  and the eager_zcopy protocol */
-    double                                 rndv_perf_diff;
     /** Maximal allowed ratio between slowest and fastest lane in a multi-lane
      *  protocol. Lanes slower than the specified ratio will not be used */
     double                                 multi_lane_max_ratio;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2106,7 +2106,7 @@ ucp_ep_config_calc_rndv_thresh(ucp_worker_t *worker,
                                int recv_reg_cost, size_t *thresh_p)
 {
     ucp_context_h context = worker->context;
-    double diff_percent   = 1.0 - context->config.ext.rndv_perf_diff / 100.0;
+    double diff_percent   = 0.99;
     ucp_ep_thresh_params_t eager_zcopy;
     ucp_ep_thresh_params_t rndv;
     double numerator, denominator;

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -545,7 +545,6 @@ void ucp_proto_rndv_rts_probe(const ucp_proto_init_params_t *init_params)
                                                      init_params->select_param),
         .remote_op_id        = UCP_OP_ID_RNDV_RECV,
         .lane                = ucp_proto_rndv_find_ctrl_lane(init_params),
-        .perf_bias           = context->config.ext.rndv_perf_diff / 100.0,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTS_NAME,
         .md_map              = 0
     };

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -95,10 +95,6 @@ typedef struct {
     /* Performance data to unpack the received data */
     ucp_proto_perf_t               *unpack_perf;
 
-    /* Reduce estimated time by this value (for example, 0.03 means to report
-       a 3% better time) */
-    double                         perf_bias;
-
     /* Name of the control message, e.g "RTS" */
     const char                     *ctrl_msg_name;
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -180,7 +180,6 @@ static void ucp_proto_rndv_rtr_probe(const ucp_proto_init_params_t *init_params)
                                                      init_params->select_param),
         .remote_op_id        = UCP_OP_ID_RNDV_SEND,
         .lane                = ucp_proto_rndv_find_ctrl_lane(init_params),
-        .perf_bias           = 0.0,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTR_NAME,
         .md_map              = 0
     };
@@ -392,7 +391,6 @@ ucp_proto_rndv_rtr_mtype_probe(const ucp_proto_init_params_t *init_params)
         .super.exclude_map   = 0,
         .remote_op_id        = UCP_OP_ID_RNDV_SEND,
         .lane                = ucp_proto_rndv_find_ctrl_lane(init_params),
-        .perf_bias           = 0.0,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTR_NAME,
     };
     ucs_memory_type_t frag_mem_type;

--- a/src/ucp/tag/offload/rndv.c
+++ b/src/ucp/tag/offload/rndv.c
@@ -185,7 +185,6 @@ ucp_tag_rndv_offload_sw_proto_probe(const ucp_proto_init_params_t *init_params)
                                                      init_params->select_param),
         .remote_op_id        = UCP_OP_ID_RNDV_RECV,
         .lane                = init_params->ep_config_key->tag_lane,
-        .perf_bias           = context->config.ext.rndv_perf_diff / 100.0,
         .ctrl_msg_name       = UCP_PROTO_RNDV_RTS_NAME,
         .md_map              = 0
     };


### PR DESCRIPTION
## What?
Get rid of control handle that allows to improve RNDV performance from the user side.

## Why?
That control allows to improve performance to change RNDV protocol selection/threshold automatic configuration. FMPOV that is not a good solution since it is not clear for customer how changing protocol performance to some value will affect protocol selection for different cases. User still would be able to use `RNVD_THRESH` for threshold manual setting.

Also after reworking of multi performance prediction this control has no effect for protov2 so probably we should completely remove it.
