### PR TITLE
UCS/SYS: Workaround uninitialized value for rlimit

### DIFF
--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -332,7 +332,7 @@ ucs_get_rlimit(int resource, rlim_t *rlimit_value, const char *name)
 
 int ucs_sys_max_open_files()
 {
-    rlim_t value;
+    rlim_t value = 0;
 
     if (ucs_get_rlimit(RLIMIT_NOFILE, &value, "max opened file") != UCS_OK) {
         return -1;
@@ -1592,8 +1592,8 @@ err:
 
 ucs_status_t ucs_sys_get_effective_memlock_rlimit(size_t *rlimit_value)
 {
+    rlim_t value = 0;
     ucs_status_t status;
-    rlim_t value;
 
     /* Privileged users have no lock limit */
     if (ucs_sys_get_mlock_cap()) {


### PR DESCRIPTION
## What?
Fix what seems to be false positive.

## Why?
```
sys/sys.c: In function 'ucs_sys_max_open_files':
sys/sys.c:341:12: error: 'value' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  341 |     return (int)value;
      |            ^~~~~~~~~~
sys/sys.c: In function 'ucs_sys_get_effective_memlock_rlimit':
sys/sys.c:1611:19: error: 'value' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1611 |     *rlimit_value = (value == RLIM_INFINITY) ? SIZE_MAX : value;
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```