### PR TITLE
UCT/CUDA/CUDA_IPC: Fix return value of is_peer_accessible.

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -282,9 +282,8 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
     uct_cuda_ipc_dev_cache_t *cache;
     uint8_t *accessible;
 
-    status = UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&this_device));
-    if (UCS_OK != status) {
-        return status;
+    if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&this_device)) != UCS_OK) {
+        return UCS_ERR_UNREACHABLE;
     }
 
     pthread_mutex_lock(&component->lock);


### PR DESCRIPTION
## What?
Fixed return value of `uct_cuda_ipc_is_peer_accessible`.
Restored old behavior, which was changed by https://github.com/openucx/ucx/pull/9978.

## Why?
Returning value other than `UCS_ERR_UNREACHABLE` causes an issue during unpacking remote key.
The issue can be reproduced by `iodemo` example application.
Client side:
```
ucp_mm.c:369  UCX  WARN  failed to dereg from md[4]=cuda_ipc: Unsupported operation
```
Server side:
```
ucp_rkey.c:899  UCX  ERROR   failed to unpack remote key from remote md[4]: Input/output error
```

