### PR TITLE
UCT/TEST: Fixed race condition in uct_sock test

### DIFF
--- a/test/gtest/uct/test_sockaddr.cc
+++ b/test/gtest/uct/test_sockaddr.cc
@@ -594,9 +594,9 @@ protected:
             self->m_client->disconnect(ep);
         }
 
-        self->m_state |= TEST_STATE_CLIENT_DISCONNECTED;
         self->m_client_disconnect_cnt++;
         self->del_user_data(sa_user_data);
+        self->m_state |= TEST_STATE_CLIENT_DISCONNECTED;
     }
 
     void cm_disconnect(entity *ent) {


### PR DESCRIPTION
## What?
Fixed race condition in uct_sock test

## Why?
Fix the following error:
```
2024-11-05T12:40:53.0873763Z Value of: m_ep_client_data.empty()
2024-11-05T12:40:53.0875383Z   Actual: false
2024-11-05T12:40:53.0876712Z Expected: true
```