### PR TITLE
UCT/DC: Increase DCI index to 16 bits - v1.18

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -270,7 +270,7 @@ static void uct_dc_mlx5_iface_progress_enable(uct_iface_h tl_iface, unsigned fla
 static UCS_F_ALWAYS_INLINE unsigned
 uct_dc_mlx5_poll_tx(uct_dc_mlx5_iface_t *iface, int poll_flags)
 {
-    uint8_t dci_index;
+    uct_dci_index_t dci_index;
     struct mlx5_cqe64 *cqe;
     uint16_t hw_ci;
     uct_dc_dci_t *dci;
@@ -367,8 +367,8 @@ static void uct_ib_mlx5dv_dci_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
 }
 
 ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
-                                          uint8_t dci_index, int connect,
-                                          uint8_t num_dci_channels)
+                                          uct_dci_index_t dci_index,
+                                          int connect, uint8_t num_dci_channels)
 {
     uct_ib_iface_t *ib_iface   = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr = {};
@@ -777,9 +777,10 @@ uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci)
 
 static void uct_dc_mlx5_iface_dcis_destroy(uct_dc_mlx5_iface_t *iface)
 {
-    uint8_t num_dcis = ucs_array_length(&iface->tx.dcis);
+    uct_dci_index_t num_dcis = ucs_array_length(&iface->tx.dcis);
     uct_dc_dci_t *dci;
-    uint8_t pool_index, dci_index;
+    uint8_t pool_index;
+    uct_dci_index_t dci_index;
 
     for (dci_index = 0; dci_index < num_dcis; dci_index++) {
         dci = uct_dc_mlx5_iface_dci(iface, dci_index);
@@ -1351,7 +1352,7 @@ uct_dc_mlx5_iface_fc_handler(uct_rc_iface_t *rc_iface, unsigned qp_num,
 
 static void uct_dc_mlx5_dci_handle_failure(uct_dc_mlx5_iface_t *iface,
                                            struct mlx5_cqe64 *cqe,
-                                           uint8_t dci_index,
+                                           uct_dci_index_t dci_index,
                                            ucs_status_t status)
 {
     uct_dc_mlx5_ep_t *ep;
@@ -1380,7 +1381,7 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ib_iface, uct_dc_mlx5_iface_t);
     struct mlx5_cqe64 *cqe     = arg;
-    uint8_t dci_index          = uct_dc_mlx5_iface_dci_find(iface, cqe);
+    uct_dci_index_t dci_index  = uct_dc_mlx5_iface_dci_find(iface, cqe);
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     UCT_DC_MLX5_IFACE_TXQP_DCI_GET(iface, dci_index, txqp, txwq);
@@ -1809,7 +1810,8 @@ UCT_TL_DEFINE_ENTRY(&uct_ib_component, dc_mlx5, uct_dc_mlx5_query_tl_devices,
                     uct_dc_mlx5_iface_t, "DC_MLX5_",
                     uct_dc_mlx5_iface_config_table, uct_dc_mlx5_iface_config_t);
 
-void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
+void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface,
+                                 uct_dci_index_t dci_index)
 {
     uct_dc_dci_t *dci        = uct_dc_mlx5_iface_dci(iface, dci_index);
     uct_ib_mlx5_txwq_t *txwq = &dci->txwq;

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -1439,7 +1439,7 @@ unsigned uct_dc_mlx5_ep_dci_release_progress(void *arg)
 {
     uct_dc_mlx5_iface_t *iface = arg;
     uint8_t pool_index;
-    uint8_t dci;
+    uct_dci_index_t dci;
     uct_dc_mlx5_dci_pool_t *dci_pool;
 
     ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
@@ -1708,7 +1708,7 @@ void uct_dc_mlx5_ep_handle_failure(uct_dc_mlx5_ep_t *ep,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                                 uct_dc_mlx5_iface_t);
-    uint8_t dci_index          = ep->dci;
+    uct_dci_index_t dci_index  = ep->dci;
     uint16_t pi                = ntohs(cqe->wqe_counter);
     uint8_t pool_index;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
@@ -13,7 +13,7 @@
 
 #include "dc_mlx5.h"
 
-#define UCT_DC_MLX5_EP_NO_DCI    ((uint8_t)-1)
+#define UCT_DC_MLX5_EP_NO_DCI    ((uct_dci_index_t)-1)
 #define UCT_DC_MLX5_HW_DCI_INDEX 0
 
 
@@ -66,12 +66,12 @@ typedef struct uct_dc_mlx5_base_av {
 struct uct_dc_mlx5_ep {
     uct_base_ep_t         super;
     ucs_arbiter_group_t   arb_group;
-    uint8_t               dci;
-    uint8_t               atomic_mr_id;
+    uct_dci_index_t       dci;
     uint16_t              flags;
     uint16_t              flush_rkey_hi;
     uct_rc_fc_t           fc;
     uct_dc_mlx5_base_av_t av;
+    uint8_t               atomic_mr_id;
     uint8_t               dci_channel_index;
 };
 
@@ -309,7 +309,7 @@ uct_dc_mlx5_iface_dci_sched_tx(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 }
 
 static UCS_F_ALWAYS_INLINE uct_dc_mlx5_ep_t *
-uct_dc_mlx5_ep_from_dci(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
+uct_dc_mlx5_ep_from_dci(uct_dc_mlx5_iface_t *iface, uct_dci_index_t dci_index)
 {
     /* Can be used with dcs* policies only, with rand policy every dci may
      * be used by many eps */
@@ -330,20 +330,20 @@ uct_dc_mlx5_init_dci_config(uct_dc_mlx5_dci_config_t *dci_config,
 }
 
 static UCS_F_ALWAYS_INLINE int
-uct_dc_mlx5_is_hw_dci(const uct_dc_mlx5_iface_t *iface, uint8_t dci)
+uct_dc_mlx5_is_hw_dci(const uct_dc_mlx5_iface_t *iface, uct_dci_index_t dci)
 {
     return dci == iface->tx.hybrid_hw_dci;
 }
 
 static UCS_F_ALWAYS_INLINE int
-uct_dc_mlx5_is_dci_shared(uct_dc_mlx5_iface_t *iface, uint8_t dci)
+uct_dc_mlx5_is_dci_shared(uct_dc_mlx5_iface_t *iface, uct_dci_index_t dci)
 {
     return uct_dc_mlx5_iface_dci(iface, dci)->flags & UCT_DC_DCI_FLAG_SHARED;
 }
 
 ucs_status_t static UCS_F_ALWAYS_INLINE
 uct_dc_mlx5_dci_pool_init_dci(uct_dc_mlx5_iface_t *iface, uint8_t pool_index,
-                              uint8_t dci_index)
+                              uct_dci_index_t dci_index)
 {
     uct_dc_mlx5_dci_pool_t *pool = &iface->tx.dci_pool[pool_index];
     uct_dc_dci_t *dci            = uct_dc_mlx5_iface_dci(iface, dci_index);
@@ -450,7 +450,7 @@ uct_dc_mlx5_iface_dci_can_alloc_or_create(uct_dc_mlx5_iface_t *iface,
                                           uint8_t pool_index)
 {
     uct_dc_mlx5_dci_pool_t *pool = &iface->tx.dci_pool[pool_index];
-    uint8_t dci_index;
+    uct_dci_index_t dci_index;
     ucs_status_t status;
 
     ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
@@ -549,14 +549,16 @@ void uct_dc_mlx5_iface_schedule_dci_alloc(uct_dc_mlx5_iface_t *iface,
     }
 }
 
-static UCS_F_ALWAYS_INLINE uint8_t
-uct_dc_mlx5_iface_dci_pool_index(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
+static UCS_F_ALWAYS_INLINE uint8_t 
+uct_dc_mlx5_iface_dci_pool_index(uct_dc_mlx5_iface_t *iface, 
+                                 uct_dci_index_t dci_index)
 {
     return uct_dc_mlx5_iface_dci(iface, dci_index)->pool_index;
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_iface_dci_release(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
+uct_dc_mlx5_iface_dci_release(uct_dc_mlx5_iface_t *iface,
+                              uct_dci_index_t dci_index)
 {
     uint8_t pool_index           = uct_dc_mlx5_iface_dci_pool_index(iface,
                                                                     dci_index);
@@ -576,7 +578,7 @@ uct_dc_mlx5_iface_dci_release(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
 /* Release endpoint's DCI below, if the endpoint does not have outstanding
  * operations */
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uint8_t dci_index)
+uct_dc_mlx5_iface_dci_put(uct_dc_mlx5_iface_t *iface, uct_dci_index_t dci_index)
 {
     uct_dc_mlx5_ep_t *ep;
     ucs_arbiter_t *waitq;
@@ -664,7 +666,8 @@ uct_dc_mlx5_iface_dci_alloc(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_iface_dci_schedule_release(uct_dc_mlx5_iface_t *iface, uint8_t dci)
+uct_dc_mlx5_iface_dci_schedule_release(uct_dc_mlx5_iface_t *iface,
+                                       uct_dci_index_t dci)
 {
     uct_worker_h worker = &iface->super.super.super.super.worker->super;
     uint8_t pool_index = uct_dc_mlx5_iface_dci_pool_index(iface, dci);
@@ -686,7 +689,7 @@ uct_dc_mlx5_iface_dci_schedule_release(uct_dc_mlx5_iface_t *iface, uint8_t dci)
 static UCS_F_ALWAYS_INLINE int
 uct_dc_mlx5_iface_dci_detach(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep)
 {
-    uint8_t dci_index = ep->dci;
+    uct_dci_index_t dci_index = ep->dci;
 
     ucs_assert(!uct_dc_mlx5_iface_is_policy_shared(iface));
     ucs_assert(dci_index != UCT_DC_MLX5_EP_NO_DCI);


### PR DESCRIPTION
## What?
Increase DCI index to 16 bits -> backported from master

## Why?
Support large number of DCIs
