### PR TITLE
UCT/DC: Convert dcis array to use new index typedef

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.h
@@ -285,7 +285,7 @@ typedef struct {
 } uct_dc_mlx5_dci_pool_t;
 
 
-UCS_ARRAY_DECLARE_TYPE(uct_dc_dci_array_t, uint16_t, uct_dc_dci_t);
+UCS_ARRAY_DECLARE_TYPE(uct_dc_dci_array_t, uct_dci_index_t, uct_dc_dci_t);
 
 struct uct_dc_mlx5_iface {
     uct_rc_mlx5_iface_common_t       super;


### PR DESCRIPTION
## What?
Convert dcis array to use new index typedef

## Why?
Follow code convension


