### PR TITLE
BINDINGS/GO/PERF: Periodic statistics

### DIFF
--- a/bindings/go/src/examples/perftest/perftest.go
+++ b/bindings/go/src/examples/perftest/perftest.go
@@ -28,7 +28,7 @@ type PerfTestParams struct {
 	port          uint
 	wakeup        bool
 	ip            string
-	printIter     uint
+	printInterval uint
 	warmUpIter    uint
 }
 
@@ -36,13 +36,13 @@ type PerfTest struct {
 	context              *UcpContext
 	memory               *UcpMemory
 	memParams            *UcpMemAttributes
-	perThreadWorkers     []*UcpWorker
+	worker               *UcpWorker
 	listener             *UcpListener
-	eps                  []*UcpEp
-	reverseEps           []*UcpEp
-	numCompletedRequests uint32
+	ep                   *UcpEp
+	numCompletedRequests int32
 	wg                   sync.WaitGroup
-	completionTime       []time.Duration
+	quit                 chan struct{}
+	wake                 []chan struct{}
 }
 
 var perfTestParams = PerfTestParams{}
@@ -56,29 +56,45 @@ func getAddressOffsetForThread(t uint) unsafe.Pointer {
 }
 
 // Printing functions
-func printHeader() {
+
+func printRule() {
 	dashes := strings.Repeat("-", 20)
-	fmt.Printf("|%20s|%20s|%20s|%20s|\n", dashes, dashes, dashes, dashes)
-	fmt.Printf("|%20s|%20s|%20s|%20s|\n", "Thread", "Iteration", "Latency ", "Bandwidth (Gb/s)")
-	fmt.Printf("|%20s|%20s|%20s|%20s|\n", dashes, dashes, dashes, dashes)
+	fmt.Printf("%20s|%20s|%20s|\n", dashes, dashes, dashes)
 }
 
-func printPerThreadStatistics(i uint, t uint) {
-	bw := float64(perfTestParams.messageSize) * float64(8e-9) / perfTest.completionTime[t].Seconds()
-	fmt.Printf("|%20s|%20s|%20s|%20f|\n", fmt.Sprintf("%v/%v", t+1, perfTestParams.numThreads),
-		fmt.Sprintf("%v/%v", i, perfTestParams.numIterations), perfTest.completionTime[t], bw)
+func printHeader() {
+	printRule()
+	fmt.Printf("%20s|%20s|%20s|\n", "# iterations", "Bandwidth (Mb/s)", "Messages")
+	printRule()
+}
+
+func printStatistics() {
+	last := atomic.LoadInt32(&perfTest.numCompletedRequests)
+	ticker := time.NewTicker(time.Duration(perfTestParams.printInterval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			curr := atomic.LoadInt32(&perfTest.numCompletedRequests)
+			rate := (curr - last) / int32(perfTestParams.printInterval)
+			bw := float64(perfTestParams.messageSize) * float64(rate) * float64(1e-6)
+			fmt.Printf("%20d|%20f|%20d|\n", curr, bw, rate)
+			last = curr
+		case <-perfTest.quit:
+			return
+		}
+	}
 }
 
 func printTotalStatistics(duration time.Duration) {
-	totalBytesTransfered := perfTestParams.messageSize * uint64(perfTestParams.numThreads) * uint64(perfTestParams.numIterations)
-	avgLat := float64(duration.Milliseconds()) / float64(perfTestParams.numIterations)
-	avgBw := float64(totalBytesTransfered) * float64(8e-9) / duration.Seconds()
+	totalBytesTransfered := perfTestParams.messageSize * uint64(perfTest.numCompletedRequests)
+	avgBw := float64(totalBytesTransfered) * float64(1e-6) / duration.Seconds()
 
-	dashes := strings.Repeat("-", 20)
-	fmt.Printf("|%20s|%20s|%20s|%20s|\n", dashes, dashes, dashes, dashes)
+	printRule()
 	fmt.Printf("Number of iterations: %v, number of threads: %v, message size: %v, "+
-		"memory type: %v, average latency (ms): %v, average bandwidth (Gb/s): %.3f \n", perfTestParams.numIterations,
-		perfTestParams.numThreads, perfTestParams.messageSize, perfTestParams.memType, avgLat, avgBw)
+		"memory type: %v, average bandwidth (Mb/s): %.3f \n", perfTestParams.numIterations,
+		perfTestParams.numThreads, perfTestParams.messageSize, perfTestParams.memType, avgBw)
 }
 
 func initContext() {
@@ -126,7 +142,7 @@ func initMemory() error {
 	return nil
 }
 
-func initWorker(i int) {
+func initWorker() {
 	workerParams := (&UcpWorkerParams{}).SetThreadMode(UCS_THREAD_MODE_MULTI)
 
 	if perfTestParams.wakeup {
@@ -134,7 +150,7 @@ func initWorker(i int) {
 		workerParams.WakeupRX()
 	}
 
-	perfTest.perThreadWorkers[i], _ = perfTest.context.NewWorker(workerParams)
+	perfTest.worker, _ = perfTest.context.NewWorker(workerParams)
 }
 
 func epErrorHandling(ep *UcpEp, status UcsStatus) {
@@ -144,24 +160,14 @@ func epErrorHandling(ep *UcpEp, status UcsStatus) {
 	}
 }
 
-func clientConnectWorker(i int) error {
-	var err error
-	epParams := &UcpEpParams{}
-	serverAddress, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("%v:%v", perfTestParams.ip, perfTestParams.port))
-	epParams.SetPeerErrorHandling().SetErrorHandler(epErrorHandling).SetSocketAddress(serverAddress)
-
-	perfTest.eps[i], err = perfTest.perThreadWorkers[i].NewEndpoint(epParams)
-	if err != nil {
-		return err
-	}
-
-	request, err := perfTest.eps[i].FlushNonBlocking(nil)
+func flush() error {
+	request, err := perfTest.ep.FlushNonBlocking(nil)
 	if err != nil {
 		return err
 	}
 
 	for request.GetStatus() == UCS_INPROGRESS {
-		progressWorker(i)
+		progressWorker()
 	}
 
 	if status := request.GetStatus(); status != UCS_OK {
@@ -172,6 +178,20 @@ func clientConnectWorker(i int) error {
 	return nil
 }
 
+func clientConnectWorker() error {
+	var err error
+	epParams := &UcpEpParams{}
+	serverAddress, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("%v:%v", perfTestParams.ip, perfTestParams.port))
+	epParams.SetPeerErrorHandling().SetErrorHandler(epErrorHandling).SetSocketAddress(serverAddress)
+
+	perfTest.ep, err = perfTest.worker.NewEndpoint(epParams)
+	if err != nil {
+		return err
+	}
+
+	return flush()
+}
+
 func initListener() error {
 	var err error
 	listenerParams := &UcpListenerParams{}
@@ -179,16 +199,13 @@ func initListener() error {
 
 	listenerParams.SetSocketAddress(addr)
 	listenerParams.SetConnectionHandler(func(connRequest *UcpConnectionRequest) {
-		// No need to synchronize, since reverse eps creating from a single thread.
-		numConnections := len(perfTest.reverseEps)
-		reverseEp, _ := perfTest.perThreadWorkers[1+numConnections].NewEndpoint(
+		perfTest.ep, _ = perfTest.worker.NewEndpoint(
 			(&UcpEpParams{}).SetConnRequest(connRequest).SetErrorHandler(epErrorHandling).SetPeerErrorHandling())
 
-		perfTest.reverseEps = append(perfTest.reverseEps, reverseEp)
-		fmt.Printf("Got connection for thread %v. Starting benchmark...\n", numConnections)
+		fmt.Printf("Got connection. Starting benchmark...\n")
 	})
 
-	perfTest.listener, err = perfTest.perThreadWorkers[0].NewListener(listenerParams)
+	perfTest.listener, err = perfTest.worker.NewListener(listenerParams)
 	if err != nil {
 		return err
 	}
@@ -196,29 +213,25 @@ func initListener() error {
 	return nil
 }
 
-func progressWorker(i int) {
-	for perfTest.perThreadWorkers[i].Progress() != 0 {
+func progressWorker() {
+	for perfTest.worker.Progress() != 0 {
 	}
 	if perfTestParams.wakeup {
-		perfTest.perThreadWorkers[i].Wait()
+		perfTest.worker.Wait()
 	}
 }
 
-func close() {
-	for _, reverseEp := range perfTest.reverseEps {
-		reverseEp.CloseNonBlockingForce(nil)
-	}
-
-	for _, ep := range perfTest.eps {
-		ep.CloseNonBlockingForce(nil)
+func closeAll() {
+	if perfTest.ep != nil {
+		perfTest.ep.CloseNonBlockingForce(nil)
 	}
 
 	if perfTest.listener != nil {
 		perfTest.listener.Close()
 	}
 
-	for _, worker := range perfTest.perThreadWorkers {
-		worker.Close()
+	if perfTest.worker != nil {
+		perfTest.worker.Close()
 	}
 
 	if perfTest.memory != nil {
@@ -232,15 +245,12 @@ func close() {
 
 func serverAmRecvHandler(header unsafe.Pointer, headerSize uint64, data *UcpAmData, replyEp *UcpEp) UcsStatus {
 	tid := *(*uint)(header)
-	if data.IsDataValid() {
-		atomic.AddUint32(&perfTest.numCompletedRequests, 1)
-	} else {
-		data.Receive(getAddressOffsetForThread(tid), perfTestParams.messageSize,
-			(&UcpRequestParams{}).SetMemType(perfTestParams.memType).SetCallback(func(request *UcpRequest, status UcsStatus, length uint64) {
-				atomic.AddUint32(&perfTest.numCompletedRequests, 1)
-				request.Close()
-			}))
+	if !data.IsDataValid() {
+		request, _ := data.Receive(getAddressOffsetForThread(tid), perfTestParams.messageSize,
+			     (&UcpRequestParams{}).SetMemType(perfTestParams.memType))
+		request.Close()
 	}
+	atomic.AddInt32(&perfTest.numCompletedRequests, 1)
 	return UCS_OK
 }
 
@@ -249,61 +259,58 @@ func serverStart() error {
 	if err := initMemory(); err != nil {
 		return err
 	}
-	// 1 global worker for listener progress and N threads for data receive.
-	perfTest.perThreadWorkers = make([]*UcpWorker, perfTestParams.numThreads+1)
-	initWorker(0)
+
+	initWorker()
+	perfTest.worker.SetAmRecvHandler(0, UCP_AM_FLAG_WHOLE_MSG, serverAmRecvHandler)
 	if err := initListener(); err != nil {
 		return err
 	}
 
-	// Submit AM recv handler for each thread
-	for t := uint(0); t < perfTestParams.numThreads; t += 1 {
-		initWorker(int(t) + 1)
-		perfTest.perThreadWorkers[t+1].SetAmRecvHandler(t, UCP_AM_FLAG_WHOLE_MSG, serverAmRecvHandler)
+	totalNumRequests := int32(perfTestParams.warmUpIter + perfTestParams.numIterations)
+	tryCudaSetDevice()
+
+	for atomic.LoadInt32(&perfTest.numCompletedRequests) < totalNumRequests {
+		progressWorker()
 	}
 
-	totalNumRequests := uint32((perfTestParams.warmUpIter + perfTestParams.numIterations) * perfTestParams.numThreads)
-	perfTest.wg.Add(int(perfTestParams.numThreads + 1))
-	for t := uint(0); t < perfTestParams.numThreads+1; t += 1 {
-		go func(tid uint) {
-			tryCudaSetDevice()
-
-			for atomic.LoadUint32(&perfTest.numCompletedRequests) < totalNumRequests {
-				progressWorker(int(tid))
-			}
-			perfTest.wg.Done()
-		}(t)
-	}
-	perfTest.wg.Wait()
-
-	close()
+	flush()
+	closeAll()
 	return nil
 }
 
-func clientThreadDoIter(i int, t uint) {
+func clientThreadDoIter(t uint) {
 	tryCudaSetDevice()
 
-	start := time.Now()
-	var request *UcpRequest
 	requestParams := (&UcpRequestParams{}).SetMemType(perfTestParams.memType)
 
 	header := unsafe.Pointer(&t)
-	request, _ = perfTest.eps[t].SendAmNonBlocking(t, header, uint64(unsafe.Sizeof(t)), getAddressOffsetForThread(t), perfTestParams.messageSize, 0, requestParams)
-
+	request, err := perfTest.ep.SendAmNonBlocking(0, header, uint64(unsafe.Sizeof(t)), getAddressOffsetForThread(t), perfTestParams.messageSize, 0, requestParams)
+	if err != nil {
+		panic(err)
+	}
 	for request.GetStatus() == UCS_INPROGRESS {
-		progressWorker(int(t))
+		<-perfTest.wake[t]
 	}
 	if request.GetStatus() != UCS_OK {
 		errorString := fmt.Sprintf("Request completion error: %v", request.GetStatus().String())
 		panic(errorString)
 	}
-	perfTest.completionTime[t] = time.Since(start)
 	request.Close()
 
-	if (i > 0) && (uint(i)%perfTestParams.printIter) == 0 {
-		printPerThreadStatistics(uint(i), t)
-	}
+	atomic.AddInt32(&perfTest.numCompletedRequests, 1)
 	perfTest.wg.Done()
+}
+
+func clientProgress() {
+	for atomic.LoadInt32(&perfTest.numCompletedRequests) < int32(perfTestParams.numIterations) {
+		progressWorker()
+		for _, ch := range perfTest.wake {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}
+	}
 }
 
 func clientStart() error {
@@ -312,45 +319,52 @@ func clientStart() error {
 		return err
 	}
 
-	perfTest.perThreadWorkers = make([]*UcpWorker, perfTestParams.numThreads)
-	perfTest.eps = make([]*UcpEp, perfTestParams.numThreads)
-	for i := 0; i < int(perfTestParams.numThreads); i += 1 {
-		initWorker(i)
-		if err := clientConnectWorker(i); err != nil {
-			return err
-		}
+	initWorker()
+	if err := clientConnectWorker(); err != nil {
+		return err
 	}
 
-	var totalDuration time.Duration = 0
+	perfTest.wake = make([]chan struct{}, perfTestParams.numThreads)
+	for i := range perfTest.wake {
+		perfTest.wake[i] = make(chan struct{})
+	}
+
+	var start time.Time
+	perfTest.quit = make(chan struct{})
+	perfTest.numCompletedRequests = int32(-perfTestParams.warmUpIter)
 	printHeader()
-	for i := -int(perfTestParams.warmUpIter); i < int(perfTestParams.numIterations); i += 1 {
-		perfTest.wg.Add(int(perfTestParams.numThreads))
-		for t := uint(0); t < perfTestParams.numThreads; t += 1 {
-			go clientThreadDoIter(i, t)
+	go printStatistics()
+	go clientProgress()
+	for {
+		threads := perfTestParams.numThreads
+		if perfTest.numCompletedRequests <= 0 {
+			start = time.Now()
+		} else if perfTest.numCompletedRequests == int32(perfTestParams.numIterations) {
+			break
+		} else if perfTest.numCompletedRequests > int32(perfTestParams.numIterations - perfTestParams.numThreads) {
+			threads = perfTestParams.numIterations - uint(perfTest.numCompletedRequests)
+		}
+		perfTest.wg.Add(int(threads))
+		for t := uint(0); t < threads; t += 1 {
+			go clientThreadDoIter(t)
 		}
 		perfTest.wg.Wait()
-		var maxDuration time.Duration = 0
-		for _, threadDuration := range perfTest.completionTime {
-			if threadDuration > maxDuration {
-				maxDuration = threadDuration
-			}
-		}
-		totalDuration += maxDuration
 	}
-	printTotalStatistics(totalDuration)
+	printTotalStatistics(time.Since(start))
+	close(perfTest.quit)
 
-	close()
+	closeAll()
 	return nil
 }
 
 func main() {
-	flag.UintVar(&perfTestParams.numThreads, "t", 1, "number of threads for send: 1(default)")
-	flag.Uint64Var(&perfTestParams.messageSize, "s", 4096, "size of the message in bytes: 4096(default)")
-	flag.UintVar(&perfTestParams.port, "p", 36458, "port to bind: 36458(default)")
-	flag.UintVar(&perfTestParams.numIterations, "n", 1000, "Number of iterations to run: 1000(default)")
-	flag.UintVar(&perfTestParams.printIter, "printIter", 100, "Print summary every n iterations: 1000(default)")
+	flag.UintVar(&perfTestParams.numThreads, "t", 1, "number of goroutines for send")
+	flag.Uint64Var(&perfTestParams.messageSize, "s", 4096, "size of the message in bytes")
+	flag.UintVar(&perfTestParams.port, "p", 36458, "port to bind")
+	flag.UintVar(&perfTestParams.numIterations, "n", 1000, "number of iterations to run")
+	flag.UintVar(&perfTestParams.printInterval, "I", 1, "print summary every n seconds")
 	flag.BoolVar(&perfTestParams.wakeup, "wakeup", false, "use polling: false(default)")
-	flag.UintVar(&perfTestParams.warmUpIter, "warmup", 5, "warmup iterations: 5(default)")
+	flag.UintVar(&perfTestParams.warmUpIter, "warmup", 100, "warmup iterations")
 	flag.StringVar(&perfTestParams.ip, "i", "", "server address to connect")
 
 	perfTestParams.memType = UCS_MEMORY_TYPE_HOST
@@ -368,7 +382,6 @@ func main() {
 
 	flag.Parse()
 
-	perfTest.completionTime = make([]time.Duration, perfTestParams.numThreads)
 	var err error
 	if perfTestParams.ip == "" {
 		err = serverStart()


### PR DESCRIPTION
## What?
Implement a cumulative statistics printout that reports performance metrics every second using a single EP for communication.

## Why?
Align performance measurement and reporting style with `ucx_perftest`, which provides similar cumulative, per-second statistics.
