### PR TITLE
UCP/PROTO: Consider RNDV_PERF_DIFF

### DIFF
--- a/src/ucp/proto/proto_perf.c
+++ b/src/ucp/proto/proto_perf.c
@@ -430,13 +430,14 @@ ucs_status_t ucp_proto_perf_aggregate2(const char *name,
     return ucp_proto_perf_aggregate(name, perf_elems, 2, perf_p);
 }
 
-void ucp_proto_perf_apply_bias(ucp_proto_perf_t *perf, double bias) {
+void ucp_proto_perf_apply_bias(ucp_proto_perf_t *perf, double bias)
+{
     ucs_linear_func_t bias_func = ucs_linear_func_make(0.0, 1.0 - bias);
     ucp_proto_perf_node_t *bias_node;
     ucp_proto_perf_factor_id_t fid;
     ucp_proto_perf_segment_t *seg;
 
-    if (bias == 0) {
+    if (fabs(bias) <= UCP_PROTO_PERF_EPSILON) {
         return;
     }
 

--- a/src/ucp/proto/proto_perf.h
+++ b/src/ucp/proto/proto_perf.h
@@ -160,6 +160,16 @@ ucs_status_t ucp_proto_perf_aggregate2(const char *name,
 
 
 /**
+ * Apply a bias change to the given perf structure.
+ *
+ * @param [in] perf         Performance data structure to update.
+ * @param [in] bias         Bias to apply. A bias equal to 0.1 indicates a 10%
+ *                          performance improvement.
+ */
+void ucp_proto_perf_apply_bias(ucp_proto_perf_t *perf, double bias);
+
+
+/**
  * Expand given perf by estimation that all messages on interval
  * [end of @a frag_seg + 1, @a max_length] would be sent in a pipeline async
  * manner using data provided by @a frag_seg as a performance for sending one

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -405,6 +405,8 @@ static void ucp_proto_rndv_ctrl_variant_probe(
                                  ucs_max(cfg_thresh, remote_proto->cfg_thresh);
     }
 
+    ucp_proto_perf_apply_bias(perf, params->perf_bias);
+
     /* Remote variants priorities are used to respect RNDV_SCHEME setting
      * so they should contain value greater than CTRL message `cfg_thresh`.
      * Equality is allowed for RTR remote variants.


### PR DESCRIPTION
## What?
Applies `UCX_RNDV_PERF_DIFF` setting effect for protov2. 

## Why?
This control effect was removed during introducing perf-factors logic. This PR brings it back.

That how it looks like with that patch:
![image](https://github.com/user-attachments/assets/19986951-09c1-47e2-8d32-205aa6ce0a95)

