### PR TITLE
PERF: Fix integer overflow: use size_t instead of unsigned for buffer size

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -473,7 +473,7 @@ public:
     }
 
     UCS_F_ALWAYS_INLINE ucs_status_t send_daemon_req(void *buffer,
-                                                     unsigned length)
+                                                     size_t length)
     {
         ucp_ep_h ep               = m_perf.ucp.ep;
         ucp_request_param_t param = {
@@ -495,7 +495,7 @@ public:
     }
 
     ucs_status_t UCS_F_ALWAYS_INLINE
-    send(ucp_ep_h ep, void *buffer, unsigned length, ucp_datatype_t datatype,
+    send(ucp_ep_h ep, void *buffer, size_t length, ucp_datatype_t datatype,
          psn_t sn, uint64_t remote_addr, ucp_rkey_h rkey, bool get_info = false)
     {
         ucp_request_param_t *param = get_info ? &m_send_get_info_params :
@@ -574,7 +574,7 @@ public:
     }
 
     ucs_status_t UCS_F_ALWAYS_INLINE
-    recv(ucp_worker_h worker, ucp_ep_h ep, void *buffer, unsigned length,
+    recv(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t length,
          ucp_datatype_t datatype, psn_t sn)
     {
         void *request;
@@ -918,7 +918,7 @@ public:
 
 private:
     ucs_status_t UCS_F_ALWAYS_INLINE
-    recv_stream_data(ucp_ep_h ep, unsigned length, ucp_datatype_t datatype)
+    recv_stream_data(ucp_ep_h ep, size_t length, ucp_datatype_t datatype)
     {
         void *data;
         size_t data_length;
@@ -937,7 +937,7 @@ private:
     }
 
     ucs_status_t UCS_F_ALWAYS_INLINE
-    recv_stream(ucp_ep_h ep, void *buf, unsigned length, ucp_datatype_t datatype)
+    recv_stream(ucp_ep_h ep, void *buf, size_t length, ucp_datatype_t datatype)
     {
         ssize_t  total = 0;
         void    *rreq;

--- a/src/tools/perf/lib/uct_tests.cc
+++ b/src/tools/perf/lib/uct_tests.cc
@@ -232,7 +232,7 @@ public:
     }
 
     ucs_status_t UCS_F_ALWAYS_INLINE
-    send(uct_ep_h ep, psn_t sn, psn_t prev_sn, void *buffer, unsigned length,
+    send(uct_ep_h ep, psn_t sn, psn_t prev_sn, void *buffer, size_t length,
          uint64_t remote_addr, uct_rkey_t rkey, uct_completion_t *comp)
     {
         uint64_t am_short_hdr;
@@ -351,7 +351,7 @@ public:
     }
 
     void UCS_F_ALWAYS_INLINE
-    send_b(uct_ep_h ep, psn_t sn, psn_t prev_sn, void *buffer, unsigned length,
+    send_b(uct_ep_h ep, psn_t sn, psn_t prev_sn, void *buffer, size_t length,
            uint64_t remote_addr, uct_rkey_t rkey, uct_completion_t *comp)
     {
         ucs_status_t status;
@@ -486,7 +486,7 @@ public:
                              volatile psn_t *recv_sn,
                              ucs_memory_type_t recv_mem_type,
                              const ucx_perf_allocator_t *recv_allocator,
-                             unsigned length, unsigned peer_index)
+                             size_t length, unsigned peer_index)
     {
         unsigned long remote_addr;
         psn_t sn, send_sn;
@@ -571,7 +571,7 @@ public:
                              volatile psn_t *recv_sn,
                              ucs_memory_type_t recv_mem_type,
                              const ucx_perf_allocator_t *recv_allocator,
-                             unsigned length, unsigned peer_index)
+                             size_t length, unsigned peer_index)
     {
         unsigned long remote_addr;
         psn_t sn, send_sn;
@@ -644,7 +644,7 @@ public:
         ucs_memory_type_t recv_mem_type;
         volatile psn_t *recv_sn;
         unsigned my_index;
-        unsigned length;
+        size_t length;
         unsigned group_size;
         unsigned peer_index;
 


### PR DESCRIPTION
## What?
In perftest there were several places where `unsigned` 32b is used to represent buffer size, which is of type `size_t` in the rest of the code

## Why?
Integer overflow occurs on large message sizes > 4GB, and as a consequence perftest produces completely random results

## How?
Use `size_t` instead of `unsigned` for buffer size
