### PR TITLE
GITHUB/WORKFLOWS: Add workflow for auto-assigning reviewers based on git blame

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,39 @@
+name: Auto-Assign Reviewers
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+      - name: Run git blame analysis
+        run: |
+          # Calculate the diff between the base branch and the current commit
+          git diff origin/${{ github.event.pull_request.base.ref }} --name-only | while read file; do
+            echo "Analyzing $file"
+            git blame -e $file || echo "Error analyzing $file"
+          done > reviewers.txt
+
+      - name: Print reviewers list
+        run: cat reviewers.txt
+
+      - name: Create pull request for changes
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ github.event.pull_request.base.ref }}
+          branch: create-pull-request/patch
+          commit-message: "[create-pull-request] Automated change"
+          title: Changes by create-pull-request action
+          body: |
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action


### PR DESCRIPTION
## What?
Automatically selects reviewers for pull requests based on git blame analysis of modified lines.

## Why?
Streamlines the review process by assigning knowledgeable contributors based on recent changes.

## How?
Uses a GitHub Action triggered on pull request events to run git blame on affected files and assigns reviewers through the GitHub API.

## NOTE
The GitHub Actions bot does not have permission to push to the repository.
https://github.com/openucx/ucx/actions/runs/11852759730/job/33031546894#step:6:122

