### PR TITLE
UCS/CONFIG/PARSER: Handle NULL entries in sparse arrays

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -141,11 +141,8 @@ const char *ucp_object_versions[] = {
 };
 
 const char *ucp_extra_op_attr_flags_names[] = {
-    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_NO_IMM_CMPL)]    = "no_imm_cmpl",
     [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_FAST_CMPL)]      = "fast_cmpl",
-    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL)] = "force_imm_cmpl",
-    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_MULTI_SEND)]     = "multi_send",
-    NULL
+    [UCP_OP_ATTR_INDEX(UCP_OP_ATTR_FLAG_MULTI_SEND)]     = "multi_send"
 };
 
 const ucs_config_flags_args_t ucp_extra_op_attr_flags_args = {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -148,6 +148,11 @@ const char *ucp_extra_op_attr_flags_names[] = {
     NULL
 };
 
+const ucs_config_flags_args_t ucp_extra_op_attr_flags_args = {
+    .args        = ucp_extra_op_attr_flags_names,
+    .num_of_args = ucs_static_array_size(ucp_extra_op_attr_flags_names)
+};
+
 static UCS_CONFIG_DEFINE_ARRAY(memunit_sizes, sizeof(size_t),
                                UCS_CONFIG_TYPE_MEMUNITS);
 
@@ -544,7 +549,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "in addition to what is set explicitly by the user. \n"
    "Possible values are: no_imm_cmpl, fast_cmpl, force_imm_cmpl, multi_send.",
    ucs_offsetof(ucp_context_config_t, extra_op_attr_flags),
-   UCS_CONFIG_TYPE_BITMAP(ucp_extra_op_attr_flags_names)},
+   UCS_CONFIG_TYPE_FLAGS((const void *)&ucp_extra_op_attr_flags_args)},
 
   {NULL}
 };

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -43,14 +43,8 @@ enum {
     UCP_TL_RSC_FLAG_AUX = UCS_BIT(0)
 };
 
-#define UCP_OP_ATTR_INDEX_MASK (UCP_OP_ATTR_FLAG_NO_IMM_CMPL    | \
-                                UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL | \
-                                UCP_OP_ATTR_FLAG_FAST_CMPL      | \
-                                UCP_OP_ATTR_FLAG_MULTI_SEND)
-
 #define UCP_OP_ATTR_INDEX(_op_attr_flag) \
-    (ucs_ilog2(ucp_proto_select_op_attr_pack((_op_attr_flag), \
-                                             UCP_OP_ATTR_INDEX_MASK)))
+    (ucs_ilog2(ucp_proto_select_op_attr_pack((_op_attr_flag))))
 
 
 typedef struct ucp_context_config {

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -44,8 +44,9 @@
 
 
 /* Pack operation attributes from uint32_t to a uint8_t */
-#define ucp_proto_select_op_attr_pack(_op_attr, _mask) \
-    (((_op_attr) & (_mask)) / UCP_PROTO_SELECT_OP_ATTR_BASE)
+#define ucp_proto_select_op_attr_pack(_op_attr) \
+    (((_op_attr) & (UCP_PROTO_SELECT_OP_ATTR_MASK)) / \
+    UCP_PROTO_SELECT_OP_ATTR_BASE)
 
 
 typedef struct {

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -135,7 +135,7 @@ static UCS_F_ALWAYS_INLINE void ucp_proto_select_param_init_common(
      * supported */
     select_param->op_id_flags   = op_id | op_flags;
     select_param->op_attr       = ucp_proto_select_op_attr_pack(
-        op_attr_mask, UCP_PROTO_SELECT_OP_ATTR_MASK);
+        op_attr_mask);
     select_param->dt_class      = dt_class;
     select_param->mem_type      = mem_info->type;
     select_param->sys_dev       = mem_info->sys_dev;

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -84,7 +84,7 @@ ucp_proto_rndv_ppln_probe(const ucp_proto_init_params_t *init_params)
     sel_param.op_id_flags = ucp_proto_select_op_id(select_param) |
                             UCP_PROTO_SELECT_OP_FLAG_PPLN_FRAG;
     sel_param.op_attr     = ucp_proto_select_op_attr_pack(
-        UCP_OP_ATTR_FLAG_MULTI_SEND, UCP_PROTO_SELECT_OP_ATTR_MASK);
+        UCP_OP_ATTR_FLAG_MULTI_SEND);
 
     proto_select = ucp_proto_select_get(worker, init_params->ep_cfg_index,
                                         init_params->rkey_cfg_index,

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -132,6 +132,11 @@ typedef struct ucs_config_bw_spec {
 } ucs_config_bw_spec_t;
 
 
+typedef struct ucs_config_flags_args {
+    const char              **args;
+    size_t                  num_of_args;
+} ucs_config_flags_args_t;
+
 #define UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY \
     { \
         .name        = "", \
@@ -231,6 +236,10 @@ void ucs_config_help_uint_enum(char *buf, size_t max, const void *arg);
 int ucs_config_sscanf_bitmap(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_bitmap(char *buf, size_t max, const void *src, const void *arg);
 void ucs_config_help_bitmap(char *buf, size_t max, const void *arg);
+
+int ucs_config_sscanf_flags(const char *buf, void *dest, const void *arg);
+int ucs_config_sprintf_flags(char *buf, size_t max, const void *src, const void *arg);
+void ucs_config_help_flags(char *buf, size_t max, const void *arg);
 
 int ucs_config_sscanf_bitmask(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_bitmask(char *buf, size_t max, const void *src, const void *arg);
@@ -382,6 +391,11 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
 #define UCS_CONFIG_TYPE_BITMAP(t)  {ucs_config_sscanf_bitmap,    ucs_config_sprintf_bitmap, \
                                     ucs_config_clone_uint,       ucs_config_release_nop, \
                                     ucs_config_help_bitmap,      ucs_config_doc_nop, \
+                                    t}
+
+#define UCS_CONFIG_TYPE_FLAGS(t)   {ucs_config_sscanf_flags, ucs_config_sprintf_bitmap, \
+                                    ucs_config_clone_uint,   ucs_config_release_nop, \
+                                    ucs_config_help_flags,   ucs_config_doc_nop, \
                                     t}
 
 #define UCS_CONFIG_TYPE_BITMASK    {ucs_config_sscanf_bitmask,   ucs_config_sprintf_bitmask, \

--- a/src/ucs/sys/string.c
+++ b/src/ucs/sys/string.c
@@ -423,6 +423,25 @@ ssize_t ucs_string_find_in_list(const char *str, const char **string_list,
     return -1;
 }
 
+ssize_t ucs_string_find_in_sparse_list(const char *str, const char **string_list,
+                                       size_t num_of_args)
+{
+    size_t i;
+
+    /* Ingnores NULL entries */
+    for (i = 0; i < num_of_args; ++i) {
+        if (string_list[i] == NULL) {
+            continue;
+        }
+        if (strcmp(string_list[i], str) == 0) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+
 char* ucs_string_split(char *str, const char *delim, int count, ...)
 {
     char *p = str;

--- a/src/ucs/sys/string.h
+++ b/src/ucs/sys/string.h
@@ -324,6 +324,17 @@ const char* ucs_mask_str(uint64_t mask, ucs_string_buffer_t *strb);
 ssize_t ucs_string_find_in_list(const char *str, const char **string_list,
                                 int case_sensitive);
 
+/**
+ * Find a string in an array of strings with NULL entries.
+ *
+ * @param str          String to search for.
+ * @param string_list  Array of strings.
+ * @param num_of_args  Number of strings in the array.
+ *
+ * @return Index of the string in the array, or -1 if not found.
+ */
+ssize_t ucs_string_find_in_sparse_list(const char *str, const char **string_list,
+                                       size_t num_of_args);
 
 /**
  * Split a string to tokens. The given string is modified in-place.


### PR DESCRIPTION
## What?
Following https://github.com/openucx/ucx/pull/10172
Introduced `UCS_CONFIG_TYPE_FLAGS` to support sparse parsing of configuration flags.
Removed unnecessary flags from `UCX_EXTRA_OP_ATTR_FLAGS`.

## Why?
UCS_CONFIG_TYPE_BITMAP required contiguous indices, leading to core dumps when NULL values were accessed due to gaps in the array.
UCS_CONFIG_TYPE_FLAGS enables sparse arrays for flags, eliminating the need for unnecessary placeholders and simplifying the flag configuration.

## How?
Implemented `UCS_CONFIG_TYPE_FLAGS` to loop until the specified number of arguments instead of relying on NULL-terminated arrays.