### PR TITLE
TEST: Cleanup tests that were skipped during init() on TeadDown

### DIFF
--- a/test/gtest/common/test.cc
+++ b/test/gtest/common/test.cc
@@ -342,7 +342,7 @@ void test_base::TearDownProxy() {
 
     watchdog_signal();
 
-    if (m_initialized) {
+    if (m_initialized || (m_state == SKIPPED)) {
         cleanup();
     }
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -879,7 +879,6 @@ public:
         modify_config("RNDV_PIPELINE_ERROR_HANDLING", "y");
         test_ucp_peer_failure_rndv_abort::init();
         if (!sender().is_rndv_put_ppln_supported()) {
-            cleanup();
             UCS_TEST_SKIP_R("RNDV pipeline is not supported");
         }
     }

--- a/test/gtest/ucp/test_ucp_tag.cc
+++ b/test/gtest/ucp/test_ucp_tag.cc
@@ -180,7 +180,6 @@ void test_ucp_tag::check_offload_support(bool offload_required)
     bool offload_supported = ucp_ep_config_key_has_tag_lane(
                                &ucp_ep_config(sender().ep())->key);
     if (offload_supported != offload_required) {
-        cleanup();
         std::string reason = offload_supported ? "tag offload" : "no tag offload";
         UCS_TEST_SKIP_R(reason);
     }

--- a/test/gtest/uct/ib/test_cqe_zipping.cc
+++ b/test/gtest/uct/ib/test_cqe_zipping.cc
@@ -75,7 +75,6 @@ public:
         test_uct_ib::init();
 
         if (!check_cqe_zip_caps()) {
-            cleanup();
             UCS_TEST_SKIP_R("unsupported");
         }
 


### PR DESCRIPTION
## What?
Enable cleanup() in TearDownProxy for tests that were skipped during initialization.

## Why?
To avoid need to call cleanup() in each test before skip if it was skipped in init()
