### PR TITLE
UCP/RNDV/RCACHE: Don't use rcache for RNDV frag mpool

### DIFF
--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -39,6 +39,11 @@ enum {
     UCP_MEMH_FLAG_IMPORTED     = UCS_BIT(0),
     UCP_MEMH_FLAG_MLOCKED      = UCS_BIT(1),
     UCP_MEMH_FLAG_HAS_AUTO_GVA = UCS_BIT(2),
+
+    /**
+     * Avoid using registration cache for the particular memory region.
+     */
+    UCP_MEMH_FLAG_NO_RCACHE    = UCS_BIT(3)
 };
 
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -1025,6 +1025,16 @@ UCS_TEST_P(test_ucp_mmap, gva, "GVA_ENABLE=y")
     }
 }
 
+UCS_TEST_P(test_ucp_mmap, rndv_mpool_mdesc_no_rcache)
+{
+    ucp_worker_h worker = sender().worker();
+    for (auto mem_type : mem_buffer::supported_mem_types()) {
+        ucp_mem_desc_t *mdesc = ucp_rndv_mpool_get(worker, mem_type,
+                                                   UCS_SYS_DEVICE_ID_UNKNOWN);
+        EXPECT_EQ(mdesc->memh, mdesc->memh->parent);
+        ucs_mpool_put(mdesc);
+    }
+}
 
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_mmap)
 


### PR DESCRIPTION
## What?
This is an auxiliary PR to introduce new invalidation design in UCX. The aim is to avoid using rcache for RNDV fragment memory pool

## Why?
RNDV fragment memory pool is created on demand and remains allocated during the application lifetime. Rcache is desirable for this use case, because:
1) does not bring any benefits
2) can be harmful in case of merging with other parent regions
3) redundant memory usage for parent memh

## How?
Introduce new UCP memh flag NO_RCACHE