### PR TITLE
UCT/GDRCOPY: rcache lookup overhead config variable

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -3,10 +3,9 @@ CPU model=Grace
 UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed
 UCX_IB_ODP_MEM_TYPES=host,cuda-managed
 UCX_IB_MLX5_DEVX_OBJECTS=
-UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBs
-# Real latency is around 30ns, rest is gdrcopy rcache overhead
-# TODO: Add gdrcopy rcache overhead as separate performance graph node
-UCX_GDR_COPY_LAT=200ns
+UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBsn
+UCX_GDR_COPY_LAT=30ns
+UCX_GDR_COPY_RCACHE_OVERHEAD=170ns
 UCX_DISTANCE_BW=auto,sys:16500MBs
 UCX_CUDA_COPY_ASYNC_MEM_TYPE=cuda
 
@@ -27,10 +26,6 @@ UCX_DISTANCE_BW=auto,sys:5100MBs
 [AMD Milan]
 CPU model=Milan
 UCX_DISTANCE_BW=auto,sys:5100MBs
-# Real latencies are around 1.4 and 0.4, rest is gdrcopy rcache overhead
-# TODO: Add gdrcopy rcache overhead as separate performance graph node
-# TODO: Add rcache overhead not only for Milan and GH systems
-UCX_GDR_COPY_LAT=get:1.65e-6,put:0.65e-6
 
 [AMD Genoa]
 CPU model=Genoa

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.h
@@ -20,6 +20,7 @@ typedef struct uct_gdr_copy_iface {
         uct_ppn_bandwidth_t   put_bw;
         ucs_linear_func_t     get_latency;
         ucs_linear_func_t     put_latency;
+        double                rcache_ovh;
     } config;
 } uct_gdr_copy_iface_t;
 
@@ -30,6 +31,7 @@ typedef struct uct_gdr_copy_iface_config {
     uct_ppn_bandwidth_t put_bw;
     double              get_latency;
     double              put_latency;
+    double              rcache_overhead;
 } uct_gdr_copy_iface_config_t;
 
 #endif


### PR DESCRIPTION
## What?
Create config variable for gdrcopy lookup overhead

## Why?
Now this overhead is mixed together with latency variable
