### PR TITLE
BINDINGS/GO/PERF: Implement flag.Value for UcsMemoryType

### DIFF
--- a/bindings/go/src/examples/perftest/perftest.go
+++ b/bindings/go/src/examples/perftest/perftest.go
@@ -368,17 +368,7 @@ func main() {
 	flag.StringVar(&perfTestParams.ip, "i", "", "server address to connect")
 
 	perfTestParams.memType = UCS_MEMORY_TYPE_HOST
-	flag.CommandLine.Func("m", "memory type: host(default), cuda", func(p string) error {
-		mtypeStr := strings.ToLower(p)
-		if mtypeStr == "host" {
-			perfTestParams.memType = UCS_MEMORY_TYPE_HOST
-		} else if mtypeStr == "cuda" {
-			perfTestParams.memType = UCS_MEMORY_TYPE_CUDA
-		} else {
-			return errors.New("memory type can be host or cuda")
-		}
-		return nil
-	})
+	flag.Var(&perfTestParams.memType, "m", "memory type: host(default), cuda")
 
 	flag.Parse()
 

--- a/bindings/go/src/ucx/ucs_constants.c
+++ b/bindings/go/src/ucx/ucs_constants.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#include "ucs_constants.h"
+
+#include <ucs/sys/string.h>
+#include <stdlib.h>
+
+const char* ucxgo_get_ucs_mem_type_name(ucs_memory_type_t idx) {
+    return ucs_memory_type_names[idx];
+}
+
+ssize_t ucxgo_parse_ucs_mem_type_name(void* value) {
+    ssize_t idx = ucs_string_find_in_list((const char *)value, ucs_memory_type_names, 0);
+    free(value);
+    return idx;
+}

--- a/bindings/go/src/ucx/ucs_constants.go
+++ b/bindings/go/src/ucx/ucs_constants.go
@@ -5,11 +5,13 @@
 
 package ucx
 
+//#include "ucs_constants.h"
 //#include <ucp/api/ucp.h>
-//static inline const char* ucxgo_get_ucs_mem_type_name(ucs_memory_type_t idx) {
-//    return ucs_memory_type_names[idx];
-//}
 import "C"
+import (
+	"errors"
+	"unsafe"
+)
 
 type UcsThreadMode int
 
@@ -32,6 +34,16 @@ const (
 
 func (m UcsMemoryType) String() string {
 	return C.GoString(C.ucxgo_get_ucs_mem_type_name(C.ucs_memory_type_t(m)))
+}
+
+func (m *UcsMemoryType) Set (value string) error {
+	cValue := unsafe.Pointer(C.CString(value))
+	res := C.ucxgo_parse_ucs_mem_type_name(cValue)
+	if res == -1 {
+		return errors.New("memory type can be either host or cuda")
+	}
+	*m = UcsMemoryType(res)
+	return nil
 }
 
 // Checks whether context's memory type mask

--- a/bindings/go/src/ucx/ucs_constants.h
+++ b/bindings/go/src/ucx/ucs_constants.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+#ifndef GO_UCS_CONSTANTS_H_
+#define GO_UCS_CONSTANTS_H_
+
+#include <ucs/memory/memory_type.h>
+#include <sys/types.h>
+
+const char* ucxgo_get_ucs_mem_type_name(ucs_memory_type_t idx);
+ssize_t ucxgo_parse_ucs_mem_type_name(void* value);
+
+#endif


### PR DESCRIPTION
## What?
Implement `flag.Value` interface for `ucx.UcsMemoryType` and use `flag.Var` function to set `-m` argument.

## Why?
For enums, `flag.Value`/`flag.Var` is the better choice because it promotes good software design principles like type safety, reusability, and clean separation of concerns.