### PR TITLE
UCP/TEST/TAG: Fix the limit on number of endpoint lanes

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -230,6 +230,10 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Maximal number of devices on which a RMA operation may be executed in parallel",
    ucs_offsetof(ucp_context_config_t, max_rma_lanes), UCS_CONFIG_TYPE_UINT},
 
+  {"EP_MAX_LANES", UCS_PP_MAKE_STRING(UCP_MAX_LANES),
+   "Maximal number of lanes per endpoint",
+   ucs_offsetof(ucp_context_config_t, ep_max_lanes), UCS_CONFIG_TYPE_UINT},
+
   {"MIN_RNDV_CHUNK_SIZE", "16k",
    "Minimum chunk size to split the message sent with rendezvous protocol on\n"
    "multiple rails. Must be greater than 0.",

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -122,6 +122,8 @@ typedef struct ucp_context_config {
     unsigned                               max_rndv_lanes;
     /** RMA multi-lane support */
     unsigned                               max_rma_lanes;
+    /** Limit number of lanes for an endpoint */
+    unsigned                               ep_max_lanes;
     /** Minimum allowed chunk size when splitting rndv message over multiple
      *  lanes */
     size_t                                 min_rndv_chunk_size;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -362,20 +362,23 @@ ucp_wireup_init_select_info(double score, unsigned addr_index,
     select_info->priority   = priority;
 }
 
-static size_t
+static unsigned
 ucp_wireup_bw_max_lanes(const ucp_wireup_select_params_t *select_params)
 {
     return (select_params->address->dst_version < 18) ? UCP_MAX_LANES_LEGACY :
                                                         UCP_MAX_LANES;
 }
 
-static size_t
+static unsigned
 ucp_wireup_max_lanes(const ucp_wireup_select_params_t *select_params,
                      ucp_lane_type_t lane_type)
 {
-    return ucp_wireup_lane_type_is_fast_path(lane_type) ?
-                   UCP_MAX_FAST_PATH_LANES :
-                   ucp_wireup_bw_max_lanes(select_params);
+    ucp_worker_h worker = select_params->ep->worker;
+
+    return ucs_min(worker->context->config.ext.ep_max_lanes,
+                   ucp_wireup_lane_type_is_fast_path(lane_type) ?
+                           UCP_MAX_FAST_PATH_LANES :
+                           ucp_wireup_bw_max_lanes(select_params));
 }
 
 /**

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -2933,9 +2933,8 @@ public:
     {
         m_err_count = 0;
 
-        // Set number of Eager/RNDV lanes to be 1 to create only 1 UCT endpoint
-        modify_config("MAX_EAGER_LANES", "1");
-        modify_config("MAX_RNDV_LANES", "1");
+        // Set number of lanes to be 1 to create only 1 UCT endpoint
+        modify_config("EP_MAX_LANES", "1");
 
         modify_config("RNDV_THRESH", "0");
 

--- a/test/gtest/ucp/test_ucp_tag_offload.cc
+++ b/test/gtest/ucp/test_ucp_tag_offload.cc
@@ -474,8 +474,7 @@ public:
         // The test checks that increase of active ifaces is handled
         // correctly. It needs to start with a single active iface, therefore
         // disable multi-rail.
-        modify_config("MAX_EAGER_LANES", "1");
-        modify_config("MAX_RNDV_LANES",  "1");
+        modify_config("EP_MAX_LANES", "1");
 
         test_ucp_tag_offload::init();
 


### PR DESCRIPTION
## Why
Fix the following CI failure:

```
$ taskset -c 2,3 make -C test/gtest test GTEST_FILTER=all_rcdc/test_ucp_tag_offload_multi.recv_from_multi/0
...
[     INFO ] ugni is not available
[     INFO ] ugni,cuda_copy,rocm_copy is not available
[     INFO ] Using random seed of 4577
Note: Google Test filter = all_rcdc/test_ucp_tag_offload_multi.recv_from_multi/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from all_rcdc/test_ucp_tag_offload_multi
[ RUN      ] all_rcdc/test_ucp_tag_offload_multi.recv_from_multi/0 <rc,dc>
/.autodirect/rdmzsysgwork/yosefe/ucx/test/gtest/ucp/test_ucp_tag_offload.cc:556: Failure
Expected equality of these values:
  0u
    Which is: 0
  ((&receiver().worker()->tm.offload.tag_hash)->size)
    Which is: 1
/.autodirect/rdmzsysgwork/yosefe/ucx/test/gtest/ucp/test_ucp_tag_offload.cc:562: Failure
Expected equality of these values:
  1u
    Which is: 1
  ((&receiver().worker()->tm.offload.tag_hash)->size)
    Which is: 2
[  FAILED  ] all_rcdc/test_ucp_tag_offload_multi.recv_from_multi/0, where GetParam() = rc,dc (2278 ms)
[----------] 1 test from all_rcdc/test_ucp_tag_offload_multi (2278 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2280 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] all_rcdc/test_ucp_tag_offload_multi.recv_from_multi/0, where GetParam() = rc,dc

 1 FAILED TEST
```

## How
To make the tag offload multi test pass, we must limit the number of lanes on an endpoint to 1. Just limiting the number of eager and rendezvous lanes is not enough, since different lanes could be selected for eager and rendezvous protocols.
We add a new configuration parameter to also limit the total lanes on and endpoint.