### PR TITLE
UCP/WIREUP: Consider EP priority in iface score calculation

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -68,6 +68,8 @@
 #define UCP_TL_AUX_SUFFIX    "aux"
 #define UCP_TL_AUX(_tl_name) _tl_name ":" UCP_TL_AUX_SUFFIX
 
+/* Factor to multiply with in order to get infinite latency */
+#define UCP_CONTEXT_INFINITE_LAT_FACTOR 100
 
 typedef enum ucp_transports_list_search_result {
     UCP_TRANSPORTS_LIST_SEARCH_RESULT_PRIMARY      = UCS_BIT(0),
@@ -545,6 +547,12 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Possible values are: no_imm_cmpl, fast_cmpl, force_imm_cmpl, multi_send.",
    ucs_offsetof(ucp_context_config_t, extra_op_attr_flags),
    UCS_CONFIG_TYPE_BITMAP(ucp_extra_op_attr_flags_names)},
+
+  {"MAX_PRIORITY_EPS", "20",
+   "Max number of prioritized endpoints. Does not affect semantics,\n"
+   "but only transport selection criteria and resulting performance.",
+   ucs_offsetof(ucp_context_config_t, max_priority_eps),
+   UCS_CONFIG_TYPE_UINT},
 
   {NULL}
 };
@@ -2585,6 +2593,28 @@ const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx)
 {
     ucs_assert(cm_idx != UCP_NULL_RESOURCE);
     return context->tl_cmpts[context->config.cm_cmpt_idxs[cm_idx]].attr.name;
+}
+
+double ucp_tl_iface_latency_with_priority(ucp_context_h context,
+                                          const ucs_linear_func_t *latency,
+                                          int is_prioritized_ep)
+{
+    unsigned num_eps = context->config.est_num_eps;
+
+    if (ucp_context_usage_tracker_enabled(context)) {
+        if (is_prioritized_ep) {
+            /* The number of priority endpoints is limited by
+             * max_priority_eps */
+            num_eps = ucs_min(num_eps, context->config.ext.max_priority_eps);
+        } else if (latency->m > UCP_PROTO_PERF_EPSILON) {
+            /* If the transport is not scalable, assume a high number of
+             * endpoints */
+            num_eps = ucs_max(num_eps, context->config.ext.max_priority_eps *
+                                               UCP_CONTEXT_INFINITE_LAT_FACTOR);
+        }
+    }
+
+    return ucs_linear_func_apply(*latency, num_eps);
 }
 
 UCS_F_CTOR void ucp_global_init(void)

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -203,6 +203,8 @@ typedef struct ucp_context_config {
     double                                 rcache_overhead;
     /** UCP extra operation attributes flags */
     uint64_t                               extra_op_attr_flags;
+    /* Upper limit to the amount of prioritized endpoints */
+    unsigned                               max_priority_eps;
 } ucp_context_config_t;
 
 
@@ -602,6 +604,10 @@ const char* ucp_feature_flags_str(unsigned feature_flags, char *str,
 void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
                                 size_t length, ucs_memory_info_t *mem_info);
 
+double ucp_tl_iface_latency_with_priority(ucp_context_h context,
+                                          const ucs_linear_func_t *latency,
+                                          int is_prioritized_ep);
+
 /**
  * Calculate a small value to overcome float imprecision
  * between two float values
@@ -646,7 +652,7 @@ int ucp_is_scalable_transport(ucp_context_h context, size_t max_num_eps)
 static UCS_F_ALWAYS_INLINE double
 ucp_tl_iface_latency(ucp_context_h context, const ucs_linear_func_t *latency)
 {
-    return ucs_linear_func_apply(*latency, context->config.est_num_eps);
+    return ucp_tl_iface_latency_with_priority(context, latency, 0);
 }
 
 static UCS_F_ALWAYS_INLINE double

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -794,7 +794,7 @@ ucp_address_pack_iface_attr_v2(const ucp_worker_iface_t *wiface, void *ptr,
     double latency_nsec, overhead_nsec, latency, bandwidth;
     size_t seg_size;
 
-    latency   = ucp_wireup_iface_lat_distance_v2(wiface);
+    latency   = ucp_wireup_iface_lat_distance_v2(wiface, 0);
     bandwidth = ucp_wireup_iface_bw_distance(wiface);
 
     latency_nsec  = latency * UCS_NSEC_PER_SEC;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -607,7 +607,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             }
 
             score        = criteria->calc_score(wiface, md_attr, address, ae,
-                                                criteria->arg);
+                                                0, criteria->arg);
             priority     = iface_attr->priority + ae->iface_attr.priority;
             is_reachable = 1;
 
@@ -664,18 +664,21 @@ out:
 static inline double
 ucp_wireup_tl_iface_latency(const ucp_worker_iface_t *wiface,
                             const ucp_unpacked_address_t *unpacked_addr,
-                            const ucp_address_iface_attr_t *remote_iface_attr)
+                            const ucp_address_iface_attr_t *remote_iface_attr,
+                            int is_prioritized_ep)
 {
-    ucp_context_h context = wiface->worker->context;
+    ucp_context_h context    = wiface->worker->context;
+    ucs_linear_func_t lat_v1 = {0, wiface->attr.latency.m};
     double local_lat, lat_lossy;
 
     if (unpacked_addr->addr_version == UCP_OBJECT_VERSION_V1) {
         local_lat = ucp_wireup_iface_lat_distance_v1(wiface);
         /* Address v1 contains just latency overhead */
-        return ((local_lat + remote_iface_attr->lat_ovh) / 2) +
-               (wiface->attr.latency.m * context->config.est_num_eps);
+        lat_v1.c  = (local_lat + remote_iface_attr->lat_ovh) / 2;
+        return ucp_tl_iface_latency_with_priority(context, &lat_v1,
+                                                  is_prioritized_ep);
     } else {
-        local_lat = ucp_wireup_iface_lat_distance_v2(wiface);
+        local_lat = ucp_wireup_iface_lat_distance_v2(wiface, is_prioritized_ep);
         /* FP8 is a lossy compression method, so in order to create a symmetric
          * calculation we pack/unpack the local latency as well */
         lat_lossy = ucp_wireup_fp8_pack_unpack_latency(local_lat);
@@ -988,7 +991,7 @@ static double ucp_wireup_rma_score_func(const ucp_worker_iface_t *wiface,
                                         const uct_md_attr_v2_t *md_attr,
                                         const ucp_unpacked_address_t *unpacked_addr,
                                         const ucp_address_entry_t *remote_addr,
-                                        void *arg)
+                                        int is_prioritized_ep, void *arg)
 {
     /* best for 4k messages */
     double local_bw;
@@ -1002,7 +1005,8 @@ static double ucp_wireup_rma_score_func(const ucp_worker_iface_t *wiface,
 
     return 1e-3 /
            (ucp_wireup_tl_iface_latency(
-                wiface, unpacked_addr, &remote_addr->iface_attr) +
+                wiface, unpacked_addr, &remote_addr->iface_attr,
+                is_prioritized_ep) +
             wiface->attr.overhead +
             (4096.0 / ucs_min(local_bw, remote_addr->iface_attr.bandwidth)));
 }
@@ -1022,12 +1026,13 @@ static double ucp_wireup_aux_score_func(const ucp_worker_iface_t *wiface,
                                         const uct_md_attr_v2_t *md_attr,
                                         const ucp_unpacked_address_t *unpacked_addr,
                                         const ucp_address_entry_t *remote_addr,
-                                        void *arg)
+                                        int is_prioritized_ep, void *arg)
 {
     /* best end-to-end latency and larger bcopy size */
     return (1e-3 /
             (ucp_wireup_tl_iface_latency(
-                wiface, unpacked_addr,  &remote_addr->iface_attr) +
+                 wiface, unpacked_addr, &remote_addr->iface_attr,
+                 is_prioritized_ep) +
              wiface->attr.overhead + remote_addr->iface_attr.overhead));
 }
 
@@ -1170,12 +1175,13 @@ double ucp_wireup_amo_score_func(const ucp_worker_iface_t *wiface,
                                  const uct_md_attr_v2_t *md_attr,
                                  const ucp_unpacked_address_t *unpacked_addr,
                                  const ucp_address_entry_t *remote_addr,
-                                 void *arg)
+                                 int is_prioritized_ep, void *arg)
 {
     /* best one-sided latency */
     return 1e-3 /
            (ucp_wireup_tl_iface_latency(
-                wiface, unpacked_addr, &remote_addr->iface_attr) +
+                wiface, unpacked_addr, &remote_addr->iface_attr,
+                is_prioritized_ep) +
             wiface->attr.overhead);
 }
 
@@ -1228,12 +1234,14 @@ static double
 ucp_wireup_am_score_func(const ucp_worker_iface_t *wiface,
                          const uct_md_attr_v2_t *md_attr,
                          const ucp_unpacked_address_t *unpacked_addr,
-                         const ucp_address_entry_t *remote_addr, void *arg)
+                         const ucp_address_entry_t *remote_addr,
+                         int is_prioritized_ep, void *arg)
 {
     /* best end-to-end latency */
     return 1e-3 /
            (ucp_wireup_tl_iface_latency(
-                wiface, unpacked_addr, &remote_addr->iface_attr) +
+                wiface, unpacked_addr, &remote_addr->iface_attr,
+                is_prioritized_ep) +
             wiface->attr.overhead + remote_addr->iface_attr.overhead);
 }
 
@@ -1327,7 +1335,8 @@ static double
 ucp_wireup_rma_bw_score_func(const ucp_worker_iface_t *wiface,
                              const uct_md_attr_v2_t *md_attr,
                              const ucp_unpacked_address_t *unpacked_addr,
-                             const ucp_address_entry_t *remote_addr, void *arg)
+                             const ucp_address_entry_t *remote_addr,
+                             int is_prioritized_ep, void *arg)
 {
     ucp_wireup_dev_usage_count *dev_count = arg;
     ucp_context_t *context                = wiface->worker->context;
@@ -1342,7 +1351,8 @@ ucp_wireup_rma_bw_score_func(const ucp_worker_iface_t *wiface,
                  ucp_wireup_iface_avail_bandwidth(wiface, unpacked_addr,
                                                   remote_addr, dev_count)) +
                 ucp_wireup_tl_iface_latency(wiface, unpacked_addr,
-                                            &remote_addr->iface_attr) +
+                                            &remote_addr->iface_attr,
+                                            is_prioritized_ep) +
                 wiface->attr.overhead +
                 ucs_linear_func_apply(mem_reg_cost,
                                       UCP_WIREUP_RMA_BW_TEST_MSG_SIZE));
@@ -1467,7 +1477,8 @@ static double
 ucp_wireup_am_bw_score_func(const ucp_worker_iface_t *wiface,
                             const uct_md_attr_v2_t *md_attr,
                             const ucp_unpacked_address_t *unpacked_addr,
-                            const ucp_address_entry_t *remote_addr, void *arg)
+                            const ucp_address_entry_t *remote_addr,
+                            int is_prioritized_ep, void *arg)
 {
     ucp_wireup_dev_usage_count *dev_count = arg;
 
@@ -1480,7 +1491,8 @@ ucp_wireup_am_bw_score_func(const ucp_worker_iface_t *wiface,
                             wiface, unpacked_addr, remote_addr, dev_count)) +
                   wiface->attr.overhead + remote_addr->iface_attr.overhead +
                   ucp_wireup_tl_iface_latency(wiface, unpacked_addr,
-                                              &remote_addr->iface_attr);
+                                              &remote_addr->iface_attr,
+                                              is_prioritized_ep);
 
     return size / t * 1e-5;
 }
@@ -2106,7 +2118,7 @@ ucp_wireup_keepalive_score_func(const ucp_worker_iface_t *wiface,
                                 const uct_md_attr_v2_t *md_attr,
                                 const ucp_unpacked_address_t *unpacked_addr,
                                 const ucp_address_entry_t *remote_addr,
-                                void *arg)
+                                int is_prioritized_ep, void *arg)
 {
     uct_perf_attr_t perf_attr;
     ucs_status_t status;
@@ -2122,7 +2134,8 @@ ucp_wireup_keepalive_score_func(const ucp_worker_iface_t *wiface,
         return 0;
     }
 
-    return ucp_wireup_am_score_func(wiface, md_attr, unpacked_addr, remote_addr, arg) *
+    return ucp_wireup_am_score_func(wiface, md_attr, unpacked_addr, remote_addr,
+                                    is_prioritized_ep, arg) *
            ((double)perf_attr.max_inflight_eps / (double)SIZE_MAX);
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -2075,7 +2075,8 @@ double ucp_wireup_iface_lat_distance_v1(const ucp_worker_iface_t *wiface)
         wiface->attr.latency.c;
 }
 
-double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface)
+double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface,
+                                        int is_prioritized_ep)
 {
     ucp_context_h context = wiface->worker->context;
     ucs_linear_func_t lat = wiface->attr.latency;
@@ -2083,7 +2084,7 @@ double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface)
     if (context->config.ext.proto_enable) {
         lat.c += wiface->distance.latency;
     }
-    return ucp_tl_iface_latency(context, &lat);
+    return ucp_tl_iface_latency_with_priority(context, &lat, is_prioritized_ep);
 }
 
 double ucp_wireup_iface_bw_distance(const ucp_worker_iface_t *wiface)

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -88,11 +88,13 @@ typedef struct {
     /**
      * Calculates score of a potential transport.
      *
-     * @param [in]  wiface        UCP worker iface.
-     * @param [in]  md_attr       Local MD attributes.
-     * @param [in]  unpacked_addr The whole remote address unpacked.
-     * @param [in]  remote_addr   Remote transport address info and attributes.
-     * @param [in]  arg           Custom argument.
+     * @param [in]  wiface            UCP worker iface.
+     * @param [in]  md_attr           Local MD attributes.
+     * @param [in]  unpacked_addr     The whole remote address unpacked.
+     * @param [in]  remote_addr       Remote transport address info and
+     *                                attributes.
+     * @param [in]  is_prioritized_ep Endpoint is prioritized.
+     * @param [in]  arg               Custom argument.
      *
      * @return Transport score, the higher the better.
      */
@@ -100,6 +102,7 @@ typedef struct {
                                               const uct_md_attr_v2_t *md_attr,
                                               const ucp_unpacked_address_t *unpacked_addr,
                                               const ucp_address_entry_t *remote_addr,
+                                              int is_prioritized_ep,
                                               void *arg);
 
     /* Custom argument of @a calc_score function */
@@ -155,7 +158,7 @@ double ucp_wireup_amo_score_func(const ucp_worker_iface_t *wiface,
                                  const uct_md_attr_v2_t *md_attr,
                                  const ucp_unpacked_address_t *unpacked_address,
                                  const ucp_address_entry_t *remote_addr,
-                                 void *arg);
+                                 int is_prioritized_ep, void *arg);
 
 size_t ucp_wireup_msg_pack(void *dest, void *arg);
 
@@ -214,7 +217,8 @@ unsigned ucp_wireup_eps_progress(void *arg);
 
 double ucp_wireup_iface_lat_distance_v1(const ucp_worker_iface_t *wiface);
 
-double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface);
+double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface,
+                                        int is_prioritized_ep);
 
 double ucp_wireup_iface_bw_distance(const ucp_worker_iface_t *wiface);
 


### PR DESCRIPTION
## What?
Consider EP priority in iface score calculation.

## Why?
Prioritize RC over DC for promoted EPs in selection process.

## How?
1) Add is_prioritized flag to score funcion callback.
2) Set est_num_eps to small number if EP is prioritized (in order to get better latency and thus select this EP).