### PR TITLE
UCT/SELF: Remove device address from is_reachable

### DIFF
--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -148,7 +148,8 @@ uct_self_iface_is_reachable_v2(const uct_iface_h tl_iface,
     const uct_self_iface_t *iface = ucs_derived_of(tl_iface, uct_self_iface_t);
     const uct_self_iface_addr_t *addr;
 
-    if (!uct_iface_is_reachable_params_addrs_valid(params)) {
+    if (!uct_iface_is_reachable_params_valid(
+                params, UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR)) {
         return 0;
     }
 
@@ -164,7 +165,8 @@ uct_self_iface_is_reachable_v2(const uct_iface_h tl_iface,
                 iface->id, *addr);
         return 0;
     }
-    return uct_iface_scope_is_reachable(tl_iface, params);
+
+    return 1;
 }
 
 static void uct_self_iface_sendrecv_am(uct_self_iface_t *iface, uint8_t am_id,


### PR DESCRIPTION
## What?
Don't check for device flag + don't call `uct_iface_scope_is_reachable`

## Why?
Device address is not relevant for `self` transport.
