### PR TITLE
RELEASE: Mark NEWS for 1.18.0-rc1 as TBD for now

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@
 ### Features:
 ### Bugfixes:
 
+## 1.18.0-rc1 (November 26, 2024)
+### Features: TBD
+### Bugfixes: TBD
+
 ## 1.17.0 (June 13, 2024)
 ### Features:
 #### UCP


### PR DESCRIPTION
## What?
Add empty v1.18.0.rc1 section for now.