### PR TITLE
UCT: Derived memh

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -844,6 +844,17 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_GVA                  = UCS_BIT(11),
 
     /**
+     * Register a memory window: a shallow copy of some existing UCT memory
+     * handle, which can be used to access the same memory region. When created,
+     * the memory window inherits the original memh access flags and state, and
+     * takes ownership of the indirect keys of the original memory handle. The
+     * lifetime of the memory window is bound to the original memh, and the
+     * original memh cannot be destroyed until all its memory windows are
+     * destroyed.
+     */
+    UCT_MD_MEM_WINDOW               = UCS_BIT(12),
+
+    /**
      * Enable local and remote access for all operations.
      */
     UCT_MD_MEM_ACCESS_ALL           = (UCT_MD_MEM_ACCESS_REMOTE_PUT |

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -844,17 +844,6 @@ enum uct_md_mem_flags {
     UCT_MD_MEM_GVA                  = UCS_BIT(11),
 
     /**
-     * Register a memory window: a shallow copy of some existing UCT memory
-     * handle, which can be used to access the same memory region. When created,
-     * the memory window inherits the original memh access flags and state, and
-     * takes ownership of the indirect keys of the original memory handle. The
-     * lifetime of the memory window is bound to the original memh, and the
-     * original memh cannot be destroyed until all its memory windows are
-     * destroyed.
-     */
-    UCT_MD_MEM_WINDOW               = UCS_BIT(12),
-
-    /**
      * Enable local and remote access for all operations.
      */
     UCT_MD_MEM_ACCESS_ALL           = (UCT_MD_MEM_ACCESS_REMOTE_PUT |

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -225,7 +225,8 @@ typedef struct {
 typedef enum {
     UCT_MD_MEM_REG_FIELD_FLAGS         = UCS_BIT(0),
     UCT_MD_MEM_REG_FIELD_DMABUF_FD     = UCS_BIT(1),
-    UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET = UCS_BIT(2)
+    UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET = UCS_BIT(2),
+    UCT_MD_MEM_REG_FIELD_MEMH          = UCS_BIT(3)
 } uct_md_mem_reg_field_mask_t;
 
 
@@ -490,6 +491,13 @@ typedef struct uct_md_mem_reg_params {
      * dmabuf region, then this field must be omitted or set to 0.
      */
     size_t                       dmabuf_offset;
+
+    /**
+     * Represents a pointer to the existing memory handle.
+     * Used to create a memory window is (with flag @ref UCT_MD_MEM_WINDOW)
+     * based on this original memh.
+     */
+    uct_mem_h                    memh;
 } uct_md_mem_reg_params_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1027,7 +1027,12 @@ typedef enum {
     /**
      * Memory domain performs memory type related copy operations.
      */
-    UCT_MD_FLAG_MEMTYPE_COPY   = UCS_BIT(13)
+    UCT_MD_FLAG_MEMTYPE_COPY   = UCS_BIT(13),
+
+    /**
+     * Memory domain supports derived memory handle registration.
+     */
+    UCT_MD_FLAG_DERIVED        = UCS_BIT(14)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1032,7 +1032,7 @@ typedef enum {
     /**
      * Memory domain supports derived memory handle registration.
      */
-    UCT_MD_FLAG_DERIVED        = UCS_BIT(14)
+    UCT_MD_FLAG_REG_DERIVED    = UCS_BIT(14)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -493,14 +493,14 @@ typedef struct uct_md_mem_reg_params {
     size_t                       dmabuf_offset;
 
     /**
-     * Represents a pointer to the existing memory handle.
-     * Used to register a derived memory handle: a shallow copy of existing UCT
-     * memory handle, which can be used to access the same memory region. When
-     * created, the derived memh inherits the original memh access flags and
-     * state. The lifetime of the derived memh is bound to the original memh,
-     * and the original memh cannot be destroyed until all its derived handles
-     * are destroyed. The derived memh cannot be used to register another
-     * derived memh.
+     * A pointer to an existing memory handle.
+     * Used to register a derived memh: a shallow copy of an existing UCT memh
+     * which can be used to access the same memory region. When created, the
+     * derived memh inherits the access flags and the state of the original
+     * memh. The lifetime of the derived memh is bound to the original memh.
+     * The original memh cannot be destroyed until all its derived handles have
+     * been destroyed. A derived memh cannot be used to register another derived
+     * memh.
      */
     uct_mem_h                    memh;
 } uct_md_mem_reg_params_t;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -494,8 +494,13 @@ typedef struct uct_md_mem_reg_params {
 
     /**
      * Represents a pointer to the existing memory handle.
-     * Used to create a memory window is (with flag @ref UCT_MD_MEM_WINDOW)
-     * based on this original memh.
+     * Used to register a derived memory handle: a shallow copy of existing UCT
+     * memory handle, which can be used to access the same memory region. When
+     * created, the derived memh inherits the original memh access flags and
+     * state. The lifetime of the derived memh is bound to the original memh,
+     * and the original memh cannot be destroyed until all its derived handles
+     * are destroyed. The derived memh cannot be used to register another
+     * derived memh.
      */
     uct_mem_h                    memh;
 } uct_md_mem_reg_params_t;

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -642,6 +642,8 @@ ucs_status_t uct_md_dummy_mem_reg(uct_md_h md, void *address, size_t length,
                                   const uct_md_mem_reg_params_t *params,
                                   uct_mem_h *memh_p)
 {
+    UCT_CHECK_NOT_DERIVED_MEMH(params, "uct_md");
+
     /* We have to emulate memory registration. Return dummy pointer */
     *memh_p = (void*)0xdeadbeef;
     return UCS_OK;

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -58,6 +58,11 @@
         } \
     }
 
+#define UCT_CHECK_NOT_DERIVED_MEMH(_params, _name) \
+    UCT_CHECK_PARAM( \
+        UCT_MD_MEM_REG_FIELD_VALUE(_params, memh, FIELD_MEMH, NULL) == NULL, \
+        _name " does not support derived memory handles");
+
 
 extern const char *uct_device_type_names[];
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -414,11 +414,11 @@ static ucs_status_t
 uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
-    unsigned flags = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0);
+    uct_mem_h base = UCT_MD_MEM_REG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL);
     uct_cuda_ipc_memh_t *memh;
 
-    if (ENABLE_PARAMS_CHECK && (flags & UCT_MD_MEM_WINDOW)) {
-        ucs_error("CUDA IPC does not support memory windows");
+    if (ENABLE_PARAMS_CHECK && (base != NULL)) {
+        ucs_error("CUDA IPC does not support derived memory handles");
         return UCS_ERR_UNSUPPORTED;
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -414,15 +414,11 @@ static ucs_status_t
 uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
-    uct_mem_h base = (params != NULL) ?
-                        UCT_MD_MEM_REG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL) :
-                        NULL;
     uct_cuda_ipc_memh_t *memh;
 
-    if (ENABLE_PARAMS_CHECK && (base != NULL)) {
-        ucs_error("CUDA IPC does not support derived memory handles");
-        return UCS_ERR_UNSUPPORTED;
-    }
+    UCT_CHECK_PARAM((params == NULL) ||
+                    UCT_MD_MEM_REG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL) == NULL,
+                    "CUDA IPC does not support derived memory handles");
 
     memh = ucs_malloc(sizeof(*memh), "uct_cuda_ipc_memh_t");
     if (NULL == memh) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -414,7 +414,9 @@ static ucs_status_t
 uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
-    uct_mem_h base = UCT_MD_MEM_REG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL);
+    uct_mem_h base = (params != NULL) ?
+                        UCT_MD_MEM_REG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL) :
+                        NULL;
     uct_cuda_ipc_memh_t *memh;
 
     if (ENABLE_PARAMS_CHECK && (base != NULL)) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -416,9 +416,7 @@ uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
 {
     uct_cuda_ipc_memh_t *memh;
 
-    UCT_CHECK_PARAM((params == NULL) ||
-                    UCT_MD_MEM_REG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL) == NULL,
-                    "CUDA IPC does not support derived memory handles");
+    UCT_CHECK_NOT_DERIVED_MEMH(params, "cuda_ipc_md");
 
     memh = ucs_malloc(sizeof(*memh), "uct_cuda_ipc_memh_t");
     if (NULL == memh) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -414,7 +414,13 @@ static ucs_status_t
 uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
+    unsigned flags = UCT_MD_MEM_REG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0);
     uct_cuda_ipc_memh_t *memh;
+
+    if (ENABLE_PARAMS_CHECK && (flags & UCT_MD_MEM_WINDOW)) {
+        ucs_error("CUDA IPC does not support memory windows");
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     memh = ucs_malloc(sizeof(*memh), "uct_cuda_ipc_memh_t");
     if (NULL == memh) {

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -594,7 +594,7 @@ uct_ib_memh_alloc_internal(uct_ib_md_t *md, size_t memh_base_size,
     uct_ib_mem_t *memh;
 
     *memh_size_p = memh_base_size + (mr_size * num_mrs);
-    memh = ucs_calloc(1, *memh_size_p, "ib_memh");
+    memh         = ucs_calloc(1, *memh_size_p, "ib_memh");
     if (memh == NULL) {
         ucs_error("%s: failed to allocated memh struct",
                   uct_ib_device_name(&md->dev));

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -598,7 +598,6 @@ uct_ib_memh_alloc_internal(uct_ib_md_t *md, size_t memh_base_size,
     if (memh == NULL) {
         ucs_error("%s: failed to allocated memh struct",
                   uct_ib_device_name(&md->dev));
-        return NULL;
     }
 
     return memh;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -584,34 +584,17 @@ ucs_status_t uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
     return UCS_OK;
 }
 
-static uct_ib_mem_t *
-uct_ib_memh_alloc_internal(uct_ib_md_t *md, size_t memh_base_size,
-                           size_t mr_size, size_t *memh_size_p)
-{
-    int num_mrs = md->relaxed_order ?
-                          2 /* UCT_IB_MR_DEFAULT and UCT_IB_MR_STRICT_ORDER */ :
-                          1 /* UCT_IB_MR_DEFAULT */;
-    uct_ib_mem_t *memh;
-
-    *memh_size_p = memh_base_size + (mr_size * num_mrs);
-    memh         = ucs_calloc(1, *memh_size_p, "ib_memh");
-    if (memh == NULL) {
-        ucs_error("%s: failed to allocated memh struct",
-                  uct_ib_device_name(&md->dev));
-    }
-
-    return memh;
-}
-
 ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
                                unsigned mem_flags, size_t memh_base_size,
                                size_t mr_size, uct_ib_mem_t **memh_p)
 {
+    size_t size = uct_ib_memh_alloc_size(md, memh_base_size, mr_size);
     uct_ib_mem_t *memh;
-    size_t memh_size;
 
-    memh = uct_ib_memh_alloc_internal(md, memh_base_size, mr_size, &memh_size);
+    memh = ucs_calloc(1, size, "ib_memh");
     if (memh == NULL) {
+        ucs_error("%s: failed to allocated memh struct",
+                  uct_ib_device_name(&md->dev));
         return UCS_ERR_NO_MEMORY;
     }
 
@@ -637,23 +620,6 @@ ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
         memh->flags |= UCT_IB_MEM_FLAG_GVA;
     }
 
-    *memh_p = memh;
-    return UCS_OK;
-}
-
-ucs_status_t uct_ib_memh_clone(uct_ib_md_t *md, const uct_ib_mem_t *src,
-                               size_t memh_base_size, size_t mr_size,
-                               uct_ib_mem_t **memh_p)
-{
-    uct_ib_mem_t *memh;
-    size_t memh_size;
-
-    memh = uct_ib_memh_alloc_internal(md, memh_base_size, mr_size, &memh_size);
-    if (memh == NULL) {
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    memcpy(memh, src, memh_size);
     *memh_p = memh;
     return UCS_OK;
 }

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -441,4 +441,13 @@ ucs_status_t uct_ib_memh_clone(uct_ib_md_t *md, const uct_ib_mem_t *src,
                                size_t memh_base_size, size_t mr_size,
                                uct_ib_mem_t **memh_p);
 
+static UCS_F_ALWAYS_INLINE size_t
+uct_ib_memh_alloc_size(uct_ib_md_t *md, size_t memh_base_size, size_t mr_size)
+{
+    int num_mrs = md->relaxed_order ?
+                          2 /* UCT_IB_MR_DEFAULT and UCT_IB_MR_STRICT_ORDER */ :
+                          1 /* UCT_IB_MR_DEFAULT */;
+    return memh_base_size + (mr_size * num_mrs);
+}
+
 #endif

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -73,6 +73,8 @@ enum {
 #endif
     UCT_IB_MEM_FLAG_GVA              = UCS_BIT(5), /**< The memory handle is a
                                                         GVA region */
+    UCT_IB_MEM_FLAG_MEM_WINDOW       = UCS_BIT(6), /**< The memory handle is a
+                                                        memory window */
 };
 
 enum {
@@ -434,5 +436,9 @@ ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
 void uct_ib_check_gpudirect_driver(uct_ib_md_t *md,
                                    const char *file,
                                    ucs_memory_type_t mem_type);
+
+ucs_status_t uct_ib_memh_clone(uct_ib_md_t *md, const uct_ib_mem_t *src,
+                               size_t memh_base_size, size_t mr_size,
+                               uct_ib_mem_t **memh_p);
 
 #endif

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -73,8 +73,8 @@ enum {
 #endif
     UCT_IB_MEM_FLAG_GVA              = UCS_BIT(5), /**< The memory handle is a
                                                         GVA region */
-    UCT_IB_MEM_FLAG_MEM_WINDOW       = UCS_BIT(6), /**< The memory handle is a
-                                                        memory window */
+    UCT_IB_MEM_FLAG_DERIVED          = UCS_BIT(6), /**< The memory handle is a
+                                                        derived memh */
 };
 
 enum {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -801,7 +801,7 @@ uct_ib_mlx5_devx_memh_clone(uct_ib_mlx5_md_t *md,
                             const uct_ib_mlx5_devx_mem_t *src,
                             uct_ib_mlx5_devx_mem_t **memh_p)
 {
-    size_t mr_size = src->super.flags & UCT_IB_MEM_IMPORTED ?
+    size_t mr_size = (src->super.flags & UCT_IB_MEM_IMPORTED) ?
                             0 : sizeof(src->mrs[0]);
     uct_ib_mem_t *ib_memh;
     ucs_status_t status;
@@ -2518,7 +2518,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
 
     ksm_atomic = 0;
     if (md->flags & UCT_IB_MLX5_MD_FLAG_KSM) {
-        md->super.cap_flags |= UCT_MD_FLAG_DERIVED;
+        md->super.cap_flags |= UCT_MD_FLAG_REG_DERIVED;
         md->super.cap_flags |= UCT_MD_FLAG_INVALIDATE_RMA;
 
         if (md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS) {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -2518,6 +2518,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
 
     ksm_atomic = 0;
     if (md->flags & UCT_IB_MLX5_MD_FLAG_KSM) {
+        md->super.cap_flags |= UCT_MD_FLAG_DERIVED;
         md->super.cap_flags |= UCT_MD_FLAG_INVALIDATE_RMA;
 
         if (md->flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS) {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -886,10 +886,13 @@ uct_ib_mlx5_devx_mem_window_reg(uct_md_h uct_md,
     uct_ib_mlx5_devx_mem_t *memh;
     ucs_status_t status;
 
-    if (base == NULL) {
+    if (ENABLE_PARAMS_CHECK && (base == NULL)) {
         ucs_error("base memory handle is not provided for memory window");
         return UCS_ERR_INVALID_PARAM;
     }
+
+    ucs_assertv(!(base->super.flags & UCT_IB_MEM_FLAG_MEM_WINDOW),
+                "memh=%p is already a memory window", base);
 
     status = uct_ib_mlx5_devx_memh_clone(md, base, &memh);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -889,7 +889,7 @@ uct_ib_mlx5_devx_derived_mem_reg(uct_md_h uct_md, uct_ib_mlx5_devx_mem_t *base,
     memh->cross_mr          = NULL;
     memh->exported_umr_mkey = NULL;
     memh->smkey_mr          = NULL;
-    memh->dm_addr_dvmr      = NULL;
+    memh->dm_addr_dvmr      = base->dm_addr_dvmr;
 
     memh->dm                = base->dm;
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -168,7 +168,8 @@ UCS_TEST_P(test_cuda_ipc_md, mpack_legacy)
                            GetParam().component, GetParam().md_name.c_str(),
                            m_md_config);
     ASSERT_EQ(CUDA_SUCCESS, cuMemAlloc(&ptr, size));
-    EXPECT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, size, NULL, &memh));
+    uct_md_mem_reg_params_t reg_params = {};
+    EXPECT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, size, &reg_params, &memh));
     EXPECT_UCS_OK(md->ops->mkey_pack(md, memh, (void *)ptr, size, NULL,
                                      &rkey));
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -22,9 +22,9 @@ protected:
         uct_mem_h memh;
         uct_cuda_ipc_rkey_t rkey;
         uct_md_mem_reg_params_t reg_params = {};
-        ASSERT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, size, &reg_params, &memh));
-        EXPECT_UCS_OK(md->ops->mkey_pack(md, memh, (void *)ptr, size, NULL,
-                                         &rkey));
+        void *addr                         = (void *)ptr;
+        ASSERT_UCS_OK(uct_md_mem_reg_v2(md, addr, size, &reg_params, &memh));
+        EXPECT_UCS_OK(uct_md_mkey_pack_v2(md, memh, addr, size, NULL, &rkey));
 
         int64_t *uuid64 = (int64_t *)rkey.uuid.bytes;
         uuid64[0]       = uuid;
@@ -40,7 +40,7 @@ protected:
         uct_md_mem_dereg_params_t params;
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
         params.memh       = memh;
-        EXPECT_UCS_OK(md->ops->mem_dereg(md, &params));
+        ASSERT_UCS_OK(uct_md_mem_dereg_v2(md, &params));
         return rkey;
     }
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -19,9 +19,10 @@ protected:
     static uct_cuda_ipc_rkey_t
     unpack_common(uct_md_h md, int64_t uuid, CUdeviceptr ptr, size_t size)
     {
-        uct_cuda_ipc_rkey_t rkey = {};
         uct_mem_h memh;
-        EXPECT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, size, NULL, &memh));
+        uct_cuda_ipc_rkey_t rkey;
+        uct_md_mem_reg_params_t reg_params = {};
+        ASSERT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, size, &reg_params, &memh));
         EXPECT_UCS_OK(md->ops->mkey_pack(md, memh, (void *)ptr, size, NULL,
                                          &rkey));
 

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -42,6 +42,17 @@ protected:
     void test_mkey_pack_mt_internal(unsigned access_mask, bool invalidate);
     void test_smkey_reg_atomic(void);
 
+    uct_mem_h reg_mem_window(uct_mem_h base) const {
+        uct_mem_h memh;
+        uct_md_mem_reg_params_t params;
+        params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
+                            UCT_MD_MEM_REG_FIELD_MEMH;
+        params.flags      = UCT_MD_MEM_WINDOW;
+        params.memh       = base;
+        ASSERT_UCS_OK(uct_md_mem_reg_v2(md(), NULL, SIZE_MAX, &params, &memh));
+        return memh;
+    }
+
 private:
 #ifdef HAVE_MLX5_DV
     uint32_t m_mlx5_flags = 0;
@@ -280,12 +291,7 @@ void test_ib_md::test_mkey_pack_mt_internal(unsigned access_mask,
     uct_ib_mem_t *ib_memh = (uct_ib_mem_t*)memh;
     EXPECT_TRUE(ib_memh->flags & UCT_IB_MEM_MULTITHREADED);
 
-    std::vector<uint8_t> rkey(md_attr().rkey_packed_size);
-    uct_md_mkey_pack_params_t pack_params;
-    pack_params.field_mask = UCT_MD_MKEY_PACK_FIELD_FLAGS;
-    pack_params.flags      = pack_flags;
-    ASSERT_UCS_OK(uct_md_mkey_pack_v2(md(), memh, buffer, size,
-                                      &pack_params, rkey.data()));
+    mkey_pack(memh, pack_flags, buffer, size);
 
     uct_md_mem_dereg_params_t params;
     params.field_mask  = UCT_MD_MEM_DEREG_FIELD_MEMH |
@@ -384,6 +390,41 @@ UCS_TEST_P(test_ib_md, mt_fail, "IB_REG_MT_THRESH=128K", "IB_REG_MT_CHUNK=16K")
         munmap(start, lower_size);
         munmap(last, upper_size);
     }
+}
+
+UCS_TEST_SKIP_COND_P(test_ib_md, mem_window,
+                     !check_invalidate_support(UCT_MD_MEM_ACCESS_RMA))
+{
+    unsigned flags = UCT_MD_FLAG_INVALIDATE_RMA | UCT_MD_FLAG_INVALIDATE_AMO;
+    std::vector<uint8_t> buffer(1024);
+    uct_mem_h base;
+    EXPECT_UCS_OK(reg_mem(UCT_MD_MEM_ACCESS_RMA, buffer.data(), buffer.size(),
+                          &base));
+
+    /* Test case 1: creating MW from memh before mkey_pack */
+    uct_mem_h mw1 = reg_mem_window(base);
+
+    /* Test case 2: creating MW from memh after mkey_pack */
+    std::vector<uint8_t> base_rkey1 = mkey_pack(base, flags);
+    uct_mem_h mw2 = reg_mem_window(base);
+    std::vector<uint8_t> mw2_rkey1 = mkey_pack(mw2, flags);
+    EXPECT_EQ(base_rkey1, mw2_rkey1);
+
+    /* Test case 3: subsequent mkey_pack calls return the same result */
+    std::vector<uint8_t> mw2_rkey2 = mkey_pack(mw2, flags);
+    EXPECT_EQ(mw2_rkey1, mw2_rkey2);
+
+    /* Test case 4: base memh can still be used to pack mkeys */
+    std::vector<uint8_t> base_rkey2 = mkey_pack(base, flags);
+    EXPECT_NE(base_rkey1, base_rkey2);
+
+    /* Test case 5: multiple MWs do not share the same rkeys */
+    std::vector<uint8_t> mw1_rkey1 = mkey_pack(mw1, flags);
+    EXPECT_NE(mw1_rkey1, mw2_rkey1);
+
+    EXPECT_UCS_OK(uct_md_mem_dereg(md(), mw1));
+    EXPECT_UCS_OK(uct_md_mem_dereg(md(), mw2));
+    EXPECT_UCS_OK(uct_md_mem_dereg(md(), base));
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -393,7 +393,9 @@ UCS_TEST_P(test_ib_md, mt_fail, "IB_REG_MT_THRESH=128K", "IB_REG_MT_CHUNK=16K")
 UCS_TEST_SKIP_COND_P(test_ib_md, derived_mem,
                      !check_invalidate_support(UCT_MD_MEM_ACCESS_RMA))
 {
-    unsigned flags = UCT_MD_FLAG_INVALIDATE_RMA | UCT_MD_FLAG_INVALIDATE_AMO;
+    unsigned flags = UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA |
+                     (check_caps(UCT_MD_FLAG_INVALIDATE_AMO) ?
+                        UCT_MD_MKEY_PACK_FLAG_INVALIDATE_AMO : 0);
     std::vector<uint8_t> buffer(1024);
     uct_mem_h base;
     EXPECT_UCS_OK(reg_mem(UCT_MD_MEM_ACCESS_RMA, buffer.data(), buffer.size(),

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -393,13 +393,14 @@ UCS_TEST_P(test_ib_md, mt_fail, "IB_REG_MT_THRESH=128K", "IB_REG_MT_CHUNK=16K")
 UCS_TEST_SKIP_COND_P(test_ib_md, derived_mem,
                      !check_invalidate_support(UCT_MD_MEM_ACCESS_RMA))
 {
-    unsigned flags = UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA |
-                     (check_caps(UCT_MD_FLAG_INVALIDATE_AMO) ?
-                        UCT_MD_MKEY_PACK_FLAG_INVALIDATE_AMO : 0);
+    bool is_atomic    = check_caps(UCT_MD_FLAG_INVALIDATE_AMO);
+    unsigned flags    = UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA |
+                        (is_atomic ? UCT_MD_MKEY_PACK_FLAG_INVALIDATE_AMO : 0);
+    unsigned md_flags = UCT_MD_MEM_ACCESS_RMA |
+                        (is_atomic ? UCT_MD_MEM_ACCESS_REMOTE_ATOMIC : 0);
     std::vector<uint8_t> buffer(1024);
     uct_mem_h base;
-    EXPECT_UCS_OK(reg_mem(UCT_MD_MEM_ACCESS_RMA, buffer.data(), buffer.size(),
-                          &base));
+    EXPECT_UCS_OK(reg_mem(md_flags, buffer.data(), buffer.size(), &base));
 
     /* Test case 1: creating derived memh from memh before mkey_pack */
     uct_mem_h der1 = reg_derived_mem(base);

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -419,11 +419,14 @@ UCS_TEST_SKIP_COND_P(test_ib_md, derived_mem,
     std::vector<uint8_t> der1_rkey1 = mkey_pack(der1, flags);
     EXPECT_NE(der1_rkey1, der2_rkey1);
 
+    /* Test case 5: derived memh pack exported mkey */
+    mkey_pack(der1, UCT_MD_MKEY_PACK_FLAG_EXPORT);
+
     /* Invalidation = destroying derived memh */
     EXPECT_UCS_OK(uct_md_mem_dereg(md(), der1));
     EXPECT_UCS_OK(uct_md_mem_dereg(md(), der2));
 
-    /* Test case 5: base memh can still be used to pack mkeys */
+    /* Test case 6: base memh can still be used to pack mkeys */
     std::vector<uint8_t> base_rkey2 = mkey_pack(base, flags);
     EXPECT_EQ(base_rkey1, base_rkey2);
 

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -42,7 +42,7 @@ protected:
     void test_mkey_pack_mt_internal(unsigned access_mask, bool invalidate);
     void test_smkey_reg_atomic(void);
 
-    uct_mem_h reg_derived_mem(uct_mem_h base) const {
+    uct_mem_h reg_derived_mem(const uct_mem_h base) const {
         uct_mem_h memh;
         uct_md_mem_reg_params_t params;
         params.field_mask = UCT_MD_MEM_REG_FIELD_MEMH;

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -420,7 +420,9 @@ UCS_TEST_SKIP_COND_P(test_ib_md, derived_mem,
     EXPECT_NE(der1_rkey1, der2_rkey1);
 
     /* Test case 5: derived memh pack exported mkey */
-    mkey_pack(der1, UCT_MD_MKEY_PACK_FLAG_EXPORT);
+    if (check_caps(UCT_MD_FLAG_EXPORTED_MKEY)) {
+        mkey_pack(der1, UCT_MD_MKEY_PACK_FLAG_EXPORT);
+    }
 
     /* Invalidation = destroying derived memh */
     EXPECT_UCS_OK(uct_md_mem_dereg(md(), der1));

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -134,13 +134,7 @@ void test_md::test_reg_mem(unsigned access_mask,
         status            = uct_md_mem_dereg_v2(md(), &params);
         ASSERT_UCS_STATUS_EQ(UCS_ERR_INVALID_PARAM, status);
 
-        std::vector<uint8_t> rkey(md_attr().rkey_packed_size);
-        uct_md_mkey_pack_params_t pack_params;
-        pack_params.field_mask = UCT_MD_MKEY_PACK_FIELD_FLAGS;
-        pack_params.flags      = invalidate_flag;
-        status = uct_md_mkey_pack_v2(md(), memh, ptr, size, &pack_params,
-                                     rkey.data());
-        EXPECT_UCS_OK(status);
+        mkey_pack(memh, invalidate_flag, ptr, size);
 
         status = uct_md_mem_dereg_v2(md(), &params);
     }
@@ -973,13 +967,7 @@ UCS_TEST_SKIP_COND_P(test_md, exported_mkey,
     status = reg_mem(UCT_MD_MEM_ACCESS_ALL, address, size, &export_memh);
     ASSERT_UCS_OK(status);
 
-    std::vector<uint8_t> mkey_buffer(md_attr().exported_mkey_packed_size);
-    uct_md_mkey_pack_params_t pack_params;
-    pack_params.field_mask = UCT_MD_MKEY_PACK_FIELD_FLAGS;
-    pack_params.flags      = UCT_MD_MKEY_PACK_FLAG_EXPORT;
-    status = uct_md_mkey_pack_v2(md(), export_memh, address, size, &pack_params,
-                                 mkey_buffer.data());
-    ASSERT_UCS_OK(status);
+    mkey_pack(export_memh, UCT_MD_MKEY_PACK_FLAG_EXPORT, address, size);
 
     uct_md_mem_dereg_params_t dereg_params;
     dereg_params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -69,10 +69,9 @@ ucs_status_t test_md::reg_mem(unsigned flags, void *address, size_t length,
     /* Register memory respecting MD reg_alignment */
     ucs_align_ptr_range(&address, &length, md_attr().reg_alignment);
 
-    uct_md_mem_reg_params_t reg_params;
-
-    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
-    reg_params.flags      = flags;
+    uct_md_mem_reg_params_t reg_params = {0};
+    reg_params.field_mask              = UCT_MD_MEM_REG_FIELD_FLAGS;
+    reg_params.flags                   = flags;
 
     return uct_md_mem_reg_v2(md(), address, length, &reg_params, memh_p);
 }

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -64,6 +64,21 @@ protected:
         return m_md_attr;
     }
 
+    std::vector<uint8_t>
+    mkey_pack(uct_mem_h memh, unsigned flags = 0, void *ptr = NULL,
+              size_t size = SIZE_MAX) const {
+        size_t rkey_size = flags & UCT_MD_MKEY_PACK_FLAG_EXPORT ?
+                                md_attr().exported_mkey_packed_size :
+                                md_attr().rkey_packed_size;
+        std::vector<uint8_t> rkey(rkey_size, 0);
+        uct_md_mkey_pack_params_t pack_params;
+        pack_params.field_mask = UCT_MD_MKEY_PACK_FIELD_FLAGS;
+        pack_params.flags      = flags;
+        EXPECT_UCS_OK(uct_md_mkey_pack_v2(md(), memh, ptr, size, &pack_params,
+                                          rkey.data()));
+        return rkey;
+    }
+
     typedef struct {
         test_md          *self;
         uct_completion_t comp;


### PR DESCRIPTION
## What?
This PR is a composite part of the new memory invalidation design based on the concept of memory windows.
Here we introduce changes on the UCT side.
On UCT side memory window represents a shallow copy of some existing UCT memory handle, which can be used to access the same memory region. When created, the memory window inherits the original memh access flags and state, and takes ownership of the indirect keys of the original memory handle. The lifetime of the memory window is bound to the original memh, and the original memh cannot be destroyed until all its memory windows are destroyed.

[Design doc](https://nvidia.sharepoint.com/:p:/r/sites/NBU-UCX/_layouts/15/doc2.aspx?sourcedoc=%7B76889907-A62B-49BC-B79B-82E09E4EF036%7D&file=Pipeline%20invalidation.pptx&action=edit&mobileredirect=true)

## Why?
The overall idea is to employ a lightweight invalidation: when failure happens we invalidate only the exposed indirect rkeys, but don't deregister the entire memory region, which is an expensive operation. Lightweight invalidation enables invalidation workflow for RNDV pipeline protocol.

## How?
1) Introduced a new option for `uct_md_mem_reg_params_t`: `UCT_MD_MEM_WINDOW`. Existing `mem_reg` call will create a memory window based on existing UCT memh
2) When memory window is requested, create a shallow copy of base UCT memh and take the ownership of its indirect memory keys.
