### PR TITLE
UCP/WIREUP: Support EP reconfiguration for non wired-up scenarios

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -556,6 +556,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, max_priority_eps),
    UCS_CONFIG_TYPE_UINT},
 
+  {"WIREUP_VIA_AM_LANE", "n",
+   "Use AM lane to send wireup messages",
+   ucs_offsetof(ucp_context_config_t, wireup_via_am_lane),
+   UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -205,6 +205,8 @@ typedef struct ucp_context_config {
     uint64_t                               extra_op_attr_flags;
     /* Upper limit to the amount of prioritized endpoints */
     unsigned                               max_priority_eps;
+    /* Use AM lane to send wireup messages */
+    int                                    wireup_via_am_lane;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -827,6 +827,7 @@ ucp_ep_create_to_worker_addr(ucp_worker_h worker,
     ucp_tl_bitmap_t ep_tl_bitmap;
     ucs_status_t status;
     ucp_ep_h ep;
+    int am_need_flush;
 
     /* allocate endpoint */
     status = ucp_ep_create_base(worker, ep_init_flags, remote_address->name,
@@ -837,7 +838,8 @@ ucp_ep_create_to_worker_addr(ucp_worker_h worker,
 
     /* initialize transport endpoints */
     status = ucp_wireup_init_lanes(ep, ep_init_flags, local_tl_bitmap,
-                                   remote_address, addr_indices);
+                                   remote_address, addr_indices,
+                                   &am_need_flush);
     if (status != UCS_OK) {
         goto err_delete;
     }
@@ -1861,40 +1863,39 @@ int ucp_ep_config_lane_is_peer_match(const ucp_ep_config_key_t *key1,
                                           config_lane2->dst_md_index);
 }
 
-static ucp_lane_index_t
-ucp_ep_config_find_match_lane(const ucp_ep_config_key_t *key1,
-                              ucp_lane_index_t lane1,
-                              const ucp_ep_config_key_t *key2)
+ucp_lane_index_t
+ucp_ep_config_find_match_lane(const ucp_ep_config_key_t *old_key,
+                              ucp_lane_index_t old_lane,
+                              const ucp_ep_config_key_t *new_key)
 {
-    ucp_lane_index_t lane_idx;
+    ucp_lane_index_t new_lane;
 
-    for (lane_idx = 0; lane_idx < key2->num_lanes; ++lane_idx) {
-        if (ucp_ep_config_lane_is_peer_match(key1, lane1, key2, lane_idx)) {
-            return lane_idx;
+    for (new_lane = 0; new_lane < new_key->num_lanes; ++new_lane) {
+        if (ucp_ep_config_lane_is_peer_match(old_key, old_lane, new_key,
+                                             new_lane)) {
+            return new_lane;
         }
     }
 
     return UCP_NULL_LANE;
 }
 
-static ucp_lane_index_t
-ucp_ep_config_find_reusable_lane(const ucp_ep_config_key_t *key1,
-                                 const ucp_ep_config_key_t *key2, ucp_ep_h ep,
-                                 const ucp_unpacked_address_t *remote_address,
-                                 const unsigned *addr_indices,
-                                 ucp_lane_index_t old_lane)
+static ucp_lane_index_t ucp_ep_config_find_reusable_lane(
+        const ucp_ep_config_key_t *old_key, const ucp_ep_config_key_t *new_key,
+        ucp_ep_h ep, const ucp_unpacked_address_t *remote_address,
+        const unsigned *addr_indices, ucp_lane_index_t old_lane)
 {
     ucp_context_h context     = ep->worker->context;
-    ucp_rsc_index_t rsc_index = key1->lanes[old_lane].rsc_index;
+    ucp_rsc_index_t rsc_index = old_key->lanes[old_lane].rsc_index;
     ucp_lane_index_t new_lane;
     unsigned addr_index;
     const ucp_address_entry_t *ae;
 
-    if (old_lane == key1->cm_lane) {
-        return key2->cm_lane;
+    if (old_lane == old_key->cm_lane) {
+        return new_key->cm_lane;
     }
 
-    new_lane = ucp_ep_config_find_match_lane(key1, old_lane, key2);
+    new_lane = ucp_ep_config_find_match_lane(old_key, old_lane, new_key);
     if (new_lane == UCP_NULL_LANE) {
         /* No matching lane was found */
         return UCP_NULL_LANE;
@@ -1921,26 +1922,24 @@ ucp_ep_config_find_reusable_lane(const ucp_ep_config_key_t *key1,
 
 /* Go through the first configuration and check if the lanes selected
  * for this configuration could be used for the second configuration */
-void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *key1,
-                                   const ucp_ep_config_key_t *key2,
+void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *old_key,
+                                   const ucp_ep_config_key_t *new_key,
                                    const ucp_ep_h ep,
                                    const ucp_unpacked_address_t *remote_address,
                                    const unsigned *addr_indices,
                                    ucp_lane_index_t *lane_map)
 {
-    ucp_lane_index_t lane1_idx;
+    ucp_lane_index_t old_lane;
 
-    for (lane1_idx = 0; lane1_idx < key1->num_lanes; ++lane1_idx) {
-        lane_map[lane1_idx] = ucp_ep_config_find_reusable_lane(key1, key2, ep,
-                                                               remote_address,
-                                                               addr_indices,
-                                                               lane1_idx);
+    for (old_lane = 0; old_lane < old_key->num_lanes; ++old_lane) {
+        lane_map[old_lane] = ucp_ep_config_find_reusable_lane(
+                old_key, new_key, ep, remote_address, addr_indices, old_lane);
     }
 }
 
-static int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
-                                       const ucp_ep_config_key_t *key2,
-                                       ucp_lane_index_t lane)
+int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
+                                const ucp_ep_config_key_t *key2,
+                                ucp_lane_index_t lane)
 {
     const ucp_ep_config_key_lane_t *config_lane1 = &key1->lanes[lane];
     const ucp_ep_config_key_lane_t *config_lane2 = &key2->lanes[lane];

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -754,12 +754,21 @@ int ucp_ep_config_lane_is_peer_match(const ucp_ep_config_key_t *key1,
                                      const ucp_ep_config_key_t *key2,
                                      ucp_lane_index_t lane2);
 
-void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *key1,
-                                   const ucp_ep_config_key_t *key2,
+ucp_lane_index_t
+ucp_ep_config_find_match_lane(const ucp_ep_config_key_t *old_key,
+                              ucp_lane_index_t old_lane,
+                              const ucp_ep_config_key_t *new_key);
+
+void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *old_key,
+                                   const ucp_ep_config_key_t *new_key,
                                    const ucp_ep_h ep,
                                    const ucp_unpacked_address_t *remote_address,
                                    const unsigned *addr_indices,
                                    ucp_lane_index_t *lane_map);
+
+int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
+                                const ucp_ep_config_key_t *key2,
+                                ucp_lane_index_t lane);
 
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2);

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2044,7 +2044,8 @@ ucp_wireup_select_wireup_msg_lane(ucp_worker_h worker,
                                   unsigned ep_init_flags,
                                   const ucp_address_entry_t *address_list,
                                   const ucp_wireup_lane_desc_t *lane_descs,
-                                  ucp_lane_index_t num_lanes)
+                                  ucp_lane_index_t num_lanes,
+                                  ucp_lane_index_t am_lane)
 {
     ucp_context_h context          = worker->context;
     ucp_lane_index_t p2p_lane      = UCP_NULL_LANE;
@@ -2054,6 +2055,11 @@ ucp_wireup_select_wireup_msg_lane(ucp_worker_h worker,
     uct_iface_attr_t *attrs;
     ucp_lane_index_t lane;
     unsigned addr_index;
+
+    if (context->config.ext.wireup_via_am_lane) {
+        ucs_assert(am_lane != UCP_NULL_LANE);
+        return am_lane;
+    }
 
     ucp_wireup_fill_aux_criteria(&criteria, ep_init_flags,
                                  UCP_ADDR_IFACE_FLAG_CB_ASYNC);
@@ -2440,7 +2446,7 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
                                                                    select_ctx),
                                           select_params->address->address_list,
                                           select_ctx->lane_descs,
-                                          key->num_lanes);
+                                          key->num_lanes, key->am_lane);
     }
 
     for (i = 0; key->rma_bw_lanes[i] != UCP_NULL_LANE; i++) {

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -171,6 +171,7 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self)
         ucp_ep_update_flags(ep, UCP_EP_FLAG_CONNECT_REQ_SENT, 0);
         break;
     case UCP_WIREUP_MSG_REPLY:
+    case UCP_WIREUP_MSG_REPLY_RECONFIG:
         ucp_ep_update_flags(ep, UCP_EP_FLAG_CONNECT_REP_SENT, 0);
         break;
     case UCP_WIREUP_MSG_ACK:
@@ -566,6 +567,7 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, ucp_ep_h ep,
                              UCP_EP_INIT_CM_WIREUP_CLIENT |
                              ucp_ep_err_mode_init_flags(msg->err_mode);
     unsigned addr_indices[UCP_MAX_LANES];
+    int am_need_flush;
     ucs_status_t status;
 
     UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_PRE_REQUEST);
@@ -589,7 +591,8 @@ ucp_wireup_process_pre_request(ucp_worker_h worker, ucp_ep_h ep,
 
     /* initialize transport endpoints */
     status = ucp_wireup_init_lanes(ep, ep_init_flags, &ucp_tl_bitmap_max,
-                                   remote_address, addr_indices);
+                                   remote_address, addr_indices,
+                                   &am_need_flush);
     if (status != UCS_OK) {
         goto err_ep_set_failed;
     }
@@ -613,7 +616,7 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
     ucp_lane_index_t lanes2remote[UCP_MAX_LANES];
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_t status;
-    int has_cm_lane;
+    int has_cm_lane, am_need_flush, full_handshake_required;
 
     UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_REQUEST);
     ucs_trace("got wireup request from 0x%"PRIx64" src_ep_id 0x%"PRIx64
@@ -684,20 +687,26 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
 
     /* Initialize lanes (possible destroy existing lanes) */
     status = ucp_wireup_init_lanes(ep, ep_init_flags, &ucp_tl_bitmap_max,
-                                   remote_address, addr_indices);
+                                   remote_address, addr_indices,
+                                   &am_need_flush);
     if (status != UCS_OK) {
         goto err_set_ep_failed;
     }
 
     ucp_wireup_match_p2p_lanes(ep, remote_address, addr_indices, lanes2remote);
 
+    /* Full handshake is required in the following cases:
+     * 1) CM flow (the client's EP has to be marked as REMOTE_CONNECTED)
+     * 2) P2P lanes exist in EP configuration (client-server flow)
+     * 3) Old AM lane was replaced (ensures message order) */
+    full_handshake_required = has_cm_lane || ucp_ep_config(ep)->p2p_lanes ||
+                              am_need_flush;
+
     /* Send a reply if remote side does not have ep_ptr (active-active flow) or
-     * there are p2p lanes (client-server flow)
+     * full handshake is required
      */
-    send_reply = /* Always send the reply in case of CM, the client's EP has to
-                  * be marked as REMOTE_CONNECTED */
-        has_cm_lane || (msg->dst_ep_id == UCS_PTR_MAP_KEY_INVALID) ||
-        ucp_ep_config(ep)->p2p_lanes;
+    send_reply = (msg->dst_ep_id == UCS_PTR_MAP_KEY_INVALID) ||
+                 full_handshake_required;
 
     /* Connect p2p addresses to remote endpoint, if at least one is true: */
     if (/* - EP has not been connected locally yet */
@@ -717,17 +726,17 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
         ucs_assert(send_reply);
     }
 
-    /* don't mark as connected to remote now in case of CM, since it destroys
-     * CM wireup EP (if it is hidden in the CM lane) that is used for sending
-     * WIREUP MSGs */
-    if (!ucp_ep_config(ep)->p2p_lanes && !has_cm_lane) {
+    if (!full_handshake_required) {
         /* mark the endpoint as connected to remote */
         ucp_wireup_remote_connected(ep);
     }
 
     if (send_reply) {
         ucs_trace("ep %p: sending wireup reply", ep);
-        ucp_wireup_msg_send(ep, UCP_WIREUP_MSG_REPLY, &tl_bitmap, lanes2remote);
+        ucp_wireup_msg_send(ep,
+                            am_need_flush ? UCP_WIREUP_MSG_REPLY_RECONFIG :
+                                            UCP_WIREUP_MSG_REPLY,
+                            &tl_bitmap, lanes2remote);
     }
 
     return;
@@ -754,15 +763,14 @@ int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg)
     return ((elem->arg == arg) && (elem->cb == ucp_wireup_send_msg_ack));
 }
 
-static UCS_F_NOINLINE void
-ucp_wireup_process_reply(ucp_worker_h worker, ucp_ep_h ep,
-                         const ucp_wireup_msg_t *msg,
-                         const ucp_unpacked_address_t *remote_address)
+static void
+ucp_wireup_process_reply_common(ucp_worker_h worker, ucp_ep_h ep,
+                                const ucp_wireup_msg_t *msg,
+                                const ucp_unpacked_address_t *remote_address)
 {
     ucs_status_t status;
     int ack;
 
-    UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_REPLY);
     ucs_trace("ep %p: got wireup reply src_ep_id 0x%"PRIx64
               " dst_ep_id 0x%"PRIx64" sn %d", ep, msg->src_ep_id,
               msg->dst_ep_id, msg->conn_sn);
@@ -793,12 +801,30 @@ ucp_wireup_process_reply(ucp_worker_h worker, ucp_ep_h ep,
 
     ucp_wireup_remote_connected(ep);
 
-    if (ack) {
+    if (ack || (msg->type == UCP_WIREUP_MSG_REPLY_RECONFIG)) {
         /* Send `UCP_WIREUP_MSG_ACK` from progress function
          * to avoid calling UCT routines from an async thread */
         ucs_callbackq_add_oneshot(&worker->uct->progress_q, ep,
                                   ucp_wireup_send_msg_ack, ep);
     }
+}
+
+static UCS_F_NOINLINE void
+ucp_wireup_process_reply(ucp_worker_h worker, ucp_ep_h ep,
+                         const ucp_wireup_msg_t *msg,
+                         const ucp_unpacked_address_t *remote_address)
+{
+    UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_REPLY);
+    ucp_wireup_process_reply_common(worker, ep, msg, remote_address);
+}
+
+static UCS_F_NOINLINE void
+ucp_wireup_process_reply_reconfig(ucp_worker_h worker, ucp_ep_h ep,
+                                  const ucp_wireup_msg_t *msg,
+                                  const ucp_unpacked_address_t *remote_address)
+{
+    UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_REPLY_RECONFIG);
+    ucp_wireup_process_reply_common(worker, ep, msg, remote_address);
 }
 
 static void ucp_ep_removed_flush_completion(ucp_request_t *req)
@@ -835,6 +861,7 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
     ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];
     ucs_status_ptr_t req;
+    int am_need_flush;
 
     /* If endpoint does not exist - create a temporary endpoint to send a
      * UCP_WIREUP_MSG_EP_REMOVED reply */
@@ -847,7 +874,8 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
 
     /* Initialize lanes of the reply EP */
     status = ucp_wireup_init_lanes(reply_ep, ep_init_flags, &ucp_tl_bitmap_max,
-                                   remote_address, addr_indices);
+                                   remote_address, addr_indices,
+                                   &am_need_flush);
     if (status != UCS_OK) {
         goto out_delete_ep;
     }
@@ -936,6 +964,8 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
         ucp_wireup_process_request(worker, ep, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_REPLY) {
         ucp_wireup_process_reply(worker, ep, msg, &remote_address);
+    } else if (msg->type == UCP_WIREUP_MSG_REPLY_RECONFIG) {
+        ucp_wireup_process_reply_reconfig(worker, ep, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_EP_CHECK) {
         ucs_assert((msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID) && (ep == NULL));
         ucp_wireup_send_ep_removed(worker, msg, &remote_address);
@@ -1352,28 +1382,107 @@ static void ucp_wireup_discard_uct_eps(ucp_ep_h ep, uct_ep_h *uct_eps,
     }
 }
 
+/* Check if AM lane should be flushed after being operational (wireup process
+ * completed) */
+static int ucp_wireup_is_am_need_flush(ucp_ep_h ep,
+                                       const ucp_ep_config_key_t *key,
+                                       const ucp_lane_index_t *reuse_lane_map)
+{
+    ucp_lane_index_t am_lane = ucp_ep_get_am_lane(ep);
+
+           /* In CM mode, messages are not sent before wireup is completed */
+    return !ucp_ep_has_cm_lane(ep) &&
+           /* AM lane exists */
+           (am_lane != UCP_NULL_LANE) && (key->am_lane != UCP_NULL_LANE) &&
+           /* Lane is not being reused by new AM lane */
+           (reuse_lane_map[am_lane] != key->am_lane) &&
+           /* Lane is operational */
+           ((ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED) ||
+            !ucp_ep_is_lane_p2p(ep, am_lane));
+}
+
+static ucp_lane_index_t ucp_wireup_get_reconfig_msg_lane(ucp_ep_h ep)
+{
+    /* EP reconfiguration can only occur after wireup
+     * request was sent and before reply was received
+     * (thus we use UCP_WIREUP_MSG_REQUEST) */
+    return ucp_wireup_get_msg_lane(ep, UCP_WIREUP_MSG_REQUEST);
+}
+
 static int
 ucp_wireup_check_is_reconfigurable(ucp_ep_h ep,
                                    const ucp_ep_config_key_t *new_key,
                                    const ucp_unpacked_address_t *remote_address,
                                    const unsigned *addr_indices)
 {
-    ucp_lane_index_t lane;
+    ucp_context_h context = ep->worker->context;
+    ucp_lane_index_t reuse_lane_map[UCP_MAX_LANES];
+    ucp_lane_index_t old_lane, new_lane;
+    const ucp_ep_config_key_t *old_key;
 
     if ((ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) ||
         ucp_ep_has_cm_lane(ep)) {
         return 1;
     }
 
-    /* TODO: Support reconfiguration when lanes are created without a wireup_ep
-     * wrapper */
-    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        if (!ucp_wireup_ep_test(ucp_ep_get_lane(ep, lane))) {
+    old_key = &ucp_ep_config(ep)->key;
+
+    /* TODO: 1) Support lanes which are connected to the same remote MD, but
+     *          different remote sys_dev (eg. TCP). */
+    for (old_lane = 0; old_lane < old_key->num_lanes; ++old_lane) {
+        new_lane = ucp_ep_config_find_match_lane(old_key, old_lane, new_key);
+
+        /* Old config has a lane with same remote MD as new config */
+        if ((new_lane != UCP_NULL_LANE) &&
+            /* The matching lanes have different remote sys_dev values */
+            (old_key->lanes[old_lane].dst_sys_dev !=
+             new_key->lanes[new_lane].dst_sys_dev)) {
             return 0;
         }
     }
 
-    return 1;
+    /* TODO: 2) Support reconfiguration for multiple lanes that require flush.
+     * HW tag matching requires flush and thus not supported for reconfig */
+    if ((ucp_ep_get_tag_lane(ep) != UCP_NULL_LANE) ||
+        /* Weak fence requires flushing RMA lanes
+         * TODO: replace with more specific 'fence mode' check after
+         * Michal's PR is merged */
+        (context->config.worker_fence_mode != UCP_FENCE_MODE_STRONG)) {
+        return 0;
+    }
+
+    ucp_ep_config_lanes_intersect(old_key, new_key, ep, remote_address,
+                                  addr_indices, reuse_lane_map);
+
+    /*
+     * The following conditions describe the cases where flush is
+     * required for only a single lane, thus we can perform
+     * reconfiguration: */
+
+    /* AM flush is not needed */
+    return !ucp_wireup_is_am_need_flush(ep, new_key, reuse_lane_map) ||
+           /* AM and wireup lanes are the same lane */
+           (ucp_ep_get_am_lane(ep) == ucp_wireup_get_reconfig_msg_lane(ep));
+}
+
+static int ucp_wireup_should_reconfigure(ucp_ep_h ep,
+                                         const ucp_lane_index_t *reuse_lane_map,
+                                         ucp_lane_index_t num_lanes)
+{
+    ucp_lane_index_t lane;
+
+    if (ucp_ep_has_cm_lane(ep) || (ucp_ep_num_lanes(ep) != num_lanes)) {
+        return 1;
+    }
+
+    /* Check whether all lanes are reused */
+    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
+        if (reuse_lane_map[lane] == UCP_NULL_LANE) {
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 static ucp_lane_index_t
@@ -1410,46 +1519,63 @@ ucp_wireup_find_non_reused_lane(ucp_ep_h ep, const ucp_ep_config_key_t *key,
 }
 
 static ucs_status_t
-ucp_wireup_replace_wireup_msg_lane(ucp_ep_h ep, ucp_ep_config_key_t *key,
-                                   uct_ep_h *new_uct_eps,
-                                   const ucp_lane_index_t *reuse_lane_map)
+ucp_wireup_replace_ordered_lane(ucp_ep_h ep, ucp_ep_config_key_t *key,
+                                uct_ep_h *new_uct_eps,
+                                const ucp_lane_index_t *reuse_lane_map)
 {
-    uct_ep_h uct_ep = NULL;
-    ucp_lane_index_t old_lane, new_wireup_lane;
-    ucp_wireup_ep_t *old_wireup_ep, *new_wireup_ep;
+    uct_ep_h uct_ep   = NULL;
+    int am_need_flush = ucp_wireup_is_am_need_flush(ep, key, reuse_lane_map);
+    ucp_lane_index_t old_lane, new_wireup_lane, old_wireup_lane;
+    ucp_lane_index_t new_order_lane;
+    ucp_wireup_ep_t *new_wireup_ep, *old_ep_wrapper;
+    uct_ep_h old_wireup_ep, new_aux_ep;
     ucp_rsc_index_t aux_rsc_index;
-    int is_p2p;
+    int is_p2p, is_wireup_ep;
     ucs_status_t status;
 
-    /* Get old wireup lane */
-    old_lane      = ucp_wireup_get_msg_lane(ep, UCP_WIREUP_MSG_REQUEST);
-    old_wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ep, old_lane));
-    ucs_assert_always(old_wireup_ep != NULL);
+    old_wireup_lane = ucp_wireup_get_reconfig_msg_lane(ep);
+    old_lane        = am_need_flush ? ucp_ep_get_am_lane(ep) : old_wireup_lane;
+    old_wireup_ep   = ucp_ep_get_lane(ep, old_lane);
+    old_ep_wrapper  = ucp_wireup_ep(old_wireup_ep);
+    is_wireup_ep    = ucp_wireup_ep_test(old_wireup_ep);
 
     /* If wireup lane is required for new configuration, select it according
      * to the following priority:
      * 1) If CM lane exists, use it.
-     * 2) If any reused wireup_ep lane exists in old configuration, use it.
-     * 3) Otherwise select a non-reused lane (which must exist), and wrap
-     *    it with a new wireup_ep wrapper. */
-
+     * 2) If old AM lane is replaced, use new AM lane or old reused lane.
+     * 3) If a non-reused lane exists, select it and wrap with a new wireup_ep
+     *    wrapper.
+     * 4) Otherwise select a reused wireup_ep lane (which must exist).
+     * The actual wireup messages will be sent from old wireup lane (used as
+     * aux), which is guaranteed to support AM. */
     if (ucp_ep_has_cm_lane(ep)) {
         new_wireup_ep   = ucp_ep_get_cm_wireup_ep(ep);
         new_wireup_lane = key->cm_lane;
     } else {
-        new_wireup_lane = ucp_wireup_find_reused_wireup_ep_lane(ep,
-                                                                reuse_lane_map);
-        if (new_wireup_lane != UCP_NULL_LANE) {
-            uct_ep = ucp_ep_get_lane(ep, new_wireup_lane);
+        if (am_need_flush) {
+            /* Send wireup reply through old AM lane:
+             * 1) If AM is reused, old lane is taken from reuse map.
+             * 2) Otherwise, old lane is accessed through new AM lane (used
+             * as auxiliary).
+             * */
+            new_wireup_lane = (reuse_lane_map[old_lane] != UCP_NULL_LANE) ?
+                                      reuse_lane_map[old_lane] :
+                                      key->am_lane;
         } else {
             new_wireup_lane = ucp_wireup_find_non_reused_lane(ep, key,
                                                               reuse_lane_map);
-            ucs_assert(new_wireup_lane != UCP_NULL_LANE);
+        }
 
+        if (new_wireup_lane != UCP_NULL_LANE) {
             status = ucp_wireup_ep_create(ep, &uct_ep);
             if (status != UCS_OK) {
                 return status;
             }
+        } else {
+            new_wireup_lane =
+                    ucp_wireup_find_reused_wireup_ep_lane(ep, reuse_lane_map);
+            ucs_assert(new_wireup_lane != UCP_NULL_LANE);
+            uct_ep = ucp_ep_get_lane(ep, new_wireup_lane);
         }
         new_wireup_ep = ucp_wireup_ep(uct_ep);
     }
@@ -1457,30 +1583,35 @@ ucp_wireup_replace_wireup_msg_lane(ucp_ep_h ep, ucp_ep_config_key_t *key,
     ucs_assert(new_wireup_ep != NULL);
 
     /* Get correct aux_rsc_index either from next_ep or aux_ep */
-    aux_rsc_index = ucp_wireup_ep_is_next_ep_active(old_wireup_ep) ?
+    aux_rsc_index = (!is_wireup_ep ||
+                     ucp_wireup_ep_is_next_ep_active(old_ep_wrapper)) ?
                             ucp_ep_get_rsc_index(ep, old_lane) :
-                            ucp_wireup_ep_get_aux_rsc_index(
-                                    &old_wireup_ep->super.super);
+                            ucp_wireup_ep_get_aux_rsc_index(old_wireup_ep);
 
     ucs_assert(aux_rsc_index != UCP_NULL_RESOURCE);
     is_p2p = ucp_ep_config_connect_p2p(ep->worker, &ucp_ep_config(ep)->key,
                                        aux_rsc_index);
 
-    /* Move aux EP to new wireup lane */
-    ucp_wireup_ep_set_aux(new_wireup_ep,
-                          ucp_wireup_ep_extract_msg_ep(old_wireup_ep),
-                          aux_rsc_index, is_p2p);
+    /* Auxiliary is not required when AM flush is done by reused lane */
+    if (!am_need_flush || (reuse_lane_map[old_lane] == UCP_NULL_LANE)) {
+        if (is_wireup_ep) {
+            new_aux_ep = ucp_wireup_ep_extract_msg_ep(old_ep_wrapper);
+            /* Remove old wireup_ep as it's not needed anymore. */
+            uct_ep_destroy(old_wireup_ep);
+        } else {
+            new_aux_ep = old_wireup_ep;
+        }
 
-    /* Remove old wireup_ep as it's not needed anymore.
-     * NOTICE: Next two lines are intentionally not merged with the lane
-     * removal loop in ucp_wireup_check_config_intersect, because of future
-     * support for non-wireup EPs reconfiguration (which will modify this
-     * code). */
-    uct_ep_destroy(&old_wireup_ep->super.super);
-    ucp_ep_set_lane(ep, old_lane, NULL);
+        /* Move aux EP to new wireup lane */
+        ucp_wireup_ep_set_aux(new_wireup_ep, new_aux_ep, aux_rsc_index, is_p2p);
+        ucp_ep_set_lane(ep, old_lane, NULL);
+    }
 
-    new_uct_eps[new_wireup_lane] = &new_wireup_ep->super.super;
-    key->wireup_msg_lane         = new_wireup_lane;
+    /* In case old AM lane is flushed, the new lane waits until it finishes */
+    new_order_lane              = am_need_flush ? key->am_lane :
+                                                  new_wireup_lane;
+    new_uct_eps[new_order_lane] = &new_wireup_ep->super.super;
+    key->wireup_msg_lane        = new_wireup_lane;
     return UCS_OK;
 }
 
@@ -1489,7 +1620,8 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
                                   const ucp_unpacked_address_t *remote_address,
                                   const unsigned *addr_indices,
                                   ucp_lane_map_t *connect_lane_bitmap,
-                                  ucs_queue_head_t *replay_pending_queue)
+                                  ucs_queue_head_t *replay_pending_queue,
+                                  int *am_need_flush_p)
 {
     uct_ep_h new_uct_eps[UCP_MAX_LANES]            = {NULL};
     ucp_lane_index_t reuse_lane_map[UCP_MAX_LANES] = {UCP_NULL_LANE};
@@ -1497,8 +1629,10 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     ucp_lane_index_t lane, reuse_lane, wireup_lane;
     uct_ep_h uct_ep;
     ucs_status_t status;
+    int should_reuse;
 
     *connect_lane_bitmap = UCS_MASK(new_key->num_lanes);
+    *am_need_flush_p     = 0;
 
     if ((ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) ||
         !ucp_wireup_check_is_reconfigurable(ep, new_key, remote_address,
@@ -1517,6 +1651,11 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     ucp_ep_config_lanes_intersect(old_key, new_key, ep, remote_address,
                                   addr_indices, reuse_lane_map);
 
+    if (!ucp_wireup_should_reconfigure(ep, reuse_lane_map,
+                                       new_key->num_lanes)) {
+        return UCS_OK;
+    }
+
     if (ucp_ep_has_cm_lane(ep)) {
         /* CM lane has to be reused by the new EP configuration */
         ucs_assert(reuse_lane_map[ucp_ep_get_cm_lane(ep)] != UCP_NULL_LANE);
@@ -1526,22 +1665,25 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
                     "new_key->wireup_msg_lane=%u", new_key->wireup_msg_lane);
     }
 
-    wireup_lane = ucp_wireup_get_msg_lane(ep, UCP_WIREUP_MSG_REQUEST);
+    if (ucp_wireup_is_am_need_flush(ep, new_key, reuse_lane_map)) {
+        wireup_lane  = ucp_ep_get_am_lane(ep);
+        should_reuse = (reuse_lane_map[wireup_lane] == new_key->am_lane);
+    } else {
+        wireup_lane  = ucp_wireup_get_reconfig_msg_lane(ep);
+        should_reuse = (reuse_lane_map[wireup_lane] != UCP_NULL_LANE);
+    }
 
     /* wireup lane has to be selected for the old configuration */
     ucs_assert(wireup_lane != UCP_NULL_LANE);
 
     /* set the correct WIREUP MSG lane */
-    reuse_lane = reuse_lane_map[wireup_lane];
-    if (reuse_lane != UCP_NULL_LANE) {
+    if (should_reuse) {
         /* previous wireup lane is part of the new configuration, so reuse it */
-        new_key->wireup_msg_lane = reuse_lane;
-    } else /* old wireup lane won't be reused */ {
-        /* previous wireup lane is not part of new configuration, so add it as
-         * auxiliary endpoint inside CM/non-reused lane, to be able to
-         * continue wireup messages exchange */
-        status = ucp_wireup_replace_wireup_msg_lane(ep, new_key, new_uct_eps,
-                                                    reuse_lane_map);
+        new_key->wireup_msg_lane = reuse_lane_map[wireup_lane];
+    } else {
+        /* Wireup/AM lane needs to be flushed to maintain message ordering */
+        status = ucp_wireup_replace_ordered_lane(ep, new_key, new_uct_eps,
+                                                 reuse_lane_map);
         if (status != UCS_OK) {
             return status;
         }
@@ -1587,6 +1729,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
         ucp_ep_set_lane(ep, lane, new_uct_eps[lane]);
     }
 
+    *am_need_flush_p = ucp_wireup_is_am_need_flush(ep, new_key, reuse_lane_map);
     return UCS_OK;
 }
 
@@ -1619,13 +1762,16 @@ ucp_wireup_try_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
 }
 
 static void
-ucp_wireup_gather_pending_reqs(ucp_ep_h ep,
-                               ucs_queue_head_t *replay_pending_queue)
+ucp_wireup_gather_pending_requests(ucp_ep_h ep,
+                                   ucs_queue_head_t *replay_pending_queue)
 {
     ucp_request_t *req;
+    ucp_lane_index_t lane;
 
+    /* Handle wireup EPs */
     ucp_wireup_eps_pending_extract(ep, replay_pending_queue);
 
+    /* rkey ptr requests */
     ucs_queue_for_each(req, &ep->worker->rkey_ptr_reqs,
                        send.rndv.rkey_ptr.queue_elem) {
         if (req->send.ep == ep) {
@@ -1633,12 +1779,27 @@ ucp_wireup_gather_pending_reqs(ucp_ep_h ep,
                            (ucs_queue_elem_t*)&req->send.uct.priv);
         }
     }
+
+    if (ep->cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
+        return;
+    }
+
+    /* Fully connected lanes */
+    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
+        if (ucp_wireup_ep_test(ucp_ep_get_lane(ep, lane))) {
+            continue;
+        }
+
+        uct_ep_pending_purge(ucp_ep_get_lane(ep, lane),
+                             ucp_request_purge_enqueue_cb,
+                             replay_pending_queue);
+    }
 }
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    const ucp_tl_bitmap_t *local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
-                                   unsigned *addr_indices)
+                                   unsigned *addr_indices, int *am_need_flush_p)
 {
     ucp_worker_h worker    = ep->worker;
     ucp_rsc_index_t cm_idx = UCP_NULL_RESOURCE;
@@ -1667,7 +1828,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                             UCP_EP_FLAG_REMOTE_CONNECTED);
     }
 
-    ucp_wireup_gather_pending_reqs(ep, &replay_pending_queue);
+    ucs_queue_head_init(&replay_pending_queue);
+    ucp_wireup_gather_pending_requests(ep, &replay_pending_queue);
 
     status = ucp_wireup_try_select_lanes(ep, ep_init_flags, &tl_bitmap,
                                          remote_address, addr_indices, &key,
@@ -1711,7 +1873,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     status = ucp_wireup_check_config_intersect(ep, &key, remote_address,
                                                addr_indices,
                                                &connect_lane_bitmap,
-                                               &replay_pending_queue);
+                                               &replay_pending_queue,
+                                               am_need_flush_p);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -47,6 +47,7 @@ enum {
     UCP_WIREUP_MSG_ACK,
     UCP_WIREUP_MSG_EP_CHECK,
     UCP_WIREUP_MSG_EP_REMOVED,
+    UCP_WIREUP_MSG_REPLY_RECONFIG,
     UCP_WIREUP_MSG_LAST
 };
 
@@ -180,7 +181,8 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    const ucp_tl_bitmap_t *local_tl_bitmap,
                                    const ucp_unpacked_address_t *remote_address,
-                                   unsigned *addr_indices);
+                                   unsigned *addr_indices,
+                                   int *am_need_flush_p);
 
 ucs_status_t
 ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -651,6 +651,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     unsigned addr_indices[UCP_MAX_RESOURCES];
     ucs_status_t status;
     uint8_t sa_data_ver;
+    int am_need_flush;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
@@ -695,8 +696,8 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
     dev_index = ucp_cm_tl_bitmap_get_dev_idx(worker->context, &tl_bitmap);
 
     ucp_context_dev_idx_tl_bitmap(context, dev_index, &tl_bitmap);
-    status    = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags,
-                                      &tl_bitmap, &addr, addr_indices);
+    status = ucp_wireup_init_lanes(ucp_ep, wireup_ep->ep_init_flags, &tl_bitmap,
+                                   &addr, addr_indices, &am_need_flush);
     if (status != UCS_OK) {
         ucs_debug("ep %p: failed to initialize lanes: %s", ucp_ep,
                   ucs_status_string(status));

--- a/test/gtest/ucp/test_ucp_ep_reconfig.cc
+++ b/test/gtest/ucp/test_ucp_ep_reconfig.cc
@@ -57,6 +57,7 @@ protected:
         bool is_lane_connected(ucp_ep_h ep, ucp_lane_index_t lane_idx,
                                const entity &other) const;
         ucp_tl_bitmap_t reduced_tl_bitmap() const;
+        unsigned num_shm_rscs() const;
 
         ucp_worker_cfg_index_t m_cfg_index       = UCP_WORKER_CFG_INDEX_NULL;
         unsigned               m_num_reused_rscs = 0;
@@ -74,10 +75,9 @@ protected:
         return GetParam().transports.size() == 1;
     }
 
-    bool has_p2p_transport()
+    virtual bool should_reconfigure()
     {
-        return has_resource(sender(), "rc_verbs") ||
-               has_resource(sender(), "rc_mlx5");
+        return true;
     }
 
     void create_entity(bool push_front, bool exclude_ifaces)
@@ -110,7 +110,22 @@ public:
             UCS_TEST_SKIP_R("test requires at least 2 ifaces to work");
         }
 
-        ensure_reused_lanes_reconfigurable();
+        if (has_transport("tcp")) {
+            UCS_TEST_SKIP_R("TODO: fix lane matching functionality in case "
+                            "there's matching remote MDs and different "
+                            "sys_devs");
+        }
+
+        if (has_transport("gga") && !reuse_lanes()) {
+            UCS_TEST_SKIP_R("TODO: revert this after replacing "
+                            "'is_lane_connected' with protocols check");
+        }
+
+        /* TODO: replace with more specific 'fence mode' check after Michal's
+         * PR is merged */
+        if (!is_proto_enabled()) {
+            UCS_TEST_SKIP_R("proto v1 use weak fence by default");
+        }
     }
 
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
@@ -120,8 +135,8 @@ public:
     }
 
     void run(bool bidirectional = false);
-    void skip_non_p2p();
-    void ensure_reused_lanes_reconfigurable();
+    virtual ucp_tl_bitmap_t tl_bitmap();
+    void check_single_flush();
 
     bool reuse_lanes() const
     {
@@ -151,9 +166,9 @@ public:
 
     void send_recv(bool bidirectional)
     {
-/* TODO: remove this when 100MB asan bug is solved */
+/* TODO: remove this when large messages asan bug is solved (size > ~70MB) */
 #ifdef __SANITIZE_ADDRESS__
-        static const size_t msg_sizes[] = {8, 1024, 16384, 65536};
+        static const size_t msg_sizes[] = {8, 1024, 16384, 32768};
 #else
         static const size_t msg_sizes[] = {8, 1024, 16384, UCS_MBYTE};
 #endif
@@ -200,10 +215,27 @@ void test_ucp_ep_reconfig::entity::store_config()
 
     /* Calculate number of reused resources by:
      * 1) Count number of resources used in EP configuration.
-     * 2) Take half of total resources to be reused. */
+     * 2) Take half of total resources to be reused.
+     * 3) For asymmetric mode, only SHM resources are reused. */
     auto num_reused   = UCS_STATIC_BITMAP_POPCOUNT(ep_tl_bitmap()) / 2;
     auto test         = static_cast<const test_ucp_ep_reconfig*>(m_test);
-    m_num_reused_rscs = test->reuse_lanes() ? num_reused : 0;
+    m_num_reused_rscs = m_exclude_ifaces ?
+                                (test->reuse_lanes() ? num_reused : 0) :
+                                num_shm_rscs();
+}
+
+unsigned test_ucp_ep_reconfig::entity::num_shm_rscs() const
+{
+    unsigned num_shm = 0;
+    auto tl_bitmap   = ep_tl_bitmap();
+    ucp_rsc_index_t rsc_idx;
+
+    UCS_STATIC_BITMAP_FOR_EACH_BIT(rsc_idx, &tl_bitmap) {
+        num_shm += (ucph()->tl_rscs[rsc_idx].tl_rsc.dev_type ==
+                    UCT_DEVICE_TYPE_SHM);
+    }
+
+    return num_shm;
 }
 
 ucp_tl_bitmap_t
@@ -231,7 +263,8 @@ test_ucp_ep_reconfig::entity::ep_tl_bitmap(unsigned max_num_rscs) const
 ucp_tl_bitmap_t test_ucp_ep_reconfig::entity::reduced_tl_bitmap() const
 {
     if ((ep() == NULL) || !m_exclude_ifaces) {
-        return ucp_tl_bitmap_max;
+        /* Take bitmap from test */
+        return ((test_ucp_ep_reconfig*)m_test)->tl_bitmap();
     }
 
     /* Use only resources not already in use, or part of reuse bitmap */
@@ -316,11 +349,13 @@ void test_ucp_ep_reconfig::entity::verify_configuration(
         UCS_STATIC_BITMAP_SET(&reused_rscs, ucp_ep_get_rsc_index(ep(), lane));
     }
 
-    if (is_reconfigured()) {
-        EXPECT_EQ(expected_reused_rscs,
-                  UCS_STATIC_BITMAP_POPCOUNT(reused_rscs));
-    } else {
+    auto test = static_cast<const test_ucp_ep_reconfig*>(m_test);
+
+    if (!is_reconfigured()) {
         EXPECT_EQ(num_lanes, reused_lanes);
+    } else if (test->reuse_lanes() && (expected_reused_rscs > 0)) {
+        EXPECT_EQ(expected_reused_rscs,
+                           UCS_STATIC_BITMAP_POPCOUNT(reused_rscs));
     }
 }
 
@@ -367,6 +402,27 @@ void test_ucp_ep_reconfig::pattern_check(const mem_buffer_vec_t &rbufs) const
     }
 }
 
+ucp_tl_bitmap_t test_ucp_ep_reconfig::tl_bitmap()
+{
+    if (!is_single_transport()) {
+        return ucp_tl_bitmap_max;
+    }
+
+    /* For single transport, half of the resources should be reserved for
+     * receiver side to use */
+    ucp_tl_bitmap_t tl_bitmap = UCS_STATIC_BITMAP_ZERO_INITIALIZER;
+    size_t num_tls            = 0;
+    ucp_rsc_index_t rsc_idx;
+
+    UCS_STATIC_BITMAP_FOR_EACH_BIT(rsc_idx, &sender().ucph()->tl_bitmap) {
+        if (++num_tls > (sender().ucph()->num_tls / 2)) {
+            UCS_STATIC_BITMAP_SET(&tl_bitmap, rsc_idx);
+        }
+    }
+
+    return tl_bitmap;
+}
+
 void test_ucp_ep_reconfig::run(bool bidirectional)
 {
     create_entities_and_connect();
@@ -375,67 +431,45 @@ void test_ucp_ep_reconfig::run(bool bidirectional)
     auto r_sender   = static_cast<const entity*>(&sender());
     auto r_receiver = static_cast<const entity*>(&receiver());
 
-    EXPECT_NE(r_sender->is_reconfigured(), r_receiver->is_reconfigured());
+    if (should_reconfigure()) {
+        EXPECT_NE(r_sender->is_reconfigured(), r_receiver->is_reconfigured());
+    } else {
+        EXPECT_FALSE(r_sender->is_reconfigured());
+        EXPECT_FALSE(r_receiver->is_reconfigured());
+    }
 
     r_sender->verify_configuration(*r_receiver, r_sender->num_reused_rscs());
     r_receiver->verify_configuration(*r_sender, r_sender->num_reused_rscs());
 }
 
-void test_ucp_ep_reconfig::skip_non_p2p()
+void test_ucp_ep_reconfig::check_single_flush()
 {
-    if (!has_p2p_transport()) {
-        UCS_TEST_SKIP_R("No p2p TLs available, config will be non-wireup");
+    if (has_transport("shm")) {
+        /* TODO: add support for reconfiguration of separate wireup and AM
+         * lanes */
+        modify_config("WIREUP_VIA_AM_LANE", "y");
     }
 }
 
-void test_ucp_ep_reconfig::ensure_reused_lanes_reconfigurable()
+UCS_TEST_P(test_ucp_ep_reconfig, basic)
 {
-    if (!reuse_lanes()) {
-        return;
-    }
-
-    if (has_transport("tcp") || has_transport("dc_x") || has_transport("shm")) {
-        UCS_TEST_SKIP_R("non wired-up lanes are not supported yet");
-    }
-}
-
-/* TODO: Remove skip condition after next PRs are merged. */
-UCS_TEST_SKIP_COND_P(test_ucp_ep_reconfig, basic, !has_transport("rc"))
-{
+    check_single_flush();
     run();
 }
 
 UCS_TEST_P(test_ucp_ep_reconfig, request_reset, "PROTO_REQUEST_RESET=y")
 {
-    if (is_single_transport()) {
-        /* One side will consume all ifaces and the other side will have no ifaces left to use */
-        UCS_TEST_SKIP_R("exclude_iface requires at least 2 transports to work "
-                        "(for example DC + SHM)");
-    }
-
-    skip_non_p2p();
+    check_single_flush();
     run();
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_ep_reconfig, resolve_remote_id, is_self(),
-                     "MAX_RNDV_LANES=0")
+UCS_TEST_P(test_ucp_ep_reconfig, resolve_remote_id)
 {
-    if (has_transport("tcp")) {
-        UCS_TEST_SKIP_R("asymmetric setup is not supported for this transport "
-                        "due to a reachability issue - only matching "
-                        "interfaces can connect");
-    }
-
-    if (has_transport("shm")) {
-        UCS_TEST_SKIP_R("AM messages might be sent before reconfiguration"
-                        "(would be supported in next PR)");
-    }
-
+    check_single_flush();
     run(true);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_ep_reconfig);
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_ep_reconfig, rc_x_v, "rc");
 
 class test_reconfig_asymmetric : public test_ucp_ep_reconfig {
 protected:
@@ -449,25 +483,38 @@ protected:
         sender().connect(&receiver(), get_ep_params());
         receiver().connect(&sender(), get_ep_params());
     }
+
+    ucp_tl_bitmap_t tl_bitmap() override
+    {
+        return ucp_tl_bitmap_max;
+    }
+
+    bool should_reconfigure() override
+    {
+        static const std::vector<std::string> ib_tls = {"rc_mlx5", "dc_mlx5",
+                                                        "rc_verbs", "ud_verbs",
+                                                        "ud_mlx5"};
+
+        /* In case there's no IB devices, new config will be identical to
+         * old config (thus no reconfiguration will be triggered). */
+        return std::any_of(ib_tls.begin(), ib_tls.end(),
+                           [&](const std::string &tl_name) {
+                               return has_resource(sender(), tl_name);
+                           });
+    }
 };
 
-/* Will be relevant when reuse + non-wireup is supported */
-UCS_TEST_SKIP_COND_P(test_reconfig_asymmetric, basic, has_transport("shm"))
+UCS_TEST_P(test_reconfig_asymmetric, basic)
 {
     run();
 }
 
-/* Will be relevant when reuse + non-wireup is supported */
-UCS_TEST_SKIP_COND_P(test_reconfig_asymmetric, request_reset,
-                     has_transport("shm"), "PROTO_REQUEST_RESET=y")
+UCS_TEST_P(test_reconfig_asymmetric, request_reset, "PROTO_REQUEST_RESET=y")
 {
-    skip_non_p2p();
     run();
 }
 
-/* SHM + single lane won't trigger reconfig. */
-UCS_TEST_SKIP_COND_P(test_reconfig_asymmetric, resolve_remote_id,
-                     has_transport("shm") || is_self(), "MAX_RNDV_LANES=0")
+UCS_TEST_P(test_reconfig_asymmetric, resolve_remote_id)
 {
     run(true);
 }


### PR DESCRIPTION
## What?
UCP/WIREUP: Support EP reconfiguration for non wired-up scenarios

## Why?
This PR introduces 2 additional usecases supported:
1) Reconfiguration during send/recv phase (after wireup completion).
2) Reconfiguration during wireup phase for non p2p transports, given that one of the following conditions takes place:
    - wireup lane and AM lane are equal.
    - AM lane is reused.
    - AM transport is p2p.

