### PR TITLE
UCP/PROTO: Added name and description for stream operation.

### DIFF
--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -87,6 +87,7 @@ const char *ucp_operation_names[] = {
     [UCP_OP_ID_TAG_SEND_SYNC]  = "tag_send_sync",
     [UCP_OP_ID_AM_SEND]        = "am_send",
     [UCP_OP_ID_AM_SEND_REPLY]  = "am_send_reply",
+    [UCP_OP_ID_STREAM_SEND]    = "stream",
     [UCP_OP_ID_PUT]            = "put",
     [UCP_OP_ID_GET]            = "get",
     [UCP_OP_ID_AMO_POST]       = "amo_post",
@@ -104,6 +105,7 @@ const char *ucp_operation_descs[] = {
     [UCP_OP_ID_AM_SEND]        = "active message by ucp_am_send*",
     [UCP_OP_ID_AM_SEND_REPLY]  = "active message by ucp_am_send* with reply "
                                  "flag",
+    [UCP_OP_ID_STREAM_SEND]    = "stream message by ucp_stream_send*",
     [UCP_OP_ID_PUT]            = "remote memory write by ucp_put*",
     [UCP_OP_ID_GET]            = "remote memory read by ucp_get*",
     [UCP_OP_ID_AMO_POST]       = "posted atomic by ucp_atomic_op*",


### PR DESCRIPTION
## What?
Added name and description for stream operation.

## Why?
Before
```
+--------------------------------+-------------------------------------------------+
| client_server intra-node cfg#3 | (null) from host memory                         |
+--------------------------------+--------------------------------------+----------+
|                        0..8184 | multi-frag stream copy-in copy-out   | tcp/eth0 |
|                      8185..inf | multi-frag stream zero-copy copy-out | tcp/eth0 |
+--------------------------------+--------------------------------------+----------+

$ ls proto_info_dir/
client_server_intra_node_cfg_1__null_from_host_memory_0_0.dot     client_server_intra_node_cfg_1__null_from_host_memory_65529_inf.dot
client_server_intra_node_cfg_1__null_from_host_memory_1_8184.dot  client_server_intra_node_cfg_1__null_from_host_memory_8185_65528.dot
```

After
```
+--------------------------------+--------------------------------------------------------+
| client_server intra-node cfg#3 | stream message by ucp_stream_send* from host memory    |
+--------------------------------+---------------------------------------------+----------+
|                        0..8184 | multi-frag stream copy-in copy-out          | tcp/eth0 |
|                      8185..inf | multi-frag stream zero-copy copy-out        | tcp/eth0 |
+--------------------------------+---------------------------------------------+----------+


$ ls proto_info_dir/
client_server_intra_node_cfg_1_stream_from_host_memory_0_0.dot     client_server_intra_node_cfg_1_stream_from_host_memory_65529_inf.dot
client_server_intra_node_cfg_1_stream_from_host_memory_1_8184.dot  client_server_intra_node_cfg_1_stream_from_host_memory_8185_65528.dot
```