### PR TITLE
AZP/RELEASE: Fix variable substitution syntax for JUCX publishing

### DIFF
--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -53,8 +53,8 @@ jobs:
           set -eE
           {
             echo -e "<settings><servers><server>"
-            echo -e "<id>ossrh</id><username>\${env.SONATYPE_USERNAME}</username>"
-            echo -e "<password>\${env.SONATYPE_PASSWORD}</password>"
+            echo -e "<id>ossrh</id><username>$(SONATYPE_USERNAME)</username>"
+            echo -e "<password>$(SONATYPE_PASSWORD)</password>"
             echo -e "</server></servers></settings>"
           } > $(temp_cfg)
         displayName: Generate temporary config


### PR DESCRIPTION
## What?
Fix variable substitution syntax according to the documentation:
https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?WT.mc_id=devops-9483-zdeptawa&view=azure-devops&tabs=yaml%2Cbatch#reference-secret-variables-in-variable-groups

## Why?
JUCX publishing failed otherwise. 

