### PR TITLE
AZP/RELEASE: Fix variable substitution syntax for JUCX publishing (v1.18.x)

### DIFF
--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -53,8 +53,8 @@ jobs:
           set -eE
           {
             echo -e "<settings><servers><server>"
-            echo -e "<id>ossrh</id><username>\${env.SONATYPE_USERNAME}</username>"
-            echo -e "<password>\${env.SONATYPE_PASSWORD}</password>"
+            echo -e "<id>ossrh</id><username>$(SONATYPE_USERNAME)</username>"
+            echo -e "<password>$(SONATYPE_PASSWORD)</password>"
             echo -e "</server></servers></settings>"
           } > $(temp_cfg)
         displayName: Generate temporary config


### PR DESCRIPTION
## What?
Porting https://github.com/openucx/ucx/pull/10343 to the release branch.

