### PR TITLE
VFS: Ignore EEXIST errno

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Manjunath Gorentla Venkata <manjugv@gmail.com>
 Marek Schimara <Marek.Schimara@bull.net>
 Mark Allen <markalle@us.ibm.com>
 Matthew Baker <bakermb@ornl.gov>
+Michal Shalev <mshalev@nvidia.com>
 Mike Dubman <miked@mellanox.com>
 Mikhail Brinskii <mikhailb@nvidia.com>
 Min Fang <minf@nvidia.com>

--- a/src/tools/vfs/vfs_main.c
+++ b/src/tools/vfs/vfs_main.c
@@ -191,10 +191,15 @@ int vfs_mount(int pid)
     }
 
     ret = mkdir(mountpoint, S_IRWXU);
-    if ((ret < 0) && (errno != EEXIST)) {
-        ret = -errno;
-        vfs_error("failed to create directory '%s': %m", mountpoint);
-        goto out_free_mountpoint;
+    if (ret < 0) {
+        if (errno == EEXIST) {
+            /* Directory already exists */
+            ret = 0;
+        } else {
+            ret = -errno;
+            vfs_error("failed to create directory '%s': %m", mountpoint);
+            goto out_free_mountpoint;
+        }
     }
 
     /* Mount a new FUSE filesystem in the mount point directory */

--- a/src/ucs/vfs/sock/vfs_sock.c
+++ b/src/ucs/vfs/sock/vfs_sock.c
@@ -55,10 +55,15 @@ int ucs_vfs_sock_mkdir(const char *sock_path, ucs_log_level_t log_level)
     }
 
     ret = mkdir(dirname, S_IRWXU);
-    if ((ret < 0) && (errno != EEXIST)) {
-        ucs_log(log_level, "failed to create directory '%s': %m",
-                sock_path_dir);
-        ret = -errno;
+    if (ret < 0) {
+        if (errno == EEXIST) {
+            /* Directory already exists */
+            ret = 0;
+        } else {
+            ucs_log(log_level, "failed to create directory '%s': %m",
+                    sock_path_dir);
+            ret = -errno;
+        }
     }
 
     ucs_free(sock_path_dir);


### PR DESCRIPTION
## What?
Ignore EEXIST errno in `vfs_mount()` and `ucs_vfs_sock_mkdir()`.

## Why?
Bug introduced in https://github.com/openucx/ucx/pull/10127 where instead of ignoring the EEXIST that returns from mkdir, `vfs_mount()` and `ucs_vfs_sock_mkdir()` return an error in case the directory already exists, which should be ignored.
