### PR TITLE
TEST/APPS: Fix test_ucx_tls.py failure

### DIFF
--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -214,8 +214,7 @@ def test_tls_allow_list(ucx_info):
 
     # Add some IB variant (both strict and alias), if available
     for tls_variant in available_tls:
-        if tls_variant.startswith("rc_") or tls_variant.startswith("dc_") or \
-           tls_variant.startswith("ud_"):
+        if tls_variant.startswith("dc_") or tls_variant.startswith("ud_"):
             tls_variants += ["ib", "\\" + tls_variant]
             break
 


### PR DESCRIPTION
## Why
Fix failures like:
```
...
Using UCX_TLS=tcp, found TL: self
Using UCX_TLS=posix, found TL: posix
Using UCX_TLS=posix, found TL: self
Using UCX_TLS=ib, found TL: rc_mlx5
Using UCX_TLS=ib, found TL: self
Using UCX_TLS=\rc_mlx5, found TL: None
```

## How
Python3 changed the order in available_tls list, exposing an issue that RC transport could be instantiated without UD for wireup.