### PR TITLE
TEST/APPS: Fix test_ucx_tls.py failure (v1.18.x)

### DIFF
--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -214,8 +214,7 @@ def test_tls_allow_list(ucx_info):
 
     # Add some IB variant (both strict and alias), if available
     for tls_variant in available_tls:
-        if tls_variant.startswith("rc_") or tls_variant.startswith("dc_") or \
-           tls_variant.startswith("ud_"):
+        if tls_variant.startswith("dc_") or tls_variant.startswith("ud_"):
             tls_variants += ["ib", "\\" + tls_variant]
             break
 


### PR DESCRIPTION
## What?
Porting https://github.com/openucx/ucx/pull/10350 to branch v1.18.x.
