### PR TITLE
RFC: UCS/ARCH: Avoid direct usage of REP MOVSB in favor of memcpy

### DIFF
--- a/src/ucs/arch/aarch64/global_opts.h
+++ b/src/ucs/arch/aarch64/global_opts.h
@@ -13,7 +13,6 @@ BEGIN_C_DECLS
 
 #define UCS_ARCH_GLOBAL_OPTS_INITALIZER {}
 
-/* built-in memcpy config */
 typedef struct ucs_arch_global_opts {
     char dummy;
 } ucs_arch_global_opts_t;

--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -41,48 +41,6 @@ struct { /* sysfs entries for system cache sizes */
     [UCS_CPU_CACHE_L3]  = {.level = 3, .type = "Unified"}
 };
 
-const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST] = {
-    [UCS_CPU_VENDOR_UNKNOWN] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_INTEL] = {
-        .min = 1 * UCS_KBYTE,
-        .max = 8 * UCS_MBYTE
-    },
-    /* TODO: investigate why `rep movsb` is slow for shared buffers
-     * on some AMD configurations */
-    [UCS_CPU_VENDOR_AMD] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_GENERIC_ARM] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_GENERIC_PPC] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_FUJITSU_ARM] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_ZHAOXIN] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_GENERIC_RV64G] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    },
-    [UCS_CPU_VENDOR_NVIDIA] = {
-        .min = UCS_MEMUNITS_INF,
-        .max = UCS_MEMUNITS_INF
-    }
-};
-
-
 static void ucs_sysfs_get_cache_size()
 {
     char type_str[32];  /* Data/Instruction/Unified */

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -87,14 +87,6 @@ typedef enum ucs_cpu_cache_type {
     UCS_CPU_CACHE_LAST
 } ucs_cpu_cache_type_t;
 
-
-/* Built-in memcpy settings */
-typedef struct ucs_cpu_builtin_memcpy {
-    size_t min;
-    size_t max;
-} ucs_cpu_builtin_memcpy_t;
-
-
 /* System constants */
 #define UCS_SYS_POINTER_SIZE       (sizeof(void*))
 #define UCS_SYS_PARAGRAPH_SIZE     16
@@ -118,9 +110,6 @@ typedef struct ucs_cpu_builtin_memcpy {
 #else
 #define UCS_SYS_CACHE_LINE_SIZE    UCS_ARCH_CACHE_LINE_SIZE
 #endif
-
-/* Array of default built-in memcpy settings for different CPU architectures */
-extern const ucs_cpu_builtin_memcpy_t ucs_cpu_builtin_memcpy[UCS_CPU_VENDOR_LAST];
 
 #if HAVE___CLEAR_CACHE
 /* libc routine declaration */

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -578,24 +578,6 @@ ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
     return UCS_CPU_VENDOR_UNKNOWN;
 }
 
-#if ENABLE_BUILTIN_MEMCPY
-static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
-{
-    if (user_val != UCS_MEMUNITS_AUTO) {
-        return user_val;
-    }
-
-    if (((ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_INTEL) &&
-         (ucs_arch_get_cpu_model() >= UCS_CPU_MODEL_INTEL_HASWELL)) ||
-        (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD) ||
-        (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_ZHAOXIN)) {
-        return auto_val;
-    } else {
-        return UCS_MEMUNITS_INF;
-    }
-}
-#endif
-
 static size_t ucs_cpu_nt_bt_thresh_min(size_t user_val)
 {
     if (user_val != UCS_MEMUNITS_AUTO) {
@@ -620,14 +602,6 @@ static size_t ucs_cpu_nt_dest_thresh()
 
 void ucs_cpu_init()
 {
-#if ENABLE_BUILTIN_MEMCPY
-    ucs_global_opts.arch.builtin_memcpy_min =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_min,
-                              ucs_cpu_builtin_memcpy[ucs_arch_get_cpu_vendor()].min);
-    ucs_global_opts.arch.builtin_memcpy_max =
-        ucs_cpu_memcpy_thresh(ucs_global_opts.arch.builtin_memcpy_max,
-                              ucs_cpu_builtin_memcpy[ucs_arch_get_cpu_vendor()].max);
-#endif
     ucs_global_opts.arch.nt_buffer_transfer_min =
         ucs_cpu_nt_bt_thresh_min(ucs_global_opts.arch.nt_buffer_transfer_min);
     ucs_global_opts.arch.nt_dest_threshold = ucs_cpu_nt_dest_thresh();

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -101,21 +101,6 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
                                        ucs_arch_memcpy_hint_t hint,
                                        size_t total_len)
 {
-#if ENABLE_BUILTIN_MEMCPY
-    if (ucs_unlikely((len > ucs_global_opts.arch.builtin_memcpy_min) &&
-                     (len < ucs_global_opts.arch.builtin_memcpy_max))) {
-        asm volatile ("rep movsb"
-                      : "=D" (dst),
-                      "=S" (src),
-                      "=c" (len)
-                      : "0" (dst),
-                      "1" (src),
-                      "2" (len)
-                      : "memory");
-        return dst;
-    }
-#endif
-
 #ifdef __AVX__
     if (ucs_unlikely(total_len >= ucs_global_opts.arch.nt_buffer_transfer_min)) {
         ucs_x86_nt_buffer_transfer(dst, src, len, hint, total_len);

--- a/src/ucs/arch/x86_64/global_opts.c
+++ b/src/ucs/arch/x86_64/global_opts.c
@@ -15,17 +15,6 @@
 #include <ucs/config/parser.h>
 
 ucs_config_field_t ucs_arch_global_opts_table[] = {
-#if ENABLE_BUILTIN_MEMCPY
-  {"BUILTIN_MEMCPY_MIN", "auto",
-   "Minimal threshold of buffer length for using built-in memcpy.",
-   ucs_offsetof(ucs_arch_global_opts_t, builtin_memcpy_min),
-   UCS_CONFIG_TYPE_MEMUNITS},
-
-  {"BUILTIN_MEMCPY_MAX", "auto",
-   "Maximal threshold of buffer length for using built-in memcpy.",
-   ucs_offsetof(ucs_arch_global_opts_t, builtin_memcpy_max),
-   UCS_CONFIG_TYPE_MEMUNITS},
-#endif
   {"NT_BUFFER_TRANSFER_MIN", "auto",
    "Minimal threshold of buffer length for using non-temporal buffer transfer.",
    ucs_offsetof(ucs_arch_global_opts_t, nt_buffer_transfer_min),
@@ -38,16 +27,6 @@ void ucs_arch_print_memcpy_limits(ucs_arch_global_opts_t *config)
 {
     char min_thresh_str[32];
     char dest_thresh_str[32];
-
-#if ENABLE_BUILTIN_MEMCPY
-    char max_thresh_str[32];
-    ucs_config_sprintf_memunits(min_thresh_str, sizeof(min_thresh_str),
-                                &config->builtin_memcpy_min, NULL);
-    ucs_config_sprintf_memunits(max_thresh_str, sizeof(max_thresh_str),
-                                &config->builtin_memcpy_max, NULL);
-    printf("# Using built-in memcpy() for size %s..%s\n",
-           min_thresh_str, max_thresh_str);
-#endif
 
     ucs_config_sprintf_memunits(min_thresh_str, sizeof(min_thresh_str),
                                 &config->nt_buffer_transfer_min, NULL);

--- a/src/ucs/arch/x86_64/global_opts.h
+++ b/src/ucs/arch/x86_64/global_opts.h
@@ -15,16 +15,12 @@
 BEGIN_C_DECLS
 
 #define UCS_ARCH_GLOBAL_OPTS_INITALIZER { \
-    .builtin_memcpy_min     = UCS_MEMUNITS_AUTO, \
-    .builtin_memcpy_max     = UCS_MEMUNITS_AUTO, \
     .nt_buffer_transfer_min = UCS_MEMUNITS_AUTO, \
     .nt_dest_threshold      = UCS_MEMUNITS_AUTO  \
 }
 
-/* built-in memcpy & nt-buffer-transfer config */
+/*  nt-buffer-transfer config */
 typedef struct ucs_arch_global_opts {
-    size_t builtin_memcpy_min;
-    size_t builtin_memcpy_max;
     size_t nt_buffer_transfer_min;
     size_t nt_dest_threshold;
 } ucs_arch_global_opts_t;

--- a/test/gtest/ucs/arch/test_x86_64.cc
+++ b/test/gtest/ucs/arch/test_x86_64.cc
@@ -137,17 +137,8 @@ UCS_TEST_SKIP_COND_F(test_arch, memcpy, RUNNING_ON_VALGRIND || !ucs::perf_retry_
     double secs;
     size_t size;
     char memunits_str[256];
-    char thresh_min_str[16];
-    char thresh_max_str[16];
     int i;
 
-    ucs_memunits_to_str(ucs_global_opts.arch.builtin_memcpy_min,
-                        thresh_min_str, sizeof(thresh_min_str));
-    ucs_memunits_to_str(ucs_global_opts.arch.builtin_memcpy_max,
-                        thresh_max_str, sizeof(thresh_max_str));
-    UCS_TEST_MESSAGE << "Using memcpy relaxed for size " <<
-                        thresh_min_str << ".." <<
-                        thresh_max_str;
     for (size = 4096; size <= 256 * UCS_MBYTE; size *= 2) {
         secs = ucs_get_accurate_time();
         for (i = 0; ucs_get_accurate_time() - secs < timeout; i++) {


### PR DESCRIPTION
Glibc has two tunable parameters that control the use of 'REP MOVSB':

a) __x86_rep_movsb_threshold
b) __x86_rep_movsb_stop_threshold

Ref: https://elixir.bootlin.com/glibc/glibc-2.34/source/sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S

Users can set the desired value of __x86_rep_movsb_threshold through the tunable glibc.cpu.x86_rep_movsb_threshold and can decide which length range uses ERMS and which range uses
vectorized routines.

Ref: https://www.gnu.org/software/libc/manual/html_node/Tunables.html

These tunable parameters are set based on the x86 CPU type and available hardware features.  Instead of replicating this infrastructure in UCX, we can utilize the 'REP MOVSB' mechanism via memcpy().
