### PR TITLE
AZP: Build RPM tarball per PR

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -86,13 +86,13 @@ build_release_pkg() {
 	else
 		echo "==== Build RPM ===="
 		echo "$PWD"
-		${WORKSPACE}/contrib/buildrpm.sh -s -b --nodeps --define "_topdir $PWD"
+		${WORKSPACE}/contrib/buildrpm.sh -s -t -b --nodeps --define "_topdir $PWD"
 		if rpm -qp ${PWD}/rpm-dist/ucx-[0-9]*.rpm --requires | grep cuda; then
 			azure_log_error "Release build depends on CUDA while it should not"
 			exit 1
 		fi
 		echo "==== Build debug RPM ===="
-		${WORKSPACE}/contrib/buildrpm.sh -s -b -d --nodeps --define "_topdir $PWD/debug"
+		${WORKSPACE}/contrib/buildrpm.sh -s -t -b -d --nodeps --define "_topdir $PWD/debug"
 	fi
 
 	# check that UCX version is present in spec file


### PR DESCRIPTION
## What?  
Build an RPM tarball as part of the UCX PR pipeline, mirroring the process used in the release pipeline.  

## Why?  
To identify RPM tarball build issues early in the development cycle. 