### PR TITLE
TEST/APPS: Fixed building rpm.

### DIFF
--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -101,11 +101,14 @@ if HAVE_NVCC
 noinst_PROGRAMS                      += test_cuda_get_symbol_address
 test_cuda_get_symbol_address_SOURCES  = test_cuda_get_symbol_address.cu
 test_cuda_get_symbol_address_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
-test_cuda_get_symbol_address_CFLAGS   = $(BASE_CFLAGS)
 test_cuda_get_symbol_address_LDFLAGS  = $(CUDA_LDFLAGS)
 test_cuda_get_symbol_address_LDADD    = $(top_builddir)/src/ucp/libucp.la \
                                         $(top_builddir)/src/ucm/libucm.la \
                                         $(CUDART_LIBS)
+test_cuda_get_symbol_address_DEPBASE  = $(DEPDIR)/test_cuda_get_symbol_address
+test_cuda_get_symbol_address_COMPILE  = \
+    $(NVCC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
+    $(test_cuda_get_symbol_address_CPPFLAGS)
 endif
 
 endif
@@ -122,9 +125,8 @@ endif
 .cu.o : ; $(NVCC) -c -o $@ $<
 
 test_cuda_get_symbol_address.o: test_cuda_get_symbol_address.cu
-	$(NVCC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
-	$(test_cuda_get_symbol_address_CPPFLAGS) -MT $@ -MD -MF \
-	$(DEPDIR)/test_cuda_get_symbol_address.Tpo -c -o $@ \
-	`test -f '$<' || echo '$(srcdir)/'`$<
-	$(AM_V_at)$(am__mv) $(DEPDIR)/test_cuda_get_symbol_address.Tpo \
-	$(DEPDIR)/test_cuda_get_symbol_address.Po
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(test_cuda_get_symbol_address_COMPILE) -MT $@ -MD -MF $(test_cuda_get_symbol_address_DEPBASE).Tpo -c -o $@ `test -f '$(<F)' || echo '$(srcdir)/'`$(<F)
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(test_cuda_get_symbol_address_DEPBASE).Tpo $(test_cuda_get_symbol_address_DEPBASE).Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='$(<F)' object='$@' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(test_cuda_get_symbol_address_COMPILE) -Xcompiler "-fPIC" -c -o $@ `test -f '$(<F)' || echo '$(srcdir)/'`$(<F)


### PR DESCRIPTION
## What?
Fixed the following scenario:
```
$ ./autogen.sh
$ ./contrib/configure-release --with-java=no
$ ./contrib/buildrpm.sh -s -t -b
...
nvcc fatal   : Could not open output file .deps/test_cuda_get_symbol_address.Tpo
```
