### PR TITLE
v1.18.x - UCT/IB/MLX5: Add DDP support for DevX

### DIFF
--- a/src/ucs/sys/compiler_def.h
+++ b/src/ucs/sys/compiler_def.h
@@ -80,6 +80,9 @@
 /* Mask of bits 0..i-1 */
 #define UCS_MASK(_i)             (((_i) >= 64) ? ~0 : (UCS_BIT(_i) - 1))
 
+/* The i-th bit */
+#define UCS_BIT_GET(_value, _i)  (!!((_value) & UCS_BIT(_i)))
+
 /*
  * Enable compiler checks for printf-like formatting.
  *

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -239,7 +239,9 @@ enum {
     /* Indicates that TX cq len in uct_ib_iface_init_attr_t is specified per
      * each IB path. Therefore IB interface constructor would need to multiply
      * TX CQ len by the number of IB paths (when it is properly initialized). */
-    UCT_IB_TX_OPS_PER_PATH           = UCS_BIT(2)
+    UCT_IB_TX_OPS_PER_PATH           = UCS_BIT(2),
+    /* Whether device and transport supports DDP */
+    UCT_IB_DDP_SUPPORTED             = UCS_BIT(3)
 };
 
 
@@ -345,7 +347,6 @@ struct uct_ib_iface {
         enum ibv_mtu                 path_mtu;
         uint8_t                      counter_set_id;
         uct_ib_iface_send_overhead_t send_overhead;
-        ucs_ternary_auto_value_t     dp_ordering_ooo; /* Activate RW OOO */
     } config;
 
     uct_ib_iface_ops_t        *ops;

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1610,6 +1610,10 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         init_attr.flags  |= UCT_IB_TM_SUPPORTED;
     }
 
+    if (md->dp_ordering_cap.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) {
+        init_attr.flags |= UCT_IB_DDP_SUPPORTED;
+    }
+
     status = uct_dc_mlx5_calc_sq_length(md, tx_queue_len, &sq_length);
     if (status != UCS_OK) {
         return status;
@@ -1623,9 +1627,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
                               tl_md, worker, params, &config->super,
                               &config->rc_mlx5_common, &init_attr);
 
-    status = uct_rc_mlx5_dp_ordering_ooo_init(
-            &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC,
-            &config->rc_mlx5_common, "dc");
+    status = uct_rc_mlx5_dp_ordering_ooo_init(&self->super,
+                                              md->dp_ordering_cap.dc,
+                                              &config->rc_mlx5_common, "dc");
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/mlx5/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_devx.c
@@ -49,15 +49,14 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
                               ib_iface->config.max_inl_cqe[UCT_IB_DIR_RX], 1));
     UCT_IB_MLX5DV_SET(dctc, dctc, atomic_mode,
                       uct_ib_mlx5_get_atomic_mode(ib_iface));
-    if (uct_ib_iface_is_roce(&iface->super.super.super)) {
-        UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_0,
-                          ucs_ternary_auto_value_is_yes_or_try(
-                                  ib_iface->config.dp_ordering_ooo));
-        UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_1, 0);
-        UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_force,
-                          ucs_ternary_auto_value_is_yes_or_no(
-                                  ib_iface->config.dp_ordering_ooo));
-    } else {
+    UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_0,
+                      UCS_BIT_GET(iface->super.config.dp_ordering, 0));
+    UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_1,
+                      UCS_BIT_GET(iface->super.config.dp_ordering, 1));
+    UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_force,
+                      iface->super.config.dp_ordering_force);
+
+    if (!uct_ib_iface_is_roce(&iface->super.super.super)) {
         UCT_IB_MLX5DV_SET(dctc, dctc, pkey_index, ib_iface->pkey_index);
     }
 
@@ -145,6 +144,9 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
     UCT_IB_MLX5DV_SET(qpc, qpc, atomic_mode,
                       uct_ib_mlx5_get_atomic_mode(&rc_iface->super));
     UCT_IB_MLX5DV_SET(qpc, qpc, rae, true);
+
+    uct_ib_mlx5_devx_set_qpc_dp_ordering(md, qpc, &iface->super);
+
     if (uct_ib_iface_is_roce(&rc_iface->super)) {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.eth_prio,
                           rc_iface->super.config.sl);
@@ -152,9 +154,6 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
             uct_ib_mlx5_devx_set_qpc_port_affinity(md, dci_config->path_index,
                                                    qpc, &opt_param_mask);
         }
-
-        uct_ib_mlx5_devx_set_qpc_dp_ordering(
-                qpc, rc_iface->super.config.dp_ordering_ooo);
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.sl,
                           rc_iface->super.config.sl);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -462,16 +462,6 @@ ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
     return UCS_OK;
 }
 
-void uct_ib_mlx5_devx_set_qpc_dp_ordering(
-        void *qpc, ucs_ternary_auto_value_t dp_ordering_ooo)
-{
-    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_0,
-                      ucs_ternary_auto_value_is_yes_or_try(dp_ordering_ooo));
-    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_1, 0);
-    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_force,
-                      ucs_ternary_auto_value_is_yes_or_no(dp_ordering_ooo));
-}
-
 void uct_ib_mlx5_devx_set_qpc_port_affinity(uct_ib_mlx5_md_t *md,
                                             uint8_t path_index, void *qpc,
                                             uint32_t *opt_param_mask)

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -323,7 +323,12 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    log_max_transport_domain[0x5];
     uint8_t    reserved_at_328[0x3];
     uint8_t    log_max_pd[0x5];
-    uint8_t    reserved_at_330[0xb];
+    uint8_t    dp_ordering_ooo_all_ud[0x1];
+    uint8_t    dp_ordering_ooo_all_uc[0x1];
+    uint8_t    dp_ordering_ooo_all_xrc[0x1];
+    uint8_t    dp_ordering_ooo_all_dc[0x1];
+    uint8_t    dp_ordering_ooo_all_rc[0x1];
+    uint8_t    reserved_at_335[0x6];
     uint8_t    log_max_xrcd[0x5];
 
     uint8_t    nic_receive_steering_discard[0x1];

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1883,12 +1883,20 @@ static void uct_ib_mlx5_devx_check_dp_ordering(uct_ib_mlx5_md_t *md, void *cap,
                                                void *cap_2,
                                                uct_ib_device_t *dev)
 {
-    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dp_ordering_ooo_rw_rc)) {
-        md->flags |= UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC;
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dp_ordering_ooo_all_rc)) {
+        md->dp_ordering_cap.rc = UCT_IB_MLX5_DP_ORDERING_OOO_ALL;
+    } else if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dp_ordering_ooo_rw_rc)) {
+        md->dp_ordering_cap.rc = UCT_IB_MLX5_DP_ORDERING_OOO_RW;
+    } else {
+        md->dp_ordering_cap.rc = UCT_IB_MLX5_DP_ORDERING_IBTA;
     }
 
-    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dp_ordering_ooo_rw_dc)) {
-        md->flags |= UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC;
+    if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dp_ordering_ooo_all_dc)) {
+        md->dp_ordering_cap.dc = UCT_IB_MLX5_DP_ORDERING_OOO_ALL;
+    } else if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dp_ordering_ooo_rw_dc)) {
+        md->dp_ordering_cap.dc = UCT_IB_MLX5_DP_ORDERING_OOO_RW;
+    } else {
+        md->dp_ordering_cap.dc = UCT_IB_MLX5_DP_ORDERING_IBTA;
     }
 
     if ((cap_2 != NULL) &&
@@ -1899,8 +1907,7 @@ static void uct_ib_mlx5_devx_check_dp_ordering(uct_ib_mlx5_md_t *md, void *cap,
     ucs_debug("%s: dp_ordering support: force=%d ooo_rw_rc=%d ooo_rw_dc=%d",
               uct_ib_device_name(dev),
               !!(md->flags & UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE),
-              !!(md->flags & UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC),
-              !!(md->flags & UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC));
+              md->dp_ordering_cap.rc, md->dp_ordering_cap.dc);
 }
 
 static void uct_ib_mlx5_devx_check_mkey_by_name(uct_ib_mlx5_md_t *md,
@@ -3153,7 +3160,8 @@ out:
 
 static uct_ib_md_ops_t uct_ib_mlx5_md_ops;
 
-static void uct_ib_mlx5dv_query_ddp(struct ibv_context *ctx, uct_ib_mlx5_md_t *md)
+static ucs_status_t 
+uct_ib_mlx5dv_check_ddp(struct ibv_context *ctx, uct_ib_mlx5_md_t *md)
 {
 #ifdef HAVE_OOO_RECV_WRS
     struct mlx5dv_context ctx_dv = {
@@ -3164,13 +3172,21 @@ static void uct_ib_mlx5dv_query_ddp(struct ibv_context *ctx, uct_ib_mlx5_md_t *m
     ret = mlx5dv_query_device(ctx, &ctx_dv);
     if (ret != 0) {
         ucs_error("mlx5dv_query_device: Failed to query device capabilities, ret=%d\n", ret);
-        return;
+        return UCS_ERR_NO_RESOURCE;
     }
 
     if (ctx_dv.ooo_recv_wrs_caps.max_rc > 0) {
-        md->flags |= UCT_IB_MLX5_MD_FLAG_DDP;
+        md->dp_ordering_cap.rc = UCT_IB_MLX5_DP_ORDERING_OOO_ALL;
     }
+
+    if (ctx_dv.ooo_recv_wrs_caps.max_dct > 0) {
+        md->dp_ordering_cap.dc = UCT_IB_MLX5_DP_ORDERING_OOO_ALL;
+    }
+#else
+    md->dp_ordering_cap.rc = UCT_IB_MLX5_DP_ORDERING_IBTA;
+    md->dp_ordering_cap.dc = UCT_IB_MLX5_DP_ORDERING_IBTA;
 #endif
+    return UCS_OK;
 }
 
 static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
@@ -3208,7 +3224,10 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
         goto err_md_free;
     }
 
-    uct_ib_mlx5dv_query_ddp(ctx, md);
+    status = uct_ib_mlx5dv_check_ddp(ctx, md);
+    if (status != UCS_OK) {
+        goto err_md_free;
+    }
 
     if (IBV_DEVICE_ATOMIC_HCA(dev)) {
         dev->atomic_arg_sizes = sizeof(uint64_t);

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -663,7 +663,8 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
                               &init_attr);
 
     status = uct_rc_mlx5_dp_ordering_ooo_init(
-            &self->super, UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC,
+            &self->super,
+            ucs_min(md->dp_ordering_cap.rc, UCT_IB_MLX5_DP_ORDERING_OOO_RW),
             &config->rc_mlx5_common, "gga");
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -204,17 +204,11 @@ enum {
     UCT_IB_MLX5_MD_FLAG_UAR_USE_WC           = UCS_BIT(17),
     /* Device supports implicit ODP with PCI relaxed order */
     UCT_IB_MLX5_MD_FLAG_GVA_RO               = UCS_BIT(18),
-    /* RoCE supports out-of-order RDMA for RC */
-    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_RC = UCS_BIT(19),
-    /* RoCE supports out-of-order RDMA for DC */
-    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_OOO_RW_DC = UCS_BIT(20),
-    /* RoCE supports forcing ordering configuration */
-    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE     = UCS_BIT(21),
-    /* Device supports DDP (OOO data placement)*/
-    UCT_IB_MLX5_MD_FLAG_DDP                   = UCS_BIT(22),
+    /* Device supports forcing ordering configuration */
+    UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE     = UCS_BIT(19),
 
     /* Object to be created by DevX */
-    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 23,
+    UCT_IB_MLX5_MD_FLAG_DEVX_OBJS_SHIFT  = 20,
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_QP       = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCQP),
     UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ      = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(RCSRQ),
     UCT_IB_MLX5_MD_FLAG_DEVX_DCT         = UCT_IB_MLX5_MD_FLAG_DEVX_OBJS(DCT),
@@ -386,6 +380,16 @@ KHASH_MAP_INIT_INT(rkeys, uct_ib_mlx5_mem_lru_entry_t*);
 #endif
 
 
+typedef enum {
+    /* IBTA-compliant ordering semantics */
+    UCT_IB_MLX5_DP_ORDERING_IBTA    = 0x0,
+    /* Out-of-order RDMA reads and writes */
+    UCT_IB_MLX5_DP_ORDERING_OOO_RW  = 0x1,
+    /* Out-of-order RDMA read/write/send/recv (DDP) */
+    UCT_IB_MLX5_DP_ORDERING_OOO_ALL = 0x2,
+} uct_ib_mlx5_dp_ordering_t;
+
+
 /**
  * MLX5 IB memory domain.
  */
@@ -431,6 +435,12 @@ typedef struct uct_ib_mlx5_md {
     uint8_t                  max_rd_atomic_dc;
     uint8_t                  log_max_dci_stream_channels;
     uint32_t                 smkey_index;
+    struct {
+        /* Max dp ordering level per transport, 
+           as listed in uct_ib_mlx5_dp_ordering_t */
+        uint8_t              rc;
+        uint8_t              dc;
+    } dp_ordering_cap;
 } uct_ib_mlx5_md_t;
 
 
@@ -985,9 +995,6 @@ uct_ib_mlx5_devx_general_cmd(struct ibv_context *context,
 ucs_status_t uct_ib_mlx5_devx_query_ooo_sl_mask(uct_ib_mlx5_md_t *md,
                                                 uint8_t port_num,
                                                 uint16_t *ooo_sl_mask_p);
-
-void uct_ib_mlx5_devx_set_qpc_dp_ordering(
-        void *qpc, ucs_ternary_auto_value_t dp_ordering_ooo);
 
 void uct_ib_mlx5_devx_set_qpc_port_affinity(uct_ib_mlx5_md_t *md,
                                             uint8_t path_index, void *qpc,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -64,12 +64,13 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, exp_backoff),
    UCS_CONFIG_TYPE_UINT},
 
-  {"SRQ_TOPO", "cyclic,cyclic_emulated",
+  {"SRQ_TOPO", "cyclic,cyclic_emulated,list",
    "List of SRQ topology types in order of preference. Supported types are:\n"
    "\n"
    "list              SRQ is organized as a buffer containing linked list of WQEs.\n"
    "\n"
    "cyclic            SRQ is organized as a continuous array of WQEs. Requires DEVX.\n"
+   "                  cannot be used with DDP enabled.\n"
    "\n"
    "cyclic_emulated   SRQ is organized as a continuous array of WQEs, but HW\n"
    "                  treats it as a linked list. Doesn`t require DEVX.",
@@ -81,6 +82,11 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
     UCS_PP_MAKE_STRING(UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ) ".",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, log_ack_req_freq),
    UCS_CONFIG_TYPE_UINT},
+
+  {"DDP_ENABLE", "try",
+   "Enable direct data placement\n",
+   ucs_offsetof(uct_rc_mlx5_iface_common_config_t, ddp_enable), 
+   UCS_CONFIG_TYPE_TERNARY},
 
   {NULL}
 };
@@ -596,21 +602,12 @@ void uct_rc_mlx5_release_desc(uct_recv_desc_t *self, void *desc)
 
 ucs_status_t
 uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
-                                 uint64_t tl_flag,
+                                 uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name)
 {
-    uct_ib_mlx5_md_t *md = uct_ib_mlx5_iface_md(&iface->super.super);
-    int dp_ordering_ooo, dp_ordering_ooo_force;
-
-    if (!uct_ib_iface_is_roce(&iface->super.super)) {
-        iface->super.super.config.dp_ordering_ooo = UCS_AUTO;
-        return UCS_OK;
-    }
-
-    dp_ordering_ooo       = !!(md->flags & tl_flag);
-    dp_ordering_ooo_force = !!(md->flags &
-                               UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE);
+    uct_ib_mlx5_md_t *md      = uct_ib_mlx5_iface_md(&iface->super.super);
+    uct_ib_mlx5_dp_ordering_t min_forced_ordering;
 
     /*
      * HCA has an mlxreg admin configuration to force enable adaptive routing
@@ -618,42 +615,54 @@ uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
      *
      * HCA cap/cap_2 booleans:
      * - if dp_ordering_ooo is set, QPC/DCTC can enable AR.
-     * - if dp_ordering_ooo_force is set, QPC/DCTC can request mlxreg
+     * - if UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE is set, QPC/DCTC can request mlxreg
      *   configuration override, useful to force disable.
-     *
-     * QP modify behavior with returned values:
-     * - UCS_AUTO: Do not affect existing system behavior.
-     * - UCS_NO  : Force AR disabling on the QP if supported. QP modify will
-     *   return error on failure.
-     * - UCS_TRY : Set AR to enable, ignored if any failure.
-     * - UCS_YES : Force AR enabling on the QP if supported. QP modify will
-     *   return error on failure.
      */
+    iface->config.dp_ordering_force =
+            ucs_ternary_auto_value_is_yes_or_no(config->super.ar_enable) ||
+            ucs_ternary_auto_value_is_yes_or_no(config->ddp_enable);
 
-    if ((config->super.ar_enable == UCS_TRY) && dp_ordering_ooo) {
-        iface->super.super.config.dp_ordering_ooo = UCS_TRY;
-    } else if (config->super.ar_enable == UCS_NO) {
-        if (!dp_ordering_ooo_force) {
-            goto failure;
-        }
-
-        iface->super.super.config.dp_ordering_ooo = UCS_NO;
-    } else if (config->super.ar_enable == UCS_YES) {
-        if (!dp_ordering_ooo_force || !dp_ordering_ooo) {
-            goto failure;
-        }
-
-        iface->super.super.config.dp_ordering_ooo = UCS_YES;
-    } else {
-        iface->super.super.config.dp_ordering_ooo = UCS_AUTO;
+    /*
+     * Fail at the following cases:
+     * - Want to force configuration but can't force it
+     * - Want to force enable or force disable adaptive routing but it is unavailable
+     * - Want to force disable adaptive routing but force enabling DDP
+    */
+    if (iface->config.dp_ordering_force &&
+        !(md->flags & UCT_IB_MLX5_MD_FLAG_DP_ORDERING_FORCE)) {
+        goto failure;
     }
+
+    if (config->ddp_enable == UCS_YES) {
+        min_forced_ordering = UCT_IB_MLX5_DP_ORDERING_OOO_ALL;
+    } else if (config->super.ar_enable == UCS_YES) {
+        min_forced_ordering = UCT_IB_MLX5_DP_ORDERING_OOO_RW;
+    } else {
+        min_forced_ordering = UCT_IB_MLX5_DP_ORDERING_IBTA;
+    }
+
+    if (min_forced_ordering > dp_ordering_cap) {
+        goto failure;
+    }
+
+    if (config->super.ar_enable == UCS_NO) {
+        iface->config.dp_ordering = UCT_IB_MLX5_DP_ORDERING_IBTA;
+        return UCS_OK;
+    }
+
+    iface->config.dp_ordering = config->ddp_enable ?
+                                        UCT_IB_MLX5_DP_ORDERING_OOO_ALL :
+                                        UCT_IB_MLX5_DP_ORDERING_OOO_RW;
+
+    iface->config.dp_ordering = ucs_min(iface->config.dp_ordering,
+                                        dp_ordering_cap);
 
     return UCS_OK;
 
 failure:
-    ucs_error("%s: cannot set ar_enable=%d for RoCE on %s",
+    ucs_error("%s: cannot set ar_enable=%d, ddp_enable=%d, capability=%d on %s",
               uct_ib_device_name(&md->super.dev), config->super.ar_enable,
-              tl_name);
+              config->ddp_enable, dp_ordering_cap, tl_name);
     return UCS_ERR_INVALID_PARAM;
 }
 
@@ -1055,9 +1064,6 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
                                         struct mlx5dv_qp_init_attr *dv_attr,
                                         unsigned scat2cqe_dir_mask)
 {
-    uct_ib_mlx5_md_t UCS_V_UNUSED *md = uct_ib_mlx5_iface_md(
-            &iface->super.super);
-
 #if HAVE_DECL_MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE
     if ((scat2cqe_dir_mask & UCS_BIT(UCT_IB_DIR_RX)) &&
         (iface->super.super.config.max_inl_cqe[UCT_IB_DIR_RX] == 0)) {
@@ -1088,7 +1094,7 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
     }
 
 #ifdef HAVE_OOO_RECV_WRS
-    if (md->flags & UCT_IB_MLX5_MD_FLAG_DDP) {
+    if (iface->config.dp_ordering == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) {
         dv_attr->create_flags |= MLX5DV_QP_CREATE_OOO_DP;
         dv_attr->comp_mask    |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
     }
@@ -1268,4 +1274,15 @@ int uct_rc_mlx5_iface_commom_clean(uct_ib_mlx5_cq_t *mlx5_cq,
     uct_ib_mlx5_update_db_cq_ci(mlx5_cq);
 
     return nfreed;
+}
+
+void uct_ib_mlx5_devx_set_qpc_dp_ordering(uct_ib_mlx5_md_t *md, void *qpc,
+                                          uct_rc_mlx5_iface_common_t *iface)
+{
+    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_0,
+                      UCS_BIT_GET(iface->config.dp_ordering, 0));
+    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_1,
+                      UCS_BIT_GET(iface->config.dp_ordering, 1));
+    UCT_IB_MLX5DV_SET(qpc, qpc, dp_ordering_force,
+                      iface->config.dp_ordering_force);
 }

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -409,6 +409,8 @@ typedef struct uct_rc_mlx5_iface_common {
         uint8_t                        atomic_fence_flag;
         uct_rc_mlx5_srq_topo_t         srq_topo;
         uint8_t                        log_ack_req_freq;
+        uint8_t                        dp_ordering;
+        uint8_t                        dp_ordering_force;
     } config;
     UCS_STATS_NODE_DECLARE(stats)
 } uct_rc_mlx5_iface_common_t;
@@ -428,6 +430,7 @@ typedef struct uct_rc_mlx5_iface_common_config {
     } tm;
     unsigned                             exp_backoff;
     unsigned                             log_ack_req_freq;
+    ucs_ternary_auto_value_t             ddp_enable;
     UCS_CONFIG_STRING_ARRAY_FIELD(types) srq_topo;
 } uct_rc_mlx5_iface_common_config_t;
 
@@ -479,10 +482,9 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_iface_ops_t*,
 
 ucs_status_t
 uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
-                                 uint64_t tl_flag,
+                                 uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name);
-
 
 #if IBV_HW_TM
 void uct_rc_mlx5_handle_unexp_rndv(uct_rc_mlx5_iface_common_t *iface,
@@ -663,6 +665,9 @@ ucs_status_t uct_rc_mlx5_devx_init_rx(uct_rc_mlx5_iface_common_t *iface,
                                       const uct_rc_iface_common_config_t *config);
 
 void uct_rc_mlx5_devx_cleanup_srq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_srq_t *srq);
+
+void uct_ib_mlx5_devx_set_qpc_dp_ordering(uct_ib_mlx5_md_t *md, void *qpc,
+                                          uct_rc_mlx5_iface_common_t *iface);
 #else
 static UCS_F_MAYBE_UNUSED ucs_status_t
 uct_rc_mlx5_devx_init_rx(uct_rc_mlx5_iface_common_t *iface,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -408,6 +408,9 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
     UCT_IB_MLX5DV_SET(qpc, qpc, mtu, path_mtu);
     UCT_IB_MLX5DV_SET(qpc, qpc, log_msg_max, UCT_IB_MLX5_LOG_MAX_MSG_SIZE);
     UCT_IB_MLX5DV_SET(qpc, qpc, remote_qpn, dest_qp_num);
+
+    uct_ib_mlx5_devx_set_qpc_dp_ordering(md, qpc, iface);
+
     if (uct_ib_iface_is_roce(&iface->super.super)) {
         status = uct_ib_iface_create_ah(&iface->super.super, ah_attr,
                                         "RC DEVX QP connect", &ah);
@@ -434,8 +437,6 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
                               uct_ib_iface_roce_dscp(&iface->super.super));
         }
 
-        uct_ib_mlx5_devx_set_qpc_dp_ordering(
-                qpc, iface->super.super.config.dp_ordering_ooo);
         uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
                                                &opt_param_mask);
     } else {

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -440,27 +440,79 @@ public:
         }
     }
 
+    bool transport_has_ddp() const
+    {
+        ucs::handle<uct_md_h> uct_md;
+
+        if (!has_transport("rc_mlx5") && !has_transport("dc_mlx5")) {
+            return false;
+        }
+
+        UCS_TEST_CREATE_HANDLE(uct_md_h, uct_md, uct_md_close, uct_md_open,
+                               &uct_ib_component,
+                               ibv_get_device_name(m_ibctx->device),
+                               m_md_config);
+
+        uct_ib_mlx5_md_t *ib_md = ucs_derived_of(uct_md, uct_ib_mlx5_md_t);
+        int rc_has_ddp          = has_transport("rc_mlx5") &&
+                                  (ib_md->dp_ordering_cap.rc ==
+                                   UCT_IB_MLX5_DP_ORDERING_OOO_ALL);
+        int dc_has_ddp          = has_transport("dc_mlx5") &&
+                                  (ib_md->dp_ordering_cap.dc ==
+                                   UCT_IB_MLX5_DP_ORDERING_OOO_ALL);
+        return rc_has_ddp || dc_has_ddp;
+    }
+    
+    void test_check_ib_sl_config() {
+        const char *max_avail_sl_str = getenv("GTEST_MAX_IB_SL");
+        uint8_t sl, max_avail_sl;
+
+        if (max_avail_sl_str == NULL) {
+            max_avail_sl = UCT_IB_SL_NUM;
+        } else {
+            max_avail_sl = std::min(strtoul(max_avail_sl_str, NULL, 0),
+                                    static_cast<unsigned long>(UCT_IB_SL_NUM));
+        }
+
+        // go over all SLs, check UCTs could be initialized on a specific SL
+        // and able to send/recv traffic
+        for (sl = 0; sl < max_avail_sl; ++sl) {
+            bool sl_supports_ar = UCS_BIT_GET(m_ooo_sl_mask, sl);
+            if (!has_transport("rc_verbs") && !has_transport("ud_verbs")) {
+                // if AR is configured on the given SL, set AR_ENABLE to "y",
+                // otherwise - to "n" in order to test that AR_ENABLE parameter
+                // works as expected w/o errors and warnings
+                modify_config("IB_AR_ENABLE", sl_supports_ar ? "y" : "n");
+            }
+
+            modify_config("IB_SL", ucs::to_string(static_cast<uint16_t>(sl)));
+
+            test_uct_ib::init();
+            send_recv_short();
+            test_uct_ib::cleanup();
+        }
+    }
+
 protected:
     uint16_t m_ooo_sl_mask;
 };
 
-UCS_TEST_P(test_uct_ib_sl, check_ib_sl_config) {
-    // go over all SLs, check UCTs could be initialized on a specific SL
-    // and able to send/recv traffic
-    for (uint8_t sl = 0; sl < UCT_IB_SL_NUM; ++sl)  {
-        if (!has_transport("rc_verbs") && !has_transport("ud_verbs")) {
-            // if AR is configured on the given SL, set AR_ENABLE to "y",
-            // otherwise - to "n" in order to test that AR_ENABLE parameter
-            // works as expected w/o errors and warnings
-            modify_config("IB_AR_ENABLE",
-                          (m_ooo_sl_mask & UCS_BIT(sl)) ? "y" : "n");
-        }
-        modify_config("IB_SL", ucs::to_string(static_cast<uint16_t>(sl)));
 
-        test_uct_ib::init();
-        send_recv_short();
-        test_uct_ib::cleanup();
+UCS_TEST_P(test_uct_ib_sl, check_ib_sl_config_without_ddp,
+           "RC_MLX5_DDP_ENABLE?=n", "DC_MLX5_DDP_ENABLE?=n")
+{
+    test_check_ib_sl_config();
+}
+
+UCS_TEST_P(test_uct_ib_sl, check_ib_sl_config_with_ddp,
+           "RC_MLX5_DDP_ENABLE?=try", "DC_MLX5_DDP_ENABLE?=try")
+
+{
+    if (!transport_has_ddp()) {
+        UCS_TEST_SKIP_R("DDP is not supported by the transport");
     }
+
+    test_check_ib_sl_config();
 }
 
 UCT_INSTANTIATE_IB_TEST_CASE(test_uct_ib_sl);


### PR DESCRIPTION
Signed-off-by: Roie Danino <rdanino@nvidia.com>
(cherry picked from commit 90cea8c023669104f7e81ace7a2e6f576f0a58b8)
Backport #10167

## What?
Porting Devx DDP Support to v1.18.x

## Why?
Performance optimization for Connect-X8 devices which enables full wirespeed.