### PR TITLE
GTEST: Refactored protocol selection mock

### DIFF
--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -1125,6 +1125,14 @@ private:
     std::unordered_map<func*, std::unique_ptr<mock_func>> m_mock_map;
 };
 
+#define UCS_MOCK_ORIG_FUNC(_mock, _orig_ptr, ...) \
+{ \
+    ucs_status_t _status = _mock.orig_func(_orig_ptr, ##__VA_ARGS__); \
+    if (_status != UCS_OK) { \
+        return _status; \
+    } \
+}
+
 // Used to manipulate and restore rlimits
 class rlimit_setter {
 public:

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -17,7 +17,7 @@ public:
     /* Can't use std::function due to coverity errors */
     using iface_attr_func_t = void (*)(uct_iface_attr&);
 
-    mock_iface()
+    mock_iface() : m_tl(nullptr)
     {
         ucs_assert(m_self == nullptr);
         m_self = this;
@@ -34,26 +34,83 @@ public:
         m_mock.cleanup();
     }
 
-    void set_mock_iface_attr(const std::string &tl_name, iface_attr_func_t cb)
+    void add_mock_iface(const std::string &dev_name, iface_attr_func_t cb)
     {
-        mock_tl(tl_name);
-        m_iface_attrs_funcs[tl_name] = cb;
+        m_iface_attrs_funcs[dev_name] = cb;
     }
 
-private:
-    void mock_tl(const std::string &tl_name)
+    void mock_transport(const std::string &tl_name)
     {
         uct_component_h component;
+
+        /* Currently only one TL can be mocked */
+        ucs_assert(nullptr == m_tl);
+
         ucs_list_for_each(component, &uct_components_list, list) {
             uct_tl_t *tl;
             ucs_list_for_each(tl, &component->tl_list, list) {
                 if (tl_name == tl->name) {
-                    EXPECT_EQ(0, m_tls.count(tl_name));
-                    m_tls[tl_name] = tl;
+                    m_mock.setup(&component->query_md_resources, query_md_mock);
+                    m_mock.setup(&tl->query_devices, query_devices_mock);
                     m_mock.setup(&tl->iface_open, iface_open_mock);
+                    m_tl = tl;
+                    return;
                 }
             }
         }
+
+        FAIL() << "Transport " << tl_name << " not found";
+    }
+
+private:
+    static ucs_status_t query_md_mock(uct_component_t *component,
+                                      uct_md_resource_desc_t **resources_p,
+                                      unsigned *num_resources_p)
+    {
+        UCS_MOCK_ORIG_FUNC(m_self->m_mock, &component->query_md_resources,
+                           component, resources_p, num_resources_p);
+        /* Keep only the first available MD */
+        *num_resources_p = ucs_min(*num_resources_p, 1);
+        return UCS_OK;
+    }
+
+    static ucs_status_t
+    query_devices_mock(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
+                       unsigned *num_tl_devices_p)
+    {
+        UCS_MOCK_ORIG_FUNC(m_self->m_mock, &m_self->m_tl->query_devices, md,
+                           tl_devices_p, num_tl_devices_p);
+        if (*num_tl_devices_p == 0) {
+            return UCS_OK;
+        }
+
+        /*
+         * The number of real devices (and their names) do not match the mocked
+         * ones. In order to pretend that all the mocked devices are supported,
+         * we remember the first real device name, and then substitute the
+         * response with the mocked devices names. For each mocked device the
+         * individual sys_dev must be set, so that they are treated as different
+         * devices. Later on the iface_open_mock will use the real device name
+         * (same for all mocks) to create the mocked iface.
+         */
+        m_self->m_real_dev_name  = (*tl_devices_p)[0].name;
+        unsigned size            = m_self->m_iface_attrs_funcs.size();
+        auto mock_devices        = (uct_tl_device_resource_t *)ucs_malloc(
+                                        sizeof(uct_tl_device_resource_t) * size,
+                                        "mock_tl_devices");
+        ucs_sys_device_t sys_dev = 1;
+        unsigned i               = 0;
+        for (const auto &it : m_self->m_iface_attrs_funcs) {
+            ucs_strncpy_safe(mock_devices[i].name, it.first.c_str(),
+                             UCT_DEVICE_NAME_MAX);
+            mock_devices[i].type         = (*tl_devices_p)[0].type;
+            mock_devices[i++].sys_device = sys_dev++;
+        }
+
+        ucs_free(*tl_devices_p);
+        *tl_devices_p     = mock_devices;
+        *num_tl_devices_p = size;
+        return UCS_OK;
     }
 
     static ucs_status_t
@@ -61,44 +118,40 @@ private:
                     const uct_iface_params_t *params,
                     const uct_iface_config_t *config, uct_iface_h *iface_p)
     {
-        uct_tl_t *tl = m_self->m_tls[params->mode.device.tl_name];
-        ucs_status_t status;
+        ucs_assert(params->field_mask & UCT_IFACE_PARAM_FIELD_DEVICE);
+        uct_iface_params_t iface_open_params   = *params;
+        iface_open_params.mode.device.dev_name = m_self->m_real_dev_name.c_str();
 
-        status = m_self->m_mock.orig_func(&tl->iface_open, md, worker, params,
-                                          config, iface_p);
-        if (status != UCS_OK) {
-            return status;
-        }
+        UCS_MOCK_ORIG_FUNC(m_self->m_mock, &m_self->m_tl->iface_open, md,
+                           worker, &iface_open_params, config, iface_p);
 
         uct_base_iface_t *base      = ucs_derived_of(*iface_p, uct_base_iface_t);
-        m_self->m_iface_names[base] = params->mode.device.tl_name;
+        m_self->m_iface_names[base] = params->mode.device.dev_name;
         m_self->m_mock.setup(&(*iface_p)->ops.iface_query, iface_query_mock);
-        return status;
+        return UCS_OK;
     }
 
     static ucs_status_t
     iface_query_mock(uct_iface_h iface, uct_iface_attr_t *iface_attr)
     {
-        ucs_status_t status = m_self->m_mock.orig_func(
-                                    &iface->ops.iface_query, iface, iface_attr);
-        if (status != UCS_OK) {
-            return status;
-        }
+        UCS_MOCK_ORIG_FUNC(m_self->m_mock, &iface->ops.iface_query, iface,
+                           iface_attr);
 
         uct_base_iface_t *base  = ucs_derived_of(iface, uct_base_iface_t);
         std::string &iface_name = m_self->m_iface_names[base];
         auto it                 = m_self->m_iface_attrs_funcs.find(iface_name);
         (it->second)(*iface_attr);
-        return status;
+        return UCS_OK;
     }
 
     /* We have to use singleton to mock C functions */
     static mock_iface *m_self;
 
     ucs::mock                                           m_mock;
-    std::unordered_map<std::string, uct_tl_t *>         m_tls;
+    uct_tl_t                                           *m_tl;
     std::unordered_map<uct_base_iface_t *, std::string> m_iface_names;
-    std::unordered_map<std::string, iface_attr_func_t>  m_iface_attrs_funcs;
+    std::map<std::string, iface_attr_func_t>            m_iface_attrs_funcs;
+    std::string                                         m_real_dev_name;
 };
 
 mock_iface *mock_iface::m_self = nullptr;
@@ -107,12 +160,15 @@ struct proto_select_data {
     size_t      range_start;
     size_t      range_end;
     std::string desc;
+    std::string config;
 };
 
 using proto_select_data_vec_t = std::vector<proto_select_data>;
 
 class test_ucp_proto_mock : public ucp_test, public mock_iface {
 public:
+    const static size_t INF = UCS_MEMUNITS_INF;
+
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant(variants, UCP_FEATURE_TAG | UCP_FEATURE_AM);
@@ -134,9 +190,6 @@ public:
          * when test is being executed on different machines.
          */
         modify_config("TOPO_PRIO", "default");
-
-        /* Currently only 1 RNDV lane is supported */
-        modify_config("MAX_RNDV_LANES", "1");
 
         ucp_test::init();
         connect();
@@ -203,7 +256,7 @@ protected:
         }
 
         return (data.range_end == attr.max_msg_length) &&
-               (data.desc == attr.desc);
+               (data.desc == attr.desc) && (data.config == attr.config);
     }
 
     static void dump_select_elem(ucp_worker_h worker,
@@ -288,30 +341,64 @@ protected:
 
 class test_ucp_proto_mock_rcx : public test_ucp_proto_mock {
 public:
+    test_ucp_proto_mock_rcx()
+    {
+        mock_transport("rc_mlx5");
+    }
+
     virtual void init() override
     {
-        set_mock_iface_attr("rc_mlx5",
-            [](uct_iface_attr_t &iface_attr) {
-                iface_attr.cap.am.max_short = 208;
-                iface_attr.bandwidth.shared = 10000000000;
-                iface_attr.latency.c        = 0.000006;
-                iface_attr.latency.m        = 0.000000001;
-            });
+        /* Device with higher BW and latency */
+        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+            iface_attr.cap.am.max_short = 2000;
+            iface_attr.bandwidth.shared = 28000000000;
+            iface_attr.latency.c        = 0.0000006;
+            iface_attr.latency.m        = 0.000000001;
+        });
+        /* Device with smaller BW but lower latency */
+        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+            iface_attr.cap.am.max_short = 208;
+            iface_attr.bandwidth.shared = 24000000000;
+            iface_attr.latency.c        = 0.0000005;
+            iface_attr.latency.m        = 0.000000001;
+        });
         test_ucp_proto_mock::init();
     }
 };
 
-UCS_TEST_P(test_ucp_proto_mock_rcx, mock_iface_attr, "IB_NUM_PATHS?=1")
+UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_1_lane,
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
+    /* Prefer mock_0:1 iface for RNDV because it has larger BW */
     check_ep_config(sender(), {
-        {0,      200,              "short"},
-        {201,    8246,             "copy-in"},
-        {8247,   377094,           "multi-frag copy-in"},
-        {377095, UCS_MEMUNITS_INF, "rendezvous zero-copy read from remote"},
+        {0,     200,   "short",                "rc_mlx5/mock_1:1"},
+        {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1"},
+        {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
+        {8247,  22502, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
+        {22503, INF,   "rendezvous zero-copy read from remote",
+                       "rc_mlx5/mock_0:1"},
+    }, key);
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_2_lanes,
+           "IB_NUM_PATHS?=2", "MAX_RNDV_LANES=2")
+{
+    ucp_proto_select_key_t key = any_key();
+    key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
+    key.param.op_attr          = 0;
+
+    /* The optimal RNDV config must use mock_0:1 and mock_1:1 proportionally. */
+    check_ep_config(sender(), {
+        {0,     200,   "short",                "rc_mlx5/mock_1:1/path0"},
+        {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1/path0"},
+        {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1/path0"},
+        {8247,  20300, "multi-frag zero-copy", "rc_mlx5/mock_1:1/path0"},
+        {20301, INF,   "rendezvous zero-copy read from remote",
+         "47% on rc_mlx5/mock_1:1/path0 and 53% on rc_mlx5/mock_0:1/path0"},
     }, key);
 }
 


### PR DESCRIPTION
## What?
This PR contains enhancements of the original protocol selection mock (https://github.com/openucx/ucx/pull/9989):
- Ability to mock any number of devices with different capabilities
- Match the exact config of protocol selection (e.g. `rc_mlx5/mock_0:1 50% on path0 and 50% on path1`)
- Small improvements

Finally all those changes are needed to reproduce real protocol selection issues (like https://redmine.mellanox.com/issues/4177809, https://redmine.mellanox.com/issues/4134043)
