### PR TITLE
UCP/RNDV: Added check for fragment type to rndv/put/mtype.

### DIFF
--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -2167,6 +2167,24 @@ UCS_TEST_P(test_ucp_am_nbx_rndv_ppln, cuda_buff_cuda_frag,
     test_ppln_send(UCS_MEMORY_TYPE_CUDA, num_frags, num_frags);
 }
 
+UCS_TEST_P(test_ucp_am_nbx_rndv_ppln, empty_rndv_frag_mem_type,
+           "RNDV_FRAG_MEM_TYPE=")
+{
+    m_check_recv_rndv_flags = false;
+
+    set_mem_type(UCS_MEMORY_TYPE_CUDA);
+    test_ppln_send(UCS_MEMORY_TYPE_CUDA, 2, 0);
+}
+
+UCS_TEST_P(test_ucp_am_nbx_rndv_ppln, cuda_managed_buff,
+           "RNDV_FRAG_MEM_TYPE=cuda")
+{
+    const size_t num_frags = 2;
+
+    set_mem_type(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    test_ppln_send(UCS_MEMORY_TYPE_CUDA, num_frags, num_frags);
+}
+
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_am_nbx_rndv_ppln);
 
 #endif


### PR DESCRIPTION
## What?
Added check for fragment memory type to rndv/put/mtype protocol.

## Why?
Fix for the following type of error:
```
 ib_md.c:287  UCX  ERROR ibv_reg_mr(address=0x4002a0000000, length=536870912, access=0xf) failed: Bad address
ucp_mm.c:76   UCX  ERROR failed to register address 0x4002a0000000 (cuda-managed) length 536870912 on md[6]=mlx5_2: Input/output error (md supports: host|cuda-managed)
 mpool.c:269  UCX  ERROR Failed to allocate memory pool (name=ucp_rndv_frags) chunk: Input/output error
```
