### PR TITLE
UCT/GGA: filter out unsupported resources from component list

### DIFF
--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -36,6 +36,15 @@
 
 
 /**
+ * Callback function to check and filter out not applicable devices.
+ *
+ * @param [in]      device      IB device.
+ * @return 1 for acceptable device, otherwise 0.
+ */
+typedef int (*uct_ib_check_device_cb_t)(struct ibv_device *device);
+
+
+/**
  * IB MD statistics counters
  */
 enum {
@@ -406,9 +415,10 @@ ucs_status_t uct_ib_rkey_unpack(uct_component_t *component,
                                 const void *rkey_buffer, uct_rkey_t *rkey_p,
                                 void **handle_p);
 
-ucs_status_t uct_ib_query_md_resources(uct_component_t *component,
-                                       uct_md_resource_desc_t **resources_p,
-                                       unsigned *num_resources_p);
+ucs_status_t
+uct_ib_base_query_md_resources(uct_md_resource_desc_t **resources_p,
+                               unsigned *num_resources_p,
+                               uct_ib_check_device_cb_t check_device_cb);
 
 ucs_status_t uct_ib_get_device_by_name(struct ibv_device **ib_device_list,
                                        int num_devices, const char *md_name,

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1765,15 +1765,13 @@ uct_ib_mlx5_devx_query_lag(uct_ib_mlx5_md_t *md, uint8_t *state)
     return UCS_OK;
 }
 
-static struct ibv_context *
-uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
+struct ibv_context* uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
 {
-    struct mlx5dv_context_attr dv_attr = {};
-    struct mlx5dv_devx_event_channel *event_channel;
+    struct mlx5dv_context_attr dv_attr = {
+        .flags = MLX5DV_CONTEXT_FLAGS_DEVX
+    };
     struct ibv_context *ctx;
-    struct ibv_cq *cq;
 
-    dv_attr.flags |= MLX5DV_CONTEXT_FLAGS_DEVX;
     ctx = mlx5dv_open_device(ibv_device, &dv_attr);
     if (ctx == NULL) {
         ucs_debug("mlx5dv_open_device(%s) failed: %m",
@@ -1781,11 +1779,20 @@ uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
         return NULL;
     }
 
+    return ctx;
+}
+
+static ucs_status_t
+uct_ib_mlx5_devx_check_event_channel(struct ibv_context *ctx)
+{
+    struct mlx5dv_devx_event_channel *event_channel;
+    struct ibv_cq *cq;
+
     cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
     if (cq == NULL) {
         uct_ib_check_memlock_limit_msg(ctx, UCS_LOG_LEVEL_DEBUG,
                                        "ibv_create_cq()");
-        goto close_ctx;
+        return UCS_ERR_UNSUPPORTED;
     }
 
     ibv_destroy_cq(cq);
@@ -1794,17 +1801,12 @@ uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
             ctx, MLX5_IB_UAPI_DEVX_CR_EV_CH_FLAGS_OMIT_DATA);
     if (event_channel == NULL) {
         ucs_diag("mlx5dv_devx_create_event_channel(%s) failed: %m",
-                 ibv_get_device_name(ibv_device));
-        goto close_ctx;
+                 ibv_get_device_name(ctx->device));
+        return UCS_ERR_UNSUPPORTED;
     }
 
     mlx5dv_devx_destroy_event_channel(event_channel);
-
-    return ctx;
-
-close_ctx:
-    ibv_close_device(ctx);
-    return NULL;
+    return UCS_OK;
 }
 
 static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops;
@@ -1851,8 +1853,21 @@ err:
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();
 }
 
-static ucs_status_t
-uct_ib_mlx5_devx_query_cap_2(struct ibv_context *ctx, void *out, size_t size)
+ucs_status_t uct_ib_mlx5_devx_query_cap(struct ibv_context *ctx, uint32_t opmod,
+                                        void *out, size_t size, char *msg_arg,
+                                        int silent)
+{
+    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)] = {};
+
+    UCT_IB_MLX5DV_SET(query_hca_cap_in, in, opcode,
+                      UCT_IB_MLX5_CMD_OP_QUERY_HCA_CAP);
+    UCT_IB_MLX5DV_SET(query_hca_cap_in, in, op_mod, opmod);
+    return uct_ib_mlx5_devx_general_cmd(ctx, in, ucs_static_array_size(in),
+                                        out, size, msg_arg, silent);
+}
+
+ucs_status_t uct_ib_mlx5_devx_query_cap_2(struct ibv_context *ctx,
+                                          void *out, size_t size)
 {
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in)] = {};
 
@@ -1866,8 +1881,7 @@ uct_ib_mlx5_devx_query_cap_2(struct ibv_context *ctx, void *out, size_t size)
                                         "QUERY_HCA_CAP, CAP2", 1);
 }
 
-static void uct_ib_mlx5_devx_check_xgvmi(uct_ib_mlx5_md_t *md, void *cap_2,
-                                         uct_ib_device_t *dev)
+int uct_ib_mlx5_devx_check_xgvmi(void *cap_2, const char *dev_name)
 {
     uint64_t object_for_other_vhca;
     uint32_t object_to_object;
@@ -1881,13 +1895,11 @@ static void uct_ib_mlx5_devx_check_xgvmi(uct_ib_mlx5_md_t *md, void *cap_2,
          UCT_IB_MLX5_HCA_CAPS_2_CROSS_VHCA_OBJ_TO_OBJ_LOCAL_MKEY_TO_REMOTE_MKEY) &&
         (object_for_other_vhca &
          UCT_IB_MLX5_HCA_CAPS_2_ALLOWED_OBJ_FOR_OTHER_VHCA_ACCESS_MKEY)) {
-        md->flags           |= UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
-        md->super.cap_flags |= UCT_MD_FLAG_EXPORTED_MKEY;
-        ucs_debug("%s: cross gvmi alias mkey is supported",
-                  uct_ib_device_name(dev));
+        ucs_debug("%s: cross gvmi alias mkey is supported", dev_name);
+        return 1;
     } else {
-        ucs_debug("%s: crossing_vhca_mkey is not supported",
-                  uct_ib_device_name(dev));
+        ucs_debug("%s: crossing_vhca_mkey is not supported", dev_name);
+        return 0;
     }
 }
 
@@ -2157,22 +2169,18 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
                                       const uct_ib_md_config_t *md_config,
                                       uct_ib_md_t **p_md)
 {
-    size_t out_len      = UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out);
-    size_t in_len       = UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_in);
-    size_t total_len    = (2 * out_len) + in_len;
-    char *buf, *out, *in, *cap_2_out;
+    uint8_t lag_state = 0;
+    size_t out_len    = UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out);
+    size_t total_len  = 2 * out_len;
+    char *buf, *out, *cap_2_out;
+    void *cap, *cap_2;
     ucs_status_t status;
-    void *cap_2;
-    uint8_t lag_state   = 0;
     uint8_t log_max_qp;
     uint16_t vhca_id;
     struct ibv_context *ctx;
     uct_ib_device_t *dev;
     uct_ib_mlx5_md_t *md;
     unsigned max_rd_atomic_dc;
-    void *cap;
-    int ret;
-    ucs_log_level_t log_level;
     ucs_mpool_params_t mp_params;
     int ksm_atomic;
 
@@ -2184,8 +2192,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     }
 
     out       = buf;
-    in        = UCS_PTR_BYTE_OFFSET(out, out_len);
-    cap_2_out = UCS_PTR_BYTE_OFFSET(in, in_len);
+    cap_2_out = UCS_PTR_BYTE_OFFSET(out, out_len);
 
     if (!mlx5dv_is_supported(ibv_device)) {
         status = UCS_ERR_UNSUPPORTED;
@@ -2201,6 +2208,11 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     if (ctx == NULL) {
         status = UCS_ERR_UNSUPPORTED;
         goto err_free_buffer;
+    }
+
+    status = uct_ib_mlx5_devx_check_event_channel(ctx);
+    if (status != UCS_OK) {
+        goto err_free_context;
     }
 
     md = ucs_derived_of(uct_ib_md_alloc(sizeof(*md), "ib_mlx5_devx_md", ctx),
@@ -2224,24 +2236,12 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         goto err_lru_cleanup;
     }
 
-    cap = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, out, capability);
-    UCT_IB_MLX5DV_SET(query_hca_cap_in, in, opcode, UCT_IB_MLX5_CMD_OP_QUERY_HCA_CAP);
-    UCT_IB_MLX5DV_SET(query_hca_cap_in, in, op_mod, UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR |
-                                                   (UCT_IB_MLX5_CAP_GENERAL << 1));
-    ret = mlx5dv_devx_general_cmd(ctx, in, in_len, out, out_len);
-    if (ret != 0) {
-        if ((errno == EPERM) || (errno == EPROTONOSUPPORT) ||
-            (errno == EOPNOTSUPP)) {
-            status    = UCS_ERR_UNSUPPORTED;
-            log_level = UCS_LOG_LEVEL_DEBUG;
-        } else {
-            status    = UCS_ERR_IO_ERROR;
-            log_level = UCS_LOG_LEVEL_ERROR;
-        }
-        ucs_log(log_level,
-                "mlx5dv_devx_general_cmd(QUERY_HCA_CAP) failed,"
-                " syndrome 0x%x: %m",
-                UCT_IB_MLX5DV_GET(query_hca_cap_out, out, syndrome));
+    cap    = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, out, capability);
+    status = uct_ib_mlx5_devx_query_cap(ctx,
+                                        UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR |
+                                        (UCT_IB_MLX5_CAP_GENERAL << 1),
+                                        out, out_len, "QUERY_HCA_CAP", 0);
+    if (status != UCS_OK) {
         goto err_lru_cleanup;
     }
 
@@ -2350,8 +2350,11 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
     status = uct_ib_mlx5_devx_query_cap_2(ctx, cap_2_out, out_len);
     if (status == UCS_OK) {
         cap_2 = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, cap_2_out, capability);
+        if (uct_ib_mlx5_devx_check_xgvmi(cap_2, uct_ib_device_name(dev))) {
+            md->flags           |= UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI;
+            md->super.cap_flags |= UCT_MD_FLAG_EXPORTED_MKEY;
+        }
 
-        uct_ib_mlx5_devx_check_xgvmi(md, cap_2, dev);
         uct_ib_mlx5_devx_check_mkey_by_name(md, cap_2, dev);
     } else {
         cap_2 = NULL;
@@ -2367,10 +2370,11 @@ ucs_status_t uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
         uint8_t arg_size;
         int cap_ops, mode8b;
 
-        UCT_IB_MLX5DV_SET(query_hca_cap_in, in, op_mod, UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR |
-                                                       (UCT_IB_MLX5_CAP_ATOMIC << 1));
-        status = uct_ib_mlx5_devx_general_cmd(ctx, in, in_len, out, out_len,
-                                              "QUERY_HCA_CAP, ATOMIC", 0);
+        status = uct_ib_mlx5_devx_query_cap(ctx,
+                                            UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR |
+                                            (UCT_IB_MLX5_CAP_ATOMIC << 1),
+                                            out, out_len,
+                                            "QUERY_HCA_CAP, ATOMIC", 0);
         if (status != UCS_OK) {
             goto err_lru_cleanup;
         }

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -17,6 +17,12 @@
 #define UCT_GGA_MLX5_OPAQUE_BUF_LEN 64
 #define UCT_GGA_MAX_MSG_SIZE        (2u * UCS_MBYTE)
 
+#if ENABLE_ASSERT
+#define UCT_GGA_MLX5_MD_CAPS        (UCT_IB_MLX5_MD_FLAG_DEVX | \
+                                     UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI | \
+                                     UCT_IB_MLX5_MD_FLAG_MMO_DMA)
+#endif /* ENABLE_ASSERT */
+
 typedef struct {
     uct_ib_md_packed_mkey_t packed_mkey;
     uct_ib_mlx5_devx_mem_t  *memh;
@@ -165,13 +171,63 @@ static ucs_status_t uct_gga_mlx5_rkey_release(uct_component_t *component,
     return UCS_OK;
 }
 
+static int uct_ib_mlx5_gga_check_device(struct ibv_device *device)
+{
+    int result = 0;
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(query_hca_cap_out)];
+    struct ibv_context *ctx;
+    ucs_status_t status;
+    size_t out_len;
+    char *cap;
+
+    ctx = uct_ib_mlx5_devx_open_device(device);
+    if (ctx == NULL) {
+        goto out;
+    }
+
+    out_len = ucs_static_array_size(out);
+    status  = uct_ib_mlx5_devx_query_cap(ctx,
+                                         UCT_IB_MLX5_HCA_CAP_OPMOD_GET_CUR |
+                                         (UCT_IB_MLX5_CAP_GENERAL << 1),
+                                         out, out_len, "QUERY_HCA_CAP", 0);
+    if (status != UCS_OK) {
+        goto out_close_ctx;
+    }
+
+    cap = UCT_IB_MLX5DV_ADDR_OF(query_hca_cap_out, out, capability);
+    if (!UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, dma_mmo_qp)) {
+        goto out_close_ctx;
+    }
+
+    status = uct_ib_mlx5_devx_query_cap_2(ctx, out, out_len);
+    if (status != UCS_OK) {
+        goto out_close_ctx;
+    }
+
+    result = uct_ib_mlx5_devx_check_xgvmi(cap, ibv_get_device_name(device));
+
+out_close_ctx:
+    uct_ib_md_device_context_close(ctx);
+out:
+    return result;
+}
+
+static ucs_status_t
+uct_ib_mlx5_gga_query_md_resources(uct_component_t *component,
+                                   uct_md_resource_desc_t **resources_p,
+                                   unsigned *num_resources_p)
+{
+    return uct_ib_base_query_md_resources(resources_p, num_resources_p,
+                                          uct_ib_mlx5_gga_check_device);
+}
+
 /* Forward declaration */
 static ucs_status_t
 uct_ib_mlx5_gga_md_open(uct_component_t *component, const char *md_name,
                         const uct_md_config_t *uct_md_config, uct_md_h *md_p);
 
 static uct_component_t uct_gga_component = {
-    .query_md_resources = uct_ib_query_md_resources,
+    .query_md_resources = uct_ib_mlx5_gga_query_md_resources,
     .md_open            = uct_ib_mlx5_gga_md_open,
     .cm_open            = ucs_empty_function_return_unsupported,
     .rkey_unpack        = uct_gga_mlx5_rkey_unpack,
@@ -723,16 +779,17 @@ uct_gga_mlx5_query_tl_devices(uct_md_h md,
 {
     uct_ib_mlx5_md_t *mlx5_md = ucs_derived_of(md, uct_ib_mlx5_md_t);
 
-    if (strcmp(mlx5_md->super.name, UCT_IB_MD_NAME(gga)) ||
-        !ucs_test_all_flags(mlx5_md->flags, UCT_IB_MLX5_MD_FLAG_DEVX |
-                                            UCT_IB_MLX5_MD_FLAG_INDIRECT_XGVMI |
-                                            UCT_IB_MLX5_MD_FLAG_MMO_DMA)) {
+    if (strcmp(mlx5_md->super.name, UCT_IB_MD_NAME(gga))) {
         return UCS_ERR_NO_DEVICE;
     }
 
+    ucs_assertv(ucs_test_all_flags(mlx5_md->flags, UCT_GGA_MLX5_MD_CAPS),
+                "md %p: flags=0x%x do not have mandatory capabilities 0x%x",
+                mlx5_md, mlx5_md->flags, UCT_GGA_MLX5_MD_CAPS);
+
     return uct_ib_device_query_ports(&mlx5_md->super.dev,
                                      UCT_IB_DEVICE_FLAG_SRQ |
-                                             UCT_IB_DEVICE_FLAG_MLX5_PRM,
+                                     UCT_IB_DEVICE_FLAG_MLX5_PRM,
                                      tl_devices_p, num_tl_devices_p);
 }
 
@@ -778,8 +835,7 @@ uct_ib_mlx5_gga_md_open(uct_component_t *component, const char *md_name,
     ib_device_list = ibv_get_device_list(&num_devices);
     if (ib_device_list == NULL) {
         ucs_debug("Failed to get GGA device list, assuming no devices are present");
-        status = UCS_ERR_NO_DEVICE;
-        goto out;
+        return UCS_ERR_NO_DEVICE;
     }
 
     status = uct_ib_get_device_by_name(ib_device_list, num_devices, md_name,


### PR DESCRIPTION
## What?
Filter out unsupported resources from GGA component

## Why?
```
# Memory domain: mlx5_0
#     Component: gga
#             register: unlimited, dmabuf, cost: 16000 + 0.060 * N nsec
#           remote key: 14 bytes
#           local memory handle is required for zcopy
#         memory types: host (access,reg,cache)
#   < no supported devices found >
```
full log: https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/92757/logs/1012
## How?
check capabilities