### PR TITLE
UCP/PROTO/RNDV: Use rma_bw_lanes for lanes sorting

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -449,11 +449,45 @@ err_deref_perf_node:
     return status;
 }
 
+/*
+ * TODO: This is a quickfix, needed to select lanes for multi-lane RNDV
+ * protocol in the order of rma_bw_lanes (RMA_BW lanes sorted by score).
+ * The proper solution is to have a generic mechanism to sort lanes based on
+ * the calculated performance, implemented in proto_multi.
+ * This function should be removed once the proper solution is implemented.
+ */
+static inline ucp_lane_index_t
+ucp_proto_common_lanes_iter(const ucp_ep_config_key_t *ep_config_key,
+                            ucp_lane_map_t lane_map, ucp_lane_type_t lane_type,
+                            ucp_lane_index_t start, ucp_lane_index_t *lane)
+{
+    if (start >= UCP_MAX_LANES) {
+        return UCP_MAX_LANES;
+    }
+
+    if (lane_type == UCP_LANE_TYPE_RMA_BW) {
+        for (; start < ep_config_key->num_lanes; ++start) {
+            *lane = ep_config_key->rma_bw_lanes[start];
+            if ((*lane == UCP_NULL_LANE) || (lane_map & UCS_BIT(*lane))) {
+                break;
+            }
+        }
+        return start;
+    }
+
+    /*
+     * By default iterate over all lanes in lane_map
+     * Reset lane_map bits below start position, then find first bit set
+     */
+    lane_map &= ~((1ULL << start) - 1);
+    *lane     = ucs_ffs64_safe(lane_map);
+    return *lane;
+}
+
 ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
-                            uct_ep_operation_t memtype_op, unsigned flags,
-                            ptrdiff_t max_iov_offs, size_t min_iov,
-                            ucp_lane_type_t lane_type,
+                            unsigned flags, ptrdiff_t max_iov_offs,
+                            size_t min_iov, ucp_lane_type_t lane_type,
                             ucs_memory_type_t reg_mem_type,
                             uint64_t tl_cap_flags, ucp_lane_index_t max_lanes,
                             ucp_lane_map_t exclude_map, ucp_lane_index_t *lanes)
@@ -464,7 +498,7 @@ ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
     const ucp_rkey_config_key_t *rkey_config_key = params->rkey_config_key;
     const ucp_proto_select_param_t *select_param = params->select_param;
     const uct_iface_attr_t *iface_attr;
-    ucp_lane_index_t lane, num_lanes;
+    ucp_lane_index_t lane, num_lanes, i;
     const uct_md_attr_v2_t *md_attr;
     const uct_component_attr_t *cmpt_attr;
     ucp_rsc_index_t rsc_index;
@@ -497,7 +531,12 @@ ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
     }
 
     lane_map = UCS_MASK(ep_config_key->num_lanes) & ~exclude_map;
-    ucs_for_each_bit(lane, lane_map) {
+    lane     = 0;
+    for (i = ucp_proto_common_lanes_iter(ep_config_key, lane_map, lane_type,
+                                         0, &lane);
+         (i < ep_config_key->num_lanes) && (lane != UCP_NULL_LANE);
+         i = ucp_proto_common_lanes_iter(ep_config_key, lane_map, lane_type,
+                                         i + 1, &lane)) {
         if (num_lanes >= max_lanes) {
             break;
         }
@@ -655,10 +694,9 @@ ucp_lane_index_t ucp_proto_common_find_lanes_with_min_frag(
     size_t tl_min_frag, tl_max_frag;
 
     num_lanes = ucp_proto_common_find_lanes(
-                   &params->super, params->memtype_op, params->flags,
-                   params->max_iov_offs, params->min_iov, lane_type,
-                   params->reg_mem_info.type, tl_cap_flags, max_lanes,
-                   exclude_map, lanes);
+                   &params->super, params->flags, params->max_iov_offs,
+                   params->min_iov, lane_type, params->reg_mem_info.type,
+                   tl_cap_flags, max_lanes, exclude_map, lanes);
 
     num_valid_lanes = 0;
     for (lane_index = 0; lane_index < num_lanes; ++lane_index) {

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -270,9 +270,8 @@ ucp_lane_index_t ucp_proto_common_find_lanes_with_min_frag(
 
 ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
-                            uct_ep_operation_t memtype_op, unsigned flags,
-                            ptrdiff_t max_iov_offs, size_t min_iov,
-                            ucp_lane_type_t lane_type,
+                            unsigned flags, ptrdiff_t max_iov_offs,
+                            size_t min_iov, ucp_lane_type_t lane_type,
                             ucs_memory_type_t reg_mem_type,
                             uint64_t tl_cap_flags, ucp_lane_index_t max_lanes,
                             ucp_lane_map_t exclude_map,

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -16,22 +16,9 @@
 #include "proto_debug.h"
 #include "proto_multi.inl"
 
-#include <ucs/algorithm/qsort_r.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
 
-
-static int
-ucp_proto_multi_compare_tl_perf(const void *elem1, const void *elem2, void *arg)
-{
-    const ucp_lane_index_t *lane1                = elem1;
-    const ucp_lane_index_t *lane2                = elem2;
-    const ucp_proto_common_tl_perf_t *lanes_perf = arg;
-
-    /* If bandwidths are equal, prefer to maintain the original ordering */
-    return ucp_score_prio_cmp(lanes_perf[*lane2].bandwidth, (intptr_t)elem1,
-                              lanes_perf[*lane1].bandwidth, (intptr_t)elem2);
-}
 
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                                   const char *perf_name,
@@ -45,7 +32,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     ucp_proto_common_tl_perf_t *lane_perf, perf;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     double max_bandwidth, max_frag_ratio, min_bandwidth;
-    ucp_lane_index_t i, lane, num_lanes, first_lane;
+    ucp_lane_index_t i, lane, num_lanes;
     ucp_proto_multi_lane_priv_t *lpriv;
     ucp_proto_perf_node_t *perf_node;
     size_t max_frag, min_length, min_end_offset;
@@ -97,17 +84,6 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
 
         /* Calculate maximal bandwidth of all lanes, to skip slow lanes */
         max_bandwidth = ucs_max(max_bandwidth, lane_perf->bandwidth);
-    }
-
-    /* Sort lanes by bandwidth */
-    if (num_lanes > 1) {
-        /* When the first lane is different from the middle one, then we should
-         * preserve the ordering with eager protocols for TAG and AM APIs */
-        first_lane = (params->first.lane_type == params->middle.lane_type) ? 0:
-                                                                             1;
-        ucs_qsort_r(lanes + first_lane, num_lanes - first_lane,
-                    sizeof(ucp_lane_index_t), ucp_proto_multi_compare_tl_perf,
-                    lanes_perf);
     }
 
     /* Select the lanes to use, and calculate their aggregate performance */

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -493,7 +493,7 @@ ucp_proto_rndv_find_ctrl_lane(const ucp_proto_init_params_t *params)
 {
     ucp_lane_index_t lane, num_lanes;
 
-    num_lanes = ucp_proto_common_find_lanes(params, UCT_EP_OP_LAST,
+    num_lanes = ucp_proto_common_find_lanes(params,
                                             UCP_PROTO_COMMON_INIT_FLAG_HDR_ONLY,
                                             UCP_PROTO_COMMON_OFFSET_INVALID, 1,
                                             UCP_LANE_TYPE_AM,


### PR DESCRIPTION
## What?
This is fix for [RM#4177809](https://redmine.mellanox.com/issues/4177809).
The root cause of the issue is sorting lanes by BW introduced in https://github.com/openucx/ucx/pull/10264
That PR solves one issue, but introduces another one
- It solves issue when we always choose first AM lane for RNDV, even if it's slower
- It introduces the issue that we may choose several paths of the same device, even though it's not optimal (must prefer another device instead)

This is a quick fix, the ideal solution would be to do lane sorting in proto_multi after performance calculation, taking into account multiple paths and performance boost of extra paths

## How?
- Revert lane sorting by BW (https://github.com/openucx/ucx/pull/10264)
- Rely on rma_bw_lanes array for finding RMA_BW lanes for RNDV
- Tested with latest version of protocol mock (https://github.com/openucx/ucx/pull/10369)

Tested on ganon:
```mpirun -np 32 --map-by ppr:16:node -x LD_PRELOAD=/home/iyastrebov/storage/ucx/bld-devel/lib/libucp.so:/home/iyastrebov/storage/ucx/bld-devel/lib/libuct.so:/home/iyastrebov/storage/ucx/bld-devel/lib/libucs.so --mca coll_ucc_enable 0 -x UCX_MULTI_PATH_RATIO=0.9 /home/mmagazinnik/PerfX/OSU_40341/osu_mbw_mr D D```

BEFORE:
```
2100..inf | (?) rendezvous zero-copy read from remote | rc_mlx5/mlx5_0:1 50% on path0 and 50% on path1

# Size                  MB/s        Messages/s
131072              49450.16         377274.79
262144              49653.20         189411.92
524288              49617.67          94638.20
1048576             49591.96          47294.58
2097152             49581.84          23642.46
4194304             49572.40          11818.98
```
AFTER:
```
2100..inf | (?) rendezvous zero-copy read from remote | 80% on rc_mlx5/mlx5_0:1/path0 and 20% on rc_mlx5/mlx5_1:1

131072              60445.56         461163.01                                                                   
262144              60461.71         230643.11                                                                   
524288              61062.24         116466.98                                                                   
1048576             61251.31          58413.80                                                                   
2097152             60680.78          28934.85                                                                   
4194304             60366.36          14392.46                                                                   
```