### PR TITLE
UCP/RKEY: Keep md_map consistent with tl_rkey

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -895,6 +895,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
             ucs_trace("rkey[%d] for remote md %d is 0x%lx not reachable",
                       rkey_index, remote_md_index, tl_rkey->rkey.rkey);
         } else {
+            rkey->md_map &= UCS_MASK(remote_md_index);
             ucs_error("failed to unpack remote key from remote md[%d]: %s",
                       remote_md_index, ucs_status_string(status));
             goto err_destroy;


### PR DESCRIPTION
## What?
When unpacking and building `ucp_rkey_h`, ensure the `md_map` field reflects the state of `tl_rkey` array.

## Why?
This ensures that `ucp_rkey_destroy` can consistently clean up a `ucp_rkey_h` object, even if its creation was interrupted by an `uct_rkey_unpack` failure.
