### PR TITLE
UCT/CUDA_IPC: Return rkey unreachable with missing device context - v1.18.x

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -284,7 +284,7 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
 
     status = UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&this_device));
     if (UCS_OK != status) {
-        return status;
+        return UCS_ERR_UNREACHABLE;
     }
 
     pthread_mutex_lock(&component->lock);


### PR DESCRIPTION
## What?
Return unreachable if the CUDA device context is not already set.

## Why?
Restores behavior of #9747 after #9978.