### PR TITLE
UCT/CUDA/CUDA_COPY: Enabled memory attributes query after switching CUDA GPU.

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -197,12 +197,6 @@ try_load_cuda_env() {
     then
         az_module_load dev/gdrcopy2.4.1_cuda12.5.1 && have_gdrcopy=yes
     fi
-
-    # Set CUDA_VISIBLE_DEVICES
-    if [ -n "${worker}" ]
-    then
-        export CUDA_VISIBLE_DEVICES=$((worker % num_gpus))
-    fi
 }
 
 load_cuda_env() {

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -260,6 +260,7 @@ if HAVE_CUDA
 gtest_SOURCES += \
 	common/cuda_context.cc \
 	ucm/cuda_hooks.cc \
+	uct/cuda/test_switch_cuda_device.cc \
 	uct/cuda/test_cuda_ipc_md.cc
 gtest_CPPFLAGS += \
 	$(CUDA_CPPFLAGS)

--- a/test/gtest/uct/cuda/test_switch_cuda_device.cc
+++ b/test/gtest/uct/cuda/test_switch_cuda_device.cc
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <uct/test_md.h>
+
+extern "C" {
+#include <ucs/sys/ptr_arith.h>
+}
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+class test_switch_cuda_device : public test_md {
+public:
+    template<class T> void detect_mem_type(ucs_memory_type_t mem_type) const;
+};
+
+template<class T>
+void test_switch_cuda_device::detect_mem_type(ucs_memory_type_t mem_type) const
+{
+    int num_devices;
+    ASSERT_EQ(cudaGetDeviceCount(&num_devices), cudaSuccess);
+
+    if (num_devices < 2) {
+        UCS_TEST_SKIP_R("less than two cuda devices available");
+    }
+
+    int current_device;
+    ASSERT_EQ(cudaGetDevice(&current_device), cudaSuccess);
+    ASSERT_EQ(cudaSetDevice((current_device + 1) % num_devices), cudaSuccess);
+
+    const size_t size = 16;
+    T buffer(size, mem_type);
+
+    EXPECT_EQ(cudaSetDevice(current_device), cudaSuccess);
+
+    ucs_memory_type_t detected_mem_type;
+    ASSERT_EQ(uct_md_detect_memory_type(m_md, buffer.ptr(), size,
+                                        &detected_mem_type),
+              UCS_OK);
+    EXPECT_EQ(detected_mem_type, mem_type);
+}
+
+#if HAVE_CUDA_FABRIC
+class cuda_fabric_mem_buffer {
+public:
+    cuda_fabric_mem_buffer(size_t size, ucs_memory_type_t mem_type);
+    virtual ~cuda_fabric_mem_buffer();
+    void *ptr() const;
+
+private:
+    size_t m_size;
+    CUmemGenericAllocationHandle m_alloc_handle;
+    CUdeviceptr m_ptr;
+};
+
+cuda_fabric_mem_buffer::cuda_fabric_mem_buffer(size_t size,
+                                               ucs_memory_type_t mem_type) :
+    m_size(size)
+{
+    size_t granularity          = 0;
+    CUmemAllocationProp prop    = {};
+    CUmemAccessDesc access_desc = {};
+    CUdevice device;
+    if (cuCtxGetDevice(&device) != CUDA_SUCCESS) {
+        UCS_TEST_ABORT("failed to get the device handle for the current "
+                       "context");
+    }
+
+    prop.type                 = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type        = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id          = device;
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+    if (cuMemGetAllocationGranularity(&granularity, &prop,
+                                      CU_MEM_ALLOC_GRANULARITY_MINIMUM) !=
+        CUDA_SUCCESS) {
+        goto err;
+    }
+
+    m_size = ucs_align_up(m_size, granularity);
+    if (cuMemCreate(&m_alloc_handle, m_size, &prop, 0) != CUDA_SUCCESS) {
+        goto err;
+    }
+
+    if (cuMemAddressReserve(&m_ptr, m_size, 0, 0, 0) != CUDA_SUCCESS) {
+        goto err_mem_release;
+    }
+
+    if (cuMemMap(m_ptr, m_size, 0, m_alloc_handle, 0) != CUDA_SUCCESS) {
+        goto err_address_free;
+    }
+
+    access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    access_desc.location.id   = device;
+    access_desc.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    if (cuMemSetAccess(m_ptr, m_size, &access_desc, 1) != CUDA_SUCCESS) {
+        goto err_mem_unmap;
+    }
+
+    return;
+
+err_mem_unmap:
+    cuMemUnmap(m_ptr, m_size);
+err_address_free:
+    cuMemAddressFree(m_ptr, m_size);
+err_mem_release:
+    cuMemRelease(m_alloc_handle);
+err:
+    UCS_TEST_SKIP_R("failed to allocate CUDA fabric memory");
+}
+
+cuda_fabric_mem_buffer::~cuda_fabric_mem_buffer()
+{
+    cuMemUnmap(m_ptr, m_size);
+    cuMemAddressFree(m_ptr, m_size);
+    cuMemRelease(m_alloc_handle);
+}
+
+void *cuda_fabric_mem_buffer::ptr() const
+{
+    return (void*)m_ptr;
+}
+#endif
+
+UCS_TEST_P(test_switch_cuda_device, detect_mem_type_cuda)
+{
+    detect_mem_type<mem_buffer>(UCS_MEMORY_TYPE_CUDA);
+}
+
+UCS_TEST_P(test_switch_cuda_device, detect_mem_type_cuda_managed)
+{
+    detect_mem_type<mem_buffer>(UCS_MEMORY_TYPE_CUDA_MANAGED);
+}
+
+#if HAVE_CUDA_FABRIC
+UCS_TEST_P(test_switch_cuda_device, detect_mem_type_cuda_fabric)
+{
+    detect_mem_type<cuda_fabric_mem_buffer>(UCS_MEMORY_TYPE_CUDA);
+}
+#endif
+
+_UCT_MD_INSTANTIATE_TEST_CASE(test_switch_cuda_device, cuda_cpy);


### PR DESCRIPTION
## What?
Enabled memory attributes query by `cuda_cpy` memory domain after switching CUDA GPU.
Added test.

Without the changes in `cuda_cpy` memory domain the test fails with the following error:
```
cuda_copy_md.c:649  UCX  ERROR cuMemGetAddressRange(0x7f8cd9e00000) error: named symbol not found
```

