### PR TITLE
UCT/CUDA/CUDA_IPC: Switched to nvmlGpuFabricInfo v1.

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -69,10 +69,10 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                                     [AC_MSG_ERROR([libnvidia-ml not found. Install appropriate nvidia-driver package])])
                               cuda_happy="no"])])
 
-         # Check for nvmlDeviceGetGpuFabricInfoV
-         AC_CHECK_DECLS([nvmlDeviceGetGpuFabricInfoV],
+         # Check for nvmlDeviceGetGpuFabricInfo
+         AC_CHECK_DECLS([nvmlDeviceGetGpuFabricInfo],
                         [AC_DEFINE([HAVE_NVML_FABRIC_INFO], 1, [Enable NVML GPU fabric info support])],
-                        [AC_MSG_NOTICE([nvmlDeviceGetGpuFabricInfoV function not found in libnvidia-ml. MNNVL support will be disabled.])],
+                        [AC_MSG_NOTICE([nvmlDeviceGetGpuFabricInfo function not found in libnvidia-ml. MNNVL support will be disabled.])],
                         [[#include <nvml.h>]])
 
 


### PR DESCRIPTION
## What?
Switched from `nvmlDeviceGetGpuFabricInfoV` to `nvmlDeviceGetGpuFabricInfo` to be able to be compiled and run with any minor version of CUDA 12.

`nvmlDeviceGetGpuFabricInfoV` was introduced in CUDA 12.4. It means that UCX built with CUDA 12.4 will fail during symbol lookup, if CUDA 12.3 is installed on the system.

Also removed `fabric_info.cliqueId` from debug output to avoid adding extra compile time macros. Because the name of the field was changed in 12.3 version.
