### PR TITLE
TEST/GTEST/UCT: Retry when it cannot allocate MEMIC memory

### DIFF
--- a/test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc
+++ b/test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc
@@ -30,14 +30,41 @@ UCS_TEST_SKIP_COND_P(uct_atomic_key_reg_rdma_mem_type, fadd64,
                      !check_atomics(UCS_BIT(UCT_ATOMIC_OP_ADD), FOP64) ||
                      !check_rdma_memory())
 {
-    mapped_buffer recvbuf(sizeof(uint64_t), receiver(), 0UL,
-                          UCS_MEMORY_TYPE_RDMA);
+    mapped_buffer *recvbuf     = nullptr;
+    const size_t buffer_size   = sizeof(uint64_t);
+    const size_t buffer_offset = 0;
+    const bool may_fail        = true;
+    const int num_retries      = 5;
+    const int sleep_usec       = 10000;
+
+    for (int i = 0; i < num_retries; ++i) {
+        try {
+            {
+                scoped_log_handler slh(hide_errors_logger);
+                recvbuf = new mapped_buffer(buffer_size, receiver(),
+                                            buffer_offset, UCS_MEMORY_TYPE_RDMA,
+                                            UCT_MD_MEM_ACCESS_ALL, may_fail);
+            }
+            break;
+        } catch (ucs::test_abort_exception& e) {
+            UCS_TEST_MESSAGE << "Retry " << i + 1 << "/" << num_retries
+                             << ": Buffer allocation failed - " << e.what();
+            usleep(sleep_usec);
+        }
+
+        if (i == (num_retries - 1)) {
+            ADD_FAILURE() << "Failed to allocate buffer";
+        }
+    }
+
     uint64_t add = rand64();
 
     run_workers(static_cast<send_func_t>(
                         &uct_amo_test::atomic_fop<uint64_t, UCT_ATOMIC_OP_ADD>),
-                recvbuf, std::vector<uint64_t>(num_senders(), add), false);
+                *recvbuf, std::vector<uint64_t>(num_senders(), add), false);
     wait_for_remote();
+
+    delete recvbuf;
 }
 
 UCT_INSTANTIATE_RC_DC_TEST_CASE(uct_atomic_key_reg_rdma_mem_type);

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -931,7 +931,8 @@ uct_test::entity::entity(const resource& resource, uct_md_config_t *md_config,
 
 void uct_test::entity::mem_alloc(size_t length, unsigned mem_flags,
                                  uct_allocated_memory_t *mem,
-                                 ucs_memory_type_t mem_type) const
+                                 ucs_memory_type_t mem_type,
+                                 bool may_fail) const
 {
     void *address   = NULL;
     uct_md_h uct_md = md();
@@ -951,7 +952,6 @@ void uct_test::entity::mem_alloc(size_t length, unsigned mem_flags,
         (mem_type == UCS_MEMORY_TYPE_HOST)) {
         status = uct_iface_mem_alloc(m_iface, length, mem_flags, "uct_test",
                                      mem);
-        ASSERT_UCS_OK(status);
     } else {
         uct_alloc_method_t alloc_methods[] = {UCT_ALLOC_METHOD_MMAP,
                                               UCT_ALLOC_METHOD_MD};
@@ -961,8 +961,14 @@ void uct_test::entity::mem_alloc(size_t length, unsigned mem_flags,
         status = uct_mem_alloc(length, alloc_methods,
                                ucs_static_array_size(alloc_methods), &params,
                                mem);
+    }
+
+    if (may_fail && (status != UCS_OK)) {
+        throw ucs::test_abort_exception();
+    } else {
         ASSERT_UCS_OK(status);
     }
+
     ucs_assert(mem->mem_type == mem_type);
 }
 
@@ -1414,8 +1420,8 @@ void uct_test::mapped_buffer::reset()
 uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
                                        const entity &entity, size_t offset,
                                        ucs_memory_type_t mem_type,
-                                       unsigned mem_flags) :
-    mapped_buffer(size, entity, offset, mem_type, mem_flags)
+                                       unsigned mem_flags, bool may_fail) :
+    mapped_buffer(size, entity, offset, mem_type, mem_flags, may_fail)
 {
     pattern_fill(seed);
 }
@@ -1423,7 +1429,7 @@ uct_test::mapped_buffer::mapped_buffer(size_t size, uint64_t seed,
 uct_test::mapped_buffer::mapped_buffer(size_t size, 
                                        const entity &entity, size_t offset,
                                        ucs_memory_type_t mem_type,
-                                       unsigned mem_flags) :
+                                       unsigned mem_flags, bool may_fail) :
     m_entity(entity)
 {
     if (size == 0)  {
@@ -1433,7 +1439,7 @@ uct_test::mapped_buffer::mapped_buffer(size_t size,
 
     size_t alloc_size = size + offset;
     if ((mem_type == UCS_MEMORY_TYPE_HOST) || (mem_type == UCS_MEMORY_TYPE_RDMA)) {
-        m_entity.mem_alloc(alloc_size, mem_flags, &m_mem, mem_type);
+        m_entity.mem_alloc(alloc_size, mem_flags, &m_mem, mem_type, may_fail);
     } else {
         m_mem.method   = UCT_ALLOC_METHOD_LAST;
         m_mem.address  = mem_buffer::allocate(alloc_size, mem_type);

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -140,7 +140,8 @@ protected:
 
         void mem_alloc(size_t length, unsigned mem_flags,
                        uct_allocated_memory_t *mem,
-                       ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST) const;
+                       ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
+                       bool may_fail = false) const;
 
         void mem_free(const uct_allocated_memory_t *mem) const;
 
@@ -245,12 +246,15 @@ protected:
     public:
         mapped_buffer(size_t size, const entity &entity, size_t offset = 0,
                       ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
-                      unsigned mem_flags = UCT_MD_MEM_ACCESS_ALL);
+                      unsigned mem_flags = UCT_MD_MEM_ACCESS_ALL,
+                      bool may_fail = false);
 
         mapped_buffer(size_t size, uint64_t seed, const entity &entity,
                       size_t offset = 0,
                       ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
-                      unsigned mem_flags = UCT_MD_MEM_ACCESS_ALL);
+                      unsigned mem_flags = UCT_MD_MEM_ACCESS_ALL,
+                      bool may_fail = false);
+
         virtual ~mapped_buffer();
 
         mapped_buffer(mapped_buffer &&other);


### PR DESCRIPTION
## What?
Added a retry mechanism for allocating MEMIC memory in `test_atomic_key_reg_rdma_mem_type`.

## Why?
To address test failures caused by memory allocation issues, ensuring tests proceed even when allocation initially fails.

## How?
Introduced retries with controlled delays and error logging in `mapped_buffer` allocation. Updated `mem_alloc` and related functions to support optional failure handling.

## Before
![image](https://github.com/user-attachments/assets/8d73b024-7830-4511-aade-0f6a3c1cb336)

## After
![image](https://github.com/user-attachments/assets/02dffe89-d5e5-4b5a-8fb5-992e74e9deb7)