### PR TITLE
UCP/PROTO: UCX_PROTO_INFO=used option

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -476,6 +476,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Enable printing protocols information. The value is interpreted as follows:\n"
    " 'y'          : Print information for all protocols\n"
    " 'n'          : Do not print any protocol information\n"
+   " used         : Print information for used protocols\n"
    " glob_pattern : Print information for operations matching the glob pattern.\n"
    "                For example: '*tag*gpu*', '*put*fast*host*'",
    ucs_offsetof(ucp_context_config_t, proto_info), UCS_CONFIG_TYPE_STRING},

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2228,6 +2228,21 @@ static void ucp_worker_keepalive_reset(ucp_worker_h worker)
     worker->keepalive.round_count = 0;
 }
 
+static void ucp_worker_trace_configs(ucp_worker_h worker)
+{
+    ucp_ep_config_t *ep_config;
+    ucp_rkey_config_t *rkey_config;
+
+    ucs_array_for_each(ep_config, &worker->ep_config) {
+        ucp_proto_select_trace(worker, &ep_config->proto_select);
+    }
+
+    ucs_carray_for_each(rkey_config, worker->rkey_config,
+                        worker->rkey_config_count) {
+        ucp_proto_select_trace(worker, &rkey_config->proto_select);
+    }
+}
+
 static void ucp_worker_destroy_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
@@ -2878,6 +2893,7 @@ static void ucp_worker_destroy_eps(ucp_worker_h worker,
 void ucp_worker_destroy(ucp_worker_h worker)
 {
     ucs_debug("destroy worker %p", worker);
+    ucp_worker_trace_configs(worker);
 
     UCS_ASYNC_BLOCK(&worker->async);
     uct_worker_progress_unregister_safe(worker->uct, &worker->keepalive.cb_id);

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -141,6 +141,9 @@ typedef struct {
 
     /* Map of used lanes */
     ucp_lane_map_t lane_map;
+
+    /* Selected count */
+    size_t         selected_count;
 } ucp_proto_query_attr_t;
 
 

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -61,6 +61,7 @@ struct ucp_proto_perf_node {
 
 /* Protocol information table */
 typedef struct {
+    char counter_str[32];
     char range_str[32];
     char desc[UCP_PROTO_DESC_STR_MAX];
     char config[UCP_PROTO_CONFIG_STR_MAX];
@@ -153,10 +154,15 @@ static void ucp_proto_table_row_separator(ucs_string_buffer_t *strb,
 }
 
 static int ucp_proto_debug_is_info_enabled(ucp_context_h context,
-                                           const char *select_param_str)
+                                           const char *select_param_str,
+                                           int show_used)
 {
     const char *proto_info_config = context->config.ext.proto_info;
     int bool_value;
+
+    if (show_used) {
+        return !strcmp(proto_info_config, "used");
+    }
 
     if (ucs_config_sscanf_bool(proto_info_config, &bool_value, NULL)) {
         return bool_value;
@@ -165,17 +171,34 @@ static int ucp_proto_debug_is_info_enabled(ucp_context_h context,
     return fnmatch(proto_info_config, select_param_str, FNM_CASEFOLD) == 0;
 }
 
+static inline size_t
+ucp_proto_select_elem_selected_count(const ucp_proto_select_elem_t *select_elem)
+{
+#ifdef ENABLE_STATS
+    const ucp_proto_threshold_elem_t *thresh_elem = select_elem->thresholds;
+    size_t total_selected_count                   = 0;
+
+    do {
+        total_selected_count += thresh_elem->proto_config.selected_count;
+    } while ((thresh_elem++)->max_msg_length < SIZE_MAX);
+
+    return total_selected_count;
+#else
+    return 0;
+#endif
+}
+
 static void
 ucp_proto_select_elem_info(ucp_worker_h worker,
                            ucp_worker_cfg_index_t ep_cfg_index,
                            ucp_worker_cfg_index_t rkey_cfg_index,
                            const ucp_proto_select_param_t *select_param,
                            ucp_proto_select_elem_t *select_elem, int show_all,
-                           ucs_string_buffer_t *strb)
+                           int show_used, ucs_string_buffer_t *strb)
 {
     UCS_STRING_BUFFER_ONSTACK(ep_cfg_strb, UCP_PROTO_CONFIG_STR_MAX);
     UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_CONFIG_STR_MAX);
-    static const char *info_row_fmt = "| %*s | %-*s | %-*s |\n";
+    static const char *info_row_fmt = "| %s%*s | %-*s | %-*s |\n";
     ucp_proto_info_table_t table;
     int hdr_col_width[2], col_width[3];
     ucp_proto_query_attr_t proto_attr;
@@ -183,12 +206,17 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
     size_t range_start, range_end;
     int proto_valid;
 
+    if (show_used && (0 == ucp_proto_select_elem_selected_count(select_elem))) {
+        return;
+    }
+
     ucp_proto_select_param_dump(worker, ep_cfg_index, rkey_cfg_index,
                                 select_param, ucp_operation_descs, &ep_cfg_strb,
                                 &sel_param_strb);
     if (!show_all &&
         !ucp_proto_debug_is_info_enabled(
-                worker->context, ucs_string_buffer_cstr(&sel_param_strb))) {
+                worker->context, ucs_string_buffer_cstr(&sel_param_strb),
+                show_used)) {
         return;
     }
 
@@ -219,7 +247,16 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
         ucs_memunits_range_str(range_start, range_end, row_elem->range_str,
                                sizeof(row_elem->range_str));
 
-        col_width[0] = ucs_max(col_width[0], strlen(row_elem->range_str));
+        if (show_used && (proto_attr.selected_count > 0)) {
+            ucs_snprintf_safe(row_elem->counter_str,
+                              sizeof(row_elem->counter_str), "%zu  ",
+                              proto_attr.selected_count);
+        } else {
+            row_elem->counter_str[0] = '\0';
+        }
+
+        col_width[0] = ucs_max(col_width[0], strlen(row_elem->counter_str) +
+                                             strlen(row_elem->range_str));
         col_width[1] = ucs_max(col_width[1], strlen(row_elem->desc));
         col_width[2] = ucs_max(col_width[2], strlen(row_elem->config));
     } while (range_end != SIZE_MAX);
@@ -241,7 +278,8 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
     /* Print contents */
     ucp_proto_table_row_separator(strb, col_width, 3);
     ucs_array_for_each(row_elem, &table) {
-        ucs_string_buffer_appendf(strb, info_row_fmt, col_width[0],
+        ucs_string_buffer_appendf(strb, info_row_fmt, row_elem->counter_str,
+                                  col_width[0] - strlen(row_elem->counter_str),
                                   row_elem->range_str, col_width[1],
                                   row_elem->desc, col_width[2],
                                   row_elem->config);
@@ -262,7 +300,7 @@ void ucp_proto_select_info(ucp_worker_h worker,
 
     kh_foreach(proto_select->hash, key.u64, select_elem,
                ucp_proto_select_elem_info(worker, ep_cfg_index, rkey_cfg_index,
-                                          &key.param, &select_elem, show_all,
+                                          &key.param, &select_elem, show_all, 0,
                                           strb);
                ucs_string_buffer_appendf(strb, "\n"))
 }
@@ -964,7 +1002,7 @@ ucp_proto_select_write_info(ucp_worker_h worker,
                                 ucp_operation_names, &ep_cfg_strb,
                                 &sel_param_strb);
     if (!ucp_proto_debug_is_info_enabled(
-                worker->context, ucs_string_buffer_cstr(&sel_param_strb))) {
+                worker->context, ucs_string_buffer_cstr(&sel_param_strb), 0)) {
         goto out;
     }
 
@@ -1029,17 +1067,19 @@ out:
 }
 
 void ucp_proto_select_elem_trace(ucp_worker_h worker,
-                                 ucp_worker_cfg_index_t ep_cfg_index,
-                                 ucp_worker_cfg_index_t rkey_cfg_index,
                                  const ucp_proto_select_param_t *select_param,
-                                 ucp_proto_select_elem_t *select_elem)
+                                 ucp_proto_select_elem_t *select_elem,
+                                 int show_used)
 {
-    ucs_string_buffer_t strb = UCS_STRING_BUFFER_INITIALIZER;
+    const ucp_proto_config_t *proto_config = &select_elem->thresholds[0].proto_config;
+    ucp_worker_cfg_index_t ep_cfg_index    = proto_config->ep_cfg_index;
+    ucp_worker_cfg_index_t rkey_cfg_index  = proto_config->rkey_cfg_index;
+    ucs_string_buffer_t strb               = UCS_STRING_BUFFER_INITIALIZER;
     char *line;
 
     /* Print human-readable protocol selection table to the log */
     ucp_proto_select_elem_info(worker, ep_cfg_index, rkey_cfg_index,
-                               select_param, select_elem, 0, &strb);
+                               select_param, select_elem, 0, show_used, &strb);
     ucs_string_buffer_for_each_token(line, &strb, "\n") {
         ucs_log_print_compact(line);
     }

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -153,10 +153,9 @@ void ucp_proto_perf_node_replace(ucp_proto_perf_node_t **old_perf_node_p,
 
 
 void ucp_proto_select_elem_trace(ucp_worker_h worker,
-                                 ucp_worker_cfg_index_t ep_cfg_index,
-                                 ucp_worker_cfg_index_t rkey_cfg_index,
                                  const ucp_proto_select_param_t *select_param,
-                                 ucp_proto_select_elem_t *select_elem);
+                                 ucp_proto_select_elem_t *select_elem,
+                                 int show_used);
 
 
 void ucp_proto_select_write_info(

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -298,6 +298,9 @@ static ucs_status_t ucp_proto_select_elem_add_envelope(
             proto_config->rkey_cfg_index = rkey_cfg_index;
             proto_config->select_param   = *select_param;
             proto_config->init_elem      = proto;
+#ifdef ENABLE_STATS
+            proto_config->selected_count = 0;
+#endif
             *last_proto_idx              = proto_idx;
         }
 
@@ -492,8 +495,7 @@ ucp_proto_select_elem_init(ucp_worker_h worker, int internal,
     ucp_proto_select_wiface_activate(worker, select_elem, ep_cfg_index);
 
     if (!internal) {
-        ucp_proto_select_elem_trace(worker, ep_cfg_index, rkey_cfg_index,
-                                    &select_param_copy, select_elem);
+        ucp_proto_select_elem_trace(worker, &select_param_copy, select_elem, 0);
     }
 
     status = UCS_OK;
@@ -580,9 +582,22 @@ void ucp_proto_select_cleanup(ucp_proto_select_t *proto_select)
     ucp_proto_select_elem_t select_elem;
 
     kh_foreach_value(proto_select->hash, select_elem,
-         ucp_proto_select_elem_cleanup(&select_elem)
+        ucp_proto_select_elem_cleanup(&select_elem)
     )
     kh_destroy(ucp_proto_select_hash, proto_select->hash);
+}
+
+void ucp_proto_select_trace(ucp_worker_h worker,
+                            ucp_proto_select_t *proto_select)
+{
+#ifdef ENABLE_STATS
+    ucp_proto_select_elem_t select_elem;
+    ucp_proto_select_key_t key;
+
+    kh_foreach(proto_select->hash, key.u64, select_elem,
+        ucp_proto_select_elem_trace(worker, &key.param, &select_elem, 1);
+    )
+#endif
 }
 
 void ucp_proto_select_add_proto(const ucp_proto_init_params_t *init_params,
@@ -718,6 +733,11 @@ void ucp_proto_select_short_init(ucp_worker_h worker,
             /* no protocol for contig/host */
             goto out_disable;
         }
+
+#ifdef ENABLE_STATS
+        /* Revert stats counter for probe operation */
+        --((ucp_proto_threshold_elem_t *)thresh)->proto_config.selected_count;
+#endif
 
         ucs_assert(thresh->proto_config.proto != NULL);
         if (!ucs_test_all_flags(thresh->proto_config.proto->flags,
@@ -864,6 +884,11 @@ int ucp_proto_select_elem_query(ucp_worker_h worker,
 
     proto_attr->max_msg_length = ucs_min(proto_attr->max_msg_length,
                                          thresh_elem->max_msg_length);
+#ifdef ENABLE_STATS
+    proto_attr->selected_count = proto_config->selected_count;
+#else
+    proto_attr->selected_count = 0;
+#endif
 
     return !(thresh_elem->proto_config.proto->flags & UCP_PROTO_FLAG_INVALID);
 }

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -121,6 +121,11 @@ typedef struct {
 
     /* Pointer to the corresponding initialization data */
     const ucp_proto_init_elem_t *init_elem;
+
+#ifdef ENABLE_STATS
+    /* Usage counter */
+    size_t                      selected_count;
+#endif
 } ucp_proto_config_t;
 
 
@@ -181,6 +186,10 @@ ucs_status_t ucp_proto_select_init(ucp_proto_select_t *proto_select);
 
 
 void ucp_proto_select_cleanup(ucp_proto_select_t *proto_select);
+
+
+void ucp_proto_select_trace(ucp_worker_h worker,
+                            ucp_proto_select_t *proto_select);
 
 
 void ucp_proto_select_add_proto(const ucp_proto_init_params_t *init_params,

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -81,6 +81,7 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
                         size_t msg_length)
 {
     const ucp_proto_select_elem_t *select_elem;
+    const ucp_proto_threshold_elem_t *thresh;
     ucp_proto_select_key_t key;
     khiter_t khiter;
 
@@ -108,7 +109,11 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
         proto_select->cache.value = select_elem;
     }
 
-    return ucp_proto_select_thresholds_search(select_elem, msg_length);
+    thresh = ucp_proto_select_thresholds_search(select_elem, msg_length);
+#ifdef ENABLE_STATS
+    ++((ucp_proto_threshold_elem_t *)thresh)->proto_config.selected_count;
+#endif
+    return thresh;
 }
 
 /*


### PR DESCRIPTION
## What?
Currently when UCX_PROTO_INFO is enabled, it shows tons all the selected protocols, most of which is never used by the application. The idea is to introduce a new option to the config variable ("used"), to limit display to only actually used protocols.
There is already a wildcard option may improve the output, but still it's not enough, because you must know in advance what to look for. On the contrary, displaying used protocols is showing the exact choice made by UCX without guesses, and it also shows the amount of selections per threshold

## Why?
Easy of debugging and diagnostics

## How?
Display only protocols with select_count > 0, and show selection count before message range
```
[1734620114.951681] [rock05:650226:0]   +---------------------------------+----------------------------------------------------------------------------------+                                                                     
[1734620114.951688] [rock05:650226:0]   | ucp_context_47 intra-node cfg#0 | rendezvous data fetch into host memory from host                                 |                                                                     
[1734620114.951690] [rock05:650226:0]   +---------------------------------+---------------------------------+------------------------------------------------+                                                                     
[1734620114.951692] [rock05:650226:0]   |                               0 | no data fetch                   |                                                |                                                                     
[1734620114.951698] [rock05:650226:0]   | 1000                    1..9109 | (?) fragmented copy-in copy-out | rc_mlx5/mlx5_0:1 50% on path0 and 50% on path1 |                                                                     
[1734620114.951704] [rock05:650226:0]   | 1234                  9110..inf | (?) zero-copy                   | rc_mlx5/mlx5_0:1 50% on path0 and 50% on path1 |                                                                     
[1734620114.951707] [rock05:650226:0]   +---------------------------------+---------------------------------+------------------------------------------------+                                                                     
```
