### PR TITLE
UCT/CUDA: Runtime CUDA >= 12.3 to enable VMM

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -52,6 +52,13 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([cudart], [cudaGetDeviceCount],
                              [CUDART_LIBS="$CUDART_LIBS -lcudart"], [cuda_happy="no"])])
+         # Check optional cuda library members
+         AS_IF([test "x$cuda_happy" = "xyes"],
+               [AC_CHECK_LIB([cuda], [cuMemRetainAllocationHandle],
+                             [AC_DEFINE([HAVE_CUMEMRETAINALLOCATIONHANDLE], [1],
+                                        [Enable cuMemRetainAllocationHandle() usage])]),
+                AC_CHECK_DECLS([CU_MEM_LOCATION_TYPE_HOST],
+                               [], [], [[#include <cuda.h>]])])
 
          # Check nvml header files
          AS_IF([test "x$cuda_happy" = "xyes"],


### PR DESCRIPTION
## What?
Do not use `cuCtxSetFlags()` if CUDA driver does not support it.

## Why?
Unresolved symbol for `cuCtxSetFlags` on CUDA driver < 12.1 causes crash.

## How?
Assumptions:
- `cuCtxSetFlags` is only needed for VMM, which has UCX support starting from CUDA driver >= 12.3
- `cuCtxSetFlags` is not strictly needed for malloc async

### Testing
Locally tested, needs final testing on platform with actual older drivers.
```
UCX_IB_GPU_DIRECT_RDMA=no ./rfs/bin/ucx_perftest -t tag_bw -m cuda 
```
