### PR TITLE
GTEST/PROTO: Enforce short protocol in proto mock

### DIFF
--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -292,6 +292,7 @@ public:
     {
         set_mock_iface_attr("rc_mlx5",
             [](uct_iface_attr_t &iface_attr) {
+                iface_attr.cap.flags       |= UCT_IFACE_FLAG_AM_SHORT;
                 iface_attr.cap.am.max_short = 208;
                 iface_attr.bandwidth.shared = 10000000000;
                 iface_attr.latency.c        = 0.000006;


### PR DESCRIPTION
## What?
`test_ucp_proto_mock_rcx.mock_iface_attr` may fail when iface does not have `UCT_IFACE_FLAG_AM_SHORT` capability.
[failing job](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=93127&view=logs&jobId=c02db851-0d7a-5132-2265-ebd0aa7c6d37&j=c02db851-0d7a-5132-2265-ebd0aa7c6d37&t=8b48d60f-a6fd-5948-384e-1fc09fc84e39)
[raw log](https://dev.azure.com/ucfconsort/0b36e3f0-8ab9-4a48-b68b-4b2350e02c88/_apis/build/builds/93127/logs/1225)

In this case `short` protocol is missing:
```
Key op flags: 2, attr: 0
0-8246 desc: copy-in, config: rc_mlx5/mlx5_2:1
8247-377094 desc: multi-frag copy-in, config: rc_mlx5/mlx5_2:1
377095-18446744073709551615 desc: rendezvous zero-copy read from remote, config: rc_mlx5/mlx5_2:1
```
To solve this issue we can enforce `UCT_IFACE_FLAG_AM_SHORT` in mock iface