### PR TITLE
AZP: Align build OS list with the support matrix

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -18,23 +18,14 @@ resources:
     - container: fedora
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:2
       options: $(DOCKER_OPT_ARGS)
-    - container: fedora34
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora34:2
+    - container: fedora41
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/fedora41/builder:inbox
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: coverity_rh7
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/coverity:mofed-5.1-2.3.8.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: rhel76
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel7.6/builder:mofed-5.0-1.0.0.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: rhel76_mofed47
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel7.6/builder:mofed-4.7-1.0.0.1
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: rhel74
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel7.4/builder:mofed-5.0-1.0.0.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: rhel72
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel7.2/builder:mofed-5.0-1.0.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: rhel82
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel8.2/builder:mofed-5.0-1.0.0.0
@@ -63,11 +54,11 @@ resources:
     - container: debian109
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian10.9/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: sles15sp2
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/sles15sp2/builder:mofed-5.0-1.0.0.0
+    - container: debian125
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian12.5/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: sles12sp5
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/sles12sp5/builder:mofed-5.0-1.0.0.0
+    - container: sles15sp6
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/sles15sp6/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: centos7_cuda_11_0
       image: nvidia/cuda:11.0.3-devel-centos7
@@ -180,6 +171,15 @@ resources:
     - container: ubuntu2204_rocm_6_0_0
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2204:rocm-6.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: kylin10sp3
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: euleros2sp12
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: centos10stream
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/centos10stream/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
 
 stages:
   - stage: Codestyle
@@ -201,15 +201,8 @@ stages:
             - ucx_docker -equals yes
         strategy:
           matrix:
-            rhel72:
-              CONTAINER: rhel72
-            rhel74:
-              CONTAINER: rhel74
             rhel76:
               CONTAINER: rhel76
-              long_test: yes
-            rhel76_mofed47:
-              CONTAINER: rhel76_mofed47
               long_test: yes
             ubuntu2004:
               CONTAINER: ubuntu2004
@@ -226,21 +219,28 @@ stages:
               CONTAINER: debian113
             debian109:
               CONTAINER: debian109
-            sles15sp2:
-              CONTAINER: sles15sp2
+            debian125:
+              CONTAINER: debian125
+            sles15sp6:
+              CONTAINER: sles15sp6
             rhel82:
               CONTAINER: rhel82
             rhel90:
               CONTAINER: rhel90
-            fedora34:
-              CONTAINER: fedora34
-              long_test: yes
+            # fedora41:
+            #   CONTAINER: fedora41
             centos7:
               CONTAINER: centos7_ib
+            # centos10stream:
+            #   CONTAINER: centos10stream
             ubuntu2004_rocm:
               CONTAINER: ubuntu2004_rocm_5_4_0
             ubuntu2204_rocm:
               CONTAINER: ubuntu2204_rocm_6_0_0
+            kylin10sp3:
+              CONTAINER: kylin10sp3
+            euleros2sp12:
+              CONTAINER: euleros2sp12
         container: $[ variables['CONTAINER'] ]
         timeoutInMinutes: 340
 


### PR DESCRIPTION
## What?
Align and expand the OS support matrix in CI builds to match supported Doca-ofed OSes (V2.9.0).
### Remove
RHEL7.2
RHEL7.4
RHEL7.6 (keep RHEL7.6_mofed)
Fedora34
sles15sp2
sles15sp5
### Add
debian12.5
euleros2.0sp12
kylin10sp3
sles15sp6
