### PR TITLE
UCP/PROTO: Consider RNDV_PERF_DIFF

### DIFF
--- a/src/ucp/proto/proto_perf.h
+++ b/src/ucp/proto/proto_perf.h
@@ -160,6 +160,21 @@ ucs_status_t ucp_proto_perf_aggregate2(const char *name,
 
 
 /**
+ * Apply function to the performance factors of the given performance structure.
+ *
+ * @param [in] perf         Performance data structure to update.
+ * @param [in] func         Function to apply to the performance factors of the
+ *                          @a perf performance structure.
+ * @param [in] name         Name for the performance node that would be created
+ *                          to represent the impact of @a func.
+ * @param [in] desc_fmt     Formatted description for the performance node that
+ *                          would be created to represent the impact of @a func.
+ */
+void ucp_proto_perf_apply_func(ucp_proto_perf_t *perf, ucs_linear_func_t func,
+                               const char *name, const char *desc_fmt, ...);
+
+
+/**
  * Expand given perf by estimation that all messages on interval
  * [end of @a frag_seg + 1, @a max_length] would be sent in a pipeline async
  * manner using data provided by @a frag_seg as a performance for sending one

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -403,6 +403,13 @@ static void ucp_proto_rndv_ctrl_variant_probe(
         cfg_thresh = remote_proto->cfg_thresh;
     }
 
+    if (fabs(params->perf_bias) > UCP_PROTO_PERF_EPSILON) {
+        ucp_proto_perf_apply_func(perf,
+                                  ucs_linear_func_make(0.0,
+                                                       1.0 - params->perf_bias),
+                                  "bias", "%.2f %%", params->perf_bias);
+    }
+
     ucp_proto_select_add_proto(&params->super.super, cfg_thresh, cfg_priority,
                                perf, rpriv, priv_size);
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -366,8 +366,8 @@ public:
     }
 };
 
-UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_1_lane,
-           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
+UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_1_lane, "IB_NUM_PATHS?=1",
+           "MAX_RNDV_LANES=1")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
@@ -378,14 +378,31 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_1_lane,
         {0,     200,   "short",                "rc_mlx5/mock_1:1"},
         {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1"},
         {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
+        {8247,  21991, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
+        {21992, INF,   "rendezvous zero-copy read from remote",
+                       "rc_mlx5/mock_0:1"},
+    }, key);
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx, zero_rndv_perf_diff, "IB_NUM_PATHS?=1",
+           "MAX_RNDV_LANES=1", "RNDV_PERF_DIFF=0")
+{
+    ucp_proto_select_key_t key = any_key();
+    key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
+    key.param.op_attr          = 0;
+
+    check_ep_config(sender(), {
+        {0,     200,   "short",                "rc_mlx5/mock_1:1"},
+        {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1"},
+        {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
         {8247,  22502, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
         {22503, INF,   "rendezvous zero-copy read from remote",
                        "rc_mlx5/mock_0:1"},
     }, key);
 }
 
-UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_2_lanes,
-           "IB_NUM_PATHS?=2", "MAX_RNDV_LANES=2")
+UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_2_lanes, "IB_NUM_PATHS?=2",
+           "MAX_RNDV_LANES=2")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
@@ -396,8 +413,8 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_2_lanes,
         {0,     200,   "short",                "rc_mlx5/mock_1:1/path0"},
         {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1/path0"},
         {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1/path0"},
-        {8247,  20300, "multi-frag zero-copy", "rc_mlx5/mock_1:1/path0"},
-        {20301, INF,   "rendezvous zero-copy read from remote",
+        {8247,  19883, "multi-frag zero-copy", "rc_mlx5/mock_1:1/path0"},
+        {19884, INF,   "rendezvous zero-copy read from remote",
          "47% on rc_mlx5/mock_1:1/path0 and 53% on rc_mlx5/mock_0:1/path0"},
     }, key);
 }


### PR DESCRIPTION
## What?
Applies `UCX_RNDV_PERF_DIFF` setting effect for protov2. 

Cherry-picked from https://github.com/openucx/ucx/pull/10292.

## Why?
This control effect was removed during introducing perf-factors logic. This PR brings it back.

That how it looks like with that patch:
![image](https://github.com/user-attachments/assets/19986951-09c1-47e2-8d32-205aa6ce0a95)
