### PR TITLE
TEST/GTEST/UCT: Fix retry when it cannot allocate MEMIC memory - add scoped_log_handler

### DIFF
--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -959,6 +959,7 @@ void uct_test::entity::mem_alloc(size_t length, unsigned mem_flags,
     params.address         = address;
 
     for (unsigned i = 0; i <= num_retries; ++i) {
+        scoped_log_handler slh(wrap_errors_logger);
         if ((md_attr().flags & (UCT_MD_FLAG_ALLOC | UCT_MD_FLAG_REG)) &&
             (mem_type == UCS_MEMORY_TYPE_HOST)) {
             status = uct_iface_mem_alloc(m_iface, length, mem_flags, "uct_test",


### PR DESCRIPTION
## What?
Following https://github.com/openucx/ucx/pull/10393, this PR fixes the retry mechanism in `uct_test::entity::mem_alloc` to ensure that errors during memory allocation retries are handled locally and do not propagate to the global error state.

## Why?
The retry mechanism allowed tests to handle temporary allocation failures but lacked a scoped_log_handler. This caused intermediate errors during retries to be logged as global errors, leading to test failures. This PR resolves that issue.

## How?
Added `scoped_log_handler slh(wrap_errors_logger);` inside the retry loop to prevent intermediate allocation failures from being logged as global errors, ensuring tests with successful retries pass.

## Before
![image](https://github.com/user-attachments/assets/63a6e8c2-4779-482e-a66f-fb7930473395)

## After
![image](https://github.com/user-attachments/assets/39e8a19e-b172-454a-a46e-f062c170a54e)