### PR TITLE
UCT/IB/MLX5/RC: perf tuning - decrease rc latency estimation

### DIFF
--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -188,7 +188,7 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     uct_rc_mlx5_iface_common_query(&rc_iface->super, iface_attr, max_am_inline,
                                    UCT_RC_MLX5_TM_EAGER_ZCOPY_MAX_IOV(0));
     iface_attr->cap.flags     |= UCT_IFACE_FLAG_EP_CHECK;
-    iface_attr->latency.m     += 1e-9; /* 1 ns per each extra QP */
+    iface_attr->latency.m     += 32e-11; /* 0.32 ns per each extra QP */
     iface_attr->ep_addr_len    = ep_addr_len;
     iface_attr->iface_addr_len = sizeof(uint8_t);
     return UCS_OK;


### PR DESCRIPTION
## What?
Decrease latency estimation for RC

## Why?
Currently, DC is selected too early, for a relatively small number of eps (~60), after some research it seems DC should be selected only when reaching 180 ~ 190 eps.
