### PR TITLE
AZP/Perf: Update the PerfX code used by the perf pipeline

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -21,7 +21,7 @@ resources:
     type: github
     name: Mellanox-lab/PerfX
     endpoint: Mellanox-lab
-    ref: refs/tags/v1.0.1
+    ref: refs/tags/v1.0.2
 
 stages:
   - stage: Prepare


### PR DESCRIPTION
## What?
Update the PerfX code used by the perf pipeline.

## Why?
The new PerfX release should print the full stderr to logs.
