### PR TITLE
UCP/PERF: Use final sync up for all UCP ucx_perftest tests

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -728,12 +728,7 @@ public:
     bool use_ack() const
     {
         /* TODO: daemon does not support bi-directional flow */
-        if (m_perf.params.ucp.is_daemon_mode) {
-            return false;
-        }
-
-        return (CMD == UCX_PERF_CMD_TAG) || (CMD == UCX_PERF_CMD_TAG_SYNC) ||
-               (CMD == UCX_PERF_CMD_AM);
+        return !m_perf.params.ucp.is_daemon_mode;
     }
 
     void send_ack(void *buffer, ucp_datatype_t datatype)


### PR DESCRIPTION
## What?
Users complain on too optimistic performance reports provided by some ucx_perftest tests (e.g. ucp_put_bw), especially visible on huge messages and low iteration count. The root cause is the absence of synchronisation between client and server at the end of the test execution. This synchronisation was added (https://github.com/openucx/ucx/pull/10310) only for some tests: (UCX_PERF_CMD_TAG, UCX_PERF_CMD_TAG_SYNC, UCX_PERF_CMD_AM). It should be extended to others

## Why?
There is a discrepancy between client and server final perf result, which is especially visible with pipeline protocols, but it occurs also with many others. On the client side we measure time needed to send all the messages, and with pipeline protocol we essentially measure the time needed to send message to the remote bounce buffer. With default window size of 32 we see an initial performance spike on the client side, but with larger amount of iterations the client and server results are converging to the same value due to implicit synchronisation between send/recv.
Workaround: increase iteration count (-n 1000) or decrease window size (-O 1)

## How?
The fix is to send ack message from receiver to the sender at the end of processing, to confirm that all messages were received. For now we only fix the final report, while intermediate reports may still have a discrepancy.

Tested manually by running all UCP STREAM_UNI tests with sync up message
