### PR TITLE
UCT/CUDA/GDR_COPY: rcache lookup overhead config variable.

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -4,9 +4,8 @@ UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed
 UCX_IB_ODP_MEM_TYPES=host,cuda-managed
 UCX_IB_MLX5_DEVX_OBJECTS=
 UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBs
-# Real latency is around 30ns, rest is gdrcopy rcache overhead
-# TODO: Add gdrcopy rcache overhead as separate performance graph node
-UCX_GDR_COPY_LAT=200ns
+UCX_GDR_COPY_LAT=30ns
+UCX_GDR_COPY_RCACHE_OVERHEAD=170ns
 UCX_DISTANCE_BW=auto,sys:16500MBs
 UCX_CUDA_COPY_ASYNC_MEM_TYPE=cuda
 

--- a/src/ucp/proto/proto_perf.c
+++ b/src/ucp/proto/proto_perf.c
@@ -237,22 +237,14 @@ const char *ucp_proto_perf_name(const ucp_proto_perf_t *perf)
 ucs_status_t
 ucp_proto_perf_add_funcs(ucp_proto_perf_t *perf, size_t start, size_t end,
                          const ucp_proto_perf_factors_t perf_factors,
-                         ucp_proto_perf_node_t *child_perf_node,
-                         const char *title, const char *desc_fmt, ...)
+                         ucp_proto_perf_node_t *perf_node,
+                         ucp_proto_perf_node_t *child_perf_node)
 {
     ucp_proto_perf_segment_t *seg, *new_seg;
-    ucp_proto_perf_node_t *perf_node;
     ucs_status_t status;
     size_t seg_end;
-    va_list ap;
 
     ucp_proto_perf_check(perf);
-
-    va_start(ap, desc_fmt);
-    perf_node = ucp_proto_perf_node_new(UCP_PROTO_PERF_NODE_TYPE_DATA, 0, title,
-                                        desc_fmt, ap);
-    va_end(ap);
-
     ucp_proto_perf_node_update_factors(perf_node, perf_factors);
     ucp_proto_perf_node_add_child(perf_node, child_perf_node);
 
@@ -458,6 +450,7 @@ ucp_proto_perf_add_ppln(const ucp_proto_perf_t *perf,
     ucs_linear_func_t factor_func;
     ucs_status_t status;
     char frag_str[64];
+    ucp_proto_perf_node_t *perf_node;
 
     if (frag_size >= max_length) {
         return NULL;
@@ -483,10 +476,11 @@ ucp_proto_perf_add_ppln(const ucp_proto_perf_t *perf,
     factors[max_factor_id].m += factors[max_factor_id].c / frag_size;
 
     ucs_memunits_to_str(frag_size, frag_str, sizeof(frag_str));
-    status = ucp_proto_perf_add_funcs(ppln_perf, frag_size + 1, max_length,
-                                      factors,
-                                      ucp_proto_perf_segment_node(frag_seg),
-                                      "pipeline", "frag size: %s", frag_str);
+    perf_node = ucp_proto_perf_node_new_data("pipeline", "frag size: %s",
+                                             frag_str);
+    status    = ucp_proto_perf_add_funcs(ppln_perf, frag_size + 1, max_length,
+                                         factors, perf_node,
+                                         ucp_proto_perf_segment_node(frag_seg));
     if (status != UCS_OK) {
         return NULL;
     }

--- a/src/ucp/proto/proto_perf.h
+++ b/src/ucp/proto/proto_perf.h
@@ -113,21 +113,19 @@ const char *ucp_proto_perf_name(const ucp_proto_perf_t *perf);
  * @param [in] start           Add the performance function to this range start (inclusive).
  * @param [in] end             Add the performance function to this range end (inclusive).
  * @param [in] perf_factors    Array of performance functions to add.
+ * @param [in] perf_node       Performance node to represent @a perf_factors
+ *                             data.
  * @param [in] child_perf_node Performance node that would be considered as
  *                             child node for all segment nodes on [start, end]
  *                             interval.
- * @param [in] title           Title for performance node that would be created
- *                             to represent @a perf_factors data.
- * @param [in] desc_fmt        Formatted description for performance node that
- *                             would be created to represent @a perf_factors data.
  *
  * @note This function may adjust the reference count of @a perf_node as needed.
  */
 ucs_status_t
 ucp_proto_perf_add_funcs(ucp_proto_perf_t *perf, size_t start, size_t end,
                          const ucp_proto_perf_factors_t perf_factors,
-                         ucp_proto_perf_node_t *child_perf_node,
-                         const char *title, const char *desc_fmt, ...);
+                         ucp_proto_perf_node_t *perf_node,
+                         ucp_proto_perf_node_t *child_perf_node);
 
 
 /**

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -83,9 +83,8 @@ static void ucp_proto_reconfig_probe(const ucp_proto_init_params_t *init_params)
 
     perf_factors[UCP_PROTO_PERF_FACTOR_LOCAL_TL] =
             ucs_linear_func_make(INFINITY, 0);
-    ucp_proto_perf_add_funcs(perf, 0, SIZE_MAX, perf_factors, NULL, "dummy",
-                             "");
-
+    ucp_proto_perf_add_funcs(perf, 0, SIZE_MAX, perf_factors,
+                             ucp_proto_perf_node_new_data("dummy", ""), NULL);
     ucp_proto_select_add_proto(init_params, UCS_MEMUNITS_INF, 0, perf, NULL, 0);
 }
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -200,6 +200,7 @@ ucp_proto_rndv_ctrl_perf(const ucp_proto_common_init_params_t *init_params,
     ucp_rsc_index_t rsc_index;
     ucp_proto_perf_t *perf;
     ucs_status_t status;
+    ucp_proto_perf_node_t *perf_node;
 
     if (lane == UCP_NULL_LANE) {
         return UCS_ERR_NO_ELEM;
@@ -237,9 +238,10 @@ ucp_proto_rndv_ctrl_perf(const ucp_proto_common_init_params_t *init_params,
     perf_factors[UCP_PROTO_PERF_FACTOR_LATENCY]    = ucs_linear_func_make(
             ucp_tl_iface_latency(worker->context, &perf_attr.latency), 0.0);
 
-    status = ucp_proto_perf_add_funcs(perf, init_params->min_length,
-                                      init_params->max_length, perf_factors,
-                                      NULL, name, "");
+    perf_node = ucp_proto_perf_node_new_data(name, "");
+    status    = ucp_proto_perf_add_funcs(perf, init_params->min_length,
+                                         init_params->max_length, perf_factors,
+                                         perf_node, NULL);
     if (status != UCS_OK) {
         goto err_destroy_perf;
     }

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -38,13 +38,15 @@ ucp_proto_rndv_ppln_add_overhead(ucp_proto_perf_t *ppln_perf, size_t frag_size)
     static const double frag_overhead = 30e-9;
     ucp_proto_perf_factors_t factors  = UCP_PROTO_PERF_FACTORS_INITIALIZER;
     char frag_str[64];
+    ucp_proto_perf_node_t *node;
 
     ucs_memunits_to_str(frag_size, frag_str, sizeof(frag_str));
     factors[UCP_PROTO_PERF_FACTOR_LOCAL_CPU] =
             ucs_linear_func_make(frag_overhead, frag_overhead / frag_size);
+    node = ucp_proto_perf_node_new_data("fragment overhead", "frag size: %s",
+                                        frag_str);
     return ucp_proto_perf_add_funcs(ppln_perf, frag_size + 1, SIZE_MAX, factors,
-                                    NULL, "fragment overhead", "frag size: %s",
-                                    frag_str);
+                                    node, NULL);
 }
 
 static void

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -29,11 +29,12 @@ typedef struct {
  * gdr copy domain configuration.
  */
 typedef struct uct_gdr_copy_md_config {
-    uct_md_config_t         super;
-    int                     shared;       /**< Shared MD instance */
-    int                     enable_rcache;/**< Enable registration cache */
-    ucs_linear_func_t       uc_reg_cost;  /**< Memory registration cost estimation
-                                             without using the cache */
+    uct_md_config_t     super;
+    int                 shared;        /**< Shared MD instance */
+    int                 enable_rcache; /**< Enable registration cache */
+    ucs_linear_func_t   uc_reg_cost;   /**< Memory registration cost estimation
+                                            without using the cache */
+    ucs_rcache_config_t rcache_config; /**< Registration cache configuration */
 } uct_gdr_copy_md_config_t;
 
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -412,12 +412,15 @@ protected:
     {
         ucp_proto_perf_factors_t perf_factors =
                 UCP_PROTO_PERF_FACTORS_INITIALIZER;
+        ucp_proto_perf_node_t *perf_node;
 
         for (auto &f : factors) {
             perf_factors[f.first] = f.second;
         }
+
+        perf_node = ucp_proto_perf_node_new_data("test", "");
         ASSERT_UCS_OK(ucp_proto_perf_add_funcs(perf.get(), start, end,
-                                               perf_factors, NULL, "test", ""));
+                                               perf_factors, perf_node, NULL));
     }
 
     static void add_func(perf_ptr_t perf, size_t start, size_t end,


### PR DESCRIPTION
## What?
Added configuration variable to set gdr_copy registration cache lookup overhead.

Original pull request: https://github.com/openucx/ucx/pull/10311.

![s](https://github.com/user-attachments/assets/e57b837b-b5b1-4d38-85ab-8ab2d0023648)

