### PR TITLE
UCS/MEMORY: Removed unused field from ucs_rcache_config.

### DIFF
--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -161,7 +161,6 @@ struct ucs_rcache_params {
  * Registration cache configuration parameters.
  */
 struct ucs_rcache_config {
-    size_t        alignment;      /**< Force address alignment */
     unsigned      event_prio;     /**< Memory events priority */
     ucs_time_t    overhead;       /**< Lookup overhead estimation */
     unsigned long max_regions;    /**< Maximal number of rcache regions */


### PR DESCRIPTION
## What?
Removed unused field from structure `ucs_rcache_config`.

The usage of the field removed by this pull request: https://github.com/openucx/ucx/pull/9441.
