### PR TITLE
BUILD/CUDA: Remove extra comma from autoconf script

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -56,7 +56,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([cuda], [cuMemRetainAllocationHandle],
                              [AC_DEFINE([HAVE_CUMEMRETAINALLOCATIONHANDLE], [1],
-                                        [Enable cuMemRetainAllocationHandle() usage])]),
+                                        [Enable cuMemRetainAllocationHandle() usage])])
                 AC_CHECK_DECLS([CU_MEM_LOCATION_TYPE_HOST],
                                [], [], [[#include <cuda.h>]])])
 


### PR DESCRIPTION
## Why
Fix error from configure:
```
...
checking for cuMemRetainAllocationHandle in -lcuda... yes
/ucx/contrib/../configure: line 26521: ,: command not found
checking whether CU_MEM_LOCATION_TYPE_HOST is declared... yes
```