### PR TITLE
BUILD/CUDA: Remove extra comma from autoconf script - v1.18.x

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -53,7 +53,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AS_IF([test "x$cuda_happy" = "xyes"],
                [AC_CHECK_LIB([cuda], [cuMemRetainAllocationHandle],
                              [AC_DEFINE([HAVE_CUMEMRETAINALLOCATIONHANDLE], [1],
-                                        [Enable cuMemRetainAllocationHandle() usage])]),
+                                        [Enable cuMemRetainAllocationHandle() usage])])
                 AC_CHECK_DECLS([CU_MEM_LOCATION_TYPE_HOST],
                                [], [], [[#include <cuda.h>]])])
 


### PR DESCRIPTION
backport #10431