### PR TITLE
UCS/STATS: Mark variable as unused to prevent build failure

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -320,6 +320,10 @@ build_gcc_debug_opt() {
 	build_gcc CFLAGS=-Og CXXFLAGS=-Og
 }
 
+build_gcc_with_dndebug() {
+	build_gcc CFLAGS=-DNDEBUG CXXFLAGS=-DNDEBUG
+}
+
 #
 # Build with armclang compiler
 #
@@ -444,6 +448,7 @@ then
 			'build_no_devx' \
 			'build_no_openmp' \
 			'build_gcc_debug_opt' \
+			'build_gcc_with_dndebug' \
 			'build_clang' \
 			'build_armclang')
 fi

--- a/src/ucs/stats/serialization.c
+++ b/src/ucs/stats/serialization.c
@@ -74,14 +74,14 @@ SGLIB_DEFINE_HASHED_CONTAINER_FUNCTIONS(ucs_stats_clsid_t, UCS_STATS_CLS_HASH_SI
 
 #define FREAD(_buf, _size, _stream) \
     { \
-        size_t _nread = fread(_buf, 1, _size, _stream); \
-        assert(_nread == _size); \
+        size_t UCS_V_UNUSED _nread = fread(_buf, 1, _size, _stream); \
+        ucs_assert(_nread == _size); \
     }
 
 #define FWRITE(_buf, _size, _stream) \
     { \
-        size_t nwrite = fwrite(_buf, 1, _size, _stream); \
-        assert(nwrite == _size); \
+        size_t UCS_V_UNUSED nwrite = fwrite(_buf, 1, _size, _stream); \
+        ucs_assert(nwrite == _size); \
     }
 
 #define FREAD_ONE(_ptr, _stream) \


### PR DESCRIPTION
## What?
Mark variable as unused to prevent build failure.
Use ucs_assert MACRO instead of assert.

## Why?
When building UCX with `DNDEBUG` flag assert macro is evaluated to `((void)0)` and it cause compilation to fail due to `unused variable` exception.
