### PR TITLE
UCP/PROTO: Removed ucp_proto_perf_node_new from include file.

### DIFF
--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -468,10 +468,10 @@ void ucp_proto_select_info_str(ucp_worker_h worker,
     }
 }
 
-ucp_proto_perf_node_t *ucp_proto_perf_node_new(ucp_proto_perf_node_type_t type,
-                                               unsigned selected_child,
-                                               const char *name,
-                                               const char *desc_fmt, va_list ap)
+static ucp_proto_perf_node_t *
+ucp_proto_perf_node_new(ucp_proto_perf_node_type_t type,
+                        unsigned selected_child, const char *name,
+                        const char *desc_fmt, va_list ap)
 {
     ucp_proto_perf_node_t *perf_node;
 

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -87,11 +87,6 @@ void ucp_proto_config_info_str(ucp_worker_h worker,
 
 
 ucp_proto_perf_node_t *
-ucp_proto_perf_node_new(ucp_proto_perf_node_type_t type,
-                        unsigned selected_child, const char *name,
-                        const char *desc_fmt, va_list ap);
-
-ucp_proto_perf_node_t *
 ucp_proto_perf_node_new_data(const char *name, const char *desc_fmt, ...);
 
 

--- a/src/ucp/proto/proto_perf.c
+++ b/src/ucp/proto/proto_perf.c
@@ -249,8 +249,7 @@ ucp_proto_perf_add_funcs(ucp_proto_perf_t *perf, size_t start, size_t end,
     ucp_proto_perf_check(perf);
 
     va_start(ap, desc_fmt);
-    perf_node = ucp_proto_perf_node_new(UCP_PROTO_PERF_NODE_TYPE_DATA, 0, title,
-                                        desc_fmt, ap);
+    perf_node = ucp_proto_perf_node_new_data(title, desc_fmt, ap);
     va_end(ap);
 
     ucp_proto_perf_node_update_factors(perf_node, perf_factors);


### PR DESCRIPTION
## What?
 Removed `ucp_proto_perf_node_new` from include file.
