### PR TITLE
UCT/CUDA_IPC: Handle memh invalidation

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -397,10 +397,17 @@ uct_cuda_ipc_mem_dereg(uct_md_h md, const uct_md_mem_dereg_params_t *params)
     uct_cuda_ipc_memh_t *memh = params->memh;
     uct_cuda_ipc_lkey_t *key, *tmp;
 
-    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
+    UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 1);
 
     ucs_list_for_each_safe(key, tmp, &memh->list, link) {
         ucs_free(key);
+    }
+
+    /* TODO: remove this when derived memory handle is ready */
+    if (UCT_MD_MEM_DEREG_FIELD_VALUE(params, flags, FIELD_FLAGS, 0) &
+        UCT_MD_MEM_DEREG_FLAG_INVALIDATE) {
+        ucs_assert(params->comp != NULL); /* suppress coverity false-positive */
+        uct_invoke_completion(params->comp, UCS_OK);
     }
 
     ucs_free(memh);


### PR DESCRIPTION
## What?
Error is seen in io-demo-cuda during invalidation:
```
ucp_mm.c:369 UCX WARN failed to dereg from md[4]=cuda_ipc: Unsupported operation
```

## Why?
cuda_ipc_md claims to support invalidation, but in case of invalidation event we show that it's not supported and just return.
```C
static ucs_status_t
uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
{
    uct_md_base_md_query(md_attr);
    md_attr->flags            = UCT_MD_FLAG_REG |
                                UCT_MD_FLAG_NEED_RKEY |
                                UCT_MD_FLAG_INVALIDATE |
                                UCT_MD_FLAG_INVALIDATE_RMA |
                                UCT_MD_FLAG_INVALIDATE_AMO;
```

## How?
CUDA does not support invalidation concept, so the best we can do as of now is just to destroy the memh