### PR TITLE
UCT/API: introduce sys_dev field for mem_alloc

### DIFF
--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1712,6 +1712,7 @@ typedef struct uct_allocated_memory {
     ucs_memory_type_t        mem_type; /**< type of allocated memory */
     uct_md_h                 md;       /**< if method==MD: MD used to allocate the memory */
     uct_mem_h                memh;     /**< if method==MD: MD memory handle */
+    ucs_sys_device_t         sys_dev;  /**< System device for allocated memory */
 } uct_allocated_memory_t;
 
 
@@ -2501,7 +2502,10 @@ typedef enum {
     UCT_MEM_ALLOC_PARAM_FIELD_MDS            = UCS_BIT(3),
 
     /** Enables @ref uct_mem_alloc_params_t::name */
-    UCT_MEM_ALLOC_PARAM_FIELD_NAME           = UCS_BIT(4)
+    UCT_MEM_ALLOC_PARAM_FIELD_NAME           = UCS_BIT(4),
+
+    /** Enables @ref uct_mem_alloc_params_t::sys_device */
+    UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEVICE     = UCS_BIT(5)
 } uct_mem_alloc_params_field_t;
 
 
@@ -2564,6 +2568,13 @@ typedef struct {
      * "anonymous-uct_mem_alloc" is used by default.
      */
     const char                   *name;
+
+    /**
+     * Index of the system device on which memory is to be allocated.
+     * Eg: UCS_SYS_DEVICE_ID_UNKNOWN to allocate on host memory, or a specfic
+     * index to allocate memory on GPU device.
+     */
+    ucs_sys_device_t             sys_dev;
 } uct_mem_alloc_params_t;
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2571,7 +2571,7 @@ typedef struct {
 
     /**
      * Index of the system device on which memory is to be allocated.
-     * Eg: UCS_SYS_DEVICE_ID_UNKNOWN to allocate on host memory, or a specfic
+     * Eg: UCS_SYS_DEVICE_ID_UNKNOWN to allocate on host memory, or a specific
      * index to allocate memory on GPU device.
      */
     ucs_sys_device_t             sys_dev;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2505,7 +2505,7 @@ typedef enum {
     UCT_MEM_ALLOC_PARAM_FIELD_NAME           = UCS_BIT(4),
 
     /** Enables @ref uct_mem_alloc_params_t::sys_device */
-    UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEVICE     = UCS_BIT(5)
+    UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEV        = UCS_BIT(5)
 } uct_mem_alloc_params_field_t;
 
 
@@ -2570,9 +2570,8 @@ typedef struct {
     const char                   *name;
 
     /**
-     * Index of the system device on which memory is to be allocated.
-     * Eg: UCS_SYS_DEVICE_ID_UNKNOWN to allocate on host memory, or a specific
-     * index to allocate memory on GPU device.
+     * System device on which memory is to be allocated, or
+     * UCS_SYS_DEVICE_ID_UNKNOWN to allow allocating on any device.
      */
     ucs_sys_device_t             sys_dev;
 } uct_mem_alloc_params_t;

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -2504,7 +2504,7 @@ typedef enum {
     /** Enables @ref uct_mem_alloc_params_t::name */
     UCT_MEM_ALLOC_PARAM_FIELD_NAME           = UCS_BIT(4),
 
-    /** Enables @ref uct_mem_alloc_params_t::sys_device */
+    /** Enables @ref uct_mem_alloc_params_t::sys_dev */
     UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEV        = UCS_BIT(5)
 } uct_mem_alloc_params_field_t;
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -539,10 +539,11 @@ ucs_status_t uct_mem_alloc_check_params(size_t length,
 
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
                               ucs_memory_type_t mem_type, unsigned flags,
-                              const char *alloc_name, uct_mem_h *memh_p)
+                              const char *alloc_name, ucs_sys_device_t sys_dev,
+                              uct_mem_h *memh_p)
 {
     return md->ops->mem_alloc(md, length_p, address_p, mem_type, flags,
-                              alloc_name, memh_p);
+                              alloc_name, sys_dev, memh_p);
 }
 
 ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh)

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -82,6 +82,7 @@ typedef ucs_status_t (*uct_md_mem_alloc_func_t)(uct_md_h md,
                                                 ucs_memory_type_t mem_type,
                                                 unsigned flags,
                                                 const char *alloc_name,
+                                                ucs_sys_device_t sys_dev,
                                                 uct_mem_h *memh_p);
 
 typedef ucs_status_t (*uct_md_mem_free_func_t)(uct_md_h md, uct_mem_h memh);
@@ -192,11 +193,13 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
  * @param [in]     flags       Memory allocation flags, see @ref uct_md_mem_flags.
  * @param [in]     name        Name of the allocated region, used to track memory
  *                             usage for debugging and profiling.
+ * @param [in]     sys_dev     System device for the allocation.
  * @param [out]    memh_p      Filled with handle for allocated region.
  */
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
                               ucs_memory_type_t mem_type, unsigned flags,
-                              const char *alloc_name, uct_mem_h *memh_p);
+                              const char *alloc_name, ucs_sys_device_t  sys_dev,
+                              uct_mem_h *memh_p);
 
 /**
  * @ingroup UCT_MD

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -198,7 +198,7 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
  */
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
                               ucs_memory_type_t mem_type, unsigned flags,
-                              const char *alloc_name, ucs_sys_device_t  sys_dev,
+                              const char *alloc_name, ucs_sys_device_t sys_dev,
                               uct_mem_h *memh_p);
 
 /**

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -155,9 +155,8 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
                  * fall-back, because this MD already exposed support for memory
                  * allocation.
                  */
-                status = uct_md_mem_alloc(md, &alloc_length, &address,
-                                          mem_type, flags, alloc_name,
-                                          sys_dev, &memh);
+                status = uct_md_mem_alloc(md, &alloc_length, &address, mem_type,
+                                          flags, alloc_name, sys_dev, &memh);
                 if (status != UCS_OK) {
                     ucs_log(log_level,
                             "failed to allocate %zu bytes using md %s for %s: %s",

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -102,7 +102,7 @@ ucs_status_t uct_mem_alloc(size_t length, const uct_alloc_method_t *methods,
                    params->name : "anonymous-uct_mem_alloc";
     mem_type     = (params->field_mask & UCT_MEM_ALLOC_PARAM_FIELD_MEM_TYPE) ?
                    params->mem_type : UCS_MEMORY_TYPE_HOST;
-    sys_dev      = (params->field_mask & UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEVICE) ?
+    sys_dev      = (params->field_mask & UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEV) ?
                    params->sys_dev : UCS_SYS_DEVICE_ID_UNKNOWN;
     alloc_length = length;
     log_level    = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -360,7 +360,8 @@ static void uct_cuda_copy_sync_memops(uct_cuda_copy_md_t *md,
 static ucs_status_t
 uct_cuda_copy_mem_alloc(uct_md_h uct_md, size_t *length_p, void **address_p,
                         ucs_memory_type_t mem_type, unsigned flags,
-                        const char *alloc_name, uct_mem_h *memh_p)
+                        const char *alloc_name, ucs_sys_device_t sys_dev,
+                        uct_mem_h *memh_p)
 {
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
     ucs_status_t status;

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1986,7 +1986,7 @@ ucs_status_t
 uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
                                   void **address_p, ucs_memory_type_t mem_type,
                                   unsigned flags, const char *alloc_name,
-                                  uct_mem_h *memh_p)
+                                  ucs_sys_device_t sys_dev, uct_mem_h *memh_p)
 {
 #if HAVE_IBV_DM
     uct_ib_md_t *md           = ucs_derived_of(uct_md, uct_ib_md_t);

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -2144,7 +2144,7 @@ static void uct_ib_mlx5dv_check_dm_ksm_reg(uct_ib_mlx5_md_t *md)
     status = uct_ib_mlx5_devx_device_mem_alloc(uct_md, &length, &address,
                                                UCS_MEMORY_TYPE_RDMA, 0,
                                                "check dm ksm registration",
-                                               &memh);
+                                               UCS_SYS_DEVICE_ID_UNKNOWN, &memh);
     if (status != UCS_OK) {
         ucs_debug("%s: KSM over device memory is not supported",
                   ucs_status_string(status));

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1160,7 +1160,7 @@ ucs_status_t
 uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
          void **address_p, ucs_memory_type_t mem_type,
                                   unsigned flags, const char *alloc_name,
-                                  uct_mem_h *memh_p);
+                                  ucs_sys_device_t sys_dev, uct_mem_h *memh_p);
 
 ucs_status_t
 uct_ib_mlx5_devx_device_mem_free(uct_md_h uct_md, uct_mem_h tl_memh);

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -240,7 +240,8 @@ static void uct_rocm_copy_md_close(uct_md_h uct_md) {
 static ucs_status_t
 uct_rocm_copy_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
                         ucs_memory_type_t mem_type, unsigned flags,
-                        const char *alloc_name, uct_mem_h *memh_p)
+                        const char *alloc_name, ucs_sys_device_t sys_dev,
+                        uct_mem_h *memh_p)
 {
     ucs_status_t status;
     hsa_status_t hsa_status;

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -516,7 +516,8 @@ uct_posix_segment_open(uct_mm_md_t *md, uct_mm_seg_id_t *seg_id_p, int *fd_p)
 static ucs_status_t
 uct_posix_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
                     ucs_memory_type_t mem_type, unsigned flags,
-                    const char *alloc_name, uct_mem_h *memh_p)
+                    const char *alloc_name, ucs_sys_device_t sys_dev,
+                    uct_mem_h *memh_p)
 {
     uct_mm_md_t                     *md = ucs_derived_of(tl_md, uct_mm_md_t);
     uct_posix_md_config_t *posix_config = ucs_derived_of(md->config,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -69,7 +69,8 @@ static ucs_status_t uct_sysv_mem_attach_common(int shmid, void **address_p)
 static ucs_status_t
 uct_sysv_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
                    ucs_memory_type_t mem_type, unsigned flags,
-                   const char *alloc_name, uct_mem_h *memh_p)
+                   const char *alloc_name, ucs_sys_device_t sys_dev,
+                   uct_mem_h *memh_p)
 {
     uct_mm_md_t *md = ucs_derived_of(tl_md, uct_mm_md_t);
     ucs_status_t status;

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -63,7 +63,8 @@ static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 static ucs_status_t
 uct_ze_copy_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
                       ucs_memory_type_t mem_type, unsigned flags,
-                      const char *alloc_name, uct_mem_h *memh_p)
+                      const char *alloc_name, ucs_sys_device_t sys_dev,
+                      uct_mem_h *memh_p)
 {
     uct_ze_copy_md_t *md = ucs_derived_of(tl_md, uct_ze_copy_md_t);
     ze_host_mem_alloc_desc_t host_desc  = {};

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -87,9 +87,11 @@ UCS_TEST_P(test_mem, md_alloc) {
                              UCT_MEM_ALLOC_PARAM_FIELD_ADDRESS   |
                              UCT_MEM_ALLOC_PARAM_FIELD_MEM_TYPE  |
                              UCT_MEM_ALLOC_PARAM_FIELD_MDS       |
-                             UCT_MEM_ALLOC_PARAM_FIELD_NAME;
+                             UCT_MEM_ALLOC_PARAM_FIELD_NAME      |
+                             UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEV;
     params.name            = "test";
     params.mem_type        = UCS_MEMORY_TYPE_HOST;
+    params.sys_dev         = UCS_SYS_DEVICE_ID_UNKNOWN; /* ignored by MDs now */
     params.address         = address;
     params.mds.count       = 1;
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1468,6 +1468,7 @@ uct_test::mapped_buffer::mapped_buffer(size_t size,
         m_mem.mem_type = mem_type;
         m_mem.memh     = UCT_MEM_HANDLE_NULL;
         m_mem.md       = NULL;
+        m_mem.sys_dev  = UCS_SYS_DEVICE_ID_UNKNOWN;
         m_entity.mem_type_reg(&m_mem, mem_flags);
     }
 


### PR DESCRIPTION
## What? Why?
As we move towards supporting multi-device configurations and relaxing GPU context setting requirements, UCP and other UCT users need to be able to indicate on which system device the allocation is being requested on without having to rely on inferring the same from context set against calling thread. This patch extends allocation params struct to include system device. In this initial implementation all UCT allocators ignore the system device argument but eventually different transports can convert the given system device into a [bus_id ](https://github.com/openucx/ucx/blob/master/src/ucs/sys/topo/base/topo.h#L101)and allocate against that specific device. 