### PR TITLE
UCP/PROTO: Do not pass va_list to variable parameters function

### DIFF
--- a/src/ucp/proto/proto_perf.c
+++ b/src/ucp/proto/proto_perf.c
@@ -465,7 +465,8 @@ void ucp_proto_perf_apply_func(ucp_proto_perf_t *perf, ucs_linear_func_t func,
         }
 
         va_start(ap, desc_fmt);
-        func_node = ucp_proto_perf_node_new_data(name, desc_fmt, ap);
+        func_node = ucp_proto_perf_node_new(UCP_PROTO_PERF_NODE_TYPE_DATA, 0,
+                                            name, desc_fmt, ap);
         va_end(ap);
 
         ucp_proto_perf_node_own_child(seg->node, &func_node);


### PR DESCRIPTION
## What?
Fix memory corruption, as we cannot pass `va_list` to function with variable number of arguments.

Triggered by #10401 from inside:
```
    if (fabs(params->perf_bias) > UCP_PROTO_PERF_EPSILON) {
```
## Why?
```
==255151== Use of uninitialised value of size 8
==255151==    at 0x72D71E7: __printf_fp_l (in /usr/lib64/libc-2.28.so)
==255151==    by 0x72D367E: vfprintf (in /usr/lib64/libc-2.28.so)
==255151==    by 0x72FC2F3: vsnprintf (in /usr/lib64/libc-2.28.so)
==255151==    by 0x4EC9DB1: ucs_vsnprintf_safe (string.c:222)
==255151==    by 0x4EC9DB1: ucs_vsnprintf_safe (string.c:216)
==255151==    by 0x570B155: ucp_proto_perf_node_new (proto_debug.c:489)
==255151==    by 0x570B34D: ucp_proto_perf_node_new_data (proto_debug.c:537)
==255151==    by 0x570ED15: ucp_proto_perf_apply_func (proto_perf.c:468)
==255151==    by 0x574579E: ucp_proto_rndv_ctrl_variant_probe (proto_rndv.c:407)
==255151==    by 0x5745919: ucp_proto_rndv_ctrl_probe (proto_rndv.c:466)
==255151==    by 0x5745C7F: ucp_proto_rndv_rts_probe (proto_rndv.c:551)
==255151==    by 0x571350F: ucp_proto_select_init_protocols (proto_select.c:220)
==255151==    by 0x57143C7: ucp_proto_select_elem_init (proto_select.c:478)

```
