### PR TITLE
AUTHORS: Fix authors order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,9 +2,9 @@ Aboorva Devarajan <aboorvad@linux.ibm.com>
 Akshay Venkatesh <akvenkatesh@nvidia.com>
 Alastair McKinstry <mckinstry@debian.org>
 Aleksey Senin <alekseys@nvidia.com>
-Alexey Rivkin <arivkin@nvidia.com>
 Alex Margolin <alex.margolin@huawei.com>
 Alex Mikheev <alexm@mellanox.com>
+Alexey Rivkin <arivkin@nvidia.com>
 Alina Sklarevich <alinas@mellanox.com>
 Alma Mastbaum <amastbaum@nvidia.com>
 Anatoly Vildemanov <anatolyv@nvidia.com>
@@ -73,8 +73,8 @@ Pak Lui <Pak.Lui@amd.com>
 Pavan Balaji <balaji@anl.gov>
 Pavel Shamis (Pasha) <pasharesearch@gmail.com>
 Peter Andreas Entschev <peter@entschev.com>
-Peter-Jan Gootzen <pgootzen@nvidia.com>
 Peter Rudenko <peterr@mellanox.com>
+Peter-Jan Gootzen <pgootzen@nvidia.com>
 Qiang Yu <Qiang.Yu@amd.com>
 Raul Akhmetshin <rakhmetshin@nvidia.com>
 Robert Dietrich <rdietrich@nvidia.com>


### PR DESCRIPTION
## What?
Fix order in author list to have CI pass.

This went in v1.18 because CI check is not enforced on v1.18. When porting AUTHORS file to master, it went in because AUTHOR CI check does not run when only changing AUTHORS file. Now this fixes it once and for all. 