### PR TITLE
UCT/CUDA: treat stitched VA as managed memory

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -689,6 +689,13 @@ uct_cuda_copy_md_query_attributes(uct_cuda_copy_md_t *md, const void *address,
         return UCS_ERR_INVALID_ADDR;
     }
 
+    if ((uintptr_t)base_address + alloc_length < (uintptr_t)address + length) {
+        /* >1 PA behind VA range, treat as managed memory to force pipeline */
+        mem_info->type = UCS_MEMORY_TYPE_CUDA_MANAGED;
+        base_address   = (CUdeviceptr)address;
+        alloc_length   = length;
+    }
+
     ucs_trace("query address %p: 0x%llx..0x%llx length %zu", address,
               base_address, base_address + alloc_length, alloc_length);
 


### PR DESCRIPTION
## What?
Detect VA ranges composed of multiple physical allocations and treat as managed memory to force pipeline protocols.

Initial tests on nvlink connected GPUs show protocols being selected correctly:
```
[1738101119.349005] [52879:0]   | ucp_context_0 inter-node cfg#2 | rendezvous data send(fast-completion|multi) from cuda-managed/GPU0 to cuda    |
[1738101119.349007] [52879:0]   +--------------------------------+---------------------------------------------------------------+---------------+
[1738101119.349010] [52879:0]   |                        0..8176 | fragmented copy-in copy-out                                   | tcp/enP2s2f1  |
[1738101119.349011] [52879:0]   |                       8177..4M | cuda_copy, flushed write to remote, frag cuda                 | cuda_ipc/cuda |
[1738101119.349012] [52879:0]   |                   4194305..inf | pipeline cuda_copy, write to remote, frag cuda                | cuda_ipc/cuda |
[1738101119.349013] [52879:0]   +--------------------------------+---------------------------------------------------------------+---------------+

```
