### PR TITLE
UCT/IB/RDMACM: Disable rdmacm support when verbs is disabled

### DIFF
--- a/src/uct/ib/rdmacm/configure.m4
+++ b/src/uct/ib/rdmacm/configure.m4
@@ -12,6 +12,8 @@ AC_ARG_WITH([rdmacm],
            [AS_HELP_STRING([--with-rdmacm=(DIR)], [Enable the use of RDMACM (default is guess).])],
            [], [with_rdmacm=guess])
 
+AS_IF([test "x$with_ib" = xno], [with_rdmacm=no])
+
 AS_IF([test "x$with_rdmacm" != xno],
       [AS_IF([test "x$with_rdmacm" = xguess -o "x$with_rdmacm" = xyes -o "x$with_rdmacm" = x],
              [ucx_check_rdmacm_dir=/usr],


### PR DESCRIPTION
## What?
Do not advertize `rdmacm` in the build_module list when `--without-verbs` is specified.

## Why?
gtest crashes because `enum_md_resources()` calls `dlopen(rdmacm)` which ends-up loading the unrelated system-wide library, which in turn loads the system-wide uct ib.

```
==== backtrace (tid:1050034) ====
 0 0x0000000000012ce0 __funlockfile()  :0
 1 0x000000000005b319 ucs_config_parser_parse_field()  src/ucs/config/parser.c:1333
 2 0x000000000005b537 ucs_config_parser_set_default_values()  src/ucs/config/parser.c:1384
 3 0x000000000005b50d ucs_config_parser_set_default_values()  src/ucs/config/parser.c:1378
 4 0x000000000005c560 ucs_config_parser_fill_opts()  src/ucs/config/parser.c:1831
 5 0x0000000000017c43 uct_config_read()  src/uct/base/uct_component.c:151
 6 0x0000000000014559 uct_md_config_read()  src/uct/base/uct_md.c:269
 7 0x0000000000756dbf uct_test::enum_resources()  test/gtest/uct/uct_test.cc:417
 8 0x00000000005d0fbe gtest_rc_verbsuct_atomic_key_reg_rdma_mem_type_EvalGenerator_()  test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc:43

```