### PR TITLE
Fix spellcheck and bump version to v1.18.1 - v1.18.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)  # Major version. Usually does not change.
 define([ucx_ver_minor], 18) # Minor version. Increased for each release.
-define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
+define([ucx_ver_patch], 1)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))

--- a/src/ucs/datastruct/dynamic_bitmap.h
+++ b/src/ucs/datastruct/dynamic_bitmap.h
@@ -30,7 +30,7 @@ UCS_ARRAY_DECLARE_TYPE(ucs_dynamic_bitmap_t, size_t, ucs_bitmap_word_t);
 
 
 /**
- * Initilaize a dynamic bitmap.
+ * Initialize a dynamic bitmap.
  *
  * @param [out] bitmap   Bitmap to initialize.
  */

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -422,7 +422,7 @@ UCS_TEST_P(test_ucp_wait_mem, envelope) {
     }
     perf_avg /= max_iter;
 
-    /* Run ping-pong with WFE while re-using previous run numbers as
+    /* Run ping-pong with WFE while reusing previous run numbers as
      * a min/max boundary. The latency of the WFE run should stay nearly
      * identical with 200 percent margin. When WFE does not work as expected
      * the slow down is typically 10x-100x */

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -405,6 +405,8 @@ Provides oneAPI Level Zero (ZE) Runtime support for UCX.
 %endif
 
 %changelog
+* Thu Jan 30 2025 Yossi Itigin <yosefe@nvidia.com> 1.18.1-1
+- Bump version to 1.18.1
 * Fri Apr 19 2024 Yossi Itigin <yosefe@nvidia.com> 1.18.0-1
 - Bump version to 1.18.0
 * Tue Oct 31 2023 Yossi Itigin <yosefe@nvidia.com> 1.17.0-1


### PR DESCRIPTION
## Why?
- Bump version since v1.18.0 was released
- Fix spell checks to make CI pass