### PR TITLE
TEST/UCP/MOCK: Improve error message and test tcp, cma, self

### DIFF
--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -165,13 +165,12 @@ static int ucp_proto_debug_is_info_enabled(ucp_context_h context,
     return fnmatch(proto_info_config, select_param_str, FNM_CASEFOLD) == 0;
 }
 
-static void
-ucp_proto_select_elem_info(ucp_worker_h worker,
-                           ucp_worker_cfg_index_t ep_cfg_index,
-                           ucp_worker_cfg_index_t rkey_cfg_index,
-                           const ucp_proto_select_param_t *select_param,
-                           ucp_proto_select_elem_t *select_elem, int show_all,
-                           ucs_string_buffer_t *strb)
+void ucp_proto_select_elem_info(ucp_worker_h worker,
+                                ucp_worker_cfg_index_t ep_cfg_index,
+                                ucp_worker_cfg_index_t rkey_cfg_index,
+                                const ucp_proto_select_param_t *select_param,
+                                const ucp_proto_select_elem_t *select_elem,
+                                int show_all, ucs_string_buffer_t *strb)
 {
     UCS_STRING_BUFFER_ONSTACK(ep_cfg_strb, UCP_PROTO_CONFIG_STR_MAX);
     UCS_STRING_BUFFER_ONSTACK(sel_param_strb, UCP_PROTO_CONFIG_STR_MAX);

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -152,6 +152,14 @@ void ucp_proto_perf_node_replace(ucp_proto_perf_node_t **old_perf_node_p,
                                  ucp_proto_perf_node_t **new_perf_node_p);
 
 
+void ucp_proto_select_elem_info(ucp_worker_h worker,
+                                ucp_worker_cfg_index_t ep_cfg_index,
+                                ucp_worker_cfg_index_t rkey_cfg_index,
+                                const ucp_proto_select_param_t *select_param,
+                                const ucp_proto_select_elem_t *select_elem,
+                                int show_all, ucs_string_buffer_t *strb);
+
+
 void ucp_proto_select_elem_trace(ucp_worker_h worker,
                                  ucp_worker_cfg_index_t ep_cfg_index,
                                  ucp_worker_cfg_index_t rkey_cfg_index,


### PR DESCRIPTION
## Why
- Provide better info message when protocol selection is not as expected
- Extend testing to cma, self, tcp transports

A failure looks like this:
```
[ RUN      ] tcp/test_ucp_proto_mock_tcp.am_send_1_lane/0 <tcp>
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/ucp/test_ucp_proto_mock.cc:357: Failure
Expected equality of these values:
  expected_data
    Which is: 65529..366864 desc: multi-frag zero-copy, config: tcp/mock
  actual_data
    Which is: 65529..366985 desc: multi-frag zero-copy, config: tcp/mock
unexpected difference at range[2]
/hpc/newhome/yosefe/workspace/hpc/ucx/contrib/../test/gtest/ucp/test_ucp_proto_mock.cc:357: Failure
Expected equality of these values:
  expected_data
    Which is: 366865..inf desc: rendezvous zero-copy fenced write to remote, config: tcp/mock
  actual_data
    Which is: 366865..366985 desc: multi-frag zero-copy, config: tcp/mock
unexpected difference at range[3]
[     INFO ] +---------------------------------+------------------------------------------------------------+
[     INFO ] | ucp_context_47 intra-node cfg#0 | active message by ucp_am_send* from host memory            |
[     INFO ] +---------------------------------+-------------------------------------------------+----------+
[     INFO ] |                         0..8184 | short                                           | tcp/mock |
[     INFO ] |                     8185..65528 | zero-copy                                       | tcp/mock |
[     INFO ] |                   65529..366985 | multi-frag zero-copy                            | tcp/mock |
[     INFO ] |                     366986..inf | (?) rendezvous zero-copy fenced write to remote | tcp/mock |
[     INFO ] +---------------------------------+-------------------------------------------------+----------+
[  FAILED  ] tcp/test_ucp_proto_mock_tcp.am_send_1_lane/0, where GetParam() = tcp (272 ms)
```