### PR TITLE
UCP/ADDRESS: cleanup deprecated flags

### DIFF
--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -204,12 +204,11 @@ UCS_ARRAY_DECLARE_TYPE(ucp_address_remote_device_array_t, unsigned,
                                        UCP_ADDRESS_FLAG_LAST))
 
 #define UCP_ADDRESS_FLAG_MD_EMPTY_DEV 0x80u  /* Device without TL addresses */
-#define UCP_ADDRESS_FLAG_MD_ALLOC     0x40u  /* MD can register  */
-#define UCP_ADDRESS_FLAG_MD_REG       0x20u  /* MD can allocate */
-#define UCP_ADDRESS_FLAG_MD_MASK_V1   (UCS_MASK(8) ^ \
-                                        (UCP_ADDRESS_FLAG_MD_EMPTY_DEV | \
-                                         UCP_ADDRESS_FLAG_MD_ALLOC | \
-                                         UCP_ADDRESS_FLAG_MD_REG))
+
+/* MD legacy bits packed to md_index before UCX 1.19
+   (UCP_ADDRESS_FLAG_MD_ALLOC | UCP_ADDRESS_FLAG_MD_REG) */
+#define UCP_ADDRESS_FLAG_MD_INDEX_LEGACY_BITS 0x60u
+
 #define UCP_ADDRESS_FLAG_MD_MASK      (UCS_MASK(8) ^ \
                                        UCP_ADDRESS_FLAG_MD_EMPTY_DEV)
 
@@ -278,7 +277,7 @@ ucp_address_unpack_worker_address_name(const void *src, char *s)
     return UCS_PTR_TYPE_OFFSET(UCS_PTR_BYTE_OFFSET(src, length), uint8_t);
 }
 
-static uint8_t ucp_address_pack_release_version()
+uint8_t ucp_address_pack_release_version()
 {
     return UCP_API_MINOR % UCP_ADDRESS_RELEASE_VERSION_MAX;
 }
@@ -287,7 +286,7 @@ static uint8_t ucp_address_pack_release_version()
  * support wire compatibility for more than 8 versions (therefore we take the
  * value which is closest to our release version)
  */
-static unsigned ucp_address_unpack_release_version(uint8_t packed_version)
+unsigned ucp_address_unpack_release_version(uint8_t packed_version)
 {
     int range = UCP_ADDRESS_RELEASE_VERSION_MAX;
     int delta = ucp_address_pack_release_version() - packed_version;
@@ -471,7 +470,6 @@ ucp_address_packed_size(ucp_worker_h worker,
                         ucp_object_version_t addr_version)
 {
     size_t size = 0;
-    size_t md_mask;
     ssize_t value_size;
     const ucp_address_packed_device_t *dev;
     ucp_md_index_t md_index;
@@ -479,11 +477,9 @@ ucp_address_packed_size(ucp_worker_h worker,
 
     /* header: version and flags */
     if (addr_version == UCP_OBJECT_VERSION_V1) {
-        size   += sizeof(uint8_t);
-        md_mask = UCP_ADDRESS_FLAG_MD_MASK_V1;
+        size += sizeof(uint8_t);
     } else {
-        size   += sizeof(uint16_t);
-        md_mask = UCP_ADDRESS_FLAG_MD_MASK;
+        size += sizeof(uint16_t);
     }
 
     if (pack_flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID) {
@@ -507,7 +503,8 @@ ucp_address_packed_size(ucp_worker_h worker,
             /* device md_index */
             md_index   = rsc->md_index;
             /* md index (+flags) can take 2 bytes with address version 2 */
-            value_size = ucp_address_packed_value_size(md_index, md_mask,
+            value_size = ucp_address_packed_value_size(md_index,
+                                                       UCP_ADDRESS_FLAG_MD_MASK,
                                                        addr_version,
                                                        rsc->tl_rsc.dev_name);
             if (value_size < 0) {
@@ -597,35 +594,18 @@ ucp_address_unpack_byte_extended(const void *ptr, size_t value_mask,
     return (void*)ptr;
 }
 
-static size_t ucp_address_md_mask(ucp_object_version_t addr_version)
-{
-    return (addr_version == UCP_OBJECT_VERSION_V1) ?
-           UCP_ADDRESS_FLAG_MD_MASK_V1 : UCP_ADDRESS_FLAG_MD_MASK;
-}
-
 static void *
-ucp_address_pack_md_info(void *ptr, int is_empty_dev, uint64_t md_flags,
-                         ucp_md_index_t md_index,
+ucp_address_pack_md_info(void *ptr, int is_empty_dev, ucp_md_index_t md_index,
                          ucp_object_version_t addr_version)
 {
     uint8_t *flags_ptr = ptr;
-    size_t mask        = ucp_address_md_mask(addr_version);
 
-    ptr = ucp_address_pack_byte_extended(ptr, md_index, mask, addr_version);
+    ptr = ucp_address_pack_byte_extended(ptr, md_index,
+                                         UCP_ADDRESS_FLAG_MD_MASK,
+                                         addr_version);
 
     if (is_empty_dev) {
         *flags_ptr |= UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
-    }
-
-    if (addr_version == UCP_OBJECT_VERSION_V1) {
-        /* Preserve wire protocol even though these flags are not used */
-        if (md_flags & UCT_MD_FLAG_ALLOC) {
-            *flags_ptr |= UCP_ADDRESS_FLAG_MD_ALLOC;
-        }
-
-        if (md_flags & UCT_MD_FLAG_REG) {
-            *flags_ptr |= UCP_ADDRESS_FLAG_MD_REG;
-        }
     }
 
     return ptr;
@@ -637,12 +617,10 @@ static void *ucp_address_unpack_md_info(const void *ptr,
                                         int *empty_dev)
 {
     uint8_t md_byte = *(uint8_t*)ptr;
-    size_t mask;
 
     *empty_dev = md_byte & UCP_ADDRESS_FLAG_MD_EMPTY_DEV;
-    mask       = ucp_address_md_mask(addr_version);
-
-    return ucp_address_unpack_byte_extended(ptr, mask, addr_version, md_index);
+    return ucp_address_unpack_byte_extended(ptr, UCP_ADDRESS_FLAG_MD_MASK,
+                                            addr_version, md_index);
 }
 
 static uint32_t ucp_address_pack_flags(uint64_t input_flags,
@@ -1219,8 +1197,7 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
                     const ucp_address_packed_device_t *devices,
                     ucp_rsc_index_t num_devices)
 {
-    ucp_context_h context       = worker->context;
-    uint64_t md_flags_pack_mask = (UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC);
+    ucp_context_h context = worker->context;
     const ucp_address_packed_device_t *dev;
     uint8_t *address_header_p;
     uct_iface_attr_t *iface_attr;
@@ -1233,7 +1210,6 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
     ucs_status_t status;
     size_t iface_addr_len;
     size_t ep_addr_len;
-    uint64_t md_flags;
     uint8_t *ep_lane_ptr;
     void *flags_ptr, *dev_flags_ptr;
     unsigned addr_index;
@@ -1290,11 +1266,9 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
 
         /* MD index */
         md_index      = context->tl_rscs[dev->rsc_index].md_index;
-        md_flags      = context->tl_mds[md_index].attr.flags &
-                            md_flags_pack_mask;
         ptr           = ucp_address_pack_md_info(ptr,
                                                  UCS_STATIC_BITMAP_IS_ZERO(dev_tl_bitmap),
-                                                 md_flags, md_index, addr_version);
+                                                 md_index, addr_version);
         dev_flags_ptr = ptr;
         ucs_assert_always((pack_flags & UCP_ADDRESS_PACK_FLAG_DEVICE_ADDR) ||
                           (dev->dev_addr_len == 0));
@@ -1468,7 +1442,7 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
 
             ucp_address_trace(pack_flags,
                               "pack addr[%d] : " UCT_TL_RESOURCE_DESC_FMT
-                              " sysdev %d paths %d eps %u md_flags 0x%" PRIx64
+                              " sysdev %d paths %d eps %u "
                               " tl_flags 0x%" PRIx64 " bw %.2f+%.2f/nMBs"
                               " ovh %.0fns lat_ovh %.0fns dev_priority %d"
                               " a32 0x%" PRIx64 "/0x%" PRIx64 " a64 0x%" PRIx64
@@ -1477,7 +1451,6 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
                               UCT_TL_RESOURCE_DESC_ARG(
                                       &context->tl_rscs[rsc_index].tl_rsc),
                               dev->sys_dev, dev->num_paths, num_ep_addrs,
-                              md_flags,
                               iface_attr->cap.flags & UCP_ADDRESS_IFACE_FLAGS,
                               iface_attr->bandwidth.dedicated / UCS_MBYTE,
                               iface_attr->bandwidth.shared / UCS_MBYTE,
@@ -1512,7 +1485,7 @@ ucp_address_do_pack(ucp_worker_h worker, ucp_ep_h ep, void *buffer, size_t size,
         ucs_assertv(addr_version == UCP_OBJECT_VERSION_V1, "addr_version=%u",
                     addr_version);
         ptr = ucp_address_pack_md_info(
-                ptr, 1, 0, ucp_address_pack_release_version(), addr_version);
+                ptr, 1, ucp_address_pack_release_version(), addr_version);
         /* Mark this device as the last one with 0 length address */
         *ucs_serialize_next(&ptr, uint8_t) = UCP_ADDRESS_FLAG_LAST;
     } else if (num_devices > 0) {
@@ -1651,6 +1624,26 @@ static ucp_rsc_index_t ucp_address_get_remote_device_index(
     device->sys_dev   = sys_dev;
     device->dev_index = dev_index;
     return ucs_array_length(device_array) - 1;
+}
+
+static void
+ucp_address_adjust_unpacked_md_index(ucp_unpacked_address_t *unpacked_address)
+{
+    /* Last version that still packs legacy bits in MD index field */
+    const unsigned max_legacy_api_version = 18u;
+    size_t i;
+
+    if ((unpacked_address->addr_version > UCP_OBJECT_VERSION_V1) ||
+        (unpacked_address->dst_version > max_legacy_api_version)) {
+        return;
+    }
+
+    /* When unpacking address from a legacy version,
+     * need to remove legacy bits */
+    for (i = 0; i < unpacked_address->address_count; ++i) {
+        unpacked_address->address_list[i].md_index &=
+                ~UCP_ADDRESS_FLAG_MD_INDEX_LEGACY_BITS;
+    }
 }
 
 ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
@@ -1877,6 +1870,8 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
     unpacked_address->dst_version   = dst_version;
     unpacked_address->address_count = address - address_list;
     unpacked_address->address_list  = address_list;
+
+    ucp_address_adjust_unpacked_md_index(unpacked_address);
     return UCS_OK;
 
 err_free:

--- a/src/ucp/wireup/address.h
+++ b/src/ucp/wireup/address.h
@@ -294,4 +294,23 @@ uint8_t ucp_address_is_am_only(const void *address);
  */
 size_t ucp_address_iface_seg_size(const uct_iface_attr_t *iface_attr);
 
+/**
+ * @brief Get current API version in packed address format.
+ *
+ * @return Packed release version.
+ */
+uint8_t ucp_address_pack_release_version();
+
+/**
+ * @brief Unpack release version from packed address format.
+ *
+ * Release version is packed into 4 bits. Unpack it assuming that we do not
+ * support wire compatibility for more than 8 versions (therefore we take the
+ * value which is closest to our release version).
+ *
+ * @param [in] packed_version Packed release version.
+ * @return Unpacked release version.
+ */
+unsigned ucp_address_unpack_release_version(uint8_t packed_version);
+
 #endif

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -12,6 +12,7 @@ extern "C" {
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_worker.inl>
 #include <ucp/core/ucp_request.h>
+#include <ucp/wireup/address.h>
 #include <ucp/wireup/wireup_ep.h>
 #include <uct/base/uct_iface.h>
 }
@@ -802,6 +803,25 @@ UCS_TEST_P(test_ucp_worker_address_query, query)
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_worker_address_query)
+
+class test_ucp_worker_address_version : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant_with_value(variants, UCP_FEATURE_AM, 0, "");
+    }
+};
+
+UCS_TEST_P(test_ucp_worker_address_version, pack_unpack)
+{
+    uint8_t  current_packed   = ucp_address_pack_release_version();
+    unsigned current_unpacked = ucp_address_unpack_release_version(current_packed);
+
+    ASSERT_EQ(UCP_API_MINOR, current_unpacked);
+    ASSERT_LT(18, current_unpacked);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_address_version, self, "self")
 
 class test_ucp_modify_uct_cfg : public test_ucp_context {
 public:


### PR DESCRIPTION
## What?
cleanup deprecated flags in UCP address

## Why?
to inclrease number of supported MDs
