### PR TITLE
 TOOLS/INFO: Optional name filter for config dump

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Bin Lei <binl@mellanox.com>
 Boris Karasev <boriska@nvidia.com>
 Brad Benton <bradford.benton@gmail.com>
 Changcheng Liu <jerrliu@nvidia.com>
+Colin Hirsch <chirsch@nvidia.com>
 Corey J. Nolet <cjnolet@gmail.com>
 David Wootton <dwootton@us.ibm.com>
 Devendar Bureddy <devendar@mellanox.com>
@@ -113,9 +114,9 @@ Christophe Harle
 Christopher Lamb
 Craig Stunkel
 Cydney Ewald Stevens
-Davide Rossetti 
+Davide Rossetti
 Donald Becker
-Duncan Poole 
+Duncan Poole
 Edgar A. Leon
 Eric Van Hensbergen
 Geoffrey Blake
@@ -129,7 +130,7 @@ Liran Liss
 Nathaniel Graham
 Oscar Hernandez
 Pavan Balaji
-Richard Graham 
+Richard Graham
 Ron Brightwell
 Sameer Kumar
 Sameh Sharkawi

--- a/src/tools/info/ucx_info.c
+++ b/src/tools/info/ucx_info.c
@@ -58,6 +58,8 @@ static void usage()
     printf("  -s                   Show system information\n");
     printf("  -c                   Show UCX configuration\n");
     printf("  -C                   Comment-out default configuration values\n");
+    printf("  -F <string>          Only show configuration values whose name "
+           "contains 'string'\n");
     printf("  -a                   Show also hidden configuration\n");
     printf("  -f                   Display fully decorated output\n");
     printf("\nUCP information (-u is required):\n");
@@ -122,6 +124,7 @@ int main(int argc, char **argv)
     size_t ucp_num_ppn;
     unsigned print_opts;
     char *tl_name, *mem_spec;
+    const char *cfg_filter;
     const char *f;
     int c;
 
@@ -132,12 +135,14 @@ int main(int argc, char **argv)
     ucp_num_eps              = 1;
     ucp_num_ppn              = 1;
     mem_spec                 = NULL;
+    cfg_filter               = NULL;
     dev_type_bitmap          = UINT_MAX;
     proc_placement           = PROCESS_PLACEMENT_SELF;
     ucp_ep_params.field_mask = 0;
     ip_addr_family           = AF_INET;
 
-    while ((c = getopt(argc, argv, "fahvc6ydbswpeCt:n:u:D:P:m:N:A:TM")) != -1) {
+    while ((c = getopt(argc, argv, "fahvc6ydbswpeCF:t:n:u:D:P:m:N:A:TM")) !=
+           -1) {
         switch (c) {
         case 'f':
             print_flags |= UCS_CONFIG_PRINT_CONFIG | UCS_CONFIG_PRINT_HEADER | UCS_CONFIG_PRINT_DOC;
@@ -150,6 +155,9 @@ int main(int argc, char **argv)
             break;
         case 'C':
             print_flags |= UCS_CONFIG_PRINT_COMMENT_DEFAULT;
+            break;
+        case 'F':
+            cfg_filter = optarg;
             break;
         case 'v':
             print_opts |= PRINT_VERSION;
@@ -304,7 +312,8 @@ int main(int argc, char **argv)
 
     if (print_flags & UCS_CONFIG_PRINT_CONFIG) {
         ucs_config_parser_print_all_opts(stdout, UCS_DEFAULT_ENV_PREFIX,
-                                         print_flags, &ucs_config_global_list);
+                                         print_flags, &ucs_config_global_list,
+                                         cfg_filter);
     }
 
     if (print_opts & (PRINT_UCP_CONTEXT|PRINT_UCP_WORKER|PRINT_UCP_EP|PRINT_MEM_MAP)) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -861,8 +861,8 @@ void ucp_config_print_cached_uct(const ucp_config_t *config, FILE *stream,
 void ucp_config_print(const ucp_config_t *config, FILE *stream,
                       const char *title, ucs_config_print_flags_t print_flags)
 {
-    ucs_config_parser_print_opts(stream, title, config, ucp_config_table,
-                                 NULL, UCS_DEFAULT_ENV_PREFIX, print_flags);
+    ucs_config_parser_print_opts(stream, title, config, ucp_config_table, NULL,
+                                 UCS_DEFAULT_ENV_PREFIX, print_flags, NULL);
     ucp_config_print_cached_uct(config, stream, title, print_flags);
 }
 

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -413,12 +413,12 @@ void ucs_global_opts_print(FILE *stream, ucs_config_print_flags_t print_flags)
 {
     ucs_config_parser_print_opts(stream, "Global configuration",
                                  &ucs_global_opts, ucs_global_opts_table, NULL,
-                                 UCS_DEFAULT_ENV_PREFIX, print_flags);
+                                 UCS_DEFAULT_ENV_PREFIX, print_flags, NULL);
     ucs_config_parser_print_opts(stream,
                                  "Global configuration (runtime read-only)",
                                  &ucs_global_opts,
                                  ucs_global_opts_read_only_table, NULL,
-                                 UCS_DEFAULT_ENV_PREFIX, print_flags);
+                                 UCS_DEFAULT_ENV_PREFIX, print_flags, NULL);
 }
 
 static void ucs_vfs_read_log_level(void *obj, ucs_string_buffer_t *strb,

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -550,10 +550,13 @@ void ucs_config_parser_release_opts(void *opts, ucs_config_field_t *fields);
  * @param table_prefix   Optional prefix to add to the variables of top-level table.
  * @param prefix         Prefix to add to all environment variables.
  * @param flags          Flags which control the output.
+ * @param filter         Filter output with substring match, if not NULL.
  */
-void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *opts,
-                                  ucs_config_field_t *fields, const char *table_prefix,
-                                  const char *prefix, ucs_config_print_flags_t flags);
+void ucs_config_parser_print_opts(FILE *stream, const char *title,
+                                  const void *opts, ucs_config_field_t *fields,
+                                  const char *table_prefix, const char *prefix,
+                                  ucs_config_print_flags_t flags,
+                                  const char *filter);
 
 /**
  * Print all options defined in the library - names, values, documentation.
@@ -561,11 +564,13 @@ void ucs_config_parser_print_opts(FILE *stream, const char *title, const void *o
  * @param stream         Output stream to print to.
  * @param prefix         Prefix to add to all environment variables.
  * @param flags          Flags which control the output.
- * @param config_list    List of config tables
+ * @param config_list    List of config tables.
+ * @param filter         Filter output with substring match, if not NULL.
  */
 void ucs_config_parser_print_all_opts(FILE *stream, const char *prefix,
                                       ucs_config_print_flags_t flags,
-                                      ucs_list_link_t *config_list);
+                                      ucs_list_link_t *config_list,
+                                      const char *filter);
 
 /**
  * Read a value from options structure.

--- a/test/apps/test_ucp_config.c
+++ b/test/apps/test_ucp_config.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
     ucp_context_print_info(context, stdout);
     ucs_config_parser_print_all_opts(stdout, UCS_DEFAULT_ENV_PREFIX,
                                      UCS_CONFIG_PRINT_CONFIG,
-                                     &ucs_config_global_list);
+                                     &ucs_config_global_list, NULL);
     ucp_worker_destroy(worker);
     ret = 0;
 


### PR DESCRIPTION
## What?
Add optional filters for `ucx_info -c` and `ucx_info -f` to select which config parameters are printed.

~~All additional command line arguments to `ucx_info -c` and `ucx_info -f` are used as disjunctive substring filter, e.g. `ucx_info -c TCP LOG` will only print config parameters that contain `TCP` and/or `LOG`.~~

When `-F string` is passed in addition to `-c` and/or `-f` then only config parameters whose name contains `string` are printed.