### PR TITLE
AZP: Cleanup workspace for perf tests

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -89,6 +89,8 @@ stages:
       - job: Perf
         displayName: Performance testing
         timeoutInMinutes: 180
+        workspace:
+          clean: outputs
         pool:
           name: MLNX
           demands:


### PR DESCRIPTION
## What?
Add auto-cleanup of working directories for the UCX performance tests pipeline.

## Why?
Large log files collected under the working directory have been found to contribute to disk space exhaustion.

