### PR TITLE
UCP/PROTO: Handle request status correctly and refactor

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -136,18 +136,16 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_bcopy_send_func(
                                       ucp_am_eager_multi_bcopy_pack_args_first,
                                       &pack_ctx, 0);
         status      = ucp_proto_bcopy_send_func_status(packed_size);
-        status      = ucp_proto_am_handle_user_header_send_status(req, status);
-    } else {
-        pack_ctx.max_payload = ucp_proto_multi_max_payload(
-                req, lpriv, UCP_AM_MID_FRAG_META_LEN);
-
-        packed_size = uct_ep_am_bcopy(uct_ep, UCP_AM_ID_AM_MIDDLE,
-                                      ucp_am_eager_multi_bcopy_pack_args_mid,
-                                      &pack_ctx, 0);
-        status      = ucp_proto_bcopy_send_func_status(packed_size);
+        return ucp_am_handle_user_header_send_status_or_release(req, status);
     }
 
-    return status;
+    pack_ctx.max_payload =
+            ucp_proto_multi_max_payload(req, lpriv, UCP_AM_MID_FRAG_META_LEN);
+
+    packed_size = uct_ep_am_bcopy(uct_ep, UCP_AM_ID_AM_MIDDLE,
+                                  ucp_am_eager_multi_bcopy_pack_args_mid,
+                                  &pack_ctx, 0);
+    return ucp_proto_bcopy_send_func_status(packed_size);
 }
 
 static ucs_status_t

--- a/src/ucp/am/eager_single.c
+++ b/src/ucp/am/eager_single.c
@@ -72,10 +72,10 @@ ucp_am_eager_short_proto_progress_common(uct_pending_req_t *self, int is_reply)
     status = uct_ep_am_short_iov(ucp_ep_get_fast_lane(req->send.ep,
                                                       spriv->super.lane),
                                  am_id, iov, iov_cnt);
-    status = ucp_proto_am_handle_user_header_send_status(req, status);
     if (ucs_unlikely(status == UCS_ERR_NO_RESOURCE)) {
         req->send.lane = spriv->super.lane; /* for pending add */
-        return status;
+        return ucp_am_handle_user_header_send_status_or_abort(
+                req, UCS_ERR_NO_RESOURCE);
     }
 
     ucp_am_release_user_header(req);
@@ -215,7 +215,7 @@ ucp_am_eager_single_bcopy_proto_progress(uct_pending_req_t *self)
             req, UCP_AM_ID_AM_SINGLE, spriv->super.lane,
             ucp_am_eager_single_bcopy_pack, req, SIZE_MAX,
             ucp_proto_request_am_bcopy_complete_success, 1);
-    return ucp_proto_am_handle_user_header_send_status(req, status);
+    return ucp_am_handle_user_header_send_status_or_abort(req, status);
 }
 
 static void ucp_am_eager_single_bcopy_probe_common(
@@ -294,7 +294,7 @@ ucp_am_eager_single_bcopy_reply_proto_progress(uct_pending_req_t *self)
             req, UCP_AM_ID_AM_SINGLE_REPLY, spriv->super.lane,
             ucp_am_eager_single_bcopy_reply_pack, req, SIZE_MAX,
             ucp_proto_request_am_bcopy_complete_success, 1);
-    return ucp_proto_am_handle_user_header_send_status(req, status);
+    return ucp_am_handle_user_header_send_status_or_abort(req, status);
 }
 
 ucp_proto_t ucp_am_eager_single_bcopy_reply_proto = {

--- a/src/ucp/am/rndv.c
+++ b/src/ucp/am/rndv.c
@@ -56,7 +56,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_rndv_proto_progress, (self),
                               UCP_AM_ID_RNDV_RTS, rpriv->lane,
                               ucp_am_rndv_rts_pack, req, max_rts_size,
                               ucp_am_rndv_rts_complete, 0);
-    return ucp_proto_am_handle_user_header_send_status(req, status);
+    return ucp_am_handle_user_header_send_status_or_abort(req, status);
 }
 
 static void ucp_am_rndv_rts_probe(const ucp_proto_init_params_t *init_params)

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -526,7 +526,7 @@ static ucs_status_t ucp_am_contig_short(uct_pending_req_t *self)
                                        req->send.msg_proto.am.header.ptr,
                                        req->send.msg_proto.am.header.length,
                                        req->send.buffer, req->send.length, 0);
-    status         = ucp_am_handle_user_header_send_status(req, status);
+    status = ucp_am_handle_user_header_send_status_or_release(req, status);
     return ucp_am_short_handle_status_from_pending(req, status);
 }
 
@@ -542,7 +542,7 @@ static ucs_status_t ucp_am_contig_short_reply(uct_pending_req_t *self)
                                        req->send.msg_proto.am.header.ptr,
                                        req->send.msg_proto.am.header.length,
                                        req->send.buffer, req->send.length, 1);
-    status         = ucp_am_handle_user_header_send_status(req, status);
+    status = ucp_am_handle_user_header_send_status_or_release(req, status);
     return ucp_am_short_handle_status_from_pending(req, status);
 }
 
@@ -553,7 +553,7 @@ static ucs_status_t ucp_am_bcopy_single(uct_pending_req_t *self)
 
     status = ucp_do_am_bcopy_single(self, UCP_AM_ID_AM_SINGLE,
                                     ucp_am_bcopy_pack_args_single);
-    status = ucp_am_handle_user_header_send_status(req, status);
+    status = ucp_am_handle_user_header_send_status_or_release(req, status);
     return ucp_am_bcopy_handle_status_from_pending(self, 0, 0, status);
 }
 
@@ -564,7 +564,7 @@ static ucs_status_t ucp_am_bcopy_single_reply(uct_pending_req_t *self)
 
     status = ucp_do_am_bcopy_single(self, UCP_AM_ID_AM_SINGLE_REPLY,
                                     ucp_am_bcopy_pack_args_single_reply);
-    status = ucp_am_handle_user_header_send_status(req, status);
+    status = ucp_am_handle_user_header_send_status_or_release(req, status);
     return ucp_am_bcopy_handle_status_from_pending(self, 0, 0, status);
 }
 
@@ -722,7 +722,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_progress_am_rndv_rts, (self),
     status = ucp_rndv_send_rts(sreq, ucp_am_rndv_rts_pack,
                                sizeof(ucp_rndv_rts_hdr_t) +
                                        sreq->send.msg_proto.am.header.length);
-    status = ucp_am_handle_user_header_send_status(sreq, status);
+    status = ucp_am_handle_user_header_send_status_or_release(sreq, status);
     return ucp_rndv_send_handle_status_from_pending(sreq, status);
 }
 

--- a/src/ucp/proto/proto_am.c
+++ b/src/ucp/proto/proto_am.c
@@ -114,28 +114,3 @@ void ucp_proto_am_zcopy_completion(uct_completion_t *self)
 
     ucp_proto_am_zcopy_req_complete(req, self->status);
 }
-
-ucs_status_t ucp_proto_am_req_copy_header(ucp_request_t *req)
-{
-    void *user_header;
-
-    if ((req->flags & UCP_REQUEST_FLAG_USER_HEADER_COPIED) ||
-        (req->send.msg_proto.am.header.length == 0)) {
-        return UCS_OK;
-    }
-
-    ucs_assert(req->send.msg_proto.am.flags & UCP_AM_SEND_FLAG_COPY_HEADER);
-    user_header = ucs_mpool_set_get_inline(&req->send.ep->worker->am_mps,
-                                           req->send.msg_proto.am.header.length);
-    if (ucs_unlikely(user_header == NULL)) {
-        ucs_error("failed to allocate active message user header copy");
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    memcpy(user_header, req->send.msg_proto.am.header.ptr,
-           req->send.msg_proto.am.header.length);
-    req->flags                       |= UCP_REQUEST_FLAG_USER_HEADER_COPIED;
-    req->send.msg_proto.am.header.ptr = user_header;
-
-    return UCS_OK;
-}

--- a/src/ucp/proto/proto_am.h
+++ b/src/ucp/proto/proto_am.h
@@ -48,6 +48,4 @@ void ucp_proto_am_zcopy_completion(uct_completion_t *self);
 
 void ucp_proto_am_zcopy_req_complete(ucp_request_t *req, ucs_status_t status);
 
-ucs_status_t ucp_proto_am_req_copy_header(ucp_request_t *req);
-
 #endif

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -63,8 +63,7 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
         return UCS_OK;
     }
 
-    if (ucp_proto_config_is_am(req->send.proto_config) &&
-        (req->send.msg_proto.am.flags & UCP_AM_SEND_FLAG_COPY_HEADER)) {
+    if (ucp_proto_config_is_am(req->send.proto_config)) {
         status = ucp_proto_am_req_copy_header(req);
         if (status != UCS_OK) {
             ucp_proto_request_abort(req, status);


### PR DESCRIPTION
## What?
- Handle request progress status properly. 
- Refactor Code.

## Why?
In some flows of send operations we can reach `ucs_fatal` because status is not handled properly. 

## How?
Instead of returning unexpected status code we should abort operation and return `UCS_OK`
