### PR TITLE
TEST/GTEST/UCT: Increase retries and add random sleep when MEMIC allocation fails

### DIFF
--- a/test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc
+++ b/test/gtest/uct/test_atomic_key_reg_rdma_mem_type.cc
@@ -31,7 +31,7 @@ UCS_TEST_SKIP_COND_P(uct_atomic_key_reg_rdma_mem_type, fadd64,
                      !check_rdma_memory())
 {
     mapped_buffer recvbuf(sizeof(uint64_t), receiver(), 0UL,
-                          UCS_MEMORY_TYPE_RDMA, UCT_MD_MEM_ACCESS_ALL, 5);
+                          UCS_MEMORY_TYPE_RDMA, UCT_MD_MEM_ACCESS_ALL, 10);
     uint64_t add = rand64();
 
     run_workers(static_cast<send_func_t>(

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -984,7 +984,7 @@ void uct_test::entity::mem_alloc(size_t length, unsigned mem_flags,
                              << ": Allocation failed - "
                              << ucs_status_string(status);
             /* Sleep only if there are more retries remaining */
-            usleep(10000);
+            usleep(ucs::rand() % 10000);
         }
     }
 


### PR DESCRIPTION
## What?
Following https://github.com/openucx/ucx/pull/10393, add another fix to the sporadic failure of `uct_atomic_key_reg_rdma_mem_type` test.

## Why?
It still fails once in a while:
![image](https://github.com/user-attachments/assets/ed9934f0-f889-48fa-a1ac-3524677178e5)

## How?
Increase the number of retries from 5 to 10 and make add random sleep between retries.
