### PR TITLE
UCT/MLX5: Initialize DP fields before creating command QP

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1632,18 +1632,18 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     init_attr.cq_len[UCT_IB_DIR_TX] = sq_length * self->tx.ndci;
 
-    /* TODO check caps instead */
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_dc_mlx5_iface_tl_ops, &uct_dc_mlx5_iface_ops,
-                              tl_md, worker, params, &config->super,
-                              &config->rc_mlx5_common, &init_attr);
-
-    status = uct_rc_mlx5_dp_ordering_ooo_init(&self->super,
+    status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
                                               md->dp_ordering_cap.dc,
                                               &config->rc_mlx5_common, "dc");
     if (status != UCS_OK) {
         return status;
     }
+
+    /* TODO check caps instead */
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
+                              &uct_dc_mlx5_iface_tl_ops, &uct_dc_mlx5_iface_ops,
+                              tl_md, worker, params, &config->super,
+                              &config->rc_mlx5_common, &init_attr);
 
     tx_cq_size = uct_ib_cq_size(&self->super.super.super, &init_attr,
                                 UCT_IB_DIR_TX);

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -772,19 +772,19 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
                                                    max_qp_rd_atom);
     init_attr.tx_moderation         = config->super.tx_cq_moderation;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_gga_mlx5_iface_tl_ops,
-                              &uct_gga_mlx5_iface_ops, tl_md, worker, params,
-                              &config->super.super, &config->rc_mlx5_common,
-                              &init_attr);
-
     status = uct_rc_mlx5_dp_ordering_ooo_init(
-            &self->super,
+            md, &self->super,
             ucs_min(md->dp_ordering_cap.rc, UCT_IB_MLX5_DP_ORDERING_OOO_RW),
             &config->rc_mlx5_common, "gga");
     if (status != UCS_OK) {
         return status;
     }
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
+                              &uct_gga_mlx5_iface_tl_ops,
+                              &uct_gga_mlx5_iface_ops, tl_md, worker, params,
+                              &config->super.super, &config->rc_mlx5_common,
+                              &init_attr);
 
     uct_gga_mlx5_iface_disable_rx(&self->super);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -600,13 +600,14 @@ void uct_rc_mlx5_release_desc(uct_recv_desc_t *self, void *desc)
     ucs_mpool_put_inline(ib_desc);
 }
 
+/* TODO do not pass iface, but only pass return value to config */
 ucs_status_t
-uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
+uct_rc_mlx5_dp_ordering_ooo_init(uct_ib_mlx5_md_t *md,
+                                 uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name)
 {
-    uct_ib_mlx5_md_t *md      = uct_ib_mlx5_iface_md(&iface->super.super);
     uct_ib_mlx5_dp_ordering_t min_forced_ordering;
 
     /*

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -481,7 +481,8 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_iface_ops_t*,
 
 
 ucs_status_t
-uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
+uct_rc_mlx5_dp_ordering_ooo_init(uct_ib_mlx5_md_t *md,
+                                 uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -929,18 +929,18 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
         init_attr.flags |= UCT_IB_DDP_SUPPORTED;
     }
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_rc_mlx5_iface_tl_ops, &uct_rc_mlx5_iface_ops,
-                              tl_md, worker, params, &config->super.super,
-                              &config->rc_mlx5_common, &init_attr);
-
-    status = uct_rc_mlx5_dp_ordering_ooo_init(&self->super,
+    status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
                                               md->dp_ordering_cap.rc,
                                               &config->rc_mlx5_common,
                                               "rc_mlx5");
     if (status != UCS_OK) {
         return status;
     }
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
+                              &uct_rc_mlx5_iface_tl_ops, &uct_rc_mlx5_iface_ops,
+                              tl_md, worker, params, &config->super.super,
+                              &config->rc_mlx5_common, &init_attr);
 
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);
     if (status != UCS_OK) {


### PR DESCRIPTION
## Why
Fix https://redmine.mellanox.com/issues/4246892

```
[ RUN      ] rcx/test_ucp_tag_match.send2_nb_recv_medium_wildcard/1 <rc_x/req_ext>
[1736352962.257227] [nemo03:678154:0]      ib_mlx5_dv.c:407  UCX  ERROR mlx5dv_devx_obj_modify(opcode=0x503) failed, syndrome 0x823f8d: Remote I/O error
```