### PR TITLE
AZP/RELEASE: Add Ubuntu 24.04 to UCX build and release pipelines - v1.18

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -34,6 +34,9 @@ jobs:
         ubuntu22_cuda12_${{ parameters.arch }}:
           build_container: ubuntu22_cuda12_${{ parameters.arch }}
           artifact_name: $(POSTFIX)-ubuntu22.04-mofed5-cuda12-${{ parameters.arch }}.tar.bz2
+        ubuntu24_cuda12_${{ parameters.arch }}:
+          build_container: ubuntu24_cuda12_${{ parameters.arch }}
+          artifact_name: $(POSTFIX)-ubuntu24.04-mofed5-cuda12-${{ parameters.arch }}.tar.bz2
         # x86 only
         ${{ if eq(parameters.arch, 'x86_64') }}:
           centos7_cuda11_${{ parameters.arch }}:

--- a/buildlib/azure-pipelines-release-drp.yml
+++ b/buildlib/azure-pipelines-release-drp.yml
@@ -42,8 +42,8 @@ resources:
       image: $(REPO_MIRROR)/ucx/x86_64/ubuntu18.04-mofed5-cuda12:3
     - container: ubuntu20_cuda12_x86_64
       image: $(REPO_MIRROR)/ucx/x86_64/ubuntu20.04-mofed5-cuda12:3
-    - container: ubuntu22_cuda12_x86_64
-      image: $(REPO_MIRROR)/ucx/x86_64/ubuntu22.04-mofed5-cuda12:3
+    - container: ubuntu24_cuda12_x86_64
+      image: $(REPO_MIRROR)/ucx/x86_64/ubuntu24.04-mofed24.10-cuda12.5:1
 
     # aarch64
     - container: centos8_cuda11_aarch64
@@ -59,6 +59,8 @@ resources:
       image: $(REPO_MIRROR)/ucx/aarch64/ubuntu20.04-mofed5-cuda12:3
     - container: ubuntu22_cuda12_aarch64
       image: $(REPO_MIRROR)/ucx/aarch64/ubuntu22.04-mofed5-cuda12:3
+    - container: ubuntu24_cuda12_aarch64
+      image: $(REPO_MIRROR)/ucx/aarch64/ubuntu24.04-mofed24.10-cuda12.5:1
 
 stages:
   - stage: Prepare

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -38,6 +38,8 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu20.04-mofed5-cuda12:3
     - container: ubuntu22_cuda12_x86_64
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda12:3
+    - container: ubuntu24_cuda12_x86_64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu24.04-mofed24.10-cuda12.5:1
 
     # aarch64
     - container: centos8_cuda11_aarch64
@@ -53,6 +55,8 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu20.04-mofed5-cuda12:3
     - container: ubuntu22_cuda12_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu22.04-mofed5-cuda12:3
+    - container: ubuntu24_cuda12_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu24.04-mofed24.10-cuda12.5:1
 
 stages:
   - stage: Prepare

--- a/buildlib/dockers/docker-compose-aarch64.yml
+++ b/buildlib/dockers/docker-compose-aarch64.yml
@@ -81,3 +81,15 @@ services:
         CUDA_VERSION: 12.0.0
         NV_DRIVER_VERSION: 525
         ARCH: aarch64
+  ubuntu24.04-mofed5-cuda12:
+    image: ubuntu24.04-mofed24.10-cuda12.5:1
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 24.10-1.1.4.0
+        UBUNTU_VERSION: 24.04
+        CUDA_VERSION: 12.5.1
+        NV_DRIVER_VERSION: 555
+        ARCH: aarch64

--- a/buildlib/dockers/docker-compose-x86_64.yml
+++ b/buildlib/dockers/docker-compose-x86_64.yml
@@ -117,3 +117,15 @@ services:
         CUDA_VERSION: 12.0.0
         NV_DRIVER_VERSION: 525
         ARCH: x86_64
+  ubuntu24.04-mofed5-cuda12:
+    image: ubuntu24.04-mofed24.10-cuda12.5:1
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 24.10-1.1.4.0
+        UBUNTU_VERSION: 24.04
+        CUDA_VERSION: 12.5.1
+        NV_DRIVER_VERSION: 555
+        ARCH: x86_64

--- a/buildlib/dockers/ubuntu-release.Dockerfile
+++ b/buildlib/dockers/ubuntu-release.Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
         automake \
         default-jdk \
         dh-make \
+        fakeroot \
         g++ \
         git \
         openjdk-8-jdk \

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -57,6 +57,9 @@ resources:
     - container: ubuntu1804
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu18.04/builder:mofed-5.0-1.0.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2404
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
@@ -220,6 +223,8 @@ stages:
               extra_modules: ""
             ubuntu2204:
               CONTAINER: ubuntu2204
+            ubuntu2404:
+              CONTAINER: ubuntu2404
             ubuntu2210:
               CONTAINER: ubuntu2210
             debian113:


### PR DESCRIPTION
## What?
Cherry-pick from https://github.com/openucx/ucx/pull/10480/.