### PR TITLE
UCP/PROTO: Disable protocols that need memory type copy

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -360,6 +360,10 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, rndv_frag_mem_types),
    UCS_CONFIG_TYPE_BITMAP(ucs_memory_type_names)},
 
+  {"MEMTYPE_COPY_ENABLE", "y",
+   "Allows memory type copies. This option influences protocol selection.\n",
+   ucs_offsetof(ucp_context_config_t, memtype_copy_enable), UCS_CONFIG_TYPE_BOOL},
+
   {"RNDV_PIPELINE_SEND_THRESH", "inf",
    "RNDV size threshold to enable sender side pipeline for mem type",
    ucs_offsetof(ucp_context_config_t, rndv_pipeline_send_thresh), UCS_CONFIG_TYPE_MEMUNITS},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -90,6 +90,8 @@ typedef struct ucp_context_config {
     size_t                                 rndv_num_frags[UCS_MEMORY_TYPE_LAST];
     /** Memory types of fragments used for RNDV pipeline protocol */
     uint64_t                               rndv_frag_mem_types;
+    /** Allows memtype copies that use bounce buffers, when set to true */
+    int                                    memtype_copy_enable;
     /** RNDV pipeline send threshold */
     size_t                                 rndv_pipeline_send_thresh;
     /** Enabling 2-stage pipeline rndv protocol */

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -563,6 +563,23 @@ err_cleanup_perf:
     return status;
 }
 
+int ucp_proto_common_check_memtype_copy(
+    const ucp_proto_common_init_params_t *params)
+{
+    if (params->super.worker->context->config.ext.memtype_copy_enable) {
+        return 1;
+    }
+
+    if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_HDR_ONLY) {
+        return 1;
+    }
+
+    return ucs_test_flags(params->flags,
+                          UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY,
+                          UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY) &&
+           (params->flags & UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS);
+}
+
 int ucp_proto_init_check_op(const ucp_proto_init_params_t *init_params,
                             uint64_t op_id_mask)
 {

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -85,4 +85,7 @@ ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
 int ucp_proto_init_check_op(const ucp_proto_init_params_t *init_params,
                             uint64_t op_id_mask);
 
+int ucp_proto_common_check_memtype_copy(
+    const ucp_proto_common_init_params_t *params);
+
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -54,6 +54,10 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         return UCS_ERR_UNSUPPORTED;
     }
 
+    if (!ucp_proto_common_check_memtype_copy(&params->super)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     /* Find first lane */
     num_lanes = ucp_proto_common_find_lanes_with_min_frag(
             &params->super, params->first.lane_type, params->first.tl_cap_flags,

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -31,6 +31,10 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
     ucp_lane_index_t lane;
     ucs_status_t status;
 
+    if (!ucp_proto_common_check_memtype_copy(&params->super)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     num_lanes = ucp_proto_common_find_lanes_with_min_frag(
             &params->super, params->lane_type, params->tl_cap_flags, 1,
             params->super.exclude_map, &lane);

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -34,6 +34,7 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
 
     if ((init_params->select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         (ucp_proto_rndv_mtype_ep(worker, frag_mem_type, mem_type) == NULL) ||
+        !init_params->worker->context->config.ext.memtype_copy_enable ||
         !ucp_proto_init_check_op(init_params, UCP_PROTO_RNDV_OP_ID_MASK)) {
         return UCS_ERR_UNSUPPORTED;
     }

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -77,7 +77,8 @@ ucp_proto_rndv_ppln_probe(const ucp_proto_init_params_t *init_params)
     if ((select_param->dt_class != UCP_DATATYPE_CONTIG) ||
         !ucp_proto_init_check_op(init_params, UCP_PROTO_RNDV_OP_ID_MASK) ||
         !ucp_proto_common_init_check_err_handling(&ack_params) ||
-        ucp_proto_rndv_init_params_is_ppln_frag(init_params)) {
+        ucp_proto_rndv_init_params_is_ppln_frag(init_params) ||
+        !ucp_proto_common_check_memtype_copy(&ack_params)) {
         return;
     }
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -499,6 +499,15 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             continue;
         }
 
+        if (!context->config.ext.memtype_copy_enable &&
+            (md_attr->flags & UCT_MD_FLAG_MEMTYPE_COPY) &&
+            (md_attr->access_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+            ucs_trace(UCT_TL_RESOURCE_DESC_FMT
+                      " : disabled to avoid memory type copies",
+                      UCT_TL_RESOURCE_DESC_ARG(resource));
+            continue;
+        }
+
         has_cm = ucp_ep_init_flags_has_cm(select_params->ep_init_flags);
         if (select_params->ep_init_flags & UCP_EP_INIT_CONNECT_TO_IFACE_ONLY) {
             local_iface_flags.mandatory |= UCT_IFACE_FLAG_CONNECT_TO_IFACE;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -969,7 +969,12 @@ typedef enum {
      * packed key by @ref uct_md_mkey_pack_v2 with
      * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE_AMO flag.
      */
-    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12)
+    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12),
+
+    /**
+     * Memory domain performs memory type related copy operations.
+     */
+    UCT_MD_FLAG_MEMTYPE_COPY   = UCS_BIT(13)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -96,7 +96,8 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
                                 UCT_MD_FLAG_NEED_RKEY |
                                 UCT_MD_FLAG_INVALIDATE |
                                 UCT_MD_FLAG_INVALIDATE_RMA |
-                                UCT_MD_FLAG_INVALIDATE_AMO;
+                                UCT_MD_FLAG_INVALIDATE_AMO |
+                                UCT_MD_FLAG_MEMTYPE_COPY;
     md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -499,6 +499,23 @@ public:
     }
 };
 
+UCS_TEST_P(test_ucp_proto_mock_rcx, memtype_copy_enable,
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1",
+           "MEMTYPE_COPY_ENABLE=n")
+{
+    ucp_proto_select_key_t key = any_key();
+    key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
+    key.param.op_attr          = 0;
+
+    check_ep_config(sender(), {
+        {0,       0, "rendezvous no data fetch", ""},
+        {1,      64, "rendezvous zero-copy fenced write to remote",
+                     "rc_mlx5/mock_0:1"},
+        {21992, INF, "rendezvous zero-copy read from remote",
+                     "rc_mlx5/mock_0:1"},
+    }, key);
+}
+
 UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_1_lane, "IB_NUM_PATHS?=1",
            "MAX_RNDV_LANES=1")
 {


### PR DESCRIPTION
## What?
Make sure to disable any protocol using locally or remotely, a memory type based copy.

## Why?
Need to avoid all cuda calls from under `ucp_worker_progress()`. Cuda memory queries are fine since they are performed under send/recv operations. `cuda_ipc` transport can be disabled altogether, and `gdr_copy` is anyways not of interest when specifying `UCX_MEMTYPE_AVOID_COPY=y`.

## How?
Disable applicable protocols altogether, for any memory type (cuda/host..).

### Test
Might need to make inline sizes to 0, see below otherwise.

```
UCX_IB_TX_INLINE_RESP=0 UCX_MEMTYPE_AVOID_COPY=y ucx_perftest
UCX_IB_TX_INLINE_RESP=0 UCX_MEMTYPE_AVOID_COPY=y ucx_perftest -t ucp_put_bw -m cuda,cuda rock
```

Used by perftest to exchange `psn_t sn`:
```
  | perftest self cfg#2 | remote memory read by ucp_get* into host memory from cuda    |
  +---------------------+-------------------------------------+------------------------+
  |             65..inf | zero-copy                           | rc_mlx5/mlx5_2:1/path0 |
```