### PR TITLE
UCT/CUDA/BASE: Print error if cuInit fails.

### DIFF
--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -103,8 +103,7 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
 
 UCS_STATIC_INIT
 {
-    /* coverity[check_return] */
-    cuInit(0);
+    UCT_CUDADRV_FUNC_LOG_ERR(cuInit(0));
 }
 
 UCS_STATIC_CLEANUP

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -41,7 +41,6 @@ static uct_cuda_ipc_dev_cache_t *uct_cuda_ipc_create_dev_cache(int dev_num)
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&num_devices));
     if (UCS_OK != status) {
-        ucs_error("cuDeviceGetCount() failed: %s", ucs_status_string(status));
         return NULL;
     }
 


### PR DESCRIPTION
## What?
Added logging for `cuInit`.
Removed duplicate logging for `cuDeviceGetCount` in `uct_cuda_ipc_create_dev_cache`.
