### PR TITLE
UCT/CUDA_COPY: Fix ep_flush logic; Remove sync_streams usage

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -158,9 +158,6 @@ uct_cuda_copy_post_cuda_async_copy(uct_ep_h tl_ep, void *dst, void *src,
     ucs_queue_push(event_q, &cuda_event->queue);
     cuda_event->comp = comp;
 
-    UCS_STATIC_BITMAP_SET(&iface->streams_to_sync,
-                          uct_cuda_copy_flush_bitmap_idx(src_type, dst_type));
-
     ucs_trace("cuda async issued: %p dst:%p[%s], src:%p[%s] len:%ld",
               cuda_event, dst, ucs_memory_type_names[dst_type], src,
               ucs_memory_type_names[src_type], length);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -20,25 +20,6 @@
 typedef uint64_t uct_cuda_copy_iface_addr_t;
 
 
-/*
-    uct_cu_stream_bitmap_t will be treated as a 2D bitmap, in which
-    each bit represents a CUstream from the queue_desc attr:
-    row index is source mem_type and column index is the dest mem_type.
-
-    For example:
-    H - Host, C - Cuda, R - ROCm, I - Infiniband (RDMA)
-
-      H C R I
-    H 0 0 0 0 
-    C 0 0 0 0 
-    R 0 0 0 0 
-    I 0 0 0 0
-
-    Bits will be set using:
-    UCS_BITMAP_SET(bitmap, uct_cuda_copy_flush_bitmap_idx(src_mem_type, dst_mem_type))
-*/
-typedef ucs_static_bitmap_s(UCT_CUDA_MEMORY_TYPES_MAP) uct_cu_stream_bitmap_t;
-
 typedef struct uct_cuda_copy_queue_desc {
     /* stream on which asynchronous memcpy operations are enqueued */
     CUstream                    stream;
@@ -76,10 +57,6 @@ typedef struct uct_cuda_copy_iface {
         void                    *event_arg;
         uct_async_event_cb_t    event_cb;
     } async;
-
-    /* 2D bitmap representing which streams in queue_desc matrix 
-       should sync during flush */
-    uct_cu_stream_bitmap_t streams_to_sync;
 } uct_cuda_copy_iface_t;
 
 
@@ -96,13 +73,5 @@ typedef struct uct_cuda_copy_event_desc {
     uct_completion_t *comp;
     ucs_queue_elem_t queue;
 } uct_cuda_copy_event_desc_t;
-
-
-static UCS_F_ALWAYS_INLINE unsigned
-uct_cuda_copy_flush_bitmap_idx(ucs_memory_type_t src_mem_type,
-                               ucs_memory_type_t dst_mem_type)
-{
-    return (src_mem_type * UCS_MEMORY_TYPE_LAST) + dst_mem_type;
-}
 
 #endif


### PR DESCRIPTION
## What?
- Fix ep_flush logic to return IN_PROGRESS if there are outstanding events in event queue.
- Remove uct_cuda_copy_sync_streams because it is unnecessary. Iface/EP flush operations are allowed to return IN_PROGRESS if there are outstanding events and user of the transport will call progress

