### PR TITLE
UCT/IB/MLX5/DV: removed device memory indirect key

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -2939,8 +2939,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    if ((flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA) ||
-        uct_ib_mlx5_devx_has_dm(memh)) {
+    if (flags & UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA) {
         if (ucs_unlikely(memh->indirect_dvmr == NULL)) {
             status = uct_ib_mlx5_devx_reg_indirect_key(md, memh);
             if (status != UCS_OK) {


### PR DESCRIPTION
## What?
Removing indirect key for device memory memh

## Why?
It's not needed and complicates mkey_pack logic