### PR TITLE
UCT/ROCM: add control of ipc cache usage

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -221,7 +221,7 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
         ret = UCS_OK;
     } else {
         rocm_copy_signal->comp        = comp;
-        rocm_copy_signal->mapped_addr = dst_addr;
+        rocm_copy_signal->mapped_addr = NULL;
         ucs_queue_push(&iface->signal_queue, &rocm_copy_signal->queue);
     }
 

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -21,11 +21,16 @@ static ucs_config_field_t uct_rocm_ipc_iface_config_table[] = {
      UCS_CONFIG_TYPE_TABLE(uct_iface_config_table)},
 
     {"MIN_ZCOPY", "128", "Minimum data size for ROCm/IPC zcopy protocols",
-     ucs_offsetof(uct_rocm_ipc_iface_config_t, min_zcopy),
+     ucs_offsetof(uct_rocm_ipc_iface_config_t, params.min_zcopy),
      UCS_CONFIG_TYPE_MEMUNITS},
 
     {"LAT", "1e-7", "Latency",
-     ucs_offsetof(uct_rocm_ipc_iface_config_t, latency), UCS_CONFIG_TYPE_TIME},
+     ucs_offsetof(uct_rocm_ipc_iface_config_t, params.latency),
+     UCS_CONFIG_TYPE_TIME},
+
+    {"CACHE_IPC_HANDLES", "y", "Enable caching IPC handles",
+     ucs_offsetof(uct_rocm_ipc_iface_config_t, params.enable_ipc_handle_cache),
+     UCS_CONFIG_TYPE_BOOL},
 
     {NULL}
 };
@@ -199,8 +204,7 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
                               tl_config UCS_STATS_ARG(params->stats_root)
                               UCS_STATS_ARG(UCT_ROCM_IPC_TL_NAME));
 
-    self->config.min_zcopy = config->min_zcopy;
-    self->config.latency   = config->latency;
+    self->config = config->params;
 
     ucs_mpool_params_reset(&mp_params);
     mp_params.elem_size       = sizeof(uct_rocm_base_signal_desc_t);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -13,21 +13,22 @@
 
 #define UCT_ROCM_IPC_TL_NAME "rocm_ipc"
 
-typedef struct uct_rocm_ipc_iface {
-    uct_base_iface_t super;
-    ucs_mpool_t signal_pool;
-    ucs_queue_head_t signal_queue;
-    struct {
-        size_t min_zcopy;
-        double latency;
-    } config;
+typedef struct uct_rocm_ipc_iface_config_params {
+    size_t min_zcopy;
+    double latency;
+    int    enable_ipc_handle_cache;
+} uct_rocm_ipc_iface_config_params_t;
 
+typedef struct uct_rocm_ipc_iface {
+    uct_base_iface_t                   super;
+    ucs_mpool_t                        signal_pool;
+    ucs_queue_head_t                   signal_queue;
+    uct_rocm_ipc_iface_config_params_t config;
 } uct_rocm_ipc_iface_t;
 
 typedef struct uct_rocm_ipc_iface_config {
-    uct_iface_config_t super;
-    size_t             min_zcopy;
-    double             latency;
+    uct_iface_config_t                 super;
+    uct_rocm_ipc_iface_config_params_t params;
 } uct_rocm_ipc_iface_config_t;
 
 #endif


### PR DESCRIPTION
## What?
add a UCX parameter that allows to control whether we want to use the rocm_ipc handle cache.

## Why?
There are some situation where caching the IPC handles/registrations is detrimental for a multitude of reasons.
