### PR TITLE
UCT/IB: Fix use of strict order as auxilary rkey

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -898,20 +898,21 @@ err:
 static ucs_status_t
 uct_ib_devx_dereg_invalidate_rkey_check(uct_ib_mlx5_md_t *md,
                                         uct_ib_mlx5_devx_mem_t *memh,
-                                        uint32_t rkey, unsigned flags_mask,
-                                        uint64_t cap_mask, const char *name)
+                                        struct mlx5dv_devx_obj *dvmr,
+                                        unsigned flags_mask, uint64_t cap_mask,
+                                        const char *name)
 {
     if (!(memh->super.flags & flags_mask)) {
         return UCS_OK;
     }
 
     if (!(md->super.cap_flags & cap_mask)) {
-        ucs_debug("%s: invalidate %s is not supported (rkey=0x%x)",
-                  uct_ib_device_name(&md->super.dev), name, rkey);
+        ucs_debug("%s: invalidate %s is not supported (dvmr=%p)",
+                  uct_ib_device_name(&md->super.dev), name, dvmr);
         return UCS_ERR_UNSUPPORTED;
     }
 
-    if (rkey == UCT_IB_INVALID_MKEY) {
+    if (dvmr == NULL) {
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -932,14 +933,14 @@ static ucs_status_t uct_ib_devx_dereg_invalidate_params_check(
 
     memh   = UCT_MD_MEM_DEREG_FIELD_VALUE(params, memh, FIELD_MEMH, NULL);
     status = uct_ib_devx_dereg_invalidate_rkey_check(
-            md, memh, memh->indirect_rkey, UCT_IB_MEM_ACCESS_REMOTE_RMA,
+            md, memh, memh->indirect_dvmr, UCT_IB_MEM_ACCESS_REMOTE_RMA,
             UCT_MD_FLAG_INVALIDATE_RMA, "RMA");
     if (status != UCS_OK) {
         return status;
     }
 
     return uct_ib_devx_dereg_invalidate_rkey_check(
-            md, memh, memh->atomic_rkey, UCT_IB_MEM_ACCESS_REMOTE_ATOMIC,
+            md, memh, memh->atomic_dvmr, UCT_IB_MEM_ACCESS_REMOTE_ATOMIC,
             UCT_MD_FLAG_INVALIDATE_AMO, "AMO");
 }
 

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -947,6 +947,16 @@ UCS_TEST_SKIP_COND_P(test_md, dereg_bad_arg,
                  UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA);
 }
 
+UCS_TEST_SKIP_COND_P(test_md, dereg_bad_arg_with_ro,
+                     !check_reg_mem_type(UCS_MEMORY_TYPE_HOST) ||
+                     !ENABLE_PARAMS_CHECK,
+                     "IB_PCI_RELAXED_ORDERING?=try")
+{
+    test_reg_mem(md_flags_remote_rma, UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA);
+    test_reg_mem(UCT_MD_MEM_ACCESS_REMOTE_ATOMIC,
+                 UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA);
+}
+
 UCS_TEST_SKIP_COND_P(test_md, exported_mkey,
                      !check_caps(UCT_MD_FLAG_EXPORTED_MKEY))
 {


### PR DESCRIPTION
## Why?
Fix [RM](https://redmine.mellanox.com/issues/4314268)
