### PR TITLE
UCT/IB/MLX5/DC: pass pool_index to dci_create, dci_find: check dci is valid

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -368,7 +368,7 @@ static void uct_ib_mlx5dv_dci_qp_init_attr(uct_ib_qp_init_attr_t *qp_attr,
 
 ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
                                           uct_dci_index_t dci_index,
-                                          int connect, uint8_t num_dci_channels)
+                                          uint8_t num_dci_channels)
 {
     uct_ib_iface_t *ib_iface   = &iface->super.super.super;
     uct_ib_mlx5_qp_attr_t attr = {};
@@ -459,13 +459,6 @@ init_qp:
                                uct_dc_mlx5_iface_dci(iface, dci_index)),
                        "iface=%p dci_index=%d", iface, dci_index);
     ucs_array_elem(&iface->tx.dcis, dci_index) = dci;
-
-    if (connect) {
-        status = uct_dc_mlx5_iface_dci_connect(iface, dci);
-        if (status != UCS_OK) {
-            goto err;
-        }
-    }
 
     if (uct_dc_mlx5_iface_is_policy_shared(iface)) {
         ucs_arbiter_group_init(&dci->arb_group);
@@ -766,8 +759,7 @@ static void uct_dc_mlx5_iface_dci_pool_destroy(uct_dc_mlx5_dci_pool_t *dci_pool)
     ucs_array_cleanup_dynamic(&dci_pool->stack);
 }
 
-static void
-uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uint16_t dci_index)
+void uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uint16_t dci_index)
 {
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.super.super.super.md,
                                           uct_ib_mlx5_md_t);
@@ -901,7 +893,7 @@ uct_dc_mlx5_iface_init_dcis_array(uct_dc_mlx5_iface_t *iface,
 
     ucs_array_length(&iface->tx.dcis) = 0;
 
-    status = uct_dc_mlx5_iface_create_dci(iface, 0, 0, 1);
+    status = uct_dc_mlx5_iface_create_dci(iface, 0, 1);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/mlx5/dc/dc_mlx5.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.h
@@ -387,8 +387,8 @@ void uct_dc_mlx5_destroy_dct(uct_dc_mlx5_iface_t *iface);
 
 void uct_dc_mlx5_iface_init_version(uct_dc_mlx5_iface_t *iface, uct_md_h md);
 
-ucs_status_t uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface,
-                                           uct_dc_dci_t *dci);
+ucs_status_t
+uct_dc_mlx5_iface_dci_connect(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci);
 
 void uct_dc_mlx5_iface_set_ep_failed(uct_dc_mlx5_iface_t *iface,
                                      uct_dc_mlx5_ep_t *ep,
@@ -401,7 +401,6 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface,
 
 ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
                                           uct_dci_index_t dci_index,
-                                          int connect,
                                           uint8_t num_dci_channels);
 
 ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
@@ -418,6 +417,8 @@ uct_dc_mlx5_dci_pool_get_or_create(uct_dc_mlx5_iface_t *iface,
 
 uint32_t
 uct_dc_mlx5_dci_config_hash(const uct_dc_mlx5_dci_config_t *dci_config);
+
+void uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uint16_t dci_index);
 
 static UCS_F_ALWAYS_INLINE uint8_t uct_dc_mlx5_is_dci_valid(const uct_dc_dci_t *dci)
 {
@@ -486,6 +487,7 @@ uct_dc_mlx5_iface_dci_find(uct_dc_mlx5_iface_t *iface, struct mlx5_cqe64 *cqe)
     uint32_t qp_num;
     int ndci;
     uct_dci_index_t dci_index;
+    uct_dc_dci_t *dci;
 
     if (ucs_likely(iface->flags & UCT_DC_MLX5_IFACE_FLAG_UIDX)) {
         dci_index = cqe->srqn_uidx >> UCT_IB_UIDX_SHIFT;
@@ -498,11 +500,9 @@ uct_dc_mlx5_iface_dci_find(uct_dc_mlx5_iface_t *iface, struct mlx5_cqe64 *cqe)
     qp_num = ntohl(cqe->sop_drop_qpn) & UCS_MASK(UCT_IB_QPN_ORDER);
     ndci   = ucs_array_length(&iface->tx.dcis);
     for (dci_index = 0; dci_index < ndci; dci_index++) {
-        if (uct_dc_mlx5_iface_dci(iface, dci_index)->txwq.super.qp_num ==
-            qp_num) {
-            ucs_assertv(uct_dc_mlx5_is_dci_valid(
-                                uct_dc_mlx5_iface_dci(iface, dci_index)),
-                        "iface=%p, dci=%d", iface, dci_index);
+        dci = uct_dc_mlx5_iface_dci(iface, dci_index);
+        if (uct_dc_mlx5_is_dci_valid(dci) &&
+            (dci->txwq.super.qp_num == qp_num)) {
             return dci_index;
         }
     }


### PR DESCRIPTION
## What?
1. Passing pool_index param into dci_create() -> dci_connect() so dci would use the correct configuration by using the correct pool index
2. in find_dci: check that dci is not null before accessing dci->txwq

## Why?
1. Currently `dci->pool_index` is initialized after dci_connect which relies on its value for determining DCI configuration (such as path_index)
2. in `uct_dc_mlx5_iface_dci_find` when UIDX is not set, `uct_dc_mlx5_iface_dci(iface, dci_index)->txwq.super.qp_num` is being accessed without checking whether DCI is valid (not null)

