### PR TITLE
UCT/IB: Skip SMI devices using netlink query

### DIFF
--- a/buildlib/tools/check_tls_perf_caps.sh
+++ b/buildlib/tools/check_tls_perf_caps.sh
@@ -30,8 +30,14 @@ for tl_name in $(grep Transport ${legacy_info_file} | awk '{print $3}')
 do
     old_tl_caps=$(grep -A 8 "Transport: $tl_name" ${legacy_info_file} || true)
     new_tl_caps=$(grep -A 8 "Transport: $tl_name" ${pr_info_file}     || true)
-    for device in  $(echo "${old_tl_caps}" | grep Device | awk '{print $3}')
+    for device in $(echo "${old_tl_caps}" | grep Device | awk '{print $3}')
     do
+      # Ignore SMI devices
+      if [[ "$device" =~ ^smi[0-9]*:.$ ]]
+      then
+        continue;
+      fi
+
       old_caps=$(echo "$old_tl_caps" | grep -A 7 "Device: $device" || true)
       new_caps=$(echo "$new_tl_caps" | grep -A 7 "Device: $device" || true)
       for cap in bandwidth latency overhead

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -145,6 +145,7 @@ get_ib_devices() {
 	set +x
 	for ibdev in $device_list
 	do
+		[[ "$device" =~ ^smi[0-9]*:.$ ]] && continue
 		num_ports=$(ibv_devinfo -d $ibdev| awk '/phys_port_cnt:/ {print $2}')
 		for port in $(seq 1 $num_ports)
 		do

--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -9,9 +9,39 @@
 
 #include <ucs/type/status.h>
 
+#include <linux/netlink.h>
 #include <netinet/in.h>
 
 BEGIN_C_DECLS
+
+/**
+ * Callback function for parsing individual netlink messages.
+ *
+ * @param [in] nlh    Pointer to the netlink message header.
+ * @param [in] arg    User-provided argument passed through from the caller.
+ *
+ * @return UCS_OK if parsing is complete, UCS_INPROGRESS if there are more
+ *         messages to be parsed, or error code otherwise.
+ */
+typedef ucs_status_t (*ucs_netlink_parse_cb_t)(const struct nlmsghdr *nlh,
+                                               void *arg);
+
+/*
+ * Send a netlink request and parse the response.
+ *
+ * @param [in]  protocol         Netlink protocol (e.g. NETLINK_ROUTE).
+ * @param [in]  nlmsg_type       Protocol message type (e.g. NETLINK_GETROUTE).
+ * @param [in]  nlmsg_flags      Flags for message header (e.g. NLM_F_ROOT).
+ * @param [in]  protocol_header  Netlink protocol header.
+ * @param [in]  header_length    Netlink protocol header length.
+ * @param [in]  parse_cb         Callback function to parse the response.
+ * @param [in]  arg              User-provided argument for the parse callback.
+ */
+ucs_status_t
+ucs_netlink_send_request(int protocol, unsigned short nlmsg_type,
+                         unsigned short nlmsg_flags,
+                         const void *protocol_header, size_t header_length,
+                         ucs_netlink_parse_cb_t parse_cb, void *arg);
 
 
 /**

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -502,4 +502,6 @@ static inline void uct_ib_destroy_cq(struct ibv_cq *cq, const char *desc)
 
 void uct_ib_handle_async_event(uct_ib_device_t *dev, uct_ib_async_event_t *event);
 
+int uct_ib_device_is_smi(struct ibv_device *ibv_device);
+
 #endif

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -111,6 +111,12 @@ static inline ucs_status_t uct_ib_query_device(struct ibv_context *ctx,
 #  define uct_ib_grh_required(_attr)                0
 #endif
 
+#if HAVE_DECL_IBV_TRANSPORT_UNSPECIFIED
+#  define IBV_DEVICE_TRANSPORT_UNSPECIFIED(_dev)    ((_dev)->transport_type == IBV_TRANSPORT_UNSPECIFIED)
+#else
+#  define IBV_DEVICE_TRANSPORT_UNSPECIFIED(_dev)    0
+#endif
+
 /* Dummy structure declaration, when not present in verbs.h */
 #if !HAVE_IBV_DM
     struct ibv_dm;

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -282,12 +282,34 @@ AS_IF([test "x$with_ib" = "xyes"],
            AC_CHECK_DECLS([ibv_alloc_dm],
                [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support])],
                [], [[#include <infiniband/verbs.h>]])])
-        
+
         # DDP support
         AS_IF([test "x$have_mlx5" = xyes], [
            AC_CHECK_DECLS([MLX5DV_CONTEXT_MASK_OOO_RECV_WRS],
                [AC_DEFINE([HAVE_OOO_RECV_WRS], 1, [Have DDP support])],
                [], [[#include <infiniband/mlx5dv.h>]])])
+
+       # RDMA netlink support requires defines from rdma_netlink.h and the
+       # ability to get netlink index from ibv_device struct.
+       have_netlink_rdma=yes
+       AC_CHECK_DECL([NETLINK_RDMA], [], [have_netlink_rdma=no],
+                     [[#include <linux/netlink.h>]])
+       AC_CHECK_DECL([RDMA_NL_NLDEV], [], [have_netlink_rdma=no],
+                     [[#include <rdma/rdma_netlink.h>]])
+       AC_CHECK_DECL([ibv_get_device_index], [], [have_netlink_rdma=no],
+                     [[#include <infiniband/verbs.h>]])
+       AS_IF([test "x$have_netlink_rdma" = xyes],
+             [AC_DEFINE([HAVE_NETLINK_RDMA], [1], [RDMA netlink support])
+              # Define replacement constants if not present in header files
+              AC_CHECK_DECL(RDMA_NLDEV_ATTR_DEV_TYPE, [],
+                            [AC_DEFINE([RDMA_NLDEV_ATTR_DEV_TYPE], 99,
+                                       [RDMA netlink device type attribute])],
+                            [[#include <rdma/rdma_netlink.h>]])
+              AC_CHECK_DECL(RDMA_DEVICE_TYPE_SMI, [],
+                            [AC_DEFINE([RDMA_DEVICE_TYPE_SMI], 1,
+                                       [RDMA netlink SMI device type])],
+                            [[#include <rdma/rdma_netlink.h>]])
+             ])
 
        mlnx_valg_libdir=$with_verbs/lib${libsuff}/mlnx_ofed/valgrind
        AC_MSG_NOTICE([Checking OFED valgrind libs $mlnx_valg_libdir])

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -250,7 +250,7 @@ if match:
 else:
     rc_max_num_eps = 0
 
-status, output = exec_cmd("ibv_devinfo  -l | tail -n +2 | sed -e 's/^[ \t]*//' | head -n -1 ")
+status, output = exec_cmd("ibv_devinfo -l | tail -n+2 | head -n-1 | sed -e 's/^[ \t]*//' | grep -v '^smi[0-9]*$'")
 dev_list = output.splitlines()
 port = "1"
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -546,6 +546,11 @@ static std::map<std::string, std::string> get_all_rdmacm_net_devices()
 
         if (!ib_devices.empty()) {
             std::string ib_device = ib_devices.front();
+            if (ib_device.rfind("smi", 0) == 0) {
+                /* Skip SMI device */
+                continue;
+            }
+
             std::string ports_dir = infiniband_dir + "/" + ib_device +
                                     "/ports";
             std::string ib_port   = read_dir(ports_dir).front();


### PR DESCRIPTION
## Why
Multi-plane ConnectX-8 device can have  SMI sub-devices, which we don't want to use for communication.
See more info: https://lore.kernel.org/lkml/171983740416.330197.16009173038296516665.b4-ty@nvidia.com/T/