### PR TITLE
UCP/PROTO: Proto lane selection

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -913,7 +913,7 @@ ucp_proto_storage_trace_lanes(const ucp_proto_lane_storage_t *storage,
                               ucp_lane_index_t *lanes, ucp_lane_index_t length,
                               const char *desc)
 {
-    ucp_context_h context = storage->params->worker->context;
+    ucp_context_h UCS_V_UNUSED context = storage->params->worker->context;
     const ucp_proto_common_tl_perf_t *lane_perf;
     ucp_lane_index_t i, lane;
     ucp_rsc_index_t rsc_index;

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -1041,7 +1041,7 @@ ucp_proto_storage_remove_slow_lanes(ucp_proto_lane_storage_t *storage)
     ucp_context_h context = storage->params->worker->context;
     double max_bw_ratio   = context->config.ext.multi_lane_max_ratio;
     double min_bw         = storage->max_bandwidth / max_bw_ratio;
-    ucp_lane_index_t removed_lanes[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t removed_lanes[UCP_PROTO_MAX_LANES] = {};
     ucp_proto_common_tl_perf_t *lane_perf;
     ucp_lane_index_t i, lane, num_fast_lanes;
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -243,7 +243,7 @@ ucp_proto_common_get_frag_size(const ucp_proto_common_init_params_t *params,
 
 /* Update 'perf' with the distance */
 static void ucp_proto_common_update_lane_perf_by_distance(
-        ucp_proto_common_tl_perf_t *perf, ucp_proto_perf_node_t *perf_node,
+        ucp_proto_common_tl_perf_t *perf,
         const ucs_sys_dev_distance_t *distance, const char *perf_name,
         const char *perf_fmt, ...)
 {
@@ -269,7 +269,7 @@ static void ucp_proto_common_update_lane_perf_by_distance(
     sys_perf_node = ucp_proto_perf_node_new_data(perf_name, "%s",
                                                  perf_node_desc);
     ucp_proto_perf_node_add_data(sys_perf_node, "", distance_func);
-    ucp_proto_perf_node_own_child(perf_node, &sys_perf_node);
+    ucp_proto_perf_node_own_child(perf->node, &sys_perf_node);
 }
 
 void ucp_proto_common_lane_perf_node(ucp_context_h context,
@@ -325,13 +325,13 @@ static void ucp_proto_common_tl_perf_reset(ucp_proto_common_tl_perf_t *tl_perf)
     tl_perf->sys_latency        = 0;
     tl_perf->min_length         = 0;
     tl_perf->max_frag           = SIZE_MAX;
+    tl_perf->node               = NULL;
 }
 
 ucs_status_t
 ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                ucp_lane_index_t lane,
-                               ucp_proto_common_tl_perf_t *tl_perf,
-                               ucp_proto_perf_node_t **perf_node_p)
+                               ucp_proto_common_tl_perf_t *tl_perf)
 {
     ucp_worker_h worker        = params->super.worker;
     ucp_context_h context      = worker->context;
@@ -349,7 +349,6 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
 
     if (lane == UCP_NULL_LANE) {
         ucp_proto_common_tl_perf_reset(tl_perf);
-        *perf_node_p = NULL;
         return UCS_OK;
     }
 
@@ -411,7 +410,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
         ucp_proto_common_get_lane_distance(&params->super, lane, sys_dev,
                                            &distance);
         ucp_proto_common_update_lane_perf_by_distance(
-                tl_perf, perf_node, &distance, "local system", "%s %s",
+                tl_perf, &distance, "local system", "%s %s",
                 ucs_topo_sys_device_get_name(sys_dev),
                 ucs_topo_sys_device_bdf_name(sys_dev, bdf_name,
                                              sizeof(bdf_name)));
@@ -425,7 +424,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
         rkey_config = &worker->rkey_config[params->super.rkey_cfg_index];
         distance    = rkey_config->lanes_distance[lane];
         ucp_proto_common_update_lane_perf_by_distance(
-                tl_perf, perf_node, &distance, "remote system", "sys-dev %d %s",
+                tl_perf, &distance, "remote system", "sys-dev %d %s",
                 rkey_config->key.sys_dev,
                 ucs_memory_type_names[rkey_config->key.mem_type]);
     }
@@ -448,7 +447,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                    tl_perf->send_post_overhead);
     ucp_proto_perf_node_add_scalar(perf_node, "recv", tl_perf->recv_overhead);
 
-    *perf_node_p = perf_node;
+    tl_perf->node = perf_node;
     return UCS_OK;
 
 err_deref_perf_node:

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -1141,7 +1141,6 @@ static void ucp_proto_select_bw_lanes(ucp_proto_lane_selection_t *selection,
         index = ucp_proto_select_find_bw_lane(selection, index_map);
         ucp_proto_select_add_lane(selection, index);
         index_map &= ~UCS_BIT(index);
-        index++;
     }
 }
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -1147,7 +1147,7 @@ static void ucp_proto_select_copy_lanes(ucp_proto_lane_selection_t *selection,
     ucp_lane_index_t i;
 
     for (i = 0; i < ucs_min(max_lanes, selection->storage->length); ++i) {
-        ucp_proto_select_add_lane(selection, 0);
+        ucp_proto_select_add_lane(selection, i);
     }
 }
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -910,8 +910,7 @@ void ucp_proto_fatal_invalid_stage(ucp_request_t *req, const char *func_name)
 
 static void
 ucp_proto_storage_trace_lanes(const ucp_proto_lane_storage_t *storage,
-                              ucp_lane_index_t *lanes,
-                              ucp_lane_index_t num_lanes,
+                              ucp_lane_index_t *lanes, ucp_lane_index_t length,
                               const char *desc)
 {
     const ucp_proto_common_tl_perf_t *lane_perf;
@@ -921,10 +920,10 @@ ucp_proto_storage_trace_lanes(const ucp_proto_lane_storage_t *storage,
         return;
     }
 
-    ucs_trace("%s=%u, protocol=%s", desc, num_lanes,
+    ucs_trace("%s=%u, protocol=%s", desc, length,
               ucp_proto_id_field(storage->params->proto_id, name));
 
-    for (i = 0; i < num_lanes; ++i) {
+    for (i = 0; i < length; ++i) {
         lane      = lanes[i];
         lane_perf = &storage->lanes_perf[lane];
 
@@ -1207,7 +1206,7 @@ ucp_proto_select_aggregate_perf(ucp_proto_lane_selection_t *selection)
         perf->recv_overhead      += lane_perf->recv_overhead;
         perf->latency             = ucs_max(perf->latency, lane_perf->latency);
         perf->sys_latency         = ucs_max(perf->sys_latency,
-                                           lane_perf->sys_latency);
+                                            lane_perf->sys_latency);
     }
 
     if (selection->length == 1) {

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -454,41 +454,6 @@ err_deref_perf_node:
     return status;
 }
 
-/*
- * TODO: This is a quickfix, needed to select lanes for multi-lane RNDV
- * protocol in the order of rma_bw_lanes (RMA_BW lanes sorted by score).
- * The proper solution is to have a generic mechanism to sort lanes based on
- * the calculated performance, implemented in proto_multi.
- * This function should be removed once the proper solution is implemented.
- */
-static inline ucp_lane_index_t
-ucp_proto_common_lanes_iter(const ucp_ep_config_key_t *ep_config_key,
-                            ucp_lane_map_t lane_map, ucp_lane_type_t lane_type,
-                            ucp_lane_index_t start, ucp_lane_index_t *lane)
-{
-    if (start >= UCP_MAX_LANES) {
-        return UCP_MAX_LANES;
-    }
-
-    if (lane_type == UCP_LANE_TYPE_RMA_BW) {
-        for (; start < ep_config_key->num_lanes; ++start) {
-            *lane = ep_config_key->rma_bw_lanes[start];
-            if ((*lane == UCP_NULL_LANE) || (lane_map & UCS_BIT(*lane))) {
-                break;
-            }
-        }
-        return start;
-    }
-
-    /*
-     * By default iterate over all lanes in lane_map
-     * Reset lane_map bits below start position, then find first bit set
-     */
-    lane_map &= ~((1ULL << start) - 1);
-    *lane     = ucs_ffs64_safe(lane_map);
-    return *lane;
-}
-
 ucp_lane_index_t
 ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
                             unsigned flags, ptrdiff_t max_iov_offs,
@@ -503,7 +468,7 @@ ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
     const ucp_rkey_config_key_t *rkey_config_key = params->rkey_config_key;
     const ucp_proto_select_param_t *select_param = params->select_param;
     const uct_iface_attr_t *iface_attr;
-    ucp_lane_index_t lane, num_lanes, i;
+    ucp_lane_index_t lane, num_lanes;
     const uct_md_attr_v2_t *md_attr;
     const uct_component_attr_t *cmpt_attr;
     ucp_rsc_index_t rsc_index;
@@ -536,12 +501,7 @@ ucp_proto_common_find_lanes(const ucp_proto_init_params_t *params,
     }
 
     lane_map = UCS_MASK(ep_config_key->num_lanes) & ~exclude_map;
-    lane     = 0;
-    for (i = ucp_proto_common_lanes_iter(ep_config_key, lane_map, lane_type,
-                                         0, &lane);
-         (i < ep_config_key->num_lanes) && (lane != UCP_NULL_LANE);
-         i = ucp_proto_common_lanes_iter(ep_config_key, lane_map, lane_type,
-                                         i + 1, &lane)) {
+    ucs_for_each_bit(lane, lane_map) {
         if (num_lanes >= max_lanes) {
             break;
         }

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -974,8 +974,9 @@ ucp_proto_storage_create(const ucp_proto_common_init_params_t *params,
 
     /* Evaluate individual lane performance */
     for (i = 0; i < storage->length; ++i) {
-        lane      = storage->lanes[i];
-        lane_perf = &storage->lanes_perf[lane];
+        lane = storage->lanes[i];
+        ucs_assert(lane < UCP_PROTO_MAX_LANES);
+        lane_perf = storage->lanes_perf + lane;
         status    = ucp_proto_common_get_lane_perf(params, lane, lane_perf);
         if (status != UCS_OK) {
             goto err;

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -1086,6 +1086,7 @@ ucp_proto_select_find_bw_lane(ucp_proto_lane_selection_t *selection,
     const ucp_proto_common_tl_perf_t *lane_perf;
     ucp_lane_index_t lane, index, max_index;
 
+    max_index = ucs_ffs64(index_map);
     ucs_for_each_bit(index, index_map) {
         lane_perf = ucp_proto_select_get_perf_index(selection, index, &lane);
         if (lane_perf->bandwidth < max_avail_bw) {

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -996,9 +996,9 @@ err:
 }
 
 static void
-ucp_proto_storage_remove_slow_lanes(ucp_context_h context,
-                                    ucp_proto_lane_storage_t *storage)
+ucp_proto_storage_remove_slow_lanes(ucp_proto_lane_storage_t *storage)
 {
+    ucp_context_h context     = storage->params->worker->context;
     const double max_bw_ratio = context->config.ext.multi_lane_max_ratio;
     ucp_proto_common_tl_perf_t *lane_perf;
     ucp_lane_index_t i, num_fast_lanes;
@@ -1161,7 +1161,7 @@ ucp_proto_select_aggregate_perf(ucp_proto_lane_selection_t *selection)
     const ucp_proto_common_tl_perf_t *lane_perf;
     ucp_lane_index_t lane;
 
-    /* TODO: Adjust performance estimation based on actual resource usage,
+    /* TODO: Adjust performance estimation based on the actual resource usage,
      * i.e. split the overall iface BW between all selected paths. */
 
     ucs_for_each_bit(lane, selection->lane_map) {
@@ -1207,7 +1207,7 @@ ucp_proto_select_lanes(const ucp_proto_common_init_params_t *params,
         return status;
     }
 
-    ucp_proto_storage_remove_slow_lanes(params->super.worker->context, storage);
+    ucp_proto_storage_remove_slow_lanes(storage);
 
     memset(selection, 0, sizeof(*selection));
     selection->storage = storage;

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -183,6 +183,50 @@ typedef struct {
 } ucp_proto_lane_desc_t;
 
 
+typedef struct {
+    const ucp_proto_init_params_t *params;
+    ucp_proto_common_tl_perf_t    lanes_perf[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t              lanes[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t              length;
+    double                        max_bandwidth;
+    int                           fixed_first_lane;
+} ucp_proto_lane_storage_t;
+
+
+typedef struct {
+    ucp_lane_map_t                lane_map;
+    ucp_lane_index_t              lanes[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t              length;
+    uint8_t                       local_rsc_count[UCP_MAX_RESOURCES];
+    ucp_proto_common_tl_perf_t    perf;
+    ucp_proto_lane_storage_t      *storage;
+} ucp_proto_lane_selection_t;
+
+
+ucs_status_t
+ucp_proto_select_lanes(const ucp_proto_common_init_params_t *params,
+                       const ucp_proto_lane_desc_t *lane_desc,
+                       const ucp_proto_lane_desc_t *first_lane_desc,
+                       ucp_lane_index_t max_lanes, ucp_lane_map_t exclude_map,
+                       ucp_proto_lane_selection_t *selection);
+
+void ucp_proto_select_destroy(ucp_proto_lane_selection_t *selection);
+
+static UCS_F_ALWAYS_INLINE const ucp_proto_common_tl_perf_t *
+ucp_proto_select_get_perf_lane(const ucp_proto_lane_selection_t *selection,
+                               ucp_lane_index_t lane)
+{
+    return &selection->storage->lanes_perf[lane];
+}
+
+static UCS_F_ALWAYS_INLINE const ucp_proto_common_tl_perf_t *
+ucp_proto_select_get_perf_index(const ucp_proto_lane_selection_t *selection,
+                                ucp_lane_index_t index, ucp_lane_index_t *lane_p)
+{
+    *lane_p = selection->storage->lanes[index];
+    return ucp_proto_select_get_perf_lane(selection, *lane_p);
+}
+
 /**
  * Called the first time the protocol starts sending a request, and only once
  * per request.

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -159,6 +159,9 @@ typedef struct {
 
     /* Maximum single message length */
     size_t max_frag;
+
+    /* Performance selection tree node */
+    ucp_proto_perf_node_t *node;
 } ucp_proto_common_tl_perf_t;
 
 
@@ -257,8 +260,7 @@ void ucp_proto_common_lane_perf_node(ucp_context_h context,
 ucs_status_t
 ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                ucp_lane_index_t lane,
-                               ucp_proto_common_tl_perf_t *perf,
-                               ucp_proto_perf_node_t **perf_node_p);
+                               ucp_proto_common_tl_perf_t *perf);
 
 
 /* @return number of lanes found */

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -174,6 +174,15 @@ typedef struct {
 } ucp_proto_common_lane_priv_t;
 
 
+typedef struct {
+    /* Required iface capabilities */
+    uint64_t        tl_cap_flags;
+
+    /* Required lane type */
+    ucp_lane_type_t lane_type;
+} ucp_proto_lane_desc_t;
+
+
 /**
  * Called the first time the protocol starts sending a request, and only once
  * per request.

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -213,18 +213,10 @@ ucp_proto_select_lanes(const ucp_proto_common_init_params_t *params,
 void ucp_proto_select_destroy(ucp_proto_lane_selection_t *selection);
 
 static UCS_F_ALWAYS_INLINE const ucp_proto_common_tl_perf_t *
-ucp_proto_select_get_perf_lane(const ucp_proto_lane_selection_t *selection,
+ucp_proto_select_get_lane_perf(const ucp_proto_lane_selection_t *selection,
                                ucp_lane_index_t lane)
 {
     return &selection->storage->lanes_perf[lane];
-}
-
-static UCS_F_ALWAYS_INLINE const ucp_proto_common_tl_perf_t *
-ucp_proto_select_get_perf_index(const ucp_proto_lane_selection_t *selection,
-                                ucp_lane_index_t index, ucp_lane_index_t *lane_p)
-{
-    *lane_p = selection->storage->lanes[index];
-    return ucp_proto_select_get_perf_lane(selection, *lane_p);
 }
 
 /**

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -129,7 +129,6 @@ ucp_proto_init_skip_recv_overhead(const ucp_proto_common_init_params_t *params,
 static ucs_status_t
 ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
                            const ucp_proto_common_tl_perf_t *tl_perf,
-                           ucp_proto_perf_node_t *const tl_perf_node,
                            size_t range_start, size_t range_end,
                            ucp_proto_perf_t *perf)
 {
@@ -184,7 +183,7 @@ ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
     return ucp_proto_perf_add_funcs(perf, range_start, range_end, perf_factors,
                                     ucp_proto_perf_node_new_data("transport",
                                                                  ""),
-                                    tl_perf_node);
+                                    tl_perf->node);
 }
 
 /**
@@ -502,7 +501,6 @@ ucp_proto_common_check_mem_access(const ucp_proto_common_init_params_t *params)
 
 ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
                                  const ucp_proto_common_tl_perf_t *tl_perf,
-                                 ucp_proto_perf_node_t *const tl_perf_node,
                                  ucp_md_map_t reg_md_map, const char *perf_name,
                                  ucp_proto_perf_t **perf_p)
 {
@@ -531,8 +529,8 @@ ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
         return status;
     }
 
-    status = ucp_proto_init_add_tl_perf(params, tl_perf, tl_perf_node,
-                                        range_start, range_end, perf);
+    status = ucp_proto_init_add_tl_perf(params, tl_perf, range_start, range_end,
+                                        perf);
     if (status != UCS_OK) {
         goto err_cleanup_perf;
     }

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -68,7 +68,6 @@ ucp_proto_init_add_buffer_copy_time(ucp_worker_h worker, const char *title,
 
 ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
                                  const ucp_proto_common_tl_perf_t *tl_perf,
-                                 ucp_proto_perf_node_t *const tl_perf_node,
                                  ucp_md_map_t reg_md_map, const char *perf_name,
                                  ucp_proto_perf_t **perf_p);
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -61,17 +61,6 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     ucs_for_each_bit(lane, selection.lane_map) {
         lane_perf = ucp_proto_select_get_lane_perf(&selection, lane);
 
-        ucs_trace("lane[%d]" UCP_PROTO_TIME_FMT(send_pre_overhead)
-                  UCP_PROTO_TIME_FMT(send_post_overhead)
-                  UCP_PROTO_TIME_FMT(recv_overhead)
-                  " bw " UCP_PROTO_PERF_FUNC_BW_FMT
-                  UCP_PROTO_TIME_FMT(latency), lane,
-                  UCP_PROTO_TIME_ARG(lane_perf->send_pre_overhead),
-                  UCP_PROTO_TIME_ARG(lane_perf->send_post_overhead),
-                  UCP_PROTO_TIME_ARG(lane_perf->recv_overhead),
-                  (lane_perf->bandwidth / UCS_MBYTE),
-                  UCP_PROTO_TIME_ARG(lane_perf->latency));
-
         /* Calculate maximal bandwidth-to-fragment-size ratio, which is used to
            adjust fragment sizes so they are proportional to bandwidth ratio and
            also do not exceed maximal supported size */

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -59,7 +59,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     min_bandwidth  = DBL_MAX;
 
     ucs_for_each_bit(lane, selection.lane_map) {
-        lane_perf = ucp_proto_select_get_perf_lane(&selection, lane);
+        lane_perf = ucp_proto_select_get_lane_perf(&selection, lane);
 
         ucs_trace("lane[%d]" UCP_PROTO_TIME_FMT(send_pre_overhead)
                   UCP_PROTO_TIME_FMT(send_post_overhead)
@@ -97,7 +97,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         ucs_assert(lane < UCP_MAX_LANES);
 
         lpriv     = &mpriv->lanes[mpriv->num_lanes++];
-        lane_perf = ucp_proto_select_get_perf_lane(&selection, lane);
+        lane_perf = ucp_proto_select_get_lane_perf(&selection, lane);
 
         ucp_proto_common_lane_priv_init(&params->super, mpriv->reg_md_map, lane,
                                         &lpriv->super);

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -27,14 +27,12 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
 {
     ucp_context_h context         = params->super.super.worker->context;
     const double max_bw_ratio     = context->config.ext.multi_lane_max_ratio;
-    ucp_proto_perf_node_t *lanes_perf_nodes[UCP_PROTO_MAX_LANES];
     ucp_proto_common_tl_perf_t lanes_perf[UCP_PROTO_MAX_LANES];
     ucp_proto_common_tl_perf_t *lane_perf, perf;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     double max_bandwidth, max_frag_ratio, min_bandwidth;
     ucp_lane_index_t i, lane, num_lanes;
     ucp_proto_multi_lane_priv_t *lpriv;
-    ucp_proto_perf_node_t *perf_node;
     size_t max_frag, min_length, min_end_offset, min_chunk;
     ucp_lane_map_t lane_map;
     ucp_md_map_t reg_md_map;
@@ -76,8 +74,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         lane      = lanes[i];
         lane_perf = &lanes_perf[lane];
 
-        status = ucp_proto_common_get_lane_perf(&params->super, lane, lane_perf,
-                                                &lanes_perf_nodes[lane]);
+        status = ucp_proto_common_get_lane_perf(&params->super, lane, lane_perf);
         if (status != UCS_OK) {
             return status;
         }
@@ -230,27 +227,26 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     }
     ucs_assert(mpriv->num_lanes == ucs_popcount(lane_map));
 
-    /* After this block, 'perf_node' and 'lane_perf_nodes[]' have extra ref */
     if (mpriv->num_lanes == 1) {
-        perf_node = lanes_perf_nodes[ucs_ffs64(lane_map)];
-        ucp_proto_perf_node_ref(perf_node);
+        perf.node = lanes_perf[ucs_ffs64(lane_map)].node;
+        ucp_proto_perf_node_ref(perf.node);
     } else {
-        perf_node = ucp_proto_perf_node_new_data("multi", "%u lanes",
+        perf.node = ucp_proto_perf_node_new_data("multi", "%u lanes",
                                                  mpriv->num_lanes);
         ucs_for_each_bit(lane, lane_map) {
             ucs_assert(lane < UCP_MAX_LANES);
-            ucp_proto_perf_node_add_child(perf_node, lanes_perf_nodes[lane]);
+            ucp_proto_perf_node_add_child(perf.node, lanes_perf[lane].node);
         }
     }
 
-    status = ucp_proto_init_perf(&params->super, &perf, perf_node, reg_md_map,
-                                 perf_name, perf_p);
+    status = ucp_proto_init_perf(&params->super, &perf, reg_md_map, perf_name,
+                                 perf_p);
 
     /* Deref unused nodes */
     for (i = 0; i < num_lanes; ++i) {
-        ucp_proto_perf_node_deref(&lanes_perf_nodes[lanes[i]]);
+        ucp_proto_perf_node_deref(&lanes_perf[lanes[i]].node);
     }
-    ucp_proto_perf_node_deref(&perf_node);
+    ucp_proto_perf_node_deref(&perf.node);
 
     return status;
 }

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -124,13 +124,8 @@ typedef struct {
      * by this protocol */
     ptrdiff_t                      opt_align_offs;
 
-    struct {
-        /* Required iface capabilities */
-        uint64_t        tl_cap_flags;
-
-        /* Required lane type */
-        ucp_lane_type_t lane_type;
-    } first, middle;
+    ucp_proto_lane_desc_t          first;
+    ucp_proto_lane_desc_t          middle;
 } ucp_proto_multi_init_params_t;
 
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -24,7 +24,6 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
 {
     const char *proto_name = ucp_proto_id_field(params->super.super.proto_id,
                                                 name);
-    ucp_proto_perf_node_t *tl_perf_node;
     ucp_proto_common_tl_perf_t tl_perf;
     ucp_lane_index_t num_lanes;
     ucp_md_map_t reg_md_map;
@@ -52,15 +51,14 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
 
     ucp_proto_common_lane_priv_init(&params->super, reg_md_map, lane,
                                     &spriv->super);
-    status = ucp_proto_common_get_lane_perf(&params->super, lane, &tl_perf,
-                                            &tl_perf_node);
+    status = ucp_proto_common_get_lane_perf(&params->super, lane, &tl_perf);
     if (status != UCS_OK) {
         return status;
     }
 
-    status = ucp_proto_init_perf(&params->super, &tl_perf, tl_perf_node,
-                                 reg_md_map, proto_name, perf_p);
-    ucp_proto_perf_node_deref(&tl_perf_node);
+    status = ucp_proto_init_perf(&params->super, &tl_perf, reg_md_map,
+                                 proto_name, perf_p);
+    ucp_proto_perf_node_deref(&tl_perf.node);
 
     return status;
 }


### PR DESCRIPTION
## What?
Formerly known as "lane sorting" task.
When CUDA context is set, then rma_bw_lanes array is adjusted with GPU distance.
When CUDA context is not set in the caller thread, then UCX protocol does not always choose fastest lanes for GPU memory.

The idea is to select lanes at the protocol selection stage after performance estimation.
We need to find the best combination of lanes for a given operation.

## Testing
https://confluence.nvidia.com/display/NSWX/Protocol+lane+selection+testing

Mock tests PR: https://github.com/openucx/ucx/pull/10547