### PR TITLE
UCT/IB/DEVX: Fix check ODP.

### DIFF
--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1660,7 +1660,8 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
                 capability.odp_cap.memory_page_fault_scheme_cap);
         version = 2;
     } else {
-        if (md_config->devx_objs & UCS_BIT(UCT_IB_DEVX_OBJ_RCQP)) {
+        if (md_config->devx_objs &
+            (UCS_BIT(UCT_IB_DEVX_OBJ_RCQP) | UCS_BIT(UCT_IB_DEVX_OBJ_DCI))) {
             reason = "version 1 is not supported for DevX QP";
             goto no_odp;
         }


### PR DESCRIPTION
## What?
Fix DEVX ODP check so it will use ODP V1 only if DEVX objects are not created.

## Why?
ODP V1 can't work with DEVX objects but we only check that RCQP is not created.

## How?
Check that we don't use DEVX object on any type.
