### PR TITLE
ARCH/X86: Use UCS function to count leading zeros

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1128,12 +1128,9 @@ run_release_mode_tests() {
 # Run nt_buffer_transfer tests
 #
 run_nt_buffer_transfer_tests() {
-    if lscpu | grep -q 'AuthenticAMD'
-    then
-	    build release --enable-gtest --enable-optimizations
-	    echo "==== Running nt_buffer_transfer tests ===="
-	    ./test/gtest/gtest --gtest_filter="test_arch.nt_buffer_transfer_*"
-    fi
+    build release --enable-gtest --enable-optimizations
+    echo "==== Running test_arch tests with optimizations ===="
+    ./test/gtest/gtest --gtest_filter="test_arch.*"
 }
 
 set_ucx_common_test_env() {

--- a/src/ucs/arch/bitops.h
+++ b/src/ucs/arch/bitops.h
@@ -121,10 +121,11 @@ BEGIN_C_DECLS
     ((sizeof(_n) <= 4) ? __builtin_ctz((uint32_t)(_n)) : __builtin_ctzl(_n))
 
 /* Returns the number of leading 0-bits in _n.
- * If _n is 0, the result is undefined
  */
 #define ucs_count_leading_zero_bits(_n) \
-    ((sizeof(_n) <= 4) ? __builtin_clz((uint32_t)(_n)) : __builtin_clzl(_n))
+    ((_n) ? ((sizeof(_n) <= 4) ? __builtin_clz((uint32_t)(_n)) : \
+                                 __builtin_clzl(_n)) : \
+     (int)(sizeof(_n) * 8))
 
 /* Returns the number of bits lower than 'bit_index' that are set in 'mask'
  * For example: ucs_bitmap2idx(mask=0xF0, idx=6) returns 2

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -1060,13 +1060,12 @@ size_t ucs_x86_nt_src_buffer_transfer(void *dst, const void *src, size_t len)
     return len;
 }
 
-static UCS_F_ALWAYS_INLINE
-void ucs_x86_copy_bytes_le_128(void *dst, const void *src, size_t len)
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_copy_bytes_le_128(void *dst, const void *src, uint32_t len)
 {
-#if defined (__LZCNT__)
     __m256i y0, y1, y2, y3;
     /* Handle lengths that fall usually within eager short range */
-    switch (_lzcnt_u32(len)) {
+    switch (ucs_count_leading_zero_bits(len)) {
     /* 0 */
     case 32:
         break;
@@ -1121,9 +1120,6 @@ void ucs_x86_copy_bytes_le_128(void *dst, const void *src, size_t len)
         _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 32), y3);
         break;
     }
-#else
-    memcpy(dst, src, len);
-#endif
 }
 
 /* This is an adaptation of the memcpy code from https://github.com/amd/aocl-libmem

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -138,6 +138,42 @@ UCS_TEST_F(test_bitops, is_equal) {
     test_bitops::check_bitwise_equality(buffer1, buffer2, indices, 0);
 }
 
+template<typename T> void test_clz()
+{
+    constexpr int bits = sizeof(T) * 8;
+    T v                = 1;
+
+    for (int i = bits - 1; v != 0; v <<= 1, --i) {
+        ASSERT_EQ(i, ucs_count_leading_zero_bits(v));
+    }
+
+    ASSERT_EQ(bits, ucs_count_leading_zero_bits(v));
+}
+
+UCS_TEST_F(test_bitops, clz) {
+    test_clz<uint32_t>();
+    test_clz<uint64_t>();
+    test_clz<int32_t>();
+    test_clz<int64_t>();
+    test_clz<size_t>();
+    test_clz<ssize_t>();
+}
+
+UCS_TEST_F(test_bitops, clz_type)
+{
+    EXPECT_GT(0, ucs_count_leading_zero_bits(~0LLU) - 1);
+
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(~0LLU) - 1);
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(0LLU) - 65);
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(~0U) - 1);
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(0U) - 33);
+
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(~0LL) - 1);
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(0LL) - 65);
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(~0) - 1);
+    EXPECT_EQ(UINT32_MAX, ucs_count_leading_zero_bits(0) - 33);
+}
+
 template<typename Type> void test_mask()
 {
     Type expected = 0;


### PR DESCRIPTION
## What?
Use common UCS count leading zeros function (implemented with `__builtin_clz()`) to address #10509.

## Why?
nvc 24.9 seems to have issue with `_lzcnt_u32()`. It defines it as `__builtin_ia32_lzcnt_u32()` but fails to find it at link time. But the `_lzcnt_u32()` function seems to be likely defined as `__builtin_clz()` in gcc, and is also properly linked by nvc.
