### PR TITLE
UCP/WIREUP/IB: Fix error message when FLID is not available

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -386,8 +386,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
         const ucp_wireup_criteria_t *criteria, ucp_tl_bitmap_t tl_bitmap,
         uint64_t remote_md_map, uint64_t local_dev_bitmap,
         uint64_t remote_dev_bitmap, int show_error,
-        ucp_wireup_select_info_t *select_info, char *info_str,
-        size_t info_str_size)
+        ucp_wireup_select_info_t *select_info)
 {
     UCS_STRING_BUFFER_ONSTACK(missing_flags_str,
                               UCP_WIREUP_MAX_FLAGS_STRING_SIZE);
@@ -410,6 +409,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
     ucp_rsc_index_t dev_index;
     ucp_lane_index_t lane;
     char tls_info[256];
+    char uct_info[256];
     char *p, *endp;
     uct_iface_attr_t *iface_attr;
     uct_md_attr_v2_t *md_attr;
@@ -600,13 +600,15 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             UCS_STATIC_BITMAP_AND_INPLACE(&rsc_addr_index_map, addr_index_map);
         }
 
+        /* ucp_wireup_is_reachable() can fail without filling uct_info string if
+         * none of the remote transports match the local one */
+        snprintf(uct_info, sizeof(uct_info), "not available");
         is_reachable = 0;
-
         UCS_STATIC_BITMAP_FOR_EACH_BIT(addr_index, &rsc_addr_index_map) {
             ae = &address->address_list[addr_index];
             if (!ucp_wireup_is_reachable(ep, select_params->ep_init_flags,
-                                         rsc_index, ae, info_str,
-                                         info_str_size)) {
+                                         rsc_index, ae, uct_info,
+                                         sizeof(uct_info))) {
                 /* Must be reachable device address, on same transport */
                 continue;
             }
@@ -632,9 +634,8 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
         /* If a local resource cannot reach any of the remote addresses,
          * generate debug message. */
         if (!is_reachable) {
-            snprintf(p, endp - p, UCT_TL_RESOURCE_DESC_FMT" - %s, ",
-                     UCT_TL_RESOURCE_DESC_ARG(resource),
-                     ucs_status_string(UCS_ERR_UNREACHABLE));
+            snprintf(p, endp - p, UCT_TL_RESOURCE_DESC_FMT " - %s, ",
+                     UCT_TL_RESOURCE_DESC_ARG(resource), uct_info);
             p += strlen(p);
         }
     }
@@ -929,7 +930,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
     status = ucp_wireup_select_transport(select_ctx, select_params,
                                          &mem_criteria, mem_type_tl_bitmap,
                                          remote_md_map, UINT64_MAX, UINT64_MAX,
-                                         !allow_am, &select_info, NULL, 0);
+                                         !allow_am, &select_info);
     if (status == UCS_OK) {
         /* Add to the list of lanes */
         status = ucp_wireup_add_lane(select_params, &select_info, lane_type,
@@ -975,8 +976,7 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
         status = ucp_wireup_select_transport(select_ctx, select_params,
                                              &mem_criteria, tl_bitmap,
                                              remote_md_map, UINT64_MAX,
-                                             UINT64_MAX, 0, &select_info,
-                                             NULL, 0);
+                                             UINT64_MAX, 0, &select_info);
         /* Break if: */
         /* - transport selection wasn't OK */
         if ((status != UCS_OK) ||
@@ -1447,8 +1447,7 @@ ucp_wireup_is_am_required(const ucp_wireup_select_params_t *select_params,
 static ucs_status_t
 ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
                        ucp_wireup_select_info_t *am_info,
-                       ucp_wireup_select_context_t *select_ctx,
-                       char *info_string, size_t info_string_length)
+                       ucp_wireup_select_context_t *select_ctx)
 {
     ucp_worker_h worker            = select_params->ep->worker;
     ucp_tl_bitmap_t tl_bitmap      = select_params->tl_bitmap;
@@ -1488,8 +1487,7 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
         status = ucp_wireup_select_transport(select_ctx, select_params,
                                              &criteria, tl_bitmap, UINT64_MAX,
                                              UINT64_MAX, UINT64_MAX, 1,
-                                             am_info, info_string,
-                                             info_string_length);
+                                             am_info);
         if (status != UCS_OK) {
             return status;
         }
@@ -1681,11 +1679,11 @@ ucp_wireup_add_bw_lanes_a2a(const ucp_wireup_select_params_t *select_params,
         ucs_for_each_bit(remote_dev_index, remote_dev_bitmap) {
             sinfo  = ucs_array_append(&sinfo_array, break);
             status = ucp_wireup_select_transport(select_ctx, select_params,
-                                                 &bw_info->criteria,
-                                                 tl_bitmap, UINT64_MAX,
+                                                 &bw_info->criteria, tl_bitmap,
+                                                 UINT64_MAX,
                                                  UCS_BIT(local_dev_index),
-                                                 UCS_BIT(remote_dev_index),
-                                                 0, sinfo, NULL, 0);
+                                                 UCS_BIT(remote_dev_index), 0,
+                                                 sinfo);
             if (status != UCS_OK) {
                 ucs_array_pop_back(&sinfo_array);
                 continue;
@@ -1781,8 +1779,7 @@ static int ucp_wireup_add_bw_lanes_pairwise(
             status = ucp_wireup_select_transport(select_ctx, select_params,
                                                  &bw_info->criteria, tl_bitmap,
                                                  UINT64_MAX, local_dev_bitmap,
-                                                 remote_dev_bitmap, 0, sinfo,
-                                                 NULL, 0);
+                                                 remote_dev_bitmap, 0, sinfo);
             if (status != UCS_OK) {
                 ucs_array_pop_back(&sinfo_array);
                 break;
@@ -2262,7 +2259,7 @@ ucp_wireup_add_tag_lane(const ucp_wireup_select_params_t *select_params,
     status = ucp_wireup_select_transport(select_ctx, select_params, &criteria,
                                          ucp_tl_bitmap_max, UINT64_MAX,
                                          UINT64_MAX, UINT64_MAX, 0,
-                                         &select_info, NULL, 0);
+                                         &select_info);
     if ((status == UCS_OK) &&
         (ucp_score_cmp(select_info.score,
                        am_info->score) >= 0)) {
@@ -2414,7 +2411,7 @@ ucp_wireup_add_keepalive_lane(const ucp_wireup_select_params_t *select_params,
 
     status = ucp_wireup_select_transport(select_ctx, select_params, &criteria,
                                          *tl_bitmap, UINT64_MAX, UINT64_MAX,
-                                         UINT64_MAX, 0, &select_info, NULL, 0);
+                                         UINT64_MAX, 0, &select_info);
     if (status == UCS_OK) {
         return ucp_wireup_add_lane(select_params, &select_info,
                                    UCP_LANE_TYPE_KEEPALIVE, /* show error */ 1,
@@ -2436,8 +2433,7 @@ ucp_wireup_select_context_init(ucp_wireup_select_context_t *select_ctx)
 static UCS_F_NOINLINE ucs_status_t
 ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
                         ucp_err_handling_mode_t err_mode,
-                        ucp_wireup_select_context_t *select_ctx,
-                        char *info_string, size_t info_string_length)
+                        ucp_wireup_select_context_t *select_ctx)
 {
     ucp_wireup_select_info_t am_info;
     ucs_status_t status;
@@ -2463,8 +2459,7 @@ ucp_wireup_search_lanes(const ucp_wireup_select_params_t *select_params,
 
     /* Add AM lane only after RMA/AMO was selected to be aware
      * about whether they need emulation over AM or not */
-    status = ucp_wireup_add_am_lane(select_params, &am_info, select_ctx,
-                                    info_string, info_string_length);
+    status = ucp_wireup_add_am_lane(select_params, &am_info, select_ctx);
     if (status != UCS_OK) {
         return status;
     }
@@ -2731,7 +2726,6 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_tl_bitmap_t scalable_tl_bitmap = worker->scalable_tl_bitmap;
     /* TODO: remove initialization after all ucp_wireup_add_X_lanes functions
        will support specifying a reason */
-    char wireup_info[256]              = {0};
     ucp_wireup_select_context_t select_ctx;
     ucp_wireup_select_params_t select_params;
     ucs_status_t status;
@@ -2742,8 +2736,7 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         ucp_wireup_select_params_init(&select_params, ep, ep_init_flags,
                                       remote_address, scalable_tl_bitmap, 0);
         status = ucp_wireup_search_lanes(&select_params, key->err_mode,
-                                         &select_ctx, wireup_info,
-                                         sizeof(wireup_info));
+                                         &select_ctx);
         if (status == UCS_OK) {
             goto out;
         }
@@ -2756,13 +2749,8 @@ ucp_wireup_select_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_wireup_select_params_init(&select_params, ep, ep_init_flags,
                                   remote_address, tl_bitmap, show_error);
     status = ucp_wireup_search_lanes(&select_params, key->err_mode,
-                                     &select_ctx, wireup_info,
-                                     sizeof(wireup_info));
+                                     &select_ctx);
     if (status != UCS_OK) {
-        if (wireup_info[0] != '\0') {
-            ucs_diag("destination is unreachable [%s]", wireup_info);
-        }
-
         return status;
     }
 
@@ -2803,7 +2791,7 @@ ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
     status = ucp_wireup_select_transport(&select_ctx, &select_params, &criteria,
                                          ucp_tl_bitmap_max, UINT64_MAX,
                                          UINT64_MAX, UINT64_MAX, 0,
-                                         select_info, NULL, 0);
+                                         select_info);
     if (status == UCS_OK) {
         return UCS_OK;
     }
@@ -2813,6 +2801,5 @@ ucp_wireup_select_aux_transport(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_wireup_fill_aux_criteria(&criteria, ep_init_flags, 0);
     return ucp_wireup_select_transport(&select_ctx, &select_params, &criteria,
                                        ucp_tl_bitmap_max, UINT64_MAX,
-                                       UINT64_MAX, UINT64_MAX, 1, select_info,
-                                       NULL, 0);
+                                       UINT64_MAX, UINT64_MAX, 1, select_info);
 }

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -530,9 +530,12 @@ void uct_ib_iface_address_pack(uct_ib_iface_t *iface, uct_ib_address_t *ib_addr)
  * @param [in]  ib_addr    IB address to unpack.
  * @param [out] params_p   Filled with address attributes as in
  *                         @ref uct_ib_address_pack_params_t.
+
+ * @return UCS_OK if the address was unpacked successfully, UCS_ERR_INVALID_PARAM
+ *         if the address is invalid.
  */
-void uct_ib_address_unpack(const uct_ib_address_t *ib_addr,
-                           uct_ib_address_pack_params_t *params_p);
+ucs_status_t uct_ib_address_unpack(const uct_ib_address_t *ib_addr,
+                                   uct_ib_address_pack_params_t *params_p);
 
 
 /**
@@ -622,11 +625,12 @@ void uct_ib_iface_fill_ah_attr_from_gid_lid(uct_ib_iface_t *iface, uint16_t lid,
                                             unsigned path_index,
                                             struct ibv_ah_attr *ah_attr);
 
-void uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
-                                         const uct_ib_address_t *ib_addr,
-                                         unsigned path_index,
-                                         struct ibv_ah_attr *ah_attr,
-                                         enum ibv_mtu *path_mtu);
+ucs_status_t
+uct_ib_iface_fill_ah_attr_from_addr(uct_ib_iface_t *iface,
+                                    const uct_ib_address_t *ib_addr,
+                                    unsigned path_index,
+                                    struct ibv_ah_attr *ah_attr,
+                                    enum ibv_mtu *path_mtu);
 
 ucs_status_t uct_ib_iface_pre_arm(uct_ib_iface_t *iface);
 

--- a/src/uct/ib/efa/srd/srd_ep.c
+++ b/src/uct/ib/efa/srd/srd_ep.c
@@ -62,8 +62,13 @@ static UCS_CLASS_INIT_FUNC(uct_srd_ep_t, const uct_ep_params_t *params)
     ucs_arbiter_group_init(&self->pending_group);
     ucs_list_head_init(&self->outstanding_list);
 
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
-                                        self->path_index, &ah_attr, &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
+                                                 self->path_index, &ah_attr,
+                                                 &path_mtu);
+    if (status != UCS_OK) {
+        goto err_arb_cleanup;
+    }
+
     status = uct_ib_iface_create_ah(&iface->super, &ah_attr, "SRD AH",
                                     &self->ah);
     if (status != UCS_OK) {

--- a/src/uct/ib/efa/srd/srd_iface.c
+++ b/src/uct/ib/efa/srd/srd_iface.c
@@ -789,8 +789,12 @@ static void uct_srd_iface_process_ctl(uct_srd_iface_t *iface,
                 sizeof(*ctl) + iface->super.addr_size, length);
 
     /* TODO do we need an actual non-zero path index ? */
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr, 0, &ah_attr,
-                                        &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr, 0,
+                                                 &ah_attr, &path_mtu);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
     status = uct_ib_iface_create_ah(&iface->super, &ah_attr, "SRD AH", &ah);
     if (status != UCS_OK) {
         ucs_error("iface=%p id=%u ep_uuid=%"PRIx64" qpn=%u failed to create ah"

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -513,11 +513,14 @@ uct_gga_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     enum ibv_mtu path_mtu;
     ucs_status_t status;
 
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr,
-                                        ep->super.super.path_index, &ah_attr,
-                                        &path_mtu);
-    ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
+    status = uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr,
+                                                 ep->super.super.path_index,
+                                                 &ah_attr, &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
 
+    ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
     qp_num = uct_ib_unpack_uint24(gga_ep_addr->super.qp_num);
     status = uct_rc_mlx5_iface_common_devx_connect_qp(
             iface, &ep->super.tx.wq.super, qp_num, &ah_attr, path_mtu,

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -371,7 +371,12 @@ ucs_status_t uct_ib_mlx5_get_compact_av(uct_ib_iface_t *iface, int *compact_av)
         return status;
     }
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, 0, &ah_attr, &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, 0, &ah_attr,
+                                                 &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     ah_attr.is_global = iface->config.force_global_addr;
     status = uct_ib_iface_create_ah(iface, &ah_attr, "compact AV check", &ah);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -787,9 +787,13 @@ uct_rc_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     uint32_t flush_rkey_hi;
     ucs_status_t status;
 
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr,
-                                        ep->super.super.path_index, &ah_attr,
-                                        &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(&iface->super.super, ib_addr,
+                                                 ep->super.super.path_index,
+                                                 &ah_attr, &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -645,6 +645,17 @@ static uint8_t uct_rc_mlx5_iface_get_address_type(uct_iface_h tl_iface)
                                             UCT_RC_MLX5_IFACE_ADDR_TYPE_BASIC;
 }
 
+static const char *uct_rc_mlx5_iface_tm_type_str(uint8_t tm_type)
+{
+    if (tm_type == UCT_RC_MLX5_IFACE_ADDR_TYPE_BASIC) {
+        return "basic";
+    } else if (tm_type == UCT_RC_MLX5_IFACE_ADDR_TYPE_TM) {
+        return "hw offload";
+    } else {
+        return "unknown";
+    }
+}
+
 static ucs_status_t uct_rc_mlx5_iface_get_address(uct_iface_h tl_iface,
                                                   uct_iface_addr_t *addr)
 {
@@ -657,7 +668,6 @@ static int
 uct_rc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                   const uct_iface_is_reachable_params_t *params)
 {
-    static const char *tm_type_to_str[] = {"basic", "tag matching"};
     uint8_t my_type = uct_rc_mlx5_iface_get_address_type(tl_iface);
     uint8_t remote_type;
     const uct_iface_addr_t *iface_addr;
@@ -668,10 +678,11 @@ uct_rc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
     /* Check hardware tag matching compatibility */
     if ((iface_addr != NULL) &&
         ((remote_type = *(uint8_t*)iface_addr) != my_type)) {
-        uct_iface_fill_info_str_buf(
-                    params, "incompatible hardware tag matching. "
-                    "%s (local) vs %s (remote)",
-                    tm_type_to_str[my_type], tm_type_to_str[remote_type]);
+        uct_iface_fill_info_str_buf(params,
+                                    "incompatible hardware tag matching. "
+                                    "%s (local) vs %s (remote)",
+                                    uct_rc_mlx5_iface_tm_type_str(my_type),
+                                    uct_rc_mlx5_iface_tm_type_str(remote_type));
         return 0;
     }
 

--- a/src/uct/ib/mlx5/ud/ud_mlx5_common.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5_common.c
@@ -45,8 +45,12 @@ uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
     struct ibv_ah_attr  ah_attr;
     enum ibv_mtu        path_mtu;
 
-    uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, path_index, &ah_attr,
-                                        &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, path_index,
+                                                 &ah_attr, &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     status = uct_ib_iface_create_ah(iface, &ah_attr, usage, &ah);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -643,9 +643,13 @@ uct_rc_verbs_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     struct ibv_ah_attr ah_attr;
     enum ibv_mtu path_mtu;
 
-    uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
-                                        ep->super.path_index, &ah_attr,
-                                        &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
+                                                 ep->super.path_index, &ah_attr,
+                                                 &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     ucs_assert(path_mtu != UCT_IB_ADDRESS_INVALID_PATH_MTU);
 
     qp_num = uct_ib_unpack_uint24(rc_addr->super.qp_num);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -597,8 +597,12 @@ uct_ud_verbs_iface_unpack_peer_address(uct_ud_iface_t *iface,
 
     memset(peer_address, 0, sizeof(*peer_address));
 
-    uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, path_index,
-                                        &ah_attr, &path_mtu);
+    status = uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, path_index,
+                                                 &ah_attr, &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     status = uct_ib_iface_create_ah(ib_iface, &ah_attr, "UD verbs connect",
                                     &peer_address->ah);
     if (status != UCS_OK) {

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -126,6 +126,7 @@ gtest_SOURCES = \
 	uct/test_pending.cc \
 	uct/test_progress.cc \
 	uct/test_uct_ep.cc \
+	uct/test_uct_iface.cc \
 	uct/test_uct_perf.cc \
 	uct/v2/test_uct_query.cc \
 	uct/test_zcopy_comp.cc \

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -109,7 +109,7 @@ public:
         uct_ib_address_pack(&pack_params, ib_addr);
 
         uct_ib_address_pack_params_t unpack_params;
-        uct_ib_address_unpack(ib_addr, &unpack_params);
+        ASSERT_UCS_OK(uct_ib_address_unpack(ib_addr, &unpack_params));
 
         if (uct_ib_iface_is_roce(iface)) {
             EXPECT_TRUE(iface->config.force_global_addr);
@@ -202,7 +202,7 @@ UCS_TEST_P(test_uct_ib_addr, address_pack_path_mtu, "IB_PATH_MTU=2048")
     uct_ib_address_t *addr = (uct_ib_address_t*)&buffer[0];
     uct_ib_iface_address_pack(iface, addr);
     uct_ib_address_pack_params_t params;
-    uct_ib_address_unpack(addr, &params);
+    ASSERT_UCS_OK(uct_ib_address_unpack(addr, &params));
     EXPECT_TRUE(params.flags & UCT_IB_ADDRESS_PACK_FLAG_PATH_MTU);
     EXPECT_EQ(IBV_MTU_2048, params.path_mtu);
 }
@@ -464,7 +464,7 @@ public:
                                    UCT_IB_MLX5_DP_ORDERING_OOO_ALL);
         return rc_has_ddp || dc_has_ddp;
     }
-    
+
     void test_check_ib_sl_config() {
         const char *max_avail_sl_str = getenv("GTEST_MAX_IB_SL");
         uint8_t sl, max_avail_sl;

--- a/test/gtest/uct/ib/test_ib_pkey.cc
+++ b/test/gtest/uct/ib/test_ib_pkey.cc
@@ -135,7 +135,7 @@ protected:
         uct_ib_address_pack_params_t params;
 
         uct_ib_iface_address_pack(iface, ib_addr);
-        uct_ib_address_unpack(ib_addr, &params);
+        ASSERT_UCS_OK(uct_ib_address_unpack(ib_addr, &params));
         EXPECT_TRUE(params.flags & UCT_IB_ADDRESS_PACK_FLAG_PKEY);
         EXPECT_EQ(m_pkey[0], params.pkey);
 

--- a/test/gtest/uct/ib/test_ud_ds.cc
+++ b/test/gtest/uct/ib/test_ud_ds.cc
@@ -107,8 +107,8 @@ unsigned test_ud_ds::N = 1000;
 UCS_TEST_P(test_ud_ds, if_addr) {
     uct_ib_address_pack_params_t unpack_params1, unpack_params2;
 
-    uct_ib_address_unpack(ib_adr1, &unpack_params1);
-    uct_ib_address_unpack(ib_adr2, &unpack_params2);
+    ASSERT_UCS_OK(uct_ib_address_unpack(ib_adr1, &unpack_params1));
+    ASSERT_UCS_OK(uct_ib_address_unpack(ib_adr2, &unpack_params2));
     EXPECT_EQ(unpack_params1.lid, unpack_params2.lid);
     EXPECT_EQ(unpack_params1.gid.global.subnet_prefix,
               unpack_params2.gid.global.subnet_prefix);

--- a/test/gtest/uct/test_uct_iface.cc
+++ b/test/gtest/uct/test_uct_iface.cc
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+extern "C" {
+#include <uct/api/uct.h>
+}
+#include "uct_test.h"
+
+
+class test_uct_iface : public uct_test {
+protected:
+    void init()
+    {
+        uct_test::init();
+        m_entities.push_back(uct_test::create_entity(0));
+    }
+
+    entity &get_entity()
+    {
+        return *m_entities.front();
+    }
+
+    void test_is_reachable();
+
+    virtual bool is_self_reachable() const
+    {
+        return true;
+    }
+};
+
+void test_uct_iface::test_is_reachable()
+{
+    const auto &iface_attr = get_entity().iface_attr();
+    auto iface             = get_entity().iface();
+    uct_iface_is_reachable_params_t params;
+    ucs_status_t status;
+
+    std::string dev_addr(ucs_max(iface_attr.device_addr_len, 4096), '\0');
+    std::string iface_addr(ucs_max(iface_attr.iface_addr_len, 4096), '\0');
+
+    char info_str[256];
+    params.field_mask         = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                                UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
+                                UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING |
+                                UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING_LENGTH |
+                                UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
+                                UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH;
+    params.info_string        = info_str;
+    params.info_string_length = sizeof(info_str);
+    params.device_addr        = (uct_device_addr_t*)&dev_addr[0];
+    params.device_addr_length = iface_attr.device_addr_len;
+    params.iface_addr         = (uct_iface_addr_t*)&iface_addr[0];
+    params.iface_addr_length  = iface_attr.iface_addr_len;
+
+    status = uct_iface_get_device_address(iface,
+                                          (uct_device_addr_t*)&dev_addr[0]);
+    ASSERT_UCS_OK(status);
+
+    status = uct_iface_get_address(iface, (uct_iface_addr_t*)&iface_addr[0]);
+    ASSERT_UCS_OK(status);
+
+    bool is_reachable = uct_iface_is_reachable_v2(iface, &params);
+    EXPECT_EQ(is_self_reachable(), is_reachable);
+
+    // Allocate corrupted address buffers, make it larger than the correct
+    // buffer size in case the corrupted data indicates a larger address length
+    // Some random buffers could still be reachable, so we fail if too many of
+    // them are reachable.
+    params.device_addr_length = dev_addr.size();
+    params.iface_addr_length  = iface_addr.size();
+    bool found_unreachable    = false;
+    for (int i = 0; i < 100; ++i) {
+        std::generate(dev_addr.begin(), dev_addr.end(), ucs::rand);
+        std::generate(iface_addr.begin(), iface_addr.end(), ucs::rand);
+
+        // Corrupted device and iface address should not be reachable, and should
+        // provide the reason in the info string
+        is_reachable = uct_iface_is_reachable_v2(iface, &params);
+        if (!is_reachable) {
+            if (i < 3) {
+                // Print only first 3 info strings to not flood the output
+                UCS_TEST_MESSAGE << info_str;
+            }
+            ASSERT_FALSE(std::string(info_str).empty());
+            found_unreachable = true;
+        }
+    }
+
+    EXPECT_TRUE(found_unreachable);
+}
+
+UCS_TEST_P(test_uct_iface, is_reachable)
+{
+    test_is_reachable();
+}
+
+UCT_INSTANTIATE_TEST_CASE(test_uct_iface)
+
+class test_uct_iface_self_unreachable : public test_uct_iface {
+protected:
+    bool is_self_reachable() const override
+    {
+        return false;
+    }
+};
+
+UCS_TEST_P(test_uct_iface_self_unreachable, is_reachable)
+{
+    test_is_reachable();
+}
+
+UCT_INSTANTIATE_CUDA_IPC_TEST_CASE(test_uct_iface_self_unreachable)


### PR DESCRIPTION
Before:

`[1740477778.122527] [swx-ucx-ibr-03:1950035:0]          select.c:641  UCX  ERROR   no active messages transport to <no debug data>: self/memory - Destination is unreachable, rc_verbs/mlx5_0:1 - Destination is unreachable`


After:

`[1740487396.304113] [swx-ucx-ibr-03:1951997:0]          select.c:642  UCX  ERROR   no active messages transport to swx-ucx-ibr-01:3618365: self/memory - unreachable, rc_verbs/mlx5_0:1 - different subnet prefix 0xfec0000000000002/0xfec0000000000001 and FLID is not available`
