### PR TITLE
DOC/RTD: Fix OpenMPI clone command to include submodules

### DIFF
--- a/docs/source/running.md
+++ b/docs/source/running.md
@@ -66,7 +66,7 @@ improvements.
 
 1. Get latest-and-greatest OpenMPI version:
   ```
-  $ git clone https://github.com/open-mpi/ompi.git
+  $ git clone --recurse-submodules  https://github.com/open-mpi/ompi.git
   $ cd ompi
   $ ./autogen.pl
   ```


### PR DESCRIPTION
## Why
Fixes #9804