### PR TITLE
UCT/DC: Fix VFS objects for DCIs and pools

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -106,7 +106,8 @@ ForEachMacros: ['UCS_STATIC_BITMAP_FOR_EACH_BIT',
                 'UCS_INIT_ONCE',
                 'UCS_TEST_F',
                 'UCX_PERF_TEST_FOREACH',
-		'ucs_lru_for_each']
+                'uct_dc_iface_for_each_valid_dci',
+                'ucs_lru_for_each']
 StatementMacros : []
 TypenameMacros: ['khash_t',
                  'ucs_array_s',

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -725,7 +725,7 @@ ucs_status_t uct_ep_create(const uct_ep_params_t *params, uct_ep_h *ep_p)
     if (params->field_mask & UCT_EP_PARAM_FIELD_IFACE) {
         status = params->iface->ops.ep_create(params, ep_p);
         if (status == UCS_OK) {
-            ucs_vfs_obj_set_dirty(params->iface, uct_iface_vfs_refresh);
+            uct_iface_vfs_set_dirty(params->iface);
         }
 
         return status;

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -1031,7 +1031,7 @@ void uct_ep_set_iface(uct_ep_h ep, uct_iface_t *iface);
 
 ucs_status_t uct_base_ep_stats_reset(uct_base_ep_t *ep, uct_base_iface_t *iface);
 
-void uct_iface_vfs_refresh(void *obj);
+void uct_iface_vfs_set_dirty(uct_iface_h iface);
 
 ucs_status_t uct_ep_invalidate(uct_ep_h ep, unsigned flags);
 

--- a/src/uct/base/uct_iface_vfs.c
+++ b/src/uct/base/uct_iface_vfs.c
@@ -134,7 +134,7 @@ uct_iface_vfs_init_cap_limits(uct_iface_h iface, uint64_t iface_cap_flags)
     }
 }
 
-void uct_iface_vfs_refresh(void *obj)
+static void uct_iface_vfs_refresh(void *obj)
 {
     uct_base_iface_t *iface = obj;
     uct_iface_attr_t iface_attr;
@@ -149,4 +149,9 @@ void uct_iface_vfs_refresh(void *obj)
     }
 
     iface->internal_ops->iface_vfs_refresh(&iface->super);
+}
+
+void uct_iface_vfs_set_dirty(uct_iface_h iface)
+{
+    ucs_vfs_obj_set_dirty(iface, uct_iface_vfs_refresh);
 }

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -254,7 +254,7 @@ ucs_status_t uct_iface_open(uct_md_h md, uct_worker_h worker,
 
     ucs_vfs_obj_add_dir(worker, *iface_p, "iface/%p", *iface_p);
     ucs_vfs_obj_add_sym_link(*iface_p, md, "memory_domain");
-    ucs_vfs_obj_set_dirty(*iface_p, uct_iface_vfs_refresh);
+    uct_iface_vfs_set_dirty(*iface_p);
 
     return UCS_OK;
 }

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.h
@@ -388,6 +388,8 @@ uct_dc_mlx5_dci_pool_init_dci(uct_dc_mlx5_iface_t *iface, uint8_t pool_index,
         dci->flags |= UCT_DC_DCI_FLAG_SHARED;
     }
 
+    uct_iface_vfs_set_dirty(&iface->super.super.super.super.super);
+
     return UCS_OK;
 
 err_destroy:
@@ -444,25 +446,6 @@ uct_dc_mlx5_iface_dci_can_alloc(uct_dc_mlx5_iface_t *iface, uint8_t pool_index)
     uct_dc_mlx5_dci_pool_t *pool = &iface->tx.dci_pool[pool_index];
 
     return ucs_likely(pool->stack_top < iface->tx.ndci);
-}
-
-static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_iface_dcis_array_copy(void *dst, void *src, size_t length)
-{
-    uct_dc_dci_t *src_dcis = (uct_dc_dci_t*)src;
-    uct_dc_dci_t *dst_dcis = (uct_dc_dci_t*)dst;
-    size_t i;
-
-    memcpy(dst_dcis, src_dcis, sizeof(uct_dc_dci_t) * length);
-
-    /* txqp is a queue and need to splice tail */
-    for (i = 0; i < length; ++i) {
-        if (uct_dc_mlx5_is_dci_valid(&src_dcis[i])) {
-            ucs_queue_head_init(&dst_dcis[i].txqp.outstanding);
-            ucs_queue_splice(&dst_dcis[i].txqp.outstanding,
-                             &src_dcis[i].txqp.outstanding);
-        }
-    }
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -576,12 +576,11 @@ public:
         uct_dc_mlx5_iface_t *iface      = ucs_derived_of(e->iface(),
                                                          uct_dc_mlx5_iface_t);
         uct_dc_mlx5_pool_stack_t *stack = &iface->tx.dci_pool[0].stack;
-        uct_dc_dci_t **dci;
+        uct_dci_index_t dci_index;
+        uct_dc_dci_t *dci;
 
-        ucs_array_for_each(dci, &iface->tx.dcis) {
-            if (uct_dc_mlx5_is_dci_valid(*dci)) {
-                uct_rc_txqp_available_set(&(*dci)->txqp, 0);
-            }
+        uct_dc_iface_for_each_valid_dci(dci_index, dci, iface) {
+            uct_rc_txqp_available_set(&dci->txqp, 0);
         }
 
         for (int i = ucs_array_length(stack); i < iface->tx.ndci; i++) {
@@ -593,12 +592,11 @@ public:
     virtual void enable_entity(entity *e, unsigned cq_num = 128) {
         uct_dc_mlx5_iface_t *iface = ucs_derived_of(e->iface(),
                                                     uct_dc_mlx5_iface_t);
-        uct_dc_dci_t **dci;
+        uct_dci_index_t dci_index;
+        uct_dc_dci_t *dci;
 
-        ucs_array_for_each(dci, &iface->tx.dcis) {
-            if (uct_dc_mlx5_is_dci_valid(*dci)) {
-                uct_rc_txqp_available_set(&(*dci)->txqp, (*dci)->txwq.bb_max);
-            }
+        uct_dc_iface_for_each_valid_dci(dci_index, dci, iface) {
+            uct_rc_txqp_available_set(&dci->txqp, dci->txwq.bb_max);
         }
 
         ucs_array_length(&iface->tx.dci_pool[0].stack) = 0;


### PR DESCRIPTION
## Why
- Fix a segfault when trying to show non-existing DCIs in VFS
- Add more details about DCIs and pools to VFS
