### PR TITLE
UCS/ARCH/BITOPS: Use same input/output variable

### DIFF
--- a/src/ucs/arch/x86_64/bitops.h
+++ b/src/ucs/arch/x86_64/bitops.h
@@ -13,38 +13,34 @@
 
 static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
 {
-    uint32_t result;
     asm("bsfl %1,%0"
-        : "=r" (result)
+        : "=r" (n)
         : "r" (n));
-    return result;
+    return n;
 }
 
 static UCS_F_ALWAYS_INLINE unsigned ucs_ffs64(uint64_t n)
 {
-    uint64_t result;
     asm("bsfq %1,%0"
-        : "=r" (result)
+        : "=r" (n)
         : "r" (n));
-    return result;
+    return n;
 }
 
 static UCS_F_ALWAYS_INLINE unsigned __ucs_ilog2_u32(uint32_t n)
 {
-    uint32_t result;
     asm("bsrl %1,%0"
-        : "=r" (result)
+        : "=r" (n)
         : "r" (n));
-    return result;
+    return n;
 }
 
 static UCS_F_ALWAYS_INLINE unsigned __ucs_ilog2_u64(uint64_t n)
 {
-    uint64_t result;
     asm("bsrq %1,%0"
-        : "=r" (result)
+        : "=r" (n)
         : "r" (n));
-    return result;
+    return n;
 }
 
 #endif

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -54,9 +54,9 @@ void test_ilog2()
 
     for (auto i = 1; i < sizeof(T) * 8; ++i) {
         auto value = (bit << i);
-        ASSERT_EQ(i, ucs_ilog2(value));
+        EXPECT_EQ(i, ucs_ilog2(value));
         value--;
-        ASSERT_EQ(i - 1, ucs_ilog2(value));
+        EXPECT_EQ(i - 1, ucs_ilog2(value));
     }
 }
 

--- a/test/gtest/ucs/test_bitops.cc
+++ b/test/gtest/ucs/test_bitops.cc
@@ -38,13 +38,31 @@ UCS_TEST_F(test_bitops, ffs64) {
     EXPECT_EQ(41u, ucs_ffs64(1ull << 41));
 }
 
-UCS_TEST_F(test_bitops, ilog2) {
+UCS_TEST_F(test_bitops, ilog2_constant) {
     EXPECT_EQ(0u, ucs_ilog2(1));
     EXPECT_EQ(2u, ucs_ilog2(4));
     EXPECT_EQ(2u, ucs_ilog2(5));
     EXPECT_EQ(2u, ucs_ilog2(7));
     EXPECT_EQ(14u, ucs_ilog2(17000));
     EXPECT_EQ(40u, ucs_ilog2(1ull << 40));
+}
+
+template<typename T>
+void test_ilog2()
+{
+    constexpr T bit = 1;
+
+    for (auto i = 1; i < sizeof(T) * 8; ++i) {
+        auto value = (bit << i);
+        ASSERT_EQ(i, ucs_ilog2(value));
+        value--;
+        ASSERT_EQ(i - 1, ucs_ilog2(value));
+    }
+}
+
+UCS_TEST_F(test_bitops, ilog2) {
+    test_ilog2<uint32_t>();
+    test_ilog2<uint64_t>();
 }
 
 UCS_TEST_F(test_bitops, popcount) {


### PR DESCRIPTION
## What?
Address ngc issue #9774:
```shell
<inline asm>:1:7: error: invalid operand for instruction
        bsfl %al,%eax
             ^~~
```
## Why?
Seems compiler fails to understand that `bsfl` does not take 8bits registers, and erroneously optimizes `bsfl %al,%eax` from:
```C
    uint8_t pool_index;
...
    pool_index = ucs_ffs32(iface->tx.dci_pool_release_bitmap);
```
```C
static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
{
    uint32_t result;
    asm("bsfl %1,%0"
        : "=r" (result)
        : "r" (n));
    return result;
}
```

## How?
Seems forcing output variable to `n` is enough for it keep 32 bits register for %1. We still see reg %0 and %1 different. 

Alternatively there was the option to force using same input/output register with the code below, but this seemed to be more constrained approach.

```C
static UCS_F_ALWAYS_INLINE unsigned ucs_ffs32(uint32_t n)
{
    asm("bsfl %0,%0"
        : "=r" (n)
        : "0" (n));
    return n;
}
```