### PR TITLE
UCP/WIREUP: reuse ucp_score_cmp

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -828,7 +828,7 @@ static int ucp_wireup_compare_score(const void *elem1, const void *elem2,
     score2 = (*lane2 == UCP_NULL_LANE) ? 0.0 : lanes[*lane2].score[lane_type];
 
     /* sort from highest score to lowest */
-    return (score1 < score2) ? 1 : ((score1 > score2) ? -1 : 0);
+    return -ucp_score_cmp(score1, score2);
 }
 
 static int ucp_wireup_compare_lane_am_bw_score(const void *elem1, const void *elem2,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -827,7 +827,7 @@ static int ucp_wireup_compare_score(const void *elem1, const void *elem2,
     score1 = (*lane1 == UCP_NULL_LANE) ? 0.0 : lanes[*lane1].score[lane_type];
     score2 = (*lane2 == UCP_NULL_LANE) ? 0.0 : lanes[*lane2].score[lane_type];
 
-    /* sort from highest score to lowest */
+    /* reverse the value of ucp_score_cmp to sort scores in descending order */
     return -ucp_score_cmp(score1, score2);
 }
 


### PR DESCRIPTION
## What?
reuse ucp_score_cmp

## Why?
stable lanes sorting and code unification
