### PR TITLE
TOOLS/INFO: Validate -m flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Nathan Hjelm <hjelmn@lanl.gov>
 Netanel Yosephian <netanelyo@mellanox.com>
 Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>
+Ovidiu Mara <ovidium@nvidia.com>
 Pak Lui <Pak.Lui@amd.com>
 Pavan Balaji <balaji@anl.gov>
 Pavel Shamis (Pasha) <pasharesearch@gmail.com>

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1474,7 +1474,7 @@ void ucp_mem_print_info(const char *mem_spec, ucp_context_h context,
     ucp_mem_map_params_t mem_params;
     char mem_types_buf[128];
     ssize_t mem_type_value;
-    size_t mem_size_value;
+    ssize_t mem_size_value;
     char memunits_str[32];
     ucs_status_t status;
     char *mem_size_str;
@@ -1491,6 +1491,11 @@ void ucp_mem_print_info(const char *mem_spec, ucp_context_h context,
     status       = ucs_str_to_memunits(mem_size_str, &mem_size_value);
     if (status != UCS_OK) {
         printf("<Failed to convert a memunits string>\n");
+        return;
+    }
+
+    if (mem_size_value <= 0) {
+        printf("<Memory size must be greater than 0>\n");
         return;
     }
 

--- a/test/gtest/ucs/test_string.cc
+++ b/test/gtest/ucs/test_string.cc
@@ -157,6 +157,76 @@ UCS_TEST_F(test_string, split) {
     }
 }
 
+UCS_TEST_F(test_string, to_memunits) {
+    size_t value;
+
+    // Just a number
+    {
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("123", &value));
+        EXPECT_EQ(123, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("0", &value));
+        EXPECT_EQ(0, value);
+    }
+    // Invalid values
+    {
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, ucs_str_to_memunits("abc", &value));
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, ucs_str_to_memunits("", &value));
+    }
+
+    // Number and 'b'
+    {
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("123B", &value));
+        EXPECT_EQ(123, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("123b", &value));
+        EXPECT_EQ(123, value);
+    }
+    // Invalid values
+    {
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, ucs_str_to_memunits("123!", &value));
+    }
+
+    // Number and multiplier
+    {
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("2k", &value));
+        EXPECT_EQ(2 * UCS_KBYTE, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("2M", &value));
+        EXPECT_EQ(2 * UCS_MBYTE, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("1G", &value));
+        EXPECT_EQ(1 * UCS_GBYTE, value);
+    }
+
+    // Number and multiplier and 'b'
+    {
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("2kb", &value));
+        EXPECT_EQ(2 * UCS_KBYTE, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("2KB", &value));
+        EXPECT_EQ(2 * UCS_KBYTE, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("2kB", &value));
+        EXPECT_EQ(2 * UCS_KBYTE, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("2MB", &value));
+        EXPECT_EQ(2 * UCS_MBYTE, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("1GB", &value));
+        EXPECT_EQ(1 * UCS_GBYTE, value);
+    }
+
+    // Special values
+    {
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("inf", &value));
+        EXPECT_EQ(UCS_MEMUNITS_INF, value);
+
+        EXPECT_EQ(UCS_OK, ucs_str_to_memunits("auto", &value));
+        EXPECT_EQ(UCS_MEMUNITS_AUTO, value);
+    }
+}
+
 class test_string_buffer : public ucs::test {
 protected:
     void test_fixed(ucs_string_buffer_t *strb, size_t capacity);


### PR DESCRIPTION
## What?
Fix input validation for -m flag in ucx_info, to allow only positive memory size values

## Why?

### Before:
```
ucx_info -u a -m -1,host
[1740736432.183591] [rock16:2056552:0]             sys.c:924  UCX  ERROR   shmget(size=0 flags=0xfb0) for user memory failed: Invalid argument, please check shared memory limits by 'ipcs -l'
[1740736432.183613] [rock16:2056552:0]             sys.c:924  UCX  ERROR   shmget(size=0 flags=0x7b0) for user memory failed: Invalid argument, please check shared memory limits by 'ipcs -l'
[1740736432.183621] [rock16:2056552:0]         mm_sysv.c:114  UCX  ERROR   failed to allocate 18446744073709551615 bytes with mm for user memory
[1740736432.183628] [rock16:2056552:0]         uct_mem.c:161  UCX  ERROR   failed to allocate 18446744073709551615 bytes using md sysv for user memory: Out of memory
[1740736445.064992] [rock16:2056552:0]        mm_posix.c:208  UCX  ERROR   Not enough memory to write total of 18446744073709551615 bytes. Please check that /dev/shm or the directory you specified has more available memory.
[1740736448.669457] [rock16:2056552:0]         uct_mem.c:161  UCX  ERROR   failed to allocate 18446744073709551615 bytes using md posix for user memory: Out of memory
#
# UCP memory allocation
#
#  allocated 0 at address 0x7f4ff8200000 with thp, pagesize: 4K
#  registered on: self mlx5_0 mlx5_1 mlx5_2 mlx5_1 knem
#
<Failed to pack rkey: Invalid parameter>
[rock16:2056552:0:2056552]    rcache.inl:89   Assertion `region->refcount > 0' failed

/.autodirect/mtrswgwork/ovidium/ucx/src/ucs/memory/rcache.inl: [ ucs_rcache_region_put_unsafe() ]
      ...
       86 {
       87     ucs_rcache_region_lru_add(rcache, region);
       88
==>    89     ucs_assert(region->refcount > 0);
       90     if (ucs_unlikely(--region->refcount == 0)) {
       91         ucs_mem_region_destroy_internal(rcache, region, 0);
       92     }

==== backtrace (tid:2056552) ====
 0 0x00000000000582d6 ucs_rcache_region_put_unsafe()  /.autodirect/mtrswgwork/ovidium/ucx/src/ucs/memory/rcache.inl:89
 1 0x00000000000582d6 ucp_memh_put_rcache()  /.autodirect/mtrswgwork/ovidium/ucx/src/ucp/core/ucp_mm.c:421
 2 0x00000000000583f7 ucp_memh_cleanup()  /.autodirect/mtrswgwork/ovidium/ucx/src/ucp/core/ucp_mm.c:450
 3 0x000000000005b592 ucp_mem_unmap()  /.autodirect/mtrswgwork/ovidium/ucx/src/ucp/core/ucp_mm.c:1166
 4 0x000000000005cb8e ucp_mem_print_info()  /.autodirect/mtrswgwork/ovidium/ucx/src/ucp/core/ucp_mm.c:1571
 5 0x0000000000403c27 print_ucp_info()  /.autodirect/mtrswgwork/ovidium/ucx/src/tools/info/proto_info.c:382
 6 0x0000000000402ced main()  /.autodirect/mtrswgwork/ovidium/ucx/src/tools/info/ucx_info.c:318
 7 0x000000000003aca3 __libc_start_main()  ???:0
 8 0x0000000000402dfe _start()  ???:0
=================================
```

```
ucx_info -u a -m 0,host
#
# UCP memory allocation
#
#  allocated 0 at address (nil) with [rock16:2059140:0:2059140] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
==== backtrace (tid:2059140) ====
 0 0x0000000000012ce0 __funlockfile()  :0
 1 0x00000000000ccc95 __strlen_avx2()  :0
 2 0x0000000000087f69 __GI__IO_fputs()  :0
 3 0x000000000005cc26 ucp_mem_print_info()  /.autodirect/mtrswgwork/ovidium/ucx/src/ucp/core/ucp_mm.c:1541
 4 0x0000000000403c27 print_ucp_info()  /.autodirect/mtrswgwork/ovidium/ucx/src/tools/info/proto_info.c:382
 5 0x0000000000402ced main()  /.autodirect/mtrswgwork/ovidium/ucx/src/tools/info/ucx_info.c:318
 6 0x000000000003aca3 __libc_start_main()  ???:0
 7 0x0000000000402dfe _start()  ???:0
=================================
```

### After:
```
ucx_info -u a -m -1,host
<Memory size must be greater than 0>
```

```
ucx_info -u a -m 0,host
<Memory size must be greater than 0>
```