### PR TITLE
CONTRIB/MOCK: Add drop and reordering

### DIFF
--- a/buildlib/pr/efa.yml
+++ b/buildlib/pr/efa.yml
@@ -18,13 +18,13 @@ jobs:
         fetchDepth: 100
         retryCountOnTaskFailure: 5
       - bash: |
-          ./contrib/test_efa.sh build_efa
+          ./contrib/test_efa.sh build
         displayName: Build rdma-core and ibmock
       - bash: |
-          ./contrib/test_efa.sh gtest_efa
+          ./contrib/test_efa.sh gtest
         displayName: Run gtests
       - bash: |
-          ./contrib/test_efa.sh install_rdma_core_efa
+          ./contrib/test_efa.sh install_rdma_core
         displayName: Setup rmda-core
       - bash: |
           ./contrib/test_efa.sh test_rpm_efa

--- a/contrib/ibmock/efa.c
+++ b/contrib/ibmock/efa.c
@@ -36,7 +36,10 @@ struct ibv_qp *efadv_create_driver_qp_impl(struct ibv_pd           *pd,
 {
     struct fake_qp *fqp;
 
-    fqp           = create_fqp(pd, attr);
+    fqp = create_fqp(pd, attr);
+    if (fqp == NULL) {
+        return NULL;
+    }
 
     fqp->qp_ex.wr_start        = dev_qp_wr_start;
     fqp->qp_ex.wr_rdma_read    = dev_qp_wr_rdma_read;

--- a/contrib/ibmock/fake.h
+++ b/contrib/ibmock/fake.h
@@ -46,11 +46,16 @@ struct fake_qp {
 
     /* Posted receives */
     struct list        recv_reqs;
+
+    unsigned           rx_drop;   /* drop count per million */
 };
 
 struct fake_cq {
-    struct ibv_cq cq;
-    struct list   wcs;
+    struct ibv_cq  cq;
+    struct list    wcs;
+    unsigned       wcs_count;  /* inserted count of cqe */
+    unsigned       poll_count; /* cq poll without returned cqe */
+    int            is_ooo;     /* read it out of order */
 };
 
 struct fake_cqe {

--- a/contrib/ibmock/verbs.c
+++ b/contrib/ibmock/verbs.c
@@ -15,9 +15,11 @@
 #include <stdbool.h>
 #include <unistd.h>
 
-#define NUM_DEVS   2
-#define SYS_PATH   "/tmp/ibmock"
-#define DUMMY_PKEY 65535         /* Dummy pkey with full membership for now */
+#define NUM_DEVS    2
+#define SYS_PATH    "/tmp/ibmock"
+#define DUMMY_PKEY  65535 /* Dummy pkey with full membership for now */
+#define ONE_MILLION 1000000
+
 
 static pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -220,7 +222,7 @@ rx_send(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
         return (fqp->qp_ex.qp_base.qp_type == IBV_QPT_UD) ? 0 : -ENOENT;
     }
 
-    if (fqp->rx_drop && (((unsigned)rand() % 1000000) < fqp->rx_drop)) {
+    if (fqp->rx_drop && (((unsigned)rand() % ONE_MILLION) < fqp->rx_drop)) {
         return 0; /* Operation is dropped, TX CQE will be called */
     }
 

--- a/contrib/ibmock/verbs.c
+++ b/contrib/ibmock/verbs.c
@@ -17,7 +17,7 @@
 
 #define NUM_DEVS   2
 #define SYS_PATH   "/tmp/ibmock"
-#define DUMMY_PKEY 65535 /* Dummy pkey with full membership for now */
+#define DUMMY_PKEY 65535         /* Dummy pkey with full membership for now */
 
 static pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -37,6 +37,24 @@ enum be_mode {
     BE_NOTSET,
     BE_LOOPBACK
 };
+
+/* Packet drop per million */
+static unsigned ibmock_drop_rate(void)
+{
+    static int rate = -1;
+    const char *str;
+
+    if (rate < 0) {
+        rate = 0;
+        str  = getenv("IBMOCK_DROP_RATE");
+        if (str) {
+            rate = atoi(str);
+            printf("ibmock drop_rate=%u\n", rate);
+        }
+    }
+
+    return rate;
+}
 
 static enum be_mode be_mode_get(void)
 {
@@ -199,7 +217,11 @@ rx_send(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
     size_t src_off, dst_off, total = 0;
 
     if (list_is_empty(&fqp->recv_reqs)) {
-        return 1;
+        return (fqp->qp_ex.qp_base.qp_type == IBV_QPT_UD) ? 0 : -ENOENT;
+    }
+
+    if (fqp->rx_drop && (((unsigned)rand() % 1000000) < fqp->rx_drop)) {
+        return 0; /* Operation is dropped, TX CQE will be called */
     }
 
     src_off = sizeof(*hdr);
@@ -220,7 +242,7 @@ rx_send(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
                 dst_off = 0;
                 if (j >= wr->num_sge) {
                     fprintf(stderr, "ibmock: error: posted RX too short\n");
-                    return -1;
+                    return -ENOSPC;
                 }
             }
 
@@ -242,7 +264,8 @@ rx_send(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
 
     fcq = (struct fake_cq*)fqp->qp_ex.qp_base.recv_cq;
     list_add_tail(&fcq->wcs, &recv->fcqe.list);
-    return 1;
+    fcq->wcs_count++;
+    return 0;
 }
 
 static int
@@ -267,7 +290,7 @@ rx_rdma(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
     if (!found) {
         fprintf(stderr, "ibmock: rx rdma rkey not found PD of QP#%d\n",
                fqp->qp_ex.qp_base.qp_num);
-        return 0;
+        return EINVAL;
     }
 
     i       = 0;
@@ -281,7 +304,7 @@ rx_rdma(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
 
         if (i >= count) {
             fprintf(stderr, "ibmock: IO error\n");
-            return 0;
+            return ENOSPC;
         }
 
         len = min(sizeof(dest) - dst_off, iov[i].iov_len - src_off);
@@ -297,10 +320,12 @@ rx_rdma(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
     }
 
     assert(total == hdr->rdma.len);
-    return 1;
+    return 0;
 }
 
-static int dev_rx_cb(struct iovec *iov, int count)
+/* returning >=0 triggers CQE, <0 ibv_post_send() error */
+static int dev_rx_cb(struct fake_qp *local_fqp,
+                     struct iovec *iov, int count)
 {
     struct fake_hdr *hdr = iov[0].iov_base;
     uint8_t *gid         = hdr->gid.raw;
@@ -309,7 +334,7 @@ static int dev_rx_cb(struct iovec *iov, int count)
     int ret;
 
     if (gid[13] != be_mode_get()) {
-        return 0; /* not ours */
+        return -EINVAL; /* not ours */
     }
 
     /* Lookup QP */
@@ -321,7 +346,7 @@ static int dev_rx_cb(struct iovec *iov, int count)
     }
 
     if (fqp == NULL) {
-        return 1;
+        return (local_fqp->qp_ex.qp_base.qp_type == IBV_QPT_UD) ? 0 : -ENOENT;
     }
 
     if (hdr->opcode == IBV_WR_SEND) {
@@ -337,14 +362,15 @@ static void dev_send_comp(void *arg, int ret)
 {
     struct fake_cqe *fcqe = arg;
 
-    if (ret < 0) {
+    if (ret != 0) {
         fcqe->wc.status = IBV_WC_GENERAL_ERR;
     }
 
     list_add_tail(&fcqe->fcq->wcs, &fcqe->list);
+    fcqe->fcq->wcs_count++;
 }
 
-static int dev_wr_send_serialize(struct ibv_qp *qp, struct ibv_send_wr *wr,
+static int dev_wr_send_serialize(struct fake_qp *fqp, struct ibv_send_wr *wr,
                                  struct ibv_ah *ah, uint32_t remote_qpn)
 {
     union {
@@ -353,6 +379,7 @@ static int dev_wr_send_serialize(struct ibv_qp *qp, struct ibv_send_wr *wr,
     } u;
     struct fake_hdr *hdr = &u.hdr;
     size_t total         = 0;
+    struct ibv_qp *qp    = &fqp->qp_ex.qp_base;
     struct iovec iov[2 * MAX_SGE + 1];
     struct fake_ah *fah;
     struct fake_cqe *fcqe;
@@ -421,8 +448,8 @@ static int dev_wr_send_serialize(struct ibv_qp *qp, struct ibv_send_wr *wr,
     wc->byte_len = total;
 
     /* TODO: Use actual backend for multi process/nodes */
-    ret = dev_rx_cb(iov, count);
-    if (ret == 0) {
+    ret = dev_rx_cb(fqp, iov, count);
+    if (ret < 0) {
         free(fcqe);
         return -1;
     }
@@ -475,7 +502,7 @@ static int dev_post_send(struct ibv_qp *qp, struct ibv_send_wr *wr,
         }
 
 
-        if (dev_wr_send_serialize(qp, wr, wr->wr.ud.ah, wr->wr.ud.remote_qpn)) {
+        if (dev_wr_send_serialize(fqp, wr, wr->wr.ud.ah, wr->wr.ud.remote_qpn)) {
             ret = -ENOMEM;
             goto fail;
         }
@@ -489,24 +516,48 @@ fail:
     return ret;
 }
 
+/* Add some reordering (linear for now) */
+static struct fake_cqe *fake_cq_get_cqe(struct fake_cq *fcq)
+{
+    struct list *entry = list_first(&fcq->wcs);
+    int index;
+
+    if (fcq->is_ooo) {
+        index = rand() % fcq->wcs_count;
+        while (--index >= 0) {
+            entry = entry->next;
+        }
+    }
+
+    return (struct fake_cqe *)entry;
+}
+
 static int dev_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc)
 {
+    int i               = 0;
     struct fake_cq *fcq = (struct fake_cq*)cq;
     struct fake_cqe *fcqe;
-    int i;
 
     lock();
+
+    fcq->poll_count = (fcq->poll_count + 1) & 0x3;
+    if (fcq->poll_count != 0) {
+        goto out; /* Simulate some polling traffic */
+    }
+
     for (i = 0; i < num_entries; i++) {
         if (list_is_empty(&fcq->wcs)) {
             break;
         }
 
-        fcqe = (struct fake_cqe*)list_first(&fcq->wcs);
+        fcqe = fake_cq_get_cqe(fcq);
         list_del(&fcqe->list);
+        fcq->wcs_count--;
         wc[i] = fcqe->wc;
         fcqe->free(fcqe);
     }
 
+out:
     unlock();
     return i;
 }
@@ -603,6 +654,8 @@ struct ibv_cq *ibv_create_cq(struct ibv_context *context, int cqe,
     cq->cq_context = cq_context;
 
     list_init(&fcq->wcs);
+    fcq->wcs_count  = 0;
+    fcq->poll_count = 0;
     return cq;
 }
 
@@ -614,9 +667,11 @@ int ibv_destroy_cq(struct ibv_cq *cq)
     while (!list_is_empty(&fcq->wcs)) {
         fcqe = (struct fake_cqe*)list_first(&fcq->wcs);
         list_del(&fcqe->list);
+        fcq->wcs_count--;
         fcqe->free(fcqe);
     }
 
+    assert(fcq->wcs_count == 0);
     free(fcq);
     return 0;
 }
@@ -624,11 +679,50 @@ int ibv_destroy_cq(struct ibv_cq *cq)
 int fake_qpn = 0;
 array_t fake_qps;
 
-struct ibv_qp *ibv_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
+struct fake_qp *create_fqp(struct ibv_pd *pd,
+                           struct ibv_qp_init_attr *attr)
 {
     struct fake_qp *fqp;
     struct ibv_qp *qp;
+    struct fake_cq *fcq;
 
+    fqp = calloc(1, sizeof(*fqp));
+    if (fqp == NULL) {
+        return NULL;
+    }
+
+    lock();
+
+    qp             = &fqp->qp_ex.qp_base;
+    qp->qp_context = pd->context;
+    qp->context    = pd->context;
+    qp->qp_type    = attr->qp_type;
+    qp->send_cq    = attr->send_cq;
+    qp->recv_cq    = attr->recv_cq;
+    qp->pd         = pd;
+    qp->srq        = attr->srq;
+    qp->state      = IBV_QPS_RESET;
+    qp->qp_num     = ++fake_qpn;
+
+    fqp->fpd       = (struct fake_pd*)pd;
+    fqp->rx_drop   = (qp->qp_type == IBV_QPT_UD)? ibmock_drop_rate() : 0;
+    list_init(&fqp->recv_reqs);
+
+    /* SRD */
+    fcq         = (struct fake_cq *)qp->recv_cq;
+    fcq->is_ooo = (qp->qp_type == IBV_QPT_DRIVER);
+    fcq         = (struct fake_cq *)qp->send_cq;
+    fcq->is_ooo = (qp->qp_type == IBV_QPT_DRIVER);
+
+    array_append(&fake_qps, &fqp, sizeof(fqp));
+
+    unlock();
+
+    return fqp;
+}
+
+struct ibv_qp *ibv_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
+{
     if ((attr->qp_type != IBV_QPT_DRIVER) && (attr->qp_type != IBV_QPT_UD)) {
         return NULL; /* RC is not supported */
     }
@@ -638,28 +732,7 @@ struct ibv_qp *ibv_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
         return NULL;
     }
 
-    fqp = calloc(1, sizeof(*fqp));
-    if (fqp == NULL) {
-        return NULL;
-    }
-
-    lock();
-    fqp->fpd = (struct fake_pd*)pd;
-    list_init(&fqp->recv_reqs);
-
-    qp          = &fqp->qp_ex.qp_base;
-    qp->context = pd->context;
-    qp->qp_type = attr->qp_type;
-    qp->send_cq = attr->send_cq;
-    qp->recv_cq = attr->recv_cq;
-    qp->pd      = pd;
-    qp->srq     = attr->srq;
-    qp->state   = IBV_QPS_RESET;
-    qp->qp_num  = ++fake_qpn;
-
-    array_append(&fake_qps, &fqp, sizeof(fqp));
-    unlock();
-    return qp;
+    return &create_fqp(pd, attr)->qp_ex.qp_base;
 }
 
 
@@ -930,7 +1003,7 @@ int dev_qp_wr_complete(struct ibv_qp_ex *qp_ex)
     lock();
     fqp->sr.wr_id = qp_ex->wr_id;
 
-    ret = dev_wr_send_serialize(&qp_ex->qp_base, &fqp->sr, fqp->ah,
+    ret = dev_wr_send_serialize(fqp, &fqp->sr, fqp->ah,
                                 fqp->remote_qpn);
     unlock();
     return ret;

--- a/contrib/ibmock/verbs.c
+++ b/contrib/ibmock/verbs.c
@@ -15,10 +15,10 @@
 #include <stdbool.h>
 #include <unistd.h>
 
-#define NUM_DEVS    2
-#define SYS_PATH    "/tmp/ibmock"
-#define DUMMY_PKEY  65535 /* Dummy pkey with full membership for now */
-#define ONE_MILLION 1000000
+#define NUM_DEVS      2
+#define SYS_PATH      "/tmp/ibmock"
+#define DUMMY_PKEY    65535 /* Dummy pkey with full membership for now */
+#define DROP_RATE_MAX 1000000
 
 
 static pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -222,7 +222,7 @@ rx_send(struct fake_qp *fqp, struct fake_hdr *hdr, struct iovec *iov, int count)
         return (fqp->qp_ex.qp_base.qp_type == IBV_QPT_UD) ? 0 : -ENOENT;
     }
 
-    if (fqp->rx_drop && (((unsigned)rand() % ONE_MILLION) < fqp->rx_drop)) {
+    if (fqp->rx_drop && (((unsigned)rand() % DROP_RATE_MAX) < fqp->rx_drop)) {
         return 0; /* Operation is dropped, TX CQE will be called */
     }
 

--- a/contrib/ibmock/verbs.h
+++ b/contrib/ibmock/verbs.h
@@ -18,4 +18,7 @@ void dev_qp_wr_set_sge_list(struct ibv_qp_ex *qp, size_t num_sge,
 void(dev_qp_wr_set_ud_addr)(struct ibv_qp_ex *qp, struct ibv_ah *ah,
                             uint32_t remote_qpn, uint32_t remote_qkey);
 int dev_qp_wr_complete(struct ibv_qp_ex *qp);
+
+struct fake_qp *create_fqp(struct ibv_pd *pd,
+                           struct ibv_qp_init_attr *attr);
 #endif /* __VERBS_H */

--- a/contrib/test_efa.sh
+++ b/contrib/test_efa.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -eEx
+#!/usr/bin/bash -eE
 #
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # See file LICENSE for terms.
@@ -84,6 +84,12 @@ install_rdma_core() {
     cd -
 }
 
+setup_env() {
+    # Setup ibmock library
+    ${1:-} export LD_LIBRARY_PATH=$(pwd)/contrib/ibmock/build:$(pwd)/$rdma_core/build/lib:$LD_LIBRARY_PATH
+    ${1:-} export CLOUD_TYPE=aws
+}
+
 run_gtests() {
     if [ ! -d /dev/infiniband ]
     then
@@ -93,9 +99,7 @@ run_gtests() {
         chmod ugo+rw /dev/infiniband/uver*
     fi
 
-    # Setup ibmock library
-    export LD_LIBRARY_PATH=$(pwd)/contrib/ibmock/build:$(pwd)/$rdma_core/build/lib:$LD_LIBRARY_PATH
-    export CLOUD_TYPE=aws
+    setup_env
 
     # Check basic ibmock functionality, error if mocked interface is not found
     UCX_LOG_LEVEL=trace \
@@ -117,21 +121,24 @@ test_ucx_rpm() {
 }
 
 case "${1-:}" in
-    install_rdma_core_efa)
+    install_rdma_core)
         install_rdma_core
         ;;
     test_rpm_efa)
         build_ucx_efa
         test_ucx_rpm
         ;;
-    build_efa)
+    build)
         build_rdma_core_efa
         build_ucx_efa
         ;;
-    gtest_efa)
+    gtest)
         run_gtests
         ;;
+    env)
+        setup_env echo
+        ;;
     *)
-        echo "error: invalid argument"
+        echo "error: invalid argument, use either (env|gtest|build|test_rpm_efa|install_rdma_core)"
         exit 1
 esac


### PR DESCRIPTION
## What?
Add support for out-of-order CQEs send/recv, and drop capabilities.

## Test
```
$ UCX_PROTO_INFO=y UCX_TLS=ud ./install/bin/ucx_perftest -l -t tag_bw  -n 1000000
Final:               1000000      0.151     0.649     0.649       11.76      11.76     1541920     1541920
$ IBMOCK_DROP_RATE=10 UCX_PROTO_INFO=y UCX_TLS=ud ./install/bin/ucx_perftest -l -t tag_bw  -n 1000000
Final:               1000000      0.150     1.222     1.400        6.24       5.45      818295      714353
```
