### PR TITLE
UCM/CUDA: Correct region size for pitched CUDA allocation hooks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Igor Ivanov <igori@mellanox.com>
 Ilia Yastrebov <iyastrebov@nvidia.com>
 Ilya Nelkenbaum <ilyan@mellanox.com>
 Ivan Kochin <ikochin@nvidia.com>
+Ivan Tsybulin <tsybulinhome@gmail.com>
 Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>
 Jeff Daily <jeff.daily@amd.com>

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -180,11 +180,11 @@ UCM_CUDA_ALLOC_FUNC(cuMemAlloc_v2, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, *,
 UCM_CUDA_ALLOC_FUNC(cuMemAllocManaged, CUresult, CUDA_SUCCESS, arg0,
                     CUdeviceptr, *, "size=%zu flags=0x%x", size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch, CUresult, CUDA_SUCCESS,
-                    ((size_t)(*arg0)) * (arg2), CUdeviceptr, *,
+                    ((size_t)(*(arg0))) * (arg2), CUdeviceptr, *,
                     "pitch=%p width=%zu height=%zu elem=%u", size_t*, size_t,
                     size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch_v2, CUresult, CUDA_SUCCESS,
-                    ((size_t)(*arg0)) * (arg2), CUdeviceptr, *,
+                    ((size_t)(*(arg0))) * (arg2), CUdeviceptr, *,
                     "pitch=%p width=%zu height=%zu elem=%u", size_t*, size_t,
                     size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cuMemMap, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, ,
@@ -276,7 +276,7 @@ UCM_CUDA_ALLOC_FUNC(cudaMalloc, cudaError_t, cudaSuccess, arg0, void*, *,
 UCM_CUDA_ALLOC_FUNC(cudaMallocManaged, cudaError_t, cudaSuccess, arg0, void*, *,
                     "size=%zu flags=0x%x", size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cudaMallocPitch, cudaError_t, cudaSuccess,
-                    ((size_t)(*arg0)) * (arg2), void*, *,
+                    ((size_t)(*(arg0))) * (arg2), void*, *,
                     "pitch=%p width=%zu height=%zu", size_t*, size_t, size_t)
 #if CUDART_VERSION >= 11020
 UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, cudaError_t, cudaSuccess, arg0, void*, *,

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -178,11 +178,11 @@ UCM_CUDA_ALLOC_FUNC(cuMemAlloc_v2, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, *,
 UCM_CUDA_ALLOC_FUNC(cuMemAllocManaged, CUresult, CUDA_SUCCESS, arg0,
                     CUdeviceptr, *, "size=%zu flags=0x%x", size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch, CUresult, CUDA_SUCCESS,
-                    ((size_t)arg1) * (arg2), CUdeviceptr, *,
+                    ((size_t)(*arg0)) * (arg2), CUdeviceptr, *,
                     "pitch=%p width=%zu height=%zu elem=%u", size_t*, size_t,
                     size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cuMemAllocPitch_v2, CUresult, CUDA_SUCCESS,
-                    ((size_t)arg1) * (arg2), CUdeviceptr, *,
+                    ((size_t)(*arg0)) * (arg2), CUdeviceptr, *,
                     "pitch=%p width=%zu height=%zu elem=%u", size_t*, size_t,
                     size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cuMemMap, CUresult, CUDA_SUCCESS, arg0, CUdeviceptr, ,
@@ -274,7 +274,7 @@ UCM_CUDA_ALLOC_FUNC(cudaMalloc, cudaError_t, cudaSuccess, arg0, void*, *,
 UCM_CUDA_ALLOC_FUNC(cudaMallocManaged, cudaError_t, cudaSuccess, arg0, void*, *,
                     "size=%zu flags=0x%x", size_t, unsigned)
 UCM_CUDA_ALLOC_FUNC(cudaMallocPitch, cudaError_t, cudaSuccess,
-                    ((size_t)arg1) * (arg2), void*, *,
+                    ((size_t)(*arg0)) * (arg2), void*, *,
                     "pitch=%p width=%zu height=%zu", size_t*, size_t, size_t)
 #if CUDART_VERSION >= 11020
 UCM_CUDA_ALLOC_FUNC(cudaMallocAsync, cudaError_t, cudaSuccess, arg0, void*, *,

--- a/src/ucm/cuda/cudamem.c
+++ b/src/ucm/cuda/cudamem.c
@@ -297,10 +297,10 @@ UCM_CUDA_FREE_FUNC(cudaFreeAsync, UCS_MEMORY_TYPE_CUDA, cudaError_t, arg0, 0,
                    "devPtr=%p, stream=%p", void*, cudaStream_t)
 #endif
 
-cudaError_t ucm_cudaMalloc3D(struct cudaPitchedPtr* pitchedDevPtr,
-                             struct cudaExtent extent)
+cudaError_t
+ucm_cudaMalloc3D(struct cudaPitchedPtr *pitchedDevPtr, struct cudaExtent extent)
 {
-    void* ptr;
+    void *ptr;
     cudaError_t ret;
     size_t size;
 

--- a/src/ucm/cuda/cudamem.h
+++ b/src/ucm/cuda/cudamem.h
@@ -44,6 +44,8 @@ cudaError_t ucm_cudaMalloc(void **devPtr, size_t size);
 cudaError_t ucm_cudaMallocManaged(void **devPtr, size_t size, unsigned int flags);
 cudaError_t ucm_cudaMallocPitch(void **devPtr, size_t *pitch,
                                 size_t width, size_t height);
+cudaError_t ucm_cudaMalloc3D(struct cudaPitchedPtr *pitchedDevPtr,
+                             struct cudaExtent extent);
 cudaError_t ucm_cudaGetSymbolAddress(void **devPtr, const void *symbol);
 #if CUDART_VERSION >= 11020
 cudaError_t ucm_cudaMallocAsync(void **devPtr, size_t size,

--- a/test/gtest/ucm/cuda_hooks.cc
+++ b/test/gtest/ucm/cuda_hooks.cc
@@ -388,11 +388,13 @@ UCS_TEST_F(cuda_hooks, test_cudaMalloc3D) {
 
     ret = cudaMalloc3D(&devPtr, extent);
     ASSERT_EQ(ret, cudaSuccess);
-    check_mem_alloc_events(devPtr.ptr, devPtr.pitch * devPtr.ysize * depth);
+    EXPECT_EQ(width, devPtr.xsize);
+    EXPECT_EQ(height, devPtr.ysize);
+    check_mem_alloc_events(devPtr.ptr, devPtr.pitch * height * depth);
 
     ret = cudaFree(devPtr.ptr);
     ASSERT_EQ(ret, cudaSuccess);
-    check_mem_free_events(devPtr.ptr, devPtr.pitch * devPtr.ysize * depth);
+    check_mem_free_events(devPtr.ptr, devPtr.pitch * height * depth);
 }
 
 #if CUDART_VERSION >= 11020


### PR DESCRIPTION
## What?
For pitched CUDA memory allocations (cuMemAllocPitch, cuMemAllocPitch_v2, cudaMallocPitch, cudaMalloc3D) the allocated region may be bigger than requested. The UCM code incorrectly marked those regions to have `width * height[ * depth]` size, but their actual size is `pitch * height[ * depth]`.

## Why?
Incorrect allocated region size leads to part of it having incorrect UCS_MEMORY_TYPE and further attempts to access device memory as host memory.

Closes #10526 
