### PR TITLE
UCT/CUDA/BASE: Changed log level of cuInit errors.

### DIFF
--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -103,7 +103,7 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
 
 UCS_STATIC_INIT
 {
-    UCT_CUDADRV_FUNC_LOG_ERR(cuInit(0));
+    UCT_CUDADRV_FUNC_LOG_DEBUG(cuInit(0));
 }
 
 UCS_STATIC_CLEANUP


### PR DESCRIPTION
## What?
Changed log level of `cuInit` errors.
Error level is too high for this logging. This code can be called on a system with no CUDA-capable device. Debug message is enough in this case.
Fixes internal issue [4338480](https://redmine.mellanox.com/issues/4338480)