### PR TITLE
UCP/CORE: Dump rkey configs when limit is reached

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2133,6 +2133,18 @@ out:
     return UCS_OK;
 }
 
+static void
+ucp_worker_dump_rkey_config_key(ucs_string_buffer_t *log_strb,
+                                ucp_rkey_config_key_t *key)
+{
+    ucs_string_buffer_appendf(
+            log_strb,
+            "md_map %" PRIx64
+            " cfg_index %d sys_dev %d mem_type %s unrch_md_map %" PRIx64 "\n",
+            key->md_map, key->ep_cfg_index, key->sys_dev,
+            ucs_memory_type_names[key->mem_type], key->unreachable_md_map);
+}
+
 ucs_status_t
 ucp_worker_add_rkey_config(ucp_worker_h worker,
                            const ucp_rkey_config_key_t *key,
@@ -2148,12 +2160,30 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     khiter_t khiter;
     char buf[128];
     int khret;
+    ucs_string_buffer_t log_strb;
 
     ucs_assert(worker->context->config.ext.proto_enable);
 
     if (worker->rkey_config_count >= UCP_WORKER_MAX_RKEY_CONFIG) {
         ucs_error("too many rkey configurations: %d (max: %d)",
                   worker->rkey_config_count, UCP_WORKER_MAX_RKEY_CONFIG);
+
+        /* Dump all rkey config keys */
+        ucs_string_buffer_init(&log_strb);
+
+        ucs_carray_for_each(rkey_config, worker->rkey_config,
+                            worker->rkey_config_count) {
+            ucs_string_buffer_appendf(&log_strb, "rkey [%ld]: ",
+                                      rkey_config - worker->rkey_config);
+            ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
+        }
+
+        ucs_string_buffer_appendf(&log_strb, "rkey key new: ");
+        ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
+
+        ucs_debug("%s", ucs_string_buffer_cstr(&log_strb));
+        ucs_string_buffer_cleanup(&log_strb);
+
         status = UCS_ERR_EXCEEDS_LIMIT;
         goto err;
     }


### PR DESCRIPTION
## What?

Dump rkey config hashtable keys when full. This is to help understand why the situation occurs.

Before this patch, the only error seen in the log is:

```
ucp_worker.c:2155 UCX  ERROR             too many rkey configurations: 128 (max: 128)
```

which is not sufficient to understand why there are so many keys in this setup.