### PR TITLE
Topic/force gva and fix gobindings

### DIFF
--- a/bindings/go/src/ucx/am_data.go
+++ b/bindings/go/src/ucx/am_data.go
@@ -20,9 +20,6 @@ type UcpAmData struct {
 	flags   UcpAmRecvAttrs
 }
 
-// To connect callback id with worker, to use in AmData.Receive()
-var idToWorker = make(map[uint64]*UcpWorker)
-
 // Whether actual data is received or need to call UcpAmData.Receive()
 func (d *UcpAmData) IsDataValid() bool {
 	return (d.flags & UCP_AM_RECV_ATTR_FLAG_RNDV) == 0

--- a/bindings/go/src/ucx/ucp_contsants.go
+++ b/bindings/go/src/ucx/ucp_contsants.go
@@ -72,6 +72,8 @@ const (
 	UCP_AM_SEND_FLAG_EAGER UcpAmSendFlags = C.UCP_AM_SEND_FLAG_EAGER
 	// Force UCP to use only rendezvous protocol for AM sends.
 	UCP_AM_SEND_FLAG_RNDV UcpAmSendFlags = C.UCP_AM_SEND_FLAG_RNDV
+	// Copy the header of the message to internal ucx buffer.
+	UCP_AM_SEND_FLAG_COPY_HEADER UcpAmSendFlags = C.UCP_AM_SEND_FLAG_COPY_HEADER
 )
 
 type UcpAmRecvAttrs uint64

--- a/bindings/go/src/ucx/worker.go
+++ b/bindings/go/src/ucx/worker.go
@@ -261,8 +261,7 @@ func (w *UcpWorker) NewListener(listenerParams *UcpListenerParams) (*UcpListener
 // received on this worker.
 func (w *UcpWorker) SetAmRecvHandler(id uint, flags UcpAmCbFlags, cb UcpAmRecvCallback) error {
 	var amHandlerParams C.ucp_am_handler_param_t
-	cbId := register(cb)
-	idToWorker[cbId] = w
+	cbId := register(&UcpAmRecvCallbackBundle{cb: cb, worker: w})
 
 	amHandlerParams.field_mask = C.UCP_AM_HANDLER_PARAM_FIELD_ID |
 		C.UCP_AM_HANDLER_PARAM_FIELD_FLAGS |


### PR DESCRIPTION
## What?
Fix gobindings issues and bugs

## Why?
- UCX mem hooks are not working with Golang.
- Fix bug: gobindings code is not thread safe.

## How?
We will try two approaches:
- Force using of GVA for Gobindings: Tests show that it's solve the mem hooks issues.
- Try using userfaultfd [POC](https://confluence.nvidia.com/pages/viewpage.action?pageId=1903178631)
