### PR TITLE
BINDINGS/GO: Bug fix - make gobindings thread safe.

### DIFF
--- a/bindings/go/src/ucx/am_data.go
+++ b/bindings/go/src/ucx/am_data.go
@@ -20,9 +20,6 @@ type UcpAmData struct {
 	flags   UcpAmRecvAttrs
 }
 
-// To connect callback id with worker, to use in AmData.Receive()
-var idToWorker = make(map[uint64]*UcpWorker)
-
 // Whether actual data is received or need to call UcpAmData.Receive()
 func (d *UcpAmData) IsDataValid() bool {
 	return (d.flags & UCP_AM_RECV_ATTR_FLAG_RNDV) == 0

--- a/bindings/go/src/ucx/listener_params.go
+++ b/bindings/go/src/ucx/listener_params.go
@@ -16,18 +16,17 @@ import (
 
 // Tuning parameters for the UCP listener.
 type UcpListenerParams struct {
-	params        C.ucp_listener_params_t
-	connHandlerId uint64
+	params   C.ucp_listener_params_t
+	callback UcpListenerConnectionHandler
 }
 
 //export ucxgo_completeConnHandler
-func ucxgo_completeConnHandler(connRequest C.ucp_conn_request_h, cbId unsafe.Pointer) {
-	id := uint64(uintptr((cbId)))
-	if callback, found := getCallback(id); found {
-		listener := connHandles2Listener[id]
-		callback.(UcpListenerConnectionHandler)(&UcpConnectionRequest{
+func ucxgo_completeConnHandler(connRequest C.ucp_conn_request_h, packedCb unsafe.Pointer) {
+	if callback := PackedCallback(packedCb).unpack(); callback != nil {
+		listener := callback.(*UcpListener)
+		listener.callback(&UcpConnectionRequest{
 			connRequest: connRequest,
-			listener:    listener,
+			listener:    listener.listener,
 		})
 	}
 }
@@ -49,10 +48,8 @@ func (p *UcpListenerParams) SetSocketAddress(a *net.TCPAddr) (*UcpListenerParams
 // Handler of an incoming connection request in a client-server connection flow.
 func (p *UcpListenerParams) SetConnectionHandler(connHandler UcpListenerConnectionHandler) *UcpListenerParams {
 	var ucpConnHndl C.ucp_listener_conn_handler_t
-	cbId := register(connHandler)
 
-	p.connHandlerId = cbId
-	ucpConnHndl.arg = unsafe.Pointer(uintptr(cbId))
+	p.callback = connHandler
 	ucpConnHndl.cb = (C.ucp_listener_conn_callback_t)(C.ucxgo_completeConnHandler)
 	p.params.field_mask |= C.UCP_LISTENER_PARAM_FIELD_CONN_HANDLER
 	p.params.conn_handler = ucpConnHndl

--- a/bindings/go/src/ucx/ucp_contsants.go
+++ b/bindings/go/src/ucx/ucp_contsants.go
@@ -72,6 +72,8 @@ const (
 	UCP_AM_SEND_FLAG_EAGER UcpAmSendFlags = C.UCP_AM_SEND_FLAG_EAGER
 	// Force UCP to use only rendezvous protocol for AM sends.
 	UCP_AM_SEND_FLAG_RNDV UcpAmSendFlags = C.UCP_AM_SEND_FLAG_RNDV
+	// Copy the header of the message to internal ucx buffer.
+	UCP_AM_SEND_FLAG_COPY_HEADER UcpAmSendFlags = C.UCP_AM_SEND_FLAG_COPY_HEADER
 )
 
 type UcpAmRecvAttrs uint64


### PR DESCRIPTION
## What?
Fix gobindings bugs.

## Why?
- cbId -> worker map, `idToWorker`, is not thread safe.
- UCX's mem hooks not working properly with Go.

## How?
- Remove `idToWorker` map and pass tuple.
- Use golang convention for passing obj to native, [Handles](https://pkg.go.dev/runtime/cgo#Handle), instead of direct use of hashmap.
- Set `GVA_ENABLE` to auto by default on ctx creation.