### PR TITLE
UCT/CUDA_IPC: Context switching aware resource management

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -108,6 +108,278 @@ ucs_status_t uct_cuda_base_check_device_name(const uct_iface_params_t *params)
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE unsigned
+uct_cuda_base_queue_head_ready(ucs_queue_head_t *queue_head)
+{
+    uct_cuda_event_desc_t *cuda_event;
+
+    if (ucs_queue_is_empty(queue_head)) {
+        return 0;
+    }
+
+    cuda_event = ucs_queue_head_elem_non_empty(queue_head,
+                                               uct_cuda_event_desc_t, queue);
+    return (CUDA_SUCCESS == cuEventQuery(cuda_event->event));
+}
+
+ucs_status_t uct_cuda_base_iface_event_fd_arm(uct_iface_h tl_iface,
+                                              unsigned events)
+{
+    uct_cuda_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_iface_t);
+    ucs_status_t status;
+    CUstream *stream;
+    ucs_queue_head_t *event_q;
+    uct_cuda_queue_desc_t *q_desc;
+    ucs_queue_iter_t iter;
+
+    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
+        event_q = &q_desc->event_queue;
+        if (uct_cuda_base_queue_head_ready(event_q)) {
+            return UCS_ERR_BUSY;
+        }
+    }
+
+    status = ucs_async_eventfd_poll(iface->eventfd);
+    if (status == UCS_OK) {
+        return UCS_ERR_BUSY;
+    } else if (status == UCS_ERR_IO_ERROR) {
+        return status;
+    }
+
+    ucs_assertv(status == UCS_ERR_NO_PROGRESS, "%s", ucs_status_string(status));
+
+    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
+        event_q = &q_desc->event_queue;
+        stream  = &q_desc->stream;
+        if (!ucs_queue_is_empty(event_q)) {
+            status =
+#if (__CUDACC_VER_MAJOR__ >= 100000)
+                UCT_CUDADRV_FUNC_LOG_ERR(
+                        cuLaunchHostFunc(*stream,
+                                         uct_cuda_base_iface_stream_cb_fxn,
+                                         iface));
+#else
+                UCT_CUDADRV_FUNC_LOG_ERR(
+                        cuStreamAddCallback(*stream,
+                                            uct_cuda_base_iface_stream_cb_fxn,
+                                            iface, 0));
+#endif
+            if (UCS_OK != status) {
+                return status;
+            }
+        }
+    }
+
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_cuda_base_progress_event_queue(uct_cuda_iface_t *iface,
+                                   ucs_queue_head_t *queue_head,
+                                   unsigned max_events)
+{
+    unsigned count = 0;
+    uct_cuda_event_desc_t *cuda_event;
+
+    ucs_queue_for_each_extract(cuda_event, queue_head, queue,
+                               (count < max_events) &&
+                               (cuEventQuery(cuda_event->event) == CUDA_SUCCESS)) {
+        ucs_trace_data("cuda event %p completed", cuda_event);
+        if (cuda_event->comp != NULL) {
+            uct_invoke_completion(cuda_event->comp, UCS_OK);
+        }
+
+        iface->ops->complete_event(&iface->super.super, cuda_event);
+        ucs_mpool_put(cuda_event);
+        count++;
+    }
+
+    return count;
+}
+
+unsigned uct_cuda_base_iface_progress(uct_iface_h tl_iface)
+{
+    uct_cuda_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_iface_t);
+    unsigned max_events     = iface->config.max_poll;
+    unsigned count          = 0;
+    ucs_queue_head_t *event_q;
+    uct_cuda_queue_desc_t *q_desc;
+    ucs_queue_iter_t iter;
+
+    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
+        event_q = &q_desc->event_queue;
+        count  += uct_cuda_base_progress_event_queue(iface, event_q,
+                                                     max_events - count);
+        if (ucs_queue_is_empty(event_q)) {
+            ucs_queue_del_iter(&iface->active_queue, iter);
+        }
+    }
+
+    return count;
+}
+
+ucs_status_t uct_cuda_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                       uct_completion_t *comp)
+{
+    uct_cuda_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_iface_t);
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (!ucs_queue_is_empty(&iface->active_queue)) {
+        UCT_TL_IFACE_STAT_FLUSH_WAIT(ucs_derived_of(tl_iface, uct_base_iface_t));
+        return UCS_INPROGRESS;
+    }
+
+    UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
+    return UCS_OK;
+}
+
+static int uct_cuda_base_is_ctx_rsc_valid(const uct_cuda_ctx_rsc_t *ctx_rsc)
+{
+#if CUDA_VERSION >= 12000
+    unsigned long long ctx_id;
+    CUresult result;
+
+    result = uct_cuda_base_ctx_get_id(ctx_rsc->ctx, &ctx_id);
+    if (result == CUDA_ERROR_CONTEXT_IS_DESTROYED) {
+        return 0;
+    } else if (result != CUDA_SUCCESS) {
+        UCT_CUDADRV_LOG(cuCtxGetId, UCS_LOG_LEVEL_WARN, result);
+        return 0;
+    }
+
+    return ctx_id == ctx_rsc->ctx_id;
+#else
+    /* Best effort check on older Cuda versions */
+    return uct_cuda_base_is_context_valid(ctx_rsc->ctx);
+#endif
+}
+
+void uct_cuda_base_stream_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
+                                  CUstream *stream)
+{
+    if ((*stream == NULL) || !uct_cuda_base_is_ctx_rsc_valid(ctx_rsc)) {
+        return;
+    }
+
+    UCT_CUDADRV_FUNC_LOG_WARN(cuStreamDestroy(*stream));
+}
+
+static void
+uct_cuda_base_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
+{
+    uct_cuda_event_desc_t *event_desc = obj;
+
+    UCT_CUDADRV_FUNC_LOG_ERR(cuEventCreate(&event_desc->event,
+                                           CU_EVENT_DISABLE_TIMING));
+}
+
+static void uct_cuda_base_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
+{
+    uct_cuda_event_desc_t *event_desc = obj;
+    uct_cuda_ctx_rsc_t *ctx_rsc       = ucs_container_of(mp, uct_cuda_ctx_rsc_t,
+                                                         event_mp);
+
+    if (uct_cuda_base_is_ctx_rsc_valid(ctx_rsc)) {
+        UCT_CUDADRV_FUNC_LOG_WARN(cuEventDestroy(event_desc->event));
+    }
+}
+
+void uct_cuda_base_queue_desc_init(uct_cuda_queue_desc_t *qdesc)
+{
+    qdesc->stream = NULL;
+    ucs_queue_head_init(&qdesc->event_queue);
+}
+
+void uct_cuda_base_queue_desc_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
+                                      uct_cuda_queue_desc_t *qdesc)
+{
+    if (!ucs_queue_is_empty(&qdesc->event_queue)) {
+        ucs_warn("cuda context %llu stream being destroyed with  %zu "
+                 "outstanding events", ctx_rsc->ctx_id,
+                 ucs_queue_length(&qdesc->event_queue));
+    }
+
+    uct_cuda_base_stream_destroy(ctx_rsc, &qdesc->stream);
+}
+
+static ucs_mpool_ops_t uct_cuda_event_desc_mpool_ops = {
+    .chunk_alloc   = ucs_mpool_chunk_malloc,
+    .chunk_release = ucs_mpool_chunk_free,
+    .obj_init      = uct_cuda_base_event_desc_init,
+    .obj_cleanup   = uct_cuda_base_event_desc_cleanup,
+    .obj_str       = NULL
+};
+
+ucs_status_t uct_cuda_base_ctx_rsc_create(uct_cuda_iface_t *iface,
+                                          unsigned long long ctx_id,
+                                          uct_cuda_ctx_rsc_t **ctx_rsc_p)
+{
+    CUcontext ctx;
+    ucs_status_t status;
+    ucs_kh_put_t ret;
+    khiter_t iter;
+    uct_cuda_ctx_rsc_t *ctx_rsc;
+    ucs_mpool_params_t mp_params;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&ctx));
+    if (status != UCS_OK) {
+        return status;
+    } else if (ctx == NULL) {
+        ucs_error("no cuda context bound to calling thread");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    iter = kh_put(cuda_ctx_rscs, &iface->ctx_rscs, ctx_id, &ret);
+    if (ret == UCS_KH_PUT_FAILED) {
+        ucs_error("failed to allocate cuda context resource hash entry");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ucs_assertv_always(ret != UCS_KH_PUT_KEY_PRESENT,
+                       "the key has already been added iface=%p key=%llu",
+                       iface, ctx_id);
+
+    ctx_rsc = iface->ops->create_rsc(&iface->super.super);
+    if (ctx_rsc == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_del_iter;
+    }
+
+    ucs_mpool_params_reset(&mp_params);
+    mp_params.elem_size       = iface->config.event_desc_size;
+    mp_params.elems_per_chunk = 128;
+    mp_params.max_elems       = iface->config.max_events;
+    mp_params.ops             = &uct_cuda_event_desc_mpool_ops;
+    mp_params.name            = "cuda_event_descriptors";
+
+    status = ucs_mpool_init(&mp_params, &ctx_rsc->event_mp);
+    if (status != UCS_OK) {
+        goto err_free_ctx_rsc;
+    }
+
+    ctx_rsc->ctx                     = ctx;
+    ctx_rsc->ctx_id                  = ctx_id;
+    kh_value(&iface->ctx_rscs, iter) = ctx_rsc;
+    *ctx_rsc_p                       = ctx_rsc;
+    return UCS_OK;
+
+err_free_ctx_rsc:
+    iface->ops->destroy_rsc(&iface->super.super, ctx_rsc);
+err_del_iter:
+    kh_del(cuda_ctx_rscs, &iface->ctx_rscs, iter);
+    return UCS_ERR_NO_MEMORY;
+}
+
+static void uct_cuda_base_ctx_rsc_destroy(uct_cuda_iface_t *iface,
+                                          uct_cuda_ctx_rsc_t *ctx_rsc)
+{
+    ucs_mpool_cleanup(&ctx_rsc->event_mp, 1);
+    iface->ops->destroy_rsc(&iface->super.super, ctx_rsc);
+}
+
 UCS_CLASS_INIT_FUNC(uct_cuda_iface_t, uct_iface_ops_t *tl_ops,
                     uct_iface_internal_ops_t *ops, uct_md_h md,
                     uct_worker_h worker, const uct_iface_params_t *params,
@@ -119,12 +391,23 @@ UCS_CLASS_INIT_FUNC(uct_cuda_iface_t, uct_iface_ops_t *tl_ops,
                               UCS_STATS_ARG(dev_name));
 
     self->eventfd = UCS_ASYNC_EVENTFD_INVALID_FD;
-
+    kh_init_inplace(cuda_ctx_rscs, &self->ctx_rscs);
+    ucs_queue_head_init(&self->active_queue);
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_iface_t)
 {
+    uct_cuda_ctx_rsc_t *ctx_rsc;
+
+    uct_base_iface_progress_disable(&self->super.super,
+                                    UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
+
+    kh_foreach_value(&self->ctx_rscs, ctx_rsc, {
+        uct_cuda_base_ctx_rsc_destroy(self, ctx_rsc);
+    });
+
+    kh_destroy_inplace(cuda_ctx_rscs, &self->ctx_rscs);
     ucs_async_eventfd_destroy(self->eventfd);
 }
 

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -10,6 +10,8 @@
 #include <ucs/sys/preprocessor.h>
 #include <ucs/profile/profile.h>
 #include <ucs/async/eventfd.h>
+#include <ucs/datastruct/khash.h>
+
 #include <cuda.h>
 #include <nvml.h>
 
@@ -125,10 +127,75 @@ typedef enum uct_cuda_base_gen {
 } uct_cuda_base_gen_t;
 
 
-typedef struct uct_cuda_iface {
-    uct_base_iface_t super;
-    int              eventfd;
+typedef struct {
+    /* Needed to allow queue descriptor to be added to iface queue */
+    ucs_queue_elem_t queue;
+    /* Stream on which asynchronous memcpy operations are enqueued */
+    CUstream         stream;
+    /* Queue of cuda events */
+    ucs_queue_head_t event_queue;
+} uct_cuda_queue_desc_t;
+
+
+typedef struct {
+    ucs_queue_elem_t queue;
+    CUevent          event;
+    uct_completion_t *comp;
+} uct_cuda_event_desc_t;
+
+
+typedef struct {
+    /* CUDA context handle */
+    CUcontext          ctx;
+    /* CUDA context id */
+    unsigned long long ctx_id;
+    /* pool of cuda events to check completion of memcpy operations */
+    ucs_mpool_t        event_mp;
+} uct_cuda_ctx_rsc_t;
+
+
+/* Hash map for CUDA context resources. The key is the CUDA context Id. */
+KHASH_INIT(cuda_ctx_rscs, unsigned long long, uct_cuda_ctx_rsc_t*, 1,
+           kh_int64_hash_func, kh_int64_hash_equal);
+
+
+typedef uct_cuda_ctx_rsc_t* (*uct_cuda_create_rsc_fn_t)(uct_iface_h);
+typedef void (*uct_cuda_destroy_rsc_fn_t)(uct_iface_h, uct_cuda_ctx_rsc_t*);
+typedef void (*uct_cuda_complete_event_fn_t)(uct_iface_h, uct_cuda_event_desc_t*);
+
+
+typedef struct {
+    uct_cuda_create_rsc_fn_t     create_rsc;
+    uct_cuda_destroy_rsc_fn_t    destroy_rsc;
+    uct_cuda_complete_event_fn_t complete_event;
+} uct_cuda_iface_ops_t;
+
+
+typedef struct {
+    uct_base_iface_t          super;
+    int                       eventfd;
+    /* CUDA resources per context */
+    khash_t(cuda_ctx_rscs)    ctx_rscs;
+    /* list of queues which require progress */
+    ucs_queue_head_t          active_queue;
+    uct_cuda_iface_ops_t      *ops;
+
+    struct {
+        unsigned              max_events;
+        unsigned              max_poll;
+        size_t                event_desc_size;
+    } config;
 } uct_cuda_iface_t;
+
+ucs_status_t uct_cuda_base_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p);
+
+ucs_status_t uct_cuda_base_iface_event_fd_arm(uct_iface_h tl_iface,
+                                              unsigned events);
+
+unsigned uct_cuda_base_iface_progress(uct_iface_h tl_iface);
+
+ucs_status_t uct_cuda_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                       uct_completion_t *comp);
 
 ucs_status_t
 uct_cuda_base_query_devices_common(
@@ -136,13 +203,22 @@ uct_cuda_base_query_devices_common(
         uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p);
 
 void
-uct_cuda_base_get_sys_dev(CUdevice cuda_device,
-                          ucs_sys_device_t *sys_dev_p);
+uct_cuda_base_get_sys_dev(CUdevice cuda_device, ucs_sys_device_t *sys_dev_p);
 
 ucs_status_t
 uct_cuda_base_get_cuda_device(ucs_sys_device_t sys_dev, CUdevice *device);
 
-ucs_status_t uct_cuda_base_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p);
+ucs_status_t uct_cuda_base_ctx_rsc_create(uct_cuda_iface_t *iface,
+                                          unsigned long long ctx_id,
+                                          uct_cuda_ctx_rsc_t **ctx_rsc_p);
+
+void uct_cuda_base_queue_desc_init(uct_cuda_queue_desc_t *qdesc);
+
+void uct_cuda_base_queue_desc_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
+                                      uct_cuda_queue_desc_t *qdesc);
+
+void uct_cuda_base_stream_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
+                                  CUstream *stream);
 
 #if (__CUDACC_VER_MAJOR__ >= 100000)
 void CUDA_CB uct_cuda_base_iface_stream_cb_fxn(void *arg);
@@ -171,5 +247,39 @@ UCS_CLASS_INIT_FUNC(uct_cuda_iface_t, uct_iface_ops_t *tl_ops,
  */
 ucs_status_t uct_cuda_primary_ctx_retain(CUdevice cuda_device, int force,
                                          CUcontext *cuda_ctx_p);
+
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_cuda_base_ctx_rsc_get(uct_cuda_iface_t *iface, uct_cuda_ctx_rsc_t **ctx_rsc_p)
+{
+    unsigned long long ctx_id;
+    CUresult result;
+    khiter_t iter;
+
+    result = uct_cuda_base_ctx_get_id(NULL, &ctx_id);
+    if (ucs_unlikely(result != CUDA_SUCCESS)) {
+        UCT_CUDADRV_LOG(cuCtxGetId, UCS_LOG_LEVEL_ERROR, result);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    iter = kh_get(cuda_ctx_rscs, &iface->ctx_rscs, ctx_id);
+    if (ucs_likely(iter != kh_end(&iface->ctx_rscs))) {
+        *ctx_rsc_p = kh_value(&iface->ctx_rscs, iter);
+        return UCS_OK;
+    }
+
+    return uct_cuda_base_ctx_rsc_create(iface, ctx_id, ctx_rsc_p);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_cuda_base_init_stream(CUstream *stream)
+{
+    if (ucs_likely(*stream != NULL)) {
+        return UCS_OK;
+    }
+
+    return UCT_CUDADRV_FUNC_LOG_ERR(
+            cuStreamCreate(stream, CU_STREAM_NON_BLOCKING));
+}
 
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -151,144 +151,6 @@ static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-
-static ucs_status_t uct_cuda_copy_iface_flush(uct_iface_h tl_iface, unsigned flags,
-                                              uct_completion_t *comp)
-{
-    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
-    uct_cuda_copy_queue_desc_t *q_desc;
-    ucs_queue_iter_t iter;
-
-    if (comp != NULL) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
-        if (!ucs_queue_is_empty(&q_desc->event_queue)) {
-            UCT_TL_IFACE_STAT_FLUSH_WAIT(ucs_derived_of(tl_iface,
-                                                        uct_base_iface_t));
-            return UCS_INPROGRESS;
-        }
-    }
-
-    UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
-    return UCS_OK;
-}
-
-static UCS_F_ALWAYS_INLINE unsigned
-uct_cuda_copy_queue_head_ready(ucs_queue_head_t *queue_head)
-{
-    uct_cuda_copy_event_desc_t *cuda_event;
-
-    if (ucs_queue_is_empty(queue_head)) {
-        return 0;
-    }
-
-    cuda_event = ucs_queue_head_elem_non_empty(queue_head,
-                                               uct_cuda_copy_event_desc_t,
-                                               queue);
-    return (CUDA_SUCCESS == cuEventQuery(cuda_event->event));
-}
-
-static UCS_F_ALWAYS_INLINE unsigned
-uct_cuda_copy_progress_event_queue(uct_cuda_copy_iface_t *iface,
-                                   ucs_queue_head_t *queue_head,
-                                   unsigned max_events)
-{
-    unsigned count = 0;
-    uct_cuda_copy_event_desc_t *cuda_event;
-
-    ucs_queue_for_each_extract(cuda_event, queue_head, queue,
-                               cuEventQuery(cuda_event->event) ==
-                                       CUDA_SUCCESS) {
-        ucs_queue_remove(queue_head, &cuda_event->queue);
-        if (cuda_event->comp != NULL) {
-            ucs_trace_data("cuda_copy event %p completed", cuda_event);
-            uct_invoke_completion(cuda_event->comp, UCS_OK);
-        }
-        ucs_trace_poll("CUDA Event Done :%p", cuda_event);
-        ucs_mpool_put(cuda_event);
-        count++;
-        if (count >= max_events) {
-            break;
-        }
-    }
-
-    return count;
-}
-
-static unsigned uct_cuda_copy_iface_progress(uct_iface_h tl_iface)
-{
-    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
-    unsigned max_events = iface->config.max_poll;
-    unsigned count      = 0;
-    ucs_queue_head_t *event_q;
-    uct_cuda_copy_queue_desc_t *q_desc;
-    ucs_queue_iter_t iter;
-
-    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
-        event_q = &q_desc->event_queue;
-        count  += uct_cuda_copy_progress_event_queue(iface, event_q,
-                                                     max_events - count);
-        if (ucs_queue_is_empty(event_q)) {
-            ucs_queue_del_iter(&iface->active_queue, iter);
-        }
-    }
-
-    return count;
-}
-
-static ucs_status_t uct_cuda_copy_iface_event_fd_arm(uct_iface_h tl_iface,
-                                                    unsigned events)
-{
-    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
-    ucs_status_t status;
-    CUstream *stream;
-    ucs_queue_head_t *event_q;
-    uct_cuda_copy_queue_desc_t *q_desc;
-    ucs_queue_iter_t iter;
-
-    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
-        event_q = &q_desc->event_queue;
-        if (uct_cuda_copy_queue_head_ready(event_q)) {
-            return UCS_ERR_BUSY;
-        }
-    }
-
-    status = ucs_async_eventfd_poll(iface->super.eventfd);
-    if (status == UCS_OK) {
-        return UCS_ERR_BUSY;
-    } else if (status == UCS_ERR_IO_ERROR) {
-        return status;
-    }
-
-    ucs_assertv(status == UCS_ERR_NO_PROGRESS, "%s", ucs_status_string(status));
-
-    ucs_queue_for_each_safe(q_desc, iter, &iface->active_queue, queue) {
-        event_q = &q_desc->event_queue;
-        stream  = &q_desc->stream;
-        if (!ucs_queue_is_empty(event_q)) {
-            status =
-#if (__CUDACC_VER_MAJOR__ >= 100000)
-                UCT_CUDADRV_FUNC_LOG_ERR(
-                        cuLaunchHostFunc(*stream,
-                                         uct_cuda_base_iface_stream_cb_fxn,
-                                         &iface->super));
-#else
-                UCT_CUDADRV_FUNC_LOG_ERR(
-                        cuStreamAddCallback(*stream,
-                                            uct_cuda_base_iface_stream_cb_fxn,
-                                            &iface->super, 0));
-#endif
-            if (UCS_OK != status) {
-                return status;
-            }
-        }
-    }
-
-    return UCS_OK;
-}
-
 static uct_iface_ops_t uct_cuda_copy_iface_ops = {
     .ep_get_short             = uct_cuda_copy_ep_get_short,
     .ep_put_short             = uct_cuda_copy_ep_put_short,
@@ -300,62 +162,19 @@ static uct_iface_ops_t uct_cuda_copy_iface_ops = {
     .ep_fence                 = uct_base_ep_fence,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cuda_copy_ep_t),
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_ep_t),
-    .iface_flush              = uct_cuda_copy_iface_flush,
+    .iface_flush              = uct_cuda_base_iface_flush,
     .iface_fence              = uct_base_iface_fence,
     .iface_progress_enable    = uct_base_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
-    .iface_progress           = uct_cuda_copy_iface_progress,
+    .iface_progress           = uct_cuda_base_iface_progress,
     .iface_event_fd_get       = uct_cuda_base_iface_event_fd_get,
-    .iface_event_arm          = uct_cuda_copy_iface_event_fd_arm,
+    .iface_event_arm          = uct_cuda_base_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_iface_t),
     .iface_query              = uct_cuda_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_cuda_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
 };
-
-static void
-uct_cuda_copy_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
-{
-    uct_cuda_copy_event_desc_t *base = (uct_cuda_copy_event_desc_t*)obj;
-
-    memset(base, 0 , sizeof(*base));
-    UCT_CUDADRV_FUNC_LOG_ERR(
-            cuEventCreate(&base->event, CU_EVENT_DISABLE_TIMING));
-}
-
-static int uct_cuda_copy_is_ctx_valid(uct_cuda_copy_ctx_rsc_t *ctx_rsc)
-{
-#if CUDA_VERSION >= 12000
-    unsigned long long ctx_id;
-    CUresult result;
-
-    result = uct_cuda_base_ctx_get_id(ctx_rsc->ctx, &ctx_id);
-    if (result == CUDA_ERROR_CONTEXT_IS_DESTROYED) {
-        return 0;
-    } else if (result != CUDA_SUCCESS) {
-        UCT_CUDADRV_LOG(cuCtxGetId, UCS_LOG_LEVEL_WARN, result);
-        return 0;
-    }
-
-    return ctx_id == ctx_rsc->ctx_id;
-#else
-    /* Best effort check on older Cuda versions */
-    return uct_cuda_base_is_context_valid(ctx_rsc->ctx);
-#endif
-}
-
-static void uct_cuda_copy_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
-{
-    uct_cuda_copy_event_desc_t *base = obj;
-    uct_cuda_copy_ctx_rsc_t *ctx_rsc = ucs_container_of(mp,
-                                                        uct_cuda_copy_ctx_rsc_t,
-                                                        event_mp);
-
-    if (uct_cuda_copy_is_ctx_valid(ctx_rsc)) {
-        UCT_CUDADRV_FUNC_LOG_WARN(cuEventDestroy(base->event));
-    }
-}
 
 static ucs_status_t
 uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
@@ -429,14 +248,6 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     return UCS_OK;
 }
 
-static ucs_mpool_ops_t uct_cuda_copy_event_desc_mpool_ops = {
-    .chunk_alloc   = ucs_mpool_chunk_malloc,
-    .chunk_release = ucs_mpool_chunk_free,
-    .obj_init      = uct_cuda_copy_event_desc_init,
-    .obj_cleanup   = uct_cuda_copy_event_desc_cleanup,
-    .obj_str       = NULL
-};
-
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .iface_estimate_perf   = uct_cuda_copy_estimate_perf,
     .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
@@ -447,75 +258,50 @@ static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .ep_is_connected       = uct_base_ep_is_connected
 };
 
-ucs_status_t uct_cuda_copy_ctx_rsc_create(uct_cuda_copy_iface_t *iface,
-                                          unsigned long long ctx_id,
-                                          uct_cuda_copy_ctx_rsc_t **ctx_rsc_p)
+static uct_cuda_ctx_rsc_t * uct_cuda_copy_ctx_rsc_create(uct_iface_h tl_iface)
 {
-    CUcontext ctx;
-    ucs_status_t status;
-    ucs_kh_put_t ret;
-    khiter_t iter;
     uct_cuda_copy_ctx_rsc_t *ctx_rsc;
-    ucs_mpool_params_t mp_params;
     ucs_memory_type_t src, dst;
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&ctx));
-    if (status != UCS_OK) {
-        return status;
-    } else if (ctx == NULL) {
-        ucs_error("no cuda context bound to calling thread");
-        return UCS_ERR_IO_ERROR;
-    }
-
-    iter = kh_put(cuda_copy_ctx_rscs, &iface->ctx_rscs, ctx_id, &ret);
-    if (ret == UCS_KH_PUT_FAILED) {
-        ucs_error("failed to allocate cuda context resource hash entry");
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    ucs_assertv_always(ret != UCS_KH_PUT_KEY_PRESENT,
-                       "the key has already been added iface=%p key=%llu",
-                       iface, ctx_id);
 
     ctx_rsc = ucs_malloc(sizeof(*ctx_rsc), "uct_cuda_copy_ctx_rsc_t");
     if (ctx_rsc == NULL) {
-        ucs_error("failed to allocate cuda context resource struct");
-        status = UCS_ERR_NO_MEMORY;
-        goto err_del_iter;
-    }
-
-    ucs_mpool_params_reset(&mp_params);
-    mp_params.elem_size       = sizeof(uct_cuda_copy_event_desc_t);
-    mp_params.elems_per_chunk = 128;
-    mp_params.max_elems       = iface->config.max_cuda_events;
-    mp_params.ops             = &uct_cuda_copy_event_desc_mpool_ops;
-    mp_params.name            = "cuda_copy_event_descriptors";
-
-    status = ucs_mpool_init(&mp_params, &ctx_rsc->event_mp);
-    if (status != UCS_OK) {
-        goto err_free_ctx_rsc;
+        ucs_error("failed to allocate cuda copy context resource struct");
+        return NULL;
     }
 
     ucs_memory_type_for_each(src) {
         ucs_memory_type_for_each(dst) {
-            ctx_rsc->queue_desc[src][dst].stream = NULL;
-            ucs_queue_head_init(&ctx_rsc->queue_desc[src][dst].event_queue);
+            uct_cuda_base_queue_desc_init(&ctx_rsc->queue_desc[src][dst]);
         }
     }
 
-    ctx_rsc->short_stream            = NULL;
-    ctx_rsc->ctx                     = ctx;
-    ctx_rsc->ctx_id                  = ctx_id;
-    kh_value(&iface->ctx_rscs, iter) = ctx_rsc;
-    *ctx_rsc_p                       = ctx_rsc;
-    return UCS_OK;
-
-err_free_ctx_rsc:
-    ucs_free(ctx_rsc);
-err_del_iter:
-    kh_del(cuda_copy_ctx_rscs, &iface->ctx_rscs, iter);
-    return UCS_ERR_NO_MEMORY;
+    ctx_rsc->short_stream = NULL;
+    return &ctx_rsc->super;
 }
+
+static void uct_cuda_copy_ctx_rsc_destroy(uct_iface_h tl_iface,
+                                          uct_cuda_ctx_rsc_t *cuda_ctx_rsc)
+{
+    uct_cuda_copy_ctx_rsc_t *ctx_rsc = ucs_derived_of(cuda_ctx_rsc,
+                                                      uct_cuda_copy_ctx_rsc_t);
+    ucs_memory_type_t src, dst;
+
+    ucs_memory_type_for_each(src) {
+        ucs_memory_type_for_each(dst) {
+            uct_cuda_base_queue_desc_destroy(cuda_ctx_rsc,
+                                             &ctx_rsc->queue_desc[src][dst]);
+        }
+    }
+
+    uct_cuda_base_stream_destroy(cuda_ctx_rsc, &ctx_rsc->short_stream);
+    ucs_free(ctx_rsc);
+}
+
+static uct_cuda_iface_ops_t uct_cuda_iface_ops = {
+    .create_rsc     = uct_cuda_copy_ctx_rsc_create,
+    .destroy_rsc    = uct_cuda_copy_ctx_rsc_destroy,
+    .complete_event = (uct_cuda_complete_event_fn_t)ucs_empty_function
+};
 
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
@@ -534,65 +320,18 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
         return status;
     }
 
-    self->id                     = ucs_generate_uuid((uintptr_t)self);
-    self->config.max_poll        = config->max_poll;
-    self->config.max_cuda_events = config->max_cuda_events;
-    self->config.bw              = config->bw;
+    self->id                           = ucs_generate_uuid((uintptr_t)self);
+    self->config.bw                    = config->bw;
+    self->super.ops                    = &uct_cuda_iface_ops;
+    self->super.config.max_events      = config->max_cuda_events;
+    self->super.config.max_poll        = config->max_poll;
+    self->super.config.event_desc_size = sizeof(uct_cuda_event_desc_t);
     UCS_STATIC_BITMAP_RESET_ALL(&self->streams_to_sync);
-
-    kh_init_inplace(cuda_copy_ctx_rscs, &self->ctx_rscs);
-
-    ucs_queue_head_init(&self->active_queue);
-
     return UCS_OK;
-}
-
-static void uct_cuda_copy_stream_destroy(CUstream *stream_p, int valid_ctx)
-{
-    if ((*stream_p == NULL) || !valid_ctx) {
-        return;
-    }
-
-    UCT_CUDADRV_FUNC_LOG_WARN(cuStreamDestroy(*stream_p));
-}
-
-static void uct_cuda_copy_ctx_rsc_destroy(uct_cuda_copy_ctx_rsc_t *ctx_rsc)
-{
-    int ctx_rsc_valid = uct_cuda_copy_is_ctx_valid(ctx_rsc);
-    ucs_memory_type_t src, dst;
-    ucs_queue_head_t *event_q;
-
-    ucs_memory_type_for_each(src) {
-        ucs_memory_type_for_each(dst) {
-            event_q = &ctx_rsc->queue_desc[src][dst].event_queue;
-            if (!ucs_queue_is_empty(event_q)) {
-                ucs_warn("cuda context %llu stream[%d][%d] being destroyed with"
-                         " %zu outstanding events",
-                         ctx_rsc->ctx_id, src, dst, ucs_queue_length(event_q));
-            }
-
-            uct_cuda_copy_stream_destroy(&ctx_rsc->queue_desc[src][dst].stream,
-                                         ctx_rsc_valid);
-        }
-    }
-
-    uct_cuda_copy_stream_destroy(&ctx_rsc->short_stream, ctx_rsc_valid);
-    ucs_mpool_cleanup(&ctx_rsc->event_mp, 1);
-    ucs_free(ctx_rsc);
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_copy_iface_t)
 {
-    uct_cuda_copy_ctx_rsc_t *ctx_rsc;
-
-    uct_base_iface_progress_disable(&self->super.super.super,
-                                    UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-
-    kh_foreach_value(&self->ctx_rscs, ctx_rsc, {
-        uct_cuda_copy_ctx_rsc_destroy(ctx_rsc);
-    });
-
-    kh_destroy_inplace(cuda_copy_ctx_rscs, &self->ctx_rscs);
 }
 
 UCS_CLASS_DEFINE(uct_cuda_copy_iface_t, uct_cuda_iface_t);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -9,7 +9,6 @@
 
 #include <ucs/datastruct/static_bitmap.h>
 #include <ucs/memory/memory_type.h>
-#include <ucs/datastruct/khash.h>
 #include <uct/base/uct_iface.h>
 #include <uct/cuda/base/cuda_iface.h>
 
@@ -41,16 +40,6 @@ typedef uint64_t uct_cuda_copy_iface_addr_t;
 typedef ucs_static_bitmap_s(UCT_CUDA_MEMORY_TYPES_MAP) uct_cu_stream_bitmap_t;
 
 
-typedef struct uct_cuda_copy_queue_desc {
-    /* stream on which asynchronous memcpy operations are enqueued */
-    CUstream                    stream;
-    /* queue of cuda events */
-    ucs_queue_head_t            event_queue;
-    /* needed to allow queue descriptor to be added to iface->active_queue */
-    ucs_queue_elem_t            queue;
-} uct_cuda_copy_queue_desc_t;
-
-
 typedef struct uct_cuda_copy_bw {
     double            h2d;
     double            d2h;
@@ -59,40 +48,22 @@ typedef struct uct_cuda_copy_bw {
 } uct_cuda_copy_bw_t;
 
 
-typedef struct uct_cuda_copy_ctx_rsc {
-    /* CUDA context handle */
-    CUcontext                  ctx;
-    /* CUDA context id */
-    unsigned long long         ctx_id;
-    /* pool of cuda events to check completion of memcpy operations */
-    ucs_mpool_t                event_mp;
+typedef struct {
+    uct_cuda_ctx_rsc_t    super;
     /* stream used to issue short operations */
-    CUstream                   short_stream;
+    CUstream              short_stream;
     /* array of queue descriptors for each src/dst memory type combination */
-    uct_cuda_copy_queue_desc_t queue_desc[UCS_MEMORY_TYPE_LAST]
-                                         [UCS_MEMORY_TYPE_LAST];
+    uct_cuda_queue_desc_t queue_desc[UCS_MEMORY_TYPE_LAST]
+                                    [UCS_MEMORY_TYPE_LAST];
 } uct_cuda_copy_ctx_rsc_t;
-
-
-/* Hash map for CUDA context resources. The key is the CUDA context Id. */
-KHASH_INIT(cuda_copy_ctx_rscs, unsigned long long, uct_cuda_copy_ctx_rsc_t*, 1,
-           kh_int64_hash_func, kh_int64_hash_equal);
 
 
 typedef struct uct_cuda_copy_iface {
     uct_cuda_iface_t            super;
     /* used to store uuid and check iface reachability */
     uct_cuda_copy_iface_addr_t  id;
-    /* CUDA resources per context */
-    khash_t(cuda_copy_ctx_rscs) ctx_rscs;
-    /* list of queues which require progress */
-    ucs_queue_head_t            active_queue;
-    /* fd to get event notifications */
-    int                         eventfd;
     /* config parameters to control cuda copy transport */
     struct {
-        unsigned                max_poll;
-        unsigned                max_cuda_events;
         uct_cuda_copy_bw_t      bw;
     } config;
     /* handler to support arm/wakeup feature */
@@ -115,32 +86,11 @@ typedef struct uct_cuda_copy_iface_config {
 } uct_cuda_copy_iface_config_t;
 
 
-typedef struct uct_cuda_copy_event_desc {
-    CUevent          event;
-    uct_completion_t *comp;
-    ucs_queue_elem_t queue;
-} uct_cuda_copy_event_desc_t;
-
-
 static UCS_F_ALWAYS_INLINE unsigned
 uct_cuda_copy_flush_bitmap_idx(ucs_memory_type_t src_mem_type,
                                ucs_memory_type_t dst_mem_type)
 {
     return (src_mem_type * UCS_MEMORY_TYPE_LAST) + dst_mem_type;
 }
-
-
-/**
- * Create the resources of the given CUDA context.
- *
- * @param [in]  iface     CUDA copy transport interface
- * @param [in]  ctx_id    CUDA context id
- * @param [out] ctx_rsc_p Returned pointer to context resources
- *
- * @return Error code as defined by @ref ucs_status_t.
- */
-ucs_status_t uct_cuda_copy_ctx_rsc_create(uct_cuda_copy_iface_t *iface,
-                                          unsigned long long ctx_id,
-                                          uct_cuda_copy_ctx_rsc_t **ctx_rsc_p);
 
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -314,116 +314,22 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_cuda_ipc_iface_flush(uct_iface_h tl_iface, unsigned flags,
-                         uct_completion_t *comp)
+static void uct_cuda_ipc_complete_event(uct_iface_h tl_iface,
+                                        uct_cuda_event_desc_t *cuda_event)
 {
-    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
-
-    if (comp != NULL) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
-    if (ucs_queue_is_empty(&iface->outstanding_d2d_event_q)) {
-        UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
-        return UCS_OK;
-    }
-
-    UCT_TL_IFACE_STAT_FLUSH_WAIT(ucs_derived_of(tl_iface, uct_base_iface_t));
-    return UCS_INPROGRESS;
-}
-
-static UCS_F_ALWAYS_INLINE unsigned
-uct_cuda_ipc_progress_event_q(uct_cuda_ipc_iface_t *iface,
-                              ucs_queue_head_t *event_q)
-{
-    unsigned count = 0;
-    uct_cuda_ipc_event_desc_t *cuda_ipc_event;
-    ucs_queue_iter_t iter;
-    ucs_status_t status;
-    unsigned max_events = iface->config.max_poll;
-
-    ucs_queue_for_each_safe(cuda_ipc_event, iter, event_q, queue) {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuEventQuery(cuda_ipc_event->event));
-        if (UCS_INPROGRESS == status) {
-            continue;
-        } else if (UCS_OK != status) {
-            return status;
-        }
-
-        ucs_queue_del_iter(event_q, iter);
-        if (cuda_ipc_event->comp != NULL) {
-            uct_invoke_completion(cuda_ipc_event->comp, UCS_OK);
-        }
-
-        status = uct_cuda_ipc_unmap_memhandle(cuda_ipc_event->pid,
-                                              cuda_ipc_event->d_bptr,
-                                              cuda_ipc_event->mapped_addr,
-                                              iface->config.enable_cache);
-        if (status != UCS_OK) {
-            ucs_fatal("failed to unmap addr:%p", cuda_ipc_event->mapped_addr);
-        }
-
-        ucs_trace_poll("CUDA_IPC Event Done :%p", cuda_ipc_event);
-        iface->stream_refcount[cuda_ipc_event->stream_id]--;
-        ucs_mpool_put(cuda_ipc_event);
-        count++;
-
-        if (count >= max_events) {
-            break;
-        }
-    }
-
-    return count;
-}
-
-static unsigned uct_cuda_ipc_iface_progress(uct_iface_h tl_iface)
-{
-    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
-
-    return uct_cuda_ipc_progress_event_q(iface, &iface->outstanding_d2d_event_q);
-}
-
-static ucs_status_t uct_cuda_ipc_iface_event_fd_arm(uct_iface_h tl_iface,
-                                                    unsigned events)
-{
-    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
-    int i;
+    uct_cuda_ipc_iface_t *iface               = ucs_derived_of(tl_iface,
+                                                               uct_cuda_ipc_iface_t);
+    uct_cuda_ipc_event_desc_t *cuda_ipc_event = ucs_derived_of(cuda_event,
+                                                               uct_cuda_ipc_event_desc_t);
     ucs_status_t status;
 
-    if (uct_cuda_ipc_progress_event_q(iface, &iface->outstanding_d2d_event_q)) {
-        return UCS_ERR_BUSY;
+    status = uct_cuda_ipc_unmap_memhandle(cuda_ipc_event->pid,
+                                          cuda_ipc_event->d_bptr,
+                                          cuda_ipc_event->mapped_addr,
+                                          iface->config.enable_cache);
+    if (status != UCS_OK) {
+        ucs_fatal("failed to unmap addr:%p", cuda_ipc_event->mapped_addr);
     }
-
-    status = ucs_async_eventfd_poll(iface->super.eventfd);
-    if (status == UCS_OK) {
-        return UCS_ERR_BUSY;
-    } else if (status == UCS_ERR_IO_ERROR) {
-        return status;
-    }
-
-    if (iface->streams_initialized) {
-        for (i = 0; i < iface->config.max_streams; i++) {
-            if (iface->stream_refcount[i]) {
-                status =
-#if (__CUDACC_VER_MAJOR__ >= 100000)
-                UCT_CUDADRV_FUNC_LOG_ERR(
-                        cuLaunchHostFunc(iface->stream_d2d[i],
-                                         uct_cuda_base_iface_stream_cb_fxn,
-                                         &iface->super));
-#else
-                UCT_CUDADRV_FUNC_LOG_ERR(
-                        cuStreamAddCallback(iface->stream_d2d[i],
-                                            uct_cuda_base_iface_stream_cb_fxn,
-                                            &iface->super, 0));
-#endif
-                if (UCS_OK != status) {
-                    return status;
-                }
-            }
-        }
-    }
-    return UCS_OK;
 }
 
 static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
@@ -436,61 +342,19 @@ static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
     .ep_check                 = (uct_ep_check_func_t)ucs_empty_function_return_unsupported,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_cuda_ipc_ep_t),
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_ep_t),
-    .iface_flush              = uct_cuda_ipc_iface_flush,
+    .iface_flush              = uct_cuda_base_iface_flush,
     .iface_fence              = uct_base_iface_fence,
     .iface_progress_enable    = uct_base_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
-    .iface_progress           = uct_cuda_ipc_iface_progress,
+    .iface_progress           = uct_cuda_base_iface_progress,
     .iface_event_fd_get       = uct_cuda_base_iface_event_fd_get,
-    .iface_event_arm          = uct_cuda_ipc_iface_event_fd_arm,
+    .iface_event_arm          = uct_cuda_base_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_iface_t),
     .iface_query              = uct_cuda_ipc_iface_query,
     .iface_get_device_address = uct_cuda_ipc_iface_get_device_address,
     .iface_get_address        = uct_cuda_ipc_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
 };
-
-static void uct_cuda_ipc_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
-{
-    uct_cuda_ipc_event_desc_t *base = (uct_cuda_ipc_event_desc_t *) obj;
-
-    memset(base, 0, sizeof(*base));
-    UCT_CUDADRV_FUNC_LOG_ERR(cuEventCreate(&base->event, CU_EVENT_DISABLE_TIMING));
-}
-
-static void uct_cuda_ipc_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
-{
-    uct_cuda_ipc_event_desc_t *base = (uct_cuda_ipc_event_desc_t *) obj;
-    uct_cuda_ipc_iface_t *iface     = ucs_container_of(mp,
-                                                       uct_cuda_ipc_iface_t,
-                                                       event_desc);
-    CUcontext cuda_context;
-
-    UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
-    if (uct_cuda_base_context_match(cuda_context, iface->cuda_context)) {
-        UCT_CUDADRV_FUNC_LOG_ERR(cuEventDestroy(base->event));
-    }
-}
-
-ucs_status_t uct_cuda_ipc_iface_init_streams(uct_cuda_ipc_iface_t *iface)
-{
-    ucs_status_t status;
-    int i;
-
-    for (i = 0; i < iface->config.max_streams; i++) {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuStreamCreate(&iface->stream_d2d[i],
-                                                         CU_STREAM_NON_BLOCKING));
-        if (UCS_OK != status) {
-            return status;
-        }
-
-        iface->stream_refcount[i] = 0;
-    }
-
-    iface->streams_initialized = 1;
-
-    return UCS_OK;
-}
 
 static ucs_status_t
 uct_cuda_ipc_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
@@ -545,14 +409,6 @@ uct_cuda_ipc_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     return UCS_OK;
 }
 
-static ucs_mpool_ops_t uct_cuda_ipc_event_desc_mpool_ops = {
-    .chunk_alloc   = ucs_mpool_chunk_malloc,
-    .chunk_release = ucs_mpool_chunk_free,
-    .obj_init      = uct_cuda_ipc_event_desc_init,
-    .obj_cleanup   = uct_cuda_ipc_event_desc_cleanup,
-    .obj_str       = NULL
-};
-
 static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .iface_estimate_perf   = uct_cuda_ipc_estimate_perf,
     .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
@@ -563,13 +419,51 @@ static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .ep_is_connected       = uct_cuda_ipc_ep_is_connected
 };
 
+static uct_cuda_ctx_rsc_t * uct_cuda_ipc_ctx_rsc_create(uct_iface_h tl_iface)
+{
+    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    uct_cuda_ipc_ctx_rsc_t *ctx_rsc;
+    unsigned i;
+
+    ctx_rsc = ucs_malloc(sizeof(*ctx_rsc), "uct_cuda_ipc_ctx_rsc_t");
+    if (ctx_rsc == NULL) {
+        ucs_error("failed to allocate cuda ipc context resource struct");
+        return NULL;
+    }
+
+    for (i = 0; i < iface->config.max_streams; i++) {
+        uct_cuda_base_queue_desc_init(&ctx_rsc->queue_desc[i]);
+    }
+
+    return &ctx_rsc->super;
+}
+
+static void uct_cuda_ipc_ctx_rsc_destroy(uct_iface_h tl_iface,
+                                         uct_cuda_ctx_rsc_t *cuda_ctx_rsc)
+{
+    uct_cuda_ipc_iface_t *iface     = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
+    uct_cuda_ipc_ctx_rsc_t *ctx_rsc = ucs_derived_of(cuda_ctx_rsc, uct_cuda_ipc_ctx_rsc_t);
+    unsigned i;
+
+    for (i = 0; i < iface->config.max_streams; i++) {
+        uct_cuda_base_queue_desc_destroy(cuda_ctx_rsc, &ctx_rsc->queue_desc[i]);
+    }
+
+    ucs_free(ctx_rsc);
+}
+
+static uct_cuda_iface_ops_t uct_cuda_iface_ops = {
+    .create_rsc     = uct_cuda_ipc_ctx_rsc_create,
+    .destroy_rsc    = uct_cuda_ipc_ctx_rsc_destroy,
+    .complete_event = uct_cuda_ipc_complete_event
+};
+
 static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
 {
     uct_cuda_ipc_iface_config_t *config = NULL;
     ucs_status_t status;
-    ucs_mpool_params_t mp_params;
 
     config = ucs_derived_of(tl_config, uct_cuda_ipc_iface_config_t);
     UCS_CLASS_CALL_SUPER_INIT(uct_cuda_iface_t, &uct_cuda_ipc_iface_ops,
@@ -586,49 +480,15 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_ipc_iface_t, uct_md_h md, uct_worker_h worke
         self->config.bandwidth = uct_cuda_ipc_iface_get_bw() ;
     }
 
-    ucs_mpool_params_reset(&mp_params);
-    mp_params.elem_size       = sizeof(uct_cuda_ipc_event_desc_t);
-    mp_params.elems_per_chunk = 128;
-    mp_params.max_elems       = self->config.max_cuda_ipc_events;
-    mp_params.ops             = &uct_cuda_ipc_event_desc_mpool_ops;
-    mp_params.name            = "CUDA_IPC EVENT objects";
-    status = ucs_mpool_init(&mp_params, &self->event_desc);
-    if (UCS_OK != status) {
-        ucs_error("mpool creation failed");
-        return UCS_ERR_IO_ERROR;
-    }
-
-    self->streams_initialized = 0;
-    self->cuda_context        = 0;
-    ucs_queue_head_init(&self->outstanding_d2d_event_q);
-
+    self->super.ops                    = &uct_cuda_iface_ops;
+    self->super.config.max_events      = self->config.max_cuda_ipc_events;
+    self->super.config.max_poll        = self->config.max_poll;
+    self->super.config.event_desc_size = sizeof(uct_cuda_ipc_event_desc_t);
     return UCS_OK;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_cuda_ipc_iface_t)
 {
-    ucs_status_t status;
-    int i;
-    CUcontext cuda_context;
-
-    UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_context));
-
-    if (self->streams_initialized &&
-        uct_cuda_base_context_match(cuda_context, self->cuda_context)) {
-        for (i = 0; i < self->config.max_streams; i++) {
-            status = UCT_CUDADRV_FUNC_LOG_ERR(cuStreamDestroy(self->stream_d2d[i]));
-            if (UCS_OK != status) {
-                continue;
-            }
-
-            ucs_assert(self->stream_refcount[i] == 0);
-        }
-        self->streams_initialized = 0;
-    }
-
-    uct_base_iface_progress_disable(&self->super.super.super,
-                                    UCT_PROGRESS_SEND | UCT_PROGRESS_RECV);
-    ucs_mpool_cleanup(&self->event_desc, 1);
 }
 
 ucs_status_t

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -19,7 +19,7 @@
 #define UCT_CUDA_IPC_MAX_PEERS 128
 
 
-typedef struct uct_cuda_ipc_iface_config_params {
+typedef struct {
     unsigned                max_poll;            /* query attempts w.o success */
     unsigned                max_streams;         /* # concurrent streams for || progress*/
     unsigned                max_cuda_ipc_events; /* max mpool entries */
@@ -30,38 +30,31 @@ typedef struct uct_cuda_ipc_iface_config_params {
     double                  overhead;            /* estimated CPU overhead */
 } uct_cuda_ipc_iface_config_params_t;
 
-typedef struct uct_cuda_ipc_iface {
+
+typedef struct {
     uct_cuda_iface_t                   super;
-    ucs_mpool_t                        event_desc;              /* cuda event desc */
-    ucs_queue_head_t                   outstanding_d2d_event_q; /* stream for outstanding d2d */
-    int                                eventfd;                 /* get event notifications */
-    int                                streams_initialized;     /* indicates if stream created */
-    CUcontext                          cuda_context;
-    CUstream                           stream_d2d[UCT_CUDA_IPC_MAX_PEERS];
-                                                                /* per-peer stream */
-    unsigned long                      stream_refcount[UCT_CUDA_IPC_MAX_PEERS];
-                                                                /* per stream outstanding ops */
-    uct_cuda_ipc_iface_config_params_t config;                  /* configurable iface parameters */
+    uct_cuda_ipc_iface_config_params_t config;
 } uct_cuda_ipc_iface_t;
 
 
-typedef struct uct_cuda_ipc_iface_config {
+typedef struct {
     uct_iface_config_t                 super;
     uct_cuda_ipc_iface_config_params_t params;
 } uct_cuda_ipc_iface_config_t;
 
 
-typedef struct uct_cuda_ipc_event_desc {
-    CUevent           event;
-    void              *mapped_addr;
-    unsigned          stream_id;
-    uct_completion_t  *comp;
-    ucs_queue_elem_t  queue;
-    uct_cuda_ipc_ep_t *ep;
-    uintptr_t         d_bptr;
-    pid_t             pid;
+typedef struct {
+    uct_cuda_event_desc_t super;
+    void                  *mapped_addr;
+    uct_cuda_ipc_ep_t     *ep;
+    uintptr_t             d_bptr;
+    pid_t                 pid;
 } uct_cuda_ipc_event_desc_t;
 
 
-ucs_status_t uct_cuda_ipc_iface_init_streams(uct_cuda_ipc_iface_t *iface);
+typedef struct {
+    uct_cuda_ctx_rsc_t    super;
+    uct_cuda_queue_desc_t queue_desc[UCT_CUDA_IPC_MAX_PEERS];
+} uct_cuda_ipc_ctx_rsc_t;
+
 #endif


### PR DESCRIPTION
## What?
Original PR: https://github.com/openucx/ucx/pull/9654

Currently CUDA_IPC transport uses integer stream_count to track outstanding work but in preparation for multi-device support, this PR moves to active_queue usage similar to cuda_copy transport. This will eventually also help unify more common code shared between cuda_ipc and cuda_copy when it comes to stream/event usage. This PR also removes max peer limitations.