### PR TITLE
UCP/PROTO: Minimal version of protocol lane selection

### DIFF
--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -391,4 +391,20 @@ ucp_proto_request_pack_rkey(ucp_request_t *req, ucp_md_map_t md_map,
     return packed_rkey_size;
 }
 
+static UCS_F_ALWAYS_INLINE ucp_rsc_index_t
+ucp_proto_common_get_rsc_index(const ucp_proto_init_params_t *params,
+                               ucp_lane_index_t lane)
+{
+    ucs_assert(lane < UCP_MAX_LANES);
+    return params->ep_config_key->lanes[lane].rsc_index;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_rsc_index_t
+ucp_proto_common_get_dev_index(const ucp_proto_init_params_t *params,
+                               ucp_lane_index_t lane)
+{
+    ucp_rsc_index_t rsc_index = ucp_proto_common_get_rsc_index(params, lane);
+    return params->worker->context->tl_rscs[rsc_index].dev_index;
+}
+
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -20,6 +20,127 @@
 #include <ucs/debug/log.h>
 
 
+static UCS_F_ALWAYS_INLINE double
+ucp_proto_multi_get_avail_bw(const ucp_proto_init_params_t *params,
+                             ucp_lane_index_t lane,
+                             const ucp_proto_common_tl_perf_t *lane_perf,
+                             const ucp_proto_lane_selection_t *selection)
+{
+    /* Minimal path ratio */
+    static const double MIN_RATIO = 0.01;
+    ucp_context_h context         = params->worker->context;
+    double multi_path_ratio       = context->config.ext.multi_path_ratio;
+    ucp_rsc_index_t dev_index     = ucp_proto_common_get_dev_index(params, lane);
+    uint8_t path_index            = selection->dev_count[dev_index];
+    double ratio;
+
+    if (UCS_CONFIG_DBL_IS_AUTO(multi_path_ratio)) {
+        ratio = ucs_min(1.0 - (lane_perf->path_ratio * path_index),
+                        lane_perf->path_ratio);
+    } else {
+        ratio = 1.0 - (multi_path_ratio * path_index);
+    }
+
+    if (ratio < MIN_RATIO) {
+        /* The iface BW is entirely consumed by the selected paths. But we still
+         * need to assign some minimal BW to the these extra paths in order to
+         * select them. We divide min ratio of the iface BW by path_index so
+         * that each additional path on the same device has lower bandwidth. */
+        ratio = MIN_RATIO / path_index;
+    }
+
+    ucs_trace("ratio=%0.3f path_index=%u avail_bw=" UCP_PROTO_PERF_FUNC_BW_FMT
+              " " UCP_PROTO_LANE_FMT, ratio, path_index,
+              (lane_perf->bandwidth * ratio) / UCS_MBYTE,
+              UCP_PROTO_LANE_ARG(params, lane, lane_perf));
+    return lane_perf->bandwidth * ratio;
+}
+
+static ucp_lane_index_t
+ucp_proto_multi_find_max_avail_bw_lane(const ucp_proto_init_params_t *params,
+                                       const ucp_lane_index_t *lanes,
+                                       const ucp_proto_common_tl_perf_t *lanes_perf,
+                                       const ucp_proto_lane_selection_t *selection,
+                                       ucp_lane_map_t index_map)
+{
+    /* Initial value is 1Bps, so we don't consider lanes with lower available
+     * bandwidth. */
+    double max_avail_bw        = 1.0;
+    ucp_lane_index_t max_index = UCP_NULL_LANE;
+    double avail_bw;
+    const ucp_proto_common_tl_perf_t *lane_perf;
+    ucp_lane_index_t lane, index;
+
+    ucs_assert(index_map != 0);
+    ucs_for_each_bit(index, index_map) {
+        lane      = lanes[index];
+        lane_perf = &lanes_perf[lane];
+        avail_bw  = ucp_proto_multi_get_avail_bw(params, lane, lane_perf,
+                                                 selection);
+        if (avail_bw > max_avail_bw) {
+            max_avail_bw = avail_bw;
+            max_index    = index;
+        }
+    }
+
+    return max_index;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_select_add_lane(ucp_proto_lane_selection_t *selection,
+                          const ucp_proto_init_params_t *params,
+                          ucp_lane_index_t lane)
+{
+    ucp_rsc_index_t dev_index = ucp_proto_common_get_dev_index(params, lane);
+
+    ucs_assertv(selection->num_lanes < UCP_PROTO_MAX_LANES,
+                "selection num_lanes=%u max_lanes=%u", selection->num_lanes,
+                UCP_PROTO_MAX_LANES);
+    selection->lanes[selection->num_lanes++] = lane;
+    selection->lane_map                     |= UCS_BIT(lane);
+    selection->dev_count[dev_index]++;
+}
+
+static void
+ucp_proto_multi_select_bw_lanes(const ucp_proto_init_params_t *params,
+                                const ucp_lane_index_t *lanes,
+                                ucp_lane_index_t num_lanes,
+                                ucp_lane_index_t max_lanes,
+                                const ucp_proto_common_tl_perf_t *lanes_perf,
+                                int fixed_first_lane,
+                                ucp_proto_lane_selection_t *selection)
+{
+    ucp_lane_index_t i, lane_index;
+    ucp_lane_map_t index_map;
+
+    memset(selection, 0, sizeof(*selection));
+
+    /* Select all available indexes */
+    index_map = UCS_MASK(num_lanes);
+
+    if (fixed_first_lane) {
+        ucp_proto_select_add_lane(selection, params, lanes[0]);
+        index_map &= ~UCS_BIT(0);
+    }
+
+    for (i = fixed_first_lane? 1 : 0; i < ucs_min(max_lanes, num_lanes); ++i) {
+        /* Greedy algorithm: find the best option at every step */
+        lane_index = ucp_proto_multi_find_max_avail_bw_lane(params, lanes,
+                                                            lanes_perf, selection,
+                                                            index_map);
+        if (lane_index == UCP_NULL_LANE) {
+            break;
+        }
+
+        ucp_proto_select_add_lane(selection, params, lanes[lane_index]);
+        index_map &= ~UCS_BIT(lane_index);
+    }
+
+    /* TODO: Aggregate performance:
+     * Split full iface bandwidth between selected paths, according to the total
+     * path ratio */
+}
+
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                                   const char *perf_name,
                                   ucp_proto_perf_t **perf_p,
@@ -32,14 +153,15 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     ucp_proto_common_tl_perf_t *lane_perf, perf;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     double max_bandwidth, max_frag_ratio, min_bandwidth;
-    ucp_lane_index_t i, lane, num_lanes;
+    ucp_lane_index_t i, lane, num_lanes, num_fast_lanes;
     ucp_proto_multi_lane_priv_t *lpriv;
     ucp_proto_perf_node_t *perf_node;
     size_t max_frag, min_length, min_end_offset, min_chunk;
-    ucp_lane_map_t lane_map;
+    ucp_proto_lane_selection_t selection;
     ucp_md_map_t reg_md_map;
     uint32_t weight_sum;
     ucs_status_t status;
+    int fixed_first_lane;
 
     ucs_assert(params->max_lanes <= UCP_PROTO_MAX_LANES);
 
@@ -97,30 +219,46 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     perf.recv_overhead      = 0;
     perf.latency            = 0;
     perf.sys_latency        = 0;
-    lane_map                = 0;
     max_frag_ratio          = 0;
     min_bandwidth           = DBL_MAX;
 
-    for (i = 0; (i < num_lanes) && (ucs_popcount(lane_map) < params->max_lanes);
-         ++i) {
+    /* Filter out slow lanes */
+    fixed_first_lane = params->first.lane_type != params->middle.lane_type;
+    for (i = fixed_first_lane ? 1 : 0, num_fast_lanes = i; i < num_lanes; ++i) {
         lane      = lanes[i];
         lane_perf = &lanes_perf[lane];
         if ((lane_perf->bandwidth * max_bw_ratio) < max_bandwidth) {
             /* Bandwidth on this lane is too low compared to the fastest
                available lane, so it's not worth using it */
-            continue;
+            ucp_proto_perf_node_deref(&lanes_perf_nodes[lane]);
+            ucs_trace("drop " UCP_PROTO_LANE_FMT,
+                      UCP_PROTO_LANE_ARG(&params->super.super, lane, lane_perf));
+        } else {
+            lanes[num_fast_lanes++] = lane;
+            ucs_trace("avail " UCP_PROTO_LANE_FMT,
+                      UCP_PROTO_LANE_ARG(&params->super.super, lane, lane_perf));
         }
+    }
 
-        ucs_trace("lane[%d]" UCP_PROTO_TIME_FMT(send_pre_overhead)
+    num_lanes = num_fast_lanes;
+    ucp_proto_multi_select_bw_lanes(&params->super.super, lanes, num_lanes,
+                                    params->max_lanes, lanes_perf,
+                                    fixed_first_lane, &selection);
+
+    ucs_trace("selected %u lanes for %s", selection.num_lanes,
+              ucp_proto_id_field(params->super.super.proto_id, name));
+    ucs_log_indent(1);
+
+    for (i = 0; i < selection.num_lanes; ++i) {
+        lane      = selection.lanes[i];
+        lane_perf = &lanes_perf[lane];
+        ucs_trace(UCP_PROTO_LANE_FMT UCP_PROTO_TIME_FMT(send_pre_overhead)
                   UCP_PROTO_TIME_FMT(send_post_overhead)
-                  UCP_PROTO_TIME_FMT(recv_overhead)
-                  " bw " UCP_PROTO_PERF_FUNC_BW_FMT
-                  UCP_PROTO_TIME_FMT(latency), lane,
+                  UCP_PROTO_TIME_FMT(recv_overhead),
+                  UCP_PROTO_LANE_ARG(&params->super.super, lane, lane_perf),
                   UCP_PROTO_TIME_ARG(lane_perf->send_pre_overhead),
                   UCP_PROTO_TIME_ARG(lane_perf->send_post_overhead),
-                  UCP_PROTO_TIME_ARG(lane_perf->recv_overhead),
-                  (lane_perf->bandwidth / UCS_MBYTE),
-                  UCP_PROTO_TIME_ARG(lane_perf->latency));
+                  UCP_PROTO_TIME_ARG(lane_perf->recv_overhead));
 
         /* Calculate maximal bandwidth-to-fragment-size ratio, which is used to
            adjust fragment sizes so they are proportional to bandwidth ratio and
@@ -138,13 +276,15 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         perf.latency             = ucs_max(perf.latency, lane_perf->latency);
         perf.sys_latency         = ucs_max(perf.sys_latency,
                                            lane_perf->sys_latency);
-        lane_map                |= UCS_BIT(lane);
     }
 
+    ucs_log_indent(-1);
+
     /* Initialize multi-lane private data and relative weights */
-    reg_md_map          = ucp_proto_common_reg_md_map(&params->super, lane_map);
+    reg_md_map          = ucp_proto_common_reg_md_map(&params->super,
+                                                      selection.lane_map);
     mpriv->reg_md_map   = reg_md_map | params->initial_reg_md_map;
-    mpriv->lane_map     = lane_map;
+    mpriv->lane_map     = selection.lane_map;
     mpriv->num_lanes    = 0;
     mpriv->min_frag     = 0;
     mpriv->max_frag_sum = 0;
@@ -154,7 +294,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     weight_sum          = 0;
     min_end_offset      = 0;
 
-    ucs_for_each_bit(lane, lane_map) {
+    ucs_for_each_bit(lane, selection.lane_map) {
         ucs_assert(lane < UCP_MAX_LANES);
 
         lpriv     = &mpriv->lanes[mpriv->num_lanes++];
@@ -232,16 +372,16 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         lpriv->opt_align      = ucp_proto_multi_get_lane_opt_align(params, lane);
         mpriv->align_thresh   = ucs_max(mpriv->align_thresh, lpriv->opt_align);
     }
-    ucs_assert(mpriv->num_lanes == ucs_popcount(lane_map));
+    ucs_assert(mpriv->num_lanes == ucs_popcount(selection.lane_map));
 
     /* After this block, 'perf_node' and 'lane_perf_nodes[]' have extra ref */
     if (mpriv->num_lanes == 1) {
-        perf_node = lanes_perf_nodes[ucs_ffs64(lane_map)];
+        perf_node = lanes_perf_nodes[ucs_ffs64(selection.lane_map)];
         ucp_proto_perf_node_ref(perf_node);
     } else {
         perf_node = ucp_proto_perf_node_new_data("multi", "%u lanes",
                                                  mpriv->num_lanes);
-        ucs_for_each_bit(lane, lane_map) {
+        ucs_for_each_bit(lane, selection.lane_map) {
             ucs_assert(lane < UCP_MAX_LANES);
             ucp_proto_perf_node_add_child(perf_node, lanes_perf_nodes[lane]);
         }

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -89,14 +89,17 @@ enum uct_perf_attr_field {
     /** Enables @ref uct_perf_attr_t::bandwidth */
     UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(8),
 
+    /** Enables @ref uct_perf_attr_t::path_bandwidth */
+    UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH     = UCS_BIT(9),
+
     /** Enables @ref uct_perf_attr_t::latency */
-    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(9),
+    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(10),
 
     /** Enable @ref uct_perf_attr_t::max_inflight_eps */
-    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10),
+    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(11),
 
     /** Enable @ref uct_perf_attr_t::flags */
-    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(11)
+    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(12)
 };
 
 /**
@@ -184,6 +187,13 @@ typedef struct {
      * Bandwidth model. This field is set by the UCT layer.
      */
     uct_ppn_bandwidth_t bandwidth;
+
+    /**
+     * Bandwidth of a single interface path. It is smaller than or equal to
+     * @ref bandwidth.
+     * This field is set by the UCT layer.
+     */
+    uct_ppn_bandwidth_t path_bandwidth;
 
     /**
      * Latency as a function of number of endpoints.

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -591,6 +591,10 @@ uct_base_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr)
         perf_attr->bandwidth = iface_attr.bandwidth;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+        perf_attr->path_bandwidth = iface_attr.bandwidth;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_LATENCY) {
         perf_attr->latency = iface_attr.latency;
     }

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -1078,4 +1078,11 @@ static UCS_F_ALWAYS_INLINE int uct_ep_op_is_fetch(uct_ep_operation_t op)
                           UCS_BIT(UCT_EP_OP_ATOMIC_FETCH));
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_perf_attr_has_bandwidth(uint64_t perf_attr_mask)
+{
+    return (perf_attr_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) ||
+           (perf_attr_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH);
+}
+
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -514,6 +514,11 @@ uct_cuda_ipc_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
         perf_attr->bandwidth.shared = uct_cuda_ipc_iface_get_bw();
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+        perf_attr->path_bandwidth.dedicated = 0;
+        perf_attr->path_bandwidth.shared    = uct_cuda_ipc_iface_get_bw();
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {
         perf_attr->send_pre_overhead = iface->config.overhead;
     }

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -157,6 +157,11 @@ uct_gdr_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
                                            iface->config.put_bw;
     }
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+        perf_attr->path_bandwidth = is_get_op ? iface->config.get_bw :
+                                                iface->config.put_bw;
+    }
+
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {
         perf_attr->send_pre_overhead = UCT_GDR_COPY_IFACE_OVERHEAD;
     }

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -189,46 +189,46 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
     .iface_is_reachable       = uct_base_iface_is_reachable
 };
 
-static UCS_F_ALWAYS_INLINE void
-uct_rocm_copy_set_default_bandwidth(uct_perf_attr_t *perf_attr)
+static UCS_F_ALWAYS_INLINE double
+uct_rocm_copy_get_default_bandwidth(const uct_perf_attr_t *perf_attr)
 {
     switch (perf_attr->operation) {
     case UCT_EP_OP_GET_SHORT:
-        perf_attr->bandwidth.shared = 2000.0 * UCS_MBYTE;
+        return 2000.0 * UCS_MBYTE;
         break;
     case UCT_EP_OP_GET_ZCOPY:
-        perf_attr->bandwidth.shared = 8000.0 * UCS_MBYTE;
+        return 8000.0 * UCS_MBYTE;
         break;
     case UCT_EP_OP_PUT_SHORT:
-        perf_attr->bandwidth.shared = 10500.0 * UCS_MBYTE;
+        return 10500.0 * UCS_MBYTE;
         break;
     case UCT_EP_OP_PUT_ZCOPY:
-        perf_attr->bandwidth.shared = 9500.0 * UCS_MBYTE;
+        return 9500.0 * UCS_MBYTE;
         break;
     default:
-        perf_attr->bandwidth.shared = 0;
+        return 0;
         break;
     }
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_rocm_copy_set_mi300a_bandwidth(uct_perf_attr_t *perf_attr)
+static UCS_F_ALWAYS_INLINE double
+uct_rocm_copy_get_mi300a_bandwidth(const uct_perf_attr_t *perf_attr)
 {
     switch (perf_attr->operation) {
     case UCT_EP_OP_GET_SHORT:
-        perf_attr->bandwidth.shared = 6000.0 * UCS_MBYTE;
+        return 6000.0 * UCS_MBYTE;
         break;
     case UCT_EP_OP_GET_ZCOPY:
-        perf_attr->bandwidth.shared = 8000.0 * UCS_MBYTE;
+        return 8000.0 * UCS_MBYTE;
         break;
     case UCT_EP_OP_PUT_SHORT:
-        perf_attr->bandwidth.shared = 10500.0 * UCS_MBYTE;
+        return 10500.0 * UCS_MBYTE;
         break;
     case UCT_EP_OP_PUT_ZCOPY:
-        perf_attr->bandwidth.shared = 25000.0 * UCS_MBYTE;
+        return 25000.0 * UCS_MBYTE;
         break;
     default:
-        perf_attr->bandwidth.shared = 0;
+        return 0;
         break;
     }
 }
@@ -239,23 +239,32 @@ uct_rocm_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     uct_rocm_copy_iface_t *iface                  = ucs_derived_of(tl_iface,
                                                                    uct_rocm_copy_iface_t);
     static uct_rocm_amd_gpu_product_t gpu_product = UCT_ROCM_AMD_GPU_UNDEFINED;
+    uct_ppn_bandwidth_t bandwidth;
 
     if (gpu_product == UCT_ROCM_AMD_GPU_UNDEFINED) {
         gpu_product = uct_rocm_base_get_gpu_product();
     }
 
-    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
-        perf_attr->bandwidth.dedicated = 0;
+    if (uct_perf_attr_has_bandwidth(perf_attr->field_mask)) {
+        bandwidth.dedicated = 0;
         if (!(perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OPERATION)) {
-            perf_attr->bandwidth.shared = 0;
+            bandwidth.shared = 0;
         } else {
             if (gpu_product == UCT_ROCM_AMD_GPU_MI300A ||
                 gpu_product == UCT_ROCM_AMD_GPU_MI300X) {
-                uct_rocm_copy_set_mi300a_bandwidth(perf_attr);
+                bandwidth.shared = uct_rocm_copy_get_mi300a_bandwidth(perf_attr);
             } else {
-                uct_rocm_copy_set_default_bandwidth(perf_attr);
+                bandwidth.shared = uct_rocm_copy_get_default_bandwidth(perf_attr);
             }
         }
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
+        perf_attr->bandwidth = bandwidth;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+        perf_attr->path_bandwidth = bandwidth;
     }
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -538,14 +538,18 @@ static uct_iface_ops_t uct_mm_iface_ops = {
 static ucs_status_t
 uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 {
-    uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
-    uct_ep_operation_t op = UCT_ATTR_VALUE(PERF, perf_attr, operation,
+    uct_mm_iface_t *iface         = ucs_derived_of(tl_iface, uct_mm_iface_t);
+    uct_ep_operation_t op         = UCT_ATTR_VALUE(PERF, perf_attr, operation,
                                            OPERATION, UCT_EP_OP_LAST);
+    uct_ppn_bandwidth_t bandwidth = {iface->super.config.bandwidth, 0};
     uct_mm_iface_op_overhead_t *overhead;
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
-        perf_attr->bandwidth.shared = 0;
-        perf_attr->bandwidth.dedicated = iface->super.config.bandwidth;
+        perf_attr->bandwidth = bandwidth;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+        perf_attr->path_bandwidth = bandwidth;
     }
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {

--- a/src/uct/ze/copy/ze_copy_iface.c
+++ b/src/uct/ze/copy/ze_copy_iface.c
@@ -135,29 +135,39 @@ static uct_iface_ops_t uct_ze_copy_iface_ops = {
 static ucs_status_t
 uct_ze_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 {
-    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
-        perf_attr->bandwidth.dedicated = 0;
+    uct_ppn_bandwidth_t bandwidth;
+
+    if (uct_perf_attr_has_bandwidth(perf_attr->field_mask)) {
+        bandwidth.dedicated = 0;
         if (!(perf_attr->field_mask & UCT_PERF_ATTR_FIELD_OPERATION)) {
-            perf_attr->bandwidth.shared = 0;
+            bandwidth.shared = 0;
         } else {
             switch (perf_attr->operation) {
             case UCT_EP_OP_GET_SHORT:
-                perf_attr->bandwidth.shared = 2000.0 * UCS_MBYTE;
+                bandwidth.shared = 2000.0 * UCS_MBYTE;
                 break;
             case UCT_EP_OP_GET_ZCOPY:
-                perf_attr->bandwidth.shared = 8000.0 * UCS_MBYTE;
+                bandwidth.shared = 8000.0 * UCS_MBYTE;
                 break;
             case UCT_EP_OP_PUT_SHORT:
-                perf_attr->bandwidth.shared = 10500.0 * UCS_MBYTE;
+                bandwidth.shared = 10500.0 * UCS_MBYTE;
                 break;
             case UCT_EP_OP_PUT_ZCOPY:
-                perf_attr->bandwidth.shared = 9500.0 * UCS_MBYTE;
+                bandwidth.shared = 9500.0 * UCS_MBYTE;
                 break;
             default:
-                perf_attr->bandwidth.shared = 0;
+                bandwidth.shared = 0;
                 break;
             }
         }
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_BANDWIDTH) {
+        perf_attr->bandwidth = bandwidth;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+        perf_attr->path_bandwidth = bandwidth;
     }
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) {


### PR DESCRIPTION
## What?
This is the minimal version of https://github.com/openucx/ucx/pull/10508

Formerly known as "lane sorting" task.
When CUDA context is set, then rma_bw_lanes array is adjusted with GPU distance.
When CUDA context is not set in the caller thread, then UCX protocol does not always choose fastest lanes for GPU memory.

The idea is to select lanes at the protocol selection stage after performance estimation.
We need to find the best combination of lanes for a given operation.

## Testing
https://confluence.nvidia.com/display/NSWX/Protocol+lane+selection+testing

Mock tests PR: https://github.com/openucx/ucx/pull/10547