### PR TITLE
POC: Define memory flags and use it for ppln protocols

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2544,7 +2544,8 @@ void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
     mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE |
                           UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS |
                           UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH |
-                          UCT_MD_MEM_ATTR_FIELD_SYS_DEV;
+                          UCT_MD_MEM_ATTR_FIELD_SYS_DEV |
+                          UCT_MD_MEM_ATTR_FIELD_FLAGS;
 
     for (i = 0; i < context->num_mem_type_detect_mds; ++i) {
         tl_md  = &context->tl_mds[context->mem_type_detect_mds[i]];
@@ -2561,6 +2562,7 @@ void ucp_memory_detect_slowpath(ucp_context_h context, const void *address,
         mem_info->sys_dev      = mem_attr.sys_dev;
         mem_info->base_address = mem_attr.base_address;
         mem_info->alloc_length = mem_attr.alloc_length;
+        mem_info->flags        = mem_attr.flags;
         return;
     }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -320,6 +320,7 @@ typedef struct ucp_context_alloc_md_index {
      * using ucp_memh_alloc(). */
     ucp_md_index_t   md_index;
     ucs_sys_device_t sys_dev;
+    uint8_t          mem_flags;
 } ucp_context_alloc_md_index_t;
 
 
@@ -660,6 +661,7 @@ ucp_memory_info_set_host(ucp_memory_info_t *mem_info)
 {
     mem_info->type    = UCS_MEMORY_TYPE_HOST;
     mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+    mem_info->flags   = 0;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -712,6 +714,7 @@ ucp_memory_detect(ucp_context_h context, const void *address, size_t length,
 
     mem_info->type    = mem_info_internal.type;
     mem_info->sys_dev = mem_info_internal.sys_dev;
+    mem_info->flags   = mem_info_internal.flags;
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -158,6 +158,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
         key->lanes[i].path_index   = 0;
         key->lanes[i].lane_types   = 0;
         key->lanes[i].seg_size     = 0;
+        key->lanes[i].distance     = 0;
     }
     key->am_lane          = UCP_NULL_LANE;
     key->wireup_msg_lane  = UCP_NULL_LANE;
@@ -318,7 +319,7 @@ ucp_ep_peer_mem_get(ucp_context_h context, ucp_ep_h ep, uint64_t address,
 
     data->size = size;
     ucp_ep_rkey_unpack_internal(ep, rkey_buf, 0, UCS_BIT(rkey_ptr_md_index), 0,
-                                &data->rkey);
+                                0, &data->rkey);
     rkey_index = ucs_bitmap2idx(data->rkey->md_map, rkey_ptr_md_index);
     status     = uct_rkey_ptr(data->rkey->tl_rkey[rkey_index].cmpt,
                               &data->rkey->tl_rkey[rkey_index].rkey, address,
@@ -1947,7 +1948,8 @@ static int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
            (config_lane1->dst_md_index == config_lane2->dst_md_index) &&
            (config_lane1->dst_sys_dev == config_lane2->dst_sys_dev) &&
            (config_lane1->lane_types == config_lane2->lane_types) &&
-           (config_lane1->seg_size == config_lane2->seg_size);
+           (config_lane1->seg_size == config_lane2->seg_size) &&
+           (config_lane1->distance == config_lane2->distance);
 }
 
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
@@ -3164,9 +3166,9 @@ void ucp_ep_config_lane_info_str(ucp_worker_h worker,
     dst_md_index = key->lanes[lane].dst_md_index;
     cmpt_index   = ucp_ep_config_get_dst_md_cmpt(key, dst_md_index);
     ucs_string_buffer_appendf(
-         strbuf, "md[%d]/%s/sysdev[%d] seg %zu", dst_md_index,
+         strbuf, "md[%d]/%s/sysdev[%d] seg %zu distance %u", dst_md_index,
          context->tl_cmpts[cmpt_index].attr.name, key->lanes[lane].dst_sys_dev,
-         key->lanes[lane].seg_size);
+         key->lanes[lane].seg_size, key->lanes[lane].distance);
 
     prio = ucp_ep_config_get_multi_lane_prio(key->rma_bw_lanes, lane);
     if (prio != -1) {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -206,6 +206,8 @@ typedef struct ucp_ep_config_key_lane {
                                         was selected for */
     size_t               seg_size; /* Maximal fragment size which can be
                                       received by the peer */
+    uint16_t             distance; /* Distance to the peer obtained during
+                                      reachability check */
 } ucp_ep_config_key_lane_t;
 
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -702,6 +702,7 @@ ucp_memh_create(ucp_context_h context, void *address, size_t length,
     ucp_memory_detect(context, ucp_memh_address(memh), ucp_memh_length(memh),
                       &info);
     memh->sys_dev = info.sys_dev;
+    memh->mem_flags = info.flags;
 
     *memh_p = memh;
     return UCS_OK;
@@ -1732,7 +1733,8 @@ void ucp_mem_rcache_cleanup(ucp_context_h context)
 ucs_status_t
 ucp_mm_get_alloc_md_index(ucp_context_h context,
                           ucs_memory_type_t alloc_mem_type,
-                          ucp_md_index_t *md_idx, ucs_sys_device_t *sys_dev)
+                          ucp_md_index_t *md_idx, ucs_sys_device_t *sys_dev,
+                          uint8_t *mem_flags)
 {
     ucs_status_t status;
     uct_allocated_memory_t mem;
@@ -1757,14 +1759,16 @@ ucp_mm_get_alloc_md_index(ucp_context_h context,
 
         context->alloc_md[alloc_mem_type].initialized = 1;
         context->alloc_md[alloc_mem_type].sys_dev     = mem_info.sys_dev;
+        context->alloc_md[alloc_mem_type].mem_flags   = mem_info.flags;
         context->alloc_md[alloc_mem_type].md_index    =
                 ucp_mem_get_md_index(context, mem.md, mem.method);
 
         uct_mem_free(&mem);
     }
 
-    *md_idx  = context->alloc_md[alloc_mem_type].md_index;
-    *sys_dev = context->alloc_md[alloc_mem_type].sys_dev;
+    *md_idx    = context->alloc_md[alloc_mem_type].md_index;
+    *sys_dev   = context->alloc_md[alloc_mem_type].sys_dev;
+    *mem_flags = context->alloc_md[alloc_mem_type].mem_flags;
     return UCS_OK;
 }
 

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -69,6 +69,7 @@ typedef struct ucp_mem {
     uct_alloc_method_t  alloc_method;   /* Method used to allocate the memory */
     ucs_sys_device_t    sys_dev;        /* System device index */
     ucs_memory_type_t   mem_type;       /* Type of allocated or registered memory */
+    uint8_t             mem_flags;      /* Memory flags */
     ucp_md_index_t      alloc_md_index; /* Index of MD used to allocate the memory */
     uint64_t            remote_uuid;    /* Remote UUID */
     ucp_md_map_t        md_map;         /* Which MDs have valid memory handles */
@@ -216,6 +217,7 @@ void ucp_memh_disable_gva(ucp_mem_h memh, ucp_md_map_t md_map);
  * @param [out] md_idx         Index of the memory domain that is used to
  *                             allocate memory.
  * @param [out] sys_dev        Device id on which the memory was allocated.
+ * @param [out] mem_flags      Memory flags specific to the allocated memory.
  *
  * @return Error code as defined by @ref ucs_status_t.
  */
@@ -223,7 +225,8 @@ ucs_status_t
 ucp_mm_get_alloc_md_index(ucp_context_h context,
                           ucs_memory_type_t alloc_mem_type,
                           ucp_md_index_t *md_idx,
-                          ucs_sys_device_t *sys_dev);
+                          ucs_sys_device_t *sys_dev,
+                          uint8_t *mem_flags);
 
 static UCS_F_ALWAYS_INLINE ucp_md_map_t
 ucp_rkey_packed_md_map(const void *rkey_buffer)

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -60,6 +60,8 @@ struct ucp_rkey_config_key {
     /* Remote memory type */
     ucs_memory_type_t      mem_type;
 
+    uint8_t                mem_flags;
+
     /* MDs for which rkey is not reachable */
     ucp_md_map_t           unreachable_md_map;
 };
@@ -207,7 +209,7 @@ ssize_t ucp_rkey_pack_memh(ucp_context_h context, ucp_md_map_t md_map,
                            const ucp_memory_info_t *mem_info,
                            ucp_sys_dev_map_t sys_dev_map,
                            const ucs_sys_dev_distance_t *sys_distance,
-                           unsigned uct_flags, void *buffer);
+                           unsigned uct_flags, int pack_mem_flags, void *buffer);
 
 
 ucs_status_t
@@ -221,7 +223,8 @@ int ucp_memh_buffer_is_dummy(const void *exported_memh_buffer);
 ucs_status_t
 ucp_ep_rkey_unpack_internal(ucp_ep_h ep, const void *buffer, size_t length,
                             ucp_md_map_t unpack_md_map,
-                            ucp_md_map_t skip_md_map, ucp_rkey_h *rkey_p);
+                            ucp_md_map_t skip_md_map, int unpack_mem_flags,
+                            ucp_rkey_h *rkey_p);
 
 
 void ucp_rkey_dump_packed(const void *buffer, size_t length,

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -31,6 +31,7 @@ ucp_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
            (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
            (rkey_config_key1.sys_dev == rkey_config_key2.sys_dev) &&
            (rkey_config_key1.mem_type == rkey_config_key2.mem_type) &&
+           (rkey_config_key1.mem_flags == rkey_config_key2.mem_flags) &&
            (rkey_config_key1.unreachable_md_map ==
             rkey_config_key2.unreachable_md_map);
 }
@@ -59,8 +60,8 @@ ucp_ep_rkey_unpack_reachable(ucp_ep_h ep, const void *buffer, size_t length,
 {
     ucp_ep_config_t *config = &ucs_array_elem(&ep->worker->ep_config,
                                               ep->cfg_index);
-    return ucp_ep_rkey_unpack_internal(ep, buffer, length,
-                                       config->key.reachable_md_map, 0, rkey_p);
+    return ucp_ep_rkey_unpack_internal(
+                ep, buffer, length, config->key.reachable_md_map, 0, 0, rkey_p);
 }
 
 #endif

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -46,6 +46,7 @@ ucp_datatype_iter_init_mem_info_from_user_memh(ucp_datatype_iter_t *dt_iter,
 
     dt_iter->mem_info.type    = memh->mem_type;
     dt_iter->mem_info.sys_dev = memh->sys_dev;
+    dt_iter->mem_info.flags   = 0; // TBD
     return UCS_OK;
 }
 

--- a/src/ucp/dt/dt.h
+++ b/src/ucp/dt/dt.h
@@ -50,6 +50,7 @@ typedef struct ucp_dt_state {
 typedef struct {
     uint8_t          type;    /**< Memory type, use uint8 for compact size */
     ucs_sys_device_t sys_dev; /**< System device index */
+    uint8_t          flags;
 } ucp_memory_info_t;
 
 

--- a/src/ucp/proto/proto_select.h
+++ b/src/ucp/proto/proto_select.h
@@ -89,6 +89,8 @@ struct ucp_proto_select_param {
             uint8_t         sys_dev;    /* Reply buffer system device */
         } UCS_S_PACKED reply;
 
+        uint8_t             mem_flags;
+
         /* Align struct size to uint64_t */
         uint8_t             padding[2];
 

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -182,7 +182,7 @@ size_t ucp_rndv_rts_pack(ucp_request_t *sreq, ucp_rndv_rts_hdr_t *rndv_rts_hdr,
                 worker->context, sreq->send.rndv.md_map,
                 sreq->send.state.dt.dt.contig.memh, sreq->send.buffer,
                 sreq->send.length, &mem_info, 0, NULL,
-                ucp_ep_config(sreq->send.ep)->uct_rkey_pack_flags, rkey_buf);
+                ucp_ep_config(sreq->send.ep)->uct_rkey_pack_flags, 0, rkey_buf);
         if (packed_rkey_size < 0) {
             ucs_fatal("failed to pack rendezvous remote key: %s",
                       ucs_status_string((ucs_status_t)packed_rkey_size));
@@ -225,7 +225,7 @@ static size_t ucp_rndv_rtr_pack(void *dest, void *arg)
                 ep->worker->context, rndv_req->send.rndv.md_map,
                 rreq->recv.dt_iter.type.contig.memh,
                 rreq->recv.dt_iter.type.contig.buffer, rndv_req->send.length,
-                &mem_info, 0, NULL, ucp_ep_config(ep)->uct_rkey_pack_flags,
+                &mem_info, 0, NULL, ucp_ep_config(ep)->uct_rkey_pack_flags, 0,
                 rndv_rtr_hdr + 1);
         if (packed_rkey_size < 0) {
             return packed_rkey_size;

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -120,15 +120,20 @@ ucp_proto_rndv_get_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_memory_info_t reg_mem_info = {
         .type    = init_params->select_param->mem_type,
-        .sys_dev = init_params->select_param->sys_dev
+        .sys_dev = init_params->select_param->sys_dev,
+        .flags   = init_params->select_param->op.mem_flags
     };
 
+    ucs_print("GET-ZCOPY enter, memtype %s, flags 0x%x", ucs_memory_type_names[init_params->select_param->mem_type],
+            init_params->select_param->op.mem_flags);
     ucp_proto_rndv_get_common_probe(
             init_params, UCS_BIT(UCP_RNDV_MODE_GET_ZCOPY), SIZE_MAX,
             UCT_EP_OP_LAST,
             UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY |
             UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
             0, 0, &reg_mem_info);
+    ucs_print("GET-ZCOPY exit");
+
 }
 
 static void
@@ -330,16 +335,21 @@ ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
 
         status = ucp_mm_get_alloc_md_index(context, frag_mem_info.type,
                                            &dummy_md_id,
-                                           &frag_mem_info.sys_dev);
+                                           &frag_mem_info.sys_dev,
+                                           &frag_mem_info.flags);
         if (status != UCS_OK) {
             continue;
         }
 
+        ucs_print("GET-MTYPE probe enter, frag type %s, flags 0x%x (rkey flags 0x%x)",
+            ucs_memory_type_names[frag_mem_info.type],
+            frag_mem_info.flags, init_params->rkey_config_key->mem_flags);
 
         ucp_proto_rndv_get_common_probe(init_params,
                                         UCS_BIT(UCP_RNDV_MODE_GET_PIPELINE),
                                         frag_size, UCT_EP_OP_PUT_ZCOPY, 0,
                                         mdesc_md_map, 1, &frag_mem_info);
+        ucs_print("GET-MTYPE exit");
     }
 }
 

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -425,9 +425,12 @@ ucp_proto_rndv_put_zcopy_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_memory_info_t reg_mem_info = {
         .type    = init_params->select_param->mem_type,
-        .sys_dev = init_params->select_param->sys_dev
+        .sys_dev = init_params->select_param->sys_dev,
+        .flags   = init_params->select_param->op.mem_flags
     };
 
+    ucs_print("PUT-ZCOPY enter, memtype %s, flags 0x%x", ucs_memory_type_names[init_params->select_param->mem_type],
+            init_params->select_param->op.mem_flags);
     ucp_proto_rndv_put_common_probe(
             init_params, UCS_BIT(UCP_RNDV_MODE_PUT_ZCOPY), SIZE_MAX,
             UCT_EP_OP_LAST,
@@ -435,6 +438,7 @@ ucp_proto_rndv_put_zcopy_probe(const ucp_proto_init_params_t *init_params)
             UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
             0, ucp_proto_rndv_put_zcopy_completion, 0,
             UCP_WORKER_STAT_RNDV_PUT_ZCOPY, &reg_mem_info);
+    ucs_print("PUT-ZCOPY exit");
 }
 
 static void
@@ -622,10 +626,14 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
 
     status = ucp_mm_get_alloc_md_index(context, frag_mem_info.type,
                                        &dummy_md_id,
-                                       &frag_mem_info.sys_dev);
+                                       &frag_mem_info.sys_dev,
+                                       &frag_mem_info.flags);
     if (status != UCS_OK) {
         return;
     }
+    ucs_print("mprobe flags: basic 0x%x, rkey 0x%x frag type %s",
+            frag_mem_info.flags, init_params->rkey_config_key->mem_flags,
+            ucs_memory_type_names[frag_mem_info.type]);
 
     flags = context->config.ext.rndv_errh_ppln_enable ?
             UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING : 0;
@@ -636,10 +644,13 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
         comp_cb = ucp_proto_rndv_put_mtype_completion;
     }
 
+    ucs_print("PUT_MTYPE probe enter, frag type %s, flags 0x%x",
+              ucs_memory_type_names[frag_mem_info.type], frag_mem_info.flags);
     ucp_proto_rndv_put_common_probe(
             init_params, UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE), frag_size,
             UCT_EP_OP_GET_ZCOPY, flags, mdesc_md_map, comp_cb, 1,
             UCP_WORKER_STAT_RNDV_PUT_MTYPE_ZCOPY, &frag_mem_info);
+    ucs_print("PUT_MTYPE probe exit");
 }
 
 static void

--- a/src/ucp/tag/tag_rndv.c
+++ b/src/ucp/tag/tag_rndv.c
@@ -134,7 +134,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_tag_rndv_rts_progress, (self),
     ucs_status_t status;
 
     rpriv        = req->send.proto_config->priv;
-    max_rts_size = sizeof(ucp_rndv_rts_hdr_t) + rpriv->packed_rkey_size;
+    max_rts_size = sizeof(ucp_rndv_rts_hdr_t) + rpriv->packed_rkey_size + 1; // TMP fix
 
     status = UCS_PROFILE_CALL(ucp_proto_rndv_rts_request_init, req);
     if (status != UCS_OK) {

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -136,6 +136,7 @@ typedef struct {
     unsigned        path_index;
     ucp_rsc_index_t rsc_index;
     uint8_t         priority;
+    uint16_t        distance;
 } ucp_wireup_select_info_t;
 
 
@@ -175,7 +176,8 @@ int ucp_wireup_msg_ack_cb_pred(const ucs_callbackq_elem_t *elem, void *arg);
 int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
                             ucp_rsc_index_t rsc_index,
                             const ucp_address_entry_t *ae,
-                            char *info_str, size_t info_str_size);
+                            char *info_str, size_t info_str_size,
+                            uint16_t *distance);
 
 ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                    const ucp_tl_bitmap_t *local_tl_bitmap,

--- a/src/ucs/memory/memtype_cache.h
+++ b/src/ucs/memory/memtype_cache.h
@@ -34,6 +34,7 @@ typedef struct ucs_memory_info {
     ucs_sys_device_t  sys_dev;       /**< System device index */
     void              *base_address; /**< Base address of the underlying allocation */
     size_t            alloc_length;  /**< Whole length of the underlying allocation */
+    uint8_t           flags;
 } ucs_memory_info_t;
 
 
@@ -79,7 +80,7 @@ ucs_status_t ucs_memtype_cache_lookup(const void *address, size_t size,
  */
 void ucs_memtype_cache_update(const void *address, size_t size,
                               ucs_memory_type_t mem_type,
-                              ucs_sys_device_t sys_dev);
+                              ucs_sys_device_t sys_dev, uint8_t flags);
 
 
 /**
@@ -115,6 +116,7 @@ ucs_memory_info_set_host(ucs_memory_info_t *mem_info)
     mem_info->sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
     mem_info->base_address = NULL;
     mem_info->alloc_length = -1;
+    mem_info->flags        = 0;
 }
 
 END_C_DECLS

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1608,7 +1608,9 @@ typedef enum uct_md_mem_attr_field {
      * Request the offset of the provided virtual address relative to the
      * beginning of its backing dmabuf region.
      */
-    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET = UCS_BIT(5)
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET = UCS_BIT(5),
+
+    UCT_MD_MEM_ATTR_FIELD_FLAGS         = UCS_BIT(6)
 } uct_md_mem_attr_field_t;
 
 
@@ -1670,6 +1672,8 @@ typedef struct uct_md_mem_attr {
      * (identified by dmabuf_fd) backing the memory region being queried.
      */
     size_t            dmabuf_offset;
+
+    uint8_t           flags;
 } uct_md_mem_attr_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -77,26 +77,36 @@ enum uct_perf_attr_field {
     /** Enables @ref uct_perf_attr_t::remote_sys_device */
     UCT_PERF_ATTR_FIELD_REMOTE_SYS_DEVICE  = UCS_BIT(4),
 
+    /** Enable @ref uct_perf_attr_t::local_memory_flags */
+    UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_FLAGS = UCS_BIT(5),
+
+    /** Enable @ref uct_perf_attr_t::remote_memory_flags */
+    UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_FLAGS = UCS_BIT(6),
+
+    /** Enable @ref uct_perf_attr_t::distance */
+    UCT_PERF_ATTR_FIELD_DISTANCE           = UCS_BIT(7),
+
     /** Enables @ref uct_perf_attr_t::send_pre_overhead */
-    UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD  = UCS_BIT(5),
+    UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD  = UCS_BIT(8),
 
     /** Enables @ref uct_perf_attr_t::send_post_overhead */
-    UCT_PERF_ATTR_FIELD_SEND_POST_OVERHEAD = UCS_BIT(6),
+    UCT_PERF_ATTR_FIELD_SEND_POST_OVERHEAD = UCS_BIT(9),
 
     /** Enables @ref uct_perf_attr_t::recv_overhead */
-    UCT_PERF_ATTR_FIELD_RECV_OVERHEAD      = UCS_BIT(7),
+    UCT_PERF_ATTR_FIELD_RECV_OVERHEAD      = UCS_BIT(10),
 
     /** Enables @ref uct_perf_attr_t::bandwidth */
-    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(8),
+    UCT_PERF_ATTR_FIELD_BANDWIDTH          = UCS_BIT(11),
 
     /** Enables @ref uct_perf_attr_t::latency */
-    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(9),
+    UCT_PERF_ATTR_FIELD_LATENCY            = UCS_BIT(12),
 
     /** Enable @ref uct_perf_attr_t::max_inflight_eps */
-    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(10),
+    UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(13),
 
     /** Enable @ref uct_perf_attr_t::flags */
-    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(11)
+    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(14)
+
 };
 
 /**
@@ -156,6 +166,12 @@ typedef struct {
      * This field must be initialized by the caller.
      */
     ucs_sys_device_t    remote_sys_device;
+
+    uint8_t             local_memory_flags;
+
+    uint8_t             remote_memory_flags;
+
+    uint16_t            distance;
 
     /**
      * This is the time spent in the UCT layer to prepare message request and
@@ -277,7 +293,8 @@ typedef enum {
     UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING_LENGTH = UCS_BIT(3), /**< info_string_length field */
     UCT_IFACE_IS_REACHABLE_FIELD_SCOPE              = UCS_BIT(4), /**< scope field */
     UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH = UCS_BIT(5), /**< device_addr_length field */
-    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH  = UCS_BIT(6)  /**< iface_addr_length field */
+    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH  = UCS_BIT(6), /**< iface_addr_length field */
+    UCT_IFACE_IS_REACHABLE_FIELD_DISTANCE           = UCS_BIT(7)  /**< distance field */
 } uct_iface_is_reachable_field_mask_t;
 
 
@@ -632,6 +649,8 @@ typedef struct uct_iface_is_reachable_params {
      * default minimum length according to the address buffer contents.
      */
     size_t                        iface_addr_length;
+
+    uint16_t                      distance;
 } uct_iface_is_reachable_params_t;
 
 
@@ -1068,7 +1087,7 @@ ucs_status_t uct_ep_query(uct_ep_h ep, uct_ep_attr_t *ep_attr);
  * @return Nonzero if reachable, 0 if not.
  */
 int uct_iface_is_reachable_v2(uct_iface_h iface,
-                              const uct_iface_is_reachable_params_t *params);
+                              uct_iface_is_reachable_params_t *params);
 
 
 /**

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -314,7 +314,7 @@ int uct_iface_scope_is_reachable(const uct_iface_h iface,
 }
 
 int uct_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                              const uct_iface_is_reachable_params_t *params)
+                              uct_iface_is_reachable_params_t *params)
 {
     const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
     char *info_str_buf            = UCS_PARAM_VALUE(
@@ -327,6 +327,10 @@ int uct_iface_is_reachable_v2(const uct_iface_h tl_iface,
 
     if ((info_str_buf != NULL) && (info_str_buf_len > 0)) {
         info_str_buf[0] = '\0';
+    }
+
+    if (params->field_mask & UCT_IFACE_IS_REACHABLE_FIELD_DISTANCE) {
+        params->distance = 0;
     }
 
     return iface->internal_ops->iface_is_reachable_v2(tl_iface, params);

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -293,7 +293,7 @@ typedef ucs_status_t (*uct_ep_connect_to_ep_v2_func_t)(
 /* Check if remote iface address is reachable */
 typedef int (*uct_iface_is_reachable_v2_func_t)(
         const uct_iface_h iface,
-        const uct_iface_is_reachable_params_t *params);
+        uct_iface_is_reachable_params_t *params);
 
 
 /* Check if a remote endpoint is connected */

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -13,6 +13,9 @@
 #include <cuda.h>
 #include <nvml.h>
 
+typedef enum {
+    UCT_CUDA_MEM_TYPE_FLAGS_FABRIC = UCS_BIT(0)
+} uct_cuda_base_memory_flags_t;
 
 const char *uct_cuda_base_cu_get_error_string(CUresult result);
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -60,7 +60,7 @@ static ucs_status_t uct_cuda_copy_iface_get_address(uct_iface_h tl_iface,
 
 static int uct_cuda_copy_iface_is_reachable_v2(
         const uct_iface_h tl_iface,
-        const uct_iface_is_reachable_params_t *params)
+        uct_iface_is_reachable_params_t *params)
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface,
                                                   uct_cuda_copy_iface_t);

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -63,7 +63,7 @@ static ucs_status_t uct_gdr_copy_iface_get_address(uct_iface_h tl_iface,
 
 static int
 uct_gdr_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                                   const uct_iface_is_reachable_params_t *params)
+                                   uct_iface_is_reachable_params_t *params)
 {
     uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_gdr_copy_iface_t);

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -918,7 +918,7 @@ static int uct_ib_iface_dev_addr_is_reachable(
 }
 
 int uct_ib_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                                 const uct_iface_is_reachable_params_t *params)
+                                 uct_iface_is_reachable_params_t *params)
 {
     uct_ib_iface_t *iface = ucs_derived_of(tl_iface, uct_ib_iface_t);
     const uct_ib_address_t *device_addr;

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -543,7 +543,7 @@ int uct_ib_iface_is_same_device(const uct_ib_address_t *ib_addr, uint16_t dlid,
                                 const union ibv_gid *dgid);
 
 int uct_ib_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                                 const uct_iface_is_reachable_params_t *params);
+                                 uct_iface_is_reachable_params_t *params);
 
 /*
  * @param xport_hdr_len       How many bytes this transport adds on top of IB header (LRH+BTH+iCRC+vCRC)

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1006,7 +1006,7 @@ void uct_dc_mlx5_iface_init_version(uct_dc_mlx5_iface_t *iface, uct_md_h md)
 
 static int
 uct_dc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                                  const uct_iface_is_reachable_params_t *params)
+                                  uct_iface_is_reachable_params_t *params)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
     const uct_dc_mlx5_iface_addr_t *addr;

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -700,7 +700,7 @@ uct_gga_mlx5_iface_is_same_device(const uct_iface_h tl_iface,
 
 static int
 uct_gga_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                                   const uct_iface_is_reachable_params_t *params)
+                                   uct_iface_is_reachable_params_t *params)
 {
     uct_ib_iface_t *iface   = ucs_derived_of(tl_iface, uct_ib_iface_t);
     uct_ib_device_t *device = uct_ib_iface_device(iface);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -655,7 +655,7 @@ static ucs_status_t uct_rc_mlx5_iface_get_address(uct_iface_h tl_iface,
 
 static int
 uct_rc_mlx5_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                                  const uct_iface_is_reachable_params_t *params)
+                                  uct_iface_is_reachable_params_t *params)
 {
     static const char *tm_type_to_str[] = {"basic", "tag matching"};
     uint8_t my_type = uct_rc_mlx5_iface_get_address_type(tl_iface);

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -422,6 +422,10 @@ ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
         mem_attr_p->dmabuf_offset = dmabuf_offset;
     }
 
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_FLAGS) {
+        mem_attr_p->flags = 0;
+    }
+
     return UCS_OK;
 }
 

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -127,7 +127,7 @@ uct_mm_iface_query_tl_devices(uct_md_h md,
 
 static int
 uct_mm_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                             const uct_iface_is_reachable_params_t *params)
+                             uct_iface_is_reachable_params_t *params)
 {
     uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
     uct_mm_md_t *md       = ucs_derived_of(iface->super.super.md, uct_mm_md_t);

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -70,7 +70,7 @@ static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
 
 static int
 uct_cma_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                              const uct_iface_is_reachable_params_t *params)
+                              uct_iface_is_reachable_params_t *params)
 {
     struct iovec iov = {
         .iov_base = &iov,

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -40,7 +40,7 @@ static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
 
 static int
 uct_knem_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                               const uct_iface_is_reachable_params_t *params)
+                               uct_iface_is_reachable_params_t *params)
 {
     return uct_iface_is_reachable_params_valid(
                    params, UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR) &&

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -143,7 +143,7 @@ static ucs_status_t uct_self_iface_get_address(uct_iface_h tl_iface,
 
 static int
 uct_self_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                               const uct_iface_is_reachable_params_t *params)
+                               uct_iface_is_reachable_params_t *params)
 {
     const uct_self_iface_t *iface = ucs_derived_of(tl_iface, uct_self_iface_t);
     const uct_self_iface_addr_t *addr;

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -195,7 +195,7 @@ uct_tcp_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *addr)
 
 static int
 uct_tcp_iface_is_reachable_v2(const uct_iface_h tl_iface,
-                              const uct_iface_is_reachable_params_t *params)
+                              uct_iface_is_reachable_params_t *params)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
     uct_iface_local_addr_ns_t *local_addr_ns;

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -194,7 +194,7 @@ static ucs_status_t uct_ze_copy_md_mem_query(uct_md_h md, const void *addr,
     }
 
     ucs_memtype_cache_update(mem_info.base_address, mem_info.alloc_length,
-                             mem_info.type, mem_info.sys_dev);
+                             mem_info.type, mem_info.sys_dev, 0);
 
     if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_MEM_TYPE) {
         mem_attr_p->mem_type = mem_info.type;
@@ -219,6 +219,9 @@ static ucs_status_t uct_ze_copy_md_mem_query(uct_md_h md, const void *addr,
     if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET) {
         mem_attr_p->dmabuf_offset = UCS_PTR_BYTE_DIFF(mem_info.base_address,
                                                       addr);
+    }
+    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_FIELD_FLAGS) {
+        mem_attr_p->flags = 0;
     }
     return UCS_OK;
 }

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -236,7 +236,7 @@ ucp_rkey_h test_ucp_mmap::mem_chunk::unpack(ucp_ep_h ep, ucp_md_map_t md_map)
     } else {
         // Different MD map means different config index on proto v2
         ASSERT_UCS_OK(ucp_ep_rkey_unpack_internal(ep, rkey_buffer, rkey_size,
-                                                  md_map, 0, &rkey));
+                                                  md_map, 0, 0, &rkey));
     }
 
     ucp_rkey_buffer_release(rkey_buffer);
@@ -468,7 +468,7 @@ void test_ucp_mmap::test_rkey_proto(ucp_mem_h memh)
                                              memh, ucp_memh_address(memh),
                                              ucp_memh_length(memh), &mem_info,
                                              sys_dev_map, &sys_distance[0], 0,
-                                             &rkey_buffer[0]);
+                                             0, &rkey_buffer[0]);
     ASSERT_EQ((ssize_t)rkey_size, packed_size);
 
     /* Unpack remote key buffer */

--- a/test/gtest/ucs/test_memtype_cache.cc
+++ b/test/gtest/ucs/test_memtype_cache.cc
@@ -279,7 +279,7 @@ protected:
         }
 
         ucs_memtype_cache_update(ptr, size, mem_type,
-                                 UCS_SYS_DEVICE_ID_UNKNOWN);
+                                 UCS_SYS_DEVICE_ID_UNKNOWN, 0);
     }
 
     void memtype_cache_update(const mem_buffer &b) {


### PR DESCRIPTION
## What?
Define memory type flags to distinguish between memory of the same type but with different capabilities or properties. For example, to differentiate between legacy pinned CUDA memory and fabric VMM memory (the latter being suitable for MNNVL).

## Why?
This allows selecting device memory pipeline protocols for all relevant cases (e.g., for `osu_bw H D`). Currently, sending host memory to legacy pinned memory does not select a pipeline protocol because the receiver responds with a normal RTR instead of RTR mtype. As a result, the sender fails to unpack cuda_ipc key (since it is legacy pinned memory) and cannot select cuda-ipc for the transfer.

## How?
This PR is PoC demonstrating the use of memory flags. It will be split into multiple PRs, starting with a separate PR for UCT API changes. Thus, no need to review it


