### PR TITLE
UCP/PROTO: Mock topo and tests

### DIFF
--- a/buildlib/tools/coverity.sh
+++ b/buildlib/tools/coverity.sh
@@ -101,6 +101,8 @@ run_coverity() {
 	cov-build --dir $cov_build $MAKEP all
 	if [ "${ucx_build_type}" == "devel" ]; then
 		cov-manage-emit --dir $cov_build --tu-pattern "file('.*/test/gtest/common/googletest/*')" delete || :
+		# Needed to suppress false positives in std::function
+		COV_OPT="$COV_OPT --checker-option UNINIT_CTOR:ctor_func:swap"
 	fi
 	cov-analyze --jobs $parallel_jobs $COV_OPT --security --concurrency --dir $cov_build
 	nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -29,40 +29,6 @@
 #define UCS_TOPO_DEVICE_NAME_UNKNOWN "<unknown>"
 #define UCS_TOPO_DEVICE_NAME_INVALID "<invalid>"
 
-/*
- * Function pointer used to refer to specific implementations of
- * ucs_topo_get_memory_distance function by topology modules.
- * This function estimates the distance between the device and the system
- * memory used by the current thread according to its CPU affinity.
- * The function must have a fallback behavior.
- */
-typedef void (*ucs_topo_get_memory_distance_func_t)(
-        ucs_sys_device_t device, ucs_sys_dev_distance_t *distance);
-
-/*
- * Topology API.
- */
-typedef struct {
-    /* Provider's ucs_topo_get_distance implementation */
-    ucs_topo_get_distance_func_t        get_distance;
-
-    /* Provider's ucs_topo_get_memory_distance implementation */
-    ucs_topo_get_memory_distance_func_t get_memory_distance;
-} ucs_sys_topo_ops_t;
-
-
-/*
- * Structure needed to define a topology module implementation
- */
-typedef struct {
-    /* Name of the topology module */
-    const char         *name;
-
-    /* provider's ops */
-    ucs_sys_topo_ops_t ops;
-
-    ucs_list_link_t    list;
-} ucs_sys_topo_provider_t;
 
 typedef int64_t ucs_bus_id_bit_rep_t;
 
@@ -109,6 +75,18 @@ static inline double ucs_topo_sysfs_numa_distance_to_latency(double distance)
 void ucs_sys_topo_reset_provider()
 {
     ucs_sys_topo_provider = NULL;
+}
+
+void ucs_sys_topo_add_provider(ucs_sys_topo_provider_t *provider)
+{
+    ucs_list_add_tail(&ucs_sys_topo_providers_list, &provider->list);
+    ucs_sys_topo_reset_provider();
+}
+
+void ucs_sys_topo_remove_provider(ucs_sys_topo_provider_t *provider)
+{
+    ucs_list_del(&provider->list);
+    ucs_sys_topo_reset_provider();
 }
 
 static ucs_sys_topo_provider_t *ucs_sys_topo_get_provider()

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -68,6 +68,43 @@ typedef ucs_status_t
                                 ucs_sys_dev_distance_t *distance);
 
 
+/*
+ * Function pointer used to refer to specific implementations of
+ * ucs_topo_get_memory_distance function by topology modules.
+ * This function estimates the distance between the device and the system
+ * memory used by the current thread according to its CPU affinity.
+ * The function must have a fallback behavior.
+ */
+typedef void (*ucs_topo_get_memory_distance_func_t)(
+        ucs_sys_device_t device, ucs_sys_dev_distance_t *distance);
+
+
+/*
+ * Topology API.
+ */
+typedef struct {
+    /* Provider's ucs_topo_get_distance implementation */
+    ucs_topo_get_distance_func_t        get_distance;
+
+    /* Provider's ucs_topo_get_memory_distance implementation */
+    ucs_topo_get_memory_distance_func_t get_memory_distance;
+} ucs_sys_topo_ops_t;
+
+
+/*
+ * Structure needed to define a topology module implementation
+ */
+typedef struct {
+    /* Name of the topology module */
+    const char         *name;
+
+    /* provider's ops */
+    ucs_sys_topo_ops_t ops;
+
+    ucs_list_link_t    list;
+} ucs_sys_topo_provider_t;
+
+
 /* Global list of topology detection methods */
 extern ucs_list_link_t ucs_sys_topo_providers_list;
 
@@ -76,6 +113,18 @@ extern ucs_list_link_t ucs_sys_topo_providers_list;
  * Reset the internal singleton system topology provider.
  */
 void ucs_sys_topo_reset_provider(void);
+
+
+/**
+ * Add topology provider to the global list of topology providers.
+ */
+void ucs_sys_topo_add_provider(ucs_sys_topo_provider_t *provider);
+
+
+/**
+ * Remove topology provider from the global list of topology providers.
+ */
+void ucs_sys_topo_remove_provider(ucs_sys_topo_provider_t *provider);
 
 
 /**

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -5,6 +5,7 @@
  */
 
 #include "ucp_test.h"
+#include <functional>
 
 extern "C" {
 #include <ucp/core/ucp_ep.inl>
@@ -15,9 +16,8 @@ extern "C" {
 
 class mock_iface {
 public:
-    /* Can't use std::function due to coverity errors */
-    using iface_attr_func_t = void (*)(uct_iface_attr&);
-    using perf_attr_func_t = void (*)(uct_perf_attr_t&);
+    using iface_attr_func_t = std::function<void(uct_iface_attr&)>;
+    using perf_attr_func_t  = std::function<void(uct_perf_attr_t&)>;
 
     mock_iface() : m_tl(nullptr)
     {
@@ -36,13 +36,12 @@ public:
         m_mock.cleanup();
     }
 
-    void add_mock_iface(
-            const std::string &dev_name = "mock",
-            iface_attr_func_t cb = [](uct_iface_attr_t &iface_attr) {},
-            perf_attr_func_t perf_cb = cx7_perf_mock)
+    void add_mock_iface(const std::string &dev_name = "mock",
+                        iface_attr_func_t cb = [](uct_iface_attr_t &iface_attr) {},
+                        perf_attr_func_t perf_cb = default_perf_mock)
     {
-        m_iface_attrs_funcs[dev_name] = cb;
-        m_perf_attrs_funcs[dev_name]  = perf_cb;
+        m_iface_attrs_funcs[dev_name] = std::move(cb);
+        m_perf_attrs_funcs[dev_name]  = std::move(perf_cb);
     }
 
     void mock_transport(const std::string &tl_name)
@@ -161,10 +160,9 @@ private:
         return UCS_OK;
     }
 
-    static void cx7_perf_mock(uct_perf_attr_t& perf_attr)
+    static void default_perf_mock(uct_perf_attr_t& perf_attr)
     {
-        perf_attr.path_bandwidth.shared    = 0.95 * perf_attr.bandwidth.shared;
-        perf_attr.path_bandwidth.dedicated = 0;
+        perf_attr.path_bandwidth = perf_attr.bandwidth;
     }
 
     /* We have to use singleton to mock C functions */
@@ -180,7 +178,68 @@ private:
 
 mock_iface *mock_iface::m_self = nullptr;
 
-class test_ucp_proto_mock : public ucp_test, public mock_iface {
+class mock_topo_provider : public ucs_sys_topo_provider_t {
+public:
+    static constexpr ucs_sys_dev_distance_t DEFAULT_DISTANCE = {0, INFINITY};
+
+    mock_topo_provider():
+        ucs_sys_topo_provider_t {
+            "mock", { &get_distance, &get_memory_distance }
+        }
+    {
+        ucs_assert(m_self == nullptr);
+        m_self = this;
+    }
+
+    ~mock_topo_provider()
+    {
+        m_self = nullptr;
+    }
+
+    void add_mock_distance(ucs_sys_device_t device1, ucs_sys_device_t device2,
+                           ucs_sys_dev_distance_t distance)
+    {
+        m_distances[make_key(device1, device2)] = distance;
+    }
+
+private:
+    static ucs_status_t
+    get_distance(ucs_sys_device_t device1, ucs_sys_device_t device2,
+                 ucs_sys_dev_distance_t *distance)
+    {
+        auto it = m_self->m_distances.find(make_key(device1, device2));
+        if (it != m_self->m_distances.end()) {
+            *distance = it->second;
+        } else {
+            *distance = DEFAULT_DISTANCE;
+        }
+        return UCS_OK;
+    }
+
+    static void get_memory_distance(ucs_sys_device_t device,
+                                    ucs_sys_dev_distance_t *distance)
+    {
+        *distance = DEFAULT_DISTANCE;
+    }
+
+    static uint16_t make_key(ucs_sys_device_t device1, ucs_sys_device_t device2)
+    {
+        if (device1 > device2) {
+            std::swap(device1, device2);
+        }
+        return (device1 << 8) | device2;
+    }
+
+    /* We have to use singleton to mock C functions */
+    static mock_topo_provider *m_self;
+
+    std::unordered_map<uint16_t, ucs_sys_dev_distance_t> m_distances;
+};
+
+mock_topo_provider *mock_topo_provider::m_self = nullptr;
+
+class test_ucp_proto_mock : public ucp_test, public mock_iface,
+                            public mock_topo_provider {
 public:
     const static size_t INF                               = UCS_MEMUNITS_INF;
     const static uint16_t AM_ID                           = 123;
@@ -248,14 +307,8 @@ public:
         }
 
         /* Reset topo provider to force reload from config */
-        ucs_sys_topo_reset_provider();
-
-        /*
-         * By default TOPO_PRIO="sysfs,default"
-         * We keep only default config to always have the same topo distances
-         * when test is being executed on different machines.
-         */
-        modify_config("TOPO_PRIO", "default");
+        ucs_sys_topo_add_provider(this);
+        modify_config("TOPO_PRIO", "mock");
 
         ucp_test::init();
         connect();
@@ -266,7 +319,7 @@ public:
         mock_iface::cleanup();
         ucp_test::cleanup();
         /* Reset topo provider to not affect subsequent tests */
-        ucs_sys_topo_reset_provider();
+        ucs_sys_topo_remove_provider(this);
     }
 
     static void check_ep_config(const entity &e,
@@ -818,6 +871,8 @@ UCS_TEST_P(test_ucp_proto_mock_self, rkey_ptr)
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_self, self, "self")
 
+#ifdef HAVE_CUDA
+
 class test_ucp_proto_mock_gpu : public test_ucp_proto_mock {
 public:
     test_ucp_proto_mock_gpu()
@@ -859,5 +914,66 @@ UCS_TEST_P(test_ucp_proto_mock_gpu, cuda_managed_ppln_host_frag,
         }, key);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_gpu, rcx_gpu,
-                              "rc_x,cuda,rocm")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_gpu, rcx_gpu, "rc_x,cuda")
+
+class test_ucp_proto_mock_gpu_selection : public test_ucp_proto_mock {
+public:
+    test_ucp_proto_mock_gpu_selection()
+    {
+        mock_transport("rc_mlx5");
+    }
+
+    virtual void init() override
+    {
+        for (unsigned i = 0; i < 15; ++i) {
+            /* GPU distance is decreasing with i */
+            ucs_sys_dev_distance_t distance = {0, 40e9 - (i * 1e9)};
+            add_mock_distance(i + 1, 0, distance);
+            add_mock_distance(i + 1, UCS_SYS_DEVICE_ID_UNKNOWN, distance);
+            char name[10];
+            snprintf(name, sizeof(name), "mock%02u", i);
+            add_mock_iface(name, [i](uct_iface_attr_t &iface_attr) {
+                iface_attr.cap.am.max_short = 2000;
+                /* BW is increasing with i */
+                iface_attr.bandwidth.shared = 30e9 + (i * 1e9);
+                iface_attr.latency.c        = 600e-9;
+                iface_attr.latency.m        = 1e-9;
+            });
+        }
+        test_ucp_proto_mock::init();
+    }
+
+    virtual void cleanup() override
+    {
+        test_ucp_proto_mock::cleanup();
+    }
+};
+
+UCS_TEST_P(test_ucp_proto_mock_gpu_selection, test, "IB_NUM_PATHS?=2",
+           "RNDV_FRAG_MEM_TYPES=host", "MAX_RNDV_LANES=4", "SELECT_DISTANCE_MD=")
+{
+    send_recv_am(1024, UCS_MEMORY_TYPE_CUDA_MANAGED);
+
+    ucp_proto_select_key_t key = any_key();
+    key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
+    key.param.op_attr          = 0;
+    key.param.mem_type         = UCS_MEMORY_TYPE_CUDA_MANAGED;
+
+    /* We expect to select lanes with largest max(BW, distance) */
+    const std::string config = "25% on rc_mlx5/mock06/path0, 26% on rc_mlx5/mock05/path0, "
+                               "26% on rc_mlx5/mock04/path0 and 23% on rc_mlx5/mock03/path0";
+    check_ep_config(sender(), {
+        {1, 8246,    "copy-in",   "rc_mlx5/mock00/path0"},
+        {8247, 512 * UCS_KBYTE,
+         "rendezvous cuda_copy, fenced write to remote, frag host, cuda_copy, frag host",
+         config},
+        {(512 * UCS_KBYTE) + 1, INF,
+         "rendezvous pipeline cuda_copy, fenced write to remote, frag host, cuda_copy, frag host",
+         config},
+    }, key);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_gpu_selection, rcx_gpu,
+                              "rc_x,cuda")
+
+#endif // HAVE_CUDA


### PR DESCRIPTION
## What?
Adds unit test for protocol selection with multiple devices with different distances. Check that selected lanes are with largest max(BW, distance). This test may be useful for wireup lane verification too

## How?
- Added mock for topology, in order to mock distance
- Replaced function pointer with std::function to be able to capture args
- Silence coverity false positive warning on std::function
- Added check for max_bcopy/MTU when sending wireup message to avoid memory corruption
