### PR TITLE
UCP/TEST: Fix failures in max_lanes test when have two IB devices

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1836,7 +1836,9 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_wireup_init_select_flags(&peer_rma_flags, 0, 0);
 
     if ((ep_init_flags & UCP_EP_INIT_CREATE_AM_LANE_ONLY) ||
-        (context->config.ext.max_rndv_lanes == 0)) {
+        (context->config.ext.max_rndv_lanes == 0) ||
+        (context->config.ext.rndv_mode == UCP_RNDV_MODE_AM) ||
+        (context->config.ext.rndv_mode == UCP_RNDV_MODE_RKEY_PTR)) {
         return UCS_OK;
     }
 

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1249,15 +1249,21 @@ UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=64", "TM_SW_RNDV=y",
     EXPECT_EQ(num_lanes(), ucp_ep_num_lanes(receiver().ep()));
 
     size_t bytes_sent = 0;
+    unsigned num_used_lanes = 0;
     for (ucp_lane_index_t lane = 0; lane < num_lanes(); ++lane) {
         size_t sender_tx   = get_bytes_sent(sender().ep(), lane);
         size_t receiver_tx = get_bytes_sent(receiver().ep(), lane);
         UCS_TEST_MESSAGE << "lane[" << static_cast<int>(lane) << "] : "
                          << "sender " << sender_tx << " receiver " << receiver_tx;
-
-        EXPECT_GT(sender_tx + receiver_tx, 0);
+        if ((sender_tx > 0) || (receiver_tx > 0)) {
+            ++num_used_lanes;
+        }
         bytes_sent += sender_tx + receiver_tx;
     }
+
+    /* One lane could be reserved for tag offload and not selected for AM/RMA
+       bandwidth lane */
+    EXPECT_GE(num_used_lanes, num_lanes() - 1);
 
     EXPECT_GE(bytes_sent, get_msg_size());
 }


### PR DESCRIPTION
## Why
Fix failures on new01 machine:
```
2025-03-06T17:40:21.7528501Z [ RUN      ] rc/multi_rail_max.max_lanes/5 <rc/rndv_am_zcopy>
2025-03-06T17:40:22.4448500Z [     INFO ] lane[0] : sender 10506263 receiver 76
2025-03-06T17:40:22.4453886Z [     INFO ] lane[1] : sender 0 receiver 0
2025-03-06T17:40:22.4459444Z /scrap/azure/agent-04/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_tag_xfer.cc:1258: Failure
2025-03-06T17:40:22.4461149Z Expected: (sender_tx + receiver_tx) > (0), actual: 0 vs 0
2025-03-06T17:40:22.4465411Z [     INFO ] lane[2] : sender 0 receiver 0
2025-03-06T17:40:22.4470367Z /scrap/azure/agent-04/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_tag_xfer.cc:1258: Failure
2025-03-06T17:40:22.4471911Z Expected: (sender_tx + receiver_tx) > (0), actual: 0 vs 0
...
2025-03-06T17:40:22.4731789Z /scrap/azure/agent-04/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_tag_xfer.cc:1258: Failure
2025-03-06T17:40:22.4732966Z Expected: (sender_tx + receiver_tx) > (0), actual: 0 vs 0
2025-03-06T17:40:23.0831853Z [  FAILED  ] rc/multi_rail_max.max_lanes/5, where GetParam() = rc/rndv_am_zcopy (1330 ms)
```

## How
1. When the test is run with RNDV_MODE=am_bcopy/zcopy, we may select rma_bw lanes on one device, leaving no place for am_bw lanes (if the am_bw score dictates the other device should be used). Fix by not adding rma_bw lanes when RDNV_MODE is forced to active messages or rkey_ptr.

2. The test is run with tag offload enabled, sometimes tag offload lane can be different than rma_bw/am_bw lanes, so we get one less lane for large data. Fix by expecting to use almost all lanes instead of all of them.

