### PR TITLE
ARCH/AARCH64: Refactor atomic operations to use __atomic_* functions

### DIFF
--- a/src/ucs/arch/atomic.h
+++ b/src/ucs/arch/atomic.h
@@ -25,37 +25,37 @@
 #define UCS_DEFINE_ATOMIC_AND(_wordsize, _suffix) \
     static inline void ucs_atomic_and##_wordsize(volatile uint##_wordsize##_t *ptr, \
                                                  uint##_wordsize##_t value) { \
-        __sync_and_and_fetch(ptr, value); \
+        __atomic_and_fetch(ptr, value, __ATOMIC_RELAXED); \
     }
 
 #define UCS_DEFINE_ATOMIC_FAND(_wordsize, _suffix) \
     static inline uint##_wordsize##_t ucs_atomic_fand##_wordsize(volatile uint##_wordsize##_t *ptr, \
                                                                  uint##_wordsize##_t value) { \
-        return __sync_fetch_and_and(ptr, value); \
+        return __atomic_fetch_and(ptr, value, __ATOMIC_RELAXED); \
     }
 
 #define UCS_DEFINE_ATOMIC_XOR(_wordsize, _suffix) \
     static inline void ucs_atomic_xor##_wordsize(volatile uint##_wordsize##_t *ptr, \
                                                  uint##_wordsize##_t value) { \
-        __sync_xor_and_fetch(ptr, value); \
+        __atomic_xor_fetch(ptr, value, __ATOMIC_RELAXED); \
     }
 
 #define UCS_DEFINE_ATOMIC_FXOR(_wordsize, _suffix) \
     static inline uint##_wordsize##_t ucs_atomic_fxor##_wordsize(volatile uint##_wordsize##_t *ptr, \
                                                                  uint##_wordsize##_t value) { \
-        return __sync_fetch_and_xor(ptr, value); \
+        return __atomic_fetch_xor(ptr, value, __ATOMIC_RELAXED); \
     }
 
 #define UCS_DEFINE_ATOMIC_OR(_wordsize, _suffix) \
     static inline void ucs_atomic_or##_wordsize(volatile uint##_wordsize##_t *ptr, \
                                                 uint##_wordsize##_t value) { \
-        __sync_or_and_fetch(ptr, value); \
+        __atomic_or_fetch(ptr, value, __ATOMIC_RELAXED); \
     }
 
 #define UCS_DEFINE_ATOMIC_FOR(_wordsize, _suffix) \
     static inline uint##_wordsize##_t ucs_atomic_for##_wordsize(volatile uint##_wordsize##_t *ptr, \
                                                                 uint##_wordsize##_t value) { \
-        return __sync_fetch_and_or(ptr, value); \
+        return __atomic_fetch_or(ptr, value, __ATOMIC_RELAXED); \
     }
 
 #define UCS_DEFINE_ATOMIC_SUB(wordsize, suffix) \


### PR DESCRIPTION
## What?
Refactor atomic operations to use __atomic_* functions for improved performance and consistency. Updated definitions for AND, OR, XOR, ADD, and SWAP operations across atomic.h and generic/atomic.h files.

## Why?
__sync functions produces LDADDAL instruction which loads from memory with acquire semantics ([source](https://developer.arm.com/documentation/ddi0602/2024-12/Base-Instructions/LDADD--LDADDA--LDADDAL--LDADDL--Atomic-add-on-word-or-doubleword-in-memory-?lang=en)).
Noticed significant performance boost in UCC workloads on Grace CPU
## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
