### PR TITLE
UCT/CUDA: Use sys_dev to allocate CUDA memory

### DIFF
--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -240,6 +240,30 @@ const char *ucs_topo_sys_device_get_name(ucs_sys_device_t sys_dev);
  */
 ucs_numa_node_t ucs_topo_sys_device_get_numa_node(ucs_sys_device_t sys_dev);
 
+
+/**
+ * Set a user-defined value for a given system device.
+ *
+ * @param [in] sys_dev System device index.
+ * @param [in] value   User-defined value to set.
+ *
+ * @return UCS_OK on success, error otherwise.
+ */
+ucs_status_t
+ucs_topo_sys_device_set_user_value(ucs_sys_device_t sys_dev, uintptr_t value);
+
+
+/**
+ * Retrieve the user-defined value of a system device.
+ *
+ * @param [in] sys_dev System device index.
+ *
+ * @return User-defined value, or UINTPTR_MAX if no value is set or the device
+ *         does not exist.
+ */
+uintptr_t ucs_topo_sys_device_get_user_value(ucs_sys_device_t sys_dev);
+
+
 /**
  * Get the number of registered system devices.
  *

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1706,12 +1706,13 @@ ucs_status_t uct_md_mem_query(uct_md_h md, const void *address, size_t length,
  * and the memory is allocated by memory allocation functions @ref uct_mem_alloc.
  */
 typedef struct uct_allocated_memory {
-    void                     *address; /**< Address of allocated memory */
-    size_t                   length;   /**< Real size of allocated memory */
-    uct_alloc_method_t       method;   /**< Method used to allocate the memory */
-    ucs_memory_type_t        mem_type; /**< type of allocated memory */
-    uct_md_h                 md;       /**< if method==MD: MD used to allocate the memory */
-    uct_mem_h                memh;     /**< if method==MD: MD memory handle */
+    void                     *address;   /**< Address of allocated memory */
+    size_t                   length;     /**< Real size of allocated memory */
+    uct_alloc_method_t       method;     /**< Method used to allocate the memory */
+    ucs_memory_type_t        mem_type;   /**< type of allocated memory */
+    uct_md_h                 md;         /**< if method==MD: MD used to allocate the memory */
+    uct_mem_h                memh;       /**< if method==MD: MD memory handle */
+    ucs_sys_device_t         sys_device; /**< System device for allocated memory */
 } uct_allocated_memory_t;
 
 
@@ -2501,7 +2502,10 @@ typedef enum {
     UCT_MEM_ALLOC_PARAM_FIELD_MDS            = UCS_BIT(3),
 
     /** Enables @ref uct_mem_alloc_params_t::name */
-    UCT_MEM_ALLOC_PARAM_FIELD_NAME           = UCS_BIT(4)
+    UCT_MEM_ALLOC_PARAM_FIELD_NAME           = UCS_BIT(4),
+
+    /** Enables @ref uct_mem_alloc_params_t::sys_device */
+    UCT_MEM_ALLOC_PARAM_FIELD_SYS_DEVICE     = UCS_BIT(5)
 } uct_mem_alloc_params_field_t;
 
 
@@ -2564,6 +2568,12 @@ typedef struct {
      * "anonymous-uct_mem_alloc" is used by default.
      */
     const char                   *name;
+
+    /**
+     * System device on which memory is to be allocated, or
+     * UCS_SYS_DEVICE_ID_UNKNOWN to allow allocating on any device.
+     */
+    ucs_sys_device_t             sys_device;
 } uct_mem_alloc_params_t;
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -539,10 +539,11 @@ ucs_status_t uct_mem_alloc_check_params(size_t length,
 }
 
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
-                              ucs_memory_type_t mem_type, unsigned flags,
+                              ucs_memory_type_t mem_type,
+                              ucs_sys_device_t sys_dev, unsigned flags,
                               const char *alloc_name, uct_mem_h *memh_p)
 {
-    return md->ops->mem_alloc(md, length_p, address_p, mem_type, flags,
+    return md->ops->mem_alloc(md, length_p, address_p, mem_type, sys_dev, flags,
                               alloc_name, memh_p);
 }
 

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -80,6 +80,7 @@ typedef ucs_status_t (*uct_md_mem_alloc_func_t)(uct_md_h md,
                                                 size_t *length_p,
                                                 void **address_p,
                                                 ucs_memory_type_t mem_type,
+                                                ucs_sys_device_t sys_dev,
                                                 unsigned flags,
                                                 const char *alloc_name,
                                                 uct_mem_h *memh_p);
@@ -189,13 +190,15 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
  *                             which may be larger than the one requested. Must be >0.
  * @param [in,out] address_p   The address
  * @param [in]     mem_type    Memory type of the allocation
+ * @param [in]     sys_dev     System device for the allocation.
  * @param [in]     flags       Memory allocation flags, see @ref uct_md_mem_flags.
  * @param [in]     name        Name of the allocated region, used to track memory
  *                             usage for debugging and profiling.
  * @param [out]    memh_p      Filled with handle for allocated region.
  */
 ucs_status_t uct_md_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
-                              ucs_memory_type_t mem_type, unsigned flags,
+                              ucs_memory_type_t mem_type,
+                              ucs_sys_device_t sys_dev, unsigned flags,
                               const char *alloc_name, uct_mem_h *memh_p);
 
 /**

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -139,6 +139,9 @@ void
 uct_cuda_base_get_sys_dev(CUdevice cuda_device,
                           ucs_sys_device_t *sys_dev_p);
 
+ucs_status_t
+uct_cuda_base_get_cuda_device(ucs_sys_device_t sys_dev, CUdevice *device);
+
 ucs_status_t uct_cuda_base_iface_event_fd_get(uct_iface_h tl_iface, int *fd_p);
 
 #if (__CUDACC_VER_MAJOR__ >= 100000)

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -55,10 +55,33 @@ void uct_cuda_base_get_sys_dev(CUdevice cuda_device,
         goto err;
     }
 
+    status = ucs_topo_sys_device_set_user_value(*sys_dev_p, cuda_device);
+    if (status != UCS_OK) {
+        goto err;
+    }
+
     return;
 
 err:
     *sys_dev_p = UCS_SYS_DEVICE_ID_UNKNOWN;
+}
+
+ucs_status_t
+uct_cuda_base_get_cuda_device(ucs_sys_device_t sys_dev, CUdevice *device)
+{
+    uintptr_t user_value;
+
+    user_value = ucs_topo_sys_device_get_user_value(sys_dev);
+    if (user_value == UINTPTR_MAX) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    *device = user_value;
+    if (*device == CU_DEVICE_INVALID) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    return UCS_OK;
 }
 
 ucs_status_t

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -35,6 +35,7 @@ typedef struct uct_cuda_copy_md {
         ucs_ternary_auto_value_t enable_fabric;
         uct_cuda_pref_loc_t      pref_loc;
         int                      cuda_async_managed;
+        int                      retain_primary_ctx;
     } config;
 } uct_cuda_copy_md_t;
 
@@ -49,6 +50,7 @@ typedef struct uct_cuda_copy_md_config {
     ucs_ternary_auto_value_t    enable_fabric;
     uct_cuda_pref_loc_t         pref_loc;
     ucs_memory_type_t           cuda_async_mem_type;
+    int                         retain_primary_ctx;
 } uct_cuda_copy_md_config_t;
 
 /**

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1988,8 +1988,8 @@ static void uct_ib_mlx5_md_port_counter_set_id_init(uct_ib_mlx5_md_t *md)
 ucs_status_t
 uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
                                   void **address_p, ucs_memory_type_t mem_type,
-                                  unsigned flags, const char *alloc_name,
-                                  uct_mem_h *memh_p)
+                                  ucs_sys_device_t sys_dev, unsigned flags,
+                                  const char *alloc_name, uct_mem_h *memh_p)
 {
 #if HAVE_IBV_DM
     uct_ib_md_t *md           = ucs_derived_of(uct_md, uct_ib_md_t);
@@ -2145,7 +2145,8 @@ static void uct_ib_mlx5dv_check_dm_ksm_reg(uct_ib_mlx5_md_t *md)
     }
 
     status = uct_ib_mlx5_devx_device_mem_alloc(uct_md, &length, &address,
-                                               UCS_MEMORY_TYPE_RDMA, 0,
+                                               UCS_MEMORY_TYPE_RDMA,
+                                               UCS_SYS_DEVICE_ID_UNKNOWN, 0,
                                                "check dm ksm registration",
                                                &memh);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1154,9 +1154,9 @@ uct_ib_mlx5_devx_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr);
 
 ucs_status_t
 uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
-         void **address_p, ucs_memory_type_t mem_type,
-                                  unsigned flags, const char *alloc_name,
-                                  uct_mem_h *memh_p);
+                                  void **address_p, ucs_memory_type_t mem_type,
+                                  ucs_sys_device_t sys_dev, unsigned flags,
+                                  const char *alloc_name, uct_mem_h *memh_p);
 
 ucs_status_t
 uct_ib_mlx5_devx_device_mem_free(uct_md_h uct_md, uct_mem_h tl_memh);

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -239,8 +239,9 @@ static void uct_rocm_copy_md_close(uct_md_h uct_md) {
 
 static ucs_status_t
 uct_rocm_copy_mem_alloc(uct_md_h md, size_t *length_p, void **address_p,
-                        ucs_memory_type_t mem_type, unsigned flags,
-                        const char *alloc_name, uct_mem_h *memh_p)
+                        ucs_memory_type_t mem_type, ucs_sys_device_t sys_dev,
+                        unsigned flags, const char *alloc_name,
+                        uct_mem_h *memh_p)
 {
     ucs_status_t status;
     hsa_status_t hsa_status;

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -515,8 +515,8 @@ uct_posix_segment_open(uct_mm_md_t *md, uct_mm_seg_id_t *seg_id_p, int *fd_p)
 
 static ucs_status_t
 uct_posix_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
-                    ucs_memory_type_t mem_type, unsigned flags,
-                    const char *alloc_name, uct_mem_h *memh_p)
+                    ucs_memory_type_t mem_type, ucs_sys_device_t sys_dev,
+                    unsigned flags, const char *alloc_name, uct_mem_h *memh_p)
 {
     uct_mm_md_t                     *md = ucs_derived_of(tl_md, uct_mm_md_t);
     uct_posix_md_config_t *posix_config = ucs_derived_of(md->config,

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -68,8 +68,8 @@ static ucs_status_t uct_sysv_mem_attach_common(int shmid, void **address_p)
 
 static ucs_status_t
 uct_sysv_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
-                   ucs_memory_type_t mem_type, unsigned flags,
-                   const char *alloc_name, uct_mem_h *memh_p)
+                   ucs_memory_type_t mem_type, ucs_sys_device_t sys_dev,
+                   unsigned flags, const char *alloc_name, uct_mem_h *memh_p)
 {
     uct_mm_md_t *md = ucs_derived_of(tl_md, uct_mm_md_t);
     ucs_status_t status;

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -62,8 +62,8 @@ static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 
 static ucs_status_t
 uct_ze_copy_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
-                      ucs_memory_type_t mem_type, unsigned flags,
-                      const char *alloc_name, uct_mem_h *memh_p)
+                      ucs_memory_type_t mem_type, ucs_sys_device_t sys_dev,
+                      unsigned flags, const char *alloc_name, uct_mem_h *memh_p)
 {
     uct_ze_copy_md_t *md = ucs_derived_of(tl_md, uct_ze_copy_md_t);
     ze_host_mem_alloc_desc_t host_desc  = {};

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -81,13 +81,30 @@ UCS_TEST_F(test_topo, print_info) {
 
 UCS_TEST_F(test_topo, bdf_name) {
     static const char *bdf_name = "0002:8f:5c.0";
+    static const char *dev_name = "test_bdf_name";
+    static const uintptr_t user_value = 1337;
+
     ucs_sys_device_t sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
 
     ucs_status_t status = ucs_topo_find_device_by_bdf_name(bdf_name, &sys_dev);
     ASSERT_UCS_OK(status);
     ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, sys_dev);
-    status = ucs_topo_sys_device_set_name(sys_dev, "test_bdf_name", 10);
+
+    status = ucs_topo_sys_device_set_name(sys_dev, dev_name, 10);
     ASSERT_UCS_OK(status);
+
+    status = ucs_topo_sys_device_set_user_value(sys_dev, user_value);
+    ASSERT_UCS_OK(status);
+
+    const char *result_name = ucs_topo_sys_device_get_name(sys_dev);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(std::string(dev_name), std::string(result_name));
+    UCS_TEST_MESSAGE << "name: " << result_name;
+
+    uintptr_t result_user_value = ucs_topo_sys_device_get_user_value(sys_dev);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(user_value, result_user_value);
+    UCS_TEST_MESSAGE << "user value: " << result_user_value;
 
     char name_buffer[UCS_SYS_BDF_NAME_MAX];
     const char *found_name = ucs_topo_sys_device_bdf_name(sys_dev, name_buffer,

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1462,12 +1462,13 @@ uct_test::mapped_buffer::mapped_buffer(size_t size,
     if ((mem_type == UCS_MEMORY_TYPE_HOST) || (mem_type == UCS_MEMORY_TYPE_RDMA)) {
         m_entity.mem_alloc(alloc_size, mem_flags, &m_mem, mem_type, num_retries);
     } else {
-        m_mem.method   = UCT_ALLOC_METHOD_LAST;
-        m_mem.address  = mem_buffer::allocate(alloc_size, mem_type);
-        m_mem.length   = alloc_size;
-        m_mem.mem_type = mem_type;
-        m_mem.memh     = UCT_MEM_HANDLE_NULL;
-        m_mem.md       = NULL;
+        m_mem.method     = UCT_ALLOC_METHOD_LAST;
+        m_mem.address    = mem_buffer::allocate(alloc_size, mem_type);
+        m_mem.length     = alloc_size;
+        m_mem.mem_type   = mem_type;
+        m_mem.memh       = UCT_MEM_HANDLE_NULL;
+        m_mem.md         = NULL;
+        m_mem.sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
         m_entity.mem_type_reg(&m_mem, mem_flags);
     }
 


### PR DESCRIPTION
## What?
Re-adds existing API PR #10448 with latest comments addressed, and UCT implementation.

## Why?
Fragments used for pipeline need to use the same GPU as the user GPU.

## How?
Set context if needed, if not available find first usable primary context. If explicit context was requested and not found, return an error.