### PR TITLE
UCT/CUDA_IPC: Fix missing legacy type detection during mpack

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -335,6 +335,7 @@ err:
 static ucs_status_t uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key,
                                                 CUdeviceptr *mapped_addr)
 {
+    ucs_log_level_t level;
 
     ucs_trace("key handle type %u", key->ph.handle_type);
 
@@ -348,10 +349,16 @@ static ucs_status_t uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key,
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL:
         return uct_cuda_ipc_open_memhandle_mempool(key, mapped_addr);
 #endif
+    case UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC:
+        level = UCS_LOG_LEVEL_DEBUG;
+        break;
     default:
-        ucs_error("unsupported key handle type");
-        return UCS_ERR_INVALID_PARAM;
+        level = UCS_LOG_LEVEL_ERROR;
+        break;
     }
+
+    ucs_log(level, "unsupported key handle type: %u", key->ph.handle_type);
+    return UCS_ERR_INVALID_PARAM;
 }
 
 static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -188,7 +188,7 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
     CUpointer_attribute attr_type[UCT_CUDA_IPC_QUERY_NUM_ATTRS];
     void *attr_data[UCT_CUDA_IPC_QUERY_NUM_ATTRS];
     int legacy_capable;
-    int allowed_handle_types;
+    uint64_t allowed_handle_types;
 #endif
 
     key = ucs_calloc(1, sizeof(*key), "uct_cuda_ipc_lkey_t");
@@ -292,7 +292,7 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
     goto common_path;
 
 non_ipc:
-    key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_ERROR;
+    key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC;
     goto common_path;
 #endif
 legacy_path:
@@ -305,9 +305,10 @@ legacy_path:
 
 common_path:
     ucs_list_add_tail(&memh->list, &key->link);
-    ucs_trace("registered addr:%p/%p length:%zd dev_num:%d buffer_id:%llu",
-              addr, (void *)key->d_bptr, key->b_len, (int)memh->dev_num,
-              key->ph.buffer_id);
+    ucs_trace("registered addr:%p/%p length:%zd type:%u dev_num:%d "
+              "buffer_id:%llu",
+              addr, (void *)key->d_bptr, key->b_len, key->ph.handle_type,
+              memh->dev_num, key->ph.buffer_id);
 
     *key_p = key;
     status = UCS_OK;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -15,7 +15,7 @@
 
 
 typedef enum uct_cuda_ipc_key_handle {
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_ERROR = 0,
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC = 0,
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, /* cudaMalloc memory */
 #if HAVE_CUDA_FABRIC
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM, /* cuMemCreate memory */

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -158,6 +158,31 @@ UCS_TEST_P(test_cuda_ipc_md, missing_device_context)
     EXPECT_NE(dev_num, rkey.dev_num); // rkey was not updated
 }
 
+UCS_TEST_P(test_cuda_ipc_md, mpack_legacy)
+{
+    constexpr size_t size = 4096;
+    ucs::handle<uct_md_h> md;
+    uct_mem_h memh;
+    uct_cuda_ipc_rkey_t rkey;
+    CUdeviceptr ptr;
+
+    UCS_TEST_CREATE_HANDLE(uct_md_h, md, uct_md_close, uct_md_open,
+                           GetParam().component, GetParam().md_name.c_str(),
+                           m_md_config);
+    ASSERT_EQ(CUDA_SUCCESS, cuMemAlloc(&ptr, size));
+    EXPECT_UCS_OK(md->ops->mem_reg(md, (void *)ptr, size, NULL, &memh));
+    EXPECT_UCS_OK(md->ops->mkey_pack(md, memh, (void *)ptr, size, NULL,
+                                     &rkey));
+
+    EXPECT_EQ(UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, rkey.ph.handle_type);
+
+    uct_md_mem_dereg_params_t params;
+    params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+    params.memh       = memh;
+    EXPECT_UCS_OK(md->ops->mem_dereg(md, &params));
+    cuMemFree(ptr);
+}
+
 UCS_MT_TEST_P(test_cuda_ipc_md, multiple_mds, 8)
 {
     cuda_context cuda_ctx;
@@ -194,9 +219,9 @@ UCS_TEST_P(test_cuda_ipc_md, mkey_pack_legacy)
     EXPECT_EQ(CUDA_SUCCESS, cuMemFree(ptr));
 }
 
-#if HAVE_CUDA_FABRIC
 UCS_TEST_P(test_cuda_ipc_md, mkey_pack_mempool)
 {
+#if HAVE_CUDA_FABRIC
     size_t size = 4 * UCS_MBYTE;
     CUdeviceptr ptr;
     CUmemoryPool mpool;
@@ -205,41 +230,9 @@ UCS_TEST_P(test_cuda_ipc_md, mkey_pack_mempool)
     alloc_mempool(&ptr, &mpool, &cu_stream, size);
     test_mkey_pack_on_thread((void*)ptr, size);
     free_mempool(&ptr, &mpool, &cu_stream);
-}
-
-UCS_MT_TEST_P(test_cuda_ipc_md, multiple_mds_mempool, 8)
-{
-    cuda_context cuda_ctx;
-    ucs::handle<uct_md_h> md;
-    UCS_TEST_CREATE_HANDLE(uct_md_h, md, uct_md_close, uct_md_open,
-                           GetParam().component, GetParam().md_name.c_str(),
-                           m_md_config);
-
-    CUdeviceptr ptr;
-    CUmemoryPool mpool, q_mpool;
-    CUstream cu_stream;
-    CUmemFabricHandle fabric_handle;
-    CUresult cu_err;
-
-    alloc_mempool(&ptr, &mpool, &cu_stream, 64);
-    EXPECT_EQ(CUDA_SUCCESS, (cuPointerGetAttribute((void*)&q_mpool,
-                    CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE, ptr)));
-
-    cu_err = cuMemPoolExportToShareableHandle((void*)&fabric_handle, q_mpool,
-                                              CU_MEM_HANDLE_TYPE_FABRIC, 0);
-    free_mempool(&ptr, &mpool, &cu_stream);
-
-    if (cu_err == CUDA_SUCCESS) {
-        for (int64_t i = 0; i < 64; ++i) {
-            /* We get unique dev_num on new UUID */
-            uct_cuda_ipc_rkey_t rkey = unpack_masync(md, i + 1);
-            EXPECT_EQ(i, rkey.dev_num);
-            /* Subsequent call with the same UUID returns value from cache */
-            rkey = unpack_masync(md, i + 1);
-            EXPECT_EQ(i, rkey.dev_num);
-        }
-    }
-}
+#else
+    UCS_TEST_SKIP_R("built without fabric support");
 #endif
+}
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_cuda_ipc_md, cuda_ipc);


### PR DESCRIPTION
## What?
After #10405, existing error becomes visible when unpacking rkey. Memory was allocated with `cuMemAlloc()` as fabric-related allocations fail (rock, perftest -m cuda,cuda, recv_memh/send_memh), then in `cuda_ipc` mpack, we erroneously see legacy attribute being false.

## Why?
The `allowed_handle_types` should apparently be 8 bytes, not 4 bytes and it seems to be corrupting the legacy variable.

## How?
Added fix and corresponding test.

```
#0  uct_cuda_ipc_open_memhandle (key=0x2470343, mapped_addr=0x7fffffffb468) at cuda_ipc/cuda_ipc_cache.c:339
#1  0x00007fffec29fbac in uct_cuda_ipc_map_memhandle_inner (mapped_addr=0x7fffffffb468, key=0x2470343) at cuda_ipc/cuda_ipc_cache.c:528
#2  uct_cuda_ipc_map_memhandle (key=0x2470343, mapped_addr=0x7fffffffb468) at cuda_ipc/cuda_ipc_cache.c:478
#3  0x00007fffec297315 in uct_cuda_ipc_is_peer_accessible (component=0x7fffec4a8f80 <uct_cuda_ipc_component>, rkey=0x2470343) at cuda_ipc/cuda_ipc_md.c:321
#4  0x00007fffec29741f in uct_cuda_ipc_rkey_unpack_inner (handle_p=0x29204c0, rkey_p=0x29204b8, rkey_buffer=0x2470343, component=0x7fffec4a8f80 <uct_cuda_ipc_component>)
    at cuda_ipc/cuda_ipc_md.c:345
#5  uct_cuda_ipc_rkey_unpack (component=0x7fffec4a8f80 <uct_cuda_ipc_component>, rkey_buffer=0x2470343, rkey_p=0x29204b8, handle_p=0x29204c0) at cuda_ipc/cuda_ipc_md.c:334
#6  0x00007ffff76bc8eb in uct_rkey_unpack (component=0x7fffec4a8f80 <uct_cuda_ipc_component>, rkey_buffer=0x2470343, rkey_ob=0x29204b8) at base/uct_md.c:349
#7  0x00007ffff7998d4d in ucp_ep_rkey_unpack_internal_inner (rkey_p=0x121c508, skip_md_map=0, unpack_md_map=4078, length=0, buffer=0x2470338, ep=0x7fffe0037140) at core/ucp_rkey.c:887
#8  ucp_ep_rkey_unpack_internal (ep=0x7fffe0037140, buffer=0x2470338, length=0, unpack_md_map=4078, skip_md_map=0, rkey_p=0x121c508) at core/ucp_rkey.c:791
#9  0x00007ffff799930d in ucp_ep_rkey_unpack_reachable (rkey_p=0x121c508, length=0, buffer=0x2470338, ep=0x7fffe0037140) at core/ucp_rkey.inl:62
#10 ucp_ep_rkey_unpack (ep=0x7fffe0037140, rkey_buffer=0x2470338, rkey_p=0x121c508) at core/ucp_rkey.c:935
#11 0x000000000040cf51 in ucp_perf_test_rkey_unpack (thread=0x1218130, params=0x7710b0, rkey_buffer=0x2470338, rkey_size=253) at libperf.c:1087
#12 0x000000000040d4aa in ucp_perf_test_receive_remote_data (perf=0x7710b0, peer_index=1) at libperf.c:1190
#13 0x000000000040e89a in ucp_perf_test_setup_endpoints (perf=0x7710b0, features=66) at libperf.c:1624
```