### PR TITLE
AZP: Update CUDA and gdrcopy versions

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -189,13 +189,13 @@ try_load_cuda_env() {
     [ "${num_gpus}" -gt 0 ] || return 0
 
     # Check cuda env module
-    az_module_load dev/cuda12.5.1 || return 0
+    az_module_load dev/cuda12.8 || return 0
     have_cuda=yes
 
     # Check gdrcopy
     if [ -w "/dev/gdrdrv" ]
     then
-        az_module_load dev/gdrcopy2.4.1_cuda12.5.1 && have_gdrcopy=yes
+        az_module_load dev/gdrcopy2.4.4_cuda12.8.0 && have_gdrcopy=yes
     fi
 }
 

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -4,8 +4,8 @@ WORKSPACE=${WORKSPACE:=$PWD}
 # build in local directory which goes away when docker exits
 ucx_build_dir=$HOME/${BUILD_ID}/build
 ucx_inst=$ucx_build_dir/install
-CUDA_MODULE="dev/cuda12.2.2"
-GDRCOPY_MODULE="dev/gdrcopy2.3.1-1_cuda12.2.2"
+CUDA_MODULE="dev/cuda12.8"
+GDRCOPY_MODULE="dev/gdrcopy2.4.4_cuda12.8.0"
 JDK_MODULE="dev/jdk"
 MVN_MODULE="dev/mvn"
 XPMEM_MODULE="dev/xpmem-90a95a4"

--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -13,7 +13,7 @@ steps:
 
       case "${{ parameters.Name }}" in
         "Build-UCX")
-          module="/hpc/local/etc/modulefiles/dev/cuda12.1"
+          module="/hpc/local/etc/modulefiles/dev/cuda12.8"
           perfxParams=(--skip-run --source-branch $(Build.SourceBranch) --omb-cuda)
           ;;
         "Perf-test-multi-node")


### PR DESCRIPTION
## What?
Update CUDA and gdrcopy modules used in CI to version 12.8.

## Why?
[HPCINFRA-3113](https://jirasw.nvidia.com/browse/HPCINFRA-3113) (Internal link).
