### PR TITLE
UCT/API: Define rkey_unpack v2

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -320,7 +320,7 @@ ucp_ep_peer_mem_get(ucp_context_h context, ucp_ep_h ep, uint64_t address,
 
     data->size = size;
     ucp_ep_rkey_unpack_internal(ep, rkey_buf, 0, UCS_BIT(rkey_ptr_md_index), 0,
-                                &data->rkey);
+                                UCS_SYS_DEVICE_ID_UNKNOWN, &data->rkey);
     rkey_index = ucs_bitmap2idx(data->rkey->md_map, rkey_ptr_md_index);
     status     = uct_rkey_ptr(data->rkey->tl_rkey[rkey_index].cmpt,
                               &data->rkey->tl_rkey[rkey_index].rkey, address,

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -221,7 +221,9 @@ int ucp_memh_buffer_is_dummy(const void *exported_memh_buffer);
 ucs_status_t
 ucp_ep_rkey_unpack_internal(ucp_ep_h ep, const void *buffer, size_t length,
                             ucp_md_map_t unpack_md_map,
-                            ucp_md_map_t skip_md_map, ucp_rkey_h *rkey_p);
+                            ucp_md_map_t skip_md_map,
+                            ucs_sys_device_t sys_device,
+                            ucp_rkey_h *rkey_p);
 
 
 void ucp_rkey_dump_packed(const void *buffer, size_t length,

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -60,7 +60,8 @@ ucp_ep_rkey_unpack_reachable(ucp_ep_h ep, const void *buffer, size_t length,
     ucp_ep_config_t *config = &ucs_array_elem(&ep->worker->ep_config,
                                               ep->cfg_index);
     return ucp_ep_rkey_unpack_internal(ep, buffer, length,
-                                       config->key.reachable_md_map, 0, rkey_p);
+                                       config->key.reachable_md_map, 0,
+                                       UCS_SYS_DEVICE_ID_UNKNOWN, rkey_p);
 }
 
 #endif

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -734,7 +734,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_rndv_send_reply,
          */
         status = ucp_ep_rkey_unpack_internal(
                   ep, rkey_buffer, rkey_length, ep_config->key.reachable_md_map,
-                  ep_config->rndv.proto_rndv_rkey_skip_mds, &rkey);
+                  ep_config->rndv.proto_rndv_rkey_skip_mds,
+                  req->send.state.dt_iter.mem_info.sys_dev, &rkey);
         if (status != UCS_OK) {
             goto err;
         }

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -715,6 +715,36 @@ typedef struct uct_rkey_compare_params {
     uint64_t                      field_mask;
 } uct_rkey_compare_params_t;
 
+
+/**
+ * @ingroup UCT_MD
+ * @brief Rkey unpack parameters field mask.
+ */
+typedef enum {
+    UCT_RKEY_UNPACK_FIELD_SYS_DEVICE = UCS_BIT(0)  /**< sys_device field */
+} uct_rkey_unpack_field_mask_t;
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Parameters for unpacking remote key using @ref uct_rkey_unpack_v2.
+ */
+typedef struct uct_rkey_unpack_params {
+    /**
+     * Mask of valid fields in this structure, using bits from
+     * @ref uct_rkey_unpack_field_mask_t. Fields not specified in this mask will
+     * be ignored. Provides ABI compatibility with respect to adding new fields.
+     */
+    uint64_t field_mask;
+
+    /**
+     * System device to unpack rkey on. Can be UCS_SYS_DEVICE_ID_UNKNOWN
+     * (default behavior).
+     */
+    ucs_sys_device_t sys_device;
+} uct_rkey_unpack_params_t;
+
+
 /**
  * @ingroup UCT_RESOURCE
  * @brief Get interface performance attributes, by memory types and operation.
@@ -1132,6 +1162,34 @@ int uct_ep_is_connected(uct_ep_h ep,
 ucs_status_t
 uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
                  const uct_rkey_compare_params_t *params, int *result);
+
+
+/**
+ * @ingroup UCT_MD
+ *
+ * @brief Unpack a remote key.
+ *
+ * @param [in]  component    Component on which to unpack the remote key.
+ * @param [in]  rkey_buffer  Packed remote key buffer.
+ * @param [in]  params       Operation parameters, see @ref
+ *                           uct_rkey_unpack_params_t.
+ * @param [out] rkey_ob      Filled with the unpacked remote key and its type.
+ *
+ * @note The remote key must be unpacked with the same component that was used
+ *       to pack it. For example, if a remote device address on the remote
+ *       memory domain which was used to pack the key is reachable by a
+ *       transport on a local component, then that component is eligible to
+ *       unpack the key.
+ *       If the remote key buffer cannot be unpacked with the given component,
+ *       UCS_ERR_INVALID_PARAM will be returned.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_rkey_unpack_v2(uct_component_h component,
+                                const void *rkey_buffer,
+                                const uct_rkey_unpack_params_t *params,
+                                uct_rkey_bundle_t *rkey_ob);
+
 
 END_C_DECLS
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -735,13 +735,13 @@ typedef struct uct_rkey_unpack_params {
      * @ref uct_rkey_unpack_field_mask_t. Fields not specified in this mask will
      * be ignored. Provides ABI compatibility with respect to adding new fields.
      */
-    uint64_t field_mask;
+    uint64_t             field_mask;
 
     /**
      * System device to unpack rkey on. Can be UCS_SYS_DEVICE_ID_UNKNOWN
      * (default behavior).
      */
-    ucs_sys_device_t sys_device;
+    ucs_sys_device_t     sys_device;
 } uct_rkey_unpack_params_t;
 
 
@@ -1183,7 +1183,7 @@ uct_rkey_compare(uct_component_h component, uct_rkey_t rkey1, uct_rkey_t rkey2,
  *       If the remote key buffer cannot be unpacked with the given component,
  *       UCS_ERR_INVALID_PARAM will be returned.
  *
- * @return Error code.
+ * @return UCS_OK on success or error code in case of failure.
  */
 ucs_status_t uct_rkey_unpack_v2(uct_component_h component,
                                 const void *rkey_buffer,

--- a/src/uct/base/uct_component.h
+++ b/src/uct/base/uct_component.h
@@ -87,7 +87,7 @@ typedef ucs_status_t (*uct_component_cm_open_func_t)(
  * @param [in]  component               Unpack the remote key buffer on this
  *                                      component.
  * @param [in]  rkey_buffer             Remote key buffer to unpack.
- * @param [in]  config                  Memory domain configuration.
+ * @param [in]  params                  Unpack operation parameters.
  * @param [out] rkey_p                  Filled with a pointer to the unpacked
  *                                      remote key.
  * @param [out] handle_p                Filled with an additional handle which
@@ -99,6 +99,7 @@ typedef ucs_status_t (*uct_component_cm_open_func_t)(
  */
 typedef ucs_status_t (*uct_component_rkey_unpack_func_t)(
                 uct_component_t *component, const void *rkey_buffer,
+                const uct_rkey_unpack_params_t *params,
                 uct_rkey_t *rkey_p, void **handle_p);
 
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -171,8 +171,9 @@ uct_md_query_empty_md_resource(uct_md_resource_desc_t **resources_p,
 }
 
 ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
-                                     const void *rkey_buffer, uct_rkey_t *rkey_p,
-                                     void **handle_p)
+                                     const void *rkey_buffer,
+                                     const uct_rkey_unpack_params_t *params,
+                                     uct_rkey_t *rkey_p, void **handle_p)
 {
     *rkey_p   = 0xdeadbeef;
     *handle_p = NULL;
@@ -343,11 +344,24 @@ ucs_status_t uct_md_mem_attach(uct_md_h md, const void *mkey_buffer,
     return md->ops->mem_attach(md, mkey_buffer, params, memh_p);
 }
 
+ucs_status_t uct_rkey_unpack_v2(uct_component_h component,
+                                const void *rkey_buffer,
+                                const uct_rkey_unpack_params_t *params,
+                                uct_rkey_bundle_t *rkey_ob)
+{
+
+    return component->rkey_unpack(component, rkey_buffer, params,
+                                  &rkey_ob->rkey, &rkey_ob->handle);
+}
+
 ucs_status_t uct_rkey_unpack(uct_component_h component, const void *rkey_buffer,
                              uct_rkey_bundle_t *rkey_ob)
 {
-    return component->rkey_unpack(component, rkey_buffer, &rkey_ob->rkey,
-                                  &rkey_ob->handle);
+    uct_rkey_unpack_params_t params = {
+        .field_mask = 0
+    };
+
+    return uct_rkey_unpack_v2(component, rkey_buffer, &params, rkey_ob);
 }
 
 ucs_status_t uct_rkey_ptr(uct_component_h component, uct_rkey_bundle_t *rkey_ob,

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -217,8 +217,9 @@ ucs_status_t uct_md_mem_free(uct_md_h md, uct_mem_h memh);
  *
  */
 ucs_status_t uct_md_stub_rkey_unpack(uct_component_t *component,
-                                     const void *rkey_buffer, uct_rkey_t *rkey_p,
-                                     void **handle_p);
+                                     const void *rkey_buffer,
+                                     const uct_rkey_unpack_params_t *params,
+                                     uct_rkey_t *rkey_p, void **handle_p);
 
 ucs_status_t uct_base_rkey_compare(uct_component_t *component, uct_rkey_t rkey1,
                                    uct_rkey_t rkey2,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -420,9 +420,10 @@ err:
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
-                 (component, rkey_buffer, rkey_p, handle_p),
+                 (component, rkey_buffer, params, rkey_p, handle_p),
                  uct_component_t *component, const void *rkey_buffer,
-                 uct_rkey_t *rkey_p, void **handle_p)
+                 const uct_rkey_unpack_params_t *params, uct_rkey_t *rkey_p,
+                 void **handle_p)
 {
     uct_cuda_ipc_component_t *com = ucs_derived_of(component,
                                                    uct_cuda_ipc_component_t);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -98,9 +98,10 @@ uct_gdr_copy_mkey_pack(uct_md_h md, uct_mem_h memh, void *address,
     return UCS_OK;
 }
 
-static ucs_status_t uct_gdr_copy_rkey_unpack(uct_component_t *component,
-                                             const void *rkey_buffer,
-                                             uct_rkey_t *rkey_p, void **handle_p)
+static ucs_status_t
+uct_gdr_copy_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                         const uct_rkey_unpack_params_t *params,
+                         uct_rkey_t *rkey_p, void **handle_p)
 {
     uct_gdr_copy_key_t *packed = (uct_gdr_copy_key_t *)rkey_buffer;
     uct_gdr_copy_key_t *key;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -747,8 +747,9 @@ ucs_status_t uct_ib_verbs_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
 }
 
 ucs_status_t uct_ib_rkey_unpack(uct_component_t *component,
-                                const void *rkey_buffer, uct_rkey_t *rkey_p,
-                                void **handle_p)
+                                const void *rkey_buffer,
+                                const uct_rkey_unpack_params_t *params,
+                                uct_rkey_t *rkey_p, void **handle_p)
 {
     uint64_t packed_rkey = *(const uint64_t*)rkey_buffer;
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -411,8 +411,9 @@ ucs_status_t uct_ib_verbs_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
                                     void *mkey_buffer);
 
 ucs_status_t uct_ib_rkey_unpack(uct_component_t *component,
-                                const void *rkey_buffer, uct_rkey_t *rkey_p,
-                                void **handle_p);
+                                const void *rkey_buffer,
+                                const uct_rkey_unpack_params_t *params,
+                                uct_rkey_t *rkey_p, void **handle_p);
 
 ucs_status_t
 uct_ib_base_query_md_resources(uct_md_resource_desc_t **resources_p,

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -132,6 +132,7 @@ uct_ib_mlx5_gga_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
 
 static ucs_status_t
 uct_gga_mlx5_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                         const uct_rkey_unpack_params_t *params,
                          uct_rkey_t *rkey_p, void **handle_p)
 {
     const uct_ib_md_packed_mkey_t *mkey = rkey_buffer;
@@ -287,6 +288,7 @@ uct_gga_mlx5_rkey_resolve(uct_gga_mlx5_md_t *md,
     uct_md_h uct_md                          = &md->super.super.super;
     uct_md_mem_attach_params_t attach_params = { 0 };
     uct_md_mkey_pack_params_t repack_params  = { 0 };
+    uct_rkey_unpack_params_t unpack_params   = { 0 };
     uint64_t repack_mkey;
     ucs_status_t status;
 
@@ -310,7 +312,7 @@ uct_gga_mlx5_rkey_resolve(uct_gga_mlx5_md_t *md,
         goto err_dereg;
     }
 
-    status = uct_ib_rkey_unpack(NULL, &repack_mkey,
+    status = uct_ib_rkey_unpack(NULL, &repack_mkey, &unpack_params,
                                 &rkey_handle->rkey_ob.rkey,
                                 &rkey_handle->rkey_ob.handle);
     uct_gga_mlx5_rkey_trace(md, rkey_handle, "new");

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -82,9 +82,10 @@ uct_rocm_copy_mkey_pack(uct_md_h uct_md, uct_mem_h memh, void *address,
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_copy_rkey_unpack(uct_component_t *component,
-                                              const void *rkey_buffer,
-                                              uct_rkey_t *rkey_p, void **handle_p)
+static ucs_status_t
+uct_rocm_copy_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                          const uct_rkey_unpack_params_t *params,
+                          uct_rkey_t *rkey_p, void **handle_p)
 {
     uct_rocm_copy_key_t *packed = (uct_rocm_copy_key_t *)rkey_buffer;
     uct_rocm_copy_key_t *key;

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -143,9 +143,10 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
     return UCS_OK;
 }
 
-static ucs_status_t uct_rocm_ipc_rkey_unpack(uct_component_t *component,
-                                             const void *rkey_buffer,
-                                             uct_rkey_t *rkey_p, void **handle_p)
+static ucs_status_t
+uct_rocm_ipc_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                         const uct_rkey_unpack_params_t *params,
+                         uct_rkey_t *rkey_p, void **handle_p)
 {
     uct_rocm_ipc_key_t *packed = (uct_rocm_ipc_key_t *)rkey_buffer;
     uct_rocm_ipc_key_t *key;

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -716,8 +716,9 @@ static void uct_posix_mem_detach(uct_mm_md_t *md, const uct_mm_remote_seg_t *rse
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_posix_rkey_unpack,
-                 (component, rkey_buffer, rkey_p, handle_p),
+                 (component, rkey_buffer, params, rkey_p, handle_p),
                  uct_component_t *component, const void *rkey_buffer,
+                 const uct_rkey_unpack_params_t *params,
                  uct_rkey_t *rkey_p, void **handle_p)
 {
     const uct_posix_packed_rkey_t *packed_rkey = rkey_buffer;

--- a/src/uct/sm/mm/sysv/mm_sysv.c
+++ b/src/uct/sm/mm/sysv/mm_sysv.c
@@ -169,8 +169,9 @@ static void uct_sysv_mem_detach(uct_mm_md_t *md, const uct_mm_remote_seg_t *rseg
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_sysv_rkey_unpack,
-                 (component, rkey_buffer, rkey_p, handle_p),
+                 (component, rkey_buffer, params, rkey_p, handle_p),
                  uct_component_t *component, const void *rkey_buffer,
+                 const uct_rkey_unpack_params_t *params,
                  uct_rkey_t *rkey_p, void **handle_p)
 {
     const uct_sysv_packed_rkey_t *packed_rkey = rkey_buffer;

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -502,6 +502,7 @@ static void uct_xpmem_mem_detach(uct_mm_md_t *md,
 
 static ucs_status_t
 uct_xpmem_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                      const uct_rkey_unpack_params_t *params,
                       uct_rkey_t *rkey_p, void **handle_p)
 {
     const uct_xpmem_packed_rkey_t *packed_rkey = rkey_buffer;

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -216,6 +216,7 @@ uct_knem_mkey_pack(uct_md_h md, uct_mem_h memh, void *address, size_t length,
 
 static ucs_status_t uct_knem_rkey_unpack(uct_component_t *component,
                                          const void *rkey_buffer,
+                                         const uct_rkey_unpack_params_t *params,
                                          uct_rkey_t *rkey_p, void **handle_p)
 {
     uct_knem_key_t *packed = (uct_knem_key_t *)rkey_buffer;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -463,9 +463,10 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
     return UCS_OK;
 }
 
-static ucs_status_t uct_self_md_rkey_unpack(uct_component_t *component,
-                                            const void *rkey_buffer, uct_rkey_t *rkey_p,
-                                            void **handle_p)
+static ucs_status_t
+uct_self_md_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                        const uct_rkey_unpack_params_t *params,
+                        uct_rkey_t *rkey_p, void **handle_p)
 {
     /**
      * Pseudo stub function for the key unpacking

--- a/src/uct/ugni/base/ugni_md.c
+++ b/src/uct/ugni/base/ugni_md.c
@@ -135,6 +135,7 @@ static ucs_status_t uct_ugni_rkey_release(uct_component_t *component,
 
 static ucs_status_t uct_ugni_rkey_unpack(uct_component_t *component,
                                          const void *rkey_buffer,
+                                         const uct_rkey_unpack_params_t *params,
                                          uct_rkey_t *rkey_p, void **handle_p)
 {
     const uint64_t *ptr = rkey_buffer;

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -109,9 +109,10 @@ static ucs_status_t uct_ze_copy_mem_free(uct_md_h tl_md, uct_mem_h memh)
     return UCT_ZE_FUNC_LOG_ERR(zeMemFree(md->ze_context, (void*)memh));
 }
 
-static ucs_status_t uct_ze_copy_rkey_unpack(uct_component_t *component,
-                                            const void *rkey_buffer,
-                                            uct_rkey_t *rkey_p, void **handle_p)
+static ucs_status_t
+uct_ze_copy_rkey_unpack(uct_component_t *component, const void *rkey_buffer,
+                        const uct_rkey_unpack_params_t *params,
+                        uct_rkey_t *rkey_p, void **handle_p)
 {
     *handle_p = NULL;
     *rkey_p   = 0xdeadbeef;

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -235,8 +235,9 @@ ucp_rkey_h test_ucp_mmap::mem_chunk::unpack(ucp_ep_h ep, ucp_md_map_t md_map)
         ASSERT_UCS_OK(ucp_ep_rkey_unpack(ep, rkey_buffer, &rkey));
     } else {
         // Different MD map means different config index on proto v2
-        ASSERT_UCS_OK(ucp_ep_rkey_unpack_internal(ep, rkey_buffer, rkey_size,
-                                                  md_map, 0, &rkey));
+        ASSERT_UCS_OK(ucp_ep_rkey_unpack_internal(
+                        ep, rkey_buffer, rkey_size, md_map, 0,
+                        UCS_SYS_DEVICE_ID_UNKNOWN, &rkey));
     }
 
     ucp_rkey_buffer_release(rkey_buffer);

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -33,8 +33,8 @@ protected:
          * handle that was created by the same process */
         uct_rkey_unpack_params_t unpack_params = { 0 };
         EXPECT_EQ(UCS_ERR_UNREACHABLE,
-                  md->component->rkey_unpack(md->component, &rkey,
-                                             &unpack_params, NULL, NULL));
+                  uct_rkey_unpack_v2(md->component, &rkey, &unpack_params,
+                                     NULL));
 
         uct_md_mem_dereg_params_t params;
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
@@ -153,8 +153,7 @@ UCS_TEST_P(test_cuda_ipc_md, missing_device_context)
     std::thread t([&md, &rkey, &status]() {
         rkey.dev_num = ~rkey.dev_num;
         uct_rkey_unpack_params_t params = { 0 };
-        status = md->component->rkey_unpack(md->component, &rkey, &params, NULL,
-                                            NULL);
+        status = uct_rkey_unpack_v2(md->component, &rkey, &params, NULL);
     });
     t.join();
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -31,8 +31,10 @@ protected:
 
         /* cuIpcOpenMemHandle used by cuda_ipc_cache does not allow to open
          * handle that was created by the same process */
+        uct_rkey_unpack_params_t unpack_params = { 0 };
         EXPECT_EQ(UCS_ERR_UNREACHABLE,
-                  md->component->rkey_unpack(md->component, &rkey, NULL, NULL));
+                  md->component->rkey_unpack(md->component, &rkey,
+                                             &unpack_params, NULL, NULL));
 
         uct_md_mem_dereg_params_t params;
         params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
@@ -150,7 +152,9 @@ UCS_TEST_P(test_cuda_ipc_md, missing_device_context)
     // Unpack without a CUDA device context
     std::thread t([&md, &rkey, &status]() {
         rkey.dev_num = ~rkey.dev_num;
-        status = md->component->rkey_unpack(md->component, &rkey, NULL, NULL);
+        uct_rkey_unpack_params_t params = { 0 };
+        status = md->component->rkey_unpack(md->component, &rkey, &params, NULL,
+                                            NULL);
     });
     t.join();
 


### PR DESCRIPTION
## What?
Define uct_rkey_unpack_v2 to be able to pass sys_device to rkey unpack. It may be needed for some transports (e.g. cuda_ipc) to properly unpack the rkey. For cuda_ipc handle should be imported on the context corresponding to the device where the user buffer was allocated.

