### PR TITLE
CI: Run gtest with BullsEye

### DIFF
--- a/buildlib/BullseyeCoverageExclusions
+++ b/buildlib/BullseyeCoverageExclusions
@@ -1,0 +1,6 @@
+exclude function **/test/**:*
+exclude folder ../../../tmp/
+exclude folder ../../../hpc/
+exclude folder ../s/build-test/
+exclude folder ../s/examples/
+exclude folder ../s/test/

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -1,5 +1,5 @@
 variables:
-  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
+  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools -v /auto/app:/auto/app -v /hpc/scrap:/hpc/scrap
   DOCKER_OPT_IB: --ulimit memlock=-1:-1 --device=/dev/infiniband/ --net=host
   DOCKER_OPT_GPU: --gpus all --device=/dev/gdrdrv --ipc=host $(DOCKER_OPT_IB)
   DOCKER_OPT_ARGS: --cap-add=SYS_PTRACE
@@ -333,28 +333,70 @@ stages:
         name: althca
         demands: ucx_althca -equals yes
         test_perf: 0
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: gpu
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: new
         demands: ucx_new -equals yes
         test_perf: 1
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: roce
         demands: ucx_roce -equals yes
         test_perf: 0
+        run_bullseye: yes
+    - template: tests.yml
+      parameters:
+        name: roce_proto_disable
+        demands: ucx_roce -equals yes
+        test_perf: 0
+        proto_enable: no
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: BlueField
         demands: ucx_bf -equals yes
         run_tests: yes
         test_perf: 0
+        run_bullseye: yes
+
+    - job: bullseye_report
+      displayName: Merge Bullseye reports
+      dependsOn: 
+        - tests_althca
+        - tests_gpu
+        - tests_new
+        - tests_roce
+        - tests_roce_proto_disable
+        - tests_BlueField
+      condition: succeededOrFailed()
+      pool:
+        name: MLNX
+        demands: ucx_docker
+      steps:
+      - bash: |
+          set -xe
+          export PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86/bin/:$PATH"
+          COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
+          REPORT_FILE="$COV_DIR"/bullseye_report.cov
+          covmerge -c "$COV_DIR"/coverage_*.cov -f "$REPORT_FILE"
+          covfn -f "$REPORT_FILE"
+          mv "$REPORT_FILE" $(Build.ArtifactStagingDirectory)
+          rm -rf "$COV_DIR"
+        displayName: Merge Bullseye files
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathToPublish: $(Build.ArtifactStagingDirectory)
+          artifactName: BullseyeCoverageReport
+        displayName: Publish Bullseye report
 
   - stage: EFA_Tests
     dependsOn: [Static_check]

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -340,7 +340,7 @@ stages:
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
-        run_bullseye: yes
+        run_bullseye: no
     - template: tests.yml
       parameters:
         name: new
@@ -372,7 +372,6 @@ stages:
       displayName: Merge Bullseye reports
       dependsOn: 
         - tests_althca
-        - tests_gpu
         - tests_new
         - tests_roce
         - tests_roce_proto_disable

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -340,7 +340,7 @@ stages:
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
-        run_bullseye: no
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: new
@@ -352,7 +352,7 @@ stages:
         name: roce
         demands: ucx_roce -equals yes
         test_perf: 0
-        run_bullseye: yes
+        run_bullseye: no
     - template: tests.yml
       parameters:
         name: roce_proto_disable
@@ -373,7 +373,7 @@ stages:
       dependsOn: 
         - tests_althca
         - tests_new
-        - tests_roce
+        - tests_gpu
       condition: succeededOrFailed()
       pool:
         name: MLNX
@@ -393,13 +393,16 @@ stages:
           covsrc -f "$REPORT_FILE"
 
           # Generate HTML report
-          REPORT_DIR="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_html"
+          REPORT_DIR="$PIPELINE_WORKSPACE/coverage_html"
           mkdir -p "$REPORT_DIR"
           covhtml -n -f "$REPORT_FILE" "$REPORT_DIR"
 
-          # Strip out workdir path from HTML reports
+          # Strip out workdir path from HTML files
           find "$REPORT_DIR" -type f -name '*.html' -exec \
             sed -i 's|\.\./\.\./\.\./\.\./\.\./scrap/azure/agent-00/AZP_WORKSPACE/0/s/|./|g' {} +
+
+          # Compress for faster upload
+          tar -czf "$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_html.tar.gz" -C "$REPORT_DIR" .
         displayName: Merge Bullseye files
       - task: PublishBuildArtifacts@1
         inputs:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -366,7 +366,7 @@ stages:
         demands: ucx_bf -equals yes
         run_tests: yes
         test_perf: 0
-        run_bullseye: yes
+        run_bullseye: no
 
     - job: bullseye_report
       displayName: Merge Bullseye reports
@@ -375,7 +375,6 @@ stages:
         - tests_new
         - tests_roce
         - tests_roce_proto_disable
-        - tests_BlueField
       condition: succeededOrFailed()
       pool:
         name: MLNX

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -1,5 +1,5 @@
 variables:
-  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools -v /auto/app:/auto/app -v /hpc/scrap:/hpc/scrap
+  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
   DOCKER_OPT_IB: --ulimit memlock=-1:-1 --device=/dev/infiniband/ --net=host
   DOCKER_OPT_GPU: --gpus all --device=/dev/gdrdrv --ipc=host $(DOCKER_OPT_IB)
   DOCKER_OPT_ARGS: --cap-add=SYS_PTRACE
@@ -379,15 +379,27 @@ stages:
         name: MLNX
         demands: ucx_docker
       steps:
+      - checkout: none
+      - download: current
+        patterns: '*.cov'
+        displayName: Download partial reports
       - bash: |
           set -xe
-          export PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86/bin/:$PATH"
-          COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
-          REPORT_FILE="$COV_DIR"/bullseye_report.cov
-          covmerge -c "$COV_DIR"/coverage_*.cov -f "$REPORT_FILE"
-          covfn -f "$REPORT_FILE"
-          mv "$REPORT_FILE" $(Build.ArtifactStagingDirectory)
-          rm -rf "$COV_DIR"
+          export PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/bin/:$PATH"
+
+          # Merge all .cov files
+          REPORT_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/bullseye_report.cov"
+          find "$PIPELINE_WORKSPACE" -name "*.cov" -print0 | xargs -0 covmerge -c -f "$REPORT_FILE"
+          covsrc -f "$REPORT_FILE"
+
+          # Generate HTML report
+          REPORT_DIR="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_html"
+          mkdir -p "$REPORT_DIR"
+          covhtml -n -f "$REPORT_FILE" "$REPORT_DIR"
+
+          # Strip out workdir path from HTML reports
+          find "$REPORT_DIR" -type f -name '*.html' -exec \
+            sed -i 's|\.\./\.\./\.\./\.\./\.\./scrap/azure/agent-00/AZP_WORKSPACE/0/s/|./|g' {} +
         displayName: Merge Bullseye files
       - task: PublishBuildArtifacts@1
         inputs:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -385,7 +385,8 @@ stages:
         displayName: Download partial reports
       - bash: |
           set -xe
-          export PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/bin/:$PATH"
+          source ./buildlib/az-helpers.sh
+          az_module_load tools/bullseyecov-9.14.2
 
           # Merge all .cov files
           REPORT_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/bullseye_report.cov"

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -359,7 +359,7 @@ stages:
         demands: ucx_roce -equals yes
         test_perf: 0
         proto_enable: no
-        run_bullseye: yes
+        run_bullseye: no
     - template: tests.yml
       parameters:
         name: BlueField
@@ -374,7 +374,6 @@ stages:
         - tests_althca
         - tests_new
         - tests_roce
-        - tests_roce_proto_disable
       condition: succeededOrFailed()
       pool:
         name: MLNX

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -338,14 +338,14 @@ stages:
       parameters:
         name: gpu
         demands: ucx_gpu -equals yes
-        test_perf: 1
+        test_perf: 0
         container: ubuntu2404_doca31_gpunetio
         run_bullseye: yes
     - template: tests.yml
       parameters:
         name: new
         demands: ucx_new -equals yes
-        test_perf: 1
+        test_perf: 0
         run_bullseye: yes
     - template: tests.yml
       parameters:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -383,7 +383,7 @@ stages:
         demands: ucx_roce -equals yes
         test_perf: 0
         proto_enable: no
-        run_bullseye: yes
+        run_bullseye: no
     - template: tests.yml
       parameters:
         name: BlueField
@@ -398,7 +398,6 @@ stages:
         - tests_althca
         - tests_new
         - tests_roce
-        - tests_roce_proto_disable
       condition: succeededOrFailed()
       pool:
         name: MLNX

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -1,5 +1,5 @@
 variables:
-  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools -v /auto/app:/auto/app -v /hpc/scrap:/hpc/scrap
+  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
   DOCKER_OPT_IB: --ulimit memlock=-1:-1 --device=/dev/infiniband/ --net=host
   DOCKER_OPT_GPU: --gpus all --device=/dev/gdrdrv --ipc=host $(DOCKER_OPT_IB)
   DOCKER_OPT_ARGS: --cap-add=SYS_PTRACE
@@ -403,15 +403,27 @@ stages:
         name: MLNX
         demands: ucx_docker
       steps:
+      - checkout: none
+      - download: current
+        patterns: '*.cov'
+        displayName: Download partial reports
       - bash: |
           set -xe
-          export PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86/bin/:$PATH"
-          COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
-          REPORT_FILE="$COV_DIR"/bullseye_report.cov
-          covmerge -c "$COV_DIR"/coverage_*.cov -f "$REPORT_FILE"
-          covfn -f "$REPORT_FILE"
-          mv "$REPORT_FILE" $(Build.ArtifactStagingDirectory)
-          rm -rf "$COV_DIR"
+          export PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/bin/:$PATH"
+
+          # Merge all .cov files
+          REPORT_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/bullseye_report.cov"
+          find "$PIPELINE_WORKSPACE" -name "*.cov" -print0 | xargs -0 covmerge -c -f "$REPORT_FILE"
+          covsrc -f "$REPORT_FILE"
+
+          # Generate HTML report
+          REPORT_DIR="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_html"
+          mkdir -p "$REPORT_DIR"
+          covhtml -n -f "$REPORT_FILE" "$REPORT_DIR"
+
+          # Strip out workdir path from HTML reports
+          find "$REPORT_DIR" -type f -name '*.html' -exec \
+            sed -i 's|\.\./\.\./\.\./\.\./\.\./scrap/azure/agent-00/AZP_WORKSPACE/0/s/|./|g' {} +
         displayName: Merge Bullseye files
       - task: PublishBuildArtifacts@1
         inputs:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -1,5 +1,5 @@
 variables:
-  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools
+  DOCKER_OPT_VOLUMES: -v /hpc/local:/hpc/local -v /auto/sw_tools:/auto/sw_tools -v /auto/app:/auto/app -v /hpc/scrap:/hpc/scrap
   DOCKER_OPT_IB: --ulimit memlock=-1:-1 --device=/dev/infiniband/ --net=host
   DOCKER_OPT_GPU: --gpus all --device=/dev/gdrdrv --ipc=host $(DOCKER_OPT_IB)
   DOCKER_OPT_ARGS: --cap-add=SYS_PTRACE
@@ -357,28 +357,70 @@ stages:
         name: althca
         demands: ucx_althca -equals yes
         test_perf: 0
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: gpu
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: new
         demands: ucx_new -equals yes
         test_perf: 1
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: roce
         demands: ucx_roce -equals yes
         test_perf: 0
+        run_bullseye: yes
+    - template: tests.yml
+      parameters:
+        name: roce_proto_disable
+        demands: ucx_roce -equals yes
+        test_perf: 0
+        proto_enable: no
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: BlueField
         demands: ucx_bf -equals yes
         run_tests: yes
         test_perf: 0
+        run_bullseye: yes
+
+    - job: bullseye_report
+      displayName: Merge Bullseye reports
+      dependsOn: 
+        - tests_althca
+        - tests_gpu
+        - tests_new
+        - tests_roce
+        - tests_roce_proto_disable
+        - tests_BlueField
+      condition: succeededOrFailed()
+      pool:
+        name: MLNX
+        demands: ucx_docker
+      steps:
+      - bash: |
+          set -xe
+          export PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86/bin/:$PATH"
+          COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
+          REPORT_FILE="$COV_DIR"/bullseye_report.cov
+          covmerge -c "$COV_DIR"/coverage_*.cov -f "$REPORT_FILE"
+          covfn -f "$REPORT_FILE"
+          mv "$REPORT_FILE" $(Build.ArtifactStagingDirectory)
+          rm -rf "$COV_DIR"
+        displayName: Merge Bullseye files
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathToPublish: $(Build.ArtifactStagingDirectory)
+          artifactName: BullseyeCoverageReport
+        displayName: Publish Bullseye report
 
   - stage: EFA_Tests
     dependsOn: [Basic_compile]

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -409,7 +409,8 @@ stages:
         displayName: Download partial reports
       - bash: |
           set -xe
-          export PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/bin/:$PATH"
+          source ./buildlib/az-helpers.sh
+          az_module_load tools/bullseyecov-9.14.2
 
           # Merge all .cov files
           REPORT_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/bullseye_report.cov"

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -364,7 +364,7 @@ stages:
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
-        run_bullseye: yes
+        run_bullseye: no
     - template: tests.yml
       parameters:
         name: new
@@ -396,7 +396,6 @@ stages:
       displayName: Merge Bullseye reports
       dependsOn: 
         - tests_althca
-        - tests_gpu
         - tests_new
         - tests_roce
         - tests_roce_proto_disable

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -390,7 +390,7 @@ stages:
         demands: ucx_bf -equals yes
         run_tests: yes
         test_perf: 0
-        run_bullseye: yes
+        run_bullseye: no
 
     - job: bullseye_report
       displayName: Merge Bullseye reports
@@ -399,7 +399,6 @@ stages:
         - tests_new
         - tests_roce
         - tests_roce_proto_disable
-        - tests_BlueField
       condition: succeededOrFailed()
       pool:
         name: MLNX

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -362,14 +362,14 @@ stages:
       parameters:
         name: gpu
         demands: ucx_gpu -equals yes
-        test_perf: 1
+        test_perf: 0
         container: ubuntu2404_doca31_gpunetio
         run_bullseye: yes
     - template: tests.yml
       parameters:
         name: new
         demands: ucx_new -equals yes
-        test_perf: 1
+        test_perf: 0
         run_bullseye: yes
     - template: tests.yml
       parameters:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -364,7 +364,7 @@ stages:
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
-        run_bullseye: no
+        run_bullseye: yes
     - template: tests.yml
       parameters:
         name: new
@@ -376,7 +376,7 @@ stages:
         name: roce
         demands: ucx_roce -equals yes
         test_perf: 0
-        run_bullseye: yes
+        run_bullseye: no
     - template: tests.yml
       parameters:
         name: roce_proto_disable
@@ -397,7 +397,7 @@ stages:
       dependsOn: 
         - tests_althca
         - tests_new
-        - tests_roce
+        - tests_gpu
       condition: succeededOrFailed()
       pool:
         name: MLNX
@@ -417,13 +417,16 @@ stages:
           covsrc -f "$REPORT_FILE"
 
           # Generate HTML report
-          REPORT_DIR="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_html"
+          REPORT_DIR="$PIPELINE_WORKSPACE/coverage_html"
           mkdir -p "$REPORT_DIR"
           covhtml -n -f "$REPORT_FILE" "$REPORT_DIR"
 
-          # Strip out workdir path from HTML reports
+          # Strip out workdir path from HTML files
           find "$REPORT_DIR" -type f -name '*.html' -exec \
             sed -i 's|\.\./\.\./\.\./\.\./\.\./scrap/azure/agent-00/AZP_WORKSPACE/0/s/|./|g' {} +
+
+          # Compress for faster upload
+          tar -czf "$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_html.tar.gz" -C "$REPORT_DIR" .
         displayName: Merge Bullseye files
       - task: PublishBuildArtifacts@1
         inputs:

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -7,6 +7,7 @@ parameters:
   run_tests: yes
   asan_check: no
   valgrind_check: no
+  run_bullseye: no
 
 jobs:
   - job: tests_${{ parameters.name }}
@@ -48,4 +49,5 @@ jobs:
           TEST_PERF: ${{ parameters.test_perf }}
           ASAN_CHECK: ${{ parameters.asan_check }}
           VALGRIND_CHECK: ${{ parameters.valgrind_check }}
+          RUN_BULLSEYE: ${{ parameters.run_bullseye }}
           RUNNING_IN_AZURE: yes

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -51,3 +51,8 @@ jobs:
           VALGRIND_CHECK: ${{ parameters.valgrind_check }}
           RUN_BULLSEYE: ${{ parameters.run_bullseye }}
           RUNNING_IN_AZURE: yes
+
+      - ${{ if eq(parameters.run_bullseye, 'yes') }}:
+        - publish: $(Build.ArtifactStagingDirectory)
+          artifact: Bullseye_partial_${{ parameters.name }}_$(worker_id)
+          displayName: Publish Bullseye coverage files

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1134,6 +1134,8 @@ run_gtest_armclang() {
 }
 
 run_gtest_bullseye() {
+	local BULLSEYE_ENABLED=false
+
 	case "$AGENT_OSARCHITECTURE" in
 		"ARM64") SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-arm64" ;;
 		*)       SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86" ;;
@@ -1150,19 +1152,23 @@ run_gtest_bullseye() {
 		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	else
 		echo "=== Enable Bullseye instrumentation ==="
+		BULLSEYE_ENABLED=true
 		COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
 		mkdir -p "$COV_DIR"
 		export COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
 		cov01 --on
 	fi
 
+	# Always run Gtest
 	build devel --enable-gtest
 	run_gtest "default"
-	cov01 --off
 
-	if ! covfn -f "${COVFILE}"; then
-		azure_log_error "Bullseye report validation failed!"
-	fi
+	if $BULLSEYE_ENABLED; then
+		cov01 --off
+        if ! covfn -f "${COVFILE}"; then
+            azure_log_error "Bullseye report validation failed!"
+        fi
+    fi
 }
 
 #

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1135,27 +1135,29 @@ run_gtest_armclang() {
 
 run_gtest_bullseye() {
 	case "$AGENT_OSARCHITECTURE" in
-		"ARM64") SRC_PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64/" ;;
-		*)       SRC_PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/" ;;
+		"ARM64") bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64" ;;
+		*)       bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64" ;;
 	esac
 
-	# Create a local Bullseye copy due to NFS instability
-	DEST_PATH="${WORKSPACE}/bullseye"
-	mkdir -p "$DEST_PATH"
-	cp -a "$SRC_PATH/." "$DEST_PATH/" || true
-
-	export PATH="$DEST_PATH/bin:$PATH"
+	export PATH="${bullseye}/bin:$PATH"
 
 	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
 		export COVFILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov"
+		export COVBUILDZONE="${BUILD_NUMBER:-$$}_${worker:-0}"
+		export LIBRARY_PATH=${bullseye}/lib:$LIBRARY_PATH
+		export LD_LIBRARY_PATH=${bullseye}/lib:$LD_LIBRARY_PATH
+		export CPATH=${bullseye}/include:$CPATH
+		export LD_RUN_PATH="${bullseye}/lib:$LD_RUN_PATH"
+		export C_INCLUDE_PATH=${bullseye}/include:$C_INCLUDE_PATH
 		cov01 --on
-		covselect --add '!**/test/**:*'	# Exclude /test directory
+		covselect --import "${WORKSPACE}/buildlib/BullseyeCoverageExclusions"
 	else
 		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	fi
 
 	# Always run Gtest
+	echo "=== Building with Bullseye instrumentation ==="
 	build devel --enable-gtest
 	run_gtest "default"
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1134,22 +1134,11 @@ run_gtest_armclang() {
 }
 
 run_gtest_bullseye() {
-	case "$AGENT_OSARCHITECTURE" in
-		"ARM64") bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64" ;;
-		*)       bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64" ;;
-	esac
-
-	export PATH="${bullseye}/bin:$PATH"
-
+	az_module_load tools/bullseyecov-9.14.2
 	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
 		export COVFILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov"
 		export COVBUILDZONE="${BUILD_NUMBER:-$$}_${worker:-0}"
-		export LIBRARY_PATH=${bullseye}/lib:$LIBRARY_PATH
-		export LD_LIBRARY_PATH=${bullseye}/lib:$LD_LIBRARY_PATH
-		export CPATH=${bullseye}/include:$CPATH
-		export LD_RUN_PATH="${bullseye}/lib:$LD_RUN_PATH"
-		export C_INCLUDE_PATH=${bullseye}/include:$C_INCLUDE_PATH
 		cov01 --on
 		covselect --import "${WORKSPACE}/buildlib/BullseyeCoverageExclusions"
 	else

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1142,21 +1142,21 @@ run_gtest_bullseye() {
 	esac
 
 	# Create a local Bullseye copy due to NFS instability
-	DEST_PATH="${WORKSPACE}/BS_LOCAL"
+	DEST_PATH="${WORKSPACE}/bullseye"
 	mkdir -p "$DEST_PATH"
 	rsync -az "$SRC_PATH/" "$DEST_PATH/" || true
 
 	export PATH="$DEST_PATH/bin:$PATH"
 
-	if ! command -v cov01 &> /dev/null; then
-		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
-	else
+	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
 		BULLSEYE_ENABLED=true
 		COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
 		mkdir -p "$COV_DIR"
 		export COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
 		cov01 --on
+	else
+		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	fi
 
 	# Always run Gtest

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1165,10 +1165,10 @@ run_gtest_bullseye() {
 
 	if $BULLSEYE_ENABLED; then
 		cov01 --off
-        if ! covfn -f "${COVFILE}"; then
-            azure_log_error "Bullseye report validation failed!"
-        fi
-    fi
+		if ! covfn -f "${COVFILE}"; then
+			azure_log_error "Bullseye report validation failed!"
+		fi
+	fi
 }
 
 #

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1329,6 +1329,8 @@ run_gtest_armclang() {
 }
 
 run_gtest_bullseye() {
+	local BULLSEYE_ENABLED=false
+
 	case "$AGENT_OSARCHITECTURE" in
 		"ARM64") SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-arm64" ;;
 		*)       SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86" ;;
@@ -1345,19 +1347,23 @@ run_gtest_bullseye() {
 		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	else
 		echo "=== Enable Bullseye instrumentation ==="
+		BULLSEYE_ENABLED=true
 		COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
 		mkdir -p "$COV_DIR"
 		export COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
 		cov01 --on
 	fi
 
+	# Always run Gtest
 	build devel --enable-gtest
 	run_gtest "default"
-	cov01 --off
 
-	if ! covfn -f "${COVFILE}"; then
-		azure_log_error "Bullseye report validation failed!"
-	fi
+	if $BULLSEYE_ENABLED; then
+		cov01 --off
+        if ! covfn -f "${COVFILE}"; then
+            azure_log_error "Bullseye report validation failed!"
+        fi
+    fi
 }
 
 #

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1337,21 +1337,21 @@ run_gtest_bullseye() {
 	esac
 
 	# Create a local Bullseye copy due to NFS instability
-	DEST_PATH="${WORKSPACE}/BS_LOCAL"
+	DEST_PATH="${WORKSPACE}/bullseye"
 	mkdir -p "$DEST_PATH"
 	rsync -az "$SRC_PATH/" "$DEST_PATH/" || true
 
 	export PATH="$DEST_PATH/bin:$PATH"
 
-	if ! command -v cov01 &> /dev/null; then
-		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
-	else
+	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
 		BULLSEYE_ENABLED=true
 		COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
 		mkdir -p "$COV_DIR"
 		export COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
 		cov01 --on
+	else
+		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	fi
 
 	# Always run Gtest

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1334,26 +1334,23 @@ run_gtest_bullseye() {
 		*)       SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86" ;;
 	esac
 
-	# Create a local copy of Bullseye binaries
+	# Create a local Bullseye copy due to NFS instability
 	DEST_PATH="${WORKSPACE}/BS_LOCAL"
 	mkdir -p "$DEST_PATH"
-	rsync -az "$SRC_PATH/" "$DEST_PATH/"
+	rsync -az "$SRC_PATH/" "$DEST_PATH/" || true
 
 	export PATH="$DEST_PATH/bin:$PATH"
 
 	if ! command -v cov01 &> /dev/null; then
 		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
-		return 0
+	else
+		echo "=== Enable Bullseye instrumentation ==="
+		COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
+		mkdir -p "$COV_DIR"
+		export COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
+		cov01 --on
 	fi
 
-	# Set Bullseye report file per job
-	COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
-	mkdir -p "$COV_DIR"
-	COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
-	export COVFILE
-
-	echo "=== Running gtests with Bullseye Coverage ==="
-	cov01 --on
 	build devel --enable-gtest
 	run_gtest "default"
 	cov01 --off

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1328,6 +1328,41 @@ run_gtest_armclang() {
 	fi
 }
 
+run_gtest_bullseye() {
+	case "$AGENT_OSARCHITECTURE" in
+		"ARM64") SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-arm64" ;;
+		*)       SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86" ;;
+	esac
+
+	# Create a local copy of Bullseye binaries
+	DEST_PATH="${WORKSPACE}/BS_LOCAL"
+	mkdir -p "$DEST_PATH"
+	rsync -az "$SRC_PATH/" "$DEST_PATH/"
+
+	export PATH="$DEST_PATH/bin:$PATH"
+
+	if ! command -v cov01 &> /dev/null; then
+		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
+		return 0
+	fi
+
+	# Set Bullseye report file per job
+	COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
+	mkdir -p "$COV_DIR"
+	COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
+	export COVFILE
+
+	echo "=== Running gtests with Bullseye Coverage ==="
+	cov01 --on
+	build devel --enable-gtest
+	run_gtest "default"
+	cov01 --off
+
+	if ! covfn -f "${COVFILE}"; then
+		azure_log_error "Bullseye report validation failed!"
+	fi
+}
+
 #
 # Run the test suite (gtest) in release configuration with small subset of tests
 #
@@ -1516,6 +1551,8 @@ then
         run_asan_check
     elif [[ "$VALGRIND_CHECK" == "yes" ]]; then
         run_valgrind_check
+    elif [[ "$RUN_BULLSEYE" == "yes" ]]; then
+        run_gtest_bullseye
     else
         run_tests
     fi

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1329,27 +1329,23 @@ run_gtest_armclang() {
 }
 
 run_gtest_bullseye() {
-	local BULLSEYE_ENABLED=false
-
 	case "$AGENT_OSARCHITECTURE" in
-		"ARM64") SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-arm64" ;;
-		*)       SRC_PATH="/auto/app/BullsEye/BullseyeCoverage-Latest-x86" ;;
+		"ARM64") SRC_PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64/" ;;
+		*)       SRC_PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/" ;;
 	esac
 
 	# Create a local Bullseye copy due to NFS instability
 	DEST_PATH="${WORKSPACE}/bullseye"
 	mkdir -p "$DEST_PATH"
-	rsync -az "$SRC_PATH/" "$DEST_PATH/" || true
+	cp -a "$SRC_PATH/." "$DEST_PATH/" || true
 
 	export PATH="$DEST_PATH/bin:$PATH"
 
 	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
-		BULLSEYE_ENABLED=true
-		COV_DIR=/hpc/scrap/azure/bullseye/${BUILD_BUILDID}-${BUILD_BUILDNUMBER}
-		mkdir -p "$COV_DIR"
-		export COVFILE=$COV_DIR/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov
+		export COVFILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov"
 		cov01 --on
+		covselect --add '!**/test/**:*'	# Exclude /test directory
 	else
 		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	fi
@@ -1358,11 +1354,12 @@ run_gtest_bullseye() {
 	build devel --enable-gtest
 	run_gtest "default"
 
-	if $BULLSEYE_ENABLED; then
+	if covsrc -f "${COVFILE}"; then
 		cov01 --off
-		if ! covfn -f "${COVFILE}"; then
-			azure_log_error "Bullseye report validation failed!"
-		fi
+		# Normalize workdir path to de-dup reports
+		sed -Ei 's|agent-[0-9]+|agent-00|g; s|/AZP_WORKSPACE/[0-9]+|/AZP_WORKSPACE/0|g' "${COVFILE}"
+	else
+		azure_log_error "Bullseye report validation failed!"
 	fi
 }
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1330,27 +1330,29 @@ run_gtest_armclang() {
 
 run_gtest_bullseye() {
 	case "$AGENT_OSARCHITECTURE" in
-		"ARM64") SRC_PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64/" ;;
-		*)       SRC_PATH="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64/" ;;
+		"ARM64") bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64" ;;
+		*)       bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64" ;;
 	esac
 
-	# Create a local Bullseye copy due to NFS instability
-	DEST_PATH="${WORKSPACE}/bullseye"
-	mkdir -p "$DEST_PATH"
-	cp -a "$SRC_PATH/." "$DEST_PATH/" || true
-
-	export PATH="$DEST_PATH/bin:$PATH"
+	export PATH="${bullseye}/bin:$PATH"
 
 	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
 		export COVFILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov"
+		export COVBUILDZONE="${BUILD_NUMBER:-$$}_${worker:-0}"
+		export LIBRARY_PATH=${bullseye}/lib:$LIBRARY_PATH
+		export LD_LIBRARY_PATH=${bullseye}/lib:$LD_LIBRARY_PATH
+		export CPATH=${bullseye}/include:$CPATH
+		export LD_RUN_PATH="${bullseye}/lib:$LD_RUN_PATH"
+		export C_INCLUDE_PATH=${bullseye}/include:$C_INCLUDE_PATH
 		cov01 --on
-		covselect --add '!**/test/**:*'	# Exclude /test directory
+		covselect --import "${WORKSPACE}/buildlib/BullseyeCoverageExclusions"
 	else
 		azure_log_warning "=== Skipping Bullseye: cov01 not found ==="
 	fi
 
 	# Always run Gtest
+	echo "=== Building with Bullseye instrumentation ==="
 	build devel --enable-gtest
 	run_gtest "default"
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1329,22 +1329,11 @@ run_gtest_armclang() {
 }
 
 run_gtest_bullseye() {
-	case "$AGENT_OSARCHITECTURE" in
-		"ARM64") bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/aarch64" ;;
-		*)       bullseye="/auto/sw_tools/Bullseye/linux/linux64/9.14.2/amd64" ;;
-	esac
-
-	export PATH="${bullseye}/bin:$PATH"
-
+	az_module_load tools/bullseyecov-9.14.2
 	if command -v cov01 &> /dev/null; then
 		echo "=== Enable Bullseye instrumentation ==="
 		export COVFILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/coverage_${SYSTEM_STAGENAME}_${SYSTEM_JOBID}.cov"
 		export COVBUILDZONE="${BUILD_NUMBER:-$$}_${worker:-0}"
-		export LIBRARY_PATH=${bullseye}/lib:$LIBRARY_PATH
-		export LD_LIBRARY_PATH=${bullseye}/lib:$LD_LIBRARY_PATH
-		export CPATH=${bullseye}/include:$CPATH
-		export LD_RUN_PATH="${bullseye}/lib:$LD_RUN_PATH"
-		export C_INCLUDE_PATH=${bullseye}/include:$C_INCLUDE_PATH
 		cov01 --on
 		covselect --import "${WORKSPACE}/buildlib/BullseyeCoverageExclusions"
 	else

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1360,10 +1360,10 @@ run_gtest_bullseye() {
 
 	if $BULLSEYE_ENABLED; then
 		cov01 --off
-        if ! covfn -f "${COVFILE}"; then
-            azure_log_error "Bullseye report validation failed!"
-        fi
-    fi
+		if ! covfn -f "${COVFILE}"; then
+			azure_log_error "Bullseye report validation failed!"
+		fi
+	fi
 }
 
 #


### PR DESCRIPTION
## What?
Integrate Bullseye instrumentation into gtest.

## Why?
Enable collection, aggregation, and reporting of code coverage data.
[JIRA: HPCINFRA-1921](https://jirasw.nvidia.com/browse/HPCINFRA-1921) (Internal link).

## How?
1. Introduce a `run_bullseye` test parameter for granular control per specific host groups.
3. When enabled, Bullseye instrumentation is applied to gtests build and run process, collecting test coverage data.
5. Coverage reports from individual jobs are merged into a single report file and stored as a pipeline artifact.

### Exclusions
While this PR enables Bullseye for gtests, the following exclusions apply:
- GPU tests are excluded due to GPU driver failures when running with Bullseye.
- BlueField nodes (ARM architecture) are excluded due to instrumentation issues causing linker errors.
- RoCe tests with the protocol disabled, as we cover the same tests with the protocol enabled already.
