### PR TITLE
BUILD/DEBIAN: Add build time depends on binutils-dev

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -3,6 +3,7 @@ Section: libs
 Priority: extra
 Maintainer: ucx-group@elist.ornl.gov
 Build-Depends: debhelper (>= 9.0),
+ binutils-dev,
  libibverbs-dev,
  librdmacm-dev,
  pkg-config,


### PR DESCRIPTION
The detailed backtrace with debug information requires binutils-dev package for debian likely OS.

## What?
Add build time depends on binutil-dev to support detailed backtrace.

## Why?
It's useful to get detailed backtrace at runtime. It should build with BFD development files to enable support it.

## How?
Add the depends into debian/control file.
