### PR TITLE
UCP/CORE: disable everything (aux as well) when ^ib is configured

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -277,7 +277,7 @@ typedef struct ucp_tl_resource_desc {
  */
 typedef struct ucp_tl_alias {
     const char                    *alias;   /* Alias name */
-    const char*                   tls[8];   /* Transports which are selected by the alias */
+    const char*                   tls[10];   /* Transports which are selected by the alias */
 } ucp_tl_alias_t;
 
 


### PR DESCRIPTION
## What?
Setting `UCX_TLS=^ib` now disables all ib transports, including auxiliary ones.
For other aliases, auxiliary disabling must be explicitly specified. 

## Why?
Based on https://github.com/openucx/ucx/pull/8778, when disabling ud based transports, they should still be available as auxiliary. Thus, `UCX_TLS=^ud` does not disable their auxiliary usage.

However, we still want `UCX_TLS=^ib` to be treated as a global exclusion of all ib transports, including auxiliary ones.
To support this, a new distinction now differentiates global aliases (e.g. ib) from specific aliases (e.g. ud, rc, etc.).
