### PR TITLE
UCT/DC: Fix segfault in uct_dc_mlx5_ep_fence

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.h
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.h
@@ -412,7 +412,8 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface,
 
 ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
                                           uct_dci_index_t dci_index,
-                                          uint8_t num_dci_channels);
+                                          uint8_t num_dci_channels,
+                                          uct_dc_dci_t **dci_p);
 
 ucs_status_t uct_dc_mlx5_iface_resize_and_fill_dcis(uct_dc_mlx5_iface_t *iface,
                                                     uint16_t size);
@@ -429,7 +430,7 @@ uct_dc_mlx5_dci_pool_get_or_create(uct_dc_mlx5_iface_t *iface,
 uint32_t
 uct_dc_mlx5_dci_config_hash(const uct_dc_mlx5_dci_config_t *dci_config);
 
-void uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uint16_t dci_index);
+void uct_dc_mlx5_destroy_dci(uct_dc_mlx5_iface_t *iface, uct_dc_dci_t *dci);
 
 static UCS_F_ALWAYS_INLINE uint8_t uct_dc_mlx5_is_dci_valid(const uct_dc_dci_t *dci)
 {
@@ -439,6 +440,9 @@ static UCS_F_ALWAYS_INLINE uint8_t uct_dc_mlx5_is_dci_valid(const uct_dc_dci_t *
 static UCS_F_ALWAYS_INLINE uct_dc_dci_t *
 uct_dc_mlx5_iface_dci(uct_dc_mlx5_iface_t *iface, uct_dci_index_t dci_index)
 {
+    ucs_assertv(dci_index < ucs_array_length(&iface->tx.dcis),
+                "dci_index=%d dcis_length=%d", dci_index,
+                ucs_array_length(&iface->tx.dcis));
     return ucs_array_elem(&iface->tx.dcis, dci_index);
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -520,7 +520,7 @@ ucs_status_t uct_rc_mlx5_base_ep_fence(uct_ep_h tl_ep, unsigned flags)
 {
     uct_rc_mlx5_base_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_base_ep_t);
 
-    return uct_rc_ep_fence(tl_ep, &ep->tx.wq.fi, 1);
+    return uct_rc_ep_fence(tl_ep, &ep->tx.wq.fi);
 }
 
 void uct_rc_mlx5_base_ep_post_check(uct_ep_h tl_ep)

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -519,14 +519,14 @@ uct_rc_ep_fm(uct_rc_iface_t *iface, uct_ib_fence_info_t* fi, int flag)
     return fence;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_rc_ep_fence(uct_ep_h tl_ep, uct_ib_fence_info_t* fi, int fence)
+static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_ep_fence(uct_ep_h tl_ep,
+                                                        uct_ib_fence_info_t *fi)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
 
     /* in case if fence is requested and enabled by configuration
      * we need to schedule fence for next RDMA operation */
-    if (fence && (iface->config.fence_mode != UCT_RC_FENCE_MODE_NONE)) {
+    if (iface->config.fence_mode != UCT_RC_FENCE_MODE_NONE) {
         fi->fence_beat = iface->tx.fi.fence_beat - 1;
     }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -516,7 +516,7 @@ ucs_status_t uct_rc_verbs_ep_fence(uct_ep_h tl_ep, unsigned flags)
 {
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
 
-    return uct_rc_ep_fence(tl_ep, &ep->fi, 1);
+    return uct_rc_ep_fence(tl_ep, &ep->fi);
 }
 
 void uct_rc_verbs_ep_post_check(uct_ep_h tl_ep)

--- a/test/gtest/uct/ib/test_dc.cc
+++ b/test/gtest/uct/ib/test_dc.cc
@@ -186,6 +186,8 @@ UCS_TEST_P(test_dc, dcs_single) {
                            0;
 
     EXPECT_EQ(UCT_DC_MLX5_EP_NO_DCI, ep->dci);
+    status = uct_ep_fence(m_e1->ep(0), 0);
+    EXPECT_UCS_OK(status);
     status = uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0);
     EXPECT_UCS_OK(status);
     /* dci 0 must be assigned to the ep */


### PR DESCRIPTION
## Why
Fix invalid access to dci at index NO_DCI during fence

## How
- Check ep->dci!= NO_DCI before accessing the array
- Add assertion that we don't access DCI at invalid index
- Small changes in DCI create flow to not fail on the new assertion