### PR TITLE
UCT/CUDA-IPC: Support multi context for rkey unpack

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -155,34 +155,50 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
 }
 
 static ucs_status_t
-uct_cuda_ipc_open_memhandle_legacy(CUipcMemHandle memh,
+uct_cuda_ipc_open_memhandle_legacy(CUipcMemHandle memh, CUdevice cu_dev,
                                    CUdeviceptr *mapped_addr)
 {
     CUresult cuerr;
+    CUcontext cuda_ctx;
+    ucs_status_t status;
+
+    status = uct_cuda_primary_ctx_retain(cu_dev, 1, &cuda_ctx);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(cuda_ctx));
+    if (status != UCS_OK) {
+        goto ctx_release;
+    }
 
     cuerr = cuIpcOpenMemHandle(mapped_addr, memh,
                                CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
     if (cuerr != CUDA_SUCCESS) {
         ucs_debug("cuIpcOpenMemHandle() failed: %s",
                   uct_cuda_base_cu_get_error_string(cuerr));
-        return (cuerr == CUDA_ERROR_ALREADY_MAPPED) ?
+        status = (cuerr == CUDA_ERROR_ALREADY_MAPPED) ?
             UCS_ERR_ALREADY_EXISTS : UCS_ERR_INVALID_PARAM;
     }
 
-    return UCS_OK;
+    UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
+
+ctx_release:
+    UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cu_dev));
+    return status;
 }
 
 #if HAVE_CUDA_FABRIC
-static ucs_status_t uct_cuda_ipc_init_access_desc(CUmemAccessDesc *access_desc)
+static void
+uct_cuda_ipc_init_access_desc(CUmemAccessDesc *access_desc, CUdevice cu_dev)
 {
     access_desc->location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     access_desc->flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-
-    return UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&access_desc->location.id));
+    access_desc->location.id   = cu_dev;
 }
 
 static ucs_status_t
-uct_cuda_ipc_open_memhandle_vmm(uct_cuda_ipc_rkey_t *key,
+uct_cuda_ipc_open_memhandle_vmm(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
                                 CUdeviceptr *mapped_addr)
 {
     CUmemAccessDesc access_desc = {};
@@ -208,10 +224,7 @@ uct_cuda_ipc_open_memhandle_vmm(uct_cuda_ipc_rkey_t *key,
         goto release_va_range;
     }
 
-    status = uct_cuda_ipc_init_access_desc(&access_desc);
-    if (status != UCS_OK) {
-        goto unmap_range;
-    }
+    uct_cuda_ipc_init_access_desc(&access_desc, cu_dev);
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemSetAccess(dptr, key->b_len, &access_desc, 1));
     if (status != UCS_OK) {
@@ -236,6 +249,7 @@ out:
 }
 
 static ucs_status_t cuda_ipc_rem_mpool_cache_create(uct_cuda_ipc_rkey_t *key,
+                                                    CUdevice cu_dev,
                                                     CUmemoryPool *mpool,
                                                     CUdeviceptr *mapped_addr)
 {
@@ -256,10 +270,7 @@ static ucs_status_t cuda_ipc_rem_mpool_cache_create(uct_cuda_ipc_rkey_t *key,
         goto err_free_mpool;
     }
 
-    status = uct_cuda_ipc_init_access_desc(&access_desc);
-    if (status != UCS_OK) {
-        goto err_free_ptr;
-    }
+    uct_cuda_ipc_init_access_desc(&access_desc, cu_dev);
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(
                 cuMemPoolSetAccess(*mpool, &access_desc, 1));
@@ -280,7 +291,7 @@ err:
 
 static ucs_status_t
 uct_cuda_ipc_open_memhandle_mempool(uct_cuda_ipc_rkey_t *key,
-                                    CUdeviceptr *mapped_addr)
+                                    CUdevice cu_dev, CUdeviceptr *mapped_addr)
 {
     khash_t(cuda_ipc_rem_mpool_cache) *hash = &uct_cuda_ipc_rem_mpool_cache.hash;
     const CUmemFabricHandle *hkey           = &key->ph.handle.fabric_handle;
@@ -304,7 +315,8 @@ uct_cuda_ipc_open_memhandle_mempool(uct_cuda_ipc_rkey_t *key,
     khiter = kh_put(cuda_ipc_rem_mpool_cache, hash, *hkey, &khret);
     if ((khret == UCS_KH_PUT_BUCKET_EMPTY) ||
         (khret == UCS_KH_PUT_BUCKET_CLEAR)) {
-        status = cuda_ipc_rem_mpool_cache_create(key, &mpool, mapped_addr);
+        status = cuda_ipc_rem_mpool_cache_create(key, cu_dev, &mpool,
+                                                 mapped_addr);
         if (status != UCS_OK) {
             /* Remove stale key from the hash if failed to construct new value.
              * Otherwise next lookup will return NULL value. */
@@ -333,25 +345,33 @@ err:
 #endif
 
 static ucs_status_t uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key,
+                                                CUdevice cu_dev,
                                                 CUdeviceptr *mapped_addr)
 {
+    ucs_log_level_t log_level;
 
     ucs_trace("key handle type %u", key->ph.handle_type);
 
     switch(key->ph.handle_type) {
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY:
-        return uct_cuda_ipc_open_memhandle_legacy(key->ph.handle.legacy,
+        return uct_cuda_ipc_open_memhandle_legacy(key->ph.handle.legacy, cu_dev,
                                                   mapped_addr);
 #if HAVE_CUDA_FABRIC
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM:
-        return uct_cuda_ipc_open_memhandle_vmm(key, mapped_addr);
+        return uct_cuda_ipc_open_memhandle_vmm(key, cu_dev, mapped_addr);
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL:
-        return uct_cuda_ipc_open_memhandle_mempool(key, mapped_addr);
+        return uct_cuda_ipc_open_memhandle_mempool(key, cu_dev, mapped_addr);
 #endif
+    case UCT_CUDA_IPC_KEY_HANDLE_TYPE_ERROR:
+        log_level = UCS_LOG_LEVEL_DEBUG;
+        break;
     default:
-        ucs_error("unsupported key handle type");
-        return UCS_ERR_INVALID_PARAM;
+        log_level = UCS_LOG_LEVEL_ERROR;
+        break;
     }
+
+    ucs_log(log_level, "unsupported key handle type: %u", key->ph.handle_type);
+    return UCS_ERR_INVALID_PARAM;
 }
 
 static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
@@ -393,7 +413,8 @@ static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
 }
 
 static ucs_status_t
-uct_cuda_ipc_get_remote_cache(pid_t pid, uct_cuda_ipc_cache_t **cache)
+uct_cuda_ipc_get_remote_cache(pid_t pid, CUdevice cu_dev,
+                              uct_cuda_ipc_cache_t **cache)
 {
     ucs_status_t status = UCS_OK;
     char target_name[64];
@@ -401,11 +422,10 @@ uct_cuda_ipc_get_remote_cache(pid_t pid, uct_cuda_ipc_cache_t **cache)
     khiter_t khiter;
     int khret;
 
-    UCT_CUDA_IPC_GET_DEVICE(key.cu_device);
-
     ucs_recursive_spin_lock(&uct_cuda_ipc_remote_cache.lock);
 
-    key.pid = pid;
+    key.cu_device = cu_dev;
+    key.pid       = pid;
 
     khiter = kh_put(cuda_ipc_rem_cache, &uct_cuda_ipc_remote_cache.hash, key,
                     &khret);
@@ -434,14 +454,15 @@ err_unlock:
 }
 
 ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, uintptr_t d_bptr,
-                                          void *mapped_addr, int cache_enabled)
+                                          void *mapped_addr, CUdevice cu_dev,
+                                          int cache_enabled)
 {
     ucs_status_t status = UCS_OK;
     uct_cuda_ipc_cache_t *cache;
     ucs_pgt_region_t *pgt_region;
     uct_cuda_ipc_cache_region_t *region;
 
-    status = uct_cuda_ipc_get_remote_cache(pid, &cache);
+    status = uct_cuda_ipc_get_remote_cache(pid, cu_dev, &cache);
     if (status != UCS_OK) {
         return status;
     }
@@ -473,8 +494,9 @@ ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, uintptr_t d_bptr,
     return status;
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle, (key, mapped_addr),
-                 uct_cuda_ipc_rkey_t *key, void **mapped_addr)
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
+                 (key, cu_dev, mapped_addr),
+                 uct_cuda_ipc_rkey_t *key, CUdevice cu_dev, void **mapped_addr)
 {
     uct_cuda_ipc_cache_t *cache;
     ucs_status_t status;
@@ -482,7 +504,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle, (key, mapped_addr),
     uct_cuda_ipc_cache_region_t *region;
     int ret;
 
-    status = uct_cuda_ipc_get_remote_cache(key->pid, &cache);
+    status = uct_cuda_ipc_get_remote_cache(key->pid, cu_dev, &cache);
     if (status != UCS_OK) {
         return status;
     }
@@ -523,21 +545,21 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle, (key, mapped_addr),
         }
     }
 
-    status = uct_cuda_ipc_open_memhandle(key, (CUdeviceptr*)mapped_addr);
+    status = uct_cuda_ipc_open_memhandle(key, cu_dev, (CUdeviceptr*)mapped_addr);
     if (ucs_unlikely(status != UCS_OK)) {
         if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
             /* unmap all overlapping regions and retry*/
             uct_cuda_ipc_cache_invalidate_regions(cache, (void *)key->d_bptr,
                                                   UCS_PTR_BYTE_OFFSET(key->d_bptr,
                                                                       key->b_len));
-            status = uct_cuda_ipc_open_memhandle(key,
+            status = uct_cuda_ipc_open_memhandle(key, cu_dev,
                                                  (CUdeviceptr*)mapped_addr);
             if (ucs_unlikely(status != UCS_OK)) {
                 if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
                     /* unmap all cache entries and retry */
                     uct_cuda_ipc_cache_purge(cache);
                     status =
-                        uct_cuda_ipc_open_memhandle(key,
+                        uct_cuda_ipc_open_memhandle(key, cu_dev,
                                                     (CUdeviceptr*)mapped_addr);
                     if (status != UCS_OK) {
                         ucs_fatal("%s: failed to open ipc mem handle. addr:%p "

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -44,7 +44,12 @@ void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache);
 
 
 ucs_status_t
-uct_cuda_ipc_map_memhandle(uct_cuda_ipc_rkey_t *key, void **mapped_addr);
+uct_cuda_ipc_map_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
+                           void **mapped_addr);
+
+
 ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, uintptr_t d_bptr,
-                                          void *mapped_addr, int cache_enabled);
+                                          void *mapped_addr, CUdevice cu_dev,
+                                          int cache_enabled);
+
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -326,6 +326,7 @@ static void uct_cuda_ipc_complete_event(uct_iface_h tl_iface,
     status = uct_cuda_ipc_unmap_memhandle(cuda_ipc_event->pid,
                                           cuda_ipc_event->d_bptr,
                                           cuda_ipc_event->mapped_addr,
+                                          cuda_ipc_event->cuda_device,
                                           iface->config.enable_cache);
     if (status != UCS_OK) {
         ucs_fatal("failed to unmap addr:%p", cuda_ipc_event->mapped_addr);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -49,6 +49,7 @@ typedef struct {
     uct_cuda_ipc_ep_t     *ep;
     uintptr_t             d_bptr;
     pid_t                 pid;
+    CUdevice              cuda_device;
 } uct_cuda_ipc_event_desc_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -107,17 +107,15 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 
 static ucs_status_t
 uct_cuda_ipc_mem_reg_push_ctx(CUdeviceptr address, CUdevice *cuda_device_p,
-                              int *is_ctx_pushed)
+                              int *is_ctx_pushed, int *is_ctx_retained)
 {
 #define UCT_CUDA_IPC_NUM_ATTRS 2
-    CUdevice cuda_device = CU_DEVICE_INVALID;
+    CUcontext cuda_curr_ctx, cuda_ctx;
+    CUdevice cuda_device;
     CUpointer_attribute attr_type[UCT_CUDA_IPC_NUM_ATTRS];
     void *attr_data[UCT_CUDA_IPC_NUM_ATTRS];
-    CUcontext cuda_ctx, cuda_curr_ctx;
     int cuda_device_ordinal;
     ucs_status_t status;
-
-    *is_ctx_pushed = 0;
 
     attr_type[0] = CU_POINTER_ATTRIBUTE_CONTEXT;
     attr_data[0] = &cuda_ctx;
@@ -128,47 +126,55 @@ uct_cuda_ipc_mem_reg_push_ctx(CUdeviceptr address, CUdevice *cuda_device_p,
             cuPointerGetAttributes(UCT_CUDA_IPC_NUM_ATTRS, attr_type, attr_data,
                                    address));
     if (status != UCS_OK) {
-        goto out;
+        return status;
     }
 
+    ucs_assertv(cuda_device_ordinal >= 0, "cuda_device_ordinal=%d",
+                cuda_device_ordinal);
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_device,
+                                                  cuda_device_ordinal));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *is_ctx_pushed = 0;
+    *cuda_device_p = cuda_device;
+
     if (cuda_ctx == NULL) {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_device,
-                                                      cuda_device_ordinal));
+        status = uct_cuda_primary_ctx_retain(*cuda_device_p, 0, &cuda_ctx);
         if (status != UCS_OK) {
-            goto out;
+           return status;
         }
 
-        status = uct_cuda_primary_ctx_retain(cuda_device, 0, &cuda_ctx);
-        if (status != UCS_OK) {
-            goto out;
-        }
+        *is_ctx_retained = 1;
     } else {
+        *is_ctx_retained = 0;
         status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_curr_ctx));
         if ((status != UCS_OK) || (cuda_curr_ctx == cuda_ctx)) {
             /* Failed to get current context or the pointer's context is
              * already current, no need to push/pop */
-            goto out;
+           return status;
         }
     }
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(cuda_ctx));
     if (status != UCS_OK) {
-        if (cuda_device != CU_DEVICE_INVALID) {
-            UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
+        if (*is_ctx_retained) {
+            UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(*cuda_device_p));
         }
-        goto out;
+        return status;
     }
 
     *is_ctx_pushed = 1;
-out:
-    *cuda_device_p = cuda_device;
-    return status;
+    return UCS_OK;
 }
 
-static void uct_cuda_ipc_mem_reg_pop_ctx(CUdevice cuda_device)
+static void uct_cuda_ipc_mem_reg_pop_ctx(CUdevice cuda_device,
+                                         int is_ctx_retained)
 {
     UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
-    if (cuda_device != CU_DEVICE_INVALID) {
+    if (is_ctx_retained) {
         UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
     }
 }
@@ -178,9 +184,9 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
                          uct_cuda_ipc_lkey_t **key_p)
 {
     uct_cuda_ipc_lkey_t *key;
-    CUdevice cuda_device;
     ucs_status_t status;
-    int is_ctx_pushed;
+    int is_ctx_pushed, is_ctx_retained;
+    CUdevice cuda_device;
 #if HAVE_CUDA_FABRIC
 #define UCT_CUDA_IPC_QUERY_NUM_ATTRS 3
     CUmemGenericAllocationHandle handle;
@@ -197,7 +203,7 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
     }
 
     status = uct_cuda_ipc_mem_reg_push_ctx((CUdeviceptr)addr, &cuda_device,
-                                           &is_ctx_pushed);
+                                           &is_ctx_pushed, &is_ctx_retained);
     if (status != UCS_OK) {
         goto out;
     }
@@ -309,12 +315,13 @@ common_path:
               addr, (void *)key->d_bptr, key->b_len, (int)memh->dev_num,
               key->ph.buffer_id);
 
-    *key_p = key;
-    status = UCS_OK;
+    memh->dev_num = cuda_device;
+    *key_p        = key;
+    status        = UCS_OK;
 
 out_pop_ctx:
     if (is_ctx_pushed) {
-        uct_cuda_ipc_mem_reg_pop_ctx(cuda_device);
+        uct_cuda_ipc_mem_reg_pop_ctx(memh->dev_num, is_ctx_retained);
     }
 out:
     if (status != UCS_OK) {
@@ -363,31 +370,46 @@ found:
 
 static ucs_status_t
 uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
-                                uct_cuda_ipc_rkey_t *rkey)
+                                uct_cuda_ipc_unpacked_rkey_t *rkey,
+                                ucs_sys_device_t sys_dev)
 {
-    CUdevice this_device;
+    CUdevice cu_dev;
     ucs_status_t status;
     void *d_mapped;
     uct_cuda_ipc_dev_cache_t *cache;
     uint8_t *accessible;
 
-    if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&this_device)) != UCS_OK) {
-        return UCS_ERR_UNREACHABLE;
+    if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
+        /* Use device of the current context */
+        if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&cu_dev)) != UCS_OK) {
+            return UCS_ERR_UNREACHABLE;
+        }
+    } else {
+        status = uct_cuda_base_get_cuda_device(sys_dev, &cu_dev);
+        if (status != UCS_OK) {
+            ucs_warn("failed to map sys device [%d] to cuda device: %s",
+                     sys_dev, ucs_status_string(status));
+            return UCS_ERR_UNREACHABLE;
+        }
     }
+
+    /* Save local device number, so we use it to find remote rcache when mapping
+     * mem_handle in uct_cuda_ipc_post_cuda_async_copy */
+    rkey->super.dev_num = cu_dev;
 
     pthread_mutex_lock(&component->lock);
 
-    cache = uct_cuda_ipc_get_dev_cache(component, rkey);
+    cache = uct_cuda_ipc_get_dev_cache(component, &rkey->super);
     if (ucs_unlikely(NULL == cache)) {
         status = UCS_ERR_NO_RESOURCE;
         goto err;
     }
 
-    /* overwrite dev_num with a unique ID; this means that relative remote
+    /* use unique id for stream id; this means that relative remote
      * device number of multiple peers do not map on the same stream and reduces
      * stream sequentialization */
-    rkey->dev_num = cache->dev_num;
-    accessible    = &cache->accessible[this_device];
+    rkey->stream_id = cache->dev_num;
+    accessible      = &cache->accessible[cu_dev];
     if (ucs_unlikely(*accessible == UCS_TRY)) { /* unchecked, add to cache */
 
         /* Check if peer is reachable by trying to open memory handle. This is
@@ -406,7 +428,7 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
          * Now, we immediately insert into cache to save on calling
          * OpenMemHandle for the same handle because the cache is globally
          * accessible using rkey->pid. */
-        status = uct_cuda_ipc_map_memhandle(rkey, &d_mapped);
+        status = uct_cuda_ipc_map_memhandle(&rkey->super, cu_dev, &d_mapped);
 
         *accessible = ((status == UCS_OK) || (status == UCS_ERR_ALREADY_EXISTS))
                       ? UCS_YES : UCS_NO;
@@ -428,25 +450,35 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
     uct_cuda_ipc_component_t *com = ucs_derived_of(component,
                                                    uct_cuda_ipc_component_t);
     uct_cuda_ipc_rkey_t *packed   = (uct_cuda_ipc_rkey_t *)rkey_buffer;
-    uct_cuda_ipc_rkey_t *key;
+    uct_cuda_ipc_unpacked_rkey_t *unpacked;
+    ucs_sys_device_t sys_dev;
     ucs_status_t status;
 
-    status = uct_cuda_ipc_is_peer_accessible(com, packed);
+    sys_dev = UCS_PARAM_VALUE(UCT_RKEY_UNPACK_FIELD, params, sys_device,
+                              SYS_DEVICE, UCS_SYS_DEVICE_ID_UNKNOWN);
+
+    unpacked = ucs_malloc(sizeof(*unpacked), "uct_cuda_ipc_unpacked_rkey_t");
+    if (NULL == unpacked) {
+        ucs_error("failed to allocate memory for uct_cuda_ipc_unpacked_rkey_t");
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
+
+    unpacked->super = *packed;
+
+    status = uct_cuda_ipc_is_peer_accessible(com, unpacked, sys_dev);
     if (status != UCS_OK) {
-        return status;
+        goto err_free_key;
     }
 
-    key = ucs_malloc(sizeof(*key), "uct_cuda_ipc_rkey_t");
-    if (NULL == key) {
-        ucs_error("failed to allocate memory for uct_cuda_ipc_rkey_t");
-        return UCS_ERR_NO_MEMORY;
-    }
-
-    *key      = *packed;
     *handle_p = NULL;
-    *rkey_p   = (uintptr_t) key;
-
+    *rkey_p   = (uintptr_t) unpacked;
     return UCS_OK;
+
+err_free_key:
+    ucs_free(unpacked);
+err:
+    return status;
 }
 
 static ucs_status_t uct_cuda_ipc_rkey_release(uct_component_t *component,
@@ -462,9 +494,6 @@ uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
                      const uct_md_mem_reg_params_t *params, uct_mem_h *memh_p)
 {
     uct_cuda_ipc_memh_t *memh;
-    CUdevice cu_device;
-
-    UCT_CUDA_IPC_GET_DEVICE(cu_device);
 
     memh = ucs_malloc(sizeof(*memh), "uct_cuda_ipc_memh_t");
     if (NULL == memh) {
@@ -472,7 +501,8 @@ uct_cuda_ipc_mem_reg(uct_md_h md, void *address, size_t length,
         return UCS_ERR_NO_MEMORY;
     }
 
-    memh->dev_num = (int) cu_device;
+    /* dev_num is initialized during pack in uct_cuda_ipc_mem_add_reg */
+    memh->dev_num = CU_DEVICE_INVALID;
     memh->pid     = getpid();
     ucs_list_head_init(&memh->list);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -140,6 +140,12 @@ typedef struct {
 } uct_cuda_ipc_rkey_t;
 
 
+typedef struct {
+    uct_cuda_ipc_rkey_t       super;
+    int                       stream_id;
+} uct_cuda_ipc_unpacked_rkey_t;
+
+
 #define UCT_CUDA_IPC_GET_DEVICE(_cu_device)                          \
     do {                                                             \
         if (UCS_OK !=                                                \

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -12,6 +12,7 @@
 
 extern "C" {
 #include <uct/cuda/cuda_ipc/cuda_ipc_md.h>
+#include <uct/cuda/base/cuda_iface.h>
 }
 
 class test_cuda_ipc_md : public test_md {
@@ -110,10 +111,35 @@ protected:
        std::exception_ptr thread_exception;
        std::thread([&]() {
            try {
-               uct_md_mkey_pack_params_t params = {};
+               uct_md_mkey_pack_params_t pack_params = {};
                std::vector<uint8_t> rkey(md_attr().rkey_packed_size);
-               ASSERT_UCS_OK(uct_md_mkey_pack_v2(md(), memh, ptr, size, &params,
-                                                 rkey.data()));
+               ASSERT_UCS_OK(uct_md_mkey_pack_v2(md(), memh, ptr, size,
+                                                 &pack_params, rkey.data()));
+
+               // No context and sys_dev is not provided
+               uct_rkey_unpack_params_t unpack_params = {};
+               ucs_status_t status = uct_rkey_unpack_v2(
+                                         md()->component, rkey.data(),
+                                         &unpack_params, NULL);
+               ASSERT_EQ(status, UCS_ERR_UNREACHABLE);
+
+               // No context and unknown sys_dev is provided
+               unpack_params.field_mask = UCT_RKEY_UNPACK_FIELD_SYS_DEVICE;
+               unpack_params.sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
+               status = uct_rkey_unpack_v2(md()->component, rkey.data(),
+                                           &unpack_params, NULL);
+               ASSERT_EQ(status, UCS_ERR_UNREACHABLE);
+
+               // No context and some valid sys_dev is provided, but
+               // cuIpcOpenMemHandle used by cuda_ipc_cache does not allow to
+               // open a handle that was created by the same process
+               ucs_sys_device_t sys_dev;
+               uct_cuda_base_get_sys_dev(0, &sys_dev);
+
+               unpack_params.sys_device = sys_dev;
+               status = uct_rkey_unpack_v2(md()->component, rkey.data(),
+                                           &unpack_params, NULL);
+               ASSERT_EQ(status, UCS_ERR_UNREACHABLE);
            } catch (...) {
                thread_exception = std::current_exception();
            }
@@ -159,32 +185,6 @@ UCS_TEST_P(test_cuda_ipc_md, missing_device_context)
 
     EXPECT_EQ(UCS_ERR_UNREACHABLE, status);
     EXPECT_NE(dev_num, rkey.dev_num); // rkey was not updated
-}
-
-UCS_MT_TEST_P(test_cuda_ipc_md, multiple_mds, 8)
-{
-    cuda_context cuda_ctx;
-    ucs::handle<uct_md_h> md;
-    UCS_TEST_CREATE_HANDLE(uct_md_h, md, uct_md_close, uct_md_open,
-                           GetParam().component, GetParam().md_name.c_str(),
-                           m_md_config);
-
-    {
-        /* Create and destroy temporary MD */
-        ucs::handle<uct_md_h> tmp_md;
-        UCS_TEST_CREATE_HANDLE(uct_md_h, tmp_md, uct_md_close, uct_md_open,
-                               GetParam().component, GetParam().md_name.c_str(),
-                               m_md_config);
-    }
-
-    for (int64_t i = 0; i < 64; ++i) {
-        /* We get unique dev_num on new UUID */
-        uct_cuda_ipc_rkey_t rkey = unpack(md, i + 1);
-        EXPECT_EQ(i, rkey.dev_num);
-        /* Subsequent call with the same UUID returns value from cache */
-        rkey = unpack(md, i + 1);
-        EXPECT_EQ(i, rkey.dev_num);
-    }
 }
 
 UCS_TEST_P(test_cuda_ipc_md, mkey_pack_legacy)

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -1197,7 +1197,7 @@ UCS_TEST_P(test_cuda, sparse_regions)
     }
 
     /* make CUDA registrations list sparse */
-    for (int i = 0; i < count; i++) {
+    for (int i = 1; i < count; i++) {
         if ((i & 1) == 0) {
             free_memory(ptr[i], UCS_MEMORY_TYPE_CUDA);
         }


### PR DESCRIPTION
## What?
Pass sys device to the rkey_unpack function, assuming it is safe to always retain primary context of that device. If sys device is not passed to the rkey_unpack function, we either use the current context or fail. It would be incorrect to use any active primary context at this stage because we don’t yet know where the target memory will reside.
