### PR TITLE
UCP/WIREUP: Fix All2All Wireup on Multi NIC-GPU

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -565,6 +565,12 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, wireup_via_am_lane),
    UCS_CONFIG_TYPE_BOOL},
 
+  {"CONNECT_ALL_TO_ALL", "n",
+   "Establish connections between all pairs of local and remote devices that\n"
+   "are reachable through the transport layer.",
+   ucs_offsetof(ucp_context_config_t, connect_all_to_all),
+   UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -205,10 +205,13 @@ typedef struct ucp_context_config {
     double                                 rcache_overhead;
     /** UCP extra operation attributes flags */
     uint64_t                               extra_op_attr_flags;
-    /* Upper limit to the amount of prioritized endpoints */
+    /** Upper limit to the amount of prioritized endpoints */
     unsigned                               max_priority_eps;
     /* Use AM lane to send wireup messages */
     int                                    wireup_via_am_lane;
+    /** Extend endpoint lanes connections of each local device to all remote
+     *  devices */
+    int                                    connect_all_to_all;
 } ucp_context_config_t;
 
 

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -21,12 +21,14 @@ class test_ucp_perf : public ucp_test, public test_perf {
 public:
     enum {
         VARIANT_TEST_TYPE,
-        VARIANT_ATOMIC_MODE
+        VARIANT_ATOMIC_MODE,
+        VARIANT_WIREUP_MODE = VARIANT_ATOMIC_MODE,
     };
 
     enum {
         ATOMIC_CPU = 1,
-        ATOMIC_DEVICE
+        ATOMIC_DEVICE,
+        WIREUP_ALL_TO_ALL
     };
 
     static void get_test_variants(std::vector<ucp_test_variant>& variants) {
@@ -48,6 +50,10 @@ public:
                 add_variant_value(variant->values, ATOMIC_DEVICE, "device");
             } else {
                 add_variant_with_value(variants, 0, i, test->title);
+
+                variant = &add_variant(variants, 0);
+                add_variant_value(variant->values, i, test->title);
+                add_variant_value(variant->values, WIREUP_ALL_TO_ALL, "all_to_all");
             }
         }
     }
@@ -342,7 +348,8 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv tls("UCX_TLS", ss.str().c_str());
     ucs::scoped_setenv warn_invalid("UCX_WARN_INVALID_CONFIG", "no");
-    const char* atomic_mode_str = "guess";
+    const char* atomic_mode_str     = "guess";
+    const char* connect_all_to_all  = "n";
 
     if (get_variant_value(VARIANT_ATOMIC_MODE) == ATOMIC_CPU) {
         atomic_mode_str = "cpu";
@@ -352,6 +359,13 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
 
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv atomic_mode("UCX_ATOMIC_MODE", atomic_mode_str);
+
+    if (get_variant_value(VARIANT_WIREUP_MODE) == WIREUP_ALL_TO_ALL) {
+        connect_all_to_all = "y";
+    }
+
+    ucs::scoped_setenv wireup_ep_allow_all_to_all_env(
+            "UCX_CONNECT_ALL_TO_ALL", connect_all_to_all);
 
     test.iters         = ucs_min(test.iters, max_iter);
     test.send_mem_type = UCS_MEMORY_TYPE_HOST;

--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -21,10 +21,11 @@ extern "C" {
 class test_ucp_tag_mem_type: public test_ucp_tag {
 public:
     enum {
-        VARIANT_GDR_OFF     = UCS_BIT(0),
-        VARIANT_TAG_OFFLOAD = UCS_BIT(1),
-        VARIANT_PROTO_V1    = UCS_BIT(2),
-        VARIANT_MAX         = UCS_BIT(3)
+        VARIANT_GDR_OFF            = UCS_BIT(0),
+        VARIANT_TAG_OFFLOAD        = UCS_BIT(1),
+        VARIANT_PROTO_V1           = UCS_BIT(2),
+        VARIANT_CONNECT_ALL_TO_ALL = UCS_BIT(3),
+        VARIANT_MAX                = UCS_BIT(4)
     };
 
     void init()
@@ -71,6 +72,10 @@ public:
         m_send_mem_type         = m_mem_type_pairs[mem_type_pair_index][0];
         m_recv_mem_type         = m_mem_type_pairs[mem_type_pair_index][1];
 
+        if (variant_flags & VARIANT_CONNECT_ALL_TO_ALL) {
+            modify_config("CONNECT_ALL_TO_ALL", "y");
+        }
+
         modify_config("MAX_EAGER_LANES", "2");
         modify_config("MAX_RNDV_LANES", "2");
 
@@ -107,6 +112,10 @@ public:
 
         if (variant_flags & VARIANT_PROTO_V1) {
             name += ",proto_v1";
+        }
+
+        if (variant_flags & VARIANT_CONNECT_ALL_TO_ALL) {
+            name += ",connect_all_to_all";
         }
 
         add_variant_with_value(variants, get_ctx_params(), variant_value, name);

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -31,7 +31,8 @@ public:
         VARIANT_RNDV_AM_BCOPY,
         VARIANT_RNDV_AM_ZCOPY,
         VARIANT_SEND_NBR,
-        VARIANT_PROTO_V1
+        VARIANT_PROTO_V1,
+        VARIANT_CONNECT_ALL_TO_ALL
     };
 
     test_ucp_tag_xfer() {
@@ -61,6 +62,8 @@ public:
             modify_config("ZCOPY_THRESH", "0");
         } else if (get_variant_value() == VARIANT_PROTO_V1) {
             modify_config("PROTO_ENABLE", "n");
+        } else if (get_variant_value() == VARIANT_CONNECT_ALL_TO_ALL) {
+            modify_config("CONNECT_ALL_TO_ALL", "y");
         }
 
         /* Init number of lanes according to test requirement
@@ -98,6 +101,8 @@ public:
             add_variant_with_value(variants, get_ctx_params(), VARIANT_PROTO_V1,
                                    "proto_v1");
         }
+        add_variant_with_value(variants, get_ctx_params(),
+                               VARIANT_CONNECT_ALL_TO_ALL, "connect_all_to_all");
     }
 
     virtual ucp_ep_params_t get_ep_params() {


### PR DESCRIPTION
## What?
Fixes on top of https://github.com/openucx/ucx/pull/10503 to finalize the All2All Wireup on Multi NIC-GPU feature.

## Why?
Performance optimization for multiple NICs/GPUs systems.

## How?
Renamed the env var to `UCX_CONNECT_ALL_TO_ALL`, added a restriction to allow only one path for this feature, fixed lane creation ordering to avoid `ucp_wireup_match_p2p_lanes()` failure, and applied additional review comments.