### PR TITLE
UCT/ROCM: Add parameter to control max elements in IPC sigpool

### DIFF
--- a/src/uct/rocm/ipc/rocm_ipc_ep.c
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.c
@@ -154,6 +154,12 @@ ucs_status_t uct_rocm_ipc_ep_zcopy(uct_ep_h tl_ep,
     }
 
     rocm_ipc_signal = ucs_mpool_get(&iface->signal_pool);
+    if (rocm_ipc_signal == NULL) {
+        ucs_error("increase the maximum number of signal pool elements with "
+                  "UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS");
+        return UCS_ERR_IO_ERROR;
+    }
+
     hsa_signal_store_screlease(rocm_ipc_signal->signal, 1);
 
     status = UCS_PROFILE_CALL_ALWAYS(hsa_amd_memory_async_copy, dst_addr,

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -32,6 +32,11 @@ static ucs_config_field_t uct_rocm_ipc_iface_config_table[] = {
      ucs_offsetof(uct_rocm_ipc_iface_config_t, params.enable_ipc_handle_cache),
      UCS_CONFIG_TYPE_BOOL},
 
+    {"SIGPOOL_MAX_ELEMS", "1024",
+      "Maximum number of elements in signal pool",
+      ucs_offsetof(uct_rocm_ipc_iface_config_t, params.sigpool_max_elems),
+      UCS_CONFIG_TYPE_UINT},
+
     {NULL}
 };
 
@@ -209,7 +214,7 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_ipc_iface_t, uct_md_h md, uct_worker_h worke
     ucs_mpool_params_reset(&mp_params);
     mp_params.elem_size       = sizeof(uct_rocm_base_signal_desc_t);
     mp_params.elems_per_chunk = 128;
-    mp_params.max_elems       = 1024;
+    mp_params.max_elems       = config->params.sigpool_max_elems;
     mp_params.ops             = &uct_rocm_base_signal_desc_mpool_ops;
     mp_params.name            = "ROCM_IPC signal objects";
     status = ucs_mpool_init(&mp_params, &self->signal_pool);

--- a/src/uct/rocm/ipc/rocm_ipc_iface.h
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.h
@@ -14,9 +14,10 @@
 #define UCT_ROCM_IPC_TL_NAME "rocm_ipc"
 
 typedef struct uct_rocm_ipc_iface_config_params {
-    size_t min_zcopy;
-    double latency;
-    int    enable_ipc_handle_cache;
+    size_t   min_zcopy;
+    double   latency;
+    int      enable_ipc_handle_cache;
+    unsigned sigpool_max_elems;
 } uct_rocm_ipc_iface_config_params_t;
 
 typedef struct uct_rocm_ipc_iface {


### PR DESCRIPTION
## What?
_Describe what this PR is doing._
Adds parameter (UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS) to control the maximum number of elements in hsa signal pool (ucs_mpool_params). Changes from 1024 (default) to parameter.

Same as #9366 but for ROCM_IPC

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

We may want to increase the number of signals for certain applications

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
