### PR TITLE
UCP/WIREUP: Fix a2a lane creation

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1655,7 +1655,7 @@ ucp_wireup_add_bw_lanes_a2a(const ucp_wireup_select_params_t *select_params,
                                                      0, sinfo, NULL, 0);
                 if (status != UCS_OK) {
                     ucs_array_pop_back(&sinfo_array);
-                    break;
+                    continue;
                 }
             }
         }
@@ -1671,7 +1671,7 @@ ucp_wireup_add_bw_lanes_a2a(const ucp_wireup_select_params_t *select_params,
                                                      0, sinfo, NULL, 0);
                 if (status != UCS_OK) {
                     ucs_array_pop_back(&sinfo_array);
-                    break;
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
## What?
Fix `ucp_wireup_add_bw_lanes_a2a()` to continue evaluating all device pairs when selecting bandwidth lanes.

## Why?
Previously, when `ucp_wireup_select_transport()` returned `UCS_ERR_UNREACHABLE` for a given (local_dev, remote_dev) pair, the loop exited early due to a break statement.
This caused some lanes to be skipped, resulting incorrect All2All lane selection.

## How?
Replaced break with continue to ensure the function evaluates all valid (local_dev, remote_dev) combinations, even if some of them are unreachable.

## Before
![image](https://github.com/user-attachments/assets/cdd5fe61-137c-413a-8d84-11d7e1861720)

## After
![image](https://github.com/user-attachments/assets/cd3475df-4957-4ae3-bec8-7fbea1c5ed0e)