### PR TITLE
Backport ConnectX-8 CI fixes - v1.18.x

### DIFF
--- a/buildlib/tools/check_tls_perf_caps.sh
+++ b/buildlib/tools/check_tls_perf_caps.sh
@@ -30,8 +30,14 @@ for tl_name in $(grep Transport ${legacy_info_file} | awk '{print $3}')
 do
     old_tl_caps=$(grep -A 8 "Transport: $tl_name" ${legacy_info_file} || true)
     new_tl_caps=$(grep -A 8 "Transport: $tl_name" ${pr_info_file}     || true)
-    for device in  $(echo "${old_tl_caps}" | grep Device | awk '{print $3}')
+    for device in $(echo "${old_tl_caps}" | grep Device | awk '{print $3}')
     do
+      # Ignore SMI devices
+      if [[ "$device" =~ ^smi[0-9]*:.$ ]]
+      then
+        continue;
+      fi
+
       old_caps=$(echo "$old_tl_caps" | grep -A 7 "Device: $device" || true)
       new_caps=$(echo "$new_tl_caps" | grep -A 7 "Device: $device" || true)
       for cap in bandwidth latency overhead

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -145,6 +145,7 @@ get_ib_devices() {
 	set +x
 	for ibdev in $device_list
 	do
+		[[ "$device" =~ ^smi[0-9]*:.$ ]] && continue
 		num_ports=$(ibv_devinfo -d $ibdev| awk '/phys_port_cnt:/ {print $2}')
 		for port in $(seq 1 $num_ports)
 		do

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -11,6 +11,7 @@
 #endif
 
 #include "ucp_am.h"
+#include <ucp/am/ucp_am.inl>
 
 #include <ucp/core/ucp_ep.h>
 #include <ucp/core/ucp_ep.inl>
@@ -255,14 +256,6 @@ ucp_am_get_short_max(const ucp_request_t *req, ssize_t max_short)
     return (UCP_DT_IS_CONTIG(req->send.datatype) &&
             UCP_MEM_IS_HOST(req->send.mem_type)) ?
             max_short : -1;
-}
-
-static UCS_F_ALWAYS_INLINE void
-ucp_am_fill_header(ucp_am_hdr_t *hdr, ucp_request_t *req)
-{
-    hdr->am_id         = req->send.msg_proto.am.am_id;
-    hdr->flags         = req->send.msg_proto.am.flags;
-    hdr->header_length = req->send.msg_proto.am.header.length;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -1040,6 +1033,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_send_nbx,
     if (worker->context->config.ext.proto_enable) {
         req->send.msg_proto.am.am_id           = id;
         req->send.msg_proto.am.flags           = flags;
+        req->send.msg_proto.am.internal_flags  = 0;
         req->send.msg_proto.am.header.ptr      = (void*)header;
         req->send.msg_proto.am.header.reg_desc = NULL;
         req->send.msg_proto.am.header.length   = header_length;

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -205,7 +205,11 @@ struct ucp_request {
                             } header UCS_S_PACKED; /* packed to avoid 32-bit
                                                       padding */
                             uint16_t       am_id;
+                            /* API flags from @ref ucp_send_am_flags enum */
                             uint16_t       flags;
+                            /* Internal implementation flags from @ref
+                             * ucp_request_am_internal_flags enum */
+                            uint8_t        internal_flags;
                         } am;
                     };
                 } msg_proto;

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2359,17 +2359,11 @@ static void ucp_worker_set_max_am_header(ucp_worker_h worker)
         /* UCT_IFACE_FLAG_AM_BCOPY is required by UCP AM feature, therefore
          * at least one interface should support it.
          * Make sure that except user header single UCT fragment can fit
-         * first fragment header and footer and at least 1 byte of data. It is
-         * needed to correctly use generic AM based multi-fragment protocols,
-         * which expect some amount of payload to be packed to the first
-         * fragment.
-         * TODO: fix generic AM based multi-fragment protocols, so that this
-         * trick is not needed.
-         */
+         * first fragment header and footer. */
         if (if_attr->cap.flags & UCT_IFACE_FLAG_AM_BCOPY) {
             max_uct_fragment = ucs_max(if_attr->cap.am.max_bcopy,
-                                       max_ucp_header - 1) -
-                               max_ucp_header - 1;
+                                       max_ucp_header) -
+                               max_ucp_header;
             max_am_header    = ucs_min(max_am_header, max_uct_fragment);
         }
     }

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -213,6 +213,11 @@ size_t ucp_datatype_iter_iov_next_iov(const ucp_datatype_iter_t *dt_iter,
     next_iter->type.iov.iov_index  = dt_iter->type.iov.iov_index;
     next_iter->type.iov.iov_offset = dt_iter->type.iov.iov_offset;
 
+    if (max_length == 0) {
+        next_iter->offset = dt_iter->offset;
+        return 0;
+    }
+
     /* Limiting data length by max_iter_length prevents from going outside the
        iov list */
     ucs_assert(dt_iter->offset <= dt_iter->length);

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -63,11 +63,16 @@ ucp_proto_multi_max_payload(ucp_request_t *req,
                             size_t hdr_size)
 {
     size_t length   = req->send.state.dt_iter.length;
-    size_t max_frag = lpriv->max_frag - hdr_size;
+    size_t max_frag;
     size_t max_payload;
 
-    ucs_assertv(lpriv->max_frag > hdr_size, "max_frag=%zu hdr_size=%zu",
-                lpriv->max_frag, hdr_size);
+    /* If header is greater than max_frag - that's ok, we allow it, but we send
+     * only the header data and empty payload. */
+    if (lpriv->max_frag <= hdr_size) {
+        return 0;
+    }
+
+    max_frag = lpriv->max_frag - hdr_size;
 
     /* Do not split very small sends to chunks, it's not worth it, and
        generic datatype may not be able to pack to a smaller buffer */

--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -131,6 +131,7 @@ noinst_HEADERS = \
 	sys/iovec.h \
 	sys/iovec.inl \
 	sys/ptr_arith.h \
+	sys/netlink.h \
 	time/time.h \
 	time/timerq.h \
 	time/timer_wheel.h \
@@ -205,6 +206,7 @@ libucs_la_SOURCES = \
 	sys/sock.c \
 	sys/topo/base/topo.c \
 	sys/stubs.c \
+	sys/netlink.c \
 	sys/uid.c \
 	time/time.c \
 	time/timer_wheel.c \

--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -1,0 +1,147 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "netlink.h"
+
+#include <ucs/debug/log.h>
+#include <ucs/sys/compiler.h>
+#include <ucs/sys/sock.h>
+#include <ucs/type/status.h>
+#include <ucs/debug/memtrack_int.h>
+
+#include <errno.h>
+#include <linux/rtnetlink.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+
+typedef struct {
+    const struct sockaddr *sa_remote;
+    int                    if_index;
+    int                    found;
+} ucs_netlink_route_info_t;
+
+
+static ucs_status_t ucs_netlink_socket_init(int *fd_p, int protocol)
+{
+    struct sockaddr_nl sa = {.nl_family = AF_NETLINK};
+    ucs_status_t status;
+
+    status = ucs_socket_create(AF_NETLINK, SOCK_RAW, protocol, fd_p);
+    if (status != UCS_OK) {
+        ucs_error("failed to create netlink socket: %s",
+                  ucs_status_string(status));
+        goto err;
+    }
+
+    if (bind(*fd_p, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        ucs_error("failed to bind netlink socket %d: %m", *fd_p);
+        status = UCS_ERR_IO_ERROR;
+        goto err_close_socket;
+    }
+
+    return UCS_OK;
+
+err_close_socket:
+    ucs_close_fd(fd_p);
+err:
+    return status;
+}
+
+static ucs_status_t
+ucs_netlink_parse_msg(const void *msg, size_t msg_len,
+                      ucs_netlink_parse_cb_t parse_cb, void *arg)
+{
+    ucs_status_t status        = UCS_INPROGRESS;
+    const struct nlmsghdr *nlh = (const struct nlmsghdr *)msg;
+
+    while ((status == UCS_INPROGRESS) && NLMSG_OK(nlh, msg_len) &&
+           (nlh->nlmsg_type != NLMSG_DONE)) {
+        if (nlh->nlmsg_type == NLMSG_ERROR) {
+            struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+            ucs_error("received error response from netlink err=%d: %s\n",
+                      err->error, strerror(-err->error));
+            return UCS_ERR_IO_ERROR;
+        }
+
+        status = parse_cb(nlh, arg);
+        nlh    = NLMSG_NEXT(nlh, msg_len);
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t
+ucs_netlink_send_request(int protocol, unsigned short nlmsg_type,
+                         unsigned short nlmsg_flags,
+                         const void *protocol_header, size_t header_length,
+                         ucs_netlink_parse_cb_t parse_cb, void *arg)
+{
+    struct nlmsghdr nlh = {0};
+    char *recv_msg      = NULL;
+    size_t recv_msg_len = 0;
+    int netlink_fd      = -1;
+    ucs_status_t status;
+    struct iovec iov[2];
+    size_t bytes_sent;
+
+    status = ucs_netlink_socket_init(&netlink_fd, protocol);
+    if (status != UCS_OK) {
+        goto out;
+    }
+
+    nlh.nlmsg_len   = NLMSG_LENGTH(header_length);
+    nlh.nlmsg_type  = nlmsg_type;
+    nlh.nlmsg_flags = NLM_F_REQUEST | nlmsg_flags;
+    iov[0].iov_base = &nlh;
+    iov[0].iov_len  = sizeof(nlh);
+    iov[1].iov_base = (void *)protocol_header;
+    iov[1].iov_len  = header_length;
+
+    do {
+        status = ucs_socket_sendv_nb(netlink_fd, iov, 2, &bytes_sent);
+    } while (status == UCS_ERR_NO_PROGRESS);
+
+    if (status != UCS_OK) {
+        ucs_error("failed to send netlink message on fd=%d: %s",
+                  netlink_fd, ucs_status_string(status));
+        goto out;
+    }
+
+    /* get message size */
+    status = ucs_socket_recv_nb(netlink_fd, NULL, MSG_PEEK | MSG_TRUNC,
+                                &recv_msg_len);
+    if (status != UCS_OK) {
+        ucs_error("failed to get netlink message size %d (%s)",
+                  status, ucs_status_string(status));
+        goto out;
+    }
+
+    recv_msg = ucs_malloc(recv_msg_len, "netlink recv message");
+    if (recv_msg == NULL) {
+        ucs_error("failed to allocate a buffer for netlink receive message of"
+                  " size %zu", recv_msg_len);
+        goto out;
+    }
+
+    status = ucs_socket_recv(netlink_fd, recv_msg, recv_msg_len);
+    if (status != UCS_OK) {
+        ucs_error("failed to receive netlink message on fd=%d: %s",
+                  netlink_fd, ucs_status_string(status));
+        goto out;
+    }
+
+    status = ucs_netlink_parse_msg(recv_msg, recv_msg_len, parse_cb, arg);
+
+out:
+    ucs_close_fd(&netlink_fd);
+    ucs_free(recv_msg);
+    return status;
+}

--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -1,0 +1,48 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCS_NETLINK_H
+#define UCS_NETLINK_H
+
+#include <ucs/type/status.h>
+
+#include <linux/netlink.h>
+#include <netinet/in.h>
+
+BEGIN_C_DECLS
+
+/**
+ * Callback function for parsing individual netlink messages.
+ *
+ * @param [in] nlh    Pointer to the netlink message header.
+ * @param [in] arg    User-provided argument passed through from the caller.
+ *
+ * @return UCS_OK if parsing is complete, UCS_INPROGRESS if there are more
+ *         messages to be parsed, or error code otherwise.
+ */
+typedef ucs_status_t (*ucs_netlink_parse_cb_t)(const struct nlmsghdr *nlh,
+                                               void *arg);
+
+/*
+ * Send a netlink request and parse the response.
+ *
+ * @param [in]  protocol         Netlink protocol (e.g. NETLINK_ROUTE).
+ * @param [in]  nlmsg_type       Protocol message type (e.g. NETLINK_GETROUTE).
+ * @param [in]  nlmsg_flags      Flags for message header (e.g. NLM_F_ROOT).
+ * @param [in]  protocol_header  Netlink protocol header.
+ * @param [in]  header_length    Netlink protocol header length.
+ * @param [in]  parse_cb         Callback function to parse the response.
+ * @param [in]  arg              User-provided argument for the parse callback.
+ */
+ucs_status_t
+ucs_netlink_send_request(int protocol, unsigned short nlmsg_type,
+                         unsigned short nlmsg_flags,
+                         const void *protocol_header, size_t header_length,
+                         ucs_netlink_parse_cb_t parse_cb, void *arg);
+
+END_C_DECLS
+
+#endif /* UCS_NETLINK_H */

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -80,7 +80,7 @@ ucs_status_t ucs_netif_ioctl(const char *if_name, unsigned long request,
 
     ucs_strncpy_zero(if_req->ifr_name, if_name, sizeof(if_req->ifr_name));
 
-    status = ucs_socket_create(AF_INET, SOCK_STREAM, &fd);
+    status = ucs_socket_create(AF_INET, SOCK_STREAM, 0, &fd);
     if (status != UCS_OK) {
         goto out;
     }
@@ -195,9 +195,9 @@ unsigned ucs_netif_bond_ad_num_ports(const char *bond_name)
     return (unsigned)ad_num_ports;
 }
 
-ucs_status_t ucs_socket_create(int domain, int type, int *fd_p)
+ucs_status_t ucs_socket_create(int domain, int type, int protocol, int *fd_p)
 {
-    int fd = socket(domain, type, 0);
+    int fd = socket(domain, type, protocol);
     if (fd < 0) {
         ucs_socket_print_error_info("socket create failed", errno);
         return UCS_ERR_IO_ERROR;
@@ -451,7 +451,7 @@ ucs_status_t ucs_socket_server_init(const struct sockaddr *saddr, socklen_t sock
 
     /* Create the server socket for accepting incoming connections */
     fd     = -1; /* Suppress compiler warning */
-    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, &fd);
+    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, 0, &fd);
     if (status != UCS_OK) {
         goto err;
     }
@@ -582,9 +582,9 @@ ucs_socket_handle_io(int fd, const void *data, size_t count,
 
 static inline ucs_status_t
 ucs_socket_do_io_nb(int fd, void *data, size_t *length_p,
-                    ucs_socket_io_func_t io_func, const char *name)
+                    ucs_socket_io_func_t io_func, const char *name, int flags)
 {
-    ssize_t ret = io_func(fd, data, *length_p, MSG_NOSIGNAL);
+    ssize_t ret = io_func(fd, data, *length_p, MSG_NOSIGNAL | flags);
     return ucs_socket_handle_io(fd, data, *length_p, length_p, 0,
                                 ret, errno, name);
 }
@@ -597,7 +597,7 @@ ucs_socket_do_io_b(int fd, void *data, size_t length,
     ucs_status_t status;
 
     do {
-        status = ucs_socket_do_io_nb(fd, data, &cur_cnt, io_func, name);
+        status = ucs_socket_do_io_nb(fd, data, &cur_cnt, io_func, name, 0);
         done_cnt += cur_cnt;
         ucs_assert(done_cnt <= length);
         cur_cnt = length - done_cnt;
@@ -624,7 +624,7 @@ ucs_socket_do_iov_nb(int fd, struct iovec *iov, size_t iov_cnt, size_t *length_p
 ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p)
 {
     return ucs_socket_do_io_nb(fd, (void*)data, length_p,
-                               (ucs_socket_io_func_t)send, "send");
+                               (ucs_socket_io_func_t)send, "send", 0);
 }
 
 /* recv is declared as 'always_inline' on some platforms, it leads to
@@ -634,9 +634,10 @@ static ssize_t ucs_socket_recv_io(int fd, void *data, size_t size, int flags)
     return recv(fd, data, size, flags);
 }
 
-ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p)
+ucs_status_t ucs_socket_recv_nb(int fd, void *data, int flags, size_t *length_p)
 {
-    return ucs_socket_do_io_nb(fd, data, length_p, ucs_socket_recv_io, "recv");
+    return ucs_socket_do_io_nb(fd, data, length_p, ucs_socket_recv_io,
+                               "recv", flags);
 }
 
 ucs_status_t ucs_socket_send(int fd, const void *data, size_t length)

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -111,11 +111,12 @@ unsigned ucs_netif_bond_ad_num_ports(const char *if_name);
  *
  * @param [in]   domain     Communication domain (AF_INET/AF_INET6/etc).
  * @param [in]   type       Communication semantics (SOCK_STREAM/SOCK_DGRAM/etc).
+ * @param [in]   protocol   Communication protocol (IPPROTO_TCP/NETLINK_ROUTE/etc).
  * @param [out]  fd_p       Pointer to created fd.
  *
  * @return UCS_OK on success or UCS_ERR_IO_ERROR on failure.
  */
-ucs_status_t ucs_socket_create(int domain, int type, int *fd_p);
+ucs_status_t ucs_socket_create(int domain, int type, int protocol, int *fd_p);
 
 
 /**
@@ -279,13 +280,14 @@ ucs_status_t ucs_socket_send_nb(int fd, const void *data, size_t *length_p);
  * @param [in]      fd              Socket fd.
  * @param [in]      data            A pointer to a buffer to receive the incoming
  *                                  data.
+ * @param [in]      flags           recv flags.
  * @param [in/out]  length_p        The length, in bytes, of the data in buffer
  *                                  pointed to by the `data` parameter. The amount of
  *                                  data received is written to this argument.
  *
  * @return UCS_OK on success or an error code on failure.
  */
-ucs_status_t ucs_socket_recv_nb(int fd, void *data, size_t *length_p);
+ucs_status_t ucs_socket_recv_nb(int fd, void *data, int flags, size_t *length_p);
 
 
 /**

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -18,11 +18,16 @@
 #include <ucs/async/async.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/netlink.h>
 #include <ucs/sys/sock.h>
 #include <ucs/sys/sys.h>
 #include <sys/poll.h>
 #include <libgen.h>
 #include <sched.h>
+
+#ifdef HAVE_NETLINK_RDMA
+#include <rdma/rdma_netlink.h>
+#endif
 
 
 /* This table is according to "Encoding for RNR NAK Timer Field"
@@ -1505,3 +1510,61 @@ const char* uct_ib_ah_attr_str(char *buf, size_t max,
     return buf;
 }
 
+#ifdef HAVE_NETLINK_RDMA
+static ucs_status_t
+uct_ib_device_is_smi_cb(const struct nlmsghdr *nlh, void *arg)
+{
+    int *is_smi_p = (int*)arg;
+    const struct nlattr *attr;
+    uint8_t dev_type;
+
+    for (attr = NLMSG_DATA(nlh); UCS_PTR_BYTE_DIFF(nlh, attr) < nlh->nlmsg_len;
+         attr = UCS_PTR_BYTE_OFFSET(attr, NLA_ALIGN(attr->nla_len))) {
+        if (attr->nla_type == RDMA_NLDEV_ATTR_DEV_TYPE /* 99 */) {
+            dev_type = *(const uint8_t*)UCS_PTR_BYTE_OFFSET(attr, NLA_HDRLEN);
+            if (dev_type == RDMA_DEVICE_TYPE_SMI /* 1 */) {
+                *is_smi_p = 1;
+                return UCS_OK;
+            }
+        }
+    }
+
+    return UCS_INPROGRESS;
+}
+
+int uct_ib_device_is_smi(struct ibv_device *ibv_device)
+{
+    struct nlattr *attr;
+    uint32_t *dev_index_attr;
+    size_t header_length;
+    ucs_status_t status;
+    int is_smi;
+
+    header_length   = NLA_HDRLEN + sizeof(*dev_index_attr);
+    attr            = ucs_alloca(header_length);
+    dev_index_attr  = (uint32_t*)UCS_PTR_BYTE_OFFSET(attr, NLA_HDRLEN);
+    attr->nla_type  = RDMA_NLDEV_ATTR_DEV_INDEX;
+    attr->nla_len   = header_length;
+    *dev_index_attr = ibv_get_device_index(ibv_device);
+    if (*dev_index_attr == -1) {
+        ucs_debug("%s: failed to get device index",
+                  ibv_get_device_name(ibv_device));
+        return 0;
+    }
+
+    is_smi = 0;
+    status = ucs_netlink_send_request(
+            NETLINK_RDMA, RDMA_NL_GET_TYPE(RDMA_NL_NLDEV, RDMA_NLDEV_CMD_GET),
+            0, attr, header_length, uct_ib_device_is_smi_cb, &is_smi);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return is_smi;
+}
+#else
+int uct_ib_device_is_smi(struct ibv_device *ibv_device)
+{
+    return 0;
+}
+#endif

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -496,4 +496,6 @@ static inline void uct_ib_destroy_cq(struct ibv_cq *cq, const char *desc)
 
 void uct_ib_handle_async_event(uct_ib_device_t *dev, uct_ib_async_event_t *event);
 
+int uct_ib_device_is_smi(struct ibv_device *ibv_device);
+
 #endif

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1219,7 +1219,8 @@ int uct_ib_md_check_odp_common(uct_ib_md_t *md, const char **reason_ptr)
     return 1;
 }
 
-void uct_ib_md_check_odp(uct_ib_md_t *md)
+static void
+uct_ib_md_check_odp(uct_ib_md_t *md, const uct_ib_md_config_t *md_config)
 {
     const char *device_name = uct_ib_device_name(&md->dev);
     const char *reason;
@@ -1229,8 +1230,8 @@ void uct_ib_md_check_odp(uct_ib_md_t *md)
         return;
     }
 
-    md->reg_nonblock_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST);
-    ucs_debug("%s: ODP is supported, version 1", device_name);
+    md->reg_nonblock_mem_types = md_config->ext.odp.mem_types;
+    ucs_debug("%s: ODP is supported", device_name);
 }
 
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
@@ -1493,7 +1494,7 @@ static ucs_status_t uct_ib_verbs_md_open(struct ibv_device *ibv_device,
 
     uct_ib_md_ece_check(md);
     uct_ib_md_parse_relaxed_order(md, md_config, 0);
-    uct_ib_md_check_odp(md);
+    uct_ib_md_check_odp(md, md_config);
 
     *p_md = md;
     return UCS_OK;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -770,13 +770,20 @@ static const char *uct_ib_device_transport_type_name(struct ibv_device *device)
 static int uct_ib_device_is_supported(struct ibv_device *device)
 {
     /* TODO: enable additional transport types when ready */
-    int ret = device->transport_type == IBV_TRANSPORT_IB;
-    if (!ret) {
-        ucs_debug("device %s of type %s is not supported",
-                  device->dev_name, uct_ib_device_transport_type_name(device));
+    if (device->transport_type != IBV_TRANSPORT_IB) {
+        ucs_debug("%s: unsupported transport type %s",
+                  ibv_get_device_name(device),
+                  uct_ib_device_transport_type_name(device));
+        return 0;
     }
 
-    return ret;
+    if (uct_ib_device_is_smi(device)) {
+        ucs_debug("%s: smi device is not supported",
+                  ibv_get_device_name(device));
+        return 0;
+    }
+
+    return 1;
 }
 
 int uct_ib_device_is_accessible(struct ibv_device *device)
@@ -1279,7 +1286,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
 
     /* Check for GPU-direct support */
     if (md_config->enable_gpudirect_rdma != UCS_NO) {
-        /* Check peer memory driver is loaded, different driver versions use 
+        /* Check peer memory driver is loaded, different driver versions use
          * different paths */
         uct_ib_check_gpudirect_driver(
                 md, "/sys/kernel/mm/memory_peers/nv_mem/version",
@@ -1290,7 +1297,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         uct_ib_check_gpudirect_driver(
                 md, "/sys/module/nv_peer_mem/version",
                 UCS_MEMORY_TYPE_CUDA);
-                
+
 
         /* check if ROCM KFD driver is loaded */
         uct_ib_check_gpudirect_driver(md, "/dev/kfd", UCS_MEMORY_TYPE_ROCM);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -375,8 +375,6 @@ ucs_status_t uct_ib_mem_prefetch(uct_ib_md_t *md, uct_ib_mem_t *ib_memh,
 void uct_ib_md_ece_check(uct_ib_md_t *md);
 
 /* Check if IB MD supports nonblocking registration */
-void uct_ib_md_check_odp(uct_ib_md_t *md);
-
 int uct_ib_md_check_odp_common(uct_ib_md_t *md, const char **reason_ptr);
 
 ucs_status_t

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -282,12 +282,34 @@ AS_IF([test "x$with_ib" = "xyes"],
            AC_CHECK_DECLS([ibv_alloc_dm],
                [AC_DEFINE([HAVE_IBV_DM], 1, [Device Memory support])],
                [], [[#include <infiniband/verbs.h>]])])
-        
+
         # DDP support
         AS_IF([test "x$have_mlx5" = xyes], [
            AC_CHECK_DECLS([MLX5DV_CONTEXT_MASK_OOO_RECV_WRS],
                [AC_DEFINE([HAVE_OOO_RECV_WRS], 1, [Have DDP support])],
                [], [[#include <infiniband/mlx5dv.h>]])])
+
+       # RDMA netlink support requires defines from rdma_netlink.h and the
+       # ability to get netlink index from ibv_device struct.
+       have_netlink_rdma=yes
+       AC_CHECK_DECL([NETLINK_RDMA], [], [have_netlink_rdma=no],
+                     [[#include <linux/netlink.h>]])
+       AC_CHECK_DECL([RDMA_NL_NLDEV], [], [have_netlink_rdma=no],
+                     [[#include <rdma/rdma_netlink.h>]])
+       AC_CHECK_DECL([ibv_get_device_index], [], [have_netlink_rdma=no],
+                     [[#include <infiniband/verbs.h>]])
+       AS_IF([test "x$have_netlink_rdma" = xyes],
+             [AC_DEFINE([HAVE_NETLINK_RDMA], [1], [RDMA netlink support])
+              # Define replacement constants if not present in header files
+              AC_CHECK_DECL(RDMA_NLDEV_ATTR_DEV_TYPE, [],
+                            [AC_DEFINE([RDMA_NLDEV_ATTR_DEV_TYPE], 99,
+                                       [RDMA netlink device type attribute])],
+                            [[#include <rdma/rdma_netlink.h>]])
+              AC_CHECK_DECL(RDMA_DEVICE_TYPE_SMI, [],
+                            [AC_DEFINE([RDMA_DEVICE_TYPE_SMI], 1,
+                                       [RDMA netlink SMI device type])],
+                            [[#include <rdma/rdma_netlink.h>]])
+             ])
 
        mlnx_valg_libdir=$with_verbs/lib${libsuff}/mlnx_ofed/valgrind
        AC_MSG_NOTICE([Checking OFED valgrind libs $mlnx_valg_libdir])

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1621,18 +1621,18 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     init_attr.cq_len[UCT_IB_DIR_TX] = sq_length * self->tx.ndci;
 
-    /* TODO check caps instead */
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_dc_mlx5_iface_tl_ops, &uct_dc_mlx5_iface_ops,
-                              tl_md, worker, params, &config->super,
-                              &config->rc_mlx5_common, &init_attr);
-
-    status = uct_rc_mlx5_dp_ordering_ooo_init(&self->super,
+    status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
                                               md->dp_ordering_cap.dc,
                                               &config->rc_mlx5_common, "dc");
     if (status != UCS_OK) {
         return status;
     }
+
+    /* TODO check caps instead */
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
+                              &uct_dc_mlx5_iface_tl_ops, &uct_dc_mlx5_iface_ops,
+                              tl_md, worker, params, &config->super,
+                              &config->rc_mlx5_common, &init_attr);
 
     tx_cq_size = uct_ib_cq_size(&self->super.super.super, &init_attr,
                                 UCT_IB_DIR_TX);

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -27,6 +27,24 @@ static uint32_t uct_ib_mlx5_flush_rkey_make()
     return ((getpid() & 0xff) << 8) | UCT_IB_MD_INVALID_FLUSH_RKEY;
 }
 
+/* Should be called after DDP is initialized */
+static int
+uct_ib_mlx5_md_check_odp_common(uct_ib_mlx5_md_t *md, const char **reason_ptr)
+{
+    if (!uct_ib_md_check_odp_common(&md->super, reason_ptr)) {
+        return 0;
+    }
+
+    /* Issue 4238670 */
+    if ((md->dp_ordering_cap.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
+        (md->dp_ordering_cap.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL)) {
+        *reason_ptr = "ODP does not work with DDP";
+        return 0;
+    }
+
+    return 1;
+}
+
 #if HAVE_DEVX
 static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
 
@@ -1614,7 +1632,7 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
     struct ibv_mr *mr;
     uint8_t version;
 
-    if (!uct_ib_md_check_odp_common(&md->super, &reason)) {
+    if (!uct_ib_mlx5_md_check_odp_common(md, &reason)) {
         goto no_odp;
     }
 
@@ -3160,7 +3178,7 @@ out:
 
 static uct_ib_md_ops_t uct_ib_mlx5_md_ops;
 
-static ucs_status_t 
+static ucs_status_t
 uct_ib_mlx5dv_check_ddp(struct ibv_context *ctx, uct_ib_mlx5_md_t *md)
 {
 #ifdef HAVE_OOO_RECV_WRS
@@ -3187,6 +3205,21 @@ uct_ib_mlx5dv_check_ddp(struct ibv_context *ctx, uct_ib_mlx5_md_t *md)
     md->dp_ordering_cap.dc = UCT_IB_MLX5_DP_ORDERING_IBTA;
 #endif
     return UCS_OK;
+}
+
+static void uct_ib_mlx5dv_md_check_odp(uct_ib_mlx5_md_t *md,
+                                       const uct_ib_md_config_t *md_config)
+{
+    const char *device_name = uct_ib_device_name(&md->super.dev);
+    const char *reason;
+
+    if (!uct_ib_mlx5_md_check_odp_common(md, &reason)) {
+        ucs_debug("%s: ODP is disabled because %s", device_name, reason);
+        return;
+    }
+
+    md->super.reg_nonblock_mem_types = md_config->ext.odp.mem_types;
+    ucs_debug("%s: ODP is supported", device_name);
 }
 
 static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
@@ -3253,7 +3286,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
 
     uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
     uct_ib_md_ece_check(&md->super);
-    uct_ib_md_check_odp(&md->super);
+    uct_ib_mlx5dv_md_check_odp(md, md_config);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();
 

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -656,19 +656,19 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
                                                    max_qp_rd_atom);
     init_attr.tx_moderation         = config->super.tx_cq_moderation;
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_gga_mlx5_iface_tl_ops,
-                              &uct_gga_mlx5_iface_ops, tl_md, worker, params,
-                              &config->super.super, &config->rc_mlx5_common,
-                              &init_attr);
-
     status = uct_rc_mlx5_dp_ordering_ooo_init(
-            &self->super,
+            md, &self->super,
             ucs_min(md->dp_ordering_cap.rc, UCT_IB_MLX5_DP_ORDERING_OOO_RW),
             &config->rc_mlx5_common, "gga");
     if (status != UCS_OK) {
         return status;
     }
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
+                              &uct_gga_mlx5_iface_tl_ops,
+                              &uct_gga_mlx5_iface_ops, tl_md, worker, params,
+                              &config->super.super, &config->rc_mlx5_common,
+                              &init_attr);
 
     uct_gga_mlx5_iface_disable_rx(&self->super);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -600,13 +600,14 @@ void uct_rc_mlx5_release_desc(uct_recv_desc_t *self, void *desc)
     ucs_mpool_put_inline(ib_desc);
 }
 
+/* TODO do not pass iface, but only pass return value to config */
 ucs_status_t
-uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
+uct_rc_mlx5_dp_ordering_ooo_init(uct_ib_mlx5_md_t *md,
+                                 uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name)
 {
-    uct_ib_mlx5_md_t *md      = uct_ib_mlx5_iface_md(&iface->super.super);
     uct_ib_mlx5_dp_ordering_t min_forced_ordering;
 
     /*

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -481,7 +481,8 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_iface_ops_t*,
 
 
 ucs_status_t
-uct_rc_mlx5_dp_ordering_ooo_init(uct_rc_mlx5_iface_common_t *iface,
+uct_rc_mlx5_dp_ordering_ooo_init(uct_ib_mlx5_md_t *md,
+                                 uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -929,18 +929,18 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
         init_attr.flags |= UCT_IB_DDP_SUPPORTED;
     }
 
-    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
-                              &uct_rc_mlx5_iface_tl_ops, &uct_rc_mlx5_iface_ops,
-                              tl_md, worker, params, &config->super.super,
-                              &config->rc_mlx5_common, &init_attr);
-
-    status = uct_rc_mlx5_dp_ordering_ooo_init(&self->super,
+    status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
                                               md->dp_ordering_cap.rc,
                                               &config->rc_mlx5_common,
                                               "rc_mlx5");
     if (status != UCS_OK) {
         return status;
     }
+
+    UCS_CLASS_CALL_SUPER_INIT(uct_rc_mlx5_iface_common_t,
+                              &uct_rc_mlx5_iface_tl_ops, &uct_rc_mlx5_iface_ops,
+                              tl_md, worker, params, &config->super.super,
+                              &config->rc_mlx5_common, &init_attr);
 
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);
     if (status != UCS_OK) {

--- a/src/uct/tcp/tcp_ep.c
+++ b/src/uct/tcp/tcp_ep.c
@@ -677,7 +677,7 @@ static ucs_status_t uct_tcp_ep_create_socket_and_connect(uct_tcp_ep_t *ep)
     struct sockaddr *saddr = (struct sockaddr*)ep->peer_addr;
     ucs_status_t status;
 
-    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, &ep->fd);
+    status = ucs_socket_create(saddr->sa_family, SOCK_STREAM, 0, &ep->fd);
     if (status != UCS_OK) {
         goto err;
     }
@@ -1289,7 +1289,7 @@ static inline unsigned uct_tcp_ep_recv(uct_tcp_ep_t *ep, size_t recv_length)
     }
 
     status = ucs_socket_recv_nb(ep->fd, UCS_PTR_BYTE_OFFSET(ep->rx.buf,
-                                                            ep->rx.length),
+                                                            ep->rx.length), 0,
                                 &recv_length);
     if (ucs_unlikely(status != UCS_OK)) {
         uct_tcp_ep_handle_recv_err(ep, status);
@@ -1585,7 +1585,7 @@ static unsigned uct_tcp_ep_progress_put_rx(uct_tcp_ep_t *ep)
     put_req     = (uct_tcp_ep_put_req_hdr_t*)ep->rx.buf;
     recv_length = put_req->length;
     status      = ucs_socket_recv_nb(ep->fd, (void*)(uintptr_t)put_req->addr,
-                                     &recv_length);
+                                     0, &recv_length);
     if (ucs_unlikely(status != UCS_OK)) {
         uct_tcp_ep_handle_recv_err(ep, status);
         return 0;

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -771,7 +771,7 @@ static ucs_status_t uct_tcp_sockcm_ep_recv_nb(uct_tcp_sockcm_ep_t *cep)
     status = ucs_socket_recv_nb(cep->fd,
                                 UCS_PTR_BYTE_OFFSET(cep->comm_ctx.buf,
                                                     cep->comm_ctx.offset),
-                                &recv_length);
+                                0, &recv_length);
     if ((status != UCS_OK) && (status != UCS_ERR_NO_PROGRESS)) {
         if (status != UCS_ERR_NOT_CONNECTED) {  /* ECONNRESET cannot return from recv() */
             uct_cm_ep_peer_error(&cep->super,
@@ -874,7 +874,7 @@ static ucs_status_t uct_tcp_sockcm_ep_client_init(uct_tcp_sockcm_ep_t *cep,
     }
 
     server_addr = params->sockaddr->addr;
-    status = ucs_socket_create(server_addr->sa_family, SOCK_STREAM, &cep->fd);
+    status = ucs_socket_create(server_addr->sa_family, SOCK_STREAM, 0, &cep->fd);
     if (status != UCS_OK) {
         goto err;
     }

--- a/test/apps/test_ucx_tls.py
+++ b/test/apps/test_ucx_tls.py
@@ -250,7 +250,7 @@ if match:
 else:
     rc_max_num_eps = 0
 
-status, output = exec_cmd("ibv_devinfo  -l | tail -n +2 | sed -e 's/^[ \t]*//' | head -n -1 ")
+status, output = exec_cmd("ibv_devinfo -l | tail -n+2 | head -n-1 | sed -e 's/^[ \t]*//' | grep -v '^smi[0-9]*$'")
 dev_list = output.splitlines()
 port = "1"
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -541,6 +541,11 @@ static std::map<std::string, std::string> get_all_rdmacm_net_devices()
 
         if (!ib_devices.empty()) {
             std::string ib_device = ib_devices.front();
+            if (ib_device.rfind("smi", 0) == 0) {
+                /* Skip SMI device */
+                continue;
+            }
+
             std::string ports_dir = infiniband_dir + "/" + ib_device +
                                     "/ports";
             std::string ib_port   = read_dir(ports_dir).front();

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -613,7 +613,7 @@ uint16_t get_port() {
     socklen_t len = sizeof(ret_addr);
     uint16_t port;
 
-    status = ucs_socket_create(AF_INET, SOCK_STREAM, &sock_fd);
+    status = ucs_socket_create(AF_INET, SOCK_STREAM, 0, &sock_fd);
     EXPECT_EQ(status, UCS_OK);
 
     memset(&addr_in, 0, sizeof(struct sockaddr_in));

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1582,11 +1582,8 @@ private:
     }
 };
 
-/* Skip tests for ud_v and ud_x because of unstable reproducible failures during
- * roce on worker CI jobs. The test fails with invalid am_bcopy length. */
-UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, short_bcopy_send,
-                     is_proto_enabled() && has_any_transport({"ud_v", "ud_x"}),
-                     "ZCOPY_THRESH=-1", "RNDV_THRESH=-1")
+UCS_TEST_P(test_ucp_am_nbx_dts, short_bcopy_send, "ZCOPY_THRESH=-1",
+           "RNDV_THRESH=-1")
 {
     test_datatypes([&]() {
         test_am(1);
@@ -1595,9 +1592,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, short_bcopy_send,
     });
 }
 
-UCS_TEST_SKIP_COND_P(test_ucp_am_nbx_dts, zcopy_send,
-                     is_proto_enabled() && has_any_transport({"ud_v", "ud_x"}),
-                     "ZCOPY_THRESH=1", "RNDV_THRESH=-1")
+UCS_TEST_P(test_ucp_am_nbx_dts, zcopy_send, "ZCOPY_THRESH=1", "RNDV_THRESH=-1")
 {
     skip_no_am_lane_caps(UCT_IFACE_FLAG_AM_ZCOPY, "am_zcopy is not supported");
     test_datatypes([&]() {

--- a/test/gtest/ucp/test_ucp_tag_xfer.cc
+++ b/test/gtest/ucp/test_ucp_tag_xfer.cc
@@ -1245,19 +1245,25 @@ UCS_TEST_P(multi_rail_max, max_lanes, "IB_NUM_PATHS?=64", "TM_SW_RNDV=y",
     receiver().connect(&sender(), get_ep_params());
     test_run_xfer(true, true, true, true, false);
 
-    EXPECT_EQ(num_lanes(), ucp_ep_num_lanes(sender().ep()));
-    EXPECT_EQ(num_lanes(), ucp_ep_num_lanes(receiver().ep()));
+    ASSERT_EQ(num_lanes(), ucp_ep_num_lanes(sender().ep()));
+    ASSERT_EQ(num_lanes(), ucp_ep_num_lanes(receiver().ep()));
 
     size_t bytes_sent = 0;
+    unsigned num_used_lanes = 0;
     for (ucp_lane_index_t lane = 0; lane < num_lanes(); ++lane) {
         size_t sender_tx   = get_bytes_sent(sender().ep(), lane);
         size_t receiver_tx = get_bytes_sent(receiver().ep(), lane);
         UCS_TEST_MESSAGE << "lane[" << static_cast<int>(lane) << "] : "
                          << "sender " << sender_tx << " receiver " << receiver_tx;
-
-        EXPECT_GT(sender_tx + receiver_tx, 0);
+        if ((sender_tx > 0) || (receiver_tx > 0)) {
+            ++num_used_lanes;
+        }
         bytes_sent += sender_tx + receiver_tx;
     }
+
+    /* One lane could be reserved for tag offload and not selected for AM/RMA
+       bandwidth lane */
+    EXPECT_GE(num_used_lanes, num_lanes() - 1);
 
     EXPECT_GE(bytes_sent, get_msg_size());
 }

--- a/test/gtest/ucs/test_sock.cc
+++ b/test/gtest/ucs/test_sock.cc
@@ -542,7 +542,7 @@ UCS_TEST_F(test_socket, socket_setopt) {
 
     optlen = sizeof(optval);
 
-    status = ucs_socket_create(AF_INET, SOCK_STREAM, &fd);
+    status = ucs_socket_create(AF_INET, SOCK_STREAM, 0, &fd);
     EXPECT_UCS_OK(status);
     EXPECT_GE(fd, 0);
 

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -1141,6 +1141,9 @@ UCS_TEST_SKIP_COND_P(test_rc_srq, reorder_list,
 
 UCS_TEST_SKIP_COND_P(test_rc_srq, reorder_cyclic,
                      !check_caps(UCT_IFACE_FLAG_AM_BCOPY),
+                     /* Disable DDP to allow cyclic SRQ */
+                     "RC_MLX5_DDP_ENABLE?=n",
+                     "DC_MLX5_DDP_ENABLE?=n",
                      "RC_SRQ_TOPO?=cyclic,cyclic_emulated")
 {
     test_reorder();

--- a/test/gtest/uct/tcp/test_tcp.cc
+++ b/test/gtest/uct/tcp/test_tcp.cc
@@ -48,7 +48,7 @@ public:
 
         scoped_log_handler slh(wrap_errors_logger);
         if (nb) {
-            status = ucs_socket_recv_nb(fd, &msg, &msg_size);
+            status = ucs_socket_recv_nb(fd, &msg, 0, &msg_size);
         } else {
             status = ucs_socket_recv(fd, &msg, msg_size);
         }
@@ -186,7 +186,7 @@ private:
         int fd;
         EXPECT_TRUE((dest_addr.ss_family == AF_INET) ||
                     (dest_addr.ss_family == AF_INET6));
-        status = ucs_socket_create(dest_addr.ss_family, SOCK_STREAM, &fd);
+        status = ucs_socket_create(dest_addr.ss_family, SOCK_STREAM, 0, &fd);
         ASSERT_UCS_OK(status);
 
         status = ucs_socket_connect(fd, (struct sockaddr*)&dest_addr);

--- a/test/gtest/uct/test_p2p_am.cc
+++ b/test/gtest/uct/test_p2p_am.cc
@@ -622,7 +622,7 @@ UCT_INSTANTIATE_TEST_CASE(uct_p2p_am_test)
 
 const unsigned uct_p2p_am_misc::RX_MAX_BUFS  = 1024; /* due to hard coded 'grow'
                                                         parameter in uct_ib_iface_recv_mpool_init */
-const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 64;
+const unsigned uct_p2p_am_misc::RX_QUEUE_LEN = 256;
 
 UCS_TEST_SKIP_COND_P(uct_p2p_am_misc, no_rx_buffs,
                      (RUNNING_ON_VALGRIND || m_rx_buf_limit_failed ||


### PR DESCRIPTION
## Why
Make CI pass on new01/new02 machines

## How
1. Ported the following commits:
786f8d4603 UCT/MLX5: Initialize DP fields before creating command QP
d472f26554 UCT/MLX5: Fix dp_ordering logic - needed to disable DDP when no AR
f5f8c388da TEST/RC: Disable DDP when forcing cyclic SRQ
25dbbc8ad0 TEST/UCT/P2P: Increase minimal RX queue length from 64 to 128
30729a96c0 TEST: Skip smi* devices in test scripts
201fad1432 UCT/IB/MLX5: Disable ODP when the device supports DDP
fc59b76351 TEST/GTEST: Skip SMI device for rdmacm tests
402159babb UCT/IB: Skip SMI devices using netlink query
a146329a5e UCP/TEST: Fix failures in max_lanes test when have two IB devices
d09569bf14 TEST/UCT: Increase RX queue length of no-buffers test to 256
1290924460 TEST/TAG: Don't require exact number of lanes with protov1
56d1aed1b UCP/PROTO/MULTI: Allow header be greater than max_frag
1. Fix merge conflicts
1. Partial porting of netlink infrastructure 46f8e6f32