### PR TITLE
UCP/WIREUP: Fix memory corruption when MTU/max_bcopy is small

### DIFF
--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -94,6 +94,23 @@ uct_ep_h ucp_wireup_ep_get_msg_ep(ucp_wireup_ep_t *wireup_ep)
     return wireup_msg_ep;
 }
 
+
+ucp_rsc_index_t ucp_wireup_ep_get_msg_rsc_index(ucp_wireup_ep_t *wireup_ep)
+{
+    ucp_rsc_index_t rsc_index;
+
+    if (ucp_wireup_ep_is_next_ep_active(wireup_ep)) {
+        rsc_index = wireup_ep->super.rsc_index;
+    } else {
+        rsc_index = wireup_ep->aux_rsc_index;
+    }
+
+    ucs_assertv(rsc_index != UCP_NULL_RESOURCE,
+                "ucp_ep=%p wireup_ep=%p aux_ep=%p",
+                wireup_ep->super.ucp_ep, wireup_ep, wireup_ep->aux_ep);
+    return rsc_index;
+}
+
 ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self)
 {
     ucp_request_t *proxy_req = ucs_container_of(self, ucp_request_t, send.uct);

--- a/src/ucp/wireup/wireup_ep.h
+++ b/src/ucp/wireup/wireup_ep.h
@@ -127,6 +127,8 @@ void ucp_wireup_ep_disown(uct_ep_h uct_ep, uct_ep_h owned_ep);
 
 uct_ep_h ucp_wireup_ep_get_msg_ep(ucp_wireup_ep_t *wireup_ep);
 
+ucp_rsc_index_t ucp_wireup_ep_get_msg_rsc_index(ucp_wireup_ep_t *wireup_ep);
+
 ucs_status_t ucp_wireup_ep_progress_pending(uct_pending_req_t *self);
 
 ucp_wireup_ep_t *ucp_wireup_ep(uct_ep_h uct_ep);


### PR DESCRIPTION
## What?
wireup uses UD uct_ep_am_bcopy to send wireup message to the peer, and that message size depends on amount of used devices. It is also limited by MTU/max_bcopy size.
With large number of devices (>15) and small MTU/max_bcopy size (1024) it leads to a memory corruption/hang in release mode, or assertion in debug.

Current solution is to detect this limit in wireup before sending a message, and report an error