### PR TITLE
UCP/RMA/FLUSH: Fix failure in ucp_ep_fence_weak when unflushed_lanes is 0

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -762,8 +762,6 @@ ucs_status_t ucp_ep_fence_weak(ucp_ep_h ep)
 {
     ucp_lane_index_t lane;
 
-    /* TODO: Handle unflushed_lanes == 0 before reaching this function
-     *       as part of optimizing flush */
     ucs_assertv(ucs_is_pow2(ep->ext->unflushed_lanes),
                 "ep=%p unflushed_lanes=0x%" PRIx64, ep,
                 ep->ext->unflushed_lanes);

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -168,8 +168,10 @@ ucp_ep_rma_handle_fence(ucp_ep_h ep, ucp_request_t *req,
 
     /* Apply a fence if EP's sequence is behind worker's */
     if (ucs_unlikely(req->flags & UCP_REQUEST_FLAG_FENCE_REQUIRED)) {
-        if (ucs_likely(
-            ucs_is_pow2_or_zero(ep->ext->unflushed_lanes | lane_map))) {
+        if (ucs_unlikely(ep->ext->unflushed_lanes == 0)) {
+            status = UCS_OK;
+        } else if (ucs_likely(
+            ucs_is_pow2(ep->ext->unflushed_lanes | lane_map))) {
             status = ucp_ep_fence_weak(ep);
         } else {
             status = ucp_ep_fence_strong(ep);


### PR DESCRIPTION
## What?
Fix assertion failure in `ucp_ep_fence_weak()` when `unflushed_lanes` is 0.

## Why?
The function `ucp_ep_fence_weak()` was being called when there were no `unflushed_lanes` to fence, causing an assertion failure.

## How?
Skip fence operation in `ucp_ep_rma_handle_fence()` when unflushed_lanes is 0.

## Before
![image](https://github.com/user-attachments/assets/54bd4b9a-eefd-4115-b7f1-e5de32fd5854)

## After
![image](https://github.com/user-attachments/assets/0a4a9ffe-1821-4e6f-93c4-e04e676f609d)
