### PR TITLE
UCP: Use correct device for cuda-managed memory ppln

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -708,6 +708,31 @@ void ucp_proto_rndv_bulk_query(const ucp_proto_query_params_t *params,
     ucp_proto_multi_query_config(&multi_query_params, attr);
 }
 
+/* If we don't know the system device of the user buffer, unpack the remote key
+ * on the system device that pipeline protocols would use for staging. */
+static UCS_F_ALWAYS_INLINE ucs_sys_device_t
+ucp_proto_rndv_ppln_frag_sys_dev(ucp_context_h context,
+                                 ucs_memory_type_t mem_type,
+                                 ucs_sys_device_t sys_dev)
+{
+    ucs_status_t status;
+    ucp_md_index_t md_index;
+    ucp_memory_info_t mem_info;
+
+    if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+        return sys_dev;
+    }
+
+    status = ucp_mm_get_alloc_md_index(context, mem_type,
+                                       UCS_SYS_DEVICE_ID_UNKNOWN, &md_index,
+                                       &mem_info);
+    if ((status == UCS_OK) && (md_index != UCP_NULL_RESOURCE)) {
+        return mem_info.sys_dev;
+    }
+
+    return UCS_SYS_DEVICE_ID_UNKNOWN;
+}
+
 UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_rndv_send_reply,
                  (worker, req, op_id, op_attr_mask, length, rkey_buffer,
                   rkey_length, sg_count),
@@ -720,6 +745,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_rndv_send_reply,
     ucp_worker_cfg_index_t rkey_cfg_index;
     ucp_proto_select_param_t sel_param;
     ucp_proto_select_t *proto_select;
+    ucs_sys_device_t sys_dev;
     ucs_status_t status;
     ucp_rkey_h rkey;
 
@@ -727,6 +753,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_rndv_send_reply,
                (op_id < UCP_OP_ID_RNDV_LAST));
 
     if (rkey_length > 0) {
+        sys_dev = ucp_proto_rndv_ppln_frag_sys_dev(
+                      worker->context, UCS_MEMORY_TYPE_CUDA,
+                      req->send.state.dt_iter.mem_info.sys_dev);
+
         ucs_assert(rkey_buffer != NULL);
         /* Do not unpack rkeys from MDs with rkey_ptr capability, except
          * rkey_ptr_lane. Examples are: sysv and posix. Such keys, if packed,
@@ -735,8 +765,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_proto_rndv_send_reply,
          */
         status = ucp_ep_rkey_unpack_internal(
                   ep, rkey_buffer, rkey_length, ep_config->key.reachable_md_map,
-                  ep_config->rndv.proto_rndv_rkey_skip_mds,
-                  req->send.state.dt_iter.mem_info.sys_dev, &rkey);
+                  ep_config->rndv.proto_rndv_rkey_skip_mds, sys_dev, &rkey);
         if (status != UCS_OK) {
             goto err;
         }


### PR DESCRIPTION
## What?
When rndv pipeline is used for CUDA-managed memory, rkey received in RTS or RTR must be unpacked with a default sys_dev instead of UNKNOWN_ID. This ensures that CUDA IPC can correctly map/import the handle from the rkey on the appropriate device, matching device where staging buffer was allocated.

Will be tested by #10601 