### PR TITLE
UCT/EFA/SRD: Add pending and control request and response

### DIFF
--- a/src/uct/ib/base/ib_log.c
+++ b/src/uct/ib/base/ib_log.c
@@ -172,7 +172,7 @@ static void uct_ib_dump_wr_opcode(struct ibv_qp *qp, uint64_t wr_id,
 
 static void uct_ib_dump_wr(struct ibv_qp *qp, uct_ib_opcode_t *op,
                            struct ibv_send_wr *wr, struct ibv_ah *ah,
-                           int remote_qpn, char *buf, size_t max)
+                           uint32_t remote_qpn, char *buf, size_t max)
 {
     char *s    = buf;
     char *ends = buf + max;
@@ -208,8 +208,8 @@ static void uct_ib_dump_wr(struct ibv_qp *qp, uct_ib_opcode_t *op,
 static void uct_ib_dump_send_wr(uct_ib_iface_t *iface, struct ibv_qp *qp,
                                 struct ibv_send_wr *wr, int max_sge,
                                 uct_log_data_dump_func_t data_dump,
-                                struct ibv_ah *ah, int remote_qpn, char *buf,
-                                size_t max)
+                                struct ibv_ah *ah, uint32_t remote_qpn,
+                                char *buf, size_t max)
 {
     static uct_ib_opcode_t opcodes[] = {
         [IBV_WR_RDMA_WRITE]           = { "RDMA_WRITE", UCT_IB_OPCODE_FLAG_HAS_RADDR },
@@ -256,7 +256,8 @@ void uct_ib_memlock_limit_msg(ucs_string_buffer_t *message, int sys_errno)
 void __uct_ib_log_post_send_one(const char *file, int line,
                                 const char *function, uct_ib_iface_t *iface,
                                 struct ibv_qp *qp, struct ibv_send_wr *wr,
-                                struct ibv_ah *ah, int remote_qpn, int max_sge,
+                                struct ibv_ah *ah, uint32_t remote_qpn,
+                                int max_sge,
                                 uct_log_data_dump_func_t data_dump_cb)
 {
     char buf[256] = {0};
@@ -272,7 +273,7 @@ void __uct_ib_log_post_send(const char *file, int line, const char *function,
                             uct_log_data_dump_func_t data_dump_cb)
 {
     struct ibv_ah *ah;
-    int remote_qpn;
+    uint32_t remote_qpn;
 
     for (; wr != NULL; wr = wr->next) {
         if (qp->qp_type == IBV_QPT_UD) {

--- a/src/uct/ib/base/ib_log.h
+++ b/src/uct/ib/base/ib_log.h
@@ -74,7 +74,8 @@ void __uct_ib_log_post_send(const char *file, int line, const char *function,
 void __uct_ib_log_post_send_one(const char *file, int line,
                                 const char *function, uct_ib_iface_t *iface,
                                 struct ibv_qp *qp, struct ibv_send_wr *wr,
-                                struct ibv_ah *ah, int remote_qn, int max_sge,
+                                struct ibv_ah *ah, uint32_t remote_qn,
+                                int max_sge,
                                 uct_log_data_dump_func_t data_dump_cb);
 
 void __uct_ib_log_recv_completion(const char *file, int line, const char *function,
@@ -93,6 +94,13 @@ void __uct_ib_log_recv_completion(const char *file, int line, const char *functi
         ucs_log(_level, "%s: %s", ibv_get_device_name((_ibv_context)->device), \
                 ucs_string_buffer_cstr(&_msg)); \
     })
+
+#define uct_ib_log_post_send_one(_iface, _qp, _wr, _ah, _remote_qpn, _max_sge, \
+                                 _dump_cb) \
+    if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \
+        __uct_ib_log_post_send_one(__FILE__, __LINE__, __func__, _iface, _qp, \
+                                   _wr, _ah, _remote_qpn, _max_sge, _dump_cb); \
+    }
 
 #define uct_ib_log_post_send(_iface, _qp, _wr, _max_sge, _dump_cb) \
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE_DATA)) { \

--- a/src/uct/ib/efa/srd/srd_def.h
+++ b/src/uct/ib/efa/srd/srd_def.h
@@ -24,10 +24,32 @@ typedef struct uct_srd_send_desc uct_srd_send_desc_t;
 
 
 typedef struct uct_srd_hdr {
+    uint8_t         id;      /* AM and flags */
     uint64_t        ep_uuid; /* Sender EP's random identifier */
     uct_srd_psn_t   psn;     /* Sender EP's packet sequence number */
-    uint8_t         id;      /* AM and flags */
 } UCS_S_PACKED uct_srd_hdr_t;
+
+
+typedef enum uct_srd_ctl_id {
+    UCT_SRD_CTL_ID_REQ = UCT_AM_ID_MAX,
+    UCT_SRD_CTL_ID_RESP
+} uct_srd_ctl_id_t;
+
+
+typedef struct uct_srd_ctl_hdr {
+    uint8_t         id;      /* Shared with @ref uct_srd_hdr_t::id */
+    uct_ib_uint24_t qpn;     /* Sender qpn */
+    uint64_t        ep_uuid;
+
+    /* packed device address follows */
+} UCS_S_PACKED uct_srd_ctl_hdr_t;
+
+
+typedef struct uct_srd_ctl_op {
+    ucs_queue_elem_t queue; /* Entry in iface tx pending control queue */
+    struct ibv_ah    *ah;
+    uint32_t         remote_qpn;
+} uct_srd_ctl_op_t;
 
 
 typedef struct uct_srd_am_short_hdr {
@@ -65,7 +87,6 @@ struct uct_srd_send_desc {
     uct_unpack_callback_t unpack_cb;
     void                  *unpack_arg;
     size_t                length;
-    uct_srd_hdr_t         hdr[];
 } UCS_V_ALIGNED(UCT_SRD_SEND_DESC_ALIGN);
 
 

--- a/src/uct/ib/efa/srd/srd_ep.h
+++ b/src/uct/ib/efa/srd/srd_ep.h
@@ -11,13 +11,15 @@
 
 
 typedef struct uct_srd_ep {
-    uct_base_ep_t   super;
-    uint64_t        ep_uuid;          /* Random EP identifier */
-    uint32_t        dest_qpn;         /* Remote QP */
-    uint32_t        inflight;         /* Entries outstanding list */
-    struct ibv_ah   *ah;              /* Remote peer */
-    uct_srd_psn_t   psn;              /* Next PSN to send */
-    uint8_t         path_index;
+    uct_base_ep_t       super;
+    uint64_t            ep_uuid;       /* Random EP identifier */
+    uint32_t            dest_qpn;      /* Remote QP */
+    uint32_t            inflight;      /* Entries outstanding list */
+    struct ibv_ah       *ah;           /* Remote peer */
+    int                 ah_added;      /* true if remote has added our AH */
+    uct_srd_psn_t       psn;           /* Next PSN to send */
+    uint8_t             path_index;
+    ucs_arbiter_group_t pending_group; /* Queue of pending requests */
 } uct_srd_ep_t;
 
 
@@ -45,5 +47,13 @@ ucs_status_t uct_srd_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                  uct_completion_t *comp);
 
 void uct_srd_ep_send_op_completion(uct_srd_send_op_t *send_op);
+
+ucs_status_t
+uct_srd_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req, unsigned flags);
+void uct_srd_ep_pending_purge(uct_ep_h ep, uct_pending_purge_callback_t cb,
+                              void *arg);
+ucs_arbiter_cb_result_t
+uct_srd_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
+                      ucs_arbiter_elem_t *elem, void *arg);
 
 #endif

--- a/src/uct/ib/efa/srd/srd_log.c
+++ b/src/uct/ib/efa/srd/srd_log.c
@@ -14,6 +14,28 @@
 #include <uct/ib/base/ib_log.h>
 
 
+const char *uct_srd_ctl_id_to_string(uct_srd_ctl_id_t id)
+{
+    return (id == UCT_SRD_CTL_ID_REQ)  ? "CTL_REQ" :
+           (id == UCT_SRD_CTL_ID_RESP) ? "CTL_RESP" :
+           "UNKNOWN";
+}
+
+static void uct_srd_dump_ctl_hdr(char *p, char *endp, uct_srd_ctl_hdr_t *ctl)
+{
+    ssize_t UCS_V_UNUSED n;
+
+    n = snprintf(p, endp - p, " %s qpn %d ep_uuid %" PRIx64 " ",
+                 uct_srd_ctl_id_to_string(ctl->id),
+                 uct_ib_unpack_uint24(ctl->qpn), ctl->ep_uuid);
+    ucs_assertv((n > 0) && (n < (endp - p)), "n=%zd max=%zu", n, endp - p);
+    p += strlen(p);
+
+    if (ctl->id == UCT_SRD_CTL_ID_REQ) {
+        uct_ib_address_str((uct_ib_address_t*)(ctl + 1), p, endp - p);
+    }
+}
+
 void uct_srd_dump_packet(uct_base_iface_t *iface, uct_am_trace_type_t type,
                          void *data, size_t length, size_t valid_length,
                          char *buffer, size_t max)
@@ -21,21 +43,30 @@ void uct_srd_dump_packet(uct_base_iface_t *iface, uct_am_trace_type_t type,
     uct_srd_hdr_t *hdr = data;
     char *p, *endp;
     int am_id;
+    ssize_t UCS_V_UNUSED n;
 
     p    = buffer;
     endp = buffer + max;
 
-    snprintf(p, endp - p, " ep_uuid 0x%" PRIx64 " psn %u", hdr->ep_uuid,
-             hdr->psn);
+    if ((hdr->id == UCT_SRD_CTL_ID_REQ) || (hdr->id == UCT_SRD_CTL_ID_RESP)) {
+        uct_srd_dump_ctl_hdr(p, endp, (uct_srd_ctl_hdr_t*)hdr);
+        return;
+    }
+
+    n = snprintf(p, endp - p, " ep_uuid 0x%" PRIx64 " psn %u", hdr->ep_uuid,
+                 hdr->psn);
+    ucs_assertv((n > 0) && (n < (endp - p)), "n=%zd max=%zu", n, endp - p);
     p += strlen(p);
 
     if (hdr->id < UCT_AM_ID_MAX) {
         am_id = hdr->id;
-        snprintf(p, endp - p, " am %d ", am_id);
+        n     = snprintf(p, endp - p, " am %d ", am_id);
+        ucs_assertv((n > 0) && (n < (endp - p)), "n=%zd max=%zu", n, endp - p);
         p += strlen(p);
         uct_iface_dump_am(iface, type, am_id, hdr + 1, length - sizeof(*hdr), p,
                           endp - p);
     } else {
-        snprintf(p, endp - p, " id %x", hdr->id);
+        n = snprintf(p, endp - p, " id %x", hdr->id);
+        ucs_assertv((n > 0) && (n < (endp - p)), "n=%zd max=%zu", n, endp - p);
     }
 }

--- a/src/uct/ib/efa/srd/srd_log.h
+++ b/src/uct/ib/efa/srd/srd_log.h
@@ -13,11 +13,15 @@
 
 #include <uct/ib/base/ib_iface.h>
 #include <uct/ib/base/ib_log.h>
+#include <uct/ib/efa/srd/srd_def.h>
 
 
 void uct_srd_dump_packet(uct_base_iface_t *iface, uct_am_trace_type_t type,
                          void *data, size_t length, size_t valid_length,
                          char *buffer, size_t max);
+
+
+const char *uct_srd_ctl_id_to_string(uct_srd_ctl_id_t id);
 
 
 #endif

--- a/test/gtest/uct/ib/test_srd.cc
+++ b/test/gtest/uct/ib/test_srd.cc
@@ -5,6 +5,7 @@
  */
 
 #include <uct/uct_test.h>
+#include <uct/ib/efa/srd/srd_ep.h>
 
 
 // FIXME: Add SRD transport to UCT_TEST_IB_TLS when possible
@@ -40,6 +41,8 @@ protected:
             int      bytes;
             uint64_t hdr;
         } stats = {}, expect = {};
+
+        progress_ctl();
 
         auto counter_func = [](void *arg, void *data, size_t length,
                                unsigned flags) {
@@ -79,9 +82,29 @@ protected:
         EXPECT_EQ(expect.hdr,   stats.hdr);
     }
 
+    void progress_ctl()
+    {
+        while (!((uct_srd_ep_t*)m_e1->ep(0))->ah_added) {
+            short_progress_loop();
+        }
+    }
+
+    int pending_purge(uct_ep_h ep)
+    {
+        int count = 0;
+
+        uct_ep_pending_purge(ep,
+                             [](uct_pending_req_t*, void *arg) {
+                                 (*reinterpret_cast<int*>(arg))++;
+                             },
+                             &count);
+        return count;
+    }
+
     completion                m_comp;
     static constexpr uint64_t m_seed = 0x54321;
 
+    uct_pending_req_t         m_req[3];
     entity *m_e1, *m_e2, *m_e3;
 };
 
@@ -97,7 +120,6 @@ void test_srd::init()
     m_entities.push_back(m_e3);
 
     m_e1->connect_to_iface(0, *m_e2);
-    m_e2->connect_to_iface(0, *m_e1);
     m_e3->connect_to_iface(0, *m_e2);
 }
 
@@ -106,6 +128,8 @@ UCS_TEST_P(test_srd, am_short_outstanding)
     int count       = 40;
     uint64_t header = 0x1234567843210987;
     char payload[]  = "the payload";
+
+    progress_ctl();
 
     while (count-- > 0) {
         ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 31, header++, payload,
@@ -172,6 +196,8 @@ UCS_TEST_P(test_srd, am_zcopy)
 
         return UCS_OK;
     };
+
+    progress_ctl();
 
     ASSERT_UCS_OK(uct_iface_set_am_handler(m_e2->iface(), id, check_func,
                                            dstbuf.ptr(), 0));
@@ -278,6 +304,8 @@ UCS_TEST_P(test_srd, get_zcopy_failure)
         iov[i].count  = 1;
     }
 
+    progress_ctl();
+
     status = uct_ep_get_zcopy(m_e1->ep(0), iov, 1, 0, 0, NULL);
     ASSERT_UCS_STATUS_EQ(UCS_ERR_INVALID_PARAM, status);
     status = uct_ep_get_zcopy(m_e1->ep(0), iov, 2, 0, 0, NULL);
@@ -295,6 +323,8 @@ UCS_TEST_P(test_srd, get_zcopy_destroy_outstanding)
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, dstbuf.ptr(), dstbuf.length(),
                             dstbuf.memh(), 1);
 
+    progress_ctl();
+
     ucs_status_t status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt,
                                            srcbuf.addr(), srcbuf.rkey(),
                                            &m_comp);
@@ -310,6 +340,8 @@ UCS_TEST_P(test_srd, get_zcopy)
     UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, dstbuf.ptr(), dstbuf.length(),
                             dstbuf.memh(), 1);
 
+    progress_ctl();
+
     srcbuf.pattern_fill(m_seed);
     ucs_status_t status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt,
                                            srcbuf.addr(), srcbuf.rkey(),
@@ -323,6 +355,8 @@ UCS_TEST_P(test_srd, get_bcopy)
 {
     mapped_buffer srcbuf(4096, 0ul, *m_e2);
     mapped_buffer dstbuf(4096, 0ul, *m_e1);
+
+    progress_ctl();
 
     srcbuf.pattern_fill(m_seed);
     ucs_status_t status = uct_ep_get_bcopy(m_e1->ep(0),
@@ -341,6 +375,8 @@ UCS_TEST_P(test_srd, get_bcopy_no_resource)
     mapped_buffer srcbuf(4096, 0ul, *m_e2);
     mapped_buffer dstbuf(4096, 0ul, *m_e1);
     ucs_status_t status;
+
+    progress_ctl();
 
     for (i = 0; i < count; i++) {
         status = uct_ep_get_bcopy(m_e1->ep(0), (uct_unpack_callback_t)memcpy,
@@ -362,6 +398,8 @@ UCS_TEST_P(test_srd, am_short_no_resource)
     int i;
     ucs_status_t status;
 
+    progress_ctl();
+
     for (i = 0; i < count; i++) {
         status = uct_ep_am_short(m_e1->ep(0), 30, 0x0, "test", 4);
         if (status != UCS_OK) {
@@ -372,6 +410,101 @@ UCS_TEST_P(test_srd, am_short_no_resource)
     ASSERT_LT(100, i);
     ASSERT_GT(count, i);
     ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, status);
+}
+
+UCS_TEST_P(test_srd, am_short_no_resource_with_pending)
+{
+    uint8_t c = 23;
+
+    m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
+
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE,
+                         uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1));
+
+    /* Can post as CTL_RESP received and pending is drained */
+    progress_ctl();
+    ASSERT_UCS_STATUS_EQ(UCS_OK, uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1));
+}
+
+UCS_TEST_P(test_srd, pending_ok_if_no_resource)
+{
+    uint8_t c = 23;
+    ucs_status_t status;
+
+    progress_ctl();
+
+    auto i = 0;
+    for (; i < 400; i++) {
+        status = uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1);
+        if (status == UCS_ERR_NO_RESOURCE) {
+            break;
+        }
+    }
+
+    ASSERT_LT(0, i);
+    ASSERT_LT(i, 400);
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[1], 0));
+    ASSERT_EQ(2, pending_purge(m_e1->ep(0)));
+}
+
+UCS_TEST_P(test_srd, pending_busy_if_ready_to_send)
+{
+    progress_ctl();
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_BUSY,
+                         uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+}
+
+UCS_TEST_P(test_srd, pending_purge_dispatch)
+{
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[1], 0));
+    ASSERT_EQ(2, pending_purge(m_e1->ep(0)));
+}
+
+UCS_TEST_P(test_srd, pending_dispatch)
+{
+    static int req_count;
+
+    req_count = 0;
+    for (auto i = 0; i < 3; i++) {
+        m_req[i].func = [](uct_pending_req_t*) {
+            req_count++;
+            if (req_count == 1) {
+                return UCS_ERR_NO_RESOURCE;
+            } else if (req_count == 2) {
+                return UCS_INPROGRESS;
+            } else {
+                return UCS_OK;
+            }
+        };
+
+        ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[i], 0));
+    }
+
+    wait_for_value(&req_count, 5, true);
+    ASSERT_EQ(0, pending_purge(m_e1->ep(0)));
+}
+
+UCS_TEST_P(test_srd, get_bcopy_no_resource_ah)
+{
+    mapped_buffer srcbuf(4096, 0ul, *m_e2);
+    mapped_buffer dstbuf(4096, 0ul, *m_e1);
+    ucs_status_t status;
+
+    status = uct_ep_get_bcopy(m_e1->ep(0), (uct_unpack_callback_t)memcpy,
+                              dstbuf.ptr(), dstbuf.length(), srcbuf.addr(),
+                              srcbuf.rkey(), NULL);
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, status);
+}
+
+UCS_TEST_P(test_srd, destroy_ep_before_ctl_resp)
+{
+    m_e1->connect_to_iface(1, *m_e2);
+    m_e1->destroy_ep(1);
+
+    progress_ctl();
 }
 
 UCT_INSTANTIATE_SRD_TEST_CASE(test_srd)


### PR DESCRIPTION
## What?
Add pending management and control message exchange to remotely add AH, before posting RMA operations.

## How?
Tracking remote AH state on iface or MD could cause issues as there could be multiple MD (protection domain) opened on the same remote HCA, and while locally iface or MD could remain, the remote entities could have been released and reopened with same QP id, making it difficult to identify if sending another control request is needed.

### Steps
All posts are anyways heavily reordered so:
1. Only one pending queue for an endpoint
2. We put RMA on pending if confirmation has not been received, as they cannot be posted
3. We put AM on pending if our pending is not empty (we could probably simply post but this could cause prio issues wrt RMA)
4. We allow the sending of AM if pending is empty, even when still expecting confirmation of remote AH add
5. We can only start dequeuing pending after receiving confirmation of remote AH add, since we do not know which type of request is in the queue