### PR TITLE
UCT/CUDA/CUDA_COPY: Changed log level in mem_free.

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -616,7 +616,8 @@ static ucs_status_t uct_cuda_copy_mem_free(uct_md_h md, uct_mem_h memh)
     if (alloc_handle->is_vmm) {
         status = uct_cuda_copy_mem_release_fabric(alloc_handle);
     } else {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemFree(alloc_handle->ptr));
+        UCT_CUDADRV_FUNC(cuMemFree(alloc_handle->ptr), UCS_LOG_LEVEL_DIAG);
+        status = UCS_OK;
     }
 
     ucs_free(alloc_handle);


### PR DESCRIPTION
## What?
Changed log level used in `uct_cuda_copy_mem_free`. `DIAG` log level is enough for the purpose of the function.

## Why?
The memory can be implicitly destroyed using CUDA Driver/Runtime API: e.g. `cuDevicePrimaryCtxRelease`, `cuDevicePrimaryCtxReset`, `cudaDeviceReset`. The following error may be observed during the resources clean up:
```
cuda_copy_md.c:610  UCX  ERROR cuMemFree_v2(alloc_handle->ptr) failed: invalid argument
      ucp_mm.c:460  UCX  WARN  failed to free: Input/output error
```
