### PR TITLE
UCT/CUDA: Set CUDA sys_device to UNKNOWN to avoid topo BW cap

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -36,24 +36,8 @@ uct_cuda_base_query_devices_common(
         uct_md_h md, uct_device_type_t dev_type,
         uct_tl_device_resource_t **tl_devices_p, unsigned *num_tl_devices_p)
 {
-    ucs_sys_device_t sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
-    CUdevice cuda_device;
-    ucs_status_t status;
-
-    if (uct_cuda_base_is_context_active()) {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&cuda_device));
-        if (status != UCS_OK) {
-            return status;
-        }
-
-        uct_cuda_base_get_sys_dev(cuda_device, &sys_device);
-    } else {
-        ucs_debug("set cuda sys_device to `unknown` as no context is"
-                  " currently active");
-    }
-
     return uct_single_device_resource(md, UCT_CUDA_DEV_NAME, dev_type,
-                                      sys_device, tl_devices_p,
+                                      UCS_SYS_DEVICE_ID_UNKNOWN, tl_devices_p,
                                       num_tl_devices_p);
 }
 


### PR DESCRIPTION
## What?
Set CUDA sys_devices to be UCS_SYS_DEVICE_ID_UNKNOWN, so that their evaluated performance is not capped by topology sysfs.

## Why?
During protocol selection we evaluate performance of cuda_ipc by checking topology distance between source and target GPU. When both GPUs (with NVLink) are on the same NUMA node, then UCP caps BW to 17000MBps. Due to this BW reduce, put_zopy over IB protocol is selected by UCX rather than cuda_ipc, which leads to significant performance degradation.

## How?
One way of fixing this issue is to set CUDA sys_device to UCS_SYS_DEVICE_ID_UNKNOWN, which essentially disables topology lookup for perf evaluation

## Testing
This change has a negative side effect on inter-node performance on ISR1.
```
BEFORE PLS: not optimal lanes, BW on 20k: 9181 MBps
130..779479 | zero-copy read from remote  | rc_mlx5/mlx5_0:1 50% on path0 and 50% on path1

PLS: optimal lanes, BW on 20k: 10000 MBps
244..inf | zero-copy read from remote | 74% on rc_mlx5/mlx5_0:1/path0 and 26% on rc_mlx5/mlx5_1:1/path0

WITH THIS FIX: BW on 20k: 6542 MBps
130..144826 | zero-copy read from remote | 50% on rc_mlx5/mlx5_1:1/path0 and 50% on rc_mlx5/mlx5_2:1/path0