### PR TITLE
UCP/RMA/FLUSH: Reduce branches in EP based fence

### DIFF
--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -775,6 +775,10 @@ ucs_status_t ucp_ep_fence_strong(ucp_ep_h ep)
     ucs_status_t status;
     void *request;
 
+    ucs_assertv(ep->ext->unflushed_lanes != 0,
+                "ep=%p unflushed_lanes=0x%" PRIx64, ep,
+                ep->ext->unflushed_lanes);
+
     request = ucp_ep_flush_internal(ep, 0, &ucp_request_null_param, NULL,
                                     ucp_ep_flushed_callback, "ep_fence_strong",
                                     UCT_FLUSH_FLAG_REMOTE);

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -171,7 +171,7 @@ ucp_ep_rma_handle_fence(ucp_ep_h ep, ucp_request_t *req,
         if (ucs_unlikely(ep->ext->unflushed_lanes == 0)) {
             status = UCS_OK;
         } else if (ucs_likely(
-            ucs_is_pow2(ep->ext->unflushed_lanes | lane_map))) {
+            ucs_is_pow2_or_zero(ep->ext->unflushed_lanes | lane_map))) {
             status = ucp_ep_fence_weak(ep);
         } else {
             status = ucp_ep_fence_strong(ep);


### PR DESCRIPTION
## What?
- [x] Optimize fence handling by reducing code branches in `ucp_ep_rma_handle_fence()`
- [x] Add assertion check for unflushed lanes = 0 in strong fence.
- [x] Add test cases that reproduces the original failure that was found by verification.

## Why?
Following https://github.com/openucx/ucx/pull/10602#discussion_r2028268723

## How?
Reduce branching in `ucp_ep_rma_handle_fence()`, by using `ucs_is_pow2_or_zero()` instead of `ucs_is_pow2()`, which is less branches, and because unflushed lanes isn't 0, this swap is valid.
The test case reproduces a case where unflushed lanes is 0 for both weak and strong fences.