### PR TITLE
GTEST/UCT: Fix pending_add test

### DIFF
--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -619,16 +619,14 @@ UCS_TEST_SKIP_COND_P(test_uct_stats, pending_add,
     EXPECT_EQ(UCS_ERR_BUSY, uct_ep_pending_add(sender().ep(0), &p_reqs[0], 0));
     EXPECT_STAT(sender, uct_ep, UCT_EP_STAT_PENDING, 0UL);
 
-    // Check that counter gets increased on every successful pending_add returns NOT_OK
+    // Make sure there is no TX resource
     fill_tx_q(0);
-
-    UCT_TEST_CALL_AND_TRY_AGAIN(
-        uct_ep_am_bcopy(sender_ep(), 0, mapped_buffer::pack,
-                        lbuf, 0), len);
+    len = uct_ep_am_bcopy(sender_ep(), 0, mapped_buffer::pack, lbuf, 0);
     if (len == (ssize_t)lbuf->length()) {
         UCS_TEST_SKIP_R("Can't add to pending");
     }
 
+    // Check that counter gets increased on every successful pending_add
     for (size_t i = 0; i < num_reqs; ++i) {
         p_reqs[i].func = NULL;
         EXPECT_UCS_OK(uct_ep_pending_add(sender().ep(0), &p_reqs[i], 0));


### PR DESCRIPTION
## What?
Fix always skipped pending add statistics tests.

### Before
```
[ RUN      ] rc_mlx5/test_uct_stats.pending_add/0 <rc_mlx5/mlx5_0:1>
[     SKIP ] (Can't add to pending)
[       OK ] rc_mlx5/test_uct_stats.pending_add/0 (42 ms)
```
### After
```
[ RUN      ] rc_mlx5/test_uct_stats.pending_add/0 <rc_mlx5/mlx5_0:1>
[       OK ] rc_mlx5/test_uct_stats.pending_add/0 (42 ms)
```