### PR TITLE
UCP/GTEST: Do not assert when checking proto v1 rma protocol

### DIFF
--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -388,8 +388,6 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
                 EXPECT_EQ(&ucp_rma_sw_proto,
                           UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index));
             } else {
-                ucs_assert(&ucp_rma_basic_proto ==
-                           UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index));
                 EXPECT_EQ(&ucp_rma_basic_proto,
                           UCP_RKEY_RMA_PROTO(rkey->cache.rma_proto_index));
             }


### PR DESCRIPTION
## What?
On protov1, `ucp_rma_basic_proto` can only be selected when both PUT and GET operations are available.