### PR TITLE
UCT/IB/RC: Adapt EP address size without flush_rkey

### DIFF
--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -591,7 +591,7 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
 
     rc_addr->super.flags = 0;
     uct_ib_pack_uint24(rc_addr->super.qp_num, ep->qp->qp_num);
-    if (uct_ib_md_is_flush_rkey_valid(md->flush_rkey)) {
+    if (uct_rc_iface_flush_rkey_enabled(&iface->super)) {
         rc_addr->super.flags  |= UCT_RC_VERBS_ADDR_HAS_ATOMIC_MR;
         rc_addr->atomic_mr_id  = uct_ib_md_get_atomic_mr_id(md);
         rc_addr->flush_rkey_hi = md->flush_rkey >> 16;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -218,7 +218,6 @@ uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_rc_verbs_iface_t);
-    uct_ib_md_t *md             = uct_ib_iface_md(&iface->super.super);
     ucs_status_t status;
 
     status = uct_rc_iface_query(&iface->super, iface_attr,
@@ -238,7 +237,7 @@ uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     /* Software overhead */
     iface_attr->overhead = UCT_RC_VERBS_IFACE_OVERHEAD;
 
-    iface_attr->ep_addr_len = uct_ib_md_is_flush_rkey_valid(md->flush_rkey) ?
+    iface_attr->ep_addr_len = uct_rc_iface_flush_rkey_enabled(&iface->super) ?
                                       sizeof(uct_rc_verbs_ep_flush_addr_t) :
                                       sizeof(uct_rc_verbs_ep_addr_t);
 

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -207,7 +207,7 @@ UCS_TEST_P(test_rc_iface_address, size_no_flush_remote)
     map_size_t sizes = {
         {"rc_mlx5", {7, 1}},
         {"dc_mlx5", {0, 5}},
-        {"rc_verbs", {7, 0}},
+        {"rc_verbs", {4, 0}},
         {"gga_mlx5", {7, 8}},
     };
     check_sizes(m_entity, sizes);


### PR DESCRIPTION
## What?
When md does not support flush_rkey, rc verbs already returns reduced size. This PR generalizes that behavior by checking iface remote flush support, which matches what is done for rc_x and dc transports.

When unpacking address, the flag `UCT_RC_VERBS_ADDR_HAS_ATOMIC_MR` is gating the access to the extra 3 bytes, so this should not impact wire compatibility. Also it is assumed symmetric iface FLUSH_REMOTE configuration.