### PR TITLE
CI: Add CUDA 12.9 support on Ubuntu 24.04

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -36,7 +36,7 @@ jobs:
           artifact_name: $(POSTFIX)-ubuntu22.04-mofed5-cuda12-${{ parameters.arch }}.tar.bz2
         ubuntu24_cuda12_${{ parameters.arch }}:
           build_container: ubuntu24_cuda12_${{ parameters.arch }}
-          artifact_name: $(POSTFIX)-ubuntu24.04-mofed5-cuda12-${{ parameters.arch }}.tar.bz2
+          artifact_name: $(POSTFIX)-ubuntu24.04-mofed24-cuda12-${{ parameters.arch }}.tar.bz2
         # x86 only
         ${{ if eq(parameters.arch, 'x86_64') }}:
           centos7_cuda11_${{ parameters.arch }}:

--- a/buildlib/pr/cuda/cuda.yml
+++ b/buildlib/pr/cuda/cuda.yml
@@ -92,6 +92,8 @@ jobs:
           CONTAINER: ubuntu22_cuda_12_0
         ubuntu22_cuda_12_1:
           CONTAINER: ubuntu22_cuda_12_1
+        ubuntu24_cuda_12_9:
+          CONTAINER: ubuntu24_cuda_12_9
 
     container: $[ variables['CONTAINER'] ]
     timeoutInMinutes: 35

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -186,6 +186,9 @@ resources:
     - container: centos10stream
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/centos10stream/builder:inbox
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu24_cuda_12_9
+      image: nvidia/cuda:12.9.0-devel-ubuntu24.04
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
 
 stages:
   - stage: Codestyle


### PR DESCRIPTION
## What?
Extend CI to cover CUDA 12.9 on Ubuntu 24.04
Fix the MOFED version in artifact naming for Ubuntu 24.04 builds.

## Why?
- Keep pace with latest CUDA releases (12.9) to ensure UCX compatibility with modern GPU environments
- Fix incorrect MOFED version in artifact naming (changing from mofed5 to mofed24) to reflect the components used in Ubuntu 24.04 builds accurately
- Enhance CI testing coverage by adding tests for the newest CUDA toolkit on the latest Ubuntu LTS release

## How?
The implementation adds:
1. A new container definition using the official NVIDIA CUDA 12.9 image for Ubuntu 24.04
2. Configuration for the CUDA-specific test pipeline to include the new environment
3. A fix for artifact naming to use the correct MOFED version

Changes are structured as two focused commits to separate the artifact naming fix from the feature addition.