### PR TITLE
UCT/EFA/SRD: Add flush and fence, enable for UCP.

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -602,13 +602,14 @@ static ucs_config_field_t ucp_config_table[] = {
    " - sm/shm  : all shared memory transports (mm, cma, knem).\n"
    " - mm      : shared memory transports - only memory mappers.\n"
    " - ugni    : ugni_smsg and ugni_rdma (uses ugni_udt for bootstrap).\n"
-   " - ib      : all infiniband transports (rc/rc_mlx5, ud/ud_mlx5, dc_mlx5).\n"
+   " - ib      : all infiniband transports (rc/rc_mlx5, ud/ud_mlx5, dc_mlx5, srd).\n"
    " - rc_v    : rc verbs (uses ud for bootstrap).\n"
    " - rc_x    : rc with accelerated verbs (uses ud_mlx5 for bootstrap).\n"
    " - rc      : rc_v and rc_x (preferably if available).\n"
    " - ud_v    : ud verbs.\n"
    " - ud_x    : ud with accelerated verbs.\n"
    " - ud      : ud_v and ud_x (preferably if available).\n"
+   " - srd     : EFA srd reliable transport.\n"
    " - dc/dc_x : dc with accelerated verbs.\n"
    " - tcp     : sockets over TCP/IP.\n"
    " - cuda    : CUDA (NVIDIA GPU) memory support.\n"
@@ -690,7 +691,8 @@ static ucp_tl_alias_t ucp_tl_aliases[] = {
   { "sm",    { "posix", "sysv", "xpmem", "knem", "cma", NULL } },
   { "shm",   { "posix", "sysv", "xpmem", "knem", "cma", NULL } },
   { "ib",    { "rc_verbs", "ud_verbs", "rc_mlx5", "ud_mlx5", "dc_mlx5",
-               "gga_mlx5", UCP_TL_AUX("ud_mlx5"), UCP_TL_AUX("ud_verbs"), NULL } },
+               "gga_mlx5", UCP_TL_AUX("ud_mlx5"), UCP_TL_AUX("ud_verbs"),
+               "srd", NULL } },
   { "ud_v",  { "ud_verbs", NULL } },
   { "ud_x",  { "ud_mlx5", NULL } },
   { "ud",    { "ud_mlx5", "ud_verbs", NULL } },

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -660,11 +660,17 @@ uint16_t uct_ib_iface_resolve_remote_flid(uct_ib_iface_t *iface,
     uct_ib_iface_is_roce(_iface) ? "RoCE" : "IB"
 
 
-#define UCT_IB_IFACE_VERBS_COMPLETION_ERR(_type, _iface, _i,  _wc) \
-    ucs_fatal("%s completion[%d] with error on %s/%p: %s, vendor_err 0x%x wr_id 0x%lx", \
-              _type, _i, uct_ib_device_name(uct_ib_iface_device(_iface)), _iface, \
-              uct_ib_wc_status_str(_wc[_i].status), _wc[_i].vendor_err, \
-              _wc[_i].wr_id);
+#define UCT_IB_IFACE_VERBS_COMPLETION_LOG(_log_lvl, _type, _iface, _i, _wc) \
+    ucs_log(_log_lvl, \
+            "%s completion[%d] with error on %s/%p: %s," \
+            " vendor_err 0x%x wr_id 0x%lx", \
+            _type, _i, uct_ib_device_name(uct_ib_iface_device(_iface)), \
+            _iface, uct_ib_wc_status_str(_wc[_i].status), _wc[_i].vendor_err, \
+            _wc[_i].wr_id);
+
+#define UCT_IB_IFACE_VERBS_COMPLETION_ERR(_type, _iface, _i, _wc) \
+    UCT_IB_IFACE_VERBS_COMPLETION_LOG(UCS_LOG_LEVEL_FATAL, _type, _iface, _i, \
+                                      _wc)
 
 #define UCT_IB_IFACE_VERBS_FOREACH_RXWQE(_iface, _i, _hdr, _wc, _wc_count) \
     for (_i = 0; _i < _wc_count && ({ \

--- a/src/uct/ib/efa/srd/srd_ep.c
+++ b/src/uct/ib/efa/srd/srd_ep.c
@@ -15,6 +15,39 @@
 #include <uct/ib/base/ib_log.h>
 
 
+int uct_srd_ep_is_connected(const uct_ep_h tl_ep,
+                            const uct_ep_is_connected_params_t *params)
+{
+    uct_srd_ep_t *ep                    = ucs_derived_of(tl_ep, uct_srd_ep_t);
+    uct_ib_iface_t *ib_iface            = ucs_derived_of(tl_ep->iface,
+                                                         uct_ib_iface_t);
+    const uct_ib_address_t *ib_addr     = (const uct_ib_address_t*)
+                                                  params->device_addr;
+    const uct_srd_iface_addr_t *if_addr = (const uct_srd_iface_addr_t*)
+                                                  params->iface_addr;
+    struct ibv_ah_attr ah_attr;
+    struct ibv_ah *ah;
+    enum ibv_mtu path_mtu;
+    ucs_status_t status;
+
+    UCT_EP_IS_CONNECTED_CHECK_DEV_IFACE_ADDRS(params);
+
+    if (ep->dest_qpn != uct_ib_unpack_uint24(if_addr->qp_num)) {
+        return 0;
+    }
+
+    uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, ep->path_index,
+                                        &ah_attr, &path_mtu);
+
+    status = uct_ib_device_get_ah_cached(uct_ib_iface_device(ib_iface),
+                                         &ah_attr, &ah);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return ah == ep->ah;
+}
+
 static UCS_CLASS_INIT_FUNC(uct_srd_ep_t, const uct_ep_params_t *params)
 {
     uct_srd_iface_t *iface              = ucs_derived_of(params->iface,
@@ -36,11 +69,11 @@ static UCS_CLASS_INIT_FUNC(uct_srd_ep_t, const uct_ep_params_t *params)
     self->ep_uuid    = ucs_generate_uuid((uintptr_t)self);
     self->path_index = UCT_EP_PARAMS_GET_PATH_INDEX(params);
     self->psn        = UCT_SRD_INITIAL_PSN;
-    self->inflight   = 0;
-    self->ah_added   = 0;
+    self->flags      = 0;
     self->dest_qpn   = uct_ib_unpack_uint24(if_addr->qp_num);
 
     ucs_arbiter_group_init(&self->pending_group);
+    ucs_list_head_init(&self->outstanding_list);
 
     uct_ib_iface_fill_ah_attr_from_addr(&iface->super, ib_addr,
                                         self->path_index, &ah_attr, &path_mtu);
@@ -78,36 +111,112 @@ err_arb_cleanup:
     return status;
 }
 
+static void uct_srd_ep_send_op_user_completion(uct_srd_send_op_t *send_op,
+                                               ucs_status_t status)
+{
+    if (send_op->user_comp != NULL) {
+        uct_invoke_completion(send_op->user_comp, status);
+    }
+}
+
+static void uct_srd_ep_send_op_flush_completion(uct_srd_send_op_t *send_op,
+                                                ucs_status_t status)
+{
+    uct_srd_ep_send_op_user_completion(send_op, status);
+}
+
 void uct_srd_ep_send_op_completion(uct_srd_send_op_t *send_op)
 {
-    if (send_op->ep != NULL) {
-        send_op->ep->inflight--;
-        send_op->comp_cb(send_op, UCS_OK);
-    }
+    uct_srd_ep_t *ep = send_op->ep;
+    uct_srd_send_op_t *flush_op;
+    ucs_status_t comp_status;
+    uct_srd_iface_t *iface;
 
     ucs_list_del(&send_op->list);
+
+    if (ep != NULL) {
+        comp_status = (ep->flags & UCT_SRD_EP_FLAG_CANCELED)?
+                      UCS_ERR_CANCELED : UCS_OK;
+
+        send_op->comp_cb(send_op, comp_status);
+
+        /* Trigger all front line flush completions */
+        while (!ucs_list_is_empty(&ep->outstanding_list)) {
+            flush_op = ucs_list_head(&ep->outstanding_list, uct_srd_send_op_t,
+                                     list);
+
+            ucs_assertv(ep == flush_op->ep, "ep=%p send_op=%p send_op_ep=%p",
+                        ep, send_op, send_op->ep);
+
+            if (flush_op->comp_cb != uct_srd_ep_send_op_flush_completion) {
+                break; /* Not a flush operation */
+            }
+
+            /*
+             * Flush(CANCEL) with see itself reported as CANCEL. Flush()
+             * followed immediately by Flush(CANCEL) will both be reported as
+             * CANCEL.
+             */
+            ucs_list_del(&flush_op->list);
+            flush_op->comp_cb(flush_op, comp_status);
+            ucs_mpool_put(flush_op);
+        }
+
+        if ((ep->flags & UCT_SRD_EP_FLAG_IFACE_FENCE) &&
+            ucs_list_is_empty(&ep->outstanding_list)) {
+            iface = ucs_derived_of(ep->super.super.iface, uct_srd_iface_t);
+            iface->tx.in_fence--;
+            ep->flags &= ~UCT_SRD_EP_FLAG_IFACE_FENCE;
+        }
+    }
+
     ucs_mpool_put(send_op);
 }
 
-static void uct_srd_ep_send_op_purge(uct_srd_ep_t *ep)
+void uct_srd_ep_send_op_purge(uct_srd_ep_t *ep)
 {
     uct_srd_iface_t *iface = ucs_derived_of(ep->super.super.iface,
                                             uct_srd_iface_t);
-    uct_srd_send_op_t *send_op;
+    uct_srd_send_op_t *send_op, *next;
 
-    ucs_list_for_each(send_op, &iface->tx.outstanding_list, list) {
-        if (send_op->ep == ep) {
-            /*
-             * Make ep invalid, as ibv_poll_cq() will return this
-             * send_op after it has been released.
-             */
-            send_op->comp_cb(send_op, UCS_ERR_CANCELED);
+    ucs_list_for_each_safe(send_op, next, &ep->outstanding_list, list) {
+        ucs_assertv(send_op->ep == ep, "send_op_ep=%p ep=%p", send_op->ep, ep);
+
+        /*
+         * Make ep invalid, as ibv_poll_cq() will return this
+         * send_op after it has been released.
+         */
+        send_op->comp_cb(send_op, UCS_ERR_CANCELED);
+
+        /*
+         * Destroy flush operation right away as ibv_poll_cq() will not return
+         * a reference to the corresponding send_op.
+         */
+        if (send_op->comp_cb == uct_srd_ep_send_op_flush_completion) {
+            ucs_list_del(&send_op->list);
+            ucs_mpool_put(send_op);
+        } else {
             send_op->ep = NULL;
-            if (--ep->inflight == 0) {
-                break;
-            }
         }
     }
+
+    ucs_list_splice_tail(&iface->tx.op_list, &ep->outstanding_list);
+    ucs_list_head_init(&ep->outstanding_list);
+    if (ep->flags & UCT_SRD_EP_FLAG_IFACE_FENCE) {
+        iface->tx.in_fence--;
+        ep->flags &= ~UCT_SRD_EP_FLAG_IFACE_FENCE;
+    }
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_srd_ep_can_tx(uct_srd_ep_t *ep, uct_srd_iface_t *iface)
+{
+    return (ucs_likely(ep->flags & UCT_SRD_EP_FLAG_AH_ADDED) ||
+            !(ep->flags & UCT_SRD_EP_FLAG_RMA)) &&
+           uct_srd_iface_can_tx(iface) &&
+           (iface->tx.in_fence == 0) &&
+           (!(ep->flags & UCT_SRD_EP_FLAG_FENCE) ||
+             ucs_list_is_empty(&ep->outstanding_list));
 }
 
 ucs_status_t
@@ -116,17 +225,18 @@ uct_srd_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *req, unsigned flags)
     uct_srd_ep_t *ep       = ucs_derived_of(tl_ep, uct_srd_ep_t);
     uct_srd_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_srd_iface_t);
 
-    if (ep->ah_added && uct_srd_iface_can_tx(iface)) {
+    if (uct_srd_ep_can_tx(ep, iface)) {
         return UCS_ERR_BUSY;
     }
 
     uct_pending_req_arb_group_push(&ep->pending_group, req);
-    if (ucs_likely(ep->ah_added)) {
+    if (ucs_likely(ep->flags & UCT_SRD_EP_FLAG_AH_ADDED)) {
         ucs_arbiter_group_schedule(&iface->tx.pending_q, &ep->pending_group);
     }
 
     ucs_trace_data("iface=%p ep=%p: added pending req=%p psn=%u ah_added=%d",
-                   iface, ep, req, ep->psn, ep->ah_added);
+                   iface, ep, req, ep->psn,
+                   !!(ep->flags & UCT_SRD_EP_FLAG_AH_ADDED));
     UCT_TL_EP_STAT_PEND(&ep->super);
     return UCS_OK;
 }
@@ -142,11 +252,11 @@ uct_srd_ep_do_pending(ucs_arbiter_t *arbiter, ucs_arbiter_group_t *group,
     uct_pending_req_t *req = ucs_container_of(elem, uct_pending_req_t, priv);
     ucs_status_t status;
 
-    if (!ep->ah_added) {
-        return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
-    }
+    if (!uct_srd_ep_can_tx(ep, iface)) {
+        if (ucs_unlikely(!(ep->flags & UCT_SRD_EP_FLAG_AH_ADDED))) {
+            return UCS_ARBITER_CB_RESULT_DESCHED_GROUP;
+        }
 
-    if (!uct_srd_iface_can_tx(iface)) {
         return UCS_ARBITER_CB_RESULT_STOP;
     }
 
@@ -206,16 +316,9 @@ static UCS_CLASS_CLEANUP_FUNC(uct_srd_ep_t)
 
     ucs_trace_func("");
 
-    if (self->inflight != 0) {
-        uct_srd_ep_send_op_purge(self);
-        if (ucs_unlikely(self->inflight != 0)) {
-            ucs_warn("iface=%p ep=%p failed to complete %u send operations",
-                     iface, self, self->inflight);
-        }
-    }
-
-    uct_srd_iface_remove_ep(iface, self);
+    uct_srd_ep_send_op_purge(self);
     uct_srd_ep_pending_purge(&self->super.super, NULL, NULL);
+    uct_srd_iface_remove_ep(iface, self);
     ucs_arbiter_group_cleanup(&self->pending_group);
 }
 
@@ -223,11 +326,13 @@ UCS_CLASS_DEFINE(uct_srd_ep_t, uct_base_ep_t);
 UCS_CLASS_DEFINE_NEW_FUNC(uct_srd_ep_t, uct_ep_t, const uct_ep_params_t*);
 UCS_CLASS_DEFINE_DELETE_FUNC(uct_srd_ep_t, uct_ep_t);
 
-static UCS_F_ALWAYS_INLINE void
-uct_srd_ep_posted(uct_srd_iface_t *iface, uct_srd_ep_t *ep)
+static UCS_F_ALWAYS_INLINE void uct_srd_ep_posted(uct_srd_iface_t *iface,
+                                                  uct_srd_ep_t *ep,
+                                                  uct_srd_send_op_t *send_op)
 {
     iface->tx.available--;
-    ep->inflight++;
+    ucs_list_add_tail(&ep->outstanding_list, &send_op->list);
+    ep->flags &= ~UCT_SRD_EP_FLAG_FENCE;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -239,12 +344,15 @@ uct_srd_ep_hdr_set(const uct_srd_ep_t *ep, uct_srd_hdr_t *neth, uint8_t id)
 }
 
 #define UCT_SRD_CHECK_RES_OR_RETURN(_ep, _iface) \
-    if (!(_ep)->ah_added || !uct_srd_iface_can_tx(_iface)) { \
+    if (!uct_srd_ep_can_tx(_ep, _iface)) { \
         UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, UCT_EP_STAT_NO_RES, 1); \
         return UCS_ERR_NO_RESOURCE; \
     } \
     uct_srd_iface_check_pending(_iface, &(_ep)->pending_group);
 
+#define UCT_SRD_CHECK_RMA_RES_OR_RETURN(_ep, _iface) \
+    (_ep)->flags |= UCT_SRD_EP_FLAG_RMA; \
+    UCT_SRD_CHECK_RES_OR_RETURN(_ep, _iface)
 
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_srd_ep_am_short_prepare(
         uct_srd_iface_t *iface, uct_srd_ep_t *ep, uint8_t id, size_t am_length)
@@ -277,9 +385,8 @@ uct_srd_ep_post_send(uct_srd_iface_t *iface, uct_srd_ep_t *ep,
     uct_srd_send_op_t *send_op = (uct_srd_send_op_t*)wr->wr_id;
 
     uct_srd_iface_post_send(iface, ep->ah, ep->dest_qpn, wr, send_flags);
-    uct_srd_ep_posted(iface, ep);
     ep->psn++;
-    ucs_list_add_tail(&iface->tx.outstanding_list, &send_op->list);
+    uct_srd_ep_posted(iface, ep, send_op);
 }
 
 static UCS_F_ALWAYS_INLINE void uct_srd_ep_am_short_post(uct_srd_iface_t *iface,
@@ -338,14 +445,6 @@ ucs_status_t uct_srd_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
 
     uct_srd_ep_am_short_post(iface, ep, length);
     return UCS_OK;
-}
-
-static void uct_srd_ep_send_op_user_completion(uct_srd_send_op_t *send_op,
-                                               ucs_status_t status)
-{
-    if (send_op->user_comp != NULL) {
-        uct_invoke_completion(send_op->user_comp, status);
-    }
 }
 
 static void uct_srd_ep_send_desc_tx(uct_srd_iface_t *iface, uct_srd_ep_t *ep,
@@ -472,8 +571,7 @@ uct_srd_ep_post_rma(uct_srd_iface_t *iface, uct_srd_ep_t *ep,
         return UCS_ERR_IO_ERROR;
     }
 
-    uct_srd_ep_posted(iface, ep);
-    ucs_list_add_tail(&iface->tx.outstanding_list, &send_op->list);
+    uct_srd_ep_posted(iface, ep, send_op);
     return UCS_INPROGRESS;
 #else
     ucs_mpool_put(send_op);
@@ -497,7 +595,7 @@ ucs_status_t uct_srd_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 
     UCT_CHECK_LENGTH(length, iface->super.config.max_inl_cqe[UCT_IB_DIR_TX] + 1,
                      iface->config.max_get_zcopy, "get_zcopy");
-    UCT_SRD_CHECK_RES_OR_RETURN(ep, iface);
+    UCT_SRD_CHECK_RMA_RES_OR_RETURN(ep, iface);
 
     send_op = ucs_mpool_get(&iface->tx.send_op_mp);
     if (send_op == NULL) {
@@ -541,7 +639,7 @@ ucs_status_t uct_srd_ep_get_bcopy(uct_ep_h tl_ep,
     ucs_status_t status;
 
     UCT_CHECK_LENGTH(length, 0, iface->config.max_get_bcopy, "get_bcopy");
-    UCT_SRD_CHECK_RES_OR_RETURN(ep, iface);
+    UCT_SRD_CHECK_RMA_RES_OR_RETURN(ep, iface);
 
     desc = uct_srd_iface_get_send_desc(iface);
     if (desc == NULL) {
@@ -566,4 +664,57 @@ ucs_status_t uct_srd_ep_get_bcopy(uct_ep_h tl_ep,
     }
 
     return status;
+}
+
+ucs_status_t uct_srd_ep_fence(uct_ep_h tl_ep, unsigned flags)
+{
+    uct_srd_ep_t *ep = ucs_derived_of(tl_ep, uct_srd_ep_t);
+
+    ep->flags |= UCT_SRD_EP_FLAG_FENCE;
+    UCT_TL_EP_STAT_FENCE(&ep->super);
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_srd_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
+{
+    uct_srd_ep_t *ep       = ucs_derived_of(tl_ep, uct_srd_ep_t);
+    uct_srd_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                            uct_srd_iface_t);
+    uct_srd_send_op_t *send_op;
+
+    if (ucs_unlikely(flags & UCT_FLUSH_FLAG_CANCEL)) {
+        /* Empty the pending */
+        uct_ep_pending_purge(tl_ep, NULL, 0);
+
+        /*
+         * Cancel the endpoint, but flush send_op will still wait for existing
+         * outstanding operations to complete, as the device could be still be
+         * using user resources (zcopy send or receive).
+         */
+        ep->flags |= UCT_SRD_EP_FLAG_CANCELED;
+    }
+
+    if (ucs_list_is_empty(&ep->outstanding_list)) {
+        UCT_TL_EP_STAT_FLUSH(&ep->super);
+        return UCS_OK;
+    } else if (comp == NULL) {
+        goto out;
+    }
+
+    send_op = ucs_mpool_get(&iface->tx.send_op_mp);
+    if (send_op == NULL) {
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    send_op->ep        = ep;
+    send_op->user_comp = comp;
+    send_op->comp_cb   = uct_srd_ep_send_op_flush_completion;
+    ucs_list_add_tail(&ep->outstanding_list, &send_op->list);
+    ucs_trace_data("ep=%p added flush psn=%u send_op=%p with user_comp=%p", ep,
+                   ep->psn, send_op, send_op->user_comp);
+
+out:
+    UCT_TL_EP_STAT_FLUSH_WAIT(&ep->super);
+    return UCS_INPROGRESS;
 }

--- a/src/uct/ib/efa/srd/srd_ep.h
+++ b/src/uct/ib/efa/srd/srd_ep.h
@@ -10,16 +10,27 @@
 #include "srd_def.h"
 
 
+typedef enum uct_srd_ep_flag {
+    UCT_SRD_EP_FLAG_CANCELED    = UCS_BIT(0), /* Endpoint was flush canceled */
+    UCT_SRD_EP_FLAG_AH_ADDED    = UCS_BIT(1), /* Remote has added AH */
+    UCT_SRD_EP_FLAG_FENCE       = UCS_BIT(2), /* EP fence operation queued */
+    UCT_SRD_EP_FLAG_IFACE_FENCE = UCS_BIT(3), /* EP has iface_fence operation */
+    UCT_SRD_EP_FLAG_ERR_HANDLER_INVOKED
+                                = UCS_BIT(4), /* EP error handler was invoked */
+    UCT_SRD_EP_FLAG_RMA         = UCS_BIT(5)  /* Endpoint has seen RMA post */
+} uct_srd_ep_flag_t;
+
+
 typedef struct uct_srd_ep {
     uct_base_ep_t       super;
-    uint64_t            ep_uuid;       /* Random EP identifier */
-    uint32_t            dest_qpn;      /* Remote QP */
-    uint32_t            inflight;      /* Entries outstanding list */
-    struct ibv_ah       *ah;           /* Remote peer */
-    int                 ah_added;      /* true if remote has added our AH */
-    uct_srd_psn_t       psn;           /* Next PSN to send */
+    unsigned            flags;            /* Endpoint state tracking */
+    uint64_t            ep_uuid;          /* Random EP identifier */
+    uint32_t            dest_qpn;         /* Remote QP */
+    struct ibv_ah       *ah;              /* Remote peer */
+    uct_srd_psn_t       psn;              /* Next PSN to send */
     uint8_t             path_index;
-    ucs_arbiter_group_t pending_group; /* Queue of pending requests */
+    ucs_arbiter_group_t pending_group;    /* Queue of pending requests */
+    ucs_list_link_t     outstanding_list; /* Ordered outstanding list */
 } uct_srd_ep_t;
 
 
@@ -27,6 +38,8 @@ UCS_CLASS_DECLARE_NEW_FUNC(uct_srd_ep_t, uct_ep_t, const uct_ep_params_t*);
 UCS_CLASS_DECLARE_DELETE_FUNC(uct_srd_ep_t, uct_ep_t);
 
 
+int uct_srd_ep_is_connected(const uct_ep_h tl_ep,
+                            const uct_ep_is_connected_params_t *params);
 ucs_status_t uct_srd_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
                                  const void *buffer, unsigned length);
 ucs_status_t uct_srd_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
@@ -45,6 +58,10 @@ ucs_status_t uct_srd_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
                                  unsigned header_length, const uct_iov_t *iov,
                                  size_t iovcnt, unsigned flags,
                                  uct_completion_t *comp);
+ucs_status_t uct_srd_ep_fence(uct_ep_h ep, unsigned flags);
+ucs_status_t uct_srd_ep_flush(uct_ep_h ep_h, unsigned flags,
+                              uct_completion_t *comp);
+void uct_srd_ep_send_op_purge(uct_srd_ep_t *ep);
 
 void uct_srd_ep_send_op_completion(uct_srd_send_op_t *send_op);
 

--- a/src/uct/ib/efa/srd/srd_iface.c
+++ b/src/uct/ib/efa/srd/srd_iface.c
@@ -138,7 +138,7 @@ uct_srd_iface_ctl_op_send(uct_srd_iface_t *iface, uct_srd_ctl_op_t *ctl_op)
     /* Post the request, no action required on TX completion */
     send_op = ucs_mpool_get(&iface->tx.send_op_mp);
     if (send_op == NULL) {
-        ucs_error("iface=%p send_op allocationd failed for ctl op send", iface);
+        ucs_debug("iface=%p send_op allocationd failed for ctl op send", iface);
         return UCS_ERR_NO_MEMORY;
     }
 
@@ -157,7 +157,7 @@ uct_srd_iface_ctl_op_send(uct_srd_iface_t *iface, uct_srd_ctl_op_t *ctl_op)
     uct_srd_iface_post_send(iface, ctl_op->ah, ctl_op->remote_qpn,
                             &iface->tx.wr_inl, IBV_SEND_INLINE);
     iface->tx.available--;
-    ucs_list_add_tail(&iface->tx.outstanding_list, &send_op->list);
+    ucs_list_add_tail(&iface->tx.op_list, &send_op->list);
     return UCS_OK;
 }
 
@@ -190,9 +190,40 @@ uct_srd_iface_get_address(uct_iface_h tl_iface, uct_iface_addr_t *iface_addr)
     return UCS_OK;
 }
 
+static void uct_srd_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
+                                         ucs_status_t ep_status)
+{
+    uct_srd_iface_t *iface     = ucs_derived_of(&ib_iface->super, uct_srd_iface_t);
+    struct ibv_wc *wc          = arg;
+    uct_srd_send_op_t *send_op = (uct_srd_send_op_t*)wc->wr_id;
+    uct_srd_ep_t *ep           = send_op->ep;
+    ucs_log_level_t log_lvl    = UCS_LOG_LEVEL_FATAL;
+    ucs_status_t status;
+
+    if (ep == NULL) {
+        ucs_debug("iface=%p wc=%p wr_id=%p failure in tx cqe without ep",
+                  iface, wc, send_op);
+        return;
+    }
+
+    /* Keep pending but purge all outstanding */
+    uct_srd_ep_send_op_purge(ep);
+
+    if (ep->flags & UCT_SRD_EP_FLAG_ERR_HANDLER_INVOKED) {
+        return;
+    }
+
+    ep->flags |= UCT_SRD_EP_FLAG_ERR_HANDLER_INVOKED;
+    status  = uct_iface_handle_ep_err(&iface->super.super.super,
+                                      &ep->super.super, ep_status);
+    log_lvl = uct_base_iface_failure_log_level(&ib_iface->super, status,
+                                               ep_status);
+    UCT_IB_IFACE_VERBS_COMPLETION_LOG(log_lvl, "send", &iface->super, 0, wc);
+}
+
 static uct_ib_iface_ops_t uct_srd_iface_ops = {
     .super = {
-        .iface_estimate_perf   = uct_base_iface_estimate_perf,
+        .iface_estimate_perf   = uct_ib_iface_estimate_perf,
         .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)
             ucs_empty_function,
         .ep_query              = (uct_ep_query_func_t)
@@ -202,12 +233,12 @@ static uct_ib_iface_ops_t uct_srd_iface_ops = {
         .ep_connect_to_ep_v2   = (uct_ep_connect_to_ep_v2_func_t)
             ucs_empty_function_return_unsupported,
         .iface_is_reachable_v2 = uct_ib_iface_is_reachable_v2,
+        .ep_is_connected       = uct_srd_ep_is_connected
     },
     .create_cq      = uct_ib_verbs_create_cq,
     .destroy_cq     = uct_ib_verbs_destroy_cq,
     .event_cq       = (uct_ib_iface_event_cq_func_t)ucs_empty_function,
-    .handle_failure = (uct_ib_iface_handle_failure_func_t)
-            ucs_empty_function_do_assert
+    .handle_failure = uct_srd_iface_handle_failure
 };
 
 static ucs_status_t
@@ -275,13 +306,19 @@ uct_srd_iface_create_qp(uct_srd_iface_t *iface,
 
     iface->config.max_send_sge  = qp_init_attr.cap.max_send_sge;
     iface->config.max_recv_sge  = qp_init_attr.cap.max_recv_sge;
-    iface->config.max_get_zcopy = efa_attr->max_rdma_size;
-    iface->config.max_get_bcopy = ucs_min(iface->super.config.seg_size,
-                                          efa_attr->max_rdma_size);
     iface->config.max_inline    = qp_init_attr.cap.max_inline_data;
     iface->config.tx_qp_len     = qp_init_attr.cap.max_send_wr;
     iface->tx.available         = qp_init_attr.cap.max_send_wr;
     iface->rx.available         = qp_init_attr.cap.max_recv_wr;
+
+    if (uct_ib_efadv_has_rdma_read(efa_attr)) {
+        iface->config.max_get_zcopy = efa_attr->max_rdma_size;
+        iface->config.max_get_bcopy = ucs_min(iface->super.config.seg_size,
+                                              efa_attr->max_rdma_size);
+    } else {
+        iface->config.max_get_bcopy = 0;
+        iface->config.max_get_zcopy = 0;
+    }
 
     ucs_debug("iface=%p: created SRD QP 0x%x on " UCT_IB_IFACE_FMT
               " TX wr:%d sge:%d inl:%d resp:%d RX wr:%d sge:%d resp:%d",
@@ -339,9 +376,11 @@ static void uct_srd_iface_send_op_purge(uct_srd_iface_t *iface)
 {
     uct_srd_send_op_t *send_op;
 
-    while (!ucs_list_is_empty(&iface->tx.outstanding_list)) {
-        send_op = ucs_list_extract_head(&iface->tx.outstanding_list,
-                                        uct_srd_send_op_t, list);
+    while (!ucs_list_is_empty(&iface->tx.op_list)) {
+        send_op = ucs_list_extract_head(&iface->tx.op_list, uct_srd_send_op_t,
+                                        list);
+
+        ucs_assertv(send_op->ep == NULL, "send_op_ep=%p", send_op->ep);
         ucs_mpool_put(send_op);
     }
 }
@@ -446,8 +485,8 @@ static UCS_CLASS_INIT_FUNC(uct_srd_iface_t, uct_md_h md, uct_worker_h worker,
     }
 
     ucs_arbiter_init(&self->tx.pending_q);
-    ucs_list_head_init(&self->tx.outstanding_list);
     ucs_queue_head_init(&self->tx.ctl_queue);
+    ucs_list_head_init(&self->tx.op_list);
 
     status = uct_srd_iface_create_qp(self, config, &efa_attr);
     if (status != UCS_OK) {
@@ -461,7 +500,6 @@ static UCS_CLASS_INIT_FUNC(uct_srd_iface_t, uct_md_h md, uct_worker_h worker,
     mp_params.alignment       = UCT_SRD_SEND_OP_ALIGN;
     mp_params.elems_per_chunk = 128;
     mp_params.ops             = &uct_srd_send_op_mpool_ops;
-    mp_params.max_elems       = self->tx.available;
 
     status = ucs_mpool_init(&mp_params, &self->tx.send_op_mp);
     if (status != UCS_OK) {
@@ -494,6 +532,7 @@ static UCS_CLASS_INIT_FUNC(uct_srd_iface_t, uct_md_h md, uct_worker_h worker,
     uct_ud_send_wr_init(&self->tx.wr_desc, self->tx.sge, 0);
 
     self->tx.in_pending   = 0;
+    self->tx.in_fence     = 0;
     self->super.config.sl = uct_ib_iface_config_select_sl(&config->super);
 
     while (self->rx.available >= self->super.config.rx_max_batch) {
@@ -546,6 +585,8 @@ static UCS_CLASS_CLEANUP_FUNC(uct_srd_iface_t)
     ucs_mpool_cleanup(&self->tx.send_op_mp, 1);
     ucs_mpool_cleanup(&self->tx.send_desc_mp, 1);
     UCS_STATS_NODE_FREE(self->stats);
+    ucs_assertv(self->tx.in_fence == 0, "iface=%p tx_in_fence=%d", self,
+                self->tx.in_fence);
 }
 
 UCS_CLASS_DEFINE(uct_srd_iface_t, uct_ib_iface_t);
@@ -567,6 +608,26 @@ ucs_config_field_t uct_srd_iface_config_table[] = {
     {NULL}
 };
 
+static ucs_status_t uct_srd_wc_to_ucs_status(struct ibv_wc *wc)
+{
+    switch (wc->status) {
+    case IBV_WC_SUCCESS:
+        return UCS_OK;
+    case IBV_WC_REM_ACCESS_ERR:
+    case IBV_WC_REM_OP_ERR:
+    case IBV_WC_REM_INV_RD_REQ_ERR:
+        return UCS_ERR_CONNECTION_RESET;
+    case IBV_WC_RETRY_EXC_ERR:
+    case IBV_WC_RNR_RETRY_EXC_ERR:
+    case IBV_WC_REM_ABORT_ERR:
+        return UCS_ERR_ENDPOINT_TIMEOUT;
+    case IBV_WC_WR_FLUSH_ERR:
+        return UCS_ERR_CANCELED;
+    default:
+        return UCS_ERR_IO_ERROR;
+    }
+}
+
 static UCS_F_ALWAYS_INLINE unsigned
 uct_srd_iface_poll_tx(uct_srd_iface_t *iface)
 {
@@ -574,6 +635,7 @@ uct_srd_iface_poll_tx(uct_srd_iface_t *iface)
     struct ibv_wc wc[num_wcs];
     ucs_status_t status;
     int i;
+    uct_srd_send_op_t *send_op;
 
     status = uct_ib_poll_cq(iface->super.cq[UCT_IB_DIR_TX], &num_wcs, wc);
     if (status != UCS_OK) {
@@ -581,12 +643,14 @@ uct_srd_iface_poll_tx(uct_srd_iface_t *iface)
     }
 
     for (i = 0; i < num_wcs; i++) {
+        send_op = (uct_srd_send_op_t*)wc[i].wr_id;
+
         if (ucs_unlikely(wc[i].status != IBV_WC_SUCCESS)) {
-            UCT_IB_IFACE_VERBS_COMPLETION_ERR("send", &iface->super, i, wc);
-            continue;
+            status = uct_srd_wc_to_ucs_status(&wc[i]);
+            iface->super.ops->handle_failure(&iface->super, &wc[i], status);
         }
 
-        uct_srd_ep_send_op_completion((uct_srd_send_op_t*)wc[i].wr_id);
+        uct_srd_ep_send_op_completion(send_op);
     }
 
     iface->tx.available += num_wcs;
@@ -713,7 +777,7 @@ static void uct_srd_iface_process_ctl(uct_srd_iface_t *iface,
 
         ep = uct_srd_iface_get_ep(iface, ctl->ep_uuid);
         if (ep != NULL) {
-            ep->ah_added = 1;
+            ep->flags |= UCT_SRD_EP_FLAG_AH_ADDED;
             ucs_arbiter_group_schedule(&iface->tx.pending_q,
                                        &ep->pending_group);
         } else {
@@ -827,17 +891,17 @@ uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.am.opt_zcopy_align  = UCS_SYS_PCI_MAX_PAYLOAD;
     iface_attr->cap.get.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
 
-    iface_attr->cap.flags = UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_AM_ZCOPY |
-                            UCT_IFACE_FLAG_CONNECT_TO_IFACE |
-                            UCT_IFACE_FLAG_PENDING | UCT_IFACE_FLAG_EP_CHECK |
-                            UCT_IFACE_FLAG_CB_SYNC |
-                            UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
+    iface_attr->cap.flags      = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                 UCT_IFACE_FLAG_PENDING |
+                                 UCT_IFACE_FLAG_CB_SYNC |
+                                 UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
+                                 UCT_IFACE_FLAG_INTER_NODE;
     iface_attr->iface_addr_len = sizeof(uct_srd_iface_addr_t);
     iface_attr->ep_addr_len    = 0;
     iface_attr->max_conn_priv  = 0;
 
-    iface_attr->latency.c += 30e-9;
-    iface_attr->overhead   = 105e-9;
+    iface_attr->latency.c += 20e-9;
+    iface_attr->overhead   = 75e-9;
 
     /* AM */
     iface_attr->cap.am.max_bcopy = iface->super.config.seg_size -
@@ -854,11 +918,79 @@ uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     /* GET */
     iface_attr->cap.get.max_bcopy = iface->config.max_get_bcopy;
     iface_attr->cap.get.max_zcopy = iface->config.max_get_zcopy;
-    iface_attr->cap.get.max_iov   = iface->config.max_send_sge;
+    iface_attr->cap.get.max_iov   = iface->config.max_recv_sge;
     iface_attr->cap.get.min_zcopy =
             iface->super.config.max_inl_cqe[UCT_IB_DIR_TX] + 1;
 
+    if (iface_attr->cap.am.max_bcopy > 0) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_AM_BCOPY;
+    }
+
+    if (iface_attr->cap.am.max_zcopy > 0) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_AM_ZCOPY;
+    }
+
+    if (iface_attr->cap.am.max_short > 0) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_AM_SHORT;
+    }
+
+    if (iface_attr->cap.get.max_bcopy > 0) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_GET_BCOPY;
+    }
+
+    if (iface_attr->cap.get.max_zcopy > 0) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_GET_ZCOPY;
+    }
+
     return status;
+}
+
+static ucs_status_t uct_srd_iface_flush(uct_iface_h tl_iface, unsigned flags,
+                                        uct_completion_t *comp)
+{
+    uct_srd_iface_t *iface = ucs_derived_of(tl_iface, uct_srd_iface_t);
+    uct_srd_ep_t *ep;
+    unsigned count;
+    ucs_status_t status;
+
+    if (comp != NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    count = 0;
+    kh_foreach_value(&iface->ep_hash, ep, {
+        status = uct_ep_flush(&ep->super.super, 0, NULL);
+        if ((status == UCS_ERR_NO_RESOURCE) || (status == UCS_INPROGRESS)) {
+            count++;
+        } else if (status != UCS_OK) {
+            return status;
+        }
+    });
+
+    if (count != 0) {
+        UCT_TL_IFACE_STAT_FLUSH_WAIT(&iface->super.super);
+        return UCS_INPROGRESS;
+    }
+
+    UCT_TL_IFACE_STAT_FLUSH(&iface->super.super);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_srd_iface_fence(uct_iface_h tl_iface, unsigned flags)
+{
+    uct_srd_iface_t *iface = ucs_derived_of(tl_iface, uct_srd_iface_t);
+    uct_srd_ep_t *ep;
+
+    kh_foreach_value(&iface->ep_hash, ep, {
+        if (!(ep->flags & UCT_SRD_EP_FLAG_IFACE_FENCE) &&
+            !ucs_list_is_empty(&ep->outstanding_list)) {
+            ep->flags |= UCT_SRD_EP_FLAG_IFACE_FENCE;
+            iface->tx.in_fence++;
+        }
+    });
+
+    UCT_TL_IFACE_STAT_FENCE(&iface->super.super);
+    return UCS_OK;
 }
 
 static ucs_status_t
@@ -886,9 +1018,9 @@ uct_srd_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
 }
 
 static uct_iface_ops_t uct_srd_iface_tl_ops = {
-    .ep_flush                 = (uct_ep_flush_func_t)
-        ucs_empty_function_return_unsupported,
-    .ep_fence                 = (uct_ep_fence_func_t)
+    .ep_flush                 = uct_srd_ep_flush,
+    .ep_fence                 = uct_srd_ep_fence,
+    .ep_check                 = (uct_ep_check_func_t)
         ucs_empty_function_return_unsupported,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_srd_ep_t),
     .ep_get_address           = (uct_ep_get_address_func_t)
@@ -904,9 +1036,8 @@ static uct_iface_ops_t uct_srd_iface_tl_ops = {
     .ep_am_short_iov          = uct_srd_ep_am_short_iov,
     .ep_pending_add           = uct_srd_ep_pending_add,
     .ep_pending_purge         = uct_srd_ep_pending_purge,
-    .iface_flush              = uct_base_iface_flush,
-    .iface_fence              = (uct_iface_fence_func_t)
-        ucs_empty_function_return_unsupported,
+    .iface_flush              = uct_srd_iface_flush,
+    .iface_fence              = uct_srd_iface_fence,
     .iface_progress_enable    = uct_base_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_srd_iface_progress,

--- a/src/uct/ib/efa/srd/srd_iface.h
+++ b/src/uct/ib/efa/srd/srd_iface.h
@@ -64,6 +64,7 @@ typedef struct uct_srd_iface {
     struct {
         int32_t                      available;
         int                          in_pending;
+        int                          in_fence;   /* Number of EP under iface_fence */
         ucs_arbiter_t                pending_q;
         struct ibv_sge               sge[UCT_IB_MAX_IOV];
         struct ibv_send_wr           wr_inl;
@@ -71,8 +72,12 @@ typedef struct uct_srd_iface {
         ucs_mpool_t                  send_op_mp;
         ucs_mpool_t                  send_desc_mp;
         uct_srd_am_short_hdr_t       am_inl_hdr;
-        ucs_list_link_t              outstanding_list;
-        ucs_queue_head_t             ctl_queue; /* pending CTL messages */
+
+        /* Pending control messages */
+        ucs_queue_head_t             ctl_queue;
+
+        /* Send operations without an endpoint, order does not matter here */
+        ucs_list_link_t              op_list;
     } tx;
 
     struct {

--- a/test/gtest/uct/ib/test_srd.cc
+++ b/test/gtest/uct/ib/test_srd.cc
@@ -7,7 +7,6 @@
 #include <uct/uct_test.h>
 #include <uct/ib/efa/srd/srd_ep.h>
 
-
 // FIXME: Add SRD transport to UCT_TEST_IB_TLS when possible
 class test_srd : public uct_test {
 public:
@@ -41,8 +40,6 @@ protected:
             int      bytes;
             uint64_t hdr;
         } stats = {}, expect = {};
-
-        progress_ctl();
 
         auto counter_func = [](void *arg, void *data, size_t length,
                                unsigned flags) {
@@ -84,27 +81,132 @@ protected:
 
     void progress_ctl()
     {
-        while (!((uct_srd_ep_t*)m_e1->ep(0))->ah_added) {
+        while (!(((uct_srd_ep_t*)m_e1->ep(0))->flags &
+               UCT_SRD_EP_FLAG_AH_ADDED)) {
             short_progress_loop();
         }
     }
 
-    int pending_purge(uct_ep_h ep)
+    void pending_purge_check(int expected_count)
     {
         int count = 0;
+        uct_ep_pending_purge(
+                m_e1->ep(0),
+                [](uct_pending_req_t*, void *arg) {
+                    (*reinterpret_cast<int*>(arg))++;
+                },
+                &count);
+        ASSERT_EQ(expected_count, count);
+    }
 
-        uct_ep_pending_purge(ep,
-                             [](uct_pending_req_t*, void *arg) {
-                                 (*reinterpret_cast<int*>(arg))++;
-                             },
-                             &count);
-        return count;
+    ucs_status_t test_get_bcopy()
+    {
+        mapped_buffer srcbuf(4096, 0ul, *m_e2);
+        mapped_buffer dstbuf(4096, 0ul, *m_e1);
+
+        m_comp.count   = 1;
+        m_comp.m_count = 0;
+
+        srcbuf.pattern_fill(m_seed);
+        ucs_status_t status = uct_ep_get_bcopy(m_e1->ep(0),
+                                               (uct_unpack_callback_t)memcpy,
+                                               dstbuf.ptr(), dstbuf.length(),
+                                               srcbuf.addr(), srcbuf.rkey(),
+                                               &m_comp);
+        if ((status != UCS_INPROGRESS) &&
+            (status != UCS_OK)) {
+            return status;
+        }
+
+        ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS, status);
+        wait_for_value(&m_comp.m_count, 1, true);
+        dstbuf.pattern_check(m_seed);
+        return UCS_OK;
+    }
+
+    ucs_status_t test_get_zcopy()
+    {
+        mapped_buffer srcbuf(4096, 0ul, *m_e2);
+        mapped_buffer dstbuf(4096, 0ul, *m_e1);
+
+        m_comp.count   = 1;
+        m_comp.m_count = 0;
+
+        UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, dstbuf.ptr(), dstbuf.length(),
+                                dstbuf.memh(), 1);
+
+        srcbuf.pattern_fill(m_seed);
+        ucs_status_t status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt,
+                                               srcbuf.addr(), srcbuf.rkey(),
+                                               &m_comp);
+        if ((status != UCS_INPROGRESS) &&
+            (status != UCS_OK)) {
+            return status;
+        }
+
+        ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS, status);
+        wait_for_value(&m_comp.m_count, 1, true);
+        dstbuf.pattern_check(m_seed);
+        return UCS_OK;
+    }
+
+    template<typename F> void test_fence(F &&send_cb, bool wait_progress = true)
+    {
+        int count = 0;
+        int c     = 1;
+        ASSERT_UCS_OK(uct_iface_set_am_handler(
+                m_e2->iface(), 31,
+                [](void *arg, void *data, size_t length, unsigned flags) {
+                    (*reinterpret_cast<int*>(arg))++;
+                    return UCS_OK;
+                },
+                &count, 0));
+
+        progress_ctl();
+
+        ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 31, 0x123, &c, 1));
+        ASSERT_UCS_OK(uct_ep_fence(m_e1->ep(0), 0));
+        ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, send_cb());
+
+        if (wait_progress) {
+            wait_for_value(&count, 1, true);
+            EXPECT_EQ(1, count);
+        }
+
+        ASSERT_UCS_OK(send_cb());
+        ASSERT_UCS_OK(send_cb());
+    }
+
+    void test_flush_comp(int flags, ucs_status_t expect_status)
+    {
+        int c = 1;
+        completion comp[2];
+
+        auto noop = [](void *arg, void *data, size_t length, unsigned flags) {
+            return UCS_OK;
+        };
+
+        ASSERT_UCS_OK(
+                uct_iface_set_am_handler(m_e2->iface(), 31, noop, NULL, 0));
+        ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 31, 0x123, &c, 1));
+
+        ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS,
+                             uct_ep_flush(m_e1->ep(0), flags, &comp[0]));
+        ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS,
+                             uct_ep_flush(m_e1->ep(0), flags, &comp[1]));
+        wait_for_value(&comp[1].m_count, 1, true);
+
+        ASSERT_EQ(comp[0].m_count, 1);
+        ASSERT_EQ(comp[1].m_count, 1);
+        ASSERT_EQ(expect_status, comp[0].status);
+        ASSERT_EQ(expect_status, comp[1].status);
     }
 
     completion                m_comp;
     static constexpr uint64_t m_seed = 0x54321;
 
-    uct_pending_req_t         m_req[3];
+    static constexpr int m_req_count = 3;
+    uct_pending_req_t m_req[m_req_count];
     entity *m_e1, *m_e2, *m_e3;
 };
 
@@ -128,8 +230,6 @@ UCS_TEST_P(test_srd, am_short_outstanding)
     int count       = 40;
     uint64_t header = 0x1234567843210987;
     char payload[]  = "the payload";
-
-    progress_ctl();
 
     while (count-- > 0) {
         ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 31, header++, payload,
@@ -196,8 +296,6 @@ UCS_TEST_P(test_srd, am_zcopy)
 
         return UCS_OK;
     };
-
-    progress_ctl();
 
     ASSERT_UCS_OK(uct_iface_set_am_handler(m_e2->iface(), id, check_func,
                                            dstbuf.ptr(), 0));
@@ -334,39 +432,16 @@ UCS_TEST_P(test_srd, get_zcopy_destroy_outstanding)
 
 UCS_TEST_P(test_srd, get_zcopy)
 {
-    mapped_buffer srcbuf(4096, 0ul, *m_e2);
-    mapped_buffer dstbuf(4096, 0ul, *m_e1);
-
-    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, dstbuf.ptr(), dstbuf.length(),
-                            dstbuf.memh(), 1);
-
     progress_ctl();
 
-    srcbuf.pattern_fill(m_seed);
-    ucs_status_t status = uct_ep_get_zcopy(m_e1->ep(0), iov, iovcnt,
-                                           srcbuf.addr(), srcbuf.rkey(),
-                                           &m_comp);
-    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS, status);
-    wait_for_value(&m_comp.m_count, 1, true);
-    dstbuf.pattern_check(m_seed);
+    ASSERT_UCS_OK(test_get_zcopy());
 }
 
 UCS_TEST_P(test_srd, get_bcopy)
 {
-    mapped_buffer srcbuf(4096, 0ul, *m_e2);
-    mapped_buffer dstbuf(4096, 0ul, *m_e1);
-
     progress_ctl();
 
-    srcbuf.pattern_fill(m_seed);
-    ucs_status_t status = uct_ep_get_bcopy(m_e1->ep(0),
-                                           (uct_unpack_callback_t)memcpy,
-                                           dstbuf.ptr(), dstbuf.length(),
-                                           srcbuf.addr(), srcbuf.rkey(),
-                                           &m_comp);
-    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS, status);
-    wait_for_value(&m_comp.m_count, 1, true);
-    dstbuf.pattern_check(m_seed);
+    ASSERT_UCS_OK(test_get_bcopy());
 }
 
 UCS_TEST_P(test_srd, get_bcopy_no_resource)
@@ -398,8 +473,6 @@ UCS_TEST_P(test_srd, am_short_no_resource)
     int i;
     ucs_status_t status;
 
-    progress_ctl();
-
     for (i = 0; i < count; i++) {
         status = uct_ep_am_short(m_e1->ep(0), 30, 0x0, "test", 4);
         if (status != UCS_OK) {
@@ -418,35 +491,10 @@ UCS_TEST_P(test_srd, am_short_no_resource_with_pending)
 
     m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
 
-    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
-    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE,
-                         uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1));
-
-    /* Can post as CTL_RESP received and pending is drained */
-    progress_ctl();
+    /* Cannot add pending as no RMA operation was posted */
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_BUSY,
+                         uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
     ASSERT_UCS_STATUS_EQ(UCS_OK, uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1));
-}
-
-UCS_TEST_P(test_srd, pending_ok_if_no_resource)
-{
-    uint8_t c = 23;
-    ucs_status_t status;
-
-    progress_ctl();
-
-    auto i = 0;
-    for (; i < 400; i++) {
-        status = uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1);
-        if (status == UCS_ERR_NO_RESOURCE) {
-            break;
-        }
-    }
-
-    ASSERT_LT(0, i);
-    ASSERT_LT(i, 400);
-    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
-    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[1], 0));
-    ASSERT_EQ(2, pending_purge(m_e1->ep(0)));
 }
 
 UCS_TEST_P(test_srd, pending_busy_if_ready_to_send)
@@ -456,16 +504,29 @@ UCS_TEST_P(test_srd, pending_busy_if_ready_to_send)
                          uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
 }
 
-UCS_TEST_P(test_srd, pending_purge_dispatch)
-{
-    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
-    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[1], 0));
-    ASSERT_EQ(2, pending_purge(m_e1->ep(0)));
-}
-
 UCS_TEST_P(test_srd, pending_dispatch)
 {
+    uint8_t c = 23;
+    auto i    = 0;
     static int req_count;
+    ucs_status_t status;
+
+    auto noop_func = [](void *arg, void *data, size_t length, unsigned flags) {
+        return UCS_OK;
+    };
+
+    ASSERT_UCS_OK(
+            uct_iface_set_am_handler(m_e2->iface(), 31, noop_func, NULL, 0));
+
+    for (; i < 400; i++) {
+        status = uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1);
+        if (status == UCS_ERR_NO_RESOURCE) {
+            break;
+        }
+    }
+
+    ASSERT_LT(0, i);
+    ASSERT_LT(i, 400);
 
     req_count = 0;
     for (auto i = 0; i < 3; i++) {
@@ -484,19 +545,29 @@ UCS_TEST_P(test_srd, pending_dispatch)
     }
 
     wait_for_value(&req_count, 5, true);
-    ASSERT_EQ(0, pending_purge(m_e1->ep(0)));
+    pending_purge_check(0);
 }
 
-UCS_TEST_P(test_srd, get_bcopy_no_resource_ah)
+UCS_TEST_P(test_srd, get_bcopy_ah_pending)
 {
     mapped_buffer srcbuf(4096, 0ul, *m_e2);
     mapped_buffer dstbuf(4096, 0ul, *m_e1);
     ucs_status_t status;
 
+    m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_BUSY,
+                         uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
     status = uct_ep_get_bcopy(m_e1->ep(0), (uct_unpack_callback_t)memcpy,
                               dstbuf.ptr(), dstbuf.length(), srcbuf.addr(),
                               srcbuf.rkey(), NULL);
     ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, status);
+
+    /* AM cannot be posted after EP has seen RMA */
+    char c = 1;
+    status = uct_ep_am_short(m_e1->ep(0), 31, 0x1, &c, 1);
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, status);
+
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
 }
 
 UCS_TEST_P(test_srd, destroy_ep_before_ctl_resp)
@@ -505,6 +576,213 @@ UCS_TEST_P(test_srd, destroy_ep_before_ctl_resp)
     m_e1->destroy_ep(1);
 
     progress_ctl();
+}
+
+UCS_TEST_P(test_srd, fence_no_resource_am_short)
+{
+    test_fence([&]() {
+        int c = 1;
+        return uct_ep_am_short(m_e1->ep(0), 31, 0x123, &c, 1);
+    });
+}
+
+UCS_TEST_P(test_srd, fence_no_resource_get_bcopy)
+{
+    test_fence([&]() { return test_get_bcopy(); });
+}
+
+UCS_TEST_P(test_srd, fence_no_resource_get_zcopy)
+{
+    test_fence([&]() { return test_get_zcopy(); });
+}
+
+UCS_TEST_P(test_srd, fence_no_resource_pending)
+{
+    int step = 0;
+    ucs_status_t status;
+
+    m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
+
+    test_fence([&]() {
+        step++;
+        if (step == 1) {
+            /* Can add to pending since fence is pending */
+            status = uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0);
+            ASSERT_UCS_OK(status);
+            return UCS_ERR_NO_RESOURCE;
+        }
+
+        /* Could send, should not be able to add to pending */
+        ASSERT_UCS_STATUS_EQ(UCS_ERR_BUSY,
+                             uct_ep_pending_add(m_e1->ep(0), &m_req[1], 0));
+        return UCS_OK;
+    });
+
+    /* Pending must have already been executed */
+    pending_purge_check(0);
+}
+
+UCS_TEST_P(test_srd, flush_no_outstanding)
+{
+    ASSERT_UCS_OK(uct_ep_flush(m_e1->ep(0), 0, NULL));
+    ASSERT_UCS_OK(uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_CANCEL, NULL));
+}
+
+UCS_TEST_P(test_srd, flush_pending_canceled_no_outstanding)
+{
+    mapped_buffer srcbuf(4096, 0ul, *m_e2);
+    mapped_buffer dstbuf(4096, 0ul, *m_e1);
+    ucs_status_t status;
+
+    m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
+    status = uct_ep_get_bcopy(m_e1->ep(0), (uct_unpack_callback_t)memcpy,
+                              dstbuf.ptr(), dstbuf.length(), srcbuf.addr(),
+                              srcbuf.rkey(), NULL);
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, status);
+
+    /* Pending added as RMA was seen and no CTL message received */
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+    ASSERT_UCS_OK(uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_CANCEL, NULL));
+
+    pending_purge_check(0);
+}
+
+UCS_TEST_P(test_srd, flush_outstanding)
+{
+    int c = 1;
+
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 31, 0x123, &c, 1));
+    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS, uct_ep_flush(m_e1->ep(0), 0, NULL));
+}
+
+UCS_TEST_P(test_srd, flush_pending_canceled_outstanding)
+{
+    int c         = 1;
+    m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
+    ucs_status_t status;
+
+    for (auto count = 10000; count > 0; --count) {
+        status = uct_ep_am_short(m_e1->ep(0), 31, 0x123, &c, 1);
+        if (status != UCS_OK) {
+            break;
+        }
+    }
+
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE, status);
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS,
+                         uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_CANCEL,
+                                      NULL));
+
+    pending_purge_check(0);
+}
+
+UCS_TEST_P(test_srd, flush_comp)
+{
+    test_flush_comp(0, UCS_OK);
+}
+
+UCS_TEST_P(test_srd, flush_comp_cancel)
+{
+    test_flush_comp(UCT_FLUSH_FLAG_CANCEL, UCS_ERR_CANCELED);
+}
+
+UCS_TEST_P(test_srd, iface_flush_comp_unsupported)
+{
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_UNSUPPORTED,
+                         uct_iface_flush(m_e1->iface(), 0, &m_comp));
+}
+
+UCS_TEST_P(test_srd, iface_flush_no_outstanding)
+{
+    m_e1->connect_to_iface(1, *m_e2);
+    m_e1->connect_to_iface(2, *m_e2);
+    m_e1->connect_to_iface(3, *m_e3);
+
+    ASSERT_UCS_OK(uct_iface_flush(m_e1->iface(), 0, NULL));
+}
+
+UCS_TEST_P(test_srd, iface_flush_inprogress)
+{
+    m_e1->connect_to_iface(1, *m_e2);
+    m_e1->connect_to_iface(2, *m_e2);
+    m_e1->connect_to_iface(3, *m_e3);
+
+    int c = 1, count = 0;
+    auto counter_func = [](void *arg, void *data, size_t length,
+                           unsigned flags) {
+        (*reinterpret_cast<int*>(arg))++;
+        return UCS_OK;
+    };
+
+    ASSERT_UCS_OK(uct_iface_set_am_handler(m_e2->iface(), 31, counter_func,
+                                           &count, 0));
+
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(1), 31, 0x123, &c, 1));
+    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS,
+                         uct_iface_flush(m_e1->iface(), 0, NULL));
+    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS,
+                         uct_iface_flush(m_e1->iface(), 0, NULL));
+    wait_for_value(&count, 1, true);
+    ASSERT_EQ(1, count);
+    ASSERT_UCS_OK(uct_iface_flush(m_e1->iface(), 0, NULL));
+}
+
+UCS_TEST_P(test_srd, iface_fence_none)
+{
+    ASSERT_UCS_OK(uct_iface_fence(m_e1->iface(), 0));
+}
+
+UCS_TEST_P(test_srd, iface_fence_outstanding)
+{
+    m_e1->connect_to_iface(1, *m_e2);
+    m_e1->connect_to_iface(2, *m_e2);
+    m_e1->connect_to_iface(3, *m_e3);
+
+    int c = 1, count = 0;
+    auto counter_func = [](void *arg, void *data, size_t length,
+                           unsigned flags) {
+        (*reinterpret_cast<int*>(arg))++;
+        return UCS_OK;
+    };
+
+    ASSERT_UCS_OK(uct_iface_set_am_handler(m_e2->iface(), 31, counter_func,
+                                           &count, 0));
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(1), 31, 0x123, &c, 1));
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(2), 31, 0x123, &c, 1));
+
+    m_req[0].func = [](uct_pending_req_t*) { return UCS_OK; };
+    /* Cannot be added we are ready to send */
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_BUSY,
+                         uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+    ASSERT_UCS_OK(uct_iface_fence(m_e1->iface(), 0));
+    ASSERT_UCS_OK(uct_ep_pending_add(m_e1->ep(0), &m_req[0], 0));
+
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE,
+                         uct_ep_am_short(m_e1->ep(0), 31, 0x123, &c, 1));
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE,
+                         uct_ep_am_short(m_e1->ep(1), 31, 0x123, &c, 1));
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE,
+                         uct_ep_am_short(m_e1->ep(2), 31, 0x123, &c, 1));
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_NO_RESOURCE,
+                         uct_ep_am_short(m_e1->ep(3), 31, 0x123, &c, 1));
+
+    wait_for_value(&count, 2, true);
+    ASSERT_EQ(2, count);
+
+    /* Iface fence on empty outstanding queues */
+    ASSERT_UCS_OK(uct_iface_fence(m_e1->iface(), 0));
+
+    /* Pending cannot be added as we are ready to transmit */
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_BUSY,
+                         uct_ep_pending_add(m_e1->ep(0), &m_req[1], 0));
+
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(1), 31, 0x123, &c, 1));
+    wait_for_value(&count, 3, true);
+    ASSERT_EQ(3, count);
+
+    /* Pending was executed too */
+    pending_purge_check(0);
 }
 
 UCT_INSTANTIATE_SRD_TEST_CASE(test_srd)


### PR DESCRIPTION
## What?
Add ep fence, ep flush, iface flush, is connected and enable for UCP usage. Other non-srd specific tests are omitted to keep PR smaller.