### PR TITLE
UCP: wireup slow connect-to-iface lanes on demand

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -577,6 +577,10 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, connect_all_to_all),
    UCS_CONFIG_TYPE_BOOL},
 
+  {"ON_DEMAND_WIREUP", "y", /* TODO: disable by default */
+   "Enable new protocol selection logic",
+   ucs_offsetof(ucp_context_config_t, on_demand_wireup), UCS_CONFIG_TYPE_BOOL},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -215,6 +215,8 @@ typedef struct ucp_context_config {
     /** Extend endpoint lanes connections of each local device to all remote
      *  devices */
     int                                    connect_all_to_all;
+    /** On demand lanes wireup */
+    int                                    on_demand_wireup;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1274,7 +1274,7 @@ ucp_ep_purge_lanes(ucp_ep_h ep, uct_pending_purge_callback_t purge_cb,
     uct_ep_h uct_ep;
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        uct_ep = ucp_ep_get_lane(ep, lane);
+        uct_ep = ucp_ep_get_lane_raw(ep, lane);
         if ((lane == ucp_ep_get_cm_lane(ep)) || (uct_ep == NULL)) {
             continue;
         }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3421,7 +3421,7 @@ ucp_wireup_ep_t* ucp_ep_get_cm_wireup_ep(ucp_ep_h ep)
         return NULL;
     }
 
-    uct_ep = ucp_ep_get_lane(ep, lane);
+    uct_ep = ucp_ep_get_lane_raw(ep, lane);
     return (uct_ep != NULL) ? ucp_wireup_ep(uct_ep) : NULL;
 }
 
@@ -3435,7 +3435,7 @@ uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep)
         return NULL;
     }
 
-    if (ucp_ep_get_lane(ep, lane) == NULL) {
+    if (ucp_ep_get_lane_raw(ep, lane) == NULL) {
         return NULL;
     }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1301,7 +1301,7 @@ static void ucp_ep_check_lanes(ucp_ep_h ep)
     uct_ep_h uct_ep;
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        uct_ep = ucp_ep_get_lane(ep, lane);
+        uct_ep = ucp_ep_get_lane_raw(ep, lane);
         if ((uct_ep != NULL) && ucp_is_uct_ep_failed(uct_ep)) {
             num_failed_tl_ep++;
         }
@@ -1324,7 +1324,7 @@ ucp_ep_set_lanes_failed(ucp_ep_h ep, uct_ep_h *uct_eps, uct_ep_h failed_ep)
     ucp_ep_update_flags(ep, UCP_EP_FLAG_FAILED, UCP_EP_FLAG_LOCAL_CONNECTED);
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        uct_ep        = ucp_ep_get_lane(ep, lane);
+        uct_ep        = ucp_ep_get_lane_raw(ep, lane);
         uct_eps[lane] = uct_ep;
 
         /* Set UCT EP to failed UCT EP to make sure if UCP EP won't be destroyed
@@ -1949,9 +1949,7 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
            (config_lane1->dst_md_index == config_lane2->dst_md_index) &&
            (config_lane1->dst_sys_dev == config_lane2->dst_sys_dev) &&
            (config_lane1->lane_types == config_lane2->lane_types) &&
-           (config_lane1->seg_size == config_lane2->seg_size) &&
-           (1 || (flags & 0 /*UCP_EP_CONFIG_CMP_IGNORE_ADDR_INDEX*/) ||
-            (config_lane1->addr_index == config_lane2->addr_index));
+           (config_lane1->seg_size == config_lane2->seg_size);
 }
 
 static int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1939,7 +1939,7 @@ void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *old_key,
 
 int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
                                 const ucp_ep_config_key_t *key2,
-                                ucp_lane_index_t lane)
+                                ucp_lane_index_t lane, unsigned flags)
 {
     const ucp_ep_config_key_lane_t *config_lane1 = &key1->lanes[lane];
     const ucp_ep_config_key_lane_t *config_lane2 = &key2->lanes[lane];
@@ -1949,11 +1949,19 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
            (config_lane1->dst_md_index == config_lane2->dst_md_index) &&
            (config_lane1->dst_sys_dev == config_lane2->dst_sys_dev) &&
            (config_lane1->lane_types == config_lane2->lane_types) &&
-           (config_lane1->seg_size == config_lane2->seg_size);
+           (config_lane1->seg_size == config_lane2->seg_size) &&
+           (1 || (flags & 0 /*UCP_EP_CONFIG_CMP_IGNORE_ADDR_INDEX*/) ||
+            (config_lane1->addr_index == config_lane2->addr_index));
 }
 
 static int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,
                                                const ucp_ep_config_key_t *key2)
+{
+    return ucp_ep_config_is_equal2(key1, key2, 0);
+}
+
+int ucp_ep_config_is_equal2(const ucp_ep_config_key_t *key1,
+                            const ucp_ep_config_key_t *key2, unsigned flags)
 {
     ucp_lane_index_t lane;
 
@@ -1974,7 +1982,7 @@ static int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,
     }
 
     for (lane = 0; lane < key1->num_lanes; ++lane) {
-        if (!ucp_ep_config_lane_is_equal(key1, key2, lane)) {
+        if (!ucp_ep_config_lane_is_equal(key1, key2, lane, flags)) {
             return 0;
         }
     }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1939,7 +1939,7 @@ void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *old_key,
 
 int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
                                 const ucp_ep_config_key_t *key2,
-                                ucp_lane_index_t lane, unsigned flags)
+                                ucp_lane_index_t lane)
 {
     const ucp_ep_config_key_lane_t *config_lane1 = &key1->lanes[lane];
     const ucp_ep_config_key_lane_t *config_lane2 = &key2->lanes[lane];
@@ -1980,7 +1980,7 @@ int ucp_ep_config_is_equal2(const ucp_ep_config_key_t *key1,
     }
 
     for (lane = 0; lane < key1->num_lanes; ++lane) {
-        if (!ucp_ep_config_lane_is_equal(key1, key2, lane, flags)) {
+        if (!ucp_ep_config_lane_is_equal(key1, key2, lane)) {
             return 0;
         }
     }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1952,14 +1952,8 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
            (config_lane1->seg_size == config_lane2->seg_size);
 }
 
-static int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,
-                                               const ucp_ep_config_key_t *key2)
-{
-    return ucp_ep_config_is_equal2(key1, key2, 0);
-}
-
-int ucp_ep_config_is_equal2(const ucp_ep_config_key_t *key1,
-                            const ucp_ep_config_key_t *key2, unsigned flags)
+int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,
+                                        const ucp_ep_config_key_t *key2)
 {
     ucp_lane_index_t lane;
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3466,9 +3466,9 @@ int ucp_ep_is_local_connected(ucp_ep_h ep)
         /* For CM case need to check all wireup lanes because transport lanes
          * can be not connected yet. */
         for (i = 0; is_local_connected && (i < ucp_ep_num_lanes(ep)); ++i) {
-            uct_ep             = ucp_ep_get_lane_raw(ep, i);
-            if ((uct_ep == NULL) &&
-                (ep->worker->context->config.ext.on_demand_wireup)) {
+            uct_ep = ucp_ep_get_lane_raw(ep, i);
+            if (uct_ep == NULL) {
+                ucs_assert(ep->worker->context->config.ext.on_demand_wireup);
                 ucs_assert(!ucp_ep_is_lane_p2p(ep, i));
                 continue;
             }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -3459,13 +3459,21 @@ int ucp_ep_is_local_connected(ucp_ep_h ep)
 {
     int is_local_connected = !!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
     ucp_wireup_ep_t *wireup_ep;
+    uct_ep_h uct_ep;
     ucp_lane_index_t i;
 
     if (ucp_ep_has_cm_lane(ep)) {
         /* For CM case need to check all wireup lanes because transport lanes
          * can be not connected yet. */
         for (i = 0; is_local_connected && (i < ucp_ep_num_lanes(ep)); ++i) {
-            wireup_ep          = ucp_wireup_ep(ucp_ep_get_lane(ep, i));
+            uct_ep             = ucp_ep_get_lane_raw(ep, i);
+            if ((uct_ep == NULL) &&
+                (ep->worker->context->config.ext.on_demand_wireup)) {
+                ucs_assert(!ucp_ep_is_lane_p2p(ep, i));
+                continue;
+            }
+
+            wireup_ep          = ucp_wireup_ep(uct_ep);
             is_local_connected = (wireup_ep == NULL) ||
                                  (wireup_ep->flags &
                                   UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1957,6 +1957,7 @@ int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,
 {
     ucp_lane_index_t lane;
 
+    /* Compare lanes layout */
     if ((key1->num_lanes != key2->num_lanes) ||
         memcmp(key1->rma_lanes, key2->rma_lanes, sizeof(key1->rma_lanes)) ||
         memcmp(key1->am_bw_lanes, key2->am_bw_lanes,

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -205,10 +205,6 @@ typedef struct ucp_ep_config_key_lane {
                                         was selected for */
     size_t               seg_size; /* Maximal fragment size which can be
                                       received by the peer */
-    unsigned             addr_index; /* Address index in the remote address,
-                                      NOTE: can be removed if remote side
-                                      sends only requested address for on
-                                      demand wireup request */
 } ucp_ep_config_key_lane_t;
 
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -768,7 +768,7 @@ void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *old_key,
 
 int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
                                 const ucp_ep_config_key_t *key2,
-                                ucp_lane_index_t lane, unsigned flags);
+                                ucp_lane_index_t lane);
 
 /**
  * @brief Compare two endpoint configurations.

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -192,6 +192,17 @@ enum {
 };
 
 
+/**
+ * Endpoint configuration comparison flags
+ */
+enum {
+    /* Compare lanes only */
+    UCP_EP_CONFIG_CMP_FLAG_LANES = UCS_BIT(0),
+
+    /* Strong compare all fields */
+    UCP_EP_CONFIG_CMP_FLAG_ALL   = UCS_MASK(8)
+};
+
 #define UCP_EP_STAT_TAG_OP(_ep, _op) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCP_EP_STAT_TAG_TX_##_op, 1);
 
@@ -770,6 +781,9 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
                                 const ucp_ep_config_key_t *key2,
                                 ucp_lane_index_t lane);
 
+int ucp_ep_config_lanes_layout_is_equal(const ucp_ep_config_key_t *key1,
+                                        const ucp_ep_config_key_t *key2);
+
 /**
  * @brief Compare two endpoint configurations.
  *
@@ -780,9 +794,6 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
  */
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2);
-
-int ucp_ep_config_is_equal2(const ucp_ep_config_key_t *key1,
-                            const ucp_ep_config_key_t *key2, unsigned flags);
 
 void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
                         ucs_string_buffer_t *strb);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -192,17 +192,6 @@ enum {
 };
 
 
-/**
- * Endpoint configuration comparison flags
- */
-enum {
-    /* Compare lanes only */
-    UCP_EP_CONFIG_CMP_FLAG_LANES = UCS_BIT(0),
-
-    /* Strong compare all fields */
-    UCP_EP_CONFIG_CMP_FLAG_ALL   = UCS_MASK(8)
-};
-
 #define UCP_EP_STAT_TAG_OP(_ep, _op) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCP_EP_STAT_TAG_TX_##_op, 1);
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -205,6 +205,10 @@ typedef struct ucp_ep_config_key_lane {
                                         was selected for */
     size_t               seg_size; /* Maximal fragment size which can be
                                       received by the peer */
+    unsigned             addr_index; /* Address index in the remote address,
+                                      NOTE: can be removed if remote side
+                                      sends only requested address for on
+                                      demand wireup request */
 } ucp_ep_config_key_lane_t;
 
 
@@ -768,7 +772,7 @@ void ucp_ep_config_lanes_intersect(const ucp_ep_config_key_t *old_key,
 
 int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
                                 const ucp_ep_config_key_t *key2,
-                                ucp_lane_index_t lane);
+                                ucp_lane_index_t lane, unsigned flags);
 
 /**
  * @brief Compare two endpoint configurations.
@@ -780,6 +784,9 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
  */
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
                            const ucp_ep_config_key_t *key2);
+
+int ucp_ep_config_is_equal2(const ucp_ep_config_key_t *key1,
+                            const ucp_ep_config_key_t *key2, unsigned flags);
 
 void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
                         ucs_string_buffer_t *strb);

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -30,7 +30,7 @@ static UCS_F_ALWAYS_INLINE uct_ep_h ucp_ep_get_fast_lane(ucp_ep_h ep,
 }
 
 static UCS_F_ALWAYS_INLINE uct_ep_h
-ucp_ep_get_lane(ucp_ep_h ep, ucp_lane_index_t lane_index)
+ucp_ep_get_lane_raw(ucp_ep_h ep, ucp_lane_index_t lane_index)
 {
     ucs_assertv(lane_index < UCP_MAX_LANES, "lane=%d", lane_index);
 
@@ -39,6 +39,26 @@ ucp_ep_get_lane(ucp_ep_h ep, ucp_lane_index_t lane_index)
     } else {
         return ep->ext->uct_eps[lane_index - UCP_MAX_FAST_PATH_LANES];
     }
+}
+
+static UCS_F_ALWAYS_INLINE uct_ep_h
+ucp_ep_get_lane(ucp_ep_h ep, ucp_lane_index_t lane_index)
+{
+    uct_ep_h lane;
+
+    /* fast-path lane must be initialized */
+    if (ucs_likely(lane_index < UCP_MAX_FAST_PATH_LANES)) {
+        lane = ep->uct_eps[lane_index];
+        ucs_assert(lane != NULL);
+        return lane;
+    }
+
+    lane = ucp_ep_get_lane_raw(ep, lane_index);
+    if (ucs_likely(lane != NULL)) {
+        return lane;
+    }
+
+    return ucp_wireup_init_slow_lane(ep, lane_index - UCP_MAX_FAST_PATH_LANES);
 }
 
 static UCS_F_ALWAYS_INLINE void ucp_ep_set_lane(ucp_ep_h ep, size_t lane_index,
@@ -135,6 +155,18 @@ static inline size_t ucp_ep_get_max_iov(ucp_ep_h ep, ucp_lane_index_t lane)
 static inline ucp_lane_index_t ucp_ep_num_lanes(ucp_ep_h ep)
 {
     return ucp_ep_config(ep)->key.num_lanes;
+}
+
+static inline ucp_lane_index_t ucp_ep_num_valid_lanes(ucp_ep_h ep)
+{
+    ucp_lane_index_t num_lanes;
+    ucp_lane_index_t i;
+
+    for (num_lanes = 0, i = 0; i < ucp_ep_num_lanes(ep); ++i) {
+        num_lanes += (ucp_ep_get_lane_raw(ep, i) != NULL);
+    }
+
+    return num_lanes;
 }
 
 static inline int ucp_ep_is_lane_p2p(ucp_ep_h ep, ucp_lane_index_t lane)

--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -208,7 +208,7 @@ void ucp_proxy_ep_replace(ucp_proxy_ep_t *proxy_ep)
         if (uct_ep == &proxy_ep->super) {
             ucs_assert(proxy_ep->uct_ep != NULL);    /* make sure there is only one match */
             ucp_ep_set_lane(ucp_ep, lane, proxy_ep->uct_ep);
-            proxy_ep->uct_ep      = NULL;
+            proxy_ep->uct_ep = NULL;
         }
     }
 

--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -195,11 +195,17 @@ uct_ep_h ucp_proxy_ep_extract(uct_ep_h ep)
 void ucp_proxy_ep_replace(ucp_proxy_ep_t *proxy_ep)
 {
     ucp_ep_h ucp_ep = proxy_ep->ucp_ep;
+    uct_ep_h uct_ep;
     ucp_lane_index_t lane;
 
     ucs_assert(proxy_ep->uct_ep != NULL);
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
-        if (ucp_ep_get_lane(ucp_ep, lane) == &proxy_ep->super) {
+        uct_ep = ucp_ep_get_lane_raw(ucp_ep, lane);
+        if (uct_ep == NULL) {
+            continue;
+        }
+
+        if (uct_ep == &proxy_ep->super) {
             ucs_assert(proxy_ep->uct_ep != NULL);    /* make sure there is only one match */
             ucp_ep_set_lane(ucp_ep, lane, proxy_ep->uct_ep);
             proxy_ep->uct_ep      = NULL;

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -194,8 +194,8 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     init_params.select_param   = select_param;
     init_params.ep_cfg_index   = ep_cfg_index;
     init_params.rkey_cfg_index = rkey_cfg_index;
-    init_params.ep_config_key  = &ucs_array_elem(&worker->ep_config,
-                                                 ep_cfg_index).key;
+    init_params.ep_config_key  = &ucp_worker_ep_config(worker,
+                                                       ep_cfg_index)->key;
     init_params.ctx            = proto_init;
 
     if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -109,7 +109,7 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
 
         /* Search for next lane to start flush */
         lane   = ucs_ffs64(all_lanes & ~req->send.flush.started_lanes);
-        uct_ep = ucp_ep_get_lane(ep, lane);
+        uct_ep = ucp_ep_get_lane_raw(ep, lane);
         if (uct_ep == NULL) {
             ucp_ep_flush_request_update_uct_comp(req, -1, UCS_BIT(lane));
             continue;
@@ -381,6 +381,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
                                        const char *debug_name,
                                        unsigned uct_flags)
 {
+    ucp_lane_index_t num_lanes = ucp_ep_num_valid_lanes(ep);
     ucs_status_t status;
     ucp_request_t *req;
 
@@ -404,12 +405,12 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
     req->send.flush.uct_flags       = uct_flags;
     req->send.flush.sw_started      = 0;
     req->send.flush.sw_done         = 0;
-    req->send.flush.num_lanes       = ucp_ep_num_lanes(ep);
+    req->send.flush.num_lanes       = num_lanes;
     req->send.flush.started_lanes   = 0;
     req->send.lane                  = UCP_NULL_LANE;
     req->send.uct.func              = ucp_ep_flush_progress_pending;
     req->send.state.uct_comp.func   = ucp_ep_flush_completion;
-    req->send.state.uct_comp.count  = ucp_ep_num_lanes(ep);
+    req->send.state.uct_comp.count  = num_lanes;
     req->send.state.uct_comp.status = UCS_OK;
 
     ucp_request_set_super(req, worker_req);

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -111,6 +111,7 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
         lane   = ucs_ffs64(all_lanes & ~req->send.flush.started_lanes);
         uct_ep = ucp_ep_get_lane_raw(ep, lane);
         if (uct_ep == NULL) {
+            ucs_info("ep %p flush not connected lane %d", ep, lane);
             ucp_ep_flush_request_update_uct_comp(req, -1, UCS_BIT(lane));
             continue;
         }
@@ -383,7 +384,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
                                        const char *debug_name,
                                        unsigned uct_flags)
 {
-    ucp_lane_index_t num_lanes = ucp_ep_num_valid_lanes(ep);
+    ucp_lane_index_t num_lanes = ucp_ep_num_lanes(ep);
     ucs_status_t status;
     ucp_request_t *req;
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2616,8 +2616,7 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         key->lanes[lane].seg_size     = select_ctx->lane_descs[lane].seg_size;
         key->lanes[lane].path_index   = ucp_wireup_default_path_index(
                                        select_ctx->lane_descs[lane].path_index);
-        key->lanes[lane].addr_index   = select_ctx->lane_descs[lane].addr_index;
-        addr_indices[lane]            = key->lanes[lane].addr_index;
+        addr_indices[lane]            = select_ctx->lane_descs[lane].addr_index;
         ucs_trace("ep %p: construct lane %d to addr_index %d", ep, lane,
                   select_ctx->lane_descs[lane].addr_index);
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2609,7 +2609,6 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
      */
     for (lane = 0; lane < key->num_lanes; ++lane) {
         ucs_assert(select_ctx->lane_descs[lane].lane_types != 0);
-        addr_indices[lane]            = select_ctx->lane_descs[lane].addr_index;
         key->lanes[lane].rsc_index    = select_ctx->lane_descs[lane].rsc_index;
         key->lanes[lane].dst_md_index = select_ctx->lane_descs[lane].dst_md_index;
         key->lanes[lane].dst_sys_dev  = select_ctx->lane_descs[lane].dst_sys_dev;
@@ -2617,7 +2616,8 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         key->lanes[lane].seg_size     = select_ctx->lane_descs[lane].seg_size;
         key->lanes[lane].path_index   = ucp_wireup_default_path_index(
                                        select_ctx->lane_descs[lane].path_index);
-
+        key->lanes[lane].addr_index   = select_ctx->lane_descs[lane].addr_index;
+        addr_indices[lane]            = key->lanes[lane].addr_index;
         ucs_trace("ep %p: construct lane %d to addr_index %d", ep, lane,
                   select_ctx->lane_descs[lane].addr_index);
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -512,10 +512,16 @@ out:
 static int ucp_ep_has_wireup_msg_pending(ucp_ep_h ucp_ep)
 {
     ucp_wireup_ep_t *wireup_ep;
+    uct_ep_h uct_ep;
     ucp_lane_index_t lane;
 
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
-        wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ucp_ep, lane));
+        uct_ep = ucp_ep_get_lane_raw(ucp_ep, lane);
+        if (uct_ep == NULL) {
+            continue;
+        }
+
+        wireup_ep = ucp_wireup_ep(uct_ep);
         if ((wireup_ep != NULL) && (wireup_ep->pending_count != 0)) {
             return 1;
         }
@@ -539,6 +545,7 @@ static void ucp_wireup_eps_progress_sched(ucp_ep_h ucp_ep)
 unsigned ucp_wireup_eps_progress(void *arg)
 {
     ucp_ep_h ucp_ep = arg;
+    uct_ep_h uct_ep;
     ucp_wireup_ep_t *wireup_ep;
     ucs_queue_head_t tmp_pending_queue;
     ucp_lane_index_t lane;
@@ -567,7 +574,12 @@ unsigned ucp_wireup_eps_progress(void *arg)
      */
     ucp_wireup_eps_pending_extract(ucp_ep, &tmp_pending_queue);
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
-        wireup_ep = ucp_wireup_ep(ucp_ep_get_lane_raw(ucp_ep, lane));
+        uct_ep = ucp_ep_get_lane_raw(ucp_ep, lane);
+        if (uct_ep == NULL) {
+            continue;
+        }
+
+        wireup_ep = ucp_wireup_ep(uct_ep);
         if (wireup_ep == NULL) {
             continue;
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -930,6 +930,9 @@ static unsigned ucp_ep_restore_init_flags(ucp_ep_h ep)
 {
     unsigned init_flags = 0;
 
+    /* suppress clang warning */
+    ucs_assert(ep != NULL);
+
     if (ucp_ep_has_cm_lane(ep)) {
         /* TODO: check if the flags matters */
         init_flags |= UCP_EP_INIT_CM_WIREUP_CLIENT |

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1257,7 +1257,8 @@ ucp_wireup_replay_pending_request(uct_pending_req_t *self, ucp_ep_h ucp_ep)
 
     if ((req->flags & UCP_REQUEST_FLAG_PROTO_SEND) &&
         ((ucp_ep->cfg_index != req->send.proto_config->ep_cfg_index) ||
-         ucp_ep->worker->context->config.ext.proto_request_reset)) {
+         (ucp_ep->worker->context->config.ext.proto_request_reset &&
+          !ucp_ep->worker->context->config.ext.on_demand_wireup))) {
         ucp_trace_req(req, "replay proto %s",
                       req->send.proto_config->proto->name);
         ucp_proto_request_restart(req);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1216,10 +1216,6 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     } else if (msg->type == UCP_WIREUP_MSG_EP_CHECK) {
         ucs_assert((msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID) && (ep == NULL));
         ucp_wireup_send_ep_removed(worker, msg, &remote_address);
-    } else if (msg->type == UCP_WIREUP_MSG_ADDR_REQUEST) {
-        ucp_wireup_process_addr_request(worker, ep, msg, &remote_address);
-    } else if (msg->type == UCP_WIREUP_MSG_ADDR_REPLY) {
-        ucp_wireup_process_addr_reply(worker, ep, msg, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_EP_REMOVED) {
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
         ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, UCS_ERR_CONNECTION_RESET);
@@ -2157,8 +2153,10 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
 
     if (ep->cfg_index == new_cfg_index) {
 #if UCS_ENABLE_ASSERT
-        for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-            ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
+        if (!worker->context->config.ext.on_demand_wireup) {
+            for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
+                ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
+            }
         }
 #endif
         status = UCS_OK; /* No change */

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -235,7 +235,8 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
     msg_hdr->err_mode  = ucp_ep_config(ep)->key.err_mode;
     msg_hdr->conn_sn   = ep->conn_sn;
     msg_hdr->src_ep_id = ucp_ep_local_id(ep);
-    if (ep->flags & UCP_EP_FLAG_REMOTE_ID) {
+    if ((ep->flags & UCP_EP_FLAG_REMOTE_ID) &&
+        (type != UCP_WIREUP_MSG_ADDR_REQUEST)) {
         msg_hdr->dst_ep_id = ucp_ep_remote_id(ep);
     } else {
         /* Destination UCP endpoint ID must be packed in case of CM */
@@ -417,21 +418,62 @@ ucp_wireup_find_remote_p2p_addr(ucp_ep_h ep, ucp_lane_index_t remote_lane,
     return UCS_ERR_UNREACHABLE;
 }
 
+/* TODO: move the function definition */
+static ucs_status_t
+ucp_wireup_connect_lane_to_iface(ucp_ep_h ep, ucp_lane_index_t lane,
+                                 unsigned path_index,
+                                 ucp_worker_iface_t *wiface,
+                                 const ucp_address_entry_t *address);
+
 ucs_status_t
 ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_unpacked_address_t *remote_address,
-                         const ucp_lane_index_t *lanes2remote)
+                         const ucp_lane_index_t *lanes2remote,
+                         const unsigned *addr_indices)
 {
     ucp_lane_index_t lane, remote_lane;
     const ucp_address_entry_t *address_entry;
     const ucp_address_entry_ep_addr_t *ep_entry;
+    const ucp_ep_config_key_lane_t *lane_desc;
+    ucp_wireup_ep_t *wireup_ep;
     ucs_status_t status;
+    uct_ep_h uct_ep;
 
     ucs_trace("ep %p: connect local transports", ep);
     ucs_log_indent(1);
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         if (!ucp_ep_is_lane_p2p(ep, lane)) {
+            uct_ep = ucp_ep_get_lane_raw(ep, lane);
+            if (uct_ep == NULL) {
+                /* this lane is not needed yet */
+                continue;
+            }
+
+            wireup_ep = ucp_wireup_ep(uct_ep);
+            if (wireup_ep == NULL) {
+                /* this lane is not needed yet */
+                continue;
+            }
+
+            lane_desc = &ucp_ep_config(ep)->key.lanes[lane];
+            ucs_assert(addr_indices[lane] < remote_address->address_count);
+
+            status = ucp_wireup_connect_lane_to_iface(ep, lane,
+                    lane_desc->path_index,
+                    ucp_worker_iface(ep->worker, lane_desc->rsc_index),
+                    &remote_address->address_list[addr_indices[lane]]);
+
+            if (status != UCS_OK) {
+                goto out;
+            }
+
+            wireup_ep->flags |= UCP_WIREUP_EP_FLAG_READY;
+            continue;
+        }
+
+        if ((addr_indices == NULL)) {
+            /* Addr reply, this lane is already connected*/
             continue;
         }
 
@@ -523,7 +565,7 @@ unsigned ucp_wireup_eps_progress(void *arg)
         }
 
         if (wireup_ep->super.uct_ep == NULL) {
-            ucs_assert(!(wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY));
+//            ucs_assert(!(wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY));
             ucs_info("waiting for next addr_reply");
             /* waiting for next addr_reply */
             continue;
@@ -753,7 +795,8 @@ ucp_wireup_process_request(ucp_worker_h worker, ucp_ep_h ep,
         /* - EP has CM lane (it is locally connected, since CM lanes are
          *   connected) */
         has_cm_lane) {
-        status = ucp_wireup_connect_local(ep, remote_address, lanes2remote);
+        status = ucp_wireup_connect_local(ep, remote_address, lanes2remote,
+                                          addr_indices);
         if (status != UCS_OK) {
             goto err_set_ep_failed;
         }
@@ -833,21 +876,14 @@ ucp_wireup_process_reply_common(ucp_worker_h worker, ucp_ep_h ep,
          * **receiver** ep lane should be connected to a given ep address. So we
          * don't pass 'lanes2remote' mapping, and use local lanes directly.
          */
-        status = ucp_wireup_connect_local(ep, remote_address, NULL);
+        status = ucp_wireup_connect_local(ep, remote_address, NULL, NULL);
         if (status != UCS_OK) {
             ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, status);
             return;
         }
 
-        if (!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
-            ack = 1;
-        } else {
-            ucs_assert(worker->context->config.ext.on_demand_wireup);
-            ucp_wireup_eps_progress(ep);
-            ack = 0;
-        }
-
         ucp_ep_update_flags(ep, UCP_EP_FLAG_LOCAL_CONNECTED, 0);
+        ack = 1;
     } else {
         ack = 0;
     }
@@ -860,6 +896,28 @@ ucp_wireup_process_reply_common(ucp_worker_h worker, ucp_ep_h ep,
         ucs_callbackq_add_oneshot(&worker->uct->progress_q, ep,
                                   ucp_wireup_send_msg_ack, ep);
     }
+}
+
+static void
+ucp_wireup_process_addr_reply(ucp_worker_h worker, ucp_ep_h ep,
+                              const ucp_wireup_msg_t *msg,
+                              const ucp_unpacked_address_t *remote_address)
+{
+    ucs_status_t status;
+
+    UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_ADDR_REPLY);
+    ucs_info("ep %p: got wireup addr reply src_ep_id 0x%"PRIx64
+              " dst_ep_id 0x%"PRIx64" sn %d", ep, msg->src_ep_id,
+              msg->dst_ep_id, msg->conn_sn);
+
+    status = ucp_wireup_connect_local(ep, remote_address, NULL, NULL);
+    if (status != UCS_OK) {
+        ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, status);
+        return;
+    }
+
+    ucp_wireup_eps_progress(ep);
+    ucp_ep_update_flags(ep, UCP_EP_FLAG_LOCAL_CONNECTED, 0);
 }
 
 static UCS_F_NOINLINE void
@@ -891,9 +949,10 @@ static void ucp_ep_removed_flush_completion(ucp_request_t *req)
     ucp_ep_register_disconnect_progress(req);
 }
 
-static UCS_F_NOINLINE void
-ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
-                           const ucp_unpacked_address_t *remote_address)
+static UCS_F_NOINLINE ucs_status_t
+ucp_wireup_create_onetime_reply_ep(
+        ucp_worker_h worker, const ucp_unpacked_address_t *remote_address,
+        uint64_t remote_ep_id, ucp_ep_h *ep_p)
 {
     /* 1. Request a peer failure detection support from a reply EP to be able
      *    to do discarding of lanes when destroying all UCP EPs in UCP worker
@@ -910,19 +969,16 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
                              UCP_EP_INIT_CREATE_AM_LANE |
                              UCP_EP_INIT_CREATE_AM_LANE_ONLY |
                              UCP_EP_INIT_ALLOW_AM_AUX_TL;
-    ucs_status_t status;
-    ucp_ep_h reply_ep;
     unsigned addr_indices[UCP_MAX_LANES];
-    ucs_status_ptr_t req;
+    ucp_ep_h reply_ep;
+    ucs_status_t status;
     int am_need_flush;
 
-    /* If endpoint does not exist - create a temporary endpoint to send a
-     * UCP_WIREUP_MSG_EP_REMOVED reply */
     status = ucp_ep_create_base(worker, ep_init_flags, remote_address->name,
-                                "wireup ep_check reply", &reply_ep);
+        "wireup onetime reply ep", &reply_ep);
     if (status != UCS_OK) {
-        ucs_error("failed to create EP: %s", ucs_status_string(status));
-        return;
+        ucs_error("failed to create onetime EP: %s", ucs_status_string(status));
+        return status;
     }
 
     /* Initialize lanes of the reply EP */
@@ -933,25 +989,86 @@ ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
         goto out_delete_ep;
     }
 
-    ucp_ep_update_remote_id(reply_ep, msg->src_ep_id);
-    status = ucp_wireup_msg_send(reply_ep, UCP_WIREUP_MSG_EP_REMOVED,
-                                 &ucp_tl_bitmap_min, NULL);
-    if (status != UCS_OK) {
-        goto out_cleanup_lanes;
-    }
+    ucp_ep_update_remote_id(reply_ep, remote_ep_id);
+    *ep_p = reply_ep;
+    return UCS_OK;
+out_delete_ep:
+    ucp_ep_delete(reply_ep);
+    return status;
+}
 
-    req = ucp_ep_flush_internal(reply_ep, UCP_REQUEST_FLAG_RELEASED,
-                                &ucp_request_null_param, NULL,
-                                ucp_ep_removed_flush_completion, "close",
-                                UCT_FLUSH_FLAG_LOCAL);
-    if (UCS_PTR_IS_PTR(req)) {
+static void ucp_wireup_destroy_onetime_reply_ep(ucp_ep_h ep)
+{
+    ucp_ep_cleanup_lanes(ep);
+    ucp_ep_delete(ep);
+}
+
+static ucs_status_ptr_t ucp_wireup_flush_onetime_reply_ep(ucp_ep_h ep)
+{
+    return ucp_ep_flush_internal(ep, UCP_REQUEST_FLAG_RELEASED,
+                                 &ucp_request_null_param, NULL,
+                                 ucp_ep_removed_flush_completion,
+                                 "close onetime EP", UCT_FLUSH_FLAG_LOCAL);
+}
+
+static UCS_F_NOINLINE void
+ucp_wireup_send_ep_removed(ucp_worker_h worker, const ucp_wireup_msg_t *msg,
+                           const ucp_unpacked_address_t *remote_address)
+{
+    ucp_ep_h reply_ep;
+    ucs_status_t status;
+
+
+    /* If endpoint does not exist - create a temporary endpoint to send a
+     * UCP_WIREUP_MSG_EP_REMOVED reply */
+    status = ucp_wireup_create_onetime_reply_ep(worker, remote_address,
+                                                msg->src_ep_id, &reply_ep);
+    if (status != UCS_OK) {
         return;
     }
 
-out_cleanup_lanes:
-    ucp_ep_cleanup_lanes(reply_ep);
-out_delete_ep:
-    ucp_ep_delete(reply_ep);
+    status = ucp_wireup_msg_send(reply_ep, UCP_WIREUP_MSG_EP_REMOVED,
+                                 &ucp_tl_bitmap_min, NULL);
+    if (status != UCS_OK) {
+        goto out_destroy_ep;
+    }
+
+    if (UCS_PTR_IS_PTR(ucp_wireup_flush_onetime_reply_ep(reply_ep))) {
+        return;
+    }
+
+out_destroy_ep:
+    ucp_wireup_destroy_onetime_reply_ep(reply_ep);
+}
+
+static void
+ucp_wireup_process_addr_request(ucp_worker_h worker, ucp_ep_h ep,
+                                const ucp_wireup_msg_t *msg,
+                                const ucp_unpacked_address_t *remote_address)
+{
+    ucp_ep_h reply_ep;
+    ucs_status_t status;
+
+    ucs_assert(worker->context->config.ext.on_demand_wireup);
+
+    if (ep == NULL) {
+        status = ucp_wireup_create_onetime_reply_ep(worker, remote_address,
+                                                    msg->src_ep_id, &reply_ep);
+        if (status != UCS_OK) {
+            ucs_fatal("failed to create onetime EP: %s",
+                      ucs_status_string(status));
+            return;
+        }
+    } else {
+        reply_ep = ep;
+    }
+
+    ucs_info("ep %p: sending wireup addr reply", ep);
+    ucp_wireup_msg_send(reply_ep, UCP_WIREUP_MSG_ADDR_REPLY, &ucp_tl_bitmap_max,
+                        NULL);
+    if (ep == NULL) {
+        ucp_wireup_flush_onetime_reply_ep(reply_ep);
+    }
 }
 
 static UCS_F_NOINLINE
@@ -1025,6 +1142,10 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     } else if (msg->type == UCP_WIREUP_MSG_EP_REMOVED) {
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
         ucp_ep_set_failed_schedule(ep, UCP_NULL_LANE, UCS_ERR_CONNECTION_RESET);
+    } else if (msg->type == UCP_WIREUP_MSG_ADDR_REQUEST) {
+        ucp_wireup_process_addr_request(worker, ep, msg, &remote_address);
+    } else if (msg->type == UCP_WIREUP_MSG_ADDR_REPLY) {
+        ucp_wireup_process_addr_reply(worker, ep, msg, &remote_address);
     } else {
         ucs_bug("invalid wireup message");
     }
@@ -1861,7 +1982,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_rsc_index_t cm_idx = UCP_NULL_RESOURCE;
     ucp_tl_bitmap_t tl_bitmap, current_tl_bitmap;
     ucp_rsc_index_t rsc_idx;
-    ucp_lane_map_t connect_lane_bitmap;
+    ucp_lane_map_t connect_lane_bitmap, connect_lane_mask;
     ucp_ep_config_key_t key;
     ucp_worker_cfg_index_t new_cfg_index;
     ucp_lane_index_t lane;
@@ -1984,22 +2105,36 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     ucp_wireup_print_config(worker, &ucp_ep_config(ep)->key, str,
                             addr_indices, cm_idx, UCS_LOG_LEVEL_DEBUG);
 
+    if (worker->context->config.ext.on_demand_wireup) {
+        /* always connect p2p, fast, wireup and keepalive lanes */
+        connect_lane_mask = (ucp_ep_config(ep)->p2p_lanes |
+                                UCS_MASK(UCP_MAX_FAST_PATH_LANES) |
+                                UCS_BIT(ucp_ep_get_wireup_msg_lane(ep)));
+        if (ucp_ep_config(ep)->key.keepalive_lane != UCP_NULL_LANE) {
+            connect_lane_mask |= UCS_BIT(ucp_ep_config(ep)->key.keepalive_lane);
+        }
+
+        connect_lane_bitmap &= connect_lane_mask;
+    }
+
+    /* establish connections on all underlying endpoints, skipping CM lane */
+    if (ucp_ep_has_cm_lane(ep)) {
+        connect_lane_bitmap &= ~UCS_BIT(ucp_ep_get_cm_lane(ep));
+    }
+
     /* establish connections on all underlying endpoints */
-    for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        if (ucp_ep_get_cm_lane(ep) == lane) {
+    ucs_for_each_bit(lane, connect_lane_bitmap) {
+        if ((ucp_ep_get_lane_raw(ep, lane) != NULL) &&
+            !ucp_wireup_ep_test(ucp_ep_get_lane_raw(ep, lane))) {
             continue;
         }
 
-        if (connect_lane_bitmap & UCS_BIT(lane)) {
-            status = ucp_wireup_connect_lane(ep, ep_init_flags, lane,
-                                             key.lanes[lane].path_index,
-                                             remote_address, addr_indices[lane]);
-            if (status != UCS_OK) {
-                goto out;
-            }
+        status = ucp_wireup_connect_lane(ep, ep_init_flags, lane,
+                                            key.lanes[lane].path_index,
+                                            remote_address, addr_indices[lane]);
+        if (status != UCS_OK) {
+            goto out;
         }
-
-        ucs_assert(ucp_ep_get_lane(ep, lane) != NULL);
     }
 
     /* If we don't have a p2p transport, we're connected */

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -986,15 +986,7 @@ ucp_wireup_process_addr_reply(ucp_worker_h worker, ucp_ep_h ep,
 
     ep_key = ucp_ep_config(ep)->key;
 
-    /* NOTE: we need only lanes layout here */
-    /* TODO: temporary HACK, check if can avoid */
-    key.reachable_md_map = ep_key.reachable_md_map;
-    memcpy(key.dst_md_cmpts, ep_key.dst_md_cmpts,
-           ucs_popcount(ep_key.reachable_md_map) * sizeof(key.dst_md_cmpts[0]));
-    key.wireup_msg_lane = ep_key.wireup_msg_lane;
-    key.flags           = ep_key.flags;
-
-    ucs_assert(ucp_ep_config_is_equal(&ep_key, &key));
+    ucs_assert(ucp_ep_config_lanes_layout_is_equal(&ep_key, &key));
     status = ucp_wireup_connect_local(ep, UCS_MASK(ucp_ep_num_lanes(ep)) &
                                           ~ucp_ep_config(ep)->p2p_lanes,
                                       remote_address, NULL, addr_indices);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -965,7 +965,7 @@ ucp_wireup_process_addr_reply(ucp_worker_h worker, ucp_ep_h ep,
     unsigned ep_init_flags = ucp_ep_restore_init_flags(ep);
     unsigned addr_indices[UCP_MAX_LANES] = {0};
     ucp_rsc_index_t dst_mds_mem[UCP_MAX_MDS] = {0};
-    ucp_ep_config_key_t key, ep_key;
+    ucp_ep_config_key_t key;
     ucs_status_t status;
 
     UCP_WIREUP_MSG_CHECK(msg, ep, UCP_WIREUP_MSG_ADDR_REPLY);
@@ -984,9 +984,9 @@ ucp_wireup_process_addr_reply(ucp_worker_h worker, ucp_ep_h ep,
         return;
     }
 
-    ep_key = ucp_ep_config(ep)->key;
+    ucs_assert_always(
+            ucp_ep_config_lanes_layout_is_equal(&ucp_ep_config(ep)->key, &key));
 
-    ucs_assert(ucp_ep_config_lanes_layout_is_equal(&ep_key, &key));
     status = ucp_wireup_connect_local(ep, UCS_MASK(ucp_ep_num_lanes(ep)) &
                                           ~ucp_ep_config(ep)->p2p_lanes,
                                       remote_address, NULL, addr_indices);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1240,7 +1240,7 @@ out:
 
 uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane)
 {
-    uct_ep_h uct_ep = ucp_ep_get_lane(ep, lane);
+    uct_ep_h uct_ep = ucp_ep_get_lane_raw(ep, lane);
 
     if ((uct_ep != NULL) && ucp_wireup_ep_test(uct_ep)) {
         return ucp_wireup_ep_extract_next_ep(uct_ep);
@@ -2158,7 +2158,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     if (ep->cfg_index == new_cfg_index) {
 #if UCS_ENABLE_ASSERT
         for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-            ucs_assert(ucp_ep_get_lane(ep, lane) != NULL);
+            ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
         }
 #endif
         status = UCS_OK; /* No change */
@@ -2224,6 +2224,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         if (status != UCS_OK) {
             goto out;
         }
+
+        ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
     }
 
     /* If we don't have a p2p transport, we're connected */

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -48,6 +48,8 @@ enum {
     UCP_WIREUP_MSG_EP_CHECK,
     UCP_WIREUP_MSG_EP_REMOVED,
     UCP_WIREUP_MSG_REPLY_RECONFIG,
+    UCP_WIREUP_MSG_ADDR_REQUEST,
+    UCP_WIREUP_MSG_ADDR_REPLY,
     UCP_WIREUP_MSG_LAST
 };
 
@@ -223,6 +225,8 @@ double ucp_wireup_iface_bw_distance(const ucp_worker_iface_t *wiface);
 
 int ucp_wireup_is_lane_connected(ucp_ep_h ep, ucp_lane_index_t lane,
                                  const ucp_address_entry_t *addr_entry);
+
+uct_ep_h ucp_wireup_init_slow_lane(ucp_ep_h ep, ucp_lane_index_t slow_lane_idx);
 
 static inline int ucp_wireup_lane_types_has_fast_path(ucp_lane_map_t lane_types)
 {

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -208,7 +208,7 @@ int ucp_wireup_connect_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
                            int has_cm_lane);
 
 ucs_status_t
-ucp_wireup_connect_local(ucp_ep_h ep,
+ucp_wireup_connect_local(ucp_ep_h ep, uint64_t lanes_bitmap,
                          const ucp_unpacked_address_t *remote_address,
                          const ucp_lane_index_t *lanes2remote,
                          const unsigned *addr_indices);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -210,7 +210,8 @@ int ucp_wireup_connect_p2p(ucp_worker_h worker, ucp_rsc_index_t rsc_index,
 ucs_status_t
 ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_unpacked_address_t *remote_address,
-                         const ucp_lane_index_t *lanes2remote);
+                         const ucp_lane_index_t *lanes2remote,
+                         const unsigned *addr_indices);
 
 uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -704,7 +704,7 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
         goto out_free_addr;
     }
 
-    status = ucp_wireup_connect_local(ucp_ep, &addr, NULL);
+    status = ucp_wireup_connect_local(ucp_ep, &addr, NULL, NULL);
     if (status != UCS_OK) {
         ucs_debug("ep %p: failed to connect lanes: %s", ucp_ep,
                   ucs_status_string(status));
@@ -1260,7 +1260,7 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
         goto out_free_request;
     }
 
-    status = ucp_wireup_connect_local(ep, remote_addr, NULL);
+    status = ucp_wireup_connect_local(ep, remote_addr, NULL, NULL);
     if (status != UCS_OK) {
         ucs_warn("server ep %p failed to connect to remote address on "
                  "device %s, tl_bitmap " UCT_TL_BITMAP_FMT ", status %s",

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -704,7 +704,9 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
         goto out_free_addr;
     }
 
-    status = ucp_wireup_connect_local(ucp_ep, &addr, NULL, NULL);
+    status = ucp_wireup_connect_local(ucp_ep,
+                                      UCS_MASK(ucp_ep_num_lanes(ucp_ep)), &addr,
+                                      NULL, NULL);
     if (status != UCS_OK) {
         ucs_debug("ep %p: failed to connect lanes: %s", ucp_ep,
                   ucs_status_string(status));
@@ -1260,7 +1262,8 @@ ucp_ep_cm_server_create_connected(ucp_worker_h worker, unsigned ep_init_flags,
         goto out_free_request;
     }
 
-    status = ucp_wireup_connect_local(ep, remote_addr, NULL, NULL);
+    status = ucp_wireup_connect_local(ep, UCS_MASK(ucp_ep_num_lanes(ep)),
+                                      remote_addr, NULL, NULL);
     if (status != UCS_OK) {
         ucs_warn("server ep %p failed to connect to remote address on "
                  "device %s, tl_bitmap " UCT_TL_BITMAP_FMT ", status %s",
@@ -1420,7 +1423,7 @@ ucp_ep_cm_connect_server_lane(ucp_ep_h ep, uct_listener_h uct_listener,
     uct_ep_h uct_ep;
     ucs_status_t status;
 
-    ucs_assert(ucp_ep_get_lane(ep, lane) == NULL);
+    ucs_assert(ucp_ep_get_lane_raw(ep, lane) == NULL);
 
     ucp_unpacked_address_for_each(ae, remote_address) {
         max_num_paths = ucs_max(max_num_paths, ae->dev_num_paths);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -379,7 +379,7 @@ ucp_wireup_cm_ep_cleanup(ucp_ep_t *ucp_ep)
         /* During discarding, UCT EP's pending queues 
          * are expected to be empty */
         ucp_worker_discard_uct_ep(
-                ucp_ep, ucp_ep_get_lane(ucp_ep, lane_idx),
+                ucp_ep, ucp_ep_get_lane_raw(ucp_ep, lane_idx),
                 ucp_ep_get_rsc_index(ucp_ep, lane_idx), UCT_FLUSH_FLAG_CANCEL,
                 (uct_pending_purge_callback_t)ucs_empty_function_do_assert_void,
                 NULL, (ucp_send_nbx_callback_t)ucs_empty_function, NULL);
@@ -405,6 +405,12 @@ static ucs_status_t ucp_cm_ep_init_lanes(ucp_ep_h ep,
 
         rsc_idx = ucp_ep_get_rsc_index(ep, lane_idx);
         if (rsc_idx == UCP_NULL_RESOURCE) {
+            continue;
+        }
+
+        if (worker->context->config.ext.on_demand_wireup &&
+            (lane_idx >= UCP_MAX_FAST_PATH_LANES) &&
+            !ucp_ep_is_lane_p2p(ep, lane_idx)) {
             continue;
         }
 

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -678,7 +678,7 @@ void ucp_wireup_eps_pending_extract(ucp_ep_t *ucp_ep, ucs_queue_head_t *queue)
     }
 
     for (lane_idx = 0; lane_idx < ucp_ep_num_lanes(ucp_ep); ++lane_idx) {
-        uct_ep = ucp_ep_get_lane(ucp_ep, lane_idx);
+        uct_ep = ucp_ep_get_lane_raw(ucp_ep, lane_idx);
         /* When creating EP with remote worker address
          * EP is using transport lanes only, with no CM lane. */
         if ((uct_ep == NULL) || (ucp_wireup_ep(uct_ep) == NULL)) {

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -2052,9 +2052,9 @@ UCS_TEST_P(test_ucp_wireup_ondemand, slow_lanes,
     check_lanes_arr_value(ep_cfg_key(ep).rma_bw_lanes, ep_cfg_key(ep).num_lanes,
                           "rma_bw", false);
 
-    // Do RMA, then at least one slow lane lane should be initialized.
+    // Do RMA, then at least one slow lane  should be initialized.
     // NOTE: number of initialized lanes depends on HW setup and protocol
-    // selection logic and may change in future
+    //       selection logic, which may be changed in future
     ucs::handle<ucp_rkey_h> rkey = rbuf.rkey(sender());
     req = ucp_put_nbx(ep, sbuf.ptr(), sbuf.size(), (uintptr_t)rbuf.ptr(),
                       rkey.get(), &params);
@@ -2062,6 +2062,10 @@ UCS_TEST_P(test_ucp_wireup_ondemand, slow_lanes,
     check_lanes_arr_value(ep_cfg_key(ep).rma_bw_lanes,
                           ep_cfg_key(ep).num_lanes, "rma_bw",
                           /*is_valid:*/ true, /*check_all_lanes:*/ false);
+
+    // Flush receiver worker to avoid accessing destroyed rbuf from test cleanup
+    short_progress_loop();
+    flush_workers();
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_wireup_ondemand);

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1932,7 +1932,7 @@ protected:
                                bool check_all_lanes = true) {
         bool result = check_all_lanes ? true : false;
 
-        UCS_TEST_MESSAGE << "testing" << type << " lanes array["
+        UCS_TEST_MESSAGE << "testing " << type << " lanes array["
             << num_lanes << "]: "
             << [](const ucp_lane_index_t* arr, size_t size) -> std::string {
             if (size == 0) {
@@ -1942,7 +1942,7 @@ protected:
             std::string arr_str = "[";
             for (size_t i = 0; i < size; ++i) {
                 arr_str += std::to_string(arr[i]);
-                if (i < size - 1) {
+                if (i < (size - 1)) {
                     arr_str += ", ";
                 }
             }
@@ -2024,7 +2024,8 @@ UCS_TEST_P(test_ucp_wireup_ondemand, slow_lanes,
     }
 
     check_lane_value(ucp_ep_get_wireup_msg_lane(ep), "wireup_msg");
-    UCS_TEST_MESSAGE << "add wireup lane " << ucp_ep_get_wireup_msg_lane(ep);
+    UCS_TEST_MESSAGE << "add wireup lane "
+                     << int(ucp_ep_get_wireup_msg_lane(ep));
     add_uniq_lane(ucp_ep_get_wireup_msg_lane(ep));
 
     check_lane_value(ep_cfg_key(ep).am_lane, "am");

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1076,7 +1076,7 @@ public:
 
         for (ucp_lane_index_t lane = 0;
              lane < ucp_ep_num_lanes(sender().ep()); lane++) {
-            uct_ep_h uct_ep = ucp_ep_get_lane(sender().ep(), lane);
+            uct_ep_h uct_ep = ucp_ep_get_lane_raw(sender().ep(), lane);
             if (uct_ep == NULL) {
                 continue;
             }

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1986,7 +1986,6 @@ protected:
 
 UCS_TEST_P(test_ucp_wireup_ondemand, slow_lanes,
            "IB_NUM_PATHS?=6", "MAX_RMA_LANES?=6") {
-    size_t max_rma_lanes          = 6;
     ucp_request_param_t params    = { 0 };
     const size_t msg_size         = 1 * UCS_GBYTE;
     const unsigned ucp_am_id_test = 1;
@@ -2059,7 +2058,8 @@ UCS_TEST_P(test_ucp_wireup_ondemand, slow_lanes,
     req = ucp_put_nbx(ep, sbuf.ptr(), sbuf.size(), (uintptr_t)rbuf.ptr(),
                       rkey.get(), &params);
     ASSERT_UCS_OK(request_wait(req));
-    check_lanes_arr_value(ep_cfg_key(ep).rma_bw_lanes, max_rma_lanes, "rma_bw",
+    check_lanes_arr_value(ep_cfg_key(ep).rma_bw_lanes,
+                          ep_cfg_key(ep).num_lanes, "rma_bw",
                           /*is_valid:*/ true, /*check_all_lanes:*/ false);
 }
 

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1953,21 +1953,20 @@ protected:
 
 UCS_TEST_P(test_ucp_wireup_ondemand, slow_lanes,
            "IB_NUM_PATHS?=6", "MAX_RMA_LANES?=6") {
-    size_t max_rma_lanes = 6;
-    ucp_request_param_t params = { 0 };
-    const size_t msg_size = 1 * UCS_GBYTE;
+    size_t max_rma_lanes          = 6;
+    ucp_request_param_t params    = { 0 };
+    const size_t msg_size         = 1 * UCS_GBYTE;
+    const unsigned ucp_am_id_test = 1;
     mem_buffer sbuf(msg_size, UCS_MEMORY_TYPE_HOST, 0);
     mapped_buffer rbuf(msg_size, receiver());
-    const unsigned ucp_am_id_test = 1;
+    ucp_am_handler_param_t am_handler_params;
 
-    ucp_am_handler_param_t am_handler_params = {
-        .field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
-                      UCP_AM_HANDLER_PARAM_FIELD_CB |
-                      UCP_AM_HANDLER_PARAM_FIELD_ARG,
-        .id         = ucp_am_id_test,
-        .cb         = am_recv_callback,
-        .arg        = this
-    };
+    am_handler_params.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
+                                   UCP_AM_HANDLER_PARAM_FIELD_CB |
+                                   UCP_AM_HANDLER_PARAM_FIELD_ARG;
+    am_handler_params.id         = ucp_am_id_test;
+    am_handler_params.cb         = am_recv_callback;
+    am_handler_params.arg        = this;
     ASSERT_UCS_OK(ucp_worker_set_am_recv_handler(receiver().worker(),
                                                  &am_handler_params));
     sender().connect(&receiver(), get_ep_params());


### PR DESCRIPTION
## What?
Establish slow & connect-to-iface lanes on demand

## Why?
with growing scale of systems p2p connection may have multiple alternative connection paths, not all of them can be utilized (depends on real usage of protocols), so we can safe resources

## How?
 - do not initialize slow and connect-to-iface lanes on first wireup round
 - per access of lane from data path protocols (`ucp_ep_lane(lane_idx)`)
 - re-request address of remote side
 - connect the lane on address replay wireup msg