### PR TITLE
Respect MAX_RNDV_RAILS

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1887,8 +1887,9 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
 
     if (context->config.ext.proto_enable &&
         (select_params->address->dst_version > UCP_RELEASE_LEGACY)) {
-        bw_info.max_lanes = ucp_wireup_max_lanes(select_params,
-                                                 bw_info.criteria.lane_type);
+        bw_info.max_lanes = MIN(
+                context->config.ext.max_rndv_lanes,
+                ucp_wireup_max_lanes(select_params, bw_info.criteria.lane_type));
     } else {
         bw_info.max_lanes = context->config.ext.max_rndv_lanes;
     }


### PR DESCRIPTION
## What?
Respect UCX_MAX_RNDV_RAILS in rndv protocol to limit the number of lanes as configured.

## Why?
Seeing up to 10% performance degradation on DGX-1 compared to proto v1 when many rkeys need to be packed, but the lanes end up not being used.

## How?
Config limit from was only applied in proto v1. This change applies the same limit in proto v2.

Default value is 2. TBD in the PR review if this value is suitable for proto v2.