### PR TITLE
UCT/MLX5: Add put fence for DDP

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -483,7 +483,7 @@ uct_dc_mlx5_ep_put_short_inline(uct_ep_h tl_ep, const void *buffer,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uint16_t atomic_mr_offset  = uct_dc_mlx5_atomic_offset(ep);
-    uint8_t fm_ce_se           = 0;
+    uint8_t fm_ce_se;
     size_t av_size;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
@@ -515,7 +515,7 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uint16_t atomic_mr_offset  = uct_dc_mlx5_atomic_offset(ep);
-    uint8_t fm_ce_se           = MLX5_WQE_CTRL_CQ_UPDATE;
+    uint8_t fm_ce_se;
     ucs_status_t status;
     size_t av_size;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
@@ -536,7 +536,8 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
                                         uct_dc_mlx5_ep_get_grh(ep));
     status = uct_rc_mlx5_common_ep_short_dm(&iface->super, UCT_IB_QPT_DCI, NULL,
                                             0, payload, length,
-                                            MLX5_OPCODE_RDMA_WRITE, fm_ce_se,
+                                            MLX5_OPCODE_RDMA_WRITE, fm_ce_se |
+                                            MLX5_WQE_CTRL_CQ_UPDATE,
                                             ep->dci_channel_index, remote_addr,
                                             rkey, txqp, txwq, av_size);
     if (UCS_STATUS_IS_ERR(status)) {
@@ -555,7 +556,7 @@ ssize_t uct_dc_mlx5_ep_put_bcopy(uct_ep_h tl_ep, uct_pack_callback_t pack_cb,
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uint16_t atomic_mr_offset  = uct_dc_mlx5_atomic_offset(ep);
-    uint8_t fm_ce_se           = 0;
+    uint8_t fm_ce_se;
     uct_rc_iface_send_desc_t *desc;
     size_t length;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
@@ -581,7 +582,7 @@ ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
     uint16_t atomic_mr_offset  = uct_dc_mlx5_atomic_offset(ep);
-    uint8_t fm_ce_se           = 0;
+    uint8_t fm_ce_se;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(UCT_IB_MLX5_AV_FULL_SIZE),

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -124,6 +124,7 @@ uct_dc_mlx5_iface_atomic_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                                            atomic_mr_offset,
                                                            &remote_addr);
     size_t av_size;
+    uint8_t fm_ce_se;
 
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
     UCT_DC_MLX5_IFACE_TXQP_GET(iface, ep, txqp, txwq);
@@ -131,12 +132,14 @@ uct_dc_mlx5_iface_atomic_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
     desc->super.sn = txwq->sw_pi;
     av_size = uct_dc_mlx5_set_dgram_seg(txwq, iface, &ep->av,
                                         uct_dc_mlx5_ep_get_grh(ep));
+    fm_ce_se = uct_rc_mlx5_ep_fm_cq_update(
+            &iface->super, txwq, iface->super.config.atomic_fence_flag);
     uct_rc_mlx5_txqp_dptr_post(&iface->super, UCT_IB_QPT_DCI, txqp, txwq,
                                opcode, desc + 1, length, &desc->lkey,
                                remote_addr, ib_rkey,
                                compare_mask, compare, swap_mask, swap_add,
-                               av_size, MLX5_WQE_CTRL_CQ_UPDATE,
-                               ep->dci_channel_index, 0, INT_MAX, NULL);
+                               av_size, fm_ce_se, ep->dci_channel_index, 0,
+                               INT_MAX, NULL);
 
     uct_dc_mlx5_add_flush_remote(ep);
     UCT_TL_EP_STAT_ATOMIC(&ep->super);
@@ -536,8 +539,8 @@ ucs_status_t uct_dc_mlx5_ep_put_short(uct_ep_h tl_ep, const void *payload,
                                         uct_dc_mlx5_ep_get_grh(ep));
     status = uct_rc_mlx5_common_ep_short_dm(&iface->super, UCT_IB_QPT_DCI, NULL,
                                             0, payload, length,
-                                            MLX5_OPCODE_RDMA_WRITE, fm_ce_se |
-                                            MLX5_WQE_CTRL_CQ_UPDATE,
+                                            MLX5_OPCODE_RDMA_WRITE,
+                                            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
                                             ep->dci_channel_index, remote_addr,
                                             rkey, txqp, txwq, av_size);
     if (UCS_STATUS_IS_ERR(status)) {
@@ -613,7 +616,7 @@ ucs_status_t uct_dc_mlx5_ep_get_bcopy(uct_ep_h tl_ep,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
-    uint8_t fm_ce_se           = 0;
+    uint8_t fm_ce_se;
     uct_rc_iface_send_desc_t *desc;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
@@ -643,8 +646,8 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_dc_mlx5_iface_t);
     uct_dc_mlx5_ep_t *ep       = ucs_derived_of(tl_ep, uct_dc_mlx5_ep_t);
-    uint8_t fm_ce_se           = 0;
     size_t total_length        = uct_iov_total_length(iov, iovcnt);
+    uint8_t fm_ce_se;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     UCT_CHECK_IOV_SIZE(iovcnt, UCT_RC_MLX5_RMA_MAX_IOV(UCT_IB_MLX5_AV_FULL_SIZE),

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -538,19 +538,6 @@ uct_gga_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     return UCS_OK;
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_gga_mlx5_ep_fence_put(uct_rc_mlx5_iface_common_t *iface,
-                          uct_ib_mlx5_txwq_t *txwq, uct_rkey_t *rkey,
-                          uint64_t *addr, uint8_t *fm_ce_se)
-{
-    if (ucs_unlikely(uct_rc_ep_fm(&iface->super, &txwq->fi, 1))) {
-        *rkey      = uct_ib_resolve_atomic_rkey(*rkey, 0, addr);
-        *fm_ce_se |= UCT_IB_MLX5_WQE_CTRL_FLAG_STRONG_ORDER;
-    } else {
-        *rkey = uct_ib_md_direct_rkey(*rkey);
-    }
-}
-
 static ucs_status_t
 uct_gga_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                           uint64_t remote_addr, uct_rkey_t rkey,
@@ -561,7 +548,7 @@ uct_gga_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
     uct_gga_mlx5_md_t *md     = ucs_derived_of(iface->super.super.super.md,
                                                uct_gga_mlx5_md_t);
     uct_gga_mlx5_rkey_handle_t *rkey_handle = (uct_gga_mlx5_rkey_handle_t*)rkey;
-    uint8_t fm_ce_se                        = MLX5_WQE_CTRL_CQ_UPDATE;
+    uint8_t fm_ce_se;
     uct_rkey_t rkey_copy;
     ucs_status_t status;
 
@@ -577,13 +564,14 @@ uct_gga_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
     UCT_RC_CHECK_RES(&iface->super, &ep->super);
 
     rkey_copy = rkey_handle->rkey_ob.rkey;
-    uct_gga_mlx5_ep_fence_put(iface, &ep->tx.wq, &rkey_copy, &remote_addr,
-                              &fm_ce_se);
+    uct_rc_mlx5_ep_fence_put(iface, &ep->tx.wq, &rkey_copy, &remote_addr, 0,
+                             &fm_ce_se);
 
     status = uct_rc_mlx5_base_ep_zcopy_post(
             ep, MLX5_OPCODE_MMO | UCT_RC_MLX5_OPCODE_FLAG_MMO_PUT, iov, iovcnt,
             0ul, 0, NULL, 0, remote_addr, rkey_copy, 0ul, 0, 0,
-            &gga_ep->dma_opaque.opaque_mr, fm_ce_se,
+            &gga_ep->dma_opaque.opaque_mr,
+            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_send_op_completion_handler, 0, comp);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
@@ -602,7 +590,7 @@ uct_gga_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
                                                uct_gga_mlx5_md_t);
     uct_gga_mlx5_rkey_handle_t *rkey_handle = (uct_gga_mlx5_rkey_handle_t*)rkey;
     size_t total_length                     = uct_iov_total_length(iov, iovcnt);
-    uint8_t fm_ce_se                        = MLX5_WQE_CTRL_CQ_UPDATE;
+    uint8_t fm_ce_se;
     uct_rkey_t rkey_copy;
     ucs_status_t status;
 
@@ -623,7 +611,8 @@ uct_gga_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
     status = uct_rc_mlx5_base_ep_zcopy_post(
             ep, MLX5_OPCODE_MMO | UCT_RC_MLX5_OPCODE_FLAG_MMO_GET, iov, iovcnt,
             total_length, 0, NULL, 0, remote_addr, rkey_copy, 0ul, 0, 0,
-            &gga_ep->dma_opaque.opaque_mr, fm_ce_se,
+            &gga_ep->dma_opaque.opaque_mr,
+            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_get_zcopy_completion_handler,
             UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp);
 
@@ -807,9 +796,7 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
 
     uct_gga_mlx5_iface_disable_rx(&self->super);
 
-    config->super.super.fc.enable        = 0; /* FC requires AM capability */
-    self->super.config.atomic_fence_flag = UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE;
-    self->super.super.config.fence_mode  = UCT_RC_FENCE_MODE_AUTO;
+    config->super.super.fc.enable = 0; /* FC requires AM capability */
 
     uct_rc_iface_adjust_max_get_zcopy(&self->super.super, &config->super.super,
             UCT_GGA_MAX_MSG_SIZE,

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -30,10 +30,11 @@ uct_rc_mlx5_ep_fence_put(uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_txwq_t *
                          uint8_t *fm_ce_se)
 {
     if (uct_rc_ep_fm(&iface->super, &txwq->fi, 1)) {
-        *fm_ce_se |= iface->config.put_fence_flag;
-        *rkey      = uct_ib_resolve_atomic_rkey(*rkey, offset, addr);
+        *fm_ce_se = iface->config.put_fence_flag;
+        *rkey     = uct_ib_resolve_atomic_rkey(*rkey, offset, addr);
     } else {
-        *rkey = uct_ib_md_direct_rkey(*rkey);
+        *fm_ce_se = 0;
+        *rkey     = uct_ib_md_direct_rkey(*rkey);
     }
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -26,9 +26,15 @@
 
 static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_ep_fence_put(uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_txwq_t *txwq,
-                         uct_rkey_t *rkey, uint64_t *addr, uint16_t offset)
+                         uct_rkey_t *rkey, uint64_t *addr, uint16_t offset,
+                         uint8_t *fm_ce_se)
 {
-    uct_rc_ep_fence_put(&iface->super, &txwq->fi, rkey, addr, offset);
+    if (uct_rc_ep_fm(&iface->super, &txwq->fi, 1)) {
+        *fm_ce_se |= iface->config.put_fence_flag;
+        *rkey      = uct_ib_resolve_atomic_rkey(*rkey, offset, addr);
+    } else {
+        *rkey = uct_ib_md_direct_rkey(*rkey);
+    }
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -42,8 +42,9 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_ep_fence_get(uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_txwq_t *txwq,
                          uct_rkey_t *rkey, uint8_t *fm_ce_se)
 {
-    *rkey      = uct_ib_md_direct_rkey(*rkey);
-    *fm_ce_se |= uct_rc_ep_fm(&iface->super, &txwq->fi, iface->config.atomic_fence_flag);
+    *rkey     = uct_ib_md_direct_rkey(*rkey);
+    *fm_ce_se = uct_rc_ep_fm(&iface->super, &txwq->fi,
+                             iface->config.atomic_fence_flag);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -698,8 +699,6 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
 
     case MLX5_OPCODE_ATOMIC_FA:
     case MLX5_OPCODE_ATOMIC_CS:
-        fm_ce_se |= uct_rc_mlx5_ep_fm_cq_update(iface, txwq,
-                                                iface->config.atomic_fence_flag);
         ucs_assert(length == sizeof(uint64_t));
         raddr = next_seg;
         uct_ib_mlx5_ep_set_rdma_seg(raddr, remote_addr, rkey);
@@ -718,8 +717,6 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
         break;
 
     case MLX5_OPCODE_ATOMIC_MASKED_CS:
-        fm_ce_se |= uct_rc_mlx5_ep_fm_cq_update(iface, txwq,
-                                                iface->config.atomic_fence_flag);
         raddr     = next_seg;
         uct_ib_mlx5_ep_set_rdma_seg(raddr, remote_addr, rkey);
 
@@ -757,7 +754,6 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
         break;
 
      case MLX5_OPCODE_ATOMIC_MASKED_FA:
-        fm_ce_se |= uct_rc_mlx5_ep_fm_cq_update(iface, txwq, iface->config.atomic_fence_flag);
         raddr     = next_seg;
         uct_ib_mlx5_ep_set_rdma_seg(raddr, remote_addr, rkey);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -407,6 +407,7 @@ typedef struct uct_rc_mlx5_iface_common {
     struct mlx5dv_devx_event_channel   *cq_event_channel;
     struct {
         uint8_t                        atomic_fence_flag;
+        uint8_t                        put_fence_flag;
         uct_rc_mlx5_srq_topo_t         srq_topo;
         uint8_t                        log_ack_req_freq;
         uint8_t                        dp_ordering_devx;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -166,9 +166,9 @@ ucs_status_t uct_rc_mlx5_base_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 
     status = uct_rc_mlx5_base_ep_zcopy_post(
             ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt, 0ul, 0, NULL, 0,
-            remote_addr, rkey, 0ul, 0, 0, NULL, fm_ce_se |
-            MLX5_WQE_CTRL_CQ_UPDATE, uct_rc_ep_send_op_completion_handler,
-            0, comp);
+            remote_addr, rkey, 0ul, 0, 0, NULL,
+            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
+            uct_rc_ep_send_op_completion_handler, 0, comp);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
     uct_rc_ep_enable_flush_remote(&ep->super);
@@ -180,7 +180,7 @@ uct_rc_mlx5_base_ep_get_bcopy(uct_ep_h tl_ep, uct_unpack_callback_t unpack_cb,
                               void *arg, size_t length, uint64_t remote_addr,
                               uct_rkey_t rkey, uct_completion_t *comp)
 {
-    uint8_t fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
+    uint8_t fm_ce_se;
     UCT_RC_MLX5_BASE_EP_DECL(tl_ep, iface, ep);
     uct_rc_iface_send_desc_t *desc;
 
@@ -192,8 +192,9 @@ uct_rc_mlx5_base_ep_get_bcopy(uct_ep_h tl_ep, uct_unpack_callback_t unpack_cb,
     uct_rc_mlx5_ep_fence_get(iface, &ep->tx.wq, &rkey, &fm_ce_se);
     uct_rc_mlx5_common_txqp_bcopy_post(iface, IBV_QPT_RC, &ep->super.txqp,
                                        &ep->tx.wq, MLX5_OPCODE_RDMA_READ,
-                                       length, remote_addr, rkey, 0, fm_ce_se,
-                                       0, 0, desc, desc + 1, NULL);
+                                       length, remote_addr, rkey, 0,
+                                       fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE, 0,
+                                       0, desc, desc + 1, NULL);
     UCT_TL_EP_STAT_OP(&ep->super.super, GET, BCOPY, length);
     UCT_RC_RDMA_READ_POSTED(&iface->super, length);
 
@@ -205,8 +206,8 @@ ucs_status_t uct_rc_mlx5_base_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                            uct_rkey_t rkey,
                                            uct_completion_t *comp)
 {
-    uint8_t fm_ce_se    = MLX5_WQE_CTRL_CQ_UPDATE;
     size_t total_length = uct_iov_total_length(iov, iovcnt);
+    uint8_t fm_ce_se;
     UCT_RC_MLX5_BASE_EP_DECL(tl_ep, iface, ep);
     ucs_status_t status;
 
@@ -220,7 +221,8 @@ ucs_status_t uct_rc_mlx5_base_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
     uct_rc_mlx5_ep_fence_get(iface, &ep->tx.wq, &rkey, &fm_ce_se);
     status = uct_rc_mlx5_base_ep_zcopy_post(
             ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt, total_length, 0, NULL, 0,
-            remote_addr, rkey, 0ul, 0, 0, NULL, fm_ce_se,
+            remote_addr, rkey, 0ul, 0, 0, NULL,
+            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_get_zcopy_completion_handler,
             UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp);
     if (!UCS_STATUS_IS_ERR(status)) {
@@ -367,6 +369,8 @@ uct_rc_mlx5_base_ep_atomic_post(uct_ep_h tl_ep, unsigned opcode,
     uint32_t ib_rkey = uct_ib_resolve_atomic_rkey(rkey,
                                                   ep->super.atomic_mr_offset,
                                                   &remote_addr);
+    uint8_t fm_ce_se = uct_rc_mlx5_ep_fm_cq_update(
+            iface, &ep->tx.wq, iface->config.atomic_fence_flag);
 
     desc->super.sn = ep->tx.wq.sw_pi;
     uct_rc_mlx5_txqp_dptr_post(iface, IBV_QPT_RC,
@@ -374,7 +378,7 @@ uct_rc_mlx5_base_ep_atomic_post(uct_ep_h tl_ep, unsigned opcode,
                                opcode, desc + 1, length, &desc->lkey,
                                remote_addr, ib_rkey,
                                compare_mask, compare, swap_mask, swap_add,
-                               0, MLX5_WQE_CTRL_CQ_UPDATE, 0, 0, INT_MAX, NULL);
+                               0, fm_ce_se, 0, 0, INT_MAX, NULL);
 
     uct_rc_ep_enable_flush_remote(&ep->super);
     UCT_TL_EP_STAT_ATOMIC(&ep->super.super);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -817,7 +817,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
 
     if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
-         (uct_ib_device_has_pci_atomics(dev) || md->super.relaxed_order))) {
+         (uct_ib_device_has_pci_atomics(dev) || md->super.relaxed_order ||
+          (self->config.put_fence_flag != 0)))) {
         if (uct_ib_device_has_pci_atomics(dev)) {
             self->config.atomic_fence_flag = UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE;
         } else {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -817,8 +817,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
 
     if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
-         (uct_ib_device_has_pci_atomics(dev) || md->super.relaxed_order ||
-          (self->config.put_fence_flag != 0)))) {
+         (uct_ib_device_has_pci_atomics(dev) || md->super.relaxed_order))) {
         if (uct_ib_device_has_pci_atomics(dev)) {
             self->config.atomic_fence_flag = UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE;
         } else {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -733,6 +733,56 @@ uct_rc_mlx5_iface_subscribe_cqs(uct_rc_mlx5_iface_common_t *iface)
     return status;
 }
 
+static int
+uct_rc_mlx5_iface_need_strong_order(uct_rc_mlx5_iface_common_t *iface)
+{
+    return (iface->config.dp_ordering_devx > UCT_IB_MLX5_DP_ORDERING_IBTA) ||
+           iface->config.ddp_enabled_dv;
+}
+
+static ucs_status_t
+uct_rc_mlx5_iface_init_fence_flags(uct_rc_mlx5_iface_common_t *iface,
+                                   uct_rc_iface_common_config_t *rc_config,
+                                   uct_ib_mlx5_md_t *md,
+                                   uct_ib_device_t *dev)
+{
+    int strong_order = uct_rc_mlx5_iface_need_strong_order(iface);
+    int pci_atomics  = uct_ib_device_has_pci_atomics(dev);
+
+    iface->config.put_fence_flag =
+            strong_order ? UCT_IB_MLX5_WQE_CTRL_FLAG_STRONG_ORDER : 0;
+
+    switch (rc_config->fence_mode) {
+    case UCT_RC_FENCE_MODE_WEAK:
+        break;
+    case UCT_RC_FENCE_MODE_AUTO:
+        if (strong_order || pci_atomics || md->super.relaxed_order) {
+            break;
+        }
+
+        /* Fall through */
+    case UCT_RC_FENCE_MODE_NONE:
+        iface->config.atomic_fence_flag = 0;
+        iface->super.config.fence_mode  = UCT_RC_FENCE_MODE_NONE;
+        return UCS_OK;
+    default:
+        ucs_error("incorrect fence value: %d", iface->super.config.fence_mode);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (strong_order) {
+        iface->config.atomic_fence_flag =
+                UCT_IB_MLX5_WQE_CTRL_FLAG_STRONG_ORDER;
+    } else if (pci_atomics) {
+        iface->config.atomic_fence_flag = UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE;
+    } else {
+        iface->config.atomic_fence_flag = 0;
+    }
+
+    iface->super.config.fence_mode = UCT_RC_FENCE_MODE_WEAK;
+    return UCS_OK;
+}
+
 UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
                     uct_rc_iface_ops_t *ops, uct_md_h tl_md,
                     uct_worker_h worker, const uct_iface_params_t *params,
@@ -815,24 +865,9 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     self->config.log_ack_req_freq  = ucs_min(mlx5_config->log_ack_req_freq,
                                              UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ);
 
-    if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
-        ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
-         (uct_ib_device_has_pci_atomics(dev) || md->super.relaxed_order))) {
-        if (uct_ib_device_has_pci_atomics(dev)) {
-            self->config.atomic_fence_flag = UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE;
-        } else {
-            self->config.atomic_fence_flag = 0;
-        }
-        self->super.config.fence_mode      = UCT_RC_FENCE_MODE_WEAK;
-    } else if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_NONE) ||
-               ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
-                !uct_ib_device_has_pci_atomics(dev))) {
-        self->config.atomic_fence_flag     = 0;
-        self->super.config.fence_mode      = UCT_RC_FENCE_MODE_NONE;
-    } else {
-        ucs_error("incorrect fence value: %d", self->super.config.fence_mode);
-        status = UCS_ERR_INVALID_PARAM;
-        goto cleanup_tm;
+    status = uct_rc_mlx5_iface_init_fence_flags(self, rc_config, md, dev);
+    if (status != UCS_OK) {
+        goto cleanup_dm;
     }
 
     /* By default set to something that is always in cache */


### PR DESCRIPTION
## What?
Add strong ordering flag for fenced RDMA write operations. 

## Why?
Stuck of UCT put perf test show that RDMA write operations may be reordered on CX8 HW.
