### PR TITLE
UCT/IB/RC: Revert adapt EP address size without flush_rkey

### DIFF
--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -591,7 +591,7 @@ ucs_status_t uct_rc_verbs_ep_get_address(uct_ep_h tl_ep, uct_ep_addr_t *addr)
 
     rc_addr->super.flags = 0;
     uct_ib_pack_uint24(rc_addr->super.qp_num, ep->qp->qp_num);
-    if (uct_rc_iface_flush_rkey_enabled(&iface->super)) {
+    if (uct_ib_md_is_flush_rkey_valid(md->flush_rkey)) {
         rc_addr->super.flags  |= UCT_RC_VERBS_ADDR_HAS_ATOMIC_MR;
         rc_addr->atomic_mr_id  = uct_ib_md_get_atomic_mr_id(md);
         rc_addr->flush_rkey_hi = md->flush_rkey >> 16;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -198,6 +198,7 @@ uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_rc_verbs_iface_t);
+    uct_ib_md_t *md             = uct_ib_iface_md(&iface->super.super);
     ucs_status_t status;
 
     status = uct_rc_iface_query(&iface->super, iface_attr,
@@ -217,7 +218,7 @@ uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     /* Software overhead */
     iface_attr->overhead = UCT_RC_VERBS_IFACE_OVERHEAD;
 
-    iface_attr->ep_addr_len = uct_rc_iface_flush_rkey_enabled(&iface->super) ?
+    iface_attr->ep_addr_len = uct_ib_md_is_flush_rkey_valid(md->flush_rkey) ?
                                       sizeof(uct_rc_verbs_ep_flush_addr_t) :
                                       sizeof(uct_rc_verbs_ep_addr_t);
 


### PR DESCRIPTION
## What?
Revert #10633, as when MD has a valid flush_rkey (devx MD), the atomic mr offset is still needed for rc verb ep fence put, as for RTR there is a valid atomic rkey, regardless of flush_remote configuration.

repro: `./test/gtest/gtest --gtest_filter=rc/test_ucp_tag_match_rndv.post_larger_recv/2`