### PR TITLE
TOOLS/PERF: Include omp.h outside of extern C declarations

### DIFF
--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -11,6 +11,12 @@
 
 #include <tools/perf/api/libperf.h>
 
+
+#if _OPENMP
+#include <omp.h>
+#endif
+
+
 BEGIN_C_DECLS
 
 /** @file libperf_int.h */
@@ -18,11 +24,6 @@ BEGIN_C_DECLS
 #include <ucs/async/async.h>
 #include <ucs/time/time.h>
 #include <ucs/sys/math.h>
-
-
-#if _OPENMP
-#include <omp.h>
-#endif
 
 
 #define TIMING_QUEUE_SIZE    2048


### PR DESCRIPTION
## What?
Fix build failure reported in #10663. libgomp (gcc) and libomp (llvm) both already protect their declarations with `extern C` when applicable.