### PR TITLE
UCT/MM: Only poll the mm_iface selected for AM_LANE

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -604,6 +604,10 @@ void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags)
 
     ++worker->num_active_ifaces;
 
+    if (!(wiface->flags & UCP_WORKER_IFACE_FLAG_AM_LANE)) {
+        uct_flags |= UCT_PROGRESS_DISCARD;
+    }
+
     uct_iface_progress_enable(wiface->iface,
                               UCT_PROGRESS_SEND | UCT_PROGRESS_RECV | uct_flags);
 }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -604,7 +604,8 @@ void ucp_worker_iface_activate(ucp_worker_iface_t *wiface, unsigned uct_flags)
 
     ++worker->num_active_ifaces;
 
-    if (!(wiface->flags & UCP_WORKER_IFACE_FLAG_AM_LANE)) {
+    if (!(uct_flags & UCT_PROGRESS_IFACE_READY) &&
+        !(wiface->flags & UCP_WORKER_IFACE_FLAG_AM_LANE)) {
         uct_flags |= UCT_PROGRESS_DISCARD;
     }
 
@@ -641,7 +642,7 @@ static ucs_status_t ucp_worker_iface_check_events_do(ucp_worker_iface_t *wiface,
     *progress_count = uct_iface_progress(wiface->iface);
     if (prev_recv_count != wiface->proxy_recv_count) {
         /* Received relevant active messages, activate the interface */
-        ucp_worker_iface_activate(wiface, 0);
+        ucp_worker_iface_activate(wiface, UCT_PROGRESS_IFACE_READY);
         return UCS_OK;
     } else if (*progress_count == 0) {
         /* Arm the interface to wait for next event */

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -124,9 +124,11 @@ enum {
                                                                of arm_ifaces list, so
                                                                it needs to be armed
                                                                in ucp_worker_arm(). */
-    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2)  /**< There is another UCP iface
+    UCP_WORKER_IFACE_FLAG_UNUSED            = UCS_BIT(2), /**< There is another UCP iface
                                                                with the same caps, but
                                                                with better performance */
+    UCP_WORKER_IFACE_FLAG_AM_LANE           = UCS_BIT(3)  /**< This interface is selected
+                                                               for AM lane */
 };
 
 

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1449,6 +1449,7 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
                        ucp_wireup_select_info_t *am_info,
                        ucp_wireup_select_context_t *select_ctx)
 {
+    ucp_worker_iface_t *wiface;
     ucp_worker_h worker            = select_params->ep->worker;
     ucp_tl_bitmap_t tl_bitmap      = select_params->tl_bitmap;
     unsigned ep_init_flags         = ucp_wireup_ep_init_flags(select_params,
@@ -1501,6 +1502,10 @@ ucp_wireup_add_am_lane(const ucp_wireup_select_params_t *select_params,
             UCS_STATIC_BITMAP_RESET(&tl_bitmap, am_info->rsc_index);
             continue;
         }
+
+        /* Mark this interface for AM lane */
+        wiface = ucp_worker_iface(worker, am_info->rsc_index);
+        wiface->flags |= UCP_WORKER_IFACE_FLAG_AM_LANE;
 
         return ucp_wireup_add_lane(select_params, am_info, UCP_LANE_TYPE_AM,
                                    /* show error */ 1, select_ctx);

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -547,9 +547,11 @@ enum uct_flush_flags {
 enum uct_progress_types {
     UCT_PROGRESS_SEND        = UCS_BIT(0),  /**< Progress send operations */
     UCT_PROGRESS_RECV        = UCS_BIT(1),  /**< Progress receive operations */
-    UCT_PROGRESS_THREAD_SAFE = UCS_BIT(7)   /**< Enable/disable progress while
+    UCT_PROGRESS_THREAD_SAFE = UCS_BIT(2),  /**< Enable/disable progress while
                                                  another thread may be calling
                                                  @ref ucp_worker_progress(). */
+    UCT_PROGRESS_DISCARD     = UCS_BIT(7)   /**< The progress check on this
+                                                 interface can be discarded; */
 };
 
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -550,6 +550,8 @@ enum uct_progress_types {
     UCT_PROGRESS_THREAD_SAFE = UCS_BIT(2),  /**< Enable/disable progress while
                                                  another thread may be calling
                                                  @ref ucp_worker_progress(). */
+    UCT_PROGRESS_IFACE_READY = UCS_BIT(3),  /**< This iface already received
+                                                 messages, activate now */
     UCT_PROGRESS_DISCARD     = UCS_BIT(7)   /**< The progress check on this
                                                  interface can be discarded; */
 };

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -412,7 +412,8 @@ void uct_base_iface_progress_enable_cb(uct_base_iface_t *iface,
     UCS_ASYNC_BLOCK(worker->async);
 
     thread_safe = flags & UCT_PROGRESS_THREAD_SAFE;
-    flags      &= ~(UCT_PROGRESS_THREAD_SAFE | UCT_PROGRESS_DISCARD);
+    flags      &= ~(UCT_PROGRESS_THREAD_SAFE | UCT_PROGRESS_DISCARD |
+                    UCT_PROGRESS_IFACE_READY);
 
     /* Add callback only if previous flags are 0 and new flags != 0 */
     if ((!iface->progress_flags && flags) &&

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -412,7 +412,7 @@ void uct_base_iface_progress_enable_cb(uct_base_iface_t *iface,
     UCS_ASYNC_BLOCK(worker->async);
 
     thread_safe = flags & UCT_PROGRESS_THREAD_SAFE;
-    flags      &= ~UCT_PROGRESS_THREAD_SAFE;
+    flags      &= ~(UCT_PROGRESS_THREAD_SAFE | UCT_PROGRESS_DISCARD);
 
     /* Add callback only if previous flags are 0 and new flags != 0 */
     if ((!iface->progress_flags && flags) &&

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -169,6 +169,18 @@ ucs_status_t uct_mm_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_OK;
 }
 
+static void uct_mm_iface_progress_enable(uct_iface_h tl_iface, unsigned flags)
+{
+    uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
+
+    if (flags & UCT_PROGRESS_DISCARD) {
+        return;
+    }
+
+    uct_base_iface_progress_enable_cb(&iface->super.super,
+                (ucs_callback_t)iface->super.super.super.ops.iface_progress, flags);
+}
+
 static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
                                        uct_iface_attr_t *iface_attr)
 {
@@ -523,7 +535,7 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_mm_ep_t),
     .iface_flush              = uct_mm_iface_flush,
     .iface_fence              = uct_sm_iface_fence,
-    .iface_progress_enable    = uct_base_iface_progress_enable,
+    .iface_progress_enable    = uct_mm_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_mm_iface_progress,
     .iface_event_fd_get       = uct_mm_iface_event_fd_get,


### PR DESCRIPTION
## What 
Enhancement: Avoid Polling on Multiple Memory Interface FIFOs

Currently, in intra-node scenarios, multiple memory interface FIFOs (e.g., `sysv`, `xpmem`) are getting polled for messages. 
This patch ensures that only the interface selected for `AM_LANE` is polled, avoiding unnecessary polling of other FIFOs; as we
use only the FIFO selected for AM_LANE for communication

---

### 1. Wireup Stage

During the wireup stage, lanes of types `UCP_LANE_TYPE_AM`, `UCP_LANE_TYPE_RKEY_PTR`, and `UCP_LANE_TYPE_RMA_BW` are constructed to reach other `ucp_worker` instances (ranks).

#### Logs:
```
[1747027683.309179] [lib-ssp-04:3568845:0]      ucp_worker.c:1903 UCX  INFO    ucp_context_0 intra-node cfg#1 tag(sysv/memory xpmem/memory cma/memory)
[1747029739.340268] [lib-ssp-04:3568845:0]          wireup.c:1280 UCX  DEBUG   ep 0x7f1b937940a0: am_lane 0 wireup_msg_lane <none> cm_lane <none> keepalive_lane <none> reachable_mds 0x1e
[1747029739.340300] [lib-ssp-04:3568845:0]          wireup.c:1290 UCX  DEBUG   ep 0x7f1b937940a0: lane[0]:  1:sysv/memory.0 md[1]           -> addr[1].md[1]/sysv/sysdev[255] seg 4294967295 am
[1747029739.340308] [lib-ssp-04:3568845:0]          wireup.c:1290 UCX  DEBUG   ep 0x7f1b937940a0: lane[1]:  4:xpmem/memory.0 md[4]          -> addr[4].md[4]/xpmem/sysdev[255] seg 4294967295 rkey_ptr
[1747029739.340317] [lib-ssp-04:3568845:0]          wireup.c:1290 UCX  DEBUG   ep 0x7f1b937940a0: lane[2]:  3:cma/memory.0 md[3]            -> addr[3].md[3]/cma/sysdev[255] seg 4294967295 rma_bw#0
```

#### GDB Output:
```
(gdb) info line
Line 1917 of "wireup/wireup.c" starts at address 0x7f1b92323422 <ucp_wireup_init_lanes+3457> and ends at 0x7f1b9232342d <ucp_wireup_init_lanes+3468>.

(gdb) p key
$3 = {
  num_lanes = 3,
  lanes = {{
      rsc_index = 1,
      dst_md_index = 1,
      dst_sys_dev = 255,
      path_index = 0,
      lane_types = 1,
      seg_size = 4294967295
  }, {
      rsc_index = 4,
      dst_md_index = 4,
      dst_sys_dev = 255,
      path_index = 0,
      lane_types = 16,
      seg_size = 4294967295
  }, {
      rsc_index = 3,
      dst_md_index = 3,
      dst_sys_dev = 255,
      path_index = 0,
      lane_types = 8,
      seg_size = 4294967295
  }},
  am_lane = 0,
  tag_lane = 255,
  wireup_msg_lane = 255,
  cm_lane = 255,
  keepalive_lane = 255,
  ...
}
```

---

### 2. Polling 
Both `sysv` and `xpmem` FIFOs are being polled during  mca_pml_ucx_progress()

```
(gdb) bt
#0  uct_worker_progress (worker=0x22fdcf0) at src/uct/api/uct.h:2823
#1  ucp_worker_progress (worker=0x2313ed0) at core/ucp_worker.c:3059
#2  0x00007f1b932336af in mca_pml_ucx_progress () at pml_ucx.c:588
#3  0x00007f1b925c8af5 in opal_progress () at runtime/opal_progress.c:224
#4  0x00007f1b92f70990 in ompi_mpi_init (argc=0, argv=0x0, requested=0, provided=0x7ffd28f05e1c, reinit_ok=false)
    at runtime/ompi_mpi_init.c:517
#5  0x00007f1b92fd4d5a in PMPI_Init (argc=0x0, argv=0x0) at init.c:69
#6  0x0000000000400b74 in main (argc=4, argv=0x7ffd28f05f98) at send_recv.c:28
```

```
(gdb) p worker->progress_q
$11 = {
    fast_elems = {{
      cb = 0x7f1b91e97ca0 <uct_mm_iface_progress>,
      arg = 0x233a310
    }, {
      cb = 0x7f1b91e97ca0 <uct_mm_iface_progress>,
      arg = 0x2337820
    }, {
      cb = 0x0,
      arg = 0x22fdcf0
    },
    ...
}
```

---

### 3. During MPI Execution

When the MPI application is running, ranks use only one memory interface FIFO to exchange messages. 
The `xpmem` FIFO is polled unnecessarily. If multiple FIFOs were used to exchange messages, it would need a mechanism to avoid out-of-order message delivery.

---
