### PR TITLE
UCS/ARCH: Add hygon cpu detection

### DIFF
--- a/src/ucs/arch/cpu.c
+++ b/src/ucs/arch/cpu.c
@@ -3,6 +3,7 @@
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
 * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
+* Copyright (C) Hygon Information Technology Co., Ltd. 2025. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -169,7 +170,8 @@ const char *ucs_cpu_vendor_name()
         [UCS_CPU_VENDOR_GENERIC_RV64G] = "Generic RV64G",
         [UCS_CPU_VENDOR_FUJITSU_ARM]   = "Fujitsu ARM",
         [UCS_CPU_VENDOR_ZHAOXIN]       = "Zhaoxin",
-        [UCS_CPU_VENDOR_NVIDIA]        = "Nvidia"
+        [UCS_CPU_VENDOR_NVIDIA]        = "Nvidia",
+        [UCS_CPU_VENDOR_HYGON]         = "Hygon"
     };
 
     return cpu_vendor_names[ucs_arch_get_cpu_vendor()];
@@ -197,7 +199,10 @@ const char *ucs_cpu_model_name()
         [UCS_CPU_MODEL_ZHAOXIN_WUDAOKOU]   = "Wudaokou",
         [UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI]   = "Lujiazui",
         [UCS_CPU_MODEL_RV64G]              = "RV64G",
-        [UCS_CPU_MODEL_NVIDIA_GRACE]       = "Grace"
+        [UCS_CPU_MODEL_NVIDIA_GRACE]       = "Grace",
+        [UCS_CPU_MODEL_HYGON_MOKSHA]       = "Moksha",
+        [UCS_CPU_MODEL_HYGON_MOKSHA2]      = "Moksha2",
+        [UCS_CPU_MODEL_HYGON_DHARMA]       = "Dharma"
     };
 
     return cpu_model_names[ucs_arch_get_cpu_model()];

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -4,6 +4,7 @@
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 * Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
 * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
+* Copyright (C) Hygon Information Technology Co., Ltd. 2025. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -42,6 +43,9 @@ typedef enum ucs_cpu_model {
     UCS_CPU_MODEL_ZHAOXIN_LUJIAZUI,
     UCS_CPU_MODEL_RV64G,
     UCS_CPU_MODEL_NVIDIA_GRACE,
+    UCS_CPU_MODEL_HYGON_MOKSHA,
+    UCS_CPU_MODEL_HYGON_MOKSHA2,
+    UCS_CPU_MODEL_HYGON_DHARMA,
     UCS_CPU_MODEL_LAST
 } ucs_cpu_model_t;
 
@@ -74,6 +78,7 @@ typedef enum ucs_cpu_vendor {
     UCS_CPU_VENDOR_ZHAOXIN,
     UCS_CPU_VENDOR_GENERIC_RV64G,
     UCS_CPU_VENDOR_NVIDIA,
+    UCS_CPU_VENDOR_HYGON,
     UCS_CPU_VENDOR_LAST
 } ucs_cpu_vendor_t;
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -590,7 +590,7 @@ ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
     } else if (!memcmp(reg.id, X86_CPUID_CENTAURHAULS, sizeof(X86_CPUID_CENTAURHAULS) - 1) ||
                !memcmp(reg.id, X86_CPUID_SHANGHAI, sizeof(X86_CPUID_SHANGHAI) - 1)) {
         return UCS_CPU_VENDOR_ZHAOXIN;
-    }else if( !memcmp(reg.id, X86_CPUID_HYGONGENUINE, sizeof(X86_CPUID_HYGONGENUINE) - 1))
+    } else if(!memcmp(reg.id, X86_CPUID_HYGONGENUINE, sizeof(X86_CPUID_HYGONGENUINE) - 1))
     {
         return UCS_CPU_VENDOR_HYGON;
     }

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -476,8 +476,7 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
             }
             break;
         case 0x18:
-            switch (model)
-            {
+            switch (model) {
             case 0x00:
                 cpu_model = UCS_CPU_MODEL_HYGON_MOKSHA;
                 break;

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -589,8 +589,7 @@ ucs_cpu_vendor_t ucs_arch_get_cpu_vendor()
     } else if (!memcmp(reg.id, X86_CPUID_CENTAURHAULS, sizeof(X86_CPUID_CENTAURHAULS) - 1) ||
                !memcmp(reg.id, X86_CPUID_SHANGHAI, sizeof(X86_CPUID_SHANGHAI) - 1)) {
         return UCS_CPU_VENDOR_ZHAOXIN;
-    } else if(!memcmp(reg.id, X86_CPUID_HYGONGENUINE, sizeof(X86_CPUID_HYGONGENUINE) - 1))
-    {
+    } else if (!memcmp(reg.id, X86_CPUID_HYGONGENUINE, sizeof(X86_CPUID_HYGONGENUINE) - 1)) {
         return UCS_CPU_VENDOR_HYGON;
     }
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -487,8 +487,6 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
             case 0x04:
                 cpu_model = UCS_CPU_MODEL_HYGON_DHARMA;
                 break;
-            default:
-                break;
             }
             break;
         /* AMD Zen3/Zen4 */

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -633,8 +633,7 @@ static size_t ucs_cpu_nt_bt_thresh_min(size_t user_val)
 
 static size_t ucs_cpu_nt_dest_thresh()
 {
-    ucs_cpu_vendor_t vendor;
-    vendor = ucs_arch_get_cpu_vendor();
+    ucs_cpu_vendor_t vendor = ucs_arch_get_cpu_vendor();
     if (vendor == UCS_CPU_VENDOR_AMD || vendor == UCS_CPU_VENDOR_HYGON) {
         return ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3) * 9 / 8;
     } else {


### PR DESCRIPTION
## What?
add support to detect hygon cpu and reuse [amd's nt optimation](https://github.com/openucx/ucx/pull/9408)

## Why?
Currently , ucx can detect hygon's cpu, so this pr add basic support.

