### PR TITLE
UCP/EP: Enhance endpoint configuration comparison with flags

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1953,11 +1953,15 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
 }
 
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
-                           const ucp_ep_config_key_t *key2)
+                           const ucp_ep_config_key_t *key2, unsigned flags)
 {
     ucp_lane_index_t lane;
     int i;
 
+    ucs_assert(flags & UCP_EP_CONFIG_CMP_FLAG_LANES);
+    ucs_assert(flags <= UCP_EP_CONFIG_CMP_MASK_ALL);
+
+    /* Compare lanes layout */
     if ((key1->num_lanes != key2->num_lanes) ||
         memcmp(key1->rma_lanes, key2->rma_lanes, sizeof(key1->rma_lanes)) ||
         memcmp(key1->am_bw_lanes, key2->am_bw_lanes,
@@ -1965,18 +1969,12 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
         memcmp(key1->rma_bw_lanes, key2->rma_bw_lanes,
                sizeof(key1->rma_bw_lanes)) ||
         memcmp(key1->amo_lanes, key2->amo_lanes, sizeof(key1->amo_lanes)) ||
-        (key1->rma_bw_md_map != key2->rma_bw_md_map) ||
-        (key1->rma_md_map != key2->rma_md_map) ||
-        (key1->reachable_md_map != key2->reachable_md_map) ||
         (key1->am_lane != key2->am_lane) ||
         (key1->tag_lane != key2->tag_lane) ||
         (key1->wireup_msg_lane != key2->wireup_msg_lane) ||
         (key1->cm_lane != key2->cm_lane) ||
         (key1->keepalive_lane != key2->keepalive_lane) ||
-        (key1->rkey_ptr_lane != key2->rkey_ptr_lane) ||
-        (key1->err_mode != key2->err_mode) ||
-        (key1->flags != key2->flags) ||
-        (key1->dst_version != key2->dst_version)) {
+        (key1->rkey_ptr_lane != key2->rkey_ptr_lane)) {
         return 0;
     }
 
@@ -1984,6 +1982,21 @@ int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
         if (!ucp_ep_config_lane_is_equal(key1, key2, lane)) {
             return 0;
         }
+    }
+
+    /* If we are comparing lanes only, we are done */
+    if (flags != UCP_EP_CONFIG_CMP_MASK_ALL) {
+        return 1;
+    }
+
+    /* Compare all the rest */
+    if ((key1->rma_bw_md_map != key2->rma_bw_md_map) ||
+        (key1->rma_md_map != key2->rma_md_map) ||
+        (key1->reachable_md_map != key2->reachable_md_map) ||
+        (key1->err_mode != key2->err_mode) ||
+        (key1->flags != key2->flags) ||
+        (key1->dst_version != key2->dst_version)) {
+        return 0;
     }
 
     for (i = 0; i < ucs_popcount(key1->reachable_md_map); ++i) {

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -192,6 +192,17 @@ enum {
 };
 
 
+/**
+ * Endpoint configuration comparison flags
+ */
+enum {
+    /* Compare lanes layout */
+    UCP_EP_CONFIG_CMP_FLAG_LANES = UCS_BIT(0),
+    /* Strong compare of all fields */
+    UCP_EP_CONFIG_CMP_MASK_ALL   = UCS_MASK(8)
+};
+
+
 #define UCP_EP_STAT_TAG_OP(_ep, _op) \
     UCS_STATS_UPDATE_COUNTER((_ep)->stats, UCP_EP_STAT_TAG_TX_##_op, 1);
 
@@ -770,8 +781,17 @@ int ucp_ep_config_lane_is_equal(const ucp_ep_config_key_t *key1,
                                 const ucp_ep_config_key_t *key2,
                                 ucp_lane_index_t lane);
 
+/**
+ * @brief Compare two endpoint configurations.
+ *
+ * @param [in] key1  First config key to compare.
+ * @param [in] key2  Second config key to compare.
+ * @param [in] flags Comparison flags (UCP_EP_CONFIG_CMP_XXX).
+ *
+ * @return Whether the configurations are equal.
+ */
 int ucp_ep_config_is_equal(const ucp_ep_config_key_t *key1,
-                           const ucp_ep_config_key_t *key2);
+                           const ucp_ep_config_key_t *key2, unsigned flags);
 
 void ucp_ep_config_name(ucp_worker_h worker, ucp_worker_cfg_index_t cfg_index,
                         ucs_string_buffer_t *strb);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2083,7 +2083,8 @@ ucs_status_t ucp_worker_get_ep_config(ucp_worker_h worker,
 
     /* Search for the given key in the ep_config array */
     ucs_array_for_each(ep_config, &worker->ep_config) {
-        if (ucp_ep_config_is_equal(&ep_config->key, key)) {
+        if (ucp_ep_config_is_equal(&ep_config->key, key,
+                                   UCP_EP_CONFIG_CMP_MASK_ALL)) {
             ep_cfg_index = ep_config - worker->ep_config.buffer;
             goto out;
         }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1868,7 +1868,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
                                                            addr_indices);
 
     if (!is_reconfigurable &&
-        !ucp_ep_config_is_equal(&ucp_ep_config(ep)->key, &key)) {
+        !ucp_ep_config_is_equal(&ucp_ep_config(ep)->key, &key,
+                                UCP_EP_CONFIG_CMP_MASK_ALL)) {
         /* Allow to choose only the lanes that were already chosen for case
          * without CM to prevent reconfiguration error.
          */
@@ -1894,7 +1895,8 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     }
 
     if ((ep->cfg_index != UCP_WORKER_CFG_INDEX_NULL) &&
-        !ucp_ep_config_is_equal(&ucp_ep_config(ep)->key, &key)) {
+        !ucp_ep_config_is_equal(&ucp_ep_config(ep)->key, &key,
+                                UCP_EP_CONFIG_CMP_MASK_ALL)) {
         ucp_wireup_gather_pending_requests(ep, &replay_pending_queue);
     }
 


### PR DESCRIPTION
## What?
Enhance endpoint configuration comparison with flags:
- Added a new parameter for comparison `flags` to the `ucp_ep_config_is_equal` function.
- Introduced flags for comparing lanes layout and performing a strong comparison.

## Why?
Part of https://github.com/openucx/ucx/pull/10640 to minimize its size
