### PR TITLE
UCP/PROTO/CUDA: Detect src/dst memtype when estimating lane perf

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -359,14 +359,21 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                              context->config.est_num_ppn,
                                              context->config.est_num_eps);
 
-    perf_attr.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
-                           UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD |
-                           UCT_PERF_ATTR_FIELD_SEND_POST_OVERHEAD |
-                           UCT_PERF_ATTR_FIELD_RECV_OVERHEAD |
-                           UCT_PERF_ATTR_FIELD_BANDWIDTH |
-                           UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH |
-                           UCT_PERF_ATTR_FIELD_LATENCY;
-    perf_attr.operation  = params->send_op;
+    perf_attr.field_mask        = UCT_PERF_ATTR_FIELD_OPERATION |
+                                  UCT_PERF_ATTR_FIELD_LOCAL_MEMORY_TYPE |
+                                  UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD |
+                                  UCT_PERF_ATTR_FIELD_SEND_POST_OVERHEAD |
+                                  UCT_PERF_ATTR_FIELD_RECV_OVERHEAD |
+                                  UCT_PERF_ATTR_FIELD_BANDWIDTH |
+                                  UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH |
+                                  UCT_PERF_ATTR_FIELD_LATENCY;
+    perf_attr.operation         = params->send_op;
+    perf_attr.local_memory_type = params->reg_mem_info.type;
+
+    if (params->super.rkey_config_key != NULL) {
+        perf_attr.field_mask        |= UCT_PERF_ATTR_FIELD_REMOTE_MEMORY_TYPE;
+        perf_attr.remote_memory_type = params->super.rkey_config_key->mem_type;
+    }
 
     status = ucp_worker_iface_estimate_perf(wiface, &perf_attr);
     if (status != UCS_OK) {


### PR DESCRIPTION
## What?
On rock and other devices cuda_copy transport is not selected for loopback d2d tests.

## Why?
This happens because cuda_copy BW is `10000MBs,h2d:8300MBs,d2h:11660MBs,d2d:320GBs`, but protocol selection does not specify the src/dst memory types when performing an evaluation.

## How?
Use existing API to pass specific information about src/dst memory to cuda_copy so that it can use appropriate BW from the config above.
Tested manually with ucx_perftest, gtest does not work with cuda out of the box