### PR TITLE
UCP/WIREUP: Introduce address request/reply wireup messages

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1274,7 +1274,7 @@ ucp_ep_purge_lanes(ucp_ep_h ep, uct_pending_purge_callback_t purge_cb,
     uct_ep_h uct_ep;
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        uct_ep = ucp_ep_get_lane(ep, lane);
+        uct_ep = ucp_ep_get_lane_raw(ep, lane);
         if ((lane == ucp_ep_get_cm_lane(ep)) || (uct_ep == NULL)) {
             continue;
         }
@@ -1301,7 +1301,7 @@ static void ucp_ep_check_lanes(ucp_ep_h ep)
     uct_ep_h uct_ep;
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        uct_ep = ucp_ep_get_lane(ep, lane);
+        uct_ep = ucp_ep_get_lane_raw(ep, lane);
         if ((uct_ep != NULL) && ucp_is_uct_ep_failed(uct_ep)) {
             num_failed_tl_ep++;
         }
@@ -3406,7 +3406,7 @@ ucp_wireup_ep_t* ucp_ep_get_cm_wireup_ep(ucp_ep_h ep)
         return NULL;
     }
 
-    uct_ep = ucp_ep_get_lane(ep, lane);
+    uct_ep = ucp_ep_get_lane_raw(ep, lane);
     return (uct_ep != NULL) ? ucp_wireup_ep(uct_ep) : NULL;
 }
 
@@ -3420,7 +3420,7 @@ uct_ep_h ucp_ep_get_cm_uct_ep(ucp_ep_h ep)
         return NULL;
     }
 
-    if (ucp_ep_get_lane(ep, lane) == NULL) {
+    if (ucp_ep_get_lane_raw(ep, lane) == NULL) {
         return NULL;
     }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1129,7 +1129,7 @@ ucp_ep_create_api_to_worker_addr(ucp_worker_h worker,
     /* if needed, send initial wireup message */
     if (!(ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
         ucs_assert(!(ep->flags & UCP_EP_FLAG_CONNECT_REQ_QUEUED));
-        status = ucp_wireup_send_request(ep);
+        status = ucp_wireup_send_request(ep, UCP_WIREUP_MSG_REQUEST);
         if (status != UCS_OK) {
             goto out_free_address;
         }

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -67,15 +67,14 @@ ucp_ep_get_lane_raw(ucp_ep_h ep, ucp_lane_index_t lane_index)
 static UCS_F_ALWAYS_INLINE uct_ep_h
 ucp_ep_get_lane(ucp_ep_h ep, ucp_lane_index_t lane_index)
 {
-    uct_ep_h uct_ep;
-    ucs_assertv(lane_index < UCP_MAX_LANES, "lane=%d", lane_index);
+    uct_ep_h uct_ep = ucp_ep_get_lane_raw(ep, lane_index);
 
-    uct_ep = ucp_ep_get_lane_raw(ep, lane_index);
     if (ucs_likely(uct_ep != NULL)) {
         return uct_ep;
     }
 
     ucs_bug("ondemand wireup is not implemented yet");
+    ucs_assert(lane_index >= UCP_MAX_FAST_PATH_LANES);
     return ucp_wireup_init_slow_lane(ep, lane_index - UCP_MAX_FAST_PATH_LANES);
 }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -236,7 +236,7 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
     msg_hdr->conn_sn   = ep->conn_sn;
     msg_hdr->src_ep_id = ucp_ep_local_id(ep);
     if (type == UCP_WIREUP_MSG_ADDR_REQUEST) {
-        /* Reuse KA reply EP for simplicity of EP lifetime management */
+        /* Reuse onetime_reply_ep for simplicity of EP lifetime management */
         msg_hdr->dst_ep_id = UCS_PTR_MAP_KEY_INVALID;
     } else if (ep->flags & UCP_EP_FLAG_REMOTE_ID) {
         msg_hdr->dst_ep_id = ucp_ep_remote_id(ep);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1090,7 +1090,7 @@ out:
 
 uct_ep_h ucp_wireup_extract_lane(ucp_ep_h ep, ucp_lane_index_t lane)
 {
-    uct_ep_h uct_ep = ucp_ep_get_lane(ep, lane);
+    uct_ep_h uct_ep = ucp_ep_get_lane_raw(ep, lane);
 
     if ((uct_ep != NULL) && ucp_wireup_ep_test(uct_ep)) {
         return ucp_wireup_ep_extract_next_ep(uct_ep);
@@ -1162,7 +1162,7 @@ ucp_wireup_connect_lane_to_iface(ucp_ep_h ep, ucp_lane_index_t lane,
                                  ucp_worker_iface_t *wiface,
                                  const ucp_address_entry_t *address)
 {
-    uct_ep_h uct_ep = ucp_ep_get_lane(ep, lane);
+    uct_ep_h uct_ep = ucp_ep_get_lane_raw(ep, lane);
     uct_ep_params_t uct_ep_params;
     ucs_status_t status;
     uct_ep_h wireup_ep;
@@ -1189,7 +1189,7 @@ ucp_wireup_connect_lane_to_iface(ucp_ep_h ep, ucp_lane_index_t lane,
         return status;
     }
 
-    if (ucp_ep_get_lane(ep, lane) == NULL) {
+    if (ucp_ep_get_lane_raw(ep, lane) == NULL) {
         if (/* Create wireup EP in case of CM lane is used, since a WIREUP EP is
              * used to keep user's pending requests and send WIREUP MSGs (if it
              * is WIREUP MSG lane) until CM and WIREUP_MSG phases are done. The
@@ -1241,7 +1241,7 @@ ucp_wireup_connect_lane_to_ep(ucp_ep_h ep, unsigned ep_init_flags,
     uct_ep_h uct_ep;
     ucs_status_t status;
 
-    if (ucp_ep_get_lane(ep, lane) == NULL) {
+    if (ucp_ep_get_lane_raw(ep, lane) == NULL) {
         status = ucp_wireup_ep_create(ep, &uct_ep);
         if (status != UCS_OK) {
             /* coverity[leaked_storage] */
@@ -1746,7 +1746,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
     ucs_assert(!(ep->flags & UCP_EP_FLAG_INTERNAL));
 
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-        ucs_assert(ucp_ep_get_lane(ep, lane) != NULL);
+        ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
     }
 
     old_key = &ucp_ep_config(ep)->key;
@@ -1796,7 +1796,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
      * could be set in case of CM, we have to not reset them */
     for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
         reuse_lane = reuse_lane_map[lane];
-        uct_ep     = ucp_ep_get_lane(ep, lane);
+        uct_ep     = ucp_ep_get_lane_raw(ep, lane);
         if (reuse_lane == UCP_NULL_LANE) {
             if (uct_ep != NULL) {
                 ucs_assert(lane != ucp_ep_get_cm_lane(ep));
@@ -1818,7 +1818,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep, ucp_ep_config_key_t *new_key,
             ucp_ep_set_lane(ep, lane, NULL);
         }
 
-        ucs_assert(ucp_ep_get_lane(ep, lane) == NULL);
+        ucs_assert(ucp_ep_get_lane_raw(ep, lane) == NULL);
     }
 
     status = ucp_ep_realloc_lanes(ep, new_key->num_lanes);
@@ -1994,7 +1994,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
     if (ep->cfg_index == new_cfg_index) {
 #if UCS_ENABLE_ASSERT
         for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-            ucs_assert(ucp_ep_get_lane(ep, lane) != NULL);
+            ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
         }
 #endif
         status = UCS_OK; /* No change */
@@ -2045,7 +2045,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
             }
         }
 
-        ucs_assert(ucp_ep_get_lane(ep, lane) != NULL);
+        ucs_assert(ucp_ep_get_lane_raw(ep, lane) != NULL);
     }
 
     /* If we don't have a p2p transport, we're connected */

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -48,6 +48,8 @@ enum {
     UCP_WIREUP_MSG_EP_CHECK,
     UCP_WIREUP_MSG_EP_REMOVED,
     UCP_WIREUP_MSG_REPLY_RECONFIG,
+    UCP_WIREUP_MSG_ADDR_REQUEST,
+    UCP_WIREUP_MSG_ADDR_REPLY,
     UCP_WIREUP_MSG_LAST
 };
 
@@ -223,6 +225,8 @@ double ucp_wireup_iface_bw_distance(const ucp_worker_iface_t *wiface);
 
 int ucp_wireup_is_lane_connected(ucp_ep_h ep, ucp_lane_index_t lane,
                                  const ucp_address_entry_t *addr_entry);
+
+uct_ep_h ucp_wireup_init_slow_lane(ucp_ep_h ep, ucp_lane_index_t slow_lane_idx);
 
 static inline int ucp_wireup_lane_types_has_fast_path(ucp_lane_map_t lane_types)
 {

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -142,7 +142,7 @@ typedef struct {
 } ucp_wireup_select_info_t;
 
 
-ucs_status_t ucp_wireup_send_request(ucp_ep_h ep);
+ucs_status_t ucp_wireup_send_request(ucp_ep_h ep, uint8_t msg_type);
 
 ucs_status_t ucp_wireup_send_pre_request(ucp_ep_h ep);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -1420,7 +1420,7 @@ ucp_ep_cm_connect_server_lane(ucp_ep_h ep, uct_listener_h uct_listener,
     uct_ep_h uct_ep;
     ucs_status_t status;
 
-    ucs_assert(ucp_ep_get_lane(ep, lane) == NULL);
+    ucs_assert(ucp_ep_get_lane_raw(ep, lane) == NULL);
 
     ucp_unpacked_address_for_each(ae, remote_address) {
         max_num_paths = ucs_max(max_num_paths, ae->dev_num_paths);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -678,7 +678,7 @@ void ucp_wireup_eps_pending_extract(ucp_ep_t *ucp_ep, ucs_queue_head_t *queue)
     }
 
     for (lane_idx = 0; lane_idx < ucp_ep_num_lanes(ucp_ep); ++lane_idx) {
-        uct_ep = ucp_ep_get_lane(ucp_ep, lane_idx);
+        uct_ep = ucp_ep_get_lane_raw(ucp_ep, lane_idx);
         /* When creating EP with remote worker address
          * EP is using transport lanes only, with no CM lane. */
         if ((uct_ep == NULL) || (ucp_wireup_ep(uct_ep) == NULL)) {

--- a/test/gtest/ucp/test_ucp_ep_reconfig.cc
+++ b/test/gtest/ucp/test_ucp_ep_reconfig.cc
@@ -301,7 +301,7 @@ void test_ucp_ep_reconfig::entity::connect(const ucp_test_base::entity *other,
                                                           ucp_ep_destroy));
 
     if (!(ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED)) {
-        ASSERT_UCS_OK(ucp_wireup_send_request(ucp_ep));
+        ASSERT_UCS_OK(ucp_wireup_send_request(ucp_ep, UCP_WIREUP_MSG_REQUEST));
     }
 
     store_config();


### PR DESCRIPTION
## What?
- Introduce address request/reply wireup messages
- Refactored lane access functions to separate raw lane retrieval from the common access method.
- Added new wireup message types: ADDR_REQUEST and ADDR_REPLY.
- Refacored KA reply EP to be reused for ADDR_REPLY.

## Why?
Part of https://github.com/openucx/ucx/pull/10640 to minimize its size