### PR TITLE
UCP/PROTO: Increase latency factor in send-zcopy protocols only for fast completions

### DIFF
--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -170,7 +170,8 @@ ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
 
     /* Send time is representing request completion, which in case of zcopy
        waits for ACK from remote side. */
-    if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY) {
+    if ((op_attr_mask & UCP_OP_ATTR_FLAG_FAST_CMPL) &&
+        (params->flags & UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY)) {
         perf_factors[UCP_PROTO_PERF_FACTOR_LATENCY].c += tl_perf->latency;
     }
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -560,10 +560,10 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_1_lane, "IB_NUM_PATHS?=1",
     /* Prefer mock_0:1 iface for RNDV because it has larger BW */
     check_ep_config(sender(), {
         {0,     200,   "short",                "rc_mlx5/mock_1:1"},
-        {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1"},
-        {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
-        {8247,  21991, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
-        {21992, INF,   "rendezvous zero-copy read from remote",
+        {201,   404,   "copy-in",              "rc_mlx5/mock_1:1"},
+        {405,   8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
+        {8247,  21145, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
+        {21146, INF,   "rendezvous zero-copy read from remote",
                        "rc_mlx5/mock_0:1"},
     }, key);
 }
@@ -577,10 +577,10 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, zero_rndv_perf_diff, "IB_NUM_PATHS?=1",
 
     check_ep_config(sender(), {
         {0,     200,   "short",                "rc_mlx5/mock_1:1"},
-        {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1"},
-        {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
-        {8247,  22502, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
-        {22503, INF,   "rendezvous zero-copy read from remote",
+        {201,   404,   "copy-in",              "rc_mlx5/mock_1:1"},
+        {405,   8246,  "zero-copy",            "rc_mlx5/mock_1:1"},
+        {8247,  21563, "multi-frag zero-copy", "rc_mlx5/mock_1:1"},
+        {21564, INF,   "rendezvous zero-copy read from remote",
                        "rc_mlx5/mock_0:1"},
     }, key);
 }
@@ -595,10 +595,10 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_2_lanes, "IB_NUM_PATHS?=2",
     /* The optimal RNDV config must use mock_0:1 and mock_1:1 proportionally. */
     check_ep_config(sender(), {
         {0,     200,   "short",                "rc_mlx5/mock_1:1/path0"},
-        {201,   6650,  "copy-in",              "rc_mlx5/mock_1:1/path0"},
-        {6651,  8246,  "zero-copy",            "rc_mlx5/mock_1:1/path0"},
-        {8247,  19883, "multi-frag zero-copy", "rc_mlx5/mock_1:1/path0"},
-        {19884, INF,   "rendezvous zero-copy read from remote",
+        {201,   404,   "copy-in",              "rc_mlx5/mock_1:1/path0"},
+        {405,   8246,  "zero-copy",            "rc_mlx5/mock_1:1/path0"},
+        {8247,  19149, "multi-frag zero-copy", "rc_mlx5/mock_1:1/path0"},
+        {19150, INF,   "rendezvous zero-copy read from remote",
          "47% on rc_mlx5/mock_1:1/path0 and 53% on rc_mlx5/mock_0:1/path0"},
     }, key);
 }
@@ -618,12 +618,13 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_4_paths,
 
     /* All existing IB paths should be selected. */
     check_ep_config(sender(), {
-        {1,       5418,   "rendezvous fragmented copy-in copy-out",
+        {1,       477,    "rendezvous fragmented copy-in copy-out",
          "rc_mlx5/mock_1:1/path0"},
-        {5419,    283699, "rendezvous zero-copy read from remote",
+        {478,     3813,   "rendezvous zero-copy", "rc_mlx5/mock_1:1/path0"},
+        {3814,    283699, "rendezvous zero-copy read from remote",
          "12% on rc_mlx5/mock_1:1/path0, 14% on rc_mlx5/mock_0:1/path0, "
          "14% on rc_mlx5/mock_0:1/path1, 12% on rc_mlx5/mock_1:1/path1, 14%"},
-         {283700, INF,    "rendezvous zero-copy fenced write to remote",
+        {283700,  INF,    "rendezvous zero-copy fenced write to remote",
          "12% on rc_mlx5/mock_1:1/path0, 14% on rc_mlx5/mock_0:1/path0, "
          "14% on rc_mlx5/mock_0:1/path1, 12% on rc_mlx5/mock_1:1/path1, 14%"},
     }, key);
@@ -667,9 +668,9 @@ UCS_TEST_P(test_ucp_proto_mock_rcx2, rndv_send_recv_small_frag,
     key.param.op_attr          = 0;
 
     check_ep_config(sender(), {
-        {1,    3724, "rendezvous fragmented copy-in copy-out",
+        {1,   433, "rendezvous fragmented copy-in copy-out",
          "rc_mlx5/mock_0:1/path0"},
-        {3725, INF,  "rendezvous zero-copy read from remote",
+        {434, INF, "rendezvous zero-copy read from remote",
          "54% on rc_mlx5/mock_0:1/path0 and 46% on rc_mlx5/mock_1:1/path0"},
     }, key);
 
@@ -716,8 +717,8 @@ UCS_TEST_P(test_ucp_proto_mock_rcx3, single_lane_no_zcopy,
 
     /* Check that get_zcopy is selected on slower device */
     check_ep_config(sender(), {
-        {1,    3662,  "rendezvous fragmented copy-in copy-out", "rc_mlx5/mock_0:1"},
-        {3663, 53753, "rendezvous zero-copy read from remote",  "rc_mlx5/mock_1:1"},
+        {1,    94,    "rendezvous fragmented copy-in copy-out", "rc_mlx5/mock_0:1"},
+        {95,   53753, "rendezvous zero-copy read from remote",  "rc_mlx5/mock_1:1"},
         {53754, INF,  "rendezvous zero-copy fenced write to remote",
          "54% on rc_mlx5/mock_0:1 and 46% on rc_mlx5/mock_1:1"},
     }, key);
@@ -747,8 +748,8 @@ UCS_TEST_P(test_ucp_proto_mock_cma, am_send_1_lane)
 
     check_ep_config(sender(), {
         {0,      92, "short",                                 "posix/memory"},
-        {93,   5345, "copy-in",                               "posix/memory"},
-        {5346, INF,  "rendezvous zero-copy read from remote", "cma/mock"},
+        {93,   5028, "copy-in",                               "posix/memory"},
+        {5029, INF,  "rendezvous zero-copy read from remote", "cma/mock"},
     }, key);
 }
 
@@ -781,10 +782,10 @@ UCS_TEST_P(test_ucp_proto_mock_tcp, am_send_1_lane)
     key.param.op_attr          = 0;
 
     check_ep_config(sender(), {
-        {0,      8184,   "short",                                       "tcp/mock"},
-        {8185,   65528,  "zero-copy",                                   "tcp/mock"},
-        {65529,  366864, "multi-frag zero-copy",                        "tcp/mock"},
-        {366865, INF,    "rendezvous zero-copy fenced write to remote", "tcp/mock"},
+        {0,      0,      "short",                                       "tcp/mock"},
+        {1,      65528,  "zero-copy",                                   "tcp/mock"},
+        {65529,  367108, "multi-frag zero-copy",                        "tcp/mock"},
+        {367109, INF,    "rendezvous zero-copy fenced write to remote", "tcp/mock"},
     }, key);
 }
 


### PR DESCRIPTION
## What?
Increase the latency factor of send-zcopy protocols in cases of fast completion only.

## Why?
To fix the performance issue revealed in https://redmine.mellanox.com/issues/4119625, this PR limits the increment of the latency factor in send-zcopy to cases of fast-completion only, as done until this PR https://github.com/openucx/ucx/pull/10213 (remote cpu overhead is still incremented for all cases that wait for a response).