### PR TITLE
UCT/CUDA/CUDA_IPC: Set context associated with local buffer - v1.19.x

### DIFF
--- a/src/uct/cuda/Makefile.am
+++ b/src/uct/cuda/Makefile.am
@@ -24,7 +24,8 @@ noinst_HEADERS = \
 	cuda_ipc/cuda_ipc_md.h \
 	cuda_ipc/cuda_ipc_iface.h \
 	cuda_ipc/cuda_ipc_ep.h \
-	cuda_ipc/cuda_ipc_cache.h
+	cuda_ipc/cuda_ipc_cache.h \
+	cuda_ipc/cuda_ipc.inl
 
 libuct_cuda_la_SOURCES = \
 	base/cuda_iface.c \

--- a/src/uct/cuda/cuda_ipc/cuda_ipc.inl
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc.inl
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_CUDA_IPC_INL
+#define UCT_CUDA_IPC_INL
+
+#include <uct/cuda/base/cuda_iface.h>
+
+#include <cuda.h>
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_cuda_ipc_check_and_push_ctx(CUdeviceptr address, CUdevice *cuda_device_p,
+                                int *is_ctx_pushed)
+{
+#define UCT_CUDA_IPC_NUM_ATTRS 2
+    CUpointer_attribute attr_type[UCT_CUDA_IPC_NUM_ATTRS];
+    void *attr_data[UCT_CUDA_IPC_NUM_ATTRS];
+    CUcontext cuda_ctx, cuda_ctx_current;
+    int cuda_device_ordinal;
+    ucs_status_t status;
+    CUdevice cuda_device;
+
+    attr_type[0] = CU_POINTER_ATTRIBUTE_CONTEXT;
+    attr_data[0] = &cuda_ctx;
+    attr_type[1] = CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
+    attr_data[1] = &cuda_device_ordinal;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuPointerGetAttributes(UCT_CUDA_IPC_NUM_ATTRS, attr_type, attr_data,
+                                   address));
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    ucs_assertv(cuda_device_ordinal >= 0, "cuda_device_ordinal=%d",
+                cuda_device_ordinal);
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_device,
+                                                  cuda_device_ordinal));
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    if (cuda_ctx == NULL) {
+        status = uct_cuda_primary_ctx_retain(cuda_device, 0, &cuda_ctx);
+        if (ucs_unlikely(status != UCS_OK)) {
+           return status;
+        }
+
+        UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetCurrent(&cuda_ctx_current));
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    if (cuda_ctx != cuda_ctx_current) {
+        status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(cuda_ctx));
+        if (ucs_unlikely(status != UCS_OK)) {
+            return status;
+        }
+
+        *is_ctx_pushed = 1;
+    } else {
+        *is_ctx_pushed = 0;
+    }
+
+    *cuda_device_p = cuda_device;
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_cuda_ipc_check_and_pop_ctx(int is_ctx_pushed)
+{
+    if (is_ctx_pushed) {
+        UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
+    }
+}
+
+#endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -141,14 +141,14 @@ uct_cuda_ipc_close_memhandle_legacy(uct_cuda_ipc_cache_region_t *region)
 {
     ucs_status_t status;
 
-    status = uct_cuda_ipc_primary_ctx_retain_and_push(region->key.dev_num);
+    status = uct_cuda_ipc_primary_ctx_retain_and_push(region->cu_dev);
     if (status != UCS_OK) {
         return status;
     }
 
     status = UCT_CUDADRV_FUNC_LOG_WARN(
             cuIpcCloseMemHandle((CUdeviceptr)region->mapped_addr));
-    uct_cuda_ipc_primary_ctx_pop_and_release(region->key.dev_num);
+    uct_cuda_ipc_primary_ctx_pop_and_release(region->cu_dev);
     return status;
 }
 
@@ -626,6 +626,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     region->key         = *key;
     region->mapped_addr = *mapped_addr;
     region->refcount    = 1;
+    region->cu_dev      = cu_dev;
 
     status = UCS_PROFILE_CALL(ucs_pgtable_insert,
                               &cache->pgtable, &region->super);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -26,6 +26,7 @@ struct uct_cuda_ipc_cache_region {
     uct_cuda_ipc_rkey_t     key;          /**< Remote memory key */
     void                    *mapped_addr; /**< Local mapped address */
     uint64_t                refcount;     /**< Track in-flight ops before unmapping*/
+    CUdevice                cu_dev;       /**< CUDA device */
 };
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -10,6 +10,7 @@
 #include "cuda_ipc_ep.h"
 #include "cuda_ipc_iface.h"
 #include "cuda_ipc_md.h"
+#include "cuda_ipc.inl"
 
 #include <uct/base/uct_log.h>
 #include <uct/base/uct_iov.inl>
@@ -64,49 +65,27 @@ uct_cuda_primary_ctx_pop_and_release(CUdevice cuda_device)
     UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_cuda_ipc_ctx_rsc_get(uct_cuda_ipc_iface_t *iface, CUdevice cuda_device,
-                         uct_cuda_ipc_ctx_rsc_t **ctx_rsc_p)
+static UCS_F_ALWAYS_INLINE ucs_status_t uct_cuda_ipc_ctx_rsc_get(
+        uct_cuda_ipc_iface_t *iface, uct_cuda_ipc_ctx_rsc_t **ctx_rsc_p)
 {
     unsigned long long ctx_id;
     ucs_status_t status;
     CUresult result;
-    CUcontext cuda_ctx;
     uct_cuda_ctx_rsc_t *ctx_rsc;
-
-    status = uct_cuda_primary_ctx_retain(cuda_device, 0, &cuda_ctx);
-    if (ucs_unlikely(status != UCS_OK)) {
-        goto err;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(cuda_ctx));
-    if (ucs_unlikely(status != UCS_OK)) {
-        /* To workaround gcc 4.8.5 compiler error */
-        status = UCS_ERR_IO_ERROR;
-        goto err_release;
-    }
 
     result = uct_cuda_base_ctx_get_id(NULL, &ctx_id);
     if (ucs_unlikely(result != CUDA_SUCCESS)) {
         UCT_CUDADRV_LOG(cuCtxGetId, UCS_LOG_LEVEL_ERROR, result);
-        status = UCS_ERR_IO_ERROR;
-        goto err_pop;
+        return UCS_ERR_IO_ERROR;
     }
 
     status = uct_cuda_base_ctx_rsc_get(&iface->super, ctx_id, &ctx_rsc);
     if (ucs_unlikely(status != UCS_OK)) {
-        goto err_pop;
+        return status;
     }
 
     *ctx_rsc_p = ucs_derived_of(ctx_rsc, uct_cuda_ipc_ctx_rsc_t);
     return UCS_OK;
-
-err_pop:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
-err_release:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
-err:
-    return status;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -117,6 +96,8 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     uct_cuda_ipc_iface_t *iface       = ucs_derived_of(tl_ep->iface,
                                                        uct_cuda_ipc_iface_t);
     uct_cuda_ipc_unpacked_rkey_t *key = (uct_cuda_ipc_unpacked_rkey_t *)rkey;
+    CUdevice cuda_device;
+    int is_ctx_pushed;
     void *mapped_rem_addr;
     void *mapped_addr;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
@@ -133,15 +114,20 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         return UCS_OK;
     }
 
-    status = uct_cuda_ipc_map_memhandle(&key->super, key->super.dev_num,
-                                        &mapped_addr);
+    status = uct_cuda_ipc_check_and_push_ctx((CUdeviceptr)iov[0].buffer,
+                                             &cuda_device, &is_ctx_pushed);
     if (ucs_unlikely(status != UCS_OK)) {
         return status;
     }
 
-    status = uct_cuda_ipc_ctx_rsc_get(iface, key->super.dev_num, &ctx_rsc);
+    status = uct_cuda_ipc_map_memhandle(&key->super, cuda_device, &mapped_addr);
     if (ucs_unlikely(status != UCS_OK)) {
-        return status;
+        goto out;
+    }
+
+    status = uct_cuda_ipc_ctx_rsc_get(iface, &ctx_rsc);
+    if (ucs_unlikely(status != UCS_OK)) {
+        goto out;
     }
 
     offset          = (uintptr_t)remote_addr - (uintptr_t)key->super.d_bptr;
@@ -158,7 +144,7 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
 
     if (ucs_unlikely(stream == NULL)) {
         ucs_error("stream=%d for dev_num=%d not available", key->stream_id,
-                  key->super.dev_num);
+                  cuda_device);
         status = UCS_ERR_IO_ERROR;
         goto out;
     }
@@ -198,13 +184,13 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     cuda_ipc_event->mapped_addr = mapped_addr;
     cuda_ipc_event->d_bptr      = (uintptr_t)key->super.d_bptr;
     cuda_ipc_event->pid         = key->super.pid;
-    cuda_ipc_event->cuda_device = key->super.dev_num;
+    cuda_ipc_event->cuda_device = cuda_device;
     ucs_trace("cuMemcpyDtoDAsync issued :%p dst:%p, src:%p  len:%ld",
              cuda_ipc_event, (void *) dst, (void *) src, iov[0].length);
     status = UCS_INPROGRESS;
 
 out:
-    uct_cuda_primary_ctx_pop_and_release(key->super.dev_num);
+    uct_cuda_ipc_check_and_pop_ctx(is_ctx_pushed);
     return status;
 }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -135,7 +135,6 @@ typedef struct {
     pid_t                     pid;     /* PID as key to resolve peer_map hash */
     CUdeviceptr               d_bptr;  /* Allocation base address */
     size_t                    b_len;   /* Allocation size */
-    int                       dev_num; /* GPU Device number */
     CUuuid                    uuid;    /* GPU Device UUID */
 } uct_cuda_ipc_rkey_t;
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -156,37 +156,6 @@ protected:
     }
 };
 
-UCS_TEST_P(test_cuda_ipc_md, missing_device_context)
-{
-    cuda_context cuda_ctx;
-    ucs_status_t status;
-    uct_cuda_ipc_rkey_t rkey;
-    ucs::handle<uct_md_h> md;
-    int dev_num;
-
-    UCS_TEST_CREATE_HANDLE(uct_md_h, md, uct_md_close, uct_md_open,
-                           GetParam().component, GetParam().md_name.c_str(),
-                           m_md_config);
-
-    // CUDA IPC cache is functional
-    rkey          = unpack(md, 1);
-    dev_num       = rkey.dev_num;
-    rkey.dev_num  = ~rkey.dev_num;
-    rkey          = unpack(md, 1);
-    EXPECT_EQ(dev_num, rkey.dev_num);
-
-    // Unpack without a CUDA device context
-    std::thread t([&md, &rkey, &status]() {
-        rkey.dev_num = ~rkey.dev_num;
-        uct_rkey_unpack_params_t params = { 0 };
-        status = uct_rkey_unpack_v2(md->component, &rkey, &params, NULL);
-    });
-    t.join();
-
-    EXPECT_EQ(UCS_ERR_UNREACHABLE, status);
-    EXPECT_NE(dev_num, rkey.dev_num); // rkey was not updated
-}
-
 UCS_TEST_P(test_cuda_ipc_md, mpack_legacy)
 {
     constexpr size_t size = 4096;


### PR DESCRIPTION
## What?
Set context associated with local buffer before performing RMA operation in cuda_ipc transport

## Why?
Fix the following scenario:

1. Allocate data using CUDA VMM API, setting access to CUDA device X.
2. Set CUDA device Y.
3. Unpack remote key.
4. Perform UCP RMA operation.
5. cuda_ipc::[get|put]_zcopy fails to perform cuMemcpyDtoDAsync.

The issue was found using https://github.com/openucx/ucx/pull/10670.

## How?
Cherry-pick https://github.com/openucx/ucx/pull/10671
