### PR TITLE
configure.ac: remove bad macro that overwrote automake internals

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Dmitry Gladkov <dmitrygla@mellanox.com>
 Doug Jacobsen <dmjacobsen@lbl.gov>
 Edgar Gabriel <edgar.gabriel@amd.com>
 Elad Persiko <eladpe@mellanox.com>
+Eli Schwartz <eschwartz@gentoo.org>
 Eugene Voronov <eugene@mellanox.com>
 Evgeny Leksikov <evgenylek@mellanox.com>
 Fabian Ruhland <ruhland@hhu.de>

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,6 @@ define([ucx_ver_minor], 20) # Minor version. Increased for each release.
 define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 
-define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))
-
 # This is the API version (see libtool library versioning)
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # current:rev:age


### PR DESCRIPTION
In the original port to autotools, a "ts" macro was defined in m4. This meant any whole word "ts" in configure.ac or any included *.m4 file got replaced with an integer plus a newline char. Automake does this sometimes, such as in:

```
rm -f conftest.ts?
```

which was translated to:

```
rm -f conftest.20250527230813
?
```

At the time it was used to replace, on a later line,
```
BUILD_TS=ts
```

But this was removed as "unused" in 2017. It was always the wrong way to define it and is now inert except for breaking automake. Get rid of it fully.

Fixes: 597216e41e0b86219f87b965b18b1622247006c4