### PR TITLE
UCT/IB: Check EFA-specific GPUDirect support

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1332,7 +1332,9 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         uct_ib_check_gpudirect_driver(
                 md, "/sys/module/nv_peer_mem/version",
                 UCS_MEMORY_TYPE_CUDA);
-
+        uct_ib_check_gpudirect_driver(
+                md, "/sys/module/efa_nv_peermem/version",
+                UCS_MEMORY_TYPE_CUDA);
 
         /* check if ROCM KFD driver is loaded */
         uct_ib_check_gpudirect_driver(md, "/dev/kfd", UCS_MEMORY_TYPE_ROCM);


### PR DESCRIPTION
## What?
Fix GPUDirect detection for AWS EFA.

## Why?
UCX fails to detect GPUDirect as AWS EFA kernel module for GPUDirect can also be `efa_nv_peermem` with `/sys/module/efa_nv_peermem/version`.

## How?
This happens to be observed on EFAv3 (200Gbp/s per interface) node.