### PR TITLE
UCT/MM: Replace CAS with FAA

### DIFF
--- a/src/uct/sm/mm/base/mm_ep.h
+++ b/src/uct/sm/mm/base/mm_ep.h
@@ -34,6 +34,9 @@ typedef struct uct_mm_ep {
        it is not always updated with the actual remote tail value */
     uint64_t                   cached_tail;
 
+    /* the sender's reserved slot in the receiver's FIFO */
+    uint64_t                   reserved_head;
+
     /* mapped remote memory chunks to which remote descriptors belong to.
      * (after attaching to them) */
     khash_t(uct_mm_remote_seg) remote_segs;


### PR DESCRIPTION
RFC: Is there a better alternative for CAS(Compare and exchange)?
-----------------------------------------------------------------------

This proof of concept is motivated by the contention and
performance issues observed with CAS in an intra-node with a larger number
of ranks.

My intention is to:

a) Highlight the challenges with CAS in high-contention; this usually happens
   when multiple ranks try to send a buffer to a single rank in a _FULL_MPI_
   workload with 256 ranks or more.

b) Propose FAA (Fetch and add) as a potentially better alternative.

c) Gather feedback, concerns, or suggestions from UCX-experts.
   Is there any other FIFO design that can solve this issue in
   a more optimized and memory-efficient way?

References:
https://medium.com/@pravvich/cas-and-faa-through-the-eyes-of-a-java-developer-8a028f213624
https://drops.dagstuhl.de/storage/00lipics/lipics-vol146-disc2019/LIPIcs.DISC.2019.28/LIPIcs.DISC.2019.28.pdf

I can envision the following issues with the POC.

a) The reserved_head is saved globally in ep->reserved_head and used
   later, if the writer cannot immediately write to the reader's FIFO.
   This could fail for UCS_THREAD_MODE_MULTI, right?

b) A writer holding a reserved_head in a reader's FIFO might waste
   polling cycles of a reader if the reserved slot is not
   used before the reader reaches that particular slot to poll for new data.

   We can minimize this problem by increasing the FIFO size (UCX_SYSV_FIFO_SIZE)
   and more aggressively advancing the 'tail' from the reader's end (UCX_SYSV_FIFO_RELEASE_FACTOR)
   
   --Arun