### PR TITLE
DEBIAN: Moved driver level dependencies under Recommends section.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -41,6 +41,7 @@ Description: Unified Communication X - XPMEM support
 Package: ucx-cuda
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends}
+Recommends: ${shlibs:Recommends}
 Architecture: any
 Build-Profiles: <cuda>
 Description: Unified Communication X - CUDA support

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -15,6 +15,8 @@ CUDA_OPT = $(shell echo ${DEB_BUILD_PROFILES} | grep -qw cuda \
 XPMEM_OPT = $(shell echo ${DEB_BUILD_PROFILES} | grep -qw xpmem \
 	&& echo --with-xpmem || echo --without-xpmem)
 
+CUDA_SUBSTVARS = debian/ucx-cuda.substvars
+
 %:
 	dh $@ 
 
@@ -33,9 +35,10 @@ override_dh_auto_install:
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-	if [ -e debian/ucx-cuda.substvars ]; then \
-	  sed -i -e 's/libnvidia-compute-\([0-9]\+\)/libnvidia-compute | libnvidia-ml1/' \
-	    debian/ucx-cuda.substvars \
-	; fi
+	if [ -e $(CUDA_SUBSTVARS) ]; then \
+		sed -i -e 's/libnvidia-compute-\([0-9]\+\), //g' $(CUDA_SUBSTVARS); \
+		echo "shlibs:Recommends=libnvidia-compute | libnvidia-ml1" >> \
+			$(CUDA_SUBSTVARS); \
+	fi
 
 override_dh_auto_clean:


### PR DESCRIPTION
## What?
Moved `ucx-cuda` package dependency on `libnvidia-compute | libnvidia-ml1` from `Depends` to `Recommends`.

## Why?
The default behavior of `apt-install` remains unchanged. And  `--no-install-recommends` can be used to avoid installing driver level packages in a container.

