### PR TITLE
UCS/SYS: Delete redundant code in ucs_read_file_vararg

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Corey J. Nolet <cjnolet@gmail.com>
 David Wootton <dwootton@us.ibm.com>
 Devendar Bureddy <devendar@mellanox.com>
 Devesh Sharma <devesh.sharma@broadcom.com>
+Dmitrii Chervov <dschervov1@yandex.ru>
 Dmitrii Gabor <dmitryg1709@gmail.com>
 Dmitry Gladkov <dmitrygla@mellanox.com>
 Doug Jacobsen <dmjacobsen@lbl.gov>

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -460,9 +460,7 @@ static ssize_t ucs_read_file_vararg(char *buffer, size_t max, int silent,
         goto out_close;
     }
 
-    if (read_bytes < max) {
-        buffer[read_bytes] = '\0';
-    }
+    buffer[read_bytes] = '\0';
 
 out_close:
     close(fd);


### PR DESCRIPTION
## What?
Delete redundant code in "ucs_read_file_vararg" function.

## Why?
There is no point to check if "read_bytes" is less than "max" because we are calling "read" with buffer size "max - 1".

## How?
Thereforce we can delete redundant check and always terminate the buffer (string) in "read_bytes" position.