### PR TITLE
UCT/IB/BASE: Fix roce ndev name read

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Corey J. Nolet <cjnolet@gmail.com>
 David Wootton <dwootton@us.ibm.com>
 Devendar Bureddy <devendar@mellanox.com>
 Devesh Sharma <devesh.sharma@broadcom.com>
+Dmitrii Chervov <dschervov1@yandex.ru>
 Dmitry Gladkov <dmitrygla@mellanox.com>
 Doug Jacobsen <dmjacobsen@lbl.gov>
 Edgar Gabriel <edgar.gabriel@amd.com>

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1497,9 +1497,9 @@ uct_ib_device_get_roce_ndev_name(uct_ib_device_t *dev, uint8_t port_num,
     ucs_assert_always(uct_ib_device_is_port_roce(dev, port_num));
 
     /* get the network device name which corresponds to a RoCE port */
-    nread = ucs_read_file_str(ndev_name, max, 1,
-                              UCT_IB_DEVICE_SYSFS_GID_NDEV_FMT,
-                              uct_ib_device_name(dev), port_num, gid_index);
+    nread = ucs_read_file(ndev_name, max, 1,
+                          UCT_IB_DEVICE_SYSFS_GID_NDEV_FMT,
+                          uct_ib_device_name(dev), port_num, gid_index);
     if (nread < 0) {
         ucs_diag("failed to read " UCT_IB_DEVICE_SYSFS_GID_NDEV_FMT": %m",
                  uct_ib_device_name(dev), port_num, 0);


### PR DESCRIPTION
## What?
Fix the bug in the function "uct_ib_device_get_roce_ndev_index".

## Why?
Because than internet interfaces with a name of length 15 (maximum allowed) cannot work with UCX.

## How?
If a network interface name have a length of 15 (maximum allowed), and we are trying to read it to a buffer of 16 bytes size, here whats happen:
1) in function "ucs_read_file_str" MAX length will be decreased
    (now it is 15);
2) in function "ucs_read_file_vararg" there are "read" call that
    uses new MAX length (15) minus one (so it became 14).
3) If our name have maximum size we cannot read it fully, and
    it will be an error, becaus we cannot get it index from name.

It is oblivious that first size decrease was for '\0' null byte, but the second is a bug. So i replaces "ucs_read_file_str" that do the negation to a "ucs_read_file" where it didn`t happening.