### PR TITLE
UCP: Added MIN_RMA_CHUNK_SIZE

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -239,6 +239,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "multiple rails. Must be greater than 0.",
    ucs_offsetof(ucp_context_config_t, min_rndv_chunk_size), UCS_CONFIG_TYPE_MEMUNITS},
 
+  {"MIN_RMA_CHUNK_SIZE", "16k",
+   "Minimum chunk size to split the message sent with RMA protocol on\n"
+   "multiple rails. Must be greater than 0.",
+   ucs_offsetof(ucp_context_config_t, min_rma_chunk_size), UCS_CONFIG_TYPE_MEMUNITS},
+
   {"RMA_ZCOPY_MAX_SEG_SIZE", "auto",
    "Max size of a segment for rma/rndv zcopy.",
    ucs_offsetof(ucp_context_config_t, rma_zcopy_max_seg_size), UCS_CONFIG_TYPE_MEMUNITS},
@@ -2123,6 +2128,12 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
 
     if (context->config.ext.min_rndv_chunk_size == 0) {
         ucs_error("minimum chunk size for rendezvous protocol must be greater"
+                  " than 0");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (context->config.ext.min_rma_chunk_size == 0) {
+        ucs_error("minimum chunk size for RMA protocol must be greater"
                   " than 0");
         return UCS_ERR_INVALID_PARAM;
     }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -127,6 +127,9 @@ typedef struct ucp_context_config {
     /** Minimum allowed chunk size when splitting rndv message over multiple
      *  lanes */
     size_t                                 min_rndv_chunk_size;
+    /** Minimum allowed chunk size when splitting rma message over multiple
+     *  lanes */
+    size_t                                 min_rma_chunk_size;
     /** Estimated number of endpoints */
     size_t                                 estimated_num_eps;
     /** Estimated number of processes per node */

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -311,9 +311,13 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         /* Make sure fragment is not zero */
         ucs_assert(max_frag > 0);
 
-        /* Min chunk is scaled, but must be within HW limits */
-        min_chunk       = ucs_min(lane_perf->bandwidth * params->min_chunk /
-                                  min_bandwidth, lane_perf->max_frag);
+        /* Min chunk is scaled, but must be within HW limits.
+           Min chunk cannot be less than UCP_MIN_BCOPY, as it's not worth to
+           split tiny messages. */
+        min_chunk       = ucs_min(lane_perf->max_frag,
+                                  ucs_max(UCP_MIN_BCOPY,
+                                          lane_perf->bandwidth *
+                                          params->min_chunk / min_bandwidth));
         max_frag        = ucs_max(max_frag, min_chunk);
         lpriv->max_frag = max_frag;
         perf.max_frag  += max_frag;

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -63,7 +63,8 @@ ucp_proto_multi_max_payload(ucp_request_t *req,
                             const ucp_proto_multi_lane_priv_t *lpriv,
                             size_t hdr_size)
 {
-    size_t length   = req->send.state.dt_iter.length;
+    size_t length = req->send.state.dt_iter.length;
+    size_t offset = length - req->send.state.dt_iter.offset;
     size_t max_frag;
     size_t max_payload;
 
@@ -77,7 +78,7 @@ ucp_proto_multi_max_payload(ucp_request_t *req,
 
     /* Do not split very small sends to chunks, it's not worth it, and
        generic datatype may not be able to pack to a smaller buffer */
-    if (length < UCP_MIN_BCOPY) {
+    if (offset < lpriv->min_end_offset) {
         return max_frag;
     }
 
@@ -85,8 +86,7 @@ ucp_proto_multi_max_payload(ucp_request_t *req,
                           max_frag);
     ucs_assertv(max_payload > 0,
                 "length=%zu weight=%zu%% lpriv->max_frag=%zu hdr_size=%zu",
-                req->send.state.dt_iter.length,
-                ucp_proto_multi_scaled_length(lpriv->weight, 100),
+                length, ucp_proto_multi_scaled_length(lpriv->weight, 100),
                 lpriv->max_frag, hdr_size);
     return max_payload;
 }

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -109,7 +109,7 @@ ucp_proto_get_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.exclude_map   = 0,
         .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = UCP_PROTO_RMA_MAX_BCOPY_LANES,
-        .min_chunk           = 0,
+        .min_chunk           = context->config.ext.min_rma_chunk_size,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_BCOPY,
         .first.lane_type     = UCP_LANE_TYPE_RMA_BW,
@@ -219,7 +219,7 @@ ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
                                                      init_params->select_param),
         .max_lanes           = context->config.ext.max_rma_lanes,
-        .min_chunk           = 0,
+        .min_chunk           = context->config.ext.min_rma_chunk_size,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,
         .first.lane_type     = UCP_LANE_TYPE_RMA_BW,

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -189,7 +189,7 @@ ucp_proto_put_offload_bcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.exclude_map   = 0,
         .super.reg_mem_info  = ucp_mem_info_unknown,
         .max_lanes           = UCP_PROTO_RMA_MAX_BCOPY_LANES,
-        .min_chunk           = 0,
+        .min_chunk           = context->config.ext.min_rma_chunk_size,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_BCOPY,
         .first.lane_type     = UCP_LANE_TYPE_RMA_BW,
@@ -280,7 +280,7 @@ ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
                                                      init_params->select_param),
         .max_lanes           = context->config.ext.max_rma_lanes,
-        .min_chunk           = 0,
+        .min_chunk           = context->config.ext.min_rma_chunk_size,
         .initial_reg_md_map  = 0,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_ZCOPY,
         .first.lane_type     = UCP_LANE_TYPE_RMA_BW,


### PR DESCRIPTION
## What?
When executing one-sided operations like GET/PUT, UCX can split the message over multiple lanes (controlled by UCX_MAX_RMA_LANES). However, there is a certain message size limit when this split is beneficial to performance. Split on lower dimensions causes performance degradations up to 3x. This PR introduces a minimum chunk size for PUT/GET operations, below which the message is not being split into multiple chunks.
```
Message size limits measured experimentally, after which split is worth
ROCK HOST memory: PUT  - from 16k
ROCK GPU memory: PUT  - from 16k

PTYCHE (Grace) HOST memory: PUT  - from 16k
PTYCHE (Grace) GPU memory: PUT  - from 16k
```
Currently this change affects only PUT/GET operations and has no any effect on eager.

## Why?
To avoid performance penalty on small message sizes with multi-protocols.

## How?
Introduces new config option UCX_MIN_RMA_CHUNK_SIZE with default value of 16k
