### PR TITLE
UCT/ROCM: force flush to finish all pending ops

### DIFF
--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -147,13 +147,12 @@ uct_rocm_ipc_iface_flush(uct_iface_h tl_iface, unsigned flags,
         return UCS_ERR_UNSUPPORTED;
     }
 
-    if (ucs_queue_is_empty(&iface->signal_queue)) {
-        UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
-        return UCS_OK;
+    while (!ucs_queue_is_empty(&iface->signal_queue)) {
+        uct_rocm_base_progress(&iface->signal_queue);
     }
 
-    UCT_TL_IFACE_STAT_FLUSH_WAIT(ucs_derived_of(tl_iface, uct_base_iface_t));
-    return UCS_INPROGRESS;
+    UCT_TL_IFACE_STAT_FLUSH(ucs_derived_of(tl_iface, uct_base_iface_t));
+    return UCS_OK;
 }
 
 static unsigned uct_rocm_ipc_iface_progress(uct_iface_h tl_iface)


### PR DESCRIPTION
## What?
This PR fixes an issue that was uncovered while testing UCX 1.19.0-rc1. The symptom is that the osu_get_bw tests fail  with device memory. Specifically, for whatever reason UCX does not seem 'wait' during the window completions for the pending operations, and the queue of pending ipc transfers is getting longer and longer until we either run out of ipc signals or we segfault because the osu benchmark is releasing the buffer while data transfers are still ongoing.

Making ```uct_rocm_ipc_iface_flush``` force to complete all pending operations (instead of potentially just indicating with UCS_INPROGRESS that there are more pending operation) seems to resolve the issue, though I suspect that there are also other solutions.

This will also need to go to the 1.19 branch.

## Why?
its not nice to segfault

## How?
force ```uct_rocm_ipc_iface_flush``` to complete all pending operations
