### PR TITLE
TEST: use cuCtxCreate_v4 by default for newer CUDA versions - v1.19.x

### DIFF
--- a/test/gtest/uct/cuda/test_switch_cuda_device.cc
+++ b/test/gtest/uct/cuda/test_switch_cuda_device.cc
@@ -199,7 +199,12 @@ void test_p2p_create_destroy_ctx::test_xfer(send_func_t send, size_t length,
     ASSERT_EQ(cuDeviceGet(&device, 0), CUDA_SUCCESS);
 
     CUcontext ctx;
+#if CUDA_VERSION >= 12050
+    CUctxCreateParams ctx_create_params = {};
+    ASSERT_EQ(cuCtxCreate_v4(&ctx, &ctx_create_params, 0, device), CUDA_SUCCESS);
+#else
     ASSERT_EQ(cuCtxCreate(&ctx, 0, device), CUDA_SUCCESS);
+#endif
     uct_p2p_rma_test::test_xfer(send, length, flags, mem_type);
     EXPECT_EQ(cuCtxDestroy(ctx), CUDA_SUCCESS);
 }


### PR DESCRIPTION
## Why?
Builds failed with newer versions. This PR addresses new use in preparation for upcoming release.

Cherry-picked https://github.com/openucx/ucx/pull/10740
