### PR TITLE
UCP/PROTO: Deleted the mistakenly made changes from v1.19.x

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -382,7 +382,6 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                            UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH |
                            UCT_PERF_ATTR_FIELD_LATENCY;
     perf_attr.operation  = params->send_op;
-    ucp_proto_common_perf_attr_set_mem_type(params, &perf_attr);
 
     status = ucp_worker_iface_estimate_perf(wiface, &perf_attr);
     if (status != UCS_OK) {


### PR DESCRIPTION
## What?
Deleted changes from https://github.com/openucx/ucx/pull/10683.

The PR https://github.com/openucx/ucx/pull/10726 contained changes from https://github.com/openucx/ucx/pull/10683, https://github.com/openucx/ucx/pull/10696.
However, only https://github.com/openucx/ucx/pull/10696 is needed in 1.19.x branch.
Moreover, the changes from https://github.com/openucx/ucx/pull/10683 may cause [performance degradation](https://redmine.mellanox.com/issues/4535752).
