### PR TITLE
DEBIAN: Add Provides field for upstream packages

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -21,6 +21,7 @@ Depends: libc6, libgomp1
 Architecture: any
 Conflicts: libucx0 (<< ${binary:Version}), libucx-dev (<< ${binary:Version}), ucx-utils (<< ${binary:Version})
 Replaces:  libucx0 (<< ${binary:Version}), libucx-dev (<< ${binary:Version}), ucx-utils (<< ${binary:Version})
+Provides:  libucx0 (= ${binary:Version}), libucx-dev (= ${binary:Version}), ucx-utils (= ${binary:Version})
 Description: Unified Communication X
  UCX is a communication library implementing high-performance messaging.
  .


### PR DESCRIPTION
## Why
Allow any library that depends on the upstream Ubuntu packaging (libucx0, libucx-dev, ucx-utils) to work with the internal UCX packaging, that is distributed in DOCA/MLNX_OFED.

[Internal issue](https://redmine.mellanox.com/issues/4512374)
