### PR TITLE
DEBIAN: Add Provides field for upstream packages - v1.19.x

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -21,6 +21,7 @@ Depends: libc6, libgomp1
 Architecture: any
 Conflicts: libucx0 (<< ${binary:Version}), libucx-dev (<< ${binary:Version}), ucx-utils (<< ${binary:Version})
 Replaces:  libucx0 (<< ${binary:Version}), libucx-dev (<< ${binary:Version}), ucx-utils (<< ${binary:Version})
+Provides:  libucx0 (= ${binary:Version}), libucx-dev (= ${binary:Version}), ucx-utils (= ${binary:Version})
 Description: Unified Communication X
  UCX is a communication library implementing high-performance messaging.
  .


### PR DESCRIPTION
## Why
Backport #10766 to v1.19.x
