### PR TITLE
CI: Migrate JUCX publish from OSSRH to Central Portal - v1.19.x

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -172,12 +172,12 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>central</id>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -450,11 +450,11 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <serverId>central</serverId>
+          <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -53,7 +53,7 @@ jobs:
           set -eE
           {
             echo -e "<settings><servers><server>"
-            echo -e "<id>ossrh</id><username>$(SONATYPE_USERNAME)</username>"
+            echo -e "<id>central</id><username>$(SONATYPE_USERNAME)</username>"
             echo -e "<password>$(SONATYPE_PASSWORD)</password>"
             echo -e "</server></servers></settings>"
           } > $(temp_cfg)


### PR DESCRIPTION
## What?
Migrate JUCX publishing from OSSRH to Central Portal to fix Maven deployment failures.

## Why?
OSSRH reached End-of-Life on June 30, 2025: https://central.sonatype.org/pages/ossrh-eol/
All namespaces were migrated to Central Portal, requiring updated build configuration to use the new publishing system.

## How?
- Use `nexus-staging-maven-plugin` with Central Portal compatibility endpoints
- Update distribution management URLs to `ossrh-staging-api.central.sonatype.com`
- Configure pipeline to use `central` server ID in settings.xml