### PR TITLE
UCP/PROTO: Protocol variants

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -504,6 +504,14 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "directory.",
    ucs_offsetof(ucp_context_config_t, proto_info_dir), UCS_CONFIG_TYPE_STRING},
 
+  {"PROTO_VARIANTS", "y",
+   "Enable multiple variants of UCP protocols, meaning that a single protocol\n"
+   "may have multiple variants (optimized for latency or bandwidth) for the same\n"
+   "operation. The value is interpreted as follows:\n"
+   " 'y'          : Enable multiple variants\n"
+   " 'n'          : Disable multiple variants\n",
+   ucs_offsetof(ucp_context_config_t, proto_variants_enable), UCS_CONFIG_TYPE_BOOL},
+
   {"REG_NONBLOCK_MEM_TYPES", "",
    "Perform only non-blocking memory registration for these memory types.\n"
    "Non-blocking registration means that the page registration may be\n"

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -504,7 +504,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "directory.",
    ucs_offsetof(ucp_context_config_t, proto_info_dir), UCS_CONFIG_TYPE_STRING},
 
-  {"PROTO_VARIANTS", "y",
+  {"PROTO_VARIANTS", "n",
    "Enable multiple variants of UCP protocols, meaning that a single protocol\n"
    "may have multiple variants (optimized for latency or bandwidth) for the same\n"
    "operation. The value is interpreted as follows:\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -184,6 +184,8 @@ typedef struct ucp_context_config {
     char                                   *select_distance_md;
     /** Directory to write protocol selection information */
     char                                   *proto_info_dir;
+    /** Enable multiple variants of UCP protocols */
+    int                                    proto_variants_enable;
     /** Memory types that perform non-blocking registration by default */
     uint64_t                               reg_nb_mem_types;
     /** Prefer native RMA transports for RMA/AMO protocols */

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -318,6 +318,7 @@ typedef struct ucp_worker {
     ucp_worker_cm_t                  *cms;                /* Array of CMs, one for each component */
     ucs_mpool_set_t                  am_mps;              /* Memory pool set for AM receives */
     ucs_mpool_t                      reg_mp;              /* Registered memory pool */
+    ucs_mpool_t                      proto_select_mp;     /* Protocol selection memory pool */
     ucp_worker_mpool_hash_t          mpool_hash;          /* Hash table of memory pools */
     ucs_queue_head_t                 rkey_ptr_reqs;       /* Queue of submitted RKEY PTR requests that
                                                            * are in-progress */

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -235,7 +235,7 @@ ucp_proto_common_get_frag_size(const ucp_proto_common_init_params_t *params,
 
 /* Update 'perf' with the distance */
 static void ucp_proto_common_update_lane_perf_by_distance(
-        ucp_proto_common_tl_perf_t *perf, ucp_proto_perf_node_t *perf_node,
+        ucp_proto_common_tl_perf_t *perf,
         const ucs_sys_dev_distance_t *distance, const char *perf_name,
         const char *perf_fmt, ...)
 {
@@ -261,7 +261,7 @@ static void ucp_proto_common_update_lane_perf_by_distance(
     sys_perf_node = ucp_proto_perf_node_new_data(perf_name, "%s",
                                                  perf_node_desc);
     ucp_proto_perf_node_add_data(sys_perf_node, "", distance_func);
-    ucp_proto_perf_node_own_child(perf_node, &sys_perf_node);
+    ucp_proto_perf_node_own_child(perf->node, &sys_perf_node);
 }
 
 void ucp_proto_common_lane_perf_node(ucp_context_h context,
@@ -317,6 +317,7 @@ static void ucp_proto_common_tl_perf_reset(ucp_proto_common_tl_perf_t *tl_perf)
     tl_perf->sys_latency        = 0;
     tl_perf->min_length         = 0;
     tl_perf->max_frag           = SIZE_MAX;
+    tl_perf->node               = NULL;
 }
 
 static void ucp_proto_common_perf_attr_set_mem_type(
@@ -337,8 +338,7 @@ static void ucp_proto_common_perf_attr_set_mem_type(
 ucs_status_t
 ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                ucp_lane_index_t lane,
-                               ucp_proto_common_tl_perf_t *tl_perf,
-                               ucp_proto_perf_node_t **perf_node_p)
+                               ucp_proto_common_tl_perf_t *tl_perf)
 {
     ucp_worker_h worker        = params->super.worker;
     ucp_context_h context      = worker->context;
@@ -356,7 +356,6 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
 
     if (lane == UCP_NULL_LANE) {
         ucp_proto_common_tl_perf_reset(tl_perf);
-        *perf_node_p = NULL;
         return UCS_OK;
     }
 
@@ -423,7 +422,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
         ucp_proto_common_get_lane_distance(&params->super, lane, sys_dev,
                                            &distance);
         ucp_proto_common_update_lane_perf_by_distance(
-                tl_perf, perf_node, &distance, "local system", "%s %s",
+                tl_perf, &distance, "local system", "%s %s",
                 ucs_topo_sys_device_get_name(sys_dev),
                 ucs_topo_sys_device_bdf_name(sys_dev, bdf_name,
                                              sizeof(bdf_name)));
@@ -437,7 +436,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
         rkey_config = &worker->rkey_config[params->super.rkey_cfg_index];
         distance    = rkey_config->lanes_distance[lane];
         ucp_proto_common_update_lane_perf_by_distance(
-                tl_perf, perf_node, &distance, "remote system", "sys-dev %d %s",
+                tl_perf, &distance, "remote system", "sys-dev %d %s",
                 rkey_config->key.sys_dev,
                 ucs_memory_type_names[rkey_config->key.mem_type]);
     }
@@ -460,7 +459,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                    tl_perf->send_post_overhead);
     ucp_proto_perf_node_add_scalar(perf_node, "recv", tl_perf->recv_overhead);
 
-    *perf_node_p = perf_node;
+    tl_perf->node = perf_node;
     return UCS_OK;
 
 err_deref_perf_node:

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -345,7 +345,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
     ucp_rsc_index_t rsc_index  = ucp_proto_common_get_rsc_index(&params->super,
                                                                 lane);
     ucp_worker_iface_t *wiface = ucp_worker_iface(worker, rsc_index);
-    ucp_proto_perf_node_t *perf_node, *lane_perf_node;
+    ucp_proto_perf_node_t *lane_perf_node;
     const ucp_rkey_config_t *rkey_config;
     ucs_sys_dev_distance_t distance;
     size_t tl_min_frag, tl_max_frag;
@@ -369,9 +369,9 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    perf_node = ucp_proto_perf_node_new_data("lane", "%u ppn %u eps",
-                                             context->config.est_num_ppn,
-                                             context->config.est_num_eps);
+    tl_perf->node = ucp_proto_perf_node_new_data("lane", "%u ppn %u eps",
+                                                 context->config.est_num_ppn,
+                                                 context->config.est_num_eps);
 
     perf_attr.field_mask        = UCT_PERF_ATTR_FIELD_OPERATION |
                                   UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD |
@@ -405,7 +405,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
 
     ucp_proto_common_lane_perf_node(context, rsc_index, &perf_attr,
                                     &lane_perf_node);
-    ucp_proto_perf_node_own_child(perf_node, &lane_perf_node);
+    ucp_proto_perf_node_own_child(tl_perf->node, &lane_perf_node);
 
     /* If reg_mem_info type is not unknown we assume the protocol is going to
      * send that mem type in a zero copy fashion. So, need to consider the
@@ -450,20 +450,18 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                 params->hdr_size);
     ucs_assert(tl_perf->sys_latency >= 0);
 
-    ucp_proto_perf_node_add_bandwidth(perf_node, "bw", tl_perf->bandwidth);
-    ucp_proto_perf_node_add_scalar(perf_node, "lat", tl_perf->latency);
-    ucp_proto_perf_node_add_scalar(perf_node, "sys-lat", tl_perf->sys_latency);
-    ucp_proto_perf_node_add_scalar(perf_node, "send-pre",
+    ucp_proto_perf_node_add_bandwidth(tl_perf->node, "bw", tl_perf->bandwidth);
+    ucp_proto_perf_node_add_scalar(tl_perf->node, "lat", tl_perf->latency);
+    ucp_proto_perf_node_add_scalar(tl_perf->node, "sys-lat", tl_perf->sys_latency);
+    ucp_proto_perf_node_add_scalar(tl_perf->node, "send-pre",
                                    tl_perf->send_pre_overhead);
-    ucp_proto_perf_node_add_scalar(perf_node, "send-post",
+    ucp_proto_perf_node_add_scalar(tl_perf->node, "send-post",
                                    tl_perf->send_post_overhead);
-    ucp_proto_perf_node_add_scalar(perf_node, "recv", tl_perf->recv_overhead);
-
-    tl_perf->node = perf_node;
+    ucp_proto_perf_node_add_scalar(tl_perf->node, "recv", tl_perf->recv_overhead);
     return UCS_OK;
 
 err_deref_perf_node:
-    ucp_proto_perf_node_deref(&perf_node);
+    ucp_proto_perf_node_deref(&tl_perf->node);
     return status;
 }
 

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -926,3 +926,196 @@ void ucp_proto_fatal_invalid_stage(ucp_request_t *req, const char *func_name)
               req->send.proto_config->proto->name, req->send.proto_stage,
               func_name);
 }
+
+static UCS_F_ALWAYS_INLINE double
+ucp_proto_select_get_avail_bw(const ucp_proto_init_params_t *params,
+                              ucp_lane_index_t lane,
+                              const ucp_proto_common_tl_perf_t *lane_perf,
+                              const ucp_proto_lane_selection_t *selection)
+{
+    /* Minimal path ratio */
+    static const double MIN_RATIO = 0.01;
+    ucp_context_h context         = params->worker->context;
+    double multi_path_ratio       = context->config.ext.multi_path_ratio;
+    ucp_rsc_index_t dev_index     = ucp_proto_common_get_dev_index(params, lane);
+    uint8_t path_index            = selection->dev_count[dev_index];
+    double ratio;
+
+    if (UCS_CONFIG_DBL_IS_AUTO(multi_path_ratio)) {
+        ratio = ucs_min(1.0 - (lane_perf->path_ratio * path_index),
+                        lane_perf->path_ratio);
+    } else {
+        ratio = 1.0 - (multi_path_ratio * path_index);
+    }
+
+    if (ratio < MIN_RATIO) {
+        /* The iface BW is entirely consumed by the selected paths. But we still
+         * need to assign some minimal BW to the these extra paths in order to
+         * select them. We divide min ratio of the iface BW by path_index so
+         * that each additional path on the same device has lower bandwidth. */
+        ratio = MIN_RATIO / path_index;
+    }
+
+    ucs_trace("ratio=%0.3f path_index=%u avail_bw=" UCP_PROTO_PERF_FUNC_BW_FMT
+              " " UCP_PROTO_LANE_FMT, ratio, path_index,
+              (lane_perf->bandwidth * ratio) / UCS_MBYTE,
+              UCP_PROTO_LANE_ARG(params, lane, lane_perf));
+
+    return lane_perf->bandwidth * ratio;
+}
+
+static UCS_F_ALWAYS_INLINE double
+ucp_proto_select_get_score(double bw, const ucp_proto_common_tl_perf_t *lane_perf,
+                           ucp_proto_variant_t variant)
+{
+    size_t msg_size = ucp_proto_common_get_variant_msg_size(variant);
+    return 1.0 / ((msg_size / bw) + lane_perf->latency);
+}
+
+static ucp_lane_index_t
+ucp_proto_select_find_max_score_lane(const ucp_proto_init_params_t *params,
+                                     const ucp_lane_index_t *lanes,
+                                     const ucp_proto_common_tl_perf_t *lanes_perf,
+                                     const ucp_proto_lane_selection_t *selection,
+                                     ucp_lane_map_t index_map)
+{
+    double max_score           = 0.0;
+    ucp_lane_index_t max_index = UCP_NULL_LANE;
+    double score;
+    double avail_bw;
+    const ucp_proto_common_tl_perf_t *lane_perf;
+    ucp_lane_index_t lane, index;
+
+    ucs_assert(index_map != 0);
+    ucs_for_each_bit(index, index_map) {
+        lane      = lanes[index];
+        lane_perf = &lanes_perf[lane];
+        avail_bw  = ucp_proto_select_get_avail_bw(params, lane, lane_perf,
+                                                 selection);
+        score     = ucp_proto_select_get_score(avail_bw, lane_perf,
+                                              selection->variant);
+        if (score > max_score) {
+            max_score = score;
+            max_index = index;
+        }
+    }
+
+    return max_index;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_proto_select_add_lane(ucp_proto_lane_selection_t *selection,
+                          const ucp_proto_init_params_t *params,
+                          ucp_lane_index_t lane)
+{
+    ucp_rsc_index_t dev_index = ucp_proto_common_get_dev_index(params, lane);
+
+    ucs_assertv(selection->num_lanes < UCP_PROTO_MAX_LANES,
+                "selection num_lanes=%u max_lanes=%u", selection->num_lanes,
+                UCP_PROTO_MAX_LANES);
+    selection->lanes[selection->num_lanes++] = lane;
+    selection->lane_map                     |= UCS_BIT(lane);
+    selection->dev_count[dev_index]++;
+}
+
+void
+ucp_proto_select_lanes(const ucp_proto_init_params_t *params,
+                       const ucp_lane_index_t *lanes,
+                       ucp_lane_index_t num_lanes, ucp_lane_index_t max_lanes,
+                       const ucp_proto_common_tl_perf_t *lanes_perf,
+                       int fixed_first_lane, ucp_proto_variant_t variant,
+                       ucp_proto_lane_selection_t *selection)
+{
+    ucp_lane_index_t i, lane_index;
+    ucp_lane_map_t index_map;
+
+    memset(selection, 0, sizeof(*selection));
+    selection->variant = variant;
+
+    /* Select all available indexes */
+    index_map = UCS_MASK(num_lanes);
+
+    if (fixed_first_lane) {
+        ucp_proto_select_add_lane(selection, params, lanes[0]);
+        index_map &= ~UCS_BIT(0);
+    }
+
+    for (i = fixed_first_lane? 1 : 0; i < ucs_min(max_lanes, num_lanes); ++i) {
+        /* Greedy algorithm: find the best option at every step */
+        lane_index = ucp_proto_select_find_max_score_lane(params, lanes,
+                                                          lanes_perf, selection,
+                                                          index_map);
+        if (lane_index == UCP_NULL_LANE) {
+            break;
+        }
+
+        ucp_proto_select_add_lane(selection, params, lanes[lane_index]);
+        index_map &= ~UCS_BIT(lane_index);
+    }
+}
+
+void ucp_proto_select_trace(const ucp_proto_init_params_t *params,
+                            const ucp_proto_lane_selection_t *selection,
+                            const ucp_proto_common_tl_perf_t *lanes_perf,
+                            const char *desc, ucs_log_level_t level)
+{
+    ucp_context_h UCS_V_UNUSED context = params->worker->context;
+    const ucp_proto_common_tl_perf_t *lane_perf;
+    ucp_lane_index_t i, lane;
+    ucp_rsc_index_t rsc_index;
+
+    if (!ucs_log_is_enabled(level)) {
+        return;
+    }
+
+    ucs_log(level, "%s(%s)=%u, protocol=%s", desc,
+            ucp_proto_common_get_variant_name(selection->variant),
+            selection->num_lanes, ucp_proto_id_field(params->proto_id, name));
+    ucs_log_indent(1);
+
+    for (i = 0; i < selection->num_lanes; ++i) {
+        lane      = selection->lanes[i];
+        lane_perf = &lanes_perf[lane];
+        rsc_index = ucp_proto_common_get_rsc_index(params, lane);
+
+        ucs_log(level, "lane[%d] " UCT_TL_RESOURCE_DESC_FMT " bw "
+                UCP_PROTO_PERF_FUNC_BW_FMT UCP_PROTO_TIME_FMT(latency)
+                UCP_PROTO_TIME_FMT(send_pre_overhead)
+                UCP_PROTO_TIME_FMT(send_post_overhead)
+                UCP_PROTO_TIME_FMT(recv_overhead), lane,
+                UCT_TL_RESOURCE_DESC_ARG(&context->tl_rscs[rsc_index].tl_rsc),
+                (lane_perf->bandwidth / UCS_MBYTE),
+                UCP_PROTO_TIME_ARG(lane_perf->latency),
+                UCP_PROTO_TIME_ARG(lane_perf->send_pre_overhead),
+                UCP_PROTO_TIME_ARG(lane_perf->send_post_overhead),
+                UCP_PROTO_TIME_ARG(lane_perf->recv_overhead));
+    }
+
+    ucs_log_indent(-1);
+}
+
+size_t
+ucp_proto_select_distinct(ucp_proto_lane_selection_t *selection, size_t count)
+{
+    size_t distinct = 1;
+    size_t i, j;
+    int unique;
+    ucs_assertv_always(count > 0 && count <= UCP_PROTO_VARIANT_LAST,
+                       "count=%zu", count);
+
+    for (i = 1; i < count; ++i) {
+        unique = 1;
+        for (j = 0; j < distinct; ++j) {
+            if (selection[i].lane_map == selection[j].lane_map) {
+                unique = 0;
+                break;
+            }
+        }
+
+        if (unique && (i != distinct)) {
+            selection[distinct++] = selection[i];
+        }
+    }
+
+    return distinct;
+}

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -189,8 +189,8 @@ typedef struct {
  * variant, which is used to print the variant name.
  */
 #define UCP_FOREACH_PROTO_VARIANT(_macro) \
-    _macro(UCP_PROTO_VARIANT_BW,  UCS_GBYTE, "bw") \
-    _macro(UCP_PROTO_VARIANT_LAT, UCS_KBYTE, "lat")
+    _macro(UCP_PROTO_VARIANT_BW,  UCS_GBYTE, "(bw)") \
+    _macro(UCP_PROTO_VARIANT_LAT, UCS_KBYTE, "(lat)")
 
 /**
  * Protocol selection variant enum
@@ -209,7 +209,26 @@ typedef struct {
     uint8_t                    dev_count[UCP_MAX_RESOURCES];
     ucp_proto_common_tl_perf_t perf;
     ucp_proto_variant_t        variant;
+    char                       name[UCP_PROTO_DESC_STR_MAX];
 } ucp_proto_lane_selection_t;
+
+
+typedef struct {
+    const char       *perf_name;
+    ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t num_lanes;
+    ucp_lane_index_t max_lanes;
+    int              fixed_first_lane;
+} ucp_proto_lane_select_req_t;
+
+
+typedef struct {
+    ucp_lane_index_t           lanes[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t           num_lanes;
+    ucp_proto_common_tl_perf_t lanes_perf[UCP_PROTO_MAX_LANES];
+    ucp_proto_lane_selection_t selections[UCP_PROTO_VARIANT_LAST];
+    ucp_lane_index_t           num_selections;
+} ucp_proto_lane_select_t;
 
 
 /* Private data per lane */
@@ -385,21 +404,11 @@ void ucp_proto_reset_fatal_not_implemented(ucp_request_t *req);
 
 void ucp_proto_fatal_invalid_stage(ucp_request_t *req, const char *func_name);
 
-void
-ucp_proto_select_lanes(const ucp_proto_init_params_t *params,
-                       const ucp_lane_index_t *lanes, ucp_lane_index_t num_lanes,
-                       ucp_lane_index_t max_lanes,
-                       const ucp_proto_common_tl_perf_t *lanes_perf,
-                       int fixed_first_lane, ucp_proto_variant_t variant,
-                       ucp_proto_lane_selection_t *selection);
+ucs_status_t
+ucp_proto_lane_select_init(const ucp_proto_common_init_params_t *params,
+                           const ucp_proto_lane_select_req_t *req,
+                           ucp_proto_lane_select_t **select_p);
 
-void
-ucp_proto_select_trace(const ucp_proto_init_params_t *params,
-                       const ucp_proto_lane_selection_t *selection,
-                       const ucp_proto_common_tl_perf_t *lanes_perf,
-                       const char *desc, ucs_log_level_t level);
-
-size_t
-ucp_proto_select_distinct(ucp_proto_lane_selection_t *selection, size_t count);
+void ucp_proto_lane_select_destroy(ucp_proto_lane_select_t *select);
 
 #endif

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -197,6 +197,25 @@ typedef struct {
 
 
 /**
+ * Protocol selection variants macro, used to iterate over all variants.
+ * The second argument is the message size for the variant, which is used to
+ * calculate the score for the variant. The third argument is the name of the
+ * variant, which is used to print the variant name.
+ */
+#define UCP_FOREACH_PROTO_VARIANT(_macro) \
+    _macro(UCP_PROTO_VARIANT_LAT, UCS_KBYTE, "lat") \
+    _macro(UCP_PROTO_VARIANT_BW,  UCS_GBYTE, "bw")
+
+/**
+ * Protocol selection variant enum
+ */
+#define UCP_PROTO_VARIANT_ENUMIFY(ID, MSG_SIZE, NAME) ID,
+typedef enum {
+    UCP_FOREACH_PROTO_VARIANT(UCP_PROTO_VARIANT_ENUMIFY)
+} ucp_proto_variant_t;
+
+
+/**
  * Called the first time the protocol starts sending a request, and only once
  * per request.
  *

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -183,10 +183,11 @@ typedef struct {
 
 
 typedef struct {
-    ucp_lane_map_t   lane_map;
-    ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
-    ucp_lane_index_t num_lanes;
-    uint8_t          dev_count[UCP_MAX_RESOURCES];
+    ucp_lane_map_t             lane_map;
+    ucp_lane_index_t           lanes[UCP_PROTO_MAX_LANES];
+    ucp_lane_index_t           num_lanes;
+    uint8_t                    dev_count[UCP_MAX_RESOURCES];
+    ucp_proto_common_tl_perf_t perf;
 } ucp_proto_lane_selection_t;
 
 

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -189,8 +189,8 @@ typedef struct {
  * variant, which is used to print the variant name.
  */
 #define UCP_FOREACH_PROTO_VARIANT(_macro) \
-    _macro(UCP_PROTO_VARIANT_LAT, UCS_KBYTE, "lat") \
-    _macro(UCP_PROTO_VARIANT_BW,  UCS_GBYTE, "bw")
+    _macro(UCP_PROTO_VARIANT_BW,  UCS_GBYTE, "bw") \
+    _macro(UCP_PROTO_VARIANT_LAT, UCS_KBYTE, "lat")
 
 /**
  * Protocol selection variant enum

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -176,6 +176,9 @@ typedef struct {
 
     /* Maximum single message length */
     size_t max_frag;
+
+    /* Performance selection tree node */
+    ucp_proto_perf_node_t *node;
 } ucp_proto_common_tl_perf_t;
 
 
@@ -298,8 +301,7 @@ void ucp_proto_common_lane_perf_node(ucp_context_h context,
 ucs_status_t
 ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                ucp_lane_index_t lane,
-                               ucp_proto_common_tl_perf_t *perf,
-                               ucp_proto_perf_node_t **perf_node_p);
+                               ucp_proto_common_tl_perf_t *perf);
 
 
 typedef int (*ucp_proto_common_filter_lane_cb_t)(

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -228,6 +228,7 @@ typedef struct {
     ucp_proto_common_tl_perf_t lanes_perf[UCP_PROTO_MAX_LANES];
     ucp_proto_lane_selection_t selections[UCP_PROTO_VARIANT_LAST];
     ucp_lane_index_t           num_selections;
+    int                        mp_alloc;
 } ucp_proto_lane_select_t;
 
 

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -413,9 +413,10 @@ ucp_proto_common_get_variant_msg_size(ucp_proto_variant_t variant)
 #define UCP_PROTO_VARIANT_IT(ID, MSG_SIZE, _) case ID: return MSG_SIZE;
     switch (variant) {
         UCP_FOREACH_PROTO_VARIANT(UCP_PROTO_VARIANT_IT)
-        default: ucs_assert_always(0);
+        default: ucs_fatal("unexpected variant %d", variant);
     }
 #undef UCP_PROTO_VARIANT_IT
+    return 0;
 }
 
 static UCS_F_ALWAYS_INLINE const char*
@@ -424,9 +425,16 @@ ucp_proto_common_get_variant_name(ucp_proto_variant_t variant)
 #define UCP_PROTO_VARIANT_IT(ID, _, NAME) case ID: return NAME;
     switch (variant) {
         UCP_FOREACH_PROTO_VARIANT(UCP_PROTO_VARIANT_IT)
-        default: ucs_assert_always(0);
+        default: ucs_fatal("unexpected variant %d", variant);
     }
 #undef UCP_PROTO_VARIANT_IT
+    return NULL;
+}
+
+static UCS_F_ALWAYS_INLINE size_t
+ucp_proto_common_get_variants_count(ucp_context_h context)
+{
+    return context->config.ext.proto_variants_enable ? UCP_PROTO_VARIANT_LAST : 1;
 }
 
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -407,4 +407,26 @@ ucp_proto_common_get_dev_index(const ucp_proto_init_params_t *params,
     return params->worker->context->tl_rscs[rsc_index].dev_index;
 }
 
+static UCS_F_ALWAYS_INLINE size_t
+ucp_proto_common_get_variant_msg_size(ucp_proto_variant_t variant)
+{
+#define UCP_PROTO_VARIANT_IT(ID, MSG_SIZE, _) case ID: return MSG_SIZE;
+    switch (variant) {
+        UCP_FOREACH_PROTO_VARIANT(UCP_PROTO_VARIANT_IT)
+        default: ucs_assert_always(0);
+    }
+#undef UCP_PROTO_VARIANT_IT
+}
+
+static UCS_F_ALWAYS_INLINE const char*
+ucp_proto_common_get_variant_name(ucp_proto_variant_t variant)
+{
+#define UCP_PROTO_VARIANT_IT(ID, _, NAME) case ID: return NAME;
+    switch (variant) {
+        UCP_FOREACH_PROTO_VARIANT(UCP_PROTO_VARIANT_IT)
+        default: ucs_assert_always(0);
+    }
+#undef UCP_PROTO_VARIANT_IT
+}
+
 #endif

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -129,7 +129,6 @@ ucp_proto_init_skip_recv_overhead(const ucp_proto_common_init_params_t *params,
 static ucs_status_t
 ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
                            const ucp_proto_common_tl_perf_t *tl_perf,
-                           ucp_proto_perf_node_t *const tl_perf_node,
                            size_t range_start, size_t range_end,
                            ucp_proto_perf_t *perf)
 {
@@ -185,7 +184,7 @@ ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
     return ucp_proto_perf_add_funcs(perf, range_start, range_end, perf_factors,
                                     ucp_proto_perf_node_new_data("transport",
                                                                  ""),
-                                    tl_perf_node);
+                                    tl_perf->node);
 }
 
 /**
@@ -503,7 +502,6 @@ ucp_proto_common_check_mem_access(const ucp_proto_common_init_params_t *params)
 
 ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
                                  const ucp_proto_common_tl_perf_t *tl_perf,
-                                 ucp_proto_perf_node_t *const tl_perf_node,
                                  ucp_md_map_t reg_md_map, const char *perf_name,
                                  ucp_proto_perf_t **perf_p)
 {
@@ -532,8 +530,8 @@ ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
         return status;
     }
 
-    status = ucp_proto_init_add_tl_perf(params, tl_perf, tl_perf_node,
-                                        range_start, range_end, perf);
+    status = ucp_proto_init_add_tl_perf(params, tl_perf, range_start, range_end,
+                                        perf);
     if (status != UCS_OK) {
         goto err_cleanup_perf;
     }

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -68,7 +68,6 @@ ucp_proto_init_add_buffer_copy_time(ucp_worker_h worker, const char *title,
 
 ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
                                  const ucp_proto_common_tl_perf_t *tl_perf,
-                                 ucp_proto_perf_node_t *const tl_perf_node,
                                  ucp_md_map_t reg_md_map, const char *perf_name,
                                  ucp_proto_perf_t **perf_p);
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -201,6 +201,7 @@ ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
 
 size_t ucp_proto_multi_priv_size(const ucp_proto_multi_priv_t *mpriv)
 {
+    ucs_assert_always(mpriv->num_lanes <= UCP_MAX_LANES);
     return ucs_offsetof(ucp_proto_multi_priv_t, lanes) +
            (mpriv->num_lanes *
             ucs_field_sizeof(ucp_proto_multi_priv_t, lanes[0]));

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -238,7 +238,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         if ((lane_perf->bandwidth * max_bw_ratio) < max_bandwidth) {
             /* Bandwidth on this lane is too low compared to the fastest
                available lane, so it's not worth using it */
-            ucp_proto_perf_node_deref(&lanes_perf_nodes[lane]);
+            ucp_proto_perf_node_deref(&lanes_perf[lane].node);
             ucs_trace("drop " UCP_PROTO_LANE_FMT,
                       UCP_PROTO_LANE_ARG(&params->super.super, lane, lane_perf));
         } else {

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -164,8 +164,15 @@ typedef ucs_status_t (*ucp_proto_multi_lane_send_func_t)(ucp_request_t *req,
 
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                                   const char *perf_name,
-                                  ucp_proto_perf_t **perf_p,
-                                  ucp_proto_multi_priv_t *mpriv);
+                                  ucp_proto_lane_select_t **select_p);
+
+
+ucs_status_t
+ucp_proto_multi_init_perf(const ucp_proto_multi_init_params_t *params,
+                          const ucp_proto_lane_select_t *select,
+                          ucp_proto_lane_selection_t *selection,
+                          ucp_proto_perf_t **perf_p,
+                          ucp_proto_multi_priv_t *mpriv);
 
 
 size_t ucp_proto_multi_priv_size(const ucp_proto_multi_priv_t *mpriv);

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -24,7 +24,6 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
 {
     const char *proto_name = ucp_proto_id_field(params->super.super.proto_id,
                                                 name);
-    ucp_proto_perf_node_t *tl_perf_node;
     ucp_proto_common_tl_perf_t tl_perf;
     ucp_lane_index_t num_lanes;
     ucp_md_map_t reg_md_map;
@@ -57,15 +56,14 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
 
     ucp_proto_common_lane_priv_init(&params->super, reg_md_map, lane,
                                     &spriv->super);
-    status = ucp_proto_common_get_lane_perf(&params->super, lane, &tl_perf,
-                                            &tl_perf_node);
+    status = ucp_proto_common_get_lane_perf(&params->super, lane, &tl_perf);
     if (status != UCS_OK) {
         return status;
     }
 
-    status = ucp_proto_init_perf(&params->super, &tl_perf, tl_perf_node,
-                                 reg_md_map, proto_name, perf_p);
-    ucp_proto_perf_node_deref(&tl_perf_node);
+    status = ucp_proto_init_perf(&params->super, &tl_perf, reg_md_map,
+                                 proto_name, perf_p);
+    ucp_proto_perf_node_deref(&tl_perf.node);
 
     return status;
 }

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -616,21 +616,16 @@ ucp_proto_rndv_ack_init(const ucp_proto_common_init_params_t *init_params,
 
 ucs_status_t
 ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
-                         const char *op_name, const char *ack_name,
+                         const char *ack_name, ucp_proto_perf_t *bulk_perf,
                          ucp_proto_perf_t **perf_p,
                          ucp_proto_rndv_bulk_priv_t *rpriv)
 {
     ucp_context_t *context        = init_params->super.super.worker->context;
     size_t rndv_align_thresh      = context->config.ext.rndv_align_thresh;
     ucp_proto_multi_priv_t *mpriv = &rpriv->mpriv;
-    ucp_proto_perf_t *bulk_perf, *ack_perf;
+    ucp_proto_perf_t *ack_perf;
     const char *proto_name;
     ucs_status_t status;
-
-    status = ucp_proto_multi_init(init_params, op_name, &bulk_perf, mpriv);
-    if (status != UCS_OK) {
-        return status;
-    }
 
     /* Adjust align split threshold by user configuration */
     mpriv->align_thresh = ucs_max(rndv_align_thresh,

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -177,7 +177,7 @@ ucp_proto_rndv_ack_init(const ucp_proto_common_init_params_t *init_params,
 
 ucs_status_t
 ucp_proto_rndv_bulk_init(const ucp_proto_multi_init_params_t *init_params,
-                         const char *name, const char *ack_name,
+                         const char *ack_name, ucp_proto_perf_t *bulk_perf,
                          ucp_proto_perf_t **perf_p,
                          ucp_proto_rndv_bulk_priv_t *rpriv);
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -534,19 +534,38 @@ public:
 };
 
 UCS_TEST_P(test_ucp_proto_mock_rcx, memtype_copy_enable,
-           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1",
-           "MEMTYPE_COPY_ENABLE=n")
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1", "MEMTYPE_COPY_ENABLE=n",
+           "PROTO_VARIANTS=n")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
     check_ep_config(sender(), {
-        {0,       0, "rendezvous no data fetch", ""},
-        {1,      64, "rendezvous zero-copy fenced write to remote",
-                     "rc_mlx5/mock_0:1"},
-        {21992, INF, "rendezvous zero-copy read from remote",
-                     "rc_mlx5/mock_0:1"},
+        {0,  0,  "rendezvous no data fetch", ""},
+        {1,  64, "rendezvous zero-copy fenced write to remote",
+                 "rc_mlx5/mock_0:1"},
+        {65, INF, "rendezvous zero-copy read from remote",
+                  "rc_mlx5/mock_0:1"},
+    }, key);
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx, proto_variants_enable,
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1", "MEMTYPE_COPY_ENABLE=n",
+           "PROTO_VARIANTS=y")
+{
+    ucp_proto_select_key_t key = any_key();
+    key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
+    key.param.op_attr          = 0;
+
+    check_ep_config(sender(), {
+        {0,     0,     "rendezvous no data fetch", ""},
+        {1,     64,    "rendezvous zero-copy fenced write to remote",
+                       "rc_mlx5/mock_1:1"},
+        {65,    16800, "rendezvous zero-copy read from remote",
+                       "rc_mlx5/mock_1:1"},
+        {16801, INF,   "rendezvous zero-copy read from remote",
+                       "rc_mlx5/mock_0:1"},
     }, key);
 }
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -39,10 +39,15 @@ public:
     void add_mock_iface(
             const std::string &dev_name = "mock",
             iface_attr_func_t cb = [](uct_iface_attr_t &iface_attr) {},
-            perf_attr_func_t perf_cb = cx7_perf_mock)
+            perf_attr_func_t perf_cb = [](uct_perf_attr_t& perf_attr) {})
     {
         m_iface_attrs_funcs[dev_name] = cb;
         m_perf_attrs_funcs[dev_name]  = perf_cb;
+    }
+
+    void add_mock_cx7_iface(const std::string &dev_name, iface_attr_func_t cb)
+    {
+        add_mock_iface(dev_name, cb, cx7_perf_mock);
     }
 
     void mock_transport(const std::string &tl_name)
@@ -163,8 +168,7 @@ private:
 
     static void cx7_perf_mock(uct_perf_attr_t& perf_attr)
     {
-        perf_attr.path_bandwidth.shared    = 0.95 * perf_attr.bandwidth.shared;
-        perf_attr.path_bandwidth.dedicated = 0;
+        perf_attr.path_bandwidth.shared = 0.95 * perf_attr.bandwidth.shared;
     }
 
     /* We have to use singleton to mock C functions */
@@ -515,7 +519,7 @@ public:
     virtual void init() override
     {
         /* Device with higher BW and latency */
-        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_cx7_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short  = 2000;
             iface_attr.bandwidth.shared  = 28e9;
             iface_attr.latency.c         = 600e-9;
@@ -523,7 +527,7 @@ public:
             iface_attr.cap.get.max_zcopy = 16384;
         });
         /* Device with smaller BW but lower latency */
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_cx7_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short = 208;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 500e-9;
@@ -661,7 +665,7 @@ public:
     virtual void init() override
     {
         /* Device with high BW and lower latency */
-        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_cx7_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.bandwidth.shared  = 28e9;
             iface_attr.latency.c         = 500e-9;
@@ -669,7 +673,7 @@ public:
             iface_attr.cap.get.max_zcopy = 16384;
         });
         /* Device with lower BW and higher latency */
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_cx7_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 600e-9;
@@ -709,7 +713,7 @@ public:
     {
         /* Device with high BW and lower latency, but 0 get_zcopy.
          * This use case is similar to cuda_ipc when NVLink is not available. */
-        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_cx7_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.bandwidth.shared  = 28e9;
             iface_attr.latency.c         = 500e-9;
@@ -717,7 +721,7 @@ public:
             iface_attr.cap.get.max_zcopy = 0;
         });
         /* Device with lower BW and higher latency */
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_cx7_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 600e-9;


### PR DESCRIPTION
## What?
This PR introduces protocol variants for multi-protocols.
The problem: with existing implementation is that for multi-protocols selection we always prefer high-bw combination of lanes (for instance `cuda_ipc`), which might not be the best choice on low message dimensions. Because high-bw protocols often have higher latency.
This PR attempts to solve this problem by introducing protocol variants, so that for a single multi-protocol we may select multiple protocols: currently **high-bw lanes selection** and **low-latency lanes selection**. 

## Why?
Improve performance of multi-protocols on low message dimensions.

## How?
- Added infra for protocol variants with a possibility to extend
- Added latency variant in addition to existing bandwidth one
- Moved protocol selection logic to proto_common, so that we can use it for single protocols as well
- Added `UCX_PROTO_VARIANTS` option that enables this feature with default value `n`
- Allocate selection on heap, added memory pool for that

TODO in next PRs:
- Enable `UCX_PROTO_VARIANTS=y` by default
- Use protocol variants in single protocols
- Long-living task: implement proper aggregation of multi-path selection (according to single path BW)

[Testing results](https://confluence.nvidia.com/display/NSWX/UCX+Protocol+Variants)