### PR TITLE
UCT/MLX5: Add DEVX QP/CQ on foreign memory support

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1831,17 +1831,18 @@ void uct_dc_mlx5_iface_reset_dci(uct_dc_mlx5_iface_t *iface,
 
     status = uct_ib_mlx5_modify_qp_state(&iface->super.super.super,
                                          &txwq->super, IBV_QPS_RESET);
+    if (status != UCS_OK) {
+        ucs_fatal("iface %p failed to reset dci[%d] qpn 0x%x: %s",
+                  iface, dci_index, txwq->super.qp_num,
+                  ucs_status_string(status));
+    }
 
     uct_rc_mlx5_iface_commom_clean(&iface->super.cq[UCT_IB_DIR_TX], NULL,
                                    txwq->super.qp_num);
 
     /* Resume posting from to the beginning of the QP */
     uct_ib_mlx5_txwq_reset(txwq);
-    if (status != UCS_OK) {
-        ucs_fatal("iface %p failed to reset dci[%d] qpn 0x%x: %s",
-                  iface, dci_index, txwq->super.qp_num,
-                  ucs_status_string(status));
-    }
+    uct_ib_mlx5_init_wq_buf(txwq);
 
     status = uct_dc_mlx5_iface_dci_connect(iface, dci);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -104,6 +104,15 @@ void uct_ib_mlx5_parse_cqe_zipping(uct_ib_mlx5_md_t *md,
     }
 }
 
+void uct_ib_mlx5_cq_calc_sizes(uct_ib_iface_t *iface, uct_ib_dir_t dir,
+                               const uct_ib_iface_init_attr_t *init_attr,
+                               size_t inl, uct_ib_mlx5_cq_attr_t *attr)
+{
+    attr->cq_size  = ucs_roundup_pow2(uct_ib_cq_size(iface, init_attr, dir));
+    attr->cqe_size = uct_ib_get_cqe_size((inl > 32) ? 128 : 64);
+    attr->umem_len = attr->cqe_size * attr->cq_size;
+}
+
 ucs_status_t
 uct_ib_mlx5_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                       const uct_ib_iface_init_attr_t *init_attr,
@@ -182,18 +191,16 @@ ucs_status_t uct_ib_mlx5_fill_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq)
     uar = uct_dv_get_info_uar0(dcq.dv.uar);
 #endif
 
-    uct_ib_mlx5_fill_cq_common(mlx5_cq, dcq.dv.cqe_cnt, dcq.dv.cqe_size,
+    uct_ib_mlx5_init_cq_common(mlx5_cq, dcq.dv.cqe_cnt, dcq.dv.cqe_size,
                                dcq.dv.cqn, dcq.dv.buf, uar, dcq.dv.dbrec, 0);
+    uct_ib_mlx5_fill_cq_buf(mlx5_cq, dcq.dv.cqe_cnt);
     return UCS_OK;
 }
 
-void uct_ib_mlx5_fill_cq_common(uct_ib_mlx5_cq_t *cq,  unsigned cq_size,
+void uct_ib_mlx5_init_cq_common(uct_ib_mlx5_cq_t *cq,  unsigned cq_size,
                                 unsigned cqe_size, uint32_t cqn, void *cq_buf,
                                 void *uar, volatile void *dbrec, int zip)
 {
-    struct mlx5_cqe64 *cqe;
-    int i;
-
     cq->cq_buf    = cq_buf;
     cq->cq_ci     = 0;
     cq->cq_sn     = 0;
@@ -226,6 +233,12 @@ void uct_ib_mlx5_fill_cq_common(uct_ib_mlx5_cq_t *cq,  unsigned cq_size,
         cq->own_field_offset = ucs_offsetof(struct mlx5_cqe64, op_own);
         cq->own_mask         = MLX5_CQE_OWNER_MASK;
     }
+}
+
+void uct_ib_mlx5_fill_cq_buf(uct_ib_mlx5_cq_t *cq,  unsigned cq_size)
+{
+    struct mlx5_cqe64 *cqe;
+    int i;
 
     /* Set owner bit for all CQEs, so that CQE would look like it is in HW
      * ownership. In this case CQ polling functions will return immediately if
@@ -323,6 +336,12 @@ void uct_ib_mlx5_iface_put_res_domain(uct_ib_mlx5_qp_t *qp)
     if (qp->type == UCT_IB_MLX5_OBJ_TYPE_VERBS) {
         uct_worker_tl_data_put(qp->verbs.rd, uct_ib_mlx5_res_domain_cleanup);
     }
+}
+
+void uct_ib_mlx5_wq_calc_sizes(uct_ib_mlx5_qp_attr_t *attr)
+{
+    attr->max_tx = uct_ib_mlx5_devx_sq_length(attr->super.cap.max_send_wr);
+    attr->len    = attr->max_tx * MLX5_SEND_WQE_BB;
 }
 
 ucs_status_t uct_ib_mlx5_iface_create_qp(uct_ib_iface_t *iface,
@@ -682,6 +701,10 @@ void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
     txwq->flags      = 0;
 #endif
     uct_ib_fence_info_init(&txwq->fi);
+}
+
+void uct_ib_mlx5_init_wq_buf(uct_ib_mlx5_txwq_t *txwq)
+{
     memset(txwq->qstart, 0, UCS_PTR_BYTE_DIFF(txwq->qstart, txwq->qend));
 
     /* Make uct_ib_mlx5_txwq_num_posted_wqes() work if no wqe has completed by
@@ -806,6 +829,7 @@ ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
     ucs_assert_always(txwq->bb_max > 0);
 
     uct_ib_mlx5_txwq_reset(txwq);
+    uct_ib_mlx5_init_wq_buf(txwq);
     return UCS_OK;
 }
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -17,6 +17,7 @@
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
 #include <ucs/type/status.h>
+#include <ucs/sys/ptr_arith.h>
 
 /**
  * When using a clang version that is higher than 3.0, the GNUC_MINOR is set
@@ -573,6 +574,20 @@ typedef struct uct_ib_mlx5_devx_uar {
 } uct_ib_mlx5_devx_uar_t;
 
 
+enum {
+    UCT_IB_MLX5_CQ_IGNORE_OVERRUN = UCS_BIT(0),
+    UCT_IB_MLX5_CQ_CQE_ZIP        = UCS_BIT(1),
+};
+
+
+typedef struct uct_ib_mlx5_cq_attr {
+    unsigned cq_size;
+    unsigned cqe_size;
+    size_t   umem_len;
+    unsigned flags;
+} uct_ib_mlx5_cq_attr_t;
+
+
 /* Completion queue */
 typedef struct uct_ib_mlx5_cq {
     uct_ib_mlx5_obj_type_t type;
@@ -625,6 +640,8 @@ typedef struct uct_ib_mlx5_qp_attr {
     int                         full_handshake;
     int                         rdma_wr_disabled;
     uint8_t                     log_num_dci_stream_channels;
+    unsigned                    max_tx;
+    unsigned                    len;
 } uct_ib_mlx5_qp_attr_t;
 
 
@@ -794,12 +811,19 @@ extern ucs_config_field_t uct_ib_mlx5_iface_config_table[];
  */
 ucs_status_t uct_ib_mlx5_fill_cq(struct ibv_cq *cq, uct_ib_mlx5_cq_t *mlx5_cq);
 
+
 /**
- * Fill internal CQ information.
+ * Init internal CQ information.
  */
-void uct_ib_mlx5_fill_cq_common(uct_ib_mlx5_cq_t *cq,  unsigned cq_size,
+void uct_ib_mlx5_init_cq_common(uct_ib_mlx5_cq_t *cq, unsigned cq_size,
                                 unsigned cqe_size, uint32_t cqn, void *cq_buf,
                                 void* uar, volatile void *dbrec, int zip);
+
+/**
+ * Fill CQ work buffer.
+ */
+void uct_ib_mlx5_fill_cq_buf(uct_ib_mlx5_cq_t *cq, unsigned cq_size);
+
 
 /**
  * Destroy CQ.
@@ -877,6 +901,8 @@ void uct_ib_mlx5_qp_mmio_cleanup(uct_ib_mlx5_qp_t *qp,
  */
 void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq);
 
+void uct_ib_mlx5_init_wq_buf(uct_ib_mlx5_txwq_t *txwq);
+
 /**
  * Add txwq attributes to a VFS object
  */
@@ -921,6 +947,8 @@ void uct_ib_mlx5_parse_cqe_zipping(uct_ib_mlx5_md_t *md,
                                    const uct_ib_mlx5_iface_config_t *mlx5_config,
                                    uct_ib_iface_init_attr_t *init_attr);
 
+size_t uct_ib_mlx5_devx_sq_length(size_t tx_qp_length);
+
 /**
  * DEVX QP API
  */
@@ -939,6 +967,13 @@ ucs_status_t uct_ib_mlx5_devx_create_qp(uct_ib_iface_t *iface,
                                         uct_ib_mlx5_txwq_t *tx,
                                         uct_ib_mlx5_qp_attr_t *attr);
 
+ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
+                                               const uct_ib_mlx5_cq_t *send_cq,
+                                               const uct_ib_mlx5_cq_t *recv_cq,
+                                               uct_ib_mlx5_qp_t *qp,
+                                               uct_ib_mlx5_txwq_t *tx,
+                                               uct_ib_mlx5_qp_attr_t *attr);
+
 ucs_status_t uct_ib_mlx5_devx_modify_qp(uct_ib_mlx5_qp_t *qp,
                                         const void *in, size_t inlen,
                                         void *out, size_t outlen);
@@ -947,6 +982,8 @@ ucs_status_t uct_ib_mlx5_devx_modify_qp_state(uct_ib_mlx5_qp_t *qp,
                                               enum ibv_qp_state state);
 
 void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp);
+
+void uct_ib_mlx5_devx_destroy_qp_common(uct_ib_mlx5_qp_t *qp);
 
 ucs_status_t uct_ib_mlx5_devx_obj_modify(struct mlx5dv_devx_obj *obj,
                                          const void *in, size_t inlen,
@@ -1023,11 +1060,25 @@ uct_ib_mlx5_devx_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                            const uct_ib_iface_init_attr_t *init_attr,
                            uct_ib_mlx5_cq_t *cq, int preferred_cpu, size_t inl);
 
+ucs_status_t
+uct_ib_mlx5_devx_create_cq_common(uct_ib_iface_t *iface, uct_ib_dir_t dir,
+                                  const uct_ib_mlx5_cq_attr_t *attr,
+                                  uct_ib_mlx5_cq_t *cq, int preferred_cpu,
+                                  size_t inl);
+
 void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t *cq);
+
+void uct_ib_mlx5_devx_destroy_cq_common(uct_ib_mlx5_cq_t *cq);
 
 ucs_status_t
 uct_ib_mlx5_devx_allow_xgvmi_access(uct_ib_mlx5_md_t *md,
                                     uint32_t exported_lkey, int silent);
+
+void uct_ib_mlx5_wq_calc_sizes(uct_ib_mlx5_qp_attr_t *attr);
+
+void uct_ib_mlx5_cq_calc_sizes(uct_ib_iface_t *iface, uct_ib_dir_t dir,
+                               const uct_ib_iface_init_attr_t *init_attr,
+                               size_t inl, uct_ib_mlx5_cq_attr_t *attr);
 
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
@@ -1207,8 +1258,6 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char* name, size_t size,
 ucs_status_t uct_ib_mlx5_devx_reg_exported_key(uct_ib_mlx5_md_t *md,
                                                uct_ib_mlx5_devx_mem_t *memh);
 #endif
-
-size_t uct_ib_mlx5_devx_sq_length(size_t tx_qp_length);
 
 ucs_status_t uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
                                    ucs_ternary_auto_value_t ar_enable,


### PR DESCRIPTION
## Why?
To create QP/CQ with work buffer and doorbell record in non-regular memory like VRAM.

## How?
Decouple memory allocation from object creation code.  