### PR TITLE
AZP/RELEASE: Add CUDA 13 support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,6 +66,7 @@ Manjunath Gorentla Venkata <manjugv@gmail.com>
 Marek Schimara <Marek.Schimara@bull.net>
 Mark Allen <markalle@us.ibm.com>
 Matthew Baker <bakermb@ornl.gov>
+Michael Braverman <michaelbr@nvidia.com>
 Michal Shalev <mshalev@nvidia.com>
 Mike Dubman <miked@mellanox.com>
 Mikhail Brinskii <mikhailb@nvidia.com>

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -37,6 +37,12 @@ jobs:
         ubuntu24_cuda12_${{ parameters.arch }}:
           build_container: ubuntu24_cuda12_${{ parameters.arch }}
           artifact_name: $(POSTFIX)-ubuntu24.04-mofed5-cuda12-${{ parameters.arch }}.tar.bz2
+        ubuntu22_cuda13_${{ parameters.arch }}:
+          build_container: ubuntu22_cuda13_${{ parameters.arch }}
+          artifact_name: $(POSTFIX)-ubuntu22.04-mofed5-cuda13-${{ parameters.arch }}.tar.bz2
+        ubuntu24_cuda13_${{ parameters.arch }}:
+          build_container: ubuntu24_cuda13_${{ parameters.arch }}
+          artifact_name: $(POSTFIX)-ubuntu24.04-mofed5-cuda13-${{ parameters.arch }}.tar.bz2
         # x86 only
         ${{ if eq(parameters.arch, 'x86_64') }}:
           centos7_cuda11_${{ parameters.arch }}:

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -199,15 +199,14 @@ try_load_cuda_env() {
         have_cuda="${cuda_local_dir}"
     else
         # Fallback to env module
-        az_module_load dev/cuda12.8 || return 0
+        az_module_load dev/cuda13.0.0 || return 0
         have_cuda=yes
     fi
 
     # Check gdrcopy
     if [ -w "/dev/gdrdrv" ]
     then
-        # TODO detect cuda version if using local CUDA
-        az_module_load dev/gdrcopy2.4.4_cuda12.8.0 && have_gdrcopy=yes
+        az_module_load dev/gdrcopy2.5.1_cuda13.0.0 && have_gdrcopy=yes
     fi
 }
 

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -212,7 +212,7 @@ try_load_cuda_env() {
 
 load_cuda_env() {
     try_load_cuda_env
-    if [ "${have_cuda}" != "yes" ] ; then
+    if [ "${have_cuda}" == "no" ] ; then
         if [ "${ucx_gpu}" = "yes" ] ; then
             azure_log_error "CUDA load failed on GPU node $(hostname -s)"
             exit 1

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -212,8 +212,8 @@ try_load_cuda_env() {
 
 load_cuda_env() {
     try_load_cuda_env
-    if [ "${have_cuda}" == "no" ] ; then
-        if [ "${ucx_gpu}" = "yes" ] ; then
+    if [ "${have_cuda}" != "yes" ] ; then
+        if [ "${ucx_gpu_test}" = "yes" ] ; then
             azure_log_error "CUDA load failed on GPU node $(hostname -s)"
             exit 1
         fi

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -213,7 +213,7 @@ try_load_cuda_env() {
 load_cuda_env() {
     try_load_cuda_env
     if [ "${have_cuda}" != "yes" ] ; then
-        if [ "${ucx_gpu_test}" = "yes" ] ; then
+        if [ "${ucx_gpu}" = "yes" ] ; then
             azure_log_error "CUDA load failed on GPU node $(hostname -s)"
             exit 1
         fi

--- a/buildlib/azure-pipelines-release-drp.yml
+++ b/buildlib/azure-pipelines-release-drp.yml
@@ -44,6 +44,10 @@ resources:
       image: $(REPO_MIRROR)/ucx/x86_64/ubuntu20.04-mofed5-cuda12:3
     - container: ubuntu24_cuda12_x86_64
       image: $(REPO_MIRROR)/ucx/x86_64/ubuntu24.04-mofed24.10-cuda12.5:1
+    - container: ubuntu22_cuda13_x86_64
+      image: $(REPO_MIRROR)/ucx/x86_64/ubuntu22.04-mofed5-cuda13:1
+    - container: ubuntu24_cuda13_x86_64
+      image: $(REPO_MIRROR)/ucx/x86_64/ubuntu24.04-mofed24.10-cuda13:1
 
     # aarch64
     - container: centos8_cuda11_aarch64
@@ -61,6 +65,10 @@ resources:
       image: $(REPO_MIRROR)/ucx/aarch64/ubuntu22.04-mofed5-cuda12:3
     - container: ubuntu24_cuda12_aarch64
       image: $(REPO_MIRROR)/ucx/aarch64/ubuntu24.04-mofed24.10-cuda12.5:1
+    - container: ubuntu22_cuda13_aarch64
+      image: $(REPO_MIRROR)/ucx/aarch64/ubuntu22.04-mofed5-cuda13:1
+    - container: ubuntu24_cuda13_aarch64
+      image: $(REPO_MIRROR)/ucx/aarch64/ubuntu24.04-mofed24.10-cuda13:1
 
 stages:
   - stage: Prepare

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -40,6 +40,10 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda12:3
     - container: ubuntu24_cuda12_x86_64
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu24.04-mofed24.10-cuda12.5:1
+    - container: ubuntu22_cuda13_x86_64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda13:1
+    - container: ubuntu24_cuda13_x86_64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu24.04-mofed24.10-cuda13:1
 
     # aarch64
     - container: centos8_cuda11_aarch64
@@ -57,6 +61,10 @@ resources:
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu22.04-mofed5-cuda12:3
     - container: ubuntu24_cuda12_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu24.04-mofed24.10-cuda12.5:1
+    - container: ubuntu22_cuda13_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu22.04-mofed5-cuda13:1
+    - container: ubuntu24_cuda13_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/aarch64/ubuntu24.04-mofed24.10-cuda13:1
 
 stages:
   - stage: Prepare

--- a/buildlib/dockers/docker-compose-aarch64.yml
+++ b/buildlib/dockers/docker-compose-aarch64.yml
@@ -93,3 +93,28 @@ services:
         CUDA_VERSION: 12.5.1
         NV_DRIVER_VERSION: 555
         ARCH: aarch64
+
+  ubuntu22.04-mofed5-cuda13:
+    image: ubuntu22.04-mofed5-cuda13:1
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.8-7.0.6.1
+        UBUNTU_VERSION: 22.04
+        CUDA_VERSION: 13.0.0
+        NV_DRIVER_VERSION: 580
+        ARCH: aarch64
+  ubuntu24.04-mofed5-cuda13:
+    image: ubuntu24.04-mofed24.10-cuda13:1
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 24.10-3.2.5.0
+        UBUNTU_VERSION: 24.04
+        CUDA_VERSION: 13.0.0
+        NV_DRIVER_VERSION: 580
+        ARCH: aarch64

--- a/buildlib/dockers/docker-compose-aarch64.yml
+++ b/buildlib/dockers/docker-compose-aarch64.yml
@@ -93,7 +93,6 @@ services:
         CUDA_VERSION: 12.5.1
         NV_DRIVER_VERSION: 555
         ARCH: aarch64
-
   ubuntu22.04-mofed5-cuda13:
     image: ubuntu22.04-mofed5-cuda13:1
     build:

--- a/buildlib/dockers/docker-compose-x86_64.yml
+++ b/buildlib/dockers/docker-compose-x86_64.yml
@@ -129,3 +129,29 @@ services:
         CUDA_VERSION: 12.5.1
         NV_DRIVER_VERSION: 555
         ARCH: x86_64
+
+
+  ubuntu22.04-mofed5-cuda13:
+    image: ubuntu22.04-mofed5-cuda13:1
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 5.8-7.0.6.1
+        UBUNTU_VERSION: 22.04
+        CUDA_VERSION: 13.0.0
+        NV_DRIVER_VERSION: 580
+        ARCH: x86_64
+  ubuntu24.04-mofed5-cuda13:
+    image: ubuntu24.04-mofed24.10-cuda13:1
+    build:
+      context: .
+      network: host
+      dockerfile: ubuntu-release.Dockerfile
+      args:
+        MOFED_VERSION: 24.10-3.2.5.0
+        UBUNTU_VERSION: 24.04
+        CUDA_VERSION: 13.0.0
+        NV_DRIVER_VERSION: 580
+        ARCH: x86_64

--- a/buildlib/dockers/docker-compose-x86_64.yml
+++ b/buildlib/dockers/docker-compose-x86_64.yml
@@ -129,8 +129,6 @@ services:
         CUDA_VERSION: 12.5.1
         NV_DRIVER_VERSION: 555
         ARCH: x86_64
-
-
   ubuntu22.04-mofed5-cuda13:
     image: ubuntu22.04-mofed5-cuda13:1
     build:

--- a/buildlib/pr/cuda/cuda.yml
+++ b/buildlib/pr/cuda/cuda.yml
@@ -92,6 +92,10 @@ jobs:
           CONTAINER: ubuntu22_cuda_12_0
         ubuntu22_cuda_12_1:
           CONTAINER: ubuntu22_cuda_12_1
+        ubuntu22_cuda_13_0:
+          CONTAINER: ubuntu22_cuda_13_0
+        ubuntu24_cuda_13_0:
+          CONTAINER: ubuntu24_cuda_13_0
 
     container: $[ variables['CONTAINER'] ]
     timeoutInMinutes: 35

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -186,6 +186,12 @@ resources:
     - container: ubuntu22_cuda12
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda12:3
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
+    - container: ubuntu22_cuda13
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda13:1
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
+    - container: ubuntu24_cuda13
+      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu24.04-mofed24.10-cuda13:1
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: ubuntu2204_rocm_6_0_0
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2204:rocm-6.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -165,6 +165,9 @@ resources:
     - container: ubuntu22_cuda_12_1
       image: nvidia/cuda:12.1.0-devel-ubuntu22.04
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
+    - container: ubuntu22_cuda_13_0
+      image: nvidia/cuda:13.0.0-devel-ubuntu22.04
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
     - container: centos8_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:1
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -254,7 +254,7 @@ stages:
     - template: wire_compat.yml
       parameters:
         name: gpu
-        demands: ucx_gpu -equals yes
+        demands: ucx_gpu_test -equals yes
         container: centos7_cuda11
         ucx_targets:
           ucx_1_15:
@@ -294,7 +294,7 @@ stages:
     - template: tests.yml
       parameters:
         name: gpu
-        demands: ucx_gpu -equals yes
+        demands: ucx_gpu_test -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
     - template: tests.yml
@@ -343,7 +343,7 @@ stages:
         parameters:
           arch: amd64
           name: gpu
-          demands: ucx_gpu
+          demands: ucx_gpu_test
 
       - template: ../jucx/jucx-test.yml
         parameters:
@@ -360,7 +360,7 @@ stages:
       - template: go/go-test.yml
         parameters:
             name: gpu
-            demands: ucx_gpu -equals yes
+            demands: ucx_gpu_test -equals yes
 
   - stage: Build_Static
     dependsOn: [Static_check]
@@ -418,7 +418,7 @@ stages:
     - template: tests.yml
       parameters:
         name: gpu
-        demands: ucx_gpu -equals yes
+        demands: ucx_gpu_test -equals yes
         test_perf: 0
         container: centos8_cuda11_asan
         asan_check: yes

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -168,6 +168,9 @@ resources:
     - container: ubuntu22_cuda_13_0
       image: nvidia/cuda:13.0.0-devel-ubuntu22.04
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
+    - container: ubuntu24_cuda_13_0
+      image: nvidia/cuda:13.0.0-devel-ubuntu24.04
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
     - container: centos8_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/centos8-mofed5-cuda11:1
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -257,7 +257,7 @@ stages:
     - template: wire_compat.yml
       parameters:
         name: gpu
-        demands: ucx_gpu_test -equals yes
+        demands: ucx_gpu -equals yes
         container: centos7_cuda11
         ucx_targets:
           ucx_1_15:
@@ -297,7 +297,7 @@ stages:
     - template: tests.yml
       parameters:
         name: gpu
-        demands: ucx_gpu_test -equals yes
+        demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
     - template: tests.yml
@@ -346,7 +346,7 @@ stages:
         parameters:
           arch: amd64
           name: gpu
-          demands: ucx_gpu_test
+          demands: ucx_gpu
 
       - template: ../jucx/jucx-test.yml
         parameters:
@@ -363,7 +363,7 @@ stages:
       - template: go/go-test.yml
         parameters:
             name: gpu
-            demands: ucx_gpu_test -equals yes
+            demands: ucx_gpu -equals yes
 
   - stage: Build_Static
     dependsOn: [Static_check]
@@ -421,7 +421,7 @@ stages:
     - template: tests.yml
       parameters:
         name: gpu
-        demands: ucx_gpu_test -equals yes
+        demands: ucx_gpu -equals yes
         test_perf: 0
         container: centos8_cuda11_asan
         asan_check: yes

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -4,8 +4,8 @@ WORKSPACE=${WORKSPACE:=$PWD}
 # build in local directory which goes away when docker exits
 ucx_build_dir=$HOME/${BUILD_ID}/build
 ucx_inst=$ucx_build_dir/install
-CUDA_MODULE="dev/cuda12.8"
-GDRCOPY_MODULE="dev/gdrcopy2.4.4_cuda12.8.0"
+CUDA_MODULE="dev/cuda13.0.0"
+GDRCOPY_MODULE="dev/gdrcopy2.5.1_cuda13.0.0"
 JDK_MODULE="dev/jdk"
 MVN_MODULE="dev/mvn"
 XPMEM_MODULE="dev/xpmem-90a95a4"

--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -13,7 +13,7 @@ steps:
 
       case "${{ parameters.Name }}" in
         "Build-UCX")
-          module="/hpc/local/etc/modulefiles/dev/cuda12.8"
+          module="/hpc/local/etc/modulefiles/dev/cuda13.0.0"
           perfxParams=(--skip-run --source-branch $(Build.SourceBranch) --omb-cuda)
           ;;
         "Perf-test-multi-node")

--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -17,11 +17,11 @@ steps:
           perfxParams=(--skip-run --source-branch $(Build.SourceBranch) --omb-cuda)
           ;;
         "Perf-test-multi-node")
-          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc"
+          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc-cuda13"
           perfxParams=(--skip-update --skip-build --use-cache --filter "--extra-ompi-opts= -H $perf_nodes")
           ;;
         "Perf-test-single-node")
-          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc"
+          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc-cuda13"
           IFS=',' read -ra nodes <<< "$perf_nodes"
           node=${nodes[RANDOM % 2]}
           perfxParams=(--skip-update --skip-build --use-cache --filter --setup rdmz-intra "--extra-ompi-opts= -H $node,$node")

--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -17,11 +17,11 @@ steps:
           perfxParams=(--skip-run --source-branch $(Build.SourceBranch) --omb-cuda)
           ;;
         "Perf-test-multi-node")
-          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc-cuda13"
+          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc"
           perfxParams=(--skip-update --skip-build --use-cache --filter "--extra-ompi-opts= -H $perf_nodes")
           ;;
         "Perf-test-single-node")
-          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc-cuda13"
+          module="/hpc/local/etc/modulefiles/hpcx-ga-gcc"
           IFS=',' read -ra nodes <<< "$perf_nodes"
           node=${nodes[RANDOM % 2]}
           perfxParams=(--skip-update --skip-build --use-cache --filter --setup rdmz-intra "--extra-ompi-opts= -H $node,$node")

--- a/test/gtest/uct/cuda/test_switch_cuda_device.cc
+++ b/test/gtest/uct/cuda/test_switch_cuda_device.cc
@@ -596,6 +596,10 @@ public:
 protected:
     void init() override
     {
+        if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+            UCS_TEST_SKIP_R("CUDA is not supported");
+        }
+
         ASSERT_EQ(cudaGetDeviceCount(&m_num_devices), cudaSuccess);
         if (m_num_devices < 2) {
             UCS_TEST_SKIP_R("less than two cuda devices available");


### PR DESCRIPTION
## What?
Add CUDA 13 support across build/CI/tests.
Skip CUDA gtests when CUDA memory type is unsupported (patch by @iyastreb).

## Why?
Issue https://github.com/openucx/ucx/issues/10787

## How?
- Bump to CUDA 13 in CI configs. 
- Build new release images.
- Verified in PR, Performance, and Release pipelines (no actual release pushed).