### PR TITLE
UCP/WIREUP: Don't request invalidate without RNDV

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -732,6 +732,13 @@ ucp_context_usage_tracker_enabled(ucp_context_h context)
     return context->config.ext.dynamic_tl_switch_interval != UCS_TIME_INFINITY;
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_context_rndv_is_enabled(ucp_context_h context)
+{
+    return (context->config.ext.rndv_intra_thresh != UCS_MEMUNITS_INF) ||
+           (context->config.ext.rndv_inter_thresh != UCS_MEMUNITS_INF);
+}
+
 void ucp_context_memaccess_tl_bitmap(ucp_context_h context,
                                      ucs_memory_type_t mem_type,
                                      uint64_t md_reg_flags,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -15,6 +15,7 @@
 #include "ucp_rkey.h"
 #include "ucp_request.inl"
 
+#include <ucp/core/ucp_context.h>
 #include <ucp/proto/proto_common.inl>
 #include <ucp/wireup/address.h>
 #include <ucp/wireup/wireup_cm.h>
@@ -337,8 +338,7 @@ static ucs_status_t ucp_worker_wakeup_init(ucp_worker_h worker,
      */
     if ((events & UCP_WAKEUP_TAG_SEND) ||
         ((events & UCP_WAKEUP_TAG_RECV) &&
-         ((context->config.ext.rndv_intra_thresh != UCS_MEMUNITS_INF) ||
-          (context->config.ext.rndv_inter_thresh != UCS_MEMUNITS_INF))))
+         ucp_context_rndv_is_enabled(context)))
     {
         worker->uct_events |= UCT_EVENT_SEND_COMP;
     }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2128,9 +2128,11 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         bw_info.max_lanes = context->config.ext.max_rndv_lanes;
     }
 
-    /* If error handling is requested we require memory invalidation
-     * support to provide correct data integrity in case of error */
-    if (ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) {
+    /* If error handling is requested and we have RNDV, we require memory
+     * invalidation support to provide correct data integrity in case of error.
+     */
+    if ((ep_init_flags & UCP_EP_INIT_ERR_MODE_PEER_FAILURE) &&
+        ucp_context_rndv_is_enabled(context)) {
         bw_info.criteria.local_md_flags |= UCT_MD_FLAG_INVALIDATE_RMA;
     }
 


### PR DESCRIPTION
## What?
Backport to 1.19.x

## Why?
the patch fixes hang with python/nixl test

## How?
the patch found in master with inverse `git bisect`