### PR TITLE
UCT/CUDA/CUDA_COPY: Fixed mapping of DMA_BUF handle.

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -929,6 +929,19 @@ out:
     return status;
 }
 
+int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev)
+{
+    int result;
+
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+    result = (sys_dev < ucs_topo_global_ctx.num_devices) &&
+             (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev !=
+              UCS_SYS_DEVICE_ID_UNKNOWN);
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+
+    return result;
+}
+
 ucs_status_t
 ucs_topo_sys_device_set_user_value(ucs_sys_device_t sys_dev, uintptr_t value)
 {

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -305,6 +305,9 @@ ucs_topo_is_reachable(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem);
 int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem);
 
 
+int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev);
+
+
 /**
  * Get the number of registered system devices.
  *


### PR DESCRIPTION
## What?
Map DMA_BUF handle via PCIe only if GPU has a sibling Direct NIC device.
Reverted fix for https://github.com/openucx/ucx/pull/10760#discussion_r2226303345.
