### PR TITLE
BUILD: Add ability to build CUDA code

### DIFF
--- a/config/cuda.am
+++ b/config/cuda.am
@@ -1,0 +1,33 @@
+#
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+
+SUFFIXES = .cu
+
+NVCC_CMD = $(NVCC) $(NVCCFLAGS) \
+		   -c $< -MD -MT $@ -MF $(DEPDIR)/cuda/$@.d -o $@ \
+		   -DHAVE_CONFIG_H $(BASE_NVCCFLAGS)
+NVCC_LT_CMD = $(LIBTOOL) --tag=CXX --mode=compile $(NVCC_CMD)
+
+define nvcc-build
+	@$(MKDIR_P) $(shell dirname $(DEPDIR)/cuda/$@)
+	@if $(AM_V_P); then set -x; else echo "  NVCC     $@"; fi; \
+	$(if $(filter .o,$(suffix $@)),$(NVCC_CMD),$(NVCC_LT_CMD)) $($(1))
+endef
+
+define nvcc-source
+	EXTRA_DIST += $(2)
+$(1): $(2)
+	$$(call nvcc-build,$(3))
+endef
+
+# Default rules when no target-specific compile flags are required
+.cu.o:
+	$(call nvcc-build)
+
+.cu.lo:
+	$(call nvcc-build)
+
+CUDA_DEP_FILES := $(shell find $(DEPDIR)/cuda/ -type f -name *.d 2>/dev/null)
+-include $(CUDA_DEP_FILES)

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -46,7 +46,8 @@ AC_ARG_ENABLE(debug,
         [enable_debug=no])
 AS_IF([test "x$enable_debug" = xyes],
         [BASE_CFLAGS="-D_DEBUG $BASE_CFLAGS"
-         BASE_CXXFLAGS="-D_DEBUG" $BASE_CXXFLAGS],
+         BASE_CXXFLAGS="-D_DEBUG" $BASE_CXXFLAGS
+         BASE_NVCCFLAGS="$BASE_NVCCFLAGS -G"],
         [])
 
 
@@ -71,9 +72,11 @@ AS_IF([test "x$enable_compiler_opt" = "xyes"], [BASE_CFLAGS="-O3 $BASE_CFLAGS"],
       [test "x$enable_compiler_opt" = "xnone"],
           [AS_IF([test "x$enable_debug" = xyes -o "x$enable_gcov" = xyes],
                  [BASE_CFLAGS="-O0 $BASE_CFLAGS"
-                  BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"],
+                  BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"
+                  BASE_NVCCFLAGS="-O0 $BASE_NVCCFLAGS"],
                  [BASE_CFLAGS="-O3 $BASE_CFLAGS"
-                  BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"])],
+                  BASE_CXXFLAGS="-O0 $BASE_CXXFLAGS"
+                  BASE_NVCCFLAGS="-O3 $BASE_NVCCFLAGS"])],
       [test "x$enable_compiler_opt" = "xno"], [],
       [BASE_CFLAGS="-O$enable_compiler_opt $BASE_CFLAGS"])
 
@@ -629,8 +632,11 @@ AC_SUBST([LDFLAGS_DYNAMIC_LIST_DATA])
 #
 # Set common C preprocessor flags
 #
+SRC_INCLUDES="-I\${abs_top_srcdir}/src -I\${abs_top_builddir} -I\${abs_top_builddir}/src"
+
 BASE_CPPFLAGS="-DCPU_FLAGS=\"$OPT_CFLAGS\""
-BASE_CPPFLAGS="$BASE_CPPFLAGS -I\${abs_top_srcdir}/src"
-BASE_CPPFLAGS="$BASE_CPPFLAGS -I\${abs_top_builddir}"
-BASE_CPPFLAGS="$BASE_CPPFLAGS -I\${abs_top_builddir}/src"
+BASE_CPPFLAGS="$BASE_CPPFLAGS $SRC_INCLUDES"
+BASE_NVCCFLAGS="$BASE_NVCCFLAGS $SRC_INCLUDES"
+
 AC_SUBST([BASE_CPPFLAGS], [$BASE_CPPFLAGS])
+AC_SUBST([BASE_NVCCFLAGS], [$BASE_NVCCFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -426,6 +426,10 @@ AC_MSG_NOTICE([        ROCM modules:   <$(echo ${uct_rocm_modules}|tr ':' ' ') >
 AC_MSG_NOTICE([          IB modules:   <$(echo ${uct_ib_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([         UCM modules:   <$(echo ${ucm_modules}|tr ':' ' ') >])
 AC_MSG_NOTICE([        Perf modules:   <$(echo ${ucx_perftest_modules}|tr ':' ' ') >])
+AS_IF([test "x$NVCC" != "xno"], [
+    AC_MSG_NOTICE([                NVCC:   ${NVCC}])
+    AC_MSG_NOTICE([           NVCCFLAGS:   ${NVCCFLAGS}])
+])
 AS_IF([test "x$enable_ucg" != "xno"], [
     AC_MSG_NOTICE([       UCG modules:   <$(echo ${ucg_modules}|tr ':' ' ') >])])
 ])

--- a/contrib/ctags.sh
+++ b/contrib/ctags.sh
@@ -9,7 +9,7 @@ cd $(dirname $0)/..
 echo "Using $PWD"
 
 rm -f tags || :
-ctags -R -f tags .
+ctags -R --langmap=c++:+.cu.cuh -f tags .
 
 find . -name "*.inl" -type f -exec \
     ctags -R -f tags \

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -98,17 +98,20 @@ test_cuda_hook_static_LDADD     = $(top_builddir)/src/ucp/libucp.la \
 endif
 
 if HAVE_NVCC
+
+include $(top_srcdir)/config/cuda.am
+
+# Could be simply added as .cu to _SOURCES if there was no specific CPPFLAGS
+$(eval $(call nvcc-source, custom-test_cuda_get_symbol_address.o, \
+	test_cuda_get_symbol_address.cu,CUDA_CPPFLAGS))
+
 noinst_PROGRAMS                      += test_cuda_get_symbol_address
-test_cuda_get_symbol_address_SOURCES  = test_cuda_get_symbol_address.cu
-test_cuda_get_symbol_address_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
+test_cuda_get_symbol_address_SOURCES  =
 test_cuda_get_symbol_address_LDFLAGS  = $(CUDA_LDFLAGS)
-test_cuda_get_symbol_address_LDADD    = $(top_builddir)/src/ucp/libucp.la \
-                                        $(top_builddir)/src/ucm/libucm.la \
-                                        $(CUDART_LIBS)
-test_cuda_get_symbol_address_DEPBASE  = $(DEPDIR)/test_cuda_get_symbol_address
-test_cuda_get_symbol_address_COMPILE  = \
-    $(NVCC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
-    $(test_cuda_get_symbol_address_CPPFLAGS)
+test_cuda_get_symbol_address_LDADD    = $(CUDART_LIBS) custom-test_cuda_get_symbol_address.o \
+                                        $(top_builddir)/src/ucp/libucp.la \
+                                        $(top_builddir)/src/ucm/libucm.la
+
 endif
 
 endif
@@ -121,12 +124,3 @@ test_tcmalloc_CFLAGS   = $(BASE_CFLAGS)
 test_tcmalloc_LDADD    = -ldl $(TCMALLOC_LIB) \
                           $(top_builddir)/src/ucp/libucp.la
 endif
-
-.cu.o : ; $(NVCC) -c -o $@ $<
-
-test_cuda_get_symbol_address.o: test_cuda_get_symbol_address.cu
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(test_cuda_get_symbol_address_COMPILE) -MT $@ -MD -MF $(test_cuda_get_symbol_address_DEPBASE).Tpo -c -o $@ `test -f '$(<F)' || echo '$(srcdir)/'`$(<F)
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(test_cuda_get_symbol_address_DEPBASE).Tpo $(test_cuda_get_symbol_address_DEPBASE).Po
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='$(<F)' object='$@' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(test_cuda_get_symbol_address_COMPILE) -Xcompiler "-fPIC" -c -o $@ `test -f '$(<F)' || echo '$(srcdir)/'`$(<F)


### PR DESCRIPTION
## What?
Add CUDA files build support.

## Why?
Need to add .cu/.cuh files in the build system.

## How?
- Separate rules in CUDA-specific Makefile with general flags
- Detect and load files dependency implicitly
- Add gencode configure option (not all CUDA libraries support all arch, and there might be later version)