### PR TITLE
UCP/RNDV: Fix rkey size estimation

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -23,7 +23,8 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
 {
     ucp_context_h context                    = params->super.super.worker->context;
     const ucp_ep_config_key_t *ep_config_key = params->super.super.ep_config_key;
-    ucp_rsc_index_t mem_sys_dev, ep_sys_dev;
+    ucp_rsc_index_t mem_sys_dev              = params->super.reg_mem_info.sys_dev;
+    ucp_rsc_index_t ep_sys_dev;
     const uct_iface_attr_t *iface_attr;
     const uct_md_attr_v2_t *md_attr;
     const uct_component_attr_t *cmpt_attr;
@@ -31,8 +32,8 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
     ucp_lane_index_t lane;
     ucs_status_t status;
 
-    /* md_map is all lanes which support get_zcopy on the given mem_type and
-     * require remote key
+    /* md_map is all lanes which support get_zcopy on the given mem_type,
+     * require remote key and can reach memory sys_dev
      */
     *md_map      = 0;
     *sys_dev_map = 0;
@@ -76,6 +77,11 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
             continue;
         }
 
+        /* Check reachability between mem_sys_dev and current lane's sys_dev */
+        if (!ucs_topo_is_reachable(ep_sys_dev, mem_sys_dev)) {
+            continue;
+        }
+
         ucs_trace_req("lane[%d]: selected md %s index %u", lane,
                       context->tl_mds[md_index].rsc.md_name, md_index);
         *md_map |= UCS_BIT(md_index);
@@ -87,7 +93,6 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
         *sys_dev_map |= UCS_BIT(ep_sys_dev);
     }
 
-    mem_sys_dev = params->super.reg_mem_info.sys_dev;
     ucs_for_each_bit(ep_sys_dev, *sys_dev_map) {
         status = ucs_topo_get_distance(mem_sys_dev, ep_sys_dev, sys_distance);
         ucs_assertv_always(status == UCS_OK, "mem_info->sys_dev=%d sys_dev=%d",


### PR DESCRIPTION
## What?
When calculating rkey size for rndv protocols need to check whether each lane can reach memory sys_dev (which may not be the case for direct NIC)


## Why?
To fix this assert  (happens on the system with direct NIC)
```
rndv_rtr.c:121  Assertion `rkey_size == rpriv->super.packed_rkey_size' failed: rkey_size=31 exp=58
```