### PR TITLE
UCP: Fix rkey pack/unpack for direct NIC

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -521,6 +521,10 @@ static ucs_status_t ucp_memh_register_gva(ucp_context_h context, ucp_mem_h memh,
         memh->flags |= UCP_MEMH_FLAG_HAS_AUTO_GVA;
     }
 
+    if (reg_md_map != 0) {
+        memh->packed_sys_dev = ucp_rkey_pack_sys_dev(memh);
+    }
+
     return UCS_OK;
 }
 
@@ -679,6 +683,8 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
     memh->md_map |= md_map_registered;
     status        = UCS_OK;
 
+    memh->packed_sys_dev = ucp_rkey_pack_sys_dev(memh);
+
     ucs_trace("memh %p: registered %s address %p length %zu md_map %" PRIx64,
               memh, alloc_name, address, length, memh->md_map);
 
@@ -727,13 +733,7 @@ static void ucp_memh_init(ucp_mem_h memh, ucp_context_h context,
     memh->alloc_method   = method;
     memh->mem_type       = mem_type;
     memh->sys_dev        = sys_dev;
-
-    /* Cache sys_dev in a format packed to rkey to minimize overhead during
-     * rndv protocols. TODO remove if using another method to mark rkey with
-     * remote flush requirement. */
-    memh->packed_sys_dev = (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ?
-                                   UCS_SYS_DEVICE_ID_UNKNOWN :
-                                   ucp_rkey_pack_sys_dev(memh);
+    memh->packed_sys_dev = sys_dev;
 }
 
 static ucs_status_t

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -45,6 +45,15 @@ enum {
 
 
 /**
+ * Rkey config flags
+ */
+enum {
+    UCP_RKEY_CONFIG_FLAG_FLUSH    = UCS_BIT(0)  /* Put and atomic operations on this rkey
+                                                   require remote flush */
+};
+
+
+/**
  * Rkey configuration key
  */
 struct ucp_rkey_config_key {
@@ -62,6 +71,9 @@ struct ucp_rkey_config_key {
 
     /* MDs for which rkey is not reachable */
     ucp_md_map_t           unreachable_md_map;
+
+    /* Rkey specific flags, e.g.  */
+    uint8_t                flags;
 };
 
 

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -31,6 +31,7 @@ ucp_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
            (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
            (rkey_config_key1.sys_dev == rkey_config_key2.sys_dev) &&
            (rkey_config_key1.mem_type == rkey_config_key2.mem_type) &&
+           (rkey_config_key1.flags == rkey_config_key2.flags) &&
            (rkey_config_key1.unreachable_md_map ==
             rkey_config_key2.unreachable_md_map);
 }

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -67,9 +67,7 @@ ucp_ep_rkey_unpack_reachable(ucp_ep_h ep, const void *buffer, size_t length,
 static UCS_F_ALWAYS_INLINE int
 ucp_rkey_need_remote_flush(const ucp_rkey_config_key_t *key)
 {
-    return (key->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
-           (key->sys_dev & UCP_SYS_DEVICE_FLUSH_BIT);
-
+    return key->flags & UCP_RKEY_CONFIG_FLAG_FLUSH;
 }
 
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -144,11 +144,11 @@ ucp_proto_multi_select_bw_lanes(const ucp_proto_init_params_t *params,
 static ucp_sys_dev_map_t
 ucp_proto_multi_init_flush_sys_dev_mask(const ucp_rkey_config_key_t *key)
 {
-    if (key == NULL || !ucp_rkey_need_remote_flush(key)) {
+    if ((key == NULL) || !ucp_rkey_need_remote_flush(key)) {
         return 0;
     }
 
-    return UCS_BIT(key->sys_dev & ~UCP_SYS_DEVICE_FLUSH_BIT);
+    return UCS_BIT(key->sys_dev);
 }
 
 ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -240,6 +240,7 @@ static ucs_status_t ucp_ep_flush_mem_start(ucp_request_t *req)
 
     ep->ext->flush_sys_dev_map = 0;
 
+    req->send.flush.mem.count           = count;
     req->send.flush.mem.started         = 0;
     req->send.uct.func                  = ucp_ep_flush_mem_progress;
     req->send.flush.mem.uct_comp.func   = ucp_ep_flush_mem_completion;

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -153,6 +153,7 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
     rkey_config_key.ep_cfg_index = ep_cfg_index;
     rkey_config_key.sys_dev      = params->super.reg_mem_info.sys_dev;
     rkey_config_key.mem_type     = params->super.reg_mem_info.type;
+    rkey_config_key.flags        = 0;
 
     rkey_config_key.unreachable_md_map = 0;
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -116,6 +116,7 @@ test_ucp_proto::create_rkey_config_key(ucp_md_map_t md_map)
     rkey_config_key.mem_type           = UCS_MEMORY_TYPE_HOST;
     rkey_config_key.sys_dev            = UCS_SYS_DEVICE_ID_UNKNOWN;
     rkey_config_key.unreachable_md_map = 0;
+    rkey_config_key.flags              = 0;
 
     return rkey_config_key;
 }


### PR DESCRIPTION
## What?
- Fix rkey pack to cache packed sys_dev when md_map is initialized
- Fix unpack rkey, because we can't rely on rkey length for ucp_ep_rley_unpack API
- Fix mem flush initialization (initialize count, otherwise get_nb never started)
