### PR TITLE
ARCH/X86: compile error fix

### DIFF
--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -499,12 +499,12 @@ ucs_cpu_model_t ucs_arch_get_cpu_model()
 }
 
 
-int ucs_arch_get_cpu_flag()
+ucs_cpu_flag_t ucs_arch_get_cpu_flag()
 {
-    static int cpu_flag = UCS_CPU_FLAG_UNKNOWN;
+    static ucs_cpu_flag_t cpu_flag = UCS_CPU_FLAG_UNKNOWN;
 
     if (UCS_CPU_FLAG_UNKNOWN == cpu_flag) {
-        uint32_t result = 0;
+        ucs_cpu_flag_t result = 0;
         uint32_t base_value;
         uint32_t _eax, _ebx, _ecx, _edx;
 


### PR DESCRIPTION
## What?

Fixes the below compile error with gcc 15.1

CC       vfs/base/libucs_la-vfs_obj.lo                                                                                                                                                                                                                      CC       vfs/base/libucs_la-vfs_cb.lo                                                                                                                                                                                                                     arch/x86_64/cpu.c:502:5: error: conflicting types for ‘ucs_arch_get_cpu_flag’ due to enum/integer mismatch; have ‘int(void)’ [-Werror=enum-int-mismatch]                                                                                                      502 | int ucs_arch_get_cpu_flag()                                                                                                                                                                                                                               |     ^~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                           In file included from src/ucs/arch/cpu.h:106,                                                                                                                                                                                  from arch/x86_64/cpu.c:15:                                                                                                                                                                                                                 

src/ucs/arch/x86_64/cpu.h:54:16: note: previous declaration of ‘ucs_arch_get_cpu_flag’ with type ‘ucs_cpu_flag_t(void)’ {aka ‘enum ucs_cpu_flag(void)’}                                                          54 | ucs_cpu_flag_t ucs_arch_get_cpu_flag() UCS_F_NOOPTIMIZE;                                                                                                                                                                                                  |                ^~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                cc1: all warnings being treated as errors                                                                                                                                                            