### PR TITLE
UCT/IB: Split dp_ordering flag for DV/DevX

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1617,7 +1617,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
         init_attr.flags  |= UCT_IB_TM_SUPPORTED;
     }
 
-    if (md->dp_ordering_cap.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) {
+    if ((md->dp_ordering_cap_devx.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
+        md->ddp_support_dv.dc) {
         init_attr.flags |= UCT_IB_DDP_SUPPORTED;
     }
 
@@ -1629,7 +1630,8 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
     init_attr.cq_len[UCT_IB_DIR_TX] = sq_length * self->tx.ndci;
 
     status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
-                                              md->dp_ordering_cap.dc,
+                                              md->dp_ordering_cap_devx.dc,
+                                              md->ddp_support_dv.dc,
                                               &config->rc_mlx5_common, "dc");
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/mlx5/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_devx.c
@@ -50,9 +50,9 @@ ucs_status_t uct_dc_mlx5_iface_devx_create_dct(uct_dc_mlx5_iface_t *iface)
     UCT_IB_MLX5DV_SET(dctc, dctc, atomic_mode,
                       uct_ib_mlx5_get_atomic_mode(ib_iface));
     UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_0,
-                      UCS_BIT_GET(iface->super.config.dp_ordering, 0));
+                      UCS_BIT_GET(iface->super.config.dp_ordering_devx, 0));
     UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_1,
-                      UCS_BIT_GET(iface->super.config.dp_ordering, 1));
+                      UCS_BIT_GET(iface->super.config.dp_ordering_devx, 1));
     UCT_IB_MLX5DV_SET(dctc, dctc, dp_ordering_force,
                       iface->super.config.dp_ordering_force);
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -460,7 +460,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
     int cuda_id;
 
     status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
-                                              md->dp_ordering_cap.rc,
+                                              md->dp_ordering_cap_devx.rc,
+                                              md->ddp_support_dv.rc,
                                               &config->mlx5, "rc_gda");
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -790,6 +790,7 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
     uct_ib_mlx5_md_t *md                = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
     uct_ib_iface_init_attr_t init_attr  = {};
     ucs_status_t status;
+    uct_ib_mlx5_dp_ordering_t dp_ordering;
 
     init_attr.qp_type               = IBV_QPT_RC;
     init_attr.cq_len[UCT_IB_DIR_TX] = config->super.tx_cq_len;
@@ -797,11 +798,11 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_iface_t,
                                                    max_qp_rd_atom);
     init_attr.tx_moderation         = config->super.tx_cq_moderation;
     init_attr.dev_name              = params->mode.device.dev_name;
+    dp_ordering                     = ucs_min(md->dp_ordering_cap_devx.rc,
+                                              UCT_IB_MLX5_DP_ORDERING_OOO_RW);
 
-    status = uct_rc_mlx5_dp_ordering_ooo_init(
-            md, &self->super,
-            ucs_min(md->dp_ordering_cap.rc, UCT_IB_MLX5_DP_ORDERING_OOO_RW),
-            &config->rc_mlx5_common, "gga");
+    status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super, dp_ordering, 0,
+                                              &config->rc_mlx5_common, "gga");
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -441,11 +441,16 @@ typedef struct uct_ib_mlx5_md {
     uint8_t                  log_max_dci_stream_channels;
     uint32_t                 smkey_index;
     struct {
-        /* Max dp ordering level per transport,
+        /* Max dp ordering level per transport in DevX,
            as listed in uct_ib_mlx5_dp_ordering_t */
         uint8_t              rc;
         uint8_t              dc;
-    } dp_ordering_cap;
+    } dp_ordering_cap_devx;
+    struct {
+        /* DDP support per transport in DV API */
+        uint8_t              rc;
+        uint8_t              dc;
+    } ddp_support_dv;
 } uct_ib_mlx5_md_t;
 
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -409,8 +409,9 @@ typedef struct uct_rc_mlx5_iface_common {
         uint8_t                        atomic_fence_flag;
         uct_rc_mlx5_srq_topo_t         srq_topo;
         uint8_t                        log_ack_req_freq;
-        uint8_t                        dp_ordering;
+        uint8_t                        dp_ordering_devx;
         uint8_t                        dp_ordering_force;
+        uint8_t                        ddp_enabled_dv;
     } config;
     UCS_STATS_NODE_DECLARE(stats)
 } uct_rc_mlx5_iface_common_t;
@@ -484,6 +485,7 @@ ucs_status_t
 uct_rc_mlx5_dp_ordering_ooo_init(uct_ib_mlx5_md_t *md,
                                  uct_rc_mlx5_iface_common_t *iface,
                                  uct_ib_mlx5_dp_ordering_t dp_ordering_cap,
+                                 int ddp_supported_dv,
                                  uct_rc_mlx5_iface_common_config_t *config,
                                  const char *tl_name);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -933,12 +933,14 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
     init_attr.tx_moderation         = config->super.tx_cq_moderation;
     init_attr.dev_name              = params->mode.device.dev_name;
 
-    if (md->dp_ordering_cap.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) {
+    if ((md->dp_ordering_cap_devx.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
+        md->ddp_support_dv.rc) {
         init_attr.flags |= UCT_IB_DDP_SUPPORTED;
     }
 
     status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
-                                              md->dp_ordering_cap.rc,
+                                              md->dp_ordering_cap_devx.rc,
+                                              md->ddp_support_dv.rc,
                                               &config->rc_mlx5_common,
                                               "rc_mlx5");
     if (status != UCS_OK) {

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -457,10 +457,10 @@ public:
 
         uct_ib_mlx5_md_t *ib_md = ucs_derived_of(uct_md, uct_ib_mlx5_md_t);
         int rc_has_ddp          = has_transport("rc_mlx5") &&
-                                  (ib_md->dp_ordering_cap.rc ==
+                                  (ib_md->dp_ordering_cap_devx.rc ==
                                    UCT_IB_MLX5_DP_ORDERING_OOO_ALL);
         int dc_has_ddp          = has_transport("dc_mlx5") &&
-                                  (ib_md->dp_ordering_cap.dc ==
+                                  (ib_md->dp_ordering_cap_devx.dc ==
                                    UCT_IB_MLX5_DP_ORDERING_OOO_ALL);
         return rc_has_ddp || dc_has_ddp;
     }


### PR DESCRIPTION
## What?
Create different flags to store dp_ordering support for DevX and DV API

## Why?
In case we use both DevX and DV API for different objects and OOO semantics was selected, we need to make sure it's supported for both.