### PR TITLE
PERF: Perftest GDAKI kernel option

### DIFF
--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -160,6 +160,9 @@ typedef enum {
                                              (_params)->uct.dev_name
 
 
+#define UCX_PERF_MEM_DEV_DEFAULT -1
+
+
 /**
  * Performance counter type.
  */
@@ -183,6 +186,12 @@ typedef struct ucx_perf_result {
     }
     latency, bandwidth, msgrate;
 } ucx_perf_result_t;
+
+
+typedef struct {
+    ucs_memory_type_t mem_type;
+    int               device_id;
+} ucx_perf_accel_dev_t;
 
 
 typedef void (*ucx_perf_rte_progress_cb_t)(void *arg);
@@ -253,6 +262,8 @@ typedef struct ucx_perf_params {
     ucx_perf_wait_mode_t   wait_mode;       /* How to wait */
     ucs_memory_type_t      send_mem_type;   /* Send memory type */
     ucs_memory_type_t      recv_mem_type;   /* Recv memory type */
+    ucx_perf_accel_dev_t   send_device;     /* Send memory device for gdaki */
+    ucx_perf_accel_dev_t   recv_device;     /* Recv memory device for gdaki */
     unsigned               flags;           /* See ucx_perf_test_flags. */
 
     size_t                 *msg_size_list;  /* Test message sizes list. The size

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -170,6 +170,8 @@ static int safe_recv(int sock, void *data, size_t size,
 ucs_status_t init_test_params(perftest_params_t *params)
 {
     static const struct sockaddr_storage empty_addr = {};
+    static const ucx_perf_accel_dev_t default_dev   =
+                            {UCS_MEMORY_TYPE_LAST, UCX_PERF_MEM_DEV_DEFAULT};
 
     memset(params, 0, sizeof(*params));
     params->super.api               = UCX_PERF_API_LAST;
@@ -193,6 +195,8 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.uct.am_hdr_size   = 8;
     params->super.send_mem_type     = UCS_MEMORY_TYPE_HOST;
     params->super.recv_mem_type     = UCS_MEMORY_TYPE_HOST;
+    params->super.send_device       = default_dev;
+    params->super.recv_device       = default_dev;
     params->super.msg_size_cnt      = 1;
     params->super.iov_stride        = 0;
     params->super.ucp.send_datatype = UCP_PERF_DATATYPE_CONTIG;

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -19,7 +19,7 @@
 #endif
 
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:R:lyz"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:a:R:lyz"
 #define TEST_ID_UNDEFINED       -1
 
 #define DEFAULT_DAEMON_PORT     1338

--- a/src/tools/perf/perftest_run.c
+++ b/src/tools/perf/perftest_run.c
@@ -104,6 +104,13 @@ void print_progress(void *UCS_V_UNUSED rte_group,
     fflush(stdout);
 }
 
+static void
+get_accel_device_str(const ucx_perf_accel_dev_t *dev, char *str, size_t size)
+{
+    ucs_snprintf_safe(str, size, "%s:%d", ucs_memory_type_names[dev->mem_type],
+                      dev->device_id);
+}
+
 static void print_header(struct perftest_context *ctx)
 {
     const char *overhead_lat_str;
@@ -111,6 +118,7 @@ static void print_header(struct perftest_context *ctx)
     const char *test_api_str;
     test_type_t *test;
     unsigned i;
+    char mem_dev_str[16];
 
     test = (ctx->params.test_id == TEST_ID_UNDEFINED) ? NULL :
            &tests[ctx->params.test_id];
@@ -148,6 +156,14 @@ static void print_header(struct perftest_context *ctx)
         printf("| Data layout:  %-60s                               |\n", test_data_str);
         printf("| Send memory:  %-60s                               |\n", ucs_memory_type_names[ctx->params.super.send_mem_type]);
         printf("| Recv memory:  %-60s                               |\n", ucs_memory_type_names[ctx->params.super.recv_mem_type]);
+        if (ctx->params.super.send_device.mem_type != UCS_MEMORY_TYPE_LAST) {
+            get_accel_device_str(&ctx->params.super.send_device, mem_dev_str, sizeof(mem_dev_str));
+            printf("| Send device:  %-60s                               |\n", mem_dev_str);
+        }
+        if (ctx->params.super.recv_device.mem_type != UCS_MEMORY_TYPE_LAST) {
+            get_accel_device_str(&ctx->params.super.recv_device, mem_dev_str, sizeof(mem_dev_str));
+            printf("| Recv device:  %-60s                               |\n", mem_dev_str);
+        }
         printf("| Message size: %-60zu                               |\n", ucx_perf_get_message_size(&ctx->params.super));
         printf("| Window size:  %-60u                               |\n", ctx->params.super.max_outstanding);
 

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -214,6 +214,8 @@ void test_perf::test_params_init(const test_spec &test,
     params.max_outstanding = test.max_outstanding;
     params.send_mem_type   = test.send_mem_type;
     params.recv_mem_type   = test.recv_mem_type;
+    params.send_device     = {UCS_MEMORY_TYPE_LAST, UCX_PERF_MEM_DEV_DEFAULT};
+    params.recv_device     = {UCS_MEMORY_TYPE_LAST, UCX_PERF_MEM_DEV_DEFAULT};
     params.percentile_rank = 50.0;
 
     memset(params.uct.md_name, 0, sizeof(params.uct.md_name));

--- a/test/gtest/ucp/cuda/test_kernels.cu
+++ b/test/gtest/ucp/cuda/test_kernels.cu
@@ -36,13 +36,18 @@ int memcmp(const void *s1, const void *s2, size_t size)
     }
 
     if (cudaHostGetDevicePointer(&d_result, h_result, 0) != cudaSuccess) {
-        result = 1;
+        result = -1;
         goto out;
     }
 
     *h_result = 0;
     memcmp_kernel<<<16, 64>>>(s1, s2, d_result, size);
-    cudaDeviceSynchronize();
+
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        result = -1;
+        goto out;
+    }
+
     result = *h_result;
 
 out:


### PR DESCRIPTION
## What?
Added GDAKI kernel option to ucx_perftest, so that we can run GDAKI tests with arbitrary GPU devices:
`ucx_perftest -a cuda:3,cuda:2`

## Why?
Easy of testing

## Testing
Currently inproc multi-GPU is not supported: for that we need to change cuda_alloc similar to: https://github.com/openucx/ucx/pull/10810

Tested on Pre Tyche:
```
UCX_PROTO_INFO=y ucx_perftest -c 0 &
UCX_PROTO_INFO=y ucx_perftest localhost -c 1 -t ucp_put_bw -n 1000 -s 1024 -m cuda -a cuda:3,cuda:2
+----------------------------------------------------------------------------------------------------------+                                                                                                                                                                                                                                         
| API:          protocol layer                                                                             |                                                                                                                                                                                                                                         
| Test:         put bandwidth                                                                              |                                                                                                                                                                                                                                         
| Data layout:  (automatic)                                                                                |                                                                                                                                                                                                                                         
| Send memory:  cuda                                                                                       |                                                                                                                                                                                                                                         
| Recv memory:  cuda                                                                                       |                                                                                                                                                                                                                                         
| Send GDAKI:   cuda:3                                                                                     |                                                                                                                                                                                                                                         
| Recv GDAKI:   cuda:2                                                                                     |
| Message size: 1024                                                                                       |
| Window size:  32                                                                                         |
+----------------------------------------------------------------------------------------------------------+
[1756211331.577478] [ptyche0343:877081:0]   +---------------------------+------------------------------------------------------------------+
[1756211331.577484] [ptyche0343:877081:0]   | perftest intra-node cfg#1 | remote memory write by ucp_put*(multi) from cuda/GPU2 to cuda    |
[1756211331.577487] [ptyche0343:877081:0]   +---------------------------+--------------------------------------------------+---------------+
[1756211331.577490] [ptyche0343:877081:0]   |                    0..inf | zero-copy                                        | cuda_ipc/cuda |
[1756211331.577491] [ptyche0343:877081:0]   +---------------------------+--------------------------------------------------+---------------+
[1756211331.577288] [ptyche0343:877092:0]   +---------------------------+------------------------------------------------------------------+
[1756211331.577295] [ptyche0343:877092:0]   | perftest intra-node cfg#1 | remote memory write by ucp_put*(multi) from cuda/GPU3 to cuda    |
[1756211331.577297] [ptyche0343:877092:0]   +---------------------------+--------------------------------------------------+---------------+
[1756211331.577300] [ptyche0343:877092:0]   |                    0..inf | zero-copy                                        | cuda_ipc/cuda |
[1756211331.577303] [ptyche0343:877092:0]   +---------------------------+--------------------------------------------------+---------------+
Final:                  1000      2.656     4.720     4.720      206.90     206.90      211866      211866
