### PR TITLE
GTEST/UCT: Relaxed test_cuda_nvml.device_get_fabric_info condition.

### DIFF
--- a/test/gtest/uct/cuda/test_cuda_nvml.cc
+++ b/test/gtest/uct/cuda/test_cuda_nvml.cc
@@ -41,6 +41,6 @@ UCS_TEST_F(test_cuda_nvml, device_get_fabric_info) {
     fabric_info.version = nvmlGpuFabricInfo_v2;
     status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetGpuFabricInfoV, device,
                                      &fabric_info);
-    EXPECT_EQ(status, UCS_OK);
+    EXPECT_TRUE((status == UCS_OK) || (status == UCS_ERR_IO_ERROR));
 }
 #endif


### PR DESCRIPTION
## What?
Relaxed test_cuda_nvml.device_get_fabric_info condition.

## Why?
`nvmlDeviceGetGpuFabricInfoV` may return an error. This is not critical.
We handle this behavior in the UCT code.