### PR TITLE
UCT/CUDA/CUDA_IPC: Handle cuMemRelease error status.

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -184,15 +184,10 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
             UCT_CUDADRV_FUNC_LOG_ERR(cuMemExportToShareableHandle(
                         &key->ph.handle.fabric_handle, handle,
                         CU_MEM_HANDLE_TYPE_FABRIC, 0));
+        UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
         if (status != UCS_OK) {
-            cuMemRelease(handle);
             ucs_debug("unable to export handle for VMM ptr: %p", addr);
             goto non_ipc;
-        }
-
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemRelease(handle));
-        if (status != UCS_OK) {
-            goto out_pop_ctx;
         }
 
         key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM;


### PR DESCRIPTION
## What?
Check return status of `cuMemRelease`.
Print warning if `cuMemRelease` fails.

## Why?
Fixed covertly issue https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=105975&view=logs&j=47731102-2aa6-52e1-fa59-082754c35edc&t=d846e2d6-0f9c-5d6b-840d-651f2020b390&l=2911
