### PR TITLE
SRC/UCP/CORE: set FLAG_LOCK for allocated buffers when NONBLOCK is not passed

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -319,7 +319,8 @@ ucp_mem_map_params2uct_flags(const ucp_context_h context,
     if (params->field_mask & UCP_MEM_MAP_PARAM_FIELD_FLAGS) {
         if (params->flags & UCP_MEM_MAP_NONBLOCK) {
             flags |= UCT_MD_MEM_FLAG_NONBLOCK;
-        } else if (params->flags & UCP_MEM_MAP_LOCK) {
+        } else if ((params->flags & UCP_MEM_MAP_LOCK) ||
+                   (params->flags & UCP_MEM_MAP_ALLOCATE)) {
             flags |= UCT_MD_MEM_FLAG_LOCK;
         }
 


### PR DESCRIPTION
## What?
Set `UCT_MD_MEM_FLAG_LOCK` flag when user is allocating a buffer using ucp_mem_map without passing `UCP_MEM_MAP_NONBLOCK` flag

## Why?
Otherwise, non-blocking registration (ODP) can still happen in `ucp_memh_register_internal`
