### PR TITLE
UCM: Print module info to debug by default

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -192,7 +192,7 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   "Directory to search for loadable modules",
   ucs_offsetof(ucs_global_opts_t, module_dir), UCS_CONFIG_TYPE_STRING},
 
- {"MODULE_LOG_LEVEL", "trace",
+ {"MODULE_LOG_LEVEL", "debug",
   "Logging level for module loader",
   ucs_offsetof(ucs_global_opts_t, module_log_level), UCS_CONFIG_TYPE_ENUM(ucs_log_level_names)},
 


### PR DESCRIPTION
## What?
print module loading related traces with debug level by default

## Why?
better debugging experience
The numer of module related traces is relativelly small and it is often useful to check them together with debug logs. To get this info user needs to set  2 env vars: `UCX_MODULE_LOG_LEVEL=debug` and `UCX_LOG_LEVEL=debug`
With this change just `UCX_LOG_LEVEL=debug`  is enough
