### PR TITLE
CI: Fix test_jenkins

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -449,7 +449,7 @@ run_ucx_perftest() {
 			opt_transports="-x posix"
 			tls="shm"
 			dev="all"
-		elif [[ " ${ip_ifaces[*]} " == *" ${ucx_dev} "* ]]; then
+		elif printf '%s\n' "$ip_ifaces" | grep -qxF "$ucx_dev"; then
 			opt_transports="-x tcp"
 			tls="tcp"
 			dev=$ucx_dev
@@ -688,7 +688,7 @@ run_mpi_tests() {
 					-mca btl tcp,self \
 					-mca btl_tcp_if_include lo \
 					-mca orte_allowed_exit_without_sync 1 \
-					-mca coll ^hcoll,ml"
+					-mca coll ^hcoll,ml,ucc"
 
 			run_ucx_perftest 1
 


### PR DESCRIPTION
## What?
Fix 2 CI issues:
1. 
```
+ mpirun --allow-run-as-root --bind-to none -x UCX_ERROR_SIGNALS -x UCX_HANDLE_ERRORS -mca pml ob1 -mca osc '^ucx' -mca btl tcp,self -mca btl_tcp_if_include lo -mca orte_allowed_exit_without_sync 1 -mca coll '^hcoll,ml' -np 2 -x UCX_NET_DEVICES=mlx5_1:1 -x UCX_TLS=rc_verbs,rc_x /scrap/azure/agent-03/AZP_WORKSPACE/2/s/install/bin/ucx_perftest -b /scrap/azure/agent-03/AZP_WORKSPACE/2/s/install/share/ucx/perftest/test_types_short_ucp -b /scrap/azure/agent-03/AZP_WORKSPACE/2/s/install/share/ucx/perftest/msg_pow2_short -w 1
...
[swx-rdmz-ucx-new-01:2083016:1:2085905]  ucp_worker.c:3058 Assertion `ucs_async_check_owner_thread(&(worker)->async)' failed

/scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_worker.c: [ ucp_worker_progress() ]
      ...
     3055     /* worker->inprogress is used only for assertion check.
     3056      * coverity[assert_side_effect]
     3057      */
==>  3058     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
     3059 
     3060     /* check that ucp_worker_progress is not called from within ucp_worker_progress */
     3061     ucs_assert(worker->inprogress++ == 0);

==== backtrace (tid:2085905) ====
 0 0x0000000000064267 ucp_worker_progress()  /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/ucp/core/ucp_worker.c:3058
 1 0x000000000000d62f ucc_context_progress()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ucc-11f0929ff0ef35f81560e9fc4462855e3c20d42b/src/core/ucc_context.c:1015
 2 0x000000000000d62f ucc_context_progress()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ucc-11f0929ff0ef35f81560e9fc4462855e3c20d42b/src/core/ucc_context.c:1000
 3 0x00000000000037fb mca_coll_ucc_progress()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/ompi/mca/coll/ucc/coll_ucc_module.c:62
 4 0x000000000003a904 opal_progress()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/opal/runtime/opal_progress.c:231
 5 0x00000000000412cd ompi_sync_wait_mt()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/opal/threads/wait_sync.c:85
 6 0x000000000000a6f6 ompi_request_wait_completion()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/ompi/mca/pml/ob1/../../../../ompi/request/request.h:428
 7 0x000000000000a6f6 ompi_request_wait_completion()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/ompi/mca/pml/ob1/../../../../ompi/request/request.h:418
 8 0x000000000000a6f6 mca_pml_ob1_recv()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/ompi/mca/pml/ob1/pml_ob1_irecv.c:135
 9 0x0000000000079721 PMPI_Recv()  /build-result/src/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi-92f9fca4eb832bb874928d25485be6e007c62e31/ompi/mpi/c/profile/precv.c:82
10 0x00000000000076ab mpi_rte_recv()  /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/tools/perf/perftest.c:676
11 0x000000000000bde3 ucx_perf_test_exchange_status()  /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/tools/perf/lib/libperf.c:1041
12 0x000000000000da02 ucx_perf_do_warmup()  /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/tools/perf/lib/libperf.c:1704
13 0x0000000000011f33 ucx_perf_thread_run_test()  /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/tools/perf/lib/libperf_thread.c:38
14 0x0000000000011f33 ucx_perf_thread_spawn._omp_fn.0()  /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../src/tools/perf/lib/libperf_thread.c:119
15 0x000000000001dc0e omp_fulfill_event()  ???:0
16 0x0000000000094ac3 start_thread()  ./nptl/pthread_create.c:442
```
ucp_perftest is ran with batch file which includes multi-thread tests (test_types_short_ucp), but ucx_perftest initializes MPI with `MPI_THREAD_FUNNELED`, which triggesr the assertion in UCC and also needs to be fixed.

2. 
```
/hpc/local/benchmarks/custom_by_michael/hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda13-x86_64/ompi/bin/mpirun
+ mpirun --allow-run-as-root --bind-to none -x UCX_ERROR_SIGNALS -x UCX_HANDLE_ERRORS -mca pml ob1 -mca osc '^ucx' -mca btl tcp,self -mca btl_tcp_if_include lo -mca orte_allowed_exit_without_sync 1 -mca coll '^hcoll,ml' -np 2 -x UCX_NET_DEVICES=eno1 -x UCX_TLS=rc_v /scrap/azure/agent-03/AZP_WORKSPACE/1/s/install/bin/ucx_perftest -b /scrap/azure/agent-03/AZP_WORKSPACE/1/s/install/share/ucx/perftest/test_types_short_ucp -b /scrap/azure/agent-03/AZP_WORKSPACE/1/s/install/share/ucx/perftest/msg_pow2_short -w 1
[1756821171.721255] [swx-rain03:701128:0]     ucp_context.c:1595 UCX  ERROR no usable transports/devices (asked rc_v on network:eno1 )
[1756821171.721314] [swx-rain03:701128:0]  tl_ucp_context.c:221  TL_UCP ERROR failed to init ucp context, No such device
[1756821171.721344] [swx-rain03:701128:0]     ucc_context.c:416  UCC  ERROR failed to create tl context for ucp
[1756821171.721261] [swx-rain03:701127:0]     ucp_context.c:1595 UCX  ERROR no usable transports/devices (asked rc_v on network:eno1 )
[1756821171.721316] [swx-rain03:701127:0]  tl_ucp_context.c:221  TL_UCP ERROR failed to init ucp context, No such device
[1756821171.721345] [swx-rain03:701127:0]     ucc_context.c:416  UCC  ERROR failed to create tl context for ucp
[swx-rain03:701128:0:701128] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
[swx-rain03:701127:0:701127] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
```
the problematic check is 
`elif [[ " ${ip_ifaces[*]} " == *" ${ucx_dev} "* ]]; then`, because looks like `ip_ifaces` isn’t actually an array - it’s a plain string containing newlines (not just spaces): like
```
eno1\n
enp60s0f0np0\n
enp60s0f1np1
```

so comparing " eno1 " and " eno1\n" fails