### PR TITLE
AZP: Test DOCA3.1 on GPU

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -66,6 +66,9 @@ resources:
     - container: sles15sp6
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/sles15sp6/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: rhel90_doca31
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/rhel9.0/builder:doca-3.1.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: centos7_cuda_11_0
       image: nvidia/cuda:11.0.3-devel-centos7
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_GPU)
@@ -327,7 +330,7 @@ stages:
         name: gpu
         demands: ucx_gpu -equals yes
         test_perf: 1
-        container: centos7_cuda11
+        container: rhel90_doca31
     - template: tests.yml
       parameters:
         name: new


### PR DESCRIPTION
## What?
Run GPU tests using the new RHEL9 image with DOCA3.1.

## Why?
Test DOCA3.1 on GPU nodes.

