### PR TITLE
UCT/CUDA: Removed unsafe usage of cuCtxGetId.

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -57,39 +57,15 @@ static UCS_F_ALWAYS_INLINE int uct_cuda_base_is_context_active()
 }
 
 
-static UCS_F_ALWAYS_INLINE int uct_cuda_base_is_context_valid(CUcontext ctx)
-{
-    unsigned version;
-    ucs_status_t status;
-
-    /* Check if CUDA context is valid by running a dummy operation on it */
-    status = UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetApiVersion(ctx, &version));
-    return (status == UCS_OK);
-}
-
-
-static UCS_F_ALWAYS_INLINE int uct_cuda_base_context_match(CUcontext ctx1,
-                                                           CUcontext ctx2)
-{
-    return ((ctx1 != NULL) && (ctx1 == ctx2) &&
-            uct_cuda_base_is_context_valid(ctx1));
-}
-
-
 static UCS_F_ALWAYS_INLINE CUresult
 uct_cuda_base_ctx_get_id(CUcontext ctx, unsigned long long *ctx_id_p)
 {
-    unsigned long long ctx_id = 0;
-
 #if CUDA_VERSION >= 12000
-    CUresult result = cuCtxGetId(ctx, &ctx_id);
-    if (ucs_unlikely(result != CUDA_SUCCESS)) {
-        return result;
-    }
-#endif
-
-    *ctx_id_p = ctx_id;
+    return cuCtxGetId(ctx, ctx_id_p);
+#else
+    *ctx_id_p = 0;
     return CUDA_SUCCESS;
+#endif
 }
 
 
@@ -192,8 +168,7 @@ void uct_cuda_base_queue_desc_init(uct_cuda_queue_desc_t *qdesc);
 void uct_cuda_base_queue_desc_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
                                       uct_cuda_queue_desc_t *qdesc);
 
-void uct_cuda_base_stream_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
-                                  CUstream *stream);
+void uct_cuda_base_stream_destroy(CUstream *stream);
 
 #if (__CUDACC_VER_MAJOR__ >= 100000)
 void CUDA_CB uct_cuda_base_iface_stream_cb_fxn(void *arg);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -313,7 +313,7 @@ static void uct_cuda_copy_ctx_rsc_destroy(uct_iface_h tl_iface,
         }
     }
 
-    uct_cuda_base_stream_destroy(cuda_ctx_rsc, &ctx_rsc->short_stream);
+    uct_cuda_base_stream_destroy(&ctx_rsc->short_stream);
     ucs_free(ctx_rsc);
 }
 


### PR DESCRIPTION
## What?
Removed unsafe usage of `cuCtxGetId`.
Updated `test_mpi_cuda.c` so that the used `CUcontext`s are deleted after clearing UCX resources.

## Why?
It's not safe to check that context is alive using `cuCtxGetId`. Accessing the `CUcontext` after it has been destroyed or released is undefined. `CUDA_ERROR_CONTEXT_IS_DESTROYED` error code cannot be used to detect the state of the `CUcontext`.

https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=106539&view=logs&j=9bfec731-a829-51fe-2647-48f0776e8294&s=ea5ef80c-b63d-5439-aa09-20a1f5179b9e&t=2cb611a4-81cf-58a3-b307-c921b40e5d32&l=7040
