### PR TITLE
AZP: Add build test on ARM

### DIFF
--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -1,0 +1,77 @@
+parameters:
+  name:
+  demands: []
+  displayName:
+
+jobs:
+  - job: ${{ parameters.name }}
+    pool:
+      name: MLNX
+      demands: ${{ parameters.demands }}
+    container: $[ variables['CONTAINER'] ]
+    strategy:
+      # x86 matrix
+      ${{ if contains(parameters.name, 'x86') }}:
+        matrix:
+          rhel76:
+            CONTAINER: rhel76
+            long_test: yes
+          ubuntu2004:
+            CONTAINER: ubuntu2004
+            long_test: yes
+            extra_modules: ""
+          ubuntu1804:
+            CONTAINER: ubuntu1804
+            extra_modules: ""
+          ubuntu2204:
+            CONTAINER: ubuntu2204
+          ubuntu2404:
+            CONTAINER: ubuntu2404
+          ubuntu2210:
+            CONTAINER: ubuntu2210
+          debian113:
+            CONTAINER: debian113
+          debian109:
+            CONTAINER: debian109
+          debian125:
+            CONTAINER: debian125
+          sles15sp6:
+            CONTAINER: sles15sp6
+          rhel82:
+            CONTAINER: rhel82
+          rhel90:
+            CONTAINER: rhel90
+          fedora41:
+            CONTAINER: fedora41
+          centos7:
+            CONTAINER: centos7_ib
+          centos10stream:
+            CONTAINER: centos10stream
+          ubuntu2004_rocm:
+            CONTAINER: ubuntu2004_rocm_5_4_0
+          ubuntu2204_rocm:
+            CONTAINER: ubuntu2204_rocm_6_0_0
+          kylin10sp3:
+            CONTAINER: kylin10sp3
+          euleros2sp12:
+            CONTAINER: euleros2sp12
+      # ARM matrix
+      ${{ if contains(parameters.name, 'arm') }}:
+        matrix:
+          ubuntu2404_arm:
+            CONTAINER: ubuntu2404_arm
+    timeoutInMinutes: 340
+
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        retryCountOnTaskFailure: 5
+
+      - bash: |
+          ./buildlib/tools/builds.sh
+        displayName: ${{ parameters.displayName }}
+        env:
+          BUILD_ID: "$(Build.BuildId)-$(Build.BuildNumber)"
+          long_test: $(long_test)
+          test_static: $(test_static)

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -54,6 +54,9 @@ resources:
     - container: ubuntu2404
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2404_arm
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
@@ -203,71 +206,19 @@ stages:
   - stage: Build
     dependsOn: [Static_check]
     jobs:
-      - job: build_source
-        pool:
-          name: MLNX
+      - template: build_job.yml
+        parameters:
+          name: build_source_x86
           demands:
-            - ucx_docker -equals yes
-        strategy:
-          matrix:
-            rhel76:
-              CONTAINER: rhel76
-              long_test: yes
-            ubuntu2004:
-              CONTAINER: ubuntu2004
-              long_test: yes
-              extra_modules: ""
-            ubuntu1804:
-              CONTAINER: ubuntu1804
-              extra_modules: ""
-            ubuntu2204:
-              CONTAINER: ubuntu2204
-            ubuntu2404:
-              CONTAINER: ubuntu2404
-            ubuntu2210:
-              CONTAINER: ubuntu2210
-            debian113:
-              CONTAINER: debian113
-            debian109:
-              CONTAINER: debian109
-            debian125:
-              CONTAINER: debian125
-            sles15sp6:
-              CONTAINER: sles15sp6
-            rhel82:
-              CONTAINER: rhel82
-            rhel90:
-              CONTAINER: rhel90
-            fedora41:
-              CONTAINER: fedora41
-            centos7:
-              CONTAINER: centos7_ib
-            centos10stream:
-              CONTAINER: centos10stream
-            ubuntu2004_rocm:
-              CONTAINER: ubuntu2004_rocm_5_4_0
-            ubuntu2204_rocm:
-              CONTAINER: ubuntu2204_rocm_6_0_0
-            kylin10sp3:
-              CONTAINER: kylin10sp3
-            euleros2sp12:
-              CONTAINER: euleros2sp12
-        container: $[ variables['CONTAINER'] ]
-        timeoutInMinutes: 340
+            - ucx_docker
+          displayName: Build x86
 
-        steps:
-          - checkout: self
-            clean: true
-            fetchDepth: 100
-            retryCountOnTaskFailure: 5
-
-          - bash: |
-              ./buildlib/tools/builds.sh
-            displayName: Build
-            env:
-              BUILD_ID: "$(Build.BuildId)-$(Build.BuildNumber)"
-              long_test: $(long_test)
-              test_static: $(test_static)
+      - template: build_job.yml
+        parameters:
+          name: build_source_arm
+          demands:
+            - ucx_arm64
+          displayName: Build ARM
 
   - stage: ucx_perftest_mad_rte
     dependsOn: [Static_check]


### PR DESCRIPTION
## What?
Adds ARM Ubuntu 24.04 build testing to the CI pipeline and refactors the Build stage to use a shared template

## Why?
Enables testing UCX builds on ARM AArch64 architecture to catch platform-specific compilation issues
(like the recent NVCC/GCC pragma incompatibility on ARM)

## How?
- Creates `build_job.yml` template with conditional matrix selection based on job name
- Refactors existing x86 builds to use the template with `ucx_docker` demands
- Adds new ARM build job using `ucx_arm64` demands and `ubuntu2404_arm` container
- Uses runtime expressions for container resolution from strategy matrix variables