### PR TITLE
AZP: Switch GPU tests to Ubuntu 24.04 DOCA 3.1 (GPUNetIO) image

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -193,9 +193,9 @@ try_load_cuda_env() {
     num_gpus=$(get_num_gpus)
     [ "${num_gpus}" -gt 0 ] || return 0
 
-    # Prefer local CUDA inside container if available
-    if which nvcc >/dev/null 2>&1; then
-        have_cuda=yes
+    # Prefer local CUDA if available
+    if find /usr/local/cuda/ -name libcudart.so &>/dev/null 2>&1; then
+        have_cuda="/usr/local/cuda"
     else
         # Fallback to env module
         az_module_load dev/cuda12.8 || return 0
@@ -205,6 +205,7 @@ try_load_cuda_env() {
     # Check gdrcopy
     if [ -w "/dev/gdrdrv" ]
     then
+        # TODO detect cuda version if using local CUDA
         az_module_load dev/gdrcopy2.4.4_cuda12.8.0 && have_gdrcopy=yes
     fi
 }

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -193,9 +193,14 @@ try_load_cuda_env() {
     num_gpus=$(get_num_gpus)
     [ "${num_gpus}" -gt 0 ] || return 0
 
-    # Check cuda env module
-    az_module_load dev/cuda12.8 || return 0
-    have_cuda=yes
+    # Prefer local CUDA inside container if available
+    if which nvcc >/dev/null 2>&1; then
+        have_cuda=yes
+    else
+        # Fallback to env module
+        az_module_load dev/cuda12.8 || return 0
+        have_cuda=yes
+    fi
 
     # Check gdrcopy
     if [ -w "/dev/gdrdrv" ]

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -57,6 +57,9 @@ resources:
     - container: ubuntu2404_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2404_doca31_gpunetio
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu24.04/builder:doca-3.1.0-gpunetio
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
@@ -284,7 +287,7 @@ stages:
         name: gpu
         demands: ucx_gpu -equals yes
         test_perf: 1
-        container: rhel90_doca31
+        container: ubuntu2404_doca31_gpunetio
     - template: tests.yml
       parameters:
         name: new

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -83,9 +83,9 @@ build() {
 	shift
 
 	config_args="--prefix=$ucx_inst --without-java"
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
-		config_args+=" --with-iodemo-cuda"
+		config_args+=" --with-cuda=$have_cuda --with-iodemo-cuda"
 
 		if has_gpunetio_devel
 		then

--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -83,7 +83,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          CUDART_STATIC_LIBS=""
          NVML_LIBS=""
          CUDA_BIN_PATH=""
-         CUDA_LIB_DIR=""
+         CUDA_LIB_DIRS=""
 
          AS_IF([test ! -z "$with_cuda" -a "x$with_cuda" != "xyes" -a "x$with_cuda" != "xguess"],
                [ucx_check_cuda_dir="$with_cuda"
@@ -92,7 +92,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                 CUDA_CPPFLAGS="-I$with_cuda/include"
                 CUDA_LDFLAGS="-L$ucx_check_cuda_libdir -L$ucx_check_cuda_libdir/stubs"
                 CUDA_BIN_PATH="$with_cuda/bin"
-                CUDA_LIB_DIR="$ucx_check_cuda_libdir"])
+                CUDA_LIB_DIRS="$ucx_check_cuda_libdir $with_cuda/compat"])
 
          CPPFLAGS="$CPPFLAGS $CUDA_CPPFLAGS"
          LDFLAGS="$LDFLAGS $CUDA_LDFLAGS"

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -260,7 +260,7 @@ run_ucp_hello() {
 
 	mem_types_list="host "
 
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
 		mem_types_list+="cuda cuda-managed "
 	fi
@@ -297,7 +297,7 @@ run_ucp_hello() {
 run_uct_hello() {
 	mem_types_list="host "
 
-	if [ "X$have_cuda" == "Xyes" ] && [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ]
+	if [ "X$have_cuda" != "Xno" ] && [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ]
 	then
 		mem_types_list+="cuda-managed "
 		if [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ]
@@ -333,7 +333,7 @@ run_client_server() {
 	msg_size_list="1 16 256 4096 65534"
 	api_list="am tag stream"
 
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
 		mem_types_list+=" cuda cuda-managed "
 	fi
@@ -374,7 +374,7 @@ run_io_demo() {
 	server_nonrdma_addr=$(get_non_rdma_ip_addr)
 	mem_types_list="host "
 
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
 		mem_types_list+="cuda cuda-managed "
 	fi
@@ -496,7 +496,7 @@ run_ucx_perftest() {
 
 	# run cuda tests if cuda module was loaded and GPU is found, and only in
 	# client/server mode, to reduce testing time
-	if [ "X$have_cuda" == "Xyes" ] && [ $with_mpi -ne 1 ]
+	if [ "X$have_cuda" != "Xno" ] && [ $with_mpi -ne 1 ]
 	then
 		gdr_options="n "
 		if (lsmod | grep -q "nv_peer_mem")
@@ -637,7 +637,7 @@ run_ucx_perftest_with_daemon() {
 # Run UCX performance cuda device test
 #
 run_ucx_perftest_cuda_device() {
-	if [ "X$have_cuda" != "Xyes" ]; then
+	if [ "X$have_cuda" == "Xno" ]; then
 		echo "==== CUDA not available, skipping CUDA device tests ===="
 		return 0
 	fi
@@ -724,7 +724,7 @@ run_mpi_tests() {
 
 			test_malloc_hooks_mpi
 
-			if [ "X$have_cuda" == "Xyes" ] && [ -x ./test/mpi/test_mpi_cuda ]
+			if [ "X$have_cuda" != "Xno" ] && [ -x ./test/mpi/test_mpi_cuda ]
 			then
 				echo "==== Running MPI CUDA tests ===="
 				${MPIRUN_COMMON} -np 2 ./test/mpi/test_mpi_cuda
@@ -927,7 +927,7 @@ test_malloc_hook() {
 
 test_no_cuda_context() {
 	echo "==== Running no CUDA context test ===="
-	if [ "X$have_cuda" == "Xyes" ] && [ -x ./test/apps/test_no_cuda_ctx ]
+	if [ "X$have_cuda" != "Xno" ] && [ -x ./test/apps/test_no_cuda_ctx ]
 	then
 		./test/apps/test_no_cuda_ctx
 	fi

--- a/src/uct/ib/mlx5/gdaki/configure.m4
+++ b/src/uct/ib/mlx5/gdaki/configure.m4
@@ -9,56 +9,65 @@ AC_ARG_WITH([doca-gpunetio],
             [with_doca_gpunetio=$withval],
             [with_doca_gpunetio=guess])
 
-AS_IF([test "x$cuda_happy" = "xyes"], [
 
-# Default value
-GPUNETIO_CFLAGS=""
-GPUNETIO_LDFLAGS=""
-GPUNETIO_LIBS="-ldoca_gpunetio"
+AS_IF([test "x$cuda_happy" = "xyes"],
+      [
+       # Default value
+       GPUNETIO_CFLAGS=""
+       GPUNETIO_LDFLAGS=""
+       GPUNETIO_LIBS="-ldoca_gpunetio"
+       AS_IF([test "x$with_doca_gpunetio" != "xno"],
+             [
+              AS_IF([test "x$with_doca_gpunetio" = "xguess"],
+                    [
+                     AS_IF([$PKG_CONFIG --exists doca-gpunetio],
+                           [GPUNETIO_CFLAGS=$(pkg-config --cflags doca-gpunetio)
+                            GPUNETIO_LDFLAGS=$(pkg-config --libs-only-L doca-gpunetio)
+                            GPUNETIO_LIBS=$(pkg-config --libs-only-l doca-gpunetio)])
+                    ],
+                    [
+                     GPUNETIO_CFLAGS="-I${with_doca_gpunetio}/include"
+                     for libdir in lib/x86_64-linux-gnu lib64; do
+                         if test -d "${with_doca_gpunetio}/${libdir}"; then
+                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -L${with_doca_gpunetio}/${libdir} "
+                             # Add rpath-link to search for doca_gpunetio dependencies
+                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${with_doca_gpunetio}/${libdir}"
+                         fi
+                     done
+                     # Add CUDA lib dirs to rpath-link for gpunetio
+                     for cuda_libdir in $CUDA_LIB_DIRS; do
+                         GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${cuda_libdir}"
+                     done
+                    ]) # "x$with_doca_gpunetio" != "xguess"
+             ]) # "x$with_doca_gpunetio" != "xno"
 
-AS_IF([test x$with_doca_gpunetio != xno], [
-  AS_IF([test x$with_doca_gpunetio = xguess],
-    [
-      AS_IF([$PKG_CONFIG --exists doca-gpunetio],
-            [
-              # Guess from pkg-config
-              GPUNETIO_CFLAGS=$(pkg-config --cflags doca-gpunetio)
-              GPUNETIO_LDFLAGS=$(pkg-config --libs-only-L doca-gpunetio)
-              GPUNETIO_LIBS=$(pkg-config --libs-only-l doca-gpunetio)
-            ])
-    ],
-    [
-      # User provided path
-      GPUNETIO_CFLAGS="-I${with_doca_gpunetio}/include"
-      for dir in lib lib64 lib/x86_64-linux-gnu; do
-        if test -d "${with_doca_gpunetio}/${dir}"; then
-          GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -L${with_doca_gpunetio}/${dir} "
-          # Add rpath-link to search for doca_gpunetio dependencies
-          GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${with_doca_gpunetio}/${dir}"
-        fi
-      done
-    ])
-])
+       save_CPPFLAGS="$CPPFLAGS"
+       save_LDFLAGS="$LDFLAGS"
+       CPPFLAGS="$CPPFLAGS $CUDA_CFLAGS $GPUNETIO_CFLAGS"
+       LDFLAGS="$LDFLAGS $CUDA_LDFLAGS $GPUNETIO_LDFLAGS"
 
-save_CPPFLAGS="$CPPFLAGS"
-save_LDFLAGS="$LDFLAGS"
-CPPFLAGS="$CPPFLAGS $CUDA_CFLAGS $GPUNETIO_CFLAGS"
-LDFLAGS="$LDFLAGS $CUDA_LDFLAGS $GPUNETIO_LDFLAGS -Wl,-rpath-link,$CUDA_LIB_DIR"
+       gpunetio_happy=yes
+       AC_CHECK_HEADERS([doca_gpunetio.h], [], [gpunetio_happy=no])
+       AC_CHECK_LIB([doca_gpunetio], [doca_gpu_verbs_bridge_export_qp],
+                    [], [gpunetio_happy=no], [$GPUNETIO_LIBS])
 
-AC_CHECK_HEADERS([doca_gpunetio.h], [have_gpunetio=yes], [have_gpunetio=no])
-AC_CHECK_LIB([doca_gpunetio], [doca_gpu_verbs_bridge_export_qp],
-             [true], [have_gpunetio=no], [$GPUNETIO_LIBS])
+       CPPFLAGS="$save_CPPFLAGS"
+       LDFLAGS="$save_LDFLAGS"
+      ],
+      [gpunetio_happy=no])
 
-CPPFLAGS="$save_CPPFLAGS"
-LDFLAGS="$save_LDFLAGS"
-
-AS_IF([test x$have_gpunetio = xyes], [
-    uct_ib_mlx5_modules="${uct_ib_mlx5_modules}:gda"
-    AC_SUBST(GPUNETIO_CFLAGS)
-    AC_SUBST(GPUNETIO_LDFLAGS)
-    AC_SUBST(GPUNETIO_LIBS)
-])
-])
+AS_IF([test "x$gpunetio_happy" = "xyes"],
+      [
+       uct_ib_mlx5_modules="${uct_ib_mlx5_modules}:gda"
+       AC_SUBST(GPUNETIO_CFLAGS)
+       AC_SUBST(GPUNETIO_LDFLAGS)
+       AC_SUBST(GPUNETIO_LIBS)
+      ],
+      [
+       # gpunetio was requested but not found
+       AS_IF([test "x$with_doca_gpunetio" != "xno" -a "x$with_doca_gpunetio" != "xguess"],
+             [AC_MSG_ERROR([doca_gpunetio not found])])
+      ])
 
 AM_CONDITIONAL([HAVE_GPUNETIO], [test x$have_gpunetio = xyes])
 AC_CONFIG_FILES([src/uct/ib/mlx5/gdaki/Makefile

--- a/src/uct/ib/mlx5/gdaki/configure.m4
+++ b/src/uct/ib/mlx5/gdaki/configure.m4
@@ -27,11 +27,11 @@ AS_IF([test "x$cuda_happy" = "xyes"],
                     ],
                     [
                      GPUNETIO_CFLAGS="-I${with_doca_gpunetio}/include"
-                     for libdir in lib/x86_64-linux-gnu lib64; do
-                         if test -d "${with_doca_gpunetio}/${libdir}"; then
-                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -L${with_doca_gpunetio}/${libdir} "
+                     for doca_libdir in lib/x86_64-linux-gnu lib64; do
+                         if test -d "${with_doca_gpunetio}/${doca_libdir}"; then
+                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -L${with_doca_gpunetio}/${doca_libdir} "
                              # Add rpath-link to search for doca_gpunetio dependencies
-                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${with_doca_gpunetio}/${libdir}"
+                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${with_doca_gpunetio}/${doca_libdir}"
                          fi
                      done
                      # Add CUDA lib dirs to rpath-link for gpunetio
@@ -49,7 +49,7 @@ AS_IF([test "x$cuda_happy" = "xyes"],
        gpunetio_happy=yes
        AC_CHECK_HEADERS([doca_gpunetio.h], [], [gpunetio_happy=no])
        AC_CHECK_LIB([doca_gpunetio], [doca_gpu_verbs_bridge_export_qp],
-                    [], [gpunetio_happy=no], [$GPUNETIO_LIBS])
+                    [true], [gpunetio_happy=no], [$GPUNETIO_LIBS])
 
        CPPFLAGS="$save_CPPFLAGS"
        LDFLAGS="$save_LDFLAGS"


### PR DESCRIPTION
## What?
Switch GPU tests to use Ubuntu 24.04 DOCA 3.1 image that includes GPUNetIO runtime and headers.
Follow-up to https://github.com/openucx/ucx/pull/10849

## Why?
The previous RHEL 9 image lacked doca-gpunetio and its headers, blocking GPUNetIO-enabled tests.