### PR TITLE
UCT/GDAKI: Fix UCX GPU device API header installation and dependencies

### DIFF
--- a/src/ucp/api/device/ucp_device_impl.h
+++ b/src/ucp/api/device/ucp_device_impl.h
@@ -9,6 +9,7 @@
 
 #include "ucp_device_types.h"
 
+#include <ucp/api/ucp_def.h>
 #include <uct/api/device/uct_device_impl.h>
 #include <ucs/sys/compiler_def.h>
 #include <ucs/type/status.h>

--- a/src/uct/ib/mlx5/gdaki/Makefile.am
+++ b/src/uct/ib/mlx5/gdaki/Makefile.am
@@ -18,10 +18,14 @@ libuct_ib_mlx5_gda_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                                  $(top_builddir)/src/uct/ib/mlx5/libuct_ib_mlx5.la \
                                  $(top_builddir)/src/uct/cuda/libuct_cuda.la \
                                  $(CUDA_LIBS) $(GPUNETIO_LIBS)
-libuct_ib_mlx5_gda_ladir       = $(includedir)/uct/ib_mlx5/gdaki
+libuct_ib_mlx5_gda_ladir       = $(includedir)/uct/ib/mlx5/gdaki
 
 libuct_ib_mlx5_gda_la_SOURCES = \
 	gdaki.c
+
+nobase_dist_libuct_ib_mlx5_gda_la_HEADERS = \
+	gdaki.cuh \
+	gdaki_dev.h
 
 noinst_HEADERS = \
 	gdaki.h


### PR DESCRIPTION
## What?
Fix UCX GPU device API header installation path and missing include dependency.

## Why?
CUDA compilation fails with "uct/ib/mlx5/gdaki/gdaki.cuh: No such file or directory" and "ucp_device_mem_list_handle_h is undefined" errors, preventing GPU device API from working and causing NIXL meson UCX device API detection fail.

## How?
1. Fix GDAKI header installation path from `uct/ib_mlx5/gdaki to uct/ib/mlx5/gdaki` (underscore vs slash)
2. Add missing `gdaki.cuh` and `gdaki_dev.h` to installed headers
3. Add missing `#include <ucp/api/ucp_def.h>` in `ucp_device_impl.h` for typedef definition