### PR TITLE
Run GDA in CI

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -163,8 +163,8 @@ check_nv_peer_mem() {
         return 0
     fi
 
-    if ! lsmod | grep -q nv_peer_mem; then
-        lsmod | grep nv_peer_mem
+    if ! lsmod | grep -q 'nv.*_peer.*mem'; then
+        lsmod | grep 'nv.*_peer.*mem'
         systemctl status nv_peer_mem
         azure_log_error "nv_peer_mem module not loaded on $(hostname -s)"
         exit 1
@@ -180,7 +180,7 @@ try_load_cuda_env() {
     have_gdrcopy=no
 
     # List relevant modules
-    lsmod | grep -P "^(nvidia|nv_peer_mem|gdrdrv)\W" || true
+    lsmod | grep -P "^(nvidia|nv.*_peer.*mem|gdrdrv)\W" || true
 
     # Check nvidia driver
     [ -f "/proc/driver/nvidia/version" ] || return 0

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -193,20 +193,27 @@ try_load_cuda_env() {
     num_gpus=$(get_num_gpus)
     [ "${num_gpus}" -gt 0 ] || return 0
 
-    # Check cuda env module
-    az_module_load dev/cuda12.8 || return 0
-    have_cuda=yes
+    # Prefer local CUDA if available
+    cuda_local_dir="/usr/local/cuda"
+    if find ${cuda_local_dir}/ -name 'libcudart.so.1[2-9]*' | grep -q .; then
+        have_cuda="${cuda_local_dir}"
+    else
+        # Fallback to env module
+        az_module_load dev/cuda12.8 || return 0
+        have_cuda=yes
+    fi
 
     # Check gdrcopy
     if [ -w "/dev/gdrdrv" ]
     then
+        # TODO detect cuda version if using local CUDA
         az_module_load dev/gdrcopy2.4.4_cuda12.8.0 && have_gdrcopy=yes
     fi
 }
 
 load_cuda_env() {
     try_load_cuda_env
-    if [ "${have_cuda}" != "yes" ] ; then
+    if [ "${have_cuda}" == "no" ] ; then
         if [ "${ucx_gpu}" = "yes" ] ; then
             azure_log_error "CUDA load failed on GPU node $(hostname -s)"
             exit 1

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -57,6 +57,9 @@ resources:
     - container: ubuntu2404_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2404_doca31_gpunetio
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu24.04/builder:doca-3.1.0-gpunetio
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
@@ -284,7 +287,7 @@ stages:
         name: gpu
         demands: ucx_gpu -equals yes
         test_perf: 1
-        container: rhel90_doca31
+        container: ubuntu2404_doca31_gpunetio
     - template: tests.yml
       parameters:
         name: new

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -83,9 +83,9 @@ build() {
 	shift
 
 	config_args="--prefix=$ucx_inst --without-java"
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ -n "$have_cuda" ] && [ "X$have_cuda" != "Xno" ]
 	then
-		config_args+=" --with-iodemo-cuda"
+		config_args+=" --with-cuda=$have_cuda --with-iodemo-cuda"
 
 		if has_gpunetio_devel
 		then

--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -83,7 +83,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          CUDART_STATIC_LIBS=""
          NVML_LIBS=""
          CUDA_BIN_PATH=""
-         CUDA_LIB_DIR=""
+         CUDA_LIB_DIRS=""
 
          AS_IF([test ! -z "$with_cuda" -a "x$with_cuda" != "xyes" -a "x$with_cuda" != "xguess"],
                [ucx_check_cuda_dir="$with_cuda"
@@ -92,7 +92,7 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                 CUDA_CPPFLAGS="-I$with_cuda/include"
                 CUDA_LDFLAGS="-L$ucx_check_cuda_libdir -L$ucx_check_cuda_libdir/stubs"
                 CUDA_BIN_PATH="$with_cuda/bin"
-                CUDA_LIB_DIR="$ucx_check_cuda_libdir"])
+                CUDA_LIB_DIRS="$ucx_check_cuda_libdir $with_cuda/compat"])
 
          CPPFLAGS="$CPPFLAGS $CUDA_CPPFLAGS"
          LDFLAGS="$LDFLAGS $CUDA_LDFLAGS"

--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -20,8 +20,11 @@ AC_DEFUN([AC_LANG_COMPILER(CUDA)], [
 
     AC_ARG_VAR([NVCC], [nvcc compiler path])
     AC_ARG_VAR([NVCCFLAGS], [nvcc compiler flags])
-    BASE_NVCCFLAGS="$BASE_NVCCFLAGS $with_nvcc_gencode"
-    AC_CHECK_TOOL([NVCC], [nvcc], [])
+    BASE_NVCCFLAGS="$BASE_NVCCFLAGS -g $with_nvcc_gencode"
+    AS_IF([test ! -z "$with_cuda" -a -d "$with_cuda/bin"],
+          [CUDA_BIN_PATH="$with_cuda/bin"],
+          [CUDA_BIN_PATH=""])
+    AC_PATH_PROG([NVCC], [nvcc], [], [$CUDA_BIN_PATH:$PATH])
     AC_SUBST([NVCC], [$NVCC])
 ])
 
@@ -82,7 +85,6 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          CUDART_LIBS=""
          CUDART_STATIC_LIBS=""
          NVML_LIBS=""
-         CUDA_BIN_PATH=""
          CUDA_LIB_DIRS=""
 
          AS_IF([test ! -z "$with_cuda" -a "x$with_cuda" != "xyes" -a "x$with_cuda" != "xguess"],
@@ -91,7 +93,6 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                 ucx_check_cuda_libdir="$with_cuda/lib$libsuff"
                 CUDA_CPPFLAGS="-I$with_cuda/include"
                 CUDA_LDFLAGS="-L$ucx_check_cuda_libdir -L$ucx_check_cuda_libdir/stubs"
-                CUDA_BIN_PATH="$with_cuda/bin"
                 CUDA_LIB_DIRS="$ucx_check_cuda_libdir $with_cuda/compat"])
 
          CPPFLAGS="$CPPFLAGS $CUDA_CPPFLAGS"

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -260,7 +260,7 @@ run_ucp_hello() {
 
 	mem_types_list="host "
 
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
 		mem_types_list+="cuda cuda-managed "
 	fi
@@ -297,7 +297,7 @@ run_ucp_hello() {
 run_uct_hello() {
 	mem_types_list="host "
 
-	if [ "X$have_cuda" == "Xyes" ] && [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ]
+	if [ "X$have_cuda" != "Xno" ] && [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ]
 	then
 		mem_types_list+="cuda-managed "
 		if [ -f "/sys/kernel/mm/memory_peers/nv_mem/version" ]
@@ -333,7 +333,7 @@ run_client_server() {
 	msg_size_list="1 16 256 4096 65534"
 	api_list="am tag stream"
 
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
 		mem_types_list+=" cuda cuda-managed "
 	fi
@@ -374,7 +374,7 @@ run_io_demo() {
 	server_nonrdma_addr=$(get_non_rdma_ip_addr)
 	mem_types_list="host "
 
-	if [ "X$have_cuda" == "Xyes" ]
+	if [ "X$have_cuda" != "Xno" ]
 	then
 		mem_types_list+="cuda cuda-managed "
 	fi
@@ -496,7 +496,7 @@ run_ucx_perftest() {
 
 	# run cuda tests if cuda module was loaded and GPU is found, and only in
 	# client/server mode, to reduce testing time
-	if [ "X$have_cuda" == "Xyes" ] && [ $with_mpi -ne 1 ]
+	if [ "X$have_cuda" != "Xno" ] && [ $with_mpi -ne 1 ]
 	then
 		gdr_options="n "
 		if (lsmod | grep -q "nv_peer_mem")
@@ -637,7 +637,7 @@ run_ucx_perftest_with_daemon() {
 # Run UCX performance cuda device test
 #
 run_ucx_perftest_cuda_device() {
-	if [ "X$have_cuda" != "Xyes" ]; then
+	if [ "X$have_cuda" == "Xno" ]; then
 		echo "==== CUDA not available, skipping CUDA device tests ===="
 		return 0
 	fi
@@ -724,7 +724,7 @@ run_mpi_tests() {
 
 			test_malloc_hooks_mpi
 
-			if [ "X$have_cuda" == "Xyes" ] && [ -x ./test/mpi/test_mpi_cuda ]
+			if [ "X$have_cuda" != "Xno" ] && [ -x ./test/mpi/test_mpi_cuda ]
 			then
 				echo "==== Running MPI CUDA tests ===="
 				${MPIRUN_COMMON} -np 2 ./test/mpi/test_mpi_cuda
@@ -927,7 +927,7 @@ test_malloc_hook() {
 
 test_no_cuda_context() {
 	echo "==== Running no CUDA context test ===="
-	if [ "X$have_cuda" == "Xyes" ] && [ -x ./test/apps/test_no_cuda_ctx ]
+	if [ "X$have_cuda" != "Xno" ] && [ -x ./test/apps/test_no_cuda_ctx ]
 	then
 		./test/apps/test_no_cuda_ctx
 	fi

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -499,9 +499,9 @@ run_ucx_perftest() {
 	if [ "X$have_cuda" != "Xno" ] && [ $with_mpi -ne 1 ]
 	then
 		gdr_options="n "
-		if (lsmod | grep -q "nv_peer_mem")
+		if (lsmod | grep -q 'nv.*_peer.*mem')
 		then
-			echo "GPUDirectRDMA module (nv_peer_mem) is present.."
+			echo "GPUDirectRDMA module (nv_peer_mem/nvidia_peermem) is present"
 			gdr_options+="y "
 		fi
 

--- a/src/tools/perf/cuda/cuda_kernel.cuh
+++ b/src/tools/perf/cuda/cuda_kernel.cuh
@@ -47,13 +47,9 @@ ucx_perf_cuda_update_report(ucx_perf_cuda_context &ctx,
     }
 }
 
-template <typename Base>
-class ucx_perf_cuda_test_runner: public Base {
+class ucx_perf_cuda_test_runner {
 public:
-    using psn_t = uint64_t;
-    using Base::m_perf;
-
-    ucx_perf_cuda_test_runner(ucx_perf_context_t &perf) : Base(perf)
+    ucx_perf_cuda_test_runner(ucx_perf_context_t &perf) : m_perf(perf)
     {
         ucs_status_t status = init_ctx();
         if (status != UCS_OK) {
@@ -62,12 +58,15 @@ public:
         }
 
         m_cpu_ctx->max_outstanding    = perf.params.max_outstanding;
-        m_cpu_ctx->max_iters          = perf.params.max_iter;
-        m_cpu_ctx->report_interval_ns = perf.params.report_interval *
-                                        UCS_NSEC_PER_SEC;
+        m_cpu_ctx->max_iters          = perf.max_iter;
         m_cpu_ctx->completed_iters    = 0;
-
-        m_poll_interval               = perf.params.report_interval / 10000;
+        if (perf.report_interval == ULONG_MAX) {
+            m_cpu_ctx->report_interval_ns = ULONG_MAX;
+        } else {
+            m_cpu_ctx->report_interval_ns = ucs_time_to_nsec(
+                                                    perf.report_interval) /
+                                            100;
+        }
     }
 
     ~ucx_perf_cuda_test_runner()
@@ -77,54 +76,26 @@ public:
 
     ucx_perf_cuda_context &gpu_ctx() const { return *m_gpu_ctx; }
 
-    UCS_F_ALWAYS_INLINE psn_t get_sn(const psn_t *gpu_ptr, const psn_t *cpu_ptr)
+    void wait_for_kernel(size_t msg_length)
     {
-        if (cpu_ptr != nullptr) {
-            return *cpu_ptr;
-        }
-
-        unsigned my_index          = rte_call(&m_perf, group_index);
-        ucs_memory_type_t mem_type = my_index ? m_perf.params.send_mem_type :
-                                                m_perf.params.recv_mem_type;
-        auto allocator             = my_index ? m_perf.send_allocator :
-                                                m_perf.recv_allocator;
-        return Base::get_sn(gpu_ptr, mem_type, allocator);
-    }
-
-    psn_t wait_sn_geq(const psn_t *gpu_ptr, const psn_t *cpu_ptr, psn_t value)
-    {
-        psn_t sn = get_sn(gpu_ptr, cpu_ptr);
-        if (sn >= value) {
-            return sn;
-        }
-
-        // TODO: use cuStreamWaitValue64 if available
-        usleep(m_poll_interval);
-        return get_sn(gpu_ptr, cpu_ptr);
-    }
-
-    void wait_for_kernel(size_t length)
-    {
-        psn_t last_completed = 0;
-        while (last_completed < m_perf.params.max_iter) {
-            psn_t completed = wait_sn_geq(&m_gpu_ctx->completed_iters,
-                                          &m_cpu_ctx->completed_iters,
-                                          last_completed);
-            psn_t delta     = completed - last_completed;
+        ucx_perf_counter_t last_completed = 0;
+        ucx_perf_counter_t completed      = m_cpu_ctx->completed_iters;
+        while (1) {
+            ucx_perf_counter_t delta = completed - last_completed;
             if (delta > 0) {
                 // TODO: calculate latency percentile on kernel
-                ucx_perf_update_multi(&m_perf, delta, delta * length);
+                ucx_perf_update(&m_perf, delta, msg_length);
+            } else if (completed >= m_perf.max_iter) {
+                break;
             }
             last_completed = completed;
+            completed      = m_cpu_ctx->completed_iters;
+            usleep(100);
         }
     }
 
-    void wait_for_sn(size_t length)
-    {
-        const psn_t *ptr = Base::sn_ptr(m_perf.recv_buffer, length);
-        while (wait_sn_geq(ptr, nullptr, m_perf.params.max_iter)
-               < m_perf.params.max_iter);
-    }
+protected:
+    ucx_perf_context_t &m_perf;
 
 private:
     ucs_status_t init_ctx()
@@ -150,7 +121,6 @@ private:
 
     ucx_perf_cuda_context *m_cpu_ctx;
     ucx_perf_cuda_context *m_gpu_ctx;
-    double                m_poll_interval;
 };
 
 

--- a/src/tools/perf/cuda/ucp_cuda_kernel.cu
+++ b/src/tools/perf/cuda/ucp_cuda_kernel.cu
@@ -23,7 +23,7 @@ ucp_perf_cuda_put_multi_bw_kernel(ucx_perf_cuda_context &ctx)
 
     for (ucx_perf_counter_t idx = 0; idx < max_iters; idx++) {
         // TODO: replace with actual put multi call
-        __nanosleep(1000000); // 1ms
+        __nanosleep(100000); // 100us
 
         ucx_perf_cuda_update_report(ctx, idx + 1, max_iters, last_report_time);
         __syncthreads();
@@ -40,23 +40,19 @@ ucp_perf_cuda_put_multi_latency_kernel(ucx_perf_cuda_context &ctx, bool is_sende
     for (ucx_perf_counter_t idx = 0; idx < max_iters; idx++) {
         // TODO: replace with actual put multi call
         // TODO: wait for completion
-        __nanosleep(1000000); // 1ms
+        __nanosleep(100000); // 100us
 
         ucx_perf_cuda_update_report(ctx, idx + 1, max_iters, last_report_time);
         __syncthreads();
     }
 }
 
-class ucp_perf_cuda_test_runner:
-    public ucx_perf_cuda_test_runner<ucp_perf_test_runner_base<uint64_t>> {
+class ucp_perf_cuda_test_runner : public ucx_perf_cuda_test_runner {
 public:
-    using psn_t = uint64_t;
-
     ucp_perf_cuda_test_runner(ucx_perf_context_t &perf) :
-        ucx_perf_cuda_test_runner<ucp_perf_test_runner_base<uint64_t>>(perf)
+        ucx_perf_cuda_test_runner(perf)
     {
         size_t length = ucx_perf_get_message_size(&m_perf.params);
-        ucs_assert(length >= sizeof(psn_t));
 
         m_perf.send_allocator->memset(m_perf.send_buffer, 0, length);
         m_perf.recv_allocator->memset(m_perf.recv_buffer, 0, length);
@@ -74,8 +70,9 @@ public:
         ucp_perf_cuda_put_multi_latency_kernel
             <UCP_DEVICE_LEVEL_BLOCK><<<1, thread_count>>>(gpu_ctx(), my_index);
         CUDA_CALL(UCS_ERR_NO_DEVICE, cudaGetLastError);
-
         wait_for_kernel(length);
+
+        CUDA_CALL(UCS_ERR_IO_ERROR, cudaDeviceSynchronize);
         ucx_perf_get_time(&m_perf);
         ucp_perf_barrier(&m_perf);
         return UCS_OK;
@@ -94,35 +91,14 @@ public:
             ucp_perf_cuda_put_multi_bw_kernel<UCP_DEVICE_LEVEL_BLOCK>
                                              <<<1, thread_count>>>(gpu_ctx());
             CUDA_CALL(UCS_ERR_NO_DEVICE, cudaGetLastError);
-
             wait_for_kernel(length);
-
-            // TODO: remove once real GDAKI is used
-            send_signal(length);
-        } else if (my_index == 0) {
-            wait_for_sn(length);
         }
+        // TODO run receiver kernel
 
+        CUDA_CALL(UCS_ERR_IO_ERROR, cudaDeviceSynchronize);
         ucx_perf_get_time(&m_perf);
         ucp_perf_barrier(&m_perf);
         return UCS_OK;
-    }
-
-private:
-    // TODO: remove once real GDAKI is used
-    void send_signal(size_t length)
-    {
-        ucs_memory_type_t mem_type = m_perf.params.send_mem_type;
-        write_sn(m_perf.send_buffer, mem_type, length, m_perf.params.max_iter,
-                 m_perf.ucp.self_send_rkey);
-
-        ucs_status_ptr_t request;
-        ucp_request_param_t param = {0};
-        request = ucp_put_nbx(m_perf.ucp.ep, m_perf.send_buffer, length,
-                              m_perf.ucp.remote_addr, m_perf.ucp.rkey, &param);
-        request_wait(request, mem_type, "write_sn");
-        request = ucp_ep_flush_nbx(m_perf.ucp.self_ep, &param);
-        request_wait(request, mem_type, "flush write_sn");
     }
 };
 

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -637,6 +637,12 @@ ucs_status_t adjust_test_params(perftest_params_t *params,
         params->super.max_outstanding = test->window_size;
     }
 
+    if (params->super.send_device.mem_type != UCS_MEMORY_TYPE_LAST) {
+        /* TODO: Add getter function for thread count */
+        params->super.device_thread_count = params->super.thread_count;
+        params->super.thread_count        = 1;
+    }
+
     return UCS_OK;
 }
 
@@ -845,12 +851,6 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
             status = UCS_ERR_INVALID_PARAM;
             goto err;
         }
-    }
-
-    if (ctx->params.super.send_device.mem_type != UCS_MEMORY_TYPE_LAST) {
-        /* TODO: Add getter function for thread count */
-        ctx->params.super.device_thread_count = ctx->params.super.thread_count;
-        ctx->params.super.thread_count        = 1;
     }
 
     return init_daemon_params(&ctx->params.super);

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -45,6 +45,13 @@ typedef struct ucs_sys_bus_id {
 typedef uint8_t ucs_sys_device_t;
 
 
+/**
+ * @ingroup UCS_RESOURCE
+ * Global state of the topology subsystem.
+ */
+typedef struct ucs_global_state ucs_global_state_t;
+
+
 /*
  * Captures the estimated latency and bandwidth between two system devices
  * referred by ucs_sys_device_t handle.
@@ -321,6 +328,23 @@ unsigned ucs_topo_num_devices(void);
  * discovered.
  */
 void ucs_topo_print_info(FILE *stream);
+
+
+/**
+ * Extract the state of the topology subsystem and clear the global context.
+ *
+ * @return A pointer to the saved state of the topology subsystem.
+ */
+ucs_global_state_t *ucs_topo_extract_state(void);
+
+
+/**
+ * Restore the state of the topology subsystem, overriding the current global
+ * context.
+ *
+ * @param [in] state A pointer to the saved state of the topology subsystem.
+ */
+void ucs_topo_restore_state(ucs_global_state_t *state);
 
 
 /**

--- a/src/uct/ib/mlx5/gdaki/configure.m4
+++ b/src/uct/ib/mlx5/gdaki/configure.m4
@@ -9,57 +9,66 @@ AC_ARG_WITH([doca-gpunetio],
             [with_doca_gpunetio=$withval],
             [with_doca_gpunetio=guess])
 
-AS_IF([test "x$cuda_happy" = "xyes"], [
 
-# Default value
-GPUNETIO_CFLAGS=""
-GPUNETIO_LDFLAGS=""
-GPUNETIO_LIBS="-ldoca_gpunetio"
+AS_IF([test "x$cuda_happy" = "xyes"],
+      [
+       # Default value
+       GPUNETIO_CFLAGS=""
+       GPUNETIO_LDFLAGS=""
+       GPUNETIO_LIBS="-ldoca_gpunetio"
+       AS_IF([test "x$with_doca_gpunetio" != "xno"],
+             [
+              AS_IF([test "x$with_doca_gpunetio" = "xguess"],
+                    [
+                     AS_IF([$PKG_CONFIG --exists doca-gpunetio],
+                           [GPUNETIO_CFLAGS=$(pkg-config --cflags doca-gpunetio)
+                            GPUNETIO_LDFLAGS=$(pkg-config --libs-only-L doca-gpunetio)
+                            GPUNETIO_LIBS=$(pkg-config --libs-only-l doca-gpunetio)])
+                    ],
+                    [
+                     GPUNETIO_CFLAGS="-I${with_doca_gpunetio}/include"
+                     for doca_libdir in lib/x86_64-linux-gnu lib64; do
+                         if test -d "${with_doca_gpunetio}/${doca_libdir}"; then
+                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -L${with_doca_gpunetio}/${doca_libdir} "
+                             # Add rpath-link to search for doca_gpunetio dependencies
+                             GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${with_doca_gpunetio}/${doca_libdir}"
+                         fi
+                     done
+                     # Add CUDA lib dirs to rpath-link for gpunetio
+                     for cuda_libdir in $CUDA_LIB_DIRS; do
+                         GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${cuda_libdir}"
+                     done
+                    ]) # "x$with_doca_gpunetio" != "xguess"
+             ]) # "x$with_doca_gpunetio" != "xno"
 
-AS_IF([test x$with_doca_gpunetio != xno], [
-  AS_IF([test x$with_doca_gpunetio = xguess],
-    [
-      AS_IF([$PKG_CONFIG --exists doca-gpunetio],
-            [
-              # Guess from pkg-config
-              GPUNETIO_CFLAGS=$(pkg-config --cflags doca-gpunetio)
-              GPUNETIO_LDFLAGS=$(pkg-config --libs-only-L doca-gpunetio)
-              GPUNETIO_LIBS=$(pkg-config --libs-only-l doca-gpunetio)
-            ])
-    ],
-    [
-      # User provided path
-      GPUNETIO_CFLAGS="-I${with_doca_gpunetio}/include"
-      for dir in lib lib64 lib/x86_64-linux-gnu; do
-        if test -d "${with_doca_gpunetio}/${dir}"; then
-          GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -L${with_doca_gpunetio}/${dir} "
-          # Add rpath-link to search for doca_gpunetio dependencies
-          GPUNETIO_LDFLAGS="$GPUNETIO_LDFLAGS -Wl,-rpath-link,${with_doca_gpunetio}/${dir}"
-        fi
-      done
-    ])
-])
+       save_CPPFLAGS="$CPPFLAGS"
+       save_LDFLAGS="$LDFLAGS"
+       CPPFLAGS="$CPPFLAGS $CUDA_CFLAGS $GPUNETIO_CFLAGS"
+       LDFLAGS="$LDFLAGS $CUDA_LDFLAGS $GPUNETIO_LDFLAGS"
 
-save_CPPFLAGS="$CPPFLAGS"
-save_LDFLAGS="$LDFLAGS"
-CPPFLAGS="$CPPFLAGS $CUDA_CFLAGS $GPUNETIO_CFLAGS"
-LDFLAGS="$LDFLAGS $CUDA_LDFLAGS $GPUNETIO_LDFLAGS -Wl,-rpath-link,$CUDA_LIB_DIR"
+       gpunetio_happy=yes
+       AC_CHECK_HEADERS([doca_gpunetio.h], [], [gpunetio_happy=no])
+       AC_CHECK_LIB([doca_gpunetio], [doca_gpu_verbs_bridge_export_qp],
+                    [true], [gpunetio_happy=no], [$GPUNETIO_LIBS])
 
-AC_CHECK_HEADERS([doca_gpunetio.h], [have_gpunetio=yes], [have_gpunetio=no])
-AC_CHECK_LIB([doca_gpunetio], [doca_gpu_verbs_bridge_export_qp],
-             [true], [have_gpunetio=no], [$GPUNETIO_LIBS])
+       CPPFLAGS="$save_CPPFLAGS"
+       LDFLAGS="$save_LDFLAGS"
+      ],
+      [gpunetio_happy=no])
 
-CPPFLAGS="$save_CPPFLAGS"
-LDFLAGS="$save_LDFLAGS"
+AS_IF([test "x$gpunetio_happy" = "xyes"],
+      [
+       uct_ib_mlx5_modules="${uct_ib_mlx5_modules}:gda"
+       AC_SUBST(GPUNETIO_CFLAGS)
+       AC_SUBST(GPUNETIO_LDFLAGS)
+       AC_SUBST(GPUNETIO_LIBS)
+      ],
+      [
+       # gpunetio was requested but not found
+       AS_IF([test "x$with_doca_gpunetio" != "xno" -a "x$with_doca_gpunetio" != "xguess"],
+             [AC_MSG_ERROR([doca_gpunetio not found])])
+      ])
 
-AS_IF([test x$have_gpunetio = xyes], [
-    uct_ib_mlx5_modules="${uct_ib_mlx5_modules}:gda"
-    AC_SUBST(GPUNETIO_CFLAGS)
-    AC_SUBST(GPUNETIO_LDFLAGS)
-    AC_SUBST(GPUNETIO_LIBS)
-])
-])
-
-AM_CONDITIONAL([HAVE_GPUNETIO], [test x$have_gpunetio = xyes])
+AM_CONDITIONAL([HAVE_GPUNETIO], [test x$gpunetio_happy = xyes])
 AC_CONFIG_FILES([src/uct/ib/mlx5/gdaki/Makefile
                  src/uct/ib/mlx5/gdaki/ucx-ib-mlx5-gda.pc])

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -634,21 +634,15 @@ static void uct_ib_doca_init(void)
     struct doca_log_backend *sdk_log;
     doca_error_t derr;
 
-    derr = doca_log_backend_create_standard();
+    derr = doca_log_level_set_global_sdk_limit(DOCA_LOG_LEVEL_WARNING);
     if (derr != DOCA_SUCCESS) {
-        ucs_error("doca_log_backend_create_standard failed: %d\n", derr);
+        ucs_error("doca_log_level_set_global_sdk_limit failed: %d\n", derr);
         return;
     }
 
     derr = doca_log_backend_create_with_file_sdk(stderr, &sdk_log);
     if (derr != DOCA_SUCCESS) {
         ucs_error("doca_log_backend_create_with_file_sdk failed: %d\n", derr);
-        return;
-    }
-
-    derr = doca_log_backend_set_sdk_level(sdk_log, DOCA_LOG_LEVEL_ERROR);
-    if (derr != DOCA_SUCCESS) {
-        ucs_error("doca_log_backend_set_sdk_level failed: %d\n", derr);
         return;
     }
 }

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -569,9 +569,8 @@ int uct_ib_mlx5_devx_uar_cmp(uct_ib_mlx5_devx_uar_t *uar,
 }
 
 #if HAVE_DEVX
-static ucs_status_t uct_ib_mlx5_devx_alloc_uar(uct_ib_mlx5_md_t *md,
-                                               uint32_t flags,
-                                               struct mlx5dv_devx_uar **uar_p)
+ucs_status_t uct_ib_mlx5_devx_alloc_uar(uct_ib_mlx5_md_t *md, uint32_t flags,
+                                        struct mlx5dv_devx_uar **uar_p)
 {
     const char *uar_type_str      = (flags == UCT_IB_MLX5_UAR_ALLOC_TYPE_WC) ?
                                     "WC" : "NC_DEDICATED";

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -441,7 +441,7 @@ typedef struct uct_ib_mlx5_md {
     uint8_t                  log_max_dci_stream_channels;
     uint32_t                 smkey_index;
     struct {
-        /* Max dp ordering level per transport, 
+        /* Max dp ordering level per transport,
            as listed in uct_ib_mlx5_dp_ordering_t */
         uint8_t              rc;
         uint8_t              dc;
@@ -931,9 +931,11 @@ void uct_ib_mlx5_verbs_srq_cleanup(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs
 /**
  * DEVX UAR API
  */
-int uct_ib_mlx5_devx_uar_cmp(uct_ib_mlx5_devx_uar_t *uar,
-                             uct_ib_mlx5_md_t *md,
+int uct_ib_mlx5_devx_uar_cmp(uct_ib_mlx5_devx_uar_t *uar, uct_ib_mlx5_md_t *md,
                              uct_ib_mlx5_mmio_mode_t mmio_mode);
+
+ucs_status_t uct_ib_mlx5_devx_alloc_uar(uct_ib_mlx5_md_t *md, uint32_t flags,
+                                        struct mlx5dv_devx_uar **uar_p);
 
 ucs_status_t uct_ib_mlx5_devx_check_uar(uct_ib_mlx5_md_t *md);
 

--- a/test/gtest/ucp/test_ucp_device.cc
+++ b/test/gtest/ucp/test_ucp_device.cc
@@ -189,4 +189,4 @@ UCS_TEST_P(test_ucp_device, create_fail)
               ucp_device_mem_list_create(sender().ep(), &params1, &handle));
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device, gdaki, "rc,rc_gda")
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device, rc_gda, "rc,rc_gda")

--- a/test/gtest/ucp/test_ucp_device.cc
+++ b/test/gtest/ucp/test_ucp_device.cc
@@ -124,7 +124,6 @@ UCS_TEST_P(test_ucp_device, mapped_buffer_kernel_memcmp)
 
 UCS_TEST_P(test_ucp_device, create_success)
 {
-    scoped_log_handler wrap_err(wrap_errors_logger);
     mem_list list(sender(), receiver());
     ucp_device_mem_list_handle_h handle = nullptr;
 
@@ -171,6 +170,8 @@ UCS_TEST_P(test_ucp_device, create_fail)
 {
     ucp_device_mem_list_handle_h handle       = nullptr;
     ucp_device_mem_list_params_t empty_params = {};
+
+    scoped_log_handler wrap_err(wrap_errors_logger);
 
     ASSERT_EQ(UCS_ERR_INVALID_PARAM,
               ucp_device_mem_list_create(sender().ep(), NULL, &handle));

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -25,6 +25,7 @@ static std::string get_sysfs_device_path(const std::string &bdf)
 class test_topo : public ucs::test {
 protected:
     std::vector<std::string> m_hcas, m_gpus, m_dmas;
+    ucs_global_state_t *m_topo_state;
 
     ucs_sys_device_t
     register_device(const std::string &name, const std::string &bdf)
@@ -75,14 +76,12 @@ public:
     virtual void init()
     {
         ucs::test::init();
-        ucs_topo_cleanup();
-        ucs_topo_init();
+        m_topo_state = ucs_topo_extract_state();
     }
 
     virtual void cleanup()
     {
-        ucs_topo_cleanup();
-        ucs_topo_init();
+        ucs_topo_restore_state(m_topo_state);
         ucs::test::cleanup();
     }
 };
@@ -149,7 +148,11 @@ UCS_TEST_F(test_topo, get_distance) {
 }
 
 UCS_TEST_F(test_topo, print_info) {
+    // Restore the state to print the info
+    ucs_topo_restore_state(m_topo_state);
     ucs_topo_print_info(stdout);
+    // Extract the state again
+    m_topo_state = ucs_topo_extract_state();
 }
 
 UCS_TEST_F(test_topo, bdf_name) {

--- a/test/gtest/uct/cuda/test_switch_cuda_device.cc
+++ b/test/gtest/uct/cuda/test_switch_cuda_device.cc
@@ -288,6 +288,9 @@ protected:
     void init() override {
         test_switch_cuda_device::init();
 
+        int current_device;
+        ASSERT_EQ(cudaGetDevice(&current_device), cudaSuccess);
+
         for (auto device = 0; device < m_num_devices; ++device) {
             uct_md_mem_attr_t attr       = {
                 .field_mask = UCT_MD_MEM_ATTR_FIELD_SYS_DEV
@@ -304,6 +307,8 @@ protected:
                              << static_cast<int>(attr.sys_dev);
             m_sys_dev.push_back(attr.sys_dev);
         }
+
+        EXPECT_EQ(cudaSetDevice(current_device), cudaSuccess);
 
         ASSERT_EQ(m_num_devices, m_sys_dev.size());
     }
@@ -349,6 +354,9 @@ protected:
     {
         CUdevice current;
 
+        int current_device;
+        ASSERT_EQ(cudaGetDevice(&current_device), cudaSuccess);
+
         // Ensure a valid context for each device
         for (auto device = 0; device < m_num_devices; ++device) {
             ASSERT_EQ(cudaSetDevice(device), cudaSuccess);
@@ -365,11 +373,16 @@ protected:
             EXPECT_EQ(m_num_devices - 1, current);
             ASSERT_UCS_OK(uct_mem_free(&mem));
         }
+
+        EXPECT_EQ(cudaSetDevice(current_device), cudaSuccess);
     }
 
     void test_same_device_alloc(ucs_memory_type_t mem_type,
                                 bool set_sys_dev = true)
     {
+        int current_device;
+        ASSERT_EQ(cudaGetDevice(&current_device), cudaSuccess);
+
         for (auto device = 0; device < m_num_devices; ++device) {
             ASSERT_EQ(cudaSetDevice(device), cudaSuccess);
             ASSERT_UCS_OK(allocate(mem_type,
@@ -379,6 +392,8 @@ protected:
             EXPECT_EQ(m_sys_dev[device], sys_device);
             ASSERT_UCS_OK(uct_mem_free(&mem));
         }
+
+        EXPECT_EQ(cudaSetDevice(current_device), cudaSuccess);
     }
 
     void skip_if_no_fabric(ucs_memory_type_t mem_type)
@@ -526,7 +541,7 @@ public:
         rkey_release(sender(), rkey_dest);
 
         // Set back an original device to avoid test failures
-        ASSERT_EQ(cudaGetDevice(&current_device), cudaSuccess);
+        EXPECT_EQ(cudaSetDevice(current_device), cudaSuccess);
     }
 
     template<typename mem_alloc_t1, typename mem_alloc_t2>

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -28,20 +28,15 @@ protected:
         uct_test::init();
         status = uct_cuda_base_get_cuda_device(GetParam()->sys_device,
                                                &m_cuda_dev);
-        if (status != UCS_OK) {
-            return;
-        }
+        ASSERT_UCS_OK(status, << " sys_device "
+                              << static_cast<int>(GetParam()->sys_device));
 
         status = UCT_CUDADRV_FUNC_LOG_ERR(
                 cuDevicePrimaryCtxRetain(&ctx, m_cuda_dev));
-        if (status != UCS_OK) {
-            return;
-        }
+        ASSERT_UCS_OK(status);
 
         status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(ctx));
-        if (status != UCS_OK) {
-            return;
-        }
+        ASSERT_UCS_OK(status);
 
         m_receiver = uct_test::create_entity(0);
         m_entities.push_back(m_receiver);


### PR DESCRIPTION
CI:
- Cherry picked changes from #10861 / #10865
- Build UCX with local cuda in CI and fix NVCC search
- Detect nvidia_peermem module for GPU-direct - since it's needed for new drivers

Build:
- Fail if building with gpunetio but it cannot be found
- Add rpath-link of cuda compat libs to GPUNETIO_LDFLAGS
- Fix NVCC search path when using local cuda installation

Code/test:
- Don't print DOCA version since it messes up some test scripts that expect specific output
- Check if UAR is supported for better handing of systems without peer mapping override configuration
- Fix hang in cuda kernel perftest - related to results reporting mechanism. PSN copy logic is not needed for Cuda kernel tests since the kernel can read GPU memory directly, and no need to read PSN on the host side.
- Fix topo test - it changed the global system devices, which messed up UCT tests that rely on valid value in GetParam()->sys_device created during global initialization.
- Fix Cuda test to restore original cuda device - otherwise GDA tests failed when using GPU1 and could not select lanes.


