### PR TITLE
UCM/CUDA: Added hook for cuLibraryGetGlobal.

### DIFF
--- a/src/ucm/cuda/cudamem.h
+++ b/src/ucm/cuda/cudamem.h
@@ -30,6 +30,10 @@ CUresult ucm_cuMemAllocAsync(CUdeviceptr *dptr, size_t size, CUstream hStream);
 CUresult ucm_cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t size,
                                      CUmemoryPool pool, CUstream hStream);
 #endif
+#if CUDART_VERSION >= 12000
+CUresult ucm_cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes,
+                                CUlibrary library, const char *name);
+#endif
 CUresult ucm_cuMemFree(CUdeviceptr dptr);
 CUresult ucm_cuMemFree_v2(CUdeviceptr dptr);
 CUresult ucm_cuMemFreeHost(void *p);


### PR DESCRIPTION
## What?
Added hook for `cuLibraryGetGlobal`.

## Why?
`cudaGetSymbolAddress` leads to `cuLibraryGetGlobal` in CUDA RT 13. It was `cuModuleGetGlobal` before.
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=107122&view=logs&j=6f19b6b7-d713-51f9-34ca-64a8f00f7407&t=6d7bb64e-bfad-52af-9e32-fec3c0a4ba72&l=1669