### PR TITLE
UCP/PROTO: Added option to use single network device.

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -125,7 +125,8 @@ enum ucp_params_field {
     UCP_PARAM_FIELD_MT_WORKERS_SHARED = UCS_BIT(5), /**< mt_workers_shared */
     UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6), /**< estimated_num_eps */
     UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7), /**< estimated_num_ppn */
-    UCP_PARAM_FIELD_NAME              = UCS_BIT(8)  /**< name */
+    UCP_PARAM_FIELD_NAME              = UCS_BIT(8),  /**< name */
+    UCP_PARAM_FIELD_NODE_LOCAL_ID     = UCS_BIT(9)   /**< node_local_id */
 };
 
 
@@ -1144,6 +1145,16 @@ typedef struct ucp_params {
      * unique name will be created for you.
      */
     const char                         *name;
+
+    /**
+     * An optimization hint for a single node. For example, when used from MPI or
+     * OpenSHMEM libraries, this number will specify the local identificator on
+     * a single node in the job. Does not affect semantics, only transport
+     * selection criteria and the resulting performance.
+     * The value can be also set by the UCX_NODE_ID environment variable, which
+     * will override the number of endpoints set by @e node_local_id
+     */
+    size_t                             node_local_id;
 } ucp_params_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -125,7 +125,7 @@ enum ucp_params_field {
     UCP_PARAM_FIELD_MT_WORKERS_SHARED = UCS_BIT(5), /**< mt_workers_shared */
     UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6), /**< estimated_num_eps */
     UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7), /**< estimated_num_ppn */
-    UCP_PARAM_FIELD_NAME              = UCS_BIT(8),  /**< name */
+    UCP_PARAM_FIELD_NAME              = UCS_BIT(8), /**< name */
     UCP_PARAM_FIELD_NODE_LOCAL_ID     = UCS_BIT(9)
 };
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -126,7 +126,7 @@ enum ucp_params_field {
     UCP_PARAM_FIELD_ESTIMATED_NUM_EPS = UCS_BIT(6), /**< estimated_num_eps */
     UCP_PARAM_FIELD_ESTIMATED_NUM_PPN = UCS_BIT(7), /**< estimated_num_ppn */
     UCP_PARAM_FIELD_NAME              = UCS_BIT(8),  /**< name */
-    UCP_PARAM_FIELD_NODE_LOCAL_ID     = UCS_BIT(9)   /**< node_local_id */
+    UCP_PARAM_FIELD_NODE_LOCAL_ID     = UCS_BIT(9)
 };
 
 
@@ -1151,8 +1151,8 @@ typedef struct ucp_params {
      * OpenSHMEM libraries, this number will specify the local identificator on
      * a single node in the job. Does not affect semantics, only transport
      * selection criteria and the resulting performance.
-     * The value can be also set by the UCX_NODE_ID environment variable, which
-     * will override the number of endpoints set by @e node_local_id
+     * The value can be also set by the UCX_LOCAL_NODE_ID environment variable,
+     * which will override the id set by @e node_local_id
      */
     size_t                             node_local_id;
 } ucp_params_t;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -581,11 +581,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, proto_use_single_net_device),
    UCS_CONFIG_TYPE_BOOL},
 
-   {"NODE_LOCAL_ID", "auto",
-    "An optimization hint for the local identificator on a single node. Does \n"
-    "not affect semantics, only transport selection criteria and the \n"
-    "resulting performance.",
-    ucs_offsetof(ucp_context_config_t, node_local_id), UCS_CONFIG_TYPE_ULUNITS},
+  {"NODE_LOCAL_ID", "auto",
+   "An optimization hint for the local identificator on a single node. Does \n"
+   "not affect semantics, only transport selection criteria and the \n"
+   "resulting performance.",
+   ucs_offsetof(ucp_context_config_t, node_local_id), UCS_CONFIG_TYPE_ULUNITS},
 
   {NULL}
 };
@@ -2009,8 +2009,7 @@ static void ucp_apply_params(ucp_context_h context, const ucp_params_t *params,
                                                         estimated_num_ppn,
                                                         ESTIMATED_NUM_PPN, 1);
 
-    context->config.node_local_id = UCP_PARAM_FIELD_VALUE(params,
-                                                          node_local_id,
+    context->config.node_local_id = UCP_PARAM_FIELD_VALUE(params, node_local_id,
                                                           NODE_LOCAL_ID, 0);
 
     if ((params->field_mask & UCP_PARAM_FIELD_MT_WORKERS_SHARED) &&

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -577,6 +577,17 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, connect_all_to_all),
    UCS_CONFIG_TYPE_BOOL},
 
+  {"PROTO_USE_SINGLE_NET_DEVICE", "n",
+   "Use only one network device for all protocols.",
+   ucs_offsetof(ucp_context_config_t, proto_use_single_net_device),
+   UCS_CONFIG_TYPE_BOOL},
+
+   {"LOCAL_RANK", "0",
+    "An optimization hint for the relative rank on a single node. Does not \n"
+    "affect semantics, only transport selection criteria and the resulting \n"
+    "performance.",
+    ucs_offsetof(ucp_context_config_t, local_rank), UCS_CONFIG_TYPE_UINT},
+
   {NULL}
 };
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -577,8 +577,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, connect_all_to_all),
    UCS_CONFIG_TYPE_BOOL},
 
-  {"PROTO_USE_SINGLE_NET_DEVICE", "n",
-   "Use only one network device for all protocols.",
+  {"SINGLE_NET_DEVICE", "n", "Use only one network device for all protocols.",
    ucs_offsetof(ucp_context_config_t, proto_use_single_net_device),
    UCS_CONFIG_TYPE_BOOL},
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -582,11 +582,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, proto_use_single_net_device),
    UCS_CONFIG_TYPE_BOOL},
 
-   {"LOCAL_RANK", "0",
-    "An optimization hint for the relative rank on a single node. Does not \n"
-    "affect semantics, only transport selection criteria and the resulting \n"
-    "performance.",
-    ucs_offsetof(ucp_context_config_t, local_rank), UCS_CONFIG_TYPE_UINT},
+   {"NODE_LOCAL_ID", "0",
+    "An optimization hint for the local identificator on a single node. Does \n"
+    "not affect semantics, only transport selection criteria and the \n"
+    "resulting performance.",
+    ucs_offsetof(ucp_context_config_t, node_local_id), UCS_CONFIG_TYPE_UINT},
 
   {NULL}
 };

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -217,8 +217,8 @@ typedef struct ucp_context_config {
     int                                    connect_all_to_all;
     /** Use only one network device for all protocols */
     int                                    proto_use_single_net_device;
-    /** Relative rank on a single node */
-    unsigned                               local_rank;
+    /** Local identificator on a single node */
+    unsigned                               node_local_id;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -215,6 +215,10 @@ typedef struct ucp_context_config {
     /** Extend endpoint lanes connections of each local device to all remote
      *  devices */
     int                                    connect_all_to_all;
+    /** Use only one network device for all protocols */
+    int                                    proto_use_single_net_device;
+    /** Relative rank on a single node */
+    unsigned                               local_rank;
 } ucp_context_config_t;
 
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -218,7 +218,7 @@ typedef struct ucp_context_config {
     /** Use only one network device for all protocols */
     int                                    proto_use_single_net_device;
     /** Local identificator on a single node */
-    unsigned                               node_local_id;
+    unsigned long                          node_local_id;
 } ucp_context_config_t;
 
 
@@ -418,6 +418,9 @@ typedef struct ucp_context {
 
         /* How many endpoints are expected to be created on single node */
         int                       est_num_ppn;
+
+        /* Local identificator on a single node */
+        unsigned long             node_local_id;
 
         struct {
             size_t                         size;    /* Request size for user */

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -152,6 +152,37 @@ ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
     return params->worker->context->tl_rscs[rsc_index].tl_rsc.sys_device;
 }
 
+int ucp_proto_common_add_unique_sys_dev(ucs_sys_device_t sys_dev,
+                                        ucs_sys_device_t *sys_devs,
+                                        ucp_lane_index_t *num_sys_devs,
+                                        ucp_lane_index_t max_sys_devs)
+{
+    ucp_lane_index_t i;
+
+    for (i = 0; i < *num_sys_devs; ++i) {
+        if (sys_dev == sys_devs[i]) {
+            return 0; /* Already exists */
+        }
+    }
+
+    if (*num_sys_devs < max_sys_devs) {
+        sys_devs[(*num_sys_devs)++] = sys_dev;
+        return 1; /* Added */
+    }
+
+    return 0; /* No space */
+}
+
+ucp_lane_index_t
+ucp_proto_common_select_sys_dev_by_node_id(const ucp_proto_init_params_t *params,
+                                           ucp_lane_index_t num_sys_devs)
+{
+    if (num_sys_devs == 0) {
+        return 0;
+    }
+    return params->worker->context->config.node_local_id % num_sys_devs;
+}
+
 /* Pack/unpack local distance to make it equal to the remote one */
 static void
 ucp_proto_common_fp8_pack_unpack_distance(ucs_sys_dev_distance_t *distance)

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -255,6 +255,15 @@ ucs_sys_device_t
 ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
                              ucp_lane_index_t lane);
 
+int ucp_proto_common_add_unique_sys_dev(ucs_sys_device_t sys_dev,
+                                        ucs_sys_device_t *sys_devs,
+                                        ucp_lane_index_t *num_sys_devs,
+                                        ucp_lane_index_t max_sys_devs);
+
+ucp_lane_index_t
+ucp_proto_common_select_sys_dev_by_node_id(const ucp_proto_init_params_t *params,
+                                           ucp_lane_index_t num_sys_devs);
+
 
 void ucp_proto_common_get_lane_distance(const ucp_proto_init_params_t *params,
                                         ucp_lane_index_t lane,

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -409,7 +409,7 @@ ucp_proto_common_get_dev_index(const ucp_proto_init_params_t *params,
 
 static UCS_F_ALWAYS_INLINE const uct_tl_resource_desc_t *
 ucp_proto_common_get_tl_rsc(const ucp_proto_init_params_t *params,
-                           ucp_lane_index_t lane)
+                            ucp_lane_index_t lane)
 {
     ucp_rsc_index_t rsc_index = ucp_proto_common_get_rsc_index(params, lane);
     return &params->worker->context->tl_rscs[rsc_index].tl_rsc;
@@ -421,6 +421,12 @@ ucp_proto_common_is_net_dev(const ucp_proto_init_params_t *params,
 {
     return ucp_proto_common_get_tl_rsc(params, lane)->dev_type ==
            UCT_DEVICE_TYPE_NET;
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_common_bandwidth_equal(double bw1, double bw2)
+{
+    return fabs(bw1 - bw2) <= UCP_PROTO_PERF_EPSILON;
 }
 
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -430,6 +430,4 @@ ucp_proto_common_get_dev_name(const ucp_proto_init_params_t *params,
     return ucp_proto_common_get_tl_rsc(params, lane)->dev_name;
 }
 
-
-
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -423,11 +423,4 @@ ucp_proto_common_is_net_dev(const ucp_proto_init_params_t *params,
            UCT_DEVICE_TYPE_NET;
 }
 
-static UCS_F_ALWAYS_INLINE const char *
-ucp_proto_common_get_dev_name(const ucp_proto_init_params_t *params,
-                             ucp_lane_index_t lane)
-{
-    return ucp_proto_common_get_tl_rsc(params, lane)->dev_name;
-}
-
 #endif

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -407,4 +407,29 @@ ucp_proto_common_get_dev_index(const ucp_proto_init_params_t *params,
     return params->worker->context->tl_rscs[rsc_index].dev_index;
 }
 
+static UCS_F_ALWAYS_INLINE const uct_tl_resource_desc_t *
+ucp_proto_common_get_tl_rsc(const ucp_proto_init_params_t *params,
+                           ucp_lane_index_t lane)
+{
+    ucp_rsc_index_t rsc_index = ucp_proto_common_get_rsc_index(params, lane);
+    return &params->worker->context->tl_rscs[rsc_index].tl_rsc;
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_common_is_net_dev(const ucp_proto_init_params_t *params,
+                            ucp_lane_index_t lane)
+{
+    return ucp_proto_common_get_tl_rsc(params, lane)->dev_type ==
+           UCT_DEVICE_TYPE_NET;
+}
+
+static UCS_F_ALWAYS_INLINE const char *
+ucp_proto_common_get_dev_name(const ucp_proto_init_params_t *params,
+                             ucp_lane_index_t lane)
+{
+    return ucp_proto_common_get_tl_rsc(params, lane)->dev_name;
+}
+
+
+
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -197,7 +197,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
     }
 
     seed = params->worker->context->config.node_local_id % num_identical_devs;
-    for (i = fixed_first_lane ? 1 : 0, num_filtered_lanes = i; i < num_lanes;
+    for (i = !!fixed_first_lane, num_filtered_lanes = i; i < num_lanes;
          ++i) {
         lane   = lanes[i];
         tl_rsc = ucp_proto_common_get_tl_rsc(params, lane);

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -159,8 +159,8 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
     double max_bandwidth;
     ucp_lane_index_t i, lane, num_identical_devs, seed, num_filtered_lanes;
     ucp_lane_map_t lane_map;
-    const char *dev_name;
-    const char *dev_names[UCP_PROTO_MAX_LANES];
+    ucs_sys_device_t sys_dev;
+    ucs_sys_device_t sys_devs[UCP_PROTO_MAX_LANES];
     const uct_tl_resource_desc_t *tl_rsc;
 
     for (lane_map = 0, max_bandwidth = 0, i = 0; i < num_lanes; ++i) {
@@ -180,15 +180,15 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
             continue;
         }
 
-        dev_name = ucp_proto_common_get_dev_name(params, lane);
+        sys_dev = ucp_proto_common_get_sys_dev(params, lane);
         for (i = 0; i < num_identical_devs; ++i) {
-            if (strcmp(dev_names[i], dev_name) == 0) {
+            if (sys_dev == sys_devs[i]) {
                 break;
             }
         }
 
         if (i == num_identical_devs) {
-            dev_names[num_identical_devs++] = dev_name;
+            sys_devs[num_identical_devs++] = sys_dev;
         }
     }
 
@@ -202,7 +202,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         lane   = lanes[i];
         tl_rsc = ucp_proto_common_get_tl_rsc(params, lane);
         if ((tl_rsc->dev_type == UCT_DEVICE_TYPE_NET) &&
-            (strcmp(tl_rsc->dev_name, dev_names[seed]) != 0)) {
+            (tl_rsc->sys_device != sys_devs[seed])) {
             ucp_proto_perf_node_deref(&perf_nodes[lane]);
             ucs_trace("filtered out " UCP_PROTO_LANE_FMT,
                       UCP_PROTO_LANE_ARG(params, lane, &tl_perfs[lane]));

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -197,8 +197,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
     }
 
     seed = params->worker->context->config.node_local_id % num_max_bw_devs;
-    for (i = !!fixed_first_lane, num_filtered_lanes = i; i < num_lanes;
-         ++i) {
+    for (i = !!fixed_first_lane, num_filtered_lanes = i; i < num_lanes; ++i) {
         lane   = lanes[i];
         tl_rsc = ucp_proto_common_get_tl_rsc(params, lane);
         if ((tl_rsc->dev_type == UCT_DEVICE_TYPE_NET) &&

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -218,7 +218,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         return num_lanes;
     }
 
-    seed = params->worker->context->config.ext.node_local_id %
+    seed = params->worker->context->config.node_local_id %
            num_identical_devs;
     for (i = fixed_first_lane ? 1 : 0, num_filtered_lanes = i; i < num_lanes;
          ++i) {

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -197,7 +197,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
 
     num_identical_devs = 0;
     ucs_for_each_bit(lane, lane_map) {
-        if (fabsf(lanes_perf[lane].bandwidth - max_bandwidth) >
+        if (fabs(lanes_perf[lane].bandwidth - max_bandwidth) >
             UCP_PROTO_PERF_EPSILON) {
             continue;
         }

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -157,7 +157,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         ucp_lane_index_t *lanes, ucp_proto_perf_node_t **perf_nodes)
 {
     double max_bandwidth;
-    ucp_lane_index_t i, lane, num_identical_devs, seed, num_filtered_lanes;
+    ucp_lane_index_t i, lane, num_max_bw_devs, seed, num_filtered_lanes;
     ucp_lane_map_t lane_map;
     ucs_sys_device_t sys_dev;
     ucs_sys_device_t sys_devs[UCP_PROTO_MAX_LANES];
@@ -173,7 +173,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         max_bandwidth = ucs_max(max_bandwidth, tl_perfs[lane].bandwidth);
     }
 
-    num_identical_devs = 0;
+    num_max_bw_devs = 0;
     ucs_for_each_bit(lane, lane_map) {
         if (fabs(tl_perfs[lane].bandwidth - max_bandwidth) >
             UCP_PROTO_PERF_EPSILON) {
@@ -181,22 +181,22 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         }
 
         sys_dev = ucp_proto_common_get_sys_dev(params, lane);
-        for (i = 0; i < num_identical_devs; ++i) {
+        for (i = 0; i < num_max_bw_devs; ++i) {
             if (sys_dev == sys_devs[i]) {
                 break;
             }
         }
 
-        if (i == num_identical_devs) {
-            sys_devs[num_identical_devs++] = sys_dev;
+        if (i == num_max_bw_devs) {
+            sys_devs[num_max_bw_devs++] = sys_dev;
         }
     }
 
-    if (num_identical_devs == 0) {
+    if (num_max_bw_devs == 0) {
         return num_lanes;
     }
 
-    seed = params->worker->context->config.node_local_id % num_identical_devs;
+    seed = params->worker->context->config.node_local_id % num_max_bw_devs;
     for (i = !!fixed_first_lane, num_filtered_lanes = i; i < num_lanes;
          ++i) {
         lane   = lanes[i];

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -196,8 +196,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         return num_lanes;
     }
 
-    seed = params->worker->context->config.node_local_id %
-           num_identical_devs;
+    seed = params->worker->context->config.node_local_id % num_identical_devs;
     for (i = fixed_first_lane ? 1 : 0, num_filtered_lanes = i; i < num_lanes;
          ++i) {
         lane   = lanes[i];

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -218,7 +218,8 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         return num_lanes;
     }
 
-    seed = params->worker->context->config.ext.local_rank % num_identical_devs;
+    seed = params->worker->context->config.ext.node_local_id %
+           num_identical_devs;
     for (i = fixed_first_lane ? 1 : 0, num_filtered_lanes = i; i < num_lanes;
          ++i) {
         lane   = lanes[i];

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -45,7 +45,7 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
     double bandwidth;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     ucs_sys_device_t sys_devs[UCP_PROTO_MAX_LANES];
-    ucp_lane_index_t num_lanes, num_identical_devs, i, lane, j;
+    ucp_lane_index_t num_lanes, num_same_bw_devs, i, lane, j;
     ucs_sys_device_t sys_dev;
 
     if (context->config.ext.proto_use_single_net_device &&
@@ -67,7 +67,7 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
             (common_params->exclude_map | UCS_BIT(lanes[0])),
             ucp_proto_common_filter_min_frag, lanes + 1);
 
-    for (num_identical_devs = 1, i = 1; i < num_lanes; ++i) {
+    for (num_same_bw_devs = 1, i = 1; i < num_lanes; ++i) {
         lane = lanes[i];
         if (!ucp_proto_common_is_net_dev(init_params, lane)) {
             continue;
@@ -79,19 +79,19 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
         }
 
         sys_dev = ucp_proto_common_get_sys_dev(init_params, lane);
-        for (j = 0; j < num_identical_devs; ++j) {
+        for (j = 0; j < num_same_bw_devs; ++j) {
             if (sys_dev == sys_devs[j]) {
                 break;
             }
         }
 
-        if (j == num_identical_devs) {
-            lanes[num_identical_devs]      = lane;
-            sys_devs[num_identical_devs++] = sys_dev;
+        if (j == num_same_bw_devs) {
+            lanes[num_same_bw_devs]      = lane;
+            sys_devs[num_same_bw_devs++] = sys_dev;
         }
     }
 
-    *lane_p = lanes[context->config.node_local_id % num_identical_devs];
+    *lane_p = lanes[context->config.node_local_id % num_same_bw_devs];
 }
 
 ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -49,6 +49,8 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
     ucs_sys_device_t sys_dev;
 
     if (!context->config.ext.proto_use_single_net_device ||
+        /* skip lane update for node_local_id 0 since the original lane would be
+         * selected anyway */
         (context->config.node_local_id == 0)) {
         return;
     }

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -49,7 +49,7 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
     const char *dev_name;
 
     if (context->config.ext.proto_use_single_net_device &&
-        context->config.node_local_id != 0) {
+        (context->config.node_local_id != 0)) {
         return;
     }
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -40,8 +40,8 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
                              ucp_lane_index_t *lane_p)
 {
     const ucp_proto_common_init_params_t *common_params = &params->super;
-    const ucp_proto_init_params_t *init_params          = &common_params->super;
-    const ucp_context_h context = init_params->worker->context;
+    const ucp_proto_init_params_t *init_params = &common_params->super;
+    const ucp_context_h context                = init_params->worker->context;
     double bandwidth;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     const char *dev_names[UCP_PROTO_MAX_LANES];

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -48,8 +48,8 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
     ucp_lane_index_t num_lanes, num_same_bw_devs, i, lane, j;
     ucs_sys_device_t sys_dev;
 
-    if (context->config.ext.proto_use_single_net_device &&
-        (context->config.node_local_id != 0)) {
+    if (!context->config.ext.proto_use_single_net_device ||
+        (context->config.node_local_id == 0)) {
         return;
     }
 

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -44,9 +44,9 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
     const ucp_context_h context                = init_params->worker->context;
     double bandwidth;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
-    const char *dev_names[UCP_PROTO_MAX_LANES];
+    ucs_sys_device_t sys_devs[UCP_PROTO_MAX_LANES];
     ucp_lane_index_t num_lanes, num_identical_devs, i, lane, j;
-    const char *dev_name;
+    ucs_sys_device_t sys_dev;
 
     if (context->config.ext.proto_use_single_net_device &&
         (context->config.node_local_id != 0)) {
@@ -57,9 +57,9 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
         return;
     }
 
-    bandwidth    = ucp_proto_single_get_bandwidth(common_params, *lane_p);
-    lanes[0]     = *lane_p;
-    dev_names[0] = ucp_proto_common_get_dev_name(init_params, lanes[0]);
+    bandwidth   = ucp_proto_single_get_bandwidth(common_params, *lane_p);
+    lanes[0]    = *lane_p;
+    sys_devs[0] = ucp_proto_common_get_sys_dev(init_params, lanes[0]);
 
     num_lanes = ucp_proto_common_find_lanes(
             init_params, common_params->flags, params->lane_type,
@@ -78,16 +78,16 @@ ucp_proto_single_update_lane(const ucp_proto_single_init_params_t *params,
             continue;
         }
 
-        dev_name = ucp_proto_common_get_dev_name(init_params, lane);
+        sys_dev = ucp_proto_common_get_sys_dev(init_params, lane);
         for (j = 0; j < num_identical_devs; ++j) {
-            if (strcmp(dev_names[j], dev_name) == 0) {
+            if (sys_dev == sys_devs[j]) {
                 break;
             }
         }
 
         if (j == num_identical_devs) {
-            lanes[num_identical_devs]       = lane;
-            dev_names[num_identical_devs++] = dev_name;
+            lanes[num_identical_devs]      = lane;
+            sys_devs[num_identical_devs++] = sys_dev;
         }
     }
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -881,13 +881,13 @@ public:
         };
 
         add_mock_iface("mock_0:1", iface_attr_func);
-        add_mock_iface("mock_1:1", iface_attr_func);
-        add_mock_iface("mock_2:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 600e-9;
             iface_attr.latency.m        = 1e-9;
         });
+        add_mock_iface("mock_2:1", iface_attr_func);
         test_ucp_proto_mock::init();
     }
 };
@@ -920,7 +920,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_all_net_devices,
              // Use two network devices with the same bandwidth in 50/50 ratio
              {18543, INF, "rendezvous zero-copy read from remote",
               "50% on rc_mlx5/mock_0:1/path0 and 50% on "
-              "rc_mlx5/mock_1:1/path0"}});
+              "rc_mlx5/mock_2:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_0,
@@ -933,7 +933,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_0,
              {8247, 18542, "multi-frag eager zero-copy copy-out",
               "rc_mlx5/mock_0:1/path0"},
              // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0
-             // Use two paths of the first network device in 50/50 ratio
+             // Use two paths of the zero network device in 50/50 ratio
              {18543, INF, "rendezvous zero-copy read from remote",
               "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}});
 }
@@ -950,7 +950,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_1,
              // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
              // Use two paths of the second network device in 50/50
              {18543, INF, "rendezvous zero-copy read from remote",
-              "rc_mlx5/mock_1:1 50% on path0 and 50% on path1"}});
+              "rc_mlx5/mock_2:1 50% on path0 and 50% on path1"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_2,
@@ -963,7 +963,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_2,
              {8247, 18542, "multi-frag eager zero-copy copy-out",
               "rc_mlx5/mock_0:1/path0"},
              // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
-             // Use two paths of the first network device in 50/50 ratio
+             // Use two paths of the zero network device in 50/50 ratio
              {18543, INF, "rendezvous zero-copy read from remote",
               "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}});
 }
@@ -1018,7 +1018,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_1,
            "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
     check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
-                  {2049, INF, "zero-copy", "rc_mlx5/mock_1:1/path0"}});
+                  {2049, INF, "zero-copy", "rc_mlx5/mock_2:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_2,

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -898,7 +898,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_all_net_devices,
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=n [default]
+    // SINGLE_NET_DEVICE=n [default]
     // Use two network devices with the same bandwidth in 50/50 ratio
     check_ep_config(sender(),
                     {
@@ -916,13 +916,13 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_all_net_devices,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
-           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0 [default]
+    // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0 [default]
     // Use two paths of the first network device in 50/50 ratio
     check_ep_config(sender(),
                     {
@@ -939,14 +939,14 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
-           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y",
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y",
            "NODE_LOCAL_ID=1")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
+    // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
     // Use two paths of the second network device in 50/50 ratio
     check_ep_config(sender(),
                     {
@@ -963,14 +963,14 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_2,
-           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y",
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y",
            "NODE_LOCAL_ID=2")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
+    // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
     // Use two paths of the first network device in 50/50 ratio
     check_ep_config(sender(),
                     {

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -922,7 +922,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=y, LOCAL_RANK=0 [default]
+    // PROTO_USE_SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0 [default]
     // Use two paths of the first network device in 50/50 ratio
     check_ep_config(sender(),
                     {
@@ -939,13 +939,14 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
-           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y", "LOCAL_RANK=1")
+           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y",
+           "NODE_LOCAL_ID=1")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=y, LOCAL_RANK=1
+    // PROTO_USE_SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
     // Use two paths of the second network device in 50/50 ratio
     check_ep_config(sender(),
                     {
@@ -962,13 +963,14 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_2,
-           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y", "LOCAL_RANK=2")
+           "IB_NUM_PATHS?=2", "PROTO_USE_SINGLE_NET_DEVICE=y",
+           "NODE_LOCAL_ID=2")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // PROTO_USE_SINGLE_NET_DEVICE=y, LOCAL_RANK=2
+    // PROTO_USE_SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
     // Use two paths of the first network device in 50/50 ratio
     check_ep_config(sender(),
                     {

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -898,7 +898,7 @@ protected:
 };
 
 void test_ucp_proto_mock_rcx_twins_tag::check_config(
-    const proto_select_data_vec_t &data_vec)
+        const proto_select_data_vec_t &data_vec)
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_TAG_SEND;
@@ -911,80 +911,64 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_all_net_devices,
            "IB_NUM_PATHS?=2")
 {
     check_config({
-                        {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-                        {201, 404, "eager copy-in copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {405, 8246, "eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {8247, 18542, "multi-frag eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        // SINGLE_NET_DEVICE=n [default]
-                        // Use two network devices with the same bandwidth in 
-                        // 50/50 ratio
-                        {18543, INF,
-                         "rendezvous zero-copy read from remote",
-                         "50% on rc_mlx5/mock_0:1/path0 and 50% on "
-                         "rc_mlx5/mock_1:1/path0"},
-                });
+            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+            {8247, 18542, "multi-frag eager zero-copy copy-out",
+             "rc_mlx5/mock_0:1/path0"},
+            // SINGLE_NET_DEVICE=n [default]
+            // Use two network devices with the same bandwidth in 50/50 ratio
+            {18543, INF, "rendezvous zero-copy read from remote",
+             "50% on rc_mlx5/mock_0:1/path0 and 50% on rc_mlx5/mock_1:1/path0"}
+    });
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_0,
            "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
 {
     check_config({
-                        {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-                        {201, 404, "eager copy-in copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {405, 8246, "eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {8247, 18542, "multi-frag eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0
-                        // Use two paths of the first network device in 50/50
-                        // ratio
-                        {18543, INF,
-                         "rendezvous zero-copy read from remote",
-                         "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"},
-                });
+            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+            {8247, 18542, "multi-frag eager zero-copy copy-out",
+             "rc_mlx5/mock_0:1/path0"},
+            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0
+            // Use two paths of the first network device in 50/50 ratio
+            {18543, INF, "rendezvous zero-copy read from remote",
+             "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}
+    });
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_1,
            "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
     check_config({
-                        {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-                        {201, 404, "eager copy-in copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {405, 8246, "eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {8247, 18542, "multi-frag eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
-                        // Use two paths of the second network device in 50/50
-                        {18543, INF,
-                         "rendezvous zero-copy read from remote",
-                         "rc_mlx5/mock_1:1 50% on path0 and 50% on path1"},
-                });
+            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+            {8247, 18542, "multi-frag eager zero-copy copy-out",
+             "rc_mlx5/mock_0:1/path0"},
+            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
+            // Use two paths of the second network device in 50/50
+            {18543, INF, "rendezvous zero-copy read from remote",
+             "rc_mlx5/mock_1:1 50% on path0 and 50% on path1"}
+    });
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_2,
            "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
 {
     check_config({
-                        {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-                        {201, 404, "eager copy-in copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {405, 8246, "eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        {8247, 18542, "multi-frag eager zero-copy copy-out",
-                         "rc_mlx5/mock_0:1/path0"},
-                        // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
-                        // Use two paths of the first network device in 50/50
-                        // ratio
-                        {18543, INF,
-                         "rendezvous zero-copy read from remote",
-                         "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"},
-                });
+            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+            {8247, 18542, "multi-frag eager zero-copy copy-out",
+             "rc_mlx5/mock_0:1/path0"},
+            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
+            // Use two paths of the first network device in 50/50 ratio
+            {18543, INF, "rendezvous zero-copy read from remote",
+             "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}
+    });
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_tag, rcx, "rc_x")
@@ -995,7 +979,7 @@ protected:
 };
 
 void test_ucp_proto_mock_rcx_twins_put::check_config(
-    const proto_select_data_vec_t &data_vec)
+        const proto_select_data_vec_t &data_vec)
 {
     uint8_t dummy;
     ucp_mem_map_params_t mem_map_params;
@@ -1029,28 +1013,22 @@ void test_ucp_proto_mock_rcx_twins_put::check_config(
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_0,
            "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
 {
-    check_config({
-                        {0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
-                        {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}
-                });
+    check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
+                  {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_1,
            "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
-    check_config({
-                        {0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
-                        {2049, INF, "zero-copy", "rc_mlx5/mock_1:1/path0"}
-                });
+    check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
+                  {2049, INF, "zero-copy", "rc_mlx5/mock_1:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_2,
            "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
 {
-    check_config({
-                        {0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
-                        {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}
-                });
+    check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
+                  {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_put, rcx, "rc_x")

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -991,21 +991,21 @@ void test_ucp_proto_mock_rcx_twins_put::check_config(
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_0,
-           "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
 {
     check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
                   {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_1,
-           "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
     check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
                   {2049, INF, "zero-copy", "rc_mlx5/mock_2:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_2,
-           "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
 {
     check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
                   {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});
@@ -1063,21 +1063,21 @@ void test_ucp_proto_mock_rcx_twins_get::check_config(
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_get, use_single_net_device_rank_0,
-           "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
 {
     check_config({{0, 624, "copy-out", "rc_mlx5/mock_0:1/path0"},
                   {625, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_get, use_single_net_device_rank_1,
-           "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
     check_config({{0, 624, "copy-out", "rc_mlx5/mock_2:1/path0"},
                   {625, INF, "zero-copy", "rc_mlx5/mock_2:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_get, use_single_net_device_rank_2,
-           "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
 {
     check_config({{0, 624, "copy-out", "rc_mlx5/mock_0:1/path0"},
                   {625, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -898,8 +898,6 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_all_net_devices,
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // SINGLE_NET_DEVICE=n [default]
-    // Use two network devices with the same bandwidth in 50/50 ratio
     check_ep_config(sender(),
                     {
                             {0, 200, "short", "rc_mlx5/mock_0:1/path0"},
@@ -907,6 +905,9 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_all_net_devices,
                             {405, 8246, "zero-copy", "rc_mlx5/mock_0:1/path0"},
                             {8247, 18540, "multi-frag zero-copy",
                              "rc_mlx5/mock_0:1/path0"},
+                            // SINGLE_NET_DEVICE=n [default]
+                            // Use two network devices with the same bandwidth
+                            // in 50/50 ratio
                             {18541, INF,
                              "rendezvous zero-copy read from remote",
                              "50% on rc_mlx5/mock_0:1/path0 and 50% on "
@@ -922,8 +923,6 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0 [default]
-    // Use two paths of the first network device in 50/50 ratio
     check_ep_config(sender(),
                     {
                             {0, 200, "short", "rc_mlx5/mock_0:1/path0"},
@@ -931,6 +930,9 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
                             {405, 8246, "zero-copy", "rc_mlx5/mock_0:1/path0"},
                             {8247, 18540, "multi-frag zero-copy",
                              "rc_mlx5/mock_0:1/path0"},
+                            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0 [default]
+                            // Use two paths of the first network device in
+                            // 50/50 ratio
                             {18541, INF,
                              "rendezvous zero-copy read from remote",
                              "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"},
@@ -939,15 +941,12 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
-           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y",
-           "NODE_LOCAL_ID=1")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
-    // Use two paths of the second network device in 50/50 ratio
     check_ep_config(sender(),
                     {
                             {0, 200, "short", "rc_mlx5/mock_0:1/path0"},
@@ -955,6 +954,9 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
                             {405, 8246, "zero-copy", "rc_mlx5/mock_0:1/path0"},
                             {8247, 18540, "multi-frag zero-copy",
                              "rc_mlx5/mock_0:1/path0"},
+                            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
+                            // Use two paths of the second network device in
+                            // 50/50 ratio
                             {18541, INF,
                              "rendezvous zero-copy read from remote",
                              "rc_mlx5/mock_1:1 50% on path0 and 50% on path1"},
@@ -963,15 +965,12 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_1,
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_2,
-           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y",
-           "NODE_LOCAL_ID=2")
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
 {
     ucp_proto_select_key_t key = any_key();
     key.param.op_id_flags      = UCP_OP_ID_AM_SEND;
     key.param.op_attr          = 0;
 
-    // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
-    // Use two paths of the first network device in 50/50 ratio
     check_ep_config(sender(),
                     {
                             {0, 200, "short", "rc_mlx5/mock_0:1/path0"},
@@ -979,6 +978,9 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins, use_single_net_device_rank_2,
                             {405, 8246, "zero-copy", "rc_mlx5/mock_0:1/path0"},
                             {8247, 18540, "multi-frag zero-copy",
                              "rc_mlx5/mock_0:1/path0"},
+                            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
+                            // Use two paths of the first network device in
+                            // 50/50 ratio
                             {18541, INF,
                              "rendezvous zero-copy read from remote",
                              "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"},

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -910,65 +910,62 @@ void test_ucp_proto_mock_rcx_twins_tag::check_config(
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_all_net_devices,
            "IB_NUM_PATHS?=2")
 {
-    check_config({
-            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
-            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
-            {8247, 18542, "multi-frag eager zero-copy copy-out",
-             "rc_mlx5/mock_0:1/path0"},
-            // SINGLE_NET_DEVICE=n [default]
-            // Use two network devices with the same bandwidth in 50/50 ratio
-            {18543, INF, "rendezvous zero-copy read from remote",
-             "50% on rc_mlx5/mock_0:1/path0 and 50% on rc_mlx5/mock_1:1/path0"}
-    });
+    check_config(
+            {{0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+             {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+             {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+             {8247, 18542, "multi-frag eager zero-copy copy-out",
+              "rc_mlx5/mock_0:1/path0"},
+             // SINGLE_NET_DEVICE=n [default]
+             // Use two network devices with the same bandwidth in 50/50 ratio
+             {18543, INF, "rendezvous zero-copy read from remote",
+              "50% on rc_mlx5/mock_0:1/path0 and 50% on "
+              "rc_mlx5/mock_1:1/path0"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_0,
            "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
 {
-    check_config({
-            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
-            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
-            {8247, 18542, "multi-frag eager zero-copy copy-out",
-             "rc_mlx5/mock_0:1/path0"},
-            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0
-            // Use two paths of the first network device in 50/50 ratio
-            {18543, INF, "rendezvous zero-copy read from remote",
-             "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}
-    });
+    check_config(
+            {{0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+             {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+             {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+             {8247, 18542, "multi-frag eager zero-copy copy-out",
+              "rc_mlx5/mock_0:1/path0"},
+             // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=0
+             // Use two paths of the first network device in 50/50 ratio
+             {18543, INF, "rendezvous zero-copy read from remote",
+              "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_1,
            "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
 {
-    check_config({
-            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
-            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
-            {8247, 18542, "multi-frag eager zero-copy copy-out",
-             "rc_mlx5/mock_0:1/path0"},
-            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
-            // Use two paths of the second network device in 50/50
-            {18543, INF, "rendezvous zero-copy read from remote",
-             "rc_mlx5/mock_1:1 50% on path0 and 50% on path1"}
-    });
+    check_config(
+            {{0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+             {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+             {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+             {8247, 18542, "multi-frag eager zero-copy copy-out",
+              "rc_mlx5/mock_0:1/path0"},
+             // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=1
+             // Use two paths of the second network device in 50/50
+             {18543, INF, "rendezvous zero-copy read from remote",
+              "rc_mlx5/mock_1:1 50% on path0 and 50% on path1"}});
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_2,
            "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=2")
 {
-    check_config({
-            {0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
-            {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
-            {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
-            {8247, 18542, "multi-frag eager zero-copy copy-out",
-             "rc_mlx5/mock_0:1/path0"},
-            // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
-            // Use two paths of the first network device in 50/50 ratio
-            {18543, INF, "rendezvous zero-copy read from remote",
-             "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}
-    });
+    check_config(
+            {{0, 200, "eager short", "rc_mlx5/mock_0:1/path0"},
+             {201, 404, "eager copy-in copy-out", "rc_mlx5/mock_0:1/path0"},
+             {405, 8246, "eager zero-copy copy-out", "rc_mlx5/mock_0:1/path0"},
+             {8247, 18542, "multi-frag eager zero-copy copy-out",
+              "rc_mlx5/mock_0:1/path0"},
+             // SINGLE_NET_DEVICE=y, NODE_LOCAL_ID=2
+             // Use two paths of the first network device in 50/50 ratio
+             {18543, INF, "rendezvous zero-copy read from remote",
+              "rc_mlx5/mock_0:1 50% on path0 and 50% on path1"}});
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_tag, rcx, "rc_x")

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -388,11 +388,11 @@ protected:
         }
     }
 
-    static void check_proto_select(const entity &e,
-                                   const ucp_proto_select_t &proto_select,
-                                   const proto_select_data_vec_t &data_vec,
-                                   const ucp_proto_select_key_t &key,
-                                   ucp_worker_cfg_index_t rkey_cfg_index = UCP_WORKER_CFG_INDEX_NULL)
+    static void check_proto_select(
+            const entity &e, const ucp_proto_select_t &proto_select,
+            const proto_select_data_vec_t &data_vec,
+            const ucp_proto_select_key_t &key,
+            ucp_worker_cfg_index_t rkey_cfg_index = UCP_WORKER_CFG_INDEX_NULL)
     {
         ucp_proto_select_elem_t select_elem;
         ucp_proto_select_key_t select_key;
@@ -1031,9 +1031,12 @@ void test_ucp_proto_mock_rcx_twins_get::check_config(
     ucp_mem_h mem;
     ASSERT_UCS_OK(ucp_mem_map(receiver().ucph(), &mem_map_params, &mem));
     ucs::handle<ucp_mem_h, ucp_context_h> mem_h{
-        mem, [](ucp_mem_h mem, ucp_context_h context) {
-            static_cast<void>(ucp_mem_unmap(context, mem));
-        }, sender().ucph()};
+        mem,
+        [](ucp_mem_h mem, ucp_context_h context) {
+             static_cast<void>(ucp_mem_unmap(context, mem));
+        },
+        sender().ucph()
+    };
 
     void *rkey_buffer;
     size_t rkey_buffer_size;


### PR DESCRIPTION
## What?
Added option to use single network device for all protocols.
Added option to pass unique id to the context.

## Why?
The combination of these two options allows to balance the traffic going from a single node with several network devices with the same estimated bandwidth.