### PR TITLE
Added hook for cuLibraryGetGlobal. Skip test_cuda_ipc_md.mkey_pack_mempool - v1.19.x

### DIFF
--- a/src/ucm/cuda/cudamem.h
+++ b/src/ucm/cuda/cudamem.h
@@ -30,6 +30,10 @@ CUresult ucm_cuMemAllocAsync(CUdeviceptr *dptr, size_t size, CUstream hStream);
 CUresult ucm_cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t size,
                                      CUmemoryPool pool, CUstream hStream);
 #endif
+#if CUDART_VERSION >= 12000
+CUresult ucm_cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes,
+                                CUlibrary library, const char *name);
+#endif
 CUresult ucm_cuMemFree(CUdeviceptr dptr);
 CUresult ucm_cuMemFree_v2(CUdeviceptr dptr);
 CUresult ucm_cuMemFreeHost(void *p);

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -193,6 +193,15 @@ UCS_TEST_P(test_cuda_ipc_md, mkey_pack_legacy)
 UCS_TEST_P(test_cuda_ipc_md, mkey_pack_mempool)
 {
 #if HAVE_CUDA_FABRIC
+    int driver_version;
+    EXPECT_EQ(CUDA_SUCCESS, cuDriverGetVersion(&driver_version));
+    if (driver_version == 13000) {
+        UCS_TEST_SKIP_R("in CUDA 13.0, calling cuMemPoolDestroy results in a "
+                        "segmentation fault if "
+                        "cuMemPoolExportToShareableHandle returned an error "
+                        "before that");
+    }
+
     size_t size = 4 * UCS_MBYTE;
     CUdeviceptr ptr;
     CUmemoryPool mpool;


### PR DESCRIPTION
## What?
- Added hook for `cuLibraryGetGlobal`.
Cherry-picked https://github.com/openucx/ucx/pull/10866 
- Skip test_cuda_ipc_md.mkey_pack_mempool when running with CUDA Driver 13.
Cherry-picked https://github.com/openucx/ucx/pull/10809
