### PR TITLE
AZP/RELEASE: Added header to Makefile.

### DIFF
--- a/src/uct/cuda/Makefile.am
+++ b/src/uct/cuda/Makefile.am
@@ -22,11 +22,12 @@ noinst_HEADERS = \
 	cuda_copy/cuda_copy_md.h \
 	cuda_copy/cuda_copy_iface.h \
 	cuda_copy/cuda_copy_ep.h \
-	cuda_ipc/cuda_ipc_md.h \
-	cuda_ipc/cuda_ipc_iface.h \
-	cuda_ipc/cuda_ipc_ep.h \
+	cuda_ipc/cuda_ipc.inl \
 	cuda_ipc/cuda_ipc_cache.h \
-	cuda_ipc/cuda_ipc.inl
+	cuda_ipc/cuda_ipc_device.h \
+	cuda_ipc/cuda_ipc_ep.h \
+	cuda_ipc/cuda_ipc_iface.h \
+	cuda_ipc/cuda_ipc_md.h
 
 libuct_cuda_la_SOURCES = \
 	base/cuda_iface.c \

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_device.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_device.h
@@ -3,8 +3,8 @@
  * See file LICENSE for terms.
  */
 
-#ifndef UCT_CUDA_IPC_EP_DEVICE_H
-#define UCT_CUDA_IPC_EP_DEVICE_H
+#ifndef UCT_CUDA_IPC_DEVICE_H
+#define UCT_CUDA_IPC_DEVICE_H
 
 #include <stddef.h>
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -8,14 +8,14 @@
 #endif
 
 #include "cuda_ipc.inl"
+#include "cuda_ipc_device.h"
+#include "cuda_ipc_ep.h"
 #include "cuda_ipc_iface.h"
 #include "cuda_ipc_md.h"
-#include "cuda_ipc_ep.h"
 
 #include <uct/cuda/base/cuda_iface.h>
 #include <uct/cuda/base/cuda_md.h>
 #include <uct/cuda/base/cuda_nvml.h>
-#include <uct/cuda/cuda_ipc/cuda_ipc_device.h>
 #include <ucs/type/class.h>
 #include <ucs/sys/string.h>
 #include <ucs/debug/assert.h>


### PR DESCRIPTION
## What?
Added missing `cuda_ipc_device.h` to the Makefile.

## Why?
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=107329&view=logs&j=4d7d522d-51dd-5ee3-6abe-aa66c5b993d0&t=29ea348b-20b1-52e8-8387-8d0a958f7c2b&l=1880