### PR TITLE
UCT/CUDA_IPC: install missing headers

### DIFF
--- a/src/uct/cuda/Makefile.am
+++ b/src/uct/cuda/Makefile.am
@@ -14,6 +14,11 @@ libuct_cuda_la_LDFLAGS  = $(CUDA_LDFLAGS) -version-info $(SOVERSION)
 libuct_cuda_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                           $(top_builddir)/src/uct/libuct.la \
                           $(CUDA_LIBS) $(NVML_LIBS)
+libuct_cuda_ladir       = $(includedir)/uct/cuda
+
+nobase_dist_libuct_cuda_la_HEADERS = \
+	cuda_ipc/cuda_ipc.cuh \
+	cuda_ipc/cuda_ipc_device.h
 
 noinst_HEADERS = \
 	base/cuda_md.h \


### PR DESCRIPTION
## What?
Install CUDA IPC public headers and set install dir for CUDA UCT headers.

## Why?
uct/api/device/uct_device_impl.h includes cuda_ipc.cuh, which requires cuda_ipc_device.h. Since it wasn’t installed, external builds including uct_device_impl.h failed.

## How?
1. Set libuct_cuda_ladir = $(includedir)/uct/cuda).
2. Add both headers to install list:
    cuda_ipc/cuda_ipc.cuh
    cuda_ipc/cuda_ipc_device.h 