### PR TITLE
UCT/GDAKI: Fix wqe_idx overflow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Hui Zhou <hzhou321@anl.gov>
 Igor Ivanov <igori@mellanox.com>
 Ilia Yastrebov <iyastrebov@nvidia.com>
 Ilya Nelkenbaum <ilyan@mellanox.com>
+Itay Alroy <ialroy@nvidia.com>
 Ivan Kochin <ikochin@nvidia.com>
 Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -109,7 +109,7 @@ uct_rc_mlx5_gda_reserv_wqe(struct doca_gpu_dev_verbs_qp *qp, unsigned count,
 
 UCS_F_DEVICE void uct_rc_mlx5_gda_wqe_prepare_put_or_atomic(
         doca_gpu_dev_verbs_qp *qp, doca_gpu_dev_verbs_wqe *wqe_ptr,
-        uint32_t wqe_idx, uint32_t opcode, unsigned ctrl_flags, uint64_t raddr,
+        uint16_t wqe_idx, uint32_t opcode, unsigned ctrl_flags, uint64_t raddr,
         uint32_t rkey, uint64_t laddr, uint32_t lkey, uint32_t bytes,
         bool is_atomic, uint64_t add)
 {


### PR DESCRIPTION
uct_gdaki_wqe_prepare_put_or_atomic assumes
wqe_idx is at most UINT16_T_MAX but single
API passed sq_rsvd_index, an ever-incrementing
uint64_t counter.

Other submit APIs avoid this issue by using inc_mask() per lane,
which properly masks the WQE index down to uint16_t.