### PR TITLE
AZP: Accept nvidia_peermem and drop legacy service check

### DIFF
--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -163,9 +163,9 @@ check_nv_peer_mem() {
         return 0
     fi
 
-    # Accept both legacy nv_peer_mem and new nvidia_peermem
-    if ! lsmod | egrep -q '^(nvidia_peermem|nv_peer_mem)\b'; then
-        azure_log_error "NV peer memory module not loaded on $(hostname -s)"
+    if ! lsmod | grep -q 'nv.*_peer.*mem'; then
+        lsmod | grep 'nv.*_peer.*mem'
+        azure_log_error "nv_peer_mem module not loaded on $(hostname -s)"
         exit 1
     fi
 }

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -163,10 +163,9 @@ check_nv_peer_mem() {
         return 0
     fi
 
-    if ! lsmod | grep -q 'nv.*_peer.*mem'; then
-        lsmod | grep 'nv.*_peer.*mem'
-        systemctl status nv_peer_mem
-        azure_log_error "nv_peer_mem module not loaded on $(hostname -s)"
+    # Accept both legacy nv_peer_mem and new nvidia_peermem
+    if ! lsmod | egrep -q '^(nvidia_peermem|nv_peer_mem)\b'; then
+        azure_log_error "NV peer memory module not loaded on $(hostname -s)"
         exit 1
     fi
 }


### PR DESCRIPTION
## What?
- Accept `nvidia_peermem` alongside `nv_peer_mem` in GPU peer-memory checks in `buildlib/az-helpers.sh`.
- Remove checking the legacy `nv_peer_mem` systemd service.
- Keep `try_load_cuda_env()` verifying via `/sys/kernel/mm/memory_peers/nv_mem/version`.

## Why?
- Hosts are migrating to `nvidia_peermem`. This avoids false negatives and removes dependency on a legacy service while preserving backward compatibility.

## How?
- `check_nv_peer_mem()`: pass if either `nvidia_peermem` or `nv_peer_mem` is loaded; drop service status check.
- `try_load_cuda_env()`: unchanged behavior, still relies on the sysfs version file.
