### PR TITLE
UCT/GDAKI: Add peer failure error handling cap.

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -325,7 +325,8 @@ uct_rc_gdaki_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
      */
     iface_attr->cap.flags = UCT_IFACE_FLAG_CONNECT_TO_EP |
                             UCT_IFACE_FLAG_INTER_NODE |
-                            UCT_IFACE_FLAG_DEVICE_EP;
+                            UCT_IFACE_FLAG_DEVICE_EP |
+                            UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE;
 
     iface_attr->ep_addr_len    = sizeof(uct_rc_mlx5_base_ep_address_t);
     iface_attr->iface_addr_len = sizeof(uint8_t);


### PR DESCRIPTION
## What?
Add peer failure error handling cap to gdaki.
