### PR TITLE
UCT/GDA/MLX5: Reduce DOCA log spam by setting ERROR level

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -698,7 +698,7 @@ static void uct_ib_doca_init(void)
     struct doca_log_backend *sdk_log;
     doca_error_t derr;
 
-    derr = doca_log_level_set_global_sdk_limit(DOCA_LOG_LEVEL_WARNING);
+    derr = doca_log_level_set_global_sdk_limit(DOCA_LOG_LEVEL_ERROR);
     if (derr != DOCA_SUCCESS) {
         ucs_error("doca_log_level_set_global_sdk_limit failed: %d\n", derr);
         return;


### PR DESCRIPTION
## What?
Reduce DOCA log level from WARNING to ERROR in GDAKI transport to prevent log spam.

## Why?
DOCA warnings were excessively spamming logs in NIXL, making it difficult to read the output.

## How?
Changed `doca_log_level_set_global_sdk_limit()` parameter from `DOCA_LOG_LEVEL_WARNING` to `DOCA_LOG_LEVEL_ERROR` in the DOCA initialization function.
