### PR TITLE
CONTRIB/CONFIGURE: Update configure scripts to handle spaces in basedir

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Keisuke Fukuda <kfukuda@preferred.jp>
 Ken Raffenetti <raffenet@mcs.anl.gov>
 Khaled Hamidouche <Khaled.Hamidouche@amd.com>
 Konstantin Belousov <kib@freebsd.org>
+Laurin Martins <laurin.martins@outlook.de>
 Leonid Genkin <lgenkin@nvidia.com>
 Lior Paz <liorpa@nvidia.com>
 Luis E. Pena <l31g@hotmail.com>

--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -11,7 +11,7 @@
 #
 
 basedir=$(cd $(dirname $0) && pwd)
-$basedir/../configure \
+"$basedir/../configure" \
 	--enable-gtest \
 	--enable-examples \
 	--enable-test-apps \

--- a/contrib/configure-opt
+++ b/contrib/configure-opt
@@ -11,6 +11,6 @@
 #
 
 basedir=$(cd $(dirname $0) && pwd)
-$basedir/configure-release \
+"$basedir/configure-release" \
 	--enable-optimizations \
 	"$@"

--- a/contrib/configure-prof
+++ b/contrib/configure-prof
@@ -11,7 +11,7 @@
 #
 
 basedir=$(cd $(dirname $0) && pwd)
-$basedir/../configure \
+"$basedir/../configure" \
 	--disable-logging \
 	--disable-debug \
 	--disable-assertions \

--- a/contrib/configure-release
+++ b/contrib/configure-release
@@ -11,7 +11,7 @@
 #
 
 basedir=$(cd $(dirname $0) && pwd)
-$basedir/../configure \
+"$basedir/../configure" \
 	--disable-logging \
 	--disable-debug \
 	--disable-assertions \

--- a/contrib/configure-release-mt
+++ b/contrib/configure-release-mt
@@ -11,6 +11,6 @@
 #
 
 basedir=$(cd $(dirname $0) && pwd)
-$basedir/../contrib/configure-release \
+"$basedir/../contrib/configure-release" \
 	--enable-mt \
 	"$@"


### PR DESCRIPTION
This change allows the basedir variable to contain spaces.

## What?
Adds quotes to the basedir variable.

## Why?
Without them the script fails when the path contains spaces.

