### PR TITLE
UCT/GDAKI: Fix WQE write ordering with threadfence

### DIFF
--- a/src/uct/cuda/gdaki/gdaki.cuh
+++ b/src/uct/cuda/gdaki/gdaki.cuh
@@ -254,6 +254,7 @@ uct_gdaki_db(struct doca_gpu_dev_verbs_qp *qp, uint64_t wqe_base, unsigned count
 {
     cuda::atomic_ref<uint64_t, cuda::thread_scope_device> ref(qp->sq_ready_index);
     uint64_t wqe_base_orig = wqe_base;
+    __threadfence();
     while (!ref.compare_exchange_strong(wqe_base, wqe_base + count,
                                         cuda::std::memory_order_relaxed)) {
         wqe_base = wqe_base_orig;


### PR DESCRIPTION
## What?
Add `__threadfence()` before updating `sq_ready_index` in `uct_gdaki_db()` to ensure proper memory ordering.

## Why?
Prevents race conditions when multiple threads write WQEs concurrently. Without the fence, a thread ringing the doorbell might update `sq_ready_index` before other threads' WQE writes are visible, causing completion queue errors (syndrome 2).

## How?
The `__threadfence()` ensures all prior WQE writes are globally visible before the `compare_exchange_strong` operation updates the ready index.
