### PR TITLE
UCP/DEVICE: Add local and remote address fields to memory list element

### DIFF
--- a/src/ucp/api/device/ucp_host.h
+++ b/src/ucp/api/device/ucp_host.h
@@ -34,10 +34,10 @@ BEGIN_C_DECLS
  * It is used to enable backward compatibility support.
  */
 enum ucp_device_mem_list_elem_field {
-    UCP_DEVICE_MEM_LIST_ELEM_FIELD_MEMH   = UCS_BIT(0), /**< Source memory handle */
-    UCP_DEVICE_MEM_LIST_ELEM_FIELD_RKEY   = UCS_BIT(1), /**< Unpacked remote memory key */
-    UCP_DEVICE_MEM_LIST_ELEM_FIELD_L_ADDR = UCS_BIT(2), /**< Local address */
-    UCP_DEVICE_MEM_LIST_ELEM_FIELD_R_ADDR = UCS_BIT(3)  /**< Remote address */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_MEMH        = UCS_BIT(0), /**< Source memory handle */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_RKEY        = UCS_BIT(1), /**< Unpacked remote memory key */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_LOCAL_ADDR  = UCS_BIT(2), /**< Local address */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_REMOTE_ADDR = UCS_BIT(3)  /**< Remote address */
 };
 
 
@@ -65,12 +65,12 @@ typedef struct ucp_device_mem_list_elem {
     /**
      * Local address of the memory to be transferred.
      */
-    void *     l_addr;
+    void *     local_addr;
 
     /**
      * Remote address of the memory to be transferred to.
      */
-    uint64_t   r_addr;
+    uint64_t   remote_addr;
 
     /**
      * Unpacked memory key for the remote memory endpoint.

--- a/src/ucp/api/device/ucp_host.h
+++ b/src/ucp/api/device/ucp_host.h
@@ -34,8 +34,10 @@ BEGIN_C_DECLS
  * It is used to enable backward compatibility support.
  */
 enum ucp_device_mem_list_elem_field {
-    UCP_DEVICE_MEM_LIST_ELEM_FIELD_MEMH = UCS_BIT(0), /**< Source memory handle */
-    UCP_DEVICE_MEM_LIST_ELEM_FIELD_RKEY = UCS_BIT(1)  /**< Unpacked remote memory key */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_MEMH   = UCS_BIT(0), /**< Source memory handle */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_RKEY   = UCS_BIT(1), /**< Unpacked remote memory key */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_L_ADDR = UCS_BIT(2), /**< Local address */
+    UCP_DEVICE_MEM_LIST_ELEM_FIELD_R_ADDR = UCS_BIT(3)  /**< Remote address */
 };
 
 
@@ -59,6 +61,16 @@ typedef struct ucp_device_mem_list_elem {
      * Local memory registration handle.
      */
     ucp_mem_h  memh;
+
+    /**
+     * Local address of the memory to be transferred.
+     */
+    void *     l_addr;
+
+    /**
+     * Remote address of the memory to be transferred to.
+     */
+    uint64_t   r_addr;
 
     /**
      * Unpacked memory key for the remote memory endpoint.

--- a/src/ucp/api/device/ucp_host.h
+++ b/src/ucp/api/device/ucp_host.h
@@ -63,12 +63,12 @@ typedef struct ucp_device_mem_list_elem {
     ucp_mem_h  memh;
 
     /**
-     * Local address of the memory to be transferred from.
+     * Local memory address for the device transfer operations.
      */
-    void *     local_addr;
+    void*     local_addr;
 
     /**
-     * Remote address of the memory to be transferred to.
+     * Remote memory address for the device transfer operations.
      */
     uint64_t   remote_addr;
 

--- a/src/ucp/api/device/ucp_host.h
+++ b/src/ucp/api/device/ucp_host.h
@@ -63,7 +63,7 @@ typedef struct ucp_device_mem_list_elem {
     ucp_mem_h  memh;
 
     /**
-     * Local address of the memory to be transferred.
+     * Local address of the memory to be transferred from.
      */
     void *     local_addr;
 


### PR DESCRIPTION
## What?
Add local and remote address fields (`l_addr`, `r_addr`) to `ucp_device_mem_list_elem_t` structure with corresponding field mask flags.

## Why?
Provide the interface definition needed for NIXL development. This establishes the API contract without implementation, allowing NIXL to progress while UCX implementation can be added separately.

## How?
Extended the memory list element structure with two new optional fields controlled by field mask flags (`UCP_DEVICE_MEM_LIST_ELEM_FIELD_L_ADDR`, `UCP_DEVICE_MEM_LIST_ELEM_FIELD_R_ADDR`) to maintain backward compatibility. No functional implementation included - this is interface-only.