### PR TITLE
UCP/RKEY: Pack sender flush flag where applicable.

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -40,7 +40,6 @@ ucp_mem_dummy_handle_t ucp_mem_dummy_handle = {
         .parent         = &ucp_mem_dummy_handle.memh,
         .mem_type       = UCS_MEMORY_TYPE_HOST,
         .sys_dev        = UCS_SYS_DEVICE_ID_UNKNOWN,
-        .packed_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN,
         .md_map         = 0,
         .inv_md_map     = 0,
         .reg_id         = 0,
@@ -727,13 +726,6 @@ static void ucp_memh_init(ucp_mem_h memh, ucp_context_h context,
     memh->alloc_method   = method;
     memh->mem_type       = mem_type;
     memh->sys_dev        = sys_dev;
-
-    /* Cache sys_dev in a format packed to rkey to minimize overhead during
-     * rndv protocols. TODO remove if using another method to mark rkey with
-     * remote flush requirement. */
-    memh->packed_sys_dev = (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ?
-                                   UCS_SYS_DEVICE_ID_UNKNOWN :
-                                   ucp_rkey_pack_sys_dev(memh);
 }
 
 static ucs_status_t

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -36,14 +36,21 @@ enum {
     /*
      * Memory handle was imported and points to some peer's memory buffer.
      */
-    UCP_MEMH_FLAG_IMPORTED     = UCS_BIT(0),
-    UCP_MEMH_FLAG_MLOCKED      = UCS_BIT(1),
-    UCP_MEMH_FLAG_HAS_AUTO_GVA = UCS_BIT(2),
+    UCP_MEMH_FLAG_IMPORTED           = UCS_BIT(0),
+    UCP_MEMH_FLAG_MLOCKED            = UCS_BIT(1),
+    UCP_MEMH_FLAG_HAS_AUTO_GVA       = UCS_BIT(2),
 
     /**
      * Avoid using registration cache for the particular memory region.
      */
-    UCP_MEMH_FLAG_NO_RCACHE    = UCS_BIT(3)
+    UCP_MEMH_FLAG_NO_RCACHE          = UCS_BIT(3),
+
+    /**
+     * Track if sender-side flush is needed, check is only done when needed
+     * and cached.
+     */
+    UCP_MEMH_FLAG_SEND_FLUSH_CHECKED = UCS_BIT(4),
+    UCP_MEMH_FLAG_SEND_FLUSH_NEEDED  = UCS_BIT(5)
 };
 
 
@@ -68,7 +75,6 @@ typedef struct ucp_mem {
     ucp_context_h       context;        /* UCP context that owns a memory handle */
     uct_alloc_method_t  alloc_method;   /* Method used to allocate the memory */
     ucs_sys_device_t    sys_dev;        /* System device index */
-    ucs_sys_device_t    packed_sys_dev; /* System device index */
     ucs_memory_type_t   mem_type;       /* Type of allocated or registered memory */
     ucp_md_index_t      alloc_md_index; /* Index of MD used to allocate the memory */
     uint64_t            remote_uuid;    /* Remote UUID */

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -170,7 +170,8 @@ static int ucp_memh_send_flush_is_needed(ucp_mem_h memh)
             ucs_for_each_bit(sys_dev, sys_dev_map) {
                 if (ucs_topo_is_sibling(sys_dev, memh->sys_dev)) {
                     /*
-                     * PUT operation on such rkey requires remote flush.
+                     * PUT operation on such device will require remote flush
+                     * when using network devices.
                      * Set a flag for the peer to recognize it.
                      */
                     memh->flags |= UCP_MEMH_FLAG_SEND_FLUSH_NEEDED;

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -66,18 +66,18 @@ struct ucp_rkey_config_key {
     /* Remote system device id */
     ucs_sys_device_t       sys_dev;
 
+    /* Rkey specific flags, like @a UCP_RKEY_CONFIG_FLAG_FLUSH */
+    uint8_t                flags;
+
     /* Remote memory type */
     ucs_memory_type_t      mem_type;
 
     /* MDs for which rkey is not reachable */
     ucp_md_map_t           unreachable_md_map;
-
-    /* Rkey specific flags, like @a UCP_RKEY_CONFIG_FLAG_FLUSH */
-    uint8_t                flags;
 };
 
 
-#define UCP_SYS_DEVICE_FLUSH_BIT UCS_BIT(7)
+#define UCP_SYS_DEVICE_FLUSH_BIT  UCS_BIT(7)
 #define UCP_SYS_DEVICE_MAX_PACKED (UCP_SYS_DEVICE_FLUSH_BIT - 1)
 
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -72,7 +72,7 @@ struct ucp_rkey_config_key {
     /* MDs for which rkey is not reachable */
     ucp_md_map_t           unreachable_md_map;
 
-    /* Rkey specific flags, e.g.  */
+    /* Rkey specific flags, like @a UCP_RKEY_CONFIG_FLAG_FLUSH */
     uint8_t                flags;
 };
 

--- a/src/ucp/core/ucp_rkey.h
+++ b/src/ucp/core/ucp_rkey.h
@@ -45,6 +45,15 @@ enum {
 
 
 /**
+ * Rkey config flags
+ */
+enum {
+    UCP_RKEY_CONFIG_FLAG_FLUSH    = UCS_BIT(0)  /* Put and atomic operations on this rkey
+                                                   require remote flush */
+};
+
+
+/**
  * Rkey configuration key
  */
 struct ucp_rkey_config_key {
@@ -62,11 +71,14 @@ struct ucp_rkey_config_key {
 
     /* MDs for which rkey is not reachable */
     ucp_md_map_t           unreachable_md_map;
+
+    /* Rkey specific flags, e.g.  */
+    uint8_t                flags;
 };
 
 
 #define UCP_SYS_DEVICE_FLUSH_BIT UCS_BIT(7)
-#define UCP_SYS_DEVICE_MAX_PACKED UCP_SYS_DEVICE_FLUSH_BIT - 1
+#define UCP_SYS_DEVICE_MAX_PACKED (UCP_SYS_DEVICE_FLUSH_BIT - 1)
 
 
 /**
@@ -242,8 +254,5 @@ void ucp_rkey_config_dump_brief(const ucp_rkey_config_key_t *rkey_config_key,
 void ucp_rkey_proto_select_dump(ucp_worker_h worker,
                                 ucp_worker_cfg_index_t rkey_cfg_index,
                                 ucs_string_buffer_t *strb);
-
-
-ucs_sys_device_t ucp_rkey_pack_sys_dev(ucp_mem_h memh);
 
 #endif

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -20,7 +20,8 @@ ucp_rkey_config_hash_func(ucp_rkey_config_key_t rkey_config_key)
             (rkey_config_key.unreachable_md_map << 32)) ^
            (rkey_config_key.ep_cfg_index << 8) ^
            (rkey_config_key.sys_dev << 16) ^
-           (rkey_config_key.mem_type << 24);
+           (rkey_config_key.mem_type << 24) ^
+           rkey_config_key.flags;
 }
 
 static UCS_F_ALWAYS_INLINE int
@@ -31,6 +32,7 @@ ucp_rkey_config_is_equal(ucp_rkey_config_key_t rkey_config_key1,
            (rkey_config_key1.ep_cfg_index == rkey_config_key2.ep_cfg_index) &&
            (rkey_config_key1.sys_dev == rkey_config_key2.sys_dev) &&
            (rkey_config_key1.mem_type == rkey_config_key2.mem_type) &&
+           (rkey_config_key1.flags == rkey_config_key2.flags) &&
            (rkey_config_key1.unreachable_md_map ==
             rkey_config_key2.unreachable_md_map);
 }
@@ -67,9 +69,7 @@ ucp_ep_rkey_unpack_reachable(ucp_ep_h ep, const void *buffer, size_t length,
 static UCS_F_ALWAYS_INLINE int
 ucp_rkey_need_remote_flush(const ucp_rkey_config_key_t *key)
 {
-    return (key->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
-           (key->sys_dev & UCP_SYS_DEVICE_FLUSH_BIT);
-
+    return key->flags & UCP_RKEY_CONFIG_FLAG_FLUSH;
 }
 
 #endif

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -151,6 +151,9 @@ static ucp_sys_dev_map_t ucp_proto_multi_init_flush_sys_dev_mask(
         return 0;
     }
 
+    ucs_assert(ucp_proto_common_get_iface_attr(&params->super.super, lane)
+                       ->cap.flags &
+               UCT_IFACE_FLAG_GET_BCOPY);
     return UCS_BIT(key->sys_dev);
 }
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -144,16 +144,16 @@ ucp_proto_multi_select_bw_lanes(const ucp_proto_init_params_t *params,
 static ucp_sys_dev_map_t ucp_proto_multi_init_flush_sys_dev_mask(
         const ucp_proto_multi_init_params_t *params, ucp_lane_index_t lane)
 {
-    const ucp_rkey_config_key_t *key = params->super.super.rkey_config_key;
+    const ucp_rkey_config_key_t *key   = params->super.super.rkey_config_key;
+    const uct_iface_attr_t *iface_attr =
+        ucp_proto_common_get_iface_attr(&params->super.super, lane);
 
     if ((key == NULL) || !ucp_rkey_need_remote_flush(key) ||
+        !(iface_attr->cap.flags & UCT_IFACE_FLAG_GET_BCOPY) ||
         !ucp_proto_common_is_net_dev(&params->super.super, lane)) {
         return 0;
     }
 
-    ucs_assert(ucp_proto_common_get_iface_attr(&params->super.super, lane)
-                       ->cap.flags &
-               UCT_IFACE_FLAG_GET_BCOPY);
     return UCS_BIT(key->sys_dev);
 }
 

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -240,6 +240,7 @@ static ucs_status_t ucp_ep_flush_mem_start(ucp_request_t *req)
 
     ep->ext->flush_sys_dev_map = 0;
 
+    req->send.flush.mem.count           = count;
     req->send.flush.mem.started         = 0;
     req->send.uct.func                  = ucp_ep_flush_mem_progress;
     req->send.flush.mem.uct_comp.func   = ucp_ep_flush_mem_completion;

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -158,6 +158,7 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
     rkey_config_key.ep_cfg_index = ep_cfg_index;
     rkey_config_key.sys_dev      = params->super.reg_mem_info.sys_dev;
     rkey_config_key.mem_type     = params->super.reg_mem_info.type;
+    rkey_config_key.flags        = 0;
 
     rkey_config_key.unreachable_md_map = 0;
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -116,6 +116,7 @@ test_ucp_proto::create_rkey_config_key(ucp_md_map_t md_map)
     rkey_config_key.mem_type           = UCS_MEMORY_TYPE_HOST;
     rkey_config_key.sys_dev            = UCS_SYS_DEVICE_ID_UNKNOWN;
     rkey_config_key.unreachable_md_map = 0;
+    rkey_config_key.flags              = 0;
 
     return rkey_config_key;
 }


### PR DESCRIPTION
## What?
Re-use #10804 to:
- Make sure to set sys_dev's flush-needed bit when packing rkey.
- Make sure to only send-flush when sys_dev needs it and the transport uses a network device (avoids cuda_ipc/cuda_copy).

## Tests
With `ucx_perftest` and `nixlbench`, confirmed pattern.