### PR TITLE
UCT/GDA/TEST: add config parameter for gda latency thresh

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -119,6 +119,11 @@ ucs_config_field_t uct_ib_md_config_table[] = {
      "Use GPU Direct RDMA for HCA to access GPU pages directly\n",
      ucs_offsetof(uct_ib_md_config_t, enable_gpudirect_rdma), UCS_CONFIG_TYPE_TERNARY},
 
+    {"GPU_IB_DISTANCE_LATENCY_THRESH", "300ns",
+     "Skip GPU device if the distance latency to the IB device is greater than this value.",
+     ucs_offsetof(uct_ib_md_config_t, ext.gpu_ib_distance_latency_thresh),
+     UCS_CONFIG_TYPE_TIME},
+
     {"PCI_BW", "",
      "Maximum effective data transfer rate of PCI bus connected to HCA\n",
      ucs_offsetof(uct_ib_md_config_t, pci_bw), UCS_CONFIG_TYPE_ARRAY(pci_bw)},

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -109,6 +109,7 @@ typedef struct uct_ib_md_ext_config {
     unsigned long            reg_retry_cnt; /**< Memory registration retry count */
     unsigned                 smkey_block_size; /**< Mkey indexes in a symmetric block */
     int                      direct_nic; /**< Direct NIC with GPU functionality */
+    double                   gpu_ib_distance_latency_thresh; /**< Threshold to filter GPU<->IB distance */
 } uct_ib_md_ext_config_t;
 
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -24,15 +24,15 @@ typedef struct {
 } uct_rc_gdaki_iface_config_t;
 
 ucs_config_field_t uct_rc_gdaki_iface_config_table[] = {
-  {UCT_IB_CONFIG_PREFIX, "", NULL,
-   ucs_offsetof(uct_rc_gdaki_iface_config_t, super),
-   UCS_CONFIG_TYPE_TABLE(uct_rc_iface_common_config_table)},
+    {UCT_IB_CONFIG_PREFIX, "", NULL,
+     ucs_offsetof(uct_rc_gdaki_iface_config_t, super),
+     UCS_CONFIG_TYPE_TABLE(uct_rc_iface_common_config_table)},
 
-  {UCT_IB_CONFIG_PREFIX, "", NULL,
-   ucs_offsetof(uct_rc_gdaki_iface_config_t, mlx5),
-   UCS_CONFIG_TYPE_TABLE(uct_rc_mlx5_common_config_table)},
+    {UCT_IB_CONFIG_PREFIX, "", NULL,
+     ucs_offsetof(uct_rc_gdaki_iface_config_t, mlx5),
+     UCS_CONFIG_TYPE_TABLE(uct_rc_mlx5_common_config_table)},
 
-  {NULL}
+    {NULL}
 };
 
 
@@ -657,7 +657,7 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
         }
 
         /* TODO this logic should be done in UCP */
-        if (dist.latency > 300.0 / UCS_NSEC_PER_SEC) {
+        if (dist.latency > md->super.config.gpu_ib_distance_latency_thresh) {
             continue;
         }
 

--- a/test/gtest/ucp/test_ucp_device.cc
+++ b/test/gtest/ucp/test_ucp_device.cc
@@ -70,6 +70,7 @@ void test_ucp_device::get_test_variants(std::vector<ucp_test_variant> &variants)
 void test_ucp_device::init()
 {
     m_env.push_back(new ucs::scoped_setenv("UCX_CUDA_IPC_ENABLE_SAME_PROCESS", "y"));
+    m_env.push_back(new ucs::scoped_setenv("UCX_IB_GPU_IB_DISTANCE_LATENCY_THRESH", "1000ns"));
     ucp_test::init();
     sender().connect(&receiver(), get_ep_params());
     if (!is_loopback()) {


### PR DESCRIPTION
## What?
Add configuration parameter to enable/disable gda depending on gpu<->nic latency

## Why?
Fixes CI tests
```
[----------] 2 tests from rc_gda/test_ucp_device
[ RUN      ] rc_gda/test_ucp_device.counter/0 <rc,rc_gda,cuda_copy,rocm_copy>
[1758822409.013691] [swx-rdmz-ucx-gpu-01:58403:0]      ucp_device.c:274  UCX  ERROR failed to select lane for local device GPU1
[1758822409.013721] [swx-rdmz-ucx-gpu-01:58403:0]      ucp_device.c:416  UCX  ERROR failed to create handle: No resources are available to initiate the operation
/__w/1/s/contrib/../test/gtest/ucp/test_ucp_device.cc:115: Failure
Error: No resources are available to initiate the operation
/__w/1/s/contrib/../test/gtest/common/test.cc:375: Failure
Failed
Got 2 errors and 0 warnings during the test
[     INFO ] < /__w/1/s/contrib/../src/ucp/core/ucp_device.c:274 failed to select lane for local device GPU1 >
[     INFO ] < /__w/1/s/contrib/../src/ucp/core/ucp_device.c:416 failed to create handle: No resources are available to initiate the operation >
[  FAILED  ] rc_gda/test_ucp_device.counter/0, where GetParam() = rc,rc_gda,cuda_copy,rocm_copy (302 ms)
[ RUN      ] rc_gda/test_ucp_device.put_single/0 <rc,rc_gda,cuda_copy,rocm_copy>
[1758822409.288464] [swx-rdmz-ucx-gpu-01:58403:0]      ucp_device.c:274  UCX  ERROR failed to select lane for local device GPU1
[1758822409.288495] [swx-rdmz-ucx-gpu-01:58403:0]      ucp_device.c:416  UCX  ERROR failed to create handle: No resources are available to initiate the operation
/__w/1/s/contrib/../test/gtest/ucp/test_ucp_device.cc:115: Failure
Error: No resources are available to initiate the operation
/__w/1/s/contrib/../test/gtest/common/test.cc:375: Failure
Failed
```

and

```
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from rc_gda/test_ucp_device_kernel
[ RUN      ] rc_gda/test_ucp_device_kernel.local_counter/0 <rc,rc_gda,cuda_copy,rocm_copy/thread>
[     SKIP ] (could not find device lanes)
[       OK ] rc_gda/test_ucp_device_kernel.local_counter/0 (160 ms)
[ RUN      ] rc_gda/test_ucp_device_kernel.local_counter/1 <rc,rc_gda,cuda_copy,rocm_copy/warp>
[     SKIP ] (could not find device lanes)
[       OK ] rc_gda/test_ucp_device_kernel.local_counter/1 (143 ms)
[----------] 2 tests from rc_gda/test_ucp_device_kernel (303 ms total)
```

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
