### PR TITLE
UCT: Add XDR perf recognition

### DIFF
--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -46,10 +46,10 @@
     _macro(ucp_rndv_get_mtype_proto) \
     _macro(ucp_rndv_ats_proto) \
     _macro(ucp_rndv_rtr_proto) \
+    _macro(ucp_rndv_put_zcopy_proto) \
     _macro(ucp_rndv_rtr_mtype_proto) \
     _macro(ucp_rndv_send_ppln_proto) \
     _macro(ucp_rndv_recv_ppln_proto) \
-    _macro(ucp_rndv_put_zcopy_proto) \
     _macro(ucp_rndv_put_mtype_proto) \
     _macro(ucp_rndv_rkey_ptr_proto) \
     _macro(ucp_rndv_rkey_ptr_mtype_proto) \

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -1092,6 +1092,20 @@ static UCS_F_ALWAYS_INLINE int uct_ep_op_is_zcopy(uct_ep_operation_t op)
                           UCS_BIT(UCT_EP_OP_EAGER_ZCOPY));
 }
 
+static UCS_F_ALWAYS_INLINE int uct_ep_op_is_get(uct_ep_operation_t op)
+{
+    return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_GET_SHORT) |
+                          UCS_BIT(UCT_EP_OP_GET_BCOPY) |
+                          UCS_BIT(UCT_EP_OP_GET_ZCOPY));
+}
+
+static UCS_F_ALWAYS_INLINE int uct_ep_op_is_put(uct_ep_operation_t op)
+{
+    return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_PUT_SHORT) |
+                          UCS_BIT(UCT_EP_OP_PUT_BCOPY) |
+                          UCS_BIT(UCT_EP_OP_PUT_ZCOPY));
+}
+
 static UCS_F_ALWAYS_INLINE int uct_ep_op_is_fetch(uct_ep_operation_t op)
 {
     return UCS_BIT(op) & (UCS_BIT(UCT_EP_OP_GET_SHORT) |

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -59,6 +59,7 @@ enum {
     UCT_IB_SPEED_EDR     = 32,
     UCT_IB_SPEED_HDR     = 64,
     UCT_IB_SPEED_NDR     = 128,
+    UCT_IB_SPEED_XDR     = 256,
     UCT_IB_SPEED_LAST
 };
 
@@ -802,6 +803,29 @@ uct_ib_wc_to_ucs_status(enum ibv_wc_status status)
     default:
         return UCS_ERR_IO_ERROR;
     }
+}
+
+static UCS_F_ALWAYS_INLINE uint32_t
+uct_ib_iface_port_active_speed(uct_ib_iface_t *iface)
+{
+#if HAVE_STRUCT_IBV_PORT_ATTR_ACTIVE_SPEED_EX
+    if (uct_ib_iface_port_attr(iface)->active_speed_ex != 0) {
+        return uct_ib_iface_port_attr(iface)->active_speed_ex;
+    }
+#endif
+    return uct_ib_iface_port_attr(iface)->active_speed;
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_ib_iface_port_is_ndr(uct_ib_iface_t *iface)
+{
+    return uct_ib_iface_port_active_speed(iface) == UCT_IB_SPEED_NDR;
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_ib_iface_port_is_xdr(uct_ib_iface_t *iface)
+{
+    return uct_ib_iface_port_active_speed(iface) == UCT_IB_SPEED_XDR;
 }
 
 #endif

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -233,6 +233,9 @@ AS_IF([test "x$with_ib" = "xyes"],
                          struct ibv_device_attr_ex.odp_caps],
                         [], [], [[#include <infiniband/verbs.h>]])
 
+       AC_CHECK_MEMBERS([struct ibv_port_attr.active_speed_ex],
+                        [], [], [[#include <infiniband/verbs.h>]])
+
        AC_CHECK_DECLS([IBV_ACCESS_RELAXED_ORDERING,
                        IBV_ACCESS_ON_DEMAND,
                        IBV_QPF_GRH_REQUIRED],

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -914,8 +914,7 @@ static ucs_status_t uct_dc_mlx5_iface_estimate_perf(uct_iface_h tl_iface,
     }
 
     if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
-        if (uct_ib_iface_port_attr(ib_iface)->active_speed ==
-            UCT_IB_SPEED_NDR) {
+        if (uct_ib_iface_port_is_ndr(ib_iface)) {
             perf_attr->flags |= UCT_PERF_ATTR_FLAGS_TX_RX_SHARED;
         }
     }


### PR DESCRIPTION
## What?
- Add recognition of XDR speed
- Initialize put_zcopy protocol before send_ppln/put_mtype, so that put_zcopy would be selected if they both have the same bandwidth