### PR TITLE
UCP: Remove single net dev filtering for single proto

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -152,37 +152,6 @@ ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
     return params->worker->context->tl_rscs[rsc_index].tl_rsc.sys_device;
 }
 
-int ucp_proto_common_add_unique_sys_dev(ucs_sys_device_t sys_dev,
-                                        ucs_sys_device_t *sys_devs,
-                                        ucp_lane_index_t *num_sys_devs,
-                                        ucp_lane_index_t max_sys_devs)
-{
-    ucp_lane_index_t i;
-
-    for (i = 0; i < *num_sys_devs; ++i) {
-        if (sys_dev == sys_devs[i]) {
-            return 0; /* Already exists */
-        }
-    }
-
-    if (*num_sys_devs < max_sys_devs) {
-        sys_devs[(*num_sys_devs)++] = sys_dev;
-        return 1; /* Added */
-    }
-
-    return 0; /* No space */
-}
-
-ucp_lane_index_t
-ucp_proto_common_select_sys_dev_by_node_id(const ucp_proto_init_params_t *params,
-                                           ucp_lane_index_t num_sys_devs)
-{
-    if (num_sys_devs == 0) {
-        return 0;
-    }
-    return params->worker->context->config.node_local_id % num_sys_devs;
-}
-
 /* Pack/unpack local distance to make it equal to the remote one */
 static void
 ucp_proto_common_fp8_pack_unpack_distance(ucs_sys_dev_distance_t *distance)

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -255,15 +255,6 @@ ucs_sys_device_t
 ucp_proto_common_get_sys_dev(const ucp_proto_init_params_t *params,
                              ucp_lane_index_t lane);
 
-int ucp_proto_common_add_unique_sys_dev(ucs_sys_device_t sys_dev,
-                                        ucs_sys_device_t *sys_devs,
-                                        ucp_lane_index_t *num_sys_devs,
-                                        ucp_lane_index_t max_sys_devs);
-
-ucp_lane_index_t
-ucp_proto_common_select_sys_dev_by_node_id(const ucp_proto_init_params_t *params,
-                                           ucp_lane_index_t num_sys_devs);
-
 
 void ucp_proto_common_get_lane_distance(const ucp_proto_init_params_t *params,
                                         ucp_lane_index_t lane,

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -181,16 +181,22 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         }
 
         sys_dev = ucp_proto_common_get_sys_dev(params, lane);
-        ucp_proto_common_add_unique_sys_dev(sys_dev, sys_devs, &num_max_bw_devs,
-                                            UCP_PROTO_MAX_LANES);
+        for (i = 0; i < num_max_bw_devs; ++i) {
+            if (sys_dev == sys_devs[i]) {
+                break;
+            }
+        }
+
+        if (i == num_max_bw_devs) {
+            sys_devs[num_max_bw_devs++] = sys_dev;
+        }
     }
 
     if (num_max_bw_devs == 0) {
         return num_lanes;
     }
 
-    seed = ucp_proto_common_select_sys_dev_by_node_id(params, num_max_bw_devs);
-
+    seed = params->worker->context->config.node_local_id % num_max_bw_devs;
     for (i = !!fixed_first_lane, num_filtered_lanes = i; i < num_lanes; ++i) {
         lane   = lanes[i];
         tl_rsc = ucp_proto_common_get_tl_rsc(params, lane);


### PR DESCRIPTION
## What?
Follow up on #10870 - do not do single net filtering for single protos
