### PR TITLE
UCT/GDAKI: Read updated qp pi on reserve wqe

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -97,7 +97,9 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_max_alloc_wqe_base(
 {
     /* TODO optimize by including sq_wqe_num in qp->sq_wqe_pi and updating it
        when processing a new completion */
-    return ep->sq_wqe_pi + ep->sq_wqe_num - count;
+    uint64_t pi = doca_gpu_dev_verbs_atomic_read<uint64_t,
+            DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(&ep->sq_wqe_pi);
+    return pi + ep->sq_wqe_num - count;
 }
 
 UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(


### PR DESCRIPTION
Outdated pis break the rollback logic in reserve
wqe, since the following might happen:

1. thread 1 secures wqe_idx and sets sq ready idx
to wqe_idx + 1, reads outdated pi and thinks wqe_idx
is outside the valid range- enters rollback loop

2. thread 2 secures wqe_idx + 1 and sets sq ready idx
to wqe_idx + 2, reads updated pi and sees that
wqe_idx + 1 is valid- never enters rollback loop

Now thread 1 is stuck waiting for sq_ready_idx to be
rolled back to wqe_idx + 1, which will never happen,
and it will also never notice that the qp has freed up
since it reads outdated sq_wqe_idx