### PR TITLE
UCP/PROTO: Prefer interfaces closer to memory

### DIFF
--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -350,7 +350,7 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
     ucs_sys_dev_distance_t distance;
     size_t tl_min_frag, tl_max_frag;
     uct_perf_attr_t perf_attr;
-    ucs_sys_device_t sys_dev;
+    ucs_sys_device_t sys_dev, device_sys_dev;
     ucs_status_t status;
     char bdf_name[32];
 
@@ -427,6 +427,15 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                 ucs_topo_sys_device_get_name(sys_dev),
                 ucs_topo_sys_device_bdf_name(sys_dev, bdf_name,
                                              sizeof(bdf_name)));
+
+        /* Add bandwidth for interfaces very close to the memory. */
+        device_sys_dev = ucp_proto_common_get_tl_rsc(&params->super, lane)->sys_device;
+        if ((sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+            (device_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+            (sys_dev != device_sys_dev) &&
+            ucs_topo_is_pci_bridge(device_sys_dev, sys_dev)) {
+            tl_perf->bandwidth *= 1.2;
+        }
     }
 
     /* For remote memory access, consider remote system topology distance */

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -832,7 +832,7 @@ ucs_numa_node_t ucs_topo_sys_device_get_numa_node(ucs_sys_device_t sys_dev)
  * @return 1 if the devices share a PCI bridge, 0 otherwise. Returns 0 the
  *         devices are the same.
  */
-static int
+int
 ucs_topo_is_pci_bridge(ucs_sys_device_t sys_dev1, ucs_sys_device_t sys_dev2)
 {
     ucs_status_t status;

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -358,6 +358,11 @@ void ucs_topo_init(void);
  */
 void ucs_topo_cleanup(void);
 
+/**
+ * Check if two system devices share a PCI bridge.
+ */
+int ucs_topo_is_pci_bridge(ucs_sys_device_t sys_dev1, ucs_sys_device_t sys_dev2);
+
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
## What?
Prefer interfaces that are closer to the memory to send. We go from 15GB/s to 357GB/s in some cases.

## Why?
Some systems have HCAs and a GPU under the same PCI bridge. In that case, although all interfaces have same bandwidth, protocol selection should first select those. This is particularly true when using multiple GPUs with pairwise traffic (GPUx to remote GPUx), where traffic should remain on sibling interfaces.

## How?
The code fetches the interfaces bandwidth and checks if it needs to further restrict it due to system topology (three values infinite/17GBs/0.2GBs/). In case of slower interfaces (11GBs) this does not work and we cannot discriminate interfaces under same PCI bridge or not.

Proposal is to boost bandwidth in such case but ideally bw/lat/distance and even partitioning of the traffic should be taken into account. We could also have proto selection not rely only on raw bw.