### PR TITLE
TEST/UCP/DEVICE: Fix device API test wireup

### DIFF
--- a/test/gtest/ucp/test_ucp_device.cc
+++ b/test/gtest/ucp/test_ucp_device.cc
@@ -8,7 +8,6 @@
 #include <ucp/ucp_test.h>
 
 #include <ucp/api/device/ucp_device_types.h>
-#include <ucp/core/ucp_ep.h>
 
 #include <common/cuda.h>
 #include "cuda/test_kernels.h"
@@ -78,10 +77,8 @@ void test_ucp_device::init()
         receiver().connect(&sender(), get_ep_params());
     }
 
-    /* Wait for endpoint to complete wireup by checking the REMOTE_CONNECTED flag */
-    while (!(sender().ep()->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
-        progress();
-    }
+    /* Flush to ensure endpoint wireup is complete before device API usage */
+    flush_ep(sender());
 }
 
 test_ucp_device::mem_list::mem_list(entity &sender, entity &receiver,


### PR DESCRIPTION
## What?
Fix wireup issue in `test_ucp_device` initialization.

## Why?
CI is failing on https://github.com/openucx/ucx/pull/10921 which adds error logging to device APIs. The test's init() function was waiting for endpoint wireup by calling ucp_device_mem_list_create() with NULL params in a loop. This caused multiple error logs ("ep didn't complete wireup" and "check parameters failed") to be printed during normal test initialization. Without error logging these were silent, but PR #10921's improved logging now exposes these errors, causing test failures.

## How?
Used flush_ep() to ensure endpoint wireup is fully complete before tests create device memory lists.