### PR TITLE
UCT/IB/ROCE: Use ipv6 non link-local GID in priority

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -22,6 +22,7 @@
 #include <ucs/sys/sock.h>
 #include <ucs/sys/sys.h>
 #include <sys/poll.h>
+#include <netinet/in.h>
 #include <libgen.h>
 #include <pthread.h>
 #include <sched.h>
@@ -851,7 +852,7 @@ const char *uct_ib_gid_str(const union ibv_gid *gid, char *str, size_t max_size)
 
 static int uct_ib_gid_is_ipv6_ll(const union ibv_gid *gid)
 {
-    return ((gid->raw[0] == 0xfe) && ((gid->raw[1] & 0xc0) == 0x80));
+    return IN6_IS_ADDR_LINKLOCAL((struct in6_addr *)gid);
 }
 
 static int uct_ib_device_is_addr_ipv4_mcast(const struct in6_addr *raw,
@@ -1081,14 +1082,14 @@ uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
     static const size_t max_str_len                     = 200;
     struct {
         uct_ib_roce_version_info_t info;
-        int                        skip_ll; /* link-local not allowed when true */
+        int                        allow_ll; /* link-local allowed when true */
     } roce_prio[] = {
-        {{UCT_IB_DEVICE_ROCE_V2, AF_INET}},
+        {{UCT_IB_DEVICE_ROCE_V2, AF_INET},  1},
+        {{UCT_IB_DEVICE_ROCE_V2, AF_INET6}, 0},
         {{UCT_IB_DEVICE_ROCE_V2, AF_INET6}, 1},
-        {{UCT_IB_DEVICE_ROCE_V2, AF_INET6}},
-        {{UCT_IB_DEVICE_ROCE_V1, AF_INET}},
-        {{UCT_IB_DEVICE_ROCE_V1, AF_INET6}, 1},
-        {{UCT_IB_DEVICE_ROCE_V1, AF_INET6}}
+        {{UCT_IB_DEVICE_ROCE_V1, AF_INET},  1},
+        {{UCT_IB_DEVICE_ROCE_V1, AF_INET6}, 0},
+        {{UCT_IB_DEVICE_ROCE_V1, AF_INET6}, 1}
     };
     int gid_tbl_len         = uct_ib_device_port_attr(dev, port_num)->gid_tbl_len;
     ucs_status_t status     = UCS_OK;
@@ -1120,7 +1121,7 @@ uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
 
             if ((roce_prio[prio_idx].info.ver         == gid_info_tmp.roce_info.ver) &&
                 (roce_prio[prio_idx].info.addr_family == gid_info_tmp.roce_info.addr_family) &&
-                (!roce_prio[prio_idx].skip_ll || !uct_ib_gid_is_ipv6_ll(&gid_info_tmp.gid)) &&
+                (roce_prio[prio_idx].allow_ll || !uct_ib_gid_is_ipv6_ll(&gid_info_tmp.gid)) &&
                 uct_ib_device_test_roce_gid_index(dev, port_num, &gid_info_tmp.gid, i) &&
                 uct_ib_device_match_roce_subnet(&gid_info_tmp, &subnets,
                                                 subnet_strs->mode)) {


### PR DESCRIPTION
## What?
When selecting RoCE GID, search for IPv6 non link-local before trying to use IPv6 link-local GID.

## Why?
Some clusters only have `gid_index=3` usable. Manually setting `UCX_IB_GID_INDEX=3` is cumbersome and error-prone.

## How?
Relevant cli: `show_gids`. Tested on two clusters:
```
UCX_LOG_LEVEL=debug ./rfs/bin/ucx_perftest -l -t ucp_put_bw | grep gid_index

# For all interfaces (mlx5_x/roce_railsx):
UCX_NET_DEVICES=mlx5_0:1 UCX_PROTO_INFO=y ./rfs/bin/ucx_perftest -l -t ucp_put_bw
UCX_NET_DEVICES=mlx5_0:1 UCX_PROTO_INFO=y ./rfs/bin/ucx_perftest -t ucp_put_bw remote-node
```