### PR TITLE
DEVICE: Document UCS_INPROGRESS return status for device APIs

### DIFF
--- a/src/ucp/api/device/ucp_device_impl.h
+++ b/src/ucp/api/device/ucp_device_impl.h
@@ -133,6 +133,9 @@ UCS_F_DEVICE ucs_status_t ucp_device_prepare_send(
  * @param [in]  flags           Flags usable to modify the function behavior.
  * @param [out] req             Request populated by the call.
  *
+ * @return UCS_INPROGRESS     - Operation successfully posted. If @a req is not
+ *                              NULL, use @ref ucp_device_progress_req to check
+ *                              for completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
@@ -188,6 +191,9 @@ UCS_F_DEVICE ucs_status_t ucp_device_put_single(
  * @param [in]  flags           Flags usable to modify the function behavior.
  * @param [out] req             Request populated by the call.
  *
+ * @return UCS_INPROGRESS     - Operation successfully posted. If @a req is not
+ *                              NULL, use @ref ucp_device_progress_req to check
+ *                              for completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
@@ -243,6 +249,10 @@ UCS_F_DEVICE ucs_status_t ucp_device_counter_inc(
  * @param [in]  flags                  Flags to modify the function behavior.
  * @param [out] req                    Request populated by the call.
  *
+ * @return UCS_INPROGRESS            - Operation successfully posted. If @a req
+ *                                     is not NULL, use @ref
+ *                                     ucp_device_progress_req to check for
+ *                                     completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
@@ -321,6 +331,10 @@ UCS_F_DEVICE ucs_status_t ucp_device_put_multi(
  * @param [in]  flags                  Flags to modify the function behavior.
  * @param [out] req                    Request populated by the call.
  *
+ * @return UCS_INPROGRESS            - Operation successfully posted. If @a req
+ *                                     is not NULL, use @ref
+ *                                     ucp_device_progress_req to check for
+ *                                     completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
@@ -410,7 +424,7 @@ UCS_F_DEVICE void ucp_device_counter_write(void *counter_ptr, uint64_t value)
  *
  * @tparam      level  Level of cooperation of the transfer.
  * @param [in]  req    Request containing operations in progress and channel to progress.
- * 
+ *
  * @return UCS_OK           - The request has completed, no more operations are
  *                            in progress.
  * @return UCS_INPROGRESS   - One or more operations in the request batch

--- a/src/uct/api/device/uct_device_impl.h
+++ b/src/uct/api/device/uct_device_impl.h
@@ -42,6 +42,10 @@ union uct_device_completion {
  * @param [in]  flags           Flags to modify the function behavior.
  * @param [in]  comp            Completion object to track the progress of operation.
  *
+ * @return UCS_INPROGRESS     - Operation successfully posted, use @ref
+ *                              uct_device_ep_progress and @ref
+ *                              uct_device_ep_check_completion to
+ *                              check for completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level>
@@ -83,6 +87,10 @@ UCS_F_DEVICE ucs_status_t uct_device_ep_put_single(
  * @param [in]  flags           Flags to modify the function behavior.
  * @param [in]  comp            Completion object to track the progress of operation.
  *
+ * @return UCS_INPROGRESS      - Operation successfully posted, use @ref
+ *                               uct_device_ep_progress and @ref
+ *                               uct_device_ep_check_completion to check
+ *                               for completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level>
@@ -139,6 +147,10 @@ UCS_F_DEVICE ucs_status_t uct_device_ep_atomic_add(
  * @param [in]  flags                  Flags to modify the function behavior.
  * @param [out] req                    Request populated by the call.
  *
+ * @return UCS_INPROGRESS            - Operation successfully posted, use @ref
+ *                                     uct_device_ep_progress and @ref
+ *                                     uct_device_ep_check_completion to check
+ *                                     for completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level>
@@ -215,6 +227,10 @@ UCS_F_DEVICE ucs_status_t uct_device_ep_put_multi(
  * @param [in]  flags                  Flags to modify the function behavior.
  * @param [in]  comp                   Completion object to track progress.
  *
+ * @return UCS_INPROGRESS            - Operation successfully posted, use @ref
+ *                                     uct_device_ep_progress and @ref
+ *                                     uct_device_ep_check_completion to check
+ *                                     for completion.
  * @return Error code as defined by @ref ucs_status_t
  */
 template<ucs_device_level_t level>


### PR DESCRIPTION
## What?
Update UCT and UCP device API documentation to specify that send operations return `UCS_INPROGRESS` when successfully posted.

## Why?
The device send functions now return `UCS_INPROGRESS` after posting operations, but the documentation only stated generic "Error code as defined by ucs_status_t" without clarifying the expected return values or that completion checking is required.

## How?
Added explicit `@return UCS_INPROGRESS` documentation to all device send functions (put_single, atomic_add, put_multi, put_multi_partial) at both UCT and UCP layers, clarifying that callers must use progress/completion APIs to check for operation completion.
