### PR TITLE
AZP: Add Rocky OS to Build stage

### DIFF
--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -45,6 +45,10 @@ jobs:
             CONTAINER: rhel90
           rhel100:
             CONTAINER: rhel100
+          rocky89:
+            CONTAINER: rocky89
+          rocky96:
+            CONTAINER: rocky96
           fedora41:
             CONTAINER: fedora41
           centos7:
@@ -66,6 +70,10 @@ jobs:
             CONTAINER: ubuntu2404_aarch64
           rhel100_aarch64:
             CONTAINER: rhel100_aarch64
+          rocky89_aarch64:
+            CONTAINER: rocky89_aarch64
+          rocky96_aarch64:
+            CONTAINER: rocky96_aarch64
     timeoutInMinutes: 340
 
     steps:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -42,6 +42,18 @@ resources:
     - container: rhel100_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/rhel10.0/builder:mofed-25.07-0.9.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: rocky89
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/rocky8.9/builder:mofed-24.10-3.2.5.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: rocky96
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/rocky9.6/builder:mofed-24.10-3.2.5.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: rocky89_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/rocky8.9/builder:mofed-24.10-3.2.5.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: rocky96_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/rocky9.6/builder:mofed-24.10-3.2.5.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu2004
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu20.04/builder:mofed-5.0-1.0.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)


### PR DESCRIPTION
## What?
Add Rocky Linux 8 and 9 to PR Build stage (x86_64 and aarch64).

## Why?
Customer requirement for Rocky Linux support.

## How?
Built HPCX builder images (rocky8.9/rocky9.6 with MOFED 24.10-3.2.5.0) for both architectures and integrated them into the UCX PR Build stage.

### Depends on https://github.com/openucx/ucx/pull/10941