### PR TITLE
UCP/WIREUP: Allow self endpoint to skip a device lane.

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2483,7 +2483,12 @@ ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
     found_lane = ucp_wireup_add_bw_lanes(select_params, &bw_info,
                                          mem_type_tl_bitmap, UCP_NULL_LANE,
                                          select_ctx, 0);
-    if (!found_lane) {
+    /*
+     * Allow self endpoint to skip a device lane, as it might only be used
+     * for memory type-based copy.
+     */
+    if (!found_lane &&
+        (select_params->address->uuid != select_params->ep->worker->uuid)) {
         ucs_error("could not find device lanes");
         return UCS_ERR_UNREACHABLE;
     }


### PR DESCRIPTION
## What?
Fix perftest failure with `cuda_ipc` but without `rc_gda` on device tests.

## Why?
Workaround: Allow self endpoints to miss a device lane (`UCP_FEATURE_DEVICE`). This can happen with `UCX_TLS=^rc_gda` as `cuda_ipc` does not support same process lane.

## How
`ucx_perftest` uses a self endpoint to copy SN on non-host memory (for instance, ucp_put_lat, to copy the sn). This self endpoint shares the same worker containing the device feature request, hence triggers failure. Using separate context and worker without `UCP_FEATURE_DEVICE` would mean that we need to register the memory both on `context` and `context_self`, which does not seem completely impossible.

Repro:
```
UCX_NET_DEVICES=ens10f0 UCX_TLS=tcp,cuda ucx_perftest \
  -m cuda -a cuda:0 -t ucp_put_single_bw -w 1000 -n 100000 -s 8 -T 32 localhost
```