### PR TITLE
AZP/COVERITY: raise aggressiveness level to medium

### DIFF
--- a/buildlib/tools/coverity.sh
+++ b/buildlib/tools/coverity.sh
@@ -102,7 +102,7 @@ run_coverity() {
 	if [ "${ucx_build_type}" == "devel" ]; then
 		cov-manage-emit --dir $cov_build --tu-pattern "file('.*/test/gtest/common/googletest/*')" delete || :
 	fi
-	cov-analyze --jobs $parallel_jobs $COV_OPT --disable PARSE_ERROR --security --concurrency --dir $cov_build
+	cov-analyze --jobs $parallel_jobs $COV_OPT --disable PARSE_ERROR --security --concurrency --dir $cov_build --aggressiveness-level medium
 	nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')
 
 	if [ $nerrors -gt 0 ]; then


### PR DESCRIPTION
## What?
Increase Coverity static analysis aggressiveness level to medium in `buildlib/tools/coverity.sh`.

## Why?
By default, `cov-analyze` uses the 'low' aggressiveness level, which provides less comprehensive analysis. Raising it to 'medium' enables more thorough static analysis to catch additional potential issues.

## How?
Added `--aggressiveness-level medium` option to the `cov-analyze` command.