### PR TITLE
DEVICE/TEST: Fix compilation error in test_kernels.cu

### DIFF
--- a/test/gtest/ucp/cuda/test_kernels.cu
+++ b/test/gtest/ucp/cuda/test_kernels.cu
@@ -156,7 +156,8 @@ ucp_test_kernel(const test_ucp_device_kernel_params_t params,
                 test_ucp_device_kernel_result_t *result_ptr)
 {
     /* Execute fence on any return, to ensure result is visible to the host */
-    scope_guard fence(__threadfence_system);
+    auto fence_func = []() { __threadfence_system(); };
+    scope_guard<decltype(fence_func)> fence(fence_func);
     ucs_status_t &status = result_ptr->status;
 
     if (blockDim.x > device_request<level>::MAX_THREADS) {


### PR DESCRIPTION
# What?
Fix compilation error in CUDA test kernel due to missing template argument for `scope_guard`.

## Why?
NVCC doesn't support Class Template Argument Deduction (CTAD) in device code, causing compilation to fail with:
```
/hpc/newhome/mshalev/workspace/gdaki/ucx/contrib/../test/gtest/ucp/cuda/test_kernels.cu(159): error: argument list for class template "scope_guard" is missing
      scope_guard fence(__threadfence_system);
      ^
```

1 error detected in the compilation of "/hpc/newhome/mshalev/workspace/gdaki/ucx/contrib/../test/gtest/ucp/cuda/test_kernels.cu".

## How?
Explicitly specify the template parameter using `decltype` and store the lambda in a named variable to pass by reference to the `scope_guard` constructor.
