### PR TITLE
UCT/CUDA: add loop unroll for warp copy

### DIFF
--- a/test/gtest/ucp/test_ucp_device.cc
+++ b/test/gtest/ucp/test_ucp_device.cc
@@ -256,7 +256,7 @@ UCS_TEST_P(test_ucp_device, create_fail)
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device, rc_gda, "rc,rc_gda")
-
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device, cuda_ipc, "rc,cuda_copy,cuda_ipc")
 
 class test_ucp_device_kernel : public test_ucp_device {
 public:
@@ -347,7 +347,8 @@ UCS_TEST_P(test_ucp_device_kernel, local_counter)
 
 UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device_kernel, rc_gda,
                                         "rc,rc_gda")
-
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device_kernel, cuda_ipc,
+                                        "rc,cuda_copy,cuda_ipc")
 
 class test_ucp_device_xfer : public test_ucp_device_kernel {
 public:
@@ -640,3 +641,5 @@ UCS_TEST_P(test_ucp_device_xfer, counter)
 
 UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device_xfer, rc_gda,
                                         "rc,rc_gda")
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_device_xfer, cuda_ipc,
+                                        "rc,cuda_copy,cuda_ipc")

--- a/test/gtest/uct/cuda/test_cuda_ipc_device.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_device.cc
@@ -53,7 +53,6 @@ protected:
     CUdevice m_cuda_dev;
     static const uint64_t SEED1     = 0xABClu;
     static const uint64_t SEED2     = 0xDEFlu;
-    static const unsigned WARP_SIZE = 32;
 };
 
 UCS_TEST_P(test_cuda_ipc_rma, has_device_ep_capability)


### PR DESCRIPTION
## What?
Implement loop unrolling for device level warp in cuda_ipc 

## Why?
Improves put performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved CUDA IPC copy paths with a generic, alignment-aware mechanism and unified warp/thread handling for more reliable and efficient device-side memory operations.
  * Added multi-level copy support enabling optimized behavior for different execution scopes.

* **Tests**
  * Expanded CUDA IPC test coverage across multiple suites to validate the updated memory-paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->