### PR TITLE
GGA: Remove XGVMI assertion

### DIFF
--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -852,9 +852,11 @@ uct_gga_mlx5_query_tl_devices(uct_md_h md,
         return UCS_ERR_NO_DEVICE;
     }
 
-    ucs_assertv(mlx5_md->super.cap_flags & UCT_MD_FLAG_EXPORTED_MKEY,
-                "md %p: cap_flags=0x%" PRIx64 " do not have EXPORTED_MKEY flag",
-                mlx5_md, mlx5_md->super.cap_flags);
+    if (!(mlx5_md->super.cap_flags & UCT_MD_FLAG_EXPORTED_MKEY)) {
+        ucs_debug("md %p: cap_flags=0x%" PRIx64 " does not have EXPORTED_MKEY "
+                  "flag", mlx5_md, mlx5_md->super.cap_flags);
+        return UCS_ERR_NO_DEVICE;
+    }
 
     ucs_assertv(ucs_test_all_flags(mlx5_md->flags, UCT_GGA_MLX5_MD_CAPS),
                 "md %p: flags=0x%x do not have mandatory capabilities 0x%x",


### PR DESCRIPTION
## What?
In PR https://github.com/openucx/ucx/pull/10476 I introduced an assertion to GGA that checks whether XGVMI capability is effectively enabled. However on DFW cluster (CX7 NIC) this is not the case, which leads to failing assertion.

## Why?
XGVMI support is advertised, but when UCX tries to actually allow XGVMI access on some dummy key, then it fails with syndrome `0x172DF6`, which corresponds to:
```
cmdif_checks_advanced.c:819:            return CMDIF_STATUS(BAD_PARAM,0x172DF6); // check_allow_other_vhca_access_mkey: unsupported mkey type
``` 
So XGVMI is not effectively supported on that platform

## How?
The fix is to convert an assertion into the if condition, which returns NO_DEVICE if device does not support XGVMI
