### PR TITLE
GTEST: Enable stress tests.

### DIFF
--- a/test/gtest/ucp/test_ucp_device.cc
+++ b/test/gtest/ucp/test_ucp_device.cc
@@ -570,7 +570,7 @@ UCS_TEST_P(test_ucp_device_xfer, put_single)
 
 /* TODO: Enable these tests in CI */
 UCS_TEST_SKIP_COND_P(test_ucp_device_xfer, put_single_stress_test,
-                     RUNNING_ON_VALGRIND || true)
+                     RUNNING_ON_VALGRIND)
 {
 #ifdef __SANITIZE_ADDRESS__
     UCS_TEST_SKIP_R("Skipping stress test under ASAN");
@@ -624,7 +624,7 @@ UCS_TEST_P(test_ucp_device_xfer, put_multi)
 }
 
 UCS_TEST_SKIP_COND_P(test_ucp_device_xfer, put_multi_stress_test,
-                     RUNNING_ON_VALGRIND || true)
+                     RUNNING_ON_VALGRIND)
 {
 #ifdef __SANITIZE_ADDRESS__
     UCS_TEST_SKIP_R("Skipping stress test under ASAN");


### PR DESCRIPTION
## What?
Enable device API stress tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled stress testing by default in standard environments, improving test coverage and reliability assurance across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->