### PR TITLE
UCT/GDA: Check that nvidia peermem driver is loaded.

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -669,7 +669,6 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
                 ucs_diag("GDAKI not supported, please load "
                          "Nvidia peermem driver by running "
                          "\"modprobe nvidia_peermem\"");
-                peermem_loaded = 0;
             }
         }
 


### PR DESCRIPTION
## What?
Check if nvidia_peermem driver is loaded at runtime while query tls

## Why?
When running with gda it requires nvidia_peermem driver to be loaded.
Need to check it at runtime before attempting to open the iface.

## How?
Use result of peer mem driver check from ib_md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device detection to verify NVIDIA peermem driver availability and skip devices when unsupported.
  * Emit a single diagnostic hint per process to guide users when the required driver is not loaded, avoiding repeated messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->