### PR TITLE
UCT/DEVICE: optimize doorbell ring

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -15,7 +15,7 @@
 #define UCT_RC_GDA_RESV_WQE_NO_RESOURCE -1ULL
 #define UCT_RC_GDA_WQE_ERR              UCS_BIT(63)
 #define UCT_RC_GDA_WQE_MASK             UCS_MASK(63)
-
+#define UCT_RC_GDA_DB_BATCH_SIZE        128
 
 UCS_F_DEVICE void *
 uct_rc_mlx5_gda_get_wqe_ptr(uct_rc_gdaki_dev_ep_t *ep, uint16_t wqe_idx)
@@ -263,13 +263,28 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep,
     const uint64_t wqe_base_orig = wqe_base;
 
     __threadfence();
+    /*
+     * Spin until sq_ready_index reaches wqe_base, then atomically advance to
+     * wqe_next to mark WQEs ready in order.
+     * If the spin fails, reset wqe_base to the original value and try again.
+     */
     while (!ref.compare_exchange_strong(wqe_base, wqe_next,
                                         cuda::std::memory_order_relaxed)) {
         wqe_base = wqe_base_orig;
     }
 
+    /*
+     * Ring doorbell when:
+     * - NODELAY: sq_ready_index reaches wqe_next (coalesce multiple threads)
+     * - Normal: crossing UCT_RC_GDA_DB_BATCH_SIZE boundary (batch updates)
+     *
+     * Note: sq_ready_index is read twice:
+     * - Lock-free check outside lock avoids contention when condition not met.
+     * - Inside lock, skip doorbell if sq_db_index already matches ready_index
+     *   (another thread already rang it).
+     */
     if ((no_delay && READ_ONCE(ep->sq_ready_index) == wqe_next) ||
-        (!no_delay && ((wqe_base ^ wqe_next) & 128))) {
+        (!no_delay && ((wqe_base ^ wqe_next) & UCT_RC_GDA_DB_BATCH_SIZE))) {
         uct_rc_mlx5_gda_lock(&ep->sq_lock);
         const uint64_t ready_index = ep->sq_ready_index;
         if (ep->sq_db_index != ready_index) {

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -269,10 +269,12 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep,
     }
 
     if (no_delay) {
+        uct_rc_mlx5_gda_lock(&ep->sq_lock);
         const uint64_t ready_index = ep->sq_ready_index;
         uct_rc_mlx5_gda_ring_db(ep, ready_index);
         uct_rc_mlx5_gda_update_dbr(ep, ready_index);
         uct_rc_mlx5_gda_ring_db(ep, ready_index);
+        uct_rc_mlx5_gda_unlock(&ep->sq_lock);
         return;
     }
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -258,7 +258,7 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep,
 {
     cuda::atomic_ref<uint64_t, cuda::thread_scope_device> ref(
             ep->sq_ready_index);
-    const uint64_t wqe_num = __ldg(&ep->sq_wqe_num);
+    const bool no_delay = (flags & UCT_DEVICE_FLAG_NODELAY);
     const uint64_t wqe_next = wqe_base + count;
     const uint64_t wqe_base_orig = wqe_base;
 
@@ -268,9 +268,17 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep,
         wqe_base = wqe_base_orig;
     }
 
+    if (no_delay) {
+        const uint64_t ready_index = ep->sq_ready_index;
+        uct_rc_mlx5_gda_ring_db(ep, ready_index);
+        uct_rc_mlx5_gda_update_dbr(ep, ready_index);
+        uct_rc_mlx5_gda_ring_db(ep, ready_index);
+        return;
+    }
+
     if (READ_ONCE(ep->sq_ready_index) == wqe_next) {
         uct_rc_mlx5_gda_lock(&ep->sq_lock);
-        const uint64_t ready_index = READ_ONCE(ep->sq_ready_index);
+        const uint64_t ready_index = ep->sq_ready_index;
         if (ready_index == wqe_next) {
             uct_rc_mlx5_gda_ring_db(ep, ready_index);
             uct_rc_mlx5_gda_update_dbr(ep, ready_index);

--- a/src/uct/ib/mlx5/gdaki/gdaki_dev.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki_dev.h
@@ -19,6 +19,7 @@ typedef struct {
 
     uint64_t                     sq_rsvd_index;
     uint64_t                     sq_ready_index;
+    uint64_t                     sq_db_index;
     int                          sq_lock;
 
     uint8_t                      *sq_wqe_daddr;


### PR DESCRIPTION
## What?
Based on [PR10959](https://github.com/openucx/ucx/pull/10959/files)
Ring doorbell only for latest ready wqe index.

| case_name              | msg_size (KB) | Version | FC Window | Latency (us) | BW (MB/s) | Ops (msg/s)    |
|------------------------|---------------|---------|-----------|--------------|-----------|----------------|
| ucp_put_single_bw      | 8             | pr      | deafult   | 7.857        | 15909.3   | 2036390        |
| ucp_put_single_bw      | 8             | master  | deafult   | 18.944       | 6598.49   | 844607         |
| ucp_put_single_lat     | 8             | pr      | deafult   | 13.314       | 9388.54   | 1201730        |
| ucp_put_single_lat     | 8             | master  | deafult   | 40.706       | 3070.83   | 393066         |
| ucp_put_multi_bw       | 8             | pr      | deafult   | 74.377       | 1680.63   | 215121         |
| ucp_put_multi_bw       | 8             | master  | deafult   | 74.404       | 1680.01   | 215041         |
| ucp_put_multi_lat      | 8             | pr      | deafult   | 45.413       | 2752.49   | 352319         |
| ucp_put_multi_lat      | 8             | master  | deafult   | 44.917       | 2782.89   | 356210         |
| ucp_put_partial_bw     | 8             | pr      | deafult   | 74.438       | 1679.24   | 214943         |
| ucp_put_partial_bw     | 8             | master  | deafult   | 74.396       | 1680.19   | 215064         |
| ucp_put_partial_lat    | 8             | pr      | deafult   | 45.421       | 2752.03   | 352260         |
| ucp_put_partial_lat    | 8             | master  | deafult   | 45.16        | 2767.94   | 354296         |
| ucp_put_single_bw      | 8             | pr      | inf       | 8.088        | 15455     | 1978250        |
| ucp_put_single_bw      | 8             | master  | inf       | 7.954        | 15714.5   | 2011460        |
| ucp_put_single_lat     | 8             | pr      | inf       | 13.372       | 9347.83   | 1196520        |
| ucp_put_single_lat     | 8             | master  | inf       | 40.805       | 3063.38   | 392113         |
| ucp_put_multi_bw       | 8             | pr      | inf       | 78.56        | 1591.15   | 203667         |
| ucp_put_multi_bw       | 8             | master  | inf       | 80.629       | 1550.31   | 198439         |
| ucp_put_multi_lat      | 8             | pr      | inf       | 46.886       | 2666.01   | 341250         |
| ucp_put_multi_lat      | 8             | master  | inf       | 47.851       | 2612.28   | 334372         |
| ucp_put_partial_bw     | 8             | pr      | inf       | 78.618       | 1589.97   | 203516         |
| ucp_put_partial_bw     | 8             | master  | inf       | 80.534       | 1552.14   | 198674         |
| ucp_put_partial_lat    | 8             | pr      | inf       | 45.999       | 2717.46   | 347835         |
| ucp_put_partial_lat    | 8             | master  | inf       | 47.798       | 2615.18   | 334742         |


## Why?
The contention of db lock is very serious for big threads number.
This pr allows gpu threads acquire lock and ring db only when the filled wqe is the last one to post.

## How?
Add double check for ready wqe index when trying to ring db.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conditional send-queue progression and synchronized completion updates to database signaling, reducing races and improving GPU-direct reliability.
  * Adjusted flow-control readiness to more accurately determine send-queue availability.

* **New Features**
  * Introduced batching mode for database updates to reduce signaling overhead and improve throughput; supports a no-delay mode for lower latency.

* **Chores**
  * Endpoint tracking and locking enhancements to support the new DB synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->