### PR TITLE
[WIP][DNM] TOOLS/PERF: fix report for multiple blocks

### DIFF
--- a/src/tools/perf/cuda/cuda_kernel.cuh
+++ b/src/tools/perf/cuda/cuda_kernel.cuh
@@ -193,7 +193,7 @@ public:
             if (delta > 0) {
                 // TODO: calculate latency percentile on kernel
                 ucx_perf_update(&m_perf, delta, delta * msgs_per_iter, msg_length);
-            } else if (completed >= m_perf.max_iter * block_count) {
+            } else if (completed >= (m_perf.max_iter * block_count)) {
                 break;
             }
             last_completed = completed;


### PR DESCRIPTION
## What?
Fix perf report for multiple blocks.

## Why?
Currently the reported bw is not mul by blocks count.

## How?
Update complete iters with considering of blocks count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CUDA kernel performance testing to track iterations more accurately and produce more reliable timing and report intervals.
  * Adjusted reporting logic to reduce drift between reported and actual completed work.

* **Bug Fixes**
  * Test runner termination and wait conditions now scale with block-level parallelism, preventing premature or delayed test completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->