### PR TITLE
UCT/IB/MLX5: Warn about UCX_IB_MLX5_DEVX_OBJECTS being set empty for Grace CPUs in ucx.conf

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -2,6 +2,7 @@
 CPU model=Grace
 UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed
 UCX_IB_ODP_MEM_TYPES=host,cuda-managed
+UCX_IB_MLX5_DEVX_OBJECTS=
 UCX_GDR_COPY_BW=0MBs,get_dedicated:30GBs,put_dedicated:30GBs
 UCX_GDR_COPY_LAT=30ns
 UCX_GDR_COPY_RCACHE_OVERHEAD=170ns

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -169,6 +169,15 @@ static inline int ucs_cpu_prefer_relaxed_order()
              (cpu_model == UCS_CPU_MODEL_AMD_TURIN)));
 }
 
+static inline int ucs_cpu_prefer_odp()
+{
+    ucs_cpu_vendor_t cpu_vendor = ucs_arch_get_cpu_vendor();
+    ucs_cpu_model_t cpu_model   = ucs_arch_get_cpu_model();
+
+    return ((cpu_vendor == UCS_CPU_VENDOR_NVIDIA) &&
+            (cpu_model == UCS_CPU_MODEL_NVIDIA_GRACE));
+}
+
 
 #define UCS_CPU_VENDOR_LABEL "CPU vendor"
 #define UCS_CPU_MODEL_LABEL  "CPU model"

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1782,6 +1782,9 @@ static void uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
             (UCS_BIT(UCT_IB_DEVX_OBJ_RCQP) | UCS_BIT(UCT_IB_DEVX_OBJ_DCI))) {
             reason = "version 1 is not supported for DevX QP";
             goto no_odp;
+        } else if (ucs_cpu_prefer_odp()) {
+            ucs_warn("%s: devx objects are disabled in ucx.conf, the performance may be degraded, as ODPv2 is not supported",
+               uct_ib_device_name(&md->super.dev));
         }
 
         odp_cap = UCT_IB_MLX5DV_ADDR_OF(


### PR DESCRIPTION
## What?
Warns about UCX_IB_MLX5_DEVX_OBJECTS being set to empty for Grace CPUs in ucx.conf

## Why?
Disabling DEVX on Grace CPUs can cause serious slowdowns for small messages.
