### PR TITLE
UCT/DEVICE: ring db in atomic way

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -282,7 +282,7 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep, unsigned cid,
             wqe_base = wqe_base_orig;
         }
     } else {
-        while (READ_ONCE(ep->sq_ready_index) != wqe_base) {
+        while (READ_ONCE(qp->sq_ready_index) != wqe_base) {
         }
         uct_rc_mlx5_gda_ring_db(ep, cid, wqe_next);
         uct_rc_mlx5_gda_update_dbr(ep, cid, wqe_next);


### PR DESCRIPTION
## What?
Ring doorbell in atomic way.
No need cas wait on db lock.
Based on [PR10959](https://github.com/openucx/ucx/pull/10959/files)

| case_name              | msg_size (KB) | Version | Latency (us) | BW (MB/s) | Ops (msg/s)    | Speedup      |
|------------------------|---------------|---------|--------------|-----------|----------------|--------------|
| ucp_put_single_bw      | 4             | pr      | 30.219       | 4136.46   | 1.05893e+06    | 1.05x ⬆️     |
| ucp_put_single_bw      | 4             | master  | 31.728       | 3939.7    | 1.00856e+06    | -            |
| ucp_put_single_lat     | 4             | pr      | 80.227       | 1558.07   | 398866         | 0.99x        |
| ucp_put_single_lat     | 4             | master  | 79.722       | 1567.94   | 401394         | -            |
| ucp_put_multi_bw       | 4             | pr      | 142.102      | 879.65    | 225191         | 1.01x        |
| ucp_put_multi_bw       | 4             | master  | 142.997      | 874.14    | 223780         | -            |
| ucp_put_multi_lat      | 4             | pr      | 79.876       | 1564.92   | 400620         | 0.99x        |
| ucp_put_multi_lat      | 4             | master  | 79.151       | 1579.25   | 404289         | -            |
| ucp_put_partial_bw     | 4             | pr      | 142.047      | 879.99    | 225278         | 1.00x        |
| ucp_put_partial_bw     | 4             | master  | 142.199      | 879.05    | 225036         | -            |
| ucp_put_partial_lat    | 4             | pr      | 79.968       | 1563.12   | 400159         | 0.99x        |
| ucp_put_partial_lat    | 4             | master  | 79.3         | 1576.28   | 403529         | -            |
| ucp_put_single_bw      | 8             | pr      | 30.99        | 8067.14   | 1.03259e+06    | 1.05x ⬆️     |
| ucp_put_single_bw      | 8             | master  | 32.441       | 7706.19   | 986393         | -            |
| ucp_put_single_lat     | 8             | pr      | 81.549       | 3065.62   | 392400         | 1.00x        |
| ucp_put_single_lat     | 8             | master  | 81.646       | 3061.99   | 391935         | -            |
| ucp_put_multi_bw       | 8             | pr      | 148.761      | 1680.55   | 215111         | 1.00x        |
| ucp_put_multi_bw       | 8             | master  | 148.697      | 1681.27   | 215203         | -            |
| ucp_put_multi_lat      | 8             | pr      | 83.206       | 3004.6    | 384589         | 1.01x        |
| ucp_put_multi_lat      | 8             | master  | 84.064       | 2973.94   | 380664         | -            |
| ucp_put_partial_bw     | 8             | pr      | 148.644      | 1681.87   | 215279         | 1.00x        |
| ucp_put_partial_bw     | 8             | master  | 148.697      | 1681.27   | 215203         | -            |
| ucp_put_partial_lat    | 8             | pr      | 83.283       | 3001.8    | 384231         | 1.00x        |
| ucp_put_partial_lat    | 8             | master  | 83.58        | 2991.13   | 382865         | -            |
## Why?
Optimize performance for doorbell.

## How?
Merge 2 stage db into 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal database operation handling and synchronization logic to optimize performance characteristics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->