### PR TITLE
Config type fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ Min Fang <minf@nvidia.com>
 Nathan Bellalou <nbellalou@nvidia.com>
 Nathan Hjelm <hjelmn@lanl.gov>
 Netanel Yosephian <netanelyo@mellanox.com>
+Nicolas Morey <nmorey@suse.com>
 Nir Wolfer <nwolfer@nvidia.com>
 Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -460,7 +460,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "Number of usage tracker rounds performed for each progress operation. Must be\n"
    "non-zero value.",
    ucs_offsetof(ucp_context_config_t, dynamic_tl_progress_factor),
-   UCS_CONFIG_TYPE_TIME_UNITS},
+   UCS_CONFIG_TYPE_UINT},
 
   {"RESOLVE_REMOTE_EP_ID", "auto",
    "Defines whether resolving remote endpoint ID is required or not when\n"

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -57,7 +57,7 @@ static ucs_config_field_t uct_self_md_config_table[] = {
      UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
 
     {"NUM_DEVICES", "1", "Number of \"self\" devices to create",
-     ucs_offsetof(uct_self_md_config_t, num_devices), UCS_CONFIG_TYPE_INT},
+     ucs_offsetof(uct_self_md_config_t, num_devices), UCS_CONFIG_TYPE_ULONG},
 
     {NULL}
 };


### PR DESCRIPTION
While debugging mpich 4.3.2 with ch4:ucx on s390x, several issues popped up.
Found, and tested on 1.19.0

First:
```
sles@ucx-debug:~/mpich/mpich-4.3.2/src/mpi/romio/test> mpirun -np 2 ./file_info -fname test
[1762529195.399132] [ucx-debug:464075:0]     ucp_context.c:2055 UCX  ERROR UCX_DYNAMIC_TL_PROGRESS_FACTOR must be > 0
[1762529195.399238] [ucx-debug:464074:0]     ucp_context.c:2055 UCX  ERROR UCX_DYNAMIC_TL_PROGRESS_FACTOR must be > 0
```
This fixed by the first patch. Config parser was wrongly looking for a time instead of a regular int. Not sure why I only see this on s390 though.

Second:
```
sles@ucx-debug:~/mpich/mpich-4.3.2/src/mpi/romio/test> ./file_info -fname test
[1762533043.448147] [ucx-debug:488518:0]            self.c:276  UCX  ERROR failed to allocate device resource
```
This is caused by UCT/SELF scaning the option to a uint while it is a size_t in memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated several configuration parameter types to improve parsing and validation consistency for runtime settings.
* **Documentation**
  * Added a new contributor to the AUTHORS list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->