### PR TITLE
Clang21 build fix

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -10,7 +10,7 @@
 #
 # Initialize CFLAGS
 #
-BASE_CFLAGS="-g -Wall -Werror"
+BASE_CFLAGS="-g -Wall"
 
 # Prevent libtool from suppression of warnings
 LT_CFLAGS="-no-suppress"

--- a/test/apps/iodemo/io_demo.cc
+++ b/test/apps/iodemo/io_demo.cc
@@ -19,6 +19,7 @@
 #include <csignal>
 #include <cerrno>
 #include <vector>
+#include <random>
 #include <map>
 #include <queue>
 #include <algorithm>
@@ -2999,8 +3000,9 @@ static int do_client(options_t& test_opts)
     LOG << "random seed: " << test_opts.random_seed;
 
     // randomize servers to optimize startup
-    std::random_shuffle(test_opts.servers.begin(), test_opts.servers.end(),
-                        IoDemoRandom::urand<size_t>);
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::shuffle(test_opts.servers.begin(), test_opts.servers.end(), rng);
 
     UcxLog vlog(LOG_PREFIX, test_opts.verbose);
     vlog << "List of servers:";


### PR DESCRIPTION
## What?
Currently UCX is failing to build with newer compiler (for example Clang 21). This PR fixes that.

## Why?
This is cause due to Clang enabling default-const-init-var-unsafe by default,
and `-Werror` makes it treat as an warning. This is better fixed by upstream
developer so `-Werror` commit mostly a RFC from upstream.

Also std::random_shuffle has been removed since C++17 (deprecated in C++14). PR would make use of recommended std::shuffle.

## How?
Not needed in this case I guess :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized test randomization to use a current C++ randomization approach for more robust shuffling.

* **Chores**
  * Relaxed compiler flags so warnings no longer fail the build (no longer treated as errors).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->