### PR TITLE
Fix #ompi/11087 loop during shutdown while flushing with disconnects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>
 Jeff Daily <jeff.daily@amd.com>
 Jianxin Xiong <jianxin.xiong@intel.com>
+Jim King <jimk@nvidia.com>
 John Snyder <jms285@duke.edu>
 Jonas Zhou <JonasZhou@zhaoxin.com>
 Joseph Schuchart <schuchart@icl.utk.edu>


### PR DESCRIPTION
An issue was reported in https://github.com/open-mpi/ompi/issues/11087 which I was able to reproduce.  A similar issue is described in #8738 as well.  This infinite loop at shutdown was caused by an overwritten status code:

1. `ucp_ep_flush_progress` encounters `UCS_ERR_CONNECTION_RESET` and calls `ucp_ep_flush_error`
https://github.com/openucx/ucx/blob/14219b1b312b1bdf0afda5b02300c721030ae408/src/ucp/rma/flush.c#L151

2. `ucp_ep_flush_error` sets `req->status` to the status code https://github.com/openucx/ucx/blob/14219b1b312b1bdf0afda5b02300c721030ae408/src/ucp/rma/flush.c#L54

3. `ucp_ep_flush_completion` reads the completion status then overwrites `req->status`:
https://github.com/openucx/ucx/blob/14219b1b312b1bdf0afda5b02300c721030ae408/src/ucp/rma/flush.c#L391-L398

Losing the error causes upper layers to fail to stop looping.  I tested it live in an environment where it happened almost all the time, passing three runs without incident.

Before, when this occurs, one would get this in the logs repeatedly:
```
[1762981592.539490] [cpu-00061:1410029:0]           flush.c:59   UCX  ERROR req 0x55555577f500: error during flush: Connection reset by remote peer
[cpu-00061:1410029] ../../../../../opal/mca/common/ucx/common_ucx.c:492  Error: ucp_disconnect_nb(112) failed: Connection reset by remote peer
```

However now, the process prints the UCX ERROR message once and then ompi completes disconnect.  Since there is no mechanism for upper layers to hint the transport that "we're disconnecting so ignore connection related errors", we still get errors on the console when this happens, but the process completes normally instead of getting stuck in an infinite loop.  In one case when I broke into a process that seemed to be hung it was furiously trying to call epoll over and over with no work to do; it had looped over 50M times because one of the upper layers keeps a loop iterator count (see [opal_common_ucx_mca_pmix_fence](https://github.com/open-mpi/ompi/blob/4b2fc510b1b4511b0a75a82a3ada671d3cf9e690/opal/mca/common/ucx/common_ucx.h#L62-L65)).

This fixes https://github.com/open-mpi/ompi/issues/11087
This possibly fixes #8738 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal error/status handling for flush operations, enhancing reliability and consistency of reported outcomes without changing visible behavior.

* **Chores**
  * Added a new contributor to the AUTHORS list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->