### PR TITLE
UCT/GDAKI: Make device endpoint initialization thread-safe

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -8,9 +8,9 @@
 
 #include <uct/ib/mlx5/rc/rc_mlx5_common.h>
 #include <uct/base/uct_iface.h>
-#include <ucs/type/spinlock.h>
 
 #include <cuda.h>
+#include <pthread.h>
 
 #include "gdaki_dev.h"
 
@@ -25,7 +25,7 @@ typedef struct uct_rc_gdaki_iface {
     CUdeviceptr                atomic_raw;
     uint64_t                   *atomic_buff;
     CUcontext                  cuda_ctx;
-    ucs_spinlock_t             ep_init_lock;
+    pthread_mutex_t            ep_init_lock;
 } uct_rc_gdaki_iface_t;
 
 


### PR DESCRIPTION
## What?
Make device endpoint initialization thread-safe by protecting it with a spinlock.

## Why?
The original `if (!ep->dev_ep_init)` check is not thread-safe - multiple threads could simultaneously pass the check and attempt initialization, causing double initialization, crashes, or access to uninitialized GPU memory.

## How?
- Add `ucs_spinlock_t ep_init_lock` to `uct_rc_gdaki_iface_t`
- Protect endpoint initialization in `uct_rc_gdaki_ep_get_device_ep()` with lock
- Initialize lock in iface init, destroy in iface cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safety for device-endpoint initialization with improved synchronization to prevent race conditions during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->