### PR TITLE
UCS/SYS: Add default gateway support to reachability check - 1.20

### DIFF
--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -48,14 +48,17 @@ ucs_netlink_send_request(int protocol, unsigned short nlmsg_type,
  * Check whether a routing table rule exists for a given network
  * interface name and a destination address.
  *
- * @param [in]  if_index   A global index representing the network interface,
-                           as assigned by the system (e.g., obtained via
-                           if_nametoindex()).
- * @param [in]  sa_remote  Pointer to the destination address.
+ * @param [in]  if_index          A global index representing the network
+                                  interface, as assigned by the system
+                                  (e.g., obtained via if_nametoindex()).
+ * @param [in]  sa_remote         Pointer to the destination address.
+ * @param [in]  allow_default_gw  Allow matching default gateway routes (1) or
+ *                                only specific subnet routes (0).
  *
  * @return 1 if rule exists, or 0 otherwise.
  */
-int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote);
+int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
+                             int allow_default_gw);
 
 END_C_DECLS
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -15,6 +15,7 @@
 #include <ucs/sys/checker.h>
 #include <ucs/sys/ptr_arith.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/sock.h>
 #include <ucs/sys/sys.h>
 #include <ucs/debug/log.h>
 #include <ucs/time/time.h>
@@ -175,6 +176,21 @@ ucs_status_t ucs_ifname_to_index(const char *ndev_name, unsigned *ndev_index_p)
 
     *ndev_index_p = ndev_index;
     return UCS_OK;
+}
+
+int ucs_netif_is_ipoib(const char *if_name)
+{
+    struct ifreq ifr;
+    ucs_status_t status;
+
+    status = ucs_netif_ioctl(if_name, SIOCGIFHWADDR, &ifr);
+    if (status != UCS_OK) {
+        /* If we can't determine the hardware type, assume it's not IPoIB */
+        ucs_debug("failed to get hardware address for %s", if_name);
+        return 0;
+    }
+
+    return ifr.ifr_hwaddr.sa_family == ARPHRD_INFINIBAND;
 }
 
 static uint64_t ucs_get_mac_address()

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -193,6 +193,16 @@ ucs_status_t ucs_ifname_to_index(const char *ndev_name, unsigned *ndev_index_p);
 
 
 /**
+ * Check if a network interface is an IPoIB (IP over InfiniBand) device.
+ *
+ * @param [in]  if_name  Network interface name to check.
+ *
+ * @return 1 if the interface is IPoIB, 0 otherwise.
+ */
+int ucs_netif_is_ipoib(const char *if_name);
+
+
+/**
  * Get a globally unique identifier of the machine running the current process.
  */
 uint64_t ucs_machine_guid();

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -710,7 +710,7 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
         return 0;
     }
 
-    if (!ucs_netlink_route_exists(ndev_index, sa_remote)) {
+    if (!ucs_netlink_route_exists(ndev_index, sa_remote, 1)) {
         /* try to use loopback interface for reachability check, because it may
          * be used for routing in case of an interface with VRF is configured
          * and a RoCE IP interface uses this VRF table for routing.
@@ -721,7 +721,7 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
             return 0;
         }
 
-        if (!ucs_netlink_route_exists(lo_ndev_index, sa_remote)) {
+        if (!ucs_netlink_route_exists(lo_ndev_index, sa_remote, 1)) {
             uct_iface_fill_info_str_buf(params,
                                         "remote address %s is not routable "
                                         "neither by interface "UCT_IB_IFACE_FMT

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -295,7 +295,12 @@ typedef enum uct_tcp_device_addr_flags {
      * Device address is extended by additional information:
      * @ref uct_iface_local_addr_ns_t for loopback reachability
      */
-    UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK = UCS_BIT(0)
+    UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK         = UCS_BIT(0),
+
+    /**
+     * Allow communication with default gateway
+     */
+    UCT_TCP_DEVICE_ADDR_FLAG_ALLOW_DEFAULT_GW = UCS_BIT(1)
 } uct_tcp_device_addr_flags_t;
 
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -13,6 +13,7 @@
 #include <ucs/async/async.h>
 #include <ucs/sys/netlink.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/sys.h>
 #include <ucs/config/types.h>
 #include <sys/socket.h>
 #include <sys/poll.h>
@@ -138,6 +139,11 @@ static ucs_status_t uct_tcp_iface_get_device_address(uct_iface_h tl_iface,
     dev_addr->flags     = 0;
     dev_addr->sa_family = saddr->sa_family;
 
+    /* Default gateway is not relevant for IPoIB interfaces */
+    if (!ucs_netif_is_ipoib(iface->if_name)) {
+        dev_addr->flags |= UCT_TCP_DEVICE_ADDR_FLAG_ALLOW_DEFAULT_GW;
+    }
+
     if (ucs_sockaddr_is_inaddr_loopback(saddr)) {
         dev_addr->flags |= UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK;
         memset(pack_ptr, 0, sizeof(uct_iface_local_addr_ns_t));
@@ -205,6 +211,7 @@ uct_tcp_iface_is_reachable_v2(const uct_iface_h tl_iface,
     struct sockaddr_storage remote_addr;
     char remote_addr_str[UCS_SOCKADDR_STRING_LEN];
     unsigned ndev_index;
+    int allow_default_gw;
     ucs_status_t status;
 
     if (!uct_iface_is_reachable_params_valid(
@@ -263,8 +270,12 @@ uct_tcp_iface_is_reachable_v2(const uct_iface_h tl_iface,
         return 0;
     }
 
+    allow_default_gw = !!(tcp_dev_addr->flags &
+                          UCT_TCP_DEVICE_ADDR_FLAG_ALLOW_DEFAULT_GW);
+
     if (!ucs_netlink_route_exists(ndev_index,
-                                  (const struct sockaddr *)&remote_addr)) {
+                                  (const struct sockaddr *)&remote_addr,
+                                  allow_default_gw)) {
         uct_iface_fill_info_str_buf(
                     params, "no route to %s",
                     ucs_sockaddr_str((const struct sockaddr *)&remote_addr,


### PR DESCRIPTION
Port #11000

## What?
Added default gateway support to the routing table reachability check
https://redmine.mellanox.com/issues/4659780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect IPoIB (InfiniBand) network interfaces.
  * Option to control whether default-gateway routes are considered during route checks.

* **Improvements**
  * Device addresses now indicate allowance of default-gateway routing for non-IPoIB paths.
  * Reachability checks respect link-layer specifics and honor the new default-gateway option.

* **Bug Fixes**
  * Corrected route parsing and destination initialization to avoid incorrect handling and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->