### PR TITLE
UCS/CONFIG: Changed the default value of HANDLE_ERRORS to none.

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -129,7 +129,7 @@ static ucs_config_field_t ucs_global_opts_table[] = {
 #if ENABLE_DEBUG_DATA
   "bt,freeze",
 #else
-  "bt",
+  "none",
 #endif
   "Error signal handling mode. Either 'none' to disable signal interception,\n"
   "or a combination of:\n"


### PR DESCRIPTION
## What?
Changed the default value of HANDLE_ERRORS to none in the release configuration.

## Why?
Intercepting error signals by default may lead to an erroneous interpretation of the error. Since the signal is intercepted even if the UCX library is just loaded by 3rd party library without even using it.