### PR TITLE
CI/JUCX: Fix CI failure by fetching full Git history

### DIFF
--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -22,7 +22,6 @@ jobs:
 
     steps:
       - checkout: self
-        fetchDepth: 200
         clean: true
         retryCountOnTaskFailure: 5
         displayName: Checkout


### PR DESCRIPTION
## What?
Remove `fetchDepth:` limit in JUCX test checkout to fetch full history.

## Why?
Fixes CI failure where `git describe` could not find tags within the previous 200-commit limit, breaking version generation.