### PR TITLE
UCP/WIREUP: Make device lanes lookup best effort - port to 1.20

### DIFF
--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -289,7 +289,7 @@ static ucs_status_t ucp_device_mem_list_create_handle(
     if (i == 0) {
         ucs_error("failed to select lane for local device %s",
                   ucs_topo_sys_device_get_name(local_sys_dev));
-        return UCS_ERR_NO_RESOURCE;
+        return UCS_ERR_NO_DEVICE;
     }
 
     /* Populate handle header */

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2496,8 +2496,7 @@ ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
                                          mem_type_tl_bitmap, UCP_NULL_LANE,
                                          select_ctx, 0);
     if (!found_lane) {
-        ucs_error("could not find device lanes");
-        return UCS_ERR_UNREACHABLE;
+        ucs_debug("ep %p: could not find device lanes", select_params->ep);
     }
 
     return UCS_OK;


### PR DESCRIPTION
## What?
Do not fail wireup if no device lanes exists.

## Why?
Early failure prevent users from using UCX host API if no device lanes found.

## How?
Change ucp_wireup_add_device_lanes to be best effort.
