### PR TITLE
UCT: prioritize routes with longer subnet masks in the reachability check

### DIFF
--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -45,20 +45,33 @@ ucs_netlink_send_request(int protocol, unsigned short nlmsg_type,
 
 
 /**
- * Check whether a routing table rule exists for a given network
- * interface name and a destination address.
+ * Check whether a route exists for a given network interface and
+ * destination address.
  *
- * @param [in]  if_index          A global index representing the network
-                                  interface, as assigned by the system
-                                  (e.g., obtained via if_nametoindex()).
- * @param [in]  sa_remote         Pointer to the destination address.
- * @param [in]  allow_default_gw  Allow matching default gateway routes (1) or
- *                                only specific subnet routes (0).
+ * @param [in]  if_index           A global index representing the network
+ *                                 interface, as assigned by the system
+ *                                 (e.g., obtained via if_nametoindex()).
+ * @param [in]  sa_remote          Pointer to the destination address.
+ * @param [out] netmask_len_p      Optional pointer to store the netmask length
+ *                                 of the route found. Pass NULL if this
+ *                                 information is not needed.
  *
- * @return 1 if rule exists, or 0 otherwise.
+ * @return 1 if a route exists, or 0 otherwise.
  */
 int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
-                             int allow_default_gw);
+                             int *netmask_len_p);
+
+/**
+ * Check if this network interface has the best route to the destination
+ * address.
+ *
+ * @param [in]  if_index         Network interface index.
+ * @param [in]  sa_remote        Pointer to the destination address.
+ *
+ * @return 1 if this network interface has the best route to the destination
+ *         address, or 0 otherwise.
+ */
+int ucs_netlink_is_best_route(int if_index, const struct sockaddr *sa_remote);
 
 END_C_DECLS
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -178,21 +178,6 @@ ucs_status_t ucs_ifname_to_index(const char *ndev_name, unsigned *ndev_index_p)
     return UCS_OK;
 }
 
-int ucs_netif_is_ipoib(const char *if_name)
-{
-    struct ifreq ifr;
-    ucs_status_t status;
-
-    status = ucs_netif_ioctl(if_name, SIOCGIFHWADDR, &ifr);
-    if (status != UCS_OK) {
-        /* If we can't determine the hardware type, assume it's not IPoIB */
-        ucs_debug("failed to get hardware address for %s", if_name);
-        return 0;
-    }
-
-    return ifr.ifr_hwaddr.sa_family == ARPHRD_INFINIBAND;
-}
-
 static uint64_t ucs_get_mac_address()
 {
     static uint64_t mac_address = 0;

--- a/src/ucs/sys/sys.h
+++ b/src/ucs/sys/sys.h
@@ -193,16 +193,6 @@ ucs_status_t ucs_ifname_to_index(const char *ndev_name, unsigned *ndev_index_p);
 
 
 /**
- * Check if a network interface is an IPoIB (IP over InfiniBand) device.
- *
- * @param [in]  if_name  Network interface name to check.
- *
- * @return 1 if the interface is IPoIB, 0 otherwise.
- */
-int ucs_netif_is_ipoib(const char *if_name);
-
-
-/**
  * Get a globally unique identifier of the machine running the current process.
  */
 uint64_t ucs_machine_guid();

--- a/src/uct/tcp/tcp.h
+++ b/src/uct/tcp/tcp.h
@@ -295,12 +295,7 @@ typedef enum uct_tcp_device_addr_flags {
      * Device address is extended by additional information:
      * @ref uct_iface_local_addr_ns_t for loopback reachability
      */
-    UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK         = UCS_BIT(0),
-
-    /**
-     * Allow communication with default gateway
-     */
-    UCT_TCP_DEVICE_ADDR_FLAG_ALLOW_DEFAULT_GW = UCS_BIT(1)
+    UCT_TCP_DEVICE_ADDR_FLAG_LOOPBACK = UCS_BIT(0)
 } uct_tcp_device_addr_flags_t;
 
 


### PR DESCRIPTION
## What?
Use a default GW routes only when no specific routes exist.

Found in a CI issue when running `./test/gtest/gtest --gtest_filter=*all/test_ucp_sockaddr_protocols_diff_net_devices.restricted_net_devices/0*`