### PR TITLE
UCS/SYS: defined UCS_INFINITY, to support -ffast-math / -Wnan-infinity-disabled compilation flags

### DIFF
--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -27,7 +27,7 @@
 /* Format string to display a protocol performance function bandwidth */
 #define UCP_PROTO_PERF_FUNC_BW_FMT "%.2f"
 #define UCP_PROTO_PERF_FUNC_BW_ARG(_perf_func) \
-    ((_perf_func)->m != 0.0) ? (1.0 / ((_perf_func)->m * UCS_MBYTE)) : INFINITY
+    ((_perf_func)->m != 0.0) ? (1.0 / ((_perf_func)->m * UCS_MBYTE)) : UCS_INFINITY
 
 /* Format string to display a protocol performance function */
 #define UCP_PROTO_PERF_FUNC_FMT \

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -15,6 +15,7 @@
 
 #include <ucp/am/ucp_am.inl>
 #include <ucp/core/ucp_worker.inl>
+#include <ucs/sys/math.h>
 
 
 /* Select a new protocol and start progressing it */
@@ -102,7 +103,7 @@ static void ucp_proto_reconfig_probe(const ucp_proto_init_params_t *init_params)
     }
 
     perf_factors[UCP_PROTO_PERF_FACTOR_LOCAL_TL] =
-            ucs_linear_func_make(INFINITY, 0);
+            ucs_linear_func_make(UCS_INFINITY, 0);
     ucp_proto_perf_add_funcs(perf, 0, SIZE_MAX, perf_factors,
                              ucp_proto_perf_node_new_data("dummy", ""), NULL);
     ucp_proto_select_add_proto(init_params, UCS_MEMUNITS_INF, 0, perf, NULL, 0);

--- a/src/ucs/sys/math.h
+++ b/src/ucs/sys/math.h
@@ -27,6 +27,12 @@ BEGIN_C_DECLS
 #define UCS_TBYTE    (1ull << 40)
 #define UCS_PBYTE    (1ull << 50)
 
+#if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__
+#define UCS_INFINITY (DBL_MAX)
+#else
+#define UCS_INFINITY (INFINITY)
+#endif
+
 #define ucs_min(_a, _b) \
 ({ \
     ucs_typeof(_a) _min_a = (_a); \

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -536,7 +536,7 @@ ucs_topo_get_distance_sysfs(ucs_sys_device_t sys_dev1,
     }
 
     distance->bandwidth = 0;
-    distance->latency   = INFINITY;
+    distance->latency   = UCS_INFINITY;
     ucs_topo_update_distance_sysfs(sys_dev1, sys_dev2, distance);
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
@@ -1241,7 +1241,7 @@ double ucs_topo_get_pci_bw(const char *dev_name, const char *sysfs_path)
 
 out_max_bw:
     ucs_debug("%s: pci bandwidth undetected, using maximal value", dev_name);
-    return INFINITY;
+    return UCS_INFINITY;
 }
 
 const char *ucs_topo_resolve_sysfs_path(const char *dev_path, char *path_buffer)

--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -163,7 +163,7 @@ static inline double ucs_time_units_to_sec(ucs_time_t t, double auto_val)
     if (t == UCS_TIME_AUTO) {
         return auto_val;
     } else if (t == UCS_TIME_INFINITY) {
-        return INFINITY;
+        return UCS_INFINITY;
     }
 
     return ucs_time_to_sec(t);

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -14,6 +14,7 @@ extern "C" {
 #include <ucp/core/ucp_rkey.h>
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/dt/dt.h>
+#include <ucs/sys/math.h>
 #include <ucs/type/float8.h>
 #include <ucs/type/serialize.h>
 }
@@ -432,7 +433,7 @@ void test_ucp_mmap::check_distance_precision(double rkey_value,
     } else if (rkey_value == pack_max) {
         /* Capped by pack_max, no cache entry */
         EXPECT_GE(std::lround(topo_value), pack_max);
-    } else if (topo_value == INFINITY) {
+    } else if (topo_value == UCS_INFINITY) {
         /* Infinity values can be packed without loss */
         EXPECT_EQ(topo_value, rkey_value);
     } else {


### PR DESCRIPTION
## What?
Added UCS_INFINITY definition in `ucs/sys/math.h` which uses `DBL_MAX` as pseudo infinity in case using built-in infinity is not allowed

## Why?
To solve issues such as https://github.com/openucx/ucx/issues/11022, in which users pass compiler flags such as:
`-Wnan-infinity-disabled`, `-ffast-math` or `-ffinite-math-only`
## How?
Conditional definition of UCS_INFINITY 