### PR TITLE
UCP/CORE: Return an error if there is no modifiable configuration - v1.20.x

### DIFF
--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -347,11 +347,11 @@ UCS_CONFIG_DECLARE_TABLE(ucs_global_opts_read_only_table,
                          "UCS global (runtime read-only)", NULL,
                          ucs_global_opts_t)
 
-
 ucs_status_t ucs_global_opts_set_value(const char *name, const char *value)
 {
-    ucs_status_t status = ucs_global_opts_set_value_modifiable(name, value);
-
+    ucs_status_t status = ucs_config_parser_set_value(&ucs_global_opts,
+                                                      ucs_global_opts_table,
+                                                      NULL, name, value);
     if (status != UCS_ERR_NO_ELEM) {
         return status;
     }
@@ -361,11 +361,10 @@ ucs_status_t ucs_global_opts_set_value(const char *name, const char *value)
                                        name, value);
 }
 
-ucs_status_t ucs_global_opts_set_value_modifiable(const char *name,
-                                                  const char *value)
+int ucs_global_opts_is_read_only(const char *name)
 {
-    return ucs_config_parser_set_value(&ucs_global_opts, ucs_global_opts_table,
-                                       NULL, name, value);
+    return ucs_config_parser_has_field(ucs_global_opts_read_only_table, NULL,
+                                       name);
 }
 
 ucs_status_t ucs_global_opts_get_value(const char *name, char *value,

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -172,13 +172,19 @@ extern ucs_global_opts_t ucs_global_opts;
 void ucs_global_opts_init(void);
 void ucs_global_opts_cleanup(void);
 ucs_status_t ucs_global_opts_set_value(const char *name, const char *value);
-ucs_status_t ucs_global_opts_set_value_modifiable(const char *name,
-                                                  const char *value);
 ucs_status_t ucs_global_opts_get_value(const char *name, char *value,
                                        size_t max);
 ucs_status_t ucs_global_opts_clone(void *dst);
 void ucs_global_opts_release(void);
 void ucs_global_opts_print(FILE *stream, ucs_config_print_flags_t print_flags);
+
+/**
+ * Check if a field is read-only.
+ *
+ * @param name Field name to check.
+ * @return     1 if the field is read-only, 0 otherwise.
+ */
+int ucs_global_opts_is_read_only(const char *name);
 
 END_C_DECLS
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -1390,18 +1390,17 @@ ucs_config_parser_set_default_values(void *opts, ucs_config_field_t *fields)
     return UCS_OK;
 }
 
-static int
-ucs_config_prefix_name_match(const char *prefix, size_t prefix_len,
-                             const char *name, const char *pattern)
+static int ucs_config_prefix_name_match(const char *prefix, const char *name,
+                                        const char *pattern)
 {
     const char *match_name;
     char *full_name;
     size_t full_name_len;
 
-    if (prefix_len == 0) {
+    if (prefix == NULL) {
         match_name = name;
     } else {
-        full_name_len = prefix_len + strlen(name) + 1;
+        full_name_len = strlen(prefix) + strlen(name) + 1;
         full_name     = ucs_alloca(full_name_len);
 
         ucs_snprintf_safe(full_name, full_name_len, "%s%s", prefix, name);
@@ -1421,14 +1420,11 @@ ucs_config_parser_set_value_internal(void *opts, ucs_config_field_t *fields,
 {
     char value_buf[256] = "";
     ucs_config_field_t *field, *sub_fields;
-    size_t prefix_len;
     ucs_status_t status;
     ucs_status_t UCS_V_UNUSED status_restore;
     int UCS_V_UNUSED ret;
     unsigned count;
     void *var;
-
-    prefix_len = (table_prefix == NULL) ? 0 : strlen(table_prefix);
 
     count = 0;
     for (field = fields; !ucs_config_field_is_last(field); ++field) {
@@ -1461,8 +1457,8 @@ ucs_config_parser_set_value_internal(void *opts, ucs_config_field_t *fields,
                     return status;
                 }
             }
-        } else if (ucs_config_prefix_name_match(table_prefix, prefix_len,
-                                                field->name, name)) {
+        } else if (ucs_config_prefix_name_match(table_prefix, field->name,
+                                                name)) {
             if (ucs_config_is_deprecated_field(field)) {
                 return UCS_ERR_NO_ELEM;
             }
@@ -2460,4 +2456,61 @@ void ucs_config_parser_cleanup()
         ucs_free(value);
     })
     kh_destroy_inplace(ucs_config_map, &ucs_config_file_vars);
+}
+
+static int
+ucs_config_parser_has_field_internal(const ucs_config_field_t *fields,
+                                     const char *prefix, const char *name,
+                                     int override_prefix)
+{
+    const ucs_config_field_t *field, *sub_fields;
+
+    if ((fields == NULL) || (name == NULL)) {
+        return 0;
+    }
+
+    for (field = fields; !ucs_config_field_is_last(field); ++field) {
+        if (ucs_config_is_table_field(field)) {
+            sub_fields = field->parser.arg;
+
+            /* Changing the prefix to the name of the sub-table allows to
+             * find the parent configuration name, e.g. IB_SEG_SIZE  */
+            if (override_prefix &&
+                ucs_config_parser_has_field_internal(sub_fields, field->name,
+                                                     name, 1)) {
+                return 1;
+            }
+
+            /* Keeping the original prefix allows to find the inherited
+             * configuration name, e.g. RC_MLX5_SEG_SIZE */
+            if ((prefix != NULL) &&
+                ucs_config_parser_has_field_internal(sub_fields, prefix, name,
+                                                     0)) {
+                return 1;
+            }
+        } else if (ucs_config_prefix_name_match(prefix, field->name, name)) {
+            return !ucs_config_is_deprecated_field(field);
+        }
+    }
+
+    return 0;
+}
+
+int ucs_config_parser_has_field(const ucs_config_field_t *fields,
+                                const char *prefix, const char *name)
+{
+    return ucs_config_parser_has_field_internal(fields, prefix, name, 1);
+}
+
+int ucs_config_global_list_has_field(const char *name)
+{
+    const ucs_config_global_list_entry_t *entry;
+
+    ucs_list_for_each(entry, &ucs_config_global_list, list) {
+        if (ucs_config_parser_has_field(entry->table, entry->prefix, name)) {
+            return 1;
+        }
+    }
+
+    return 0;
 }

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -640,6 +640,25 @@ void ucs_config_parser_get_env_vars(ucs_string_buffer_t *env_strb,
 void ucs_config_parser_cleanup(void);
 
 
+/**
+ * Check if a field exists in the configuration table.
+ *
+ * @param fields Array of fields which define the configuration table.
+ * @param prefix Configuration table prefix.
+ * @param name   Field name to check.
+ * @return       1 if the field exists, 0 otherwise.
+ */
+int ucs_config_parser_has_field(const ucs_config_field_t *fields,
+                                const char *prefix, const char *name);
+
+/**
+ * Check if a field exists in the global configuration list.
+ *
+ * @param name   Field name to check.
+ * @return       1 if the field exists, 0 otherwise.
+ */
+int ucs_config_global_list_has_field(const char *name);
+
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
## What?
`ucp_config_modify` returns an error if there is no modifiable configuration matching the passed name.

## Why?
Previously `ucp_config_modify` saved the option and issued a warning only after a UCP worker creation. So the caller had no indication of the success of the method call.

## How?
Calling `uct_query_components` method fills in `ucs_config_global_list` list. This list is used to check the presence of an option.

Cherry-picked https://github.com/openucx/ucx/pull/11003
