### PR TITLE
UCP: Do not warn about correct env name

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2312,9 +2312,9 @@ static void ucp_warn_unused_uct_config(ucp_context_h context)
 
     if (num_unused_cached_kv > 0) {
         ucs_string_buffer_rtrim(&unused_cached_uct_cfg , ",");
-        ucs_warn("invalid configuration%s: %s",
-                 (num_unused_cached_kv > 1) ? "s" : "",
-                 ucs_string_buffer_cstr(&unused_cached_uct_cfg));
+        ucs_debug("configuration%s not applied due to missing resource: %s",
+                  (num_unused_cached_kv > 1) ? "s" : "",
+                  ucs_string_buffer_cstr(&unused_cached_uct_cfg));
     }
 
     ucs_string_buffer_cleanup(&unused_cached_uct_cfg);


### PR DESCRIPTION
## What?
Print about unused var with debug level

## Why?
After #11003 only existing env var names are added to the cache.  However they may still be unused if the corresponding UCT resource (md, iface) is not created (i.e. when UCX can load IB module, but there is no IB device on the system)

