### PR TITLE
UCP/PROTO/CORE: Added 'auto' option for UCX_PROTO_INFO

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -487,10 +487,11 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, worker_addr_version),
    UCS_CONFIG_TYPE_ENUM(ucp_object_versions)},
 
-  {"PROTO_INFO", "n",
+  {"PROTO_INFO", "auto",
    "Enable printing protocols information. The value is interpreted as follows:\n"
    " 'y'          : Print information for all protocols\n"
    " 'n'          : Do not print any protocol information\n"
+   " 'auto'       : Print information when UCX_LOG_LEVEL is 'debug' or higher\n"
    " glob_pattern : Print information for operations matching the glob pattern.\n"
    "                For example: '*tag*gpu*', '*put*fast*host*'",
    ucs_offsetof(ucp_context_config_t, proto_info), UCS_CONFIG_TYPE_STRING},

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -161,10 +161,17 @@ static int ucp_proto_debug_is_info_enabled(ucp_context_h context,
     const char *proto_info_config = context->config.ext.proto_info;
     int bool_value;
 
+    /* Handle "auto" - enable when log level is DEBUG or higher */
+    if (!strcasecmp(proto_info_config, "auto")) {
+        return ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG);
+    }
+
+    /* Handle boolean */
     if (ucs_config_sscanf_bool(proto_info_config, &bool_value, NULL)) {
         return bool_value;
     }
 
+    /* Handle glob pattern */
     return fnmatch(proto_info_config, select_param_str, FNM_CASEFOLD) == 0;
 }
 


### PR DESCRIPTION
## What?
Added `auto` option for `UCX_PROTO_INFO`

## Why?
We would want to include the proto info output whenever the log level is debug or higher.
In order to still respect the value of `UCX_PROTO_INFO` set by the user, I added a new value `auto` that will trigger the print according to the current log level.

### Examples for when the proto info is printed:
| UCX_LOG_LEVEL | UCX_PROTO_INFO | Printed? |
|---------------|----------------|------------------------|
| warn (default) | auto (default) | ❌ No |
| debug | auto (default) | ✅ Yes |
| trace | auto (default) | ✅ Yes |
| info | auto (default) | ❌ No |
| info | y | ✅ Yes |
| debug | n | ❌ No |
| any | glob_pattern | Only matching |
