### PR TITLE
UCT/CUDA: add rkey_ptr flag to cuda_ipc component

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2681,7 +2681,13 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
         }
 
         cmpt_attr = ucp_cmpt_attr_by_md_index(context, config->md_index[lane]);
-        if (cmpt_attr->flags & UCT_COMPONENT_FLAG_RKEY_PTR) {
+        md_attr   = &context->tl_mds[config->md_index[lane]].attr;
+        if ((cmpt_attr->flags & UCT_COMPONENT_FLAG_RKEY_PTR) &&
+            (md_attr->access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+            /* Only treat rkey_ptr backends as RNDV rkey_ptr candidates if their
+             * MD can provide a CPU-dereferenceable pointer. Otherwise (e.g. GPU
+             * backends), rkey_ptr would yield a device pointer and the CPU copy
+             * path is not applicable, so do not add them to rkey_ptr lane/skip. */
             dst_md_index = config->key.lanes[lane].dst_md_index;
             if (lane == key->rkey_ptr_lane) {
                 config->rndv.rkey_ptr_lane_dst_mds     = UCS_BIT(dst_md_index);
@@ -3735,8 +3741,8 @@ static ucs_status_t ucp_ep_query_transport(ucp_ep_h ep, ucp_ep_attr_t *attr)
                                     lane_index * attr->transports.entry_size);
 
         /* Each field updated in the following block must have its ending offset
-         * compared to attr->transports.entry_size before the field is 
-         * updated. If the field's ending offset is greater than the 
+         * compared to attr->transports.entry_size before the field is
+         * updated. If the field's ending offset is greater than the
          * attr->transports.entry_size value, the field cannot be updated because
          * that will cause a storage overlay.
          */

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -583,7 +583,7 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
         },
         .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
         .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_cuda_ipc_component.super),
-        .flags              = 0,
+        .flags              = UCT_COMPONENT_FLAG_RKEY_PTR,
         .md_vfs_init        =
                 (uct_component_md_vfs_init_func_t)ucs_empty_function
     },

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -100,8 +100,7 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
                                 UCT_MD_FLAG_INVALIDATE |
                                 UCT_MD_FLAG_INVALIDATE_RMA |
                                 UCT_MD_FLAG_INVALIDATE_AMO |
-                                UCT_MD_FLAG_MEMTYPE_COPY |
-                                UCT_MD_FLAG_RKEY_PTR;
+                                UCT_MD_FLAG_MEMTYPE_COPY;
     md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
     md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -104,6 +104,8 @@ public:
 
     virtual void init() {
         ucs::skip_on_address_sanitizer();
+        m_env.push_back(new ucs::scoped_setenv("UCX_CUDA_IPC_ENABLE_SAME_PROCESS",
+                                               "y"));
         if (get_variant_value() == VARIANT_PROTO_DISABLE) {
             modify_config("PROTO_ENABLE", "n");
         }
@@ -408,7 +410,9 @@ void test_ucp_mmap::test_rkey_management(ucp_mem_h memh, bool is_dummy,
     void *ptr;
     status = ucp_rkey_ptr(rkey, (uint64_t)ucp_memh_address(memh), &ptr);
     if (status == UCS_OK) {
-        EXPECT_EQ(0, memcmp(ucp_memh_address(memh), ptr, ucp_memh_length(memh)));
+        EXPECT_TRUE(mem_buffer::compare(ucp_memh_address(memh), ptr,
+                                        ucp_memh_length(memh),
+                                        memh->mem_type, memh->mem_type));
     } else {
         EXPECT_EQ(UCS_ERR_UNREACHABLE, status);
     }

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -236,6 +236,16 @@ bool test_md::check_caps(uint64_t flags) const
     return ((md() == nullptr) || ucs_test_all_flags(m_md_attr.flags, flags));
 }
 
+bool test_md::check_component_caps(uint64_t flags) const
+{
+    uct_component_attr attr;
+
+    attr.field_mask = UCT_COMPONENT_ATTR_FIELD_FLAGS;
+    EXPECT_UCS_OK(uct_component_query(GetParam().component, &attr));
+
+    return ucs_test_all_flags(attr.flags, flags);
+}
+
 bool test_md::check_reg_mem_type(ucs_memory_type_t mem_type)
 {
     return ((md() == nullptr) || (check_caps(UCT_MD_FLAG_REG) &&
@@ -282,7 +292,8 @@ void test_md::dereg_cb(uct_completion_t *comp)
     md_comp->self->m_comp_count++;
 }
 
-UCS_TEST_SKIP_COND_P(test_md, rkey_ptr, !check_caps(UCT_MD_FLAG_RKEY_PTR)) {
+UCS_TEST_SKIP_COND_P(test_md, rkey_ptr,
+                     !check_component_caps(UCT_COMPONENT_FLAG_RKEY_PTR)) {
     uct_md_h md_ref                       = md();
     uct_md_mkey_pack_params_t pack_params = {};
     void *ptr                             = nullptr;

--- a/test/gtest/uct/test_md.h
+++ b/test/gtest/uct/test_md.h
@@ -40,6 +40,7 @@ protected:
     virtual void modify_config(const std::string& name, const std::string& value,
                                modify_config_mode_t mode);
     bool check_caps(uint64_t flags) const;
+    bool check_component_caps(uint64_t flags) const;
     bool check_reg_mem_type(ucs_memory_type_t mem_type);
     bool check_alloc_mem_type(ucs_memory_type_t mem_type);
     void alloc_memory(void **address, size_t size, char *fill,


### PR DESCRIPTION
## What?
Add UCT_COMPONENT_FLAG_RKEY_PTR to cuda_ipc component. With this flag ucp_rkey_ptr can use cuda_ipc