### PR TITLE
TOOLS/PERF/CUDA: Fix counter reset between warmup and benchmark

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ Graham Lopez <lopezmg@ornl.gov>
 Guy Shattah <sguy@mellanox.com>
 Hessam Mirsadeghi <hmirsadeghi@nvidia.com>
 Hiroyuki Sato <hiroysato@gmail.com>
+Hod Badihi <hbadihi@nvidia.com>
 Howard Pritchard <howardp@lanl.gov>
 Huaxiang Fan <huaxiangf@nvidia.com>
 Hui Zhou <hzhou321@anl.gov>

--- a/src/tools/perf/cuda/ucp_cuda_kernel.cu
+++ b/src/tools/perf/cuda/ucp_cuda_kernel.cu
@@ -479,7 +479,7 @@ public:
     ucp_perf_cuda_test_runner(ucx_perf_context_t &perf) :
         ucx_perf_cuda_test_runner(perf)
     {
-        size_t length = ucx_perf_get_message_size(&m_perf.params);
+        size_t length = ucx_perf_get_message_size(&m_perf.params) + ONESIDED_SIGNAL_SIZE;
 
         m_perf.send_allocator->memset(m_perf.send_buffer, 0, length);
         m_perf.recv_allocator->memset(m_perf.recv_buffer, 0, length);


### PR DESCRIPTION
## What?
Fix GPU counter reset between warmup and benchmark phases in device performance tests.

## Why?
GPU memory counters (`counter_send` and `counter_recv`) were not being reset between the warmup phase and actual benchmark execution. This caused incorrect behavior because:

1. During warmup, counters accumulated values (e.g., `counter_recv` reached value N after N warmup iterations)
2. The actual benchmark kernels expected counters to start from 0, but they contained stale warmup values this affected both latency and bandwidth tests


| Test | Message Size | Master (buggy) | PR (fixed) | Change |
|------|--------------|----------------|------------|--------|
| `put_multi_lat` | 8 B | 11.5µs | ~18µs | ⚠️ Significant change |
| `put_multi_bw` | 4 MB | 38075 MB/s | 38200 MB/s | No change |
| `put_single_lat` | 8 B | 9.225µs | 9.235µs | No change |

**Test setup:** 2-node configuration with `-m cuda -a cuda:0`

