### PR TITLE
UCT/IB/MLX5/GDAKI: Fixed check UAR support.

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1029,8 +1029,7 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
             goto err;
         }
 
-        if (!uct_gdaki_is_dmabuf_supported(ib_md) &&
-            !uct_gdaki_is_uar_supported(ib_mlx5_md, device)) {
+        if (!uct_gdaki_is_uar_supported(ib_mlx5_md, device)) {
             status = UCS_ERR_NO_DEVICE;
             goto err;
         }


### PR DESCRIPTION
## What?
UAR support should be checked regardless of DMA_BUF support.
