### PR TITLE
AZP: always fetch UCX submodules in CI

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -72,6 +72,7 @@ jobs:
 
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/az-github-draft.yml
+++ b/buildlib/az-github-draft.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
     - checkout: self
+      submodules: true
       clean: true
       fetchDepth: 100
       path: "we/need/to/go/deeper"

--- a/buildlib/az-helpers.sh
+++ b/buildlib/az-helpers.sh
@@ -291,7 +291,7 @@ git_clone_with_retry() {
 
     for attempt in $(seq 1 $max_attempts); do
         echo "Attempt $attempt of $max_attempts: Cloning UCX (branch: $branch)"
-        if git clone --depth "$depth" -b "$branch" "$BUILD_REPOSITORY_URI" "$target_dir"; then
+        if git clone --recurse-submodules --shallow-submodules --depth "$depth" -b "$branch" "$BUILD_REPOSITORY_URI" "$target_dir"; then
             echo "Clone successful"
             return 0
         fi

--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -34,6 +34,7 @@ stages:
 
         steps:
           - checkout: self
+            submodules: true
             clean: true
             fetchDepth: 10
             retryCountOnTaskFailure: 5

--- a/buildlib/azure-pipelines-release-drp.yml
+++ b/buildlib/azure-pipelines-release-drp.yml
@@ -92,6 +92,7 @@ stages:
             - ucx_docker_drp
         steps:
           - checkout: self
+            submodules: true
             fetchDepth: 100
             clean: true
             retryCountOnTaskFailure: 5

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -88,6 +88,7 @@ stages:
           - ucx_docker
         steps:
           - checkout: self
+            submodules: true
             fetchDepth: 100
             clean: true
             retryCountOnTaskFailure: 5

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -27,6 +27,7 @@ stages:
           - ucx_docker -equals yes
         steps:
           - checkout: self
+            submodules: true
             clean: true
             retryCountOnTaskFailure: 5
           - bash: |

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 200
         retryCountOnTaskFailure: 5

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
       - checkout: self
+        submodules: true
         clean: true
         retryCountOnTaskFailure: 5
         displayName: Checkout

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -78,6 +78,7 @@ jobs:
 
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/codestyle.yml
+++ b/buildlib/pr/codestyle.yml
@@ -8,6 +8,7 @@ jobs:
       - ucx_docker -equals yes
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5
@@ -38,6 +39,7 @@ jobs:
     container: fedora
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5
@@ -72,6 +74,7 @@ jobs:
     container: fedora
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5
@@ -97,6 +100,7 @@ jobs:
     container: fedora
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5
@@ -116,6 +120,7 @@ jobs:
     container: fedora
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/coverity.yml
+++ b/buildlib/pr/coverity.yml
@@ -16,6 +16,7 @@ jobs:
       timeoutInMinutes: 90
       steps:
         - checkout: self
+          submodules: true
           clean: true
           fetchDepth: 100
           retryCountOnTaskFailure: 5

--- a/buildlib/pr/cuda/cuda.yml
+++ b/buildlib/pr/cuda/cuda.yml
@@ -11,6 +11,7 @@ jobs:
 
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/cuda/cuda_compatible.yml
+++ b/buildlib/pr/cuda/cuda_compatible.yml
@@ -8,6 +8,7 @@ jobs:
     container: centos7_cuda11
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/efa.yml
+++ b/buildlib/pr/efa.yml
@@ -14,6 +14,7 @@ jobs:
       clean: outputs
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -13,6 +13,7 @@ jobs:
 
     steps:
     - checkout: self
+      submodules: true
       fetchDepth: 100
       clean: true
       displayName: Checkout

--- a/buildlib/pr/io_demo/io-demo.yml
+++ b/buildlib/pr/io_demo/io-demo.yml
@@ -14,6 +14,7 @@ jobs:
       - bash: chmod u+rwx ./ -R
 
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         displayName: Checkout

--- a/buildlib/pr/mad_tests.yml
+++ b/buildlib/pr/mad_tests.yml
@@ -8,6 +8,7 @@ jobs:
       clean: outputs
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5
@@ -34,6 +35,7 @@ jobs:
       clean: outputs
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -419,6 +419,7 @@ stages:
 
         steps:
           - checkout: self
+            submodules: true
             clean: true
             fetchDepth: 100
             retryCountOnTaskFailure: 5

--- a/buildlib/pr/namespace_tests.yml
+++ b/buildlib/pr/namespace_tests.yml
@@ -9,6 +9,7 @@ jobs:
       clean: outputs
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/static_checks.yml
+++ b/buildlib/pr/static_checks.yml
@@ -8,6 +8,7 @@ jobs:
     container: fedora
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -26,6 +26,7 @@ jobs:
       clean: outputs
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 100
         retryCountOnTaskFailure: 5

--- a/buildlib/pr/wire_compat.yml
+++ b/buildlib/pr/wire_compat.yml
@@ -27,6 +27,7 @@ jobs:
       container: ${{ parameters.container }}
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 1
         retryCountOnTaskFailure: 5
@@ -63,6 +64,7 @@ jobs:
       test_dir: $(System.DefaultWorkingDirectory)/$(ucx_legacy)/examples
     steps:
       - checkout: self
+        submodules: true
         clean: true
         fetchDepth: 1
         retryCountOnTaskFailure: 5


### PR DESCRIPTION
## What?
Always fetch UCX submodules in Azure CI.

## Why?
Avoid CI breakage when jobs depend on submodule content.

## How?
- Set `submodules: true` on UCX `checkout: self` steps.
- Add `--recurse-submodules` to `git_clone_with_retry`.