### PR TITLE
UCT/API: Add stream-related interfaces

### DIFF
--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -286,16 +286,6 @@ typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
                                                       const uct_device_addr_t *dev_addr,
                                                       const uct_iface_addr_t *iface_addr);
 
-/* interface - stream operation ordering, for supporting transports */
-typedef ucs_status_t (*uct_iface_stream_op_block_func_t)(
-        const uct_iface_h iface, uct_iface_stream_h stream,
-        void (*ready_cb)(void *),
-        void *arg,
-        uct_iface_stream_op_handle_h *op_handle);
-
-typedef ucs_status_t (*uct_iface_stream_op_unblock_func_t)(
-        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
-
 /**
  * Transport interface operations.
  * Every operation exposed in the API must appear in the table below, to allow
@@ -380,10 +370,6 @@ typedef struct uct_iface_ops {
     uct_iface_get_device_address_func_t iface_get_device_address;
     uct_iface_get_address_func_t        iface_get_address;
     uct_iface_is_reachable_func_t       iface_is_reachable;
-
-    /* interface - virtually insert operations on the stream */
-    uct_iface_stream_op_block_func_t    iface_stream_op_block;
-    uct_iface_stream_op_unblock_func_t  iface_stream_op_unblock;
 
 } uct_iface_ops_t;
 

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -287,14 +287,13 @@ typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
                                                       const uct_iface_addr_t *iface_addr);
 
 /* interface - stream operation ordering, for supporting transports */
-typedef ucs_status_t (*uct_iface_stream_op_begin_func_t)(
+typedef ucs_status_t (*uct_iface_stream_op_block_func_t)(
         const uct_iface_h iface, uct_iface_stream_h stream,
+        void (*ready_cb)(void *),
+        void *arg,
         uct_iface_stream_op_handle_h *op_handle);
 
-typedef ucs_status_t (*uct_iface_stream_op_is_ready_func_t)(
-        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
-
-typedef ucs_status_t (*uct_iface_stream_op_finish_func_t)(
+typedef ucs_status_t (*uct_iface_stream_op_unblock_func_t)(
         const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
 
 /**
@@ -383,9 +382,8 @@ typedef struct uct_iface_ops {
     uct_iface_is_reachable_func_t       iface_is_reachable;
 
     /* interface - virtually insert operations on the stream */
-    uct_iface_stream_op_begin_func_t    iface_stream_op_begin;
-    uct_iface_stream_op_is_ready_func_t iface_stream_op_is_ready;
-    uct_iface_stream_op_finish_func_t   iface_stream_op_finish;
+    uct_iface_stream_op_block_func_t    iface_stream_op_block;
+    uct_iface_stream_op_unblock_func_t  iface_stream_op_unblock;
 
 } uct_iface_ops_t;
 

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -286,6 +286,7 @@ typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
                                                       const uct_device_addr_t *dev_addr,
                                                       const uct_iface_addr_t *iface_addr);
 
+
 /**
  * Transport interface operations.
  * Every operation exposed in the API must appear in the table below, to allow

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -286,6 +286,16 @@ typedef int          (*uct_iface_is_reachable_func_t)(const uct_iface_h iface,
                                                       const uct_device_addr_t *dev_addr,
                                                       const uct_iface_addr_t *iface_addr);
 
+/* interface - stream operation ordering, for supporting transports */
+typedef ucs_status_t (*uct_iface_stream_op_begin_func_t)(
+        const uct_iface_h iface, uct_iface_stream_h stream,
+        uct_iface_stream_op_handle_h *op_handle);
+
+typedef ucs_status_t (*uct_iface_stream_op_is_ready_func_t)(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
+
+typedef ucs_status_t (*uct_iface_stream_op_finish_func_t)(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
 
 /**
  * Transport interface operations.
@@ -371,6 +381,11 @@ typedef struct uct_iface_ops {
     uct_iface_get_device_address_func_t iface_get_device_address;
     uct_iface_get_address_func_t        iface_get_address;
     uct_iface_is_reachable_func_t       iface_is_reachable;
+
+    /* interface - virtually insert operations on the stream */
+    uct_iface_stream_op_begin_func_t    iface_stream_op_begin;
+    uct_iface_stream_op_is_ready_func_t iface_stream_op_is_ready;
+    uct_iface_stream_op_finish_func_t   iface_stream_op_finish;
 
 } uct_iface_ops_t;
 

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1301,6 +1301,20 @@ struct uct_iface_params {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief User stream descriptor.
+ */
+struct uct_iface_stream;
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief User stream interface handle.
+ */
+struct uct_iface_stream_op_handle;
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief Parameters for creating a UCT endpoint by @ref uct_ep_create
  */
 struct uct_ep_params {
@@ -3640,6 +3654,7 @@ UCT_INLINE_API unsigned uct_iface_progress(uct_iface_h iface)
 {
     return iface->ops.iface_progress(iface);
 }
+
 
 /**
  * @ingroup UCT_CLIENT_SERVER

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -3641,65 +3641,6 @@ UCT_INLINE_API unsigned uct_iface_progress(uct_iface_h iface)
     return iface->ops.iface_progress(iface);
 }
 
-
-/**
- * @ingroup UCT_RESOURCE
- * @brief Declare an operation ordered with respect to a stream.
- *
- * Declares the beginning of an operation that is to be ordered with respect to
- * the specified @a stream. This call returns an @a op_handle, which is used to
- * track the operation state. Anything added to the stream after this call will
- * remain blocked until @ref uct_iface_stream_op_unblock is called.
- *
- * When all preexisting operations in @a stream have completed, the transport
- * will call the callback @a ready_cb with @a ready_arg as a parameter. The
- * user can then start any needed operation.
- *
- * After completing the operation’s processing, the user must eventually
- * always call @ref uct_iface_stream_op_unblock.
- *
- * @param [in]  iface     Interface used for state management.
- * @param [in]  stream    Stream to order against.
- * @param [in]  ready_cb  Callback called when preexisting @stream operations
- *                        have completed.
- * @param [in]  ready_arg Parameter passed to the callback.
- * @param [out] op_handle Operation handle used for subsequent tracking.
- *
- * @return Error code.
- */
-UCT_INLINE_API ucs_status_t
-uct_iface_stream_op_block(const uct_iface_h iface, uct_iface_stream_h stream,
-                          void (*ready_cb)(void *arg),
-                          void *ready_arg,
-                          uct_iface_stream_op_handle_h *op_handle)
-{
-    return iface->ops.iface_stream_op_block(iface, stream,
-                                            ready_cb, ready_arg, op_handle);
-}
-
-
-/**
- * @ingroup UCT_RESOURCE
- * @brief Unblock a stream when operation has completed.
- *
- * Declares that the operation associated with @a op_handle has completed
- * its processing. This will release the wait on the stream associated with
- * @a op_handle, unblock any subsequent operations that were waiting on
- * this stream, and release the resources associated with @a op_handle.
- *
- * @param [in]  iface     Interface used for state management.
- * @param [in]  op_handle Operation handle previously returned by
- *                        @ref uct_iface_stream_op_begin.
- *
- * @return Error code.
- */
-UCT_INLINE_API ucs_status_t uct_iface_stream_op_unblock(
-        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle)
-{
-    return iface->ops.iface_stream_op_unblock(iface, op_handle);
-}
-
-
 /**
  * @ingroup UCT_CLIENT_SERVER
  * @brief Open a connection manager.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -3643,6 +3643,88 @@ UCT_INLINE_API unsigned uct_iface_progress(uct_iface_h iface)
 
 
 /**
+ * @ingroup UCT_RESOURCE
+ * @brief Declare an operation ordered with respect to a stream.
+ *
+ * Declares the beginning of an operation that is to be ordered with respect to
+ * the specified @a stream. This call returns an @a op_handle, which is used to
+ * track the operation state. Anything added to the stream after this call will
+ * remain blocked until @ref uct_iface_stream_op_finish is called.
+ *
+ * The user may call @ref uct_iface_stream_op_is_ready to verify that all
+ * previously issued operations on the @a stream have completed before
+ * starting the operation’s own processing. This check is optional and
+ * depends on the user's ordering requirements.
+ *
+ * After completing the operation’s processing, the user must eventually
+ * call @ref uct_iface_stream_op_finish.
+ *
+ * @param [in]  iface     Interface used for state management.
+ * @param [in]  stream    Stream to order against.
+ * @param [out] op_handle Operation handle used for subsequent tracking.
+ *
+ * @return Error code.
+ */
+UCT_INLINE_API ucs_status_t
+uct_iface_stream_op_begin(const uct_iface_h iface, uct_iface_stream_h stream,
+                          uct_iface_stream_op_handle_h *op_handle)
+{
+    return iface->ops.iface_stream_op_begin(iface, stream, op_handle);
+}
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Check if all predecessors of a stream operation have completed.
+ *
+ * Checks whether all work on the stream that was issued prior to the
+ * creation of the operation represented by @a op_handle has completed.
+ * This can be used by the user to guarantee strict ordering of operations
+ * from the stream perspective. Calling this function is optional; the user
+ * may start processing without calling it, depending on its ordering
+ * requirements.
+ *
+ * If all prior operations have completed, the function returns @ref UCS_OK.
+ * Otherwise, it returns @ref UCS_INPROGRESS, indicating that there are still
+ * remaining operations being processed on the stream.
+ *
+ * @param [in]  iface     Interface used for state management.
+ * @param [in]  op_handle Operation handle previously returned by
+ *                        @ref uct_iface_stream_op_begin.
+ *
+ * @return @ref UCS_OK if the operation is ready, @ref UCS_INPROGRESS if it
+ *         is still blocked, or another error code on failure.
+ */
+UCT_INLINE_API ucs_status_t uct_iface_stream_op_is_ready(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle)
+{
+    return iface->ops.iface_stream_op_is_ready(iface, op_handle);
+}
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Mark a previously declared stream operation as finished.
+ *
+ * Declares that the operation associated with @a op_handle has completed
+ * its processing. This will release the wait on the stream associated with
+ * @a op_handle, unblock any subsequent operations that were waiting on
+ * this stream, and release the resources associated with @a op_handle.
+ *
+ * @param [in]  iface     Interface used for state management.
+ * @param [in]  op_handle Operation handle previously returned by
+ *                        @ref uct_iface_stream_op_begin.
+ *
+ * @return Error code.
+ */
+UCT_INLINE_API ucs_status_t uct_iface_stream_op_finish(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle)
+{
+    return iface->ops.iface_stream_op_finish(iface, op_handle);
+}
+
+
+/**
  * @ingroup UCT_CLIENT_SERVER
  * @brief Open a connection manager.
  *

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -113,6 +113,9 @@ typedef void*                        uct_conn_request_h;
 typedef struct uct_device_ep         *uct_device_ep_h;
 typedef struct uct_device_mem_element uct_device_mem_element_t;
 
+typedef struct uct_iface_stream_op_handle *uct_iface_stream_op_handle_h;
+typedef struct uct_iface_stream           *uct_iface_stream_h;
+
 /**
  * @}
  */

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1308,6 +1308,58 @@ ucs_status_t uct_iface_mem_element_pack(uct_iface_h iface, uct_mem_h memh,
                                         uct_rkey_t rkey,
                                         uct_device_mem_element_t *mem_element);
 
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Declare an operation ordered with respect to a stream.
+ *
+ * Declares the beginning of an operation that is to be ordered with respect to
+ * the specified @a stream. This call returns an @a op_handle, which is used to
+ * track the operation state. Anything added to the stream after this call will
+ * remain blocked until @ref uct_iface_stream_op_unblock is called.
+ *
+ * When all preexisting operations in @a stream have completed, the transport
+ * will call the callback @a ready_cb with @a ready_arg as a parameter. The
+ * user can then start any needed operation.
+ *
+ * After completing the operation’s processing, the user must eventually
+ * always call @ref uct_iface_stream_op_unblock.
+ *
+ * @param [in]  iface     Interface used for state management.
+ * @param [in]  stream    Stream to order against.
+ * @param [in]  ready_cb  Callback called when preexisting @stream operations
+ *                        have completed.
+ * @param [in]  ready_arg Parameter passed to the callback.
+ * @param [out] op_handle Operation handle used for subsequent tracking.
+ *
+ * @return Error code.
+ */
+ucs_status_t
+uct_iface_stream_op_block(const uct_iface_h iface, uct_iface_stream_h stream,
+                          void (*ready_cb)(void *arg),
+                          void *ready_arg,
+                          uct_iface_stream_op_handle_h *op_handle);
+
+
+/**
+ * @ingroup UCT_RESOURCE
+ * @brief Unblock a stream when operation has completed.
+ *
+ * Declares that the operation associated with @a op_handle has completed
+ * its processing. This will release the wait on the stream associated with
+ * @a op_handle, unblock any subsequent operations that were waiting on
+ * this stream, and release the resources associated with @a op_handle.
+ *
+ * @param [in]  iface     Interface used for state management.
+ * @param [in]  op_handle Operation handle previously returned by
+ *                        @ref uct_iface_stream_op_begin.
+ *
+ * @return Error code.
+ */
+ucs_status_t uct_iface_stream_op_unblock(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
+
+
 END_C_DECLS
 
 #endif

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1336,8 +1336,7 @@ ucs_status_t uct_iface_mem_element_pack(uct_iface_h iface, uct_mem_h memh,
  */
 ucs_status_t
 uct_iface_stream_op_block(const uct_iface_h iface, uct_iface_stream_h stream,
-                          void (*ready_cb)(void *arg),
-                          void *ready_arg,
+                          void (*ready_cb)(void *arg), void *ready_arg,
                           uct_iface_stream_op_handle_h *op_handle);
 
 
@@ -1356,8 +1355,9 @@ uct_iface_stream_op_block(const uct_iface_h iface, uct_iface_stream_h stream,
  *
  * @return Error code.
  */
-ucs_status_t uct_iface_stream_op_unblock(
-        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
+ucs_status_t
+uct_iface_stream_op_unblock(const uct_iface_h iface,
+                            uct_iface_stream_op_handle_h op_handle);
 
 
 END_C_DECLS

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -1104,3 +1104,27 @@ ucs_status_t uct_iface_mem_element_pack(uct_iface_h tl_iface, uct_mem_h memh,
     return iface->internal_ops->iface_mem_element_pack(tl_iface, memh, rkey,
                                                        mem_element);
 }
+
+ucs_status_t
+uct_iface_stream_op_block(const uct_iface_h iface, uct_iface_stream_h stream,
+                          void (*ready_cb)(void *arg),
+                          void *ready_arg,
+                          uct_iface_stream_op_handle_h *op_handle)
+{
+    if (iface->internal_ops.iface_stream_op_block == NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return iface->internal_ops.iface_stream_op_block(iface, stream,
+                                                     ready_cb, ready_arg, op_handle);
+}
+
+ucs_status_t uct_iface_stream_op_unblock(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle)
+{
+    if (iface->internal_ops.iface_stream_op_unblock == NULL) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return iface->internal_ops.iface_stream_op_unblock(iface, op_handle);
+}

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -1106,25 +1106,29 @@ ucs_status_t uct_iface_mem_element_pack(uct_iface_h tl_iface, uct_mem_h memh,
 }
 
 ucs_status_t
-uct_iface_stream_op_block(const uct_iface_h iface, uct_iface_stream_h stream,
-                          void (*ready_cb)(void *arg),
-                          void *ready_arg,
+uct_iface_stream_op_block(const uct_iface_h tl_iface, uct_iface_stream_h stream,
+                          void (*ready_cb)(void *arg), void *ready_arg,
                           uct_iface_stream_op_handle_h *op_handle)
 {
-    if (iface->internal_ops.iface_stream_op_block == NULL) {
+    const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+
+    if (iface->internal_ops->iface_stream_op_block == NULL) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    return iface->internal_ops.iface_stream_op_block(iface, stream,
-                                                     ready_cb, ready_arg, op_handle);
+    return iface->internal_ops->iface_stream_op_block(tl_iface, stream,
+                                                      ready_cb, ready_arg,
+                                                      op_handle);
 }
 
-ucs_status_t uct_iface_stream_op_unblock(
-        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle)
+ucs_status_t uct_iface_stream_op_unblock(const uct_iface_h tl_iface,
+                                         uct_iface_stream_op_handle_h op_handle)
 {
-    if (iface->internal_ops.iface_stream_op_unblock == NULL) {
+    const uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+
+    if (iface->internal_ops->iface_stream_op_unblock == NULL) {
         return UCS_ERR_UNSUPPORTED;
     }
 
-    return iface->internal_ops.iface_stream_op_unblock(iface, op_handle);
+    return iface->internal_ops->iface_stream_op_unblock(tl_iface, op_handle);
 }

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -318,11 +318,10 @@ typedef ucs_status_t (*uct_iface_mem_element_pack_func_t)(
         uct_device_mem_element_t *mem_element);
 
 
-/* Bock a stream operations and wait for previous operations to completed */
+/* Block a stream operations and wait for previous operations to complete */
 typedef ucs_status_t (*uct_iface_stream_op_block_func_t)(
         const uct_iface_h iface, uct_iface_stream_h stream,
-        void (*ready_cb)(void *),
-        void *arg,
+        void (*ready_cb)(void*), void *arg,
         uct_iface_stream_op_handle_h *op_handle);
 
 

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -318,18 +318,33 @@ typedef ucs_status_t (*uct_iface_mem_element_pack_func_t)(
         uct_device_mem_element_t *mem_element);
 
 
+/* Bock a stream operations and wait for previous operations to completed */
+typedef ucs_status_t (*uct_iface_stream_op_block_func_t)(
+        const uct_iface_h iface, uct_iface_stream_h stream,
+        void (*ready_cb)(void *),
+        void *arg,
+        uct_iface_stream_op_handle_h *op_handle);
+
+
+/* Unblock a stream operations */
+typedef ucs_status_t (*uct_iface_stream_op_unblock_func_t)(
+        const uct_iface_h iface, uct_iface_stream_op_handle_h op_handle);
+
+
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {
-    uct_iface_query_v2_func_t        iface_query_v2;
-    uct_iface_estimate_perf_func_t   iface_estimate_perf;
-    uct_iface_vfs_refresh_func_t     iface_vfs_refresh;
-    uct_iface_mem_element_pack_func_t iface_mem_element_pack;
-    uct_ep_query_func_t              ep_query;
-    uct_ep_invalidate_func_t         ep_invalidate;
-    uct_ep_connect_to_ep_v2_func_t   ep_connect_to_ep_v2;
-    uct_iface_is_reachable_v2_func_t iface_is_reachable_v2;
-    uct_ep_is_connected_func_t       ep_is_connected;
-    uct_ep_get_device_ep_func_t      ep_get_device_ep;
+    uct_iface_query_v2_func_t          iface_query_v2;
+    uct_iface_estimate_perf_func_t     iface_estimate_perf;
+    uct_iface_vfs_refresh_func_t       iface_vfs_refresh;
+    uct_iface_mem_element_pack_func_t  iface_mem_element_pack;
+    uct_ep_query_func_t                ep_query;
+    uct_ep_invalidate_func_t           ep_invalidate;
+    uct_ep_connect_to_ep_v2_func_t     ep_connect_to_ep_v2;
+    uct_iface_is_reachable_v2_func_t   iface_is_reachable_v2;
+    uct_ep_is_connected_func_t         ep_is_connected;
+    uct_ep_get_device_ep_func_t        ep_get_device_ep;
+    uct_iface_stream_op_block_func_t   iface_stream_op_block;
+    uct_iface_stream_op_unblock_func_t iface_stream_op_unblock;
 } uct_iface_internal_ops_t;
 
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -267,7 +267,8 @@ gtest_SOURCES += \
 	ucm/cuda_hooks.cc \
 	uct/cuda/test_switch_cuda_device.cc \
 	uct/cuda/test_cuda_ipc_md.cc \
-	uct/cuda/test_cuda_nvml.cc
+	uct/cuda/test_cuda_nvml.cc \
+	uct/cuda/test_cuda_stream.cc
 
 if HAVE_NVCC
 if HAVE_GPUNETIO # temporarily all device code depends on doca

--- a/test/gtest/uct/cuda/test_cuda_stream.cc
+++ b/test/gtest/uct/cuda/test_cuda_stream.cc
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <uct/uct_test.h>
+#include <cuda.h>
+
+
+class test_user_stream : public uct_test {
+protected:
+    void init() override
+    {
+        uct_test::init();
+
+        CUctxCreateParams params = {};
+        CUcontext ctx;
+        CUdevice dev;
+        ASSERT_EQ(CUDA_SUCCESS, cuInit(0));
+        ASSERT_EQ(CUDA_SUCCESS, cuDeviceGet(&dev, 0));
+        ASSERT_EQ(CUDA_SUCCESS, cuCtxCreate(&ctx, &params, 0, dev));
+
+        EXPECT_EQ(CUDA_SUCCESS,
+                  cuStreamCreate(&m_stream, CU_STREAM_NON_BLOCKING));
+        m_iface_stream = reinterpret_cast<uct_iface_stream_h>(m_stream);
+
+        entity *e = uct_test::create_entity(0ul);
+        m_iface   = e->iface();
+        m_entities.push_back(e);
+    }
+
+    void cleanup() override
+    {
+        EXPECT_EQ(CUDA_SUCCESS, cuStreamDestroy(m_stream));
+        uct_test::cleanup();
+    }
+
+    uct_iface_stream_op_handle_h m_op_handle;
+    uct_iface_h                  m_iface;
+    CUstream                     m_stream;
+    uct_iface_stream_h           m_iface_stream;
+
+private:
+};
+
+namespace {
+void increment_cb(void *arg)
+{
+    (*reinterpret_cast<int*>(arg))++;
+}
+
+void host_wait_cb(void *data)
+{
+    while (*reinterpret_cast<int*>(data) != 1) {
+        sched_yield();
+    }
+}
+} // namespace
+
+UCS_TEST_P(test_user_stream, stream_already_ready)
+{
+    int done = 0;
+
+    ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                            increment_cb, &done, &m_op_handle));
+    wait_for_value(&done, 1, true);
+    ASSERT_EQ(1, done);
+    ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, m_op_handle));
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+}
+
+UCS_TEST_P(test_user_stream, stream_not_ready_waited)
+{
+    int done = 0;
+
+    ASSERT_EQ(CUDA_SUCCESS, cuLaunchHostFunc(m_stream, host_wait_cb, &done));
+    ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                            increment_cb, &done, &m_op_handle));
+    done = 1;
+    wait_for_value(&done, 2, true);
+    ASSERT_EQ(2, done);
+    ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, m_op_handle));
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+}
+
+UCS_TEST_P(test_user_stream, stream_not_ready_unblocked)
+{
+    int done = 0;
+
+    ASSERT_EQ(CUDA_SUCCESS, cuLaunchHostFunc(m_stream, host_wait_cb, &done));
+    ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                            increment_cb, &done, &m_op_handle));
+    ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, m_op_handle));
+    done = 1;
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+}
+
+UCS_TEST_P(test_user_stream, stream_blocked_after)
+{
+    int done = 0, ready = 0;
+
+    auto host_signal_cb = [](void *data) { *reinterpret_cast<int*>(data) = 1; };
+
+    // Block user stream
+    ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                            increment_cb, &ready,
+                                            &m_op_handle));
+    ASSERT_EQ(CUDA_SUCCESS, cuLaunchHostFunc(m_stream, host_signal_cb, &done));
+
+    for (int i = 0; i < 1000; ++i) {
+        ASSERT_EQ(CUDA_ERROR_NOT_READY, cuStreamQuery(m_stream));
+    }
+    ASSERT_EQ(0, done);
+
+    ASSERT_EQ(0, ready);
+    ASSERT_EQ(1, uct_iface_progress(m_iface));
+    ASSERT_EQ(1, ready);
+
+    // Unblock user stream
+    ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, m_op_handle));
+    wait_for_value(&done, 1, true);
+    ASSERT_EQ(1, done);
+
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+}
+
+UCS_TEST_P(test_user_stream, stream_repeat)
+{
+    int done = 0, total = 30, ready = 0, count = 0;
+    std::vector<uct_iface_stream_op_handle_h> handles;
+    uct_iface_stream_op_handle_h op_handle;
+
+    for (auto i = 0; i < total; ++i) {
+        ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                                increment_cb, &ready,
+                                                &op_handle));
+        ASSERT_EQ(CUDA_SUCCESS,
+                  cuLaunchHostFunc(m_stream, increment_cb, &done));
+        handles.push_back(op_handle);
+    }
+
+    for (auto handle : handles) {
+        wait_for_value(&ready, ++count, true);
+        EXPECT_EQ(count, ready);
+        ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, handle));
+    }
+
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+    ASSERT_EQ(total, done);
+}
+
+UCS_TEST_P(test_user_stream, stream_arm_busy)
+{
+    int ready = 0, fd;
+    uct_iface_stream_op_handle_h handle;
+
+    ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                            increment_cb, &ready, &handle));
+    ASSERT_UCS_OK(uct_iface_event_fd_get(m_iface, &fd));
+    ASSERT_EQ(UCS_ERR_BUSY, uct_iface_event_arm(m_iface, 0));
+    ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, handle));
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+}
+
+UCS_TEST_P(test_user_stream, stream_arm_success)
+{
+    int done = 0, ready = 0, fd;
+    uct_iface_stream_op_handle_h handle;
+    uct_test::async_event_ctx async_event_ctx;
+
+    ASSERT_EQ(CUDA_SUCCESS, cuLaunchHostFunc(m_stream, host_wait_cb, &done));
+    ASSERT_UCS_OK(uct_iface_stream_op_block(m_iface, m_iface_stream,
+                                            increment_cb, &ready, &handle));
+    ASSERT_UCS_OK(uct_iface_event_fd_get(m_iface, &fd));
+    ASSERT_EQ(UCS_OK, uct_iface_event_arm(m_iface, 0));
+    ASSERT_UCS_OK(uct_iface_stream_op_unblock(m_iface, handle));
+
+    ASSERT_FALSE(async_event_ctx.wait_for_event(*m_entities.back(), 0.2));
+    done = 1;
+    EXPECT_TRUE(async_event_ctx.wait_for_event(*m_entities.back(), 1.));
+    EXPECT_EQ(CUDA_SUCCESS, cuStreamSynchronize(m_stream));
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_user_stream, cuda_copy)


### PR DESCRIPTION
## What?
Introduce UCT Stream API.

## Why?
User need to be able to guarantee ordering of endpoint operations with regard to a given stream.

## How?
Make sure to start UCX endpoint operations after all pre-existing work on a given stream has completed, and only allow work queued on a stream after UCX request creation, to proceed after given request has completed.