### PR TITLE
CI/CODESPELL: Skip submodule path

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -33,10 +33,7 @@ mkdir -p config/m4 config/aux
 
 if [ "X$with_ucg" = "Xyes" ]
 then
-	git submodule update --init --recursive --remote src/ucg
-elif [ -f src/ucg/configure.m4 ]
-then
-	git submodule deinit -f src/ucg
+	git submodule update --init --recursive --remote
 fi
 
 autoreconf -v --install || exit 1

--- a/buildlib/tools/codestyle.sh
+++ b/buildlib/tools/codestyle.sh
@@ -34,6 +34,5 @@ codestyle_check_spell() {
     python3 -m venv /tmp/codespell_env
     source /tmp/codespell_env/bin/activate
     pip3 install codespell
-
     codespell $(codespell_skip_args) "$@"
 }


### PR DESCRIPTION
## What?
Ignore spell checking for submodules.