### PR TITLE
UCT/IB/MLX5/GDAKI: Disable dma_buf by default

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -125,6 +125,10 @@ ucs_config_field_t uct_ib_md_config_table[] = {
      ucs_offsetof(uct_ib_md_config_t, ext.gda_max_hca_per_gpu),
      UCS_CONFIG_TYPE_UINT},
 
+    {"GDA_DMABUF_ENABLE", "n",
+     "Enable DMA-BUF in GDA.",
+     ucs_offsetof(uct_ib_md_config_t, ext.gda_dmabuf_enable), UCS_CONFIG_TYPE_BOOL},
+
     {"PCI_BW", "",
      "Maximum effective data transfer rate of PCI bus connected to HCA\n",
      ucs_offsetof(uct_ib_md_config_t, pci_bw), UCS_CONFIG_TYPE_ARRAY(pci_bw)},

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -111,6 +111,7 @@ typedef struct uct_ib_md_ext_config {
     unsigned                 smkey_block_size; /**< Mkey indexes in a symmetric block */
     int                      direct_nic; /**< Direct NIC with GPU functionality */
     unsigned                 gda_max_hca_per_gpu; /**< Threshold of IB per GPU */
+    int                      gda_dmabuf_enable; /**< Enable DMA-BUF in GDA */
 } uct_ib_md_ext_config_t;
 
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -97,7 +97,8 @@ static int uct_gdaki_is_dmabuf_supported(const uct_ib_md_t *md)
         return dmabuf_supported;
     }
 
-    dmabuf_supported = !!(md->cap_flags & UCT_MD_FLAG_REG_DMABUF) &&
+    dmabuf_supported = md->config.gda_dmabuf_enable &&
+                       !!(md->cap_flags & UCT_MD_FLAG_REG_DMABUF) &&
                        uct_cuda_copy_md_is_dmabuf_supported();
     return dmabuf_supported;
 }


### PR DESCRIPTION
## Why?
Temporarily, before we fix it.
