### PR TITLE
fix: Update autogen.sh to install dependencies

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -36,5 +36,6 @@ then
 	git submodule update --init --recursive --remote
 fi
 
-autoreconf -v --install || exit 1
+sudo apt install -y autoconf automake libtool pkg-config || exit 1
+#autoreconf -v --install || exit 1
 rm -rf autom4te.cache


### PR DESCRIPTION
Replaced autoreconf command with apt install for dependencies.

## What?
_Describe what this PR is doing._
fix: The default autoreconf -v -install || exit 1 line of command is failing when launching from autogen.sh with autoreconf not found.
## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._
Not sure if there is any related bug for this autogen script file.
## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
By adding command to install autoconf, automake, lib tool and pkg-config ensures no missing of install of autoconf. 