### PR TITLE
UCS/ARCH: Improve tsc freq measurement accuracy for x86_64

### DIFF
--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -287,7 +287,7 @@ static double ucs_arch_x86_tsc_freq_from_cpu_model()
 
 static double ucs_arch_x86_tsc_freq_measure()
 {
-    static const double relative_accuracy = 1e-6; /* 1KHz for every 1GHz */
+    static const double relative_accuracy = 3e-6; /* 3KHz for every 1GHz */
     static const double max_time          = 1e-3; /* 1ms */
     static const unsigned init_iterations = 10;
     static const unsigned max_count       = 10;
@@ -321,8 +321,8 @@ static double ucs_arch_x86_tsc_freq_measure()
     /* Calculate the frequency and stop when the relative error is below
        the required accuracy threshold */
     relative_error = 0.0;
-    curr_freq = 0.0;
-    count     = 0;
+    curr_freq      = 0.0;
+    count          = 0;
     do {
         prev_freq = curr_freq;
 


### PR DESCRIPTION
## What?
Improve tsc freq measurement accuracy for x86_64

## Why?
The current implementation does not reach the promised accuracy (5 digits after decimal point) and is inconsistent (example below)
This may cause variation in time measurements that use this frequency to convert clock cycles to time (for example in `ucx_perftest`)


<details>
<summary>Before Change</summary>

```
[1767611329.975743] [funk21:3073005:0]             cpu.c:338  UCX  DEBUG measured tsc frequency 2593.715 MHz after 0.30 ms
[1767611338.713300] [funk21:3073029:0]             cpu.c:338  UCX  DEBUG measured tsc frequency 2596.700 MHz after 0.32 ms
[1767611343.342336] [funk21:3073098:0]             cpu.c:338  UCX  DEBUG measured tsc frequency 2591.702 MHz after 0.09 ms
[1767611348.157724] [funk21:3073119:0]             cpu.c:338  UCX  DEBUG measured tsc frequency 2552.643 MHz after 0.03 ms
[1767611351.999610] [funk21:3073141:0]             cpu.c:338  UCX  DEBUG measured tsc frequency 2584.050 MHz after 0.12 ms
```

</details>

<details>
<summary>After Change</summary>

```
[1767713345.653713] [funk07:1782993:0]             cpu.c:353  UCX  DEBUG measured tsc frequency 2595.163 MHz after 0.28 ms (relative error 5.24e-07)
[1767713396.947277] [funk07:1783447:0]             cpu.c:353  UCX  DEBUG measured tsc frequency 2595.159 MHz after 0.28 ms (relative error 6.05e-07)
[1767713407.449480] [funk07:1783529:0]             cpu.c:353  UCX  DEBUG measured tsc frequency 2595.161 MHz after 0.29 ms (relative error 5.87e-07)
[1767713412.160808] [funk07:1783550:0]             cpu.c:353  UCX  DEBUG measured tsc frequency 2595.163 MHz after 0.28 ms (relative error 5.89e-07)
[1767713417.528252] [funk07:1783573:0]             cpu.c:353  UCX  DEBUG measured tsc frequency 2595.159 MHz after 0.29 ms (relative error 5.87e-07)

```

</details>

## How?
- Use `clock_gettime` to get nanosecond precision time measurements
- Use only most recent measurement instead of averaging
- Use counter to ensure stability and consistency

_**Note:**_ I chose a relative accuracy of `3e-6` which means ~3KHz error for every 1GHz, it is possible to get even more accurate but it may be required to increase the `1ms` time limit.
