### PR TITLE
UCP/PROTO: Refactoring: move perf node into ucp_proto_perf_node_t

### DIFF
--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -176,6 +176,9 @@ typedef struct {
 
     /* Maximum single message length */
     size_t max_frag;
+
+    /* Performance selection tree node */
+    ucp_proto_perf_node_t *node;
 } ucp_proto_common_tl_perf_t;
 
 
@@ -279,8 +282,7 @@ void ucp_proto_common_lane_perf_node(ucp_context_h context,
 ucs_status_t
 ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                ucp_lane_index_t lane,
-                               ucp_proto_common_tl_perf_t *perf,
-                               ucp_proto_perf_node_t **perf_node_p);
+                               ucp_proto_common_tl_perf_t *perf);
 
 
 typedef int (*ucp_proto_common_filter_lane_cb_t)(

--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -130,7 +130,6 @@ ucp_proto_init_skip_recv_overhead(const ucp_proto_common_init_params_t *params,
 static ucs_status_t
 ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
                            const ucp_proto_common_tl_perf_t *tl_perf,
-                           ucp_proto_perf_node_t *const tl_perf_node,
                            size_t range_start, size_t range_end,
                            ucp_proto_perf_t *perf)
 {
@@ -186,7 +185,7 @@ ucp_proto_init_add_tl_perf(const ucp_proto_common_init_params_t *params,
     return ucp_proto_perf_add_funcs(perf, range_start, range_end, perf_factors,
                                     ucp_proto_perf_node_new_data("transport",
                                                                  ""),
-                                    tl_perf_node);
+                                    tl_perf->node);
 }
 
 /**
@@ -504,7 +503,6 @@ ucp_proto_common_check_mem_access(const ucp_proto_common_init_params_t *params)
 
 ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
                                  const ucp_proto_common_tl_perf_t *tl_perf,
-                                 ucp_proto_perf_node_t *const tl_perf_node,
                                  ucp_md_map_t reg_md_map, const char *perf_name,
                                  ucp_proto_perf_t **perf_p)
 {
@@ -533,8 +531,8 @@ ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
         return status;
     }
 
-    status = ucp_proto_init_add_tl_perf(params, tl_perf, tl_perf_node,
-                                        range_start, range_end, perf);
+    status = ucp_proto_init_add_tl_perf(params, tl_perf, range_start, range_end,
+                                        perf);
     if (status != UCS_OK) {
         goto err_cleanup_perf;
     }

--- a/src/ucp/proto/proto_init.h
+++ b/src/ucp/proto/proto_init.h
@@ -68,7 +68,6 @@ ucp_proto_init_add_buffer_copy_time(ucp_worker_h worker, const char *title,
 
 ucs_status_t ucp_proto_init_perf(const ucp_proto_common_init_params_t *params,
                                  const ucp_proto_common_tl_perf_t *tl_perf,
-                                 ucp_proto_perf_node_t *const tl_perf_node,
                                  ucp_md_map_t reg_md_map, const char *perf_name,
                                  ucp_proto_perf_t **perf_p);
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -160,8 +160,8 @@ static ucp_sys_dev_map_t ucp_proto_multi_init_flush_sys_dev_mask(
 
 static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         ucp_lane_index_t num_lanes, const ucp_proto_init_params_t *params,
-        const ucp_proto_common_tl_perf_t *tl_perfs, int fixed_first_lane,
-        ucp_lane_index_t *lanes, ucp_proto_perf_node_t **perf_nodes)
+        ucp_proto_common_tl_perf_t *tl_perfs, int fixed_first_lane,
+        ucp_lane_index_t *lanes)
 {
     ucp_lane_index_t num_max_bw_devs = 0;
     double max_bandwidth;
@@ -209,7 +209,7 @@ static ucp_lane_index_t ucp_proto_multi_filter_net_devices(
         tl_rsc = ucp_proto_common_get_tl_rsc(params, lane);
         if ((tl_rsc->dev_type == UCT_DEVICE_TYPE_NET) &&
             (tl_rsc->sys_device != sys_devs[seed])) {
-            ucp_proto_perf_node_deref(&perf_nodes[lane]);
+            ucp_proto_perf_node_deref(&tl_perfs[lane].node);
             ucs_trace("filtered out " UCP_PROTO_LANE_FMT,
                       UCP_PROTO_LANE_ARG(params, lane, &tl_perfs[lane]));
         } else {
@@ -225,16 +225,14 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                                   ucp_proto_perf_t **perf_p,
                                   ucp_proto_multi_priv_t *mpriv)
 {
-    ucp_context_h context         = params->super.super.worker->context;
-    const double max_bw_ratio     = context->config.ext.multi_lane_max_ratio;
-    ucp_proto_perf_node_t *lanes_perf_nodes[UCP_PROTO_MAX_LANES];
+    ucp_context_h context     = params->super.super.worker->context;
+    const double max_bw_ratio = context->config.ext.multi_lane_max_ratio;
     ucp_proto_common_tl_perf_t lanes_perf[UCP_PROTO_MAX_LANES];
     ucp_proto_common_tl_perf_t *lane_perf, perf;
     ucp_lane_index_t lanes[UCP_PROTO_MAX_LANES];
     double max_bandwidth, max_frag_ratio, min_bandwidth;
     ucp_lane_index_t i, lane, num_lanes, num_fast_lanes;
     ucp_proto_multi_lane_priv_t *lpriv;
-    ucp_proto_perf_node_t *perf_node;
     size_t max_frag, min_length, min_end_offset, min_chunk;
     ucp_proto_lane_selection_t selection;
     ucp_md_map_t reg_md_map;
@@ -282,8 +280,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         lane      = lanes[i];
         lane_perf = &lanes_perf[lane];
 
-        status = ucp_proto_common_get_lane_perf(&params->super, lane, lane_perf,
-                                                &lanes_perf_nodes[lane]);
+        status = ucp_proto_common_get_lane_perf(&params->super, lane, lane_perf);
         if (status != UCS_OK) {
             return status;
         }
@@ -310,7 +307,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         if ((lane_perf->bandwidth * max_bw_ratio) < max_bandwidth) {
             /* Bandwidth on this lane is too low compared to the fastest
                available lane, so it's not worth using it */
-            ucp_proto_perf_node_deref(&lanes_perf_nodes[lane]);
+            ucp_proto_perf_node_deref(&lanes_perf[lane].node);
             ucs_trace("drop " UCP_PROTO_LANE_FMT,
                       UCP_PROTO_LANE_ARG(&params->super.super, lane, lane_perf));
         } else {
@@ -325,8 +322,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
         num_lanes = ucp_proto_multi_filter_net_devices(num_lanes,
                                                        &params->super.super,
                                                        lanes_perf,
-                                                       fixed_first_lane, lanes,
-                                                       lanes_perf_nodes);
+                                                       fixed_first_lane, lanes);
     }
 
     ucp_proto_multi_select_bw_lanes(&params->super.super, lanes, num_lanes,
@@ -468,27 +464,26 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     }
     ucs_assert(mpriv->num_lanes == ucs_popcount(selection.lane_map));
 
-    /* After this block, 'perf_node' and 'lane_perf_nodes[]' have extra ref */
     if (mpriv->num_lanes == 1) {
-        perf_node = lanes_perf_nodes[ucs_ffs64(selection.lane_map)];
-        ucp_proto_perf_node_ref(perf_node);
+        perf.node = lanes_perf[ucs_ffs64(selection.lane_map)].node;
+        ucp_proto_perf_node_ref(perf.node);
     } else {
-        perf_node = ucp_proto_perf_node_new_data("multi", "%u lanes",
+        perf.node = ucp_proto_perf_node_new_data("multi", "%u lanes",
                                                  mpriv->num_lanes);
         ucs_for_each_bit(lane, selection.lane_map) {
             ucs_assert(lane < UCP_MAX_LANES);
-            ucp_proto_perf_node_add_child(perf_node, lanes_perf_nodes[lane]);
+            ucp_proto_perf_node_add_child(perf.node, lanes_perf[lane].node);
         }
     }
 
-    status = ucp_proto_init_perf(&params->super, &perf, perf_node, reg_md_map,
-                                 perf_name, perf_p);
+    status = ucp_proto_init_perf(&params->super, &perf, reg_md_map, perf_name,
+                                 perf_p);
 
     /* Deref unused nodes */
     for (i = 0; i < num_lanes; ++i) {
-        ucp_proto_perf_node_deref(&lanes_perf_nodes[lanes[i]]);
+        ucp_proto_perf_node_deref(&lanes_perf[lanes[i]].node);
     }
-    ucp_proto_perf_node_deref(&perf_node);
+    ucp_proto_perf_node_deref(&perf.node);
 
     return status;
 }

--- a/src/ucp/proto/proto_single.c
+++ b/src/ucp/proto/proto_single.c
@@ -24,7 +24,6 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
 {
     const char *proto_name = ucp_proto_id_field(params->super.super.proto_id,
                                                 name);
-    ucp_proto_perf_node_t *tl_perf_node;
     ucp_proto_common_tl_perf_t tl_perf;
     ucp_lane_index_t num_lanes;
     ucp_md_map_t reg_md_map;
@@ -57,15 +56,14 @@ ucs_status_t ucp_proto_single_init(const ucp_proto_single_init_params_t *params,
 
     ucp_proto_common_lane_priv_init(&params->super, reg_md_map, lane,
                                     &spriv->super);
-    status = ucp_proto_common_get_lane_perf(&params->super, lane, &tl_perf,
-                                            &tl_perf_node);
+    status = ucp_proto_common_get_lane_perf(&params->super, lane, &tl_perf);
     if (status != UCS_OK) {
         return status;
     }
 
-    status = ucp_proto_init_perf(&params->super, &tl_perf, tl_perf_node,
-                                 reg_md_map, proto_name, perf_p);
-    ucp_proto_perf_node_deref(&tl_perf_node);
+    status = ucp_proto_init_perf(&params->super, &tl_perf, reg_md_map,
+                                 proto_name, perf_p);
+    ucp_proto_perf_node_deref(&tl_perf.node);
 
     return status;
 }


### PR DESCRIPTION
## What?
Minor refactoring that moves perf node into ucp_proto_perf_node_t structure.
These 2 structures are always used together and related 1:1. This will simplify implementation of the lane selection variants (https://github.com/openucx/ucx/pull/10778)

## Why?
The goals of this refactoring are:
- reduce number of arguments passed to the functions
- reduce number of local variables
- simplify business logic
