### PR TITLE
UCT/IB/DFLOW: Fixed async event lookup bug

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -446,6 +446,9 @@ static void uct_ib_async_event_handler(int fd, ucs_event_set_types_t events,
 #if HAVE_DECL_IBV_EVENT_GID_CHANGE
     case IBV_EVENT_GID_CHANGE:
 #endif
+#if HAVE_DECL_IBV_EVENT_PORT_SPEED_CHANGE
+    case IBV_EVENT_PORT_SPEED_CHANGE:
+#endif
     case IBV_EVENT_LID_CHANGE:
     case IBV_EVENT_PKEY_CHANGE:
     case IBV_EVENT_SM_CHANGE:
@@ -525,6 +528,14 @@ void uct_ib_handle_async_event(uct_ib_device_t *dev, uct_ib_async_event_t *event
                  ibv_event_type_str(event->event_type), event->port_num);
         level = UCS_LOG_LEVEL_WARN;
         break;
+#if HAVE_DECL_IBV_EVENT_PORT_SPEED_CHANGE
+    case IBV_EVENT_PORT_SPEED_CHANGE:
+        snprintf(event_info, sizeof(event_info), "%s on port %d",
+                 ibv_event_type_str(event->event_type), event->port_num);
+        uct_ib_device_async_event_dispatch(dev, event);
+        level = UCS_LOG_LEVEL_DIAG;
+        break;
+#endif
     default:
         snprintf(event_info, sizeof(event_info), "%s (%d)",
                  ibv_event_type_str(event->event_type), event->event_type);

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -182,7 +182,7 @@ KHASH_TYPE(uct_ib_ah, struct ibv_ah_attr, struct ibv_ah*);
 typedef struct uct_ib_async_event {
     enum ibv_event_type event_type;             /* Event type */
     union {
-        uint8_t         port_num;               /* Port number */
+        uint32_t        port_num;               /* Port number */
         uint32_t        qp_num;                 /* QP number */
         uint32_t        dct_num;                /* DCT number */
         void            *cookie;                /* Pointer to resource */

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1662,6 +1662,7 @@ unsigned uct_ib_iface_port_speed_change_progress(void *arg)
 
     async_ctx->cb(async_ctx->arg, UCT_EVENT_SPEED_CHANGE);
     ucs_callbackq_remove_safe(async_ctx->super.cbq, async_ctx->super.cb_id);
+    async_ctx->super.cb_id = UCS_CALLBACKQ_ID_NULL;
     return 1;
 }
 
@@ -1916,10 +1917,10 @@ int uct_ib_iface_prepare_rx_wrs(uct_ib_iface_t *iface, ucs_mpool_t *mp,
 static uct_ppn_bandwidth_t
 uct_ib_iface_get_bandwidth(uct_ib_iface_t *iface, double wire_speed)
 {
-    uct_ib_md_t *md      = uct_ib_iface_md(iface);
-    uint8_t active_mtu   = uct_ib_iface_port_attr(iface)->active_mtu;
-    size_t mtu           = ucs_min(uct_ib_mtu_value((enum ibv_mtu)active_mtu),
-                                   iface->config.seg_size);
+    uct_ib_md_t *md    = uct_ib_iface_md(iface);
+    uint8_t active_mtu = uct_ib_iface_port_attr(iface)->active_mtu;
+    size_t mtu         = ucs_min(uct_ib_mtu_value((enum ibv_mtu)active_mtu),
+                                 iface->config.seg_size);
     size_t extra_pkt_len;
     uct_ppn_bandwidth_t bandwidth;
 


### PR DESCRIPTION
## What?
This PR contains several small fixes related to IB async events:
1. Change type of `uct_ib_async_event_t::port_num` from `uint8_t` to `uint32_t`
We always setup events by `uint32_t resource_id`, even for port_num. But when event occurs, then we use uint8_t port_num from union, which may not match uint32_t (either because of non-zero garbage in local variable or big-endian). As a result, port events were not dispatched
2. Added missing switch cases for port speed events
3. Minor formatting fix from previous PR
