### PR TITLE
UCT/IB: Use global traffic class for RoCEv2 with auto configuration

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1006,19 +1006,21 @@ int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
 }
 
 unsigned long
-uct_ib_device_query_roce_tclass(const char *dev_name, uint8_t port_num)
+uct_ib_device_query_roce_tclass(uct_ib_device_t *dev, uint8_t port_num)
 {
-    char buf[128];
+    char buf[64];
     unsigned long tclass;
     int ret;
 
-    ret = ucs_read_file(buf, sizeof(buf) - 1, 1, UCT_IB_DEVICE_SYSFS_ROCE_TC,
-                        dev_name, port_num);
+    ret = ucs_read_file(buf, sizeof(buf) - 1, 1,
+                        UCT_IB_DEVICE_SYSFS_ROCE_TC_FMT,
+                        uct_ib_device_name(dev), port_num);
     if ((ret < 0) || (sscanf(buf, "Global tclass=%lu", &tclass) != 1)) {
         tclass = UCT_IB_DEFAULT_ROCEV2_DSCP;
     }
 
-    ucs_debug("'%s:%d' global_traffic_class=%lu", dev_name, port_num, tclass);
+    ucs_debug("'%s:%d' global_traffic_class=%lu",
+              uct_ib_device_name(dev), port_num, tclass);
     return tclass;
 }
 

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -68,7 +68,7 @@
 #define UCT_IB_DEVICE_SYSFS_GID_ATTR_PFX  UCT_IB_DEVICE_SYSFS_PFX "/ports/%d/gid_attrs"
 #define UCT_IB_DEVICE_SYSFS_GID_TYPE_FMT  UCT_IB_DEVICE_SYSFS_GID_ATTR_PFX "/types/%d"
 #define UCT_IB_DEVICE_SYSFS_GID_NDEV_FMT  UCT_IB_DEVICE_SYSFS_GID_ATTR_PFX "/ndevs/%d"
-#define UCT_IB_DEVICE_SYSFS_ROCE_TC       UCT_IB_DEVICE_SYSFS_PFX "/tc/%d/traffic_class"
+#define UCT_IB_DEVICE_SYSFS_ROCE_TC_FMT   UCT_IB_DEVICE_SYSFS_PFX "/tc/%d/traffic_class"
 #define UCT_IB_DEVICE_ECE_DEFAULT         0x0         /* default ECE */
 #define UCT_IB_DEVICE_ECE_MAX             0xffffffffU /* max ECE */
 #define UCT_IB_DEVICE_DEFAULT_GID_INDEX 0   /* The gid index used by default for an IB/RoCE port */
@@ -452,7 +452,7 @@ int uct_ib_device_test_roce_gid_index(uct_ib_device_t *dev, uint8_t port_num,
                                       uint8_t gid_index);
 
 unsigned long
-uct_ib_device_query_roce_tclass(const char *dev_name, uint8_t port_num);
+uct_ib_device_query_roce_tclass(uct_ib_device_t *dev, uint8_t port_num);
 
 ucs_status_t
 uct_ib_device_async_event_register(uct_ib_device_t *dev,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1755,8 +1755,7 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
     if (config->traffic_class == UCS_ULUNITS_AUTO) {
         self->config.traffic_class =
                 uct_ib_iface_is_roce_v2(self) ?
-                        uct_ib_device_query_roce_tclass(uct_ib_device_name(dev),
-                                                        port_num) :
+                        uct_ib_device_query_roce_tclass(dev, port_num) :
                         0;
     } else {
         self->config.traffic_class = config->traffic_class;


### PR DESCRIPTION
## What?
Use any global traffic configured for RoCEv2, from:
```
$ cat /sys/class/infiniband/mlx5_0/tc/1/traffic_class
Global tclass=106
```