### PR TITLE
ARCH/X86: Enable erms memcpy for Turin

### DIFF
--- a/config/ucx.conf
+++ b/config/ucx.conf
@@ -36,3 +36,10 @@ CPU model=Milan
 # TODO: Add gdrcopy rcache overhead as separate performance graph node
 # TODO: Add rcache overhead not only for Milan and GH systems
 UCX_GDR_COPY_LAT=get:1.65e-6,put:0.65e-6
+
+[AMD Turin]
+CPU model=Turin
+# Configure ERMS (Enhanced REP MOVSB) instructions range optimized for Turin
+# Use within range: 26KB - 8MB
+UCX_BUILTIN_MEMCPY_MIN=26KB
+UCX_BUILTIN_MEMCPY_MAX=8MB


### PR DESCRIPTION
## What?
Enable ucx builtin_memcpy for Turin
