### PR TITLE
AZP: fetch submodules in codestyle

### DIFF
--- a/buildlib/pr/codestyle.yml
+++ b/buildlib/pr/codestyle.yml
@@ -103,7 +103,7 @@ jobs:
         retryCountOnTaskFailure: 5
 
       - bash: |
-          set -eE
+          set -eEx
           source ./buildlib/tools/codestyle.sh
           codestyle_check_spell
         displayName: codespell test

--- a/buildlib/tools/codestyle.sh
+++ b/buildlib/tools/codestyle.sh
@@ -34,6 +34,5 @@ codestyle_check_spell() {
     python3 -m venv /tmp/codespell_env
     source /tmp/codespell_env/bin/activate
     pip3 install codespell
-    echo codespell $(codespell_skip_args) "$@"
     codespell $(codespell_skip_args) "$@"
 }


### PR DESCRIPTION
## Why?
This way code style check will be able to read list of submodules for git configuration.