### PR TITLE
UCP/PROTO: Round-robin for multi protocols

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -156,6 +156,13 @@ const char *ucp_extra_op_attr_flags_names[] = {
 static UCS_CONFIG_DEFINE_ARRAY(memunit_sizes, sizeof(size_t),
                                UCS_CONFIG_TYPE_MEMUNITS);
 
+static const char *ucp_round_robin_modes[] = {
+    [UCP_ROUND_ROBIN_MODE_DISABLED] = "disabled",
+    [UCP_ROUND_ROBIN_MODE_ALWAYS]   = "always",
+    [UCP_ROUND_ROBIN_MODE_FLUSH]    = "flush",
+    NULL
+};
+
 static ucs_config_field_t ucp_context_config_table[] = {
   {"SELECT_DISTANCE_MD", "cuda_cpy",
    "MD whose distance is queried when evaluating transport selection score",
@@ -282,6 +289,15 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "          the DEVICE atomic mode, the DEVICE mode is selected.\n"
    "          Otherwise the CPU mode is selected.",
    ucs_offsetof(ucp_context_config_t, atomic_mode), UCS_CONFIG_TYPE_ENUM(ucp_atomic_modes)},
+
+  {"LANE_ROUND_ROBIN", "always",
+   "Round-robin mode for multi-lane protocols.\n"
+   " disabled - No round-robin, always use first lane.\n"
+   " always   - Use round-robin without resetting on flush (default).\n"
+   " flush    - Use round-robin and reset to first lane on flush.\n"
+   "Resetting on flush ensures deterministic lane selection after flush operations.",
+   ucs_offsetof(ucp_context_config_t, round_robin_mode),
+   UCS_CONFIG_TYPE_ENUM(ucp_round_robin_modes)},
 
   {"ADDRESS_DEBUG_INFO",
 #if ENABLE_DEBUG_DATA

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -48,6 +48,16 @@ enum {
                                 UCP_OP_ATTR_FLAG_FAST_CMPL      | \
                                 UCP_OP_ATTR_FLAG_MULTI_SEND)
 
+
+/**
+ * Round-robin mode for multi-lane protocols
+ */
+typedef enum {
+    UCP_ROUND_ROBIN_MODE_DISABLED = 0,  /* No round-robin, always use first lane */
+    UCP_ROUND_ROBIN_MODE_ALWAYS   = 1,  /* Round-robin without reset on flush */
+    UCP_ROUND_ROBIN_MODE_FLUSH    = 2   /* Round-robin with reset on flush */
+} ucp_round_robin_mode_t;
+
 #define UCP_OP_ATTR_INDEX(_op_attr_flag) \
     (ucs_ilog2(ucp_proto_select_op_attr_pack((_op_attr_flag), \
                                              UCP_OP_ATTR_INDEX_MASK)))
@@ -114,6 +124,8 @@ typedef struct ucp_context_config {
     unsigned                               max_worker_address_name;
     /** Atomic mode */
     ucp_atomic_mode_t                      atomic_mode;
+    /** Round-robin mode for multi-lane protocols */
+    ucp_round_robin_mode_t                 round_robin_mode;
     /** If use mutex for MT support or not */
     int                                    use_mt_mutex;
     /** On-demand progress */

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -211,6 +211,7 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
     ep->am_lane                           = UCP_NULL_LANE;
     ep->flags                             = 0;
     ep->conn_sn                           = UCP_EP_MATCH_CONN_SN_MAX;
+    ep->flush_generation                  = 0;
 #if UCS_ENABLE_ASSERT
     ep->refcounts.create                  =
     ep->refcounts.flush                   =

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -580,6 +580,11 @@ typedef struct ucp_ep {
     uct_ep_h                      uct_eps[UCP_MAX_FAST_PATH_LANES];
     ucp_ep_ext_t                  *ext;                   /* Endpoint extension */
 
+    /* Flush generation counter - incremented on each flush operation.
+     * Used by multi-lane protocols to detect when round-robin state should
+     * be reset. Provides lazy reset without tracking protocol configs. */
+    uint32_t                      flush_generation;
+
 #if ENABLE_DEBUG_DATA
     char                          peer_name[UCP_WORKER_ADDRESS_NAME_MAX];
     /* Endpoint name for tracing and analysis */

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -373,6 +373,8 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     mpriv->min_frag     = 0;
     mpriv->max_frag_sum = 0;
     mpriv->align_thresh = 1;
+    mpriv->rr_lane_idx   = 0;
+    mpriv->rr_generation = 0;
     perf.max_frag       = 0;
     perf.min_length     = 0;
     weight_sum          = 0;

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -101,6 +101,12 @@ typedef struct {
     ucp_lane_index_t            num_lanes;    /* Number of lanes to use */
     size_t                      align_thresh; /* Cached value of threshold for
                                                  enabling data split alignment */
+    /* Round-robin state with generation tracking.
+     * NOTE: These fields are mutable even though accessed via const pointer,
+     * as they represent cached per-endpoint runtime state. The generation
+     * number allows lazy reset on flush without tracking protocol configs. */
+    ucp_lane_index_t            rr_lane_idx;  /* Round-robin lane index counter */
+    uint32_t                    rr_generation; /* Generation when last used */
     ucp_proto_multi_lane_priv_t lanes[UCP_MAX_LANES]; /* Array of lanes */
 } ucp_proto_multi_priv_t;
 


### PR DESCRIPTION
## What?
Proposal for multi-protocol round robin. On system with 4 equal rails, performance gain can be with nixlbench:
- 512 B batch 2048
    - 0.771 GB/s to 0.915 GB/s
- 2 KB  batch 2048
    - 3.064 GB/s to 3.650 GB/s
- 8 KB  batch 2048
   - 1.864 GB/s to 14.618 GB/s (>7x)