### PR TITLE
AZP: Propogate Coverity failures

### DIFF
--- a/buildlib/tools/coverity.sh
+++ b/buildlib/tools/coverity.sh
@@ -104,6 +104,7 @@ run_coverity() {
 	fi
 	cov-analyze --jobs $parallel_jobs $COV_OPT --disable PARSE_ERROR --security --concurrency --dir $cov_build
 	nerrors=$(cov-format-errors --dir $cov_build | awk '/Processing [0-9]+ errors?/ { print $2 }')
+	# Fail on empty output (e.g. license expiration)
 	[ -n "$nerrors" ] || { echo "ERROR: cov-format-errors failed"; exit 1; }
 
 	if [ $nerrors -gt 0 ]; then


### PR DESCRIPTION
## What?
Fail the Coverity Azure job if `cov-format-errors` fails.

## Why?
Fix silent Coverity failures such as license expiration.

## How?
Add a check after parsing `cov-format-errors` output: if `nerrors` is empty, exit 1.