### PR TITLE
CI: Run ASAN GPU tests on CUDA 13 container

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -447,7 +447,7 @@ stages:
         name: gpu
         demands: ucx_gpu -equals yes
         test_perf: 0
-        container: centos8_cuda11_asan
+        container: ubuntu24_cuda13
         asan_check: yes
     - template: tests.yml
       parameters:


### PR DESCRIPTION
## What?
Switch AddressSanitizer GPU CI job to a CUDA 13 container.

## Why?
Align ASAN GPU testing with the general GPU tests that use CUDA 13.

## How?
Update the `AddressSanitizer` stage GPU job `container` in `ucx/buildlib/pr/main.yml` to use the existing `ubuntu24_cuda13` resource.