### PR TITLE
CI: rm copyright headers

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -1,8 +1,4 @@
-# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
-# See file LICENSE for terms.
-
 # A workflow to trigger ci on hybrid infra (github + self hosted runner)
-
 name: Blossom-CI
 run-name: >
   ${{ github.event_name == 'workflow_dispatch' &&


### PR DESCRIPTION
## What?
Fix Blossom workflow template validation by removing the copyright header.

## Why?
Blossom validates the workflow file against a strict template format.