### PR TITLE
v1.20.x CI/CODESPELL: Skip submodule path (#11078)

### DIFF
--- a/buildlib/tools/codestyle.sh
+++ b/buildlib/tools/codestyle.sh
@@ -23,9 +23,16 @@ codestyle_check_commit_title() {
     return $err
 }
 
+codespell_skip_args() {
+    for path in $(git config --file .gitmodules --get-regexp path | cut -f2 -d' ')
+    do
+        echo --skip "./$path/*"
+    done
+}
+
 codestyle_check_spell() {
     python3 -m venv /tmp/codespell_env
     source /tmp/codespell_env/bin/activate
     pip3 install codespell
-    codespell "$@"
+    codespell $(codespell_skip_args) "$@"
 }


### PR DESCRIPTION
(cherry picked from commit 688f8eb87df2104b7ca40f0d1ae4c21853c19ebb)

## What?
Port to v1.20.x @tvegas1 fix for codespell issues coming from submodules

## Why?
We have multiple v1.20.x PRs failing because of that codespell issue