### PR TITLE
AZP: Full workspace cleanup to fix checkout failures - master

### DIFF
--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -68,6 +68,8 @@ jobs:
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}
+    workspace:
+      clean: all
 
 
     steps:

--- a/buildlib/az-github-draft.yml
+++ b/buildlib/az-github-draft.yml
@@ -12,6 +12,8 @@ jobs:
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}
+    workspace:
+      clean: all
 
     steps:
     - checkout: self

--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -31,6 +31,8 @@ stages:
           name: MLNX
           demands:
           - ucx_perf_master
+        workspace:
+          clean: all
 
         steps:
           - checkout: self

--- a/buildlib/azure-pipelines-release-drp.yml
+++ b/buildlib/azure-pipelines-release-drp.yml
@@ -90,6 +90,8 @@ stages:
           name: MLNX
           demands:
             - ucx_docker_drp
+        workspace:
+          clean: all
         steps:
           - checkout: self
             fetchDepth: 100

--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -86,6 +86,8 @@ stages:
           name: MLNX
           demands:
           - ucx_docker
+        workspace:
+          clean: all
         steps:
           - checkout: self
             fetchDepth: 100

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -25,6 +25,8 @@ stages:
           name: MLNX
           demands:
           - ucx_docker -equals yes
+        workspace:
+          clean: all
         steps:
           - checkout: self
             clean: true

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -18,6 +18,8 @@ jobs:
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}
+    workspace:
+      clean: all
 
     steps:
       - checkout: self

--- a/buildlib/jucx/jucx-test.yml
+++ b/buildlib/jucx/jucx-test.yml
@@ -7,7 +7,7 @@ jobs:
   - job: jucx_test_${{ parameters.arch }}
     displayName: JUCX Test ${{ parameters.arch }}
     workspace:
-      clean: outputs
+      clean: all
 
     pool:
       name: MLNX

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -9,6 +9,8 @@ jobs:
       name: MLNX
       demands: ${{ parameters.demands }}
     container: $[ variables['CONTAINER'] ]
+    workspace:
+      clean: all
     strategy:
       # x86_64 matrix
       ${{ if contains(parameters.name, 'x86_64') }}:

--- a/buildlib/pr/codestyle.yml
+++ b/buildlib/pr/codestyle.yml
@@ -6,6 +6,8 @@ jobs:
       name: MLNX
       demands:
       - ucx_docker -equals yes
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true
@@ -36,6 +38,8 @@ jobs:
       demands:
       - ucx_docker -equals yes
     container: fedora
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true
@@ -70,6 +74,8 @@ jobs:
       demands:
       - ucx_docker -equals yes
     container: fedora
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true
@@ -95,6 +101,8 @@ jobs:
       demands:
       - ucx_docker -equals yes
     container: fedora
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true
@@ -114,6 +122,8 @@ jobs:
       demands:
       - ucx_docker -equals yes
     container: fedora
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/coverity.yml
+++ b/buildlib/pr/coverity.yml
@@ -7,7 +7,7 @@ jobs:
   - ${{each mode in parameters.modes }}:
     - job: coverity_${{ mode }}
       workspace:
-        clean: outputs
+        clean: all
       pool:
         name: MLNX
         demands: ${{ parameters.demands }}

--- a/buildlib/pr/cuda/cuda_compatible.yml
+++ b/buildlib/pr/cuda/cuda_compatible.yml
@@ -6,6 +6,8 @@ jobs:
       demands:
         - ucx_gpu_test -equals yes
     container: centos7_cuda11
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/efa.yml
+++ b/buildlib/pr/efa.yml
@@ -11,7 +11,7 @@ jobs:
     container: ${{ parameters.container }}
     timeoutInMinutes: 140
     workspace:
-      clean: outputs
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/go/go-test.yml
+++ b/buildlib/pr/go/go-test.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     workspace:
-      clean: outputs
+      clean: all
 
     pool:
       name: MLNX

--- a/buildlib/pr/mad_tests.yml
+++ b/buildlib/pr/mad_tests.yml
@@ -5,7 +5,7 @@ jobs:
       name: MLNX
       demands: mad_server
     workspace:
-      clean: outputs
+      clean: all
     steps:
       - checkout: self
         clean: true
@@ -31,7 +31,7 @@ jobs:
       name: MLNX
       demands: mad_client
     workspace:
-      clean: outputs
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -397,6 +397,8 @@ stages:
           name: MLNX
           demands:
             - ucx_docker -equals yes
+        workspace:
+          clean: all
         strategy:
           matrix:
             centos7:

--- a/buildlib/pr/namespace_tests.yml
+++ b/buildlib/pr/namespace_tests.yml
@@ -6,7 +6,7 @@ jobs:
     displayName: ${{ parameters.name }} on worker
     timeoutInMinutes: 30
     workspace:
-      clean: outputs
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/static_checks.yml
+++ b/buildlib/pr/static_checks.yml
@@ -6,6 +6,8 @@ jobs:
       demands:
       - ucx_docker -equals yes
     container: fedora
+    workspace:
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -23,7 +23,7 @@ jobs:
     ${{ if parameters.container }}:
       container: ${{ parameters.container }}
     workspace:
-      clean: outputs
+      clean: all
     steps:
       - checkout: self
         clean: true

--- a/buildlib/pr/wire_compat.yml
+++ b/buildlib/pr/wire_compat.yml
@@ -18,7 +18,7 @@ jobs:
   - job: build_pr_${{ parameters.name }}
     displayName: Build on ${{ parameters.name }}
     workspace:
-      clean: outputs
+      clean: all
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}
@@ -49,7 +49,7 @@ jobs:
     dependsOn: build_pr_${{ parameters.name }}
     displayName: Test wire compatibility ${{ parameters.name }}
     workspace:
-      clean: outputs
+      clean: all
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}


### PR DESCRIPTION
Port https://github.com/openucx/ucx/pull/11135 to master.

## What?
Add `workspace: clean: all` to Azure Pipelines jobs that use `checkout`

## Why?
Checkout fails with "unable to rmdir: Directory not empty" when submodule directories remain.
The default `clean: true` cannot remove non-empty submodule dirs.

## How?
`workspace: clean: all` forces a full workspace wipe before checkout.