### PR TITLE
UCP/CORE: Add alloc memory type to the supported memory types mask

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1672,8 +1672,8 @@ ucp_add_component_resources(ucp_context_h context, ucp_rsc_index_t cmpt_index,
     ucp_rsc_index_t i;
     const uct_md_attr_v2_t *md_attr;
     unsigned md_index;
-    uint64_t mem_type_mask;
-    uint64_t mem_type_bitmap;
+    uint64_t detect_mem_type_mask;
+    uint64_t alloc_mem_type_mask;
 
     /* List memory domain resources */
     uct_component_attr.field_mask   = UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES |
@@ -1687,7 +1687,8 @@ ucp_add_component_resources(ucp_context_h context, ucp_rsc_index_t cmpt_index,
     }
 
     /* Open all memory domains */
-    mem_type_mask = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    detect_mem_type_mask = UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    alloc_mem_type_mask  = UCS_BIT(UCS_MEMORY_TYPE_HOST);
     for (i = 0; i < tl_cmpt->attr.md_resource_count; ++i) {
         if (avail_mds == 0) {
             ucs_debug("only first %zu domains kept for component %s with %u "
@@ -1727,18 +1728,20 @@ ucp_add_component_resources(ucp_context_h context, ucp_rsc_index_t cmpt_index,
 
         avail_mds--;
 
-        /* List of memory type MDs */
-        mem_type_bitmap = md_attr->detect_mem_types;
-        if (~mem_type_mask & mem_type_bitmap) {
+        /* List of detect memory type MDs */
+        if (~detect_mem_type_mask & md_attr->detect_mem_types) {
             context->mem_type_detect_mds[context->num_mem_type_detect_mds] = md_index;
             ++context->num_mem_type_detect_mds;
-            mem_type_mask |= mem_type_bitmap;
         }
+
+        detect_mem_type_mask |= md_attr->detect_mem_types;
+        alloc_mem_type_mask  |= md_attr->alloc_mem_types;
 
         ++context->num_mds;
     }
 
-    context->mem_type_mask |= mem_type_mask;
+    context->supported_mem_type_mask |= (detect_mem_type_mask |
+                                         alloc_mem_type_mask);
 
     status = UCS_OK;
 out:
@@ -1917,7 +1920,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->num_mds                  = 0;
     context->tl_rscs                  = NULL;
     context->num_tls                  = 0;
-    context->mem_type_mask            = 0;
+    context->supported_mem_type_mask  = 0;
     context->num_mem_type_detect_mds  = 0;
     context->export_md_map            = 0;
 
@@ -2640,7 +2643,7 @@ ucs_status_t ucp_context_query(ucp_context_h context, ucp_context_attr_t *attr)
     }
 
     if (attr->field_mask & UCP_ATTR_FIELD_MEMORY_TYPES) {
-        attr->memory_types = context->mem_type_mask;
+        attr->memory_types = context->supported_mem_type_mask;
     }
 
     if (attr->field_mask & UCP_ATTR_FIELD_NAME) {

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -394,7 +394,8 @@ typedef struct ucp_context {
        exists. */
     ucp_md_index_t                dmabuf_mds[UCS_MEMORY_TYPE_LAST];
 
-    uint64_t                      mem_type_mask;            /* Supported mem type mask */
+    /* Mask of supported memory types */
+    uint64_t                      supported_mem_type_mask;
 
     ucp_tl_resource_desc_t        *tl_rscs;   /* Array of communication resources */
     ucp_tl_bitmap_t               tl_bitmap;  /* Cached map of tl resources used by workers.

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1553,11 +1553,11 @@ void ucp_mem_print_info(const char *mem_spec, ucp_context_h context,
         mem_type_value = ucs_string_find_in_list(mem_type_str,
                                                  ucs_memory_type_names, 0);
         if ((mem_type_value < 0) ||
-            !(UCS_BIT(mem_type_value) & context->mem_type_mask)) {
+            !UCS_BIT_GET(context->supported_mem_type_mask, mem_type_value)) {
             printf("<Invalid memory type '%s', supported types: %s>\n",
                    mem_type_str,
                    ucs_flags_str(mem_types_buf, sizeof(mem_types_buf),
-                                 context->mem_type_mask,
+                                 context->supported_mem_type_mask,
                                  ucs_memory_type_names));
             return;
         }


### PR DESCRIPTION
## What?
- Add any `alloc_memory_type` to the `supported_mem_type_mask` alongside the existing `detect_memory_type`.
- Renamed `mem_type_mask` to `supported_mem_type_mask` for clarity.

## Why?
It is possible to fetch the supported memory types using the UCP API `ucp_context_query`
Until now the supported memory types were `detect_memory_type`, but I found out that `UCS_MEMORY_TYPE_RDMA` is not set as `detect_memory_type` (it is set only as `alloc_memory_type` in `ib_mlx5dv_md`).
This change includes `UCS_MEMORY_TYPE_RDMA` in the supported memory types.