### PR TITLE
CI: Match Blossom-supported template

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -3,7 +3,7 @@ name: Blossom-CI
 run-name: >
   ${{ github.event_name == 'workflow_dispatch' &&
       format(
-        'Blossom CI: {0}{1} PR #{2}',
+        'Blossom CI • Jenkins Job: {0}{1} • PR #{2}',
         fromJson(github.event.inputs.args).job,
         fromJson(github.event.inputs.args).build && format(' #{0}', fromJson(github.event.inputs.args).build) || '',
         fromJson(github.event.inputs.args).pr


### PR DESCRIPTION
## What?
Fix Blossom GHA workflow to match the Blossom-supported template.

## Why?
GHA Authorization step fails.
