### PR TITLE
AZP: Fix debian package dependency cleanup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>
 Ovidiu Mara <ovidium@nvidia.com>
 Pak Lui <Pak.Lui@amd.com>
+Paul Taylor <pataylor@nvidia.com>
 Pavan Balaji <balaji@anl.gov>
 Pavel Shamis (Pasha) <pasharesearch@gmail.com>
 Peter Andreas Entschev <peter@entschev.com>

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -117,7 +117,7 @@ jobs:
 
           # Remove superfluous dependency
           dpkg-deb -R "ucx-cuda-${VER}.deb" tmp    # Extract
-          sed -i 's/libnvidia-compute | libnvidia-ml1, //g' tmp/DEBIAN/control
+          sed -i 's/libnvidia-compute | libnvidia-ml1[^,]*, //g' tmp/DEBIAN/control
           dpkg-deb -b tmp "ucx-cuda-${VER}.deb"        # Rebuild
           dpkg-deb -I "ucx-cuda-${VER}.deb"
           dpkg-deb -I "ucx-${VER}.deb"


### PR DESCRIPTION
## What?
Remove `libnvidia-compute` dependency from debian package dependencies.

## Why?
Fixes #11140

## How?
It appears the string `sed -i 's/libnvidia-compute | libnvidia-ml1, //g' tmp/DEBIAN/control` is replacing has changed:
```shell
$ dpkg-deb -R ucx-cuda-1.19.0.deb tmp
$ grep Depends: tmp/DEBIAN/control
> Depends: libc6 (>= 2.34), libnvidia-compute | libnvidia-ml1 (>= 555.42.06), ucx
```

Updating the pattern with a wildcard match seems to work:
```shell
$ sed 's/libnvidia-compute | libnvidia-ml1.*, //g' tmp/DEBIAN/control | grep Depends
> Depends: libc6 (>= 2.34), ucx
```