### PR TITLE
UCT/IB/BASE: fixed ib mem handle flags enum order

### DIFF
--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -65,8 +65,6 @@ enum {
                                                         threads */
     UCT_IB_MEM_IMPORTED              = UCS_BIT(3), /**< The memory handle was
                                                         created by mem_attach */
-    UCT_IB_MEM_DIRECT_NIC            = UCS_BIT(6), /**< The memory handle was
-                                                        registered using Direct NIC */
 #if ENABLE_PARAMS_CHECK
     UCT_IB_MEM_ACCESS_REMOTE_RMA     = UCS_BIT(4), /**< RMA access was requested
                                                         for the memory region */
@@ -75,6 +73,8 @@ enum {
 #endif
     UCT_IB_MEM_FLAG_GVA              = UCS_BIT(5), /**< The memory handle is a
                                                         GVA region */
+    UCT_IB_MEM_DIRECT_NIC            = UCS_BIT(6), /**< The memory handle was
+                                                        registered using Direct NIC */
 };
 
 enum {


### PR DESCRIPTION
## What?
Moving UCT_IB_MEM_DIRECT_NIC to the end of the enum

## Why?
I misplaced it in one of my recent PRs accidentally
