### PR TITLE
UCT/TEST: Fix statistical failure in `stale_dest_ep_id_update` test

### DIFF
--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -1041,6 +1041,10 @@ UCS_TEST_SKIP_COND_P(test_ud, stale_dest_ep_id_update,
 
     /* Wait for m_e2's dest_ep_id to be updated from the stale value */
     wait_for_value(&ep(m_e2)->dest_ep_id, REMOTE_EP_ID, true,
+                   TEST_UD_LINGER_TIMEOUT_IN_SEC);
+
+    /* Wait for m_e1 to set dest_ep_id */
+    wait_for_value(&ep(m_e1, REMOTE_EP_ID)->dest_ep_id, ep(m_e2)->ep_id, true,
                    TEST_UD_LINGER_TIMEOUT_IN_SEC);
 
     EXPECT_EQ(REMOTE_EP_ID, ep(m_e1, REMOTE_EP_ID)->ep_id);


### PR DESCRIPTION
## What?
Add another wait step to the `stale_dest_ep_id_update` to ensure the `dest_ep_id` is updated before the check.

## Why?
I encountered a statistical failure when running the CI:
```
[ RUN      ] ud_mlx5/test_ud.stale_dest_ep_id_update/1 <ud_mlx5/mlx5_1:1>
/scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/uct/ib/test_ud.cc:1047: Failure
Expected: (((1<<24)-1)) != (ep(m_e1, REMOTE_EP_ID)->dest_ep_id), actual: 16777215 vs 16777215
[  FAILED  ] ud_mlx5/test_ud.stale_dest_ep_id_update/1, where GetParam() = ud_mlx5/mlx5_1:1 (88 ms)
```
https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=113890&view=logs&j=855ed0d2-4c0f-5fdc-c25b-80877de09725&t=e8091e47-44ab-514e-3b46-383d23f0a23e&l=34385 

I could not reproduce it reliably, but the suggested change should prevent this race condition