### PR TITLE
BUILD: Make valgrind optional in configure-devel

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,6 +107,7 @@ Srinivasan Subramanian <srinivasan.subramanian@amd.com>
 Stephen Richmond <srichmond@dancer.icl.utk.edu>
 Swen Boehm <boehms@ornl.gov>
 Thomas Vegas <tvegas@nvidia.com>
+Tomer Gilad <tgilad@nvidia.com>
 Tony Curtis <tonycurtis32@gmail.com>
 Tzafrir Cohen <tzafrirc@nvidia.com>
 Valentin Petrov <valentinp@mellanox.com>

--- a/contrib/configure-devel
+++ b/contrib/configure-devel
@@ -15,7 +15,7 @@ $basedir/../configure \
 	--enable-gtest \
 	--enable-examples \
 	--enable-test-apps \
-	--with-valgrind \
+	--with-valgrind=guess \
 	--enable-profiling \
 	--enable-frame-pointer \
 	--enable-stats \


### PR DESCRIPTION
## What?
Add `--with-valgrind=guess` mode and update configure-devel to use it, making valgrind optional in development builds.

## Why?
Building using configure-devel on a machine without valgrind is currently not possible, as the flag --with-valgrind will fail the build if specified and the headers are not found.

## How?
Added a new `guess` mode to `--with-valgrind` with the following behavior:

1. Not specified (or `--with-valgrind=no`) - Valgrind disabled (NVALGRIND=1 defined)
2. `--with-valgrind=guess` - Try to find headers in `/usr/include/valgrind/`. If found, enable support; if not found, warn and continue without valgrind (used by configure-devel)
3. `--with-valgrind=DIR` - Search for headers under `DIR/include/valgrind/`. Fail if not found
4. `--with-valgrind` (or `--with-valgrind=yes`) - Search for headers in `/usr/include/valgrind/`. Fail if not found (previous default behavior)

This maintains backward compatibility while allowing development builds to proceed without valgrind installed.
