### PR TITLE
CONFIG/SPEC: Optionally replace knem with xpmem

### DIFF
--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -385,6 +385,12 @@ Provides Gemini/Aries transport for UCX.
 %if %{with xpmem}
 %package xpmem
 Requires: %{name}%{?_isa} = %{version}-%{release}
+%if %{without knem}
+# Upgrade path for ucx-knem:
+Provides: ucx-knem = %{version}-%{release}
+Conflicts: ucx-knem < %{version}-%{release}
+Obsoletes: ucx-knem < %{version}-%{release}
+%endif
 Summary: UCX XPMEM transport support.
 Group: System Environment/Libraries
 


### PR DESCRIPTION
Provide an upgrade path to replace the knem subpackage when it is removed: If the the xpmem subpackage is built but the knem one isn't, have it obsolete the knem one.

Technically this is the role of the main package, but this reduces the impact of the change.