### PR TITLE
CI: Add CTyunOS 25.07 support

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -39,6 +39,7 @@ runs_on_dockers:
   - { name: "rocky89-mofed24.10", url: "harbor.mellanox.com/hpcx/aarch64/rocky8.9/builder:mofed-24.10-3.2.5.0", arch: aarch64 }
   - { name: "rocky96-mofed24.10", url: "harbor.mellanox.com/hpcx/aarch64/rocky9.6/builder:mofed-24.10-3.2.5.0", arch: aarch64 }
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/aarch64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: aarch64 }
+  - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: aarch64 }
 
 taskName: '${arch}/${name}'
 

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -78,6 +78,8 @@ jobs:
             CONTAINER: rocky89_aarch64
           rocky96_aarch64:
             CONTAINER: rocky96_aarch64
+          ctyunos2507_aarch64:
+            CONTAINER: ctyunos2507_aarch64
     timeoutInMinutes: 340
 
     steps:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -234,6 +234,9 @@ resources:
     - container: ctyunos2507
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ctyunos25.07/builder:mofed-26.01-0.8.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ctyunos2507_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ctyunos25.07/builder:mofed-26.01-0.8.0.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: centos10stream
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/centos10stream/builder:inbox
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)


### PR DESCRIPTION
  ## What?
  Add CI support for CTyunOS 25.07.

  ## Why?
  CTyunOS is a Chinese cloud operating system.
  This enables automated builds and testing on CTyunOS 25.07.

  ## How?
  - Added container definition using hpcx images with MOFED 26.01-0.8.0.0
  - Integrated into existing build matrix