### PR TITLE
CI: Add support for Sles16

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -29,6 +29,7 @@ runs_on_dockers:
   - { name: "rhel90-mofed5.6", url: "harbor.mellanox.com/ucx/x86_64/rhel9.0/builder:mofed-5.6-0.5.0.0", arch: x86_64 }
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/x86_64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: x86_64 }
   - { name: "sles15sp7-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/sles15sp7/builder:mofed-26.01-0.8.8.0", arch: x86_64 }
+  - { name: "sles16sp0-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/sles16sp0/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
   - { name: "kylin10sp3-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0", arch: x86_64 }
   - { name: "euleros2sp12-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0", arch: x86_64 }
   - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
@@ -41,6 +42,7 @@ runs_on_dockers:
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/aarch64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: aarch64 }
   - { name: "sles15sp7-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/sles15sp7/builder:mofed-26.01-0.8.8.0", arch: aarch64 }
   - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: aarch64 }
+  - { name: "sles16sp0-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/sles16sp0/builder:mofed-26.01-0.8.0.0", arch: aarch64 }
 
 taskName: '${arch}/${name}'
 

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -41,6 +41,8 @@ jobs:
             CONTAINER: debian130
           sles15sp7:
             CONTAINER: sles15sp7
+          sles16sp0:
+            CONTAINER: sles16sp0
           rhel82:
             CONTAINER: rhel82
           rhel90:
@@ -82,6 +84,8 @@ jobs:
             CONTAINER: rocky96_aarch64
           ctyunos2507_aarch64:
             CONTAINER: ctyunos2507_aarch64
+          sles16sp0_aarch64:
+            CONTAINER: sles16sp0_aarch64
     timeoutInMinutes: 340
 
     steps:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -96,6 +96,12 @@ resources:
     - container: sles15sp7_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/sles15sp7/builder:mofed-26.01-0.8.8.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: sles16sp0
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/sles16sp0/builder:mofed-26.01-0.8.0.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: sles16sp0_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/sles16sp0/builder:mofed-26.01-0.8.0.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: rhel90_doca31
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/rhel9.0/builder:doca-3.1.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)


### PR DESCRIPTION
  ## What?
  Add CI support for SLES16sp0.

  ## Why?
  SLES 16 (SUSE Linux Enterprise Server 16) is the latest enterprise Linux distribution from SUSE.
  This enables automated builds and testing on SLES 16 SP0.

  ## How?
  - Added container definitions using hpcx images with MOFED 26.01-0.8.0.0
  - Integrated into existing build matrix for both x86_64 and aarch64 architectures