### PR TITLE
CI: Add SLES15sp7 support

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -28,7 +28,6 @@ runs_on_dockers:
   - { name: "rhel82-mofed5.0", url: "harbor.mellanox.com/ucx/x86_64/rhel8.2/builder:mofed-5.0-1.0.0.0", arch: x86_64 }
   - { name: "rhel90-mofed5.6", url: "harbor.mellanox.com/ucx/x86_64/rhel9.0/builder:mofed-5.6-0.5.0.0", arch: x86_64 }
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/x86_64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: x86_64 }
-  - { name: "sles15sp6-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/sles15sp6/builder:doca-2.9.0", arch: x86_64 }
   - { name: "sles15sp7-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/sles15sp7/builder:mofed-26.01-0.8.8.0", arch: x86_64 }
   - { name: "kylin10sp3-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0", arch: x86_64 }
   - { name: "euleros2sp12-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0", arch: x86_64 }

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -39,8 +39,6 @@ jobs:
             CONTAINER: debian125
           debian130:
             CONTAINER: debian130
-          sles15sp6:
-            CONTAINER: sles15sp6
           sles15sp7:
             CONTAINER: sles15sp7
           rhel82:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -90,9 +90,6 @@ resources:
     - container: debian130
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian13.0/builder:doca-3.2.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: sles15sp6
-      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/sles15sp6/builder:doca-2.9.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: sles15sp7
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/sles15sp7/builder:mofed-26.01-0.8.8.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)


### PR DESCRIPTION
  ## What?
  Add CI support for SLES15sp7.

  ## Why?
  Verify UCX builds on SLES 15 SP7.

  ## How?
  - Added container definitions using hpcx images with MOFED 26.01-0.8.8.0
  - Integrated into existing build matrix for both x86_64 and aarch64 architectures