### PR TITLE
CI: Target IB-capable nodes for tests

### DIFF
--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -19,10 +19,12 @@ runs_on_dockers:
       name: "hca-cx8",
       url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
       arch: x86_64,
-      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "ib-network" }],
-      limits: "{memory: 16Gi, cpu: 10000m, rdma/hca_cx8: 1}",
-      requests: "{memory: 16Gi, cpu: 10000m, rdma/hca_cx8: 1}",
-      caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
+      nodeSelector: "kubernetes.io/hostname=yok-t-ipp-blossom-prod-gpu-rdm-01",
+      tolerations: "[{key: 'node.kubernetes.io/unschedulable', operator: 'Exists', effect: 'NoSchedule'}]",
+      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "cx8-ib-network" }],
+      limits: "{memory: 16Gi, cpu: 10000m, nvidia.com/cx8_vfs: 1}",
+      requests: "{memory: 16Gi, cpu: 10000m, nvidia.com/cx8_vfs: 1}",
+      caps_add: "[ IPC_LOCK, NET_RAW ]"
     }
   # BlueField
   - {

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -45,8 +45,10 @@ steps:
     parallel: false
     timeout: "${STEP_TIMEOUT_MINUTES}"
     run: |
+      # Limit tests to 2 CPUs to prevent max_threads exhaustion in k8s (similar to Azure CPU affinity)
       allowed_cpus=$(awk '/^Cpus_allowed_list:/ {print $2}' /proc/self/status)
       first_chunk=${allowed_cpus%%,*}
+      # In k8s, pin to up to 2 CPUs so max_threads stays bounded and avoids resource exhaustion.
       if [[ "${first_chunk}" == *-* ]]; then
         start_cpu=${first_chunk%-*}
         end_cpu=${first_chunk#*-}

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -39,7 +39,7 @@ runs_on_dockers:
 
 matrix:
   axes:
-    arch: [x86_64, aarch64]
+    arch: [x86_64]
     worker: [0, 1, 2, 3]
 
 taskName: '${name}/${arch}/w${worker}'
@@ -56,4 +56,19 @@ steps:
     parallel: false
     timeout: "${STEP_TIMEOUT_MINUTES}"
     run: |
-      ASAN_CHECK="no" ./contrib/test_jenkins.sh
+      allowed_cpus=$(awk '/^Cpus_allowed_list:/ {print $2}' /proc/self/status)
+      first_chunk=${allowed_cpus%%,*}
+      if [[ "${first_chunk}" == *-* ]]; then
+        start_cpu=${first_chunk%-*}
+        end_cpu=${first_chunk#*-}
+        if [ "${end_cpu}" -gt "${start_cpu}" ]; then
+          cpu_set="${start_cpu}-$((start_cpu + 1))"
+        else
+          cpu_set="${start_cpu}"
+        fi
+      else
+        cpu_set="${first_chunk}"
+      fi
+
+      echo "Running test_jenkins.sh with CPU affinity: ${cpu_set} (allowed: ${allowed_cpus})"
+      ASAN_CHECK="no" taskset -c "${cpu_set}" ./contrib/test_jenkins.sh

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -19,24 +19,11 @@ runs_on_dockers:
       name: "hca-ib",
       url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
       arch: x86_64,
-      nodeSelector: "kubernetes.io/hostname=yok-t-ipp-blossom-prod-gpu-rdm-01",
       tolerations: "[{key: 'node.kubernetes.io/unschedulable', operator: 'Exists', effect: 'NoSchedule'}]",
       annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "cx8-ib-network" }],
       limits: "{memory: 16Gi, cpu: 10000m, nvidia.com/cx8_vfs: 1}",
       requests: "{memory: 16Gi, cpu: 10000m, nvidia.com/cx8_vfs: 1}",
       caps_add: "[ IPC_LOCK, NET_RAW ]"
-    }
-  # BlueField
-  - {
-      name: "bf3",
-      url: "harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0",
-      arch: aarch64,
-      nodeSelector: "hardware.node.kubernetes.io=BF3,kubernetes.io/arch=arm64",
-      tolerations: "[{key: 'hardware.node.kubernetes.io', operator: 'Equal', value: 'BF3'}]",
-      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "ib-network" }],
-      limits: "{memory: 16Gi, cpu: 10000m}",
-      requests: "{memory: 16Gi, cpu: 10000m}",
-      caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
     }
 
 matrix:

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -60,4 +60,4 @@ steps:
       fi
 
       echo "Running test_jenkins.sh with CPU affinity: ${cpu_set} (allowed: ${allowed_cpus})"
-      ASAN_CHECK="no" taskset -c "${cpu_set}" ./contrib/test_jenkins.sh
+      taskset -c "${cpu_set}" ./contrib/test_jenkins.sh

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -14,9 +14,9 @@ kubernetes:
   requests: "{memory: 16Gi, cpu: 6000m}"
 
 runs_on_dockers:
-  # HCA CX8
+  # HCA IB
   - {
-      name: "hca-cx8",
+      name: "hca-ib",
       url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
       arch: x86_64,
       nodeSelector: "kubernetes.io/hostname=yok-t-ipp-blossom-prod-gpu-rdm-01",

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -14,12 +14,21 @@ kubernetes:
   requests: "{memory: 16Gi, cpu: 6000m}"
 
 runs_on_dockers:
-  - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0", arch: x86_64 }
+  - {
+      name: "ubuntu2404-doca2.9",
+      url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
+      arch: x86_64,
+      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "ib-network" }],
+      limits: "{memory: 16Gi, cpu: 10000m, hugepages-2Mi: 8Gi, rdma/hca_cx8: 1}",
+      requests: "{memory: 16Gi, cpu: 10000m, hugepages-2Mi: 8Gi, rdma/hca_cx8: 1}",
+      caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
+    }
 
 matrix:
   axes:
     arch: [x86_64]
-    worker: [0, 1, 2, 3]
+    worker: [0]
+    # worker: [0, 1, 2, 3]
 
 taskName: '${arch}/${name}/w${axis_index}'
 

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -14,7 +14,18 @@ kubernetes:
   requests: "{memory: 16Gi, cpu: 6000m}"
 
 runs_on_dockers:
-  # HCA IB
+  # HCA RoCE (CX7)
+  - {
+      name: "hca-roce",
+      url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
+      arch: x86_64,
+      tolerations: "[{key: 'node.kubernetes.io/unschedulable', operator: 'Exists', effect: 'NoSchedule'}]",
+      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "sriov-cx7-p2" }],
+      limits: "{memory: 16Gi, cpu: 10000m, nvidia.com/sriov_cx7_p2: 1}",
+      requests: "{memory: 16Gi, cpu: 10000m, nvidia.com/sriov_cx7_p2: 1}",
+      caps_add: "[ IPC_LOCK, NET_RAW ]"
+    }
+  # HCA IB (CX8)
   - {
       name: "hca-ib",
       url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -5,7 +5,7 @@
 job: ucx-test
 
 failFast: false
-timeout_minutes: 90
+timeout_minutes: 240
 
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
@@ -14,34 +14,46 @@ kubernetes:
   requests: "{memory: 16Gi, cpu: 6000m}"
 
 runs_on_dockers:
+  # HCA CX8
   - {
-      name: "ubuntu2404-doca2.9",
+      name: "hca-cx8",
       url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
       arch: x86_64,
       annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "ib-network" }],
-      limits: "{memory: 16Gi, cpu: 10000m, hugepages-2Mi: 8Gi, rdma/hca_cx8: 1}",
-      requests: "{memory: 16Gi, cpu: 10000m, hugepages-2Mi: 8Gi, rdma/hca_cx8: 1}",
+      limits: "{memory: 16Gi, cpu: 10000m, rdma/hca_cx8: 1}",
+      requests: "{memory: 16Gi, cpu: 10000m, rdma/hca_cx8: 1}",
+      caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
+    }
+  # BlueField
+  - {
+      name: "bf3",
+      url: "harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0",
+      arch: aarch64,
+      nodeSelector: "hardware.node.kubernetes.io=BF3,kubernetes.io/arch=arm64",
+      tolerations: "[{key: 'hardware.node.kubernetes.io', operator: 'Equal', value: 'BF3'}]",
+      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "ib-network" }],
+      limits: "{memory: 16Gi, cpu: 10000m}",
+      requests: "{memory: 16Gi, cpu: 10000m}",
       caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
     }
 
 matrix:
   axes:
-    arch: [x86_64]
-    worker: [0]
-    # worker: [0, 1, 2, 3]
+    arch: [x86_64, aarch64]
+    worker: [0, 1, 2, 3]
 
-taskName: '${arch}/${name}/w${axis_index}'
+taskName: '${name}/${arch}/w${worker}'
 
 env:
   RUN_TESTS: "yes"
   TEST_PERF: "0"
-  ASAN_CHECK: "no"
   VALGRIND_CHECK: "no"
   nworkers: "4"
+  STEP_TIMEOUT_MINUTES: "120"
 
 steps:
   - name: Test
     parallel: false
-    timeout: 360
+    timeout: "${STEP_TIMEOUT_MINUTES}"
     run: |
-      ./contrib/test_jenkins.sh
+      ASAN_CHECK="no" ./contrib/test_jenkins.sh

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -14,17 +14,6 @@ kubernetes:
   requests: "{memory: 16Gi, cpu: 6000m}"
 
 runs_on_dockers:
-  # HCA RoCE (CX7)
-  - {
-      name: "hca-roce",
-      url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0",
-      arch: x86_64,
-      tolerations: "[{key: 'node.kubernetes.io/unschedulable', operator: 'Exists', effect: 'NoSchedule'}]",
-      annotations: [{ key: "k8s.v1.cni.cncf.io/networks", value: "sriov-cx7-p2" }],
-      limits: "{memory: 16Gi, cpu: 10000m, nvidia.com/sriov_cx7_p2: 1}",
-      requests: "{memory: 16Gi, cpu: 10000m, nvidia.com/sriov_cx7_p2: 1}",
-      caps_add: "[ IPC_LOCK, NET_RAW ]"
-    }
   # HCA IB (CX8)
   - {
       name: "hca-ib",


### PR DESCRIPTION
## What?
Update UCX gtest k8s jobs to target IB-capable nodes (CX8) in Blossom.

## Why?
Ensure tests run on IB-capable nodes with the required RDMA access.

## How?
Add `runs_on_dockers` entry `hca-ib` in `test_matrix.yaml` with `cx8-ib-network` annotation, `nvidia.com/cx8_vfs: 1`, and `caps_add: [IPC_LOCK, NET_RAW]`.

RoCE (CX7) coverage will land in a follow-up PR.