### PR TITLE
UCP: add 'gaudi' alias mapping to 'gaudi_gdr'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -114,6 +114,7 @@ Valentin Petrov <valentinp@mellanox.com>
 Wenbin Lu <wenbin.lu@stonybrook.edu>
 Xin Zhao <xinz@mellanox.com>
 Xu Yifeng <yifeng.xyf@alibaba-inc.com>
+Yaser Afshar <yaser.afshar@intel.com>
 Yiltan Hassan Temucin <yiltan.temucin@amd.com>
 Yossi Itigin <yosefe@nvidia.com>
 Yuriy Shestakov <yuriis@mellanox.com>

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -731,6 +731,7 @@ static ucp_tl_alias_t ucp_tl_aliases[] = {
   { "cuda",  { "cuda_copy", "cuda_ipc", "gdr_copy", NULL } },
   { "rocm",  { "rocm_copy", "rocm_ipc", "rocm_gdr", NULL } },
   { "ze",    { "ze_copy", "ze_ipc", "ze_gdr", NULL } },
+  { "gaudi", { "gaudi_gdr", NULL } },
   { "gga",   { "gga_mlx5", NULL } },
   { NULL }
 };


### PR DESCRIPTION
## What?

Add a new UCP transport alias for Gaudi:

- Alias: `gaudi`
- Expansion: `gaudi_gdr`

This allows users to select the Gaudi transport using:
```
UCX_TLS=gaudi
```
consistent with existing accelerator stacks such as `cuda`, `rocm`, and `ze`.

## Why?

Gaudi memory‑type and the `gaudi_gdr` UCT transport have been added under `uct/gaudi/`, along with support for the `-m gaudi` memtype option. However, UCP did not yet expose a corresponding alias. Without this alias, users must explicitly set:
```
UCX_TLS=gaudi_gdr
```
instead of the documented and user‑friendly `gaudi` shorthand.

Adding the alias restores consistency with other GPU backends and simplifies configuration for tools such as `ucx_perftest`.

## How?

Add the following entry to the `ucp_tl_aliases[]` table in
`src/ucp/core/ucp_context.c`:

```
{ "gaudi", { "gaudi_gdr", NULL } },
```

No auxiliary transports are needed, as `gaudi_gdr` is currently the only Gaudi UCT component.

