### PR TITLE
UCP/AM: Protect interval tree insert when message length is 0

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1463,7 +1463,8 @@ ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *rdesc,
         first_ftr = (ucp_am_first_ftr_t*)(first_rdesc + 1);
         seg_end   = first_rdesc->payload_offset + first_ftr->total_size - 1;
 
-        if (!ucs_interval_tree_is_equal_range(ucp_am_rdesc_frag_tree(
+        if ((first_ftr->total_size > 0) &&
+            !ucs_interval_tree_is_equal_range(ucp_am_rdesc_frag_tree(
                                                       first_rdesc),
                                               first_rdesc->payload_offset,
                                               seg_end)) {


### PR DESCRIPTION
## What?
UCP/AM: Protect interval tree insert when message length is 0

## Why?
Fix CI issue when running on BF machine
