### PR TITLE
UCP/TEST: Allow ucp tests to no set `WARN_INVALID_CONFIG=n`

### DIFF
--- a/test/gtest/ucp/ucp_test.cc
+++ b/test/gtest/ucp/ucp_test.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -414,7 +414,8 @@ bool ucp_test::is_proto_enabled() const
     return m_ucp_config->ctx.proto_enable;
 }
 
-void ucp_test::set_ucp_config(ucp_config_t *config, const std::string& tls)
+void ucp_test::set_ucp_config(ucp_config_t *config, const std::string &tls,
+                              bool warn_invalid_config)
 {
     ucs_status_t status;
 
@@ -422,9 +423,12 @@ void ucp_test::set_ucp_config(ucp_config_t *config, const std::string& tls)
     if (status != UCS_OK) {
         UCS_TEST_ABORT("Failed to set UCX transports");
     }
-    status = ucp_config_modify(config, "WARN_INVALID_CONFIG", "n");
-    if (status != UCS_OK) {
-        UCS_TEST_ABORT("Failed to set UCX to ignore invalid configuration");
+
+    if (!warn_invalid_config) {
+        status = ucp_config_modify(config, "WARN_INVALID_CONFIG", "n");
+        if (status != UCS_OK) {
+            UCS_TEST_ABORT("Failed to set UCX to ignore invalid configuration");
+        }
     }
 }
 
@@ -665,7 +669,8 @@ ucp_test_base::entity::entity(const ucp_test_param& test_param,
     /* Set transports configuration */
     std::stringstream ss;
     ss << test_param.transports;
-    ucp_test::set_ucp_config(ucp_config, ss.str());
+    ucp_test::set_ucp_config(ucp_config, ss.str(),
+                             test_owner->m_warn_invalid_config);
 
     {
         scoped_log_handler slh(hide_errors_logger);

--- a/test/gtest/ucp/ucp_test.h
+++ b/test/gtest/ucp/ucp_test.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * See file LICENSE for terms.
 */
 
@@ -62,6 +62,8 @@ public:
         MULTI_THREAD_CONTEXT, /* workers are single-threaded, context is mt-shared */
         MULTI_THREAD_WORKER   /* workers are multi-threaded, context is mt-single */
     };
+
+    bool m_warn_invalid_config = false;
 
     class entity {
         typedef std::vector<ucs::handle<ucp_ep_h, entity*> > ep_vec_t;
@@ -228,7 +230,8 @@ public:
     void disable_keepalive();
 
 private:
-    static void set_ucp_config(ucp_config_t *config, const std::string& tls);
+    static void set_ucp_config(ucp_config_t *config, const std::string& tls,
+                               bool warn_invalid_config = false);
     static bool check_tls(const std::string& tls);
     ucs_status_t request_process(void *req, int worker_index, bool wait,
                                  bool wakeup = false,


### PR DESCRIPTION
## What?
Allow tests to not disable `WARN_INVALID_CONFIG` when the test expects these warnings

## Why?
Some new tests that I want to add need to check for certain warnings to appear.
These warnings are not printed when `WARN_INVALID_CONFIG=n`, and currently `ucp_test` sets it for all tests.
Calling `ucp_config_modify("WARN_INVALID_CONFIG", "y");` from the test is not enough because it's always overriden by `create_entity()` afterwards.

How?
Tests that want to keep the warnings for invalid config should set `m_warn_invalid_config = true` before calling `create_entity()`
Other tests keep the previous behavior.
