### PR TITLE
UCS/SYS: Define `UCS_F_NOOPTIMIZE` for clang to allow using clang tools

### DIFF
--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -31,12 +31,10 @@
 #endif
 
 /* A function which should not be optimized */
-#if defined(HAVE_ATTRIBUTE_NOOPTIMIZE) && (HAVE_ATTRIBUTE_NOOPTIMIZE == 1)
 #if defined(__clang__)
-#define UCS_F_NOOPTIMIZE __attribute__((nooptimize))
-#else
+#define UCS_F_NOOPTIMIZE __attribute__((optnone))
+#elif defined(HAVE_ATTRIBUTE_NOOPTIMIZE) && (HAVE_ATTRIBUTE_NOOPTIMIZE == 1)
 #define UCS_F_NOOPTIMIZE __attribute__((optimize("O0")))
-#endif
 #else
 #define UCS_F_NOOPTIMIZE
 #endif


### PR DESCRIPTION
## What?
Define `UCS_F_NOOPTIMIZE` for clang

## Why?
Currently this macro is defined using GCC syntax, and it causes an error when running tools like `clang-tidy` on the repo.
This is not meant to add full support for compiling UCX with clang, but only to run checks with clang tools such as `clang-tidy` without errors.