### PR TITLE
UCT/CUDA_IPC: Add POSIX FD handle type for same-machine VMM IPC

### DIFF
--- a/src/uct/cuda/configure.m4
+++ b/src/uct/cuda/configure.m4
@@ -5,6 +5,9 @@
 
 UCX_CHECK_CUDA
 
+AC_CHECK_DECLS([SYS_pidfd_getfd], [], [],
+               [[#include <sys/syscall.h>]])
+
 AS_IF([test "x$cuda_happy" = "xyes"], [uct_modules="${uct_modules}:cuda"])
 uct_cuda_modules=""
 m4_include([src/uct/cuda/gdr_copy/configure.m4])

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -19,6 +19,7 @@
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/ptr_arith.h>
+#include <ucs/sys/uid.h>
 #include <ucs/type/rwlock.h>
 #include <uct/cuda/base/cuda_ctx.inl>
 typedef struct uct_cuda_ipc_cache_hash_key {
@@ -173,10 +174,10 @@ uct_cuda_ipc_close_memhandle_legacy(uct_cuda_ipc_cache_region_t *region)
 
 static ucs_status_t uct_cuda_ipc_close_memhandle(uct_cuda_ipc_cache_region_t *region)
 {
-#if HAVE_CUDA_FABRIC
     ucs_status_t status;
 
-    if (region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM) {
+    if ((region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM) ||
+        (region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD)) {
         status = UCT_CUDADRV_FUNC_LOG_WARN(cuMemUnmap(
                     (CUdeviceptr)region->mapped_addr, region->key.b_len));
         if (status != UCS_OK) {
@@ -185,7 +186,9 @@ static ucs_status_t uct_cuda_ipc_close_memhandle(uct_cuda_ipc_cache_region_t *re
 
         return UCT_CUDADRV_FUNC_LOG_WARN(cuMemAddressFree(
                 (CUdeviceptr)region->mapped_addr, region->key.b_len));
-    } else if (region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL) {
+    }
+#if HAVE_CUDA_FABRIC
+    if (region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL) {
         return UCT_CUDADRV_FUNC_LOG_WARN(
                 cuMemFree((CUdeviceptr)region->mapped_addr));
     }
@@ -292,7 +295,7 @@ uct_cuda_ipc_open_memhandle_legacy(CUipcMemHandle memh, CUdevice cu_dev,
     return status;
 }
 
-#if HAVE_CUDA_FABRIC
+#if HAVE_CUDA_FABRIC || HAVE_DECL_SYS_PIDFD_GETFD
 static void
 uct_cuda_ipc_init_access_desc(CUmemAccessDesc *access_desc, CUdevice cu_dev)
 {
@@ -304,6 +307,8 @@ uct_cuda_ipc_init_access_desc(CUmemAccessDesc *access_desc, CUdevice cu_dev)
 static ucs_status_t
 uct_cuda_ipc_open_memhandle_vmm(const uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
                                 CUdeviceptr *mapped_addr,
+                                void *shareable_handle,
+                                CUmemAllocationHandleType handle_type,
                                 ucs_log_level_t log_level)
 {
     CUmemAccessDesc access_desc = {};
@@ -312,8 +317,9 @@ uct_cuda_ipc_open_memhandle_vmm(const uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
     CUmemGenericAllocationHandle handle;
 
     status = UCT_CUDADRV_FUNC(cuMemImportFromShareableHandle(&handle,
-                (void*)&key->ph.handle.fabric_handle,
-                CU_MEM_HANDLE_TYPE_FABRIC), log_level);
+                                                             shareable_handle,
+                                                             handle_type),
+                              log_level);
     if (status != UCS_OK) {
         goto out;
     }
@@ -351,6 +357,8 @@ out:
     return status;
 }
 
+#endif /* HAVE_CUDA_FABRIC || HAVE_DECL_SYS_PIDFD_GETFD */
+#if HAVE_CUDA_FABRIC
 static ucs_status_t cuda_ipc_rem_mpool_cache_create(uct_cuda_ipc_rkey_t *key,
                                                     CUdevice cu_dev,
                                                     CUmemoryPool *mpool,
@@ -446,7 +454,51 @@ err:
     pthread_rwlock_unlock(&uct_cuda_ipc_rem_mpool_cache.lock);
     return status;
 }
-#endif
+#endif /* HAVE_CUDA_FABRIC */
+
+#if HAVE_DECL_SYS_PIDFD_GETFD
+static ucs_status_t
+uct_cuda_ipc_open_memhandle_posix_fd(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
+                                     CUdeviceptr *mapped_addr,
+                                     ucs_log_level_t log_level)
+{
+    int pidfd, local_fd;
+    ucs_status_t status;
+
+    if (key->ph.handle.posix_fd.system_id != ucs_get_system_id()) {
+        ucs_debug("posix_fd import: different machine "
+                  "(remote system_id=0x%" PRIx64
+                  " local system_id=0x%" PRIx64 ")",
+                  key->ph.handle.posix_fd.system_id,
+                  ucs_get_system_id());
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    pidfd = syscall(SYS_pidfd_open, (int)key->pid, 0);
+    if (pidfd < 0) {
+        ucs_log(log_level, "pidfd_open(%d) failed: %m", (int)key->pid);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    local_fd = syscall(SYS_pidfd_getfd, pidfd, key->ph.handle.posix_fd.fd, 0);
+    if (local_fd < 0) {
+        ucs_log(log_level, "pidfd_getfd(pidfd=%d, pid=%d, fd=%d) failed: %m",
+                pidfd, (int)key->pid, key->ph.handle.posix_fd.fd);
+        status = UCS_ERR_IO_ERROR;
+        goto close_pidfd;
+    }
+
+    status = uct_cuda_ipc_open_memhandle_vmm(
+            key, cu_dev, mapped_addr, (void*)(uintptr_t)local_fd,
+            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, log_level);
+    close(local_fd);
+    ucs_trace("posix_fd import from pid=%d: %s", (int)key->pid,
+              ucs_status_string(status));
+close_pidfd:
+    close(pidfd);
+    return status;
+}
+#endif /* HAVE_DECL_SYS_PIDFD_GETFD */
 
 static ucs_status_t
 uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
@@ -462,11 +514,17 @@ uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
                                                   mapped_addr, log_level);
 #if HAVE_CUDA_FABRIC
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM:
-        return uct_cuda_ipc_open_memhandle_vmm(key, cu_dev, mapped_addr,
-                                               log_level);
+        return uct_cuda_ipc_open_memhandle_vmm(
+                key, cu_dev, mapped_addr, (void*)&key->ph.handle.fabric_handle,
+                CU_MEM_HANDLE_TYPE_FABRIC, log_level);
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL:
         return uct_cuda_ipc_open_memhandle_mempool(key, cu_dev, mapped_addr,
                                                    log_level);
+#endif
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    case UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD:
+        return uct_cuda_ipc_open_memhandle_posix_fd(key, cu_dev, mapped_addr,
+                                                    log_level);
 #endif
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC:
         level = UCS_LOG_LEVEL_DEBUG;
@@ -486,7 +544,6 @@ static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
     ucs_list_link_t region_list;
     ucs_status_t status;
     uct_cuda_ipc_cache_region_t *region, *tmp;
-    int handle_type;
 
     ucs_list_head_init(&region_list);
     ucs_pgtable_search_range(&cache->pgtable, (ucs_pgt_addr_t)from,
@@ -498,13 +555,8 @@ static void uct_cuda_ipc_cache_invalidate_regions(uct_cuda_ipc_cache_t *cache,
 
         status = uct_cuda_ipc_close_memhandle(region);
         if (status != UCS_OK) {
-#if HAVE_CUDA_FABRIC
-            handle_type = region->key.ph.handle_type;
-#else
-            handle_type = 1; /* legacy memory type is the only valid type */
-#endif
             ucs_error("failed to close memhandle for base addr:%p type:%d (%s)",
-                      (void *)region->key.d_bptr, handle_type,
+                      (void*)region->key.d_bptr, region->key.ph.handle_type,
                       ucs_status_string(status));
         }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -458,10 +458,11 @@ err:
 
 #if HAVE_DECL_SYS_PIDFD_GETFD
 static ucs_status_t
-uct_cuda_ipc_open_memhandle_posix_fd(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
-                                     CUdeviceptr *mapped_addr,
+uct_cuda_ipc_open_memhandle_posix_fd(uct_cuda_ipc_extended_rkey_t *ext_key,
+                                     CUdevice cu_dev, CUdeviceptr *mapped_addr,
                                      ucs_log_level_t log_level)
 {
+    uct_cuda_ipc_rkey_t *key = &ext_key->super;
     int pidfd, local_fd;
     ucs_status_t status;
 
@@ -471,6 +472,13 @@ uct_cuda_ipc_open_memhandle_posix_fd(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
                   " local system_id=0x%" PRIx64 ")",
                   key->ph.handle.posix_fd.system_id,
                   ucs_get_system_id());
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    if (ext_key->pid_ns != ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID)) {
+        ucs_debug("posix_fd import: peer pid=%d is in a different pid namespace "
+                  "(remote=%u local=%u)", (int)key->pid, ext_key->pid_ns,
+                  ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID));
         return UCS_ERR_UNREACHABLE;
     }
 
@@ -501,9 +509,11 @@ close_pidfd:
 #endif /* HAVE_DECL_SYS_PIDFD_GETFD */
 
 static ucs_status_t
-uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
-                            CUdeviceptr *mapped_addr, ucs_log_level_t log_level)
+uct_cuda_ipc_open_memhandle(uct_cuda_ipc_extended_rkey_t *ext_key,
+                            CUdevice cu_dev, CUdeviceptr *mapped_addr,
+                            ucs_log_level_t log_level)
 {
+    uct_cuda_ipc_rkey_t *key = &ext_key->super;
     ucs_log_level_t level;
 
     ucs_trace("key handle type %u", key->ph.handle_type);
@@ -523,7 +533,7 @@ uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
 #endif
 #if HAVE_DECL_SYS_PIDFD_GETFD
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD:
-        return uct_cuda_ipc_open_memhandle_posix_fd(key, cu_dev, mapped_addr,
+        return uct_cuda_ipc_open_memhandle_posix_fd(ext_key, cu_dev, mapped_addr,
                                                     log_level);
 #endif
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC:
@@ -677,9 +687,11 @@ void uct_cuda_ipc_unmap_memhandle(pid_t pid, ucs_sys_ns_t pid_ns,
 
 static ucs_status_t
 uct_cuda_ipc_cache_put_region(uct_cuda_ipc_cache_t *cache,
-                              uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
-                              void **mapped_addr, ucs_log_level_t log_level)
+                              uct_cuda_ipc_extended_rkey_t *ext_key,
+                              CUdevice cu_dev, void **mapped_addr,
+                              ucs_log_level_t log_level)
 {
+    uct_cuda_ipc_rkey_t *key = &ext_key->super;
     ucs_pgt_region_t *pgt_region;
     uct_cuda_ipc_cache_region_t *region;
     ucs_status_t status;
@@ -717,15 +729,15 @@ uct_cuda_ipc_cache_put_region(uct_cuda_ipc_cache_t *cache,
         }
     }
 
-    status = uct_cuda_ipc_open_memhandle(key, cu_dev, (CUdeviceptr*)mapped_addr,
-                                         log_level);
+    status = uct_cuda_ipc_open_memhandle(ext_key, cu_dev,
+                                         (CUdeviceptr*)mapped_addr, log_level);
     if (ucs_unlikely(status != UCS_OK)) {
         if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
             /* unmap all overlapping regions and retry*/
             uct_cuda_ipc_cache_invalidate_regions(cache, (void *)key->d_bptr,
                                                   UCS_PTR_BYTE_OFFSET(key->d_bptr,
                                                                       key->b_len));
-            status = uct_cuda_ipc_open_memhandle(key, cu_dev,
+            status = uct_cuda_ipc_open_memhandle(ext_key, cu_dev,
                                                  (CUdeviceptr*)mapped_addr,
                                                  log_level);
             if (ucs_unlikely(status != UCS_OK)) {
@@ -733,7 +745,8 @@ uct_cuda_ipc_cache_put_region(uct_cuda_ipc_cache_t *cache,
                     /* unmap all cache entries and retry */
                     uct_cuda_ipc_cache_purge(cache);
                     status = uct_cuda_ipc_open_memhandle(
-                            key, cu_dev, (CUdeviceptr*)mapped_addr, log_level);
+                            ext_key, cu_dev, (CUdeviceptr*)mapped_addr,
+                            log_level);
                     if (status != UCS_OK) {
                         ucs_fatal("%s: failed to open ipc mem handle. addr:%p "
                                   "len:%lu (%s)", cache->name,
@@ -841,8 +854,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     ucs_rw_spinlock_write_lock(&uct_cuda_ipc_remote_cache.lock);
     status = uct_cuda_ipc_remote_cache_put(hash_key, &cache);
     if (status == UCS_OK) {
-        status = uct_cuda_ipc_cache_put_region(cache, key, cu_dev, mapped_addr,
-                                               log_level);
+        status = uct_cuda_ipc_cache_put_region(cache, ext_key, cu_dev,
+                                               mapped_addr, log_level);
     }
 
     ucs_rw_spinlock_write_unlock(&uct_cuda_ipc_remote_cache.lock);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -16,6 +16,7 @@
 #include <ucs/profile/profile.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
+#include <ucs/sys/uid.h>
 #include <ucs/type/class.h>
 #include <uct/api/v2/uct_v2.h>
 #include <uct/cuda/base/cuda_nvml.h>
@@ -134,6 +135,98 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     return UCS_OK;
 }
 
+#if HAVE_DECL_SYS_PIDFD_GETFD
+static ucs_status_t
+uct_cuda_ipc_mem_export_posix_fd(void *addr, uct_cuda_ipc_lkey_t *key)
+{
+    CUmemGenericAllocationHandle alloc_handle;
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC(cuMemRetainAllocationHandle(&alloc_handle, addr),
+                              UCS_LOG_LEVEL_DIAG);
+    if (status != UCS_OK) {
+        ucs_debug("unable to export POSIX FD handle for ptr: %p", addr);
+        return status;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemExportToShareableHandle(
+            &key->ph.handle.posix_fd.fd, alloc_handle,
+            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+    UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(alloc_handle));
+    if (status != UCS_OK) {
+        ucs_debug("unable to export POSIX FD handle for ptr: %p", addr);
+        return status;
+    }
+
+    key->ph.handle_type               = UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD;
+    key->ph.handle.posix_fd.system_id = ucs_get_system_id();
+    ucs_trace("posix_fd export: addr=%p fd=%d pid=%d system_id=0x%" PRIx64,
+              addr, key->ph.handle.posix_fd.fd, getpid(),
+              key->ph.handle.posix_fd.system_id);
+    return UCS_OK;
+}
+#endif
+
+#if HAVE_CUDA_FABRIC
+static ucs_status_t
+uct_cuda_ipc_mem_export_fabric_mempool(const void *addr,
+                                       uct_cuda_ipc_lkey_t *key,
+                                       CUmemoryPool mempool)
+{
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemPoolExportToShareableHandle(
+            (void*)&key->ph.handle.fabric_handle, mempool,
+            CU_MEM_HANDLE_TYPE_FABRIC, 0));
+    if (status != UCS_OK) {
+        ucs_debug("unable to export handle for mempool ptr: %p", addr);
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuMemPoolExportPointer(&key->ph.ptr, (CUdeviceptr)key->d_bptr));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL;
+    ucs_trace("packed mempool handle and export pointer for %p", addr);
+    return UCS_OK;
+}
+
+static ucs_status_t uct_cuda_ipc_mem_export_fabric(void *addr,
+                                                   uct_cuda_ipc_lkey_t *key,
+                                                   CUmemoryPool mempool)
+{
+    CUmemGenericAllocationHandle handle;
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC(cuMemRetainAllocationHandle(&handle, addr),
+                              UCS_LOG_LEVEL_DIAG);
+    if (status == UCS_OK) {
+        status = UCT_CUDADRV_FUNC_LOG_ERR(
+                cuMemExportToShareableHandle(&key->ph.handle.fabric_handle,
+                                             handle, CU_MEM_HANDLE_TYPE_FABRIC,
+                                             0));
+        UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
+        if (status != UCS_OK) {
+            ucs_debug("unable to export handle for VMM ptr: %p", addr);
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM;
+        ucs_trace("packed vmm fabric handle for %p", addr);
+        return UCS_OK;
+    }
+
+    if (mempool == NULL) {
+        return UCS_ERR_INVALID_ADDR;
+    }
+
+    return uct_cuda_ipc_mem_export_fabric_mempool(addr, key, mempool);
+}
+#endif /* HAVE_CUDA_FABRIC */
+
 static ucs_status_t
 uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
                          uct_cuda_ipc_lkey_t **key_p)
@@ -142,9 +235,8 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
     ucs_status_t status;
     int is_ctx_pushed;
     CUdevice cuda_device;
-#if HAVE_CUDA_FABRIC
+#if HAVE_CUDA_FABRIC || HAVE_DECL_SYS_PIDFD_GETFD
 #define UCT_CUDA_IPC_QUERY_NUM_ATTRS 3
-    CUmemGenericAllocationHandle handle;
     CUmemoryPool mempool;
     CUpointer_attribute attr_type[UCT_CUDA_IPC_QUERY_NUM_ATTRS];
     void *attr_data[UCT_CUDA_IPC_QUERY_NUM_ATTRS];
@@ -176,7 +268,7 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
         goto out_pop_ctx;
     }
 
-#if HAVE_CUDA_FABRIC
+#if HAVE_CUDA_FABRIC || HAVE_DECL_SYS_PIDFD_GETFD
     /* cuda_ipc can handle VMM, mallocasync, and legacy pinned device so need to
      * pack appropriate handle */
 
@@ -198,59 +290,30 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
         goto legacy_path;
     }
 
-    if (!(allowed_handle_types & CU_MEM_HANDLE_TYPE_FABRIC)) {
-        goto non_ipc;
-    }
-
-    status =
-        UCT_CUDADRV_FUNC(cuMemRetainAllocationHandle(&handle, addr),
-                UCS_LOG_LEVEL_DIAG);
-    if (status == UCS_OK) {
-        status =
-            UCT_CUDADRV_FUNC_LOG_ERR(cuMemExportToShareableHandle(
-                        &key->ph.handle.fabric_handle, handle,
-                        CU_MEM_HANDLE_TYPE_FABRIC, 0));
-        UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
-        if (status != UCS_OK) {
-            ucs_debug("unable to export handle for VMM ptr: %p", addr);
-            goto non_ipc;
+#if HAVE_CUDA_FABRIC
+    if (allowed_handle_types & CU_MEM_HANDLE_TYPE_FABRIC) {
+        status = uct_cuda_ipc_mem_export_fabric(addr, key, mempool);
+        if (status == UCS_OK) {
+            goto common_path;
         }
-
-        key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM;
-        ucs_trace("packed vmm fabric handle for %p", addr);
-        goto common_path;
+        if (status != UCS_ERR_UNSUPPORTED) {
+            goto out_pop_ctx;
+        }
     }
+#endif /* HAVE_CUDA_FABRIC */
 
-    if (mempool == 0) {
-        /* cuda_ipc can only handle UCS_MEMORY_TYPE_CUDA, which has to be either
-         * legacy type, or VMM type, or mempool type. Return error if memory
-         * does not belong to any of the three types */
-        status = UCS_ERR_INVALID_ADDR;
-        goto out_pop_ctx;
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    if (allowed_handle_types & CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+        status = uct_cuda_ipc_mem_export_posix_fd(addr, key);
+        if (status == UCS_OK) {
+            goto common_path;
+        }
     }
+#endif /* HAVE_DECL_SYS_PIDFD_GETFD */
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemPoolExportToShareableHandle(
-                (void *)&key->ph.handle.fabric_handle, mempool,
-                CU_MEM_HANDLE_TYPE_FABRIC, 0));
-    if (status != UCS_OK) {
-        ucs_debug("unable to export handle for mempool ptr: %p", addr);
-        goto non_ipc;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemPoolExportPointer(&key->ph.ptr,
-                (CUdeviceptr)key->d_bptr));
-    if (status != UCS_OK) {
-        goto out_pop_ctx;
-    }
-
-    key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL;
-    ucs_trace("packed mempool handle and export pointer for %p", addr);
-    goto common_path;
-
-non_ipc:
     key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC;
     goto common_path;
-#endif
+#endif /* HAVE_CUDA_FABRIC || HAVE_DECL_SYS_PIDFD_GETFD */
 legacy_path:
     key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY;
     status              = UCT_CUDADRV_FUNC_LOG_ERR(
@@ -484,6 +547,9 @@ uct_cuda_ipc_mem_dereg(uct_md_h md, const uct_md_mem_dereg_params_t *params)
     UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
 
     ucs_list_for_each_safe(key, tmp, &memh->list, link) {
+        if (key->ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD) {
+            close(key->ph.handle.posix_fd.fd);
+        }
         ucs_free(key);
     }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -17,10 +17,9 @@
 typedef enum {
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC = 0,
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, /* cudaMalloc memory */
-#if HAVE_CUDA_FABRIC
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM, /* cuMemCreate memory */
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL /* cudaMallocAsync memory */
-#endif
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL, /* cudaMallocAsync memory */
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD, /* POSIX file descriptor */
 } uct_cuda_ipc_key_handle_t;
 
 
@@ -31,6 +30,11 @@ typedef struct uct_cuda_ipc_md_handle {
 #if HAVE_CUDA_FABRIC
         CUmemFabricHandle     fabric_handle; /* VMM/Mallocasync export handle */
 #endif
+        struct {
+            int               fd;            /* POSIX file descriptor */
+            uint64_t          system_id;     /* Machine identifier for
+                                                same-machine verification */
+        } posix_fd;
     } handle;
 #if HAVE_CUDA_FABRIC
     CUmemPoolPtrExportData    ptr;

--- a/test/gtest/uct/cuda/cuda_vmm_mem_buffer.h
+++ b/test/gtest/uct/cuda/cuda_vmm_mem_buffer.h
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_TEST_CUDA_VMM_MEM_BUFFER_H
+#define UCT_TEST_CUDA_VMM_MEM_BUFFER_H
+
+#include <common/test_helpers.h>
+#include <cuda.h>
+
+extern "C" {
+#include <ucs/sys/ptr_arith.h>
+}
+
+static inline CUresult uct_test_cuda_ctx_create_compat(CUcontext *ctx,
+                                                       unsigned int flags,
+                                                       CUdevice dev)
+{
+#if CUDA_VERSION >= 13000
+    CUctxCreateParams ctx_create_params = {};
+    return cuCtxCreate(ctx, &ctx_create_params, flags, dev);
+#else
+    return cuCtxCreate(ctx, flags, dev);
+#endif
+}
+
+class cuda_vmm_mem_buffer {
+public:
+    cuda_vmm_mem_buffer() = default;
+
+    cuda_vmm_mem_buffer(size_t size, ucs_memory_type_t mem_type)
+    {
+        init(size, 0);
+    }
+
+    virtual ~cuda_vmm_mem_buffer()
+    {
+        cuMemUnmap(m_ptr, m_size);
+        cuMemAddressFree(m_ptr, m_size);
+        cuMemRelease(m_alloc_handle);
+    }
+
+    void *ptr() const
+    {
+        return (void*)m_ptr;
+    }
+
+    size_t size() const
+    {
+        return m_size;
+    }
+
+protected:
+    void init(size_t size, unsigned handle_type)
+    {
+        size_t granularity          = 0;
+        CUmemAllocationProp prop    = {};
+        CUmemAccessDesc access_desc = {};
+        CUdevice device;
+        if (cuCtxGetDevice(&device) != CUDA_SUCCESS) {
+            UCS_TEST_ABORT("failed to get the device handle for the current "
+                           "context");
+        }
+
+        prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id   = device;
+        if (handle_type != 0) {
+            prop.requestedHandleTypes = (CUmemAllocationHandleType)handle_type;
+        }
+        if (cuMemGetAllocationGranularity(&granularity, &prop,
+                                          CU_MEM_ALLOC_GRANULARITY_MINIMUM) !=
+            CUDA_SUCCESS) {
+            goto err;
+        }
+
+        m_size = ucs_align_up(size, granularity);
+        if (cuMemCreate(&m_alloc_handle, m_size, &prop, 0) != CUDA_SUCCESS) {
+            goto err;
+        }
+
+        if (cuMemAddressReserve(&m_ptr, m_size, 0, 0, 0) != CUDA_SUCCESS) {
+            goto err_mem_release;
+        }
+
+        if (cuMemMap(m_ptr, m_size, 0, m_alloc_handle, 0) != CUDA_SUCCESS) {
+            goto err_address_free;
+        }
+
+        access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        access_desc.location.id   = device;
+        access_desc.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+        if (cuMemSetAccess(m_ptr, m_size, &access_desc, 1) != CUDA_SUCCESS) {
+            goto err_mem_unmap;
+        }
+
+        return;
+
+    err_mem_unmap:
+        cuMemUnmap(m_ptr, m_size);
+    err_address_free:
+        cuMemAddressFree(m_ptr, m_size);
+    err_mem_release:
+        cuMemRelease(m_alloc_handle);
+    err:
+        UCS_TEST_SKIP_R("failed to allocate CUDA VMM memory");
+    }
+
+private:
+    size_t m_size                               = 0;
+    CUmemGenericAllocationHandle m_alloc_handle = 0;
+    CUdeviceptr m_ptr                           = 0;
+};
+
+#if HAVE_CUDA_FABRIC
+class cuda_fabric_mem_buffer : public cuda_vmm_mem_buffer {
+public:
+    cuda_fabric_mem_buffer(size_t size, ucs_memory_type_t mem_type)
+    {
+        init(size, CU_MEM_HANDLE_TYPE_FABRIC);
+    }
+};
+#endif
+
+class cuda_posix_fd_mem_buffer : public cuda_vmm_mem_buffer {
+public:
+    cuda_posix_fd_mem_buffer(size_t size, ucs_memory_type_t mem_type)
+    {
+        init(size, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    }
+};
+
+#endif

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -4,16 +4,18 @@
  * See file LICENSE for terms.
  */
 
+#include "cuda_vmm_mem_buffer.h"
+
 #include <thread>
 #include <vector>
 
 #include <uct/test_md.h>
-#include <cuda.h>
 
 extern "C" {
 #include <uct/cuda/cuda_ipc/cuda_ipc_md.h>
 #include <uct/cuda/cuda_ipc/cuda_ipc_cache.h>
 #include <uct/cuda/base/cuda_iface.h>
+#include <ucs/sys/uid.h>
 #include <uct/cuda/base/cuda_util.h>
 #include <ucs/datastruct/pgtable.h>
 #include <ucs/debug/memtrack_int.h>
@@ -164,6 +166,33 @@ protected:
        dereg_params.memh       = memh;
        EXPECT_UCS_OK(uct_md_mem_dereg_v2(md(), &dereg_params));
     }
+
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    ucs_status_t pack_posix_fd_key(cuda_posix_fd_mem_buffer &buf, size_t size,
+                                   uct_mem_h *memh, uct_cuda_ipc_rkey_t *rkey)
+    {
+        uct_md_mem_reg_params_t reg_params    = {};
+        uct_md_mkey_pack_params_t pack_params = {};
+        ucs_status_t status;
+
+        status = uct_md_mem_reg_v2(md(), buf.ptr(), size, &reg_params, memh);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        return uct_md_mkey_pack_v2(md(), *memh, buf.ptr(), size, &pack_params,
+                                   rkey);
+    }
+
+    static void
+    tamper_rkey_uuid(uct_cuda_ipc_rkey_t *rkey, int64_t value0, int64_t value1)
+    {
+        int64_t *uuid64 = reinterpret_cast<int64_t*>(rkey->uuid.bytes);
+        uuid64[0]       = value0;
+        uuid64[1]       = value1;
+    }
+
+#endif
 };
 
 UCS_TEST_P(test_cuda_ipc_md, mpack_legacy)
@@ -226,11 +255,134 @@ UCS_TEST_P(test_cuda_ipc_md, mkey_pack_mempool)
 #endif
 }
 
+UCS_TEST_P(test_cuda_ipc_md, mkey_pack_posix_fd)
+{
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    cuda_posix_fd_mem_buffer buf(4096, UCS_MEMORY_TYPE_CUDA);
+    uct_mem_h memh;
+    uct_cuda_ipc_rkey_t rkey = {};
+
+    ASSERT_UCS_OK(pack_posix_fd_key(buf, buf.size(), &memh, &rkey));
+    EXPECT_EQ(UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD, rkey.ph.handle_type);
+    EXPECT_EQ(ucs_get_system_id(), rkey.ph.handle.posix_fd.system_id);
+
+    uct_md_mem_dereg_params_t dereg_params;
+    dereg_params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+    dereg_params.memh       = memh;
+    EXPECT_UCS_OK(uct_md_mem_dereg_v2(md(), &dereg_params));
+#else
+    UCS_TEST_SKIP_R("built without pidfd support");
+#endif
+}
+
+UCS_TEST_P(test_cuda_ipc_md, posix_fd_system_id_mismatch)
+{
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    cuda_posix_fd_mem_buffer buf(4096, UCS_MEMORY_TYPE_CUDA);
+    uct_mem_h memh;
+    uct_cuda_ipc_rkey_t rkey = {};
+
+    ASSERT_UCS_OK(pack_posix_fd_key(buf, buf.size(), &memh, &rkey));
+    EXPECT_EQ(UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD, rkey.ph.handle_type);
+    EXPECT_EQ(ucs_get_system_id(), rkey.ph.handle.posix_fd.system_id);
+
+    /* Tamper system_id to simulate a different machine */
+    rkey.ph.handle.posix_fd.system_id ^= 0xDEADBEEFDEADBEEFULL;
+
+    /* Tamper UUID to bypass same-process shortcut */
+    tamper_rkey_uuid(&rkey, 0xDEADLL, 0xBEEFLL);
+
+    uct_rkey_unpack_params_t unpack_params = {0};
+    EXPECT_EQ(UCS_ERR_UNREACHABLE,
+              uct_rkey_unpack_v2(md()->component, &rkey, &unpack_params, NULL));
+
+    uct_md_mem_dereg_params_t dereg_params;
+    dereg_params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+    dereg_params.memh       = memh;
+    EXPECT_UCS_OK(uct_md_mem_dereg_v2(md(), &dereg_params));
+#else
+    UCS_TEST_SKIP_R("built without pidfd support");
+#endif
+}
+
 UCS_TEST_P(test_cuda_ipc_md, mnnvl_disabled)
 {
     /* Currently MNNVL is always disabled in CI */
     uct_cuda_ipc_md_t *cuda_ipc_md = ucs_derived_of(md(), uct_cuda_ipc_md_t);
     EXPECT_FALSE(cuda_ipc_md->enable_mnnvl);
+}
+
+UCS_TEST_P(test_cuda_ipc_md, posix_fd_same_node_ipc)
+{
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    cuda_posix_fd_mem_buffer buf(4096, UCS_MEMORY_TYPE_CUDA);
+    size_t size = buf.size();
+    uct_mem_h memh;
+    uct_cuda_ipc_rkey_t rkey = {};
+
+    ASSERT_EQ(CUDA_SUCCESS, cuMemsetD8((CUdeviceptr)buf.ptr(), 0xAB, size));
+
+    ASSERT_UCS_OK(pack_posix_fd_key(buf, size, &memh, &rkey));
+    ASSERT_EQ(UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD, rkey.ph.handle_type);
+    ASSERT_EQ(ucs_get_system_id(), rkey.ph.handle.posix_fd.system_id);
+
+    /* Tamper UUID to bypass same-process shortcut and exercise the full
+     * POSIX FD import path (pidfd_open/pidfd_getfd + cuMemImport) */
+    tamper_rkey_uuid(&rkey, 0x1234LL, 0x5678LL);
+
+    uct_component_t *component = md()->component;
+
+    /* Unpack on a separate thread with its own CUDA context */
+    std::exception_ptr thread_exception;
+    std::thread([&]() {
+        try {
+            CUdevice dev;
+            CUcontext ctx;
+            ASSERT_EQ(CUDA_SUCCESS, cuDeviceGet(&dev, 0));
+            ASSERT_EQ(CUDA_SUCCESS,
+                      uct_test_cuda_ctx_create_compat(&ctx, 0, dev));
+
+            uct_rkey_unpack_params_t unpack_params = {};
+            uct_rkey_bundle_t rkey_bundle = {};
+            ASSERT_UCS_OK(uct_rkey_unpack_v2(component, &rkey, &unpack_params,
+                                             &rkey_bundle));
+
+            uct_cuda_ipc_unpacked_rkey_t *unpacked =
+                    (uct_cuda_ipc_unpacked_rkey_t*)rkey_bundle.rkey;
+            void *mapped_addr;
+            ucs_status_t map_status = uct_cuda_ipc_map_memhandle(
+                    &unpacked->super, dev, &mapped_addr, UCS_LOG_LEVEL_ERROR);
+            ASSERT_UCS_OK(map_status);
+
+            std::vector<uint8_t> host_buf(size);
+            ASSERT_EQ(CUDA_SUCCESS,
+                      cuMemcpyDtoH(host_buf.data(), (CUdeviceptr)mapped_addr,
+                                   size));
+            for (size_t i = 0; i < size; i++) {
+                ASSERT_EQ(0xAB, host_buf[i]) << "Data mismatch at byte " << i;
+            }
+
+            uct_cuda_ipc_unmap_memhandle(
+                    unpacked->super.super.pid, unpacked->super.pid_ns,
+                    unpacked->super.super.d_bptr, mapped_addr, dev, 0);
+            EXPECT_UCS_OK(uct_rkey_release(component, &rkey_bundle));
+            EXPECT_EQ(cuCtxDestroy(ctx), CUDA_SUCCESS);
+        } catch (...) {
+            thread_exception = std::current_exception();
+        }
+    }).join();
+
+    if (thread_exception) {
+        std::rethrow_exception(thread_exception);
+    }
+
+    uct_md_mem_dereg_params_t dereg_params;
+    dereg_params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+    dereg_params.memh       = memh;
+    EXPECT_UCS_OK(uct_md_mem_dereg_v2(md(), &dereg_params));
+#else
+    UCS_TEST_SKIP_R("built without pidfd support");
+#endif
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_cuda_ipc_md, cuda_ipc);

--- a/test/gtest/uct/cuda/test_switch_cuda_device.cc
+++ b/test/gtest/uct/cuda/test_switch_cuda_device.cc
@@ -4,15 +4,15 @@
  * See file LICENSE for terms.
  */
 
+#include "cuda_vmm_mem_buffer.h"
+
 #include <uct/test_md.h>
 #include <uct/test_p2p_rma.h>
 
 extern "C" {
-#include <ucs/sys/ptr_arith.h>
 #include <uct/base/uct_md.h>
 }
 
-#include <cuda.h>
 #include <cuda_runtime.h>
 #include <thread>
 
@@ -51,108 +51,6 @@ void test_switch_cuda_device::detect_mem_type(ucs_memory_type_t mem_type) const
               UCS_OK);
     EXPECT_EQ(detected_mem_type, mem_type);
 }
-
-class cuda_vmm_mem_buffer {
-public:
-    cuda_vmm_mem_buffer() = default;
-    cuda_vmm_mem_buffer(size_t size, ucs_memory_type_t mem_type);
-    virtual ~cuda_vmm_mem_buffer();
-    void *ptr() const;
-
-protected:
-    void init(size_t size, unsigned handle_type);
-
-private:
-    size_t m_size                               = 0;
-    CUmemGenericAllocationHandle m_alloc_handle = 0;
-    CUdeviceptr m_ptr                           = 0;
-};
-
-cuda_vmm_mem_buffer::cuda_vmm_mem_buffer(size_t size,
-                                         ucs_memory_type_t mem_type)
-{
-    init(size, 0);
-}
-
-cuda_vmm_mem_buffer::~cuda_vmm_mem_buffer()
-{
-    cuMemUnmap(m_ptr, m_size);
-    cuMemAddressFree(m_ptr, m_size);
-    cuMemRelease(m_alloc_handle);
-}
-
-void *cuda_vmm_mem_buffer::ptr() const
-{
-    return (void*)m_ptr;
-}
-
-void cuda_vmm_mem_buffer::init(size_t size, unsigned handle_type)
-{
-    size_t granularity          = 0;
-    CUmemAllocationProp prop    = {};
-    CUmemAccessDesc access_desc = {};
-    CUdevice device;
-    if (cuCtxGetDevice(&device) != CUDA_SUCCESS) {
-        UCS_TEST_ABORT("failed to get the device handle for the current "
-                       "context");
-    }
-
-    prop.type                 = CU_MEM_ALLOCATION_TYPE_PINNED;
-    prop.location.type        = CU_MEM_LOCATION_TYPE_DEVICE;
-    prop.location.id          = device;
-    if (handle_type != 0) {
-        prop.requestedHandleTypes = (CUmemAllocationHandleType)handle_type;
-    }
-    if (cuMemGetAllocationGranularity(&granularity, &prop,
-                                      CU_MEM_ALLOC_GRANULARITY_MINIMUM) !=
-        CUDA_SUCCESS) {
-        goto err;
-    }
-
-    m_size = ucs_align_up(size, granularity);
-    if (cuMemCreate(&m_alloc_handle, m_size, &prop, 0) != CUDA_SUCCESS) {
-        goto err;
-    }
-
-    if (cuMemAddressReserve(&m_ptr, m_size, 0, 0, 0) != CUDA_SUCCESS) {
-        goto err_mem_release;
-    }
-
-    if (cuMemMap(m_ptr, m_size, 0, m_alloc_handle, 0) != CUDA_SUCCESS) {
-        goto err_address_free;
-    }
-
-    access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    access_desc.location.id   = device;
-    access_desc.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    if (cuMemSetAccess(m_ptr, m_size, &access_desc, 1) != CUDA_SUCCESS) {
-        goto err_mem_unmap;
-    }
-
-    return;
-
-err_mem_unmap:
-    cuMemUnmap(m_ptr, m_size);
-err_address_free:
-    cuMemAddressFree(m_ptr, m_size);
-err_mem_release:
-    cuMemRelease(m_alloc_handle);
-err:
-    UCS_TEST_SKIP_R("failed to allocate CUDA fabric memory");
-}
-
-#if HAVE_CUDA_FABRIC
-class cuda_fabric_mem_buffer : public cuda_vmm_mem_buffer {
-public:
-    cuda_fabric_mem_buffer(size_t size, ucs_memory_type_t mem_type);
-};
-
-cuda_fabric_mem_buffer::cuda_fabric_mem_buffer(size_t size,
-                                               ucs_memory_type_t mem_type)
-{
-    init(size, CU_MEM_HANDLE_TYPE_FABRIC);
-}
-#endif
 
 UCS_TEST_P(test_switch_cuda_device, detect_mem_type_cuda)
 {
@@ -225,13 +123,8 @@ void test_p2p_create_destroy_ctx::test_xfer(send_func_t send, size_t length,
         }
     }
 
-#if CUDA_VERSION >= 13000
-    CUctxCreateParams ctx_create_params = {};
-    ASSERT_EQ(cuCtxCreate(&m_cuda_context, &ctx_create_params, 0, device),
+    ASSERT_EQ(uct_test_cuda_ctx_create_compat(&m_cuda_context, 0, device),
               CUDA_SUCCESS);
-#else
-    ASSERT_EQ(cuCtxCreate(&m_cuda_context, 0, device), CUDA_SUCCESS);
-#endif
     uct_p2p_rma_test::test_xfer(send, length, flags, mem_type);
 }
 

--- a/test/mpi/test_cuda_common.c
+++ b/test/mpi/test_cuda_common.c
@@ -93,6 +93,9 @@ static alloc_mem_t alloc_mempool(size_t);
 static void free_mempool(alloc_mem_t*);
 static alloc_mem_t alloc_vmm_fabric(size_t);
 #endif
+#if HAVE_DECL_SYS_PIDFD_GETFD
+static alloc_mem_t alloc_vmm_posix_fd(size_t);
+#endif
 
 static int test_alloc_prim_send_prim(const test_params_t*);
 static int test_alloc_prim_send_no(const test_params_t*);
@@ -109,7 +112,10 @@ const allocator_t allocators[] = {
     {"VMM", alloc_vmm, free_vmm},
 #if HAVE_CUDA_FABRIC
     {"mempool", alloc_mempool, free_mempool},
-    {"VMM_Fabric", alloc_vmm_fabric, free_vmm}
+    {"VMM_Fabric", alloc_vmm_fabric, free_vmm},
+#endif
+#if HAVE_DECL_SYS_PIDFD_GETFD
+    {"VMM_PosixFD", alloc_vmm_posix_fd, free_vmm},
 #endif
 };
 
@@ -294,6 +300,13 @@ static void free_vmm(alloc_mem_t *alloc_mem)
     CUDA_CHECK(cuMemAddressFree(alloc_mem->ptr, alloc_mem->size));
     CUDA_CHECK(cuMemRelease((CUmemGenericAllocationHandle)alloc_mem->obj));
 }
+
+#if HAVE_DECL_SYS_PIDFD_GETFD
+static alloc_mem_t alloc_vmm_posix_fd(size_t size)
+{
+    return alloc_vmm_type(size, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+}
+#endif
 
 #if HAVE_CUDA_FABRIC
 static alloc_mem_t alloc_vmm_fabric(size_t size)


### PR DESCRIPTION
## What?
Add support for CUDA VMM allocations that expose POSIX file descriptor handles (CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) as an IPC transport in cuda_ipc

## Why?
Before this change cuda ipc could not share VMM allocations within the same node without NVLink enabled.

## How?
When a VMM allocation does not support fabric handles but supports POSIX FD handles, the FD is exported along with a system_id to identify the source machine. On the receiver side, system_id is verified to ensure both peers are on the same machine, and the FD is duplicated via pidfd_open/pidfd_getfd (Linux 5.6+) before importing through cuMemImportFromShareableHandle.
This requires pidfd_open/pidfd_getfd to be available at compile time for it to work.
