### PR TITLE
Avoid warning/error: assignment discards 'const' qualifier from pointer target type

### DIFF
--- a/src/tools/perf/mad/perftest_mad.c
+++ b/src/tools/perf/mad/perftest_mad.c
@@ -601,7 +601,7 @@ static ucs_status_t perftest_mad_parse_ca_and_port(const char *mad_port,
                                                    int *ca_port)
 {
     static const int default_port = 1;
-    char *sep                     = strchr(mad_port, ':');
+    const char *sep               = strchr(mad_port, ':');
     size_t len;
 
     if (sep == NULL) {

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -584,7 +584,7 @@ static ucs_status_t init_daemon_params(ucx_perf_params_t *params)
 ucs_status_t parse_test_params(perftest_params_t *params, char opt,
                                const char *opt_arg)
 {
-    char *optarg2 = NULL;
+    const char *optarg2 = NULL;
     test_type_t *test;
     unsigned i;
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -644,7 +644,7 @@ int ucs_config_sprintf_bw(char *buf, size_t max, const void *src,
 int ucs_config_sscanf_bw_spec(const char *buf, void *dest, const void *arg)
 {
     ucs_config_bw_spec_t *dst = (ucs_config_bw_spec_t*)dest;
-    char                 *delim;
+    const char           *delim;
 
     delim = strchr(buf, ':');
     if (!delim) {

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1396,7 +1396,7 @@ ucs_status_t uct_ib_device_find_port(uct_ib_device_t *dev,
     const char *ibdev_name;
     unsigned port_num;
     size_t devname_len;
-    char *p;
+    const char *p;
 
     p = strrchr(resource_dev_name, ':');
     if (p == NULL) {
@@ -1411,7 +1411,7 @@ ucs_status_t uct_ib_device_find_port(uct_ib_device_t *dev,
         goto err; /* Device name is wrong */
     }
 
-    port_num = strtod(p + 1, &p);
+    port_num = strtod(p + 1, (char **) &p);
     if (*p != '\0') {
         goto err; /* Failed to parse port number */
     }


### PR DESCRIPTION
Fixes https://github.com/openucx/ucx/issues/11185
