### PR TITLE
UCT/IB/ZE: Enable GPUDirect RDMA for Intel Xe devices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,6 +115,7 @@ Wenbin Lu <wenbin.lu@stonybrook.edu>
 Xin Zhao <xinz@mellanox.com>
 Xu Yifeng <yifeng.xyf@alibaba-inc.com>
 Yaser Afshar <yaser.afshar@intel.com>
+Yihua Xu <yihua.xu@intel.com>
 Yiltan Hassan Temucin <yiltan.temucin@amd.com>
 Yossi Itigin <yosefe@nvidia.com>
 Yuriy Shestakov <yuriis@mellanox.com>

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1345,6 +1345,10 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         /* check if ROCM KFD driver is loaded */
         uct_ib_check_gpudirect_driver(md, "/dev/kfd", UCS_MEMORY_TYPE_ROCM);
 
+        /* Check if Intel Xe driver is loaded */
+        uct_ib_check_gpudirect_driver(md, "/sys/module/xe/srcversion",
+                                      UCS_MEMORY_TYPE_ZE_DEVICE);
+
         /* Check for HabanaLabs Gaudi DMABuf support */
         uct_ib_check_gpudirect_driver(md, "/dev/accel/accel0",
                                       UCS_MEMORY_TYPE_GAUDI);
@@ -1358,8 +1362,8 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         !(md->cap_flags & UCT_MD_FLAG_REG_DMABUF) &&
         (md_config->enable_gpudirect_rdma == UCS_YES)) {
         ucs_error("%s: Couldn't enable GPUDirect RDMA. Please make sure "
-                  "nv_peer_mem or amdgpu plugin installed correctly, or dmabuf "
-                  "is supported.",
+                  "nv_peer_mem, amdgpu plugin, or Intel Xe driver is "
+                  "installed correctly, or dmabuf is supported.",
                   uct_ib_device_name(&md->dev));
         status = UCS_ERR_UNSUPPORTED;
         goto err_cleanup_device;

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2023-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -48,7 +48,8 @@ static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
     md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |


### PR DESCRIPTION
## What?

Revives #11005 with minor cleanup: Add GPUDirect RDMA (GDR) support for Intel Xe devices by:

1. Detecting Intel Xe driver presence (`/sys/module/xe/srcversion`) in IB MD to enable GDR capability for `UCS_MEMORY_TYPE_ZE_DEVICE`
2. Extending ZE copy MD `access_mem_types` to include `UCS_MEMORY_TYPE_HOST` to allow IB transports to access host memory through ZE MD registration

## Why?

In GDR mode, eliminating extra memcpy operations between host staging buffers and GPU memory improves bandwidth and reduces latency for RDMA transfers on Intel GPU hardware. Currently, the IB layer does not recognize Intel Xe devices for GPUDirect, and the ZE copy MD does not expose HOST memory access required for GDR interoperability.

## How?

- **IB MD (`src/uct/ib/base/ib_md.c`):** Add `uct_ib_check_gpudirect_driver()` call to probe `/sys/module/xe/srcversion` alongside existing CUDA and ROCm checks. This sets the appropriate bit in `md->reg_mem_types` when the Xe kernel module is loaded.
- **ZE Copy MD (`src/uct/ze/copy/ze_copy_md.c`):** Add `UCS_BIT(UCS_MEMORY_TYPE_HOST)` to `md_attr->access_mem_types` alongside existing ZE memory types. This allows IB transports to register host memory through the ZE MD for GDR operations.

Related: #11180 (UCT/ZE: Add device topology registration) - Complementary ZE infrastructure changes. These PRs are independent but both advance ZE/IB integration.

Signed-off-by: Yihua Xu <yihua.xu@intel.com>
Signed-off-by: Yaser Afshar <yaser.afshar@intel.com>