### PR TITLE
v1.20.x - UCP/API: docs - user can modify buffer after calling ucp_atomic_op_nbx as its being packed (copied) (#11126)

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -3787,9 +3787,12 @@ ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
  * @a param.reply_buffer. Please see @ref atomic_ops "table" below for more
  * details.
  *
- * @note    The user should not modify any part of the @a buffer (or also
- *          @a param->reply_buffer for fetch operations), until the operation
- *          completes.
+ * @note    The user should not modify any part of the @a param->reply_buffer 
+ *          in fetching operations, until the operation completes.
+ * @note    For non-fethcing operations @a buffer can be modified or released 
+ *          immediately after the call to this function, without waiting for the
+ *          operation completion.
+ * 
  * @note    Only ucp_dt_make_config(4) and ucp_dt_make_contig(8) are supported
  *          in @a param->datatype, see @ref ucp_dt_make_contig. Also, currently
  *          atomic operations can handle one element only. Thus, @a count


### PR DESCRIPTION
(cherry picked from commit b2d053e49426ba8e8447035138edcf6d0b7b2802)
