### PR TITLE
UCS/RCACHE: Fix locking for gdrcopy - v1.20.x

### DIFF
--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -61,6 +61,7 @@ enum {
     UCS_RCACHE_FLAG_NO_PFN_CHECK  = UCS_BIT(0), /**< PFN check not supported for this rcache */
     UCS_RCACHE_FLAG_PURGE_ON_FORK = UCS_BIT(1), /**< purge rcache on fork */
     UCS_RCACHE_FLAG_SYNC_EVENTS   = UCS_BIT(2), /**< Synchronize memory events handling */
+    UCS_RCACHE_FLAG_NEED_LRU_LOCK = UCS_BIT(3), /**< rcache not protected by other lock */
 };
 
 /*

--- a/src/ucs/memory/rcache.inl
+++ b/src/ucs/memory/rcache.inl
@@ -18,34 +18,59 @@ ucs_rcache_region_test(ucs_rcache_region_t *region, int prot, size_t alignment)
            ((alignment == 1) || (region->alignment >= alignment));
 }
 
-
-/* LRU spinlock must be held */
 static UCS_F_ALWAYS_INLINE void
-ucs_rcache_region_lru_add(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
+ucs_rcache_region_lru_get_impl(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
 {
-    if (region->lru_flags & UCS_RCACHE_LRU_FLAG_IN_LRU) {
-        return;
-    }
-
-    ucs_rcache_region_trace(rcache, region, "lru add");
-    ucs_list_add_tail(&rcache->lru.list, &region->lru_list);
-    region->lru_flags |= UCS_RCACHE_LRU_FLAG_IN_LRU;
-}
-
-
-/* LRU spinlock must be held */
-static UCS_F_ALWAYS_INLINE void
-ucs_rcache_region_lru_remove(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
-{
-    if (!(region->lru_flags & UCS_RCACHE_LRU_FLAG_IN_LRU)) {
-        return;
-    }
-
     ucs_rcache_region_trace(rcache, region, "lru remove");
     ucs_list_del(&region->lru_list);
     region->lru_flags &= ~UCS_RCACHE_LRU_FLAG_IN_LRU;
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucs_rcache_region_lru_get(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
+{
+    if (rcache->lru.mode == UCS_RCACHE_LRU_DISABLED) {
+        return;
+    }
+    if (!(region->lru_flags & UCS_RCACHE_LRU_FLAG_IN_LRU)) {
+        return;
+    }
+    /* A used region cannot be evicted */
+    if (rcache->lru.mode == UCS_RCACHE_LRU_LOCKED) {
+        ucs_spin_lock(&rcache->lru.lock);
+        ucs_rcache_region_lru_get_impl(rcache, region);
+        ucs_spin_unlock(&rcache->lru.lock);
+    } else {
+        ucs_rcache_region_lru_get_impl(rcache, region);
+    }
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_rcache_region_lru_put_impl(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
+{
+    ucs_rcache_region_trace(rcache, region, "lru add");
+    ucs_list_add_tail(&rcache->lru.list, &region->lru_list);
+    region->lru_flags |= UCS_RCACHE_LRU_FLAG_IN_LRU;
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucs_rcache_region_lru_put(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
+{
+    if (rcache->lru.mode == UCS_RCACHE_LRU_DISABLED) {
+        return;
+    }
+    if (region->lru_flags & UCS_RCACHE_LRU_FLAG_IN_LRU) {
+        return;
+    }
+    /* When we finish using a region, it's a candidate for LRU eviction */
+    if (rcache->lru.mode == UCS_RCACHE_LRU_LOCKED) {
+        ucs_spin_lock(&rcache->lru.lock);
+        ucs_rcache_region_lru_put_impl(rcache, region);
+        ucs_spin_unlock(&rcache->lru.lock);
+    } else {
+        ucs_rcache_region_lru_put_impl(rcache, region);
+    }
+}
 
 static UCS_F_ALWAYS_INLINE ucs_rcache_region_t *
 ucs_rcache_lookup_unsafe(ucs_rcache_t *rcache, void *address, size_t length,
@@ -76,7 +101,7 @@ ucs_rcache_lookup_unsafe(ucs_rcache_t *rcache, void *address, size_t length,
     }
 
     region->refcount++;
-    ucs_rcache_region_lru_remove(rcache, region);
+    ucs_rcache_region_lru_get(rcache, region);
     UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_HITS_FAST, 1);
     return region;
 }
@@ -96,7 +121,7 @@ ucs_rcache_lookup(ucs_rcache_t *rcache, void *address, size_t length,
 static UCS_F_ALWAYS_INLINE void
 ucs_rcache_region_put_unsafe(ucs_rcache_t *rcache, ucs_rcache_region_t *region)
 {
-    ucs_rcache_region_lru_add(rcache, region);
+    ucs_rcache_region_lru_put(rcache, region);
 
     ucs_assert(region->refcount > 0);
     if (ucs_unlikely(--region->refcount == 0)) {

--- a/src/ucs/memory/rcache_int.h
+++ b/src/ucs/memory/rcache_int.h
@@ -64,6 +64,12 @@ typedef struct ucs_rcache_distribution {
     size_t total_size; /**< Total size of regions in the group */
 } ucs_rcache_distribution_t;
 
+typedef enum {
+    UCS_RCACHE_LRU_DISABLED, /* LRU is completely disabled */
+    UCS_RCACHE_LRU_LOCKED,   /* LRU enabled and needs its own locking */
+    UCS_RCACHE_LRU_UNSAFE    /* LRU enabled and protected by other lock */
+} ucs_rcache_lru_mode_t;
+
 struct ucs_rcache {
     ucs_rcache_params_t params;          /**< rcache parameters (immutable) */
 
@@ -94,8 +100,9 @@ struct ucs_rcache {
     size_t              unreleased_size; /**< Total size of the regions in gc_list and in inv_q */
 
     struct {
-        ucs_spinlock_t  lock;            /**< Lock for this structure */
-        ucs_list_link_t list;            /**< List of regions, sorted by usage:
+        ucs_rcache_lru_mode_t mode;      /**< Whether lru is enabled and needs locking */
+        ucs_spinlock_t        lock;      /**< Lock for this structure */
+        ucs_list_link_t       list;      /**< List of regions, sorted by usage:
                                               The head of the list is the least
                                               recently used region, and the tail
                                               is the most recently used region. */

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -493,6 +493,7 @@ uct_gdr_copy_md_create(uct_component_t *component,
     rcache_params.ucm_events         = UCM_EVENT_MEM_TYPE_FREE;
     rcache_params.context            = md;
     rcache_params.ops                = &uct_gdr_copy_rcache_ops;
+    rcache_params.flags             |= UCS_RCACHE_FLAG_NEED_LRU_LOCK;
 
     status = ucs_rcache_create(&rcache_params, "gdr_copy", ucs_stats_get_root(),
                                &md->rcache);


### PR DESCRIPTION
(cherry picked from commit 5687e9a81e63ee07147a5d60b491070b426b5363)

From #11149 -- Disable LRU for infinite size and ensure consistent locking.
