### PR TITLE
CI: Fix Jenkins Codestyle job failures

### DIFF
--- a/test/gtest/common/googletest/gtest-death-test.cc
+++ b/test/gtest/common/googletest/gtest-death-test.cc
@@ -34,7 +34,6 @@
 
 #include <utility>
 #include <cstdint>
-#include <cstddef>
 
 #include "internal/gtest-port.h"
 #include "internal/custom/gtest.h"


### PR DESCRIPTION
  ## What?
  Fix Jenkins codestyle Format Check for PRs that modify C/C++ files with no formatting changes.

  ## Why?
  `git-clang-format --diff` produces empty output when changed C/C++ files are already
  correctly formatted. The script only checked for `"no modified files to format"` before
  running `git apply`, so an empty patch caused `git apply` to fail with
  `error: unrecognized input` (exit 128).

  ## How?
  Add checks for empty `format.patch` and the `"clang-format did not modify any files"`
  message before attempting `git apply`.