### PR TITLE
CI: pin ci-demo to stable_ucx tag

### DIFF
--- a/.ci/jenkins/Jenkinsfile.github
+++ b/.ci/jenkins/Jenkinsfile.github
@@ -6,7 +6,7 @@
  */
 
 @Library('blossom-github-lib@master')
-@Library('github.com/Mellanox/ci-demo@master')
+@Library('github.com/Mellanox/ci-demo@stable_ucx')
 def matrix = new com.mellanox.cicd.Matrix()
 
 import ipp.blossom.*

--- a/.ci/jenkins/Jenkinsfile.gitlab
+++ b/.ci/jenkins/Jenkinsfile.gitlab
@@ -5,7 +5,7 @@
  * See file LICENSE for terms.
  */
 
-@Library('github.com/Mellanox/ci-demo@master')
+@Library('github.com/Mellanox/ci-demo@stable_ucx')
 def matrix = new com.mellanox.cicd.Matrix()
 
 // Reports per-job status to GitLab. JOB_BASE_NAME is set by Jenkins.


### PR DESCRIPTION
## What?
Pin ci-demo library to `stable_ucx` tag instead of `master`.

## Why?
Recent changes in ci-demo `master` broke our CI pipeline.

## How?
Changed `@Library` annotation in Jenkinsfile from `ci-demo@master` to `ci-demo@stable_ucx`.