### PR TITLE
UCP/RMA: non blocking strong ucp_worker_fence for one sided RMA operations

### DIFF
--- a/src/tools/info/type_info.c
+++ b/src/tools/info/type_info.c
@@ -274,12 +274,12 @@ void print_type_info(const char * tl_name)
     PRINT_FIELD_SIZE(ucp_request_t, send.state.dt_iter);
     PRINT_FIELD_SIZE(ucp_request_t, send.state.dt);
     PRINT_FIELD_SIZE(ucp_request_t, send.msg_proto);
-    PRINT_FIELD_SIZE(ucp_request_t, send.rma);
+    PRINT_FIELD_SIZE(ucp_request_t, send.fenced_req.rma);
     PRINT_FIELD_SIZE(ucp_request_t, send.proto);
     PRINT_FIELD_SIZE(ucp_request_t, send.rndv);
     PRINT_FIELD_SIZE(ucp_request_t, send.rkey_ptr);
     PRINT_FIELD_SIZE(ucp_request_t, send.flush);
-    PRINT_FIELD_SIZE(ucp_request_t, send.amo);
+    PRINT_FIELD_SIZE(ucp_request_t, send.fenced_req.amo);
     PRINT_FIELD_SIZE(ucp_request_t, recv);
     PRINT_FIELD_SIZE(ucp_request_t, recv.dt_iter);
     PRINT_FIELD_SIZE(ucp_request_t, recv.uct_ctx);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -627,21 +627,19 @@ ucp_ep_fence_try_advance_epoch(ucp_ep_h ep, uint64_t target_fence_seq)
 static int
 ucp_ep_fence_dispatch_request(ucp_ep_h ep)
 {
-    ucp_ep_ext_t      *ep_ext  = ep->ext;
-    ucp_request_t     *req;
-    uct_pending_req_t *uct_req;
-    ucs_status_t       status;
-    int                batch;
+    ucp_ep_ext_t   *ep_ext = ep->ext;
+    ucp_request_t  *req;
+    ucs_status_t   status;
+    int            batch;
 
-    req     = ucs_queue_pull_elem_non_empty(&ep_ext->fence_pending_q,
-                                            ucp_request_t,
-                                            send.fenced_req.fence_pending_elem);
-    uct_req = &req->send.uct;
+    req = ucs_queue_pull_elem_non_empty(&ep_ext->fence_pending_q,
+                                        ucp_request_t,
+                                        send.fenced_req.fence_pending_elem);
 
     for (batch = 0; batch < UCP_EP_FENCE_PROGRESS_BATCH; ++batch) {
         /* protect from coverity as in ucp_request.inl - function ucp_request_try_send */
         /* coverity[address_free] */
-        status = uct_req->func(uct_req);
+        status = req->send.uct.func(&req->send.uct);
         if (status != UCS_INPROGRESS) {
             break;
         }

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -311,6 +311,9 @@ static int UCS_F_ALWAYS_INLINE ucp_request_try_send(ucp_request_t *req)
     } else if (status == UCS_INPROGRESS) {
         /* Not completed, but made progress */
         return 0;
+    } else if (status == UCP_STATUS_FENCE_DEFER) {
+        /* Deferred due to strong fence, treat as retry-later */
+        return ucp_request_pending_add(req);
     } else if (status == UCS_ERR_NO_RESOURCE) {
         /* No send resources, try to add to pending queue */
         return ucp_request_pending_add(req);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2604,7 +2604,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->context              = context;
     worker->uuid                 = ucs_generate_uuid((uintptr_t)worker);
     worker->flush_ops_count      = 0;
-    worker->fence_seq            = 0;
+    worker->fence_seq            = 1; /* Start at 1; 0 is sentinel for "fence_seq not yet snapshotted" */
     worker->inprogress           = 0;
     worker->num_active_ifaces    = 0;
     worker->num_ifaces           = 0;

--- a/src/ucp/rma/amo_basic.c
+++ b/src/ucp/rma/amo_basic.c
@@ -33,11 +33,11 @@ ucs_status_t ucp_amo_check_send_status(ucp_request_t *req, ucs_status_t status)
 static ucs_status_t ucp_amo_basic_progress_post(uct_pending_req_t *self)
 {
     ucp_request_t *req   = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_rkey_h rkey      = req->send.amo.rkey;
+    ucp_rkey_h rkey      = req->send.fenced_req.amo.rkey;
     ucp_ep_t *ep         = req->send.ep;
-    uint64_t value       = req->send.amo.value;
-    uint64_t remote_addr = req->send.amo.remote_addr;
-    uct_atomic_op_t op   = req->send.amo.uct_op;
+    uint64_t value       = req->send.fenced_req.amo.value;
+    uint64_t remote_addr = req->send.fenced_req.amo.remote_addr;
+    uct_atomic_op_t op   = req->send.fenced_req.amo.uct_op;
     ucs_status_t status;
 
     req->send.lane = rkey->cache.amo_lane;
@@ -58,12 +58,12 @@ static ucs_status_t ucp_amo_basic_progress_post(uct_pending_req_t *self)
 static ucs_status_t ucp_amo_basic_progress_fetch(uct_pending_req_t *self)
 {
     ucp_request_t *req    = ucs_container_of(self, ucp_request_t, send.uct);
-    ucp_rkey_h rkey       = req->send.amo.rkey;
+    ucp_rkey_h rkey       = req->send.fenced_req.amo.rkey;
     ucp_ep_t *ep          = req->send.ep;
-    uint64_t value        = req->send.amo.value;
+    uint64_t value        = req->send.fenced_req.amo.value;
     uint64_t *result      = req->send.buffer;
-    uint64_t remote_addr  = req->send.amo.remote_addr;
-    uct_atomic_op_t op    = req->send.amo.uct_op;
+    uint64_t remote_addr  = req->send.fenced_req.amo.remote_addr;
+    uct_atomic_op_t op    = req->send.fenced_req.amo.uct_op;
     uct_ep_h uct_ep;
     ucs_status_t status;
 

--- a/src/ucp/rma/amo_send.c
+++ b/src/ucp/rma/amo_send.c
@@ -95,9 +95,9 @@ static UCS_F_ALWAYS_INLINE void
 ucp_amo_init_proto(ucp_request_t *req, uct_atomic_op_t op,
                    uint64_t remote_addr, ucp_rkey_h rkey)
 {
-    req->send.amo.uct_op      = op;
-    req->send.amo.remote_addr = remote_addr;
-    req->send.amo.rkey        = rkey;
+    req->send.fenced_req.amo.uct_op      = op;
+    req->send.fenced_req.amo.remote_addr = remote_addr;
+    req->send.fenced_req.amo.rkey        = rkey;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -105,10 +105,10 @@ ucp_amo_init_common(ucp_request_t *req, ucp_ep_h ep, uct_atomic_op_t op,
                     uint64_t remote_addr, ucp_rkey_h rkey, uint64_t value,
                     size_t size)
 {
-    req->flags                = 0;
-    req->send.ep              = ep;
-    req->send.length          = size;
-    req->send.amo.value       = value;
+    req->flags                      = 0;
+    req->send.ep                    = ep;
+    req->send.length                = size;
+    req->send.fenced_req.amo.value  = value;
 #if UCS_ENABLE_ASSERT
     req->send.lane            = UCP_NULL_LANE;
 #endif
@@ -216,7 +216,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_atomic_op_nbx,
         ucp_amo_init_proto(req, ucp_uct_atomic_op_table[opcode], remote_addr,
                            rkey);
         if (param->op_attr_mask & UCP_OP_ATTR_FIELD_REPLY_BUFFER) {
-            req->send.amo.reply_buffer = param->reply_buffer;
+            req->send.fenced_req.amo.reply_buffer = param->reply_buffer;
             op_id    = (opcode == UCP_ATOMIC_OP_CSWAP) ? UCP_OP_ID_AMO_CSWAP :
                                                          UCP_OP_ID_AMO_FETCH;
             status_p = ucp_proto_request_send_op_reply(

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -28,6 +28,7 @@
  */
 #define UCP_PROTO_RMA_MAX_BCOPY_LANES 1
 
+#define UCP_EP_FENCE_SPIN_TIMEOUT_US  20   /* max microseconds to spin */
 
 /**
  * Defines functions for RMA protocol
@@ -112,5 +113,7 @@ void ucp_rma_sw_send_cmpl(ucp_ep_h ep);
 ucs_status_t ucp_ep_fence_weak(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_fence_strong(ucp_ep_h ep);
+
+ucs_status_t ucp_ep_fence_strong_nb(ucp_ep_h ep, uint64_t fence_seq);
 
 #endif

--- a/src/ucp/rma/rma_basic.c
+++ b/src/ucp/rma/rma_basic.c
@@ -33,7 +33,7 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
 {
     ucp_request_t *req              = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_ep_t *ep                    = req->send.ep;
-    ucp_rkey_h rkey                 = req->send.rma.rkey;
+    ucp_rkey_h rkey                 = req->send.fenced_req.rma.rkey;
     ucp_lane_index_t lane           = req->send.lane;
     ucp_ep_rma_config_t *rma_config = &ucp_ep_config(ep)->rma[lane];
     ucp_md_index_t md_index;
@@ -50,7 +50,7 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
         status     = UCS_PROFILE_CALL(uct_ep_put_short,
                                       ucp_ep_get_fast_lane(ep, lane),
                                       req->send.buffer, packed_len,
-                                      req->send.rma.remote_addr,
+                                      req->send.fenced_req.rma.remote_addr,
                                       rkey->cache.rma_rkey);
     } else if (ucs_likely(req->send.length < rma_config->put_zcopy_thresh)) {
         ucp_memcpy_pack_context_t pack_ctx;
@@ -59,7 +59,7 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
         packed_len      = UCS_PROFILE_CALL(uct_ep_put_bcopy,
                                            ucp_ep_get_fast_lane(ep, lane),
                                            ucp_rma_basic_memcpy_pack, &pack_ctx,
-                                           req->send.rma.remote_addr,
+                                           req->send.fenced_req.rma.remote_addr,
                                            rkey->cache.rma_rkey);
         status = (packed_len > 0) ? UCS_OK : (ucs_status_t)packed_len;
     } else {
@@ -76,7 +76,7 @@ static ucs_status_t ucp_rma_basic_progress_put(uct_pending_req_t *self)
 
         status = UCS_PROFILE_CALL(uct_ep_put_zcopy,
                                   ucp_ep_get_fast_lane(ep, lane), &iov, 1,
-                                  req->send.rma.remote_addr,
+                                  req->send.fenced_req.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
     }
@@ -89,7 +89,7 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
 {
     ucp_request_t *req              = ucs_container_of(self, ucp_request_t, send.uct);
     ucp_ep_t *ep                    = req->send.ep;
-    ucp_rkey_h rkey                 = req->send.rma.rkey;
+    ucp_rkey_h rkey                 = req->send.fenced_req.rma.rkey;
     ucp_lane_index_t lane           = req->send.lane;
     ucp_ep_rma_config_t *rma_config = &ucp_ep_config(ep)->rma[lane];
     ucp_md_index_t md_index;
@@ -105,7 +105,7 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
                                        ucp_ep_get_fast_lane(ep, lane),
                                        (uct_unpack_callback_t)memcpy,
                                        (void*)req->send.buffer, frag_length,
-                                       req->send.rma.remote_addr,
+                                       req->send.fenced_req.rma.remote_addr,
                                        rkey->cache.rma_rkey,
                                        &req->send.state.uct_comp);
     } else {
@@ -120,7 +120,7 @@ static ucs_status_t ucp_rma_basic_progress_get(uct_pending_req_t *self)
 
         status = UCS_PROFILE_CALL(uct_ep_get_zcopy,
                                   ucp_ep_get_fast_lane(ep, lane), &iov, 1,
-                                  req->send.rma.remote_addr,
+                                  req->send.fenced_req.rma.remote_addr,
                                   rkey->cache.rma_rkey,
                                   &req->send.state.uct_comp);
     }

--- a/src/ucp/rma/rma_sw.c
+++ b/src/ucp/rma/rma_sw.c
@@ -26,7 +26,7 @@ static size_t ucp_rma_sw_put_pack_cb(void *dest, void *arg)
     ucp_put_hdr_t *puth = dest;
     size_t length;
 
-    puth->address  = req->send.rma.remote_addr;
+    puth->address  = req->send.fenced_req.rma.remote_addr;
     puth->ep_id    = ucp_ep_remote_id(ep);
     puth->mem_type = UCS_MEMORY_TYPE_HOST;
 
@@ -58,10 +58,10 @@ static size_t ucp_rma_sw_get_req_pack_cb(void *dest, void *arg)
     ucp_request_t *req         = arg;
     ucp_get_req_hdr_t *getreqh = dest;
 
-    getreqh->address    = req->send.rma.remote_addr;
+    getreqh->address    = req->send.fenced_req.rma.remote_addr;
     getreqh->length     = req->send.length;
     getreqh->req.ep_id  = ucp_send_request_get_ep_remote_id(req);
-    getreqh->mem_type   = req->send.rma.rkey->mem_type;
+    getreqh->mem_type   = req->send.fenced_req.rma.rkey->mem_type;
     getreqh->req.req_id = ucp_send_request_get_id(req);
     ucs_assert(getreqh->req.ep_id != UCS_PTR_MAP_KEY_INVALID);
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,14 +50,14 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_ep_ext_t, 216);
+    EXPECTED_SIZE(ucp_ep_ext_t, 248);
 #if ENABLE_PARAMS_CHECK
     EXPECTED_SIZE(ucp_rkey_t, 40 + sizeof(ucp_ep_h));
 #else
     EXPECTED_SIZE(ucp_rkey_t, 40);
 #endif
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 272);
+    EXPECTED_SIZE(ucp_request_t, 288);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(ucp_mem_t, 160);
     EXPECTED_SIZE(uct_ep_t, 8);


### PR DESCRIPTION
## What?
Create non-blocking worker fence for one sided RMA operations

## Why?
redmine.mellanox.com/issues/4399081#change-41579081
[RMA multi rail perf improvements](https://nvidia.atlassian.net/wiki/spaces/NSWX/pages/2496502924/RMA+Multi-Rail+Performance+Improvement)
Current strong fence implementation is a synchronised flush operation across all active rails, inherently blocking, and limiting multi-rail performances, as faster rails are forced to wait for slower ones to complete their operations.

## How?
Treat worker fence as epoch increment. Post-fence requests are queued in per-EP pending queue and drain asynchronously using callback once the preceding epoch's flush completes.
Add lane mask to flush only needed lanes.
Allow time-bounded inline spin to resolve small fences synchronously and avoid async overhead
Non blocking fence enabled with UCX_FENCE_MODE=ep_based only
