### PR TITLE
AZP: Increase CUDA stage timeout to 60m

### DIFF
--- a/buildlib/pr/cuda/cuda.yml
+++ b/buildlib/pr/cuda/cuda.yml
@@ -102,7 +102,7 @@ jobs:
           CONTAINER: rocky9_cuda_13_0
 
     container: $[ variables['CONTAINER'] ]
-    timeoutInMinutes: 35
+    timeoutInMinutes: 60
     variables:
       workspace: $(System.DefaultWorkingDirectory)/ucx_src_$(Build.BuildId)
     steps:


### PR DESCRIPTION
## What?
Increase CUDA stage timeout from 35m to 60m.

## Why?
The Cuda stage times out due to slow Docker image pool when pulling `nvidia/cuda` images.