### PR TITLE
UCT/CUDA/CUDA_IPC: allow multiple devices with same process

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -554,8 +554,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     }
 
     if ((getpid() == key->pid) &&
-        (ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID) == ext_key->pid_ns) &&
-        (memcmp(uuid.bytes, key->uuid.bytes, sizeof(uuid.bytes)) == 0)) {
+        (ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID) == ext_key->pid_ns)) {
         /* TODO: added for test purpose to enable cuda_ipc tests in gtest
          * mapped addrr is set to be same as d_bptr avoiding any calls to
          * uct_cuda_ipc_open_memhandle which would fail with invalid argument


### PR DESCRIPTION
## What?
The uct_cuda_ipc_map_memhandle contains a check for testing that if the peer is the same device in the same process then the mapped address is set to d_bptr instead of going through the rest of the flow. This change expands that check to all devices in the same process.

## Why?
#10933 removed the reachability check failure if the two peers are in the same process. Now cuda_ipc can be used within the same process, but it fails when calling `cuIpcOpenMemHandle`, which does not seem to work within the same process.
