### PR TITLE
UCT/ROCM: adjust hsa memory type check for new rocm releases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,6 +66,7 @@ Leonid Genkin <lgenkin@nvidia.com>
 Lior Paz <liorpa@nvidia.com>
 Luis E. Pena <l31g@hotmail.com>
 Manjunath Gorentla Venkata <manjugv@gmail.com>
+Manu Shantharam <manu.shantharam@amd.com>
 Marek Schimara <Marek.Schimara@bull.net>
 Mark Allen <markalle@us.ibm.com>
 Matthew Baker <bakermb@ornl.gov>

--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -106,10 +106,10 @@ AS_IF([test "x$with_rocm" != "xno"],
         AC_COMPUTE_INT([hip_version], [HIP_VERSION],
                         [#include <hip_version.h>],
                         [hip_version=0])
-        AC_MSG_RESULT([$hip_version])
+        AC_MSG_RESULT(["$hip_version"])
         CPPFLAGS="$SAVE_CPPFLAGS"])
 
-    AS_IF([test $hip_version -ge 70000000],
+    AS_IF([test "$hip_version" -ge 70000000],
         [AC_DEFINE([HAVE_ROCM_RESERVED_ADDR_TYPE], [1],
                     [ROCm 7.0+ has HSA_EXT_POINTER_TYPE_RESERVED_ADDR])])
 

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -254,12 +254,11 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size, void **base_ptr,
         /* HSA_EXT_POINTER_TYPE_RESERVED_ADDR check is required
          * for rocm7+ for hip managed memory
          */
-        if (info.type == HSA_EXT_POINTER_TYPE_UNKNOWN
+        if ((info.type == HSA_EXT_POINTER_TYPE_UNKNOWN)
 #ifdef HAVE_ROCM_RESERVED_ADDR_TYPE
-            || info.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR) {
-#else
-        ) {
+            || (info.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR)
 #endif
+        ) {
             *dev_type = HSA_DEVICE_TYPE_CPU;
         } else {
             status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE,


### PR DESCRIPTION
Newer rocm releases return HSA_EXT_POINTER_TYPE_RESERVED_ADDR instead of HSA_EXT_POINTER_TYPE_UNKNOWN for hip managed memory.

Add rocm version detection and guard code based on the detected version

## What?
Adding functionality to detect rocm version and enable code paths based on the version.

## Why?
Some of the hip tests related to "managed memory" are failing with rocm 7.x

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
