### PR TITLE
UCT/IB: Only query RoCE type for valid GID to avoid logs

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -768,8 +768,8 @@ static unsigned long uct_ib_device_get_ib_gid_index(uct_ib_md_t *md)
     }
 }
 
-ucs_status_t uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num,
-                                      unsigned flags)
+static ucs_status_t
+uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num, unsigned flags)
 {
     uct_ib_md_t *md = ucs_container_of(dev, uct_ib_md_t, dev);
     const uct_ib_device_spec_t *dev_info;
@@ -829,6 +829,11 @@ ucs_status_t uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num,
     status    = uct_ib_device_query_gid(dev, port_num, gid_index, &gid,
                                         UCS_LOG_LEVEL_DIAG);
     if (status != UCS_OK) {
+        if (status == UCS_ERR_INVALID_ADDR) {
+            ucs_trace("%s:%d (%s) has invalid address", uct_ib_device_name(dev),
+                      port_num, dev_info->name);
+        }
+
         return status;
     }
 
@@ -931,16 +936,18 @@ uct_ib_device_query_gid_info(struct ibv_context *ctx, const char *dev_name,
                              uint8_t port_num, unsigned gid_index,
                              uct_ib_device_gid_info_t *info)
 {
-    const union ibv_gid zero_gid = {};
     char buf[16];
     int ret;
 
     ret = ibv_query_gid(ctx, port_num, gid_index, &info->gid);
     if (ret == 0) {
-        ret = (memcmp(&info->gid, &zero_gid, sizeof(zero_gid)) ?
-               ucs_read_file(buf, sizeof(buf) - 1, 1,
+        if (!uct_ib_device_is_gid_valid(&info->gid)) {
+            return UCS_ERR_INVALID_ADDR;
+        }
+
+        ret = ucs_read_file(buf, sizeof(buf) - 1, 1,
                             UCT_IB_DEVICE_SYSFS_GID_TYPE_FMT,
-                            dev_name, port_num, gid_index) : -1);
+                            dev_name, port_num, gid_index);
         if (ret > 0) {
             if (!strncmp(buf, "IB/RoCE v1", 10)) {
                 info->roce_info.ver = UCT_IB_DEVICE_ROCE_V1;
@@ -1182,6 +1189,10 @@ uct_ib_device_select_gid(uct_ib_device_t *dev, uint8_t port_num,
             status = uct_ib_device_query_gid_info(dev->ibv_context,
                                                   uct_ib_device_name(dev),
                                                   port_num, i, &gid_info_tmp);
+            if (status == UCS_ERR_INVALID_ADDR) {
+                continue;
+            }
+
             if (status != UCS_OK) {
                 goto out;
             }
@@ -1434,18 +1445,14 @@ ucs_status_t uct_ib_device_query_gid(uct_ib_device_t *dev, uint8_t port_num,
 
     status = uct_ib_device_query_gid_info(dev->ibv_context, uct_ib_device_name(dev),
                                           port_num, gid_index, &gid_info);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    if (!uct_ib_device_is_gid_valid(&gid_info.gid)) {
+    if (status == UCS_OK) {
+        *gid = gid_info.gid;
+    } else if (status == UCS_ERR_INVALID_ADDR) {
         ucs_log(error_level, "invalid gid[%d] on %s:%d", gid_index,
                 uct_ib_device_name(dev), port_num);
-        return UCS_ERR_INVALID_ADDR;
     }
 
-    *gid = gid_info.gid;
-    return UCS_OK;
+    return status;
 }
 
 const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status)

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -279,13 +279,6 @@ extern const double uct_ib_qp_rnr_time_ms[];
 
 
 /**
- * Check if a port on a device is active and supports the given flags.
- */
-ucs_status_t uct_ib_device_port_check(uct_ib_device_t *dev, uint8_t port_num,
-                                      unsigned flags);
-
-
-/**
  * Helper function to set ECE to qp.
  *
  * @param dev              IB device use to create qp.

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -378,12 +378,12 @@ static ucs_status_t uct_ud_iface_gid_hash_init(uct_ud_iface_t *iface,
         status = uct_ib_device_query_gid_info(dev->ibv_context,
                                               uct_ib_device_name(dev),
                                               port, gid_idx, &gid_info);
-        if (status != UCS_OK) {
-            goto err;
+        if (status == UCS_ERR_INVALID_ADDR) {
+            continue;
         }
 
-        if (!memcmp(&gid_info.gid, &zero_gid, sizeof(zero_gid))) {
-            continue;
+        if (status != UCS_OK) {
+            goto err;
         }
 
         ucs_debug("iface %p: adding gid %s to hash on device %s port %d index "


### PR DESCRIPTION
## What?
Do not query RoCE type when GID is invalid.

## Why?
Although it shows a file size of 4kB, the sysfs code in driver returns EINVAL on read(), when the corresponding GID entry is invalid. This is producing a lot of debug logs, since the Verb API advertises a GID table size of 256.

## How?
Check for zero GID and remove log:
```
sys.c:460  UCX  DEBUG failed to read from /sys/class/infiniband/mlx5_0/ports/1/gid_attrs/types/51: Invalid argument