### PR TITLE
TEST/UCP/MOCK: Set `cap.put.max_short` to fix random test failure

### DIFF
--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -587,6 +587,7 @@ public:
         /* Device with higher BW and latency */
         add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short  = 2000;
+            iface_attr.cap.put.max_short = 2048;
             iface_attr.bandwidth.shared  = 28e9;
             iface_attr.latency.c         = 600e-9;
             iface_attr.latency.m         = 1e-9;
@@ -594,10 +595,11 @@ public:
         });
         /* Device with smaller BW but lower latency */
         add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
-            iface_attr.cap.am.max_short = 208;
-            iface_attr.bandwidth.shared = 24e9;
-            iface_attr.latency.c        = 500e-9;
-            iface_attr.latency.m        = 1e-9;
+            iface_attr.cap.am.max_short  = 208;
+            iface_attr.cap.put.max_short = 2048;
+            iface_attr.bandwidth.shared  = 24e9;
+            iface_attr.latency.c         = 500e-9;
+            iface_attr.latency.m         = 1e-9;
         });
         test_ucp_proto_mock::init();
     }
@@ -958,10 +960,11 @@ public:
     virtual void init() override
     {
         auto iface_attr_func = [](uct_iface_attr_t &iface_attr) {
-            iface_attr.cap.am.max_short = 208;
-            iface_attr.bandwidth.shared = 28e9;
-            iface_attr.latency.c        = 500e-9;
-            iface_attr.latency.m        = 1e-9;
+            iface_attr.cap.am.max_short  = 208;
+            iface_attr.cap.put.max_short = 2048;
+            iface_attr.bandwidth.shared  = 28e9;
+            iface_attr.latency.c         = 500e-9;
+            iface_attr.latency.m         = 1e-9;
         };
 
         add_mock_iface("mock_0:1", iface_attr_func);


### PR DESCRIPTION
## What

PUT protocol selection mock tests fail randomly in CI with a short range of `0..220` instead of the expected `0..2048`.

## Why

The mock interface callbacks set `cap.am.max_short` but not `cap.put.max_short`. Since the mock first calls the real `iface_query` and then applies overrides, the unmocked `cap.put.max_short` retains the real hardware value. Without mocking, this value depends on Device Memory (DM) availability and it may change depending on the CI machine.

## How

Explicitly set `cap.put.max_short = 2048` in the mock callbacks for `test_ucp_proto_mock_rcx` and `test_ucp_proto_mock_rcx_twins`, removing the dependency on the real hardware's DM support.

---

<details>

<summary>Test failure logs</summary>

```
[----------] 1 test from rcx/test_ucp_proto_mock_rcx_twins_put
[ RUN      ] rcx/test_ucp_proto_mock_rcx_twins_put.use_single_net_device_rank_1/0 <rc_x>
/scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/test_ucp_proto_mock.cc:370: Failure
Expected equality of these values:
  expected_data
    Which is: 0..2048 desc: short, config: rc_mlx5/mock_0:1/path0
  actual_data
    Which is: 0..220 desc: short, config: rc_mlx5/mock_0:1/path0
unexpected difference at range[0]
[     INFO ] +-----------------------------------+-------------------------------------------------------------+
[     INFO ] | ucp_context_3331 intra-node cfg#0 | remote memory write by ucp_put* from host memory to host    |
[     INFO ] +-----------------------------------+------------------------------------+------------------------+
[     INFO ] |                            0..220 | short                              | rc_mlx5/mock_0:1/path0 |
[     INFO ] |                          221..477 | copy-in                            | rc_mlx5/mock_2:1/path0 |
[     INFO ] |                          478..inf | zero-copy                          | rc_mlx5/mock_2:1/path0 |
[     INFO ] +-----------------------------------+------------------------------------+------------------------+
[  FAILED  ] rcx/test_ucp_proto_mock_rcx_twins_put.use_single_net_device_rank_1/0, where GetParam() = rc_x (438 ms)
[----------] 1 test from rcx/test_ucp_proto_mock_rcx_twins_put (438 ms total)
```

</details>