### PR TITLE
UCT/ROCM: adjust hsa memory type check for new rocm releases - v1.20.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ Leonid Genkin <lgenkin@nvidia.com>
 Lior Paz <liorpa@nvidia.com>
 Luis E. Pena <l31g@hotmail.com>
 Manjunath Gorentla Venkata <manjugv@gmail.com>
+Manu Shantharam <manu.shantharam@amd.com>
 Marek Schimara <Marek.Schimara@bull.net>
 Mark Allen <markalle@us.ibm.com>
 Matthew Baker <bakermb@ornl.gov>

--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Advanced Micro Devices, Inc. 2016 - 2023. ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2016 - 2026. ALL RIGHTS RESERVED.
 # Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
@@ -97,6 +97,22 @@ AS_IF([test "x$with_rocm" != "xno"],
            AC_SUBST([ROCM_LIBS])
            AC_SUBST([ROCM_ROOT])],
           [AC_MSG_WARN([ROCm not found])])
+
+    AS_IF([test "x$rocm_happy" = "xyes"],
+        [HIP_BUILD_FLAGS([$with_rocm], [HIP_LIBS], [HIP_LDFLAGS], [HIP_CPPFLAGS])
+        CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"
+
+        AC_MSG_CHECKING([for HIP version])
+        AC_COMPUTE_INT([hip_version], [HIP_VERSION],
+                        [#include <hip_version.h>],
+                        [hip_version=0])
+        AC_MSG_RESULT(["$hip_version"])
+        CPPFLAGS="$SAVE_CPPFLAGS"])
+
+    AS_IF([test "$hip_version" -ge 70000000],
+        [AC_DEFINE([HAVE_ROCM_RESERVED_ADDR_TYPE], [1],
+                    [ROCm 7.0+ has HSA_EXT_POINTER_TYPE_RESERVED_ADDR])])
+
    AC_CHECK_FUNCS([hsa_amd_portable_export_dmabuf])
 
     CPPFLAGS="$SAVE_CPPFLAGS"

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Advanced Micro Devices, Inc. 2019-2023. ALL RIGHTS RESERVED.
+ * Copyright (C) Advanced Micro Devices, Inc. 2019-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -251,7 +251,14 @@ hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size, void **base_ptr,
         *base_size = info.sizeInBytes;
     }
     if (dev_type != NULL) {
-        if (info.type == HSA_EXT_POINTER_TYPE_UNKNOWN) {
+        /* HSA_EXT_POINTER_TYPE_RESERVED_ADDR check is required
+         * for rocm7+ for hip managed memory
+         */
+        if ((info.type == HSA_EXT_POINTER_TYPE_UNKNOWN)
+#ifdef HAVE_ROCM_RESERVED_ADDR_TYPE
+            || (info.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR)
+#endif
+        ) {
             *dev_type = HSA_DEVICE_TYPE_CPU;
         } else {
             status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE,


### PR DESCRIPTION
* UCT/ROCM: adjust hsa memory type check for new rocm releases

Newer rocm releases return HSA_EXT_POINTER_TYPE_RESERVED_ADDR instead of HSA_EXT_POINTER_TYPE_UNKNOWN for hip managed memory.

Add rocm version detection and guard code based on the detected version

* UCT/ROCM: Fix formatting issue and update the Copyright date

* UCT/ROCM: Addressing review comments

## What?
Cherry-picking the commit from the master branch

## Why?
Bug-fix being propagated from master to v1.20.x

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
