### PR TITLE
UCT/CUDA_IPC: Add cuda IPC cache invalidation

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -44,11 +44,22 @@ KHASH_INIT(cuda_ipc_rem_cache, uct_cuda_ipc_cache_hash_key_t,
            uct_cuda_ipc_cache_t*, 1, uct_cuda_ipc_cache_hash_func,
            uct_cuda_ipc_cache_hash_equal);
 
+/*
+ * Cache limit propagation:
+ *
+ * The cache limits (max_regions, max_size) are configured via MD config
+ * (uct_cuda_ipc_md_config_t), which is transient and not accessible after
+ * md_open returns. Per-peer caches are created on-demand in
+ * uct_cuda_ipc_get_remote_cache(), which has no access to the MD. Therefore
+ * the limits are stored here as globals and read directly by the eviction loop.
+ * Each md_open tightens the limits to min(current, configured), so the most
+ * restrictive value across all MDs is always in effect.
+ */
 typedef struct uct_cuda_ipc_remote_cache {
     khash_t(cuda_ipc_rem_cache) hash;
     ucs_recursive_spinlock_t    lock;
-    unsigned long               max_regions; /**< Limit propagated to new caches */
-    size_t                      max_size;    /**< Limit propagated to new caches */
+    unsigned long               max_regions; /**< Global max regions limit */
+    size_t                      max_size;    /**< Global max total size limit */
 } uct_cuda_ipc_remote_cache_t;
 
 uct_cuda_ipc_remote_cache_t uct_cuda_ipc_remote_cache;
@@ -187,39 +198,53 @@ uct_cuda_ipc_cache_region_remove(uct_cuda_ipc_cache_t *cache,
 
     status = ucs_pgtable_remove(&cache->pgtable, &region->super);
     if (status != UCS_OK) {
-        ucs_error("failed to remove address:%p from cache (%s)",
+        ucs_warn("failed to remove address:%p from cache (%s)",
                   (void *)region->key.d_bptr, ucs_status_string(status));
     }
 
-    if (region->in_lru) {
-        ucs_list_del(&region->lru_list);
-        region->in_lru = 0;
-    }
+    ucs_assertv(region->in_lru, "region=%p, refcount=%lu", region, region->refcount);
+    ucs_list_del(&region->lru_list);
+    region->in_lru = 0;
 
     ucs_assert(cache->num_regions > 0);
     cache->num_regions--;
     cache->total_size -= region->key.b_len;
 }
 
+static void
+uct_cuda_ipc_cache_region_destroy(uct_cuda_ipc_cache_t *cache,
+                                  uct_cuda_ipc_cache_region_t *region)
+{
+    uct_cuda_ipc_cache_region_remove(cache, region);
+
+    ucs_trace("%s: destroy region " UCS_PGT_REGION_FMT " size:%lu",
+              cache->name, UCS_PGT_REGION_ARG(&region->super),
+              region->key.b_len);
+
+    uct_cuda_ipc_close_memhandle(region);
+    ucs_free(region);
+}
+
 static void uct_cuda_ipc_cache_evict_lru(uct_cuda_ipc_cache_t *cache)
 {
+    unsigned long max_regions = uct_cuda_ipc_remote_cache.max_regions;
+    size_t max_size           = uct_cuda_ipc_remote_cache.max_size;
     uct_cuda_ipc_cache_region_t *region, *tmp;
 
     ucs_list_for_each_safe(region, tmp, &cache->lru_list, lru_list) {
-        if ((cache->num_regions <= cache->max_regions) &&
-            (cache->total_size <= cache->max_size)) {
+        if ((cache->num_regions <= max_regions) &&
+            (cache->total_size  <= max_size)) {
             break;
         }
 
-        ucs_assert(region->refcount == 0);
-        uct_cuda_ipc_cache_region_remove(cache, region);
+        if (region->refcount > 0) {
+            /* In-use region -- pull off LRU, it will be re-added on release */
+            ucs_list_del(&region->lru_list);
+            region->in_lru = 0;
+            continue;
+        }
 
-        ucs_trace("%s: lru evict region " UCS_PGT_REGION_FMT " size:%lu",
-                  cache->name, UCS_PGT_REGION_ARG(&region->super),
-                  region->key.b_len);
-
-        uct_cuda_ipc_close_memhandle(region);
-        ucs_free(region);
+        uct_cuda_ipc_cache_region_destroy(cache, region);
     }
 }
 
@@ -510,9 +535,7 @@ uct_cuda_ipc_get_remote_cache(const uct_cuda_ipc_cache_hash_key_t *key,
         (khret == UCS_KH_PUT_BUCKET_CLEAR)) {
         ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%d:%ld:%d",
                           key->pid, key->pid_ns, key->cu_device);
-        status = uct_cuda_ipc_create_cache(cache, target_name,
-                                           uct_cuda_ipc_remote_cache.max_regions,
-                                           uct_cuda_ipc_remote_cache.max_size);
+        status = uct_cuda_ipc_create_cache(cache, target_name);
         if (status != UCS_OK) {
             kh_del(cuda_ipc_rem_cache, &uct_cuda_ipc_remote_cache.hash, khiter);
             ucs_error("could not create create cuda ipc cache: %s",
@@ -564,15 +587,11 @@ ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, ucs_sys_ns_t pid_ns,
     ucs_assert(region->refcount >= 1);
     region->refcount--;
 
-    /*
-     * check refcount to see if an in-flight transfer is using the same mapping
-     */
     if (!region->refcount && !cache_enabled) {
-        uct_cuda_ipc_cache_region_remove(cache, region);
         ucs_assert(region->mapped_addr == mapped_addr);
-        status = uct_cuda_ipc_close_memhandle(region);
-        ucs_free(region);
-    } else if (!region->refcount && !region->in_lru) {
+        uct_cuda_ipc_cache_region_destroy(cache, region);
+    } else if (!region->in_lru) {
+        /* Region becomes an eviction candidate -- add to LRU tail */
         ucs_list_add_tail(&cache->lru_list, &region->lru_list);
         region->in_lru = 1;
     }
@@ -630,10 +649,12 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
                       UCS_PGT_REGION_FMT, cache->name, (void *)key->d_bptr,
                       key->b_len, UCS_PGT_REGION_ARG(&region->super));
 
+            /* Move to LRU tail (most recently used) */
             if (region->in_lru) {
                 ucs_list_del(&region->lru_list);
-                region->in_lru = 0;
             }
+            ucs_list_add_tail(&cache->lru_list, &region->lru_list);
+            region->in_lru = 1;
 
             *mapped_addr = region->mapped_addr;
             ucs_assert(region->refcount < UINT64_MAX);
@@ -646,9 +667,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
                       cache->name, UCS_PGT_REGION_ARG(&region->super),
                       (void *)key->d_bptr, key->b_len);
 
-            uct_cuda_ipc_cache_region_remove(cache, region);
-            uct_cuda_ipc_close_memhandle(region);
-            ucs_free(region);
+            uct_cuda_ipc_cache_region_destroy(cache, region);
         }
     }
 
@@ -706,7 +725,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     region->mapped_addr = *mapped_addr;
     region->refcount    = 1;
     region->cu_dev      = cu_dev;
-    region->in_lru      = 0;
+    region->in_lru      = 0; /* will be set after pgtable insert */
 
     status = UCS_PROFILE_CALL(ucs_pgtable_insert,
                               &cache->pgtable, &region->super);
@@ -729,14 +748,16 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
 
     cache->num_regions++;
     cache->total_size += key->b_len;
+    ucs_list_add_tail(&cache->lru_list, &region->lru_list);
+    region->in_lru = 1;
 
     uct_cuda_ipc_cache_evict_lru(cache);
 
     ucs_trace("%s: cuda_ipc cache new region:"UCS_PGT_REGION_FMT" size:%lu"
               " (regions:%lu/%lu size:%zu/%zu)",
               cache->name, UCS_PGT_REGION_ARG(&region->super), key->b_len,
-              cache->num_regions, cache->max_regions,
-              cache->total_size, cache->max_size);
+              cache->num_regions, uct_cuda_ipc_remote_cache.max_regions,
+              cache->total_size, uct_cuda_ipc_remote_cache.max_size);
 
     status = UCS_OK;
 
@@ -746,9 +767,7 @@ err:
 }
 
 ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
-                                       const char *name,
-                                       unsigned long max_regions,
-                                       size_t max_size)
+                                       const char *name)
 {
     ucs_status_t status;
     uct_cuda_ipc_cache_t *cache_desc;
@@ -783,8 +802,6 @@ ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
     ucs_list_head_init(&cache_desc->lru_list);
     cache_desc->num_regions = 0;
     cache_desc->total_size  = 0;
-    cache_desc->max_regions = max_regions;
-    cache_desc->max_size    = max_size;
 
     *cache = cache_desc;
     return UCS_OK;
@@ -808,8 +825,10 @@ void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache)
 void uct_cuda_ipc_cache_set_global_limits(unsigned long max_regions,
                                           size_t max_size)
 {
-    uct_cuda_ipc_remote_cache.max_regions = max_regions;
-    uct_cuda_ipc_remote_cache.max_size    = max_size;
+    uct_cuda_ipc_remote_cache.max_regions = ucs_min(uct_cuda_ipc_remote_cache.max_regions, 
+                                                    max_regions);
+    uct_cuda_ipc_remote_cache.max_size    = ucs_min(uct_cuda_ipc_remote_cache.max_size,
+                                                    max_size);
 }
 
 UCS_STATIC_INIT {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -36,18 +36,14 @@ struct uct_cuda_ipc_cache {
     pthread_rwlock_t      lock;         /**< Protects the page table */
     ucs_pgtable_t         pgtable;      /**< Page table to hold the regions */
     char                  *name;        /**< Name */
-    ucs_list_link_t       lru_list;     /**< LRU list of idle regions (refcount==0) */
+    ucs_list_link_t       lru_list;     /**< LRU list of all cached regions */
     unsigned long         num_regions;  /**< Current number of cached regions */
     size_t                total_size;   /**< Current total size of cached regions */
-    unsigned long         max_regions;  /**< Max allowed regions (ULONG_MAX=unlimited) */
-    size_t                max_size;     /**< Max allowed total size (SIZE_MAX=unlimited) */
 };
 
 
 ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
-                                       const char *name,
-                                       unsigned long max_regions,
-                                       size_t max_size);
+                                       const char *name);
 
 
 void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -41,14 +41,16 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
      ucs_offsetof(uct_cuda_ipc_md_config_t, enable_mnnvl), UCS_CONFIG_TYPE_TERNARY},
 
     {"CACHE_MAX_REGIONS", "inf",
-     "Maximal number of regions in the CUDA IPC remote handle cache.\n"
-     "Regions are evicted from the cache in LRU order when this limit is exceeded.",
+     "Maximum number of regions in each per-peer CUDA IPC remote handle cache.\n"
+     "Each remote peer has a separate cache; this limit applies independently\n"
+     "to each one. Regions are evicted in LRU order when this limit is exceeded.",
      ucs_offsetof(uct_cuda_ipc_md_config_t, cache_max_regions),
      UCS_CONFIG_TYPE_ULUNITS},
 
     {"CACHE_MAX_SIZE", "inf",
-     "Maximal total size of CUDA IPC remote handle cache regions.\n"
-     "Regions are evicted from the cache in LRU order when this limit is exceeded.",
+     "Maximum total size of regions in each per-peer CUDA IPC remote handle cache.\n"
+     "Each remote peer has a separate cache; this limit applies independently\n"
+     "to each one. Regions are evicted in LRU order when this limit is exceeded.",
      ucs_offsetof(uct_cuda_ipc_md_config_t, cache_max_size),
      UCS_CONFIG_TYPE_MEMUNITS},
 
@@ -623,15 +625,13 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
         return UCS_ERR_NO_MEMORY;
     }
 
-    md->super.ops         = &md_ops;
-    md->super.component   = &uct_cuda_ipc_component.super;
-    md->enable_mnnvl      = uct_cuda_ipc_md_check_fabric_info(
+    md->super.ops       = &md_ops;
+    md->super.component = &uct_cuda_ipc_component.super;
+    md->enable_mnnvl    = uct_cuda_ipc_md_check_fabric_info(
                                                   md, ipc_config->enable_mnnvl);
-    md->cache_max_regions = ipc_config->cache_max_regions;
-    md->cache_max_size    = ipc_config->cache_max_size;
 
-    uct_cuda_ipc_cache_set_global_limits(md->cache_max_regions,
-                                         md->cache_max_size);
+    uct_cuda_ipc_cache_set_global_limits(ipc_config->cache_max_regions,
+                                         ipc_config->cache_max_size);
 
     *md_p                 = &md->super;
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -45,8 +45,6 @@ typedef struct uct_cuda_ipc_md_handle {
 typedef struct uct_cuda_ipc_md {
     uct_md_t                 super;             /**< Domain info */
     int                      enable_mnnvl;      /**< Multi-node NVLINK support status */
-    unsigned long            cache_max_regions;  /**< Max cached IPC regions per peer */
-    size_t                   cache_max_size;     /**< Max total cached IPC mapping size per peer */
 } uct_cuda_ipc_md_t;
 
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -244,6 +244,8 @@ protected:
     virtual void init() {
         ucs::test::init();
         m_cache = NULL;
+        /* Reset global limits to unlimited before each test */
+        uct_cuda_ipc_cache_set_global_limits(ULONG_MAX, SIZE_MAX);
     }
 
     virtual void cleanup() {
@@ -251,12 +253,15 @@ protected:
             drain_cache();
             uct_cuda_ipc_destroy_cache(m_cache);
         }
+        uct_cuda_ipc_cache_set_global_limits(ULONG_MAX, SIZE_MAX);
         ucs::test::cleanup();
     }
 
     void create_cache(unsigned long max_regions, size_t max_size) {
-        ASSERT_EQ(UCS_OK, uct_cuda_ipc_create_cache(&m_cache, "test_lru",
-                                                     max_regions, max_size));
+        uct_cuda_ipc_cache_set_global_limits(max_regions, max_size);
+        m_max_regions = max_regions;
+        m_max_size    = max_size;
+        ASSERT_EQ(UCS_OK, uct_cuda_ipc_create_cache(&m_cache, "test_lru"));
     }
 
     uct_cuda_ipc_cache_region_t *insert_region(size_t index) {
@@ -288,6 +293,8 @@ protected:
 
         m_cache->num_regions++;
         m_cache->total_size += REGION_SIZE;
+        ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
+        region->in_lru = 1;
 
         return region;
     }
@@ -295,17 +302,19 @@ protected:
     void release_region(uct_cuda_ipc_cache_region_t *region) {
         ASSERT_GE(region->refcount, 1UL);
         region->refcount--;
-        if ((region->refcount == 0) && !region->in_lru) {
+        if (!region->in_lru) {
             ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
             region->in_lru = 1;
         }
     }
 
     void reacquire_region(uct_cuda_ipc_cache_region_t *region) {
+        /* Move to LRU tail (most recently used) */
         if (region->in_lru) {
             ucs_list_del(&region->lru_list);
-            region->in_lru = 0;
         }
+        ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
+        region->in_lru = 1;
         region->refcount++;
     }
 
@@ -313,12 +322,17 @@ protected:
         uct_cuda_ipc_cache_region_t *region, *tmp;
 
         ucs_list_for_each_safe(region, tmp, &m_cache->lru_list, lru_list) {
-            if ((m_cache->num_regions <= m_cache->max_regions) &&
-                (m_cache->total_size <= m_cache->max_size)) {
+            if ((m_cache->num_regions <= m_max_regions) &&
+                (m_cache->total_size <= m_max_size)) {
                 break;
             }
 
-            ASSERT_EQ(0UL, region->refcount);
+            if (region->refcount > 0) {
+                /* In-use -- pull off LRU, will be re-added on release */
+                ucs_list_del(&region->lru_list);
+                region->in_lru = 0;
+                continue;
+            }
 
             ASSERT_EQ(UCS_OK, ucs_pgtable_remove(&m_cache->pgtable,
                                                   &region->super));
@@ -360,6 +374,8 @@ protected:
     }
 
     uct_cuda_ipc_cache_t *m_cache;
+    unsigned long         m_max_regions;
+    size_t                m_max_size;
 };
 
 const size_t    test_cuda_ipc_cache_lru::REGION_SIZE;


### PR DESCRIPTION
NVL576 bring-up : Add LRU list to cuda IPC cache,
enabling  automatic LRU (and cache) eviction.
LRU is disabled by default, enabled when any of
these two parameters is not inf :
UCX_CUDA_IPC_CACHE_MAX_REGIONS and UCX_CUDA_IPC_CACHE_MAX_SIZE Add cuda IPC LRU gtest

## What?
Add LRU list to cuda ipc remote cache

## Why?
NVL576 bring-up : in setups with limited CPU VA space, no cache invalidation may lead to VA exhaustion.
LRU allows automatic cache eviction and limits cache size.

## How?
LRU similar to rcache, disabled by default. Enabled by configuring any of these params to finite values: UCX_CUDA_IPC_CACHE_MAX_REGIONS and UCX_CUDA_IPC_CACHE_MAX_SIZE