### PR TITLE
UCT/IB/UD: Fix premature skb release on uncompleted tx operations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,6 +109,7 @@ Shuki Zanyovka <shuki.zanyovka@huawei.com>
 Sourav Chakraborty <souchakr@amd.com>
 Srinivasan Subramanian <srinivasan.subramanian@amd.com>
 Stephen Richmond <srichmond@dancer.icl.utk.edu>
+Sunny Tiwari <sunnytiwari@google.com>
 Swen Boehm <boehms@ornl.gov>
 Thomas Vegas <tvegas@nvidia.com>
 Tomer Gilad <tgilad@nvidia.com>

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -187,6 +187,7 @@ static uint16_t uct_ud_mlx5_ep_send_ctl(uct_ud_ep_t *ud_ep, uct_ud_send_skb_t *s
         ++dptr;
     }
 
+    skb->tx_sn = sn;
     uct_ud_mlx5_post_send(iface, ep, ce_se, ctrl, wqe_size, skb->neth,
                           max_log_sge);
     return sn;
@@ -325,6 +326,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_ud_mlx5_ep_inline_iov_post(
                                                  iov, iovcnt);
     }
 
+    skb->tx_sn = iface->tx.wq.sw_pi;
     uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size, neth,
                           UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
 
@@ -435,6 +437,7 @@ static ssize_t uct_ud_mlx5_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
     ctrl = uct_ud_mlx5_ep_get_next_wqe(iface, ep, &wqe_size, &next_seg);
     dptr = next_seg;
     uct_ib_mlx5_set_data_seg(dptr, skb->neth, skb->len, skb->lkey);
+    skb->tx_sn = iface->tx.wq.sw_pi;
     uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size + sizeof(*dptr),
                           skb->neth, INT_MAX);
 

--- a/src/uct/ib/ud/base/ud_def.h
+++ b/src/uct/ib/ud/base/ud_def.h
@@ -155,6 +155,7 @@ typedef struct uct_ud_send_skb {
     uint32_t                lkey;
     uint16_t                len;        /* data size */
     uint16_t                flags;
+    uint16_t                tx_sn;      /* Sequence number when posted to NIC */
     uct_ud_neth_t           neth[0];
 } UCS_S_PACKED UCS_V_ALIGNED(UCT_UD_SKB_ALIGN) uct_ud_send_skb_t;
 

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -180,13 +180,13 @@ uct_ud_ep_window_release_inline(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
         }
         if (ucs_likely(!(skb->flags & UCT_UD_SEND_SKB_FLAG_COMP))) {
             /* fast path case: skb without completion callback */
-            uct_ud_skb_release(skb, 1);
+            uct_ud_skb_release(iface, skb, 1);
         } else if (ucs_likely(!is_async)) {
             /* dispatch user completion immediately */
             cdesc = uct_ud_comp_desc(skb);
             uct_completion_update_status(cdesc->comp, status);
             uct_ud_iface_dispatch_comp(iface, cdesc->comp);
-            uct_ud_skb_release(skb, 1);
+            uct_ud_skb_release(iface, skb, 1);
         } else {
             /* Don't call user completion from async context. Instead, put
              * it on a queue which will be progressed from main thread.
@@ -1131,6 +1131,7 @@ uct_ud_ep_comp_skb_add(uct_ud_iface_t *iface, uct_ud_ep_t *ep,
      */
     skb->flags                  = UCT_UD_SEND_SKB_FLAG_COMP;
     skb->len                    = sizeof(skb->neth[0]);
+    skb->tx_sn                  = iface->tx.comp_sn;
     skb->neth->packet_type      = 0;
     skb->neth->psn              = (uct_ud_psn_t)(ep->tx.psn - 1);
     uct_ud_neth_set_dest_id(skb->neth, UCT_UD_EP_NULL_ID);

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -571,6 +571,8 @@ UCS_CLASS_INIT_FUNC(uct_ud_iface_t, uct_ud_iface_ops_t *ops,
 
     ucs_queue_head_init(&self->tx.async_comp_q);
     ucs_queue_head_init(&self->rx.pending_q);
+    ucs_queue_head_init(&self->tx.skb_pending_free);
+    self->tx.comp_sn = UINT16_MAX;
 
     status = UCS_STATS_NODE_ALLOC(&self->stats, &uct_ud_iface_stats_class,
                                   self->super.stats, "-%p", self);
@@ -623,6 +625,14 @@ static UCS_CLASS_CLEANUP_FUNC(uct_ud_iface_t)
     ucs_twheel_cleanup(&self->tx.timer);
     ucs_debug("iface(%p): cep cleanup", self);
     uct_ud_iface_free_async_comps(self);
+    {
+        uct_ud_send_skb_t *skb;
+        while (!ucs_queue_is_empty(&self->tx.skb_pending_free)) {
+            skb = ucs_queue_pull_elem_non_empty(&self->tx.skb_pending_free,
+                                                uct_ud_send_skb_t, queue);
+            ucs_mpool_put(skb);
+        }
+    }
     ucs_mpool_cleanup(&self->tx.mp, 0);
     /* TODO: qp to error state and cleanup all wqes */
     uct_ud_iface_free_pending_rx(self);
@@ -866,7 +876,7 @@ uct_ud_iface_dispatch_async_comps_do(uct_ud_iface_t *iface, uct_ud_ep_t *ep)
             ucs_trace("ep %p: dispatch async comp %p", ep, cdesc->comp);
             ucs_queue_del_iter(&iface->tx.async_comp_q, iter);
             uct_ud_iface_dispatch_comp(iface, cdesc->comp);
-            uct_ud_skb_release(skb, 0);
+            uct_ud_skb_release(iface, skb, 0);
             ++count;
         }
     }
@@ -879,7 +889,7 @@ static void uct_ud_iface_free_async_comps(uct_ud_iface_t *iface)
     uct_ud_send_skb_t *skb;
 
     ucs_queue_for_each_extract(skb, &iface->tx.async_comp_q, queue, 1) {
-        uct_ud_skb_release(skb, 0);
+        uct_ud_skb_release(iface, skb, 0);
     }
 }
 
@@ -1079,14 +1089,25 @@ void uct_ud_iface_ctl_skb_complete(uct_ud_iface_t *iface,
     }
 
     uct_ud_ep_window_release_completed(cdesc->ep, is_async);
-    uct_ud_skb_release(skb, 0);
+    uct_ud_skb_release(iface, skb, 0);
+}
 
+static void uct_ud_iface_free_pending_skbs(uct_ud_iface_t *iface, uint16_t sn)
+{
+    uct_ud_send_skb_t *skb;
+
+    iface->tx.comp_sn = sn;
+    ucs_queue_for_each_extract(skb, &iface->tx.skb_pending_free, queue,
+                               UCT_UD_PSN_COMPARE(skb->tx_sn, <=, sn)) {
+        ucs_mpool_put(skb);
+    }
 }
 
 void uct_ud_iface_send_completion_ordered(uct_ud_iface_t *iface, uint16_t sn,
                                           int is_async)
 {
     uct_ud_ctl_desc_t *cdesc;
+    uct_ud_iface_free_pending_skbs(iface, sn);
     ucs_queue_for_each_extract(cdesc, &iface->tx.outstanding.queue, queue,
                                UCS_CIRCULAR_COMPARE16(cdesc->sn, <=, sn)) {
         uct_ud_iface_ctl_skb_complete(iface, cdesc, is_async);
@@ -1100,6 +1121,7 @@ void uct_ud_iface_send_completion_unordered(uct_ud_iface_t *iface, uint16_t sn,
                              &iface->tx.outstanding.map, sn);
     uct_ud_ctl_desc_t *cdesc;
 
+    uct_ud_iface_free_pending_skbs(iface, sn);
     if (ucs_likely(khiter != kh_end(&iface->tx.outstanding.map))) {
         cdesc = kh_value(&iface->tx.outstanding.map, khiter);
         uct_ud_iface_ctl_skb_complete(iface, cdesc, is_async);

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -182,6 +182,8 @@ struct uct_ud_iface {
         } outstanding;
         ucs_arbiter_t          pending_q;
         ucs_queue_head_t       async_comp_q;
+        ucs_queue_head_t       skb_pending_free;
+        uint16_t               comp_sn;
         ucs_twheel_t           timer;
         ucs_time_t             tick;
         double                 timer_backoff;

--- a/src/uct/ib/ud/base/ud_inl.h
+++ b/src/uct/ib/ud/base/ud_inl.h
@@ -69,14 +69,18 @@ uct_ud_send_skb_t *uct_ud_iface_get_tx_skb(uct_ud_iface_t *iface,
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_ud_skb_release(uct_ud_send_skb_t *skb, int is_inline)
+uct_ud_skb_release(uct_ud_iface_t *iface, uct_ud_send_skb_t *skb, int is_inline)
 {
     ucs_assert(!(skb->flags & UCT_UD_SEND_SKB_FLAG_INVALID));
     skb->flags = UCT_UD_SEND_SKB_FLAG_INVALID;
-    if (is_inline) {
-        ucs_mpool_put_inline(skb);
+    if (UCT_UD_PSN_COMPARE(skb->tx_sn, <=, iface->tx.comp_sn)) {
+        if (is_inline) {
+            ucs_mpool_put_inline(skb);
+        } else {
+            ucs_mpool_put(skb);
+        }
     } else {
-        ucs_mpool_put(skb);
+        ucs_queue_push(&iface->tx.skb_pending_free, &skb->queue);
     }
 }
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -125,6 +125,7 @@ uct_ud_verbs_ep_tx_skb(uct_ud_verbs_iface_t *iface, uct_ud_verbs_ep_t *ep,
     iface->tx.sge[0].lkey   = skb->lkey;
     iface->tx.sge[0].length = skb->len;
     iface->tx.sge[0].addr   = (uintptr_t)skb->neth;
+    skb->tx_sn              = iface->tx.send_sn;
     uct_ud_verbs_post_send(iface, ep, &iface->tx.wr_skb, send_flags, max_log_sge);
 }
 
@@ -196,6 +197,7 @@ ucs_status_t uct_ud_verbs_ep_am_short(uct_ep_h tl_ep, uint8_t id, uint64_t hdr,
     iface->tx.sge[0].length = sizeof(uct_ud_neth_t) + sizeof(*am_hdr);
     iface->tx.sge[0].addr   = (uintptr_t)skb->neth;
 
+    skb->tx_sn = iface->tx.send_sn;
     uct_ud_verbs_ep_tx_inlv(iface, ep, buffer, length);
 
     skb->len = iface->tx.sge[0].length;
@@ -232,6 +234,7 @@ static ucs_status_t uct_ud_verbs_ep_am_short_iov(uct_ep_h tl_ep, uint8_t id,
     iface->tx.sge[0].addr              = (uintptr_t)skb->neth;
     iface->tx.wr_inl.num_sge           = uct_ib_verbs_sge_fill_iov(iface->tx.sge + 1,
                                                                     iov, iovcnt) + 1;
+    skb->tx_sn                         = iface->tx.send_sn;
     uct_ud_verbs_post_send(iface, ep, &iface->tx.wr_inl, IBV_SEND_INLINE,
                            iface->tx.wr_inl.num_sge);
 
@@ -352,6 +355,7 @@ ucs_status_t uct_ud_verbs_ep_put_short(uct_ep_h tl_ep,
     iface->tx.sge[0].addr   = (uintptr_t)neth;
     iface->tx.sge[0].length = sizeof(*neth) + sizeof(*put_hdr);
 
+    skb->tx_sn = iface->tx.send_sn;
     uct_ud_verbs_ep_tx_inlv(iface, ep, buffer, length);
 
     skb->len = iface->tx.sge[0].length;

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -685,6 +685,72 @@ UCS_TEST_P(test_ud, connect_iface_single_drop_creq) {
 }
 #endif
 
+UCS_TEST_SKIP_COND_P(test_ud, skb_pending_free_gc,
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT))
+{
+    uct_ud_iface_t *ud_iface = iface(m_e1);
+    uct_ud_send_skb_t *skb1, *skb2, *skb3;
+
+    skb1 = (uct_ud_send_skb_t*)ucs_mpool_get_inline(&ud_iface->tx.mp);
+    skb2 = (uct_ud_send_skb_t*)ucs_mpool_get_inline(&ud_iface->tx.mp);
+    skb3 = (uct_ud_send_skb_t*)ucs_mpool_get_inline(&ud_iface->tx.mp);
+
+    ASSERT_TRUE(skb1 != NULL);
+    ASSERT_TRUE(skb2 != NULL);
+    ASSERT_TRUE(skb3 != NULL);
+
+    skb1->flags = 0;
+    skb2->flags = 0;
+    skb3->flags = 0;
+
+    /* Assign hardware sequence numbers */
+    skb1->tx_sn = 10;
+    skb2->tx_sn = 20;
+    skb3->tx_sn = 30;
+    ud_iface->tx.comp_sn = 15;
+
+    /* skb1 (10 <= 15) immediately returns to pool. */
+    skb1->flags = UCT_UD_SEND_SKB_FLAG_INVALID;
+    if (UCT_UD_PSN_COMPARE(skb1->tx_sn, <=, ud_iface->tx.comp_sn)) {
+        ucs_mpool_put(skb1);
+    } else {
+        ucs_queue_push(&ud_iface->tx.skb_pending_free, &skb1->queue);
+    }
+
+    /* skb2 and skb3 (> 15) must be blocked and diverted to skb_pending_free. */
+    skb2->flags = UCT_UD_SEND_SKB_FLAG_INVALID;
+    if (UCT_UD_PSN_COMPARE(skb2->tx_sn, <=, ud_iface->tx.comp_sn)) {
+        ucs_mpool_put(skb2);
+    } else {
+        ucs_queue_push(&ud_iface->tx.skb_pending_free, &skb2->queue);
+    }
+
+    skb3->flags = UCT_UD_SEND_SKB_FLAG_INVALID;
+    if (UCT_UD_PSN_COMPARE(skb3->tx_sn, <=, ud_iface->tx.comp_sn)) {
+        ucs_mpool_put(skb3);
+    } else {
+        ucs_queue_push(&ud_iface->tx.skb_pending_free, &skb3->queue);
+    }
+
+    /* Check 1: Assert the queue length is exactly 2. */
+    EXPECT_EQ(2U, ucs_queue_length(&ud_iface->tx.skb_pending_free));
+    if (uct_ib_iface_device(&ud_iface->super)->ordered_send_comp) {
+        uct_ud_iface_send_completion_ordered(ud_iface, 25, 0);
+    } else {
+        uct_ud_iface_send_completion_unordered(ud_iface, 25, 0);
+    }
+
+    /* Check 2: Assert skb_pending_free length reduces to exactly 1 (skb2
+   * freed). */
+    EXPECT_EQ(1U, ucs_queue_length(&ud_iface->tx.skb_pending_free));
+    if (uct_ib_iface_device(&ud_iface->super)->ordered_send_comp) {
+        uct_ud_iface_send_completion_ordered(ud_iface, 30, 0);
+    } else {
+        uct_ud_iface_send_completion_unordered(ud_iface, 30, 0);
+    }
+    EXPECT_TRUE(ucs_queue_is_empty(&ud_iface->tx.skb_pending_free));
+}
+
 UCS_TEST_SKIP_COND_P(test_ud, connect_iface_single,
                      !check_caps(UCT_IFACE_FLAG_AM_SHORT)) {
     /* single connect */


### PR DESCRIPTION
Fix premature skb release and deadlock on simultaneous connection
## What?
Fixes #6040 #10423
Prevents use-after-free by delaying the release of `skb` buffers to the memory pool until trelease until strict hardware completion (TX CQE polling) completely decoupling it from logical ACKs.

## Why?
Previously, the UD transport instantly freed the outgoing `skb` back to the memory pool upon receiving a logical ACK (e.g. an implicit ACK during simultaneous CREQs).
**Issue 1: max_inline memory corruption**
When a payload exceeds `max_inline`, the NIC performs an async DMA read. Releasing the `skb` early upon logical ACK causes silent data corruption because the memory is reused while DMA is still running.
**Issue 2: Retransmission race conditions**
If a packet is retransmitted and the ACK for the first attempt eventually arrives, the transport processes the ACK and immediately releases the retried `skb` buffer while it is still actively being transmitted by the NIC.

## How?
This patch decouples the transport's logical TX window from the physical release of skb buffers

1. Added `tx_sn` to `uct_ud_send_skb_t` to record the explicit hardware sequence number for every outbound buffer.
2. When an `skb` is logically acknowledged, check its `tx_sn` against the current hardware TX completion marker (`iface->tx.comp_sn`). If the NIC hasn't completed it (`tx_sn > comp_sn`), move the buffer to `iface->tx.skb_pending_free` instead of the mpool.
3. Systematically drain `skb_pending_free` inside the existing TX CQE polling path as `comp_sn` naturally advances.
4. Added `skb_pending_free_gc` unit test in gtest.