### PR TITLE
UCT/ROCM: add functionality to get / set gpu number from agents

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -195,7 +195,9 @@ ucs_status_t uct_rocm_base_query_devices(uct_md_h md,
 
 hsa_agent_t uct_rocm_base_get_dev_agent(int gpu_num)
 {
-    ucs_assertv(gpu_num < uct_rocm_base_agents.num_gpu, "gpu_num %d, number of gpus %d", gpu_num, uct_rocm_base_agents.num_gpu);
+    ucs_assertv(gpu_num < uct_rocm_base_agents.num_gpu,
+                "gpu_num %d, number of gpus %d", gpu_num,
+                uct_rocm_base_agents.num_gpu);
     return uct_rocm_base_agents.gpu_agents[gpu_num];
 }
 


### PR DESCRIPTION
Add functions to get gpu agent/number
Set last_device_agent_used appropriately

## What?
Adds functionality to get gpu agents and set the last gpu used appropriately.

## Why?
uct_rocm_base_last_device_agent_used was not being set based on the correct gpu agent. 

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
