### PR TITLE
UCP/API: Add SGL datatype support for ucp_put_nbx

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -509,7 +509,7 @@ enum ucp_dt_type {
     UCP_DATATYPE_CONTIG  = 0,      /**< Contiguous datatype */
     UCP_DATATYPE_STRIDED = 1,      /**< Strided datatype */
     UCP_DATATYPE_IOV     = 2,      /**< Scatter-gather list with multiple pointers */
-    UCP_DATATYPE_VECTOR  = 4,      /**< Vector datatype */
+    UCP_DATATYPE_SGL     = 4,      /**< Scatter-gather list datatype */
     UCP_DATATYPE_GENERIC = 7,      /**< Generic datatype with
                                         user-defined pack/unpack routines */
     UCP_DATATYPE_SHIFT   = 3,      /**< Number of bits defining
@@ -725,13 +725,9 @@ typedef enum {
     UCP_OP_ATTR_FIELD_MEMORY_TYPE     = UCS_BIT(6),  /**< memory type field */
     UCP_OP_ATTR_FIELD_RECV_INFO       = UCS_BIT(7),  /**< recv_info field */
     UCP_OP_ATTR_FIELD_MEMH            = UCS_BIT(8),  /**< memory handle field */
-    UCP_OP_ATTR_FIELD_REMOTE_DATATYPE = UCS_BIT(9),  /**< remote datatype for
-                                                          vector operations */
-    UCP_OP_ATTR_FIELD_REMOTE          = UCS_BIT(10), /**< remote descriptor for
-                                                          vector operations */
-    UCP_OP_ATTR_FIELD_REMOTE_COUNT    = UCS_BIT(11), /**< remote element count for
-                                                          vector operations */
-
+    UCP_OP_ATTR_FIELD_REMOTE_DATATYPE = UCS_BIT(9),  /**< remote datatype field */
+    UCP_OP_ATTR_FIELD_REMOTE          = UCS_BIT(10), /**< remote descriptor field */
+    UCP_OP_ATTR_FIELD_REMOTE_COUNT    = UCS_BIT(11), /**< remote element count field */
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL      = UCS_BIT(16), /**< Deny immediate completion,
                                                           i.e NULL cannot be returned.
                                                           If a completion callback is
@@ -870,22 +866,22 @@ enum ucp_am_handler_param_field {
 
 /**
  * @ingroup UCP_DATATYPE
- * @brief Generate an identifier for vector data type.
+ * @brief Generate an identifier for scatter-gather list (SGL) data type.
  *
- * This macro creates a datatype identifier for vector operations. The same
- * identifier is used for both local and remote vector descriptors:
+ * This macro creates a datatype identifier for SGL operations. The same
+ * identifier is used for both local and remote SGL descriptors:
  * - When passed via @ref ucp_request_param_t::datatype, the @a buffer
- *   parameter should point to a @ref ucp_dt_local_vector_t descriptor.
+ *   parameter should point to a @ref ucp_dt_local_sgl_t descriptor.
  * - When passed via @ref ucp_request_param_t::remote_datatype, the
  *   @ref ucp_request_param_t::remote field should point to a
- *   @ref ucp_dt_remote_vector_t descriptor.
+ *   @ref ucp_dt_remote_sgl_t descriptor.
  * The @a count parameter of @ref ucp_put_nbx specifies the number of
  * local elements, and @ref ucp_request_param_t::remote_count specifies
  * the number of remote elements.
  *
  * @return Data-type identifier.
  */
-#define ucp_dt_make_vector() ((ucp_datatype_t)UCP_DATATYPE_VECTOR)
+#define ucp_dt_make_sgl() ((ucp_datatype_t)UCP_DATATYPE_SGL)
 
 
 /**
@@ -907,77 +903,77 @@ typedef struct ucp_dt_iov {
 
 /**
  * @ingroup UCP_DATATYPE
- * @brief Flags for specifying valid fields in @ref ucp_dt_local_vector_t.
+ * @brief Flags for specifying valid fields in @ref ucp_dt_local_sgl_t.
  */
-enum ucp_dt_local_vector_field {
-    UCP_DT_LOCAL_VECTOR_FIELD_BUFFERS = UCS_BIT(0), /**< buffers array is valid */
-    UCP_DT_LOCAL_VECTOR_FIELD_LENGTHS = UCS_BIT(1), /**< lengths array is valid */
-    UCP_DT_LOCAL_VECTOR_FIELD_MEMHS   = UCS_BIT(2)  /**< memhs array is valid */
+enum ucp_dt_local_sgl_field {
+    UCP_DT_LOCAL_SGL_FIELD_BUFFERS = UCS_BIT(0), /**< buffers array is valid */
+    UCP_DT_LOCAL_SGL_FIELD_LENGTHS = UCS_BIT(1), /**< lengths array is valid */
+    UCP_DT_LOCAL_SGL_FIELD_MEMHS   = UCS_BIT(2)  /**< memhs array is valid */
 };
 
 
 /**
  * @ingroup UCP_DATATYPE
- * @brief Flags for specifying valid fields in @ref ucp_dt_remote_vector_t.
+ * @brief Flags for specifying valid fields in @ref ucp_dt_remote_sgl_t.
  */
-enum ucp_dt_remote_vector_field {
-    UCP_DT_REMOTE_VECTOR_FIELD_REMOTE_ADDRS = UCS_BIT(0), /**< remote_addrs array is valid */
-    UCP_DT_REMOTE_VECTOR_FIELD_LENGTHS      = UCS_BIT(1), /**< lengths array is valid */
-    UCP_DT_REMOTE_VECTOR_FIELD_RKEYS        = UCS_BIT(2)  /**< rkeys array is valid */
+enum ucp_dt_remote_sgl_field {
+    UCP_DT_REMOTE_SGL_FIELD_REMOTE_ADDRS = UCS_BIT(0), /**< remote_addrs array is valid */
+    UCP_DT_REMOTE_SGL_FIELD_LENGTHS      = UCS_BIT(1), /**< lengths array is valid */
+    UCP_DT_REMOTE_SGL_FIELD_RKEYS        = UCS_BIT(2)  /**< rkeys array is valid */
 };
 
 
 /**
  * @ingroup UCP_DATATYPE
- * @brief Local vector descriptor for multi-element operations.
+ * @brief Local SGL descriptor for multi-element operations.
  *
  * This structure describes per-element local buffers, lengths, and memory
  * handles. Element @a i describes a local buffer at @a buffers[i] of
  * @a lengths[i] bytes with memory handle @a memhs[i].
  *
- * The descriptor @ref ucp_dt_local_vector_t itself is copied by the library,
+ * The descriptor @ref ucp_dt_local_sgl_t itself is copied by the library,
  * so the caller may release it after the call returns. However, the arrays
  * @a buffers, @a lengths, and @a memhs are not copied and must remain valid
  * until the data transfer request is completed.
  *
  * Pass as the @a buffer parameter to @ref ucp_put_nbx with
- * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_vector().
+ * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_sgl().
  *
  * @note Currently only N->N mapping is supported: both sides must use
- *       the vector datatype with equal counts and matching lengths.
+ *       the SGL datatype with equal counts and matching lengths.
  */
 typedef struct {
     uint64_t        field_mask; /**< Valid fields, using bits from
-                                     @ref ucp_dt_local_vector_field */
+                                     @ref ucp_dt_local_sgl_field */
     void * const    *buffers;   /**< Array of local buffer pointers */
     const size_t    *lengths;   /**< Array of transfer lengths in bytes */
     ucp_mem_h const *memhs;     /**< Array of local memory handles */
-} ucp_dt_local_vector_t;
+} ucp_dt_local_sgl_t;
 
 
 /**
  * @ingroup UCP_DATATYPE
- * @brief Remote vector descriptor for multi-element operations.
+ * @brief Remote SGL descriptor for multi-element operations.
  *
  * This structure describes per-element remote addresses, lengths, and keys.
  * Element @a i targets remote address @a remote_addrs[i] using key
  * @a rkeys[i].
  *
- * The descriptor @ref ucp_dt_remote_vector_t itself is copied by the library,
+ * The descriptor @ref ucp_dt_remote_sgl_t itself is copied by the library,
  * so the caller may release it after the call returns. However, the arrays
  * @a remote_addrs, @a lengths, and @a rkeys are not copied and must remain
  * valid until the data transfer request is completed.
  *
  * Pass via @ref ucp_request_param_t::remote with
- * @ref ucp_request_param_t::remote_datatype set to @ref ucp_dt_make_vector().
+ * @ref ucp_request_param_t::remote_datatype set to @ref ucp_dt_make_sgl().
  */
 typedef struct {
     uint64_t         field_mask;    /**< Valid fields, using bits from
-                                         @ref ucp_dt_remote_vector_field */
+                                         @ref ucp_dt_remote_sgl_field */
     const uint64_t   *remote_addrs; /**< Array of remote memory addresses */
     const size_t     *lengths;      /**< Array of transfer lengths in bytes */
     ucp_rkey_h const *rkeys;        /**< Array of remote memory keys */
-} ucp_dt_remote_vector_t;
+} ucp_dt_remote_sgl_t;
 
 
 /**
@@ -1948,9 +1944,9 @@ typedef struct {
     ucp_mem_h memh;
 
     /**
-     * Remote datatype identifier for vector operations. When set (along
+     * Remote datatype identifier for SGL operations. When set (along
      * with @ref UCP_OP_ATTR_FIELD_REMOTE_DATATYPE), specifies the datatype
-     * of the remote side. Currently only @ref ucp_dt_make_vector() is
+     * of the remote side. Currently only @ref ucp_dt_make_sgl() is
      * supported. When this field is set, @a remote and @a remote_count
      * should also be set.
      */
@@ -1959,7 +1955,7 @@ typedef struct {
     /**
      * Remote data descriptor. The type is determined by @a remote_datatype.
      * Used together with @a remote_datatype and @a remote_count to specify
-     * the remote side of vector operations. This field is used when
+     * the remote side of SGL operations. This field is used when
      * @ref UCP_OP_ATTR_FIELD_REMOTE is set in @a op_attr_mask.
      */
     const void *remote;
@@ -3793,8 +3789,8 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  * @brief Invalid remote address sentinel.
  *
  * This value should be passed as the @a remote_addr parameter of
- * @ref ucp_put_nbx when remote addresses are provided through a vector
- * descriptor (@ref ucp_dt_remote_vector_t) instead.
+ * @ref ucp_put_nbx when remote addresses are provided through an SGL
+ * descriptor (@ref ucp_dt_remote_sgl_t) instead.
  */
 #define UCP_REMOTE_ADDR_INVALID  UINT64_MAX
 
@@ -3804,8 +3800,8 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  * @brief Invalid remote key sentinel.
  *
  * This value should be passed as the @a rkey parameter of
- * @ref ucp_put_nbx when remote keys are provided through a vector
- * descriptor (@ref ucp_dt_remote_vector_t) instead.
+ * @ref ucp_put_nbx when remote keys are provided through an SGL
+ * descriptor (@ref ucp_dt_remote_sgl_t) instead.
  */
 #define UCP_RKEY_INVALID         NULL
 
@@ -3848,14 +3844,14 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  * @param [in]  remote_addr  Pointer to the destination remote memory address
  *                           to write to. When
  *                           @ref ucp_request_param_t::remote_datatype is
- *                           @ref ucp_dt_make_vector(), this should be set to
+ *                           @ref ucp_dt_make_sgl(), this should be set to
  *                           @ref UCP_REMOTE_ADDR_INVALID, as remote addresses
  *                           are specified in @ref ucp_request_param_t::remote
  *                           instead.
  * @param [in]  rkey         Remote memory key associated with the
  *                           remote memory address. When
  *                           @ref ucp_request_param_t::remote_datatype is
- *                           @ref ucp_dt_make_vector(), this should be set to
+ *                           @ref ucp_dt_make_sgl(), this should be set to
  *                           @ref UCP_RKEY_INVALID, as remote keys are specified
  *                           in @ref ucp_request_param_t::remote instead.
  * @param [in]  param       Operation parameters, see @ref ucp_request_param_t
@@ -3870,7 +3866,7 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  *                                @ref ucp_request_free "ucp_request_free()" routine.
  *
  * @note Supported datatypes for @a param->datatype are
- * @ref ucp_dt_make_contig, @ref ucp_dt_make_iov, and @ref ucp_dt_make_vector.
+ * @ref ucp_dt_make_contig, @ref ucp_dt_make_iov, and @ref ucp_dt_make_sgl.
  */
 ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
                              uint64_t remote_addr, ucp_rkey_h rkey,

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -942,6 +942,9 @@ enum ucp_dt_remote_vector_field {
  *
  * Pass as the @a buffer parameter to @ref ucp_put_nbx with
  * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_vector().
+ *
+ * @note Currently only N->N mapping is supported: both sides must use
+ *       the vector datatype with equal counts and matching lengths.
  */
 typedef struct {
     uint64_t        field_mask; /**< Valid fields, using bits from
@@ -1966,6 +1969,9 @@ typedef struct {
      * @ref UCP_OP_ATTR_FIELD_REMOTE_COUNT), specifies how many elements the
      * remote side has, independent of the local @a count parameter. Used
      * together with @a remote_datatype and @a remote.
+     *
+     * @note Currently must equal the local @a count (only N->N mapping is
+     *       supported).
      */
     size_t remote_count;
 } ucp_request_param_t;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -944,11 +944,11 @@ enum ucp_dt_remote_vector_field {
  * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_vector().
  */
 typedef struct {
-    uint64_t        field_mask;  /**< Valid fields, using bits from
-                                      @ref ucp_dt_local_vector_field */
-    void * const    *buffers;    /**< Array of local buffer pointers */
-    const size_t    *lengths;    /**< Array of transfer lengths in bytes */
-    ucp_mem_h const *memhs;      /**< Array of local memory handles */
+    uint64_t        field_mask; /**< Valid fields, using bits from
+                                     @ref ucp_dt_local_vector_field */
+    void * const    *buffers;   /**< Array of local buffer pointers */
+    const size_t    *lengths;   /**< Array of transfer lengths in bytes */
+    ucp_mem_h const *memhs;     /**< Array of local memory handles */
 } ucp_dt_local_vector_t;
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -935,9 +935,9 @@ enum ucp_dt_remote_vector_field {
  * handles. Element @a i describes a local buffer at @a buffers[i] of
  * @a lengths[i] bytes with memory handle @a memhs[i].
  *
- * The descriptor structure itself is copied by the library, so the caller may
- * release it after the call returns. However, the arrays it points to
- * (@a buffers, @a lengths, @a memhs) are not copied and must remain valid
+ * The descriptor @ref ucp_dt_local_vector_t itself is copied by the library,
+ * so the caller may release it after the call returns. However, the arrays
+ * @a buffers, @a lengths, and @a memhs are not copied and must remain valid
  * until the data transfer request is completed.
  *
  * Pass as the @a buffer parameter to @ref ucp_put_nbx with
@@ -960,9 +960,9 @@ typedef struct {
  * Element @a i targets remote address @a remote_addrs[i] using key
  * @a rkeys[i].
  *
- * The descriptor structure itself is copied by the library, so the caller may
- * release it after the call returns. However, the arrays it points to
- * (@a remote_addrs, @a lengths, @a rkeys) are not copied and must remain
+ * The descriptor @ref ucp_dt_remote_vector_t itself is copied by the library,
+ * so the caller may release it after the call returns. However, the arrays
+ * @a remote_addrs, @a lengths, and @a rkeys are not copied and must remain
  * valid until the data transfer request is completed.
  *
  * Pass via @ref ucp_request_param_t::remote with
@@ -3787,8 +3787,8 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  * @brief Invalid remote address sentinel.
  *
  * This value should be passed as the @a remote_addr parameter of
- * @ref ucp_put_nbx when per-element remote addresses are provided through
- * a vector descriptor (@ref ucp_dt_remote_vector_t) instead.
+ * @ref ucp_put_nbx when remote addresses are provided through a vector
+ * descriptor (@ref ucp_dt_remote_vector_t) instead.
  */
 #define UCP_REMOTE_ADDR_INVALID  UINT64_MAX
 
@@ -3798,8 +3798,8 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  * @brief Invalid remote key sentinel.
  *
  * This value should be passed as the @a rkey parameter of
- * @ref ucp_put_nbx when per-element remote keys are provided through
- * a vector descriptor (@ref ucp_dt_remote_vector_t) instead.
+ * @ref ucp_put_nbx when remote keys are provided through a vector
+ * descriptor (@ref ucp_dt_remote_vector_t) instead.
  */
 #define UCP_RKEY_INVALID         NULL
 
@@ -3843,15 +3843,15 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  *                           to write to. When
  *                           @ref ucp_request_param_t::remote_datatype is
  *                           @ref ucp_dt_make_vector(), this should be set to
- *                           @ref UCP_REMOTE_ADDR_INVALID (remote addresses are
- *                           specified in @ref ucp_request_param_t::remote
- *                           instead).
+ *                           @ref UCP_REMOTE_ADDR_INVALID, as remote addresses
+ *                           are specified in @ref ucp_request_param_t::remote
+ *                           instead.
  * @param [in]  rkey         Remote memory key associated with the
  *                           remote memory address. When
  *                           @ref ucp_request_param_t::remote_datatype is
  *                           @ref ucp_dt_make_vector(), this should be set to
- *                           @ref UCP_RKEY_INVALID (remote keys are specified in
- *                           @ref ucp_request_param_t::remote instead).
+ *                           @ref UCP_RKEY_INVALID, as remote keys are specified
+ *                           in @ref ucp_request_param_t::remote instead.
  * @param [in]  param       Operation parameters, see @ref ucp_request_param_t
  *
  * @return UCS_OK               - The operation was completed immediately.

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -3786,28 +3786,6 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
 
 /**
  * @ingroup UCP_COMM
- * @brief Invalid remote address sentinel.
- *
- * This value should be passed as the @a remote_addr parameter of
- * @ref ucp_put_nbx when remote addresses are provided through an SGL
- * descriptor (@ref ucp_dt_remote_sgl_t) instead.
- */
-#define UCP_REMOTE_ADDR_INVALID  UINT64_MAX
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Invalid remote key sentinel.
- *
- * This value should be passed as the @a rkey parameter of
- * @ref ucp_put_nbx when remote keys are provided through an SGL
- * descriptor (@ref ucp_dt_remote_sgl_t) instead.
- */
-#define UCP_RKEY_INVALID         NULL
-
-
-/**
- * @ingroup UCP_COMM
  * @brief Non-blocking remote memory put operation.
  *
  * This routine initiates a storage of contiguous block of data that is

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -509,6 +509,7 @@ enum ucp_dt_type {
     UCP_DATATYPE_CONTIG  = 0,      /**< Contiguous datatype */
     UCP_DATATYPE_STRIDED = 1,      /**< Strided datatype */
     UCP_DATATYPE_IOV     = 2,      /**< Scatter-gather list with multiple pointers */
+    UCP_DATATYPE_VECTOR  = 4,      /**< Vector datatype */
     UCP_DATATYPE_GENERIC = 7,      /**< Generic datatype with
                                         user-defined pack/unpack routines */
     UCP_DATATYPE_SHIFT   = 3,      /**< Number of bits defining
@@ -715,42 +716,46 @@ typedef enum {
  * compatibility support.
  */
 typedef enum {
-    UCP_OP_ATTR_FIELD_REQUEST       = UCS_BIT(0),  /**< request field */
-    UCP_OP_ATTR_FIELD_CALLBACK      = UCS_BIT(1),  /**< cb field */
-    UCP_OP_ATTR_FIELD_USER_DATA     = UCS_BIT(2),  /**< user_data field */
-    UCP_OP_ATTR_FIELD_DATATYPE      = UCS_BIT(3),  /**< datatype field */
-    UCP_OP_ATTR_FIELD_FLAGS         = UCS_BIT(4),  /**< operation-specific flags */
-    UCP_OP_ATTR_FIELD_REPLY_BUFFER  = UCS_BIT(5),  /**< reply_buffer field */
-    UCP_OP_ATTR_FIELD_MEMORY_TYPE   = UCS_BIT(6),  /**< memory type field */
-    UCP_OP_ATTR_FIELD_RECV_INFO     = UCS_BIT(7),  /**< recv_info field */
-    UCP_OP_ATTR_FIELD_MEMH          = UCS_BIT(8),  /**< memory handle field */
+    UCP_OP_ATTR_FIELD_REQUEST         = UCS_BIT(0),  /**< request field */
+    UCP_OP_ATTR_FIELD_CALLBACK        = UCS_BIT(1),  /**< cb field */
+    UCP_OP_ATTR_FIELD_USER_DATA       = UCS_BIT(2),  /**< user_data field */
+    UCP_OP_ATTR_FIELD_DATATYPE        = UCS_BIT(3),  /**< datatype field */
+    UCP_OP_ATTR_FIELD_FLAGS           = UCS_BIT(4),  /**< operation-specific flags */
+    UCP_OP_ATTR_FIELD_REPLY_BUFFER    = UCS_BIT(5),  /**< reply_buffer field */
+    UCP_OP_ATTR_FIELD_MEMORY_TYPE     = UCS_BIT(6),  /**< memory type field */
+    UCP_OP_ATTR_FIELD_RECV_INFO       = UCS_BIT(7),  /**< recv_info field */
+    UCP_OP_ATTR_FIELD_MEMH            = UCS_BIT(8),  /**< memory handle field */
+    UCP_OP_ATTR_FIELD_REMOTE_DATATYPE = UCS_BIT(9),  /**< remote datatype for
+                                                          vector operations */
+    UCP_OP_ATTR_FIELD_REMOTE_COUNT    = UCS_BIT(10), /**< remote element count for
+                                                          vector operations */
 
-    UCP_OP_ATTR_FLAG_NO_IMM_CMPL    = UCS_BIT(16), /**< Deny immediate completion,
-                                                        i.e NULL cannot be returned.
-                                                        If a completion callback is
-                                                        provided, it can be called
-                                                        before the function
-                                                        returns. */
-    UCP_OP_ATTR_FLAG_FAST_CMPL      = UCS_BIT(17), /**< expedite local completion,
-                                                        even if it delays remote
-                                                        data delivery. Note for
-                                                        implementer: this option
-                                                        can disable zero copy
-                                                        and/or rendezvous protocols
-                                                        which require
-                                                        synchronization with the
-                                                        remote peer before releasing
-                                                        the local send buffer */
-    UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL = UCS_BIT(18), /**< force immediate complete
-                                                        operation, fail if the
-                                                        operation cannot be
-                                                        completed immediately */
-    UCP_OP_ATTR_FLAG_MULTI_SEND     = UCS_BIT(19)  /**< optimize for bandwidth of
-                                                        multiple in-flight operations,
-                                                        rather than for the latency
-                                                        of a single operation.
-                                                        This flag and UCP_OP_ATTR_FLAG_FAST_CMPL
-                                                        are mutually exclusive. */
+    UCP_OP_ATTR_FLAG_NO_IMM_CMPL      = UCS_BIT(16), /**< Deny immediate completion,
+                                                          i.e NULL cannot be returned.
+                                                          If a completion callback is
+                                                          provided, it can be called
+                                                          before the function
+                                                          returns. */
+    UCP_OP_ATTR_FLAG_FAST_CMPL        = UCS_BIT(17), /**< expedite local completion,
+                                                          even if it delays remote
+                                                          data delivery. Note for
+                                                          implementer: this option
+                                                          can disable zero copy
+                                                          and/or rendezvous protocols
+                                                          which require
+                                                          synchronization with the
+                                                          remote peer before releasing
+                                                          the local send buffer */
+    UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL   = UCS_BIT(18), /**< force immediate complete
+                                                          operation, fail if the
+                                                          operation cannot be
+                                                          completed immediately */
+    UCP_OP_ATTR_FLAG_MULTI_SEND       = UCS_BIT(19)  /**< optimize for bandwidth of
+                                                          multiple in-flight operations,
+                                                          rather than for the latency
+                                                          of a single operation.
+                                                          This flag and UCP_OP_ATTR_FLAG_FAST_CMPL
+                                                          are mutually exclusive. */
 } ucp_op_attr_t;
 
 
@@ -863,6 +868,23 @@ enum ucp_am_handler_param_field {
 
 /**
  * @ingroup UCP_DATATYPE
+ * @brief Generate an identifier for vector data type.
+ *
+ * This macro creates a datatype identifier for vector operations. The same
+ * identifier is used for both local and remote vector descriptors:
+ * - When passed via @a param->datatype, the @a buffer parameter should point
+ *   to a @ref ucp_dt_local_vector_t descriptor.
+ * - When passed via @a param->remote_datatype, the @a param->remote should
+ *   point to a @ref ucp_dt_remote_vector_t descriptor.
+ * The @a count parameter specifies the number of elements.
+ *
+ * @return Data-type identifier.
+ */
+#define ucp_dt_make_vector() ((ucp_datatype_t)UCP_DATATYPE_VECTOR)
+
+
+/**
+ * @ingroup UCP_DATATYPE
  * @brief Structure for scatter-gather I/O.
  *
  * This structure is used to specify a list of buffers which can be used
@@ -876,6 +898,76 @@ typedef struct ucp_dt_iov {
     void   *buffer;   /**< Pointer to a data buffer */
     size_t  length;   /**< Length of the @a buffer in bytes */
 } ucp_dt_iov_t;
+
+
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief Flags for specifying valid fields in @ref ucp_dt_local_vector_t.
+ */
+enum ucp_dt_local_vector_field {
+    UCP_DT_LOCAL_VECTOR_FIELD_BUFFERS = UCS_BIT(0), /**< buffers array is valid */
+    UCP_DT_LOCAL_VECTOR_FIELD_LENGTHS = UCS_BIT(1), /**< lengths array is valid */
+    UCP_DT_LOCAL_VECTOR_FIELD_MEMHS   = UCS_BIT(2)  /**< memhs array is valid */
+};
+
+
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief Flags for specifying valid fields in @ref ucp_dt_remote_vector_t.
+ */
+enum ucp_dt_remote_vector_field {
+    UCP_DT_REMOTE_VECTOR_FIELD_REMOTE_ADDRS = UCS_BIT(0), /**< remote_addrs array is valid */
+    UCP_DT_REMOTE_VECTOR_FIELD_LENGTHS      = UCS_BIT(1), /**< lengths array is valid */
+    UCP_DT_REMOTE_VECTOR_FIELD_RKEYS        = UCS_BIT(2)  /**< rkeys array is valid */
+};
+
+
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief Local vector descriptor for multi-element operations.
+ *
+ * This structure describes per-element local buffers, lengths, and memory
+ * handles. Element @a i describes a local buffer at @a buffers[i] of
+ * @a lengths[i] bytes with memory handle @a memhs[i].
+ *
+ * Pass as the @a buffer parameter to @ref ucp_put_nbx with
+ * @a param->datatype set to @ref ucp_dt_make_vector().
+ *
+ * @note The arrays pointed to by this struct are NOT copied and must
+ *       remain valid until the operation completes. This is the same
+ *       contract as @ref ucp_dt_iov_t.
+ */
+typedef struct {
+    uint64_t          field_mask; /**< Valid fields, using bits from
+                                       @ref ucp_dt_local_vector_field */
+    void * const     *buffers;    /**< Array of local buffer pointers */
+    const size_t     *lengths;    /**< Array of transfer lengths in bytes */
+    ucp_mem_h const  *memhs;      /**< Array of local memory handles */
+} ucp_dt_local_vector_t;
+
+
+/**
+ * @ingroup UCP_DATATYPE
+ * @brief Remote vector descriptor for multi-element operations.
+ *
+ * This structure describes per-element remote addresses, lengths, and keys.
+ * Element @a i targets remote address @a remote_addrs[i] using key
+ * @a rkeys[i].
+ *
+ * Pass via @a param->remote with @a param->remote_datatype set to
+ * @ref ucp_dt_make_vector().
+ *
+ * @note The arrays pointed to by this struct are NOT copied and must
+ *       remain valid until the operation completes. This is the same
+ *       contract as @ref ucp_dt_iov_t.
+ */
+typedef struct {
+    uint64_t          field_mask;   /**< Valid fields, using bits from
+                                         @ref ucp_dt_remote_vector_field */
+    const uint64_t   *remote_addrs; /**< Array of remote memory addresses */
+    const size_t     *lengths;      /**< Array of transfer lengths in bytes */
+    ucp_rkey_h const *rkeys;        /**< Array of remote memory keys */
+} ucp_dt_remote_vector_t;
 
 
 /**
@@ -1845,6 +1937,30 @@ typedef struct {
      */
     ucp_mem_h memh;
 
+    /**
+     * Remote datatype identifier for vector operations. When set (along
+     * with @ref UCP_OP_ATTR_FIELD_REMOTE_DATATYPE), specifies the datatype
+     * of the remote side. Currently only @ref ucp_dt_make_vector() is
+     * supported. When this field is set, @a remote and @a remote_count
+     * should also be set.
+     */
+    ucp_datatype_t remote_datatype;
+
+    /**
+     * Remote data descriptor. The type is determined by @a remote_datatype.
+     * Used together with @a remote_datatype and @a remote_count to specify
+     * the remote side of vector operations. This field is used when
+     * @ref UCP_OP_ATTR_FIELD_REMOTE_DATATYPE is set in @a op_attr_mask.
+     */
+    const void *remote;
+
+    /**
+     * Number of elements in the remote descriptor. When set (along with
+     * @ref UCP_OP_ATTR_FIELD_REMOTE_COUNT), specifies how many elements the
+     * remote side has, independent of the local @a count parameter. Used
+     * together with @a remote_datatype and @a remote.
+     */
+    size_t remote_count;
 } ucp_request_param_t;
 
 
@@ -3661,6 +3777,28 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
 
 /**
  * @ingroup UCP_COMM
+ * @brief Unused remote address sentinel.
+ *
+ * This value should be passed as the @a remote_addr parameter when
+ * per-element remote addresses are provided through a vector descriptor
+ * (@ref ucp_dt_remote_vector_t) instead.
+ */
+#define UCP_REMOTE_ADDR_UNUSED   0
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Unused remote key sentinel.
+ *
+ * This value should be passed as the @a rkey parameter when per-element
+ * remote keys are provided through a vector descriptor
+ * (@ref ucp_dt_remote_vector_t) instead.
+ */
+#define UCP_RKEY_UNUSED          NULL
+
+
+/**
+ * @ingroup UCP_COMM
  * @brief Non-blocking remote memory put operation.
  *
  * This routine initiates a storage of contiguous block of data that is
@@ -3695,9 +3833,15 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  *                           the type defaults to ucp_dt_make_contig(1), which
  *                           corresponds to byte elements.
  * @param [in]  remote_addr  Pointer to the destination remote memory address
- *                           to write to.
+ *                           to write to. When @a param->remote_datatype is
+ *                           @ref ucp_dt_make_vector(), this should be set to
+ *                           @ref UCP_REMOTE_ADDR_UNUSED (remote addresses are
+ *                           specified in @a param->remote instead).
  * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
+ *                           remote memory address. When @a param->remote_datatype
+ *                           is @ref ucp_dt_make_vector(), this should be set to
+ *                           @ref UCP_RKEY_UNUSED (remote keys are specified in
+ *                           @a param->remote instead).
  * @param [in]  param       Operation parameters, see @ref ucp_request_param_t
  *
  * @return UCS_OK               - The operation was completed immediately.
@@ -3709,8 +3853,8 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  *                                responsible for releasing the handle using
  *                                @ref ucp_request_free "ucp_request_free()" routine.
  *
- * @note Only the datatype ucp_dt_make_contig(1) is supported
- * for @a param->datatype, see @ref ucp_dt_make_contig.
+ * @note Supported datatypes for @a param->datatype are
+ * @ref ucp_dt_make_contig, @ref ucp_dt_make_iov, and @ref ucp_dt_make_vector.
  */
 ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
                              uint64_t remote_addr, ucp_rkey_h rkey,

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -727,7 +727,9 @@ typedef enum {
     UCP_OP_ATTR_FIELD_MEMH            = UCS_BIT(8),  /**< memory handle field */
     UCP_OP_ATTR_FIELD_REMOTE_DATATYPE = UCS_BIT(9),  /**< remote datatype for
                                                           vector operations */
-    UCP_OP_ATTR_FIELD_REMOTE_COUNT    = UCS_BIT(10), /**< remote element count for
+    UCP_OP_ATTR_FIELD_REMOTE          = UCS_BIT(10), /**< remote descriptor for
+                                                          vector operations */
+    UCP_OP_ATTR_FIELD_REMOTE_COUNT    = UCS_BIT(11), /**< remote element count for
                                                           vector operations */
 
     UCP_OP_ATTR_FLAG_NO_IMM_CMPL      = UCS_BIT(16), /**< Deny immediate completion,
@@ -942,11 +944,11 @@ enum ucp_dt_remote_vector_field {
  * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_vector().
  */
 typedef struct {
-    uint64_t          field_mask; /**< Valid fields, using bits from
-                                       @ref ucp_dt_local_vector_field */
-    void * const     *buffers;    /**< Array of local buffer pointers */
-    const size_t     *lengths;    /**< Array of transfer lengths in bytes */
-    ucp_mem_h const  *memhs;      /**< Array of local memory handles */
+    uint64_t        field_mask;  /**< Valid fields, using bits from
+                                      @ref ucp_dt_local_vector_field */
+    void * const    *buffers;    /**< Array of local buffer pointers */
+    const size_t    *lengths;    /**< Array of transfer lengths in bytes */
+    ucp_mem_h const *memhs;      /**< Array of local memory handles */
 } ucp_dt_local_vector_t;
 
 
@@ -967,7 +969,7 @@ typedef struct {
  * @ref ucp_request_param_t::remote_datatype set to @ref ucp_dt_make_vector().
  */
 typedef struct {
-    uint64_t          field_mask;   /**< Valid fields, using bits from
+    uint64_t         field_mask;    /**< Valid fields, using bits from
                                          @ref ucp_dt_remote_vector_field */
     const uint64_t   *remote_addrs; /**< Array of remote memory addresses */
     const size_t     *lengths;      /**< Array of transfer lengths in bytes */
@@ -1955,7 +1957,7 @@ typedef struct {
      * Remote data descriptor. The type is determined by @a remote_datatype.
      * Used together with @a remote_datatype and @a remote_count to specify
      * the remote side of vector operations. This field is used when
-     * @ref UCP_OP_ATTR_FIELD_REMOTE_DATATYPE is set in @a op_attr_mask.
+     * @ref UCP_OP_ATTR_FIELD_REMOTE is set in @a op_attr_mask.
      */
     const void *remote;
 
@@ -3782,24 +3784,24 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
 
 /**
  * @ingroup UCP_COMM
- * @brief Unused remote address sentinel.
+ * @brief Invalid remote address sentinel.
  *
  * This value should be passed as the @a remote_addr parameter of
  * @ref ucp_put_nbx when per-element remote addresses are provided through
  * a vector descriptor (@ref ucp_dt_remote_vector_t) instead.
  */
-#define UCP_REMOTE_ADDR_UNUSED   UINT64_MAX
+#define UCP_REMOTE_ADDR_INVALID  UINT64_MAX
 
 
 /**
  * @ingroup UCP_COMM
- * @brief Unused remote key sentinel.
+ * @brief Invalid remote key sentinel.
  *
  * This value should be passed as the @a rkey parameter of
  * @ref ucp_put_nbx when per-element remote keys are provided through
  * a vector descriptor (@ref ucp_dt_remote_vector_t) instead.
  */
-#define UCP_RKEY_UNUSED          NULL
+#define UCP_RKEY_INVALID         NULL
 
 
 /**
@@ -3841,14 +3843,14 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  *                           to write to. When
  *                           @ref ucp_request_param_t::remote_datatype is
  *                           @ref ucp_dt_make_vector(), this should be set to
- *                           @ref UCP_REMOTE_ADDR_UNUSED (remote addresses are
+ *                           @ref UCP_REMOTE_ADDR_INVALID (remote addresses are
  *                           specified in @ref ucp_request_param_t::remote
  *                           instead).
  * @param [in]  rkey         Remote memory key associated with the
  *                           remote memory address. When
  *                           @ref ucp_request_param_t::remote_datatype is
  *                           @ref ucp_dt_make_vector(), this should be set to
- *                           @ref UCP_RKEY_UNUSED (remote keys are specified in
+ *                           @ref UCP_RKEY_INVALID (remote keys are specified in
  *                           @ref ucp_request_param_t::remote instead).
  * @param [in]  param       Operation parameters, see @ref ucp_request_param_t
  *

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -872,11 +872,14 @@ enum ucp_am_handler_param_field {
  *
  * This macro creates a datatype identifier for vector operations. The same
  * identifier is used for both local and remote vector descriptors:
- * - When passed via @a param->datatype, the @a buffer parameter should point
- *   to a @ref ucp_dt_local_vector_t descriptor.
- * - When passed via @a param->remote_datatype, the @a param->remote should
- *   point to a @ref ucp_dt_remote_vector_t descriptor.
- * The @a count parameter specifies the number of elements.
+ * - When passed via @ref ucp_request_param_t::datatype, the @a buffer
+ *   parameter should point to a @ref ucp_dt_local_vector_t descriptor.
+ * - When passed via @ref ucp_request_param_t::remote_datatype, the
+ *   @ref ucp_request_param_t::remote field should point to a
+ *   @ref ucp_dt_remote_vector_t descriptor.
+ * The @a count parameter of @ref ucp_put_nbx specifies the number of
+ * local elements, and @ref ucp_request_param_t::remote_count specifies
+ * the number of remote elements.
  *
  * @return Data-type identifier.
  */
@@ -930,12 +933,13 @@ enum ucp_dt_remote_vector_field {
  * handles. Element @a i describes a local buffer at @a buffers[i] of
  * @a lengths[i] bytes with memory handle @a memhs[i].
  *
- * Pass as the @a buffer parameter to @ref ucp_put_nbx with
- * @a param->datatype set to @ref ucp_dt_make_vector().
+ * The descriptor structure itself is copied by the library, so the caller may
+ * release it after the call returns. However, the arrays it points to
+ * (@a buffers, @a lengths, @a memhs) are not copied and must remain valid
+ * until the data transfer request is completed.
  *
- * @note The arrays pointed to by this struct are NOT copied and must
- *       remain valid until the operation completes. This is the same
- *       contract as @ref ucp_dt_iov_t.
+ * Pass as the @a buffer parameter to @ref ucp_put_nbx with
+ * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_vector().
  */
 typedef struct {
     uint64_t          field_mask; /**< Valid fields, using bits from
@@ -954,12 +958,13 @@ typedef struct {
  * Element @a i targets remote address @a remote_addrs[i] using key
  * @a rkeys[i].
  *
- * Pass via @a param->remote with @a param->remote_datatype set to
- * @ref ucp_dt_make_vector().
+ * The descriptor structure itself is copied by the library, so the caller may
+ * release it after the call returns. However, the arrays it points to
+ * (@a remote_addrs, @a lengths, @a rkeys) are not copied and must remain
+ * valid until the data transfer request is completed.
  *
- * @note The arrays pointed to by this struct are NOT copied and must
- *       remain valid until the operation completes. This is the same
- *       contract as @ref ucp_dt_iov_t.
+ * Pass via @ref ucp_request_param_t::remote with
+ * @ref ucp_request_param_t::remote_datatype set to @ref ucp_dt_make_vector().
  */
 typedef struct {
     uint64_t          field_mask;   /**< Valid fields, using bits from
@@ -3779,20 +3784,20 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  * @ingroup UCP_COMM
  * @brief Unused remote address sentinel.
  *
- * This value should be passed as the @a remote_addr parameter when
- * per-element remote addresses are provided through a vector descriptor
- * (@ref ucp_dt_remote_vector_t) instead.
+ * This value should be passed as the @a remote_addr parameter of
+ * @ref ucp_put_nbx when per-element remote addresses are provided through
+ * a vector descriptor (@ref ucp_dt_remote_vector_t) instead.
  */
-#define UCP_REMOTE_ADDR_UNUSED   0
+#define UCP_REMOTE_ADDR_UNUSED   UINT64_MAX
 
 
 /**
  * @ingroup UCP_COMM
  * @brief Unused remote key sentinel.
  *
- * This value should be passed as the @a rkey parameter when per-element
- * remote keys are provided through a vector descriptor
- * (@ref ucp_dt_remote_vector_t) instead.
+ * This value should be passed as the @a rkey parameter of
+ * @ref ucp_put_nbx when per-element remote keys are provided through
+ * a vector descriptor (@ref ucp_dt_remote_vector_t) instead.
  */
 #define UCP_RKEY_UNUSED          NULL
 
@@ -3833,15 +3838,18 @@ ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
  *                           the type defaults to ucp_dt_make_contig(1), which
  *                           corresponds to byte elements.
  * @param [in]  remote_addr  Pointer to the destination remote memory address
- *                           to write to. When @a param->remote_datatype is
+ *                           to write to. When
+ *                           @ref ucp_request_param_t::remote_datatype is
  *                           @ref ucp_dt_make_vector(), this should be set to
  *                           @ref UCP_REMOTE_ADDR_UNUSED (remote addresses are
- *                           specified in @a param->remote instead).
+ *                           specified in @ref ucp_request_param_t::remote
+ *                           instead).
  * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address. When @a param->remote_datatype
- *                           is @ref ucp_dt_make_vector(), this should be set to
+ *                           remote memory address. When
+ *                           @ref ucp_request_param_t::remote_datatype is
+ *                           @ref ucp_dt_make_vector(), this should be set to
  *                           @ref UCP_RKEY_UNUSED (remote keys are specified in
- *                           @a param->remote instead).
+ *                           @ref ucp_request_param_t::remote instead).
  * @param [in]  param       Operation parameters, see @ref ucp_request_param_t
  *
  * @return UCS_OK               - The operation was completed immediately.

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -158,6 +158,28 @@ typedef struct ucp_rkey                  *ucp_rkey_h;
 
 
 /**
+ * @ingroup UCP_COMM
+ * @brief Invalid remote address sentinel.
+ *
+ * This value should be passed as the @a remote_addr parameter of
+ * @ref ucp_put_nbx when remote addresses are provided through an SGL
+ * descriptor (@ref ucp_dt_remote_sgl_t) instead.
+ */
+#define UCP_REMOTE_ADDR_INVALID  UINT64_MAX
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Invalid remote key sentinel.
+ *
+ * This value should be passed as the @a rkey parameter of
+ * @ref ucp_put_nbx when remote keys are provided through an SGL
+ * descriptor (@ref ucp_dt_remote_sgl_t) instead.
+ */
+#define UCP_RKEY_INVALID         NULL
+
+
+/**
  * @ingroup UCP_MEM
  * @brief UCP Memory handle
  *


### PR DESCRIPTION
## What?
Add SGL (scatter-gather list) datatype support to the UCP API, enabling multi-element put operations where each element has its own local buffer, remote address, and remote key.

## Why?
Currently, `ucp_put_nbx` only supports contiguous and IOV datatypes, requiring a separate call for each distinct remote address/key combination. Applications that need to transfer many small, non-contiguous buffers to different remote locations must issue individual put operations, incurring per-operation overhead. An SGL datatype allows describing all of these in a single `ucp_put_nbx` call, reducing CPU overhead and enabling transport-level optimizations.

## How?
This PR adds only the UCP public API header changes (`src/ucp/api/ucp.h`). Implementation will follow in subsequent PRs.

**New datatype:**
- `UCP_DATATYPE_SGL` enum value
- `ucp_dt_make_sgl()` macro (analogous to `ucp_dt_make_iov()`)

**New descriptor types:**
- `ucp_dt_local_sgl_t` - per-element local buffers, lengths, and memory handles (passed as the `buffer` parameter)
- `ucp_dt_remote_sgl_t` - per-element remote addresses, lengths, and remote keys (passed via `param->remote`)
- `ucp_dt_local_sgl_field` / `ucp_dt_remote_sgl_field` - field mask enums for forward compatibility

**New `ucp_request_param_t` fields:**
- `remote_datatype` - identifies the remote descriptor type (`UCP_OP_ATTR_FIELD_REMOTE_DATATYPE`)
- `remote` - pointer to the remote descriptor (`UCP_OP_ATTR_FIELD_REMOTE`)
- `remote_count` - number of remote elements (`UCP_OP_ATTR_FIELD_REMOTE_COUNT`)

**New sentinels:**
- `UCP_REMOTE_ADDR_INVALID` - sentinel for `remote_addr` when using SGL datatype
- `UCP_RKEY_INVALID` - sentinel for `rkey` when using SGL datatype

**Limitations:**
- Currently only N->N mapping is supported: both sides must use the SGL datatype with equal counts and matching lengths.

**Usage example:**
```c
ucp_dt_local_sgl_t local_sgl = {
    .field_mask = UCP_DT_LOCAL_SGL_FIELD_BUFFERS |
                  UCP_DT_LOCAL_SGL_FIELD_LENGTHS |
                  UCP_DT_LOCAL_SGL_FIELD_MEMHS,
    .buffers    = buffers,
    .lengths    = lengths,
    .memhs      = memhs
};

ucp_dt_remote_sgl_t remote_sgl = {
    .field_mask   = UCP_DT_REMOTE_SGL_FIELD_REMOTE_ADDRS |
                    UCP_DT_REMOTE_SGL_FIELD_LENGTHS |
                    UCP_DT_REMOTE_SGL_FIELD_RKEYS,
    .remote_addrs = remote_addrs,
    .lengths      = lengths,
    .rkeys        = rkeys
};

ucp_request_param_t param = {
    .op_attr_mask    = UCP_OP_ATTR_FIELD_DATATYPE |
                       UCP_OP_ATTR_FIELD_REMOTE_DATATYPE |
                       UCP_OP_ATTR_FIELD_REMOTE |
                       UCP_OP_ATTR_FIELD_REMOTE_COUNT |
                       UCP_OP_ATTR_FIELD_CALLBACK,
    .datatype        = ucp_dt_make_sgl(),
    .remote_datatype = ucp_dt_make_sgl(),
    .remote          = &remote_sgl,
    .remote_count    = count,
    .cb.send         = send_cb
};

ucs_status_ptr_t req = ucp_put_nbx(ep, &local_sgl, count,
                                   UCP_REMOTE_ADDR_INVALID,
                                   UCP_RKEY_INVALID, &param);
```
