### PR TITLE
AZP: Fix debian package dependency cleanup - v1.20.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>
 Ovidiu Mara <ovidium@nvidia.com>
 Pak Lui <Pak.Lui@amd.com>
+Paul Taylor <pataylor@nvidia.com>
 Pavan Balaji <balaji@anl.gov>
 Pavel Shamis (Pasha) <pasharesearch@gmail.com>
 Peter Andreas Entschev <peter@entschev.com>

--- a/buildlib/az-distro-release.yml
+++ b/buildlib/az-distro-release.yml
@@ -117,7 +117,7 @@ jobs:
 
           # Remove superfluous dependency
           dpkg-deb -R "ucx-cuda-${VER}.deb" tmp    # Extract
-          sed -i 's/libnvidia-compute | libnvidia-ml1, //g' tmp/DEBIAN/control
+          sed -i 's/libnvidia-compute | libnvidia-ml1[^,]*, //g' tmp/DEBIAN/control
           dpkg-deb -b tmp "ucx-cuda-${VER}.deb"        # Rebuild
           dpkg-deb -I "ucx-cuda-${VER}.deb"
           dpkg-deb -I "ucx-${VER}.deb"


### PR DESCRIPTION
## What
Backport #11141, UCX 1.20 is mentioned in #11257.