### PR TITLE
NEWS: Added NEWS for v1.20.1-rc1 - v1.20.x

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,7 +22,7 @@
 #### UCP
  * Increased TLS info buffer size in transport selection to prevent potential truncation
  * Fixed incorrect warning about valid environment variable names
- * Return an error when there is no modifiable configuration
+ * Fixed ucp_config_modify not reporting an error when no matching modifiable configuration exists.
 #### RDMA CORE (IB, ROCE, etc.)
  * Fixed DevX objects flag handling
  * Fixed device memory allocation alignment in MLX5 DevX
@@ -32,6 +32,7 @@
  * Fix RoCE reachable route check when node_guuid is not unique among HCAs
 #### CUDA
  * Fixed CUDA context handling for system device during rkey unpack
+#### ROCM
  * Fixed HSA memory type check for newer ROCm releases
 #### UCS
  * Fixed rcache locking for GDR copy


### PR DESCRIPTION
## What?
Updated NEWS file with recent changes

## Why?
Part of the release process of v1.20.1

Added changes:

## Features / Enhancements

| # | Proposed NEWS line | Component | Commit | PR |
|---|---|---|---|---|
| 1 | Added 'auto' option for `UCX_IB_MLX5_DEVX_OBJECTS` which disables DevX when ODP is available (for Grace) | UCT/IB | [`e93933b`](https://github.com/openucx/ucx/commit/e93933bfa3ccc040c945127ae36603aadabe0da7) | cherry-pick of [2004c74](https://github.com/openucx/ucx/commit/2004c744488c0eff163169b43d67f590406e5e46) |
| 2 | Prioritize routes with longer subnet masks for improved reachability check accuracy | UCT | [`f656dbd`](https://github.com/openucx/ucx/commit/f656dbdf93e72e60b5d6ca78b9e3d9e744e789bd) | [#11051](https://github.com/openucx/ucx/pull/11051) |
| 3 | Cache RoCE network interface index per `sys_dev` to avoid repeated lookups | UCT/IB | [`8a2986e`](https://github.com/openucx/ucx/commit/8a2986e68e2c6d189598e0749e4eb68926b8f5f9) | [#11231](https://github.com/openucx/ucx/pull/11231) |

## Bugfixes

| # | Proposed NEWS line | Component | Commit | PR |
|---|---|---|---|---|
| 1 | Fixed CUDA context handling for system device during rkey unpack | UCT/CUDA | [`8b77fb8`](https://github.com/openucx/ucx/commit/8b77fb8da8a3d924394292fdedb4cd2a2835fa30) | [#11240](https://github.com/openucx/ucx/pull/11240) |
| 2 | Fixed HSA memory type check for newer ROCm releases (hip managed memory) | UCT/ROCM | [`e4932d0`](https://github.com/openucx/ucx/commit/e4932d059e7b19c3d2e8583aeb372714da687425) | [#11244](https://github.com/openucx/ucx/pull/11244) / [#11236](https://github.com/openucx/ucx/pull/11236) |
| 3 | Fixed DevX objects flag handling | UCT/IB | [`93f547a`](https://github.com/openucx/ucx/commit/93f547aa98dc6d9d5602be59d4d30444d0ea85ed) | [#11175](https://github.com/openucx/ucx/pull/11175) / backport [#11192](https://github.com/openucx/ucx/pull/11192) |
| 4 | Fixed rcache locking for GDR copy | UCS | [`960691e`](https://github.com/openucx/ucx/commit/960691e121655f455b2cf223cb7ac3e75ed794ca) | [#11149](https://github.com/openucx/ucx/pull/11149) / backport [#11190](https://github.com/openucx/ucx/pull/11190) |
| 5 | Fixed device memory allocation alignment in MLX5 DevX | UCT/IB | [`a7a9437`](https://github.com/openucx/ucx/commit/a7a9437adfe558765d094245cb81e84e125fb334) | [#11178](https://github.com/openucx/ucx/pull/11178) / backport [#11188](https://github.com/openucx/ucx/pull/11188) |
| 6 | Fixed IB memory handle flags enum order | UCT/IB | [`1775883`](https://github.com/openucx/ucx/commit/17758836895c1ff839dd3bb5df8b7d0024d50676) | backport [#11148](https://github.com/openucx/ucx/pull/11148) |
| 7 | Disabled indirect atomic registration for Direct NIC | UCT/IB | [`7d784a4`](https://github.com/openucx/ucx/commit/7d784a4ff14612a23775548d34536766f9f43b76) | [#11111](https://github.com/openucx/ucx/pull/11111) / backport [#11148](https://github.com/openucx/ucx/pull/11148) |
| 8 | Fixed stale destination endpoint ID and stale acks from before connection reset in UD transport | UCT/IB | [`476facd`](https://github.com/openucx/ucx/commit/476facd2b79d5e7866ca1162636258898f816c27) | [#11128](https://github.com/openucx/ucx/pull/11128) / original [#11092](https://github.com/openucx/ucx/pull/11092) |
| 9 | Increased TLS info buffer size in transport selection to prevent potential truncation | UCP | [`9f1b529`](https://github.com/openucx/ucx/commit/9f1b529211ee2b901dfe64ab13ba5ab1dec46b72) | [#11131](https://github.com/openucx/ucx/pull/11131) |
| 10 | Fixed incorrect warning about valid environment variable names | UCP | [`7a08d2d`](https://github.com/openucx/ucx/commit/7a08d2da251072340682c6f85a7dd6b3ac5c489f) | backport [#11058](https://github.com/openucx/ucx/pull/11058) |
| 11 | Fixed `ucp_config_modify` not reporting an error when no matching modifiable configuration exists | UCP | [`bbd7e17`](https://github.com/openucx/ucx/commit/bbd7e178e389d7e09c462246470e08c01041e509) | [#11047](https://github.com/openucx/ucx/pull/11047) |

## Documentation

| # | Proposed NEWS line | Component | Commit | PR |
|---|---|---|---|---|
| 1 | Clarified that user buffer can be modified after calling `ucp_atomic_op_nbx` (data is packed immediately) | UCP/API | [`4a7f271`](https://github.com/openucx/ucx/commit/4a7f2710a5ee77bd7304fb5e6612101900ac6327) | [#11126](https://github.com/openucx/ucx/pull/11126) / backport [#11189](https://github.com/openucx/ucx/pull/11189) |

## Packaging / CI

| # | Proposed NEWS line | Component | Commit | PR |
|---|---|---|---|---|
| 1 | Fixed Debian package dependency cleanup | Build | [`1517269`](https://github.com/openucx/ucx/commit/1517269ac4f3b5d8d567785eb82e19f22d47a9b9) | [#11267](https://github.com/openucx/ucx/pull/11267) |
| 2 | Obsoleted KNEM sub-package | Packaging | [`d9a4f35`](https://github.com/openucx/ucx/commit/d9a4f352dd09e365bcdb90b9548a1f072e80e0ed) | [#11164](https://github.com/openucx/ucx/pull/11164) |
| 3 | Fixed full workspace cleanup to resolve checkout failures | CI | [`0165b63`](https://github.com/openucx/ucx/commit/0165b630fffae87c017166b96f25854477c5b4d5) | [#11135](https://github.com/openucx/ucx/pull/11135) |

## Testing

| # | Proposed NEWS line | Component | Commit | PR |
|---|---|---|---|---|
| 1 | Fixed `stale_dest_ep_id_update` test for UD transport | Testing | [`1619616`](https://github.com/openucx/ucx/commit/1619616921557bb860e77ccf623b5bc07ae96aa9) | [#11193](https://github.com/openucx/ucx/pull/11193) |

---