### PR TITLE
CONFIGURE.AC: bump version to v1.20.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)  # Major version. Usually does not change.
 define([ucx_ver_minor], 20) # Minor version. Increased for each release.
-define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
+define([ucx_ver_patch], 1)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 
 define([ts], esyscmd([sh -c "date +%Y%m%d%H%M%S"]))

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -455,6 +455,8 @@ with the host CPU.
 %endif
 
 %changelog
+* Thu Mar 19 2026 Roie Danino <rdanino@nvidia.com> 1.20.1-1
+- Bump version to 1.20.1
 * Fri Apr 11 2025 Yossi Itigin <yosefe@nvidia.com> 1.20.0-1
 - Bump version to 1.20.0
 * Sat Oct 12 2024 Yossi Itigin <yosefe@nvidia.com> 1.19.0-1


### PR DESCRIPTION
## What?
Bump UCX version to v1.20.1

## Why?
Needed for releasing v1.20.1-rc1