### PR TITLE
UCS/SYS: Disable "always inline" when -Og flag is present - v1.21.x

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -82,6 +82,21 @@ AS_IF([test "x$enable_compiler_opt" = "xyes"], [BASE_CFLAGS="-O3 $BASE_CFLAGS"],
 
 
 #
+# Define OPTIMIZATION_LEVEL to the numeric value of the last -O flag.
+# Non-numeric levels (e.g. -Og, -Oz, -Ofast) leave OPTIMIZATION_LEVEL undefined.
+#
+opt_level=""
+for flag in $BASE_CFLAGS $CFLAGS; do
+    case $flag in -O*) opt_level=${flag#-O};; esac
+done
+case $opt_level in
+    [[0-9]])
+        AC_DEFINE_UNQUOTED([OPTIMIZATION_LEVEL], [$opt_level],
+                           [Numeric compiler optimization level]) ;;
+esac
+
+
+#
 # CHECK_CROSS_COMP (program, true-action, false-action)
 #
 # The macro checks if it can run the program; it executes

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -21,7 +21,7 @@ ucp_proto_request_complete_success(ucp_request_t *req)
     return UCS_OK;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_request_bcopy_complete_success(ucp_request_t *req)
 {
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, 0, UCP_DT_MASK_ALL);

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -131,7 +131,7 @@ ucp_proto_put_offload_update_remote_flush(ucp_ep_h ep,
     ep->ext->flush_sys_dev_map |= flush_sys_dev_mask;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_put_offload_bcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
                                       ucp_datatype_iter_t *next_iter,

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -91,7 +91,7 @@ ucp_proto_rndv_put_common_flush_completion_send_atp(uct_completion_t *uct_comp)
     ucp_request_send(req);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_rndv_put_common_flush_send(ucp_request_t *req, ucp_lane_index_t lane)
 {
     ucp_ep_h ep = req->send.ep;
@@ -208,7 +208,7 @@ ucp_proto_rndv_put_common_fenced_atp_progress(uct_pending_req_t *uct_req)
             ucp_proto_rndv_put_common_fenced_atp_send);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_rndv_put_common_data_sent(ucp_request_t *req)
 {
     const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
@@ -502,7 +502,7 @@ static void ucp_proto_rndv_put_mtype_pack_completion(uct_completion_t *uct_comp)
     ucp_request_send(req);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_put_mtype_send_func(
+static UCS_F_INLINE_OPTIMIZED ucs_status_t ucp_proto_rndv_put_mtype_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -188,7 +188,7 @@ void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
     }
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
 {
     if (!(req->flags & UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED)) {

--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -30,6 +30,13 @@
 #  pragma warning(disable: 268)
 #endif
 
+/* Inline the function only when optimization level is high enough */
+#if defined(OPTIMIZATION_LEVEL) && (OPTIMIZATION_LEVEL >= 2)
+#define UCS_F_INLINE_OPTIMIZED   UCS_F_ALWAYS_INLINE
+#else
+#define UCS_F_INLINE_OPTIMIZED   inline
+#endif
+
 /* A function which should not be optimized */
 #if defined(__clang__)
 #define UCS_F_NOOPTIMIZE __attribute__((optnone))


### PR DESCRIPTION
## What?
Disable "always inline" when -Og flag is present.

## Why?
Support -Og optimization level.

backport https://github.com/openucx/ucx/pull/11251