### PR TITLE
UCT/IB/RC: add adaptive TX CQ moderation

### DIFF
--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -469,7 +469,9 @@ uct_rc_txqp_completion_inl_resp(uct_rc_txqp_t *txqp, const void *resp, uint16_t 
 static UCS_F_ALWAYS_INLINE uint8_t
 uct_rc_iface_tx_moderation(uct_rc_iface_t *iface, uct_rc_txqp_t *txqp, uint8_t flag)
 {
-    return (txqp->unsignaled >= iface->config.tx_moderation) ? flag : 0;
+    return (txqp->unsignaled >= iface->config.tx_moderation) ||
+           (iface->tx.cq_available <= (signed)iface->config.tx_moderation)
+           ? flag : 0;
 }
 
 static UCS_F_ALWAYS_INLINE void


### PR DESCRIPTION
## Summary
- When many RC endpoints each send fewer messages than `tx_moderation`, no signaled sends are generated and TX CQ credits are never reclaimed, exhausting the TX buffer pool.
- Fix `uct_rc_iface_tx_moderation()` to also check iface-level `cq_available`: when CQ credits drop to the `tx_moderation` threshold, force the next send on any endpoint to be signaled.

Closes #1307