### PR TITLE
wireup: add tcp as fallback auxiliary transport for rc and dc

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -624,14 +624,14 @@ static ucs_config_field_t ucp_config_table[] = {
    " - mm      : shared memory transports - only memory mappers.\n"
    " - ugni    : ugni_smsg and ugni_rdma (uses ugni_udt for bootstrap).\n"
    " - ib      : all infiniband transports (rc/rc_mlx5, ud/ud_mlx5, dc_mlx5, srd).\n"
-   " - rc_v    : rc verbs (uses ud for bootstrap).\n"
-   " - rc_x    : rc with accelerated verbs (uses ud_mlx5 for bootstrap).\n"
+   " - rc_v    : rc verbs (uses ud or tcp for bootstrap).\n"
+   " - rc_x    : rc with accelerated verbs (uses ud_mlx5 or tcp for bootstrap).\n"
    " - rc      : rc_v and rc_x (preferably if available).\n"
    " - ud_v    : ud verbs.\n"
    " - ud_x    : ud with accelerated verbs.\n"
    " - ud      : ud_v and ud_x (preferably if available).\n"
    " - srd     : EFA srd reliable transport.\n"
-   " - dc/dc_x : dc with accelerated verbs.\n"
+   " - dc/dc_x : dc with accelerated verbs (uses ud_mlx5 or tcp for bootstrap).\n"
    " - tcp     : sockets over TCP/IP.\n"
    " - cuda    : CUDA (NVIDIA GPU) memory support.\n"
    " - rocm    : ROCm (AMD GPU) memory support.\n"
@@ -717,12 +717,12 @@ static ucp_tl_alias_t ucp_tl_aliases[] = {
   { "ud_v",  { "ud_verbs", NULL } },
   { "ud_x",  { "ud_mlx5", NULL } },
   { "ud",    { "ud_mlx5", "ud_verbs", NULL } },
-  { "rc_v",  { "rc_verbs", UCP_TL_AUX("ud_verbs"), NULL } },
-  { "rc_x",  { "rc_mlx5", UCP_TL_AUX("ud_mlx5"), NULL } },
+  { "rc_v",  { "rc_verbs", UCP_TL_AUX("ud_verbs"), UCP_TL_AUX("tcp"), NULL } },
+  { "rc_x",  { "rc_mlx5", UCP_TL_AUX("ud_mlx5"), UCP_TL_AUX("tcp"), NULL } },
   { "rc",    { "rc_mlx5", UCP_TL_AUX("ud_mlx5"), "rc_verbs",
-               UCP_TL_AUX("ud_verbs"), NULL } },
-  { "dc",    { "dc_mlx5", UCP_TL_AUX("ud_mlx5"), NULL } },
-  { "dc_x",  { "dc_mlx5", UCP_TL_AUX("ud_mlx5"), NULL } },
+               UCP_TL_AUX("ud_verbs"), UCP_TL_AUX("tcp"), NULL } },
+  { "dc",    { "dc_mlx5", UCP_TL_AUX("ud_mlx5"), UCP_TL_AUX("tcp"), NULL } },
+  { "dc_x",  { "dc_mlx5", UCP_TL_AUX("ud_mlx5"), UCP_TL_AUX("tcp"), NULL } },
   { "ugni",  { "ugni_smsg", UCP_TL_AUX("ugni_udt"), "ugni_rdma", NULL } },
   { "cuda",  { "cuda_copy", "cuda_ipc", "gdr_copy", NULL } },
   { "rocm",  { "rocm_copy", "rocm_ipc", "rocm_gdr", NULL } },

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1804,8 +1804,10 @@ public:
 // unpacked by min/max values of the corresponding fp8 types.
 // TCP may also be loaded as an auxiliary transport for RC/DC aliases.
 UCS_TEST_SKIP_COND_P(test_ucp_address_v2, pack_iface_attrs,
-                     has_transport("tcp") ||
-                     has_resource(sender(), "tcp")) {
+                     has_transport("tcp")) {
+    if (has_resource(sender(), "tcp")) {
+        UCS_TEST_SKIP_R("tcp is loaded as auxiliary transport");
+    }
     ucs_status_t status;
     size_t size;
     void *buffer;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1801,9 +1801,11 @@ public:
 };
 
 // On some systems TCP has very low BW and high latency, which would be
-// unpacked by min/max values of the corresponding fp8 types
+// unpacked by min/max values of the corresponding fp8 types.
+// TCP may also be loaded as an auxiliary transport for RC/DC aliases.
 UCS_TEST_SKIP_COND_P(test_ucp_address_v2, pack_iface_attrs,
-                     has_transport("tcp")) {
+                     has_transport("tcp") ||
+                     has_resource(sender(), "tcp")) {
     ucs_status_t status;
     size_t size;
     void *buffer;


### PR DESCRIPTION
## Summary

When UCX_TLS=rc_v is used on systems where UD transport is unavailable (e.g. SoftRoCE/rxe), endpoint creation fails because no CONNECT_TO_IFACE transport exists for wireup bootstrap. This adds TCP as a fallback auxiliary transport in the rc_v, rc_x, rc, dc, and dc_x aliases. UD is still preferred when available due to lower latency scoring; TCP is only used when UD cannot be loaded.

Fixes #4794