### PR TITLE
UCT/GDR_COPY: Add option for PCIe BAR1 export

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -218,6 +218,8 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                         [AC_MSG_NOTICE([nvmlDeviceGetGpuFabricInfoV function not found in libnvidia-ml. MNNVL support will be disabled.])],
                         [[#include <nvml.h>]])
 
+         AC_CHECK_DECLS([NVML_FI_DEV_C2C_LINK_COUNT], [], [],
+                        [[#include <nvml.h>]])
 
          # Check for cuda static library
          have_cuda_static="no"

--- a/config/m4/gdrcopy.m4
+++ b/config/m4/gdrcopy.m4
@@ -39,8 +39,8 @@ AS_IF([test "x$with_gdrcopy" != "xno"],
             ], [gdrcopy_happy="no"])
 
         AS_IF([test "x$gdrcopy_happy" = "xyes"], [
-            AC_CHECK_DECLS([gdr_pin_buffer_v2], [], [], [#include "gdrapi.h"])
-            AC_CHECK_DECLS([gdr_copy_to_mapping], [], [], [#include "gdrapi.h"])
+            AC_CHECK_DECLS([gdr_pin_buffer_v2, gdr_copy_to_mapping], [], [],
+                            [#include "gdrapi.h"])
         ])
 
         CFLAGS="$save_CFLAGS"

--- a/config/m4/gdrcopy.m4
+++ b/config/m4/gdrcopy.m4
@@ -38,8 +38,10 @@ AS_IF([test "x$with_gdrcopy" != "xno"],
                             gdrcopy_happy="no"])
             ], [gdrcopy_happy="no"])
 
-        AS_IF([test "x$gdrcopy_happy" = "xyes"],
-            [AC_CHECK_DECLS([gdr_copy_to_mapping], [], [], [#include "gdrapi.h"])])
+        AS_IF([test "x$gdrcopy_happy" = "xyes"], [
+            AC_CHECK_DECLS([gdr_pin_buffer_v2], [], [], [#include "gdrapi.h"])
+            AC_CHECK_DECLS([gdr_copy_to_mapping], [], [], [#include "gdrapi.h"])
+        ])
 
         CFLAGS="$save_CFLAGS"
         CPPFLAGS="$save_CPPFLAGS"

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -28,42 +28,38 @@
 #define UCT_GDR_COPY_RCACHE_OVERHEAD_AUTO 50.0e-9
 
 
-static const char *uct_gdr_copy_pin_mode_names[] = {
-    [UCT_GDR_COPY_PIN_MODE_DEFAULT]  = "default",
-    [UCT_GDR_COPY_PIN_MODE_PCIE]     = "pcie",
-    [UCT_GDR_COPY_PIN_MODE_TRY_PCIE] = "try_pcie",
-    [UCT_GDR_COPY_PIN_MODE_LAST]     = NULL
-};
-
 static ucs_status_t
-uct_gdr_copy_pin_params_get(uct_gdr_copy_pin_mode_t pin_mode,
-                            uint32_t *pin_gdr_flags_p, int *pin_pcie_fallback_p)
+uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
+                                 uint32_t *pin_gdr_flags_p, int *pin_pcie_fallback_p)
 {
 #if HAVE_DECL_GDR_PIN_BUFFER_V2
-    switch (pin_mode) {
-    case UCT_GDR_COPY_PIN_MODE_DEFAULT:
-        *pin_gdr_flags_p     = GDR_PIN_FLAG_DEFAULT;
-        *pin_pcie_fallback_p = 0;
-        break;
-    case UCT_GDR_COPY_PIN_MODE_PCIE:
+    switch (use_pcie) {
+    case UCS_YES:
         *pin_gdr_flags_p     = GDR_PIN_FLAG_FORCE_PCIE;
         *pin_pcie_fallback_p = 0;
         break;
-    case UCT_GDR_COPY_PIN_MODE_TRY_PCIE:
+    case UCS_AUTO:
+        /* Fallthrough */
+    case UCS_NO:
+        *pin_gdr_flags_p     = GDR_PIN_FLAG_DEFAULT;
+        *pin_pcie_fallback_p = 0;
+        break;
+    case UCS_TRY:
         *pin_gdr_flags_p     = GDR_PIN_FLAG_FORCE_PCIE;
         *pin_pcie_fallback_p = 1;
         break;
     default:
-        ucs_error("invalid GDR_COPY PIN_MODE %d", pin_mode);
+        ucs_error("invalid USE_PCIE %d", use_pcie);
         return UCS_ERR_INVALID_PARAM;
     }
 
     return UCS_OK;
 #else
-    if (pin_mode != UCT_GDR_COPY_PIN_MODE_DEFAULT) {
-        ucs_error(
-                "PIN_MODE=%s requires GDRCopy with gdr_pin_buffer_v2",
-                uct_gdr_copy_pin_mode_names[pin_mode]);
+    if ((use_pcie != UCS_AUTO) && (use_pcie != UCS_NO)) {
+        char buf[64];
+
+        ucs_config_sprintf_ternary_auto(buf, sizeof(buf), &use_pcie, NULL);
+        ucs_error("USE_PCIE=%s requires GDRCopy with gdr_pin_buffer_v2", buf);
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -102,13 +98,14 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
     {"MEM_REG_GROWTH", "0.06ns", "Memory registration growth rate", /* TODO take default from device */
      ucs_offsetof(uct_gdr_copy_md_config_t, uc_reg_cost.c), UCS_CONFIG_TYPE_TIME},
 
-    {"PIN_MODE", "default",
+    {"USE_PCIE", "auto",
      "Mapping type for CPU access:\n"
-     " default  - Default mapping C2C or PCIe\n"
-     " pcie     - Force a PCIe based mapping (BAR1), may fail at registration\n"
-     " try_pcie - Prefer PCIe (BAR1), fall back to default mapping if pin fails\n",
-     ucs_offsetof(uct_gdr_copy_md_config_t, pin_mode),
-     UCS_CONFIG_TYPE_ENUM(uct_gdr_copy_pin_mode_names)},
+     " auto - default, driver chooses C2C or PCIe\n"
+     " yes  - Force PCIe (BAR1); may fail at registration\n"
+     " no   - default, driver chooses C2C or PCIe\n"
+     " try  - Try PCIe first, fall back to default in case of failure\n",
+     ucs_offsetof(uct_gdr_copy_md_config_t, use_pcie),
+     UCS_CONFIG_TYPE_TERNARY_AUTO},
 
     {"", "RCACHE_PURGE_ON_FORK=n", NULL,
      ucs_offsetof(uct_gdr_copy_md_config_t, rcache_config),
@@ -204,9 +201,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
     ret       = gdr_pin_buffer_v2(md->gdrcpy_ctx, d_ptr, length, pin_flags,
                                   &mem_hndl->mh);
     if (ret && (pin_flags != GDR_PIN_FLAG_DEFAULT) && md->pin_pcie_fallback) {
-        ucs_debug("GPU memory non-default pin failed with length:%lu ret:%d "
-                  "pin_flags %u, "
-                  "retrying with default pin flag",
+        ucs_debug("GPU memory non-default pin failed with length %lu ret %d "
+                  "pin_flags %u, retrying with default pin flag",
                   length, ret, pin_flags);
         pin_flags = GDR_PIN_FLAG_DEFAULT;
         ret       = gdr_pin_buffer_v2(md->gdrcpy_ctx, d_ptr, length, pin_flags,
@@ -217,7 +213,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
 #endif
     if (ret) {
         ucs_log(log_level,
-                "GPU memory pin failed. length :%lu ret:%d pin_flags %u",
+                "GPU memory pin failed. length %lu ret %d pin_flags %u",
                 length, ret, pin_flags);
         goto err;
     }
@@ -548,9 +544,9 @@ uct_gdr_copy_md_create(uct_component_t *component,
     md->reg_cost        = md_config->uc_reg_cost;
     md->super.ops       = &uct_gdr_copy_md_ops;
     md->rcache          = NULL;
-    status              = uct_gdr_copy_pin_params_get(md_config->pin_mode,
-                                                      &md->pin_gdr_flags,
-                                                      &md->pin_pcie_fallback);
+    status              = uct_gdr_copy_use_pcie_params_get(md_config->use_pcie,
+                                                           &md->pin_gdr_flags,
+                                                           &md->pin_pcie_fallback);
     if (status != UCS_OK) {
         goto err_free;
     }
@@ -624,14 +620,14 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
             ucs_error("inconsistent gdr_copy rcache enable param");
             status = UCS_ERR_INVALID_PARAM;
         } else {
-            status = uct_gdr_copy_pin_params_get(md_config->pin_mode,
-                                                 &new_pin_flags,
-                                                 &new_pin_fallback);
+            status = uct_gdr_copy_use_pcie_params_get(md_config->use_pcie,
+                                                      &new_pin_flags,
+                                                      &new_pin_fallback);
             if (status == UCS_OK) {
                 if ((uct_gdr_copy_context.md->pin_gdr_flags != new_pin_flags) ||
                     (uct_gdr_copy_context.md->pin_pcie_fallback !=
                      new_pin_fallback)) {
-                    ucs_error("inconsistent PIN_MODE: shared pin_flags=%u "
+                    ucs_error("inconsistent USE_PCIE: shared pin_flags=%u "
                               "fallback=%d, opening pin_flags=%u fallback=%d",
                               uct_gdr_copy_context.md->pin_gdr_flags,
                               uct_gdr_copy_context.md->pin_pcie_fallback,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -49,17 +49,13 @@ uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
         *pin_pcie_fallback_p = 1;
         break;
     default:
-        ucs_error("invalid USE_PCIE %d", use_pcie);
         return UCS_ERR_INVALID_PARAM;
     }
 
     return UCS_OK;
 #else
-    char buf[64];
-
-    if ((use_pcie != UCS_AUTO) && (use_pcie != UCS_NO)) {
-        ucs_config_sprintf_ternary_auto(buf, sizeof(buf), &use_pcie, NULL);
-        ucs_error("USE_PCIE=%s requires GDRCopy with gdr_pin_buffer_v2", buf);
+    if (use_pcie == UCS_YES) {
+        ucs_error("USE_PCIE=yes requires GDRCopy with gdr_pin_buffer_v2", buf);
         return UCS_ERR_INVALID_PARAM;
     }
 
@@ -627,7 +623,7 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
                 if ((uct_gdr_copy_context.md->pin_gdr_flags != new_pin_flags) ||
                     (uct_gdr_copy_context.md->pin_pcie_fallback !=
                      new_pin_fallback)) {
-                    ucs_error("inconsistent USE_PCIE: shared pin_flags=%u "
+                    ucs_error("inconsistent pin mode: shared pin_flags=%u "
                               "fallback=%d, opening pin_flags=%u fallback=%d",
                               uct_gdr_copy_context.md->pin_gdr_flags,
                               uct_gdr_copy_context.md->pin_pcie_fallback,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -32,8 +32,6 @@ static ucs_status_t
 uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
                                  uint32_t *pin_gdr_flags_p, int *pin_pcie_fallback_p)
 {
-    char buf[64];
-
 #if HAVE_DECL_GDR_PIN_BUFFER_V2
     switch (use_pcie) {
     case UCS_YES:
@@ -57,6 +55,8 @@ uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
 
     return UCS_OK;
 #else
+    char buf[64];
+
     if ((use_pcie != UCS_AUTO) && (use_pcie != UCS_NO)) {
         ucs_config_sprintf_ternary_auto(buf, sizeof(buf), &use_pcie, NULL);
         ucs_error("USE_PCIE=%s requires GDRCopy with gdr_pin_buffer_v2", buf);

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -28,6 +28,12 @@
 #define UCT_GDR_COPY_RCACHE_OVERHEAD_AUTO 50.0e-9
 
 
+static const char *uct_gdr_copy_pin_mode_names[] = {
+    [UCT_GDR_COPY_PIN_MODE_DEFAULT] = "default",
+    [UCT_GDR_COPY_PIN_MODE_PCIE]    = "pcie",
+    [UCT_GDR_COPY_PIN_MODE_LAST]    = NULL
+};
+
 typedef struct {
     pthread_mutex_t   lock;
     unsigned          refcount;
@@ -56,6 +62,13 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
 
     {"MEM_REG_GROWTH", "0.06ns", "Memory registration growth rate", /* TODO take default from device */
      ucs_offsetof(uct_gdr_copy_md_config_t, uc_reg_cost.c), UCS_CONFIG_TYPE_TIME},
+
+    {"PIN_MODE", "default",
+     "Mapping type for CPU access:\n"
+     " default  - Default mapping C2C or PCIe\n"
+     " pcie     - Force a PCIe based mapping (BAR1), may fail at registration.\n",
+     ucs_offsetof(uct_gdr_copy_md_config_t, pin_mode),
+     UCS_CONFIG_TYPE_ENUM(uct_gdr_copy_pin_mode_names)},
 
     {"", "RCACHE_PURGE_ON_FORK=n", NULL,
      ucs_offsetof(uct_gdr_copy_md_config_t, rcache_config),
@@ -139,6 +152,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
     unsigned long d_ptr   = ((unsigned long)(char*)address);
     ucs_log_level_t log_level;
+    uint32_t pin_gdr_flags = 0;
     int ret;
 
     ucs_assert((address != NULL) && (length != 0));
@@ -146,10 +160,18 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
     log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
                 UCS_LOG_LEVEL_ERROR;
 
+#if HAVE_DECL_GDR_PIN_BUFFER_V2
+    pin_gdr_flags = (md->pin_mode == UCT_GDR_COPY_PIN_MODE_PCIE) ?
+                    GDR_PIN_FLAG_FORCE_PCIE : GDR_PIN_FLAG_DEFAULT;
+    ret           = gdr_pin_buffer_v2(md->gdrcpy_ctx, d_ptr, length, pin_gdr_flags,
+                                      &mem_hndl->mh);
+#else
     ret = gdr_pin_buffer(md->gdrcpy_ctx, d_ptr, length, 0, 0, &mem_hndl->mh);
+#endif
     if (ret) {
-        ucs_log(log_level, "gdr_pin_buffer failed. length :%lu ret:%d",
-                length, ret);
+        ucs_log(log_level,
+                "GPU memory pin failed. length :%lu ret:%d pin_flags:%u",
+                length, ret, pin_gdr_flags);
         goto err;
     }
 
@@ -167,9 +189,11 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
         goto unmap_buffer;
     }
 
-    ucs_trace("registered memory:%p..%p length:%lu info.va:0x%"PRIx64" bar_ptr:%p",
+    ucs_trace("registered memory:%p..%p length:%lu info.va:0x%" PRIx64
+              " bar_ptr:%p mode:%s",
               address, UCS_PTR_BYTE_OFFSET(address, length), length,
-              mem_hndl->info.va, mem_hndl->bar_ptr);
+              mem_hndl->info.va, mem_hndl->bar_ptr,
+              uct_gdr_copy_pin_mode_names[md->pin_mode]);
 
     return UCS_OK;
 
@@ -468,6 +492,13 @@ uct_gdr_copy_md_create(uct_component_t *component,
     uct_gdr_copy_md_t *md;
     ucs_status_t status;
 
+#if !HAVE_DECL_GDR_PIN_BUFFER_V2
+    if (md_config->pin_mode == UCT_GDR_COPY_PIN_MODE_PCIE) {
+        ucs_error("PCIe pin mode requires GDRCopy with gdr_pin_buffer_v2");
+        return UCS_ERR_INVALID_PARAM;
+    }
+#endif
+
     md = ucs_malloc(sizeof(*md), "uct_gdr_copy_md_t");
     if (md == NULL) {
         ucs_error("failed to allocate memory for uct_gdr_copy_md_t");
@@ -478,6 +509,7 @@ uct_gdr_copy_md_create(uct_component_t *component,
     md->reg_cost        = md_config->uc_reg_cost;
     md->super.ops       = &uct_gdr_copy_md_ops;
     md->rcache          = NULL;
+    md->pin_mode        = md_config->pin_mode;
 
     md->gdrcpy_ctx = gdr_open();
     if (md->gdrcpy_ctx == NULL) {
@@ -544,6 +576,12 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
         if ((uct_gdr_copy_context.md->rcache != NULL) !=
              md_config->enable_rcache) {
             ucs_error("inconsistent gdr_copy rcache enable param");
+            status = UCS_ERR_INVALID_PARAM;
+        } else if (uct_gdr_copy_context.md->pin_mode != md_config->pin_mode) {
+            ucs_error("inconsistent gdr_copy PIN_MODE: shared=%s, opening=%s",
+                      uct_gdr_copy_pin_mode_names
+                              [uct_gdr_copy_context.md->pin_mode],
+                      uct_gdr_copy_pin_mode_names[md_config->pin_mode]);
             status = UCS_ERR_INVALID_PARAM;
         } else {
             status = UCS_OK;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -32,6 +32,8 @@ static ucs_status_t
 uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
                                  uint32_t *pin_gdr_flags_p, int *pin_pcie_fallback_p)
 {
+    char buf[64];
+
 #if HAVE_DECL_GDR_PIN_BUFFER_V2
     switch (use_pcie) {
     case UCS_YES:
@@ -56,8 +58,6 @@ uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
     return UCS_OK;
 #else
     if ((use_pcie != UCS_AUTO) && (use_pcie != UCS_NO)) {
-        char buf[64];
-
         ucs_config_sprintf_ternary_auto(buf, sizeof(buf), &use_pcie, NULL);
         ucs_error("USE_PCIE=%s requires GDRCopy with gdr_pin_buffer_v2", buf);
         return UCS_ERR_INVALID_PARAM;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -62,7 +62,7 @@ uct_gdr_copy_pin_params_get(uct_gdr_copy_pin_mode_t pin_mode,
 #else
     if (pin_mode != UCT_GDR_COPY_PIN_MODE_DEFAULT) {
         ucs_error(
-                "GDR_COPY PIN_MODE=%s requires GDRCopy with gdr_pin_buffer_v2",
+                "PIN_MODE=%s requires GDRCopy with gdr_pin_buffer_v2",
                 uct_gdr_copy_pin_mode_names[pin_mode]);
         return UCS_ERR_INVALID_PARAM;
     }
@@ -236,8 +236,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
         goto unmap_buffer;
     }
 
-    ucs_trace("registered memory:%p..%p length:%lu info.va:0x%" PRIx64
-              " bar_ptr:%p pin_flags %u",
+    ucs_trace("registered memory %p..%p length %lu info.va 0x%" PRIx64
+              " bar_ptr %p pin_flags %u",
               address, UCS_PTR_BYTE_OFFSET(address, length), length,
               mem_hndl->info.va, mem_hndl->bar_ptr, pin_flags);
 
@@ -605,6 +605,8 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
             ucs_derived_of(config, uct_gdr_copy_md_config_t);
     uct_gdr_copy_md_t *md;
     ucs_status_t status;
+    uint32_t new_pin_flags;
+    int new_pin_fallback;
 
     if (!md_config->shared) {
         status = uct_gdr_copy_md_create(component, md_config, &md);
@@ -622,9 +624,6 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
             ucs_error("inconsistent gdr_copy rcache enable param");
             status = UCS_ERR_INVALID_PARAM;
         } else {
-            uint32_t new_pin_flags;
-            int new_pin_fallback;
-
             status = uct_gdr_copy_pin_params_get(md_config->pin_mode,
                                                  &new_pin_flags,
                                                  &new_pin_fallback);
@@ -632,8 +631,7 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
                 if ((uct_gdr_copy_context.md->pin_gdr_flags != new_pin_flags) ||
                     (uct_gdr_copy_context.md->pin_pcie_fallback !=
                      new_pin_fallback)) {
-                    ucs_error("inconsistent gdr_copy PIN_MODE: shared "
-                              "pin_flags=%u "
+                    ucs_error("inconsistent PIN_MODE: shared pin_flags=%u "
                               "fallback=%d, opening pin_flags=%u fallback=%d",
                               uct_gdr_copy_context.md->pin_gdr_flags,
                               uct_gdr_copy_context.md->pin_pcie_fallback,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -29,10 +29,49 @@
 
 
 static const char *uct_gdr_copy_pin_mode_names[] = {
-    [UCT_GDR_COPY_PIN_MODE_DEFAULT] = "default",
-    [UCT_GDR_COPY_PIN_MODE_PCIE]    = "pcie",
-    [UCT_GDR_COPY_PIN_MODE_LAST]    = NULL
+    [UCT_GDR_COPY_PIN_MODE_DEFAULT]  = "default",
+    [UCT_GDR_COPY_PIN_MODE_PCIE]     = "pcie",
+    [UCT_GDR_COPY_PIN_MODE_TRY_PCIE] = "try_pcie",
+    [UCT_GDR_COPY_PIN_MODE_LAST]     = NULL
 };
+
+static ucs_status_t
+uct_gdr_copy_pin_params_get(uct_gdr_copy_pin_mode_t pin_mode,
+                            uint32_t *pin_gdr_flags_p, int *pin_pcie_fallback_p)
+{
+#if HAVE_DECL_GDR_PIN_BUFFER_V2
+    switch (pin_mode) {
+    case UCT_GDR_COPY_PIN_MODE_DEFAULT:
+        *pin_gdr_flags_p     = GDR_PIN_FLAG_DEFAULT;
+        *pin_pcie_fallback_p = 0;
+        break;
+    case UCT_GDR_COPY_PIN_MODE_PCIE:
+        *pin_gdr_flags_p     = GDR_PIN_FLAG_FORCE_PCIE;
+        *pin_pcie_fallback_p = 0;
+        break;
+    case UCT_GDR_COPY_PIN_MODE_TRY_PCIE:
+        *pin_gdr_flags_p     = GDR_PIN_FLAG_FORCE_PCIE;
+        *pin_pcie_fallback_p = 1;
+        break;
+    default:
+        ucs_error("invalid GDR_COPY PIN_MODE %d", pin_mode);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+#else
+    if (pin_mode != UCT_GDR_COPY_PIN_MODE_DEFAULT) {
+        ucs_error(
+                "GDR_COPY PIN_MODE=%s requires GDRCopy with gdr_pin_buffer_v2",
+                uct_gdr_copy_pin_mode_names[pin_mode]);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    *pin_gdr_flags_p     = 0;
+    *pin_pcie_fallback_p = 0;
+    return UCS_OK;
+#endif
+}
 
 typedef struct {
     pthread_mutex_t   lock;
@@ -66,7 +105,8 @@ static ucs_config_field_t uct_gdr_copy_md_config_table[] = {
     {"PIN_MODE", "default",
      "Mapping type for CPU access:\n"
      " default  - Default mapping C2C or PCIe\n"
-     " pcie     - Force a PCIe based mapping (BAR1), may fail at registration.\n",
+     " pcie     - Force a PCIe based mapping (BAR1), may fail at registration\n"
+     " try_pcie - Prefer PCIe (BAR1), fall back to default mapping if pin fails\n",
      ucs_offsetof(uct_gdr_copy_md_config_t, pin_mode),
      UCS_CONFIG_TYPE_ENUM(uct_gdr_copy_pin_mode_names)},
 
@@ -149,29 +189,36 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
                  uct_md_h uct_md, void *address, size_t length,
                  unsigned flags, uct_gdr_copy_mem_t *mem_hndl)
 {
-    uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
-    unsigned long d_ptr   = ((unsigned long)(char*)address);
-    ucs_log_level_t log_level;
-    uint32_t pin_gdr_flags = 0;
+    uct_gdr_copy_md_t *md     = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
+    unsigned long d_ptr       = ((unsigned long)(char*)address);
+    ucs_log_level_t log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ?
+                                        UCS_LOG_LEVEL_DEBUG :
+                                        UCS_LOG_LEVEL_ERROR;
+    uint32_t pin_flags        = 0;
     int ret;
 
     ucs_assert((address != NULL) && (length != 0));
 
-    log_level = (flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ? UCS_LOG_LEVEL_DEBUG :
-                UCS_LOG_LEVEL_ERROR;
-
 #if HAVE_DECL_GDR_PIN_BUFFER_V2
-    pin_gdr_flags = (md->pin_mode == UCT_GDR_COPY_PIN_MODE_PCIE) ?
-                    GDR_PIN_FLAG_FORCE_PCIE : GDR_PIN_FLAG_DEFAULT;
-    ret           = gdr_pin_buffer_v2(md->gdrcpy_ctx, d_ptr, length, pin_gdr_flags,
+    pin_flags = md->pin_gdr_flags;
+    ret       = gdr_pin_buffer_v2(md->gdrcpy_ctx, d_ptr, length, pin_flags,
+                                  &mem_hndl->mh);
+    if (ret && (pin_flags != GDR_PIN_FLAG_DEFAULT) && md->pin_pcie_fallback) {
+        ucs_debug("GPU memory non-default pin failed with length:%lu ret:%d "
+                  "pin_flags %u, "
+                  "retrying with default pin flag",
+                  length, ret, pin_flags);
+        pin_flags = GDR_PIN_FLAG_DEFAULT;
+        ret       = gdr_pin_buffer_v2(md->gdrcpy_ctx, d_ptr, length, pin_flags,
                                       &mem_hndl->mh);
+    }
 #else
     ret = gdr_pin_buffer(md->gdrcpy_ctx, d_ptr, length, 0, 0, &mem_hndl->mh);
 #endif
     if (ret) {
         ucs_log(log_level,
-                "GPU memory pin failed. length :%lu ret:%d pin_flags:%u",
-                length, ret, pin_gdr_flags);
+                "GPU memory pin failed. length :%lu ret:%d pin_flags %u",
+                length, ret, pin_flags);
         goto err;
     }
 
@@ -190,10 +237,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_gdr_copy_mem_reg_internal,
     }
 
     ucs_trace("registered memory:%p..%p length:%lu info.va:0x%" PRIx64
-              " bar_ptr:%p mode:%s",
+              " bar_ptr:%p pin_flags %u",
               address, UCS_PTR_BYTE_OFFSET(address, length), length,
-              mem_hndl->info.va, mem_hndl->bar_ptr,
-              uct_gdr_copy_pin_mode_names[md->pin_mode]);
+              mem_hndl->info.va, mem_hndl->bar_ptr, pin_flags);
 
     return UCS_OK;
 
@@ -492,13 +538,6 @@ uct_gdr_copy_md_create(uct_component_t *component,
     uct_gdr_copy_md_t *md;
     ucs_status_t status;
 
-#if !HAVE_DECL_GDR_PIN_BUFFER_V2
-    if (md_config->pin_mode == UCT_GDR_COPY_PIN_MODE_PCIE) {
-        ucs_error("PCIe pin mode requires GDRCopy with gdr_pin_buffer_v2");
-        return UCS_ERR_INVALID_PARAM;
-    }
-#endif
-
     md = ucs_malloc(sizeof(*md), "uct_gdr_copy_md_t");
     if (md == NULL) {
         ucs_error("failed to allocate memory for uct_gdr_copy_md_t");
@@ -509,7 +548,12 @@ uct_gdr_copy_md_create(uct_component_t *component,
     md->reg_cost        = md_config->uc_reg_cost;
     md->super.ops       = &uct_gdr_copy_md_ops;
     md->rcache          = NULL;
-    md->pin_mode        = md_config->pin_mode;
+    status              = uct_gdr_copy_pin_params_get(md_config->pin_mode,
+                                                      &md->pin_gdr_flags,
+                                                      &md->pin_pcie_fallback);
+    if (status != UCS_OK) {
+        goto err_free;
+    }
 
     md->gdrcpy_ctx = gdr_open();
     if (md->gdrcpy_ctx == NULL) {
@@ -577,14 +621,26 @@ uct_gdr_copy_md_open(uct_component_t *component, const char *md_name,
              md_config->enable_rcache) {
             ucs_error("inconsistent gdr_copy rcache enable param");
             status = UCS_ERR_INVALID_PARAM;
-        } else if (uct_gdr_copy_context.md->pin_mode != md_config->pin_mode) {
-            ucs_error("inconsistent gdr_copy PIN_MODE: shared=%s, opening=%s",
-                      uct_gdr_copy_pin_mode_names
-                              [uct_gdr_copy_context.md->pin_mode],
-                      uct_gdr_copy_pin_mode_names[md_config->pin_mode]);
-            status = UCS_ERR_INVALID_PARAM;
         } else {
-            status = UCS_OK;
+            uint32_t new_pin_flags;
+            int new_pin_fallback;
+
+            status = uct_gdr_copy_pin_params_get(md_config->pin_mode,
+                                                 &new_pin_flags,
+                                                 &new_pin_fallback);
+            if (status == UCS_OK) {
+                if ((uct_gdr_copy_context.md->pin_gdr_flags != new_pin_flags) ||
+                    (uct_gdr_copy_context.md->pin_pcie_fallback !=
+                     new_pin_fallback)) {
+                    ucs_error("inconsistent gdr_copy PIN_MODE: shared "
+                              "pin_flags=%u "
+                              "fallback=%d, opening pin_flags=%u fallback=%d",
+                              uct_gdr_copy_context.md->pin_gdr_flags,
+                              uct_gdr_copy_context.md->pin_pcie_fallback,
+                              new_pin_flags, new_pin_fallback);
+                    status = UCS_ERR_INVALID_PARAM;
+                }
+            }
         }
     } else {
         status = uct_gdr_copy_md_create(component, md_config,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -13,14 +13,23 @@
 extern uct_component_t uct_gdr_copy_component;
 
 
+/** Pin mode for GDRCopy GPU memory registration (default vs PCIe-based mapping). */
+typedef enum uct_gdr_copy_pin_mode {
+    UCT_GDR_COPY_PIN_MODE_DEFAULT = 0,
+    UCT_GDR_COPY_PIN_MODE_PCIE    = 1,
+    UCT_GDR_COPY_PIN_MODE_LAST
+} uct_gdr_copy_pin_mode_t;
+
+
 /**
  * @brief gdr_copy MD descriptor
  */
 typedef struct {
-    uct_md_t            super;      /**< Domain info */
-    gdr_t               gdrcpy_ctx; /**< gdr copy context */
-    ucs_linear_func_t   reg_cost;   /**< Memory registration cost */
-    ucs_rcache_t        *rcache;    /**< Registration cache */
+    uct_md_t                super;      /**< Domain info */
+    gdr_t                   gdrcpy_ctx; /**< gdr copy context */
+    ucs_linear_func_t       reg_cost;   /**< Memory registration cost */
+    ucs_rcache_t            *rcache;    /**< Registration cache */
+    uct_gdr_copy_pin_mode_t pin_mode;   /**< see PIN_MODE; converted at gdr_pin_buffer_v2 */
 } uct_gdr_copy_md_t;
 
 
@@ -28,12 +37,13 @@ typedef struct {
  * gdr copy domain configuration.
  */
 typedef struct uct_gdr_copy_md_config {
-    uct_md_config_t     super;
-    int                 shared;        /**< Shared MD instance */
-    int                 enable_rcache; /**< Enable registration cache */
-    ucs_linear_func_t   uc_reg_cost;   /**< Memory registration cost estimation
-                                            without using the cache */
-    ucs_rcache_config_t rcache_config; /**< Registration cache configuration */
+    uct_md_config_t         super;
+    int                     shared;        /**< Shared MD instance */
+    int                     enable_rcache; /**< Enable registration cache */
+    ucs_linear_func_t       uc_reg_cost;   /**< Memory registration cost estimation
+                                                without using the cache */
+    ucs_rcache_config_t     rcache_config; /**< Registration cache configuration */
+    uct_gdr_copy_pin_mode_t pin_mode;      /**< default or pcie mapping preference; see PIN_MODE */
 } uct_gdr_copy_md_config_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -13,15 +13,6 @@
 extern uct_component_t uct_gdr_copy_component;
 
 
-/** Pin mode for GDRCopy GPU memory registration (default vs PCIe-based mapping). */
-typedef enum uct_gdr_copy_pin_mode {
-    UCT_GDR_COPY_PIN_MODE_DEFAULT  = 0,
-    UCT_GDR_COPY_PIN_MODE_PCIE     = 1,
-    UCT_GDR_COPY_PIN_MODE_TRY_PCIE = 2,
-    UCT_GDR_COPY_PIN_MODE_LAST
-} uct_gdr_copy_pin_mode_t;
-
-
 /**
  * @brief gdr_copy MD descriptor
  */
@@ -44,8 +35,8 @@ typedef struct uct_gdr_copy_md_config {
     int                     enable_rcache; /**< Enable registration cache */
     ucs_linear_func_t       uc_reg_cost;   /**< Memory registration cost estimation
                                                 without using the cache */
-    ucs_rcache_config_t     rcache_config; /**< Registration cache configuration */
-    uct_gdr_copy_pin_mode_t pin_mode;      /**< default, pcie, or try_pcie; see PIN_MODE */
+    ucs_rcache_config_t          rcache_config; /**< Registration cache configuration */
+    ucs_ternary_auto_value_t   use_pcie;        /**< UCS_CONFIG_TYPE_TERNARY_AUTO; see USE_PCIE */
 } uct_gdr_copy_md_config_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -15,8 +15,9 @@ extern uct_component_t uct_gdr_copy_component;
 
 /** Pin mode for GDRCopy GPU memory registration (default vs PCIe-based mapping). */
 typedef enum uct_gdr_copy_pin_mode {
-    UCT_GDR_COPY_PIN_MODE_DEFAULT = 0,
-    UCT_GDR_COPY_PIN_MODE_PCIE    = 1,
+    UCT_GDR_COPY_PIN_MODE_DEFAULT  = 0,
+    UCT_GDR_COPY_PIN_MODE_PCIE     = 1,
+    UCT_GDR_COPY_PIN_MODE_TRY_PCIE = 2,
     UCT_GDR_COPY_PIN_MODE_LAST
 } uct_gdr_copy_pin_mode_t;
 
@@ -25,11 +26,12 @@ typedef enum uct_gdr_copy_pin_mode {
  * @brief gdr_copy MD descriptor
  */
 typedef struct {
-    uct_md_t                super;      /**< Domain info */
-    gdr_t                   gdrcpy_ctx; /**< gdr copy context */
-    ucs_linear_func_t       reg_cost;   /**< Memory registration cost */
-    ucs_rcache_t            *rcache;    /**< Registration cache */
-    uct_gdr_copy_pin_mode_t pin_mode;   /**< see PIN_MODE; converted at gdr_pin_buffer_v2 */
+    uct_md_t          super;               /**< Domain info */
+    gdr_t             gdrcpy_ctx;        /**< gdr copy context */
+    ucs_linear_func_t reg_cost;          /**< Memory registration cost */
+    ucs_rcache_t      *rcache;           /**< Registration cache */
+    uint32_t          pin_gdr_flags;       /**< First gdr_pin_buffer_v2 flags (0 if v2 absent) */
+    int               pin_pcie_fallback; /**< If nonzero, retry pin with default flags on failure */
 } uct_gdr_copy_md_t;
 
 
@@ -43,7 +45,7 @@ typedef struct uct_gdr_copy_md_config {
     ucs_linear_func_t       uc_reg_cost;   /**< Memory registration cost estimation
                                                 without using the cache */
     ucs_rcache_config_t     rcache_config; /**< Registration cache configuration */
-    uct_gdr_copy_pin_mode_t pin_mode;      /**< default or pcie mapping preference; see PIN_MODE */
+    uct_gdr_copy_pin_mode_t pin_mode;      /**< default, pcie, or try_pcie; see PIN_MODE */
 } uct_gdr_copy_md_config_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -26,11 +26,11 @@ typedef enum uct_gdr_copy_pin_mode {
  * @brief gdr_copy MD descriptor
  */
 typedef struct {
-    uct_md_t          super;               /**< Domain info */
+    uct_md_t          super;             /**< Domain info */
     gdr_t             gdrcpy_ctx;        /**< gdr copy context */
     ucs_linear_func_t reg_cost;          /**< Memory registration cost */
     ucs_rcache_t      *rcache;           /**< Registration cache */
-    uint32_t          pin_gdr_flags;       /**< First gdr_pin_buffer_v2 flags (0 if v2 absent) */
+    uint32_t          pin_gdr_flags;     /**< First gdr_pin_buffer_v2 flags (0 if v2 absent) */
     int               pin_pcie_fallback; /**< If nonzero, retry pin with default flags on failure */
 } uct_gdr_copy_md_t;
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.h
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.h
@@ -30,13 +30,13 @@ typedef struct {
  * gdr copy domain configuration.
  */
 typedef struct uct_gdr_copy_md_config {
-    uct_md_config_t         super;
-    int                     shared;        /**< Shared MD instance */
-    int                     enable_rcache; /**< Enable registration cache */
-    ucs_linear_func_t       uc_reg_cost;   /**< Memory registration cost estimation
-                                                without using the cache */
-    ucs_rcache_config_t          rcache_config; /**< Registration cache configuration */
-    ucs_ternary_auto_value_t   use_pcie;        /**< UCS_CONFIG_TYPE_TERNARY_AUTO; see USE_PCIE */
+    uct_md_config_t          super;
+    int                      shared;        /**< Shared MD instance */
+    int                      enable_rcache; /**< Enable registration cache */
+    ucs_linear_func_t        uc_reg_cost;   /**< Memory registration cost estimation
+                                                 without using the cache */
+    ucs_rcache_config_t      rcache_config; /**< Registration cache configuration */
+    ucs_ternary_auto_value_t use_pcie;      /**< UCS_CONFIG_TYPE_TERNARY_AUTO; see USE_PCIE */
 } uct_gdr_copy_md_config_t;
 
 

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -221,6 +221,37 @@ void mem_buffer::get_bar1_free_size_nvml()
 #endif
 }
 
+bool mem_buffer::cuda_gpu_has_c2c(unsigned gpu_index)
+{
+#if HAVE_CUDA && HAVE_DECL_NVML_FI_DEV_C2C_LINK_COUNT
+    bool has_c2c;
+    nvmlDevice_t device;
+    nvmlFieldValue_t value = {0};
+
+    if (NVML_CALL(nvmlInit_v2()) != UCS_OK) {
+        return false;
+    }
+
+    if (NVML_CALL(nvmlDeviceGetHandleByIndex(gpu_index, &device)) != UCS_OK) {
+        NVML_CALL(nvmlShutdown());
+        return false;
+    }
+
+    value.fieldId = NVML_FI_DEV_C2C_LINK_COUNT;
+    if (NVML_CALL(nvmlDeviceGetFieldValues(device, 1, &value)) != UCS_OK) {
+        NVML_CALL(nvmlShutdown());
+        return false;
+    }
+
+    has_c2c = (value.nvmlReturn == NVML_SUCCESS) && (value.value.uiVal > 0);
+    NVML_CALL(nvmlShutdown());
+    return has_c2c;
+#else
+    (void)gpu_index;
+    return false;
+#endif
+}
+
 void *mem_buffer::allocate(size_t size, ucs_memory_type_t mem_type, bool async)
 {
     void *ptr;

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -97,6 +97,9 @@ public:
     /* Get from NVML BAR1 free size */
     static void get_bar1_free_size_nvml();
 
+    /* NVML NVLink-C2C link count > 0 for CUDA device */
+    static bool cuda_gpu_has_c2c(unsigned gpu_index = 0);
+
     /* Return free memory on the BAR1 / GPU. If GPU is not used
      * SIZE_MAX is returned */
     static size_t get_bar1_free_size()

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -1277,7 +1277,7 @@ protected:
 };
 
 UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_default_pin,
-                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_PIN_MODE?=default")
+                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_USE_PCIE?=auto")
 {
     ASSERT_UCS_OK(register_mem());
 }
@@ -1285,7 +1285,7 @@ UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_default_pin,
 UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin,
                      !mem_buffer::cuda_gpu_has_c2c() ||
                              !check_caps(UCT_MD_FLAG_REG),
-                     "GDR_COPY_PIN_MODE?=pcie")
+                     "GDR_COPY_USE_PCIE?=yes")
 {
     ASSERT_UCS_OK(register_mem());
 }
@@ -1293,14 +1293,14 @@ UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin,
 UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin_fail,
                      mem_buffer::cuda_gpu_has_c2c() ||
                              !check_caps(UCT_MD_FLAG_REG),
-                     "GDR_COPY_PIN_MODE?=pcie")
+                     "GDR_COPY_USE_PCIE?=yes")
 {
     scoped_log_handler slh(wrap_errors_logger);
     ASSERT_UCS_STATUS_EQ(UCS_ERR_IO_ERROR, register_mem());
 }
 
 UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_try_pcie_pin,
-                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_PIN_MODE=try_pcie")
+                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_USE_PCIE=try")
 {
     ASSERT_UCS_OK(register_mem());
 }

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -1257,30 +1257,54 @@ UCT_MD_INSTANTIATE_TEST_CASE(test_cuda)
 #if HAVE_DECL_GDR_PIN_BUFFER_V2
 
 class test_gdr_copy : public test_md {
+protected:
+    ucs_status_t register_mem()
+    {
+        constexpr size_t size = 65536;
+        void *address         = NULL;
+        uct_mem_h memh;
+        ucs_status_t status;
+
+        alloc_memory(&address, size, NULL, UCS_MEMORY_TYPE_CUDA);
+        status = reg_mem(UCT_MD_MEM_ACCESS_ALL, address, size, &memh);
+        if (status == UCS_OK) {
+            (void)uct_md_mem_dereg(md(), memh);
+        }
+
+        free_memory(address, UCS_MEMORY_TYPE_CUDA);
+        return status;
+    }
 };
 
-UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin,
-                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_PIN_MODE?=pcie")
+UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_default_pin,
+                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_PIN_MODE?=default")
 {
-    constexpr size_t size = 65536;
-    void *address         = NULL;
-    uct_mem_h memh;
-    ucs_status_t status;
+    ASSERT_UCS_OK(register_mem());
+}
 
-    if (!mem_buffer::cuda_gpu_has_c2c()) {
-        UCS_TEST_SKIP_R("Cannot find C2C on the system");
-    }
+UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin,
+                     !mem_buffer::cuda_gpu_has_c2c() ||
+                             !check_caps(UCT_MD_FLAG_REG),
+                     "GDR_COPY_PIN_MODE?=pcie")
+{
+    ASSERT_UCS_OK(register_mem());
+}
 
-    alloc_memory(&address, size, NULL, UCS_MEMORY_TYPE_CUDA);
+UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin_fail,
+                     mem_buffer::cuda_gpu_has_c2c() ||
+                             !check_caps(UCT_MD_FLAG_REG),
+                     "GDR_COPY_PIN_MODE?=pcie")
+{
+    scoped_log_handler slh(wrap_errors_logger);
+    ASSERT_UCS_STATUS_EQ(UCS_ERR_IO_ERROR, register_mem());
+}
 
-    status = reg_mem(UCT_MD_MEM_ACCESS_ALL, address, size, &memh);
-    ASSERT_UCS_OK(status);
-
-    status = uct_md_mem_dereg(md(), memh);
-    ASSERT_UCS_OK(status);
-
-    free_memory(address, UCS_MEMORY_TYPE_CUDA);
+UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_try_pcie_pin,
+                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_PIN_MODE=try_pcie")
+{
+    ASSERT_UCS_OK(register_mem());
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_gdr_copy, gdr_copy)
+
 #endif /* HAVE_DECL_GDR_PIN_BUFFER_V2 */

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -4,6 +4,10 @@
 * See file LICENSE for terms.
 */
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "test_md.h"
 
 #include <common/mem_buffer.h>
@@ -1249,3 +1253,34 @@ UCS_TEST_P(test_cuda, sparse_regions)
 }
 
 UCT_MD_INSTANTIATE_TEST_CASE(test_cuda)
+
+#if HAVE_DECL_GDR_PIN_BUFFER_V2
+
+class test_gdr_copy : public test_md {
+};
+
+UCS_TEST_SKIP_COND_P(test_gdr_copy, gdr_copy_reg_cuda_pcie_pin,
+                     !check_caps(UCT_MD_FLAG_REG), "GDR_COPY_PIN_MODE?=pcie")
+{
+    constexpr size_t size = 65536;
+    void *address         = NULL;
+    uct_mem_h memh;
+    ucs_status_t status;
+
+    if (!mem_buffer::cuda_gpu_has_c2c()) {
+        UCS_TEST_SKIP_R("Cannot find C2C on the system");
+    }
+
+    alloc_memory(&address, size, NULL, UCS_MEMORY_TYPE_CUDA);
+
+    status = reg_mem(UCT_MD_MEM_ACCESS_ALL, address, size, &memh);
+    ASSERT_UCS_OK(status);
+
+    status = uct_md_mem_dereg(md(), memh);
+    ASSERT_UCS_OK(status);
+
+    free_memory(address, UCS_MEMORY_TYPE_CUDA);
+}
+
+_UCT_MD_INSTANTIATE_TEST_CASE(test_gdr_copy, gdr_copy)
+#endif /* HAVE_DECL_GDR_PIN_BUFFER_V2 */


### PR DESCRIPTION
## What?
Add option to export to PCIe BAR1.

## How
Call `gdr_pin_buffer_v2(, flag=1, ..)` made, confirmed functional with OSU latency benchmark.