### PR TITLE
UCT/PLUGIN: add definition in uct_iface_attr_v2_t for uct_iface_query_v2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Elad Persiko <eladpe@mellanox.com>
 Eugene Voronov <eugene@mellanox.com>
 Evgeny Leksikov <evgenylek@mellanox.com>
 Fabian Ruhland <ruhland@hhu.de>
+Fei Teng <fteng@nvidia.com>
 Gilbert Lee <gilbert.lee@amd.com>
 Gilles Gouaillardet <gilles.gouaillardet@gmail.com>
 Gonzalo Brito Gadeschi <gonzalob@nvidia.com>

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1140,19 +1140,19 @@ typedef struct {
      * Plugin-contributed capability flags (bitmask of UCT_IFACE_FLAG_*).
      * Valid when @ref UCT_IFACE_ATTR_FIELD_FLAGS is set.
      */
-    uint64_t    flags;
+    uint64_t   flags;
 
     /**
      * Length in bytes of the opaque TX token.
      * Valid when @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH is set.
      */
-    size_t      tx_token_length;
+    size_t     tx_token_length;
 
     /**
      * Length in bytes of the opaque RX token.
      * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH is set.
      */
-    size_t      rx_token_length;
+    size_t     rx_token_length;
 
     /**
      * TX token input buffer.
@@ -1161,7 +1161,7 @@ typedef struct {
      * the TX token received from the sender.
      * @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN must be set together.
      */
-    const void  *tx_token;
+    const void *tx_token;
 
     /**
      * RX token output buffer.
@@ -1170,7 +1170,7 @@ typedef struct {
      * bytes; callee fills it with RX token.
      * @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN must be set together.
      */
-    void        *rx_token;
+    void       *rx_token;
 } uct_iface_attr_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1067,14 +1067,11 @@ enum uct_iface_attr_field {
     /** Enables @ref uct_iface_attr_v2_t::cap */
     UCT_IFACE_ATTR_FIELD_CAP_FLAGS               = UCS_BIT(1),
 
-    /** Enables @ref uct_iface_attr_v2_t::flags. */
-    UCT_IFACE_ATTR_FIELD_FLAGS                   = UCS_BIT(2),
-
     /** Enables @ref uct_iface_attr_v2_t::tx_token_length. */
-    UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH         = UCS_BIT(3),
+    UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH         = UCS_BIT(2),
 
     /** Enables @ref uct_iface_attr_v2_t::rx_token_length. */
-    UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH         = UCS_BIT(4),
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH         = UCS_BIT(3),
 
     /**
      * Enables the RX token derivation path.
@@ -1082,7 +1079,7 @@ enum uct_iface_attr_field {
      * When both set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
      * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
      */
-    UCT_IFACE_ATTR_FIELD_TX_TOKEN                = UCS_BIT(5),
+    UCT_IFACE_ATTR_FIELD_TX_TOKEN                = UCS_BIT(4),
 
     /**
      * Enables the RX token derivation path.
@@ -1090,7 +1087,7 @@ enum uct_iface_attr_field {
      * when both set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
      * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
      */
-    UCT_IFACE_ATTR_FIELD_RX_TOKEN                = UCS_BIT(6)
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN                = UCS_BIT(5)
 };
 
 
@@ -1133,12 +1130,6 @@ typedef struct {
     struct {
         uint64_t flags; /**< Flags from @ref UCT_RESOURCE_IFACE_CAP_V2 */
     } cap;
-
-    /**
-     * UCT interface v2 flags (bitmask of UCT_IFACE_ATTR_FIELD_*).
-     * Valid when @ref UCT_IFACE_ATTR_FIELD_FLAGS is set.
-     */
-    uint64_t   flags;
 
     /**
      * Length in bytes of the opaque TX token.

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1061,7 +1061,6 @@ typedef enum {
  * are present, for backward compatibility support.
  */
 enum uct_iface_attr_field {
-<<<<<<< HEAD
     /** Enables @ref uct_iface_attr_v2_t::max_put_sgl_zcopy_count */
     UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT = UCS_BIT(0),
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -425,15 +425,15 @@ struct uct_ep_attr {
      * Caller allocates a buffer of @ref uct_iface_attr_v2_t::tx_token_length
      * bytes and sets this pointer; callee fills the buffer with the token.
      */
-     void                    *tx_token;
+    void                    *tx_token;
 
-     /**
-      * Opaque RX token buffer.
-      * Valid when @ref UCT_EP_ATTR_FIELD_RX_TOKEN is set in @ref field_mask.
-      * Caller allocates a buffer of @ref uct_iface_attr_v2_t::rx_token_length
-      * bytes and sets this pointer; callee fills the buffer with the token.
-      */
-     void                    *rx_token;
+    /**
+     * Opaque RX token buffer.
+     * Valid when @ref UCT_EP_ATTR_FIELD_RX_TOKEN is set in @ref field_mask.
+     * Caller allocates a buffer of @ref uct_iface_attr_v2_t::rx_token_length
+     * bytes and sets this pointer; callee fills the buffer with the token.
+     */
+    void                    *rx_token;
 };
 
 
@@ -1074,16 +1074,25 @@ enum uct_iface_attr_field {
 
     /** Enables @ref uct_iface_attr_v2_t::tx_token_length (output). */
     UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH = UCS_BIT(3),
- 
+
     /** Enables @ref uct_iface_attr_v2_t::rx_token_length (output). */
     UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH = UCS_BIT(4),
- 
+
     /**
      * Enables the RX token derivation path.
-     * When set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
+     * Need to be set together with @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN
+     * When both set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
      * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
      */
-    UCT_IFACE_ATTR_FIELD_RX_TOKEN        = UCS_BIT(5)
+    UCT_IFACE_ATTR_FIELD_TX_TOKEN        = UCS_BIT(5),
+
+    /**
+     * Enables the RX token derivation path.
+     * Need to be set together with @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN,
+     * when both set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
+     * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
+     */
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN        = UCS_BIT(6)
 };
 
 
@@ -1131,35 +1140,37 @@ typedef struct {
      * Plugin-contributed capability flags (bitmask of UCT_IFACE_FLAG_*).
      * Valid when @ref UCT_IFACE_ATTR_FIELD_FLAGS is set.
      */
-    uint64_t   flags;
- 
+    uint64_t    flags;
+
     /**
      * Length in bytes of the opaque TX token.
      * Valid when @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH is set.
      */
-    size_t     tx_token_length;
- 
+    size_t      tx_token_length;
+
     /**
      * Length in bytes of the opaque RX token.
      * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH is set.
      */
-    size_t     rx_token_length;
- 
+    size_t      rx_token_length;
+
     /**
      * TX token input buffer.
-     * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN is set.
+     * Valid when @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN is set.
      * Caller sets this to a buffer of @ref tx_token_length bytes containing
      * the TX token received from the sender.
+     * @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN must be set together.
      */
-    const void *tx_token;
- 
+    const void  *tx_token;
+
     /**
      * RX token output buffer.
      * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN is set.
      * Caller sets this to a pre-allocated buffer of @ref rx_token_length
      * bytes; callee fills it with RX token.
+     * @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN must be set together.
      */
-    void       *rx_token;
+    void        *rx_token;
 } uct_iface_attr_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -273,7 +273,11 @@ enum uct_ep_attr_field {
     /** Enables @ref uct_ep_attr::local_address */
     UCT_EP_ATTR_FIELD_LOCAL_SOCKADDR  = UCS_BIT(0),
     /** Enables @ref uct_ep_attr::remote_address */
-    UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(1)
+    UCT_EP_ATTR_FIELD_REMOTE_SOCKADDR = UCS_BIT(1),
+    /** Enables @ref uct_ep_attr::tx_token */
+    UCT_EP_ATTR_FIELD_TX_TOKEN        = UCS_BIT(2),
+    /** Enables @ref uct_ep_attr::rx_token */
+    UCT_EP_ATTR_FIELD_RX_TOKEN        = UCS_BIT(3)
 };
 
 
@@ -414,6 +418,22 @@ struct uct_ep_attr {
      * Remote sockaddr the endpoint is connected to.
      */
     struct sockaddr_storage remote_address;
+
+    /**
+     * Opaque TX token buffer.
+     * Valid when @ref UCT_EP_ATTR_FIELD_TX_TOKEN is set in @ref field_mask.
+     * Caller allocates a buffer of @ref uct_iface_attr_v2_t::tx_token_length
+     * bytes and sets this pointer; callee fills the buffer with the token.
+     */
+     void                    *tx_token;
+
+     /**
+      * Opaque RX token buffer.
+      * Valid when @ref UCT_EP_ATTR_FIELD_RX_TOKEN is set in @ref field_mask.
+      * Caller allocates a buffer of @ref uct_iface_attr_v2_t::rx_token_length
+      * bytes and sets this pointer; callee fills the buffer with the token.
+      */
+     void                    *rx_token;
 };
 
 
@@ -1035,14 +1055,35 @@ typedef enum {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface attribute fields.
+ * @brief UCT interface v2 attributes field mask.
+ *
+ * The enumeration allows specifying which fields in @ref uct_iface_attr_v2_t
+ * are present, for backward compatibility support.
  */
 enum uct_iface_attr_field {
     /** Enables @ref uct_iface_attr_v2_t::max_put_sgl_zcopy_count */
     UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT = UCS_BIT(0),
 
     /** Enables @ref uct_iface_attr_v2_t::cap */
-    UCT_IFACE_ATTR_FIELD_CAP_FLAGS               = UCS_BIT(1)
+    UCT_IFACE_ATTR_FIELD_CAP_FLAGS               = UCS_BIT(1),
+
+    /** Enables @ref uct_iface_attr_v2_t::flags (output).
+     *  Returns plugin-contributed capability flags.
+     */
+    UCT_IFACE_ATTR_FIELD_FLAGS           = UCS_BIT(2),
+
+    /** Enables @ref uct_iface_attr_v2_t::tx_token_length (output). */
+    UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH = UCS_BIT(3),
+ 
+    /** Enables @ref uct_iface_attr_v2_t::rx_token_length (output). */
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH = UCS_BIT(4),
+ 
+    /**
+     * Enables the RX token derivation path.
+     * When set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
+     * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
+     */
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN        = UCS_BIT(5)
 };
 
 
@@ -1066,12 +1107,12 @@ enum uct_iface_attr_field {
 
 /**
  * @ingroup UCT_RESOURCE
- * @brief Interface attributes, used by @ref uct_iface_query_v2.
+ * @brief UCT interface v2 attributes, used by @ref uct_iface_query_v2.
  */
 typedef struct {
     /**
      * Mask of valid fields in this structure, using bits from
-     * @ref uct_iface_attr_field_t.
+     * @ref uct_iface_attr_field.
      */
     uint64_t field_mask;
 
@@ -1085,6 +1126,40 @@ typedef struct {
     struct {
         uint64_t flags; /**< Flags from @ref UCT_RESOURCE_IFACE_CAP_V2 */
     } cap;
+
+    /**
+     * Plugin-contributed capability flags (bitmask of UCT_IFACE_FLAG_*).
+     * Valid when @ref UCT_IFACE_ATTR_FIELD_FLAGS is set.
+     */
+    uint64_t   flags;
+ 
+    /**
+     * Length in bytes of the opaque TX token.
+     * Valid when @ref UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH is set.
+     */
+    size_t     tx_token_length;
+ 
+    /**
+     * Length in bytes of the opaque RX token.
+     * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH is set.
+     */
+    size_t     rx_token_length;
+ 
+    /**
+     * TX token input buffer.
+     * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN is set.
+     * Caller sets this to a buffer of @ref tx_token_length bytes containing
+     * the TX token received from the sender.
+     */
+    const void *tx_token;
+ 
+    /**
+     * RX token output buffer.
+     * Valid when @ref UCT_IFACE_ATTR_FIELD_RX_TOKEN is set.
+     * Caller sets this to a pre-allocated buffer of @ref rx_token_length
+     * bytes; callee fills it with RX token.
+     */
+    void       *rx_token;
 } uct_iface_attr_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1061,21 +1061,20 @@ typedef enum {
  * are present, for backward compatibility support.
  */
 enum uct_iface_attr_field {
+<<<<<<< HEAD
     /** Enables @ref uct_iface_attr_v2_t::max_put_sgl_zcopy_count */
     UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT = UCS_BIT(0),
 
     /** Enables @ref uct_iface_attr_v2_t::cap */
     UCT_IFACE_ATTR_FIELD_CAP_FLAGS               = UCS_BIT(1),
 
-    /** Enables @ref uct_iface_attr_v2_t::flags (output).
-     *  Returns plugin-contributed capability flags.
-     */
+    /** Enables @ref uct_iface_attr_v2_t::flags. */
     UCT_IFACE_ATTR_FIELD_FLAGS           = UCS_BIT(2),
 
-    /** Enables @ref uct_iface_attr_v2_t::tx_token_length (output). */
+    /** Enables @ref uct_iface_attr_v2_t::tx_token_length. */
     UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH = UCS_BIT(3),
 
-    /** Enables @ref uct_iface_attr_v2_t::rx_token_length (output). */
+    /** Enables @ref uct_iface_attr_v2_t::rx_token_length. */
     UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH = UCS_BIT(4),
 
     /**

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1137,7 +1137,7 @@ typedef struct {
     } cap;
 
     /**
-     * Plugin-contributed capability flags (bitmask of UCT_IFACE_FLAG_*).
+     * UCT interface v2 flags (bitmask of UCT_IFACE_ATTR_FIELD_*).
      * Valid when @ref UCT_IFACE_ATTR_FIELD_FLAGS is set.
      */
     uint64_t   flags;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1068,13 +1068,13 @@ enum uct_iface_attr_field {
     UCT_IFACE_ATTR_FIELD_CAP_FLAGS               = UCS_BIT(1),
 
     /** Enables @ref uct_iface_attr_v2_t::flags. */
-    UCT_IFACE_ATTR_FIELD_FLAGS           = UCS_BIT(2),
+    UCT_IFACE_ATTR_FIELD_FLAGS                   = UCS_BIT(2),
 
     /** Enables @ref uct_iface_attr_v2_t::tx_token_length. */
-    UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH = UCS_BIT(3),
+    UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH         = UCS_BIT(3),
 
     /** Enables @ref uct_iface_attr_v2_t::rx_token_length. */
-    UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH = UCS_BIT(4),
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH         = UCS_BIT(4),
 
     /**
      * Enables the RX token derivation path.
@@ -1082,7 +1082,7 @@ enum uct_iface_attr_field {
      * When both set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
      * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
      */
-    UCT_IFACE_ATTR_FIELD_TX_TOKEN        = UCS_BIT(5),
+    UCT_IFACE_ATTR_FIELD_TX_TOKEN                = UCS_BIT(5),
 
     /**
      * Enables the RX token derivation path.
@@ -1090,7 +1090,7 @@ enum uct_iface_attr_field {
      * when both set, @ref uct_iface_attr_v2_t::tx_token is input (from sender),
      * and @ref uct_iface_attr_v2_t::rx_token is output (derived by receiver).
      */
-    UCT_IFACE_ATTR_FIELD_RX_TOKEN        = UCS_BIT(6)
+    UCT_IFACE_ATTR_FIELD_RX_TOKEN                = UCS_BIT(6)
 };
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -573,12 +573,32 @@ ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
 ucs_status_t
 uct_iface_base_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
 {
+    uint64_t tx_token_mask = iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_TX_TOKEN;
+    uint64_t rx_token_mask = iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_RX_TOKEN;
+    int token_pair_set = 0;
+    if (tx_token_mask ^ rx_token_mask) {
+        ucs_error("invalid field_mask: TX/RX token fields must be set together");
+        return UCS_ERR_INVALID_PARAM;
+    } else if (tx_token_mask && rx_token_mask) {
+        iface_attr->tx_token_length = 0;
+        iface_attr->rx_token_length = 0;
+        token_pair_set = 1;
+    }
+
     if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
         iface_attr->cap.flags = 0;
     }
 
     if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
         iface_attr->max_put_sgl_zcopy_count = 0;
+    }
+
+    if (!token_pair_set && iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH) {
+        iface_attr->tx_token_length = 0;
+    }
+
+    if (!token_pair_set && iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_RX_TOKEN_LENGTH) {
+        iface_attr->rx_token_length = 0;
     }
 
     return UCS_OK;


### PR DESCRIPTION
## What?
_add definition in uct_iface_attr_v2_t for uct_iface_query_v2._

## Why?
_The definition is used for following interface implementation. This PR is seperated from [PR #11277](https://github.com/openucx/ucx/pull/11277)_
