### PR TITLE
UCP/CORE: Detect memory type on cache miss with non-host detect MDs

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1767,6 +1767,10 @@ ucp_add_component_resources(ucp_context_h context, ucp_rsc_index_t cmpt_index,
             ++context->num_mem_type_detect_mds;
         }
 
+        if (md_attr->detect_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST)) {
+            context->has_non_host_detect_md = 1;
+        }
+
         detect_mem_type_mask |= md_attr->detect_mem_types;
         alloc_mem_type_mask  |= md_attr->alloc_mem_types;
 
@@ -1955,6 +1959,7 @@ static ucs_status_t ucp_fill_resources(ucp_context_h context,
     context->num_tls                  = 0;
     context->supported_mem_type_mask  = 0;
     context->num_mem_type_detect_mds  = 0;
+    context->has_non_host_detect_md   = 0;
     context->export_md_map            = 0;
 
     ucs_memory_type_for_each(mem_type) {

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -388,6 +388,7 @@ typedef struct ucp_context {
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */
+    uint8_t                       has_non_host_detect_md;  /* Any detect MD supports non-host memory types */
 
     /* Map of dmabuf providers per memory type. Each entry in the array is
        either the index of the provider MD, or UCP_NULL_RESOURCE if no such MD
@@ -683,6 +684,14 @@ ucp_memory_detect_internal(ucp_context_h context, const void *address,
 
     status = ucs_memtype_cache_lookup(address, length, mem_info);
     if (ucs_likely(status == UCS_ERR_NO_ELEM)) {
+        if (context->has_non_host_detect_md) {
+            ucs_trace_req("address %p length %zu: not found in memtype cache, "
+                          "running slowpath for non-host capable context",
+                          address, length);
+            ucp_memory_detect_slowpath(context, address, length, mem_info);
+            return;
+        }
+
         ucs_trace_req("address %p length %zu: not found in memtype cache, "
                       "assuming host memory",
                       address, length);


### PR DESCRIPTION
## What?
- On memtype cache miss, avoid assuming host memory when detect‑capable MDs supporting non-host memory types are present.
- Add a context-level flag indicating whether any detect-capable MD supports non-host memory types.
- Use this flag to choose cache-miss behavior: run slowpath detection or fall back to host memory.

## Why?
- External runtimes may allocate accelerator memory outside UCX-visible contexts, resulting in missing memtype cache entries.
- Falling back to host memory on cache miss can select host-only transports for accelerator pointers, leading to incorrect behavior or runtime failures.
- Running slowpath detection when non-host detection is possible prevents wrong transport and protocol selection.

## How?
- Set the new context flag during resource discovery when any MD advertises non-host detect support.
- On memtype cache miss, invoke slowpath detection when the flag is set.
- Slowpath queries detect-capable MDs to resolve memory type and sys_dev before transport and protocol selection.
