### PR TITLE
UCT/API/V2: Introduce iface_query_v2

### DIFF
--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -181,7 +181,6 @@ UCS_CLASS_INIT_FUNC(ucp_proxy_ep_t, const uct_iface_ops_t *ops, ucp_ep_h ucp_ep,
     self->iface.super.ops.iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucp_proxy_ep_fatal;
     self->iface.super.ops.iface_event_arm          = (uct_iface_event_arm_func_t)ucp_proxy_ep_fatal;
     self->iface.super.ops.iface_close              = (uct_iface_close_func_t)ucp_proxy_ep_fatal;
-    self->iface.super.ops.iface_query              = (uct_iface_query_func_t)ucp_proxy_ep_fatal;
     self->iface.super.ops.iface_get_device_address = (uct_iface_get_device_address_func_t)ucp_proxy_ep_fatal;
     self->iface.super.ops.iface_get_address        = (uct_iface_get_address_func_t)ucp_proxy_ep_fatal;
     self->iface.super.ops.iface_is_reachable       = (uct_iface_is_reachable_func_t)ucp_proxy_ep_fatal;

--- a/src/uct/api/tl.h
+++ b/src/uct/api/tl.h
@@ -271,9 +271,6 @@ typedef ucs_status_t (*uct_iface_event_arm_func_t)(uct_iface_h iface,
 
 typedef void         (*uct_iface_close_func_t)(uct_iface_h iface);
 
-typedef ucs_status_t (*uct_iface_query_func_t)(uct_iface_h iface,
-                                               uct_iface_attr_t *iface_attr);
-
 /* interface - connection establishment */
 
 typedef ucs_status_t (*uct_iface_get_device_address_func_t)(uct_iface_h iface,
@@ -365,7 +362,6 @@ typedef struct uct_iface_ops {
 
     /* interface - management */
     uct_iface_close_func_t              iface_close;
-    uct_iface_query_func_t              iface_query;
 
     /* interface - connection establishment */
     uct_iface_get_device_address_func_t iface_get_device_address;

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1036,16 +1036,55 @@ typedef enum {
 /**
  * @ingroup UCT_RESOURCE
  * @brief Interface attribute fields.
+ *
+ * The enumeration allows specifying which fields in @ref uct_iface_attr_v2_t
+ * are present.
  */
-enum uct_iface_attr_field {
-    /* Reserved for future use */
-    UCT_IFACE_ATTR_FIELD_RESERVED = 0
-};
+typedef enum uct_iface_attr_field {
+    /** Enables @ref uct_iface_attr_v2_t::cap */
+    UCT_IFACE_ATTR_FIELD_CAP           = UCS_BIT(0),
+
+    /** Enables @ref uct_iface_attr_v2_t::device_addr_len */
+    UCT_IFACE_ATTR_FIELD_DEVICE_ADDR   = UCS_BIT(1),
+
+    /** Enables @ref uct_iface_attr_v2_t::iface_addr_len */
+    UCT_IFACE_ATTR_FIELD_IFACE_ADDR    = UCS_BIT(2),
+
+    /** Enables @ref uct_iface_attr_v2_t::ep_addr_len */
+    UCT_IFACE_ATTR_FIELD_EP_ADDR       = UCS_BIT(3),
+
+    /** Enables @ref uct_iface_attr_v2_t::max_conn_priv */
+    UCT_IFACE_ATTR_FIELD_MAX_CONN_PRIV = UCS_BIT(4),
+
+    /** Enables @ref uct_iface_attr_v2_t::listen_sockaddr */
+    UCT_IFACE_ATTR_FIELD_SOCKADDR      = UCS_BIT(5),
+
+    /** Enables @ref uct_iface_attr_v2_t::overhead */
+    UCT_IFACE_ATTR_FIELD_OVERHEAD      = UCS_BIT(6),
+
+    /** Enables @ref uct_iface_attr_v2_t::bandwidth */
+    UCT_IFACE_ATTR_FIELD_BANDWIDTH     = UCS_BIT(7),
+
+    /** Enables @ref uct_iface_attr_v2_t::latency */
+    UCT_IFACE_ATTR_FIELD_LATENCY       = UCS_BIT(8),
+
+    /** Enables @ref uct_iface_attr_v2_t::priority */
+    UCT_IFACE_ATTR_FIELD_PRIORITY      = UCS_BIT(9),
+
+    /** Enables @ref uct_iface_attr_v2_t::max_num_eps */
+    UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS   = UCS_BIT(10),
+
+    /** Enables @ref uct_iface_attr_v2_t::dev_num_paths */
+    UCT_IFACE_ATTR_FIELD_DEV_NUM_PATHS = UCS_BIT(11)
+} uct_iface_attr_field_t;
 
 
 /**
  * @ingroup UCT_RESOURCE
  * @brief Interface attributes, used by @ref uct_iface_query_v2.
+ *
+ * This structure defines the attributes of a transport interface which include
+ * its capabilities, performance characteristics, and addressing information.
  */
 typedef struct {
     /**
@@ -1053,6 +1092,81 @@ typedef struct {
      * @ref uct_iface_attr_field_t.
      */
     uint64_t field_mask;
+
+    struct {
+        struct {
+            size_t          max_short;
+            size_t          max_bcopy;
+            size_t          min_zcopy;
+            size_t          max_zcopy;
+            size_t          opt_zcopy_align;
+            size_t          align_mtu;
+            size_t          max_iov;
+        } put;
+
+        struct {
+            size_t          max_short;
+            size_t          max_bcopy;
+            size_t          min_zcopy;
+            size_t          max_zcopy;
+            size_t          opt_zcopy_align;
+            size_t          align_mtu;
+            size_t          max_iov;
+        } get;
+
+        struct {
+            size_t          max_short;
+            size_t          max_bcopy;
+            size_t          min_zcopy;
+            size_t          max_zcopy;
+            size_t          opt_zcopy_align;
+            size_t          align_mtu;
+            size_t          max_hdr;
+            size_t          max_iov;
+        } am;
+
+        struct {
+            struct {
+                size_t      min_recv;
+                size_t      max_zcopy;
+                size_t      max_iov;
+                size_t      max_outstanding;
+            } recv;
+
+            struct {
+                  size_t    max_short;
+                  size_t    max_bcopy;
+                  size_t    max_zcopy;
+                  size_t    max_iov;
+            } eager;
+
+            struct {
+                  size_t    max_zcopy;
+                  size_t    max_hdr;
+                  size_t    max_iov;
+            } rndv;
+        } tag;
+
+        struct {
+            uint64_t        op_flags;
+            uint64_t        fop_flags;
+        } atomic32, atomic64;
+
+        uint64_t            flags;
+        uint64_t            event_flags;
+    } cap;
+
+    size_t                  device_addr_len;
+    size_t                  iface_addr_len;
+    size_t                  ep_addr_len;
+    size_t                  max_conn_priv;
+    struct sockaddr_storage listen_sockaddr;
+    double                  overhead;
+    uct_ppn_bandwidth_t     bandwidth;
+    ucs_linear_func_t       latency;
+    uint8_t                 priority;
+    size_t                  max_num_eps;
+    unsigned                dev_num_paths;
 } uct_iface_attr_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1083,7 +1083,7 @@ typedef enum uct_iface_attr_field {
  * @ingroup UCT_RESOURCE
  * @brief Interface attributes, used by @ref uct_iface_query_v2.
  *
- * This structure defines the attributes of a transport interface which include
+ * This structure defines the attributes of a transport interface including
  * its capabilities, performance characteristics, and addressing information.
  */
 typedef struct {

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -23,6 +23,22 @@
 #include <ucs/vfs/base/vfs_obj.h>
 
 
+#define UCT_IFACE_ATTR_V2_FIELD_COPY(_dst, _src, _field, _flag) \
+    { \
+        if ((_dst)->field_mask & (_flag)) { \
+            ucs_assert((_src)->field_mask & (_flag)); \
+            memcpy(&((_dst)->_field), &((_src)->_field), \
+                   sizeof((_src)->_field)); \
+        } \
+    }
+
+#define UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(_v1, _v2, _field, _flag) \
+    do { \
+        ucs_assert((_v2)->field_mask & (_flag)); \
+        (_v1)->_field = (_v2)->_field; \
+    } while (0)
+
+
 const char *uct_ep_operation_names[] = {
     [UCT_EP_OP_AM_SHORT]     = "am_short",
     [UCT_EP_OP_AM_BCOPY]     = "am_bcopy",
@@ -190,17 +206,190 @@ void uct_iface_set_async_event_params(const uct_iface_params_t *params,
 }
 
 
-ucs_status_t uct_iface_query(uct_iface_h iface, uct_iface_attr_t *iface_attr)
+static void
+uct_iface_attr_from_v2(uct_iface_attr_t *dst, const uct_iface_attr_v2_t *src)
 {
-    return iface->ops.iface_query(iface, iface_attr);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.max_short,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.max_bcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.min_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.max_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.opt_zcopy_align,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.align_mtu,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.put.max_iov,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.max_short,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.max_bcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.min_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.max_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.opt_zcopy_align,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.align_mtu,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.get.max_iov,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.max_short,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.max_bcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.min_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.max_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.opt_zcopy_align,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.align_mtu,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.max_hdr,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.am.max_iov,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.recv.min_recv,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.recv.max_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.recv.max_iov,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src,
+                                        cap.tag.recv.max_outstanding,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.eager.max_short,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.eager.max_bcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.eager.max_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.eager.max_iov,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.rndv.max_zcopy,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.rndv.max_hdr,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.tag.rndv.max_iov,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.atomic32.op_flags,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.atomic32.fop_flags,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.atomic64.op_flags,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.atomic64.fop_flags,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.flags,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, cap.event_flags,
+                                        UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, device_addr_len,
+                                        UCT_IFACE_ATTR_FIELD_DEVICE_ADDR);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, iface_addr_len,
+                                        UCT_IFACE_ATTR_FIELD_IFACE_ADDR);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, ep_addr_len,
+                                        UCT_IFACE_ATTR_FIELD_EP_ADDR);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, max_conn_priv,
+                                        UCT_IFACE_ATTR_FIELD_MAX_CONN_PRIV);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, listen_sockaddr,
+                                        UCT_IFACE_ATTR_FIELD_SOCKADDR);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, overhead,
+                                        UCT_IFACE_ATTR_FIELD_OVERHEAD);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, bandwidth,
+                                        UCT_IFACE_ATTR_FIELD_BANDWIDTH);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, latency,
+                                        UCT_IFACE_ATTR_FIELD_LATENCY);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, priority,
+                                        UCT_IFACE_ATTR_FIELD_PRIORITY);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, max_num_eps,
+                                        UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS);
+    UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(dst, src, dev_num_paths,
+                                        UCT_IFACE_ATTR_FIELD_DEV_NUM_PATHS);
+}
+
+static void
+uct_iface_attr_v2_copy(uct_iface_attr_v2_t *dst,
+                        const uct_iface_attr_v2_t *src)
+{
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, cap,
+                                 UCT_IFACE_ATTR_FIELD_CAP);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, device_addr_len,
+                                 UCT_IFACE_ATTR_FIELD_DEVICE_ADDR);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, iface_addr_len,
+                                 UCT_IFACE_ATTR_FIELD_IFACE_ADDR);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, ep_addr_len,
+                                 UCT_IFACE_ATTR_FIELD_EP_ADDR);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, max_conn_priv,
+                                 UCT_IFACE_ATTR_FIELD_MAX_CONN_PRIV);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, listen_sockaddr,
+                                 UCT_IFACE_ATTR_FIELD_SOCKADDR);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, overhead,
+                                 UCT_IFACE_ATTR_FIELD_OVERHEAD);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, bandwidth,
+                                 UCT_IFACE_ATTR_FIELD_BANDWIDTH);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, latency,
+                                 UCT_IFACE_ATTR_FIELD_LATENCY);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, priority,
+                                 UCT_IFACE_ATTR_FIELD_PRIORITY);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, max_num_eps,
+                                 UCT_IFACE_ATTR_FIELD_MAX_NUM_EPS);
+    UCT_IFACE_ATTR_V2_FIELD_COPY(dst, src, dev_num_paths,
+                                 UCT_IFACE_ATTR_FIELD_DEV_NUM_PATHS);
+}
+
+static ucs_status_t
+uct_iface_attr_v2_init(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
+{
+    uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+    ucs_status_t status;
+
+    memset(iface_attr, 0, sizeof(*iface_attr));
+
+    iface_attr->field_mask = UINT64_MAX;
+
+    status = iface->internal_ops->iface_query_v2(tl_iface, iface_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t uct_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+{
+    ucs_status_t status;
+    uct_iface_attr_v2_t iface_attr_v2;
+
+    status = uct_iface_attr_v2_init(tl_iface, &iface_attr_v2);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    uct_iface_attr_from_v2(iface_attr, &iface_attr_v2);
+
+    return UCS_OK;
 }
 
 ucs_status_t
 uct_iface_query_v2(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
-    uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+    ucs_status_t status;
+    uct_iface_attr_v2_t iface_attr_v2;
 
-    return iface->internal_ops->iface_query_v2(tl_iface, iface_attr);
+    status = uct_iface_attr_v2_init(tl_iface, &iface_attr_v2);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    /* Populate fields based on field mask set by user in iface_attr */
+    uct_iface_attr_v2_copy(iface_attr, &iface_attr_v2);
+
+    return UCS_OK;
 }
 
 ucs_status_t
@@ -506,7 +695,8 @@ ucs_status_t uct_iface_handle_ep_err(uct_iface_h iface, uct_ep_h ep,
     return status;
 }
 
-void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr)
+void uct_base_iface_query(uct_base_iface_t *iface,
+                          uct_iface_attr_v2_t *iface_attr)
 {
     memset(iface_attr, 0, sizeof(*iface_attr));
 
@@ -571,8 +761,11 @@ ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
 }
 
 ucs_status_t
-uct_iface_base_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
+uct_iface_base_query_v2(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
+    uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
+
+    uct_base_iface_query(iface, iface_attr);
     return UCS_OK;
 }
 
@@ -635,7 +828,6 @@ UCS_CLASS_INIT_FUNC(uct_iface_t, uct_iface_ops_t *ops)
     ucs_assert_always(ops->iface_progress_disable   != NULL);
     ucs_assert_always(ops->iface_progress           != NULL);
     ucs_assert_always(ops->iface_close              != NULL);
-    ucs_assert_always(ops->iface_query              != NULL);
     ucs_assert_always(ops->iface_get_device_address != NULL);
     ucs_assert_always(ops->iface_is_reachable       != NULL);
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -26,15 +26,18 @@
 #define UCT_IFACE_ATTR_V2_FIELD_COPY(_dst, _src, _field, _flag) \
     { \
         if ((_dst)->field_mask & (_flag)) { \
-            ucs_assert((_src)->field_mask & (_flag)); \
+            ucs_assertv((_src)->field_mask & (_flag), \
+                        "%s not set in field_mask", #_field); \
             memcpy(&((_dst)->_field), &((_src)->_field), \
                    sizeof((_src)->_field)); \
         } \
     }
 
+
 #define UCT_IFACE_ATTR_SET_V1_FIELD_FROM_V2(_v1, _v2, _field, _flag) \
     do { \
-        ucs_assert((_v2)->field_mask & (_flag)); \
+        ucs_assertv((_v2)->field_mask & (_flag), \
+                    "%s not set in field_mask", #_field); \
         (_v1)->_field = (_v2)->_field; \
     } while (0)
 
@@ -346,18 +349,12 @@ static ucs_status_t
 uct_iface_attr_v2_init(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
-    ucs_status_t status;
 
     memset(iface_attr, 0, sizeof(*iface_attr));
 
     iface_attr->field_mask = UINT64_MAX;
 
-    status = iface->internal_ops->iface_query_v2(tl_iface, iface_attr);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    return UCS_OK;
+    return iface->internal_ops->iface_query_v2(tl_iface, iface_attr);
 }
 
 ucs_status_t uct_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -698,8 +698,6 @@ ucs_status_t uct_iface_handle_ep_err(uct_iface_h iface, uct_ep_h ep,
 void uct_base_iface_query(uct_base_iface_t *iface,
                           uct_iface_attr_v2_t *iface_attr)
 {
-    memset(iface_attr, 0, sizeof(*iface_attr));
-
     iface_attr->max_num_eps   = iface->config.max_num_eps;
     iface_attr->dev_num_paths = 1;
 }

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -820,7 +820,8 @@ uct_iface_param_am_alignment(const uct_iface_params_t *params, size_t elem_size,
                              size_t base_offset, size_t payload_offset,
                              size_t *align, size_t *align_offset);
 
-void uct_base_iface_query(uct_base_iface_t *iface, uct_iface_attr_t *iface_attr);
+void uct_base_iface_query(uct_base_iface_t *iface,
+                          uct_iface_attr_v2_t *iface_attr);
 
 ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
                                         uct_device_type_t dev_type,

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -95,7 +95,7 @@ static int uct_cuda_copy_iface_is_reachable_v2(
 }
 
 static ucs_status_t uct_cuda_copy_iface_query(uct_iface_h tl_iface,
-                                              uct_iface_attr_t *iface_attr)
+                                              uct_iface_attr_v2_t *iface_attr)
 {
     uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_copy_iface_t);
 
@@ -168,7 +168,6 @@ static uct_iface_ops_t uct_cuda_copy_iface_ops = {
     .iface_event_fd_get       = uct_cuda_base_iface_event_fd_get,
     .iface_event_arm          = uct_cuda_base_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_iface_t),
-    .iface_query              = uct_cuda_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_cuda_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -264,7 +263,7 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 }
 
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
-    .iface_query_v2        = uct_iface_base_query_v2,
+    .iface_query_v2        = uct_cuda_copy_iface_query,
     .iface_estimate_perf   = uct_cuda_copy_estimate_perf,
     .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -248,7 +248,7 @@ static size_t uct_cuda_ipc_iface_get_max_get_zcopy(uct_cuda_ipc_iface_t *iface)
 }
 
 static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
-                                             uct_iface_attr_t *iface_attr)
+                                             uct_iface_attr_v2_t *iface_attr)
 {
     uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_cuda_ipc_iface_t);
     uct_cuda_ipc_md_t *md       = ucs_derived_of(iface->super.super.md,
@@ -340,7 +340,6 @@ static uct_iface_ops_t uct_cuda_ipc_iface_ops = {
     .iface_event_fd_get       = uct_cuda_base_iface_event_fd_get,
     .iface_event_arm          = uct_cuda_base_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_iface_t),
-    .iface_query              = uct_cuda_ipc_iface_query,
     .iface_get_device_address = uct_cuda_ipc_iface_get_device_address,
     .iface_get_address        = uct_cuda_ipc_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -405,7 +404,7 @@ uct_cuda_ipc_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 }
 
 static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_cuda_ipc_iface_query,
     .iface_estimate_perf    = uct_cuda_ipc_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/cuda/gdr_copy/gdr_copy_iface.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_iface.c
@@ -88,7 +88,7 @@ uct_gdr_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
 }
 
 static ucs_status_t
-uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_gdr_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_gdr_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_gdr_copy_iface_t);
 
@@ -203,14 +203,13 @@ static uct_iface_ops_t uct_gdr_copy_iface_ops = {
     .iface_progress_disable   = (uct_iface_progress_disable_func_t)ucs_empty_function,
     .iface_progress           = (uct_iface_progress_func_t)ucs_empty_function_return_zero,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_gdr_copy_iface_t),
-    .iface_query              = uct_gdr_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_gdr_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
 };
 
 static uct_iface_internal_ops_t uct_gdr_copy_iface_internal_ops = {
-    .iface_query_v2        = uct_iface_base_query_v2,
+    .iface_query_v2        = uct_gdr_copy_iface_query,
     .iface_estimate_perf   = uct_gdr_copy_estimate_perf,
     .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/gaudi/gaudi_gdr/gaudi_gdr_iface.c
+++ b/src/uct/gaudi/gaudi_gdr/gaudi_gdr_iface.c
@@ -14,7 +14,8 @@
 #include <uct/gaudi/base/gaudi_base.h>
 
 static ucs_status_t
-uct_gaudi_gdr_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_gaudi_gdr_iface_query(uct_iface_h tl_iface,
+                          uct_iface_attr_v2_t *iface_attr)
 {
     uct_gaudi_gdr_iface_t *iface = ucs_derived_of(tl_iface,
                                                   uct_gaudi_gdr_iface_t);
@@ -76,7 +77,6 @@ static uct_iface_ops_t uct_gaudi_gdr_iface_ops = {
     .iface_event_arm          = (uct_iface_event_arm_func_t)
             ucs_empty_function_return_unsupported,
     .iface_close              = (uct_iface_close_func_t)ucs_empty_function,
-    .iface_query              = uct_gaudi_gdr_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)
             ucs_empty_function_return_success,
     .iface_get_address        = (uct_iface_get_address_func_t)
@@ -85,7 +85,7 @@ static uct_iface_ops_t uct_gaudi_gdr_iface_ops = {
 };
 
 static uct_iface_internal_ops_t uct_gaudi_gdr_iface_internal_ops = {
-    .iface_query_v2      = uct_iface_base_query_v2,
+    .iface_query_v2      = uct_gaudi_gdr_iface_query,
     .iface_estimate_perf = (uct_iface_estimate_perf_func_t)
             ucs_empty_function_return_unsupported,
     .iface_vfs_refresh   = (uct_iface_vfs_refresh_func_t)ucs_empty_function,

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1937,7 +1937,7 @@ uct_ib_iface_get_bandwidth(uct_ib_iface_t *iface, double wire_speed)
 }
 
 ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface,
-                                uct_iface_attr_t *iface_attr)
+                                uct_iface_attr_v2_t *iface_attr)
 {
     static const uint8_t ib_port_widths[] =
             {[1] = 1, [2] = 4, [4] = 8, [8] = 12, [16] = 2};

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -568,7 +568,7 @@ int uct_ib_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                  const uct_iface_is_reachable_params_t *params);
 
 ucs_status_t uct_ib_iface_query(uct_ib_iface_t *iface,
-                                uct_iface_attr_t *iface_attr);
+                                uct_iface_attr_v2_t *iface_attr);
 
 
 ucs_status_t

--- a/src/uct/ib/efa/srd/srd_iface.c
+++ b/src/uct/ib/efa/srd/srd_iface.c
@@ -222,7 +222,81 @@ static void uct_srd_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
 }
 
 static ucs_status_t
-uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr);
+uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
+{
+    uct_srd_iface_t *iface = ucs_derived_of(tl_iface, uct_srd_iface_t);
+    uct_ib_md_t *ib_md     = uct_ib_iface_md(&iface->super);
+    size_t active_mtu      = uct_ib_mtu_value(
+            uct_ib_iface_port_attr(&iface->super)->active_mtu);
+    ucs_status_t status;
+    struct efadv_device_attr efa_attr;
+    int ret;
+
+    status = uct_ib_iface_query(&iface->super, iface_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    iface_attr->cap.am.align_mtu        = active_mtu;
+    iface_attr->cap.get.align_mtu       = active_mtu;
+    iface_attr->cap.put.align_mtu       = active_mtu;
+    iface_attr->cap.am.opt_zcopy_align  = UCS_SYS_PCI_MAX_PAYLOAD;
+    iface_attr->cap.get.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
+    iface_attr->cap.put.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
+
+    iface_attr->cap.flags      = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                 UCT_IFACE_FLAG_PENDING |
+                                 UCT_IFACE_FLAG_CB_SYNC |
+                                 UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
+                                 UCT_IFACE_FLAG_INTER_NODE |
+                                 UCT_IFACE_FLAG_AM_BCOPY |
+                                 UCT_IFACE_FLAG_AM_SHORT |
+                                 UCT_IFACE_FLAG_AM_ZCOPY;
+    iface_attr->iface_addr_len = sizeof(uct_srd_iface_addr_t);
+    iface_attr->ep_addr_len    = 0;
+    iface_attr->max_conn_priv  = 0;
+
+    iface_attr->latency.c += 20e-9;
+    iface_attr->overhead   = 75e-9;
+
+    iface_attr->cap.am.max_bcopy = iface->super.config.seg_size -
+                                   sizeof(uct_srd_hdr_t);
+    iface_attr->cap.am.min_zcopy = 0;
+    iface_attr->cap.am.max_zcopy = iface->super.config.seg_size -
+                                   sizeof(uct_srd_hdr_t);
+    iface_attr->cap.am.max_iov   = iface->config.max_send_sge - 1;
+    iface_attr->cap.am.max_hdr   = uct_ib_iface_hdr_size(
+            iface->super.config.seg_size, sizeof(uct_srd_hdr_t));
+    iface_attr->cap.am.max_short = uct_ib_iface_hdr_size(
+            iface->config.max_inline, sizeof(uct_srd_hdr_t));
+
+    ret = efadv_query_device(ib_md->pd->context, &efa_attr, sizeof(efa_attr));
+    if (ret != 0) {
+        return UCS_ERR_IO_ERROR;
+    }
+
+    if (uct_ib_efadv_has_rdma_read(&efa_attr)) {
+        iface_attr->cap.get.max_bcopy = iface->config.max_rdma_bcopy;
+        iface_attr->cap.get.max_zcopy = iface->config.max_rdma_zcopy;
+        iface_attr->cap.get.max_iov   = iface->config.max_rdma_sge;
+        iface_attr->cap.get.min_zcopy = 0;
+
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_GET_BCOPY |
+                                 UCT_IFACE_FLAG_GET_ZCOPY;
+    }
+
+    if (uct_ib_efadv_has_rdma_write(&efa_attr)) {
+        iface_attr->cap.put.max_bcopy = iface->config.max_rdma_bcopy;
+        iface_attr->cap.put.max_zcopy = iface->config.max_rdma_zcopy;
+        iface_attr->cap.put.max_iov   = iface->config.max_rdma_sge;
+        iface_attr->cap.put.min_zcopy = 0;
+
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_PUT_BCOPY |
+                                 UCT_IFACE_FLAG_PUT_ZCOPY;
+    }
+
+    return status;
+}
 
 static uct_ib_iface_ops_t uct_srd_iface_ops = {
     .super = {
@@ -875,86 +949,6 @@ static unsigned uct_srd_iface_progress(uct_iface_h tl_iface)
     /* Poll RX might schedule CTL_RESP, or TX might have resources */
     uct_srd_iface_pending_ctl_progress(iface);
     return count;
-}
-
-ucs_status_t
-uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
-{
-    uct_srd_iface_t *iface = ucs_derived_of(tl_iface, uct_srd_iface_t);
-    uct_ib_md_t *ib_md     = uct_ib_iface_md(&iface->super);
-    size_t active_mtu      = uct_ib_mtu_value(
-            uct_ib_iface_port_attr(&iface->super)->active_mtu);
-    ucs_status_t status;
-    struct efadv_device_attr efa_attr;
-    int ret;
-
-    /* Common parameters */
-    status = uct_ib_iface_query(&iface->super, iface_attr);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    /* General attributes */
-    iface_attr->cap.am.align_mtu        = active_mtu;
-    iface_attr->cap.get.align_mtu       = active_mtu;
-    iface_attr->cap.put.align_mtu       = active_mtu;
-    iface_attr->cap.am.opt_zcopy_align  = UCS_SYS_PCI_MAX_PAYLOAD;
-    iface_attr->cap.get.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
-    iface_attr->cap.put.opt_zcopy_align = UCS_SYS_PCI_MAX_PAYLOAD;
-
-    iface_attr->cap.flags      = UCT_IFACE_FLAG_CONNECT_TO_IFACE |
-                                 UCT_IFACE_FLAG_PENDING |
-                                 UCT_IFACE_FLAG_CB_SYNC |
-                                 UCT_IFACE_FLAG_ERRHANDLE_PEER_FAILURE |
-                                 UCT_IFACE_FLAG_INTER_NODE |
-                                 UCT_IFACE_FLAG_AM_BCOPY |
-                                 UCT_IFACE_FLAG_AM_SHORT |
-                                 UCT_IFACE_FLAG_AM_ZCOPY;
-    iface_attr->iface_addr_len = sizeof(uct_srd_iface_addr_t);
-    iface_attr->ep_addr_len    = 0;
-    iface_attr->max_conn_priv  = 0;
-
-    iface_attr->latency.c += 20e-9;
-    iface_attr->overhead   = 75e-9;
-
-    /* AM */
-    iface_attr->cap.am.max_bcopy = iface->super.config.seg_size -
-                                   sizeof(uct_srd_hdr_t);
-    iface_attr->cap.am.min_zcopy = 0;
-    iface_attr->cap.am.max_zcopy = iface->super.config.seg_size -
-                                   sizeof(uct_srd_hdr_t);
-    iface_attr->cap.am.max_iov   = iface->config.max_send_sge - 1;
-    iface_attr->cap.am.max_hdr   = uct_ib_iface_hdr_size(
-            iface->super.config.seg_size, sizeof(uct_srd_hdr_t));
-    iface_attr->cap.am.max_short = uct_ib_iface_hdr_size(
-            iface->config.max_inline, sizeof(uct_srd_hdr_t));
-
-    ret = efadv_query_device(ib_md->pd->context, &efa_attr, sizeof(efa_attr));
-    if (ret != 0) {
-        return UCS_ERR_IO_ERROR;
-    }
-
-    if (uct_ib_efadv_has_rdma_read(&efa_attr)) {
-        iface_attr->cap.get.max_bcopy = iface->config.max_rdma_bcopy;
-        iface_attr->cap.get.max_zcopy = iface->config.max_rdma_zcopy;
-        iface_attr->cap.get.max_iov   = iface->config.max_rdma_sge;
-        iface_attr->cap.get.min_zcopy = 0;
-
-        iface_attr->cap.flags |= UCT_IFACE_FLAG_GET_BCOPY |
-                                 UCT_IFACE_FLAG_GET_ZCOPY;
-    }
-
-    if (uct_ib_efadv_has_rdma_write(&efa_attr)) {
-        iface_attr->cap.put.max_bcopy = iface->config.max_rdma_bcopy;
-        iface_attr->cap.put.max_zcopy = iface->config.max_rdma_zcopy;
-        iface_attr->cap.put.max_iov   = iface->config.max_rdma_sge;
-        iface_attr->cap.put.min_zcopy = 0;
-
-        iface_attr->cap.flags |= UCT_IFACE_FLAG_PUT_BCOPY |
-                                 UCT_IFACE_FLAG_PUT_ZCOPY;
-    }
-
-    return status;
 }
 
 static ucs_status_t uct_srd_iface_flush(uct_iface_h tl_iface, unsigned flags,

--- a/src/uct/ib/efa/srd/srd_iface.c
+++ b/src/uct/ib/efa/srd/srd_iface.c
@@ -221,9 +221,12 @@ static void uct_srd_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg,
     UCT_IB_IFACE_VERBS_COMPLETION_LOG(log_lvl, "send", &iface->super, 0, wc);
 }
 
+static ucs_status_t
+uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr);
+
 static uct_ib_iface_ops_t uct_srd_iface_ops = {
     .super = {
-        .iface_query_v2        = uct_iface_base_query_v2,
+        .iface_query_v2        = uct_srd_iface_query,
         .iface_estimate_perf   = uct_ib_iface_estimate_perf,
         .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)
             ucs_empty_function,
@@ -875,7 +878,7 @@ static unsigned uct_srd_iface_progress(uct_iface_h tl_iface)
 }
 
 ucs_status_t
-uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_srd_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_srd_iface_t *iface = ucs_derived_of(tl_iface, uct_srd_iface_t);
     uct_ib_md_t *ib_md     = uct_ib_iface_md(&iface->super);
@@ -1045,7 +1048,6 @@ static uct_iface_ops_t uct_srd_iface_tl_ops = {
     .iface_progress_enable    = uct_base_iface_progress_enable,
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_srd_iface_progress,
-    .iface_query              = uct_srd_iface_query,
     .iface_get_address        = uct_srd_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -205,7 +205,8 @@ uct_dc_mlx5_ep_create_connected(const uct_ep_params_t *params, uct_ep_h* ep_p)
     }
 }
 
-static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t uct_dc_mlx5_iface_query(uct_iface_h tl_iface,
+                                            uct_iface_attr_v2_t *iface_attr)
 {
     uct_dc_mlx5_iface_t *iface = ucs_derived_of(tl_iface, uct_dc_mlx5_iface_t);
     size_t max_am_inline       = UCT_IB_MLX5_AM_MAX_SHORT(UCT_IB_MLX5_AV_FULL_SIZE);
@@ -1385,7 +1386,7 @@ static void uct_dc_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface,
 static uct_rc_iface_ops_t uct_dc_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_dc_mlx5_iface_query,
             .iface_estimate_perf    = uct_dc_mlx5_iface_estimate_perf,
             .iface_vfs_refresh      = uct_dc_mlx5_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -1447,7 +1448,6 @@ static uct_iface_ops_t uct_dc_mlx5_iface_tl_ops = {
     .ep_create                = uct_dc_mlx5_ep_create_connected,
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_ep_t),
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_dc_mlx5_iface_t),
-    .iface_query              = uct_dc_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
     .iface_get_address        = uct_dc_mlx5_iface_get_address,

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -481,7 +481,7 @@ int uct_rc_gdaki_ep_is_connected(uct_ep_h tl_ep,
 }
 
 static ucs_status_t
-uct_rc_gdaki_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_rc_gdaki_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rc_gdaki_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_rc_gdaki_iface_t);
@@ -639,7 +639,7 @@ static UCS_CLASS_DECLARE_DELETE_FUNC(uct_rc_gdaki_iface_t, uct_iface_t);
 static uct_rc_iface_ops_t uct_rc_gdaki_internal_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_rc_gdaki_iface_query,
             .iface_estimate_perf    = uct_ib_iface_estimate_perf,
             .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -666,7 +666,6 @@ static uct_iface_ops_t uct_rc_gdaki_iface_tl_ops = {
     .ep_connect_to_ep  = uct_base_ep_connect_to_ep,
     .ep_pending_purge  = (uct_ep_pending_purge_func_t)ucs_empty_function,
     .iface_close       = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_gdaki_iface_t),
-    .iface_query       = uct_rc_gdaki_iface_query,
     .iface_get_address = uct_rc_gdaki_iface_get_address,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -335,7 +335,7 @@ static unsigned uct_gga_mlx5_iface_progress(uct_iface_h iface)
 }
 
 static ucs_status_t
-uct_gga_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_gga_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
     size_t iface_mtu      = uct_ib_mtu_value(iface->super.config.path_mtu);
@@ -686,7 +686,6 @@ static uct_iface_ops_t uct_gga_mlx5_iface_tl_ops = {
     .iface_event_fd_get       = uct_rc_mlx5_iface_event_fd_get,
     .iface_event_arm          = uct_rc_mlx5_iface_arm,
     .iface_close              = uct_gga_mlx5_iface_t_delete,
-    .iface_query              = uct_gga_mlx5_iface_query,
     .iface_get_address        = uct_gga_mlx5_iface_get_address,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -747,7 +746,7 @@ uct_gga_mlx5_ep_is_connected(uct_ep_h tl_ep,
 static uct_rc_iface_ops_t uct_gga_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_gga_mlx5_iface_query,
             .iface_estimate_perf    = uct_rc_iface_estimate_perf,
             .iface_vfs_refresh      = uct_rc_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -999,7 +999,7 @@ void uct_rc_mlx5_tag_cleanup(uct_rc_mlx5_iface_common_t *iface)
 }
 
 static void uct_rc_mlx5_tag_query(uct_rc_mlx5_iface_common_t *iface,
-                                  uct_iface_attr_t *iface_attr,
+                                  uct_iface_attr_v2_t *iface_attr,
                                   size_t max_inline, size_t max_tag_eager_iov)
 {
 #if IBV_HW_TM
@@ -1120,7 +1120,7 @@ void uct_rc_mlx5_common_fill_dv_qp_attr(uct_rc_mlx5_iface_common_t *iface,
 #endif
 
 void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
-                                    uct_iface_attr_t *iface_attr,
+                                    uct_iface_attr_v2_t *iface_attr,
                                     size_t max_inline, size_t max_tag_eager_iov)
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(ib_iface,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -594,7 +594,7 @@ ucs_status_t uct_rc_mlx5_iface_common_dm_init(uct_rc_mlx5_iface_common_t *iface,
 void uct_rc_mlx5_iface_common_dm_cleanup(uct_rc_mlx5_iface_common_t *iface);
 
 void uct_rc_mlx5_iface_common_query(uct_ib_iface_t *ib_iface,
-                                    uct_iface_attr_t *iface_attr,
+                                    uct_iface_attr_v2_t *iface_attr,
                                     size_t max_inline, size_t max_tag_eager_iov);
 
 ucs_status_t

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -141,7 +141,8 @@ static unsigned uct_rc_mlx5_iface_progress_tm(void *arg)
                                            UCT_IB_MLX5_POLL_FLAG_CQE_ZIP);
 }
 
-static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface,
+                                            uct_iface_attr_v2_t *iface_attr)
 {
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(tl_iface, uct_rc_mlx5_iface_common_t);
     uct_rc_iface_t *rc_iface   = &iface->super;
@@ -977,7 +978,7 @@ static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_mlx5_iface_t, uct_iface_t);
 static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_rc_mlx5_iface_query,
             .iface_estimate_perf    = uct_rc_iface_estimate_perf,
             .iface_vfs_refresh      = uct_rc_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -1044,7 +1045,6 @@ static uct_iface_ops_t uct_rc_mlx5_iface_tl_ops = {
     .iface_event_fd_get       = uct_rc_mlx5_iface_event_fd_get,
     .iface_event_arm          = uct_rc_mlx5_iface_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_mlx5_iface_t),
-    .iface_query              = uct_rc_mlx5_iface_query,
     .iface_get_address        = uct_rc_mlx5_iface_get_address,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -618,7 +618,7 @@ static unsigned uct_ud_mlx5_iface_async_progress(uct_ud_iface_t *ud_iface)
 }
 
 static ucs_status_t
-uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_ud_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ud_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_iface_t);
     ucs_status_t status;
@@ -856,7 +856,7 @@ static void uct_ud_mlx5_iface_handle_failure(uct_ib_iface_t *ib_iface, void *arg
 static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_ud_mlx5_iface_query,
             .iface_estimate_perf    = uct_ib_iface_estimate_perf,
             .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -907,7 +907,6 @@ static uct_iface_ops_t uct_ud_mlx5_iface_tl_ops = {
                                 ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_ud_mlx5_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_mlx5_iface_t),
-    .iface_query              = uct_ud_mlx5_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -165,7 +165,7 @@ static ucs_mpool_ops_t uct_rc_send_op_mpool_ops = {
 };
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
                                 size_t am_min_hdr, size_t rma_max_iov)

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -374,7 +374,7 @@ extern ucs_config_field_t uct_rc_iface_common_config_table[];
 unsigned uct_rc_iface_do_progress(uct_iface_h tl_iface);
 
 ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
                                 size_t am_min_hdr, size_t rma_max_iov);

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -194,7 +194,7 @@ static void uct_rc_verbs_iface_init_inl_wrs(uct_rc_verbs_iface_t *iface)
 }
 
 static ucs_status_t
-uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_iface,
                                                  uct_rc_verbs_iface_t);
@@ -486,7 +486,6 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
     .iface_event_fd_get       = uct_ib_iface_event_fd_get,
     .iface_event_arm          = uct_rc_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rc_verbs_iface_t),
-    .iface_query              = uct_rc_verbs_iface_query,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_success,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -495,7 +494,7 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_rc_verbs_iface_query,
             .iface_estimate_perf    = uct_rc_iface_estimate_perf,
             .iface_vfs_refresh      = uct_rc_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -872,7 +872,6 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucs_empty_function_return_unsupported,
     .iface_event_arm          = (uct_iface_event_arm_func_t)ucs_empty_function_return_unsupported,
     .iface_close              = (uct_iface_close_func_t)ucs_empty_function,
-    .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/ib/ud/base/ud_iface.c
+++ b/src/uct/ib/ud/base/ud_iface.c
@@ -704,7 +704,7 @@ ucs_config_field_t uct_ud_iface_config_table[] = {
 
 
 ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t am_max_iov, size_t am_max_hdr)
 {
     ucs_status_t status;

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -248,7 +248,7 @@ extern ucs_config_field_t uct_ud_iface_config_table[];
 
 
 ucs_status_t uct_ud_iface_query(uct_ud_iface_t *iface,
-                                uct_iface_attr_t *iface_attr,
+                                uct_iface_attr_v2_t *iface_attr,
                                 size_t am_max_iov, size_t am_max_hdr);
 
 void uct_ud_iface_release_desc(uct_recv_desc_t *self, void *desc);

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -560,7 +560,7 @@ static void uct_ud_verbs_iface_async_handler(int fd,
 }
 
 static ucs_status_t
-uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_ud_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ud_verbs_iface_t *iface = ucs_derived_of(tl_iface, uct_ud_verbs_iface_t);
     size_t am_max_hdr;
@@ -664,7 +664,7 @@ static void UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t)(uct_iface_t*);
 static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_ud_verbs_iface_query,
             .iface_estimate_perf    = uct_ib_iface_estimate_perf,
             .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)uct_ud_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -715,7 +715,6 @@ static uct_iface_ops_t uct_ud_verbs_iface_tl_ops = {
                                 ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_ud_verbs_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ud_verbs_iface_t),
-    .iface_query              = uct_ud_verbs_iface_query,
     .iface_get_device_address = uct_ib_iface_get_device_address,
     .iface_get_address        = uct_ud_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -86,7 +86,7 @@ static int uct_rocm_copy_iface_is_reachable_v2(
 }
 
 static ucs_status_t uct_rocm_copy_iface_query(uct_iface_h tl_iface,
-                                              uct_iface_attr_t *iface_attr)
+                                              uct_iface_attr_v2_t *iface_attr)
 {
     uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_copy_iface_t);
 
@@ -182,7 +182,6 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_rocm_copy_iface_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_copy_iface_t),
-    .iface_query              = uct_rocm_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_rocm_copy_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -294,7 +293,7 @@ uct_rocm_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 
 
 static uct_iface_internal_ops_t uct_rocm_copy_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_rocm_copy_iface_query,
     .iface_estimate_perf    = uct_rocm_copy_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -98,7 +98,7 @@ uct_rocm_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
 }
 
 static ucs_status_t uct_rocm_ipc_iface_query(uct_iface_h tl_iface,
-                                             uct_iface_attr_t *iface_attr)
+                                             uct_iface_attr_v2_t *iface_attr)
 {
     uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_ipc_iface_t);
 
@@ -163,7 +163,7 @@ static unsigned uct_rocm_ipc_iface_progress(uct_iface_h tl_iface)
 }
 
 static uct_iface_internal_ops_t uct_rocm_ipc_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_rocm_ipc_iface_query,
     .iface_estimate_perf    = uct_base_iface_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -189,7 +189,6 @@ static uct_iface_ops_t uct_rocm_ipc_iface_ops = {
     .iface_progress_disable   = uct_base_iface_progress_disable,
     .iface_progress           = uct_rocm_ipc_iface_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_ipc_iface_t),
-    .iface_query              = uct_rocm_ipc_iface_query,
     .iface_get_address        = uct_rocm_ipc_iface_get_address,
     .iface_get_device_address = uct_rocm_ipc_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/sm/mm/base/mm_iface.c
+++ b/src/uct/sm/mm/base/mm_iface.c
@@ -170,7 +170,7 @@ ucs_status_t uct_mm_iface_flush(uct_iface_h tl_iface, unsigned flags,
 }
 
 static ucs_status_t uct_mm_iface_query(uct_iface_h tl_iface,
-                                       uct_iface_attr_t *iface_attr)
+                                       uct_iface_attr_v2_t *iface_attr)
 {
     uct_mm_iface_t *iface = ucs_derived_of(tl_iface, uct_mm_iface_t);
     uct_mm_md_t    *md    = ucs_derived_of(iface->super.super.md, uct_mm_md_t);
@@ -529,7 +529,6 @@ static uct_iface_ops_t uct_mm_iface_ops = {
     .iface_event_fd_get       = uct_mm_iface_event_fd_get,
     .iface_event_arm          = uct_mm_iface_event_fd_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_mm_iface_t),
-    .iface_query              = uct_mm_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_get_address        = uct_mm_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -602,7 +601,7 @@ uct_mm_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 }
 
 static uct_iface_internal_ops_t uct_mm_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_mm_iface_query,
     .iface_estimate_perf    = uct_mm_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function,

--- a/src/uct/sm/scopy/base/scopy_iface.c
+++ b/src/uct/sm/scopy/base/scopy_iface.c
@@ -62,7 +62,8 @@ static ucs_mpool_ops_t uct_scopy_mpool_ops = {
     .obj_str       = NULL
 };
 
-void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr)
+void uct_scopy_iface_query(uct_scopy_iface_t *iface,
+                           uct_iface_attr_v2_t *iface_attr)
 {
     uct_base_iface_query(&iface->super.super, iface_attr);
 

--- a/src/uct/sm/scopy/base/scopy_iface.h
+++ b/src/uct/sm/scopy/base/scopy_iface.h
@@ -59,7 +59,8 @@ typedef struct uct_scopy_iface_ops {
 } uct_scopy_iface_ops_t;
 
 
-void uct_scopy_iface_query(uct_scopy_iface_t *iface, uct_iface_attr_t *iface_attr);
+void uct_scopy_iface_query(uct_scopy_iface_t *iface,
+                           uct_iface_attr_v2_t *iface_attr);
 
 ucs_status_t
 uct_scopy_iface_estimate_perf(uct_iface_h iface, uct_perf_attr_t *perf_attr);

--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -50,7 +50,7 @@ static ucs_status_t uct_cma_iface_get_address(uct_iface_t *tl_iface,
 }
 
 static ucs_status_t uct_cma_iface_query(uct_iface_h tl_iface,
-                                        uct_iface_attr_t *iface_attr)
+                                        uct_iface_attr_v2_t *iface_attr)
 {
     uct_cma_iface_t *iface = ucs_derived_of(tl_iface, uct_cma_iface_t);
 
@@ -145,7 +145,6 @@ static uct_iface_ops_t uct_cma_iface_tl_ops = {
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_scopy_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_cma_iface_t),
-    .iface_query              = uct_cma_iface_query,
     .iface_get_address        = uct_cma_iface_get_address,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -153,7 +152,7 @@ static uct_iface_ops_t uct_cma_iface_tl_ops = {
 
 static uct_scopy_iface_ops_t uct_cma_iface_ops = {
     .super = {
-        .iface_query_v2         = uct_iface_base_query_v2,
+        .iface_query_v2         = uct_cma_iface_query,
         .iface_estimate_perf    = uct_scopy_iface_estimate_perf,
         .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
         .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/sm/scopy/knem/knem_iface.c
+++ b/src/uct/sm/scopy/knem/knem_iface.c
@@ -25,7 +25,7 @@ static ucs_config_field_t uct_knem_iface_config_table[] = {
 };
 
 static ucs_status_t uct_knem_iface_query(uct_iface_h tl_iface,
-                                         uct_iface_attr_t *iface_attr)
+                                         uct_iface_attr_v2_t *iface_attr)
 {
     uct_knem_iface_t *iface = ucs_derived_of(tl_iface, uct_knem_iface_t);
 
@@ -67,7 +67,6 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucs_empty_function_return_unsupported,
     .iface_event_arm          = uct_scopy_iface_event_arm,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_knem_iface_t),
-    .iface_query              = uct_knem_iface_query,
     .iface_get_device_address = uct_sm_iface_get_device_address,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_success,
     .iface_is_reachable       = uct_base_iface_is_reachable,
@@ -75,7 +74,7 @@ static uct_iface_ops_t uct_knem_iface_tl_ops = {
 
 static uct_scopy_iface_ops_t uct_knem_iface_ops = {
     .super = {
-        .iface_query_v2         = uct_iface_base_query_v2,
+        .iface_query_v2         = uct_knem_iface_query,
         .iface_estimate_perf    = uct_scopy_iface_estimate_perf,
         .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
         .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -63,7 +63,8 @@ static ucs_config_field_t uct_self_md_config_table[] = {
 };
 
 
-static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *attr)
+static ucs_status_t uct_self_iface_query(uct_iface_h tl_iface,
+                                         uct_iface_attr_v2_t *attr)
 {
     uct_self_iface_t *iface = ucs_derived_of(tl_iface, uct_self_iface_t);
 
@@ -378,7 +379,7 @@ ssize_t uct_self_ep_am_bcopy(uct_ep_h tl_ep, uint8_t id,
 }
 
 static uct_iface_internal_ops_t uct_self_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_self_iface_query,
     .iface_estimate_perf    = uct_base_iface_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -415,7 +416,6 @@ static uct_iface_ops_t uct_self_iface_ops = {
     .iface_progress_disable   = (uct_iface_progress_disable_func_t)ucs_empty_function,
     .iface_progress           = (uct_iface_progress_func_t)ucs_empty_function_return_zero,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_self_iface_t),
-    .iface_query              = uct_self_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_success,
     .iface_get_address        = uct_self_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -313,7 +313,7 @@ out:
 }
 
 static ucs_status_t uct_tcp_iface_query(uct_iface_h tl_iface,
-                                        uct_iface_attr_t *attr)
+                                        uct_iface_attr_v2_t *attr)
 {
     uct_tcp_iface_t *iface = ucs_derived_of(tl_iface, uct_tcp_iface_t);
     size_t am_buf_size     = iface->config.tx_seg_size -
@@ -559,7 +559,6 @@ static uct_iface_ops_t uct_tcp_iface_ops = {
     .iface_event_fd_get       = uct_tcp_iface_event_fd_get,
     .iface_event_arm          = (uct_iface_event_arm_func_t)ucs_empty_function_return_success,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_tcp_iface_t),
-    .iface_query              = uct_tcp_iface_query,
     .iface_get_address        = uct_tcp_iface_get_address,
     .iface_get_device_address = uct_tcp_iface_get_device_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -672,7 +671,7 @@ static ucs_mpool_ops_t uct_tcp_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_tcp_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_tcp_iface_query,
     .iface_estimate_perf    = uct_base_iface_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/tcp/tcp_sockcm.c
+++ b/src/uct/tcp/tcp_sockcm.c
@@ -187,7 +187,6 @@ static uct_iface_ops_t uct_tcp_sockcm_iface_ops = {
     .iface_event_fd_get       = (uct_iface_event_fd_get_func_t)ucs_empty_function_return_unsupported,
     .iface_event_arm          = (uct_iface_event_arm_func_t)ucs_empty_function_return_unsupported,
     .iface_close              = (uct_iface_close_func_t)ucs_empty_function,
-    .iface_query              = (uct_iface_query_func_t)ucs_empty_function_return_unsupported,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)ucs_empty_function_return_unsupported,
     .iface_get_address        = (uct_iface_get_address_func_t)ucs_empty_function_return_unsupported,
     .iface_is_reachable       = uct_base_iface_is_reachable

--- a/src/uct/ugni/rdma/ugni_rdma_iface.c
+++ b/src/uct/ugni/rdma/ugni_rdma_iface.c
@@ -28,7 +28,8 @@ static ucs_config_field_t uct_ugni_rdma_iface_config_table[] = {
     {NULL}
 };
 
-static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t uct_ugni_rdma_iface_query(uct_iface_h tl_iface,
+                                              uct_iface_attr_v2_t *iface_attr)
 {
     uct_ugni_rdma_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_rdma_iface_t);
 
@@ -207,7 +208,6 @@ static uct_iface_ops_t uct_ugni_aries_rdma_iface_ops = {
     .iface_progress_disable   = (uct_iface_progress_disable_func_t)ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_rdma_iface_t),
-    .iface_query              = uct_ugni_rdma_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_is_reachable       = uct_ugni_iface_is_reachable
@@ -234,7 +234,6 @@ static uct_iface_ops_t uct_ugni_gemini_rdma_iface_ops = {
     .iface_progress_disable   = (uct_iface_progress_disable_func_t)ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_rdma_iface_t),
-    .iface_query              = uct_ugni_rdma_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_is_reachable       = uct_ugni_iface_is_reachable
@@ -262,6 +261,18 @@ static uct_iface_ops_t *uct_ugni_rdma_choose_ops_by_device(uct_ugni_device_t *de
     }
 }
 
+static uct_iface_internal_ops_t uct_ugni_rdma_iface_internal_ops = {
+    .iface_query_v2         = uct_ugni_rdma_iface_query,
+    .iface_estimate_perf    = uct_base_iface_estimate_perf,
+    .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate          = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2    = (uct_ep_connect_to_ep_v2_func_t)ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2  = uct_ugni_iface_is_reachable_v2,
+    .ep_is_connected        = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int,
+    .ep_get_device_ep       = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported
+};
+
 static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
@@ -277,7 +288,8 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_rdma_iface_t, uct_md_h md, uct_worker_h work
         status = UCS_ERR_NO_DEVICE;
         goto exit;
     }
-    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params, ops, NULL,
+    UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params, ops,
+                              &uct_ugni_rdma_iface_internal_ops,
                               &config->super UCS_STATS_ARG(NULL));
     /* Setting initial configuration */
     self->config.fma_seg_size  = UCT_UGNI_MAX_FMA;

--- a/src/uct/ugni/smsg/ugni_smsg_iface.c
+++ b/src/uct/ugni/smsg/ugni_smsg_iface.c
@@ -189,7 +189,8 @@ static unsigned uct_ugni_smsg_progress(void *arg)
     return count - 2;
 }
 
-static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t uct_ugni_smsg_iface_query(uct_iface_h tl_iface,
+                                              uct_iface_attr_v2_t *iface_attr)
 {
     uct_ugni_smsg_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_smsg_iface_t);
 
@@ -247,7 +248,6 @@ static uct_iface_ops_t uct_ugni_smsg_iface_ops = {
     .iface_progress_disable   = (uct_iface_progress_disable_func_t)ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_smsg_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_smsg_iface_t),
-    .iface_query              = uct_ugni_smsg_iface_query,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_is_reachable       = uct_base_iface_is_reachable
@@ -270,7 +270,7 @@ static ucs_mpool_ops_t uct_ugni_smsg_mbox_mpool_ops = {
 };
 
 static uct_iface_internal_ops_t uct_ugni_smsg_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_ugni_smsg_iface_query,
     .iface_estimate_perf    = uct_base_iface_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/src/uct/ugni/udt/ugni_udt_iface.c
+++ b/src/uct/ugni/udt/ugni_udt_iface.c
@@ -160,7 +160,8 @@ static void uct_ugni_udt_iface_release_desc(uct_recv_desc_t *self, void *desc)
     ucs_mpool_put(ugni_desc);
 }
 
-static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+static ucs_status_t uct_ugni_udt_iface_query(uct_iface_h tl_iface,
+                                             uct_iface_attr_v2_t *iface_attr)
 {
     uct_ugni_udt_iface_t *iface = ucs_derived_of(tl_iface, uct_ugni_udt_iface_t);
 
@@ -370,7 +371,6 @@ static uct_iface_ops_t uct_ugni_udt_iface_ops = {
     .iface_progress_disable   = (uct_iface_progress_disable_func_t)ucs_empty_function,
     .iface_progress           = (void*)uct_ugni_udt_progress,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ugni_udt_iface_t),
-    .iface_query              = uct_ugni_udt_iface_query,
     .iface_get_address        = uct_ugni_iface_get_address,
     .iface_get_device_address = uct_ugni_iface_get_dev_address,
     .iface_is_reachable       = uct_ugni_iface_is_reachable
@@ -382,6 +382,18 @@ static ucs_mpool_ops_t uct_ugni_udt_desc_mpool_ops = {
     .obj_init      = NULL,
     .obj_cleanup   = NULL,
     .obj_str       = NULL
+};
+
+static uct_iface_internal_ops_t uct_ugni_udt_iface_internal_ops = {
+    .iface_query_v2         = uct_ugni_udt_iface_query,
+    .iface_estimate_perf    = uct_base_iface_estimate_perf,
+    .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
+    .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
+    .ep_invalidate          = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
+    .ep_connect_to_ep_v2    = (uct_ep_connect_to_ep_v2_func_t)ucs_empty_function_return_unsupported,
+    .iface_is_reachable_v2  = uct_ugni_iface_is_reachable_v2,
+    .ep_is_connected        = (uct_ep_is_connected_func_t)ucs_empty_function_return_zero_int,
+    .ep_get_device_ep       = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported
 };
 
 static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worker,
@@ -396,7 +408,8 @@ static UCS_CLASS_INIT_FUNC(uct_ugni_udt_iface_t, uct_md_h md, uct_worker_h worke
     ucs_mpool_params_t mp_params;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ugni_iface_t, md, worker, params,
-                              &uct_ugni_udt_iface_ops, NULL,
+                              &uct_ugni_udt_iface_ops,
+                              &uct_ugni_udt_iface_internal_ops,
                               &config->super UCS_STATS_ARG(NULL));
 
     /* Setting initial configuration */

--- a/src/uct/ze/copy/ze_copy_iface.c
+++ b/src/uct/ze/copy/ze_copy_iface.c
@@ -55,7 +55,7 @@ uct_ze_copy_iface_is_reachable_v2(const uct_iface_h tl_iface,
 }
 
 static ucs_status_t
-uct_ze_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
+uct_ze_copy_iface_query(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
     uct_ze_copy_iface_t *iface = ucs_derived_of(tl_iface, uct_ze_copy_iface_t);
 
@@ -154,7 +154,6 @@ static uct_iface_ops_t uct_ze_copy_iface_ops = {
     .iface_progress           = (uct_iface_progress_func_t)
             ucs_empty_function_return_zero,
     .iface_close              = UCS_CLASS_DELETE_FUNC_NAME(uct_ze_copy_iface_t),
-    .iface_query              = uct_ze_copy_iface_query,
     .iface_get_device_address = (uct_iface_get_device_address_func_t)
             ucs_empty_function_return_success,
     .iface_get_address        = uct_ze_copy_iface_get_address,
@@ -225,7 +224,7 @@ uct_ze_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 
 
 static uct_iface_internal_ops_t uct_ze_copy_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_ze_copy_iface_query,
     .iface_estimate_perf    = uct_ze_copy_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -17,7 +17,7 @@ extern "C" {
 class mock_iface {
 public:
     /* Can't use std::function due to coverity errors */
-    using iface_attr_func_t = void (*)(uct_iface_attr&);
+    using iface_attr_func_t = void (*)(uct_iface_attr_v2_t&);
     using perf_attr_func_t = void (*)(uct_perf_attr_t&);
 
     mock_iface() : m_tl(nullptr)
@@ -39,7 +39,7 @@ public:
 
     void add_mock_iface(
             const std::string &dev_name = "mock",
-            iface_attr_func_t cb = [](uct_iface_attr_t &iface_attr) {},
+            iface_attr_func_t cb = [](uct_iface_attr_v2_t &iface_attr) {},
             perf_attr_func_t perf_cb = cx7_perf_mock)
     {
         m_iface_attrs_funcs[dev_name] = cb;
@@ -130,18 +130,22 @@ private:
 
         uct_base_iface_t *base      = ucs_derived_of(*iface_p, uct_base_iface_t);
         m_self->m_iface_names[base] = params->mode.device.dev_name;
-        m_self->m_mock.setup(&(*iface_p)->ops.iface_query, iface_query_mock);
-        m_self->m_mock.setup(&base->internal_ops->iface_estimate_perf, perf_mock);
+        m_self->m_mock.setup(&base->internal_ops->iface_query_v2,
+                             iface_query_mock);
+        m_self->m_mock.setup(&base->internal_ops->iface_estimate_perf,
+                             perf_mock);
         return UCS_OK;
     }
 
     static ucs_status_t
-    iface_query_mock(uct_iface_h iface, uct_iface_attr_t *iface_attr)
+    iface_query_mock(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
     {
-        UCS_MOCK_ORIG_FUNC(m_self->m_mock, &iface->ops.iface_query, iface,
+        uct_base_iface_t *base = ucs_derived_of(iface, uct_base_iface_t);
+
+        UCS_MOCK_ORIG_FUNC(m_self->m_mock,
+                           &base->internal_ops->iface_query_v2, iface,
                            iface_attr);
 
-        uct_base_iface_t *base  = ucs_derived_of(iface, uct_base_iface_t);
         std::string &iface_name = m_self->m_iface_names[base];
         auto it                 = m_self->m_iface_attrs_funcs.find(iface_name);
         (it->second)(*iface_attr);
@@ -585,7 +589,7 @@ public:
     virtual void init() override
     {
         /* Device with higher BW and latency */
-        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_0:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short  = 2000;
             iface_attr.cap.put.max_short = 2048;
             iface_attr.bandwidth.shared  = 28e9;
@@ -594,7 +598,7 @@ public:
             iface_attr.cap.get.max_zcopy = 16384;
         });
         /* Device with smaller BW but lower latency */
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_1:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.cap.put.max_short = 2048;
             iface_attr.bandwidth.shared  = 24e9;
@@ -729,7 +733,7 @@ public:
     virtual void init() override
     {
         /* Device with high BW and lower latency */
-        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_0:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.bandwidth.shared  = 28e9;
             iface_attr.latency.c         = 500e-9;
@@ -737,7 +741,7 @@ public:
             iface_attr.cap.get.max_zcopy = 16384;
         });
         /* Device with lower BW and higher latency */
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_1:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 600e-9;
@@ -777,7 +781,7 @@ public:
     {
         /* Device with high BW and lower latency, but 0 get_zcopy.
          * This use case is similar to cuda_ipc when NVLink is not available. */
-        add_mock_iface("mock_0:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_0:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.bandwidth.shared  = 28e9;
             iface_attr.latency.c         = 500e-9;
@@ -785,7 +789,7 @@ public:
             iface_attr.cap.get.max_zcopy = 0;
         });
         /* Device with lower BW and higher latency */
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_1:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 600e-9;
@@ -851,7 +855,7 @@ public:
 
     virtual void init() override
     {
-        add_mock_iface("mock", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.bandwidth.dedicated = 0;
             iface_attr.bandwidth.shared    = 100e9 / 8; /* 100Gb/s */
             iface_attr.latency.c           = 20e-6;
@@ -915,7 +919,7 @@ public:
 
     virtual void init() override
     {
-        add_mock_iface("mock", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 28e9;
             iface_attr.latency.c        = 600e-9;
@@ -959,7 +963,7 @@ public:
 
     virtual void init() override
     {
-        auto iface_attr_func = [](uct_iface_attr_t &iface_attr) {
+        auto iface_attr_func = [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.cap.put.max_short = 2048;
             iface_attr.bandwidth.shared  = 28e9;
@@ -968,7 +972,7 @@ public:
         };
 
         add_mock_iface("mock_0:1", iface_attr_func);
-        add_mock_iface("mock_1:1", [](uct_iface_attr_t &iface_attr) {
+        add_mock_iface("mock_1:1", [](uct_iface_attr_v2_t &iface_attr) {
             iface_attr.cap.am.max_short = 2000;
             iface_attr.bandwidth.shared = 24e9;
             iface_attr.latency.c        = 600e-9;

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -30,6 +30,7 @@ class test_uct_query : public uct_test {
 public:
     void init() override;
     ucs_status_t iface_estimate_perf(uct_perf_attr_t *perf_attr) const;
+    ucs_status_t iface_query_v2(uct_iface_attr_v2_t *iface_attr) const;
     const uct_iface_attr &get_iface_attr() const;
     static uct_perf_attr_t init_perf_attr();
 
@@ -52,6 +53,12 @@ test_uct_query::iface_estimate_perf(uct_perf_attr_t *perf_attr) const
 const uct_iface_attr &test_uct_query::get_iface_attr() const
 {
     return m_e->iface_attr();
+}
+
+ucs_status_t
+test_uct_query::iface_query_v2(uct_iface_attr_v2_t *iface_attr) const
+{
+    return uct_iface_query_v2(m_e->iface(), iface_attr);
 }
 
 uct_perf_attr_t test_uct_query::init_perf_attr()
@@ -102,6 +109,47 @@ UCS_TEST_P(test_uct_query, query_perf)
            and gdr_copy transports */
         EXPECT_NE(perf_attr.bandwidth.shared, perf_attr_get.bandwidth.shared);
     }
+}
+
+UCS_TEST_P(test_uct_query, iface_query_v2_consistency)
+{
+    const uct_iface_attr_t &attr_v1 = get_iface_attr();
+    uct_iface_attr_v2_t attr_v2;
+
+    attr_v2.field_mask = UINT64_MAX;
+    ASSERT_UCS_OK(iface_query_v2(&attr_v2));
+
+    EXPECT_EQ(attr_v1.cap.put.max_short, attr_v2.cap.put.max_short);
+    EXPECT_EQ(attr_v1.cap.put.max_bcopy, attr_v2.cap.put.max_bcopy);
+    EXPECT_EQ(attr_v1.cap.put.max_zcopy, attr_v2.cap.put.max_zcopy);
+    EXPECT_EQ(attr_v1.cap.put.max_iov, attr_v2.cap.put.max_iov);
+    EXPECT_EQ(attr_v1.cap.get.max_short, attr_v2.cap.get.max_short);
+    EXPECT_EQ(attr_v1.cap.get.max_bcopy, attr_v2.cap.get.max_bcopy);
+    EXPECT_EQ(attr_v1.cap.get.max_zcopy, attr_v2.cap.get.max_zcopy);
+    EXPECT_EQ(attr_v1.cap.get.max_iov, attr_v2.cap.get.max_iov);
+    EXPECT_EQ(attr_v1.cap.am.max_short, attr_v2.cap.am.max_short);
+    EXPECT_EQ(attr_v1.cap.am.max_bcopy, attr_v2.cap.am.max_bcopy);
+    EXPECT_EQ(attr_v1.cap.am.max_zcopy, attr_v2.cap.am.max_zcopy);
+    EXPECT_EQ(attr_v1.cap.am.max_hdr, attr_v2.cap.am.max_hdr);
+    EXPECT_EQ(attr_v1.cap.am.max_iov, attr_v2.cap.am.max_iov);
+    EXPECT_EQ(attr_v1.cap.flags, attr_v2.cap.flags);
+    EXPECT_EQ(attr_v1.cap.event_flags, attr_v2.cap.event_flags);
+    EXPECT_EQ(attr_v1.cap.atomic32.op_flags, attr_v2.cap.atomic32.op_flags);
+    EXPECT_EQ(attr_v1.cap.atomic32.fop_flags, attr_v2.cap.atomic32.fop_flags);
+    EXPECT_EQ(attr_v1.cap.atomic64.op_flags, attr_v2.cap.atomic64.op_flags);
+    EXPECT_EQ(attr_v1.cap.atomic64.fop_flags, attr_v2.cap.atomic64.fop_flags);
+    EXPECT_EQ(attr_v1.device_addr_len, attr_v2.device_addr_len);
+    EXPECT_EQ(attr_v1.iface_addr_len, attr_v2.iface_addr_len);
+    EXPECT_EQ(attr_v1.ep_addr_len, attr_v2.ep_addr_len);
+    EXPECT_EQ(attr_v1.max_conn_priv, attr_v2.max_conn_priv);
+    EXPECT_EQ(attr_v1.overhead, attr_v2.overhead);
+    EXPECT_EQ(attr_v1.bandwidth.dedicated, attr_v2.bandwidth.dedicated);
+    EXPECT_EQ(attr_v1.bandwidth.shared, attr_v2.bandwidth.shared);
+    EXPECT_EQ(attr_v1.latency.c, attr_v2.latency.c);
+    EXPECT_EQ(attr_v1.latency.m, attr_v2.latency.m);
+    EXPECT_EQ(attr_v1.priority, attr_v2.priority);
+    EXPECT_EQ(attr_v1.max_num_eps, attr_v2.max_num_eps);
+    EXPECT_EQ(attr_v1.dev_num_paths, attr_v2.dev_num_paths);
 }
 
 UCT_INSTANTIATE_TEST_CASE(test_uct_query)


### PR DESCRIPTION
## What?
Introduce `iface_query_v2` following the same pattern as `md_query_v2` (PR #8428).
Extend `uct_iface_attr_v2_t` to include all v1 attributes so that a single call to `uct_iface_query_v2()` returns all interface attributes.

## Why?
Without this change, adding new fields to `uct_iface_attr_v2_t` (e.g. SGL zcopy capabilities) would force callers to invoke `uct_iface_query()` for the main attributes and `uct_iface_query_v2()` for the v2-only fields.
By making `uct_iface_query_v2()` a superset, the same way `uct_md_query_v2()` replaced `uct_md_query()`, callers get a single extensible query API. `uct_iface_query()` is implemented on top of it.

## How?
- Extend `uct_iface_attr_v2_t` with all fields from `uct_iface_attr_t` and add `uct_iface_attr_field_t` field-mask enum.
- `uct_iface_query()` now calls `iface_query_v2` internally and converts v2 → v1, mirroring the md_query_v2 pattern.
- Remove `iface_query` from `uct_iface_ops_t`. All transports implement `iface_query_v2` instead.
- Add `iface_query_v2_consistency` test to verify v1 and v2 return the same attributes.