### PR TITLE
UCP/AM/PSN: resolve ep on init for reply ep lookup

### DIFF
--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -389,6 +389,19 @@ static void ucp_am_eager_multi_zcopy_psn_completion(uct_completion_t *self)
     }
 }
 
+static ucs_status_t ucp_am_eager_multi_zcopy_psn_init(ucp_request_t *req)
+{
+    const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    status = ucp_ep_resolve_remote_id(req->send.ep, mpriv->lanes[0].super.lane);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return ucp_am_eager_multi_zcopy_init(req);
+}
+
 static ucs_status_t
 ucp_am_eager_multi_zcopy_psn_proto_progress(uct_pending_req_t *self)
 {
@@ -397,9 +410,9 @@ ucp_am_eager_multi_zcopy_psn_proto_progress(uct_pending_req_t *self)
 
     /* coverity[tainted_data_downcast] */
     status = ucp_proto_multi_zcopy_progress(
-            req, req->send.proto_config->priv, ucp_am_eager_multi_zcopy_init,
-            UCT_MD_MEM_ACCESS_LOCAL_READ, UCP_DT_MASK_CONTIG_IOV,
-            ucp_am_eager_multi_zcopy_psn_send_func,
+            req, req->send.proto_config->priv,
+            ucp_am_eager_multi_zcopy_psn_init, UCT_MD_MEM_ACCESS_LOCAL_READ,
+            UCP_DT_MASK_CONTIG_IOV, ucp_am_eager_multi_zcopy_psn_send_func,
             ucp_request_invoke_uct_completion_success,
             ucp_am_eager_multi_zcopy_psn_completion);
     if (status == UCS_INPROGRESS) {


### PR DESCRIPTION
## What?
resolve ep on init for reply ep lookup in AM/PSN protocol

## Why?
FIX https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=119254&view=logs&j=e9f41fe8-0028-5581-5e8e-7a1cd6bcdb28&t=295210a1-365c-5340-a2e8-220f0ed895bd
```
2026-04-10T16:16:52.2405347Z [ RUN      ] dcx/test_ucp_fault_tolerance.initiator_failure/5 <dc_x/AM|FLUSH>
2026-04-10T16:16:52.5454943Z [     INFO ] AM BW lane: 1/2
2026-04-10T16:16:52.5456199Z [     INFO ] AM BW lane: 0/2
2026-04-10T16:16:52.5456772Z [     INFO ] Attempting AM|FLUSH operation before failure injection...
2026-04-10T16:16:52.5490958Z [swx-rain02-bf1:3948636:0:3948636] ucp_worker.inl:126  Assertion `id != UCS_PTR_MAP_KEY_INVALID' failed
2026-04-10T16:18:47.8047626Z ==== backtrace (tid:3948636) ====
2026-04-10T16:18:47.8049398Z  0 0x0000000000123aac ucp_worker_get_ep_by_id()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_worker.inl:126
2026-04-10T16:18:47.8050631Z  1 0x0000000000123aac ucs_ptr_hash_get()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/ptr_map.inl:66
2026-04-10T16:18:47.8051697Z  2 0x0000000000123aac ucs_ptr_map_get()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/ptr_map.inl:111
2026-04-10T16:18:47.8052612Z  3 0x0000000000123aac ucs_ptr_map_get_ep()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_worker.inl:18
2026-04-10T16:18:47.8053488Z  4 0x0000000000123aac ucp_worker_get_ep_by_id()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_worker.inl:127
2026-04-10T16:18:47.8054330Z  5 0x0000000000123aac ucp_am_is_duplicate_psn()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_am.c:1725
2026-04-10T16:18:47.8055189Z  6 0x0000000000123aac ucp_am_handler_first_psn_inner()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_am.c:1750
2026-04-10T16:18:47.8057369Z  7 0x0000000000123aac ucp_am_handler_first_psn()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_am.c:1743
2026-04-10T16:18:47.8059240Z  8 0x00000000001205c0 uct_iface_invoke_am()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/uct/base/uct_iface.h:903
2026-04-10T16:18:47.8061597Z  9 0x00000000001205c0 uct_rc_mlx5_iface_common_am_handler()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/mlx5/rc/rc_mlx5.inl:412
2026-04-10T16:18:47.8062579Z 10 0x00000000001205c0 uct_rc_mlx5_iface_common_poll_rx()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/mlx5/rc/rc_mlx5.inl:1492
2026-04-10T16:18:47.8063486Z 11 0x00000000001205c0 uct_dc_mlx5_iface_progress()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/mlx5/dc/dc_mlx5.c:321
2026-04-10T16:18:47.8064379Z 12 0x00000000001205c0 uct_dc_mlx5_iface_progress_ll()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/uct/ib/mlx5/dc/dc_mlx5.c:336
2026-04-10T16:18:47.8065241Z 13 0x0000000000198e7c ucs_callbackq_dispatch()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucs/datastruct/callbackq.h:215
2026-04-10T16:18:47.8066085Z 14 0x0000000000198e7c uct_worker_progress()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/uct/api/uct.h:2825
2026-04-10T16:18:47.8066918Z 15 0x0000000000198e7c ucp_worker_progress()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../src/ucp/core/ucp_worker.c:3189
2026-04-10T16:18:47.8067784Z 16 0x0000000001a76ee0 ucp_test_base::entity::progress()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/ucp_test.cc:1049
2026-04-10T16:18:47.8068631Z 17 0x0000000001a76ee0 ucp_test::progress()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/ucp_test.cc:172
2026-04-10T16:18:47.8069496Z 18 0x0000000001a78224 ucp_test::check_events()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/ucp_test.cc:250
2026-04-10T16:18:47.8070392Z 19 0x0000000001a78224 ucp_test::request_process()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/ucp_test.cc:293
2026-04-10T16:18:47.8071375Z 20 0x0000000001009184 test_ucp_fault_tolerance::do_am_send_and_wait()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/test_ucp_fault_tolerance.cc:338
2026-04-10T16:18:47.8072340Z 21 0x0000000001009184 test_ucp_fault_tolerance::do_am_send_and_wait()  /scrap/azure/agent-03/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucp/test_ucp_fault_tolerance.cc:338
```
