### PR TITLE
UCT/IB: Revert ARM Neon writing to BlueFlame

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -537,7 +537,7 @@ static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
                                                        void * restrict src)
 {
 #if defined(__ARM_NEON)
-    vst4q_u64(dst, vld4q_u64(src));
+    UCS_WORD_COPY(int16x8_t, dst, int16x8_t, src, MLX5_SEND_WQE_BB);
 #else
 #if defined(__SSE4_2__)
     typedef __m128i uct_ib_mlx5_send_wqe_bb_block_t;


### PR DESCRIPTION
## What?
Revert ARM Neon writing to BlueFlame

## Why?
There's no performance gain from using it on Grace, and on Fujitsu ARM it cause perf degradation

https://redmine.mellanox.com/issues/4273759
