### PR TITLE
UCT/DEVICE: use CPU mem as AMO local buf

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -224,10 +224,12 @@ uct_rc_gdaki_umem_reg(const uct_ib_md_t *md, struct ibv_context *ibv_context,
     umem_in.pgsz_bitmap = pgsz_bitmap;
 
     if (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM) {
-        dmabuf            = uct_cuda_copy_md_get_dmabuf(address, length,
-                                                        UCS_SYS_DEVICE_ID_UNKNOWN);
-        umem_in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
-        umem_in.dmabuf_fd = dmabuf.fd;
+        dmabuf = uct_cuda_copy_md_get_dmabuf(address, length,
+                                             UCS_SYS_DEVICE_ID_UNKNOWN);
+        if (dmabuf.fd != UCT_DMABUF_FD_INVALID) {
+            umem_in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
+            umem_in.dmabuf_fd = dmabuf.fd;
+        }
     }
 
     umem = mlx5dv_devx_umem_reg_ex(ibv_context, &umem_in);
@@ -871,13 +873,11 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
 
         for (i = 0; i < iface->num_channels; ++i) {
             channel = &ep->channel_block->channels[i];
-            status  = UCT_CUDADRV_FUNC_LOG_ERR(cuMemHostRegister(
-                    channel->qp.reg->addr.ptr, UCT_IB_MLX5_BF_REG_SIZE * 2,
-                    CU_MEMHOSTREGISTER_PORTABLE | CU_MEMHOSTREGISTER_DEVICEMAP |
-                            CU_MEMHOSTREGISTER_IOMEMORY));
-            if ((status != UCS_OK) && (i-- > 0)) {
-                goto out_unreg;
-            }
+            (void)cuMemHostRegister(channel->qp.reg->addr.ptr,
+                                    UCT_IB_MLX5_BF_REG_SIZE * 2,
+                                    CU_MEMHOSTREGISTER_PORTABLE |
+                                    CU_MEMHOSTREGISTER_DEVICEMAP |
+                                    CU_MEMHOSTREGISTER_IOMEMORY);
 
             status = UCT_CUDADRV_FUNC_LOG_ERR(
                     cuMemHostGetDevicePointer(&sq_db, channel->qp.reg->addr.ptr,

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -845,8 +845,8 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
         dev_ep           = ucs_calloc(1, dev_ep_host_size, "dev_ep");
         if (dev_ep == NULL) {
             ucs_error("failed to allocate dev_ep on host buffer size=%zu ep=%p "
-                      "iface=%p" dev_ep_host_size,
-                      ep, iface);
+                      "iface=%p",
+                      dev_ep_host_size, ep, iface);
             status = UCS_ERR_NO_MEMORY;
             goto out_ctx;
         }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -979,27 +979,6 @@ static uct_iface_ops_t uct_rc_gdaki_iface_tl_ops = {
             ucs_empty_function_return_unsupported,
 };
 
-static ucs_status_t uct_rc_gdaki_reg_mr(const uct_ib_md_t *md, void *address,
-                                        size_t length, struct ibv_mr **mr_p)
-{
-    uct_md_mem_reg_params_t params;
-    uct_cuda_copy_md_dmabuf_t dmabuf;
-    ucs_status_t status;
-
-    params.field_mask    = UCT_MD_MEM_REG_FIELD_FLAGS |
-                           UCT_MD_MEM_REG_FIELD_DMABUF_FD |
-                           UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET;
-    params.flags         = 0;
-    dmabuf               = uct_rc_gdaki_get_dmabuf(md, address, length);
-    params.dmabuf_fd     = dmabuf.fd;
-    params.dmabuf_offset = dmabuf.offset;
-
-    status = uct_ib_reg_mr(md, address, length, &params,
-                           UCT_IB_MEM_ACCESS_FLAGS, NULL, mr_p);
-    ucs_close_fd(&dmabuf.fd);
-    return status;
-}
-
 static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
                            uct_worker_h worker,
                            const uct_iface_params_t *params,
@@ -1009,6 +988,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
             ucs_derived_of(tl_config, uct_rc_gdaki_iface_config_t);
     uct_ib_mlx5_md_t *md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
     uct_ib_iface_init_attr_t init_attr = {};
+    uct_md_mem_reg_params_t reg_params = {};
     UCS_STRING_BUFFER_ONSTACK(strb, 64);
     char *gpu_name, *ib_name;
     char pci_addr[UCS_SYS_BDF_NAME_MAX];
@@ -1073,8 +1053,9 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
         goto err_ctx_release;
     }
 
-    status = uct_rc_gdaki_reg_mr(&md->super, &self->atomic_buff,
-                                 sizeof(uint64_t), &self->atomic_mr);
+    status = uct_ib_reg_mr(&md->super, &self->atomic_buff, sizeof(uint64_t),
+                           &reg_params, UCT_IB_MEM_ACCESS_FLAGS, NULL,
+                           &self->atomic_mr);
     if (status != UCS_OK) {
         goto err_ctx;
     }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -205,6 +205,7 @@ static int uct_gdaki_is_dmabuf_supported(const uct_ib_md_t *md)
     return dmabuf_supported;
 }
 
+#if HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF
 static uct_cuda_copy_md_dmabuf_t uct_rc_gdaki_get_dmabuf(const uct_ib_md_t *md,
                                                          const void *address,
                                                          size_t length)
@@ -222,6 +223,7 @@ static uct_cuda_copy_md_dmabuf_t uct_rc_gdaki_get_dmabuf(const uct_ib_md_t *md,
 
     return dmabuf;
 }
+#endif
 
 static struct mlx5dv_devx_umem *
 uct_rc_gdaki_umem_reg(const uct_ib_md_t *md, struct ibv_context *ibv_context,

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -863,7 +863,7 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
             goto out_free;
         }
 
-        dev_ep->atomic_va    = iface->atomic_buff;
+        dev_ep->atomic_va    = (void*)&iface->atomic_buff;
         dev_ep->atomic_lkey  = htonl(iface->atomic_mr->lkey);
         dev_ep->sq_wqe_num   = uct_ib_mlx5_devx_sq_length(
                 iface->super.super.config.tx_qp_len);
@@ -1073,16 +1073,10 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
         goto err_ctx_release;
     }
 
-    status = uct_rc_gdaki_alloc(sizeof(uint64_t), sizeof(uint64_t),
-                                (void**)&self->atomic_buff, &self->atomic_raw);
-    if (status != UCS_OK) {
-        goto err_ctx;
-    }
-
-    status = uct_rc_gdaki_reg_mr(&md->super, self->atomic_buff,
+    status = uct_rc_gdaki_reg_mr(&md->super, &self->atomic_buff,
                                  sizeof(uint64_t), &self->atomic_mr);
     if (status != UCS_OK) {
-        goto err_atomic;
+        goto err_ctx;
     }
 
     if (pthread_mutex_init(&self->ep_init_lock, NULL) != 0) {
@@ -1104,8 +1098,6 @@ err_pool:
     pthread_mutex_destroy(&self->ep_init_lock);
 err_lock:
     ibv_dereg_mr(self->atomic_mr);
-err_atomic:
-    cuMemFree(self->atomic_raw);
 err_ctx:
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
 err_ctx_release:
@@ -1121,7 +1113,6 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_gdaki_iface_t)
     if (self->ep_alloc_mode == UCT_RC_GDAKI_EP_ALLOC_MODE_POOL) {
         uct_rc_gdaki_iface_cleanup_channel_pool(self);
     }
-    cuMemFree(self->atomic_raw);
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(self->cuda_dev));
 }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -205,47 +205,37 @@ static int uct_gdaki_is_dmabuf_supported(const uct_ib_md_t *md)
     return dmabuf_supported;
 }
 
-#if HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF
-static uct_cuda_copy_md_dmabuf_t uct_rc_gdaki_get_dmabuf(const uct_ib_md_t *md,
-                                                         const void *address,
-                                                         size_t length)
-{
-    uct_ib_mlx5_md_t *ib_mlx5_md     = ucs_derived_of(md, uct_ib_mlx5_md_t);
-    uct_cuda_copy_md_dmabuf_t dmabuf = {
-        .fd     = UCT_DMABUF_FD_INVALID,
-        .offset = 0
-    };
-
-    if (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM) {
-        return uct_cuda_copy_md_get_dmabuf(address, length,
-                                           UCS_SYS_DEVICE_ID_UNKNOWN);
-    }
-
-    return dmabuf;
-}
-#endif
-
 static struct mlx5dv_devx_umem *
 uct_rc_gdaki_umem_reg(const uct_ib_md_t *md, struct ibv_context *ibv_context,
                       void *address, size_t length, uint64_t pgsz_bitmap)
 {
 #if HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF
+    uct_ib_mlx5_md_t *ib_mlx5_md       = ucs_derived_of(md, uct_ib_mlx5_md_t);
     struct mlx5dv_devx_umem_in umem_in = {};
-    uct_cuda_copy_md_dmabuf_t dmabuf;
+    uct_cuda_copy_md_dmabuf_t dmabuf   = {
+        .fd     = UCT_DMABUF_FD_INVALID,
+        .offset = 0
+    };
     struct mlx5dv_devx_umem *umem;
 
     umem_in.addr        = address;
     umem_in.size        = length;
     umem_in.access      = IBV_ACCESS_LOCAL_WRITE;
     umem_in.pgsz_bitmap = pgsz_bitmap;
-    dmabuf              = uct_rc_gdaki_get_dmabuf(md, address, length);
-    if (dmabuf.fd != UCT_DMABUF_FD_INVALID) {
+
+    if (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM) {
+        dmabuf            = uct_cuda_copy_md_get_dmabuf(address, length,
+                                                        UCS_SYS_DEVICE_ID_UNKNOWN);
         umem_in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
         umem_in.dmabuf_fd = dmabuf.fd;
     }
 
     umem = mlx5dv_devx_umem_reg_ex(ibv_context, &umem_in);
-    ucs_close_fd(&dmabuf.fd);
+
+    if (dmabuf.fd != UCT_DMABUF_FD_INVALID) {
+        ucs_close_fd(&dmabuf.fd);
+    }
+
     return umem;
 #else
     return mlx5dv_devx_umem_reg(ibv_context, address, length,

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -855,7 +855,7 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
             goto out_free;
         }
 
-        dev_ep->atomic_va    = (void*)&iface->atomic_buff;
+        dev_ep->atomic_va    = iface->atomic_buff;
         dev_ep->atomic_lkey  = htonl(iface->atomic_mr->lkey);
         dev_ep->sq_wqe_num   = uct_ib_mlx5_devx_sq_length(
                 iface->super.super.config.tx_qp_len);
@@ -986,6 +986,7 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
     char pci_addr[UCS_SYS_BDF_NAME_MAX];
     ucs_status_t status;
     int cuda_id;
+    int ret;
 
     if (config->num_channels > UINT8_MAX + 1) {
          ucs_error("num_channels exceeds maximum value of 256");
@@ -1045,11 +1046,20 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
         goto err_ctx_release;
     }
 
-    status = uct_ib_reg_mr(&md->super, &self->atomic_buff, sizeof(uint64_t),
+    ret = ucs_posix_memalign((void**)&self->atomic_buff,
+                             UCS_SYS_CACHE_LINE_SIZE, sizeof(uint64_t),
+                             "gdaki_atomic_buf");
+    if (ret != 0) {
+        ucs_error("failed to allocate AMO buffer");
+        status = UCS_ERR_NO_MEMORY;
+        goto err_ctx;
+    }
+
+    status = uct_ib_reg_mr(&md->super, self->atomic_buff, sizeof(uint64_t),
                            &reg_params, UCT_IB_MEM_ACCESS_FLAGS, NULL,
                            &self->atomic_mr);
     if (status != UCS_OK) {
-        goto err_ctx;
+        goto err_atomic_buff;
     }
 
     if (pthread_mutex_init(&self->ep_init_lock, NULL) != 0) {
@@ -1071,6 +1081,8 @@ err_pool:
     pthread_mutex_destroy(&self->ep_init_lock);
 err_lock:
     ibv_dereg_mr(self->atomic_mr);
+err_atomic_buff:
+    ucs_free(self->atomic_buff);
 err_ctx:
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
 err_ctx_release:
@@ -1082,6 +1094,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_gdaki_iface_t)
 {
     pthread_mutex_destroy(&self->ep_init_lock);
     ibv_dereg_mr(self->atomic_mr);
+    ucs_free(self->atomic_buff);
     (void)UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(self->cuda_ctx));
     if (self->ep_alloc_mode == UCT_RC_GDAKI_EP_ALLOC_MODE_POOL) {
         uct_rc_gdaki_iface_cleanup_channel_pool(self);

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -844,6 +844,9 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
                            iface->num_channels * UCT_GDAKI_DEV_QP_SIZE;
         dev_ep           = ucs_calloc(1, dev_ep_host_size, "dev_ep");
         if (dev_ep == NULL) {
+            ucs_error("failed to allocate dev_ep on host buffer size=%zu ep=%p "
+                      "iface=%p" dev_ep_host_size,
+                      ep, iface);
             status = UCS_ERR_NO_MEMORY;
             goto out_ctx;
         }
@@ -868,11 +871,13 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
 
         for (i = 0; i < iface->num_channels; ++i) {
             channel = &ep->channel_block->channels[i];
-            (void)cuMemHostRegister(channel->qp.reg->addr.ptr,
-                                    UCT_IB_MLX5_BF_REG_SIZE * 2,
-                                    CU_MEMHOSTREGISTER_PORTABLE |
-                                    CU_MEMHOSTREGISTER_DEVICEMAP |
-                                    CU_MEMHOSTREGISTER_IOMEMORY);
+            status  = UCT_CUDADRV_FUNC_LOG_ERR(cuMemHostRegister(
+                    channel->qp.reg->addr.ptr, UCT_IB_MLX5_BF_REG_SIZE * 2,
+                    CU_MEMHOSTREGISTER_PORTABLE | CU_MEMHOSTREGISTER_DEVICEMAP |
+                            CU_MEMHOSTREGISTER_IOMEMORY));
+            if ((status != UCS_OK) && (i-- > 0)) {
+                goto out_unreg;
+            }
 
             status = UCT_CUDADRV_FUNC_LOG_ERR(
                     cuMemHostGetDevicePointer(&sq_db, channel->qp.reg->addr.ptr,
@@ -892,7 +897,7 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
                 cuMemcpyHtoD((CUdeviceptr)ep->channel_block->gpu_ptr, dev_ep,
                              dev_ep_host_size));
         if (status != UCS_OK) {
-            goto out_free;
+            goto out_unreg;
         }
 
         ucs_free(dev_ep);

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -38,8 +38,7 @@ typedef struct uct_rc_gdaki_iface {
     uct_rc_mlx5_iface_common_t super;
     CUdevice                   cuda_dev;
     struct ibv_mr              *atomic_mr;
-    CUdeviceptr                atomic_raw;
-    uint64_t                   *atomic_buff;
+    uint64_t                   atomic_buff;
     CUcontext                  cuda_ctx;
     unsigned                   num_channels;
     unsigned                   ep_alloc_mode;

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -38,7 +38,7 @@ typedef struct uct_rc_gdaki_iface {
     uct_rc_mlx5_iface_common_t super;
     CUdevice                   cuda_dev;
     struct ibv_mr              *atomic_mr;
-    uint64_t                   atomic_buff;
+    uint64_t                   *atomic_buff;
     CUcontext                  cuda_ctx;
     unsigned                   num_channels;
     unsigned                   ep_alloc_mode;


### PR DESCRIPTION
## What?
Use CPU memory as the AMO swap local buffer.

## Why?
By using CPU memory as the AMO local buffer, we're able to prevent CUDA context retain during iface init.

> Nodes: 2
Ranks: 2 * 8
Experts: 2 * 8 * 16
Mode: rdma only
Tokens: 2,4,8,16,32,64,128,256,512

Amo local buf on cpu:
 token | D+C BW (GB/s) | Dispatch (GB/s) | Combine (GB/s) | Disp send (us) | Disp recv (us) | Comb send (us) | Comb recv (us)
-------|------------------|-------------------|------------------|-----------------|-----------------|------------------|----
|     2 |          2.88 |            2.41 |           3.86 |          13.71 |           6.55 |          15.39 |           8.88
|     4 |          7.33 |            6.29 |           9.44 |          14.16 |           6.67 |          15.49 |          10.00
|     8 |         14.17 |           12.80 |          17.12 |          13.93 |           6.82 |          15.67 |          10.56
|    16 |         23.47 |           21.75 |          26.66 |          14.41 |           6.88 |          16.13 |          10.72
|    32 |         32.61 |           31.38 |          35.46 |          15.56 |           7.05 |          17.36 |          11.04
|    64 |         40.14 |           39.97 |          41.55 |          16.57 |           7.90 |          19.92 |          11.84
|   128 |         44.30 |           45.15 |          44.61 |          19.05 |           9.90 |          27.51 |          16.53
|   256 |         46.67 |           47.95 |          46.51 |          27.60 |          16.66 |          45.69 |          27.68
|   512 |         47.78 |           49.37 |          47.00 |          42.86 |          30.60 |          77.54 |          50.03

Amo local buf on gpu:
 token | D+C BW (GB/s) | Dispatch (GB/s) | Combine (GB/s) | Disp send (us) | Disp recv (us) | Comb send (us) | Comb recv (us)
-------|------------------|-------------------|------------------|-----------------|-----------------|------------------|----
|     2 |          2.87 |            2.40 |           3.85 |          13.64 |           6.55 |          15.36 |           8.88
|     4 |          7.34 |            6.30 |           9.41 |          14.15 |           6.68 |          15.47 |          10.00
|     8 |         14.20 |           12.67 |          17.13 |          13.90 |           6.82 |          15.64 |          10.55
|    16 |         23.48 |           21.57 |          26.68 |          14.39 |           6.89 |          16.12 |          10.71
|    32 |         32.62 |           31.81 |          35.24 |          15.52 |           7.06 |          17.41 |          11.03
|    64 |         40.14 |           40.09 |          41.58 |          16.60 |           7.90 |          19.96 |          11.86
|   128 |         44.38 |           45.21 |          44.81 |          19.07 |           9.90 |          27.44 |          16.53
|   256 |         46.58 |           48.02 |          46.41 |          27.58 |          16.70 |          45.72 |          27.69
|   512 |         47.72 |           49.55 |          46.90 |          42.82 |          30.60 |          77.59 |          50.02
-----------------------------------------------------------------------------------------------------------------------------
