### PR TITLE
UCP: Use NO_RESOURCE for proxy stub iface

### DIFF
--- a/src/ucp/core/ucp_proxy_ep.c
+++ b/src/ucp/core/ucp_proxy_ep.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -134,7 +134,7 @@ UCS_CLASS_INIT_FUNC(ucp_proxy_ep_t, const uct_iface_ops_t *ops, ucp_ep_h ucp_ep,
     uct_iface_close_func_t stub_close;
     ucs_status_t status;
 
-    status = ucp_stub_iface_open(UCS_ERR_UNSUPPORTED, &self->iface);
+    status = ucp_stub_iface_open(UCS_ERR_NO_RESOURCE, &self->iface);
     if (status != UCS_OK) {
         return status;
     }


### PR DESCRIPTION
## What?
Open the proxy stub iface with `UCS_ERR_NO_RESOURCE` so stub/internal paths align with “not ready, retry” semantics.

## Why?
`UCS_ERR_NO_RESOURCE` fits a stub that is not ready yet rather than a missing feature.

## How?
Pass `UCS_ERR_NO_RESOURCE` into `ucp_stub_iface_open()`.