### PR TITLE
UCP/EP/FT: handle the case when no more lanes to fallback 

### DIFF
--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -75,7 +75,7 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
         return UCS_ERR_NO_MEMORY;
     }
 
-    ucp_trace_req(req, "allocating AM header descriptor 0x%p", reg_desc);
+    ucp_trace_req(req, "allocating AM header descriptor %p", reg_desc);
     if (req->send.msg_proto.am.header.length != 0) {
         ucs_assert(req->send.msg_proto.am.header.ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);

--- a/src/ucp/am/eager.inl
+++ b/src/ucp/am/eager.inl
@@ -75,6 +75,7 @@ ucp_am_eager_zcopy_pack_user_header(ucp_request_t *req)
         return UCS_ERR_NO_MEMORY;
     }
 
+    ucp_trace_req(req, "allocating AM header descriptor 0x%p", reg_desc);
     if (req->send.msg_proto.am.header.length != 0) {
         ucs_assert(req->send.msg_proto.am.header.ptr != NULL);
         ucp_am_pack_user_header(reg_desc + 1, req);

--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -403,14 +403,8 @@ static ucs_status_t ucp_am_eager_multi_zcopy_psn_init(ucp_request_t *req)
         return status;
     }
 
-    /**
-     * At least 1 non-failed AM lane must be available.
-     */
-    if (ucp_ep_get_am_lane(req->send.ep) == UCP_NULL_LANE) {
-        ucs_trace_req("req %p: ep %p does not have any AM lanes",
-                      req, req->send.ep);
-        return UCS_ERR_UNREACHABLE;
-    }
+    ucs_assertv(ucp_ep_get_am_lane(req->send.ep) != UCP_NULL_LANE,
+                "req %p: ep %p does not have any AM lanes", req, req->send.ep);
 
     return ucp_am_eager_multi_zcopy_init(req);
 }
@@ -447,8 +441,8 @@ static ucs_status_t ucp_am_eager_multi_zcopy_psn_reset(ucp_request_t *req)
         return status;
     }
 
-    return (ucp_ep_get_am_lane(req->send.ep) == UCP_NULL_LANE) ?
-           UCS_ERR_UNREACHABLE : UCS_OK;
+    ucs_assert(ucp_ep_get_am_lane(req->send.ep) != UCP_NULL_LANE);
+    return UCS_OK;
 }
 
 ucp_proto_t ucp_am_eager_multi_zcopy_psn_proto = {

--- a/src/ucp/am/eager_multi.c
+++ b/src/ucp/am/eager_multi.c
@@ -380,7 +380,11 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_eager_multi_zcopy_psn_send_func(
 
 static void ucp_am_eager_multi_zcopy_psn_completion(uct_completion_t *self)
 {
-    if (ucs_likely(self->status == UCS_OK)) {
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t,
+                                          send.state.uct_comp);
+
+    if (ucs_likely(self->status == UCS_OK) ||
+        (req->send.ep->flags & UCP_EP_FLAG_FAILED)) {
         ucp_am_eager_zcopy_completion(self);
     } else {
         /* NOTE: do not release the user header to allow the request to be
@@ -397,6 +401,15 @@ static ucs_status_t ucp_am_eager_multi_zcopy_psn_init(ucp_request_t *req)
     status = ucp_ep_resolve_remote_id(req->send.ep, mpriv->lanes[0].super.lane);
     if (status != UCS_OK) {
         return status;
+    }
+
+    /**
+     * At least 1 non-failed AM lane must be available.
+     */
+    if (ucp_ep_get_am_lane(req->send.ep) == UCP_NULL_LANE) {
+        ucs_trace_req("req %p: ep %p does not have any AM lanes",
+                      req, req->send.ep);
+        return UCS_ERR_UNREACHABLE;
     }
 
     return ucp_am_eager_multi_zcopy_init(req);
@@ -430,7 +443,12 @@ static ucs_status_t ucp_am_eager_multi_zcopy_psn_reset(ucp_request_t *req)
     ucp_datatype_iter_rewind(&req->send.state.dt_iter, UCP_DT_MASK_CONTIG_IOV);
     /* Restart the request from the very first fragment */
     req->send.msg_proto.am.internal_flags &= ~UCP_REQUEST_AM_FLAG_HEADER_SENT;
-    return status;
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return (ucp_ep_get_am_lane(req->send.ep) == UCP_NULL_LANE) ?
+           UCS_ERR_UNREACHABLE : UCS_OK;
 }
 
 ucp_proto_t ucp_am_eager_multi_zcopy_psn_proto = {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1616,7 +1616,7 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
     ++ucp_ep->worker->counters.ep_failures;
 
     /* The EP can be closed from last completion callback */
-    ucp_ep_discard_lanes(ucp_ep, UCS_MASK(ucp_ep_num_lanes(ucp_ep)), status,
+    ucp_ep_discard_lanes(ucp_ep, ucp_ep_get_live_lanes(ucp_ep), status,
                          ucp_ep->cfg_index);
     ucp_stream_ep_cleanup(ucp_ep, status);
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -854,7 +854,7 @@ static ucs_status_t ucp_ep_init_create_wireup(ucp_ep_h ep,
         return status;
     }
 
-    ucp_ep_set_cfg_index(ep, cfg_index);
+    ucp_ep_set_cfg_index(ep, cfg_index, 1);
     ep->am_lane = key.am_lane;
     if (!ucp_ep_has_cm_lane(ep)) {
         ucp_ep_update_flags(ep, UCP_EP_FLAG_CONNECT_REQ_QUEUED, 0);
@@ -1463,6 +1463,9 @@ ucp_ep_config_reactivate_worker_ifaces(ucp_worker_h worker,
                                        ucp_worker_cfg_index_t old_cfg_index,
                                        ucp_worker_cfg_index_t new_cfg_index)
 {
+    ucs_trace("worker %p: reactivating interfaces deactivate cfg_index %u "
+              "activate cfg_index %u", worker, old_cfg_index, new_cfg_index);
+
     if (old_cfg_index == new_cfg_index) {
         return;
     }
@@ -1487,6 +1490,7 @@ static void ucp_ep_discard_lanes_callback(void *request, ucs_status_t status,
         return;
     }
 
+    ucs_trace("ep %p: discard lanes completed", arg->ucp_ep);
     ucp_ep_reqs_purge(arg->ucp_ep, arg->status);
     ucp_ep_config_reactivate_worker_ifaces(arg->ucp_ep->worker,
                                            arg->deactivate_cfg_index,
@@ -1535,6 +1539,8 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
          * endpoint's requests, if we already started discard and purge process
          * this endpoint. Doing so could complete send requests before UCT lanes
          * using them are flushed and destroyed. */
+        ucp_ep_config_reactivate_worker_ifaces(ep->worker, old_cfg_index,
+                                               ep->cfg_index);
         return;
     }
 
@@ -1666,6 +1672,7 @@ ucp_ep_reconfig_internal(ucp_ep_h ep, ucp_lane_map_t failed_lanes)
     int port_speed_changed       = 0;
     ucp_lane_index_t lane;
     ucp_worker_iface_t *wiface;
+    ucp_worker_cfg_index_t new_cfg_index;
     ucs_status_t status;
 
     for (lane = 0; lane < cfg_key.num_lanes; lane++) {
@@ -1709,11 +1716,12 @@ ucp_ep_reconfig_internal(ucp_ep_h ep, ucp_lane_map_t failed_lanes)
     }
 
     status = ucp_worker_get_ep_config(worker, &cfg_key, ep_init_flags,
-                                      &ep->cfg_index);
+                                      &new_cfg_index);
     if (status != UCS_OK) {
         return status;
     }
 
+    ucp_ep_set_cfg_index(ep, new_cfg_index, 0);
     ep->am_lane = cfg_key.am_lane;
 out:
     return UCS_OK;
@@ -1731,6 +1739,9 @@ ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
 
     status = ucp_ep_reconfig_internal(ucp_ep, failed_lanes);
     if (status != UCS_OK) {
+        ucs_assertv(ucp_ep->cfg_index == old_cfg_index,
+                    "ep %p: cfg_index %u -> %u after reconfiguration error %s", ucp_ep, old_cfg_index,
+                    ucp_ep->cfg_index, ucs_status_string(status));
         return status;
     }
 
@@ -4151,9 +4162,15 @@ static void ucp_ep_config_proto_init(ucp_worker_h worker,
                              &ep_config->am_u.max_reply_eager_short);
 }
 
-void ucp_ep_set_cfg_index(ucp_ep_h ep, ucp_worker_cfg_index_t cfg_index)
+void ucp_ep_set_cfg_index(ucp_ep_h ep, ucp_worker_cfg_index_t cfg_index,
+                          int reactivate)
 {
-    ucp_ep_config_reactivate_worker_ifaces(ep->worker, ep->cfg_index, cfg_index);
+    if (reactivate) {
+        ucp_ep_config_reactivate_worker_ifaces(ep->worker, ep->cfg_index,
+                                               cfg_index);
+    }
+
+    ucs_trace("ep %p: set cfg_index %u -> %u", ep, ep->cfg_index, cfg_index);
     ep->cfg_index = cfg_index;
     ucp_ep_config_proto_init(ep->worker, cfg_index);
 }

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1740,8 +1740,9 @@ ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
     status = ucp_ep_reconfig_internal(ucp_ep, failed_lanes);
     if (status != UCS_OK) {
         ucs_assertv(ucp_ep->cfg_index == old_cfg_index,
-                    "ep %p: cfg_index %u -> %u after reconfiguration error %s", ucp_ep, old_cfg_index,
-                    ucp_ep->cfg_index, ucs_status_string(status));
+                    "ep %p: cfg_index %u -> %u after reconfiguration error %s",
+                    ucp_ep, old_cfg_index, ucp_ep->cfg_index,
+                    ucs_status_string(status));
         return status;
     }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -960,8 +960,11 @@ ucs_status_t ucp_ep_realloc_lanes(ucp_ep_h ep, unsigned new_num_lanes);
  *
  * @param [in] ep         Endpoint object.
  * @param [in] cfg_index  Endpoint configuration index.
+ * @param [in] reactivate Flag indicating whether to reactivate worker
+ *                        interfaces.
  */
-void ucp_ep_set_cfg_index(ucp_ep_h ep, ucp_worker_cfg_index_t cfg_index);
+void ucp_ep_set_cfg_index(ucp_ep_h ep, ucp_worker_cfg_index_t cfg_index,
+                          int reactivate);
 
 
 /**

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -841,7 +841,9 @@ void ucp_proto_request_restart(ucp_request_t *req)
 
     status = proto_config->proto->reset(req);
     if (status != UCS_OK) {
-        ucs_assert_always(status == UCS_ERR_CANCELED);
+        ucs_assertv_always(status == UCS_ERR_CANCELED,
+                           "req %p, failed to reset: status %s", req,
+                           ucs_status_string(status));
         return;
     }
 

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -104,7 +104,8 @@ ucp_proto_request_zcopy_complete(ucp_request_t *req, ucs_status_t status)
     }
 
     if (ucs_unlikely(status != UCS_OK) &&
-        ucp_ep_err_mode_eq(req->send.ep, UCP_ERR_HANDLING_MODE_FAILOVER)) {
+        ucp_ep_err_mode_eq(req->send.ep, UCP_ERR_HANDLING_MODE_FAILOVER) &&
+        !(req->send.ep->flags & UCP_EP_FLAG_FAILED)) {
         ucp_proto_request_restart(req);
     } else {
         ucp_request_complete_send(req, status);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1951,7 +1951,7 @@ ucs_status_t ucp_wireup_init_lanes(ucp_ep_h ep, unsigned ep_init_flags,
         ucs_fatal("endpoint reconfiguration not supported yet");
     }
 
-    ucp_ep_set_cfg_index(ep, new_cfg_index);
+    ucp_ep_set_cfg_index(ep, new_cfg_index, 1);
     ep->am_lane = key.am_lane;
 
     snprintf(str, sizeof(str), "ep %p", ep);

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -513,7 +513,7 @@ static unsigned ucp_cm_client_uct_connect_progress(void *arg)
             goto err;
         }
 
-        ucp_ep_set_cfg_index(ep, cfg_index);
+        ucp_ep_set_cfg_index(ep, cfg_index, 1);
         ep->am_lane = key.am_lane;
 
         status = ucp_cm_ep_init_lanes(ep, &tl_bitmap);

--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -223,14 +223,15 @@ protected:
                                         << ucs_status_string(status);
                 ASSERT_EQ(0, m_err_count) << "Error callback invoked " << m_err_count << " times";
             } else {
+                // The last lane is expected to fail
                 short_progress_loop();
-                size_t min_expected_err_count = 1;
                 if ((failure_side == FAILURE_SIDE_TARGET) &&
                     has_transport("dc_x")) {
-                    min_expected_err_count = 0;
+                    // DC transport is not able to detect failure of remote DCI since DC is a connect2iface transport.
+                    // This is a test limitation.
+                } else {
+                    ASSERT_EQ(1, m_err_count) << "Error callback invoked " << m_err_count << " times";
                 }
-                ASSERT_LE(min_expected_err_count, m_err_count)
-                        << "Error callback invoked " << m_err_count << " times";
             }
         }
 
@@ -350,7 +351,6 @@ private:
     }
 
     ucs_status_t do_am_send_and_wait(ucp_ep_h ep, size_t size, bool flush_after) {
-
         m_am_received = false;
 
         mem_buffer sbuf(size, UCS_MEMORY_TYPE_HOST);

--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -30,7 +30,7 @@ public:
                                op_name(TEST_OP_GET | TEST_OP_FLUSH));
         add_variant_with_value(variants, UCP_FEATURE_AM,  TEST_OP_AM,
                                op_name(TEST_OP_AM));
-        add_variant_with_value(variants, UCP_FEATURE_AM | UCP_FEATURE_RMA,  TEST_OP_AM | TEST_OP_FLUSH,
+        add_variant_with_value(variants, UCP_FEATURE_AM,  TEST_OP_AM | TEST_OP_FLUSH,
                                op_name(TEST_OP_AM | TEST_OP_FLUSH));
     }
 
@@ -185,8 +185,18 @@ protected:
         EXPECT_EQ(UCS_OK, status) << op_str << " operation returned status: "
                                   << ucs_status_string(status);
 
+        size_t num_lanes_to_fail = am_bw_lanes.size();
+        if (has_any_transport({"ud_v", "ud_x"}) &&
+            (failure_side == FAILURE_SIDE_INITIATOR)) {
+            /* TODO: remove this once UD ep purge assertions are fixed */
+            UCS_TEST_MESSAGE << "Keep 1 live lane for UD transports since "
+                             << "local error injection on all lanes leads to "
+                                "failed assertion in ud_ep_purge";
+            num_lanes_to_fail--;
+        }
+
         ucp_ep_h ucp_ep_for_injection = get_ucp_ep_for_err_injection(failure_side);
-        for (size_t lane_idx = 0; lane_idx < am_bw_lanes.size() - 1; ++lane_idx) {
+        for (size_t lane_idx = 0; lane_idx < num_lanes_to_fail; ++lane_idx) {
             ucp_lane_index_t lane = am_bw_lanes[lane_idx];
             uct_ep_h uct_ep_for_injection = ucp_ep_get_lane(ucp_ep_for_injection, lane);
             status = uct_ep_invalidate(uct_ep_for_injection, 0);
@@ -200,14 +210,30 @@ protected:
             UCS_TEST_MESSAGE << "Attempting " << op_str
                              << " operation after failure injection on lane "
                              << size_t(lane) << '/' << am_bw_lanes.size() << "...";
+
+            std::unique_ptr<scoped_log_handler> slh;
+            if (lane_idx == (am_bw_lanes.size() - 1)) {
+                slh.reset(new scoped_log_handler(hide_errors_logger));
+            }
+
             status = do_am_send_and_wait(sender().ep(0, INJECTED_EP_INDEX), am_msg_size(),
                                          op_mask & TEST_OP_FLUSH);
-            EXPECT_EQ(UCS_OK, status) << op_str << " operation returned status: "
-                                      << ucs_status_string(status);
+            if (lane_idx < (am_bw_lanes.size() - 1)) {
+                EXPECT_EQ(UCS_OK, status) << op_str << " operation returned status: "
+                                        << ucs_status_string(status);
+                ASSERT_EQ(0, m_err_count) << "Error callback invoked " << m_err_count << " times";
+            } else {
+                short_progress_loop();
+                size_t min_expected_err_count = 1;
+                if ((failure_side == FAILURE_SIDE_TARGET) &&
+                    has_transport("dc_x")) {
+                    min_expected_err_count = 0;
+                }
+                ASSERT_LE(min_expected_err_count, m_err_count)
+                        << "Error callback invoked " << m_err_count << " times";
+            }
         }
 
-        short_progress_loop();
-        ASSERT_EQ(0, m_err_count) << "Error callback invoked " << m_err_count << " times";
         UCS_TEST_MESSAGE << "Success";
     }
 
@@ -324,6 +350,7 @@ private:
     }
 
     ucs_status_t do_am_send_and_wait(ucp_ep_h ep, size_t size, bool flush_after) {
+
         m_am_received = false;
 
         mem_buffer sbuf(size, UCS_MEMORY_TYPE_HOST);
@@ -337,6 +364,7 @@ private:
         if (flush_after) {
             ucs_status_t status = request_wait(ucp_ep_flush_nbx(ep, &param));
             if (status != UCS_OK) {
+                request_wait(sptr);
                 return status;
             }
         }
@@ -355,9 +383,10 @@ private:
                                  ucp_rkey_h rkey, size_t size, bool flush) {
         ucp_request_param_t param;
         param.op_attr_mask = 0;
-
         rbuf.memset(0);
-        ucs_status_ptr_t put_status_ptr   = ucp_put_nbx(ep, lbuf.ptr(), size, uintptr_t(rbuf.ptr()), rkey, &param);
+
+        ucs_status_ptr_t put_status_ptr   = ucp_put_nbx(ep, lbuf.ptr(), size, uintptr_t(rbuf.ptr()),
+                                                        rkey, &param);
         ucs_status_ptr_t flush_status_ptr = flush ? ucp_ep_flush_nbx(ep, &param) : NULL;
         ucs_status_t status               = request_wait(put_status_ptr);
         if (status == UCS_OK) {


### PR DESCRIPTION
## What?
Handle the case when no more lanes to fallback, fixes:
- recursive request restart from zcopy completion
- am header leak
- ep_config ref counter fix for ifaces reactivation in lanes discard flow

## Why?
to fix various failures like hang, segfaults and assertions
