### PR TITLE
UCT/DEVOCE: code optimize option

### DIFF
--- a/src/ucp/api/device/ucp_device_impl.h
+++ b/src/ucp/api/device/ucp_device_impl.h
@@ -197,6 +197,7 @@ ucp_device_prepare_send(const ucp_device_local_mem_list_h src_mem_list_h,
  * @param [in]  channel_id         Channel ID to use for the transfer.
  * @param [in]  flags              Flags usable to modify the function behavior.
  * @param [out] req                Request populated by the call.
+ * @param [in]  code_opt           Code optimization hint.
  *
  * @return UCS_INPROGRESS     - Operation successfully posted. If @a req is not
  *                              NULL, use @ref ucp_device_progress_req to check
@@ -210,7 +211,8 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
                unsigned src_mem_list_index, const size_t src_offset,
                const ucp_device_remote_mem_list_h dst_mem_list_h,
                unsigned dst_mem_list_index, size_t dst_offset, size_t length,
-               unsigned channel_id, uint64_t flags, ucp_device_request_t *req)
+               unsigned channel_id, uint64_t flags, ucp_device_request_t *req,
+               uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
     const void *address;
     const uct_device_mem_element_t *uct_elem;
@@ -232,7 +234,7 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
                                     src_uct_elem, uct_elem,
                                     UCS_PTR_BYTE_OFFSET(address, src_offset),
                                     remote_address + dst_offset, length,
-                                    channel_id, flags, comp);
+                                    channel_id, flags, comp, code_opt);
 }
 
 
@@ -261,6 +263,7 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
  * @param [in]  channel_id     Channel ID to use for the transfer.
  * @param [in]  flags          Flags usable to modify the function behavior.
  * @param [out] req            Request populated by the call.
+ * @param [in]  code_opt       Code optimization hint.
  *
  * @return UCS_INPROGRESS     - Operation successfully posted. If @a req is not
  *                              NULL, use @ref ucp_device_progress_req to check
@@ -272,7 +275,8 @@ template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
 UCS_F_DEVICE ucs_status_t ucp_device_counter_inc(
         const uint64_t inc_value, const ucp_device_remote_mem_list_h mem_list_h,
         unsigned mem_list_index, size_t offset, unsigned channel_id,
-        uint64_t flags, ucp_device_request_t *req)
+        uint64_t flags, ucp_device_request_t *req,
+        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
     uint64_t remote_address;
     const uct_device_mem_element_t *uct_elem;
@@ -290,7 +294,7 @@ UCS_F_DEVICE ucs_status_t ucp_device_counter_inc(
     return UCP_DEVICE_SEND_BLOCKING(level, uct_device_ep_atomic_add, device_ep,
                                     req, uct_elem, inc_value,
                                     remote_address + offset, channel_id, flags,
-                                    comp);
+                                    comp, code_opt);
 }
 
 

--- a/src/ucp/api/device/ucp_device_impl.h
+++ b/src/ucp/api/device/ucp_device_impl.h
@@ -87,12 +87,13 @@ UCS_F_DEVICE void ucp_device_request_init(uct_device_ep_t *device_ep,
 /**
  * Macro for device put operations with retry logic
  */
-#define UCP_DEVICE_SEND_BLOCKING(_level, _uct_device_ep_send, _device_ep, \
-                                 _req, ...) \
+#define UCP_DEVICE_SEND_BLOCKING(_level, _code_opt, _uct_device_ep_send, \
+                                 _device_ep, _req, ...) \
     ({ \
         ucs_status_t _status; \
         do { \
-            _status = _uct_device_ep_send<_level>(_device_ep, __VA_ARGS__); \
+            _status = _uct_device_ep_send<_level, _code_opt>(_device_ep, \
+                                                             __VA_ARGS__); \
             if (_status != UCS_ERR_NO_RESOURCE) { \
                 break; \
             } \
@@ -187,6 +188,7 @@ ucp_device_prepare_send(const ucp_device_local_mem_list_h src_mem_list_h,
  * of the routine with bit from @ref ucp_device_flags_t.
  *
  * @tparam      level              Level of cooperation of the transfer.
+ * @tparam      code_opt           Code optimization hint.
  * @param [in]  src_mem_list_h     Local memory descriptor list handle to use.
  * @param [in]  src_mem_list_index Index in descriptor list pointing to the memory
  * @param [in]  src_offset         Local offset to send data from.
@@ -197,7 +199,6 @@ ucp_device_prepare_send(const ucp_device_local_mem_list_h src_mem_list_h,
  * @param [in]  channel_id         Channel ID to use for the transfer.
  * @param [in]  flags              Flags usable to modify the function behavior.
  * @param [out] req                Request populated by the call.
- * @param [in]  code_opt           Code optimization hint.
  *
  * @return UCS_INPROGRESS     - Operation successfully posted. If @a req is not
  *                              NULL, use @ref ucp_device_progress_req to check
@@ -205,14 +206,14 @@ ucp_device_prepare_send(const ucp_device_local_mem_list_h src_mem_list_h,
  * @return UCS_OK             - Operation completed successfully.
  * @return Error code as defined by @ref ucs_status_t
  */
-template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
+template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t
 ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
                unsigned src_mem_list_index, const size_t src_offset,
                const ucp_device_remote_mem_list_h dst_mem_list_h,
                unsigned dst_mem_list_index, size_t dst_offset, size_t length,
-               unsigned channel_id, uint64_t flags, ucp_device_request_t *req,
-               uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+               unsigned channel_id, uint64_t flags, ucp_device_request_t *req)
 {
     const void *address;
     const uct_device_mem_element_t *uct_elem;
@@ -230,11 +231,11 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
         return status;
     }
 
-    return UCP_DEVICE_SEND_BLOCKING(level, uct_device_ep_put, device_ep, req,
-                                    src_uct_elem, uct_elem,
+    return UCP_DEVICE_SEND_BLOCKING(level, code_opt, uct_device_ep_put,
+                                    device_ep, req, src_uct_elem, uct_elem,
                                     UCS_PTR_BYTE_OFFSET(address, src_offset),
                                     remote_address + dst_offset, length,
-                                    channel_id, flags, comp, code_opt);
+                                    channel_id, flags, comp);
 }
 
 
@@ -255,6 +256,7 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
  * routine.
  *
  * @tparam      level          Level of cooperation of the transfer.
+ * @tparam      code_opt       Code optimization hint.
  * @param [in]  inc_value      Value used to increment the remote address.
  * @param [in]  mem_list_h     Remote memory descriptor list handle to use.
  * @param [in]  mem_list_index Index in descriptor list pointing to the memory
@@ -263,7 +265,6 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
  * @param [in]  channel_id     Channel ID to use for the transfer.
  * @param [in]  flags          Flags usable to modify the function behavior.
  * @param [out] req            Request populated by the call.
- * @param [in]  code_opt       Code optimization hint.
  *
  * @return UCS_INPROGRESS     - Operation successfully posted. If @a req is not
  *                              NULL, use @ref ucp_device_progress_req to check
@@ -271,12 +272,12 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
  * @return UCS_OK             - Operation completed successfully.
  * @return Error code as defined by @ref ucs_status_t
  */
-template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD>
+template<ucs_device_level_t level = UCS_DEVICE_LEVEL_THREAD,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t ucp_device_counter_inc(
         const uint64_t inc_value, const ucp_device_remote_mem_list_h mem_list_h,
         unsigned mem_list_index, size_t offset, unsigned channel_id,
-        uint64_t flags, ucp_device_request_t *req,
-        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+        uint64_t flags, ucp_device_request_t *req)
 {
     uint64_t remote_address;
     const uct_device_mem_element_t *uct_elem;
@@ -291,10 +292,10 @@ UCS_F_DEVICE ucs_status_t ucp_device_counter_inc(
         return status;
     }
 
-    return UCP_DEVICE_SEND_BLOCKING(level, uct_device_ep_atomic_add, device_ep,
-                                    req, uct_elem, inc_value,
+    return UCP_DEVICE_SEND_BLOCKING(level, code_opt, uct_device_ep_atomic_add,
+                                    device_ep, req, uct_elem, inc_value,
                                     remote_address + offset, channel_id, flags,
-                                    comp, code_opt);
+                                    comp);
 }
 
 

--- a/src/uct/api/device/uct_device_impl.h
+++ b/src/uct/api/device/uct_device_impl.h
@@ -60,6 +60,7 @@ union uct_device_completion {
  * @param [in]  channel_id      Channel ID to use for the transfer.
  * @param [in]  flags           Flags to modify the function behavior.
  * @param [in]  comp            Completion object to track the progress of operation.
+ * @param [in]  code_opt        Code optimization hint.
  *
  * @return UCS_INPROGRESS     - Operation successfully posted, use @ref
  *                              uct_device_ep_progress and @ref
@@ -74,13 +75,14 @@ uct_device_ep_put(uct_device_ep_h device_ep,
                   const uct_device_local_mem_list_elem_t *src_uct_elem,
                   const uct_device_mem_element_t *mem_elem, const void *address,
                   uint64_t remote_address, size_t length, unsigned channel_id,
-                  uint64_t flags, uct_device_completion_t *comp)
+                  uint64_t flags, uct_device_completion_t *comp,
+                  uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
 #if UCT_RC_MLX5_GDA_SUPPORTED
     if (device_ep->uct_tl_id == UCT_DEVICE_TL_RC_MLX5_GDA) {
         return uct_rc_mlx5_gda_ep_put<level>(device_ep, src_uct_elem, mem_elem,
                                              address, remote_address, length,
-                                             channel_id, flags, comp);
+                                             channel_id, flags, comp, code_opt);
     }
 #endif
 #if UCT_CUDA_IPC_SUPPORTED
@@ -113,6 +115,7 @@ uct_device_ep_put(uct_device_ep_h device_ep,
  * @param [in]  channel_id      Channel ID to use for the transfer.
  * @param [in]  flags           Flags to modify the function behavior.
  * @param [in]  comp            Completion object to track the progress of operation.
+ * @param [in]  code_opt        Code optimization hint.
  *
  * @return UCS_INPROGRESS      - Operation successfully posted, use @ref
  *                               uct_device_ep_progress and @ref
@@ -125,13 +128,15 @@ template<ucs_device_level_t level>
 UCS_F_DEVICE ucs_status_t uct_device_ep_atomic_add(
         uct_device_ep_h device_ep, const uct_device_mem_element_t *mem_elem,
         uint64_t inc_value, uint64_t remote_address, unsigned channel_id,
-        uint64_t flags, uct_device_completion_t *comp)
+        uint64_t flags, uct_device_completion_t *comp,
+        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
 #if UCT_RC_MLX5_GDA_SUPPORTED
     if (device_ep->uct_tl_id == UCT_DEVICE_TL_RC_MLX5_GDA) {
         return uct_rc_mlx5_gda_ep_atomic_add<level>(device_ep, mem_elem,
                                                     inc_value, remote_address,
-                                                    channel_id, flags, comp);
+                                                    channel_id, flags, comp,
+                                                    code_opt);
     }
 #endif
 #if UCT_CUDA_IPC_SUPPORTED

--- a/src/uct/api/device/uct_device_impl.h
+++ b/src/uct/api/device/uct_device_impl.h
@@ -51,6 +51,7 @@ union uct_device_completion {
  * The @a flags parameter can be used to modify the behavior
  * of the routine.
  *
+ * @tparam      code_opt        Code optimization hint.
  * @param [in]  device_ep       Device endpoint to be used for the operation.
  * @param [in]  src_mem_elem    Local memory element representing the memory to be transferred.
  * @param [in]  mem_elem        Remote memory element representing the memory to be transferred.
@@ -60,7 +61,6 @@ union uct_device_completion {
  * @param [in]  channel_id      Channel ID to use for the transfer.
  * @param [in]  flags           Flags to modify the function behavior.
  * @param [in]  comp            Completion object to track the progress of operation.
- * @param [in]  code_opt        Code optimization hint.
  *
  * @return UCS_INPROGRESS     - Operation successfully posted, use @ref
  *                              uct_device_ep_progress and @ref
@@ -69,20 +69,21 @@ union uct_device_completion {
  * @return UCS_OK             - Operation completed successfully.
  * @return Error code as defined by @ref ucs_status_t
  */
-template<ucs_device_level_t level>
+template<ucs_device_level_t level,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t
 uct_device_ep_put(uct_device_ep_h device_ep,
                   const uct_device_local_mem_list_elem_t *src_uct_elem,
                   const uct_device_mem_element_t *mem_elem, const void *address,
                   uint64_t remote_address, size_t length, unsigned channel_id,
-                  uint64_t flags, uct_device_completion_t *comp,
-                  uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+                  uint64_t flags, uct_device_completion_t *comp)
 {
 #if UCT_RC_MLX5_GDA_SUPPORTED
     if (device_ep->uct_tl_id == UCT_DEVICE_TL_RC_MLX5_GDA) {
-        return uct_rc_mlx5_gda_ep_put<level>(device_ep, src_uct_elem, mem_elem,
-                                             address, remote_address, length,
-                                             channel_id, flags, comp, code_opt);
+        return uct_rc_mlx5_gda_ep_put<level, code_opt>(device_ep, src_uct_elem,
+                                                       mem_elem, address,
+                                                       remote_address, length,
+                                                       channel_id, flags, comp);
     }
 #endif
 #if UCT_CUDA_IPC_SUPPORTED
@@ -108,6 +109,7 @@ uct_device_ep_put(uct_device_ep_h device_ep,
  * The @a flags parameter can be used to modify the behavior
  * of the routine.
  *
+ * @tparam      code_opt        Code optimization hint.
  * @param [in]  device_ep       Device endpoint to be used for the operation.
  * @param [in]  mem_elem        Memory element representing the memory to be modified.
  * @param [in]  inc_value       Value of the remote increment.
@@ -115,7 +117,6 @@ uct_device_ep_put(uct_device_ep_h device_ep,
  * @param [in]  channel_id      Channel ID to use for the transfer.
  * @param [in]  flags           Flags to modify the function behavior.
  * @param [in]  comp            Completion object to track the progress of operation.
- * @param [in]  code_opt        Code optimization hint.
  *
  * @return UCS_INPROGRESS      - Operation successfully posted, use @ref
  *                               uct_device_ep_progress and @ref
@@ -124,19 +125,18 @@ uct_device_ep_put(uct_device_ep_h device_ep,
  * @return UCS_OK              - Operation completed successfully.
  * @return Error code as defined by @ref ucs_status_t
  */
-template<ucs_device_level_t level>
+template<ucs_device_level_t level,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t uct_device_ep_atomic_add(
         uct_device_ep_h device_ep, const uct_device_mem_element_t *mem_elem,
         uint64_t inc_value, uint64_t remote_address, unsigned channel_id,
-        uint64_t flags, uct_device_completion_t *comp,
-        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+        uint64_t flags, uct_device_completion_t *comp)
 {
 #if UCT_RC_MLX5_GDA_SUPPORTED
     if (device_ep->uct_tl_id == UCT_DEVICE_TL_RC_MLX5_GDA) {
-        return uct_rc_mlx5_gda_ep_atomic_add<level>(device_ep, mem_elem,
-                                                    inc_value, remote_address,
-                                                    channel_id, flags, comp,
-                                                    code_opt);
+        return uct_rc_mlx5_gda_ep_atomic_add<level, code_opt>(
+                device_ep, mem_elem, inc_value, remote_address, channel_id,
+                flags, comp);
     }
 #endif
 #if UCT_CUDA_IPC_SUPPORTED

--- a/src/uct/api/device/uct_device_types.h
+++ b/src/uct/api/device/uct_device_types.h
@@ -57,7 +57,7 @@ typedef enum {
  */
 typedef enum {
     UCT_DEVICE_CODE_OPT_DEFAULT       = 0,
-    UCT_DEVICE_CODE_OPT_SKIP_ROLLBACK = UCS_BIT(0),
+    UCT_DEVICE_CODE_OPT_SQ_SKIP_CHECK = UCS_BIT(0),
     UCT_DEVICE_CODE_OPT_DB_ONCE       = UCS_BIT(1)
 } uct_device_code_opt_t;
 

--- a/src/uct/api/device/uct_device_types.h
+++ b/src/uct/api/device/uct_device_types.h
@@ -57,7 +57,8 @@ typedef enum {
  */
 typedef enum {
     UCT_DEVICE_CODE_OPT_DEFAULT       = 0,
-    UCT_DEVICE_CODE_OPT_SKIP_ROLLBACK = UCS_BIT(0)
+    UCT_DEVICE_CODE_OPT_SKIP_ROLLBACK = UCS_BIT(0),
+    UCT_DEVICE_CODE_OPT_DB_ONCE       = UCS_BIT(1)
 } uct_device_code_opt_t;
 
 

--- a/src/uct/api/device/uct_device_types.h
+++ b/src/uct/api/device/uct_device_types.h
@@ -52,6 +52,14 @@ typedef enum {
     UCT_DEVICE_FLAG_NODELAY = UCS_BIT(0) /**< Complete before return. */
 } uct_device_flags_t;
 
+/**
+ * @brief Specify code optimization hints.
+ */
+typedef enum {
+    UCT_DEVICE_CODE_OPT_DEFAULT       = 0,
+    UCT_DEVICE_CODE_OPT_SKIP_ROLLBACK = UCS_BIT(0)
+} uct_device_code_opt_t;
+
 
 /* Device transport id (for internal use) */
 typedef enum {

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -125,9 +125,18 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_max_alloc_wqe_base(
 }
 
 UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(
-        uct_rc_gdaki_dev_ep_t *ep, unsigned cid, unsigned count)
+        uct_rc_gdaki_dev_ep_t *ep, unsigned cid, unsigned count,
+        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
     uct_rc_gdaki_dev_qp_t *qp = uct_rc_mlx5_gda_get_qp(ep, cid);
+    uint64_t wqe_base;
+
+    if (code_opt & UCT_DEVICE_CODE_OPT_SKIP_ROLLBACK) {
+        return atomicAdd(reinterpret_cast<unsigned long long*>(
+                                 &qp->sq_rsvd_index),
+                         static_cast<unsigned long long>(count));
+    }
+
     /* Do not attempt to reserve if the available space is less than the
      * requested count, to avoid starvation of threads trying to rollback the
      * reservation with atomicCAS. */
@@ -136,9 +145,9 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(
         return UCT_RC_GDA_RESV_WQE_NO_RESOURCE;
     }
 
-    uint64_t wqe_base = atomicAdd(reinterpret_cast<unsigned long long*>(
-                                          &qp->sq_rsvd_index),
-                                  static_cast<unsigned long long>(count));
+    wqe_base = atomicAdd(reinterpret_cast<unsigned long long*>(
+                                 &qp->sq_rsvd_index),
+                         static_cast<unsigned long long>(count));
 
     /*
      *  Attempt to reserve 'count' WQEs by atomically incrementing the reserved
@@ -173,12 +182,13 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(
 }
 
 template<ucs_device_level_t level>
-UCS_F_DEVICE void
-uct_rc_mlx5_gda_reserv_wqe(uct_rc_gdaki_dev_ep_t *ep, unsigned cid,
-                           unsigned count, unsigned lane_id, uint64_t &wqe_base)
+UCS_F_DEVICE void uct_rc_mlx5_gda_reserv_wqe(
+        uct_rc_gdaki_dev_ep_t *ep, unsigned cid, unsigned count,
+        unsigned lane_id, uint64_t &wqe_base,
+        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
     if (lane_id == 0) {
-        wqe_base = uct_rc_mlx5_gda_reserv_wqe_thread(ep, cid, count);
+        wqe_base = uct_rc_mlx5_gda_reserv_wqe_thread(ep, cid, count, code_opt);
     }
 
     if (level == UCS_DEVICE_LEVEL_WARP) {
@@ -267,7 +277,7 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_single(
         const void *address, uint32_t lkey, uint64_t remote_address,
         uint32_t rkey, size_t length, unsigned cid, uint64_t flags,
         uct_device_completion_t *tl_comp, uint32_t opcode, bool is_atomic,
-        uint64_t add)
+        uint64_t add, uct_device_code_opt_t code_opt)
 {
     uct_rc_gda_completion_t *comp = &tl_comp->rc_gda;
     unsigned cflag                = 0;
@@ -276,7 +286,7 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_single(
     unsigned num_lanes;
 
     uct_rc_mlx5_gda_exec_init<level>(lane_id, num_lanes);
-    uct_rc_mlx5_gda_reserv_wqe<level>(ep, cid, 1, lane_id, wqe_base);
+    uct_rc_mlx5_gda_reserv_wqe<level>(ep, cid, 1, lane_id, wqe_base, code_opt);
     if (wqe_base == UCT_RC_GDA_RESV_WQE_NO_RESOURCE) {
         return UCS_ERR_NO_RESOURCE;
     }
@@ -314,7 +324,8 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_put(
         const uct_device_local_mem_list_elem_t *src_uct_elem,
         const uct_device_mem_element_t *tl_mem_elem, const void *address,
         uint64_t remote_address, size_t length, unsigned channel_id,
-        uint64_t flags, uct_device_completion_t *comp)
+        uint64_t flags, uct_device_completion_t *comp,
+        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
     auto ep       = reinterpret_cast<uct_rc_gdaki_dev_ep_t*>(tl_ep);
     auto mem_elem = reinterpret_cast<const uct_ib_md_device_mem_element_t*>(
@@ -328,14 +339,16 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_put(
                                             local_mem_elem->lkey,
                                             remote_address, mem_elem->rkey,
                                             length, cid, flags, comp,
-                                            MLX5_OPCODE_RDMA_WRITE, false, 0);
+                                            MLX5_OPCODE_RDMA_WRITE, false, 0,
+                                            code_opt);
 }
 
 template<ucs_device_level_t level>
 UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_atomic_add(
         uct_device_ep_h tl_ep, const uct_device_mem_element_t *tl_mem_elem,
         uint64_t value, uint64_t remote_address, unsigned channel_id,
-        uint64_t flags, uct_device_completion_t *comp)
+        uint64_t flags, uct_device_completion_t *comp,
+        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
 {
     auto ep       = reinterpret_cast<uct_rc_gdaki_dev_ep_t*>(tl_ep);
     auto mem_elem = reinterpret_cast<const uct_ib_md_device_mem_element_t*>(
@@ -346,7 +359,8 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_atomic_add(
                                             ep->atomic_lkey, remote_address,
                                             mem_elem->rkey, sizeof(uint64_t),
                                             cid, flags, comp,
-                                            MLX5_OPCODE_ATOMIC_FA, true, value);
+                                            MLX5_OPCODE_ATOMIC_FA, true, value,
+                                            code_opt);
 }
 
 UCS_F_DEVICE void

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -124,9 +124,9 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_max_alloc_wqe_base(
     return pi + ep->sq_wqe_num + 1 - count;
 }
 
+template<uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(
-        uct_rc_gdaki_dev_ep_t *ep, unsigned cid, unsigned count,
-        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+        uct_rc_gdaki_dev_ep_t *ep, unsigned cid, unsigned count)
 {
     uct_rc_gdaki_dev_qp_t *qp = uct_rc_mlx5_gda_get_qp(ep, cid);
     uint64_t wqe_base;
@@ -181,14 +181,14 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(
     return wqe_base;
 }
 
-template<ucs_device_level_t level>
-UCS_F_DEVICE void uct_rc_mlx5_gda_reserv_wqe(
-        uct_rc_gdaki_dev_ep_t *ep, unsigned cid, unsigned count,
-        unsigned lane_id, uint64_t &wqe_base,
-        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+template<ucs_device_level_t level,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
+UCS_F_DEVICE void
+uct_rc_mlx5_gda_reserv_wqe(uct_rc_gdaki_dev_ep_t *ep, unsigned cid,
+                           unsigned count, unsigned lane_id, uint64_t &wqe_base)
 {
     if (lane_id == 0) {
-        wqe_base = uct_rc_mlx5_gda_reserv_wqe_thread(ep, cid, count, code_opt);
+        wqe_base = uct_rc_mlx5_gda_reserv_wqe_thread<code_opt>(ep, cid, count);
     }
 
     if (level == UCS_DEVICE_LEVEL_WARP) {
@@ -271,13 +271,14 @@ uct_rc_mlx5_gda_fc(const uct_rc_gdaki_dev_ep_t *ep, uint16_t wqe_idx)
     return !(wqe_idx & ep->sq_fc_mask);
 }
 
-template<ucs_device_level_t level>
+template<ucs_device_level_t level,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_single(
         uct_rc_gdaki_dev_ep_t *ep, const uct_device_mem_element_t *tl_mem_elem,
         const void *address, uint32_t lkey, uint64_t remote_address,
         uint32_t rkey, size_t length, unsigned cid, uint64_t flags,
         uct_device_completion_t *tl_comp, uint32_t opcode, bool is_atomic,
-        uint64_t add, uct_device_code_opt_t code_opt)
+        uint64_t add)
 {
     uct_rc_gda_completion_t *comp = &tl_comp->rc_gda;
     unsigned cflag                = 0;
@@ -286,7 +287,7 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_single(
     unsigned num_lanes;
 
     uct_rc_mlx5_gda_exec_init<level>(lane_id, num_lanes);
-    uct_rc_mlx5_gda_reserv_wqe<level>(ep, cid, 1, lane_id, wqe_base, code_opt);
+    uct_rc_mlx5_gda_reserv_wqe<level, code_opt>(ep, cid, 1, lane_id, wqe_base);
     if (wqe_base == UCT_RC_GDA_RESV_WQE_NO_RESOURCE) {
         return UCS_ERR_NO_RESOURCE;
     }
@@ -318,14 +319,14 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_single(
     return UCS_INPROGRESS;
 }
 
-template<ucs_device_level_t level>
+template<ucs_device_level_t level,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_put(
         uct_device_ep_h tl_ep,
         const uct_device_local_mem_list_elem_t *src_uct_elem,
         const uct_device_mem_element_t *tl_mem_elem, const void *address,
         uint64_t remote_address, size_t length, unsigned channel_id,
-        uint64_t flags, uct_device_completion_t *comp,
-        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+        uint64_t flags, uct_device_completion_t *comp)
 {
     auto ep       = reinterpret_cast<uct_rc_gdaki_dev_ep_t*>(tl_ep);
     auto mem_elem = reinterpret_cast<const uct_ib_md_device_mem_element_t*>(
@@ -335,32 +336,28 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_put(
                     &src_uct_elem->uct_mem_element);
     auto cid = channel_id & ep->channel_mask;
 
-    return uct_rc_mlx5_gda_ep_single<level>(ep, tl_mem_elem, address,
-                                            local_mem_elem->lkey,
-                                            remote_address, mem_elem->rkey,
-                                            length, cid, flags, comp,
-                                            MLX5_OPCODE_RDMA_WRITE, false, 0,
-                                            code_opt);
+    return uct_rc_mlx5_gda_ep_single<level, code_opt>(
+            ep, tl_mem_elem, address, local_mem_elem->lkey, remote_address,
+            mem_elem->rkey, length, cid, flags, comp, MLX5_OPCODE_RDMA_WRITE,
+            false, 0);
 }
 
-template<ucs_device_level_t level>
+template<ucs_device_level_t level,
+         uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_atomic_add(
         uct_device_ep_h tl_ep, const uct_device_mem_element_t *tl_mem_elem,
         uint64_t value, uint64_t remote_address, unsigned channel_id,
-        uint64_t flags, uct_device_completion_t *comp,
-        uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT)
+        uint64_t flags, uct_device_completion_t *comp)
 {
     auto ep       = reinterpret_cast<uct_rc_gdaki_dev_ep_t*>(tl_ep);
     auto mem_elem = reinterpret_cast<const uct_ib_md_device_mem_element_t*>(
             tl_mem_elem);
     auto cid      = channel_id & ep->channel_mask;
 
-    return uct_rc_mlx5_gda_ep_single<level>(ep, tl_mem_elem, ep->atomic_va,
-                                            ep->atomic_lkey, remote_address,
-                                            mem_elem->rkey, sizeof(uint64_t),
-                                            cid, flags, comp,
-                                            MLX5_OPCODE_ATOMIC_FA, true, value,
-                                            code_opt);
+    return uct_rc_mlx5_gda_ep_single<level, code_opt>(
+            ep, tl_mem_elem, ep->atomic_va, ep->atomic_lkey, remote_address,
+            mem_elem->rkey, sizeof(uint64_t), cid, flags, comp,
+            MLX5_OPCODE_ATOMIC_FA, true, value);
 }
 
 UCS_F_DEVICE void

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -131,7 +131,7 @@ UCS_F_DEVICE uint64_t uct_rc_mlx5_gda_reserv_wqe_thread(
     uct_rc_gdaki_dev_qp_t *qp = uct_rc_mlx5_gda_get_qp(ep, cid);
     uint64_t wqe_base;
 
-    if (code_opt & UCT_DEVICE_CODE_OPT_SKIP_ROLLBACK) {
+    if (code_opt & UCT_DEVICE_CODE_OPT_SQ_SKIP_CHECK) {
         return atomicAdd(reinterpret_cast<unsigned long long*>(
                                  &qp->sq_rsvd_index),
                          static_cast<unsigned long long>(count));

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -237,6 +237,7 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_wqe_prepare_put_or_atomic(
     doca_gpu_dev_verbs_store_wqe_seg(dseg_ptr, (uint64_t*)&(dseg));
 }
 
+template<uct_device_code_opt_t code_opt = UCT_DEVICE_CODE_OPT_DEFAULT>
 UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep, unsigned cid,
                                      uint64_t wqe_base, unsigned count,
                                      uint64_t flags)
@@ -258,7 +259,9 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep, unsigned cid,
 
         while (READ_ONCE(qp->sq_ready_index) != wqe_base) {
         }
-        doca_gpu_dev_common_ring_db(db_ptr, qpn_ds, wqe_next);
+        if (!(code_opt & UCT_DEVICE_CODE_OPT_DB_ONCE)) {
+            doca_gpu_dev_common_ring_db(db_ptr, qpn_ds, wqe_next);
+        }
         doca_gpu_dev_common_update_dbr(dbrec_ptr, wqe_next);
         doca_gpu_dev_common_ring_db(db_ptr, qpn_ds, wqe_next);
         ref.store(wqe_next, cuda::std::memory_order_release);
@@ -312,7 +315,7 @@ UCS_F_DEVICE ucs_status_t uct_rc_mlx5_gda_ep_single(
     uct_rc_mlx5_gda_sync<level>();
 
     if (lane_id == 0) {
-        uct_rc_mlx5_gda_db(ep, cid, wqe_base, 1, flags);
+        uct_rc_mlx5_gda_db<code_opt>(ep, cid, wqe_base, 1, flags);
     }
 
     uct_rc_mlx5_gda_sync<level>();


### PR DESCRIPTION
## What?
Introduce optimization options for SQ reserve check and RDB operations like nccl/doca_gpunetio.

## Why?
In deepep/nvshmem, free WQE slots are not checked, and the DB is rang only once.
With this approach could reduce send time by 1–2 us.