### PR TITLE
DOCS: Bump readthedocs deps to fix urllib3 vulnerability

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/.readthedoc.requirements.txt
+++ b/docs/.readthedoc.requirements.txt
@@ -1,5 +1,5 @@
-breathe==4.30.0
-sphinx==4.0.2
-sphinx_rtd_theme==0.5.2
-urllib3<2.0
-recommonmark
+breathe==4.36.0
+sphinx==9.1.0
+sphinx_rtd_theme==3.1.0
+urllib3==2.6.3
+recommonmark==0.7.1


### PR DESCRIPTION
  ## What?
  Bump readthedocs build deps to resolve Dependabot alert #1
  (urllib3 `<2.0` vulnerability, medium severity, patched in 2.5.0).

  ## Why?
  https://github.com/openucx/ucx/security/dependabot/1

  ## How?
  - `urllib3 <2.0` → `==2.6.3` (the fix)
  - Other deps bumped to latest stable while here
  - RTD env bumped to Ubuntu 24.04 + Python 3.12 (required by sphinx 9.x)