### PR TITLE
UCT/CUDA_IPC: Implement uct_ep_put_sgl_zcopy

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -100,6 +100,60 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_cuda_ipc_ctx_rsc_get(
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_cuda_ipc_get_stream_and_event(uct_cuda_ipc_iface_t *iface,
+                                  unsigned stream_id,
+                                  uct_cuda_queue_desc_t **q_desc_p,
+                                  CUstream **stream_p,
+                                  uct_cuda_ipc_event_desc_t **event_p)
+{
+    uct_cuda_ipc_ctx_rsc_t *ctx_rsc;
+    ucs_status_t status;
+
+    status = uct_cuda_ipc_ctx_rsc_get(iface, &ctx_rsc);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    *q_desc_p = &ctx_rsc->queue_desc[stream_id % iface->config.max_streams];
+    *stream_p = &(*q_desc_p)->stream;
+
+    status = uct_cuda_base_init_stream(*stream_p);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    *event_p = uct_cuda_base_event_desc_mpool_get(&ctx_rsc->super.event_mp);
+    if (ucs_unlikely(*event_p == NULL)) {
+        ucs_error("Failed to allocate cuda_ipc event object");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_cuda_ipc_event_record_and_enqueue(uct_cuda_ipc_iface_t *iface,
+                                      uct_cuda_queue_desc_t *q_desc,
+                                      uct_cuda_ipc_event_desc_t *event,
+                                      CUstream stream)
+{
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuEventRecord(event->super.event,
+                                                    stream));
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    if (ucs_queue_is_empty(&q_desc->event_queue)) {
+        ucs_queue_push(&iface->super.active_queue, &q_desc->queue);
+    }
+
+    ucs_queue_push(&q_desc->event_queue, &event->super.queue);
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
                                   const uct_iov_t *iov, uct_rkey_t rkey,
                                   uct_completion_t *comp, int direction)
@@ -112,11 +166,9 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     void *mapped_rem_addr;
     void *mapped_addr;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
-    uct_cuda_ipc_ctx_rsc_t *ctx_rsc;
     uct_cuda_queue_desc_t *q_desc;
     ucs_status_t status;
     CUdeviceptr dst, src;
-    CUcontext UCS_V_UNUSED cuda_context;
     CUstream *stream;
 
     if (ucs_unlikely(0 == iov[0].length)) {
@@ -137,31 +189,10 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         goto out;
     }
 
-    status = uct_cuda_ipc_ctx_rsc_get(iface, &ctx_rsc);
+    status = uct_cuda_ipc_get_stream_and_event(iface, key->stream_id,
+                                               &q_desc, &stream,
+                                               &cuda_ipc_event);
     if (ucs_unlikely(status != UCS_OK)) {
-        goto out;
-    }
-
-    /* round-robin */
-    q_desc = &ctx_rsc->queue_desc[key->stream_id % iface->config.max_streams];
-    stream = &q_desc->stream;
-    status = uct_cuda_base_init_stream(stream);
-    if (ucs_unlikely(status != UCS_OK)) {
-        goto out;
-    }
-
-    if (ucs_unlikely(stream == NULL)) {
-        ucs_error("stream=%d for dev_num=%d not available", key->stream_id,
-                  cuda_device);
-        status = UCS_ERR_IO_ERROR;
-        goto out;
-    }
-
-    cuda_ipc_event = uct_cuda_base_event_desc_mpool_get(
-            &ctx_rsc->super.event_mp);
-    if (ucs_unlikely(cuda_ipc_event == NULL)) {
-        ucs_error("Failed to allocate cuda_ipc event object");
-        status = UCS_ERR_NO_MEMORY;
         goto out;
     }
 
@@ -177,24 +208,22 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
         goto out;
     }
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuEventRecord(cuda_ipc_event->super.event,
-                                                    *stream));
-    if (UCS_OK != status) {
+    status = uct_cuda_ipc_event_record_and_enqueue(iface, q_desc,
+                                                   cuda_ipc_event, *stream);
+    if (ucs_unlikely(status != UCS_OK)) {
         ucs_mpool_put(cuda_ipc_event);
         goto out;
     }
 
-    if (ucs_queue_is_empty(&q_desc->event_queue)) {
-        ucs_queue_push(&iface->super.active_queue, &q_desc->queue);
-    }
-
-    ucs_queue_push(&q_desc->event_queue, &cuda_ipc_event->super.queue);
     cuda_ipc_event->super.comp  = comp;
     cuda_ipc_event->mapped_addr = mapped_addr;
     cuda_ipc_event->d_bptr      = (uintptr_t)key->super.super.d_bptr;
     cuda_ipc_event->pid         = key->super.super.pid;
     cuda_ipc_event->pid_ns      = key->super.pid_ns;
     cuda_ipc_event->cuda_device = cuda_device;
+#if CUDA_VERSION >= 13000
+    cuda_ipc_event->sgl_mapping = NULL;
+#endif
     ucs_trace("cuMemcpyDtoDAsync issued :%p dst:%p, src:%p  len:%ld",
              cuda_ipc_event, (void *) dst, (void *) src, iov[0].length);
     status = UCS_INPROGRESS;
@@ -245,6 +274,156 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_zcopy,
                                 uct_iov_total_length(iov, iovcnt));
     return status;
 }
+
+#if CUDA_VERSION >= 13000
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
+                 (tl_ep, buffers, lengths, memhs, remote_addrs, rkeys, counts,
+                  strides, count, comp),
+                 uct_ep_h tl_ep, void * const *buffers,
+                 const size_t *lengths, uct_mem_h const *memhs UCS_V_UNUSED,
+                 const uint64_t *remote_addrs, uct_rkey_t const *rkeys,
+                 const size_t *counts, const size_t *strides,
+                 size_t count, uct_completion_t *comp)
+{
+    uct_cuda_ipc_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                 uct_cuda_ipc_iface_t);
+    uct_cuda_ipc_unpacked_rkey_t *key;
+    uct_cuda_ipc_event_desc_t *cuda_ipc_event;
+    uct_cuda_ipc_sgl_mapping_t *mapping;
+    uct_cuda_queue_desc_t *q_desc;
+    CUmemcpyAttributes attr;
+    void *mapped_rem_addr, *mapped_addr;
+    CUdeviceptr *cuda_dsts;
+    size_t attrs_idx;
+    size_t i, total_length;
+    CUdevice cuda_device;
+    CUstream *stream;
+    ucs_status_t status;
+    int is_ctx_pushed;
+
+    if (ucs_unlikely(count == 0)) {
+        ucs_trace_data("Zero count put_sgl_zcopy: skip it");
+        return UCS_OK;
+    }
+
+    /* TODO: add strided elements support */
+    if (ucs_unlikely((counts != NULL) || (strides != NULL))) {
+        ucs_error("cuda_ipc put_sgl_zcopy does not support strided elements");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    total_length = 0;
+    for (i = 0; i < count; i++) {
+        total_length += lengths[i];
+    }
+
+    if (ucs_unlikely(total_length == 0)) {
+        ucs_trace_data("Zero length put_sgl_zcopy: skip it");
+        return UCS_OK;
+    }
+
+    status = uct_cuda_ipc_check_and_push_ctx((CUdeviceptr)buffers[0],
+                                             &cuda_device, &is_ctx_pushed);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    mapping = ucs_malloc(sizeof(*mapping) + count * sizeof(*mapping->entries),
+                         "cuda_ipc_sgl_mapping");
+    if (ucs_unlikely(mapping == NULL)) {
+        ucs_error("Failed to allocate cuda_ipc sgl mapping");
+        status = UCS_ERR_NO_MEMORY;
+        goto out_ctx;
+    }
+
+    mapping->count   = count;
+    mapping->entries = (uct_cuda_ipc_sgl_entry_t *)(mapping + 1);
+
+    cuda_dsts = ucs_malloc(count * sizeof(CUdeviceptr), "cuda_ipc_sgl_dsts");
+    if (ucs_unlikely(cuda_dsts == NULL)) {
+        ucs_error("Failed to allocate cuda_ipc sgl dsts");
+        ucs_free(mapping);
+        status = UCS_ERR_NO_MEMORY;
+        goto out_ctx;
+    }
+
+    memset(&attr, 0, sizeof(attr));
+    attr.srcAccessOrder = CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
+    attrs_idx           = 0;
+
+    for (i = 0; i < count; i++) {
+        key = (uct_cuda_ipc_unpacked_rkey_t *)rkeys[i];
+
+        status = uct_cuda_ipc_get_remote_address(&key->super, remote_addrs[i],
+                                                 cuda_device, &mapped_rem_addr,
+                                                 &mapped_addr);
+        if (ucs_unlikely(status != UCS_OK)) {
+            uct_cuda_ipc_sgl_unmap(mapping, i, cuda_device,
+                                   iface->config.enable_cache);
+            ucs_free(cuda_dsts);
+            ucs_free(mapping);
+            goto out_ctx;
+        }
+
+        mapping->entries[i].pid         = key->super.super.pid;
+        mapping->entries[i].pid_ns      = key->super.pid_ns;
+        mapping->entries[i].d_bptr      = (uintptr_t)key->super.super.d_bptr;
+        mapping->entries[i].mapped_addr = mapped_addr;
+        cuda_dsts[i]                    = (CUdeviceptr)mapped_rem_addr;
+    }
+
+    key    = (uct_cuda_ipc_unpacked_rkey_t *)rkeys[0];
+    status = uct_cuda_ipc_get_stream_and_event(iface, key->stream_id,
+                                               &q_desc, &stream,
+                                               &cuda_ipc_event);
+    if (ucs_unlikely(status != UCS_OK)) {
+        ucs_free(cuda_dsts);
+        goto out_unmap;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuMemcpyBatchAsync(cuda_dsts, (CUdeviceptr *)buffers,
+                               (size_t *)lengths, count, &attr, &attrs_idx, 1,
+                               *stream));
+    ucs_free(cuda_dsts);
+    if (ucs_unlikely(status != UCS_OK)) {
+        ucs_mpool_put(cuda_ipc_event);
+        goto out_unmap;
+    }
+
+    status = uct_cuda_ipc_event_record_and_enqueue(iface, q_desc,
+                                                   cuda_ipc_event, *stream);
+    if (ucs_unlikely(status != UCS_OK)) {
+        ucs_mpool_put(cuda_ipc_event);
+        goto out_unmap;
+    }
+
+    cuda_ipc_event->super.comp  = comp;
+    cuda_ipc_event->sgl_mapping = mapping;
+    cuda_ipc_event->mapped_addr = NULL;
+    cuda_ipc_event->d_bptr      = 0;
+    cuda_ipc_event->pid         = 0;
+    cuda_ipc_event->cuda_device = cuda_device;
+
+    ucs_trace("cuMemcpyBatchAsync issued: count=%zu total_length=%zu",
+              count, total_length);
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
+                      total_length);
+
+    status = UCS_INPROGRESS;
+    goto out_ctx;
+
+out_unmap:
+    uct_cuda_ipc_sgl_unmap(mapping, count, cuda_device,
+                           iface->config.enable_cache);
+    ucs_free(mapping);
+
+out_ctx:
+    uct_cuda_ipc_check_and_pop_ctx(is_ctx_pushed);
+    return status;
+}
+#endif /* CUDA_VERSION >= 13000 */
 
 ucs_status_t uct_cuda_ipc_ep_get_device_ep(uct_ep_h tl_ep,
                                            uct_device_ep_h *device_ep_p)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -348,10 +348,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
                                                  cuda_device, &mapped_rem_addr,
                                                  &mapped_addr);
         if (ucs_unlikely(status != UCS_OK)) {
-            uct_cuda_ipc_sgl_unmap(mapping, i, cuda_device,
-                                   iface->config.enable_cache);
-            ucs_free(mapping);
-            goto out_ctx;
+            goto out_unmap;
         }
 
         mapping->entries[i].pid         = key->super.super.pid;
@@ -402,7 +399,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
     goto out_ctx;
 
 out_unmap:
-    uct_cuda_ipc_sgl_unmap(mapping, count, cuda_device,
+    uct_cuda_ipc_sgl_unmap(mapping, i, cuda_device,
                            iface->config.enable_cache);
     ucs_free(mapping);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -328,7 +328,9 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
         return status;
     }
 
-    mapping = ucs_malloc(sizeof(*mapping) + count * sizeof(*mapping->entries),
+    mapping = ucs_malloc(sizeof(*mapping) +
+                         count * (sizeof(*mapping->entries) +
+                                  sizeof(CUdeviceptr)),
                          "cuda_ipc_sgl_mapping");
     if (ucs_unlikely(mapping == NULL)) {
         ucs_error("Failed to allocate cuda_ipc sgl mapping");
@@ -338,14 +340,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
 
     mapping->count   = count;
     mapping->entries = (uct_cuda_ipc_sgl_entry_t *)(mapping + 1);
-
-    cuda_dsts = ucs_malloc(count * sizeof(CUdeviceptr), "cuda_ipc_sgl_dsts");
-    if (ucs_unlikely(cuda_dsts == NULL)) {
-        ucs_error("Failed to allocate cuda_ipc sgl dsts");
-        ucs_free(mapping);
-        status = UCS_ERR_NO_MEMORY;
-        goto out_ctx;
-    }
+    cuda_dsts        = (CUdeviceptr *)(mapping->entries + count);
 
     memset(&attr, 0, sizeof(attr));
     attr.srcAccessOrder = CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
@@ -360,7 +355,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
         if (ucs_unlikely(status != UCS_OK)) {
             uct_cuda_ipc_sgl_unmap(mapping, i, cuda_device,
                                    iface->config.enable_cache);
-            ucs_free(cuda_dsts);
             ucs_free(mapping);
             goto out_ctx;
         }
@@ -377,7 +371,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
                                                &q_desc, &stream,
                                                &cuda_ipc_event);
     if (ucs_unlikely(status != UCS_OK)) {
-        ucs_free(cuda_dsts);
         goto out_unmap;
     }
 
@@ -385,7 +378,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
             cuMemcpyBatchAsync(cuda_dsts, (CUdeviceptr *)buffers,
                                (size_t *)lengths, count, &attr, &attrs_idx, 1,
                                *stream));
-    ucs_free(cuda_dsts);
     if (ucs_unlikely(status != UCS_OK)) {
         ucs_mpool_put(cuda_ipc_event);
         goto out_unmap;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -301,11 +301,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
     ucs_status_t status;
     int is_ctx_pushed;
 
-    if (ucs_unlikely(count == 0)) {
-        ucs_trace_data("Zero count put_sgl_zcopy: skip it");
-        return UCS_OK;
-    }
-
     /* TODO: add strided elements support */
     if (ucs_unlikely((counts != NULL) || (strides != NULL))) {
         ucs_error("cuda_ipc put_sgl_zcopy does not support strided elements");

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -333,7 +333,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
         goto out_ctx;
     }
 
-    mapping->count   = count;
+    mapping->count   = 0;
     mapping->entries = (uct_cuda_ipc_sgl_entry_t *)(mapping + 1);
     cuda_dsts        = (CUdeviceptr *)(mapping->entries + count);
 
@@ -356,6 +356,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
         mapping->entries[i].d_bptr      = (uintptr_t)key->super.super.d_bptr;
         mapping->entries[i].mapped_addr = mapped_addr;
         cuda_dsts[i]                    = (CUdeviceptr)mapped_rem_addr;
+        mapping->count++;
     }
 
     key    = (uct_cuda_ipc_unpacked_rkey_t *)rkeys[0];
@@ -399,9 +400,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_ep_put_sgl_zcopy,
     goto out_ctx;
 
 out_unmap:
-    uct_cuda_ipc_sgl_unmap(mapping, i, cuda_device,
-                           iface->config.enable_cache);
-    ucs_free(mapping);
+    uct_cuda_ipc_sgl_mapping_destroy(mapping, cuda_device,
+                                     iface->config.enable_cache);
 
 out_ctx:
     uct_cuda_ipc_check_and_pop_ctx(is_ctx_pushed);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.h
@@ -33,6 +33,17 @@ ucs_status_t uct_cuda_ipc_ep_put_zcopy(uct_ep_h tl_ep,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
 
+ucs_status_t uct_cuda_ipc_ep_put_sgl_zcopy(uct_ep_h tl_ep,
+                                           void * const *buffers,
+                                           const size_t *lengths,
+                                           uct_mem_h const *memhs,
+                                           const uint64_t *remote_addrs,
+                                           uct_rkey_t const *rkeys,
+                                           const size_t *counts,
+                                           const size_t *strides,
+                                           size_t count,
+                                           uct_completion_t *comp);
+
 int uct_cuda_ipc_ep_is_connected(const uct_ep_h tl_ep,
                                  const uct_ep_is_connected_params_t *params);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -334,6 +334,18 @@ static void uct_cuda_ipc_complete_event(uct_iface_h tl_iface,
     uct_cuda_ipc_event_desc_t *cuda_ipc_event = ucs_derived_of(cuda_event,
                                                                uct_cuda_ipc_event_desc_t);
 
+#if CUDA_VERSION >= 13000
+    if (cuda_ipc_event->sgl_mapping != NULL) {
+        uct_cuda_ipc_sgl_mapping_t *mapping = cuda_ipc_event->sgl_mapping;
+
+        uct_cuda_ipc_sgl_unmap(mapping, mapping->count,
+                               cuda_ipc_event->cuda_device,
+                               iface->config.enable_cache);
+        ucs_free(mapping);
+        return;
+    }
+#endif
+
     uct_cuda_ipc_unmap_memhandle(cuda_ipc_event->pid, cuda_ipc_event->pid_ns,
                                  cuda_ipc_event->d_bptr,
                                  cuda_ipc_event->mapped_addr,
@@ -423,8 +435,31 @@ uct_cuda_ipc_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     return UCS_OK;
 }
 
+static ucs_status_t
+uct_cuda_ipc_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
+{
+    ucs_status_t status;
+
+    status = uct_iface_base_query_v2(iface, iface_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+#if CUDA_VERSION >= 13000
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY;
+    }
+
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
+        iface_attr->max_put_sgl_zcopy_count = SIZE_MAX;
+    }
+#endif
+
+    return UCS_OK;
+}
+
 static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
-    .iface_query_v2         = uct_iface_base_query_v2,
+    .iface_query_v2         = uct_cuda_ipc_iface_query_v2,
     .iface_estimate_perf    = uct_cuda_ipc_estimate_perf,
     .iface_vfs_refresh      = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -432,7 +467,12 @@ static uct_iface_internal_ops_t uct_cuda_ipc_iface_internal_ops = {
     .ep_connect_to_ep_v2    = (uct_ep_connect_to_ep_v2_func_t)ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2  = uct_cuda_ipc_iface_is_reachable_v2,
     .ep_is_connected        = uct_cuda_ipc_ep_is_connected,
-    .ep_get_device_ep       = uct_cuda_ipc_ep_get_device_ep
+    .ep_get_device_ep       = uct_cuda_ipc_ep_get_device_ep,
+#if CUDA_VERSION >= 13000
+    .ep_put_sgl_zcopy       = uct_cuda_ipc_ep_put_sgl_zcopy
+#else
+    .ep_put_sgl_zcopy       = (uct_ep_put_sgl_zcopy_func_t)ucs_empty_function_return_unsupported
+#endif
 };
 
 static uct_cuda_ctx_rsc_t * uct_cuda_ipc_ctx_rsc_create(uct_iface_h tl_iface)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -336,12 +336,9 @@ static void uct_cuda_ipc_complete_event(uct_iface_h tl_iface,
 
 #if CUDA_VERSION >= 13000
     if (cuda_ipc_event->sgl_mapping != NULL) {
-        uct_cuda_ipc_sgl_mapping_t *mapping = cuda_ipc_event->sgl_mapping;
-
-        uct_cuda_ipc_sgl_unmap(mapping, mapping->count,
-                               cuda_ipc_event->cuda_device,
-                               iface->config.enable_cache);
-        ucs_free(mapping);
+        uct_cuda_ipc_sgl_mapping_destroy(cuda_ipc_event->sgl_mapping,
+                                         cuda_ipc_event->cuda_device,
+                                         iface->config.enable_cache);
         return;
     }
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2018. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2018-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -43,6 +43,39 @@ typedef struct {
 } uct_cuda_ipc_iface_config_t;
 
 
+#if CUDA_VERSION >= 13000
+typedef struct {
+    pid_t        pid;
+    ucs_sys_ns_t pid_ns;
+    uintptr_t    d_bptr;
+    void         *mapped_addr;
+} uct_cuda_ipc_sgl_entry_t;
+
+
+typedef struct {
+    size_t                   count;
+    uct_cuda_ipc_sgl_entry_t *entries;
+} uct_cuda_ipc_sgl_mapping_t;
+
+
+static UCS_F_ALWAYS_INLINE void
+uct_cuda_ipc_sgl_unmap(uct_cuda_ipc_sgl_mapping_t *mapping,
+                       size_t count, CUdevice cuda_device,
+                       int enable_cache)
+{
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        uct_cuda_ipc_unmap_memhandle(mapping->entries[i].pid,
+                                     mapping->entries[i].pid_ns,
+                                     mapping->entries[i].d_bptr,
+                                     mapping->entries[i].mapped_addr,
+                                     cuda_device, enable_cache);
+    }
+}
+#endif
+
+
 typedef struct {
     uct_cuda_event_desc_t super;
     void                  *mapped_addr;
@@ -51,6 +84,9 @@ typedef struct {
     pid_t                 pid;
     ucs_sys_ns_t          pid_ns;
     CUdevice              cuda_device;
+#if CUDA_VERSION >= 13000
+    uct_cuda_ipc_sgl_mapping_t *sgl_mapping;
+#endif
 } uct_cuda_ipc_event_desc_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -59,19 +59,20 @@ typedef struct {
 
 
 static UCS_F_ALWAYS_INLINE void
-uct_cuda_ipc_sgl_unmap(uct_cuda_ipc_sgl_mapping_t *mapping,
-                       size_t count, CUdevice cuda_device,
-                       int enable_cache)
+uct_cuda_ipc_sgl_mapping_destroy(uct_cuda_ipc_sgl_mapping_t *mapping,
+                                 CUdevice cuda_device, int enable_cache)
 {
     size_t i;
 
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < mapping->count; i++) {
         uct_cuda_ipc_unmap_memhandle(mapping->entries[i].pid,
                                      mapping->entries[i].pid_ns,
                                      mapping->entries[i].d_bptr,
                                      mapping->entries[i].mapped_addr,
                                      cuda_device, enable_cache);
     }
+
+    ucs_free(mapping);
 }
 #endif
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_device.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_device.cc
@@ -377,9 +377,12 @@ UCS_TEST_P(test_cuda_ipc_put_sgl, iface_caps_v2)
     EXPECT_EQ(flag_set, count_set);
 }
 
-UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, various_counts,
-                     !is_sgl_supported())
+UCS_TEST_P(test_cuda_ipc_put_sgl, various_counts)
 {
+    if (!is_sgl_supported()) {
+        UCS_TEST_SKIP_R("put sgl zcopy is not supported");
+    }
+
     static constexpr size_t length = 2 * UCS_KBYTE;
     static const size_t counts[]   = {1, 2, 4, 10, 1024};
 
@@ -396,9 +399,12 @@ UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, various_counts,
     }
 }
 
-UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, various_lengths,
-                     !is_sgl_supported())
+UCS_TEST_P(test_cuda_ipc_put_sgl, various_lengths)
 {
+    if (!is_sgl_supported()) {
+        UCS_TEST_SKIP_R("put sgl zcopy is not supported");
+    }
+
     sgl_arrays sgl;
     init_sgl(sgl, {64, 256, UCS_KBYTE, 4 * UCS_KBYTE, 16 * UCS_KBYTE});
     ASSERT_UCS_OK_OR_INPROGRESS(put_sgl(sgl));
@@ -406,9 +412,12 @@ UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, various_lengths,
     check_sgl(sgl);
 }
 
-UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, with_callback,
-                     !is_sgl_supported())
+UCS_TEST_P(test_cuda_ipc_put_sgl, with_callback)
 {
+    if (!is_sgl_supported()) {
+        UCS_TEST_SKIP_R("put sgl zcopy is not supported");
+    }
+
     sgl_arrays sgl;
     init_sgl(sgl, std::vector<size_t>(10, UCS_KBYTE));
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_device.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_device.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2025-2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -11,6 +11,7 @@
 #include <cuda.h>
 #include <common/cuda.h>
 #include <memory>
+#include <vector>
 
 class test_cuda_ipc_rma : public uct_test {
 protected:
@@ -289,3 +290,144 @@ UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_cuda_ipc_rma_device, cuda_ipc)
+
+class test_cuda_ipc_put_sgl : public test_cuda_ipc_rma {
+protected:
+    struct sgl_arrays {
+        std::vector<std::unique_ptr<mapped_buffer>> sendbufs;
+        std::vector<std::unique_ptr<mapped_buffer>> recvbufs;
+        std::vector<void*> buffers;
+        std::vector<size_t> lengths;
+        std::vector<uct_mem_h> memhs;
+        std::vector<uint64_t> remote_addrs;
+        std::vector<uct_rkey_t> rkeys;
+    };
+
+    struct sgl_completion {
+        uct_completion_t uct;
+        unsigned         done;
+    };
+
+    bool is_sgl_supported() {
+        uct_iface_attr_v2_t attr = {};
+        attr.field_mask = UCT_IFACE_ATTR_FIELD_CAP_FLAGS |
+                          UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT;
+
+        if (uct_iface_query_v2(m_sender->iface(), &attr) != UCS_OK) {
+            return false;
+        }
+
+        return (attr.cap.flags & UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY) &&
+               (attr.max_put_sgl_zcopy_count > 0);
+    }
+
+    void init_sgl(sgl_arrays &sgl, const std::vector<size_t> &sizes) {
+        size_t count = sizes.size();
+
+        sgl.buffers.resize(count);
+        sgl.lengths = sizes;
+        sgl.memhs.resize(count);
+        sgl.remote_addrs.resize(count);
+        sgl.rkeys.resize(count);
+
+        for (size_t i = 0; i < count; ++i) {
+            sgl.sendbufs.emplace_back(new mapped_buffer(sizes[i], SEED1 + i,
+                                                        *m_sender, 0,
+                                                        UCS_MEMORY_TYPE_CUDA));
+            sgl.recvbufs.emplace_back(new mapped_buffer(sizes[i], SEED2,
+                                                        *m_receiver, 0,
+                                                        UCS_MEMORY_TYPE_CUDA));
+            sgl.buffers[i]      = sgl.sendbufs[i]->ptr();
+            sgl.memhs[i]        = sgl.sendbufs[i]->memh();
+            sgl.remote_addrs[i] = (uint64_t)sgl.recvbufs[i]->ptr();
+            sgl.rkeys[i]        = sgl.recvbufs[i]->rkey();
+        }
+    }
+
+    ucs_status_t put_sgl(const sgl_arrays &sgl,
+                         uct_completion_t *comp = NULL) {
+        return uct_ep_put_sgl_zcopy(m_sender->ep(0), sgl.buffers.data(),
+                                    sgl.lengths.data(), sgl.memhs.data(),
+                                    sgl.remote_addrs.data(),
+                                    sgl.rkeys.data(), NULL, NULL,
+                                    sgl.lengths.size(), comp);
+    }
+
+    void check_sgl(const sgl_arrays &sgl) {
+        for (size_t i = 0; i < sgl.recvbufs.size(); ++i) {
+            sgl.recvbufs[i]->pattern_check(SEED1 + i);
+        }
+    }
+
+    static void completion_cb(uct_completion_t *self) {
+        ucs_container_of(self, sgl_completion, uct)->done = 1;
+    }
+};
+
+UCS_TEST_P(test_cuda_ipc_put_sgl, iface_caps_v2)
+{
+    uct_iface_attr_v2_t attr = {};
+    attr.field_mask = UCT_IFACE_ATTR_FIELD_CAP_FLAGS |
+                      UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT;
+
+    ASSERT_UCS_OK(uct_iface_query_v2(m_sender->iface(), &attr));
+
+    bool flag_set  = attr.cap.flags & UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY;
+    bool count_set = attr.max_put_sgl_zcopy_count > 0;
+    EXPECT_EQ(flag_set, count_set);
+}
+
+UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, various_counts,
+                     !is_sgl_supported())
+{
+    static constexpr size_t length = 2 * UCS_KBYTE;
+    static const size_t counts[]   = {1, 2, 4, 10, 1024};
+
+    for (size_t count : counts) {
+        sgl_arrays sgl;
+        init_sgl(sgl, std::vector<size_t>(count, length));
+        ASSERT_UCS_OK_OR_INPROGRESS(put_sgl(sgl));
+        m_sender->flush();
+        check_sgl(sgl);
+
+        if (HasFailure()) {
+            break;
+        }
+    }
+}
+
+UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, various_lengths,
+                     !is_sgl_supported())
+{
+    sgl_arrays sgl;
+    init_sgl(sgl, {64, 256, UCS_KBYTE, 4 * UCS_KBYTE, 16 * UCS_KBYTE});
+    ASSERT_UCS_OK_OR_INPROGRESS(put_sgl(sgl));
+    m_sender->flush();
+    check_sgl(sgl);
+}
+
+UCS_TEST_SKIP_COND_P(test_cuda_ipc_put_sgl, with_callback,
+                     !is_sgl_supported())
+{
+    sgl_arrays sgl;
+    init_sgl(sgl, std::vector<size_t>(10, UCS_KBYTE));
+
+    sgl_completion comp = {};
+    comp.uct.func       = completion_cb;
+    comp.uct.count      = 1;
+    comp.uct.status     = UCS_OK;
+
+    ucs_status_t status = put_sgl(sgl, &comp.uct);
+    ASSERT_UCS_OK_OR_INPROGRESS(status);
+
+    if (status == UCS_INPROGRESS) {
+        wait_for_flag(&comp.done);
+        EXPECT_EQ(1u, comp.done);
+        EXPECT_UCS_OK(comp.uct.status);
+    }
+
+    m_sender->flush();
+    check_sgl(sgl);
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_cuda_ipc_put_sgl, cuda_ipc)


### PR DESCRIPTION
## What?
Implement `uct_ep_put_sgl_zcopy` for the `cuda_ipc` transport.

## Why?
Allow UCP SGL put offload to run over `cuda_ipc`, replacing N separate per-buffer copies with a single batched submission and reducing per-element overhead on multi-buffer transfers.

## How?
On CUDA 13+, issue one `cuMemcpyBatchAsync` for the whole SGL, with all mappings tracked in a per-event `uct_cuda_ipc_sgl_mapping_t` and unmapped on completion. On older CUDA, fall back to per-element `uct_cuda_ipc_ep_put_zcopy`, arming the user completion only on the last element.