### PR TITLE
UCT/API: Add v2 cap flags and UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1,6 +1,6 @@
 /**
  * @file        uct_v2.h
- * @date        2021
+ * @date        2021-2026
  * @copyright   NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
  * @brief       Unified Communication Transport
  */
@@ -1039,8 +1039,29 @@ typedef enum {
  */
 enum uct_iface_attr_field {
     /** Enables @ref uct_iface_attr_v2_t::max_put_sgl_zcopy_count */
-    UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT = UCS_BIT(0)
+    UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT = UCS_BIT(0),
+
+    /** Enables @ref uct_iface_attr_v2_t::cap */
+    UCT_IFACE_ATTR_FIELD_CAP_FLAGS           = UCS_BIT(1)
 };
+
+
+/**
+ * @defgroup UCT_RESOURCE_IFACE_CAP_V2   UCT v2 interface operations and
+                                         capabilities
+ * @ingroup UCT_RESOURCE
+ *
+ * @brief  List of capabilities supported by UCX API
+ *
+ * The definition list presents interface capabilities for
+ * @ref uct_iface_attr_v2_t, reported through @ref uct_iface_query_v2.
+ * @{
+ */
+        /* PUT capabilities */
+#define UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY       UCS_BIT(0)  /**< Zero-copy SGL put */
+/**
+ * @}
+ */
 
 
 /**
@@ -1059,6 +1080,11 @@ typedef struct {
      * @anchor uct_iface_attr_v2_max_put_sgl_zcopy_count
      */
     size_t   max_put_sgl_zcopy_count;
+
+    /** Interface capabilities (v2 flags) */
+    struct {
+        uint64_t flags; /**< Flags from @ref UCT_RESOURCE_IFACE_CAP_V2 */
+    } cap;
 } uct_iface_attr_v2_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1042,7 +1042,7 @@ enum uct_iface_attr_field {
     UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT = UCS_BIT(0),
 
     /** Enables @ref uct_iface_attr_v2_t::cap */
-    UCT_IFACE_ATTR_FIELD_CAP_FLAGS           = UCS_BIT(1)
+    UCT_IFACE_ATTR_FIELD_CAP_FLAGS               = UCS_BIT(1)
 };
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * Copyright (C) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
@@ -573,6 +573,14 @@ ucs_status_t uct_single_device_resource(uct_md_h md, const char *dev_name,
 ucs_status_t
 uct_iface_base_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
 {
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
+        iface_attr->cap.flags = 0;
+    }
+
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
+        iface_attr->max_put_sgl_zcopy_count = 0;
+    }
+
     return UCS_OK;
 }
 


### PR DESCRIPTION
## What?
Add a v2 cap-flags field to `uct_iface_attr_v2_t`, with the matching `UCT_IFACE_ATTR_FIELD_CAP_FLAGS` field-mask bit and the first v2 cap flag, `UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY`.

## Why?
Allow transports to advertise native support for `uct_ep_put_sgl_zcopy` through `uct_iface_query_v2`, so consumers (e.g. UCP) can probe SGL zcopy capability without relying on a v1 iface flag.

## How?
Extend `uct_iface_attr_v2_t` with the new `cap.flags` field, define `UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY`, and zero-init the new field in `uct_iface_base_query_v2()` so transports that don't override `iface_query_v2` report no v2 caps.