### PR TITLE
UCT/CUDA_IPC: Keep lru invariant - region in cache <-> region in lru - v1.21.x

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -238,7 +238,7 @@ static void uct_cuda_ipc_cache_evict_lru(uct_cuda_ipc_cache_t *cache)
         }
 
         if (region->refcount > 0) {
-            /* In-use region -- keep on LRU, revisit on next eviction pass.*/
+            /* In-use region -- keep on LRU, revisit on next eviction pass */
             continue;
         }
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -202,9 +202,7 @@ uct_cuda_ipc_cache_region_remove(uct_cuda_ipc_cache_t *cache,
                   (void *)region->key.d_bptr, ucs_status_string(status));
     }
 
-    ucs_assertv(region->in_lru, "region=%p, refcount=%lu", region, region->refcount);
     ucs_list_del(&region->lru_list);
-    region->in_lru = 0;
 
     ucs_assert(cache->num_regions > 0);
     cache->num_regions--;
@@ -716,7 +714,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     region->mapped_addr = *mapped_addr;
     region->refcount    = 1;
     region->cu_dev      = cu_dev;
-    region->in_lru      = 0; /* will be set after pgtable insert */
 
     status = UCS_PROFILE_CALL(ucs_pgtable_insert,
                               &cache->pgtable, &region->super);
@@ -740,7 +737,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     cache->num_regions++;
     cache->total_size += key->b_len;
     ucs_list_add_tail(&cache->lru_list, &region->lru_list);
-    region->in_lru = 1;
 
     uct_cuda_ipc_cache_evict_lru(cache);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -238,9 +238,7 @@ static void uct_cuda_ipc_cache_evict_lru(uct_cuda_ipc_cache_t *cache)
         }
 
         if (region->refcount > 0) {
-            /* In-use region -- pull off LRU, it will be re-added on release */
-            ucs_list_del(&region->lru_list);
-            region->in_lru = 0;
+            /* In-use region -- keep on LRU, revisit on next eviction pass.*/
             continue;
         }
 
@@ -590,10 +588,6 @@ ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, ucs_sys_ns_t pid_ns,
     if (!region->refcount && !cache_enabled) {
         ucs_assert(region->mapped_addr == mapped_addr);
         uct_cuda_ipc_cache_region_destroy(cache, region);
-    } else if (!region->in_lru) {
-        /* Region becomes an eviction candidate -- add to LRU tail */
-        ucs_list_add_tail(&cache->lru_list, &region->lru_list);
-        region->in_lru = 1;
     }
 
     pthread_rwlock_unlock(&cache->lock);
@@ -648,12 +642,10 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
                       UCS_PGT_REGION_FMT, cache->name, (void *)key->d_bptr,
                       key->b_len, UCS_PGT_REGION_ARG(&region->super));
 
-            /* Move to LRU tail (most recently used) */
-            if (region->in_lru) {
-                ucs_list_del(&region->lru_list);
-            }
+            /* Move to LRU tail (most recently used). Region is always on LRU
+             * while alive, so unconditional del/add_tail is safe. */
+            ucs_list_del(&region->lru_list);
             ucs_list_add_tail(&cache->lru_list, &region->lru_list);
-            region->in_lru = 1;
 
             *mapped_addr = region->mapped_addr;
             ucs_assert(region->refcount < UINT64_MAX);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -28,7 +28,6 @@ struct uct_cuda_ipc_cache_region {
     void                    *mapped_addr; /**< Local mapped address */
     uint64_t                refcount;     /**< Track in-flight ops before unmapping*/
     CUdevice                cu_dev;       /**< CUDA device */
-    uint8_t                 in_lru;       /**< Whether region is on the LRU list */
 };
 
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -311,9 +311,10 @@ protected:
         region->refcount++;
     }
 
-    void destroy_region(uct_cuda_ipc_cache_region_t *region) {
+    void destroy_region(uct_cuda_ipc_cache_region_t *region)
+    {
         ucs_status_t status = ucs_pgtable_remove(&m_cache->pgtable,
-                                                  &region->super);
+                                                 &region->super);
         ASSERT_EQ(UCS_OK, status);
 
         ASSERT_TRUE(region->in_lru);
@@ -538,10 +539,9 @@ UCS_TEST_F(test_cuda_ipc_cache_lru, unlimited) {
 }
 
 UCS_TEST_F(test_cuda_ipc_cache_lru, stale_destroy_while_in_use) {
-    /* Regression test for Bug A: evict_lru must not pull in-use regions off
-     * the LRU. Otherwise a subsequent destroy (e.g. stale-buffer_id branch
-     * in map_memhandle) hits an assertion / list corruption because the
-     * region is alive in the pgtable but not on the LRU. */
+    /* Check that evict_lru does not pull in-use regions off
+     * the LRU. This could cause a failure if region is destroyed
+     * while not in LRU. */
     create_cache(0 /* force eviction on every insert */, SIZE_MAX);
 
     uct_cuda_ipc_cache_region_t *r1 = insert_region(0);

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -285,7 +285,6 @@ protected:
         region->mapped_addr    = (void *)addr;
         region->refcount       = 1;
         region->cu_dev         = 0;
-        region->in_lru         = 0;
 
         ucs_status_t status = ucs_pgtable_insert(&m_cache->pgtable,
                                                   &region->super);
@@ -294,7 +293,6 @@ protected:
         m_cache->num_regions++;
         m_cache->total_size += REGION_SIZE;
         ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
-        region->in_lru = 1;
 
         return region;
     }
@@ -317,9 +315,7 @@ protected:
                                                  &region->super);
         ASSERT_EQ(UCS_OK, status);
 
-        ASSERT_TRUE(region->in_lru);
         ucs_list_del(&region->lru_list);
-        region->in_lru = 0;
 
         ASSERT_GT(m_cache->num_regions, 0UL);
         m_cache->num_regions--;
@@ -344,7 +340,6 @@ protected:
             ASSERT_EQ(UCS_OK, ucs_pgtable_remove(&m_cache->pgtable,
                                                   &region->super));
             ucs_list_del(&region->lru_list);
-            region->in_lru = 0;
             m_cache->num_regions--;
             m_cache->total_size -= region->key.b_len;
 
@@ -546,12 +541,10 @@ UCS_TEST_F(test_cuda_ipc_cache_lru, stale_destroy_while_in_use) {
 
     uct_cuda_ipc_cache_region_t *r1 = insert_region(0);
     ASSERT_EQ(1UL, r1->refcount);
-    ASSERT_EQ(1, r1->in_lru);
 
     evict_lru();
 
     /* Core assertion: in-use region must stay on LRU after eviction */
-    EXPECT_EQ(1, r1->in_lru);
     EXPECT_EQ(1UL, m_cache->num_regions);
     EXPECT_TRUE(pgtable_has(0));
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -302,20 +302,29 @@ protected:
     void release_region(uct_cuda_ipc_cache_region_t *region) {
         ASSERT_GE(region->refcount, 1UL);
         region->refcount--;
-        if (!region->in_lru) {
-            ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
-            region->in_lru = 1;
-        }
     }
 
     void reacquire_region(uct_cuda_ipc_cache_region_t *region) {
         /* Move to LRU tail (most recently used) */
-        if (region->in_lru) {
-            ucs_list_del(&region->lru_list);
-        }
+        ucs_list_del(&region->lru_list);
         ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
-        region->in_lru = 1;
         region->refcount++;
+    }
+
+    void destroy_region(uct_cuda_ipc_cache_region_t *region) {
+        ucs_status_t status = ucs_pgtable_remove(&m_cache->pgtable,
+                                                  &region->super);
+        ASSERT_EQ(UCS_OK, status);
+
+        ASSERT_TRUE(region->in_lru);
+        ucs_list_del(&region->lru_list);
+        region->in_lru = 0;
+
+        ASSERT_GT(m_cache->num_regions, 0UL);
+        m_cache->num_regions--;
+        m_cache->total_size -= region->key.b_len;
+
+        ucs_free(region);
     }
 
     void evict_lru() {
@@ -328,9 +337,6 @@ protected:
             }
 
             if (region->refcount > 0) {
-                /* In-use -- pull off LRU, will be re-added on release */
-                ucs_list_del(&region->lru_list);
-                region->in_lru = 0;
                 continue;
             }
 
@@ -529,4 +535,30 @@ UCS_TEST_F(test_cuda_ipc_cache_lru, unlimited) {
     for (size_t i = 0; i < num_insert; i++) {
         EXPECT_TRUE(pgtable_has(i));
     }
+}
+
+UCS_TEST_F(test_cuda_ipc_cache_lru, stale_destroy_while_in_use) {
+    /* Regression test for Bug A: evict_lru must not pull in-use regions off
+     * the LRU. Otherwise a subsequent destroy (e.g. stale-buffer_id branch
+     * in map_memhandle) hits an assertion / list corruption because the
+     * region is alive in the pgtable but not on the LRU. */
+    create_cache(0 /* force eviction on every insert */, SIZE_MAX);
+
+    uct_cuda_ipc_cache_region_t *r1 = insert_region(0);
+    ASSERT_EQ(1UL, r1->refcount);
+    ASSERT_EQ(1, r1->in_lru);
+
+    evict_lru();
+
+    /* Core assertion: in-use region must stay on LRU after eviction */
+    EXPECT_EQ(1, r1->in_lru);
+    EXPECT_EQ(1UL, m_cache->num_regions);
+    EXPECT_TRUE(pgtable_has(0));
+
+    /* Simulate the stale-buffer_id destroy path */
+    destroy_region(r1);
+
+    EXPECT_EQ(0UL, m_cache->num_regions);
+    EXPECT_EQ(0UL, m_cache->total_size);
+    EXPECT_TRUE(ucs_list_is_empty(&m_cache->lru_list));
 }


### PR DESCRIPTION
Keep lru invariant - region in cache if and only if region in lru

## What?
Modify the initial design to keep only regions candidates for eviction in lru, and thus remove from lru regions with refcount > 0. This caused a failure when regions with refcount > 0 were removed from cache on cache miss and were assumed to also be in lru. 
Initial design was based on the assumption that regions with refcount > 0 cannot be removed from cache because are in use - and therefore can safely be removed from lru and pushed back later. 
This assumption appears to be false - on cache miss regions with refcount > 0 can be removed. 
Unclear for now if this is a bug or by design

## Why?
https://redmine.mellanox.com/issues/4983516

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
