### PR TITLE
UCT/CUDA/CUDA_IPC: Removed extra code.

### DIFF
--- a/src/uct/cuda/base/cuda_ctx.c
+++ b/src/uct/cuda/base/cuda_ctx.c
@@ -152,15 +152,12 @@ ucs_status_t uct_cuda_ctx_primary_push_avail(int retain_inactive,
         status = uct_cuda_ctx_primary_push(*avail_cuda_device_p, retain_inactive,
                                            log_level);
         if (status == UCS_OK) {
-            break;
+            return UCS_OK;
         }
     }
 
-    if (status != UCS_OK) {
-        ucs_log(log_level, "no active cuda primary context for memory allocation");
-    }
-
-    return status;
+    ucs_log(log_level, "no active cuda primary context for memory allocation");
+    return UCS_ERR_NO_DEVICE;
 }
 
 void uct_cuda_ctx_primary_pop_and_release(CUdevice cuda_device)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -330,26 +330,12 @@ found:
 static ucs_status_t
 uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
                                 uct_cuda_ipc_unpacked_rkey_t *rkey,
-                                ucs_sys_device_t sys_dev)
+                                CUdevice cu_dev)
 {
-    CUdevice cu_dev;
     ucs_status_t status;
     void *d_mapped;
     uct_cuda_ipc_dev_cache_t *cache;
     uint8_t *accessible;
-
-    if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
-        /* Use device of the current context */
-        if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&cu_dev)) != UCS_OK) {
-            return UCS_ERR_UNREACHABLE;
-        }
-    } else {
-        cu_dev = uct_cuda_get_cuda_device(sys_dev);
-        if (cu_dev == CU_DEVICE_INVALID) {
-            ucs_warn("failed to map sys device [%d] to cuda device", sys_dev);
-            return UCS_ERR_UNREACHABLE;
-        }
-    }
 
     pthread_mutex_lock(&component->lock);
 
@@ -441,7 +427,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
         goto err_free_key;
     }
 
-    status = uct_cuda_ipc_is_peer_accessible(com, unpacked, sys_dev);
+    status = uct_cuda_ipc_is_peer_accessible(com, unpacked, avail_cuda_device);
     if (cuda_device != avail_cuda_device) {
         uct_cuda_ctx_primary_pop_and_release(avail_cuda_device);
     }


### PR DESCRIPTION
## What?
Removed extra code from `uct_cuda_ipc_is_peer_accessible`.
Plus minor change in `uct_cuda_ctx_primary_push_avail`.

## Why?
https://github.com/openucx/ucx/pull/11194 added code to the `uct_cuda_ipc_rkey_unpack` right before the call for `uct_cuda_ipc_is_peer_accessible`. The code is partially duplicated in `uct_cuda_ipc_is_peer_accessible`. The duplicated code can be removed from `uct_cuda_ipc_is_peer_accessible`, since only `uct_cuda_ipc_rkey_unpack` calls `uct_cuda_ipc_is_peer_accessible`.
