### PR TITLE
UCT/GDRCOPY: Fix build PCIe BAR1 without v2 function

### DIFF
--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -55,7 +55,7 @@ uct_gdr_copy_use_pcie_params_get(ucs_ternary_auto_value_t use_pcie,
     return UCS_OK;
 #else
     if (use_pcie == UCS_YES) {
-        ucs_error("USE_PCIE=yes requires GDRCopy with gdr_pin_buffer_v2", buf);
+        ucs_error("USE_PCIE=yes requires GDRCopy with gdr_pin_buffer_v2");
         return UCS_ERR_INVALID_PARAM;
     }
 


### PR DESCRIPTION
## What?
Fix build when `gdr_pin_buffer_v2()` is not found in gdr_copy headers.