### PR TITLE
UCT/ZE/COPY: Fix mem_query sys_dev by mapping allocation device handle

### DIFF
--- a/src/uct/ze/base/ze_base.c
+++ b/src/uct/ze/base/ze_base.c
@@ -356,6 +356,41 @@ uct_ze_base_get_device_handle_from_subdevice(const uct_ze_subdevice_t *subdevice
     return subdevice->device->subdevices[subdevice->subdevice_idx];
 }
 
+ucs_sys_device_t uct_ze_base_get_sys_dev_from_handle(ze_device_handle_t device)
+{
+    const uct_ze_device_t *dev;
+    int i, j;
+
+    if ((device == NULL) || (uct_ze_base_init() != ZE_RESULT_SUCCESS)) {
+        return UCS_SYS_DEVICE_ID_UNKNOWN;
+    }
+
+    for (i = 0; i < uct_ze_base.num_devices; i++) {
+        dev = &uct_ze_base.devices[i];
+
+        /* Skip entries not fully initialized during discovery. */
+        if (dev->num_subdevices <= 0) {
+            continue;
+        }
+
+        if (dev->root_device == device) {
+            return dev->sys_dev;
+        }
+
+        for (j = 0; j < dev->num_subdevices; j++) {
+            if (dev->subdevices[j] == device) {
+                return dev->sys_dev;
+            }
+        }
+    }
+
+    ucs_trace("cannot map ze device handle %p to sys_dev, "
+              "falling back to unknown",
+              (void*)device);
+
+    return UCS_SYS_DEVICE_ID_UNKNOWN;
+}
+
 /**
  * Query MD resources - returns one MD per sub-device
  * This is correct because each sub-device has separate memory

--- a/src/uct/ze/base/ze_base.h
+++ b/src/uct/ze/base/ze_base.h
@@ -63,6 +63,8 @@ const uct_ze_subdevice_t *uct_ze_base_get_subdevice_by_global_id(int global_id);
 ze_device_handle_t uct_ze_base_get_device_handle_from_subdevice(
         const uct_ze_subdevice_t *subdevice);
 
+ucs_sys_device_t uct_ze_base_get_sys_dev_from_handle(ze_device_handle_t device);
+
 ucs_status_t
 uct_ze_base_query_md_resources(uct_component_h component,
                                uct_md_resource_desc_t **resources_p,

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -155,11 +155,12 @@ uct_ze_copy_md_query_attributes(uct_md_h md, const void *addr, size_t length,
         .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
         .pNext = dmabuf_fd ? &export_fd : NULL
     };
+    ze_device_handle_t ze_device             = NULL;
     ze_result_t ret;
     void *base_address;
     size_t alloc_length;
 
-    ret = zeMemGetAllocProperties(ze_md->ze_context, addr, &props, NULL);
+    ret = zeMemGetAllocProperties(ze_md->ze_context, addr, &props, &ze_device);
     if ((ret != ZE_RESULT_SUCCESS) || (props.type == ZE_MEMORY_TYPE_UNKNOWN)) {
         return UCS_ERR_INVALID_ADDR;
     }
@@ -179,7 +180,7 @@ uct_ze_copy_md_query_attributes(uct_md_h md, const void *addr, size_t length,
     }
     mem_info->base_address = base_address;
     mem_info->alloc_length = alloc_length;
-    mem_info->sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+    mem_info->sys_dev      = uct_ze_base_get_sys_dev_from_handle(ze_device);
     if (dmabuf_fd) {
         *dmabuf_fd = export_fd.fd;
     }


### PR DESCRIPTION
## What?
- Fix the ZE mem_query path to return a concrete `sys_dev` for ZE device and ZE managed allocations, instead of always returning `UCS_SYS_DEVICE_ID_UNKNOWN`.
- Retrieve the allocation ze_device_handle_t from Level Zero allocation properties.
- Add a ZE base helper that maps a Level Zero root-device or sub-device handle to the corresponding UCX `sys_dev`.
- Preserve a safe fallback to `UCS_SYS_DEVICE_ID_UNKNOWN` when mapping is not possible, and reduce fallback logging to trace level.

## Why?
- Returning `UCS_SYS_DEVICE_ID_UNKNOWN` for ZE memory weakens topology-aware behavior and can lead to suboptimal affinity and protocol selection.
- This change aligns mem_query results with actual ZE topology and existing sys_device reporting.
- Compatibility and safety are preserved through explicit fallback behavior for unsupported or unmapped handles.
