### PR TITLE
TEST/APPS: Disable test app subdirs unless test apps is enabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -116,6 +116,7 @@ Tomer Gilad <tgilad@nvidia.com>
 Tony Curtis <tonycurtis32@gmail.com>
 Tzafrir Cohen <tzafrirc@nvidia.com>
 Valentin Petrov <valentinp@mellanox.com>
+Vihang Mehta <vihang@gimletlabs.ai>
 Wenbin Lu <wenbin.lu@stonybrook.edu>
 Xin Zhao <xinz@mellanox.com>
 Xu Yifeng <yifeng.xyf@alibaba-inc.com>

--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -6,11 +6,10 @@
 # See file LICENSE for terms.
 #
 
-SUBDIRS = profiling
-
-SUBDIRS += iodemo
 
 if HAVE_TEST_APPS
+SUBDIRS = profiling iodemo
+
 noinst_PROGRAMS = \
 	test_ucp_dlopen \
 	test_ucp_config \

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -155,7 +155,6 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.so
 %if "%{debug}" == "1"
 %{_bindir}/ucs_stats_parser
 %endif
-@HAVE_GLIBCXX_NOTHROW_TRUE@%{_bindir}/io_demo
 %{_datadir}/ucx
 %exclude %{_datadir}/ucx/examples
 %doc README AUTHORS NEWS


### PR DESCRIPTION
## What?
The test app build was running despite me not setting `--enable-test-apps`. This
ensures that it is properly disabled unless requested.

## Why?
`std::random_shuffle` has been removed from new compilers and the `iodemo` app
was failing to build.
