### PR TITLE
TEST/GTEST: Disable failing fault-tolerance test

### DIFF
--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -195,6 +195,15 @@ protected:
             num_lanes_to_fail--;
         }
 
+        if (has_any_transport({"rc_v", "rc_x"}) &&
+            (failure_side == FAILURE_SIDE_INITIATOR)) {
+            /* TODO: fix RC AM initiator failure handling: invalidating a local
+             * RC UCT EP triggers the error callback immediately (per lane),
+             * causing m_err_count > 0 before all lanes are down */
+            UCS_TEST_SKIP_R("RC AM initiator failure triggers error callback "
+                            "per invalidated lane");
+        }
+
         ucp_ep_h ucp_ep_for_injection = get_ucp_ep_for_err_injection(failure_side);
         for (size_t lane_idx = 0; lane_idx < num_lanes_to_fail; ++lane_idx) {
             ucp_lane_index_t lane = am_bw_lanes[lane_idx];


### PR DESCRIPTION
## What?
Skip failing test

## Why?
From CI logs:
```
2026-05-03T06:43:18.0631648Z /scrap/azure/agent-03/AZP_WORKSPACE/2/s/contrib/../test/gtest/ucp/test_ucp_fault_tolerance.cc:233: Failure
2026-05-03T06:43:18.0633126Z Expected equality of these values:
2026-05-03T06:43:18.0633990Z   1
2026-05-03T06:43:18.0634959Z   m_err_count
2026-05-03T06:43:18.0635915Z     Which is: 2
2026-05-03T06:43:18.0637428Z Error callback invoked 2 times
2026-05-03T06:43:18.1043959Z [  FAILED  ] rcx/test_ucp_fault_tolerance.initiator_failure/4, where GetParam() = rc_x/AM (346 ms)
```