### PR TITLE
UCT/IB/MLX5: Add initiator small fence WQE control flag

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -130,8 +130,9 @@ struct mlx5_grh_av {
 #  define MLX5_WQE_CTRL_SOLICITED  (1<<1)
 #endif
 
-#define UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE        (2<<5)
-#define UCT_IB_MLX5_WQE_CTRL_FLAG_STRONG_ORDER (3<<5)
+#define UCT_IB_MLX5_WQE_CTRL_FLAG_INITIATOR_SMALL_FENCE (1<<5)
+#define UCT_IB_MLX5_WQE_CTRL_FLAG_FENCE                 (2<<5)
+#define UCT_IB_MLX5_WQE_CTRL_FLAG_STRONG_ORDER          (3<<5)
 
 #define UCT_IB_MLX5_AM_ZCOPY_MAX_IOV  3UL
 


### PR DESCRIPTION
## What?
Add `UCT_IB_MLX5_WQE_CTRL_FLAG_INITIATOR_SMALL_FENCE` to the mlx5 WQE control flags.

## Why?
The mlx5 PRM defines an "Initiator Small Fence" mode (`fm=0x1`) that waits only for prior local operations on the same SQ. UCX currently exposes only the regular Fence and Strong Ordering modes.

## How?
Defined as `(1 << 5)`, matching the existing `_FLAG_FENCE` /`_FLAG_STRONG_ORDER` macros, so it can be OR'ed into `fm_ce_se`.