### PR TITLE
UCP/API: Add strides and counts to SGL datatype

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -908,7 +908,9 @@ typedef struct ucp_dt_iov {
 enum ucp_dt_local_sgl_field {
     UCP_DT_LOCAL_SGL_FIELD_BUFFERS = UCS_BIT(0), /**< buffers array is valid */
     UCP_DT_LOCAL_SGL_FIELD_LENGTHS = UCS_BIT(1), /**< lengths array is valid */
-    UCP_DT_LOCAL_SGL_FIELD_MEMHS   = UCS_BIT(2)  /**< memhs array is valid */
+    UCP_DT_LOCAL_SGL_FIELD_MEMHS   = UCS_BIT(2), /**< memhs array is valid */
+    UCP_DT_LOCAL_SGL_FIELD_COUNTS  = UCS_BIT(3), /**< counts array is valid */
+    UCP_DT_LOCAL_SGL_FIELD_STRIDES = UCS_BIT(4)  /**< strides array is valid */
 };
 
 
@@ -931,10 +933,16 @@ enum ucp_dt_remote_sgl_field {
  * handles. Element @a i describes a local buffer at @a buffers[i] of
  * @a lengths[i] bytes with memory handle @a memhs[i].
  *
+ * Optionally, the @a counts and @a strides arrays describe a repeating
+ * pattern for each element: element @a i represents @a counts[i] blocks
+ * of @a lengths[i] bytes, each separated by @a strides[i] bytes, starting
+ * at @a buffers[i]. When @a counts and @a strides are not set, each
+ * element is transferred once (equivalent to count=1, stride=0).
+ *
  * The descriptor @ref ucp_dt_local_sgl_t itself is copied by the library,
  * so the caller may release it after the call returns. However, the arrays
- * @a buffers, @a lengths, and @a memhs are not copied and must remain valid
- * until the data transfer request is completed.
+ * @a buffers, @a lengths, @a memhs, @a counts, and @a strides are not copied
+ * and must remain valid until the data transfer request is completed.
  *
  * Pass as the @a buffer parameter to @ref ucp_put_nbx with
  * @ref ucp_request_param_t::datatype set to @ref ucp_dt_make_sgl().
@@ -948,6 +956,8 @@ typedef struct {
     void * const    *buffers;   /**< Array of local buffer pointers */
     const size_t    *lengths;   /**< Array of transfer lengths in bytes */
     ucp_mem_h const *memhs;     /**< Array of local memory handles */
+    const size_t    *counts;    /**< Array of repetition counts */
+    const size_t    *strides;   /**< Array of strides in bytes */
 } ucp_dt_local_sgl_t;
 
 


### PR DESCRIPTION
## What?
Add two optional arrays, `counts` and `strides`, to `ucp_dt_local_sgl_t`, together with the corresponding field-mask bits. When set, element i represents `counts[i]` blocks of `lengths[i]` bytes, each separated by `strides[i]` bytes, starting at `buffers[i]`. When not set, each element is transferred once (equivalent to count=1, stride=0), preserving the existing behavior.

## Why?
The current SGL descriptor requires one entry per transferred buffer, so a regular strided layout has to be expanded into long `buffers`/`lengths` arrays.
Allowing per-element `counts`/`strides` lets the caller describe such patterns compactly.

## How?
API-only change in `src/ucp/api/ucp.h`. Implementation will follow in subsequent PRs.