### PR TITLE
UCT/API: Add strides and counts to uct_ep_put_sgl_zcopy

### DIFF
--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1259,6 +1259,13 @@ ucs_status_t uct_ep_get_device_ep(uct_ep_h ep, uct_device_ep_h *device_ep_p);
  * @param [in] remote_addrs Array of remote addresses.
  * @param [in] rkeys        Array of remote keys, obtained from
  *                          @ref ::uct_rkey_unpack.
+ * @param [in] counts       Array of repetition counts per element, or NULL.
+ *                          When provided, element @a i represents @a counts[i]
+ *                          blocks of @a lengths[i] bytes, each separated by
+ *                          @a strides[i] bytes, starting at @a buffers[i] /
+ *                          @a remote_addrs[i]. When NULL, each element is
+ *                          transferred once (equivalent to count=1, stride=0).
+ * @param [in] strides      Array of strides in bytes per element, or NULL.
  * @param [in] count        Number of elements in the arrays. Must not exceed
  *                          @ref uct_iface_attr_v2_max_put_sgl_zcopy_count
  *                          "uct_iface_attr_v2_t::max_put_sgl_zcopy_count".
@@ -1273,6 +1280,7 @@ ucs_status_t
 uct_ep_put_sgl_zcopy(uct_ep_h ep, void * const *buffers,
                      const size_t *lengths, uct_mem_h const *memhs,
                      const uint64_t *remote_addrs, uct_rkey_t const *rkeys,
+                     const size_t *counts, const size_t *strides,
                      size_t count, uct_completion_t *comp);
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -1098,13 +1098,14 @@ ucs_status_t
 uct_ep_put_sgl_zcopy(uct_ep_h ep, void * const *buffers,
                      const size_t *lengths, uct_mem_h const *memhs,
                      const uint64_t *remote_addrs, uct_rkey_t const *rkeys,
+                     const size_t *counts, const size_t *strides,
                      size_t count, uct_completion_t *comp)
 {
     const uct_base_iface_t *iface = ucs_derived_of(ep->iface, uct_base_iface_t);
 
     return iface->internal_ops->ep_put_sgl_zcopy(ep, buffers, lengths, memhs,
-                                                 remote_addrs, rkeys, count,
-                                                 comp);
+                                                 remote_addrs, rkeys, counts,
+                                                 strides, count, comp);
 }
 
 typedef struct uct_stub_iface {

--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -316,7 +316,8 @@ typedef ucs_status_t (*uct_ep_get_device_ep_func_t)(
 typedef ucs_status_t (*uct_ep_put_sgl_zcopy_func_t)(
         uct_ep_h ep, void * const *buffers, const size_t *lengths,
         uct_mem_h const *memhs, const uint64_t *remote_addrs,
-        uct_rkey_t const *rkeys, size_t count, uct_completion_t *comp);
+        uct_rkey_t const *rkeys, const size_t *counts, const size_t *strides,
+        size_t count, uct_completion_t *comp);
 
 /* Internal operations, not exposed by the external API */
 typedef struct uct_iface_internal_ops {


### PR DESCRIPTION
## What?
Add two optional `const size_t *` parameters, `counts` and `strides`, to `uct_ep_put_sgl_zcopy` (and the matching internal function pointer typedef and dispatch wrapper). When provided, element i represents `counts[i]` blocks of `lengths[i]` bytes, each separated by `strides[i]` bytes, starting at `buffers[i]` / `remote_addrs[i]`. When `NULL`, each element is transferred once (equivalent to count=1, stride=0), preserving the existing behavior.

## Why?
The current SGL zero-copy put requires one entry per transferred buffer, so a regular strided layout has to be expanded into long `buffers`/`lengths`/`remote_addrs` arrays. Allowing per-element `counts`/`strides` lets the caller describe such patterns compactly.

## How?
API-only change in `src/uct/api/v2/uct_v2.h`, with the matching typedef in `src/uct/base/uct_iface.h` and dispatch wrapper in `src/uct/base/uct_iface.c` updated. Implementation will follow in subsequent PRs.