### PR TITLE
AZP: Dry-run install of built packages to catch packaging regressions - v1.21.x

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -94,7 +94,12 @@ build_release_pkg() {
 			exit 1
 		fi
 		echo "==== Test install RPM (dry-run) ===="
-		rpm -Uvh --test ${PWD}/rpm-dist/*/*.rpm
+		if rpm -q rpm >/dev/null 2>&1; then
+			rpm -Uvh --test ${PWD}/rpm-dist/*/*.rpm
+		else
+			azure_log_warning "Skip RPM install test: rpm db not readable as non-root"
+			azure_complete_with_issues "Skip RPM install test: rpm db not readable as non-root"
+		fi
 		echo "==== Build debug RPM ===="
 		${WORKSPACE}/contrib/buildrpm.sh -s -b -d --nodeps --define "_topdir $PWD/debug"
 	fi

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -83,6 +83,8 @@ build_release_pkg() {
 			cd $subdir
 			dpkg-buildpackage -us -uc
 		)
+		echo "==== Test install DEB (dry-run) ===="
+		apt-get install -s -y ./*.deb
 	else
 		echo "==== Build RPM ===="
 		echo "$PWD"
@@ -91,6 +93,8 @@ build_release_pkg() {
 			azure_log_error "Release build depends on CUDA while it should not"
 			exit 1
 		fi
+		echo "==== Test install RPM (dry-run) ===="
+		rpm -Uvh --test ${PWD}/rpm-dist/*/*.rpm
 		echo "==== Build debug RPM ===="
 		${WORKSPACE}/contrib/buildrpm.sh -s -b -d --nodeps --define "_topdir $PWD/debug"
 	fi


### PR DESCRIPTION
## What?
Porting https://github.com/openucx/ucx/pull/11382 to v1.21.x.
Run install dry-run on freshly built DEB/RPM in `build_release_pkg` (same container).

## Why?
The Build stage produced packages but never validated they could be installed. We hit a regression where artifacts failed to install on the same OS they were built on - this catches it in PR CI.

## How?
- DEB: `apt-get install -s -y ./*.deb`
- RPM: `rpm -Uvh --test rpm-dist/*/*.rpm` (skipped on euleros/kylin where the rpm db isn't readable as non-root)