### PR TITLE
GTEST: fix err counting in test_ucp_fault_tolerance

### DIFF
--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -36,6 +36,8 @@ public:
 
     test_ucp_fault_tolerance() {
         configure_peer_failure_settings();
+        // reduce UD testing time 
+        modify_config("KEEPALIVE_INTERVAL", "0.3s");
     }
 
 protected:
@@ -125,6 +127,7 @@ protected:
     static void err_cb(void *arg, ucp_ep_h ep, ucs_status_t status) {
         test_ucp_fault_tolerance *self =
             reinterpret_cast<test_ucp_fault_tolerance*>(arg);
+        ucp_ep_h sender_ep = self->sender().ep(0, INJECTED_EP_INDEX);
 
         UCS_TEST_MESSAGE << "Error callback invoked: " << ucs_status_string(status);
 
@@ -133,7 +136,10 @@ protected:
                     (UCS_ERR_CANCELED == status));
 
         self->m_err_status = status;
-        ++self->m_err_count;
+        ++self->m_total_err_count;
+        if (ep == sender_ep) {
+            ++self->m_initiator_err_count;
+        }
     }
 
     static void shuffle_lanes(std::vector<ucp_lane_index_t> &lanes, const std::string &lane_type) {
@@ -195,15 +201,6 @@ protected:
             num_lanes_to_fail--;
         }
 
-        if (has_any_transport({"rc_v", "rc_x"}) &&
-            (failure_side == FAILURE_SIDE_INITIATOR)) {
-            /* TODO: fix RC AM initiator failure handling: invalidating a local
-             * RC UCT EP triggers the error callback immediately (per lane),
-             * causing m_err_count > 0 before all lanes are down */
-            UCS_TEST_SKIP_R("RC AM initiator failure triggers error callback "
-                            "per invalidated lane");
-        }
-
         ucp_ep_h ucp_ep_for_injection = get_ucp_ep_for_err_injection(failure_side);
         for (size_t lane_idx = 0; lane_idx < num_lanes_to_fail; ++lane_idx) {
             ucp_lane_index_t lane = am_bw_lanes[lane_idx];
@@ -230,7 +227,7 @@ protected:
             if (lane_idx < (am_bw_lanes.size() - 1)) {
                 EXPECT_EQ(UCS_OK, status) << op_str << " operation returned status: "
                                         << ucs_status_string(status);
-                ASSERT_EQ(0, m_err_count) << "Error callback invoked " << m_err_count << " times";
+                ASSERT_EQ(0, m_total_err_count) << "Error callback invoked " << m_total_err_count << " times";
             } else {
                 // The last lane is expected to fail
                 short_progress_loop();
@@ -239,7 +236,16 @@ protected:
                     // DC transport is not able to detect failure of remote DCI since DC is a connect2iface transport.
                     // This is a test limitation.
                 } else {
-                    ASSERT_EQ(1, m_err_count) << "Error callback invoked " << m_err_count << " times";
+                    ucs_time_t deadline = ucs::get_deadline();
+                    while ((m_initiator_err_count == 0) && (ucs_get_time() < deadline)) {
+                        short_progress_loop();
+                    }
+
+                    // Initiator EP should invoke error callback only once
+                    ASSERT_EQ(1, m_initiator_err_count) << "Error callback invoked " << m_initiator_err_count << " times";
+                    // Remote side may detect failure by keepalive or other control messages but not more than 1 time
+                    ASSERT_LE(m_total_err_count - m_initiator_err_count, 1)
+                            << "Error callback invoked " << m_total_err_count << " times";
                 }
             }
         }
@@ -308,7 +314,7 @@ protected:
         }
 
         short_progress_loop();
-        ASSERT_EQ(0, m_err_count) << "Error callback invoked " << m_err_count << " times";
+        ASSERT_EQ(0, m_total_err_count) << "Error callback invoked " << m_total_err_count << " times";
         UCS_TEST_MESSAGE << "Success";
     }
 
@@ -453,8 +459,9 @@ protected:
     volatile bool m_am_received    = false;
 
 private:
-    size_t       m_err_count  = 0;
-    ucs_status_t m_err_status = UCS_OK;
+    size_t m_initiator_err_count = 0;
+    size_t m_total_err_count     = 0;
+    ucs_status_t m_err_status    = UCS_OK;
 };
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_fault_tolerance)


### PR DESCRIPTION
## What?
fix err counting in test_ucp_fault_tolerance

## Why?
one side error injection can lead to remote failure as well
