### PR TITLE
CI: Add DL cluster (GB300) test pipeline

### DIFF
--- a/.ci/dockerfiles/Dockerfile.dl-base
+++ b/.ci/dockerfiles/Dockerfile.dl-base
@@ -1,0 +1,15 @@
+# Wraps the hpcx aarch64 builder with the svc-nixl user pyxis maps to on dlcluster.
+
+ARG BASE_IMAGE=harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:mofed-24.10-3.2.5.0
+FROM ${BASE_IMAGE}
+
+# Workaround: pyxis on dlcluster invokes a csh login flow when /bin/csh is
+# present, which aborts container start by reading bash-syntax env scripts.
+RUN apt-get -y purge tcsh && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -f -g 30 hardware && \
+    useradd -u 149917 -g 30 -m -s /bin/bash svcnbu-swx-hpcx
+
+ENTRYPOINT ["/bin/bash", "-c", "exec \"$@\"", "--"]

--- a/.ci/dockerfiles/Dockerfile.dl-base
+++ b/.ci/dockerfiles/Dockerfile.dl-base
@@ -1,4 +1,4 @@
-# Wraps the hpcx aarch64 builder with the svc-nixl user pyxis maps to on dlcluster.
+# Wraps the hpcx aarch64 builder with the svcnbu-swx-hpcx user pyxis maps to on dlcluster.
 
 ARG BASE_IMAGE=harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:mofed-24.10-3.2.5.0
 FROM ${BASE_IMAGE}

--- a/.ci/jenkins/Jenkinsfile.github
+++ b/.ci/jenkins/Jenkinsfile.github
@@ -6,7 +6,7 @@
  */
 
 @Library('blossom-github-lib@master')
-@Library('github.com/Mellanox/ci-demo@stable_ucx')
+@Library('ci-demo')
 def matrix = new com.mellanox.cicd.Matrix()
 
 import ipp.blossom.*

--- a/.ci/jenkins/proj_jjb_oss.yaml
+++ b/.ci/jenkins/proj_jjb_oss.yaml
@@ -88,6 +88,7 @@
         'ucx-build-static-oss',
         'ucx-test-oss',
         'ucx-test-gpu-oss',
+        'ucx-test-dl-oss',
       ]
 
       try {{
@@ -164,7 +165,7 @@
     name: ucx-dispatcher-oss
     jjb_proj: "ucx"
     jobs:
-      - "{jjb_proj}-dispatcher"
+      - "{jjb_proj}-dispatcher-oss"
 
 - project:
     name: ucx-codestyle
@@ -219,5 +220,13 @@
     jjb_proj: "ucx-test-gpu-oss"
     jjb_conf_file: ".ci/pipeline/test_gpu_matrix.yaml"
     jjb_description: "UCX GTest GPU (GitHub Blossom). Do NOT edit via Web GUI!"
+    jobs:
+      - "{jjb_proj}"
+
+- project:
+    name: ucx-test-dl
+    jjb_proj: "ucx-test-dl-oss"
+    jjb_conf_file: ".ci/pipeline/test_dl_matrix.yaml"
+    jjb_description: "UCX GTest on DL cluster (GB300/aarch64). Do NOT edit via Web GUI!"
     jobs:
       - "{jjb_proj}"

--- a/.ci/jenkins/proj_jjb_oss.yaml
+++ b/.ci/jenkins/proj_jjb_oss.yaml
@@ -88,7 +88,7 @@
         'ucx-build-static-oss',
         'ucx-test-oss',
         'ucx-test-gpu-oss',
-        'ucx-test-dl-oss',
+        'ucx-test-dl-gpu-oss',
       ]
 
       try {{
@@ -224,8 +224,8 @@
       - "{jjb_proj}"
 
 - project:
-    name: ucx-test-dl
-    jjb_proj: "ucx-test-dl-oss"
+    name: ucx-test-dl-gpu
+    jjb_proj: "ucx-test-dl-gpu-oss"
     jjb_conf_file: ".ci/pipeline/test_dl_matrix.yaml"
     jjb_description: "UCX GTest on DL cluster (GB300/aarch64). Do NOT edit via Web GUI!"
     jobs:

--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -55,4 +55,6 @@ steps:
     parallel: false
     timeout: 60
     run: |
+      # Workspace UID differs from container UID; trust it for git.
+      git config --global --add safe.directory '*'
       ./buildlib/tools/builds.sh

--- a/.ci/pipeline/test_dl_matrix.yaml
+++ b/.ci/pipeline/test_dl_matrix.yaml
@@ -28,8 +28,8 @@ env:
   ASAN_CHECK: "no"
   VALGRIND_CHECK: "no"
   RUNNING_IN_AZURE: "no"
-  nworkers: "1"
-  worker: "0"
+  NWORKERS: "1"
+  WORKER: "0"
   SLURM_NODES: 1
   SLURM_PARTITION: gb300nvl72_ci
   SLURM_HEAD_NODE: dlcluster.nvidia.com
@@ -109,9 +109,9 @@ steps:
         "ASAN_CHECK=${ASAN_CHECK}",
         "VALGRIND_CHECK=${VALGRIND_CHECK}",
         "RUNNING_IN_AZURE=${RUNNING_IN_AZURE}",
-        "EXECUTOR_NUMBER=${worker}",
-        "nworkers=${nworkers}",
-        "worker=${worker}"
+        "EXECUTOR_NUMBER=${WORKER}",
+        "nworkers=${NWORKERS}",
+        "worker=${WORKER}"
       ]
 
 pipeline_stop:

--- a/.ci/pipeline/test_dl_matrix.yaml
+++ b/.ci/pipeline/test_dl_matrix.yaml
@@ -1,0 +1,124 @@
+# Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
+#
+# UCX DL Cluster (GB300/aarch64) test matrix.
+---
+job: ucx-test-dl
+
+failFast: false
+timeout_minutes: 240
+
+registry_host: harbor.mellanox.com
+registry_auth: ucx_harbor_credentials
+registry_path: /ucx/ci
+
+kubernetes:
+  cloud: il-ipp-blossom-prod-nbu-swx-ucx
+  namespace: nbu-swx-ucx
+  limits: "{memory: 16Gi, cpu: 16000m}"
+  requests: "{memory: 8Gi, cpu: 8000m}"
+
+credentials:
+  - {credentialsId: 'ucx_harbor_credentials', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}
+
+env:
+  DOCKER_IMAGE: "harbor.mellanox.com#ucx/aarch64/ubuntu24.04/dl-base:2"
+  RUN_TESTS: "yes"
+  TEST_PERF: "1"
+  ASAN_CHECK: "no"
+  VALGRIND_CHECK: "no"
+  RUNNING_IN_AZURE: "no"
+  nworkers: "1"
+  worker: "0"
+  SLURM_NODES: 1
+  SLURM_PARTITION: gb300nvl72_ci
+  SLURM_HEAD_NODE: dlcluster.nvidia.com
+  SLURM_HEAD_USER: svcnbu-swx-hpcx
+  SLURM_ACCOUNT: blackwell-ci
+  SLURM_JOB_TIMEOUT: '02:45:00'
+  SLURM_IMMEDIATE_TIMEOUT: 3600
+  SSH_CREDENTIALS_ID: 'svcnbu-swx-hpcx_id_rsa_ssh_key'
+  JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
+  TEST_TIMEOUT: 140
+  CI_IMAGE_TAG: "20260504-1"
+
+pvc_volumes:
+  - {claimName: nbu-swx-ucx-pvc, mountPath: /mnt/pvc, readOnly: false}
+
+runs_on_dockers:
+  - {
+     file: '.ci/dockerfiles/Dockerfile.build_helper',
+     name: 'build_helper_dl',
+     arch: "aarch64",
+     tag: "${CI_IMAGE_TAG}",
+     build_args: '--build-arg BASE_IMAGE=dockerhub.nvidia.com/ubuntu:24.04 --build-arg ARCH=aarch64'
+    }
+
+matrix:
+  axes:
+    arch:
+      - aarch64
+
+taskName: '${arch}/${name}'
+
+steps:
+  - name: Allocate
+    containerSelector: "{name: 'build_helper_dl'}"
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: allocation
+    args:
+      partition: "${SLURM_PARTITION}"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      nodes: "${SLURM_NODES}"
+      jobTimeout: "${SLURM_JOB_TIMEOUT}"
+      immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
+      jobName: "ucx-ci-dl-${BUILD_NUMBER}"
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      extraArgs: ["--account=${SLURM_ACCOUNT}"]
+
+  - name: Checkout & test
+    containerSelector: "{name: 'build_helper_dl'}"
+    timeout: "${TEST_TIMEOUT}"
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      # Workaround: dlcluster's UCX_NET_DEVICES preset breaks UCX loopback.
+      # memlock unlimited is required for UCX.
+      testScript: "unset UCX_NET_DEVICES && ulimit -l unlimited && git clone https://github.com/openucx/ucx.git . && git fetch --no-tags origin ${sha1} && git checkout ${sha1} && ./contrib/test_jenkins.sh"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      dockerImage: "${DOCKER_IMAGE}"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      containerName: "ucx-ci-dl-${BUILD_NUMBER}"
+      # Workaround: svc-nixl's host ~/.cshrc breaks pyxis csh login flow.
+      extraArgs: ["--no-container-mount-home"]
+      slurmEnv: [
+        "SHELL=/bin/bash",
+        "RUN_TESTS=${RUN_TESTS}",
+        "TEST_PERF=${TEST_PERF}",
+        "ASAN_CHECK=${ASAN_CHECK}",
+        "VALGRIND_CHECK=${VALGRIND_CHECK}",
+        "RUNNING_IN_AZURE=${RUNNING_IN_AZURE}",
+        "EXECUTOR_NUMBER=${worker}",
+        "nworkers=${nworkers}",
+        "worker=${worker}"
+      ]
+
+pipeline_stop:
+  containerSelector: "{name: 'build_helper_dl'}"
+  parallel: false
+  shell: action
+  module: slurmCI
+  run: stopAllForBuild
+  args:
+    credentialsId: "${SSH_CREDENTIALS_ID}"
+    headNode: "${SLURM_HEAD_NODE}"
+    headUser: "${SLURM_HEAD_USER}"
+    jobIdDir: "${JOB_ID_FILE_ROOT}"

--- a/.ci/pipeline/test_dl_matrix.yaml
+++ b/.ci/pipeline/test_dl_matrix.yaml
@@ -3,7 +3,7 @@
 #
 # UCX DL Cluster (GB300/aarch64) test matrix.
 ---
-job: ucx-test-dl
+job: ucx-test-dl-gpu
 
 failFast: false
 timeout_minutes: 240

--- a/.ci/pipeline/test_dl_matrix.yaml
+++ b/.ci/pipeline/test_dl_matrix.yaml
@@ -22,7 +22,7 @@ credentials:
   - {credentialsId: 'ucx_harbor_credentials', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}
 
 env:
-  DOCKER_IMAGE: "harbor.mellanox.com#ucx/aarch64/ubuntu24.04/dl-base:2"
+  DOCKER_IMAGE: "${registry_host}#${registry_path}/aarch64/dl-base:${CI_IMAGE_TAG}"
   RUN_TESTS: "yes"
   TEST_PERF: "1"
   ASAN_CHECK: "no"
@@ -46,6 +46,12 @@ pvc_volumes:
   - {claimName: nbu-swx-ucx-pvc, mountPath: /mnt/pvc, readOnly: false}
 
 runs_on_dockers:
+  - {
+     file: '.ci/dockerfiles/Dockerfile.dl-base',
+     name: 'dl-base',
+     arch: "aarch64",
+     tag: "${CI_IMAGE_TAG}"
+    }
   - {
      file: '.ci/dockerfiles/Dockerfile.build_helper',
      name: 'build_helper_dl',

--- a/.ci/pipeline/test_dl_matrix.yaml
+++ b/.ci/pipeline/test_dl_matrix.yaml
@@ -97,10 +97,7 @@ steps:
       dockerImage: "${DOCKER_IMAGE}"
       credentialsId: "${SSH_CREDENTIALS_ID}"
       containerName: "ucx-ci-dl-${BUILD_NUMBER}"
-      # Workaround: svc-nixl's host ~/.cshrc breaks pyxis csh login flow.
-      extraArgs: ["--no-container-mount-home"]
       slurmEnv: [
-        "SHELL=/bin/bash",
         "RUN_TESTS=${RUN_TESTS}",
         "TEST_PERF=${TEST_PERF}",
         "ASAN_CHECK=${ASAN_CHECK}",


### PR DESCRIPTION
## What?
Add a Jenkins-based test pipeline that runs `contrib/test_jenkins.sh` on the DL cluster (GB300/aarch64) via SLURM.

## Why?
Azure CI agents can't reach `dlcluster.nvidia.com`, so UCX has no aarch64 GB300 coverage in PR CI today. Tracked in HPCINFRA-4292.

## How?
- `.ci/pipeline/test_dl_matrix.yaml`: allocate on dlcluster, srun `test_jenkins.sh` in a container, clean up.
- `.ci/dockerfiles/Dockerfile.dl-base`: small wrapper over the existing hpcx aarch64 builder, adding the `svc-nixl` user pyxis expects.
- `.ci/jenkins/proj_jjb_oss.yaml`: register `ucx-test-dl-oss` in the dispatcher fanout.
