### PR TITLE
UCS/SOCK: Fix ipv6 scope format

### DIFF
--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -801,7 +801,7 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
     if (sock_addr->sa_family == AF_INET6) {
         str_len = strlen(str);
-        ucs_snprintf_zero(str + str_len, max_size - str_len, "%%%d",
+        ucs_snprintf_zero(str + str_len, max_size - str_len, "%%%x",
                           ((struct sockaddr_in6*)sock_addr)->sin6_scope_id);
     }
 


### PR DESCRIPTION
## What?
Use hexadecimal for ipv6 scope formatting.