### PR TITLE
UCP/PROTO/MULTI: Use minimum protocol size of 1 when possible - v1.21.x

### DIFF
--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -233,7 +233,8 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     double max_bandwidth, max_frag_ratio, min_bandwidth;
     ucp_lane_index_t i, lane, num_lanes, num_fast_lanes;
     ucp_proto_multi_lane_priv_t *lpriv;
-    size_t max_frag, min_length, min_end_offset, min_chunk;
+    size_t max_frag, min_end_offset, min_chunk;
+    size_t UCS_V_UNUSED min_length;
     ucp_proto_lane_selection_t selection;
     ucp_md_map_t reg_md_map;
     uint32_t weight_sum;
@@ -374,7 +375,6 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     mpriv->max_frag_sum = 0;
     mpriv->align_thresh = 1;
     perf.max_frag       = 0;
-    perf.min_length     = 0;
     weight_sum          = 0;
     min_end_offset      = 0;
 
@@ -448,7 +448,6 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                      lpriv->weight;
         ucs_assert(ucp_proto_multi_scaled_length(lpriv->weight, min_length) >=
                    lane_perf->min_length);
-        perf.min_length = ucs_max(perf.min_length, min_length);
 
         weight_sum           += lpriv->weight;
         min_end_offset       += min_chunk;
@@ -463,6 +462,9 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                 ucp_proto_multi_init_flush_sys_dev_mask(params, lane);
     }
     ucs_assert(mpriv->num_lanes == ucs_popcount(selection.lane_map));
+
+    /* Multi-lane protocols with non-zero min_frag pad length if needed */
+    perf.min_length = mpriv->min_frag;
 
     if (mpriv->num_lanes == 1) {
         perf.node = lanes_perf[ucs_ffs64(selection.lane_map)].node;

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1145,3 +1145,23 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_get, use_single_net_device_rank_2,
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_get, rcx, "rc_x")
+
+class test_ucp_proto_mock_rcx_twins_get_inline_0 :
+    public test_ucp_proto_mock_rcx_twins_get {
+protected:
+    test_ucp_proto_mock_rcx_twins_get_inline_0()
+    {
+        modify_config("IB_NUM_PATHS", "1", SETENV_IF_NOT_EXIST);
+        modify_config("IB_TX_INLINE_RESP", "0", SETENV_IF_NOT_EXIST);
+    }
+};
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_twins_get_inline_0,
+           multi_rail_max_min_size_one, "MAX_RMA_RAILS=2", "ZCOPY_THRESH=0")
+{
+    check_config({{1, INF, "zero-copy",
+                   "50% on rc_mlx5/mock_0:1 and 50% on rc_mlx5/mock_2:1"}});
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_get_inline_0, rcx,
+                              "rc_x")


### PR DESCRIPTION
## What?
backport #11369.