### PR TITLE
UCT/CUDA: Fix dmabuf offset for interior addresses

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -881,7 +881,9 @@ uct_cuda_copy_md_mem_query(uct_md_h tl_md, const void *address, size_t length,
             mem_attr->dmabuf_fd = dmabuf.fd;
         }
         if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET) {
-            mem_attr->dmabuf_offset = dmabuf.offset;
+            mem_attr->dmabuf_offset =
+                    dmabuf.offset + UCS_PTR_BYTE_DIFF(addr_mem_info.base_address,
+                                                      address);
         }
     }
 

--- a/test/gtest/ucp/test_ucp_memheap.cc
+++ b/test/gtest/ucp/test_ucp_memheap.cc
@@ -24,18 +24,23 @@ void test_ucp_memheap::test_xfer(send_func_t send_func, size_t size,
                                  ucs_memory_type_t send_mem_type,
                                  ucs_memory_type_t target_mem_type,
                                  unsigned mem_map_flags,
-                                 bool is_ep_flush, bool user_memh, void *arg)
+                                 bool is_ep_flush, bool user_memh, void *arg,
+                                 size_t reg_offset)
 {
     ucp_mem_map_params_t params;
     ucs_status_t status;
     ptrdiff_t padding;
     ucp_mem_h memheap_memh, send_memh = NULL;
+    void *mapped_ptr;
 
     ucs_assert(!(mem_map_flags & (UCP_MEM_MAP_ALLOCATE | UCP_MEM_MAP_FIXED)));
 
-    mem_buffer memheap(num_iters * size + alignment, target_mem_type);
-    padding = UCS_PTR_BYTE_DIFF(memheap.ptr(),
-                                ucs_align_up_pow2_ptr(memheap.ptr(), alignment));
+    mem_buffer memheap(reg_offset + num_iters * size + alignment,
+                       target_mem_type);
+    mapped_ptr = UCS_PTR_BYTE_OFFSET(memheap.ptr(), reg_offset);
+    padding    = UCS_PTR_BYTE_DIFF(mapped_ptr,
+                                   ucs_align_up_pow2_ptr(mapped_ptr,
+                                                         alignment));
     ucs_assert(padding >= 0);
     ucs_assert(padding < alignment);
 
@@ -43,8 +48,8 @@ void test_ucp_memheap::test_xfer(send_func_t send_func, size_t size,
     params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                         UCP_MEM_MAP_PARAM_FIELD_LENGTH |
                         UCP_MEM_MAP_PARAM_FIELD_FLAGS;
-    params.address    = memheap.ptr();
-    params.length     = memheap.size();
+    params.address    = mapped_ptr;
+    params.length     = memheap.size() - reg_offset;
     params.flags      = mem_map_flags;
 
     status = ucp_mem_map(receiver().ucph(), &params, &memheap_memh);
@@ -77,7 +82,7 @@ void test_ucp_memheap::test_xfer(send_func_t send_func, size_t size,
 
     /* Perform data sends */
     for (unsigned i = 0; i < num_iters; ++i) {
-        ptrdiff_t offset = padding + (i * size);
+        ptrdiff_t offset = reg_offset + padding + (i * size);
         ucs_assert(offset + size <= memheap.size());
 
         (this->*send_func)(size,
@@ -98,8 +103,10 @@ void test_ucp_memheap::test_xfer(send_func_t send_func, size_t size,
     }
 
     /* Validate data */
-    if (!mem_buffer::compare(UCS_PTR_BYTE_OFFSET(expected_data.ptr(), padding),
-                             UCS_PTR_BYTE_OFFSET(memheap.ptr(), padding),
+    if (!mem_buffer::compare(UCS_PTR_BYTE_OFFSET(expected_data.ptr(),
+                                                reg_offset + padding),
+                             UCS_PTR_BYTE_OFFSET(memheap.ptr(),
+                                                reg_offset + padding),
                              size * num_iters, send_mem_type, target_mem_type)) {
         ADD_FAILURE() << "data validation failed";
     }

--- a/test/gtest/ucp/test_ucp_memheap.h
+++ b/test/gtest/ucp/test_ucp_memheap.h
@@ -39,7 +39,8 @@ protected:
     void test_xfer(send_func_t send_func, size_t size, unsigned num_iters,
                    size_t alignment, ucs_memory_type_t send_mem_type,
                    ucs_memory_type_t target_mem_type, unsigned mem_map_flags,
-                   bool is_ep_flush, bool user_memh, void *arg);
+                   bool is_ep_flush, bool user_memh, void *arg,
+                   size_t reg_offset = 0);
 };
 
 #endif

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -346,6 +346,48 @@ UCS_TEST_P(test_ucp_rma, proto_disabled_unsupported, "PROTO_ENABLE=n")
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_rma)
 
 
+class test_ucp_rma_dmabuf : public test_ucp_rma {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants) {
+        add_variant_with_value(variants, UCP_FEATURE_RMA, 0, "");
+    }
+
+    void init() override
+    {
+        if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+            UCS_TEST_SKIP_R("CUDA is not supported");
+        }
+
+        modify_config("MEMTYPE_REG_WHOLE_ALLOC_TYPES", "");
+        modify_config("CUDA_COPY_REG_WHOLE_ALLOC", "on", SETENV_IF_NOT_EXIST);
+        modify_config("CUDA_COPY_DMABUF", "try", SETENV_IF_NOT_EXIST);
+        test_ucp_rma::init();
+
+        if (receiver().ucph()->dmabuf_mds[UCS_MEMORY_TYPE_CUDA] ==
+            UCP_NULL_RESOURCE) {
+            UCS_TEST_SKIP_R("CUDA dmabuf is not supported");
+        }
+
+        if (receiver().ucph()->dmabuf_reg_md_map == 0) {
+            UCS_TEST_SKIP_R("dmabuf registration is not supported");
+        }
+    }
+};
+
+UCS_TEST_P(test_ucp_rma_dmabuf, put_registration_offset)
+{
+    ucs_memory_type_t mem_types[] = {UCS_MEMORY_TYPE_HOST,
+                                     UCS_MEMORY_TYPE_CUDA};
+
+    test_xfer(static_cast<send_func_t>(&test_ucp_rma::put_b),
+              ucs_get_page_size() - 1, 1, 1, UCS_MEMORY_TYPE_HOST,
+              UCS_MEMORY_TYPE_CUDA, 0, false, false, mem_types,
+              ucs_get_page_size());
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_rma_dmabuf, ib_cuda, "ib,cuda_copy")
+
+
 class test_ucp_proto_emulation_enable : public test_ucp_rma {
 public:
     static constexpr size_t SMALL_SIZE = 8;


### PR DESCRIPTION
## Commit Comment

When CUDA dma-buf registration exports the whole allocation, the dma-buf offset returned by cuda_copy mem query must still describe the queried user address. The current code reports only the allocation-base offset, so registration of an interior CUDA buffer can produce a remote key whose zero point is shifted to the allocation base and RDMA writes can land on neighboring memory.

Add the queried-address delta to the exported allocation offset and cover the case with a UCP RMA test that maps an interior CUDA page through dma-buf and validates the PUT target.

## Regression

This is a regression introduced by 88e51147f01b3a860cf0a89e3dd0dc79b070733b (`UCT/IB/MLX5/GDAKI: Added dma_buf support. (#11055)`). Before that change, `UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET` was calculated from the queried address relative to the aligned allocation base. The regression moved the calculation into `uct_cuda_copy_md_get_dmabuf()` and then returned only the allocation-base offset from `uct_cuda_copy_md_mem_query()`, losing the delta for interior addresses.

## Testing

With this fix:

```text
./test/gtest/gtest --gtest_filter="*test_ucp_rma_dmabuf.put_registration_offset*" --gtest_color=no
[ RUN      ] ib_cuda/test_ucp_rma_dmabuf.put_registration_offset/0 <ib,cuda_copy>
[       OK ] ib_cuda/test_ucp_rma_dmabuf.put_registration_offset/0 (875 ms)
[  PASSED  ] 1 test.
```

Without this fix:

```text
[ RUN      ] ib_cuda/test_ucp_rma_dmabuf.put_registration_offset/0 <ib,cuda_copy>
ucp/test_ucp_memheap.cc:111: Failure
Failed
data validation failed
[  FAILED  ] ib_cuda/test_ucp_rma_dmabuf.put_registration_offset/0
```