### PR TITLE
TOOLS/PERF: Progress responder for SW GET.

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -153,7 +153,7 @@ public:
     {
         *total_length = ucx_perf_get_message_size(&m_perf.params);
 
-        if (CMD == UCX_PERF_CMD_PUT) {
+        if ((CMD == UCX_PERF_CMD_PUT) || (CMD == UCX_PERF_CMD_GET)) {
             ucs_assert(*total_length >= sizeof(psn_t));
         }
 
@@ -599,6 +599,7 @@ public:
     void send_last_iter(ucp_ep_h ep, void *buffer, size_t size,
                         uint64_t remote_addr, ucp_rkey_h rkey)
     {
+        psn_t last_sn         = LAST_ITER_SN;
         uint64_t atomic_value = 0;
         ucs_status_ptr_t status_p;
         ucp_request_param_t atomic_param;
@@ -648,6 +649,16 @@ public:
             atomic_param.reply_buffer  = &atomic_value;
             status_p = ucp_atomic_op_nbx(ep, m_atomic_op, buffer, 1,
                                          remote_addr, rkey, &atomic_param);
+            break;
+        case UCX_PERF_CMD_GET:
+            /* Ensure all outstanding GETs are completed before signaling
+             * completion to server by PUTting LAST_ITER_SN to the sn slot at
+             * the end of server's recv buffer */
+            wait_send_window(m_max_outstanding);
+
+            status_p = ucp_put_nbx(ep, &last_sn, sizeof(last_sn),
+                                   remote_addr + size - sizeof(last_sn), rkey,
+                                   &m_send_params);
             break;
         default:
             status_p = NULL;
@@ -710,7 +721,8 @@ public:
 
     inline bool use_psn() const
     {
-        return (CMD == UCX_PERF_CMD_PUT) || is_atomic();
+        return (CMD == UCX_PERF_CMD_PUT) || (CMD == UCX_PERF_CMD_GET) ||
+               is_atomic();
     }
 
     void reset_buffers(size_t length, psn_t sn)

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -655,6 +655,7 @@ public:
              * completion to server by PUTting LAST_ITER_SN to the sn slot at
              * the end of server's recv buffer */
             wait_send_window(m_max_outstanding);
+            fence();
 
             status_p = ucp_put_nbx(ep, &last_sn, sizeof(last_sn),
                                    remote_addr + size - sizeof(last_sn), rkey,

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -651,12 +651,7 @@ public:
                                          remote_addr, rkey, &atomic_param);
             break;
         case UCX_PERF_CMD_GET:
-            /* Ensure all outstanding GETs are completed before signaling
-             * completion to server by PUTting LAST_ITER_SN to the sn slot at
-             * the end of server's recv buffer */
-            wait_send_window(m_max_outstanding);
-            fence();
-
+            /* Set remotely LAST_ITER_SN */
             status_p = ucp_put_nbx(ep, &last_sn, sizeof(last_sn),
                                    remote_addr + size - sizeof(last_sn), rkey,
                                    &m_send_params);


### PR DESCRIPTION
## What?
Progress `ucx_perftest` responder to handle software GET RMA operations.

## Why?
Some GET RMA protocols will need remote progressing and end of test synchronization.

## How?
Implement like the RMA software PUT operations.