### PR TITLE
AGENTS: Add source and test guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
 # Claude Code Instructions
 
 @AGENTS.md
+
+When working on a file, look for `AGENTS.md` in that file's directory and each
+parent directory up to the repository root. Follow the nearest guide together
+with the higher-level guides.

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -14,6 +14,7 @@ pr:
     - .gitignore
     - .readthedocs.yaml
     - AGENTS.md
+    - "**/AGENTS.md"
     - CLAUDE.md
     - contrib/pr_merge_check.py
     - contrib/check_qps.sh

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Guide for `src`
+
+This subtree contains UCX runtime code. Keep source edits aligned with the
+layer boundaries below.
+
+## Layer Boundaries
+
+- `ucs`: shared infrastructure only. Avoid pulling protocol or transport policy
+  into UCS.
+- `uct`: transport-facing primitives and hardware-specific implementations.
+  Keep backend-specific behavior inside the relevant transport directory.
+- `ucp`: protocol, endpoint, worker, request, tag, AM, stream, RMA, rendezvous,
+  and wireup logic. UCP should compose UCT capabilities rather than baking in a
+  specific transport backend unless the existing code already does so.
+- `ucm`: memory allocation/event interception and memory hook logic. Be careful
+  with initialization order, async-signal-safety assumptions, and interactions
+  with external allocators.
+- `tools`: user-facing utilities. Keep command-line behavior and output stable
+  unless the task explicitly changes it.
+
+## Source Changes
+
+- Update the local `Makefile.am` whenever adding, removing, or renaming source
+  or header files.
+- API headers live under directories such as `src/ucp/api`, `src/uct/api`, and
+  `src/ucm/api`. Public API changes should include Doxygen comments and should
+  be treated as compatibility-sensitive.
+- Inline helpers normally use `.inl`; forward declarations use `_fwd.h`; type
+  declarations use `_types.h`; macro definition headers use `_def.h`.
+- Keep error handling local: log at the first point that determines the real
+  error cause, and propagate `ucs_status_t` without duplicating logs in callers.
+- Use `ucs_assert*` for internal invariants, not user-input validation.
+
+## Performance and Concurrency
+
+- Many paths are latency-sensitive. Avoid extra allocations, locks, atomics,
+  string formatting, or logging in fast paths unless the local code already
+  pays that cost.
+- Check existing progress, async, callback queue, and worker locking patterns
+  before changing concurrency behavior.

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Guide for `test`
+
+This subtree contains UCX tests. The main suite is `test/gtest`, written in
+C++11 on top of GoogleTest.
+
+## Test Layout
+
+- `test/gtest/ucs`: tests for UCS services and data structures.
+- `test/gtest/uct`: transport and transport API tests.
+- `test/gtest/ucp`: high-level protocol tests.
+- `test/gtest/ucm`: memory hook and allocator interception tests.
+- `test/gtest/common`: shared test helpers and GoogleTest integration.
+- `test/apps`: standalone app tests.
+- `test/mpi`: MPI-oriented tests.
+
+## Adding or Editing Tests
+
+- Add new gtest source files to `test/gtest/Makefile.am`.
+- Keep tests close to the layer being changed. A UCP behavior change usually
+  belongs under `test/gtest/ucp`, not in a lower-layer transport test.
+- Bug-fix tests should fail without the fix whenever practical.
+- Prefer deterministic tests. Avoid sleeps, timing thresholds, and reliance on
+  specific hardware unless the test is already in a hardware-specific area.
+- Reuse helpers from `test/gtest/common` and existing fixtures before adding a
+  new fixture shape.


### PR DESCRIPTION
## What
- Add AGENTS.md guidance for src/ and test/.
- Make CLAUDE.md discover AGENTS.md files by walking from the edited file up to the repo root.
- Exclude nested AGENTS.md files from PR CI path triggers with an Azure Pipelines wildcard.

## Testing
- Not run; documentation-only change.
- Checked whitespace with git diff --check upstream/master..HEAD.