### PR TITLE
UCP/MM: Add MAX_HCA_PER_GPU policy for GPU registrations

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -602,9 +602,9 @@ static ucs_config_field_t ucp_context_config_table[] = {
 
   {"MAX_HCA_PER_GPU", "inf",
    "Maximum number of HCAs to register GPU memory on.\n"
-   " - inf : register on all reachable HCAs (default).\n"
-   " - 0   : register only on HCAs with the highest bandwidth to the GPU.\n"
-   " - <N> : register on up to N highest-bandwidth reachable HCAs.",
+   " - inf  : register on all HCAs (default).\n"
+   " - auto : register only on HCAs closest to the GPU.\n"
+   " - <N>  : register on up to N closest HCAs.",
    ucs_offsetof(ucp_context_config_t, max_hca_per_gpu),
    UCS_CONFIG_TYPE_ULUNITS},
 
@@ -1851,9 +1851,9 @@ static ucp_md_map_t ucp_fill_fallback_reg_nonblock_mds(ucp_context_h context)
 }
 
 typedef struct ucp_reg_select_md {
-    ucp_md_index_t md_index;
-    const char     *name;
-    double         bandwidth;
+    ucp_md_index_t         md_index;
+    const char             *name;
+    ucs_sys_dev_distance_t distance;
 } ucp_reg_select_md_t;
 
 static int
@@ -1863,8 +1863,7 @@ ucp_reg_select_md_cmp(const void *pa, const void *pb, void *UCS_V_UNUSED arg)
     const ucp_reg_select_md_t *b = pb;
     int cmp;
 
-    /* Sort by bandwidth descending (highest first = closest) */
-    cmp = ucs_fp_compare(b->bandwidth, a->bandwidth);
+    cmp = ucs_topo_distance_cmp(&a->distance, &b->distance);
     if (cmp != 0) {
         return cmp;
     }
@@ -1880,11 +1879,10 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
     ucp_md_map_t result                = 0;
     unsigned count                     = 0;
     ucp_reg_select_md_t select_mds[UCP_MAX_MDS];
-    ucs_sys_dev_distance_t distance;
+    ucs_sys_dev_distance_t distance, best;
     ucs_sys_device_t sys_dev;
     unsigned select_count, i;
     ucp_md_index_t md_index;
-    double bw;
     int reachable;
 
     if (ucp_reg_devices_mode(config->max_hca_per_gpu) == UCP_REG_DEVICES_ALL) {
@@ -1893,18 +1891,22 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
 
     ucs_for_each_bit(md_index, md_map) {
         if (context->tl_mds[md_index].sys_dev_map == 0) {
-            bw = UCS_INFINITY;
+            best = ucs_topo_default_distance;
         } else {
-            reachable = 1;
-            bw        = 0;
+            reachable      = 1;
+            best.latency   = UCS_INFINITY;
+            best.bandwidth = 0;
             ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
                 if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
+                    /* Consistent with ucp_memh_sys_dev_reachable: skip the
+                     * entire MD if any of its ports is unreachable */
                     reachable = 0;
                     break;
                 }
                 if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
-                     UCS_OK) && (ucs_fp_compare(distance.bandwidth, bw) > 0)) {
-                    bw = distance.bandwidth;
+                     UCS_OK) &&
+                    (ucs_topo_distance_cmp(&distance, &best) < 0)) {
+                    best = distance;
                 }
             }
 
@@ -1913,12 +1915,12 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
             }
         }
 
-        select_mds[count].md_index  = md_index;
-        select_mds[count].name      = context->tl_mds[md_index].rsc.md_name;
-        select_mds[count].bandwidth = bw;
-        ucs_trace("reg_select: sys_dev=%d md[%d]=%s bw=%.2e",
+        select_mds[count].md_index = md_index;
+        select_mds[count].name     = context->tl_mds[md_index].rsc.md_name;
+        select_mds[count].distance = best;
+        ucs_trace("reg_select: sys_dev=%d md[%d]=%s lat=%.2e bw=%.2e",
                   mem_sys_dev, md_index, select_mds[count].name,
-                  select_mds[count].bandwidth);
+                  best.latency, best.bandwidth);
         count++;
     }
 
@@ -1933,8 +1935,8 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
     case UCP_REG_DEVICES_CLOSEST:
         select_count = count;
         for (i = 1; i < count; i++) {
-            if (ucs_fp_compare(select_mds[i].bandwidth,
-                               select_mds[0].bandwidth) != 0) {
+            if (ucs_topo_distance_cmp(&select_mds[i].distance,
+                                      &select_mds[0].distance) != 0) {
                 select_count = i;
                 break;
             }
@@ -1945,8 +1947,9 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
                                count);
         break;
     default:
-        ucs_assertv(0, "invalid reg_devices_mode=%d",
-                    ucp_reg_devices_mode(config->max_hca_per_gpu));
+        ucs_assertv(0, "invalid reg_devices_mode=%d, max_hca_per_gpu=%lu",
+                    ucp_reg_devices_mode(config->max_hca_per_gpu),
+                    config->max_hca_per_gpu);
         return 0;
     }
 
@@ -1955,6 +1958,20 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
     }
 
     return result;
+}
+
+ucp_md_map_t ucp_context_get_net_md_map(ucp_context_h context)
+{
+    ucp_md_map_t net_md_map = 0;
+    ucp_rsc_index_t tl_idx;
+
+    for (tl_idx = 0; tl_idx < context->num_tls; ++tl_idx) {
+        if (context->tl_rscs[tl_idx].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
+            net_md_map |= UCS_BIT(context->tl_rscs[tl_idx].md_index);
+        }
+    }
+
+    return net_md_map;
 }
 
 static void ucp_fill_resources_reg_md_map_update(ucp_context_h context)

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1880,9 +1880,11 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
     unsigned count                     = 0;
     ucp_reg_select_md_t select_mds[UCP_MAX_MDS];
     ucs_sys_dev_distance_t distance, best;
+    ucp_sys_dev_map_t sys_dev_map;
     ucs_sys_device_t sys_dev;
     unsigned select_count, i;
     ucp_md_index_t md_index;
+    ucp_rsc_index_t tl_idx;
     int reachable;
 
     if (ucp_reg_devices_mode(config->max_hca_per_gpu) == UCP_REG_DEVICES_ALL) {
@@ -1890,29 +1892,41 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
     }
 
     ucs_for_each_bit(md_index, md_map) {
-        if (context->tl_mds[md_index].sys_dev_map == 0) {
-            best = ucs_topo_default_distance;
-        } else {
-            reachable      = 1;
-            best.latency   = UCS_INFINITY;
-            best.bandwidth = 0;
-            ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
-                if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
-                    /* Consistent with ucp_memh_sys_dev_reachable: skip the
-                     * entire MD if any of its ports is unreachable */
-                    reachable = 0;
-                    break;
-                }
-                if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
-                     UCS_OK) &&
-                    (ucs_topo_distance_cmp(&distance, &best) < 0)) {
-                    best = distance;
-                }
+        /* TODO: rc_gda has the gpu in the sys_dev_map so we need to skip it.
+         * This should be fixed in the tl. */
+        sys_dev_map = 0;
+        for (tl_idx = 0; tl_idx < context->num_tls; tl_idx++) {
+            if ((context->tl_rscs[tl_idx].md_index == md_index) &&
+                (context->tl_rscs[tl_idx].tl_rsc.sys_device <
+                 UCP_MAX_SYS_DEVICES) &&
+                (strncmp(context->tl_rscs[tl_idx].tl_rsc.dev_name,
+                         "cuda", 4) != 0)) {
+                sys_dev_map |=
+                    UCS_BIT(context->tl_rscs[tl_idx].tl_rsc.sys_device);
             }
+        }
 
-            if (!reachable) {
-                continue;
+        best.latency   = UCS_INFINITY;
+        best.bandwidth = 0;
+        reachable      = 1;
+
+        ucs_for_each_bit(sys_dev, sys_dev_map) {
+            ucs_assert(sys_dev != mem_sys_dev);
+            if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
+                /* Consistent with ucp_memh_sys_dev_reachable: skip the
+                 * entire MD if any of its ports is unreachable */
+                reachable = 0;
+                break;
             }
+            if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
+                 UCS_OK) &&
+                (ucs_topo_distance_cmp(&distance, &best) < 0)) {
+                best = distance;
+            }
+        }
+
+        if (!reachable) {
+            continue;
         }
 
         select_mds[count].md_index = md_index;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -14,6 +14,7 @@
 #include "ucp_request.h"
 
 #include <ucs/config/parser.h>
+#include <ucs/algorithm/qsort_r.h>
 #include <ucs/algorithm/crc.h>
 #include <ucs/arch/atomic.h>
 #include <ucs/datastruct/mpool.inl>
@@ -22,12 +23,17 @@
 #include <ucs/debug/log.h>
 #include <ucs/debug/debug_int.h>
 #include <ucs/sys/compiler.h>
+#include <ucs/sys/math.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <ucs/type/init_once.h>
 #include <ucs/vfs/base/vfs_cb.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
 
 
 #define UCP_RSC_CONFIG_ALL    "all"
@@ -596,6 +602,16 @@ static ucs_config_field_t ucp_context_config_table[] = {
   {"SINGLE_NET_DEVICE", "n", "Use only one network device for all protocols.",
    ucs_offsetof(ucp_context_config_t, proto_use_single_net_device),
    UCS_CONFIG_TYPE_BOOL},
+
+  {"DMABUF_REG_DEVICES", "all",
+   "Specifies which dmabuf-capable UCP memory domain(s) to use for broad "
+   "memory registration.\n"
+   " - all     : register on all reachable dmabuf-capable memory domains.\n"
+   " - closest : register on reachable memory domains with the lowest latency "
+   "from the memory device.\n"
+   " - <N>     : register on up to N lowest-latency reachable memory domains.",
+   ucs_offsetof(ucp_context_config_t, dmabuf_reg_devices),
+   UCS_CONFIG_TYPE_STRING},
 
   {"NODE_LOCAL_ID", "auto",
    "An optimization hint for the local identificator on a single node. Does \n"
@@ -1839,6 +1855,215 @@ static ucp_md_map_t ucp_fill_fallback_reg_nonblock_mds(ucp_context_h context)
     return (md_map == 0) ? ~md_map : md_map;
 }
 
+static int ucp_dmabuf_reg_select_md_name_cmp(const void *pa, const void *pb,
+                                             void *UCS_V_UNUSED arg)
+{
+    const ucp_dmabuf_reg_select_md_t *a = pa;
+    const ucp_dmabuf_reg_select_md_t *b = pb;
+
+    return strcmp(a->name, b->name);
+}
+
+static int ucp_dmabuf_reg_select_md_cmp(const ucp_dmabuf_reg_select_md_t *a,
+                                        const ucp_dmabuf_reg_select_md_t *b)
+{
+    int cmp;
+
+    cmp = ucs_fp_compare(a->latency, b->latency);
+    if (cmp != 0) {
+        return cmp;
+    }
+
+    if (a->last_used != b->last_used) {
+        return (a->last_used < b->last_used) ? -1 : 1;
+    }
+
+    return ucp_dmabuf_reg_select_md_name_cmp(a, b, NULL);
+}
+
+static int ucp_dmabuf_reg_select_md_qsort_cmp(const void *pa, const void *pb,
+                                              void *UCS_V_UNUSED arg)
+{
+    const ucp_dmabuf_reg_select_md_t *a = pa;
+    const ucp_dmabuf_reg_select_md_t *b = pb;
+
+    return ucp_dmabuf_reg_select_md_cmp(a, b);
+}
+
+static ucp_md_map_t
+ucp_dmabuf_reg_select_all(const ucp_dmabuf_reg_select_md_t *mds, unsigned count)
+{
+    ucp_md_map_t md_map = 0;
+    unsigned i;
+
+    for (i = 0; i < count; ++i) {
+        md_map |= UCS_BIT(mds[i].md_index);
+    }
+
+    return md_map;
+}
+
+static ucp_md_map_t
+ucp_dmabuf_reg_select_closest(const ucp_dmabuf_reg_select_md_t *mds,
+                              unsigned count)
+{
+    double min_latency = mds[0].latency;
+    ucp_md_map_t md_map;
+    unsigned i;
+
+    for (i = 1; i < count; ++i) {
+        if (ucs_fp_compare(mds[i].latency, min_latency) < 0) {
+            min_latency = mds[i].latency;
+        }
+    }
+
+    md_map = 0;
+    for (i = 0; i < count; ++i) {
+        if (ucs_fp_compare(mds[i].latency, min_latency) == 0) {
+            md_map |= UCS_BIT(mds[i].md_index);
+        }
+    }
+
+    return md_map;
+}
+
+static ucp_md_map_t
+ucp_dmabuf_reg_select_limit(const ucp_context_config_t *config,
+                            ucp_dmabuf_reg_select_md_t *mds, unsigned count)
+{
+    ucp_md_map_t md_map = 0;
+    unsigned i;
+
+    if (config->dmabuf_reg_devices_count >= count) {
+        return ucp_dmabuf_reg_select_all(mds, count);
+    }
+
+    ucs_qsort_r(mds, count, sizeof(*mds), ucp_dmabuf_reg_select_md_qsort_cmp,
+                NULL);
+    for (i = 0; i < config->dmabuf_reg_devices_count; ++i) {
+        md_map |= UCS_BIT(mds[i].md_index);
+    }
+
+    return md_map;
+}
+
+ucp_md_map_t ucp_dmabuf_reg_select(const ucp_context_config_t *config,
+                                   ucp_dmabuf_reg_select_md_t *mds,
+                                   unsigned count)
+{
+    ucs_assert(count <= UCP_MAX_MDS);
+
+    if (count == 0) {
+        return 0;
+    }
+
+    switch (config->dmabuf_reg_devices_mode) {
+    case UCP_DMABUF_REG_DEVICES_ALL:
+        return ucp_dmabuf_reg_select_all(mds, count);
+    case UCP_DMABUF_REG_DEVICES_CLOSEST:
+        return ucp_dmabuf_reg_select_closest(mds, count);
+    case UCP_DMABUF_REG_DEVICES_LIMIT:
+        return ucp_dmabuf_reg_select_limit(config, mds, count);
+    }
+
+    ucs_assertv(0, "invalid dmabuf_reg_devices_mode=%d",
+                config->dmabuf_reg_devices_mode);
+    return 0;
+}
+
+static uint32_t ucp_context_dmabuf_reg_md_last_used(ucp_context_h context,
+                                                    ucp_md_index_t md_index)
+{
+    return context->dmabuf_reg_md[md_index].last_used;
+}
+
+static double ucp_context_dmabuf_reg_latency(ucp_context_h context,
+                                             ucp_md_index_t md_index,
+                                             ucs_sys_device_t mem_sys_dev)
+{
+    double latency    = UCS_INFINITY;
+    int have_distance = 0;
+    ucs_sys_dev_distance_t distance;
+    ucs_sys_device_t sys_dev;
+
+    ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
+        if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
+             UCS_OK) &&
+            (!have_distance ||
+             (ucs_fp_compare(distance.latency, latency) < 0))) {
+            latency       = distance.latency;
+            have_distance = 1;
+        }
+    }
+
+    return have_distance ? latency : ucs_topo_default_distance.latency;
+}
+
+static ucp_md_map_t
+ucp_context_select_dmabuf_reg_md_map_config(ucp_context_h context,
+                                            const ucp_context_config_t *config,
+                                            ucp_md_map_t md_map,
+                                            ucs_sys_device_t mem_sys_dev)
+{
+    int track_lru  = config->dmabuf_reg_devices_mode ==
+                     UCP_DMABUF_REG_DEVICES_LIMIT;
+    unsigned count = 0;
+    ucp_dmabuf_reg_select_md_t select_mds[UCP_MAX_MDS];
+    ucp_md_index_t md_index;
+
+    md_map &= context->dmabuf_reg_md_map;
+    if (config->dmabuf_reg_devices_mode == UCP_DMABUF_REG_DEVICES_ALL) {
+        return md_map;
+    }
+
+    ucs_for_each_bit(md_index, md_map) {
+        select_mds[count].md_index  = md_index;
+        select_mds[count].name      = context->tl_mds[md_index].rsc.md_name;
+        select_mds[count].latency   = ucp_context_dmabuf_reg_latency(context,
+                                                                     md_index,
+                                                                     mem_sys_dev);
+        select_mds[count].last_used = 0;
+        if (track_lru) {
+            select_mds[count].last_used =
+                    ucp_context_dmabuf_reg_md_last_used(context, md_index);
+        }
+        ucs_trace("dmabuf_reg_select: md[%d]=%s mem_sys_dev=%d latency=%.2e"
+                  " last_used=%u",
+                  md_index, select_mds[count].name, mem_sys_dev,
+                  select_mds[count].latency, select_mds[count].last_used);
+        ++count;
+    }
+
+    return ucp_dmabuf_reg_select(config, select_mds, count);
+}
+
+ucp_md_map_t ucp_context_select_dmabuf_reg_md_map(ucp_context_h context,
+                                                  ucp_md_map_t md_map,
+                                                  ucs_sys_device_t mem_sys_dev)
+{
+    return ucp_context_select_dmabuf_reg_md_map_config(context,
+                                                       &context->config.ext,
+                                                       md_map, mem_sys_dev);
+}
+
+
+void ucp_context_dmabuf_reg_mark_used(ucp_context_h context,
+                                      ucp_md_map_t md_map)
+{
+    ucp_md_index_t md_index;
+
+    if (context->config.ext.dmabuf_reg_devices_mode !=
+        UCP_DMABUF_REG_DEVICES_LIMIT) {
+        return;
+    }
+
+    md_map &= context->dmabuf_reg_md_map;
+    ucs_for_each_bit(md_index, md_map) {
+        context->dmabuf_reg_md[md_index].last_used =
+                ucs_atomic_fadd32(&context->dmabuf_reg_timestamp, 1) + 1;
+    }
+}
+
 static void ucp_fill_resources_reg_md_map_update(ucp_context_h context)
 {
     UCS_STRING_BUFFER_ONSTACK(strb, 256);
@@ -2215,6 +2440,43 @@ ucp_dynamic_tl_switch_config_valid(const ucp_context_config_t *config)
     return 1;
 }
 
+static ucs_status_t
+ucp_context_config_parse_dmabuf_reg_devices(ucp_context_config_t *config)
+{
+    char buffer[32];
+    unsigned long count;
+    char *value, *endptr;
+
+    ucs_strncpy_safe(buffer, config->dmabuf_reg_devices, sizeof(buffer));
+    value = ucs_strtrim(buffer);
+
+    if (!strcasecmp(value, "all")) {
+        config->dmabuf_reg_devices_mode  = UCP_DMABUF_REG_DEVICES_ALL;
+        config->dmabuf_reg_devices_count = UCP_MAX_MDS;
+        return UCS_OK;
+    }
+
+    if (!strcasecmp(value, "closest")) {
+        config->dmabuf_reg_devices_mode  = UCP_DMABUF_REG_DEVICES_CLOSEST;
+        config->dmabuf_reg_devices_count = UCP_MAX_MDS;
+        return UCS_OK;
+    }
+
+    errno = 0;
+    count = strtoul(value, &endptr, 10);
+    if ((value[0] == '\0') || (endptr[0] != '\0') || (errno != 0) ||
+        (count == 0) || (count > UINT_MAX)) {
+        ucs_error("invalid UCX_DMABUF_REG_DEVICES value '%s', expected "
+                  "'all', 'closest', or a positive number",
+                  config->dmabuf_reg_devices);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    config->dmabuf_reg_devices_mode  = UCP_DMABUF_REG_DEVICES_LIMIT;
+    config->dmabuf_reg_devices_count = ucs_min((unsigned)count, UCP_MAX_MDS);
+    return UCS_OK;
+}
+
 static ucs_status_t ucp_fill_config(ucp_context_h context,
                                     const ucp_params_t *params,
                                     const ucp_config_t *config)
@@ -2234,6 +2496,11 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                                           ucp_context_config_table);
     if (status != UCS_OK) {
         goto err;
+    }
+
+    status = ucp_context_config_parse_dmabuf_reg_devices(&context->config.ext);
+    if (status != UCS_OK) {
+        goto err_free_config_ext;
     }
 
     if (context->config.ext.estimated_num_eps != UCS_ULUNITS_AUTO) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -31,12 +31,10 @@
 #include <ucs/vfs/base/vfs_obj.h>
 #include <string.h>
 #include <dlfcn.h>
-#include <errno.h>
-#include <limits.h>
-#include <stdlib.h>
 
 
 #define UCP_RSC_CONFIG_ALL    "all"
+
 
 #define UCP_AM_HANDLER_FOREACH(_macro) \
     _macro(UCP_AM_ID_WIREUP) \
@@ -603,15 +601,13 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, proto_use_single_net_device),
    UCS_CONFIG_TYPE_BOOL},
 
-  {"DMABUF_REG_DEVICES", "all",
-   "Specifies which dmabuf-capable UCP memory domain(s) to use for broad "
-   "memory registration.\n"
-   " - all     : register on all reachable dmabuf-capable memory domains.\n"
-   " - closest : register on reachable memory domains with the lowest latency "
-   "from the memory device.\n"
-   " - <N>     : register on up to N lowest-latency reachable memory domains.",
-   ucs_offsetof(ucp_context_config_t, dmabuf_reg_devices),
-   UCS_CONFIG_TYPE_STRING},
+  {"MAX_HCA_PER_GPU", "inf",
+   "Maximum number of HCAs to register GPU memory on.\n"
+   " - inf : register on all reachable HCAs (default).\n"
+   " - 0   : register only on HCAs with the lowest latency to the GPU.\n"
+   " - <N> : register on up to N lowest-latency reachable HCAs.",
+   ucs_offsetof(ucp_context_config_t, max_hca_per_gpu),
+   UCS_CONFIG_TYPE_ULUNITS},
 
   {"NODE_LOCAL_ID", "auto",
    "An optimization hint for the local identificator on a single node. Does \n"
@@ -1855,18 +1851,11 @@ static ucp_md_map_t ucp_fill_fallback_reg_nonblock_mds(ucp_context_h context)
     return (md_map == 0) ? ~md_map : md_map;
 }
 
-static int ucp_dmabuf_reg_select_md_name_cmp(const void *pa, const void *pb,
-                                             void *UCS_V_UNUSED arg)
+static int ucp_reg_select_md_cmp(const void *pa, const void *pb,
+                                 void *UCS_V_UNUSED arg)
 {
-    const ucp_dmabuf_reg_select_md_t *a = pa;
-    const ucp_dmabuf_reg_select_md_t *b = pb;
-
-    return strcmp(a->name, b->name);
-}
-
-static int ucp_dmabuf_reg_select_md_cmp(const ucp_dmabuf_reg_select_md_t *a,
-                                        const ucp_dmabuf_reg_select_md_t *b)
-{
+    const ucp_reg_select_md_t *a = pa;
+    const ucp_reg_select_md_t *b = pb;
     int cmp;
 
     cmp = ucs_fp_compare(a->latency, b->latency);
@@ -1874,193 +1863,154 @@ static int ucp_dmabuf_reg_select_md_cmp(const ucp_dmabuf_reg_select_md_t *a,
         return cmp;
     }
 
-    if (a->last_used != b->last_used) {
-        return (a->last_used < b->last_used) ? -1 : 1;
+    if (a->use_count != b->use_count) {
+        return (a->use_count < b->use_count) ? -1 : 1;
     }
 
-    return ucp_dmabuf_reg_select_md_name_cmp(a, b, NULL);
+    return strcmp(a->name, b->name);
 }
 
-static int ucp_dmabuf_reg_select_md_qsort_cmp(const void *pa, const void *pb,
-                                              void *UCS_V_UNUSED arg)
-{
-    const ucp_dmabuf_reg_select_md_t *a = pa;
-    const ucp_dmabuf_reg_select_md_t *b = pb;
-
-    return ucp_dmabuf_reg_select_md_cmp(a, b);
-}
-
-static ucp_md_map_t
-ucp_dmabuf_reg_select_all(const ucp_dmabuf_reg_select_md_t *mds, unsigned count)
+ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
+                             ucp_reg_select_md_t *mds,
+                             unsigned count)
 {
     ucp_md_map_t md_map = 0;
-    unsigned i;
+    unsigned i, select_count;
 
-    for (i = 0; i < count; ++i) {
-        md_map |= UCS_BIT(mds[i].md_index);
-    }
-
-    return md_map;
-}
-
-static ucp_md_map_t
-ucp_dmabuf_reg_select_closest(const ucp_dmabuf_reg_select_md_t *mds,
-                              unsigned count)
-{
-    double min_latency = mds[0].latency;
-    ucp_md_map_t md_map;
-    unsigned i;
-
-    for (i = 1; i < count; ++i) {
-        if (ucs_fp_compare(mds[i].latency, min_latency) < 0) {
-            min_latency = mds[i].latency;
-        }
-    }
-
-    md_map = 0;
-    for (i = 0; i < count; ++i) {
-        if (ucs_fp_compare(mds[i].latency, min_latency) == 0) {
-            md_map |= UCS_BIT(mds[i].md_index);
-        }
-    }
-
-    return md_map;
-}
-
-static ucp_md_map_t
-ucp_dmabuf_reg_select_limit(const ucp_context_config_t *config,
-                            ucp_dmabuf_reg_select_md_t *mds, unsigned count)
-{
-    ucp_md_map_t md_map = 0;
-    unsigned i;
-
-    if (config->dmabuf_reg_devices_count >= count) {
-        return ucp_dmabuf_reg_select_all(mds, count);
-    }
-
-    ucs_qsort_r(mds, count, sizeof(*mds), ucp_dmabuf_reg_select_md_qsort_cmp,
-                NULL);
-    for (i = 0; i < config->dmabuf_reg_devices_count; ++i) {
-        md_map |= UCS_BIT(mds[i].md_index);
-    }
-
-    return md_map;
-}
-
-ucp_md_map_t ucp_dmabuf_reg_select(const ucp_context_config_t *config,
-                                   ucp_dmabuf_reg_select_md_t *mds,
-                                   unsigned count)
-{
     ucs_assert(count <= UCP_MAX_MDS);
 
     if (count == 0) {
         return 0;
     }
 
-    switch (config->dmabuf_reg_devices_mode) {
-    case UCP_DMABUF_REG_DEVICES_ALL:
-        return ucp_dmabuf_reg_select_all(mds, count);
-    case UCP_DMABUF_REG_DEVICES_CLOSEST:
-        return ucp_dmabuf_reg_select_closest(mds, count);
-    case UCP_DMABUF_REG_DEVICES_LIMIT:
-        return ucp_dmabuf_reg_select_limit(config, mds, count);
-    }
-
-    ucs_assertv(0, "invalid dmabuf_reg_devices_mode=%d",
-                config->dmabuf_reg_devices_mode);
-    return 0;
-}
-
-static uint32_t ucp_context_dmabuf_reg_md_last_used(ucp_context_h context,
-                                                    ucp_md_index_t md_index)
-{
-    return context->dmabuf_reg_md[md_index].last_used;
-}
-
-static double ucp_context_dmabuf_reg_latency(ucp_context_h context,
-                                             ucp_md_index_t md_index,
-                                             ucs_sys_device_t mem_sys_dev)
-{
-    double latency    = UCS_INFINITY;
-    int have_distance = 0;
-    ucs_sys_dev_distance_t distance;
-    ucs_sys_device_t sys_dev;
-
-    ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
-        if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
-             UCS_OK) &&
-            (!have_distance ||
-             (ucs_fp_compare(distance.latency, latency) < 0))) {
-            latency       = distance.latency;
-            have_distance = 1;
+    switch (ucp_reg_devices_mode(config->max_hca_per_gpu)) {
+    case UCP_REG_DEVICES_ALL:
+        select_count = count;
+        break;
+    case UCP_REG_DEVICES_CLOSEST:
+        ucs_qsort_r(mds, count, sizeof(*mds), ucp_reg_select_md_cmp, NULL);
+        select_count = count;
+        for (i = 1; i < count; i++) {
+            if (ucs_fp_compare(mds[i].latency, mds[0].latency) != 0) {
+                select_count = i;
+                break;
+            }
         }
+        break;
+    case UCP_REG_DEVICES_LIMIT:
+        ucs_qsort_r(mds, count, sizeof(*mds), ucp_reg_select_md_cmp, NULL);
+        select_count = ucs_min(ucp_reg_devices_count(config->max_hca_per_gpu),
+                               count);
+        break;
+    default:
+        ucs_assertv(0, "invalid reg_devices_mode=%d",
+                    ucp_reg_devices_mode(config->max_hca_per_gpu));
+        return 0;
     }
 
-    return have_distance ? latency : ucs_topo_default_distance.latency;
+    for (i = 0; i < select_count; i++) {
+        md_map |= UCS_BIT(mds[i].md_index);
+    }
+
+    return md_map;
 }
 
-static ucp_md_map_t
-ucp_context_select_dmabuf_reg_md_map_config(ucp_context_h context,
-                                            const ucp_context_config_t *config,
-                                            ucp_md_map_t md_map,
-                                            ucs_sys_device_t mem_sys_dev)
+static double ucp_context_reg_md_latency(ucp_context_h context,
+                                         ucp_md_index_t md_index,
+                                         ucs_sys_device_t mem_sys_dev)
 {
-    int track_lru  = config->dmabuf_reg_devices_mode ==
-                     UCP_DMABUF_REG_DEVICES_LIMIT;
-    unsigned count = 0;
-    ucp_dmabuf_reg_select_md_t select_mds[UCP_MAX_MDS];
+    if ((mem_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+        (mem_sys_dev < UCP_MAX_SYS_DEVICES)) {
+        return context->reg_md[md_index].latency[mem_sys_dev];
+    }
+
+    return ucs_topo_default_distance.latency;
+}
+
+ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
+                                           ucp_md_map_t md_map,
+                                           ucs_sys_device_t mem_sys_dev)
+{
+    const ucp_context_config_t *config = &context->config.ext;
+    unsigned count                     = 0;
+    ucp_reg_select_md_t select_mds[UCP_MAX_MDS];
     ucp_md_index_t md_index;
 
-    md_map &= context->dmabuf_reg_md_map;
-    if (config->dmabuf_reg_devices_mode == UCP_DMABUF_REG_DEVICES_ALL) {
+    if (ucp_reg_devices_mode(config->max_hca_per_gpu) == UCP_REG_DEVICES_ALL) {
         return md_map;
     }
 
     ucs_for_each_bit(md_index, md_map) {
         select_mds[count].md_index  = md_index;
         select_mds[count].name      = context->tl_mds[md_index].rsc.md_name;
-        select_mds[count].latency   = ucp_context_dmabuf_reg_latency(context,
-                                                                     md_index,
-                                                                     mem_sys_dev);
-        select_mds[count].last_used = 0;
-        if (track_lru) {
-            select_mds[count].last_used =
-                    ucp_context_dmabuf_reg_md_last_used(context, md_index);
-        }
-        ucs_trace("dmabuf_reg_select: md[%d]=%s mem_sys_dev=%d latency=%.2e"
-                  " last_used=%u",
+        select_mds[count].latency   = ucp_context_reg_md_latency(context,
+                                                                  md_index,
+                                                                  mem_sys_dev);
+        select_mds[count].use_count = context->reg_md[md_index].use_count;
+        ucs_trace("reg_select: md[%d]=%s mem_sys_dev=%d latency=%.2e"
+                  " use_count=%u",
                   md_index, select_mds[count].name, mem_sys_dev,
-                  select_mds[count].latency, select_mds[count].last_used);
-        ++count;
+                  select_mds[count].latency, select_mds[count].use_count);
+        count++;
     }
 
-    return ucp_dmabuf_reg_select(config, select_mds, count);
-}
-
-ucp_md_map_t ucp_context_select_dmabuf_reg_md_map(ucp_context_h context,
-                                                  ucp_md_map_t md_map,
-                                                  ucs_sys_device_t mem_sys_dev)
-{
-    return ucp_context_select_dmabuf_reg_md_map_config(context,
-                                                       &context->config.ext,
-                                                       md_map, mem_sys_dev);
+    return ucp_reg_select(config, select_mds, count);
 }
 
 
-void ucp_context_dmabuf_reg_mark_used(ucp_context_h context,
-                                      ucp_md_map_t md_map)
+void ucp_context_reg_mark_used(ucp_context_h context,
+                               ucp_md_map_t md_map)
 {
     ucp_md_index_t md_index;
 
-    if (context->config.ext.dmabuf_reg_devices_mode !=
-        UCP_DMABUF_REG_DEVICES_LIMIT) {
-        return;
-    }
-
     md_map &= context->dmabuf_reg_md_map;
     ucs_for_each_bit(md_index, md_map) {
-        context->dmabuf_reg_md[md_index].last_used =
-                ucs_atomic_fadd32(&context->dmabuf_reg_timestamp, 1) + 1;
+        ucs_atomic_add32(&context->reg_md[md_index].use_count, 1);
+    }
+}
+
+static void ucp_context_build_reg_md_topo(ucp_context_h context)
+{
+    unsigned num_sys_devs = ucs_topo_num_devices();
+    ucs_sys_device_t mem_sys_dev, sys_dev;
+    ucs_sys_dev_distance_t distance;
+    ucp_md_index_t md_index;
+    double latency;
+
+    ucs_for_each_bit(md_index, context->dmabuf_reg_md_map) {
+        if (context->tl_mds[md_index].sys_dev_map == 0) {
+            /* MD with no known sys devices is reachable from everywhere */
+            for (mem_sys_dev = 0; mem_sys_dev < num_sys_devs; ++mem_sys_dev) {
+                context->reg_dev_reachable[mem_sys_dev] |= UCS_BIT(md_index);
+                context->reg_md[md_index].latency[mem_sys_dev] =
+                        ucs_topo_default_distance.latency;
+            }
+            continue;
+        }
+
+        for (mem_sys_dev = 0; mem_sys_dev < num_sys_devs; ++mem_sys_dev) {
+            latency = UCS_INFINITY;
+            ucs_for_each_bit(sys_dev,
+                             context->tl_mds[md_index].sys_dev_map) {
+                if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
+                    latency = UCS_INFINITY;
+                    break;
+                }
+                if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
+                     UCS_OK) &&
+                    (ucs_fp_compare(distance.latency, latency) < 0)) {
+                    latency = distance.latency;
+                }
+            }
+
+            if (latency == UCS_INFINITY) {
+                context->reg_md[md_index].latency[mem_sys_dev] =
+                        ucs_topo_default_distance.latency;
+            } else {
+                context->reg_dev_reachable[mem_sys_dev] |= UCS_BIT(md_index);
+                context->reg_md[md_index].latency[mem_sys_dev] = latency;
+            }
+        }
     }
 }
 
@@ -2084,6 +2034,8 @@ static void ucp_fill_resources_reg_md_map_update(ucp_context_h context)
             context->dmabuf_reg_md_map |= UCS_BIT(md_index);
         }
     }
+
+    ucp_context_build_reg_md_topo(context);
 
     fallback_reg_nonblock_md_map = ucp_fill_fallback_reg_nonblock_mds(context);
 
@@ -2440,43 +2392,6 @@ ucp_dynamic_tl_switch_config_valid(const ucp_context_config_t *config)
     return 1;
 }
 
-static ucs_status_t
-ucp_context_config_parse_dmabuf_reg_devices(ucp_context_config_t *config)
-{
-    char buffer[32];
-    unsigned long count;
-    char *value, *endptr;
-
-    ucs_strncpy_safe(buffer, config->dmabuf_reg_devices, sizeof(buffer));
-    value = ucs_strtrim(buffer);
-
-    if (!strcasecmp(value, "all")) {
-        config->dmabuf_reg_devices_mode  = UCP_DMABUF_REG_DEVICES_ALL;
-        config->dmabuf_reg_devices_count = UCP_MAX_MDS;
-        return UCS_OK;
-    }
-
-    if (!strcasecmp(value, "closest")) {
-        config->dmabuf_reg_devices_mode  = UCP_DMABUF_REG_DEVICES_CLOSEST;
-        config->dmabuf_reg_devices_count = UCP_MAX_MDS;
-        return UCS_OK;
-    }
-
-    errno = 0;
-    count = strtoul(value, &endptr, 10);
-    if ((value[0] == '\0') || (endptr[0] != '\0') || (errno != 0) ||
-        (count == 0) || (count > UINT_MAX)) {
-        ucs_error("invalid UCX_DMABUF_REG_DEVICES value '%s', expected "
-                  "'all', 'closest', or a positive number",
-                  config->dmabuf_reg_devices);
-        return UCS_ERR_INVALID_PARAM;
-    }
-
-    config->dmabuf_reg_devices_mode  = UCP_DMABUF_REG_DEVICES_LIMIT;
-    config->dmabuf_reg_devices_count = ucs_min((unsigned)count, UCP_MAX_MDS);
-    return UCS_OK;
-}
-
 static ucs_status_t ucp_fill_config(ucp_context_h context,
                                     const ucp_params_t *params,
                                     const ucp_config_t *config)
@@ -2496,11 +2411,6 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                                           ucp_context_config_table);
     if (status != UCS_OK) {
         goto err;
-    }
-
-    status = ucp_context_config_parse_dmabuf_reg_devices(&context->config.ext);
-    if (status != UCS_OK) {
-        goto err_free_config_ext;
     }
 
     if (context->config.ext.estimated_num_eps != UCS_ULUNITS_AUTO) {

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1932,7 +1932,7 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
         select_mds[count].md_index = md_index;
         select_mds[count].name     = context->tl_mds[md_index].rsc.md_name;
         select_mds[count].distance = best;
-        ucs_trace("reg_select: sys_dev=%d md[%d]=%s lat=%.2e bw=%.2e",
+        ucs_trace("reg_select: mem_sys_dev=%d md[%d]=%s lat=%.2e bw=%.2e",
                   mem_sys_dev, md_index, select_mds[count].name,
                   best.latency, best.bandwidth);
         count++;
@@ -1943,7 +1943,7 @@ ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
     }
 
     ucs_qsort_r(select_mds, count, sizeof(select_mds[0]),
-                 ucp_reg_select_md_cmp, NULL);
+                ucp_reg_select_md_cmp, NULL);
 
     switch (ucp_reg_devices_mode(config->max_hca_per_gpu)) {
     case UCP_REG_DEVICES_CLOSEST:

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -35,7 +35,6 @@
 
 #define UCP_RSC_CONFIG_ALL    "all"
 
-
 #define UCP_AM_HANDLER_FOREACH(_macro) \
     _macro(UCP_AM_ID_WIREUP) \
     _macro(UCP_AM_ID_EAGER_ONLY) \
@@ -1851,8 +1850,8 @@ static ucp_md_map_t ucp_fill_fallback_reg_nonblock_mds(ucp_context_h context)
     return (md_map == 0) ? ~md_map : md_map;
 }
 
-static int ucp_reg_select_md_cmp(const void *pa, const void *pb,
-                                 void *UCS_V_UNUSED arg)
+static int
+ucp_reg_select_md_cmp(const void *pa, const void *pb, void *UCS_V_UNUSED arg)
 {
     const ucp_reg_select_md_t *a = pa;
     const ucp_reg_select_md_t *b = pb;
@@ -1871,8 +1870,7 @@ static int ucp_reg_select_md_cmp(const void *pa, const void *pb,
 }
 
 ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
-                             ucp_reg_select_md_t *mds,
-                             unsigned count)
+                            ucp_reg_select_md_t *mds, unsigned count)
 {
     ucp_md_map_t md_map = 0;
     unsigned i, select_count;
@@ -1944,8 +1942,8 @@ ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
         select_mds[count].md_index  = md_index;
         select_mds[count].name      = context->tl_mds[md_index].rsc.md_name;
         select_mds[count].latency   = ucp_context_reg_md_latency(context,
-                                                                  md_index,
-                                                                  mem_sys_dev);
+                                                                 md_index,
+                                                                 mem_sys_dev);
         select_mds[count].use_count = context->reg_md[md_index].use_count;
         ucs_trace("reg_select: md[%d]=%s mem_sys_dev=%d latency=%.2e"
                   " use_count=%u",
@@ -1958,8 +1956,7 @@ ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
 }
 
 
-void ucp_context_reg_mark_used(ucp_context_h context,
-                               ucp_md_map_t md_map)
+void ucp_context_reg_mark_used(ucp_context_h context, ucp_md_map_t md_map)
 {
     ucp_md_index_t md_index;
 
@@ -1990,8 +1987,7 @@ static void ucp_context_build_reg_md_topo(ucp_context_h context)
 
         for (mem_sys_dev = 0; mem_sys_dev < num_sys_devs; ++mem_sys_dev) {
             latency = UCS_INFINITY;
-            ucs_for_each_bit(sys_dev,
-                             context->tl_mds[md_index].sys_dev_map) {
+            ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
                 if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
                     latency = UCS_INFINITY;
                     break;

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -603,8 +603,8 @@ static ucs_config_field_t ucp_context_config_table[] = {
   {"MAX_HCA_PER_GPU", "inf",
    "Maximum number of HCAs to register GPU memory on.\n"
    " - inf : register on all reachable HCAs (default).\n"
-   " - 0   : register only on HCAs with the lowest latency to the GPU.\n"
-   " - <N> : register on up to N lowest-latency reachable HCAs.",
+   " - 0   : register only on HCAs with the highest bandwidth to the GPU.\n"
+   " - <N> : register on up to N highest-bandwidth reachable HCAs.",
    ucs_offsetof(ucp_context_config_t, max_hca_per_gpu),
    UCS_CONFIG_TYPE_ULUNITS},
 
@@ -1850,6 +1850,12 @@ static ucp_md_map_t ucp_fill_fallback_reg_nonblock_mds(ucp_context_h context)
     return (md_map == 0) ? ~md_map : md_map;
 }
 
+typedef struct ucp_reg_select_md {
+    ucp_md_index_t md_index;
+    const char     *name;
+    double         bandwidth;
+} ucp_reg_select_md_t;
+
 static int
 ucp_reg_select_md_cmp(const void *pa, const void *pb, void *UCS_V_UNUSED arg)
 {
@@ -1857,46 +1863,86 @@ ucp_reg_select_md_cmp(const void *pa, const void *pb, void *UCS_V_UNUSED arg)
     const ucp_reg_select_md_t *b = pb;
     int cmp;
 
-    cmp = ucs_fp_compare(a->latency, b->latency);
+    /* Sort by bandwidth descending (highest first = closest) */
+    cmp = ucs_fp_compare(b->bandwidth, a->bandwidth);
     if (cmp != 0) {
         return cmp;
-    }
-
-    if (a->use_count != b->use_count) {
-        return (a->use_count < b->use_count) ? -1 : 1;
     }
 
     return strcmp(a->name, b->name);
 }
 
-ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
-                            ucp_reg_select_md_t *mds, unsigned count)
+ucp_md_map_t
+ucp_context_select_reg_mds(ucp_context_h context, ucp_md_map_t md_map,
+                           ucs_sys_device_t mem_sys_dev)
 {
-    ucp_md_map_t md_map = 0;
-    unsigned i, select_count;
+    const ucp_context_config_t *config = &context->config.ext;
+    ucp_md_map_t result                = 0;
+    unsigned count                     = 0;
+    ucp_reg_select_md_t select_mds[UCP_MAX_MDS];
+    ucs_sys_dev_distance_t distance;
+    ucs_sys_device_t sys_dev;
+    unsigned select_count, i;
+    ucp_md_index_t md_index;
+    double bw;
+    int reachable;
 
-    ucs_assert(count <= UCP_MAX_MDS);
+    if (ucp_reg_devices_mode(config->max_hca_per_gpu) == UCP_REG_DEVICES_ALL) {
+        return md_map;
+    }
+
+    ucs_for_each_bit(md_index, md_map) {
+        if (context->tl_mds[md_index].sys_dev_map == 0) {
+            bw = UCS_INFINITY;
+        } else {
+            reachable = 1;
+            bw        = 0;
+            ucs_for_each_bit(sys_dev,
+                             context->tl_mds[md_index].sys_dev_map) {
+                if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
+                    reachable = 0;
+                    break;
+                }
+                if ((ucs_topo_get_distance(mem_sys_dev, sys_dev,
+                                           &distance) == UCS_OK) &&
+                    (ucs_fp_compare(distance.bandwidth, bw) > 0)) {
+                    bw = distance.bandwidth;
+                }
+            }
+
+            if (!reachable) {
+                continue;
+            }
+        }
+
+        select_mds[count].md_index  = md_index;
+        select_mds[count].name      = context->tl_mds[md_index].rsc.md_name;
+        select_mds[count].bandwidth = bw;
+        ucs_trace("reg_select: sys_dev=%d md[%d]=%s bw=%.2e",
+                  mem_sys_dev, md_index, select_mds[count].name,
+                  select_mds[count].bandwidth);
+        count++;
+    }
 
     if (count == 0) {
         return 0;
     }
 
+    ucs_qsort_r(select_mds, count, sizeof(select_mds[0]),
+                 ucp_reg_select_md_cmp, NULL);
+
     switch (ucp_reg_devices_mode(config->max_hca_per_gpu)) {
-    case UCP_REG_DEVICES_ALL:
-        select_count = count;
-        break;
     case UCP_REG_DEVICES_CLOSEST:
-        ucs_qsort_r(mds, count, sizeof(*mds), ucp_reg_select_md_cmp, NULL);
         select_count = count;
         for (i = 1; i < count; i++) {
-            if (ucs_fp_compare(mds[i].latency, mds[0].latency) != 0) {
+            if (ucs_fp_compare(select_mds[i].bandwidth,
+                               select_mds[0].bandwidth) != 0) {
                 select_count = i;
                 break;
             }
         }
         break;
     case UCP_REG_DEVICES_LIMIT:
-        ucs_qsort_r(mds, count, sizeof(*mds), ucp_reg_select_md_cmp, NULL);
         select_count = ucs_min(ucp_reg_devices_count(config->max_hca_per_gpu),
                                count);
         break;
@@ -1907,107 +1953,10 @@ ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
     }
 
     for (i = 0; i < select_count; i++) {
-        md_map |= UCS_BIT(mds[i].md_index);
+        result |= UCS_BIT(select_mds[i].md_index);
     }
 
-    return md_map;
-}
-
-static double ucp_context_reg_md_latency(ucp_context_h context,
-                                         ucp_md_index_t md_index,
-                                         ucs_sys_device_t mem_sys_dev)
-{
-    if ((mem_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
-        (mem_sys_dev < UCP_MAX_SYS_DEVICES)) {
-        return context->reg_md[md_index].latency[mem_sys_dev];
-    }
-
-    return ucs_topo_default_distance.latency;
-}
-
-ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
-                                           ucp_md_map_t md_map,
-                                           ucs_sys_device_t mem_sys_dev)
-{
-    const ucp_context_config_t *config = &context->config.ext;
-    unsigned count                     = 0;
-    ucp_reg_select_md_t select_mds[UCP_MAX_MDS];
-    ucp_md_index_t md_index;
-
-    if (ucp_reg_devices_mode(config->max_hca_per_gpu) == UCP_REG_DEVICES_ALL) {
-        return md_map;
-    }
-
-    ucs_for_each_bit(md_index, md_map) {
-        select_mds[count].md_index  = md_index;
-        select_mds[count].name      = context->tl_mds[md_index].rsc.md_name;
-        select_mds[count].latency   = ucp_context_reg_md_latency(context,
-                                                                 md_index,
-                                                                 mem_sys_dev);
-        select_mds[count].use_count = context->reg_md[md_index].use_count;
-        ucs_trace("reg_select: md[%d]=%s mem_sys_dev=%d latency=%.2e"
-                  " use_count=%u",
-                  md_index, select_mds[count].name, mem_sys_dev,
-                  select_mds[count].latency, select_mds[count].use_count);
-        count++;
-    }
-
-    return ucp_reg_select(config, select_mds, count);
-}
-
-
-void ucp_context_reg_mark_used(ucp_context_h context, ucp_md_map_t md_map)
-{
-    ucp_md_index_t md_index;
-
-    md_map &= context->dmabuf_reg_md_map;
-    ucs_for_each_bit(md_index, md_map) {
-        ucs_atomic_add32(&context->reg_md[md_index].use_count, 1);
-    }
-}
-
-static void ucp_context_build_reg_md_topo(ucp_context_h context)
-{
-    unsigned num_sys_devs = ucs_topo_num_devices();
-    ucs_sys_device_t mem_sys_dev, sys_dev;
-    ucs_sys_dev_distance_t distance;
-    ucp_md_index_t md_index;
-    double latency;
-
-    ucs_for_each_bit(md_index, context->dmabuf_reg_md_map) {
-        if (context->tl_mds[md_index].sys_dev_map == 0) {
-            /* MD with no known sys devices is reachable from everywhere */
-            for (mem_sys_dev = 0; mem_sys_dev < num_sys_devs; ++mem_sys_dev) {
-                context->reg_dev_reachable[mem_sys_dev] |= UCS_BIT(md_index);
-                context->reg_md[md_index].latency[mem_sys_dev] =
-                        ucs_topo_default_distance.latency;
-            }
-            continue;
-        }
-
-        for (mem_sys_dev = 0; mem_sys_dev < num_sys_devs; ++mem_sys_dev) {
-            latency = UCS_INFINITY;
-            ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
-                if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
-                    latency = UCS_INFINITY;
-                    break;
-                }
-                if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
-                     UCS_OK) &&
-                    (ucs_fp_compare(distance.latency, latency) < 0)) {
-                    latency = distance.latency;
-                }
-            }
-
-            if (latency == UCS_INFINITY) {
-                context->reg_md[md_index].latency[mem_sys_dev] =
-                        ucs_topo_default_distance.latency;
-            } else {
-                context->reg_dev_reachable[mem_sys_dev] |= UCS_BIT(md_index);
-                context->reg_md[md_index].latency[mem_sys_dev] = latency;
-            }
-        }
-    }
+    return result;
 }
 
 static void ucp_fill_resources_reg_md_map_update(ucp_context_h context)
@@ -2030,8 +1979,6 @@ static void ucp_fill_resources_reg_md_map_update(ucp_context_h context)
             context->dmabuf_reg_md_map |= UCS_BIT(md_index);
         }
     }
-
-    ucp_context_build_reg_md_topo(context);
 
     fallback_reg_nonblock_md_map = ucp_fill_fallback_reg_nonblock_mds(context);
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1872,9 +1872,9 @@ ucp_reg_select_md_cmp(const void *pa, const void *pb, void *UCS_V_UNUSED arg)
     return strcmp(a->name, b->name);
 }
 
-ucp_md_map_t
-ucp_context_select_reg_mds(ucp_context_h context, ucp_md_map_t md_map,
-                           ucs_sys_device_t mem_sys_dev)
+ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
+                                        ucp_md_map_t md_map,
+                                        ucs_sys_device_t mem_sys_dev)
 {
     const ucp_context_config_t *config = &context->config.ext;
     ucp_md_map_t result                = 0;
@@ -1897,15 +1897,13 @@ ucp_context_select_reg_mds(ucp_context_h context, ucp_md_map_t md_map,
         } else {
             reachable = 1;
             bw        = 0;
-            ucs_for_each_bit(sys_dev,
-                             context->tl_mds[md_index].sys_dev_map) {
+            ucs_for_each_bit(sys_dev, context->tl_mds[md_index].sys_dev_map) {
                 if (!ucs_topo_is_reachable(sys_dev, mem_sys_dev)) {
                     reachable = 0;
                     break;
                 }
-                if ((ucs_topo_get_distance(mem_sys_dev, sys_dev,
-                                           &distance) == UCS_OK) &&
-                    (ucs_fp_compare(distance.bandwidth, bw) > 0)) {
+                if ((ucs_topo_get_distance(mem_sys_dev, sys_dev, &distance) ==
+                     UCS_OK) && (ucs_fp_compare(distance.bandwidth, bw) > 0)) {
                     bw = distance.bandwidth;
                 }
             }

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -52,6 +52,25 @@ enum {
     (ucs_ilog2(ucp_proto_select_op_attr_pack((_op_attr_flag), \
                                              UCP_OP_ATTR_INDEX_MASK)))
 
+typedef enum {
+    UCP_DMABUF_REG_DEVICES_ALL,
+    UCP_DMABUF_REG_DEVICES_CLOSEST,
+    UCP_DMABUF_REG_DEVICES_LIMIT
+} ucp_dmabuf_reg_devices_mode_t;
+
+
+typedef struct ucp_dmabuf_reg_select_md {
+    ucp_md_index_t md_index;
+    const char     *name;
+    double         latency;
+    uint32_t       last_used;
+} ucp_dmabuf_reg_select_md_t;
+
+
+typedef struct ucp_dmabuf_reg_md {
+    uint32_t last_used;
+} ucp_dmabuf_reg_md_t;
+
 
 typedef struct ucp_context_config {
     /** Threshold for switching UCP to buffered copy(bcopy) protocol */
@@ -222,6 +241,12 @@ typedef struct ucp_context_config {
     int                                    connect_all_to_all;
     /** Use only one network device for all protocols */
     int                                    proto_use_single_net_device;
+    /** Select dmabuf-capable memory domains for broad registration */
+    char                                   *dmabuf_reg_devices;
+    /** Parsed dmabuf registration memory-domain selection mode */
+    ucp_dmabuf_reg_devices_mode_t          dmabuf_reg_devices_mode;
+    /** Number of dmabuf-capable memory domains for broad registration */
+    unsigned                               dmabuf_reg_devices_count;
     /** Local identificator on a single node */
     unsigned long                          node_local_id;
 } ucp_context_config_t;
@@ -387,6 +412,12 @@ typedef struct ucp_context {
 
     /* Map of MDs that support dmabuf registration */
     ucp_md_map_t                  dmabuf_reg_md_map;
+
+    /* Dmabuf registration selection state per MD */
+    ucp_dmabuf_reg_md_t           dmabuf_reg_md[UCP_MAX_MDS];
+
+    /* Monotonic counter for LRU-based dmabuf MD selection */
+    volatile uint32_t             dmabuf_reg_timestamp;
 
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
@@ -759,6 +790,20 @@ void ucp_tl_bitmap_validate(const ucp_tl_bitmap_t *tl_bitmap,
 
 
 const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
+
+
+ucp_md_map_t ucp_dmabuf_reg_select(const ucp_context_config_t *config,
+                                   ucp_dmabuf_reg_select_md_t *mds,
+                                   unsigned count);
+
+
+ucp_md_map_t ucp_context_select_dmabuf_reg_md_map(ucp_context_h context,
+                                                  ucp_md_map_t md_map,
+                                                  ucs_sys_device_t mem_sys_dev);
+
+
+void ucp_context_dmabuf_reg_mark_used(ucp_context_h context,
+                                      ucp_md_map_t md_map);
 
 
 ucs_status_t

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -813,8 +813,7 @@ const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
 
 
 ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
-                            ucp_reg_select_md_t *mds,
-                            unsigned count);
+                            ucp_reg_select_md_t *mds, unsigned count);
 
 
 ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
@@ -822,8 +821,7 @@ ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
                                            ucs_sys_device_t mem_sys_dev);
 
 
-void ucp_context_reg_mark_used(ucp_context_h context,
-                               ucp_md_map_t md_map);
+void ucp_context_reg_mark_used(ucp_context_h context, ucp_md_map_t md_map);
 
 
 ucs_status_t

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -62,10 +62,9 @@ typedef enum {
 static UCS_F_ALWAYS_INLINE ucp_reg_devices_mode_t
 ucp_reg_devices_mode(unsigned long max_hca_per_gpu)
 {
-    if ((max_hca_per_gpu == UCS_ULUNITS_INF) ||
-        (max_hca_per_gpu == UCS_ULUNITS_AUTO)) {
+    if (max_hca_per_gpu == UCS_ULUNITS_INF) {
         return UCP_REG_DEVICES_ALL;
-    } else if (max_hca_per_gpu == 0) {
+    } else if (max_hca_per_gpu == UCS_ULUNITS_AUTO) {
         return UCP_REG_DEVICES_CLOSEST;
     }
     return UCP_REG_DEVICES_LIMIT;
@@ -252,7 +251,7 @@ typedef struct ucp_context_config {
     int                                    connect_all_to_all;
     /** Use only one network device for all protocols */
     int                                    proto_use_single_net_device;
-    /** Max HCAs for GPU memory registration: 0=closest, N=limit, inf=all */
+    /** Max HCAs for GPU memory registration: auto=closest, N=limit, inf=all */
     unsigned long                          max_hca_per_gpu;
     /** Local identificator on a single node */
     unsigned long                          node_local_id;
@@ -796,6 +795,9 @@ const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
 ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
                                         ucp_md_map_t md_map,
                                         ucs_sys_device_t mem_sys_dev);
+
+
+ucp_md_map_t ucp_context_get_net_md_map(ucp_context_h context);
 
 
 ucs_status_t

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -53,23 +53,47 @@ enum {
                                              UCP_OP_ATTR_INDEX_MASK)))
 
 typedef enum {
-    UCP_DMABUF_REG_DEVICES_ALL,
-    UCP_DMABUF_REG_DEVICES_CLOSEST,
-    UCP_DMABUF_REG_DEVICES_LIMIT
-} ucp_dmabuf_reg_devices_mode_t;
+    UCP_REG_DEVICES_ALL,
+    UCP_REG_DEVICES_CLOSEST,
+    UCP_REG_DEVICES_LIMIT
+} ucp_reg_devices_mode_t;
 
 
-typedef struct ucp_dmabuf_reg_select_md {
+static UCS_F_ALWAYS_INLINE ucp_reg_devices_mode_t
+ucp_reg_devices_mode(unsigned long max_hca_per_gpu)
+{
+    if ((max_hca_per_gpu == UCS_ULUNITS_INF) ||
+        (max_hca_per_gpu == UCS_ULUNITS_AUTO)) {
+        return UCP_REG_DEVICES_ALL;
+    } else if (max_hca_per_gpu == 0) {
+        return UCP_REG_DEVICES_CLOSEST;
+    }
+    return UCP_REG_DEVICES_LIMIT;
+}
+
+
+static UCS_F_ALWAYS_INLINE unsigned
+ucp_reg_devices_count(unsigned long max_hca_per_gpu)
+{
+    if (ucp_reg_devices_mode(max_hca_per_gpu) == UCP_REG_DEVICES_LIMIT) {
+        return (unsigned)ucs_min(max_hca_per_gpu, UCP_MAX_MDS);
+    }
+    return UCP_MAX_MDS;
+}
+
+
+typedef struct ucp_reg_select_md {
     ucp_md_index_t md_index;
     const char     *name;
     double         latency;
-    uint32_t       last_used;
-} ucp_dmabuf_reg_select_md_t;
+    uint32_t       use_count;
+} ucp_reg_select_md_t;
 
 
-typedef struct ucp_dmabuf_reg_md {
-    uint32_t last_used;
-} ucp_dmabuf_reg_md_t;
+typedef struct ucp_reg_md {
+    uint32_t use_count;
+    double   latency[UCP_MAX_SYS_DEVICES];
+} ucp_reg_md_t;
 
 
 typedef struct ucp_context_config {
@@ -241,12 +265,8 @@ typedef struct ucp_context_config {
     int                                    connect_all_to_all;
     /** Use only one network device for all protocols */
     int                                    proto_use_single_net_device;
-    /** Select dmabuf-capable memory domains for broad registration */
-    char                                   *dmabuf_reg_devices;
-    /** Parsed dmabuf registration memory-domain selection mode */
-    ucp_dmabuf_reg_devices_mode_t          dmabuf_reg_devices_mode;
-    /** Number of dmabuf-capable memory domains for broad registration */
-    unsigned                               dmabuf_reg_devices_count;
+    /** Max HCAs for GPU memory registration: 0=closest, N=limit, inf=all */
+    unsigned long                          max_hca_per_gpu;
     /** Local identificator on a single node */
     unsigned long                          node_local_id;
 } ucp_context_config_t;
@@ -413,11 +433,11 @@ typedef struct ucp_context {
     /* Map of MDs that support dmabuf registration */
     ucp_md_map_t                  dmabuf_reg_md_map;
 
-    /* Dmabuf registration selection state per MD */
-    ucp_dmabuf_reg_md_t           dmabuf_reg_md[UCP_MAX_MDS];
+    /* Pre-computed reachable dmabuf-capable MD map per memory sys_dev */
+    ucp_md_map_t                  reg_dev_reachable[UCP_MAX_SYS_DEVICES];
 
-    /* Monotonic counter for LRU-based dmabuf MD selection */
-    volatile uint32_t             dmabuf_reg_timestamp;
+    /* Registration selection state per MD (includes pre-computed latencies) */
+    ucp_reg_md_t                  reg_md[UCP_MAX_MDS];
 
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
@@ -792,18 +812,18 @@ void ucp_tl_bitmap_validate(const ucp_tl_bitmap_t *tl_bitmap,
 const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
 
 
-ucp_md_map_t ucp_dmabuf_reg_select(const ucp_context_config_t *config,
-                                   ucp_dmabuf_reg_select_md_t *mds,
-                                   unsigned count);
+ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
+                            ucp_reg_select_md_t *mds,
+                            unsigned count);
 
 
-ucp_md_map_t ucp_context_select_dmabuf_reg_md_map(ucp_context_h context,
-                                                  ucp_md_map_t md_map,
-                                                  ucs_sys_device_t mem_sys_dev);
+ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
+                                           ucp_md_map_t md_map,
+                                           ucs_sys_device_t mem_sys_dev);
 
 
-void ucp_context_dmabuf_reg_mark_used(ucp_context_h context,
-                                      ucp_md_map_t md_map);
+void ucp_context_reg_mark_used(ucp_context_h context,
+                               ucp_md_map_t md_map);
 
 
 ucs_status_t

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -82,19 +82,6 @@ ucp_reg_devices_count(unsigned long max_hca_per_gpu)
 }
 
 
-typedef struct ucp_reg_select_md {
-    ucp_md_index_t md_index;
-    const char     *name;
-    double         latency;
-    uint32_t       use_count;
-} ucp_reg_select_md_t;
-
-
-typedef struct ucp_reg_md {
-    uint32_t use_count;
-    double   latency[UCP_MAX_SYS_DEVICES];
-} ucp_reg_md_t;
-
 
 typedef struct ucp_context_config {
     /** Threshold for switching UCP to buffered copy(bcopy) protocol */
@@ -432,12 +419,6 @@ typedef struct ucp_context {
 
     /* Map of MDs that support dmabuf registration */
     ucp_md_map_t                  dmabuf_reg_md_map;
-
-    /* Pre-computed reachable dmabuf-capable MD map per memory sys_dev */
-    ucp_md_map_t                  reg_dev_reachable[UCP_MAX_SYS_DEVICES];
-
-    /* Registration selection state per MD (includes pre-computed latencies) */
-    ucp_reg_md_t                  reg_md[UCP_MAX_MDS];
 
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
@@ -812,16 +793,9 @@ void ucp_tl_bitmap_validate(const ucp_tl_bitmap_t *tl_bitmap,
 const char* ucp_context_cm_name(ucp_context_h context, ucp_rsc_index_t cm_idx);
 
 
-ucp_md_map_t ucp_reg_select(const ucp_context_config_t *config,
-                            ucp_reg_select_md_t *mds, unsigned count);
-
-
-ucp_md_map_t ucp_context_select_reg_md_map(ucp_context_h context,
-                                           ucp_md_map_t md_map,
-                                           ucs_sys_device_t mem_sys_dev);
-
-
-void ucp_context_reg_mark_used(ucp_context_h context, ucp_md_map_t md_map);
+ucp_md_map_t ucp_context_select_reg_mds(ucp_context_h context,
+                                        ucp_md_map_t md_map,
+                                        ucs_sys_device_t mem_sys_dev);
 
 
 ucs_status_t

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -846,21 +846,21 @@ ucp_memh_init_from_parent(ucp_mem_h memh, ucp_md_map_t parent_md_map)
  * The network MDs are ranked by distance (latency, then bandwidth) to the
  * buffer's sys_dev and the closest N selected. */
 static ucp_md_map_t
-ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
-                          ucs_sys_device_t sys_dev, ucp_md_map_t reg_md_map)
+ucp_memh_apply_reg_policy(ucp_context_h context, ucp_mem_h memh,
+                          ucp_md_map_t reg_md_map)
 {
     ucp_md_map_t net_md_map, policy_md_map, selected;
     ucp_md_index_t md_index;
 
-    if ((sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ||
-        (mem_type != UCS_MEMORY_TYPE_CUDA)) {
+    if ((memh->sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ||
+        (memh->mem_type != UCS_MEMORY_TYPE_CUDA)) {
         return reg_md_map;
     }
 
-    net_md_map = ucp_context_get_net_md_map(context);
-
+    net_md_map    = ucp_context_get_net_md_map(context);
     policy_md_map = reg_md_map & net_md_map;
-    selected      = ucp_context_select_reg_mds(context, policy_md_map, sys_dev);
+    selected      = ucp_context_select_reg_mds(context, policy_md_map,
+                                               memh->sys_dev);
 
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE)) {
         UCS_STRING_BUFFER_ONSTACK(strb, 256);
@@ -872,7 +872,8 @@ ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
                                       context->tl_mds[md_index].rsc.md_name);
         }
         ucs_trace("reg_devices_policy: mem_type=%d sys_dev=%d selected=[%s]",
-                  mem_type, sys_dev, ucs_string_buffer_cstr(&strb));
+                  memh->mem_type, memh->sys_dev,
+                  ucs_string_buffer_cstr(&strb));
     }
 
     return (reg_md_map & ~net_md_map) | selected;
@@ -894,8 +895,7 @@ ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh, unsigned uct_flags,
     }
 
     if (apply_reg_policy) {
-        reg_md_map = ucp_memh_apply_reg_policy(context, mem_type, memh->sys_dev,
-                                               reg_md_map);
+        reg_md_map = ucp_memh_apply_reg_policy(context, memh, reg_md_map);
     }
 
     reg_md_map  &= ~memh->md_map;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -842,31 +842,30 @@ ucp_memh_init_from_parent(ucp_mem_h memh, ucp_md_map_t parent_md_map)
     }
 }
 
-/* Apply UCX_MAX_HCA_PER_GPU policy to narrow the dmabuf-capable portion of
- * reg_md_map by reachability and the configured device-limit selection.
- * Only called for user-facing registrations (ucp_mem_map); internal
- * allocations such as RNDV fragment pools bypass this entirely. */
+/* Apply UCX_MAX_HCA_PER_GPU policy.
+ * The network MDs are ranked by bandwidth to the
+ * buffer's sys_dev and the highest N selected. */
 static ucp_md_map_t
 ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
                           ucs_sys_device_t sys_dev, ucp_md_map_t reg_md_map)
 {
-    ucp_md_map_t policy_md_map, reachable, selected;
+    ucp_md_map_t net_md_map = 0;
+    ucp_md_map_t policy_md_map, selected;
     ucp_md_index_t md_index;
+    ucp_rsc_index_t tl_idx;
 
-    if (context->dmabuf_mds[mem_type] == UCP_NULL_RESOURCE) {
+    if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
         return reg_md_map;
     }
 
-    policy_md_map = context->dmabuf_reg_md_map & reg_md_map;
-
-    if ((sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
-        (sys_dev < UCP_MAX_SYS_DEVICES)) {
-        reachable = context->reg_dev_reachable[sys_dev] & policy_md_map;
-    } else {
-        reachable = policy_md_map;
+    for (tl_idx = 0; tl_idx < context->num_tls; ++tl_idx) {
+        if (context->tl_rscs[tl_idx].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
+            net_md_map |= UCS_BIT(context->tl_rscs[tl_idx].md_index);
+        }
     }
 
-    selected = ucp_context_select_reg_md_map(context, reachable, sys_dev);
+    policy_md_map = reg_md_map & net_md_map;
+    selected      = ucp_context_select_reg_mds(context, policy_md_map, sys_dev);
 
     if (ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
         UCS_STRING_BUFFER_ONSTACK(strb, 256);
@@ -881,21 +880,20 @@ ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
                   mem_type, sys_dev, ucs_string_buffer_cstr(&strb));
     }
 
-    return (reg_md_map & ~context->dmabuf_reg_md_map) | selected;
+    return (reg_md_map & ~net_md_map) | selected;
 }
 
 static ucs_status_t
 ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh, unsigned uct_flags,
                       int apply_reg_policy, const char *alloc_name)
 {
+    ucs_memory_type_t mem_type = memh->mem_type;
+    ucp_md_map_t reg_md_map    = context->reg_md_map[mem_type];
     void *address              = ucp_memh_address(memh);
     size_t length              = ucp_memh_length(memh);
-    ucs_memory_type_t mem_type = memh->mem_type;
-    ucp_md_map_t reg_md_map;
     ucp_md_map_t cache_md_map;
     ucs_status_t status;
 
-    reg_md_map = context->reg_md_map[mem_type];
     if (uct_flags & UCT_MD_MEM_FLAG_LOCK) {
         reg_md_map |= context->reg_block_md_map[mem_type];
     }
@@ -1231,7 +1229,6 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
 out:
     if (status == UCS_OK) {
         ucs_assert(ucp_memh_is_user_memh(memh));
-        ucp_context_reg_mark_used(context, memh->md_map);
         *memh_p = memh;
     }
     return status;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -871,9 +871,10 @@ ucp_memh_apply_reg_policy(ucp_context_h context, ucp_mem_h memh,
             ucs_string_buffer_appendf(&strb, "%s",
                                       context->tl_mds[md_index].rsc.md_name);
         }
-        ucs_trace("reg_devices_policy: mem_type=%d sys_dev=%d selected=[%s]",
-                  memh->mem_type, memh->sys_dev,
-                  ucs_string_buffer_cstr(&strb));
+        ucs_trace("reg_devices_policy: mem_type=%s sys_dev=%d "
+                  "reg_md_map=0x%" PRIx64 " selected=[%s]",
+                  ucs_memory_type_names[memh->mem_type], memh->sys_dev,
+                  reg_md_map, ucs_string_buffer_cstr(&strb));
     }
 
     return (reg_md_map & ~net_md_map) | selected;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -545,23 +545,6 @@ static int ucp_memh_sys_dev_reachable(ucs_sys_device_t mem_sys_dev,
     return 1;
 }
 
-static ucp_md_map_t
-ucp_memh_reachable_dmabuf_md_map(ucp_context_h context,
-                                 ucs_sys_device_t mem_sys_dev,
-                                 ucp_md_map_t dmabuf_md_map)
-{
-    ucp_md_index_t md_index;
-
-    ucs_for_each_bit(md_index, dmabuf_md_map) {
-        if (!ucp_memh_sys_dev_reachable(
-                    mem_sys_dev, context->tl_mds[md_index].sys_dev_map)) {
-            dmabuf_md_map &= ~UCS_BIT(md_index);
-        }
-    }
-
-    return dmabuf_md_map;
-}
-
 static ucs_status_t
 ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                            ucp_md_map_t md_map, unsigned uct_flags,
@@ -859,55 +842,69 @@ ucp_memh_init_from_parent(ucp_mem_h memh, ucp_md_map_t parent_md_map)
     }
 }
 
-static ucp_md_map_t ucp_memh_reg_md_map(ucp_context_h context,
-                                        ucs_memory_type_t mem_type,
-                                        unsigned uct_flags)
-{
-    ucp_md_map_t reg_md_map = context->reg_md_map[mem_type];
-
-    if (uct_flags & UCT_MD_MEM_FLAG_LOCK) {
-        reg_md_map |= context->reg_block_md_map[mem_type];
-    }
-
-    return reg_md_map;
-}
-
-/* Apply UCX_DMABUF_REG_DEVICES policy to narrow the dmabuf portion of
+/* Apply UCX_MAX_HCA_PER_GPU policy to narrow the dmabuf-capable portion of
  * reg_md_map by reachability and the configured device-limit selection.
  * Only called for user-facing registrations (ucp_mem_map); internal
  * allocations such as RNDV fragment pools bypass this entirely. */
 static ucp_md_map_t
-ucp_memh_apply_dmabuf_policy(ucp_context_h context, ucs_memory_type_t mem_type,
-                             ucs_sys_device_t sys_dev, ucp_md_map_t reg_md_map)
+ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
+                          ucs_sys_device_t sys_dev, ucp_md_map_t reg_md_map)
 {
-    ucp_md_map_t dmabuf_md_map, reachable, selected;
+    ucp_md_map_t policy_md_map, reachable, selected;
+    ucp_md_index_t md_index;
 
     if (context->dmabuf_mds[mem_type] == UCP_NULL_RESOURCE) {
         return reg_md_map;
     }
 
-    dmabuf_md_map = context->dmabuf_reg_md_map & reg_md_map;
-    reachable     = ucp_memh_reachable_dmabuf_md_map(context, sys_dev,
-                                                     dmabuf_md_map);
-    selected      = ucp_context_select_dmabuf_reg_md_map(context, reachable,
-                                                         sys_dev);
-    ucs_trace("dmabuf_policy: mem_type=%d sys_dev=%d dmabuf=0x%" PRIx64
-              " reachable=0x%" PRIx64 " selected=0x%" PRIx64,
-              mem_type, sys_dev, (uint64_t)dmabuf_md_map, (uint64_t)reachable,
-              (uint64_t)selected);
+    policy_md_map = context->dmabuf_reg_md_map & reg_md_map;
+
+    if ((sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+        (sys_dev < UCP_MAX_SYS_DEVICES)) {
+        reachable = context->reg_dev_reachable[sys_dev] & policy_md_map;
+    } else {
+        reachable = policy_md_map;
+    }
+
+    selected = ucp_context_select_reg_md_map(context, reachable, sys_dev);
+
+    if (ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
+        UCS_STRING_BUFFER_ONSTACK(strb, 256);
+        ucs_for_each_bit(md_index, selected) {
+            if (ucs_string_buffer_length(&strb) > 0) {
+                ucs_string_buffer_appendf(&strb, ",");
+            }
+            ucs_string_buffer_appendf(&strb, "%s",
+                                      context->tl_mds[md_index].rsc.md_name);
+        }
+        ucs_debug("reg_devices_policy: mem_type=%d sys_dev=%d selected=[%s]",
+                  mem_type, sys_dev, ucs_string_buffer_cstr(&strb));
+    }
+
     return (reg_md_map & ~context->dmabuf_reg_md_map) | selected;
 }
 
 static ucs_status_t ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh,
-                                          ucp_md_map_t reg_md_map,
                                           unsigned uct_flags,
+                                          int apply_reg_policy,
                                           const char *alloc_name)
 {
     void *address              = ucp_memh_address(memh);
     size_t length              = ucp_memh_length(memh);
     ucs_memory_type_t mem_type = memh->mem_type;
+    ucp_md_map_t reg_md_map;
     ucp_md_map_t cache_md_map;
     ucs_status_t status;
+
+    reg_md_map = context->reg_md_map[mem_type];
+    if (uct_flags & UCT_MD_MEM_FLAG_LOCK) {
+        reg_md_map |= context->reg_block_md_map[mem_type];
+    }
+
+    if (apply_reg_policy) {
+        reg_md_map = ucp_memh_apply_reg_policy(context, mem_type,
+                                               memh->sys_dev, reg_md_map);
+    }
 
     reg_md_map  &= ~memh->md_map;
     cache_md_map = context->cache_md_map[mem_type] & reg_md_map;
@@ -1071,8 +1068,7 @@ err_free_memh:
 static ucs_status_t ucp_memh_alloc(ucp_context_h context, void *address,
                                    size_t length, ucs_memory_type_t mem_type,
                                    ucs_sys_device_t sys_dev, uint8_t memh_flags,
-                                   ucp_md_map_t reg_md_map, unsigned uct_flags,
-                                   int apply_dmabuf_policy,
+                                   unsigned uct_flags, int apply_reg_policy,
                                    const char *alloc_name, ucp_mem_h *memh_p)
 {
     uct_allocated_memory_t mem;
@@ -1091,12 +1087,7 @@ static ucs_status_t ucp_memh_alloc(ucp_context_h context, void *address,
         goto err_dealloc;
     }
 
-    if (apply_dmabuf_policy) {
-        reg_md_map = ucp_memh_apply_dmabuf_policy(context, memh->mem_type,
-                                                   memh->sys_dev, reg_md_map);
-    }
-
-    status = ucp_memh_init_uct_reg(context, memh, reg_md_map, uct_flags,
+    status = ucp_memh_init_uct_reg(context, memh, uct_flags, apply_reg_policy,
                                    alloc_name);
     if (status != UCS_OK) {
         goto err_free_memh;
@@ -1224,22 +1215,15 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
     } else if (flags & UCP_MEM_MAP_ALLOCATE) {
         status = ucp_memh_alloc(context, address, length, mem_type,
                                 UCS_SYS_DEVICE_ID_UNKNOWN, 0,
-                                ucp_memh_reg_md_map(context, mem_type,
-                                                    uct_flags),
                                 uct_flags, 1, alloc_name, &memh);
     } else {
-        ucp_md_map_t reg_md_map;
-
         status = ucp_memh_create(context, address, length, mem_type,
                                  UCT_ALLOC_METHOD_LAST, 0, uct_flags, &memh);
         if (status != UCS_OK) {
             goto out;
         }
 
-        reg_md_map = ucp_memh_apply_dmabuf_policy(
-                context, mem_type, memh->sys_dev,
-                ucp_memh_reg_md_map(context, mem_type, uct_flags));
-        status = ucp_memh_init_uct_reg(context, memh, reg_md_map, uct_flags,
+        status = ucp_memh_init_uct_reg(context, memh, uct_flags, 1,
                                        alloc_name);
         if (status != UCS_OK) {
             ucs_free(memh);
@@ -1249,9 +1233,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
 out:
     if (status == UCS_OK) {
         ucs_assert(ucp_memh_is_user_memh(memh));
-        ucp_context_dmabuf_reg_mark_used(context,
-                                         memh->md_map &
-                                                 context->dmabuf_reg_md_map);
+        ucp_context_reg_mark_used(context, memh->md_map);
         *memh_p = memh;
     }
     return status;
@@ -1469,9 +1451,6 @@ ucp_mpool_malloc(ucp_worker_h worker, ucs_mpool_t *mp, size_t *size_p, void **ch
     status = ucp_memh_alloc(worker->context, NULL, *size_p + sizeof(*chunk_hdr),
                             UCS_MEMORY_TYPE_HOST, UCS_SYS_DEVICE_ID_UNKNOWN,
                             UCP_MEMH_FLAG_NO_RCACHE,
-                            ucp_memh_reg_md_map(worker->context,
-                                                UCS_MEMORY_TYPE_HOST,
-                                                UCT_MD_MEM_ACCESS_RMA),
                             UCT_MD_MEM_ACCESS_RMA, 0, ucs_mpool_name(mp),
                             &memh);
     if (status != UCS_OK) {
@@ -1526,9 +1505,6 @@ ucp_rndv_frag_malloc_mpools(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
     /* payload; need to get default flags from ucp_mem_map_params2uct_flags() */
     status = ucp_memh_alloc(context, NULL, frag_size * num_elems, mem_type,
                             sys_dev, UCP_MEMH_FLAG_NO_RCACHE,
-                            ucp_memh_reg_md_map(context, mem_type,
-                                                UCT_MD_MEM_ACCESS_RMA |
-                                                        UCT_MD_MEM_FLAG_LOCK),
                             UCT_MD_MEM_ACCESS_RMA | UCT_MD_MEM_FLAG_LOCK, 0,
                             ucs_mpool_name(mp), &chunk_hdr->memh);
     if (status != UCS_OK) {

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -854,7 +854,8 @@ ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
     ucp_md_index_t md_index;
     ucp_rsc_index_t tl_idx;
 
-    if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
+    if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN ||
+        mem_type != UCS_MEMORY_TYPE_CUDA) {
         return reg_md_map;
     }
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -545,6 +545,23 @@ static int ucp_memh_sys_dev_reachable(ucs_sys_device_t mem_sys_dev,
     return 1;
 }
 
+static ucp_md_map_t
+ucp_memh_reachable_dmabuf_md_map(ucp_context_h context,
+                                 ucs_sys_device_t mem_sys_dev,
+                                 ucp_md_map_t dmabuf_md_map)
+{
+    ucp_md_index_t md_index;
+
+    ucs_for_each_bit(md_index, dmabuf_md_map) {
+        if (!ucp_memh_sys_dev_reachable(
+                    mem_sys_dev, context->tl_mds[md_index].sys_dev_map)) {
+            dmabuf_md_map &= ~UCS_BIT(md_index);
+        }
+    }
+
+    return dmabuf_md_map;
+}
+
 static ucs_status_t
 ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                            ucp_md_map_t md_map, unsigned uct_flags,
@@ -842,20 +859,55 @@ ucp_memh_init_from_parent(ucp_mem_h memh, ucp_md_map_t parent_md_map)
     }
 }
 
-static ucs_status_t ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh,
-                                          unsigned uct_flags,
-                                          const char *alloc_name)
+static ucp_md_map_t ucp_memh_reg_md_map(ucp_context_h context,
+                                        ucs_memory_type_t mem_type,
+                                        unsigned uct_flags)
 {
-    ucs_memory_type_t mem_type = memh->mem_type;
-    ucp_md_map_t reg_md_map    = context->reg_md_map[mem_type];
-    void *address              = ucp_memh_address(memh);
-    size_t length              = ucp_memh_length(memh);
-    ucp_md_map_t cache_md_map;
-    ucs_status_t status;
+    ucp_md_map_t reg_md_map = context->reg_md_map[mem_type];
 
     if (uct_flags & UCT_MD_MEM_FLAG_LOCK) {
         reg_md_map |= context->reg_block_md_map[mem_type];
     }
+
+    return reg_md_map;
+}
+
+/* Apply UCX_DMABUF_REG_DEVICES policy to narrow the dmabuf portion of
+ * reg_md_map by reachability and the configured device-limit selection.
+ * Only called for user-facing registrations (ucp_mem_map); internal
+ * allocations such as RNDV fragment pools bypass this entirely. */
+static ucp_md_map_t
+ucp_memh_apply_dmabuf_policy(ucp_context_h context, ucs_memory_type_t mem_type,
+                             ucs_sys_device_t sys_dev, ucp_md_map_t reg_md_map)
+{
+    ucp_md_map_t dmabuf_md_map, reachable, selected;
+
+    if (context->dmabuf_mds[mem_type] == UCP_NULL_RESOURCE) {
+        return reg_md_map;
+    }
+
+    dmabuf_md_map = context->dmabuf_reg_md_map & reg_md_map;
+    reachable     = ucp_memh_reachable_dmabuf_md_map(context, sys_dev,
+                                                     dmabuf_md_map);
+    selected      = ucp_context_select_dmabuf_reg_md_map(context, reachable,
+                                                         sys_dev);
+    ucs_trace("dmabuf_policy: mem_type=%d sys_dev=%d dmabuf=0x%" PRIx64
+              " reachable=0x%" PRIx64 " selected=0x%" PRIx64,
+              mem_type, sys_dev, (uint64_t)dmabuf_md_map, (uint64_t)reachable,
+              (uint64_t)selected);
+    return (reg_md_map & ~context->dmabuf_reg_md_map) | selected;
+}
+
+static ucs_status_t ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh,
+                                          ucp_md_map_t reg_md_map,
+                                          unsigned uct_flags,
+                                          const char *alloc_name)
+{
+    void *address              = ucp_memh_address(memh);
+    size_t length              = ucp_memh_length(memh);
+    ucs_memory_type_t mem_type = memh->mem_type;
+    ucp_md_map_t cache_md_map;
+    ucs_status_t status;
 
     reg_md_map  &= ~memh->md_map;
     cache_md_map = context->cache_md_map[mem_type] & reg_md_map;
@@ -1019,8 +1071,9 @@ err_free_memh:
 static ucs_status_t ucp_memh_alloc(ucp_context_h context, void *address,
                                    size_t length, ucs_memory_type_t mem_type,
                                    ucs_sys_device_t sys_dev, uint8_t memh_flags,
-                                   unsigned uct_flags, const char *alloc_name,
-                                   ucp_mem_h *memh_p)
+                                   ucp_md_map_t reg_md_map, unsigned uct_flags,
+                                   int apply_dmabuf_policy,
+                                   const char *alloc_name, ucp_mem_h *memh_p)
 {
     uct_allocated_memory_t mem;
     ucs_status_t status;
@@ -1038,7 +1091,13 @@ static ucs_status_t ucp_memh_alloc(ucp_context_h context, void *address,
         goto err_dealloc;
     }
 
-    status = ucp_memh_init_uct_reg(context, memh, uct_flags, alloc_name);
+    if (apply_dmabuf_policy) {
+        reg_md_map = ucp_memh_apply_dmabuf_policy(context, memh->mem_type,
+                                                   memh->sys_dev, reg_md_map);
+    }
+
+    status = ucp_memh_init_uct_reg(context, memh, reg_md_map, uct_flags,
+                                   alloc_name);
     if (status != UCS_OK) {
         goto err_free_memh;
     }
@@ -1164,16 +1223,24 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         status = ucp_memh_import(context, exported_memh_buffer, &memh);
     } else if (flags & UCP_MEM_MAP_ALLOCATE) {
         status = ucp_memh_alloc(context, address, length, mem_type,
-                                UCS_SYS_DEVICE_ID_UNKNOWN, 0, uct_flags,
-                                alloc_name, &memh);
+                                UCS_SYS_DEVICE_ID_UNKNOWN, 0,
+                                ucp_memh_reg_md_map(context, mem_type,
+                                                    uct_flags),
+                                uct_flags, 1, alloc_name, &memh);
     } else {
+        ucp_md_map_t reg_md_map;
+
         status = ucp_memh_create(context, address, length, mem_type,
                                  UCT_ALLOC_METHOD_LAST, 0, uct_flags, &memh);
         if (status != UCS_OK) {
             goto out;
         }
 
-        status = ucp_memh_init_uct_reg(context, memh, uct_flags, alloc_name);
+        reg_md_map = ucp_memh_apply_dmabuf_policy(
+                context, mem_type, memh->sys_dev,
+                ucp_memh_reg_md_map(context, mem_type, uct_flags));
+        status = ucp_memh_init_uct_reg(context, memh, reg_md_map, uct_flags,
+                                       alloc_name);
         if (status != UCS_OK) {
             ucs_free(memh);
         }
@@ -1182,6 +1249,9 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
 out:
     if (status == UCS_OK) {
         ucs_assert(ucp_memh_is_user_memh(memh));
+        ucp_context_dmabuf_reg_mark_used(context,
+                                         memh->md_map &
+                                                 context->dmabuf_reg_md_map);
         *memh_p = memh;
     }
     return status;
@@ -1398,8 +1468,12 @@ ucp_mpool_malloc(ucp_worker_h worker, ucs_mpool_t *mp, size_t *size_p, void **ch
 
     status = ucp_memh_alloc(worker->context, NULL, *size_p + sizeof(*chunk_hdr),
                             UCS_MEMORY_TYPE_HOST, UCS_SYS_DEVICE_ID_UNKNOWN,
-                            UCP_MEMH_FLAG_NO_RCACHE, UCT_MD_MEM_ACCESS_RMA,
-                            ucs_mpool_name(mp), &memh);
+                            UCP_MEMH_FLAG_NO_RCACHE,
+                            ucp_memh_reg_md_map(worker->context,
+                                                UCS_MEMORY_TYPE_HOST,
+                                                UCT_MD_MEM_ACCESS_RMA),
+                            UCT_MD_MEM_ACCESS_RMA, 0, ucs_mpool_name(mp),
+                            &memh);
     if (status != UCS_OK) {
         goto out;
     }
@@ -1452,7 +1526,10 @@ ucp_rndv_frag_malloc_mpools(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
     /* payload; need to get default flags from ucp_mem_map_params2uct_flags() */
     status = ucp_memh_alloc(context, NULL, frag_size * num_elems, mem_type,
                             sys_dev, UCP_MEMH_FLAG_NO_RCACHE,
-                            UCT_MD_MEM_ACCESS_RMA | UCT_MD_MEM_FLAG_LOCK,
+                            ucp_memh_reg_md_map(context, mem_type,
+                                                UCT_MD_MEM_ACCESS_RMA |
+                                                        UCT_MD_MEM_FLAG_LOCK),
+                            UCT_MD_MEM_ACCESS_RMA | UCT_MD_MEM_FLAG_LOCK, 0,
                             ucs_mpool_name(mp), &chunk_hdr->memh);
     if (status != UCS_OK) {
         return status;

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -843,32 +843,26 @@ ucp_memh_init_from_parent(ucp_mem_h memh, ucp_md_map_t parent_md_map)
 }
 
 /* Apply UCX_MAX_HCA_PER_GPU policy.
- * The network MDs are ranked by bandwidth to the
- * buffer's sys_dev and the highest N selected. */
+ * The network MDs are ranked by distance (latency, then bandwidth) to the
+ * buffer's sys_dev and the closest N selected. */
 static ucp_md_map_t
 ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
                           ucs_sys_device_t sys_dev, ucp_md_map_t reg_md_map)
 {
-    ucp_md_map_t net_md_map = 0;
-    ucp_md_map_t policy_md_map, selected;
+    ucp_md_map_t net_md_map, policy_md_map, selected;
     ucp_md_index_t md_index;
-    ucp_rsc_index_t tl_idx;
 
-    if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN ||
-        mem_type != UCS_MEMORY_TYPE_CUDA) {
+    if ((sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ||
+        (mem_type != UCS_MEMORY_TYPE_CUDA)) {
         return reg_md_map;
     }
 
-    for (tl_idx = 0; tl_idx < context->num_tls; ++tl_idx) {
-        if (context->tl_rscs[tl_idx].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
-            net_md_map |= UCS_BIT(context->tl_rscs[tl_idx].md_index);
-        }
-    }
+    net_md_map = ucp_context_get_net_md_map(context);
 
     policy_md_map = reg_md_map & net_md_map;
     selected      = ucp_context_select_reg_mds(context, policy_md_map, sys_dev);
 
-    if (ucs_log_is_enabled(UCS_LOG_LEVEL_DEBUG)) {
+    if (ucs_log_is_enabled(UCS_LOG_LEVEL_TRACE)) {
         UCS_STRING_BUFFER_ONSTACK(strb, 256);
         ucs_for_each_bit(md_index, selected) {
             if (ucs_string_buffer_length(&strb) > 0) {
@@ -877,7 +871,7 @@ ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
             ucs_string_buffer_appendf(&strb, "%s",
                                       context->tl_mds[md_index].rsc.md_name);
         }
-        ucs_debug("reg_devices_policy: mem_type=%d sys_dev=%d selected=[%s]",
+        ucs_trace("reg_devices_policy: mem_type=%d sys_dev=%d selected=[%s]",
                   mem_type, sys_dev, ucs_string_buffer_cstr(&strb));
     }
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -884,10 +884,9 @@ ucp_memh_apply_reg_policy(ucp_context_h context, ucs_memory_type_t mem_type,
     return (reg_md_map & ~context->dmabuf_reg_md_map) | selected;
 }
 
-static ucs_status_t ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh,
-                                          unsigned uct_flags,
-                                          int apply_reg_policy,
-                                          const char *alloc_name)
+static ucs_status_t
+ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh, unsigned uct_flags,
+                      int apply_reg_policy, const char *alloc_name)
 {
     void *address              = ucp_memh_address(memh);
     size_t length              = ucp_memh_length(memh);
@@ -902,8 +901,8 @@ static ucs_status_t ucp_memh_init_uct_reg(ucp_context_h context, ucp_mem_h memh,
     }
 
     if (apply_reg_policy) {
-        reg_md_map = ucp_memh_apply_reg_policy(context, mem_type,
-                                               memh->sys_dev, reg_md_map);
+        reg_md_map = ucp_memh_apply_reg_policy(context, mem_type, memh->sys_dev,
+                                               reg_md_map);
     }
 
     reg_md_map  &= ~memh->md_map;
@@ -1214,8 +1213,8 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
         status = ucp_memh_import(context, exported_memh_buffer, &memh);
     } else if (flags & UCP_MEM_MAP_ALLOCATE) {
         status = ucp_memh_alloc(context, address, length, mem_type,
-                                UCS_SYS_DEVICE_ID_UNKNOWN, 0,
-                                uct_flags, 1, alloc_name, &memh);
+                                UCS_SYS_DEVICE_ID_UNKNOWN, 0, uct_flags, 1,
+                                alloc_name, &memh);
     } else {
         status = ucp_memh_create(context, address, length, mem_type,
                                  UCT_ALLOC_METHOD_LAST, 0, uct_flags, &memh);
@@ -1223,8 +1222,7 @@ ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *para
             goto out;
         }
 
-        status = ucp_memh_init_uct_reg(context, memh, uct_flags, 1,
-                                       alloc_name);
+        status = ucp_memh_init_uct_reg(context, memh, uct_flags, 1, alloc_name);
         if (status != UCS_OK) {
             ucs_free(memh);
         }
@@ -1450,9 +1448,8 @@ ucp_mpool_malloc(ucp_worker_h worker, ucs_mpool_t *mp, size_t *size_p, void **ch
 
     status = ucp_memh_alloc(worker->context, NULL, *size_p + sizeof(*chunk_hdr),
                             UCS_MEMORY_TYPE_HOST, UCS_SYS_DEVICE_ID_UNKNOWN,
-                            UCP_MEMH_FLAG_NO_RCACHE,
-                            UCT_MD_MEM_ACCESS_RMA, 0, ucs_mpool_name(mp),
-                            &memh);
+                            UCP_MEMH_FLAG_NO_RCACHE, UCT_MD_MEM_ACCESS_RMA, 0,
+                            ucs_mpool_name(mp), &memh);
     if (status != UCS_OK) {
         goto out;
     }

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -676,6 +676,19 @@ const char *ucs_topo_distance_str(const ucs_sys_dev_distance_t *distance,
     return ucs_string_buffer_cstr(&strb);
 }
 
+int ucs_topo_distance_cmp(const ucs_sys_dev_distance_t *distance1,
+                          const ucs_sys_dev_distance_t *distance2)
+{
+    int cmp;
+
+    cmp = ucs_fp_compare(distance1->latency, distance2->latency);
+    if (cmp != 0) {
+        return cmp;
+    }
+
+    return ucs_fp_compare(distance2->bandwidth, distance1->bandwidth);
+}
+
 ucs_sys_device_t ucs_topo_get_sysfs_dev(const char *dev_name,
                                         const char *sysfs_path,
                                         unsigned name_priority)

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -149,6 +149,22 @@ const char *ucs_topo_distance_str(const ucs_sys_dev_distance_t *distance,
                                   char *buffer, size_t max);
 
 /**
+ * Compare two distances.
+ *
+ * First compares by latency (lower is better), then by bandwidth (higher is
+ * better) as a tiebreaker.
+ *
+ * @param [in] distance1  First distance to compare.
+ * @param [in] distance2  Second distance to compare.
+ *
+ * @return Negative if distance1 is better, positive if distance2 is better,
+ *         0 if equal.
+ */
+int ucs_topo_distance_cmp(const ucs_sys_dev_distance_t *distance1,
+                          const ucs_sys_dev_distance_t *distance2);
+
+
+/**
  * Gets a system device. If the device doesn't exist, it will be added.
  *
  * @param [in]  dev_name       Device Name.

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -196,6 +196,39 @@ void mem_buffer::set_device_context()
     device_set = true;
 }
 
+int mem_buffer::cuda_get_device_count()
+{
+#if HAVE_CUDA
+    int num_gpus = 0;
+    if (cudaGetDeviceCount(&num_gpus) != cudaSuccess) {
+        return 0;
+    }
+    return num_gpus;
+#else
+    return 0;
+#endif
+}
+
+int mem_buffer::cuda_get_device()
+{
+#if HAVE_CUDA
+    int device = 0;
+    cudaGetDevice(&device);
+    return device;
+#else
+    return 0;
+#endif
+}
+
+void mem_buffer::cuda_set_device(int device)
+{
+#if HAVE_CUDA
+    CUDA_CALL(cudaSetDevice(device), ": device=" << device);
+#else
+    (void)device;
+#endif
+}
+
 size_t mem_buffer::m_bar1_free_size = SIZE_MAX;
 
 void mem_buffer::get_bar1_free_size_nvml()

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -196,31 +196,31 @@ void mem_buffer::set_device_context()
     device_set = true;
 }
 
-int mem_buffer::cuda_get_device_count()
+int mem_buffer::get_device_count()
 {
 #if HAVE_CUDA
     int num_gpus = 0;
     if (cudaGetDeviceCount(&num_gpus) != cudaSuccess) {
-        return 0;
+        return -1;
     }
     return num_gpus;
 #else
-    return 0;
+    return -1;
 #endif
 }
 
-int mem_buffer::cuda_get_device()
+int mem_buffer::get_device()
 {
 #if HAVE_CUDA
-    int device = 0;
-    cudaGetDevice(&device);
+    int device = -1;
+    CUDA_CALL(cudaGetDevice(&device), "");
     return device;
 #else
-    return 0;
+    return -1;
 #endif
 }
 
-void mem_buffer::cuda_set_device(int device)
+void mem_buffer::set_device(int device)
 {
 #if HAVE_CUDA
     CUDA_CALL(cudaSetDevice(device), ": device=" << device);

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -88,14 +88,14 @@ public:
     /* set device context if compiled with GPU support */
     static void set_device_context();
 
-    /* Return the number of CUDA GPU devices, or 0 if not supported */
-    static int cuda_get_device_count();
+    /* Return the number of CUDA GPU devices, or -1 if not supported */
+    static int get_device_count();
 
-    /* Return the current CUDA device index, or 0 if not supported */
-    static int cuda_get_device();
+    /* Return the current CUDA device index, or -1 if not supported */
+    static int get_device();
 
     /* Set the current CUDA device */
-    static void cuda_set_device(int device);
+    static void set_device(int device);
 
     /* returns whether ROCM device supports managed memory */
     static bool is_rocm_managed_supported();

--- a/test/gtest/common/mem_buffer.h
+++ b/test/gtest/common/mem_buffer.h
@@ -88,6 +88,15 @@ public:
     /* set device context if compiled with GPU support */
     static void set_device_context();
 
+    /* Return the number of CUDA GPU devices, or 0 if not supported */
+    static int cuda_get_device_count();
+
+    /* Return the current CUDA device index, or 0 if not supported */
+    static int cuda_get_device();
+
+    /* Set the current CUDA device */
+    static void cuda_set_device(int device);
+
     /* returns whether ROCM device supports managed memory */
     static bool is_rocm_managed_supported();
 

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -15,10 +15,6 @@ extern "C" {
 #include <ucs/sys/sys.h>
 }
 
-#if HAVE_CUDA
-#include <cuda_runtime.h>
-#endif
-
 class test_ucp_lib_query : public ucs::test {
 };
 
@@ -74,117 +70,6 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_config)
     EXPECT_EQ(UCP_REG_DEVICES_LIMIT,
               ucp_reg_devices_mode(e->ucph()->config.ext.max_hca_per_gpu));
     EXPECT_EQ(2u, ucp_reg_devices_count(e->ucph()->config.ext.max_hca_per_gpu));
-}
-
-UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
-{
-    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
-        UCS_TEST_SKIP_R("CUDA is not supported");
-    }
-
-    modify_config("MAX_HCA_PER_GPU", "inf");
-    entity *e_all         = create_entity();
-    ucp_context_h ctx_all = e_all->ucph();
-
-    ucp_md_map_t net_md_map = ucp_context_get_net_md_map(ctx_all);
-
-    if (ucs_popcount(net_md_map) < 2) {
-        UCS_TEST_SKIP_R("need at least 2 network MDs");
-    }
-
-    const size_t size = 4096;
-    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
-
-    ucp_mem_map_params_t params;
-    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    params.address    = ptr;
-    params.length     = size;
-
-    ucp_mem_h memh;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh));
-    ucp_md_map_t net_all     = memh->md_map & net_md_map;
-    ucp_md_map_t non_net_all = memh->md_map & ~net_md_map;
-    ASSERT_UCS_OK(ucp_mem_unmap(ctx_all, memh));
-
-    /* LIMIT=1: at most 1 network MD */
-    modify_config("MAX_HCA_PER_GPU", "1");
-    entity *e_lim         = create_entity();
-    ucp_context_h ctx_lim = e_lim->ucph();
-
-    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh));
-    ucp_md_map_t net_lim     = memh->md_map & net_md_map;
-    ucp_md_map_t non_net_lim = memh->md_map & ~net_md_map;
-    ASSERT_UCS_OK(ucp_mem_unmap(ctx_lim, memh));
-
-    /* CLOSEST: subset of all */
-    modify_config("MAX_HCA_PER_GPU", "auto");
-    entity *e_close         = create_entity();
-    ucp_context_h ctx_close = e_close->ucph();
-
-    ASSERT_UCS_OK(ucp_mem_map(ctx_close, &params, &memh));
-    ucp_md_map_t net_close = memh->md_map & net_md_map;
-    ASSERT_UCS_OK(ucp_mem_unmap(ctx_close, memh));
-
-    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
-
-    EXPECT_GT(ucs_popcount(net_all), 0);
-    EXPECT_LE(ucs_popcount(net_lim), 1);
-    EXPECT_GT(ucs_popcount(net_close), 0);
-    EXPECT_LE(ucs_popcount(net_close), ucs_popcount(net_all));
-    EXPECT_EQ(non_net_all, non_net_lim);
-}
-
-UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_per_gpu)
-{
-#if !HAVE_CUDA
-    UCS_TEST_SKIP_R("CUDA is not available");
-#else
-    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
-        UCS_TEST_SKIP_R("CUDA is not supported");
-    }
-
-    int num_gpus;
-    if ((cudaGetDeviceCount(&num_gpus) != cudaSuccess) || (num_gpus < 2)) {
-        UCS_TEST_SKIP_R("need at least 2 CUDA devices");
-    }
-
-    modify_config("MAX_HCA_PER_GPU", "1");
-    entity *e         = create_entity();
-    ucp_context_h ctx = e->ucph();
-
-    ucp_md_map_t net_md_map = ucp_context_get_net_md_map(ctx);
-
-    if (ucs_popcount(net_md_map) < 2) {
-        UCS_TEST_SKIP_R("need at least 2 network MDs");
-    }
-
-    int orig_dev;
-    ASSERT_EQ(cudaGetDevice(&orig_dev), cudaSuccess);
-
-    const size_t size = 4096;
-    ucp_mem_map_params_t params;
-    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-
-    for (int gpu = 0; gpu < ucs_min(num_gpus, 4); gpu++) {
-        ASSERT_EQ(cudaSetDevice(gpu), cudaSuccess);
-
-        void *ptr      = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
-        params.address = ptr;
-        params.length  = size;
-
-        ucp_mem_h memh;
-        ASSERT_UCS_OK(ucp_mem_map(ctx, &params, &memh));
-        ucp_md_map_t net_map = memh->md_map & net_md_map;
-        EXPECT_LE(ucs_popcount(net_map), 1)
-                << "GPU " << gpu << " should have at most 1 network MD";
-        ASSERT_UCS_OK(ucp_mem_unmap(ctx, memh));
-        mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
-    }
-
-    ASSERT_EQ(cudaSetDevice(orig_dev), cudaSuccess);
-#endif
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_context, all, "all")

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -180,7 +180,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_per_gpu)
     for (int gpu = 0; gpu < ucs_min(num_gpus, 4); gpu++) {
         ASSERT_EQ(cudaSetDevice(gpu), cudaSuccess);
 
-        void *ptr = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+        void *ptr      = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
         params.address = ptr;
         params.length  = size;
 

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -7,6 +7,7 @@
 #include "ucp_test.h"
 
 #include <cstddef>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -63,25 +64,25 @@ UCS_TEST_P(test_ucp_context, minimal_field_mask) {
     }
 }
 
-UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_config)
+UCS_TEST_P(test_ucp_context, max_hca_per_gpu_config)
 {
-    modify_config("DMABUF_REG_DEVICES", "2");
+    modify_config("MAX_HCA_PER_GPU", "2");
 
     entity *e = create_entity();
-    EXPECT_EQ(UCP_DMABUF_REG_DEVICES_LIMIT,
-              e->ucph()->config.ext.dmabuf_reg_devices_mode);
-    EXPECT_EQ(2u, e->ucph()->config.ext.dmabuf_reg_devices_count);
+    EXPECT_EQ(UCP_REG_DEVICES_LIMIT,
+              ucp_reg_devices_mode(e->ucph()->config.ext.max_hca_per_gpu));
+    EXPECT_EQ(2u, ucp_reg_devices_count(e->ucph()->config.ext.max_hca_per_gpu));
 }
 
-UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_limits_memh_md_map)
+UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
 {
     if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA is not supported");
     }
 
-    /* Create entity with dmabuf_reg_devices=all to discover how many dmabuf MDs
+    /* Create entity with max_hca_per_gpu=inf to discover how many dmabuf MDs
      * are available on this system */
-    modify_config("DMABUF_REG_DEVICES", "all");
+    modify_config("MAX_HCA_PER_GPU", "inf");
     entity *e_all         = create_entity();
     ucp_context_h ctx_all = e_all->ucph();
 
@@ -103,9 +104,9 @@ UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_limits_memh_md_map)
     ucp_md_map_t dmabuf_all = memh_all->md_map & ctx_all->dmabuf_reg_md_map;
     ucp_mem_unmap(ctx_all, memh_all);
 
-    /* Create a second entity with dmabuf_reg_devices=1 and verify that fewer
+    /* Create a second entity with max_hca_per_gpu=1 and verify that fewer
      * dmabuf MDs end up on the memh */
-    modify_config("DMABUF_REG_DEVICES", "1");
+    modify_config("MAX_HCA_PER_GPU", "1");
     entity *e_lim         = create_entity();
     ucp_context_h ctx_lim = e_lim->ucph();
 
@@ -121,13 +122,13 @@ UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_limits_memh_md_map)
     mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
 }
 
-UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_closest_is_subset)
+UCS_TEST_P(test_ucp_context, max_hca_per_gpu_closest_is_subset)
 {
     if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA is not supported");
     }
 
-    modify_config("DMABUF_REG_DEVICES", "all");
+    modify_config("MAX_HCA_PER_GPU", "inf");
     entity *e_all         = create_entity();
     ucp_context_h ctx_all = e_all->ucph();
 
@@ -149,7 +150,7 @@ UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_closest_is_subset)
     ucp_md_map_t dmabuf_all = memh_all->md_map & ctx_all->dmabuf_reg_md_map;
     ucp_mem_unmap(ctx_all, memh_all);
 
-    modify_config("DMABUF_REG_DEVICES", "closest");
+    modify_config("MAX_HCA_PER_GPU", "0");
     entity *e_close         = create_entity();
     ucp_context_h ctx_close = e_close->ucph();
 
@@ -165,17 +166,17 @@ UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_closest_is_subset)
     mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
 }
 
-UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_all_preserves_non_dmabuf)
+UCS_TEST_P(test_ucp_context, max_hca_per_gpu_preserves_non_dmabuf)
 {
     if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA is not supported");
     }
 
-    modify_config("DMABUF_REG_DEVICES", "all");
+    modify_config("MAX_HCA_PER_GPU", "inf");
     entity *e_all         = create_entity();
     ucp_context_h ctx_all = e_all->ucph();
 
-    modify_config("DMABUF_REG_DEVICES", "1");
+    modify_config("MAX_HCA_PER_GPU", "1");
     entity *e_lim         = create_entity();
     ucp_context_h ctx_lim = e_lim->ucph();
 
@@ -274,28 +275,37 @@ UCS_TEST_P(test_ucp_version, version_string) {
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_version, all, "all")
 
-class test_ucp_dmabuf_reg_devices : public ucs::test {
+class test_ucp_reg_devices : public ucs::test {
 protected:
     static ucp_context_config_t
-    config(ucp_dmabuf_reg_devices_mode_t mode, unsigned count = UCP_MAX_MDS)
+    config(ucp_reg_devices_mode_t mode, unsigned count = UCP_MAX_MDS)
     {
         ucp_context_config_t config = {};
 
-        config.dmabuf_reg_devices_mode  = mode;
-        config.dmabuf_reg_devices_count = count;
+        switch (mode) {
+        case UCP_REG_DEVICES_ALL:
+            config.max_hca_per_gpu = UCS_ULUNITS_INF;
+            break;
+        case UCP_REG_DEVICES_CLOSEST:
+            config.max_hca_per_gpu = 0;
+            break;
+        case UCP_REG_DEVICES_LIMIT:
+            config.max_hca_per_gpu = count;
+            break;
+        }
         return config;
     }
 
-    static ucp_dmabuf_reg_select_md_t md(ucp_md_index_t md_index,
+    static ucp_reg_select_md_t md(ucp_md_index_t md_index,
                                          const char *name, double latency,
-                                         uint32_t last_used = 0)
+                                         uint32_t use_count = 0)
     {
-        ucp_dmabuf_reg_select_md_t md = {};
+        ucp_reg_select_md_t md = {};
 
-        md.md_index  = md_index;
-        md.name      = name;
-        md.latency   = latency;
-        md.last_used = last_used;
+        md.md_index   = md_index;
+        md.name       = name;
+        md.latency    = latency;
+        md.use_count  = use_count;
         return md;
     }
 
@@ -307,14 +317,22 @@ protected:
     }
 
     static void init_context(ucp_context_t &context, ucp_tl_md_t *tl_mds,
-                             ucp_dmabuf_reg_devices_mode_t mode, unsigned count)
+                             ucp_reg_devices_mode_t mode, unsigned count)
     {
-        context.tl_mds                              = tl_mds;
-        context.num_mds                             = 4;
-        context.dmabuf_reg_md_map                   = UCS_MASK(4);
-        context.dmabuf_reg_timestamp                = 0;
-        context.config.ext.dmabuf_reg_devices_mode  = mode;
-        context.config.ext.dmabuf_reg_devices_count = count;
+        context.tl_mds            = tl_mds;
+        context.num_mds           = 4;
+        context.dmabuf_reg_md_map = UCS_MASK(4);
+        switch (mode) {
+        case UCP_REG_DEVICES_ALL:
+            context.config.ext.max_hca_per_gpu = UCS_ULUNITS_INF;
+            break;
+        case UCP_REG_DEVICES_CLOSEST:
+            context.config.ext.max_hca_per_gpu = 0;
+            break;
+        case UCP_REG_DEVICES_LIMIT:
+            context.config.ext.max_hca_per_gpu = count;
+            break;
+        }
 
         set_context_md(tl_mds, 0, "mlx5_0");
         set_context_md(tl_mds, 1, "mlx5_1");
@@ -323,83 +341,83 @@ protected:
     }
 };
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, closest_by_latency) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_CLOSEST);
-    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_2", 5e-7),
+UCS_TEST_F(test_ucp_reg_devices, closest_by_latency) {
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_CLOSEST);
+    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_2", 5e-7),
                                                    md(1, "mlx5_0", 3e-7),
                                                    md(2, "mlx5_1", 3e-7),
                                                    md(3, "mlx5_3", 1e-6)};
 
     EXPECT_EQ(UCS_BIT(1) | UCS_BIT(2),
-              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+              ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, closest_selects_all_equal_latency) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_CLOSEST);
-    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
+UCS_TEST_F(test_ucp_reg_devices, closest_selects_all_equal_latency) {
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_CLOSEST);
+    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
                                                    md(1, "mlx5_1", 3e-7)};
 
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
-              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+              ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, limit_uses_latency_before_last_used) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 2);
-    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
+UCS_TEST_F(test_ucp_reg_devices, limit_uses_latency_before_use_count) {
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 2);
+    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
                                                    md(1, "mlx5_1", 5e-7, 0),
                                                    md(2, "mlx5_2", 3e-7, 8),
                                                    md(3, "mlx5_3", 5e-7, 0)};
 
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2),
-              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+              ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices,
+UCS_TEST_F(test_ucp_reg_devices,
            limit_larger_than_available_selects_all) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 8);
-    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 8);
+    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
                                                    md(1, "mlx5_1", 5e-7)};
 
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
-              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+              ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, empty_selects_none) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 1);
+UCS_TEST_F(test_ucp_reg_devices, empty_selects_none) {
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 1);
 
-    EXPECT_EQ((ucp_md_map_t)0, ucp_dmabuf_reg_select(&cfg, NULL, 0));
+    EXPECT_EQ((ucp_md_map_t)0, ucp_reg_select(&cfg, NULL, 0));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, limit_prefers_least_recently_used) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 1);
-    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
+UCS_TEST_F(test_ucp_reg_devices, limit_prefers_least_used) {
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 1);
+    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
                                                    md(1, "mlx5_1", 3e-7, 0)};
 
-    EXPECT_EQ(UCS_BIT(1), ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+    EXPECT_EQ(UCS_BIT(1), ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, limit_uses_name_after_last_used) {
-    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 1);
-    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_1", 3e-7, 0),
+UCS_TEST_F(test_ucp_reg_devices, limit_uses_name_after_use_count) {
+    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 1);
+    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_1", 3e-7, 0),
                                                    md(1, "mlx5_0", 3e-7, 0)};
 
-    EXPECT_EQ(UCS_BIT(1), ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+    EXPECT_EQ(UCS_BIT(1), ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_dmabuf_reg_devices, context_selection_rotates_mds) {
-    ucp_context_t context = {};
+UCS_TEST_F(test_ucp_reg_devices, context_selection_rotates_mds) {
+    std::unique_ptr<ucp_context_t> ctx(new ucp_context_t{});
     ucp_tl_md_t tl_mds[4] = {};
     ucp_md_map_t md_map;
 
-    init_context(context, tl_mds, UCP_DMABUF_REG_DEVICES_LIMIT, 1);
+    init_context(*ctx, tl_mds, UCP_REG_DEVICES_LIMIT, 1);
 
-    md_map = ucp_context_select_dmabuf_reg_md_map(&context,
+    md_map = ucp_context_select_reg_md_map(ctx.get(),
                                                   UCS_BIT(1) | UCS_BIT(3),
                                                   UCS_SYS_DEVICE_ID_UNKNOWN);
     EXPECT_EQ(UCS_BIT(1), md_map);
 
-    ucp_context_dmabuf_reg_mark_used(&context, UCS_BIT(1));
-    md_map = ucp_context_select_dmabuf_reg_md_map(&context,
+    ucp_context_reg_mark_used(ctx.get(), UCS_BIT(1));
+    md_map = ucp_context_select_reg_md_map(ctx.get(),
                                                   UCS_BIT(1) | UCS_BIT(3),
                                                   UCS_SYS_DEVICE_ID_UNKNOWN);
     EXPECT_EQ(UCS_BIT(3), md_map);

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -299,7 +299,7 @@ protected:
     static ucp_reg_select_md_t md(ucp_md_index_t md_index, const char *name,
                                   double latency, uint32_t use_count = 0)
     {
-        ucp_reg_select_md_t md = {};
+        ucp_reg_select_md_t md;
 
         md.md_index  = md_index;
         md.name      = name;

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -8,9 +8,11 @@
 
 #include <cstddef>
 #include <set>
+#include <vector>
 
 extern "C" {
 #include <ucp/core/ucp_context.h>
+#include <ucp/core/ucp_mm.h>
 #include <ucs/sys/sys.h>
 }
 
@@ -59,6 +61,154 @@ UCS_TEST_P(test_ucp_context, minimal_field_mask) {
         UCS_TEST_CREATE_HANDLE(ucp_worker_h, worker, ucp_worker_destroy,
                                ucp_worker_create, ucph.get(), &params);
     }
+}
+
+UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_config)
+{
+    modify_config("DMABUF_REG_DEVICES", "2");
+
+    entity *e = create_entity();
+    EXPECT_EQ(UCP_DMABUF_REG_DEVICES_LIMIT,
+              e->ucph()->config.ext.dmabuf_reg_devices_mode);
+    EXPECT_EQ(2u, e->ucph()->config.ext.dmabuf_reg_devices_count);
+}
+
+UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_limits_memh_md_map)
+{
+    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA is not supported");
+    }
+
+    /* Create entity with dmabuf_reg_devices=all to discover how many dmabuf MDs
+     * are available on this system */
+    modify_config("DMABUF_REG_DEVICES", "all");
+    entity *e_all         = create_entity();
+    ucp_context_h ctx_all = e_all->ucph();
+
+    if (ucs_popcount(ctx_all->dmabuf_reg_md_map) < 2) {
+        UCS_TEST_SKIP_R("need at least 2 dmabuf-capable MDs");
+    }
+
+    const size_t size = 4096;
+    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+
+    ucp_mem_map_params_t params = {};
+    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                  UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address              = ptr;
+    params.length               = size;
+
+    ucp_mem_h memh_all;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh_all));
+    ucp_md_map_t dmabuf_all = memh_all->md_map & ctx_all->dmabuf_reg_md_map;
+    ucp_mem_unmap(ctx_all, memh_all);
+
+    /* Create a second entity with dmabuf_reg_devices=1 and verify that fewer
+     * dmabuf MDs end up on the memh */
+    modify_config("DMABUF_REG_DEVICES", "1");
+    entity *e_lim         = create_entity();
+    ucp_context_h ctx_lim = e_lim->ucph();
+
+    ucp_mem_h memh_lim;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh_lim));
+    ucp_md_map_t dmabuf_lim = memh_lim->md_map & ctx_lim->dmabuf_reg_md_map;
+    ucp_mem_unmap(ctx_lim, memh_lim);
+
+    EXPECT_GT(ucs_popcount(dmabuf_all), 0);
+    EXPECT_LE(ucs_popcount(dmabuf_lim), 1);
+    EXPECT_LE(ucs_popcount(dmabuf_lim), ucs_popcount(dmabuf_all));
+
+    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+}
+
+UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_closest_is_subset)
+{
+    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA is not supported");
+    }
+
+    modify_config("DMABUF_REG_DEVICES", "all");
+    entity *e_all         = create_entity();
+    ucp_context_h ctx_all = e_all->ucph();
+
+    if (ucs_popcount(ctx_all->dmabuf_reg_md_map) < 2) {
+        UCS_TEST_SKIP_R("need at least 2 dmabuf-capable MDs");
+    }
+
+    const size_t size = 4096;
+    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+
+    ucp_mem_map_params_t params = {};
+    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                  UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address              = ptr;
+    params.length               = size;
+
+    ucp_mem_h memh_all;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh_all));
+    ucp_md_map_t dmabuf_all = memh_all->md_map & ctx_all->dmabuf_reg_md_map;
+    ucp_mem_unmap(ctx_all, memh_all);
+
+    modify_config("DMABUF_REG_DEVICES", "closest");
+    entity *e_close         = create_entity();
+    ucp_context_h ctx_close = e_close->ucph();
+
+    ucp_mem_h memh_close;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_close, &params, &memh_close));
+    ucp_md_map_t dmabuf_close = memh_close->md_map &
+                                ctx_close->dmabuf_reg_md_map;
+    ucp_mem_unmap(ctx_close, memh_close);
+
+    EXPECT_GT(ucs_popcount(dmabuf_close), 0);
+    EXPECT_LE(ucs_popcount(dmabuf_close), ucs_popcount(dmabuf_all));
+
+    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+}
+
+UCS_TEST_P(test_ucp_context, dmabuf_reg_devices_all_preserves_non_dmabuf)
+{
+    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA is not supported");
+    }
+
+    modify_config("DMABUF_REG_DEVICES", "all");
+    entity *e_all         = create_entity();
+    ucp_context_h ctx_all = e_all->ucph();
+
+    modify_config("DMABUF_REG_DEVICES", "1");
+    entity *e_lim         = create_entity();
+    ucp_context_h ctx_lim = e_lim->ucph();
+
+    if (ctx_all->dmabuf_reg_md_map == 0) {
+        UCS_TEST_SKIP_R("no dmabuf-capable MDs");
+    }
+
+    const size_t size = 4096;
+    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+
+    ucp_mem_map_params_t params = {};
+    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                  UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address              = ptr;
+    params.length               = size;
+
+    ucp_mem_h memh_all;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh_all));
+
+    ucp_mem_h memh_lim;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh_lim));
+
+    /* Non-dmabuf MDs (e.g. cuda_copy, self) should be registered identically
+     * regardless of the dmabuf device policy */
+    ucp_md_map_t non_dmabuf_all = memh_all->md_map &
+                                  ~ctx_all->dmabuf_reg_md_map;
+    ucp_md_map_t non_dmabuf_lim = memh_lim->md_map &
+                                  ~ctx_lim->dmabuf_reg_md_map;
+    EXPECT_EQ(non_dmabuf_all, non_dmabuf_lim);
+
+    ucp_mem_unmap(ctx_all, memh_all);
+    ucp_mem_unmap(ctx_lim, memh_lim);
+    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_context, all, "all")
@@ -123,6 +273,137 @@ UCS_TEST_P(test_ucp_version, version_string) {
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_version, all, "all")
+
+class test_ucp_dmabuf_reg_devices : public ucs::test {
+protected:
+    static ucp_context_config_t
+    config(ucp_dmabuf_reg_devices_mode_t mode, unsigned count = UCP_MAX_MDS)
+    {
+        ucp_context_config_t config = {};
+
+        config.dmabuf_reg_devices_mode  = mode;
+        config.dmabuf_reg_devices_count = count;
+        return config;
+    }
+
+    static ucp_dmabuf_reg_select_md_t md(ucp_md_index_t md_index,
+                                         const char *name, double latency,
+                                         uint32_t last_used = 0)
+    {
+        ucp_dmabuf_reg_select_md_t md = {};
+
+        md.md_index  = md_index;
+        md.name      = name;
+        md.latency   = latency;
+        md.last_used = last_used;
+        return md;
+    }
+
+    static void set_context_md(ucp_tl_md_t *tl_mds, ucp_md_index_t md_index,
+                               const char *name)
+    {
+        ucs_strncpy_safe(tl_mds[md_index].rsc.md_name, name,
+                         sizeof(tl_mds[md_index].rsc.md_name));
+    }
+
+    static void init_context(ucp_context_t &context, ucp_tl_md_t *tl_mds,
+                             ucp_dmabuf_reg_devices_mode_t mode, unsigned count)
+    {
+        context.tl_mds                              = tl_mds;
+        context.num_mds                             = 4;
+        context.dmabuf_reg_md_map                   = UCS_MASK(4);
+        context.dmabuf_reg_timestamp                = 0;
+        context.config.ext.dmabuf_reg_devices_mode  = mode;
+        context.config.ext.dmabuf_reg_devices_count = count;
+
+        set_context_md(tl_mds, 0, "mlx5_0");
+        set_context_md(tl_mds, 1, "mlx5_1");
+        set_context_md(tl_mds, 2, "mlx5_2");
+        set_context_md(tl_mds, 3, "mlx5_3");
+    }
+};
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, closest_by_latency) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_CLOSEST);
+    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_2", 5e-7),
+                                                   md(1, "mlx5_0", 3e-7),
+                                                   md(2, "mlx5_1", 3e-7),
+                                                   md(3, "mlx5_3", 1e-6)};
+
+    EXPECT_EQ(UCS_BIT(1) | UCS_BIT(2),
+              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, closest_selects_all_equal_latency) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_CLOSEST);
+    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
+                                                   md(1, "mlx5_1", 3e-7)};
+
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
+              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, limit_uses_latency_before_last_used) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 2);
+    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
+                                                   md(1, "mlx5_1", 5e-7, 0),
+                                                   md(2, "mlx5_2", 3e-7, 8),
+                                                   md(3, "mlx5_3", 5e-7, 0)};
+
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2),
+              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices,
+           limit_larger_than_available_selects_all) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 8);
+    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
+                                                   md(1, "mlx5_1", 5e-7)};
+
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
+              ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, empty_selects_none) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 1);
+
+    EXPECT_EQ((ucp_md_map_t)0, ucp_dmabuf_reg_select(&cfg, NULL, 0));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, limit_prefers_least_recently_used) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 1);
+    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
+                                                   md(1, "mlx5_1", 3e-7, 0)};
+
+    EXPECT_EQ(UCS_BIT(1), ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, limit_uses_name_after_last_used) {
+    ucp_context_config_t cfg = config(UCP_DMABUF_REG_DEVICES_LIMIT, 1);
+    std::vector<ucp_dmabuf_reg_select_md_t> mds = {md(0, "mlx5_1", 3e-7, 0),
+                                                   md(1, "mlx5_0", 3e-7, 0)};
+
+    EXPECT_EQ(UCS_BIT(1), ucp_dmabuf_reg_select(&cfg, mds.data(), mds.size()));
+}
+
+UCS_TEST_F(test_ucp_dmabuf_reg_devices, context_selection_rotates_mds) {
+    ucp_context_t context = {};
+    ucp_tl_md_t tl_mds[4] = {};
+    ucp_md_map_t md_map;
+
+    init_context(context, tl_mds, UCP_DMABUF_REG_DEVICES_LIMIT, 1);
+
+    md_map = ucp_context_select_dmabuf_reg_md_map(&context,
+                                                  UCS_BIT(1) | UCS_BIT(3),
+                                                  UCS_SYS_DEVICE_ID_UNKNOWN);
+    EXPECT_EQ(UCS_BIT(1), md_map);
+
+    ucp_context_dmabuf_reg_mark_used(&context, UCS_BIT(1));
+    md_map = ucp_context_select_dmabuf_reg_md_map(&context,
+                                                  UCS_BIT(1) | UCS_BIT(3),
+                                                  UCS_SYS_DEVICE_ID_UNKNOWN);
+    EXPECT_EQ(UCS_BIT(3), md_map);
+}
 
 namespace {
 

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -7,15 +7,17 @@
 #include "ucp_test.h"
 
 #include <cstddef>
-#include <memory>
 #include <set>
-#include <vector>
 
 extern "C" {
 #include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_mm.h>
 #include <ucs/sys/sys.h>
 }
+
+#if HAVE_CUDA
+#include <cuda_runtime.h>
+#endif
 
 class test_ucp_lib_query : public ucs::test {
 };
@@ -80,136 +82,119 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
         UCS_TEST_SKIP_R("CUDA is not supported");
     }
 
-    /* Create entity with max_hca_per_gpu=inf to discover how many dmabuf MDs
-     * are available on this system */
     modify_config("MAX_HCA_PER_GPU", "inf");
     entity *e_all         = create_entity();
     ucp_context_h ctx_all = e_all->ucph();
 
-    if (ucs_popcount(ctx_all->dmabuf_reg_md_map) < 2) {
-        UCS_TEST_SKIP_R("need at least 2 dmabuf-capable MDs");
+    ucp_md_map_t net_md_map = 0;
+    for (ucp_rsc_index_t i = 0; i < ctx_all->num_tls; ++i) {
+        if (ctx_all->tl_rscs[i].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
+            net_md_map |= UCS_BIT(ctx_all->tl_rscs[i].md_index);
+        }
+    }
+
+    if (ucs_popcount(net_md_map) < 2) {
+        UCS_TEST_SKIP_R("need at least 2 network MDs");
     }
 
     const size_t size = 4096;
     void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
 
-    ucp_mem_map_params_t params = {};
-    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                                  UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    params.address              = ptr;
-    params.length               = size;
+    ucp_mem_map_params_t params;
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address    = ptr;
+    params.length     = size;
 
-    ucp_mem_h memh_all;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh_all));
-    ucp_md_map_t dmabuf_all = memh_all->md_map & ctx_all->dmabuf_reg_md_map;
-    ucp_mem_unmap(ctx_all, memh_all);
+    ucp_mem_h memh;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh));
+    ucp_md_map_t net_all     = memh->md_map & net_md_map;
+    ucp_md_map_t non_net_all = memh->md_map & ~net_md_map;
+    ucp_mem_unmap(ctx_all, memh);
 
-    /* Create a second entity with max_hca_per_gpu=1 and verify that fewer
-     * dmabuf MDs end up on the memh */
+    /* LIMIT=1: at most 1 network MD */
     modify_config("MAX_HCA_PER_GPU", "1");
     entity *e_lim         = create_entity();
     ucp_context_h ctx_lim = e_lim->ucph();
 
-    ucp_mem_h memh_lim;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh_lim));
-    ucp_md_map_t dmabuf_lim = memh_lim->md_map & ctx_lim->dmabuf_reg_md_map;
-    ucp_mem_unmap(ctx_lim, memh_lim);
+    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh));
+    ucp_md_map_t net_lim     = memh->md_map & net_md_map;
+    ucp_md_map_t non_net_lim = memh->md_map & ~net_md_map;
+    ucp_mem_unmap(ctx_lim, memh);
 
-    EXPECT_GT(ucs_popcount(dmabuf_all), 0);
-    EXPECT_LE(ucs_popcount(dmabuf_lim), 1);
-    EXPECT_LE(ucs_popcount(dmabuf_lim), ucs_popcount(dmabuf_all));
-
-    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
-}
-
-UCS_TEST_P(test_ucp_context, max_hca_per_gpu_closest_is_subset)
-{
-    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
-        UCS_TEST_SKIP_R("CUDA is not supported");
-    }
-
-    modify_config("MAX_HCA_PER_GPU", "inf");
-    entity *e_all         = create_entity();
-    ucp_context_h ctx_all = e_all->ucph();
-
-    if (ucs_popcount(ctx_all->dmabuf_reg_md_map) < 2) {
-        UCS_TEST_SKIP_R("need at least 2 dmabuf-capable MDs");
-    }
-
-    const size_t size = 4096;
-    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
-
-    ucp_mem_map_params_t params = {};
-    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                                  UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    params.address              = ptr;
-    params.length               = size;
-
-    ucp_mem_h memh_all;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh_all));
-    ucp_md_map_t dmabuf_all = memh_all->md_map & ctx_all->dmabuf_reg_md_map;
-    ucp_mem_unmap(ctx_all, memh_all);
-
+    /* CLOSEST: subset of all */
     modify_config("MAX_HCA_PER_GPU", "0");
     entity *e_close         = create_entity();
     ucp_context_h ctx_close = e_close->ucph();
 
-    ucp_mem_h memh_close;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_close, &params, &memh_close));
-    ucp_md_map_t dmabuf_close = memh_close->md_map &
-                                ctx_close->dmabuf_reg_md_map;
-    ucp_mem_unmap(ctx_close, memh_close);
-
-    EXPECT_GT(ucs_popcount(dmabuf_close), 0);
-    EXPECT_LE(ucs_popcount(dmabuf_close), ucs_popcount(dmabuf_all));
+    ASSERT_UCS_OK(ucp_mem_map(ctx_close, &params, &memh));
+    ucp_md_map_t net_close = memh->md_map & net_md_map;
+    ucp_mem_unmap(ctx_close, memh);
 
     mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+
+    EXPECT_GT(ucs_popcount(net_all), 0);
+    EXPECT_LE(ucs_popcount(net_lim), 1);
+    EXPECT_GT(ucs_popcount(net_close), 0);
+    EXPECT_LE(ucs_popcount(net_close), ucs_popcount(net_all));
+    EXPECT_EQ(non_net_all, non_net_lim);
 }
 
-UCS_TEST_P(test_ucp_context, max_hca_per_gpu_preserves_non_dmabuf)
+UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_per_gpu)
 {
+#if !HAVE_CUDA
+    UCS_TEST_SKIP_R("CUDA is not available");
+#else
     if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA is not supported");
     }
 
-    modify_config("MAX_HCA_PER_GPU", "inf");
-    entity *e_all         = create_entity();
-    ucp_context_h ctx_all = e_all->ucph();
-
-    modify_config("MAX_HCA_PER_GPU", "1");
-    entity *e_lim         = create_entity();
-    ucp_context_h ctx_lim = e_lim->ucph();
-
-    if (ctx_all->dmabuf_reg_md_map == 0) {
-        UCS_TEST_SKIP_R("no dmabuf-capable MDs");
+    int num_gpus;
+    if ((cudaGetDeviceCount(&num_gpus) != cudaSuccess) || (num_gpus < 2)) {
+        UCS_TEST_SKIP_R("need at least 2 CUDA devices");
     }
 
+    modify_config("MAX_HCA_PER_GPU", "1");
+    entity *e         = create_entity();
+    ucp_context_h ctx = e->ucph();
+
+    ucp_md_map_t net_md_map = 0;
+    for (ucp_rsc_index_t i = 0; i < ctx->num_tls; ++i) {
+        if (ctx->tl_rscs[i].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
+            net_md_map |= UCS_BIT(ctx->tl_rscs[i].md_index);
+        }
+    }
+
+    if (ucs_popcount(net_md_map) < 2) {
+        UCS_TEST_SKIP_R("need at least 2 network MDs");
+    }
+
+    int orig_dev;
+    ASSERT_EQ(cudaGetDevice(&orig_dev), cudaSuccess);
+
     const size_t size = 4096;
-    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+    ucp_mem_map_params_t params;
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
 
-    ucp_mem_map_params_t params = {};
-    params.field_mask           = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                                  UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    params.address              = ptr;
-    params.length               = size;
+    for (int gpu = 0; gpu < ucs_min(num_gpus, 4); gpu++) {
+        ASSERT_EQ(cudaSetDevice(gpu), cudaSuccess);
 
-    ucp_mem_h memh_all;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh_all));
+        void *ptr = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+        params.address = ptr;
+        params.length  = size;
 
-    ucp_mem_h memh_lim;
-    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh_lim));
+        ucp_mem_h memh;
+        ASSERT_UCS_OK(ucp_mem_map(ctx, &params, &memh));
+        ucp_md_map_t net_map = memh->md_map & net_md_map;
+        EXPECT_LE(ucs_popcount(net_map), 1)
+                << "GPU " << gpu << " should have at most 1 network MD";
+        ucp_mem_unmap(ctx, memh);
+        mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+    }
 
-    /* Non-dmabuf MDs (e.g. cuda_copy, self) should be registered identically
-     * regardless of the dmabuf device policy */
-    ucp_md_map_t non_dmabuf_all = memh_all->md_map &
-                                  ~ctx_all->dmabuf_reg_md_map;
-    ucp_md_map_t non_dmabuf_lim = memh_lim->md_map &
-                                  ~ctx_lim->dmabuf_reg_md_map;
-    EXPECT_EQ(non_dmabuf_all, non_dmabuf_lim);
-
-    ucp_mem_unmap(ctx_all, memh_all);
-    ucp_mem_unmap(ctx_lim, memh_lim);
-    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+    ASSERT_EQ(cudaSetDevice(orig_dev), cudaSuccess);
+#endif
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_context, all, "all")
@@ -274,150 +259,6 @@ UCS_TEST_P(test_ucp_version, version_string) {
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_version, all, "all")
-
-class test_ucp_reg_devices : public ucs::test {
-protected:
-    static ucp_context_config_t
-    config(ucp_reg_devices_mode_t mode, unsigned count = UCP_MAX_MDS)
-    {
-        ucp_context_config_t config = {};
-
-        switch (mode) {
-        case UCP_REG_DEVICES_ALL:
-            config.max_hca_per_gpu = UCS_ULUNITS_INF;
-            break;
-        case UCP_REG_DEVICES_CLOSEST:
-            config.max_hca_per_gpu = 0;
-            break;
-        case UCP_REG_DEVICES_LIMIT:
-            config.max_hca_per_gpu = count;
-            break;
-        }
-        return config;
-    }
-
-    static ucp_reg_select_md_t md(ucp_md_index_t md_index, const char *name,
-                                  double latency, uint32_t use_count = 0)
-    {
-        ucp_reg_select_md_t md;
-
-        md.md_index  = md_index;
-        md.name      = name;
-        md.latency   = latency;
-        md.use_count = use_count;
-        return md;
-    }
-
-    static void set_context_md(ucp_tl_md_t *tl_mds, ucp_md_index_t md_index,
-                               const char *name)
-    {
-        ucs_strncpy_safe(tl_mds[md_index].rsc.md_name, name,
-                         sizeof(tl_mds[md_index].rsc.md_name));
-    }
-
-    static void init_context(ucp_context_t &context, ucp_tl_md_t *tl_mds,
-                             ucp_reg_devices_mode_t mode, unsigned count)
-    {
-        context.tl_mds            = tl_mds;
-        context.num_mds           = 4;
-        context.dmabuf_reg_md_map = UCS_MASK(4);
-        switch (mode) {
-        case UCP_REG_DEVICES_ALL:
-            context.config.ext.max_hca_per_gpu = UCS_ULUNITS_INF;
-            break;
-        case UCP_REG_DEVICES_CLOSEST:
-            context.config.ext.max_hca_per_gpu = 0;
-            break;
-        case UCP_REG_DEVICES_LIMIT:
-            context.config.ext.max_hca_per_gpu = count;
-            break;
-        }
-
-        set_context_md(tl_mds, 0, "mlx5_0");
-        set_context_md(tl_mds, 1, "mlx5_1");
-        set_context_md(tl_mds, 2, "mlx5_2");
-        set_context_md(tl_mds, 3, "mlx5_3");
-    }
-};
-
-UCS_TEST_F(test_ucp_reg_devices, closest_by_latency) {
-    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_CLOSEST);
-    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_2", 5e-7),
-                                            md(1, "mlx5_0", 3e-7),
-                                            md(2, "mlx5_1", 3e-7),
-                                            md(3, "mlx5_3", 1e-6)};
-
-    EXPECT_EQ(UCS_BIT(1) | UCS_BIT(2),
-              ucp_reg_select(&cfg, mds.data(), mds.size()));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, closest_selects_all_equal_latency) {
-    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_CLOSEST);
-    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
-                                            md(1, "mlx5_1", 3e-7)};
-
-    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
-              ucp_reg_select(&cfg, mds.data(), mds.size()));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, limit_uses_latency_before_use_count) {
-    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 2);
-    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
-                                            md(1, "mlx5_1", 5e-7, 0),
-                                            md(2, "mlx5_2", 3e-7, 8),
-                                            md(3, "mlx5_3", 5e-7, 0)};
-
-    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2),
-              ucp_reg_select(&cfg, mds.data(), mds.size()));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, limit_larger_than_available_selects_all) {
-    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 8);
-    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
-                                            md(1, "mlx5_1", 5e-7)};
-
-    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
-              ucp_reg_select(&cfg, mds.data(), mds.size()));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, empty_selects_none) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 1);
-
-    EXPECT_EQ((ucp_md_map_t)0, ucp_reg_select(&cfg, NULL, 0));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, limit_prefers_least_used) {
-    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 1);
-    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
-                                            md(1, "mlx5_1", 3e-7, 0)};
-
-    EXPECT_EQ(UCS_BIT(1), ucp_reg_select(&cfg, mds.data(), mds.size()));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, limit_uses_name_after_use_count) {
-    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 1);
-    std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_1", 3e-7, 0),
-                                            md(1, "mlx5_0", 3e-7, 0)};
-
-    EXPECT_EQ(UCS_BIT(1), ucp_reg_select(&cfg, mds.data(), mds.size()));
-}
-
-UCS_TEST_F(test_ucp_reg_devices, context_selection_rotates_mds) {
-    std::unique_ptr<ucp_context_t> ctx(new ucp_context_t{});
-    ucp_tl_md_t tl_mds[4] = {};
-    ucp_md_map_t md_map;
-
-    init_context(*ctx, tl_mds, UCP_REG_DEVICES_LIMIT, 1);
-
-    md_map = ucp_context_select_reg_md_map(ctx.get(), UCS_BIT(1) | UCS_BIT(3),
-                                           UCS_SYS_DEVICE_ID_UNKNOWN);
-    EXPECT_EQ(UCS_BIT(1), md_map);
-
-    ucp_context_reg_mark_used(ctx.get(), UCS_BIT(1));
-    md_map = ucp_context_select_reg_md_map(ctx.get(), UCS_BIT(1) | UCS_BIT(3),
-                                           UCS_SYS_DEVICE_ID_UNKNOWN);
-    EXPECT_EQ(UCS_BIT(3), md_map);
-}
 
 namespace {
 

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -86,12 +86,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
     entity *e_all         = create_entity();
     ucp_context_h ctx_all = e_all->ucph();
 
-    ucp_md_map_t net_md_map = 0;
-    for (ucp_rsc_index_t i = 0; i < ctx_all->num_tls; ++i) {
-        if (ctx_all->tl_rscs[i].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
-            net_md_map |= UCS_BIT(ctx_all->tl_rscs[i].md_index);
-        }
-    }
+    ucp_md_map_t net_md_map = ucp_context_get_net_md_map(ctx_all);
 
     if (ucs_popcount(net_md_map) < 2) {
         UCS_TEST_SKIP_R("need at least 2 network MDs");
@@ -123,7 +118,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
     ASSERT_UCS_OK(ucp_mem_unmap(ctx_lim, memh));
 
     /* CLOSEST: subset of all */
-    modify_config("MAX_HCA_PER_GPU", "0");
+    modify_config("MAX_HCA_PER_GPU", "auto");
     entity *e_close         = create_entity();
     ucp_context_h ctx_close = e_close->ucph();
 
@@ -158,12 +153,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_per_gpu)
     entity *e         = create_entity();
     ucp_context_h ctx = e->ucph();
 
-    ucp_md_map_t net_md_map = 0;
-    for (ucp_rsc_index_t i = 0; i < ctx->num_tls; ++i) {
-        if (ctx->tl_rscs[i].tl_rsc.dev_type == UCT_DEVICE_TYPE_NET) {
-            net_md_map |= UCS_BIT(ctx->tl_rscs[i].md_index);
-        }
-    }
+    ucp_md_map_t net_md_map = ucp_context_get_net_md_map(ctx);
 
     if (ucs_popcount(net_md_map) < 2) {
         UCS_TEST_SKIP_R("need at least 2 network MDs");

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -110,7 +110,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
     ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh));
     ucp_md_map_t net_all     = memh->md_map & net_md_map;
     ucp_md_map_t non_net_all = memh->md_map & ~net_md_map;
-    ucp_mem_unmap(ctx_all, memh);
+    ASSERT_UCS_OK(ucp_mem_unmap(ctx_all, memh));
 
     /* LIMIT=1: at most 1 network MD */
     modify_config("MAX_HCA_PER_GPU", "1");
@@ -120,7 +120,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
     ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh));
     ucp_md_map_t net_lim     = memh->md_map & net_md_map;
     ucp_md_map_t non_net_lim = memh->md_map & ~net_md_map;
-    ucp_mem_unmap(ctx_lim, memh);
+    ASSERT_UCS_OK(ucp_mem_unmap(ctx_lim, memh));
 
     /* CLOSEST: subset of all */
     modify_config("MAX_HCA_PER_GPU", "0");
@@ -129,7 +129,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_memh_md_map)
 
     ASSERT_UCS_OK(ucp_mem_map(ctx_close, &params, &memh));
     ucp_md_map_t net_close = memh->md_map & net_md_map;
-    ucp_mem_unmap(ctx_close, memh);
+    ASSERT_UCS_OK(ucp_mem_unmap(ctx_close, memh));
 
     mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
 
@@ -189,7 +189,7 @@ UCS_TEST_P(test_ucp_context, max_hca_per_gpu_limits_per_gpu)
         ucp_md_map_t net_map = memh->md_map & net_md_map;
         EXPECT_LE(ucs_popcount(net_map), 1)
                 << "GPU " << gpu << " should have at most 1 network MD";
-        ucp_mem_unmap(ctx, memh);
+        ASSERT_UCS_OK(ucp_mem_unmap(ctx, memh));
         mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
     }
 

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -296,16 +296,15 @@ protected:
         return config;
     }
 
-    static ucp_reg_select_md_t md(ucp_md_index_t md_index,
-                                         const char *name, double latency,
-                                         uint32_t use_count = 0)
+    static ucp_reg_select_md_t md(ucp_md_index_t md_index, const char *name,
+                                  double latency, uint32_t use_count = 0)
     {
         ucp_reg_select_md_t md = {};
 
-        md.md_index   = md_index;
-        md.name       = name;
-        md.latency    = latency;
-        md.use_count  = use_count;
+        md.md_index  = md_index;
+        md.name      = name;
+        md.latency   = latency;
+        md.use_count = use_count;
         return md;
     }
 
@@ -342,41 +341,40 @@ protected:
 };
 
 UCS_TEST_F(test_ucp_reg_devices, closest_by_latency) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_CLOSEST);
+    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_CLOSEST);
     std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_2", 5e-7),
-                                                   md(1, "mlx5_0", 3e-7),
-                                                   md(2, "mlx5_1", 3e-7),
-                                                   md(3, "mlx5_3", 1e-6)};
+                                            md(1, "mlx5_0", 3e-7),
+                                            md(2, "mlx5_1", 3e-7),
+                                            md(3, "mlx5_3", 1e-6)};
 
     EXPECT_EQ(UCS_BIT(1) | UCS_BIT(2),
               ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
 UCS_TEST_F(test_ucp_reg_devices, closest_selects_all_equal_latency) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_CLOSEST);
+    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_CLOSEST);
     std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
-                                                   md(1, "mlx5_1", 3e-7)};
+                                            md(1, "mlx5_1", 3e-7)};
 
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
               ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
 UCS_TEST_F(test_ucp_reg_devices, limit_uses_latency_before_use_count) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 2);
+    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 2);
     std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
-                                                   md(1, "mlx5_1", 5e-7, 0),
-                                                   md(2, "mlx5_2", 3e-7, 8),
-                                                   md(3, "mlx5_3", 5e-7, 0)};
+                                            md(1, "mlx5_1", 5e-7, 0),
+                                            md(2, "mlx5_2", 3e-7, 8),
+                                            md(3, "mlx5_3", 5e-7, 0)};
 
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2),
               ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
-UCS_TEST_F(test_ucp_reg_devices,
-           limit_larger_than_available_selects_all) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 8);
+UCS_TEST_F(test_ucp_reg_devices, limit_larger_than_available_selects_all) {
+    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 8);
     std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7),
-                                                   md(1, "mlx5_1", 5e-7)};
+                                            md(1, "mlx5_1", 5e-7)};
 
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1),
               ucp_reg_select(&cfg, mds.data(), mds.size()));
@@ -389,17 +387,17 @@ UCS_TEST_F(test_ucp_reg_devices, empty_selects_none) {
 }
 
 UCS_TEST_F(test_ucp_reg_devices, limit_prefers_least_used) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 1);
+    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 1);
     std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_0", 3e-7, 9),
-                                                   md(1, "mlx5_1", 3e-7, 0)};
+                                            md(1, "mlx5_1", 3e-7, 0)};
 
     EXPECT_EQ(UCS_BIT(1), ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
 
 UCS_TEST_F(test_ucp_reg_devices, limit_uses_name_after_use_count) {
-    ucp_context_config_t cfg = config(UCP_REG_DEVICES_LIMIT, 1);
+    ucp_context_config_t cfg             = config(UCP_REG_DEVICES_LIMIT, 1);
     std::vector<ucp_reg_select_md_t> mds = {md(0, "mlx5_1", 3e-7, 0),
-                                                   md(1, "mlx5_0", 3e-7, 0)};
+                                            md(1, "mlx5_0", 3e-7, 0)};
 
     EXPECT_EQ(UCS_BIT(1), ucp_reg_select(&cfg, mds.data(), mds.size()));
 }
@@ -411,15 +409,13 @@ UCS_TEST_F(test_ucp_reg_devices, context_selection_rotates_mds) {
 
     init_context(*ctx, tl_mds, UCP_REG_DEVICES_LIMIT, 1);
 
-    md_map = ucp_context_select_reg_md_map(ctx.get(),
-                                                  UCS_BIT(1) | UCS_BIT(3),
-                                                  UCS_SYS_DEVICE_ID_UNKNOWN);
+    md_map = ucp_context_select_reg_md_map(ctx.get(), UCS_BIT(1) | UCS_BIT(3),
+                                           UCS_SYS_DEVICE_ID_UNKNOWN);
     EXPECT_EQ(UCS_BIT(1), md_map);
 
     ucp_context_reg_mark_used(ctx.get(), UCS_BIT(1));
-    md_map = ucp_context_select_reg_md_map(ctx.get(),
-                                                  UCS_BIT(1) | UCS_BIT(3),
-                                                  UCS_SYS_DEVICE_ID_UNKNOWN);
+    md_map = ucp_context_select_reg_md_map(ctx.get(), UCS_BIT(1) | UCS_BIT(3),
+                                           UCS_SYS_DEVICE_ID_UNKNOWN);
     EXPECT_EQ(UCS_BIT(3), md_map);
 }
 

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -1349,3 +1349,120 @@ UCS_TEST_P(test_ucp_mmap_export, export_import) {
 }
 
 UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_mmap_export)
+
+
+class test_ucp_mmap_max_hca : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_TAG);
+    }
+};
+
+UCS_TEST_P(test_ucp_mmap_max_hca, limits_memh_md_map)
+{
+    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA is not supported");
+    }
+
+    modify_config("MAX_HCA_PER_GPU", "inf");
+    entity *e_all         = create_entity();
+    ucp_context_h ctx_all = e_all->ucph();
+
+    ucp_md_map_t net_md_map = ucp_context_get_net_md_map(ctx_all);
+
+    if (ucs_popcount(net_md_map) < 2) {
+        UCS_TEST_SKIP_R("need at least 2 network MDs");
+    }
+
+    const size_t size = 4096;
+    void *ptr         = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+
+    ucp_mem_map_params_t params;
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    params.address    = ptr;
+    params.length     = size;
+
+    ucp_mem_h memh;
+    ASSERT_UCS_OK(ucp_mem_map(ctx_all, &params, &memh));
+    ucp_md_map_t net_all     = memh->md_map & net_md_map;
+    ucp_md_map_t non_net_all = memh->md_map & ~net_md_map;
+    ASSERT_UCS_OK(ucp_mem_unmap(ctx_all, memh));
+
+    /* LIMIT=1: at most 1 network MD */
+    modify_config("MAX_HCA_PER_GPU", "1");
+    entity *e_lim         = create_entity();
+    ucp_context_h ctx_lim = e_lim->ucph();
+
+    ASSERT_UCS_OK(ucp_mem_map(ctx_lim, &params, &memh));
+    ucp_md_map_t net_lim     = memh->md_map & net_md_map;
+    ucp_md_map_t non_net_lim = memh->md_map & ~net_md_map;
+    ASSERT_UCS_OK(ucp_mem_unmap(ctx_lim, memh));
+
+    /* CLOSEST: subset of all */
+    modify_config("MAX_HCA_PER_GPU", "auto");
+    entity *e_close         = create_entity();
+    ucp_context_h ctx_close = e_close->ucph();
+
+    ASSERT_UCS_OK(ucp_mem_map(ctx_close, &params, &memh));
+    ucp_md_map_t net_close = memh->md_map & net_md_map;
+    ASSERT_UCS_OK(ucp_mem_unmap(ctx_close, memh));
+
+    mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+
+    EXPECT_GT(ucs_popcount(net_all), 0);
+    EXPECT_LE(ucs_popcount(net_lim), 1);
+    EXPECT_GT(ucs_popcount(net_close), 0);
+    EXPECT_LE(ucs_popcount(net_close), ucs_popcount(net_all));
+    EXPECT_EQ(non_net_all, non_net_lim);
+}
+
+UCS_TEST_P(test_ucp_mmap_max_hca, limits_per_gpu)
+{
+    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA is not supported");
+    }
+
+    int num_gpus = mem_buffer::cuda_get_device_count();
+    if (num_gpus < 2) {
+        UCS_TEST_SKIP_R("need at least 2 CUDA devices");
+    }
+
+    modify_config("MAX_HCA_PER_GPU", "1");
+    entity *e         = create_entity();
+    ucp_context_h ctx = e->ucph();
+
+    ucp_md_map_t net_md_map = ucp_context_get_net_md_map(ctx);
+
+    if (ucs_popcount(net_md_map) < 2) {
+        UCS_TEST_SKIP_R("need at least 2 network MDs");
+    }
+
+    int orig_dev = mem_buffer::cuda_get_device();
+
+    const size_t size = 4096;
+    ucp_mem_map_params_t params;
+    params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                        UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+
+    for (int gpu = 0; gpu < ucs_min(num_gpus, 4); gpu++) {
+        mem_buffer::cuda_set_device(gpu);
+
+        void *ptr      = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
+        params.address = ptr;
+        params.length  = size;
+
+        ucp_mem_h memh;
+        ASSERT_UCS_OK(ucp_mem_map(ctx, &params, &memh));
+        ucp_md_map_t net_map = memh->md_map & net_md_map;
+        EXPECT_LE(ucs_popcount(net_map), 1)
+                << "GPU " << gpu << " should have at most 1 network MD";
+        ASSERT_UCS_OK(ucp_mem_unmap(ctx, memh));
+        mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
+    }
+
+    mem_buffer::cuda_set_device(orig_dev);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mmap_max_hca, all, "all")

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -1424,7 +1424,7 @@ UCS_TEST_P(test_ucp_mmap_max_hca, limits_per_gpu)
         UCS_TEST_SKIP_R("CUDA is not supported");
     }
 
-    int num_gpus = mem_buffer::cuda_get_device_count();
+    int num_gpus = mem_buffer::get_device_count();
     if (num_gpus < 2) {
         UCS_TEST_SKIP_R("need at least 2 CUDA devices");
     }
@@ -1439,7 +1439,7 @@ UCS_TEST_P(test_ucp_mmap_max_hca, limits_per_gpu)
         UCS_TEST_SKIP_R("need at least 2 network MDs");
     }
 
-    int orig_dev = mem_buffer::cuda_get_device();
+    int orig_dev = mem_buffer::get_device();
 
     const size_t size = 4096;
     ucp_mem_map_params_t params;
@@ -1447,7 +1447,7 @@ UCS_TEST_P(test_ucp_mmap_max_hca, limits_per_gpu)
                         UCP_MEM_MAP_PARAM_FIELD_LENGTH;
 
     for (int gpu = 0; gpu < ucs_min(num_gpus, 4); gpu++) {
-        mem_buffer::cuda_set_device(gpu);
+        mem_buffer::set_device(gpu);
 
         void *ptr      = mem_buffer::allocate(size, UCS_MEMORY_TYPE_CUDA);
         params.address = ptr;
@@ -1462,7 +1462,7 @@ UCS_TEST_P(test_ucp_mmap_max_hca, limits_per_gpu)
         mem_buffer::release(ptr, UCS_MEMORY_TYPE_CUDA);
     }
 
-    mem_buffer::cuda_set_device(orig_dev);
+    mem_buffer::set_device(orig_dev);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mmap_max_hca, all, "all")

--- a/test/gtest/uct/test_md.cc
+++ b/test/gtest/uct/test_md.cc
@@ -602,9 +602,9 @@ UCS_TEST_P(test_md, sys_device) {
 
         /* Expect 0 latency and infinite bandwidth within same device */
         ucs_sys_dev_distance_t distance;
-        ucs_topo_get_distance(tl_resources[i].sys_device,
-                              tl_resources[i].sys_device,
-                              &distance);
+        status = ucs_topo_get_distance(tl_resources[i].sys_device,
+                                       tl_resources[i].sys_device, &distance);
+        ASSERT_UCS_OK(status);
         EXPECT_NEAR(distance.latency, 0, 1e-9);
         EXPECT_GT(distance.bandwidth, 1e12);
 


### PR DESCRIPTION
## What?

Add `UCX_MAX_HCA_PER_GPU` to limit how many HCAs UCP registers GPU memory on.
Supported values:

  - `inf`: register on all reachable HCAs, default
  - `auto`: register on the closest reachable HCA set
  - `<N>` : register on up to N closest reachable HCAs

## Why?
UCX currently registers on all MDs, causing high ICM memory usage. This should reduce it.

## How?
At ucp_mem_map() time, identify the network-device MDs (UCT_DEVICE_TYPE_NET) in the registration MD map and rank them by topology latency and bandwidth to the buffer's system device. Select the closest N according to UCX_MAX_HCA_PER_GPU, breaking ties by MD name. Non-network MDs (e.g. cuda_copy) are kept unchanged. Buffers with unknown system device bypass the policy entirely.
