### PR TITLE
UCT/GDA: Replace mark_wqes_ready with CAS-based WQE ordering.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Artem Ryabov <artemry@nvidia.com>
 Artemy Kovalyov <artemyko@mellanox.com>
 Arun Chandran <Arun.Chandran@amd.com>
 Aurelien Bouteiller <bouteill@icl.utk.edu>
+BatshevaBlack <bblack@nvidia.com>
 Bin Lei <binl@mellanox.com>
 Boris Karasev <boriska@nvidia.com>
 Brad Benton <bradford.benton@gmail.com>

--- a/src/uct/ib/mlx5/gdaki/gdaki.cuh
+++ b/src/uct/ib/mlx5/gdaki/gdaki.cuh
@@ -240,7 +240,11 @@ UCS_F_DEVICE void uct_rc_mlx5_gda_db(uct_rc_gdaki_dev_ep_t *ep, unsigned cid,
 
     __threadfence();
     if (skip_db) {
-        doca_gpu_dev_common_mark_wqes_ready(qp->sq_ready_index, wqe_base, wqe_next - 1);
+        const uint64_t wqe_base_orig = wqe_base;
+        while (!ref.compare_exchange_strong(wqe_base, wqe_next,
+                                            cuda::std::memory_order_relaxed)) {
+            wqe_base = wqe_base_orig;
+        }
     } else {
         uint32_t qpn_ds = __ldg(&qp->qpn_ds);
         auto *db_ptr = (uint64_t*)__ldg((uintptr_t*)&qp->sq_db);


### PR DESCRIPTION
  ### What?

Replace the call to doca_gpu_dev_common_mark_wqes_ready() in uct_rc_mlx5_gda_db() with the previous CAS-based approach: each thread spins on a relaxed compare_exchange_strong against sq_ready_index, advancing it atomically from wqe_base to wqe_next.

  ### Why?

doca_gpu_dev_common_mark_wqes_ready() uses a GPU-scope fence.release + spin-wait + fence.acquire sequence to serialize WQE posting order. When N threads call it concurrently on the same QP, this serializes into O(N) fence round-trips, causing a significant bandwidth regression at high thread counts (e.g. ~34% drop with 32 threads, NUM_CHANNELS=1; up to ~3.5× drop in
  HybridEP combine).

  Perftest results (T=32, NUM_CHANNELS=1, message size 64B):

<img width="400" height="120" alt="image" src="https://github.com/user-attachments/assets/55eaeda1-44e1-404a-b189-ceb585eac1a8" />

  ### How?

  - Drop the mark_wqes_ready call.
  - Inline a relaxed compare_exchange_strong CAS loop: O(1) per thread, no GPU-scope fence overhead.