### PR TITLE
CI: fix build result not set to FAILURE on exception

### DIFF
--- a/.ci/jenkins/Jenkinsfile.github
+++ b/.ci/jenkins/Jenkinsfile.github
@@ -28,6 +28,7 @@ if (params.githubData) {
 try {
   matrix.main()
 } catch (Exception ex) {
+  currentBuild.result = 'FAILURE'
   println ex
   throw ex
 } finally {


### PR DESCRIPTION
## What
Update Jenkinsfile behavior on corner case failures.

## Why?
In some very specific cases, the job may fail to run but will report as succeeded to GH checks.

## How?
Force update the build result on any failure.