### PR TITLE
UCT/IB/BASE: Fix reachability check when devices in different subnets use the same LID

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -30,6 +30,52 @@
 #include <stdlib.h>
 #include <poll.h>
 #include <float.h>
+#include <pthread.h>
+
+
+/*
+ * Process-wide registry of IB port LIDs that are locally present on a
+ * link-local (fe80::) subnet.  When a pure-IB iface is created it registers
+ * its own LID here; the reachability check consults the table so that ANY
+ * local port whose LID matches the remote LID causes the connection to be
+ * rejected.  This prevents two ports on the same isolated fabric from
+ * mistakenly connecting to matching LIDs on a *different* isolated fabric that
+ * happens to share the same link-local prefix.
+ */
+static pthread_mutex_t uct_ib_link_local_lid_lock = PTHREAD_MUTEX_INITIALIZER;
+/* refcount per LID value (uint16_t → index 0..65535) */
+static uint8_t         uct_ib_link_local_lid_refcnt[1u << 16];
+
+static void uct_ib_link_local_lid_register(uint16_t lid)
+{
+    if (lid == 0) {
+        return; /* LID 0 is unassigned; skip */
+    }
+    pthread_mutex_lock(&uct_ib_link_local_lid_lock);
+    if (uct_ib_link_local_lid_refcnt[lid] < UINT8_MAX) {
+        __atomic_store_n(&uct_ib_link_local_lid_refcnt[lid],
+                         uct_ib_link_local_lid_refcnt[lid] + 1, __ATOMIC_RELEASE);
+    }
+    pthread_mutex_unlock(&uct_ib_link_local_lid_lock);
+}
+
+static void uct_ib_link_local_lid_unregister(uint16_t lid)
+{
+    if (lid == 0) {
+        return;
+    }
+    pthread_mutex_lock(&uct_ib_link_local_lid_lock);
+    if (uct_ib_link_local_lid_refcnt[lid] > 0) {
+        __atomic_store_n(&uct_ib_link_local_lid_refcnt[lid],
+                         uct_ib_link_local_lid_refcnt[lid] - 1, __ATOMIC_RELEASE);
+    }
+    pthread_mutex_unlock(&uct_ib_link_local_lid_lock);
+}
+
+static int uct_ib_link_local_lid_is_local(uint16_t lid)
+{
+    return __atomic_load_n(&uct_ib_link_local_lid_refcnt[lid], __ATOMIC_ACQUIRE) > 0;
+}
 
 
 /**
@@ -929,6 +975,23 @@ static int uct_ib_iface_dev_addr_is_reachable(
     if (!is_local_eth && !(ib_addr->flags & UCT_IB_ADDRESS_FLAG_LINK_LAYER_ETH)) {
         if (params.gid.global.subnet_prefix ==
             iface->gid_info.gid.global.subnet_prefix) {
+            /* For the link-local subnet prefix, multiple isolated IB
+             * fabrics may share the same fe80:: default prefix while
+             * being physically disjoint.  Any remote LID that is also
+             * present on a local port means the remote must be on a
+             * different isolated fabric: within a single fabric LIDs are
+             * unique, so a collision implies separate fabrics. */
+            if ((iface->gid_info.gid.global.subnet_prefix ==
+                 UCT_IB_LINK_LOCAL_PREFIX) &&
+                uct_ib_link_local_lid_is_local(params.lid)) {
+                uct_iface_fill_info_str_buf(
+                        is_reachable_params,
+                        "link-local IB subnet: remote LID %d matches a"
+                        " local port LID, indicating separate isolated"
+                        " fabrics",
+                        params.lid);
+                return 0;
+            }
             return 1;
         }
 
@@ -1843,6 +1906,14 @@ UCS_CLASS_INIT_FUNC(uct_ib_iface_t, uct_iface_ops_t *tl_ops,
               self->config.rx_headroom_offset, self->config.rx_payload_offset,
               self->config.rx_hdr_offset, self->config.seg_size);
 
+    /* Register this port's LID in the process-wide link-local LID table so
+     * that other local ports on the same isolated fabric can detect LID
+     * collisions with remote peers on different isolated fabrics. */
+    if (!uct_ib_iface_is_roce(self) &&
+        (self->gid_info.gid.global.subnet_prefix == UCT_IB_LINK_LOCAL_PREFIX)) {
+        uct_ib_link_local_lid_register(uct_ib_iface_port_attr(self)->lid);
+    }
+
     return UCS_OK;
 
 err_destroy_send_cq:
@@ -1860,6 +1931,11 @@ err:
 static UCS_CLASS_CLEANUP_FUNC(uct_ib_iface_t)
 {
     int ret;
+
+    if (!uct_ib_iface_is_roce(self) &&
+        (self->gid_info.gid.global.subnet_prefix == UCT_IB_LINK_LOCAL_PREFIX)) {
+        uct_ib_link_local_lid_unregister(uct_ib_iface_port_attr(self)->lid);
+    }
 
     self->ops->destroy_cq(self, UCT_IB_DIR_RX);
     self->ops->destroy_cq(self, UCT_IB_DIR_TX);


### PR DESCRIPTION
## What?
Introduce a process-wide registry of local IB port LIDs for link-local (fe80::) subnets. When a pure-IB iface is created, it registers its LID; uct_ib_iface_dev_addr_is_reachable consults the registry to reject remote addresses whose LID matches any local port LID.                 

## Why?
 Isolated IB fabrics without a subnet manager all default to the same fe80:: link-local subnet prefix. UCX's reachability check compared only subnet prefixes, so two nodes on physically separate isolated fabrics appeared mutually reachable. RC QPs were established and traffic was sent to LIDs that did not exist on the local fabric
                                                                                                                                                                                                                                                                                           
## How?
 - A static uint8_t uct_ib_link_local_lid_refcnt[65536] array (64 KB BSS, demand-paged) indexed by LID value acts as the registry, protected by a pthread_mutex_t for writes.                                                                                                             
  - Reads in the hot-path reachability check use __atomic_load_n(..., __ATOMIC_ACQUIRE), making the check lock-free and scalable to multi-threaded environments.
  - Registration (uct_ib_link_local_lid_register) and unregistration (uct_ib_link_local_lid_unregister) are called from UCS_CLASS_INIT_FUNC and UCS_CLASS_CLEANUP_FUNC of uct_ib_iface_t respectively, guarded by !uct_ib_iface_is_roce() && subnet_prefix == UCT_IB_LINK_LOCAL_PREFIX.    
  - The registry is consulted only on the IB × IB × link-local × subnet-prefix-match path, so it has zero cost for RoCE and SM-managed IB fabrics (which carry a non-link-local subnet prefix).         