### PR TITLE
TEST/GTEST/UCT/IB: Register with page aligned hole

### DIFF
--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -336,7 +336,7 @@ UCS_TEST_P(test_ib_md, smkey_reg_atomic_mt, "IB_REG_MT_THRESH=1k",
 UCS_TEST_P(test_ib_md, mt_fail, "IB_REG_MT_THRESH=128K", "IB_REG_MT_CHUNK=16K")
 {
     size_t size             = UCS_MBYTE;
-    const size_t align_mask = (8 * UCS_KBYTE) - 1;
+    const size_t align_mask = (2 * ucs_get_page_size()) - 1;
     size_t lower_size       = ((size / 3)) & ~align_mask;
     size_t upper_size       = (size / 2) & ~align_mask;
     void *start, *mid, *last;
@@ -359,7 +359,7 @@ UCS_TEST_P(test_ib_md, mt_fail, "IB_REG_MT_THRESH=128K", "IB_REG_MT_CHUNK=16K")
     ASSERT_NE(nullptr, start);
     mid  = UCS_PTR_BYTE_OFFSET(start, lower_size);
     last = UCS_PTR_BYTE_OFFSET(start, size - upper_size);
-    munmap(mid, size - upper_size - lower_size);
+    ASSERT_EQ(0, munmap(mid, size - upper_size - lower_size));
 
     /* Trigger MT registration failure */
     scoped_log_handler wrap_err(wrap_errors_logger);


### PR DESCRIPTION
## What?
Fix registration by using right page alignment.

```
[ RUN      ] ib/test_ib_md.mt_fail/1 <mlx5_1>
gtest/uct/ib/test_ib_md.cc:366: Failure
Expected: (UCS_OK) != (reg_mem(UCT_MD_MEM_ACCESS_RMA, start, size, &memh)), actual: 0 vs 0
gtest/uct/ib/test_ib_md.cc:371: Failure
Expected: (nullptr) != (mid), actual: (nullptr) vs NULL

