### PR TITLE
UCP/DEVICE: Replace div/mod with shift/and in lane demux

### DIFF
--- a/src/ucp/api/device/ucp_device_impl.h
+++ b/src/ucp/api/device/ucp_device_impl.h
@@ -54,7 +54,7 @@ UCS_F_DEVICE ucs_status_t ucp_device_check_params(const T mem_list_h,
                                                   unsigned index)
 {
     if (UCP_DEVICE_ENABLE_PARAMS_CHECK) {
-        if ((mem_list_h->version != UCP_DEVICE_MEM_LIST_VERSION_V1) ||
+        if ((mem_list_h->version != UCP_DEVICE_MEM_LIST_VERSION) ||
             (index >= mem_list_h->length)) {
             ucs_device_error("Invalid parameters for %p\n", mem_list_h);
             return UCS_ERR_INVALID_PARAM;

--- a/src/ucp/api/device/ucp_device_impl.h
+++ b/src/ucp/api/device/ucp_device_impl.h
@@ -105,17 +105,26 @@ UCS_F_DEVICE void ucp_device_request_init(uct_device_ep_t *device_ep,
     })
 
 
-#define UCP_DEVICE_GET_LANE(_handle, _channel_id, _lane, _uct_channel_id) \
-    _lane           = _channel_id % _handle->num_lanes; \
-    _uct_channel_id = _channel_id / _handle->num_lanes;
+template<typename H>
+UCS_F_DEVICE void ucp_device_get_lane(const H handle, unsigned channel_id,
+                                      unsigned &lane, unsigned &uct_channel_id)
+{
+    lane           = channel_id & handle->num_lanes_mask;
+    uct_channel_id = channel_id >> handle->num_lanes_shift;
+}
 
 
-#define UCP_DEVICE_GET_ELEM(_handle, _index) \
-    static_cast<ucs_typeof(_handle->mem_elements[0])*>(UCS_PTR_BYTE_OFFSET( \
-            _handle->mem_elements, \
-            (sizeof(_handle->mem_elements[0]) + \
-             (sizeof(_handle->mem_elements[0].tl[0]) * _handle->num_lanes)) * \
-                    _index))
+template<typename H>
+UCS_F_DEVICE auto ucp_device_get_elem(H handle, unsigned index)
+        -> decltype(&handle->mem_elements[0])
+{
+    return static_cast<decltype(&handle->mem_elements[0])>(
+            UCS_PTR_BYTE_OFFSET(handle->mem_elements,
+                                (sizeof(handle->mem_elements[0]) +
+                                 (sizeof(handle->mem_elements[0].tl[0])
+                                  << handle->num_lanes_shift)) *
+                                        index));
+}
 
 
 UCS_F_DEVICE ucs_status_t ucp_device_prepare_send_remote(
@@ -131,7 +140,7 @@ UCS_F_DEVICE ucs_status_t ucp_device_prepare_send_remote(
         return status;
     }
 
-    const auto dst_mem_element = UCP_DEVICE_GET_ELEM(dst_mem_list_h,
+    const auto dst_mem_element = ucp_device_get_elem(dst_mem_list_h,
                                                      dst_mem_list_index);
     remote_address             = dst_mem_element->addr;
     device_ep                  = dst_mem_element->tl[lane].ep;
@@ -165,7 +174,7 @@ UCS_F_DEVICE ucs_status_t ucp_device_prepare_send(
         return status;
     }
 
-    const auto src_mem_elem = UCP_DEVICE_GET_ELEM(src_mem_list_h,
+    const auto src_mem_elem = ucp_device_get_elem(src_mem_list_h,
                                                   src_mem_list_index);
     src_uct_elem            = src_mem_elem->tl + lane;
     address                 = src_mem_elem->addr;
@@ -229,7 +238,7 @@ ucp_device_put(const ucp_device_local_mem_list_h src_mem_list_h,
     uct_device_ep_t *device_ep;
     ucs_status_t status;
 
-    UCP_DEVICE_GET_LANE(dst_mem_list_h, channel_id, lane, uct_channel_id);
+    ucp_device_get_lane(dst_mem_list_h, channel_id, lane, uct_channel_id);
 
     status = ucp_device_prepare_send(src_mem_list_h, src_mem_list_index,
                                      dst_mem_list_h, dst_mem_list_index,
@@ -293,7 +302,7 @@ UCS_F_DEVICE ucs_status_t ucp_device_counter_inc(
     uct_device_ep_t *device_ep;
     ucs_status_t status;
 
-    UCP_DEVICE_GET_LANE(mem_list_h, channel_id, lane, uct_channel_id);
+    ucp_device_get_lane(mem_list_h, channel_id, lane, uct_channel_id);
 
     status = ucp_device_prepare_send_remote(mem_list_h, mem_list_index,
                                             remote_address, lane, req,
@@ -333,7 +342,7 @@ ucp_device_get_ptr(const ucp_device_remote_mem_list_h mem_list_h,
         return status;
     }
 
-    const auto mem_element = UCP_DEVICE_GET_ELEM(mem_list_h, mem_list_index);
+    const auto mem_element = ucp_device_get_elem(mem_list_h, mem_list_index);
 
     return uct_device_ep_get_ptr(mem_element->tl[0].ep, &mem_element->tl[0].uct,
                                  mem_element->addr, addr_p);

--- a/src/ucp/api/device/ucp_device_types.h
+++ b/src/ucp/api/device/ucp_device_types.h
@@ -33,9 +33,10 @@ typedef struct ucp_device_remote_mem_list {
     uint16_t                     version;
 
     /**
-     * Number of lanes in each memory descriptor.
+     * Bit-shift and bit-mask based on number of lanes.
      */
-    uint16_t                     num_lanes;
+    uint8_t                      num_lanes_shift;
+    uint8_t                      num_lanes_mask;
 
     /**
      * Number of entries in the memory descriptors array @a elems.
@@ -67,9 +68,10 @@ typedef struct ucp_device_local_mem_list {
     uint16_t                    version;
 
     /**
-     * Number of lanes in each memory descriptor.
+     * Bit-shift and bit-mask based on number of lanes.
      */
-    uint16_t                    num_lanes;
+    uint8_t                     num_lanes_shift;
+    uint8_t                     num_lanes_mask;
 
     /**
      * Number of entries in the memory descriptors array @a elems.

--- a/src/ucp/api/device/ucp_device_types.h
+++ b/src/ucp/api/device/ucp_device_types.h
@@ -12,7 +12,7 @@
 #include <uct/api/uct.h>
 
 
-#define UCP_DEVICE_MEM_LIST_VERSION_V1 2
+#define UCP_DEVICE_MEM_LIST_VERSION 3
 
 
 /**

--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -147,7 +147,9 @@ ucp_device_get_tl_bitmap(const ucp_worker_h worker,
                          ucp_tl_bitmap_t tl_bitmap[UCP_DEVICE_TL_TYPE_LAST],
                          ucs_sys_device_t local_sys_dev)
 {
+    ucp_rsc_index_t last_pow2_bit[UCP_DEVICE_TL_TYPE_LAST];
     const ucp_worker_iface_t *wiface;
+    ucp_tl_bitmap_t mask;
     ucp_rsc_index_t tl_id;
     int tl_type;
 
@@ -155,6 +157,7 @@ ucp_device_get_tl_bitmap(const ucp_worker_h worker,
     for (tl_type = UCP_DEVICE_TL_TYPE_FIRST;
          tl_type < UCP_DEVICE_TL_TYPE_LAST; tl_type++) {
         UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap[tl_type]);
+        last_pow2_bit[tl_type] = 0;
     }
 
     UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &worker->context->tl_bitmap) {
@@ -174,7 +177,17 @@ ucp_device_get_tl_bitmap(const ucp_worker_h worker,
         } else {
             tl_type = UCP_DEVICE_TL_TYPE_NOLKEY;
         }
+
         UCS_STATIC_BITMAP_SET(&tl_bitmap[tl_type], tl_id);
+        if (ucs_is_pow2(UCS_STATIC_BITMAP_POPCOUNT(tl_bitmap[tl_type]))) {
+            last_pow2_bit[tl_type] = tl_id;
+        }
+    }
+
+    for (tl_type = UCP_DEVICE_TL_TYPE_FIRST;
+         tl_type < UCP_DEVICE_TL_TYPE_LAST; tl_type++) {
+        UCS_STATIC_BITMAP_MASK(&mask, last_pow2_bit[tl_type] + 1);
+        UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap[tl_type], mask);
     }
 }
 
@@ -296,10 +309,11 @@ static ucs_status_t ucp_device_local_mem_list_create_handle(
         ucp_element = UCS_PTR_BYTE_OFFSET(ucp_element, params->element_size);
     }
 
-    handle->version = UCP_DEVICE_MEM_LIST_VERSION_V1;
-    handle->length  = params->num_elements;
-    handle->num_lanes = num_lanes;
-    status          = ucp_device_mem_list_export_handle(
+    handle->version         = UCP_DEVICE_MEM_LIST_VERSION_V1;
+    handle->length          = params->num_elements;
+    handle->num_lanes_mask  = num_lanes - 1;
+    handle->num_lanes_shift = ucs_ilog2(num_lanes);
+    status                  = ucp_device_mem_list_export_handle(
             worker, handle, handle_size, mem_type, local_sys_dev, mem,
             "ucp_device_local_mem_list_handle_t");
 
@@ -616,10 +630,11 @@ static ucs_status_t ucp_device_remote_mem_list_create_handle(
         ucp_element = UCS_PTR_BYTE_OFFSET(ucp_element, params->element_size);
     }
 
-    handle->version = UCP_DEVICE_MEM_LIST_VERSION_V1;
-    handle->length  = params->num_elements;
-    handle->num_lanes = num_lanes;
-    status          = ucp_device_mem_list_export_handle(
+    handle->version         = UCP_DEVICE_MEM_LIST_VERSION_V1;
+    handle->length          = params->num_elements;
+    handle->num_lanes_mask  = num_lanes - 1;
+    handle->num_lanes_shift = ucs_ilog2(num_lanes);
+    status                  = ucp_device_mem_list_export_handle(
             ep->worker, handle, handle_size, mem_type, local_sys_dev, mem,
             "ucp_device_remote_mem_list_handle_t");
 

--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -184,8 +184,8 @@ ucp_device_get_tl_bitmap(const ucp_worker_h worker,
         }
     }
 
-    for (tl_type = UCP_DEVICE_TL_TYPE_FIRST;
-         tl_type < UCP_DEVICE_TL_TYPE_LAST; tl_type++) {
+    for (tl_type = UCP_DEVICE_TL_TYPE_FIRST; tl_type < UCP_DEVICE_TL_TYPE_LAST;
+         tl_type++) {
         UCS_STATIC_BITMAP_MASK(&mask, last_pow2_bit[tl_type] + 1);
         UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap[tl_type], mask);
     }
@@ -309,7 +309,8 @@ static ucs_status_t ucp_device_local_mem_list_create_handle(
         ucp_element = UCS_PTR_BYTE_OFFSET(ucp_element, params->element_size);
     }
 
-    handle->version         = UCP_DEVICE_MEM_LIST_VERSION_V1;
+    UCS_STATIC_ASSERT(UCP_MAX_LANES <= 255);
+    handle->version         = UCP_DEVICE_MEM_LIST_VERSION;
     handle->length          = params->num_elements;
     handle->num_lanes_mask  = num_lanes - 1;
     handle->num_lanes_shift = ucs_ilog2(num_lanes);
@@ -579,6 +580,7 @@ static ucs_status_t ucp_device_remote_mem_list_create_handle(
     /* handle->num_lanes is the least common multiple of both lane types, so:
      * - each lane is replicated num_lanes / popcount(tl_bitmap) times
      * - channel_id % num_lanes maps to the correct lane, regardless of lane type
+     * handle->num_lanes is always power of 2
      */
     num_lanes = UCS_STATIC_BITMAP_POPCOUNT(tl_bitmap[UCP_DEVICE_TL_TYPE_LKEY]);
     if (!num_lanes) {
@@ -630,7 +632,7 @@ static ucs_status_t ucp_device_remote_mem_list_create_handle(
         ucp_element = UCS_PTR_BYTE_OFFSET(ucp_element, params->element_size);
     }
 
-    handle->version         = UCP_DEVICE_MEM_LIST_VERSION_V1;
+    handle->version         = UCP_DEVICE_MEM_LIST_VERSION;
     handle->length          = params->num_elements;
     handle->num_lanes_mask  = num_lanes - 1;
     handle->num_lanes_shift = ucs_ilog2(num_lanes);


### PR DESCRIPTION
## Why?
Ensuring that the number of lanes is always a power of two and using bitwise operations to select the lane improves `ucp_device_put` time by ~100ns.