### PR TITLE
UCP/PROTO: Prevent emulated protocol usage in progress callback

### DIFF
--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -15,7 +15,6 @@
 
 #include <ucp/am/ucp_am.inl>
 #include <ucp/core/ucp_worker.inl>
-#include <ucs/memory/memory_type.h>
 #include <ucs/sys/math.h>
 
 
@@ -44,37 +43,6 @@ static void ucp_proto_reconfig_abort(ucp_request_t *req, ucs_status_t status)
     ucp_request_complete_send(req, status);
 }
 
-static int
-ucp_proto_reconfig_report_no_rma_emulation_no_proto(ucp_request_t *req,
-                                                    ucp_ep_h ep)
-{
-    ucp_operation_id_t op_id;
-    ucs_memory_type_t local_mem_type, remote_mem_type;
-
-    if (ep->worker->context->config.ext.proto_emulation_enable) {
-        return 0;
-    }
-
-    op_id = ucp_proto_select_op_id(&req->send.proto_config->select_param);
-    if (((op_id != UCP_OP_ID_PUT) && (op_id != UCP_OP_ID_GET))) {
-        return 0;
-    }
-
-    local_mem_type  = req->send.proto_config->select_param.mem_type;
-    remote_mem_type = req->send.rma.rkey->mem_type;
-
-    ucs_error("No zero-copy protocol found for %s %s %s %s, %zu bytes. "
-              "Please check for proper GPU and/or HCA support, or set "
-              "UCX_PROTO_EMULATION_ENABLE=y to proceed by allowing slower "
-              "software emulation.",
-              (op_id == UCP_OP_ID_PUT) ? "put from" : "get into",
-              ucs_memory_type_names[local_mem_type],
-              (op_id == UCP_OP_ID_PUT) ? "to" : "from",
-              ucs_memory_type_names[remote_mem_type],
-              req->send.state.dt_iter.length);
-    return 1;
-}
-
 static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
@@ -84,11 +52,6 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
 
     /* This protocol should not be selected for valid and connected endpoint */
     if (ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED) {
-        if (ucp_proto_reconfig_report_no_rma_emulation_no_proto(req, ep)) {
-            ucp_proto_request_abort(req, UCS_ERR_CANCELED);
-            return UCS_OK;
-        }
-
         ucp_ep_config_name(ep->worker, req->send.proto_config->ep_cfg_index,
                            &strb);
         ucs_string_buffer_appendf(&strb, " | ");

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -48,7 +48,7 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        if (ucs_unlikely(ucp_proto_rma_emulation_abort(req))) {
+        if (ucp_proto_rma_emulation_abort(req)) {
             return UCS_OK;
         }
 

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -48,6 +48,10 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        if (ucs_unlikely(ucp_proto_rma_emulation_abort(req))) {
+            return UCS_OK;
+        }
+
         status = ucp_ep_resolve_remote_id(ep, spriv->super.lane);
         if (status != UCS_OK) {
             return status;
@@ -108,10 +112,6 @@ ucp_proto_get_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {
-        return;
-    }
-
-    if (!init_params->worker->context->config.ext.proto_emulation_enable) {
         return;
     }
 

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -57,7 +57,7 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        if (ucs_unlikely(ucp_proto_rma_emulation_abort(req))) {
+        if (ucp_proto_rma_emulation_abort(req)) {
             return UCS_OK;
         }
 

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -57,6 +57,10 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        if (ucs_unlikely(ucp_proto_rma_emulation_abort(req))) {
+            return UCS_OK;
+        }
+
         status = ucp_ep_resolve_remote_id(req->send.ep,
                                           mpriv->lanes[0].super.lane);
         if (status != UCS_OK) {
@@ -116,10 +120,6 @@ ucp_proto_put_am_bcopy_probe(const ucp_proto_init_params_t *init_params)
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
-        return;
-    }
-
-    if (!init_params->worker->context->config.ext.proto_emulation_enable) {
         return;
     }
 

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -11,6 +11,8 @@
 
 #include <ucp/api/ucp.h>
 #include <ucp/core/ucp_request.inl>
+#include <ucp/proto/proto_common.h>
+#include <ucp/proto/proto_select.inl>
 #include <ucs/debug/log.h>
 
 
@@ -142,6 +144,41 @@ ucp_proto_sw_rma_cfg_thresh(ucp_context_h context, size_t default_value)
     return (context->config.ext.prefer_offload == UCS_YES) ?
            UCS_MEMUNITS_INF: /* used only as last resort */
            default_value;
+}
+
+static UCS_F_ALWAYS_INLINE int ucp_proto_rma_emulation_abort(ucp_request_t *req)
+{
+    ucp_operation_id_t op_id;
+    const char *op_name;
+    ucs_memory_type_t local_mem_type, remote_mem_type;
+
+    if (ucs_likely(req->send.ep->worker->context->config.ext
+                           .proto_emulation_enable)) {
+        return 0;
+    }
+
+    if (req->send.state.dt_iter.length == 0) {
+        return 0;
+    }
+
+    op_id   = ucp_proto_select_op_id(&req->send.proto_config->select_param);
+    op_name = ((op_id <= UCP_OP_ID_LAST) &&
+               (ucp_operation_names[op_id] != NULL)) ?
+               ucp_operation_names[op_id] : "unknown";
+
+    local_mem_type  = req->send.proto_config->select_param.mem_type;
+    remote_mem_type = req->send.rma.rkey->mem_type;
+
+    ucs_error("No zero-copy protocol found for %s (op_id %u), %s -> %s, %zu "
+              "bytes. "
+              "Please check for proper GPU and/or HCA support, or set "
+              "UCX_PROTO_EMULATION_ENABLE=y to proceed by allowing slower "
+              "software emulation.",
+              op_name, (unsigned)op_id, ucs_memory_type_names[local_mem_type],
+              ucs_memory_type_names[remote_mem_type],
+              req->send.state.dt_iter.length);
+    ucp_proto_request_abort(req, UCS_ERR_CANCELED);
+    return 1;
 }
 
 static UCS_F_ALWAYS_INLINE int


### PR DESCRIPTION
## What?
Rework #11289.

## Why?
For instance with `UCX_NET_DEVICES=eth0`, it is possible that TCP AM lane is ready but endpoint is still not remote connected, as WIREUP exchange has not been performed yet. In that scheme, a PUT already resolved to `proto_reconfig` will busy loop between `ucp_request_send()` and `ucp_pending_add()` as TCP is ready to send.

With emulated protocol available in such case, the put can be sent before WIREUP exchange completion.

## How?
Cancel request when actually trying to progress an emulated protocol.
```
./test/gtest/gtest --gtest_filter=*emulated*

UCX_PROTO_EMULATION_ENABLE=n \
UCX_TLS=tcp,cuda_copy UCX_PROTO_INFO=y \
UCX_NET_DEVICES=ens10f0 \
    ./rfs/bin/ucx_perftest -t ucp_put_bw -m cuda