### PR TITLE
BUILD/CI: Run static checks in parallel

### DIFF
--- a/buildlib/pr/basic_compile.yml
+++ b/buildlib/pr/basic_compile.yml
@@ -1,0 +1,42 @@
+jobs:
+  - job: basic_compile
+    displayName: Basic compile
+    pool:
+      name: MLNX
+      demands:
+        - ucx_docker
+    container: ubuntu2404
+    workspace:
+      clean: all
+    timeoutInMinutes: 60
+
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        fetchTags: false
+        retryCountOnTaskFailure: 5
+
+      - bash: |
+          set -eEx
+          BUILD_ID="${BUILD_BUILDID}-${BUILD_BUILDNUMBER}"
+          source buildlib/tools/common.sh
+          cd "${WORKSPACE}"
+          rm -rf "${ucx_build_dir}"
+          ./autogen.sh
+          mkdir -p "${ucx_build_dir}"
+          cd "${ucx_build_dir}"
+          "${WORKSPACE}/contrib/configure-devel" \
+              --disable-gtest \
+              --disable-examples \
+              --disable-test-apps \
+              --disable-dependency-tracking \
+              --disable-static \
+              --without-go \
+              --without-java \
+              --without-valgrind \
+              --enable-compiler-opt=0 \
+              CFLAGS="-g0" \
+              CXXFLAGS="-g0"
+          make -j${parallel_jobs}
+        displayName: Basic compile

--- a/buildlib/pr/basic_compile.yml
+++ b/buildlib/pr/basic_compile.yml
@@ -21,11 +21,7 @@ jobs:
           set -eEx
           BUILD_ID="${BUILD_BUILDID}-${BUILD_BUILDNUMBER}"
           source buildlib/tools/common.sh
-          cd "${WORKSPACE}"
-          rm -rf "${ucx_build_dir}"
-          ./autogen.sh
-          mkdir -p "${ucx_build_dir}"
-          cd "${ucx_build_dir}"
+          prepare_build
           "${WORKSPACE}/contrib/configure-devel" \
               --disable-gtest \
               --disable-examples \

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -261,7 +261,7 @@ stages:
     - template: static_checks.yml
 
   - stage: Build
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
       - template: build_job.yml
         parameters:
@@ -278,7 +278,7 @@ stages:
           displayName: Build on aarch64
 
   - stage: ucx_perftest_mad_rte
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     displayName: ucx_perftest over MAD RTE
     lockBehavior: sequential
     variables:
@@ -287,7 +287,7 @@ stages:
     - template: mad_tests.yml
 
   - stage: WireCompat
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
     - template: wire_compat.yml
       parameters:
@@ -326,7 +326,7 @@ stages:
           container: coverity_rh7
 
   - stage: Tests
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
     - template: tests.yml
       parameters:
@@ -357,7 +357,7 @@ stages:
         test_perf: 0
 
   - stage: EFA_Tests
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
     - template: efa.yml
       parameters:
@@ -365,7 +365,7 @@ stages:
         demands: ucx_new -equals yes
 
   - stage: Namespace_Tests
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
     - template: namespace_tests.yml
       parameters:
@@ -373,13 +373,13 @@ stages:
         demands: ucx_new -equals yes
 
   - stage: io_demo
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     condition: false
     jobs:
     - template: io_demo/io-demo.yml
 
   - stage: jucx
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
       - template: ../jucx/jucx-test.yml
         parameters:
@@ -393,7 +393,7 @@ stages:
           demands: ucx-arm64
 
   - stage: go
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
       - template: go/go-test.yml
         parameters:
@@ -405,7 +405,7 @@ stages:
             demands: ucx_gpu -equals yes
 
   - stage: Build_Static
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
       - job: build_source
         pool:
@@ -451,7 +451,7 @@ stages:
 
 
   - stage: Cuda
-    dependsOn: [Static_check]
+    dependsOn: [Codestyle]
     jobs:
       - template: cuda/cuda.yml
 
@@ -489,6 +489,6 @@ stages:
 
 
 #  - stage: Cuda_compatible
-#    dependsOn: [Static_check]
+#    dependsOn: [Codestyle]
 #    jobs:
 #    - template: cuda/cuda_compatible.yml

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -255,13 +255,18 @@ stages:
     jobs:
     - template: codestyle.yml
 
+  - stage: Basic_compile
+    dependsOn: []
+    jobs:
+    - template: basic_compile.yml
+
   - stage: Static_check
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
     - template: static_checks.yml
 
   - stage: Build
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
       - template: build_job.yml
         parameters:
@@ -278,7 +283,7 @@ stages:
           displayName: Build on aarch64
 
   - stage: ucx_perftest_mad_rte
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     displayName: ucx_perftest over MAD RTE
     lockBehavior: sequential
     variables:
@@ -287,7 +292,7 @@ stages:
     - template: mad_tests.yml
 
   - stage: WireCompat
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
     - template: wire_compat.yml
       parameters:
@@ -326,7 +331,7 @@ stages:
           container: coverity_rh7
 
   - stage: Tests
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
     - template: tests.yml
       parameters:
@@ -357,7 +362,7 @@ stages:
         test_perf: 0
 
   - stage: EFA_Tests
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
     - template: efa.yml
       parameters:
@@ -365,7 +370,7 @@ stages:
         demands: ucx_new -equals yes
 
   - stage: Namespace_Tests
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
     - template: namespace_tests.yml
       parameters:
@@ -373,13 +378,13 @@ stages:
         demands: ucx_new -equals yes
 
   - stage: io_demo
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     condition: false
     jobs:
     - template: io_demo/io-demo.yml
 
   - stage: jucx
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
       - template: ../jucx/jucx-test.yml
         parameters:
@@ -393,7 +398,7 @@ stages:
           demands: ucx-arm64
 
   - stage: go
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
       - template: go/go-test.yml
         parameters:
@@ -405,7 +410,7 @@ stages:
             demands: ucx_gpu -equals yes
 
   - stage: Build_Static
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
       - job: build_source
         pool:
@@ -451,7 +456,7 @@ stages:
 
 
   - stage: Cuda
-    dependsOn: [Codestyle]
+    dependsOn: [Basic_compile]
     jobs:
       - template: cuda/cuda.yml
 
@@ -489,6 +494,6 @@ stages:
 
 
 #  - stage: Cuda_compatible
-#    dependsOn: [Codestyle]
+#    dependsOn: [Basic_compile]
 #    jobs:
 #    - template: cuda/cuda_compatible.yml


### PR DESCRIPTION
Reduce PR testing time by adding a lightweight `Basic_compile` stage before the heavier CI stages.

`Basic_compile` runs on `ubuntu2404`, skips tags on checkout, disables tests/examples/bindings/static/dependency tracking/valgrind, and builds the global `make` target with `--enable-compiler-opt=0` and `-g0`.

`Static_check` now runs in parallel with most stages; `Coverity` and `AddressSanitizer` still depend on it.
