### PR TITLE
UCT/CUDA: Skip CUDA cleanup for destroyed contexts

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -315,11 +315,25 @@ ucs_status_t uct_cuda_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_OK;
 }
 
-void uct_cuda_base_stream_destroy(CUstream *stream)
+static int uct_cuda_base_is_ctx_rsc_valid(const uct_cuda_ctx_rsc_t *ctx_rsc)
 {
-    if (*stream != NULL) {
-        (void)UCT_CUDADRV_FUNC_LOG_WARN(cuStreamDestroy(*stream));
+    unsigned version;
+    ucs_status_t status;
+
+    /* Avoid CUDA destroy calls after the application reset the context. */
+    status = UCT_CUDADRV_FUNC_LOG_DEBUG(
+                    cuCtxGetApiVersion(ctx_rsc->ctx, &version));
+    return (status == UCS_OK);
+}
+
+void uct_cuda_base_stream_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
+                                  CUstream *stream)
+{
+    if ((*stream == NULL) || !uct_cuda_base_is_ctx_rsc_valid(ctx_rsc)) {
+        return;
     }
+
+    (void)UCT_CUDADRV_FUNC_LOG_WARN(cuStreamDestroy(*stream));
 }
 
 static void
@@ -334,8 +348,12 @@ uct_cuda_base_event_desc_init(ucs_mpool_t *mp, void *obj, void *chunk)
 static void uct_cuda_base_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
 {
     uct_cuda_event_desc_t *event_desc = obj;
+    uct_cuda_ctx_rsc_t *ctx_rsc       = ucs_container_of(mp, uct_cuda_ctx_rsc_t,
+                                                         event_mp);
 
-    (void)UCT_CUDADRV_FUNC_LOG_WARN(cuEventDestroy(event_desc->event));
+    if (uct_cuda_base_is_ctx_rsc_valid(ctx_rsc)) {
+        (void)UCT_CUDADRV_FUNC_LOG_WARN(cuEventDestroy(event_desc->event));
+    }
 }
 
 void uct_cuda_base_queue_desc_init(uct_cuda_queue_desc_t *qdesc)
@@ -353,7 +371,7 @@ void uct_cuda_base_queue_desc_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
                  ucs_queue_length(&qdesc->event_queue));
     }
 
-    uct_cuda_base_stream_destroy(&qdesc->stream);
+    uct_cuda_base_stream_destroy(ctx_rsc, &qdesc->stream);
 }
 
 static ucs_mpool_ops_t uct_cuda_event_desc_mpool_ops = {

--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -315,25 +315,63 @@ ucs_status_t uct_cuda_base_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_OK;
 }
 
-static int uct_cuda_base_is_ctx_rsc_valid(const uct_cuda_ctx_rsc_t *ctx_rsc)
+static ucs_status_t
+uct_cuda_base_ctx_rsc_push(const uct_cuda_ctx_rsc_t *ctx_rsc, int *pushed)
 {
-    unsigned version;
+    CUcontext primary_ctx;
     ucs_status_t status;
 
-    /* Avoid CUDA destroy calls after the application reset the context. */
-    status = UCT_CUDADRV_FUNC_LOG_DEBUG(
-                    cuCtxGetApiVersion(ctx_rsc->ctx, &version));
-    return (status == UCS_OK);
+    *pushed = 0;
+    if (ctx_rsc->primary_ctx == NULL) {
+        return UCS_OK;
+    }
+
+    status = uct_cuda_ctx_primary_retain(ctx_rsc->cuda_device, 0,
+                                         &primary_ctx);
+    if (status == UCS_ERR_NO_DEVICE) {
+        return status;
+    } else if (status != UCS_OK) {
+        return status;
+    }
+
+    if (primary_ctx != ctx_rsc->primary_ctx) {
+        UCT_CUDADRV_FUNC_LOG_WARN(
+                cuDevicePrimaryCtxRelease(ctx_rsc->cuda_device));
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxPushCurrent(primary_ctx));
+    UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(ctx_rsc->cuda_device));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *pushed = 1;
+    return UCS_OK;
+}
+
+static void uct_cuda_base_ctx_rsc_pop(int pushed)
+{
+    if (pushed) {
+        UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
+    }
 }
 
 void uct_cuda_base_stream_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
                                   CUstream *stream)
 {
-    if ((*stream == NULL) || !uct_cuda_base_is_ctx_rsc_valid(ctx_rsc)) {
+    int pushed;
+
+    if (*stream == NULL) {
+        return;
+    }
+
+    if (uct_cuda_base_ctx_rsc_push(ctx_rsc, &pushed) != UCS_OK) {
         return;
     }
 
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuStreamDestroy(*stream));
+    uct_cuda_base_ctx_rsc_pop(pushed);
 }
 
 static void
@@ -350,10 +388,14 @@ static void uct_cuda_base_event_desc_cleanup(ucs_mpool_t *mp, void *obj)
     uct_cuda_event_desc_t *event_desc = obj;
     uct_cuda_ctx_rsc_t *ctx_rsc       = ucs_container_of(mp, uct_cuda_ctx_rsc_t,
                                                          event_mp);
+    int pushed;
 
-    if (uct_cuda_base_is_ctx_rsc_valid(ctx_rsc)) {
-        (void)UCT_CUDADRV_FUNC_LOG_WARN(cuEventDestroy(event_desc->event));
+    if (uct_cuda_base_ctx_rsc_push(ctx_rsc, &pushed) != UCS_OK) {
+        return;
     }
+
+    (void)UCT_CUDADRV_FUNC_LOG_WARN(cuEventDestroy(event_desc->event));
+    uct_cuda_base_ctx_rsc_pop(pushed);
 }
 
 void uct_cuda_base_queue_desc_init(uct_cuda_queue_desc_t *qdesc)
@@ -381,6 +423,52 @@ static ucs_mpool_ops_t uct_cuda_event_desc_mpool_ops = {
     .obj_cleanup   = uct_cuda_base_event_desc_cleanup,
     .obj_str       = NULL
 };
+
+static void uct_cuda_base_ctx_rsc_release_primary_ctx(
+        uct_cuda_ctx_rsc_t *ctx_rsc)
+{
+    if (ctx_rsc->primary_ctx == NULL) {
+        return;
+    }
+
+    UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(ctx_rsc->cuda_device));
+    ctx_rsc->primary_ctx = NULL;
+    ctx_rsc->cuda_device = CU_DEVICE_INVALID;
+}
+
+static ucs_status_t
+uct_cuda_base_ctx_rsc_retain_primary_ctx(uct_cuda_ctx_rsc_t *ctx_rsc)
+{
+    CUcontext primary_ctx;
+    CUdevice cuda_device;
+    ucs_status_t status;
+
+    ctx_rsc->primary_ctx = NULL;
+    ctx_rsc->cuda_device = CU_DEVICE_INVALID;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&cuda_device));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_cuda_ctx_primary_retain(cuda_device, 0, &primary_ctx);
+    if (status == UCS_ERR_NO_DEVICE) {
+        return UCS_OK;
+    } else if (status != UCS_OK) {
+        return status;
+    }
+
+    if (primary_ctx != ctx_rsc->ctx) {
+        UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
+        ucs_debug("cuda context %p is not the primary context on device %d",
+                  ctx_rsc->ctx, cuda_device);
+        return UCS_OK;
+    }
+
+    ctx_rsc->primary_ctx = primary_ctx;
+    ctx_rsc->cuda_device = cuda_device;
+    return UCS_OK;
+}
 
 ucs_status_t uct_cuda_base_ctx_rsc_create(uct_cuda_iface_t *iface,
                                           unsigned long long ctx_id,
@@ -417,6 +505,14 @@ ucs_status_t uct_cuda_base_ctx_rsc_create(uct_cuda_iface_t *iface,
         goto err_del_iter;
     }
 
+    ctx_rsc->ctx    = ctx;
+    ctx_rsc->ctx_id = ctx_id;
+
+    status = uct_cuda_base_ctx_rsc_retain_primary_ctx(ctx_rsc);
+    if (status != UCS_OK) {
+        goto err_free_ctx_rsc;
+    }
+
     ucs_mpool_params_reset(&mp_params);
     mp_params.elem_size       = iface->config.event_desc_size;
     mp_params.elems_per_chunk = 128;
@@ -426,27 +522,34 @@ ucs_status_t uct_cuda_base_ctx_rsc_create(uct_cuda_iface_t *iface,
 
     status = ucs_mpool_init(&mp_params, &ctx_rsc->event_mp);
     if (status != UCS_OK) {
-        goto err_free_ctx_rsc;
+        goto err_release_primary_ctx;
     }
 
-    ctx_rsc->ctx                     = ctx;
-    ctx_rsc->ctx_id                  = ctx_id;
     kh_value(&iface->ctx_rscs, iter) = ctx_rsc;
     *ctx_rsc_p                       = ctx_rsc;
     return UCS_OK;
 
+err_release_primary_ctx:
+    uct_cuda_base_ctx_rsc_release_primary_ctx(ctx_rsc);
 err_free_ctx_rsc:
     iface->ops->destroy_rsc(&iface->super.super, ctx_rsc);
 err_del_iter:
     kh_del(cuda_ctx_rscs, &iface->ctx_rscs, iter);
-    return UCS_ERR_NO_MEMORY;
+    return status;
 }
 
 static void uct_cuda_base_ctx_rsc_destroy(uct_cuda_iface_t *iface,
                                           uct_cuda_ctx_rsc_t *ctx_rsc)
 {
+    CUcontext primary_ctx = ctx_rsc->primary_ctx;
+    CUdevice cuda_device  = ctx_rsc->cuda_device;
+
     ucs_mpool_cleanup(&ctx_rsc->event_mp, 1);
     iface->ops->destroy_rsc(&iface->super.super, ctx_rsc);
+
+    if (primary_ctx != NULL) {
+        UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_device));
+    }
 }
 
 static ucs_mpool_ops_t uct_cuda_flush_desc_mpool_ops = {

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -129,7 +129,8 @@ void uct_cuda_base_queue_desc_init(uct_cuda_queue_desc_t *qdesc);
 void uct_cuda_base_queue_desc_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
                                       uct_cuda_queue_desc_t *qdesc);
 
-void uct_cuda_base_stream_destroy(CUstream *stream);
+void uct_cuda_base_stream_destroy(const uct_cuda_ctx_rsc_t *ctx_rsc,
+                                  CUstream *stream);
 
 #if (__CUDACC_VER_MAJOR__ >= 100000)
 void CUDA_CB uct_cuda_base_iface_stream_cb_fxn(void *arg);

--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -61,6 +61,10 @@ typedef struct {
 typedef struct {
     /* CUDA context handle */
     CUcontext          ctx;
+    /* Retained CUDA primary context, if @ctx is a primary context */
+    CUcontext          primary_ctx;
+    /* CUDA device of @primary_ctx */
+    CUdevice           cuda_device;
     /* CUDA context id */
     unsigned long long ctx_id;
     /* pool of cuda events to check completion of memcpy operations */

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -310,7 +310,7 @@ static void uct_cuda_copy_ctx_rsc_destroy(uct_iface_h tl_iface,
         }
     }
 
-    uct_cuda_base_stream_destroy(&ctx_rsc->short_stream);
+    uct_cuda_base_stream_destroy(cuda_ctx_rsc, &ctx_rsc->short_stream);
     ucs_free(ctx_rsc);
 }
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -267,6 +267,7 @@ endif # HAVE_IB
 if HAVE_CUDA
 gtest_SOURCES += \
 	ucm/cuda_hooks.cc \
+	uct/cuda/test_cuda_ctx_cleanup.cc \
 	uct/cuda/test_switch_cuda_device.cc \
 	uct/cuda/test_cuda_ipc_md.cc \
 	uct/cuda/test_cuda_nvml.cc

--- a/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
+++ b/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
@@ -150,7 +150,11 @@ protected:
         pop_current_cuda_contexts(&popped);
         ASSERT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxReset(m_device));
         m_restore_current_ctx = popped;
-        m_ctx_retained = false;
+        /*
+         * cuDevicePrimaryCtxReset() does not release the retain taken by
+         * push_primary_ctx(), so cleanup() should still release it.
+         */
+        ASSERT_TRUE(m_ctx_retained);
     }
 
     static uct_cuda_ctx_rsc_t *create_rsc(uct_iface_h iface)

--- a/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
+++ b/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
@@ -203,6 +203,9 @@ protected:
             m_ctx_retained = false;
         }
 
+        restore_current_cuda_context(m_restore_current_ctx);
+        m_restore_current_ctx = 0;
+
         ucs::test::cleanup();
     }
 
@@ -258,16 +261,49 @@ protected:
         m_ctx_retained = false;
     }
 
+    void pop_current_cuda_contexts(int *popped)
+    {
+        CUcontext cuda_ctx;
+
+        *popped = 0;
+        for (;;) {
+            ASSERT_EQ(CUDA_SUCCESS, cuCtxGetCurrent(&cuda_ctx));
+            if (cuda_ctx == NULL) {
+                return;
+            }
+
+            ASSERT_EQ(CUDA_SUCCESS, cuCtxPopCurrent(NULL));
+            *popped = 1;
+        }
+    }
+
+    void restore_current_cuda_context(int popped)
+    {
+        CUcontext cuda_ctx;
+
+        if (!popped) {
+            return;
+        }
+
+        /* Restore the gtest CUDA guard context that was current before reset. */
+        ASSERT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxRetain(&cuda_ctx, m_device));
+        ASSERT_EQ(CUDA_SUCCESS, cuCtxPushCurrent(cuda_ctx));
+    }
+
     void reset_primary_ctx()
     {
         CUcontext cuda_ctx;
+        int popped;
 
         ASSERT_TRUE(m_ctx_pushed);
         ASSERT_EQ(CUDA_SUCCESS, cuCtxPopCurrent(&cuda_ctx));
         ASSERT_EQ(m_cuda_ctx, cuda_ctx);
         m_ctx_pushed = false;
 
+        /* Avoid resetting a primary context which is still current. */
+        pop_current_cuda_contexts(&popped);
         ASSERT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxReset(m_device));
+        m_restore_current_ctx = popped;
         m_ctx_retained = false;
     }
 
@@ -293,6 +329,7 @@ protected:
     CUdevice m_device = 0;
     bool m_ctx_pushed = false;
     bool m_ctx_retained = false;
+    int m_restore_current_ctx = 0;
 
 private:
     void init_iface()

--- a/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
+++ b/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
@@ -13,160 +13,6 @@ extern "C" {
 
 #include <cuda.h>
 
-#include <atomic>
-#include <cstdlib>
-#include <dlfcn.h>
-
-
-static std::atomic<bool>     g_destroy_audit(false);
-static std::atomic<bool>     g_primary_ctx_audit(false);
-static std::atomic<unsigned> g_event_destroy_count(0);
-static std::atomic<unsigned> g_stream_destroy_count(0);
-static std::atomic<unsigned> g_ctx_push_count(0);
-static std::atomic<unsigned> g_primary_ctx_retain_count(0);
-static std::atomic<unsigned> g_primary_ctx_release_count(0);
-
-template<typename func_t>
-static func_t cuda_real_func(const char *symbol)
-{
-    static void *handle = dlopen("libcuda.so.1", RTLD_NOW | RTLD_LOCAL);
-    void *func;
-
-    if (handle == NULL) {
-        abort();
-    }
-
-    func = dlsym(handle, symbol);
-    if (func == NULL) {
-        abort();
-    }
-
-    return reinterpret_cast<func_t>(func);
-}
-
-extern "C" CUresult cuEventDestroy_v2(CUevent event)
-{
-    typedef CUresult (*func_t)(CUevent);
-
-    if (g_destroy_audit.load(std::memory_order_relaxed)) {
-        ++g_event_destroy_count;
-        return CUDA_SUCCESS;
-    }
-
-    return cuda_real_func<func_t>("cuEventDestroy_v2")(event);
-}
-
-extern "C" CUresult cuStreamDestroy_v2(CUstream stream)
-{
-    typedef CUresult (*func_t)(CUstream);
-
-    if (g_destroy_audit.load(std::memory_order_relaxed)) {
-        ++g_stream_destroy_count;
-        return CUDA_SUCCESS;
-    }
-
-    return cuda_real_func<func_t>("cuStreamDestroy_v2")(stream);
-}
-
-extern "C" CUresult cuCtxPushCurrent(CUcontext ctx)
-{
-    typedef CUresult (*func_t)(CUcontext);
-    CUresult result;
-
-    result = cuda_real_func<func_t>("cuCtxPushCurrent_v2")(ctx);
-    if (g_destroy_audit.load(std::memory_order_relaxed) &&
-        (result == CUDA_SUCCESS)) {
-        ++g_ctx_push_count;
-    }
-
-    return result;
-}
-
-extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *ctx, CUdevice dev)
-{
-    typedef CUresult (*func_t)(CUcontext*, CUdevice);
-    CUresult result;
-
-    result = cuda_real_func<func_t>("cuDevicePrimaryCtxRetain")(ctx, dev);
-    if (g_primary_ctx_audit.load(std::memory_order_relaxed) &&
-        (result == CUDA_SUCCESS)) {
-        ++g_primary_ctx_retain_count;
-    }
-
-    return result;
-}
-
-extern "C" CUresult cuDevicePrimaryCtxRelease(CUdevice dev)
-{
-    typedef CUresult (*func_t)(CUdevice);
-    CUresult result;
-
-    result = cuda_real_func<func_t>("cuDevicePrimaryCtxRelease")(dev);
-    if (g_primary_ctx_audit.load(std::memory_order_relaxed) &&
-        (result == CUDA_SUCCESS)) {
-        ++g_primary_ctx_release_count;
-    }
-
-    return result;
-}
-
-
-class scoped_cuda_destroy_audit {
-public:
-    scoped_cuda_destroy_audit()
-    {
-        g_event_destroy_count.store(0, std::memory_order_relaxed);
-        g_stream_destroy_count.store(0, std::memory_order_relaxed);
-        g_ctx_push_count.store(0, std::memory_order_relaxed);
-        g_destroy_audit.store(true, std::memory_order_relaxed);
-    }
-
-    ~scoped_cuda_destroy_audit()
-    {
-        g_destroy_audit.store(false, std::memory_order_relaxed);
-    }
-
-    unsigned event_destroy_count() const
-    {
-        return g_event_destroy_count.load(std::memory_order_relaxed);
-    }
-
-    unsigned stream_destroy_count() const
-    {
-        return g_stream_destroy_count.load(std::memory_order_relaxed);
-    }
-
-    unsigned ctx_push_count() const
-    {
-        return g_ctx_push_count.load(std::memory_order_relaxed);
-    }
-};
-
-class scoped_cuda_primary_ctx_audit {
-public:
-    scoped_cuda_primary_ctx_audit()
-    {
-        g_primary_ctx_retain_count.store(0, std::memory_order_relaxed);
-        g_primary_ctx_release_count.store(0, std::memory_order_relaxed);
-        g_primary_ctx_audit.store(true, std::memory_order_relaxed);
-    }
-
-    ~scoped_cuda_primary_ctx_audit()
-    {
-        g_primary_ctx_audit.store(false, std::memory_order_relaxed);
-    }
-
-    unsigned retain_count() const
-    {
-        return g_primary_ctx_retain_count.load(std::memory_order_relaxed);
-    }
-
-    unsigned release_count() const
-    {
-        return g_primary_ctx_release_count.load(std::memory_order_relaxed);
-    }
-};
-
 
 class test_cuda_ctx_cleanup : public ucs::test {
 protected:
@@ -358,15 +204,11 @@ private:
 
 UCS_TEST_F(test_cuda_ctx_cleanup, retain_primary_ctx_until_rsc_cleanup)
 {
-    scoped_cuda_primary_ctx_audit audit;
-
     create_ctx_rsc();
-    EXPECT_EQ(1u, audit.retain_count());
     EXPECT_EQ(m_cuda_ctx, m_ctx_rsc->primary_ctx);
     EXPECT_EQ(m_device, m_ctx_rsc->cuda_device);
 
     destroy_ctx_rsc();
-    EXPECT_EQ(1u, audit.release_count());
 }
 
 UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_release)
@@ -382,11 +224,7 @@ UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_release)
 
     release_primary_ctx();
 
-    scoped_cuda_destroy_audit audit;
     ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
-    EXPECT_LT(0u, audit.ctx_push_count());
-    EXPECT_LT(0u, audit.event_destroy_count());
-
     free_ctx_rsc();
 }
 
@@ -401,11 +239,7 @@ UCS_TEST_F(test_cuda_ctx_cleanup, stream_cleanup_after_primary_ctx_release)
 
     release_primary_ctx();
 
-    scoped_cuda_destroy_audit audit;
     uct_cuda_base_queue_desc_destroy(m_ctx_rsc, &qdesc);
-    EXPECT_EQ(1u, audit.ctx_push_count());
-    EXPECT_EQ(1u, audit.stream_destroy_count());
-
     destroy_ctx_rsc();
 }
 
@@ -422,11 +256,7 @@ UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_reset)
 
     reset_primary_ctx();
 
-    scoped_cuda_destroy_audit audit;
     ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
-    EXPECT_EQ(0u, audit.ctx_push_count());
-    EXPECT_EQ(0u, audit.event_destroy_count());
-
     free_ctx_rsc();
 }
 
@@ -441,10 +271,6 @@ UCS_TEST_F(test_cuda_ctx_cleanup, stream_cleanup_after_primary_ctx_reset)
 
     reset_primary_ctx();
 
-    scoped_cuda_destroy_audit audit;
     uct_cuda_base_queue_desc_destroy(m_ctx_rsc, &qdesc);
-    EXPECT_EQ(0u, audit.ctx_push_count());
-    EXPECT_EQ(0u, audit.stream_destroy_count());
-
     destroy_ctx_rsc();
 }

--- a/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
+++ b/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
@@ -19,8 +19,12 @@ extern "C" {
 
 
 static std::atomic<bool>     g_destroy_audit(false);
+static std::atomic<bool>     g_primary_ctx_audit(false);
 static std::atomic<unsigned> g_event_destroy_count(0);
 static std::atomic<unsigned> g_stream_destroy_count(0);
+static std::atomic<unsigned> g_ctx_push_count(0);
+static std::atomic<unsigned> g_primary_ctx_retain_count(0);
+static std::atomic<unsigned> g_primary_ctx_release_count(0);
 
 template<typename func_t>
 static func_t cuda_real_func(const char *symbol)
@@ -64,6 +68,48 @@ extern "C" CUresult cuStreamDestroy_v2(CUstream stream)
     return cuda_real_func<func_t>("cuStreamDestroy_v2")(stream);
 }
 
+extern "C" CUresult cuCtxPushCurrent(CUcontext ctx)
+{
+    typedef CUresult (*func_t)(CUcontext);
+    CUresult result;
+
+    result = cuda_real_func<func_t>("cuCtxPushCurrent_v2")(ctx);
+    if (g_destroy_audit.load(std::memory_order_relaxed) &&
+        (result == CUDA_SUCCESS)) {
+        ++g_ctx_push_count;
+    }
+
+    return result;
+}
+
+extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *ctx, CUdevice dev)
+{
+    typedef CUresult (*func_t)(CUcontext*, CUdevice);
+    CUresult result;
+
+    result = cuda_real_func<func_t>("cuDevicePrimaryCtxRetain")(ctx, dev);
+    if (g_primary_ctx_audit.load(std::memory_order_relaxed) &&
+        (result == CUDA_SUCCESS)) {
+        ++g_primary_ctx_retain_count;
+    }
+
+    return result;
+}
+
+extern "C" CUresult cuDevicePrimaryCtxRelease(CUdevice dev)
+{
+    typedef CUresult (*func_t)(CUdevice);
+    CUresult result;
+
+    result = cuda_real_func<func_t>("cuDevicePrimaryCtxRelease")(dev);
+    if (g_primary_ctx_audit.load(std::memory_order_relaxed) &&
+        (result == CUDA_SUCCESS)) {
+        ++g_primary_ctx_release_count;
+    }
+
+    return result;
+}
+
 
 class scoped_cuda_destroy_audit {
 public:
@@ -71,6 +117,7 @@ public:
     {
         g_event_destroy_count.store(0, std::memory_order_relaxed);
         g_stream_destroy_count.store(0, std::memory_order_relaxed);
+        g_ctx_push_count.store(0, std::memory_order_relaxed);
         g_destroy_audit.store(true, std::memory_order_relaxed);
     }
 
@@ -87,6 +134,36 @@ public:
     unsigned stream_destroy_count() const
     {
         return g_stream_destroy_count.load(std::memory_order_relaxed);
+    }
+
+    unsigned ctx_push_count() const
+    {
+        return g_ctx_push_count.load(std::memory_order_relaxed);
+    }
+};
+
+class scoped_cuda_primary_ctx_audit {
+public:
+    scoped_cuda_primary_ctx_audit()
+    {
+        g_primary_ctx_retain_count.store(0, std::memory_order_relaxed);
+        g_primary_ctx_release_count.store(0, std::memory_order_relaxed);
+        g_primary_ctx_audit.store(true, std::memory_order_relaxed);
+    }
+
+    ~scoped_cuda_primary_ctx_audit()
+    {
+        g_primary_ctx_audit.store(false, std::memory_order_relaxed);
+    }
+
+    unsigned retain_count() const
+    {
+        return g_primary_ctx_retain_count.load(std::memory_order_relaxed);
+    }
+
+    unsigned release_count() const
+    {
+        return g_primary_ctx_release_count.load(std::memory_order_relaxed);
     }
 };
 
@@ -112,11 +189,7 @@ protected:
 
     void cleanup() override
     {
-        if (m_ctx_rsc != NULL) {
-            ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
-            destroy_rsc(NULL, m_ctx_rsc);
-            m_ctx_rsc = NULL;
-        }
+        destroy_ctx_rsc();
 
         kh_destroy_inplace(cuda_ctx_rscs, &m_iface.ctx_rscs);
 
@@ -138,6 +211,52 @@ protected:
         ASSERT_UCS_OK(uct_cuda_base_ctx_rsc_create(&m_iface, 1, &m_ctx_rsc));
     }
 
+    void release_ctx_rsc_primary_ctx()
+    {
+        if ((m_ctx_rsc == NULL) || (m_ctx_rsc->primary_ctx == NULL)) {
+            return;
+        }
+
+        cuDevicePrimaryCtxRelease(m_ctx_rsc->cuda_device);
+        m_ctx_rsc->primary_ctx = NULL;
+        m_ctx_rsc->cuda_device = CU_DEVICE_INVALID;
+    }
+
+    void free_ctx_rsc()
+    {
+        if (m_ctx_rsc == NULL) {
+            return;
+        }
+
+        release_ctx_rsc_primary_ctx();
+        destroy_rsc(NULL, m_ctx_rsc);
+        m_ctx_rsc = NULL;
+    }
+
+    void destroy_ctx_rsc()
+    {
+        if (m_ctx_rsc == NULL) {
+            return;
+        }
+
+        ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
+        free_ctx_rsc();
+    }
+
+    void release_primary_ctx()
+    {
+        CUcontext cuda_ctx;
+
+        ASSERT_TRUE(m_ctx_pushed);
+        ASSERT_EQ(CUDA_SUCCESS, cuCtxPopCurrent(&cuda_ctx));
+        ASSERT_EQ(m_cuda_ctx, cuda_ctx);
+        m_ctx_pushed = false;
+
+        ASSERT_TRUE(m_ctx_retained);
+        ASSERT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxRelease(m_device));
+        m_ctx_retained = false;
+    }
+
     void reset_primary_ctx()
     {
         CUcontext cuda_ctx;
@@ -148,6 +267,7 @@ protected:
         m_ctx_pushed = false;
 
         ASSERT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxReset(m_device));
+        m_ctx_retained = false;
     }
 
     static uct_cuda_ctx_rsc_t *create_rsc(uct_iface_h iface)
@@ -198,6 +318,59 @@ private:
     }
 };
 
+UCS_TEST_F(test_cuda_ctx_cleanup, retain_primary_ctx_until_rsc_cleanup)
+{
+    scoped_cuda_primary_ctx_audit audit;
+
+    create_ctx_rsc();
+    EXPECT_EQ(1u, audit.retain_count());
+    EXPECT_EQ(m_cuda_ctx, m_ctx_rsc->primary_ctx);
+    EXPECT_EQ(m_device, m_ctx_rsc->cuda_device);
+
+    destroy_ctx_rsc();
+    EXPECT_EQ(1u, audit.release_count());
+}
+
+UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_release)
+{
+    uct_cuda_event_desc_t *event_desc;
+
+    create_ctx_rsc();
+
+    event_desc = static_cast<uct_cuda_event_desc_t*>(
+            ucs_mpool_get(&m_ctx_rsc->event_mp));
+    ASSERT_NE(nullptr, event_desc);
+    ucs_mpool_put(event_desc);
+
+    release_primary_ctx();
+
+    scoped_cuda_destroy_audit audit;
+    ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
+    EXPECT_LT(0u, audit.ctx_push_count());
+    EXPECT_LT(0u, audit.event_destroy_count());
+
+    free_ctx_rsc();
+}
+
+UCS_TEST_F(test_cuda_ctx_cleanup, stream_cleanup_after_primary_ctx_release)
+{
+    uct_cuda_queue_desc_t qdesc;
+
+    create_ctx_rsc();
+
+    uct_cuda_base_queue_desc_init(&qdesc);
+    ASSERT_UCS_OK(uct_cuda_base_init_stream(&qdesc.stream));
+
+    release_primary_ctx();
+
+    scoped_cuda_destroy_audit audit;
+    uct_cuda_base_queue_desc_destroy(m_ctx_rsc, &qdesc);
+    EXPECT_EQ(1u, audit.ctx_push_count());
+    EXPECT_EQ(1u, audit.stream_destroy_count());
+
+    destroy_ctx_rsc();
+}
+
 UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_reset)
 {
     uct_cuda_event_desc_t *event_desc;
@@ -213,10 +386,10 @@ UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_reset)
 
     scoped_cuda_destroy_audit audit;
     ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
+    EXPECT_EQ(0u, audit.ctx_push_count());
     EXPECT_EQ(0u, audit.event_destroy_count());
 
-    destroy_rsc(NULL, m_ctx_rsc);
-    m_ctx_rsc = NULL;
+    free_ctx_rsc();
 }
 
 UCS_TEST_F(test_cuda_ctx_cleanup, stream_cleanup_after_primary_ctx_reset)
@@ -232,5 +405,8 @@ UCS_TEST_F(test_cuda_ctx_cleanup, stream_cleanup_after_primary_ctx_reset)
 
     scoped_cuda_destroy_audit audit;
     uct_cuda_base_queue_desc_destroy(m_ctx_rsc, &qdesc);
+    EXPECT_EQ(0u, audit.ctx_push_count());
     EXPECT_EQ(0u, audit.stream_destroy_count());
+
+    destroy_ctx_rsc();
 }

--- a/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
+++ b/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <uct/cuda/base/cuda_iface.h>
+#include <ucs/datastruct/mpool.h>
+}
+
+#include <cuda.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <dlfcn.h>
+
+
+static std::atomic<bool>     g_destroy_audit(false);
+static std::atomic<unsigned> g_event_destroy_count(0);
+static std::atomic<unsigned> g_stream_destroy_count(0);
+
+template<typename func_t>
+static func_t cuda_real_func(const char *symbol)
+{
+    static void *handle = dlopen("libcuda.so.1", RTLD_NOW | RTLD_LOCAL);
+    void *func;
+
+    if (handle == NULL) {
+        abort();
+    }
+
+    func = dlsym(handle, symbol);
+    if (func == NULL) {
+        abort();
+    }
+
+    return reinterpret_cast<func_t>(func);
+}
+
+extern "C" CUresult cuEventDestroy_v2(CUevent event)
+{
+    typedef CUresult (*func_t)(CUevent);
+
+    if (g_destroy_audit.load(std::memory_order_relaxed)) {
+        ++g_event_destroy_count;
+        return CUDA_SUCCESS;
+    }
+
+    return cuda_real_func<func_t>("cuEventDestroy_v2")(event);
+}
+
+extern "C" CUresult cuStreamDestroy_v2(CUstream stream)
+{
+    typedef CUresult (*func_t)(CUstream);
+
+    if (g_destroy_audit.load(std::memory_order_relaxed)) {
+        ++g_stream_destroy_count;
+        return CUDA_SUCCESS;
+    }
+
+    return cuda_real_func<func_t>("cuStreamDestroy_v2")(stream);
+}
+
+
+class scoped_cuda_destroy_audit {
+public:
+    scoped_cuda_destroy_audit()
+    {
+        g_event_destroy_count.store(0, std::memory_order_relaxed);
+        g_stream_destroy_count.store(0, std::memory_order_relaxed);
+        g_destroy_audit.store(true, std::memory_order_relaxed);
+    }
+
+    ~scoped_cuda_destroy_audit()
+    {
+        g_destroy_audit.store(false, std::memory_order_relaxed);
+    }
+
+    unsigned event_destroy_count() const
+    {
+        return g_event_destroy_count.load(std::memory_order_relaxed);
+    }
+
+    unsigned stream_destroy_count() const
+    {
+        return g_stream_destroy_count.load(std::memory_order_relaxed);
+    }
+};
+
+
+class test_cuda_ctx_cleanup : public ucs::test {
+protected:
+    void init() override
+    {
+        int num_devices;
+
+        ucs::test::init();
+
+        ASSERT_EQ(CUDA_SUCCESS, cuInit(0));
+        ASSERT_EQ(CUDA_SUCCESS, cuDeviceGetCount(&num_devices));
+        if (num_devices == 0) {
+            UCS_TEST_SKIP_R("no cuda devices available");
+        }
+
+        ASSERT_EQ(CUDA_SUCCESS, cuDeviceGet(&m_device, 0));
+        init_iface();
+        push_primary_ctx();
+    }
+
+    void cleanup() override
+    {
+        if (m_ctx_rsc != NULL) {
+            ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
+            destroy_rsc(NULL, m_ctx_rsc);
+            m_ctx_rsc = NULL;
+        }
+
+        kh_destroy_inplace(cuda_ctx_rscs, &m_iface.ctx_rscs);
+
+        if (m_ctx_pushed) {
+            EXPECT_EQ(CUDA_SUCCESS, cuCtxPopCurrent(NULL));
+            m_ctx_pushed = false;
+        }
+
+        if (m_ctx_retained) {
+            EXPECT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxRelease(m_device));
+            m_ctx_retained = false;
+        }
+
+        ucs::test::cleanup();
+    }
+
+    void create_ctx_rsc()
+    {
+        ASSERT_UCS_OK(uct_cuda_base_ctx_rsc_create(&m_iface, 1, &m_ctx_rsc));
+    }
+
+    void reset_primary_ctx()
+    {
+        CUcontext cuda_ctx;
+
+        ASSERT_TRUE(m_ctx_pushed);
+        ASSERT_EQ(CUDA_SUCCESS, cuCtxPopCurrent(&cuda_ctx));
+        ASSERT_EQ(m_cuda_ctx, cuda_ctx);
+        m_ctx_pushed = false;
+
+        ASSERT_EQ(CUDA_SUCCESS, cuDevicePrimaryCtxReset(m_device));
+    }
+
+    static uct_cuda_ctx_rsc_t *create_rsc(uct_iface_h iface)
+    {
+        return static_cast<uct_cuda_ctx_rsc_t*>(
+                ucs_calloc(1, sizeof(uct_cuda_ctx_rsc_t),
+                           "test_cuda_ctx_rsc"));
+    }
+
+    static void destroy_rsc(uct_iface_h iface, uct_cuda_ctx_rsc_t *ctx_rsc)
+    {
+        ucs_free(ctx_rsc);
+    }
+
+    static void complete_event(uct_iface_h iface, uct_cuda_event_desc_t *event)
+    {
+    }
+
+    uct_cuda_iface_t m_iface = {};
+    uct_cuda_ctx_rsc_t *m_ctx_rsc = NULL;
+    CUcontext m_cuda_ctx = NULL;
+    CUdevice m_device = 0;
+    bool m_ctx_pushed = false;
+    bool m_ctx_retained = false;
+
+private:
+    void init_iface()
+    {
+        static uct_cuda_iface_ops_t iface_ops = {
+            create_rsc,
+            destroy_rsc,
+            complete_event
+        };
+
+        m_iface.ops                    = &iface_ops;
+        m_iface.config.event_desc_size = sizeof(uct_cuda_event_desc_t);
+        m_iface.config.max_events      = 128;
+        kh_init_inplace(cuda_ctx_rscs, &m_iface.ctx_rscs);
+    }
+
+    void push_primary_ctx()
+    {
+        ASSERT_EQ(CUDA_SUCCESS,
+                  cuDevicePrimaryCtxRetain(&m_cuda_ctx, m_device));
+        m_ctx_retained = true;
+        ASSERT_EQ(CUDA_SUCCESS, cuCtxPushCurrent(m_cuda_ctx));
+        m_ctx_pushed = true;
+    }
+};
+
+UCS_TEST_F(test_cuda_ctx_cleanup, event_cleanup_after_primary_ctx_reset)
+{
+    uct_cuda_event_desc_t *event_desc;
+
+    create_ctx_rsc();
+
+    event_desc = static_cast<uct_cuda_event_desc_t*>(
+            ucs_mpool_get(&m_ctx_rsc->event_mp));
+    ASSERT_NE(nullptr, event_desc);
+    ucs_mpool_put(event_desc);
+
+    reset_primary_ctx();
+
+    scoped_cuda_destroy_audit audit;
+    ucs_mpool_cleanup(&m_ctx_rsc->event_mp, 1);
+    EXPECT_EQ(0u, audit.event_destroy_count());
+
+    destroy_rsc(NULL, m_ctx_rsc);
+    m_ctx_rsc = NULL;
+}
+
+UCS_TEST_F(test_cuda_ctx_cleanup, stream_cleanup_after_primary_ctx_reset)
+{
+    uct_cuda_queue_desc_t qdesc;
+
+    create_ctx_rsc();
+
+    uct_cuda_base_queue_desc_init(&qdesc);
+    ASSERT_UCS_OK(uct_cuda_base_init_stream(&qdesc.stream));
+
+    reset_primary_ctx();
+
+    scoped_cuda_destroy_audit audit;
+    uct_cuda_base_queue_desc_destroy(m_ctx_rsc, &qdesc);
+    EXPECT_EQ(0u, audit.stream_destroy_count());
+}

--- a/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
+++ b/test/gtest/uct/cuda/test_cuda_ctx_cleanup.cc
@@ -217,7 +217,8 @@ protected:
             return;
         }
 
-        cuDevicePrimaryCtxRelease(m_ctx_rsc->cuda_device);
+        EXPECT_EQ(CUDA_SUCCESS,
+                  cuDevicePrimaryCtxRelease(m_ctx_rsc->cuda_device));
         m_ctx_rsc->primary_ctx = NULL;
         m_ctx_rsc->cuda_device = CU_DEVICE_INVALID;
     }


### PR DESCRIPTION
## What?
Avoid calling cuStreamDestroy or cuEventDestroy on resources from a context that is no longer valid

## Why?
CUDA may warn or crash in that path.
