### PR TITLE
AZP: Exclude .ci/ from PR pipeline trigger

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -10,6 +10,7 @@ pr:
   paths:
     exclude:
     - .agents
+    - .ci
     - .claude/skills
     - .gitignore
     - .readthedocs.yaml


### PR DESCRIPTION
## What?
Add `.ci/` to the path-exclude list for the AZP PR pipeline.

## Why?
The `.ci/` tree drives Jenkins/Blossom CI only. AZP runs aren't affected by changes there, so skip the AZP PR pipeline when only `.ci/` files are touched. Suggested in PR #11408 review.
