### PR TITLE
UCP/EP: fix discard_lanes_arg leak and OOO discard refcounter

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -77,8 +77,6 @@ typedef struct ucp_ep_discard_lanes_arg {
     ucp_ep_h               ucp_ep;
     /* Config to deactivate when discard completes */
     ucp_worker_cfg_index_t deactivate_cfg_index;
-    /* Config to activate when discard completes */
-    ucp_worker_cfg_index_t activate_cfg_index;
     /* Completion status of operations after discarding is * done */
     ucs_status_t           status;
 } ucp_ep_discard_lanes_arg_t;
@@ -142,7 +140,6 @@ static const uct_iface_ops_t ucp_failed_tl_iface_ops = {
 
 static ucp_ep_discard_lanes_arg_t ucp_failed_tl_ep_discard_arg = {
     .deactivate_cfg_index = UCP_WORKER_CFG_INDEX_NULL,
-    .activate_cfg_index   = UCP_WORKER_CFG_INDEX_NULL,
     .status               = UCS_ERR_CANCELED
 };
 
@@ -1443,8 +1440,13 @@ static void
 ucp_ep_config_deactivate_worker_ifaces(ucp_worker_h worker,
                                        ucp_worker_cfg_index_t cfg_index)
 {
-    ucp_ep_config_t *ep_config = ucp_worker_ep_config(worker, cfg_index);
+    ucp_ep_config_t *ep_config;
 
+    if (cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
+        return;
+    }
+
+    ep_config = ucp_worker_ep_config(worker, cfg_index);
     ucs_trace("deactivate wifaces worker %p ep config %u ep count %u", worker,
               cfg_index, ep_config->ep_count);
     ucs_assertv(ep_config->ep_count > 0, "worker %p ep config %u", worker,
@@ -1469,11 +1471,7 @@ ucp_ep_config_reactivate_worker_ifaces(ucp_worker_h worker,
         return;
     }
 
-    if (old_cfg_index != UCP_WORKER_CFG_INDEX_NULL) {
-        ucp_ep_config_deactivate_worker_ifaces(worker, old_cfg_index);
-    }
-
-    ucs_assert(new_cfg_index != UCP_WORKER_CFG_INDEX_NULL);
+    ucp_ep_config_deactivate_worker_ifaces(worker, old_cfg_index);
     ucp_ep_config_activate_worker_ifaces(worker, new_cfg_index);
 }
 
@@ -1491,9 +1489,8 @@ static void ucp_ep_discard_lanes_callback(void *request, ucs_status_t status,
 
     ucs_trace("ep %p: discard lanes completed", arg->ucp_ep);
     ucp_ep_reqs_purge(arg->ucp_ep, arg->status);
-    ucp_ep_config_reactivate_worker_ifaces(arg->ucp_ep->worker,
-                                           arg->deactivate_cfg_index,
-                                           arg->activate_cfg_index);
+    ucp_ep_config_deactivate_worker_ifaces(arg->ucp_ep->worker,
+                                           arg->deactivate_cfg_index);
     ucp_ep_release_discard_arg(arg);
 }
 
@@ -1558,9 +1555,17 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
     discard_arg->ucp_ep               = ep;
     discard_arg->discard_counter      = 1;
     discard_arg->destroy_counter      = ucs_popcount(lanes);
-    discard_arg->deactivate_cfg_index = old_cfg_index;
-    discard_arg->activate_cfg_index   = ep->cfg_index;
     discard_arg->status               = discard_status;
+
+    /* Activate ifaces for the new configuration upfront before discard callback
+     * completion to avoid race condition which leads to negative EP reference
+     * counter when discard callbacks run out of order */
+    if (old_cfg_index != ep->cfg_index) {
+        ucp_ep_config_activate_worker_ifaces(ep->worker, ep->cfg_index);
+        discard_arg->deactivate_cfg_index = old_cfg_index;
+    } else {
+        discard_arg->deactivate_cfg_index = UCP_WORKER_CFG_INDEX_NULL;
+    }
 
     ucs_debug("ep %p: discarding lanes", ep);
     ucp_ep_extract_failed_lanes(ep, lanes, &discard_arg->failed_ep, uct_eps);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -143,7 +143,7 @@ static ucp_ep_discard_lanes_arg_t ucp_failed_tl_ep_discard_arg = {
     .status               = UCS_ERR_CANCELED
 };
 
-static void ucp_ep_failed_tl_iface_init(void)
+static void ucp_failed_tl_iface_init(void)
 {
     uct_iface_close_func_t stub_close;
     ucs_status_t status;
@@ -165,6 +165,12 @@ UCS_STATIC_CLEANUP {
     UCS_CLEANUP_ONCE(&ucp_failed_tl_iface_once) {
         uct_iface_close(ucp_failed_tl_iface);
     }
+}
+
+uct_iface_h ucp_failed_tl_iface_get(void)
+{
+    ucp_failed_tl_iface_init();
+    return ucp_failed_tl_iface;
 }
 
 int ucp_is_uct_ep_failed(uct_ep_h uct_ep)
@@ -1540,8 +1546,6 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
         return;
     }
 
-    ucp_ep_failed_tl_iface_init();
-
     discard_arg = ucs_malloc(sizeof(*discard_arg), "discard_lanes_arg");
     if (discard_arg == NULL) {
         ucs_error("ep %p: failed to allocate memory for discarding lanes"
@@ -1551,7 +1555,7 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
         return;
     }
 
-    discard_arg->failed_ep.iface      = ucp_failed_tl_iface;
+    discard_arg->failed_ep.iface      = ucp_failed_tl_iface_get();
     discard_arg->ucp_ep               = ep;
     discard_arg->discard_counter      = 1;
     discard_arg->destroy_counter      = ucs_popcount(lanes);
@@ -1817,7 +1821,7 @@ void ucp_ep_cleanup_lanes(ucp_ep_h ep)
 
     ucs_debug("ep %p: cleanup lanes", ep);
 
-    ucp_ep_failed_tl_iface_init();
+    ucp_failed_tl_iface_init();
 
     ucp_ep_extract_failed_lanes(ep, UCS_MASK(ucp_ep_num_lanes(ep)),
                                 &ucp_failed_tl_ep_discard_arg.failed_ep,

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -675,6 +675,8 @@ typedef struct ucp_conn_request {
 
 int ucp_is_uct_ep_failed(uct_ep_h uct_ep);
 
+uct_iface_h ucp_failed_tl_iface_get(void);
+
 void ucp_ep_config_key_reset(ucp_ep_config_key_t *key);
 
 void ucp_ep_config_cm_lane_info_str(ucp_worker_h worker,

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3745,8 +3745,9 @@ ucp_worker_discard_tl_uct_ep(ucp_ep_h ucp_ep, uct_ep_h uct_ep,
     khiter_t iter;
 
     if (ucp_is_uct_ep_failed(uct_ep)) {
-        /* No need to discard failed TL EP, because it may lead to adding the
-         * same UCT EP to the hash of discarded UCT EPs */
+        /* Failed TL EPs do not enter the worker discard hash; destroy
+         * directly to take ownership of uct_ep from the caller. */
+        uct_ep_destroy(uct_ep);
         return UCS_OK;
     }
 

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -316,6 +316,11 @@ out:
         m_destroyed_ep_count++;
     }
 
+    static void failed_ep_destroy_func(uct_ep_h ep) {
+        m_failed_destroy_count++;
+        ep->iface = NULL;
+    }
+
     static ep_test_info_t& ep_test_info_get(uct_ep_h ep) {
         ep_test_info_map_t::iterator it = m_ep_test_info_map.find(ep);
 
@@ -417,6 +422,7 @@ out:
 protected:
     static       unsigned m_created_ep_count;
     static       unsigned m_destroyed_ep_count;
+    static       unsigned m_failed_destroy_count;
     static       ucp_ep_t m_fake_ep;
     static       ucp_ep_h m_ucp_ep;
     static const unsigned m_pending_purge_reqs_count;
@@ -428,6 +434,7 @@ protected:
 
 unsigned test_ucp_worker_discard::m_created_ep_count               = 0;
 unsigned test_ucp_worker_discard::m_destroyed_ep_count             = 0;
+unsigned test_ucp_worker_discard::m_failed_destroy_count           = 0;
 ucp_ep_t test_ucp_worker_discard::m_fake_ep                        = {};
 ucp_ep_h test_ucp_worker_discard::m_ucp_ep                         = NULL;
 const unsigned test_ucp_worker_discard::m_pending_purge_reqs_count = 10;
@@ -635,6 +642,56 @@ UCS_TEST_P(test_ucp_worker_discard, wireup_ep_flush_ok_not_wait_comp)
                         8                                        /* UCT EP count */,
                         6                                        /* WIREUP EP count */,
                         3                                        /* WIREUP AUX EP count */);
+}
+
+/*
+ * Regression test for PR #11446.
+ *
+ * Verifies that ucp_worker_discard_uct_ep() takes ownership of and destroys a
+ * UCT EP that is already a failed-TL stub (i.e. ucp_is_uct_ep_failed() is
+ * true). Before the fix, ucp_worker_discard_tl_uct_ep() returned UCS_OK
+ * without calling uct_ep_destroy() on the input, leaking the EP.
+ *
+ * The test fabricates a uct_iface_t whose ep_flush pointer matches the
+ * failed-TL iface singleton (so ucp_is_uct_ep_failed() returns true) but
+ * owns its own ep_destroy so the test can observe the destruction.
+ */
+UCS_TEST_P(test_ucp_worker_discard, failed_tl_uct_ep_destroyed)
+{
+    /* The discard_disabled variant exercises the same early-return branch,
+     * skip to keep the test focused. */
+    if (get_variant_value() & TEST_DISCARD_DISABLED) {
+        UCS_TEST_SKIP_R("not applicable for discard_disabled variant");
+    }
+
+    m_ucp_ep                 = sender().ep();
+    m_failed_destroy_count   = 0;
+    unsigned discarded_count = 0;
+
+    uct_iface_h failed_iface = ucp_failed_tl_iface_get();
+    uct_iface_t fake_iface          = {};
+    fake_iface.ops.ep_flush         = failed_iface->ops.ep_flush;
+    fake_iface.ops.ep_pending_purge = (uct_ep_pending_purge_func_t)ucs_empty_function;
+    fake_iface.ops.ep_destroy       = failed_ep_destroy_func;
+
+    uct_ep_t fake_ep = {};
+    fake_ep.iface    = &fake_iface;
+
+    ASSERT_TRUE(ucp_is_uct_ep_failed(&fake_ep));
+
+    ucs_status_t status;
+    UCS_ASYNC_BLOCK(&sender().worker()->async);
+    status = ucp_worker_discard_uct_ep(
+            m_ucp_ep, &fake_ep, UCP_NULL_RESOURCE, UCT_FLUSH_FLAG_LOCAL,
+            (uct_pending_purge_callback_t)ucs_empty_function, NULL,
+            discarded_cb, static_cast<void*>(&discarded_count));
+    UCS_ASYNC_UNBLOCK(&sender().worker()->async);
+
+    EXPECT_EQ(UCS_OK, status);
+    /* Pre-fix: 0 (uct_ep leaked); post-fix: 1 */
+    EXPECT_EQ(1u, m_failed_destroy_count);
+    /* discarded_cb is not invoked for failed-TL EPs (no request scheduled) */
+    EXPECT_EQ(0u, discarded_count);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_discard, all, "all")


### PR DESCRIPTION
## What?
fix EP discard_lanes_arg leak and Out-of-Order (OOO) discard refcounter

## Why?
Discovered with https://github.com/openucx/ucx/pull/11379 , but upstreamed as independent bugfix

## How?
- EP discard_lanes_arg leak: destroy failed stub EP directly to take ownership of uct_ep from the caller
- OOO discard refcounter: activate ifaces for the new configuration upfront before discard callback completion to avoid race condition which leads to negative EP reference counter when discard callbacks run out of order.