### PR TITLE
WIP-DNM-UCT/MLX5-disable-DDP-by-default

### DIFF
--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -425,6 +425,20 @@ build_fuse() {
 	fi
 }
 
+#
+# Build without GDA-KI
+#
+build_no_gda() {
+	echo "==== Build without GDA-KI ===="
+	${WORKSPACE}/contrib/configure-release --prefix=$ucx_inst --without-gda
+	$MAKEP
+
+	if [ -f ${ucx_build_dir}/src/uct/ib/mlx5/gdaki/.libs/libuct_ib_mlx5_gda.so ] ; then
+		azure_log_error "build --without-gda created GDA-KI SO"
+		exit 1
+	fi
+}
+
 az_init_modules
 prepare_build
 
@@ -437,7 +451,8 @@ tests=('build_docs' \
 		'build_no_verbs' \
 		'build_release_pkg' \
 		'build_cmake_examples' \
-		'build_fuse')
+		'build_fuse' \
+		'build_no_gda')
 if [ "${long_test}" = "yes" ]
 then
 	tests+=('check_config_h' \

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -82,6 +82,21 @@ AS_IF([test "x$enable_compiler_opt" = "xyes"], [BASE_CFLAGS="-O3 $BASE_CFLAGS"],
 
 
 #
+# Define OPTIMIZATION_LEVEL to the numeric value of the last -O flag.
+# Non-numeric levels (e.g. -Og, -Oz, -Ofast) leave OPTIMIZATION_LEVEL undefined.
+#
+opt_level=""
+for flag in $BASE_CFLAGS $CFLAGS; do
+    case $flag in -O*) opt_level=${flag#-O};; esac
+done
+case $opt_level in
+    [[0-9]])
+        AC_DEFINE_UNQUOTED([OPTIMIZATION_LEVEL], [$opt_level],
+                           [Numeric compiler optimization level]) ;;
+esac
+
+
+#
 # CHECK_CROSS_COMP (program, true-action, false-action)
 #
 # The macro checks if it can run the program; it executes

--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -132,6 +132,19 @@ AC_DEFUN([UCX_CUDA_CHECK_NVCC], [
                    [AC_MSG_RESULT([no])
                     NVCC=""])
                 AC_LANG_POP
+
+                # Check curand_kernel.h (optional, required for random channel mode)
+                AC_MSG_CHECKING([for curand_kernel.h])
+                AC_LANG_PUSH([CUDA])
+                AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+                    #include <curand_kernel.h>
+                    __global__ void test(curandState *s) { curand_init(0, 0, 0, s); }
+                ]])],
+                [AC_MSG_RESULT([yes])
+                 AC_DEFINE([HAVE_CURAND], [1], [cuRAND device API is available])],
+                [AC_MSG_RESULT([no])
+                 AC_MSG_NOTICE([curand_kernel.h not found. Install libcurand-devel to enable random channel mode in perftest.])])
+                AC_LANG_POP
             ])
         ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_LCOV], [false])
      AM_CONDITIONAL([HAVE_ZE], [false])
      AM_CONDITIONAL([HAVE_GAUDI], [false])
+     AM_CONDITIONAL([HAVE_GDA], [false])
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -117,7 +117,6 @@ if [ $opt_binrpm -eq 1 ]; then
 	with_args+=" $(with_arg mad)"
 	with_args+=" $(with_arg mlx5)"
 	with_args+=" $(with_arg efa)"
-	with_args+=" $(with_arg gda)"
 
 	echo rpmbuild -bb $rpmmacros $rpmopts $rpmspec $defines $with_args | bash -eEx
 fi

--- a/contrib/lsan.supp
+++ b/contrib/lsan.supp
@@ -1,5 +1,4 @@
 leak:libcuda
-leak:dlopen
 leak:dlsym
 leak:nvmlInitWithFlags
 leak:bfd_map_over_sections

--- a/debian/control.in
+++ b/debian/control.in
@@ -1,7 +1,7 @@
 Source: @PACKAGE@
 Section: libs
 Priority: extra
-Maintainer: ucx-group@elist.ornl.gov
+Maintainer: UCX Team <ucx-group@elist.ornl.gov>
 Build-Depends: debhelper (>= 9.0),
  libibverbs-dev,
  librdmacm-dev,

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -33,6 +33,13 @@ override_dh_auto_configure:
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/tmp
 
+# GDAKI files are packaged in ucx-cuda; the main ucx install's would claim
+# them too. Install ucx first with those paths excluded, then install the
+# remaining packages.
+override_dh_install:
+	dh_install -pucx -Xgda
+	dh_install --remaining-packages
+
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 	if [ -e $(CUDA_SUBSTVARS) ]; then \

--- a/debian/ucx-cuda.install
+++ b/debian/ucx-cuda.install
@@ -2,3 +2,4 @@ usr/lib/ucx/libucx_perftest_cuda.*
 usr/lib/ucx/libuc?_cuda.*
 usr/lib/ucx/libuct_ib_mlx5_gda.*
 usr/include/uct/ib/mlx5/gdaki/*
+usr/lib/pkgconfig/ucx-ib-mlx5-gda.pc

--- a/src/tools/perf/cuda/ucp_cuda_kernel.cu
+++ b/src/tools/perf/cuda/ucp_cuda_kernel.cu
@@ -9,7 +9,9 @@
 #endif
 
 #include "cuda_kernel.cuh"
+#ifdef HAVE_CURAND
 #include "curand_kernel.h"
+#endif
 
 #include <ucp/api/device/ucp_host.h>
 #include <ucp/api/device/ucp_device_impl.h>
@@ -25,16 +27,21 @@ public:
     __device__
     ucp_perf_cuda_request_manager(const ucx_perf_cuda_context &ctx,
                                   ucp_device_request_t *requests,
-                                  curandState *rand_state)
+                                  unsigned global_thread_id)
         : m_size(ctx.max_outstanding),
           m_fc_window(ctx.device_fc_window),
           m_reqs_count(ucs_div_round_up(m_size, m_fc_window)),
           m_channel_mode(ctx.channel_mode),
           m_pending_count(0),
           m_requests(requests),
-          m_pending_map(0),
-          m_rand_state(rand_state)
+          m_pending_map(0)
     {
+#ifdef HAVE_CURAND
+        if (ctx.channel_mode == UCX_PERF_CHANNEL_MODE_RANDOM) {
+            curand_init(ctx.channel_rand_seed, global_thread_id, 0,
+                        &m_rand_state);
+        }
+#endif
         assert(m_size <= CAPACITY);
         for (size_type i = 0; i < m_reqs_count; ++i) {
             m_pending[i] = 0;
@@ -106,7 +113,11 @@ public:
         case UCX_PERF_CHANNEL_MODE_SINGLE:
             return 0;
         case UCX_PERF_CHANNEL_MODE_RANDOM:
-            return curand(m_rand_state) % (gridDim.x * blockDim.x);
+#ifdef HAVE_CURAND
+            return curand(&m_rand_state) % (gridDim.x * blockDim.x);
+#else
+            [[fallthrough]];
+#endif
         case UCX_PERF_CHANNEL_MODE_PER_THREAD:
         default:
             return ucx_perf_cuda_thread_index<level>(threadIdx.x +
@@ -125,7 +136,9 @@ private:
     ucp_device_request_t          *m_requests;
     uint32_t                      m_pending_map;
     uint8_t                       m_pending[CAPACITY];
-    curandState                   *m_rand_state;
+#ifdef HAVE_CURAND
+    mutable curandState           m_rand_state;
+#endif
 };
 
 struct ucp_perf_cuda_params {
@@ -345,13 +358,8 @@ ucp_perf_cuda_put_bw_kernel(ucx_perf_cuda_context &ctx,
     unsigned global_thread_id  = ucx_perf_cuda_thread_index<level>(
         thread_index + blockIdx.x * blockDim.x);
     ucp_device_request_t *reqs = &shared_requests[reqs_count * thread_index];
-    curandState rand_state;
 
-    if (ctx.channel_mode == UCX_PERF_CHANNEL_MODE_RANDOM) {
-        curand_init(ctx.channel_rand_seed, global_thread_id, 0, &rand_state);
-    }
-
-    ucp_perf_cuda_request_manager req_mgr(ctx, reqs, &rand_state);
+    ucp_perf_cuda_request_manager req_mgr(ctx, reqs, global_thread_id);
 
     if (ctx.device_fc_window > 1) {
         ctx.status = ucp_perf_cuda_put_bw_kernel_impl<level, cmd, true>(
@@ -374,13 +382,8 @@ ucp_perf_cuda_put_latency_kernel(ucx_perf_cuda_context &ctx,
     unsigned global_thread_id    = ucx_perf_cuda_thread_index<level>(
         thread_index + blockIdx.x * blockDim.x);
     ucp_device_request_t *req    = &shared_requests[thread_index];
-    curandState rand_state;
 
-    if (ctx.channel_mode == UCX_PERF_CHANNEL_MODE_RANDOM) {
-        curand_init(ctx.channel_rand_seed, global_thread_id, 0, &rand_state);
-    }
-
-    ucp_perf_cuda_request_manager req_mgr(ctx, req, &rand_state);
+    ucp_perf_cuda_request_manager req_mgr(ctx, req, global_thread_id);
     ucx_perf_cuda_reporter reporter(ctx);
 
     for (ucx_perf_counter_t idx = 0; idx < max_iters; idx++) {

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -500,11 +500,21 @@ static ucs_status_t parse_channel_mode(const char *opt_arg,
 {
     if (!strcmp(opt_arg, "single")) {
         *channel_mode = UCX_PERF_CHANNEL_MODE_SINGLE;
-    } else if (!strncmp(opt_arg, "random:", 7)) {
-        *channel_mode      = UCX_PERF_CHANNEL_MODE_RANDOM;
-        *channel_rand_seed = strtoull(opt_arg + 7, NULL, 10);
-    } else if (!strcmp(opt_arg, "random")) {
+    } else if (!strncmp(opt_arg, "random", 6)) {
+        if (opt_arg[6] != '\0' && opt_arg[6] != ':') {
+            return UCS_ERR_INVALID_PARAM;
+        }
+
+#ifdef HAVE_CURAND
         *channel_mode = UCX_PERF_CHANNEL_MODE_RANDOM;
+
+        if (opt_arg[6] == ':') {
+            *channel_rand_seed = strtoull(opt_arg + 7, NULL, 10);
+        }
+#else
+        ucs_warn("random channel mode is not supported (UCX was built without cuRAND). Falling back to per-thread mode.");
+        *channel_mode = UCX_PERF_CHANNEL_MODE_PER_THREAD;
+#endif
     } else if (!strcmp(opt_arg, "per-thread")) {
         *channel_mode = UCX_PERF_CHANNEL_MODE_PER_THREAD;
     } else {

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -694,13 +694,20 @@ ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker)
     char ep_name[UCP_WORKER_ADDRESS_NAME_MAX];
     unsigned addr_indices[UCP_MAX_LANES];
     ucp_lane_index_t num_lanes;
+    ucp_rsc_index_t rsc_index;
 
     ucs_memory_type_for_each(mem_type) {
-        /* Mem type EP requires host memory support */
-        ucp_context_memaccess_tl_bitmap(context,
-                                        UCS_BIT(mem_type) |
-                                        UCS_BIT(UCS_MEMORY_TYPE_HOST),
-                                        0, &mem_access_tls);
+        ucp_context_memaccess_tl_bitmap(context, UCS_BIT(mem_type), 0,
+                                        &mem_access_tls);
+
+        /* Exclude transports that map remote memory via rkey pointer
+         * since mem_type EP is for in-process communication */
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(rsc_index, &mem_access_tls) {
+            if (context->tl_mds[context->tl_rscs[rsc_index].md_index].attr.flags &
+                UCT_MD_FLAG_RKEY_PTR) {
+                UCS_STATIC_BITMAP_RESET(&mem_access_tls, rsc_index);
+            }
+        }
 
         if (UCP_MEM_IS_HOST(mem_type) ||
             UCS_STATIC_BITMAP_IS_ZERO(mem_access_tls)) {
@@ -737,9 +744,8 @@ ucs_status_t ucp_worker_mem_type_eps_create(ucp_worker_h worker)
             goto err_free_address_list;
         }
 
-        /* Mem type EP cannot have more than one lane */
         num_lanes = ucp_ep_num_lanes(worker->mem_type_ep[mem_type]);
-        ucs_assertv_always(num_lanes == 1, "num_lanes=%u", num_lanes);
+        ucs_assertv_always(num_lanes <= 2, "num_lanes=%u", num_lanes);
         UCS_ASYNC_UNBLOCK(&worker->async);
 
         ucs_free(local_address.address_list);

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -750,7 +750,7 @@ ucs_status_t ucp_request_progress_counter(uct_pending_req_t *self)
 
     ++proto_config->selections;
 
-    return UCS_OK;
+    return status;
 }
 
 ucs_status_t ucp_request_progress_wrapper(uct_pending_req_t *self)

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -21,7 +21,7 @@ ucp_proto_request_complete_success(ucp_request_t *req)
     return UCS_OK;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_request_bcopy_complete_success(ucp_request_t *req)
 {
     ucp_datatype_iter_cleanup(&req->send.state.dt_iter, 0, UCP_DT_MASK_ALL);

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -131,7 +131,7 @@ ucp_proto_put_offload_update_remote_flush(ucp_ep_h ep,
     ep->ext->flush_sys_dev_map |= flush_sys_dev_mask;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_put_offload_bcopy_send_func(ucp_request_t *req,
                                       const ucp_proto_multi_lane_priv_t *lpriv,
                                       ucp_datatype_iter_t *next_iter,

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -91,7 +91,7 @@ ucp_proto_rndv_put_common_flush_completion_send_atp(uct_completion_t *uct_comp)
     ucp_request_send(req);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_rndv_put_common_flush_send(ucp_request_t *req, ucp_lane_index_t lane)
 {
     ucp_ep_h ep = req->send.ep;
@@ -208,7 +208,7 @@ ucp_proto_rndv_put_common_fenced_atp_progress(uct_pending_req_t *uct_req)
             ucp_proto_rndv_put_common_fenced_atp_send);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_rndv_put_common_data_sent(ucp_request_t *req)
 {
     const ucp_proto_rndv_put_priv_t *rpriv = req->send.proto_config->priv;
@@ -502,7 +502,7 @@ static void ucp_proto_rndv_put_mtype_pack_completion(uct_completion_t *uct_comp)
     ucp_request_send(req);
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_rndv_put_mtype_send_func(
+static UCS_F_INLINE_OPTIMIZED ucs_status_t ucp_proto_rndv_put_mtype_send_func(
         ucp_request_t *req, const ucp_proto_multi_lane_priv_t *lpriv,
         ucp_datatype_iter_t *next_iter, ucp_lane_index_t *lane_shift)
 {

--- a/src/ucp/tag/eager_multi.c
+++ b/src/ucp/tag/eager_multi.c
@@ -188,7 +188,7 @@ void ucp_proto_eager_sync_ack_handler(ucp_worker_h worker,
     }
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
+static UCS_F_INLINE_OPTIMIZED ucs_status_t
 ucp_proto_eager_sync_bcopy_request_init(ucp_request_t *req)
 {
     if (!(req->flags & UCP_REQUEST_FLAG_SYNC_REMOTE_COMPLETED)) {

--- a/src/ucs/config/global_opts.c
+++ b/src/ucs/config/global_opts.c
@@ -56,7 +56,6 @@ ucs_global_opts_t ucs_global_opts = {
     .module_dir            = UCX_MODULE_DIR, /* defined in Makefile.am */
     .module_log_level      = UCS_LOG_LEVEL_TRACE,
     .modules               = { {NULL, 0}, UCS_CONFIG_ALLOW_LIST_ALLOW_ALL },
-    .plugin_path           = { NULL, 0 },
     .arch                  = UCS_ARCH_GLOBAL_OPTS_INITALIZER,
     .rcache_stat_min       = 0,
     .rcache_stat_max       = 0
@@ -203,11 +202,6 @@ static ucs_config_field_t ucs_global_opts_table[] = {
   " *     - load all modules\n"
   " ^cu*  - do not load modules that begin with 'cu'",
   ucs_offsetof(ucs_global_opts_t, modules), UCS_CONFIG_TYPE_ALLOW_LIST},
-
- {"PLUGIN_PATH", "",
-  "Colon-separated list of additional directories to search for loadable\n"
-  "plugin modules",
-  ucs_offsetof(ucs_global_opts_t, plugin_path), UCS_CONFIG_TYPE_PATH_ARRAY},
 
  {"TOPO_PRIO", "sysfs,default",
   "Comma-separated list of providers for detecting system topology.\n"

--- a/src/ucs/config/global_opts.h
+++ b/src/ucs/config/global_opts.h
@@ -140,9 +140,6 @@ typedef struct {
     /* which modules to load */
     ucs_config_allow_list_t    modules;
 
-    /* additional directories to search for loadable plugin modules */
-    ucs_config_names_array_t   plugin_path;
-
     /* arch-specific global options */
     ucs_arch_global_opts_t     arch;
 

--- a/src/ucs/config/parser.c
+++ b/src/ucs/config/parser.c
@@ -822,8 +822,7 @@ ucs_status_t ucs_config_clone_range_spec(const void *src, void *dest, const void
     return UCS_OK;
 }
 
-static int ucs_config_sscanf_array_delim(const char *buf, void *dest,
-                                         const void *arg, const char *delim)
+int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg)
 {
     ucs_config_array_field_t *field = dest;
     void *temp_field;
@@ -837,10 +836,10 @@ static int ucs_config_sscanf_array_delim(const char *buf, void *dest,
         return 0;
     }
 
-    saveptr    = NULL;
-    token      = strtok_r(str_dup, delim, &saveptr);
+    saveptr = NULL;
+    token = strtok_r(str_dup, ",", &saveptr);
     temp_field = ucs_calloc(UCS_CONFIG_ARRAY_MAX, array->elem_size, "config array");
-    i          = 0;
+    i = 0;
     while (token != NULL) {
         ret = array->parser.read(token, (char*)temp_field + i * array->elem_size,
                                  array->parser.arg);
@@ -854,7 +853,7 @@ static int ucs_config_sscanf_array_delim(const char *buf, void *dest,
         if (i >= UCS_CONFIG_ARRAY_MAX) {
             break;
         }
-        token = strtok_r(NULL, delim, &saveptr);
+        token = strtok_r(NULL, ",", &saveptr);
     }
 
     field->data = temp_field;
@@ -863,19 +862,8 @@ static int ucs_config_sscanf_array_delim(const char *buf, void *dest,
     return 1;
 }
 
-int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg)
-{
-    return ucs_config_sscanf_array_delim(buf, dest, arg, ",");
-}
-
-int ucs_config_sscanf_path_array(const char *buf, void *dest, const void *arg)
-{
-    return ucs_config_sscanf_array_delim(buf, dest, arg, ":");
-}
-
-static int ucs_config_sprintf_array_delim(char *buf, size_t max,
-                                          const void *src, const void *arg,
-                                          char delim)
+int ucs_config_sprintf_array(char *buf, size_t max,
+                             const void *src, const void *arg)
 {
     const ucs_config_array_field_t *field = src;
     const ucs_config_array_t *array       = arg;
@@ -886,7 +874,7 @@ static int ucs_config_sprintf_array_delim(char *buf, size_t max,
     offset = 0;
     for (i = 0; i < field->count; ++i) {
         if (i > 0 && offset < max) {
-            buf[offset++] = delim;
+            buf[offset++] = ',';
         }
         ret = array->parser.write(buf + offset, max - offset,
                                   (char*)field->data + i * array->elem_size,
@@ -898,18 +886,6 @@ static int ucs_config_sprintf_array_delim(char *buf, size_t max,
         offset += strlen(buf + offset);
     }
     return 1;
-}
-
-int ucs_config_sprintf_array(char *buf, size_t max, const void *src,
-                             const void *arg)
-{
-    return ucs_config_sprintf_array_delim(buf, max, src, arg, ',');
-}
-
-int ucs_config_sprintf_path_array(char *buf, size_t max, const void *src,
-                                  const void *arg)
-{
-    return ucs_config_sprintf_array_delim(buf, max, src, arg, ':');
 }
 
 ucs_status_t ucs_config_clone_array(const void *src, void *dest, const void *arg)
@@ -957,23 +933,12 @@ void ucs_config_release_array(void *ptr, const void *arg)
     ucs_free(array_field->data);
 }
 
-static void ucs_config_help_array_delim(char *buf, size_t max, const void *arg,
-                                        const char *delim_name)
+void ucs_config_help_array(char *buf, size_t max, const void *arg)
 {
     const ucs_config_array_t *array = arg;
 
-    snprintf(buf, max, "%s-separated list of: ", delim_name);
+    snprintf(buf, max, "comma-separated list of: ");
     array->parser.help(buf + strlen(buf), max - strlen(buf), array->parser.arg);
-}
-
-void ucs_config_help_array(char *buf, size_t max, const void *arg)
-{
-    ucs_config_help_array_delim(buf, max, arg, "comma");
-}
-
-void ucs_config_help_path_array(char *buf, size_t max, const void *arg)
-{
-    ucs_config_help_array_delim(buf, max, arg, "colon");
 }
 
 int ucs_config_sscanf_allow_list(const char *buf, void *dest, const void *arg)

--- a/src/ucs/config/parser.h
+++ b/src/ucs/config/parser.h
@@ -264,13 +264,9 @@ ucs_status_t ucs_config_clone_range_spec(const void *src, void *dest, const void
 
 int ucs_config_sscanf_array(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_array(char *buf, size_t max, const void *src, const void *arg);
-int ucs_config_sscanf_path_array(const char *buf, void *dest, const void *arg);
-int ucs_config_sprintf_path_array(char *buf, size_t max, const void *src,
-                                  const void *arg);
 ucs_status_t ucs_config_clone_array(const void *src, void *dest, const void *arg);
 void ucs_config_release_array(void *ptr, const void *arg);
 void ucs_config_help_array(char *buf, size_t max, const void *arg);
-void ucs_config_help_path_array(char *buf, size_t max, const void *arg);
 
 int ucs_config_sscanf_allow_list(const char *buf, void *dest, const void *arg);
 int ucs_config_sprintf_allow_list(char *buf, size_t max, const void *src,
@@ -471,15 +467,6 @@ void ucs_config_help_generic(char *buf, size_t max, const void *arg);
  */
 #define UCS_CONFIG_TYPE_STRING_ARRAY \
     UCS_CONFIG_TYPE_ARRAY(string)
-
-/**
- * Colon-separated array of path strings (e.g. "/path/a:/path/b")
- */
-#define UCS_CONFIG_TYPE_PATH_ARRAY \
-    {ucs_config_sscanf_path_array, ucs_config_sprintf_path_array, \
-     ucs_config_clone_array,       ucs_config_release_array, \
-     ucs_config_help_path_array,   ucs_config_doc_nop, \
-     &ucs_config_array_string}
 
 UCS_CONFIG_DECLARE_ARRAY(string)
 

--- a/src/ucs/sys/compiler.h
+++ b/src/ucs/sys/compiler.h
@@ -30,6 +30,13 @@
 #  pragma warning(disable: 268)
 #endif
 
+/* Inline the function only when optimization level is high enough */
+#if defined(OPTIMIZATION_LEVEL) && (OPTIMIZATION_LEVEL >= 2)
+#define UCS_F_INLINE_OPTIMIZED   UCS_F_ALWAYS_INLINE
+#else
+#define UCS_F_INLINE_OPTIMIZED   inline
+#endif
+
 /* A function which should not be optimized */
 #if defined(__clang__)
 #define UCS_F_NOOPTIMIZE __attribute__((optnone))

--- a/src/ucs/sys/module.c
+++ b/src/ucs/sys/module.c
@@ -15,8 +15,6 @@
 #include "module.h"
 
 #include <ucs/sys/preprocessor.h>
-#include <ucs/datastruct/string_buffer.h>
-#include <ucs/datastruct/string_set.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/debug/assert.h>
 #include <ucs/debug/log.h>
@@ -28,7 +26,6 @@
 #include <dlfcn.h>
 #include <link.h>
 #include <libgen.h>
-#include <dirent.h>
 
 
 #ifdef UCX_SHARED_LIB
@@ -43,17 +40,16 @@
     ucs_log(ucs_min(UCS_LOG_LEVEL_TRACE, ucs_global_opts.module_log_level), \
             _fmt, ##  __VA_ARGS__)
 
-static char *ucs_module_srch_paths_buf[UCS_MODULE_SRCH_PATH_MAX];
-
 static struct {
-    ucs_init_once_t              init;
-    char                         module_ext[NAME_MAX];
-    ucs_array_s(unsigned, char*) srch_path;
+    ucs_init_once_t  init;
+    char             module_ext[NAME_MAX];
+    unsigned         srchpath_cnt;
+    char             *srch_path[UCS_MODULE_SRCH_PATH_MAX];
 } ucs_module_loader_state = {
-    .init       = UCS_INIT_ONCE_INITIALIZER,
-    .module_ext = ".so", /* default extension */
-    .srch_path  = UCS_ARRAY_FIXED_INITIALIZER(ucs_module_srch_paths_buf,
-                                              UCS_MODULE_SRCH_PATH_MAX)
+    .init         = UCS_INIT_ONCE_INITIALIZER,
+    .module_ext   = ".so", /* default extension */
+    .srchpath_cnt = 0,
+    .srch_path    = { NULL, NULL}
 };
 
 /* Should be called with lock held */
@@ -108,7 +104,7 @@ static void ucs_module_loader_add_dl_dir()
     }
 
     snprintf(path, max_length, "%s/%s", dirname(dlpath_dup), UCX_MODULE_SUBDIR);
-    *ucs_array_append(&ucs_module_loader_state.srch_path, goto out) = path;
+    ucs_module_loader_state.srch_path[ucs_module_loader_state.srchpath_cnt++] = path;
 
 out:
     ucs_free(dlpath_dup);
@@ -117,18 +113,17 @@ out:
 /* Should be called with lock held */
 static void ucs_module_loader_add_install_dir()
 {
-    *ucs_array_append(&ucs_module_loader_state.srch_path,
-                      return ) = ucs_global_opts.module_dir;
+    ucs_module_loader_state.srch_path[ucs_module_loader_state.srchpath_cnt++] =
+                    ucs_global_opts.module_dir;
 }
 
 static void ucs_module_loader_init_paths()
 {
     UCS_INIT_ONCE(&ucs_module_loader_state.init) {
-        ucs_assert(ucs_array_length(&ucs_module_loader_state.srch_path) == 0);
+        ucs_assert(ucs_module_loader_state.srchpath_cnt == 0);
         ucs_module_loader_add_dl_dir();
         ucs_module_loader_add_install_dir();
-        ucs_assert(ucs_array_length(&ucs_module_loader_state.srch_path) <=
-                   UCS_MODULE_SRCH_PATH_MAX);
+        ucs_assert(ucs_module_loader_state.srchpath_cnt <= UCS_MODULE_SRCH_PATH_MAX);
     }
 }
 
@@ -228,15 +223,28 @@ static int ucs_module_is_enabled(const char *module_name)
     }
 
     found = ucs_config_names_search(&ucs_global_opts.modules.array,
-        module_name) >= 0;
+                                    module_name) >= 0;
     return ((mode == UCS_CONFIG_ALLOW_LIST_ALLOW) && found) ||
            ((mode == UCS_CONFIG_ALLOW_LIST_NEGATE) && !found);
 }
 
-static int ucs_module_flags_to_dlopen_mode(unsigned flags)
+static void ucs_module_load_one(const char *framework, const char *module_name,
+                                unsigned flags)
 {
-    int mode = RTLD_LAZY;
+    char *module_path;
+    const char *error;
+    unsigned i;
+    void *dl;
+    int mode;
+    ucs_status_t status;
 
+    if (!ucs_module_is_enabled(module_name)) {
+        ucs_module_trace("module '%s' is disabled by configuration",
+                         module_name);
+        goto out;
+    }
+
+    mode = RTLD_LAZY;
     if (flags & UCS_MODULE_LOAD_FLAG_NODELETE) {
         mode |= RTLD_NODELETE;
     }
@@ -246,177 +254,66 @@ static int ucs_module_flags_to_dlopen_mode(unsigned flags)
         mode |= RTLD_LOCAL;
     }
 
-    return mode;
-}
-
-static void *ucs_module_try_load(const char *module_path, int mode)
-{
-    const char *error;
-    void *dl;
-
-    (void)dlerror();
-    dl = dlopen(module_path, mode);
-    if (dl == NULL) {
-        error = dlerror();
-        ucs_module_debug("dlopen('%s', mode=0x%x) failed: %s", module_path,
-                         mode, error ? error : "Unknown error");
-    }
-
-    return dl;
-}
-
-static int ucs_module_filename_match(const char *filename, const char *prefix,
-                                     size_t prefix_len)
-{
-    size_t suffix_len = strlen(ucs_module_loader_state.module_ext);
-    size_t name_len   = strlen(filename);
-
-    return (name_len > (prefix_len + suffix_len)) &&
-           (strncmp(filename, prefix, prefix_len) == 0) &&
-           (strcmp(filename + name_len - suffix_len,
-                   ucs_module_loader_state.module_ext) == 0);
-}
-
-/* e.g. "libuct_ib_mlx5.so" -> "libuct_ib_mlx5" (strip suffix for set key) */
-static void
-ucs_module_filename_to_base(const char *filename, char *base, size_t base_max)
-{
-    size_t suffix_len = strlen(ucs_module_loader_state.module_ext);
-    size_t name_len   = strlen(filename);
-    size_t base_len   = name_len - suffix_len;
-
-    if (base_len >= base_max) {
-        base_len = base_max - 1;
-    }
-    memcpy(base, filename, base_len);
-    base[base_len] = '\0';
-}
-
-static void ucs_module_load_from_dir(const char *dir, const char *framework,
-                                     int mode, ucs_string_set_t *loaded_set)
-{
-    char prefix[NAME_MAX];
-    char base[NAME_MAX];
-    char *module_path;
-    size_t prefix_len;
-    struct dirent *entry;
-    ucs_status_t status;
-    void *dl;
-    DIR *dp;
-
-    dp = opendir(dir);
-    if (dp == NULL) {
-        ucs_module_trace("cannot open module directory '%s'", dir);
-        return;
-    }
+    ucs_module_trace("loading module '%s' with mode 0x%x", module_name, mode);
 
     status = ucs_string_alloc_path_buffer(&module_path, "module_path");
     if (status != UCS_OK) {
-        goto out_closedir;
+        goto out;
     }
 
-    snprintf(prefix, sizeof(prefix), "lib%s_", framework);
-    prefix_len = strlen(prefix);
+    for (i = 0; i < ucs_module_loader_state.srchpath_cnt; ++i) {
+        snprintf(module_path, PATH_MAX, "%s/lib%s_%s%s",
+                 ucs_module_loader_state.srch_path[i], framework, module_name,
+                 ucs_module_loader_state.module_ext);
 
-    while ((entry = readdir(dp)) != NULL) {
-        if (!ucs_module_filename_match(entry->d_name, prefix, prefix_len)) {
-            continue;
+        /* Clear error state */
+        (void)dlerror();
+        dl = dlopen(module_path, mode);
+        if (dl != NULL) {
+            ucs_module_init(module_path, dl);
+            goto out_free_module_path;
+        } else {
+            /* If a module fails to load, silently give up */
+            error = dlerror();
+            ucs_module_debug("dlopen('%s', mode=0x%x) failed: %s", module_path,
+                             mode, error ? error : "Unknown error");
         }
-
-        ucs_module_filename_to_base(entry->d_name, base, sizeof(base));
-        if (strchr(base + prefix_len, '_') != NULL) {
-            ucs_module_debug("module name contains '_': %s, skipping", base + prefix_len);
-            continue;
-        }
-
-        snprintf(module_path, PATH_MAX, "%s/%s", dir, entry->d_name);
-        if (!ucs_module_is_enabled(base + prefix_len)) {
-            ucs_module_debug("module is disabled: %s, skipping", base + prefix_len);
-            continue;
-        }
-
-        if (ucs_string_set_contains(loaded_set, base)) {
-            continue;
-        }
-
-        dl = ucs_module_try_load(module_path, mode);
-        if (dl == NULL) {
-            continue;
-        }
-
-        ucs_module_init(module_path, dl);
-        (void)ucs_string_set_add(loaded_set, base);
     }
 
+out_free_module_path:
     ucs_free(module_path);
-out_closedir:
-    closedir(dp);
+out:
+    return;
+    /* coverity[leaked_storage] : a loaded module is never unloaded */
 }
-
-static void ucs_module_check_expected_loaded(const char *framework,
-                                             const char *expected_modules,
-                                             const ucs_string_set_t *loaded_set)
-{
-    ucs_string_buffer_t strb;
-    char *module_name;
-    char base[NAME_MAX];
-
-    if ((expected_modules == NULL) || (expected_modules[0] == '\0')) {
-        return;
-    }
-
-    ucs_string_buffer_init(&strb);
-    ucs_string_buffer_appendf(&strb, "%s", expected_modules);
-
-    ucs_string_buffer_for_each_token(module_name, &strb, ":") {
-        if (ucs_module_is_enabled(module_name)) {
-            snprintf(base, sizeof(base), "lib%s_%s", framework, module_name);
-            if (!ucs_string_set_contains(loaded_set, base)) {
-                ucs_module_debug("required module '%s' for framework '%s' "
-                                 "was not loaded",
-                                 module_name, framework);
-            }
-        }
-    }
-
-    ucs_string_buffer_cleanup(&strb);
-}
-
 #endif /* UCX_SHARED_LIB */
 
-void ucs_load_modules(const char *framework, const char *expected_modules,
+void ucs_load_modules(const char *framework, const char *modules,
                       ucs_init_once_t *init_once, unsigned flags)
 {
 #ifdef UCX_SHARED_LIB
-    unsigned i;
-    int mode;
-    ucs_string_set_t loaded_set;
+    char *modules_str;
+    char *saveptr;
+    char *module_name;
 
     ucs_module_loader_init_paths();
 
     UCS_INIT_ONCE(init_once) {
         ucs_assert(ucs_sys_is_dynamic_lib());
 
-        ucs_string_set_init(&loaded_set);
-        mode = ucs_module_flags_to_dlopen_mode(flags);
-
-        /* Load modules from directories */
-        for (i = 0; i < ucs_global_opts.plugin_path.count; ++i) {
-            ucs_module_load_from_dir(ucs_global_opts.plugin_path.names[i],
-                                     framework, mode, &loaded_set);
+        ucs_module_debug("loading modules for %s", framework);
+        modules_str = ucs_strdup(modules, "modules_list");
+        if (modules_str != NULL) {
+            saveptr     = NULL;
+            module_name = strtok_r(modules_str, ":", &saveptr);
+            while (module_name != NULL) {
+                ucs_module_load_one(framework, module_name, flags);
+                module_name = strtok_r(NULL, ":", &saveptr);
+            }
+            ucs_free(modules_str);
+        } else {
+            ucs_error("failed to allocate module names list");
         }
-
-        for (i = 0; i < ucs_array_length(&ucs_module_loader_state.srch_path);
-             ++i) {
-            ucs_module_load_from_dir(
-                    ucs_array_elem(&ucs_module_loader_state.srch_path, i),
-                    framework, mode, &loaded_set);
-        }
-
-        ucs_module_check_expected_loaded(framework, expected_modules,
-                                         &loaded_set);
-
-        ucs_string_set_cleanup(&loaded_set);
     }
 #endif /* UCX_SHARED_LIB */
 }

--- a/src/ucs/sys/module.h
+++ b/src/ucs/sys/module.h
@@ -58,11 +58,6 @@ typedef enum {
  * will be different, in which case we prefer the 'local' library rather than the
  * 'installed' one.
  *
- * After loading expected modules, external plugins matching the framework are
- * discovered and loaded from:
- *  1. Directories listed in UCX_PLUGIN_PATH (colon-separated)
- *  2. The same built-in module search directories listed above
- *
  * @param [in] _name  Framework name (as a token)
  */
 #define UCS_MODULE_FRAMEWORK_LOAD(_name, _flags) \
@@ -94,7 +89,7 @@ typedef enum {
 /**
  * Internal function. Please use @ref UCS_MODULE_FRAMEWORK_LOAD macro instead.
  */
-void ucs_load_modules(const char *framework, const char *expected_modules,
+void ucs_load_modules(const char *framework, const char *modules,
                       ucs_init_once_t *init_once, unsigned flags);
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc.inl
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc.inl
@@ -82,6 +82,19 @@ uct_cuda_ipc_check_and_pop_ctx(int is_ctx_pushed)
     }
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_cuda_ipc_is_rkey_local(const uct_cuda_ipc_extended_rkey_t *rkey)
+{
+    static pid_t pid = 0;
+
+    if (ucs_unlikely(pid == 0)) {
+        pid = getpid();
+    }
+
+    return (pid == rkey->super.pid) &&
+           (ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID) == rkey->pid_ns);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_cuda_ipc_get_remote_address(
         uct_cuda_ipc_extended_rkey_t *rkey, uint64_t raddr, CUdevice cu_dev,
         void **laddr_p, void **base_addr_p)

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -202,9 +202,7 @@ uct_cuda_ipc_cache_region_remove(uct_cuda_ipc_cache_t *cache,
                   (void *)region->key.d_bptr, ucs_status_string(status));
     }
 
-    ucs_assertv(region->in_lru, "region=%p, refcount=%lu", region, region->refcount);
     ucs_list_del(&region->lru_list);
-    region->in_lru = 0;
 
     ucs_assert(cache->num_regions > 0);
     cache->num_regions--;
@@ -238,9 +236,7 @@ static void uct_cuda_ipc_cache_evict_lru(uct_cuda_ipc_cache_t *cache)
         }
 
         if (region->refcount > 0) {
-            /* In-use region -- pull off LRU, it will be re-added on release */
-            ucs_list_del(&region->lru_list);
-            region->in_lru = 0;
+            /* In-use region -- keep on LRU, revisit on next eviction pass */
             continue;
         }
 
@@ -590,10 +586,6 @@ ucs_status_t uct_cuda_ipc_unmap_memhandle(pid_t pid, ucs_sys_ns_t pid_ns,
     if (!region->refcount && !cache_enabled) {
         ucs_assert(region->mapped_addr == mapped_addr);
         uct_cuda_ipc_cache_region_destroy(cache, region);
-    } else if (!region->in_lru) {
-        /* Region becomes an eviction candidate -- add to LRU tail */
-        ucs_list_add_tail(&cache->lru_list, &region->lru_list);
-        region->in_lru = 1;
     }
 
     pthread_rwlock_unlock(&cache->lock);
@@ -648,12 +640,10 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
                       UCS_PGT_REGION_FMT, cache->name, (void *)key->d_bptr,
                       key->b_len, UCS_PGT_REGION_ARG(&region->super));
 
-            /* Move to LRU tail (most recently used) */
-            if (region->in_lru) {
-                ucs_list_del(&region->lru_list);
-            }
+            /* Move to LRU tail (most recently used). Region is always on LRU
+             * while alive, so unconditional del/add_tail is safe. */
+            ucs_list_del(&region->lru_list);
             ucs_list_add_tail(&cache->lru_list, &region->lru_list);
-            region->in_lru = 1;
 
             *mapped_addr = region->mapped_addr;
             ucs_assert(region->refcount < UINT64_MAX);
@@ -724,7 +714,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     region->mapped_addr = *mapped_addr;
     region->refcount    = 1;
     region->cu_dev      = cu_dev;
-    region->in_lru      = 0; /* will be set after pgtable insert */
 
     status = UCS_PROFILE_CALL(ucs_pgtable_insert,
                               &cache->pgtable, &region->super);
@@ -748,7 +737,6 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
     cache->num_regions++;
     cache->total_size += key->b_len;
     ucs_list_add_tail(&cache->lru_list, &region->lru_list);
-    region->in_lru = 1;
 
     uct_cuda_ipc_cache_evict_lru(cache);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -18,7 +18,7 @@
 #include <ucs/sys/ptr_arith.h>
 #include <ucs/datastruct/khash.h>
 #include <uct/cuda/base/cuda_ctx.inl>
-
+#include "cuda_ipc.inl"
 
 typedef struct uct_cuda_ipc_cache_hash_key {
     pid_t        pid;
@@ -620,8 +620,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
         return status;
     }
 
-    if ((getpid() == key->pid) &&
-        (ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID) == ext_key->pid_ns) &&
+    if (uct_cuda_ipc_is_rkey_local(ext_key) &&
         (memcmp(uuid.bytes, key->uuid.bytes, sizeof(uuid.bytes)) == 0)) {
         /* TODO: added for test purpose to enable cuda_ipc tests in gtest
          * mapped addrr is set to be same as d_bptr avoiding any calls to

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -28,7 +28,6 @@ struct uct_cuda_ipc_cache_region {
     void                    *mapped_addr; /**< Local mapped address */
     uint64_t                refcount;     /**< Track in-flight ops before unmapping*/
     CUdevice                cu_dev;       /**< CUDA device */
-    uint8_t                 in_lru;       /**< Whether region is on the LRU list */
 };
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -85,16 +85,18 @@ static uct_cuda_ipc_dev_cache_t *uct_cuda_ipc_create_dev_cache(int dev_num)
 
 static uct_cuda_ipc_dev_cache_t *
 uct_cuda_ipc_get_dev_cache(uct_cuda_ipc_component_t *component,
-                           uct_cuda_ipc_rkey_t *rkey)
+                           const uct_cuda_ipc_extended_rkey_t *ext_rkey)
 {
+    const uct_cuda_ipc_rkey_t *rkey   = &ext_rkey->super;
     khash_t(cuda_ipc_uuid_hash) *hash = &component->uuid_hash;
     uct_cuda_ipc_uuid_hash_key_t key;
     uct_cuda_ipc_dev_cache_t *cache;
     khiter_t iter;
     int ret;
 
-    key.uuid = rkey->uuid;
-    key.type = rkey->ph.handle_type;
+    key.uuid     = rkey->uuid;
+    key.type     = rkey->ph.handle_type;
+    key.is_local = uct_cuda_ipc_is_rkey_local(ext_rkey);
 
     iter = kh_put(cuda_ipc_uuid_hash, hash, key, &ret);
     if (ret == UCS_KH_PUT_KEY_PRESENT) {
@@ -351,7 +353,7 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
 
     pthread_mutex_lock(&component->lock);
 
-    cache = uct_cuda_ipc_get_dev_cache(component, &rkey->super.super);
+    cache = uct_cuda_ipc_get_dev_cache(component, &rkey->super);
     if (ucs_unlikely(NULL == cache)) {
         status = UCS_ERR_NO_RESOURCE;
         goto err;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -14,7 +14,7 @@
 #include <ucs/config/types.h>
 
 
-typedef enum uct_cuda_ipc_key_handle {
+typedef enum {
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC = 0,
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, /* cudaMalloc memory */
 #if HAVE_CUDA_FABRIC
@@ -48,9 +48,10 @@ typedef struct uct_cuda_ipc_md {
 } uct_cuda_ipc_md_t;
 
 
-typedef struct uct_cuda_ipc_uuid_hash_key {
-    int     type;
-    CUuuid  uuid;
+typedef struct {
+    uint8_t type;     /**< uct_cuda_ipc_key_handle_t */
+    uint8_t is_local; /**< 1 if the key is local (PID+PID_NS), 0 otherwise */
+    CUuuid  uuid;     /**< GPU Device UUID */
 } uct_cuda_ipc_uuid_hash_key_t;
 
 
@@ -69,7 +70,8 @@ uct_cuda_ipc_uuid_equals(uct_cuda_ipc_uuid_hash_key_t key1,
     int64_t *a64 = (int64_t *)key1.uuid.bytes;
     int64_t *b64 = (int64_t *)key2.uuid.bytes;
 
-    return (key1.type == key2.type) && (a64[0] == b64[0]) && (a64[1] == b64[1]);
+    return (key1.type == key2.type) && (key1.is_local == key2.is_local) &&
+           (a64[0] == b64[0]) && (a64[1] == b64[1]);
 }
 
 
@@ -77,7 +79,7 @@ static UCS_F_ALWAYS_INLINE khint32_t
 uct_cuda_ipc_uuid_hash_func(uct_cuda_ipc_uuid_hash_key_t key)
 {
     int64_t *i64 = (int64_t *)key.uuid.bytes;
-    return kh_int64_hash_func(i64[0] ^ i64[1] ^ key.type);
+    return kh_int64_hash_func(i64[0] ^ i64[1] ^ (key.type << 1) ^ key.is_local);
 }
 
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2020. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
  * Copyright (C) The University of Tennessee and The University
  *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
  *
@@ -128,6 +128,12 @@ ucs_config_field_t uct_ib_md_config_table[] = {
     {"GDA_DMABUF_ENABLE", "try",
      "Enable DMA-BUF in GDA.",
      ucs_offsetof(uct_ib_md_config_t, ext.gda_dmabuf_enable), UCS_CONFIG_TYPE_TERNARY},
+
+    {"GDA_RETAIN_INACTIVE_CTX", "n",
+     "Retain and use an inactive CUDA primary context to query device "
+     "capabilities.",
+     ucs_offsetof(uct_ib_md_config_t, ext.gda_retain_inactive_ctx),
+     UCS_CONFIG_TYPE_BOOL},
 
     {"PCI_BW", "",
      "Maximum effective data transfer rate of PCI bus connected to HCA\n",

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2016. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
  * Copyright (C) The University of Tennessee and The University
  *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
  *
@@ -114,6 +114,8 @@ typedef struct uct_ib_md_ext_config {
     int                      direct_nic; /**< Direct NIC with GPU functionality */
     unsigned                 gda_max_hca_per_gpu; /**< Threshold of IB per GPU */
     int                      gda_dmabuf_enable; /**< Enable DMA-BUF in GDA */
+    /**< Retain and use an inactive CUDA primary context to query device capabilities */
+    int                      gda_retain_inactive_ctx;
 } uct_ib_md_ext_config_t;
 
 

--- a/src/uct/ib/mlx5/gdaki/Makefile.am
+++ b/src/uct/ib/mlx5/gdaki/Makefile.am
@@ -3,7 +3,7 @@
 # See file LICENSE for terms.
 #
 
-if HAVE_CUDA
+if HAVE_GDA
 
 module_LTLIBRARIES             = libuct_ib_mlx5_gda.la
 libuct_ib_mlx5_gda_la_CPPFLAGS = $(BASE_CPPFLAGS) $(IBVERBS_CPPFLAGS) \

--- a/src/uct/ib/mlx5/gdaki/configure.m4
+++ b/src/uct/ib/mlx5/gdaki/configure.m4
@@ -5,8 +5,16 @@
 
 UCX_CHECK_CUDA
 
-AS_IF([test "x$cuda_happy" = "xyes"], [
-    uct_ib_mlx5_modules="${uct_ib_mlx5_modules}:gda"])
+AC_ARG_WITH([gda],
+            [AS_HELP_STRING([--without-gda], [Disable GDA-KI])],
+            [], [with_gda=yes])
 
+AS_IF([test "x$with_gda" = "xyes"] && [test "x$cuda_happy" = "xyes"],
+      [gda_happy=yes], [gda_happy=no])
+
+AS_IF([test "x$gda_happy" = "xyes"],
+      [uct_ib_mlx5_modules="${uct_ib_mlx5_modules}:gda"])
+
+AM_CONDITIONAL([HAVE_GDA], [test "x$gda_happy" != "xno"])
 AC_CONFIG_FILES([src/uct/ib/mlx5/gdaki/Makefile
                  src/uct/ib/mlx5/gdaki/ucx-ib-mlx5-gda.pc])

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -20,6 +20,7 @@
 #include <uct/ib/mlx5/rc/rc_mlx5.h>
 #include <uct/cuda/cuda_copy/cuda_copy_md.h>
 #include <uct/cuda/base/cuda_util.h>
+#include <uct/cuda/base/cuda_ctx.h>
 
 #include "gpunetio/common/doca_gpunetio_verbs_def.h"
 
@@ -102,27 +103,15 @@ static void uct_rc_gdaki_calc_dev_ep_layout(size_t num_channels,
 
 static int uct_gdaki_check_umem_dmabuf(const uct_ib_md_t *md)
 {
-    ucs_status_t status = UCS_ERR_UNSUPPORTED;
+    int ret = 0;
 #if HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF
     struct mlx5dv_devx_umem_in umem_in = {};
     struct mlx5dv_devx_umem *umem;
     uct_cuda_copy_md_dmabuf_t dmabuf;
     CUdeviceptr buff;
-    CUcontext cuda_ctx;
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDevicePrimaryCtxRetain(&cuda_ctx, 0));
-    if (status != UCS_OK) {
+    if (UCT_CUDADRV_FUNC_LOG_ERR(cuMemAlloc(&buff, 1)) != UCS_OK) {
         return 0;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(cuda_ctx));
-    if (status != UCS_OK) {
-        goto out_ctx_release;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemAlloc(&buff, 1));
-    if (status != UCS_OK) {
-        goto out_ctx_pop;
     }
 
     dmabuf = uct_cuda_copy_md_get_dmabuf((void*)buff, 1,
@@ -136,22 +125,18 @@ static int uct_gdaki_check_umem_dmabuf(const uct_ib_md_t *md)
     umem_in.dmabuf_fd   = dmabuf.fd;
 
     umem = mlx5dv_devx_umem_reg_ex(md->dev.ibv_context, &umem_in);
-    if (umem == NULL) {
-        status = UCS_ERR_NO_MEMORY;
-        goto out_free;
+    if (umem != NULL) {
+        mlx5dv_devx_umem_dereg(umem);
+        ret = 1;
+    } else {
+        ret = 0;
     }
 
-    mlx5dv_devx_umem_dereg(umem);
-out_free:
     ucs_close_fd(&dmabuf.fd);
-    cuMemFree(buff);
-out_ctx_pop:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
-out_ctx_release:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(0));
+    (void)UCT_CUDADRV_FUNC_LOG_WARN(cuMemFree(buff));
 #endif
 
-    return status == UCS_OK;
+    return ret;
 }
 
 static int uct_gdaki_is_dmabuf_supported(const uct_ib_md_t *md)
@@ -803,28 +788,15 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_gdaki_iface_t, uct_iface_t, uct_md_h,
 
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_gdaki_iface_t, uct_iface_t);
 
-static ucs_status_t
-uct_gdaki_md_check_uar(uct_ib_mlx5_md_t *md, CUdevice cuda_dev)
+static ucs_status_t uct_gdaki_md_check_uar(uct_ib_mlx5_md_t *md)
 {
     struct mlx5dv_devx_uar *uar;
     ucs_status_t status;
-    CUcontext cuda_ctx;
     unsigned flags;
 
     status = uct_ib_mlx5_devx_alloc_uar(md, 0, &uar);
     if (status != UCS_OK) {
-        goto out;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(
-            cuDevicePrimaryCtxRetain(&cuda_ctx, cuda_dev));
-    if (status != UCS_OK) {
-        goto out_free_uar;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxPushCurrent(cuda_ctx));
-    if (status != UCS_OK) {
-        goto out_ctx_release;
+        return status;
     }
 
     flags  = CU_MEMHOSTREGISTER_PORTABLE | CU_MEMHOSTREGISTER_DEVICEMAP |
@@ -832,15 +804,10 @@ uct_gdaki_md_check_uar(uct_ib_mlx5_md_t *md, CUdevice cuda_dev)
     status = UCT_CUDADRV_FUNC_LOG_DEBUG(
             cuMemHostRegister(uar->reg_addr, UCT_IB_MLX5_BF_REG_SIZE, flags));
     if (status == UCS_OK) {
-        UCT_CUDADRV_FUNC_LOG_DEBUG(cuMemHostUnregister(uar->reg_addr));
+        UCT_CUDADRV_FUNC_LOG_WARN(cuMemHostUnregister(uar->reg_addr));
     }
 
-    UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
-out_ctx_release:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(cuda_dev));
-out_free_uar:
     mlx5dv_devx_free_uar(uar);
-out:
     return status;
 }
 
@@ -865,7 +832,7 @@ static int uct_gdaki_is_peermem_loaded(const uct_ib_md_t *md)
     return peermem_loaded;
 }
 
-static int uct_gdaki_is_uar_supported(uct_ib_mlx5_md_t *md, CUdevice cu_device)
+static int uct_gdaki_is_uar_supported(uct_ib_mlx5_md_t *md)
 {
     /**
       * Save the result of UAR support in a global flag to avoid the overhead of
@@ -878,7 +845,7 @@ static int uct_gdaki_is_uar_supported(uct_ib_mlx5_md_t *md, CUdevice cu_device)
         return uar_supported;
     }
 
-    uar_supported = (uct_gdaki_md_check_uar(md, cu_device) == UCS_OK);
+    uar_supported = (uct_gdaki_md_check_uar(md) == UCS_OK);
     if (uar_supported == 0) {
         ucs_diag("GDAKI not supported, please add NVreg_RegistryDwords="
                  "\"PeerMappingOverride=1;\" option for nvidia kernel driver");
@@ -1021,6 +988,81 @@ out_buff:
     return dmat;
 }
 
+static CUdevice uct_gdaki_push_primary_ctx(int retain_inactive_ctx)
+{
+    CUdevice cuda_dev;
+    ucs_status_t status;
+
+    status = uct_cuda_ctx_primary_push_first_active(&cuda_dev);
+    if (status == UCS_OK) {
+        return cuda_dev;
+    }
+
+    if ((status != UCS_ERR_NO_DEVICE) || !retain_inactive_ctx) {
+        if (status == UCS_ERR_NO_DEVICE) {
+            ucs_diag("no active primary CUDA context on any device. Please set "
+                     "UCX_IB_GDA_RETAIN_INACTIVE_CTX=yes to retain inactive "
+                     "context.");
+        }
+        return CU_DEVICE_INVALID;
+    }
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_dev, 0));
+    if (status != UCS_OK) {
+        return CU_DEVICE_INVALID;
+    }
+
+    status = uct_cuda_ctx_primary_push(cuda_dev, 1, UCS_LOG_LEVEL_ERROR);
+    if (status != UCS_OK) {
+        return CU_DEVICE_INVALID;
+    }
+
+    return cuda_dev;
+}
+
+static int
+uct_gdaki_check_cuda_ctx_dependent_features(uct_ib_mlx5_md_t *ib_mlx5_md)
+{
+    uct_ib_md_t *ib_md = &ib_mlx5_md->super;
+    CUdevice cuda_dev;
+    char dmabuf_str[8];
+    int ret;
+
+    cuda_dev = uct_gdaki_push_primary_ctx(
+            ib_md->config.gda_retain_inactive_ctx);
+    if (cuda_dev == CU_DEVICE_INVALID) {
+        return 0;
+    }
+
+    if ((ib_md->config.gda_dmabuf_enable != UCS_NO) &&
+        uct_gdaki_is_dmabuf_supported(ib_md)) {
+        ib_mlx5_md->flags |= UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM;
+        ucs_debug("%s: using dmabuf for gda transport",
+                  uct_ib_device_name(&ib_md->dev));
+    } else if ((ib_md->config.gda_dmabuf_enable != UCS_YES) &&
+               uct_gdaki_is_peermem_loaded(ib_md)) {
+        ucs_debug("%s: using peermem for gda transport",
+                  uct_ib_device_name(&ib_md->dev));
+    } else {
+        ucs_config_sprintf_ternary_auto(dmabuf_str, sizeof(dmabuf_str),
+                                        &ib_md->config.gda_dmabuf_enable, NULL);
+        ucs_diag("%s: GPU-direct RDMA is not available (GDA_DMABUF_ENABLE=%s)",
+                 uct_ib_device_name(&ib_md->dev), dmabuf_str);
+        ret = 0;
+        goto out;
+    }
+
+    if (uct_gdaki_is_uar_supported(ib_mlx5_md)) {
+        ret = 1;
+    } else {
+        ret = 0;
+    }
+
+out:
+    uct_cuda_ctx_primary_pop_and_release(cuda_dev);
+    return ret;
+}
+
 static ucs_status_t
 uct_gdaki_query_tl_devices(uct_md_h tl_md,
                            uct_tl_device_resource_t **tl_devices_p,
@@ -1038,7 +1080,6 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
     ucs_sys_device_t dev;
     int i;
     uct_gdaki_dev_matrix_elem_t *ibdesc;
-    char dmabuf_str[8];
 
     UCS_INIT_ONCE(&dmat_once) {
         dmat = uct_gdaki_dev_matrix_init(ib_md->config.gda_max_hca_per_gpu,
@@ -1050,20 +1091,7 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
         goto out;
     }
 
-    if ((ib_md->config.gda_dmabuf_enable != UCS_NO) &&
-        uct_gdaki_is_dmabuf_supported(ib_md)) {
-        ib_mlx5_md->flags |= UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM;
-        ucs_debug("%s: using dmabuf for gda transport",
-                  uct_ib_device_name(&ib_md->dev));
-    } else if ((ib_md->config.gda_dmabuf_enable != UCS_YES) &&
-               uct_gdaki_is_peermem_loaded(ib_md)) {
-        ucs_debug("%s: using peermem for gda transport",
-                  uct_ib_device_name(&ib_md->dev));
-    } else {
-        ucs_config_sprintf_ternary_auto(dmabuf_str, sizeof(dmabuf_str),
-                                        &ib_md->config.gda_dmabuf_enable, NULL);
-        ucs_diag("%s: GPU-direct RDMA is not available (GDA_DMABUF_ENABLE=%s)",
-                 uct_ib_device_name(&ib_md->dev), dmabuf_str);
+    if (!uct_gdaki_check_cuda_ctx_dependent_features(ib_mlx5_md)) {
         status = UCS_ERR_NO_DEVICE;
         goto out;
     }
@@ -1094,11 +1122,6 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
     ucs_for_each_bit(i, ibdesc->cuda_map) {
         status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&device, i));
         if (status != UCS_OK) {
-            goto err;
-        }
-
-        if (!uct_gdaki_is_uar_supported(ib_mlx5_md, device)) {
-            status = UCS_ERR_NO_DEVICE;
             goto err;
         }
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -181,45 +181,39 @@ static int uct_gdaki_is_dmabuf_supported(const uct_ib_md_t *md)
     return dmabuf_supported;
 }
 
-static uct_cuda_copy_md_dmabuf_t uct_rc_gdaki_get_dmabuf(const uct_ib_md_t *md,
-                                                         const void *address,
-                                                         size_t length)
-{
-    uct_ib_mlx5_md_t *ib_mlx5_md     = ucs_derived_of(md, uct_ib_mlx5_md_t);
-    uct_cuda_copy_md_dmabuf_t dmabuf = {
-        .fd     = UCT_DMABUF_FD_INVALID,
-        .offset = 0
-    };
-
-    if (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM) {
-        return uct_cuda_copy_md_get_dmabuf(address, length,
-                                           UCS_SYS_DEVICE_ID_UNKNOWN);
-    }
-
-    return dmabuf;
-}
-
 static struct mlx5dv_devx_umem *
 uct_rc_gdaki_umem_reg(const uct_ib_md_t *md, struct ibv_context *ibv_context,
                       void *address, size_t length, uint64_t pgsz_bitmap)
 {
 #if HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF
+    uct_ib_mlx5_md_t *ib_mlx5_md       = ucs_derived_of(md, uct_ib_mlx5_md_t);
     struct mlx5dv_devx_umem_in umem_in = {};
-    uct_cuda_copy_md_dmabuf_t dmabuf;
+    uct_cuda_copy_md_dmabuf_t dmabuf   = {
+        .fd     = UCT_DMABUF_FD_INVALID,
+        .offset = 0
+    };
     struct mlx5dv_devx_umem *umem;
 
     umem_in.addr        = address;
     umem_in.size        = length;
     umem_in.access      = IBV_ACCESS_LOCAL_WRITE;
     umem_in.pgsz_bitmap = pgsz_bitmap;
-    dmabuf              = uct_rc_gdaki_get_dmabuf(md, address, length);
-    if (dmabuf.fd != UCT_DMABUF_FD_INVALID) {
-        umem_in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
-        umem_in.dmabuf_fd = dmabuf.fd;
+
+    if (ib_mlx5_md->flags & UCT_IB_MLX5_MD_FLAG_REG_DMABUF_UMEM) {
+        dmabuf = uct_cuda_copy_md_get_dmabuf(address, length,
+                                             UCS_SYS_DEVICE_ID_UNKNOWN);
+        if (dmabuf.fd != UCT_DMABUF_FD_INVALID) {
+            umem_in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
+            umem_in.dmabuf_fd = dmabuf.fd;
+        }
     }
 
     umem = mlx5dv_devx_umem_reg_ex(ibv_context, &umem_in);
-    ucs_close_fd(&dmabuf.fd);
+
+    if (dmabuf.fd != UCT_DMABUF_FD_INVALID) {
+        ucs_close_fd(&dmabuf.fd);
+    }
+
     return umem;
 #else
     return mlx5dv_devx_umem_reg(ibv_context, address, length,
@@ -559,6 +553,9 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
 
         dev_ep = ucs_calloc(1, qp_attr.umem_offset, "dev_ep");
         if (dev_ep == NULL) {
+            ucs_error("failed to allocate dev_ep on host buffer size=%zu ep=%p "
+                      "iface=%p",
+                      qp_attr.umem_offset, ep, iface);
             status = UCS_ERR_NO_MEMORY;
             goto out_ctx;
         }
@@ -604,7 +601,7 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
                                                        dev_ep,
                                                        qp_attr.umem_offset));
         if (status != UCS_OK) {
-            goto out_free;
+            goto out_unreg;
         }
 
         ucs_free(dev_ep);
@@ -681,27 +678,6 @@ static uct_iface_ops_t uct_rc_gdaki_iface_tl_ops = {
             ucs_empty_function_return_unsupported,
 };
 
-static ucs_status_t uct_rc_gdaki_reg_mr(const uct_ib_md_t *md, void *address,
-                                        size_t length, struct ibv_mr **mr_p)
-{
-    uct_md_mem_reg_params_t params;
-    uct_cuda_copy_md_dmabuf_t dmabuf;
-    ucs_status_t status;
-
-    params.field_mask    = UCT_MD_MEM_REG_FIELD_FLAGS |
-                           UCT_MD_MEM_REG_FIELD_DMABUF_FD |
-                           UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET;
-    params.flags         = 0;
-    dmabuf               = uct_rc_gdaki_get_dmabuf(md, address, length);
-    params.dmabuf_fd     = dmabuf.fd;
-    params.dmabuf_offset = dmabuf.offset;
-
-    status = uct_ib_reg_mr(md, address, length, &params,
-                           UCT_IB_MEM_ACCESS_FLAGS, NULL, mr_p);
-    ucs_close_fd(&dmabuf.fd);
-    return status;
-}
-
 static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
                            uct_worker_h worker,
                            const uct_iface_params_t *params,
@@ -711,11 +687,13 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
             ucs_derived_of(tl_config, uct_rc_gdaki_iface_config_t);
     uct_ib_mlx5_md_t *md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
     uct_ib_iface_init_attr_t init_attr = {};
+    uct_md_mem_reg_params_t reg_params = {};
     UCS_STRING_BUFFER_ONSTACK(strb, 64);
     char *gpu_name, *ib_name;
     char pci_addr[UCS_SYS_BDF_NAME_MAX];
     ucs_status_t status;
     int cuda_id;
+    int ret;
 
     if (config->num_channels > UINT8_MAX + 1) {
          ucs_error("num_channels exceeds maximum value of 256");
@@ -774,16 +752,20 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
         goto err_ctx_release;
     }
 
-    status = uct_rc_gdaki_alloc(sizeof(uint64_t), sizeof(uint64_t),
-                                (void**)&self->atomic_buff, &self->atomic_raw);
-    if (status != UCS_OK) {
+    ret = ucs_posix_memalign((void**)&self->atomic_buff,
+                             UCS_SYS_CACHE_LINE_SIZE, sizeof(uint64_t),
+                             "gdaki_atomic_buf");
+    if (ret != 0) {
+        ucs_error("failed to allocate AMO buffer");
+        status = UCS_ERR_NO_MEMORY;
         goto err_ctx;
     }
 
-    status = uct_rc_gdaki_reg_mr(&md->super, self->atomic_buff,
-                                 sizeof(uint64_t), &self->atomic_mr);
+    status = uct_ib_reg_mr(&md->super, self->atomic_buff, sizeof(uint64_t),
+                           &reg_params, UCT_IB_MEM_ACCESS_FLAGS, NULL,
+                           &self->atomic_mr);
     if (status != UCS_OK) {
-        goto err_atomic;
+        goto err_atomic_buff;
     }
 
     if (pthread_mutex_init(&self->ep_init_lock, NULL) != 0) {
@@ -796,8 +778,8 @@ static UCS_CLASS_INIT_FUNC(uct_rc_gdaki_iface_t, uct_md_h tl_md,
 
 err_lock:
     ibv_dereg_mr(self->atomic_mr);
-err_atomic:
-    cuMemFree(self->atomic_raw);
+err_atomic_buff:
+    ucs_free(self->atomic_buff);
 err_ctx:
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));
 err_ctx_release:
@@ -809,7 +791,7 @@ static UCS_CLASS_CLEANUP_FUNC(uct_rc_gdaki_iface_t)
 {
     pthread_mutex_destroy(&self->ep_init_lock);
     ibv_dereg_mr(self->atomic_mr);
-    cuMemFree(self->atomic_raw);
+    ucs_free(self->atomic_buff);
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuDevicePrimaryCtxRelease(self->cuda_dev));
 }
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -22,7 +22,6 @@ typedef struct uct_rc_gdaki_iface {
     uct_rc_mlx5_iface_common_t super;
     CUdevice                   cuda_dev;
     struct ibv_mr              *atomic_mr;
-    CUdeviceptr                atomic_raw;
     uint64_t                   *atomic_buff;
     CUcontext                  cuda_ctx;
     unsigned                   num_channels;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -83,7 +83,7 @@ ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, log_ack_req_freq),
    UCS_CONFIG_TYPE_UINT},
 
-  {"DDP_ENABLE", "try",
+  {"DDP_ENABLE", "n",
    "Enable direct data placement\n",
    ucs_offsetof(uct_rc_mlx5_iface_common_config_t, ddp_enable), 
    UCS_CONFIG_TYPE_TERNARY},

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -195,9 +195,8 @@ ucs_status_t uct_rocm_base_query_devices(uct_md_h md,
 
 hsa_agent_t uct_rocm_base_get_dev_agent(int gpu_num)
 {
-    ucs_assertv(gpu_num < uct_rocm_base_agents.num_gpu,
-                "gpu_num %d, number of gpus %d", gpu_num,
-                uct_rocm_base_agents.num_gpu);
+    ucs_assertv(gpu_num < uct_rocm_base_agents.num_gpu, "gpu %d, num_gpus %d",
+                gpu_num, uct_rocm_base_agents.num_gpu);
     return uct_rocm_base_agents.gpu_agents[gpu_num];
 }
 

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -57,7 +57,8 @@ uct_rocm_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     md_attr->cache_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->alloc_mem_types  = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
+    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
+                                UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ROCM);
     if (md->have_dmabuf) {
         md_attr->dmabuf_mem_types |= UCS_BIT(UCS_MEMORY_TYPE_ROCM);

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -285,7 +285,6 @@ protected:
         region->mapped_addr    = (void *)addr;
         region->refcount       = 1;
         region->cu_dev         = 0;
-        region->in_lru         = 0;
 
         ucs_status_t status = ucs_pgtable_insert(&m_cache->pgtable,
                                                   &region->super);
@@ -294,7 +293,6 @@ protected:
         m_cache->num_regions++;
         m_cache->total_size += REGION_SIZE;
         ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
-        region->in_lru = 1;
 
         return region;
     }
@@ -302,20 +300,28 @@ protected:
     void release_region(uct_cuda_ipc_cache_region_t *region) {
         ASSERT_GE(region->refcount, 1UL);
         region->refcount--;
-        if (!region->in_lru) {
-            ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
-            region->in_lru = 1;
-        }
     }
 
     void reacquire_region(uct_cuda_ipc_cache_region_t *region) {
         /* Move to LRU tail (most recently used) */
-        if (region->in_lru) {
-            ucs_list_del(&region->lru_list);
-        }
+        ucs_list_del(&region->lru_list);
         ucs_list_add_tail(&m_cache->lru_list, &region->lru_list);
-        region->in_lru = 1;
         region->refcount++;
+    }
+
+    void destroy_region(uct_cuda_ipc_cache_region_t *region)
+    {
+        ucs_status_t status = ucs_pgtable_remove(&m_cache->pgtable,
+                                                 &region->super);
+        ASSERT_EQ(UCS_OK, status);
+
+        ucs_list_del(&region->lru_list);
+
+        ASSERT_GT(m_cache->num_regions, 0UL);
+        m_cache->num_regions--;
+        m_cache->total_size -= region->key.b_len;
+
+        ucs_free(region);
     }
 
     void evict_lru() {
@@ -328,16 +334,12 @@ protected:
             }
 
             if (region->refcount > 0) {
-                /* In-use -- pull off LRU, will be re-added on release */
-                ucs_list_del(&region->lru_list);
-                region->in_lru = 0;
                 continue;
             }
 
             ASSERT_EQ(UCS_OK, ucs_pgtable_remove(&m_cache->pgtable,
                                                   &region->super));
             ucs_list_del(&region->lru_list);
-            region->in_lru = 0;
             m_cache->num_regions--;
             m_cache->total_size -= region->key.b_len;
 
@@ -529,4 +531,27 @@ UCS_TEST_F(test_cuda_ipc_cache_lru, unlimited) {
     for (size_t i = 0; i < num_insert; i++) {
         EXPECT_TRUE(pgtable_has(i));
     }
+}
+
+UCS_TEST_F(test_cuda_ipc_cache_lru, stale_destroy_while_in_use) {
+    /* Check that evict_lru does not pull in-use regions off
+     * the LRU. This could cause a failure if region is destroyed
+     * while not in LRU. */
+    create_cache(0 /* force eviction on every insert */, SIZE_MAX);
+
+    uct_cuda_ipc_cache_region_t *r1 = insert_region(0);
+    ASSERT_EQ(1UL, r1->refcount);
+
+    evict_lru();
+
+    /* Core assertion: in-use region must stay on LRU after eviction */
+    EXPECT_EQ(1UL, m_cache->num_regions);
+    EXPECT_TRUE(pgtable_has(0));
+
+    /* Simulate the stale-buffer_id destroy path */
+    destroy_region(r1);
+
+    EXPECT_EQ(0UL, m_cache->num_regions);
+    EXPECT_EQ(0UL, m_cache->total_size);
+    EXPECT_TRUE(ucs_list_is_empty(&m_cache->lru_list));
 }

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -2,7 +2,6 @@
 %bcond_without cma
 %bcond_with    cuda
 %bcond_with    gdrcopy
-%bcond_with    gda
 %bcond_without ib
 %bcond_with    knem
 %bcond_without rdmacm
@@ -137,7 +136,6 @@ Provides header files and examples for developing with UCX.
            %_with_arg ugni ugni \
            %_with_arg mad mad \
            %_with_arg ze ze \
-           %_with_arg gda gda \
            %{?configure_options}
 make %{?_smp_mflags} V=1
 
@@ -214,7 +212,7 @@ Provides static libraries required for developing with UCX.
 %if %{with vfs}
 %{_libdir}/pkgconfig/ucx-fuse.pc
 %endif
-%if %{with gda}
+%if %{with cuda} && %{with mlx5}
 %{_libdir}/pkgconfig/ucx-ib-mlx5-gda.pc
 %endif
 
@@ -434,7 +432,7 @@ Provides oneAPI Level Zero (ZE) Runtime support for UCX.
 %{_libdir}/ucx/libucm_ze.so.*
 %endif
 
-%if %{with gda}
+%if %{with cuda} && %{with mlx5}
 %package ib-mlx5-gda
 Requires: %{name}-cuda%{?_isa} = %{version}-%{release}
 Requires: %{name}-ib%{?_isa} = %{version}-%{release}

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -165,6 +165,7 @@ rm -f %{buildroot}%{_libdir}/ucx/lib*.so
 
 %files devel
 %{_includedir}/uc*
+%exclude %{_includedir}/uct/ib/mlx5/gdaki*
 %{_libdir}/lib*.so
 %{_libdir}/pkgconfig/ucx.pc
 %{_libdir}/pkgconfig/ucx-uct.pc
@@ -445,7 +446,8 @@ to initiate network communications directly without explicit synchronization
 with the host CPU.
 
 %files ib-mlx5-gda
-%{_libdir}/ucx/libuct_ib_mlx5_gda.so.*
+%{_libdir}/ucx/libuct_ib_mlx5_gda.*
+%{_includedir}/uct/ib/mlx5/gdaki/*
 %endif
 
 %changelog


### PR DESCRIPTION
## Summary

Disable mlx5 DDP by default by changing the common RC/DC mlx5 `DDP_ENABLE` default from `try` to `n`.

DDP remains available as an explicit opt-in with `UCX_RC_MLX5_DDP_ENABLE` / `UCX_DC_MLX5_DDP_ENABLE`.

## Rationale

The current default can enable DDP automatically on capable mlx5 devices. In high fan-in message workloads, the DDP-enabled path can lose forward progress, while forcing DDP off avoids the hang. This change makes the non-DDP path the default and keeps DDP available for explicit testing or deployment.

## Validation

- Built UCX successfully.
- Confirmed the patched configuration reports `UCX_RC_MLX5_DDP_ENABLE=n` and `UCX_DC_MLX5_DDP_ENABLE=n` by default.
- Verified an internal high fan-in MPI reproducer passes with the patched default.
- Verified the same reproducer still fails when mlx5 DDP is explicitly forced back to `try`.

## Status

WIP-DNM pending agreement on whether default-off is the desired mitigation or whether a narrower DDP-side fix is required.
