### PR TITLE
UCP/WIREUP: Add device lanes that can access host memory - v1.21.x

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -898,14 +898,14 @@ static void ucp_wireup_unset_tl_by_md(const ucp_wireup_select_params_t *sparams,
 }
 
 static void ucp_wireup_memaccess_bitmap(ucp_context_h context,
-                                        ucs_memory_type_t mem_type,
+                                        uint64_t mem_type_bitmap,
                                         ucp_tl_bitmap_t *tl_bitmap)
 {
     const uint64_t md_reg_flags = UCT_MD_FLAG_NEED_MEMH | UCT_MD_FLAG_NEED_RKEY;
 
     /* If a local or a remote key is needed, the memory domain has to be able
        to register. Otherwise, it must be able to access. */
-    ucp_context_memaccess_tl_bitmap(context, UCS_BIT(mem_type), md_reg_flags,
+    ucp_context_memaccess_tl_bitmap(context, mem_type_bitmap, md_reg_flags,
                                     tl_bitmap);
 }
 
@@ -936,7 +936,8 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
     mem_criteria.alloc_mem_types = 0;
     mem_criteria.lane_type       = lane_type;
 
-    ucp_wireup_memaccess_bitmap(context, mem_type, &mem_type_tl_bitmap);
+    ucp_wireup_memaccess_bitmap(context, UCS_BIT(mem_type),
+                                &mem_type_tl_bitmap);
     UCS_STATIC_BITMAP_AND_INPLACE(&mem_type_tl_bitmap, tl_bitmap);
 
     status = ucp_wireup_select_transport(select_ctx, select_params,
@@ -1878,7 +1879,7 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
                 continue;
             }
 
-            ucp_wireup_memaccess_bitmap(worker->context, mem_type,
+            ucp_wireup_memaccess_bitmap(worker->context, UCS_BIT(mem_type),
                                         &mem_type_tl_bitmap);
             UCS_STATIC_BITMAP_AND_INPLACE(&mem_type_tl_bitmap, tl_bitmap);
 
@@ -2204,7 +2205,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
 
         ucs_memory_type_for_each(mem_type) {
-            ucp_wireup_memaccess_bitmap(context, mem_type, &mem_type_tl_bitmap);
+            ucp_wireup_memaccess_bitmap(context, UCS_BIT(mem_type),
+                                        &mem_type_tl_bitmap);
 
             found_lane |= ucp_wireup_add_bw_lanes(
                     select_params, &bw_info,
@@ -2456,6 +2458,19 @@ static double ucp_wireup_device_score_func(const ucp_worker_iface_t *wiface,
                                             dev_count) / UCS_MBYTE;
 }
 
+static int ucp_wireup_add_bw_lanes_mem_type(
+        ucp_context_h context, uint64_t mem_type_bitmap,
+        const ucp_wireup_select_params_t *select_params,
+        ucp_wireup_select_bw_info_t *bw_info,
+        ucp_wireup_select_context_t *select_ctx)
+{
+    ucp_tl_bitmap_t mem_type_tl_bitmap;
+
+    ucp_wireup_memaccess_bitmap(context, mem_type_bitmap, &mem_type_tl_bitmap);
+    return ucp_wireup_add_bw_lanes(select_params, bw_info, mem_type_tl_bitmap,
+                                   UCP_NULL_LANE, select_ctx, 0);
+}
+
 /* Also ignore error mode when set to peer failure */
 static ucs_status_t
 ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
@@ -2464,10 +2479,16 @@ ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
     ucp_context_h context  = select_params->ep->worker->context;
     unsigned ep_init_flags = ucp_wireup_ep_init_flags(select_params,
                                                       select_ctx);
-    ucp_wireup_select_flags_t iface_rma_flags, peer_rma_flags;
+    const uint64_t mem_type_bitmaps[] = {
+        /* CUDA -> CUDA */
+        UCS_BIT(UCS_MEMORY_TYPE_CUDA),
+        /* CUDA -> Host */
+        UCS_BIT(UCS_MEMORY_TYPE_CUDA) | UCS_BIT(UCS_MEMORY_TYPE_HOST)
+    };
     ucp_wireup_select_bw_info_t bw_info = {};
-    ucp_tl_bitmap_t mem_type_tl_bitmap;
-    int found_lane;
+    int found_lane = 0;
+    ucp_wireup_select_flags_t iface_rma_flags, peer_rma_flags;
+    size_t i;
 
     if (!context->config.ext.proto_enable ||
         (ep_init_flags &
@@ -2498,12 +2519,12 @@ ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
      * memory list creation.
      */
     bw_info.max_lanes = ucp_wireup_bw_max_lanes(select_params);
+    for (i = 0; i < ucs_static_array_size(mem_type_bitmaps); ++i) {
+        found_lane |= ucp_wireup_add_bw_lanes_mem_type(
+                context, mem_type_bitmaps[i], select_params, &bw_info,
+                select_ctx);
+    }
 
-    ucp_wireup_memaccess_bitmap(context, UCS_MEMORY_TYPE_CUDA,
-                                &mem_type_tl_bitmap);
-    found_lane = ucp_wireup_add_bw_lanes(select_params, &bw_info,
-                                         mem_type_tl_bitmap, UCP_NULL_LANE,
-                                         select_ctx, 0);
     if (!found_lane) {
         ucs_debug("ep %p: could not find device lanes", select_params->ep);
     }


### PR DESCRIPTION
## What?
Add device lanes that can access host memory.

## Why?
`cuda_ipc` lanes can outscore `rc_gda` lanes on bandwidth. However, `cuda_ipc` can only be used for D2D data transfer. Therefore, absent of `rc_gda` memory disables D2H data transfers.
Moreover, `rc_gda` lanes are still needed as a fallback, when `cuda_ipc` cannot be used, e.g. when the nodes are in different domains.