### PR TITLE
UCP/PROTO: Endpoint without p2p lane or cm lane are considered final - v1.21.x

### DIFF
--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -82,8 +82,12 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
     UCS_STRING_BUFFER_ONSTACK(strb, 256);
     ucs_status_t status;
 
-    /* This protocol should not be selected for valid and connected endpoint */
-    if (ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED) {
+    /* EP is in final state when the remote is connected, or there is no
+     * p2p lane and the configuration index is already the latest.
+     */
+    if ((ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED) ||
+        (!ucp_ep_config(ep)->p2p_lanes && !ucp_ep_has_cm_lane(ep) &&
+         (ep->cfg_index == req->send.proto_config->ep_cfg_index))) {
         if (ucp_proto_reconfig_report_no_rma_emulation_no_proto(req, ep)) {
             ucp_proto_request_abort(req, UCS_ERR_CANCELED);
             return UCS_OK;

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -1871,3 +1871,52 @@ UCS_TEST_SKIP_COND_P(test_ucp_address_v2, diff_seg_sizes,
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_address_v2)
+
+class test_ucp_reconfig_connect_remote : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_RMA);
+    }
+
+    void init() override
+    {
+        if (!is_proto_enabled()) {
+            UCS_TEST_SKIP_R("Proto v2 is disabled");
+        }
+
+        modify_config("PROTOS", "^put*");
+        ucp_test::init();
+    }
+};
+
+/*
+ * This test excludes all put protocols to force proto_reconfig for put
+ * operations and verifies the request completes with UCS_ERR_CANCELED rather
+ * than hanging.
+ */
+UCS_TEST_P(test_ucp_reconfig_connect_remote, put_canceled)
+{
+    ucs::watchdog_set(ucs::WATCHDOG_TEST, 30.0);
+    scoped_log_handler slh(wrap_errors_logger);
+
+    sender().connect(&receiver(), get_ep_params());
+    if (!is_loopback()) {
+        receiver().connect(&sender(), get_ep_params());
+    }
+
+    static const size_t size = 4096;
+    std::vector<uint8_t> sendbuf(size, 0xab);
+    mapped_buffer recvbuf(size, receiver());
+    ucs::handle<ucp_rkey_h> rkey;
+    recvbuf.rkey(sender(), rkey);
+
+    ucp_request_param_t param = {};
+    auto sreq                 = ucp_put_nbx(sender().ep(), sendbuf.data(), size,
+                                            (uintptr_t)recvbuf.ptr(),
+                                            rkey.get(), &param);
+    ucs_status_t status       = request_wait(sreq);
+    EXPECT_EQ(UCS_ERR_CANCELED, status);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_reconfig_connect_remote, tcp, "tcp")


### PR DESCRIPTION
## What?
backport #11440.