### PR TITLE
CI/BUILD: Add Ubuntu 26.04 and TencentOS 4.4 to PR build matrix

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -18,6 +18,7 @@ runs_on_dockers:
   - { name: "ubuntu2004-mofed5.0", url: "harbor.mellanox.com/ucx/x86_64/ubuntu20.04/builder:mofed-5.0-1.0.0.0", arch: x86_64 }
   - { name: "ubuntu2204-mofed5.7", url: "harbor.mellanox.com/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0", arch: x86_64 }
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0", arch: x86_64 }
+  - { name: "ubuntu2604-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu26.04/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
   - { name: "rocky89-mofed24.10", url: "harbor.mellanox.com/hpcx/x86_64/rocky8.9/builder:mofed-24.10-3.2.5.0", arch: x86_64 }
   - { name: "rocky96-mofed24.10", url: "harbor.mellanox.com/hpcx/x86_64/rocky9.6/builder:mofed-24.10-3.2.5.0", arch: x86_64 }
   - { name: "debian125-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/debian12.5/builder:doca-2.9.0", arch: x86_64 }
@@ -33,15 +34,18 @@ runs_on_dockers:
   - { name: "kylin10sp3-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0", arch: x86_64 }
   - { name: "euleros2sp12-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0", arch: x86_64 }
   - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
+  - { name: "tencentos44-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/tencentos4.4/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
   - { name: "ubuntu2004-rocm5.4", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2004:rocm_5_4_0", arch: x86_64 }
   - { name: "ubuntu2204-rocm6.0", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2204:rocm-6.0.0", arch: x86_64 }
   # aarch64
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0", arch: aarch64 }
+  - { name: "ubuntu2604-mofed26.04", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu26.04/builder:mofed-26.04-0.7.6.0", arch: aarch64 }
   - { name: "rocky89-mofed24.10", url: "harbor.mellanox.com/hpcx/aarch64/rocky8.9/builder:mofed-24.10-3.2.5.0", arch: aarch64 }
   - { name: "rocky96-mofed24.10", url: "harbor.mellanox.com/hpcx/aarch64/rocky9.6/builder:mofed-24.10-3.2.5.0", arch: aarch64 }
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/aarch64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: aarch64 }
   - { name: "sles15sp7-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/sles15sp7/builder:mofed-26.01-0.8.8.0", arch: aarch64 }
   - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: aarch64 }
+  - { name: "tencentos44-mofed26.04", url: "harbor.mellanox.com/hpcx/aarch64/tencentos4.4/builder:mofed-26.04-0.7.6.0", arch: aarch64 }
   - { name: "sles16sp0-mofed26.01", url: "harbor.mellanox.com/hpcx/aarch64/sles16sp0/builder:mofed-26.01-0.8.0.0", arch: aarch64 }
 
 taskName: '${arch}/${name}'

--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Nathan Hjelm <hjelmn@lanl.gov>
 Netanel Yosephian <netanelyo@mellanox.com>
 Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>
+Or Balayla <obalayla@nvidia.com>
 Ovidiu Mara <ovidium@nvidia.com>
 Pak Lui <Pak.Lui@amd.com>
 Paul Taylor <pataylor@nvidia.com>

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -75,6 +75,8 @@ jobs:
             CONTAINER: ctyunos2507
           ubuntu2604:
             CONTAINER: ubuntu2604
+          tencentos44:
+            CONTAINER: tencentos44
       # ARM matrix
       ${{ if contains(parameters.name, 'aarch64') }}:
         matrix:
@@ -94,6 +96,8 @@ jobs:
             CONTAINER: sles16sp0_aarch64
           ubuntu2604_aarch64:
             CONTAINER: ubuntu2604_aarch64
+          tencentos44_aarch64:
+            CONTAINER: tencentos44_aarch64
     timeoutInMinutes: 340
 
     steps:

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -73,6 +73,8 @@ jobs:
             CONTAINER: euleros2sp12
           ctyunos2507:
             CONTAINER: ctyunos2507
+          ubuntu2604:
+            CONTAINER: ubuntu2604
       # ARM matrix
       ${{ if contains(parameters.name, 'aarch64') }}:
         matrix:
@@ -90,6 +92,8 @@ jobs:
             CONTAINER: ctyunos2507_aarch64
           sles16sp0_aarch64:
             CONTAINER: sles16sp0_aarch64
+          ubuntu2604_aarch64:
+            CONTAINER: ubuntu2604_aarch64
     timeoutInMinutes: 340
 
     steps:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -84,6 +84,12 @@ resources:
     - container: ubuntu2604_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ubuntu26.04/builder:mofed-26.04-0.7.6.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: tencentos44
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/tencentos4.4/builder:mofed-26.04-0.7.6.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: tencentos44_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/tencentos4.4/builder:mofed-26.04-0.7.6.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -78,6 +78,12 @@ resources:
     - container: ubuntu2404_doca31_gpunetio
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu24.04/builder:doca-3.1.0-gpunetio
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
+    - container: ubuntu2604
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu26.04/builder:mofed-26.04-0.7.6.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2604_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ubuntu26.04/builder:mofed-26.04-0.7.6.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -397,7 +397,8 @@ build_cmake_examples() {
 
 		mkdir -p /tmp/cmake-ucx
 		pushd /tmp/cmake-ucx
-		cmake ${WORKSPACE}/examples/cmake -DCMAKE_PREFIX_PATH=$ucx_inst
+		cmake ${WORKSPACE}/examples/cmake -DCMAKE_PREFIX_PATH=$ucx_inst \
+		      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 		cmake --build .
 
 		if ./test_ucp && ./test_uct


### PR DESCRIPTION
## What?
Add Ubuntu 26.04 (x86_64 + aarch64) and TencentOS 4.4 (x86_64 + aarch64) builder containers to the PR build matrix in `buildlib/pr/main.yml` and `buildlib/pr/build_job.yml`. MOFED builder images only, no inbox variants.

A small follow-up commit (`BUILD: Set CMAKE_POLICY_VERSION_MINIMUM in examples cmake test`) is bundled because the new Ubuntu 26.04 aarch64 builder ships CMake 4.x, which dropped support for `cmake_minimum_required(VERSION 2.8)` in `examples/cmake/CMakeLists.txt`. Passing `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` at the CI invocation keeps both ends working: RHEL 7.6's CMake 2.8.12 ignores the unknown variable, CMake 4.x uses it to accept the existing 2.8 declaration.

## Why?
Add coverage for two new OSes whose HPC-X builder images are now in harbor. TencentOS 4.4 is the customer-requested replacement for TencentOS 3.3 (Redmine FR #4843699, JIRA HPCINFRA-4312 parent).

Per dpressle's review on this PR, the TencentOS 4.4 image tag was switched from `doca-3.1.0` to `mofed-26.04-0.7.6.0`. TencentOS 4.4 is not supported in DOCA-host 3.1.0, and MOFED `26.04-0.7.6.0` is the first GA line that ships a `tencentos4.4` package dir — same MOFED tag the Ubuntu 26.04 row right above uses.

## CI status
All checks introduced or affected by this PR pass: `Codestyle commit title`, `Codestyle AUTHORS file update check`, `Build build_x86_64 ubuntu2604`, `Build build_x86_64 tencentos44`, `Build build_aarch64 ubuntu2604_aarch64`, `Build build_aarch64 tencentos44_aarch64`, and `Build build_x86_64 rhel76` (which the cmake commit fixes).

Marking ready once captainx changes in https://github.com/Mellanox-lab/hpcx-build/pull/84 are merged (the TencentOS 4.4 image we point at was produced from that branch).
