### PR TITLE
UCS/ASYNC: Filter stale missed fd events

### DIFF
--- a/src/ucs/async/async.c
+++ b/src/ucs/async/async.c
@@ -658,7 +658,19 @@ void __ucs_async_poll_missed(ucs_async_context_t *async)
         if (handler != NULL) {
             ucs_assert(handler->async == async);
             handler->missed = 0;
-            ucs_async_handler_invoke(handler, events);
+            if (handler_id < UCS_ASYNC_TIMER_ID_MIN) {
+                events &= handler->events;
+            }
+
+            if ((handler_id >= UCS_ASYNC_TIMER_ID_MIN) || (events != 0)) {
+                ucs_async_handler_invoke(handler, events);
+            } else {
+                ucs_trace_async("skipping stale missed "
+                                UCS_ASYNC_HANDLER_FMT
+                                " with current events 0x%x",
+                                UCS_ASYNC_HANDLER_ARG(handler),
+                                handler->events);
+            }
             ucs_async_handler_put(handler);
         }
         UCS_ASYNC_UNBLOCK(async);

--- a/src/uct/tcp/tcp_sockcm_ep.c
+++ b/src/uct/tcp/tcp_sockcm_ep.c
@@ -549,7 +549,6 @@ ucs_status_t uct_tcp_sockcm_ep_send(uct_tcp_sockcm_ep_t *cep)
     }
 
     if (uct_tcp_sockcm_ep_send_skip_event(cep)) {
-        ucs_assert(!(cep->state & UCT_TCP_SOCKCM_EP_DISCONNECTING));
         return UCS_OK;
     }
 

--- a/test/gtest/ucs/test_async.cc
+++ b/test/gtest/ucs/test_async.cc
@@ -10,6 +10,7 @@
 extern "C" {
 #include <ucs/arch/atomic.h>
 #include <ucs/async/async.h>
+#include <ucs/async/async_int.h>
 #include <ucs/async/pipe.h>
 #include <ucs/sys/sys.h>
 }
@@ -639,6 +640,35 @@ UCS_TEST_P(test_async, ctx_event_block_two_miss) {
 
     le.check_miss();
     EXPECT_GT(le.count(), prev_count);
+}
+
+UCS_TEST_SKIP_COND_P(test_async, modify_missed_event,
+                     GetParam() == UCS_ASYNC_MODE_POLL)
+{
+    local_event le(GetParam());
+    const int event_id = le.event_id();
+    ucs_status_t status;
+    int count;
+
+    ASSERT_UCS_OK(ucs_async_modify_handler(event_id, UCS_EVENT_SET_EVREAD |
+                                                     UCS_EVENT_SET_EVWRITE));
+    le.block();
+    count = le.count();
+
+    std::thread([event_id, &status]() {
+        int handler_id = event_id;
+
+        status = ucs_async_dispatch_handlers(&handler_id, 1,
+                                             UCS_EVENT_SET_EVWRITE);
+    }).join();
+
+    EXPECT_EQ(UCS_ERR_NO_PROGRESS, status);
+    EXPECT_EQ(count, le.count());
+    le.unblock();
+
+    ASSERT_UCS_OK(ucs_async_modify_handler(event_id, UCS_EVENT_SET_EVREAD));
+    le.check_miss();
+    EXPECT_EQ(count, le.count());
 }
 
 UCS_TEST_P(test_async, ctx_timer_block) {


### PR DESCRIPTION
## What?
A missed fd event can be queued while the async context is blocked. Recheck events against the current mask before invoking the callback prevents tcp_sockcm from receiving a stale EVWRITE after it already
dropped EVWRITE and entered disconnecting state.

## Why?
Fixes #11455