### PR TITLE
UCT/IB/GDAKI: Use NVML to enumerate GPUs in dev_matrix_init

### DIFF
--- a/src/uct/cuda/base/cuda_nvml.c
+++ b/src/uct/cuda/base/cuda_nvml.c
@@ -49,7 +49,9 @@
 
 #define UCT_CUDA_NVML_FOR_EACH_ACTION(_macro, _fail_action) \
     _macro(nvmlInit_v2, _fail_action); \
+    _macro(nvmlDeviceGetCount_v2, _fail_action); \
     _macro(nvmlDeviceGetHandleByIndex, _fail_action); \
+    _macro(nvmlDeviceGetPciInfo_v3, _fail_action); \
     _macro(nvmlDeviceGetFieldValues, _fail_action); \
     _macro(nvmlDeviceGetNvLinkRemotePciInfo, _fail_action); \
     _macro(nvmlShutdown, _fail_action)

--- a/src/uct/cuda/base/cuda_nvml.h
+++ b/src/uct/cuda/base/cuda_nvml.h
@@ -34,7 +34,9 @@
 
 
 #define UCT_CUDA_NVML_FOR_EACH(_macro) \
+    _macro(nvmlDeviceGetCount_v2, unsigned*); \
     _macro(nvmlDeviceGetHandleByIndex, unsigned, nvmlDevice_t*); \
+    _macro(nvmlDeviceGetPciInfo_v3, nvmlDevice_t, nvmlPciInfo_t*); \
     _macro(nvmlDeviceGetFieldValues, nvmlDevice_t, int, nvmlFieldValue_t*); \
     _macro(nvmlDeviceGetNvLinkRemotePciInfo, nvmlDevice_t, unsigned int, \
            nvmlPciInfo_t*)

--- a/src/uct/ib/mlx5/gdaki/Makefile.am
+++ b/src/uct/ib/mlx5/gdaki/Makefile.am
@@ -16,7 +16,7 @@ libuct_ib_mlx5_gda_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
                                  $(top_builddir)/src/uct/ib/libuct_ib.la \
                                  $(top_builddir)/src/uct/ib/mlx5/libuct_ib_mlx5.la \
                                  $(top_builddir)/src/uct/cuda/libuct_cuda.la \
-                                 $(CUDA_LIBS)
+                                 $(CUDA_LIBS) $(NVML_LIBS)
 libuct_ib_mlx5_gda_ladir       = $(includedir)/uct/ib/mlx5/gdaki
 
 libuct_ib_mlx5_gda_la_SOURCES = \

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1187,6 +1187,7 @@ typedef struct {
 typedef struct {
     ucs_sys_device_t sys_dev;
     uint64_t         cuda_map;
+    int              direct_nic;
 } uct_gdaki_dev_matrix_elem_t;
 
 typedef struct {
@@ -1240,7 +1241,8 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 
     status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetCount_v2, &nvml_dev_count);
     if (status != UCS_OK) {
-        /* NVML unavailable: keep legacy CUDA-only enumeration. */
+        ucs_diag("NVML unavailable: using legacy CUDA-only enumeration");
+
         for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
             status = uct_gdaki_get_cuda_sys_dev(cuda_idx,
                                                 &gpus[cuda_idx].sys_dev);
@@ -1358,18 +1360,19 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
                                             sysfs_path, 0);
         context = ibv_open_device(ibdev);
         if (context == NULL) {
-            ucs_diag("ibv_open_device(%s) failed: %m, can't detect direct NIC "
-                     "device",
-                     ibv_get_device_name(ibdev));
-        } else {
-            uct_ib_mlx5dv_check_direct_nic(context, sys_dev_ib,
-                                           ib_md->config.direct_nic);
-            ibv_close_device(context);
+            ucs_error("ibv_open_device(%s) failed: %m",
+                      ibv_get_device_name(ibdev));
+            status = UCS_ERR_IO_ERROR;
+            goto out;
         }
 
+        ibdesc->direct_nic = uct_ib_mlx5dv_check_direct_nic(context, sys_dev_ib,
+                                                            1) !=
+                             UCS_SYS_DEVICE_ID_UNKNOWN;
         ibdesc->sys_dev = ucs_topo_get_sysfs_dev(ibv_get_device_name(ibdev),
                                                  sysfs_path, 0);
         scores[ibdev_index].index = ibdev_index;
+        ibv_close_device(context);
     }
 
     /* Enumerate physical GPUs via NVML (or CUDA fallback). NVML is used here
@@ -1411,6 +1414,12 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
                 ibdesc->cuda_map |= UCS_BIT(gpus[gpu_index].cuda_idx);
             }
             scores[ibdev_index].usecount++;
+
+            /* direct NIC is closest and can be only one */
+            if (ibdesc->direct_nic) {
+                ucs_assert_always(ibdev_index == 0);
+                break;
+            }
         }
     }
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -25,7 +25,7 @@
 
 #include "gpunetio/common/doca_gpunetio_verbs_def.h"
 
-#define UCT_GDAKI_MAX_CUDA_PER_IB 64
+#define UCT_GDAKI_MAX_CUDA_DEVICES 64
 
 #define UCT_GDAKI_CQ_PAGE_OFFSET_SHIFT 6
 #define UCT_GDAKI_DEV_EP_SIZE          64
@@ -1201,15 +1201,29 @@ static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
 
     /* Prefer lower latency device, and if same latency prefer the less utilized */
     return (ucs_fp_compare(a->dist.latency, b->dist.latency) *
-            UCT_GDAKI_MAX_CUDA_PER_IB) +
+            UCT_GDAKI_MAX_CUDA_DEVICES) +
            ucs_signum(a->usecount - b->usecount);
+}
+
+static ucs_status_t uct_gdaki_get_cuda_sys_dev(int cuda_idx,
+                                               ucs_sys_device_t *p_sys_dev)
+{
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_dev, cuda_idx));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *p_sys_dev = uct_cuda_get_sys_dev(cuda_dev);
+    return UCS_OK;
 }
 
 static ucs_status_t
 uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 {
-    unsigned nvml_count, i;
-    int cudadev_count, cuda_idx;
+    unsigned nvml_dev_count, nvml_idx;
+    int cuda_dev_count, cuda_idx;
     ucs_sys_bus_id_t bus_id;
     nvmlDevice_t nvml_dev;
     nvmlPciInfo_t nvml_pci;
@@ -1217,32 +1231,31 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
     CUdevice cuda_dev;
     ucs_status_t status;
 
-    status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetCount_v2, &nvml_count);
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cuda_dev_count));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_assert_always(cuda_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
+
+    status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetCount_v2, &nvml_dev_count);
     if (status != UCS_OK) {
         /* NVML unavailable: keep legacy CUDA-only enumeration. */
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cudadev_count));
-        if (status != UCS_OK) {
-            return status;
-        }
-
-        ucs_assert_always(cudadev_count <= UCT_GDAKI_MAX_CUDA_PER_IB);
-        for (cuda_idx = 0; cuda_idx < cudadev_count; cuda_idx++) {
-            status = UCT_CUDADRV_FUNC_LOG_ERR(
-                    cuDeviceGet(&cuda_dev, cuda_idx));
+        for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
+            status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &gpus[cuda_idx].sys_dev);
             if (status != UCS_OK) {
                 return status;
             }
 
-            gpus[cuda_idx].sys_dev  = uct_cuda_get_sys_dev(cuda_dev);
             gpus[cuda_idx].cuda_idx = cuda_idx;
         }
 
-        *count_p = cudadev_count;
+        *count_p = cudad_dev_count;
         return UCS_OK;
     }
 
-    ucs_assert_always(nvml_count <= UCT_GDAKI_MAX_CUDA_PER_IB);
-    for (i = 0; i < nvml_count; i++) {
+    ucs_assert_always(nvml_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
+    for (nvml_idx = 0; i < nvml_dev_count; i++) {
         status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, i,
                                          &nvml_dev);
         if (status != UCS_OK) {
@@ -1260,36 +1273,30 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
         bus_id.slot     = nvml_pci.device;
         bus_id.function = 0;
 
-        status = ucs_topo_find_device_by_bus_id(&bus_id, &gpus[i].sys_dev);
+        status = ucs_topo_find_device_by_bus_id(&bus_id, &gpus[nvml_idx].sys_dev);
         if (status != UCS_OK) {
             return status;
         }
 
-        gpus[i].cuda_idx = -1;
+        gpus[nvml_idx].cuda_idx = -1;
     }
 
     /* Map CUDA-visible devices back to their NVML entry via sys_dev. */
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cudadev_count));
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    for (cuda_idx = 0; cuda_idx < cudadev_count; cuda_idx++) {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_dev, cuda_idx));
+    for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
+        status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &cuda_sys_dev);
         if (status != UCS_OK) {
             return status;
         }
 
-        cuda_sys_dev = uct_cuda_get_sys_dev(cuda_dev);
-        for (i = 0; i < nvml_count; i++) {
-            if (gpus[i].sys_dev == cuda_sys_dev) {
-                gpus[i].cuda_idx = cuda_idx;
+        for (nvml_idx = 0; nvml_idx < nvml_dev_count; nvml_idx++) {
+            if (gpus[nvml_idx].sys_dev == cuda_sys_dev) {
+                gpus[nvml_idx].cuda_idx = cuda_idx;
                 break;
             }
         }
     }
 
-    *count_p = nvml_count;
+    *count_p = nvml_dev_count;
     return UCS_OK;
 }
 
@@ -1298,7 +1305,7 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
 {
     unsigned long ib_per_cuda         = ib_md->config.gda_max_hca_per_gpu;
     uct_gdaki_dev_matrix_elem_t *dmat = NULL;
-    uct_gdaki_gpu_info_t gpus[UCT_GDAKI_MAX_CUDA_PER_IB];
+    uct_gdaki_gpu_info_t gpus[UCT_GDAKI_MAX_CUDA_DEVICES];
     ucs_status_t status;
     int ibdev_index, ibdev_count;
     unsigned gpu_count, gpu_index;

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -21,6 +21,7 @@
 #include <uct/cuda/cuda_copy/cuda_copy_md.h>
 #include <uct/cuda/base/cuda_util.h>
 #include <uct/cuda/base/cuda_ctx.h>
+#include <uct/cuda/base/cuda_nvml.h>
 
 #include "gpunetio/common/doca_gpunetio_verbs_def.h"
 
@@ -1188,6 +1189,11 @@ typedef struct {
     uint64_t         cuda_map;
 } uct_gdaki_dev_matrix_elem_t;
 
+typedef struct {
+    ucs_sys_device_t sys_dev;
+    int              cuda_idx; /* CUDA driver index, -1 if not CUDA-visible */
+} uct_gdaki_gpu_info_t;
+
 static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
 {
     const uct_gdaki_dev_score_t *a = pa;
@@ -1199,21 +1205,109 @@ static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
            ucs_signum(a->usecount - b->usecount);
 }
 
+static ucs_status_t
+uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
+{
+    unsigned nvml_count, i;
+    int cudadev_count, cuda_idx;
+    ucs_sys_bus_id_t bus_id;
+    nvmlDevice_t nvml_dev;
+    nvmlPciInfo_t nvml_pci;
+    ucs_sys_device_t cuda_sys_dev;
+    CUdevice cuda_dev;
+    ucs_status_t status;
+
+    status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetCount_v2, &nvml_count);
+    if (status != UCS_OK) {
+        /* NVML unavailable: keep legacy CUDA-only enumeration. */
+        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cudadev_count));
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        ucs_assert_always(cudadev_count <= UCT_GDAKI_MAX_CUDA_PER_IB);
+        for (cuda_idx = 0; cuda_idx < cudadev_count; cuda_idx++) {
+            status = UCT_CUDADRV_FUNC_LOG_ERR(
+                    cuDeviceGet(&cuda_dev, cuda_idx));
+            if (status != UCS_OK) {
+                return status;
+            }
+
+            gpus[cuda_idx].sys_dev  = uct_cuda_get_sys_dev(cuda_dev);
+            gpus[cuda_idx].cuda_idx = cuda_idx;
+        }
+
+        *count_p = cudadev_count;
+        return UCS_OK;
+    }
+
+    ucs_assert_always(nvml_count <= UCT_GDAKI_MAX_CUDA_PER_IB);
+    for (i = 0; i < nvml_count; i++) {
+        status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, i,
+                                         &nvml_dev);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetPciInfo_v3, nvml_dev,
+                                         &nvml_pci);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        bus_id.domain   = nvml_pci.domain;
+        bus_id.bus      = nvml_pci.bus;
+        bus_id.slot     = nvml_pci.device;
+        bus_id.function = 0;
+
+        status = ucs_topo_find_device_by_bus_id(&bus_id, &gpus[i].sys_dev);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        gpus[i].cuda_idx = -1;
+    }
+
+    /* Map CUDA-visible devices back to their NVML entry via sys_dev. */
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cudadev_count));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    for (cuda_idx = 0; cuda_idx < cudadev_count; cuda_idx++) {
+        status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_dev, cuda_idx));
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        cuda_sys_dev = uct_cuda_get_sys_dev(cuda_dev);
+        for (i = 0; i < nvml_count; i++) {
+            if (gpus[i].sys_dev == cuda_sys_dev) {
+                gpus[i].cuda_idx = cuda_idx;
+                break;
+            }
+        }
+    }
+
+    *count_p = nvml_count;
+    return UCS_OK;
+}
+
 uct_gdaki_dev_matrix_elem_t *
 uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
 {
     unsigned long ib_per_cuda         = ib_md->config.gda_max_hca_per_gpu;
     uct_gdaki_dev_matrix_elem_t *dmat = NULL;
+    uct_gdaki_gpu_info_t gpus[UCT_GDAKI_MAX_CUDA_PER_IB];
     ucs_status_t status;
-    int ibdev_index, cudadev_index, ibdev_count, cudadev_count;
+    int ibdev_index, ibdev_count;
+    unsigned gpu_count, gpu_index;
     struct ibv_device **device_list;
     struct ibv_device *ibdev;
     uct_gdaki_dev_score_t *scores;
     char *path_buffer;
-    ucs_sys_device_t cuda_sys_dev;
     const char *sysfs_path;
     uct_gdaki_dev_matrix_elem_t *ibdesc;
-    CUdevice cuda_dev;
     struct ibv_context *context;
     ucs_sys_device_t sys_dev_ib;
 
@@ -1269,48 +1363,44 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
         scores[ibdev_index].index = ibdev_index;
     }
 
-    /* Get the number of CUDA devices */
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cudadev_count));
+    /* Enumerate physical GPUs via NVML (or CUDA fallback). NVML is used here
+     * so that CUDA_VISIBLE_DEVICES does not hide GPUs from the topology
+     * calculation */
+    status = uct_gdaki_enum_gpus(gpus, &gpu_count);
     if (status != UCS_OK) {
         goto out;
     }
 
-    if (cudadev_count == 0) {
+    if (gpu_count == 0) {
         goto out;
     }
 
-    ucs_assert(cudadev_count < UCT_GDAKI_MAX_CUDA_PER_IB);
-
     if (ib_per_cuda == UCS_ULUNITS_AUTO) {
-        ib_per_cuda = ibdev_count / cudadev_count;
+        ib_per_cuda = ibdev_count / gpu_count;
     }
 
-    /* Map each CUDA device to the best suited IB devices */
-    for (cudadev_index = 0; cudadev_index < cudadev_count; cudadev_index++) {
-        status = UCT_CUDADRV_FUNC_LOG_ERR(
-                cuDeviceGet(&cuda_dev, cudadev_index));
-        if (status != UCS_OK) {
-            goto out;
-        }
-
+    /* Map each GPU to the best suited IB devices */
+    for (gpu_index = 0; gpu_index < gpu_count; gpu_index++) {
         /* Update PCI distance in IB device scores */
-        cuda_sys_dev = uct_cuda_get_sys_dev(cuda_dev);
         for (ibdev_index = 0; ibdev_index < ibdev_count; ibdev_index++) {
             ibdesc = &dmat[scores[ibdev_index].index];
-            status = ucs_topo_get_distance(cuda_sys_dev, ibdesc->sys_dev,
+            status = ucs_topo_get_distance(gpus[gpu_index].sys_dev,
+                                           ibdesc->sys_dev,
                                            &scores[ibdev_index].dist);
             if (status != UCS_OK) {
                 goto out;
             }
         }
 
-        /* Sort and select the best suited IB devices for this CUDA device */
+        /* Sort and select the best suited IB devices for this GPU */
         ucs_qsort_r(scores, ibdev_count, sizeof(*scores),
                     uct_gdaki_dev_matrix_score, NULL);
 
         for (ibdev_index = 0; ibdev_index < ib_per_cuda; ibdev_index++) {
-            ibdesc            = &dmat[scores[ibdev_index].index];
-            ibdesc->cuda_map |= UCS_BIT(cudadev_index);
+            ibdesc = &dmat[scores[ibdev_index].index];
+            if (gpus[gpu_index].cuda_idx >= 0) {
+                ibdesc->cuda_map |= UCS_BIT(gpus[gpu_index].cuda_idx);
+            }
             scores[ibdev_index].usecount++;
         }
     }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -83,20 +83,20 @@ ucs_config_field_t uct_rc_gdaki_iface_config_table[] = {
 
 
 ucs_status_t
-uct_rc_gdaki_alloc(size_t size, size_t align, void **p_buf, CUdeviceptr *p_orig)
+uct_rc_gdaki_alloc(size_t size, size_t align, void **buf_p, CUdeviceptr *orig_p)
 {
     unsigned int flag = 1;
     ucs_status_t status;
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemAlloc(p_orig, size + align - 1));
+    status = UCT_CUDADRV_FUNC_LOG_ERR(cuMemAlloc(orig_p, size + align - 1));
     if (status != UCS_OK) {
         return status;
     }
 
-    *p_buf = (void*)ucs_align_up_pow2_ptr(*p_orig, align);
+    *buf_p = (void*)ucs_align_up_pow2_ptr(*orig_p, align);
     status = UCT_CUDADRV_FUNC_LOG_ERR(
             cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                  (CUdeviceptr)*p_buf));
+                                  (CUdeviceptr)*buf_p));
     if (status != UCS_OK) {
         goto err;
     }
@@ -104,7 +104,7 @@ uct_rc_gdaki_alloc(size_t size, size_t align, void **p_buf, CUdeviceptr *p_orig)
     return UCS_OK;
 
 err:
-    cuMemFree(*p_orig);
+    cuMemFree(*orig_p);
     return status;
 }
 
@@ -1205,17 +1205,18 @@ static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
            ucs_signum(a->usecount - b->usecount);
 }
 
-static ucs_status_t uct_gdaki_get_cuda_sys_dev(int cuda_idx,
-                                               ucs_sys_device_t *p_sys_dev)
+static ucs_status_t
+uct_gdaki_get_cuda_sys_dev(int cuda_idx, ucs_sys_device_t *sys_dev_p)
 {
     ucs_status_t status;
+    CUdevice cuda_dev;
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGet(&cuda_dev, cuda_idx));
     if (status != UCS_OK) {
         return status;
     }
 
-    *p_sys_dev = uct_cuda_get_sys_dev(cuda_dev);
+    *sys_dev_p = uct_cuda_get_sys_dev(cuda_dev);
     return UCS_OK;
 }
 
@@ -1228,7 +1229,6 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
     nvmlDevice_t nvml_dev;
     nvmlPciInfo_t nvml_pci;
     ucs_sys_device_t cuda_sys_dev;
-    CUdevice cuda_dev;
     ucs_status_t status;
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cuda_dev_count));
@@ -1242,7 +1242,8 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
     if (status != UCS_OK) {
         /* NVML unavailable: keep legacy CUDA-only enumeration. */
         for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
-            status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &gpus[cuda_idx].sys_dev);
+            status = uct_gdaki_get_cuda_sys_dev(cuda_idx,
+                                                &gpus[cuda_idx].sys_dev);
             if (status != UCS_OK) {
                 return status;
             }
@@ -1250,13 +1251,13 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
             gpus[cuda_idx].cuda_idx = cuda_idx;
         }
 
-        *count_p = cudad_dev_count;
+        *count_p = cuda_dev_count;
         return UCS_OK;
     }
 
     ucs_assert_always(nvml_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
-    for (nvml_idx = 0; i < nvml_dev_count; i++) {
-        status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, i,
+    for (nvml_idx = 0; nvml_idx < nvml_dev_count; nvml_idx++) {
+        status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, nvml_idx,
                                          &nvml_dev);
         if (status != UCS_OK) {
             return status;
@@ -1273,7 +1274,8 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
         bus_id.slot     = nvml_pci.device;
         bus_id.function = 0;
 
-        status = ucs_topo_find_device_by_bus_id(&bus_id, &gpus[nvml_idx].sys_dev);
+        status = ucs_topo_find_device_by_bus_id(&bus_id,
+                                                &gpus[nvml_idx].sys_dev);
         if (status != UCS_OK) {
             return status;
         }


### PR DESCRIPTION
## Why?
CUDA_VISIBLE_DEVICES hides physical GPUs from cuDeviceGetCount(), which made uct_gdaki_dev_matrix_init() compute the wrong NIC/GPU mapping and ib_per_cuda ratio