### PR TITLE
UCP/WIREUP: Add device lanes that can access host memory.

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -898,14 +898,14 @@ static void ucp_wireup_unset_tl_by_md(const ucp_wireup_select_params_t *sparams,
 }
 
 static void ucp_wireup_memaccess_bitmap(ucp_context_h context,
-                                        ucs_memory_type_t mem_type,
+                                        uint64_t mem_type_bitmap,
                                         ucp_tl_bitmap_t *tl_bitmap)
 {
     const uint64_t md_reg_flags = UCT_MD_FLAG_NEED_MEMH | UCT_MD_FLAG_NEED_RKEY;
 
     /* If a local or a remote key is needed, the memory domain has to be able
        to register. Otherwise, it must be able to access. */
-    ucp_context_memaccess_tl_bitmap(context, UCS_BIT(mem_type), md_reg_flags,
+    ucp_context_memaccess_tl_bitmap(context, mem_type_bitmap, md_reg_flags,
                                     tl_bitmap);
 }
 
@@ -936,7 +936,8 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_add_memaccess_lanes(
     mem_criteria.alloc_mem_types = 0;
     mem_criteria.lane_type       = lane_type;
 
-    ucp_wireup_memaccess_bitmap(context, mem_type, &mem_type_tl_bitmap);
+    ucp_wireup_memaccess_bitmap(context, UCS_BIT(mem_type),
+                                &mem_type_tl_bitmap);
     UCS_STATIC_BITMAP_AND_INPLACE(&mem_type_tl_bitmap, tl_bitmap);
 
     status = ucp_wireup_select_transport(select_ctx, select_params,
@@ -1884,7 +1885,7 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
                 continue;
             }
 
-            ucp_wireup_memaccess_bitmap(worker->context, mem_type,
+            ucp_wireup_memaccess_bitmap(worker->context, UCS_BIT(mem_type),
                                         &mem_type_tl_bitmap);
             UCS_STATIC_BITMAP_AND_INPLACE(&mem_type_tl_bitmap, tl_bitmap);
 
@@ -2210,7 +2211,8 @@ ucp_wireup_add_rma_bw_lanes(const ucp_wireup_select_params_t *select_params,
         UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
 
         ucs_memory_type_for_each(mem_type) {
-            ucp_wireup_memaccess_bitmap(context, mem_type, &mem_type_tl_bitmap);
+            ucp_wireup_memaccess_bitmap(context, UCS_BIT(mem_type),
+                                        &mem_type_tl_bitmap);
 
             found_lane |= ucp_wireup_add_bw_lanes(
                     select_params, &bw_info,
@@ -2467,13 +2469,16 @@ static ucs_status_t
 ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
                             ucp_wireup_select_context_t *select_ctx)
 {
-    ucp_context_h context  = select_params->ep->worker->context;
-    unsigned ep_init_flags = ucp_wireup_ep_init_flags(select_params,
-                                                      select_ctx);
-    ucp_wireup_select_flags_t iface_rma_flags, peer_rma_flags;
+    ucp_context_h context        = select_params->ep->worker->context;
+    const unsigned ep_init_flags = ucp_wireup_ep_init_flags(select_params,
+                                                            select_ctx);
     ucp_wireup_select_bw_info_t bw_info = {};
+    const uint64_t mem_type_bitmaps[]   = {UCS_BIT(UCS_MEMORY_TYPE_CUDA),
+                                           UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                                                   UCS_BIT(UCS_MEMORY_TYPE_HOST)};
+    int found_lane                      = 0;
+    size_t i;
     ucp_tl_bitmap_t mem_type_tl_bitmap;
-    int found_lane;
 
     if (!context->config.ext.proto_enable ||
         (ep_init_flags &
@@ -2485,8 +2490,6 @@ ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
         return UCS_OK;
     }
 
-    ucp_wireup_init_select_flags(&iface_rma_flags, 0, 0);
-    ucp_wireup_init_select_flags(&peer_rma_flags, 0, 0);
     ucp_wireup_criteria_init(&bw_info.criteria);
 
     bw_info.criteria.calc_score = ucp_wireup_device_score_func;
@@ -2505,11 +2508,14 @@ ucp_wireup_add_device_lanes(const ucp_wireup_select_params_t *select_params,
      */
     bw_info.max_lanes = ucp_wireup_bw_max_lanes(select_params);
 
-    ucp_wireup_memaccess_bitmap(context, UCS_MEMORY_TYPE_CUDA,
-                                &mem_type_tl_bitmap);
-    found_lane = ucp_wireup_add_bw_lanes(select_params, &bw_info,
-                                         mem_type_tl_bitmap, UCP_NULL_LANE,
-                                         select_ctx, 0);
+    for (i = 0; i < ucs_static_array_size(mem_type_bitmaps); ++i) {
+        ucp_wireup_memaccess_bitmap(context, mem_type_bitmaps[i],
+                                    &mem_type_tl_bitmap);
+        found_lane |= ucp_wireup_add_bw_lanes(select_params, &bw_info,
+                                              mem_type_tl_bitmap, UCP_NULL_LANE,
+                                              select_ctx, 0);
+    }
+
     if (!found_lane) {
         ucs_debug("ep %p: could not find device lanes", select_params->ep);
     }


### PR DESCRIPTION
## What?
Add device lanes that can access host memory.

## Why?
`cuda_ipc` lanes can outscore `rc_gda` lanes on bandwidth. However, `cuda_ipc` can only be used for D2D data transfer. Therefore, absent of `rc_gda` memory disables D2H data transfers.
Moreover, `rc_gda` lanes are still needed as a fallback, when `cuda_ipc` cannot be used, e.g. when the nodes are in different domains.
