### PR TITLE
UCP/WIREUP: Cleanup code adding a2a lanes.

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -1604,19 +1604,18 @@ ucp_proto_select_info_score_compare(const void *e1, const void *e2,
 }
 
 static int
-ucp_wireup_add_fast_lanes_a2a(ucp_worker_h worker,
-                              ucp_proto_select_info_array_t *sinfo_array,
-                              const ucp_wireup_select_params_t *select_params,
+ucp_wireup_add_fast_lanes_a2a(const ucp_wireup_select_params_t *select_params,
                               ucp_lane_type_t lane_type, unsigned max_lanes,
+                              ucp_proto_select_info_array_t *sinfo_array,
                               ucp_wireup_select_context_t *select_ctx)
 {
     int found_lane         = 0;
     double max_bw          = 0;
     double lane_bw         = 0;
+    ucp_worker_h worker    = select_params->ep->worker;
     ucp_context_h context  = worker->context;
     const double max_ratio = 1. / context->config.ext.multi_lane_max_ratio;
-    int is_local           = select_params->ep->worker->uuid <
-                             select_params->address->uuid;
+    int is_local           = worker->uuid < select_params->address->uuid;
     ucs_status_t status;
     const ucp_wireup_select_info_t *sinfo;
 
@@ -1671,15 +1670,13 @@ ucp_wireup_add_fast_lanes_a2a(ucp_worker_h worker,
 
 static int
 ucp_wireup_add_bw_lanes_a2a(const ucp_wireup_select_params_t *select_params,
-                            ucp_wireup_select_bw_info_t *bw_info,
-                            ucp_tl_bitmap_t tl_bitmap, ucp_lane_index_t excl_lane,
-                            ucp_wireup_select_context_t *select_ctx,
-                            unsigned allow_extra_path)
+                            const ucp_wireup_select_bw_info_t *bw_info,
+                            ucp_tl_bitmap_t tl_bitmap,
+                            ucp_wireup_select_context_t *select_ctx)
 {
     ucp_proto_select_info_array_t sinfo_array = UCS_ARRAY_DYNAMIC_INITIALIZER;
-    ucp_ep_h ep                               = select_params->ep;
-    uint64_t local_dev_bitmap                 = bw_info->local_dev_bitmap;
-    uint64_t remote_dev_bitmap                = bw_info->remote_dev_bitmap;
+    const uint64_t local_dev_bitmap           = bw_info->local_dev_bitmap;
+    const uint64_t remote_dev_bitmap          = bw_info->remote_dev_bitmap;
     ucp_wireup_select_info_t *sinfo;
     int found_lane;
     ucs_status_t status;
@@ -1703,10 +1700,10 @@ ucp_wireup_add_bw_lanes_a2a(const ucp_wireup_select_params_t *select_params,
         }
     }
 
-    found_lane = ucp_wireup_add_fast_lanes_a2a(ep->worker, &sinfo_array,
-                                               select_params,
+    found_lane = ucp_wireup_add_fast_lanes_a2a(select_params,
                                                bw_info->criteria.lane_type,
-                                               bw_info->max_lanes, select_ctx);
+                                               bw_info->max_lanes, &sinfo_array,
+                                               select_ctx);
     ucs_array_cleanup_dynamic(&sinfo_array);
     return found_lane;
 }
@@ -1892,8 +1889,7 @@ ucp_wireup_add_bw_lanes(const ucp_wireup_select_params_t *select_params,
                 found_lane |= ucp_wireup_add_bw_lanes_a2a(select_params,
                                                           bw_info,
                                                           mem_type_tl_bitmap,
-                                                          excl_lane, select_ctx,
-                                                          allow_extra_path);
+                                                          select_ctx);
             }
         }
     }


### PR DESCRIPTION
## What?
Code cleanup: removed unused function parameters; added missed const qualifiers; fixed function parameters order to not mix in and out parameters.