### PR TITLE
UCP/AM: Fix memory release crash.

### DIFF
--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -147,6 +147,16 @@ static UCS_F_ALWAYS_INLINE void ucp_am_release_long_desc(ucp_recv_desc_t *desc)
     ucs_free((char*)desc - desc->release_desc_offset);
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_am_release_data_desc(ucp_recv_desc_t *desc)
+{
+    if (ucs_unlikely(desc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
+        ucp_am_release_long_desc(desc);
+    } else {
+        ucp_recv_desc_release(desc);
+    }
+}
+
 static UCS_F_ALWAYS_INLINE int
 ucp_am_rdesc_in_progress(ucp_recv_desc_t *desc, ucs_status_t am_cb_status)
 {
@@ -1230,7 +1240,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
          */
         desc->flags &= ~UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
     } else {
-        ucp_recv_desc_release(desc);
+        ucp_am_release_data_desc(desc);
     }
 
 out:

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -147,8 +147,7 @@ static UCS_F_ALWAYS_INLINE void ucp_am_release_long_desc(ucp_recv_desc_t *desc)
     ucs_free((char*)desc - desc->release_desc_offset);
 }
 
-static UCS_F_ALWAYS_INLINE void
-ucp_am_release_data_desc(ucp_recv_desc_t *desc)
+static UCS_F_ALWAYS_INLINE void ucp_am_release_data_desc(ucp_recv_desc_t *desc)
 {
     if (ucs_unlikely(desc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
         ucp_am_release_long_desc(desc);

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1230,7 +1230,9 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
          */
         desc->flags &= ~UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
     } else if (ucs_unlikely(desc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
+        UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);
         ucp_am_release_long_desc(desc);
+        return ret;
     } else {
         ucp_recv_desc_release(desc);
     }

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -147,15 +147,6 @@ static UCS_F_ALWAYS_INLINE void ucp_am_release_long_desc(ucp_recv_desc_t *desc)
     ucs_free((char*)desc - desc->release_desc_offset);
 }
 
-static UCS_F_ALWAYS_INLINE void ucp_am_release_data_desc(ucp_recv_desc_t *desc)
-{
-    if (ucs_unlikely(desc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
-        ucp_am_release_long_desc(desc);
-    } else {
-        ucp_recv_desc_release(desc);
-    }
-}
-
 static UCS_F_ALWAYS_INLINE int
 ucp_am_rdesc_in_progress(ucp_recv_desc_t *desc, ucs_status_t am_cb_status)
 {
@@ -1238,8 +1229,10 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
          * returning UCS_OK) back to UCT.
          */
         desc->flags &= ~UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
+    } else if (ucs_unlikely(desc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
+        ucp_am_release_long_desc(desc);
     } else {
-        ucp_am_release_data_desc(desc);
+        ucp_recv_desc_release(desc);
     }
 
 out:

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1455,6 +1455,9 @@ public:
 
         param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
         param.recv_info.length = &recv_length;
+
+	// Dummy data to fix a Coverity false positive.
+	param.user_data  = this;
         param.cb.recv_am = [](void *, ucs_status_t, size_t, void *) {
             ADD_FAILURE();
         };

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1446,11 +1446,11 @@ public:
         ucp_recv_desc_t *rdesc = (ucp_recv_desc_t*)m_data_ptr - 1;
         if (!(rdesc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
             ucp_am_data_release(receiver().worker(), m_data_ptr);
-            UCS_TEST_SKIP_R("eager AM was not assembled into malloc-backed desc");
+            UCS_TEST_SKIP_R("eager AM was not in malloc-backed desc");
         }
 
         std::vector<char> rbuf(size);
-        size_t recv_length = SIZE_MAX;
+        size_t recv_length        = SIZE_MAX;
         ucp_request_param_t param = {};
 
         param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
@@ -1465,7 +1465,7 @@ public:
     }
 
 private:
-    void   *m_data_ptr;
+    void *m_data_ptr;
     size_t m_data_length;
 };
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1405,7 +1405,8 @@ public:
     {
         modify_config("RNDV_THRESH", "inf");
         modify_config("ZCOPY_THRESH", "inf");
-        m_data_ptr = NULL;
+        m_data_ptr    = NULL;
+        m_data_length = 0;
     }
 
     virtual ucs_status_t
@@ -1415,7 +1416,8 @@ public:
         EXPECT_LT(m_recv_counter, m_send_counter);
         EXPECT_TRUE(rx_param->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA);
 
-        m_data_ptr = data;
+        m_data_ptr    = data;
+        m_data_length = length;
 
         check_header(header, header_length);
         mem_buffer::pattern_check(data, length, SEED);
@@ -1434,8 +1436,37 @@ public:
         ucp_am_data_release(receiver().worker(), m_data_ptr);
     }
 
+    void test_recv_data_late(size_t size)
+    {
+        test_am_send_recv(size, 0, 0, UCP_AM_FLAG_PERSISTENT_DATA);
+
+        ASSERT_TRUE(m_data_ptr != NULL);
+        ASSERT_EQ(size, m_data_length);
+
+        ucp_recv_desc_t *rdesc = (ucp_recv_desc_t*)m_data_ptr - 1;
+        if (!(rdesc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
+            ucp_am_data_release(receiver().worker(), m_data_ptr);
+            UCS_TEST_SKIP_R("eager AM was not assembled into malloc-backed desc");
+        }
+
+        std::vector<char> rbuf(size);
+        size_t recv_length = SIZE_MAX;
+        ucp_request_param_t param = {};
+
+        param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
+        param.recv_info.length = &recv_length;
+
+        ucs_status_ptr_t rptr = ucp_am_recv_data_nbx(receiver().worker(),
+                                                     m_data_ptr, rbuf.data(),
+                                                     rbuf.size(), &param);
+        EXPECT_EQ(UCS_OK, request_wait(rptr));
+        EXPECT_EQ(size, recv_length);
+        mem_buffer::pattern_check(rbuf.data(), rbuf.size(), SEED);
+    }
+
 private:
-    void *m_data_ptr;
+    void   *m_data_ptr;
+    size_t m_data_length;
 };
 
 UCS_TEST_P(test_ucp_am_nbx_eager_data_release, short)
@@ -1451,6 +1482,11 @@ UCS_TEST_P(test_ucp_am_nbx_eager_data_release, single)
 UCS_TEST_P(test_ucp_am_nbx_eager_data_release, multi)
 {
     test_data_release(fragment_size() * 2);
+}
+
+UCS_TEST_P(test_ucp_am_nbx_eager_data_release, multi_recv_data_late)
+{
+    test_recv_data_late(fragment_size() * 2);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_am_nbx_eager_data_release)

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1456,9 +1456,13 @@ public:
         param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
         param.recv_info.length = &recv_length;
 
-        // Dummy data to fix a Coverity false positive.
-        param.user_data  = this;
-        param.cb.recv_am = [](void *, ucs_status_t, size_t, void *) {
+        // The following lines are for working around a
+        // false positive NULL dereference in Coverity;
+        // the callback is never called even when set.
+        param.op_attr_mask |= UCP_OP_ATTR_FIELD_USER_DATA;
+        param.user_data     = this;
+        param.op_attr_mask |= UCP_OP_ATTR_FIELD_CALLBACK;
+        param.cb.recv_am    = [](void *, ucs_status_t, size_t, void *) {
             ADD_FAILURE();
         };
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1405,7 +1405,7 @@ public:
     {
         modify_config("RNDV_THRESH", "inf");
         modify_config("ZCOPY_THRESH", "inf");
-        m_data_ptr    = NULL;
+        m_data_ptr    = nullptr;
         m_data_length = 0;
     }
 
@@ -1440,19 +1440,19 @@ public:
     {
         test_am_send_recv(size, 0, 0, UCP_AM_FLAG_PERSISTENT_DATA);
 
-        ASSERT_TRUE(m_data_ptr != NULL);
+        ASSERT_TRUE(m_data_ptr != nullptr);
         ASSERT_EQ(size, m_data_length);
 
-        ucp_recv_desc_t *rdesc = (ucp_recv_desc_t*)m_data_ptr - 1;
+        ucp_recv_desc_t *rdesc = static_cast<ucp_recv_desc_t *>(m_data_ptr) - 1;
         if (!(rdesc->flags & UCP_RECV_DESC_FLAG_MALLOC)) {
             ucp_am_data_release(receiver().worker(), m_data_ptr);
             UCS_TEST_SKIP_R("eager AM was not in malloc-backed desc");
         }
 
         std::vector<char> rbuf(size);
-        size_t recv_length        = SIZE_MAX;
-        ucp_request_param_t param = {};
+        ucp_request_param_t param;
 
+        size_t recv_length     = SIZE_MAX;
         param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
         param.recv_info.length = &recv_length;
 

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1456,8 +1456,8 @@ public:
         param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
         param.recv_info.length = &recv_length;
 
-	// Dummy data to fix a Coverity false positive.
-	param.user_data  = this;
+        // Dummy data to fix a Coverity false positive.
+        param.user_data  = this;
         param.cb.recv_am = [](void *, ucs_status_t, size_t, void *) {
             ADD_FAILURE();
         };

--- a/test/gtest/ucp/test_ucp_am.cc
+++ b/test/gtest/ucp/test_ucp_am.cc
@@ -1455,6 +1455,9 @@ public:
 
         param.op_attr_mask     = UCP_OP_ATTR_FIELD_RECV_INFO;
         param.recv_info.length = &recv_length;
+        param.cb.recv_am = [](void *, ucs_status_t, size_t, void *) {
+            ADD_FAILURE();
+        };
 
         ucs_status_ptr_t rptr = ucp_am_recv_data_nbx(receiver().worker(),
                                                      m_data_ptr, rbuf.data(),


### PR DESCRIPTION
## What?
Correctly handle the case that a receive descriptor with `UCP_RECV_DESC_FLAG_MALLOC` is freed after receiving a large eager AM where the data is collected later with `ucp_am_recv_data_nbx()`, i.e. outside of the AM callback.

## Why?
Otherwise it segfaults after trying to use the wrong memory release function.

## How?
Check for the flag and call the appropriate release function.