### PR TITLE
CI: Use NPROC in all Jenkins jobs

### DIFF
--- a/buildlib/tools/static_checks.sh
+++ b/buildlib/tools/static_checks.sh
@@ -16,7 +16,7 @@ echo "##vso[task.setvariable variable=report_dir]$report_dir"
 export PATH="`csclng --print-path-to-wrap`:`cscppc --print-path-to-wrap`:`cswrap --print-path-to-wrap`:$PATH"
 export CSCLNG_ADD_OPTS="-Xanalyzer:-analyzer-output=html:-o:$report_dir"
 set -o pipefail
-make -j`nproc` |& tee $report_dir/compile.log
+make -j${NPROC} |& tee $report_dir/compile.log
 set +o pipefail
 
 cs_errors="cs.err"

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -867,7 +867,7 @@ test_init_mt() {
 	echo "==== Running multi-thread init ===="
 	# Each thread requires 5MB. Cap threads number by total available shared memory.
 	max_threads=$(df /dev/shm | awk '/shm/ {printf "%d", $4 / 5000}')
-	num_threads=$(($max_threads < $(nproc) ? $max_threads : $(nproc)))
+	num_threads=$(($max_threads < ${NPROC} ? $max_threads : ${NPROC}))
 	$MAKEP
 	for ((i=0;i<10;++i))
 	do


### PR DESCRIPTION
## What?
  Replace remaining raw `nproc` with `${NPROC}` in Jenkins-invoked CI scripts:
  - `buildlib/tools/static_checks.sh`
  - `contrib/test_jenkins.sh` (`test_init_mt`)

  ## Why?
  Follow-up to #11161. Both scripts source `common.sh` but still called `nproc` directly, missing the
  adaptive cap on k8s. 