### PR TITLE
UCS/DATASTRUCT: Add `ucs_string_buffer_vappendf`

### DIFF
--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -58,21 +58,23 @@ static void ucs_string_buffer_add_null_terminator(ucs_string_buffer_t *strb)
     *ucs_array_end(strb) = '\0';
 }
 
-void ucs_string_buffer_appendf(ucs_string_buffer_t *strb, const char *fmt, ...)
+void ucs_string_buffer_vappendf(ucs_string_buffer_t *strb, const char *fmt,
+                                va_list ap)
 {
     ucs_status_t status;
     size_t max_print;
-    va_list ap;
+    va_list ap_retry;
     int ret;
 
     ucs_array_reserve(strb, ucs_array_length(strb) + UCS_STRING_BUFFER_RESERVE);
     ucs_assert(ucs_array_begin(strb) != NULL); /* For coverity */
 
+    /* Keep a copy of `ap` for the grow-and-retry path */
+    va_copy(ap_retry, ap);
+
     /* try to write to existing buffer */
-    va_start(ap, fmt);
     max_print = ucs_array_available_length(strb);
     ret       = vsnprintf(ucs_array_end(strb), max_print, fmt, ap);
-    va_end(ap);
 
     /* if failed, grow the buffer accommodate for the expected extra length */
     if (ret >= max_print) {
@@ -86,10 +88,8 @@ void ucs_string_buffer_appendf(ucs_string_buffer_t *strb, const char *fmt, ...)
             goto out;
         }
 
-        va_start(ap, fmt);
         max_print = ucs_array_available_length(strb);
-        ret       = vsnprintf(ucs_array_end(strb), max_print, fmt, ap);
-        va_end(ap);
+        ret       = vsnprintf(ucs_array_end(strb), max_print, fmt, ap_retry);
 
         /* since we've grown the buffer, it should be sufficient now */
         ucs_assertv(ret < max_print, "ret=%d max_print=%zu", ret, max_print);
@@ -100,8 +100,18 @@ void ucs_string_buffer_appendf(ucs_string_buffer_t *strb, const char *fmt, ...)
 
     /* \0 should be written by vsnprintf */
 out:
+    va_end(ap_retry);
     ucs_assert(ucs_array_available_length(strb) >= 1);
     ucs_assert(*ucs_array_end(strb) == '\0');
+}
+
+void ucs_string_buffer_appendf(ucs_string_buffer_t *strb, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    ucs_string_buffer_vappendf(strb, fmt, ap);
+    va_end(ap);
 }
 
 void ucs_string_buffer_append_hex(ucs_string_buffer_t *strb, const void *data,

--- a/src/ucs/datastruct/string_buffer.h
+++ b/src/ucs/datastruct/string_buffer.h
@@ -12,6 +12,7 @@
 #include <ucs/datastruct/array.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -151,6 +152,17 @@ size_t ucs_string_buffer_length(ucs_string_buffer_t *strb);
  */
 void ucs_string_buffer_appendf(ucs_string_buffer_t *strb, const char *fmt, ...)
     UCS_F_PRINTF(2, 3);
+
+
+/**
+ * va_list counterpart of @ref ucs_string_buffer_appendf.
+ *
+ * @param [inout] strb   String buffer to append to.
+ * @param [in]    fmt    Format string.
+ * @param [in]    ap     Variadic argument list. Caller must va_end() it.
+ */
+void ucs_string_buffer_vappendf(ucs_string_buffer_t *strb, const char *fmt,
+                                va_list ap);
 
 
 /**


### PR DESCRIPTION
## What?
Add `ucs_string_buffer_vappendf` to the string buffer API, then use it in the existing `ucs_string_buffer_appendf`
Functionality for existing callers of `ucs_string_buffer_appendf` does not change.

## Why?
This variation of `appendf` allows callers with variadic args to call `appendf` on a string buffer directly.
The existing API does not allow this, and callers have to format the string into a helper buffer before calling  `ucs_string_buffer_appendf`.

***NOTE:*** This will be used in a later PR
