### PR TITLE
UCT/IB: accept RTN_LOCAL routes for RoCE reachability

### DIFF
--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -35,6 +35,7 @@ typedef struct {
 typedef struct {
     struct sockaddr_storage dest;
     uint8_t                 subnet_prefix_len;
+    uint8_t                 route_type;
 } ucs_netlink_route_entry_t;
 
 UCS_ARRAY_DECLARE_TYPE(ucs_netlink_rt_rules_t, unsigned,
@@ -243,6 +244,7 @@ ucs_netlink_parse_rt_entry_cb(const struct nlmsghdr *nlh, void *arg)
     }
 
     new_rule->subnet_prefix_len = rt_msg->rtm_dst_len;
+    new_rule->route_type        = rt_msg->rtm_type;
 
     return UCS_INPROGRESS;
 }
@@ -256,6 +258,26 @@ ucs_netlink_lookup_in_iface_rules(const struct sockaddr *sa_remote,
 
     ucs_array_for_each(curr_entry, iface_rules) {
         if ((curr_entry->subnet_prefix_len > found_netmask_len) &&
+            ucs_sockaddr_is_same_subnet(
+                    sa_remote, (const struct sockaddr*)&curr_entry->dest,
+                    curr_entry->subnet_prefix_len)) {
+            found_netmask_len = curr_entry->subnet_prefix_len;
+        }
+    }
+
+    return found_netmask_len;
+}
+
+static int
+ucs_netlink_lookup_local_route_in_iface_rules(
+        const struct sockaddr *sa_remote, ucs_netlink_rt_rules_t *iface_rules)
+{
+    int found_netmask_len = -1;
+    ucs_netlink_route_entry_t *curr_entry;
+
+    ucs_array_for_each(curr_entry, iface_rules) {
+        if ((curr_entry->route_type == RTN_LOCAL) &&
+            (curr_entry->subnet_prefix_len > found_netmask_len) &&
             ucs_sockaddr_is_same_subnet(
                     sa_remote, (const struct sockaddr*)&curr_entry->dest,
                     curr_entry->subnet_prefix_len)) {
@@ -335,6 +357,40 @@ int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
     }
 
     return (info.netmask_len > -1);
+}
+
+int ucs_netlink_local_route_exists(const struct sockaddr *sa_remote,
+                                   int *if_index_p)
+{
+    int best_netmask_len = -1;
+    int best_if_index    = -1;
+    ucs_netlink_rt_rules_t *iface_rules;
+    int curr_netmask_len;
+    khiter_t iter;
+
+    ucs_netlink_init_routing_table_cache();
+
+    for (iter = kh_begin(&ucs_netlink_routing_table_cache);
+         iter != kh_end(&ucs_netlink_routing_table_cache); ++iter) {
+        if (!kh_exist(&ucs_netlink_routing_table_cache, iter)) {
+            continue;
+        }
+
+        iface_rules = &kh_val(&ucs_netlink_routing_table_cache, iter);
+        curr_netmask_len =
+                ucs_netlink_lookup_local_route_in_iface_rules(sa_remote,
+                                                              iface_rules);
+        if (curr_netmask_len > best_netmask_len) {
+            best_netmask_len = curr_netmask_len;
+            best_if_index    = kh_key(&ucs_netlink_routing_table_cache, iter);
+        }
+    }
+
+    if (if_index_p != NULL) {
+        *if_index_p = best_if_index;
+    }
+
+    return best_netmask_len > -1;
 }
 
 int ucs_netlink_is_best_route(int if_index, const struct sockaddr *sa_remote)

--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -353,8 +353,7 @@ int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
     return (info.netmask_len > -1);
 }
 
-int ucs_netlink_local_route_exists(const struct sockaddr *sa_remote,
-                                   int *if_index_p)
+int ucs_netlink_get_local_route_ndev_index(const struct sockaddr *sa_remote)
 {
     int best_netmask_len = -1;
     int best_if_index    = -1;
@@ -365,18 +364,14 @@ int ucs_netlink_local_route_exists(const struct sockaddr *sa_remote,
 
     kh_foreach(&ucs_netlink_routing_table_cache, if_index, iface_rules, {
         int curr_netmask_len = ucs_netlink_lookup_in_iface_rules_by_type(
-                                            sa_remote, &iface_rules, RTN_LOCAL);
+                sa_remote, &iface_rules, RTN_LOCAL);
         if (curr_netmask_len > best_netmask_len) {
             best_netmask_len = curr_netmask_len;
             best_if_index    = if_index;
         }
     })
 
-    if (if_index_p != NULL) {
-        *if_index_p = best_if_index;
-    }
-
-    return best_netmask_len > -1;
+    return best_if_index;
 }
 
 int ucs_netlink_is_best_route(int if_index, const struct sockaddr *sa_remote)

--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -250,13 +250,19 @@ ucs_netlink_parse_rt_entry_cb(const struct nlmsghdr *nlh, void *arg)
 }
 
 static int
-ucs_netlink_lookup_in_iface_rules(const struct sockaddr *sa_remote,
-                                  ucs_netlink_rt_rules_t *iface_rules)
+ucs_netlink_lookup_in_iface_rules_by_type(const struct sockaddr *sa_remote,
+                                          ucs_netlink_rt_rules_t *iface_rules,
+                                          uint8_t route_type)
 {
     int found_netmask_len = -1;
     ucs_netlink_route_entry_t *curr_entry;
 
     ucs_array_for_each(curr_entry, iface_rules) {
+        if ((route_type != RTN_UNSPEC) &&
+            (curr_entry->route_type != route_type)) {
+            continue;
+        }
+
         if ((curr_entry->subnet_prefix_len > found_netmask_len) &&
             ucs_sockaddr_is_same_subnet(
                     sa_remote, (const struct sockaddr*)&curr_entry->dest,
@@ -269,23 +275,19 @@ ucs_netlink_lookup_in_iface_rules(const struct sockaddr *sa_remote,
 }
 
 static int
+ucs_netlink_lookup_in_iface_rules(const struct sockaddr *sa_remote,
+                                  ucs_netlink_rt_rules_t *iface_rules)
+{
+    return ucs_netlink_lookup_in_iface_rules_by_type(sa_remote, iface_rules,
+                                                     RTN_UNSPEC);
+}
+
+static int
 ucs_netlink_lookup_local_route_in_iface_rules(
         const struct sockaddr *sa_remote, ucs_netlink_rt_rules_t *iface_rules)
 {
-    int found_netmask_len = -1;
-    ucs_netlink_route_entry_t *curr_entry;
-
-    ucs_array_for_each(curr_entry, iface_rules) {
-        if ((curr_entry->route_type == RTN_LOCAL) &&
-            (curr_entry->subnet_prefix_len > found_netmask_len) &&
-            ucs_sockaddr_is_same_subnet(
-                    sa_remote, (const struct sockaddr*)&curr_entry->dest,
-                    curr_entry->subnet_prefix_len)) {
-            found_netmask_len = curr_entry->subnet_prefix_len;
-        }
-    }
-
-    return found_netmask_len;
+    return ucs_netlink_lookup_in_iface_rules_by_type(sa_remote, iface_rules,
+                                                     RTN_LOCAL);
 }
 
 static void ucs_netlink_init_routing_table_cache(void)

--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -282,14 +282,6 @@ ucs_netlink_lookup_in_iface_rules(const struct sockaddr *sa_remote,
                                                      RTN_UNSPEC);
 }
 
-static int
-ucs_netlink_lookup_local_route_in_iface_rules(
-        const struct sockaddr *sa_remote, ucs_netlink_rt_rules_t *iface_rules)
-{
-    return ucs_netlink_lookup_in_iface_rules_by_type(sa_remote, iface_rules,
-                                                     RTN_LOCAL);
-}
-
 static void ucs_netlink_init_routing_table_cache(void)
 {
     static ucs_init_once_t init_once = UCS_INIT_ONCE_INITIALIZER;
@@ -366,27 +358,19 @@ int ucs_netlink_local_route_exists(const struct sockaddr *sa_remote,
 {
     int best_netmask_len = -1;
     int best_if_index    = -1;
-    ucs_netlink_rt_rules_t *iface_rules;
-    int curr_netmask_len;
-    khiter_t iter;
+    ucs_netlink_rt_rules_t iface_rules;
+    khint32_t if_index;
 
     ucs_netlink_init_routing_table_cache();
 
-    for (iter = kh_begin(&ucs_netlink_routing_table_cache);
-         iter != kh_end(&ucs_netlink_routing_table_cache); ++iter) {
-        if (!kh_exist(&ucs_netlink_routing_table_cache, iter)) {
-            continue;
-        }
-
-        iface_rules = &kh_val(&ucs_netlink_routing_table_cache, iter);
-        curr_netmask_len =
-                ucs_netlink_lookup_local_route_in_iface_rules(sa_remote,
-                                                              iface_rules);
+    kh_foreach(&ucs_netlink_routing_table_cache, if_index, iface_rules, {
+        int curr_netmask_len = ucs_netlink_lookup_in_iface_rules_by_type(
+                                            sa_remote, &iface_rules, RTN_LOCAL);
         if (curr_netmask_len > best_netmask_len) {
             best_netmask_len = curr_netmask_len;
-            best_if_index    = kh_key(&ucs_netlink_routing_table_cache, iter);
+            best_if_index    = if_index;
         }
-    }
+    })
 
     if (if_index_p != NULL) {
         *if_index_p = best_if_index;

--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -62,6 +62,18 @@ int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
                              int *netmask_len_p);
 
 /**
+ * Check whether a local route exists for a given destination address.
+ *
+ * @param [in]  sa_remote        Pointer to the destination address.
+ * @param [out] if_index_p       Optional pointer to store the network
+ *                               interface index of the local route found.
+ *
+ * @return 1 if a local route exists, or 0 otherwise.
+ */
+int ucs_netlink_local_route_exists(const struct sockaddr *sa_remote,
+                                   int *if_index_p);
+
+/**
  * Check if this network interface has the best route to the destination
  * address.
  *

--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -62,16 +62,14 @@ int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
                              int *netmask_len_p);
 
 /**
- * Check whether a local route exists for a given destination address.
+ * Get the network interface index of a local route to a given destination
+ * address.
  *
  * @param [in]  sa_remote        Pointer to the destination address.
- * @param [out] if_index_p       Optional pointer to store the network
- *                               interface index of the local route found.
  *
- * @return 1 if a local route exists, or 0 otherwise.
+ * @return Network interface index of a local route, or -1 if not found.
  */
-int ucs_netlink_local_route_exists(const struct sockaddr *sa_remote,
-                                   int *if_index_p);
+int ucs_netlink_get_local_route_ndev_index(const struct sockaddr *sa_remote);
 
 /**
  * Check if this network interface has the best route to the destination

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -700,10 +700,11 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     uint8_t port_num     = iface->config.port_num;
+    unsigned lo_ndev_index = 0;
     char ndev_ifname[IFNAMSIZ], lo_ifname[IFNAMSIZ], local_ifname[IFNAMSIZ];
     char remote_str[128];
-    unsigned ndev_index, lo_ndev_index = 0;
     int local_ndev_index;
+    unsigned ndev_index;
 
     if (uct_ib_device_get_roce_ndev_index(dev, port_num, gid_index,
                                           &ndev_index) != UCS_OK) {

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -700,9 +700,10 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
 {
     uct_ib_device_t *dev = uct_ib_iface_device(iface);
     uint8_t port_num     = iface->config.port_num;
-    char ndev_ifname[IFNAMSIZ], lo_ifname[IFNAMSIZ];
+    char ndev_ifname[IFNAMSIZ], lo_ifname[IFNAMSIZ], local_ifname[IFNAMSIZ];
     char remote_str[128];
-    unsigned ndev_index, lo_ndev_index;
+    unsigned ndev_index, lo_ndev_index = 0;
+    int local_ndev_index;
 
     if (uct_ib_device_get_roce_ndev_index(dev, port_num, gid_index,
                                           &ndev_index) != UCS_OK) {
@@ -729,8 +730,21 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
         return 1;
     }
 
+    /* A same-host RoCE address can have the most specific route through a VRF
+     * master instead of the RoCE netdev or loopback. Accept only kernel local
+     * routes, which keeps this narrower than reachability_mode=all. */
+    if (ucs_netlink_local_route_exists(sa_remote, &local_ndev_index)) {
+        ucs_trace(UCT_IB_IFACE_FMT ": found local route via %s to %s",
+                  UCT_IB_IFACE_ARG(iface),
+                  ucs_ndev_index_to_ifname(local_ndev_index, local_ifname,
+                                           sizeof(local_ifname)),
+                  ucs_sockaddr_str(sa_remote, remote_str, sizeof(remote_str)));
+        return 1;
+    }
+
     uct_iface_fill_info_str_buf(
-            params, "no route to %s from %s (idx %u) or %s (idx %u)",
+            params, "no route to %s from %s (idx %u), %s (idx %u), or local "
+                    "route",
             ucs_sockaddr_str(sa_remote, remote_str, sizeof(remote_str)),
             ucs_ndev_index_to_ifname(ndev_index, ndev_ifname,
                                      sizeof(ndev_ifname)),

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -734,7 +734,8 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
     /* A same-host RoCE address can have the most specific route through a VRF
      * master instead of the RoCE netdev or loopback. Accept only kernel local
      * routes, which keeps this narrower than reachability_mode=all. */
-    if (ucs_netlink_local_route_exists(sa_remote, &local_ndev_index)) {
+    local_ndev_index = ucs_netlink_get_local_route_ndev_index(sa_remote);
+    if (local_ndev_index >= 0) {
         ucs_trace(UCT_IB_IFACE_FMT ": found local route via %s to %s",
                   UCT_IB_IFACE_ARG(iface),
                   ucs_ndev_index_to_ifname(local_ndev_index, local_ifname,


### PR DESCRIPTION
## What
A fix for reachability issue found here https://redmine.mellanox.com/issues/5021232 .
Accept matching kernel `RTN_LOCAL` routes in RoCE route reachability.

## Why
On VRF-configured Doris GB200 RoCE VFs, same-host GID addresses can appear as local routes on `eth_r*_vf0`, not on the selected RoCE netdev or `lo`. UCX route mode rejected those lanes and could later fail with `cannot find remote protocol`.

## How
Cache netlink `rtm_type`, add a helper to find the best matching `RTN_LOCAL` route, and use it as a fallback after the existing selected-netdev and loopback checks fail. This stays narrower than `reachability_mode=all` because only kernel-local destinations are accepted.