### PR TITLE
UCP/CORE: Verify rcache validity before calling ucp_memh_invalidate

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -420,7 +420,9 @@ int ucp_request_memh_invalidate(ucp_request_t *req, ucs_status_t status)
         memh_p = &req->send.state.dt.dt.contig.memh;
     }
 
-    if ((*memh_p == NULL) || ucp_memh_is_user_memh(*memh_p)) {
+    if ((context->rcache == NULL) ||
+        (*memh_p == NULL) ||
+        ucp_memh_is_user_memh(*memh_p)) {
         return 0;
     }
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -951,6 +951,13 @@ UCS_TEST_P(test_ucp_peer_failure_rndv_abort, get_zcopy_memory_invalidation,
     rndv_progress_failure_test(rndv_mode::rndv_get, false);
 }
 
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort,
+           get_zcopy_memory_invalidation_no_rcache, "RNDV_SCHEME=get_zcopy",
+           "RCACHE_ENABLE=n")
+{
+    rndv_progress_failure_test(rndv_mode::rndv_get, false);
+}
+
 UCS_TEST_P(test_ucp_peer_failure_rndv_abort, put_zcopy_memory_invalidation,
            "RNDV_SCHEME=put_zcopy")
 {


### PR DESCRIPTION
## What?
Prevent SIGSEGV failure in `ucs_rcache_region_invalidate()` due to unavailable rcache. 

## Why?
#11467 

## How?
Verify rcache is not null before calling `ucp_memh_invalidate()`
