### PR TITLE
CI: reduce CPU requests in all CI pipelines

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -10,8 +10,8 @@ timeout_minutes: 90
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 16Gi, cpu: 16000m}"
-  requests: "{memory: 16Gi, cpu: 16000m}"
+  limits: "{memory: 16Gi, cpu: 8000m}"
+  requests: "{memory: 16Gi, cpu: 8000m}"
 
 runs_on_dockers:
   # x86_64

--- a/.ci/pipeline/build_static_matrix.yaml
+++ b/.ci/pipeline/build_static_matrix.yaml
@@ -10,8 +10,8 @@ timeout_minutes: 90
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 8Gi, cpu: 8000m}"
-  requests: "{memory: 8Gi, cpu: 8000m}"
+  limits: "{memory: 8Gi, cpu: 6000m}"
+  requests: "{memory: 8Gi, cpu: 6000m}"
 
 volumes:
   - {mountPath: /hpc/local, hostPath: /hpc/local}

--- a/.ci/pipeline/codestyle_matrix.yaml
+++ b/.ci/pipeline/codestyle_matrix.yaml
@@ -10,8 +10,8 @@ timeout_minutes: 90
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 4Gi, cpu: 4000m}"
-  requests: "{memory: 4Gi, cpu: 4000m}"
+  limits: "{memory: 4Gi, cpu: 2000m}"
+  requests: "{memory: 4Gi, cpu: 2000m}"
 
 runs_on_dockers:
   - { name: "fedora33", url: "harbor.mellanox.com/ucx/fedora33:2", arch: x86_64 }

--- a/.ci/pipeline/coverity_matrix.yaml
+++ b/.ci/pipeline/coverity_matrix.yaml
@@ -10,8 +10,8 @@ timeout_minutes: 90
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 8Gi, cpu: 8000m}"
-  requests: "{memory: 8Gi, cpu: 8000m}"
+  limits: "{memory: 8Gi, cpu: 6000m}"
+  requests: "{memory: 8Gi, cpu: 6000m}"
 
 volumes:
   - {mountPath: /hpc/local, hostPath: /hpc/local}

--- a/.ci/pipeline/static_checks_matrix.yaml
+++ b/.ci/pipeline/static_checks_matrix.yaml
@@ -10,8 +10,8 @@ timeout_minutes: 90
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 8Gi, cpu: 8000m}"
-  requests: "{memory: 8Gi, cpu: 8000m}"
+  limits: "{memory: 8Gi, cpu: 4000m}"
+  requests: "{memory: 8Gi, cpu: 4000m}"
 
 runs_on_dockers:
   - { name: "fedora33", url: "harbor.mellanox.com/ucx/fedora33:2", arch: x86_64 }

--- a/.ci/pipeline/test_dl_matrix.yaml
+++ b/.ci/pipeline/test_dl_matrix.yaml
@@ -15,8 +15,8 @@ registry_path: /ucx/ci
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 16Gi, cpu: 16000m}"
-  requests: "{memory: 8Gi, cpu: 8000m}"
+  limits: "{memory: 8Gi, cpu: 4000m}"
+  requests: "{memory: 8Gi, cpu: 4000m}"
 
 credentials:
   - {credentialsId: 'ucx_harbor_credentials', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}

--- a/.ci/pipeline/test_gpu_matrix.yaml
+++ b/.ci/pipeline/test_gpu_matrix.yaml
@@ -14,8 +14,8 @@ registry_path: /ucx/ci
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 16Gi, cpu: 16000m}"
-  requests: "{memory: 8Gi, cpu: 8000m}"
+  limits: "{memory: 8Gi, cpu: 4000m}"
+  requests: "{memory: 8Gi, cpu: 4000m}"
   privileged: true
 
 credentials:

--- a/.ci/pipeline/test_matrix.yaml
+++ b/.ci/pipeline/test_matrix.yaml
@@ -10,8 +10,8 @@ timeout_minutes: 90
 kubernetes:
   cloud: il-ipp-blossom-prod-nbu-swx-ucx
   namespace: nbu-swx-ucx
-  limits: "{memory: 16Gi, cpu: 16000m}"
-  requests: "{memory: 16Gi, cpu: 16000m}"
+  limits: "{memory: 16Gi, cpu: 6000m}"
+  requests: "{memory: 16Gi, cpu: 6000m}"
 
 runs_on_dockers:
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0", arch: x86_64 }

--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ Min Fang <minf@nvidia.com>
 Nathan Bellalou <nbellalou@nvidia.com>
 Nathan Hjelm <hjelmn@lanl.gov>
 Netanel Yosephian <netanelyo@mellanox.com>
+Nir Wolfer <nwolfer@nvidia.com>
 Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>
 Or Balayla <obalayla@nvidia.com>


### PR DESCRIPTION
## What?
We are requesting too much CPU per pod running in our CI piplines, which limits how many CIs can run in parallel due to quota in our namespace

## Why?
Utilization with old requests is around 5% on average. Reducing the requests to half should allow running more than 1-2 pipelines at a time
