### PR TITLE
UCS/SOCK: Skip IPv4 link-local addresses in ucs_netif_get_addr

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Aboorva Devarajan <aboorvad@linux.ibm.com>
+Adit Ranadive <aranadive@nvidia.com>
 Akshay Venkatesh <akvenkatesh@nvidia.com>
 Alastair McKinstry <mckinstry@debian.org>
 Aleksey Senin <alekseys@nvidia.com>

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -107,6 +107,7 @@ ucs_status_t ucs_netif_get_addr(const char *if_name, sa_family_t af,
     ucs_status_t status = UCS_ERR_NO_DEVICE;
     struct ifaddrs *ifa;
     struct ifaddrs *ifaddrs;
+    const struct sockaddr_in *saddr4;
     const struct sockaddr_in6 *saddr6;
     size_t addrlen;
 
@@ -131,7 +132,13 @@ ucs_status_t ucs_netif_get_addr(const char *if_name, sa_family_t af,
             continue;
         }
 
-        if (ifa->ifa_addr->sa_family == AF_INET6) {
+        if (ifa->ifa_addr->sa_family == AF_INET) {
+            saddr4 = (const struct sockaddr_in*)ifa->ifa_addr;
+            if ((ntohl(saddr4->sin_addr.s_addr) & 0xFFFF0000) == 0xA9FE0000) {
+                /* Skip IPv4 link-local addresses (169.254.0.0/16) */
+                continue;
+            }
+        } else if (ifa->ifa_addr->sa_family == AF_INET6) {
             saddr6 = (const struct sockaddr_in6*)ifa->ifa_addr;
             if (IN6_IS_ADDR_LINKLOCAL(&saddr6->sin6_addr)) {
                 continue;


### PR DESCRIPTION
## What?
Skip IPv4 link-local addresses (169.254.0.0/16) in ucs_netif_get_addr(), mirroring the existing IPv6 link-local filter.

## Why?
In Kubernetes with CNI plugins, pods have interfaces (e.g. pod-id-link0) with non-routable 169.254.x.x addresses. UCX auto-selects these for TCP transport, causing cross-node connections to fail with Connection refused.

## How?
Single check in src/ucs/sys/sock.c in the ucs_netif_get_addr() loop, before the existing IPv6 link-local check. Affects both address binding and device enumeration via ucs_netif_is_active().
