### PR TITLE
REVIEW: Update PR review skill workflow

### DIFF
--- a/.agents/skills/ucx-pr-review/SKILL.md
+++ b/.agents/skills/ucx-pr-review/SKILL.md
@@ -17,19 +17,32 @@ Read these files before making review claims:
 - `REVIEW.md`; it points to the repository guides and style docs to load for
   changed paths.
 
+## Code Checkout
+
+Use a separate shallow clone as reference for surrounding code and related
+context from other files in the codebase; do not disturb the user's worktree.
+
+```sh
+user_name=$(id -un)
+repo_dir=$(mktemp -d "${TMPDIR%/}/ucx-pr-${user_name}-<PR>.XXXXXX")
+git clone --depth=1 --branch <base-ref> https://github.com/openucx/ucx.git "$repo_dir"
+git -C "$repo_dir" fetch --depth=1 origin pull/<PR>/head:pr-<PR>
+git -C "$repo_dir" checkout pr-<PR>
+git -C "$repo_dir" rev-parse HEAD
+```
+
 ## GitHub Workflow
 
 1. Identify the base branch, changed files, added/deleted line count, CI state,
    and author intent from the PR title and description.
-2. Read existing PR discussion first and apply the `REVIEW.md` guidance on
-   duplicate, answered, or resolved issues. On GitHub, if the same issue is
-   already raised in an unresolved thread, add `:+1:` to the existing comment
-   instead of opening a new thread.
-3. Inspect the diff before inspecting unrelated code. Use surrounding code only
-   to verify a suspected issue or local convention.
+2. Read existing PR discussion first and apply the existing-comments rules
+   below.
+3. Treat the GitHub/app/`gh` PR diff as authoritative for changed files and
+   review line anchors.
 4. Apply the PR size and scope rules from `REVIEW.md`.
 5. Apply the risk order and checklist from `REVIEW.md`.
-6. Before posting a finding, verify the exact changed line and current behavior.
+6. Run the candidate-comment gate below before keeping any finding.
+7. Run the review-submission self-check before returning or posting the review.
 
 If the `gh` CLI is available and the user permits network access, useful
 commands are:
@@ -40,9 +53,70 @@ gh pr diff <PR>
 gh pr checks <PR>
 ```
 
-## Comment Rules
+## Existing Comments
 
+- Avoid adding a comment that duplicates a previous comment.
+- If the same issue was already raised in an unresolved thread, add a `+1`
+  reaction with `gh api` instead of opening a new thread. For inline PR review
+  comments, use:
+
+```sh
+gh api -X POST repos/<owner>/<repo>/pulls/comments/<comment-id>/reactions \
+  -H "Accept: application/vnd.github+json" \
+  -f content="+1"
+```
+
+  For top-level PR conversation comments, use
+  `repos/<owner>/<repo>/issues/comments/<comment-id>/reactions` instead.
+- If the author replied with a good explanation, accept the intent unless the
+  current code or CI contradicts it.
+- If new evidence changes an existing concern, reply in the existing thread
+  instead of opening a duplicate thread.
+
+## Candidate Comment Gate
+
+Keep a finding only after verifying all of these:
+
+- It is not already covered by an existing comment.
+- The issue is still present in the latest diff.
+- The comment is anchored to a changed line, or clearly belongs as PR-level
+  feedback.
+- The impact is concrete.
+- The severity matches `REVIEW.md`.
+
+## Review Submission
+
+- Submit reviews explicitly with `gh`, not the GitHub app connector.
 - Use the tone, severity, and length rules from `REVIEW.md`.
+- Accumulate all inline comments and submit them in one review submission. Do
+  not submit one GitHub review per comment.
+- Leave the review body empty unless there is a real PR-level concern.
+- Do not generate boilerplate review summaries, finding counts, severity
+  counts, or `Code Review` headings.
+- Remove comments about intentional tradeoffs that were already explained,
+  comments that are only interesting observations, and any finding whose impact
+  is unclear.
+- Scrub comments for `REVIEW.md` style violations such as severity headings,
+  emoji labels, `[P*]` labels, and uppercase severity labels.
+- Check every inline comment for suggestion eligibility. If the requested fix is
+  an obvious, small, deterministic replacement of changed lines, use a GitHub
+  suggestion block instead of prose-only feedback; add at most one short
+  justification sentence after it.
+- Downgrade uncertain blockers to questions or no-prefix comments.
+- Use `COMMENT` mode when all comments are minor or explicitly non-blocking.
+- Use `REQUEST_CHANGES` mode when there are blocker or other must-fix findings.
+- Use `APPROVE` mode when there are no comments.
+- For review-body-only submissions, use `gh pr review <PR> --repo <owner>/<repo>`
+  with exactly one of `--comment`, `--request-changes`, or `--approve`; pass
+  non-empty review text with `--body-file <file>` to avoid shell quoting issues.
+- For inline comments, create one review through `gh api` and the GitHub
+  `POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews` endpoint. Put the
+  event (`COMMENT`, `REQUEST_CHANGES`, or `APPROVE`), optional body, and all
+  inline comments in a temporary JSON file and submit it with:
+
+```sh
+gh api -X POST repos/<owner>/<repo>/pulls/<PR>/reviews --input <review-json>
+```
 
 ## Output
 
@@ -52,6 +126,3 @@ When returning a review in chat, use one of these formats:
 - Draft GitHub comments: provide the exact proposed comment text for each
   changed line.
 - No findings: say so and note residual test or hardware coverage gaps.
-
-For each finding, say whether to post a new comment or add `:+1:` to an
-existing unresolved thread.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -33,9 +33,35 @@ which signals a soft suggestion versus a hard requirement.
 Large PRs slow down the entire team. Enforce these hard limits:
 
 - **More than 500 added lines** — not allowed; ask the author to split
-- **Bug fix PRs** — must contain only the fix and its tests; no unrelated refactoring
+- **Bug fix PRs** — must contain only the fix and directly related test
+  coverage; no unrelated refactoring
 - **Feature PRs** — must not refactor code unrelated to the feature
 - **Refactoring** — must be in a separate PR, with no functional changes
+
+---
+
+## Test Expectations
+
+Derive required test coverage first from the PR's stated goal, then from the
+behavioral risks introduced by the implementation. Avoid asking for tests that
+cover incidental implementation details without a plausible regression risk.
+
+- **Bug fixes** — should usually add or update a focused regression test,
+  because the existing suite did not catch the issue. If a test is not
+  practical, ask the author to explain the coverage gap
+- **New APIs** — should usually include a test that exercises the new API
+  contract, including error handling or compatibility behavior when relevant
+- **Internal flow changes** — should be covered by existing tests/CI or by a
+  new focused test. If relying on existing coverage, identify the relevant test
+  or CI job before asking for more tests
+- **Build/CI changes** — should have enough validation to show the stated CI
+  behavior changed as intended, either through CI results, dry-run output, or a
+  small script/unit test when practical
+- **Configure/build options** — new or changed user-facing configure flags
+  should usually add CI coverage for the explicit enable/disable path that
+  changed. In UCX this often belongs in `buildlib/tools/builds.sh` or
+  `contrib/test_jenkins.sh`; for disable options, also verify the disabled
+  module, object, or generated artifact is absent when practical
 
 ---
 
@@ -52,8 +78,24 @@ Review by risk, in order:
 1. API/ABI and wire compatibility.
 2. Correctness, error handling, cleanup, and resource lifetime.
 3. Concurrency and hot-path performance.
-4. Tests and build metadata for changed files.
+4. Test expectations and build metadata for changed files.
 5. Documentation and style.
+
+Focused checks:
+
+- For resource lifetime changes, verify ownership and cleanup scope before
+  posting a finding. For keyed or cached resources, trace the key/value scope
+  end to end and check whether cleanup affects only the intended key, all
+  matching keys, or unrelated live users.
+- When a change marks, initializes, validates, or reclassifies an object/state,
+  trace the object from acquisition to first use. The fix should be placed at
+  the earliest point where the invariant becomes true, before any consumer can
+  observe the old state.
+- When a PR adds or changes `AC_ARG_WITH`, `AC_ARG_ENABLE`, `AC_DEFINE`, or an
+  `AM_CONDITIONAL`, trace the option through `configure.m4`, `Makefile.am`,
+  and CI/build scripts. Check explicit `--with-*`/`--enable-*` failure paths,
+  explicit `--without-*`/`--disable-*` paths, default behavior, and whether a
+  relevant build job exercises the new behavior.
 
 When a finding depends on a code rule, cite the rule from the relevant
 `AGENTS.md`, `docs/CodeStyle.md`, `docs/LoggingStyle.md`, or
@@ -82,15 +124,37 @@ When a finding depends on a code rule, cite the rule from the relevant
 | *(none)* | Should fix; warrants discussion if there is a good reason not to |
 | `minor:` | Nice to fix, will not block merge |
 
+**Severity formatting:** Do not use markdown severity headings, emoji labels,
+`[P2]`, `[important]`, or uppercase labels such as `MINOR`/`BLOCKER`. If
+severity is needed, use only the inline prefixes from the table: `blocker:` or
+`minor:`.
+
 **Blocker bar is high.** Config naming debates, default value choices, and documentation gaps are
 never blockers — they go in the no-prefix or `minor:` bucket.
 
-**Length**: 1–2 sentences per comment. Use simple English — many contributors are non-native
-speakers. Lead with the *problem* (`"this can be NULL here"`) not the solution (`"you should add a
-null check"`). Skip suggested code blocks unless the fix is non-obvious. One comment per distinct
-issue; do not bundle unrelated points. Inline comments for file-level issues; general PR comment
-only for PR-level concerns.
+**Length**: 1–2 sentences per comment. Use a longer comment only when the
+issue is complicated and non-obvious.
 
-Use the GitHub `suggestion` block (` ```suggestion ... ``` `) when the fix is
-mechanical and unambiguous.
-For anything requiring judgment, describe the problem and let the author propose the fix.
+**Language:** Use simple English — many contributors are non-native speakers.
+
+**Comment order:** Start with the requested change, then briefly explain why it
+is needed when the reason is not obvious. Example:
+`pls add $(UCX_LT_RELEASE) here as well; otherwise libucs_signal stays outside
+the suffix scheme.`
+
+**Comment scope:** One comment per distinct issue; do not bundle unrelated
+points.
+
+**Comment placement:** Inline comments for file-level issues; general PR
+comment only for PR-level concerns.
+
+**Review body:** Avoid generic review-summary comments such as `Code Review`,
+finding counts, severity counts, or `N findings posted inline`. Leave the
+review body empty when inline comments are self-contained. Use a top-level PR
+comment only for a real PR-level concern.
+
+**Code suggestions:** Prefer a GitHub `suggestion` block
+(` ```suggestion ... ``` `) when the requested change is obvious and
+mechanical. If needed, add one short sentence after the suggestion explaining
+why the change is needed. For anything requiring judgment, describe the problem
+and let the author propose the fix.


### PR DESCRIPTION
## What?
Update UCX PR review guidance and the local review skill.

- Add workflow guardrails for shallow PR checkout, existing-comment handling, candidate-comment filtering, and one-piece review submission.
- Refine review comment style to avoid severity banners and generated summaries.
- Prefer concise requested-change-first comments and suggestion blocks for obvious mechanical changes.
- Add focused guidance for placing state/invariant fixes before first use.

## Why?
This makes automated and human PR reviews closer to UCX reviewer style: concise, non-duplicative, batched into one review, and focused on actionable findings.

## Validation
- Verified the branch contains only one commit on top of upstream/master.
- Ran `git diff --check upstream/master...HEAD`.
