### PR TITLE
GTEST/UCP: Make sure GGA has GDR disabled for TAG memory type tests

### DIFF
--- a/test/gtest/ucp/test_ucp_tag_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_tag_mem_type.cc
@@ -40,6 +40,8 @@ public:
 
             m_env.push_back(
                     new ucs::scoped_setenv("UCX_IB_GPU_DIRECT_RDMA", "n"));
+            m_env.push_back(
+                    new ucs::scoped_setenv("UCX_GGA_GPU_DIRECT_RDMA", "n"));
         }
 
         if (variant_flags & VARIANT_TAG_OFFLOAD) {


### PR DESCRIPTION
## What?
Similarly as IB, disable GGA for TAG memory type tests.

## Why?
GGA is not under `IB_` prefix like RC, and the test it meant to disable GDR.

```
ib_mlx5_log.c:179  UCX  ERROR Local QP operation error on mlx5_1:1/IB (synd 0x2 vend 0x9d hw_synd 0/157)
ib_mlx5_log.c:179  UCX  ERROR RC QP 0xdbc2 wqe[0]: MMO s-- DMA[lkey 0x1c39f7 va 0x55555cda0200] G[va 0x15552f200000 len 160 lkey 0x201100] S[va 0x55555b608f60 len 160 lkey 0x201000] [rqpn 0xdbbd dlid=69 sl=0 port=1 src_path_bits=0]