### PR TITLE
UCT/CUDA: Improve reachability of cuda_ipc to detect different pid namespaces without Fabric API

### DIFF
--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -12,7 +12,11 @@
 #include "cuda_util.h"
 
 #include <ucs/sys/module.h>
+#include <ucs/sys/ptr_arith.h>
 #include <ucs/sys/string.h>
+
+#include <limits.h>
+#include <stdint.h>
 
 
 ucs_status_t
@@ -53,6 +57,132 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
 
     return uct_md_query_single_md_resource(component, resources_p,
                                            num_resources_p);
+}
+
+ucs_status_t
+uct_cuda_base_fabric_alloc(CUdevice cuda_device, size_t *granularity_p,
+                           uct_cuda_base_fabric_alloc_t *alloc_handle,
+                           ucs_log_level_t log_level)
+{
+#if HAVE_CUDA_FABRIC
+    CUmemAllocationProp prop    = {};
+    CUmemAccessDesc access_desc = {};
+    uint64_t allowed_types;
+    ucs_status_t status;
+
+    prop.type                            = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.requestedHandleTypes            = CU_MEM_HANDLE_TYPE_FABRIC;
+    prop.location.type                   = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id                     = cuda_device;
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+
+    if (*granularity_p == SIZE_MAX) {
+        status = UCT_CUDADRV_FUNC(cuMemGetAllocationGranularity(
+                          granularity_p, &prop,
+                          CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+                          log_level);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
+
+    alloc_handle->length = ucs_align_up(alloc_handle->length, *granularity_p);
+
+    status = UCT_CUDADRV_FUNC(cuMemCreate(&alloc_handle->generic_handle,
+                                          alloc_handle->length, &prop, 0),
+                              log_level);
+    if (status != UCS_OK) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    status = UCT_CUDADRV_FUNC(
+            cuMemAddressReserve(&alloc_handle->ptr, alloc_handle->length,
+                                *granularity_p, 0, 0),
+            log_level);
+    if (status != UCS_OK) {
+        goto err_mem_release;
+    }
+
+    status = UCT_CUDADRV_FUNC(
+            cuMemMap(alloc_handle->ptr, alloc_handle->length, 0,
+                     alloc_handle->generic_handle, 0),
+            log_level);
+    if (status != UCS_OK) {
+        goto err_address_free;
+    }
+
+    access_desc.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    access_desc.location.id   = cuda_device;
+
+    status = UCT_CUDADRV_FUNC(
+            cuMemSetAccess(alloc_handle->ptr, alloc_handle->length,
+                           &access_desc, 1),
+            log_level);
+    if (status != UCS_OK) {
+        goto err_mem_unmap;
+    }
+
+    status = UCT_CUDADRV_FUNC(
+            cuPointerGetAttribute(&allowed_types,
+                                  CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES,
+                                  alloc_handle->ptr),
+            log_level);
+    if (status != UCS_OK) {
+        goto err_mem_unmap;
+    } else if (!(allowed_types & CU_MEM_HANDLE_TYPE_FABRIC)) {
+        ucs_log(log_level,
+                "allocated memory at %p of size %ld does not have fabric "
+                "property",
+                (void*)alloc_handle->ptr, alloc_handle->length);
+        status = UCS_ERR_UNSUPPORTED;
+        goto err_mem_unmap;
+    }
+
+    ucs_trace("allocated vmm fabric memory at %p of size %ld",
+              (void*)alloc_handle->ptr, alloc_handle->length);
+    return UCS_OK;
+
+err_mem_unmap:
+    UCT_CUDADRV_FUNC_LOG_DEBUG(
+            cuMemUnmap(alloc_handle->ptr, alloc_handle->length));
+err_address_free:
+    UCT_CUDADRV_FUNC_LOG_DEBUG(
+            cuMemAddressFree(alloc_handle->ptr, alloc_handle->length));
+err_mem_release:
+    UCT_CUDADRV_FUNC_LOG_DEBUG(cuMemRelease(alloc_handle->generic_handle));
+    return status;
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+ucs_status_t
+uct_cuda_base_fabric_release(uct_cuda_base_fabric_alloc_t *alloc_handle,
+                             ucs_log_level_t log_level)
+{
+#if HAVE_CUDA_FABRIC
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC(cuMemRelease(alloc_handle->generic_handle),
+                              log_level);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = UCT_CUDADRV_FUNC(cuMemUnmap(alloc_handle->ptr,
+                                         alloc_handle->length),
+                              log_level);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return UCT_CUDADRV_FUNC(cuMemAddressFree(alloc_handle->ptr,
+                                             alloc_handle->length),
+                            log_level);
+#else
+    return UCS_ERR_UNSUPPORTED;
+#endif
 }
 
 UCS_STATIC_INIT

--- a/src/uct/cuda/base/cuda_md.h
+++ b/src/uct/cuda/base/cuda_md.h
@@ -6,8 +6,18 @@
 #ifndef UCT_CUDA_MD_H
 #define UCT_CUDA_MD_H
 
+#include <uct/cuda/base/cuda_util.h>
 #include <uct/base/uct_iface.h>
 #include <uct/base/uct_md.h>
+
+
+typedef struct uct_cuda_base_fabric_alloc {
+    CUdeviceptr                 ptr;
+    size_t                      length;
+#if HAVE_CUDA_FABRIC
+    CUmemGenericAllocationHandle generic_handle;
+#endif
+} uct_cuda_base_fabric_alloc_t;
 
 
 ucs_status_t
@@ -41,5 +51,16 @@ uct_cuda_base_query_devices(uct_md_h md,
  *         invalid.
  */
 ucs_status_t uct_cuda_base_check_device_name(const uct_iface_params_t *params);
+
+
+ucs_status_t
+uct_cuda_base_fabric_alloc(CUdevice cuda_device, size_t *granularity_p,
+                           uct_cuda_base_fabric_alloc_t *alloc_handle,
+                           ucs_log_level_t log_level);
+
+
+ucs_status_t
+uct_cuda_base_fabric_release(uct_cuda_base_fabric_alloc_t *alloc_handle,
+                             ucs_log_level_t log_level);
 
 #endif

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -196,12 +196,10 @@ uct_cuda_copy_mem_alloc_fabric(uct_cuda_copy_md_t *md,
                                CUdevice cu_device, unsigned flags)
 {
 #if HAVE_CUDA_FABRIC
-    CUmemAllocationProp prop    = {};
-    CUmemAccessDesc access_desc = {};
+    uct_cuda_base_fabric_alloc_t base_alloc;
     ucs_log_level_t log_level   = (md->config.enable_fabric == UCS_YES) ?
                                   UCS_LOG_LEVEL_ERROR : UCS_LOG_LEVEL_DEBUG;
     ucs_status_t status;
-    uint64_t allowed_types;
 
     if (!(flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) &&
         (md->config.enable_fabric == UCS_YES)) {
@@ -210,85 +208,18 @@ uct_cuda_copy_mem_alloc_fabric(uct_cuda_copy_md_t *md,
         log_level = UCS_LOG_LEVEL_DEBUG;
     }
 
-    prop.type                            = CU_MEM_ALLOCATION_TYPE_PINNED;
-    prop.requestedHandleTypes            = CU_MEM_HANDLE_TYPE_FABRIC;
-    prop.location.type                   = CU_MEM_LOCATION_TYPE_DEVICE;
-    prop.location.id                     = cu_device;
-    prop.allocFlags.gpuDirectRDMACapable = 1;
-
-    if (md->granularity == SIZE_MAX) {
-        status = UCT_CUDADRV_FUNC(cuMemGetAllocationGranularity(
-                &md->granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-                log_level);
-        if (status != UCS_OK) {
-            return status;
-        }
-    }
-
-    alloc_handle->length = ucs_align_up(alloc_handle->length, md->granularity);
-
-    status = UCT_CUDADRV_FUNC(cuMemCreate(&alloc_handle->generic_handle,
-                                          alloc_handle->length, &prop, 0),
-                              log_level);
+    base_alloc.length = alloc_handle->length;
+    status = uct_cuda_base_fabric_alloc(cu_device, &md->granularity,
+                                        &base_alloc, log_level);
     if (status != UCS_OK) {
-        return UCS_ERR_NO_MEMORY;
+        return status;
     }
 
-    status = UCT_CUDADRV_FUNC(cuMemAddressReserve(
-                                     &alloc_handle->ptr, alloc_handle->length,
-                                     md->granularity, 0, 0),
-                              log_level);
-    if (status != UCS_OK) {
-        goto err_mem_release;
-    }
-
-    status = UCT_CUDADRV_FUNC(cuMemMap(alloc_handle->ptr, alloc_handle->length,
-                                       0, alloc_handle->generic_handle, 0),
-                              log_level);
-    if (status != UCS_OK) {
-        goto err_address_free;
-    }
-
-    access_desc.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    access_desc.location.id   = cu_device;
-
-    status = UCT_CUDADRV_FUNC(cuMemSetAccess(
-                     alloc_handle->ptr, alloc_handle->length, &access_desc, 1),
-                     log_level);
-    if (status != UCS_OK) {
-        goto err_mem_unmap;
-    }
-
-    status = UCT_CUDADRV_FUNC(
-            cuPointerGetAttribute(&allowed_types,
-                                  CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES,
-                                  alloc_handle->ptr),
-            log_level);
-    if (status != UCS_OK) {
-        goto err_mem_unmap;
-    } else if (!(allowed_types & CU_MEM_HANDLE_TYPE_FABRIC)) {
-        ucs_log(log_level,
-                "allocated memory at %p of size %ld does not have fabric "
-                "property",
-                (void*)alloc_handle->ptr, alloc_handle->length);
-        goto err_mem_unmap;
-    }
-
-    alloc_handle->is_vmm = 1;
-
-    ucs_trace("allocated vmm fabric memory at %p of size %ld",
-              (void*)alloc_handle->ptr, alloc_handle->length);
+    alloc_handle->ptr            = base_alloc.ptr;
+    alloc_handle->length         = base_alloc.length;
+    alloc_handle->is_vmm         = 1;
+    alloc_handle->generic_handle = base_alloc.generic_handle;
     return UCS_OK;
-
-err_mem_unmap:
-    UCT_CUDADRV_FUNC_LOG_DEBUG(
-            cuMemUnmap(alloc_handle->ptr, alloc_handle->length));
-err_address_free:
-    UCT_CUDADRV_FUNC_LOG_DEBUG(
-            cuMemAddressFree(alloc_handle->ptr, alloc_handle->length));
-err_mem_release:
-    UCT_CUDADRV_FUNC_LOG_DEBUG(cuMemRelease(alloc_handle->generic_handle));
 #endif
     return UCS_ERR_NO_MEMORY;
 }
@@ -441,22 +372,12 @@ static ucs_status_t
 uct_cuda_copy_mem_release_fabric(uct_cuda_copy_alloc_handle_t *alloc_handle)
 {
 #if HAVE_CUDA_FABRIC
-    ucs_status_t status;
+    uct_cuda_base_fabric_alloc_t base_alloc;
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(
-            cuMemRelease(alloc_handle->generic_handle));
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = UCT_CUDADRV_FUNC_LOG_ERR(
-            cuMemUnmap(alloc_handle->ptr, alloc_handle->length));
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    return UCT_CUDADRV_FUNC_LOG_ERR(
-            cuMemAddressFree(alloc_handle->ptr, alloc_handle->length));
+    base_alloc.ptr            = alloc_handle->ptr;
+    base_alloc.length         = alloc_handle->length;
+    base_alloc.generic_handle = alloc_handle->generic_handle;
+    return uct_cuda_base_fabric_release(&base_alloc, UCS_LOG_LEVEL_ERROR);
 #else
     return UCS_ERR_UNSUPPORTED;
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -22,10 +22,15 @@
 #include <uct/cuda/base/cuda_md.h>
 #include <uct/cuda/base/cuda_nvml.h>
 
+#include <limits.h>
 #include <pthread.h>
 
 typedef enum {
-    UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL = UCS_BIT(0)
+    UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL  = UCS_BIT(0),
+    /* Local process is capable of exporting/importing CUDA fabric (IPC)
+     * handles, which are required to share GPU memory across different PID
+     * namespaces. */
+    UCT_CUDA_IPC_DEVICE_ADDR_FLAG_FABRIC = UCS_BIT(1)
 } uct_cuda_ipc_device_addr_flags_t;
 
 
@@ -82,6 +87,53 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
 /* Forward declaration for the delete function */
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_ipc_iface_t)(uct_iface_t*);
 
+#if HAVE_CUDA_FABRIC
+static int uct_cuda_ipc_iface_check_fabric_supported(void)
+{
+    uct_cuda_base_fabric_alloc_t alloc_handle = {
+        .ptr    = 0,
+        .length = 1
+    };
+    ucs_status_t status;
+    CUdevice cu_device;
+    size_t granularity = SIZE_MAX;
+
+    status = UCT_CUDADRV_FUNC(cuCtxGetDevice(&cu_device),
+                              UCS_LOG_LEVEL_DEBUG);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    status = uct_cuda_base_fabric_alloc(cu_device, &granularity, &alloc_handle,
+                                        UCS_LOG_LEVEL_DEBUG);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    uct_cuda_base_fabric_release(&alloc_handle, UCS_LOG_LEVEL_DEBUG);
+    return 1;
+}
+#endif
+
+/* Whether the local process supports CUDA fabric IPC handles. Fabric handles
+ * are required to share GPU memory across different PID namespaces. */
+static int uct_cuda_ipc_iface_fabric_supported(void)
+{
+#if HAVE_CUDA_FABRIC
+    static int fabric_supported = -1;
+
+    if (fabric_supported == -1) {
+        fabric_supported = uct_cuda_ipc_iface_check_fabric_supported();
+        ucs_debug("CUDA fabric IPC support is %s",
+                  fabric_supported ? "enabled" : "disabled");
+    }
+
+    return fabric_supported;
+#else
+    return 0;
+#endif
+}
+
 ucs_status_t uct_cuda_ipc_iface_get_device_address(uct_iface_t *tl_iface,
                                                    uct_device_addr_t *addr)
 {
@@ -91,8 +143,12 @@ ucs_status_t uct_cuda_ipc_iface_get_device_address(uct_iface_t *tl_iface,
     uct_cuda_ipc_md_t *md                = ucs_derived_of(iface->super.super.md,
                                                            uct_cuda_ipc_md_t);
 
+    dev_addr->flags = 0;
     if (md->enable_mnnvl) {
-        dev_addr->flags = UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL;
+        dev_addr->flags |= UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL;
+    }
+    if (uct_cuda_ipc_iface_fabric_supported()) {
+        dev_addr->flags |= UCT_CUDA_IPC_DEVICE_ADDR_FLAG_FABRIC;
     }
 
     dev_addr->system_uuid = ucs_get_system_id();
@@ -107,18 +163,36 @@ static ucs_status_t uct_cuda_ipc_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
+/* Extract the flags byte from a device address, handling addresses produced by
+ * older peers (which only contained the system UUID and no trailing flags). */
+static uint8_t
+uct_cuda_ipc_iface_dev_addr_flags(const uct_cuda_ipc_device_addr_t *dev_addr,
+                                  size_t dev_addr_len)
+{
+    if (dev_addr_len == sizeof(uint64_t)) {
+        return 0;
+    }
+
+    ucs_assertv(dev_addr_len >= sizeof(uct_cuda_ipc_device_addr_t),
+                "dev_addr_len=%zu", dev_addr_len);
+    return dev_addr->flags;
+}
+
 static int
 uct_cuda_ipc_iface_mnnvl_supported(uct_cuda_ipc_md_t *md,
                                    const uct_cuda_ipc_device_addr_t *dev_addr,
                                    size_t dev_addr_len)
 {
-    if (md->enable_mnnvl && (dev_addr_len != sizeof(uint64_t))) {
-        ucs_assertv(dev_addr_len >= sizeof(uct_cuda_ipc_device_addr_t),
-                    "dev_addr_len=%zu", dev_addr_len);
-        return (dev_addr->flags & UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL);
-    }
+    return md->enable_mnnvl &&
+           (uct_cuda_ipc_iface_dev_addr_flags(dev_addr, dev_addr_len) &
+            UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL);
+}
 
-    return 0;
+static int uct_cuda_ipc_iface_remote_fabric_supported(
+        const uct_cuda_ipc_device_addr_t *dev_addr, size_t dev_addr_len)
+{
+    return !!(uct_cuda_ipc_iface_dev_addr_flags(dev_addr, dev_addr_len) &
+              UCT_CUDA_IPC_DEVICE_ADDR_FLAG_FABRIC);
 }
 
 static int
@@ -129,7 +203,9 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     uct_cuda_ipc_md_t *md       = ucs_derived_of(iface->super.super.md,
                                                  uct_cuda_ipc_md_t);
     const uct_cuda_ipc_device_addr_t *dev_addr;
+    uct_cuda_ipc_iface_address_t remote_iface_addr;
     size_t dev_addr_len;
+    size_t iface_addr_len;
     int same_uuid;
 
     if (!uct_iface_is_reachable_params_addrs_valid(params)) {
@@ -142,13 +218,37 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     dev_addr     = (const uct_cuda_ipc_device_addr_t *)params->device_addr;
     same_uuid    = (ucs_get_system_id() == dev_addr->system_uuid);
 
-    if (same_uuid ||
-        uct_cuda_ipc_iface_mnnvl_supported(md, dev_addr, dev_addr_len)) {
-        return uct_iface_scope_is_reachable(tl_iface, params);
+    if (!same_uuid &&
+        !uct_cuda_ipc_iface_mnnvl_supported(md, dev_addr, dev_addr_len)) {
+        uct_iface_fill_info_str_buf(params, "different machine and no MNNVL");
+        return 0;
     }
 
-    uct_iface_fill_info_str_buf(params, "different machine and no MNNVL");
-    return 0;
+    /* Legacy CUDA IPC handles cannot be exchanged across PID namespaces;
+     * both peers must support fabric IPC handles in that case. */
+    iface_addr_len    = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
+                                        iface_addr_length, IFACE_ADDR_LENGTH,
+                                        uct_cuda_ipc_iface_address_length());
+    remote_iface_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
+                                                          iface_addr_len);
+    if (remote_iface_addr.pid_ns != ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID)) {
+        if (!uct_cuda_ipc_iface_fabric_supported()) {
+            uct_iface_fill_info_str_buf(
+                    params,
+                    "different PID namespace and local FABRIC not supported");
+            return 0;
+        }
+
+        if (!uct_cuda_ipc_iface_remote_fabric_supported(dev_addr,
+                                                        dev_addr_len)) {
+            uct_iface_fill_info_str_buf(
+                    params,
+                    "different PID namespace and remote FABRIC not supported");
+            return 0;
+        }
+    }
+
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static double uct_cuda_ipc_iface_get_bw()
@@ -257,7 +357,8 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
     uct_base_iface_query(&iface->super.super, iface_attr);
 
     iface_attr->iface_addr_len          = uct_cuda_ipc_iface_address_length();
-    iface_attr->device_addr_len         = md->enable_mnnvl ?
+    iface_attr->device_addr_len         = (md->enable_mnnvl ||
+                                           uct_cuda_ipc_iface_fabric_supported()) ?
                                           sizeof(uct_cuda_ipc_device_addr_t) :
                                           sizeof(uint64_t);
     iface_attr->ep_addr_len             = 0;


### PR DESCRIPTION
## What?
Improve reachability of cuda_ipc to detect different pid namespaces without Fabric API.

## Why?
Early detection of non-reachable cuda_ipc lanes.
