### PR TITLE
UCT/DEVICE: fix gda qp state

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_devx.c
@@ -100,32 +100,15 @@ ucs_status_t uct_dc_mlx5_iface_devx_dci_connect(uct_dc_mlx5_iface_t *iface,
 {
     uct_rc_iface_t *rc_iface = &iface->super.super;
     uct_ib_mlx5_md_t *md     = uct_ib_mlx5_iface_md(&rc_iface->super);
-    char in_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_in)]   = {};
-    char out_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_out)] = {};
-    char in_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_in)]    = {};
-    char out_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_out)]  = {};
-    char in_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_in)]     = {};
-    char out_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_out)]   = {};
+    char in_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_in)]   = {};
+    char out_2rtr[UCT_IB_MLX5DV_ST_SZ_BYTES(init2rtr_qp_out)] = {};
+    char in_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_in)]    = {};
+    char out_2rts[UCT_IB_MLX5DV_ST_SZ_BYTES(rtr2rts_qp_out)]  = {};
     uint32_t opt_param_mask = UCT_IB_MLX5_QP_OPTPAR_RAE;
     ucs_status_t status;
     void *qpc;
 
-    UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, opcode, UCT_IB_MLX5_CMD_OP_RST2INIT_QP);
-    UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, qpn, qp->qp_num);
-
-    qpc = UCT_IB_MLX5DV_ADDR_OF(rst2init_qp_in, in_2init, qpc);
-    UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
-    UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.vhca_port_num,
-                      rc_iface->super.config.port_num);
-    if (!uct_ib_iface_is_roce(&rc_iface->super)) {
-        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index,
-                          rc_iface->super.pkey_index);
-    }
-    UCT_IB_MLX5DV_SET(qpc, qpc, counter_set_id,
-                      uct_ib_mlx5_iface_get_counter_set_id(&rc_iface->super));
-
-    status = uct_ib_mlx5_devx_modify_qp(qp, in_2init, sizeof(in_2init),
-                                        out_2init, sizeof(out_2init));
+    status = uct_ib_mlx5_devx_qp_rst2init(&rc_iface->super, qp);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -412,6 +412,32 @@ ucs_status_t uct_ib_mlx5_devx_modify_qp_state(uct_ib_mlx5_qp_t *qp,
     return uct_ib_mlx5_devx_modify_qp(qp, in, sizeof(in), out, sizeof(out));
 }
 
+ucs_status_t
+uct_ib_mlx5_devx_qp_rst2init(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp)
+{
+    char in_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_in)]   = {};
+    char out_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_out)] = {};
+    void *qpc;
+
+    UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, opcode,
+                      UCT_IB_MLX5_CMD_OP_RST2INIT_QP);
+    UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, qpn, qp->qp_num);
+
+    qpc = UCT_IB_MLX5DV_ADDR_OF(rst2init_qp_in, in_2init, qpc);
+    UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
+    UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.vhca_port_num,
+                      iface->config.port_num);
+    if (!uct_ib_iface_is_roce(iface)) {
+        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index,
+                          iface->pkey_index);
+    }
+    UCT_IB_MLX5DV_SET(qpc, qpc, counter_set_id,
+                      uct_ib_mlx5_iface_get_counter_set_id(iface));
+
+    return uct_ib_mlx5_devx_modify_qp(qp, in_2init, sizeof(in_2init), out_2init,
+                                      sizeof(out_2init));
+}
+
 void uct_ib_mlx5_devx_destroy_qp_common(uct_ib_mlx5_qp_t *qp)
 {
     uct_ib_mlx5_devx_obj_destroy(qp->devx.obj, "QP");

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -134,10 +134,8 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
     uct_ib_mlx5_md_t *md = ucs_derived_of(iface->super.md, uct_ib_mlx5_md_t);
     uct_ib_device_t *dev = &md->super.dev;
     uint64_t bf_size     = 0;
-    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_in)]           = {};
-    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_out)]         = {};
-    char in_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_in)]   = {};
-    char out_2init[UCT_IB_MLX5DV_ST_SZ_BYTES(rst2init_qp_out)] = {};
+    char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_in)]   = {};
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_out)] = {};
     uct_ib_mlx5_mmio_mode_t mmio_mode;
     uct_ib_mlx5_devx_uar_t *uar;
     ucs_status_t status;
@@ -226,30 +224,14 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
     }
 
     qp->qp_num = UCT_IB_MLX5DV_GET(create_qp_out, out, qpn);
+    qp->type   = UCT_IB_MLX5_OBJ_TYPE_DEVX;
 
     if (attr->super.qp_type == IBV_QPT_RC) {
-        qpc = UCT_IB_MLX5DV_ADDR_OF(rst2init_qp_in, in_2init, qpc);
-        UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, opcode, UCT_IB_MLX5_CMD_OP_RST2INIT_QP);
-        UCT_IB_MLX5DV_SET(rst2init_qp_in, in_2init, qpn, qp->qp_num);
-        UCT_IB_MLX5DV_SET(qpc, qpc, pm_state, UCT_IB_MLX5_QPC_PM_STATE_MIGRATED);
-        UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.vhca_port_num, attr->super.port);
-        if (!uct_ib_iface_is_roce(iface)) {
-            UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.pkey_index,
-                              iface->pkey_index);
-        }
-        UCT_IB_MLX5DV_SET(qpc, qpc, counter_set_id,
-                          uct_ib_mlx5_iface_get_counter_set_id(iface));
-        UCT_IB_MLX5DV_SET(qpc, qpc, rwe, true);
-
-        status = uct_ib_mlx5_devx_obj_modify(qp->devx.obj, in_2init,
-                                             sizeof(in_2init), out_2init,
-                                             sizeof(out_2init), "2INIT_QP");
+        status = uct_ib_mlx5_devx_qp_rst2init(iface, qp);
         if (status != UCS_OK) {
             goto err_free;
         }
     }
-
-    qp->type = UCT_IB_MLX5_OBJ_TYPE_DEVX;
 
     attr->super.cap.max_send_wr = attr->max_tx;
     attr->super.cap.max_recv_wr = 0;
@@ -433,6 +415,9 @@ uct_ib_mlx5_devx_qp_rst2init(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp)
     }
     UCT_IB_MLX5DV_SET(qpc, qpc, counter_set_id,
                       uct_ib_mlx5_iface_get_counter_set_id(iface));
+    if (iface->config.qp_type == IBV_QPT_RC) {
+        UCT_IB_MLX5DV_SET(qpc, qpc, rwe, true);
+    }
 
     return uct_ib_mlx5_devx_modify_qp(qp, in_2init, sizeof(in_2init), out_2init,
                                       sizeof(out_2init));

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -414,6 +414,47 @@ uct_rc_gdaki_channel_block(uct_rc_gdaki_iface_t *iface, ucs_mpool_t *mp,
     }
 }
 
+static ucs_status_t uct_rc_gdaki_channel_reset_qp(uct_ib_iface_t *ib_iface,
+                                                  uct_ib_mlx5_txwq_t *txwq)
+{
+    ucs_status_t status;
+
+    (void)uct_ib_mlx5_modify_qp_state(ib_iface, &txwq->super, IBV_QPS_ERR);
+
+    status = uct_ib_mlx5_modify_qp_state(ib_iface, &txwq->super, IBV_QPS_RESET);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    uct_ib_mlx5_txwq_reset(txwq);
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_rc_gdaki_channel_connect(uct_rc_gdaki_iface_t *iface,
+                             uct_rc_gdaki_channel_t *channel,
+                             uint32_t dest_qp_num,
+                             const struct ibv_ah_attr *ah_attr,
+                             enum ibv_mtu path_mtu, uint8_t path_index)
+{
+    uct_ib_iface_t *ib_iface = &iface->super.super.super;
+    ucs_status_t status;
+
+    status = uct_rc_gdaki_channel_reset_qp(ib_iface, &channel->qp);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_mlx5_devx_qp_rst2init(ib_iface, &channel->qp.super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return uct_rc_mlx5_iface_common_devx_connect_qp(
+            &iface->super, &channel->qp.super, dest_qp_num, ah_attr, path_mtu,
+            path_index, iface->super.super.config.max_rd_atomic);
+}
+
 static void uct_rc_gdaki_chunk_channels_destroy(uct_rc_gdaki_iface_t *iface,
                                                 ucs_mpool_t *mp, void *elems,
                                                 unsigned num_elems,
@@ -661,7 +702,8 @@ uct_rc_gdaki_ep_reset_channels(uct_rc_gdaki_ep_t *ep)
     ep->channel_block = NULL;
 }
 
-static void uct_rc_gdaki_cleanup_channels_pooled(uct_rc_gdaki_ep_t *ep)
+static void uct_rc_gdaki_cleanup_channels_pooled(uct_rc_gdaki_iface_t *iface,
+                                                 uct_rc_gdaki_ep_t *ep)
 {
     if (ep->channel_block == NULL) {
         return;
@@ -747,7 +789,7 @@ static void uct_rc_gdaki_ep_cleanup_channels(uct_rc_gdaki_iface_t *iface,
                                              uct_rc_gdaki_ep_t *ep)
 {
     if (iface->ep_alloc_mode == UCT_RC_GDAKI_EP_ALLOC_MODE_POOL) {
-        uct_rc_gdaki_cleanup_channels_pooled(ep);
+        uct_rc_gdaki_cleanup_channels_pooled(iface, ep);
         return;
     }
 
@@ -849,9 +891,8 @@ uct_rc_gdaki_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     for (i = 0; i < iface->num_channels; i++) {
         dest_qp_num = uct_ib_unpack_uint24(
                 *ucs_serialize_next(&ep_addr, uct_ib_uint24_t));
-        status      = uct_rc_mlx5_iface_common_devx_connect_qp(
-                &iface->super, &channels[i].qp.super, dest_qp_num, &ah_attr,
-                path_mtu, path_index, iface->super.super.config.max_rd_atomic);
+        status = uct_rc_gdaki_channel_connect(iface, &channels[i], dest_qp_num,
+                                              &ah_attr, path_mtu, path_index);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -430,29 +430,30 @@ static ucs_status_t uct_rc_gdaki_channel_reset_qp(uct_ib_iface_t *ib_iface,
     return UCS_OK;
 }
 
-static ucs_status_t
-uct_rc_gdaki_channel_connect(uct_rc_gdaki_iface_t *iface,
-                             uct_rc_gdaki_channel_t *channel,
-                             uint32_t dest_qp_num,
-                             struct ibv_ah_attr *ah_attr,
-                             enum ibv_mtu path_mtu, uint8_t path_index)
+static void
+uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
+                                     uct_rc_gdaki_channel_block_t *block)
 {
     uct_ib_iface_t *ib_iface = &iface->super.super.super;
+    uct_rc_gdaki_channel_t *channel;
     ucs_status_t status;
+    unsigned i;
 
-    status = uct_rc_gdaki_channel_reset_qp(ib_iface, &channel->qp);
-    if (status != UCS_OK) {
-        return status;
+    for (i = 0; i < iface->num_channels; i++) {
+        channel = &block->channels[i];
+        status  = uct_rc_gdaki_channel_reset_qp(ib_iface, &channel->qp);
+        if (status != UCS_OK) {
+            ucs_warn("failed to reset gdaki qp %u: %s",
+                     channel->qp.super.qp_num, ucs_status_string(status));
+            continue;
+        }
+
+        status = uct_ib_mlx5_devx_qp_rst2init(ib_iface, &channel->qp.super);
+        if (status != UCS_OK) {
+            ucs_warn("failed to move gdaki qp %u to INIT: %s",
+                     channel->qp.super.qp_num, ucs_status_string(status));
+        }
     }
-
-    status = uct_ib_mlx5_devx_qp_rst2init(ib_iface, &channel->qp.super);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    return uct_rc_mlx5_iface_common_devx_connect_qp(
-            &iface->super, &channel->qp.super, dest_qp_num, ah_attr, path_mtu,
-            path_index, iface->super.super.config.max_rd_atomic);
 }
 
 static void uct_rc_gdaki_chunk_channels_destroy(uct_rc_gdaki_iface_t *iface,
@@ -709,6 +710,7 @@ static void uct_rc_gdaki_cleanup_channels_pooled(uct_rc_gdaki_iface_t *iface,
         return;
     }
 
+    uct_rc_gdaki_channel_block_reset_qps(iface, ep->channel_block);
     ucs_mpool_put(ep->channel_block);
     uct_rc_gdaki_ep_reset_channels(ep);
 }
@@ -891,8 +893,9 @@ uct_rc_gdaki_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     for (i = 0; i < iface->num_channels; i++) {
         dest_qp_num = uct_ib_unpack_uint24(
                 *ucs_serialize_next(&ep_addr, uct_ib_uint24_t));
-        status = uct_rc_gdaki_channel_connect(iface, &channels[i], dest_qp_num,
-                                              &ah_attr, path_mtu, path_index);
+        status      = uct_rc_mlx5_iface_common_devx_connect_qp(
+                &iface->super, &channels[i].qp.super, dest_qp_num, &ah_attr,
+                path_mtu, path_index, iface->super.super.config.max_rd_atomic);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -414,14 +414,16 @@ uct_rc_gdaki_channel_block(uct_rc_gdaki_iface_t *iface, ucs_mpool_t *mp,
     }
 }
 
-static void
+static ucs_status_t
 uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
                                      uct_rc_gdaki_channel_block_t *block)
 {
     uct_ib_iface_t *ib_iface = &iface->super.super.super;
     uct_rc_gdaki_channel_t *channel;
-    ucs_status_t status;
+    ucs_status_t status, first_status;
     unsigned i;
+
+    first_status = UCS_OK;
 
     for (i = 0; i < iface->num_channels; i++) {
         channel = &block->channels[i];
@@ -432,8 +434,11 @@ uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
         status = uct_ib_mlx5_modify_qp_state(ib_iface, &channel->qp.super,
                                              IBV_QPS_RESET);
         if (status != UCS_OK) {
-            ucs_warn("failed to reset gdaki qp %u: %s",
+            ucs_warn("failed to reset gdaki qp 0x%x: %s",
                      channel->qp.super.qp_num, ucs_status_string(status));
+            if (first_status == UCS_OK) {
+                first_status = status;
+            }
             continue;
         }
 
@@ -441,10 +446,16 @@ uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
 
         status = uct_ib_mlx5_devx_qp_rst2init(ib_iface, &channel->qp.super);
         if (status != UCS_OK) {
-            ucs_warn("failed to move gdaki qp %u to INIT: %s",
+            ucs_warn("failed to move gdaki qp 0x%x to init: %s",
                      channel->qp.super.qp_num, ucs_status_string(status));
+            if (first_status == UCS_OK) {
+                first_status = status;
+            }
+            continue;
         }
     }
+
+    return first_status;
 }
 
 static void uct_rc_gdaki_chunk_channels_destroy(uct_rc_gdaki_iface_t *iface,
@@ -472,7 +483,8 @@ static ucs_status_t
 uct_rc_gdaki_init_channel_chunk(uct_rc_gdaki_iface_t *iface,
                                 uct_rc_gdaki_channel_block_mem_t *mem,
                                 size_t dev_ep_size, ucs_mpool_t *mp,
-                                void *elems, unsigned num_elems)
+                                ucs_mpool_chunk_t *mp_chunk, void *elems,
+                                unsigned num_elems)
 {
     uct_ib_iface_init_attr_t init_attr = {};
     uct_ib_mlx5_cq_attr_t cq_attr      = {};
@@ -510,6 +522,7 @@ uct_rc_gdaki_init_channel_chunk(uct_rc_gdaki_iface_t *iface,
                                                        ep_index);
             channel       = &channel_block->channels[channel_index];
             if (channel_index == 0) {
+                channel_block->chunk   = mp_chunk;
                 channel_block->gpu_ptr = (uintptr_t)
                         UCS_PTR_BYTE_OFFSET(mem->gpu_mem, ep_offset);
             }
@@ -552,6 +565,57 @@ err_cleanup:
     return status;
 }
 
+static void uct_rc_gdaki_channel_chunk_rebuild(uct_rc_gdaki_iface_t *iface,
+                                               ucs_mpool_t *mp,
+                                               ucs_mpool_chunk_t *chunk)
+{
+    uct_rc_gdaki_pool_priv_t *priv = ucs_mpool_priv(mp);
+    uct_rc_gdaki_channel_block_mem_t *hdr =
+            (uct_rc_gdaki_channel_block_mem_t*)chunk - 1;
+    uct_rc_gdaki_channel_block_t *block;
+    ucs_status_t status;
+
+    uct_rc_gdaki_chunk_channels_destroy(iface, mp, chunk->elems,
+                                        chunk->num_elems, chunk->num_elems,
+                                        iface->num_channels - 1);
+
+    status = uct_rc_gdaki_init_channel_chunk(iface, hdr, priv->dev_ep_size, mp,
+                                             chunk, chunk->elems,
+                                             chunk->num_elems);
+    if (status != UCS_OK) {
+        ucs_fatal("failed to rebuild gdaki channel chunk %p: %s", chunk,
+                  ucs_status_string(status));
+    }
+
+    while (!ucs_list_is_empty(&hdr->err_list)) {
+        block = ucs_list_extract_head(&hdr->err_list,
+                                      uct_rc_gdaki_channel_block_t, err_list);
+        ucs_list_head_init(&block->err_list);
+        ucs_mpool_put(block);
+    }
+}
+
+static void
+uct_rc_gdaki_channel_block_try_rebuild(uct_rc_gdaki_iface_t *iface,
+                                       uct_rc_gdaki_channel_block_t *block)
+{
+    ucs_mpool_t *mp = &iface->channel_pool;
+    ucs_mpool_chunk_t *chunk;
+    uct_rc_gdaki_channel_block_mem_t *hdr;
+
+    chunk = block->chunk;
+    ucs_assert(chunk != NULL);
+
+    hdr = (uct_rc_gdaki_channel_block_mem_t*)chunk - 1;
+    ucs_list_add_tail(&hdr->err_list, &block->err_list);
+    ++hdr->err_count;
+
+    if (hdr->err_count == chunk->num_elems) {
+        uct_rc_gdaki_channel_chunk_rebuild(iface, mp, chunk);
+        hdr->err_count = 0;
+    }
+}
+
 static ucs_status_t
 uct_rc_gdaki_pool_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
 {
@@ -576,6 +640,9 @@ uct_rc_gdaki_pool_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
         goto err_free_hdr;
     }
 
+    ucs_list_head_init(&hdr->err_list);
+    hdr->err_count = 0;
+
     gpu_alloc_size = num_elems * priv->dev_ep_size;
     status = uct_rc_gdaki_init_umem(iface, priv->pgsz_bitmap, gpu_alloc_size,
                                     hdr);
@@ -584,7 +651,7 @@ uct_rc_gdaki_pool_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
     }
 
     status = uct_rc_gdaki_init_channel_chunk(
-            iface, hdr, priv->dev_ep_size, mp,
+            iface, hdr, priv->dev_ep_size, mp, (ucs_mpool_chunk_t*)(hdr + 1),
             ucs_mpool_chunk_elems(mp, (void*)(hdr + 1)), num_elems);
     if (status != UCS_OK) {
         goto err_umem;
@@ -697,12 +764,18 @@ uct_rc_gdaki_ep_reset_channels(uct_rc_gdaki_ep_t *ep)
 static void uct_rc_gdaki_cleanup_channels_pooled(uct_rc_gdaki_iface_t *iface,
                                                  uct_rc_gdaki_ep_t *ep)
 {
+    ucs_status_t status;
+
     if (ep->channel_block == NULL) {
         return;
     }
 
-    uct_rc_gdaki_channel_block_reset_qps(iface, ep->channel_block);
-    ucs_mpool_put(ep->channel_block);
+    status = uct_rc_gdaki_channel_block_reset_qps(iface, ep->channel_block);
+    if (status == UCS_OK) {
+        ucs_mpool_put(ep->channel_block);
+    } else {
+        uct_rc_gdaki_channel_block_try_rebuild(iface, ep->channel_block);
+    }
     uct_rc_gdaki_ep_reset_channels(ep);
 }
 
@@ -737,7 +810,7 @@ uct_rc_gdaki_ep_init_channels_direct(uct_rc_gdaki_iface_t *iface,
     ep->channel_block->gpu_ptr = (uintptr_t)ep->mem.gpu_mem;
 
     status = uct_rc_gdaki_init_channel_chunk(iface, &ep->mem, dev_ep_size, NULL,
-                                             ep->channel_block, 1);
+                                             NULL, ep->channel_block, 1);
     if (status != UCS_OK) {
         goto err_umem;
     }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -434,7 +434,7 @@ static ucs_status_t
 uct_rc_gdaki_channel_connect(uct_rc_gdaki_iface_t *iface,
                              uct_rc_gdaki_channel_t *channel,
                              uint32_t dest_qp_num,
-                             const struct ibv_ah_attr *ah_attr,
+                             struct ibv_ah_attr *ah_attr,
                              enum ibv_mtu path_mtu, uint8_t path_index)
 {
     uct_ib_iface_t *ib_iface = &iface->super.super.super;

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -414,22 +414,6 @@ uct_rc_gdaki_channel_block(uct_rc_gdaki_iface_t *iface, ucs_mpool_t *mp,
     }
 }
 
-static ucs_status_t uct_rc_gdaki_channel_reset_qp(uct_ib_iface_t *ib_iface,
-                                                  uct_ib_mlx5_txwq_t *txwq)
-{
-    ucs_status_t status;
-
-    (void)uct_ib_mlx5_modify_qp_state(ib_iface, &txwq->super, IBV_QPS_ERR);
-
-    status = uct_ib_mlx5_modify_qp_state(ib_iface, &txwq->super, IBV_QPS_RESET);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    uct_ib_mlx5_txwq_reset(txwq);
-    return UCS_OK;
-}
-
 static void
 uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
                                      uct_rc_gdaki_channel_block_t *block)
@@ -441,12 +425,19 @@ uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
 
     for (i = 0; i < iface->num_channels; i++) {
         channel = &block->channels[i];
-        status  = uct_rc_gdaki_channel_reset_qp(ib_iface, &channel->qp);
+
+        (void)uct_ib_mlx5_modify_qp_state(ib_iface, &channel->qp.super,
+                                          IBV_QPS_ERR);
+
+        status = uct_ib_mlx5_modify_qp_state(ib_iface, &channel->qp.super,
+                                             IBV_QPS_RESET);
         if (status != UCS_OK) {
             ucs_warn("failed to reset gdaki qp %u: %s",
                      channel->qp.super.qp_num, ucs_status_string(status));
             continue;
         }
+
+        uct_ib_mlx5_txwq_reset(&channel->qp);
 
         status = uct_ib_mlx5_devx_qp_rst2init(ib_iface, &channel->qp.super);
         if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -414,16 +414,14 @@ uct_rc_gdaki_channel_block(uct_rc_gdaki_iface_t *iface, ucs_mpool_t *mp,
     }
 }
 
-static ucs_status_t
+static void
 uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
                                      uct_rc_gdaki_channel_block_t *block)
 {
     uct_ib_iface_t *ib_iface = &iface->super.super.super;
     uct_rc_gdaki_channel_t *channel;
-    ucs_status_t status, first_status;
+    ucs_status_t status;
     unsigned i;
-
-    first_status = UCS_OK;
 
     for (i = 0; i < iface->num_channels; i++) {
         channel = &block->channels[i];
@@ -434,28 +432,20 @@ uct_rc_gdaki_channel_block_reset_qps(uct_rc_gdaki_iface_t *iface,
         status = uct_ib_mlx5_modify_qp_state(ib_iface, &channel->qp.super,
                                              IBV_QPS_RESET);
         if (status != UCS_OK) {
-            ucs_warn("failed to reset gdaki qp 0x%x: %s",
-                     channel->qp.super.qp_num, ucs_status_string(status));
-            if (first_status == UCS_OK) {
-                first_status = status;
-            }
-            continue;
+            ucs_fatal("failed to reset gdaki qp 0x%x: %s",
+                      channel->qp.super.qp_num, ucs_status_string(status));
+            return;
         }
 
         uct_ib_mlx5_txwq_reset(&channel->qp);
 
         status = uct_ib_mlx5_devx_qp_rst2init(ib_iface, &channel->qp.super);
         if (status != UCS_OK) {
-            ucs_warn("failed to move gdaki qp 0x%x to init: %s",
-                     channel->qp.super.qp_num, ucs_status_string(status));
-            if (first_status == UCS_OK) {
-                first_status = status;
-            }
-            continue;
+            ucs_fatal("failed to move gdaki qp 0x%x to init: %s",
+                      channel->qp.super.qp_num, ucs_status_string(status));
+            return;
         }
     }
-
-    return first_status;
 }
 
 static void uct_rc_gdaki_chunk_channels_destroy(uct_rc_gdaki_iface_t *iface,
@@ -482,8 +472,7 @@ static void uct_rc_gdaki_chunk_channels_destroy(uct_rc_gdaki_iface_t *iface,
 static ucs_status_t
 uct_rc_gdaki_init_channel_chunk(uct_rc_gdaki_iface_t *iface,
                                 uct_rc_gdaki_channel_block_mem_t *mem,
-                                size_t dev_ep_size, ucs_mpool_t *mp,
-                                ucs_mpool_chunk_t *mp_chunk, void *elems,
+                                size_t dev_ep_size, ucs_mpool_t *mp, void *elems,
                                 unsigned num_elems)
 {
     uct_ib_iface_init_attr_t init_attr = {};
@@ -522,7 +511,6 @@ uct_rc_gdaki_init_channel_chunk(uct_rc_gdaki_iface_t *iface,
                                                        ep_index);
             channel       = &channel_block->channels[channel_index];
             if (channel_index == 0) {
-                channel_block->chunk   = mp_chunk;
                 channel_block->gpu_ptr = (uintptr_t)
                         UCS_PTR_BYTE_OFFSET(mem->gpu_mem, ep_offset);
             }
@@ -565,57 +553,6 @@ err_cleanup:
     return status;
 }
 
-static void uct_rc_gdaki_channel_chunk_rebuild(uct_rc_gdaki_iface_t *iface,
-                                               ucs_mpool_t *mp,
-                                               ucs_mpool_chunk_t *chunk)
-{
-    uct_rc_gdaki_pool_priv_t *priv = ucs_mpool_priv(mp);
-    uct_rc_gdaki_channel_block_mem_t *hdr =
-            (uct_rc_gdaki_channel_block_mem_t*)chunk - 1;
-    uct_rc_gdaki_channel_block_t *block;
-    ucs_status_t status;
-
-    uct_rc_gdaki_chunk_channels_destroy(iface, mp, chunk->elems,
-                                        chunk->num_elems, chunk->num_elems,
-                                        iface->num_channels - 1);
-
-    status = uct_rc_gdaki_init_channel_chunk(iface, hdr, priv->dev_ep_size, mp,
-                                             chunk, chunk->elems,
-                                             chunk->num_elems);
-    if (status != UCS_OK) {
-        ucs_fatal("failed to rebuild gdaki channel chunk %p: %s", chunk,
-                  ucs_status_string(status));
-    }
-
-    while (!ucs_list_is_empty(&hdr->err_list)) {
-        block = ucs_list_extract_head(&hdr->err_list,
-                                      uct_rc_gdaki_channel_block_t, err_list);
-        ucs_list_head_init(&block->err_list);
-        ucs_mpool_put(block);
-    }
-}
-
-static void
-uct_rc_gdaki_channel_block_try_rebuild(uct_rc_gdaki_iface_t *iface,
-                                       uct_rc_gdaki_channel_block_t *block)
-{
-    ucs_mpool_t *mp = &iface->channel_pool;
-    ucs_mpool_chunk_t *chunk;
-    uct_rc_gdaki_channel_block_mem_t *hdr;
-
-    chunk = block->chunk;
-    ucs_assert(chunk != NULL);
-
-    hdr = (uct_rc_gdaki_channel_block_mem_t*)chunk - 1;
-    ucs_list_add_tail(&hdr->err_list, &block->err_list);
-    ++hdr->err_count;
-
-    if (hdr->err_count == chunk->num_elems) {
-        uct_rc_gdaki_channel_chunk_rebuild(iface, mp, chunk);
-        hdr->err_count = 0;
-    }
-}
-
 static ucs_status_t
 uct_rc_gdaki_pool_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
 {
@@ -640,9 +577,6 @@ uct_rc_gdaki_pool_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
         goto err_free_hdr;
     }
 
-    ucs_list_head_init(&hdr->err_list);
-    hdr->err_count = 0;
-
     gpu_alloc_size = num_elems * priv->dev_ep_size;
     status = uct_rc_gdaki_init_umem(iface, priv->pgsz_bitmap, gpu_alloc_size,
                                     hdr);
@@ -651,7 +585,7 @@ uct_rc_gdaki_pool_chunk_alloc(ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
     }
 
     status = uct_rc_gdaki_init_channel_chunk(
-            iface, hdr, priv->dev_ep_size, mp, (ucs_mpool_chunk_t*)(hdr + 1),
+            iface, hdr, priv->dev_ep_size, mp,
             ucs_mpool_chunk_elems(mp, (void*)(hdr + 1)), num_elems);
     if (status != UCS_OK) {
         goto err_umem;
@@ -764,18 +698,12 @@ uct_rc_gdaki_ep_reset_channels(uct_rc_gdaki_ep_t *ep)
 static void uct_rc_gdaki_cleanup_channels_pooled(uct_rc_gdaki_iface_t *iface,
                                                  uct_rc_gdaki_ep_t *ep)
 {
-    ucs_status_t status;
-
     if (ep->channel_block == NULL) {
         return;
     }
 
-    status = uct_rc_gdaki_channel_block_reset_qps(iface, ep->channel_block);
-    if (status == UCS_OK) {
-        ucs_mpool_put(ep->channel_block);
-    } else {
-        uct_rc_gdaki_channel_block_try_rebuild(iface, ep->channel_block);
-    }
+    uct_rc_gdaki_channel_block_reset_qps(iface, ep->channel_block);
+    ucs_mpool_put(ep->channel_block);
     uct_rc_gdaki_ep_reset_channels(ep);
 }
 
@@ -810,7 +738,7 @@ uct_rc_gdaki_ep_init_channels_direct(uct_rc_gdaki_iface_t *iface,
     ep->channel_block->gpu_ptr = (uintptr_t)ep->mem.gpu_mem;
 
     status = uct_rc_gdaki_init_channel_chunk(iface, &ep->mem, dev_ep_size, NULL,
-                                             NULL, ep->channel_block, 1);
+                                             ep->channel_block, 1);
     if (status != UCS_OK) {
         goto err_umem;
     }

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -8,6 +8,7 @@
 
 #include <uct/ib/mlx5/rc/rc_mlx5_common.h>
 #include <uct/base/uct_iface.h>
+#include <ucs/datastruct/list.h>
 #include <ucs/datastruct/mpool.h>
 
 #include <cuda.h>
@@ -25,6 +26,8 @@ typedef struct {
 
 typedef struct {
     uintptr_t              gpu_ptr;
+    ucs_mpool_chunk_t      *chunk;
+    ucs_list_link_t        err_list;
     uct_rc_gdaki_channel_t channels[0];
 } uct_rc_gdaki_channel_block_t;
 
@@ -32,6 +35,8 @@ typedef struct {
     void                    *gpu_mem;
     CUdeviceptr             gpu_raw;
     struct mlx5dv_devx_umem *umem;
+    ucs_list_link_t         err_list;
+    unsigned                err_count;
 } uct_rc_gdaki_channel_block_mem_t;
 
 typedef struct uct_rc_gdaki_iface {

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -8,7 +8,6 @@
 
 #include <uct/ib/mlx5/rc/rc_mlx5_common.h>
 #include <uct/base/uct_iface.h>
-#include <ucs/datastruct/list.h>
 #include <ucs/datastruct/mpool.h>
 
 #include <cuda.h>
@@ -26,8 +25,6 @@ typedef struct {
 
 typedef struct {
     uintptr_t              gpu_ptr;
-    ucs_mpool_chunk_t      *chunk;
-    ucs_list_link_t        err_list;
     uct_rc_gdaki_channel_t channels[0];
 } uct_rc_gdaki_channel_block_t;
 
@@ -35,8 +32,6 @@ typedef struct {
     void                    *gpu_mem;
     CUdeviceptr             gpu_raw;
     struct mlx5dv_devx_umem *umem;
-    ucs_list_link_t         err_list;
-    unsigned                err_count;
 } uct_rc_gdaki_channel_block_mem_t;
 
 typedef struct uct_rc_gdaki_iface {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -991,6 +991,9 @@ ucs_status_t uct_ib_mlx5_devx_modify_qp(uct_ib_mlx5_qp_t *qp,
 ucs_status_t uct_ib_mlx5_devx_modify_qp_state(uct_ib_mlx5_qp_t *qp,
                                               enum ibv_qp_state state);
 
+ucs_status_t
+uct_ib_mlx5_devx_qp_rst2init(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp);
+
 void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp);
 
 void uct_ib_mlx5_devx_destroy_qp_common(uct_ib_mlx5_qp_t *qp);
@@ -1182,6 +1185,12 @@ uct_ib_mlx5_devx_modify_qp(uct_ib_mlx5_qp_t *qp,
 
 static inline ucs_status_t
 uct_ib_mlx5_devx_modify_qp_state(uct_ib_mlx5_qp_t *qp, enum ibv_qp_state state)
+{
+    return UCS_ERR_UNSUPPORTED;
+}
+
+static inline ucs_status_t
+uct_ib_mlx5_devx_qp_rst2init(uct_ib_iface_t *iface, uct_ib_mlx5_qp_t *qp)
 {
     return UCS_ERR_UNSUPPORTED;
 }

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -189,7 +189,7 @@ protected:
     entity *m_receiver;
 
 private:
-    CUdevice m_cuda_dev;
+    CUdevice m_cuda_dev = CU_DEVICE_INVALID;
 };
 
 UCS_TEST_P(test_device, put)
@@ -198,7 +198,7 @@ UCS_TEST_P(test_device, put)
     device_put(0x1111111111111111lu, 0x2222222222222222lu);
 }
 
-UCS_TEST_P(test_device, reconnect, "IB_GDA_RETAIN_INACTIVE_CTX?=y")
+UCS_TEST_P(test_device, reconnect)
 {
     skip_if_no_cuda();
     skip_if_not_rc_gda();
@@ -210,6 +210,8 @@ UCS_TEST_P(test_device, reconnect, "IB_GDA_RETAIN_INACTIVE_CTX?=y")
 
     m_sender->create_ep(0);
     m_sender->connect_p2p_ep(m_sender->ep(0), m_receiver->ep(0));
+    m_receiver->connect_p2p_ep(m_receiver->ep(0), m_sender->ep(0));
+    short_progress_loop();
 
     device_put(0x3333333333333333lu, 0x4444444444444444lu);
 }

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -110,6 +110,29 @@ protected:
         }
     }
 
+    bool is_connected_to(const entity &remote, uct_ep_h ep) const
+    {
+        uct_iface_attr_t iface_attr;
+        uct_ep_is_connected_params_t params;
+        std::string dev_addr, ep_addr;
+
+        ASSERT_UCS_OK(uct_iface_query(remote.iface(), &iface_attr));
+        dev_addr.resize(iface_attr.device_addr_len);
+        ep_addr.resize(iface_attr.ep_addr_len);
+
+        ASSERT_UCS_OK(uct_iface_get_device_address(
+                remote.iface(), (uct_device_addr_t*)dev_addr.data()));
+        ASSERT_UCS_OK(uct_ep_get_address(remote.ep(0),
+                                         (uct_ep_addr_t*)ep_addr.data()));
+
+        params.field_mask  = UCT_EP_IS_CONNECTED_FIELD_DEVICE_ADDR |
+                             UCT_EP_IS_CONNECTED_FIELD_EP_ADDR;
+        params.device_addr = (uct_device_addr_t*)dev_addr.data();
+        params.ep_addr     = (uct_ep_addr_t*)ep_addr.data();
+
+        return uct_ep_is_connected(ep, &params);
+    }
+
     void device_put(uint64_t send_seed, uint64_t recv_seed)
     {
         constexpr size_t length = 1024;
@@ -203,14 +226,25 @@ UCS_TEST_P(test_device, reconnect)
     skip_if_no_cuda();
     skip_if_not_rc_gda();
 
+    EXPECT_TRUE(is_connected_to(*m_receiver, m_sender->ep(0)));
+    EXPECT_TRUE(is_connected_to(*m_sender, m_receiver->ep(0)));
+
     device_put(0x1111111111111111lu, 0x2222222222222222lu);
 
     m_sender->destroy_ep(0);
+    m_receiver->destroy_ep(0);
     short_progress_loop();
 
     m_sender->create_ep(0);
+    m_receiver->create_ep(0);
+    EXPECT_FALSE(is_connected_to(*m_receiver, m_sender->ep(0)));
+    EXPECT_FALSE(is_connected_to(*m_sender, m_receiver->ep(0)));
+
     m_sender->connect_p2p_ep(m_sender->ep(0), m_receiver->ep(0));
+    EXPECT_TRUE(is_connected_to(*m_receiver, m_sender->ep(0)));
+
     m_receiver->connect_p2p_ep(m_receiver->ep(0), m_sender->ep(0));
+    EXPECT_TRUE(is_connected_to(*m_sender, m_receiver->ep(0)));
     short_progress_loop();
 
     device_put(0x3333333333333333lu, 0x4444444444444444lu);

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -95,6 +95,56 @@ static auto &g_test_device_cuda_ctx_guard =
 
 class test_device : public uct_test {
 protected:
+    void skip_if_no_cuda() const
+    {
+        if (!(m_sender->md_attr().reg_mem_types &
+              UCS_BIT(UCS_MEMORY_TYPE_CUDA))) {
+            UCS_TEST_SKIP_R("CUDA registration not supported");
+        }
+    }
+
+    void skip_if_not_rc_gda() const
+    {
+        if (!has_transport("rc_gda")) {
+            UCS_TEST_SKIP_R("rc_gda transport not supported");
+        }
+    }
+
+    void device_put(uint64_t send_seed, uint64_t recv_seed)
+    {
+        constexpr size_t length = 1024;
+        mapped_buffer sendbuf(length, send_seed, *m_sender, 0,
+                              UCS_MEMORY_TYPE_CUDA);
+        mapped_buffer recvbuf(length, recv_seed, *m_receiver, 0,
+                              UCS_MEMORY_TYPE_CUDA);
+
+        uct_device_mem_elem_t src_elem_host;
+        ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
+                                           recvbuf.rkey(), &src_elem_host));
+
+        mapped_buffer src_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
+                                  UCS_MEMORY_TYPE_CUDA);
+        ASSERT_EQ(CUDA_SUCCESS,
+                  cuMemcpyHtoD((CUdeviceptr)src_elembuf.ptr(), &src_elem_host,
+                               sizeof(src_elem_host)));
+
+        mapped_buffer rem_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
+                                  UCS_MEMORY_TYPE_CUDA);
+        ASSERT_EQ(CUDA_SUCCESS,
+                  cuMemcpyHtoD((CUdeviceptr)rem_elembuf.ptr(), &src_elem_host,
+                               sizeof(src_elem_host)));
+
+        uct_device_ep_h dev_ep;
+        ASSERT_UCS_OK(uct_ep_get_device_ep(m_sender->ep(0), &dev_ep));
+        ASSERT_UCS_OK(ucx_cuda::launch_uct_put(
+                dev_ep, (const uct_device_mem_elem_t*)src_elembuf.ptr(),
+                (const uct_device_mem_elem_t*)rem_elembuf.ptr(), sendbuf.ptr(),
+                (uintptr_t)recvbuf.ptr(), length));
+
+        recvbuf.pattern_check(send_seed);
+        recvbuf.pattern_fill(recv_seed);
+    }
+
     void init()
     {
         CUcontext ctx;
@@ -144,41 +194,24 @@ private:
 
 UCS_TEST_P(test_device, put)
 {
-    if (!(m_sender->md_attr().reg_mem_types & UCS_BIT(UCS_MEMORY_TYPE_CUDA))) {
-        UCS_TEST_SKIP_R("CUDA registration not supported");
-    }
+    skip_if_no_cuda();
+    device_put(0x1111111111111111lu, 0x2222222222222222lu);
+}
 
-    constexpr uint64_t SEED1 = 0x1111111111111111lu;
-    constexpr uint64_t SEED2 = 0x2222222222222222lu;
-    constexpr size_t length  = 1024;
-    mapped_buffer sendbuf(length, SEED1, *m_sender, 0, UCS_MEMORY_TYPE_CUDA);
-    mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
+UCS_TEST_P(test_device, reconnect, "IB_GDA_RETAIN_INACTIVE_CTX?=y")
+{
+    skip_if_no_cuda();
+    skip_if_not_rc_gda();
 
-    uct_device_mem_elem_t src_elem_host;
-    ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host));
+    device_put(0x1111111111111111lu, 0x2222222222222222lu);
 
-    mapped_buffer src_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
-                              UCS_MEMORY_TYPE_CUDA);
-    ASSERT_EQ(CUDA_SUCCESS,
-              cuMemcpyHtoD((CUdeviceptr)src_elembuf.ptr(), &src_elem_host,
-                           sizeof(src_elem_host)));
+    m_sender->destroy_ep(0);
+    short_progress_loop();
 
-    mapped_buffer rem_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
-                              UCS_MEMORY_TYPE_CUDA);
-    ASSERT_EQ(CUDA_SUCCESS,
-              cuMemcpyHtoD((CUdeviceptr)rem_elembuf.ptr(), &src_elem_host,
-                           sizeof(src_elem_host)));
+    m_sender->create_ep(0);
+    m_sender->connect_p2p_ep(m_sender->ep(0), m_receiver->ep(0));
 
-    uct_device_ep_h dev_ep;
-    ASSERT_UCS_OK(uct_ep_get_device_ep(m_sender->ep(0), &dev_ep));
-    ASSERT_UCS_OK(ucx_cuda::launch_uct_put(
-            dev_ep, (const uct_device_mem_elem_t*)src_elembuf.ptr(),
-            (const uct_device_mem_elem_t*)rem_elembuf.ptr(), sendbuf.ptr(),
-            (uintptr_t)recvbuf.ptr(), length));
-
-    recvbuf.pattern_check(SEED1);
-    recvbuf.pattern_fill(SEED2);
+    device_put(0x3333333333333333lu, 0x4444444444444444lu);
 }
 
 UCS_TEST_P(test_device, atomic)

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -193,6 +193,7 @@ protected:
         void revoke_ep(unsigned index);
         void destroy_eps();
         void connect(unsigned index, entity& other, unsigned other_index);
+        void connect_p2p_ep(uct_ep_h from, uct_ep_h to);
         void connect_to_iface(unsigned index, entity &other,
                               unsigned path_index = 0);
         void connect_to_ep(unsigned index, entity &other, unsigned other_index,
@@ -225,9 +226,6 @@ protected:
         private:
             async_wrapper(const async_wrapper &);
         };
-
-
-        void connect_p2p_ep(uct_ep_h from, uct_ep_h to);
 
         const resource              m_resource;
         ucs::handle<uct_md_h>       m_md;


### PR DESCRIPTION
What?
Fix wrong qp state when rc_gda reconnect.

Why?
When a rc_gda EP is destroyed and a new one is created, its channels may be reused from the pool with QPs still in a RTS state. 

How?

- Introduce uct_rc_gdaki_channel_reset_qp() to forward QPs' states  → ERR → RESET.
- Introduce uct_rc_gdaki_channel_connect() performs QP reset before connect.
- Add reconnect test.