### PR TITLE
UCT/GGA: Backport fix #11507 to 1.21.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ Yihua Xu <yihua.xu@intel.com>
 Yiltan Hassan Temucin <yiltan.temucin@amd.com>
 Yossi Itigin <yosefe@nvidia.com>
 Yuriy Shestakov <yuriis@mellanox.com>
+Zhenlong Ma <zhenlongm@nvidia.com>
 Zhongkai Zhang <zhzhang@habana.ai>
 Zhu Yanjun <yanjunz@mellanox.com>
 Zihao Zhao <zizhao@nvidia.com>

--- a/buildlib/tools/builds.sh
+++ b/buildlib/tools/builds.sh
@@ -321,6 +321,13 @@ build_no_devx() {
 	build_gcc --with-devx=no
 }
 
+build_no_gga() {
+	echo "==== Build without GGA transport ===="
+	${WORKSPACE}/contrib/configure-devel --prefix=$ucx_inst --without-gga --disable-gtest
+	$MAKEP
+	check_no_gga
+}
+
 build_no_openmp() {
 	build_gcc --disable-openmp
 }
@@ -448,6 +455,13 @@ build_no_gda() {
 	fi
 }
 
+check_no_gga() {
+	if [ -f ${ucx_build_dir}/src/uct/ib/mlx5/gga/.libs/libuct_ib_mlx5_la-gga_mlx5.o ] ; then
+		azure_log_error "build --without-gga created GGA object"
+		exit 1
+	fi
+}
+
 az_init_modules
 prepare_build
 
@@ -470,6 +484,7 @@ then
 			'build_pgi' \
 			'build_gcc' \
 			'build_no_devx' \
+            'build_no_gga' \
 			'build_no_openmp' \
 			'build_gcc_debug_opt' \
 			'build_gcc_with_dndebug' \

--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_TL_DC], [false])
      AM_CONDITIONAL([HAVE_DC_DV], [false])
      AM_CONDITIONAL([HAVE_TL_UD], [false])
+     AM_CONDITIONAL([HAVE_TL_GGA], [false])
      AM_CONDITIONAL([HAVE_CRAY_UGNI], [false])
      AM_CONDITIONAL([HAVE_CUDA], [false])
      AM_CONDITIONAL([HAVE_CUDA_STATIC], [false])

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -57,6 +57,14 @@ AC_ARG_WITH([dc],
             [],
             [with_dc=yes])
 
+#
+# GGA Support
+#
+AC_ARG_WITH([gga],
+            [AS_HELP_STRING([--with-gga], [Compile with GGA DPU transport support])],
+            [],
+            [with_gga=guess])
+
 
 #
 # TM (IB Tag Matching) Support
@@ -205,6 +213,16 @@ AS_IF([test "x$with_ib" = "xyes"],
        AS_IF([test x$with_devx = xyes -a x$have_devx != xyes], [
                AC_MSG_ERROR([devx requested but not found])])
 
+       AS_IF([test "x$with_gga" != xno], [
+               AS_IF([test "x$have_mlx5" = xyes -a "x$has_mlx5_mmo" = xyes -a "x$have_devx" = xyes -a "x$with_rc" != xno],
+                     [have_gga=yes
+                      AC_DEFINE([HAVE_TL_GGA], 1, [GGA transport support])],
+                     [AS_IF([test "x$with_gga" = xyes],
+                            [AC_MSG_ERROR([GGA requested but MLX5, MLX5 MMO, DEVX, or RC support is not available])])
+                      have_gga=no])
+             ],
+             [have_gga=no])
+
        AC_CHECK_DECLS([IBV_LINK_LAYER_INFINIBAND,
                        IBV_LINK_LAYER_ETHERNET,
                        IBV_EVENT_GID_CHANGE,
@@ -335,9 +353,13 @@ AS_IF([test "x$with_ib" = "xyes"],
        uct_modules="${uct_modules}:ib"
     ],
     [
+        AS_IF([test "x$with_gga" = xyes],
+              [AC_MSG_ERROR([GGA requested but IB/verbs support is not available])])
         with_dc=no
         with_rc=no
         with_ud=no
+        with_gga=no
+        have_gga=no
         with_mlx5=no
     ])
 
@@ -351,6 +373,7 @@ AM_CONDITIONAL([HAVE_TL_DC],   [test "x$with_dc" != xno])
 AM_CONDITIONAL([HAVE_DC_DV],   [test -n "$have_dc_dv"])
 AM_CONDITIONAL([HAVE_TL_UD],   [test "x$with_ud" != xno])
 AM_CONDITIONAL([HAVE_DEVX],    [test -n "$have_devx"])
+AM_CONDITIONAL([HAVE_TL_GGA],  [test "x$have_gga" = xyes])
 AM_CONDITIONAL([HAVE_MLX5_HW_UD], [test "x$have_mlx5" = xyes -a "x$has_get_av" != xno])
 AM_CONDITIONAL([HAVE_MLX5_MMO],   [test -n "$has_mlx5_mmo"])
 

--- a/src/uct/ib/mlx5/Makefile.am
+++ b/src/uct/ib/mlx5/Makefile.am
@@ -43,10 +43,10 @@ if HAVE_DEVX
 libuct_ib_mlx5_la_SOURCES += \
 	rc/rc_mlx5_devx.c
 
-if HAVE_MLX5_MMO
+if HAVE_TL_GGA
 libuct_ib_mlx5_la_SOURCES += \
 	gga/gga_mlx5.c
-endif # HAVE_MLX5_MMO
+endif # HAVE_TL_GGA
 endif # HAVE_DEVX
 
 endif # HAVE_TL_RC


### PR DESCRIPTION
## What?
Port changes [#11507](https://github.com/openucx/ucx/pull/11507) to 1.21.x branch to support NIXL. The changes have been approved and merged into the master branch.

## Why?
The motivation of the changes can be seen in [#11507](https://github.com/openucx/ucx/pull/11507).

The changes are to support NIXL, which currently uses version 1.21.x.

## How?

Cherry-picked the merged changes from [#11507](https://github.com/openucx/ucx/pull/11507) onto the `1.21.x` branch.