### PR TITLE
UCP/PROTO: Fix bandwidth formatting macros

### DIFF
--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -27,7 +27,7 @@
 
 
 #define UCP_PROTO_LANE_FMT \
-    "lane[%d] " UCT_TL_RESOURCE_DESC_FMT " bw " UCP_PROTO_PERF_FUNC_BW_FMT \
+    "lane[%d] " UCT_TL_RESOURCE_DESC_FMT UCP_PROTO_BW_FMT(bw) \
     UCP_PROTO_TIME_FMT(latency)
 
 
@@ -36,7 +36,7 @@
     UCT_TL_RESOURCE_DESC_ARG( \
         &(_params)->worker->context->tl_rscs[ \
             ucp_proto_common_get_rsc_index(_params, _lane)].tl_rsc), \
-    (_lane_perf)->bandwidth / UCS_MBYTE, \
+    UCP_PROTO_BW_ARG((_lane_perf)->bandwidth), \
     UCP_PROTO_TIME_ARG((_lane_perf)->latency)
 
 

--- a/src/ucp/proto/proto_debug.h
+++ b/src/ucp/proto/proto_debug.h
@@ -19,6 +19,10 @@
 #define UCP_PROTO_TIME_FMT(_time_var) " " #_time_var ": %.2f ns"
 #define UCP_PROTO_TIME_ARG(_time_val) ((_time_val) * 1e9)
 
+/* Format string to display a protocol bandwidth */
+#define UCP_PROTO_BW_FMT(_bw_var) " " #_bw_var ": %.2f MB/s"
+#define UCP_PROTO_BW_ARG(_bw_val) ((_bw_val) / UCS_MBYTE)
+
 /* Format string to display a protocol performance function time */
 #define UCP_PROTO_PERF_FUNC_TIME_FMT "%.2f+%.3f*N"
 #define UCP_PROTO_PERF_FUNC_TIME_ARG(_perf_func) \

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -49,9 +49,9 @@ ucp_proto_multi_get_avail_bw(const ucp_proto_init_params_t *params,
         ratio = MIN_RATIO / path_index;
     }
 
-    ucs_trace("ratio=%0.3f path_index=%u avail_bw=" UCP_PROTO_PERF_FUNC_BW_FMT
+    ucs_trace("ratio=%0.3f path_index=%u" UCP_PROTO_BW_FMT(avail_bw)
               " " UCP_PROTO_LANE_FMT, ratio, path_index,
-              (lane_perf->bandwidth * ratio) / UCS_MBYTE,
+              UCP_PROTO_BW_ARG(lane_perf->bandwidth * ratio),
               UCP_PROTO_LANE_ARG(params, lane, lane_perf));
     return lane_perf->bandwidth * ratio;
 }


### PR DESCRIPTION
## What?
Add `UCP_PROTO_BW_FMT` and `UCP_PROTO_BW_ARG` macros

## Why?
Some places in the code wrongly used `UCP_PROTO_PERF_FUNC_BW_FMT`.
Also the units were missing and now they are correctly added.