### PR TITLE
AZP/PERF: Quote SourceVersionMessage in SHA extraction

### DIFF
--- a/buildlib/azure-pipelines-perf.yml
+++ b/buildlib/azure-pipelines-perf.yml
@@ -110,8 +110,8 @@ stages:
               echo "PR's merge message: $(Build.SourceVersionMessage)"
               
               # Extract commit SHAs from the PR's merge message.
-              SHA_After=$(echo $(Build.SourceVersionMessage) | awk '{print $2}')
-              SHA_Before=$(echo $(Build.SourceVersionMessage) | awk '{print $4}')
+              SHA_After=$(echo "$(Build.SourceVersionMessage)" | awk '{print $2}')
+              SHA_Before=$(echo "$(Build.SourceVersionMessage)" | awk '{print $4}')
                             
               printf '\n%79s\n\n' | tr ' ' =
               echo "Base SHA from Git log:       $(cd $(WorkDir)/ucx && git rev-parse HEAD^)"

--- a/buildlib/tools/perf-common.yml
+++ b/buildlib/tools/perf-common.yml
@@ -4,8 +4,8 @@ parameters:
 steps:
   - bash: |
       set -eE -o pipefail
-      SHA_After=$(echo $(Build.SourceVersionMessage) | awk '{print $2}')
-      SHA_Before=$(echo $(Build.SourceVersionMessage) | awk '{print $4}')
+      SHA_After=$(echo "$(Build.SourceVersionMessage)" | awk '{print $2}')
+      SHA_Before=$(echo "$(Build.SourceVersionMessage)" | awk '{print $4}')
 
       module=""
       perfxParams=""


### PR DESCRIPTION
## What?
Quote the `$(Build.SourceVersionMessage)` macro where the perf pipeline word-slices it for the before/after SHAs.

## Why?
Expanded unquoted inside a command substitution, a commit subject with parentheses (e.g. a `(#11507)` PR suffix) makes an unbalanced `(` and bash aborts with `unexpected EOF while looking for matching ')'`, failing the perf job.

## How?
Wrap the macro in double quotes so the text stays literal. Behaviour is otherwise unchanged.