### PR TITLE
CI: Add PR title validation workflow

### DIFF
--- a/.agents/skills/ucx-development/SKILL.md
+++ b/.agents/skills/ucx-development/SKILL.md
@@ -32,6 +32,10 @@ Before editing or judging code:
 6. Report the build/test commands used and any hardware, optional dependency,
    or coverage gaps.
 
+## Pull Requests
+
+PR and commit titles should match `^[0-9A-Z/_-]*: \w`.
+
 ## Build
 
 The two main helpers are `configure-devel` and `configure-release`: pick `configure-devel` for failure investigation, debug-oriented and feature work (logging, assertions, gtest, and valgrind enabled), `configure-release` for performance work (those checks disabled and optimized for speed).

--- a/.agents/skills/ucx-development/SKILL.md
+++ b/.agents/skills/ucx-development/SKILL.md
@@ -34,7 +34,9 @@ Before editing or judging code:
 
 ## Pull Requests
 
-PR and commit titles should match `^[0-9A-Z/_-]*: \w`.
+PR and commit titles should match `^[0-9A-Z/_-]+: \w`: The title should start
+with module path, followed by a semicolon, and an imperative description of
+the change. For example: "UCP/WIREUP: consider NUMA locality for lane selection".
 
 ## Build
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          if ! grep -qP '^[0-9A-Z/_-]*: \w' <<<"${PR_TITLE}"; then
+            echo "Bad PR title: '${PR_TITLE}'" >&2
+            exit 1
+          fi

--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -12,6 +12,7 @@ pr:
     - .agents
     - .ci
     - .claude/skills
+    - .github
     - .gitignore
     - .readthedocs.yaml
     - AGENTS.md


### PR DESCRIPTION
## What?
Add a GitHub Actions workflow that validates pull request titles when a PR is opened or edited.

## Why?
The squash-and-merge flow depends on a clean PR title, while commit validation is already handled by AZP.

## How?
Run a title-only pull_request_target check and document the same title regex in the UCX development skill.
