### PR TITLE
UCT/IB: Limit EMR relaxed ordering to device memory

### DIFF
--- a/src/tools/perf/cuda/cuda_alloc.c
+++ b/src/tools/perf/cuda/cuda_alloc.c
@@ -76,6 +76,7 @@ uct_perf_cuda_alloc_reg_mem(const ucx_perf_context_t *perf,
                             uct_allocated_memory_t *alloc_mem)
 {
     uct_md_attr_v2_t md_attr = {.field_mask = UCT_MD_ATTR_FIELD_REG_ALIGNMENT};
+    uct_md_mem_reg_params_t reg_params;
     size_t reg_length;
     void *reg_address;
     ucs_status_t status;
@@ -96,8 +97,13 @@ uct_perf_cuda_alloc_reg_mem(const ucx_perf_context_t *perf,
     reg_length  = length;
     ucs_align_ptr_range(&reg_address, &reg_length, md_attr.reg_alignment);
 
-    status = uct_md_mem_reg(perf->uct.md, reg_address, reg_length, flags,
-                            &alloc_mem->memh);
+    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
+                            UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+    reg_params.flags      = flags;
+    reg_params.mem_type   = mem_type;
+
+    status = uct_md_mem_reg_v2(perf->uct.md, reg_address, reg_length,
+                               &reg_params, &alloc_mem->memh);
     if (status != UCS_OK) {
         cudaFree(alloc_mem->address);
         ucs_error("failed to register memory");

--- a/src/tools/perf/cuda/cuda_alloc.c
+++ b/src/tools/perf/cuda/cuda_alloc.c
@@ -14,7 +14,6 @@
 #include <cuda_runtime.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/ptr_arith.h>
-#include <uct/api/v2/uct_v2.h>
 
 
 static ucs_status_t ucx_perf_cuda_init(ucx_perf_context_t *perf)
@@ -76,7 +75,6 @@ uct_perf_cuda_alloc_reg_mem(const ucx_perf_context_t *perf,
                             uct_allocated_memory_t *alloc_mem)
 {
     uct_md_attr_v2_t md_attr = {.field_mask = UCT_MD_ATTR_FIELD_REG_ALIGNMENT};
-    uct_md_mem_reg_params_t reg_params;
     size_t reg_length;
     void *reg_address;
     ucs_status_t status;
@@ -97,13 +95,8 @@ uct_perf_cuda_alloc_reg_mem(const ucx_perf_context_t *perf,
     reg_length  = length;
     ucs_align_ptr_range(&reg_address, &reg_length, md_attr.reg_alignment);
 
-    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
-                            UCT_MD_MEM_REG_FIELD_MEM_TYPE;
-    reg_params.flags      = flags;
-    reg_params.mem_type   = mem_type;
-
-    status = uct_md_mem_reg_v2(perf->uct.md, reg_address, reg_length,
-                               &reg_params, &alloc_mem->memh);
+    status = uct_perf_md_mem_reg(perf->uct.md, reg_address, reg_length, flags,
+                                 mem_type, &alloc_mem->memh);
     if (status != UCS_OK) {
         cudaFree(alloc_mem->address);
         ucs_error("failed to register memory");

--- a/src/tools/perf/lib/libperf_int.h
+++ b/src/tools/perf/lib/libperf_int.h
@@ -10,6 +10,7 @@
 #define LIBPERF_INT_H_
 
 #include <tools/perf/api/libperf.h>
+#include <uct/api/v2/uct_v2.h>
 
 
 #if _OPENMP
@@ -190,6 +191,21 @@ void ucp_perf_barrier(ucx_perf_context_t *perf);
 ucs_status_t ucp_perf_test_alloc_mem(ucx_perf_context_t *perf);
 void ucp_perf_test_free_mem(ucx_perf_context_t *perf);
 ucs_status_t uct_perf_test_alloc_mem(ucx_perf_context_t *perf);
+
+static inline ucs_status_t
+uct_perf_md_mem_reg(uct_md_h md, void *address, size_t length, unsigned flags,
+                    ucs_memory_type_t mem_type, uct_mem_h *memh_p)
+{
+    uct_md_mem_reg_params_t params;
+
+    params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
+                        UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+    params.flags      = flags;
+    params.mem_type   = mem_type;
+
+    return uct_md_mem_reg_v2(md, address, length, &params, memh_p);
+}
+
 void uct_perf_test_free_mem(ucx_perf_context_t *perf);
 ucs_status_t ucx_perf_thread_spawn(ucx_perf_context_t *perf,
                                    ucx_perf_result_t* result);

--- a/src/tools/perf/rocm/rocm_alloc.c
+++ b/src/tools/perf/rocm/rocm_alloc.c
@@ -12,7 +12,6 @@
 #include <tools/perf/lib/libperf_int.h>
 
 #include <hip/hip_runtime.h>
-#include <uct/api/v2/uct_v2.h>
 #include <ucs/sys/compiler.h>
 
 
@@ -67,7 +66,6 @@ uct_perf_rocm_alloc_reg_mem(const ucx_perf_context_t *perf,
                             unsigned flags,
                             uct_allocated_memory_t *alloc_mem)
 {
-    uct_md_mem_reg_params_t reg_params;
     ucs_status_t status;
 
     status = ucx_perf_rocm_alloc(length, mem_type, &alloc_mem->address);
@@ -75,13 +73,8 @@ uct_perf_rocm_alloc_reg_mem(const ucx_perf_context_t *perf,
         return status;
     }
 
-    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
-                            UCT_MD_MEM_REG_FIELD_MEM_TYPE;
-    reg_params.flags      = flags;
-    reg_params.mem_type   = mem_type;
-
-    status = uct_md_mem_reg_v2(perf->uct.md, alloc_mem->address, length,
-                               &reg_params, &alloc_mem->memh);
+    status = uct_perf_md_mem_reg(perf->uct.md, alloc_mem->address, length,
+                                 flags, mem_type, &alloc_mem->memh);
     if (status != UCS_OK) {
         hipFree(alloc_mem->address);
         ucs_error("failed to register memory");

--- a/src/tools/perf/rocm/rocm_alloc.c
+++ b/src/tools/perf/rocm/rocm_alloc.c
@@ -12,6 +12,7 @@
 #include <tools/perf/lib/libperf_int.h>
 
 #include <hip/hip_runtime.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/sys/compiler.h>
 
 
@@ -66,6 +67,7 @@ uct_perf_rocm_alloc_reg_mem(const ucx_perf_context_t *perf,
                             unsigned flags,
                             uct_allocated_memory_t *alloc_mem)
 {
+    uct_md_mem_reg_params_t reg_params;
     ucs_status_t status;
 
     status = ucx_perf_rocm_alloc(length, mem_type, &alloc_mem->address);
@@ -73,8 +75,13 @@ uct_perf_rocm_alloc_reg_mem(const ucx_perf_context_t *perf,
         return status;
     }
 
-    status = uct_md_mem_reg(perf->uct.md, alloc_mem->address,
-                            length, flags, &alloc_mem->memh);
+    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
+                            UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+    reg_params.flags      = flags;
+    reg_params.mem_type   = mem_type;
+
+    status = uct_md_mem_reg_v2(perf->uct.md, alloc_mem->address, length,
+                               &reg_params, &alloc_mem->memh);
     if (status != UCS_OK) {
         hipFree(alloc_mem->address);
         ucs_error("failed to register memory");

--- a/src/tools/perf/ze/ze_alloc.c
+++ b/src/tools/perf/ze/ze_alloc.c
@@ -9,6 +9,7 @@
 
 #include <tools/perf/lib/libperf_int.h>
 
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>
 #include <uct/ze/base/ze_base.h>
@@ -179,6 +180,7 @@ uct_perf_ze_alloc_reg_mem(const ucx_perf_context_t *perf, size_t length,
                           ucs_memory_type_t mem_type, unsigned flags,
                           uct_allocated_memory_t *alloc_mem)
 {
+    uct_md_mem_reg_params_t reg_params;
     ucs_status_t status;
 
     status = ucx_perf_ze_alloc(length, mem_type, &alloc_mem->address);
@@ -186,8 +188,13 @@ uct_perf_ze_alloc_reg_mem(const ucx_perf_context_t *perf, size_t length,
         return status;
     }
 
-    status = uct_md_mem_reg(perf->uct.md, alloc_mem->address, length, flags,
-                            &alloc_mem->memh);
+    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
+                            UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+    reg_params.flags      = flags;
+    reg_params.mem_type   = mem_type;
+
+    status = uct_md_mem_reg_v2(perf->uct.md, alloc_mem->address, length,
+                               &reg_params, &alloc_mem->memh);
     if (status != UCS_OK) {
         ucs_error("failed to register memory");
         zeMemFree(gpu_context, alloc_mem->address);

--- a/src/tools/perf/ze/ze_alloc.c
+++ b/src/tools/perf/ze/ze_alloc.c
@@ -9,7 +9,6 @@
 
 #include <tools/perf/lib/libperf_int.h>
 
-#include <uct/api/v2/uct_v2.h>
 #include <ucs/sys/compiler.h>
 #include <ucs/sys/sys.h>
 #include <uct/ze/base/ze_base.h>
@@ -180,7 +179,6 @@ uct_perf_ze_alloc_reg_mem(const ucx_perf_context_t *perf, size_t length,
                           ucs_memory_type_t mem_type, unsigned flags,
                           uct_allocated_memory_t *alloc_mem)
 {
-    uct_md_mem_reg_params_t reg_params;
     ucs_status_t status;
 
     status = ucx_perf_ze_alloc(length, mem_type, &alloc_mem->address);
@@ -188,13 +186,8 @@ uct_perf_ze_alloc_reg_mem(const ucx_perf_context_t *perf, size_t length,
         return status;
     }
 
-    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
-                            UCT_MD_MEM_REG_FIELD_MEM_TYPE;
-    reg_params.flags      = flags;
-    reg_params.mem_type   = mem_type;
-
-    status = uct_md_mem_reg_v2(perf->uct.md, alloc_mem->address, length,
-                               &reg_params, &alloc_mem->memh);
+    status = uct_perf_md_mem_reg(perf->uct.md, alloc_mem->address, length,
+                                 flags, mem_type, &alloc_mem->memh);
     if (status != UCS_OK) {
         ucs_error("failed to register memory");
         zeMemFree(gpu_context, alloc_mem->address);

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -97,6 +97,7 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
     ucs_status_t status;
     ucs_log_level_t level;
     ucs_memory_info_t mem_info;
+    uct_md_mem_reg_params_t reg_params;
     size_t reg_length;
     void *base_address;
 
@@ -191,8 +192,16 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             }
 
             /* MD supports registration, register new memh on it */
-            status = uct_md_mem_reg(context->tl_mds[md_index].md, base_address,
-                                    reg_length, uct_flags, &uct_memh[memh_index]);
+            reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+            reg_params.flags      = uct_flags;
+            if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
+                reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+                reg_params.mem_type    = mem_type;
+            }
+
+            status = uct_md_mem_reg_v2(context->tl_mds[md_index].md,
+                                       base_address, reg_length, &reg_params,
+                                       &uct_memh[memh_index]);
             if (status == UCS_OK) {
                 ucs_trace("registered address %p length %zu on md[%d]"
                           " memh[%d]=%p",
@@ -635,6 +644,11 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                     context->reg_block_md_map[mem_type]);
 
         reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+        if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
+            reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+            reg_params.mem_type    = mem_type;
+        }
+
         if (dmabuf_md_map & UCS_BIT(md_index)) {
             /* If this MD can consume a dmabuf and we have it - provide it */
             reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_DMABUF_FD |
@@ -1275,6 +1289,7 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
     ucp_context_h context            = worker->context;
     const uct_md_attr_v2_t *md_attr  = &context->tl_mds[md_index].attr;
     uct_md_mkey_pack_params_t params = { .field_mask = 0 };
+    uct_md_mem_reg_params_t reg_params;
     uct_component_h cmpt;
     ucp_tl_md_t *tl_md;
     ucs_status_t status;
@@ -1290,9 +1305,16 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
     tl_md  = &context->tl_mds[md_index];
     cmpt   = context->tl_cmpts[tl_md->cmpt_index].cmpt;
     if (!(context->cache_md_map[mem_type] & UCS_BIT(md_index))) {
-        status = uct_md_mem_reg(context->tl_mds[md_index].md, remote_addr,
-                                length, UCT_MD_MEM_ACCESS_ALL,
-                                &pack_context->uct_memh);
+        reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+        reg_params.flags      = UCT_MD_MEM_ACCESS_ALL;
+        if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
+            reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+            reg_params.mem_type    = mem_type;
+        }
+
+        status = uct_md_mem_reg_v2(context->tl_mds[md_index].md, remote_addr,
+                                   length, &reg_params,
+                                   &pack_context->uct_memh);
         if (status != UCS_OK) {
             return status;
         }

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -146,6 +146,13 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
     /* prev_uct_memh should contain the handles which should be reused */
     ucs_assert(prev_memh_index == prev_num_memh);
 
+    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+    reg_params.flags      = uct_flags;
+    if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
+        reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+        reg_params.mem_type    = mem_type;
+    }
+
     /* Go over requested MD map, and use / register new handles */
     new_md_map      = 0;
     memh_index      = 0;
@@ -192,13 +199,6 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
             }
 
             /* MD supports registration, register new memh on it */
-            reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
-            reg_params.flags      = uct_flags;
-            if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
-                reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
-                reg_params.mem_type    = mem_type;
-            }
-
             status = uct_md_mem_reg_v2(context->tl_mds[md_index].md,
                                        base_address, reg_length, &reg_params,
                                        &uct_memh[memh_index]);
@@ -568,6 +568,7 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
     ucp_md_map_t dmabuf_md_map          = 0;
     ucp_md_map_t reg_md_map;
     uct_md_mem_reg_params_t reg_params;
+    uct_md_mem_reg_params_t md_reg_params;
     uct_md_mem_attr_t mem_attr;
     ucp_md_index_t md_index;
     ucs_status_t status;
@@ -594,9 +595,14 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
     }
 
     /* When adding registrations, existing access flags must be supported */
+    reg_params.field_mask    = UCT_MD_MEM_REG_FIELD_FLAGS;
     reg_params.flags         = uct_flags | memh->uct_flags;
     reg_params.dmabuf_fd     = UCT_DMABUF_FD_INVALID;
     reg_params.dmabuf_offset = 0;
+    if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
+        reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+        reg_params.mem_type    = mem_type;
+    }
 
     if ((dmabuf_prov_md_index != UCP_NULL_RESOURCE) &&
         (reg_md_map & context->dmabuf_reg_md_map)) {
@@ -643,16 +649,13 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                     context->reg_md_map[mem_type],
                     context->reg_block_md_map[mem_type]);
 
-        reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
-        if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
-            reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
-            reg_params.mem_type    = mem_type;
-        }
-
+        md_reg_params = reg_params;
         if (dmabuf_md_map & UCS_BIT(md_index)) {
             /* If this MD can consume a dmabuf and we have it - provide it */
-            reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_DMABUF_FD |
-                                     UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET;
+            md_reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_DMABUF_FD |
+                                        UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET;
+        } else {
+            md_reg_params.dmabuf_fd = UCT_DMABUF_FD_INVALID;
         }
 
         reg_address = address;
@@ -664,11 +667,12 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
         }
 
         status = uct_md_mem_reg_v2(context->tl_mds[md_index].md, reg_address,
-                                   reg_length, &reg_params, &memh->uct[md_index]);
+                                   reg_length, &md_reg_params,
+                                   &memh->uct[md_index]);
         if (ucs_unlikely(status != UCS_OK)) {
             ucp_memh_register_log_fail(err_level, reg_address, reg_length,
-                                       mem_type, reg_params.dmabuf_fd, md_index,
-                                       context, status);
+                                       mem_type, md_reg_params.dmabuf_fd,
+                                       md_index, context, status);
             if (allow_partial_reg &&
                 (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS)) {
                 continue;
@@ -680,10 +684,8 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
 
         ucs_trace("register address %p length %zu dmabuf-fd %d flags %ld "
                   "on md[%d]=%s %p",
-                  reg_address, reg_length,
-                  (dmabuf_md_map & UCS_BIT(md_index)) ? reg_params.dmabuf_fd :
-                                                        UCT_DMABUF_FD_INVALID,
-                  reg_params.flags,
+                  reg_address, reg_length, md_reg_params.dmabuf_fd,
+                  md_reg_params.flags,
                   md_index, context->tl_mds[md_index].rsc.md_name,
                   memh->uct[md_index]);
         md_map_registered |= UCS_BIT(md_index);

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -172,6 +172,7 @@ static inline int ucs_cpu_model_prefer_relaxed_order(
              (cpu_model == UCS_CPU_MODEL_AMD_TURIN)));
 }
 
+
 #define UCS_CPU_VENDOR_LABEL "CPU vendor"
 #define UCS_CPU_MODEL_LABEL  "CPU model"
 

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -161,19 +161,21 @@ static inline void ucs_clear_cache(void *start, void *end)
 }
 
 
-static inline int ucs_cpu_prefer_relaxed_order()
+static inline int ucs_cpu_model_prefer_relaxed_order(
+        ucs_cpu_vendor_t cpu_vendor, ucs_cpu_model_t cpu_model)
 {
-    ucs_cpu_vendor_t cpu_vendor = ucs_arch_get_cpu_vendor();
-    ucs_cpu_model_t cpu_model   = ucs_arch_get_cpu_model();
-
     return ((cpu_vendor == UCS_CPU_VENDOR_AMD) &&
             ((cpu_model == UCS_CPU_MODEL_AMD_NAPLES) ||
              (cpu_model == UCS_CPU_MODEL_AMD_ROME) ||
              (cpu_model == UCS_CPU_MODEL_AMD_MILAN) ||
              (cpu_model == UCS_CPU_MODEL_AMD_GENOA) ||
-             (cpu_model == UCS_CPU_MODEL_AMD_TURIN))) ||
-           ((cpu_vendor == UCS_CPU_VENDOR_INTEL) &&
-            (cpu_model == UCS_CPU_MODEL_INTEL_EMERALD_RAPIDS));
+             (cpu_model == UCS_CPU_MODEL_AMD_TURIN)));
+}
+
+static inline int ucs_cpu_prefer_relaxed_order()
+{
+    return ucs_cpu_model_prefer_relaxed_order(ucs_arch_get_cpu_vendor(),
+                                              ucs_arch_get_cpu_model());
 }
 
 

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -172,13 +172,6 @@ static inline int ucs_cpu_model_prefer_relaxed_order(
              (cpu_model == UCS_CPU_MODEL_AMD_TURIN)));
 }
 
-static inline int ucs_cpu_prefer_relaxed_order()
-{
-    return ucs_cpu_model_prefer_relaxed_order(ucs_arch_get_cpu_vendor(),
-                                              ucs_arch_get_cpu_model());
-}
-
-
 #define UCS_CPU_VENDOR_LABEL "CPU vendor"
 #define UCS_CPU_MODEL_LABEL  "CPU model"
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -226,7 +226,8 @@ typedef struct {
 typedef enum {
     UCT_MD_MEM_REG_FIELD_FLAGS         = UCS_BIT(0),
     UCT_MD_MEM_REG_FIELD_DMABUF_FD     = UCS_BIT(1),
-    UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET = UCS_BIT(2)
+    UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET = UCS_BIT(2),
+    UCT_MD_MEM_REG_FIELD_MEM_TYPE      = UCS_BIT(3)
 } uct_md_mem_reg_field_mask_t;
 
 
@@ -491,6 +492,13 @@ typedef struct uct_md_mem_reg_params {
      * dmabuf region, then this field must be omitted or set to 0.
      */
     size_t                       dmabuf_offset;
+
+    /**
+     * Memory type of the region to register.
+     *
+     * If not set, it's assumed to be @ref UCS_MEMORY_TYPE_HOST.
+     */
+    ucs_memory_type_t            mem_type;
 } uct_md_mem_reg_params_t;
 
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -666,14 +666,12 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
                                   uct_mem_h *memh_p)
 {
     uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    int relaxed_order = uct_ib_memh_is_relaxed_order(md, params);
     struct ibv_mr *mr_default;
     uct_ib_verbs_mem_t *memh;
     uct_ib_mem_t *ib_memh;
     uint64_t access_flags;
     ucs_status_t status;
-    int relaxed_order;
-
-    relaxed_order = uct_ib_memh_is_relaxed_order(md, params);
 
     status = uct_ib_memh_alloc(md, length,
                                UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
@@ -1201,6 +1199,22 @@ out:
     return status;
 }
 
+static void uct_ib_md_log_relaxed_order(uct_ib_md_t *md)
+{
+    UCS_STRING_BUFFER_ONSTACK(strb, 128);
+
+    if (!md->relaxed_order) {
+        ucs_debug("%s: relaxed order memory access is disabled",
+                  uct_ib_device_name(&md->dev));
+        return;
+    }
+
+    ucs_string_buffer_append_flags(&strb, md->relaxed_order_mem_types,
+                                   ucs_memory_type_names);
+    ucs_debug("%s: relaxed order memory access is enabled for %s",
+              uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb));
+}
+
 void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                    const uct_ib_md_config_t *md_config,
                                    int is_supported)
@@ -1227,28 +1241,9 @@ void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                     0;
     }
 
-    if (mem_types & UCS_MEMORY_TYPES_CPU_ACCESSIBLE) {
-        md->relaxed_order_mem_types = mem_types;
-    } else {
-        md->relaxed_order_auto_mem_types = mem_types;
-    }
-
-    md->relaxed_order = mem_types != 0;
-
-    if ((md->relaxed_order_mem_types != 0) ||
-        (md->relaxed_order_auto_mem_types != 0)) {
-        UCS_STRING_BUFFER_ONSTACK(strb, 128);
-
-        ucs_string_buffer_append_flags(&strb,
-                                       md->relaxed_order_mem_types |
-                                       md->relaxed_order_auto_mem_types,
-                                       ucs_memory_type_names);
-        ucs_debug("%s: relaxed order memory access is enabled for %s",
-                  uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb));
-    } else {
-        ucs_debug("%s: relaxed order memory access is disabled",
-                  uct_ib_device_name(&md->dev));
-    }
+    md->relaxed_order_mem_types = mem_types;
+    md->relaxed_order           = (mem_types != 0);
+    uct_ib_md_log_relaxed_order(md);
 }
 
 void uct_ib_check_gpudirect_driver(uct_ib_md_t *md, const char *file,
@@ -1335,10 +1330,9 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_NEED_MEMH |
                           UCT_MD_FLAG_NEED_RKEY |
                           UCT_MD_FLAG_ADVISE;
-    md->reg_cost                     = md_config->reg_cost;
-    md->relaxed_order                = 0;
-    md->relaxed_order_mem_types      = 0;
-    md->relaxed_order_auto_mem_types = 0;
+    md->reg_cost                = md_config->reg_cost;
+    md->relaxed_order           = 0;
+    md->relaxed_order_mem_types = 0;
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1209,10 +1209,6 @@ void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
     uint64_t all_mem_types = UCS_MASK(UCS_MEMORY_TYPE_LAST);
     uint64_t mem_types     = 0;
 
-    md->relaxed_order                = 0;
-    md->relaxed_order_mem_types      = 0;
-    md->relaxed_order_auto_mem_types = 0;
-
     if (md_config->mr_relaxed_order == UCS_YES) {
         if (have_relaxed_order) {
             mem_types = all_mem_types;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -601,10 +601,11 @@ ucs_status_t uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
 }
 
 ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
-                               unsigned mem_flags, size_t memh_base_size,
-                               size_t mr_size, uct_ib_mem_t **memh_p)
+                               unsigned mem_flags, int relaxed_order,
+                               size_t memh_base_size, size_t mr_size,
+                               uct_ib_mem_t **memh_p)
 {
-    int num_mrs = md->relaxed_order ?
+    int num_mrs = relaxed_order ?
                           2 /* UCT_IB_MR_DEFAULT and UCT_IB_MR_STRICT_ORDER */ :
                           1 /* UCT_IB_MR_DEFAULT */;
     uct_ib_mem_t *memh;
@@ -638,6 +639,10 @@ ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
         memh->flags |= UCT_IB_MEM_FLAG_GVA;
     }
 
+    if (relaxed_order) {
+        memh->flags |= UCT_IB_MEM_RELAXED_ORDER;
+    }
+
     *memh_p = memh;
     return UCS_OK;
 }
@@ -666,17 +671,21 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
     uct_ib_mem_t *ib_memh;
     uint64_t access_flags;
     ucs_status_t status;
+    int relaxed_order;
+
+    relaxed_order = uct_ib_memh_is_relaxed_order(md, params);
 
     status = uct_ib_memh_alloc(md, length,
                                UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
                                                           FIELD_FLAGS, 0),
-                               sizeof(*memh), sizeof(memh->mrs[0]), &ib_memh);
+                               relaxed_order, sizeof(*memh),
+                               sizeof(memh->mrs[0]), &ib_memh);
     if (status != UCS_OK) {
         goto err;
     }
 
     memh         = ucs_derived_of(ib_memh, uct_ib_verbs_mem_t);
-    access_flags = uct_ib_memh_access_flags(&memh->super, md->relaxed_order,
+    access_flags = uct_ib_memh_access_flags(&memh->super, relaxed_order,
                                             md->dev.mr_access_flags);
 
     status = uct_ib_reg_mr(md, address, length, params, access_flags, NULL,
@@ -689,7 +698,7 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
     memh->super.rkey                = mr_default->rkey;
     memh->mrs[UCT_IB_MR_DEFAULT].ib = mr_default;
 
-    if (md->relaxed_order) {
+    if (relaxed_order) {
         status = uct_ib_reg_mr(md, address, length, params,
                                access_flags & ~IBV_ACCESS_RELAXED_ORDERING,
                                NULL, &memh->mrs[UCT_IB_MR_STRICT_ORDER].ib);
@@ -716,7 +725,6 @@ err:
 ucs_status_t
 uct_ib_verbs_mem_dereg(uct_md_h uct_md, const uct_md_mem_dereg_params_t *params)
 {
-    uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
     uct_ib_verbs_mem_t *memh;
     ucs_status_t status;
 
@@ -724,7 +732,7 @@ uct_ib_verbs_mem_dereg(uct_md_h uct_md, const uct_md_mem_dereg_params_t *params)
 
     memh = params->memh;
 
-    if (md->relaxed_order) {
+    if (memh->super.flags & UCT_IB_MEM_RELAXED_ORDER) {
         status = uct_ib_dereg_mr(memh->mrs[UCT_IB_MR_STRICT_ORDER].ib);
         if (status != UCS_OK) {
             return status;
@@ -745,9 +753,9 @@ ucs_status_t uct_ib_verbs_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
                                     const uct_md_mkey_pack_params_t *params,
                                     void *mkey_buffer)
 {
-    uct_ib_md_t *md                 = ucs_derived_of(uct_md, uct_ib_md_t);
     uct_ib_verbs_mem_t *memh        = uct_memh;
-    uct_ib_mr_type_t atomic_mr_type = uct_ib_md_get_atomic_mr_type(md);
+    uct_ib_mr_type_t atomic_mr_type = uct_ib_memh_get_atomic_mr_type(
+                                              &memh->super);
     unsigned flags;
 
     flags = UCS_PARAM_VALUE(UCT_MD_MKEY_PACK_FIELD, params, flags, FLAGS, 0);
@@ -1198,10 +1206,16 @@ void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                    int is_supported)
 {
     int have_relaxed_order = (IBV_ACCESS_RELAXED_ORDERING != 0) && is_supported;
+    uint64_t all_mem_types = UCS_MASK(UCS_MEMORY_TYPE_LAST);
+    uint64_t mem_types     = 0;
+
+    md->relaxed_order                = 0;
+    md->relaxed_order_mem_types      = 0;
+    md->relaxed_order_auto_mem_types = 0;
 
     if (md_config->mr_relaxed_order == UCS_YES) {
         if (have_relaxed_order) {
-            md->relaxed_order = 1;
+            mem_types = all_mem_types;
         } else {
             ucs_warn("%s: relaxed order memory access requested, but "
                      "unsupported",
@@ -1209,14 +1223,36 @@ void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
             return;
         }
     } else if (md_config->mr_relaxed_order == UCS_TRY) {
-        md->relaxed_order = have_relaxed_order;
+        mem_types = have_relaxed_order ? all_mem_types : 0;
     } else if (md_config->mr_relaxed_order == UCS_AUTO) {
-        md->relaxed_order = have_relaxed_order &&
-                            ucs_cpu_prefer_relaxed_order();
+        mem_types = have_relaxed_order ?
+                    uct_ib_md_relaxed_order_auto_mem_types(
+                            ucs_arch_get_cpu_vendor(), ucs_arch_get_cpu_model()) :
+                    0;
     }
 
-    ucs_debug("%s: relaxed order memory access is %sabled",
-              uct_ib_device_name(&md->dev), md->relaxed_order ? "en" : "dis");
+    if (mem_types & UCS_MEMORY_TYPES_CPU_ACCESSIBLE) {
+        md->relaxed_order_mem_types = mem_types;
+    } else {
+        md->relaxed_order_auto_mem_types = mem_types;
+    }
+
+    md->relaxed_order = mem_types != 0;
+
+    if ((md->relaxed_order_mem_types != 0) ||
+        (md->relaxed_order_auto_mem_types != 0)) {
+        UCS_STRING_BUFFER_ONSTACK(strb, 128);
+
+        ucs_string_buffer_append_flags(&strb,
+                                       md->relaxed_order_mem_types |
+                                       md->relaxed_order_auto_mem_types,
+                                       ucs_memory_type_names);
+        ucs_debug("%s: relaxed order memory access is enabled for %s",
+                  uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb));
+    } else {
+        ucs_debug("%s: relaxed order memory access is disabled",
+                  uct_ib_device_name(&md->dev));
+    }
 }
 
 void uct_ib_check_gpudirect_driver(uct_ib_md_t *md, const char *file,
@@ -1303,8 +1339,10 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_NEED_MEMH |
                           UCT_MD_FLAG_NEED_RKEY |
                           UCT_MD_FLAG_ADVISE;
-    md->reg_cost        = md_config->reg_cost;
-    md->relaxed_order   = 0;
+    md->reg_cost                     = md_config->reg_cost;
+    md->relaxed_order                = 0;
+    md->relaxed_order_mem_types      = 0;
+    md->relaxed_order_auto_mem_types = 0;
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -666,7 +666,7 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
                                   const uct_md_mem_reg_params_t *params,
                                   uct_mem_h *memh_p)
 {
-    uct_ib_md_t *md = ucs_derived_of(uct_md, uct_ib_md_t);
+    uct_ib_md_t *md   = ucs_derived_of(uct_md, uct_ib_md_t);
     int relaxed_order = uct_ib_memh_is_relaxed_order(md, params);
     struct ibv_mr *mr_default;
     uct_ib_verbs_mem_t *memh;
@@ -1220,7 +1220,7 @@ static void uct_ib_md_log_relaxed_order(uct_ib_md_t *md)
 {
     UCS_STRING_BUFFER_ONSTACK(strb, 128);
 
-    if (!md->relaxed_order) {
+    if (!uct_ib_md_is_relaxed_order(md)) {
         ucs_debug("%s: relaxed order memory access is disabled",
                   uct_ib_device_name(&md->dev));
         return;
@@ -1259,7 +1259,6 @@ void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
     }
 
     md->relaxed_order_mem_types = mem_types;
-    md->relaxed_order           = (mem_types != 0);
     uct_ib_md_log_relaxed_order(md);
 }
 
@@ -1348,7 +1347,6 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_NEED_RKEY |
                           UCT_MD_FLAG_ADVISE;
     md->reg_cost                = md_config->reg_cost;
-    md->relaxed_order           = 0;
     md->relaxed_order_mem_types = 0;
 
     /* Create statistics */

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -12,6 +12,8 @@
 #include "ib_device.h"
 
 #include <uct/base/uct_md.h>
+#include <ucs/arch/cpu.h>
+#include <ucs/memory/memory_type.h>
 #include <ucs/stats/stats.h>
 
 #define UCT_IB_MD_MAX_MR_SIZE        0x80000000UL
@@ -75,6 +77,8 @@ enum {
                                                         GVA region */
     UCT_IB_MEM_DIRECT_NIC            = UCS_BIT(6), /**< The memory handle was
                                                         registered using Direct NIC */
+    UCT_IB_MEM_RELAXED_ORDER         = UCS_BIT(7), /**< Relaxed ordering is enabled
+                                                        for this memory handle */
 };
 
 enum {
@@ -160,6 +164,8 @@ typedef struct uct_ib_md {
     uint64_t                 subnet_filter;
     double                   pci_bw;
     int                      relaxed_order;
+    uint64_t                 relaxed_order_mem_types;
+    uint64_t                 relaxed_order_auto_mem_types;
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;
@@ -325,9 +331,50 @@ static inline uint16_t uct_ib_md_atomic_offset(uint8_t atomic_mr_id)
 
 
 static UCS_F_ALWAYS_INLINE uct_ib_mr_type_t
-uct_ib_md_get_atomic_mr_type(uct_ib_md_t *md)
+uct_ib_memh_get_atomic_mr_type(const uct_ib_mem_t *memh)
 {
-    return md->relaxed_order ? UCT_IB_MR_STRICT_ORDER : UCT_IB_MR_DEFAULT;
+    return (memh->flags & UCT_IB_MEM_RELAXED_ORDER) ?
+           UCT_IB_MR_STRICT_ORDER : UCT_IB_MR_DEFAULT;
+}
+
+static UCS_F_ALWAYS_INLINE uint64_t
+uct_ib_md_relaxed_order_auto_mem_types(ucs_cpu_vendor_t cpu_vendor,
+                                       ucs_cpu_model_t cpu_model)
+{
+    if (ucs_cpu_model_prefer_relaxed_order(cpu_vendor, cpu_model)) {
+        return UCS_MASK(UCS_MEMORY_TYPE_LAST);
+    }
+
+    if ((cpu_vendor == UCS_CPU_VENDOR_INTEL) &&
+        (cpu_model == UCS_CPU_MODEL_INTEL_EMERALD_RAPIDS)) {
+        return UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+               UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+    }
+
+    return 0;
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
+                             const uct_md_mem_reg_params_t *params)
+{
+    ucs_memory_type_t mem_type;
+
+    mem_type = UCT_MD_MEM_REG_FIELD_VALUE(params, mem_type, FIELD_MEM_TYPE,
+                                          UCS_MEMORY_TYPE_HOST);
+    if (mem_type >= UCS_MEMORY_TYPE_LAST) {
+        return 0;
+    }
+
+    if (md->relaxed_order_mem_types != 0) {
+        return !!(md->relaxed_order_mem_types & UCS_BIT(mem_type));
+    }
+
+    if (UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE) {
+        return 0;
+    }
+
+    return !!(md->relaxed_order_auto_mem_types & UCS_BIT(mem_type));
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t uct_ib_memh_get_lkey(uct_mem_h memh)
@@ -439,8 +486,9 @@ ucs_status_t uct_ib_fork_init(const uct_ib_md_config_t *md_config,
                               int *fork_init_p);
 
 ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
-                               unsigned mem_flags, size_t memh_base_size,
-                               size_t mr_size, uct_ib_mem_t **memh_p);
+                               unsigned mem_flags, int relaxed_order,
+                               size_t memh_base_size, size_t mr_size,
+                               uct_ib_mem_t **memh_p);
 
 void uct_ib_check_gpudirect_driver(uct_ib_md_t *md,
                                    const char *file,

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -360,21 +360,15 @@ uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
 {
     ucs_memory_type_t mem_type;
 
-    mem_type = UCT_MD_MEM_REG_FIELD_VALUE(params, mem_type, FIELD_MEM_TYPE,
+    mem_type = (params == NULL) ? UCS_MEMORY_TYPE_HOST :
+               UCT_MD_MEM_REG_FIELD_VALUE(params, mem_type, FIELD_MEM_TYPE,
                                           UCS_MEMORY_TYPE_HOST);
     if (mem_type >= UCS_MEMORY_TYPE_LAST) {
         return 0;
     }
 
-    if (md->relaxed_order_mem_types != 0) {
-        return !!(md->relaxed_order_mem_types & UCS_BIT(mem_type));
-    }
-
-    if (UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE) {
-        return 0;
-    }
-
-    return !!(md->relaxed_order_auto_mem_types & UCS_BIT(mem_type));
+    return !!((md->relaxed_order_mem_types |
+               md->relaxed_order_auto_mem_types) & UCS_BIT(mem_type));
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t uct_ib_memh_get_lkey(uct_mem_h memh)

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -165,7 +165,6 @@ typedef struct uct_ib_md {
     double                   pci_bw;
     int                      relaxed_order;
     uint64_t                 relaxed_order_mem_types;
-    uint64_t                 relaxed_order_auto_mem_types;
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;
@@ -363,12 +362,10 @@ uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
     mem_type = (params == NULL) ? UCS_MEMORY_TYPE_HOST :
                UCT_MD_MEM_REG_FIELD_VALUE(params, mem_type, FIELD_MEM_TYPE,
                                           UCS_MEMORY_TYPE_HOST);
-    if (mem_type >= UCS_MEMORY_TYPE_LAST) {
-        return 0;
-    }
 
-    return !!((md->relaxed_order_mem_types |
-               md->relaxed_order_auto_mem_types) & UCS_BIT(mem_type));
+    ucs_assert(mem_type < UCS_MEMORY_TYPE_LAST);
+
+    return !!(md->relaxed_order_mem_types & UCS_BIT(mem_type));
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t uct_ib_memh_get_lkey(uct_mem_h memh)

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -163,7 +163,6 @@ typedef struct uct_ib_md {
     int                      check_subnet_filter;
     uint64_t                 subnet_filter;
     double                   pci_bw;
-    int                      relaxed_order;
     uint64_t                 relaxed_order_mem_types;
     int                      fork_init;
     uint64_t                 reg_mem_types;
@@ -351,6 +350,12 @@ uct_ib_md_relaxed_order_auto_mem_types(ucs_cpu_vendor_t cpu_vendor,
     }
 
     return 0;
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_ib_md_is_relaxed_order(const uct_ib_md_t *md)
+{
+    return md->relaxed_order_mem_types != 0;
 }
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -583,21 +583,21 @@ static UCS_F_ALWAYS_INLINE uint32_t uct_ib_mlx5_mkey_index(uint32_t mkey)
 }
 
 static UCS_F_ALWAYS_INLINE uct_ib_mr_type_t uct_ib_devx_get_atomic_mr_type(
-        uct_ib_md_t *md, const uct_ib_mlx5_devx_mem_t *memh)
+        const uct_ib_mlx5_devx_mem_t *memh)
 {
     /* Device memory only supports default mr */
     if (uct_ib_mlx5_devx_has_dm(memh)) {
         return UCT_IB_MR_DEFAULT;
     }
 
-    return uct_ib_md_get_atomic_mr_type(md);
+    return uct_ib_memh_get_atomic_mr_type(&memh->super);
 }
 
 UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_ib_mlx5_devx_reg_atomic_key,
                         (md, memh), uct_ib_mlx5_md_t *md,
                         uct_ib_mlx5_devx_mem_t *memh)
 {
-    uct_ib_mr_type_t mr_type = uct_ib_devx_get_atomic_mr_type(&md->super, memh);
+    uct_ib_mr_type_t mr_type = uct_ib_devx_get_atomic_mr_type(memh);
     uint8_t mr_id            = uct_ib_md_get_atomic_mr_id(&md->super);
     uint32_t atomic_offset   = uct_ib_md_atomic_offset(mr_id);
     uint32_t mkey_index;
@@ -819,6 +819,10 @@ uct_ib_mlx5_direct_nic_reg_mr(uct_ib_mlx5_md_t *md, void *address,
 #endif
 }
 
+static int
+uct_ib_mlx5_devx_memh_has_ro(uct_ib_mlx5_md_t *md,
+                             uct_ib_mlx5_devx_mem_t *memh);
+
 static ucs_status_t
 uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
                         void *address, size_t length,
@@ -827,7 +831,8 @@ uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
                         uint32_t *lkey_p, uint32_t *rkey_p)
 {
     uint64_t access_flags =
-            uct_ib_memh_access_flags(&memh->super, md->super.relaxed_order,
+            uct_ib_memh_access_flags(&memh->super,
+                                     uct_ib_mlx5_devx_memh_has_ro(md, memh),
                                      md->super.dev.mr_access_flags) &
             access_mask;
     unsigned flags        = UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
@@ -888,15 +893,15 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_mr(uct_ib_mlx5_md_t *md,
 
 static ucs_status_t
 uct_ib_mlx5_devx_memh_alloc(uct_ib_mlx5_md_t *md, size_t length,
-                            unsigned flags, size_t mr_size,
+                            unsigned flags, int relaxed_order, size_t mr_size,
                             uct_ib_mlx5_devx_mem_t **memh_p)
 {
     uct_ib_mlx5_devx_mem_t *memh;
     uct_ib_mem_t *ib_memh;
     ucs_status_t status;
 
-    status = uct_ib_memh_alloc(&md->super, length, flags, sizeof(*memh),
-                               mr_size, &ib_memh);
+    status = uct_ib_memh_alloc(&md->super, length, flags, relaxed_order,
+                               sizeof(*memh), mr_size, &ib_memh);
     if (status != UCS_OK) {
         return status;
     }
@@ -917,7 +922,7 @@ uct_ib_mlx5_devx_memh_has_ro(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh)
         return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
     }
 
-    return md->super.relaxed_order;
+    return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
 }
 
 static ucs_status_t
@@ -930,14 +935,15 @@ uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
     ucs_status_t status;
     int relaxed_order;
 
+    relaxed_order = md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
     status = uct_ib_mlx5_devx_memh_alloc(md, SIZE_MAX,
                                          UCT_MD_MEM_FLAG_NONBLOCK | flags,
-                                         sizeof(memh->mrs[0]), &memh);
+                                         relaxed_order, sizeof(memh->mrs[0]),
+                                         &memh);
     if (status != UCS_OK) {
         goto err;
     }
 
-    relaxed_order = md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
     access_flags  = uct_ib_memh_access_flags(&memh->super, relaxed_order,
                                              md->super.dev.mr_access_flags);
     status = uct_ib_reg_mr(&md->super, NULL, SIZE_MAX, &params, access_flags,
@@ -979,12 +985,14 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
     uct_ib_mlx5_devx_mem_t *memh;
     ucs_status_t status;
     uint32_t dummy_mkey;
+    int relaxed_order;
 
     if (flags & UCT_MD_MEM_GVA) {
         return uct_ib_mlx5_devx_mem_reg_gva(uct_md, flags, memh_p);
     }
 
-    status = uct_ib_mlx5_devx_memh_alloc(md, length, flags,
+    relaxed_order = uct_ib_memh_is_relaxed_order(&md->super, params);
+    status = uct_ib_mlx5_devx_memh_alloc(md, length, flags, relaxed_order,
                                          sizeof(memh->mrs[0]), &memh);
     if (status != UCS_OK) {
         goto err;
@@ -1001,7 +1009,7 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
         uct_ib_mlx5_devx_reg_symmetric(md, memh, address);
     }
 
-    if (md->super.relaxed_order) {
+    if (uct_ib_mlx5_devx_memh_has_ro(md, memh)) {
         status = uct_ib_mlx5_devx_reg_mr(md, memh, address, length, params,
                                          UCT_IB_MR_STRICT_ORDER,
                                          ~IBV_ACCESS_RELAXED_ORDERING,
@@ -1828,7 +1836,8 @@ uct_ib_mlx5_devx_check_odp(uct_ib_mlx5_md_t *md,
         ucs_string_buffer_cleanup(&strb);
     }
 
-    if (!md->super.relaxed_order) {
+    if (!(md->super.relaxed_order_mem_types &
+          UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
         return version;
     }
 
@@ -2146,7 +2155,7 @@ uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
     mem_flags = UCT_MD_MEM_ACCESS_REMOTE_GET | UCT_MD_MEM_ACCESS_REMOTE_PUT |
                 UCT_MD_MEM_ACCESS_REMOTE_ATOMIC;
 
-    status = uct_ib_memh_alloc(md, dm_attr.length, mem_flags,
+    status = uct_ib_memh_alloc(md, dm_attr.length, mem_flags, 0,
                                sizeof(uct_ib_mlx5_devx_mem_t),
                                sizeof(struct ibv_mr), (uct_ib_mem_t**)&memh);
     if (status != UCS_OK) {
@@ -3046,7 +3055,7 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     void *access_key;
     int ret;
 
-    status = uct_ib_mlx5_devx_memh_alloc(md, 0, 0, 0, &memh);
+    status = uct_ib_mlx5_devx_memh_alloc(md, 0, 0, 0, 0, &memh);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -989,7 +989,8 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
     }
 
     relaxed_order = uct_ib_memh_is_relaxed_order(&md->super, params);
-    status = uct_ib_mlx5_devx_memh_alloc(md, length, flags, relaxed_order,
+    status        = uct_ib_mlx5_devx_memh_alloc(md, length, flags,
+                                                relaxed_order,
                                          sizeof(memh->mrs[0]), &memh);
     if (status != UCS_OK) {
         goto err;

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -821,7 +821,14 @@ uct_ib_mlx5_direct_nic_reg_mr(uct_ib_mlx5_md_t *md, void *address,
 
 static int
 uct_ib_mlx5_devx_memh_has_ro(uct_ib_mlx5_md_t *md,
-                             uct_ib_mlx5_devx_mem_t *memh);
+                             uct_ib_mlx5_devx_mem_t *memh)
+{
+    if (memh->super.flags & UCT_IB_MEM_FLAG_GVA) {
+        return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
+    }
+
+    return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
+}
 
 static ucs_status_t
 uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
@@ -913,16 +920,6 @@ uct_ib_mlx5_devx_memh_alloc(uct_ib_mlx5_md_t *md, size_t length,
 
     *memh_p = memh;
     return UCS_OK;
-}
-
-static int
-uct_ib_mlx5_devx_memh_has_ro(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh)
-{
-    if (memh->super.flags & UCT_IB_MEM_FLAG_GVA) {
-        return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
-    }
-
-    return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
 }
 
 static ucs_status_t

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -757,7 +757,8 @@ uct_rc_mlx5_iface_init_fence_flags(uct_rc_mlx5_iface_common_t *iface,
     case UCT_RC_FENCE_MODE_WEAK:
         break;
     case UCT_RC_FENCE_MODE_AUTO:
-        if (strong_order || pci_atomics || md->super.relaxed_order) {
+        if (strong_order || pci_atomics ||
+            uct_ib_md_is_relaxed_order(&md->super)) {
             break;
         }
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -591,7 +591,7 @@ uct_rc_iface_fence_relaxed_order(uct_iface_h tl_iface)
 
     ucs_assert(tl_iface->ops.iface_fence == uct_rc_iface_fence);
 
-    if (!md->relaxed_order) {
+    if (!uct_ib_md_is_relaxed_order(md)) {
         return UCS_OK;
     }
 

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -114,6 +114,9 @@ protected:
        uct_md_mem_reg_params_t reg_params  = {};
        uct_rkey_bundle_t       rkey_bundle = {};
        uct_mem_h memh;
+
+       reg_params.field_mask = UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+       reg_params.mem_type   = UCS_MEMORY_TYPE_CUDA;
        ASSERT_UCS_OK(uct_md_mem_reg_v2(md(), ptr, size, &reg_params, &memh));
 
        std::exception_ptr thread_exception;

--- a/test/gtest/uct/cuda/test_switch_cuda_device.cc
+++ b/test/gtest/uct/cuda/test_switch_cuda_device.cc
@@ -552,7 +552,8 @@ public:
         const size_t size = UCS_MBYTE;
         mem_src_t src_buf(size, src_type);
         mem_dest_t dest_buf(size, dest_type);
-        rkey_mem_pair_t rkey_dest = rkey_unpack(sender(), dest_buf.ptr(), size);
+        rkey_mem_pair_t rkey_dest = rkey_unpack(sender(), dest_buf.ptr(),
+                                                  size, dest_type);
 
         // Set different device context and call send op
         ASSERT_EQ(cudaSetDevice((current_device + 1) % m_num_devices), cudaSuccess);
@@ -634,12 +635,15 @@ protected:
     }
 
 private:
-    rkey_mem_pair_t rkey_unpack(entity &e, void *buf, size_t size)
+    rkey_mem_pair_t rkey_unpack(entity &e, void *buf, size_t size,
+                                  ucs_memory_type_t mem_type)
     {
         uct_md_mem_reg_params_t reg_params = {};
         uct_rkey_bundle_t rkey             = {};
         uct_mem_h memh                     = NULL;
 
+        reg_params.field_mask = UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+        reg_params.mem_type   = mem_type;
         ASSERT_UCS_OK(uct_md_mem_reg_v2(e.md(), buf, size, &reg_params, &memh));
 
         if (e.md_attr().rkey_packed_size == 0) {

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -14,10 +14,6 @@
 #include <common/test.h>
 #include <uct/test_md.h>
 
-class test_ib_md_relaxed_order_policy : public ucs::test
-{
-};
-
 class test_ib_md : public test_md
 {
 protected:
@@ -54,7 +50,7 @@ private:
                        bool is_expected_to_have_auxiliary_key);
 };
 
-UCS_TEST_F(test_ib_md_relaxed_order_policy, auto_mem_types)
+TEST(test_ib_md_relaxed_order_policy, auto_mem_types)
 {
     uint64_t all_mem_types  = UCS_MASK(UCS_MEMORY_TYPE_LAST);
     uint64_t cuda_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
@@ -72,13 +68,14 @@ UCS_TEST_F(test_ib_md_relaxed_order_policy, auto_mem_types)
                       UCS_CPU_VENDOR_INTEL, UCS_CPU_MODEL_INTEL_ICELAKE));
 }
 
-UCS_TEST_F(test_ib_md_relaxed_order_policy, memh_mem_type)
+TEST(test_ib_md_relaxed_order_policy, memh_mem_type)
 {
     uct_md_mem_reg_params_t params = {};
     uct_ib_md_t md                 = {};
 
     md.relaxed_order_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
 
+    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, NULL));
     EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
 
     params.field_mask = UCT_MD_MEM_REG_FIELD_MEM_TYPE;

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -85,9 +85,6 @@ TEST(test_ib_md_relaxed_order_policy, memh_mem_type)
     params.mem_type = UCS_MEMORY_TYPE_HOST;
     EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
 
-    md.relaxed_order_mem_types      = 0;
-    md.relaxed_order_auto_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-
     params.mem_type = UCS_MEMORY_TYPE_CUDA;
     EXPECT_TRUE(uct_ib_memh_is_relaxed_order(&md, &params));
 

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -14,6 +14,10 @@
 #include <common/test.h>
 #include <uct/test_md.h>
 
+class test_ib_md_relaxed_order_policy : public ucs::test
+{
+};
+
 class test_ib_md : public test_md
 {
 protected:
@@ -49,6 +53,53 @@ private:
     void check_mlx5_mr(uct_ib_mem_t *ib_memh, bool is_expected_to_have_atomic,
                        bool is_expected_to_have_auxiliary_key);
 };
+
+UCS_TEST_F(test_ib_md_relaxed_order_policy, auto_mem_types)
+{
+    uint64_t all_mem_types  = UCS_MASK(UCS_MEMORY_TYPE_LAST);
+    uint64_t cuda_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
+                              UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);
+
+    EXPECT_EQ(all_mem_types,
+              uct_ib_md_relaxed_order_auto_mem_types(UCS_CPU_VENDOR_AMD,
+                                                     UCS_CPU_MODEL_AMD_ROME));
+    EXPECT_EQ(cuda_mem_types,
+              uct_ib_md_relaxed_order_auto_mem_types(
+                      UCS_CPU_VENDOR_INTEL,
+                      UCS_CPU_MODEL_INTEL_EMERALD_RAPIDS));
+    EXPECT_EQ(0ul,
+              uct_ib_md_relaxed_order_auto_mem_types(
+                      UCS_CPU_VENDOR_INTEL, UCS_CPU_MODEL_INTEL_ICELAKE));
+}
+
+UCS_TEST_F(test_ib_md_relaxed_order_policy, memh_mem_type)
+{
+    uct_md_mem_reg_params_t params = {};
+    uct_ib_md_t md                 = {};
+
+    md.relaxed_order_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+
+    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+
+    params.field_mask = UCT_MD_MEM_REG_FIELD_MEM_TYPE;
+    params.mem_type   = UCS_MEMORY_TYPE_CUDA;
+    EXPECT_TRUE(uct_ib_memh_is_relaxed_order(&md, &params));
+
+    params.mem_type = UCS_MEMORY_TYPE_HOST;
+    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+
+    md.relaxed_order_mem_types      = 0;
+    md.relaxed_order_auto_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+
+    params.mem_type = UCS_MEMORY_TYPE_CUDA;
+    EXPECT_TRUE(uct_ib_memh_is_relaxed_order(&md, &params));
+
+    params.mem_type = UCS_MEMORY_TYPE_RDMA;
+    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+
+    params.mem_type = UCS_MEMORY_TYPE_HOST;
+    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+}
 
 void test_ib_md::init() {
     test_md::init();

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -188,15 +188,18 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access,
         EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC);
     }
 
-    check_mlx5_mr(ib_memh, false, ib_md().relaxed_order);
+    check_mlx5_mr(ib_memh, false,
+                  uct_ib_md_is_relaxed_order(&ib_md()));
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
-    check_mlx5_mr(ib_memh, (amo_access && has_ksm()) || ib_md().relaxed_order,
-                  ib_md().relaxed_order);
+    check_mlx5_mr(ib_memh,
+                  (amo_access && has_ksm()) ||
+                          uct_ib_md_is_relaxed_order(&ib_md()),
+                  uct_ib_md_is_relaxed_order(&ib_md()));
 
     status = uct_md_mem_dereg(md(), memh);
     EXPECT_UCS_OK(status);

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -1057,13 +1057,15 @@ protected:
         uint8_t saved_dp_ordering = md->dp_ordering_cap_devx.rc;
         uint8_t saved_pci_fadd    = dev->pci_fadd_arg_sizes;
         uint8_t saved_pci_cswap   = dev->pci_cswap_arg_sizes;
-        int saved_relaxed_order   = md->super.relaxed_order;
+        uint64_t saved_relaxed_order_mem_types =
+                md->super.relaxed_order_mem_types;
         uct_iface_h tl_iface      = NULL;
         ucs_status_t status;
 
         m_iface.reset();
         md->dp_ordering_cap_devx.rc = dp_ordering;
-        md->super.relaxed_order     = relaxed_order;
+        md->super.relaxed_order_mem_types =
+                relaxed_order ? UCS_BIT(UCS_MEMORY_TYPE_HOST) : 0;
         dev->pci_fadd_arg_sizes     = pci_atomics ? sizeof(uint64_t) : 0;
         dev->pci_cswap_arg_sizes    = pci_atomics ? sizeof(uint64_t) : 0;
 
@@ -1073,7 +1075,8 @@ protected:
 
         dev->pci_cswap_arg_sizes    = saved_pci_cswap;
         dev->pci_fadd_arg_sizes     = saved_pci_fadd;
-        md->super.relaxed_order     = saved_relaxed_order;
+        md->super.relaxed_order_mem_types =
+                saved_relaxed_order_mem_types;
         md->dp_ordering_cap_devx.rc = saved_dp_ordering;
 
         if (status == UCS_OK) {

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1016,8 +1016,10 @@ void uct_test::entity::mem_type_reg(uct_allocated_memory_t *mem,
         ucs_align_ptr_range(&reg_address, &reg_length, md_attr().reg_alignment);
 
         uct_md_mem_reg_params_t reg_params;
-        reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+        reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS |
+                                UCT_MD_MEM_REG_FIELD_MEM_TYPE;
         reg_params.flags      = mem_flags;
+        reg_params.mem_type   = mem->mem_type;
 
         ucs_status_t status = uct_md_mem_reg_v2(m_md, reg_address, reg_length,
                                                 &reg_params, &mem->memh);


### PR DESCRIPTION
## What?
Narrow Intel Emerald Rapids auto relaxed-order policy to CUDA/CUDA managed memory.

## Why?
[Internal issue](https://redmine.mellanox.com/issues/5030855)

5f64b52f09 enabled RO globally for Emerald Rapids. On CX-8/EMR host-memory collectives, relaxed host registrations create long completion/visibility tail latency under many concurrent RDMA operations. Keeping host registrations strict recovers the Zodiac regression, while preserving the intended GPUDirect RDMA benefit for CUDA memory.
