### PR TITLE
UCT/ROCM: flush in-flight ops using flush marker signal (#11474) - v1.21.x

### DIFF
--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -8,6 +8,7 @@
 #endif
 
 #include "rocm_base.h"
+#include "rocm_signal.h"
 
 #include <ucs/sys/string.h>
 #include <ucs/sys/module.h>
@@ -544,6 +545,36 @@ uct_rocm_amd_gpu_product_t uct_rocm_base_get_gpu_product(void)
     }
 
     return gpu_product;
+}
+
+ucs_status_t uct_rocm_base_ep_flush(uct_ep_h tl_ep, ucs_mpool_t *signal_pool,
+                                    ucs_queue_head_t *signal_queue,
+                                    uct_completion_t *comp)
+{
+    uct_rocm_base_signal_desc_t *flush_signal;
+
+    if (ucs_queue_is_empty(signal_queue)) {
+        UCT_TL_EP_STAT_FLUSH(ucs_derived_of(tl_ep, uct_base_ep_t));
+        return UCS_OK;
+    }
+
+    if (comp == NULL) {
+        UCT_TL_EP_STAT_FLUSH_WAIT(ucs_derived_of(tl_ep, uct_base_ep_t));
+        return UCS_INPROGRESS;
+    }
+
+    flush_signal = ucs_mpool_get(signal_pool);
+    if (flush_signal == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    hsa_signal_store_screlease(flush_signal->signal, 0);
+    flush_signal->comp        = comp;
+    flush_signal->mapped_addr = NULL;
+    ucs_queue_push(signal_queue, &flush_signal->queue);
+
+    UCT_TL_EP_STAT_FLUSH_WAIT(ucs_derived_of(tl_ep, uct_base_ep_t));
+    return UCS_INPROGRESS;
 }
 
 UCS_MODULE_INIT() {

--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -46,5 +46,8 @@ ucs_status_t uct_rocm_base_mem_query(uct_md_h md, const void *addr,
 ucs_status_t uct_rocm_base_get_link_type(hsa_amd_link_info_type_t *type);
 uct_rocm_amd_gpu_product_t uct_rocm_base_get_gpu_product(void);
 int uct_rocm_base_is_dmabuf_supported();
+ucs_status_t uct_rocm_base_ep_flush(uct_ep_h tl_ep, ucs_mpool_t *signal_pool,
+                                    ucs_queue_head_t *signal_queue,
+                                    uct_completion_t *comp);
 
 #endif

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -156,6 +156,15 @@ uct_rocm_copy_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_INPROGRESS;
 }
 
+static ucs_status_t
+uct_rocm_copy_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
+{
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                  uct_rocm_copy_iface_t);
+    return uct_rocm_base_ep_flush(tl_ep, &iface->signal_pool,
+                                  &iface->signal_queue, comp);
+}
+
 static unsigned uct_rocm_copy_iface_progress(uct_iface_h tl_iface)
 {
     uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_iface,
@@ -172,7 +181,7 @@ static uct_iface_ops_t uct_rocm_copy_iface_ops = {
     .ep_put_zcopy             = uct_rocm_copy_ep_put_zcopy,
     .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
     .ep_pending_purge         = (uct_ep_pending_purge_func_t)ucs_empty_function,
-    .ep_flush                 = uct_base_ep_flush,
+    .ep_flush                 = uct_rocm_copy_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_rocm_copy_ep_t),
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_copy_ep_t),

--- a/src/uct/rocm/ipc/rocm_ipc_iface.c
+++ b/src/uct/rocm/ipc/rocm_ipc_iface.c
@@ -155,6 +155,15 @@ uct_rocm_ipc_iface_flush(uct_iface_h tl_iface, unsigned flags,
     return UCS_INPROGRESS;
 }
 
+static ucs_status_t
+uct_rocm_ipc_ep_flush(uct_ep_h tl_ep, unsigned flags, uct_completion_t *comp)
+{
+    uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                 uct_rocm_ipc_iface_t);
+    return uct_rocm_base_ep_flush(tl_ep, &iface->signal_pool,
+                                  &iface->signal_queue, comp);
+}
+
 static unsigned uct_rocm_ipc_iface_progress(uct_iface_h tl_iface)
 {
     uct_rocm_ipc_iface_t *iface = ucs_derived_of(tl_iface, uct_rocm_ipc_iface_t);
@@ -178,7 +187,7 @@ static uct_iface_ops_t uct_rocm_ipc_iface_ops = {
     .ep_get_zcopy             = uct_rocm_ipc_ep_get_zcopy,
     .ep_pending_add           = (uct_ep_pending_add_func_t)ucs_empty_function_return_busy,
     .ep_pending_purge         = (uct_ep_pending_purge_func_t)ucs_empty_function,
-    .ep_flush                 = uct_base_ep_flush,
+    .ep_flush                 = uct_rocm_ipc_ep_flush,
     .ep_fence                 = uct_base_ep_fence,
     .ep_create                = UCS_CLASS_NEW_FUNC_NAME(uct_rocm_ipc_ep_t),
     .ep_destroy               = UCS_CLASS_DELETE_FUNC_NAME(uct_rocm_ipc_ep_t),


### PR DESCRIPTION
* UCT/ROCM: flush in-flight ops using flush marker signal

* UCT/ROCM: address review comment

## What?
Cherry-pick from the master

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
