### PR TITLE
UCS/TOPO: Support MPS MLOPart with CUDA device aliasing

### DIFF
--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -160,53 +160,37 @@ static ucp_sys_dev_map_t ucp_proto_multi_init_flush_sys_dev_mask(
     return UCS_BIT(key->sys_dev);
 }
 
-typedef struct {
-    ucs_bus_id_bit_rep_t bus_id;
-    uintptr_t            user_value;
-    ucs_sys_device_t     sys_dev;
-} ucp_proto_multi_sys_dev_sort_key_t;
-
-static ucp_proto_multi_sys_dev_sort_key_t
-ucp_proto_multi_sys_dev_sort_key(ucs_sys_device_t sys_dev)
+static ucs_bus_id_bit_rep_t
+ucp_proto_multi_sys_dev_bus_id_key(ucs_sys_device_t sys_dev)
 {
-    ucp_proto_multi_sys_dev_sort_key_t key;
     ucs_sys_bus_id_t bus_id;
 
     if (ucs_topo_get_device_bus_id(sys_dev, &bus_id) != UCS_OK) {
         ucs_fatal("failed to get device bus id for sys_dev %d", sys_dev);
     }
 
-    key.bus_id     = ucs_topo_get_bus_id_bit_repr(&bus_id);
-    key.user_value = ucs_topo_sys_device_get_user_value(sys_dev);
-    key.sys_dev    = sys_dev;
-
-    return key;
+    return ucs_topo_get_bus_id_bit_repr(&bus_id);
 }
 
 static int ucp_proto_multi_sys_dev_cmp(const void *pa, const void *pb,
                                        void *UCS_V_UNUSED arg)
 {
-    const ucs_sys_device_t a = *(const ucs_sys_device_t*)pa;
-    const ucs_sys_device_t b = *(const ucs_sys_device_t*)pb;
-    ucp_proto_multi_sys_dev_sort_key_t key_a =
-            ucp_proto_multi_sys_dev_sort_key(a);
-    ucp_proto_multi_sys_dev_sort_key_t key_b =
-            ucp_proto_multi_sys_dev_sort_key(b);
+    const ucs_sys_device_t a    = *(const ucs_sys_device_t*)pa;
+    const ucs_sys_device_t b    = *(const ucs_sys_device_t*)pb;
+    ucs_bus_id_bit_rep_t key_a  = ucp_proto_multi_sys_dev_bus_id_key(a);
+    ucs_bus_id_bit_rep_t key_b  = ucp_proto_multi_sys_dev_bus_id_key(b);
+    uintptr_t user_value_a, user_value_b;
 
     /* Sort by topology identity so every rank on the node observes the same
      * ordering regardless of local device discovery order. */
-    if (key_a.bus_id != key_b.bus_id) {
-        return (key_a.bus_id > key_b.bus_id) -
-               (key_a.bus_id < key_b.bus_id);
+    if (key_a != key_b) {
+        return (key_a > key_b) - (key_a < key_b);
     }
 
-    if (key_a.user_value != key_b.user_value) {
-        return (key_a.user_value > key_b.user_value) -
-               (key_a.user_value < key_b.user_value);
-    }
+    user_value_a = ucs_topo_sys_device_get_user_value(a);
+    user_value_b = ucs_topo_sys_device_get_user_value(b);
 
-    return (key_a.sys_dev > key_b.sys_dev) -
-           (key_a.sys_dev < key_b.sys_dev);
+    return (user_value_a > user_value_b) - (user_value_a < user_value_b);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_sys_dev_distance_t

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -160,31 +160,53 @@ static ucp_sys_dev_map_t ucp_proto_multi_init_flush_sys_dev_mask(
     return UCS_BIT(key->sys_dev);
 }
 
-/* Pack a device's PCI bus id (BDF) into a comparable key. Devices without a
- * bus id sort last, ordered by sys_dev to keep a deterministic total order. */
-static ucs_bus_id_bit_rep_t
-ucp_proto_multi_sys_dev_bus_id_key(ucs_sys_device_t sys_dev)
+typedef struct {
+    ucs_bus_id_bit_rep_t bus_id;
+    uintptr_t            user_value;
+    ucs_sys_device_t     sys_dev;
+} ucp_proto_multi_sys_dev_sort_key_t;
+
+static ucp_proto_multi_sys_dev_sort_key_t
+ucp_proto_multi_sys_dev_sort_key(ucs_sys_device_t sys_dev)
 {
+    ucp_proto_multi_sys_dev_sort_key_t key;
     ucs_sys_bus_id_t bus_id;
 
     if (ucs_topo_get_device_bus_id(sys_dev, &bus_id) != UCS_OK) {
         ucs_fatal("failed to get device bus id for sys_dev %d", sys_dev);
     }
 
-    return ucs_topo_get_bus_id_bit_repr(&bus_id);
+    key.bus_id     = ucs_topo_get_bus_id_bit_repr(&bus_id);
+    key.user_value = ucs_topo_sys_device_get_user_value(sys_dev);
+    key.sys_dev    = sys_dev;
+
+    return key;
 }
 
 static int ucp_proto_multi_sys_dev_cmp(const void *pa, const void *pb,
                                        void *UCS_V_UNUSED arg)
 {
-    const ucs_sys_device_t a   = *(const ucs_sys_device_t*)pa;
-    const ucs_sys_device_t b   = *(const ucs_sys_device_t*)pb;
-    ucs_bus_id_bit_rep_t key_a = ucp_proto_multi_sys_dev_bus_id_key(a);
-    ucs_bus_id_bit_rep_t key_b = ucp_proto_multi_sys_dev_bus_id_key(b);
+    const ucs_sys_device_t a = *(const ucs_sys_device_t*)pa;
+    const ucs_sys_device_t b = *(const ucs_sys_device_t*)pb;
+    ucp_proto_multi_sys_dev_sort_key_t key_a =
+            ucp_proto_multi_sys_dev_sort_key(a);
+    ucp_proto_multi_sys_dev_sort_key_t key_b =
+            ucp_proto_multi_sys_dev_sort_key(b);
 
-    /* ascending order by PCI bus id so every rank on the node observes the
-     * same ordering regardless of local device discovery order */
-    return (key_a > key_b) - (key_a < key_b);
+    /* Sort by topology identity so every rank on the node observes the same
+     * ordering regardless of local device discovery order. */
+    if (key_a.bus_id != key_b.bus_id) {
+        return (key_a.bus_id > key_b.bus_id) -
+               (key_a.bus_id < key_b.bus_id);
+    }
+
+    if (key_a.user_value != key_b.user_value) {
+        return (key_a.user_value > key_b.user_value) -
+               (key_a.user_value < key_b.user_value);
+    }
+
+    return (key_a.sys_dev > key_b.sys_dev) -
+           (key_a.sys_dev < key_b.sys_dev);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_sys_dev_distance_t

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -1255,7 +1255,7 @@ void ucs_topo_restore_state(ucs_global_state_t *state)
         status = ucs_topo_bus_value_hash_add_nolock(&device->bus_id,
                                                     device->user_value,
                                                     sys_dev);
-        ucs_assert(status == UCS_OK);
+        ucs_assert_always(status == UCS_OK);
     }
 
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -92,10 +92,10 @@ KHASH_INIT(bus_to_sys_dev, ucs_topo_bus_value_key_t, ucs_sys_device_t, 1,
            ucs_topo_bus_value_key_hash, ucs_topo_bus_value_key_equal);
 
 typedef struct ucs_topo_global_ctx {
-    ucs_spinlock_t                   lock;
-    khash_t(bus_to_sys_dev)          bus_to_sys_dev_hash;
-    ucs_topo_sys_device_info_t       devices[UCS_TOPO_MAX_SYS_DEVICES];
-    unsigned                         num_devices;
+    ucs_spinlock_t             lock;
+    khash_t(bus_to_sys_dev)    bus_to_sys_dev_hash;
+    ucs_topo_sys_device_info_t devices[UCS_TOPO_MAX_SYS_DEVICES];
+    unsigned                   num_devices;
 } ucs_topo_global_ctx_t;
 
 

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -364,7 +364,7 @@ ucs_topo_add_device_locked(const ucs_sys_bus_id_t *bus_id,
     device->sibling_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
     device->sys_dev_aux     = UCS_SYS_DEVICE_ID_UNKNOWN;
 
-    if (user_value == UINTPTR_MAX) {
+    if (user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
         ucs_debug("added sys_dev %d for bus id %s", *sys_dev, name);
     } else {
         ucs_debug("added sys_dev %d for bus id %s with user value %" PRIuPTR,
@@ -374,97 +374,113 @@ ucs_topo_add_device_locked(const ucs_sys_bus_id_t *bus_id,
     return UCS_OK;
 }
 
-ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
-                                            ucs_sys_device_t *sys_dev)
+static ucs_status_t
+ucs_topo_find_device_by_bus_id_locked(const ucs_sys_bus_id_t *bus_id,
+                                      ucs_sys_device_t *sys_dev_p)
 {
     ucs_bus_id_bit_rep_t bus_id_bit_rep;
     int kh_put_status;
     khiter_t hash_it;
     ucs_status_t status;
 
-    bus_id_bit_rep  = ucs_topo_get_bus_id_bit_repr(bus_id);
+    bus_id_bit_rep = ucs_topo_get_bus_id_bit_repr(bus_id);
 
-    ucs_spin_lock(&ucs_topo_global_ctx.lock);
     hash_it = kh_put(
             bus_to_sys_dev /*name*/,
             &ucs_topo_global_ctx.bus_to_sys_dev_hash /*pointer to hashmap*/,
             bus_id_bit_rep /*key*/, &kh_put_status);
 
     if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
-        *sys_dev = kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it);
-        status   = UCS_OK;
+        *sys_dev_p = kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash,
+                              hash_it);
+        status     = UCS_OK;
     } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
                (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
         status = ucs_topo_add_device_locked(
-                bus_id, ucs_topo_read_device_numa_node(bus_id), UINTPTR_MAX,
-                sys_dev);
+                bus_id, ucs_topo_read_device_numa_node(bus_id),
+                UCS_SYS_DEVICE_USER_VALUE_EMPTY, sys_dev_p);
         if (status != UCS_OK) {
             kh_del(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash,
                    hash_it);
-            goto out;
+            return status;
         }
 
-        kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
+        kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) =
+                *sys_dev_p;
         status = UCS_OK;
     } else {
         ucs_error("failed to put key into hash table");
         status = UCS_ERR_IO_ERROR;
     }
 
-out:
+    return status;
+}
+
+ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
+                                            ucs_sys_device_t *sys_dev)
+{
+    ucs_status_t status;
+
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+    status = ucs_topo_find_device_by_bus_id_locked(bus_id, sys_dev);
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+
     return status;
 }
 
 ucs_status_t
 ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
                                               uintptr_t user_value,
-                                              ucs_sys_device_t *sys_dev)
+                                              ucs_sys_device_t *sys_dev_p)
 {
-    ucs_sys_device_t base_sys_dev;
+    ucs_topo_sys_device_info_t *base_device;
+    ucs_sys_device_t base_sys_dev, sys_dev;
     ucs_topo_sys_device_info_t *device;
     ucs_status_t status;
-    ucs_sys_device_t dev;
 
-    if (user_value == UINTPTR_MAX) {
+    if (user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
+        ucs_error("empty user value is reserved");
         return UCS_ERR_INVALID_PARAM;
-    }
-
-    status = ucs_topo_find_device_by_bus_id(bus_id, &base_sys_dev);
-    if (status != UCS_OK) {
-        return status;
     }
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
 
-    device = &ucs_topo_global_ctx.devices[base_sys_dev];
-    if (device->user_value == UINTPTR_MAX) {
-        device->user_value = user_value;
-        *sys_dev           = base_sys_dev;
-        status             = UCS_OK;
+    /* Keep the BDF hash as the canonical BDF-only lookup. */
+    status = ucs_topo_find_device_by_bus_id_locked(bus_id, &base_sys_dev);
+    if (status != UCS_OK) {
         goto out_unlock;
     }
 
-    for (dev = 0; dev < ucs_topo_global_ctx.num_devices; ++dev) {
-        device = &ucs_topo_global_ctx.devices[dev];
+    base_device = &ucs_topo_global_ctx.devices[base_sys_dev];
+    if (base_device->user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
+        /* First logical device for this BDF reuses the canonical sys_dev. */
+        base_device->user_value = user_value;
+        *sys_dev_p              = base_sys_dev;
+        status                  = UCS_OK;
+        goto out_unlock;
+    }
+
+    /* Find a previous duplicate-BDF sys_dev with the same user value. */
+    for (sys_dev = 0; sys_dev < ucs_topo_global_ctx.num_devices; ++sys_dev) {
+        device = &ucs_topo_global_ctx.devices[sys_dev];
         if (!ucs_topo_bus_id_equal(&device->bus_id, bus_id)) {
             continue;
         }
 
-        ucs_assertv_always(device->user_value != UINTPTR_MAX,
-                           "sys_dev %u for bus id has no user value",
-                           dev);
+        ucs_assertv_always(
+                device->user_value != UCS_SYS_DEVICE_USER_VALUE_EMPTY,
+                "sys_dev %u has no user value", sys_dev);
 
         if (device->user_value == user_value) {
-            *sys_dev = dev;
-            status   = UCS_OK;
+            *sys_dev_p = sys_dev;
+            status     = UCS_OK;
             goto out_unlock;
         }
     }
 
+    /* No matching user value exists, so add another sys_dev for this BDF. */
     status = ucs_topo_add_device_locked(
-            bus_id, ucs_topo_global_ctx.devices[base_sys_dev].numa_node,
-            user_value, sys_dev);
+            bus_id, base_device->numa_node, user_value, sys_dev_p);
 
 out_unlock:
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
@@ -474,12 +490,18 @@ out_unlock:
 ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
                                         ucs_sys_bus_id_t *bus_id)
 {
-    if (sys_dev >= ucs_topo_global_ctx.num_devices) {
-        return UCS_ERR_NO_ELEM;
-    }
+    ucs_status_t status;
 
-    *bus_id = ucs_topo_global_ctx.devices[sys_dev].bus_id;
-    return UCS_OK;
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+    if (sys_dev >= ucs_topo_global_ctx.num_devices) {
+        status = UCS_ERR_NO_ELEM;
+    } else {
+        *bus_id = ucs_topo_global_ctx.devices[sys_dev].bus_id;
+        status  = UCS_OK;
+    }
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+
+    return status;
 }
 
 static ucs_status_t
@@ -1162,7 +1184,7 @@ uintptr_t ucs_topo_sys_device_get_user_value(ucs_sys_device_t sys_dev)
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
     if (sys_dev >= ucs_topo_global_ctx.num_devices) {
-        user_value = UINTPTR_MAX;
+        user_value = UCS_SYS_DEVICE_USER_VALUE_EMPTY;
     } else {
         user_value = ucs_topo_global_ctx.devices[sys_dev].user_value;
     }
@@ -1244,6 +1266,7 @@ void ucs_topo_restore_state(ucs_global_state_t *state)
                          ucs_topo_get_bus_id_bit_repr(&device->bus_id),
                          &kh_put_status);
         ucs_assert(kh_put_status != UCS_KH_PUT_FAILED);
+        /* Preserve the first sys_dev as the canonical BDF-only lookup. */
         if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
             (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
             kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) =

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -247,6 +247,13 @@ ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
             (bus_id->function));
 }
 
+static int ucs_topo_bus_id_equal(const ucs_sys_bus_id_t *bus_id1,
+                                 const ucs_sys_bus_id_t *bus_id2)
+{
+    return ucs_topo_get_bus_id_bit_repr(bus_id1) ==
+           ucs_topo_get_bus_id_bit_repr(bus_id2);
+}
+
 unsigned ucs_topo_num_devices()
 {
     unsigned num_devices;
@@ -325,6 +332,48 @@ out:
     return numa_node;
 }
 
+static ucs_status_t
+ucs_topo_add_device_locked(const ucs_sys_bus_id_t *bus_id,
+                           ucs_numa_node_t numa_node, uintptr_t user_value,
+                           ucs_sys_device_t *sys_dev)
+{
+    ucs_topo_sys_device_info_t *device;
+    char *name;
+
+    ucs_assert_always(ucs_topo_global_ctx.num_devices <
+                      UCS_TOPO_MAX_SYS_DEVICES);
+
+    name = ucs_malloc(UCS_SYS_BDF_NAME_MAX, "sys_dev_bdf_name");
+    if (name == NULL) {
+        ucs_error("failed to allocate memory for sys_dev_bdf_name");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ucs_topo_bus_id_str(bus_id, 1, name, UCS_SYS_BDF_NAME_MAX);
+
+    *sys_dev = ucs_topo_global_ctx.num_devices;
+    ++ucs_topo_global_ctx.num_devices;
+
+    device                  = &ucs_topo_global_ctx.devices[*sys_dev];
+    device->bus_id          = *bus_id;
+    device->name            = name;
+    device->name_priority   = 0;
+    device->numa_node       = numa_node;
+    device->user_value      = user_value;
+    device->sibling_role    = UCS_TOPO_SIBLING_ROLE_NONE;
+    device->sibling_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+    device->sys_dev_aux     = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+    if (user_value == UINTPTR_MAX) {
+        ucs_debug("added sys_dev %d for bus id %s", *sys_dev, name);
+    } else {
+        ucs_debug("added sys_dev %d for bus id %s with user value %" PRIuPTR,
+                  *sys_dev, name, user_value);
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                                             ucs_sys_device_t *sys_dev)
 {
@@ -332,7 +381,6 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
     int kh_put_status;
     khiter_t hash_it;
     ucs_status_t status;
-    char *name;
 
     bus_id_bit_rep  = ucs_topo_get_bus_id_bit_repr(bus_id);
 
@@ -347,39 +395,16 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
         status   = UCS_OK;
     } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
                (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
-        ucs_assert_always(ucs_topo_global_ctx.num_devices <
-                          UCS_TOPO_MAX_SYS_DEVICES);
-        *sys_dev = ucs_topo_global_ctx.num_devices;
-        ++ucs_topo_global_ctx.num_devices;
-
-        kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
-
-        /* Set default name to abbreviated BDF */
-        name = ucs_malloc(UCS_SYS_BDF_NAME_MAX, "sys_dev_bdf_name");
-        if (name == NULL) {
-            ucs_error("failed to allocate memory for sys_dev_bdf_name");
-            status = UCS_ERR_NO_MEMORY;
+        status = ucs_topo_add_device_locked(
+                bus_id, ucs_topo_read_device_numa_node(bus_id), UINTPTR_MAX,
+                sys_dev);
+        if (status != UCS_OK) {
             kh_del(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash,
                    hash_it);
             goto out;
         }
 
-        ucs_topo_bus_id_str(bus_id, 1, name, UCS_SYS_BDF_NAME_MAX);
-
-        ucs_topo_global_ctx.devices[*sys_dev].bus_id        = *bus_id;
-        ucs_topo_global_ctx.devices[*sys_dev].name          = name;
-        ucs_topo_global_ctx.devices[*sys_dev].name_priority = 0;
-        ucs_topo_global_ctx.devices[*sys_dev].numa_node     =
-                ucs_topo_read_device_numa_node(bus_id);
-        ucs_topo_global_ctx.devices[*sys_dev].user_value    = UINTPTR_MAX;
-        ucs_topo_global_ctx.devices[*sys_dev].sibling_role =
-                UCS_TOPO_SIBLING_ROLE_NONE;
-        ucs_topo_global_ctx.devices[*sys_dev].sibling_sys_dev =
-                UCS_SYS_DEVICE_ID_UNKNOWN;
-        ucs_topo_global_ctx.devices[*sys_dev].sys_dev_aux =
-                UCS_SYS_DEVICE_ID_UNKNOWN;
-
-        ucs_debug("added sys_dev %d for bus id %s", *sys_dev, name);
+        kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = *sys_dev;
         status = UCS_OK;
     } else {
         ucs_error("failed to put key into hash table");
@@ -387,6 +412,61 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
     }
 
 out:
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+    return status;
+}
+
+ucs_status_t
+ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
+                                              uintptr_t user_value,
+                                              ucs_sys_device_t *sys_dev)
+{
+    ucs_sys_device_t base_sys_dev;
+    ucs_topo_sys_device_info_t *device;
+    ucs_status_t status;
+    ucs_sys_device_t dev;
+
+    if (user_value == UINTPTR_MAX) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = ucs_topo_find_device_by_bus_id(bus_id, &base_sys_dev);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+
+    device = &ucs_topo_global_ctx.devices[base_sys_dev];
+    if (device->user_value == UINTPTR_MAX) {
+        device->user_value = user_value;
+        *sys_dev           = base_sys_dev;
+        status             = UCS_OK;
+        goto out_unlock;
+    }
+
+    for (dev = 0; dev < ucs_topo_global_ctx.num_devices; ++dev) {
+        device = &ucs_topo_global_ctx.devices[dev];
+        if (!ucs_topo_bus_id_equal(&device->bus_id, bus_id)) {
+            continue;
+        }
+
+        ucs_assertv_always(device->user_value != UINTPTR_MAX,
+                           "sys_dev %u for bus id has no user value",
+                           dev);
+
+        if (device->user_value == user_value) {
+            *sys_dev = dev;
+            status   = UCS_OK;
+            goto out_unlock;
+        }
+    }
+
+    status = ucs_topo_add_device_locked(
+            bus_id, ucs_topo_global_ctx.devices[base_sys_dev].numa_node,
+            user_value, sys_dev);
+
+out_unlock:
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
     return status;
 }
@@ -1163,9 +1243,12 @@ void ucs_topo_restore_state(ucs_global_state_t *state)
                          &ucs_topo_global_ctx.bus_to_sys_dev_hash,
                          ucs_topo_get_bus_id_bit_repr(&device->bus_id),
                          &kh_put_status);
-        ucs_assert((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
-                   (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR));
-        kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = sys_dev;
+        ucs_assert(kh_put_status != UCS_KH_PUT_FAILED);
+        if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
+            (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
+            kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) =
+                    sys_dev;
+        }
     }
 
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -68,13 +68,34 @@ typedef struct {
     ucs_sys_device_t        sibling_sys_dev;
 } ucs_topo_sys_device_info_t;
 
-KHASH_MAP_INIT_INT64(bus_to_sys_dev, ucs_sys_device_t);
+typedef struct {
+    ucs_bus_id_bit_rep_t    bus_id_bit_rep;
+    uintptr_t               user_value;
+} ucs_topo_bus_value_key_t;
+
+static inline int
+ucs_topo_bus_value_key_equal(ucs_topo_bus_value_key_t key1,
+                             ucs_topo_bus_value_key_t key2)
+{
+    return (key1.bus_id_bit_rep == key2.bus_id_bit_rep) &&
+           (key1.user_value == key2.user_value);
+}
+
+static inline khint32_t
+ucs_topo_bus_value_key_hash(ucs_topo_bus_value_key_t key)
+{
+    return kh_int64_hash_func((uint64_t)key.bus_id_bit_rep ^
+                              (uint64_t)key.user_value);
+}
+
+KHASH_INIT(bus_to_sys_dev, ucs_topo_bus_value_key_t, ucs_sys_device_t, 1,
+           ucs_topo_bus_value_key_hash, ucs_topo_bus_value_key_equal);
 
 typedef struct ucs_topo_global_ctx {
-    ucs_spinlock_t             lock;
-    khash_t(bus_to_sys_dev)    bus_to_sys_dev_hash;
-    ucs_topo_sys_device_info_t devices[UCS_TOPO_MAX_SYS_DEVICES];
-    unsigned                   num_devices;
+    ucs_spinlock_t                   lock;
+    khash_t(bus_to_sys_dev)          bus_to_sys_dev_hash;
+    ucs_topo_sys_device_info_t       devices[UCS_TOPO_MAX_SYS_DEVICES];
+    unsigned                         num_devices;
 } ucs_topo_global_ctx_t;
 
 
@@ -247,11 +268,16 @@ ucs_topo_get_bus_id_bit_repr(const ucs_sys_bus_id_t *bus_id)
             (bus_id->function));
 }
 
-static int ucs_topo_bus_id_equal(const ucs_sys_bus_id_t *bus_id1,
-                                 const ucs_sys_bus_id_t *bus_id2)
+static ucs_topo_bus_value_key_t
+ucs_topo_bus_value_key_make(const ucs_sys_bus_id_t *bus_id,
+                            uintptr_t user_value)
 {
-    return ucs_topo_get_bus_id_bit_repr(bus_id1) ==
-           ucs_topo_get_bus_id_bit_repr(bus_id2);
+    ucs_topo_bus_value_key_t key;
+
+    key.bus_id_bit_rep = ucs_topo_get_bus_id_bit_repr(bus_id);
+    key.user_value     = user_value;
+
+    return key;
 }
 
 unsigned ucs_topo_num_devices()
@@ -333,79 +359,99 @@ out:
 }
 
 static ucs_status_t
-ucs_topo_add_device_locked(const ucs_sys_bus_id_t *bus_id,
-                           ucs_numa_node_t numa_node, uintptr_t user_value,
-                           ucs_sys_device_t *sys_dev)
+ucs_topo_bus_value_hash_add_nolock(const ucs_sys_bus_id_t *bus_id,
+                                   uintptr_t user_value,
+                                   ucs_sys_device_t sys_dev)
 {
-    ucs_topo_sys_device_info_t *device;
-    char *name;
+    ucs_topo_bus_value_key_t key;
+    int kh_put_status;
+    khiter_t hash_it;
 
-    ucs_assert_always(ucs_topo_global_ctx.num_devices <
-                      UCS_TOPO_MAX_SYS_DEVICES);
-
-    name = ucs_malloc(UCS_SYS_BDF_NAME_MAX, "sys_dev_bdf_name");
-    if (name == NULL) {
-        ucs_error("failed to allocate memory for sys_dev_bdf_name");
-        return UCS_ERR_NO_MEMORY;
+    key     = ucs_topo_bus_value_key_make(bus_id, user_value);
+    hash_it = kh_put(bus_to_sys_dev,
+                     &ucs_topo_global_ctx.bus_to_sys_dev_hash, key,
+                     &kh_put_status);
+    if (kh_put_status == UCS_KH_PUT_FAILED) {
+        ucs_error("failed to put key into hash table");
+        return UCS_ERR_IO_ERROR;
     }
 
-    ucs_topo_bus_id_str(bus_id, 1, name, UCS_SYS_BDF_NAME_MAX);
+    if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
+        if (kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) !=
+            sys_dev) {
+            ucs_error("user value %" PRIuPTR " for bus id 0x%" PRIx64
+                      " already exists", user_value,
+                      (uint64_t)key.bus_id_bit_rep);
+            return UCS_ERR_ALREADY_EXISTS;
+        }
 
-    *sys_dev = ucs_topo_global_ctx.num_devices;
-    ++ucs_topo_global_ctx.num_devices;
-
-    device                  = &ucs_topo_global_ctx.devices[*sys_dev];
-    device->bus_id          = *bus_id;
-    device->name            = name;
-    device->name_priority   = 0;
-    device->numa_node       = numa_node;
-    device->user_value      = user_value;
-    device->sibling_role    = UCS_TOPO_SIBLING_ROLE_NONE;
-    device->sibling_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-    device->sys_dev_aux     = UCS_SYS_DEVICE_ID_UNKNOWN;
-
-    if (user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
-        ucs_debug("added sys_dev %d for bus id %s", *sys_dev, name);
-    } else {
-        ucs_debug("added sys_dev %d for bus id %s with user value %" PRIuPTR,
-                  *sys_dev, name, user_value);
+        return UCS_OK;
     }
 
+    kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) = sys_dev;
     return UCS_OK;
 }
 
 static ucs_status_t
-ucs_topo_find_device_by_bus_id_locked(const ucs_sys_bus_id_t *bus_id,
-                                      ucs_sys_device_t *sys_dev_p)
+ucs_topo_find_device_by_bus_id_value_nolock(const ucs_sys_bus_id_t *bus_id,
+                                            const ucs_numa_node_t *numa_node_p,
+                                            uintptr_t user_value,
+                                            ucs_sys_device_t *sys_dev_p)
 {
-    ucs_bus_id_bit_rep_t bus_id_bit_rep;
+    ucs_topo_sys_device_info_t *device;
+    ucs_topo_bus_value_key_t key;
+    ucs_numa_node_t numa_node;
     int kh_put_status;
     khiter_t hash_it;
     ucs_status_t status;
+    char *name;
 
-    bus_id_bit_rep = ucs_topo_get_bus_id_bit_repr(bus_id);
-
-    hash_it = kh_put(
-            bus_to_sys_dev /*name*/,
-            &ucs_topo_global_ctx.bus_to_sys_dev_hash /*pointer to hashmap*/,
-            bus_id_bit_rep /*key*/, &kh_put_status);
+    key     = ucs_topo_bus_value_key_make(bus_id, user_value);
+    hash_it = kh_put(bus_to_sys_dev,
+                     &ucs_topo_global_ctx.bus_to_sys_dev_hash, key,
+                     &kh_put_status);
 
     if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
-        *sys_dev_p = kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash,
-                              hash_it);
+        *sys_dev_p = kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it);
         status     = UCS_OK;
     } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
                (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
-        status = ucs_topo_add_device_locked(
-                bus_id, ucs_topo_read_device_numa_node(bus_id),
-                UCS_SYS_DEVICE_USER_VALUE_EMPTY, sys_dev_p);
-        if (status != UCS_OK) {
-            kh_del(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash,
-                   hash_it);
-            return status;
+        ucs_assert_always(ucs_topo_global_ctx.num_devices <
+                          UCS_TOPO_MAX_SYS_DEVICES);
+
+        name = ucs_malloc(UCS_SYS_BDF_NAME_MAX, "sys_dev_bdf_name");
+        if (name == NULL) {
+            ucs_error("failed to allocate memory for sys_dev_bdf_name");
+            kh_del(bus_to_sys_dev,
+                   &ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it);
+            return UCS_ERR_NO_MEMORY;
         }
 
-        kh_value(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) =
+        ucs_topo_bus_id_str(bus_id, 1, name, UCS_SYS_BDF_NAME_MAX);
+
+        numa_node = (numa_node_p == NULL) ?
+                    ucs_topo_read_device_numa_node(bus_id) : *numa_node_p;
+
+        *sys_dev_p = ucs_topo_global_ctx.num_devices++;
+        device     = &ucs_topo_global_ctx.devices[*sys_dev_p];
+
+        device->bus_id          = *bus_id;
+        device->name            = name;
+        device->name_priority   = 0;
+        device->numa_node       = numa_node;
+        device->user_value      = user_value;
+        device->sibling_role    = UCS_TOPO_SIBLING_ROLE_NONE;
+        device->sibling_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+        device->sys_dev_aux     = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+        if (user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
+            ucs_debug("added sys_dev %d for bus id %s", *sys_dev_p, name);
+        } else {
+            ucs_debug("added sys_dev %d for bus id %s with user value %"
+                      PRIuPTR, *sys_dev_p, name, user_value);
+        }
+
+        kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) =
                 *sys_dev_p;
         status = UCS_OK;
     } else {
@@ -422,7 +468,8 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
     ucs_status_t status;
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
-    status = ucs_topo_find_device_by_bus_id_locked(bus_id, sys_dev);
+    status = ucs_topo_find_device_by_bus_id_value_nolock(
+            bus_id, NULL, UCS_SYS_DEVICE_USER_VALUE_EMPTY, sys_dev);
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
 
     return status;
@@ -433,9 +480,6 @@ ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
                                               uintptr_t user_value,
                                               ucs_sys_device_t *sys_dev_p)
 {
-    ucs_topo_sys_device_info_t *base_device;
-    ucs_sys_device_t base_sys_dev, sys_dev;
-    ucs_topo_sys_device_info_t *device;
     ucs_status_t status;
 
     if (user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
@@ -444,46 +488,10 @@ ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
     }
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
-
-    /* Keep the BDF hash as the canonical BDF-only lookup. */
-    status = ucs_topo_find_device_by_bus_id_locked(bus_id, &base_sys_dev);
-    if (status != UCS_OK) {
-        goto out_unlock;
-    }
-
-    base_device = &ucs_topo_global_ctx.devices[base_sys_dev];
-    if (base_device->user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
-        /* First logical device for this BDF reuses the canonical sys_dev. */
-        base_device->user_value = user_value;
-        *sys_dev_p              = base_sys_dev;
-        status                  = UCS_OK;
-        goto out_unlock;
-    }
-
-    /* Find a previous duplicate-BDF sys_dev with the same user value. */
-    for (sys_dev = 0; sys_dev < ucs_topo_global_ctx.num_devices; ++sys_dev) {
-        device = &ucs_topo_global_ctx.devices[sys_dev];
-        if (!ucs_topo_bus_id_equal(&device->bus_id, bus_id)) {
-            continue;
-        }
-
-        ucs_assertv_always(
-                device->user_value != UCS_SYS_DEVICE_USER_VALUE_EMPTY,
-                "sys_dev %u has no user value", sys_dev);
-
-        if (device->user_value == user_value) {
-            *sys_dev_p = sys_dev;
-            status     = UCS_OK;
-            goto out_unlock;
-        }
-    }
-
-    /* No matching user value exists, so add another sys_dev for this BDF. */
-    status = ucs_topo_add_device_locked(
-            bus_id, base_device->numa_node, user_value, sys_dev_p);
-
-out_unlock:
+    status = ucs_topo_find_device_by_bus_id_value_nolock(
+            bus_id, NULL, user_value, sys_dev_p);
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+
     return status;
 }
 
@@ -1161,23 +1169,6 @@ int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev)
     return result;
 }
 
-ucs_status_t
-ucs_topo_sys_device_set_user_value(ucs_sys_device_t sys_dev, uintptr_t value)
-{
-    ucs_spin_lock(&ucs_topo_global_ctx.lock);
-    if (sys_dev >= ucs_topo_global_ctx.num_devices) {
-        ucs_error("system device %d is invalid (max: %d)", sys_dev,
-                  ucs_topo_global_ctx.num_devices);
-        ucs_spin_unlock(&ucs_topo_global_ctx.lock);
-        return UCS_ERR_INVALID_PARAM;
-    }
-
-    ucs_topo_global_ctx.devices[sys_dev].user_value = value;
-    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
-
-    return UCS_OK;
-}
-
 uintptr_t ucs_topo_sys_device_get_user_value(ucs_sys_device_t sys_dev)
 {
     uintptr_t user_value;
@@ -1246,8 +1237,7 @@ void ucs_topo_restore_state(ucs_global_state_t *state)
 {
     const ucs_topo_sys_device_info_t *device;
     ucs_sys_device_t sys_dev;
-    int kh_put_status;
-    khiter_t hash_it;
+    ucs_status_t status;
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
 
@@ -1260,18 +1250,12 @@ void ucs_topo_restore_state(ucs_global_state_t *state)
     /* Create the hash table */
     kh_clear(bus_to_sys_dev, &ucs_topo_global_ctx.bus_to_sys_dev_hash);
     for (sys_dev = 0; sys_dev < ucs_topo_global_ctx.num_devices; ++sys_dev) {
-        device  = &ucs_topo_global_ctx.devices[sys_dev];
-        hash_it = kh_put(bus_to_sys_dev,
-                         &ucs_topo_global_ctx.bus_to_sys_dev_hash,
-                         ucs_topo_get_bus_id_bit_repr(&device->bus_id),
-                         &kh_put_status);
-        ucs_assert(kh_put_status != UCS_KH_PUT_FAILED);
-        /* Preserve the first sys_dev as the canonical BDF-only lookup. */
-        if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
-            (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
-            kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) =
-                    sys_dev;
-        }
+        device = &ucs_topo_global_ctx.devices[sys_dev];
+
+        status = ucs_topo_bus_value_hash_add_nolock(&device->bus_id,
+                                                    device->user_value,
+                                                    sys_dev);
+        ucs_assert(status == UCS_OK);
     }
 
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -364,6 +364,7 @@ ucs_topo_bus_value_hash_add_nolock(const ucs_sys_bus_id_t *bus_id,
                                    ucs_sys_device_t sys_dev)
 {
     ucs_topo_bus_value_key_t key;
+    ucs_sys_device_t existing_sys_dev;
     int kh_put_status;
     khiter_t hash_it;
 
@@ -377,11 +378,13 @@ ucs_topo_bus_value_hash_add_nolock(const ucs_sys_bus_id_t *bus_id,
     }
 
     if (kh_put_status == UCS_KH_PUT_KEY_PRESENT) {
-        if (kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it) !=
-            sys_dev) {
+        existing_sys_dev = kh_val(&ucs_topo_global_ctx.bus_to_sys_dev_hash,
+                                  hash_it);
+        if (existing_sys_dev != sys_dev) {
             ucs_error("user value %" PRIuPTR " for bus id 0x%" PRIx64
-                      " already exists", user_value,
-                      (uint64_t)key.bus_id_bit_rep);
+                      " maps to sys_dev %u, not sys_dev %u", user_value,
+                      (uint64_t)key.bus_id_bit_rep, existing_sys_dev,
+                      sys_dev);
             return UCS_ERR_ALREADY_EXISTS;
         }
 
@@ -393,10 +396,10 @@ ucs_topo_bus_value_hash_add_nolock(const ucs_sys_bus_id_t *bus_id,
 }
 
 static ucs_status_t
-ucs_topo_find_device_by_bus_id_value_nolock(const ucs_sys_bus_id_t *bus_id,
-                                            const ucs_numa_node_t *numa_node_p,
-                                            uintptr_t user_value,
-                                            ucs_sys_device_t *sys_dev_p)
+ucs_topo_find_device_by_bus_id_value(const ucs_sys_bus_id_t *bus_id,
+                                     const ucs_numa_node_t *numa_node_p,
+                                     uintptr_t user_value,
+                                     ucs_sys_device_t *sys_dev_p)
 {
     ucs_topo_sys_device_info_t *device;
     ucs_topo_bus_value_key_t key;
@@ -405,6 +408,8 @@ ucs_topo_find_device_by_bus_id_value_nolock(const ucs_sys_bus_id_t *bus_id,
     khiter_t hash_it;
     ucs_status_t status;
     char *name;
+
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
 
     key     = ucs_topo_bus_value_key_make(bus_id, user_value);
     hash_it = kh_put(bus_to_sys_dev,
@@ -424,7 +429,8 @@ ucs_topo_find_device_by_bus_id_value_nolock(const ucs_sys_bus_id_t *bus_id,
             ucs_error("failed to allocate memory for sys_dev_bdf_name");
             kh_del(bus_to_sys_dev,
                    &ucs_topo_global_ctx.bus_to_sys_dev_hash, hash_it);
-            return UCS_ERR_NO_MEMORY;
+            status = UCS_ERR_NO_MEMORY;
+            goto out_unlock;
         }
 
         ucs_topo_bus_id_str(bus_id, 1, name, UCS_SYS_BDF_NAME_MAX);
@@ -459,6 +465,8 @@ ucs_topo_find_device_by_bus_id_value_nolock(const ucs_sys_bus_id_t *bus_id,
         status = UCS_ERR_IO_ERROR;
     }
 
+out_unlock:
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
     return status;
 }
 
@@ -467,10 +475,8 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 {
     ucs_status_t status;
 
-    ucs_spin_lock(&ucs_topo_global_ctx.lock);
-    status = ucs_topo_find_device_by_bus_id_value_nolock(
+    status = ucs_topo_find_device_by_bus_id_value(
             bus_id, NULL, UCS_SYS_DEVICE_USER_VALUE_EMPTY, sys_dev);
-    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
 
     return status;
 }
@@ -487,10 +493,8 @@ ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    ucs_spin_lock(&ucs_topo_global_ctx.lock);
-    status = ucs_topo_find_device_by_bus_id_value_nolock(
-            bus_id, NULL, user_value, sys_dev_p);
-    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+    status = ucs_topo_find_device_by_bus_id_value(bus_id, NULL, user_value,
+                                                  sys_dev_p);
 
     return status;
 }
@@ -500,6 +504,7 @@ ucs_status_t ucs_topo_get_device_bus_id(ucs_sys_device_t sys_dev,
 {
     ucs_status_t status;
 
+    /* Read num_devices and device entry under the topology update lock. */
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
     if (sys_dev >= ucs_topo_global_ctx.num_devices) {
         status = UCS_ERR_NO_ELEM;

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -398,7 +398,6 @@ ucs_topo_bus_value_hash_add_nolock(const ucs_sys_bus_id_t *bus_id,
 
 static ucs_status_t
 ucs_topo_find_device_by_bus_id_value(const ucs_sys_bus_id_t *bus_id,
-                                     const ucs_numa_node_t *numa_node_p,
                                      uintptr_t user_value,
                                      ucs_sys_device_t *sys_dev_p)
 {
@@ -436,8 +435,7 @@ ucs_topo_find_device_by_bus_id_value(const ucs_sys_bus_id_t *bus_id,
 
         ucs_topo_bus_id_str(bus_id, 1, name, UCS_SYS_BDF_NAME_MAX);
 
-        numa_node = (numa_node_p == NULL) ?
-                    ucs_topo_read_device_numa_node(bus_id) : *numa_node_p;
+        numa_node = ucs_topo_read_device_numa_node(bus_id);
 
         *sys_dev_p = ucs_topo_global_ctx.num_devices++;
         device     = &ucs_topo_global_ctx.devices[*sys_dev_p];
@@ -477,7 +475,7 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
     ucs_status_t status;
 
     status = ucs_topo_find_device_by_bus_id_value(
-            bus_id, NULL, UCS_SYS_DEVICE_USER_VALUE_EMPTY, sys_dev);
+            bus_id, UCS_SYS_DEVICE_USER_VALUE_EMPTY, sys_dev);
 
     return status;
 }
@@ -494,7 +492,7 @@ ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
         return UCS_ERR_INVALID_PARAM;
     }
 
-    status = ucs_topo_find_device_by_bus_id_value(bus_id, NULL, user_value,
+    status = ucs_topo_find_device_by_bus_id_value(bus_id, user_value,
                                                   sys_dev_p);
 
     return status;
@@ -725,18 +723,22 @@ ucs_topo_is_reachable(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
     result =
+            (sys_dev >= ucs_topo_global_ctx.num_devices) ||
+            (sys_dev_mem >= ucs_topo_global_ctx.num_devices) ||
             /*
              * Memory device was never matched with a sibling, it does not
-             * mandate and auxiliary path.
+             * mandate an auxiliary path.
              */
             (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
              UCS_SYS_DEVICE_ID_UNKNOWN) ||
             /* The device itself never uses auxiliary path */
             (ucs_topo_global_ctx.devices[sys_dev].sibling_role !=
              UCS_TOPO_SIBLING_ROLE_DEV) ||
-            /* The device and memory device identified each other as siblings */
-            (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev ==
-             sys_dev_mem) ||
+            /*
+             * MPS MLOParts create multiple MEM aliases for one DEV. Each MEM
+             * alias records its matched DEV; the DEV stores only one
+             * representative MEM sibling.
+             */
             (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
              sys_dev);
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
@@ -755,10 +757,12 @@ int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
                  (sys_dev < ucs_topo_global_ctx.num_devices) &&
                  (sys_dev_mem != UCS_SYS_DEVICE_ID_UNKNOWN) &&
                  (sys_dev_mem < ucs_topo_global_ctx.num_devices) &&
-                 ((ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev ==
-                   sys_dev_mem) ||
-                  (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
-                   sys_dev));
+                 (ucs_topo_global_ctx.devices[sys_dev].sibling_role ==
+                  UCS_TOPO_SIBLING_ROLE_DEV) &&
+                 (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_role ==
+                  UCS_TOPO_SIBLING_ROLE_MEM) &&
+                 (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
+                  sys_dev);
 
     if (is_sibling) {
         role_dev     = ucs_topo_global_ctx.devices[sys_dev].sibling_role;

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -65,6 +65,7 @@ typedef struct {
     ucs_sys_device_t        sys_dev_aux;
 
     ucs_topo_sibling_role_t sibling_role; /* Role of the current device */
+    /* MEM role: matched DEV. DEV role: one representative matched MEM. */
     ucs_sys_device_t        sibling_sys_dev;
 } ucs_topo_sys_device_info_t;
 
@@ -733,9 +734,11 @@ ucs_topo_is_reachable(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
             /* The device itself never uses auxiliary path */
             (ucs_topo_global_ctx.devices[sys_dev].sibling_role !=
              UCS_TOPO_SIBLING_ROLE_DEV) ||
-            /* The device is the identified sibling */
+            /* The device and memory device identified each other as siblings */
             (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev ==
-             sys_dev_mem);
+             sys_dev_mem) ||
+            (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
+             sys_dev);
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
 
     return result;
@@ -748,10 +751,14 @@ int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
     ucs_topo_sibling_role_t UCS_V_UNUSED role_dev_mem;
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
-    is_sibling = (sys_dev < ucs_topo_global_ctx.num_devices) &&
+    is_sibling = (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+                 (sys_dev < ucs_topo_global_ctx.num_devices) &&
                  (sys_dev_mem != UCS_SYS_DEVICE_ID_UNKNOWN) &&
-                 (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev ==
-                  sys_dev_mem);
+                 (sys_dev_mem < ucs_topo_global_ctx.num_devices) &&
+                 ((ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev ==
+                   sys_dev_mem) ||
+                  (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
+                   sys_dev));
 
     if (is_sibling) {
         role_dev     = ucs_topo_global_ctx.devices[sys_dev].sibling_role;
@@ -1147,11 +1154,9 @@ ucs_status_t ucs_topo_sys_device_set_sys_dev_aux(ucs_sys_device_t sys_dev,
     ucs_topo_global_ctx.devices[sys_dev].sibling_role =
             UCS_TOPO_SIBLING_ROLE_DEV;
 
-    /* Try to match the device with a sibling */
+    /* Try to match the device with all existing memory aliases. */
     for (dev = 0; dev < ucs_topo_global_ctx.num_devices; ++dev) {
-        if (ucs_topo_sys_device_sibling_match(sys_dev, dev)) {
-            break;
-        }
+        ucs_topo_sys_device_sibling_match(sys_dev, dev);
     }
 
     status = UCS_OK;

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -757,19 +757,19 @@ int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
                  (sys_dev < ucs_topo_global_ctx.num_devices) &&
                  (sys_dev_mem != UCS_SYS_DEVICE_ID_UNKNOWN) &&
                  (sys_dev_mem < ucs_topo_global_ctx.num_devices) &&
-                 (ucs_topo_global_ctx.devices[sys_dev].sibling_role ==
-                  UCS_TOPO_SIBLING_ROLE_DEV) &&
-                 (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_role ==
-                  UCS_TOPO_SIBLING_ROLE_MEM) &&
+                 /*
+                  * MLOPart allows multiple MEM devices to point at one DEV, so
+                  * the MEM-side sibling is the canonical relationship.
+                  */
                  (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
                   sys_dev);
 
     if (is_sibling) {
         role_dev     = ucs_topo_global_ctx.devices[sys_dev].sibling_role;
         role_dev_mem = ucs_topo_global_ctx.devices[sys_dev_mem].sibling_role;
-        ucs_assertv((role_dev != UCS_TOPO_SIBLING_ROLE_NONE) &&
-                    (role_dev_mem != UCS_TOPO_SIBLING_ROLE_NONE) &&
-                    (role_dev != role_dev_mem), "sys_dev=%u sys_dev_mem=%u"
+        ucs_assertv((role_dev == UCS_TOPO_SIBLING_ROLE_DEV) &&
+                    (role_dev_mem == UCS_TOPO_SIBLING_ROLE_MEM),
+                    "sys_dev=%u sys_dev_mem=%u"
                     " sys_dev_role=%d sys_dev_mem_role=%d",
                     sys_dev, sys_dev_mem, role_dev, role_dev_mem);
     }

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -165,6 +165,27 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
 
 
 /**
+ * Find system device by pci bus id and user-defined value.
+ *
+ * This is used for logical devices which share the same PCI bus id but still
+ * need different system device indexes. If an existing system device with the
+ * same bus id and user value exists, it is returned. Otherwise, if the
+ * canonical system device for this bus id has no user value, it is claimed; if
+ * not, a new system device with the same bus id is created.
+ *
+ * @param [in]  bus_id      pointer to bus id of the device of interest.
+ * @param [in]  user_value  user-defined value identifying the logical device.
+ * @param [out] sys_dev     system device index associated with the value.
+ *
+ * @return UCS_OK or error in case device cannot be found.
+ */
+ucs_status_t
+ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
+                                              uintptr_t user_value,
+                                              ucs_sys_device_t *sys_dev);
+
+
+/**
  * Find pci bus id of the given system device.
  *
  * @param [in]  sys_dev system device index.

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -25,6 +25,9 @@ BEGIN_C_DECLS
  * e.g. virtual devices like CMA/knem */
 #define UCS_SYS_DEVICE_ID_UNKNOWN UINT8_MAX
 
+/* User-defined system device value is not set */
+#define UCS_SYS_DEVICE_USER_VALUE_EMPTY UINTPTR_MAX
+
 /* Maximal size of BDF string */
 #define UCS_SYS_BDF_NAME_MAX 16
 
@@ -170,19 +173,20 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
  * This is used for logical devices which share the same PCI bus id but still
  * need different system device indexes. If an existing system device with the
  * same bus id and user value exists, it is returned. Otherwise, if the
- * canonical system device for this bus id has no user value, it is claimed; if
- * not, a new system device with the same bus id is created.
+ * canonical system device for this bus id has no user value, the requested user
+ * value is assigned to it and it is returned; if not, a new system device with
+ * the same bus id is created.
  *
  * @param [in]  bus_id      pointer to bus id of the device of interest.
  * @param [in]  user_value  user-defined value identifying the logical device.
- * @param [out] sys_dev     system device index associated with the value.
+ * @param [out] sys_dev_p   system device index associated with the value.
  *
  * @return UCS_OK or error in case device cannot be found.
  */
 ucs_status_t
 ucs_topo_find_device_by_bus_id_and_user_value(const ucs_sys_bus_id_t *bus_id,
                                               uintptr_t user_value,
-                                              ucs_sys_device_t *sys_dev);
+                                              ucs_sys_device_t *sys_dev_p);
 
 
 /**
@@ -404,8 +408,8 @@ ucs_topo_sys_device_set_user_value(ucs_sys_device_t sys_dev, uintptr_t value);
  *
  * @param [in] sys_dev System device index.
  *
- * @return User-defined value, or UINTPTR_MAX if no value is set or the device
- *         does not exist.
+ * @return User-defined value, or UCS_SYS_DEVICE_USER_VALUE_EMPTY if no value is
+ *         set or the device does not exist.
  */
 uintptr_t ucs_topo_sys_device_get_user_value(ucs_sys_device_t sys_dev);
 

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -171,11 +171,10 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
  * Find system device by pci bus id and user-defined value.
  *
  * This is used for logical devices which share the same PCI bus id but still
- * need different system device indexes. If an existing system device with the
- * same bus id and user value exists, it is returned. Otherwise, if the
- * canonical system device for this bus id has no user value, the requested user
- * value is assigned to it and it is returned; if not, a new system device with
- * the same bus id is created.
+ * need different system device indexes. The lookup key is a combination of the
+ * bus id and the user value. BDF-only lookup uses an implicit empty user value.
+ * If an existing system device with the same bus id and user value exists, it is
+ * returned. Otherwise, a system device for this key is registered and returned.
  *
  * @param [in]  bus_id      pointer to bus id of the device of interest.
  * @param [in]  user_value  user-defined value identifying the logical device.
@@ -389,18 +388,6 @@ ucs_numa_node_t ucs_topo_sys_device_get_numa_node(ucs_sys_device_t sys_dev);
  */
 ucs_status_t ucs_topo_sys_device_set_numa_node(ucs_sys_device_t sys_dev,
                                                ucs_numa_node_t numa_node);
-
-
-/**
- * Set a user-defined value for a given system device.
- *
- * @param [in] sys_dev System device index.
- * @param [in] value   User-defined value to set.
- *
- * @return UCS_OK on success, error otherwise.
- */
-ucs_status_t
-ucs_topo_sys_device_set_user_value(ucs_sys_device_t sys_dev, uintptr_t value);
 
 
 /**

--- a/src/uct/cuda/base/cuda_util.c
+++ b/src/uct/cuda/base/cuda_util.c
@@ -61,12 +61,8 @@ ucs_sys_device_t uct_cuda_get_sys_dev(CUdevice cuda_device)
     /* Function - always 0 */
     bus_id.function = 0;
 
-    status = ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev);
-    if (status != UCS_OK) {
-        goto err;
-    }
-
-    status = ucs_topo_sys_device_set_user_value(sys_dev, cuda_device);
+    status = ucs_topo_find_device_by_bus_id_and_user_value(
+            &bus_id, (uintptr_t)cuda_device, &sys_dev);
     if (status != UCS_OK) {
         goto err;
     }

--- a/src/uct/cuda/base/cuda_util.c
+++ b/src/uct/cuda/base/cuda_util.c
@@ -83,7 +83,7 @@ CUdevice uct_cuda_get_cuda_device(ucs_sys_device_t sys_dev)
     uintptr_t user_value;
 
     user_value = ucs_topo_sys_device_get_user_value(sys_dev);
-    if (user_value == UINTPTR_MAX) {
+    if (user_value == UCS_SYS_DEVICE_USER_VALUE_EMPTY) {
         return CU_DEVICE_INVALID;
     }
 

--- a/src/uct/gaudi/base/gaudi_base.c
+++ b/src/uct/gaudi/base/gaudi_base.c
@@ -169,7 +169,7 @@ uct_gaudi_base_configure_sys_device_from_fd(int fd, int index,
     struct hlthunk_hw_ip_info hw_ip;
     const unsigned sys_device_priority = 10;
     char device_name[16];
-    int rc;
+    int hw_ip_rc;
 
     ucs_assert(fd >= 0);
 
@@ -179,9 +179,9 @@ uct_gaudi_base_configure_sys_device_from_fd(int fd, int index,
     }
 
     memset(&hw_ip, 0, sizeof(hw_ip));
-    rc = hlthunk_get_hw_ip_info(fd, &hw_ip);
-    if (rc) {
-        ucs_debug("failed to get hw_ip info for fd %d (rc=%d)", fd, rc);
+    hw_ip_rc = hlthunk_get_hw_ip_info(fd, &hw_ip);
+    if (hw_ip_rc) {
+        ucs_debug("failed to get hw_ip info for fd %d (rc=%d)", fd, hw_ip_rc);
     }
 
     ucs_snprintf_safe(device_name, sizeof(device_name), "GAUDI_%d", index);
@@ -198,7 +198,7 @@ uct_gaudi_base_configure_sys_device_from_fd(int fd, int index,
                   ucs_status_string(status));
     }
 
-    if (rc == 0) {
+    if (hw_ip_rc == 0) {
         ucs_debug("registered %s (sys_dev %d module_id %u)", device_name,
                   *sys_dev_p, hw_ip.module_id);
     } else {

--- a/src/uct/gaudi/base/gaudi_base.c
+++ b/src/uct/gaudi/base/gaudi_base.c
@@ -181,15 +181,7 @@ uct_gaudi_base_configure_sys_device_from_fd(int fd, int index,
     memset(&hw_ip, 0, sizeof(hw_ip));
     rc = hlthunk_get_hw_ip_info(fd, &hw_ip);
     if (rc) {
-        ucs_error("failed to get hw_ip info for fd %d (rc=%d)", fd, rc);
-        goto err;
-    }
-
-    status = ucs_topo_sys_device_set_user_value(*sys_dev_p, hw_ip.module_id);
-    if (status != UCS_OK) {
-        ucs_error("failed to set user value %u for sys_dev %d", hw_ip.module_id,
-                  *sys_dev_p);
-        goto err;
+        ucs_debug("failed to get hw_ip info for fd %d (rc=%d)", fd, rc);
     }
 
     ucs_snprintf_safe(device_name, sizeof(device_name), "GAUDI_%d", index);
@@ -206,7 +198,12 @@ uct_gaudi_base_configure_sys_device_from_fd(int fd, int index,
                   ucs_status_string(status));
     }
 
-    ucs_debug("registered %s (sys_dev %d)", device_name, *sys_dev_p);
+    if (rc == 0) {
+        ucs_debug("registered %s (sys_dev %d module_id %u)", device_name,
+                  *sys_dev_p, hw_ip.module_id);
+    } else {
+        ucs_debug("registered %s (sys_dev %d)", device_name, *sys_dev_p);
+    }
 
     return;
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -11,6 +11,7 @@
 #include "gdaki.h"
 
 #include <ucs/sys/sock.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <ucs/time/time.h>
 #include <ucs/datastruct/string_buffer.h>
 #include <ucs/algorithm/qsort_r.h>
@@ -1240,8 +1241,26 @@ typedef struct {
 
 typedef struct {
     ucs_sys_device_t sys_dev;
+    ucs_sys_bus_id_t bus_id;
     int              cuda_idx; /* CUDA driver index, -1 if not CUDA-visible */
 } uct_gdaki_gpu_info_t;
+
+static int
+uct_gdaki_gpu_bus_id_match(const uct_gdaki_gpu_info_t *gpus, unsigned count,
+                           const ucs_sys_bus_id_t *bus_id)
+{
+    ucs_bus_id_bit_rep_t bus_id_key = ucs_topo_get_bus_id_bit_repr(bus_id);
+    unsigned gpu_idx;
+
+    for (gpu_idx = 0; gpu_idx < count; gpu_idx++) {
+        if (bus_id_key ==
+            ucs_topo_get_bus_id_bit_repr(&gpus[gpu_idx].bus_id)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
 
 static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
 {
@@ -1272,12 +1291,12 @@ uct_gdaki_get_cuda_sys_dev(int cuda_idx, ucs_sys_device_t *sys_dev_p)
 static ucs_status_t
 uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 {
-    unsigned nvml_dev_count, nvml_idx;
+    unsigned nvml_dev_count, nvml_idx, gpu_count;
     int cuda_dev_count, cuda_idx;
     ucs_sys_bus_id_t bus_id;
     nvmlDevice_t nvml_dev;
     nvmlPciInfo_t nvml_pci;
-    ucs_sys_device_t cuda_sys_dev;
+    ucs_sys_device_t sys_dev;
     ucs_status_t status;
 
     status = UCT_CUDADRV_FUNC_LOG_ERR(cuDeviceGetCount(&cuda_dev_count));
@@ -1287,25 +1306,39 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 
     ucs_assert_always(cuda_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
 
+    gpu_count = 0;
+    for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
+        status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &sys_dev);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        status = ucs_topo_get_device_bus_id(sys_dev, &bus_id);
+        if (status != UCS_OK) {
+            return status;
+        }
+
+        if (uct_gdaki_gpu_bus_id_match(gpus, gpu_count, &bus_id)) {
+            /* Same BDF. TODO: support MLOPart. */
+            continue;
+        }
+
+        gpus[gpu_count].sys_dev  = sys_dev;
+        gpus[gpu_count].bus_id   = bus_id;
+        gpus[gpu_count].cuda_idx = cuda_idx;
+        gpu_count++;
+    }
+
     status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetCount_v2, &nvml_dev_count);
     if (status != UCS_OK) {
         ucs_diag("NVML unavailable: using legacy CUDA-only enumeration");
-
-        for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
-            status = uct_gdaki_get_cuda_sys_dev(cuda_idx,
-                                                &gpus[cuda_idx].sys_dev);
-            if (status != UCS_OK) {
-                return status;
-            }
-
-            gpus[cuda_idx].cuda_idx = cuda_idx;
-        }
-
-        *count_p = cuda_dev_count;
+        *count_p = gpu_count;
         return UCS_OK;
     }
 
     ucs_assert_always(nvml_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
+
+    /* Add non-CUDA-visible devices from NVML. TODO: support MLOPart. */
     for (nvml_idx = 0; nvml_idx < nvml_dev_count; nvml_idx++) {
         status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, nvml_idx,
                                          &nvml_dev);
@@ -1324,31 +1357,29 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
         bus_id.slot     = nvml_pci.device;
         bus_id.function = 0;
 
-        status = ucs_topo_find_device_by_bus_id(&bus_id,
-                                                &gpus[nvml_idx].sys_dev);
+        if (uct_gdaki_gpu_bus_id_match(gpus, gpu_count, &bus_id)) {
+            /* Already added as CUDA-visible. */
+            continue;
+        }
+
+        status = ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev);
         if (status != UCS_OK) {
             return status;
         }
 
-        gpus[nvml_idx].cuda_idx = -1;
-    }
-
-    /* Map CUDA-visible devices back to their NVML entry via sys_dev. */
-    for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
-        status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &cuda_sys_dev);
-        if (status != UCS_OK) {
-            return status;
+        if (gpu_count == UCT_GDAKI_MAX_CUDA_DEVICES) {
+            ucs_error("exceeded maximal number of GDAKI CUDA devices (%u)",
+                      UCT_GDAKI_MAX_CUDA_DEVICES);
+            return UCS_ERR_EXCEEDS_LIMIT;
         }
 
-        for (nvml_idx = 0; nvml_idx < nvml_dev_count; nvml_idx++) {
-            if (gpus[nvml_idx].sys_dev == cuda_sys_dev) {
-                gpus[nvml_idx].cuda_idx = cuda_idx;
-                break;
-            }
-        }
+        gpus[gpu_count].sys_dev  = sys_dev;
+        gpus[gpu_count].bus_id   = bus_id;
+        gpus[gpu_count].cuda_idx = -1;
+        gpu_count++;
     }
 
-    *count_p = nvml_dev_count;
+    *count_p = gpu_count;
     return UCS_OK;
 }
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -24,6 +24,8 @@
 #include <uct/cuda/base/cuda_ctx.h>
 #include <uct/cuda/base/cuda_nvml.h>
 
+#include <string.h>
+
 #include "gpunetio/common/doca_gpunetio_verbs_def.h"
 
 #define UCT_GDAKI_MAX_CUDA_DEVICES 64
@@ -1245,9 +1247,9 @@ typedef struct {
     int              cuda_idx; /* CUDA driver index, -1 if not CUDA-visible */
 } uct_gdaki_gpu_info_t;
 
-static int
-uct_gdaki_gpu_bus_id_match(const uct_gdaki_gpu_info_t *gpus, unsigned count,
-                           const ucs_sys_bus_id_t *bus_id)
+static const uct_gdaki_gpu_info_t *
+uct_gdaki_gpu_bus_id_lookup(const uct_gdaki_gpu_info_t *gpus, unsigned count,
+                            const ucs_sys_bus_id_t *bus_id)
 {
     ucs_bus_id_bit_rep_t bus_id_key = ucs_topo_get_bus_id_bit_repr(bus_id);
     unsigned gpu_idx;
@@ -1255,11 +1257,11 @@ uct_gdaki_gpu_bus_id_match(const uct_gdaki_gpu_info_t *gpus, unsigned count,
     for (gpu_idx = 0; gpu_idx < count; gpu_idx++) {
         if (bus_id_key ==
             ucs_topo_get_bus_id_bit_repr(&gpus[gpu_idx].bus_id)) {
-            return 1;
+            return &gpus[gpu_idx];
         }
     }
 
-    return 0;
+    return NULL;
 }
 
 static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
@@ -1291,7 +1293,9 @@ uct_gdaki_get_cuda_sys_dev(int cuda_idx, ucs_sys_device_t *sys_dev_p)
 static ucs_status_t
 uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 {
-    unsigned nvml_dev_count, nvml_idx, gpu_count;
+    uct_gdaki_gpu_info_t cuda_gpus[UCT_GDAKI_MAX_CUDA_DEVICES];
+    const uct_gdaki_gpu_info_t *gpu_info;
+    unsigned nvml_dev_count, nvml_idx, gpu_count, cuda_gpu_count;
     int cuda_dev_count, cuda_idx;
     ucs_sys_bus_id_t bus_id;
     nvmlDevice_t nvml_dev;
@@ -1306,7 +1310,7 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 
     ucs_assert_always(cuda_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
 
-    gpu_count = 0;
+    cuda_gpu_count = 0;
     for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
         status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &sys_dev);
         if (status != UCS_OK) {
@@ -1318,7 +1322,8 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
             return status;
         }
 
-        if (uct_gdaki_gpu_bus_id_match(gpus, gpu_count, &bus_id)) {
+        if (uct_gdaki_gpu_bus_id_lookup(cuda_gpus, cuda_gpu_count,
+                                        &bus_id) != NULL) {
             ucs_debug("skip cuda device %d with duplicate bdf "
                       "%04x:%02x:%02x.%u", cuda_idx,
                       (unsigned)bus_id.domain, (unsigned)bus_id.bus,
@@ -1327,22 +1332,24 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
             continue;
         }
 
-        gpus[gpu_count].sys_dev  = sys_dev;
-        gpus[gpu_count].bus_id   = bus_id;
-        gpus[gpu_count].cuda_idx = cuda_idx;
-        gpu_count++;
+        cuda_gpus[cuda_gpu_count].sys_dev  = sys_dev;
+        cuda_gpus[cuda_gpu_count].bus_id   = bus_id;
+        cuda_gpus[cuda_gpu_count].cuda_idx = cuda_idx;
+        cuda_gpu_count++;
     }
 
     status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetCount_v2, &nvml_dev_count);
     if (status != UCS_OK) {
         ucs_diag("NVML unavailable: using legacy CUDA-only enumeration");
-        *count_p = gpu_count;
+        memcpy(gpus, cuda_gpus, cuda_gpu_count * sizeof(*gpus));
+        *count_p = cuda_gpu_count;
         return UCS_OK;
     }
 
     ucs_assert_always(nvml_dev_count <= UCT_GDAKI_MAX_CUDA_DEVICES);
 
     /* Add non-CUDA-visible devices from NVML. TODO: support MLOPart. */
+    gpu_count = 0;
     for (nvml_idx = 0; nvml_idx < nvml_dev_count; nvml_idx++) {
         status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, nvml_idx,
                                          &nvml_dev);
@@ -1361,7 +1368,10 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
         bus_id.slot     = nvml_pci.device;
         bus_id.function = 0;
 
-        if (uct_gdaki_gpu_bus_id_match(gpus, gpu_count, &bus_id)) {
+        gpu_info = uct_gdaki_gpu_bus_id_lookup(cuda_gpus, cuda_gpu_count,
+                                               &bus_id);
+        if (gpu_info != NULL) {
+            gpus[gpu_count++] = *gpu_info;
             /* Already added as CUDA-visible. */
             continue;
         }

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1319,6 +1319,10 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
         }
 
         if (uct_gdaki_gpu_bus_id_match(gpus, gpu_count, &bus_id)) {
+            ucs_debug("skip cuda device %d with duplicate bdf "
+                      "%04x:%02x:%02x.%u", cuda_idx,
+                      (unsigned)bus_id.domain, (unsigned)bus_id.bus,
+                      (unsigned)bus_id.slot, (unsigned)bus_id.function);
             /* Same BDF. TODO: support MLOPart. */
             continue;
         }

--- a/src/uct/ze/base/ze_base.c
+++ b/src/uct/ze/base/ze_base.c
@@ -207,24 +207,22 @@ uct_ze_base_set_device_sys_dev(uct_ze_device_t *device, int device_idx,
         ucs_debug("device %d shares sys_dev %u with device %d (same pci)",
                   device_idx, device->sys_dev, found_idx);
     } else {
-        status = ucs_topo_find_device_by_bus_id(bus_id, &device->sys_dev);
+        status = ucs_topo_find_device_by_bus_id_and_user_value(
+                bus_id, (uintptr_t)device_idx, &device->sys_dev);
         if (status != UCS_OK) {
-            ucs_debug("ucs_topo_find_device_by_bus_id failed for device %d",
+            ucs_debug("ucs_topo_find_device_by_bus_id_and_user_value failed "
+                      "for device %d",
                       device_idx);
             device->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
         } else {
             ucs_snprintf_safe(name, sizeof(name), "GPU%d", device_idx);
             ucs_topo_sys_device_set_name(device->sys_dev, name, 10);
 
-            status = ucs_topo_sys_device_set_user_value(device->sys_dev,
-                                                        device_idx);
-            if (status == UCS_OK) {
-                status = ucs_topo_sys_device_enable_aux_path(device->sys_dev);
-                if (status != UCS_OK) {
-                    ucs_debug("ucs_topo_sys_device_enable_aux_path failed "
-                              "for device %d",
-                              device_idx);
-                }
+            status = ucs_topo_sys_device_enable_aux_path(device->sys_dev);
+            if (status != UCS_OK) {
+                ucs_debug("ucs_topo_sys_device_enable_aux_path failed "
+                          "for device %d",
+                          device_idx);
             }
         }
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1616,12 +1616,10 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_get_inline_0, rcx,
  * lane-index insertion order (mock_1:1 first) differ from the
  * deterministic bus-id sorted order [mock_0:1, mock_1:1, mock_2:1].
  *
- * Installs a "proto_mock" topology provider that gives any sys_dev 
- * pair a 100ns latency penalty unless their indices differ by 1, and 
- * forces the local memory onto mock_1:1's sys_dev. 
- * Because the three mock devices get consecutive sys_devs, mock_0:1 and 
- * mock_2:1 are adjacent to the buffer while mock_1:1 (the buffer's own device) 
- * is "far".
+ * Installs a "proto_mock" topology provider that gives any known sys_dev
+ * pair a 100ns latency penalty unless it is one of the explicit adjacent
+ * pairs with mock_1:1. This makes mock_0:1 and mock_2:1 adjacent to the
+ * buffer while mock_1:1 (the buffer's own device) is "far".
  *
  * Each test asserts two ranges in the proto cache:
  *   - 0..64 (get/bcopy "copy-out"): reg_mem_info unknown, so all NICs
@@ -1662,6 +1660,10 @@ public:
         add_mock_iface("mock_2:1", iface_attr_slow); /* bus 2 */
         test_ucp_proto_mock::init();
 
+        s_low_adjacent_sys_dev  = get_mock_sys_dev_by_name("mock_0:1");
+        s_local_sys_dev         = get_mock_sys_dev_by_name("mock_1:1");
+        s_high_adjacent_sys_dev = get_mock_sys_dev_by_name("mock_2:1");
+
         const ucs_sys_topo_ops_t topo_ops = {
             .get_distance                   = get_distance,
             .get_memory_distance            = get_memory_distance,
@@ -1673,6 +1675,9 @@ public:
     virtual void cleanup() override
     {
         ucs_sys_topo_provider_pop();
+        s_low_adjacent_sys_dev  = UCS_SYS_DEVICE_ID_UNKNOWN;
+        s_local_sys_dev         = UCS_SYS_DEVICE_ID_UNKNOWN;
+        s_high_adjacent_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
         test_ucp_proto_mock::cleanup();
     }
 
@@ -1710,6 +1715,22 @@ protected:
                           key, rkey->cfg_index);
     }
 
+    static int is_adjacent_to_local(ucs_sys_device_t device1,
+                                    ucs_sys_device_t device2)
+    {
+        if (device1 == s_local_sys_dev) {
+            return (device2 == s_low_adjacent_sys_dev) ||
+                   (device2 == s_high_adjacent_sys_dev);
+        }
+
+        if (device2 == s_local_sys_dev) {
+            return (device1 == s_low_adjacent_sys_dev) ||
+                   (device1 == s_high_adjacent_sys_dev);
+        }
+
+        return 0;
+    }
+
     static ucs_status_t get_distance(ucs_sys_device_t device1,
                                      ucs_sys_device_t device2,
                                      ucs_sys_dev_distance_t *distance)
@@ -1717,7 +1738,7 @@ protected:
         *distance = ucs_topo_default_distance;
         if ((device1 != UCS_SYS_DEVICE_ID_UNKNOWN) &&
             (device2 != UCS_SYS_DEVICE_ID_UNKNOWN) &&
-            (sys_dev_delta(device1, device2) != 1)) {
+            !is_adjacent_to_local(device1, device2)) {
             distance->latency = 100e-9;
         }
         return UCS_OK;
@@ -1737,12 +1758,20 @@ protected:
     }
 
 private:
-    static unsigned
-    sys_dev_delta(ucs_sys_device_t device1, ucs_sys_device_t device2)
-    {
-        return (device1 > device2) ? (device1 - device2) : (device2 - device1);
-    }
+    static ucs_sys_device_t s_low_adjacent_sys_dev;
+    static ucs_sys_device_t s_local_sys_dev;
+    static ucs_sys_device_t s_high_adjacent_sys_dev;
 };
+
+ucs_sys_device_t
+test_ucp_proto_mock_rcx_trio_local_distance_get::s_low_adjacent_sys_dev =
+        UCS_SYS_DEVICE_ID_UNKNOWN;
+ucs_sys_device_t
+test_ucp_proto_mock_rcx_trio_local_distance_get::s_local_sys_dev =
+        UCS_SYS_DEVICE_ID_UNKNOWN;
+ucs_sys_device_t
+test_ucp_proto_mock_rcx_trio_local_distance_get::s_high_adjacent_sys_dev =
+        UCS_SYS_DEVICE_ID_UNKNOWN;
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_trio_local_distance_get,
            single_net_dev_local_id_0_picks_lowest_adjacent_sys_dev,

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1454,6 +1454,100 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_put, use_single_net_device_rank_2,
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_put, rcx, "rc_x")
 
+class test_ucp_proto_mock_rcx_same_bdf_put : public test_ucp_proto_mock {
+public:
+    test_ucp_proto_mock_rcx_same_bdf_put() :
+        m_topo_state(nullptr),
+        m_low_user_value_sys_dev(UCS_SYS_DEVICE_ID_UNKNOWN),
+        m_high_user_value_sys_dev(UCS_SYS_DEVICE_ID_UNKNOWN)
+    {
+        mock_transport("rc_mlx5");
+    }
+
+    virtual void init() override
+    {
+        auto iface_attr_func = [](uct_iface_attr_t &iface_attr) {
+            iface_attr.cap.put.max_short = 2048;
+            iface_attr.bandwidth.shared  = 28e9;
+            iface_attr.latency.c         = 500e-9;
+            iface_attr.latency.m         = 1e-9;
+        };
+
+        setup_same_bdf_topology();
+        add_mock_iface_on_sys_device("mock_0:1", m_high_user_value_sys_dev,
+                                     iface_attr_func);
+        add_mock_iface_on_sys_device("mock_1:1", m_low_user_value_sys_dev,
+                                     iface_attr_func);
+        test_ucp_proto_mock::init();
+    }
+
+    virtual void cleanup() override
+    {
+        test_ucp_proto_mock::cleanup();
+        if (m_topo_state != nullptr) {
+            ucs_topo_restore_state(m_topo_state);
+            m_topo_state = nullptr;
+        }
+    }
+
+protected:
+    void check_config(const proto_select_data_vec_t &data_vec)
+    {
+        ucp_proto_select_key_t key = any_key();
+        key.param.op_id_flags      = UCP_OP_ID_PUT;
+        key.param.op_attr          = 0;
+
+        check_rkey_config(sender(), data_vec, key, 0);
+    }
+
+private:
+    void setup_same_bdf_topology()
+    {
+        ucs_sys_bus_id_t bus_id;
+
+        bus_id.domain   = 0xfffd;
+        bus_id.bus      = 0xfd;
+        bus_id.slot     = 0x1f;
+        bus_id.function = 0;
+
+        m_topo_state = ucs_topo_extract_state();
+        ASSERT_TRUE(m_topo_state != nullptr);
+
+        ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(
+                &bus_id, 2, &m_high_user_value_sys_dev));
+        ASSERT_UCS_OK(ucs_topo_sys_device_set_name(
+                m_high_user_value_sys_dev, "mock_high_user_value", 10));
+
+        ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(
+                &bus_id, 1, &m_low_user_value_sys_dev));
+        ASSERT_UCS_OK(ucs_topo_sys_device_set_name(
+                m_low_user_value_sys_dev, "mock_low_user_value", 10));
+    }
+
+    ucs_global_state_t *m_topo_state;
+    ucs_sys_device_t    m_low_user_value_sys_dev;
+    ucs_sys_device_t    m_high_user_value_sys_dev;
+};
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_same_bdf_put,
+           single_net_device_orders_same_bdf_by_user_value_0,
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=0")
+{
+    check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
+                  {2049, INF, "zero-copy", "rc_mlx5/mock_1:1/path0"}});
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_same_bdf_put,
+           single_net_device_orders_same_bdf_by_user_value_1,
+           "IB_NUM_PATHS?=2", "SINGLE_NET_DEVICE=y", "NODE_LOCAL_ID=1")
+{
+    check_config({{0, 2048, "short", "rc_mlx5/mock_0:1/path0"},
+                  {2049, INF, "zero-copy", "rc_mlx5/mock_0:1/path0"}});
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_same_bdf_put, rcx,
+                              "rc_x")
+
 class test_ucp_proto_mock_rcx_twins_get : public test_ucp_proto_mock_rcx_twins {
 protected:
     void check_config(const proto_select_data_vec_t &data_vec);

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1457,7 +1457,6 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_put, rcx, "rc_x")
 class test_ucp_proto_mock_rcx_same_bdf_put : public test_ucp_proto_mock {
 public:
     test_ucp_proto_mock_rcx_same_bdf_put() :
-        m_topo_state(nullptr),
         m_low_user_value_sys_dev(UCS_SYS_DEVICE_ID_UNKNOWN),
         m_high_user_value_sys_dev(UCS_SYS_DEVICE_ID_UNKNOWN)
     {
@@ -1481,15 +1480,6 @@ public:
         test_ucp_proto_mock::init();
     }
 
-    virtual void cleanup() override
-    {
-        test_ucp_proto_mock::cleanup();
-        if (m_topo_state != nullptr) {
-            ucs_topo_restore_state(m_topo_state);
-            m_topo_state = nullptr;
-        }
-    }
-
 protected:
     void check_config(const proto_select_data_vec_t &data_vec)
     {
@@ -1510,9 +1500,8 @@ private:
         bus_id.slot     = 0x1f;
         bus_id.function = 0;
 
-        m_topo_state = ucs_topo_extract_state();
-        ASSERT_TRUE(m_topo_state != nullptr);
-
+        /* Do not extract/restore topology here: UCP init still probes real
+         * transports, and clearing global topology can break hardware caches. */
         ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(
                 &bus_id, 2, &m_high_user_value_sys_dev));
         ASSERT_UCS_OK(ucs_topo_sys_device_set_name(
@@ -1524,9 +1513,8 @@ private:
                 m_low_user_value_sys_dev, "mock_low_user_value", 10));
     }
 
-    ucs_global_state_t *m_topo_state;
-    ucs_sys_device_t    m_low_user_value_sys_dev;
-    ucs_sys_device_t    m_high_user_value_sys_dev;
+    ucs_sys_device_t m_low_user_value_sys_dev;
+    ucs_sys_device_t m_high_user_value_sys_dev;
 };
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_same_bdf_put,

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -218,15 +218,23 @@ UCS_TEST_F(test_topo, find_device_by_bus_id_and_user_value) {
     ASSERT_TRUE(state != NULL);
     ucs_topo_restore_state(state);
 
+    status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &bdf_dev);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(dev1, bdf_dev);
+
     status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
                                                            user_value2,
                                                            &dev2_again);
     ASSERT_UCS_OK(status);
     EXPECT_EQ(dev2, dev2_again);
 
-    status = ucs_topo_find_device_by_bus_id_and_user_value(
-            &dummy_bus_id, UINTPTR_MAX, &dev2_again);
-    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    {
+        scoped_log_handler slh(hide_errors_logger);
+
+        status = ucs_topo_find_device_by_bus_id_and_user_value(
+                &dummy_bus_id, UCS_SYS_DEVICE_USER_VALUE_EMPTY, &dev2_again);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+    }
 }
 
 UCS_TEST_F(test_topo, get_distance) {

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -447,6 +447,7 @@ UCS_TEST_F(test_topo, sibling_error) {
     scoped_log_handler slh(hide_errors_logger);
     ASSERT_EQ(UCS_ERR_INVALID_PARAM, ucs_topo_sys_device_set_sys_dev_aux(1, 0));
     ASSERT_EQ(UCS_ERR_INVALID_PARAM, ucs_topo_sys_device_enable_aux_path(1));
+    ASSERT_TRUE(ucs_topo_is_reachable(1, 0));
 }
 
 UCS_TEST_F(test_topo, sibling) {
@@ -500,7 +501,6 @@ UCS_TEST_F(test_topo, sibling) {
     if (!sibling_dma.empty()) {
         ASSERT_FALSE(ucs_topo_is_reachable(hca_devs[1], gpu_dev));
         ASSERT_TRUE(ucs_topo_is_sibling(hca_devs[0], gpu_dev));
-        ASSERT_TRUE(ucs_topo_is_sibling(gpu_dev, hca_devs[0]));
     } else {
         ASSERT_TRUE(ucs_topo_is_reachable(hca_devs[1], gpu_dev));
         ASSERT_FALSE(ucs_topo_is_sibling(hca_devs[0], gpu_dev));
@@ -546,7 +546,6 @@ UCS_TEST_F(test_topo, sibling_multiple_memory_devices) {
         EXPECT_TRUE(ucs_topo_device_has_sibling(gpu_dev));
         EXPECT_TRUE(ucs_topo_is_reachable(hca_dev, gpu_dev));
         EXPECT_TRUE(ucs_topo_is_sibling(hca_dev, gpu_dev));
-        EXPECT_TRUE(ucs_topo_is_sibling(gpu_dev, hca_dev));
     };
 
     expect_sibling(gpu_dev0);

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -497,8 +497,6 @@ UCS_TEST_F(test_topo, sibling) {
     ASSERT_FALSE(ucs_topo_is_sibling(hca_devs[1], gpu_dev));
     ASSERT_FALSE(ucs_topo_is_sibling(hca_devs[2], gpu_dev));
 
-    ASSERT_TRUE(ucs_topo_is_reachable(hca_devs[1], gpu_dev));
-
     if (!sibling_dma.empty()) {
         ASSERT_FALSE(ucs_topo_is_reachable(hca_devs[1], gpu_dev));
         ASSERT_TRUE(ucs_topo_is_sibling(hca_devs[0], gpu_dev));
@@ -508,4 +506,57 @@ UCS_TEST_F(test_topo, sibling) {
         ASSERT_FALSE(ucs_topo_is_sibling(hca_devs[0], gpu_dev));
         ASSERT_FALSE(ucs_topo_is_sibling(gpu_dev, hca_devs[0]));
     }
+}
+
+// Multiple GPUs with same HCA sibling can be seen with MPS MLOPart
+UCS_TEST_F(test_topo, sibling_multiple_memory_devices) {
+    static const uintptr_t user_value1 = 1;
+    static const uintptr_t user_value2 = 2;
+
+    read_pcie_devices();
+    if ((m_hcas.empty()) || (m_gpus.empty()) || (m_dmas.empty())) {
+        UCS_TEST_SKIP_R("Not enough HCA, GPU and DMA PCIe device");
+    }
+
+    std::string sibling_gpu, sibling_dma;
+    get_siblings(m_hcas[0], sibling_gpu, sibling_dma);
+    if (sibling_dma.empty()) {
+        UCS_TEST_SKIP_R("No sibling DMA device found");
+    }
+
+    auto hca_dev = register_device("hca0", m_hcas[0]);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, hca_dev);
+    auto dma_dev = register_device("dma", sibling_dma);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, dma_dev);
+    auto gpu_dev0 = register_device("gpu0", sibling_gpu);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, gpu_dev0);
+
+    ucs_sys_bus_id_t gpu_bus_id;
+    ASSERT_UCS_OK(ucs_topo_get_device_bus_id(gpu_dev0, &gpu_bus_id));
+
+    ucs_sys_device_t gpu_dev1, gpu_dev2;
+    ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(
+            &gpu_bus_id, user_value1, &gpu_dev1));
+
+    ASSERT_UCS_OK(ucs_topo_sys_device_enable_aux_path(gpu_dev0));
+    ASSERT_UCS_OK(ucs_topo_sys_device_enable_aux_path(gpu_dev1));
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_sys_dev_aux(hca_dev, dma_dev));
+
+    auto expect_sibling = [hca_dev](ucs_sys_device_t gpu_dev) {
+        EXPECT_TRUE(ucs_topo_device_has_sibling(gpu_dev));
+        EXPECT_TRUE(ucs_topo_is_reachable(hca_dev, gpu_dev));
+        EXPECT_TRUE(ucs_topo_is_sibling(hca_dev, gpu_dev));
+        EXPECT_TRUE(ucs_topo_is_sibling(gpu_dev, hca_dev));
+    };
+
+    expect_sibling(gpu_dev0);
+    expect_sibling(gpu_dev1);
+
+    ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(
+            &gpu_bus_id, user_value2, &gpu_dev2));
+    ASSERT_UCS_OK(ucs_topo_sys_device_enable_aux_path(gpu_dev2));
+
+    expect_sibling(gpu_dev0);
+    expect_sibling(gpu_dev1);
+    expect_sibling(gpu_dev2);
 }

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -162,6 +162,73 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     EXPECT_GE(ucs_topo_num_devices(), 2);
 }
 
+UCS_TEST_F(test_topo, find_device_by_bus_id_and_user_value) {
+    static const uintptr_t user_value1 = 17;
+    static const uintptr_t user_value2 = 42;
+    ucs_global_state_t *state;
+    ucs_sys_device_t dev1, dev2, dev1_again, dev2_again, bdf_dev;
+    ucs_sys_bus_id_t dummy_bus_id;
+    ucs_sys_bus_id_t bus_id1;
+    ucs_sys_bus_id_t bus_id2;
+    ucs_sys_dev_distance_t distance;
+    ucs_status_t status;
+
+    dummy_bus_id.domain   = 0x0001;
+    dummy_bus_id.bus      = 0x23;
+    dummy_bus_id.slot     = 0x04;
+    dummy_bus_id.function = 0;
+
+    status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
+                                                           user_value1, &dev1);
+    ASSERT_UCS_OK(status);
+    EXPECT_LT(dev1, UCS_SYS_DEVICE_ID_MAX);
+
+    status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
+                                                           user_value1,
+                                                           &dev1_again);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(dev1, dev1_again);
+
+    status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
+                                                           user_value2, &dev2);
+    ASSERT_UCS_OK(status);
+    EXPECT_NE(dev1, dev2);
+
+    status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &bdf_dev);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(dev1, bdf_dev);
+
+    EXPECT_EQ(user_value1, ucs_topo_sys_device_get_user_value(dev1));
+    EXPECT_EQ(user_value2, ucs_topo_sys_device_get_user_value(dev2));
+
+    status = ucs_topo_get_device_bus_id(dev1, &bus_id1);
+    ASSERT_UCS_OK(status);
+    status = ucs_topo_get_device_bus_id(dev2, &bus_id2);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(bus_id1.domain, bus_id2.domain);
+    EXPECT_EQ(bus_id1.bus, bus_id2.bus);
+    EXPECT_EQ(bus_id1.slot, bus_id2.slot);
+    EXPECT_EQ(bus_id1.function, bus_id2.function);
+
+    status = ucs_topo_get_distance(dev1, dev2, &distance);
+    ASSERT_UCS_OK(status);
+    EXPECT_NEAR(distance.latency, 0.0, 1e-9);
+
+    state = ucs_topo_extract_state();
+    ASSERT_TRUE(state != NULL);
+    ucs_topo_restore_state(state);
+
+    status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
+                                                           user_value2,
+                                                           &dev2_again);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(dev2, dev2_again);
+
+    status = ucs_topo_find_device_by_bus_id_and_user_value(
+            &dummy_bus_id, UINTPTR_MAX, &dev2_again);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
+}
+
 UCS_TEST_F(test_topo, get_distance) {
     ucs_status_t status;
     ucs_sys_dev_distance_t distance;

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -166,7 +166,8 @@ UCS_TEST_F(test_topo, find_device_by_bus_id_and_user_value) {
     static const uintptr_t user_value1 = 17;
     static const uintptr_t user_value2 = 42;
     ucs_global_state_t *state;
-    ucs_sys_device_t dev1, dev2, dev1_again, dev2_again, bdf_dev;
+    ucs_sys_device_t dev1, dev2, dev1_again, dev2_again;
+    ucs_sys_device_t bdf_dev, bdf_dev_again;
     ucs_sys_bus_id_t dummy_bus_id;
     ucs_sys_bus_id_t bus_id1;
     ucs_sys_bus_id_t bus_id2;
@@ -196,10 +197,13 @@ UCS_TEST_F(test_topo, find_device_by_bus_id_and_user_value) {
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &bdf_dev);
     ASSERT_UCS_OK(status);
-    EXPECT_EQ(dev1, bdf_dev);
+    EXPECT_NE(dev1, bdf_dev);
+    EXPECT_NE(dev2, bdf_dev);
 
     EXPECT_EQ(user_value1, ucs_topo_sys_device_get_user_value(dev1));
     EXPECT_EQ(user_value2, ucs_topo_sys_device_get_user_value(dev2));
+    EXPECT_EQ(UCS_SYS_DEVICE_USER_VALUE_EMPTY,
+              ucs_topo_sys_device_get_user_value(bdf_dev));
 
     status = ucs_topo_get_device_bus_id(dev1, &bus_id1);
     ASSERT_UCS_OK(status);
@@ -218,9 +222,17 @@ UCS_TEST_F(test_topo, find_device_by_bus_id_and_user_value) {
     ASSERT_TRUE(state != NULL);
     ucs_topo_restore_state(state);
 
-    status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &bdf_dev);
+    status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &bdf_dev_again);
     ASSERT_UCS_OK(status);
-    EXPECT_EQ(dev1, bdf_dev);
+    EXPECT_EQ(bdf_dev, bdf_dev_again);
+    EXPECT_NE(dev1, bdf_dev_again);
+    EXPECT_NE(dev2, bdf_dev_again);
+
+    status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
+                                                           user_value1,
+                                                           &dev1_again);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(dev1, dev1_again);
 
     status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
                                                            user_value2,
@@ -300,7 +312,6 @@ UCS_TEST_F(test_topo, print_info) {
 UCS_TEST_F(test_topo, bdf_name) {
     static const char *bdf_name = "0002:8f:5c.0";
     static const char *dev_name = "test_bdf_name";
-    static const uintptr_t user_value = 1337;
 
     ucs_sys_device_t sys_dev    = UCS_SYS_DEVICE_ID_UNKNOWN;
 
@@ -311,18 +322,10 @@ UCS_TEST_F(test_topo, bdf_name) {
     status = ucs_topo_sys_device_set_name(sys_dev, dev_name, 10);
     ASSERT_UCS_OK(status);
 
-    status = ucs_topo_sys_device_set_user_value(sys_dev, user_value);
-    ASSERT_UCS_OK(status);
-
     const char *result_name = ucs_topo_sys_device_get_name(sys_dev);
     ASSERT_UCS_OK(status);
     EXPECT_EQ(std::string(dev_name), std::string(result_name));
     UCS_TEST_MESSAGE << "name: " << result_name;
-
-    uintptr_t result_user_value = ucs_topo_sys_device_get_user_value(sys_dev);
-    ASSERT_UCS_OK(status);
-    EXPECT_EQ(user_value, result_user_value);
-    UCS_TEST_MESSAGE << "user value: " << result_user_value;
 
     char name_buffer[UCS_SYS_BDF_NAME_MAX];
     const char *found_name = ucs_topo_sys_device_bdf_name(sys_dev, name_buffer,


### PR DESCRIPTION
## What?
Since CUDA 13.1, MPS MLOPart can expose CUDA devices that share the same PCIe BDF. Add topology support for distinguishing such logical devices.

## Why?
UCX previously used BDF alone as the topology key, so same-BDF CUDA devices could alias to the same `sys_dev`. This breaks reverse lookup paths such as `uct_cuda_get_cuda_device(sys_dev)`.

## How?
- Add `ucs_topo_find_device_by_bus_id_and_user_value()`.
- Key the topology hash by `(BDF, user_value)`.
- Keep existing BDF-only users on an implicit empty `user_value`.
- Update CUDA sys_dev lookup to pass `CUdevice` as `user_value`.
- Update topology restore to rebuild the `(BDF, user_value)` hash.
- Use `user_value` as the same-BDF tie-breaker for UCP single-net-device ordering.