### PR TITLE
CI: replace ofed_info with apt/yum package query

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ A clear and concise description of what the bug is.
 - For RDMA/IB/RoCE related issues:
     - Driver version:
         - `rpm -q rdma-core` or `rpm -q libibverbs`
-        - or: MLNX_OFED version `ofed_info -s`
+        - or: DOCA version `apt info doca-networking` / `yum info doca-networking`
    - HW information from `ibstat` or `ibv_devinfo -vv` command
 - For GPU related issues:
   - GPU type

--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -298,7 +298,7 @@ check_machine() {
 	lscpu
 	uname -a
 	free -m
-	ofed_info -s || true
+	apt info doca-networking doca-devel 2>/dev/null || yum info doca-networking doca-devel 2>/dev/null || true
 	ibv_devinfo -v || true
 	show_gids || true
 }


### PR DESCRIPTION
## What?
Replace `ofed_info -s` with `apt`/`yum` queries for DOCA package version in `check_machine()` and the bug report template.

## Why?
`ofed_scripts` are removed from DOCA-Host starting DOCA 4.0 (Nov/2026) per NVIDIA change notice NW-SW-4759377.

## How?
- `common.sh`: query `doca-networking`/`doca-devel` via apt/yum.
- `bug_report.md`: update driver version hint accordingly.