### PR TITLE
UCT/ROCM: fix dmabuf support check for coreos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Gonzalo Brito Gadeschi <gonzalob@nvidia.com>
 Graham Lopez <lopezmg@ornl.gov>
 Guy Ealey Morag <gealeymorag@nvidia.com>
 Guy Shattah <sguy@mellanox.com>
+Hannes Hansen <mail@hannesh.de>
 Hessam Mirsadeghi <hmirsadeghi@nvidia.com>
 Hiroyuki Sato <hiroysato@gmail.com>
 Hod Badihi <hbadihi@nvidia.com>

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -297,50 +297,142 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     return UCS_OK;
 }
 
-int uct_rocm_base_is_dmabuf_supported()
+FILE* uct_rocm_base_load_prod_config_file() 
 {
-    int dmabuf_supported = 0;
-
-#if HAVE_HSA_AMD_PORTABLE_EXPORT_DMABUF
-    const char kernel_opt1[] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
-    const char kernel_opt2[] = "CONFIG_PCI_P2PDMA=y";
-    int found_opt1           = 0;
-    int found_opt2           = 0;
-    FILE *fp;
-    struct utsname utsname;
+    /* Skip if zcat is unavailable or /proc/config.gz does not exist.
+     * popen() succeeds even when the file is missing, producing an empty
+     * stream that falsely triggers the "not found" error path.
+     * Check if zcat is available in the system */
+    int has_zcat = 0;
+    int has_config_file = 0;
     char kernel_conf_file[128];
-    char buf[256];
+    const char path[] = "/proc/config.gz";
+    char popen_cmd[256];
 
+    ucs_snprintf_safe(kernel_conf_file, sizeof(kernel_conf_file), path);
+    has_zcat = (system("which zcat > /dev/null 2>&1") == 0);
+    has_config_file = (access(path, R_OK) == 0);
+    if (!has_zcat || !has_config_file) {
+        ucs_trace("Skipping %s (zcat %s, file %s)", kernel_conf_file,
+            has_zcat ? "available" : "unavailable",
+            has_config_file ? "exists" : "not found");
+        return NULL;
+    }
+    ucs_snprintf_safe(popen_cmd, sizeof(popen_cmd), "zcat %s 2>/dev/null", path);
+    return popen(popen_cmd, "r");
+}
+
+FILE* uct_rocm_base_load_kernel_config_file()
+{
+    const char *fmts[] = {
+        "/boot/config-%s",
+        "/usr/src/linux-%s/.config",
+        "/usr/src/linux/.config",
+        "/usr/lib/modules/%s/config",
+        "/usr/lib/ostree-boot/config-%s",
+        "/usr/lib/kernel/config-%s",
+        "/usr/src/linux-headers-%s/.config",
+        "/lib/modules/%s/build/.config"
+    };
+    FILE* fp = NULL;
+    char kernel_conf_file[128];
+    struct utsname utsname;
+    
     if (uname(&utsname) == -1) {
         ucs_trace("could not get kernel name");
-        goto out;
+        return NULL;
     }
 
-    ucs_snprintf_safe(kernel_conf_file, sizeof(kernel_conf_file),
-                      "/boot/config-%s", utsname.release);
-    fp = fopen(kernel_conf_file, "r");
-    if (fp == NULL) {
-        ucs_trace("could not open kernel conf file %s error: %m",
-                  kernel_conf_file);
-        goto out;
+    for (size_t i = 0; i < sizeof(fmts) / sizeof(fmts[0]); ++i) {
+        const char *path = fmts[i];
+        ucs_snprintf_safe(kernel_conf_file, sizeof(kernel_conf_file), path, utsname.release);
+        fp = fopen(kernel_conf_file, "r");
+        if (fp != NULL) {
+            ucs_trace("reading kernel config from %s", kernel_conf_file);
+            return fp;
+        }
+        ucs_trace("could not open kernel conf file %s error: %m", kernel_conf_file);
     }
+    return fp;
+}
+
+int uct_rocm_base_file_contains_dmabuf_support(FILE* fp, const char kernel_opt1[], const char kernel_opt2[])
+{
+    int dmabuf_supported = 0;
+    int found_opt1           = 0;
+    int found_opt2           = 0;
+    char buf[256];
 
     while (fgets(buf, sizeof(buf), fp) != NULL) {
-        if (strstr(buf, kernel_opt1) != NULL) {
+        if (!found_opt1 && (strstr(buf, kernel_opt1) != NULL)) {
             found_opt1 = 1;
         }
-        if (strstr(buf, kernel_opt2) != NULL) {
+        if (!found_opt2 && (strstr(buf, kernel_opt2) != NULL)) {
             found_opt2 = 1;
         }
         if (found_opt1 && found_opt2) {
             dmabuf_supported = 1;
-            break;
         }
     }
-    fclose(fp);
-#endif
-out:
     return dmabuf_supported;
+}
+
+int uct_rocm_base_kernel_config_supports_dmabuf()
+{
+    int dmabuf_supported = 0;
+    FILE* fp = NULL;
+    const char kernel_opt1[] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
+    const char kernel_opt2[] = "CONFIG_PCI_P2PDMA=y";
+
+    /* Special handling for /proc/config.gz */
+    fp = uct_rocm_base_load_prod_config_file();
+    if (fp != NULL) {
+        dmabuf_supported = uct_rocm_base_file_contains_dmabuf_support(fp, kernel_opt1, kernel_opt2);
+        pclose(fp);
+        if (dmabuf_supported == 1) {
+            return dmabuf_supported;
+        }
+    }
+
+    fp = uct_rocm_base_load_kernel_config_file();
+    if (fp == NULL) {
+        ucs_trace("no kernel conf file found");
+        return 0;
+    }
+    dmabuf_supported = uct_rocm_base_file_contains_dmabuf_support(fp, kernel_opt1, kernel_opt2);
+    fclose(fp);
+    return dmabuf_supported;
+} 
+
+int uct_rocm_base_kernel_symbols_supports_dmabuf()
+{
+    int dmabuf_supported = 0;
+    FILE* fp = NULL;
+    const char kernel_sym1[] = "dma_buf_move_notify";
+    const char kernel_sym2[] = "pci_p2pdma";
+
+    fp = fopen("/proc/kallsyms", "r");
+    if (fp == NULL) {
+        ucs_trace("no /proc/kallsyms file found");
+        return dmabuf_supported;
+    }
+    dmabuf_supported = uct_rocm_base_file_contains_dmabuf_support(fp, kernel_sym1, kernel_sym2);
+    fclose(fp);
+    return dmabuf_supported;
+}
+
+int uct_rocm_base_is_dmabuf_supported()
+{
+#if HAVE_HSA_AMD_PORTABLE_EXPORT_DMABUF    
+    if (uct_rocm_base_kernel_config_supports_dmabuf()) {
+        return 1;
+    }
+
+    ucs_trace("no kernel conf file found or no support for dmabuf found, trying /proc/kallsyms fallback");
+    return uct_rocm_base_kernel_symbols_supports_dmabuf();
+#else
+    return 0;
+#endif
 }
 
 static void uct_rocm_base_dmabuf_export(const void *addr, const size_t length,

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -298,12 +298,12 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     return UCS_OK;
 }
 
-gzFile* uct_rocm_base_load_prod_config_file() 
+gzFile uct_rocm_base_load_prod_config_file() 
 {
     int has_config_file = 0;
     char kernel_conf_file[128];
     const char path[] = "/proc/config.gz";
-    gzFile* zfp = NULL;
+    gzFile zfp = NULL;
 
     ucs_snprintf_safe(kernel_conf_file, sizeof(kernel_conf_file), path);
     has_config_file = (access(path, R_OK) == 0);
@@ -375,7 +375,7 @@ int uct_rocm_base_file_contains_dmabuf_support(FILE* fp, const char kernel_opt1[
     return dmabuf_supported;
 }
 
-int uct_rocm_base_gzfile_contains_dmabuf_support(gzFile* zfp, const char kernel_opt1[], const char kernel_opt2[])
+int uct_rocm_base_gzfile_contains_dmabuf_support(gzFile zfp, const char kernel_opt1[], const char kernel_opt2[])
 {
     int dmabuf_supported = 0;
     int found_opt1           = 0;
@@ -400,7 +400,7 @@ int uct_rocm_base_kernel_config_supports_dmabuf()
 {
     int dmabuf_supported = 0;
     FILE* fp = NULL;
-    gzFile* zfp = NULL;
+    gzFile zfp = NULL;
     const char kernel_opt1[] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
     const char kernel_opt2[] = "CONFIG_PCI_P2PDMA=y";
 

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -15,7 +15,6 @@
 #include <ucs/memory/memtype_cache.h>
 #include <sys/utsname.h>
 #include <pthread.h>
-#include <zlib.h>
 
 #define MAX_AGENTS 127
 static struct agents {
@@ -298,39 +297,16 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     return UCS_OK;
 }
 
-gzFile uct_rocm_base_load_prod_config_file() 
-{
-    int has_config_file = 0;
-    char kernel_conf_file[128];
-    const char path[] = "/proc/config.gz";
-    gzFile zfp = NULL;
-
-    ucs_snprintf_safe(kernel_conf_file, sizeof(kernel_conf_file), path);
-    has_config_file = (access(path, R_OK) == 0);
-    if (!has_config_file) {
-        ucs_trace("Skipping %s (file not found)", kernel_conf_file);
-        return NULL;
-    }
-
-    zfp = gzopen(path, "rb");
-    if (zfp == NULL) {
-        ucs_trace("Skipping %s (not present or unreadable)", kernel_conf_file);
-        return NULL;
-    }
-
-    return zfp;
-}
-
 FILE* uct_rocm_base_load_kernel_config_file()
 {
     const char *fmts[] = {
         "/boot/config-%s",
         "/usr/src/linux-%s/.config",
-        "/usr/src/linux/.config",
         "/usr/lib/modules/%s/config",
         "/usr/lib/kernel/config-%s",
         "/usr/src/linux-headers-%s/.config",
-        "/lib/modules/%s/build/.config"
+        "/lib/modules/%s/build/.config",
+        "/usr/lib/ostree-boot/config-%s"
     };
     FILE* fp = NULL;
     char kernel_conf_file[128];
@@ -375,44 +351,12 @@ int uct_rocm_base_file_contains_dmabuf_support(FILE* fp, const char kernel_opt1[
     return dmabuf_supported;
 }
 
-int uct_rocm_base_gzfile_contains_dmabuf_support(gzFile zfp, const char kernel_opt1[], const char kernel_opt2[])
-{
-    int dmabuf_supported = 0;
-    int found_opt1           = 0;
-    int found_opt2           = 0;
-    char buf[256];
-
-    while (gzgets(zfp, buf, sizeof(buf)) != NULL) {
-        if (!found_opt1 && (strstr(buf, kernel_opt1) != NULL)) {
-            found_opt1 = 1;
-        }
-        if (!found_opt2 && (strstr(buf, kernel_opt2) != NULL)) {
-            found_opt2 = 1;
-        }
-        if (found_opt1 && found_opt2) {
-            dmabuf_supported = 1;
-        }
-    }
-    return dmabuf_supported;
-}
-
 int uct_rocm_base_kernel_config_supports_dmabuf()
 {
     int dmabuf_supported = 0;
     FILE* fp = NULL;
-    gzFile zfp = NULL;
     const char kernel_opt1[] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
     const char kernel_opt2[] = "CONFIG_PCI_P2PDMA=y";
-
-    /* Special handling for /proc/config.gz */
-    zfp = uct_rocm_base_load_prod_config_file();
-    if (zfp != NULL) {
-        dmabuf_supported = uct_rocm_base_gzfile_contains_dmabuf_support(zfp, kernel_opt1, kernel_opt2);
-        gzclose(zfp);
-        if (dmabuf_supported == 1) {
-            return dmabuf_supported;
-        }
-    }
 
     fp = uct_rocm_base_load_kernel_config_file();
     if (fp == NULL) {

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -15,6 +15,7 @@
 #include <ucs/memory/memtype_cache.h>
 #include <sys/utsname.h>
 #include <pthread.h>
+#include <zlib.h>
 
 #define MAX_AGENTS 127
 static struct agents {
@@ -297,29 +298,27 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     return UCS_OK;
 }
 
-FILE* uct_rocm_base_load_prod_config_file() 
+gzFile* uct_rocm_base_load_prod_config_file() 
 {
-    /* Skip if zcat is unavailable or /proc/config.gz does not exist.
-     * popen() succeeds even when the file is missing, producing an empty
-     * stream that falsely triggers the "not found" error path.
-     * Check if zcat is available in the system */
-    int has_zcat = 0;
     int has_config_file = 0;
     char kernel_conf_file[128];
     const char path[] = "/proc/config.gz";
-    char popen_cmd[256];
+    gzFile* zfp = NULL;
 
     ucs_snprintf_safe(kernel_conf_file, sizeof(kernel_conf_file), path);
-    has_zcat = (system("which zcat > /dev/null 2>&1") == 0);
     has_config_file = (access(path, R_OK) == 0);
-    if (!has_zcat || !has_config_file) {
-        ucs_trace("Skipping %s (zcat %s, file %s)", kernel_conf_file,
-            has_zcat ? "available" : "unavailable",
-            has_config_file ? "exists" : "not found");
+    if (!has_config_file) {
+        ucs_trace("Skipping %s (file not found)", kernel_conf_file);
         return NULL;
     }
-    ucs_snprintf_safe(popen_cmd, sizeof(popen_cmd), "zcat %s 2>/dev/null", path);
-    return popen(popen_cmd, "r");
+
+    zfp = gzopen(path, "rb");
+    if (zfp == NULL) {
+        ucs_trace("Skipping %s (not present or unreadable)", kernel_conf_file);
+        return NULL;
+    }
+
+    return zfp;
 }
 
 FILE* uct_rocm_base_load_kernel_config_file()
@@ -329,7 +328,6 @@ FILE* uct_rocm_base_load_kernel_config_file()
         "/usr/src/linux-%s/.config",
         "/usr/src/linux/.config",
         "/usr/lib/modules/%s/config",
-        "/usr/lib/ostree-boot/config-%s",
         "/usr/lib/kernel/config-%s",
         "/usr/src/linux-headers-%s/.config",
         "/lib/modules/%s/build/.config"
@@ -377,18 +375,40 @@ int uct_rocm_base_file_contains_dmabuf_support(FILE* fp, const char kernel_opt1[
     return dmabuf_supported;
 }
 
+int uct_rocm_base_gzfile_contains_dmabuf_support(gzFile* zfp, const char kernel_opt1[], const char kernel_opt2[])
+{
+    int dmabuf_supported = 0;
+    int found_opt1           = 0;
+    int found_opt2           = 0;
+    char buf[256];
+
+    while (gzgets(zfp, buf, sizeof(buf)) != NULL) {
+        if (!found_opt1 && (strstr(buf, kernel_opt1) != NULL)) {
+            found_opt1 = 1;
+        }
+        if (!found_opt2 && (strstr(buf, kernel_opt2) != NULL)) {
+            found_opt2 = 1;
+        }
+        if (found_opt1 && found_opt2) {
+            dmabuf_supported = 1;
+        }
+    }
+    return dmabuf_supported;
+}
+
 int uct_rocm_base_kernel_config_supports_dmabuf()
 {
     int dmabuf_supported = 0;
     FILE* fp = NULL;
+    gzFile* zfp = NULL;
     const char kernel_opt1[] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
     const char kernel_opt2[] = "CONFIG_PCI_P2PDMA=y";
 
     /* Special handling for /proc/config.gz */
-    fp = uct_rocm_base_load_prod_config_file();
-    if (fp != NULL) {
-        dmabuf_supported = uct_rocm_base_file_contains_dmabuf_support(fp, kernel_opt1, kernel_opt2);
-        pclose(fp);
+    zfp = uct_rocm_base_load_prod_config_file();
+    if (zfp != NULL) {
+        dmabuf_supported = uct_rocm_base_gzfile_contains_dmabuf_support(zfp, kernel_opt1, kernel_opt2);
+        gzclose(zfp);
         if (dmabuf_supported == 1) {
             return dmabuf_supported;
         }


### PR DESCRIPTION
## What?
Instead of only checking `/boot/config-%s`, it will check also other locations that are used by other OS.

## Why?
On Fedora CoreOS and possibly other OS, `/boot/config-%s` does not exist. Instead they use other locations. See https://github.com/openucx/ucx/issues/11540 for more.

## How?
Instead of checking a single path, loop over a list of locations.
The current implementation is missing  `"/proc/config.gz"`. For now I left out the gz handling to keep it simple.

This is based on the help from @edgargabriel who helped us to identify the root cause and pointed us to the implementation of ROCM (https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/src/misc/rocmwrap.cc#L282)